### PR TITLE
Fixing recursive locking under Windows.

### DIFF
--- a/src/core/security/server_secure_chttp2.c
+++ b/src/core/security/server_secure_chttp2.c
@@ -138,10 +138,12 @@ static void destroy_done(void *statep) {
    callbacks) */
 static void destroy(grpc_server *server, void *statep) {
   grpc_server_secure_state *state = statep;
+  grpc_tcp_server *tcp;
   gpr_mu_lock(&state->mu);
   state->is_shutdown = 1;
-  grpc_tcp_server_destroy(state->tcp, destroy_done, state);
+  tcp = state->tcp;
   gpr_mu_unlock(&state->mu);
+  grpc_tcp_server_destroy(tcp, destroy_done, state);
 }
 
 int grpc_server_add_secure_http2_port(grpc_server *server, const char *addr,


### PR DESCRIPTION
Shutting down is synchronous under Windows, so we don't want to do that while holding a lock.