### PR TITLE
Adding a handler for abort().

### DIFF
--- a/test/core/util/test_config.c
+++ b/test/core/util/test_config.c
@@ -66,10 +66,20 @@ LONG crash_handler(struct _EXCEPTION_POINTERS* ex_info) {
   return EXCEPTION_EXECUTE_HANDLER;
 }
 
+void abort_handler(int sig) {
+  gpr_log(GPR_DEBUG, "Abort handler called.");
+  if (IsDebuggerPresent()) {
+    __debugbreak();
+  } else {
+    _exit(1);
+  }
+}
+
 static void install_crash_handler() {
   SetUnhandledExceptionFilter((LPTOP_LEVEL_EXCEPTION_FILTER) crash_handler);
   _set_abort_behavior(0, _WRITE_ABORT_MSG);
   _set_abort_behavior(0, _CALL_REPORTFAULT);
+  signal(SIGABRT, abort_handler);
 }
 #else
 static void install_crash_handler() { }


### PR DESCRIPTION
We want to have a chance to debug a call to abort() in case we have a debugger attached.