### PR TITLE
Latency tweaks

### DIFF
--- a/src/core/iomgr/fd_posix.h
+++ b/src/core/iomgr/fd_posix.h
@@ -52,6 +52,7 @@ typedef struct grpc_fd_watcher {
   struct grpc_fd_watcher *prev;
   grpc_pollset *pollset;
   grpc_fd *fd;
+  int r, w;
 } grpc_fd_watcher;
 
 struct grpc_fd {

--- a/src/core/iomgr/pollset_multipoller_with_poll_posix.c
+++ b/src/core/iomgr/pollset_multipoller_with_poll_posix.c
@@ -172,6 +172,9 @@ static int multipoll_with_poll_pollset_maybe_work(
   }
 
   r = poll(h->pfds, h->pfd_count, timeout);
+
+  end_polling(pollset);
+
   if (r < 0) {
     if (errno != EINTR) {
       gpr_log(GPR_ERROR, "poll() failed: %s", strerror(errno));
@@ -192,7 +195,6 @@ static int multipoll_with_poll_pollset_maybe_work(
     }
   }
   grpc_pollset_kick_post_poll(&pollset->kick_state);
-  end_polling(pollset);
 
   gpr_mu_lock(&pollset->mu);
   pollset->counter = 0;

--- a/src/core/iomgr/pollset_posix.c
+++ b/src/core/iomgr/pollset_posix.c
@@ -396,6 +396,9 @@ static int unary_poll_pollset_maybe_work(grpc_pollset *pollset,
   pfd[1].events = grpc_fd_begin_poll(fd, pollset, POLLIN, POLLOUT, &fd_watcher);
 
   r = poll(pfd, GPR_ARRAY_SIZE(pfd), timeout);
+
+  grpc_fd_end_poll(&fd_watcher);
+
   if (r < 0) {
     if (errno != EINTR) {
       gpr_log(GPR_ERROR, "poll() failed: %s", strerror(errno));
@@ -415,7 +418,6 @@ static int unary_poll_pollset_maybe_work(grpc_pollset *pollset,
   }
 
   grpc_pollset_kick_post_poll(&pollset->kick_state);
-  grpc_fd_end_poll(&fd_watcher);
 
   gpr_mu_lock(&pollset->mu);
   pollset->counter = 0;


### PR DESCRIPTION
David - these are a few tweaks I've been toying with to improve latency. They're not extensively tested, more of 'here's some initial thoughts'.

The first is a maybe that's worth exploring, to avoid kicking unnecessarily - I don't think it immediately buys us anything meaningful, but it might open the way to something - so keep it in the toolchest for now.

The second seems to help on my localhost tests on my mac. We kick every fd on the watcher list on a notify - we probably only need to kick one, and only if there's nothing listening for the event that just came up. We _certainly_ don't need to kick the fd that just woke up though - so we remove that one from the list before starting notifications.