### PR TITLE
Making the usage of gflags uniform across distributions.

### DIFF
--- a/examples/pubsub/main.cc
+++ b/examples/pubsub/main.cc
@@ -60,6 +60,13 @@ DEFINE_string(oauth_scope,
               "https://www.googleapis.com/auth/cloud-platform",
               "Scope for OAuth tokens.");
 
+// In some distros, gflags is in the namespace google, and in some others,
+// in gflags. This hack is enabling us to find both.
+namespace google { }
+namespace gflags { }
+using namespace google;
+using namespace gflags;
+
 namespace {
 
 const char kTopic[] = "testtopics";
@@ -81,7 +88,7 @@ grpc::string GetServiceAccountJsonKey() {
 
 int main(int argc, char** argv) {
   grpc_init();
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  ParseCommandLineFlags(&argc, &argv, true);
   gpr_log(GPR_INFO, "Start PUBSUB client");
 
   std::ostringstream ss;

--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -92,6 +92,13 @@ using grpc::testing::StreamingOutputCallRequest;
 using grpc::testing::StreamingOutputCallResponse;
 using grpc::testing::TestService;
 
+// In some distros, gflags is in the namespace google, and in some others,
+// in gflags. This hack is enabling us to find both.
+namespace google { }
+namespace gflags { }
+using namespace google;
+using namespace gflags;
+
 namespace {
 // The same value is defined by the Java client.
 const std::vector<int> request_stream_sizes = {27182, 8, 1828, 45904};
@@ -386,7 +393,7 @@ void DoPingPong() {
 int main(int argc, char** argv) {
   grpc_init();
 
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  ParseCommandLineFlags(&argc, &argv, true);
 
   if (FLAGS_test_case == "empty_unary") {
     DoEmpty();

--- a/test/cpp/interop/server.cc
+++ b/test/cpp/interop/server.cc
@@ -73,6 +73,13 @@ using grpc::testing::StreamingOutputCallResponse;
 using grpc::testing::TestService;
 using grpc::Status;
 
+// In some distros, gflags is in the namespace google, and in some others,
+// in gflags. This hack is enabling us to find both.
+namespace google { }
+namespace gflags { }
+using namespace google;
+using namespace gflags;
+
 bool SetPayload(PayloadType type, int size, Payload* payload) {
   PayloadType response_type = type;
   // TODO(yangg): Support UNCOMPRESSABLE payload.
@@ -217,7 +224,7 @@ void RunServer() {
 
 int main(int argc, char** argv) {
   grpc_init();
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  ParseCommandLineFlags(&argc, &argv, true);
 
   GPR_ASSERT(FLAGS_port != 0);
   RunServer();

--- a/test/cpp/qps/client.cc
+++ b/test/cpp/qps/client.cc
@@ -80,6 +80,13 @@ using grpc::testing::SimpleResponse;
 using grpc::testing::StatsRequest;
 using grpc::testing::TestService;
 
+// In some distros, gflags is in the namespace google, and in some others,
+// in gflags. This hack is enabling us to find both.
+namespace google { }
+namespace gflags { }
+using namespace google;
+using namespace gflags;
+
 static double now() {
   gpr_timespec tv = gpr_now();
   return 1e9 * tv.tv_sec + tv.tv_nsec;
@@ -221,7 +228,7 @@ void RunTest(const int client_threads, const int client_channels,
 
 int main(int argc, char **argv) {
   grpc_init();
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  ParseCommandLineFlags(&argc, &argv, true);
 
   GPR_ASSERT(FLAGS_server_port);
 

--- a/test/cpp/qps/server.cc
+++ b/test/cpp/qps/server.cc
@@ -68,6 +68,13 @@ using grpc::testing::StatsRequest;
 using grpc::testing::TestService;
 using grpc::Status;
 
+// In some distros, gflags is in the namespace google, and in some others,
+// in gflags. This hack is enabling us to find both.
+namespace google { }
+namespace gflags { }
+using namespace google;
+using namespace gflags;
+
 static bool got_sigint = false;
 
 static void sigint_handler(int x) { got_sigint = 1; }
@@ -149,7 +156,7 @@ static void RunServer() {
 
 int main(int argc, char** argv) {
   grpc_init();
-  google::ParseCommandLineFlags(&argc, &argv, true);
+  ParseCommandLineFlags(&argc, &argv, true);
 
   signal(SIGINT, sigint_handler);
 


### PR DESCRIPTION
.deb-based distributions are renaming the gflags namespace to google, whereas .rpm-based distributions kept the default namespace set to gflags.
