### PR TITLE
Removing an assert on chand->security_connector->auth_context.

### DIFF
--- a/src/core/security/server_auth_filter.c
+++ b/src/core/security/server_auth_filter.c
@@ -78,7 +78,6 @@ static void init_call_elem(grpc_call_element *elem,
   calld->unused = 0;
 
   GPR_ASSERT(initial_op && initial_op->context != NULL &&
-             chand->security_connector->auth_context != NULL &&
              initial_op->context[GRPC_CONTEXT_SECURITY].value == NULL);
 
   /* Create a security context for the call and reference the auth context from


### PR DESCRIPTION
That value actually MAY be NULL in some circumstances, and that's not a problem.

Ping @jboeuf on that one.