### PR TITLE
Not all Linuxes are equal, and secure_getenv isn't always there.

### DIFF
--- a/include/grpc/support/port_platform.h
+++ b/include/grpc/support/port_platform.h
@@ -70,6 +70,7 @@
 #define GPR_POSIX_TIME 1
 #define GPR_GETPID_IN_UNISTD_H 1
 #elif defined(__linux__)
+#include <features.h>
 #define GPR_CPU_LINUX 1
 #define GPR_GCC_ATOMIC 1
 #define GPR_LINUX 1
@@ -78,7 +79,14 @@
 #define GPR_LINUX_EVENTFD 1
 #define GPR_POSIX_SOCKET 1
 #define GPR_POSIX_SOCKETADDR 1
+#ifdef __GLIBC_PREREQ
+#if __GLIBC_PREREQ(2, 17)
 #define GPR_LINUX_ENV 1
+#endif
+#endif
+#ifndef GPR_LINUX_ENV
+#define GPR_POSIX_ENV 1
+#endif
 #define GPR_POSIX_FILE 1
 #define GPR_POSIX_STRING 1
 #define GPR_POSIX_SYNC 1


### PR DESCRIPTION
Let's include <features.h> to figure out if the system we're on is supporting secure_getenv, and adapt accordingly.
I suspect we might want to do the same with epoll, as it was added to glibc in 2.3.2, and eventfd has been added to glibc in 2.8.

Attempted fix for #498.
