### PR TITLE
Fix php generated code test

### DIFF
--- a/src/php/tests/generated_code/GeneratedCodeTest.php
+++ b/src/php/tests/generated_code/GeneratedCodeTest.php
@@ -41,7 +41,7 @@ class GeneratedCodeTest extends PHPUnit_Framework_TestCase {
   protected static $client;
   protected static $timeout;
   public static function setUpBeforeClass() {
-    self::$client = new math\MathClient(getenv('GRPC_TEST_HOST'));
+    self::$client = new math\MathClient(new Grpc\BaseStub(getenv('GRPC_TEST_HOST'), []));
   }
 
   public function testSimpleRequest() {


### PR DESCRIPTION
Fix php generated code test. The generated code expected the caller to pass in an object thru the constructor, instead of just the hostname. 

I believe Michael already submited a pull request for this. I just want to practice submiting a pull request on my own for the first time. Feel free to discard this.