### PR TITLE
Runner scripts for interop tests on Windows

### DIFF
--- a/tools/gce_setup/grpc_docker.sh
+++ b/tools/gce_setup/grpc_docker.sh
@@ -876,8 +876,8 @@ test_runner() {
     # machine through ssh and we use gcloud auth support to logon to the proxy.
     echo "will run:"
     echo "  $cmd"
-    echo "on jtattermusch-windows-interop2 (through grpc-windows-proxy)"
-    gcloud compute $project_opt ssh $zone_opt stoked-keyword-656@grpc-windows-proxy --command "ssh jtattermusch-interop-windows2 '$cmd'" &
+    echo "on $host (through grpc-windows-proxy)"
+    gcloud compute $project_opt ssh $zone_opt stoked-keyword-656@grpc-windows-proxy --command "ssh $host '$cmd'" &
   fi
   #
   PID=$!


### PR DESCRIPTION
I've setup a windows machine with sshd server running, that allows running interop clients from Windows. This adds support to be able to run the windows clients using grpc_interop_test and grpc_cloud_prod_test (currently failing...).

Example usage:
$ grpc_interop_test empty_unary jtattermusch-interop-windows2 csharp_dotnet grpc-docker-server csharp_mono