### PR TITLE
Fix errors and warnings breaking compilation under GCC+Windows (MSYS2/MinGW)

### DIFF
--- a/src/core/iomgr/resolve_address_windows.c
+++ b/src/core/iomgr/resolve_address_windows.c
@@ -65,7 +65,6 @@ grpc_resolved_addresses *grpc_blocking_resolve_address(
   int s;
   size_t i;
   grpc_resolved_addresses *addrs = NULL;
-  const gpr_timespec start_time = gpr_now();
 
   /* parse name, splitting it into host and port parts */
   gpr_split_host_port(name, &host, &port);
@@ -108,9 +107,6 @@ grpc_resolved_addresses *grpc_blocking_resolve_address(
   }
 
   {
-    const gpr_timespec delay = gpr_time_sub(gpr_now(), start_time);
-    const int delay_ms =
-        delay.tv_sec * GPR_MS_PER_SEC + delay.tv_nsec / GPR_NS_PER_MS;
     for (i = 0; i < addrs->naddrs; i++) {
       char *buf;
       grpc_sockaddr_to_string(&buf, (struct sockaddr *)&addrs->addrs[i].addr,

--- a/src/core/iomgr/tcp_server_windows.c
+++ b/src/core/iomgr/tcp_server_windows.c
@@ -192,7 +192,7 @@ static void start_accept(server_port *port) {
   }
 
   /* TODO(jtattermusch): probably a race here, we regularly get use-after-free on server shutdown */
-  GPR_ASSERT(port->socket != 0xfeeefeee);
+  GPR_ASSERT(port->socket != (grpc_winsocket*)0xfeeefeee);
   success = port->AcceptEx(port->socket->socket, sock, port->addresses, 0,
                            addrlen, addrlen, &bytes_received,
                            &port->socket->read_info.overlapped);


### PR DESCRIPTION
The most severe error was the lack of proper casting at
638c1ee16147f40981cdfc785d520eb162dbcbea

@jtattermusch could you check if I understood your original intention?