### PR TITLE
Remove unused references to malloc.h

### DIFF
--- a/src/node/ext/byte_buffer.cc
+++ b/src/node/ext/byte_buffer.cc
@@ -32,7 +32,6 @@
  */
 
 #include <string.h>
-#include <malloc.h>
 
 #include <node.h>
 #include <nan.h>

--- a/src/node/ext/channel.cc
+++ b/src/node/ext/channel.cc
@@ -31,8 +31,6 @@
  *
  */
 
-#include <malloc.h>
-
 #include <vector>
 
 #include <node.h>

--- a/src/node/ext/server.cc
+++ b/src/node/ext/server.cc
@@ -38,8 +38,6 @@
 #include <node.h>
 #include <nan.h>
 
-#include <malloc.h>
-
 #include <vector>
 #include "grpc/grpc.h"
 #include "grpc/grpc_security.h"


### PR DESCRIPTION
`malloc.h` is Linux-specific, non-standard and generally deprecated, and prevents the code from compiling on OS X (where it's in `/usr/include/malloc` and not in the default include path). One should use `<cstdlib>` instead. At any rate, it doesn't seem to be in use at all.