### PR TITLE
Remove a major source of contention in thread_pool

### DIFF
--- a/src/cpp/server/thread_pool.cc
+++ b/src/cpp/server/thread_pool.cc
@@ -41,8 +41,10 @@ ThreadPool::ThreadPool(int num_threads) {
       for (;;) {
         std::unique_lock<std::mutex> lock(mu_);
         // Wait until work is available or we are shutting down.
-        if (!shutdown_ || callbacks_.empty())
-          cv_.wait(lock, [=]() { return shutdown_ || !callbacks_.empty(); });
+        auto have_work = [=]() { return shutdown_ || !callbacks_.empty(); };
+        if (!have_work()) {
+          cv_.wait(lock, have_work);
+        }
         // Drain callbacks before considering shutdown to ensure all work
         // gets completed.
         if (!callbacks_.empty()) {


### PR DESCRIPTION
- notify_one when new work is available to avoid thundering herd
  problems
- checking conditions before entering cv_.wait() prevents a case that
  these are not validated
