### PR TITLE
Small tweaks to run_tests

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -19,7 +19,7 @@ class SimpleConfig(object):
 
   def __init__(self, config):
     self.build_config = config
-    self.maxjobs = 32 * multiprocessing.cpu_count()
+    self.maxjobs = 2 * multiprocessing.cpu_count()
     self.allow_hashing = (config != 'gcov')
 
   def run_command(self, binary):
@@ -32,7 +32,7 @@ class ValgrindConfig(object):
   def __init__(self, config, tool):
     self.build_config = config
     self.tool = tool
-    self.maxjobs = 4 * multiprocessing.cpu_count()
+    self.maxjobs = 2 * multiprocessing.cpu_count()
     self.allow_hashing = False
 
   def run_command(self, binary):

--- a/tools/run_tests/watch_dirs.py
+++ b/tools/run_tests/watch_dirs.py
@@ -25,6 +25,7 @@ class DirWatcher(object):
         continue
       for root, _, files in os.walk(path):
         for f in files:
+          if f and f[0] == '.': continue
           try:
             st = os.stat(os.path.join(root, f))
           except OSError as e:


### PR DESCRIPTION
Run faster on smaller machines.

Don't watch '.' prefixed files for changes. These files don't typically contribute to builds, and are used as vim temp files.
