### PR TITLE
Python: OS X doesn't have librt, so don't link to it.

### DIFF
--- a/src/python/src/setup.py
+++ b/src/python/src/setup.py
@@ -31,6 +31,7 @@
 
 from distutils import core as _core
 import setuptools
+import sys
 
 _EXTENSION_SOURCES = (
     'grpc/_adapter/_c.c',
@@ -50,8 +51,9 @@ _EXTENSION_INCLUDE_DIRECTORIES = (
 _EXTENSION_LIBRARIES = (
     'grpc',
     'gpr',
-    'rt',
 )
+if not "darwin" in sys.platform:
+    _EXTENSION_LIBRARIES += ('rt',)
 
 _EXTENSION_MODULE = _core.Extension(
     'grpc._adapter._c', sources=list(_EXTENSION_SOURCES),


### PR DESCRIPTION
This should the compilation problem mentioned in [issue 1195](https://github.com/grpc/grpc/issues/1195).