### PR TITLE
Various Windows fixes.

### DIFF
--- a/examples/pubsub/publisher_test.cc
+++ b/examples/pubsub/publisher_test.cc
@@ -107,7 +107,7 @@ class PublisherTest : public ::testing::Test {
     int port = grpc_pick_unused_port_or_die();
     server_address_ << "localhost:" << port;
     ServerBuilder builder;
-    builder.AddPort(server_address_.str(), grpc::InsecureServerCredentials());
+    builder.AddListeningPort(server_address_.str(), grpc::InsecureServerCredentials());
     builder.RegisterService(&service_);
     server_ = builder.BuildAndStart();
 

--- a/examples/pubsub/subscriber_test.cc
+++ b/examples/pubsub/subscriber_test.cc
@@ -105,7 +105,7 @@ class SubscriberTest : public ::testing::Test {
     int port = grpc_pick_unused_port_or_die();
     server_address_ << "localhost:" << port;
     ServerBuilder builder;
-    builder.AddPort(server_address_.str(), grpc::InsecureServerCredentials());
+    builder.AddListeningPort(server_address_.str(), grpc::InsecureServerCredentials());
     builder.RegisterService(&service_);
     server_ = builder.BuildAndStart();
 

--- a/include/grpc++/server.h
+++ b/include/grpc++/server.h
@@ -86,7 +86,7 @@ class Server GRPC_FINAL : private CallHook,
   bool RegisterAsyncService(AsynchronousService* service);
   void RegisterAsyncGenericService(AsyncGenericService* service);
   // Add a listening port. Can be called multiple times.
-  int AddPort(const grpc::string& addr, ServerCredentials* creds);
+  int AddListeningPort(const grpc::string& addr, ServerCredentials* creds);
   // Start the server.
   bool Start();
 

--- a/include/grpc++/server_builder.h
+++ b/include/grpc++/server_builder.h
@@ -69,9 +69,9 @@ class ServerBuilder {
   void RegisterAsyncGenericService(AsyncGenericService* service);
 
   // Add a listening port. Can be called multiple times.
-  void AddPort(const grpc::string& addr,
-               std::shared_ptr<ServerCredentials> creds,
-               int* selected_port = nullptr);
+  void AddListeningPort(const grpc::string& addr,
+                        std::shared_ptr<ServerCredentials> creds,
+                        int* selected_port = nullptr);
 
   // Set the thread pool used for running appliation rpc handlers.
   // Does not take ownership.

--- a/include/grpc/support/atm_win32.h
+++ b/include/grpc/support/atm_win32.h
@@ -63,25 +63,31 @@ static __inline int gpr_atm_no_barrier_cas(gpr_atm *p, gpr_atm o, gpr_atm n) {
 /* InterlockedCompareExchangePointerNoFence() not available on vista or
    windows7 */
 #ifdef GPR_ARCH_64
-  return o == (gpr_atm)InterlockedCompareExchangeAcquire64(p, n, o);
+  return o == (gpr_atm)InterlockedCompareExchangeAcquire64((volatile LONGLONG *) p,
+                                                           (LONGLONG) n, (LONGLONG) o);
 #else
-  return o == (gpr_atm)InterlockedCompareExchangeAcquire(p, n, o);
+  return o == (gpr_atm)InterlockedCompareExchangeAcquire((volatile LONG *) p,
+                                                         (LONG) n, (LONG) o);
 #endif
 }
 
 static __inline int gpr_atm_acq_cas(gpr_atm *p, gpr_atm o, gpr_atm n) {
 #ifdef GPR_ARCH_64
-  return o == (gpr_atm)InterlockedCompareExchangeAcquire64(p, n, o);
+  return o == (gpr_atm)InterlockedCompareExchangeAcquire64((volatile LONGLONG) p,
+                                                           (LONGLONG) n, (LONGLONG) o);
 #else
-  return o == (gpr_atm)InterlockedCompareExchangeAcquire(p, n, o);
+  return o == (gpr_atm)InterlockedCompareExchangeAcquire((volatile LONG *) p,
+                                                         (LONG) n, (LONG) o);
 #endif
 }
 
 static __inline int gpr_atm_rel_cas(gpr_atm *p, gpr_atm o, gpr_atm n) {
 #ifdef GPR_ARCH_64
-  return o == (gpr_atm)InterlockedCompareExchangeRelease64(p, n, o);
+  return o == (gpr_atm)InterlockedCompareExchangeRelease64((volatile LONGLONG *) p,
+                                                           (LONGLONG) n, (LONGLONG) o);
 #else
-  return o == (gpr_atm)InterlockedCompareExchangeRelease(p, n, o);
+  return o == (gpr_atm)InterlockedCompareExchangeRelease((volatile LONG *) p,
+                                                         (LONG) n, (LONG) o);
 #endif
 }
 
@@ -101,11 +107,15 @@ static __inline gpr_atm gpr_atm_full_fetch_add(gpr_atm *p, gpr_atm delta) {
 #ifdef GPR_ARCH_64
   do {
     old = *p;
-  } while (old != (gpr_atm)InterlockedCompareExchange64(p, old + delta, old));
+  } while (old != (gpr_atm)InterlockedCompareExchange64((volatile LONGLONG *) p,
+                                                        (LONGLONG) old + delta,
+                                                        (LONGLONG) old));
 #else
   do {
     old = *p;
-  } while (old != (gpr_atm)InterlockedCompareExchange(p, old + delta, old));
+  } while (old != (gpr_atm)InterlockedCompareExchange((volatile LONG *) p,
+                                                      (LONG) old + delta,
+                                                      (LONG) old));
 #endif
   return old;
 }

--- a/src/core/iomgr/sockaddr_win32.h
+++ b/src/core/iomgr/sockaddr_win32.h
@@ -38,4 +38,9 @@
 #include <winsock2.h>
 #include <mswsock.h>
 
+#ifdef __MINGW32__
+/* mingw seems to be missing that definition. */
+const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
+#endif
+
 #endif  /* GRPC_INTERNAL_CORE_IOMGR_SOCKADDR_WIN32_H */

--- a/src/core/iomgr/tcp_server_windows.c
+++ b/src/core/iomgr/tcp_server_windows.c
@@ -53,9 +53,6 @@
 #define INIT_PORT_CAP 2
 #define MIN_SAFE_ACCEPT_QUEUE_SIZE 100
 
-static gpr_once s_init_max_accept_queue_size;
-static int s_max_accept_queue_size;
-
 /* one listening port */
 typedef struct server_port {
   gpr_uint8 addresses[sizeof(struct sockaddr_in6) * 2 + 32];

--- a/src/core/iomgr/tcp_windows.c
+++ b/src/core/iomgr/tcp_windows.c
@@ -172,7 +172,7 @@ static void win_notify_on_read(grpc_endpoint *ep,
   tcp->read_slice = gpr_slice_malloc(8192);
 
   buffer.len = GPR_SLICE_LENGTH(tcp->read_slice);
-  buffer.buf = GPR_SLICE_START_PTR(tcp->read_slice);
+  buffer.buf = (char *)GPR_SLICE_START_PTR(tcp->read_slice);
 
   gpr_log(GPR_DEBUG, "win_notify_on_read: calling WSARecv without overlap");
   status = WSARecv(tcp->socket->socket, &buffer, 1, &bytes_read, &flags,
@@ -284,7 +284,7 @@ static grpc_endpoint_write_status win_write(grpc_endpoint *ep,
 
   for (i = 0; i < tcp->write_slices.count; i++) {
     buffers[i].len = GPR_SLICE_LENGTH(tcp->write_slices.slices[i]);
-    buffers[i].buf = GPR_SLICE_START_PTR(tcp->write_slices.slices[i]);
+    buffers[i].buf = (char *)GPR_SLICE_START_PTR(tcp->write_slices.slices[i]);
   }
 
   gpr_log(GPR_DEBUG, "win_write: calling WSASend without overlap");

--- a/src/core/support/env_win32.c
+++ b/src/core/support/env_win32.c
@@ -36,6 +36,7 @@
 #ifdef GPR_WIN32
 
 #include "src/core/support/env.h"
+#include "src/core/support/string.h"
 
 #include <stdlib.h>
 
@@ -43,14 +44,16 @@
 #include <grpc/support/log.h>
 
 char *gpr_getenv(const char *name) {
-  size_t required_size;
+  size_t size;
   char *result = NULL;
+  char *duplicated;
+  errno_t err;
 
-  getenv_s(&required_size, NULL, 0, name);
-  if (required_size == 0) return NULL;
-  result = gpr_malloc(required_size);
-  getenv_s(&required_size, result, required_size, name);
-  return result;
+  err = _dupenv_s(&result, &size, name);
+  if (err) return NULL;
+  duplicated = gpr_strdup(result);
+  free(result);
+  return duplicated;
 }
 
 void gpr_setenv(const char *name, const char *value) {

--- a/src/core/support/file_win32.c
+++ b/src/core/support/file_win32.c
@@ -72,7 +72,7 @@ FILE *gpr_tmpfile(const char *prefix, char **tmp_filename_out) {
   if (_tfopen_s(&result, tmp_filename, TEXT("wb+")) != 0) goto end;
 
 end:
-  if (result && tmp_filename) {
+  if (result && tmp_filename_out) {
     *tmp_filename_out = gpr_tchar_to_char(tmp_filename);
   }
 

--- a/src/core/support/string_win32.c
+++ b/src/core/support/string_win32.c
@@ -44,6 +44,8 @@
 
 #include <grpc/support/alloc.h>
 
+#include "src/core/support/string.h"
+
 int gpr_asprintf(char **strp, const char *format, ...) {
   va_list args;
   int ret;
@@ -53,7 +55,7 @@ int gpr_asprintf(char **strp, const char *format, ...) {
   va_start(args, format);
   ret = _vscprintf(format, args);
   va_end(args);
-  if (!(0 <= ret && ret < ~(size_t)0)) {
+  if (ret < 0) {
     *strp = NULL;
     return -1;
   }
@@ -69,7 +71,7 @@ int gpr_asprintf(char **strp, const char *format, ...) {
   va_start(args, format);
   ret = vsnprintf_s(*strp, strp_buflen, _TRUNCATE, format, args);
   va_end(args);
-  if (ret == strp_buflen - 1) {
+  if ((size_t)ret == strp_buflen - 1) {
     return ret;
   }
 

--- a/src/core/support/sync_win32.c
+++ b/src/core/support/sync_win32.c
@@ -37,6 +37,7 @@
 
 #ifdef GPR_WIN32
 
+#undef _WIN32_WINNT
 #define _WIN32_WINNT 0x0600
 #include <windows.h>
 #include <grpc/support/log.h>

--- a/src/core/support/time_win32.c
+++ b/src/core/support/time_win32.c
@@ -42,8 +42,8 @@
 
 gpr_timespec gpr_now(void) {
   gpr_timespec now_tv;
-  struct __timeb32 now_tb;
-  _ftime32_s(&now_tb);
+  struct _timeb now_tb;
+  _ftime_s(&now_tb);
   now_tv.tv_sec = now_tb.time;
   now_tv.tv_nsec = now_tb.millitm * 1000000;
   return now_tv;

--- a/src/cpp/common/call.cc
+++ b/src/cpp/common/call.cc
@@ -48,7 +48,6 @@ CallOpBuffer::CallOpBuffer()
       initial_metadata_count_(0),
       initial_metadata_(nullptr),
       recv_initial_metadata_(nullptr),
-      recv_initial_metadata_arr_{0, 0, nullptr},
       send_message_(nullptr),
       send_message_buffer_(nullptr),
       send_buf_(nullptr),
@@ -58,7 +57,6 @@ CallOpBuffer::CallOpBuffer()
       client_send_close_(false),
       recv_trailing_metadata_(nullptr),
       recv_status_(nullptr),
-      recv_trailing_metadata_arr_{0, 0, nullptr},
       status_code_(GRPC_STATUS_OK),
       status_details_(nullptr),
       status_details_capacity_(0),
@@ -66,7 +64,12 @@ CallOpBuffer::CallOpBuffer()
       trailing_metadata_count_(0),
       trailing_metadata_(nullptr),
       cancelled_buf_(0),
-      recv_closed_(nullptr) {}
+      recv_closed_(nullptr) {
+  memset(&recv_trailing_metadata_arr_, 0, sizeof(recv_trailing_metadata_arr_));
+  memset(&recv_initial_metadata_arr_, 0, sizeof(recv_initial_metadata_arr_));
+  recv_trailing_metadata_arr_.metadata = nullptr;
+  recv_initial_metadata_arr_.metadata = nullptr;
+}
 
 void CallOpBuffer::Reset(void* next_return_tag) {
   return_tag_ = next_return_tag;

--- a/src/cpp/server/server.cc
+++ b/src/cpp/server/server.cc
@@ -234,7 +234,8 @@ void Server::RegisterAsyncGenericService(AsyncGenericService* service) {
   service->server_ = this;
 }
 
-int Server::AddPort(const grpc::string& addr, ServerCredentials* creds) {
+int Server::AddListeningPort(const grpc::string& addr,
+                             ServerCredentials* creds) {
   GPR_ASSERT(!started_);
   return creds->AddPortToServer(addr, server_);
 }

--- a/src/cpp/server/server_builder.cc
+++ b/src/cpp/server/server_builder.cc
@@ -62,9 +62,9 @@ void ServerBuilder::RegisterAsyncGenericService(AsyncGenericService* service) {
   generic_service_ = service;
 }
 
-void ServerBuilder::AddPort(const grpc::string& addr,
-                            std::shared_ptr<ServerCredentials> creds,
-                            int* selected_port) {
+void ServerBuilder::AddListeningPort(const grpc::string& addr,
+                                     std::shared_ptr<ServerCredentials> creds,
+                                     int* selected_port) {
   ports_.push_back(Port{addr, creds, selected_port});
 }
 
@@ -99,7 +99,7 @@ std::unique_ptr<Server> ServerBuilder::BuildAndStart() {
     server->RegisterAsyncGenericService(generic_service_);
   }
   for (auto& port : ports_) {
-    int r = server->AddPort(port.addr, port.creds.get());
+    int r = server->AddListeningPort(port.addr, port.creds.get());
     if (!r) return nullptr;
     if (port.selected_port != nullptr) {
       *port.selected_port = r;

--- a/src/csharp/Grpc.Core.Tests/ClientServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ClientServerTest.cs
@@ -74,7 +74,7 @@ namespace Grpc.Core.Tests
                 ServerServiceDefinition.CreateBuilder(serviceName)
                     .AddMethod(unaryEchoStringMethod, HandleUnaryEchoString).Build());
 
-            int port = server.AddPort(host + ":0");
+            int port = server.AddListeningPort(host + ":0");
             server.Start();
 
             using (Channel channel = new Channel(host + ":" + port))
@@ -97,7 +97,7 @@ namespace Grpc.Core.Tests
                 ServerServiceDefinition.CreateBuilder(serviceName)
                 .AddMethod(unaryEchoStringMethod, HandleUnaryEchoString).Build());
 
-            int port = server.AddPort(host + ":0");
+            int port = server.AddListeningPort(host + ":0");
             server.Start();
 
             using (Channel channel = new Channel(host + ":" + port))
@@ -117,7 +117,7 @@ namespace Grpc.Core.Tests
             server.AddServiceDefinition(
                 ServerServiceDefinition.CreateBuilder(serviceName).Build());
 
-            int port = server.AddPort(host + ":0");
+            int port = server.AddListeningPort(host + ":0");
             server.Start();
 
             using (Channel channel = new Channel(host + ":" + port))

--- a/src/csharp/Grpc.Core.Tests/ServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ServerTest.cs
@@ -47,7 +47,7 @@ namespace Grpc.Core.Tests
             GrpcEnvironment.Initialize();
 
             Server server = new Server();
-            server.AddPort("localhost:0");
+            server.AddListeningPort("localhost:0");
             server.Start();
             server.ShutdownAsync().Wait();
 

--- a/src/csharp/Grpc.Core/Internal/ServerSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerSafeHandle.cs
@@ -80,12 +80,12 @@ namespace Grpc.Core.Internal
             return grpcsharp_server_create(cq, args);
         }
 
-        public int AddPort(string addr)
+        public int AddListeningPort(string addr)
         {
             return grpcsharp_server_add_http2_port(this, addr);
         }
 
-        public int AddPort(string addr, ServerCredentialsSafeHandle credentials)
+        public int AddListeningPort(string addr, ServerCredentialsSafeHandle credentials)
         {
             return grpcsharp_server_add_secure_http2_port(this, addr, credentials);
         }

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -76,17 +76,17 @@ namespace Grpc.Core
         }
 
         // only call before Start()
-        public int AddPort(string addr)
+        public int AddListeningPort(string addr)
         {
-            return handle.AddPort(addr);
+            return handle.AddListeningPort(addr);
         }
 
         // only call before Start()
-        public int AddPort(string addr, ServerCredentials credentials)
+        public int AddListeningPort(string addr, ServerCredentials credentials)
         {
             using (var nativeCredentials = credentials.ToNativeCredentials())
             {
-                return handle.AddPort(addr, nativeCredentials);
+                return handle.AddListeningPort(addr, nativeCredentials);
             }
         }
 

--- a/src/csharp/Grpc.Examples.Tests/MathClientServerTests.cs
+++ b/src/csharp/Grpc.Examples.Tests/MathClientServerTests.cs
@@ -58,7 +58,7 @@ namespace math.Tests
 
             server = new Server();
             server.AddServiceDefinition(MathGrpc.BindService(new MathServiceImpl()));
-            int port = server.AddPort(host + ":0");
+            int port = server.AddListeningPort(host + ":0");
             server.Start();
             channel = new Channel(host + ":" + port);
 

--- a/src/csharp/Grpc.IntegrationTesting/InteropClientServerTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClientServerTest.cs
@@ -59,7 +59,7 @@ namespace Grpc.IntegrationTesting
 
             server = new Server();
             server.AddServiceDefinition(TestServiceGrpc.BindService(new TestServiceImpl()));
-            int port = server.AddPort(host + ":0", TestCredentials.CreateTestServerCredentials());
+            int port = server.AddListeningPort(host + ":0", TestCredentials.CreateTestServerCredentials());
             server.Start();
 
             var channelArgs = ChannelArgs.CreateBuilder()

--- a/src/csharp/Grpc.IntegrationTesting/InteropServer.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropServer.cs
@@ -96,11 +96,11 @@ namespace Grpc.IntegrationTesting
             string addr = "0.0.0.0:" + options.port;
             if (options.useTls)
             {
-                server.AddPort(addr, TestCredentials.CreateTestServerCredentials());
+                server.AddListeningPort(addr, TestCredentials.CreateTestServerCredentials());
             }
             else
             {
-                server.AddPort(addr);
+                server.AddListeningPort(addr);
             }
             Console.WriteLine("Running server on " + addr);
             server.Start();

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -99,7 +99,7 @@ class AsyncEnd2endTest : public ::testing::Test {
     server_address_ << "localhost:" << port;
     // Setup server
     ServerBuilder builder;
-    builder.AddPort(server_address_.str(), grpc::InsecureServerCredentials());
+    builder.AddListeningPort(server_address_.str(), grpc::InsecureServerCredentials());
     builder.RegisterAsyncService(&service_);
     server_ = builder.BuildAndStart();
   }

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -151,7 +151,7 @@ class End2endTest : public ::testing::Test {
     server_address_ << "localhost:" << port;
     // Setup server
     ServerBuilder builder;
-    builder.AddPort(server_address_.str(), InsecureServerCredentials());
+    builder.AddListeningPort(server_address_.str(), InsecureServerCredentials());
     builder.RegisterService(&service_);
     builder.RegisterService(&dup_pkg_service_);
     builder.SetThreadPool(&thread_pool_);

--- a/test/cpp/end2end/generic_end2end_test.cc
+++ b/test/cpp/end2end/generic_end2end_test.cc
@@ -98,7 +98,7 @@ class GenericEnd2endTest : public ::testing::Test {
     server_address_ << "localhost:" << port;
     // Setup server
     ServerBuilder builder;
-    builder.AddPort(server_address_.str(), InsecureServerCredentials());
+    builder.AddListeningPort(server_address_.str(), InsecureServerCredentials());
     builder.RegisterAsyncGenericService(&generic_service_);
     server_ = builder.BuildAndStart();
   }

--- a/test/cpp/interop/server.cc
+++ b/test/cpp/interop/server.cc
@@ -217,7 +217,7 @@ void RunServer() {
         "", {{test_server1_key, test_server1_cert}}};
     creds = grpc::SslServerCredentials(ssl_opts);
   }
-  builder.AddPort(server_address.str(), creds);
+  builder.AddListeningPort(server_address.str(), creds);
   std::unique_ptr<Server> server(builder.BuildAndStart());
   gpr_log(GPR_INFO, "Server listening on %s", server_address.str().c_str());
   while (!got_sigint) {

--- a/test/cpp/qps/server.cc
+++ b/test/cpp/qps/server.cc
@@ -137,7 +137,7 @@ static void RunServer() {
   SimpleResponse response;
 
   ServerBuilder builder;
-  builder.AddPort(server_address, grpc::InsecureServerCredentials());
+  builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
   builder.RegisterService(&service);
 
   std::unique_ptr<ThreadPool> pool(new ThreadPool(FLAGS_server_threads));

--- a/test/cpp/qps/server_async.cc
+++ b/test/cpp/qps/server_async.cc
@@ -68,7 +68,7 @@ class AsyncQpsServerTest : public Server {
     gpr_join_host_port(&server_address, "::", port);
 
     ServerBuilder builder;
-    builder.AddPort(server_address, InsecureServerCredentials());
+    builder.AddListeningPort(server_address, InsecureServerCredentials());
     gpr_free(server_address);
 
     builder.RegisterAsyncService(&async_service_);

--- a/test/cpp/qps/server_sync.cc
+++ b/test/cpp/qps/server_sync.cc
@@ -84,7 +84,7 @@ class SynchronousServer GRPC_FINAL : public grpc::testing::Server {
 
     char* server_address = NULL;
     gpr_join_host_port(&server_address, "::", port);
-    builder.AddPort(server_address, InsecureServerCredentials());
+    builder.AddListeningPort(server_address, InsecureServerCredentials());
     gpr_free(server_address);
 
     builder.RegisterService(&service_);

--- a/test/cpp/qps/worker.cc
+++ b/test/cpp/qps/worker.cc
@@ -210,7 +210,7 @@ static void RunServer() {
   WorkerImpl service;
 
   ServerBuilder builder;
-  builder.AddPort(server_address, InsecureServerCredentials());
+  builder.AddListeningPort(server_address, InsecureServerCredentials());
   builder.RegisterService(&service);
 
   gpr_free(server_address);

--- a/vsprojects/vs2013/global.props
+++ b/vsprojects/vs2013/global.props
@@ -5,7 +5,7 @@
   <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)\..\..;$(SolutionDir)\..\..\include;$(SolutionDir)\..\..\third_party\zlib;$(SolutionDir)\..\third_party;$(SolutionDir)\..\..\third_party\openssl\inc32</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\..\..;$(SolutionDir)\..\..\include;$(SolutionDir)\..\..\third_party\zlib;$(SolutionDir)\..\third_party;$(SolutionDir)\..\..\third_party\openssl\inc32;$(SolutionDir)\..\..\third_party\protobuf\src</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>EnableAllWarnings</WarningLevel>
     </ClCompile>


### PR DESCRIPTION
-) using dupenv_s instead of getenv_s and calling strdup ourselves.
-) few impossible-to-obtain if checks.
-) various signed/unsigned casting.
-) using time_t instead of time32_t
-) checking output of FormatMessage for failures.
-) don't redefine _WIN32_WINNT without undefining it first.
-) fixed msvc's interlocked casting.
-) renamed AddPort to AddListeningPort.
-) added protobuf's third_party includes to search path.
-) added a missing definition for inet_ntop in mingw32.
-) removed useless declarations.