### PR TITLE
Fix C# interop tests

### DIFF
--- a/src/csharp/Grpc.Core/Call.cs
+++ b/src/csharp/Grpc.Core/Call.cs
@@ -52,7 +52,7 @@ namespace Grpc.Core
 
         public Call(string serviceName, Method<TRequest, TResponse> method, Channel channel, Metadata headers)
         {
-            this.name = Preconditions.CheckNotNull(serviceName) + "/" + method.Name;
+            this.name = method.GetFullName(serviceName);
             this.requestMarshaller = method.RequestMarshaller;
             this.responseMarshaller = method.ResponseMarshaller;
             this.channel = Preconditions.CheckNotNull(channel);

--- a/src/csharp/Grpc.Core/Method.cs
+++ b/src/csharp/Grpc.Core/Method.cs
@@ -32,6 +32,7 @@
 #endregion
 
 using System;
+using Grpc.Core.Utils;
 
 namespace Grpc.Core
 {
@@ -94,6 +95,14 @@ namespace Grpc.Core
             {
                 return this.responseMarshaller;
             }
+        }
+
+        /// <summary>
+        /// Gets full name of the method including the service name.
+        /// </summary>
+        internal string GetFullName(string serviceName)
+        {
+            return "/" + Preconditions.CheckNotNull(serviceName) + "/" + this.Name;
         }
     }
 }

--- a/src/csharp/Grpc.Core/ServerServiceDefinition.cs
+++ b/src/csharp/Grpc.Core/ServerServiceDefinition.cs
@@ -79,7 +79,7 @@ namespace Grpc.Core
                     where TRequest : class
                     where TResponse : class
             {
-                callHandlers.Add(GetFullMethodName(serviceName, method.Name), ServerCalls.UnaryCall(method, handler));
+                callHandlers.Add(method.GetFullName(serviceName), ServerCalls.UnaryCall(method, handler));
                 return this;
             }
 
@@ -89,7 +89,7 @@ namespace Grpc.Core
                     where TRequest : class
                     where TResponse : class
             {
-                callHandlers.Add(GetFullMethodName(serviceName, method.Name), ServerCalls.ClientStreamingCall(method, handler));
+                callHandlers.Add(method.GetFullName(serviceName), ServerCalls.ClientStreamingCall(method, handler));
                 return this;
             }
 
@@ -99,7 +99,7 @@ namespace Grpc.Core
                     where TRequest : class
                     where TResponse : class
             {
-                callHandlers.Add(GetFullMethodName(serviceName, method.Name), ServerCalls.ServerStreamingCall(method, handler));
+                callHandlers.Add(method.GetFullName(serviceName), ServerCalls.ServerStreamingCall(method, handler));
                 return this;
             }
 
@@ -109,18 +109,13 @@ namespace Grpc.Core
                     where TRequest : class
                     where TResponse : class
             {
-                callHandlers.Add(GetFullMethodName(serviceName, method.Name), ServerCalls.DuplexStreamingCall(method, handler));
+                callHandlers.Add(method.GetFullName(serviceName), ServerCalls.DuplexStreamingCall(method, handler));
                 return this;
             }
 
             public ServerServiceDefinition Build()
             {
                 return new ServerServiceDefinition(callHandlers.ToImmutableDictionary());
-            }
-
-            private string GetFullMethodName(string serviceName, string methodName)
-            {
-                return serviceName + "/" + methodName;
             }
         }
     }


### PR DESCRIPTION
-- fix: leading slash was missing at the beginning of full method name
-- a bit of refactoring
This should fix the interop tests that are failing.