### PR TITLE
Let's workaround #2140 a bit.

### DIFF
--- a/tools/jenkins/run_jenkins.sh
+++ b/tools/jenkins/run_jenkins.sh
@@ -70,7 +70,8 @@ then
   DOCKER_CID=`cat docker.cid`
   docker kill $DOCKER_CID
   docker cp $DOCKER_CID:/var/local/git/grpc/report.xml $git_root
-  docker rm $DOCKER_CID
+  sleep 4
+  docker rm $DOCKER_CID || true
 
 elif [ "$platform" == "windows" ]
 then


### PR DESCRIPTION
Let's wait 4 seconds before removing the docker container, and let's make the removal a non-fatal condition of the jenkins script.