### PR TITLE
Adds an interop test: oauth2_auth_token

### DIFF
--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -392,6 +392,50 @@ Asserts:
 * clients are free to assert that the response payload body contents are zero
   and comparing the entire response message against a golden response
 
+### oauth2_auth_token
+
+Similar to the other auth tests, this test is only for cloud-to-prod path.
+
+This test verifies unary calls succeed in sending messages using an OAuth2 token that is obtained OOB.  For the purpose of the test, the OAuth2 token is actually obtained from the service account credentials via the language-specific authorization library.  
+
+The difference between this test and the other auth tests is that rather than configuring the test client with ServiceAccountCredentials directly, the test first uses the authorization library to obtain an authorization token.
+
+The test
+- uses the flag`--service_account_key_file` with the path to a json key file
+downloaded from https://console.developers.google.com. Alternately, if using a usable auth implementation, it may specify the file location in the environment variable GOOGLE_APPLICATION_CREDENTIALS
+- uses the flag `--oauth_scope` for the oauth scope.  For testing against grpc-test.sandbox.google.com, "https://www.googleapis.com/auth/xapi.zoo" should be passed as the `--oauth_scope`.
+
+Server features:
+* [UnaryCall][]
+* [Compressable Payload][]
+* [Echo Authenticated Username][]
+* [Echo OAuth Scope][]
+
+Procedure:
+ 1. Client use the auth library to obtain an authorization token
+ 2. Client calls UnaryCall, attaching the authorization token obtained in step1, with the following message
+
+    ```
+    {
+      response_type: COMPRESSABLE
+      response_size: 314159
+      payload:{
+        body: 271828 bytes of zeros
+      }
+      fill_username: true
+      fill_oauth_scope: true
+    }
+    ```
+    
+Asserts:
+* call was successful
+* received SimpleResponse.username is in the json key file used by the auth library to obtain the authorization token
+* received SimpleResponse.oauth_scope is in `--oauth_scope`
+* response payload body is 314159 bytes in size
+* clients are free to assert that the response payload body contents are zero
+  and comparing the entire response message against a golden response
+
+
 ### Metadata (TODO: fix name)
 
 Status: Not yet implementable
@@ -559,11 +603,6 @@ pushback (i.e., attempts to send succeed only after appropriate delays).
 Propagation of status code and message (yangg)
 
 Multiple thousand simultaneous calls on same Channel (ctiller)
-
-OAuth2 tokens + Service Credentials from GCE metadata server (GCE->prod only)
-(abhishek)
-
-OAuth2 tokens + JWT signing key (GCE->prod only) (abhishek)
 
 Metadata: client headers, server headers + trailers, binary+ascii
 


### PR DESCRIPTION
- test is similar to the existing auth tests: only on the cloud-to-prod path
- uses an auth library to obtain the auth token OOB. This should be simplest, as many languages already use such an auth library in their existing auth tests.

@hsaliak: this is the draft I talked about yesterday. 