### PR TITLE
Use consistent port numbers

### DIFF
--- a/src/node/examples/math_server.js
+++ b/src/node/examples/math_server.js
@@ -119,7 +119,7 @@ var server = new Server({
 });
 
 if (require.main === module) {
-  server.bind('0.0.0.0:7070');
+  server.bind('0.0.0.0:50051');
   server.listen();
 }
 

--- a/src/node/examples/stock_server.js
+++ b/src/node/examples/stock_server.js
@@ -83,7 +83,7 @@ var stockServer = new StockServer({
 });
 
 if (require.main === module) {
-  stockServer.bind('0.0.0.0:8080');
+  stockServer.bind('0.0.0.0:50051');
   stockServer.listen();
 }
 

--- a/src/ruby/ext/grpc/rb_server.c
+++ b/src/ruby/ext/grpc/rb_server.c
@@ -282,12 +282,12 @@ static VALUE grpc_rb_server_destroy(VALUE self) {
   call-seq:
     // insecure port
     insecure_server = Server.new(cq, {'arg1': 'value1'})
-    insecure_server.add_http2_port('mydomain:7575')
+    insecure_server.add_http2_port('mydomain:50051')
 
     // secure port
     server_creds = ...
     secure_server = Server.new(cq, {'arg1': 'value1'})
-    secure_server.add_http_port('mydomain:7575', server_creds)
+    secure_server.add_http_port('mydomain:50051', server_creds)
 
     Adds a http2 port to server */
 static VALUE grpc_rb_server_add_http2_port(int argc, VALUE *argv, VALUE self) {


### PR DESCRIPTION
Update 2 node examples and 1 ruby comment to use port 50051 for gRPC services to make things a bit more consistent.

+ @murgatroid99 