### PR TITLE
Fix podspec example in README to work with dir hierarchies

### DIFF
--- a/src/objective-c/README.md
+++ b/src/objective-c/README.md
@@ -50,13 +50,15 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.8'
 
   s.subspec 'Messages' do |ms|
-    ms.source_files = '*.pbobjc.{h,m}'
+    ms.source_files = '*.pbobjc.{h,m}', '**/*.pbobjc.{h,m}'
+    ms.header_mappings_dir = '.'
     ms.requires_arc = false
     ms.dependency 'Protobuf', '~> 3.0'
   end
 
   s.subspec 'Services' do |ss|
-    ss.source_files = '*.pbrpc.{h,m}'
+    ss.source_files = '*.pbrpc.{h,m}', '**/*.pbrpc.{h,m}'
+    ss.header_mappings_dir = '.'
     ss.requires_arc = true
     ss.dependency 'gRPC', '~> 0.0'
     ss.dependency '<Podspec file name>/Messages'


### PR DESCRIPTION
Because the sample protos were all in a flat directory, I hadn't noticed the issue. @marcwan ran into it while generating files for his API.