### PR TITLE
Rename GRXWriteable methods

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -231,7 +231,7 @@
                                             handler:resumingHandler]] errorHandler:errorHandler];
 }
 
-- (void)didReceiveValue:(id)value {
+- (void)writeValue:(id)value {
   // TODO(jcanizales): Throw/assert if value isn't NSData.
 
   // Pause the input and only resume it when the C layer notifies us that writes

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -255,7 +255,7 @@
                             errorHandler:errorHandler];
 }
 
-- (void)didFinishWithError:(NSError *)errorOrNil {
+- (void)writesFinishedWithError:(NSError *)errorOrNil {
   if (errorOrNil) {
     [self cancel];
   } else {
@@ -306,7 +306,7 @@
 
 - (void)startWithWriteable:(id<GRXWriteable>)writeable {
   // The following produces a retain cycle self:_responseWriteable:self, which is only
-  // broken when didFinishWithError: is sent to the wrapped writeable.
+  // broken when writesFinishedWithError: is sent to the wrapped writeable.
   // Care is taken not to retain self strongly in any of the blocks used in
   // the implementation of GRPCCall, so that the life of the instance is
   // determined by this retain cycle.

--- a/src/objective-c/GRPCClient/private/GRPCDelegateWrapper.h
+++ b/src/objective-c/GRPCClient/private/GRPCDelegateWrapper.h
@@ -57,9 +57,8 @@
 - (instancetype)initWithWriteable:(id<GRXWriteable>)writeable writer:(id<GRXWriter>)writer
     NS_DESIGNATED_INITIALIZER;
 
-// Enqueues didReceiveValue: to be sent to the writeable in the main thread.
-// The passed handler is invoked from the main thread after didReceiveValue:
-// returns.
+// Enqueues writeValue: to be sent to the writeable in the main thread.
+// The passed handler is invoked from the main thread after writeValue: returns.
 - (void)enqueueMessage:(NSData *)message completionHandler:(void (^)())handler;
 
 // Enqueues didFinishWithError:nil to be sent to the writeable in the main

--- a/src/objective-c/GRPCClient/private/GRPCDelegateWrapper.h
+++ b/src/objective-c/GRPCClient/private/GRPCDelegateWrapper.h
@@ -38,11 +38,11 @@
 
 // This is a thread-safe wrapper over a GRXWriteable instance. It lets one
 // enqueue calls to a GRXWriteable instance for the main thread, guaranteeing
-// that didFinishWithError: is the last message sent to it (no matter what
+// that writesFinishedWithError: is the last message sent to it (no matter what
 // messages are sent to the wrapper, in what order, nor from which thread). It
 // also guarantees that, if cancelWithError: is called from the main thread
 // (e.g. by the app cancelling the writes), no further messages are sent to the
-// writeable except didFinishWithError:.
+// writeable except writesFinishedWithError:.
 //
 // TODO(jcanizales): Let the user specify another queue for the writeable
 // callbacks.
@@ -51,7 +51,7 @@
 
 // The GRXWriteable passed is the wrapped writeable.
 // Both the GRXWriter instance and the GRXWriteable instance are retained until
-// didFinishWithError: is sent to the writeable, and released after that.
+// writesFinishedWithError: is sent to the writeable, and released after that.
 // This is used to create a retain cycle that keeps both objects alive until the
 // writing is explicitly finished.
 - (instancetype)initWithWriteable:(id<GRXWriteable>)writeable writer:(id<GRXWriter>)writer
@@ -61,12 +61,12 @@
 // The passed handler is invoked from the main thread after writeValue: returns.
 - (void)enqueueMessage:(NSData *)message completionHandler:(void (^)())handler;
 
-// Enqueues didFinishWithError:nil to be sent to the writeable in the main
+// Enqueues writesFinishedWithError:nil to be sent to the writeable in the main
 // thread. After that message is sent to the writeable, all other methods of
 // this object are effectively noops.
 - (void)enqueueSuccessfulCompletion;
 
-// If the writeable has not yet received a didFinishWithError: message, this
+// If the writeable has not yet received a writesFinishedWithError: message, this
 // will enqueue one to be sent to it in the main thread, and cancel all other
 // pending messages to the writeable enqueued by this object (both past and
 // future).
@@ -74,7 +74,7 @@
 - (void)cancelWithError:(NSError *)error;
 
 // Cancels all pending messages to the writeable enqueued by this object (both
-// past and future). Because the writeable won't receive didFinishWithError:,
+// past and future). Because the writeable won't receive writesFinishedWithError:,
 // this also releases the writeable and the writer.
 - (void)cancelSilently;
 @end

--- a/src/objective-c/GRPCClient/private/GRPCDelegateWrapper.m
+++ b/src/objective-c/GRPCClient/private/GRPCDelegateWrapper.m
@@ -69,7 +69,7 @@
     // the race.
     id<GRXWriteable> writeable = self.writeable;
     if (writeable) {
-      [writeable didReceiveValue:message];
+      [writeable writeValue:message];
       handler();
     }
   });

--- a/src/objective-c/GRPCClient/private/GRPCDelegateWrapper.m
+++ b/src/objective-c/GRPCClient/private/GRPCDelegateWrapper.m
@@ -43,7 +43,7 @@
 
 @implementation GRPCDelegateWrapper {
   dispatch_queue_t _writeableQueue;
-  // This ensures that didFinishWithError: is only sent once to the writeable.
+  // This ensures that writesFinishedWithError: is only sent once to the writeable.
   dispatch_once_t _alreadyFinished;
 }
 
@@ -80,7 +80,7 @@
     dispatch_once(&_alreadyFinished, ^{
       // Cancellation is now impossible. None of the other three blocks can run
       // concurrently with this one.
-      [self.writeable didFinishWithError:nil];
+      [self.writeable writesFinishedWithError:nil];
       // Break the retain cycle with writer, and skip any possible message to the
       // wrapped writeable enqueued after this one.
       self.writeable = nil;
@@ -100,7 +100,7 @@
     self.writeable = nil;
 
     dispatch_async(_writeableQueue, ^{
-      [writeable didFinishWithError:error];
+      [writeable writesFinishedWithError:error];
       // Break the retain cycle with writer.
       self.writer = nil;
     });

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -73,7 +73,7 @@
     _responseWriteable = [[GRXWriteable alloc] initWithValueHandler:^(NSData *value) {
       [responsesWriteable writeValue:[responseClass parseFromData:value]];
     } completionHandler:^(NSError *errorOrNil) {
-      [responsesWriteable didFinishWithError:errorOrNil];
+      [responsesWriteable writesFinishedWithError:errorOrNil];
     }];
   }
   return self;

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -71,7 +71,7 @@
   if ((self = [super initWithHost:host method:method requestsWriter:bytesWriter])) {
     // A writeable that parses the proto messages received.
     _responseWriteable = [[GRXWriteable alloc] initWithValueHandler:^(NSData *value) {
-      [responsesWriteable didReceiveValue:[responseClass parseFromData:value]];
+      [responsesWriteable writeValue:[responseClass parseFromData:value]];
     } completionHandler:^(NSError *errorOrNil) {
       [responsesWriteable didFinishWithError:errorOrNil];
     }];

--- a/src/objective-c/RxLibrary/GRXBufferedPipe.h
+++ b/src/objective-c/RxLibrary/GRXBufferedPipe.h
@@ -38,8 +38,8 @@
 
 // A buffered pipe is a Writeable that also acts as a Writer (to whichever other writeable is passed
 // to -startWithWriteable:).
-// Once it is started, whatever values are written into it (via -didReceiveValue:) will be
-// propagated immediately, unless flow control prevents it.
+// Once it is started, whatever values are written into it (via -writeValue:) will be propagated
+// immediately, unless flow control prevents it.
 // If it is throttled and keeps receiving values, as well as if it receives values before being
 // started, it will buffer them and propagate them in order as soon as its state becomes
 // GRXWriterStateStarted.

--- a/src/objective-c/RxLibrary/GRXBufferedPipe.h
+++ b/src/objective-c/RxLibrary/GRXBufferedPipe.h
@@ -43,7 +43,7 @@
 // If it is throttled and keeps receiving values, as well as if it receives values before being
 // started, it will buffer them and propagate them in order as soon as its state becomes
 // GRXWriterStateStarted.
-// If it receives an error (via -didFinishWithError:), it will drop any buffered values and
+// If it receives an error (via -writesFinishedWithError:), it will drop any buffered values and
 // propagate the error immediately.
 @interface GRXBufferedPipe : NSObject<GRXWriteable, GRXWriter>
 

--- a/src/objective-c/RxLibrary/GRXBufferedPipe.m
+++ b/src/objective-c/RxLibrary/GRXBufferedPipe.m
@@ -62,7 +62,7 @@
 
 - (void)writeBufferUntilPausedOrStopped {
   while (_state == GRXWriterStateStarted && _queue.count > 0) {
-    [_writeable didReceiveValue:[self popValue]];
+    [_writeable writeValue:[self popValue]];
   }
   if (_inputIsFinished && _queue.count == 0) {
     // Our writer finished normally while we were paused or not-started-yet.
@@ -77,10 +77,10 @@
   return _state == GRXWriterStateStarted && _queue.count == 0;
 }
 
-- (void)didReceiveValue:(id)value {
+- (void)writeValue:(id)value {
   if (self.shouldFastForward) {
     // Skip the queue.
-    [_writeable didReceiveValue:value];
+    [_writeable writeValue:value];
   } else {
     // Even if we're paused and with enqueued values, we can't excert back-pressure to our writer.
     // So just buffer the new value.

--- a/src/objective-c/RxLibrary/GRXBufferedPipe.m
+++ b/src/objective-c/RxLibrary/GRXBufferedPipe.m
@@ -88,7 +88,7 @@
   }
 }
 
-- (void)didFinishWithError:(NSError *)errorOrNil {
+- (void)writesFinishedWithError:(NSError *)errorOrNil {
   _inputIsFinished = YES;
   _errorOrNil = errorOrNil;
   if (errorOrNil || self.shouldFastForward) {
@@ -136,7 +136,7 @@
 - (void)finishWithError:(NSError *)errorOrNil {
   id<GRXWriteable> writeable = _writeable;
   self.state = GRXWriterStateFinished;
-  [writeable didFinishWithError:errorOrNil];
+  [writeable writesFinishedWithError:errorOrNil];
 }
 
 @end

--- a/src/objective-c/RxLibrary/GRXImmediateWriter.m
+++ b/src/objective-c/RxLibrary/GRXImmediateWriter.m
@@ -109,7 +109,7 @@
 - (void)writeUntilPausedOrStopped {
   id value;
   while (value = [_enumerator nextObject]) {
-    [_writeable didReceiveValue:value];
+    [_writeable writeValue:value];
     // If the writeable has a reference to us, it might change our state to paused or finished.
     if (_state == GRXWriterStatePaused || _state == GRXWriterStateFinished) {
       return;

--- a/src/objective-c/RxLibrary/GRXImmediateWriter.m
+++ b/src/objective-c/RxLibrary/GRXImmediateWriter.m
@@ -130,7 +130,7 @@
   _errorOrNil = nil;
   id<GRXWriteable> writeable = _writeable;
   _writeable = nil;
-  [writeable didFinishWithError:errorOrNil];
+  [writeable writesFinishedWithError:errorOrNil];
 }
 
 - (void)setState:(GRXWriterState)newState {

--- a/src/objective-c/RxLibrary/GRXWriteable.h
+++ b/src/objective-c/RxLibrary/GRXWriteable.h
@@ -38,11 +38,10 @@
 @protocol GRXWriteable <NSObject>
 
 // Push the next value of the sequence to the receiving object.
-// TODO(jcanizales): Name it enumerator:(id<GRXEnumerator>) didProduceValue:(id)?
-- (void)didReceiveValue:(id)value;
+- (void)writeValue:(id)value;
 
 // Signal that the sequence is completed, or that an error ocurred. After this
-// message is sent to the instance, neither it nor didReceiveValue: may be
+// message is sent to the instance, neither it nor writeValue: may be
 // called again.
 // TODO(jcanizales): enumerator:(id<GRXEnumerator>) didFinishWithError:(NSError*)?
 - (void)didFinishWithError:(NSError *)errorOrNil;

--- a/src/objective-c/RxLibrary/GRXWriteable.h
+++ b/src/objective-c/RxLibrary/GRXWriteable.h
@@ -43,8 +43,7 @@
 // Signal that the sequence is completed, or that an error ocurred. After this
 // message is sent to the instance, neither it nor writeValue: may be
 // called again.
-// TODO(jcanizales): enumerator:(id<GRXEnumerator>) didFinishWithError:(NSError*)?
-- (void)didFinishWithError:(NSError *)errorOrNil;
+- (void)writesFinishedWithError:(NSError *)errorOrNil;
 @end
 
 typedef void (^GRXValueHandler)(id value);

--- a/src/objective-c/RxLibrary/GRXWriteable.m
+++ b/src/objective-c/RxLibrary/GRXWriteable.m
@@ -76,7 +76,7 @@
   return self;
 }
 
-- (void)didReceiveValue:(id)value {
+- (void)writeValue:(id)value {
   if (_valueHandler) {
     _valueHandler(value);
   }

--- a/src/objective-c/RxLibrary/GRXWriteable.m
+++ b/src/objective-c/RxLibrary/GRXWriteable.m
@@ -82,7 +82,7 @@
   }
 }
 
-- (void)didFinishWithError:(NSError *)errorOrNil {
+- (void)writesFinishedWithError:(NSError *)errorOrNil {
   if (_completionHandler) {
     _completionHandler(errorOrNil);
   }

--- a/src/objective-c/RxLibrary/GRXWriter.h
+++ b/src/objective-c/RxLibrary/GRXWriter.h
@@ -50,7 +50,7 @@ typedef NS_ENUM(NSInteger, GRXWriterState) {
   // The writer is temporarily paused, and won't send any more values to the
   // writeable unless its state is set back to Started. The writer might still
   // transition to the Finished state at any moment, and is allowed to send
-  // didFinishWithError: to its writeable.
+  // writesFinishedWithError: to its writeable.
   //
   // Not all implementations of writer have to support pausing, and thus
   // trying to set an writer's state to this value might have no effect.
@@ -59,7 +59,7 @@ typedef NS_ENUM(NSInteger, GRXWriterState) {
   // The writer has released its writeable and won't interact with it anymore.
   //
   // One seldomly wants to set an writer's state to this value, as its
-  // writeable isn't notified with a didFinishWithError: message. Instead, sending
+  // writeable isn't notified with a writesFinishedWithError: message. Instead, sending
   // finishWithError: to the writer will make it notify the writeable and then
   // transition to this state.
   GRXWriterStateFinished
@@ -105,7 +105,7 @@ typedef NS_ENUM(NSInteger, GRXWriterState) {
 // This method might only be called on writers in the NotStarted state.
 - (void)startWithWriteable:(id<GRXWriteable>)writeable;
 
-// Send didFinishWithError:errorOrNil immediately to the writeable, and don't send
+// Send writesFinishedWithError:errorOrNil immediately to the writeable, and don't send
 // any more messages to it.
 //
 // This method might only be called on writers in the Started or Paused

--- a/src/objective-c/RxLibrary/GRXWriter.m
+++ b/src/objective-c/RxLibrary/GRXWriter.m
@@ -62,7 +62,7 @@
 - (void)finishOutputWithError:(NSError *)errorOrNil {
   id<GRXWriteable> writeable = _writeable;
   _writeable = nil;
-  [writeable didFinishWithError:errorOrNil];
+  [writeable writesFinishedWithError:errorOrNil];
 }
 
 // This is used to stop the input writer. It nillifies our reference to it
@@ -79,7 +79,7 @@
   [_writeable writeValue:value];
 }
 
-- (void)didFinishWithError:(NSError *)errorOrNil {
+- (void)writesFinishedWithError:(NSError *)errorOrNil {
   _writer = nil;
   [self finishOutputWithError:errorOrNil];
 }

--- a/src/objective-c/RxLibrary/GRXWriter.m
+++ b/src/objective-c/RxLibrary/GRXWriter.m
@@ -75,8 +75,8 @@
 
 #pragma mark GRXWriteable implementation
 
-- (void)didReceiveValue:(id)value {
-  [_writeable didReceiveValue:value];
+- (void)writeValue:(id)value {
+  [_writeable writeValue:value];
 }
 
 - (void)didFinishWithError:(NSError *)errorOrNil {

--- a/src/objective-c/RxLibrary/transformations/GRXMappingWriter.m
+++ b/src/objective-c/RxLibrary/transformations/GRXMappingWriter.m
@@ -57,7 +57,7 @@ static id (^kIdentity)(id value) = ^id(id value) {
 }
 
 // Override
-- (void)didReceiveValue:(id)value {
-  [super didReceiveValue:_map(value)];
+- (void)writeValue:(id)value {
+  [super writeValue:_map(value)];
 }
 @end

--- a/src/objective-c/examples/Sample/SampleTests/RemoteProtoTests.m
+++ b/src/objective-c/examples/Sample/SampleTests/RemoteProtoTests.m
@@ -227,7 +227,7 @@
                                                      requestedResponseSize:responses[index]];
         [requestsBuffer writeValue:request];
       } else {
-        [requestsBuffer didFinishWithError:nil];
+        [requestsBuffer writesFinishedWithError:nil];
       }
     }
                                        

--- a/src/objective-c/examples/Sample/SampleTests/RemoteProtoTests.m
+++ b/src/objective-c/examples/Sample/SampleTests/RemoteProtoTests.m
@@ -208,7 +208,7 @@
 
   id request = [RMTStreamingOutputCallRequest messageWithPayloadSize:requests[index]
                                                requestedResponseSize:responses[index]];
-  [requestsBuffer didReceiveValue:request];
+  [requestsBuffer writeValue:request];
 
   [_service fullDuplexCallWithRequestsWriter:requestsBuffer
                                      handler:^(BOOL done,
@@ -225,7 +225,7 @@
       if (index < 4) {
         id request = [RMTStreamingOutputCallRequest messageWithPayloadSize:requests[index]
                                                      requestedResponseSize:responses[index]];
-        [requestsBuffer didReceiveValue:request];
+        [requestsBuffer writeValue:request];
       } else {
         [requestsBuffer didFinishWithError:nil];
       }


### PR DESCRIPTION
Small change I wanted to get out before splitting the sample app from the tests (as I fear XCode refactoring will involve running the same command in various projects after the split).

I think it clarifies things when reading implementations of GRXWriteable or GRXWriter: a writer calls "write", hence its name; and a writeable defines what happens when "write:value" is invoked (implements "write"). LGTY?