### PR TITLE
Remove failing globs from examples and tests

### DIFF
--- a/src/objective-c/README.md
+++ b/src/objective-c/README.md
@@ -52,11 +52,11 @@ Pod::Spec.new do |s|
 
   # Run protoc with the Objective-C and gRPC plugins to generate protocol messages and gRPC clients.
   # You can run this command manually if you later change your protos and need to regenerate.
-  s.prepare_command = "protoc --objc_out=. --objcgrpc_out=. *.proto **/*.proto"
+  s.prepare_command = "protoc --objc_out=. --objcgrpc_out=. *.proto"
 
   # The --objc_out plugin generates a pair of .pbobjc.h/.pbobjc.m files for each .proto file.
   s.subspec "Messages" do |ms|
-    ms.source_files = "*.pbobjc.{h,m}", "**/*.pbobjc.{h,m}"
+    ms.source_files = "*.pbobjc.{h,m}"
     ms.header_mappings_dir = "."
     ms.requires_arc = false
     ms.dependency "Protobuf", "~> 3.0.0-alpha-3"
@@ -65,7 +65,7 @@ Pod::Spec.new do |s|
   # The --objcgrpc_out plugin generates a pair of .pbrpc.h/.pbrpc.m files for each .proto file with
   # a service defined.
   s.subspec "Services" do |ss|
-    ss.source_files = "*.pbrpc.{h,m}", "**/*.pbrpc.{h,m}"
+    ss.source_files = "*.pbrpc.{h,m}"
     ss.header_mappings_dir = "."
     ss.requires_arc = true
     ss.dependency "gRPC", "~> 0.5"
@@ -74,9 +74,21 @@ Pod::Spec.new do |s|
 end
 ```
 
-The file should be named `<Podspec file name>.podspec`. Once your library has a Podspec, Cocoapods
-can install it into any XCode project. For that, go into your project's directory and create a
-Podfile by running:
+The file should be named `<Podspec file name>.podspec`.
+
+Note: If your proto files are in a directory hierarchy, you might want to adjust the _globs_ used in
+the sample Podspec above. For example, you could use:
+
+```ruby
+  s.prepare_command = "protoc --objc_out=. --objcgrpc_out=. *.proto **/*.proto"
+  ...
+    ms.source_files = "*.pbobjc.{h,m}", "**/*.pbobjc.{h,m}"
+  ...
+    ss.source_files = "*.pbrpc.{h,m}", "**/*.pbrpc.{h,m}"
+```
+
+Once your library has a Podspec, Cocoapods can install it into any XCode project. For that, go into
+your project's directory and create a Podfile by running:
 
 ```sh
 pod init

--- a/src/objective-c/generated_libraries/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/generated_libraries/RemoteTestClient/RemoteTest.podspec
@@ -7,17 +7,17 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.8"
 
   # Run protoc with the Objective-C and gRPC plugins to generate protocol messages and gRPC clients.
-  s.prepare_command = "protoc --objc_out=. --objcgrpc_out=. *.proto **/*.proto"
+  s.prepare_command = "protoc --objc_out=. --objcgrpc_out=. *.proto"
 
   s.subspec "Messages" do |ms|
-    ms.source_files = "*.pbobjc.{h,m}", "**/*.pbobjc.{h,m}"
+    ms.source_files = "*.pbobjc.{h,m}"
     ms.header_mappings_dir = "."
     ms.requires_arc = false
     ms.dependency "Protobuf", "~> 3.0.0-alpha-3"
   end
 
   s.subspec "Services" do |ss|
-    ss.source_files = "*.pbrpc.{h,m}", "**/*.pbrpc.{h,m}"
+    ss.source_files = "*.pbrpc.{h,m}"
     ss.header_mappings_dir = "."
     ss.requires_arc = true
     ss.dependency "gRPC", "~> 0.5"

--- a/src/objective-c/generated_libraries/RouteGuideClient/RouteGuide.podspec
+++ b/src/objective-c/generated_libraries/RouteGuideClient/RouteGuide.podspec
@@ -7,17 +7,17 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.8"
 
   # Run protoc with the Objective-C and gRPC plugins to generate protocol messages and gRPC clients.
-  s.prepare_command = "protoc --objc_out=. --objcgrpc_out=. *.proto **/*.proto"
+  s.prepare_command = "protoc --objc_out=. --objcgrpc_out=. *.proto"
 
   s.subspec "Messages" do |ms|
-    ms.source_files = "*.pbobjc.{h,m}", "**/*.pbobjc.{h,m}"
+    ms.source_files = "*.pbobjc.{h,m}"
     ms.header_mappings_dir = "."
     ms.requires_arc = false
     ms.dependency "Protobuf", "~> 3.0.0-alpha-3"
   end
 
   s.subspec "Services" do |ss|
-    ss.source_files = "*.pbrpc.{h,m}", "**/*.pbrpc.{h,m}"
+    ss.source_files = "*.pbrpc.{h,m}"
     ss.header_mappings_dir = "."
     ss.requires_arc = true
     ss.dependency "gRPC", "~> 0.5"


### PR DESCRIPTION
When any of `*.proto` or `**/*.proto` fail to find files, instead of failing silently `pod install` is aborted. We can achieve the desired result with a `find ... -exec`, but maybe compiling everything recursively would be surprising (in the bad sense)?