### PR TITLE
Trace and trim locks, properly handle SIGINT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,15 @@ CPPFLAGS_dbg = -O0
 LDFLAGS_dbg =
 DEFINES_dbg = _DEBUG DEBUG
 
+VALID_CONFIG_mutrace = 1
+CC_mutrace = $(DEFAULT_CC)
+CXX_mutrace = $(DEFAULT_CXX)
+LD_mutrace = $(DEFAULT_CC)
+LDXX_mutrace = $(DEFAULT_CXX)
+CPPFLAGS_mutrace = -O0
+LDFLAGS_mutrace = -rdynamic
+DEFINES_mutrace = _DEBUG DEBUG
+
 VALID_CONFIG_valgrind = 1
 REQUIRE_CUSTOM_LIBRARIES_valgrind = 1
 CC_valgrind = $(DEFAULT_CC)

--- a/src/core/iomgr/alarm.c
+++ b/src/core/iomgr/alarm.c
@@ -307,6 +307,10 @@ static int run_some_expired_alarms(gpr_mu *drop_mu, gpr_timespec now,
 
   /* TODO(ctiller): verify that there are any alarms (atomically) here */
 
+  if (gpr_time_cmp(g_shard_queue[0]->min_deadline, now) >= 0) {
+    return 0;
+  }
+
   if (gpr_mu_trylock(&g_checker_mu)) {
     gpr_mu_lock(&g_mu);
 

--- a/src/core/transport/metadata.c
+++ b/src/core/transport/metadata.c
@@ -97,7 +97,7 @@ static void internal_string_ref(internal_string *s);
 static void internal_string_unref(internal_string *s);
 static void discard_metadata(grpc_mdctx *ctx);
 static void gc_mdtab(grpc_mdctx *ctx);
-static void metadata_context_destroy(grpc_mdctx *ctx);
+static void metadata_context_destroy_locked(grpc_mdctx *ctx);
 
 static void lock(grpc_mdctx *ctx) { gpr_mu_lock(&ctx->mu); }
 
@@ -122,8 +122,7 @@ static void unlock(grpc_mdctx *ctx) {
       discard_metadata(ctx);
     }
     if (ctx->strtab_count == 0) {
-      gpr_mu_unlock(&ctx->mu);
-      metadata_context_destroy(ctx);
+      metadata_context_destroy_locked(ctx);
       return;
     }
   }
@@ -185,8 +184,7 @@ static void discard_metadata(grpc_mdctx *ctx) {
   }
 }
 
-static void metadata_context_destroy(grpc_mdctx *ctx) {
-  gpr_mu_lock(&ctx->mu);
+static void metadata_context_destroy_locked(grpc_mdctx *ctx) {
   GPR_ASSERT(ctx->strtab_count == 0);
   GPR_ASSERT(ctx->mdtab_count == 0);
   GPR_ASSERT(ctx->mdtab_free == 0);

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -111,6 +111,15 @@ CPPFLAGS_dbg = -O0
 LDFLAGS_dbg =
 DEFINES_dbg = _DEBUG DEBUG
 
+VALID_CONFIG_mutrace = 1
+CC_mutrace = $(DEFAULT_CC)
+CXX_mutrace = $(DEFAULT_CXX)
+LD_mutrace = $(DEFAULT_CC)
+LDXX_mutrace = $(DEFAULT_CXX)
+CPPFLAGS_mutrace = -O0
+LDFLAGS_mutrace = -rdynamic
+DEFINES_mutrace = _DEBUG DEBUG
+
 VALID_CONFIG_valgrind = 1
 REQUIRE_CUSTOM_LIBRARIES_valgrind = 1
 CC_valgrind = $(DEFAULT_CC)

--- a/test/cpp/qps/worker.cc
+++ b/test/cpp/qps/worker.cc
@@ -71,6 +71,8 @@ using namespace gflags;
 
 static bool got_sigint = false;
 
+static void sigint_handler(int x) {got_sigint = true;}
+
 namespace grpc {
 namespace testing {
 
@@ -247,6 +249,8 @@ static void RunServer() {
 int main(int argc, char** argv) {
   grpc_init();
   ParseCommandLineFlags(&argc, &argv, true);
+
+  signal(SIGINT, sigint_handler);
 
   grpc::testing::RunServer();
 


### PR DESCRIPTION
The goal of this pull request is to enable a reduction in contention issues as discussed in issue #241. This is being done using mutrace and identification of problematic locks.
