### PR TITLE
Remove the ability to specify a cancellation string

### DIFF
--- a/src/core/security/security_context.c
+++ b/src/core/security/security_context.c
@@ -89,7 +89,7 @@ grpc_client_security_context *grpc_client_security_context_create(void) {
 void grpc_client_security_context_destroy(void *ctx) {
   grpc_client_security_context *c = (grpc_client_security_context *)ctx;
   grpc_credentials_unref(c->creds);
-  grpc_auth_context_unref(c->auth_context);
+  GRPC_AUTH_CONTEXT_UNREF(c->auth_context, "client_security_context");
   gpr_free(ctx);
 }
 
@@ -104,7 +104,7 @@ grpc_server_security_context *grpc_server_security_context_create(void) {
 
 void grpc_server_security_context_destroy(void *ctx) {
   grpc_server_security_context *c = (grpc_server_security_context *)ctx;
-  grpc_auth_context_unref(c->auth_context);
+  GRPC_AUTH_CONTEXT_UNREF(c->auth_context, "server_security_context");
   gpr_free(ctx);
 }
 
@@ -120,21 +120,40 @@ grpc_auth_context *grpc_auth_context_create(grpc_auth_context *chained,
   memset(ctx->properties, 0, property_count * sizeof(grpc_auth_property));
   ctx->property_count = property_count;
   gpr_ref_init(&ctx->refcount, 1);
-  if (chained != NULL) ctx->chained = grpc_auth_context_ref(chained);
+  if (chained != NULL) ctx->chained = GRPC_AUTH_CONTEXT_REF(chained, "chained");
   return ctx;
 }
 
+#ifdef GRPC_AUTH_CONTEXT_REFCOUNT_DEBUG
+grpc_auth_context *grpc_auth_context_ref(grpc_auth_context *ctx,
+                                         const char *file, int line,
+                                         const char *reason) {
+  if (ctx == NULL) return NULL;
+  gpr_log(file, line, GPR_LOG_SEVERITY_DEBUG,
+          "AUTH_CONTEXT:%p   ref %d -> %d %s", ctx, (int)ctx->refcount.count,
+          (int)ctx->refcount.count + 1, reason);
+#else
 grpc_auth_context *grpc_auth_context_ref(grpc_auth_context *ctx) {
   if (ctx == NULL) return NULL;
+#endif
   gpr_ref(&ctx->refcount);
   return ctx;
 }
 
+#ifdef GRPC_AUTH_CONTEXT_REFCOUNT_DEBUG
+void grpc_auth_context_unref(grpc_auth_context *ctx, const char *file, int line,
+                             const char *reason) {
+  if (ctx == NULL) return;
+  gpr_log(file, line, GPR_LOG_SEVERITY_DEBUG,
+          "AUTH_CONTEXT:%p unref %d -> %d %s", ctx, (int)ctx->refcount.count,
+          (int)ctx->refcount.count - 1, reason);
+#else
 void grpc_auth_context_unref(grpc_auth_context *ctx) {
   if (ctx == NULL) return;
+#endif
   if (gpr_unref(&ctx->refcount)) {
     size_t i;
-    grpc_auth_context_unref(ctx->chained);
+    GRPC_AUTH_CONTEXT_UNREF(ctx->chained, "chained");
     if (ctx->properties != NULL) {
       for (i = 0; i < ctx->property_count; i++) {
         grpc_auth_property_reset(&ctx->properties[i]);
@@ -223,8 +242,8 @@ grpc_auth_property grpc_auth_property_init(const char *name, const char *value,
 }
 
 void grpc_auth_property_reset(grpc_auth_property *property) {
-  if (property->name != NULL) gpr_free(property->name);
-  if (property->value != NULL) gpr_free(property->value);
+  gpr_free(property->name);
+  gpr_free(property->value);
   memset(property, 0, sizeof(grpc_auth_property));
 }
 

--- a/src/core/security/security_context.h
+++ b/src/core/security/security_context.h
@@ -55,9 +55,22 @@ grpc_auth_context *grpc_auth_context_create(grpc_auth_context *chained,
                                             size_t property_count);
 
 /* Refcounting. */
-grpc_auth_context *grpc_auth_context_ref(
-    grpc_auth_context *ctx);
-void grpc_auth_context_unref(grpc_auth_context *ctx);
+#ifdef GRPC_AUTH_CONTEXT_REFCOUNT_DEBUG
+#define GRPC_AUTH_CONTEXT_REF(p, r) \
+  grpc_auth_context_ref((p), __FILE__, __LINE__, (r))
+#define GRPC_AUTH_CONTEXT_UNREF(p, r) \
+  grpc_auth_context_unref((p), __FILE__, __LINE__, (r))
+grpc_auth_context *grpc_auth_context_ref(grpc_auth_context *policy,
+                                         const char *file, int line,
+                                         const char *reason);
+void grpc_auth_context_unref(grpc_auth_context *policy, const char *file,
+                             int line, const char *reason);
+#else
+#define GRPC_AUTH_CONTEXT_REF(p, r) grpc_auth_context_ref((p))
+#define GRPC_AUTH_CONTEXT_UNREF(p, r) grpc_auth_context_unref((p))
+grpc_auth_context *grpc_auth_context_ref(grpc_auth_context *policy);
+void grpc_auth_context_unref(grpc_auth_context *policy);
+#endif
 
 grpc_auth_property grpc_auth_property_init_from_cstring(const char *name,
                                                         const char *value);

--- a/src/core/security/server_auth_filter.c
+++ b/src/core/security/server_auth_filter.c
@@ -82,9 +82,13 @@ static void init_call_elem(grpc_call_element *elem,
 
   /* Create a security context for the call and reference the auth context from
      the channel. */
+  if (initial_op->context[GRPC_CONTEXT_SECURITY].value != NULL) {
+    initial_op->context[GRPC_CONTEXT_SECURITY].destroy(
+        initial_op->context[GRPC_CONTEXT_SECURITY].value);
+  }
   server_ctx = grpc_server_security_context_create();
-  server_ctx->auth_context =
-      grpc_auth_context_ref(chand->security_connector->auth_context);
+  server_ctx->auth_context = GRPC_AUTH_CONTEXT_REF(
+      chand->security_connector->auth_context, "server_security_context");
   initial_op->context[GRPC_CONTEXT_SECURITY].value = server_ctx;
   initial_op->context[GRPC_CONTEXT_SECURITY].destroy =
       grpc_server_security_context_destroy;

--- a/src/core/transport/chttp2/incoming_metadata.c
+++ b/src/core/transport/chttp2/incoming_metadata.c
@@ -47,6 +47,10 @@ void grpc_chttp2_incoming_metadata_buffer_init(
 
 void grpc_chttp2_incoming_metadata_buffer_destroy(
     grpc_chttp2_incoming_metadata_buffer *buffer) {
+  size_t i;
+  for (i = 0; i < buffer->count; i++) {
+    grpc_mdelem_unref(buffer->elems[i].md);
+  }
   gpr_free(buffer->elems);
 }
 

--- a/src/core/transport/chttp2_transport.c
+++ b/src/core/transport/chttp2_transport.c
@@ -436,6 +436,8 @@ static void destroy_stream(grpc_transport *gt, grpc_stream *gs) {
   grpc_chttp2_data_parser_destroy(&s->parsing.data_parser);
   grpc_chttp2_incoming_metadata_buffer_destroy(&s->parsing.incoming_metadata);
   grpc_chttp2_incoming_metadata_buffer_destroy(&s->global.incoming_metadata);
+  grpc_chttp2_incoming_metadata_live_op_buffer_end(
+      &s->global.outstanding_metadata);
 
   UNREF_TRANSPORT(t, "stream");
 }

--- a/src/core/transport/metadata.c
+++ b/src/core/transport/metadata.c
@@ -120,7 +120,7 @@ static void unlock(grpc_mdctx *ctx) {
   if (ctx->refs == 0) {
     /* uncomment if you're having trouble diagnosing an mdelem leak to make
        things clearer (slows down destruction a lot, however) */
-    /* gc_mdtab(ctx); */
+    gc_mdtab(ctx);
     if (ctx->mdtab_count && ctx->mdtab_count == ctx->mdtab_free) {
       discard_metadata(ctx);
     }

--- a/src/core/transport/transport.c
+++ b/src/core/transport/transport.c
@@ -112,8 +112,8 @@ void grpc_transport_op_add_cancellation(grpc_transport_op *op,
                                         grpc_mdstr *message) {
   if (op->cancel_with_status == GRPC_STATUS_OK) {
     op->cancel_with_status = status;
-    op->cancel_message = message;
-  } else if (message) {
+  }
+  if (message) {
     grpc_mdstr_unref(message);
   }
 }

--- a/src/core/transport/transport.h
+++ b/src/core/transport/transport.h
@@ -77,7 +77,6 @@ typedef struct grpc_transport_op {
   grpc_pollset *bind_pollset;
 
   grpc_status_code cancel_with_status;
-  grpc_mdstr *cancel_message;
 
   /* Indexes correspond to grpc_context_index enum values */
   grpc_call_context_element *context;

--- a/src/core/transport/transport_op_string.c
+++ b/src/core/transport/transport_op_string.c
@@ -144,11 +144,6 @@ char *grpc_transport_op_string(grpc_transport_op *op) {
     first = 0;
     gpr_asprintf(&tmp, "CANCEL:%d", op->cancel_with_status);
     gpr_strvec_add(&b, tmp);
-    if (op->cancel_message) {
-      gpr_asprintf(&tmp, ";msg='%s'",
-                   grpc_mdstr_as_c_string(op->cancel_message));
-      gpr_strvec_add(&b, tmp);
-    }
   }
 
   out = gpr_strvec_flatten(&b, NULL);

--- a/test/core/bad_client/bad_client.c
+++ b/test/core/bad_client/bad_client.c
@@ -41,6 +41,7 @@
 #include "src/core/support/string.h"
 #include "src/core/transport/chttp2_transport.h"
 
+#include <grpc/support/alloc.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/thd.h>
 
@@ -88,6 +89,8 @@ void grpc_run_bad_client_test(grpc_bad_client_server_side_validator validator,
 
   /* Add a debug log */
   gpr_log(GPR_INFO, "TEST: %s", hex);
+
+  gpr_free(hex);
 
   /* Init grpc */
   grpc_init();

--- a/test/core/end2end/tests/request_with_flags.c
+++ b/test/core/end2end/tests/request_with_flags.c
@@ -105,7 +105,7 @@ static void test_invoke_request_with_flags(
   gpr_slice request_payload_slice = gpr_slice_from_copied_string("hello world");
   grpc_byte_buffer *request_payload =
       grpc_raw_byte_buffer_create(&request_payload_slice, 1);
-  gpr_timespec deadline = five_seconds_time();
+  gpr_timespec deadline = GRPC_TIMEOUT_MILLIS_TO_DEADLINE(100);
   grpc_end2end_test_fixture f =
       begin_test(config, "test_invoke_request_with_flags", NULL, NULL);
   cq_verifier *cqv = cq_verifier_create(f.cq);
@@ -155,6 +155,11 @@ static void test_invoke_request_with_flags(
   op++;
   expectation = call_start_batch_expected_result;
   GPR_ASSERT(expectation == grpc_call_start_batch(c, ops, op - ops, tag(1)));
+
+  if (expectation == GRPC_CALL_OK) {
+    cq_expect_completion(cqv, tag(1), 1);
+    cq_verify(cqv);
+  }
 
   gpr_free(details);
   grpc_metadata_array_destroy(&initial_metadata_recv);

--- a/test/core/security/auth_context_test.c
+++ b/test/core/security/auth_context_test.c
@@ -52,7 +52,7 @@ static void test_empty_context(void) {
   GPR_ASSERT(grpc_auth_property_iterator_next(&it) == NULL);
   it = grpc_auth_context_find_properties_by_name(ctx, "foo");
   GPR_ASSERT(grpc_auth_property_iterator_next(&it) == NULL);
-  grpc_auth_context_unref(ctx);
+  GRPC_AUTH_CONTEXT_UNREF(ctx, "test");
 }
 
 static void test_simple_context(void) {
@@ -86,7 +86,7 @@ static void test_simple_context(void) {
   GPR_ASSERT(grpc_auth_property_iterator_next(&it) == &ctx->properties[1]);
   GPR_ASSERT(grpc_auth_property_iterator_next(&it) == NULL);
 
-  grpc_auth_context_unref(ctx);
+  GRPC_AUTH_CONTEXT_UNREF(ctx, "test");
 }
 
 static void test_chained_context(void) {
@@ -96,7 +96,7 @@ static void test_chained_context(void) {
   size_t i;
 
   gpr_log(GPR_INFO, "test_chained_context");
-  grpc_auth_context_unref(chained);
+  GRPC_AUTH_CONTEXT_UNREF(chained, "chained");
   chained->properties[0] =
       grpc_auth_property_init_from_cstring("name", "padapo");
   chained->properties[1] = grpc_auth_property_init_from_cstring("foo", "baz");
@@ -129,7 +129,7 @@ static void test_chained_context(void) {
   GPR_ASSERT(grpc_auth_property_iterator_next(&it) == &chained->properties[0]);
   GPR_ASSERT(grpc_auth_property_iterator_next(&it) == NULL);
 
-  grpc_auth_context_unref(ctx);
+  GRPC_AUTH_CONTEXT_UNREF(ctx, "test");
 }
 
 

--- a/test/core/security/security_connector_test.c
+++ b/test/core/security/security_connector_test.c
@@ -73,7 +73,7 @@ static void test_unauthenticated_ssl_peer(void) {
   GPR_ASSERT(check_transport_security_type(ctx));
 
   tsi_peer_destruct(&peer);
-  grpc_auth_context_unref(ctx);
+  GRPC_AUTH_CONTEXT_UNREF(ctx, "test");
 }
 
 static int check_identity(const grpc_auth_context *ctx,
@@ -145,7 +145,7 @@ static void test_cn_only_ssl_peer_to_auth_context(void) {
   GPR_ASSERT(check_x509_cn(ctx, expected_cn));
 
   tsi_peer_destruct(&peer);
-  grpc_auth_context_unref(ctx);
+  GRPC_AUTH_CONTEXT_UNREF(ctx, "test");
 }
 
 static void test_cn_and_one_san_ssl_peer_to_auth_context(void) {
@@ -171,7 +171,7 @@ static void test_cn_and_one_san_ssl_peer_to_auth_context(void) {
   GPR_ASSERT(check_x509_cn(ctx, expected_cn));
 
   tsi_peer_destruct(&peer);
-  grpc_auth_context_unref(ctx);
+  GRPC_AUTH_CONTEXT_UNREF(ctx, "test");
 }
 
 static void test_cn_and_multiple_sans_ssl_peer_to_auth_context(void) {
@@ -202,7 +202,7 @@ static void test_cn_and_multiple_sans_ssl_peer_to_auth_context(void) {
   GPR_ASSERT(check_x509_cn(ctx, expected_cn));
 
   tsi_peer_destruct(&peer);
-  grpc_auth_context_unref(ctx);
+  GRPC_AUTH_CONTEXT_UNREF(ctx, "test");
 }
 
 static void test_cn_and_multiple_sans_and_others_ssl_peer_to_auth_context(
@@ -238,8 +238,7 @@ static void test_cn_and_multiple_sans_and_others_ssl_peer_to_auth_context(
   GPR_ASSERT(check_x509_cn(ctx, expected_cn));
 
   tsi_peer_destruct(&peer);
-  grpc_auth_context_unref(ctx);
-
+  GRPC_AUTH_CONTEXT_UNREF(ctx, "test");
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
We weren't using it, it was broken.

This includes #2261 