### PR TITLE
Change Python development status to "Alpha"

### DIFF
--- a/src/python/README.md
+++ b/src/python/README.md
@@ -7,7 +7,7 @@ The Python facility of gRPC.
 Status
 -------
 
-Usable with limitations, Pre-Alpha
+Usable with limitations, Alpha
 
 Prerequisites
 -----------------------


### PR DESCRIPTION
We actually went alpha in the last release cycle several weeks ago but
missed updating this documentation.