### PR TITLE
Bump version of grpc ruby for release on the release branch

### DIFF
--- a/src/ruby/lib/grpc/version.rb
+++ b/src/ruby/lib/grpc/version.rb
@@ -29,5 +29,5 @@
 
 # GRPC contains the General RPC module.
 module GRPC
-  VERSION = '0.9.3'
+  VERSION = '0.9.4'
 end


### PR DESCRIPTION
- grpc ruby 0.9.3 should have released from the release branch but was not
- it needs to be re-released from that branch