### PR TITLE
Clarify caller contract for grpc_call_start_batch

### DIFF
--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -396,7 +396,9 @@ grpc_call *grpc_channel_create_registered_call(
    completion of type 'tag' to the completion queue bound to the call.
    The order of ops specified in the batch has no significance.
    Only one operation of each type can be active at once in any given
-   batch. 
+   batch. You must call grpc_completion_queue_next or
+   grpc_completion_queue_pluck on the completion queue associated with 'call'
+   for work to be performed.
    THREAD SAFETY: access to grpc_call_start_batch in multi-threaded environment
    needs to be synchronized. As an optimization, you may synchronize batches
    containing just send operations independently from batches containing just


### PR DESCRIPTION
I forgot this and spent much longer than I should have debugging something that was behaving as intended.