### PR TITLE
Fix client sending invalid GOAWAY last-stream-id

### DIFF
--- a/src/core/transport/chttp2_transport.c
+++ b/src/core/transport/chttp2_transport.c
@@ -1655,7 +1655,9 @@ static int process_read(transport *t, gpr_slice slice) {
       if (!init_frame_parser(t)) {
         return 0;
       }
-      t->last_incoming_stream_id = t->incoming_stream_id;
+      if (!t->is_client) {
+        t->last_incoming_stream_id = t->incoming_stream_id;
+      }
       if (t->incoming_frame_size == 0) {
         if (!parse_frame_slice(t, gpr_empty_slice(), 1)) {
           return 0;

--- a/src/core/transport/chttp2_transport.c
+++ b/src/core/transport/chttp2_transport.c
@@ -1655,6 +1655,12 @@ static int process_read(transport *t, gpr_slice slice) {
       if (!init_frame_parser(t)) {
         return 0;
       }
+      /* t->last_incoming_stream_id is used as last-stream-id when
+         sending GOAWAY frame.
+         https://tools.ietf.org/html/draft-ietf-httpbis-http2-17#section-6.8
+         says that last-stream-id is peer-initiated stream ID.  So,
+         since we don't have server pushed streams, client should send
+         GOAWAY last-stream-id=0 in this case. */
       if (!t->is_client) {
         t->last_incoming_stream_id = t->incoming_stream_id;
       }


### PR DESCRIPTION
Previously client sends its own initiated stream ID in last-stream-id
field of GOAWAY, which misses the point in HTTP/2 specification.
Unless server push is utilized heavily, client should not assign its
transport's last_incoming_stream_id, since it is a response from
server to client's initiated stream ID.  This commit fixes it.

See GH-1024