### PR TITLE
*API BREAKAGE* Renaming Stub to GrpcStub.

### DIFF
--- a/examples/pubsub/publisher.h
+++ b/examples/pubsub/publisher.h
@@ -57,7 +57,7 @@ class Publisher {
   Status Publish(const grpc::string& topic, const grpc::string& data);
 
  private:
-  std::unique_ptr<tech::pubsub::PublisherService::Stub> stub_;
+  std::unique_ptr<tech::pubsub::PublisherService::GrpcStub> stub_;
 };
 
 }  // namespace pubsub

--- a/examples/pubsub/subscriber.h
+++ b/examples/pubsub/subscriber.h
@@ -58,7 +58,7 @@ class Subscriber {
   Status Pull(const grpc::string& name, grpc::string* data);
 
  private:
-  std::unique_ptr<tech::pubsub::SubscriberService::Stub> stub_;
+  std::unique_ptr<tech::pubsub::SubscriberService::GrpcStub> stub_;
 };
 
 }  // namespace pubsub

--- a/src/compiler/cpp_generator.h
+++ b/src/compiler/cpp_generator.h
@@ -55,6 +55,9 @@ grpc::string GetSourceIncludes(const Parameters &params);
 grpc::string GetHeaderServices(const grpc::protobuf::FileDescriptor *file,
                                const Parameters &params);
 
+grpc::string
+  GetNakedHeaderService(const grpc::protobuf::ServiceDescriptor *service);
+
 // Return the services for generated source file.
 grpc::string GetSourceServices(const grpc::protobuf::FileDescriptor *file,
                                const Parameters &params);

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -164,7 +164,7 @@ class AsyncEnd2endTest : public ::testing::Test {
 
   CompletionQueue cli_cq_;
   CompletionQueue srv_cq_;
-  std::unique_ptr<grpc::cpp::test::util::TestService::Stub> stub_;
+  std::unique_ptr<grpc::cpp::test::util::TestService::GrpcStub> stub_;
   std::unique_ptr<Server> server_;
   grpc::cpp::test::util::TestService::AsyncService service_;
   std::ostringstream server_address_;

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -196,7 +196,7 @@ class End2endTest : public ::testing::Test {
     stub_ = std::move(grpc::cpp::test::util::TestService::NewStub(channel));
   }
 
-  std::unique_ptr<grpc::cpp::test::util::TestService::Stub> stub_;
+  std::unique_ptr<grpc::cpp::test::util::TestService::GrpcStub> stub_;
   std::unique_ptr<Server> server_;
   std::ostringstream server_address_;
   TestServiceImpl service_;
@@ -204,7 +204,7 @@ class End2endTest : public ::testing::Test {
   ThreadPool thread_pool_;
 };
 
-static void SendRpc(grpc::cpp::test::util::TestService::Stub* stub,
+static void SendRpc(grpc::cpp::test::util::TestService::GrpcStub* stub,
                     int num_rpcs) {
   EchoRequest request;
   EchoResponse response;
@@ -409,14 +409,14 @@ TEST_F(End2endTest, DiffPackageServices) {
   EchoResponse response;
   request.set_message("Hello");
 
-  std::unique_ptr<grpc::cpp::test::util::TestService::Stub> stub(
+  std::unique_ptr<grpc::cpp::test::util::TestService::GrpcStub> stub(
       grpc::cpp::test::util::TestService::NewStub(channel));
   ClientContext context;
   Status s = stub->Echo(&context, request, &response);
   EXPECT_EQ(response.message(), request.message());
   EXPECT_TRUE(s.IsOk());
 
-  std::unique_ptr<grpc::cpp::test::util::duplicate::TestService::Stub>
+  std::unique_ptr<grpc::cpp::test::util::duplicate::TestService::GrpcStub>
       dup_pkg_stub(
           grpc::cpp::test::util::duplicate::TestService::NewStub(channel));
   ClientContext context2;
@@ -432,7 +432,7 @@ TEST_F(End2endTest, BadCredentials) {
   EXPECT_EQ(nullptr, bad_creds.get());
   std::shared_ptr<ChannelInterface> channel =
       CreateChannel(server_address_.str(), bad_creds, ChannelArguments());
-  std::unique_ptr<grpc::cpp::test::util::TestService::Stub> stub(
+  std::unique_ptr<grpc::cpp::test::util::TestService::GrpcStub> stub(
       grpc::cpp::test::util::TestService::NewStub(channel));
   EchoRequest request;
   EchoResponse response;

--- a/test/cpp/end2end/generic_end2end_test.cc
+++ b/test/cpp/end2end/generic_end2end_test.cc
@@ -194,7 +194,7 @@ class GenericEnd2endTest : public ::testing::Test {
 
   CompletionQueue cli_cq_;
   CompletionQueue srv_cq_;
-  std::unique_ptr<grpc::cpp::test::util::TestService::Stub> stub_;
+  std::unique_ptr<grpc::cpp::test::util::TestService::GrpcStub> stub_;
   std::unique_ptr<grpc::GenericStub> generic_stub_;
   std::unique_ptr<Server> server_;
   AsyncGenericService generic_service_;

--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -174,7 +174,7 @@ void DoEmpty() {
   gpr_log(GPR_INFO, "Sending an empty rpc...");
   std::shared_ptr<ChannelInterface> channel =
       CreateChannelForTestCase("empty_unary");
-  std::unique_ptr<TestService::Stub> stub(TestService::NewStub(channel));
+  std::unique_ptr<TestService::GrpcStub> stub(TestService::NewStub(channel));
 
   grpc::testing::Empty request = grpc::testing::Empty::default_instance();
   grpc::testing::Empty response = grpc::testing::Empty::default_instance();
@@ -189,7 +189,7 @@ void DoEmpty() {
 // Shared code to set large payload, make rpc and check response payload.
 void PerformLargeUnary(std::shared_ptr<ChannelInterface> channel,
                        SimpleRequest* request, SimpleResponse* response) {
-  std::unique_ptr<TestService::Stub> stub(TestService::NewStub(channel));
+  std::unique_ptr<TestService::GrpcStub> stub(TestService::NewStub(channel));
 
   ClientContext context;
   request->set_response_type(grpc::testing::PayloadType::COMPRESSABLE);
@@ -273,7 +273,7 @@ void DoRequestStreaming() {
   gpr_log(GPR_INFO, "Sending request steaming rpc ...");
   std::shared_ptr<ChannelInterface> channel =
       CreateChannelForTestCase("client_streaming");
-  std::unique_ptr<TestService::Stub> stub(TestService::NewStub(channel));
+  std::unique_ptr<TestService::GrpcStub> stub(TestService::NewStub(channel));
 
   grpc::ClientContext context;
   StreamingInputCallRequest request;
@@ -301,7 +301,7 @@ void DoResponseStreaming() {
   gpr_log(GPR_INFO, "Receiving response steaming rpc ...");
   std::shared_ptr<ChannelInterface> channel =
       CreateChannelForTestCase("server_streaming");
-  std::unique_ptr<TestService::Stub> stub(TestService::NewStub(channel));
+  std::unique_ptr<TestService::GrpcStub> stub(TestService::NewStub(channel));
 
   grpc::ClientContext context;
   StreamingOutputCallRequest request;
@@ -330,7 +330,7 @@ void DoResponseStreamingWithSlowConsumer() {
   gpr_log(GPR_INFO, "Receiving response steaming rpc with slow consumer ...");
   std::shared_ptr<ChannelInterface> channel =
       CreateChannelForTestCase("slow_consumer");
-  std::unique_ptr<TestService::Stub> stub(TestService::NewStub(channel));
+  std::unique_ptr<TestService::GrpcStub> stub(TestService::NewStub(channel));
 
   grpc::ClientContext context;
   StreamingOutputCallRequest request;
@@ -362,7 +362,7 @@ void DoHalfDuplex() {
   gpr_log(GPR_INFO, "Sending half-duplex streaming rpc ...");
   std::shared_ptr<ChannelInterface> channel =
       CreateChannelForTestCase("half_duplex");
-  std::unique_ptr<TestService::Stub> stub(TestService::NewStub(channel));
+  std::unique_ptr<TestService::GrpcStub> stub(TestService::NewStub(channel));
 
   grpc::ClientContext context;
   std::unique_ptr<grpc::ClientReaderWriter<StreamingOutputCallRequest,
@@ -395,7 +395,7 @@ void DoPingPong() {
   gpr_log(GPR_INFO, "Sending Ping Pong streaming rpc ...");
   std::shared_ptr<ChannelInterface> channel =
       CreateChannelForTestCase("ping_pong");
-  std::unique_ptr<TestService::Stub> stub(TestService::NewStub(channel));
+  std::unique_ptr<TestService::GrpcStub> stub(TestService::NewStub(channel));
 
   grpc::ClientContext context;
   std::unique_ptr<grpc::ClientReaderWriter<StreamingOutputCallRequest,

--- a/test/cpp/qps/client.h
+++ b/test/cpp/qps/client.h
@@ -88,11 +88,11 @@ class Client {
         : channel_(CreateTestChannel(target, config.enable_ssl())),
           stub_(TestService::NewStub(channel_)) {}
     ChannelInterface* get_channel() { return channel_.get(); }
-    TestService::Stub* get_stub() { return stub_.get(); }
+    TestService::GrpcStub* get_stub() { return stub_.get(); }
 
    private:
     std::shared_ptr<ChannelInterface> channel_;
-    std::unique_ptr<TestService::Stub> stub_;
+    std::unique_ptr<TestService::GrpcStub> stub_;
   };
   std::vector<ClientChannelInfo> channels_;
 
@@ -150,7 +150,7 @@ class Client {
     Thread(const Thread&);
     Thread& operator=(const Thread&);
 
-    TestService::Stub* stub_;
+    TestService::GrpcStub* stub_;
     ClientConfig config_;
     std::mutex mu_;
     std::condition_variable cv_;

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -96,7 +96,7 @@ ScenarioResult RunScenario(const ClientConfig& initial_client_config,
 
   // Start servers
   struct ServerData {
-    unique_ptr<Worker::Stub> stub;
+    unique_ptr<Worker::GrpcStub> stub;
     unique_ptr<ClientReaderWriter<ServerArgs, ServerStatus>> stream;
   };
   vector<ServerData> servers;
@@ -125,7 +125,7 @@ ScenarioResult RunScenario(const ClientConfig& initial_client_config,
 
   // Start clients
   struct ClientData {
-    unique_ptr<Worker::Stub> stub;
+    unique_ptr<Worker::GrpcStub> stub;
     unique_ptr<ClientReaderWriter<ClientArgs, ClientStatus>> stream;
   };
   vector<ClientData> clients;

--- a/test/cpp/util/cli_call_test.cc
+++ b/test/cpp/util/cli_call_test.cc
@@ -90,7 +90,7 @@ class CliCallTest : public ::testing::Test {
   }
 
   std::shared_ptr<ChannelInterface> channel_;
-  std::unique_ptr<grpc::cpp::test::util::TestService::Stub> stub_;
+  std::unique_ptr<grpc::cpp::test::util::TestService::GrpcStub> stub_;
   std::unique_ptr<Server> server_;
   std::ostringstream server_address_;
   TestServiceImpl service_;


### PR DESCRIPTION
This Pull Requests will change the current code generator by renaming Stub to GrpcStub. It also exposes a code generator API that lets output the naked service definitions, in order to be able to inject them in other RPC-based service systems.