### PR TITLE
Node 0.11+ compatibility

### DIFF
--- a/src/node/ext/byte_buffer.cc
+++ b/src/node/ext/byte_buffer.cc
@@ -44,7 +44,6 @@
 namespace grpc {
 namespace node {
 
-using ::node::Buffer;
 using v8::Context;
 using v8::Function;
 using v8::Handle;
@@ -54,8 +53,8 @@ using v8::Value;
 
 grpc_byte_buffer *BufferToByteBuffer(Handle<Value> buffer) {
   NanScope();
-  int length = Buffer::Length(buffer);
-  char *data = Buffer::Data(buffer);
+  int length = ::node::Buffer::Length(buffer);
+  char *data = ::node::Buffer::Data(buffer);
   gpr_slice slice = gpr_slice_malloc(length);
   memcpy(GPR_SLICE_START_PTR(slice), data, length);
   grpc_byte_buffer *byte_buffer(grpc_byte_buffer_create(&slice, 1));
@@ -66,7 +65,7 @@ grpc_byte_buffer *BufferToByteBuffer(Handle<Value> buffer) {
 Handle<Value> ByteBufferToBuffer(grpc_byte_buffer *buffer) {
   NanEscapableScope();
   if (buffer == NULL) {
-    NanReturnNull();
+    return NanNull();
   }
   size_t length = grpc_byte_buffer_length(buffer);
   char *result = reinterpret_cast<char *>(calloc(length, sizeof(char)));
@@ -82,12 +81,14 @@ Handle<Value> ByteBufferToBuffer(grpc_byte_buffer *buffer) {
 
 Handle<Value> MakeFastBuffer(Handle<Value> slowBuffer) {
   NanEscapableScope();
-  Handle<Object> globalObj = Context::GetCurrent()->Global();
+  Handle<Object> globalObj = NanGetCurrentContext()->Global();
   Handle<Function> bufferConstructor = Handle<Function>::Cast(
       globalObj->Get(NanNew("Buffer")));
-  Handle<Value> consArgs[3] = { slowBuffer,
-                                NanNew<Number>(Buffer::Length(slowBuffer)),
-                                NanNew<Number>(0) };
+  Handle<Value> consArgs[3] = {
+    slowBuffer,
+    NanNew<Number>(::node::Buffer::Length(slowBuffer)),
+    NanNew<Number>(0)
+  };
   Handle<Object> fastBuffer = bufferConstructor->NewInstance(3, consArgs);
   return NanEscapeScope(fastBuffer);
 }

--- a/src/node/ext/call.cc
+++ b/src/node/ext/call.cc
@@ -102,8 +102,8 @@ bool CreateMetadataArray(Handle<Object> metadata, grpc_metadata_array *array,
       if (::node::Buffer::HasInstance(value)) {
         current->value = ::node::Buffer::Data(value);
         current->value_length = ::node::Buffer::Length(value);
-        Persistent<Value> handle;
-        NanAssignPersistent(handle, value);
+        Persistent<Value> *handle = new Persistent<Value>();
+        NanAssignPersistent(*handle, value);
         resources->handles.push_back(unique_ptr<PersistentHolder>(
             new PersistentHolder(handle)));
       } else if (value->IsString()) {
@@ -196,8 +196,8 @@ class SendMessageOp : public Op {
       return false;
     }
     out->data.send_message = BufferToByteBuffer(value);
-    Persistent<Value> handle;
-    NanAssignPersistent(handle, value);
+    Persistent<Value> *handle = new Persistent<Value>();
+    NanAssignPersistent(*handle, value);
     resources->handles.push_back(unique_ptr<PersistentHolder>(
         new PersistentHolder(handle)));
     return true;

--- a/src/node/ext/call.h
+++ b/src/node/ext/call.h
@@ -118,7 +118,7 @@ class Call : public ::node::ObjectWrap {
   static NAN_METHOD(New);
   static NAN_METHOD(StartBatch);
   static NAN_METHOD(Cancel);
-  static v8::Persistent<v8::Function> constructor;
+  static NanCallback *constructor;
   // Used for typechecking instances of this javascript class
   static v8::Persistent<v8::FunctionTemplate> fun_tpl;
 

--- a/src/node/ext/call.h
+++ b/src/node/ext/call.h
@@ -40,6 +40,7 @@
 #include <node.h>
 #include <nan.h>
 #include "grpc/grpc.h"
+#include "grpc/support/log.h"
 
 #include "channel.h"
 
@@ -54,16 +55,17 @@ v8::Handle<v8::Value> ParseMetadata(const grpc_metadata_array *metadata_array);
 
 class PersistentHolder {
  public:
-  explicit PersistentHolder(v8::Persistent<v8::Value> persist) :
+  explicit PersistentHolder(v8::Persistent<v8::Value> *persist) :
       persist(persist) {
   }
 
   ~PersistentHolder() {
-    NanDisposePersistent(persist);
+    NanDisposePersistent(*persist);
+    delete persist;
   }
 
  private:
-  v8::Persistent<v8::Value> persist;
+  v8::Persistent<v8::Value> *persist;
 };
 
 struct Resources {

--- a/src/node/ext/channel.h
+++ b/src/node/ext/channel.h
@@ -66,7 +66,7 @@ class Channel : public ::node::ObjectWrap {
 
   static NAN_METHOD(New);
   static NAN_METHOD(Close);
-  static v8::Persistent<v8::Function> constructor;
+  static NanCallback *constructor;
   static v8::Persistent<v8::FunctionTemplate> fun_tpl;
 
   grpc_channel *wrapped_channel;

--- a/src/node/ext/credentials.cc
+++ b/src/node/ext/credentials.cc
@@ -41,8 +41,6 @@
 namespace grpc {
 namespace node {
 
-using ::node::Buffer;
-using v8::Arguments;
 using v8::Exception;
 using v8::External;
 using v8::Function;
@@ -56,7 +54,7 @@ using v8::ObjectTemplate;
 using v8::Persistent;
 using v8::Value;
 
-Persistent<Function> Credentials::constructor;
+NanCallback *Credentials::constructor;
 Persistent<FunctionTemplate> Credentials::fun_tpl;
 
 Credentials::Credentials(grpc_credentials *credentials)
@@ -68,24 +66,25 @@ Credentials::~Credentials() {
 
 void Credentials::Init(Handle<Object> exports) {
   NanScope();
-  Local<FunctionTemplate> tpl = FunctionTemplate::New(New);
+  Local<FunctionTemplate> tpl = NanNew<FunctionTemplate>(New);
   tpl->SetClassName(NanNew("Credentials"));
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
   NanAssignPersistent(fun_tpl, tpl);
-  NanAssignPersistent(constructor, tpl->GetFunction());
-  constructor->Set(NanNew("createDefault"),
-                   FunctionTemplate::New(CreateDefault)->GetFunction());
-  constructor->Set(NanNew("createSsl"),
-                   FunctionTemplate::New(CreateSsl)->GetFunction());
-  constructor->Set(NanNew("createComposite"),
-                   FunctionTemplate::New(CreateComposite)->GetFunction());
-  constructor->Set(NanNew("createGce"),
-                   FunctionTemplate::New(CreateGce)->GetFunction());
-  constructor->Set(NanNew("createFake"),
-                   FunctionTemplate::New(CreateFake)->GetFunction());
-  constructor->Set(NanNew("createIam"),
-                   FunctionTemplate::New(CreateIam)->GetFunction());
-  exports->Set(NanNew("Credentials"), constructor);
+  Handle<Function> ctr = tpl->GetFunction();
+  ctr->Set(NanNew("createDefault"),
+           NanNew<FunctionTemplate>(CreateDefault)->GetFunction());
+  ctr->Set(NanNew("createSsl"),
+           NanNew<FunctionTemplate>(CreateSsl)->GetFunction());
+  ctr->Set(NanNew("createComposite"),
+           NanNew<FunctionTemplate>(CreateComposite)->GetFunction());
+  ctr->Set(NanNew("createGce"),
+           NanNew<FunctionTemplate>(CreateGce)->GetFunction());
+  ctr->Set(NanNew("createFake"),
+           NanNew<FunctionTemplate>(CreateFake)->GetFunction());
+  ctr->Set(NanNew("createIam"),
+           NanNew<FunctionTemplate>(CreateIam)->GetFunction());
+  constructor = new NanCallback(ctr);
+  exports->Set(NanNew("Credentials"), ctr);
 }
 
 bool Credentials::HasInstance(Handle<Value> val) {
@@ -100,8 +99,8 @@ Handle<Value> Credentials::WrapStruct(grpc_credentials *credentials) {
   }
   const int argc = 1;
   Handle<Value> argv[argc] = {
-      External::New(reinterpret_cast<void *>(credentials))};
-  return NanEscapeScope(constructor->NewInstance(argc, argv));
+    NanNew<External>(reinterpret_cast<void *>(credentials))};
+  return NanEscapeScope(constructor->GetFunction()->NewInstance(argc, argv));
 }
 
 grpc_credentials *Credentials::GetWrappedCredentials() {
@@ -116,15 +115,16 @@ NAN_METHOD(Credentials::New) {
       return NanThrowTypeError(
           "Credentials can only be created with the provided functions");
     }
+    Handle<External> ext = args[0].As<External>();
     grpc_credentials *creds_value =
-        reinterpret_cast<grpc_credentials *>(External::Unwrap(args[0]));
+        reinterpret_cast<grpc_credentials *>(ext->Value());
     Credentials *credentials = new Credentials(creds_value);
     credentials->Wrap(args.This());
     NanReturnValue(args.This());
   } else {
     const int argc = 1;
     Local<Value> argv[argc] = {args[0]};
-    NanReturnValue(constructor->NewInstance(argc, argv));
+    NanReturnValue(constructor->GetFunction()->NewInstance(argc, argv));
   }
 }
 
@@ -137,19 +137,19 @@ NAN_METHOD(Credentials::CreateSsl) {
   NanScope();
   char *root_certs = NULL;
   grpc_ssl_pem_key_cert_pair key_cert_pair = {NULL, NULL};
-  if (Buffer::HasInstance(args[0])) {
-    root_certs = Buffer::Data(args[0]);
+  if (::node::Buffer::HasInstance(args[0])) {
+    root_certs = ::node::Buffer::Data(args[0]);
   } else if (!(args[0]->IsNull() || args[0]->IsUndefined())) {
     return NanThrowTypeError("createSsl's first argument must be a Buffer");
   }
-  if (Buffer::HasInstance(args[1])) {
-    key_cert_pair.private_key = Buffer::Data(args[1]);
+  if (::node::Buffer::HasInstance(args[1])) {
+    key_cert_pair.private_key = ::node::Buffer::Data(args[1]);
   } else if (!(args[1]->IsNull() || args[1]->IsUndefined())) {
     return NanThrowTypeError(
         "createSSl's second argument must be a Buffer if provided");
   }
-  if (Buffer::HasInstance(args[2])) {
-    key_cert_pair.cert_chain = Buffer::Data(args[2]);
+  if (::node::Buffer::HasInstance(args[2])) {
+    key_cert_pair.cert_chain = ::node::Buffer::Data(args[2]);
   } else if (!(args[2]->IsNull() || args[2]->IsUndefined())) {
     return NanThrowTypeError(
         "createSSl's third argument must be a Buffer if provided");

--- a/src/node/ext/credentials.h
+++ b/src/node/ext/credentials.h
@@ -68,7 +68,7 @@ class Credentials : public ::node::ObjectWrap {
   static NAN_METHOD(CreateGce);
   static NAN_METHOD(CreateFake);
   static NAN_METHOD(CreateIam);
-  static v8::Persistent<v8::Function> constructor;
+  static NanCallback *constructor;
   // Used for typechecking instances of this javascript class
   static v8::Persistent<v8::FunctionTemplate> fun_tpl;
 

--- a/src/node/ext/node_grpc.cc
+++ b/src/node/ext/node_grpc.cc
@@ -51,7 +51,7 @@ using v8::String;
 
 void InitStatusConstants(Handle<Object> exports) {
   NanScope();
-  Handle<Object> status = Object::New();
+  Handle<Object> status = NanNew<Object>();
   exports->Set(NanNew("status"), status);
   Handle<Value> OK(NanNew<Uint32, uint32_t>(GRPC_STATUS_OK));
   status->Set(NanNew("OK"), OK);
@@ -100,7 +100,7 @@ void InitStatusConstants(Handle<Object> exports) {
 
 void InitCallErrorConstants(Handle<Object> exports) {
   NanScope();
-  Handle<Object> call_error = Object::New();
+  Handle<Object> call_error = NanNew<Object>();
   exports->Set(NanNew("callError"), call_error);
   Handle<Value> OK(NanNew<Uint32, uint32_t>(GRPC_CALL_OK));
   call_error->Set(NanNew("OK"), OK);
@@ -131,7 +131,7 @@ void InitCallErrorConstants(Handle<Object> exports) {
 
 void InitOpTypeConstants(Handle<Object> exports) {
   NanScope();
-  Handle<Object> op_type = Object::New();
+  Handle<Object> op_type = NanNew<Object>();
   exports->Set(NanNew("opType"), op_type);
   Handle<Value> SEND_INITIAL_METADATA(
       NanNew<Uint32, uint32_t>(GRPC_OP_SEND_INITIAL_METADATA));

--- a/src/node/ext/server.h
+++ b/src/node/ext/server.h
@@ -67,7 +67,7 @@ class Server : public ::node::ObjectWrap {
   static NAN_METHOD(AddSecureHttp2Port);
   static NAN_METHOD(Start);
   static NAN_METHOD(Shutdown);
-  static v8::Persistent<v8::Function> constructor;
+  static NanCallback *constructor;
   static v8::Persistent<v8::FunctionTemplate> fun_tpl;
 
   grpc_server *wrapped_server;

--- a/src/node/ext/server_credentials.h
+++ b/src/node/ext/server_credentials.h
@@ -64,7 +64,7 @@ class ServerCredentials : public ::node::ObjectWrap {
   static NAN_METHOD(New);
   static NAN_METHOD(CreateSsl);
   static NAN_METHOD(CreateFake);
-  static v8::Persistent<v8::Function> constructor;
+  static NanCallback *constructor;
   // Used for typechecking instances of this javascript class
   static v8::Persistent<v8::FunctionTemplate> fun_tpl;
 

--- a/src/node/package.json
+++ b/src/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": "Google Inc.",
   "description": "gRPC Library for Node",
   "homepage": "http://www.grpc.io/",
@@ -39,7 +39,7 @@
     "strftime": "^0.8.2"
   },
   "engines": {
-    "node": ">=0.10.13 <0.11"
+    "node": ">=0.10.13"
   },
   "files": [
     "LICENSE",

--- a/src/node/package.json
+++ b/src/node/package.json
@@ -24,19 +24,22 @@
     "test": "node ./node_modules/mocha/bin/mocha && npm run-script lint"
   },
   "dependencies": {
-    "bindings": "^1.2.1",
-    "jshint": "^2.5.5",
-    "nan": "~1.3.0",
+    "bindings": "^1.2.0",
+    "nan": "^1.5.0",
     "protobufjs": "murgatroid99/ProtoBuf.js",
-    "underscore": "^1.7.0",
+    "underscore": "^1.6.0",
     "underscore.string": "^3.0.0"
   },
   "devDependencies": {
     "async": "^0.9.0",
     "google-auth-library": "^0.9.2",
+    "jshint": "^2.5.0",
     "minimist": "^1.1.0",
     "mocha": "~1.21.0",
     "strftime": "^0.8.2"
+  },
+  "engines": {
+    "node": ">=0.10.13 <0.11"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
This allows the extension to compile on Node 0.11, 0.12, and io.js 1.x, which fixes #948. On Node 0.11 and 0.12, there is a segmentation fault at cleanup time, which I will investigate later.