### PR TITLE
Creating nuget package for gRPC C#

### DIFF
--- a/src/csharp/Grpc.Core/.gitignore
+++ b/src/csharp/Grpc.Core/.gitignore
@@ -1,2 +1,3 @@
 bin
 obj
+*.nupkg

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -34,8 +34,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.0.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Bcl.Immutable.1.0.34\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csharp/Grpc.Core/Grpc.Core.nuspec
+++ b/src/csharp/Grpc.Core/Grpc.Core.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<package >
+<package>
   <metadata>
     <id>Grpc.Core</id>
     <title>gRPC Core</title>
@@ -7,7 +7,7 @@
     <description>Core C# implementation of gRPC - an RPC library and framework. See project site for more info.
      This is an experimental release, not ready to use.
     </description>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <authors>Google Inc.</authors>
     <owners>jtattermusch</owners>
     <licenseUrl>https://github.com/grpc/grpc/blob/master/LICENSE</licenseUrl>
@@ -16,6 +16,12 @@
     <releaseNotes>The first experimental release. Not ready to use.</releaseNotes>
     <copyright>Copyright 2015, Google Inc.</copyright>
     <tags>gRPC RPC Protocol HTTP/2</tags>
+	<dependencies>
+	  <dependency id="Microsoft.Bcl.Immutable" version="1.0.34" />
+      <dependency id="grpc.dependencies.zlib.redist" version="1.2.8.9" />
+	  <dependency id="grpc.dependencies.openssl.redist" version="1.0.2.2" />
+	  <dependency id="grpc.native.csharp_ext.redist" version="0.6.0.0" />
+    </dependencies>
   </metadata>
   <files>
     <file src="bin/Release/Grpc.Core.dll" target="lib/net45" />

--- a/src/csharp/Grpc.Core/Grpc.Core.nuspec
+++ b/src/csharp/Grpc.Core/Grpc.Core.nuspec
@@ -18,9 +18,7 @@
     <tags>gRPC RPC Protocol HTTP/2</tags>
 	<dependencies>
 	  <dependency id="Microsoft.Bcl.Immutable" version="1.0.34" />
-      <dependency id="grpc.dependencies.zlib.redist" version="1.2.8.9" />
-	  <dependency id="grpc.dependencies.openssl.redist" version="1.0.2.2" />
-	  <dependency id="grpc.native.csharp_ext.redist" version="0.6.0.0" />
+	  <dependency id="grpc.native.csharp_ext" version="0.6.0.0" />
     </dependencies>
   </metadata>
   <files>

--- a/src/csharp/Grpc.Core/packages.config
+++ b/src/csharp/Grpc.Core/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="grpc.dependencies.openssl.redist" version="1.0.2.2" targetFramework="net45" />
   <package id="grpc.dependencies.zlib.redist" version="1.2.8.9" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net45" />
 </packages>

--- a/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
+++ b/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
@@ -39,8 +39,9 @@
     <Reference Include="Google.ProtocolBuffers">
       <HintPath>..\packages\Google.ProtocolBuffers.2.4.1.521\lib\net40\Google.ProtocolBuffers.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable">
-      <HintPath>..\packages\System.Collections.Immutable.1.1.34-rc\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.0.34.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Bcl.Immutable.1.0.34\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csharp/Grpc.IntegrationTesting/packages.config
+++ b/src/csharp/Grpc.IntegrationTesting/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.ProtocolBuffers" version="2.4.1.521" targetFramework="net45" />
+  <package id="Microsoft.Bcl.Immutable" version="1.0.34" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.34-rc" targetFramework="net45" />
 </packages>

--- a/templates/vsprojects/vcxproj_defs.include
+++ b/templates/vsprojects/vcxproj_defs.include
@@ -56,7 +56,7 @@ ${gen_package_props(packages)}\
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\global.props" />
     % for prop in additional_props:
-    <Import Project="..\${prop}." />
+    <Import Project="..\${prop}.props" />
     % endfor
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />

--- a/vsprojects/grpc_csharp_ext/grpc_csharp_ext.vcxproj
+++ b/vsprojects/grpc_csharp_ext/grpc_csharp_ext.vcxproj
@@ -46,7 +46,7 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
     <Import Project="..\global.props" />
-    <Import Project="..\winsock." />
+    <Import Project="..\winsock.props" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/vsprojects/nuget_package/.gitignore
+++ b/vsprojects/nuget_package/.gitignore
@@ -1,0 +1,3 @@
+/tmp
+/output
+*.nupkg

--- a/vsprojects/nuget_package/README.md
+++ b/vsprojects/nuget_package/README.md
@@ -1,0 +1,20 @@
+gRPC Native Nuget package
+=========================
+
+Prerequisites
+-------------
+Multiple versions of VS installed to be able to build all the targets:
+* Visual Studio 2013
+* Visual Studio 2010 (you might need SP1 to prevent LNK1123 error)
+
+NuGet binary
+
+Building the package
+--------------------
+
+Build all flavors of gRPC C# extension and package them as a NuGet package.
+```
+buildall.bat
+
+nuget pack grpc.native.csharp_ext
+```

--- a/vsprojects/nuget_package/buildall.bat
+++ b/vsprojects/nuget_package/buildall.bat
@@ -1,0 +1,46 @@
+@echo off
+setlocal
+
+REM setlocal
+REM call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" amd64
+REM call :build x64 Release v120 || goto :eof
+REM call :build x64 Debug v120 || goto :eof
+REM endlocal
+
+setlocal
+call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x86
+call :build Win32 Release v120 || goto :eof
+call :build Win32 Debug v120 || goto :eof
+endlocal
+
+REM setlocal
+REM call "C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat" amd64
+REM call :build x64 Release v110 || goto :eof
+REM call :build x64 Debug v110 || goto :eof
+REM endlocal
+
+REM setlocal
+REM call "C:\Program Files (x86)\Microsoft Visual Studio 11.0\VC\vcvarsall.bat" x86
+REM call :build Win32 Release v110 || goto :eof
+REM call :build Win32 Debug v110 || goto :eof
+REM endlocal
+
+REM setlocal
+REM call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" amd64
+REM call :build x64 Release v100 || goto :eof
+REM call :build x64 Debug v100 || goto :eof
+REM endlocal
+
+setlocal
+call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
+call :build Win32 Release v100 || goto :eof
+call :build Win32 Debug v100 || goto :eof
+endlocal
+
+goto :eof
+
+:build
+msbuild /t:grpc_csharp_ext /P:Platform=%1 /P:Configuration=%2 /P:PlatformToolset=%3 /P:OutDir=..\nuget_package\output\%3\%1\%2\ /P:IntDir=..\nuget_package\tmp\%3\%1\%2\ ..\grpc.sln || goto :eof
+goto :eof
+
+

--- a/vsprojects/nuget_package/grpc.native.csharp_ext.nuspec
+++ b/vsprojects/nuget_package/grpc.native.csharp_ext.nuspec
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>grpc.native.csharp_ext</id>
+    <version>0.6.0.0</version>
+    <authors>Google Inc.</authors>
+    <owners>Jan Tattermusch</owners>
+    <licenseUrl>https://github.com/grpc/grpc/blob/master/LICENSE</licenseUrl>
+    <projectUrl>http://github.com/grpc/grpc</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Native extension needed by gRPC C# library. This is not the package you are looking for, it is only meant to be used as a dependency.</description>
+    <releaseNotes>Release of gRPC C core 0.6.0 libraries.</releaseNotes>
+    <copyright>Copyright 2015</copyright>
+    <title>gRPC C# Native Extension</title>
+    <summary>Native library required by gRPC C#</summary>
+    <tags>gRPC native</tags>
+	<dependencies>
+      <dependency id="grpc.dependencies.zlib.redist" version="1.2.8.9" />
+	  <dependency id="grpc.dependencies.openssl.redist" version="1.0.2.2" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="grpc.native.csharp_ext.props" target="\build\portable-net45\grpc.native.csharp_ext.props" />
+    <file src="grpc.native.csharp_ext.targets" target="\build\portable-net45\grpc.native.csharp_ext.targets" />
+    <file src="output\v100\Win32\Release\grpc_csharp_ext.dll" target="/build/native/bin/v100\Win32\Release\grpc_csharp_ext.dll" />
+    <file src="output\v120\Win32\Release\grpc_csharp_ext.dll" target="/build/native/bin/v120\Win32\Release\grpc_csharp_ext.dll" />
+    <file src="output\v100\Win32\Debug\grpc_csharp_ext.dll" target="/build/native/bin/v100\Win32\Debug\grpc_csharp_ext.dll" />
+    <file src="output\v120\Win32\Debug\grpc_csharp_ext.dll" target="/build/native/bin/v120\Win32\Debug\grpc_csharp_ext.dll" />
+  </files>
+</package>

--- a/vsprojects/nuget_package/grpc.native.csharp_ext.props
+++ b/vsprojects/nuget_package/grpc.native.csharp_ext.props
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Whether or not copy native dependencies to output directory after building -->
+    <CopyNativeDependencies Condition=" '$(CopyNativeDependencies)' == '' ">true</CopyNativeDependencies>
+    
+	<!-- Set defaults for native dependencies if not already set. Properties can be overriden in the project files. -->
+	<NativeDependenciesToolset Condition=" '$(NativeDependenciesToolset)' == '' ">v120</NativeDependenciesToolset>
+    <NativeDependenciesPlatform Condition=" '$(NativeDependenciesPlatform)' == '' ">Win32</NativeDependenciesPlatform>
+    <NativeDependenciesConfiguration Condition=" '$(NativeDependenciesConfiguration)' == '' ">Debug</NativeDependenciesConfiguration>
+  </PropertyGroup>
+</Project>

--- a/vsprojects/nuget_package/grpc.native.csharp_ext.targets
+++ b/vsprojects/nuget_package/grpc.native.csharp_ext.targets
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Choose>
+    <!-- Under older versions of Monodevelop, Choose is not supported and is just ignored, which gives us the desired effect. -->
+    <When Condition=" '$(OS)' != 'Unix' ">
+      <ItemGroup Condition=" '$(CopyNativeDependencies)' == 'true' ">
+        <Content Include="$(MSBuildThisFileDirectory)..\..\build\native\bin\$(NativeDependenciesToolset)\$(NativeDependenciesPlatform)\$(NativeDependenciesConfiguration)\grpc_csharp_ext.dll">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+      </ItemGroup>
+	</When>
+  <Otherwise />
+  </Choose>
+</Project>


### PR DESCRIPTION
-- the package depends on grpc.native.csharp_ext that contains multiple versions of grpc_sharp_ext.dll (compiled with different configurations).
-- the goal is to have a single nuget package for C# that will fetch all the necessary dlls.