### PR TITLE
Freelist grpc_fd objects

### DIFF
--- a/src/core/iomgr/fd_posix.h
+++ b/src/core/iomgr/fd_posix.h
@@ -69,6 +69,7 @@ typedef struct grpc_fd {
 
   grpc_iomgr_cb_func on_done;
   void *on_done_user_data;
+  struct grpc_fd *freelist_next;
 } grpc_fd;
 
 /* Create a wrapped file descriptor.
@@ -134,5 +135,8 @@ void grpc_fd_become_writable(grpc_fd *fd, int allow_synchronous_callback);
 /* Reference counting for fds */
 void grpc_fd_ref(grpc_fd *fd);
 void grpc_fd_unref(grpc_fd *fd);
+
+void grpc_fd_global_init(void);
+void grpc_fd_global_shutdown(void);
 
 #endif /* __GRPC_INTERNAL_IOMGR_FD_POSIX_H_ */

--- a/src/core/iomgr/iomgr.c
+++ b/src/core/iomgr/iomgr.c
@@ -98,7 +98,6 @@ void grpc_iomgr_shutdown(void) {
   gpr_timespec shutdown_deadline =
       gpr_time_add(gpr_now(), gpr_time_from_seconds(10));
 
-  grpc_iomgr_platform_shutdown();
 
   gpr_mu_lock(&g_mu);
   g_shutdown = 1;
@@ -129,6 +128,7 @@ void grpc_iomgr_shutdown(void) {
 
   gpr_event_wait(&g_background_callback_executor_done, gpr_inf_future);
 
+  grpc_iomgr_platform_shutdown();
   grpc_alarm_list_shutdown();
   gpr_mu_destroy(&g_mu);
   gpr_cv_destroy(&g_cv);

--- a/src/core/iomgr/iomgr_posix.c
+++ b/src/core/iomgr/iomgr_posix.c
@@ -32,7 +32,14 @@
  */
 
 #include "src/core/iomgr/iomgr_posix.h"
+#include "src/core/iomgr/fd_posix.h"
 
-void grpc_iomgr_platform_init(void) { grpc_pollset_global_init(); }
+void grpc_iomgr_platform_init(void) {
+  grpc_fd_global_init();
+  grpc_pollset_global_init();
+}
 
-void grpc_iomgr_platform_shutdown(void) { grpc_pollset_global_shutdown(); }
+void grpc_iomgr_platform_shutdown(void) {
+  grpc_pollset_global_shutdown();
+  grpc_fd_global_shutdown();
+}


### PR DESCRIPTION
This is necessary for efficient implementations where multiple threads
simultaneously sit in epoll_wait and the like on the same pollset.
