### PR TITLE
Introduce slowdown factor for unit test deadlines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ LDXX_valgrind = g++
 CPPFLAGS_valgrind = -O0
 OPENSSL_CFLAGS_valgrind = -DPURIFY
 LDFLAGS_valgrind =
-DEFINES_valgrind = _DEBUG DEBUG
+DEFINES_valgrind = _DEBUG DEBUG GRPC_TEST_SLOWDOWN_FACTOR=20
 
 VALID_CONFIG_tsan = 1
 REQUIRE_CUSTOM_LIBRARIES_tsan = 1
@@ -87,7 +87,7 @@ LD_tsan = clang
 LDXX_tsan = clang++
 CPPFLAGS_tsan = -O1 -fsanitize=thread -fno-omit-frame-pointer
 LDFLAGS_tsan = -fsanitize=thread
-DEFINES_tsan = NDEBUG
+DEFINES_tsan = NDEBUG GRPC_TEST_SLOWDOWN_FACTOR=10
 
 VALID_CONFIG_asan = 1
 REQUIRE_CUSTOM_LIBRARIES_asan = 1
@@ -97,7 +97,7 @@ LD_asan = clang
 LDXX_asan = clang++
 CPPFLAGS_asan = -O1 -fsanitize=address -fno-omit-frame-pointer
 LDFLAGS_asan = -fsanitize=address
-DEFINES_asan = NDEBUG
+DEFINES_asan = NDEBUG GRPC_TEST_SLOWDOWN_FACTOR=5
 
 VALID_CONFIG_msan = 1
 REQUIRE_CUSTOM_LIBRARIES_msan = 1
@@ -108,7 +108,7 @@ LDXX_msan = clang++-libc++
 CPPFLAGS_msan = -O1 -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer -DGTEST_HAS_TR1_TUPLE=0 -DGTEST_USE_OWN_TR1_TUPLE=1
 OPENSSL_CFLAGS_msan = -DPURIFY
 LDFLAGS_msan = -fsanitize=memory -DGTEST_HAS_TR1_TUPLE=0 -DGTEST_USE_OWN_TR1_TUPLE=1
-DEFINES_msan = NDEBUG
+DEFINES_msan = NDEBUG GRPC_TEST_SLOWDOWN_FACTOR=20
 
 VALID_CONFIG_ubsan = 1
 REQUIRE_CUSTOM_LIBRARIES_ubsan = 1
@@ -119,7 +119,7 @@ LDXX_ubsan = clang++
 CPPFLAGS_ubsan = -O1 -fsanitize=undefined -fno-omit-frame-pointer
 OPENSSL_CFLAGS_ubsan = -DPURIFY
 LDFLAGS_ubsan = -fsanitize=undefined
-DEFINES_ubsan = NDEBUG
+DEFINES_ubsan = NDEBUG GRPC_TEST_SLOWDOWN_FACTOR=10
 
 VALID_CONFIG_gcov = 1
 CC_gcov = gcc

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -94,7 +94,7 @@ LDXX_valgrind = g++
 CPPFLAGS_valgrind = -O0
 OPENSSL_CFLAGS_valgrind = -DPURIFY
 LDFLAGS_valgrind =
-DEFINES_valgrind = _DEBUG DEBUG
+DEFINES_valgrind = _DEBUG DEBUG GRPC_TEST_SLOWDOWN_FACTOR=20
 
 VALID_CONFIG_tsan = 1
 REQUIRE_CUSTOM_LIBRARIES_tsan = 1
@@ -104,7 +104,7 @@ LD_tsan = clang
 LDXX_tsan = clang++
 CPPFLAGS_tsan = -O1 -fsanitize=thread -fno-omit-frame-pointer
 LDFLAGS_tsan = -fsanitize=thread
-DEFINES_tsan = NDEBUG
+DEFINES_tsan = NDEBUG GRPC_TEST_SLOWDOWN_FACTOR=10
 
 VALID_CONFIG_asan = 1
 REQUIRE_CUSTOM_LIBRARIES_asan = 1
@@ -114,7 +114,7 @@ LD_asan = clang
 LDXX_asan = clang++
 CPPFLAGS_asan = -O1 -fsanitize=address -fno-omit-frame-pointer
 LDFLAGS_asan = -fsanitize=address
-DEFINES_asan = NDEBUG
+DEFINES_asan = NDEBUG GRPC_TEST_SLOWDOWN_FACTOR=5
 
 VALID_CONFIG_msan = 1
 REQUIRE_CUSTOM_LIBRARIES_msan = 1
@@ -125,7 +125,7 @@ LDXX_msan = clang++-libc++
 CPPFLAGS_msan = -O1 -fsanitize=memory -fsanitize-memory-track-origins -fno-omit-frame-pointer -DGTEST_HAS_TR1_TUPLE=0 -DGTEST_USE_OWN_TR1_TUPLE=1
 OPENSSL_CFLAGS_msan = -DPURIFY
 LDFLAGS_msan = -fsanitize=memory -DGTEST_HAS_TR1_TUPLE=0 -DGTEST_USE_OWN_TR1_TUPLE=1
-DEFINES_msan = NDEBUG
+DEFINES_msan = NDEBUG GRPC_TEST_SLOWDOWN_FACTOR=20
 
 VALID_CONFIG_ubsan = 1
 REQUIRE_CUSTOM_LIBRARIES_ubsan = 1
@@ -136,7 +136,7 @@ LDXX_ubsan = clang++
 CPPFLAGS_ubsan = -O1 -fsanitize=undefined -fno-omit-frame-pointer
 OPENSSL_CFLAGS_ubsan = -DPURIFY
 LDFLAGS_ubsan = -fsanitize=undefined
-DEFINES_ubsan = NDEBUG
+DEFINES_ubsan = NDEBUG GRPC_TEST_SLOWDOWN_FACTOR=10
 
 VALID_CONFIG_gcov = 1
 CC_gcov = gcc

--- a/test/core/channel/channel_stack_test.c
+++ b/test/core/channel/channel_stack_test.c
@@ -77,10 +77,10 @@ static void channel_func(grpc_channel_element *elem,
 }
 
 static void test_create_channel_stack(void) {
-  const grpc_channel_filter
-      filter = {call_func,         channel_func,         sizeof(int),
-                call_init_func,    call_destroy_func,    sizeof(int),
-                channel_init_func, channel_destroy_func, "some_test_filter" };
+  const grpc_channel_filter filter = {
+      call_func,         channel_func,         sizeof(int),
+      call_init_func,    call_destroy_func,    sizeof(int),
+      channel_init_func, channel_destroy_func, "some_test_filter"};
   const grpc_channel_filter *filters = &filter;
   grpc_channel_stack *channel_stack;
   grpc_call_stack *call_stack;

--- a/test/core/channel/metadata_buffer_test.c
+++ b/test/core/channel/metadata_buffer_test.c
@@ -110,14 +110,14 @@ static void init_channel_elem(grpc_channel_element *elem,
 static void destroy_channel_elem(grpc_channel_element *elem) {}
 
 static const grpc_channel_filter top_filter = {
-    fail_call_op,      fail_channel_op,     sizeof(size_t),
-    init_call_elem,    destroy_call_elem,   sizeof(channel_data),
-    init_channel_elem, destroy_channel_elem, "top_filter" };
+    fail_call_op,      fail_channel_op,      sizeof(size_t),
+    init_call_elem,    destroy_call_elem,    sizeof(channel_data),
+    init_channel_elem, destroy_channel_elem, "top_filter"};
 
 static const grpc_channel_filter bottom_filter = {
-    expect_call_op,    fail_channel_op,     sizeof(size_t),
-    init_call_elem,    destroy_call_elem,   sizeof(channel_data),
-    init_channel_elem, destroy_channel_elem, "bottom_filter" };
+    expect_call_op,    fail_channel_op,      sizeof(size_t),
+    init_call_elem,    destroy_call_elem,    sizeof(channel_data),
+    init_channel_elem, destroy_channel_elem, "bottom_filter"};
 
 static const grpc_channel_filter *filters[2] = {&top_filter, &bottom_filter};
 
@@ -149,7 +149,7 @@ static void test_case(size_t key_prefix_len, size_t value_prefix_len,
     op.flags = i;
     op.data.metadata = grpc_mdelem_from_slices(mdctx, key, value);
     op.done_cb = do_nothing;
-    op.user_data = (void *)(gpr_uintptr)i;
+    op.user_data = (void *)(gpr_uintptr) i;
 
     grpc_metadata_buffer_queue(&buffer, &op);
   }

--- a/test/core/echo/client.c
+++ b/test/core/echo/client.c
@@ -78,9 +78,8 @@ int main(int argc, char **argv) {
 
   GPR_ASSERT(argc == 2);
   channel = grpc_channel_create(argv[1], NULL);
-  call = grpc_channel_create_call_old(
-      channel, "/foo", "localhost",
-      gpr_time_add(gpr_time_from_seconds(5), gpr_now()));
+  call = grpc_channel_create_call_old(channel, "/foo", "localhost",
+                                      GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5));
   GPR_ASSERT(grpc_call_invoke_old(call, cq, (void *)1, (void *)1, 0) ==
              GRPC_CALL_OK);
 

--- a/test/core/echo/server.c
+++ b/test/core/echo/server.c
@@ -165,8 +165,7 @@ int main(int argc, char **argv) {
       grpc_completion_queue_shutdown(cq);
       shutdown_started = 1;
     }
-    ev = grpc_completion_queue_next(
-        cq, gpr_time_add(gpr_now(), gpr_time_from_micros(1000000)));
+    ev = grpc_completion_queue_next(cq, GRPC_TIMEOUT_SECONDS_TO_DEADLINE(1));
     if (!ev) continue;
     s = ev->tag;
     switch (ev->type) {

--- a/test/core/echo/server.c
+++ b/test/core/echo/server.c
@@ -165,7 +165,8 @@ int main(int argc, char **argv) {
       grpc_completion_queue_shutdown(cq);
       shutdown_started = 1;
     }
-    ev = grpc_completion_queue_next(cq, GRPC_TIMEOUT_SECONDS_TO_DEADLINE(1));
+    ev = grpc_completion_queue_next(
+        cq, gpr_time_add(gpr_now(), gpr_time_from_seconds(1)));
     if (!ev) continue;
     s = ev->tag;
     switch (ev->type) {

--- a/test/core/end2end/cq_verifier.c
+++ b/test/core/end2end/cq_verifier.c
@@ -371,7 +371,7 @@ void cq_verify(cq_verifier *v) {
 }
 
 void cq_verify_empty(cq_verifier *v) {
-  gpr_timespec deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(3);
+  gpr_timespec deadline = gpr_time_add(gpr_now(), gpr_time_from_seconds(1));
   grpc_event *ev;
 
   GPR_ASSERT(v->expect.next == &v->expect && "expectation queue must be empty");

--- a/test/core/end2end/cq_verifier.c
+++ b/test/core/end2end/cq_verifier.c
@@ -116,7 +116,8 @@ static int has_metadata(const grpc_metadata *md, size_t count, const char *key,
   return 0;
 }
 
-int contains_metadata(grpc_metadata_array *array, const char *key, const char *value) {
+int contains_metadata(grpc_metadata_array *array, const char *key,
+                      const char *value) {
   return has_metadata(array->metadata, array->count, key, value);
 }
 
@@ -327,8 +328,7 @@ static void fail_no_event_received(cq_verifier *v) {
 }
 
 void cq_verify(cq_verifier *v) {
-  gpr_timespec deadline =
-      gpr_time_add(gpr_now(), gpr_time_from_micros(10 * GPR_US_PER_SEC));
+  gpr_timespec deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(10);
   grpc_event *ev;
   expectation *e;
   char *s;
@@ -371,8 +371,7 @@ void cq_verify(cq_verifier *v) {
 }
 
 void cq_verify_empty(cq_verifier *v) {
-  gpr_timespec deadline =
-      gpr_time_add(gpr_now(), gpr_time_from_micros(3000000));
+  gpr_timespec deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(3);
   grpc_event *ev;
 
   GPR_ASSERT(v->expect.next == &v->expect && "expectation queue must be empty");

--- a/test/core/end2end/cq_verifier.h
+++ b/test/core/end2end/cq_verifier.h
@@ -35,6 +35,7 @@
 #define __GRPC_TEST_END2END_CQ_VERIFIER_H__
 
 #include <grpc/grpc.h>
+#include "test/core/util/test_config.h"
 
 /* A cq_verifier can verify that expected events arrive in a timely fashion
    on a single completion queue */

--- a/test/core/end2end/dualstack_socket_test.c
+++ b/test/core/end2end/dualstack_socket_test.c
@@ -45,7 +45,7 @@
 static void *tag(gpr_intptr i) { return (void *)i; }
 
 static gpr_timespec ms_from_now(int ms) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_MS * ms));
+  return GRPC_TIMEOUT_MILLIS_TO_DEADLINE(ms);
 }
 
 static void drain_cq(grpc_completion_queue *cq) {

--- a/test/core/end2end/fixtures/chttp2_fake_security.c
+++ b/test/core/end2end/fixtures/chttp2_fake_security.c
@@ -117,7 +117,8 @@ static grpc_end2end_test_config configs[] = {
      chttp2_create_fixture_secure_fullstack,
      chttp2_init_client_fake_secure_fullstack,
      chttp2_init_server_fake_secure_fullstack,
-     chttp2_tear_down_secure_fullstack}, };
+     chttp2_tear_down_secure_fullstack},
+};
 
 int main(int argc, char **argv) {
   size_t i;

--- a/test/core/end2end/fixtures/chttp2_fullstack.c
+++ b/test/core/end2end/fixtures/chttp2_fullstack.c
@@ -99,7 +99,8 @@ void chttp2_tear_down_fullstack(grpc_end2end_test_fixture *f) {
 static grpc_end2end_test_config configs[] = {
     {"chttp2/fullstack", FEATURE_MASK_SUPPORTS_DELAYED_CONNECTION,
      chttp2_create_fixture_fullstack, chttp2_init_client_fullstack,
-     chttp2_init_server_fullstack, chttp2_tear_down_fullstack}, };
+     chttp2_init_server_fullstack, chttp2_tear_down_fullstack},
+};
 
 int main(int argc, char **argv) {
   size_t i;

--- a/test/core/end2end/fixtures/chttp2_simple_ssl_fullstack.c
+++ b/test/core/end2end/fixtures/chttp2_simple_ssl_fullstack.c
@@ -101,8 +101,7 @@ void chttp2_tear_down_secure_fullstack(grpc_end2end_test_fixture *f) {
 
 static void chttp2_init_client_simple_ssl_secure_fullstack(
     grpc_end2end_test_fixture *f, grpc_channel_args *client_args) {
-  grpc_credentials *ssl_creds =
-      grpc_ssl_credentials_create(NULL, NULL);
+  grpc_credentials *ssl_creds = grpc_ssl_credentials_create(NULL, NULL);
   grpc_arg ssl_name_override = {GRPC_ARG_STRING,
                                 GRPC_SSL_TARGET_NAME_OVERRIDE_ARG,
                                 {"foo.test.google.fr"}};
@@ -128,7 +127,8 @@ static grpc_end2end_test_config configs[] = {
      chttp2_create_fixture_secure_fullstack,
      chttp2_init_client_simple_ssl_secure_fullstack,
      chttp2_init_server_simple_ssl_secure_fullstack,
-     chttp2_tear_down_secure_fullstack}, };
+     chttp2_tear_down_secure_fullstack},
+};
 
 int main(int argc, char **argv) {
   size_t i;

--- a/test/core/end2end/fixtures/chttp2_simple_ssl_with_oauth2_fullstack.c
+++ b/test/core/end2end/fixtures/chttp2_simple_ssl_with_oauth2_fullstack.c
@@ -133,7 +133,8 @@ static grpc_end2end_test_config configs[] = {
      chttp2_create_fixture_secure_fullstack,
      chttp2_init_client_simple_ssl_with_oauth2_secure_fullstack,
      chttp2_init_server_simple_ssl_secure_fullstack,
-     chttp2_tear_down_secure_fullstack}, };
+     chttp2_tear_down_secure_fullstack},
+};
 
 int main(int argc, char **argv) {
   size_t i;

--- a/test/core/end2end/fixtures/chttp2_socket_pair.c
+++ b/test/core/end2end/fixtures/chttp2_socket_pair.c
@@ -133,7 +133,8 @@ static void chttp2_tear_down_socketpair(grpc_end2end_test_fixture *f) {
 static grpc_end2end_test_config configs[] = {
     {"chttp2/socketpair", 0, chttp2_create_fixture_socketpair,
      chttp2_init_client_socketpair, chttp2_init_server_socketpair,
-     chttp2_tear_down_socketpair}, };
+     chttp2_tear_down_socketpair},
+};
 
 int main(int argc, char **argv) {
   size_t i;

--- a/test/core/end2end/fixtures/chttp2_socket_pair_one_byte_at_a_time.c
+++ b/test/core/end2end/fixtures/chttp2_socket_pair_one_byte_at_a_time.c
@@ -133,7 +133,8 @@ static void chttp2_tear_down_socketpair(grpc_end2end_test_fixture *f) {
 static grpc_end2end_test_config configs[] = {
     {"chttp2/socketpair_one_byte_at_a_time", 0,
      chttp2_create_fixture_socketpair, chttp2_init_client_socketpair,
-     chttp2_init_server_socketpair, chttp2_tear_down_socketpair}, };
+     chttp2_init_server_socketpair, chttp2_tear_down_socketpair},
+};
 
 int main(int argc, char **argv) {
   size_t i;

--- a/test/core/end2end/no_server_test.c
+++ b/test/core/end2end/no_server_test.c
@@ -41,8 +41,7 @@ static void *tag(gpr_intptr i) { return (void *)i; }
 int main(int argc, char **argv) {
   grpc_channel *chan;
   grpc_call *call;
-  gpr_timespec timeout = gpr_time_from_seconds(4);
-  gpr_timespec deadline = gpr_time_add(gpr_now(), timeout);
+  gpr_timespec deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5);
   grpc_completion_queue *cq;
   cq_verifier *cqv;
   grpc_event *ev;

--- a/test/core/end2end/tests/cancel_after_accept.c
+++ b/test/core/end2end/tests/cancel_after_accept.c
@@ -62,7 +62,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -163,11 +163,9 @@ static void test_cancel_after_accept(grpc_end2end_test_config config,
   op++;
   GPR_ASSERT(GRPC_CALL_OK == grpc_call_start_batch(c, ops, op - ops, tag(1)));
 
-  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, &s,
-                                                      &call_details,
-                                                      &request_metadata_recv,
-                                                      f.server_cq,
-                                                      tag(2)));
+  GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(
+                                 f.server, &s, &call_details,
+                                 &request_metadata_recv, f.server_cq, tag(2)));
   cq_expect_completion(v_server, tag(2), GRPC_OP_OK);
   cq_verify(v_server);
 

--- a/test/core/end2end/tests/cancel_after_accept_and_writes_closed.c
+++ b/test/core/end2end/tests/cancel_after_accept_and_writes_closed.c
@@ -62,7 +62,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -121,8 +121,8 @@ static void test_cancel_after_accept_and_writes_closed(
              grpc_call_invoke_old(c, f.client_cq, tag(2), tag(3), 0));
 
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
-  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo",
-                           "foo.test.google.fr", deadline, NULL);
+  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "foo.test.google.fr",
+                           deadline, NULL);
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==

--- a/test/core/end2end/tests/cancel_after_accept_and_writes_closed_legacy.c
+++ b/test/core/end2end/tests/cancel_after_accept_and_writes_closed_legacy.c
@@ -62,7 +62,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/cancel_after_accept_legacy.c
+++ b/test/core/end2end/tests/cancel_after_accept_legacy.c
@@ -62,7 +62,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/cancel_after_invoke.c
+++ b/test/core/end2end/tests/cancel_after_invoke.c
@@ -62,7 +62,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/cancel_after_invoke_legacy.c
+++ b/test/core/end2end/tests/cancel_after_invoke_legacy.c
@@ -62,7 +62,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/cancel_before_invoke.c
+++ b/test/core/end2end/tests/cancel_before_invoke.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -103,7 +103,8 @@ static void end_test(grpc_end2end_test_fixture *f) {
 }
 
 /* Cancel before invoke */
-static void test_cancel_before_invoke(grpc_end2end_test_config config, int test_ops) {
+static void test_cancel_before_invoke(grpc_end2end_test_config config,
+                                      int test_ops) {
   grpc_op ops[6];
   grpc_op *op;
   grpc_call *c;

--- a/test/core/end2end/tests/cancel_before_invoke_legacy.c
+++ b/test/core/end2end/tests/cancel_before_invoke_legacy.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/cancel_in_a_vacuum.c
+++ b/test/core/end2end/tests/cancel_in_a_vacuum.c
@@ -60,7 +60,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/cancel_in_a_vacuum_legacy.c
+++ b/test/core/end2end/tests/cancel_in_a_vacuum_legacy.c
@@ -60,7 +60,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/census_simple_request.c
+++ b/test/core/end2end/tests/census_simple_request.c
@@ -46,7 +46,7 @@
 #include "test/core/end2end/cq_verifier.h"
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,

--- a/test/core/end2end/tests/census_simple_request_legacy.c
+++ b/test/core/end2end/tests/census_simple_request_legacy.c
@@ -46,7 +46,7 @@
 #include "test/core/end2end/cq_verifier.h"
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,

--- a/test/core/end2end/tests/disappearing_server.c
+++ b/test/core/end2end/tests/disappearing_server.c
@@ -49,7 +49,7 @@ enum { TIMEOUT = 200000 };
 static void *tag(gpr_intptr t) { return (void *)t; }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -109,8 +109,8 @@ static void do_request_and_shutdown_server(grpc_end2end_test_fixture *f,
   cq_verify(v_client);
 
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f->server, tag(100)));
-  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo",
-                           "foo.test.google.fr", deadline, NULL);
+  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "foo.test.google.fr",
+                           deadline, NULL);
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==

--- a/test/core/end2end/tests/disappearing_server_legacy.c
+++ b/test/core/end2end/tests/disappearing_server_legacy.c
@@ -49,7 +49,7 @@ enum { TIMEOUT = 200000 };
 static void *tag(gpr_intptr t) { return (void *)t; }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/early_server_shutdown_finishes_inflight_calls.c
+++ b/test/core/end2end/tests/early_server_shutdown_finishes_inflight_calls.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -123,8 +123,8 @@ static void test_early_server_shutdown_finishes_inflight_calls(
   cq_verify(v_client);
 
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
-  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo",
-                           "foo.test.google.fr", deadline, NULL);
+  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "foo.test.google.fr",
+                           deadline, NULL);
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==

--- a/test/core/end2end/tests/early_server_shutdown_finishes_inflight_calls_legacy.c
+++ b/test/core/end2end/tests/early_server_shutdown_finishes_inflight_calls_legacy.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/early_server_shutdown_finishes_tags.c
+++ b/test/core/end2end/tests/early_server_shutdown_finishes_tags.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/early_server_shutdown_finishes_tags_legacy.c
+++ b/test/core/end2end/tests/early_server_shutdown_finishes_tags_legacy.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/empty_batch.c
+++ b/test/core/end2end/tests/empty_batch.c
@@ -63,7 +63,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/graceful_server_shutdown.c
+++ b/test/core/end2end/tests/graceful_server_shutdown.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -122,8 +122,8 @@ static void test_early_server_shutdown_finishes_inflight_calls(
   cq_verify(v_client);
 
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
-  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo",
-                           "foo.test.google.fr", deadline, NULL);
+  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "foo.test.google.fr",
+                           deadline, NULL);
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==

--- a/test/core/end2end/tests/graceful_server_shutdown_legacy.c
+++ b/test/core/end2end/tests/graceful_server_shutdown_legacy.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/invoke_large_request.c
+++ b/test/core/end2end/tests/invoke_large_request.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static void drain_cq(grpc_completion_queue *cq) {
@@ -138,8 +138,8 @@ static void test_invoke_large_request(grpc_end2end_test_config config) {
      request (as this request is very large) */
   cq_verify_empty(v_client);
 
-  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo",
-                           "foo.test.google.fr", deadline, NULL);
+  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "foo.test.google.fr",
+                           deadline, NULL);
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==

--- a/test/core/end2end/tests/invoke_large_request_legacy.c
+++ b/test/core/end2end/tests/invoke_large_request_legacy.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static void drain_cq(grpc_completion_queue *cq) {

--- a/test/core/end2end/tests/max_concurrent_streams.c
+++ b/test/core/end2end/tests/max_concurrent_streams.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -121,8 +121,8 @@ static void simple_request_body(grpc_end2end_test_fixture f) {
   cq_verify(v_client);
 
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
-  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo",
-                           "foo.test.google.fr", deadline, NULL);
+  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "foo.test.google.fr",
+                           deadline, NULL);
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==

--- a/test/core/end2end/tests/max_concurrent_streams_legacy.c
+++ b/test/core/end2end/tests/max_concurrent_streams_legacy.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/no_op.c
+++ b/test/core/end2end/tests/no_op.c
@@ -59,7 +59,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/no_op_legacy.c
+++ b/test/core/end2end/tests/no_op_legacy.c
@@ -59,7 +59,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/ping_pong_streaming.c
+++ b/test/core/end2end/tests/ping_pong_streaming.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -127,8 +127,8 @@ static void test_pingpong_streaming(grpc_end2end_test_config config,
 
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
 
-  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo",
-                           "foo.test.google.fr", deadline, NULL);
+  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "foo.test.google.fr",
+                           deadline, NULL);
   cq_verify(v_server);
   GPR_ASSERT(GRPC_CALL_OK ==
              grpc_call_server_accept_old(s, f.server_cq, tag(102)));

--- a/test/core/end2end/tests/ping_pong_streaming_legacy.c
+++ b/test/core/end2end/tests/ping_pong_streaming_legacy.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/request_response_with_binary_metadata_and_payload.c
+++ b/test/core/end2end/tests/request_response_with_binary_metadata_and_payload.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -175,8 +175,7 @@ static void test_request_response_with_metadata_and_payload(
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, &s,
                                                       &call_details,
                                                       &request_metadata_recv,
-                                                      f.server_cq,
-                                                      tag(101)));
+                                                      f.server_cq, tag(101)));
   cq_expect_completion(v_server, tag(101), GRPC_OP_OK);
   cq_verify(v_server);
 

--- a/test/core/end2end/tests/request_response_with_binary_metadata_and_payload_legacy.c
+++ b/test/core/end2end/tests/request_response_with_binary_metadata_and_payload_legacy.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -157,9 +157,10 @@ static void test_request_response_with_metadata_and_payload(
   cq_verify(v_client);
 
   cq_expect_server_rpc_new(
-      v_server, &s, tag(100), "/foo", "foo.test.google.fr", deadline, "key1-bin",
-      "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc", "key2-bin",
-      "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d", NULL);
+      v_server, &s, tag(100), "/foo", "foo.test.google.fr", deadline,
+      "key1-bin", "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc",
+      "key2-bin", "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d",
+      NULL);
   cq_verify(v_server);
 
   grpc_call_server_accept_old(s, f.server_cq, tag(102));

--- a/test/core/end2end/tests/request_response_with_metadata_and_payload.c
+++ b/test/core/end2end/tests/request_response_with_metadata_and_payload.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -168,8 +168,7 @@ static void test_request_response_with_metadata_and_payload(
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, &s,
                                                       &call_details,
                                                       &request_metadata_recv,
-                                                      f.server_cq,
-                                                      tag(101)));
+                                                      f.server_cq, tag(101)));
   cq_expect_completion(v_server, tag(101), GRPC_OP_OK);
   cq_verify(v_server);
 

--- a/test/core/end2end/tests/request_response_with_metadata_and_payload_legacy.c
+++ b/test/core/end2end/tests/request_response_with_metadata_and_payload_legacy.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/request_response_with_payload.c
+++ b/test/core/end2end/tests/request_response_with_payload.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -162,8 +162,7 @@ static void request_response_with_payload(grpc_end2end_test_fixture f) {
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, &s,
                                                       &call_details,
                                                       &request_metadata_recv,
-                                                      f.server_cq,
-                                                      tag(101)));
+                                                      f.server_cq, tag(101)));
   cq_expect_completion(v_server, tag(101), GRPC_OP_OK);
   cq_verify(v_server);
 

--- a/test/core/end2end/tests/request_response_with_payload_legacy.c
+++ b/test/core/end2end/tests/request_response_with_payload_legacy.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/request_response_with_trailing_metadata_and_payload.c
+++ b/test/core/end2end/tests/request_response_with_trailing_metadata_and_payload.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -169,8 +169,7 @@ static void test_request_response_with_metadata_and_payload(
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, &s,
                                                       &call_details,
                                                       &request_metadata_recv,
-                                                      f.server_cq,
-                                                      tag(101)));
+                                                      f.server_cq, tag(101)));
   cq_expect_completion(v_server, tag(101), GRPC_OP_OK);
   cq_verify(v_server);
 

--- a/test/core/end2end/tests/request_response_with_trailing_metadata_and_payload_legacy.c
+++ b/test/core/end2end/tests/request_response_with_trailing_metadata_and_payload_legacy.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/request_with_large_metadata.c
+++ b/test/core/end2end/tests/request_with_large_metadata.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -134,7 +134,7 @@ static void test_request_with_large_metadata(grpc_end2end_test_config config) {
   meta.key = "key";
   meta.value = gpr_malloc(large_size + 1);
   memset((char *)meta.value, 'a', large_size);
-  ((char*)meta.value)[large_size] = 0;
+  ((char *)meta.value)[large_size] = 0;
   meta.value_length = large_size;
 
   grpc_metadata_array_init(&initial_metadata_recv);
@@ -166,8 +166,7 @@ static void test_request_with_large_metadata(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, &s,
                                                       &call_details,
                                                       &request_metadata_recv,
-                                                      f.server_cq,
-                                                      tag(101)));
+                                                      f.server_cq, tag(101)));
   cq_expect_completion(v_server, tag(101), GRPC_OP_OK);
   cq_verify(v_server);
 

--- a/test/core/end2end/tests/request_with_large_metadata_legacy.c
+++ b/test/core/end2end/tests/request_with_large_metadata_legacy.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -118,7 +118,7 @@ static void test_request_with_large_metadata(grpc_end2end_test_config config) {
   meta.key = "key";
   meta.value = gpr_malloc(large_size + 1);
   memset((char *)meta.value, 'a', large_size);
-  ((char*)meta.value)[large_size] = 0;
+  ((char *)meta.value)[large_size] = 0;
   meta.value_length = large_size;
 
   c = grpc_channel_create_call_old(f.client, "/foo", "foo.test.google.fr",

--- a/test/core/end2end/tests/request_with_payload.c
+++ b/test/core/end2end/tests/request_with_payload.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -157,8 +157,7 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, &s,
                                                       &call_details,
                                                       &request_metadata_recv,
-                                                      f.server_cq,
-                                                      tag(101)));
+                                                      f.server_cq, tag(101)));
   cq_expect_completion(v_server, tag(101), GRPC_OP_OK);
   cq_verify(v_server);
 

--- a/test/core/end2end/tests/request_with_payload_legacy.c
+++ b/test/core/end2end/tests/request_with_payload_legacy.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/simple_delayed_request.c
+++ b/test/core/end2end/tests/simple_delayed_request.c
@@ -49,7 +49,7 @@ enum { TIMEOUT = 200000 };
 static void *tag(gpr_intptr t) { return (void *)t; }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -144,8 +144,7 @@ static void simple_delayed_request_body(grpc_end2end_test_config config,
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f->server, &s,
                                                       &call_details,
                                                       &request_metadata_recv,
-                                                      f->server_cq,
-                                                      tag(101)));
+                                                      f->server_cq, tag(101)));
   cq_expect_completion(v_server, tag(101), GRPC_OP_OK);
   cq_verify(v_server);
 

--- a/test/core/end2end/tests/simple_delayed_request_legacy.c
+++ b/test/core/end2end/tests/simple_delayed_request_legacy.c
@@ -49,7 +49,7 @@ enum { TIMEOUT = 200000 };
 static void *tag(gpr_intptr t) { return (void *)t; }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/simple_request.c
+++ b/test/core/end2end/tests/simple_request.c
@@ -63,7 +63,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -150,8 +150,7 @@ static void simple_request_body(grpc_end2end_test_fixture f) {
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call(f.server, &s,
                                                       &call_details,
                                                       &request_metadata_recv,
-                                                      f.server_cq,
-                                                      tag(101)));
+                                                      f.server_cq, tag(101)));
   cq_expect_completion(v_server, tag(101), GRPC_OP_OK);
   cq_verify(v_server);
 

--- a/test/core/end2end/tests/simple_request_legacy.c
+++ b/test/core/end2end/tests/simple_request_legacy.c
@@ -62,7 +62,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }

--- a/test/core/end2end/tests/thread_stress.c
+++ b/test/core/end2end/tests/thread_stress.c
@@ -41,6 +41,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 #include <grpc/support/thd.h>
+#include "test/core/util/test_config.h"
 
 #define SERVER_THREADS 16
 #define CLIENT_THREADS 16
@@ -53,7 +54,7 @@ static gpr_mu g_mu;
 static int g_active_requests;
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -280,11 +281,11 @@ static void run_test(grpc_end2end_test_config config, int requests_in_flight) {
   /* kick off threads */
   for (i = 0; i < CLIENT_THREADS; i++) {
     gpr_event_init(&g_client_done[i]);
-    gpr_thd_new(&thd_id, client_thread, (void *)(gpr_intptr)i, NULL);
+    gpr_thd_new(&thd_id, client_thread, (void *)(gpr_intptr) i, NULL);
   }
   for (i = 0; i < SERVER_THREADS; i++) {
     gpr_event_init(&g_server_done[i]);
-    gpr_thd_new(&thd_id, server_thread, (void *)(gpr_intptr)i, NULL);
+    gpr_thd_new(&thd_id, server_thread, (void *)(gpr_intptr) i, NULL);
   }
 
   /* start requests */

--- a/test/core/end2end/tests/thread_stress_legacy.c
+++ b/test/core/end2end/tests/thread_stress_legacy.c
@@ -41,6 +41,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 #include <grpc/support/thd.h>
+#include "test/core/util/test_config.h"
 
 #define SERVER_THREADS 16
 #define CLIENT_THREADS 16
@@ -53,7 +54,7 @@ static gpr_mu g_mu;
 static int g_active_requests;
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -280,11 +281,11 @@ static void run_test(grpc_end2end_test_config config, int requests_in_flight) {
   /* kick off threads */
   for (i = 0; i < CLIENT_THREADS; i++) {
     gpr_event_init(&g_client_done[i]);
-    gpr_thd_new(&thd_id, client_thread, (void *)(gpr_intptr)i, NULL);
+    gpr_thd_new(&thd_id, client_thread, (void *)(gpr_intptr) i, NULL);
   }
   for (i = 0; i < SERVER_THREADS; i++) {
     gpr_event_init(&g_server_done[i]);
-    gpr_thd_new(&thd_id, server_thread, (void *)(gpr_intptr)i, NULL);
+    gpr_thd_new(&thd_id, server_thread, (void *)(gpr_intptr) i, NULL);
   }
 
   /* start requests */

--- a/test/core/end2end/tests/writes_done_hangs_with_pending_read.c
+++ b/test/core/end2end/tests/writes_done_hangs_with_pending_read.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -140,8 +140,8 @@ static void test_writes_done_hangs_with_pending_read(
   cq_verify(v_client);
 
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
-  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo",
-                           "foo.test.google.fr", deadline, NULL);
+  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "foo.test.google.fr",
+                           deadline, NULL);
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==

--- a/test/core/end2end/tests/writes_done_hangs_with_pending_read_legacy.c
+++ b/test/core/end2end/tests/writes_done_hangs_with_pending_read_legacy.c
@@ -61,7 +61,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
 }
 
 static gpr_timespec n_seconds_time(int n) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(GPR_US_PER_SEC * n));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(n);
 }
 
 static gpr_timespec five_seconds_time(void) { return n_seconds_time(5); }
@@ -140,8 +140,8 @@ static void test_writes_done_hangs_with_pending_read(
   cq_verify(v_client);
 
   GPR_ASSERT(GRPC_CALL_OK == grpc_server_request_call_old(f.server, tag(100)));
-  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo",
-                           "foo.test.google.fr", deadline, NULL);
+  cq_expect_server_rpc_new(v_server, &s, tag(100), "/foo", "foo.test.google.fr",
+                           deadline, NULL);
   cq_verify(v_server);
 
   GPR_ASSERT(GRPC_CALL_OK ==

--- a/test/core/httpcli/httpcli_test.c
+++ b/test/core/httpcli/httpcli_test.c
@@ -43,7 +43,7 @@
 static gpr_event g_done;
 
 static gpr_timespec n_seconds_time(int seconds) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(seconds * 1000000));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(seconds);
 }
 
 static void on_finish(void *arg, const grpc_httpcli_response *response) {

--- a/test/core/iomgr/alarm_list_test.c
+++ b/test/core/iomgr/alarm_list_test.c
@@ -61,13 +61,13 @@ static void add_test(void) {
   /* 10 ms alarms.  will expire in the current epoch */
   for (i = 0; i < 10; i++) {
     grpc_alarm_init(&alarms[i], gpr_time_add(start, gpr_time_from_millis(10)),
-                    cb, (void *)(gpr_intptr)i, start);
+                    cb, (void *)(gpr_intptr) i, start);
   }
 
   /* 1010 ms alarms.  will expire in the next epoch */
   for (i = 10; i < 20; i++) {
     grpc_alarm_init(&alarms[i], gpr_time_add(start, gpr_time_from_millis(1010)),
-                    cb, (void *)(gpr_intptr)i, start);
+                    cb, (void *)(gpr_intptr) i, start);
   }
 
   /* collect alarms.  Only the first batch should be ready. */
@@ -115,15 +115,15 @@ void destruction_test(void) {
   memset(cb_called, 0, sizeof(cb_called));
 
   grpc_alarm_init(&alarms[0], gpr_time_from_millis(100), cb,
-                  (void *)(gpr_intptr)0, gpr_time_0);
+                  (void *)(gpr_intptr) 0, gpr_time_0);
   grpc_alarm_init(&alarms[1], gpr_time_from_millis(3), cb,
-                  (void *)(gpr_intptr)1, gpr_time_0);
+                  (void *)(gpr_intptr) 1, gpr_time_0);
   grpc_alarm_init(&alarms[2], gpr_time_from_millis(100), cb,
-                  (void *)(gpr_intptr)2, gpr_time_0);
+                  (void *)(gpr_intptr) 2, gpr_time_0);
   grpc_alarm_init(&alarms[3], gpr_time_from_millis(3), cb,
-                  (void *)(gpr_intptr)3, gpr_time_0);
+                  (void *)(gpr_intptr) 3, gpr_time_0);
   grpc_alarm_init(&alarms[4], gpr_time_from_millis(1), cb,
-                  (void *)(gpr_intptr)4, gpr_time_0);
+                  (void *)(gpr_intptr) 4, gpr_time_0);
   GPR_ASSERT(1 == grpc_alarm_check(NULL, gpr_time_from_millis(2), NULL));
   GPR_ASSERT(1 == cb_called[4][1]);
   grpc_alarm_cancel(&alarms[0]);

--- a/test/core/iomgr/alarm_test.c
+++ b/test/core/iomgr/alarm_test.c
@@ -113,10 +113,10 @@ static void test_grpc_alarm(void) {
   gpr_cv_init(&arg.cv);
   gpr_event_init(&arg.fcb_arg);
 
-  grpc_alarm_init(&alarm, gpr_time_add(gpr_time_from_millis(100), gpr_now()),
-                  alarm_cb, &arg, gpr_now());
+  grpc_alarm_init(&alarm, GRPC_TIMEOUT_MILLIS_TO_DEADLINE(100), alarm_cb, &arg,
+                  gpr_now());
 
-  alarm_deadline = gpr_time_add(gpr_now(), gpr_time_from_seconds(1));
+  alarm_deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(1);
   gpr_mu_lock(&arg.mu);
   while (arg.done == 0) {
     if (gpr_cv_wait(&arg.cv, &arg.mu, alarm_deadline)) {
@@ -126,7 +126,7 @@ static void test_grpc_alarm(void) {
   }
   gpr_mu_unlock(&arg.mu);
 
-  followup_deadline = gpr_time_add(gpr_now(), gpr_time_from_seconds(5));
+  followup_deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5);
   fdone = gpr_event_wait(&arg.fcb_arg, followup_deadline);
 
   if (arg.counter != 1) {
@@ -162,12 +162,11 @@ static void test_grpc_alarm(void) {
   gpr_cv_init(&arg2.cv);
   gpr_event_init(&arg2.fcb_arg);
 
-  grpc_alarm_init(&alarm_to_cancel,
-                  gpr_time_add(gpr_time_from_millis(100), gpr_now()), alarm_cb,
-                  &arg2, gpr_now());
+  grpc_alarm_init(&alarm_to_cancel, GRPC_TIMEOUT_MILLIS_TO_DEADLINE(100),
+                  alarm_cb, &arg2, gpr_now());
   grpc_alarm_cancel(&alarm_to_cancel);
 
-  alarm_deadline = gpr_time_add(gpr_now(), gpr_time_from_seconds(1));
+  alarm_deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(1);
   gpr_mu_lock(&arg2.mu);
   while (arg2.done == 0) {
     gpr_cv_wait(&arg2.cv, &arg2.mu, alarm_deadline);
@@ -176,7 +175,7 @@ static void test_grpc_alarm(void) {
 
   gpr_log(GPR_INFO, "alarm done = %d", arg2.done);
 
-  followup_deadline = gpr_time_add(gpr_now(), gpr_time_from_seconds(5));
+  followup_deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5);
   fdone = gpr_event_wait(&arg2.fcb_arg, followup_deadline);
 
   if (arg2.counter != arg2.done_success_ctr) {

--- a/test/core/iomgr/endpoint_tests.c
+++ b/test/core/iomgr/endpoint_tests.c
@@ -39,6 +39,7 @@
 #include <grpc/support/slice.h>
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
+#include "test/core/util/test_config.h"
 
 /*
    General test notes:
@@ -211,7 +212,7 @@ static void read_and_write_test(grpc_endpoint_test_config config,
                                 size_t num_bytes, size_t write_size,
                                 size_t slice_size, int shutdown) {
   struct read_and_write_test_state state;
-  gpr_timespec deadline = gpr_time_add(gpr_now(), gpr_time_from_seconds(20));
+  gpr_timespec deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(20);
   grpc_endpoint_test_fixture f = begin_test(config, __FUNCTION__, slice_size);
 
   if (shutdown) {
@@ -290,7 +291,7 @@ static void shutdown_during_write_test_read_handler(
 
   if (error != GRPC_ENDPOINT_CB_OK) {
     grpc_endpoint_destroy(st->ep);
-    gpr_event_set(&st->ev, (void *)(gpr_intptr)error);
+    gpr_event_set(&st->ev, (void *)(gpr_intptr) error);
   } else {
     grpc_endpoint_notify_on_read(
         st->ep, shutdown_during_write_test_read_handler, user_data);
@@ -309,7 +310,7 @@ static void shutdown_during_write_test_write_handler(
     gpr_log(GPR_ERROR,
             "shutdown_during_write_test_write_handler completed unexpectedly");
   }
-  gpr_event_set(&st->ev, (void *)(gpr_intptr)1);
+  gpr_event_set(&st->ev, (void *)(gpr_intptr) 1);
 }
 
 static void shutdown_during_write_test(grpc_endpoint_test_config config,
@@ -345,8 +346,7 @@ static void shutdown_during_write_test(grpc_endpoint_test_config config,
         abort();
       case GRPC_ENDPOINT_WRITE_PENDING:
         grpc_endpoint_shutdown(write_st.ep);
-        deadline =
-            gpr_time_add(gpr_now(), gpr_time_from_micros(10 * GPR_US_PER_SEC));
+        deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(10);
         GPR_ASSERT(gpr_event_wait(&write_st.ev, deadline));
         grpc_endpoint_destroy(write_st.ep);
         GPR_ASSERT(gpr_event_wait(&read_st.ev, deadline));

--- a/test/core/iomgr/resolve_address_test.c
+++ b/test/core/iomgr/resolve_address_test.c
@@ -39,7 +39,7 @@
 #include "test/core/util/test_config.h"
 
 static gpr_timespec test_deadline(void) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(100000000));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(100);
 }
 
 static void must_succeed(void* evp, grpc_resolved_addresses* p) {
@@ -83,8 +83,9 @@ static void test_ipv6_with_port(void) {
 }
 
 static void test_ipv6_without_port(void) {
-  const char* const kCases[] = {"2001:db8::1", "2001:db8::1.2.3.4",
-                                "[2001:db8::1]", };
+  const char* const kCases[] = {
+      "2001:db8::1", "2001:db8::1.2.3.4", "[2001:db8::1]",
+  };
   unsigned i;
   for (i = 0; i < sizeof(kCases) / sizeof(*kCases); i++) {
     gpr_event ev;
@@ -95,7 +96,9 @@ static void test_ipv6_without_port(void) {
 }
 
 static void test_invalid_ip_addresses(void) {
-  const char* const kCases[] = {"293.283.1238.3:1", "[2001:db8::11111]:1", };
+  const char* const kCases[] = {
+      "293.283.1238.3:1", "[2001:db8::11111]:1",
+  };
   unsigned i;
   for (i = 0; i < sizeof(kCases) / sizeof(*kCases); i++) {
     gpr_event ev;
@@ -106,8 +109,9 @@ static void test_invalid_ip_addresses(void) {
 }
 
 static void test_unparseable_hostports(void) {
-  const char* const kCases[] = {"[",         "[::1",        "[::1]bad",
-                                "[1.2.3.4]", "[localhost]", "[localhost]:1", };
+  const char* const kCases[] = {
+      "[", "[::1", "[::1]bad", "[1.2.3.4]", "[localhost]", "[localhost]:1",
+  };
   unsigned i;
   for (i = 0; i < sizeof(kCases) / sizeof(*kCases); i++) {
     gpr_event ev;

--- a/test/core/iomgr/tcp_client_posix_test.c
+++ b/test/core/iomgr/tcp_client_posix_test.c
@@ -43,9 +43,10 @@
 #include "src/core/iomgr/socket_utils_posix.h"
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
+#include "test/core/util/test_config.h"
 
 static gpr_timespec test_deadline(void) {
-  return gpr_time_add(gpr_now(), gpr_time_from_seconds(10));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(10);
 }
 
 static void must_succeed(void *arg, grpc_endpoint *tcp) {
@@ -150,13 +151,12 @@ void test_times_out(void) {
 
   /* connect to dummy server address */
 
-  connect_deadline = gpr_time_add(gpr_now(), gpr_time_from_micros(1000000));
+  connect_deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(1);
 
   grpc_tcp_client_connect(must_fail, &ev, (struct sockaddr *)&addr, addr_len,
                           connect_deadline);
   /* Make sure the event doesn't trigger early */
-  GPR_ASSERT(!gpr_event_wait(
-                 &ev, gpr_time_add(gpr_now(), gpr_time_from_micros(500000))));
+  GPR_ASSERT(!gpr_event_wait(&ev, GRPC_TIMEOUT_MILLIS_TO_DEADLINE(500)));
   /* Now wait until it should have triggered */
   sleep(1);
 
@@ -168,7 +168,8 @@ void test_times_out(void) {
   }
 }
 
-int main(void) {
+int main(int argc, char **argv) {
+  grpc_test_init(argc, argv);
   grpc_iomgr_init();
   test_succeeds();
   gpr_log(GPR_ERROR, "End of first test");

--- a/test/core/iomgr/tcp_posix_test.c
+++ b/test/core/iomgr/tcp_posix_test.c
@@ -163,8 +163,7 @@ static void read_test(ssize_t num_bytes, ssize_t slice_size) {
   grpc_endpoint *ep;
   struct read_socket_state state;
   ssize_t written_bytes;
-  gpr_timespec rel_deadline = {20, 0};
-  gpr_timespec deadline = gpr_time_add(gpr_now(), rel_deadline);
+  gpr_timespec deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(20);
 
   gpr_log(GPR_INFO, "Read test of size %d, slice size %d", num_bytes,
           slice_size);
@@ -206,8 +205,7 @@ static void large_read_test(ssize_t slice_size) {
   grpc_endpoint *ep;
   struct read_socket_state state;
   ssize_t written_bytes;
-  gpr_timespec rel_deadline = {20, 0};
-  gpr_timespec deadline = gpr_time_add(gpr_now(), rel_deadline);
+  gpr_timespec deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(20);
 
   gpr_log(GPR_INFO, "Start large read test, slice size %d", slice_size);
 
@@ -343,8 +341,7 @@ static void write_test(ssize_t num_bytes, ssize_t slice_size) {
   size_t num_blocks;
   gpr_slice *slices;
   int current_data = 0;
-  gpr_timespec rel_deadline = {20, 0};
-  gpr_timespec deadline = gpr_time_add(gpr_now(), rel_deadline);
+  gpr_timespec deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(20);
 
   gpr_log(GPR_INFO, "Start write test with %d bytes, slice size %d", num_bytes,
           slice_size);
@@ -400,8 +397,7 @@ static void write_error_test(ssize_t num_bytes, ssize_t slice_size) {
   size_t num_blocks;
   gpr_slice *slices;
   int current_data = 0;
-  gpr_timespec rel_deadline = {20, 0};
-  gpr_timespec deadline = gpr_time_add(gpr_now(), rel_deadline);
+  gpr_timespec deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(20);
 
   gpr_log(GPR_INFO, "Start write error test with %d bytes, slice size %d",
           num_bytes, slice_size);
@@ -482,7 +478,8 @@ static grpc_endpoint_test_fixture create_fixture_tcp_socketpair(
 }
 
 static grpc_endpoint_test_config configs[] = {
-    {"tcp/tcp_socketpair", create_fixture_tcp_socketpair, clean_up}, };
+    {"tcp/tcp_socketpair", create_fixture_tcp_socketpair, clean_up},
+};
 
 int main(int argc, char **argv) {
   grpc_test_init(argc, argv);

--- a/test/core/iomgr/tcp_server_posix_test.c
+++ b/test/core/iomgr/tcp_server_posix_test.c
@@ -123,7 +123,7 @@ static void test_connect(int n) {
   grpc_tcp_server_start(s, NULL, 0, on_connect, NULL);
 
   for (i = 0; i < n; i++) {
-    deadline = gpr_time_add(gpr_now(), gpr_time_from_micros(10000000));
+    deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(1);
 
     nconnects_before = nconnects;
     clifd = socket(addr.ss_family, SOCK_STREAM, 0);

--- a/test/core/json/json_rewrite.c
+++ b/test/core/json/json_rewrite.c
@@ -40,9 +40,7 @@
 #include "src/core/json/json_reader.h"
 #include "src/core/json/json_writer.h"
 
-typedef struct json_writer_userdata {
-  FILE* out;
-} json_writer_userdata;
+typedef struct json_writer_userdata { FILE* out; } json_writer_userdata;
 
 typedef struct stacked_container {
   grpc_json_type type;
@@ -76,11 +74,9 @@ static void json_writer_output_string_with_len(void* userdata, const char* str,
   fwrite(str, len, 1, state->out);
 }
 
-grpc_json_writer_vtable writer_vtable = {
-  json_writer_output_char,
-  json_writer_output_string,
-  json_writer_output_string_with_len
-};
+grpc_json_writer_vtable writer_vtable = {json_writer_output_char,
+                                         json_writer_output_string,
+                                         json_writer_output_string_with_len};
 
 static void check_string(json_reader_userdata* state, size_t needed) {
   if (state->free_space >= needed) return;
@@ -202,19 +198,12 @@ static void json_reader_set_null(void* userdata) {
 }
 
 static grpc_json_reader_vtable reader_vtable = {
-  json_reader_string_clear,
-  json_reader_string_add_char,
-  json_reader_string_add_utf32,
-  json_reader_read_char,
-  json_reader_container_begins,
-  json_reader_container_ends,
-  json_reader_set_key,
-  json_reader_set_string,
-  json_reader_set_number,
-  json_reader_set_true,
-  json_reader_set_false,
-  json_reader_set_null
-};
+    json_reader_string_clear,     json_reader_string_add_char,
+    json_reader_string_add_utf32, json_reader_read_char,
+    json_reader_container_begins, json_reader_container_ends,
+    json_reader_set_key,          json_reader_set_string,
+    json_reader_set_number,       json_reader_set_true,
+    json_reader_set_false,        json_reader_set_null};
 
 int rewrite(FILE* in, FILE* out, int indent) {
   grpc_json_writer writer;

--- a/test/core/json/json_rewrite_test.c
+++ b/test/core/json/json_rewrite_test.c
@@ -42,9 +42,7 @@
 #include "src/core/json/json_reader.h"
 #include "src/core/json/json_writer.h"
 
-typedef struct json_writer_userdata {
-  FILE* cmp;
-} json_writer_userdata;
+typedef struct json_writer_userdata { FILE* cmp; } json_writer_userdata;
 
 typedef struct stacked_container {
   grpc_json_type type;
@@ -83,11 +81,9 @@ static void json_writer_output_string_with_len(void* userdata, const char* str,
   }
 }
 
-grpc_json_writer_vtable writer_vtable = {
-  json_writer_output_char,
-  json_writer_output_string,
-  json_writer_output_string_with_len
-};
+grpc_json_writer_vtable writer_vtable = {json_writer_output_char,
+                                         json_writer_output_string,
+                                         json_writer_output_string_with_len};
 
 static void check_string(json_reader_userdata* state, size_t needed) {
   if (state->free_space >= needed) return;
@@ -216,19 +212,12 @@ static void json_reader_set_null(void* userdata) {
 }
 
 static grpc_json_reader_vtable reader_vtable = {
-  json_reader_string_clear,
-  json_reader_string_add_char,
-  json_reader_string_add_utf32,
-  json_reader_read_char,
-  json_reader_container_begins,
-  json_reader_container_ends,
-  json_reader_set_key,
-  json_reader_set_string,
-  json_reader_set_number,
-  json_reader_set_true,
-  json_reader_set_false,
-  json_reader_set_null
-};
+    json_reader_string_clear,     json_reader_string_add_char,
+    json_reader_string_add_utf32, json_reader_read_char,
+    json_reader_container_begins, json_reader_container_ends,
+    json_reader_set_key,          json_reader_set_string,
+    json_reader_set_number,       json_reader_set_true,
+    json_reader_set_false,        json_reader_set_null};
 
 int rewrite_and_compare(FILE* in, FILE* cmp, int indent) {
   grpc_json_writer writer;
@@ -275,26 +264,14 @@ typedef struct test_file {
 } test_file;
 
 static test_file test_files[] = {
-  {
-    "test/core/json/rewrite_test_input.json",
-    "test/core/json/rewrite_test_output_condensed.json",
-    0
-  },
-  {
-    "test/core/json/rewrite_test_input.json",
-    "test/core/json/rewrite_test_output_indented.json",
-    2
-  },
-  {
-    "test/core/json/rewrite_test_output_indented.json",
-    "test/core/json/rewrite_test_output_condensed.json",
-    0
-  },
-  {
-    "test/core/json/rewrite_test_output_condensed.json",
-    "test/core/json/rewrite_test_output_indented.json",
-    2
-  },
+    {"test/core/json/rewrite_test_input.json",
+     "test/core/json/rewrite_test_output_condensed.json", 0},
+    {"test/core/json/rewrite_test_input.json",
+     "test/core/json/rewrite_test_output_indented.json", 2},
+    {"test/core/json/rewrite_test_output_indented.json",
+     "test/core/json/rewrite_test_output_condensed.json", 0},
+    {"test/core/json/rewrite_test_output_condensed.json",
+     "test/core/json/rewrite_test_output_indented.json", 2},
 };
 
 void test_rewrites() {
@@ -305,8 +282,8 @@ void test_rewrites() {
     FILE* input = fopen(test->input, "rb");
     FILE* cmp = fopen(test->cmp, "rb");
     int status;
-    gpr_log(GPR_INFO, "Testing file %s against %s using indent=%i",
-            test->input, test->cmp, test->indent);
+    gpr_log(GPR_INFO, "Testing file %s against %s using indent=%i", test->input,
+            test->cmp, test->indent);
     status = rewrite_and_compare(input, cmp, test->indent);
     GPR_ASSERT(status);
     fclose(input);

--- a/test/core/json/json_test.c
+++ b/test/core/json/json_test.c
@@ -47,80 +47,83 @@ typedef struct testing_pair {
 } testing_pair;
 
 static testing_pair testing_pairs[] = {
-  /* Testing valid parsing. */
+    /* Testing valid parsing. */
 
-  /* Testing trivial parses, with de-indentation. */
-  { " 0 ", "0" },
-  { " 1 ", "1" },
-  { " \"a\" ", "\"a\"" },
-  { " true ", "true" },
-  /* Testing the parser's ability to decode trivial UTF-16. */
-  { "\"\\u0020\\\\\\u0010\\u000a\\u000D\"", "\" \\\\\\u0010\\n\\r\"" },
-  /* Testing various UTF-8 sequences. */
-  { "\"ßâñć௵⇒\"", "\"\\u00df\\u00e2\\u00f1\\u0107\\u0bf5\\u21d2\"" },
-  { "\"\\u00df\\u00e2\\u00f1\\u0107\\u0bf5\\u21d2\"", "\"\\u00df\\u00e2\\u00f1\\u0107\\u0bf5\\u21d2\"" },
-  /* Testing UTF-8 character "𝄞", U+11D1E. */
-  { "\"\xf0\x9d\x84\x9e\"", "\"\\ud834\\udd1e\"" },
-  { "\"\\ud834\\udd1e\"", "\"\\ud834\\udd1e\"" },
-  /* Testing nested empty containers. */
-  { " [ [ ] , { } , [ ] ] ", "[[],{},[]]", },
-  /* Testing escapes and control chars in key strings. */
-  { " { \"\x7f\\n\\\\a , b\": 1, \"\": 0 } ", "{\"\\u007f\\n\\\\a , b\":1,\"\":0}" },
-  /* Testing the writer's ability to cut off invalid UTF-8 sequences. */
-  { "\"abc\xf0\x9d\x24\"", "\"abc\"" },
-  { "\"\xff\"", "\"\"" },
-  /* Testing valid number parsing. */
-  { "[0, 42 , 0.0123, 123.456]", "[0,42,0.0123,123.456]"},
-  { "[1e4,-53.235e-31, 0.3e+3]", "[1e4,-53.235e-31,0.3e+3]" },
-  /* Testing keywords parsing. */
-  { "[true, false, null]", "[true,false,null]" },
+    /* Testing trivial parses, with de-indentation. */
+    {" 0 ", "0"},
+    {" 1 ", "1"},
+    {" \"a\" ", "\"a\""},
+    {" true ", "true"},
+    /* Testing the parser's ability to decode trivial UTF-16. */
+    {"\"\\u0020\\\\\\u0010\\u000a\\u000D\"", "\" \\\\\\u0010\\n\\r\""},
+    /* Testing various UTF-8 sequences. */
+    {"\"ßâñć௵⇒\"", "\"\\u00df\\u00e2\\u00f1\\u0107\\u0bf5\\u21d2\""},
+    {"\"\\u00df\\u00e2\\u00f1\\u0107\\u0bf5\\u21d2\"",
+     "\"\\u00df\\u00e2\\u00f1\\u0107\\u0bf5\\u21d2\""},
+    /* Testing UTF-8 character "𝄞", U+11D1E. */
+    {"\"\xf0\x9d\x84\x9e\"", "\"\\ud834\\udd1e\""},
+    {"\"\\ud834\\udd1e\"", "\"\\ud834\\udd1e\""},
+    /* Testing nested empty containers. */
+    {
+     " [ [ ] , { } , [ ] ] ", "[[],{},[]]",
+    },
+    /* Testing escapes and control chars in key strings. */
+    {" { \"\x7f\\n\\\\a , b\": 1, \"\": 0 } ",
+     "{\"\\u007f\\n\\\\a , b\":1,\"\":0}"},
+    /* Testing the writer's ability to cut off invalid UTF-8 sequences. */
+    {"\"abc\xf0\x9d\x24\"", "\"abc\""},
+    {"\"\xff\"", "\"\""},
+    /* Testing valid number parsing. */
+    {"[0, 42 , 0.0123, 123.456]", "[0,42,0.0123,123.456]"},
+    {"[1e4,-53.235e-31, 0.3e+3]", "[1e4,-53.235e-31,0.3e+3]"},
+    /* Testing keywords parsing. */
+    {"[true, false, null]", "[true,false,null]"},
 
+    /* Testing invalid parsing. */
 
-  /* Testing invalid parsing. */
-
-  /* Testing plain invalid things, exercising the state machine. */
-  { "\\", NULL },
-  { "nu ll", NULL },
-  { "fals", NULL },
-  /* Testing unterminated string. */
-  { "\"\\x", NULL },
-  /* Testing invalid UTF-16 number. */
-  { "\"\\u123x", NULL },
-  /* Testing imbalanced surrogate pairs. */
-  { "\"\\ud834f", NULL },
-  { "\"\\ud834\\n", NULL },
-  { "\"\\udd1ef", NULL },
-  { "\"\\ud834\\ud834\"", NULL },
-  { "\"\\ud834\\u1234\"", NULL },
-  /* Testing embedded invalid whitechars. */
-  { "\"\n\"", NULL },
-  { "\"\t\"", NULL },
-  /* Testing empty json data. */
-  { "", NULL },
-  /* Testing extra characters after end of parsing. */
-  { "{},", NULL },
-  /* Testing imbalanced containers. */
-  { "{}}", NULL },
-  { "[]]", NULL },
-  { "{{}", NULL },
-  { "[[]", NULL },
-  { "[}", NULL },
-  { "{]", NULL },
-  /*Testing trailing comma. */
-  { "{,}", NULL },
-  { "[1,2,3,4,]", NULL },
-  /* Testing having a key syntax in an array. */
-  { "[\"x\":0]", NULL },
-  /* Testing invalid numbers. */
-  { "1.", NULL },
-  { "1e", NULL },
-  { ".12", NULL },
-  { "1.x", NULL },
-  { "1.12x", NULL },
-  { "1ex", NULL },
-  { "1e12x", NULL },
-  { ".12x", NULL },
-  { "000", NULL },
+    /* Testing plain invalid things, exercising the state machine. */
+    {"\\", NULL},
+    {"nu ll", NULL},
+    {"fals", NULL},
+    /* Testing unterminated string. */
+    {"\"\\x", NULL},
+    /* Testing invalid UTF-16 number. */
+    {"\"\\u123x", NULL},
+    /* Testing imbalanced surrogate pairs. */
+    {"\"\\ud834f", NULL},
+    {"\"\\ud834\\n", NULL},
+    {"\"\\udd1ef", NULL},
+    {"\"\\ud834\\ud834\"", NULL},
+    {"\"\\ud834\\u1234\"", NULL},
+    /* Testing embedded invalid whitechars. */
+    {"\"\n\"", NULL},
+    {"\"\t\"", NULL},
+    /* Testing empty json data. */
+    {"", NULL},
+    /* Testing extra characters after end of parsing. */
+    {"{},", NULL},
+    /* Testing imbalanced containers. */
+    {"{}}", NULL},
+    {"[]]", NULL},
+    {"{{}", NULL},
+    {"[[]", NULL},
+    {"[}", NULL},
+    {"{]", NULL},
+    /*Testing trailing comma. */
+    {"{,}", NULL},
+    {"[1,2,3,4,]", NULL},
+    /* Testing having a key syntax in an array. */
+    {"[\"x\":0]", NULL},
+    /* Testing invalid numbers. */
+    {"1.", NULL},
+    {"1e", NULL},
+    {".12", NULL},
+    {"1.x", NULL},
+    {"1.12x", NULL},
+    {"1ex", NULL},
+    {"1e12x", NULL},
+    {".12x", NULL},
+    {"000", NULL},
 };
 
 static void test_pairs() {
@@ -169,7 +172,7 @@ static void test_atypical() {
   gpr_free(scratchpad);
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   grpc_test_init(argc, argv);
   test_pairs();
   test_atypical();

--- a/test/core/security/credentials_test.c
+++ b/test/core/security/credentials_test.c
@@ -55,7 +55,8 @@ static const char test_root_cert[] = "I am the root!";
    Maximum size for a string literal is 509 chars in C89, yay!  */
 static const char test_json_key_str_part1[] =
     "{ \"private_key\": \"-----BEGIN PRIVATE KEY-----"
-    "\\nMIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAOEvJsnoHnyHkXcp\\n7mJEqg"
+    "\\nMIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAOEvJsnoHnyHkXcp\\n7mJE"
+    "qg"
     "WGjiw71NfXByguekSKho65FxaGbsnSM9SMQAqVk7Q2rG+I0OpsT0LrWQtZ\\nyjSeg/"
     "rWBQvS4hle4LfijkP3J5BG+"
     "IXDMP8RfziNRQsenAXDNPkY4kJCvKux2xdD\\nOnVF6N7dL3nTYZg+"
@@ -66,11 +67,14 @@ static const char test_json_key_str_part1[] =
 static const char test_json_key_str_part2[] =
     "53XxNVnxBHsYb+AYEfklR96yVi8HywjVHP34+OQZ\\nCslxoHQM8s+"
     "dBnjfScLu22JqkPv04xyxmt0QAKm9+vTdAkEA4ib7YvEAn2jXzcCI\\nEkoy2L/"
-    "XydR1GCHoacdfdAwiL2npOdnbvi4ZmdYRPY1LSTO058tQHKVXV7NLeCa3\\nAARh2QJBAMKeDAG"
-    "W303SQv2cZTdbeaLKJbB5drz3eo3j7dDKjrTD9JupixFbzcGw\\n8FZi5c8idxiwC36kbAL6HzA"
+    "XydR1GCHoacdfdAwiL2npOdnbvi4ZmdYRPY1LSTO058tQHKVXV7NLeCa3\\nAARh2QJBAMKeDA"
+    "G"
+    "W303SQv2cZTdbeaLKJbB5drz3eo3j7dDKjrTD9JupixFbzcGw\\n8FZi5c8idxiwC36kbAL6Hz"
+    "A"
     "ZoX+ofI0CQE6KCzPJTtYNqyShgKAZdJ8hwOcvCZtf\\n6z8RJm0+"
     "6YBd38lfh5j8mZd7aHFf6I17j5AQY7oPEc47TjJj/"
-    "5nZ68ECQQDvYuI3\\nLyK5fS8g0SYbmPOL9TlcHDOqwG0mrX9qpg5DC2fniXNSrrZ64GTDKdzZY"
+    "5nZ68ECQQDvYuI3\\nLyK5fS8g0SYbmPOL9TlcHDOqwG0mrX9qpg5DC2fniXNSrrZ64GTDKdzZ"
+    "Y"
     "Ap6LI9W\\nIqv4vr6y38N79TTC\\n-----END PRIVATE KEY-----\\n\", ";
 static const char test_json_key_str_part3[] =
     "\"private_key_id\": \"e6b5137873db8d2ef81e06a47289e6434ec8a165\", "
@@ -614,9 +618,10 @@ static void test_service_account_creds_signing_failure(void) {
   grpc_jwt_encode_and_sign_set_override(NULL);
 }
 
-static void on_jwt_creds_get_metadata_success(
-    void *user_data, grpc_mdelem **md_elems, size_t num_md,
-    grpc_credentials_status status) {
+static void on_jwt_creds_get_metadata_success(void *user_data,
+                                              grpc_mdelem **md_elems,
+                                              size_t num_md,
+                                              grpc_credentials_status status) {
   char *expected_md_value;
   gpr_asprintf(&expected_md_value, "Bearer %s", test_signed_jwt);
   GPR_ASSERT(status == GRPC_CREDENTIALS_OK);
@@ -630,9 +635,10 @@ static void on_jwt_creds_get_metadata_success(
   gpr_free(expected_md_value);
 }
 
-static void on_jwt_creds_get_metadata_failure(
-    void *user_data, grpc_mdelem **md_elems, size_t num_md,
-    grpc_credentials_status status) {
+static void on_jwt_creds_get_metadata_failure(void *user_data,
+                                              grpc_mdelem **md_elems,
+                                              size_t num_md,
+                                              grpc_credentials_status status) {
   GPR_ASSERT(status == GRPC_CREDENTIALS_ERROR);
   GPR_ASSERT(num_md == 0);
   GPR_ASSERT(user_data != NULL);

--- a/test/core/security/json_token_test.c
+++ b/test/core/security/json_token_test.c
@@ -49,7 +49,8 @@
    Maximum size for a string literal is 509 chars in C89, yay!  */
 static const char test_json_key_str_part1[] =
     "{ \"private_key\": \"-----BEGIN PRIVATE KEY-----"
-    "\\nMIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAOEvJsnoHnyHkXcp\\n7mJEqg"
+    "\\nMIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAOEvJsnoHnyHkXcp\\n7mJE"
+    "qg"
     "WGjiw71NfXByguekSKho65FxaGbsnSM9SMQAqVk7Q2rG+I0OpsT0LrWQtZ\\nyjSeg/"
     "rWBQvS4hle4LfijkP3J5BG+"
     "IXDMP8RfziNRQsenAXDNPkY4kJCvKux2xdD\\nOnVF6N7dL3nTYZg+"
@@ -60,11 +61,14 @@ static const char test_json_key_str_part1[] =
 static const char test_json_key_str_part2[] =
     "53XxNVnxBHsYb+AYEfklR96yVi8HywjVHP34+OQZ\\nCslxoHQM8s+"
     "dBnjfScLu22JqkPv04xyxmt0QAKm9+vTdAkEA4ib7YvEAn2jXzcCI\\nEkoy2L/"
-    "XydR1GCHoacdfdAwiL2npOdnbvi4ZmdYRPY1LSTO058tQHKVXV7NLeCa3\\nAARh2QJBAMKeDAG"
-    "W303SQv2cZTdbeaLKJbB5drz3eo3j7dDKjrTD9JupixFbzcGw\\n8FZi5c8idxiwC36kbAL6HzA"
+    "XydR1GCHoacdfdAwiL2npOdnbvi4ZmdYRPY1LSTO058tQHKVXV7NLeCa3\\nAARh2QJBAMKeDA"
+    "G"
+    "W303SQv2cZTdbeaLKJbB5drz3eo3j7dDKjrTD9JupixFbzcGw\\n8FZi5c8idxiwC36kbAL6Hz"
+    "A"
     "ZoX+ofI0CQE6KCzPJTtYNqyShgKAZdJ8hwOcvCZtf\\n6z8RJm0+"
     "6YBd38lfh5j8mZd7aHFf6I17j5AQY7oPEc47TjJj/"
-    "5nZ68ECQQDvYuI3\\nLyK5fS8g0SYbmPOL9TlcHDOqwG0mrX9qpg5DC2fniXNSrrZ64GTDKdzZY"
+    "5nZ68ECQQDvYuI3\\nLyK5fS8g0SYbmPOL9TlcHDOqwG0mrX9qpg5DC2fniXNSrrZ64GTDKdzZ"
+    "Y"
     "Ap6LI9W\\nIqv4vr6y38N79TTC\\n-----END PRIVATE KEY-----\\n\", ";
 static const char test_json_key_str_part3[] =
     "\"private_key_id\": \"e6b5137873db8d2ef81e06a47289e6434ec8a165\", "

--- a/test/core/security/print_google_default_creds_token.c
+++ b/test/core/security/print_google_default_creds_token.c
@@ -73,8 +73,7 @@ int main(int argc, char **argv) {
   char *service_url = "https://test.foo.google.com/Foo";
   gpr_cmdline *cl = gpr_cmdline_create("print_google_default_creds_token");
   gpr_cmdline_add_string(cl, "service_url",
-                         "Service URL for the token request.",
-                         &service_url);
+                         "Service URL for the token request.", &service_url);
   gpr_cmdline_parse(cl, argc, argv);
 
   grpc_init();

--- a/test/core/security/secure_endpoint_test.c
+++ b/test/core/security/secure_endpoint_test.c
@@ -130,7 +130,8 @@ static grpc_endpoint_test_config configs[] = {
     {"secure_ep/tcp_socketpair",
      secure_endpoint_create_fixture_tcp_socketpair_noleftover, clean_up},
     {"secure_ep/tcp_socketpair_leftover",
-     secure_endpoint_create_fixture_tcp_socketpair_leftover, clean_up}, };
+     secure_endpoint_create_fixture_tcp_socketpair_leftover, clean_up},
+};
 
 static void verify_leftover(void *user_data, gpr_slice *slices, size_t nslices,
                             grpc_endpoint_cb_status error) {

--- a/test/core/statistics/census_log_tests.c
+++ b/test/core/statistics/census_log_tests.c
@@ -42,6 +42,7 @@
 #include <grpc/support/thd.h>
 #include <grpc/support/time.h>
 #include <grpc/support/useful.h>
+#include "test/core/util/test_config.h"
 
 /* Fills in 'record' of size 'size'. Each byte in record is filled in with the
    same value. The value is extracted from 'record' pointer. */
@@ -123,8 +124,8 @@ static void assert_log_empty(void) {
 /* Given log size and record size, computes the minimum usable space. */
 static gpr_int32 min_usable_space(size_t log_size, size_t record_size) {
   gpr_int32 usable_space;
-  gpr_int32 num_blocks = GPR_MAX(log_size / CENSUS_LOG_MAX_RECORD_SIZE,
-                                 gpr_cpu_num_cores());
+  gpr_int32 num_blocks =
+      GPR_MAX(log_size / CENSUS_LOG_MAX_RECORD_SIZE, gpr_cpu_num_cores());
   gpr_int32 waste_per_block = CENSUS_LOG_MAX_RECORD_SIZE % record_size;
   /* In the worst case, all except one core-local block is full. */
   gpr_int32 num_full_blocks = num_blocks - 1;
@@ -198,7 +199,7 @@ static void writer_thread(void* arg) {
          This should never happen for circular logs. */
       printf("   Writer stalled due to out-of-space: %d out of %d written\n",
              records_written, args->num_records);
-      gpr_sleep_until(gpr_time_add(gpr_now(), gpr_time_from_micros(10000)));
+      gpr_sleep_until(GRPC_TIMEOUT_MILLIS_TO_DEADLINE(10));
     }
   }
   /* Done. Decrement count and signal. */

--- a/test/core/statistics/hash_table_test.c
+++ b/test/core/statistics/hash_table_test.c
@@ -97,7 +97,7 @@ static void test_table_with_int_key(void) {
   for (i = 0; i < 20; ++i) {
     census_ht_key key;
     key.val = i;
-    census_ht_insert(ht, key, (void*)(gpr_intptr)i);
+    census_ht_insert(ht, key, (void*)(gpr_intptr) i);
     GPR_ASSERT(census_ht_get_size(ht) == i + 1);
   }
   for (i = 0; i < 20; i++) {
@@ -105,7 +105,7 @@ static void test_table_with_int_key(void) {
     census_ht_key key;
     key.val = i;
     val = census_ht_find(ht, key);
-    GPR_ASSERT(val == (void*)(gpr_intptr)i);
+    GPR_ASSERT(val == (void*)(gpr_intptr) i);
   }
   elements = census_ht_get_all_elements(ht, &num_elements);
   GPR_ASSERT(elements != NULL);

--- a/test/core/statistics/trace_test.c
+++ b/test/core/statistics/trace_test.c
@@ -111,7 +111,7 @@ static void mimic_trace_op_sequences(void* arg) {
     id = census_tracing_start_op();
     census_add_method_tag(id, method_name);
     /* pretend doing 1us work. */
-    gpr_sleep_until(gpr_time_add(gpr_now(), gpr_time_from_micros(1)));
+    gpr_sleep_until(GRPC_TIMEOUT_MICROS_TO_DEADLINE(1));
     census_tracing_end_op(id);
   }
   gpr_log(GPR_INFO, "End trace op sequence thread.");

--- a/test/core/support/file_test.c
+++ b/test/core/support/file_test.c
@@ -148,7 +148,6 @@ static void test_load_big_file(void) {
   gpr_slice_unref(slice);
 }
 
-
 int main(int argc, char **argv) {
   grpc_test_init(argc, argv);
   test_load_empty_file();

--- a/test/core/support/sync_test.c
+++ b/test/core/support/sync_test.c
@@ -56,9 +56,9 @@ typedef struct queue {
                  (That is, except during initialization or
                  destruction, the fields below should be accessed
                  only by a thread that holds mu.) */
-  int head;    /* Index of head of queue 0..N-1. */
-  int length;  /* Number of valid elements in queue 0..N. */
-  int elem[N]; /* elem[head .. head+length-1] are queue elements. */
+  int head;         /* Index of head of queue 0..N-1. */
+  int length;       /* Number of valid elements in queue 0..N. */
+  int elem[N];      /* elem[head .. head+length-1] are queue elements. */
 } queue;
 
 /* Initialize *q. */

--- a/test/core/surface/completion_queue_benchmark.c
+++ b/test/core/surface/completion_queue_benchmark.c
@@ -53,23 +53,23 @@ static void producer_thread(void *arg) {
   test_thread_options *opt = arg;
   int i;
 
-  gpr_event_set(&opt->on_started, (void *)(gpr_intptr)1);
+  gpr_event_set(&opt->on_started, (void *)(gpr_intptr) 1);
   GPR_ASSERT(gpr_event_wait(opt->start, gpr_inf_future));
 
   for (i = 0; i < opt->iterations; i++) {
     grpc_cq_begin_op(opt->cc, NULL, GRPC_WRITE_ACCEPTED);
-    grpc_cq_end_write_accepted(opt->cc, (void *)(gpr_intptr)1, NULL, NULL, NULL,
-                               GRPC_OP_OK);
+    grpc_cq_end_write_accepted(opt->cc, (void *)(gpr_intptr) 1, NULL, NULL,
+                               NULL, GRPC_OP_OK);
   }
 
-  gpr_event_set(&opt->on_finished, (void *)(gpr_intptr)1);
+  gpr_event_set(&opt->on_finished, (void *)(gpr_intptr) 1);
 }
 
 static void consumer_thread(void *arg) {
   test_thread_options *opt = arg;
   grpc_event *ev;
 
-  gpr_event_set(&opt->on_started, (void *)(gpr_intptr)1);
+  gpr_event_set(&opt->on_started, (void *)(gpr_intptr) 1);
   GPR_ASSERT(gpr_event_wait(opt->start, gpr_inf_future));
 
   for (;;) {
@@ -78,7 +78,7 @@ static void consumer_thread(void *arg) {
       case GRPC_WRITE_ACCEPTED:
         break;
       case GRPC_QUEUE_SHUTDOWN:
-        gpr_event_set(&opt->on_finished, (void *)(gpr_intptr)1);
+        gpr_event_set(&opt->on_finished, (void *)(gpr_intptr) 1);
         return;
       default:
         gpr_log(GPR_ERROR, "Invalid event received: %d", ev->type);
@@ -112,7 +112,7 @@ double ops_per_second(int consumers, int producers, int iterations) {
 
   /* start the benchmark */
   t_start = gpr_now();
-  gpr_event_set(&start, (void *)(gpr_intptr)1);
+  gpr_event_set(&start, (void *)(gpr_intptr) 1);
 
   /* wait for producers to finish */
   for (i = 0; i < producers; i++) {

--- a/test/core/surface/completion_queue_test.c
+++ b/test/core/surface/completion_queue_test.c
@@ -248,7 +248,7 @@ typedef struct test_thread_options {
 } test_thread_options;
 
 gpr_timespec ten_seconds_time(void) {
-  return gpr_time_add(gpr_now(), gpr_time_from_micros(10 * 1000000));
+  return GRPC_TIMEOUT_SECONDS_TO_DEADLINE(1);
 }
 
 static void producer_thread(void *arg) {
@@ -256,7 +256,7 @@ static void producer_thread(void *arg) {
   int i;
 
   gpr_log(GPR_INFO, "producer %d started", opt->id);
-  gpr_event_set(&opt->on_started, (void *)(gpr_intptr)1);
+  gpr_event_set(&opt->on_started, (void *)(gpr_intptr) 1);
   GPR_ASSERT(gpr_event_wait(opt->phase1, ten_seconds_time()));
 
   gpr_log(GPR_INFO, "producer %d phase 1", opt->id);
@@ -265,18 +265,18 @@ static void producer_thread(void *arg) {
   }
 
   gpr_log(GPR_INFO, "producer %d phase 1 done", opt->id);
-  gpr_event_set(&opt->on_phase1_done, (void *)(gpr_intptr)1);
+  gpr_event_set(&opt->on_phase1_done, (void *)(gpr_intptr) 1);
   GPR_ASSERT(gpr_event_wait(opt->phase2, ten_seconds_time()));
 
   gpr_log(GPR_INFO, "producer %d phase 2", opt->id);
   for (i = 0; i < TEST_THREAD_EVENTS; i++) {
-    grpc_cq_end_write_accepted(opt->cc, (void *)(gpr_intptr)1, NULL, NULL, NULL,
-                               GRPC_OP_OK);
+    grpc_cq_end_write_accepted(opt->cc, (void *)(gpr_intptr) 1, NULL, NULL,
+                               NULL, GRPC_OP_OK);
     opt->events_triggered++;
   }
 
   gpr_log(GPR_INFO, "producer %d phase 2 done", opt->id);
-  gpr_event_set(&opt->on_finished, (void *)(gpr_intptr)1);
+  gpr_event_set(&opt->on_finished, (void *)(gpr_intptr) 1);
 }
 
 static void consumer_thread(void *arg) {
@@ -284,13 +284,13 @@ static void consumer_thread(void *arg) {
   grpc_event *ev;
 
   gpr_log(GPR_INFO, "consumer %d started", opt->id);
-  gpr_event_set(&opt->on_started, (void *)(gpr_intptr)1);
+  gpr_event_set(&opt->on_started, (void *)(gpr_intptr) 1);
   GPR_ASSERT(gpr_event_wait(opt->phase1, ten_seconds_time()));
 
   gpr_log(GPR_INFO, "consumer %d phase 1", opt->id);
 
   gpr_log(GPR_INFO, "consumer %d phase 1 done", opt->id);
-  gpr_event_set(&opt->on_phase1_done, (void *)(gpr_intptr)1);
+  gpr_event_set(&opt->on_phase1_done, (void *)(gpr_intptr) 1);
   GPR_ASSERT(gpr_event_wait(opt->phase2, ten_seconds_time()));
 
   gpr_log(GPR_INFO, "consumer %d phase 2", opt->id);
@@ -305,7 +305,7 @@ static void consumer_thread(void *arg) {
         break;
       case GRPC_QUEUE_SHUTDOWN:
         gpr_log(GPR_INFO, "consumer %d phase 2 done", opt->id);
-        gpr_event_set(&opt->on_finished, (void *)(gpr_intptr)1);
+        gpr_event_set(&opt->on_finished, (void *)(gpr_intptr) 1);
         grpc_event_finish(ev);
         return;
       default:
@@ -350,7 +350,7 @@ static void test_threading(int producers, int consumers) {
   /* start phase1: producers will pre-declare all operations they will
      complete */
   gpr_log(GPR_INFO, "start phase 1");
-  gpr_event_set(&phase1, (void *)(gpr_intptr)1);
+  gpr_event_set(&phase1, (void *)(gpr_intptr) 1);
 
   gpr_log(GPR_INFO, "wait phase 1");
   for (i = 0; i < producers + consumers; i++) {
@@ -360,7 +360,7 @@ static void test_threading(int producers, int consumers) {
 
   /* start phase2: operations will complete, and consumers will consume them */
   gpr_log(GPR_INFO, "start phase 2");
-  gpr_event_set(&phase2, (void *)(gpr_intptr)1);
+  gpr_event_set(&phase2, (void *)(gpr_intptr) 1);
 
   /* in parallel, we shutdown the completion channel - all events should still
      be consumed */

--- a/test/core/surface/lame_client_test.c
+++ b/test/core/surface/lame_client_test.c
@@ -51,9 +51,8 @@ int main(int argc, char **argv) {
 
   chan = grpc_lame_client_channel_create();
   GPR_ASSERT(chan);
-  call = grpc_channel_create_call_old(
-      chan, "/Foo", "anywhere",
-      gpr_time_add(gpr_now(), gpr_time_from_seconds(100)));
+  call = grpc_channel_create_call_old(chan, "/Foo", "anywhere",
+                                      GRPC_TIMEOUT_SECONDS_TO_DEADLINE(100));
   GPR_ASSERT(call);
   cq = grpc_completion_queue_create();
   cqv = cq_verifier_create(cq);

--- a/test/core/transport/chttp2/hpack_parser_test.c
+++ b/test/core/transport/chttp2/hpack_parser_test.c
@@ -42,9 +42,7 @@
 #include "test/core/util/slice_splitter.h"
 #include "test/core/util/test_config.h"
 
-typedef struct {
-  va_list args;
-} test_checker;
+typedef struct { va_list args; } test_checker;
 
 static void onhdr(void *ud, grpc_mdelem *md) {
   const char *ekey, *evalue;

--- a/test/core/transport/chttp2/stream_map_test.c
+++ b/test/core/transport/chttp2/stream_map_test.c
@@ -93,7 +93,7 @@ static void test_basic_add_find(size_t n) {
   grpc_chttp2_stream_map_init(&map, 8);
   GPR_ASSERT(0 == grpc_chttp2_stream_map_size(&map));
   for (i = 1; i <= n; i++) {
-    grpc_chttp2_stream_map_add(&map, i, (void *)(gpr_uintptr)i);
+    grpc_chttp2_stream_map_add(&map, i, (void *)(gpr_uintptr) i);
   }
   GPR_ASSERT(n == grpc_chttp2_stream_map_size(&map));
   GPR_ASSERT(NULL == grpc_chttp2_stream_map_find(&map, 0));
@@ -148,7 +148,7 @@ static void test_delete_evens_sweep(size_t n) {
 
   grpc_chttp2_stream_map_init(&map, 8);
   for (i = 1; i <= n; i++) {
-    grpc_chttp2_stream_map_add(&map, i, (void *)(gpr_uintptr)i);
+    grpc_chttp2_stream_map_add(&map, i, (void *)(gpr_uintptr) i);
   }
   for (i = 1; i <= n; i++) {
     if ((i & 1) == 0) {
@@ -170,7 +170,7 @@ static void test_delete_evens_incremental(size_t n) {
 
   grpc_chttp2_stream_map_init(&map, 8);
   for (i = 1; i <= n; i++) {
-    grpc_chttp2_stream_map_add(&map, i, (void *)(gpr_uintptr)i);
+    grpc_chttp2_stream_map_add(&map, i, (void *)(gpr_uintptr) i);
     if ((i & 1) == 0) {
       grpc_chttp2_stream_map_delete(&map, i);
     }

--- a/test/core/transport/chttp2_transport_end2end_test.c
+++ b/test/core/transport/chttp2_transport_end2end_test.c
@@ -100,7 +100,8 @@ grpc_transport_test_config fixture_configs[] = {
     {"chttp2_on_socketpair/medium",
      create_http2_transport_for_test_medium_slices},
     {"chttp2_on_socketpair/large",
-     create_http2_transport_for_test_large_slices}, };
+     create_http2_transport_for_test_large_slices},
+};
 
 /* Driver function: run the test suite for each test configuration */
 int main(int argc, char **argv) {

--- a/test/core/tsi/transport_security_test.c
+++ b/test/core/tsi/transport_security_test.c
@@ -189,9 +189,9 @@ typedef struct name_list {
 } name_list;
 
 typedef struct {
-   size_t name_count;
-   char *buffer;
-   name_list *names;
+  size_t name_count;
+  char *buffer;
+  name_list *names;
 } parsed_dns_names;
 
 name_list *name_list_add(const char *n) {

--- a/test/core/util/port_posix.c
+++ b/test/core/util/port_posix.c
@@ -113,11 +113,12 @@ int grpc_pick_unused_port(void) {
 
   /* Type of port to first pick in next iteration */
   int is_tcp = 1;
-  int try = 0;
+  int try
+    = 0;
 
   for (;;) {
-    int port =
-        try < NUM_RANDOM_PORTS_TO_PICK ? rand() % (65536 - 30000) + 30000 : 0;
+    int port = try
+      < NUM_RANDOM_PORTS_TO_PICK ? rand() % (65536 - 30000) + 30000 : 0;
     if (!is_port_available(&port, is_tcp)) {
       continue;
     }

--- a/test/core/util/test_config.h
+++ b/test/core/util/test_config.h
@@ -34,9 +34,23 @@
 #ifndef __GRPC_TEST_UTIL_TEST_CONFIG_H__
 #define __GRPC_TEST_UTIL_TEST_CONFIG_H__
 
+#include <grpc/support/time.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /*  __cplusplus */
+
+#ifndef GRPC_TEST_SLOWDOWN_FACTOR
+#define GRPC_TEST_SLOWDOWN_FACTOR 1.0
+#endif
+
+#define GRPC_TIMEOUT_SECONDS_TO_DEADLINE(x) \
+  gpr_time_add(gpr_now(),                   \
+               gpr_time_from_micros(GRPC_TEST_SLOWDOWN_FACTOR * 1e6 * (x)))
+
+#define GRPC_TIMEOUT_MILLIS_TO_DEADLINE(x) \
+  gpr_time_add(gpr_now(),                   \
+               gpr_time_from_micros(GRPC_TEST_SLOWDOWN_FACTOR * 1e3 * (x)))
 
 void grpc_test_init(int argc, char **argv);
 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -232,6 +232,7 @@ class TestCache(object):
 
   def finished(self, cmdline, bin_hash):
     self._last_successful_run[cmdline] = bin_hash
+    self.save()
 
   def dump(self):
     return [{'cmdline': k, 'hash': v}
@@ -286,7 +287,6 @@ if forever:
                      'All tests are now passing properly',
                      do_newline=True)
     jobset.message('IDLE', 'No change detected')
-    test_cache.save()
     while not have_files_changed():
       time.sleep(1)
 else:
@@ -297,5 +297,4 @@ else:
     jobset.message('SUCCESS', 'All tests passed', do_newline=True)
   else:
     jobset.message('FAILED', 'Some tests failed', do_newline=True)
-  test_cache.save()
   sys.exit(result)


### PR DESCRIPTION
Dramatically lowers (eliminates maybe?) false negatives from ?SAN runs.