### PR TITLE
Fix memory leak.

### DIFF
--- a/src/core/security/security_context.c
+++ b/src/core/security/security_context.c
@@ -353,6 +353,7 @@ static grpc_security_status ssl_channel_check_peer(grpc_security_context *ctx,
                                                    ? c->overridden_target_name
                                                    : c->target_name,
                                                &peer);
+  tsi_peer_destruct(&c->peer);
   c->peer = peer;
   return status;
 }


### PR DESCRIPTION
This code path can be taken twice, and blindly copying over the peer the
second time causes objects owned by the first to be lost.

Fixes #542 
