### PR TITLE
Use ssl name override if it's in the channel argument

### DIFF
--- a/include/grpc++/channel_arguments.h
+++ b/include/grpc++/channel_arguments.h
@@ -66,7 +66,7 @@ class ChannelArguments {
   void SetChannelArgs(grpc_channel_args* channel_args) const;
 
  private:
-  friend class Channel;
+  friend class SecureCredentials;
   friend class testing::ChannelArgumentsTest;
 
   // TODO(yangg) implement copy and assign

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -54,7 +54,8 @@ class SecureCredentials GRPC_FINAL : public Credentials {
     grpc_channel_args channel_args;
     args.SetChannelArgs(&channel_args);
     return std::shared_ptr<ChannelInterface>(new Channel(
-        target,
+        args.GetSslTargetNameOverride().empty()
+            ? target : args.GetSslTargetNameOverride(),
         grpc_secure_channel_create(c_creds_, target.c_str(), &channel_args)));
   }
 


### PR DESCRIPTION
This logic was lost in pr #835 and has caused our interop test to fail.