### PR TITLE
Generate interop-related code in PHP docker build

### DIFF
--- a/tools/dockerfile/grpc_php/Dockerfile
+++ b/tools/dockerfile/grpc_php/Dockerfile
@@ -48,4 +48,6 @@ RUN cd /var/local/git/grpc/src/php/ext/grpc \
 
 RUN cd /var/local/git/grpc/src/php && composer install
 
+RUN cd /var/local/git/grpc/src/php && protoc-gen-php -i tests/interop/ -o tests/interop/ tests/interop/test.proto
+
 RUN cd /var/local/git/grpc/src/php && ./bin/run_tests.sh


### PR DESCRIPTION
This should fix the current interop test failures.