### PR TITLE
Avoid polluting our compilation with previously installed grpc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,8 @@ LDFLAGS += -fPIC
 endif
 
 INCLUDES = . include $(GENDIR)
+LDFLAGS += -Llibs/$(CONFIG)
+
 ifeq ($(SYSTEM),Darwin)
 ifneq ($(wildcard /usr/local/ssl/include),)
 INCLUDES += /usr/local/ssl/include

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -276,6 +276,8 @@ LDFLAGS += -fPIC
 endif
 
 INCLUDES = . include $(GENDIR)
+LDFLAGS += -Llibs/$(CONFIG)
+
 ifeq ($(SYSTEM),Darwin)
 ifneq ($(wildcard /usr/local/ssl/include),)
 INCLUDES += /usr/local/ssl/include


### PR DESCRIPTION
Fixes #1849, I think.