### PR TITLE
gRPC C# nuget package fixes

### DIFF
--- a/src/csharp/Grpc.Tools.nuspec
+++ b/src/csharp/Grpc.Tools.nuspec
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package>
+  <metadata>
+    <id>Grpc.Tools</id>
+    <title>gRPC C# Tools</title>
+    <summary>Tools for C# implementation of gRPC - an RPC library and framework</summary>
+    <description>Precompiled Windows binaries for generating protocol buffer messages and gRPC client/server code</description>
+    <version>0.5.0</version>
+    <authors>Google Inc.</authors>
+    <owners>grpc-packages</owners>
+    <licenseUrl>https://github.com/grpc/grpc/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/grpc/grpc</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes>protoc.exe - protocol buffer compiler v3.0.0-alpha-3; grpc_csharp_plugin.exe - gRPC C# protoc plugin version 0.5.0</releaseNotes>
+    <copyright>Copyright 2015, Google Inc.</copyright>
+    <tags>gRPC RPC Protocol HTTP/2</tags>
+  </metadata>
+  <files>
+    <file src="protoc.exe" target="tools" />
+    <file src="grpc_csharp_plugin.exe" target="tools" />
+  </files>
+</package>

--- a/src/csharp/Grpc.nuspec
+++ b/src/csharp/Grpc.nuspec
@@ -5,7 +5,7 @@
     <title>gRPC C#</title>
     <summary>C# implementation of gRPC - an RPC library and framework</summary>
     <description>C# implementation of gRPC - an RPC library and framework. See project site for more info.</description>
-    <version>0.5.0</version>
+    <version>0.5.0.1</version>
     <authors>Google Inc.</authors>
     <owners>grpc-packages</owners>
     <licenseUrl>https://github.com/grpc/grpc/blob/master/LICENSE</licenseUrl>
@@ -18,8 +18,5 @@
       <dependency id="Grpc.Core" version="0.5.0" />
     </dependencies>
   </metadata>
-  <files>
-     <file src="protoc.exe" target="tools" />
-	 <file src="grpc_csharp_plugin.exe" target="tools" />
-  </files>
+  <files/>
 </package>

--- a/src/csharp/build_packages.bat
+++ b/src/csharp/build_packages.bat
@@ -13,6 +13,7 @@ endlocal
 %NUGET% pack ..\..\vsprojects\nuget_package\grpc.native.csharp_ext.nuspec || goto :error
 %NUGET% pack Grpc.Core\Grpc.Core.nuspec -Symbols || goto :error
 %NUGET% pack Grpc.Auth\Grpc.Auth.nuspec -Symbols || goto :error
+%NUGET% pack Grpc.Tools.nuspec || goto :error
 %NUGET% pack Grpc.nuspec || goto :error
 
 goto :EOF


### PR DESCRIPTION
Put tools into a separate package Grpc.Tools. Because of http://nuget.codeplex.com/workitem/595,
Grpc package itself cannot contain tools.

Fixes #1813