### PR TITLE
Remove HTTP mappings from status.h

### DIFF
--- a/include/grpc++/status_code_enum.h
+++ b/include/grpc++/status_code_enum.h
@@ -37,51 +37,37 @@
 namespace grpc {
 
 enum StatusCode {
-  /* Not an error; returned on success
-
-     HTTP Mapping: 200 OK */
+  /* Not an error; returned on success */
   OK = 0,
 
-  /* The operation was cancelled (typically by the caller).
-
-     HTTP Mapping: 499 Client Closed Request */
+  /* The operation was cancelled (typically by the caller). */
   CANCELLED = 1,
 
   /* Unknown error.  An example of where this error may be returned is
      if a Status value received from another address space belongs to
      an error-space that is not known in this address space.  Also
      errors raised by APIs that do not return enough error information
-     may be converted to this error.
-
-     HTTP Mapping: 500 Internal Server Error */
+     may be converted to this error. */
   UNKNOWN = 2,
 
   /* Client specified an invalid argument.  Note that this differs
      from FAILED_PRECONDITION.  INVALID_ARGUMENT indicates arguments
      that are problematic regardless of the state of the system
-     (e.g., a malformed file name).
-
-     HTTP Mapping: 400 Bad Request */
+     (e.g., a malformed file name). */
   INVALID_ARGUMENT = 3,
 
   /* Deadline expired before operation could complete.  For operations
      that change the state of the system, this error may be returned
      even if the operation has completed successfully.  For example, a
      successful response from a server could have been delayed long
-     enough for the deadline to expire.
-
-     HTTP Mapping: 504 Gateway Timeout */
+     enough for the deadline to expire. */
   DEADLINE_EXCEEDED = 4,
 
-  /* Some requested entity (e.g., file or directory) was not found.
-
-     HTTP Mapping: 404 Not Found */
+  /* Some requested entity (e.g., file or directory) was not found. */
   NOT_FOUND = 5,
 
   /* Some entity that we attempted to create (e.g., file or directory)
-     already exists.
-
-     HTTP Mapping: 409 Conflict */
+     already exists. */
   ALREADY_EXISTS = 6,
 
   /* The caller does not have permission to execute the specified
@@ -89,21 +75,15 @@ enum StatusCode {
      caused by exhausting some resource (use RESOURCE_EXHAUSTED
      instead for those errors).  PERMISSION_DENIED must not be
      used if the caller can not be identified (use UNAUTHENTICATED
-     instead for those errors).
-
-     HTTP Mapping: 403 Forbidden */
+     instead for those errors). */
   PERMISSION_DENIED = 7,
 
   /* The request does not have valid authentication credentials for the
-     operation.
-
-     HTTP Mapping: 401 Unauthorized */
+     operation. */
   UNAUTHENTICATED = 16,
 
   /* Some resource has been exhausted, perhaps a per-user quota, or
-     perhaps the entire file system is out of space.
-
-     HTTP Mapping: 429 Too Many Requests */
+     perhaps the entire file system is out of space. */
   RESOURCE_EXHAUSTED = 8,
 
   /* Operation was rejected because the system is not in a state
@@ -124,23 +104,14 @@ enum StatusCode {
       (d) Use FAILED_PRECONDITION if the client performs conditional
           REST Get/Update/Delete on a resource and the resource on the
           server does not match the condition. E.g., conflicting
-          read-modify-write on the same resource.
-
-     HTTP Mapping: 400 Bad Request
-
-     NOTE: HTTP spec says 412 Precondition Failed should only be used if
-     the request contains Etag related headers. So if the server does see
-     Etag related headers in the request, it may choose to return 412
-     instead of 400 for this error code. */
+          read-modify-write on the same resource. */
   FAILED_PRECONDITION = 9,
 
   /* The operation was aborted, typically due to a concurrency issue
      like sequencer check failures, transaction aborts, etc.
 
      See litmus test above for deciding between FAILED_PRECONDITION,
-     ABORTED, and UNAVAILABLE.
-
-     HTTP Mapping: 409 Conflict */
+     ABORTED, and UNAVAILABLE. */
   ABORTED = 10,
 
   /* Operation was attempted past the valid range.  E.g., seeking or
@@ -157,21 +128,15 @@ enum StatusCode {
      OUT_OF_RANGE.  We recommend using OUT_OF_RANGE (the more specific
      error) when it applies so that callers who are iterating through
      a space can easily look for an OUT_OF_RANGE error to detect when
-     they are done.
-
-     HTTP Mapping: 400 Bad Request */
+     they are done. */
   OUT_OF_RANGE = 11,
 
-  /* Operation is not implemented or not supported/enabled in this service.
-
-     HTTP Mapping: 501 Not Implemented */
+  /* Operation is not implemented or not supported/enabled in this service. */
   UNIMPLEMENTED = 12,
 
   /* Internal errors.  Means some invariants expected by underlying
      system has been broken.  If you see one of these errors,
-     something is very broken.
-
-     HTTP Mapping: 500 Internal Server Error */
+     something is very broken. */
   INTERNAL = 13,
 
   /* The service is currently unavailable.  This is a most likely a
@@ -179,14 +144,10 @@ enum StatusCode {
      a backoff.
 
      See litmus test above for deciding between FAILED_PRECONDITION,
-     ABORTED, and UNAVAILABLE.
-
-     HTTP Mapping: 503 Service Unavailable */
+     ABORTED, and UNAVAILABLE. */
   UNAVAILABLE = 14,
 
-  /* Unrecoverable data loss or corruption.
-
-     HTTP Mapping: 500 Internal Server Error */
+  /* Unrecoverable data loss or corruption. */
   DATA_LOSS = 15,
 
   /* Force users to include a default branch: */

--- a/include/grpc/status.h
+++ b/include/grpc/status.h
@@ -39,51 +39,37 @@ extern "C" {
 #endif
 
 typedef enum {
-  /* Not an error; returned on success
-
-     HTTP Mapping: 200 OK */
+  /* Not an error; returned on success */
   GRPC_STATUS_OK = 0,
 
-  /* The operation was cancelled (typically by the caller).
-
-     HTTP Mapping: 499 Client Closed Request */
+  /* The operation was cancelled (typically by the caller). */
   GRPC_STATUS_CANCELLED = 1,
 
   /* Unknown error.  An example of where this error may be returned is
      if a Status value received from another address space belongs to
      an error-space that is not known in this address space.  Also
      errors raised by APIs that do not return enough error information
-     may be converted to this error.
-
-     HTTP Mapping: 500 Internal Server Error */
+     may be converted to this error. */
   GRPC_STATUS_UNKNOWN = 2,
 
   /* Client specified an invalid argument.  Note that this differs
      from FAILED_PRECONDITION.  INVALID_ARGUMENT indicates arguments
      that are problematic regardless of the state of the system
-     (e.g., a malformed file name).
-
-     HTTP Mapping: 400 Bad Request */
+     (e.g., a malformed file name). */
   GRPC_STATUS_INVALID_ARGUMENT = 3,
 
   /* Deadline expired before operation could complete.  For operations
      that change the state of the system, this error may be returned
      even if the operation has completed successfully.  For example, a
      successful response from a server could have been delayed long
-     enough for the deadline to expire.
-
-     HTTP Mapping: 504 Gateway Timeout */
+     enough for the deadline to expire. */
   GRPC_STATUS_DEADLINE_EXCEEDED = 4,
 
-  /* Some requested entity (e.g., file or directory) was not found.
-
-     HTTP Mapping: 404 Not Found */
+  /* Some requested entity (e.g., file or directory) was not found. */
   GRPC_STATUS_NOT_FOUND = 5,
 
   /* Some entity that we attempted to create (e.g., file or directory)
-     already exists.
-
-     HTTP Mapping: 409 Conflict */
+     already exists. */
   GRPC_STATUS_ALREADY_EXISTS = 6,
 
   /* The caller does not have permission to execute the specified
@@ -91,21 +77,15 @@ typedef enum {
      caused by exhausting some resource (use RESOURCE_EXHAUSTED
      instead for those errors).  PERMISSION_DENIED must not be
      used if the caller can not be identified (use UNAUTHENTICATED
-     instead for those errors).
-
-     HTTP Mapping: 403 Forbidden */
+     instead for those errors). */
   GRPC_STATUS_PERMISSION_DENIED = 7,
 
   /* The request does not have valid authentication credentials for the
-     operation.
-
-     HTTP Mapping: 401 Unauthorized */
+     operation. */
   GRPC_STATUS_UNAUTHENTICATED = 16,
 
   /* Some resource has been exhausted, perhaps a per-user quota, or
-     perhaps the entire file system is out of space.
-
-     HTTP Mapping: 429 Too Many Requests */
+     perhaps the entire file system is out of space. */
   GRPC_STATUS_RESOURCE_EXHAUSTED = 8,
 
   /* Operation was rejected because the system is not in a state
@@ -126,23 +106,14 @@ typedef enum {
       (d) Use FAILED_PRECONDITION if the client performs conditional
           REST Get/Update/Delete on a resource and the resource on the
           server does not match the condition. E.g., conflicting
-          read-modify-write on the same resource.
-
-     HTTP Mapping: 400 Bad Request
-
-     NOTE: HTTP spec says 412 Precondition Failed should only be used if
-     the request contains Etag related headers. So if the server does see
-     Etag related headers in the request, it may choose to return 412
-     instead of 400 for this error code. */
+          read-modify-write on the same resource. */
   GRPC_STATUS_FAILED_PRECONDITION = 9,
 
   /* The operation was aborted, typically due to a concurrency issue
      like sequencer check failures, transaction aborts, etc.
 
      See litmus test above for deciding between FAILED_PRECONDITION,
-     ABORTED, and UNAVAILABLE.
-
-     HTTP Mapping: 409 Conflict */
+     ABORTED, and UNAVAILABLE. */
   GRPC_STATUS_ABORTED = 10,
 
   /* Operation was attempted past the valid range.  E.g., seeking or
@@ -159,21 +130,15 @@ typedef enum {
      OUT_OF_RANGE.  We recommend using OUT_OF_RANGE (the more specific
      error) when it applies so that callers who are iterating through
      a space can easily look for an OUT_OF_RANGE error to detect when
-     they are done.
-
-     HTTP Mapping: 400 Bad Request */
+     they are done. */
   GRPC_STATUS_OUT_OF_RANGE = 11,
 
-  /* Operation is not implemented or not supported/enabled in this service.
-
-     HTTP Mapping: 501 Not Implemented */
+  /* Operation is not implemented or not supported/enabled in this service. */
   GRPC_STATUS_UNIMPLEMENTED = 12,
 
   /* Internal errors.  Means some invariants expected by underlying
      system has been broken.  If you see one of these errors,
-     something is very broken.
-
-     HTTP Mapping: 500 Internal Server Error */
+     something is very broken. */
   GRPC_STATUS_INTERNAL = 13,
 
   /* The service is currently unavailable.  This is a most likely a
@@ -181,14 +146,10 @@ typedef enum {
      a backoff.
 
      See litmus test above for deciding between FAILED_PRECONDITION,
-     ABORTED, and UNAVAILABLE.
-
-     HTTP Mapping: 503 Service Unavailable */
+     ABORTED, and UNAVAILABLE. */
   GRPC_STATUS_UNAVAILABLE = 14,
 
-  /* Unrecoverable data loss or corruption.
-
-     HTTP Mapping: 500 Internal Server Error */
+  /* Unrecoverable data loss or corruption. */
   GRPC_STATUS_DATA_LOSS = 15,
 
   /* Force users to include a default branch: */

--- a/src/csharp/Grpc.Core/StatusCode.cs
+++ b/src/csharp/Grpc.Core/StatusCode.cs
@@ -41,64 +41,44 @@ namespace Grpc.Core
     /// </summary>
     public enum StatusCode
     {
-        /* Not an error; returned on success
-
-     HTTP Mapping: 200 OK */
+        /* Not an error; returned on success */
         OK = 0,
-        /* The operation was cancelled (typically by the caller).
-
-     HTTP Mapping: 499 Client Closed Request */
+        /* The operation was cancelled (typically by the caller). */
         Cancelled = 1,
         /* Unknown error.  An example of where this error may be returned is
      if a Status value received from another address space belongs to
      an error-space that is not known in this address space.  Also
      errors raised by APIs that do not return enough error information
-     may be converted to this error.
-
-     HTTP Mapping: 500 Internal Server Error */
+     may be converted to this error. */
         Unknown = 2,
         /* Client specified an invalid argument.  Note that this differs
      from FAILED_PRECONDITION.  INVALID_ARGUMENT indicates arguments
      that are problematic regardless of the state of the system
-     (e.g., a malformed file name).
-
-     HTTP Mapping: 400 Bad Request */
+     (e.g., a malformed file name). */
         InvalidArgument = 3,
         /* Deadline expired before operation could complete.  For operations
      that change the state of the system, this error may be returned
      even if the operation has completed successfully.  For example, a
      successful response from a server could have been delayed long
-     enough for the deadline to expire.
-
-     HTTP Mapping: 504 Gateway Timeout */
+     enough for the deadline to expire. */
         DeadlineExceeded = 4,
-        /* Some requested entity (e.g., file or directory) was not found.
-
-     HTTP Mapping: 404 Not Found */
+        /* Some requested entity (e.g., file or directory) was not found. */
         NotFound = 5,
         /* Some entity that we attempted to create (e.g., file or directory)
-     already exists.
-
-     HTTP Mapping: 409 Conflict */
+     already exists. */
         AlreadyExists = 6,
         /* The caller does not have permission to execute the specified
      operation.  PERMISSION_DENIED must not be used for rejections
      caused by exhausting some resource (use RESOURCE_EXHAUSTED
      instead for those errors).  PERMISSION_DENIED must not be
      used if the caller can not be identified (use UNAUTHENTICATED
-     instead for those errors).
-
-     HTTP Mapping: 403 Forbidden */
+     instead for those errors). */
         PermissionDenied = 7,
         /* The request does not have valid authentication credentials for the
-     operation.
-
-     HTTP Mapping: 401 Unauthorized */
+     operation. */
         Unauthenticated = 16,
         /* Some resource has been exhausted, perhaps a per-user quota, or
-     perhaps the entire file system is out of space.
-
-     HTTP Mapping: 429 Too Many Requests */
+     perhaps the entire file system is out of space. */
         ResourceExhausted = 8,
         /* Operation was rejected because the system is not in a state
      required for the operation's execution.  For example, directory
@@ -118,22 +98,13 @@ namespace Grpc.Core
       (d) Use FAILED_PRECONDITION if the client performs conditional
           REST Get/Update/Delete on a resource and the resource on the
           server does not match the condition. E.g., conflicting
-          read-modify-write on the same resource.
-
-     HTTP Mapping: 400 Bad Request
-
-     NOTE: HTTP spec says 412 Precondition Failed should only be used if
-     the request contains Etag related headers. So if the server does see
-     Etag related headers in the request, it may choose to return 412
-     instead of 400 for this error code. */
+          read-modify-write on the same resource. */
         FailedPrecondition = 9,
         /* The operation was aborted, typically due to a concurrency issue
      like sequencer check failures, transaction aborts, etc.
 
      See litmus test above for deciding between FAILED_PRECONDITION,
-     ABORTED, and UNAVAILABLE.
-
-     HTTP Mapping: 409 Conflict */
+     ABORTED, and UNAVAILABLE. */
         Aborted = 10,
         /* Operation was attempted past the valid range.  E.g., seeking or
      reading past end of file.
@@ -149,32 +120,22 @@ namespace Grpc.Core
      OUT_OF_RANGE.  We recommend using OUT_OF_RANGE (the more specific
      error) when it applies so that callers who are iterating through
      a space can easily look for an OUT_OF_RANGE error to detect when
-     they are done.
-
-     HTTP Mapping: 400 Bad Request */
+     they are done. */
         OutOfRange = 11,
-        /* Operation is not implemented or not supported/enabled in this service.
-
-     HTTP Mapping: 501 Not Implemented */
+        /* Operation is not implemented or not supported/enabled in this service. */
         Unimplemented = 12,
         /* Internal errors.  Means some invariants expected by underlying
      system has been broken.  If you see one of these errors,
-     something is very broken.
-
-     HTTP Mapping: 500 Internal Server Error */
+     something is very broken. */
         Internal = 13,
         /* The service is currently unavailable.  This is a most likely a
      transient condition and may be corrected by retrying with
      a backoff.
 
      See litmus test above for deciding between FAILED_PRECONDITION,
-     ABORTED, and UNAVAILABLE.
-
-     HTTP Mapping: 503 Service Unavailable */
+     ABORTED, and UNAVAILABLE. */
         Unavailable = 14,
-        /* Unrecoverable data loss or corruption.
-
-     HTTP Mapping: 500 Internal Server Error */
+        /* Unrecoverable data loss or corruption. */
         DataLoss = 15
     }
 }


### PR DESCRIPTION
The mappings are a combination of useless, inaccurate, and harmful.
Leave them out until they are helpful and correct.

Fundamental issues:
 - If in need of mappings, a user would need HTTP -> gRPC code mappings.
   But the docs don't provide that since the mappings are not 1:1.
 - There _is no_ gRPC -> HTTP code mapping taking place in gRPC. This
   may change in the future, but until then the docs are misleading.

But even given those were resolved, there are additional issues. Two
obvious examples:
 - 501 Not Implemented is refering to HTTP methods such as GET and POST
   not being implement. That should not be used for gRPC methods not
   found (UNIMPLEMENTED).
 - 404 Not Found is for when the resource is not found. In gRPC, the
   resource is the gRPC method, not the parameters (NOT_FOUND). If there
   is a REST conversion layer on top of gRPC, then 404 would be
   appropriate, but that just shows that the mapping can not be
   canonical.