### PR TITLE
Prepare for the new batch call API.

### DIFF
--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -275,8 +275,9 @@ void grpc_completion_queue_destroy(grpc_completion_queue *cq);
 /* Create a call given a grpc_channel, in order to call 'method'. The request
    is not sent until grpc_call_invoke is called. All completions are sent to
    'completion_queue'. */
-grpc_call *grpc_channel_create_call(grpc_channel *channel, const char *method,
-                                    const char *host, gpr_timespec deadline);
+grpc_call *grpc_channel_create_call_old(grpc_channel *channel,
+                                        const char *method, const char *host,
+                                        gpr_timespec deadline);
 
 /* Create a client channel */
 grpc_channel *grpc_channel_create(const char *target,
@@ -307,8 +308,9 @@ void grpc_channel_destroy(grpc_channel *channel);
    REQUIRES: grpc_call_start_invoke/grpc_call_server_end_initial_metadata have
              not been called on this call.
    Produces no events. */
-grpc_call_error grpc_call_add_metadata(grpc_call *call, grpc_metadata *metadata,
-                                       gpr_uint32 flags);
+grpc_call_error grpc_call_add_metadata_old(grpc_call *call,
+                                           grpc_metadata *metadata,
+                                           gpr_uint32 flags);
 
 /* Invoke the RPC. Starts sending metadata and request headers on the wire.
    flags is a bit-field combination of the write flags defined above.
@@ -319,9 +321,9 @@ grpc_call_error grpc_call_add_metadata(grpc_call *call, grpc_metadata *metadata,
    Produces a GRPC_FINISHED event with finished_tag when the call has been
        completed (there may be other events for the call pending at this
        time) */
-grpc_call_error grpc_call_invoke(grpc_call *call, grpc_completion_queue *cq,
-                                 void *metadata_read_tag, void *finished_tag,
-                                 gpr_uint32 flags);
+grpc_call_error grpc_call_invoke_old(grpc_call *call, grpc_completion_queue *cq,
+                                     void *metadata_read_tag,
+                                     void *finished_tag, gpr_uint32 flags);
 
 /* Accept an incoming RPC, binding a completion queue to it.
    To be called before sending or receiving messages.
@@ -330,9 +332,9 @@ grpc_call_error grpc_call_invoke(grpc_call *call, grpc_completion_queue *cq,
    Produces a GRPC_FINISHED event with finished_tag when the call has been
        completed (there may be other events for the call pending at this
        time) */
-grpc_call_error grpc_call_server_accept(grpc_call *call,
-                                        grpc_completion_queue *cq,
-                                        void *finished_tag);
+grpc_call_error grpc_call_server_accept_old(grpc_call *call,
+                                            grpc_completion_queue *cq,
+                                            void *finished_tag);
 
 /* Start sending metadata.
    To be called before sending messages.
@@ -340,8 +342,8 @@ grpc_call_error grpc_call_server_accept(grpc_call *call,
    REQUIRES: Can be called at most once per call.
              Can only be called on the server.
              Must be called after grpc_call_server_accept */
-grpc_call_error grpc_call_server_end_initial_metadata(grpc_call *call,
-                                                      gpr_uint32 flags);
+grpc_call_error grpc_call_server_end_initial_metadata_old(grpc_call *call,
+                                                          gpr_uint32 flags);
 
 /* Called by clients to cancel an RPC on the server.
    Can be called multiple times, from any thread. */
@@ -370,9 +372,9 @@ grpc_call_error grpc_call_cancel_with_status(grpc_call *call,
              grpc_call_server_end_of_initial_metadata must have been called
              successfully.
    Produces a GRPC_WRITE_ACCEPTED event. */
-grpc_call_error grpc_call_start_write(grpc_call *call,
-                                      grpc_byte_buffer *byte_buffer, void *tag,
-                                      gpr_uint32 flags);
+grpc_call_error grpc_call_start_write_old(grpc_call *call,
+                                          grpc_byte_buffer *byte_buffer,
+                                          void *tag, gpr_uint32 flags);
 
 /* Queue a status for writing.
    REQUIRES: No other writes are pending on the call.
@@ -380,17 +382,17 @@ grpc_call_error grpc_call_start_write(grpc_call *call,
              call prior to calling this.
              Only callable on the server.
    Produces a GRPC_FINISH_ACCEPTED event when the status is sent. */
-grpc_call_error grpc_call_start_write_status(grpc_call *call,
-                                             grpc_status_code status_code,
-                                             const char *status_message,
-                                             void *tag);
+grpc_call_error grpc_call_start_write_status_old(grpc_call *call,
+                                                 grpc_status_code status_code,
+                                                 const char *status_message,
+                                                 void *tag);
 
 /* No more messages to send.
    REQUIRES: No other writes are pending on the call.
              Only callable on the client.
    Produces a GRPC_FINISH_ACCEPTED event when all bytes for the call have passed
        outgoing flow control. */
-grpc_call_error grpc_call_writes_done(grpc_call *call, void *tag);
+grpc_call_error grpc_call_writes_done_old(grpc_call *call, void *tag);
 
 /* Initiate a read on a call. Output event contains a byte buffer with the
    result of the read.
@@ -402,7 +404,7 @@ grpc_call_error grpc_call_writes_done(grpc_call *call, void *tag);
              On the server:
                grpc_call_server_accept must be called before calling this.
    Produces a single GRPC_READ event. */
-grpc_call_error grpc_call_start_read(grpc_call *call, void *tag);
+grpc_call_error grpc_call_start_read_old(grpc_call *call, void *tag);
 
 /* Destroy a call. */
 void grpc_call_destroy(grpc_call *call);
@@ -414,7 +416,8 @@ void grpc_call_destroy(grpc_call *call);
    tag_cancel.
    REQUIRES: Server must not have been shutdown.
    NOTE: calling this is the only way to obtain GRPC_SERVER_RPC_NEW events. */
-grpc_call_error grpc_server_request_call(grpc_server *server, void *tag_new);
+grpc_call_error grpc_server_request_call_old(grpc_server *server,
+                                             void *tag_new);
 
 /* Create a server */
 grpc_server *grpc_server_create(grpc_completion_queue *cq,

--- a/src/core/surface/call.c
+++ b/src/core/surface/call.c
@@ -348,8 +348,9 @@ void grpc_call_add_mdelem(grpc_call *call, grpc_mdelem *mdelem,
   elem->filter->call_op(elem, NULL, &op);
 }
 
-grpc_call_error grpc_call_add_metadata(grpc_call *call, grpc_metadata *metadata,
-                                       gpr_uint32 flags) {
+grpc_call_error grpc_call_add_metadata_old(grpc_call *call,
+                                           grpc_metadata *metadata,
+                                           gpr_uint32 flags) {
   grpc_mdelem *mdelem;
 
   if (call->is_client) {
@@ -455,9 +456,9 @@ static void call_started(void *user_data, grpc_op_error error) {
   grpc_call_internal_unref(call);
 }
 
-grpc_call_error grpc_call_invoke(grpc_call *call, grpc_completion_queue *cq,
-                                 void *metadata_read_tag, void *finished_tag,
-                                 gpr_uint32 flags) {
+grpc_call_error grpc_call_invoke_old(grpc_call *call, grpc_completion_queue *cq,
+                                     void *metadata_read_tag,
+                                     void *finished_tag, gpr_uint32 flags) {
   grpc_call_element *elem;
   grpc_call_op op;
 
@@ -527,9 +528,9 @@ grpc_call_error grpc_call_invoke(grpc_call *call, grpc_completion_queue *cq,
   return GRPC_CALL_OK;
 }
 
-grpc_call_error grpc_call_server_accept(grpc_call *call,
-                                        grpc_completion_queue *cq,
-                                        void *finished_tag) {
+grpc_call_error grpc_call_server_accept_old(grpc_call *call,
+                                            grpc_completion_queue *cq,
+                                            void *finished_tag) {
   /* validate preconditions */
   if (call->is_client) {
     gpr_log(GPR_ERROR, "can only call %s on servers", __FUNCTION__);
@@ -563,8 +564,8 @@ grpc_call_error grpc_call_server_accept(grpc_call *call,
   return GRPC_CALL_OK;
 }
 
-grpc_call_error grpc_call_server_end_initial_metadata(grpc_call *call,
-                                                      gpr_uint32 flags) {
+grpc_call_error grpc_call_server_end_initial_metadata_old(grpc_call *call,
+                                                          gpr_uint32 flags) {
   grpc_call_element *elem;
   grpc_call_op op;
 
@@ -634,7 +635,7 @@ static void request_more_data(grpc_call *call) {
   elem->filter->call_op(elem, NULL, &op);
 }
 
-grpc_call_error grpc_call_start_read(grpc_call *call, void *tag) {
+grpc_call_error grpc_call_start_read_old(grpc_call *call, void *tag) {
   gpr_uint8 request_more = 0;
 
   switch (call->state) {
@@ -677,9 +678,9 @@ grpc_call_error grpc_call_start_read(grpc_call *call, void *tag) {
   return GRPC_CALL_OK;
 }
 
-grpc_call_error grpc_call_start_write(grpc_call *call,
-                                      grpc_byte_buffer *byte_buffer, void *tag,
-                                      gpr_uint32 flags) {
+grpc_call_error grpc_call_start_write_old(grpc_call *call,
+                                          grpc_byte_buffer *byte_buffer,
+                                          void *tag, gpr_uint32 flags) {
   grpc_call_element *elem;
   grpc_call_op op;
 
@@ -732,7 +733,7 @@ grpc_call_error grpc_call_start_write(grpc_call *call,
   return GRPC_CALL_OK;
 }
 
-grpc_call_error grpc_call_writes_done(grpc_call *call, void *tag) {
+grpc_call_error grpc_call_writes_done_old(grpc_call *call, void *tag) {
   grpc_call_element *elem;
   grpc_call_op op;
 
@@ -780,9 +781,10 @@ grpc_call_error grpc_call_writes_done(grpc_call *call, void *tag) {
   return GRPC_CALL_OK;
 }
 
-grpc_call_error grpc_call_start_write_status(grpc_call *call,
-                                             grpc_status_code status,
-                                             const char *details, void *tag) {
+grpc_call_error grpc_call_start_write_status_old(grpc_call *call,
+                                                 grpc_status_code status,
+                                                 const char *details,
+                                                 void *tag) {
   grpc_call_element *elem;
   grpc_call_op op;
 

--- a/src/core/surface/channel.c
+++ b/src/core/surface/channel.c
@@ -74,9 +74,9 @@ grpc_channel *grpc_channel_create_from_filters(
 
 static void do_nothing(void *ignored, grpc_op_error error) {}
 
-grpc_call *grpc_channel_create_call(grpc_channel *channel, const char *method,
-                                    const char *host,
-                                    gpr_timespec absolute_deadline) {
+grpc_call *grpc_channel_create_call_old(grpc_channel *channel,
+                                        const char *method, const char *host,
+                                        gpr_timespec absolute_deadline) {
   grpc_call *call;
   grpc_mdelem *path_mdelem;
   grpc_mdelem *authority_mdelem;

--- a/src/core/surface/server.c
+++ b/src/core/surface/server.c
@@ -625,7 +625,8 @@ void grpc_server_add_listener(grpc_server *server, void *arg,
   server->listeners = l;
 }
 
-grpc_call_error grpc_server_request_call(grpc_server *server, void *tag_new) {
+grpc_call_error grpc_server_request_call_old(grpc_server *server,
+                                             void *tag_new) {
   call_data *calld;
 
   grpc_cq_begin_op(server->cq, NULL, GRPC_SERVER_RPC_NEW);

--- a/src/cpp/client/channel.cc
+++ b/src/cpp/client/channel.cc
@@ -99,7 +99,7 @@ Status Channel::StartBlockingRpc(const RpcMethod &method,
                                  const google::protobuf::Message &request,
                                  google::protobuf::Message *result) {
   Status status;
-  grpc_call *call = grpc_channel_create_call(
+  grpc_call *call = grpc_channel_create_call_old(
       c_channel_, method.name(), target_.c_str(), context->RawDeadline());
   context->set_call(call);
   grpc_event *ev;
@@ -114,8 +114,8 @@ Status Channel::StartBlockingRpc(const RpcMethod &method,
   // add_metadata from context
   //
   // invoke
-  GPR_ASSERT(grpc_call_invoke(call, cq, metadata_read_tag, finished_tag,
-                              GRPC_WRITE_BUFFER_HINT) == GRPC_CALL_OK);
+  GPR_ASSERT(grpc_call_invoke_old(call, cq, metadata_read_tag, finished_tag,
+                                  GRPC_WRITE_BUFFER_HINT) == GRPC_CALL_OK);
   // write request
   grpc_byte_buffer *write_buffer = nullptr;
   bool success = SerializeProto(request, &write_buffer);
@@ -126,8 +126,8 @@ Status Channel::StartBlockingRpc(const RpcMethod &method,
     GetFinalStatus(cq, finished_tag, nullptr);
     return status;
   }
-  GPR_ASSERT(grpc_call_start_write(call, write_buffer, write_tag,
-                                   GRPC_WRITE_BUFFER_HINT) == GRPC_CALL_OK);
+  GPR_ASSERT(grpc_call_start_write_old(call, write_buffer, write_tag,
+                                       GRPC_WRITE_BUFFER_HINT) == GRPC_CALL_OK);
   grpc_byte_buffer_destroy(write_buffer);
   ev = grpc_completion_queue_pluck(cq, write_tag, gpr_inf_future);
 
@@ -138,7 +138,7 @@ Status Channel::StartBlockingRpc(const RpcMethod &method,
     return status;
   }
   // writes done
-  GPR_ASSERT(grpc_call_writes_done(call, halfclose_tag) == GRPC_CALL_OK);
+  GPR_ASSERT(grpc_call_writes_done_old(call, halfclose_tag) == GRPC_CALL_OK);
   ev = grpc_completion_queue_pluck(cq, halfclose_tag, gpr_inf_future);
   grpc_event_finish(ev);
   // start read metadata
@@ -146,7 +146,7 @@ Status Channel::StartBlockingRpc(const RpcMethod &method,
   ev = grpc_completion_queue_pluck(cq, metadata_read_tag, gpr_inf_future);
   grpc_event_finish(ev);
   // start read
-  GPR_ASSERT(grpc_call_start_read(call, read_tag) == GRPC_CALL_OK);
+  GPR_ASSERT(grpc_call_start_read_old(call, read_tag) == GRPC_CALL_OK);
   ev = grpc_completion_queue_pluck(cq, read_tag, gpr_inf_future);
   if (ev->data.read) {
     if (!DeserializeProto(ev->data.read, result)) {
@@ -167,7 +167,7 @@ StreamContextInterface *Channel::CreateStream(
     const RpcMethod &method, ClientContext *context,
     const google::protobuf::Message *request,
     google::protobuf::Message *result) {
-  grpc_call *call = grpc_channel_create_call(
+  grpc_call *call = grpc_channel_create_call_old(
       c_channel_, method.name(), target_.c_str(), context->RawDeadline());
   context->set_call(call);
   grpc_completion_queue *cq = grpc_completion_queue_create();

--- a/src/cpp/server/async_server.cc
+++ b/src/cpp/server/async_server.cc
@@ -72,7 +72,7 @@ void AsyncServer::RequestOneRpc() {
     return;
   }
   lock.unlock();
-  grpc_call_error err = grpc_server_request_call(server_, nullptr);
+  grpc_call_error err = grpc_server_request_call_old(server_, nullptr);
   GPR_ASSERT(err == GRPC_CALL_OK);
 }
 

--- a/src/cpp/server/async_server_context.cc
+++ b/src/cpp/server/async_server_context.cc
@@ -53,14 +53,15 @@ AsyncServerContext::AsyncServerContext(
 AsyncServerContext::~AsyncServerContext() { grpc_call_destroy(call_); }
 
 void AsyncServerContext::Accept(grpc_completion_queue *cq) {
-  GPR_ASSERT(grpc_call_server_accept(call_, cq, this) == GRPC_CALL_OK);
-  GPR_ASSERT(grpc_call_server_end_initial_metadata(call_, 0) == GRPC_CALL_OK);
+  GPR_ASSERT(grpc_call_server_accept_old(call_, cq, this) == GRPC_CALL_OK);
+  GPR_ASSERT(grpc_call_server_end_initial_metadata_old(call_, 0) ==
+             GRPC_CALL_OK);
 }
 
 bool AsyncServerContext::StartRead(google::protobuf::Message *request) {
   GPR_ASSERT(request);
   request_ = request;
-  grpc_call_error err = grpc_call_start_read(call_, this);
+  grpc_call_error err = grpc_call_start_read_old(call_, this);
   return err == GRPC_CALL_OK;
 }
 
@@ -70,13 +71,13 @@ bool AsyncServerContext::StartWrite(const google::protobuf::Message &response,
   if (!SerializeProto(response, &buffer)) {
     return false;
   }
-  grpc_call_error err = grpc_call_start_write(call_, buffer, this, flags);
+  grpc_call_error err = grpc_call_start_write_old(call_, buffer, this, flags);
   grpc_byte_buffer_destroy(buffer);
   return err == GRPC_CALL_OK;
 }
 
 bool AsyncServerContext::StartWriteStatus(const Status &status) {
-  grpc_call_error err = grpc_call_start_write_status(
+  grpc_call_error err = grpc_call_start_write_status_old(
       call_, static_cast<grpc_status_code>(status.code()),
       status.details().empty() ? nullptr
                                : const_cast<char *>(status.details().c_str()),

--- a/src/cpp/server/server.cc
+++ b/src/cpp/server/server.cc
@@ -111,7 +111,7 @@ void Server::Start() {
 
 void Server::AllowOneRpc() {
   GPR_ASSERT(started_);
-  grpc_call_error err = grpc_server_request_call(server_, nullptr);
+  grpc_call_error err = grpc_server_request_call_old(server_, nullptr);
   GPR_ASSERT(err == GRPC_CALL_OK);
 }
 

--- a/src/cpp/stream/stream_context.cc
+++ b/src/cpp/stream/stream_context.cc
@@ -80,22 +80,22 @@ void StreamContext::Start(bool buffered) {
   if (is_client_) {
     // TODO(yangg) handle metadata send path
     int flag = buffered ? GRPC_WRITE_BUFFER_HINT : 0;
-    grpc_call_error error = grpc_call_invoke(
+    grpc_call_error error = grpc_call_invoke_old(
         call(), cq(), client_metadata_read_tag(), finished_tag(), flag);
     GPR_ASSERT(GRPC_CALL_OK == error);
   } else {
     // TODO(yangg) metadata needs to be added before accept
     // TODO(yangg) correctly set flag to accept
-    GPR_ASSERT(grpc_call_server_accept(call(), cq(), finished_tag()) ==
+    GPR_ASSERT(grpc_call_server_accept_old(call(), cq(), finished_tag()) ==
                GRPC_CALL_OK);
-    GPR_ASSERT(grpc_call_server_end_initial_metadata(call(), 0) ==
+    GPR_ASSERT(grpc_call_server_end_initial_metadata_old(call(), 0) ==
                GRPC_CALL_OK);
   }
 }
 
 bool StreamContext::Read(google::protobuf::Message *msg) {
   // TODO(yangg) check peer_halfclosed_ here for possible early return.
-  grpc_call_error err = grpc_call_start_read(call(), read_tag());
+  grpc_call_error err = grpc_call_start_read_old(call(), read_tag());
   GPR_ASSERT(err == GRPC_CALL_OK);
   grpc_event *read_ev =
       grpc_completion_queue_pluck(cq(), read_tag(), gpr_inf_future);
@@ -129,7 +129,7 @@ bool StreamContext::Write(const google::protobuf::Message *msg, bool is_last) {
     }
     int flag = is_last ? GRPC_WRITE_BUFFER_HINT : 0;
     grpc_call_error err =
-        grpc_call_start_write(call(), out_buf, write_tag(), flag);
+        grpc_call_start_write_old(call(), out_buf, write_tag(), flag);
     grpc_byte_buffer_destroy(out_buf);
     GPR_ASSERT(err == GRPC_CALL_OK);
 
@@ -140,7 +140,7 @@ bool StreamContext::Write(const google::protobuf::Message *msg, bool is_last) {
     grpc_event_finish(ev);
   }
   if (ret && is_last) {
-    grpc_call_error err = grpc_call_writes_done(call(), halfclose_tag());
+    grpc_call_error err = grpc_call_writes_done_old(call(), halfclose_tag());
     GPR_ASSERT(err == GRPC_CALL_OK);
     ev = grpc_completion_queue_pluck(cq(), halfclose_tag(), gpr_inf_future);
     GPR_ASSERT(ev->type == GRPC_FINISH_ACCEPTED);

--- a/src/node/.gitignore
+++ b/src/node/.gitignore
@@ -1,0 +1,2 @@
+build
+node_modules

--- a/src/node/ext/call.cc
+++ b/src/node/ext/call.cc
@@ -152,9 +152,9 @@ NAN_METHOD(Call::New) {
       NanUtf8String method(args[1]);
       double deadline = args[2]->NumberValue();
       grpc_channel *wrapped_channel = channel->GetWrappedChannel();
-      grpc_call *wrapped_call =
-          grpc_channel_create_call(wrapped_channel, *method, channel->GetHost(),
-                                   MillisecondsToTimespec(deadline));
+      grpc_call *wrapped_call = grpc_channel_create_call_old(
+          wrapped_channel, *method, channel->GetHost(),
+          MillisecondsToTimespec(deadline));
       call = new Call(wrapped_call);
       args.This()->SetHiddenValue(String::NewSymbol("channel_"),
                                   channel_object);
@@ -195,7 +195,7 @@ NAN_METHOD(Call::AddMetadata) {
       if (Buffer::HasInstance(value)) {
         metadata.value = Buffer::Data(value);
         metadata.value_length = Buffer::Length(value);
-        error = grpc_call_add_metadata(call->wrapped_call, &metadata, 0);
+        error = grpc_call_add_metadata_old(call->wrapped_call, &metadata, 0);
       } else if (value->IsString()) {
         Handle<String> string_value = value->ToString();
         NanUtf8String utf8_value(string_value);
@@ -203,7 +203,7 @@ NAN_METHOD(Call::AddMetadata) {
         metadata.value_length = string_value->Length();
         gpr_log(GPR_DEBUG, "adding metadata: %s, %s, %d", metadata.key,
                 metadata.value, metadata.value_length);
-        error = grpc_call_add_metadata(call->wrapped_call, &metadata, 0);
+        error = grpc_call_add_metadata_old(call->wrapped_call, &metadata, 0);
       } else {
         return NanThrowTypeError(
             "addMetadata values must be strings or buffers");
@@ -232,7 +232,7 @@ NAN_METHOD(Call::Invoke) {
   }
   Call *call = ObjectWrap::Unwrap<Call>(args.This());
   unsigned int flags = args[3]->Uint32Value();
-  grpc_call_error error = grpc_call_invoke(
+  grpc_call_error error = grpc_call_invoke_old(
       call->wrapped_call, CompletionQueueAsyncWorker::GetQueue(),
       CreateTag(args[0], args.This()), CreateTag(args[1], args.This()), flags);
   if (error == GRPC_CALL_OK) {
@@ -253,7 +253,7 @@ NAN_METHOD(Call::ServerAccept) {
     return NanThrowTypeError("accept's first argument must be a function");
   }
   Call *call = ObjectWrap::Unwrap<Call>(args.This());
-  grpc_call_error error = grpc_call_server_accept(
+  grpc_call_error error = grpc_call_server_accept_old(
       call->wrapped_call, CompletionQueueAsyncWorker::GetQueue(),
       CreateTag(args[0], args.This()));
   if (error == GRPC_CALL_OK) {
@@ -277,7 +277,7 @@ NAN_METHOD(Call::ServerEndInitialMetadata) {
   Call *call = ObjectWrap::Unwrap<Call>(args.This());
   unsigned int flags = args[1]->Uint32Value();
   grpc_call_error error =
-      grpc_call_server_end_initial_metadata(call->wrapped_call, flags);
+      grpc_call_server_end_initial_metadata_old(call->wrapped_call, flags);
   if (error != GRPC_CALL_OK) {
     return NanThrowError("serverEndInitialMetadata failed", error);
   }
@@ -315,7 +315,7 @@ NAN_METHOD(Call::StartWrite) {
   Call *call = ObjectWrap::Unwrap<Call>(args.This());
   grpc_byte_buffer *buffer = BufferToByteBuffer(args[0]);
   unsigned int flags = args[2]->Uint32Value();
-  grpc_call_error error = grpc_call_start_write(
+  grpc_call_error error = grpc_call_start_write_old(
       call->wrapped_call, buffer, CreateTag(args[1], args.This()), flags);
   if (error == GRPC_CALL_OK) {
     CompletionQueueAsyncWorker::Next();
@@ -345,7 +345,7 @@ NAN_METHOD(Call::StartWriteStatus) {
   }
   Call *call = ObjectWrap::Unwrap<Call>(args.This());
   NanUtf8String details(args[1]);
-  grpc_call_error error = grpc_call_start_write_status(
+  grpc_call_error error = grpc_call_start_write_status_old(
       call->wrapped_call, (grpc_status_code)args[0]->Uint32Value(), *details,
       CreateTag(args[2], args.This()));
   if (error == GRPC_CALL_OK) {
@@ -365,7 +365,7 @@ NAN_METHOD(Call::WritesDone) {
     return NanThrowTypeError("writesDone's first argument must be a function");
   }
   Call *call = ObjectWrap::Unwrap<Call>(args.This());
-  grpc_call_error error = grpc_call_writes_done(
+  grpc_call_error error = grpc_call_writes_done_old(
       call->wrapped_call, CreateTag(args[0], args.This()));
   if (error == GRPC_CALL_OK) {
     CompletionQueueAsyncWorker::Next();
@@ -384,8 +384,8 @@ NAN_METHOD(Call::StartRead) {
     return NanThrowTypeError("startRead's first argument must be a function");
   }
   Call *call = ObjectWrap::Unwrap<Call>(args.This());
-  grpc_call_error error =
-      grpc_call_start_read(call->wrapped_call, CreateTag(args[0], args.This()));
+  grpc_call_error error = grpc_call_start_read_old(
+      call->wrapped_call, CreateTag(args[0], args.This()));
   if (error == GRPC_CALL_OK) {
     CompletionQueueAsyncWorker::Next();
   } else {

--- a/src/node/ext/server.cc
+++ b/src/node/ext/server.cc
@@ -175,7 +175,7 @@ NAN_METHOD(Server::RequestCall) {
     return NanThrowTypeError("requestCall can only be called on a Server");
   }
   Server *server = ObjectWrap::Unwrap<Server>(args.This());
-  grpc_call_error error = grpc_server_request_call(
+  grpc_call_error error = grpc_server_request_call_old(
       server->wrapped_server, CreateTag(args[0], NanNull()));
   if (error == GRPC_CALL_OK) {
     CompletionQueueAsyncWorker::Next();

--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -135,7 +135,7 @@ int php_grpc_call_add_metadata_array_walk(void *elem TSRMLS_DC, int num_args,
       metadata.key = (char *)key;
       metadata.value = Z_STRVAL_P(*data);
       metadata.value_length = Z_STRLEN_P(*data);
-      error_code = grpc_call_add_metadata(call, &metadata, 0u);
+      error_code = grpc_call_add_metadata_old(call, &metadata, 0u);
       MAYBE_THROW_CALL_ERROR(add_metadata, error_code);
       break;
     case IS_ARRAY:
@@ -188,8 +188,8 @@ PHP_METHOD(Call, __construct) {
   wrapped_grpc_timeval *deadline =
       (wrapped_grpc_timeval *)zend_object_store_get_object(
           deadline_obj TSRMLS_CC);
-  call->wrapped = grpc_channel_create_call(channel->wrapped, method,
-                                           channel->target, deadline->wrapped);
+  call->wrapped = grpc_channel_create_call_old(
+      channel->wrapped, method, channel->target, deadline->wrapped);
 }
 
 /**
@@ -252,8 +252,8 @@ PHP_METHOD(Call, invoke) {
   wrapped_grpc_completion_queue *queue =
       (wrapped_grpc_completion_queue *)zend_object_store_get_object(
           queue_obj TSRMLS_CC);
-  error_code = grpc_call_invoke(call->wrapped, queue->wrapped, (void *)tag1,
-                                (void *)tag2, (gpr_uint32)flags);
+  error_code = grpc_call_invoke_old(call->wrapped, queue->wrapped, (void *)tag1,
+                                    (void *)tag2, (gpr_uint32)flags);
   MAYBE_THROW_CALL_ERROR(invoke, error_code);
 }
 
@@ -287,7 +287,7 @@ PHP_METHOD(Call, server_accept) {
       (wrapped_grpc_completion_queue *)zend_object_store_get_object(
           queue_obj TSRMLS_CC);
   error_code =
-      grpc_call_server_accept(call->wrapped, queue->wrapped, (void *)tag);
+      grpc_call_server_accept_old(call->wrapped, queue->wrapped, (void *)tag);
   MAYBE_THROW_CALL_ERROR(server_accept, error_code);
 }
 
@@ -303,7 +303,7 @@ PHP_METHOD(Call, server_end_initial_metadata) {
   }
   wrapped_grpc_call *call =
       (wrapped_grpc_call *)zend_object_store_get_object(getThis() TSRMLS_CC);
-  error_code = grpc_call_server_end_initial_metadata(call->wrapped, flags);
+  error_code = grpc_call_server_end_initial_metadata_old(call->wrapped, flags);
   MAYBE_THROW_CALL_ERROR(server_end_initial_metadata, error_code);
 }
 
@@ -342,9 +342,9 @@ PHP_METHOD(Call, start_write) {
                          1 TSRMLS_CC);
     return;
   }
-  error_code = grpc_call_start_write(call->wrapped,
-                                     string_to_byte_buffer(buffer, buffer_len),
-                                     (void *)tag, (gpr_uint32)flags);
+  error_code = grpc_call_start_write_old(
+      call->wrapped, string_to_byte_buffer(buffer, buffer_len), (void *)tag,
+      (gpr_uint32)flags);
   MAYBE_THROW_CALL_ERROR(start_write, error_code);
 }
 
@@ -372,9 +372,9 @@ PHP_METHOD(Call, start_write_status) {
         "start_write_status expects a long, a string, and a long", 1 TSRMLS_CC);
     return;
   }
-  error_code =
-      grpc_call_start_write_status(call->wrapped, (grpc_status_code)status_code,
-                                   status_details, (void *)tag);
+  error_code = grpc_call_start_write_status_old(call->wrapped,
+                                                (grpc_status_code)status_code,
+                                                status_details, (void *)tag);
   MAYBE_THROW_CALL_ERROR(start_write_status, error_code);
 }
 
@@ -393,7 +393,7 @@ PHP_METHOD(Call, writes_done) {
                          "writes_done expects a long", 1 TSRMLS_CC);
     return;
   }
-  error_code = grpc_call_writes_done(call->wrapped, (void *)tag);
+  error_code = grpc_call_writes_done_old(call->wrapped, (void *)tag);
   MAYBE_THROW_CALL_ERROR(writes_done, error_code);
 }
 
@@ -414,7 +414,7 @@ PHP_METHOD(Call, start_read) {
                          "start_read expects a long", 1 TSRMLS_CC);
     return;
   }
-  error_code = grpc_call_start_read(call->wrapped, (void *)tag);
+  error_code = grpc_call_start_read_old(call->wrapped, (void *)tag);
   MAYBE_THROW_CALL_ERROR(start_read, error_code);
 }
 

--- a/src/php/ext/grpc/server.c
+++ b/src/php/ext/grpc/server.c
@@ -125,7 +125,7 @@ PHP_METHOD(Server, request_call) {
                          "request_call expects a long", 1 TSRMLS_CC);
     return;
   }
-  error_code = grpc_server_request_call(server->wrapped, (void *)tag_new);
+  error_code = grpc_server_request_call_old(server->wrapped, (void *)tag_new);
   MAYBE_THROW_CALL_ERROR(request_call, error_code);
 }
 

--- a/src/python/src/_adapter/_call.c
+++ b/src/python/src/_adapter/_call.c
@@ -56,9 +56,9 @@ static int pygrpc_call_init(Call *self, PyObject *args, PyObject *kwds) {
   /* TODO(nathaniel): Hoist the gpr_timespec <-> PyFloat arithmetic into its own
    * function with its own test coverage.
    */
-  self->c_call =
-      grpc_channel_create_call(((Channel *)channel)->c_channel, method, host,
-                               gpr_time_from_nanos(deadline * GPR_NS_PER_SEC));
+  self->c_call = grpc_channel_create_call_old(
+      ((Channel *)channel)->c_channel, method, host,
+      gpr_time_from_nanos(deadline * GPR_NS_PER_SEC));
 
   return 0;
 }
@@ -82,7 +82,7 @@ static const PyObject *pygrpc_call_invoke(Call *self, PyObject *args) {
     return NULL;
   }
 
-  call_error = grpc_call_invoke(
+  call_error = grpc_call_invoke_old(
       self->c_call, ((CompletionQueue *)completion_queue)->c_completion_queue,
       (void *)metadata_tag, (void *)finish_tag, 0);
 
@@ -111,7 +111,8 @@ static const PyObject *pygrpc_call_write(Call *self, PyObject *args) {
   byte_buffer = grpc_byte_buffer_create(&slice, 1);
   gpr_slice_unref(slice);
 
-  call_error = grpc_call_start_write(self->c_call, byte_buffer, (void *)tag, 0);
+  call_error =
+      grpc_call_start_write_old(self->c_call, byte_buffer, (void *)tag, 0);
 
   grpc_byte_buffer_destroy(byte_buffer);
 
@@ -131,7 +132,7 @@ static const PyObject *pygrpc_call_complete(Call *self, PyObject *args) {
     return NULL;
   }
 
-  call_error = grpc_call_writes_done(self->c_call, (void *)tag);
+  call_error = grpc_call_writes_done_old(self->c_call, (void *)tag);
 
   result = pygrpc_translate_call_error(call_error);
   if (result != NULL) {
@@ -151,7 +152,7 @@ static const PyObject *pygrpc_call_accept(Call *self, PyObject *args) {
     return NULL;
   }
 
-  call_error = grpc_call_server_accept(
+  call_error = grpc_call_server_accept_old(
       self->c_call, ((CompletionQueue *)completion_queue)->c_completion_queue,
       (void *)tag);
   result = pygrpc_translate_call_error(call_error);
@@ -166,7 +167,7 @@ static const PyObject *pygrpc_call_accept(Call *self, PyObject *args) {
 static const PyObject *pygrpc_call_premetadata(Call *self, PyObject *args) {
   /* TODO(b/18702680): Actually support metadata. */
   return pygrpc_translate_call_error(
-      grpc_call_server_end_initial_metadata(self->c_call, 0));
+      grpc_call_server_end_initial_metadata_old(self->c_call, 0));
 }
 
 static const PyObject *pygrpc_call_read(Call *self, PyObject *args) {
@@ -178,7 +179,7 @@ static const PyObject *pygrpc_call_read(Call *self, PyObject *args) {
     return NULL;
   }
 
-  call_error = grpc_call_start_read(self->c_call, (void *)tag);
+  call_error = grpc_call_start_read_old(self->c_call, (void *)tag);
 
   result = pygrpc_translate_call_error(call_error);
   if (result != NULL) {
@@ -208,8 +209,8 @@ static const PyObject *pygrpc_call_status(Call *self, PyObject *args) {
   Py_DECREF(code);
   Py_DECREF(details);
 
-  call_error = grpc_call_start_write_status(self->c_call, c_code, c_message,
-                                            (void *)tag);
+  call_error = grpc_call_start_write_status_old(self->c_call, c_code, c_message,
+                                                (void *)tag);
 
   result = pygrpc_translate_call_error(call_error);
   if (result != NULL) {

--- a/src/python/src/_adapter/_server.c
+++ b/src/python/src/_adapter/_server.c
@@ -88,7 +88,7 @@ static const PyObject *pygrpc_server_service(Server *self, PyObject *args) {
     return NULL;
   }
 
-  call_error = grpc_server_request_call(self->c_server, (void *)tag);
+  call_error = grpc_server_request_call_old(self->c_server, (void *)tag);
 
   result = pygrpc_translate_call_error(call_error);
   if (result != NULL) {

--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -125,7 +125,7 @@ int grpc_rb_call_add_metadata_hash_cb(VALUE key, VALUE val, VALUE call_obj) {
       md_obj_args[1] = rb_ary_entry(val, i);
       md_obj = rb_class_new_instance(2, md_obj_args, rb_cMetadata);
       md = grpc_rb_get_wrapped_metadata(md_obj);
-      err = grpc_call_add_metadata(call, md, NUM2UINT(flags));
+      err = grpc_call_add_metadata_old(call, md, NUM2UINT(flags));
       if (err != GRPC_CALL_OK) {
         rb_raise(rb_eCallError, "add metadata failed: %s (code=%d)",
                  grpc_call_error_detail_of(err), err);
@@ -136,7 +136,7 @@ int grpc_rb_call_add_metadata_hash_cb(VALUE key, VALUE val, VALUE call_obj) {
     md_obj_args[1] = val;
     md_obj = rb_class_new_instance(2, md_obj_args, rb_cMetadata);
     md = grpc_rb_get_wrapped_metadata(md_obj);
-    err = grpc_call_add_metadata(call, md, NUM2UINT(flags));
+    err = grpc_call_add_metadata_old(call, md, NUM2UINT(flags));
     if (err != GRPC_CALL_OK) {
       rb_raise(rb_eCallError, "add metadata failed: %s (code=%d)",
                grpc_call_error_detail_of(err), err);
@@ -220,8 +220,8 @@ static VALUE grpc_rb_call_invoke(int argc, VALUE *argv, VALUE self) {
   }
   cq = grpc_rb_get_wrapped_completion_queue(cqueue);
   Data_Get_Struct(self, grpc_call, call);
-  err = grpc_call_invoke(call, cq, ROBJECT(metadata_read_tag),
-                         ROBJECT(finished_tag), NUM2UINT(flags));
+  err = grpc_call_invoke_old(call, cq, ROBJECT(metadata_read_tag),
+                             ROBJECT(finished_tag), NUM2UINT(flags));
   if (err != GRPC_CALL_OK) {
     rb_raise(rb_eCallError, "invoke failed: %s (code=%d)",
              grpc_call_error_detail_of(err), err);
@@ -242,7 +242,7 @@ static VALUE grpc_rb_call_start_read(VALUE self, VALUE tag) {
   grpc_call *call = NULL;
   grpc_call_error err;
   Data_Get_Struct(self, grpc_call, call);
-  err = grpc_call_start_read(call, ROBJECT(tag));
+  err = grpc_call_start_read_old(call, ROBJECT(tag));
   if (err != GRPC_CALL_OK) {
     rb_raise(rb_eCallError, "start read failed: %s (code=%d)",
              grpc_call_error_detail_of(err), err);
@@ -330,7 +330,7 @@ static VALUE grpc_rb_call_start_write(int argc, VALUE *argv, VALUE self) {
   }
   bfr = grpc_rb_get_wrapped_byte_buffer(byte_buffer);
   Data_Get_Struct(self, grpc_call, call);
-  err = grpc_call_start_write(call, bfr, ROBJECT(tag), NUM2UINT(flags));
+  err = grpc_call_start_write_old(call, bfr, ROBJECT(tag), NUM2UINT(flags));
   if (err != GRPC_CALL_OK) {
     rb_raise(rb_eCallError, "start write failed: %s (code=%d)",
              grpc_call_error_detail_of(err), err);
@@ -358,8 +358,8 @@ static VALUE grpc_rb_call_start_write_status(VALUE self, VALUE code,
   grpc_call *call = NULL;
   grpc_call_error err;
   Data_Get_Struct(self, grpc_call, call);
-  err = grpc_call_start_write_status(call, NUM2UINT(code),
-                                     StringValueCStr(status), ROBJECT(tag));
+  err = grpc_call_start_write_status_old(call, NUM2UINT(code),
+                                         StringValueCStr(status), ROBJECT(tag));
   if (err != GRPC_CALL_OK) {
     rb_raise(rb_eCallError, "start write status: %s (code=%d)",
              grpc_call_error_detail_of(err), err);
@@ -374,7 +374,7 @@ static VALUE grpc_rb_call_writes_done(VALUE self, VALUE tag) {
   grpc_call *call = NULL;
   grpc_call_error err;
   Data_Get_Struct(self, grpc_call, call);
-  err = grpc_call_writes_done(call, ROBJECT(tag));
+  err = grpc_call_writes_done_old(call, ROBJECT(tag));
   if (err != GRPC_CALL_OK) {
     rb_raise(rb_eCallError, "writes done: %s (code=%d)",
              grpc_call_error_detail_of(err), err);
@@ -405,7 +405,7 @@ static VALUE grpc_rb_call_server_end_initial_metadata(int argc, VALUE *argv,
     flags = UINT2NUM(0); /* Default to no flags */
   }
   Data_Get_Struct(self, grpc_call, call);
-  err = grpc_call_server_end_initial_metadata(call, NUM2UINT(flags));
+  err = grpc_call_server_end_initial_metadata_old(call, NUM2UINT(flags));
   if (err != GRPC_CALL_OK) {
     rb_raise(rb_eCallError, "end_initial_metadata failed: %s (code=%d)",
              grpc_call_error_detail_of(err), err);
@@ -430,7 +430,7 @@ static VALUE grpc_rb_call_server_accept(VALUE self, VALUE cqueue,
   grpc_completion_queue *cq = grpc_rb_get_wrapped_completion_queue(cqueue);
   grpc_call_error err;
   Data_Get_Struct(self, grpc_call, call);
-  err = grpc_call_server_accept(call, cq, ROBJECT(finished_tag));
+  err = grpc_call_server_accept_old(call, cq, ROBJECT(finished_tag));
   if (err != GRPC_CALL_OK) {
     rb_raise(rb_eCallError, "server_accept failed: %s (code=%d)",
              grpc_call_error_detail_of(err), err);

--- a/src/ruby/ext/grpc/rb_channel.c
+++ b/src/ruby/ext/grpc/rb_channel.c
@@ -192,9 +192,10 @@ static VALUE grpc_rb_channel_create_call(VALUE self, VALUE method, VALUE host,
     rb_raise(rb_eRuntimeError, "closed!");
   }
 
-  call = grpc_channel_create_call(ch, method_chars, host_chars,
-                                  grpc_rb_time_timeval(deadline,
-                                                       /* absolute time */ 0));
+  call =
+      grpc_channel_create_call_old(ch, method_chars, host_chars,
+                                   grpc_rb_time_timeval(deadline,
+                                                        /* absolute time */ 0));
   if (call == NULL) {
     rb_raise(rb_eRuntimeError, "cannot create call with method %s",
              method_chars);

--- a/src/ruby/ext/grpc/rb_server.c
+++ b/src/ruby/ext/grpc/rb_server.c
@@ -175,7 +175,7 @@ static VALUE grpc_rb_server_request_call(VALUE self, VALUE tag_new) {
   if (s->wrapped == NULL) {
     rb_raise(rb_eRuntimeError, "closed!");
   } else {
-    err = grpc_server_request_call(s->wrapped, ROBJECT(tag_new));
+    err = grpc_server_request_call_old(s->wrapped, ROBJECT(tag_new));
     if (err != GRPC_CALL_OK) {
       rb_raise(rb_eCallError, "server request failed: %s (code=%d)",
                grpc_call_error_detail_of(err), err);

--- a/test/core/echo/client.c
+++ b/test/core/echo/client.c
@@ -52,7 +52,7 @@ static void start_write_next_slice(grpc_call *call, int first, int length) {
   for (i = 0; i < length; i++)
     GPR_SLICE_START_PTR(slice)[i] = (first + i) % 256;
   byte_buffer = grpc_byte_buffer_create(&slice, 1);
-  GPR_ASSERT(grpc_call_start_write(call, byte_buffer, (void *)1, 0) ==
+  GPR_ASSERT(grpc_call_start_write_old(call, byte_buffer, (void *)1, 0) ==
              GRPC_CALL_OK);
   gpr_slice_unref(slice);
   grpc_byte_buffer_destroy(byte_buffer);
@@ -78,15 +78,15 @@ int main(int argc, char **argv) {
 
   GPR_ASSERT(argc == 2);
   channel = grpc_channel_create(argv[1], NULL);
-  call = grpc_channel_create_call(channel, "/foo", "localhost",
-                                  gpr_time_add(gpr_time_from_seconds(5),
-                                               gpr_now()));
-  GPR_ASSERT(grpc_call_invoke(call, cq, (void *)1, (void *)1, 0) ==
+  call = grpc_channel_create_call_old(
+      channel, "/foo", "localhost",
+      gpr_time_add(gpr_time_from_seconds(5), gpr_now()));
+  GPR_ASSERT(grpc_call_invoke_old(call, cq, (void *)1, (void *)1, 0) ==
              GRPC_CALL_OK);
 
   start_write_next_slice(call, bytes_written, WRITE_SLICE_LENGTH);
   bytes_written += WRITE_SLICE_LENGTH;
-  GPR_ASSERT(grpc_call_start_read(call, (void *)1) == GRPC_CALL_OK);
+  GPR_ASSERT(grpc_call_start_read_old(call, (void *)1) == GRPC_CALL_OK);
   waiting_finishes = 2;
   while (waiting_finishes) {
     ev = grpc_completion_queue_next(cq, gpr_inf_future);
@@ -96,7 +96,8 @@ int main(int argc, char **argv) {
           start_write_next_slice(call, bytes_written, WRITE_SLICE_LENGTH);
           bytes_written += WRITE_SLICE_LENGTH;
         } else {
-          GPR_ASSERT(grpc_call_writes_done(call, (void *)1) == GRPC_CALL_OK);
+          GPR_ASSERT(grpc_call_writes_done_old(call, (void *)1) ==
+                     GRPC_CALL_OK);
         }
         break;
       case GRPC_CLIENT_METADATA_READ:
@@ -112,7 +113,7 @@ int main(int argc, char **argv) {
         }
         grpc_byte_buffer_reader_destroy(bb_reader);
         if (bytes_read < TOTAL_BYTES) {
-          GPR_ASSERT(grpc_call_start_read(call, (void *)1) == GRPC_CALL_OK);
+          GPR_ASSERT(grpc_call_start_read_old(call, (void *)1) == GRPC_CALL_OK);
         }
         break;
       case GRPC_FINISHED:

--- a/test/core/echo/server.c
+++ b/test/core/echo/server.c
@@ -64,7 +64,7 @@ static void request_call(void) {
   call_state *tag = gpr_malloc(sizeof(*tag));
   gpr_ref_init(&tag->pending_ops, 2);
   tag->bytes_read = 0;
-  grpc_server_request_call(server, tag);
+  grpc_server_request_call_old(server, tag);
 }
 
 static void assert_read_ok(call_state *s, grpc_byte_buffer *b) {
@@ -173,10 +173,10 @@ int main(int argc, char **argv) {
       case GRPC_SERVER_RPC_NEW:
         if (ev->call != NULL) {
           /* initial ops are already started in request_call */
-          grpc_call_server_accept(ev->call, cq, s);
-          grpc_call_server_end_initial_metadata(ev->call,
-                                                GRPC_WRITE_BUFFER_HINT);
-          GPR_ASSERT(grpc_call_start_read(ev->call, s) == GRPC_CALL_OK);
+          grpc_call_server_accept_old(ev->call, cq, s);
+          grpc_call_server_end_initial_metadata_old(ev->call,
+                                                    GRPC_WRITE_BUFFER_HINT);
+          GPR_ASSERT(grpc_call_start_read_old(ev->call, s) == GRPC_CALL_OK);
           request_call();
         } else {
           GPR_ASSERT(shutdown_started);
@@ -185,17 +185,17 @@ int main(int argc, char **argv) {
         break;
       case GRPC_WRITE_ACCEPTED:
         GPR_ASSERT(ev->data.write_accepted == GRPC_OP_OK);
-        GPR_ASSERT(grpc_call_start_read(ev->call, s) == GRPC_CALL_OK);
+        GPR_ASSERT(grpc_call_start_read_old(ev->call, s) == GRPC_CALL_OK);
         break;
       case GRPC_READ:
         if (ev->data.read) {
           assert_read_ok(ev->tag, ev->data.read);
-          GPR_ASSERT(grpc_call_start_write(ev->call, ev->data.read, s,
-                                           GRPC_WRITE_BUFFER_HINT) ==
+          GPR_ASSERT(grpc_call_start_write_old(ev->call, ev->data.read, s,
+                                               GRPC_WRITE_BUFFER_HINT) ==
                      GRPC_CALL_OK);
         } else {
-          GPR_ASSERT(grpc_call_start_write_status(ev->call, GRPC_STATUS_OK,
-                                                  NULL, s) == GRPC_CALL_OK);
+          GPR_ASSERT(grpc_call_start_write_status_old(ev->call, GRPC_STATUS_OK,
+                                                      NULL, s) == GRPC_CALL_OK);
         }
         break;
       case GRPC_FINISH_ACCEPTED:

--- a/test/core/end2end/dualstack_socket_test.c
+++ b/test/core/end2end/dualstack_socket_test.c
@@ -112,29 +112,31 @@ void test_connect(const char *server_host, const char *client_host, int port,
   }
 
   /* Send a trivial request. */
-  c = grpc_channel_create_call(client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(client, "/foo", "test.google.com", deadline);
   GPR_ASSERT(c);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_invoke(c, client_cq, tag(2), tag(3), 0));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(4)));
+  GPR_ASSERT(GRPC_CALL_OK ==
+             grpc_call_invoke_old(c, client_cq, tag(2), tag(3), 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(4)));
   if (expect_ok) {
     /* Check for a successful request. */
     cq_expect_finish_accepted(v_client, tag(4), GRPC_OP_OK);
     cq_verify(v_client);
 
-    GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(server, tag(100)));
+    GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(server, tag(100)));
     cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "test.google.com",
                              deadline, NULL);
     cq_verify(v_server);
 
-    GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_accept(s, server_cq, tag(102)));
-    GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata(s, 0));
+    GPR_ASSERT(GRPC_CALL_OK ==
+               grpc_call_server_accept_old(s, server_cq, tag(102)));
+    GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata_old(s, 0));
     cq_expect_client_metadata_read(v_client, tag(2), NULL);
     cq_verify(v_client);
 
     GPR_ASSERT(GRPC_CALL_OK ==
-               grpc_call_start_write_status(s, GRPC_STATUS_UNIMPLEMENTED, "xyz",
-                                            tag(5)));
+               grpc_call_start_write_status_old(s, GRPC_STATUS_UNIMPLEMENTED,
+                                                "xyz", tag(5)));
     cq_expect_finished_with_status(v_client, tag(3), GRPC_STATUS_UNIMPLEMENTED,
                                    "xyz", NULL);
     cq_verify(v_client);

--- a/test/core/end2end/no_server_test.c
+++ b/test/core/end2end/no_server_test.c
@@ -56,8 +56,8 @@ int main(int argc, char **argv) {
 
   /* create a call, channel to a non existant server */
   chan = grpc_channel_create("nonexistant:54321", NULL);
-  call = grpc_channel_create_call(chan, "/foo", "nonexistant", deadline);
-  GPR_ASSERT(grpc_call_invoke(call, cq, tag(2), tag(3), 0) == GRPC_CALL_OK);
+  call = grpc_channel_create_call_old(chan, "/foo", "nonexistant", deadline);
+  GPR_ASSERT(grpc_call_invoke_old(call, cq, tag(2), tag(3), 0) == GRPC_CALL_OK);
   /* verify that all tags get completed */
   cq_expect_client_metadata_read(cqv, tag(2), NULL);
   cq_expect_finished_with_status(cqv, tag(3), GRPC_STATUS_DEADLINE_EXCEEDED,

--- a/test/core/end2end/tests/cancel_after_accept.c
+++ b/test/core/end2end/tests/cancel_after_accept.c
@@ -113,19 +113,21 @@ static void test_cancel_after_accept(grpc_end2end_test_config config,
   cq_verifier *v_client = cq_verifier_create(f.client_cq);
   cq_verifier *v_server = cq_verifier_create(f.server_cq);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
   cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "test.google.com",
                            deadline, NULL);
   cq_verify(v_server);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_accept(s, f.server_cq, tag(102)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata(s, 0));
+  GPR_ASSERT(GRPC_CALL_OK ==
+             grpc_call_server_accept_old(s, f.server_cq, tag(102)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata_old(s, 0));
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_verify(v_client);
 

--- a/test/core/end2end/tests/cancel_after_accept_and_writes_closed.c
+++ b/test/core/end2end/tests/cancel_after_accept_and_writes_closed.c
@@ -113,27 +113,29 @@ static void test_cancel_after_accept_and_writes_closed(
   cq_verifier *v_client = cq_verifier_create(f.client_cq);
   cq_verifier *v_server = cq_verifier_create(f.server_cq);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
   cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "test.google.com",
                            deadline, NULL);
   cq_verify(v_server);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_accept(s, f.server_cq, tag(102)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata(s, 0));
+  GPR_ASSERT(GRPC_CALL_OK ==
+             grpc_call_server_accept_old(s, f.server_cq, tag(102)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata_old(s, 0));
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(4)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(4)));
   cq_expect_finish_accepted(v_client, tag(4), GRPC_OP_OK);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(s, tag(101)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(s, tag(101)));
   cq_expect_empty_read(v_server, tag(101));
   cq_verify(v_server);
 

--- a/test/core/end2end/tests/cancel_after_invoke.c
+++ b/test/core/end2end/tests/cancel_after_invoke.c
@@ -111,11 +111,12 @@ static void test_cancel_after_invoke(grpc_end2end_test_config config,
   gpr_timespec deadline = five_seconds_time();
   cq_verifier *v_client = cq_verifier_create(f.client_cq);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
   GPR_ASSERT(GRPC_CALL_OK == mode.initiate_cancel(c));
 

--- a/test/core/end2end/tests/cancel_before_invoke.c
+++ b/test/core/end2end/tests/cancel_before_invoke.c
@@ -109,13 +109,14 @@ static void test_cancel_before_invoke(grpc_end2end_test_config config) {
   gpr_timespec deadline = five_seconds_time();
   cq_verifier *v_client = cq_verifier_create(f.client_cq);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK == grpc_call_cancel(c));
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_expect_finished_with_status(v_client, tag(3), GRPC_STATUS_CANCELLED, NULL,
                                  NULL);

--- a/test/core/end2end/tests/cancel_in_a_vacuum.c
+++ b/test/core/end2end/tests/cancel_in_a_vacuum.c
@@ -109,7 +109,8 @@ static void test_cancel_in_a_vacuum(grpc_end2end_test_config config,
   gpr_timespec deadline = five_seconds_time();
   cq_verifier *v_client = cq_verifier_create(f.client_cq);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK == mode.initiate_cancel(c));

--- a/test/core/end2end/tests/census_simple_request.c
+++ b/test/core/end2end/tests/census_simple_request.c
@@ -106,27 +106,29 @@ static void test_body(grpc_end2end_test_fixture f) {
   cq_verifier *v_client = cq_verifier_create(f.client_cq);
   cq_verifier *v_server = cq_verifier_create(f.server_cq);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
   tag(1);
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(4)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(4)));
   cq_expect_finish_accepted(v_client, tag(4), GRPC_OP_OK);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
   cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "test.google.com",
                            deadline, NULL);
   cq_verify(v_server);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_accept(s, f.server_cq, tag(102)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata(s, 0));
+  GPR_ASSERT(GRPC_CALL_OK ==
+             grpc_call_server_accept_old(s, f.server_cq, tag(102)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata_old(s, 0));
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status(
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status_old(
                                  s, GRPC_STATUS_UNIMPLEMENTED, "xyz", tag(5)));
   cq_expect_finished_with_status(v_client, tag(3), GRPC_STATUS_UNIMPLEMENTED,
                                  "xyz", NULL);

--- a/test/core/end2end/tests/disappearing_server.c
+++ b/test/core/end2end/tests/disappearing_server.c
@@ -97,24 +97,25 @@ static void do_request_and_shutdown_server(grpc_end2end_test_fixture *f,
   grpc_call *s;
   gpr_timespec deadline = five_seconds_time();
 
-  c = grpc_channel_create_call(f->client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f->client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f->client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f->client_cq, tag(2), tag(3), 0));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(4)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(4)));
   cq_expect_finish_accepted(v_client, tag(4), GRPC_OP_OK);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f->server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f->server, tag(100)));
   cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "test.google.com",
                            deadline, NULL);
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_server_accept(s, f->server_cq, tag(102)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata(s, 0));
+             grpc_call_server_accept_old(s, f->server_cq, tag(102)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata_old(s, 0));
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_verify(v_client);
 
@@ -122,7 +123,7 @@ static void do_request_and_shutdown_server(grpc_end2end_test_fixture *f,
      - and still complete the request */
   grpc_server_shutdown(f->server);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status(
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status_old(
                                  s, GRPC_STATUS_UNIMPLEMENTED, "xyz", tag(5)));
   cq_expect_finished_with_status(v_client, tag(3), GRPC_STATUS_UNIMPLEMENTED,
                                  "xyz", NULL);

--- a/test/core/end2end/tests/early_server_shutdown_finishes_inflight_calls.c
+++ b/test/core/end2end/tests/early_server_shutdown_finishes_inflight_calls.c
@@ -111,23 +111,25 @@ static void test_early_server_shutdown_finishes_inflight_calls(
   cq_verifier *v_client = cq_verifier_create(f.client_cq);
   cq_verifier *v_server = cq_verifier_create(f.server_cq);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(4)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(4)));
   cq_expect_finish_accepted(v_client, tag(4), GRPC_OP_OK);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
   cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "test.google.com",
                            deadline, NULL);
   cq_verify(v_server);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_accept(s, f.server_cq, tag(102)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata(s, 0));
+  GPR_ASSERT(GRPC_CALL_OK ==
+             grpc_call_server_accept_old(s, f.server_cq, tag(102)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata_old(s, 0));
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_verify(v_client);
 

--- a/test/core/end2end/tests/early_server_shutdown_finishes_tags.c
+++ b/test/core/end2end/tests/early_server_shutdown_finishes_tags.c
@@ -110,7 +110,7 @@ static void test_early_server_shutdown_finishes_tags(
 
   /* upon shutdown, the server should finish all requested calls indicating
      no new call */
-  grpc_server_request_call(f.server, tag(1000));
+  grpc_server_request_call_old(f.server, tag(1000));
   grpc_server_shutdown(f.server);
   cq_expect_server_rpc_new(v_server, &s, tag(1000), NULL, NULL, gpr_inf_past,
                            NULL);

--- a/test/core/end2end/tests/graceful_server_shutdown.c
+++ b/test/core/end2end/tests/graceful_server_shutdown.c
@@ -110,23 +110,25 @@ static void test_early_server_shutdown_finishes_inflight_calls(
   cq_verifier *v_client = cq_verifier_create(f.client_cq);
   cq_verifier *v_server = cq_verifier_create(f.server_cq);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(4)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(4)));
   cq_expect_finish_accepted(v_client, tag(4), GRPC_OP_OK);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
   cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "test.google.com",
                            deadline, NULL);
   cq_verify(v_server);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_accept(s, f.server_cq, tag(102)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata(s, 0));
+  GPR_ASSERT(GRPC_CALL_OK ==
+             grpc_call_server_accept_old(s, f.server_cq, tag(102)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata_old(s, 0));
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_verify(v_client);
 
@@ -134,7 +136,7 @@ static void test_early_server_shutdown_finishes_inflight_calls(
   grpc_server_shutdown_and_notify(f.server, tag(0xdead));
   cq_verify_empty(v_server);
 
-  grpc_call_start_write_status(s, GRPC_STATUS_OK, NULL, tag(103));
+  grpc_call_start_write_status_old(s, GRPC_STATUS_OK, NULL, tag(103));
   grpc_call_destroy(s);
   cq_expect_finish_accepted(v_server, tag(103), GRPC_OP_OK);
   cq_expect_finished(v_server, tag(102), NULL);

--- a/test/core/end2end/tests/invoke_large_request.c
+++ b/test/core/end2end/tests/invoke_large_request.c
@@ -120,16 +120,17 @@ static void test_invoke_large_request(grpc_end2end_test_config config) {
   /* byte buffer holds the slice, we can unref it already */
   gpr_slice_unref(request_payload_slice);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_start_write(c, request_payload, tag(4), 0));
+             grpc_call_start_write_old(c, request_payload, tag(4), 0));
   /* destroy byte buffer early to ensure async code keeps track of its contents
      correctly */
   grpc_byte_buffer_destroy(request_payload);
@@ -141,20 +142,21 @@ static void test_invoke_large_request(grpc_end2end_test_config config) {
                            deadline, NULL);
   cq_verify(v_server);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_accept(s, f.server_cq, tag(102)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata(s, 0));
+  GPR_ASSERT(GRPC_CALL_OK ==
+             grpc_call_server_accept_old(s, f.server_cq, tag(102)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata_old(s, 0));
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(s, tag(5)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(s, tag(5)));
   /* now the write can be accepted */
   cq_expect_write_accepted(v_client, tag(4), GRPC_OP_OK);
   cq_verify(v_client);
   cq_expect_read(v_server, tag(5), large_slice());
   cq_verify(v_server);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(8)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status(
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(8)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status_old(
                                  s, GRPC_STATUS_UNIMPLEMENTED, "xyz", tag(9)));
 
   cq_expect_finish_accepted(v_client, tag(8), GRPC_OP_OK);

--- a/test/core/end2end/tests/ping_pong_streaming.c
+++ b/test/core/end2end/tests/ping_pong_streaming.c
@@ -118,19 +118,21 @@ static void test_pingpong_streaming(grpc_end2end_test_config config,
   cq_verifier *v_server = cq_verifier_create(f.server_cq);
 
   gpr_log(GPR_INFO, "testing with %d message pairs.", messages);
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
 
   cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "test.google.com",
                            deadline, NULL);
   cq_verify(v_server);
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_accept(s, f.server_cq, tag(102)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata(s, 0));
+  GPR_ASSERT(GRPC_CALL_OK ==
+             grpc_call_server_accept_old(s, f.server_cq, tag(102)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata_old(s, 0));
 
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_verify(v_client);
@@ -138,7 +140,7 @@ static void test_pingpong_streaming(grpc_end2end_test_config config,
   for (i = 0; i < messages; i++) {
     request_payload = grpc_byte_buffer_create(&request_payload_slice, 1);
     GPR_ASSERT(GRPC_CALL_OK ==
-               grpc_call_start_write(c, request_payload, tag(2), 0));
+               grpc_call_start_write_old(c, request_payload, tag(2), 0));
     /* destroy byte buffer early to ensure async code keeps track of its
        contents
        correctly */
@@ -146,14 +148,14 @@ static void test_pingpong_streaming(grpc_end2end_test_config config,
     cq_expect_write_accepted(v_client, tag(2), GRPC_OP_OK);
     cq_verify(v_client);
 
-    GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(s, tag(3)));
+    GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(s, tag(3)));
     cq_expect_read(v_server, tag(3),
                    gpr_slice_from_copied_string("hello world"));
     cq_verify(v_server);
 
     response_payload = grpc_byte_buffer_create(&response_payload_slice, 1);
     GPR_ASSERT(GRPC_CALL_OK ==
-               grpc_call_start_write(s, response_payload, tag(4), 0));
+               grpc_call_start_write_old(s, response_payload, tag(4), 0));
     /* destroy byte buffer early to ensure async code keeps track of its
        contents
        correctly */
@@ -161,7 +163,7 @@ static void test_pingpong_streaming(grpc_end2end_test_config config,
     cq_expect_write_accepted(v_server, tag(4), GRPC_OP_OK);
     cq_verify(v_server);
 
-    GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(c, tag(5)));
+    GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(c, tag(5)));
     cq_expect_read(v_client, tag(5), gpr_slice_from_copied_string("hello you"));
     cq_verify(v_client);
   }
@@ -169,8 +171,8 @@ static void test_pingpong_streaming(grpc_end2end_test_config config,
   gpr_slice_unref(request_payload_slice);
   gpr_slice_unref(response_payload_slice);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(6)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status(
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(6)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status_old(
                                  s, GRPC_STATUS_UNIMPLEMENTED, "xyz", tag(7)));
 
   cq_expect_finish_accepted(v_client, tag(6), GRPC_OP_OK);

--- a/test/core/end2end/tests/request_response_with_binary_metadata_and_payload.c
+++ b/test/core/end2end/tests/request_response_with_binary_metadata_and_payload.c
@@ -131,24 +131,25 @@ static void test_request_response_with_metadata_and_payload(
   cq_verifier *v_client = cq_verifier_create(f.client_cq);
   cq_verifier *v_server = cq_verifier_create(f.server_cq);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
 
   /* byte buffer holds the slice, we can unref it already */
   gpr_slice_unref(request_payload_slice);
   gpr_slice_unref(response_payload_slice);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   /* add multiple metadata */
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(c, &meta1, 0));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(c, &meta2, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(c, &meta1, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(c, &meta2, 0));
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_start_write(c, request_payload, tag(4), 0));
+             grpc_call_start_write_old(c, request_payload, tag(4), 0));
   /* destroy byte buffer early to ensure async code keeps track of its contents
      correctly */
   grpc_byte_buffer_destroy(request_payload);
@@ -161,20 +162,20 @@ static void test_request_response_with_metadata_and_payload(
       "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d", NULL);
   cq_verify(v_server);
 
-  grpc_call_server_accept(s, f.server_cq, tag(102));
+  grpc_call_server_accept_old(s, f.server_cq, tag(102));
 
   /* add multiple metadata */
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(s, &meta3, 0));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(s, &meta4, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(s, &meta3, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(s, &meta4, 0));
 
-  grpc_call_server_end_initial_metadata(s, 0);
+  grpc_call_server_end_initial_metadata_old(s, 0);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(s, tag(5)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(s, tag(5)));
   cq_expect_read(v_server, tag(5), gpr_slice_from_copied_string("hello world"));
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_start_write(s, response_payload, tag(6), 0));
+             grpc_call_start_write_old(s, response_payload, tag(6), 0));
   /* destroy byte buffer early to ensure async code keeps track of its contents
      correctly */
   grpc_byte_buffer_destroy(response_payload);
@@ -189,12 +190,12 @@ static void test_request_response_with_metadata_and_payload(
       "\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff", NULL);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(c, tag(7)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(c, tag(7)));
   cq_expect_read(v_client, tag(7), gpr_slice_from_copied_string("hello you"));
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(8)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status(
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(8)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status_old(
                                  s, GRPC_STATUS_UNIMPLEMENTED, "xyz", tag(9)));
 
   cq_expect_finish_accepted(v_client, tag(8), GRPC_OP_OK);

--- a/test/core/end2end/tests/request_response_with_metadata_and_payload.c
+++ b/test/core/end2end/tests/request_response_with_metadata_and_payload.c
@@ -122,24 +122,25 @@ static void test_request_response_with_metadata_and_payload(
   cq_verifier *v_client = cq_verifier_create(f.client_cq);
   cq_verifier *v_server = cq_verifier_create(f.server_cq);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
 
   /* byte buffer holds the slice, we can unref it already */
   gpr_slice_unref(request_payload_slice);
   gpr_slice_unref(response_payload_slice);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   /* add multiple metadata */
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(c, &meta1, 0));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(c, &meta2, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(c, &meta1, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(c, &meta2, 0));
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_start_write(c, request_payload, tag(4), 0));
+             grpc_call_start_write_old(c, request_payload, tag(4), 0));
   /* destroy byte buffer early to ensure async code keeps track of its contents
      correctly */
   grpc_byte_buffer_destroy(request_payload);
@@ -150,20 +151,20 @@ static void test_request_response_with_metadata_and_payload(
                            deadline, "key1", "val1", "key2", "val2", NULL);
   cq_verify(v_server);
 
-  grpc_call_server_accept(s, f.server_cq, tag(102));
+  grpc_call_server_accept_old(s, f.server_cq, tag(102));
 
   /* add multiple metadata */
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(s, &meta3, 0));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(s, &meta4, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(s, &meta3, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(s, &meta4, 0));
 
-  grpc_call_server_end_initial_metadata(s, 0);
+  grpc_call_server_end_initial_metadata_old(s, 0);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(s, tag(5)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(s, tag(5)));
   cq_expect_read(v_server, tag(5), gpr_slice_from_copied_string("hello world"));
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_start_write(s, response_payload, tag(6), 0));
+             grpc_call_start_write_old(s, response_payload, tag(6), 0));
   /* destroy byte buffer early to ensure async code keeps track of its contents
      correctly */
   grpc_byte_buffer_destroy(response_payload);
@@ -175,12 +176,12 @@ static void test_request_response_with_metadata_and_payload(
                                  "val4", NULL);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(c, tag(7)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(c, tag(7)));
   cq_expect_read(v_client, tag(7), gpr_slice_from_copied_string("hello you"));
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(8)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status(
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(8)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status_old(
                                  s, GRPC_STATUS_UNIMPLEMENTED, "xyz", tag(9)));
 
   cq_expect_finish_accepted(v_client, tag(8), GRPC_OP_OK);

--- a/test/core/end2end/tests/request_response_with_payload.c
+++ b/test/core/end2end/tests/request_response_with_payload.c
@@ -119,16 +119,17 @@ static void request_response_with_payload(grpc_end2end_test_fixture f) {
   gpr_slice_unref(request_payload_slice);
   gpr_slice_unref(response_payload_slice);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_start_write(c, request_payload, tag(4), 0));
+             grpc_call_start_write_old(c, request_payload, tag(4), 0));
   /* destroy byte buffer early to ensure async code keeps track of its contents
      correctly */
   grpc_byte_buffer_destroy(request_payload);
@@ -139,28 +140,29 @@ static void request_response_with_payload(grpc_end2end_test_fixture f) {
                            deadline, NULL);
   cq_verify(v_server);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_accept(s, f.server_cq, tag(102)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata(s, 0));
+  GPR_ASSERT(GRPC_CALL_OK ==
+             grpc_call_server_accept_old(s, f.server_cq, tag(102)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata_old(s, 0));
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(s, tag(5)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(s, tag(5)));
   cq_expect_read(v_server, tag(5), gpr_slice_from_copied_string("hello world"));
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_start_write(s, response_payload, tag(6), 0));
+             grpc_call_start_write_old(s, response_payload, tag(6), 0));
   /* destroy byte buffer early to ensure async code keeps track of its contents
      correctly */
   grpc_byte_buffer_destroy(response_payload);
   cq_expect_write_accepted(v_server, tag(6), GRPC_OP_OK);
   cq_verify(v_server);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(c, tag(7)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(c, tag(7)));
   cq_expect_read(v_client, tag(7), gpr_slice_from_copied_string("hello you"));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(8)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status(
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(8)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status_old(
                                  s, GRPC_STATUS_UNIMPLEMENTED, "xyz", tag(9)));
 
   cq_expect_finish_accepted(v_client, tag(8), GRPC_OP_OK);

--- a/test/core/end2end/tests/request_response_with_trailing_metadata_and_payload.c
+++ b/test/core/end2end/tests/request_response_with_trailing_metadata_and_payload.c
@@ -124,24 +124,25 @@ static void test_request_response_with_metadata_and_payload(
   cq_verifier *v_client = cq_verifier_create(f.client_cq);
   cq_verifier *v_server = cq_verifier_create(f.server_cq);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
 
   /* byte buffer holds the slice, we can unref it already */
   gpr_slice_unref(request_payload_slice);
   gpr_slice_unref(response_payload_slice);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   /* add multiple metadata */
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(c, &meta1, 0));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(c, &meta2, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(c, &meta1, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(c, &meta2, 0));
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_start_write(c, request_payload, tag(4), 0));
+             grpc_call_start_write_old(c, request_payload, tag(4), 0));
   /* destroy byte buffer early to ensure async code keeps track of its contents
      correctly */
   grpc_byte_buffer_destroy(request_payload);
@@ -152,23 +153,23 @@ static void test_request_response_with_metadata_and_payload(
                            deadline, "key1", "val1", "key2", "val2", NULL);
   cq_verify(v_server);
 
-  grpc_call_server_accept(s, f.server_cq, tag(102));
+  grpc_call_server_accept_old(s, f.server_cq, tag(102));
 
   /* add multiple metadata */
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(s, &meta3, 0));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(s, &meta4, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(s, &meta3, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(s, &meta4, 0));
 
-  grpc_call_server_end_initial_metadata(s, 0);
+  grpc_call_server_end_initial_metadata_old(s, 0);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(s, &meta5, 0));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(s, &meta6, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(s, &meta5, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(s, &meta6, 0));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(s, tag(5)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(s, tag(5)));
   cq_expect_read(v_server, tag(5), gpr_slice_from_copied_string("hello world"));
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_start_write(s, response_payload, tag(6), 0));
+             grpc_call_start_write_old(s, response_payload, tag(6), 0));
   /* destroy byte buffer early to ensure async code keeps track of its contents
      correctly */
   grpc_byte_buffer_destroy(response_payload);
@@ -180,12 +181,12 @@ static void test_request_response_with_metadata_and_payload(
                                  "val4", NULL);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(c, tag(7)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(c, tag(7)));
   cq_expect_read(v_client, tag(7), gpr_slice_from_copied_string("hello you"));
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(8)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status(
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(8)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status_old(
                                  s, GRPC_STATUS_UNIMPLEMENTED, "xyz", tag(9)));
 
   cq_expect_finish_accepted(v_client, tag(8), GRPC_OP_OK);

--- a/test/core/end2end/tests/request_with_large_metadata.c
+++ b/test/core/end2end/tests/request_with_large_metadata.c
@@ -113,7 +113,7 @@ static void test_request_with_large_metadata(grpc_end2end_test_config config) {
   cq_verifier *v_server = cq_verifier_create(f.server_cq);
   const int large_size = 64 * 1024;
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
 
   meta.key = "key";
   meta.value = gpr_malloc(large_size + 1);
@@ -121,14 +121,15 @@ static void test_request_with_large_metadata(grpc_end2end_test_config config) {
   meta.value[large_size] = 0;
   meta.value_length = large_size;
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   /* add the metadata */
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(c, &meta, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(c, &meta, 0));
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
   cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "test.google.com",
                            deadline, "key", meta.value, NULL);
@@ -140,9 +141,9 @@ static void test_request_with_large_metadata(grpc_end2end_test_config config) {
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(8)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(8)));
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_start_write_status(s, GRPC_STATUS_OK, NULL, tag(9)));
+             grpc_call_start_write_status_old(s, GRPC_STATUS_OK, NULL, tag(9)));
 
   cq_expect_finish_accepted(v_client, tag(8), GRPC_OP_OK);
   cq_expect_finished_with_status(v_client, tag(3), GRPC_STATUS_OK, NULL, NULL);

--- a/test/core/end2end/tests/request_with_payload.c
+++ b/test/core/end2end/tests/request_with_payload.c
@@ -116,15 +116,16 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
   /* byte buffer holds the slice, we can unref it already */
   gpr_slice_unref(payload_slice);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write(c, payload, tag(4), 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_old(c, payload, tag(4), 0));
   /* destroy byte buffer early to ensure async code keeps track of its contents
      correctly */
   grpc_byte_buffer_destroy(payload);
@@ -139,11 +140,11 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(s, tag(4)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(s, tag(4)));
   cq_expect_read(v_server, tag(4), gpr_slice_from_copied_string("hello world"));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(5)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status(
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(5)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status_old(
                                  s, GRPC_STATUS_UNIMPLEMENTED, "xyz", tag(6)));
   cq_expect_finish_accepted(v_client, tag(5), GRPC_OP_OK);
   cq_expect_finished_with_status(v_client, tag(3), GRPC_STATUS_UNIMPLEMENTED,

--- a/test/core/end2end/tests/simple_delayed_request.c
+++ b/test/core/end2end/tests/simple_delayed_request.c
@@ -103,32 +103,33 @@ static void simple_delayed_request_body(grpc_end2end_test_config config,
 
   config.init_client(f, client_args);
 
-  c = grpc_channel_create_call(f->client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f->client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f->client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f->client_cq, tag(2), tag(3), 0));
 
   config.init_server(f, server_args);
 
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(4)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(4)));
   cq_expect_finish_accepted(v_client, tag(4), GRPC_OP_OK);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f->server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f->server, tag(100)));
   cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "test.google.com",
                            deadline, NULL);
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_server_accept(s, f->server_cq, tag(102)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata(s, 0));
+             grpc_call_server_accept_old(s, f->server_cq, tag(102)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata_old(s, 0));
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status(
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status_old(
                                  s, GRPC_STATUS_UNIMPLEMENTED, "xyz", tag(5)));
   cq_expect_finished_with_status(v_client, tag(3), GRPC_STATUS_UNIMPLEMENTED,
                                  "xyz", NULL);

--- a/test/core/end2end/tests/simple_request.c
+++ b/test/core/end2end/tests/simple_request.c
@@ -110,27 +110,29 @@ static void simple_request_body(grpc_end2end_test_fixture f) {
   cq_verifier *v_client = cq_verifier_create(f.client_cq);
   cq_verifier *v_server = cq_verifier_create(f.server_cq);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(4)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(4)));
   cq_expect_finish_accepted(v_client, tag(4), GRPC_OP_OK);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
   cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "test.google.com",
                            deadline, NULL);
   cq_verify(v_server);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_accept(s, f.server_cq, tag(102)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata(s, 0));
+  GPR_ASSERT(GRPC_CALL_OK ==
+             grpc_call_server_accept_old(s, f.server_cq, tag(102)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata_old(s, 0));
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status(
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status_old(
                                  s, GRPC_STATUS_UNIMPLEMENTED, "xyz", tag(5)));
   cq_expect_finished_with_status(v_client, tag(3), GRPC_STATUS_UNIMPLEMENTED,
                                  "xyz", NULL);
@@ -156,25 +158,27 @@ static void simple_request_body2(grpc_end2end_test_fixture f) {
   cq_verifier *v_client = cq_verifier_create(f.client_cq);
   cq_verifier *v_server = cq_verifier_create(f.server_cq);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(4)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(4)));
   cq_expect_finish_accepted(v_client, tag(4), GRPC_OP_OK);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
   cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "test.google.com",
                            deadline, NULL);
   cq_verify(v_server);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_accept(s, f.server_cq, tag(102)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata(s, 0));
+  GPR_ASSERT(GRPC_CALL_OK ==
+             grpc_call_server_accept_old(s, f.server_cq, tag(102)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata_old(s, 0));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status(
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status_old(
                                  s, GRPC_STATUS_UNIMPLEMENTED, "xyz", tag(5)));
   cq_expect_finish_accepted(v_server, tag(5), GRPC_OP_OK);
   cq_verify(v_server);

--- a/test/core/end2end/tests/thread_stress.c
+++ b/test/core/end2end/tests/thread_stress.c
@@ -108,7 +108,7 @@ static void drain_cq(int client, grpc_completion_queue *cq) {
 static void start_request(void) {
   gpr_slice slice = gpr_slice_malloc(100);
   grpc_byte_buffer *buf;
-  grpc_call *call = grpc_channel_create_call(
+  grpc_call *call = grpc_channel_create_call_old(
       g_fixture.client, "/Foo", "test.google.com", g_test_end_time);
 
   memset(GPR_SLICE_START_PTR(slice), 1, GPR_SLICE_LENGTH(slice));
@@ -117,9 +117,9 @@ static void start_request(void) {
 
   g_active_requests++;
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(call, g_fixture.client_cq, NULL, NULL, 0));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(call, NULL));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write(call, buf, NULL, 0));
+             grpc_call_invoke_old(call, g_fixture.client_cq, NULL, NULL, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(call, NULL));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_old(call, buf, NULL, 0));
 
   grpc_byte_buffer_destroy(buf);
 }
@@ -143,7 +143,7 @@ static void client_thread(void *p) {
         case GRPC_READ:
           break;
         case GRPC_WRITE_ACCEPTED:
-          GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(ev->call, NULL));
+          GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(ev->call, NULL));
           break;
         case GRPC_FINISH_ACCEPTED:
           break;
@@ -179,13 +179,13 @@ static void client_thread(void *p) {
 static void request_server_call(void) {
   gpr_refcount *rc = gpr_malloc(sizeof(gpr_refcount));
   gpr_ref_init(rc, 2);
-  grpc_server_request_call(g_fixture.server, rc);
+  grpc_server_request_call_old(g_fixture.server, rc);
 }
 
 static void maybe_end_server_call(grpc_call *call, gpr_refcount *rc) {
   if (gpr_unref(rc)) {
-    GPR_ASSERT(GRPC_CALL_OK ==
-               grpc_call_start_write_status(call, GRPC_STATUS_OK, NULL, NULL));
+    GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status_old(
+                                   call, GRPC_STATUS_OK, NULL, NULL));
     gpr_free(rc);
   }
 }
@@ -215,20 +215,22 @@ static void server_thread(void *p) {
         case GRPC_SERVER_RPC_NEW:
           if (ev->call) {
             GPR_ASSERT(GRPC_CALL_OK ==
-                       grpc_call_server_accept(ev->call, g_fixture.server_cq,
-                                               ev->tag));
+                       grpc_call_server_accept_old(
+                           ev->call, g_fixture.server_cq, ev->tag));
             GPR_ASSERT(GRPC_CALL_OK ==
-                       grpc_call_server_end_initial_metadata(ev->call, 0));
-            GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(ev->call, ev->tag));
+                       grpc_call_server_end_initial_metadata_old(ev->call, 0));
             GPR_ASSERT(GRPC_CALL_OK ==
-                       grpc_call_start_write(ev->call, buf, ev->tag, 0));
+                       grpc_call_start_read_old(ev->call, ev->tag));
+            GPR_ASSERT(GRPC_CALL_OK ==
+                       grpc_call_start_write_old(ev->call, buf, ev->tag, 0));
           } else {
             gpr_free(ev->tag);
           }
           break;
         case GRPC_READ:
           if (ev->data.read) {
-            GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(ev->call, ev->tag));
+            GPR_ASSERT(GRPC_CALL_OK ==
+                       grpc_call_start_read_old(ev->call, ev->tag));
           } else {
             maybe_end_server_call(ev->call, ev->tag);
           }

--- a/test/core/end2end/tests/writes_done_hangs_with_pending_read.c
+++ b/test/core/end2end/tests/writes_done_hangs_with_pending_read.c
@@ -124,44 +124,46 @@ static void test_writes_done_hangs_with_pending_read(
   gpr_slice_unref(request_payload_slice);
   gpr_slice_unref(response_payload_slice);
 
-  c = grpc_channel_create_call(f.client, "/foo", "test.google.com", deadline);
+  c = grpc_channel_create_call_old(f.client, "/foo", "test.google.com",
+                                   deadline);
   GPR_ASSERT(c);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_invoke(c, f.client_cq, tag(2), tag(3), 0));
+             grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_start_write(c, request_payload, tag(4), 0));
+             grpc_call_start_write_old(c, request_payload, tag(4), 0));
   /* destroy byte buffer early to ensure async code keeps track of its contents
      correctly */
   grpc_byte_buffer_destroy(request_payload);
   cq_expect_write_accepted(v_client, tag(4), GRPC_OP_OK);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, tag(100)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
   cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "test.google.com",
                            deadline, NULL);
   cq_verify(v_server);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_accept(s, f.server_cq, tag(102)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata(s, 0));
+  GPR_ASSERT(GRPC_CALL_OK ==
+             grpc_call_server_accept_old(s, f.server_cq, tag(102)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_server_end_initial_metadata_old(s, 0));
   cq_expect_client_metadata_read(v_client, tag(2), NULL);
   cq_verify(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(s, tag(5)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(s, tag(5)));
   cq_expect_read(v_server, tag(5), gpr_slice_from_copied_string("hello world"));
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_start_write(s, response_payload, tag(6), 0));
+             grpc_call_start_write_old(s, response_payload, tag(6), 0));
   /* destroy byte buffer early to ensure async code keeps track of its contents
      correctly */
   grpc_byte_buffer_destroy(response_payload);
   cq_expect_write_accepted(v_server, tag(6), GRPC_OP_OK);
   cq_verify(v_server);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done(c, tag(6)));
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status(
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_writes_done_old(c, tag(6)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_write_status_old(
                                  s, GRPC_STATUS_UNIMPLEMENTED, "xyz", tag(7)));
 
   cq_expect_finish_accepted(v_client, tag(6), GRPC_OP_OK);
@@ -170,7 +172,7 @@ static void test_writes_done_hangs_with_pending_read(
   /* does not return status because there is a pending message to be read */
   cq_verify_empty(v_client);
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read(c, tag(8)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_read_old(c, tag(8)));
   cq_expect_read(v_client, tag(8), gpr_slice_from_copied_string("hello you"));
   cq_verify(v_client);
 

--- a/test/core/fling/client.c
+++ b/test/core/fling/client.c
@@ -53,15 +53,15 @@ static grpc_call *call;
 static void init_ping_pong_request(void) {}
 
 static void step_ping_pong_request(void) {
-  call = grpc_channel_create_call(channel, "/Reflector/reflectUnary",
-                                  "localhost", gpr_inf_future);
-  GPR_ASSERT(grpc_call_invoke(call, cq, (void *)1, (void *)1,
-                              GRPC_WRITE_BUFFER_HINT) == GRPC_CALL_OK);
-  GPR_ASSERT(grpc_call_start_write(call, the_buffer, (void *)1,
-                                   GRPC_WRITE_BUFFER_HINT) == GRPC_CALL_OK);
+  call = grpc_channel_create_call_old(channel, "/Reflector/reflectUnary",
+                                      "localhost", gpr_inf_future);
+  GPR_ASSERT(grpc_call_invoke_old(call, cq, (void *)1, (void *)1,
+                                  GRPC_WRITE_BUFFER_HINT) == GRPC_CALL_OK);
+  GPR_ASSERT(grpc_call_start_write_old(call, the_buffer, (void *)1,
+                                       GRPC_WRITE_BUFFER_HINT) == GRPC_CALL_OK);
   grpc_event_finish(grpc_completion_queue_next(cq, gpr_inf_future));
-  GPR_ASSERT(grpc_call_start_read(call, (void *)1) == GRPC_CALL_OK);
-  GPR_ASSERT(grpc_call_writes_done(call, (void *)1) == GRPC_CALL_OK);
+  GPR_ASSERT(grpc_call_start_read_old(call, (void *)1) == GRPC_CALL_OK);
+  GPR_ASSERT(grpc_call_writes_done_old(call, (void *)1) == GRPC_CALL_OK);
   grpc_event_finish(grpc_completion_queue_next(cq, gpr_inf_future));
   grpc_event_finish(grpc_completion_queue_next(cq, gpr_inf_future));
   grpc_event_finish(grpc_completion_queue_next(cq, gpr_inf_future));
@@ -70,17 +70,17 @@ static void step_ping_pong_request(void) {
 }
 
 static void init_ping_pong_stream(void) {
-  call = grpc_channel_create_call(channel, "/Reflector/reflectStream",
-                                  "localhost", gpr_inf_future);
-  GPR_ASSERT(grpc_call_invoke(call, cq, (void *)1, (void *)1, 0) ==
+  call = grpc_channel_create_call_old(channel, "/Reflector/reflectStream",
+                                      "localhost", gpr_inf_future);
+  GPR_ASSERT(grpc_call_invoke_old(call, cq, (void *)1, (void *)1, 0) ==
              GRPC_CALL_OK);
   grpc_event_finish(grpc_completion_queue_next(cq, gpr_inf_future));
 }
 
 static void step_ping_pong_stream(void) {
-  GPR_ASSERT(grpc_call_start_write(call, the_buffer, (void *)1, 0) ==
+  GPR_ASSERT(grpc_call_start_write_old(call, the_buffer, (void *)1, 0) ==
              GRPC_CALL_OK);
-  GPR_ASSERT(grpc_call_start_read(call, (void *)1) == GRPC_CALL_OK);
+  GPR_ASSERT(grpc_call_start_read_old(call, (void *)1) == GRPC_CALL_OK);
   grpc_event_finish(grpc_completion_queue_next(cq, gpr_inf_future));
   grpc_event_finish(grpc_completion_queue_next(cq, gpr_inf_future));
 }

--- a/test/core/fling/server.c
+++ b/test/core/fling/server.c
@@ -62,7 +62,7 @@ typedef struct {
 static void request_call(void) {
   call_state *s = gpr_malloc(sizeof(call_state));
   gpr_ref_init(&s->pending_ops, 2);
-  grpc_server_request_call(server, s);
+  grpc_server_request_call_old(server, s);
 }
 
 static void sigint_handler(int x) { got_sigint = 1; }
@@ -142,9 +142,9 @@ int main(int argc, char **argv) {
           } else {
             s->flags = GRPC_WRITE_BUFFER_HINT;
           }
-          grpc_call_server_accept(ev->call, cq, s);
-          grpc_call_server_end_initial_metadata(ev->call, s->flags);
-          GPR_ASSERT(grpc_call_start_read(ev->call, s) == GRPC_CALL_OK);
+          grpc_call_server_accept_old(ev->call, cq, s);
+          grpc_call_server_end_initial_metadata_old(ev->call, s->flags);
+          GPR_ASSERT(grpc_call_start_read_old(ev->call, s) == GRPC_CALL_OK);
           request_call();
         } else {
           GPR_ASSERT(shutdown_started);
@@ -153,15 +153,15 @@ int main(int argc, char **argv) {
         break;
       case GRPC_WRITE_ACCEPTED:
         GPR_ASSERT(ev->data.write_accepted == GRPC_OP_OK);
-        GPR_ASSERT(grpc_call_start_read(ev->call, s) == GRPC_CALL_OK);
+        GPR_ASSERT(grpc_call_start_read_old(ev->call, s) == GRPC_CALL_OK);
         break;
       case GRPC_READ:
         if (ev->data.read) {
-          GPR_ASSERT(grpc_call_start_write(ev->call, ev->data.read, s,
-                                           s->flags) == GRPC_CALL_OK);
+          GPR_ASSERT(grpc_call_start_write_old(ev->call, ev->data.read, s,
+                                               s->flags) == GRPC_CALL_OK);
         } else {
-          GPR_ASSERT(grpc_call_start_write_status(ev->call, GRPC_STATUS_OK,
-                                                  NULL, s) == GRPC_CALL_OK);
+          GPR_ASSERT(grpc_call_start_write_status_old(ev->call, GRPC_STATUS_OK,
+                                                      NULL, s) == GRPC_CALL_OK);
         }
         break;
       case GRPC_FINISH_ACCEPTED:

--- a/test/core/surface/lame_client_test.c
+++ b/test/core/surface/lame_client_test.c
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
 
   chan = grpc_lame_client_channel_create();
   GPR_ASSERT(chan);
-  call = grpc_channel_create_call(
+  call = grpc_channel_create_call_old(
       chan, "/Foo", "anywhere",
       gpr_time_add(gpr_now(), gpr_time_from_seconds(100)));
   GPR_ASSERT(call);
@@ -59,10 +59,10 @@ int main(int argc, char **argv) {
   cqv = cq_verifier_create(cq);
 
   /* we should be able to add metadata */
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata(call, &md, 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_add_metadata_old(call, &md, 0));
 
   /* and invoke the call */
-  GPR_ASSERT(GRPC_CALL_OK == grpc_call_invoke(call, cq, tag(2), tag(3), 0));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_call_invoke_old(call, cq, tag(2), tag(3), 0));
 
   /* the call should immediately fail */
   cq_expect_client_metadata_read(cqv, tag(2), NULL);


### PR DESCRIPTION
Rename all core API functions that are on their way to deprecation with an _old tag across all wrappings.

@murgatroid99 @tbetbetbe @nathanielmanistaatgoogle - please check my wrapping changes (they were made in bulk)
