### PR TITLE
Fix compilation of Node package on Mac

### DIFF
--- a/src/node/binding.gyp
+++ b/src/node/binding.gyp
@@ -18,12 +18,29 @@
       ],
       'link_settings': {
         'libraries': [
-          '-lrt',
           '-lpthread',
           '-lgrpc',
           '-lgpr'
-        ],
+        ]
       },
+      "conditions": [
+        ['OS == "mac"', {
+          'xcode_settings': {
+            'MACOSX_DEPLOYMENT_TARGET': '10.9',
+            'OTHER_CFLAGS': [
+              '-std=c++11',
+              '-stdlib=libc++'
+            ]
+          }
+        }],
+        ['OS != "mac"', {
+          'link_settings': {
+            'libraries': [
+              '-lrt'
+            ]
+          }
+        }]
+      ],
       "target_name": "grpc",
       "sources": [
         "ext/byte_buffer.cc",


### PR DESCRIPTION
This conditionally:

* Sets compilation target 10.9.
* Adds C++11 compilation.
* Removes `librt` dependency.

This fixes [issue 1997](https://github.com/grpc/grpc/issues/1197).