### PR TITLE
Fix for changed parseFromData: signature (now parseFromData:error:)

### DIFF
--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -59,7 +59,7 @@
                responseClass:(Class)responseClass
           responsesWriteable:(id<GRXWriteable>)responsesWriteable {
   // Because we can't tell the type system to constrain the class, we need to check at runtime:
-  if (![responseClass respondsToSelector:@selector(parseFromData:)]) {
+  if (![responseClass respondsToSelector:@selector(parseFromData:error:)]) {
     [NSException raise:NSInvalidArgumentException
                 format:@"A protobuf class to parse the responses must be provided."];
   }
@@ -71,7 +71,7 @@
   if ((self = [super initWithHost:host method:method requestsWriter:bytesWriter])) {
     // A writeable that parses the proto messages received.
     _responseWriteable = [[GRXWriteable alloc] initWithValueHandler:^(NSData *value) {
-      [responsesWriteable writeValue:[responseClass parseFromData:value]];
+      [responsesWriteable writeValue:[responseClass parseFromData:value error:NULL]];
     } completionHandler:^(NSError *errorOrNil) {
       [responsesWriteable writesFinishedWithError:errorOrNil];
     }];

--- a/src/objective-c/examples/Sample/Sample/ViewController.m
+++ b/src/objective-c/examples/Sample/Sample/ViewController.m
@@ -80,7 +80,7 @@
                                    requestsWriter:requestsWriter];
 
   id<GRXWriteable> responsesWriteable = [[GRXWriteable alloc] initWithValueHandler:^(NSData *value) {
-    RMTSimpleResponse *response = [RMTSimpleResponse parseFromData:value];
+    RMTSimpleResponse *response = [RMTSimpleResponse parseFromData:value error:NULL];
     NSLog(@"Received response:\n%@", response);
   } completionHandler:^(NSError *errorOrNil) {
     if (errorOrNil) {

--- a/src/objective-c/examples/Sample/SampleTests/RemoteTests.m
+++ b/src/objective-c/examples/Sample/SampleTests/RemoteTests.m
@@ -125,7 +125,7 @@
     XCTAssertNotNil(value, @"nil value received as response.");
     [response fulfill];
     XCTAssertGreaterThan(value.length, 0, @"Empty response received.");
-    RMTSimpleResponse *response = [RMTSimpleResponse parseFromData:value];
+    RMTSimpleResponse *response = [RMTSimpleResponse parseFromData:value error:NULL];
     // We expect empty strings, not nil:
     XCTAssertNotNil(response.username, @"Response's username is nil.");
     XCTAssertNotNil(response.oauthScope, @"Response's OAuth scope is nil.");

--- a/src/objective-c/examples/Sample/SampleTests/SampleTests.m
+++ b/src/objective-c/examples/Sample/SampleTests/SampleTests.m
@@ -123,7 +123,7 @@
 
   id<GRXWriteable> responsesWriteable = [[GRXWriteable alloc] initWithValueHandler:^(NSData *value) {
     XCTAssertNotNil(value, @"nil value received as response.");
-    RGDFeature *feature = [RGDFeature parseFromData:value];
+    RGDFeature *feature = [RGDFeature parseFromData:value error:NULL];
     XCTAssertEqualObjects(point, feature.location);
     XCTAssertNotNil(feature.name, @"Response's name is nil.");
     [response fulfill];


### PR DESCRIPTION
Hi! Looks like GPBMessage.h changed, I've updated the gRPC code to reflect this.

