### PR TITLE
Added important (!) profiling mark.

### DIFF
--- a/src/core/profiling/basic_timers.c
+++ b/src/core/profiling/basic_timers.c
@@ -45,7 +45,12 @@
 #include <grpc/support/thd.h>
 #include <stdio.h>
 
-typedef enum { BEGIN = '{', END = '}', MARK = '.' } marker_type;
+typedef enum {
+  BEGIN = '{',
+  END = '}',
+  MARK = '.',
+  IMPORTANT = '!'
+} marker_type;
 
 typedef struct grpc_timer_entry {
   grpc_precise_clock tm;
@@ -98,6 +103,13 @@ static void grpc_timers_log_add(int tag, marker_type type, void* id,
 void grpc_timer_add_mark(int tag, void* id, const char* file, int line) {
   if (tag < GRPC_PTAG_IGNORE_THRESHOLD) {
     grpc_timers_log_add(tag, MARK, id, file, line);
+  }
+}
+
+void grpc_timer_add_important_mark(int tag, void* id, const char* file,
+                                   int line) {
+  if (tag < GRPC_PTAG_IGNORE_THRESHOLD) {
+    grpc_timers_log_add(tag, IMPORTANT, id, file, line);
   }
 }
 

--- a/src/core/profiling/stap_probes.d
+++ b/src/core/profiling/stap_probes.d
@@ -1,5 +1,6 @@
 provider _stap {
 	probe add_mark(int tag);
+	probe add_important_mark(int tag);
 	probe timing_ns_begin(int tag);
 	probe timing_ns_end(int tag);
 };

--- a/src/core/profiling/stap_timers.c
+++ b/src/core/profiling/stap_timers.c
@@ -46,6 +46,11 @@ void grpc_timer_add_mark(int tag, void* id, const char* file, int line) {
   _STAP_ADD_MARK(tag);
 }
 
+void grpc_timer_add_important_mark(int tag, void* id, const char* file,
+                                   int line) {
+  _STAP_ADD_IMPORTANT_MARK(tag);
+}
+
 void grpc_timer_begin(int tag, void* id, const char* file, int line) {
   _STAP_TIMING_NS_BEGIN(tag);
 }

--- a/src/core/profiling/timers.h
+++ b/src/core/profiling/timers.h
@@ -42,6 +42,8 @@ void grpc_timers_global_init(void);
 void grpc_timers_global_destroy(void);
 
 void grpc_timer_add_mark(int tag, void *id, const char *file, int line);
+void grpc_timer_add_important_mark(int tag, void *id, const char *file,
+                                   int line);
 void grpc_timer_begin(int tag, void *id, const char *file, int line);
 void grpc_timer_end(int tag, void *id, const char *file, int line);
 
@@ -82,6 +84,10 @@ enum grpc_profiling_tags {
   do {                           \
   } while (0)
 
+#define GRPC_TIMER_IMPORTANT_MARK(tag, id) \
+  do {                           \
+  } while (0)
+
 #define GRPC_TIMER_BEGIN(tag, id) \
   do {                            \
   } while (0)
@@ -100,6 +106,12 @@ enum grpc_profiling_tags {
 #define GRPC_TIMER_MARK(tag, id)                                              \
   if (tag < GRPC_PTAG_IGNORE_THRESHOLD) {                                     \
     grpc_timer_add_mark(tag, ((void *)(gpr_intptr)(id)), __FILE__, __LINE__); \
+  }
+
+#define GRPC_TIMER_IMPORTANT_MARK(tag, id)                                   \
+  if (tag < GRPC_PTAG_IGNORE_THRESHOLD) {                                    \
+    grpc_timer_add_important_mark(tag, ((void *)(gpr_intptr)(id)), __FILE__, \
+                                  __LINE__);                                 \
   }
 
 #define GRPC_TIMER_BEGIN(tag, id)                                          \


### PR DESCRIPTION
It's meant to have a special status in the analysis, whereby latencies
from important marks to all their enclosing BEGIN ({) and END (})
markings will be measured.