### PR TITLE
Fixes for older C++ compilers (remove lambdas, brace init, and nullptr ambiguity)

### DIFF
--- a/include/grpc++/impl/call.h
+++ b/include/grpc++/impl/call.h
@@ -172,17 +172,31 @@ class CallOpRecvMessage {
   grpc_byte_buffer* recv_buf_;
 };
 
+namespace CallOpGenericRecvMessageHelper {
+class DeserializeFunc {
+ public:
+  virtual Status deser(grpc_byte_buffer* buf,int max_message_size) = 0;
+};
+
+template<class R> class DeserializeFuncType : public DeserializeFunc {
+ public:
+  DeserializeFuncType(R *message): message_(message) {}
+  Status deser(grpc_byte_buffer* buf,int max_message_size) {
+    return SerializationTraits<R>::Deserialize(buf, message_,
+					       max_message_size);
+  }
+ private:
+  R *message_; // Not a managed pointer because management is external to this
+};
+}; // namespace CallOpGenericRecvMessageHelper
+
 class CallOpGenericRecvMessage {
  public:
   CallOpGenericRecvMessage() : got_message(false) {}
 
-  template <class R>
-  void RecvMessage(R* message) {
-    deserialize_ = [message](grpc_byte_buffer* buf,
-                             int max_message_size) -> Status {
-      return SerializationTraits<R>::Deserialize(buf, message,
-                                                 max_message_size);
-    };
+  template <class R> void RecvMessage(R* message) {
+    deserialize_.reset(new CallOpGenericRecvMessageHelper::
+		       DeserializeFuncType<R>(message));
   }
 
   bool got_message;
@@ -201,7 +215,7 @@ class CallOpGenericRecvMessage {
     if (recv_buf_) {
       if (*status) {
         got_message = true;
-        *status = deserialize_(recv_buf_, max_message_size).ok();
+        *status = deserialize_->deser(recv_buf_, max_message_size).ok();
       } else {
         got_message = false;
         grpc_byte_buffer_destroy(recv_buf_);
@@ -210,12 +224,11 @@ class CallOpGenericRecvMessage {
       got_message = false;
       *status = false;
     }
-    deserialize_ = DeserializeFunc();
+    deserialize_.reset();
   }
 
  private:
-  typedef std::function<Status(grpc_byte_buffer*, int)> DeserializeFunc;
-  DeserializeFunc deserialize_;
+  std::unique_ptr<CallOpGenericRecvMessageHelper::DeserializeFunc> deserialize_;
   grpc_byte_buffer* recv_buf_;
 };
 

--- a/include/grpc++/impl/call.h
+++ b/include/grpc++/impl/call.h
@@ -179,10 +179,11 @@ class DeserializeFunc {
 };
 
 template <class R>
-class DeserializeFuncType : public DeserializeFunc {
+class DeserializeFuncType GRPC_FINAL : public DeserializeFunc {
  public:
   DeserializeFuncType(R* message) : message_(message) {}
-  Status Deserialize(grpc_byte_buffer* buf, int max_message_size) {
+  Status Deserialize(grpc_byte_buffer* buf,
+                     int max_message_size) GRPC_OVERRIDE {
     return SerializationTraits<R>::Deserialize(buf, message_, max_message_size);
   }
 

--- a/include/grpc++/impl/call.h
+++ b/include/grpc++/impl/call.h
@@ -175,28 +175,30 @@ class CallOpRecvMessage {
 namespace CallOpGenericRecvMessageHelper {
 class DeserializeFunc {
  public:
-  virtual Status deser(grpc_byte_buffer* buf,int max_message_size) = 0;
+  virtual Status Deserialize(grpc_byte_buffer* buf, int max_message_size) = 0;
 };
 
-template<class R> class DeserializeFuncType : public DeserializeFunc {
+template <class R>
+class DeserializeFuncType : public DeserializeFunc {
  public:
-  DeserializeFuncType(R *message): message_(message) {}
-  Status deser(grpc_byte_buffer* buf,int max_message_size) {
-    return SerializationTraits<R>::Deserialize(buf, message_,
-					       max_message_size);
+  DeserializeFuncType(R* message) : message_(message) {}
+  Status Deserialize(grpc_byte_buffer* buf, int max_message_size) {
+    return SerializationTraits<R>::Deserialize(buf, message_, max_message_size);
   }
+
  private:
-  R *message_; // Not a managed pointer because management is external to this
+  R* message_;  // Not a managed pointer because management is external to this
 };
-}; // namespace CallOpGenericRecvMessageHelper
+}  // namespace CallOpGenericRecvMessageHelper
 
 class CallOpGenericRecvMessage {
  public:
   CallOpGenericRecvMessage() : got_message(false) {}
 
-  template <class R> void RecvMessage(R* message) {
-    deserialize_.reset(new CallOpGenericRecvMessageHelper::
-		       DeserializeFuncType<R>(message));
+  template <class R>
+  void RecvMessage(R* message) {
+    deserialize_.reset(
+        new CallOpGenericRecvMessageHelper::DeserializeFuncType<R>(message));
   }
 
   bool got_message;
@@ -215,7 +217,7 @@ class CallOpGenericRecvMessage {
     if (recv_buf_) {
       if (*status) {
         got_message = true;
-        *status = deserialize_->deser(recv_buf_, max_message_size).ok();
+        *status = deserialize_->Deserialize(recv_buf_, max_message_size).ok();
       } else {
         got_message = false;
         grpc_byte_buffer_destroy(recv_buf_);

--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -57,13 +57,12 @@ void PrintProtoRpcDeclarationAsPragma(Printer *printer,
   vars["server_stream"] = method->server_streaming() ? "stream " : "";
 
   printer->Print(vars,
-      "#pragma mark $method_name$($client_stream$$request_type$)"
-      " returns ($server_stream$$response_type$)\n\n");
+                 "#pragma mark $method_name$($client_stream$$request_type$)"
+                 " returns ($server_stream$$response_type$)\n\n");
 }
 
-void PrintMethodSignature(Printer *printer,
-                          const MethodDescriptor *method,
-                          const map<string, string>& vars) {
+void PrintMethodSignature(Printer *printer, const MethodDescriptor *method,
+                          const map<string, string> &vars) {
   // TODO(jcanizales): Print method comments.
 
   printer->Print(vars, "- ($return_type$)$method_name$With");
@@ -75,16 +74,17 @@ void PrintMethodSignature(Printer *printer,
 
   // TODO(jcanizales): Put this on a new line and align colons.
   if (method->server_streaming()) {
-    printer->Print(vars, " eventHandler:(void(^)(BOOL done, "
-      "$response_class$ *response, NSError *error))eventHandler");
+    printer->Print(vars,
+                   " eventHandler:(void(^)(BOOL done, "
+                   "$response_class$ *response, NSError *error))eventHandler");
   } else {
-    printer->Print(vars, " handler:(void(^)($response_class$ *response, "
-      "NSError *error))handler");
+    printer->Print(vars,
+                   " handler:(void(^)($response_class$ *response, "
+                   "NSError *error))handler");
   }
 }
 
-void PrintSimpleSignature(Printer *printer,
-                          const MethodDescriptor *method,
+void PrintSimpleSignature(Printer *printer, const MethodDescriptor *method,
                           map<string, string> vars) {
   vars["method_name"] =
       grpc_generator::LowercaseFirstLetter(vars["method_name"]);
@@ -92,26 +92,24 @@ void PrintSimpleSignature(Printer *printer,
   PrintMethodSignature(printer, method, vars);
 }
 
-void PrintAdvancedSignature(Printer *printer,
-                            const MethodDescriptor *method,
+void PrintAdvancedSignature(Printer *printer, const MethodDescriptor *method,
                             map<string, string> vars) {
   vars["method_name"] = "RPCTo" + vars["method_name"];
   vars["return_type"] = "ProtoRPC *";
   PrintMethodSignature(printer, method, vars);
 }
 
-inline map<string, string>&& GetMethodVars(const MethodDescriptor *method) {
-  map<string,string> res;
+inline map<string, string> GetMethodVars(const MethodDescriptor *method) {
+  map<string, string> res;
   res["method_name"] = method->name();
   res["request_type"] = method->input_type()->name();
   res["response_type"] = method->output_type()->name();
   res["request_class"] = ClassName(method->input_type());
   res["response_class"] = ClassName(method->output_type());
-  return std::forward<map<string,string>>(res);
+  return res;
 }
 
-void PrintMethodDeclarations(Printer *printer,
-                             const MethodDescriptor *method) {
+void PrintMethodDeclarations(Printer *printer, const MethodDescriptor *method) {
   map<string, string> vars = GetMethodVars(method);
 
   PrintProtoRpcDeclarationAsPragma(printer, method, vars);
@@ -122,8 +120,7 @@ void PrintMethodDeclarations(Printer *printer,
   printer->Print(";\n\n\n");
 }
 
-void PrintSimpleImplementation(Printer *printer,
-                               const MethodDescriptor *method,
+void PrintSimpleImplementation(Printer *printer, const MethodDescriptor *method,
                                map<string, string> vars) {
   printer->Print("{\n");
   printer->Print(vars, "  [[self RPCTo$method_name$With");
@@ -180,7 +177,7 @@ void PrintMethodImplementations(Printer *printer,
   PrintAdvancedImplementation(printer, method, vars);
 }
 
-} // namespace
+}  // namespace
 
 string GetHeader(const ServiceDescriptor *service) {
   string output;
@@ -188,7 +185,7 @@ string GetHeader(const ServiceDescriptor *service) {
     // Scope the output stream so it closes and finalizes output to the string.
     grpc::protobuf::io::StringOutputStream output_stream(&output);
     Printer printer(&output_stream, '$');
-  
+
     printer.Print("@protocol GRXWriteable;\n");
     printer.Print("@protocol GRXWriter;\n\n");
 
@@ -201,12 +198,15 @@ string GetHeader(const ServiceDescriptor *service) {
     }
     printer.Print("@end\n\n");
 
-    printer.Print("// Basic service implementation, over gRPC, that only does"
+    printer.Print(
+        "// Basic service implementation, over gRPC, that only does"
         " marshalling and parsing.\n");
-    printer.Print(vars, "@interface $service_class$ :"
-      " ProtoService<$service_class$>\n");
-    printer.Print("- (instancetype)initWithHost:(NSString *)host"
-      " NS_DESIGNATED_INITIALIZER;\n");
+    printer.Print(vars,
+                  "@interface $service_class$ :"
+                  " ProtoService<$service_class$>\n");
+    printer.Print(
+        "- (instancetype)initWithHost:(NSString *)host"
+        " NS_DESIGNATED_INITIALIZER;\n");
     printer.Print("@end\n");
   }
   return output;
@@ -224,18 +224,20 @@ string GetSource(const ServiceDescriptor *service) {
                                 {"package", service->file()->package()}};
 
     printer.Print(vars,
-        "static NSString *const kPackageName = @\"$package$\";\n");
-    printer.Print(vars,
-        "static NSString *const kServiceName = @\"$service_name$\";\n\n");
+                  "static NSString *const kPackageName = @\"$package$\";\n");
+    printer.Print(
+        vars, "static NSString *const kServiceName = @\"$service_name$\";\n\n");
 
     printer.Print(vars, "@implementation $service_class$\n\n");
-  
+
     printer.Print("// Designated initializer\n");
     printer.Print("- (instancetype)initWithHost:(NSString *)host {\n");
-    printer.Print("  return (self = [super initWithHost:host"
+    printer.Print(
+        "  return (self = [super initWithHost:host"
         " packageName:kPackageName serviceName:kServiceName]);\n");
     printer.Print("}\n\n");
-    printer.Print("// Override superclass initializer to disallow different"
+    printer.Print(
+        "// Override superclass initializer to disallow different"
         " package and service names.\n");
     printer.Print("- (instancetype)initWithHost:(NSString *)host\n");
     printer.Print("                 packageName:(NSString *)packageName\n");
@@ -252,4 +254,4 @@ string GetSource(const ServiceDescriptor *service) {
   return output;
 }
 
-} // namespace grpc_objective_c_generator
+}  // namespace grpc_objective_c_generator

--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -100,14 +100,14 @@ void PrintAdvancedSignature(Printer *printer,
   PrintMethodSignature(printer, method, vars);
 }
 
-inline map<string, string> GetMethodVars(const MethodDescriptor *method) {
+inline map<string, string>&& GetMethodVars(const MethodDescriptor *method) {
   map<string,string> res;
   res["method_name"] = method->name();
   res["request_type"] = method->input_type()->name();
   res["response_type"] = method->output_type()->name();
   res["request_class"] = ClassName(method->input_type());
   res["response_class"] = ClassName(method->output_type());
-  return res;
+  return std::forward<map<string,string>>(res);
 }
 
 void PrintMethodDeclarations(Printer *printer,

--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -101,11 +101,13 @@ void PrintAdvancedSignature(Printer *printer,
 }
 
 inline map<string, string> GetMethodVars(const MethodDescriptor *method) {
-  return {{ "method_name", method->name() },
-          { "request_type", method->input_type()->name() },
-          { "response_type", method->output_type()->name() },
-          { "request_class", ClassName(method->input_type()) },
-          { "response_class", ClassName(method->output_type()) }};
+  map<string,string> res;
+  res["method_name"] = method->name();
+  res["request_type"] = method->input_type()->name();
+  res["response_type"] = method->output_type()->name();
+  res["request_class"] = ClassName(method->input_type());
+  res["response_class"] = ClassName(method->output_type());
+  return res;
 }
 
 void PrintMethodDeclarations(Printer *printer,

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -99,7 +99,8 @@ void CheckAuthContext(T* context) {
 class TestServiceImpl : public ::grpc::cpp::test::util::TestService::Service {
  public:
   TestServiceImpl() : signal_client_(false), host_() {}
-  explicit TestServiceImpl(const grpc::string& host) : signal_client_(false), host_(new grpc::string(host)) {}
+  explicit TestServiceImpl(const grpc::string& host)
+      : signal_client_(false), host_(new grpc::string(host)) {}
 
   Status Echo(ServerContext* context, const EchoRequest* request,
               EchoResponse* response) GRPC_OVERRIDE {
@@ -224,7 +225,8 @@ class TestServiceImplDupPkg
 
 class End2endTest : public ::testing::Test {
  protected:
-  End2endTest() : kMaxMessageSize_(8192), special_service_("special"), thread_pool_(2) {}
+  End2endTest()
+      : kMaxMessageSize_(8192), special_service_("special"), thread_pool_(2) {}
 
   void SetUp() GRPC_OVERRIDE {
     int port = grpc_pick_unused_port_or_die();

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -98,7 +98,7 @@ void CheckAuthContext(T* context) {
 
 class TestServiceImpl : public ::grpc::cpp::test::util::TestService::Service {
  public:
-  TestServiceImpl() : signal_client_(false), host_(nullptr) {}
+  TestServiceImpl() : signal_client_(false), host_() {}
   explicit TestServiceImpl(const grpc::string& host) : signal_client_(false), host_(new grpc::string(host)) {}
 
   Status Echo(ServerContext* context, const EchoRequest* request,


### PR DESCRIPTION
Fixes #2412 .
Note that the qps family of tests will still not build, as these use numerous banned features (lambdas, local templates) . However, this should enable all of the other tests and C++ library to build in gcc 4.4 .
