### PR TITLE
nullptr->shared_ptr typecast for gcc 4.4

### DIFF
--- a/include/grpc++/config.h
+++ b/include/grpc++/config.h
@@ -112,6 +112,9 @@ public:
   template <class T> operator std::unique_ptr<T>() const {
     return std::unique_ptr<T>(static_cast<T *>(0));
   }
+  template <class T> operator std::shared_ptr<T>() const {
+    return std::shared_ptr<T>(static_cast<T *>(0));
+  }
   operator bool() const {return false;}
 private:
   void operator&() const = delete;


### PR DESCRIPTION
Had to extend our nullptr imitator to account for recently-introduced uses of shared_ptr