### PR TITLE
Only keep docker containers for tests that failed

### DIFF
--- a/tools/jenkins/run_jenkins.sh
+++ b/tools/jenkins/run_jenkins.sh
@@ -47,15 +47,29 @@ then
     FETCH_PULL_REQUEST_CMD="&& git fetch $GIT_URL refs/pull/$ghprbPullId/merge refs/pull/$ghprbPullId/head"
   fi
 
+  # Make sure the CID file is gone.
+  rm -f docker.cid
+
   # Run tests inside docker
-  docker run grpc/grpc_jenkins_slave bash -c -l "git clone --recursive $GIT_URL /var/local/git/grpc \
+  docker run --cidfile=docker.cid grpc/grpc_jenkins_slave bash -c -l "git clone --recursive $GIT_URL /var/local/git/grpc \
     && cd /var/local/git/grpc \
     $FETCH_PULL_REQUEST_CMD \
     && git checkout -f $GIT_COMMIT \
     && git submodule update \
     && nvm use 0.12 \
     && rvm use ruby-2.1 \
-    && tools/run_tests/run_tests.py -t -l $language"
+    && tools/run_tests/run_tests.py -t -l $language" || DOCKER_FAILED="true"
+
+  DOCKER_CID=`cat docker.cid`
+  if [ "$DOCKER_FAILED" == "" ]
+  then
+    echo "Docker finished successfully, deleting the container $DOCKER_CID"
+    docker rm $DOCKER_CID
+  else
+    echo "Docker exited with failure, keeping container $DOCKER_CID."
+    echo "You can SSH to the worker and use 'docker start CID' and 'docker exec -i -t CID bash' to debug the problem."
+  fi
+
 elif [ "$platform" == "windows" ]
 then
   echo "building $language on Windows"


### PR DESCRIPTION
-- Delete docker containers for successful tests to prevent running out of space on linux workers.
-- Keep containers for failed runs to allow troubleshooting.
