### PR TITLE
Install simple Windows exception handlers.

### DIFF
--- a/include/grpc/support/port_platform.h
+++ b/include/grpc/support/port_platform.h
@@ -82,6 +82,7 @@
 #define GPR_WIN32_ATOMIC 1
 #define GPR_MSVC_TLS 1
 #endif
+#define GPR_WINDOWS_CRASH_HANDLER 1
 #elif defined(_WIN32) || defined(WIN32)
 #define GPR_ARCH_32 1
 #define GPR_WIN32 1
@@ -94,6 +95,7 @@
 #define GPR_WIN32_ATOMIC 1
 #define GPR_MSVC_TLS 1
 #endif
+#define GPR_WINDOWS_CRASH_HANDLER 1
 #elif defined(ANDROID) || defined(__ANDROID__)
 #define GPR_ANDROID 1
 #define GPR_ARCH_32 1

--- a/test/core/util/test_config.c
+++ b/test/core/util/test_config.c
@@ -48,7 +48,35 @@ static int seed(void) { return getpid(); }
 static int seed(void) { return _getpid(); }
 #endif
 
+#if GPR_WINDOWS_CRASH_HANDLER
+LONG crash_handler(struct _EXCEPTION_POINTERS* ex_info) {
+  gpr_log(GPR_DEBUG, "Exception handler called, dumping information");
+  while (ex_info->ExceptionRecord) {
+    DWORD code = ex_info->ExceptionRecord->ExceptionCode;
+    DWORD flgs = ex_info->ExceptionRecord->ExceptionFlags;
+    PVOID addr = ex_info->ExceptionRecord->ExceptionAddress;
+    gpr_log("code: %x - flags: %d - address: %p", code, flgs, addr);
+    ex_info->ExceptionRecord = ex_info->ExceptionRecord->ExceptionRecord;
+  }
+  if (IsDebuggerPresent()) {
+    __debugbreak();
+  } else {
+    _exit(1);
+  }
+  return EXCEPTION_EXECUTE_HANDLER;
+}
+
+static void install_crash_handler() {
+  SetUnhandledExceptionFilter((LPTOP_LEVEL_EXCEPTION_FILTER) crash_handler);
+  _set_abort_behavior(0, _WRITE_ABORT_MSG);
+  _set_abort_behavior(0, _CALL_REPORTFAULT);
+}
+#else
+static void install_crash_handler() { }
+#endif
+
 void grpc_test_init(int argc, char **argv) {
+  install_crash_handler();
   gpr_log(GPR_DEBUG, "test slowdown: machine=%f build=%f total=%f",
           (double)GRPC_TEST_SLOWDOWN_MACHINE_FACTOR,
           (double)GRPC_TEST_SLOWDOWN_BUILD_FACTOR,


### PR DESCRIPTION
Will prevent Windows tests to display a pop-up message in case of a failure. Essential for Jenkins testing.