### PR TITLE
Fixing Windows port after the removal of the backup poller.

### DIFF
--- a/src/core/iomgr/pollset.h
+++ b/src/core/iomgr/pollset.h
@@ -62,7 +62,10 @@ void grpc_pollset_destroy(grpc_pollset *pollset);
    May involve invoking asynchronous callbacks, or actually polling file
    descriptors.
    Requires GRPC_POLLSET_MU(pollset) locked.
-   May unlock GRPC_POLLSET_MU(pollset) during its execution. */
+   May unlock GRPC_POLLSET_MU(pollset) during its execution.
+   
+   Returns true if some work has been done, and false if the deadline
+   got attained. */
 int grpc_pollset_work(grpc_pollset *pollset, gpr_timespec deadline);
 
 /* Break one polling thread out of polling work for this pollset.

--- a/src/core/iomgr/pollset_windows.h
+++ b/src/core/iomgr/pollset_windows.h
@@ -41,10 +41,12 @@
 
 /* There isn't really any such thing as a pollset under Windows, due to the
    nature of the IO completion ports. A Windows "pollset" is merely a mutex
-   and a condition variable, as this is the minimal set of features we need
-   implemented for the rest of grpc. But we won't use them directly. */
+   and a condition variable, used to synchronize with the IOCP. */
 
-typedef struct grpc_pollset { gpr_mu mu; } grpc_pollset;
+typedef struct grpc_pollset {
+  gpr_mu mu;
+  gpr_cv cv;
+} grpc_pollset;
 
 #define GRPC_POLLSET_MU(pollset) (&(pollset)->mu)
 


### PR DESCRIPTION
With the backup poller gone, the caller of grpc_pollset_work is expecting it to sleep. Aligning the behavior of the Windows port with the behavior of the Posix port.

Fixes #2159.
