### PR TITLE
Backport ruby 0.9.x release to the release branch

### DIFF
--- a/src/ruby/grpc.gemspec
+++ b/src/ruby/grpc.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license       = 'BSD-3-Clause'
 
   s.required_ruby_version = '>= 2.0.0'
-  s.requirements << 'libgrpc ~> 0.6.0 needs to be installed'
+  s.requirements << 'libgrpc ~> 0.9.1 needs to be installed'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- spec/*`.split("\n")

--- a/src/ruby/lib/grpc/version.rb
+++ b/src/ruby/lib/grpc/version.rb
@@ -29,5 +29,5 @@
 
 # GRPC contains the General RPC module.
 module GRPC
-  VERSION = '0.9.3'
+  VERSION = '0.9.4'
 end

--- a/src/ruby/lib/grpc/version.rb
+++ b/src/ruby/lib/grpc/version.rb
@@ -29,5 +29,5 @@
 
 # GRPC contains the General RPC module.
 module GRPC
-  VERSION = '0.9.0'
+  VERSION = '0.9.2'
 end

--- a/src/ruby/lib/grpc/version.rb
+++ b/src/ruby/lib/grpc/version.rb
@@ -29,5 +29,5 @@
 
 # GRPC contains the General RPC module.
 module GRPC
-  VERSION = '0.9.2'
+  VERSION = '0.9.3'
 end


### PR DESCRIPTION
Updates the release branch with the commits necessary to create an installable 0.9.x ruby gem.
- Allows grpc-ruby 0.9.4 will be built and released from the release branch

@murgatroid99, @nicolasnoble  PTAL

@nicolasnoble , please merge once satisfied.

I've built the 0.9.4 gem from this branch and confirmed that installs ok, passes tests etc.