### PR TITLE
Test client stream cancellation and fix bug exposed by the test.

### DIFF
--- a/include/grpc++/stream.h
+++ b/include/grpc++/stream.h
@@ -173,7 +173,7 @@ class ClientWriter GRPC_FINAL : public ClientStreamingInterface,
     buf.AddRecvMessage(response_);
     buf.AddClientRecvStatus(context_, &status);
     call_.PerformOps(&buf);
-    GPR_ASSERT(cq_.Pluck(&buf) && buf.got_message);
+    GPR_ASSERT(cq_.Pluck(&buf));
     return status;
   }
 

--- a/src/cpp/common/completion_queue.cc
+++ b/src/cpp/common/completion_queue.cc
@@ -92,7 +92,8 @@ bool CompletionQueue::Pluck(CompletionQueueTag* tag) {
   void* ignored = tag;
   GPR_ASSERT(tag->FinalizeResult(&ignored, &ok));
   GPR_ASSERT(ignored == tag);
-  return ok;
+  // Ignore mutations by FinalizeResult: Pluck returns the C API status
+  return ev->data.op_complete == GRPC_OP_OK;
 }
 
 void CompletionQueue::TryPluck(CompletionQueueTag* tag) {

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -491,6 +491,27 @@ TEST_F(End2endTest, ServerCancelsRpc) {
   EXPECT_TRUE(s.details().empty());
 }
 
+// Client cancels request stream after sending two messages
+TEST_F(End2endTest, ClientCancelsRequestStream) {
+  ResetStub();
+  EchoRequest request;
+  EchoResponse response;
+  ClientContext context;
+  request.set_message("hello");
+
+  auto stream = stub_->RequestStream(&context, &response);
+  EXPECT_TRUE(stream->Write(request));
+  EXPECT_TRUE(stream->Write(request));
+  
+  context.TryCancel();
+
+  Status s = stream->Finish();
+  EXPECT_EQ(grpc::StatusCode::CANCELLED, s.code());
+  
+  EXPECT_EQ(response.message(), "");
+
+}
+
 // Client cancels server stream after sending some messages
 TEST_F(End2endTest, ClientCancelsResponseStream) {
   ResetStub();


### PR DESCRIPTION
This is a second attempt to get PR1308 ( https://github.com/grpc/grpc/pull/1308) that I had to abandon due to a botched merge. Includes the original test and a fix by ctiller all in one commit.