### PR TITLE
Add PHP to jenkins

### DIFF
--- a/tools/jenkins/grpc_jenkins_slave/Dockerfile
+++ b/tools/jenkins/grpc_jenkins_slave/Dockerfile
@@ -115,5 +115,19 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.0.0a2
 
+##################
+# PHP dependencies
+
+# Install dependencies
+
+RUN /bin/bash -l -c "echo 'deb http://packages.dotdeb.org wheezy-php55 all' \
+    >> /etc/apt/sources.list.d/dotdeb.list"
+RUN /bin/bash -l -c "echo 'deb-src http://packages.dotdeb.org wheezy-php55 all' \
+    >> /etc/apt/sources.list.d/dotdeb.list"
+RUN wget http://www.dotdeb.org/dotdeb.gpg -O- | apt-key add -
+
+RUN apt-get update && apt-get install -y \
+    git php5 php5-dev phpunit unzip
+
 # Define the default command.
 CMD ["bash"]


### PR DESCRIPTION
 * For issue #1920 
 * Tested by building the docker image via this command: `tools/jenkins/grpc_jenkins_slave$ sudo docker build -t grpc/grpc_jenkins_slave .`
 * And running the script: `sudo platform=linux language=php GIT_URL=https://github.com/grpc/grpc.git ./run_jenkins.sh`