### PR TITLE
Cleanup makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ endif
 
 .SECONDARY = %.pb.h %.pb.cc
 
+PROTOC_PLUGINS= bins/$(CONFIG)/cpp_plugin bins/$(CONFIG)/ruby_plugin
 ifeq ($(DEP_MISSING),)
 all: static shared
 dep_error:
@@ -901,8 +902,6 @@ test_cxx: buildtests_cxx
 
 tools: privatelibs bins/$(CONFIG)/gen_hpack_tables bins/$(CONFIG)/grpc_fetch_oauth2
 
-protoc_plugins: bins/$(CONFIG)/cpp_plugin bins/$(CONFIG)/ruby_plugin
-
 buildbenchmarks: privatelibs bins/$(CONFIG)/grpc_completion_queue_benchmark bins/$(CONFIG)/low_level_ping_pong_benchmark
 
 benchmarks: buildbenchmarks
@@ -937,37 +936,37 @@ strip-shared_cxx: shared_cxx
 	$(E) "[STRIP]   Stripping libgrpc++.so"
 	$(Q) $(STRIP) libs/$(CONFIG)/libgrpc++.$(SHARED_EXT)
 
-gens/test/cpp/interop/empty.pb.cc: test/cpp/interop/empty.proto protoc_plugins
+gens/test/cpp/interop/empty.pb.cc: test/cpp/interop/empty.proto $(PROTOC_PLUGINS)
 	$(E) "[PROTOC]  Generating protobuf CC file from $<"
 	$(Q) mkdir -p `dirname $@`
 	$(Q) $(PROTOC) --cpp_out=gens --grpc_out=gens --plugin=protoc-gen-grpc=bins/$(CONFIG)/cpp_plugin $<
 
-gens/test/cpp/interop/messages.pb.cc: test/cpp/interop/messages.proto protoc_plugins
+gens/test/cpp/interop/messages.pb.cc: test/cpp/interop/messages.proto $(PROTOC_PLUGINS)
 	$(E) "[PROTOC]  Generating protobuf CC file from $<"
 	$(Q) mkdir -p `dirname $@`
 	$(Q) $(PROTOC) --cpp_out=gens --grpc_out=gens --plugin=protoc-gen-grpc=bins/$(CONFIG)/cpp_plugin $<
 
-gens/test/cpp/interop/test.pb.cc: test/cpp/interop/test.proto protoc_plugins
+gens/test/cpp/interop/test.pb.cc: test/cpp/interop/test.proto $(PROTOC_PLUGINS)
 	$(E) "[PROTOC]  Generating protobuf CC file from $<"
 	$(Q) mkdir -p `dirname $@`
 	$(Q) $(PROTOC) --cpp_out=gens --grpc_out=gens --plugin=protoc-gen-grpc=bins/$(CONFIG)/cpp_plugin $<
 
-gens/test/cpp/qps/qpstest.pb.cc: test/cpp/qps/qpstest.proto protoc_plugins
+gens/test/cpp/qps/qpstest.pb.cc: test/cpp/qps/qpstest.proto $(PROTOC_PLUGINS)
 	$(E) "[PROTOC]  Generating protobuf CC file from $<"
 	$(Q) mkdir -p `dirname $@`
 	$(Q) $(PROTOC) --cpp_out=gens --grpc_out=gens --plugin=protoc-gen-grpc=bins/$(CONFIG)/cpp_plugin $<
 
-gens/test/cpp/util/echo.pb.cc: test/cpp/util/echo.proto protoc_plugins
+gens/test/cpp/util/echo.pb.cc: test/cpp/util/echo.proto $(PROTOC_PLUGINS)
 	$(E) "[PROTOC]  Generating protobuf CC file from $<"
 	$(Q) mkdir -p `dirname $@`
 	$(Q) $(PROTOC) --cpp_out=gens --grpc_out=gens --plugin=protoc-gen-grpc=bins/$(CONFIG)/cpp_plugin $<
 
-gens/test/cpp/util/echo_duplicate.pb.cc: test/cpp/util/echo_duplicate.proto protoc_plugins
+gens/test/cpp/util/echo_duplicate.pb.cc: test/cpp/util/echo_duplicate.proto $(PROTOC_PLUGINS)
 	$(E) "[PROTOC]  Generating protobuf CC file from $<"
 	$(Q) mkdir -p `dirname $@`
 	$(Q) $(PROTOC) --cpp_out=gens --grpc_out=gens --plugin=protoc-gen-grpc=bins/$(CONFIG)/cpp_plugin $<
 
-gens/test/cpp/util/messages.pb.cc: test/cpp/util/messages.proto protoc_plugins
+gens/test/cpp/util/messages.pb.cc: test/cpp/util/messages.proto $(PROTOC_PLUGINS)
 	$(E) "[PROTOC]  Generating protobuf CC file from $<"
 	$(Q) mkdir -p `dirname $@`
 	$(Q) $(PROTOC) --cpp_out=gens --grpc_out=gens --plugin=protoc-gen-grpc=bins/$(CONFIG)/cpp_plugin $<

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -219,6 +219,13 @@ endif
 
 .SECONDARY = %.pb.h %.pb.cc
 
+PROTOC_PLUGINS=\
+% for tgt in targets:
+% if tgt.build == 'protoc':
+ bins/$(CONFIG)/${tgt.name}\
+% endif
+% endfor
+
 ifeq ($(DEP_MISSING),)
 all: static shared\
 % for tgt in targets:
@@ -394,14 +401,6 @@ tools: privatelibs\
 % endfor
 
 
-protoc_plugins:\
-% for tgt in targets:
-% if tgt.build == 'protoc':
- bins/$(CONFIG)/${tgt.name}\
-% endif
-% endfor
-
-
 buildbenchmarks: privatelibs\
 % for tgt in targets:
 % if tgt.build == 'benchmark':
@@ -459,7 +458,7 @@ strip-shared_cxx: shared_cxx
 % endfor
 
 % for p in protos:
-gens/${p}.pb.cc: ${p}.proto protoc_plugins
+gens/${p}.pb.cc: ${p}.proto $(PROTOC_PLUGINS)
 	$(E) "[PROTOC]  Generating protobuf CC file from $<"
 	$(Q) mkdir -p `dirname $@`
 	$(Q) $(PROTOC) --cpp_out=gens --grpc_out=gens --plugin=protoc-gen-grpc=bins/$(CONFIG)/cpp_plugin $<


### PR DESCRIPTION
Speed up 'make clean', actually use dependency information (and generate them in one pass).
The individual commit comments make sense to read for further info.
