### PR TITLE
Fix:  Segfault in ServerContext.IsCancelled #985 

### DIFF
--- a/src/cpp/common/completion_queue.cc
+++ b/src/cpp/common/completion_queue.cc
@@ -95,8 +95,8 @@ bool CompletionQueue::Pluck(CompletionQueueTag* tag) {
 void CompletionQueue::TryPluck(CompletionQueueTag* tag) {
   std::unique_ptr<grpc_event, EventDeleter> ev;
 
-  ev.reset(grpc_completion_queue_pluck(cq_, tag, gpr_inf_past));
   if (!ev) return;
+  ev.reset(grpc_completion_queue_pluck(cq_, tag, gpr_inf_past));
   bool ok = ev->data.op_complete == GRPC_OP_OK;
   void* ignored = tag;
   // the tag must be swallowed if using TryPluck


### PR DESCRIPTION
root cause:
we are accessing the "ev.reset" without valdating the ev. hence when ev is NULL it is crashing while calling reset.

Fix:
ev is validated  before accessing it.