### PR TITLE
Implemented aggregation over important mark times.

### DIFF
--- a/tools/profile_analyzer/profile_analyzer.py
+++ b/tools/profile_analyzer/profile_analyzer.py
@@ -90,6 +90,7 @@ def print_grouped_imark_statistics(group_key, imarks_group):
   print '{:>40s}: {:>15s} {:>15s} {:>15s} {:>15s}'.format(
         'Relative mark', '50th p.', '90th p.', '95th p.', '99th p.')
   for key, time_values in values.iteritems():
+    time_values = sorted(time_values)
     print '{:>40s}: {:>15.3f} {:>15.3f} {:>15.3f} {:>15.3f}'.format(
           key, percentile(time_values, 50), percentile(time_values, 90),
           percentile(time_values, 95), percentile(time_values, 99))
@@ -132,10 +133,9 @@ for entry in entries():
         imark.append_post_entry(entry)
 
 def percentile(vals, percent):
-  """ Calculates the interpolated percentile given a (possibly unsorted sequence)
-  and a percent (in the usual 0-100 range)."""
+  """ Calculates the interpolated percentile given a sorted sequence and a
+  percent (in the usual 0-100 range)."""
   assert vals, "Empty input sequence."
-  vals = sorted(vals)
   percent /= 100.0
   k = (len(vals)-1) * percent
   f = math.floor(k)
@@ -149,7 +149,7 @@ def percentile(vals, percent):
 
 print 'tag 50%/90%/95%/99% us'
 for tag in sorted(times.keys()):
-  vals = times[tag]
+  vals = sorted(times[tag])
   print '%d %.2f/%.2f/%.2f/%.2f' % (tag,
                                     percentile(vals, 50),
                                     percentile(vals, 90),


### PR DESCRIPTION
Implemented aggregation over important mark times.
    
Namely, 50,90,95 and 99th percentiles are now reported on important marks.
    
Example output:
   
```
Block marks:
============
Block tag          50th p.      90th p.      95th p.      99th p.
201         :        9.789       12.594       14.277       15.508
205         :        9.964       12.849       14.449       15.817
500         :        9.987       15.150       15.814       16.916


Important marks:
================
222222/7f6e6b7f6700@src/core/iomgr/tcp_posix.c:545
Relative mark                                            50th p.      90th p.      95th p.      99th p.
205 { (src/core/iomgr/tcp_posix.c:541)            :        0.020        0.035        0.039        0.050
205 } (src/core/iomgr/tcp_posix.c:557)            :        9.927       12.259       14.400       14.993
500 { (src/core/surface/call.c:1176)              :        1.373        2.367        2.438        2.563
500 } (src/core/surface/call.c:1276)              :       10.510       13.139       15.061       15.764

222222/7f6e6adf4700@src/core/iomgr/tcp_posix.c:545
Relative mark                                            50th p.      90th p.      95th p.      99th p.
500 { (src/core/surface/call.c:1176)              :        1.428        2.401        2.486        2.650
205 { (src/core/iomgr/tcp_posix.c:541)            :        0.025        0.031        0.036        0.045
205 } (src/core/iomgr/tcp_posix.c:557)            :        9.950       14.060       14.462       16.206
500 } (src/core/surface/call.c:1276)              :       10.565       14.776       15.174       17.177
```