### PR TITLE
Remove usage of xray

### DIFF
--- a/src/ruby/grpc.gemspec
+++ b/src/ruby/grpc.gemspec
@@ -13,6 +13,9 @@ Gem::Specification.new do |s|
   s.description   = 'Send RPCs from Ruby using GRPC'
   s.license       = 'BSD-3-Clause'
 
+  s.required_ruby_version = '>= 2.0.0'
+  s.requirements << 'libgrpc ~> 0.6.0 needs to be installed'
+
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.executables   = `git ls-files -- bin/*.rb`.split("\n").map do |f|
@@ -25,13 +28,12 @@ Gem::Specification.new do |s|
   s.add_dependency 'googleauth', '~> 0.4'  # reqd for interop tests
   s.add_dependency 'logging', '~> 1.8'
   s.add_dependency 'minitest', '~> 5.4'  # reqd for interop tests
-  s.add_dependency 'xray', '~> 1.1'
 
   s.add_development_dependency 'bundler', '~> 1.9'
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rake-compiler', '~> 0.9'
-  s.add_development_dependency 'rubocop', '~> 0.30'
   s.add_development_dependency 'rspec', '~> 3.2'
+  s.add_development_dependency 'rubocop', '~> 0.30'
 
   s.extensions = %w(ext/grpc/extconf.rb)
 end

--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -28,7 +28,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 require 'grpc/generic/active_call'
-require 'xray/thread_dump_signal_handler'
 
 # GRPC contains the General RPC module.
 module GRPC

--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -31,7 +31,6 @@ require 'grpc/grpc'
 require 'grpc/generic/active_call'
 require 'grpc/generic/service'
 require 'thread'
-require 'xray/thread_dump_signal_handler'
 
 # A global that contains signals the gRPC servers should respond to.
 $grpc_signals = []

--- a/src/ruby/spec/generic/client_stub_spec.rb
+++ b/src/ruby/spec/generic/client_stub_spec.rb
@@ -28,7 +28,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 require 'grpc'
-require 'xray/thread_dump_signal_handler'
 
 # Notifier is useful high-level synchronization primitive.
 class Notifier

--- a/src/ruby/spec/generic/rpc_server_pool_spec.rb
+++ b/src/ruby/spec/generic/rpc_server_pool_spec.rb
@@ -28,7 +28,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 require 'grpc'
-require 'xray/thread_dump_signal_handler'
 
 Pool = GRPC::RpcServer::Pool
 

--- a/src/ruby/spec/generic/rpc_server_spec.rb
+++ b/src/ruby/spec/generic/rpc_server_spec.rb
@@ -28,7 +28,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 require 'grpc'
-require 'xray/thread_dump_signal_handler'
 
 def load_test_certs
   test_root = File.join(File.dirname(File.dirname(__FILE__)), 'testdata')


### PR DESCRIPTION
- xray was useful during dev testing but is neither a dev or runtime dep
- its presence causes issues for libraries that handle signals themselves

Also
- updates grpc.gemspec with requirements

Fixes #1283