### PR TITLE
Addressing security concerns.

### DIFF
--- a/src/core/json/json.c
+++ b/src/core/json/json.c
@@ -38,8 +38,8 @@
 #include "src/core/json/json.h"
 
 grpc_json *grpc_json_create(grpc_json_type type) {
-  grpc_json *json = gpr_malloc(sizeof(grpc_json));
-  memset(json, 0, sizeof(grpc_json));
+  grpc_json *json = gpr_malloc(sizeof(*json));
+  memset(json, 0, sizeof(*json));
   json->type = type;
 
   return json;

--- a/src/core/json/json_reader.c
+++ b/src/core/json/json_reader.c
@@ -93,7 +93,7 @@ static void json_reader_set_null(grpc_json_reader* reader) {
 /* Call this function to initialize the reader structure. */
 void grpc_json_reader_init(grpc_json_reader* reader,
                            grpc_json_reader_vtable* vtable, void* userdata) {
-  memset(reader, 0, sizeof(grpc_json_reader));
+  memset(reader, 0, sizeof(*reader));
   reader->vtable = vtable;
   reader->userdata = userdata;
   json_reader_string_clear(reader);

--- a/src/core/json/json_writer.c
+++ b/src/core/json/json_writer.c
@@ -51,7 +51,7 @@ static void json_writer_output_string_with_len(grpc_json_writer* writer, const c
 
 void grpc_json_writer_init(grpc_json_writer* writer, int indent,
                            grpc_json_writer_vtable* vtable, void* userdata) {
-  memset(writer, 0, sizeof(grpc_json_writer));
+  memset(writer, 0, sizeof(*writer));
   writer->container_empty = 1;
   writer->indent = indent;
   writer->vtable = vtable;
@@ -77,7 +77,7 @@ static void json_writer_output_indent(
 
   while (spaces >= (sizeof(spacesstr) - 1)) {
     json_writer_output_string_with_len(writer, spacesstr,
-                                            sizeof(spacesstr) - 1);
+                                       sizeof(spacesstr) - 1);
     spaces -= (sizeof(spacesstr) - 1);
   }
 
@@ -117,10 +117,10 @@ static void json_writer_escape_string(grpc_json_writer* writer,
     gpr_uint8 c = (gpr_uint8)*string++;
     if (c == 0) {
       break;
-    } else if ((c >= 32) && (c <= 127)) {
+    } else if ((c >= 32) && (c <= 126)) {
       if ((c == '\\') || (c == '"')) json_writer_output_char(writer, '\\');
       json_writer_output_char(writer, c);
-    } else if (c < 32) {
+    } else if ((c < 32) || (c == 127)) {
       switch (c) {
         case '\b':
           json_writer_output_string_with_len(writer, "\\b", 2);
@@ -161,6 +161,7 @@ static void json_writer_escape_string(grpc_json_writer* writer,
       for (i = 0; i < extra; i++) {
         utf32 <<= 6;
         c = *string++;
+        /* Breaks out and bail on any invalid UTF-8 sequence, including \0. */
         if ((c & 0xc0) != 0x80) {
           valid = 0;
           break;

--- a/test/core/json/json_test.c
+++ b/test/core/json/json_test.c
@@ -65,7 +65,7 @@ static testing_pair testing_pairs[] = {
   /* Testing nested empty containers. */
   { " [ [ ] , { } , [ ] ] ", "[[],{},[]]", },
   /* Testing escapes and control chars in key strings. */
-  { " { \"\\n\\\\a , b\": 1, \"\": 0 } ", "{\"\\n\\\\a , b\":1,\"\":0}" },
+  { " { \"\x7f\\n\\\\a , b\": 1, \"\": 0 } ", "{\"\\u007f\\n\\\\a , b\":1,\"\":0}" },
   /* Testing the writer's ability to cut off invalid UTF-8 sequences. */
   { "\"abc\xf0\x9d\x24\"", "\"abc\"" },
   { "\"\xff\"", "\"\"" },


### PR DESCRIPTION
-) 0x7f (Backspace) isn't a printable character.
-) use sizeof(var) instead of sizeof(type).
