### PR TITLE
Fixing variable names discrepancy in ruby's extension builder.

### DIFF
--- a/tools/run_tests/build_ruby.sh
+++ b/tools/run_tests/build_ruby.sh
@@ -31,7 +31,7 @@
 
 set -ex
 
-export CONFIG=${CONFIG:-opt}
+export GRPC_CONFIG=${CONFIG:-opt}
 
 # change to grpc's ruby directory
 cd $(dirname $0)/../../src/ruby


### PR DESCRIPTION
CONFIG != GRPC_CONFIG, meaning we're always building released, even in debug.