### PR TITLE
Make several python scripts explicitly python2.7

### DIFF
--- a/test/core/end2end/gen_build_json.py
+++ b/test/core/end2end/gen_build_json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
 
 """Generates the appropriate build.json data for all the end2end tests."""
 

--- a/tools/buildgen/mako_renderer.py
+++ b/tools/buildgen/mako_renderer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
 
 """Simple Mako renderer.
 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
 """Run tests in parallel."""
 
 import argparse


### PR DESCRIPTION
I tried actually doing a build on my home desktop, and none of these
run with python 3.3, which is /usr/bin/python on my home desktop.
