### PR TITLE
Reworking the cascade kick to be Windows-specific.

### DIFF
--- a/src/core/iomgr/pollset_windows.h
+++ b/src/core/iomgr/pollset_windows.h
@@ -46,6 +46,7 @@
 typedef struct grpc_pollset {
   gpr_mu mu;
   gpr_cv cv;
+  int shutting_down;
 } grpc_pollset;
 
 #define GRPC_POLLSET_MU(pollset) (&(pollset)->mu)

--- a/src/core/surface/completion_queue.c
+++ b/src/core/surface/completion_queue.c
@@ -208,7 +208,6 @@ grpc_event grpc_completion_queue_next(grpc_completion_queue *cc,
     }
     if (cc->shutdown) {
       ev = create_shutdown_event();
-      grpc_pollset_kick(&cc->pollset);
       break;
     }
     if (!grpc_pollset_work(&cc->pollset, deadline)) {


### PR DESCRIPTION
This brings the Windows port more in-par with Linux. We're now making sure all of the pollsets are going to return immediately before calling the shutdown callback.