### PR TITLE
Subclass GRXWriter instead of conforming to its protocol

### DIFF
--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -67,7 +67,7 @@ void PrintMethodSignature(Printer *printer, const MethodDescriptor *method,
 
   printer->Print(vars, "- ($return_type$)$method_name$With");
   if (method->client_streaming()) {
-    printer->Print("RequestsWriter:(id<GRXWriter>)requestWriter");
+    printer->Print("RequestsWriter:(GRXWriter *)requestWriter");
   } else {
     printer->Print(vars, "Request:($request_class$ *)request");
   }

--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -89,7 +89,7 @@ extern id const kGRPCStatusMetadataKey;
 // To finish a call right away, invoke cancel.
 - (instancetype)initWithHost:(NSString *)host
                         path:(NSString *)path
-              requestsWriter:(id<GRXWriter>)requestsWriter NS_DESIGNATED_INITIALIZER;
+              requestsWriter:(GRXWriter *)requestsWriter NS_DESIGNATED_INITIALIZER;
 
 // Finishes the request side of this call, notifies the server that the RPC
 // should be cancelled, and finishes the response side of the call with an error

--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -52,7 +52,7 @@
 extern id const kGRPCStatusMetadataKey;
 
 // Represents a single gRPC remote call.
-@interface GRPCCall : NSObject<GRXWriter>
+@interface GRPCCall : GRXWriter
 
 // These HTTP headers will be passed to the server as part of this call. Each HTTP header is a
 // name-value pair with string names and either string or binary values.

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -79,7 +79,7 @@ NSString * const kGRPCStatusMetadataKey = @"io.grpc.StatusMetadataKey";
   // all. This wrapper over our actual writeable ensures thread-safety and
   // correct ordering.
   GRPCDelegateWrapper *_responseWriteable;
-  id<GRXWriter> _requestWriter;
+  GRXWriter *_requestWriter;
 
   NSMutableDictionary *_requestMetadata;
   NSMutableDictionary *_responseMetadata;
@@ -94,7 +94,7 @@ NSString * const kGRPCStatusMetadataKey = @"io.grpc.StatusMetadataKey";
 // Designated initializer
 - (instancetype)initWithHost:(NSString *)host
                         path:(NSString *)path
-              requestsWriter:(id<GRXWriter>)requestWriter {
+              requestsWriter:(GRXWriter *)requestWriter {
   if (!host || !path) {
     [NSException raise:NSInvalidArgumentException format:@"Neither host nor method can be nil."];
   }

--- a/src/objective-c/GRPCClient/private/GRPCDelegateWrapper.h
+++ b/src/objective-c/GRPCClient/private/GRPCDelegateWrapper.h
@@ -54,7 +54,7 @@
 // writesFinishedWithError: is sent to the writeable, and released after that.
 // This is used to create a retain cycle that keeps both objects alive until the
 // writing is explicitly finished.
-- (instancetype)initWithWriteable:(id<GRXWriteable>)writeable writer:(id<GRXWriter>)writer
+- (instancetype)initWithWriteable:(id<GRXWriteable>)writeable writer:(GRXWriter *)writer
     NS_DESIGNATED_INITIALIZER;
 
 // Enqueues writeValue: to be sent to the writeable in the main thread.

--- a/src/objective-c/GRPCClient/private/GRPCDelegateWrapper.h
+++ b/src/objective-c/GRPCClient/private/GRPCDelegateWrapper.h
@@ -33,8 +33,9 @@
 
 #import <Foundation/Foundation.h>
 
+#import <RxLibrary/GRXWriter.h>
+
 @protocol GRXWriteable;
-@protocol GRXWriter;
 
 // This is a thread-safe wrapper over a GRXWriteable instance. It lets one
 // enqueue calls to a GRXWriteable instance for the main thread, guaranteeing

--- a/src/objective-c/GRPCClient/private/GRPCDelegateWrapper.m
+++ b/src/objective-c/GRPCClient/private/GRPCDelegateWrapper.m
@@ -38,7 +38,7 @@
 @interface GRPCDelegateWrapper ()
 // These are atomic so that cancellation can nillify them from any thread.
 @property(atomic, strong) id<GRXWriteable> writeable;
-@property(atomic, strong) id<GRXWriter> writer;
+@property(atomic, strong) GRXWriter *writer;
 @end
 
 @implementation GRPCDelegateWrapper {
@@ -52,7 +52,7 @@
 }
 
 // Designated initializer
-- (instancetype)initWithWriteable:(id<GRXWriteable>)writeable writer:(id<GRXWriter>)writer {
+- (instancetype)initWithWriteable:(id<GRXWriteable>)writeable writer:(GRXWriter *)writer {
   if (self = [super init]) {
     _writeableQueue = dispatch_get_main_queue();
     _writeable = writeable;

--- a/src/objective-c/ProtoRPC/ProtoRPC.h
+++ b/src/objective-c/ProtoRPC/ProtoRPC.h
@@ -40,7 +40,7 @@
 
 - (instancetype)initWithHost:(NSString *)host
                       method:(ProtoMethod *)method
-              requestsWriter:(id<GRXWriter>)requestsWriter
+              requestsWriter:(GRXWriter *)requestsWriter
                responseClass:(Class)responseClass
           responsesWriteable:(id<GRXWriteable>)responsesWriteable NS_DESIGNATED_INITIALIZER;
 

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -35,7 +35,7 @@
 
 #import <GPBProtocolBuffers.h>
 #import <RxLibrary/GRXWriteable.h>
-#import <RxLibrary/GRXWriter.h>
+#import <RxLibrary/GRXForwardingWriter.h>
 #import <RxLibrary/GRXWriter+Transformations.h>
 
 @implementation ProtoRPC {
@@ -66,7 +66,7 @@
   }
   // A writer that serializes the proto messages to send.
   id<GRXWriter> bytesWriter =
-      [[[GRXWriter alloc] initWithWriter:requestsWriter] map:^id(GPBMessage *proto) {
+      [[[GRXForwardingWriter alloc] initWithWriter:requestsWriter] map:^id(GPBMessage *proto) {
         // TODO(jcanizales): Fail with an understandable error message if the requestsWriter isn't
         // sending GPBMessages.
         return [proto data];

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -46,7 +46,7 @@
 #pragma clang diagnostic ignored "-Wobjc-designated-initializers"
 - (instancetype)initWithHost:(NSString *)host
                         path:(NSString *)path
-              requestsWriter:(id<GRXWriter>)requestsWriter {
+              requestsWriter:(GRXWriter *)requestsWriter {
   [NSException raise:NSInvalidArgumentException
               format:@"Please use ProtoRPC's designated initializer instead."];
   return nil;
@@ -56,7 +56,7 @@
 // Designated initializer
 - (instancetype)initWithHost:(NSString *)host
                       method:(ProtoMethod *)method
-              requestsWriter:(id<GRXWriter>)requestsWriter
+              requestsWriter:(GRXWriter *)requestsWriter
                responseClass:(Class)responseClass
           responsesWriteable:(id<GRXWriteable>)responsesWriteable {
   // Because we can't tell the type system to constrain the class, we need to check at runtime:

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -35,7 +35,6 @@
 
 #import <GPBProtocolBuffers.h>
 #import <RxLibrary/GRXWriteable.h>
-#import <RxLibrary/GRXForwardingWriter.h>
 #import <RxLibrary/GRXWriter+Transformations.h>
 
 @implementation ProtoRPC {
@@ -65,12 +64,11 @@
                 format:@"A protobuf class to parse the responses must be provided."];
   }
   // A writer that serializes the proto messages to send.
-  id<GRXWriter> bytesWriter =
-      [[[GRXForwardingWriter alloc] initWithWriter:requestsWriter] map:^id(GPBMessage *proto) {
-        // TODO(jcanizales): Fail with an understandable error message if the requestsWriter isn't
-        // sending GPBMessages.
-        return [proto data];
-      }];
+  GRXWriter *bytesWriter = [requestsWriter map:^id(GPBMessage *proto) {
+    // TODO(jcanizales): Fail with an understandable error message if the requestsWriter isn't
+    // sending GPBMessages.
+    return [proto data];
+  }];
   if ((self = [super initWithHost:host path:method.HTTPPath requestsWriter:bytesWriter])) {
     // A writeable that parses the proto messages received.
     _responseWriteable = [[GRXWriteable alloc] initWithValueHandler:^(NSData *value) {

--- a/src/objective-c/ProtoRPC/ProtoService.h
+++ b/src/objective-c/ProtoRPC/ProtoService.h
@@ -35,7 +35,7 @@
 
 @class ProtoRPC;
 @protocol GRXWriteable;
-@protocol GRXWriter;
+@class GRXWriter;
 
 @interface ProtoService : NSObject
 - (instancetype)initWithHost:(NSString *)host
@@ -43,7 +43,7 @@
                  serviceName:(NSString *)serviceName NS_DESIGNATED_INITIALIZER;
 
 - (ProtoRPC *)RPCToMethod:(NSString *)method
-           requestsWriter:(id<GRXWriter>)requestsWriter
+           requestsWriter:(GRXWriter *)requestsWriter
   	        responseClass:(Class)responseClass
   	   responsesWriteable:(id<GRXWriteable>)responsesWriteable;
 @end

--- a/src/objective-c/ProtoRPC/ProtoService.m
+++ b/src/objective-c/ProtoRPC/ProtoService.m
@@ -66,7 +66,7 @@
 }
 
 - (ProtoRPC *)RPCToMethod:(NSString *)method
-           requestsWriter:(id<GRXWriter>)requestsWriter
+           requestsWriter:(GRXWriter *)requestsWriter
             responseClass:(Class)responseClass
        responsesWriteable:(id<GRXWriteable>)responsesWriteable {
   ProtoMethod *methodName = [[ProtoMethod alloc] initWithPackage:_packageName

--- a/src/objective-c/RxLibrary/GRXBufferedPipe.h
+++ b/src/objective-c/RxLibrary/GRXBufferedPipe.h
@@ -51,7 +51,7 @@
 // pipe will keep buffering all data written to it, your application could run out of memory and
 // crash. If you want to react to flow control signals to prevent that, instead of using this class
 // you can implement an object that conforms to GRXWriter.
-@interface GRXBufferedPipe : NSObject<GRXWriteable, GRXWriter>
+@interface GRXBufferedPipe : GRXWriter<GRXWriteable>
 
 // Convenience constructor.
 + (instancetype)pipe;

--- a/src/objective-c/RxLibrary/GRXForwardingWriter.h
+++ b/src/objective-c/RxLibrary/GRXForwardingWriter.h
@@ -33,6 +33,11 @@
 
 #import "GRXWriter.h"
 
-@implementation GRXWriter
-
+// A "proxy" class that simply forwards values, completion, and errors from its
+// input writer to its writeable.
+// It is useful as a superclass for pipes that act as a transformation of their
+// input writer, and for classes that represent objects with input and
+// output sequences of values, like an RPC.
+@interface GRXForwardingWriter : GRXWriter
+- (instancetype)initWithWriter:(id<GRXWriter>)writer NS_DESIGNATED_INITIALIZER;
 @end

--- a/src/objective-c/RxLibrary/GRXForwardingWriter.h
+++ b/src/objective-c/RxLibrary/GRXForwardingWriter.h
@@ -39,5 +39,5 @@
 // input writer, and for classes that represent objects with input and
 // output sequences of values, like an RPC.
 @interface GRXForwardingWriter : GRXWriter
-- (instancetype)initWithWriter:(id<GRXWriter>)writer NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithWriter:(GRXWriter *)writer NS_DESIGNATED_INITIALIZER;
 @end

--- a/src/objective-c/RxLibrary/GRXForwardingWriter.m
+++ b/src/objective-c/RxLibrary/GRXForwardingWriter.m
@@ -31,33 +31,82 @@
  *
  */
 
-#import "GRXMappingWriter.h"
-
-static id (^kIdentity)(id value) = ^id(id value) {
-  return value;
-};
+#import "GRXForwardingWriter.h"
 
 @interface GRXForwardingWriter () <GRXWriteable>
 @end
 
-@implementation GRXMappingWriter {
-  id (^_map)(id value);
+@implementation GRXForwardingWriter {
+  id<GRXWriter> _writer;
+  id<GRXWriteable> _writeable;
 }
 
-- (instancetype)initWithWriter:(id<GRXWriter>)writer {
-  return [self initWithWriter:writer map:nil];
+- (instancetype)init {
+  return [self initWithWriter:nil];
 }
 
 // Designated initializer
-- (instancetype)initWithWriter:(id<GRXWriter>)writer map:(id (^)(id value))map {
-  if ((self = [super initWithWriter:writer])) {
-    _map = map ?: kIdentity;
+- (instancetype)initWithWriter:(id<GRXWriter>)writer {
+  if (!writer) {
+    [NSException raise:NSInvalidArgumentException format:@"writer can't be nil."];
+  }
+  if ((self = [super init])) {
+    _writer = writer;
   }
   return self;
 }
 
-// Override
-- (void)writeValue:(id)value {
-  [super writeValue:_map(value)];
+// This is used to send a completion or an error to the writeable. It nillifies
+// our reference to it in order to guarantee no more messages are sent to it,
+// and to release it.
+- (void)finishOutputWithError:(NSError *)errorOrNil {
+  id<GRXWriteable> writeable = _writeable;
+  _writeable = nil;
+  [writeable writesFinishedWithError:errorOrNil];
 }
+
+// This is used to stop the input writer. It nillifies our reference to it
+// to release it.
+- (void)finishInput {
+  id<GRXWriter> writer = _writer;
+  _writer = nil;
+  writer.state = GRXWriterStateFinished;
+}
+
+#pragma mark GRXWriteable implementation
+
+- (void)writeValue:(id)value {
+  [_writeable writeValue:value];
+}
+
+- (void)writesFinishedWithError:(NSError *)errorOrNil {
+  _writer = nil;
+  [self finishOutputWithError:errorOrNil];
+}
+
+#pragma mark GRXWriter implementation
+
+- (GRXWriterState)state {
+  return _writer ? _writer.state : GRXWriterStateFinished;
+}
+
+- (void)setState:(GRXWriterState)state {
+  if (state == GRXWriterStateFinished) {
+    _writeable = nil;
+    [self finishInput];
+  } else {
+    _writer.state = state;
+  }
+}
+
+- (void)startWithWriteable:(id<GRXWriteable>)writeable {
+  _writeable = writeable;
+  [_writer startWithWriteable:self];
+}
+
+- (void)finishWithError:(NSError *)errorOrNil {
+  [self finishOutputWithError:errorOrNil];
+  [self finishInput];
+}
+
 @end

--- a/src/objective-c/RxLibrary/GRXForwardingWriter.m
+++ b/src/objective-c/RxLibrary/GRXForwardingWriter.m
@@ -37,7 +37,7 @@
 @end
 
 @implementation GRXForwardingWriter {
-  id<GRXWriter> _writer;
+  GRXWriter *_writer;
   id<GRXWriteable> _writeable;
 }
 
@@ -46,7 +46,7 @@
 }
 
 // Designated initializer
-- (instancetype)initWithWriter:(id<GRXWriter>)writer {
+- (instancetype)initWithWriter:(GRXWriter *)writer {
   if (!writer) {
     [NSException raise:NSInvalidArgumentException format:@"writer can't be nil."];
   }
@@ -68,7 +68,7 @@
 // This is used to stop the input writer. It nillifies our reference to it
 // to release it.
 - (void)finishInput {
-  id<GRXWriter> writer = _writer;
+  GRXWriter *writer = _writer;
   _writer = nil;
   writer.state = GRXWriterStateFinished;
 }

--- a/src/objective-c/RxLibrary/GRXImmediateWriter.h
+++ b/src/objective-c/RxLibrary/GRXImmediateWriter.h
@@ -40,7 +40,7 @@
 //
 // Unless the writeable callback pauses them or stops them early, these writers will do all their
 // interactions with the writeable before the start method returns.
-@interface GRXImmediateWriter : NSObject<GRXWriter>
+@interface GRXImmediateWriter : GRXWriter
 
 // Returns a writer that pulls values from the passed NSEnumerator instance and pushes them to
 // its writeable. The NSEnumerator is released when it finishes.

--- a/src/objective-c/RxLibrary/GRXImmediateWriter.h
+++ b/src/objective-c/RxLibrary/GRXImmediateWriter.h
@@ -44,11 +44,11 @@
 
 // Returns a writer that pulls values from the passed NSEnumerator instance and pushes them to
 // its writeable. The NSEnumerator is released when it finishes.
-+ (id<GRXWriter>)writerWithEnumerator:(NSEnumerator *)enumerator;
++ (GRXWriter *)writerWithEnumerator:(NSEnumerator *)enumerator;
 
 // Returns a writer that pushes to its writeable the successive values returned by the passed
 // block. When the block first returns nil, it is released.
-+ (id<GRXWriter>)writerWithValueSupplier:(id (^)())block;
++ (GRXWriter *)writerWithValueSupplier:(id (^)())block;
 
 // Returns a writer that iterates over the values of the passed container and pushes them to
 // its writeable. The container is released when the iteration is over.
@@ -56,18 +56,18 @@
 // Note that the usual speed gain of NSFastEnumeration over NSEnumerator results from not having to
 // call one method per element. Because GRXWriteable instances accept values one by one, that speed
 // gain doesn't happen here.
-+ (id<GRXWriter>)writerWithContainer:(id<NSFastEnumeration>)container;
++ (GRXWriter *)writerWithContainer:(id<NSFastEnumeration>)container;
 
 // Returns a writer that sends the passed value to its writeable and then finishes (releasing the
 // value).
-+ (id<GRXWriter>)writerWithValue:(id)value;
++ (GRXWriter *)writerWithValue:(id)value;
 
 // Returns a writer that, as part of its start method, sends the passed error to the writeable
 // (then releasing the error).
-+ (id<GRXWriter>)writerWithError:(NSError *)error;
++ (GRXWriter *)writerWithError:(NSError *)error;
 
 // Returns a writer that, as part of its start method, finishes immediately without sending any
 // values to its writeable.
-+ (id<GRXWriter>)emptyWriter;
++ (GRXWriter *)emptyWriter;
 
 @end

--- a/src/objective-c/RxLibrary/GRXImmediateWriter.m
+++ b/src/objective-c/RxLibrary/GRXImmediateWriter.m
@@ -63,19 +63,19 @@
   return [[self alloc] initWithEnumerator:enumerator error:errorOrNil];
 }
 
-+ (id<GRXWriter>)writerWithEnumerator:(NSEnumerator *)enumerator {
++ (GRXWriter *)writerWithEnumerator:(NSEnumerator *)enumerator {
   return [self writerWithEnumerator:enumerator error:nil];
 }
 
-+ (id<GRXWriter>)writerWithValueSupplier:(id (^)())block {
++ (GRXWriter *)writerWithValueSupplier:(id (^)())block {
   return [self writerWithEnumerator:[NSEnumerator grx_enumeratorWithValueSupplier:block]];
 }
 
-+ (id<GRXWriter>)writerWithContainer:(id<NSFastEnumeration>)container {
++ (GRXWriter *)writerWithContainer:(id<NSFastEnumeration>)container {
   return [self writerWithEnumerator:[NSEnumerator grx_enumeratorWithContainer:container]];;
 }
 
-+ (id<GRXWriter>)writerWithValue:(id)value {
++ (GRXWriter *)writerWithValue:(id)value {
   if (value) {
     return [self writerWithEnumerator:[NSEnumerator grx_enumeratorWithSingleValue:value]];
   } else {
@@ -83,7 +83,7 @@
   }
 }
 
-+ (id<GRXWriter>)writerWithError:(NSError *)error {
++ (GRXWriter *)writerWithError:(NSError *)error {
   if (error) {
     return [self writerWithEnumerator:nil error:error];
   } else {
@@ -91,7 +91,7 @@
   }
 }
 
-+ (id<GRXWriter>)emptyWriter {
++ (GRXWriter *)emptyWriter {
   static GRXImmediateWriter *emptyWriter;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{

--- a/src/objective-c/RxLibrary/GRXWriter+Immediate.m
+++ b/src/objective-c/RxLibrary/GRXWriter+Immediate.m
@@ -38,27 +38,27 @@
 @implementation GRXWriter (Immediate)
 
 + (instancetype)writerWithEnumerator:(NSEnumerator *)enumerator {
-  return [[self alloc] initWithWriter:[GRXImmediateWriter writerWithEnumerator:enumerator]];
+  return [GRXImmediateWriter writerWithEnumerator:enumerator];
 }
 
 + (instancetype)writerWithValueSupplier:(id (^)())block {
-  return [[self alloc] initWithWriter:[GRXImmediateWriter writerWithValueSupplier:block]];
+  return [GRXImmediateWriter writerWithValueSupplier:block];
 }
 
 + (instancetype)writerWithContainer:(id<NSFastEnumeration>)container {
-  return [[self alloc] initWithWriter:[GRXImmediateWriter writerWithContainer:container]];
+  return [GRXImmediateWriter writerWithContainer:container];
 }
 
 + (instancetype)writerWithValue:(id)value {
-  return [[self alloc] initWithWriter:[GRXImmediateWriter writerWithValue:value]];
+  return [GRXImmediateWriter writerWithValue:value];
 }
 
 + (instancetype)writerWithError:(NSError *)error {
-  return [[self alloc] initWithWriter:[GRXImmediateWriter writerWithError:error]];
+  return [GRXImmediateWriter writerWithError:error];
 }
 
 + (instancetype)emptyWriter {
-  return [[self alloc] initWithWriter:[GRXImmediateWriter emptyWriter]];
+  return [GRXImmediateWriter emptyWriter];
 }
 
 @end

--- a/src/objective-c/RxLibrary/GRXWriter.h
+++ b/src/objective-c/RxLibrary/GRXWriter.h
@@ -85,7 +85,7 @@ typedef NS_ENUM(NSInteger, GRXWriterState) {
 // Unless otherwise indicated by a conforming class, no messages should be sent
 // concurrently to a GRXWriter. I.e., conforming classes aren't required to
 // be thread-safe.
-@protocol GRXWriter <NSObject>
+@interface GRXWriter : NSObject
 
 // This property can be used to query the current state of the writer, which
 // determines how it might currently use its writeable. Some state transitions can
@@ -115,13 +115,4 @@ typedef NS_ENUM(NSInteger, GRXWriterState) {
 // stopping. I know I've relied on it in part of the code that uses this, but
 // can't remember the details in the presence of concurrency.
 - (void)finishWithError:(NSError *)errorOrNil;
-@end
-
-// A "proxy" class that simply forwards values, completion, and errors from its
-// input writer to its writeable.
-// It is useful as a superclass for pipes that act as a transformation of their
-// input writer, and for classes that represent objects with input and
-// output sequences of values, like an RPC.
-@interface GRXWriter : NSObject<GRXWriter>
-- (instancetype)initWithWriter:(id<GRXWriter>)writer NS_DESIGNATED_INITIALIZER;
 @end

--- a/src/objective-c/RxLibrary/transformations/GRXMappingWriter.h
+++ b/src/objective-c/RxLibrary/transformations/GRXMappingWriter.h
@@ -35,6 +35,6 @@
 
 // A "proxy" writer that transforms all the values of its input writer by using a mapping function.
 @interface GRXMappingWriter : GRXForwardingWriter
-- (instancetype)initWithWriter:(id<GRXWriter>)writer map:(id (^)(id value))map
+- (instancetype)initWithWriter:(GRXWriter *)writer map:(id (^)(id value))map
     NS_DESIGNATED_INITIALIZER;
 @end

--- a/src/objective-c/RxLibrary/transformations/GRXMappingWriter.h
+++ b/src/objective-c/RxLibrary/transformations/GRXMappingWriter.h
@@ -31,10 +31,10 @@
  *
  */
 
-#import "RxLibrary/GRXWriter.h"
+#import "RxLibrary/GRXForwardingWriter.h"
 
 // A "proxy" writer that transforms all the values of its input writer by using a mapping function.
-@interface GRXMappingWriter : GRXWriter
+@interface GRXMappingWriter : GRXForwardingWriter
 - (instancetype)initWithWriter:(id<GRXWriter>)writer map:(id (^)(id value))map
     NS_DESIGNATED_INITIALIZER;
 @end

--- a/src/objective-c/RxLibrary/transformations/GRXMappingWriter.m
+++ b/src/objective-c/RxLibrary/transformations/GRXMappingWriter.m
@@ -44,12 +44,12 @@ static id (^kIdentity)(id value) = ^id(id value) {
   id (^_map)(id value);
 }
 
-- (instancetype)initWithWriter:(id<GRXWriter>)writer {
+- (instancetype)initWithWriter:(GRXWriter *)writer {
   return [self initWithWriter:writer map:nil];
 }
 
 // Designated initializer
-- (instancetype)initWithWriter:(id<GRXWriter>)writer map:(id (^)(id value))map {
+- (instancetype)initWithWriter:(GRXWriter *)writer map:(id (^)(id value))map {
   if ((self = [super initWithWriter:writer])) {
     _map = map ?: kIdentity;
   }

--- a/src/objective-c/tests/GRPCClientTests.m
+++ b/src/objective-c/tests/GRPCClientTests.m
@@ -120,7 +120,7 @@ static ProtoMethod *kUnaryCallMethod;
   request.responseSize = 100;
   request.fillUsername = YES;
   request.fillOauthScope = YES;
-  id<GRXWriter> requestsWriter = [GRXWriter writerWithValue:[request data]];
+  GRXWriter *requestsWriter = [GRXWriter writerWithValue:[request data]];
 
   GRPCCall *call = [[GRPCCall alloc] initWithHost:kHostAddress
                                              path:kUnaryCallMethod.HTTPPath
@@ -150,7 +150,7 @@ static ProtoMethod *kUnaryCallMethod;
   RMTSimpleRequest *request = [RMTSimpleRequest message];
   request.fillUsername = YES;
   request.fillOauthScope = YES;
-  id<GRXWriter> requestsWriter = [GRXWriter writerWithValue:[request data]];
+  GRXWriter *requestsWriter = [GRXWriter writerWithValue:[request data]];
 
   GRPCCall *call = [[GRPCCall alloc] initWithHost:kHostAddress
                                              path:kUnaryCallMethod.HTTPPath

--- a/src/objective-c/tests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests.m
@@ -143,7 +143,7 @@
   RMTStreamingInputCallRequest *request4 = [RMTStreamingInputCallRequest message];
   request4.payload.body = [NSMutableData dataWithLength:45904];
 
-  id<GRXWriter> writer = [GRXWriter writerWithContainer:@[request1, request2, request3, request4]];
+  GRXWriter *writer = [GRXWriter writerWithContainer:@[request1, request2, request3, request4]];
 
   [_service streamingInputCallWithRequestsWriter:writer
                                          handler:^(RMTStreamingInputCallResponse *response,

--- a/src/objective-c/tests/LocalClearTextTests.m
+++ b/src/objective-c/tests/LocalClearTextTests.m
@@ -64,7 +64,7 @@ static NSString * const kService = @"RouteGuide";
 //                                                         interface:kService
 //                                                            method:@"EmptyCall"];
 //
-//  id<GRXWriter> requestsWriter = [GRXWriter writerWithValue:[NSData data]];
+//  GRXWriter *requestsWriter = [GRXWriter writerWithValue:[NSData data]];
 //
 //  GRPCCall *call = [[GRPCCall alloc] initWithHost:kRouteGuideHost
 //                                           method:method
@@ -91,7 +91,7 @@ static NSString * const kService = @"RouteGuide";
                                                      service:kService
                                                       method:@"RecordRoute"];
 
-  id<GRXWriter> requestsWriter = [GRXWriter emptyWriter];
+  GRXWriter *requestsWriter = [GRXWriter emptyWriter];
 
   GRPCCall *call = [[GRPCCall alloc] initWithHost:kRouteGuideHost
                                              path:method.HTTPPath
@@ -122,7 +122,7 @@ static NSString * const kService = @"RouteGuide";
   RGDPoint *point = [RGDPoint message];
   point.latitude = 28E7;
   point.longitude = -15E7;
-  id<GRXWriter> requestsWriter = [GRXWriter writerWithValue:[point data]];
+  GRXWriter *requestsWriter = [GRXWriter writerWithValue:[point data]];
 
   GRPCCall *call = [[GRPCCall alloc] initWithHost:kRouteGuideHost
                                              path:method.HTTPPath


### PR DESCRIPTION
Fixes #2113

More simplifications that those in commit 29f55d5 are possible now, but one of them depends on #2109, so I'll do them later (#2487). They also won't break the API so they aren't required to happen for Beta.