### PR TITLE
php: refactor and cleanup some scripts

### DIFF
--- a/src/php/bin/determine_extension_dir.sh
+++ b/src/php/bin/determine_extension_dir.sh
@@ -29,7 +29,21 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set -e
-cd $(dirname $0)
-source ./determine_extension_dir.sh
-php $extension_dir -d extension=grpc.so \
-  ../tests/interop/interop_client.php $@ 1>&2
+default_extension_dir=`php -i | grep extension_dir | sed 's/.*=> //g'`
+if command -v brew >/dev/null && [ -d `brew --prefix`/opt/grpc-php ]; then
+  # homebrew and the grpc-php formula are installed
+  extension_dir="-d extension_dir="`brew --prefix`/opt/grpc-php
+elif [ ! -f $default_extension_dir/grpc.so ]; then
+  # the grpc extension is not found in the default PHP extension dir
+  # try the source modules directory
+  module_dir=../ext/grpc/modules
+  if [ ! -f $module_dir/grpc.so ]; then
+    echo "Please run 'phpize && ./configure && make' from ext/grpc first"
+    exit 1
+  fi
+  # sym-link in system supplied extensions
+  for f in $default_extension_dir/*.so; do
+    ln -s $f $module_dir/$(basename $f) &> /dev/null || true
+  done
+  extension_dir="-d extension_dir="$module_dir
+fi

--- a/src/php/bin/determine_extension_dir.sh
+++ b/src/php/bin/determine_extension_dir.sh
@@ -29,10 +29,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set -e
-default_extension_dir=`php -i | grep extension_dir | sed 's/.*=> //g'`
-if command -v brew >/dev/null && [ -d `brew --prefix`/opt/grpc-php ]; then
+default_extension_dir=$(php -i | grep extension_dir | sed 's/.*=> //g')
+if command -v brew >/dev/null && [ -d $(brew --prefix)/opt/grpc-php ]; then
   # homebrew and the grpc-php formula are installed
-  extension_dir="-d extension_dir="`brew --prefix`/opt/grpc-php
+  extension_dir="-d extension_dir="$(brew --prefix)/opt/grpc-php
 elif [ ! -f $default_extension_dir/grpc.so ]; then
   # the grpc extension is not found in the default PHP extension dir
   # try the source modules directory

--- a/src/php/bin/run_gen_code_test.sh
+++ b/src/php/bin/run_gen_code_test.sh
@@ -32,7 +32,7 @@ set -e
 cd $(dirname $0)
 source ./determine_extension_dir.sh
 export GRPC_TEST_HOST=localhost:7071
-php $extension_dir -d extension=grpc.so `which phpunit` -v --debug --strict \
+php $extension_dir -d extension=grpc.so $(which phpunit) -v --debug --strict \
   ../tests/generated_code/GeneratedCodeTest.php
-php $extension_dir -d extension=grpc.so `which phpunit` -v --debug --strict \
+php $extension_dir -d extension=grpc.so $(which phpunit) -v --debug --strict \
   ../tests/generated_code/GeneratedCodeWithCallbackTest.php

--- a/src/php/bin/run_gen_code_test.sh
+++ b/src/php/bin/run_gen_code_test.sh
@@ -1,4 +1,4 @@
-# Runs the generated code test against the ruby server
+#!/bin/bash
 # Copyright 2015, Google Inc.
 # All rights reserved.
 #
@@ -28,10 +28,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+set -e
 cd $(dirname $0)
-GRPC_TEST_HOST=localhost:50051 php -d extension_dir=../ext/grpc/modules/ \
-  -d extension=grpc.so `which phpunit` -v --debug --strict \
+source ./determine_extension_dir.sh
+export GRPC_TEST_HOST=localhost:7071
+php $extension_dir -d extension=grpc.so `which phpunit` -v --debug --strict \
   ../tests/generated_code/GeneratedCodeTest.php
-GRPC_TEST_HOST=localhost:50051 php -d extension_dir=../ext/grpc/modules/ \
-  -d extension=grpc.so `which phpunit` -v --debug --strict \
+php $extension_dir -d extension=grpc.so `which phpunit` -v --debug --strict \
   ../tests/generated_code/GeneratedCodeWithCallbackTest.php

--- a/src/php/bin/run_tests.sh
+++ b/src/php/bin/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2015, Google Inc.
 # All rights reserved.
 #
@@ -32,33 +32,6 @@
 # against it
 set -e
 cd $(dirname $0)
-default_extension_dir=`php -i | grep extension_dir | sed 's/.*=> //g'`
-
-if command -v brew >/dev/null && [ -d `brew --prefix`/opt/grpc-php ]
-then
-  # homebrew and the grpc-php formula are installed
-  extension_dir="-d extension_dir="`brew --prefix`/opt/grpc-php
-elif [ ! -e $default_extension_dir/grpc.so ]
-then
-  # the grpc extension is not found in the default PHP extension dir
-  # try the source modules directory
-  module_dir=../ext/grpc/modules
-  if [ ! -d $module_dir ]
-  then
-    echo "Please run 'phpize && ./configure && make' from ext/grpc first"
-    exit 1
-  fi
-
-  # sym-link in system supplied extensions
-  for f in $default_extension_dir/*.so
-  do
-    ln -s $f $module_dir/$(basename $f) &> /dev/null || true
-  done
-
-  extension_dir='-d extension_dir='$module_dir
-fi
-
-php \
-  $extension_dir \
-  -d extension=grpc.so \
-  `which phpunit` -v --debug --strict ../tests/unit_tests
+source ./determine_extension_dir.sh
+php $extension_dir -d extension=grpc.so `which phpunit` -v --debug --strict \
+  ../tests/unit_tests

--- a/src/php/bin/run_tests.sh
+++ b/src/php/bin/run_tests.sh
@@ -33,5 +33,5 @@
 set -e
 cd $(dirname $0)
 source ./determine_extension_dir.sh
-php $extension_dir -d extension=grpc.so `which phpunit` -v --debug --strict \
+php $extension_dir -d extension=grpc.so $(which phpunit) -v --debug --strict \
   ../tests/unit_tests


### PR DESCRIPTION
 * For issue #1883 
 * There are 3 places where the PHP extension grpc.so can be in now
   * installed by homebrew: `$brew_home/opt/grpc-php`
   * compiled from source (without install): `src/php/ext/grpc/modules`
   * installed by pecl (or with install above): whatever PHP default extension_dir is
 * Previously I had this logic of determining where to find `grpc.so` all over the place. This attempts to refactor it to one place and clean up all the scripts that needs this