### PR TITLE
Running ldconfig shouldn't fail; so we can run fakeroot make install properly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1986,7 +1986,7 @@ endif
 endif
 ifneq ($(SYSTEM),MINGW32)
 ifneq ($(SYSTEM),Darwin)
-	$(Q) ldconfig
+	$(Q) ldconfig || true
 endif
 endif
 
@@ -2005,7 +2005,7 @@ endif
 endif
 ifneq ($(SYSTEM),MINGW32)
 ifneq ($(SYSTEM),Darwin)
-	$(Q) ldconfig
+	$(Q) ldconfig || true
 endif
 endif
 
@@ -2024,7 +2024,7 @@ endif
 endif
 ifneq ($(SYSTEM),MINGW32)
 ifneq ($(SYSTEM),Darwin)
-	$(Q) ldconfig
+	$(Q) ldconfig || true
 endif
 endif
 
@@ -2035,7 +2035,7 @@ ifneq ($(PROTOBUF_DEP),)
 	$(Q) $(MAKE) -C third_party/protobuf install prefix=$(prefix)
 ifneq ($(SYSTEM),MINGW32)
 ifneq ($(SYSTEM),Darwin)
-	$(Q) ldconfig
+	$(Q) ldconfig || true
 endif
 endif
 endif

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -780,7 +780,7 @@ endif
 % endfor
 ifneq ($(SYSTEM),MINGW32)
 ifneq ($(SYSTEM),Darwin)
-	$(Q) ldconfig
+	$(Q) ldconfig || true
 endif
 endif
 </%def>
@@ -800,7 +800,7 @@ ifneq ($(PROTOBUF_DEP),)
 	$(Q) $(MAKE) -C third_party/protobuf install prefix=$(prefix)
 ifneq ($(SYSTEM),MINGW32)
 ifneq ($(SYSTEM),Darwin)
-	$(Q) ldconfig
+	$(Q) ldconfig || true
 endif
 endif
 endif


### PR DESCRIPTION
Creating a Debian or RPM package relies on being able to run make install without being root. Currently, the Makefile tries to run ldconfig (with reasons) after installing libraries, but will force the makefile to stop if it failed as you're not running make install as root.
