### PR TITLE
Reformat style of using PyObject_HEAD

### DIFF
--- a/src/python/src/grpc/_adapter/_call.h
+++ b/src/python/src/grpc/_adapter/_call.h
@@ -37,7 +37,10 @@
 #include <Python.h>
 #include <grpc/grpc.h>
 
-typedef struct { PyObject_HEAD grpc_call *c_call; } Call;
+typedef struct {
+  PyObject_HEAD;
+  grpc_call *c_call;
+} Call;
 
 PyTypeObject pygrpc_CallType;
 

--- a/src/python/src/grpc/_adapter/_channel.h
+++ b/src/python/src/grpc/_adapter/_channel.h
@@ -37,7 +37,10 @@
 #include <Python.h>
 #include <grpc/grpc.h>
 
-typedef struct { PyObject_HEAD grpc_channel *c_channel; } Channel;
+typedef struct {
+  PyObject_HEAD;
+  grpc_channel *c_channel;
+} Channel;
 
 PyTypeObject pygrpc_ChannelType;
 

--- a/src/python/src/grpc/_adapter/_client_credentials.h
+++ b/src/python/src/grpc/_adapter/_client_credentials.h
@@ -38,7 +38,8 @@
 #include <grpc/grpc_security.h>
 
 typedef struct {
-  PyObject_HEAD grpc_credentials *c_client_credentials;
+  PyObject_HEAD;
+  grpc_credentials *c_client_credentials;
 } ClientCredentials;
 
 PyTypeObject pygrpc_ClientCredentialsType;

--- a/src/python/src/grpc/_adapter/_completion_queue.h
+++ b/src/python/src/grpc/_adapter/_completion_queue.h
@@ -38,7 +38,8 @@
 #include <grpc/grpc.h>
 
 typedef struct {
-  PyObject_HEAD grpc_completion_queue *c_completion_queue;
+  PyObject_HEAD;
+  grpc_completion_queue *c_completion_queue;
 } CompletionQueue;
 
 PyTypeObject pygrpc_CompletionQueueType;

--- a/src/python/src/grpc/_adapter/_server.h
+++ b/src/python/src/grpc/_adapter/_server.h
@@ -37,7 +37,10 @@
 #include <Python.h>
 #include <grpc/grpc.h>
 
-typedef struct { PyObject_HEAD grpc_server *c_server; } Server;
+typedef struct {
+  PyObject_HEAD;
+  grpc_server *c_server;
+} Server;
 
 int pygrpc_add_server(PyObject *module);
 

--- a/src/python/src/grpc/_adapter/_server_credentials.h
+++ b/src/python/src/grpc/_adapter/_server_credentials.h
@@ -38,7 +38,8 @@
 #include <grpc/grpc_security.h>
 
 typedef struct {
-  PyObject_HEAD grpc_server_credentials *c_server_credentials;
+  PyObject_HEAD;
+  grpc_server_credentials *c_server_credentials;
 } ServerCredentials;
 
 PyTypeObject pygrpc_ServerCredentialsType;


### PR DESCRIPTION
Simple clean-up. As it is it makes PyObject_HEAD look like a storage specifier.

@nathanielmanistaatgoogle please review and merge