### PR TITLE
Fix authority in uri_parser

### DIFF
--- a/src/core/client_config/uri_parser.c
+++ b/src/core/client_config/uri_parser.c
@@ -99,7 +99,7 @@ grpc_uri *grpc_uri_parse(const char *uri_text, int suppress_errors) {
   if (uri_text[scheme_end + 1] == '/' && uri_text[scheme_end + 2] == '/') {
     authority_begin = scheme_end + 3;
     for (i = authority_begin; uri_text[i] != 0; i++) {
-      if (uri_text[i] == '/') {
+      if (uri_text[i] == '/' && authority_end == -1) {
         authority_end = i;
       }
       if (uri_text[i] == '?') {

--- a/src/core/client_config/uri_parser.c
+++ b/src/core/client_config/uri_parser.c
@@ -98,8 +98,8 @@ grpc_uri *grpc_uri_parse(const char *uri_text, int suppress_errors) {
 
   if (uri_text[scheme_end + 1] == '/' && uri_text[scheme_end + 2] == '/') {
     authority_begin = scheme_end + 3;
-    for (i = authority_begin; uri_text[i] != 0; i++) {
-      if (uri_text[i] == '/' && authority_end == -1) {
+    for (i = authority_begin; uri_text[i] != 0 && authority_end == -1; i++) {
+      if (uri_text[i] == '/') {
         authority_end = i;
       }
       if (uri_text[i] == '?') {

--- a/test/core/client_config/uri_parser_test.c
+++ b/test/core/client_config/uri_parser_test.c
@@ -60,6 +60,7 @@ int main(int argc, char **argv) {
   test_succeeds("http://www.google.com:90", "http", "www.google.com:90", "");
   test_succeeds("a192.4-df:foo.coom", "a192.4-df", "", "foo.coom");
   test_succeeds("a+b:foo.coom", "a+b", "", "foo.coom");
+  test_succeeds("zookeeper://127.0.0.1:2181/foo/bar", "zookeeper", "127.0.0.1:2181", "/foo/bar");
   test_fails("xyz");
   test_fails("http://www.google.com?why-are-you-using-queries");
   test_fails("dns:foo.com#fragments-arent-supported-here");


### PR DESCRIPTION
Fix authority and path in uri_parser.c. Authority begins with "//" and ends with the next "/".