### PR TITLE
Set verbosity to 2 for Python tests

### DIFF
--- a/src/python/interop/interop/_insecure_interop_test.py
+++ b/src/python/interop/interop/_insecure_interop_test.py
@@ -54,4 +54,4 @@ class InsecureInteropTest(
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/interop/interop/_secure_interop_test.py
+++ b/src/python/interop/interop/_secure_interop_test.py
@@ -61,4 +61,4 @@ class SecureInteropTest(
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/src/grpc/_adapter/_blocking_invocation_inline_service_test.py
+++ b/src/python/src/grpc/_adapter/_blocking_invocation_inline_service_test.py
@@ -43,4 +43,4 @@ class BlockingInvocationInlineServiceTest(
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/src/grpc/_adapter/_c_test.py
+++ b/src/python/src/grpc/_adapter/_c_test.py
@@ -216,4 +216,4 @@ class _CTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/src/grpc/_adapter/_event_invocation_synchronous_event_service_test.py
+++ b/src/python/src/grpc/_adapter/_event_invocation_synchronous_event_service_test.py
@@ -43,4 +43,4 @@ class EventInvocationSynchronousEventServiceTest(
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/src/grpc/_adapter/_future_invocation_asynchronous_event_service_test.py
+++ b/src/python/src/grpc/_adapter/_future_invocation_asynchronous_event_service_test.py
@@ -43,4 +43,4 @@ class FutureInvocationAsynchronousEventServiceTest(
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/src/grpc/_adapter/_links_test.py
+++ b/src/python/src/grpc/_adapter/_links_test.py
@@ -274,4 +274,4 @@ class RoundTripTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/src/grpc/_adapter/_lonely_rear_link_test.py
+++ b/src/python/src/grpc/_adapter/_lonely_rear_link_test.py
@@ -97,4 +97,4 @@ class LonelyRearLinkTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/src/grpc/_adapter/_low_test.py
+++ b/src/python/src/grpc/_adapter/_low_test.py
@@ -412,4 +412,4 @@ class ExpirationTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/src/grpc/early_adopter/implementations_test.py
+++ b/src/python/src/grpc/early_adopter/implementations_test.py
@@ -177,4 +177,4 @@ class EarlyAdopterImplementationsTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/src/grpc/framework/base/implementations_test.py
+++ b/src/python/src/grpc/framework/base/implementations_test.py
@@ -77,4 +77,4 @@ class ImplementationsTest(
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/src/grpc/framework/face/blocking_invocation_inline_service_test.py
+++ b/src/python/src/grpc/framework/face/blocking_invocation_inline_service_test.py
@@ -43,4 +43,4 @@ class BlockingInvocationInlineServiceTest(
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/src/grpc/framework/face/event_invocation_synchronous_event_service_test.py
+++ b/src/python/src/grpc/framework/face/event_invocation_synchronous_event_service_test.py
@@ -43,4 +43,4 @@ class EventInvocationSynchronousEventServiceTest(
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/src/grpc/framework/face/future_invocation_asynchronous_event_service_test.py
+++ b/src/python/src/grpc/framework/face/future_invocation_asynchronous_event_service_test.py
@@ -43,4 +43,4 @@ class FutureInvocationAsynchronousEventServiceTest(
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/src/grpc/framework/foundation/_later_test.py
+++ b/src/python/src/grpc/framework/foundation/_later_test.py
@@ -148,4 +148,4 @@ class LaterTest(unittest.TestCase):
       self.assertEqual(return_value, future_passed_to_callback_cell[0].result())
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/src/python/src/grpc/framework/foundation/_logging_pool_test.py
+++ b/src/python/src/grpc/framework/foundation/_logging_pool_test.py
@@ -61,4 +61,4 @@ class LoggingPoolTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-  unittest.main()
+  unittest.main(verbosity=2)

--- a/test/compiler/python_plugin_test.py
+++ b/test/compiler/python_plugin_test.py
@@ -520,4 +520,4 @@ class PythonPluginTest(unittest.TestCase):
 
 if __name__ == '__main__':
   os.chdir(os.path.dirname(sys.argv[0]))
-  unittest.main()
+  unittest.main(verbosity=2)


### PR DESCRIPTION
Fixes #1762.

Will catch-up in #1558 later...