### PR TITLE
partial fix for #546

### DIFF
--- a/src/core/iomgr/tcp_windows.c
+++ b/src/core/iomgr/tcp_windows.c
@@ -127,6 +127,7 @@ static void on_read(void *tcpp, int success) {
 
   if (socket->read_info.wsa_error != 0) {
     char *utf8_message = gpr_format_message(info->wsa_error);
+    gpr_log(GPR_ERROR, "ReadFile overlapped error: %s", utf8_message);
     gpr_free(utf8_message);
     status = GRPC_ENDPOINT_CB_ERROR;
   } else {


### PR DESCRIPTION
after surrounding start_accept(sp) by "if (success)" the the server doesn't always fail with assertion error upon shutdown but instead

-- Finishes "cleanly" but hangs upon shutdown (which is probably better than crashing)
-- Sometimes races into use-after-free, which is clearly indicated by the assertion I added.

So this is not really a fix, but it reveals some underlying problems with C core on windows.