### PR TITLE
To allow local private changes to be build into private

### DIFF
--- a/tools/dockerfile/grpc_node/build.sh
+++ b/tools/dockerfile/grpc_node/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+cp -R /var/local/git-clone/grpc /var/local/git
+
+make clean -C /var/local/git/grpc
+
+make install_c -j12 -C /var/local/git/grpc
+
+cd /var/local/git/grpc/src/node && npm install && node-gyp rebuild

--- a/tools/dockerfile/grpc_ruby/build.sh
+++ b/tools/dockerfile/grpc_ruby/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+cp -R /var/local/git-clone/grpc /var/local/git
+
+make clean -C /var/local/git/grpc
+
+make install_c -j12 -C /var/local/git/grpc
+
+/bin/bash -l -c 'cd /var/local/git/grpc/src/ruby && gem update bundler && bundle && rake'


### PR DESCRIPTION
docker images to do interop testing before submitting code
c++ and java are done previously, adding ruby and node.
see script tools/gce_setup/private_build_and_test.sh