### PR TITLE
Make metadata_test test_things_stick_around use fewer strings

### DIFF
--- a/test/core/transport/metadata_test.c
+++ b/test/core/transport/metadata_test.c
@@ -178,7 +178,7 @@ static void test_things_stick_around(void) {
   grpc_mdctx *ctx;
   int i, j;
   char *buffer;
-  int nstrs = 10000;
+  int nstrs = 1000;
   grpc_mdstr **strs = gpr_malloc(sizeof(grpc_mdstr *) * nstrs);
   int *shuf = gpr_malloc(sizeof(int) * nstrs);
   grpc_mdstr *test;


### PR DESCRIPTION
This test is quadratic in nstr and times out under tsan.