### PR TITLE
Adding 2 helper build scripts to allow docker images to be built

### DIFF
--- a/tools/dockerfile/grpc_csharp_mono/build.sh
+++ b/tools/dockerfile/grpc_csharp_mono/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cp -R /var/local/git-clone/grpc /var/local/git
+
+make install_grpc_csharp_ext -j12 -C /var/local/git/grpc
+
+cd /var/local/git/grpc/src/csharp && mono /var/local/NuGet.exe restore Grpc.sln
+
+cd /var/local/git/grpc/src/csharp && xbuild Grpc.sln
+

--- a/tools/dockerfile/grpc_php/build.sh
+++ b/tools/dockerfile/grpc_php/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+cp -R /var/local/git-clone/grpc /var/local/git
+
+make clean -C /var/local/git/grpc
+
+make install_c -j12 -C /var/local/git/grpc
+
+cd /var/local/git/grpc/src/php/ext/grpc && git pull && phpize
+
+cd /var/local/git/grpc/src/php/ext/grpc \
+  && ./configure \
+  && make
+
+cd /var/local/git/grpc/src/php && composer install
+
+cd /var/local/git/grpc/src/php && protoc-gen-php -i tests/interop/ -o tests/interop/ tests/interop/test.proto
+


### PR DESCRIPTION
from local repositories.

Framework is already set up in private_build_and_test.sh; helper build script
is needed for each langauge.