### PR TITLE
Faking tools target for win32.

### DIFF
--- a/templates/vsprojects/Grpc.mak.template
+++ b/templates/vsprojects/Grpc.mak.template
@@ -72,6 +72,12 @@ LIBS=$(OPENSSL_LIBS) $(ZLIB_LIBS) $(GENERAL_LIBS) $(WINSOCK_LIBS)
 
 all: buildtests
 
+tools:
+
+tools_c:
+
+tools_cxx:
+
 $(OUT_DIR):
 	mkdir $(OUT_DIR)
 

--- a/vsprojects/Grpc.mak
+++ b/vsprojects/Grpc.mak
@@ -51,6 +51,12 @@ LIBS=$(OPENSSL_LIBS) $(ZLIB_LIBS) $(GENERAL_LIBS) $(WINSOCK_LIBS)
 
 all: buildtests
 
+tools:
+
+tools_c:
+
+tools_cxx:
+
 $(OUT_DIR):
 	mkdir $(OUT_DIR)
 


### PR DESCRIPTION
With run_test.py, we need a tools target now. Let's fake it for Windows so we can at least build.