### PR TITLE
Fix backslash line endings for grpc_python/Dockerfile.

### DIFF
--- a/tools/dockerfile/grpc_python/Dockerfile
+++ b/tools/dockerfile/grpc_python/Dockerfile
@@ -44,21 +44,21 @@ RUN cd /var/local/git/grpc \
   && pip install src/python/interop
 
 # Run Python GRPC's tests
+# TODO(nathaniel): It would be nice for these to be auto-discoverable?
 RUN cd /var/local/git/grpc \
-  # TODO(nathaniel): It would be nice for these to be auto-discoverable?
-  && python2.7 -B -m grpc._adapter._blocking_invocation_inline_service_test
-  && python2.7 -B -m grpc._adapter._c_test
-  && python2.7 -B -m grpc._adapter._event_invocation_synchronous_event_service_test
-  && python2.7 -B -m grpc._adapter._future_invocation_asynchronous_event_service_test
-  && python2.7 -B -m grpc._adapter._links_test
-  && python2.7 -B -m grpc._adapter._lonely_rear_link_test
-  && python2.7 -B -m grpc._adapter._low_test
-  && python2.7 -B -m grpc.framework.assembly.implementations_test
-  && python2.7 -B -m grpc.framework.base.packets.implementations_test
-  && python2.7 -B -m grpc.framework.face.blocking_invocation_inline_service_test
-  && python2.7 -B -m grpc.framework.face.event_invocation_synchronous_event_service_test
-  && python2.7 -B -m grpc.framework.face.future_invocation_asynchronous_event_service_test
-  && python2.7 -B -m grpc.framework.foundation._later_test
+  && python2.7 -B -m grpc._adapter._blocking_invocation_inline_service_test \
+  && python2.7 -B -m grpc._adapter._c_test \
+  && python2.7 -B -m grpc._adapter._event_invocation_synchronous_event_service_test \
+  && python2.7 -B -m grpc._adapter._future_invocation_asynchronous_event_service_test \
+  && python2.7 -B -m grpc._adapter._links_test \
+  && python2.7 -B -m grpc._adapter._lonely_rear_link_test \
+  && python2.7 -B -m grpc._adapter._low_test \
+  && python2.7 -B -m grpc.framework.assembly.implementations_test \
+  && python2.7 -B -m grpc.framework.base.packets.implementations_test \
+  && python2.7 -B -m grpc.framework.face.blocking_invocation_inline_service_test \
+  && python2.7 -B -m grpc.framework.face.event_invocation_synchronous_event_service_test \
+  && python2.7 -B -m grpc.framework.face.future_invocation_asynchronous_event_service_test \
+  && python2.7 -B -m grpc.framework.foundation._later_test \
   && python2.7 -B -m grpc.framework.foundation._logging_pool_test
 
 # Add a cacerts directory containing the Google root pem file, allowing the interop client to access the production test instance


### PR DESCRIPTION
Without the correct line endings docker had errors interpreting '&&' as a command.