### PR TITLE
Fix MacOS Python test linker paths

### DIFF
--- a/tools/run_tests/run_python.sh
+++ b/tools/run_tests/run_python.sh
@@ -35,5 +35,6 @@ cd $(dirname $0)/../..
 
 root=`pwd`
 export LD_LIBRARY_PATH=$root/libs/$CONFIG
+export DYLD_LIBRARY_PATH=$root/libs/$CONFIG
 source python2.7_virtual_environment/bin/activate
 python2.7 -B $*


### PR DESCRIPTION
I could have sworn that I'd done this before.