### PR TITLE
Use class names for types as generated by the messages plugin

### DIFF
--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -32,19 +32,20 @@
  */
 
 #include <map>
+#include <sstream>
 
+#include "src/compiler/config.h"
 #include "src/compiler/objective_c_generator.h"
 #include "src/compiler/objective_c_generator_helpers.h"
 
-#include "src/compiler/config.h"
+#include <google/protobuf/compiler/objectivec/objectivec_helpers.h>
 
-#include <sstream>
-
+using ::google::protobuf::compiler::objectivec::ClassName;
 using ::grpc::protobuf::io::Printer;
 using ::grpc::protobuf::MethodDescriptor;
 using ::grpc::protobuf::ServiceDescriptor;
-using ::std::map;
 using ::grpc::string;
+using ::std::map;
 
 namespace grpc_objective_c_generator {
 namespace {
@@ -69,7 +70,7 @@ void PrintMethodSignature(Printer *printer,
   if (method->client_streaming()) {
     printer->Print("RequestsWriter:(id<GRXWriter>)request");
   } else {
-    printer->Print(vars, "Request:($prefix$$request_type$ *)request");
+    printer->Print(vars, "Request:($request_class$ *)request");
   }
 
   // TODO(jcanizales): Put this on a new line and align colons.
@@ -78,8 +79,7 @@ void PrintMethodSignature(Printer *printer,
   if (method->server_streaming()) {
     printer->Print("BOOL done, ");
   }
-  printer->Print(vars,
-      "$prefix$$response_type$ *response, NSError *error))handler");
+  printer->Print(vars, "$response_class$ *response, NSError *error))handler");
 }
 
 void PrintSimpleSignature(Printer *printer,
@@ -99,12 +99,17 @@ void PrintAdvancedSignature(Printer *printer,
   PrintMethodSignature(printer, method, vars);
 }
 
+inline map<string, string> GetMethodVars(const MethodDescriptor *method) {
+  return {{ "method_name", method->name() },
+          { "request_type", method->input_type()->name() },
+          { "response_type", method->output_type()->name() },
+          { "request_class", ClassName(method->input_type()) },
+          { "response_class", ClassName(method->output_type()) }};
+}
+
 void PrintMethodDeclarations(Printer *printer,
-                             const MethodDescriptor *method,
-                             map<string, string> vars) {
-  vars["method_name"] = method->name();
-  vars["request_type"] = method->input_type()->name();
-  vars["response_type"] = method->output_type()->name();
+                             const MethodDescriptor *method) {
+  map<string, string> vars = GetMethodVars(method);
 
   PrintProtoRpcDeclarationAsPragma(printer, method, vars);
 
@@ -141,8 +146,7 @@ void PrintAdvancedImplementation(Printer *printer,
     printer->Print("[GRXWriter writerWithValue:request]\n");
   }
 
-  printer->Print(vars,
-      "             responseClass:[$prefix$$response_type$ class]\n");
+  printer->Print(vars, "             responseClass:[$response_class$ class]\n");
 
   printer->Print("        responsesWriteable:[GRXWriteable ");
   if (method->server_streaming()) {
@@ -155,11 +159,8 @@ void PrintAdvancedImplementation(Printer *printer,
 }
 
 void PrintMethodImplementations(Printer *printer,
-                                const MethodDescriptor *method,
-                                map<string, string> vars) {
-  vars["method_name"] = method->name();
-  vars["request_type"] = method->input_type()->name();
-  vars["response_type"] = method->output_type()->name();
+                                const MethodDescriptor *method) {
+  map<string, string> vars = GetMethodVars(method);
 
   PrintProtoRpcDeclarationAsPragma(printer, method, vars);
 
@@ -174,7 +175,7 @@ void PrintMethodImplementations(Printer *printer,
 
 } // namespace
 
-string GetHeader(const ServiceDescriptor *service, const string prefix) {
+string GetHeader(const ServiceDescriptor *service) {
   string output;
   {
     // Scope the output stream so it closes and finalizes output to the string.
@@ -184,19 +185,19 @@ string GetHeader(const ServiceDescriptor *service, const string prefix) {
     printer.Print("@protocol GRXWriteable;\n");
     printer.Print("@protocol GRXWriter;\n\n");
 
-    map<string, string> vars = {{"service_name", service->name()},
-                                {"prefix",       prefix}};
-    printer.Print(vars, "@protocol $prefix$$service_name$ <NSObject>\n\n");
+    map<string, string> vars = {{"service_class", ServiceClassName(service)}};
+
+    printer.Print(vars, "@protocol $service_class$ <NSObject>\n\n");
 
     for (int i = 0; i < service->method_count(); i++) {
-      PrintMethodDeclarations(&printer, service->method(i), vars);
+      PrintMethodDeclarations(&printer, service->method(i));
     }
     printer.Print("@end\n\n");
 
     printer.Print("// Basic service implementation, over gRPC, that only does"
         " marshalling and parsing.\n");
-    printer.Print(vars, "@interface $prefix$$service_name$ :"
-      " ProtoService<$prefix$$service_name$>\n");
+    printer.Print(vars, "@interface $service_class$ :"
+      " ProtoService<$service_class$>\n");
     printer.Print("- (instancetype)initWithHost:(NSString *)host"
       " NS_DESIGNATED_INITIALIZER;\n");
     printer.Print("@end\n");
@@ -204,7 +205,7 @@ string GetHeader(const ServiceDescriptor *service, const string prefix) {
   return output;
 }
 
-string GetSource(const ServiceDescriptor *service, const string prefix) {
+string GetSource(const ServiceDescriptor *service) {
   string output;
   {
     // Scope the output stream so it closes and finalizes output to the string.
@@ -212,15 +213,15 @@ string GetSource(const ServiceDescriptor *service, const string prefix) {
     Printer printer(&output_stream, '$');
 
     map<string, string> vars = {{"service_name", service->name()},
-                                {"package", service->file()->package()},
-                                {"prefix",       prefix}};
+                                {"service_class", ServiceClassName(service)},
+                                {"package", service->file()->package()}};
 
     printer.Print(vars,
         "static NSString *const kPackageName = @\"$package$\";\n");
     printer.Print(vars,
         "static NSString *const kServiceName = @\"$service_name$\";\n\n");
 
-    printer.Print(vars, "@implementation $prefix$$service_name$\n\n");
+    printer.Print(vars, "@implementation $service_class$\n\n");
   
     printer.Print("// Designated initializer\n");
     printer.Print("- (instancetype)initWithHost:(NSString *)host {\n");
@@ -236,7 +237,7 @@ string GetSource(const ServiceDescriptor *service, const string prefix) {
     printer.Print("}\n\n\n");
 
     for (int i = 0; i < service->method_count(); i++) {
-      PrintMethodImplementations(&printer, service->method(i), vars);
+      PrintMethodImplementations(&printer, service->method(i));
     }
 
     printer.Print("@end\n");

--- a/src/compiler/objective_c_generator.h
+++ b/src/compiler/objective_c_generator.h
@@ -38,15 +38,16 @@
 
 namespace grpc_objective_c_generator {
 
+using ::grpc::protobuf::ServiceDescriptor;
+using ::grpc::string;
+
 // Returns the content to be included in the "global_scope" insertion point of
 // the generated header file.
-grpc::string GetHeader(const grpc::protobuf::ServiceDescriptor *service,
-                       const grpc::string prefix);
+string GetHeader(const ServiceDescriptor *service);
 
 // Returns the content to be included in the "global_scope" insertion point of
 // the generated implementation file.
-grpc::string GetSource(const grpc::protobuf::ServiceDescriptor *service,
-                       const grpc::string prefix);
+string GetSource(const ServiceDescriptor *service);
 
 }  // namespace grpc_objective_c_generator
 

--- a/src/compiler/objective_c_generator_helpers.h
+++ b/src/compiler/objective_c_generator_helpers.h
@@ -40,8 +40,18 @@
 
 namespace grpc_objective_c_generator {
 
-inline grpc::string MessageHeaderName(const grpc::protobuf::FileDescriptor *file) {
+using ::grpc::protobuf::FileDescriptor;
+using ::grpc::protobuf::ServiceDescriptor;
+using ::grpc::string;
+
+inline string MessageHeaderName(const FileDescriptor *file) {
   return grpc_generator::FileNameInUpperCamel(file) + ".pbobjc.h";
+}
+
+inline string ServiceClassName(const ServiceDescriptor *service) {
+  const FileDescriptor *file = service->file();
+  string prefix = file->options().objc_class_prefix();
+  return prefix + service->name();
 }
 
 }

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -77,7 +77,7 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
       string declarations;
       for (int i = 0; i < file->service_count(); i++) {
         const grpc::protobuf::ServiceDescriptor *service = file->service(i);
-        declarations += grpc_objective_c_generator::GetHeader(service, prefix);
+        declarations += grpc_objective_c_generator::GetHeader(service);
       }
 
       Write(context, file_name + ".pbrpc.h",
@@ -95,7 +95,7 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
       string definitions;
       for (int i = 0; i < file->service_count(); i++) {
         const grpc::protobuf::ServiceDescriptor *service = file->service(i);
-        definitions += grpc_objective_c_generator::GetSource(service, prefix);
+        definitions += grpc_objective_c_generator::GetSource(service);
       }
 
       Write(context, file_name + ".pbrpc.m", imports + '\n' + definitions);


### PR DESCRIPTION
Tested by assigning different prefixes to each of empty.proto, messages.proto and test.proto. The generated files use the correct prefixes instead of only test.proto's.