### PR TITLE
Fixing VS's documentation.

### DIFF
--- a/vsprojects/README.md
+++ b/vsprojects/README.md
@@ -12,7 +12,7 @@ download nuget.exe from the web and manually restore the NuGet packages.
 ```
 > REM Run from this directory.
 > REM No need to do this if you have NuGet visual studio extension.
-> nuget restore
+> nuget restore grpc.sln
 ```
 
 After that, you can build the solution using one of these options:


### PR DESCRIPTION
The nuget command line tool can't find which solution we want to restore packages on. The documentation needs some update.