### PR TITLE
Changing size type in Transport Security (TSI) from uint32_t to size_t

### DIFF
--- a/src/core/security/secure_endpoint.c
+++ b/src/core/security/secure_endpoint.c
@@ -126,8 +126,8 @@ static void on_read(void *user_data, gpr_slice *slices, size_t nslices,
     size_t message_size = GPR_SLICE_LENGTH(encrypted);
 
     while (message_size > 0 || keep_looping) {
-      gpr_uint32 unprotected_buffer_size_written = end - cur;
-      gpr_uint32 processed_message_size = message_size;
+      size_t unprotected_buffer_size_written = end - cur;
+      size_t processed_message_size = message_size;
       gpr_mu_lock(&ep->protector_mu);
       result = tsi_frame_protector_unprotect(ep->protector, message_bytes,
                                              &processed_message_size, cur,
@@ -245,8 +245,8 @@ static grpc_endpoint_write_status endpoint_write(grpc_endpoint *secure_ep,
     gpr_uint8 *message_bytes = GPR_SLICE_START_PTR(plain);
     size_t message_size = GPR_SLICE_LENGTH(plain);
     while (message_size > 0) {
-      gpr_uint32 protected_buffer_size_to_send = end - cur;
-      gpr_uint32 processed_message_size = message_size;
+      size_t protected_buffer_size_to_send = end - cur;
+      size_t processed_message_size = message_size;
       gpr_mu_lock(&ep->protector_mu);
       result = tsi_frame_protector_protect(ep->protector, message_bytes,
                                            &processed_message_size, cur,
@@ -268,9 +268,9 @@ static grpc_endpoint_write_status endpoint_write(grpc_endpoint *secure_ep,
     if (result != TSI_OK) break;
   }
   if (result == TSI_OK) {
-    gpr_uint32 still_pending_size;
+    size_t still_pending_size;
     do {
-      gpr_uint32 protected_buffer_size_to_send = end - cur;
+      size_t protected_buffer_size_to_send = end - cur;
       gpr_mu_lock(&ep->protector_mu);
       result = tsi_frame_protector_protect_flush(ep->protector, cur,
                                                  &protected_buffer_size_to_send,

--- a/src/core/security/secure_transport_setup.c
+++ b/src/core/security/secure_transport_setup.c
@@ -131,7 +131,7 @@ static void send_handshake_bytes_to_peer(grpc_secure_transport_setup *s) {
   grpc_endpoint_write_status write_status;
 
   do {
-    uint32_t to_send_size = s->handshake_buffer_size - offset;
+    size_t to_send_size = s->handshake_buffer_size - offset;
     result = tsi_handshaker_get_bytes_to_send_to_peer(
         s->handshaker, s->handshake_buffer + offset, &to_send_size);
     offset += to_send_size;
@@ -174,7 +174,7 @@ static void on_handshake_data_received_from_peer(
     void *setup, gpr_slice *slices, size_t nslices,
     grpc_endpoint_cb_status error) {
   grpc_secure_transport_setup *s = setup;
-  uint32_t consumed_slice_size = 0;
+  size_t consumed_slice_size = 0;
   tsi_result result = TSI_OK;
   size_t i;
   size_t num_left_overs;

--- a/src/core/security/security_context.c
+++ b/src/core/security/security_context.c
@@ -411,9 +411,9 @@ grpc_security_status grpc_ssl_server_security_context_create(
   c->base.vtable = &ssl_server_vtable;
   result = tsi_create_ssl_server_handshaker_factory(
       (const unsigned char **)&config->pem_private_key,
-      (const gpr_uint32 *)&config->pem_private_key_size,
+      &config->pem_private_key_size,
       (const unsigned char **)&config->pem_cert_chain,
-      (const gpr_uint32 *)&config->pem_cert_chain_size, 1,
+      &config->pem_cert_chain_size, 1,
       config->pem_root_certs, config->pem_root_certs_size,
       GRPC_SSL_CIPHER_SUITES, alpn_protocol_strings,
       alpn_protocol_string_lengths, num_alpn_protocols, &c->handshaker_factory);

--- a/src/core/tsi/ssl_transport_security.c
+++ b/src/core/tsi/ssl_transport_security.c
@@ -76,9 +76,9 @@ typedef struct {
      associated with the contexts at the same index.  */
   SSL_CTX** ssl_contexts;
   tsi_peer* ssl_context_x509_subject_names;
-  uint32_t ssl_context_count;
+  size_t ssl_context_count;
   unsigned char* alpn_protocol_list;
-  uint32_t alpn_protocol_list_length;
+  size_t alpn_protocol_list_length;
 } tsi_ssl_server_handshaker_factory;
 
 typedef struct {
@@ -95,8 +95,8 @@ typedef struct {
   BIO* into_ssl;
   BIO* from_ssl;
   unsigned char* buffer;
-  uint32_t buffer_size;
-  uint32_t buffer_offset;
+  size_t buffer_size;
+  size_t buffer_offset;
 } tsi_ssl_frame_protector;
 
 /* --- Library Initialization. ---*/
@@ -159,7 +159,7 @@ static void ssl_info_callback(const SSL* ssl, int where, int ret) {
 
 /* Gets the subject CN from an X509 cert. */
 static tsi_result ssl_get_x509_common_name(X509* cert, unsigned char** utf8,
-                                           uint32_t* utf8_size) {
+                                           size_t* utf8_size) {
   int common_name_index = -1;
   X509_NAME_ENTRY* common_name_entry = NULL;
   ASN1_STRING* common_name_asn1 = NULL;
@@ -200,7 +200,7 @@ static tsi_result ssl_get_x509_common_name(X509* cert, unsigned char** utf8,
 static tsi_result peer_property_from_x509_common_name(
     X509* cert, tsi_peer_property* property) {
   unsigned char* common_name;
-  uint32_t common_name_size;
+  size_t common_name_size;
   tsi_result result =
       ssl_get_x509_common_name(cert, &common_name, &common_name_size);
   if (result != TSI_OK) return result;
@@ -266,7 +266,7 @@ static tsi_result peer_property_from_x509_subject_alt_names(
 static tsi_result peer_from_x509(X509* cert, int include_certificate_type,
                                  tsi_peer* peer) {
   /* TODO(jboeuf): Maybe add more properties. */
-  uint32_t property_count = include_certificate_type ? 3 : 2;
+  size_t property_count = include_certificate_type ? 3 : 2;
   tsi_result result = tsi_construct_peer(property_count, peer);
   if (result != TSI_OK) return result;
   do {
@@ -299,7 +299,7 @@ static void log_ssl_error_stack(void) {
 
 /* Performs an SSL_read and handle errors. */
 static tsi_result do_ssl_read(SSL* ssl, unsigned char* unprotected_bytes,
-                              uint32_t* unprotected_bytes_size) {
+                              size_t* unprotected_bytes_size) {
   int read_from_ssl = SSL_read(ssl, unprotected_bytes, *unprotected_bytes_size);
   if (read_from_ssl == 0) {
     gpr_log(GPR_ERROR, "SSL_read returned 0 unexpectedly.");
@@ -333,7 +333,7 @@ static tsi_result do_ssl_read(SSL* ssl, unsigned char* unprotected_bytes,
 
 /* Performs an SSL_write and handle errors. */
 static tsi_result do_ssl_write(SSL* ssl, unsigned char* unprotected_bytes,
-                               uint32_t unprotected_bytes_size) {
+                               size_t unprotected_bytes_size) {
   int ssl_write_result =
       SSL_write(ssl, unprotected_bytes, unprotected_bytes_size);
   if (ssl_write_result < 0) {
@@ -354,7 +354,7 @@ static tsi_result do_ssl_write(SSL* ssl, unsigned char* unprotected_bytes,
 /* Loads an in-memory PEM certificate chain into the SSL context. */
 static tsi_result ssl_ctx_use_certificate_chain(
     SSL_CTX* context, const unsigned char* pem_cert_chain,
-    uint32_t pem_cert_chain_size) {
+    size_t pem_cert_chain_size) {
   tsi_result result = TSI_OK;
   X509* certificate = NULL;
   BIO* pem = BIO_new_mem_buf((void*)pem_cert_chain, pem_cert_chain_size);
@@ -395,7 +395,7 @@ static tsi_result ssl_ctx_use_certificate_chain(
 /* Loads an in-memory PEM private key into the SSL context. */
 static tsi_result ssl_ctx_use_private_key(SSL_CTX* context,
                                           const unsigned char* pem_key,
-                                          uint32_t pem_key_size) {
+                                          size_t pem_key_size) {
   tsi_result result = TSI_OK;
   EVP_PKEY* private_key = NULL;
   BIO* pem = BIO_new_mem_buf((void*)pem_key, pem_key_size);
@@ -419,10 +419,10 @@ static tsi_result ssl_ctx_use_private_key(SSL_CTX* context,
 /* Loads in-memory PEM verification certs into the SSL context and optionally
    returns the verification cert names (root_names can be NULL). */
 static tsi_result ssl_ctx_load_verification_certs(
-    SSL_CTX* context, const unsigned char* pem_roots, uint32_t pem_roots_size,
+    SSL_CTX* context, const unsigned char* pem_roots, size_t pem_roots_size,
     STACK_OF(X509_NAME) * *root_names) {
   tsi_result result = TSI_OK;
-  uint32_t num_roots = 0;
+  size_t num_roots = 0;
   X509* root = NULL;
   X509_NAME* root_name = NULL;
   BIO* pem = BIO_new_mem_buf((void*)pem_roots, pem_roots_size);
@@ -485,8 +485,8 @@ static tsi_result ssl_ctx_load_verification_certs(
    cipher list and the ephemeral ECDH key. */
 static tsi_result populate_ssl_context(
     SSL_CTX* context, const unsigned char* pem_private_key,
-    uint32_t pem_private_key_size, const unsigned char* pem_certificate_chain,
-    uint32_t pem_certificate_chain_size, const char* cipher_list) {
+    size_t pem_private_key_size, const unsigned char* pem_certificate_chain,
+    size_t pem_certificate_chain_size, const char* cipher_list) {
   tsi_result result = TSI_OK;
   if (pem_certificate_chain != NULL) {
     result = ssl_ctx_use_certificate_chain(context, pem_certificate_chain,
@@ -522,7 +522,7 @@ static tsi_result populate_ssl_context(
 
 /* Extracts the CN and the SANs from an X509 cert as a peer object. */
 static tsi_result extract_x509_subject_names_from_pem_cert(
-    const unsigned char* pem_cert, uint32_t pem_cert_size, tsi_peer* peer) {
+    const unsigned char* pem_cert, size_t pem_cert_size, tsi_peer* peer) {
   tsi_result result = TSI_OK;
   X509* cert = NULL;
   BIO* pem = BIO_new_mem_buf((void*)pem_cert, pem_cert_size);
@@ -544,7 +544,7 @@ static tsi_result extract_x509_subject_names_from_pem_cert(
 static tsi_result build_alpn_protocol_name_list(
     const unsigned char** alpn_protocols,
     const unsigned char* alpn_protocols_lengths, uint16_t num_alpn_protocols,
-    unsigned char** protocol_name_list, uint32_t* protocol_name_list_length) {
+    unsigned char** protocol_name_list, size_t* protocol_name_list_length) {
   uint16_t i;
   unsigned char* current;
   *protocol_name_list = NULL;
@@ -575,15 +575,15 @@ static tsi_result build_alpn_protocol_name_list(
 
 static tsi_result ssl_protector_protect(
     tsi_frame_protector* self, const unsigned char* unprotected_bytes,
-    uint32_t* unprotected_bytes_size, unsigned char* protected_output_frames,
-    uint32_t* protected_output_frames_size) {
+    size_t* unprotected_bytes_size, unsigned char* protected_output_frames,
+    size_t* protected_output_frames_size) {
   tsi_ssl_frame_protector* impl = (tsi_ssl_frame_protector*)self;
   int read_from_ssl;
-  uint32_t available;
+  size_t available;
   tsi_result result = TSI_OK;
 
   /* First see if we have some pending data in the SSL BIO. */
-  uint32_t pending_in_ssl = BIO_ctrl_pending(impl->from_ssl);
+  size_t pending_in_ssl = BIO_ctrl_pending(impl->from_ssl);
   if (pending_in_ssl > 0) {
     *unprotected_bytes_size = 0;
     read_from_ssl = BIO_read(impl->from_ssl, protected_output_frames,
@@ -627,7 +627,7 @@ static tsi_result ssl_protector_protect(
 
 static tsi_result ssl_protector_protect_flush(
     tsi_frame_protector* self, unsigned char* protected_output_frames,
-    uint32_t* protected_output_frames_size, uint32_t* still_pending_size) {
+    size_t* protected_output_frames_size, size_t* still_pending_size) {
   tsi_result result = TSI_OK;
   tsi_ssl_frame_protector* impl = (tsi_ssl_frame_protector*)self;
   int read_from_ssl = 0;
@@ -654,12 +654,12 @@ static tsi_result ssl_protector_protect_flush(
 
 static tsi_result ssl_protector_unprotect(
     tsi_frame_protector* self, const unsigned char* protected_frames_bytes,
-    uint32_t* protected_frames_bytes_size, unsigned char* unprotected_bytes,
-    uint32_t* unprotected_bytes_size) {
+    size_t* protected_frames_bytes_size, unsigned char* unprotected_bytes,
+    size_t* unprotected_bytes_size) {
   tsi_result result = TSI_OK;
   int written_into_ssl = 0;
-  uint32_t output_bytes_size = *unprotected_bytes_size;
-  uint32_t output_bytes_offset = 0;
+  size_t output_bytes_size = *unprotected_bytes_size;
+  size_t output_bytes_offset = 0;
   tsi_ssl_frame_protector* impl = (tsi_ssl_frame_protector*)self;
 
   /* First, try to read remaining data from ssl. */
@@ -708,7 +708,7 @@ static const tsi_frame_protector_vtable frame_protector_vtable = {
 /* --- tsi_handshaker methods implementation. ---*/
 
 static tsi_result ssl_handshaker_get_bytes_to_send_to_peer(
-    tsi_handshaker* self, unsigned char* bytes, uint32_t* bytes_size) {
+    tsi_handshaker* self, unsigned char* bytes, size_t* bytes_size) {
   tsi_ssl_handshaker* impl = (tsi_ssl_handshaker*)self;
   int bytes_read_from_ssl = 0;
   if (bytes == NULL || bytes_size == NULL || *bytes_size == 0 ||
@@ -725,7 +725,7 @@ static tsi_result ssl_handshaker_get_bytes_to_send_to_peer(
       return TSI_OK;
     }
   }
-  *bytes_size = (uint32_t)bytes_read_from_ssl;
+  *bytes_size = (size_t)bytes_read_from_ssl;
   return BIO_ctrl_pending(impl->from_ssl) == 0 ? TSI_OK : TSI_INCOMPLETE_DATA;
 }
 
@@ -739,7 +739,7 @@ static tsi_result ssl_handshaker_get_result(tsi_handshaker* self) {
 }
 
 static tsi_result ssl_handshaker_process_bytes_from_peer(
-    tsi_handshaker* self, const unsigned char* bytes, uint32_t* bytes_size) {
+    tsi_handshaker* self, const unsigned char* bytes, size_t* bytes_size) {
   tsi_ssl_handshaker* impl = (tsi_ssl_handshaker*)self;
   int bytes_written_into_ssl_size = 0;
   if (bytes == NULL || bytes_size == 0 || *bytes_size > INT_MAX) {
@@ -796,7 +796,7 @@ static tsi_result ssl_handshaker_extract_peer(tsi_handshaker* self,
   }
   SSL_get0_alpn_selected(impl->ssl, &alpn_selected, &alpn_selected_len);
   if (alpn_selected != NULL) {
-    uint32_t i;
+    size_t i;
     tsi_peer_property* new_properties =
         calloc(1, sizeof(tsi_peer_property) * (peer->property_count + 1));
     if (new_properties == NULL) return TSI_OUT_OF_RESOURCES;
@@ -818,9 +818,9 @@ static tsi_result ssl_handshaker_extract_peer(tsi_handshaker* self,
 }
 
 static tsi_result ssl_handshaker_create_frame_protector(
-    tsi_handshaker* self, uint32_t* max_output_protected_frame_size,
+    tsi_handshaker* self, size_t* max_output_protected_frame_size,
     tsi_frame_protector** protector) {
-  uint32_t actual_max_output_protected_frame_size =
+  size_t actual_max_output_protected_frame_size =
       TSI_SSL_MAX_PROTECTED_FRAME_SIZE_UPPER_BOUND;
   tsi_ssl_handshaker* impl = (tsi_ssl_handshaker*)self;
   tsi_ssl_frame_protector* protector_impl =
@@ -993,7 +993,7 @@ static void ssl_server_handshaker_factory_destroy(
     tsi_ssl_handshaker_factory* self) {
   tsi_ssl_server_handshaker_factory* impl =
       (tsi_ssl_server_handshaker_factory*)self;
-  uint32_t i;
+  size_t i;
   for (i = 0; i < impl->ssl_context_count; i++) {
     if (impl->ssl_contexts[i] != NULL) {
       SSL_CTX_free(impl->ssl_contexts[i]);
@@ -1008,7 +1008,7 @@ static void ssl_server_handshaker_factory_destroy(
   free(impl);
 }
 
-static int does_entry_match_name(const char* entry, uint32_t entry_length,
+static int does_entry_match_name(const char* entry, size_t entry_length,
                                  const char* name) {
   const char* name_subdomain = NULL;
   if (entry_length == 0) return 0;
@@ -1035,7 +1035,7 @@ static int ssl_server_handshaker_factory_servername_callback(SSL* ssl, int* ap,
                                                              void* arg) {
   tsi_ssl_server_handshaker_factory* impl =
       (tsi_ssl_server_handshaker_factory*)arg;
-  uint32_t i = 0;
+  size_t i = 0;
   const char* servername = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
   if (servername == NULL || strlen(servername) == 0) {
     return SSL_TLSEXT_ERR_NOACK;
@@ -1080,9 +1080,9 @@ static int server_handshaker_factory_alpn_callback(
 /* --- tsi_ssl_handshaker_factory constructors. --- */
 
 tsi_result tsi_create_ssl_client_handshaker_factory(
-    const unsigned char* pem_private_key, uint32_t pem_private_key_size,
-    const unsigned char* pem_cert_chain, uint32_t pem_cert_chain_size,
-    const unsigned char* pem_root_certs, uint32_t pem_root_certs_size,
+    const unsigned char* pem_private_key, size_t pem_private_key_size,
+    const unsigned char* pem_cert_chain, size_t pem_cert_chain_size,
+    const unsigned char* pem_root_certs, size_t pem_root_certs_size,
     const char* cipher_list, const unsigned char** alpn_protocols,
     const unsigned char* alpn_protocols_lengths, uint16_t num_alpn_protocols,
     tsi_ssl_handshaker_factory** factory) {
@@ -1115,7 +1115,7 @@ tsi_result tsi_create_ssl_client_handshaker_factory(
 
     if (num_alpn_protocols != 0) {
       unsigned char* alpn_protocol_list = NULL;
-      uint32_t alpn_protocol_list_length = 0;
+      size_t alpn_protocol_list_length = 0;
       int ssl_failed;
       result = build_alpn_protocol_name_list(
           alpn_protocols, alpn_protocols_lengths, num_alpn_protocols,
@@ -1157,17 +1157,17 @@ tsi_result tsi_create_ssl_client_handshaker_factory(
 
 tsi_result tsi_create_ssl_server_handshaker_factory(
     const unsigned char** pem_private_keys,
-    const uint32_t* pem_private_keys_sizes,
+    const size_t* pem_private_keys_sizes,
     const unsigned char** pem_cert_chains,
-    const uint32_t* pem_cert_chains_sizes, uint32_t key_cert_pair_count,
+    const size_t* pem_cert_chains_sizes, size_t key_cert_pair_count,
     const unsigned char* pem_client_root_certs,
-    uint32_t pem_client_root_certs_size, const char* cipher_list,
+    size_t pem_client_root_certs_size, const char* cipher_list,
     const unsigned char** alpn_protocols,
     const unsigned char* alpn_protocols_lengths, uint16_t num_alpn_protocols,
     tsi_ssl_handshaker_factory** factory) {
   tsi_ssl_server_handshaker_factory* impl = NULL;
   tsi_result result = TSI_OK;
-  uint32_t i = 0;
+  size_t i = 0;
 
   gpr_once_init(&init_openssl_once, init_openssl);
 
@@ -1255,7 +1255,7 @@ tsi_result tsi_create_ssl_server_handshaker_factory(
 /* --- tsi_ssl utils. --- */
 
 int tsi_ssl_peer_matches_name(const tsi_peer* peer, const char* name) {
-  uint32_t i = 0;
+  size_t i = 0;
   const tsi_peer_property* property = tsi_peer_get_property_by_name(
       peer, TSI_X509_SUBJECT_COMMON_NAME_PEER_PROPERTY);
   if (property == NULL || property->type != TSI_PEER_PROPERTY_TYPE_STRING) {

--- a/src/core/tsi/ssl_transport_security.h
+++ b/src/core/tsi/ssl_transport_security.h
@@ -89,9 +89,9 @@ typedef struct tsi_ssl_handshaker_factory tsi_ssl_handshaker_factory;
    - This method returns TSI_OK on success or TSI_INVALID_PARAMETER in the case
      where a parameter is invalid.  */
 tsi_result tsi_create_ssl_client_handshaker_factory(
-    const unsigned char* pem_private_key, uint32_t pem_private_key_size,
-    const unsigned char* pem_cert_chain, uint32_t pem_cert_chain_size,
-    const unsigned char* pem_root_certs, uint32_t pem_root_certs_size,
+    const unsigned char* pem_private_key, size_t pem_private_key_size,
+    const unsigned char* pem_cert_chain, size_t pem_cert_chain_size,
+    const unsigned char* pem_root_certs, size_t pem_root_certs_size,
     const char* cipher_suites, const unsigned char** alpn_protocols,
     const unsigned char* alpn_protocols_lengths, uint16_t num_alpn_protocols,
     tsi_ssl_handshaker_factory** factory);
@@ -132,11 +132,11 @@ tsi_result tsi_create_ssl_client_handshaker_factory(
      where a parameter is invalid.  */
 tsi_result tsi_create_ssl_server_handshaker_factory(
     const unsigned char** pem_private_keys,
-    const uint32_t* pem_private_keys_sizes,
+    const size_t* pem_private_keys_sizes,
     const unsigned char** pem_cert_chains,
-    const uint32_t* pem_cert_chains_sizes, uint32_t key_cert_pair_count,
+    const size_t* pem_cert_chains_sizes, size_t key_cert_pair_count,
     const unsigned char* pem_client_root_certs,
-    uint32_t pem_client_root_certs_size, const char* cipher_suites,
+    size_t pem_client_root_certs_size, const char* cipher_suites,
     const unsigned char** alpn_protocols,
     const unsigned char* alpn_protocols_lengths, uint16_t num_alpn_protocols,
     tsi_ssl_handshaker_factory** factory);

--- a/src/core/tsi/transport_security.c
+++ b/src/core/tsi/transport_security.c
@@ -40,7 +40,7 @@
 
 char* tsi_strdup(const char* src) {
   char* dst;
-  uint32_t len;
+  size_t len;
   if (!src) return NULL;
   len = strlen(src) + 1;
   dst = malloc(len);
@@ -90,9 +90,9 @@ const char* tsi_result_to_string(tsi_result result) {
 
 tsi_result tsi_frame_protector_protect(tsi_frame_protector* self,
                                        const unsigned char* unprotected_bytes,
-                                       uint32_t* unprotected_bytes_size,
+                                       size_t* unprotected_bytes_size,
                                        unsigned char* protected_output_frames,
-                                       uint32_t* protected_output_frames_size) {
+                                       size_t* protected_output_frames_size) {
   if (self == NULL || unprotected_bytes == NULL ||
       unprotected_bytes_size == NULL || protected_output_frames == NULL ||
       protected_output_frames_size == NULL) {
@@ -105,7 +105,7 @@ tsi_result tsi_frame_protector_protect(tsi_frame_protector* self,
 
 tsi_result tsi_frame_protector_protect_flush(
     tsi_frame_protector* self, unsigned char* protected_output_frames,
-    uint32_t* protected_output_frames_size, uint32_t* still_pending_size) {
+    size_t* protected_output_frames_size, size_t* still_pending_size) {
   if (self == NULL || protected_output_frames == NULL ||
       protected_output_frames == NULL || still_pending_size == NULL) {
     return TSI_INVALID_ARGUMENT;
@@ -117,8 +117,8 @@ tsi_result tsi_frame_protector_protect_flush(
 
 tsi_result tsi_frame_protector_unprotect(
     tsi_frame_protector* self, const unsigned char* protected_frames_bytes,
-    uint32_t* protected_frames_bytes_size, unsigned char* unprotected_bytes,
-    uint32_t* unprotected_bytes_size) {
+    size_t* protected_frames_bytes_size, unsigned char* unprotected_bytes,
+    size_t* unprotected_bytes_size) {
   if (self == NULL || protected_frames_bytes == NULL ||
       protected_frames_bytes_size == NULL || unprotected_bytes == NULL ||
       unprotected_bytes_size == NULL) {
@@ -140,7 +140,7 @@ void tsi_frame_protector_destroy(tsi_frame_protector* self) {
 
 tsi_result tsi_handshaker_get_bytes_to_send_to_peer(tsi_handshaker* self,
                                                     unsigned char* bytes,
-                                                    uint32_t* bytes_size) {
+                                                    size_t* bytes_size) {
   if (self == NULL) return TSI_INVALID_ARGUMENT;
   if (self->frame_protector_created) return TSI_FAILED_PRECONDITION;
   return self->vtable->get_bytes_to_send_to_peer(self, bytes, bytes_size);
@@ -148,7 +148,7 @@ tsi_result tsi_handshaker_get_bytes_to_send_to_peer(tsi_handshaker* self,
 
 tsi_result tsi_handshaker_process_bytes_from_peer(tsi_handshaker* self,
                                                   const unsigned char* bytes,
-                                                  uint32_t* bytes_size) {
+                                                  size_t* bytes_size) {
   if (self == NULL) return TSI_INVALID_ARGUMENT;
   if (self->frame_protector_created) return TSI_FAILED_PRECONDITION;
   return self->vtable->process_bytes_from_peer(self, bytes, bytes_size);
@@ -171,7 +171,7 @@ tsi_result tsi_handshaker_extract_peer(tsi_handshaker* self, tsi_peer* peer) {
 }
 
 tsi_result tsi_handshaker_create_frame_protector(
-    tsi_handshaker* self, uint32_t* max_protected_frame_size,
+    tsi_handshaker* self, size_t* max_protected_frame_size,
     tsi_frame_protector** protector) {
   tsi_result result;
   if (self == NULL || protector == NULL) return TSI_INVALID_ARGUMENT;
@@ -196,7 +196,7 @@ void tsi_handshaker_destroy(tsi_handshaker* self) {
 
 const tsi_peer_property* tsi_peer_get_property_by_name(const tsi_peer* self,
                                                        const char* name) {
-  uint32_t i;
+  size_t i;
   if (self == NULL) return NULL;
   for (i = 0; i < self->property_count; i++) {
     const tsi_peer_property* property = &self->properties[i];
@@ -218,8 +218,8 @@ tsi_peer_property tsi_init_peer_property(void) {
 }
 
 static void tsi_peer_destroy_list_property(tsi_peer_property* children,
-                                           uint32_t child_count) {
-  uint32_t i;
+                                           size_t child_count) {
+  size_t i;
   for (i = 0; i < child_count; i++) {
     tsi_peer_property_destruct(&children[i]);
   }
@@ -292,7 +292,7 @@ tsi_result tsi_construct_real_peer_property(const char* name, double value,
 }
 
 tsi_result tsi_construct_allocated_string_peer_property(
-    const char* name, uint32_t value_length, tsi_peer_property* property) {
+    const char* name, size_t value_length, tsi_peer_property* property) {
   *property = tsi_init_peer_property();
   property->type = TSI_PEER_PROPERTY_TYPE_STRING;
   if (name != NULL) {
@@ -318,7 +318,7 @@ tsi_result tsi_construct_string_peer_property_from_cstring(
 
 tsi_result tsi_construct_string_peer_property(const char* name,
                                               const char* value,
-                                              uint32_t value_length,
+                                              size_t value_length,
                                               tsi_peer_property* property) {
   tsi_result result = tsi_construct_allocated_string_peer_property(
       name, value_length, property);
@@ -330,7 +330,7 @@ tsi_result tsi_construct_string_peer_property(const char* name,
 }
 
 tsi_result tsi_construct_list_peer_property(const char* name,
-                                            uint32_t child_count,
+                                            size_t child_count,
                                             tsi_peer_property* property) {
   *property = tsi_init_peer_property();
   property->type = TSI_PEER_PROPERTY_TYPE_LIST;
@@ -350,7 +350,7 @@ tsi_result tsi_construct_list_peer_property(const char* name,
   return TSI_OK;
 }
 
-tsi_result tsi_construct_peer(uint32_t property_count, tsi_peer* peer) {
+tsi_result tsi_construct_peer(size_t property_count, tsi_peer* peer) {
   memset(peer, 0, sizeof(tsi_peer));
   if (property_count > 0) {
     peer->properties = calloc(property_count, sizeof(tsi_peer_property));

--- a/src/core/tsi/transport_security.h
+++ b/src/core/tsi/transport_security.h
@@ -45,18 +45,18 @@ extern "C" {
 typedef struct {
   tsi_result (*protect)(tsi_frame_protector* self,
                         const unsigned char* unprotected_bytes,
-                        uint32_t* unprotected_bytes_size,
+                        size_t* unprotected_bytes_size,
                         unsigned char* protected_output_frames,
-                        uint32_t* protected_output_frames_size);
+                        size_t* protected_output_frames_size);
   tsi_result (*protect_flush)(tsi_frame_protector* self,
                               unsigned char* protected_output_frames,
-                              uint32_t* protected_output_frames_size,
-                              uint32_t* still_pending_size);
+                              size_t* protected_output_frames_size,
+                              size_t* still_pending_size);
   tsi_result (*unprotect)(tsi_frame_protector* self,
                           const unsigned char* protected_frames_bytes,
-                          uint32_t* protected_frames_bytes_size,
+                          size_t* protected_frames_bytes_size,
                           unsigned char* unprotected_bytes,
-                          uint32_t* unprotected_bytes_size);
+                          size_t* unprotected_bytes_size);
   void (*destroy)(tsi_frame_protector* self);
 } tsi_frame_protector_vtable;
 
@@ -69,14 +69,14 @@ struct tsi_frame_protector {
 typedef struct {
   tsi_result (*get_bytes_to_send_to_peer)(tsi_handshaker* self,
                                           unsigned char* bytes,
-                                          uint32_t* bytes_size);
+                                          size_t* bytes_size);
   tsi_result (*process_bytes_from_peer)(tsi_handshaker* self,
                                         const unsigned char* bytes,
-                                        uint32_t* bytes_size);
+                                        size_t* bytes_size);
   tsi_result (*get_result)(tsi_handshaker* self);
   tsi_result (*extract_peer)(tsi_handshaker* self, tsi_peer* peer);
   tsi_result (*create_frame_protector)(tsi_handshaker* self,
-                                       uint32_t* max_protected_frame_size,
+                                       size_t* max_protected_frame_size,
                                        tsi_frame_protector** protector);
   void (*destroy)(tsi_handshaker* self);
 } tsi_handshaker_vtable;
@@ -87,7 +87,7 @@ struct tsi_handshaker {
 };
 
 /* Peer and property construction/destruction functions. */
-tsi_result tsi_construct_peer(uint32_t property_count, tsi_peer* peer);
+tsi_result tsi_construct_peer(size_t property_count, tsi_peer* peer);
 tsi_peer_property tsi_init_peer_property(void);
 void tsi_peer_property_destruct(tsi_peer_property* property);
 tsi_result tsi_construct_signed_integer_peer_property(
@@ -98,14 +98,14 @@ tsi_result tsi_construct_real_peer_property(const char* name, double value,
                                             tsi_peer_property* property);
 tsi_result tsi_construct_string_peer_property(const char* name,
                                               const char* value,
-                                              uint32_t value_length,
+                                              size_t value_length,
                                               tsi_peer_property* property);
 tsi_result tsi_construct_allocated_string_peer_property(
-    const char* name, uint32_t value_length, tsi_peer_property* property);
+    const char* name, size_t value_length, tsi_peer_property* property);
 tsi_result tsi_construct_string_peer_property_from_cstring(
     const char* name, const char* value, tsi_peer_property* property);
 tsi_result tsi_construct_list_peer_property(const char* name,
-                                            uint32_t child_count,
+                                            size_t child_count,
                                             tsi_peer_property* property);
 
 /* Utils. */

--- a/test/core/security/secure_endpoint_test.c
+++ b/test/core/security/secure_endpoint_test.c
@@ -61,7 +61,7 @@ static grpc_endpoint_test_fixture secure_endpoint_create_fixture_tcp_socketpair(
   } else {
     int i;
     tsi_result result;
-    gpr_uint32 still_pending_size;
+    size_t still_pending_size;
     size_t total_buffer_size = 8192;
     size_t buffer_size = total_buffer_size;
     gpr_uint8 *encrypted_buffer = gpr_malloc(buffer_size);
@@ -72,8 +72,8 @@ static grpc_endpoint_test_fixture secure_endpoint_create_fixture_tcp_socketpair(
       gpr_uint8 *message_bytes = GPR_SLICE_START_PTR(plain);
       size_t message_size = GPR_SLICE_LENGTH(plain);
       while (message_size > 0) {
-        gpr_uint32 protected_buffer_size_to_send = buffer_size;
-        gpr_uint32 processed_message_size = message_size;
+        size_t protected_buffer_size_to_send = buffer_size;
+        size_t processed_message_size = message_size;
         result = tsi_frame_protector_protect(
             fake_write_protector, message_bytes, &processed_message_size, cur,
             &protected_buffer_size_to_send);
@@ -88,7 +88,7 @@ static grpc_endpoint_test_fixture secure_endpoint_create_fixture_tcp_socketpair(
       gpr_slice_unref(plain);
     }
     do {
-      gpr_uint32 protected_buffer_size_to_send = buffer_size;
+      size_t protected_buffer_size_to_send = buffer_size;
       result = tsi_frame_protector_protect_flush(fake_write_protector, cur,
                                                  &protected_buffer_size_to_send,
                                                  &still_pending_size);


### PR DESCRIPTION
Will remove grpc impedance mismatch.
