### PR TITLE
Work around Mac XCode 6.2 shared_ptr behavior

### DIFF
--- a/src/cpp/client/create_channel.cc
+++ b/src/cpp/client/create_channel.cc
@@ -45,6 +45,8 @@ std::shared_ptr<ChannelInterface> CreateChannel(
     const ChannelArguments& args) {
   return creds ? creds->CreateChannel(target, args)
                : std::shared_ptr<ChannelInterface>(
-                     new Channel(target, grpc_lame_client_channel_create()));
+                     static_cast<ChannelInterface*>(
+                         new Channel(target,
+                                     grpc_lame_client_channel_create())));
 }
 }  // namespace grpc

--- a/src/cpp/client/insecure_credentials.cc
+++ b/src/cpp/client/insecure_credentials.cc
@@ -48,8 +48,9 @@ class InsecureCredentialsImpl GRPC_FINAL : public Credentials {
       const string& target, const grpc::ChannelArguments& args) GRPC_OVERRIDE {
     grpc_channel_args channel_args;
     args.SetChannelArgs(&channel_args);
-    return std::shared_ptr<ChannelInterface>(new Channel(
-        target, grpc_channel_create(target.c_str(), &channel_args)));
+    return std::shared_ptr<ChannelInterface>(static_cast<ChannelInterface*>(
+        new Channel(
+            target, grpc_channel_create(target.c_str(), &channel_args))));
   }
 
   SecureCredentials* AsSecureCredentials() GRPC_OVERRIDE { return nullptr; }

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -43,10 +43,12 @@ std::shared_ptr<grpc::ChannelInterface> SecureCredentials::CreateChannel(
     const string& target, const grpc::ChannelArguments& args) {
   grpc_channel_args channel_args;
   args.SetChannelArgs(&channel_args);
-  return std::shared_ptr<ChannelInterface>(new Channel(
-      args.GetSslTargetNameOverride().empty() ? target
-                                              : args.GetSslTargetNameOverride(),
-      grpc_secure_channel_create(c_creds_, target.c_str(), &channel_args)));
+  return std::shared_ptr<ChannelInterface>(static_cast<ChannelInterface*>(
+      new Channel(
+          args.GetSslTargetNameOverride().empty() ?
+              target : args.GetSslTargetNameOverride(),
+          grpc_secure_channel_create(c_creds_, target.c_str(),
+                                     &channel_args))));
 }
 
 namespace {


### PR DESCRIPTION
XCode 6.2 has some wonky behavior with respect to its internal C++11 features,
resulting in strange compile-time errors.