### PR TITLE
Changed to newer, simpler server construction interface

### DIFF
--- a/src/node/README.md
+++ b/src/node/README.md
@@ -54,10 +54,10 @@ function loadObject(reflectionObject)
 Returns the same structure that `load` returns, but takes a reflection object from `ProtoBuf.js` instead of a file name.
 
 ```javascript
-function buildServer(serviceArray)
+function Server([serverOpions])
 ```
 
-Takes an array of service objects and returns a constructor for a server that handles requests to all of those services.
+Constructs a server to which service/implementation pairs can be added.
 
 
 ```javascript

--- a/src/node/examples/math_server.js
+++ b/src/node/examples/math_server.js
@@ -36,8 +36,6 @@
 var grpc = require('..');
 var math = grpc.load(__dirname + '/math.proto').math;
 
-var Server = grpc.buildServer([math.Math.service]);
-
 /**
  * Server function for division. Provides the /Math/DivMany and /Math/Div
  * functions (Div is just DivMany with only one stream element). For each
@@ -108,19 +106,17 @@ function mathDivMany(stream) {
     stream.end();
   });
 }
-
-var server = new Server({
-  'math.Math' : {
-    div: mathDiv,
-    fib: mathFib,
-    sum: mathSum,
-    divMany: mathDivMany
-  }
+var server = new grpc.Server();
+server.addProtoService(math.Math.service, {
+  div: mathDiv,
+  fib: mathFib,
+  sum: mathSum,
+  divMany: mathDivMany
 });
 
 if (require.main === module) {
   server.bind('0.0.0.0:50051');
-  server.listen();
+  server.start();
 }
 
 /**

--- a/src/node/examples/route_guide_server.js
+++ b/src/node/examples/route_guide_server.js
@@ -40,8 +40,6 @@ var _ = require('lodash');
 var grpc = require('..');
 var examples = grpc.load(__dirname + '/route_guide.proto').examples;
 
-var Server = grpc.buildServer([examples.RouteGuide.service]);
-
 var COORD_FACTOR = 1e7;
 
 /**
@@ -228,14 +226,14 @@ function routeChat(call) {
  * @return {Server} The new server object
  */
 function getServer() {
-  return new Server({
-    'examples.RouteGuide' : {
-      getFeature: getFeature,
-      listFeatures: listFeatures,
-      recordRoute: recordRoute,
-      routeChat: routeChat
-    }
+  var server = new grpc.Server();
+  server.addProtoService(examples.RouteGuide.service, {
+    getFeature: getFeature,
+    listFeatures: listFeatures,
+    recordRoute: recordRoute,
+    routeChat: routeChat
   });
+  return server;
 }
 
 if (require.main === module) {

--- a/src/node/examples/stock_server.js
+++ b/src/node/examples/stock_server.js
@@ -37,8 +37,6 @@ var _ = require('lodash');
 var grpc = require('..');
 var examples = grpc.load(__dirname + '/stock.proto').examples;
 
-var StockServer = grpc.buildServer([examples.Stock.service]);
-
 function getLastTradePrice(call, callback) {
   callback(null, {symbol: call.request.symbol, price: 88});
 }
@@ -73,13 +71,12 @@ function getLastTradePriceMultiple(call) {
   });
 }
 
-var stockServer = new StockServer({
-  'examples.Stock' : {
-    getLastTradePrice: getLastTradePrice,
-    getLastTradePriceMultiple: getLastTradePriceMultiple,
-    watchFutureTrades: watchFutureTrades,
-    getHighestTradePrice: getHighestTradePrice
-  }
+var stockServer = new grpc.Server();
+stockServer.addProtoService(examples.Stock.service, {
+  getLastTradePrice: getLastTradePrice,
+  getLastTradePriceMultiple: getLastTradePriceMultiple,
+  watchFutureTrades: watchFutureTrades,
+  getHighestTradePrice: getHighestTradePrice
 });
 
 if (require.main === module) {

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -133,9 +133,9 @@ exports.loadObject = loadObject;
 exports.load = load;
 
 /**
- * See docs for server.makeServerConstructor
+ * See docs for Server
  */
-exports.buildServer = server.makeProtobufServerConstructor;
+exports.Server = server.Server;
 
 /**
  * Status name to code number mapping
@@ -159,5 +159,3 @@ exports.ServerCredentials = grpc.ServerCredentials;
 exports.getGoogleAuthDelegate = getGoogleAuthDelegate;
 
 exports.makeGenericClientConstructor = client.makeClientConstructor;
-
-exports.makeGenericServerConstructor = server.makeServerConstructor;

--- a/src/node/interop/interop_server.js
+++ b/src/node/interop/interop_server.js
@@ -172,7 +172,7 @@ function getServer(port, tls) {
                                                     key_data,
                                                     pem_data);
   }
-  var server = new grpc.Server(null, options);
+  var server = new grpc.Server(options);
   server.addProtoService(testProto.TestService.service, {
     emptyCall: handleEmpty,
     unaryCall: handleUnary,

--- a/src/node/interop/interop_server.js
+++ b/src/node/interop/interop_server.js
@@ -38,7 +38,6 @@ var path = require('path');
 var _ = require('lodash');
 var grpc = require('..');
 var testProto = grpc.load(__dirname + '/test.proto').grpc.testing;
-var Server = grpc.buildServer([testProto.TestService.service]);
 
 /**
  * Create a buffer filled with size zeroes
@@ -173,16 +172,15 @@ function getServer(port, tls) {
                                                     key_data,
                                                     pem_data);
   }
-  var server = new Server({
-    'grpc.testing.TestService' : {
-      emptyCall: handleEmpty,
-      unaryCall: handleUnary,
-      streamingOutputCall: handleStreamingOutput,
-      streamingInputCall: handleStreamingInput,
-      fullDuplexCall: handleFullDuplex,
-      halfDuplexCall: handleHalfDuplex
-    }
-  }, null, options);
+  var server = new grpc.Server(null, options);
+  server.addProtoService(testProto.TestService.service, {
+    emptyCall: handleEmpty,
+    unaryCall: handleUnary,
+    streamingOutputCall: handleStreamingOutput,
+    streamingInputCall: handleStreamingInput,
+    fullDuplexCall: handleFullDuplex,
+    halfDuplexCall: handleHalfDuplex
+  });
   var port_num = server.bind('0.0.0.0:' + port, server_creds);
   return {server: server, port: port_num};
 }

--- a/src/node/test/health_test.js
+++ b/src/node/test/health_test.js
@@ -49,14 +49,13 @@ describe('Health Checking', function() {
       'grpc.test.TestService': 'SERVING'
     }
   };
-  var HealthServer = grpc.buildServer([health.service]);
-  var healthServer = new HealthServer({
-    'grpc.health.v1alpha.Health': new health.Implementation(statusMap)
-  });
+  var healthServer = new grpc.Server();
+  healthServer.addProtoService(health.service,
+                               new health.Implementation(statusMap));
   var healthClient;
   before(function() {
     var port_num = healthServer.bind('0.0.0.0:0');
-    healthServer.listen();
+    healthServer.start();
     healthClient = new health.Client('localhost:' + port_num);
   });
   after(function() {

--- a/src/node/test/interop_sanity_test.js
+++ b/src/node/test/interop_sanity_test.js
@@ -46,7 +46,7 @@ describe('Interop tests', function() {
   before(function(done) {
     var server_obj = interop_server.getServer(0, true);
     server = server_obj.server;
-    server.listen();
+    server.start();
     port = 'localhost:' + server_obj.port;
     done();
   });

--- a/src/node/test/math_client_test.js
+++ b/src/node/test/math_client_test.js
@@ -52,7 +52,7 @@ var server = require('../examples/math_server.js');
 describe('Math client', function() {
   before(function(done) {
     var port_num = server.bind('0.0.0.0:0');
-    server.listen();
+    server.start();
     math_client = new math.Math('localhost:' + port_num);
     done();
   });


### PR DESCRIPTION
This replaces the existing two-phase server construction with creating a server object and then attaching service/implementation pairs to it. Also changes `start` to `listen`, because that more clearly indicates what it does.

This resolves #2456. With the new change, it also resolves #2465.