### PR TITLE
Adding Dockerfile for grpc/scan-build.

### DIFF
--- a/tools/dockerfile/grpc_scan_build/Dockerfile
+++ b/tools/dockerfile/grpc_scan_build/Dockerfile
@@ -1,0 +1,47 @@
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FROM grpc/clang:latest
+
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  libtool \
+  libgflags-dev \
+  libgtest-dev \
+  && apt-get clean
+
+RUN git clone --recursive https://github.com/grpc/grpc.git
+
+EXPOSE 8181
+
+CMD \
+  (cd grpc ; git pull) && \
+  (cd grpc ; git submodule update --init --recursive) && \
+  llvm/tools/clang/tools/scan-build/scan-build -o /tmp/grpc --use-analyzer=/usr/local/bin/clang make -C grpc buildtests && \
+  llvm/tools/clang/tools/scan-view/scan-view /tmp/grpc/`ls /tmp/grpc` --host 0.0.0.0 --no-browser --allow-all-hosts


### PR DESCRIPTION
This can be simply used that way:

  docker run -p 8182:8181 grpc/scan-build

This will grab grpc's latest github code, compile it through clang's scan-build tool (http://clang-analyzer.llvm.org/scan-build.html) and output the result on stdout. This will also start an HTTP server on port 8182 on your machine, displaying the report nicely.
As a nice side-effect, this will also produce scan reports for openssl and protobuf.

The server can be then stopped this way:

  docker ps -l # figure out the container-id
  docker kill container-id