### PR TITLE
Remove an extra unref

### DIFF
--- a/src/cpp/util/byte_buffer.cc
+++ b/src/cpp/util/byte_buffer.cc
@@ -60,7 +60,6 @@ void ByteBuffer::Dump(std::vector<Slice>* slices) {
   gpr_slice s;
   while (grpc_byte_buffer_reader_next(reader, &s)) {
     slices->push_back(Slice(s, Slice::STEAL_REF));
-    gpr_slice_unref(s);
   }
   grpc_byte_buffer_reader_destroy(reader);
 }

--- a/test/cpp/end2end/generic_end2end_test.cc
+++ b/test/cpp/end2end/generic_end2end_test.cc
@@ -149,7 +149,8 @@ class GenericEnd2endTest : public ::testing::Test {
       GenericServerContext srv_ctx;
       GenericServerAsyncReaderWriter stream(&srv_ctx);
 
-      send_request.set_message("Hello");
+      // The string needs to be long enough to test heap-based slice.
+      send_request.set_message("Hello world. Hello world. Hello world.");
       std::unique_ptr<GenericClientAsyncReaderWriter> call =
           generic_stub_->Call(&cli_ctx, kMethodName, &cli_cq_, tag(1));
       client_ok(1);


### PR DESCRIPTION
buffer_ should hold a ref, then
reader->Next ===> ref
Slice ctor ===> nothing
push_back copy ===> ref
temp Slice dtor ===> unref

When the buffer_ and vector are destroyed, two unref will happen and net to 0.