### PR TITLE
Fix flaky test

### DIFF
--- a/test/cpp/end2end/client_crash_test.cc
+++ b/test/cpp/end2end/client_crash_test.cc
@@ -140,7 +140,8 @@ TEST_F(CrashTest, KillAfterWrite) {
 
   KillServer();
 
-  EXPECT_FALSE(stream->Read(&response));
+  // This may succeed or fail depending on how quick the server was
+  stream->Read(&response);
 
   EXPECT_FALSE(stream->Finish().ok());
 }


### PR DESCRIPTION
Assertation could be false if the server responds quickly enough (it's
unlikely to). Removing the assert does not change the nature of the
test.

Fixes #2157