### PR TITLE
fix json_rewrite_test CRLF handling

### DIFF
--- a/test/core/json/json_rewrite_test.c
+++ b/test/core/json/json_rewrite_test.c
@@ -64,6 +64,11 @@ typedef struct json_reader_userdata {
 static void json_writer_output_char(void* userdata, char c) {
   json_writer_userdata* state = userdata;
   int cmp = fgetc(state->cmp);
+
+  /* treat CRLF as LF */
+  if (cmp == '\r' && c == '\n') {
+	  cmp = fgetc(state->cmp);
+  }
   GPR_ASSERT(cmp == c);
 }
 

--- a/test/core/json/json_rewrite_test.c
+++ b/test/core/json/json_rewrite_test.c
@@ -67,7 +67,7 @@ static void json_writer_output_char(void* userdata, char c) {
 
   /* treat CRLF as LF */
   if (cmp == '\r' && c == '\n') {
-	  cmp = fgetc(state->cmp);
+    cmp = fgetc(state->cmp);
   }
   GPR_ASSERT(cmp == c);
 }


### PR DESCRIPTION
fixes json_rewrite_test on windows on jenkins. Part of #1912.