### PR TITLE
Filtering stdout for JUnit report in case of timeouts.

### DIFF
--- a/tools/run_tests/jobset.py
+++ b/tools/run_tests/jobset.py
@@ -209,10 +209,11 @@ class Job(object):
     elif self._state == _RUNNING and time.time() - self._start > 600:
       self._tempfile.seek(0)
       stdout = self._tempfile.read()
+      filtered_stdout = filter(lambda x: x in string.printable, stdout.decode(errors='ignore'))
       message('TIMEOUT', self._spec.shortname, stdout, do_newline=True)
       self.kill()
       if self._xml_test is not None:
-        ET.SubElement(self._xml_test, 'system-out').text = stdout
+        ET.SubElement(self._xml_test, 'system-out').text = filtered_stdout
         ET.SubElement(self._xml_test, 'error', message='Timeout')
     return self._state
 


### PR DESCRIPTION
We're not properly filtering stdout in case we're timeouting. This generates invalid XML output.