### PR TITLE
Cascade-kick pollsets when shutting down.

### DIFF
--- a/src/core/surface/completion_queue.c
+++ b/src/core/surface/completion_queue.c
@@ -208,6 +208,7 @@ grpc_event grpc_completion_queue_next(grpc_completion_queue *cc,
     }
     if (cc->shutdown) {
       ev = create_shutdown_event();
+      grpc_pollset_kick(&cc->pollset);
       break;
     }
     if (!grpc_pollset_work(&cc->pollset, deadline)) {


### PR DESCRIPTION
In the case we're using a threadpool, depending on where the threads are waiting in completion queue's next, they'll get stuck on shutdown because we're only kicking one of them. Instead, let's cascade-kick the pollsets when we shutdown so that we make sure all of them are exitting properly.