### PR TITLE
Clean up Python C API use in src/python/src/grpc/_adapter/*.c.

### DIFF
--- a/src/python/src/grpc/_adapter/_c.c
+++ b/src/python/src/grpc/_adapter/_c.c
@@ -40,19 +40,20 @@
 #include "grpc/_adapter/_server.h"
 #include "grpc/_adapter/_server_credentials.h"
 
-static PyObject *init(PyObject *self, PyObject *args) {
+static PyObject *init(PyObject *self) {
   grpc_init();
   Py_RETURN_NONE;
 }
 
-static PyObject *shutdown(PyObject *self, PyObject *args) {
+static PyObject *shutdown(PyObject *self) {
   grpc_shutdown();
   Py_RETURN_NONE;
 }
 
 static PyMethodDef _c_methods[] = {
-    {"init", init, METH_VARARGS, "Initialize the module's static state."},
-    {"shut_down", shutdown, METH_VARARGS,
+    {"init", (PyCFunction)init, METH_NOARGS,
+     "Initialize the module's static state."},
+    {"shut_down", (PyCFunction)shutdown, METH_NOARGS,
      "Shut down the module's static state."},
     {NULL},
 };

--- a/src/python/src/grpc/_adapter/_channel.c
+++ b/src/python/src/grpc/_adapter/_channel.c
@@ -38,9 +38,10 @@
 
 static int pygrpc_channel_init(Channel *self, PyObject *args, PyObject *kwds) {
   const char *hostport;
+  static char *kwlist[] = {"hostport", NULL};
 
-  if (!(PyArg_ParseTuple(args, "s", &hostport))) {
-    self->c_channel = NULL;
+  if (!(PyArg_ParseTupleAndKeywords(args, kwds, "s:Channel", kwlist,
+                                    &hostport))) {
     return -1;
   }
 
@@ -56,7 +57,7 @@ static void pygrpc_channel_dealloc(Channel *self) {
 }
 
 PyTypeObject pygrpc_ChannelType = {
-    PyObject_HEAD_INIT(NULL)0,          /*ob_size*/
+    PyVarObject_HEAD_INIT(NULL, 0)
     "_grpc.Channel",                    /*tp_name*/
     sizeof(Channel),                    /*tp_basicsize*/
     0,                                  /*tp_itemsize*/
@@ -92,17 +93,16 @@ PyTypeObject pygrpc_ChannelType = {
     0,                                  /* tp_descr_set */
     0,                                  /* tp_dictoffset */
     (initproc)pygrpc_channel_init,      /* tp_init */
+    0,                                  /* tp_alloc */
+    PyType_GenericNew,                  /* tp_new */
 };
 
 int pygrpc_add_channel(PyObject *module) {
-  pygrpc_ChannelType.tp_new = PyType_GenericNew;
   if (PyType_Ready(&pygrpc_ChannelType) < 0) {
-    PyErr_SetString(PyExc_RuntimeError, "Error defining pygrpc_ChannelType!");
     return -1;
   }
   if (PyModule_AddObject(module, "Channel", (PyObject *)&pygrpc_ChannelType) ==
       -1) {
-    PyErr_SetString(PyExc_ImportError, "Couldn't add Channel type to module!");
     return -1;
   }
   return 0;

--- a/src/python/src/grpc/_adapter/_server.c
+++ b/src/python/src/grpc/_adapter/_server.c
@@ -43,9 +43,11 @@
 static int pygrpc_server_init(Server *self, PyObject *args, PyObject *kwds) {
   const PyObject *completion_queue;
   PyObject *server_credentials;
-  if (!(PyArg_ParseTuple(args, "O!O", &pygrpc_CompletionQueueType,
-                         &completion_queue, &server_credentials))) {
-    self->c_server = NULL;
+  static char *kwlist[] = {"completion_queue", "server_credentials", NULL};
+
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!O:Server", kwlist,
+                                   &pygrpc_CompletionQueueType,
+                                   &completion_queue, &server_credentials)) {
     return -1;
   }
   if (server_credentials == Py_None) {
@@ -59,7 +61,9 @@ static int pygrpc_server_init(Server *self, PyObject *args, PyObject *kwds) {
         ((CompletionQueue *)completion_queue)->c_completion_queue, NULL);
     return 0;
   } else {
-    self->c_server = NULL;
+    PyErr_Format(PyExc_TypeError,
+                 "server_credentials must be _grpc.ServerCredentials, not %s",
+                 Py_TYPE(server_credentials)->tp_name);
     return -1;
   }
 }
@@ -74,7 +78,9 @@ static void pygrpc_server_dealloc(Server *self) {
 static PyObject *pygrpc_server_add_http2_addr(Server *self, PyObject *args) {
   const char *addr;
   int port;
-  PyArg_ParseTuple(args, "s", &addr);
+  if (!PyArg_ParseTuple(args, "s:add_http2_addr", &addr)) {
+    return NULL;
+  }
 
   port = grpc_server_add_http2_port(self->c_server, addr);
   if (port == 0) {
@@ -89,7 +95,9 @@ static PyObject *pygrpc_server_add_secure_http2_addr(Server *self,
                                                      PyObject *args) {
   const char *addr;
   int port;
-  PyArg_ParseTuple(args, "s", &addr);
+  if (!PyArg_ParseTuple(args, "s:add_secure_http2_addr", &addr)) {
+    return NULL;
+  }
   port = grpc_server_add_secure_http2_port(self->c_server, addr);
   if (port == 0) {
     PyErr_SetString(PyExc_RuntimeError, "Couldn't add port to server!");
@@ -104,14 +112,9 @@ static PyObject *pygrpc_server_start(Server *self) {
   Py_RETURN_NONE;
 }
 
-static const PyObject *pygrpc_server_service(Server *self, PyObject *args) {
-  const PyObject *tag;
+static const PyObject *pygrpc_server_service(Server *self, PyObject *tag) {
   grpc_call_error call_error;
   const PyObject *result;
-
-  if (!(PyArg_ParseTuple(args, "O", &tag))) {
-    return NULL;
-  }
 
   call_error = grpc_server_request_call_old(self->c_server, (void *)tag);
 
@@ -135,13 +138,13 @@ static PyMethodDef methods[] = {
      METH_VARARGS, "Add a secure HTTP2 address."},
     {"start", (PyCFunction)pygrpc_server_start, METH_NOARGS,
      "Starts the server."},
-    {"service", (PyCFunction)pygrpc_server_service, METH_VARARGS,
+    {"service", (PyCFunction)pygrpc_server_service, METH_O,
      "Services a call."},
     {"stop", (PyCFunction)pygrpc_server_stop, METH_NOARGS, "Stops the server."},
     {NULL}};
 
 static PyTypeObject pygrpc_ServerType = {
-    PyObject_HEAD_INIT(NULL)0,         /*ob_size*/
+    PyVarObject_HEAD_INIT(NULL, 0)
     "_gprc.Server",                    /*tp_name*/
     sizeof(Server),                    /*tp_basicsize*/
     0,                                 /*tp_itemsize*/
@@ -177,17 +180,16 @@ static PyTypeObject pygrpc_ServerType = {
     0,                                 /* tp_descr_set */
     0,                                 /* tp_dictoffset */
     (initproc)pygrpc_server_init,      /* tp_init */
+    0,                                 /* tp_alloc */
+    PyType_GenericNew,                 /* tp_new */
 };
 
 int pygrpc_add_server(PyObject *module) {
-  pygrpc_ServerType.tp_new = PyType_GenericNew;
   if (PyType_Ready(&pygrpc_ServerType) < 0) {
-    PyErr_SetString(PyExc_RuntimeError, "Error defining pygrpc_ServerType!");
     return -1;
   }
   if (PyModule_AddObject(module, "Server", (PyObject *)&pygrpc_ServerType) ==
       -1) {
-    PyErr_SetString(PyExc_ImportError, "Couldn't add Server type to module!");
     return -1;
   }
   return 0;


### PR DESCRIPTION
Specifically:
- Use METH_O and METH_NOARGS where appropriate, modifying the C functions
  appropriately.  METH_O is for functions that take a single PyObject, and
  it's passed directly instead of 'args'.  METH_NOARGS is for functions
  that take no arguments, and they get called with just one argument
  ('self'.)
- In PyArg_ParseTuple*() calls, specify the callable's name for more
  descriptive exception messages.
- For tp_init functions (which always take keyword arguments) introduce
  keyword argument parsing (using the C local variables as keywords,
  although I don't know if they're the best names to use.) This is mostly
  as a way to show how keyword arguments are done in C.  An alternative
  method is to use _PyArg_NoKeywords(kwds) (see
  https://hg.python.org/cpython/file/70a55b2dee71/Python/getargs.c#l1820,
  but unfortunately it's not part of the official API,) or check manually
  that the dict is empty.
- Check the return value of Python API functions that can return an error
  indicator (NULL or -1.) PyFloat_AsDouble is also one of these, but we
  don't check the return type (we would have to compare the result to 1.0
  with ==, which is not a thing you should do) so just call PyErr_Occurred
  unconditionally.
- Change Py_BuildValue() calls with just "O" formats into PyTuple_Pack
  calls.  It requires less runtime checking.
- Replace Py_BuildValue()/PyObject_CallObject pairs with
  PyObject_CallFunctionObjArgs (since all of them have just PyObject*
  arguments.) If the Py_BuildValue formats had included other types,
  PyObject_CallFunction() would have been easier, but no need in these
  cases.
- Replace Py_BuildValue("f", ...) with PyFloat_FromDouble(...). Less
  runtime checking and parsing necessary, and more obvious in what it does.
- In the PyType structs, replace "PyObject_HEAD_INIT(NULL) 0" with
  "PyVarObject_HEAD_INIT(NULL, 0)".  Anything with an ob_size struct member
  is a PyVarObject, although the distinction isn't all that import; it's
  just a more convenient macro.
- Assign tp_new in the PyType structs directly, like all other struct
  members, rather than right before the PyType_Ready() call.
- Remove PyErr_SetString() calls in places that already have a (meaningful)
  exception set.
- Add a PyErr_Format() for an error return that wasn't setting an exception
  (PyObject_TypeCheck() doesn't set an exception.)
- Remove NULL assignments to struct members in the error paths of the
  tp_init functions.  PyObject structs are always zeroed after allocation,
  guaranteed.  (If there's a way for them to already contain an object
  you'd use Py_CLEAR() to clear them, but that can't happen in these
  cases.)
- Remove a few unnecessary parentheses.

(This is a redo of https://github.com/grpc/grpc/pull/626 without the merge artifacts.)
