### PR TITLE
Node differentiate between binary and string headers

### DIFF
--- a/src/node/ext/call.cc
+++ b/src/node/ext/call.cc
@@ -75,6 +75,9 @@ using v8::Value;
 NanCallback *Call::constructor;
 Persistent<FunctionTemplate> Call::fun_tpl;
 
+bool EndsWith(const char *str, const char *substr) {
+  return strcmp(str+strlen(str)-strlen(substr), substr) == 0;
+}
 
 bool CreateMetadataArray(Handle<Object> metadata, grpc_metadata_array *array,
                          shared_ptr<Resources> resources) {
@@ -99,14 +102,19 @@ bool CreateMetadataArray(Handle<Object> metadata, grpc_metadata_array *array,
       Handle<Value> value = values->Get(j);
       grpc_metadata *current = &array->metadata[array->count];
       current->key = **utf8_key;
-      if (::node::Buffer::HasInstance(value)) {
-        current->value = ::node::Buffer::Data(value);
-        current->value_length = ::node::Buffer::Length(value);
-        Persistent<Value> *handle = new Persistent<Value>();
-        NanAssignPersistent(*handle, value);
-        resources->handles.push_back(unique_ptr<PersistentHolder>(
-            new PersistentHolder(handle)));
-      } else if (value->IsString()) {
+      // Only allow binary headers for "-bin" keys
+      if (EndsWith(current->key, "-bin")) {
+        if (::node::Buffer::HasInstance(value)) {
+          current->value = ::node::Buffer::Data(value);
+          current->value_length = ::node::Buffer::Length(value);
+          Persistent<Value> *handle = new Persistent<Value>();
+          NanAssignPersistent(*handle, value);
+          resources->handles.push_back(unique_ptr<PersistentHolder>(
+              new PersistentHolder(handle)));
+          continue;
+        }
+      }
+      if (value->IsString()) {
         Handle<String> string_value = value->ToString();
         NanUtf8String *utf8_value = new NanUtf8String(string_value);
         resources->strings.push_back(unique_ptr<NanUtf8String>(utf8_value));
@@ -146,9 +154,13 @@ Handle<Value> ParseMetadata(const grpc_metadata_array *metadata_array) {
       array = NanNew<Array>(size_map[elem->key]);
       metadata_object->Set(key_string, array);
     }
-    array->Set(index_map[elem->key],
-               MakeFastBuffer(
-                   NanNewBufferHandle(elem->value, elem->value_length)));
+    if (EndsWith(elem->key, "-bin")) {
+      array->Set(index_map[elem->key],
+                 MakeFastBuffer(
+                     NanNewBufferHandle(elem->value, elem->value_length)));
+    } else {
+      array->Set(index_map[elem->key], NanNew(elem->value));
+    }
     index_map[elem->key] += 1;
   }
   return NanEscapeScope(metadata_object);

--- a/src/node/package.json
+++ b/src/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "author": "Google Inc.",
   "description": "gRPC Library for Node",
   "homepage": "http://www.grpc.io/",

--- a/src/node/test/call_test.js
+++ b/src/node/test/call_test.js
@@ -142,8 +142,8 @@ describe('call', function() {
       assert.doesNotThrow(function() {
         var batch = {};
         batch[grpc.opType.SEND_INITIAL_METADATA] = {
-          'key1': [new Buffer('value1')],
-          'key2': [new Buffer('value2')]
+          'key1-bin': [new Buffer('value1')],
+          'key2-bin': [new Buffer('value2')]
         };
         call.startBatch(batch, function(err, resp) {
           assert.ifError(err);

--- a/src/node/test/end_to_end_test.js
+++ b/src/node/test/end_to_end_test.js
@@ -138,21 +138,21 @@ describe('end-to-end', function() {
     client_batch[grpc.opType.RECV_STATUS_ON_CLIENT] = true;
     call.startBatch(client_batch, function(err, response) {
       assert.ifError(err);
-      assert(response['send metadata']);
-      assert(response['client close']);
-      assert(response.hasOwnProperty('metadata'));
-      assert.strictEqual(response.metadata.server_key[0].toString(),
-                         'server_value');
-      assert.deepEqual(response.status, {'code': grpc.status.OK,
-                                         'details': status_text,
-                                         'metadata': {}});
+      assert.deepEqual(response,{
+        'send metadata': true,
+        'client close': true,
+        metadata: {server_key: ['server_value']},
+        status: {'code': grpc.status.OK,
+                 'details': status_text,
+                 'metadata': {}}
+      });
       done();
     });
 
     server.requestCall(function(err, call_details) {
       var new_call = call_details['new call'];
       assert.notEqual(new_call, null);
-      assert.strictEqual(new_call.metadata.client_key[0].toString(),
+      assert.strictEqual(new_call.metadata.client_key[0],
                          'client_value');
       var server_call = new_call.call;
       assert.notEqual(server_call, null);


### PR DESCRIPTION
This closes #559. Since it removes the ability to pass binary headers for keys that don't end in "-bin", it breaks the API, so it requires a version bump.