### PR TITLE
For Docker grpc_java, no longer build Netty

### DIFF
--- a/tools/dockerfile/grpc_java/Dockerfile
+++ b/tools/dockerfile/grpc_java/Dockerfile
@@ -30,10 +30,8 @@
 # Dockerfile for the gRPC Java dev image
 FROM grpc/java_base
 
-RUN git clone --recursive --depth 1 https://github.com/grpc/grpc-java.git /var/local/git/grpc-java
-RUN cd /var/local/git/grpc-java/lib/netty && \
-  mvn -pl codec-http2 -am -DskipTests install clean
-RUN cd /var/local/git/grpc-java && \
+RUN git clone --recursive --depth 1 https://github.com/grpc/grpc-java.git /var/local/git/grpc-java && \
+  cd /var/local/git/grpc-java && \
   ./gradlew :grpc-interop-testing:installDist -PskipCodegen=true
 
 # Add a service_account directory containing the auth creds file

--- a/tools/dockerfile/grpc_java_base/Dockerfile
+++ b/tools/dockerfile/grpc_java_base/Dockerfile
@@ -44,20 +44,11 @@ RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true 
       && \
   apt-get clean && rm -r /var/cache/oracle-jdk8-installer/
 
-# Install maven
-RUN wget -O - http://mirror.olnevhost.net/pub/apache/maven/binaries/apache-maven-3.2.1-bin.tar.gz | \
-  tar xz -C /var/local
-
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
-ENV M2_HOME /var/local/apache-maven-3.2.1
-ENV PATH $PATH:$JAVA_HOME/bin:$M2_HOME/bin
-ENV LD_LIBRARY_PATH /usr/local/lib
+ENV PATH $PATH:$JAVA_HOME/bin
 
-# Trigger download of as many Maven and Gradle artifacts as possible. We don't build grpc-java
-# because we don't want to install netty
+# Trigger download of as many Gradle artifacts as possible.
 RUN git clone --recursive --depth 1 https://github.com/grpc/grpc-java.git && \
-  cd grpc-java/lib/netty && \
-  mvn -pl codec-http2 -am -DskipTests verify && \
-  cd ../.. && \
-  ./gradlew && \
+  cd grpc-java && \
+  ./gradlew build -PskipCodegen=true && \
   rm -r "$(pwd)"


### PR DESCRIPTION
In grpc/grpc-java#425 we will be removing the netty submodule.