### PR TITLE
PHP: add composer.json to top level for packagist submission

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+  "name": "grpc/grpc",
+  "type": "library",
+  "description": "gRPC library for PHP",
+  "keywords": ["rpc"],
+  "homepage": "http://grpc.io",
+  "license": "BSD-3-Clause",
+  "require": {
+    "php": ">=5.5.0",
+    "google/auth": "dev-master"
+  },
+  "autoload": {
+    "psr-4": {
+      "Grpc\\": "src/php/lib/Grpc/"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1788 

In order to submit our PHP code to the [Packagist](https://packagist.org) repository, the github repo has to have a `composer.json` file at the top level. Packagist does not allow a package submission with the `composer.json` in a sub-folder (for us, under `src/php`), nor allow us to submit a .zip file.

After exploring a few options / workarounds (for internal folks, please see the doc under gRPC > Install-Distro > PHP Packaging issues for more details), we have decided to add a `composer.json` file to the top level so that we can submit our repo to Packagist.