### PR TITLE
Update README.rst

### DIFF
--- a/src/python/src/README.rst
+++ b/src/python/src/README.rst
@@ -13,7 +13,7 @@ Run the following command to install gRPC Python.
 
   $ curl -fsSL https://goo.gl/getgrpc | bash -s python
 
-This will download and run the [gRPC install script][] to install the grpc core, then uses pip to install this package.  It also installs the Protocol Buffers compiler (_protoc_) and the gRPC _protoc_ plugin for python.
+This will download and run the [gRPC install script][] to install grpc core. The script then uses pip to install this package.  It also installs the Protocol Buffers compiler (_protoc_) and the gRPC _protoc_ plugin for python.
 
 Otherwise, `install from source`_
 

--- a/src/python/src/README.rst
+++ b/src/python/src/README.rst
@@ -6,22 +6,18 @@ Package for GRPC Python.
 Dependencies
 ------------
 
-Ensure that you have installed GRPC core.
-
-On debian linux systems, install from our released deb package:
-
-::
-
-  $ wget https://github.com/grpc/grpc/releases/download/release-0_5_0/libgrpc_0.5.0_amd64.deb
-  $ wget https://github.com/grpc/grpc/releases/download/release-0_5_0/libgrpc-dev_0.5.0_amd64.deb
-  $ sudo dpkg -i libgrpc_0.5.0_amd64.deb libgrpc-dev_0.5.0_amd64.deb
-
-Otherwise, install from source:
+Ensure you have installed the gRPC core.  On Mac OS X, install homebrew_. On Linux, install linuxbrew_.
+Run the following command to install gRPC Python.
 
 ::
 
-  git clone https://github.com/grpc/grpc.git
-  cd grpc
-  ./configure
-  make && make install
+  $ curl -fsSL https://goo.gl/getgrpc | bash -s python
 
+This will download and run the [gRPC install script][] to install the grpc core, then uses pip to install this package.  It also installs the Protocol Buffers compiler (_protoc_) and the gRPC _protoc_ plugin for python.
+
+Otherwise, `install from source`_
+
+.. _`install from source`: https://github.com/grpc/grpc/blob/master/src/python/README.md#building-from-source
+.. _homebrew: http://brew.sh
+.. _linuxbrew: https://github.com/Homebrew/linuxbrew#installation
+.. _`gRPC install script`: https://raw.githubusercontent.com/grpc/homebrew-grpc/master/scripts/install


### PR DESCRIPTION
There was one other location where we had installation instructions, that did not get updated last week.
It's used when publishing python packages, e.g, https://pypi.python.org/pypi/grpcio
PTAL