### PR TITLE
Added the tag enun name to the profiling marks.

### DIFF
--- a/src/core/profiling/stap_timers.c
+++ b/src/core/profiling/stap_timers.c
@@ -42,20 +42,23 @@
 #include "src/core/profiling/stap_probes.h"
 
 /* Latency profiler API implementation. */
-void grpc_timer_add_mark(int tag, void* id, const char* file, int line) {
+void grpc_timer_add_mark(int tag, const char* tagstr, void* id,
+                         const char* file, int line) {
   _STAP_ADD_MARK(tag);
 }
 
-void grpc_timer_add_important_mark(int tag, void* id, const char* file,
-                                   int line) {
+void grpc_timer_add_important_mark(int tag, const char* tagstr, void* id,
+                                   const char* file, int line) {
   _STAP_ADD_IMPORTANT_MARK(tag);
 }
 
-void grpc_timer_begin(int tag, void* id, const char* file, int line) {
+void grpc_timer_begin(int tag, const char* tagstr, void* id, const char* file,
+                      int line) {
   _STAP_TIMING_NS_BEGIN(tag);
 }
 
-void grpc_timer_end(int tag, void* id, const char* file, int line) {
+void grpc_timer_end(int tag, const char* tagstr, void* id, const char* file,
+                    int line) {
   _STAP_TIMING_NS_END(tag);
 }
 

--- a/src/core/profiling/timers.h
+++ b/src/core/profiling/timers.h
@@ -41,11 +41,14 @@ extern "C" {
 void grpc_timers_global_init(void);
 void grpc_timers_global_destroy(void);
 
-void grpc_timer_add_mark(int tag, void *id, const char *file, int line);
-void grpc_timer_add_important_mark(int tag, void *id, const char *file,
-                                   int line);
-void grpc_timer_begin(int tag, void *id, const char *file, int line);
-void grpc_timer_end(int tag, void *id, const char *file, int line);
+void grpc_timer_add_mark(int tag, const char *tagstr, void *id,
+                         const char *file, int line);
+void grpc_timer_add_important_mark(int tag, const char *tagstr, void *id,
+                                   const char *file, int line);
+void grpc_timer_begin(int tag, const char *tagstr, void *id, const char *file,
+                      int line);
+void grpc_timer_end(int tag, const char *tagstr, void *id, const char *file,
+                    int line);
 
 enum grpc_profiling_tags {
   /* Any GRPC_PTAG_* >= than the threshold won't generate any profiling mark. */
@@ -103,25 +106,27 @@ enum grpc_profiling_tags {
 #endif
 
 /* Generic profiling interface. */
-#define GRPC_TIMER_MARK(tag, id)                                              \
-  if (tag < GRPC_PTAG_IGNORE_THRESHOLD) {                                     \
-    grpc_timer_add_mark(tag, ((void *)(gpr_intptr)(id)), __FILE__, __LINE__); \
-  }
-
-#define GRPC_TIMER_IMPORTANT_MARK(tag, id)                                   \
-  if (tag < GRPC_PTAG_IGNORE_THRESHOLD) {                                    \
-    grpc_timer_add_important_mark(tag, ((void *)(gpr_intptr)(id)), __FILE__, \
-                                  __LINE__);                                 \
-  }
-
-#define GRPC_TIMER_BEGIN(tag, id)                                          \
-  if (tag < GRPC_PTAG_IGNORE_THRESHOLD) {                                  \
-    grpc_timer_begin(tag, ((void *)(gpr_intptr)(id)), __FILE__, __LINE__); \
-  }
-
-#define GRPC_TIMER_END(tag, id)                                          \
+#define GRPC_TIMER_MARK(tag, id)                                         \
   if (tag < GRPC_PTAG_IGNORE_THRESHOLD) {                                \
-    grpc_timer_end(tag, ((void *)(gpr_intptr)(id)), __FILE__, __LINE__); \
+    grpc_timer_add_mark(tag, #tag, ((void *)(gpr_intptr)(id)), __FILE__, \
+                        __LINE__);                                       \
+  }
+
+#define GRPC_TIMER_IMPORTANT_MARK(tag, id)                               \
+  if (tag < GRPC_PTAG_IGNORE_THRESHOLD) {                                \
+    grpc_timer_add_important_mark(tag, #tag, ((void *)(gpr_intptr)(id)), \
+                                  __FILE__, __LINE__);                   \
+  }
+
+#define GRPC_TIMER_BEGIN(tag, id)                                     \
+  if (tag < GRPC_PTAG_IGNORE_THRESHOLD) {                             \
+    grpc_timer_begin(tag, #tag, ((void *)(gpr_intptr)(id)), __FILE__, \
+                     __LINE__);                                       \
+  }
+
+#define GRPC_TIMER_END(tag, id)                                                \
+  if (tag < GRPC_PTAG_IGNORE_THRESHOLD) {                                      \
+    grpc_timer_end(tag, #tag, ((void *)(gpr_intptr)(id)), __FILE__, __LINE__); \
   }
 
 #ifdef GRPC_STAP_PROFILER


### PR DESCRIPTION
For example, whereas previously we'd have

GRPC_LAT_PROF 1986206380734.095703 0x7f0b4bff7700 { 200 (nil) src/core/iomgr/tcp_posix.c 337

now we have:

GRPC_LAT_PROF 1986206380734.095703 0x7f0b4bff7700 { 200(GRPC_PTAG_HANDLE_READ) (nil) src/core/iomgr/tcp_posix.c 337

Note the literal enum name in parenthesis following the tag int value.