### PR TITLE
Support ruby 2.2.0

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -77,7 +77,6 @@ end
 
 dir_config('grpc', HEADER_DIRS, LIB_DIRS)
 
-$CFLAGS << ' -std=c89 '
 $CFLAGS << ' -Wno-implicit-function-declaration '
 $CFLAGS << ' -Wno-pointer-sign '
 $CFLAGS << ' -Wno-return-type '

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -119,12 +119,12 @@ gpr_timespec grpc_rb_time_timeval(VALUE time, int interval) {
       break;
 
     case T_FLOAT:
-      if (interval && RFLOAT(time)->float_value < 0.0)
+      if (interval && RFLOAT_VALUE(time) < 0.0)
         rb_raise(rb_eArgError, "%s must be positive", tstr);
       else {
         double f, d;
 
-        d = modf(RFLOAT(time)->float_value, &f);
+        d = modf(RFLOAT_VALUE(time), &f);
         if (d < 0) {
           d += 1;
           f -= 1;
@@ -132,7 +132,7 @@ gpr_timespec grpc_rb_time_timeval(VALUE time, int interval) {
         t.tv_sec = (time_t)f;
         if (f != t.tv_sec) {
           rb_raise(rb_eRangeError, "%f out of Time range",
-                   RFLOAT(time)->float_value);
+                   RFLOAT_VALUE(time));
         }
         t.tv_nsec = (time_t)(d * 1e9 + 0.5);
       }


### PR DESCRIPTION
I got following error when compiling ruby ext on ruby-2.2.0.

```
"gcc -o conftest -I/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/x86_64-linux -I/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/backward -I/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0 -I. -I/opt/local/include -I/usr/local/include -I/home/mattn/.rbenv/versions/2.2.0/include     -O3 -fno-fast-math -ggdb3 -Wall -Wextra -Wno-unused-parameter -Wno-parentheses -Wno-long-long -Wno-missing-field-initializers -Wunused-variable -Wpointer-arith -Wwrite-strings -Wdeclaration-after-statement -Wimplicit-function-declaration -Wdeprecated-declarations -Wno-packed-bitfield-compat -std=c89  -Wno-implicit-function-declaration  -Wno-pointer-sign  -Wno-return-type  -Wall  -pedantic  conftest.c  -L/opt/local/lib -Wl,-R/opt/local/lib -L/usr/local/lib -Wl,-R/usr/local/lib -L/home/mattn/.rbenv/versions/2.2.0/lib -Wl,-R/home/mattn/.rbenv/versions/2.2.0/lib -L. -L/home/mattn/.rbenv/versions/2.2.0/lib -Wl,-R/home/mattn/.rbenv/versions/2.2.0/lib -L. -L/home/mattn/.rbenv/versions/2.2.0/lib  -fstack-protector -rdynamic -Wl,-export-dynamic -lgrpc -lgpr -ldl     -Wl,-R/home/mattn/.rbenv/versions/2.2.0/lib -L/home/mattn/.rbenv/versions/2.2.0/lib -lruby-static  -lpthread -ldl -lcrypt -lm   -lc"
In file included from /home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby.h:33:0,
                 from conftest.c:1:
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:309:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘int’
 static inline int
               ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:489:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘int’
 static inline int rb_type(VALUE obj);
               ^
In file included from /home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby.h:33:0,
                 from conftest.c:1:
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:610:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘long’
 static inline long
               ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:619:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘unsigned’
 static inline unsigned long
               ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:633:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘int’
 static inline int
               ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:659:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘short’
 static inline short
               ^
In file included from /home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:29:0,
                 from /home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby.h:33,
                 from conftest.c:1:
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/defines.h:138:20: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘long’
 # define LONG_LONG long long
                    ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:674:15: note: in expansion of macro ‘LONG_LONG’
 static inline LONG_LONG
               ^
In file included from /home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby.h:33:0,
                 from conftest.c:1:
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1153:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘void’
 static inline void
               ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1170:1: error: unknown type name ‘inline’
 RUBY_UNTYPED_DATA_FUNC(static inline VALUE rb_data_object_alloc_warning(VALUE,void*,RUBY_DATA_FUNC,RUBY_DATA_FUNC));
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1170:44: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘rb_data_object_alloc_warning’
 RUBY_UNTYPED_DATA_FUNC(static inline VALUE rb_data_object_alloc_warning(VALUE,void*,RUBY_DATA_FUNC,RUBY_DATA_FUNC));
                                            ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1165:39: note: in definition of macro ‘RUBY_UNTYPED_DATA_FUNC’
 # define RUBY_UNTYPED_DATA_FUNC(func) func __attribute__((warning("untyped Data is unsafe; use TypedData instead")))
                                       ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1171:38: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘void’
 RUBY_UNTYPED_DATA_FUNC(static inline void *rb_data_object_get_warning(VALUE));
                                      ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1165:39: note: in definition of macro ‘RUBY_UNTYPED_DATA_FUNC’
 # define RUBY_UNTYPED_DATA_FUNC(func) func __attribute__((warning("untyped Data is unsafe; use TypedData instead")))
                                       ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1173:1: error: unknown type name ‘inline’
 static inline VALUE
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1174:1: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘rb_data_object_alloc_warning’
 rb_data_object_alloc_warning(VALUE klass, void *ptr, RUBY_DATA_FUNC mark, RUBY_DATA_FUNC free)
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1188:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘void’
 static inline void *
               ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1195:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘void’
 static inline void *
               ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1249:1: error: unknown type name ‘inline’
 static inline VALUE
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1250:1: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘rb_obj_wb_unprotect’
 rb_obj_wb_unprotect(VALUE x, RB_UNUSED_VAR(const char *filename), RB_UNUSED_VAR(int line))
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1261:1: error: unknown type name ‘inline’
 static inline VALUE
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1262:1: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘rb_obj_written’
 rb_obj_written(VALUE a, RB_UNUSED_VAR(VALUE oldv), VALUE b, RB_UNUSED_VAR(const char *filename), RB_UNUSED_VAR(int line))
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1281:1: error: unknown type name ‘inline’
 static inline VALUE
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1282:1: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘rb_obj_write’
 rb_obj_write(VALUE a, VALUE *slot, VALUE b, RB_UNUSED_VAR(const char *filename), RB_UNUSED_VAR(int line))
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1321:1: error: unknown type name ‘inline’
 static inline VALUE
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1322:1: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘rb_long2num_inline’
 rb_long2num_inline(long v)
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1331:1: error: unknown type name ‘inline’
 static inline VALUE
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1332:1: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘rb_ulong2num_inline’
 rb_ulong2num_inline(unsigned long v)
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1341:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘char’
 static inline char
               ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1657:1: error: unknown type name ‘inline’
 static inline VALUE
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1658:1: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘rb_class_of’
 rb_class_of(VALUE obj)
 ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1673:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘int’
 static inline int
               ^
In file included from /home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1710:0,
                 from /home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby.h:33,
                 from conftest.c:1:
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/intern.h:300:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘void’
 static inline void
               ^
In file included from /home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:24:0,
                 from /home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby.h:33,
                 from conftest.c:1:
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/intern.h:376:26: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘void’
 DEPRECATED(static inline void rb_disable_super(void));
                          ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/x86_64-linux/ruby/config.h:124:52: note: in definition of macro ‘DEPRECATED’
 #define DEPRECATED(x) __attribute__ ((deprecated)) x
                                                    ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/intern.h:377:26: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘void’
 DEPRECATED(static inline void rb_enable_super(void));
                          ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/x86_64-linux/ruby/config.h:124:52: note: in definition of macro ‘DEPRECATED’
 #define DEPRECATED(x) __attribute__ ((deprecated)) x
                                                    ^
In file included from /home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/ruby.h:1710:0,
                 from /home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby.h:33,
                 from conftest.c:1:
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/intern.h:378:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘void’
 static inline void rb_disable_super(void)
               ^
/home/mattn/.rbenv/versions/2.2.0/include/ruby-2.2.0/ruby/intern.h:382:15: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘void’
 static inline void rb_enable_super(void)
               ^
checked program was:
/* begin */
1: #include "ruby.h"
2: 
3: int main(int argc, char **argv)
4: {
5:   return 0;
6: }
/* end */
```

```
$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/4.8/lto-wrapper
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 4.8.2-19ubuntu1' --with-bugurl=file:///usr/share/doc/gcc-4.8/README.Bugs --enable-languages=c,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-4.8 --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --with-gxx-include-dir=/usr/include/c++/4.8 --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --enable-gnu-unique-object --disable-libmudflap --enable-plugin --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-4.8-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-4.8-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-4.8-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --enable-objc-gc --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 4.8.2 (Ubuntu 4.8.2-19ubuntu1)
```
```
$ ruby -v
ruby 2.2.0p0 (2014-12-25 revision 49005) [x86_64-linux]
```
This ruby is installed via rbenv.
The error is caused by extconf.rb expect `-std=c89`. But since ruby.h contains `static inline int`, it's not c89.
Below's change are:

* remove `-std=c89`
* use `RFLOAT_VALUE(x)` instead of `RFLOAT(x)->float_value` for compatible

