### PR TITLE
Updates Objective-C proto plugin

### DIFF
--- a/src/compiler/generator_helpers.h
+++ b/src/compiler/generator_helpers.h
@@ -103,6 +103,14 @@ inline grpc::string CapitalizeFirstLetter(grpc::string s) {
   return s;
 }
 
+inline grpc::string LowercaseFirstLetter(grpc::string s) {
+  if (s.empty()) {
+    return s;
+  }
+  s[0] = ::tolower(s[0]);
+  return s;
+}
+
 inline grpc::string LowerUnderscoreToUpperCamel(grpc::string str) {
   std::vector<grpc::string> tokens = tokenize(str, "_");
   grpc::string result = "";

--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -118,9 +118,9 @@ void PrintSimpleImplementation(Printer *printer,
                                const MethodDescriptor *method,
                                map<string, string> vars) {
   printer->Print("{\n");
-  printer->Print(vars, "[[self RPCTo$method_name$With");
+  printer->Print(vars, "  [[self RPCTo$method_name$With");
   if (method->client_streaming()) {
-    printer->Print("RequestsWriter:requestsWriter"); //TODO(jcanizales):request?
+    printer->Print("RequestsWriter:request");
   } else {
     printer->Print("Request:request");
   }
@@ -136,12 +136,13 @@ void PrintAdvancedImplementation(Printer *printer,
 
   printer->Print("            requestsWriter:");
   if (method->client_streaming()) {
-    printer->Print("requestsWriter\n");
+    printer->Print("request\n");
   } else {
     printer->Print("[GRXWriter writerWithValue:request]\n");
   }
 
-  printer->Print(vars, "             responseClass:[$response_type$ class]\n");
+  printer->Print(vars,
+      "             responseClass:[$prefix$$response_type$ class]\n");
 
   printer->Print("        responsesWriteable:[GRXWriteable ");
   if (method->server_streaming()) {

--- a/src/compiler/objective_c_generator.h
+++ b/src/compiler/objective_c_generator.h
@@ -39,9 +39,10 @@
 namespace grpc_objective_c_generator {
 
 grpc::string GetHeader(const grpc::protobuf::ServiceDescriptor *service,
-                       const grpc::string message_header);
+                       const grpc::string prefix);
 
-grpc::string GetSource(const grpc::protobuf::ServiceDescriptor *service);
+grpc::string GetSource(const grpc::protobuf::ServiceDescriptor *service,
+                       const grpc::string prefix);
 
 }  // namespace grpc_objective_c_generator
 

--- a/src/compiler/objective_c_generator.h
+++ b/src/compiler/objective_c_generator.h
@@ -38,9 +38,13 @@
 
 namespace grpc_objective_c_generator {
 
+// Returns the content to be included in the "global_scope" insertion point of
+// the generated header file.
 grpc::string GetHeader(const grpc::protobuf::ServiceDescriptor *service,
                        const grpc::string prefix);
 
+// Returns the content to be included in the "global_scope" insertion point of
+// the generated implementation file.
 grpc::string GetSource(const grpc::protobuf::ServiceDescriptor *service,
                        const grpc::string prefix);
 

--- a/src/compiler/objective_c_generator_helpers.h
+++ b/src/compiler/objective_c_generator_helpers.h
@@ -40,18 +40,8 @@
 
 namespace grpc_objective_c_generator {
 
-const grpc::string prefix = "PBG";
-
 inline grpc::string MessageHeaderName(const grpc::protobuf::FileDescriptor *file) {
-  return grpc_generator::FileNameInUpperCamel(file) + ".pb.h";
-}
-
-inline grpc::string StubFileName(grpc::string service_name) {
-  return prefix + service_name + "Stub";
-}
-
-inline grpc::string PrefixedName(grpc::string name) {
-  return prefix + name;
+  return grpc_generator::FileNameInUpperCamel(file) + ".pbobjc.h";
 }
 
 }

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -62,20 +62,20 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
 
       // Generate .pb.h
 
-      Insert(context, file_name + ".pb.h", "imports",
+      Insert(context, file_name + ".pbobjc.h", "imports",
           "#import <gRPC/ProtoService.h>\n");
 
-      Insert(context, file_name + ".pb.h", "global_scope",
+      Insert(context, file_name + ".pbobjc.h", "global_scope",
           grpc_objective_c_generator::GetHeader(service, prefix));
 
       // Generate .pb.m
 
-      Insert(context, file_name + ".pb.m", "imports",
+      Insert(context, file_name + ".pbobjc.m", "imports",
           "#import <gRPC/GRXWriteable.h>\n"
           "#import <gRPC/GRXWriter+Immediate.h>\n"
           "#import <gRPC/ProtoRPC.h>\n");
 
-      Insert(context, file_name + ".pb.m", "global_scope",
+      Insert(context, file_name + ".pbobjc.m", "global_scope",
           grpc_objective_c_generator::GetSource(service, prefix));
     }
 

--- a/src/objective-c/examples/Sample/RemoteTestClient/Test.pb.m
+++ b/src/objective-c/examples/Sample/RemoteTestClient/Test.pb.m
@@ -44,7 +44,6 @@ static NSString *const kServiceName = @"TestService";
   return [self initWithHost:host];
 }
 
-
 #pragma mark EmptyCall(grpc.testing.Empty) returns (grpc.testing.Empty)
 
 // One empty request followed by one empty response.

--- a/src/objective-c/examples/Sample/RemoteTestClient/Test.pb.m
+++ b/src/objective-c/examples/Sample/RemoteTestClient/Test.pb.m
@@ -44,6 +44,7 @@ static NSString *const kServiceName = @"TestService";
   return [self initWithHost:host];
 }
 
+
 #pragma mark EmptyCall(grpc.testing.Empty) returns (grpc.testing.Empty)
 
 // One empty request followed by one empty response.


### PR DESCRIPTION
It now generates a surface according to the last design (except for some nits), an implementation compatible with our current version of the proto-gRPC runtime, and uses proto3.

Known missing things:
- The input and output messages for rpc methods are referred-to using the prefix of the rpc service. Because one such message can be defined in another file, we have to use the prefix specified in that file instead.
- We're not propagating the comments from the .proto file.
- We can't yet generate code for services defined in a 2.6 file, nor for rpc methods whose input or output types are defined in a 2.6 file.
- We're naming "handler" the block parameter for both single-response methods and stream-response methods. In the surface design we agreed to call the latter "eventHandler".