### PR TITLE
Make interop server respond to sigint

### DIFF
--- a/test/cpp/interop/server.cc
+++ b/test/cpp/interop/server.cc
@@ -35,6 +35,8 @@
 #include <sstream>
 #include <thread>
 
+#include <signal.h>
+
 #include <gflags/gflags.h>
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
@@ -79,6 +81,8 @@ namespace google { }
 namespace gflags { }
 using namespace google;
 using namespace gflags;
+
+static bool got_sigint = false;
 
 bool SetPayload(PayloadType type, int size, Payload* payload) {
   PayloadType response_type = type;
@@ -217,14 +221,17 @@ void RunServer() {
   }
   std::unique_ptr<Server> server(builder.BuildAndStart());
   gpr_log(GPR_INFO, "Server listening on %s", server_address.str().c_str());
-  while (true) {
+  while (!got_sigint) {
     std::this_thread::sleep_for(std::chrono::seconds(5));
   }
 }
 
+static void sigint_handler(int x) { got_sigint = true; }
+
 int main(int argc, char** argv) {
   grpc_init();
   ParseCommandLineFlags(&argc, &argv, true);
+  signal(SIGINT, sigint_handler);
 
   GPR_ASSERT(FLAGS_port != 0);
   RunServer();


### PR DESCRIPTION
This will allow the test to shut down cleanly, and avoid failing.
