### PR TITLE
Base64 decode improvements

### DIFF
--- a/src/core/security/base64.c
+++ b/src/core/security/base64.c
@@ -163,7 +163,7 @@ static int decode_group(const unsigned char *codes, size_t num_codes,
   if (codes[2] == GRPC_BASE64_PAD_BYTE) {
     if (codes[3] == GRPC_BASE64_PAD_BYTE) {
       decode_one_char(codes, result, result_offset);
-      } else {
+    } else {
       gpr_log(GPR_ERROR, "Invalid padding detected.");
       return 0;
     }

--- a/src/core/security/base64.h
+++ b/src/core/security/base64.h
@@ -45,4 +45,8 @@ char *grpc_base64_encode(const void *data, size_t data_size, int url_safe,
    slice in case of failure. */
 gpr_slice grpc_base64_decode(const char *b64, int url_safe);
 
+/* Same as above except that the length is provided by the caller. */
+gpr_slice grpc_base64_decode_with_len(const char *b64, size_t b64_len,
+                                      int url_safe);
+
 #endif  /* GRPC_INTERNAL_CORE_SECURITY_BASE64_H */

--- a/test/core/security/base64_test.c
+++ b/test/core/security/base64_test.c
@@ -169,6 +169,43 @@ static void test_rfc4648_test_vectors(void) {
   gpr_free(b64);
 }
 
+static void test_unpadded_decode(void) {
+  gpr_slice decoded;
+
+  decoded = grpc_base64_decode("Zm9vYmFy", 0);
+  GPR_ASSERT(!GPR_SLICE_IS_EMPTY(decoded));
+  GPR_ASSERT(gpr_slice_str_cmp(decoded, "foobar") == 0);
+  gpr_slice_unref(decoded);
+
+  decoded = grpc_base64_decode("Zm9vYmE", 0);
+  GPR_ASSERT(!GPR_SLICE_IS_EMPTY(decoded));
+  GPR_ASSERT(gpr_slice_str_cmp(decoded, "fooba") == 0);
+  gpr_slice_unref(decoded);
+
+  decoded = grpc_base64_decode("Zm9vYg", 0);
+  GPR_ASSERT(!GPR_SLICE_IS_EMPTY(decoded));
+  GPR_ASSERT(gpr_slice_str_cmp(decoded, "foob") == 0);
+  gpr_slice_unref(decoded);
+
+  decoded = grpc_base64_decode("Zm9v", 0);
+  GPR_ASSERT(!GPR_SLICE_IS_EMPTY(decoded));
+  GPR_ASSERT(gpr_slice_str_cmp(decoded, "foo") == 0);
+  gpr_slice_unref(decoded);
+
+  decoded = grpc_base64_decode("Zm8", 0);
+  GPR_ASSERT(!GPR_SLICE_IS_EMPTY(decoded));
+  GPR_ASSERT(gpr_slice_str_cmp(decoded, "fo") == 0);
+  gpr_slice_unref(decoded);
+
+  decoded = grpc_base64_decode("Zg", 0);
+  GPR_ASSERT(!GPR_SLICE_IS_EMPTY(decoded));
+  GPR_ASSERT(gpr_slice_str_cmp(decoded, "f") == 0);
+  gpr_slice_unref(decoded);
+
+  decoded = grpc_base64_decode("", 0);
+  GPR_ASSERT(GPR_SLICE_IS_EMPTY(decoded));
+}
+
 int main(int argc, char **argv) {
   grpc_test_init(argc, argv);
   test_simple_encode_decode_b64_no_multiline();
@@ -181,5 +218,6 @@ int main(int argc, char **argv) {
   test_full_range_encode_decode_b64_urlsafe_multiline();
   test_url_safe_unsafe_mismtach_failure();
   test_rfc4648_test_vectors();
+  test_unpadded_decode();
   return 0;
 }


### PR DESCRIPTION
- Allow ablity to specify the length for decoding.
- Allow for non-padded encodings to be decoded properly.