### PR TITLE
make sure docker image is up-to-date before each build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1216,7 +1216,7 @@ else
 endif
 endif
 	$(Q)$(MAKE) -C third_party/openssl clean
-	$(Q)$(MAKE) -C third_party/openssl build_crypto build_ssl
+	$(Q)(unset CPPFLAGS; $(MAKE) -C third_party/openssl build_crypto build_ssl)
 	$(Q)mkdir -p $(LIBDIR)/$(CONFIG)/openssl
 	$(Q)cp third_party/openssl/libssl.a third_party/openssl/libcrypto.a $(LIBDIR)/$(CONFIG)/openssl
 

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -665,7 +665,7 @@ else
 endif
 endif
 	$(Q)$(MAKE) -C third_party/openssl clean
-	$(Q)$(MAKE) -C third_party/openssl build_crypto build_ssl
+	$(Q)(unset CPPFLAGS; $(MAKE) -C third_party/openssl build_crypto build_ssl)
 	$(Q)mkdir -p $(LIBDIR)/$(CONFIG)/openssl
 	$(Q)cp third_party/openssl/libssl.a third_party/openssl/libcrypto.a $(LIBDIR)/$(CONFIG)/openssl
 

--- a/tools/jenkins/grpc_jenkins_slave/Dockerfile
+++ b/tools/jenkins/grpc_jenkins_slave/Dockerfile
@@ -116,6 +116,9 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.0.0a2
 
+# For sanity test
+RUN pip install simplejson mako
+
 ##################
 # PHP dependencies
 

--- a/tools/jenkins/run_jenkins.sh
+++ b/tools/jenkins/run_jenkins.sh
@@ -74,7 +74,7 @@ then
     docker rm $DOCKER_CID
   else
     echo "Docker exited with failure, keeping container $DOCKER_CID."
-    echo "You can SSH to the worker and use 'docker start CID' and 'docker exec -i -t CID bash' to debug the problem."
+    echo "You can SSH to the worker and use 'docker commit CID YOUR_IMAGE_NAME' and 'docker run -i -t YOUR_IMAGE_NAME bash' to debug the problem."
     exit 1
   fi
 

--- a/tools/jenkins/run_jenkins.sh
+++ b/tools/jenkins/run_jenkins.sh
@@ -41,6 +41,12 @@ if [ "$platform" == "linux" ]
 then
   echo "building $language on Linux"
 
+  # Use image name based on Dockerfile checksum
+  DOCKER_IMAGE_NAME=grpc_jenkins_slave_`sha1sum tools/jenkins/grpc_jenkins_slave/Dockerfile | cut -f1 -d\ `
+
+  # Make sure docker image has been built. Should be instantaneous if so.
+  docker build -t $DOCKER_IMAGE_NAME tools/jenkins/grpc_jenkins_slave
+
   if [ "$ghprbPullId" != "" ]
   then
     # if we are building a pull request, grab corresponding refs.
@@ -51,12 +57,11 @@ then
   rm -f docker.cid
 
   # Run tests inside docker
-  docker run --cidfile=docker.cid grpc/grpc_jenkins_slave bash -c -l "git clone --recursive $GIT_URL /var/local/git/grpc \
+  docker run --cidfile=docker.cid $DOCKER_IMAGE_NAME bash -c -l "git clone --recursive $GIT_URL /var/local/git/grpc \
     && cd /var/local/git/grpc \
     $FETCH_PULL_REQUEST_CMD \
     && git checkout -f $GIT_COMMIT \
     && git submodule update \
-    && pip install simplejson mako \
     && nvm use 0.12 \
     && rvm use ruby-2.1 \
     && CONFIG=$config tools/run_tests/prepare_travis.sh \


### PR DESCRIPTION
-- make sure docker image is always up-to-date 
-- fix build CPPFLAGS openssl build breakage
-- update instructions on attaching to a failed docker build.