### PR TITLE
Have cpu_linux.c define _GNU_SOURCE at the beginning of the file

### DIFF
--- a/src/core/support/cpu_linux.c
+++ b/src/core/support/cpu_linux.c
@@ -33,7 +33,7 @@
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
-#undef  /* _GNU_SOURCE */
+#endif  /* _GNU_SOURCE */
 
 #include <grpc/support/port_platform.h>
 


### PR DESCRIPTION
Feature test macros need to be defined before including any other headers.
