### PR TITLE
Allowing us to import google::protobuf::int64.

### DIFF
--- a/include/grpc++/config.h
+++ b/include/grpc++/config.h
@@ -42,14 +42,19 @@
 #define GRPC_OVERRIDE override
 #endif
 
-#ifndef GRPC_CUSTOM_STRING
-#include <string>
-#define GRPC_CUSTOM_STRING std::string
+#ifndef GRPC_CUSTOM_PROTOBUF_INT64
+#include <google/protobuf/stubs/common.h>
+#define GRPC_CUSTOM_PROTOBUF_INT64 ::google::protobuf::int64
 #endif
 
 #ifndef GRPC_CUSTOM_MESSAGE
 #include <google/protobuf/message.h>
 #define GRPC_CUSTOM_MESSAGE ::google::protobuf::Message
+#endif
+
+#ifndef GRPC_CUSTOM_STRING
+#include <string>
+#define GRPC_CUSTOM_STRING std::string
 #endif
 
 #ifndef GRPC_CUSTOM_ZEROCOPYOUTPUTSTREAM
@@ -66,6 +71,7 @@ typedef GRPC_CUSTOM_STRING string;
 namespace protobuf {
 
 typedef GRPC_CUSTOM_MESSAGE Message;
+typedef GRPC_CUSTOM_PROTOBUF_INT64 int64;
 
 namespace io {
 typedef GRPC_CUSTOM_ZEROCOPYOUTPUTSTREAM ZeroCopyOutputStream;

--- a/src/cpp/proto/proto_utils.cc
+++ b/src/cpp/proto/proto_utils.cc
@@ -84,7 +84,7 @@ class GrpcBufferWriter GRPC_FINAL
     byte_count_ -= count;
   }
 
-  gpr_int64 ByteCount() const GRPC_OVERRIDE { return byte_count_; }
+  grpc::protobuf::int64 ByteCount() const GRPC_OVERRIDE { return byte_count_; }
 
  private:
   const int block_size_;
@@ -142,7 +142,7 @@ class GrpcBufferReader GRPC_FINAL
     return false;
   }
 
-  gpr_int64 ByteCount() const GRPC_OVERRIDE {
+  grpc::protobuf::int64 ByteCount() const GRPC_OVERRIDE {
     return byte_count_ - backup_count_;
   }
 


### PR DESCRIPTION
If for any reason, our definition of gpr_int64 is different from the definition of google::protobuf::int64, the virtual override would fail, as this needs to be of the precisely exactly the same type.
That change allows us to use protobuf's int64 definition.