### PR TITLE
Added JSON option for gRPC file loading

### DIFF
--- a/src/node/index.js
+++ b/src/node/index.js
@@ -67,10 +67,25 @@ function loadObject(value) {
 /**
  * Load a gRPC object from a .proto file.
  * @param {string} filename The file to load
+ * @param {string=} format The file format to expect. Must be either 'proto' or
+ *     'json'. Defaults to 'proto'
  * @return {Object<string, *>} The resulting gRPC object
  */
-function load(filename) {
-  var builder = ProtoBuf.loadProtoFile(filename);
+function load(filename, format) {
+  if (!format) {
+    format = 'proto';
+  }
+  var builder;
+  switch(format) {
+    case 'proto':
+    builder = ProtoBuf.loadProtoFile(filename);
+    break;
+    case 'json':
+    builder = ProtoBuf.loadJsonFile(filename);
+    break;
+    default:
+    throw new Error('Unrecognized format "' + format + '"');
+  }
 
   return loadObject(builder.ns);
 }

--- a/src/node/test/surface_test.js
+++ b/src/node/test/surface_test.js
@@ -47,6 +47,28 @@ var mathService = math_proto.lookup('math.Math');
 
 var capitalize = require('underscore.string/capitalize');
 
+describe('File loader', function() {
+  it('Should load a proto file by default', function() {
+    assert.doesNotThrow(function() {
+      grpc.load(__dirname + '/test_service.proto');
+    });
+  });
+  it('Should load a proto file with the proto format', function() {
+    assert.doesNotThrow(function() {
+      grpc.load(__dirname + '/test_service.proto', 'proto');
+    });
+  });
+  it('Should load a json file with the json format', function() {
+    assert.doesNotThrow(function() {
+      grpc.load(__dirname + '/test_service.json', 'json');
+    });
+  });
+  it('Should fail to load a file with an unknown format', function() {
+    assert.throws(function() {
+      grpc.load(__dirname + '/test_service.proto', 'fake_format');
+    });
+  });
+});
 describe('Surface server constructor', function() {
   it('Should fail with conflicting method names', function() {
     assert.throws(function() {

--- a/src/node/test/test_service.json
+++ b/src/node/test/test_service.json
@@ -1,0 +1,55 @@
+{
+    "package": null,
+    "messages": [
+        {
+            "name": "Request",
+            "fields": [
+                {
+                    "rule": "optional",
+                    "type": "bool",
+                    "name": "error",
+                    "id": 1
+                }
+            ]
+        },
+        {
+            "name": "Response",
+            "fields": [
+                {
+                    "rule": "optional",
+                    "type": "int32",
+                    "name": "count",
+                    "id": 1
+                }
+            ]
+        }
+    ],
+    "services": [
+        {
+            "name": "TestService",
+            "options": {},
+            "rpc": {
+                "Unary": {
+                    "request": "Request",
+                    "response": "Response",
+                    "options": {}
+                },
+                "ClientStream": {
+                    "request": "Request",
+                    "response": "Response",
+                    "options": {}
+                },
+                "ServerStream": {
+                    "request": "Request",
+                    "response": "Response",
+                    "options": {}
+                },
+                "BidiStream": {
+                    "request": "Request",
+                    "response": "Response",
+                    "options": {}
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This is part of #1281. Loading binary files will be considerably more complicated, and will probably require additional features in ProtoBuf.js