### PR TITLE
add missing defines on windows (WIN64)

### DIFF
--- a/include/grpc/support/atm_win32.h
+++ b/include/grpc/support/atm_win32.h
@@ -73,7 +73,7 @@ static __inline int gpr_atm_no_barrier_cas(gpr_atm *p, gpr_atm o, gpr_atm n) {
 
 static __inline int gpr_atm_acq_cas(gpr_atm *p, gpr_atm o, gpr_atm n) {
 #ifdef GPR_ARCH_64
-  return o == (gpr_atm)InterlockedCompareExchangeAcquire64((volatile LONGLONG) p,
+  return o == (gpr_atm)InterlockedCompareExchangeAcquire64((volatile LONGLONG *) p,
                                                            (LONGLONG) n, (LONGLONG) o);
 #else
   return o == (gpr_atm)InterlockedCompareExchangeAcquire((volatile LONG *) p,

--- a/include/grpc/support/port_platform.h
+++ b/include/grpc/support/port_platform.h
@@ -45,8 +45,10 @@
 #define GPR_WINSOCK_SOCKET 1
 #ifdef __GNUC__
 #define GPR_GCC_ATOMIC 1
+#define GPR_GCC_TLS 1
 #else
 #define GPR_WIN32_ATOMIC 1
+#define GPR_MSVC_TLS 1
 #endif
 #elif defined(_WIN32) || defined(WIN32)
 #define GPR_ARCH_32 1


### PR DESCRIPTION
I found this when making grpc buildable on Windows 64bit mode.


