### PR TITLE
Fix mistaken method name: "append", not "add"

### DIFF
--- a/src/python/src/grpc/framework/face/_calls.py
+++ b/src/python/src/grpc/framework/face/_calls.py
@@ -248,7 +248,7 @@ class _OperationFuture(future.Future):
     """See future.Future.add_done_callback for specification."""
     with self._condition:
       if self._callbacks is not None:
-        self._callbacks.add(fn)
+        self._callbacks.append(fn)
         return
 
     callable_util.call_logging_exceptions(fn, _DONE_CALLBACK_LOG_MESSAGE, self)


### PR DESCRIPTION
This defect was originally introduced in Google-internal source control
on 18 August 2014. Wow. Clearly unit test coverage is needed for this
feature.