### PR TITLE
Fix poll_kick_posix_test under asan

### DIFF
--- a/src/core/iomgr/pollset_kick.c
+++ b/src/core/iomgr/pollset_kick.c
@@ -138,6 +138,7 @@ void grpc_pollset_kick_kick(grpc_pollset_kick_state *kick_state) {
 }
 
 void grpc_pollset_kick_global_init_fallback_fd(void) {
+  gpr_mu_init(&fd_freelist_mu);
   grpc_wakeup_fd_global_init_force_fallback();
 }
 

--- a/test/core/iomgr/poll_kick_posix_test.c
+++ b/test/core/iomgr/poll_kick_posix_test.c
@@ -105,6 +105,7 @@ static void test_over_free(void) {
     grpc_pollset_kick_post_poll(&kick_state[i]);
     grpc_pollset_kick_destroy(&kick_state[i]);
   }
+  gpr_free(kick_state);
 }
 
 static void run_tests(void) {


### PR DESCRIPTION
1. Init the freelist_mu in the forced-fallback path
2. Free allocated memory in the test_over_free test case.
