### PR TITLE
qps_test memory leak elimination: delete spare contexts lying around at the end of test

### DIFF
--- a/test/cpp/qps/client_async.cc
+++ b/test/cpp/qps/client_async.cc
@@ -199,6 +199,15 @@ class AsyncClient : public Client {
         delete ClientRpcContext::detag(got_tag);
       }
     }
+    // Now clear out all the pre-allocated idle contexts
+    for (int ch = 0; ch < channel_count_; ch++) {
+      if (!contexts_[ch].empty()) {
+        // Get an idle context from the front of the list
+        auto* ctx = *(contexts_[ch].begin());
+        contexts_[ch].pop_front();
+        delete ctx;
+      }
+    }
   }
 
   bool ThreadFunc(Histogram* histogram,

--- a/test/cpp/qps/client_async.cc
+++ b/test/cpp/qps/client_async.cc
@@ -201,7 +201,7 @@ class AsyncClient : public Client {
     }
     // Now clear out all the pre-allocated idle contexts
     for (int ch = 0; ch < channel_count_; ch++) {
-      if (!contexts_[ch].empty()) {
+      while (!contexts_[ch].empty()) {
         // Get an idle context from the front of the list
         auto* ctx = *(contexts_[ch].begin());
         contexts_[ch].pop_front();

--- a/test/cpp/qps/qps_test_openloop.cc
+++ b/test/cpp/qps/qps_test_openloop.cc
@@ -60,7 +60,7 @@ static void RunQPS() {
   client_config.set_rpc_type(UNARY);
   client_config.set_load_type(POISSON);
   client_config.mutable_load_params()->
-    mutable_poisson()->set_offered_load(10000.0);
+    mutable_poisson()->set_offered_load(1000.0);
 
   ServerConfig server_config;
   server_config.set_server_type(ASYNC_SERVER);


### PR DESCRIPTION
Also reduce the rate of the openloop test - this may be an issue with
sanitizers particularly because of issue #2278