### PR TITLE
Fix return behavior of run_tools.py

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -80,17 +80,20 @@ def _build_and_run(check_cancelled):
        for cfg in build_configs
        for target in _MAKE_TEST_TARGETS),
       check_cancelled, maxjobs=1):
-    sys.exit(1)
+    return 1
 
   # run all the tests
-  jobset.run((
+  if not jobset.run((
       config.run_command(x)
       for config in run_configs
       for filt in filters
       for x in itertools.chain.from_iterable(itertools.repeat(
           glob.glob('bins/%s/%s_test' % (
               config.build_config, filt)),
-          runs_per_test))), check_cancelled)
+          runs_per_test))), check_cancelled):
+    return 2
+
+  return 0
 
 
 if forever:
@@ -102,5 +105,5 @@ if forever:
     while not have_files_changed():
       time.sleep(1)
 else:
-  _build_and_run(lambda: False)
+  sys.exit(_build_and_run(lambda: False))
 


### PR DESCRIPTION
If not running in forever mode, and a test fails, fail run_tests.py
also.

If running in forever mode and make fails, wait for the next run.
