### PR TITLE
Remove timeval functions

### DIFF
--- a/include/grpc/support/time.h
+++ b/include/grpc/support/time.h
@@ -103,10 +103,6 @@ int gpr_time_similar(gpr_timespec a, gpr_timespec b, gpr_timespec threshold);
 /* Sleep until at least 'until' - an absolute timeout */
 void gpr_sleep_until(gpr_timespec until);
 
-struct timeval gpr_timeval_from_timespec(gpr_timespec t);
-
-gpr_timespec gpr_timespec_from_timeval(struct timeval t);
-
 double gpr_timespec_to_micros(gpr_timespec t);
 
 #ifdef __cplusplus

--- a/src/core/support/time.c
+++ b/src/core/support/time.c
@@ -234,22 +234,6 @@ int gpr_time_similar(gpr_timespec a, gpr_timespec b, gpr_timespec threshold) {
   }
 }
 
-struct timeval gpr_timeval_from_timespec(gpr_timespec t) {
-  /* TODO(klempner): Consider whether this should round up, since it is likely
-     to be used for delays */
-  struct timeval tv;
-  tv.tv_sec = t.tv_sec;
-  tv.tv_usec = t.tv_nsec / 1000;
-  return tv;
-}
-
-gpr_timespec gpr_timespec_from_timeval(struct timeval t) {
-  gpr_timespec ts;
-  ts.tv_sec = t.tv_sec;
-  ts.tv_nsec = t.tv_usec * 1000;
-  return ts;
-}
-
 gpr_int32 gpr_time_to_millis(gpr_timespec t) {
   if (t.tv_sec >= 2147483) {
     if (t.tv_sec == 2147483 && t.tv_nsec < 648 * GPR_NS_PER_MS) {

--- a/src/node/ext/timeval.cc
+++ b/src/node/ext/timeval.cc
@@ -56,9 +56,8 @@ double TimespecToMilliseconds(gpr_timespec timespec) {
   } else if (gpr_time_cmp(timespec, gpr_inf_past) == 0) {
     return -std::numeric_limits<double>::infinity();
   } else {
-    struct timeval time = gpr_timeval_from_timespec(timespec);
-    return (static_cast<double>(time.tv_sec) * 1000 +
-            static_cast<double>(time.tv_usec) / 1000);
+    return (static_cast<double>(timespec.tv_sec) * 1000 +
+            static_cast<double>(timespec.tv_nsec) / 1000000);
   }
 }
 


### PR DESCRIPTION
They only had one caller, which could easily be converted to use
timespec instead of timeval.
