### PR TITLE
Fixes a regression in the ruby dockerfile

### DIFF
--- a/tools/dockerfile/grpc_ruby/Dockerfile
+++ b/tools/dockerfile/grpc_ruby/Dockerfile
@@ -9,6 +9,9 @@ RUN cd /var/local/git/grpc \
 # Build the C core.
 RUN make install_c -C /var/local/git/grpc
 
+# Install the grpc gem locally with its dependencies and build the extension
+RUN /bin/bash -l -c 'cd /var/local/git/grpc/src/ruby && bundle && rake compile:grpc && gem build grpc.gemspec && gem install grpc'
+
 # TODO add a command to run the unittest tests when the bug below is fixed
 # - the tests fail due to an error in the C threading library:
 #   they fail with 'ruby: __pthread_mutex_cond_lock_adjust for unknown reasons' at the end of a testcase


### PR DESCRIPTION
- the line that built and installed grpc ruby was mistakenly removed in #146
