### PR TITLE
Allowing OSX platforms to be targeted

### DIFF
--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name     = 'gRPC'
   s.version  = '0.0.1'
-  s.summary  = 'Generic gRPC client library for iOS'
+  s.summary  = 'Generic gRPC client library for iOS/OSX'
   s.homepage = 'https://www.grpc.io'
   s.license  = 'New BSD'
   s.authors  = { 'Jorge Canizales' => 'jcanizales@google.com',
@@ -9,8 +9,8 @@ Pod::Spec.new do |s|
 
   # s.source = { :git => 'https://github.com/grpc/grpc.git',  :tag => 'release-0_5_0' }
 
-  s.platform = :ios
   s.ios.deployment_target = '6.0'
+  s.osx.deployment_target = '10.8'
   s.requires_arc = true
 
   s.subspec 'RxLibrary' do |rs|


### PR DESCRIPTION
This is to address https://github.com/grpc/grpc/issues/1299, so brave alpha testers can fully enjoy the gRPC experience. It looks like it's currently broken while the protobuf layer is being introduced, but pod install works fine for OSX targets.
