### PR TITLE
Objective c interop tests

### DIFF
--- a/src/objective-c/examples/Sample/SampleTests/RemoteProtoTests.m
+++ b/src/objective-c/examples/Sample/SampleTests/RemoteProtoTests.m
@@ -167,10 +167,10 @@
 
 - (void)testEmptyStreamRPC {
   __weak XCTestExpectation *expectation = [self expectationWithDescription:@"EmptyStream"];
-  [_service fullDuplexCallWithRequestsWriter:[GRXWriter writerWithContainer:@[]]
+  [_service fullDuplexCallWithRequestsWriter:[GRXWriter emptyWriter]
                                      handler:^(bool done, RMTStreamingOutputCallResponse *response, NSError *error) {
                                        XCTAssertNil(error, @"Finished with unexpected error: %@", error);
-                                       XCTAssert(done, @"Unexpected response");
+                                       XCTAssert(done, @"Unexpected response: %@", response);
                                        [expectation fulfill];
                                      }];
   [self waitForExpectationsWithTimeout:4 handler:nil];
@@ -178,14 +178,15 @@
 
 - (void)testCancelAfterBeginRPC {
   __weak XCTestExpectation *expectation = [self expectationWithDescription:@"CancelAfterBegin"];
-  ProtoRPC *call = [_service RPCToStreamingInputCallWithRequestsWriter:[GRXWriter writerWithContainer:@[]]
+  // TODO(mlumish): change to writing that blocks instead of writing
+  ProtoRPC *call = [_service RPCToStreamingInputCallWithRequestsWriter:[GRXWriter emptyWriter]
                                                                handler:^(RMTStreamingInputCallResponse *response, NSError *error) {
                                                                  XCTAssertEqual([error code], GRPC_STATUS_CANCELLED);
                                                                  [expectation fulfill];
                                                                }];
   [call start];
   [call cancel];
-  [self waitForExpectationsWithTimeout:4 handler:nil];
+  [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 @end

--- a/src/objective-c/examples/Sample/SampleTests/RemoteProtoTests.m
+++ b/src/objective-c/examples/Sample/SampleTests/RemoteProtoTests.m
@@ -31,9 +31,12 @@
  *
  */
 
+#include <grpc/status.h>
+
 #import <UIKit/UIKit.h>
 #import <XCTest/XCTest.h>
 
+#import <gRPC/ProtoRPC.h>
 #import <gRPC/GRXWriter+Immediate.h>
 #import <RemoteTest/Messages.pb.h>
 #import <RemoteTest/Test.pb.h>
@@ -177,11 +180,12 @@
   __weak XCTestExpectation *expectation = [self expectationWithDescription:@"CancelAfterBegin"];
   ProtoRPC *call = [_service RPCToStreamingInputCallWithRequestsWriter:[GRXWriter writerWithContainer:@[]]
                                                                handler:^(RMTStreamingInputCallResponse *response, NSError *error) {
-                                                                 // TODO(mlumish): check for actual CANCELLED error code
-                                                                 XCTAssertEqualObjects(error, nil);
+                                                                 XCTAssertEqual([error code], GRPC_STATUS_CANCELLED);
+                                                                 [expectation fulfill];
                                                                }];
   [call start];
   [call cancel];
+  [self waitForExpectationsWithTimeout:4 handler:nil];
 }
 
 @end


### PR DESCRIPTION
Add server_streaming, empty_stream, and cancel_after_begin interop tests. The remaining unimplemented tests depend on `GRXBufferedPipe`. When that is available, `testCancelAfterBeginRPC` should also be rewritten to use it.