### PR TITLE
Fix duplicated symbols

### DIFF
--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -56,6 +56,8 @@
 #include "completion_queue.h"
 #include "byte_buffer.h"
 
+zend_class_entry *grpc_ce_call;
+
 /* Frees and destroys an instance of wrapped_grpc_call */
 void free_wrapped_grpc_call(void *object TSRMLS_DC) {
   wrapped_grpc_call *call = (wrapped_grpc_call *)object;

--- a/src/php/ext/grpc/call.h
+++ b/src/php/ext/grpc/call.h
@@ -57,7 +57,7 @@
   } while (0)
 
 /* Class entry for the Call PHP class */
-zend_class_entry *grpc_ce_call;
+extern zend_class_entry *grpc_ce_call;
 
 /* Wrapper struct for grpc_call that can be associated with a PHP object */
 typedef struct wrapped_grpc_call {

--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -55,6 +55,8 @@
 #include "server.h"
 #include "credentials.h"
 
+zend_class_entry *grpc_ce_channel;
+
 /* Frees and destroys an instance of wrapped_grpc_channel */
 void free_wrapped_grpc_channel(void *object TSRMLS_DC) {
   wrapped_grpc_channel *channel = (wrapped_grpc_channel *)object;

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -46,7 +46,7 @@
 #include "grpc/grpc.h"
 
 /* Class entry for the PHP Channel class */
-zend_class_entry *grpc_ce_channel;
+extern zend_class_entry *grpc_ce_channel;
 
 /* Wrapper struct for grpc_channel that can be associated with a PHP object */
 typedef struct wrapped_grpc_channel {

--- a/src/php/ext/grpc/completion_queue.c
+++ b/src/php/ext/grpc/completion_queue.c
@@ -52,6 +52,8 @@
 #include "event.h"
 #include "timeval.h"
 
+zend_class_entry *grpc_ce_completion_queue;
+
 /* Frees and destroys a wrapped instance of grpc_completion_queue */
 void free_wrapped_grpc_completion_queue(void *object TSRMLS_DC) {
   wrapped_grpc_completion_queue *queue = NULL;

--- a/src/php/ext/grpc/completion_queue.h
+++ b/src/php/ext/grpc/completion_queue.h
@@ -46,7 +46,7 @@
 #include "grpc/grpc.h"
 
 /* Class entry for the PHP CompletionQueue class */
-zend_class_entry *grpc_ce_completion_queue;
+extern zend_class_entry *grpc_ce_completion_queue;
 
 /* Wrapper class for grpc_completion_queue that can be associated with a
    PHP object */

--- a/src/php/ext/grpc/credentials.c
+++ b/src/php/ext/grpc/credentials.c
@@ -49,6 +49,8 @@
 #include "grpc/grpc.h"
 #include "grpc/grpc_security.h"
 
+zend_class_entry *grpc_ce_credentials;
+
 /* Frees and destroys an instance of wrapped_grpc_credentials */
 void free_wrapped_grpc_credentials(void *object TSRMLS_DC) {
   wrapped_grpc_credentials *creds = (wrapped_grpc_credentials *)object;

--- a/src/php/ext/grpc/credentials.h
+++ b/src/php/ext/grpc/credentials.h
@@ -47,7 +47,7 @@
 #include "grpc/grpc_security.h"
 
 /* Class entry for the Credentials PHP class */
-zend_class_entry *grpc_ce_credentials;
+extern zend_class_entry *grpc_ce_credentials;
 
 /* Wrapper struct for grpc_credentials that can be associated with a PHP
  * object */

--- a/src/php/ext/grpc/server.c
+++ b/src/php/ext/grpc/server.c
@@ -56,6 +56,8 @@
 #include "channel.h"
 #include "server_credentials.h"
 
+zend_class_entry *grpc_ce_server;
+
 /* Frees and destroys an instance of wrapped_grpc_server */
 void free_wrapped_grpc_server(void *object TSRMLS_DC) {
   wrapped_grpc_server *server = (wrapped_grpc_server *)object;

--- a/src/php/ext/grpc/server.h
+++ b/src/php/ext/grpc/server.h
@@ -46,7 +46,7 @@
 #include "grpc/grpc.h"
 
 /* Class entry for the Server PHP class */
-zend_class_entry *grpc_ce_server;
+extern zend_class_entry *grpc_ce_server;
 
 /* Wrapper struct for grpc_server that can be associated with a PHP object */
 typedef struct wrapped_grpc_server {

--- a/src/php/ext/grpc/server_credentials.c
+++ b/src/php/ext/grpc/server_credentials.c
@@ -49,6 +49,8 @@
 #include "grpc/grpc.h"
 #include "grpc/grpc_security.h"
 
+zend_class_entry *grpc_ce_server_credentials;
+
 /* Frees and destroys an instace of wrapped_grpc_server_credentials */
 void free_wrapped_grpc_server_credentials(void *object TSRMLS_DC) {
   wrapped_grpc_server_credentials *creds =

--- a/src/php/ext/grpc/server_credentials.h
+++ b/src/php/ext/grpc/server_credentials.h
@@ -47,7 +47,7 @@
 #include "grpc/grpc_security.h"
 
 /* Class entry for the Server_Credentials PHP class */
-zend_class_entry *grpc_ce_server_credentials;
+extern zend_class_entry *grpc_ce_server_credentials;
 
 /* Wrapper struct for grpc_server_credentials that can be associated with a PHP
  * object */

--- a/src/php/ext/grpc/timeval.c
+++ b/src/php/ext/grpc/timeval.c
@@ -50,6 +50,8 @@
 #include "grpc/grpc.h"
 #include "grpc/support/time.h"
 
+zend_class_entry *grpc_ce_timeval;
+
 /* Frees and destroys an instance of wrapped_grpc_call */
 void free_wrapped_grpc_timeval(void *object TSRMLS_DC) { efree(object); }
 

--- a/src/php/ext/grpc/timeval.h
+++ b/src/php/ext/grpc/timeval.h
@@ -47,7 +47,7 @@
 #include "grpc/support/time.h"
 
 /* Class entry for the Timeval PHP Class */
-zend_class_entry *grpc_ce_timeval;
+extern zend_class_entry *grpc_ce_timeval;
 
 /* Wrapper struct for timeval that can be associated with a PHP object */
 typedef struct wrapped_grpc_timeval {


### PR DESCRIPTION
Fix duplicated symbols caused by having definition instead of declaration in
header file.