### PR TITLE
Fix a race in QPS client shutdown

### DIFF
--- a/test/cpp/qps/client_sync.cc
+++ b/test/cpp/qps/client_sync.cc
@@ -105,6 +105,7 @@ class SynchronousStreamingClient GRPC_FINAL : public SynchronousClient {
     StartThreads(num_threads_);
   }
   ~SynchronousStreamingClient() {
+    EndThreads();
     if (stream_) {
       SimpleResponse response;
       stream_->WritesDone();


### PR DESCRIPTION
Previously we were cleaning up threads only AFTER local resources were
reclaimed, leading to many crashes.