### PR TITLE
Fixed memory leak in server_async

### DIFF
--- a/include/grpc++/server_context.h
+++ b/include/grpc++/server_context.h
@@ -106,6 +106,10 @@ class ServerContext {
   template <class R, class W>
   friend class ::grpc::ServerReaderWriter;
 
+  // Prevent copying.
+  ServerContext(const ServerContext&);
+  ServerContext& operator=(const ServerContext&);
+
   class CompletionOp;
 
   void BeginCompletionOp(Call* call);

--- a/test/cpp/qps/server_async.cc
+++ b/test/cpp/qps/server_async.cc
@@ -33,6 +33,7 @@
 
 #include <forward_list>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -158,11 +159,12 @@ class AsyncQpsServerTest : public Server {
                            void *)> request_method,
         std::function<grpc::Status(const RequestType *, ResponseType *)>
             invoke_method)
-        : next_state_(&ServerRpcContextUnaryImpl::invoker),
+        : srv_ctx_(new ServerContext),
+          next_state_(&ServerRpcContextUnaryImpl::invoker),
           request_method_(request_method),
           invoke_method_(invoke_method),
-          response_writer_(&srv_ctx_) {
-      request_method_(&srv_ctx_, &req_, &response_writer_,
+          response_writer_(srv_ctx_.get()) {
+      request_method_(srv_ctx_.get(), &req_, &response_writer_,
                       AsyncQpsServerTest::tag(this));
     }
     ~ServerRpcContextUnaryImpl() GRPC_OVERRIDE {}
@@ -170,14 +172,14 @@ class AsyncQpsServerTest : public Server {
       return (this->*next_state_)(ok);
     }
     void Reset() GRPC_OVERRIDE {
-      srv_ctx_ = ServerContext();
+      srv_ctx_.reset(new ServerContext);
       req_ = RequestType();
       response_writer_ =
-          grpc::ServerAsyncResponseWriter<ResponseType>(&srv_ctx_);
+          grpc::ServerAsyncResponseWriter<ResponseType>(srv_ctx_.get());
 
       // Then request the method
       next_state_ = &ServerRpcContextUnaryImpl::invoker;
-      request_method_(&srv_ctx_, &req_, &response_writer_,
+      request_method_(srv_ctx_.get(), &req_, &response_writer_,
                       AsyncQpsServerTest::tag(this));
     }
 
@@ -198,7 +200,7 @@ class AsyncQpsServerTest : public Server {
       response_writer_.Finish(response, status, AsyncQpsServerTest::tag(this));
       return true;
     }
-    ServerContext srv_ctx_;
+    std::unique_ptr<ServerContext> srv_ctx_;
     RequestType req_;
     bool (ServerRpcContextUnaryImpl::*next_state_)(bool);
     std::function<void(ServerContext *, RequestType *,
@@ -218,25 +220,26 @@ class AsyncQpsServerTest : public Server {
                            void *)> request_method,
         std::function<grpc::Status(const RequestType *, ResponseType *)>
             invoke_method)
-        : next_state_(&ServerRpcContextStreamingImpl::request_done),
+        : srv_ctx_(new ServerContext),
+          next_state_(&ServerRpcContextStreamingImpl::request_done),
           request_method_(request_method),
           invoke_method_(invoke_method),
-          stream_(&srv_ctx_) {
-      request_method_(&srv_ctx_, &stream_, AsyncQpsServerTest::tag(this));
+          stream_(srv_ctx_.get()) {
+      request_method_(srv_ctx_.get(), &stream_, AsyncQpsServerTest::tag(this));
     }
     ~ServerRpcContextStreamingImpl() GRPC_OVERRIDE {}
     bool RunNextState(bool ok) GRPC_OVERRIDE {
       return (this->*next_state_)(ok);
     }
     void Reset() GRPC_OVERRIDE {
-      srv_ctx_ = ServerContext();
+      srv_ctx_.reset(new ServerContext);
       req_ = RequestType();
-      stream_ =
-          grpc::ServerAsyncReaderWriter<ResponseType, RequestType>(&srv_ctx_);
+      stream_ = grpc::ServerAsyncReaderWriter<ResponseType, RequestType>(
+          srv_ctx_.get());
 
       // Then request the method
       next_state_ = &ServerRpcContextStreamingImpl::request_done;
-      request_method_(&srv_ctx_, &stream_, AsyncQpsServerTest::tag(this));
+      request_method_(srv_ctx_.get(), &stream_, AsyncQpsServerTest::tag(this));
     }
 
    private:
@@ -278,7 +281,7 @@ class AsyncQpsServerTest : public Server {
     }
     bool finish_done(bool ok) { return false; /* reset the context */ }
 
-    ServerContext srv_ctx_;
+    std::unique_ptr<ServerContext> srv_ctx_;
     RequestType req_;
     bool (ServerRpcContextStreamingImpl::*next_state_)(bool);
     std::function<void(


### PR DESCRIPTION
ServerContext was being recreated in server_async.cc's Reset() methods without properly disposing of the previous instance.