### PR TITLE
Remove dead members of server context, including IsCancelled API

### DIFF
--- a/include/grpc++/server_context.h
+++ b/include/grpc++/server_context.h
@@ -78,8 +78,6 @@ class ServerContext {
   void AddInitialMetadata(const grpc::string& key, const grpc::string& value);
   void AddTrailingMetadata(const grpc::string& key, const grpc::string& value);
 
-  bool IsCancelled();
-
   const std::multimap<grpc::string, grpc::string>& client_metadata() {
     return client_metadata_;
   }
@@ -112,7 +110,6 @@ class ServerContext {
 
   std::chrono::system_clock::time_point deadline_;
   grpc_call* call_;
-  CompletionQueue* cq_;
   bool sent_initial_metadata_;
   std::multimap<grpc::string, grpc::string> client_metadata_;
   std::multimap<grpc::string, grpc::string> initial_metadata_;

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -94,7 +94,6 @@ bool ServerContext::CompletionOp::FinalizeResult(void** tag, bool* status) {
 ServerContext::ServerContext()
     : completion_op_(nullptr),
       call_(nullptr),
-      cq_(nullptr),
       sent_initial_metadata_(false) {}
 
 ServerContext::ServerContext(gpr_timespec deadline, grpc_metadata* metadata,
@@ -102,7 +101,6 @@ ServerContext::ServerContext(gpr_timespec deadline, grpc_metadata* metadata,
     : completion_op_(nullptr),
       deadline_(Timespec2Timepoint(deadline)),
       call_(nullptr),
-      cq_(nullptr),
       sent_initial_metadata_(false) {
   for (size_t i = 0; i < metadata_count; i++) {
     client_metadata_.insert(std::make_pair(
@@ -135,10 +133,6 @@ void ServerContext::AddInitialMetadata(const grpc::string& key,
 void ServerContext::AddTrailingMetadata(const grpc::string& key,
                                         const grpc::string& value) {
   trailing_metadata_.insert(std::make_pair(key, value));
-}
-
-bool ServerContext::IsCancelled() {
-  return completion_op_ && completion_op_->CheckCancelled(cq_);
 }
 
 }  // namespace grpc


### PR DESCRIPTION
Issue #985 points out a seg fault in ServerContext.IsCancelled. However, I believe that this particular API is out-of-date. It is not used in any source or tests. For that matter, neither is the referenced cq_ member of class ServerContext. We may need to add something back like this in the future, but it is not in place or used at the present.

