### PR TITLE
Add missing GRPC_OVERRIDE, NFC

### DIFF
--- a/include/grpc++/async_unary_call.h
+++ b/include/grpc++/async_unary_call.h
@@ -92,7 +92,7 @@ class ServerAsyncResponseWriter GRPC_FINAL
   explicit ServerAsyncResponseWriter(ServerContext* ctx)
       : call_(nullptr, nullptr, nullptr), ctx_(ctx) {}
 
-  void SendInitialMetadata(void* tag) {
+  void SendInitialMetadata(void* tag) GRPC_OVERRIDE {
     GPR_ASSERT(!ctx_->sent_initial_metadata_);
 
     meta_buf_.Reset(tag);

--- a/include/grpc++/server.h
+++ b/include/grpc++/server.h
@@ -96,7 +96,7 @@ class Server GRPC_FINAL : private CallHook,
   void RequestAsyncCall(void* registered_method, ServerContext* context,
                         grpc::protobuf::Message* request,
                         ServerAsyncStreamingInterface* stream,
-                        CompletionQueue* cq, void* tag);
+                        CompletionQueue* cq, void* tag) GRPC_OVERRIDE;
 
   // Completion queue.
   CompletionQueue cq_;

--- a/test/cpp/qps/client_async.cc
+++ b/test/cpp/qps/client_async.cc
@@ -94,7 +94,7 @@ class ClientRpcContextUnaryImpl : public ClientRpcContext {
     hist->Add((Timer::Now() - start_) * 1e9);
   }
 
-  void StartNewClone() {
+  void StartNewClone() GRPC_OVERRIDE {
     new ClientRpcContextUnaryImpl(stub_, req_, start_req_, callback_);
   }
 
@@ -175,7 +175,7 @@ class AsyncClient GRPC_FINAL : public Client {
     }
   }
 
-  void ThreadFunc(Histogram *histogram, size_t thread_idx) {
+  void ThreadFunc(Histogram *histogram, size_t thread_idx) GRPC_OVERRIDE {
     void *got_tag;
     bool ok;
     cli_cqs_[thread_idx]->Next(&got_tag, &ok);


### PR DESCRIPTION
Testing asan configuration with the latest clang compiler fails due to
the warning `-Winconsistent-missing-override`. This patch fixes it.