### PR TITLE
Removed grpc_byte_buffer_reader_{create,destroy}.

### DIFF
--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -170,14 +170,15 @@ void grpc_byte_buffer_destroy(grpc_byte_buffer *byte_buffer);
 struct grpc_byte_buffer_reader;
 typedef struct grpc_byte_buffer_reader grpc_byte_buffer_reader;
 
-grpc_byte_buffer_reader *grpc_byte_buffer_reader_create(
-    grpc_byte_buffer *buffer);
+/** Initialize \a reader to read over \a buffer */
+void grpc_byte_buffer_reader_init(grpc_byte_buffer_reader *reader,
+                                  grpc_byte_buffer *buffer);
+
 /* At the end of the stream, returns 0. Otherwise, returns 1 and sets slice to
    be the returned slice. Caller is responsible for calling gpr_slice_unref on
    the result. */
 int grpc_byte_buffer_reader_next(grpc_byte_buffer_reader *reader,
                                  gpr_slice *slice);
-void grpc_byte_buffer_reader_destroy(grpc_byte_buffer_reader *reader);
 
 /* A single metadata element */
 typedef struct grpc_metadata {

--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -93,7 +93,7 @@ typedef struct {
 } grpc_arg;
 
 /** An array of arguments that can be passed around.
-    
+
     Used to set optional channel-level configuration.
     These configuration options are modelled as key-value pairs as defined
     by grpc_arg; keys are strings to allow easy backwards-compatible extension
@@ -173,6 +173,9 @@ typedef struct grpc_byte_buffer_reader grpc_byte_buffer_reader;
 /** Initialize \a reader to read over \a buffer */
 void grpc_byte_buffer_reader_init(grpc_byte_buffer_reader *reader,
                                   grpc_byte_buffer *buffer);
+
+/** Cleanup and destroy \a reader */
+void grpc_byte_buffer_reader_destroy(grpc_byte_buffer_reader *reader);
 
 /* At the end of the stream, returns 0. Otherwise, returns 1 and sets slice to
    be the returned slice. Caller is responsible for calling gpr_slice_unref on

--- a/src/core/surface/byte_buffer_reader.c
+++ b/src/core/surface/byte_buffer_reader.c
@@ -48,6 +48,11 @@ void grpc_byte_buffer_reader_init(grpc_byte_buffer_reader *reader,
   }
 }
 
+void grpc_byte_buffer_reader_destroy(grpc_byte_buffer_reader *reader) {
+  /* no-op: the user is responsible for memory deallocation.
+   * Other cleanup operations would go here if needed. */
+}
+
 int grpc_byte_buffer_reader_next(grpc_byte_buffer_reader *reader,
                                  gpr_slice *slice) {
   grpc_byte_buffer *buffer = reader->buffer;

--- a/src/core/surface/byte_buffer_reader.c
+++ b/src/core/surface/byte_buffer_reader.c
@@ -39,15 +39,13 @@
 #include <grpc/support/slice_buffer.h>
 #include <grpc/byte_buffer.h>
 
-grpc_byte_buffer_reader *grpc_byte_buffer_reader_create(
-    grpc_byte_buffer *buffer) {
-  grpc_byte_buffer_reader *reader = malloc(sizeof(grpc_byte_buffer_reader));
+void grpc_byte_buffer_reader_init(grpc_byte_buffer_reader *reader,
+                                  grpc_byte_buffer *buffer) {
   reader->buffer = buffer;
   switch (buffer->type) {
     case GRPC_BB_SLICE_BUFFER:
       reader->current.index = 0;
   }
-  return reader;
 }
 
 int grpc_byte_buffer_reader_next(grpc_byte_buffer_reader *reader,
@@ -67,8 +65,4 @@ int grpc_byte_buffer_reader_next(grpc_byte_buffer_reader *reader,
       break;
   }
   return 0;
-}
-
-void grpc_byte_buffer_reader_destroy(grpc_byte_buffer_reader *reader) {
-  free(reader);
 }

--- a/src/cpp/proto/proto_utils.cc
+++ b/src/cpp/proto/proto_utils.cc
@@ -36,6 +36,7 @@
 
 #include <grpc/grpc.h>
 #include <grpc/byte_buffer.h>
+#include <grpc/byte_buffer_reader.h>
 #include <grpc/support/slice.h>
 #include <grpc/support/slice_buffer.h>
 #include <grpc/support/port_platform.h>
@@ -100,11 +101,9 @@ class GrpcBufferReader GRPC_FINAL
  public:
   explicit GrpcBufferReader(grpc_byte_buffer* buffer)
       : byte_count_(0), backup_count_(0) {
-    reader_ = grpc_byte_buffer_reader_create(buffer);
+    grpc_byte_buffer_reader_init(&reader_, buffer);
   }
-  ~GrpcBufferReader() GRPC_OVERRIDE {
-    grpc_byte_buffer_reader_destroy(reader_);
-  }
+  ~GrpcBufferReader() GRPC_OVERRIDE {}
 
   bool Next(const void** data, int* size) GRPC_OVERRIDE {
     if (backup_count_ > 0) {
@@ -114,7 +113,7 @@ class GrpcBufferReader GRPC_FINAL
       backup_count_ = 0;
       return true;
     }
-    if (!grpc_byte_buffer_reader_next(reader_, &slice_)) {
+    if (!grpc_byte_buffer_reader_next(&reader_, &slice_)) {
       return false;
     }
     gpr_slice_unref(slice_);
@@ -147,7 +146,7 @@ class GrpcBufferReader GRPC_FINAL
  private:
   gpr_int64 byte_count_;
   gpr_int64 backup_count_;
-  grpc_byte_buffer_reader* reader_;
+  grpc_byte_buffer_reader reader_;
   gpr_slice slice_;
 };
 

--- a/src/cpp/util/byte_buffer.cc
+++ b/src/cpp/util/byte_buffer.cc
@@ -31,6 +31,7 @@
  *
  */
 
+#include <grpc/byte_buffer_reader.h>
 #include <grpc++/byte_buffer.h>
 
 namespace grpc {
@@ -56,12 +57,12 @@ void ByteBuffer::Dump(std::vector<Slice>* slices) {
   if (!buffer_) {
     return;
   }
-  grpc_byte_buffer_reader* reader = grpc_byte_buffer_reader_create(buffer_);
+  grpc_byte_buffer_reader reader;
+  grpc_byte_buffer_reader_init(&reader,buffer_);
   gpr_slice s;
-  while (grpc_byte_buffer_reader_next(reader, &s)) {
+  while (grpc_byte_buffer_reader_next(&reader, &s)) {
     slices->push_back(Slice(s, Slice::STEAL_REF));
   }
-  grpc_byte_buffer_reader_destroy(reader);
 }
 
 size_t ByteBuffer::Length() {

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -33,6 +33,7 @@
 
 #include "src/core/support/string.h"
 
+#include <grpc/byte_buffer_reader.h>
 #include <grpc/support/port_platform.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -236,13 +237,13 @@ GPR_EXPORT gpr_intptr GPR_CALLTYPE grpcsharp_batch_context_recv_message_length(
  */
 GPR_EXPORT void GPR_CALLTYPE grpcsharp_batch_context_recv_message_to_buffer(
     const grpcsharp_batch_context *ctx, char *buffer, size_t buffer_len) {
-  grpc_byte_buffer_reader *reader;
+  grpc_byte_buffer_reader reader;
   gpr_slice slice;
   size_t offset = 0;
 
-  reader = grpc_byte_buffer_reader_create(ctx->recv_message);
+  grpc_byte_buffer_reader_init(&reader, ctx->recv_message);
 
-  while (grpc_byte_buffer_reader_next(reader, &slice)) {
+  while (grpc_byte_buffer_reader_next(&reader, &slice)) {
     size_t len = GPR_SLICE_LENGTH(slice);
     GPR_ASSERT(offset + len <= buffer_len);
     memcpy(buffer + offset, GPR_SLICE_START_PTR(slice),
@@ -250,7 +251,6 @@ GPR_EXPORT void GPR_CALLTYPE grpcsharp_batch_context_recv_message_to_buffer(
     offset += len;
     gpr_slice_unref(slice);
   }
-  grpc_byte_buffer_reader_destroy(reader);
 }
 
 GPR_EXPORT grpc_status_code GPR_CALLTYPE

--- a/src/node/ext/byte_buffer.cc
+++ b/src/node/ext/byte_buffer.cc
@@ -36,6 +36,7 @@
 #include <node.h>
 #include <nan.h>
 #include "grpc/grpc.h"
+#include "grpc/byte_buffer_reader.h"
 #include "grpc/support/slice.h"
 
 #include "byte_buffer.h"
@@ -69,9 +70,10 @@ Handle<Value> ByteBufferToBuffer(grpc_byte_buffer *buffer) {
   size_t length = grpc_byte_buffer_length(buffer);
   char *result = reinterpret_cast<char *>(calloc(length, sizeof(char)));
   size_t offset = 0;
-  grpc_byte_buffer_reader *reader = grpc_byte_buffer_reader_create(buffer);
+  grpc_byte_buffer_reader reader;
+  grpc_byte_buffer_reader_init(&reader, buffer);
   gpr_slice next;
-  while (grpc_byte_buffer_reader_next(reader, &next) != 0) {
+  while (grpc_byte_buffer_reader_next(&reader, &next) != 0) {
     memcpy(result + offset, GPR_SLICE_START_PTR(next), GPR_SLICE_LENGTH(next));
     offset += GPR_SLICE_LENGTH(next);
   }

--- a/src/objective-c/GRPCClient/private/NSData+GRPC.m
+++ b/src/objective-c/GRPCClient/private/NSData+GRPC.m
@@ -34,23 +34,26 @@
 #import "NSData+GRPC.h"
 
 #include <grpc/byte_buffer.h>
+#include <grpc/byte_buffer_reader.h>
 #include <string.h>
 
 // TODO(jcanizales): Move these two incantations to the C library.
 
 static void CopyByteBufferToCharArray(grpc_byte_buffer *buffer, char *array) {
   size_t offset = 0;
-  grpc_byte_buffer_reader *reader = grpc_byte_buffer_reader_create(buffer);
+  grpc_byte_buffer_reader reader;
+  grpc_byte_buffer_reader_init(&reader, buffer);
   gpr_slice next;
-  while (grpc_byte_buffer_reader_next(reader, &next) != 0){
-    memcpy(array + offset, GPR_SLICE_START_PTR(next), (size_t) GPR_SLICE_LENGTH(next));
+  while (grpc_byte_buffer_reader_next(&reader, &next) != 0){
+    memcpy(array + offset, GPR_SLICE_START_PTR(next),
+           (size_t)GPR_SLICE_LENGTH(next));
     offset += GPR_SLICE_LENGTH(next);
     gpr_slice_unref(next);
   }
-  grpc_byte_buffer_reader_destroy(reader);
 }
 
-static grpc_byte_buffer *CopyCharArrayToNewByteBuffer(const char *array, size_t length) {
+static grpc_byte_buffer *CopyCharArrayToNewByteBuffer(const char *array,
+                                                      size_t length) {
   gpr_slice slice = gpr_slice_from_copied_buffer(array, length);
   grpc_byte_buffer *buffer = grpc_byte_buffer_create(&slice, 1);
   gpr_slice_unref(slice);

--- a/src/php/ext/grpc/byte_buffer.c
+++ b/src/php/ext/grpc/byte_buffer.c
@@ -46,6 +46,7 @@
 #include "byte_buffer.h"
 
 #include <grpc/grpc.h>
+#include <grpc/byte_buffer_reader.h>
 #include <grpc/support/slice.h>
 
 grpc_byte_buffer *string_to_byte_buffer(char *string, size_t length) {
@@ -65,9 +66,10 @@ void byte_buffer_to_string(grpc_byte_buffer *buffer, char **out_string,
   size_t length = grpc_byte_buffer_length(buffer);
   char *string = ecalloc(length + 1, sizeof(char));
   size_t offset = 0;
-  grpc_byte_buffer_reader *reader = grpc_byte_buffer_reader_create(buffer);
+  grpc_byte_buffer_reader reader;
+  grpc_byte_buffer_reader_init(&reader, buffer);
   gpr_slice next;
-  while (grpc_byte_buffer_reader_next(reader, &next) != 0) {
+  while (grpc_byte_buffer_reader_next(&reader, &next) != 0) {
     memcpy(string + offset, GPR_SLICE_START_PTR(next), GPR_SLICE_LENGTH(next));
     offset += GPR_SLICE_LENGTH(next);
   }

--- a/src/ruby/ext/grpc/rb_byte_buffer.c
+++ b/src/ruby/ext/grpc/rb_byte_buffer.c
@@ -36,6 +36,7 @@
 #include <ruby/ruby.h>
 
 #include <grpc/grpc.h>
+#include <grpc/byte_buffer_reader.h>
 #include <grpc/support/slice.h>
 #include "rb_grpc.h"
 
@@ -50,7 +51,7 @@ VALUE grpc_rb_byte_buffer_to_s(grpc_byte_buffer *buffer) {
   size_t length = 0;
   char *string = NULL;
   size_t offset = 0;
-  grpc_byte_buffer_reader *reader = NULL;
+  grpc_byte_buffer_reader reader;
   gpr_slice next;
   if (buffer == NULL) {
     return Qnil;
@@ -58,8 +59,8 @@ VALUE grpc_rb_byte_buffer_to_s(grpc_byte_buffer *buffer) {
   }
   length = grpc_byte_buffer_length(buffer);
   string = xmalloc(length + 1);
-  reader = grpc_byte_buffer_reader_create(buffer);
-  while (grpc_byte_buffer_reader_next(reader, &next) != 0) {
+  grpc_byte_buffer_reader_init(&reader, buffer);
+  while (grpc_byte_buffer_reader_next(&reader, &next) != 0) {
     memcpy(string + offset, GPR_SLICE_START_PTR(next), GPR_SLICE_LENGTH(next));
     offset += GPR_SLICE_LENGTH(next);
   }

--- a/test/core/surface/byte_buffer_reader_test.c
+++ b/test/core/surface/byte_buffer_reader_test.c
@@ -46,21 +46,10 @@
 
 #define LOG_TEST(x) gpr_log(GPR_INFO, "%s", x)
 
-static void test_create(void) {
-  grpc_byte_buffer *buffer;
-  grpc_byte_buffer_reader *reader;
-  gpr_slice empty = gpr_empty_slice();
-  LOG_TEST("test_create");
-  buffer = grpc_byte_buffer_create(&empty, 1);
-  reader = grpc_byte_buffer_reader_create(buffer);
-  grpc_byte_buffer_reader_destroy(reader);
-  grpc_byte_buffer_destroy(buffer);
-}
-
 static void test_read_one_slice(void) {
   gpr_slice slice;
   grpc_byte_buffer *buffer;
-  grpc_byte_buffer_reader *reader;
+  grpc_byte_buffer_reader reader;
   gpr_slice first_slice, second_slice;
   int first_code, second_code;
 
@@ -68,21 +57,20 @@ static void test_read_one_slice(void) {
   slice = gpr_slice_from_copied_string("test");
   buffer = grpc_byte_buffer_create(&slice, 1);
   gpr_slice_unref(slice);
-  reader = grpc_byte_buffer_reader_create(buffer);
-  first_code = grpc_byte_buffer_reader_next(reader, &first_slice);
+  grpc_byte_buffer_reader_init(&reader, buffer);
+  first_code = grpc_byte_buffer_reader_next(&reader, &first_slice);
   GPR_ASSERT(first_code != 0);
   GPR_ASSERT(memcmp(GPR_SLICE_START_PTR(first_slice), "test", 4) == 0);
   gpr_slice_unref(first_slice);
-  second_code = grpc_byte_buffer_reader_next(reader, &second_slice);
+  second_code = grpc_byte_buffer_reader_next(&reader, &second_slice);
   GPR_ASSERT(second_code == 0);
-  grpc_byte_buffer_reader_destroy(reader);
   grpc_byte_buffer_destroy(buffer);
 }
 
 static void test_read_one_slice_malloc(void) {
   gpr_slice slice;
   grpc_byte_buffer *buffer;
-  grpc_byte_buffer_reader *reader;
+  grpc_byte_buffer_reader reader;
   gpr_slice first_slice, second_slice;
   int first_code, second_code;
 
@@ -91,20 +79,18 @@ static void test_read_one_slice_malloc(void) {
   memcpy(GPR_SLICE_START_PTR(slice), "test", 4);
   buffer = grpc_byte_buffer_create(&slice, 1);
   gpr_slice_unref(slice);
-  reader = grpc_byte_buffer_reader_create(buffer);
-  first_code = grpc_byte_buffer_reader_next(reader, &first_slice);
+  grpc_byte_buffer_reader_init(&reader, buffer);
+  first_code = grpc_byte_buffer_reader_next(&reader, &first_slice);
   GPR_ASSERT(first_code != 0);
   GPR_ASSERT(memcmp(GPR_SLICE_START_PTR(first_slice), "test", 4) == 0);
   gpr_slice_unref(first_slice);
-  second_code = grpc_byte_buffer_reader_next(reader, &second_slice);
+  second_code = grpc_byte_buffer_reader_next(&reader, &second_slice);
   GPR_ASSERT(second_code == 0);
-  grpc_byte_buffer_reader_destroy(reader);
   grpc_byte_buffer_destroy(buffer);
 }
 
 int main(int argc, char **argv) {
   grpc_test_init(argc, argv);
-  test_create();
   test_read_one_slice();
   test_read_one_slice_malloc();
   return 0;


### PR DESCRIPTION
Introduced grpc_byte_buffer_init instead. It's now the user's responsibility to manage memory.