### PR TITLE
strcmp: change all !str[n]cmp to str[n]cmp == 0

### DIFF
--- a/src/core/iomgr/resolve_address_posix.c
+++ b/src/core/iomgr/resolve_address_posix.c
@@ -109,7 +109,7 @@ grpc_resolved_addresses *grpc_blocking_resolve_address(
     };
     int i;
     for (i = 0; i < (int)(sizeof(svc) / sizeof(svc[0])); i++) {
-      if (!strcmp(port, svc[i][0])) {
+      if (strcmp(port, svc[i][0]) == 0) {
         s = getaddrinfo(host, svc[i][1], &hints, &result);
         break;
       }

--- a/src/core/security/credentials.c
+++ b/src/core/security/credentials.c
@@ -348,7 +348,7 @@ static void jwt_get_request_metadata(grpc_credentials *creds,
   {
     gpr_mu_lock(&c->cache_mu);
     if (c->cached.service_url != NULL &&
-        !strcmp(c->cached.service_url, service_url) &&
+        strcmp(c->cached.service_url, service_url) == 0 &&
         c->cached.jwt_md != NULL &&
         (gpr_time_cmp(gpr_time_sub(c->cached.jwt_expiration, gpr_now()),
                       refresh_threshold) > 0)) {
@@ -957,7 +957,7 @@ static grpc_credentials_array get_creds_array(grpc_credentials **creds_addr) {
   grpc_credentials *creds = *creds_addr;
   result.creds_array = creds_addr;
   result.num_creds = 1;
-  if (!strcmp(creds->type, GRPC_CREDENTIALS_TYPE_COMPOSITE)) {
+  if (strcmp(creds->type, GRPC_CREDENTIALS_TYPE_COMPOSITE) == 0) {
     result = *grpc_composite_credentials_get_credentials(creds);
   }
   return result;
@@ -995,7 +995,7 @@ const grpc_credentials_array *grpc_composite_credentials_get_credentials(
     grpc_credentials *creds) {
   const grpc_composite_credentials *c =
       (const grpc_composite_credentials *)creds;
-  GPR_ASSERT(!strcmp(creds->type, GRPC_CREDENTIALS_TYPE_COMPOSITE));
+  GPR_ASSERT(strcmp(creds->type, GRPC_CREDENTIALS_TYPE_COMPOSITE) == 0);
   return &c->inner;
 }
 
@@ -1003,14 +1003,14 @@ grpc_credentials *grpc_credentials_contains_type(
     grpc_credentials *creds, const char *type,
     grpc_credentials **composite_creds) {
   size_t i;
-  if (!strcmp(creds->type, type)) {
+  if (strcmp(creds->type, type) == 0) {
     if (composite_creds != NULL) *composite_creds = NULL;
     return creds;
-  } else if (!strcmp(creds->type, GRPC_CREDENTIALS_TYPE_COMPOSITE)) {
+  } else if (strcmp(creds->type, GRPC_CREDENTIALS_TYPE_COMPOSITE) == 0) {
     const grpc_credentials_array *inner_creds_array =
         grpc_composite_credentials_get_credentials(creds);
     for (i = 0; i < inner_creds_array->num_creds; i++) {
-      if (!strcmp(type, inner_creds_array->creds_array[i]->type)) {
+      if (strcmp(type, inner_creds_array->creds_array[i]->type) == 0) {
         if (composite_creds != NULL) *composite_creds = creds;
         return inner_creds_array->creds_array[i];
       }

--- a/src/core/security/google_default_credentials.c
+++ b/src/core/security/google_default_credentials.c
@@ -75,8 +75,8 @@ static void on_compute_engine_detection_http_response(
     size_t i;
     for (i = 0; i < response->hdr_count; i++) {
       grpc_httpcli_header *header = &response->hdrs[i];
-      if (!strcmp(header->key, "Metadata-Flavor") &&
-          !strcmp(header->value, "Google")) {
+      if (strcmp(header->key, "Metadata-Flavor") == 0 &&
+          strcmp(header->value, "Google") == 0) {
         detector->success = 1;
         break;
       }

--- a/src/core/security/json_token.c
+++ b/src/core/security/json_token.c
@@ -257,7 +257,7 @@ static char *dot_concat_and_free_strings(char *str1, char *str2) {
 }
 
 const EVP_MD *openssl_digest_from_algorithm(const char *algorithm) {
-  if (!strcmp(algorithm, GRPC_JWT_RSA_SHA256_ALGORITHM)) {
+  if (strcmp(algorithm, GRPC_JWT_RSA_SHA256_ALGORITHM) == 0) {
     return EVP_sha256();
   } else {
     gpr_log(GPR_ERROR, "Unknown algorithm %s.", algorithm);

--- a/src/core/security/security_context.c
+++ b/src/core/security/security_context.c
@@ -421,7 +421,7 @@ static grpc_security_status ssl_channel_check_call_host(
   /* If the target name was overridden, then the original target_name was
      'checked' transitively during the previous peer check at the end of the
      handshake. */
-  if (c->overridden_target_name != NULL && !strcmp(host, c->target_name)) {
+  if (c->overridden_target_name != NULL && strcmp(host, c->target_name) == 0) {
     return GRPC_SECURITY_OK;
   } else {
     return GRPC_SECURITY_ERROR;
@@ -610,7 +610,7 @@ grpc_channel *grpc_ssl_channel_create(grpc_credentials *ssl_creds,
 
   for (i = 0; args && i < args->num_args; i++) {
     grpc_arg *arg = &args->args[i];
-    if (!strcmp(arg->key, GRPC_SSL_TARGET_NAME_OVERRIDE_ARG) &&
+    if (strcmp(arg->key, GRPC_SSL_TARGET_NAME_OVERRIDE_ARG) == 0 &&
         arg->type == GRPC_ARG_STRING) {
       overridden_target_name = arg->value.string;
       break;

--- a/src/core/security/server_secure_chttp2.c
+++ b/src/core/security/server_secure_chttp2.c
@@ -139,11 +139,11 @@ int grpc_server_add_secure_http2_port(grpc_server *server, const char *addr, grp
   /* create security context */
   if (creds == NULL) goto error;
 
-  if (!strcmp(creds->type, GRPC_CREDENTIALS_TYPE_SSL)) {
+  if (strcmp(creds->type, GRPC_CREDENTIALS_TYPE_SSL) == 0) {
     status = grpc_ssl_server_security_context_create(
         grpc_ssl_server_credentials_get_config(creds), &ctx);
-  } else if (!strcmp(creds->type,
-                     GRPC_CREDENTIALS_TYPE_FAKE_TRANSPORT_SECURITY)) {
+  } else if (strcmp(creds->type,
+                    GRPC_CREDENTIALS_TYPE_FAKE_TRANSPORT_SECURITY) == 0) {
     ctx = grpc_fake_server_security_context_create();
     status = GRPC_SECURITY_OK;
   }

--- a/src/core/tsi/fake_transport_security.c
+++ b/src/core/tsi/fake_transport_security.c
@@ -102,8 +102,8 @@ static tsi_result tsi_fake_handshake_message_from_string(
     const char* msg_string, tsi_fake_handshake_message* msg) {
   int i;
   for (i = 0; i < TSI_FAKE_HANDSHAKE_MESSAGE_MAX; i++) {
-    if (!strncmp(msg_string, tsi_fake_handshake_message_strings[i],
-                 strlen(tsi_fake_handshake_message_strings[i]))) {
+    if (strncmp(msg_string, tsi_fake_handshake_message_strings[i],
+                strlen(tsi_fake_handshake_message_strings[i])) == 0) {
       *msg = i;
       return TSI_OK;
     }

--- a/src/core/tsi/ssl_transport_security.c
+++ b/src/core/tsi/ssl_transport_security.c
@@ -1083,7 +1083,8 @@ static int does_entry_match_name(const char* entry, size_t entry_length,
     if (entry_length == 0) return 0;
   }
 
-  if ((name_length == entry_length) && !strncmp(name, entry, entry_length)) {
+  if ((name_length == entry_length) &&
+      strncmp(name, entry, entry_length) == 0) {
     return 1; /* Perfect match. */
   }
   if (entry[0] != '*') return 0;
@@ -1110,7 +1111,7 @@ static int does_entry_match_name(const char* entry, size_t entry_length,
     name_subdomain_length--;
   }
   return ((entry_length > 0) && (name_subdomain_length == entry_length) &&
-          !strncmp(entry, name_subdomain, entry_length));
+          strncmp(entry, name_subdomain, entry_length) == 0);
 }
 
 static int ssl_server_handshaker_factory_servername_callback(SSL* ssl, int* ap,

--- a/src/core/tsi/transport_security.c
+++ b/src/core/tsi/transport_security.c
@@ -208,7 +208,7 @@ const tsi_peer_property* tsi_peer_get_property_by_name(const tsi_peer* self,
       return property;
     }
     if (name != NULL && property->name != NULL &&
-        !strcmp(property->name, name)) {
+        strcmp(property->name, name) == 0) {
       return property;
     }
   }

--- a/test/core/network_benchmarks/low_level_ping_pong.c
+++ b/test/core/network_benchmarks/low_level_ping_pong.c
@@ -654,7 +654,7 @@ int main(int argc, char **argv) {
   }
 
   for (i = 0; i < GPR_ARRAY_SIZE(test_strategies); ++i) {
-    if (!strcmp(test_strategies[i].name, read_strategy)) {
+    if (strcmp(test_strategies[i].name, read_strategy) == 0) {
       test_strategy = &test_strategies[i];
     }
   }

--- a/test/core/security/base64_test.c
+++ b/test/core/security/base64_test.c
@@ -58,8 +58,8 @@ static void test_simple_encode_decode_b64(int url_safe, int multiline) {
       grpc_base64_encode(hello, strlen(hello), url_safe, multiline);
   gpr_slice hello_slice = grpc_base64_decode(hello_b64, url_safe);
   GPR_ASSERT(GPR_SLICE_LENGTH(hello_slice) == strlen(hello));
-  GPR_ASSERT(!strncmp((const char *)GPR_SLICE_START_PTR(hello_slice), hello,
-                      GPR_SLICE_LENGTH(hello_slice)));
+  GPR_ASSERT(strncmp((const char *)GPR_SLICE_START_PTR(hello_slice), hello,
+                     GPR_SLICE_LENGTH(hello_slice)) == 0);
 
   gpr_slice_unref(hello_slice);
   gpr_free(hello_b64);
@@ -141,31 +141,31 @@ static void test_rfc4648_test_vectors(void) {
   char *b64;
 
   b64 = grpc_base64_encode("", 0, 0, 0);
-  GPR_ASSERT(!strcmp("", b64));
+  GPR_ASSERT(strcmp("", b64) == 0);
   gpr_free(b64);
 
   b64 = grpc_base64_encode("f", 1, 0, 0);
-  GPR_ASSERT(!strcmp("Zg==", b64));
+  GPR_ASSERT(strcmp("Zg==", b64) == 0);
   gpr_free(b64);
 
   b64 = grpc_base64_encode("fo", 2, 0, 0);
-  GPR_ASSERT(!strcmp("Zm8=", b64));
+  GPR_ASSERT(strcmp("Zm8=", b64) == 0);
   gpr_free(b64);
 
   b64 = grpc_base64_encode("foo", 3, 0, 0);
-  GPR_ASSERT(!strcmp("Zm9v", b64));
+  GPR_ASSERT(strcmp("Zm9v", b64) == 0);
   gpr_free(b64);
 
   b64 = grpc_base64_encode("foob", 4, 0, 0);
-  GPR_ASSERT(!strcmp("Zm9vYg==", b64));
+  GPR_ASSERT(strcmp("Zm9vYg==", b64) == 0);
   gpr_free(b64);
 
   b64 = grpc_base64_encode("fooba", 5, 0, 0);
-  GPR_ASSERT(!strcmp("Zm9vYmE=", b64));
+  GPR_ASSERT(strcmp("Zm9vYmE=", b64) == 0);
   gpr_free(b64);
 
   b64 = grpc_base64_encode("foobar", 6, 0, 0);
-  GPR_ASSERT(!strcmp("Zm9vYmFy", b64));
+  GPR_ASSERT(strcmp("Zm9vYmFy", b64) == 0);
   gpr_free(b64);
 }
 

--- a/test/core/security/credentials_test.c
+++ b/test/core/security/credentials_test.c
@@ -143,9 +143,10 @@ static void test_oauth2_token_fetcher_creds_parsing_ok(void) {
              GRPC_CREDENTIALS_OK);
   GPR_ASSERT(token_lifetime.tv_sec == 3599);
   GPR_ASSERT(token_lifetime.tv_nsec == 0);
-  GPR_ASSERT(!strcmp(grpc_mdstr_as_c_string(token_elem->key), "Authorization"));
-  GPR_ASSERT(!strcmp(grpc_mdstr_as_c_string(token_elem->value),
-                     "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"));
+  GPR_ASSERT(strcmp(grpc_mdstr_as_c_string(token_elem->key),
+                    "Authorization") == 0);
+  GPR_ASSERT(strcmp(grpc_mdstr_as_c_string(token_elem->value),
+                    "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_") == 0);
   grpc_mdelem_unref(token_elem);
   grpc_mdctx_unref(ctx);
 }
@@ -294,15 +295,16 @@ static void test_ssl_oauth2_composite_creds(void) {
       grpc_composite_credentials_create(ssl_creds, oauth2_creds);
   grpc_credentials_unref(ssl_creds);
   grpc_credentials_unref(oauth2_creds);
-  GPR_ASSERT(!strcmp(composite_creds->type, GRPC_CREDENTIALS_TYPE_COMPOSITE));
+  GPR_ASSERT(strcmp(composite_creds->type,
+                    GRPC_CREDENTIALS_TYPE_COMPOSITE) == 0);
   GPR_ASSERT(grpc_credentials_has_request_metadata(composite_creds));
   GPR_ASSERT(!grpc_credentials_has_request_metadata_only(composite_creds));
   creds_array = grpc_composite_credentials_get_credentials(composite_creds);
   GPR_ASSERT(creds_array->num_creds == 2);
-  GPR_ASSERT(
-      !strcmp(creds_array->creds_array[0]->type, GRPC_CREDENTIALS_TYPE_SSL));
-  GPR_ASSERT(
-      !strcmp(creds_array->creds_array[1]->type, GRPC_CREDENTIALS_TYPE_OAUTH2));
+  GPR_ASSERT(strcmp(creds_array->creds_array[0]->type,
+                    GRPC_CREDENTIALS_TYPE_SSL) == 0);
+  GPR_ASSERT(strcmp(creds_array->creds_array[1]->type,
+                    GRPC_CREDENTIALS_TYPE_OAUTH2) == 0);
   grpc_credentials_get_request_metadata(composite_creds, test_service_url,
                                         check_ssl_oauth2_composite_metadata,
                                         composite_creds);
@@ -338,17 +340,18 @@ static void test_ssl_oauth2_iam_composite_creds(void) {
   grpc_credentials_unref(oauth2_creds);
   grpc_credentials_unref(aux_creds);
   grpc_credentials_unref(iam_creds);
-  GPR_ASSERT(!strcmp(composite_creds->type, GRPC_CREDENTIALS_TYPE_COMPOSITE));
+  GPR_ASSERT(strcmp(composite_creds->type,
+                    GRPC_CREDENTIALS_TYPE_COMPOSITE) == 0);
   GPR_ASSERT(grpc_credentials_has_request_metadata(composite_creds));
   GPR_ASSERT(!grpc_credentials_has_request_metadata_only(composite_creds));
   creds_array = grpc_composite_credentials_get_credentials(composite_creds);
   GPR_ASSERT(creds_array->num_creds == 3);
-  GPR_ASSERT(
-      !strcmp(creds_array->creds_array[0]->type, GRPC_CREDENTIALS_TYPE_SSL));
-  GPR_ASSERT(
-      !strcmp(creds_array->creds_array[1]->type, GRPC_CREDENTIALS_TYPE_OAUTH2));
-  GPR_ASSERT(
-      !strcmp(creds_array->creds_array[2]->type, GRPC_CREDENTIALS_TYPE_IAM));
+  GPR_ASSERT(strcmp(creds_array->creds_array[0]->type,
+                    GRPC_CREDENTIALS_TYPE_SSL) == 0);
+  GPR_ASSERT(strcmp(creds_array->creds_array[1]->type,
+                    GRPC_CREDENTIALS_TYPE_OAUTH2) == 0);
+  GPR_ASSERT(strcmp(creds_array->creds_array[2]->type,
+                    GRPC_CREDENTIALS_TYPE_IAM) == 0);
   grpc_credentials_get_request_metadata(composite_creds, test_service_url,
                                         check_ssl_oauth2_iam_composite_metadata,
                                         composite_creds);
@@ -359,12 +362,12 @@ static void on_oauth2_creds_get_metadata_success(
     grpc_credentials_status status) {
   GPR_ASSERT(status == GRPC_CREDENTIALS_OK);
   GPR_ASSERT(num_md == 1);
-  GPR_ASSERT(
-      !strcmp(grpc_mdstr_as_c_string(md_elems[0]->key), "Authorization"));
-  GPR_ASSERT(!strcmp(grpc_mdstr_as_c_string(md_elems[0]->value),
-                     "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_"));
+  GPR_ASSERT(strcmp(grpc_mdstr_as_c_string(md_elems[0]->key),
+                    "Authorization") == 0);
+  GPR_ASSERT(strcmp(grpc_mdstr_as_c_string(md_elems[0]->value),
+                    "Bearer ya29.AHES6ZRN3-HlhAPya30GnW_bHSb_") == 0);
   GPR_ASSERT(user_data != NULL);
-  GPR_ASSERT(!strcmp((const char *)user_data, test_user_data));
+  GPR_ASSERT(strcmp((const char *)user_data, test_user_data) == 0);
 }
 
 static void on_oauth2_creds_get_metadata_failure(
@@ -373,19 +376,19 @@ static void on_oauth2_creds_get_metadata_failure(
   GPR_ASSERT(status == GRPC_CREDENTIALS_ERROR);
   GPR_ASSERT(num_md == 0);
   GPR_ASSERT(user_data != NULL);
-  GPR_ASSERT(!strcmp((const char *)user_data, test_user_data));
+  GPR_ASSERT(strcmp((const char *)user_data, test_user_data) == 0);
 }
 
 static void validate_compute_engine_http_request(
     const grpc_httpcli_request *request) {
   GPR_ASSERT(!request->use_ssl);
-  GPR_ASSERT(!strcmp(request->host, "metadata"));
-  GPR_ASSERT(
-      !strcmp(request->path,
-              "/computeMetadata/v1/instance/service-accounts/default/token"));
+  GPR_ASSERT(strcmp(request->host, "metadata") == 0);
+  GPR_ASSERT(strcmp(request->path,
+             "/computeMetadata/v1/instance/service-accounts/default/token")
+             == 0);
   GPR_ASSERT(request->hdr_count == 1);
-  GPR_ASSERT(!strcmp(request->hdrs[0].key, "Metadata-Flavor"));
-  GPR_ASSERT(!strcmp(request->hdrs[0].value, "Google"));
+  GPR_ASSERT(strcmp(request->hdrs[0].key, "Metadata-Flavor") == 0);
+  GPR_ASSERT(strcmp(request->hdrs[0].value, "Google") == 0);
 }
 
 static int compute_engine_httpcli_get_success_override(
@@ -467,19 +470,19 @@ static void validate_jwt_encode_and_sign_params(
   GPR_ASSERT(json_key->private_key != NULL);
   GPR_ASSERT(RSA_check_key(json_key->private_key));
   GPR_ASSERT(json_key->type != NULL &&
-             !(strcmp(json_key->type, "service_account")));
+             strcmp(json_key->type, "service_account") == 0);
   GPR_ASSERT(json_key->private_key_id != NULL &&
-             !strcmp(json_key->private_key_id,
-                     "e6b5137873db8d2ef81e06a47289e6434ec8a165"));
+             strcmp(json_key->private_key_id,
+                    "e6b5137873db8d2ef81e06a47289e6434ec8a165") == 0);
   GPR_ASSERT(json_key->client_id != NULL &&
-             !strcmp(json_key->client_id,
-                     "777-abaslkan11hlb6nmim3bpspl31ud.apps."
-                     "googleusercontent.com"));
+             strcmp(json_key->client_id,
+                    "777-abaslkan11hlb6nmim3bpspl31ud.apps."
+                    "googleusercontent.com") == 0);
   GPR_ASSERT(json_key->client_email != NULL &&
-             !strcmp(json_key->client_email,
-                     "777-abaslkan11hlb6nmim3bpspl31ud@developer."
-                     "gserviceaccount.com"));
-  if (scope != NULL) GPR_ASSERT(!strcmp(scope, test_scope));
+             strcmp(json_key->client_email,
+                    "777-abaslkan11hlb6nmim3bpspl31ud@developer."
+                    "gserviceaccount.com") == 0);
+  if (scope != NULL) GPR_ASSERT(strcmp(scope, test_scope) == 0);
   GPR_ASSERT(!gpr_time_cmp(token_lifetime, grpc_max_auth_token_lifetime));
 }
 
@@ -517,12 +520,12 @@ static void validate_service_account_http_request(
   GPR_ASSERT(!memcmp(expected_body, body, body_size));
   gpr_free(expected_body);
   GPR_ASSERT(request->use_ssl);
-  GPR_ASSERT(!strcmp(request->host, "www.googleapis.com"));
-  GPR_ASSERT(!strcmp(request->path, "/oauth2/v3/token"));
+  GPR_ASSERT(strcmp(request->host, "www.googleapis.com") == 0);
+  GPR_ASSERT(strcmp(request->path, "/oauth2/v3/token") == 0);
   GPR_ASSERT(request->hdr_count == 1);
-  GPR_ASSERT(!strcmp(request->hdrs[0].key, "Content-Type"));
-  GPR_ASSERT(
-      !strcmp(request->hdrs[0].value, "application/x-www-form-urlencoded"));
+  GPR_ASSERT(strcmp(request->hdrs[0].key, "Content-Type") == 0);
+  GPR_ASSERT(strcmp(request->hdrs[0].value,
+                    "application/x-www-form-urlencoded") == 0);
 }
 
 static int service_account_httpcli_post_success(
@@ -626,12 +629,12 @@ static void on_jwt_creds_get_metadata_success(void *user_data,
   gpr_asprintf(&expected_md_value, "Bearer %s", test_signed_jwt);
   GPR_ASSERT(status == GRPC_CREDENTIALS_OK);
   GPR_ASSERT(num_md == 1);
-  GPR_ASSERT(
-      !strcmp(grpc_mdstr_as_c_string(md_elems[0]->key), "Authorization"));
-  GPR_ASSERT(
-      !strcmp(grpc_mdstr_as_c_string(md_elems[0]->value), expected_md_value));
+  GPR_ASSERT(strcmp(grpc_mdstr_as_c_string(md_elems[0]->key),
+                    "Authorization") == 0);
+  GPR_ASSERT(strcmp(grpc_mdstr_as_c_string(md_elems[0]->value),
+                    expected_md_value) == 0);
   GPR_ASSERT(user_data != NULL);
-  GPR_ASSERT(!strcmp((const char *)user_data, test_user_data));
+  GPR_ASSERT(strcmp((const char *)user_data, test_user_data) == 0);
   gpr_free(expected_md_value);
 }
 
@@ -642,7 +645,7 @@ static void on_jwt_creds_get_metadata_failure(void *user_data,
   GPR_ASSERT(status == GRPC_CREDENTIALS_ERROR);
   GPR_ASSERT(num_md == 0);
   GPR_ASSERT(user_data != NULL);
-  GPR_ASSERT(!strcmp((const char *)user_data, test_user_data));
+  GPR_ASSERT(strcmp((const char *)user_data, test_user_data) == 0);
 }
 
 static void test_jwt_creds_success(void) {

--- a/test/core/security/json_token_test.c
+++ b/test/core/security/json_token_test.c
@@ -102,18 +102,18 @@ static void test_parse_json_key_success(void) {
       grpc_auth_json_key_create_from_string(json_string);
   GPR_ASSERT(grpc_auth_json_key_is_valid(&json_key));
   GPR_ASSERT(json_key.type != NULL &&
-             !(strcmp(json_key.type, "service_account")));
+             strcmp(json_key.type, "service_account") == 0);
   GPR_ASSERT(json_key.private_key_id != NULL &&
-             !strcmp(json_key.private_key_id,
-                     "e6b5137873db8d2ef81e06a47289e6434ec8a165"));
+             strcmp(json_key.private_key_id,
+                    "e6b5137873db8d2ef81e06a47289e6434ec8a165") == 0);
   GPR_ASSERT(json_key.client_id != NULL &&
-             !strcmp(json_key.client_id,
-                     "777-abaslkan11hlb6nmim3bpspl31ud.apps."
-                     "googleusercontent.com"));
+             strcmp(json_key.client_id,
+                    "777-abaslkan11hlb6nmim3bpspl31ud.apps."
+                    "googleusercontent.com") == 0);
   GPR_ASSERT(json_key.client_email != NULL &&
-             !strcmp(json_key.client_email,
-                     "777-abaslkan11hlb6nmim3bpspl31ud@developer."
-                     "gserviceaccount.com"));
+             strcmp(json_key.client_email,
+                    "777-abaslkan11hlb6nmim3bpspl31ud@developer."
+                    "gserviceaccount.com") == 0);
   GPR_ASSERT(json_key.private_key != NULL);
   gpr_free(json_string);
   grpc_auth_json_key_destruct(&json_key);
@@ -248,15 +248,16 @@ static void check_jwt_header(grpc_json *header) {
   }
   GPR_ASSERT(alg != NULL);
   GPR_ASSERT(alg->type == GRPC_JSON_STRING);
-  GPR_ASSERT(!strcmp(alg->value, "RS256"));
+  GPR_ASSERT(strcmp(alg->value, "RS256") == 0);
 
   GPR_ASSERT(typ != NULL);
   GPR_ASSERT(typ->type == GRPC_JSON_STRING);
-  GPR_ASSERT(!strcmp(typ->value, "JWT"));
+  GPR_ASSERT(strcmp(typ->value, "JWT") == 0);
 
   GPR_ASSERT(kid != NULL);
   GPR_ASSERT(kid->type == GRPC_JSON_STRING);
-  GPR_ASSERT(!strcmp(kid->value, "e6b5137873db8d2ef81e06a47289e6434ec8a165"));
+  GPR_ASSERT(strcmp(kid->value,
+                    "e6b5137873db8d2ef81e06a47289e6434ec8a165") == 0);
 }
 
 static void check_jwt_claim(grpc_json *claim, const char *expected_audience,
@@ -290,27 +291,26 @@ static void check_jwt_claim(grpc_json *claim, const char *expected_audience,
 
   GPR_ASSERT(iss != NULL);
   GPR_ASSERT(iss->type == GRPC_JSON_STRING);
-  GPR_ASSERT(
-      !strcmp(
-          iss->value,
-          "777-abaslkan11hlb6nmim3bpspl31ud@developer.gserviceaccount.com"));
+  GPR_ASSERT(strcmp(iss->value,
+          "777-abaslkan11hlb6nmim3bpspl31ud@developer.gserviceaccount.com")
+             ==0);
 
   if (expected_scope != NULL) {
     GPR_ASSERT(scope != NULL);
     GPR_ASSERT(sub == NULL);
     GPR_ASSERT(scope->type == GRPC_JSON_STRING);
-    GPR_ASSERT(!strcmp(scope->value, expected_scope));
+    GPR_ASSERT(strcmp(scope->value, expected_scope) == 0);
   } else {
     /* Claims without scope must have a sub. */
     GPR_ASSERT(scope == NULL);
     GPR_ASSERT(sub != NULL);
     GPR_ASSERT(sub->type == GRPC_JSON_STRING);
-    GPR_ASSERT(!strcmp(iss->value, sub->value));
+    GPR_ASSERT(strcmp(iss->value, sub->value) == 0);
   }
 
   GPR_ASSERT(aud != NULL);
   GPR_ASSERT(aud->type == GRPC_JSON_STRING);
-  GPR_ASSERT(!strcmp(aud->value, expected_audience));
+  GPR_ASSERT(strcmp(aud->value, expected_audience) == 0);
 
   GPR_ASSERT(exp != NULL);
   GPR_ASSERT(exp->type == GRPC_JSON_NUMBER);

--- a/test/core/support/env_test.c
+++ b/test/core/support/env_test.c
@@ -53,7 +53,7 @@ static void test_setenv_getenv(void) {
   gpr_setenv(name, value);
   retrieved_value = gpr_getenv(name);
   GPR_ASSERT(retrieved_value != NULL);
-  GPR_ASSERT(!strcmp(value, retrieved_value));
+  GPR_ASSERT(strcmp(value, retrieved_value) == 0);
   gpr_free(retrieved_value);
 }
 


### PR DESCRIPTION
Change all !str[n]cmp to be str[n]cmp == 0 consistently across the codebase.

Issue #231

Signed-off-by: Ronnie Sahlberg <ronniesahlberg@gmail.com>