### PR TITLE
Fixed integer conversion warnings in src/core/security

### DIFF
--- a/src/core/security/base64.c
+++ b/src/core/security/base64.c
@@ -128,7 +128,7 @@ gpr_slice grpc_base64_decode(const char *b64, int url_safe) {
   size_t num_codes = 0;
 
   while (b64_len--) {
-    unsigned char c = *b64++;
+    unsigned char c = (unsigned char)(*b64++);
     signed char code;
     if (c >= GPR_ARRAY_SIZE(base64_bytes)) continue;
     if (url_safe) {
@@ -149,7 +149,7 @@ gpr_slice grpc_base64_decode(const char *b64, int url_safe) {
         goto fail;
       }
     } else {
-      codes[num_codes++] = code;
+      codes[num_codes++] = (unsigned char)code;
       if (num_codes == 4) {
         if (codes[0] == GRPC_BASE64_PAD_BYTE ||
             codes[1] == GRPC_BASE64_PAD_BYTE) {
@@ -159,7 +159,7 @@ gpr_slice grpc_base64_decode(const char *b64, int url_safe) {
         if (codes[2] == GRPC_BASE64_PAD_BYTE) {
           if (codes[3] == GRPC_BASE64_PAD_BYTE) {
             /* Double padding. */
-            gpr_uint32 packed = (codes[0] << 2) | (codes[1] >> 4);
+            gpr_uint32 packed = (gpr_uint32)((codes[0] << 2) | (codes[1] >> 4));
             current[result_size++] = (unsigned char)packed;
           } else {
             gpr_log(GPR_ERROR, "Invalid padding detected.");
@@ -168,13 +168,13 @@ gpr_slice grpc_base64_decode(const char *b64, int url_safe) {
         } else if (codes[3] == GRPC_BASE64_PAD_BYTE) {
           /* Single padding. */
           gpr_uint32 packed =
-              (codes[0] << 10) | (codes[1] << 4) | (codes[2] >> 2);
+              (gpr_uint32)((codes[0] << 10) | (codes[1] << 4) | (codes[2] >> 2));
           current[result_size++] = (unsigned char)(packed >> 8);
           current[result_size++] = (unsigned char)(packed);
         } else {
           /* No padding. */
           gpr_uint32 packed =
-              (codes[0] << 18) | (codes[1] << 12) | (codes[2] << 6) | codes[3];
+              (gpr_uint32)((codes[0] << 18) | (codes[1] << 12) | (codes[2] << 6) | codes[3]);
           current[result_size++] = (unsigned char)(packed >> 16);
           current[result_size++] = (unsigned char)(packed >> 8);
           current[result_size++] = (unsigned char)(packed);
@@ -189,7 +189,7 @@ gpr_slice grpc_base64_decode(const char *b64, int url_safe) {
     gpr_slice_unref(result);
     return gpr_empty_slice();
   }
-  GPR_SLICE_SET_LENGTH(result, result_size);
+  GPR_SLICE_SET_LENGTH(result, (gpr_uint8)result_size);
   return result;
 
 fail:

--- a/src/core/security/base64.c
+++ b/src/core/security/base64.c
@@ -189,7 +189,7 @@ gpr_slice grpc_base64_decode(const char *b64, int url_safe) {
     gpr_slice_unref(result);
     return gpr_empty_slice();
   }
-  GPR_SLICE_SET_LENGTH(result, (gpr_uint8)result_size);
+  GPR_SLICE_SET_LENGTH(result, result_size);
   return result;
 
 fail:

--- a/src/core/security/secure_endpoint.c
+++ b/src/core/security/secure_endpoint.c
@@ -116,7 +116,7 @@ static void on_read(void *user_data, gpr_slice *slices, size_t nslices,
                     grpc_endpoint_cb_status error) {
   unsigned i;
   gpr_uint8 keep_looping = 0;
-  int input_buffer_count = 0;
+  size_t input_buffer_count = 0;
   tsi_result result = TSI_OK;
   secure_endpoint *ep = (secure_endpoint *)user_data;
   gpr_uint8 *cur = GPR_SLICE_START_PTR(ep->read_staging_buffer);
@@ -181,9 +181,9 @@ static void on_read(void *user_data, gpr_slice *slices, size_t nslices,
     return;
   }
   /* The upper level will unref the slices. */
-  input_buffer_count = (int)ep->input_buffer.count;
+  input_buffer_count = ep->input_buffer.count;
   ep->input_buffer.count = 0;
-  call_read_cb(ep, ep->input_buffer.slices, (size_t)input_buffer_count, error);
+  call_read_cb(ep, ep->input_buffer.slices, input_buffer_count, error);
 }
 
 static void endpoint_notify_on_read(grpc_endpoint *secure_ep,

--- a/src/core/security/secure_transport_setup.c
+++ b/src/core/security/secure_transport_setup.c
@@ -235,7 +235,7 @@ static void on_handshake_data_received_from_peer(
     gpr_slice_unref(slices[i]); /* split_tail above increments refcount. */
   }
   gpr_slice_buffer_addn(&s->left_overs, &slices[i + 1],
-                        num_left_overs - has_left_overs_in_current_slice);
+                        num_left_overs - (size_t)has_left_overs_in_current_slice);
   check_peer(s);
 }
 

--- a/src/core/security/security_connector.c
+++ b/src/core/security/security_connector.c
@@ -550,7 +550,7 @@ grpc_security_status grpc_ssl_channel_security_connector_create(
     alpn_protocol_strings[i] =
         (const unsigned char *)grpc_chttp2_get_alpn_version_index(i);
     alpn_protocol_string_lengths[i] =
-        strlen(grpc_chttp2_get_alpn_version_index(i));
+        (unsigned char)strlen(grpc_chttp2_get_alpn_version_index(i));
   }
 
   if (config == NULL || target_name == NULL) {
@@ -589,7 +589,7 @@ grpc_security_status grpc_ssl_channel_security_connector_create(
       config->pem_private_key, config->pem_private_key_size,
       config->pem_cert_chain, config->pem_cert_chain_size, pem_root_certs,
       pem_root_certs_size, ssl_cipher_suites(), alpn_protocol_strings,
-      alpn_protocol_string_lengths, num_alpn_protocols, &c->handshaker_factory);
+      alpn_protocol_string_lengths, (uint16_t)num_alpn_protocols, &c->handshaker_factory);
   if (result != TSI_OK) {
     gpr_log(GPR_ERROR, "Handshaker factory creation failed with %s.",
             tsi_result_to_string(result));
@@ -623,7 +623,7 @@ grpc_security_status grpc_ssl_server_security_connector_create(
     alpn_protocol_strings[i] =
         (const unsigned char *)grpc_chttp2_get_alpn_version_index(i);
     alpn_protocol_string_lengths[i] =
-        strlen(grpc_chttp2_get_alpn_version_index(i));
+        (unsigned char)strlen(grpc_chttp2_get_alpn_version_index(i));
   }
 
   if (config == NULL || config->num_key_cert_pairs == 0) {
@@ -642,7 +642,7 @@ grpc_security_status grpc_ssl_server_security_connector_create(
       (const unsigned char **)config->pem_cert_chains,
       config->pem_cert_chains_sizes, config->num_key_cert_pairs,
       config->pem_root_certs, config->pem_root_certs_size, ssl_cipher_suites(),
-      alpn_protocol_strings, alpn_protocol_string_lengths, num_alpn_protocols,
+      alpn_protocol_strings, alpn_protocol_string_lengths, (uint16_t)num_alpn_protocols,
       &c->handshaker_factory);
   if (result != TSI_OK) {
     gpr_log(GPR_ERROR, "Handshaker factory creation failed with %s.",
@@ -661,4 +661,3 @@ error:
   gpr_free(alpn_protocol_string_lengths);
   return GRPC_SECURITY_ERROR;
 }
-


### PR DESCRIPTION
Added some typecasts to avoid GCC warning about integer conversions when we eventually turn that warning on