### PR TITLE
Using HTTP2 compliant cipher suites by default.

### DIFF
--- a/src/core/security/security_context.c
+++ b/src/core/security/security_context.c
@@ -62,9 +62,9 @@ static const char *installed_roots_path = INSTALL_PREFIX "/share/grpc/roots.pem"
 
 /* Defines the cipher suites that we accept by default. All these cipher suites
    are compliant with HTTP2. */
-#define GRPC_SSL_CIPHER_SUITES                                                 \
-  "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:AES128-GCM-SHA256:" \
-  "AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384"
+#define GRPC_SSL_CIPHER_SUITES                                            \
+  "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-" \
+  "SHA384:ECDHE-RSA-AES256-GCM-SHA384"
 
 static gpr_once cipher_suites_once = GPR_ONCE_INIT;
 static const char *cipher_suites = NULL;


### PR DESCRIPTION
- Added a way to override the cipher suites with an environment
  variable so that we can still do interop testing with java7.
- Takes care of #681.
