### PR TITLE
Implements #276

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1837,6 +1837,11 @@ test_cxx: buildtests_cxx
 	$(Q) $(BINDIR)/$(CONFIG)/thread_pool_test || ( echo test thread_pool_test failed ; exit 1 )
 
 
+test_python: static_c
+	$(E) "[RUN]     Testing python code"
+	$(Q) tools/run_tests/run_tests.py -lpython -c$(CONFIG)
+
+
 tools: privatelibs $(BINDIR)/$(CONFIG)/gen_hpack_tables $(BINDIR)/$(CONFIG)/grpc_create_jwt $(BINDIR)/$(CONFIG)/grpc_fetch_oauth2 $(BINDIR)/$(CONFIG)/grpc_print_google_default_creds_token
 
 buildbenchmarks: privatelibs $(BINDIR)/$(CONFIG)/grpc_completion_queue_benchmark $(BINDIR)/$(CONFIG)/low_level_ping_pong_benchmark

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -653,6 +653,11 @@ test_cxx: buildtests_cxx
 % endfor
 
 
+test_python: static_c
+	$(E) "[RUN]     Testing python code"
+	$(Q) tools/run_tests/run_tests.py -lpython -c$(CONFIG)
+
+
 tools: privatelibs\
 % for tgt in targets:
 % if tgt.build == 'tool':


### PR DESCRIPTION
Adds a Makefile target called 'test_python' that first builds grpc, then call run_tests.py to run the python tests for the current configuration.