### PR TITLE
Add PHP timeout interop test

### DIFF
--- a/src/php/lib/Grpc/AbstractCall.php
+++ b/src/php/lib/Grpc/AbstractCall.php
@@ -43,9 +43,19 @@ abstract class AbstractCall {
    * Create a new Call wrapper object.
    * @param Channel $channel The channel to communicate on
    * @param string $method The method to call on the remote server
+   * @param callback $deserialize A callback function to deserialize
+   * the response
+   * @param (optional) long $timeout Timeout in microseconds
    */
-  public function __construct(Channel $channel, $method, $deserialize) {
-    $this->call = new Call($channel, $method, Timeval::infFuture());
+  public function __construct(Channel $channel, $method, $deserialize, $timeout = false) {
+    if ($timeout) {
+      $now = Timeval::now();
+      $delta = new Timeval($timeout);
+      $deadline = $now->add($delta);
+    } else {
+      $deadline = Timeval::infFuture();
+    }
+    $this->call = new Call($channel, $method, $deadline);
     $this->deserialize = $deserialize;
     $this->metadata = null;
   }

--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -83,6 +83,21 @@ class BaseStub {
     return "https://" . $this->hostname . $service_name;
   }
 
+  /**
+   * extract $timeout from $metadata
+   * @param $metadata The metadata map
+   * @return list($metadata_copy, $timeout)
+   */
+  private function _extract_timeout_from_metadata($metadata) {
+    $timeout = false;
+    $metadata_copy = $metadata;
+    if (isset($metadata['timeout'])) {
+      $timeout = $metadata['timeout'];
+      unset($metadata_copy['timeout']);
+    }
+    return array($metadata_copy, $timeout);
+  }
+
   /* This class is intended to be subclassed by generated code, so all functions
      begin with "_" to avoid name collisions. */
 
@@ -99,8 +114,8 @@ class BaseStub {
                                  $argument,
                                  callable $deserialize,
                                  $metadata = array()) {
-    $call = new UnaryCall($this->channel, $method, $deserialize);
-    $actual_metadata = $metadata;
+    list($actual_metadata, $timeout)  = $this->_extract_timeout_from_metadata($metadata);
+    $call = new UnaryCall($this->channel, $method, $deserialize, $timeout);
     $jwt_aud_uri = $this->_get_jwt_aud_uri($method);
     if (is_callable($this->update_metadata)) {
       $actual_metadata = call_user_func($this->update_metadata,
@@ -126,8 +141,8 @@ class BaseStub {
                                        $arguments,
                                        callable $deserialize,
                                        $metadata = array()) {
-    $call = new ClientStreamingCall($this->channel, $method, $deserialize);
-    $actual_metadata = $metadata;
+    list($actual_metadata, $timeout)  = $this->_extract_timeout_from_metadata($metadata);
+    $call = new ClientStreamingCall($this->channel, $method, $deserialize, $timeout);
     $jwt_aud_uri = $this->_get_jwt_aud_uri($method);
     if (is_callable($this->update_metadata)) {
       $actual_metadata = call_user_func($this->update_metadata,
@@ -152,8 +167,8 @@ class BaseStub {
                                        $argument,
                                        callable $deserialize,
                                        $metadata = array()) {
-    $call = new ServerStreamingCall($this->channel, $method, $deserialize);
-    $actual_metadata = $metadata;
+    list($actual_metadata, $timeout)  = $this->_extract_timeout_from_metadata($metadata);
+    $call = new ServerStreamingCall($this->channel, $method, $deserialize, $timeout);
     $jwt_aud_uri = $this->_get_jwt_aud_uri($method);
     if (is_callable($this->update_metadata)) {
       $actual_metadata = call_user_func($this->update_metadata,
@@ -175,8 +190,8 @@ class BaseStub {
   public function _bidiRequest($method,
                                callable $deserialize,
                                $metadata = array()) {
-    $call = new BidiStreamingCall($this->channel, $method, $deserialize);
-    $actual_metadata = $metadata;
+    list($actual_metadata, $timeout)  = $this->_extract_timeout_from_metadata($metadata);
+    $call = new BidiStreamingCall($this->channel, $method, $deserialize, $timeout);
     $jwt_aud_uri = $this->_get_jwt_aud_uri($method);
     if (is_callable($this->update_metadata)) {
       $actual_metadata = call_user_func($this->update_metadata,

--- a/src/php/tests/unit_tests/TimevalTest.php
+++ b/src/php/tests/unit_tests/TimevalTest.php
@@ -61,4 +61,26 @@ class TimevalTest extends PHPUnit_Framework_TestCase{
     $this->assertLessThan(0, Grpc\Timeval::compare($zero, $now));
     $this->assertLessThan(0, Grpc\Timeval::compare($now, $future));
   }
+
+  public function testNowAndAdd() {
+    $now = Grpc\Timeval::now();
+    $delta = new Grpc\Timeval(1000);
+    $deadline = $now->add($delta);
+    $this->assertGreaterThan(0, Grpc\Timeval::compare($deadline, $now));
+  }
+
+  public function testNowAndSubtract() {
+    $now = Grpc\Timeval::now();
+    $delta = new Grpc\Timeval(1000);
+    $deadline = $now->subtract($delta);
+    $this->assertLessThan(0, Grpc\Timeval::compare($deadline, $now));
+  }
+
+  public function testAddAndSubtract() {
+    $now = Grpc\Timeval::now();
+    $delta = new Grpc\Timeval(1000);
+    $deadline = $now->add($delta);
+    $back_to_now = $deadline->subtract($delta);
+    $this->assertSame(0, Grpc\Timeval::compare($back_to_now, $now));
+  }
 }


### PR DESCRIPTION
 * Add an optional `$timeout` parameter to the `AbstractCall` class constructor, and pass it to the underlying `Call` class, instead of always passing `Timeval::infFuture()`
 * Add `timeout_on_sleeping_server` interop test
 * Add more unit tests to `TimevalTest` because we are now using the `->add()` function
 * For issue #2062 