### PR TITLE
bump grpc ruby version

### DIFF
--- a/src/ruby/lib/grpc/version.rb
+++ b/src/ruby/lib/grpc/version.rb
@@ -29,5 +29,5 @@
 
 # GRPC contains the General RPC module.
 module GRPC
-  VERSION = '0.9.0'
+  VERSION = '0.9.2'
 end


### PR DESCRIPTION
Allows a new ruby gem release, which fixes #1854