### PR TITLE
Add a tsan suppression file with OPENSSL_cleanse and use it in run_tests

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -108,10 +108,11 @@ class PythonLanguage(object):
 _CONFIGS = {
     'dbg': SimpleConfig('dbg'),
     'opt': SimpleConfig('opt'),
-    'tsan': SimpleConfig('tsan'),
+    'tsan': SimpleConfig('tsan', environ={
+        'TSAN_OPTIONS': 'suppressions=tools/tsan_suppressions.txt'}),
     'msan': SimpleConfig('msan'),
     'asan': SimpleConfig('asan', environ={
-        'ASAN_OPTIONS': 'detect_leaks=1:color=always'}),
+        'ASAN_OPTIONS': 'detect_leaks=1:color=always:suppressions=tools/tsan_suppressions.txt'}),
     'gcov': SimpleConfig('gcov'),
     'memcheck': ValgrindConfig('valgrind', 'memcheck'),
     'helgrind': ValgrindConfig('dbg', 'helgrind')

--- a/tools/tsan_suppressions.txt
+++ b/tools/tsan_suppressions.txt
@@ -1,0 +1,2 @@
+# OPENSSL_cleanse does racy access to a global
+race:OPENSSL_cleanse


### PR DESCRIPTION
This clears out most of the remaining race reports under tsan.
