### PR TITLE
README: fix the path to the python requirements.txt file

### DIFF
--- a/src/python/README.md
+++ b/src/python/README.md
@@ -46,7 +46,7 @@ Installing
 
 - Install gRPC Python's dependencies
 ```
-$ pip install -r requirements.txt
+$ pip install -r src/python/requirements.txt
 ```
 
 - Install gRPC Python


### PR DESCRIPTION
All the other commands in the README are supposed to be run from grpc root.
Change the requirements.txt command to be so too.

Signed-off-by: Ronnie Sahlberg <ronniesahlberg@gmail.com>