### PR TITLE
Disabling saving failed containers.

### DIFF
--- a/tools/jenkins/run_jenkins.sh
+++ b/tools/jenkins/run_jenkins.sh
@@ -73,15 +73,7 @@ then
   DOCKER_CID=`cat docker.cid`
   docker kill $DOCKER_CID
   docker cp $DOCKER_CID:/var/local/git/grpc/report.xml $git_root
-  if [ "$DOCKER_FAILED" == "" ]
-  then
-    echo "Docker finished successfully, deleting the container $DOCKER_CID"
-    docker rm $DOCKER_CID
-  else
-    echo "Docker exited with failure, keeping container $DOCKER_CID."
-    echo "You can SSH to the worker and use 'docker commit CID YOUR_IMAGE_NAME' and 'docker run -i -t YOUR_IMAGE_NAME bash' to debug the problem."
-    exit 1
-  fi
+  docker rm $DOCKER_CID
 
 elif [ "$platform" == "windows" ]
 then


### PR DESCRIPTION
We clearly don't have enough space for that, if we are to run our tests every few minutes.
We can revisit that later and automatically purge old containers for example.