### PR TITLE
Update homebrew PHP extension location

### DIFF
--- a/src/php/bin/determine_extension_dir.sh
+++ b/src/php/bin/determine_extension_dir.sh
@@ -27,12 +27,12 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 set -e
 default_extension_dir=$(php-config --extension-dir)
-if command -v brew >/dev/null && [ -d $(brew --prefix)/opt/grpc-php ]; then
-  # homebrew and the grpc-php formula are installed
-  extension_dir="-d extension_dir="$(brew --prefix)/opt/grpc-php
+if command -v brew > /dev/null && \
+   brew ls --versions | grep php5[5\|6]-grpc > /dev/null; then
+  # the grpc php extension was installed by homebrew
+  :
 elif [ ! -e $default_extension_dir/grpc.so ]; then
   # the grpc extension is not found in the default PHP extension dir
   # try the source modules directory
@@ -45,5 +45,5 @@ elif [ ! -e $default_extension_dir/grpc.so ]; then
   for f in $default_extension_dir/*.so; do
     ln -s $f $module_dir/$(basename $f) &> /dev/null || true
   done
-  extension_dir="-d extension_dir="$module_dir
+  extension_dir="-d extension_dir=${module_dir} -d extension=grpc.so"
 fi

--- a/src/php/bin/determine_extension_dir.sh
+++ b/src/php/bin/determine_extension_dir.sh
@@ -30,7 +30,7 @@
 set -e
 default_extension_dir=$(php-config --extension-dir)
 if command -v brew > /dev/null && \
-   brew ls --versions | grep php5[5\|6]-grpc > /dev/null; then
+   brew ls --versions | grep php5[56]-grpc > /dev/null; then
   # the grpc php extension was installed by homebrew
   :
 elif [ ! -e $default_extension_dir/grpc.so ]; then

--- a/src/php/bin/interop_client.sh
+++ b/src/php/bin/interop_client.sh
@@ -31,5 +31,5 @@
 set -e
 cd $(dirname $0)
 source ./determine_extension_dir.sh
-php $extension_dir -d extension=grpc.so \
+php $extension_dir \
   ../tests/interop/interop_client.php $@ 1>&2

--- a/src/php/bin/run_gen_code_test.sh
+++ b/src/php/bin/run_gen_code_test.sh
@@ -31,8 +31,8 @@
 set -e
 cd $(dirname $0)
 source ./determine_extension_dir.sh
-export GRPC_TEST_HOST=localhost:7071
-php $extension_dir -d extension=grpc.so $(which phpunit) -v --debug --strict \
+export GRPC_TEST_HOST=localhost:50051
+php $extension_dir $(which phpunit) -v --debug --strict \
   ../tests/generated_code/GeneratedCodeTest.php
-php $extension_dir -d extension=grpc.so $(which phpunit) -v --debug --strict \
+php $extension_dir $(which phpunit) -v --debug --strict \
   ../tests/generated_code/GeneratedCodeWithCallbackTest.php

--- a/src/php/bin/run_tests.sh
+++ b/src/php/bin/run_tests.sh
@@ -33,5 +33,5 @@
 set -e
 cd $(dirname $0)
 source ./determine_extension_dir.sh
-php $extension_dir -d extension=grpc.so $(which phpunit) -v --debug --strict \
+php $extension_dir $(which phpunit) -v --debug --strict \
   ../tests/unit_tests


### PR DESCRIPTION
This works in conjunction with grpc/homebrew-grpc#46.

This PR changes the way how our PHP test scripts locate the grpc extension library because of the new (and hopefully proper) way of building our grpc PHP extension via homebrew. 