### PR TITLE
Teach run_tests about individual Python tests

### DIFF
--- a/tools/run_tests/python_tests.json
+++ b/tools/run_tests/python_tests.json
@@ -1,0 +1,18 @@
+[
+  "grpc._adapter._blocking_invocation_inline_service_test",
+  "grpc._adapter._c_test",
+  "grpc._adapter._event_invocation_synchronous_event_service_test",
+  "grpc._adapter._future_invocation_asynchronous_event_service_test",
+  "grpc._adapter._links_test",
+  "grpc._adapter._lonely_rear_link_test",
+  "grpc._adapter._low_test",
+  "grpc.early_adopter.implementations_test",
+  "grpc.framework.assembly.implementations_test",
+  "grpc.framework.base.packets.implementations_test",
+  "grpc.framework.face.blocking_invocation_inline_service_test",
+  "grpc.framework.face.event_invocation_synchronous_event_service_test",
+  "grpc.framework.face.future_invocation_asynchronous_event_service_test",
+  "grpc.framework.foundation._later_test",
+  "grpc.framework.foundation._logging_pool_test"
+]
+

--- a/tools/run_tests/run_python.sh
+++ b/tools/run_tests/run_python.sh
@@ -36,24 +36,4 @@ cd $(dirname $0)/../..
 root=`pwd`
 export LD_LIBRARY_PATH=$root/libs/opt
 source python2.7_virtual_environment/bin/activate
-# TODO(issue 215): Properly itemize these in run_tests.py so that they can be parallelized.
-# TODO(atash): Enable dynamic unused port discovery for this test.
-# TODO(mlumish): Re-enable this test when we can install protoc
-# python2.7 -B test/compiler/python_plugin_test.py --build_mode=opt
-python2.7 -B -m grpc._adapter._blocking_invocation_inline_service_test
-python2.7 -B -m grpc._adapter._c_test
-python2.7 -B -m grpc._adapter._event_invocation_synchronous_event_service_test
-python2.7 -B -m grpc._adapter._future_invocation_asynchronous_event_service_test
-python2.7 -B -m grpc._adapter._links_test
-python2.7 -B -m grpc._adapter._lonely_rear_link_test
-python2.7 -B -m grpc._adapter._low_test
-python2.7 -B -m grpc.early_adopter.implementations_test
-python2.7 -B -m grpc.framework.assembly.implementations_test
-python2.7 -B -m grpc.framework.base.packets.implementations_test
-python2.7 -B -m grpc.framework.face.blocking_invocation_inline_service_test
-python2.7 -B -m grpc.framework.face.event_invocation_synchronous_event_service_test
-python2.7 -B -m grpc.framework.face.future_invocation_asynchronous_event_service_test
-python2.7 -B -m grpc.framework.foundation._later_test
-python2.7 -B -m grpc.framework.foundation._logging_pool_test
-# TODO(nathaniel): Get tests working under 3.4 (requires 3.X-friendly protobuf)
-# python3.4 -B -m unittest discover -s src/python -p '*.py'
+python2.7 -B -m $*


### PR DESCRIPTION
Allows:
- running python tests in parallel
- clearer Travis output
- subjects each python test to the five minute run_tests timeout,
  instead of ALL the tests to the five minute timeout
- allows easier benchmarking of which tests are slow

@murgatroid99 @tbetbetbe @jtattermusch @nicolasnoble - hopefully this can server as a template for one way of doing this for other languages