### PR TITLE
wrap refresh token credentials in c++

### DIFF
--- a/include/grpc++/credentials.h
+++ b/include/grpc++/credentials.h
@@ -50,8 +50,8 @@ class Credentials {
 
  protected:
   friend std::unique_ptr<Credentials> CompositeCredentials(
-    const std::unique_ptr<Credentials>& creds1,
-    const std::unique_ptr<Credentials>& creds2);
+      const std::unique_ptr<Credentials>& creds1,
+      const std::unique_ptr<Credentials>& creds2);
 
   virtual SecureCredentials* AsSecureCredentials() = 0;
 
@@ -112,6 +112,12 @@ std::unique_ptr<Credentials> ServiceAccountCredentials(
 // will be cropped to this value.
 std::unique_ptr<Credentials> JWTCredentials(
     const grpc::string& json_key, std::chrono::seconds token_lifetime);
+
+// Builds refresh token credentials.
+// json_refresh_token is the JSON string containing the refresh token along
+// with a client_id and client_secret.
+std::unique_ptr<Credentials> RefreshTokenCredentials(
+    const grpc::string& json_refresh_token);
 
 // Builds IAM credentials.
 std::unique_ptr<Credentials> IAMCredentials(

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -55,7 +55,8 @@ class SecureCredentials GRPC_FINAL : public Credentials {
     args.SetChannelArgs(&channel_args);
     return std::shared_ptr<ChannelInterface>(new Channel(
         args.GetSslTargetNameOverride().empty()
-            ? target : args.GetSslTargetNameOverride(),
+            ? target
+            : args.GetSslTargetNameOverride(),
         grpc_secure_channel_create(c_creds_, target.c_str(), &channel_args)));
   }
 
@@ -111,7 +112,7 @@ std::unique_ptr<Credentials> ServiceAccountCredentials(
 
 // Builds JWT credentials.
 std::unique_ptr<Credentials> JWTCredentials(
-    const grpc::string &json_key, std::chrono::seconds token_lifetime) {
+    const grpc::string& json_key, std::chrono::seconds token_lifetime) {
   if (token_lifetime.count() <= 0) {
     gpr_log(GPR_ERROR,
             "Trying to create JWTCredentials with non-positive lifetime");
@@ -120,6 +121,13 @@ std::unique_ptr<Credentials> JWTCredentials(
   gpr_timespec lifetime = gpr_time_from_seconds(token_lifetime.count());
   return WrapCredentials(
       grpc_jwt_credentials_create(json_key.c_str(), lifetime));
+}
+
+// Builds refresh token credentials.
+std::unique_ptr<Credentials> RefreshTokenCredentials(
+    const grpc::string& json_refresh_token) {
+  return WrapCredentials(
+      grpc_refresh_token_credentials_create(json_refresh_token.c_str()));
 }
 
 // Builds IAM credentials.


### PR DESCRIPTION
Sorry there are some clang-format noise