### PR TITLE
Fixes for Windows atomics.

### DIFF
--- a/include/grpc/support/atm.h
+++ b/include/grpc/support/atm.h
@@ -83,7 +83,7 @@
 #include <grpc/support/atm_gcc_atomic.h>
 #elif defined(GPR_GCC_SYNC)
 #include <grpc/support/atm_gcc_sync.h>
-#elif defined(GPR_WIN32)
+#elif defined(GPR_WIN32_ATOMIC)
 #include <grpc/support/atm_win32.h>
 #else
 #error could not determine platform for atm

--- a/include/grpc/support/atm_win32.h
+++ b/include/grpc/support/atm_win32.h
@@ -51,7 +51,7 @@ static __inline gpr_atm gpr_atm_acq_load(const gpr_atm *p) {
 
 static __inline gpr_atm gpr_atm_no_barrier_load(const gpr_atm *p) {
   /* TODO(dklempner): Can we implement something better here? */
-  gpr_atm_acq_load(p);
+  return gpr_atm_acq_load(p);
 }
 
 static __inline void gpr_atm_rel_store(gpr_atm *p, gpr_atm value) {

--- a/include/grpc/support/port_platform.h
+++ b/include/grpc/support/port_platform.h
@@ -43,11 +43,21 @@
 #define GPR_ARCH_64 1
 #define GPR_GETPID_IN_PROCESS_H 1
 #define GPR_WINSOCK_SOCKET 1
+#ifdef __GNUC__
+#define GPR_GCC_ATOMIC 1
+#else
+#define GPR_WIN32_ATOMIC 1
+#endif
 #elif defined(_WIN32) || defined(WIN32)
 #define GPR_ARCH_32 1
 #define GPR_WIN32 1
 #define GPR_GETPID_IN_PROCESS_H 1
 #define GPR_WINSOCK_SOCKET 1
+#ifdef __GNUC__
+#define GPR_GCC_ATOMIC 1
+#else
+#define GPR_WIN32_ATOMIC 1
+#endif
 #elif defined(ANDROID) || defined(__ANDROID__)
 #define GPR_ANDROID 1
 #define GPR_ARCH_32 1
@@ -167,8 +177,8 @@
 #endif
 
 /* Validate platform combinations */
-#if defined(GPR_GCC_ATOMIC) + defined(GPR_GCC_SYNC) + defined(GPR_WIN32) != 1
-#error Must define exactly one of GPR_GCC_ATOMIC, GPR_GCC_SYNC, GPR_WIN32
+#if defined(GPR_GCC_ATOMIC) + defined(GPR_GCC_SYNC) + defined(GPR_WIN32_ATOMIC) != 1
+#error Must define exactly one of GPR_GCC_ATOMIC, GPR_GCC_SYNC, GPR_WIN32_ATOMIC
 #endif
 
 #if defined(GPR_ARCH_32) + defined(GPR_ARCH_64) != 1


### PR DESCRIPTION
-) gpr_atm_no_barrier_load should actually return something.
-) If compiling under mingw32, your compiler is gcc and gcc atomics become available.