### PR TITLE
Remove the racy check added in commit 74c14e5a

### DIFF
--- a/src/core/iomgr/alarm.c
+++ b/src/core/iomgr/alarm.c
@@ -307,10 +307,6 @@ static int run_some_expired_alarms(gpr_mu *drop_mu, gpr_timespec now,
 
   /* TODO(ctiller): verify that there are any alarms (atomically) here */
 
-  if (gpr_time_cmp(g_shard_queue[0]->min_deadline, now) >= 0) {
-    return 0;
-  }
-
   if (gpr_mu_trylock(&g_checker_mu)) {
     gpr_mu_lock(&g_mu);
 


### PR DESCRIPTION
That previous commit was potentially unsafe since checking the deadline involves more than 1 word
read. Restoring earlier status quo. Will find an alternative lock-mitigation mechanism.
