### PR TITLE
Updates to use the latest version of protobuf-ruby

### DIFF
--- a/src/ruby/grpc.gemspec
+++ b/src/ruby/grpc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'xray'
   s.add_dependency 'logging', '~> 1.8'
-  s.add_dependency 'google-protobuf', '~> 3.0.0alpha'
+  s.add_dependency 'google-protobuf', '~> 3.0.0alpha.1.1'
   s.add_dependency 'minitest', '~> 5.4'  # not a dev dependency, used by the interop tests
 
   s.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
This resolves issues decoding empty messages.
