### PR TITLE
fix CRLF line ending problem with run_jenkins.sh

### DIFF
--- a/tools/jenkins/run_jenkins.sh
+++ b/tools/jenkins/run_jenkins.sh
@@ -27,11 +27,15 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+#
 # This script is invoked by Jenkins and triggers a test run based on
 # env variable settings.
-
-set -ex
+#
+# To prevent cygwin bash complaining about empty lines ending with \r
+# we set the igncr option. The option doesn't exist on Linux, so we fallback
+# to just 'set -ex' there.
+# NOTE: No empty lines should appear in this file before igncr is set!
+set -ex -o igncr || set -ex
 
 if [ "$platform" == "linux" ]
 then


### PR DESCRIPTION
Without this, the script complains on Windows:
+ tools/jenkins/run_jenkins.sh
tools/jenkins/run_jenkins.sh: line 30: $'\r': command not found
tools/jenkins/run_jenkins.sh: line 33: $'\r': command not found