### PR TITLE
implement gpr_cpu_num_cores() and gpr_cpu_current_cpu() on Windows

### DIFF
--- a/src/core/support/cpu_windows.c
+++ b/src/core/support/cpu_windows.c
@@ -34,19 +34,17 @@
 #include <grpc/support/port_platform.h>
 
 #ifdef GPR_WIN32
-
+#include <Windows.h>
 #include <grpc/support/log.h>
 
 unsigned gpr_cpu_num_cores(void) {
-  /* TODO(jtattermusch): implement */
-  gpr_log(GPR_ERROR, "Cannot determine number of CPUs: assuming 1");
-  return 1;
+  SYSTEM_INFO si;
+  GetSystemInfo(&si);
+  return si.dwNumberOfProcessors;
 }
 
 unsigned gpr_cpu_current_cpu(void) {
-  /* TODO(jtattermusch): implement */
-  gpr_log(GPR_ERROR, "Cannot determine current CPU");
-  return 0;
+  return GetCurrentProcessorNumber();
 }
 
 #endif /* GPR_WIN32 */

--- a/src/core/support/cpu_windows.c
+++ b/src/core/support/cpu_windows.c
@@ -34,7 +34,7 @@
 #include <grpc/support/port_platform.h>
 
 #ifdef GPR_WIN32
-#include <Windows.h>
+#include <windows.h>
 #include <grpc/support/log.h>
 
 unsigned gpr_cpu_num_cores(void) {


### PR DESCRIPTION
I'm testing grpc on Windows x64 nowadays, but there are some non-implemented functions. So, I added some lines for the Windows platform like this. May I do that?