### PR TITLE
Replaced std::this_thread::sleep_for for gpr_sleep_until.

### DIFF
--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -96,14 +96,16 @@ class TestServiceImpl : public ::grpc::cpp::test::util::TestService::Service {
         signal_client_ = true;
       }
       while (!context->IsCancelled()) {
-        std::this_thread::sleep_for(std::chrono::microseconds(
-            request->param().client_cancel_after_us()));
+        gpr_sleep_until(gpr_time_add(
+            gpr_now(),
+            gpr_time_from_micros(request->param().client_cancel_after_us())));
       }
       return Status::Cancelled;
     } else if (request->has_param() &&
                request->param().server_cancel_after_us()) {
-      std::this_thread::sleep_for(
-          std::chrono::microseconds(request->param().server_cancel_after_us()));
+      gpr_sleep_until(gpr_time_add(
+            gpr_now(),
+            gpr_time_from_micros(request->param().server_cancel_after_us())));
       return Status::Cancelled;
     } else {
       EXPECT_FALSE(context->IsCancelled());
@@ -469,7 +471,7 @@ TEST_F(End2endTest, BadCredentials) {
 }
 
 void CancelRpc(ClientContext* context, int delay_us, TestServiceImpl* service) {
-  std::this_thread::sleep_for(std::chrono::microseconds(delay_us));
+  gpr_sleep_until(gpr_time_add(gpr_now(), gpr_time_from_micros(delay_us)));
   while (!service->signal_client()) {
   }
   context->TryCancel();

--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -94,14 +94,16 @@ class TestServiceImpl : public ::grpc::cpp::test::util::TestService::Service {
         signal_client_ = true;
       }
       while (!context->IsCancelled()) {
-        std::this_thread::sleep_for(std::chrono::microseconds(
-            request->param().client_cancel_after_us()));
+        gpr_sleep_until(gpr_time_add(
+            gpr_now(),
+            gpr_time_from_micros(request->param().client_cancel_after_us())));
       }
       return Status::Cancelled;
     } else if (request->has_param() &&
                request->param().server_cancel_after_us()) {
-      std::this_thread::sleep_for(
-          std::chrono::microseconds(request->param().server_cancel_after_us()));
+      gpr_sleep_until(gpr_time_add(
+          gpr_now(),
+          gpr_time_from_micros(request->param().server_cancel_after_us())));
       return Status::Cancelled;
     } else {
       EXPECT_FALSE(context->IsCancelled());

--- a/test/cpp/qps/worker.cc
+++ b/test/cpp/qps/worker.cc
@@ -37,6 +37,7 @@
 #include <thread>
 
 #include <grpc/grpc.h>
+#include <grpc/support/time.h>
 #include <gflags/gflags.h>
 
 #include "qps_worker.h"
@@ -56,7 +57,7 @@ static void RunServer() {
   QpsWorker worker(FLAGS_driver_port, FLAGS_server_port);
 
   while (!got_sigint) {
-    std::this_thread::sleep_for(std::chrono::seconds(5));
+    gpr_sleep_until(gpr_time_add(gpr_now(), gpr_time_from_seconds(5)));
   }
 }
 


### PR DESCRIPTION
std::this_thread::sleep_for isn't available in gcc <= 4.6 (4.7?) nor VS2010.

Part of issue #1689 
Fixes #1688 