### PR TITLE
Add and use a special API for creating backup pollers

### DIFF
--- a/src/core/iomgr/pollset_multipoller_with_poll_posix.c
+++ b/src/core/iomgr/pollset_multipoller_with_poll_posix.c
@@ -248,4 +248,9 @@ void grpc_platform_become_multipoller(grpc_pollset *pollset, grpc_fd **fds,
   }
 }
 
+void grpc_platform_become_backup_poller(grpc_pollset *pollset, grpc_fd **fds,
+                                        size_t nfds) {
+  grpc_platform_become_multipoller(pollset, fds, nfds);
+}
+
 #endif

--- a/src/core/iomgr/pollset_posix.c
+++ b/src/core/iomgr/pollset_posix.c
@@ -102,6 +102,8 @@ void grpc_pollset_global_init(void) {
   /* initialize the backup pollset */
   grpc_pollset_init(&g_backup_pollset);
 
+  grpc_platform_become_backup_poller(&g_backup_pollset, NULL, 0);
+
   /* start the backup poller thread */
   g_shutdown_backup_poller = 0;
   gpr_event_init(&g_backup_poller_done);

--- a/src/core/iomgr/pollset_posix.h
+++ b/src/core/iomgr/pollset_posix.h
@@ -104,4 +104,8 @@ grpc_pollset *grpc_backup_pollset(void);
 void grpc_platform_become_multipoller(grpc_pollset *pollset,
                                       struct grpc_fd **fds, size_t fd_count);
 
+/* Set up backup poller. This probably wants to be a multipoller. */
+void grpc_platform_become_backup_poller(grpc_pollset *pollset, struct grpc_fd **fds,
+                                        size_t fd_count);
+
 #endif  /* GRPC_INTERNAL_CORE_IOMGR_POLLSET_POSIX_H */


### PR DESCRIPTION
This solves two issues:
1. The backup poller in Linux wants to be level triggered epoll. We want
epoll rather than poll (even with a single fd), but we also want level
triggering so we don't get spurious events that have already been
handled.
2. We can avoid potential issues in performance testing by ensuring the
backup poller doesn't randomly change in the background -- keeping in
mind that the case where we have a non-multipoller backup poller is
uninteresting in real environments.