### PR TITLE
Add Bazel target for Objective-C proto-gRPC runtime

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1259,3 +1259,21 @@ objc_bundle_library(
     name = "gRPCCertificates",
     resources = ["etc/roots.pem"],
 )
+
+proto_objc_rpc_path = objc_path + "/ProtoRPC"
+
+objc_library(
+  name = "proto_objc_rpc",
+  hdrs = glob([
+    proto_objc_rpc_path + "/*.h",
+  ]),
+  srcs = glob([
+    proto_objc_rpc_path + "/*.m",
+  ]),
+  includes = [objc_path],
+  deps = [
+    ":grpc_client",
+    ":rx_library",
+    "//external:protobuf_objc",
+  ],
+)

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -66,6 +66,8 @@
   // A writer that serializes the proto messages to send.
   id<GRXWriter> bytesWriter =
       [[[GRXWriter alloc] initWithWriter:requestsWriter] map:^id(GPBMessage *proto) {
+        // TODO(jcanizales): Fail with an understandable error message if the requestsWriter isn't
+        // sending GPBMessages.
         return [proto data];
       }];
   if ((self = [super initWithHost:host method:method requestsWriter:bytesWriter])) {

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -33,7 +33,7 @@
 
 #import "ProtoRPC.h"
 
-#import <Protobuf/GPBProtocolBuffers.h>
+#import <GPBProtocolBuffers.h>
 #import <RxLibrary/GRXWriteable.h>
 #import <RxLibrary/GRXWriter.h>
 #import <RxLibrary/GRXWriter+Transformations.h>

--- a/templates/BUILD.template
+++ b/templates/BUILD.template
@@ -205,3 +205,21 @@ objc_bundle_library(
     name = "gRPCCertificates",
     resources = ["etc/roots.pem"],
 )
+
+proto_objc_rpc_path = objc_path + "/ProtoRPC"
+
+objc_library(
+  name = "proto_objc_rpc",
+  hdrs = glob([
+    proto_objc_rpc_path + "/*.h",
+  ]),
+  srcs = glob([
+    proto_objc_rpc_path + "/*.m",
+  ]),
+  includes = [objc_path],
+  deps = [
+    ":grpc_client",
+    ":rx_library",
+    "//external:protobuf_objc",
+  ],
+)


### PR DESCRIPTION
This is what the generated files depend on.

Tested in a local app by pointing the `//external:protobuf_objc` dependency to the ObjC proto3 runtime target added here: https://github.com/google/protobuf/pull/554

Part of #2120.