### PR TITLE
Add support for forcing cert-based client auth

### DIFF
--- a/src/core/support/env_linux.c
+++ b/src/core/support/env_linux.c
@@ -43,6 +43,7 @@
 #include "src/core/support/env.h"
 
 #include <stdlib.h>
+#include <sys/auxv.h>
 
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
@@ -51,6 +52,9 @@
 
 char *gpr_getenv(const char *name) {
   char *result = secure_getenv(name);
+  if ((result == NULL) && (getauxval(AT_SECURE) != 0)) {
+    gpr_log(GPR_INFO, "Invalid env variable lookup from secure mode.");
+  }
   return result == NULL ? result : gpr_strdup(result);
 }
 

--- a/src/core/tsi/ssl_transport_security.c
+++ b/src/core/tsi/ssl_transport_security.c
@@ -49,6 +49,8 @@
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 
+#include "src/core/support/env.h"
+
 /* --- Constants. ---*/
 
 #define TSI_SSL_MAX_PROTECTED_FRAME_SIZE_UPPER_BOUND 16384
@@ -1211,6 +1213,15 @@ static int server_handshaker_factory_npn_advertised_callback(
 
 /* --- tsi_ssl_handshaker_factory constructors. --- */
 
+static void set_verification_mode(SSL_CTX *ctx) {
+  int flags = SSL_VERIFY_PEER;
+  char *overridden = gpr_getenv("GRPC_SSL_VERIFY_FAIL_IF_NO_PEER_CERT");
+  if (overridden != NULL) {
+    flags |= SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+  }
+  SSL_CTX_set_verify(ctx, flags, NULL);
+}
+
 tsi_result tsi_create_ssl_client_handshaker_factory(
     const unsigned char* pem_private_key, size_t pem_private_key_size,
     const unsigned char* pem_cert_chain, size_t pem_cert_chain_size,
@@ -1278,7 +1289,7 @@ tsi_result tsi_create_ssl_client_handshaker_factory(
     ssl_client_handshaker_factory_destroy(&impl->base);
     return result;
   }
-  SSL_CTX_set_verify(ssl_context, SSL_VERIFY_PEER, NULL);
+  set_verification_mode(ssl_context);
   /* TODO(jboeuf): Add revocation verification. */
 
   impl->base.create_handshaker =
@@ -1358,7 +1369,7 @@ tsi_result tsi_create_ssl_server_handshaker_factory(
           break;
         }
         SSL_CTX_set_client_CA_list(impl->ssl_contexts[i], root_names);
-        SSL_CTX_set_verify(impl->ssl_contexts[i], SSL_VERIFY_PEER, NULL);
+        set_verification_mode(impl->ssl_contexts[i]);
         /* TODO(jboeuf): Add revocation verification. */
       }
 

--- a/src/core/tsi/ssl_transport_security.c
+++ b/src/core/tsi/ssl_transport_security.c
@@ -1321,6 +1321,12 @@ tsi_result tsi_create_ssl_server_handshaker_factory(
     return TSI_INVALID_ARGUMENT;
   }
 
+  if ((pem_client_root_certs == NULL) &&
+      (gpr_getenv("GRPC_SSL_VERIFY_FAIL_IF_NO_PEER_CERT") != NULL)) {
+    gpr_log(GPR_ERROR, "No client certs provided, but verification required.");
+    return TSI_INVALID_ARGUMENT;
+  }
+
   impl = calloc(1, sizeof(tsi_ssl_server_handshaker_factory));
   if (impl == NULL) return TSI_OUT_OF_RESOURCES;
   impl->base.create_handshaker =


### PR DESCRIPTION
This set of patches adds support for an environment variable "GRPC_SSL_VERIFY_FAIL_IF_NO_PEER_CERT". If this is set, clients will be required to present valid client credentials and servers will be required to set root certs for client auth.

It also adds a warning message in the event that an environment variable is looked up from a secure context.