### PR TITLE
Fix fling test leaks

### DIFF
--- a/src/core/channel/connected_channel.c
+++ b/src/core/channel/connected_channel.c
@@ -467,16 +467,10 @@ static void transport_goaway(void *user_data, grpc_transport *transport,
   /* transport got goaway ==> call up and handle it */
   grpc_channel_element *elem = user_data;
   channel_data *chand = elem->channel_data;
-  char *msg;
   grpc_channel_op op;
 
   GPR_ASSERT(elem->filter == &grpc_connected_channel_filter);
   GPR_ASSERT(chand->transport == transport);
-
-  msg = gpr_hexdump((const char *)GPR_SLICE_START_PTR(debug),
-                    GPR_SLICE_LENGTH(debug), GPR_HEXDUMP_PLAINTEXT);
-  gpr_log(GPR_DEBUG, "got goaway: status=%d, message=%s", status, msg);
-  gpr_free(msg);
 
   op.type = GRPC_TRANSPORT_GOAWAY;
   op.dir = GRPC_CALL_UP;

--- a/test/core/fling/client.c
+++ b/test/core/fling/client.c
@@ -55,7 +55,6 @@ static grpc_op stream_step_ops[2];
 static grpc_metadata_array initial_metadata_recv;
 static grpc_metadata_array trailing_metadata_recv;
 static grpc_byte_buffer *response_payload_recv = NULL;
-static grpc_call_details call_details;
 static grpc_status_code status;
 static char *details = NULL;
 static size_t details_capacity = 0;
@@ -64,7 +63,6 @@ static grpc_op *op;
 static void init_ping_pong_request(void) {
   grpc_metadata_array_init(&initial_metadata_recv);
   grpc_metadata_array_init(&trailing_metadata_recv);
-  grpc_call_details_init(&call_details);
 
   op = ops;
 
@@ -97,6 +95,7 @@ static void step_ping_pong_request(void) {
              grpc_call_start_batch(call, ops, op - ops, (void *)1));
   grpc_event_finish(grpc_completion_queue_next(cq, gpr_inf_future));
   grpc_call_destroy(call);
+  grpc_byte_buffer_destroy(response_payload_recv);
   call = NULL;
 }
 
@@ -121,6 +120,7 @@ static void step_ping_pong_stream(void) {
   GPR_ASSERT(GRPC_CALL_OK ==
              grpc_call_start_batch(call, stream_step_ops, 2, (void *)1));
   grpc_event_finish(grpc_completion_queue_next(cq, gpr_inf_future));
+  grpc_byte_buffer_destroy(response_payload_recv);
 }
 
 static double now(void) {

--- a/test/core/transport/metadata_test.c
+++ b/test/core/transport/metadata_test.c
@@ -44,7 +44,7 @@
 #define LOG_TEST() gpr_log(GPR_INFO, "%s", __FUNCTION__)
 
 /* a large number */
-#define MANY 1000000
+#define MANY 100000
 
 static void test_no_op(void) {
   grpc_mdctx *ctx;


### PR DESCRIPTION
This also removes some debug spam, and speeds up a unit test (they were accidentally picked up, but seem worthwhile)
