### PR TITLE
Removed const-ness from Reporter interface methods

### DIFF
--- a/test/cpp/qps/report.cc
+++ b/test/cpp/qps/report.cc
@@ -43,39 +43,39 @@ void CompositeReporter::add(std::unique_ptr<Reporter> reporter) {
   reporters_.emplace_back(std::move(reporter));
 }
 
-void CompositeReporter::ReportQPS(const ScenarioResult& result) const {
+void CompositeReporter::ReportQPS(const ScenarioResult& result) {
   for (size_t i = 0; i < reporters_.size(); ++i) {
     reporters_[i]->ReportQPS(result);
   }
 }
 
-void CompositeReporter::ReportQPSPerCore(const ScenarioResult& result) const {
+void CompositeReporter::ReportQPSPerCore(const ScenarioResult& result) {
   for (size_t i = 0; i < reporters_.size(); ++i) {
     reporters_[i]->ReportQPSPerCore(result);
   }
 }
 
-void CompositeReporter::ReportLatency(const ScenarioResult& result) const {
+void CompositeReporter::ReportLatency(const ScenarioResult& result) {
   for (size_t i = 0; i < reporters_.size(); ++i) {
     reporters_[i]->ReportLatency(result);
   }
 }
 
-void CompositeReporter::ReportTimes(const ScenarioResult& result) const {
+void CompositeReporter::ReportTimes(const ScenarioResult& result) {
   for (size_t i = 0; i < reporters_.size(); ++i) {
     reporters_[i]->ReportTimes(result);
   }
 }
 
 
-void GprLogReporter::ReportQPS(const ScenarioResult& result) const {
+void GprLogReporter::ReportQPS(const ScenarioResult& result) {
   gpr_log(GPR_INFO, "QPS: %.1f",
           result.latencies.Count() /
               average(result.client_resources,
                       [](ResourceUsage u) { return u.wall_time; }));
 }
 
-void GprLogReporter::ReportQPSPerCore(const ScenarioResult& result)  const {
+void GprLogReporter::ReportQPSPerCore(const ScenarioResult& result) {
   auto qps =
       result.latencies.Count() /
       average(result.client_resources,
@@ -85,7 +85,7 @@ void GprLogReporter::ReportQPSPerCore(const ScenarioResult& result)  const {
           qps / result.server_config.threads());
 }
 
-void GprLogReporter::ReportLatency(const ScenarioResult& result) const {
+void GprLogReporter::ReportLatency(const ScenarioResult& result) {
   gpr_log(GPR_INFO,
           "Latencies (50/90/95/99/99.9%%-ile): %.1f/%.1f/%.1f/%.1f/%.1f us",
           result.latencies.Percentile(50) / 1000,
@@ -95,7 +95,7 @@ void GprLogReporter::ReportLatency(const ScenarioResult& result) const {
           result.latencies.Percentile(99.9) / 1000);
 }
 
-void GprLogReporter::ReportTimes(const ScenarioResult& result) const {
+void GprLogReporter::ReportTimes(const ScenarioResult& result) {
   gpr_log(GPR_INFO, "Server system time: %.2f%%",
           100.0 * sum(result.server_resources,
                       [](ResourceUsage u) { return u.system_time; }) /

--- a/test/cpp/qps/report.h
+++ b/test/cpp/qps/report.h
@@ -59,16 +59,16 @@ class Reporter {
   string name() const { return name_; }
 
   /** Reports QPS for the given \a result. */
-  virtual void ReportQPS(const ScenarioResult& result) const = 0;
+  virtual void ReportQPS(const ScenarioResult& result) = 0;
 
   /** Reports QPS per core as (YYY/server core). */
-  virtual void ReportQPSPerCore(const ScenarioResult& result) const = 0;
+  virtual void ReportQPSPerCore(const ScenarioResult& result) = 0;
 
   /** Reports latencies for the 50, 90, 95, 99 and 99.9 percentiles, in ms. */
-  virtual void ReportLatency(const ScenarioResult& result) const = 0;
+  virtual void ReportLatency(const ScenarioResult& result) = 0;
 
   /** Reports system and user time for client and server systems. */
-  virtual void ReportTimes(const ScenarioResult& result) const = 0;
+  virtual void ReportTimes(const ScenarioResult& result) = 0;
 
  private:
   const string name_;
@@ -82,10 +82,10 @@ class CompositeReporter : public Reporter {
   /** Adds a \a reporter to the composite. */
   void add(std::unique_ptr<Reporter> reporter);
 
-  void ReportQPS(const ScenarioResult& result) const GRPC_OVERRIDE;
-  void ReportQPSPerCore(const ScenarioResult& result) const GRPC_OVERRIDE;
-  void ReportLatency(const ScenarioResult& result) const GRPC_OVERRIDE;
-  void ReportTimes(const ScenarioResult& result) const GRPC_OVERRIDE;
+  void ReportQPS(const ScenarioResult& result) GRPC_OVERRIDE;
+  void ReportQPSPerCore(const ScenarioResult& result) GRPC_OVERRIDE;
+  void ReportLatency(const ScenarioResult& result) GRPC_OVERRIDE;
+  void ReportTimes(const ScenarioResult& result) GRPC_OVERRIDE;
 
  private:
   std::vector<std::unique_ptr<Reporter> > reporters_;
@@ -97,10 +97,10 @@ class GprLogReporter : public Reporter {
   GprLogReporter(const string& name) : Reporter(name) {}
 
  private:
-  void ReportQPS(const ScenarioResult& result) const GRPC_OVERRIDE;
-  void ReportQPSPerCore(const ScenarioResult& result) const GRPC_OVERRIDE;
-  void ReportLatency(const ScenarioResult& result) const GRPC_OVERRIDE;
-  void ReportTimes(const ScenarioResult& result) const GRPC_OVERRIDE;
+  void ReportQPS(const ScenarioResult& result) GRPC_OVERRIDE;
+  void ReportQPSPerCore(const ScenarioResult& result) GRPC_OVERRIDE;
+  void ReportLatency(const ScenarioResult& result) GRPC_OVERRIDE;
+  void ReportTimes(const ScenarioResult& result) GRPC_OVERRIDE;
 };
 
 }  // namespace testing


### PR DESCRIPTION
I shot myself in the foot when I made them so. It limits implementing classes too much.