### PR TITLE
backport PHP script cleanup fixes to 0.9 branch

### DIFF
--- a/src/php/bin/determine_extension_dir.sh
+++ b/src/php/bin/determine_extension_dir.sh
@@ -29,10 +29,21 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set -e
-cd $(dirname $0)
-source ./determine_extension_dir.sh
-export GRPC_TEST_HOST=localhost:7071
-php $extension_dir -d extension=grpc.so $(which phpunit) -v --debug --strict \
-  ../tests/generated_code/GeneratedCodeTest.php
-php $extension_dir -d extension=grpc.so $(which phpunit) -v --debug --strict \
-  ../tests/generated_code/GeneratedCodeWithCallbackTest.php
+default_extension_dir=$(php-config --extension-dir)
+if command -v brew >/dev/null && [ -d $(brew --prefix)/opt/grpc-php ]; then
+  # homebrew and the grpc-php formula are installed
+  extension_dir="-d extension_dir="$(brew --prefix)/opt/grpc-php
+elif [ ! -e $default_extension_dir/grpc.so ]; then
+  # the grpc extension is not found in the default PHP extension dir
+  # try the source modules directory
+  module_dir=../ext/grpc/modules
+  if [ ! -e $module_dir/grpc.so ]; then
+    echo "Please run 'phpize && ./configure && make' from ext/grpc first"
+    exit 1
+  fi
+  # sym-link in system supplied extensions
+  for f in $default_extension_dir/*.so; do
+    ln -s $f $module_dir/$(basename $f) &> /dev/null || true
+  done
+  extension_dir="-d extension_dir="$module_dir
+fi

--- a/src/php/bin/interop_client.sh
+++ b/src/php/bin/interop_client.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2015, Google Inc.
 # All rights reserved.
 #
@@ -28,11 +28,8 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
-set +e
+set -e
 cd $(dirname $0)
-
-module_dir=../ext/grpc/modules
-
-php -d extension_dir=$module_dir -d extension=grpc.so \
+source ./determine_extension_dir.sh
+php $extension_dir -d extension=grpc.so \
   ../tests/interop/interop_client.php $@ 1>&2

--- a/src/php/bin/run_tests.sh
+++ b/src/php/bin/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2015, Google Inc.
 # All rights reserved.
 #
@@ -32,29 +32,6 @@
 # against it
 set -e
 cd $(dirname $0)
-default_extension_dir=`php -i | grep extension_dir | sed 's/.*=> //g'`
-
-if [ ! -e $default_extension_dir/grpc.so ]
-then
-  # the grpc extension is not found in the default PHP extension dir
-  # try the source modules directory
-  module_dir=../ext/grpc/modules
-  if [ ! -d $module_dir ]
-  then
-    echo "Please run 'phpize && ./configure && make' from ext/grpc first"
-    exit 1
-  fi
-
-  # sym-link in system supplied extensions
-  for f in $default_extension_dir/*.so
-  do
-    ln -s $f $module_dir/$(basename $f) &> /dev/null || true
-  done
-
-  extension_dir='-d extension_dir='$module_dir
-fi
-
-php \
-  $extension_dir \
-  -d extension=grpc.so \
-  `which phpunit` -v --debug --strict ../tests/unit_tests
+source ./determine_extension_dir.sh
+php $extension_dir -d extension=grpc.so $(which phpunit) -v --debug --strict \
+  ../tests/unit_tests


### PR DESCRIPTION
 * Cont issue #1883 and PR #2203 and #2244 
 * Discovered a bug when `default_extension_dir=$(php -i | grep extension_dir | sed 's/.*=> //g')` isn't safe. Decided to might as well backport #2203 back to the 0.9 branch