### PR TITLE
Fix early shutdown

### DIFF
--- a/include/grpc++/client_context.h
+++ b/include/grpc++/client_context.h
@@ -35,6 +35,7 @@
 #define GRPCXX_CLIENT_CONTEXT_H
 
 #include <map>
+#include <memory>
 #include <string>
 
 #include <grpc/support/log.h>
@@ -126,9 +127,10 @@ class ClientContext {
   friend class ::grpc::ClientAsyncResponseReader;
 
   grpc_call* call() { return call_; }
-  void set_call(grpc_call* call) {
+  void set_call(grpc_call* call, const std::shared_ptr<ChannelInterface>& channel) {
     GPR_ASSERT(call_ == nullptr);
     call_ = call;
+    channel_ = channel;
   }
 
   grpc_completion_queue* cq() { return cq_; }
@@ -137,6 +139,7 @@ class ClientContext {
   grpc::string authority() { return authority_; }
 
   bool initial_metadata_received_;
+  std::shared_ptr<ChannelInterface> channel_;
   grpc_call* call_;
   grpc_completion_queue* cq_;
   gpr_timespec deadline_;

--- a/src/cpp/client/channel.cc
+++ b/src/cpp/client/channel.cc
@@ -71,7 +71,7 @@ Call Channel::CreateCall(const RpcMethod& method, ClientContext* context,
                                          : context->authority().c_str(),
                                      context->raw_deadline());
   GRPC_TIMER_MARK(CALL_CREATED, c_call);
-  context->set_call(c_call);
+  context->set_call(c_call, shared_from_this());
   return Call(c_call, this, cq);
 }
 

--- a/src/cpp/client/channel.h
+++ b/src/cpp/client/channel.h
@@ -51,6 +51,7 @@ class Credentials;
 class StreamContextInterface;
 
 class Channel GRPC_FINAL : public GrpcLibrary,
+                           public std::enable_shared_from_this<Channel>,
                            public ChannelInterface {
  public:
   Channel(const grpc::string& target, grpc_channel* c_channel);


### PR DESCRIPTION
Since ClientContext is responsible for deleting the C call, we need it to also keep the C++ channel alive for some time to avoid early grpc shutdown.