### PR TITLE
include string_util.h for the prototype of gpr_strdup and fix a typo.

### DIFF
--- a/src/core/support/log_win32.c
+++ b/src/core/support/log_win32.c
@@ -42,6 +42,7 @@
 #include <grpc/support/log_win32.h>
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
+#include <grpc/support/string_util.h>
 
 #include "src/core/support/string.h"
 #include "src/core/support/string_win32.h"
@@ -106,7 +107,7 @@ char *gpr_format_message(DWORD messageid) {
                                NULL, messageid,
                                MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
                                (LPTSTR)(&tmessage), 0, NULL);
-  if (status == 0) return gpr_strdup("Unable to retreive error string");
+  if (status == 0) return gpr_strdup("Unable to retrieve error string");
   message = gpr_tchar_to_char(tmessage);
   LocalFree(tmessage);
   return message;


### PR DESCRIPTION
Fixes two warnings in log_win32.c under msvc2015
log_win32.c(109): warning C4013: 'gpr_strdup' undefined; assuming extern returning int
log_win32.c(109): warning C4047: 'return': 'char *' differs in levels of indirection from 'int'

and corrects a typo in an error message