### PR TITLE
Change PHP method names to camel case

### DIFF
--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -263,7 +263,7 @@ PHP_METHOD(Call, __construct) {
  * @param array batch Array of actions to take
  * @return object Object with results of all actions
  */
-PHP_METHOD(Call, start_batch) {
+PHP_METHOD(Call, startBatch) {
   wrapped_grpc_call *call =
       (wrapped_grpc_call *)zend_object_store_get_object(getThis() TSRMLS_CC);
   grpc_op ops[8];
@@ -494,7 +494,7 @@ PHP_METHOD(Call, cancel) {
 
 static zend_function_entry call_methods[] = {
     PHP_ME(Call, __construct, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
-    PHP_ME(Call, start_batch, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(Call, startBatch, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(Call, cancel, NULL, ZEND_ACC_PUBLIC) PHP_FE_END};
 
 void grpc_init_call(TSRMLS_D) {

--- a/src/php/ext/grpc/server.c
+++ b/src/php/ext/grpc/server.c
@@ -133,7 +133,7 @@ PHP_METHOD(Server, __construct) {
  * @param long $tag_cancel The tag to use if the call is cancelled
  * @return Void
  */
-PHP_METHOD(Server, request_call) {
+PHP_METHOD(Server, requestCall) {
   grpc_call_error error_code;
   wrapped_grpc_server *server =
       (wrapped_grpc_server *)zend_object_store_get_object(getThis() TSRMLS_CC);
@@ -178,7 +178,7 @@ cleanup:
  * @param string $addr The address to add
  * @return true on success, false on failure
  */
-PHP_METHOD(Server, add_http2_port) {
+PHP_METHOD(Server, addHttp2Port) {
   wrapped_grpc_server *server =
       (wrapped_grpc_server *)zend_object_store_get_object(getThis() TSRMLS_CC);
   const char *addr;
@@ -193,7 +193,7 @@ PHP_METHOD(Server, add_http2_port) {
   RETURN_LONG(grpc_server_add_http2_port(server->wrapped, addr));
 }
 
-PHP_METHOD(Server, add_secure_http2_port) {
+PHP_METHOD(Server, addSecureHttp2Port) {
   wrapped_grpc_server *server =
       (wrapped_grpc_server *)zend_object_store_get_object(getThis() TSRMLS_CC);
   const char *addr;
@@ -227,9 +227,9 @@ PHP_METHOD(Server, start) {
 
 static zend_function_entry server_methods[] = {
     PHP_ME(Server, __construct, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
-    PHP_ME(Server, request_call, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(Server, add_http2_port, NULL, ZEND_ACC_PUBLIC)
-    PHP_ME(Server, add_secure_http2_port, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(Server, requestCall, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(Server, addHttp2Port, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(Server, addSecureHttp2Port, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(Server, start, NULL, ZEND_ACC_PUBLIC) PHP_FE_END};
 
 void grpc_init_server(TSRMLS_D) {

--- a/src/php/ext/grpc/timeval.c
+++ b/src/php/ext/grpc/timeval.c
@@ -227,7 +227,7 @@ PHP_METHOD(Timeval, zero) {
  * Returns the infinite future time value as a timeval object
  * @return Timeval Infinite future time value
  */
-PHP_METHOD(Timeval, inf_future) {
+PHP_METHOD(Timeval, infFuture) {
   zval *grpc_php_timeval_inf_future = grpc_php_wrap_timeval(gpr_inf_future);
   RETURN_DESTROY_ZVAL(grpc_php_timeval_inf_future);
 }
@@ -236,7 +236,7 @@ PHP_METHOD(Timeval, inf_future) {
  * Returns the infinite past time value as a timeval object
  * @return Timeval Infinite past time value
  */
-PHP_METHOD(Timeval, inf_past) {
+PHP_METHOD(Timeval, infPast) {
   zval *grpc_php_timeval_inf_past = grpc_php_wrap_timeval(gpr_inf_past);
   RETURN_DESTROY_ZVAL(grpc_php_timeval_inf_past);
 }
@@ -245,7 +245,7 @@ PHP_METHOD(Timeval, inf_past) {
  * Sleep until this time, interpreted as an absolute timeout
  * @return void
  */
-PHP_METHOD(Timeval, sleep_until) {
+PHP_METHOD(Timeval, sleepUntil) {
   wrapped_grpc_timeval *this =
       (wrapped_grpc_timeval *)zend_object_store_get_object(getThis() TSRMLS_CC);
   gpr_sleep_until(this->wrapped);
@@ -255,11 +255,11 @@ static zend_function_entry timeval_methods[] = {
     PHP_ME(Timeval, __construct, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
     PHP_ME(Timeval, add, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(Timeval, compare, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(Timeval, inf_future, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(Timeval, inf_past, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(Timeval, infFuture, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+    PHP_ME(Timeval, infPast, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_ME(Timeval, now, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
     PHP_ME(Timeval, similar, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
-    PHP_ME(Timeval, sleep_until, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(Timeval, sleepUntil, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(Timeval, subtract, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(Timeval, zero, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_STATIC) PHP_FE_END};
 

--- a/src/php/lib/Grpc/AbstractCall.php
+++ b/src/php/lib/Grpc/AbstractCall.php
@@ -45,7 +45,7 @@ abstract class AbstractCall {
    * @param string $method The method to call on the remote server
    */
   public function __construct(Channel $channel, $method, $deserialize) {
-    $this->call = new Call($channel, $method, Timeval::inf_future());
+    $this->call = new Call($channel, $method, Timeval::infFuture());
     $this->deserialize = $deserialize;
     $this->metadata = null;
   }

--- a/src/php/lib/Grpc/BidiStreamingCall.php
+++ b/src/php/lib/Grpc/BidiStreamingCall.php
@@ -43,7 +43,7 @@ class BidiStreamingCall extends AbstractCall {
    * @param array $metadata Metadata to send with the call, if applicable
    */
   public function start($metadata) {
-    $this->call->start_batch([OP_SEND_INITIAL_METADATA => $metadata]);
+    $this->call->startBatch([OP_SEND_INITIAL_METADATA => $metadata]);
   }
 
   /**
@@ -55,7 +55,7 @@ class BidiStreamingCall extends AbstractCall {
     if ($this->metadata === null) {
       $batch[OP_RECV_INITIAL_METADATA] = true;
     }
-    $read_event = $this->call->start_batch($batch);
+    $read_event = $this->call->startBatch($batch);
     if ($this->metadata === null) {
       $this->metadata = $read_event->metadata;
     }
@@ -68,14 +68,14 @@ class BidiStreamingCall extends AbstractCall {
    * @param ByteBuffer $data The data to write
    */
   public function write($data) {
-    $this->call->start_batch([OP_SEND_MESSAGE => $data->serialize()]);
+    $this->call->startBatch([OP_SEND_MESSAGE => $data->serialize()]);
   }
 
   /**
    * Indicate that no more writes will be sent.
    */
   public function writesDone() {
-    $this->call->start_batch([OP_SEND_CLOSE_FROM_CLIENT => true]);
+    $this->call->startBatch([OP_SEND_CLOSE_FROM_CLIENT => true]);
   }
 
   /**
@@ -84,7 +84,7 @@ class BidiStreamingCall extends AbstractCall {
    *     and array $metadata members
    */
   public function getStatus() {
-    $status_event = $this->call->start_batch([
+    $status_event = $this->call->startBatch([
         OP_RECV_STATUS_ON_CLIENT => true
                                               ]);
     return $status_event->status;

--- a/src/php/lib/Grpc/ClientStreamingCall.php
+++ b/src/php/lib/Grpc/ClientStreamingCall.php
@@ -44,11 +44,11 @@ class ClientStreamingCall extends AbstractCall {
    * @param array $metadata Metadata to send with the call, if applicable
    */
   public function start($arg_iter, $metadata = array()) {
-    $event = $this->call->start_batch([OP_SEND_INITIAL_METADATA => $metadata]);
+    $event = $this->call->startBatch([OP_SEND_INITIAL_METADATA => $metadata]);
     foreach($arg_iter as $arg) {
-      $this->call->start_batch([OP_SEND_MESSAGE => $arg->serialize()]);
+      $this->call->startBatch([OP_SEND_MESSAGE => $arg->serialize()]);
     }
-    $this->call->start_batch([OP_SEND_CLOSE_FROM_CLIENT => true]);
+    $this->call->startBatch([OP_SEND_CLOSE_FROM_CLIENT => true]);
   }
 
   /**
@@ -56,7 +56,7 @@ class ClientStreamingCall extends AbstractCall {
    * @return [response data, status]
    */
   public function wait() {
-    $event = $this->call->start_batch([
+    $event = $this->call->startBatch([
         OP_RECV_INITIAL_METADATA => true,
         OP_RECV_MESSAGE => true,
         OP_RECV_STATUS_ON_CLIENT => true]);

--- a/src/php/lib/Grpc/ServerStreamingCall.php
+++ b/src/php/lib/Grpc/ServerStreamingCall.php
@@ -44,7 +44,7 @@ class ServerStreamingCall extends AbstractCall {
    * @param array $metadata Metadata to send with the call, if applicable
    */
   public function start($arg, $metadata = array()) {
-    $event = $this->call->start_batch([
+    $event = $this->call->startBatch([
         OP_SEND_INITIAL_METADATA => $metadata,
         OP_RECV_INITIAL_METADATA => true,
         OP_SEND_MESSAGE => $arg->serialize(),
@@ -56,10 +56,10 @@ class ServerStreamingCall extends AbstractCall {
    * @return An iterator of response values
    */
   public function responses() {
-    $response = $this->call->start_batch([OP_RECV_MESSAGE => true])->message;
+    $response = $this->call->startBatch([OP_RECV_MESSAGE => true])->message;
     while($response !== null) {
       yield $this->deserializeResponse($response);
-      $response = $this->call->start_batch([OP_RECV_MESSAGE => true])->message;
+      $response = $this->call->startBatch([OP_RECV_MESSAGE => true])->message;
     }
   }
 
@@ -69,7 +69,7 @@ class ServerStreamingCall extends AbstractCall {
    *     and array $metadata members
    */
   public function getStatus() {
-    $status_event = $this->call->start_batch([
+    $status_event = $this->call->startBatch([
         OP_RECV_STATUS_ON_CLIENT => true
                                               ]);
     return $status_event->status;

--- a/src/php/lib/Grpc/UnaryCall.php
+++ b/src/php/lib/Grpc/UnaryCall.php
@@ -44,7 +44,7 @@ class UnaryCall extends AbstractCall {
    * @param array $metadata Metadata to send with the call, if applicable
    */
   public function start($arg, $metadata = array()) {
-    $event = $this->call->start_batch([
+    $event = $this->call->startBatch([
         OP_SEND_INITIAL_METADATA => $metadata,
         OP_RECV_INITIAL_METADATA => true,
         OP_SEND_MESSAGE => $arg->serialize(),
@@ -57,7 +57,7 @@ class UnaryCall extends AbstractCall {
    * @return [response data, status]
    */
   public function wait() {
-    $event = $this->call->start_batch([
+    $event = $this->call->startBatch([
         OP_RECV_MESSAGE => true,
         OP_RECV_STATUS_ON_CLIENT => true]);
     return array($this->deserializeResponse($event->message), $event->status);

--- a/src/php/tests/unit_tests/CallTest.php
+++ b/src/php/tests/unit_tests/CallTest.php
@@ -37,21 +37,21 @@ class CallTest extends PHPUnit_Framework_TestCase{
 
   public static function setUpBeforeClass() {
     self::$server = new Grpc\Server([]);
-    self::$port = self::$server->add_http2_port('0.0.0.0:0');
+    self::$port = self::$server->addHttp2Port('0.0.0.0:0');
   }
 
   public function setUp() {
     $this->channel = new Grpc\Channel('localhost:' . self::$port, []);
     $this->call = new Grpc\Call($this->channel,
                                 '/foo',
-                                Grpc\Timeval::inf_future());
+                                Grpc\Timeval::infFuture());
   }
 
   public function testAddEmptyMetadata() {
     $batch = [
         Grpc\OP_SEND_INITIAL_METADATA => []
               ];
-    $result = $this->call->start_batch($batch);
+    $result = $this->call->startBatch($batch);
     $this->assertTrue($result->send_metadata);
   }
 
@@ -59,7 +59,7 @@ class CallTest extends PHPUnit_Framework_TestCase{
     $batch = [
         Grpc\OP_SEND_INITIAL_METADATA => ['key' => ['value']]
               ];
-    $result = $this->call->start_batch($batch);
+    $result = $this->call->startBatch($batch);
     $this->assertTrue($result->send_metadata);
   }
 
@@ -67,7 +67,7 @@ class CallTest extends PHPUnit_Framework_TestCase{
     $batch = [
         Grpc\OP_SEND_INITIAL_METADATA => ['key' => ['value1', 'value2']]
               ];
-    $result = $this->call->start_batch($batch);
+    $result = $this->call->startBatch($batch);
     $this->assertTrue($result->send_metadata);
   }
 
@@ -76,7 +76,7 @@ class CallTest extends PHPUnit_Framework_TestCase{
         Grpc\OP_SEND_INITIAL_METADATA => ['key1' => ['value1'],
                                           'key2' => ['value2', 'value3']]
               ];
-    $result = $this->call->start_batch($batch);
+    $result = $this->call->startBatch($batch);
     $this->assertTrue($result->send_metadata);
   }
 }

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -34,7 +34,7 @@
 class EndToEndTest extends PHPUnit_Framework_TestCase{
   public function setUp() {
     $this->server = new Grpc\Server([]);
-    $port = $this->server->add_http2_port('0.0.0.0:0');
+    $port = $this->server->addHttp2Port('0.0.0.0:0');
     $this->channel = new Grpc\Channel('localhost:' . $port, []);
     $this->server->start();
   }
@@ -45,13 +45,13 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
   }
 
   public function testSimpleRequestBody() {
-    $deadline = Grpc\Timeval::inf_future();
+    $deadline = Grpc\Timeval::infFuture();
     $status_text = 'xyz';
     $call = new Grpc\Call($this->channel,
                           'dummy_method',
                           $deadline);
 
-    $event = $call->start_batch([
+    $event = $call->startBatch([
         Grpc\OP_SEND_INITIAL_METADATA => [],
         Grpc\OP_SEND_CLOSE_FROM_CLIENT => true
                                        ]);
@@ -59,12 +59,12 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
     $this->assertTrue($event->send_metadata);
     $this->assertTrue($event->send_close);
 
-    $event = $this->server->request_call();
+    $event = $this->server->requestCall();
     $this->assertSame('dummy_method', $event->method);
     $this->assertSame([], $event->metadata);
     $server_call = $event->call;
 
-    $event = $server_call->start_batch([
+    $event = $server_call->startBatch([
         Grpc\OP_SEND_INITIAL_METADATA => [],
         Grpc\OP_SEND_STATUS_FROM_SERVER => [
             'metadata' => [],
@@ -78,7 +78,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
     $this->assertTrue($event->send_status);
     $this->assertFalse($event->cancelled);
 
-    $event = $call->start_batch([
+    $event = $call->startBatch([
         Grpc\OP_RECV_INITIAL_METADATA => true,
         Grpc\OP_RECV_STATUS_ON_CLIENT => true
                                  ]);
@@ -94,7 +94,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
   }
 
   public function testClientServerFullRequestResponse() {
-    $deadline = Grpc\Timeval::inf_future();
+    $deadline = Grpc\Timeval::infFuture();
     $req_text = 'client_server_full_request_response';
     $reply_text = 'reply:client_server_full_request_response';
     $status_text = 'status:client_server_full_response_text';
@@ -103,7 +103,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
                           'dummy_method',
                           $deadline);
 
-    $event = $call->start_batch([
+    $event = $call->startBatch([
         Grpc\OP_SEND_INITIAL_METADATA => [],
         Grpc\OP_SEND_CLOSE_FROM_CLIENT => true,
         Grpc\OP_SEND_MESSAGE => $req_text
@@ -113,11 +113,11 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
     $this->assertTrue($event->send_close);
     $this->assertTrue($event->send_message);
 
-    $event = $this->server->request_call();
+    $event = $this->server->requestCall();
     $this->assertSame('dummy_method', $event->method);
     $server_call = $event->call;
 
-    $event = $server_call->start_batch([
+    $event = $server_call->startBatch([
         Grpc\OP_SEND_INITIAL_METADATA => [],
         Grpc\OP_SEND_MESSAGE => $reply_text,
         Grpc\OP_SEND_STATUS_FROM_SERVER => [
@@ -135,7 +135,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
     $this->assertFalse($event->cancelled);
     $this->assertSame($req_text, $event->message);
 
-    $event = $call->start_batch([
+    $event = $call->startBatch([
         Grpc\OP_RECV_INITIAL_METADATA => true,
         Grpc\OP_RECV_MESSAGE => true,
         Grpc\OP_RECV_STATUS_ON_CLIENT => true,

--- a/src/php/tests/unit_tests/SecureEndToEndTest.php
+++ b/src/php/tests/unit_tests/SecureEndToEndTest.php
@@ -40,8 +40,8 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase{
         file_get_contents(dirname(__FILE__) . '/../data/server1.key'),
         file_get_contents(dirname(__FILE__) . '/../data/server1.pem'));
     $this->server = new Grpc\Server();
-    $port = $this->server->add_secure_http2_port('0.0.0.0:0',
-                                                 $server_credentials);
+    $port = $this->server->addSecureHttp2Port('0.0.0.0:0',
+                                              $server_credentials);
     $this->server->start();
     $this->channel = new Grpc\Channel(
         'localhost:' . $port,
@@ -57,13 +57,13 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase{
   }
 
   public function testSimpleRequestBody() {
-    $deadline = Grpc\Timeval::inf_future();
+    $deadline = Grpc\Timeval::infFuture();
     $status_text = 'xyz';
     $call = new Grpc\Call($this->channel,
                           'dummy_method',
                           $deadline);
 
-    $event = $call->start_batch([
+    $event = $call->startBatch([
         Grpc\OP_SEND_INITIAL_METADATA => [],
         Grpc\OP_SEND_CLOSE_FROM_CLIENT => true
                                        ]);
@@ -71,12 +71,12 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase{
     $this->assertTrue($event->send_metadata);
     $this->assertTrue($event->send_close);
 
-    $event = $this->server->request_call();
+    $event = $this->server->requestCall();
     $this->assertSame('dummy_method', $event->method);
     $this->assertSame([], $event->metadata);
     $server_call = $event->call;
 
-    $event = $server_call->start_batch([
+    $event = $server_call->startBatch([
         Grpc\OP_SEND_INITIAL_METADATA => [],
         Grpc\OP_SEND_STATUS_FROM_SERVER => [
             'metadata' => [],
@@ -90,7 +90,7 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase{
     $this->assertTrue($event->send_status);
     $this->assertFalse($event->cancelled);
 
-    $event = $call->start_batch([
+    $event = $call->startBatch([
         Grpc\OP_RECV_INITIAL_METADATA => true,
         Grpc\OP_RECV_STATUS_ON_CLIENT => true
                                  ]);
@@ -106,7 +106,7 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase{
   }
 
   public function testClientServerFullRequestResponse() {
-    $deadline = Grpc\Timeval::inf_future();
+    $deadline = Grpc\Timeval::infFuture();
     $req_text = 'client_server_full_request_response';
     $reply_text = 'reply:client_server_full_request_response';
     $status_text = 'status:client_server_full_response_text';
@@ -115,7 +115,7 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase{
                           'dummy_method',
                           $deadline);
 
-    $event = $call->start_batch([
+    $event = $call->startBatch([
         Grpc\OP_SEND_INITIAL_METADATA => [],
         Grpc\OP_SEND_CLOSE_FROM_CLIENT => true,
         Grpc\OP_SEND_MESSAGE => $req_text
@@ -125,11 +125,11 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase{
     $this->assertTrue($event->send_close);
     $this->assertTrue($event->send_message);
 
-    $event = $this->server->request_call();
+    $event = $this->server->requestCall();
     $this->assertSame('dummy_method', $event->method);
     $server_call = $event->call;
 
-    $event = $server_call->start_batch([
+    $event = $server_call->startBatch([
         Grpc\OP_SEND_INITIAL_METADATA => [],
         Grpc\OP_SEND_MESSAGE => $reply_text,
         Grpc\OP_SEND_STATUS_FROM_SERVER => [
@@ -147,7 +147,7 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase{
     $this->assertFalse($event->cancelled);
     $this->assertSame($req_text, $event->message);
 
-    $event = $call->start_batch([
+    $event = $call->startBatch([
         Grpc\OP_RECV_INITIAL_METADATA => true,
         Grpc\OP_RECV_MESSAGE => true,
         Grpc\OP_RECV_STATUS_ON_CLIENT => true,

--- a/src/php/tests/unit_tests/TimevalTest.php
+++ b/src/php/tests/unit_tests/TimevalTest.php
@@ -39,14 +39,14 @@ class TimevalTest extends PHPUnit_Framework_TestCase{
 
   public function testPastIsLessThanZero() {
     $zero = Grpc\Timeval::zero();
-    $past = Grpc\Timeval::inf_past();
+    $past = Grpc\Timeval::infPast();
     $this->assertLessThan(0, Grpc\Timeval::compare($past, $zero));
     $this->assertGreaterThan(0, Grpc\Timeval::compare($zero, $past));
   }
 
   public function testFutureIsGreaterThanZero() {
     $zero = Grpc\Timeval::zero();
-    $future = Grpc\Timeval::inf_future();
+    $future = Grpc\Timeval::infFuture();
     $this->assertLessThan(0, Grpc\Timeval::compare($zero, $future));
     $this->assertGreaterThan(0, Grpc\Timeval::compare($future, $zero));
   }
@@ -56,7 +56,7 @@ class TimevalTest extends PHPUnit_Framework_TestCase{
    */
   public function testNowIsBetweenZeroAndFuture() {
     $zero = Grpc\Timeval::zero();
-    $future = Grpc\Timeval::inf_future();
+    $future = Grpc\Timeval::infFuture();
     $now = Grpc\Timeval::now();
     $this->assertLessThan(0, Grpc\Timeval::compare($zero, $now));
     $this->assertLessThan(0, Grpc\Timeval::compare($now, $future));


### PR DESCRIPTION
This change is in accordance with [PSR-1](http://www.php-fig.org/psr/psr-1/#4.3.-methods), and closes #131.