### PR TITLE
Solving crashes in async tests

### DIFF
--- a/src/cpp/server/server.cc
+++ b/src/cpp/server/server.cc
@@ -287,14 +287,12 @@ void Server::Wait() {
 }
 
 void Server::PerformOpsOnCall(CallOpBuffer* buf, Call* call) {
-  if (call->call()) {
-    static const size_t MAX_OPS = 8;
-    size_t nops = MAX_OPS;
-    grpc_op ops[MAX_OPS];
-    buf->FillOps(ops, &nops);
-    GPR_ASSERT(GRPC_CALL_OK ==
-               grpc_call_start_batch(call->call(), ops, nops, buf));
-  }
+  static const size_t MAX_OPS = 8;
+  size_t nops = MAX_OPS;
+  grpc_op ops[MAX_OPS];
+  buf->FillOps(ops, &nops);
+  GPR_ASSERT(GRPC_CALL_OK ==
+             grpc_call_start_batch(call->call(), ops, nops, buf));
 }
 
 class Server::AsyncRequest GRPC_FINAL : public CompletionQueueTag {
@@ -326,6 +324,7 @@ class Server::AsyncRequest GRPC_FINAL : public CompletionQueueTag {
 
   bool FinalizeResult(void** tag, bool* status) GRPC_OVERRIDE {
     *tag = tag_;
+    bool orig_status = *status;
     if (*status && request_) {
       if (payload_) {
         *status = DeserializeProto(payload_, request_);
@@ -345,7 +344,7 @@ class Server::AsyncRequest GRPC_FINAL : public CompletionQueueTag {
     }
     ctx_->call_ = call_;
     Call call(call_, server_, cq_);
-    if (call_) {
+    if (orig_status && call_) {
       ctx_->BeginCompletionOp(&call);
     }
     // just the pointers inside call are copied here

--- a/src/cpp/server/server.cc
+++ b/src/cpp/server/server.cc
@@ -287,12 +287,14 @@ void Server::Wait() {
 }
 
 void Server::PerformOpsOnCall(CallOpBuffer* buf, Call* call) {
-  static const size_t MAX_OPS = 8;
-  size_t nops = MAX_OPS;
-  grpc_op ops[MAX_OPS];
-  buf->FillOps(ops, &nops);
-  GPR_ASSERT(GRPC_CALL_OK ==
-             grpc_call_start_batch(call->call(), ops, nops, buf));
+  if (call->call()) {
+    static const size_t MAX_OPS = 8;
+    size_t nops = MAX_OPS;
+    grpc_op ops[MAX_OPS];
+    buf->FillOps(ops, &nops);
+    GPR_ASSERT(GRPC_CALL_OK ==
+               grpc_call_start_batch(call->call(), ops, nops, buf));
+  }
 }
 
 class Server::AsyncRequest GRPC_FINAL : public CompletionQueueTag {
@@ -343,7 +345,9 @@ class Server::AsyncRequest GRPC_FINAL : public CompletionQueueTag {
     }
     ctx_->call_ = call_;
     Call call(call_, server_, cq_);
-    ctx_->BeginCompletionOp(&call);
+    if (call_) {
+      ctx_->BeginCompletionOp(&call);
+    }
     // just the pointers inside call are copied here
     stream_->BindCall(&call);
     delete this;

--- a/test/cpp/qps/server_async.cc
+++ b/test/cpp/qps/server_async.cc
@@ -143,21 +143,24 @@ class AsyncQpsServerTest {
       delete contexts_.front();
       contexts_.pop_front();
     }
+    for (auto& thr: threads_) {
+      thr.join();
+    }
   }
   void ServeRpcs(int num_threads) {
-    std::vector<std::thread> threads;
     for (int i = 0; i < num_threads; i++) {
-      threads.push_back(std::thread([=]() {
+      threads_.push_back(std::thread([=]() {
         // Wait until work is available or we are shutting down
         bool ok;
         void *got_tag;
         while (srv_cq_.Next(&got_tag, &ok)) {
-          EXPECT_EQ(ok, true);
-          ServerRpcContext *ctx = detag(got_tag);
-          // The tag is a pointer to an RPC context to invoke
-          if (ctx->RunNextState() == false) {
-            // this RPC context is done, so refresh it
-            ctx->Reset();
+          if (ok) {
+            ServerRpcContext *ctx = detag(got_tag);
+            // The tag is a pointer to an RPC context to invoke
+            if (ctx->RunNextState() == false) {
+              // this RPC context is done, so refresh it
+              ctx->Reset();
+            }
           }
         }
         return;
@@ -260,6 +263,7 @@ class AsyncQpsServerTest {
   }
   CompletionQueue srv_cq_;
   TestService::AsyncService async_service_;
+  std::vector<std::thread> threads_;
   std::unique_ptr<Server> server_;
   std::function<void(ServerContext *, SimpleRequest *,
                      grpc::ServerAsyncResponseWriter<SimpleResponse> *, void *)>


### PR DESCRIPTION
Avoid thread safety issues on destructor with a proper join.

Also had been misusing EXPECT_EQ, as well as actually having an invalid
expectation on the ok field. Now it should be sane. This no longer causes a
segfault or abort trap for me.

