### PR TITLE
Few VS2010 fixes.

### DIFF
--- a/include/grpc++/server.h
+++ b/include/grpc++/server.h
@@ -80,7 +80,6 @@ class Server GRPC_FINAL : public GrpcLibrary,
 
   // ServerBuilder use only
   Server(ThreadPoolInterface* thread_pool, bool thread_pool_owned);
-  Server() = delete;
   // Register a service. This call does not take ownership of the service.
   // The service must exist for the lifetime of the Server instance.
   bool RegisterService(RpcService* service);
@@ -118,7 +117,7 @@ class Server GRPC_FINAL : public GrpcLibrary,
   int num_running_cb_;
   grpc::condition_variable callback_cv_;
 
-  std::list<SyncRequest> sync_methods_;
+  std::list<SyncRequest>* sync_methods_;
 
   // Pointer to the c grpc server.
   grpc_server* const server_;
@@ -126,6 +125,8 @@ class Server GRPC_FINAL : public GrpcLibrary,
   ThreadPoolInterface* thread_pool_;
   // Whether the thread pool is created and owned by the server.
   bool thread_pool_owned_;
+ private:
+  Server() : server_(NULL) { abort(); }
 };
 
 }  // namespace grpc

--- a/src/cpp/server/server.cc
+++ b/src/cpp/server/server.cc
@@ -180,6 +180,7 @@ Server::Server(ThreadPoolInterface* thread_pool, bool thread_pool_owned)
     : started_(false),
       shutdown_(false),
       num_running_cb_(0),
+      sync_methods_(new std::list<SyncRequest>),
       server_(grpc_server_create(cq_.cq(), nullptr)),
       thread_pool_(thread_pool),
       thread_pool_owned_(thread_pool_owned) {}
@@ -196,6 +197,7 @@ Server::~Server() {
   if (thread_pool_owned_) {
     delete thread_pool_;
   }
+  delete sync_methods_;
 }
 
 bool Server::RegisterService(RpcService* service) {
@@ -208,7 +210,8 @@ bool Server::RegisterService(RpcService* service) {
               method->name());
       return false;
     }
-    sync_methods_.emplace_back(method, tag);
+    SyncRequest request(method, tag);
+    sync_methods_->emplace_back(request);
   }
   return true;
 }
@@ -250,8 +253,8 @@ bool Server::Start() {
   grpc_server_start(server_);
 
   // Start processing rpcs.
-  if (!sync_methods_.empty()) {
-    for (auto m = sync_methods_.begin(); m != sync_methods_.end(); m++) {
+  if (!sync_methods_->empty()) {
+    for (auto m = sync_methods_->begin(); m != sync_methods_->end(); m++) {
       m->Request(server_);
     }
 

--- a/src/cpp/server/server_builder.cc
+++ b/src/cpp/server/server_builder.cc
@@ -66,7 +66,8 @@ void ServerBuilder::RegisterAsyncGenericService(AsyncGenericService* service) {
 void ServerBuilder::AddListeningPort(const grpc::string& addr,
                                      std::shared_ptr<ServerCredentials> creds,
                                      int* selected_port) {
-  ports_.push_back(Port{addr, creds, selected_port});
+  Port port = {addr, creds, selected_port};
+  ports_.push_back(port);
 }
 
 void ServerBuilder::SetThreadPool(ThreadPoolInterface* thread_pool) {


### PR DESCRIPTION
-) = delete isn't supported. Moving destructor out of scope.
-) variadic templates aren't supported. Replacing emplace_back's construction.
-) C++11's {} inline construction isn't supported. Adding temporary variables.
-) std::list<> can't work on a non-declared class. Changing to a raw pointer.