### PR TITLE
Make PHP library work with PHP 5.6

### DIFF
--- a/src/php/bin/interop_client.sh
+++ b/src/php/bin/interop_client.sh
@@ -32,7 +32,7 @@
 set +e
 cd $(dirname $0)
 
-module_dir=`php --version | grep -q 'PHP 5.6' && echo '../ext/grpc' || '../ext/grpc/modules'`
+module_dir=`php --version | grep -q 'PHP 5.6' && echo '../ext/grpc' || echo '../ext/grpc/modules'`
 
 php -d extension_dir=$module_dir -d extension=grpc.so \
   ../tests/interop/interop_client.php $@ 1>&2

--- a/src/php/bin/interop_client.sh
+++ b/src/php/bin/interop_client.sh
@@ -31,5 +31,8 @@
 
 set +e
 cd $(dirname $0)
-php -d extension_dir=../ext/grpc/modules/ -d extension=grpc.so \
+
+module_dir=`php --version | grep -q 'PHP 5.6' && echo '../ext/grpc' || '../ext/grpc/modules'`
+
+php -d extension_dir=$module_dir -d extension=grpc.so \
   ../tests/interop/interop_client.php $@ 1>&2

--- a/src/php/bin/run_tests.sh
+++ b/src/php/bin/run_tests.sh
@@ -34,7 +34,7 @@ set -e
 cd $(dirname $0)
 default_extension_dir=`php -i | grep extension_dir | sed 's/.*=> //g'`
 
-module_dir=`php --version | grep -q 'PHP 5.6' && echo '../ext/grpc' || '../ext/grpc/modules'`
+module_dir=`php --version | grep -q 'PHP 5.6' && echo '../ext/grpc' || echo '../ext/grpc/modules'`
 
 # sym-link in system supplied extensions
 for f in $default_extension_dir/*.so

--- a/src/php/bin/run_tests.sh
+++ b/src/php/bin/run_tests.sh
@@ -34,13 +34,15 @@ set -e
 cd $(dirname $0)
 default_extension_dir=`php -i | grep extension_dir | sed 's/.*=> //g'`
 
+module_dir=`php --version | grep -q 'PHP 5.6' && echo '../ext/grpc' || '../ext/grpc/modules'`
+
 # sym-link in system supplied extensions
 for f in $default_extension_dir/*.so
 do
-  ln -s $f ../ext/grpc/modules/$(basename $f) &> /dev/null || true
+  ln -s $f $module_dir/$(basename $f) &> /dev/null || true
 done
 
 php \
-  -d extension_dir=../ext/grpc/modules/ \
+  -d extension_dir=$module_dir \
   -d extension=grpc.so \
   `which phpunit` -v --debug --strict ../tests/unit_tests

--- a/src/php/ext/grpc/byte_buffer.c
+++ b/src/php/ext/grpc/byte_buffer.c
@@ -35,18 +35,18 @@
 #include "config.h"
 #endif
 
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
-#include "ext/spl/spl_exceptions.h"
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
+#include <ext/spl/spl_exceptions.h>
 #include "php_grpc.h"
 
 #include <string.h>
 
 #include "byte_buffer.h"
 
-#include "grpc/grpc.h"
-#include "grpc/support/slice.h"
+#include <grpc/grpc.h>
+#include <grpc/support/slice.h>
 
 grpc_byte_buffer *string_to_byte_buffer(char *string, size_t length) {
   gpr_slice slice = gpr_slice_from_copied_buffer(string, length);

--- a/src/php/ext/grpc/byte_buffer.h
+++ b/src/php/ext/grpc/byte_buffer.h
@@ -34,7 +34,7 @@
 #ifndef NET_GRPC_PHP_GRPC_BYTE_BUFFER_H_
 #define NET_GRPC_PHP_GRPC_BYTE_BUFFER_H_
 
-#include "grpc/grpc.h"
+#include <grpc/grpc.h>
 
 grpc_byte_buffer *string_to_byte_buffer(char *string, size_t length);
 

--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -37,20 +37,20 @@
 #include "config.h"
 #endif
 
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
-#include "ext/spl/spl_exceptions.h"
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
+#include <ext/spl/spl_exceptions.h>
 #include "php_grpc.h"
 
-#include "zend_exceptions.h"
-#include "zend_hash.h"
+#include <zend_exceptions.h>
+#include <zend_hash.h>
 
 #include <stdbool.h>
 
-#include "grpc/support/log.h"
-#include "grpc/support/alloc.h"
-#include "grpc/grpc.h"
+#include <grpc/support/log.h>
+#include <grpc/support/alloc.h>
+#include <grpc/grpc.h>
 
 #include "timeval.h"
 #include "channel.h"

--- a/src/php/ext/grpc/call.h
+++ b/src/php/ext/grpc/call.h
@@ -38,12 +38,12 @@
 #include "config.h"
 #endif
 
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
 #include "php_grpc.h"
 
-#include "grpc/grpc.h"
+#include <grpc/grpc.h>
 
 /* Class entry for the Call PHP class */
 extern zend_class_entry *grpc_ce_call;

--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -37,19 +37,19 @@
 #include "config.h"
 #endif
 
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
-#include "ext/spl/spl_exceptions.h"
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
+#include <ext/spl/spl_exceptions.h>
 #include "php_grpc.h"
 
-#include "zend_exceptions.h"
+#include <zend_exceptions.h>
 
 #include <stdbool.h>
 
-#include "grpc/grpc.h"
-#include "grpc/support/log.h"
-#include "grpc/grpc_security.h"
+#include <grpc/grpc.h>
+#include <grpc/support/log.h>
+#include <grpc/grpc_security.h>
 
 #include "server.h"
 #include "credentials.h"

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -38,12 +38,12 @@
 #include "config.h"
 #endif
 
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
 #include "php_grpc.h"
 
-#include "grpc/grpc.h"
+#include <grpc/grpc.h>
 
 /* Class entry for the PHP Channel class */
 extern zend_class_entry *grpc_ce_channel;

--- a/src/php/ext/grpc/config.m4
+++ b/src/php/ext/grpc/config.m4
@@ -66,5 +66,5 @@ if test "$PHP_GRPC" != "no"; then
 
   PHP_SUBST(GRPC_SHARED_LIBADD)
 
-  PHP_NEW_EXTENSION(grpc, byte_buffer.c call.c channel.c credentials.c timeval.c server.c server_credentials.c php_grpc.c, $ext_shared, , -Wall -Werror -pedantic -std=c99)
+  PHP_NEW_EXTENSION(grpc, byte_buffer.c call.c channel.c credentials.c timeval.c server.c server_credentials.c php_grpc.c, $ext_shared, , -Wall -Werror -std=c11)
 fi

--- a/src/php/ext/grpc/credentials.c
+++ b/src/php/ext/grpc/credentials.c
@@ -37,17 +37,17 @@
 #include "config.h"
 #endif
 
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
-#include "ext/spl/spl_exceptions.h"
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
+#include <ext/spl/spl_exceptions.h>
 #include "php_grpc.h"
 
-#include "zend_exceptions.h"
-#include "zend_hash.h"
+#include <zend_exceptions.h>
+#include <zend_hash.h>
 
-#include "grpc/grpc.h"
-#include "grpc/grpc_security.h"
+#include <grpc/grpc.h>
+#include <grpc/grpc_security.h>
 
 zend_class_entry *grpc_ce_credentials;
 

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -42,9 +42,9 @@
 #include "config.h"
 #endif
 
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
 #include "php_grpc.h"
 
 // ZEND_DECLARE_MODULE_GLOBALS(grpc)

--- a/src/php/ext/grpc/server.c
+++ b/src/php/ext/grpc/server.c
@@ -37,19 +37,19 @@
 #include "config.h"
 #endif
 
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
-#include "ext/spl/spl_exceptions.h"
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
+#include <ext/spl/spl_exceptions.h>
 #include "php_grpc.h"
 
-#include "zend_exceptions.h"
+#include <zend_exceptions.h>
 
 #include <stdbool.h>
 
-#include "grpc/grpc.h"
-#include "grpc/support/log.h"
-#include "grpc/grpc_security.h"
+#include <grpc/grpc.h>
+#include <grpc/support/log.h>
+#include <grpc/grpc_security.h>
 
 #include "server.h"
 #include "channel.h"

--- a/src/php/ext/grpc/server.h
+++ b/src/php/ext/grpc/server.h
@@ -38,12 +38,12 @@
 #include "config.h"
 #endif
 
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
 #include "php_grpc.h"
 
-#include "grpc/grpc.h"
+#include <grpc/grpc.h>
 
 /* Class entry for the Server PHP class */
 extern zend_class_entry *grpc_ce_server;

--- a/src/php/ext/grpc/server_credentials.c
+++ b/src/php/ext/grpc/server_credentials.c
@@ -37,17 +37,17 @@
 #include "config.h"
 #endif
 
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
-#include "ext/spl/spl_exceptions.h"
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
+#include <ext/spl/spl_exceptions.h>
 #include "php_grpc.h"
 
-#include "zend_exceptions.h"
-#include "zend_hash.h"
+#include <zend_exceptions.h>
+#include <zend_hash.h>
 
-#include "grpc/grpc.h"
-#include "grpc/grpc_security.h"
+#include <grpc/grpc.h>
+#include <grpc/grpc_security.h>
 
 zend_class_entry *grpc_ce_server_credentials;
 

--- a/src/php/ext/grpc/server_credentials.h
+++ b/src/php/ext/grpc/server_credentials.h
@@ -38,13 +38,13 @@
 #include "config.h"
 #endif
 
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
 #include "php_grpc.h"
 
-#include "grpc/grpc.h"
-#include "grpc/grpc_security.h"
+#include <grpc/grpc.h>
+#include <grpc/grpc_security.h>
 
 /* Class entry for the Server_Credentials PHP class */
 extern zend_class_entry *grpc_ce_server_credentials;

--- a/src/php/ext/grpc/timeval.c
+++ b/src/php/ext/grpc/timeval.c
@@ -37,18 +37,18 @@
 #include "config.h"
 #endif
 
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
-#include "ext/spl/spl_exceptions.h"
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
+#include <ext/spl/spl_exceptions.h>
 #include "php_grpc.h"
 
-#include "zend_exceptions.h"
+#include <zend_exceptions.h>
 
 #include <stdbool.h>
 
-#include "grpc/grpc.h"
-#include "grpc/support/time.h"
+#include <grpc/grpc.h>
+#include <grpc/support/time.h>
 
 zend_class_entry *grpc_ce_timeval;
 

--- a/src/php/ext/grpc/timeval.h
+++ b/src/php/ext/grpc/timeval.h
@@ -38,13 +38,13 @@
 #include "config.h"
 #endif
 
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
 #include "php_grpc.h"
 
-#include "grpc/grpc.h"
-#include "grpc/support/time.h"
+#include <grpc/grpc.h>
+#include <grpc/support/time.h>
 
 /* Class entry for the Timeval PHP Class */
 extern zend_class_entry *grpc_ce_timeval;


### PR DESCRIPTION
This fixes #1151. Adding the angle bracket include lines didn't actually help with this, but it's probably better to write them like that anyway.