### PR TITLE
Fixing typos in build.json: .cpp -> .cc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2654,8 +2654,8 @@ endif
 
 
 CPP_PLUGIN_SRC = \
-    src/compiler/cpp_plugin.cpp \
-    src/compiler/cpp_generator.cpp \
+    src/compiler/cpp_plugin.cc \
+    src/compiler/cpp_generator.cc \
 
 CPP_PLUGIN_OBJS = $(addprefix objs/$(CONFIG)/, $(addsuffix .o, $(basename $(CPP_PLUGIN_SRC))))
 
@@ -2675,8 +2675,8 @@ endif
 
 
 RUBY_PLUGIN_SRC = \
-    src/compiler/ruby_plugin.cpp \
-    src/compiler/ruby_generator.cpp \
+    src/compiler/ruby_plugin.cc \
+    src/compiler/ruby_generator.cc \
 
 RUBY_PLUGIN_OBJS = $(addprefix objs/$(CONFIG)/, $(addsuffix .o, $(basename $(RUBY_PLUGIN_SRC))))
 

--- a/build.json
+++ b/build.json
@@ -422,8 +422,8 @@
       "c++": true,
       "secure": false,
       "src": [
-        "src/compiler/cpp_plugin.cpp",
-        "src/compiler/cpp_generator.cpp"
+        "src/compiler/cpp_plugin.cc",
+        "src/compiler/cpp_generator.cc"
       ],
       "headers": [
         "src/compiler/cpp_generator.h",
@@ -437,8 +437,8 @@
       "c++": true,
       "secure": false,
       "src": [
-        "src/compiler/ruby_plugin.cpp",
-        "src/compiler/ruby_generator.cpp"
+        "src/compiler/ruby_plugin.cc",
+        "src/compiler/ruby_generator.cc"
       ],
       "headers": [
         "src/compiler/cpp_generator.h",


### PR DESCRIPTION
This was working so far because of GNU make's magic that automatically finds the sources depending on its output, and not on its input.

This also explains why running "make" would always rebuild the plugins: because GNU make think some dependencies are phony and aren't there.
