### PR TITLE
Encapsulate logger within GRPC module

### DIFF
--- a/src/ruby/bin/apis/pubsub_demo.rb
+++ b/src/ruby/bin/apis/pubsub_demo.rb
@@ -79,7 +79,7 @@ end
 def publisher_stub(opts)
   address = "#{opts.host}:#{opts.port}"
   stub_clz = Tech::Pubsub::PublisherService::Stub # shorter
-  logger.info("... access PublisherService at #{address}")
+  GRPC.logger.info("... access PublisherService at #{address}")
   stub_clz.new(address,
                creds: ssl_creds, update_metadata: auth_proc(opts),
                GRPC::Core::Channel::SSL_TARGET => opts.host)
@@ -89,7 +89,7 @@ end
 def subscriber_stub(opts)
   address = "#{opts.host}:#{opts.port}"
   stub_clz = Tech::Pubsub::SubscriberService::Stub # shorter
-  logger.info("... access SubscriberService at #{address}")
+  GRPC.logger.info("... access SubscriberService at #{address}")
   stub_clz.new(address,
                creds: ssl_creds, update_metadata: auth_proc(opts),
                GRPC::Core::Channel::SSL_TARGET => opts.host)

--- a/src/ruby/bin/interop/interop_client.rb
+++ b/src/ruby/bin/interop/interop_client.rb
@@ -70,7 +70,7 @@ end
 # loads the certificates used to access the test server securely.
 def load_prod_cert
   fail 'could not find a production cert' if ENV['SSL_CERT_FILE'].nil?
-  logger.info("loading prod certs from #{ENV['SSL_CERT_FILE']}")
+  GRPC.logger.info("loading prod certs from #{ENV['SSL_CERT_FILE']}")
   File.open(ENV['SSL_CERT_FILE']).read
 end
 
@@ -115,10 +115,10 @@ def create_stub(opts)
       stub_opts[:update_metadata] = auth_creds.updater_proc
     end
 
-    logger.info("... connecting securely to #{address}")
+    GRPC.logger.info("... connecting securely to #{address}")
     Grpc::Testing::TestService::Stub.new(address, **stub_opts)
   else
-    logger.info("... connecting insecurely to #{address}")
+    GRPC.logger.info("... connecting insecurely to #{address}")
     Grpc::Testing::TestService::Stub.new(address)
   end
 end

--- a/src/ruby/bin/interop/interop_server.rb
+++ b/src/ruby/bin/interop/interop_server.rb
@@ -129,13 +129,13 @@ class TestTarget < Grpc::Testing::TestService::Service
     Thread.new do
       begin
         reqs.each do |req|
-          logger.info("read #{req.inspect}")
+          GRPC.logger.info("read #{req.inspect}")
           resp_size = req.response_parameters[0].size
           resp = cls.new(payload: Payload.new(type: req.response_type,
                                               body: nulls(resp_size)))
           q.push(resp)
         end
-        logger.info('finished reads')
+        GRPC.logger.info('finished reads')
         q.push(self)
       rescue StandardError => e
         q.push(e)  # share the exception with the enumerator
@@ -179,10 +179,10 @@ def main
   s = GRPC::RpcServer.new
   if opts['secure']
     s.add_http2_port(host, test_server_creds)
-    logger.info("... running securely on #{host}")
+    GRPC.logger.info("... running securely on #{host}")
   else
     s.add_http2_port(host)
-    logger.info("... running insecurely on #{host}")
+    GRPC.logger.info("... running insecurely on #{host}")
   end
   s.handle(TestTarget)
   s.run_till_terminated

--- a/src/ruby/bin/math_client.rb
+++ b/src/ruby/bin/math_client.rb
@@ -46,51 +46,51 @@ require 'optparse'
 include GRPC::Core::TimeConsts
 
 def do_div(stub)
-  logger.info('request_response')
-  logger.info('----------------')
+  GRPC.logger.info('request_response')
+  GRPC.logger.info('----------------')
   req = Math::DivArgs.new(dividend: 7, divisor: 3)
-  logger.info("div(7/3): req=#{req.inspect}")
+  GRPC.logger.info("div(7/3): req=#{req.inspect}")
   resp = stub.div(req, INFINITE_FUTURE)
-  logger.info("Answer: #{resp.inspect}")
-  logger.info('----------------')
+  GRPC.logger.info("Answer: #{resp.inspect}")
+  GRPC.logger.info('----------------')
 end
 
 def do_sum(stub)
   # to make client streaming requests, pass an enumerable of the inputs
-  logger.info('client_streamer')
-  logger.info('---------------')
+  GRPC.logger.info('client_streamer')
+  GRPC.logger.info('---------------')
   reqs = [1, 2, 3, 4, 5].map { |x| Math::Num.new(num: x) }
-  logger.info("sum(1, 2, 3, 4, 5): reqs=#{reqs.inspect}")
+  GRPC.logger.info("sum(1, 2, 3, 4, 5): reqs=#{reqs.inspect}")
   resp = stub.sum(reqs)  # reqs.is_a?(Enumerable)
-  logger.info("Answer: #{resp.inspect}")
-  logger.info('---------------')
+  GRPC.logger.info("Answer: #{resp.inspect}")
+  GRPC.logger.info('---------------')
 end
 
 def do_fib(stub)
-  logger.info('server_streamer')
-  logger.info('----------------')
+  GRPC.logger.info('server_streamer')
+  GRPC.logger.info('----------------')
   req = Math::FibArgs.new(limit: 11)
-  logger.info("fib(11): req=#{req.inspect}")
+  GRPC.logger.info("fib(11): req=#{req.inspect}")
   resp = stub.fib(req, INFINITE_FUTURE)
   resp.each do |r|
-    logger.info("Answer: #{r.inspect}")
+    GRPC.logger.info("Answer: #{r.inspect}")
   end
-  logger.info('----------------')
+  GRPC.logger.info('----------------')
 end
 
 def do_div_many(stub)
-  logger.info('bidi_streamer')
-  logger.info('-------------')
+  GRPC.logger.info('bidi_streamer')
+  GRPC.logger.info('-------------')
   reqs = []
   reqs << Math::DivArgs.new(dividend: 7, divisor: 3)
   reqs << Math::DivArgs.new(dividend: 5, divisor: 2)
   reqs << Math::DivArgs.new(dividend: 7, divisor: 2)
-  logger.info("div(7/3), div(5/2), div(7/2): reqs=#{reqs.inspect}")
+  GRPC.logger.info("div(7/3), div(5/2), div(7/2): reqs=#{reqs.inspect}")
   resp = stub.div_many(reqs, 10)
   resp.each do |r|
-    logger.info("Answer: #{r.inspect}")
+    GRPC.logger.info("Answer: #{r.inspect}")
   end
-  logger.info('----------------')
+  GRPC.logger.info('----------------')
 end
 
 def load_test_certs
@@ -132,10 +132,10 @@ def main
     p stub_opts
     p options['host']
     stub = Math::Math::Stub.new(options['host'], **stub_opts)
-    logger.info("... connecting securely on #{options['host']}")
+    GRPC.logger.info("... connecting securely on #{options['host']}")
   else
     stub = Math::Math::Stub.new(options['host'])
-    logger.info("... connecting insecurely on #{options['host']}")
+    GRPC.logger.info("... connecting insecurely on #{options['host']}")
   end
 
   do_div(stub)

--- a/src/ruby/bin/math_server.rb
+++ b/src/ruby/bin/math_server.rb
@@ -128,13 +128,13 @@ class Calculator < Math::Math::Service
     t = Thread.new do
       begin
         requests.each do |req|
-          logger.info("read #{req.inspect}")
+          GRPC.logger.info("read #{req.inspect}")
           resp = Math::DivReply.new(quotient: req.dividend / req.divisor,
                                     remainder: req.dividend % req.divisor)
           q.push(resp)
           Thread.pass  # let the internal Bidi threads run
         end
-        logger.info('finished reads')
+        GRPC.logger.info('finished reads')
         q.push(self)
       rescue StandardError => e
         q.push(e)  # share the exception with the enumerator
@@ -176,10 +176,10 @@ def main
   s = GRPC::RpcServer.new
   if options['secure']
     s.add_http2_port(options['host'], test_server_creds)
-    logger.info("... running securely on #{options['host']}")
+    GRPC.logger.info("... running securely on #{options['host']}")
   else
     s.add_http2_port(options['host'])
-    logger.info("... running insecurely on #{options['host']}")
+    GRPC.logger.info("... running insecurely on #{options['host']}")
   end
 
   s.handle(Calculator)

--- a/src/ruby/bin/noproto_client.rb
+++ b/src/ruby/bin/noproto_client.rb
@@ -94,15 +94,15 @@ def main
     p stub_opts
     p options['host']
     stub = NoProtoStub.new(options['host'], **stub_opts)
-    logger.info("... connecting securely on #{options['host']}")
+    GRPC.logger.info("... connecting securely on #{options['host']}")
   else
     stub = NoProtoStub.new(options['host'])
-    logger.info("... connecting insecurely on #{options['host']}")
+    GRPC.logger.info("... connecting insecurely on #{options['host']}")
   end
 
-  logger.info('sending a NoProto rpc')
+  GRPC.logger.info('sending a NoProto rpc')
   resp = stub.an_rpc(NoProtoMsg.new)
-  logger.info("got a response: #{resp}")
+  GRPC.logger.info("got a response: #{resp}")
 end
 
 main

--- a/src/ruby/bin/noproto_server.rb
+++ b/src/ruby/bin/noproto_server.rb
@@ -63,7 +63,7 @@ class NoProto < NoProtoService
   end
 
   def an_rpc(req, _call)
-    logger.info('echo service received a request')
+    GRPC.logger.info('echo service received a request')
     req
   end
 end
@@ -98,10 +98,10 @@ def main
   s = GRPC::RpcServer.new
   if options['secure']
     s.add_http2_port(options['host'], test_server_creds)
-    logger.info("... running securely on #{options['host']}")
+    GRPC.logger.info("... running securely on #{options['host']}")
   else
     s.add_http2_port(options['host'])
-    logger.info("... running insecurely on #{options['host']}")
+    GRPC.logger.info("... running insecurely on #{options['host']}")
   end
 
   s.handle(NoProto)

--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -188,7 +188,7 @@ module GRPC
     # @param marshalled [false, true] indicates if the object is already
     # marshalled.
     def remote_send(req, marshalled = false)
-      logger.debug("sending #{req}, marshalled? #{marshalled}")
+      GRPC.logger.debug("sending #{req}, marshalled? #{marshalled}")
       if marshalled
         payload = req
       else
@@ -230,14 +230,14 @@ module GRPC
         @call.metadata = batch_result.metadata
         @metadata_tag = nil
       end
-      logger.debug("received req: #{batch_result}")
+      GRPC.logger.debug("received req: #{batch_result}")
       unless batch_result.nil? || batch_result.message.nil?
-        logger.debug("received req.to_s: #{batch_result.message}")
+        GRPC.logger.debug("received req.to_s: #{batch_result.message}")
         res = @unmarshal.call(batch_result.message)
-        logger.debug("received_req (unmarshalled): #{res.inspect}")
+        GRPC.logger.debug("received_req (unmarshalled): #{res.inspect}")
         return res
       end
-      logger.debug('found nil; the final response has been sent')
+      GRPC.logger.debug('found nil; the final response has been sent')
       nil
     end
 

--- a/src/ruby/lib/grpc/generic/rpc_desc.rb
+++ b/src/ruby/lib/grpc/generic/rpc_desc.rb
@@ -84,22 +84,22 @@ module GRPC
     rescue BadStatus => e
       # this is raised by handlers that want GRPC to send an application error
       # code and detail message and some additional app-specific metadata.
-      logger.debug("app err: #{active_call}, status:#{e.code}:#{e.details}")
+      GRPC.logger.debug("app err:#{active_call}, status:#{e.code}:#{e.details}")
       send_status(active_call, e.code, e.details, **e.metadata)
     rescue Core::CallError => e
       # This is raised by GRPC internals but should rarely, if ever happen.
       # Log it, but don't notify the other endpoint..
-      logger.warn("failed call: #{active_call}\n#{e}")
+      GRPC.logger.warn("failed call: #{active_call}\n#{e}")
     rescue Core::OutOfTime
       # This is raised when active_call#method.call exceeeds the deadline
       # event.  Send a status of deadline exceeded
-      logger.warn("late call: #{active_call}")
+      GRPC.logger.warn("late call: #{active_call}")
       send_status(active_call, DEADLINE_EXCEEDED, 'late')
     rescue StandardError => e
       # This will usuaally be an unhandled error in the handling code.
       # Send back a UNKNOWN status to the client
-      logger.warn("failed handler: #{active_call}; sending status:UNKNOWN")
-      logger.warn(e)
+      GRPC.logger.warn("failed handler: #{active_call}; sending status:UNKNOWN")
+      GRPC.logger.warn(e)
       send_status(active_call, UNKNOWN, 'no reason given')
     end
 
@@ -139,8 +139,8 @@ module GRPC
       details = 'Not sure why' if details.nil?
       active_client.send_status(code, details, code == OK, **kw)
     rescue StandardError => e
-      logger.warn("Could not send status #{code}:#{details}")
-      logger.warn(e)
+      GRPC.logger.warn("Could not send status #{code}:#{details}")
+      GRPC.logger.warn(e)
     end
   end
 end

--- a/src/ruby/lib/grpc/generic/service.rb
+++ b/src/ruby/lib/grpc/generic/service.rb
@@ -175,23 +175,23 @@ module GRPC
             route = "/#{route_prefix}/#{name}"
             if desc.request_response?
               define_method(mth_name) do |req, deadline = nil, **kw|
-                logger.debug("calling #{@host}:#{route}")
+                GRPC.logger.debug("calling #{@host}:#{route}")
                 request_response(route, req, marshal, unmarshal, deadline, **kw)
               end
             elsif desc.client_streamer?
               define_method(mth_name) do |reqs, deadline = nil, **kw|
-                logger.debug("calling #{@host}:#{route}")
+                GRPC.logger.debug("calling #{@host}:#{route}")
                 client_streamer(route, reqs, marshal, unmarshal, deadline, **kw)
               end
             elsif desc.server_streamer?
               define_method(mth_name) do |req, deadline = nil, **kw, &blk|
-                logger.debug("calling #{@host}:#{route}")
+                GRPC.logger.debug("calling #{@host}:#{route}")
                 server_streamer(route, req, marshal, unmarshal, deadline, **kw,
                                 &blk)
               end
             else  # is a bidi_stream
               define_method(mth_name) do |reqs, deadline = nil, **kw, &blk|
-                logger.debug("calling #{@host}:#{route}")
+                GRPC.logger.debug("calling #{@host}:#{route}")
                 bidi_streamer(route, reqs, marshal, unmarshal, deadline, **kw,
                               &blk)
               end

--- a/src/ruby/lib/grpc/logconfig.rb
+++ b/src/ruby/lib/grpc/logconfig.rb
@@ -29,7 +29,10 @@
 
 require 'logging'
 
-include Logging.globally  # logger is accessible everywhere
+# GRPC contains the General RPC module.
+module GRPC
+  extend Logging.globally
+end
 
 Logging.logger.root.appenders = Logging.appenders.stdout
 Logging.logger.root.level = :info

--- a/src/ruby/spec/generic/rpc_server_spec.rb
+++ b/src/ruby/spec/generic/rpc_server_spec.rb
@@ -69,7 +69,7 @@ class EchoService
   end
 
   def an_rpc(req, call)
-    logger.info('echo service received a request')
+    GRPC.logger.info('echo service received a request')
     call.output_metadata.update(@trailing_metadata)
     @received_md << call.metadata unless call.metadata.nil?
     req
@@ -109,7 +109,7 @@ class SlowService
   end
 
   def an_rpc(req, call)
-    logger.info("starting a slow #{@delay} rpc")
+    GRPC.logger.info("starting a slow #{@delay} rpc")
     sleep @delay
     @received_md << call.metadata unless call.metadata.nil?
     req  # send back the req as the response


### PR DESCRIPTION
Hello!

GRPC's logger is included in the global scope as the variable `logger`. Aside from this not being a great practice, it also conflicts with Rails and thus the settings that GRPC sets on its logger override Rails's logger settings.

In this PR I've moved `logger` to `GRPC.logger` so that it's accessible globally, but under the GRPC module. This should make the gem friendlier to other libraries.

I've signed the CLA under this username (@ngauthier).

Thanks!
Nick