### PR TITLE
Revamped iomgr's callback mechanism

### DIFF
--- a/src/core/channel/child_channel.c
+++ b/src/core/channel/child_channel.c
@@ -218,7 +218,6 @@ static void maybe_destroy_channel(grpc_child_channel *channel) {
       !chand->sending_farewell && !chand->calling_back) {
     chand->finally_destroy_channel_iocb.cb = finally_destroy_channel;
     chand->finally_destroy_channel_iocb.cb_arg = channel;
-    chand->finally_destroy_channel_iocb.is_ext_managed = 1; /* GPR_TRUE */
     grpc_iomgr_add_callback(&chand->finally_destroy_channel_iocb);
   } else if (chand->destroyed && !chand->disconnected &&
              chand->active_calls == 0 && !chand->sending_farewell &&
@@ -226,7 +225,6 @@ static void maybe_destroy_channel(grpc_child_channel *channel) {
     chand->sending_farewell = 1;
     chand->send_farewells_iocb.cb = send_farewells;
     chand->send_farewells_iocb.cb_arg = channel;
-    chand->send_farewells_iocb.is_ext_managed = 1;  /* GPR_TRUE */
     grpc_iomgr_add_callback(&chand->send_farewells_iocb);
   }
 }

--- a/src/core/iomgr/fd_posix.c
+++ b/src/core/iomgr/fd_posix.c
@@ -302,7 +302,8 @@ void grpc_fd_shutdown(grpc_fd *fd) {
   set_ready_locked(&fd->writest, &fd->shutdown_closures[0], &ncb);
   gpr_mu_unlock(&fd->set_state_mu);
   GPR_ASSERT(ncb <= 2);
-  process_callbacks(fd->shutdown_closures[0], ncb, 0, 0);
+  process_callbacks(fd->shutdown_closures[0], ncb, 0 /* GPR_FALSE */,
+                    0 /* GPR_FALSE */);
 }
 
 void grpc_fd_notify_on_read(grpc_fd *fd, grpc_iomgr_closure *closure) {

--- a/src/core/iomgr/fd_posix.c
+++ b/src/core/iomgr/fd_posix.c
@@ -91,6 +91,7 @@ static grpc_fd *alloc_fd(int fd) {
     gpr_mu_init(&r->set_state_mu);
     gpr_mu_init(&r->watcher_mu);
   }
+
   gpr_atm_rel_store(&r->refst, 1);
   gpr_atm_rel_store(&r->readst, NOT_READY);
   gpr_atm_rel_store(&r->writest, NOT_READY);
@@ -117,7 +118,10 @@ static void unref_by(grpc_fd *fd, int n) {
   gpr_atm old = gpr_atm_full_fetch_add(&fd->refst, -n);
   if (old == n) {
     close(fd->fd);
-    grpc_iomgr_add_callback(fd->on_done, fd->on_done_user_data);
+    fd->on_done_iocb.cb = fd->on_done;
+    fd->on_done_iocb.cb_arg = fd->on_done_user_data;
+    fd->on_done_iocb.is_ext_managed = 1;
+    grpc_iomgr_add_callback(&fd->on_done_iocb);
     freelist_fd(fd);
     grpc_iomgr_unref();
   } else {
@@ -196,20 +200,25 @@ void grpc_fd_ref(grpc_fd *fd) { ref_by(fd, 2); }
 void grpc_fd_unref(grpc_fd *fd) { unref_by(fd, 2); }
 
 static void make_callback(grpc_iomgr_cb_func cb, void *arg, int success,
-                          int allow_synchronous_callback) {
+                          int allow_synchronous_callback,
+                          grpc_iomgr_closure *iocb) {
   if (allow_synchronous_callback) {
     cb(arg, success);
   } else {
-    grpc_iomgr_add_delayed_callback(cb, arg, success);
+    /* !iocb: allocate -> managed by iomgr
+     *  iocb: "iocb" holds an instance managed by fd_posix */
+    iocb = grpc_iomgr_cb_create(cb, arg, !iocb /* is_ext_managed */);
+    grpc_iomgr_add_delayed_callback(iocb, success);
   }
 }
 
 static void make_callbacks(grpc_iomgr_closure *callbacks, size_t n, int success,
-                           int allow_synchronous_callback) {
+                           int allow_synchronous_callback,
+                           grpc_iomgr_closure *iocbs) {
   size_t i;
   for (i = 0; i < n; i++) {
     make_callback(callbacks[i].cb, callbacks[i].cb_arg, success,
-                  allow_synchronous_callback);
+                  allow_synchronous_callback, iocbs + i);
   }
 }
 
@@ -238,7 +247,7 @@ static void notify_on(grpc_fd *fd, gpr_atm *st, grpc_iomgr_closure *closure,
       gpr_atm_rel_store(st, NOT_READY);
       make_callback(closure->cb, closure->cb_arg,
                     !gpr_atm_acq_load(&fd->shutdown),
-                    allow_synchronous_callback);
+                    allow_synchronous_callback, NULL);
       return;
     default: /* WAITING */
       /* upcallptr was set to a different closure.  This is an error! */
@@ -284,11 +293,14 @@ static void set_ready(grpc_fd *fd, gpr_atm *st,
   int success;
   grpc_iomgr_closure cb;
   size_t ncb = 0;
+  grpc_iomgr_closure *ready_iocb;
   gpr_mu_lock(&fd->set_state_mu);
   set_ready_locked(st, &cb, &ncb);
   gpr_mu_unlock(&fd->set_state_mu);
   success = !gpr_atm_acq_load(&fd->shutdown);
-  make_callbacks(&cb, ncb, success, allow_synchronous_callback);
+  assert(ncb <= 1);
+  ready_iocb = grpc_iomgr_cb_create(cb.cb, cb.cb_arg, 0);
+  make_callbacks(&cb, ncb, success, allow_synchronous_callback, ready_iocb);
 }
 
 void grpc_fd_shutdown(grpc_fd *fd) {
@@ -300,7 +312,8 @@ void grpc_fd_shutdown(grpc_fd *fd) {
   set_ready_locked(&fd->readst, cb, &ncb);
   set_ready_locked(&fd->writest, cb, &ncb);
   gpr_mu_unlock(&fd->set_state_mu);
-  make_callbacks(cb, ncb, 0, 0);
+  assert(ncb <= 2);
+  make_callbacks(cb, ncb, 0, 0, fd->shutdown_iocbs);
 }
 
 void grpc_fd_notify_on_read(grpc_fd *fd, grpc_iomgr_closure *closure) {

--- a/src/core/iomgr/fd_posix.h
+++ b/src/core/iomgr/fd_posix.h
@@ -91,12 +91,10 @@ struct grpc_fd {
   gpr_atm readst;
   gpr_atm writest;
 
-  grpc_iomgr_cb_func on_done;
-  void *on_done_user_data;
   struct grpc_fd *freelist_next;
 
-  grpc_iomgr_closure on_done_iocb;
-  grpc_iomgr_closure shutdown_iocbs[2];
+  grpc_iomgr_closure on_done_closure;
+  grpc_iomgr_closure shutdown_closures[2];
 };
 
 /* Create a wrapped file descriptor.

--- a/src/core/iomgr/fd_posix.h
+++ b/src/core/iomgr/fd_posix.h
@@ -96,8 +96,6 @@ struct grpc_fd {
   struct grpc_fd *freelist_next;
 
   grpc_iomgr_closure on_done_iocb;
-  /*grpc_iomgr_closure *ready_iocb; XXX: the only one  we need to allocate on
-   * the spot*/
   grpc_iomgr_closure shutdown_iocbs[2];
 };
 

--- a/src/core/iomgr/fd_posix.h
+++ b/src/core/iomgr/fd_posix.h
@@ -94,7 +94,7 @@ struct grpc_fd {
   struct grpc_fd *freelist_next;
 
   grpc_iomgr_closure on_done_closure;
-  grpc_iomgr_closure shutdown_closures[2];
+  grpc_iomgr_closure *shutdown_closures[2];
 };
 
 /* Create a wrapped file descriptor.

--- a/src/core/iomgr/fd_posix.h
+++ b/src/core/iomgr/fd_posix.h
@@ -40,11 +40,6 @@
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>
 
-typedef struct {
-  grpc_iomgr_cb_func cb;
-  void *cb_arg;
-} grpc_iomgr_closure;
-
 typedef struct grpc_fd grpc_fd;
 
 typedef struct grpc_fd_watcher {
@@ -99,6 +94,11 @@ struct grpc_fd {
   grpc_iomgr_cb_func on_done;
   void *on_done_user_data;
   struct grpc_fd *freelist_next;
+
+  grpc_iomgr_closure on_done_iocb;
+  /*grpc_iomgr_closure *ready_iocb; XXX: the only one  we need to allocate on
+   * the spot*/
+  grpc_iomgr_closure shutdown_iocbs[2];
 };
 
 /* Create a wrapped file descriptor.

--- a/src/core/iomgr/iomgr.c
+++ b/src/core/iomgr/iomgr.c
@@ -163,7 +163,6 @@ void grpc_iomgr_closure_init(grpc_iomgr_closure *closure, grpc_iomgr_cb_func cb,
                              void *cb_arg) {
   closure->cb = cb;
   closure->cb_arg = cb_arg;
-  closure->success = -1;  /* uninitialized */
   closure->next = NULL;
 }
 
@@ -182,7 +181,7 @@ void grpc_iomgr_add_delayed_callback(grpc_iomgr_closure *closure, int success) {
 
 
 void grpc_iomgr_add_callback(grpc_iomgr_closure *closure) {
-  grpc_iomgr_add_delayed_callback(closure, 1);
+  grpc_iomgr_add_delayed_callback(closure, 1 /* GPR_TRUE */);
 }
 
 

--- a/src/core/iomgr/iomgr.h
+++ b/src/core/iomgr/iomgr.h
@@ -47,6 +47,7 @@ typedef struct grpc_iomgr_closure {
 void grpc_iomgr_closure_init(grpc_iomgr_closure *closure, grpc_iomgr_cb_func cb,
                              void *cb_arg);
 
+/* TODO(dgq): get rid of the managed_closure concept. */
 void grpc_iomgr_managed_closure_init(grpc_iomgr_closure *manager,
                                      grpc_iomgr_cb_func managed_cb,
                                      void *managed_cb_arg);

--- a/src/core/iomgr/iomgr.h
+++ b/src/core/iomgr/iomgr.h
@@ -34,29 +34,43 @@
 #ifndef GRPC_INTERNAL_CORE_IOMGR_IOMGR_H
 #define GRPC_INTERNAL_CORE_IOMGR_IOMGR_H
 
-/* gRPC Callback definition */
+/** gRPC Callback definition.
+ *
+ * \param arg Arbitrary input.
+ * \param success An indication on the state of the iomgr. On false, cleanup
+ * actions should be taken (eg, shutdown). */
 typedef void (*grpc_iomgr_cb_func)(void *arg, int success);
 
+/** A closure over a grpc_iomgr_cb_func. */
 typedef struct grpc_iomgr_closure {
+  /** Bound callback. */
   grpc_iomgr_cb_func cb;
+
+  /** Arguments to be passed to "cb". */
   void *cb_arg;
+
+  /** Internal. A boolean indication to "cb" on the state of the iomgr.
+   * For instance, closures created during a shutdown would have this field set
+   * to false. */
   int success;
-  struct grpc_iomgr_closure *next;  /** Do not touch */
+
+  /**< Internal. Do not touch */
+  struct grpc_iomgr_closure *next;
 } grpc_iomgr_closure;
 
+/** Initializes \a closure with \a cb and \a cb_arg. */
 void grpc_iomgr_closure_init(grpc_iomgr_closure *closure, grpc_iomgr_cb_func cb,
                              void *cb_arg);
 
-/* TODO(dgq): get rid of the managed_closure concept. */
-void grpc_iomgr_managed_closure_init(grpc_iomgr_closure *manager,
-                                     grpc_iomgr_cb_func managed_cb,
-                                     void *managed_cb_arg);
-
+/** Initializes the iomgr. */
 void grpc_iomgr_init(void);
+
+/** Signals the intention to shutdown the iomgr. */
 void grpc_iomgr_shutdown(void);
 
-/* This function is called from within a callback or from anywhere else
-   and causes the invocation of a callback at some point in the future */
+/** Registers a closure to be invoked at some point in the future.
+ *
+ * Can be called from within a callback or from anywhere else */
 void grpc_iomgr_add_callback(grpc_iomgr_closure *closure);
 
 #endif  /* GRPC_INTERNAL_CORE_IOMGR_IOMGR_H */

--- a/src/core/iomgr/iomgr.h
+++ b/src/core/iomgr/iomgr.h
@@ -41,18 +41,21 @@ typedef struct grpc_iomgr_closure {
   grpc_iomgr_cb_func cb;
   void *cb_arg;
   int success;
-  int is_ext_managed;  /** is memory being managed externally? */
   struct grpc_iomgr_closure *next;  /** Do not touch */
 } grpc_iomgr_closure;
 
-grpc_iomgr_closure *grpc_iomgr_cb_create(grpc_iomgr_cb_func cb, void *cb_arg,
-                                    int is_ext_managed);
+void grpc_iomgr_closure_init(grpc_iomgr_closure *closure, grpc_iomgr_cb_func cb,
+                             void *cb_arg);
+
+void grpc_iomgr_managed_closure_init(grpc_iomgr_closure *manager,
+                                     grpc_iomgr_cb_func managed_cb,
+                                     void *managed_cb_arg);
 
 void grpc_iomgr_init(void);
 void grpc_iomgr_shutdown(void);
 
 /* This function is called from within a callback or from anywhere else
    and causes the invocation of a callback at some point in the future */
-void grpc_iomgr_add_callback(grpc_iomgr_closure *iocb);
+void grpc_iomgr_add_callback(grpc_iomgr_closure *closure);
 
 #endif  /* GRPC_INTERNAL_CORE_IOMGR_IOMGR_H */

--- a/src/core/iomgr/iomgr.h
+++ b/src/core/iomgr/iomgr.h
@@ -37,11 +37,22 @@
 /* gRPC Callback definition */
 typedef void (*grpc_iomgr_cb_func)(void *arg, int success);
 
+typedef struct grpc_iomgr_closure {
+  grpc_iomgr_cb_func cb;
+  void *cb_arg;
+  int success;
+  int is_ext_managed;  /** is memory being managed externally? */
+  struct grpc_iomgr_closure *next;  /** Do not touch */
+} grpc_iomgr_closure;
+
+grpc_iomgr_closure *grpc_iomgr_cb_create(grpc_iomgr_cb_func cb, void *cb_arg,
+                                    int is_ext_managed);
+
 void grpc_iomgr_init(void);
 void grpc_iomgr_shutdown(void);
 
 /* This function is called from within a callback or from anywhere else
    and causes the invocation of a callback at some point in the future */
-void grpc_iomgr_add_callback(grpc_iomgr_cb_func cb, void *cb_arg);
+void grpc_iomgr_add_callback(grpc_iomgr_closure *iocb);
 
 #endif  /* GRPC_INTERNAL_CORE_IOMGR_IOMGR_H */

--- a/src/core/iomgr/iomgr_internal.h
+++ b/src/core/iomgr/iomgr_internal.h
@@ -35,12 +35,10 @@
 #define GRPC_INTERNAL_CORE_IOMGR_IOMGR_INTERNAL_H
 
 #include "src/core/iomgr/iomgr.h"
-#include "src/core/iomgr/iomgr_internal.h"
 #include <grpc/support/sync.h>
 
 int grpc_maybe_call_delayed_callbacks(gpr_mu *drop_mu, int success);
-void grpc_iomgr_add_delayed_callback(grpc_iomgr_cb_func cb, void *cb_arg,
-                                     int success);
+void grpc_iomgr_add_delayed_callback(grpc_iomgr_closure *iocb, int success);
 
 void grpc_iomgr_ref(void);
 void grpc_iomgr_unref(void);

--- a/src/core/iomgr/pollset_posix.c
+++ b/src/core/iomgr/pollset_posix.c
@@ -257,6 +257,7 @@ typedef struct grpc_unary_promote_args {
   const grpc_pollset_vtable *original_vtable;
   grpc_pollset *pollset;
   grpc_fd *fd;
+  grpc_iomgr_closure promotion_iocb;
 } grpc_unary_promote_args;
 
 static void unary_poll_do_promote(void *args, int success) {
@@ -279,7 +280,7 @@ static void unary_poll_do_promote(void *args, int success) {
   /* First we need to ensure that nobody is polling concurrently */
   while (pollset->counter != 0) {
     grpc_pollset_kick(pollset);
-    grpc_iomgr_add_callback(unary_poll_do_promote, up_args);
+    grpc_iomgr_add_callback(&up_args->promotion_iocb);
     gpr_mu_unlock(&pollset->mu);
     return;
   }
@@ -363,7 +364,10 @@ static void unary_poll_pollset_add_fd(grpc_pollset *pollset, grpc_fd *fd) {
   up_args->pollset = pollset;
   up_args->fd = fd;
   up_args->original_vtable = pollset->vtable;
-  grpc_iomgr_add_callback(unary_poll_do_promote, up_args);
+  up_args->promotion_iocb.cb = unary_poll_do_promote;
+  up_args->promotion_iocb.cb_arg = up_args;
+  up_args->promotion_iocb.is_ext_managed = 1;
+  grpc_iomgr_add_callback(&up_args->promotion_iocb);
 
   grpc_pollset_kick(pollset);
 }

--- a/src/core/iomgr/pollset_posix.c
+++ b/src/core/iomgr/pollset_posix.c
@@ -366,7 +366,6 @@ static void unary_poll_pollset_add_fd(grpc_pollset *pollset, grpc_fd *fd) {
   up_args->original_vtable = pollset->vtable;
   up_args->promotion_iocb.cb = unary_poll_do_promote;
   up_args->promotion_iocb.cb_arg = up_args;
-  up_args->promotion_iocb.is_ext_managed = 1;
   grpc_iomgr_add_callback(&up_args->promotion_iocb);
 
   grpc_pollset_kick(pollset);

--- a/src/core/iomgr/pollset_posix.c
+++ b/src/core/iomgr/pollset_posix.c
@@ -257,7 +257,7 @@ typedef struct grpc_unary_promote_args {
   const grpc_pollset_vtable *original_vtable;
   grpc_pollset *pollset;
   grpc_fd *fd;
-  grpc_iomgr_closure promotion_iocb;
+  grpc_iomgr_closure promotion_closure;
 } grpc_unary_promote_args;
 
 static void unary_poll_do_promote(void *args, int success) {
@@ -280,7 +280,7 @@ static void unary_poll_do_promote(void *args, int success) {
   /* First we need to ensure that nobody is polling concurrently */
   while (pollset->counter != 0) {
     grpc_pollset_kick(pollset);
-    grpc_iomgr_add_callback(&up_args->promotion_iocb);
+    grpc_iomgr_add_callback(&up_args->promotion_closure);
     gpr_mu_unlock(&pollset->mu);
     return;
   }
@@ -364,9 +364,9 @@ static void unary_poll_pollset_add_fd(grpc_pollset *pollset, grpc_fd *fd) {
   up_args->pollset = pollset;
   up_args->fd = fd;
   up_args->original_vtable = pollset->vtable;
-  up_args->promotion_iocb.cb = unary_poll_do_promote;
-  up_args->promotion_iocb.cb_arg = up_args;
-  grpc_iomgr_add_callback(&up_args->promotion_iocb);
+  up_args->promotion_closure.cb = unary_poll_do_promote;
+  up_args->promotion_closure.cb_arg = up_args;
+  grpc_iomgr_add_callback(&up_args->promotion_closure);
 
   grpc_pollset_kick(pollset);
 }

--- a/src/core/iomgr/pollset_windows.c
+++ b/src/core/iomgr/pollset_windows.c
@@ -66,15 +66,15 @@ int grpc_pollset_work(grpc_pollset *pollset, gpr_timespec deadline) {
   gpr_timespec now;
   now = gpr_now();
   if (gpr_time_cmp(now, deadline) > 0) {
-    return 0;
+    return 0 /* GPR_FALSE */;
   }
-  if (grpc_maybe_call_delayed_callbacks(NULL, 1)) {
-    return 1;
+  if (grpc_maybe_call_delayed_callbacks(NULL, 1 /* GPR_TRUE */)) {
+    return 1 /* GPR_TRUE */;
   }
   if (grpc_alarm_check(NULL, now, &deadline)) {
-    return 1;
+    return 1 /* GPR_TRUE */;
   }
-  return 0;
+  return 0 /* GPR_FALSE */;
 }
 
 void grpc_pollset_kick(grpc_pollset *p) { }

--- a/src/core/iomgr/socket_windows.c
+++ b/src/core/iomgr/socket_windows.c
@@ -62,17 +62,16 @@ grpc_winsocket *grpc_winsocket_create(SOCKET socket) {
 int grpc_winsocket_shutdown(grpc_winsocket *socket) {
   int callbacks_set = 0;
   gpr_mu_lock(&socket->state_mu);
-  socket->shutdown_iocb.is_ext_managed = 1; /* GPR_TRUE */
   if (socket->read_info.cb) {
     callbacks_set++;
-    socket->shutdown_iocb.cb = socket->read_info.cb;
-    socket->shutdown_iocb.cb_arg = socket->read_info.opaque;
+    grpc_iomgr_closure_init(&socket->shutdown_iocb, socket->read_info.cb,
+                            socket->read_info.opaque);
     grpc_iomgr_add_delayed_callback(socket->shutdown_iocb, 0);
   }
   if (socket->write_info.cb) {
     callbacks_set++;
-    socket->shutdown_iocb.cb = socket->write_info.cb;
-    socket->shutdown_iocb.cb_arg = socket->write_info.opaque;
+    grpc_iomgr_closure_init(&socket->shutdown_iocb, socket->write_info.cb,
+                            socket->write_info.opaque);
     grpc_iomgr_add_delayed_callback(socket->shutdown_iocb, 0);
   }
   gpr_mu_unlock(&socket->state_mu);

--- a/src/core/iomgr/socket_windows.c
+++ b/src/core/iomgr/socket_windows.c
@@ -39,7 +39,6 @@
 #include <grpc/support/log.h>
 
 #include "src/core/iomgr/iocp_windows.h"
-#include "src/core/iomgr/iomgr.h"
 #include "src/core/iomgr/iomgr_internal.h"
 #include "src/core/iomgr/pollset.h"
 #include "src/core/iomgr/pollset_windows.h"
@@ -64,15 +63,15 @@ int grpc_winsocket_shutdown(grpc_winsocket *socket) {
   gpr_mu_lock(&socket->state_mu);
   if (socket->read_info.cb) {
     callbacks_set++;
-    grpc_iomgr_closure_init(&socket->shutdown_iocb, socket->read_info.cb,
+    grpc_iomgr_closure_init(&socket->shutdown_closure, socket->read_info.cb,
                             socket->read_info.opaque);
-    grpc_iomgr_add_delayed_callback(socket->shutdown_iocb, 0);
+    grpc_iomgr_add_delayed_callback(&socket->shutdown_closure, 0);
   }
   if (socket->write_info.cb) {
     callbacks_set++;
-    grpc_iomgr_closure_init(&socket->shutdown_iocb, socket->write_info.cb,
+    grpc_iomgr_closure_init(&socket->shutdown_closure, socket->write_info.cb,
                             socket->write_info.opaque);
-    grpc_iomgr_add_delayed_callback(socket->shutdown_iocb, 0);
+    grpc_iomgr_add_delayed_callback(&socket->shutdown_closure, 0);
   }
   gpr_mu_unlock(&socket->state_mu);
   return callbacks_set;

--- a/src/core/iomgr/socket_windows.h
+++ b/src/core/iomgr/socket_windows.h
@@ -93,6 +93,8 @@ typedef struct grpc_winsocket {
      there is a pending operation that the IO Completion Port will have to
      wait for. The socket will be collected at that time. */
   int orphan;
+
+  grpc_iomgr_closure shutdown_iocb;
 } grpc_winsocket;
 
 /* Create a wrapped windows handle. This takes ownership of it, meaning that

--- a/src/core/iomgr/socket_windows.h
+++ b/src/core/iomgr/socket_windows.h
@@ -39,6 +39,8 @@
 #include <grpc/support/sync.h>
 #include <grpc/support/atm.h>
 
+#include "src/core/iomgr/iomgr.h"
+
 /* This holds the data for an outstanding read or write on a socket.
    The mutex to protect the concurrent access to that data is the one
    inside the winsocket wrapper. */
@@ -94,7 +96,7 @@ typedef struct grpc_winsocket {
      wait for. The socket will be collected at that time. */
   int orphan;
 
-  grpc_iomgr_closure shutdown_iocb;
+  grpc_iomgr_closure shutdown_closure;
 } grpc_winsocket;
 
 /* Create a wrapped windows handle. This takes ownership of it, meaning that

--- a/src/core/iomgr/tcp_posix.c
+++ b/src/core/iomgr/tcp_posix.c
@@ -281,7 +281,7 @@ typedef struct {
   grpc_iomgr_closure read_closure;
   grpc_iomgr_closure write_closure;
 
-  grpc_iomgr_closure handle_read_iocb;
+  grpc_iomgr_closure handle_read_closure;
 } grpc_tcp;
 
 static void grpc_tcp_handle_read(void *arg /* grpc_tcp */, int success);
@@ -445,8 +445,8 @@ static void grpc_tcp_notify_on_read(grpc_endpoint *ep, grpc_endpoint_read_cb cb,
     tcp->finished_edge = 0;
     grpc_fd_notify_on_read(tcp->em_fd, &tcp->read_closure);
   } else {
-    tcp->handle_read_iocb.cb_arg = tcp;
-    grpc_iomgr_add_callback(&tcp->handle_read_iocb);
+    tcp->handle_read_closure.cb_arg = tcp;
+    grpc_iomgr_add_callback(&tcp->handle_read_closure);
   }
 }
 
@@ -596,7 +596,7 @@ grpc_endpoint *grpc_tcp_create(grpc_fd *em_fd, size_t slice_size) {
   tcp->write_closure.cb = grpc_tcp_handle_write;
   tcp->write_closure.cb_arg = tcp;
 
-  tcp->handle_read_iocb.cb = grpc_tcp_handle_read;
+  tcp->handle_read_closure.cb = grpc_tcp_handle_read;
   return &tcp->base;
 }
 

--- a/src/core/iomgr/tcp_posix.c
+++ b/src/core/iomgr/tcp_posix.c
@@ -597,7 +597,6 @@ grpc_endpoint *grpc_tcp_create(grpc_fd *em_fd, size_t slice_size) {
   tcp->write_closure.cb_arg = tcp;
 
   tcp->handle_read_iocb.cb = grpc_tcp_handle_read;
-  tcp->handle_read_iocb.is_ext_managed = 1;
   return &tcp->base;
 }
 

--- a/src/core/iomgr/tcp_posix.c
+++ b/src/core/iomgr/tcp_posix.c
@@ -280,6 +280,8 @@ typedef struct {
 
   grpc_iomgr_closure read_closure;
   grpc_iomgr_closure write_closure;
+
+  grpc_iomgr_closure handle_read_iocb;
 } grpc_tcp;
 
 static void grpc_tcp_handle_read(void *arg /* grpc_tcp */, int success);
@@ -443,7 +445,8 @@ static void grpc_tcp_notify_on_read(grpc_endpoint *ep, grpc_endpoint_read_cb cb,
     tcp->finished_edge = 0;
     grpc_fd_notify_on_read(tcp->em_fd, &tcp->read_closure);
   } else {
-    grpc_iomgr_add_callback(grpc_tcp_handle_read, tcp);
+    tcp->handle_read_iocb.cb_arg = tcp;
+    grpc_iomgr_add_callback(&tcp->handle_read_iocb);
   }
 }
 
@@ -592,6 +595,9 @@ grpc_endpoint *grpc_tcp_create(grpc_fd *em_fd, size_t slice_size) {
   tcp->read_closure.cb_arg = tcp;
   tcp->write_closure.cb = grpc_tcp_handle_write;
   tcp->write_closure.cb_arg = tcp;
+
+  tcp->handle_read_iocb.cb = grpc_tcp_handle_read;
+  tcp->handle_read_iocb.is_ext_managed = 1;
   return &tcp->base;
 }
 

--- a/src/core/security/credentials.c
+++ b/src/core/security/credentials.c
@@ -54,6 +54,7 @@
 typedef struct {
   grpc_credentials *creds;
   grpc_credentials_metadata_cb cb;
+  grpc_iomgr_closure *on_simulated_token_fetch_done_closure;
   void *user_data;
 } grpc_credentials_metadata_request;
 
@@ -65,6 +66,8 @@ grpc_credentials_metadata_request_create(grpc_credentials *creds,
       gpr_malloc(sizeof(grpc_credentials_metadata_request));
   r->creds = grpc_credentials_ref(creds);
   r->cb = cb;
+  r->on_simulated_token_fetch_done_closure =
+      gpr_malloc(sizeof(grpc_iomgr_closure));
   r->user_data = user_data;
   return r;
 }
@@ -72,6 +75,7 @@ grpc_credentials_metadata_request_create(grpc_credentials *creds,
 static void grpc_credentials_metadata_request_destroy(
     grpc_credentials_metadata_request *r) {
   grpc_credentials_unref(r->creds);
+  gpr_free(r->on_simulated_token_fetch_done_closure);
   gpr_free(r);
 }
 
@@ -824,20 +828,6 @@ void on_simulated_token_fetch_done(void *user_data, int success) {
   grpc_credentials_metadata_request_destroy(r);
 }
 
-/* TODO(dgq): get rid of the concept of "managed closure" altogether */
-typedef struct {
-  grpc_iomgr_closure managed;
-  grpc_iomgr_closure *manager;
-} managed_closure_arg;
-
-static void closure_manager_func(void *arg, int success) {
-  managed_closure_arg *mc_arg = (managed_closure_arg*) arg;
-
-  mc_arg->managed.cb(mc_arg->managed.cb_arg, success);
-  gpr_free(mc_arg->manager);
-  gpr_free(mc_arg);
-}
-
 static void fake_oauth2_get_request_metadata(grpc_credentials *creds,
                                              const char *service_url,
                                              grpc_credentials_metadata_cb cb,
@@ -845,20 +835,11 @@ static void fake_oauth2_get_request_metadata(grpc_credentials *creds,
   grpc_fake_oauth2_credentials *c = (grpc_fake_oauth2_credentials *)creds;
 
   if (c->is_async) {
-    /* TODO(dgq): get rid of the managed closure */
-    grpc_iomgr_closure *on_simulated_token_fetch_done_closure =
-        gpr_malloc(sizeof(grpc_iomgr_closure));
-    managed_closure_arg *managed_arg = gpr_malloc(sizeof(managed_closure_arg));
-
-    managed_arg->manager = on_simulated_token_fetch_done_closure;
-    managed_arg->managed.cb = on_simulated_token_fetch_done;
-    managed_arg->managed.cb_arg =
+    grpc_credentials_metadata_request *cb_arg =
         grpc_credentials_metadata_request_create(creds, cb, user_data);
-
-    grpc_iomgr_closure_init(on_simulated_token_fetch_done_closure,
-                            closure_manager_func, managed_arg);
-
-    grpc_iomgr_add_callback(on_simulated_token_fetch_done_closure);
+    grpc_iomgr_closure_init(cb_arg->on_simulated_token_fetch_done_closure,
+                            on_simulated_token_fetch_done, cb_arg);
+    grpc_iomgr_add_callback(cb_arg->on_simulated_token_fetch_done_closure);
   } else {
     cb(user_data, c->access_token_md->entries, 1, GRPC_CREDENTIALS_OK);
   }

--- a/src/core/security/credentials.c
+++ b/src/core/security/credentials.c
@@ -833,6 +833,7 @@ static void fake_oauth2_get_request_metadata(grpc_credentials *creds,
   if (c->is_async) {
     grpc_iomgr_closure *on_simulated_token_fetch_done_closure =
         gpr_malloc(sizeof(grpc_iomgr_closure));
+    /* TODO(dgq): get rid of the managed_closure altogether */
     grpc_iomgr_managed_closure_init(
         on_simulated_token_fetch_done_closure, on_simulated_token_fetch_done,
         grpc_credentials_metadata_request_create(creds, cb, user_data));

--- a/src/core/security/credentials.c
+++ b/src/core/security/credentials.c
@@ -832,8 +832,10 @@ static void fake_oauth2_get_request_metadata(grpc_credentials *creds,
 
   if (c->is_async) {
     grpc_iomgr_add_callback(
+        grpc_iomgr_cb_create(
         on_simulated_token_fetch_done,
-        grpc_credentials_metadata_request_create(creds, cb, user_data));
+        grpc_credentials_metadata_request_create(creds, cb, user_data),
+        0 /*GPR_FALSE*/));
   } else {
     cb(user_data, c->access_token_md->entries, 1, GRPC_CREDENTIALS_OK);
   }

--- a/src/core/security/credentials.c
+++ b/src/core/security/credentials.c
@@ -831,11 +831,12 @@ static void fake_oauth2_get_request_metadata(grpc_credentials *creds,
   grpc_fake_oauth2_credentials *c = (grpc_fake_oauth2_credentials *)creds;
 
   if (c->is_async) {
-    grpc_iomgr_add_callback(
-        grpc_iomgr_cb_create(
-        on_simulated_token_fetch_done,
-        grpc_credentials_metadata_request_create(creds, cb, user_data),
-        0 /*GPR_FALSE*/));
+    grpc_iomgr_closure *on_simulated_token_fetch_done_closure =
+        gpr_malloc(sizeof(grpc_iomgr_closure));
+    grpc_iomgr_managed_closure_init(
+        on_simulated_token_fetch_done_closure, on_simulated_token_fetch_done,
+        grpc_credentials_metadata_request_create(creds, cb, user_data));
+    grpc_iomgr_add_callback(on_simulated_token_fetch_done_closure);
   } else {
     cb(user_data, c->access_token_md->entries, 1, GRPC_CREDENTIALS_OK);
   }

--- a/src/core/surface/call.c
+++ b/src/core/surface/call.c
@@ -370,7 +370,6 @@ void grpc_call_internal_unref(grpc_call *c, int allow_immediate_deletion) {
     } else {
       c->destroy_iocb.cb = destroy_call;
       c->destroy_iocb.cb_arg = c;
-      c->destroy_iocb.is_ext_managed = 1; /* GPR_TRUE */
       grpc_iomgr_add_callback(&c->destroy_iocb);
     }
   }

--- a/src/core/surface/call.c
+++ b/src/core/surface/call.c
@@ -226,7 +226,7 @@ struct grpc_call {
 
   gpr_slice_buffer incoming_message;
   gpr_uint32 incoming_message_length;
-  grpc_iomgr_closure destroy_iocb;
+  grpc_iomgr_closure destroy_closure;
 };
 
 #define CALL_STACK_FROM_CALL(call) ((grpc_call_stack *)((call) + 1))
@@ -368,9 +368,9 @@ void grpc_call_internal_unref(grpc_call *c, int allow_immediate_deletion) {
     if (allow_immediate_deletion) {
       destroy_call(c, 1);
     } else {
-      c->destroy_iocb.cb = destroy_call;
-      c->destroy_iocb.cb_arg = c;
-      grpc_iomgr_add_callback(&c->destroy_iocb);
+      c->destroy_closure.cb = destroy_call;
+      c->destroy_closure.cb_arg = c;
+      grpc_iomgr_add_callback(&c->destroy_closure);
     }
   }
 }

--- a/src/core/surface/channel.c
+++ b/src/core/surface/channel.c
@@ -196,7 +196,6 @@ void grpc_channel_internal_unref(grpc_channel *channel) {
   if (gpr_unref(&channel->refs)) {
     channel->destroy_iocb.cb = destroy_channel;
     channel->destroy_iocb.cb_arg = channel;
-    channel->destroy_iocb.is_ext_managed = 1;
     grpc_iomgr_add_callback(&channel->destroy_iocb);
   }
 }

--- a/src/core/surface/channel.c
+++ b/src/core/surface/channel.c
@@ -61,7 +61,7 @@ struct grpc_channel {
 
   gpr_mu registered_call_mu;
   registered_call *registered_calls;
-  grpc_iomgr_closure destroy_iocb;
+  grpc_iomgr_closure destroy_closure;
 };
 
 #define CHANNEL_STACK_FROM_CHANNEL(c) ((grpc_channel_stack *)((c) + 1))
@@ -194,9 +194,9 @@ static void destroy_channel(void *p, int ok) {
 
 void grpc_channel_internal_unref(grpc_channel *channel) {
   if (gpr_unref(&channel->refs)) {
-    channel->destroy_iocb.cb = destroy_channel;
-    channel->destroy_iocb.cb_arg = channel;
-    grpc_iomgr_add_callback(&channel->destroy_iocb);
+    channel->destroy_closure.cb = destroy_channel;
+    channel->destroy_closure.cb_arg = channel;
+    grpc_iomgr_add_callback(&channel->destroy_closure);
   }
 }
 

--- a/src/core/surface/server.c
+++ b/src/core/surface/server.c
@@ -122,8 +122,8 @@ struct channel_data {
   channel_registered_method *registered_methods;
   gpr_uint32 registered_method_slots;
   gpr_uint32 registered_method_max_probes;
-  grpc_iomgr_closure finish_shutdown_channel_iocb;
-  grpc_iomgr_closure finish_destroy_channel_iocb;
+  grpc_iomgr_closure finish_shutdown_channel_closure;
+  grpc_iomgr_closure finish_destroy_channel_closure;
 };
 
 struct grpc_server {
@@ -179,6 +179,8 @@ struct call_data {
   grpc_stream_state *recv_state;
   void (*on_done_recv)(void *user_data, int success);
   void *recv_user_data;
+
+  grpc_iomgr_closure kill_zombie_closure;
 
   call_data **root[CALL_LIST_COUNT];
   call_link links[CALL_LIST_COUNT];
@@ -306,9 +308,9 @@ static void destroy_channel(channel_data *chand) {
   GPR_ASSERT(chand->server != NULL);
   orphan_channel(chand);
   server_ref(chand->server);
-  chand->finish_destroy_channel_iocb.cb = finish_destroy_channel;
-  chand->finish_destroy_channel_iocb.cb_arg = chand;
-  grpc_iomgr_add_callback(&chand->finish_destroy_channel_iocb);
+  chand->finish_destroy_channel_closure.cb = finish_destroy_channel;
+  chand->finish_destroy_channel_closure.cb_arg = chand;
+  grpc_iomgr_add_callback(&chand->finish_destroy_channel_closure);
 }
 
 static void finish_start_new_rpc_and_unlock(grpc_server *server,
@@ -419,29 +421,24 @@ static void server_on_recv(void *ptr, int success) {
     case GRPC_STREAM_RECV_CLOSED:
       gpr_mu_lock(&chand->server->mu);
       if (calld->state == NOT_STARTED) {
-        grpc_iomgr_closure *kill_zombie_closure =
-            gpr_malloc(sizeof(grpc_iomgr_closure));
         calld->state = ZOMBIED;
-        grpc_iomgr_managed_closure_init(kill_zombie_closure, kill_zombie, elem);
-        grpc_iomgr_add_callback(kill_zombie_closure);
+        grpc_iomgr_closure_init(&calld->kill_zombie_closure, kill_zombie, elem);
+        grpc_iomgr_add_callback(&calld->kill_zombie_closure);
       }
       gpr_mu_unlock(&chand->server->mu);
       break;
     case GRPC_STREAM_CLOSED:
       gpr_mu_lock(&chand->server->mu);
       if (calld->state == NOT_STARTED) {
-        grpc_iomgr_closure *kill_zombie_closure =
-            gpr_malloc(sizeof(grpc_iomgr_closure));
         calld->state = ZOMBIED;
-        grpc_iomgr_managed_closure_init(kill_zombie_closure, kill_zombie, elem);
-        grpc_iomgr_add_callback(kill_zombie_closure);
+        grpc_iomgr_closure_init(&calld->kill_zombie_closure, kill_zombie, elem);
+        grpc_iomgr_add_callback(&calld->kill_zombie_closure);
       } else if (calld->state == PENDING) {
-        grpc_iomgr_closure *kill_zombie_closure =
-            gpr_malloc(sizeof(grpc_iomgr_closure));
         call_list_remove(calld, PENDING_START);
         calld->state = ZOMBIED;
-        grpc_iomgr_managed_closure_init(kill_zombie_closure, kill_zombie, elem);
-        grpc_iomgr_add_callback(kill_zombie_closure);
+        grpc_iomgr_closure_init(&calld->kill_zombie_closure, kill_zombie, elem);
+        grpc_iomgr_add_callback(&calld->kill_zombie_closure);
+
       }
       gpr_mu_unlock(&chand->server->mu);
       break;
@@ -515,9 +512,9 @@ static void finish_shutdown_channel(void *cd, int success) {
 
 static void shutdown_channel(channel_data *chand) {
   grpc_channel_internal_ref(chand->channel);
-  chand->finish_shutdown_channel_iocb.cb = finish_shutdown_channel;
-  chand->finish_shutdown_channel_iocb.cb_arg = chand;
-  grpc_iomgr_add_callback(&chand->finish_shutdown_channel_iocb);
+  chand->finish_shutdown_channel_closure.cb = finish_shutdown_channel;
+  chand->finish_shutdown_channel_closure.cb_arg = chand;
+  grpc_iomgr_add_callback(&chand->finish_shutdown_channel_closure);
 }
 
 static void init_call_elem(grpc_call_element *elem,
@@ -958,14 +955,12 @@ void grpc_server_destroy(grpc_server *server) {
     /* TODO(dgq): If we knew the size of the call list (or an upper bound), we
      * could allocate all the memory for the closures in advance in a single
      * chunk */
-    grpc_iomgr_closure *kill_zombie_closure =
-        gpr_malloc(sizeof(grpc_iomgr_closure));
     gpr_log(GPR_DEBUG, "server destroys call %p", calld->call);
     calld->state = ZOMBIED;
-    grpc_iomgr_managed_closure_init(
-        kill_zombie_closure, kill_zombie,
+    grpc_iomgr_closure_init(
+        &calld->kill_zombie_closure, kill_zombie,
         grpc_call_stack_element(grpc_call_get_call_stack(calld->call), 0));
-    grpc_iomgr_add_callback(kill_zombie_closure);
+    grpc_iomgr_add_callback(&calld->kill_zombie_closure);
   }
 
   for (c = server->root_channel_data.next; c != &server->root_channel_data;

--- a/test/core/iomgr/alarm_test.c
+++ b/test/core/iomgr/alarm_test.c
@@ -55,6 +55,7 @@ void no_op_cb(void *arg, int success) {}
 typedef struct {
   gpr_cv cv;
   gpr_mu mu;
+  grpc_iomgr_closure *iocb;
   int counter;
   int done_success_ctr;
   int done_cancel_ctr;
@@ -81,7 +82,10 @@ static void alarm_cb(void *arg /* alarm_arg */, int success) {
   a->success = success;
   gpr_cv_signal(&a->cv);
   gpr_mu_unlock(&a->mu);
-  grpc_iomgr_add_callback(followup_cb, &a->fcb_arg);
+  a->iocb->cb = followup_cb;
+  a->iocb->cb_arg = &a->fcb_arg;
+  a->iocb->is_ext_managed = 1;
+  grpc_iomgr_add_callback(a->iocb);
 }
 
 /* Test grpc_alarm add and cancel. */
@@ -107,6 +111,7 @@ static void test_grpc_alarm(void) {
   arg.done = 0;
   gpr_mu_init(&arg.mu);
   gpr_cv_init(&arg.cv);
+  arg.iocb = gpr_malloc(sizeof(grpc_iomgr_closure));
   gpr_event_init(&arg.fcb_arg);
 
   grpc_alarm_init(&alarm, GRPC_TIMEOUT_MILLIS_TO_DEADLINE(100), alarm_cb, &arg,
@@ -148,6 +153,7 @@ static void test_grpc_alarm(void) {
   }
   gpr_cv_destroy(&arg.cv);
   gpr_mu_destroy(&arg.mu);
+  gpr_free(arg.iocb);
 
   arg2.counter = 0;
   arg2.success = SUCCESS_NOT_SET;
@@ -156,6 +162,8 @@ static void test_grpc_alarm(void) {
   arg2.done = 0;
   gpr_mu_init(&arg2.mu);
   gpr_cv_init(&arg2.cv);
+  arg2.iocb = gpr_malloc(sizeof(grpc_iomgr_closure));
+
   gpr_event_init(&arg2.fcb_arg);
 
   grpc_alarm_init(&alarm_to_cancel, GRPC_TIMEOUT_MILLIS_TO_DEADLINE(100),
@@ -206,6 +214,7 @@ static void test_grpc_alarm(void) {
   }
   gpr_cv_destroy(&arg2.cv);
   gpr_mu_destroy(&arg2.mu);
+  gpr_free(arg2.iocb);
 
   grpc_iomgr_shutdown();
 }


### PR DESCRIPTION
This is a tentative (see discussion below) pull request for the modification of the way the iomgr deals with callbacks.

In particular, the allocation of the callback (now exposed and called grpc_iomgr_cb) is the responsibility of the iomgr user. In some cases, this allows the user to reduce the number of mallocs and/or group them into single chunk.

**Discussion**: In instances where it isn't possible to anticipate the number of necesary callback allocations,  the callback needs to be allocated "in situ" right before passing it over to the iomgr. The release of these allocations is currently performed conditionally inside iomgr (depending on whether the callback has been marked as "externally managed"). 
The alternative is to make the deallocation part of the callback itself. However, this introduces a non trivial amount of complexity due to not always having control over the callback function. For instance, fd_posix.c:notify_on creates a callback whose function comes from the outside (closure->cb). In other cases, even when we have access to the callback function, such as credentials.c:on_simulated_token_fetch_done, they'd have to be modified to receive a pointer to its enclosing grpc_iomgr_cb. 
Both these scenarios can be addressed by creating wrapper around callbacks that'd run whichever callback function and then free itself. However, a functionally equivalent approach is have the iomgr conditionally free(), as described.

