### PR TITLE
Bug fix. User can destroy status after calling Finish and we should keep...

### DIFF
--- a/include/grpc++/impl/call.h
+++ b/include/grpc++/impl/call.h
@@ -109,7 +109,9 @@ class CallOpBuffer : public CompletionQueueTag {
   char* status_details_;
   size_t status_details_capacity_;
   // Server send status
-  const Status* send_status_;
+  bool send_status_;
+  grpc_status_code send_status_code_;
+  grpc::string send_status_details_;
   size_t trailing_metadata_count_;
   grpc_metadata* trailing_metadata_;
   int cancelled_buf_;

--- a/include/grpc++/impl/call.h
+++ b/include/grpc++/impl/call.h
@@ -109,7 +109,7 @@ class CallOpBuffer : public CompletionQueueTag {
   char* status_details_;
   size_t status_details_capacity_;
   // Server send status
-  bool send_status_;
+  bool send_status_available_;
   grpc_status_code send_status_code_;
   grpc::string send_status_details_;
   size_t trailing_metadata_count_;

--- a/src/cpp/common/call.cc
+++ b/src/cpp/common/call.cc
@@ -60,7 +60,7 @@ CallOpBuffer::CallOpBuffer()
       status_code_(GRPC_STATUS_OK),
       status_details_(nullptr),
       status_details_capacity_(0),
-      send_status_(false),
+      send_status_available_(false),
       send_status_code_(GRPC_STATUS_OK),
       trailing_metadata_count_(0),
       trailing_metadata_(nullptr),
@@ -105,7 +105,7 @@ void CallOpBuffer::Reset(void* next_return_tag) {
 
   status_code_ = GRPC_STATUS_OK;
 
-  send_status_ = false;
+  send_status_available_ = false;
   send_status_code_ = GRPC_STATUS_OK;
   send_status_details_.clear();
   trailing_metadata_count_ = 0;
@@ -211,7 +211,7 @@ void CallOpBuffer::AddServerSendStatus(
   } else {
     trailing_metadata_count_ = 0;
   }
-  send_status_ = true;
+  send_status_available_ = true;
   send_status_code_ = static_cast<grpc_status_code>(status.code());
   send_status_details_ = status.details();
 }
@@ -262,7 +262,7 @@ void CallOpBuffer::FillOps(grpc_op* ops, size_t* nops) {
         &status_details_capacity_;
     (*nops)++;
   }
-  if (send_status_) {
+  if (send_status_available_) {
     ops[*nops].op = GRPC_OP_SEND_STATUS_FROM_SERVER;
     ops[*nops].data.send_status_from_server.trailing_metadata_count =
         trailing_metadata_count_;

--- a/src/cpp/common/call.cc
+++ b/src/cpp/common/call.cc
@@ -60,7 +60,8 @@ CallOpBuffer::CallOpBuffer()
       status_code_(GRPC_STATUS_OK),
       status_details_(nullptr),
       status_details_capacity_(0),
-      send_status_(nullptr),
+      send_status_(false),
+      send_status_code_(GRPC_STATUS_OK),
       trailing_metadata_count_(0),
       trailing_metadata_(nullptr),
       cancelled_buf_(0),
@@ -104,7 +105,9 @@ void CallOpBuffer::Reset(void* next_return_tag) {
 
   status_code_ = GRPC_STATUS_OK;
 
-  send_status_ = nullptr;
+  send_status_ = false;
+  send_status_code_ = GRPC_STATUS_OK;
+  send_status_details_.clear();
   trailing_metadata_count_ = 0;
   trailing_metadata_ = nullptr;
 
@@ -208,7 +211,9 @@ void CallOpBuffer::AddServerSendStatus(
   } else {
     trailing_metadata_count_ = 0;
   }
-  send_status_ = &status;
+  send_status_ = true;
+  send_status_code_ = static_cast<grpc_status_code>(status.code());
+  send_status_details_ = status.details();
 }
 
 void CallOpBuffer::FillOps(grpc_op* ops, size_t* nops) {
@@ -263,10 +268,9 @@ void CallOpBuffer::FillOps(grpc_op* ops, size_t* nops) {
         trailing_metadata_count_;
     ops[*nops].data.send_status_from_server.trailing_metadata =
         trailing_metadata_;
-    ops[*nops].data.send_status_from_server.status =
-        static_cast<grpc_status_code>(send_status_->code());
+    ops[*nops].data.send_status_from_server.status = send_status_code_;
     ops[*nops].data.send_status_from_server.status_details =
-        send_status_->details().c_str();
+        send_status_details_.empty() ? nullptr : send_status_details_.c_str();
     (*nops)++;
   }
   if (recv_closed_) {


### PR DESCRIPTION
... a copy of it instead of a pointer
Also should not keep address of a temporary.