### PR TITLE
Suppressing a data race in OpenSSL

### DIFF
--- a/tools/tsan_suppressions.txt
+++ b/tools/tsan_suppressions.txt
@@ -1,4 +1,8 @@
 # OPENSSL_cleanse does racy access to a global
 race:OPENSSL_cleanse
 race:cleanse_ctr
+# these are legitimate races in OpenSSL, and it appears those folks are looking at it
+# https://www.mail-archive.com/openssl-dev@openssl.org/msg09019.html
+race:ssleay_rand_add
+race:ssleay_rand_bytes
 


### PR DESCRIPTION
This race is (probably) legit on some platforms, but (likely) safe on Intel at least.
For now, since it's a little outside our control, I'm suppressing it to focus on any remaining races in our code.