### PR TITLE
Fix NPE for trying to add metadata to error when it was nil

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -319,9 +319,12 @@ NSString * const kGRPCStatusMetadataKey = @"io.grpc.StatusMetadataKey";
     if (strongSelf) {
       [strongSelf->_responseMetadata addEntriesFromDictionary:trailers];
 
-      NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
-      userInfo[kGRPCStatusMetadataKey] = strongSelf->_responseMetadata;
-      error = [NSError errorWithDomain:error.domain code:error.code userInfo:userInfo];
+      if (error) {
+        NSMutableDictionary *userInfo =
+            [NSMutableDictionary dictionaryWithDictionary:error.userInfo];
+        userInfo[kGRPCStatusMetadataKey] = strongSelf->_responseMetadata;
+        error = [NSError errorWithDomain:error.domain code:error.code userInfo:userInfo];
+      }
       [strongSelf finishWithError:error];
     }
   }];


### PR DESCRIPTION
Caused by #2051, which I only tested for RPCs that failed... We need Travis set up.