### PR TITLE
Move GRPCDelegateWrapper to GRXConcurrentWriteable

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -35,10 +35,10 @@
 
 #include <grpc/grpc.h>
 #include <grpc/support/time.h>
+#import <RxLibrary/GRXConcurrentWriteable.h>
 
 #import "private/GRPCChannel.h"
 #import "private/GRPCCompletionQueue.h"
-#import "private/GRPCDelegateWrapper.h"
 #import "private/GRPCWrappedCall.h"
 #import "private/NSData+GRPC.h"
 #import "private/NSDictionary+GRPC.h"
@@ -78,7 +78,7 @@ NSString * const kGRPCStatusMetadataKey = @"io.grpc.StatusMetadataKey";
   // do. Particularly, in the face of errors, there's no ordering guarantee at
   // all. This wrapper over our actual writeable ensures thread-safety and
   // correct ordering.
-  GRPCDelegateWrapper *_responseWriteable;
+  GRXConcurrentWriteable *_responseWriteable;
   GRXWriter *_requestWriter;
 
   NSMutableDictionary *_requestMetadata;
@@ -191,7 +191,7 @@ NSString * const kGRPCStatusMetadataKey = @"io.grpc.StatusMetadataKey";
     return;
   }
   __weak GRPCCall *weakSelf = self;
-  __weak GRPCDelegateWrapper *weakWriteable = _responseWriteable;
+  __weak GRXConcurrentWriteable *weakWriteable = _responseWriteable;
 
   dispatch_async(_callQueue, ^{
     [weakSelf startReadWithHandler:^(grpc_byte_buffer *message) {
@@ -340,7 +340,7 @@ NSString * const kGRPCStatusMetadataKey = @"io.grpc.StatusMetadataKey";
   // Care is taken not to retain self strongly in any of the blocks used in
   // the implementation of GRPCCall, so that the life of the instance is
   // determined by this retain cycle.
-  _responseWriteable = [[GRPCDelegateWrapper alloc] initWithWriteable:writeable writer:self];
+  _responseWriteable = [[GRXConcurrentWriteable alloc] initWithWriteable:writeable writer:self];
   [self sendHeaders:_requestMetadata];
   [self invokeCall];
 }

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -216,7 +216,7 @@ NSString * const kGRPCStatusMetadataKey = @"io.grpc.StatusMetadataKey";
         [weakSelf cancelCall];
         return;
       }
-      [weakWriteable enqueueMessage:data completionHandler:^{
+      [weakWriteable enqueueValue:data completionHandler:^{
         [weakSelf startNextRead];
       }];
     }];

--- a/src/objective-c/RxLibrary/GRXConcurrentWriteable.h
+++ b/src/objective-c/RxLibrary/GRXConcurrentWriteable.h
@@ -48,7 +48,7 @@
 // TODO(jcanizales): Let the user specify another queue for the writeable
 // callbacks.
 // TODO(jcanizales): Rename to GRXWriteableWrapper and move to the Rx library.
-@interface GRPCDelegateWrapper : NSObject
+@interface GRXConcurrentWriteable : NSObject
 
 // The GRXWriteable passed is the wrapped writeable.
 // Both the GRXWriter instance and the GRXWriteable instance are retained until

--- a/src/objective-c/RxLibrary/GRXConcurrentWriteable.h
+++ b/src/objective-c/RxLibrary/GRXConcurrentWriteable.h
@@ -33,9 +33,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import <RxLibrary/GRXWriter.h>
-
-@protocol GRXWriteable;
+#import "GRXWriter.h"
+#import "GRXWriteable.h"
 
 // This is a thread-safe wrapper over a GRXWriteable instance. It lets one
 // enqueue calls to a GRXWriteable instance for the main thread, guaranteeing
@@ -47,7 +46,6 @@
 //
 // TODO(jcanizales): Let the user specify another queue for the writeable
 // callbacks.
-// TODO(jcanizales): Rename to GRXWriteableWrapper and move to the Rx library.
 @interface GRXConcurrentWriteable : NSObject
 
 // The GRXWriteable passed is the wrapped writeable.
@@ -60,7 +58,7 @@
 
 // Enqueues writeValue: to be sent to the writeable in the main thread.
 // The passed handler is invoked from the main thread after writeValue: returns.
-- (void)enqueueMessage:(NSData *)message completionHandler:(void (^)())handler;
+- (void)enqueueValue:(id)value completionHandler:(void (^)())handler;
 
 // Enqueues writesFinishedWithError:nil to be sent to the writeable in the main
 // thread. After that message is sent to the writeable, all other methods of

--- a/src/objective-c/RxLibrary/GRXConcurrentWriteable.h
+++ b/src/objective-c/RxLibrary/GRXConcurrentWriteable.h
@@ -36,44 +36,36 @@
 #import "GRXWriter.h"
 #import "GRXWriteable.h"
 
-// This is a thread-safe wrapper over a GRXWriteable instance. It lets one
-// enqueue calls to a GRXWriteable instance for the main thread, guaranteeing
-// that writesFinishedWithError: is the last message sent to it (no matter what
-// messages are sent to the wrapper, in what order, nor from which thread). It
-// also guarantees that, if cancelWithError: is called from the main thread
-// (e.g. by the app cancelling the writes), no further messages are sent to the
-// writeable except writesFinishedWithError:.
+// This is a thread-safe wrapper over a GRXWriteable instance. It lets one enqueue calls to a
+// GRXWriteable instance for the main thread, guaranteeing that writesFinishedWithError: is the last
+// message sent to it (no matter what messages are sent to the wrapper, in what order, nor from
+// which thread). It also guarantees that, if cancelWithError: is called from the main thread (e.g.
+// by the app cancelling the writes), no further messages are sent to the writeable except
+// writesFinishedWithError:.
 //
-// TODO(jcanizales): Let the user specify another queue for the writeable
-// callbacks.
+// TODO(jcanizales): Let the user specify another queue for the writeable callbacks.
 @interface GRXConcurrentWriteable : NSObject
 
 // The GRXWriteable passed is the wrapped writeable.
-// Both the GRXWriter instance and the GRXWriteable instance are retained until
-// writesFinishedWithError: is sent to the writeable, and released after that.
-// This is used to create a retain cycle that keeps both objects alive until the
-// writing is explicitly finished.
-- (instancetype)initWithWriteable:(id<GRXWriteable>)writeable writer:(GRXWriter *)writer
-    NS_DESIGNATED_INITIALIZER;
+// The GRXWriteable instance is retained until writesFinishedWithError: is sent to it, and released
+// after that.
+- (instancetype)initWithWriteable:(id<GRXWriteable>)writeable NS_DESIGNATED_INITIALIZER;
 
 // Enqueues writeValue: to be sent to the writeable in the main thread.
 // The passed handler is invoked from the main thread after writeValue: returns.
 - (void)enqueueValue:(id)value completionHandler:(void (^)())handler;
 
-// Enqueues writesFinishedWithError:nil to be sent to the writeable in the main
-// thread. After that message is sent to the writeable, all other methods of
-// this object are effectively noops.
+// Enqueues writesFinishedWithError:nil to be sent to the writeable in the main thread. After that
+// message is sent to the writeable, all other methods of this object are effectively noops.
 - (void)enqueueSuccessfulCompletion;
 
-// If the writeable has not yet received a writesFinishedWithError: message, this
-// will enqueue one to be sent to it in the main thread, and cancel all other
-// pending messages to the writeable enqueued by this object (both past and
-// future).
+// If the writeable has not yet received a writesFinishedWithError: message, this will enqueue one
+// to be sent to it in the main thread, and cancel all other pending messages to the writeable
+// enqueued by this object (both past and future).
 // The error argument cannot be nil.
 - (void)cancelWithError:(NSError *)error;
 
-// Cancels all pending messages to the writeable enqueued by this object (both
-// past and future). Because the writeable won't receive writesFinishedWithError:,
-// this also releases the writeable and the writer.
+// Cancels all pending messages to the writeable enqueued by this object (both past and future).
+// Because the writeable won't receive writesFinishedWithError:, this also releases the writeable.
 - (void)cancelSilently;
 @end

--- a/src/objective-c/RxLibrary/GRXConcurrentWriteable.m
+++ b/src/objective-c/RxLibrary/GRXConcurrentWriteable.m
@@ -31,17 +31,17 @@
  *
  */
 
-#import "GRPCDelegateWrapper.h"
+#import "GRXConcurrentWriteable.h"
 
 #import <RxLibrary/GRXWriteable.h>
 
-@interface GRPCDelegateWrapper ()
+@interface GRXConcurrentWriteable ()
 // These are atomic so that cancellation can nillify them from any thread.
 @property(atomic, strong) id<GRXWriteable> writeable;
 @property(atomic, strong) GRXWriter *writer;
 @end
 
-@implementation GRPCDelegateWrapper {
+@implementation GRXConcurrentWriteable {
   dispatch_queue_t _writeableQueue;
   // This ensures that writesFinishedWithError: is only sent once to the writeable.
   dispatch_once_t _alreadyFinished;

--- a/src/objective-c/RxLibrary/GRXConcurrentWriteable.m
+++ b/src/objective-c/RxLibrary/GRXConcurrentWriteable.m
@@ -61,7 +61,7 @@
   return self;
 }
 
-- (void)enqueueMessage:(NSData *)message completionHandler:(void (^)())handler {
+- (void)enqueueValue:(id)value completionHandler:(void (^)())handler {
   dispatch_async(_writeableQueue, ^{
     // We're racing a possible cancellation performed by another thread. To turn
     // all already-enqueued messages into noops, cancellation nillifies the
@@ -69,7 +69,7 @@
     // the race.
     id<GRXWriteable> writeable = self.writeable;
     if (writeable) {
-      [writeable writeValue:message];
+      [writeable writeValue:value];
       handler();
     }
   });


### PR DESCRIPTION
Fixes #2109.

Also makes the retain cycle `GRPCCall` <-> `GRPCDelegateWrapper` explicit and encapsulated within `GRPCCall` (which simplifies `GRXConcurrentWriteable` as a bonus).