### PR TITLE
Increase test timeout

### DIFF
--- a/src/python/src/grpc/_adapter/_links_test.py
+++ b/src/python/src/grpc/_adapter/_links_test.py
@@ -40,7 +40,7 @@ from grpc.framework.base import interfaces
 from grpc.framework.foundation import logging_pool
 
 _IDENTITY = lambda x: x
-_TIMEOUT = 2
+_TIMEOUT = 32
 
 
 # TODO(nathaniel): End-to-end metadata testing.


### PR DESCRIPTION
The previous timeout was short enough that it led to erroneous failures.

Fixes #1875.