### PR TITLE
Tentative fix for "error: can't start new thread" in Python tests

### DIFF
--- a/src/python/src/grpc/framework/face/_test_case.py
+++ b/src/python/src/grpc/framework/face/_test_case.py
@@ -35,7 +35,7 @@ from grpc.framework.face.testing import test_case
 from grpc.framework.foundation import logging_pool
 
 _TIMEOUT = 3
-_MAXIMUM_POOL_SIZE = 100
+_MAXIMUM_POOL_SIZE = 10
 
 
 class FaceTestCase(test_case.FaceTestCase):


### PR DESCRIPTION
Fixes #1037 (tentatively)

Is a PR to run on Travis. I'll be restarting the Python test jobs several times over the next day or two and keeping track of what happens.

Related to #1192; if this works and is merged, both PRs will be closed.