### PR TITLE
Add a timeout to echo client's RPCs

### DIFF
--- a/test/core/echo/client.c
+++ b/test/core/echo/client.c
@@ -78,7 +78,9 @@ int main(int argc, char **argv) {
 
   GPR_ASSERT(argc == 2);
   channel = grpc_channel_create(argv[1], NULL);
-  call = grpc_channel_create_call(channel, "/foo", "localhost", gpr_inf_future);
+  call = grpc_channel_create_call(channel, "/foo", "localhost",
+                                  gpr_time_add(gpr_time_from_seconds(5),
+                                               gpr_now()));
   GPR_ASSERT(grpc_call_invoke(call, cq, (void *)1, (void *)1, 0) ==
              GRPC_CALL_OK);
 


### PR DESCRIPTION
This ensures that echo test fails in a timely manner rather than
hanging when it breaks.
