### PR TITLE
Cleaning up our posix definition / usage.

### DIFF
--- a/include/grpc/support/port_platform.h
+++ b/include/grpc/support/port_platform.h
@@ -37,10 +37,6 @@
 /* Override this file with one for your platform if you need to redefine
    things.  */
 
-/* For a common case, assume that the platform has a C99-like stdint.h */
-
-#include <stdint.h>
-
 #if !defined(GPR_NO_AUTODETECT_PLATFORM)
 #if defined(_WIN64) || defined(WIN64)
 #define GPR_WIN32 1
@@ -70,19 +66,39 @@
 #define GPR_POSIX_TIME 1
 #define GPR_GETPID_IN_UNISTD_H 1
 #elif defined(__linux__)
+#ifndef _BSD_SOURCE
+#define _BSD_SOURCE
+#endif
+#ifndef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#endif
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 #include <features.h>
 #define GPR_CPU_LINUX 1
 #define GPR_GCC_ATOMIC 1
 #define GPR_LINUX 1
 #define GPR_LINUX_MULTIPOLL_WITH_EPOLL 1
 #define GPR_POSIX_WAKEUP_FD 1
-#define GPR_LINUX_EVENTFD 1
 #define GPR_POSIX_SOCKET 1
 #define GPR_POSIX_SOCKETADDR 1
 #ifdef __GLIBC_PREREQ
+#if __GLIBC_PREREQ(2, 9)
+#define GPR_LINUX_EVENTFD 1
+#endif
+#if __GLIBC_PREREQ(2, 10)
+#define GPR_LINUX_SOCKETUTILS 1
+#endif
 #if __GLIBC_PREREQ(2, 17)
 #define GPR_LINUX_ENV 1
 #endif
+#endif
+#ifndef GPR_LINUX_EVENTFD
+#define GPR_POSIX_NO_SPECIAL_WAKEUP_FD 1
+#endif
+#ifndef GPR_LINUX_SOCKETUTILS
+#define GPR_POSIX_SOCKETUTILS
 #endif
 #ifndef GPR_LINUX_ENV
 #define GPR_POSIX_ENV 1
@@ -98,6 +114,9 @@
 #define GPR_ARCH_32 1
 #endif /* _LP64 */
 #elif defined(__APPLE__)
+#ifndef _BSD_SOURCE
+#define _BSD_SOURCE
+#endif
 #define GPR_CPU_POSIX 1
 #define GPR_GCC_ATOMIC 1
 #define GPR_POSIX_LOG 1
@@ -122,6 +141,10 @@
 #error Could not auto-detect platform
 #endif
 #endif /* GPR_NO_AUTODETECT_PLATFORM */
+
+/* For a common case, assume that the platform has a C99-like stdint.h */
+
+#include <stdint.h>
 
 /* Cache line alignment */
 #ifndef GPR_CACHELINE_SIZE

--- a/src/core/iomgr/socket_utils_linux.c
+++ b/src/core/iomgr/socket_utils_linux.c
@@ -31,12 +31,9 @@
  *
  */
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
 #include <grpc/support/port_platform.h>
 
-#ifdef GPR_LINUX
+#ifdef GPR_LINUX_SOCKETUTILS
 
 #include "src/core/iomgr/socket_utils_posix.h"
 

--- a/src/core/support/file_posix.c
+++ b/src/core/support/file_posix.c
@@ -31,19 +31,6 @@
  *
  */
 
-/* Posix code for gpr fdopen and mkstemp support. */
-
-#if !defined _POSIX_C_SOURCE || _POSIX_C_SOURCE < 200112L
-#undef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200112L
-#endif
-
-/* Don't know why I have to do this for mkstemp, looks like _POSIX_C_SOURCE
-   should be enough... */
-#ifndef _BSD_SOURCE
-#define _BSD_SOURCE
-#endif
-
 #include <grpc/support/port_platform.h>
 
 #ifdef GPR_POSIX_FILE

--- a/src/core/support/log_posix.c
+++ b/src/core/support/log_posix.c
@@ -31,16 +31,6 @@
  *
  */
 
-#if !defined _POSIX_C_SOURCE || _POSIX_C_SOURCE < 200112L
-#undef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200112L
-#endif
-
-/* FIXME: "posix" files probably shouldn't depend on _GNU_SOURCE */
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-
 #include <grpc/support/port_platform.h>
 
 #if defined(GPR_POSIX_LOG)

--- a/src/core/support/string_posix.c
+++ b/src/core/support/string_posix.c
@@ -31,13 +31,6 @@
  *
  */
 
-/* Posix code for gpr snprintf support. */
-
-#if !defined _POSIX_C_SOURCE || _POSIX_C_SOURCE < 200112L
-#undef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200112L
-#endif
-
 #include <grpc/support/port_platform.h>
 
 #ifdef GPR_POSIX_STRING

--- a/src/core/support/sync_posix.c
+++ b/src/core/support/sync_posix.c
@@ -31,13 +31,6 @@
  *
  */
 
-/* Posix gpr synchroization support code. */
-
-#if !defined _POSIX_C_SOURCE || _POSIX_C_SOURCE < 199309L
-#undef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 199309L
-#endif
-
 #include <grpc/support/port_platform.h>
 
 #ifdef GPR_POSIX_SYNC

--- a/src/core/support/time_posix.c
+++ b/src/core/support/time_posix.c
@@ -31,14 +31,6 @@
  *
  */
 
-/* Posix code for gpr time support. */
-
-/* So we get nanosleep and clock_* */
-#if !defined _POSIX_C_SOURCE || _POSIX_C_SOURCE < 199309L
-#undef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 199309L
-#endif
-
 #include <grpc/support/port_platform.h>
 
 #ifdef GPR_POSIX_TIME


### PR DESCRIPTION
-) Let's not use _POSIX_SOURCE. It usually implies too much C99. _BSD_SOURCE would be the right thing to do here.
-) _BSD_SOURCE is getting deprecated by glibc, so we also have to define _DEFAULT_SOURCE under Linux.
-) accept4 and eventfd arn't as old as we may think; let's detect for it.
-) stdint.h interferes with all these definitions if included too early; let's move it down.
