### PR TITLE
Change Node metadata representation to a more reasonable one

### DIFF
--- a/src/node/ext/event.cc
+++ b/src/node/ext/event.cc
@@ -31,6 +31,8 @@
  *
  */
 
+#include <map>
+
 #include <node.h>
 #include <nan.h>
 #include "grpc/grpc.h"
@@ -43,6 +45,7 @@
 namespace grpc {
 namespace node {
 
+using ::node::Buffer;
 using v8::Array;
 using v8::Date;
 using v8::Handle;
@@ -52,6 +55,36 @@ using v8::Object;
 using v8::Persistent;
 using v8::String;
 using v8::Value;
+
+Handle<Value> ParseMetadata(grpc_metadata *metadata_elements, size_t length) {
+  NanEscapableScope();
+  std::map<char*, size_t> size_map;
+  std::map<char*, size_t> index_map;
+
+  for (unsigned int i = 0; i < length; i++) {
+    char *key = metadata_elements[i].key;
+    if (size_map.count(key)) {
+      size_map[key] += 1;
+    }
+    index_map[key] = 0;
+  }
+  Handle<Object> metadata_object = NanNew<Object>();
+  for (unsigned int i = 0; i < length; i++) {
+    grpc_metadata* elem = &metadata_elements[i];
+    Handle<String> key_string = String::New(elem->key);
+    Handle<Array> array;
+    if (metadata_object->Has(key_string)) {
+      array = Handle<Array>::Cast(metadata_object->Get(key_string));
+    } else {
+      array = NanNew<Array>(size_map[elem->key]);
+      metadata_object->Set(key_string, array);
+    }
+    array->Set(index_map[elem->key],
+               NanNewBufferHandle(elem->value, elem->value_length));
+    index_map[elem->key] += 1;
+  }
+  return NanEscapeScope(metadata_object);
+}
 
 Handle<Value> GetEventData(grpc_event *event) {
   NanEscapableScope();
@@ -72,18 +105,7 @@ Handle<Value> GetEventData(grpc_event *event) {
     case GRPC_CLIENT_METADATA_READ:
       count = event->data.client_metadata_read.count;
       items = event->data.client_metadata_read.elements;
-      metadata = NanNew<Array>(static_cast<int>(count));
-      for (unsigned int i = 0; i < count; i++) {
-        Handle<Object> item_obj = NanNew<Object>();
-        item_obj->Set(NanNew<String, const char *>("key"),
-                      NanNew<String, char *>(items[i].key));
-        item_obj->Set(
-            NanNew<String, const char *>("value"),
-            NanNew<String, char *>(items[i].value,
-                                   static_cast<int>(items[i].value_length)));
-        metadata->Set(i, item_obj);
-      }
-      return NanEscapeScope(metadata);
+      return NanEscapeScope(ParseMetadata(items, count));
     case GRPC_FINISHED:
       status = NanNew<Object>();
       status->Set(NanNew("code"), NanNew<Number>(event->data.finished.status));
@@ -93,18 +115,7 @@ Handle<Value> GetEventData(grpc_event *event) {
       }
       count = event->data.finished.metadata_count;
       items = event->data.finished.metadata_elements;
-      metadata = NanNew<Array>(static_cast<int>(count));
-      for (unsigned int i = 0; i < count; i++) {
-        Handle<Object> item_obj = NanNew<Object>();
-        item_obj->Set(NanNew<String, const char *>("key"),
-                      NanNew<String, char *>(items[i].key));
-        item_obj->Set(
-            NanNew<String, const char *>("value"),
-            NanNew<String, char *>(items[i].value,
-                                   static_cast<int>(items[i].value_length)));
-        metadata->Set(i, item_obj);
-      }
-      status->Set(NanNew("metadata"), metadata);
+      status->Set(NanNew("metadata"), ParseMetadata(items, count));
       return NanEscapeScope(status);
     case GRPC_SERVER_RPC_NEW:
       rpc_new = NanNew<Object>();
@@ -133,7 +144,7 @@ Handle<Value> GetEventData(grpc_event *event) {
                                    static_cast<int>(items[i].value_length)));
         metadata->Set(i, item_obj);
       }
-      rpc_new->Set(NanNew<String, const char *>("metadata"), metadata);
+      rpc_new->Set(NanNew("metadata"), ParseMetadata(items, count));
       return NanEscapeScope(rpc_new);
     default:
       return NanEscapeScope(NanNull());

--- a/src/node/test/call_test.js
+++ b/src/node/test/call_test.js
@@ -99,24 +99,30 @@ describe('call', function() {
     });
   });
   describe('addMetadata', function() {
-    it('should succeed with objects containing keys and values', function() {
+    it('should succeed with a map from strings to string arrays', function() {
       var call = new grpc.Call(channel, 'method', getDeadline(1));
       assert.doesNotThrow(function() {
-        call.addMetadata();
+        call.addMetadata({'key': ['value']});
       });
       assert.doesNotThrow(function() {
-        call.addMetadata({'key' : 'key',
-                          'value' : new Buffer('value')});
+        call.addMetadata({'key1': ['value1'], 'key2': ['value2']});
+      });
+    });
+    it('should succeed with a map from strings to buffer arrays', function() {
+      var call = new grpc.Call(channel, 'method', getDeadline(1));
+      assert.doesNotThrow(function() {
+        call.addMetadata({'key': [new Buffer('value')]});
       });
       assert.doesNotThrow(function() {
-        call.addMetadata({'key' : 'key1',
-                          'value' : new Buffer('value1')},
-                         {'key' : 'key2',
-                          'value' : new Buffer('value2')});
+        call.addMetadata({'key1': [new Buffer('value1')],
+                          'key2': [new Buffer('value2')]});
       });
     });
     it('should fail with other parameter types', function() {
       var call = new grpc.Call(channel, 'method', getDeadline(1));
+      assert.throws(function() {
+        call.addMetadata();
+      });
       assert.throws(function() {
         call.addMetadata(null);
       }, TypeError);
@@ -133,7 +139,7 @@ describe('call', function() {
                   function() {done();},
                   0);
       assert.throws(function() {
-        call.addMetadata({'key' : 'key', 'value' : new Buffer('value') });
+        call.addMetadata({'key': ['value']});
       }, function(err) {
         return err.code === grpc.callError.ALREADY_INVOKED;
       });

--- a/src/node/test/server_test.js
+++ b/src/node/test/server_test.js
@@ -75,6 +75,9 @@ describe('echo server', function() {
 
     channel = new grpc.Channel('localhost:' + port_num);
   });
+  after(function() {
+    server.shutdown();
+  });
   it('should echo inputs as responses', function(done) {
     done = multiDone(done, 4);
 
@@ -95,7 +98,6 @@ describe('echo server', function() {
       var status = event.data;
       assert.strictEqual(status.code, grpc.status.OK);
       assert.strictEqual(status.details, status_text);
-      server.shutdown();
       done();
     }, 0);
     call.startWrite(


### PR DESCRIPTION
Node metadata is now represented as objects that map key strings to arrays of value buffers (because metadata values can have arbitrary binary data). For simplicity, `call.addMetadata` also accepts string values in place of buffer values. This closes #264
