### PR TITLE
Tuning down the census log test size.

### DIFF
--- a/test/core/statistics/census_log_tests.c
+++ b/test/core/statistics/census_log_tests.c
@@ -268,7 +268,7 @@ static void multiple_writers_single_reader(int circular_log) {
   /* Sleep interval between read iterations. */
   static const gpr_int32 READ_ITERATION_INTERVAL_IN_MSEC = 10;
   /* Number of records written by each writer. */
-  static const gpr_int32 NUM_RECORDS_PER_WRITER = 10 * 1024 * 1024;
+  static const gpr_int32 NUM_RECORDS_PER_WRITER = 1024 * 1024;
   /* Maximum record size. */
   static const size_t MAX_RECORD_SIZE = 10;
   int ix;


### PR DESCRIPTION
Smallest GCE instances can't run such a big test. So to be able to run tests on smaller instances, such as cloud9's, we need to tune that down.
