### PR TITLE
Clean up some warnings in the ruby wrapping code

### DIFF
--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -131,7 +131,8 @@ static size_t md_ary_datasize(const void *p) {
 
 static const rb_data_type_t grpc_rb_md_ary_data_type = {
     "grpc_metadata_array",
-    {GRPC_RB_GC_NOT_MARKED, GRPC_RB_GC_DONT_FREE, md_ary_datasize},
+    {GRPC_RB_GC_NOT_MARKED, GRPC_RB_GC_DONT_FREE, md_ary_datasize,
+     {NULL, NULL}},
     NULL,
     NULL,
     0};
@@ -139,7 +140,8 @@ static const rb_data_type_t grpc_rb_md_ary_data_type = {
 /* Describes grpc_call struct for RTypedData */
 static const rb_data_type_t grpc_call_data_type = {
     "grpc_call",
-    {GRPC_RB_GC_NOT_MARKED, grpc_rb_call_destroy, GRPC_RB_MEMSIZE_UNAVAILABLE},
+    {GRPC_RB_GC_NOT_MARKED, grpc_rb_call_destroy, GRPC_RB_MEMSIZE_UNAVAILABLE,
+     {NULL, NULL}},
     NULL,
     NULL,
     /* it is unsafe to specify RUBY_TYPED_FREE_IMMEDIATELY because
@@ -275,6 +277,8 @@ static int grpc_rb_md_ary_capacity_hash_cb(VALUE key, VALUE val,
                                            VALUE md_ary_obj) {
   grpc_metadata_array *md_ary = NULL;
 
+  (void)key;
+
   /* Construct a metadata object from key and value and add it */
   TypedData_Get_Struct(md_ary_obj, grpc_metadata_array,
                        &grpc_rb_md_ary_data_type, md_ary);
@@ -348,6 +352,7 @@ VALUE grpc_rb_md_ary_to_h(grpc_metadata_array *md_ary) {
 */
 static int grpc_rb_call_check_op_keys_hash_cb(VALUE key, VALUE val,
                                               VALUE ops_ary) {
+  (void)val;
   /* Update the capacity; the value is an array, add capacity for each value in
    * the array */
   if (TYPE(key) != T_FIXNUM) {

--- a/src/ruby/ext/grpc/rb_channel.c
+++ b/src/ruby/ext/grpc/rb_channel.c
@@ -107,7 +107,8 @@ static void grpc_rb_channel_mark(void *p) {
 
 static rb_data_type_t grpc_channel_data_type = {
     "grpc_channel",
-    {grpc_rb_channel_mark, grpc_rb_channel_free, GRPC_RB_MEMSIZE_UNAVAILABLE},
+    {grpc_rb_channel_mark, grpc_rb_channel_free, GRPC_RB_MEMSIZE_UNAVAILABLE,
+     {NULL, NULL}},
     NULL, NULL,
     RUBY_TYPED_FREE_IMMEDIATELY
 };

--- a/src/ruby/ext/grpc/rb_channel_args.c
+++ b/src/ruby/ext/grpc/rb_channel_args.c
@@ -41,7 +41,8 @@
 
 static rb_data_type_t grpc_rb_channel_args_data_type = {
     "grpc_channel_args",
-    {GRPC_RB_GC_NOT_MARKED, GRPC_RB_GC_DONT_FREE, GRPC_RB_MEMSIZE_UNAVAILABLE},
+    {GRPC_RB_GC_NOT_MARKED, GRPC_RB_GC_DONT_FREE, GRPC_RB_MEMSIZE_UNAVAILABLE,
+     {NULL, NULL}},
     NULL, NULL,
     RUBY_TYPED_FREE_IMMEDIATELY
 };

--- a/src/ruby/ext/grpc/rb_completion_queue.c
+++ b/src/ruby/ext/grpc/rb_completion_queue.c
@@ -118,7 +118,7 @@ static void grpc_rb_completion_queue_destroy(void *p) {
 static rb_data_type_t grpc_rb_completion_queue_data_type = {
     "grpc_completion_queue",
     {GRPC_RB_GC_NOT_MARKED, grpc_rb_completion_queue_destroy,
-     GRPC_RB_MEMSIZE_UNAVAILABLE},
+     GRPC_RB_MEMSIZE_UNAVAILABLE, {NULL, NULL}},
     NULL, NULL,
     /* cannot immediately free because grpc_rb_completion_queue_shutdown_drain
      * calls rb_thread_call_without_gvl. */

--- a/src/ruby/ext/grpc/rb_credentials.c
+++ b/src/ruby/ext/grpc/rb_credentials.c
@@ -89,7 +89,7 @@ static void grpc_rb_credentials_mark(void *p) {
 static rb_data_type_t grpc_rb_credentials_data_type = {
     "grpc_credentials",
     {grpc_rb_credentials_mark, grpc_rb_credentials_free,
-     GRPC_RB_MEMSIZE_UNAVAILABLE},
+     GRPC_RB_MEMSIZE_UNAVAILABLE, {NULL, NULL}},
     NULL,
     NULL,
     RUBY_TYPED_FREE_IMMEDIATELY};

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -51,7 +51,8 @@ static VALUE grpc_rb_cTimeVal = Qnil;
 
 static rb_data_type_t grpc_rb_timespec_data_type = {
     "gpr_timespec",
-    {GRPC_RB_GC_NOT_MARKED, GRPC_RB_GC_DONT_FREE, GRPC_RB_MEMSIZE_UNAVAILABLE},
+    {GRPC_RB_GC_NOT_MARKED, GRPC_RB_GC_DONT_FREE, GRPC_RB_MEMSIZE_UNAVAILABLE,
+     {NULL, NULL}},
     NULL,
     NULL,
     RUBY_TYPED_FREE_IMMEDIATELY};
@@ -75,6 +76,7 @@ VALUE grpc_rb_cannot_init(VALUE self) {
 
 /* Init/Clone func that fails by raising an exception. */
 VALUE grpc_rb_cannot_init_copy(VALUE copy, VALUE self) {
+  (void)self;
   rb_raise(rb_eTypeError,
            "initialization of %s only allowed from the gRPC native layer",
            rb_obj_classname(copy));
@@ -250,7 +252,10 @@ static void Init_grpc_time_consts() {
   id_tv_nsec = rb_intern("tv_nsec");
 }
 
-static void grpc_rb_shutdown(ruby_vm_t *vm) { grpc_shutdown(); }
+static void grpc_rb_shutdown(ruby_vm_t *vm) {
+  (void)vm;
+  grpc_shutdown();
+}
 
 /* Initialize the GRPC module structs */
 

--- a/src/ruby/ext/grpc/rb_server.c
+++ b/src/ruby/ext/grpc/rb_server.c
@@ -94,7 +94,8 @@ static void grpc_rb_server_mark(void *p) {
 
 static const rb_data_type_t grpc_rb_server_data_type = {
     "grpc_server",
-    {grpc_rb_server_mark, grpc_rb_server_free, GRPC_RB_MEMSIZE_UNAVAILABLE},
+    {grpc_rb_server_mark, grpc_rb_server_free, GRPC_RB_MEMSIZE_UNAVAILABLE,
+     {NULL, NULL}},
     NULL,
     NULL,
     /* It is unsafe to specify RUBY_TYPED_FREE_IMMEDIATELY because the free function would block

--- a/src/ruby/ext/grpc/rb_server_credentials.c
+++ b/src/ruby/ext/grpc/rb_server_credentials.c
@@ -89,7 +89,7 @@ static void grpc_rb_server_credentials_mark(void *p) {
 static const rb_data_type_t grpc_rb_server_credentials_data_type = {
     "grpc_server_credentials",
     {grpc_rb_server_credentials_mark, grpc_rb_server_credentials_free,
-     GRPC_RB_MEMSIZE_UNAVAILABLE},
+     GRPC_RB_MEMSIZE_UNAVAILABLE, {NULL, NULL}},
     NULL, NULL,
     RUBY_TYPED_FREE_IMMEDIATELY
 };


### PR DESCRIPTION
This fixes #2457 and grpc/homebrew-grpc#49 (actually the same issue).