### PR TITLE
Introduced InteropContextInspector 

### DIFF
--- a/include/grpc++/server_context.h
+++ b/include/grpc++/server_context.h
@@ -97,7 +97,7 @@ class ServerContext {
   void AddInitialMetadata(const grpc::string& key, const grpc::string& value);
   void AddTrailingMetadata(const grpc::string& key, const grpc::string& value);
 
-  bool IsCancelled();
+  bool IsCancelled() const;
 
   const std::multimap<grpc::string, grpc::string>& client_metadata() {
     return client_metadata_;

--- a/include/grpc++/server_context.h
+++ b/include/grpc++/server_context.h
@@ -76,6 +76,10 @@ class CallOpBuffer;
 class CompletionQueue;
 class Server;
 
+namespace testing {
+class InteropContextInspector;
+}  // namespace testing
+
 // Interface of server side rpc context.
 class ServerContext {
  public:
@@ -104,6 +108,7 @@ class ServerContext {
   }
 
  private:
+  friend class ::grpc::testing::InteropContextInspector;
   friend class ::grpc::Server;
   template <class W, class R>
   friend class ::grpc::ServerAsyncReader;

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -144,7 +144,7 @@ void ServerContext::AddTrailingMetadata(const grpc::string& key,
   trailing_metadata_.insert(std::make_pair(key, value));
 }
 
-bool ServerContext::IsCancelled() {
+bool ServerContext::IsCancelled() const {
   return completion_op_ && completion_op_->CheckCancelled(cq_);
 }
 

--- a/test/cpp/interop/server_helper.cc
+++ b/test/cpp/interop/server_helper.cc
@@ -62,5 +62,14 @@ InteropContextInspector::InteropContextInspector(
     const ::grpc::ServerContext& context)
     : context_(context) {}
 
+std::shared_ptr<const AuthContext> InteropContextInspector::GetAuthContext()
+    const {
+  return context_.auth_context();
+}
+
+bool InteropContextInspector::IsCancelled() const {
+  return context_.IsCancelled();
+}
+
 }  // namespace testing
 }  // namespace grpc

--- a/test/cpp/interop/server_helper.cc
+++ b/test/cpp/interop/server_helper.cc
@@ -58,5 +58,9 @@ std::shared_ptr<ServerCredentials> CreateInteropServerCredentials() {
   }
 }
 
+InteropContextInspector::InteropContextInspector(
+    const ::grpc::ServerContext& context)
+    : context_(context) {}
+
 }  // namespace testing
 }  // namespace grpc

--- a/test/cpp/interop/server_helper.h
+++ b/test/cpp/interop/server_helper.h
@@ -46,7 +46,7 @@ std::shared_ptr<ServerCredentials> CreateInteropServerCredentials();
 
 class InteropContextInspector {
  public:
-  InteropContextInspector (const ::grpc::ServerContext& context);
+  InteropContextInspector(const ::grpc::ServerContext& context);
 
   // Inspector methods, able to peek inside ServerContext go here.
 

--- a/test/cpp/interop/server_helper.h
+++ b/test/cpp/interop/server_helper.h
@@ -48,7 +48,9 @@ class InteropContextInspector {
  public:
   InteropContextInspector(const ::grpc::ServerContext& context);
 
-  // Inspector methods, able to peek inside ServerContext go here.
+  // Inspector methods, able to peek inside ServerContext, follow.
+  std::shared_ptr<const AuthContext> GetAuthContext() const;
+  bool IsCancelled() const;
 
  private:
   const ::grpc::ServerContext& context_;

--- a/test/cpp/interop/server_helper.h
+++ b/test/cpp/interop/server_helper.h
@@ -36,12 +36,23 @@
 
 #include <memory>
 
+#include <grpc++/server_context.h>
 #include <grpc++/server_credentials.h>
 
 namespace grpc {
 namespace testing {
 
 std::shared_ptr<ServerCredentials> CreateInteropServerCredentials();
+
+class InteropContextInspector {
+ public:
+  InteropContextInspector (const ::grpc::ServerContext& context);
+
+  // Inspector methods, able to peek inside ServerContext go here.
+
+ private:
+  const ::grpc::ServerContext& context_;
+};
 
 }  // namespace testing
 }  // namespace grpc


### PR DESCRIPTION
In order to be able to peek into server contexts during interop testing.

This is just the skeleton, as the motivating usecase (compression) lives in #2135. 