### PR TITLE
php extension: do not link rt in osx

### DIFF
--- a/src/php/README.md
+++ b/src/php/README.md
@@ -5,14 +5,27 @@ This directory contains source code for PHP implementation of gRPC layered on sh
 
 #Status
 
-Pre-Alpha : This gRPC PHP implementation is work-in-progress and is not expected to work yet.
+Alpha : Ready for early adopters
 
 ## ENVIRONMENT
 
-Prerequisite: PHP 5.5 or later, PHPUnit, pecl
+Prerequisite: PHP 5.5 or later, `phpunit`, `pecl`
+
+Linux:
 
 ```sh
-sudo apt-get install php5 php5-dev phpunit php-pear
+$ sudo apt-get install php5 php5-dev phpunit php-pear
+```
+
+OS X:
+
+```sh
+$ curl https://phar.phpunit.de/phpunit.phar -o phpunit.phar
+$ chmod +x phpunit.phar
+$ sudo mv phpunit.phar /usr/local/bin/phpunit
+
+$ curl -O http://pear.php.net/go-pear.phar
+$ sudo php -d detect_unicode=0 go-pear.phar
 ```
 
 ## Build from Homebrew
@@ -71,8 +84,8 @@ $ make
 $ sudo make install
 ```
 
-In your php.ini file, add the line `extension=grpc.so` to load the extension
-at PHP startup.
+(Optional) In your php.ini file, add the line `extension=grpc.so` to load
+the extension at PHP startup.
 
 Install Composer
 

--- a/src/php/ext/grpc/config.m4
+++ b/src/php/ext/grpc/config.m4
@@ -35,8 +35,13 @@ if test "$PHP_GRPC" != "no"; then
   PHP_ADD_LIBRARY(dl,,GRPC_SHARED_LIBADD)
   PHP_ADD_LIBRARY(dl)
 
-  PHP_ADD_LIBRARY(rt,,GRPC_SHARED_LIBADD)
-  PHP_ADD_LIBRARY(rt)
+  case $host in
+    *darwin*) ;;
+    *)
+      PHP_ADD_LIBRARY(rt,,GRPC_SHARED_LIBADD)
+      PHP_ADD_LIBRARY(rt)
+      ;;
+  esac
 
   GRPC_LIBDIR=$GRPC_DIR/${GRPC_LIB_SUBDIR-lib}
 


### PR DESCRIPTION
 * For issue #2218 
 * Do not link to `rt` library in OS X