### PR TITLE
Send a scheme of http or https as appropriate, rather than grpc.

### DIFF
--- a/src/core/channel/http_client_filter.c
+++ b/src/core/channel/http_client_filter.c
@@ -131,12 +131,12 @@ static void destroy_call_elem(grpc_call_element *elem) {
   ignore_unused(channeld);
 }
 
-static char *scheme_from_args(const grpc_channel_args *args) {
+static const char *scheme_from_args(const grpc_channel_args *args) {
   int i;
   if (args != NULL) {
     for (i = 0; i < args->num_args; ++i) {
       if (args->args[i].type == GRPC_ARG_STRING &&
-          strcmp(args->args[i].key, "grpc.scheme") == 0) {
+          strcmp(args->args[i].key, GRPC_ARG_HTTP2_SCHEME) == 0) {
         return args->args[i].value.string;
       }
     }

--- a/src/core/channel/http_client_filter.h
+++ b/src/core/channel/http_client_filter.h
@@ -39,4 +39,6 @@
 /* Processes metadata on the client side for HTTP2 transports */
 extern const grpc_channel_filter grpc_http_client_filter;
 
+#define GRPC_ARG_HTTP2_SCHEME "grpc.http2_scheme"
+
 #endif /* __GRPC_INTERNAL_CHANNEL_HTTP_CLIENT_FILTER_H__ */

--- a/src/core/security/security_context.c
+++ b/src/core/security/security_context.c
@@ -36,6 +36,7 @@
 #include <string.h>
 
 #include "src/core/channel/channel_args.h"
+#include "src/core/channel/http_client_filter.h"
 #include "src/core/security/credentials.h"
 #include "src/core/security/secure_endpoint.h"
 #include "src/core/surface/lame_client.h"
@@ -463,7 +464,7 @@ grpc_channel *grpc_ssl_channel_create(grpc_credentials *ssl_creds,
     return grpc_lame_client_channel_create();
   }
   arg.type = GRPC_ARG_STRING;
-  arg.key = "grpc.scheme";
+  arg.key = GRPC_ARG_HTTP2_SCHEME;
   arg.value.string = "https";
   new_args = grpc_channel_args_copy_and_add(args, &arg);
   channel = grpc_secure_channel_create_internal(target, new_args, ctx);


### PR DESCRIPTION
This requires additional logic to determine whether to send http or
https. This change assumes a default of http, and plumbs down https
through a synthesized channel arg when using the ssl transport.
