### PR TITLE
Fixes the shebang line

### DIFF
--- a/src/ruby/bin/interop/interop_client.rb
+++ b/src/ruby/bin/interop/interop_client.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 # Copyright 2014, Google Inc.
 # All rights reserved.
 #
@@ -27,7 +29,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#!/usr/bin/env ruby
 # interop_client is a testing tool that accesses a gRPC interop testing
 # server and runs a test on it.
 #

--- a/src/ruby/bin/interop/interop_server.rb
+++ b/src/ruby/bin/interop/interop_server.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 # Copyright 2014, Google Inc.
 # All rights reserved.
 #
@@ -27,8 +29,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#!/usr/bin/env ruby
-#
 # interop_server is a Testing app that runs a gRPC interop testing server.
 #
 # It helps validate interoperation b/w gRPC in different environments

--- a/src/ruby/bin/math_client.rb
+++ b/src/ruby/bin/math_client.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 # Copyright 2014, Google Inc.
 # All rights reserved.
 #
@@ -27,8 +29,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#!/usr/bin/env ruby
-#
+
 # Sample app that accesses a Calc service running on a Ruby gRPC server and
 # helps validate RpcServer as a gRPC server using proto2 serialization.
 #

--- a/src/ruby/bin/math_server.rb
+++ b/src/ruby/bin/math_server.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 # Copyright 2014, Google Inc.
 # All rights reserved.
 #
@@ -27,8 +29,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#!/usr/bin/env ruby
-#
 # Sample gRPC Ruby server that implements the Math::Calc service and helps
 # validate GRPC::RpcServer as GRPC implementation using proto2 serialization.
 #

--- a/src/ruby/bin/noproto_client.rb
+++ b/src/ruby/bin/noproto_client.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 # Copyright 2014, Google Inc.
 # All rights reserved.
 #
@@ -27,7 +29,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#!/usr/bin/env ruby
 # Sample app that helps validate RpcServer without protobuf serialization.
 #
 # Usage: $ ruby -S path/to/noproto_client.rb

--- a/src/ruby/bin/noproto_server.rb
+++ b/src/ruby/bin/noproto_server.rb
@@ -1,3 +1,5 @@
+#!/usr/bin/env ruby
+
 # Copyright 2014, Google Inc.
 # All rights reserved.
 #
@@ -27,7 +29,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#!/usr/bin/env ruby
 # Sample app that helps validate RpcServer without protobuf serialization.
 #
 # Usage: $ path/to/noproto_server.rb


### PR DESCRIPTION
- fixes the shebang line by moving it above the copyright notice in
  executables.
- also fixes the execution bit on all the binaries
