### PR TITLE
Add 'installDist' task to grpc-java Docker build

### DIFF
--- a/tools/dockerfile/grpc_java/Dockerfile
+++ b/tools/dockerfile/grpc_java/Dockerfile
@@ -34,7 +34,7 @@ RUN git clone --recursive --depth 1 https://github.com/grpc/grpc-java.git /var/l
 RUN cd /var/local/git/grpc-java/lib/netty && \
   mvn -pl codec-http2 -am -DskipTests install clean
 RUN cd /var/local/git/grpc-java && \
-  ./gradlew build
+  ./gradlew build installDist
 
 # Specify the default command such that the interop server runs on its known testing port
 CMD ["/var/local/git/grpc-java/run-test-server.sh", "--use_tls=true", "--port=8030"]

--- a/tools/dockerfile/grpc_java/build.sh
+++ b/tools/dockerfile/grpc_java/build.sh
@@ -4,6 +4,6 @@ cp -R /var/local/git-clone /var/local/git
 cd /var/local/git/grpc-java/lib/netty && \
   mvn -pl codec-http2 -am -DskipTests install clean
 cd /var/local/git/grpc-java && \
-  ./gradlew build
+  ./gradlew build installDist
 
 echo 'build finished'


### PR DESCRIPTION
This will allow us to not run Gradle every time we run an integration
test.

@donnadionne 