### PR TITLE
Fix grpc_java* Docker images

### DIFF
--- a/tools/dockerfile/grpc_java/Dockerfile
+++ b/tools/dockerfile/grpc_java/Dockerfile
@@ -1,13 +1,11 @@
 # Dockerfile for the gRPC Java dev image
 FROM grpc/java_base
 
-RUN  cd /var/local/git/grpc-java/lib/okhttp && \
-  mvn -pl okhttp -am install
-RUN  cd /var/local/git/grpc-java/lib/netty && \
-  mvn -pl codec-http2 -am -DskipTests install
+RUN git clone --recursive --depth 1 git@github.com:google/grpc-java.git /var/local/git/grpc-java
+RUN cd /var/local/git/grpc-java/lib/netty && \
+  mvn -pl codec-http2 -am -DskipTests install clean
 RUN cd /var/local/git/grpc-java && \
-  protoc --version>ver.txt && \
-  mvn install
+  ./gradlew build
 
 # Specify the default command such that the interop server runs on its known testing port
 CMD ["/var/local/git/grpc-java/run-test-server.sh", "--use_tls=true", "--port=8030"]

--- a/tools/dockerfile/grpc_java_base/Dockerfile
+++ b/tools/dockerfile/grpc_java_base/Dockerfile
@@ -9,35 +9,36 @@ RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true 
 RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list
 RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
-RUN apt-get update && apt-get -y install oracle-java8-installer
+RUN apt-get update && apt-get -y install oracle-java8-installer && \
+  apt-get clean && rm -r /var/cache/oracle-jdk8-installer/
 
 # Install maven
-RUN wget http://mirror.olnevhost.net/pub/apache/maven/binaries/apache-maven-3.2.1-bin.tar.gz && \
-  tar xvf apache-maven-3.2.1-bin.tar.gz -C /var/local
+RUN wget -O - http://mirror.olnevhost.net/pub/apache/maven/binaries/apache-maven-3.2.1-bin.tar.gz | \
+  tar xz -C /var/local
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 ENV M2_HOME /var/local/apache-maven-3.2.1
 ENV PATH $PATH:$JAVA_HOME/bin:$M2_HOME/bin
 ENV LD_LIBRARY_PATH /usr/local/lib
 
+# Get the protobuf source from GitHub and install it
+RUN wget -O - https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.tar.bz2 | \
+  tar xj && \
+  cd protobuf-2.6.1 && \
+  ./configure --prefix=/usr && \
+  make -j12 && make check && make install && \
+  rm -r "$(pwd)"
+
 # Install a GitHub SSH service credential that gives access to the GitHub repo while it's private
 # TODO: remove this once the repo is public
-ADD .ssh .ssh
-RUN chmod 600 .ssh/github.rsa
-RUN mkdir -p $HOME/.ssh && echo 'Host github.com' > $HOME/.ssh/config
-RUN echo "    IdentityFile /.ssh/github.rsa" >> $HOME/.ssh/config
-RUN echo 'StrictHostKeyChecking no' >> $HOME/.ssh/config
+COPY .ssh/github.rsa /root/.ssh/id_rsa
+RUN echo 'Host github.com\nStrictHostKeyChecking no' > /root/.ssh/config
 
-# Get the protobuf source from GitHub and install it
-RUN git clone --recursive --branch v2.6.1 git@github.com:google/protobuf.git /var/local/git/protobuf
-RUN cd /var/local/git/protobuf && \
-  ./autogen.sh && \
-  ./configure --prefix=/usr && \
-  make -j12 && make check && make install && make clean
-
-RUN cd /var/local/git/grpc-java/lib/okhttp && \
-  mvn -pl okhttp -am validate
-RUN cd /var/local/git/grpc-java/lib/netty && \
-  mvn -pl codec-http2 -am validate
-RUN cd /var/local/git/grpc-java && \
-  mvn validate
+# Trigger download of as many Maven and Gradle artifacts as possible. We don't build grpc-java
+# because we don't want to install netty
+RUN git clone --recursive --depth 1 git@github.com:google/grpc-java.git && \
+  cd grpc-java/lib/netty && \
+  mvn -pl codec-http2 -am -DskipTests verify && \
+  cd ../.. && \
+  ./gradlew && \
+  rm -r "$(pwd)"


### PR DESCRIPTION
The images seem to have been broken starting with 12e12a3, but the
removal of Maven support from grpc-java also broke them further.

SSH handling no longer uses $HOME as it does not agree with /etc/passwd
in older docker versions[1] and prevented SSH from seeing the config
file.

Some effort was also made to reduce the image sizes by removing
temporary files.
1. https://github.com/docker/docker/issues/2968
