### PR TITLE
Fixed string.h include

### DIFF
--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -31,12 +31,13 @@
  *
  */
 
+#include "src/core/support/string.h"
+
 #include <grpc/support/port_platform.h>
 #include <grpc/support/alloc.h>
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/slice.h>
-#include <grpc/support/string.h>
 
 #include <string.h>
 


### PR DESCRIPTION
support/string.h is no longer a public header.
