### PR TITLE
changes to allow VS solution/project generation and grpc.mak generation for c++ tests

### DIFF
--- a/build.json
+++ b/build.json
@@ -1890,6 +1890,9 @@
         "grpc",
         "gpr_test_util",
         "gpr"
+      ],
+      "platforms": [
+        "posix"
       ]
     },
     {
@@ -1907,6 +1910,9 @@
         "grpc",
         "gpr_test_util",
         "gpr"
+      ],
+      "platforms": [
+        "posix"
       ]
     },
     {
@@ -1965,6 +1971,9 @@
         "grpc",
         "gpr_test_util",
         "gpr"
+      ],
+      "platforms": [
+        "posix"
       ]
     },
     {
@@ -2188,6 +2197,9 @@
         "gpr_test_util",
         "gpr",
         "grpc++_test_config"
+      ],
+      "platforms": [
+        "posix"
       ]
     },
     {
@@ -2206,6 +2218,9 @@
         "gpr_test_util",
         "gpr",
         "grpc++_test_config"
+      ],
+      "platforms": [
+        "posix"
       ]
     },
     {
@@ -2220,6 +2235,9 @@
         "grpc",
         "gpr_test_util",
         "gpr"
+      ],
+      "platforms": [
+        "posix"
       ]
     },
     {
@@ -2324,6 +2342,9 @@
         "grpc",
         "gpr_test_util",
         "gpr"
+      ],
+      "platforms": [
+        "posix"
       ]
     },
     {
@@ -2342,6 +2363,9 @@
         "gpr_test_util",
         "gpr",
         "grpc++_test_config"
+      ],
+      "platforms": [
+        "posix"
       ]
     },
     {
@@ -2360,6 +2384,9 @@
         "gpr_test_util",
         "gpr",
         "grpc++_test_config"
+      ],
+      "platforms": [
+        "posix"
       ]
     },
     {
@@ -2411,6 +2438,9 @@
         "grpc",
         "gpr_test_util",
         "gpr"
+      ],
+      "platforms": [
+        "posix"
       ]
     },
     {
@@ -2460,6 +2490,9 @@
         "grpc",
         "gpr_test_util",
         "gpr"
+      ],
+      "platforms": [
+        "posix"
       ]
     },
     {
@@ -2477,6 +2510,9 @@
         "grpc",
         "gpr_test_util",
         "gpr"
+      ],
+      "platforms": [
+        "posix"
       ]
     },
     {

--- a/templates/vsprojects/Grpc.mak.template
+++ b/templates/vsprojects/Grpc.mak.template
@@ -33,16 +33,18 @@
 <%def name="to_windows_path(path)">${path.replace('/','\\')}</%def>\
 <%
   build_from_project_file = set(['gpr',
-                                 'grpc',
-                                 'grpc_unsecure',
                                  'gpr_test_util',
+                                 'grpc',
                                  'grpc_test_util',
                                  'grpc_test_util_unsecure',
+                                 'grpc_unsecure',
+                                 'grpc++',
+                                 'grpc++_unsecure'
                                 ])
   buildable_targets = [ target for target in targets + libs
                         if target.build in ['all', 'test', 'private', 'tool', 'benchmark'] and
                         target.language in ['c', 'c++'] and
-                        all([src.endswith('.c') for src in target.src]) and
+                        all([(src.endswith('.c') or src.endswith('.cc') or src.endswith('.proto')) for src in target.src]) and
                         'windows' in target.get('platforms', ['windows']) ]
   c_test_targets = [ target for target in buildable_targets if target.build == 'test' and not target.language == 'c++' ]
   cxx_test_targets = [ target for target in buildable_targets if target.build == 'test' and target.language == 'c++' ]
@@ -60,8 +62,19 @@ REPO_ROOT=..
 OPENSSL_INCLUDES = .\packages\${get_openssl()}\build\native\include
 ZLIB_INCLUDES = .\packages\${get_zlib()}\build\native\include
 INCLUDES=/I$(REPO_ROOT) /I$(REPO_ROOT)\include /I$(OPENSSL_INCLUDES) /I$(ZLIB_INCLUDES)
-DEFINES=/D WIN32 /D _LIB /D _USE_32BIT_TIME_T /D _UNICODE /D UNICODE /D _CRT_SECURE_NO_WARNINGS
+
+GFLAGS_INCLUDES = .\..\third_party\gflags\include
+GTEST_INCLUDES = .\..\third_party\gtest\include
+PROTOBUF_INCLUDES = .\..\third_party\protobuf\src
+CXX_INCLUDES=/I$(GFLAGS_INCLUDES) /I$(GTEST_INCLUDES) /I$(PROTOBUF_INCLUDES)
+
+#_SCL_SECURE_NO_WARNINGS supresses a ton of "potentially unsafe use of std lib" warnings
+DEFINES=/D WIN32 /D _LIB /D _USE_32BIT_TIME_T /D _UNICODE /D UNICODE /D _CRT_SECURE_NO_WARNINGS /D _SCL_SECURE_NO_WARNINGS
+
+#important options: /TC vs. /TP: compile as C vs. compile as C++
 CFLAGS=/c $(INCLUDES) /Z7 /W3 /WX- /sdl $(DEFINES) /EHsc /RTC1 /MDd /GS /fp:precise /Zc:wchar_t /Zc:forScope /Gd /TC /analyze-
+CXXFLAGS=/c $(INCLUDES) $(CXX_INCLUDES) /Z7 /W3 /WX- /sdl $(DEFINES) /EHsc /RTC1 /MDd /GS /fp:precise /Zc:wchar_t /Zc:forScope /Gd /TP /analyze-
+
 LFLAGS=/DEBUG /INCREMENTAL /SUBSYSTEM:CONSOLE /TLBID:1 /DYNAMICBASE /NXCOMPAT /MACHINE:X86
 
 OPENSSL_LIBS=.\packages\${get_openssl()}\build\native\lib\v120\Win32\Debug\static\ssleay32.lib .\packages\${get_openssl()}\build\native\lib\v120\Win32\Debug\static\libeay32.lib
@@ -69,6 +82,12 @@ WINSOCK_LIBS=ws2_32.lib
 GENERAL_LIBS=advapi32.lib comdlg32.lib gdi32.lib kernel32.lib odbc32.lib odbccp32.lib ole32.lib oleaut32.lib shell32.lib user32.lib uuid.lib winspool.lib
 ZLIB_LIBS=.\packages\${get_zlib()}\build\native\lib\v120\Win32\Debug\static\cdecl\zlib.lib
 LIBS=$(OPENSSL_LIBS) $(ZLIB_LIBS) $(GENERAL_LIBS) $(WINSOCK_LIBS)
+
+#shlwapi.lib provides PathMatchSpec() for gflags in windows
+GFLAGS_LIBS=.\..\third_party\gflags\lib\Debug\gflags.lib shlwapi.lib
+GTEST_LIBS=.\..\third_party\gtest\msvc\gtest\Debug\gtestd.lib
+PROTOBUF_LIBS=.\..\third_party\protobuf\vsprojects\Debug\libprotobuf.lib
+CXX_LIBS=$(GFLAGS_LIBS) $(GTEST_LIBS) $(PROTOBUF_LIBS)
 
 all: buildtests
 
@@ -99,16 +118,33 @@ buildtests_c: \
 ${target.name}.exe \
 % endfor
 
-	echo All tests built.
+	echo All C tests built.
 
 buildtests_cxx: \
 % for target in cxx_test_targets:
 ${target.name}.exe \
 % endfor
 
-	echo All tests built.
+	echo All C++ tests built.
 
 % for target in buildable_targets:
+
+## replace all .proto includes with .pb.cc / .grpc.pb.cc
+%if target.src:
+%for source in target.src:
+%if source.endswith(".proto"):
+<%
+      src_name_parts = source.split(".")
+      target.src.append(src_name_parts[0] + ".pb.cc")
+      target.src.append(src_name_parts[0] + ".grpc.pb.cc")
+%>\
+%endif
+%endfor
+%endif
+## remove all .proto includes
+<%
+  target.src = [item for item in target.src if not re.search('([^/]+)\.proto$', item)]
+%>\
 %if target.name in build_from_project_file:
 build_${target.name}:
 	msbuild grpc.sln /t:${target.name} /p:Configuration=Debug /p:Linkage-grpc_dependencies_zlib=static
@@ -116,11 +152,22 @@ build_${target.name}:
 %if target.build == 'private':
 Debug\${target.name}.lib: \
 %else:
-${target.name}.exe: build_libs \
+${target.name}.exe: \
+%for dep in target.get('deps', []):
+%if dep in build_from_project_file:
+build_${dep} \
+%else:
+Debug\${dep}.lib \
+%endif
+%endfor
 %endif
 $(OUT_DIR)
 	echo Building ${target.name}
+%if target.language == 'c++':
+    $(CC) $(CXXFLAGS) /Fo:$(OUT_DIR)\ \
+%else:
 	$(CC) $(CFLAGS) /Fo:$(OUT_DIR)\ \
+%endif
 %for source in target.src:
 $(REPO_ROOT)\${to_windows_path(source)} \
 %endfor
@@ -135,13 +182,19 @@ $(REPO_ROOT)\${to_windows_path('vsprojects/dummy.c')} \
 %for dep in target.get('deps', []):
 Debug\${dep}.lib \
 %endfor
+%if target.language == 'c++':
+$(CXX_LIBS) \
+%endif
 $(LIBS) \
 %endif
-%for source in target.src:
-$(OUT_DIR)\${re.search('([^/]+)\.c$', source).group(1)}.obj \
-%endfor
 %if not target.src:
 $(OUT_DIR)\dummy.obj \
+%else:
+%for source in target.src:
+%if re.search('([^/]+)\.c{1,2}$', source):
+$(OUT_DIR)\${re.search('([^/]+)\.c{1,2}$', source).group(1)}.obj \
+%endif
+%endfor
 %endif
 
 %if target.build != 'private':

--- a/templates/vsprojects/build_test_protos.sh
+++ b/templates/vsprojects/build_test_protos.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+GRPC_CPP_PLUGIN_PATH=`which grpc_cpp_plugin`
+
+cd `dirname $0`/../..
+
+find ./test -type f -name "*.proto" |
+while read p ; do
+  echo "processing $p"
+  DIR=$(dirname "$p")
+  protoc $p --grpc_out=./ --plugin=protoc-gen-grpc=$GRPC_CPP_PLUGIN_PATH
+  protoc $p --cpp_out=./
+done

--- a/templates/vsprojects/sln_defs.include
+++ b/templates/vsprojects/sln_defs.include
@@ -15,6 +15,13 @@ cpp_proj_type = "{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}"
 %>\
 % for project in solution_projects:
 Project("${cpp_proj_type}") = "${project.name}", "${project.name}\${project.name}.vcxproj", "${project.vs_project_guid}"
+	ProjectSection(myProperties) = preProject
+  % if project.is_library:
+        	lib = "True"
+  % else:
+        	lib = "False"
+  % endif
+	EndProjectSection
   % if project.get('deps', None):
 	ProjectSection(ProjectDependencies) = postProject
     % for dep in project.get('deps', []):

--- a/templates/vsprojects/vcxproj_defs.include
+++ b/templates/vsprojects/vcxproj_defs.include
@@ -12,19 +12,21 @@
     if t.name == name:
       target = t
   if not configuration_type and target:
+    print target.name
     if target.build == 'test' or target.build == 'tool':
       configuration_type = 'Application'
   if not configuration_type:
     configuration_type = 'StaticLibrary'
   if not project_guid:
     project_guid = project.vs_project_guid
+  if target.build == 'test' and target.language == 'c++':
+    props.extend(['cpptest'])
   if configuration_type == 'Application':
+    print target.build
     if target.build == 'protoc':
       props.extend(['protoc'])
     else:
       props.extend(['winsock', 'protobuf', 'zlib', 'openssl'])
-    if target.language == 'c++':
-      props.extend(['protobuf'])
   props.extend(['global'])
 %>\
 <?xml version="1.0" encoding="utf-8"?>
@@ -113,6 +115,13 @@ ${gen_package_props(packages)}\
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <TargetName>${name}</TargetName>
+    % if "zlib" in packages:
+    <Linkage-grpc_dependencies_zlib>static</Linkage-grpc_dependencies_zlib>
+    <Configuration-grpc_dependencies_zlib>Debug</Configuration-grpc_dependencies_zlib>
+    % endif
+    % if "openssl" in packages:
+    <Configuration-grpc_dependencies_openssl>Debug</Configuration-grpc_dependencies_openssl>
+    % endif
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetName>${name}</TargetName>
@@ -200,8 +209,20 @@ ${gen_package_props(packages)}\
   % if project.get('src',[]):
   <ItemGroup>
     % for src_name in project.src:
+      % if src_name.endswith(".proto"):
+<% src_name_parts = src_name.split(".") %>\
+    <ClCompile Include="${get_repo_root()}\${to_windows_path(src_name_parts[0] + ".pb.cc")}">
+    </ClCompile>
+    <ClInclude Include="${get_repo_root()}\${to_windows_path(src_name_parts[0] + ".pb.h")}">
+    </ClInclude>
+    <ClCompile Include="${get_repo_root()}\${to_windows_path(src_name_parts[0] + ".grpc.pb.cc")}">
+    </ClCompile>
+    <ClInclude Include="${get_repo_root()}\${to_windows_path(src_name_parts[0] + ".grpc.pb.h")}">
+    </ClInclude>
+      % else:
     <ClCompile Include="${get_repo_root()}\${to_windows_path(src_name)}">
     </ClCompile>
+      % endif
     % endfor
   </ItemGroup>
   % elif configuration_type != 'StaticLibrary':

--- a/tools/buildgen/generate_projects-old.sh
+++ b/tools/buildgen/generate_projects-old.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+set -e
+
+if [ "x$TEST" = "x" ] ; then
+  TEST=false
+fi
+
+
+cd `dirname $0`/../..
+mako_renderer=tools/buildgen/mako_renderer.py
+
+if [ "x$TEST" != "x" ] ; then
+  tools/buildgen/build-cleaner.py build.json
+fi
+
+. tools/buildgen/generate_build_additions.sh
+
+global_plugins=`find ./tools/buildgen/plugins -name '*.py' |
+  sort | grep -v __init__ | awk ' { printf "-p %s ", $0 } '`
+
+for dir in . ; do
+  local_plugins=`find $dir/templates -name '*.py' |
+    sort | grep -v __init__ | awk ' { printf "-p %s ", $0 } '`
+
+  plugins="$global_plugins $local_plugins"
+
+  find -L $dir/templates -type f -and -name *.template | while read file ; do
+    out=${dir}/${file#$dir/templates/}  # strip templates dir prefix
+    out=${out%.*}  # strip template extension
+    echo "generating file: $out"
+    json_files="build.json $gen_build_files"
+    data=`for i in $json_files ; do echo $i ; done | awk ' { printf "-d %s ", $0 } '`
+    if [ "x$TEST" = "xtrue" ] ; then
+      actual_out=$out
+      out=`mktemp /tmp/gentXXXXXX`
+    fi
+    mkdir -p `dirname $out`  # make sure dest directory exist
+    $mako_renderer $plugins $data -o $out $file
+    if [ "x$TEST" = "xtrue" ] ; then
+      diff -q $out $actual_out
+      rm $out
+    fi
+  done
+done
+
+rm $gen_build_files

--- a/tools/buildgen/plugins/generate_vsprojects.py
+++ b/tools/buildgen/plugins/generate_vsprojects.py
@@ -70,7 +70,7 @@ def mako_plugin(dictionary):
                 if project.get('vs_project_guid', None)]
 
   projects = [project for project in projects
-                if project['language'] != 'c++' or project['build'] == 'all' or project['build'] == 'protoc']
+                if project['language'] != 'c++' or project['build'] == 'all' or project['build'] == 'protoc' or (project['language'] == 'c++' and  (project['build'] == 'test' or project['build'] == 'private'))]
 
   project_dict = dict([(p['name'], p) for p in projects])
 

--- a/vsprojects/README.md
+++ b/vsprojects/README.md
@@ -36,32 +36,45 @@ After that, you can build the solution using one of these options:
    * install [NuGet](http://www.nuget.org)
     * nuget should automatically bring in built versions of zlib and openssl when building grpc.sln (the versions in `/third_party/` are not used).  If it doesn't work use `tools->nuget...->manage...`.  The packages are put in `/vsprojects/packages/`
 
-#C/C++ Test Build Steps
+#C/C++ Test Solution/Project Build Steps
+   * A basic git version of grpc only has templates for non-test items.  This checklist adds test items to grpc.sln and makes individual vs projects for them
    * set up dependencies (above)
    * add `"debug": true,` to the top of build.json.  This is the base file for all build tracking, see [templates](https://github.com/grpc/grpc/tree/master/templates) for more information
     * `"debug": true,` gets picked up by `/tools/buildgen/plugins/generate_vsprojects.py`.  It tells the script to add visual studio GUIDs to all projects.  Otherwise only the projects that already have GUIDs in build.json will be built
-   * A basic git version of grpc only has templates for non-test items.  run `/templates/vsprojects/generate_debug_projects.sh` to make debug templates/projects.  This runs a regular visual studio buildgen process, which creates the `.sln` file with all of the new debug projects, then uses git diff to find the new project names from the `.sln` that need templates added.  It builds the new templates based on the diff, then re-runs the visual studio buildgen, which builds the vs projects for each of the new debug targets
+   * run `/templates/vsprojects/generate_debug_projects.sh` to make debug templates/projects.  This runs a regular visual studio buildgen process, which creates the `.sln` file with all of the new debug projects, then uses git diff to find the new project names from the `.sln` that need templates added.  It builds the new templates based on the diff, then re-runs the visual studio buildgen, which builds the vs projects for each of the new debug targets
     * copy over the `/vsprojects/` folder to your windows build setup (assuming this was built on linux in order to have easy access to python/mako and shell scripts)
    * run `/templates/vsprojects/build_test_protos.sh`
     * this builds all `.proto` files in `/test/` in-place.  there might be a better place to put them that mirrors what happens in the linux build process (todo)
     * each `.proto` file gets built into a `.grpc.pb.cc`, .`grpc.pb.h`, `.pb.cc`, and `.pb.h`.  These are included in each test project in lieu of the `.proto` includes specified in `build.json`.  This substitution is done by `/templates/vsprojects/vcxproj_defs.include`
     * copy over the `/test/` folder in order to get the new files (assuming this was built on linux in order to have an easy protobuf+grpc plugin installation)
 
-#Testing
+#Making and running tests with `/tools/run_tests/run_tests.py` or `/vsprojects/make.bat`
+`run_tests.py` and `make.bat` both rely on `/vsprojects/grpc.mak`, an NMAKE script that includes C/C++ tests in addition to the base grpc projects.  It builds the base projects by calling grpc.sln, but most things are built with a command line similar to a makefile workflow.
 
-This is incomplete (only runs some tests for now), todo.  The above .sln-based buildgen makes more tets but isn't tied in to automatic test running yet.
+ arguments for `/vsprojects/make.bat`:
 
-Use `run_tests.py`, that also supports Windows (with a bit limited experience).
-```
-> REM Run from repository root.
-> python tools\run_tests\run_tests.py -l c
-```
+ * no options or `all` or `buildtests`: builds all tests
+ * `buildtests_c`: just c tests
+ * `buildtests_cxx`: just c++ tests
+ * names of individual tests: just those tests (example: `make.bat gpr_string_test`)
 
-Also, you can `make.bat` directly to build and run gRPC tests.
-```
-> REM Run from this directory.
-> make.bat alarm_test
-```
+using `run_tests.py` on windows:
+
+ * when `run_tests.py` detects that it's running on windows it calls `make.bat` to build the tests and expects to find tests in `/vsprojects/test_bins/`
+
+`run_tests.py` options:
+
+ * `run_tests.py --help`
+ * `run_tests.py -l c`: run c language tests
+ * `run_tests.py -l c++`: run c++ language tests
+ * note: `run_tests.py` doesn't normally show build steps, so if a build fails it is best to fall back to `make.bat`
+ * if `make.bat` fails, it might be easier to open up the `.sln` file in the visual studio gui (see above for how to build the test projects) and build the offending test from its project file.  The `.mak` and project file templates are slightly different, so it's possible that a project will build one way and not another.  Please report this if it happens.
+
+It can be helpful to disable the firewall when running tests so that 400 connection warnings don't pop up.
+
+Individual tests can be run by directly running the executable in `/vsprojects/run_tests/` (this is `/bins/opt/` on linux).  Many C tests have no output; they either pass or fail internally and communicate this with their exit code (`0=pass`, `nonzero=fail`)
+
+`run_tests.py` will fail if it can't build something, so not-building tests are disabled with a "platforms = posix" note in build.json.  The buildgen tools will not add a test to a windows build unless it is marked "windows" or has no platforms identified.  As tests are ported they will get this mark removed.
 
 # Building protoc plugins
 For generating service stub code, gRPC relies on plugins for `protoc` (the protocol buffer compiler). The solution `grpc_protoc_plugins.sln` allows you to build

--- a/vsprojects/README.md
+++ b/vsprojects/README.md
@@ -19,7 +19,37 @@ After that, you can build the solution using one of these options:
 1. open `grpc.sln` with Visual Studio and hit "Build".
 2. build from commandline using `msbuild grpc.sln /p:Configuration=Debug`
 
+#C/C++ Test Dependencies
+   * gtest isn't available as a git repo like the other dependencies.  download it and add it to `/third_party/gtest/` (the folder will end up with `/build-aux/`, `/cmake/`, `/codegear/`, etc. folders in it).  
+    * if using vs2013: open/import the gtest solution in `/msvc/`, and save over the first solution (you will have to change it from read-only).  change all projects to use `/MDd` (Property Pages - C/C++ - Code Generation - Runtime Library) and build. This is a "multithreaded debug" setting and it needs to match grpc.
+    * build all
+   * open protobuf solution in `/third_party/protobuf/vsprojects`
+    * if using vs2013: on import the gtest stuff will probably fail, I think the paths are interpreted wrong.  it's ok.
+    * tests and test_plugin will fail when built.  also ok
+    * build all
+   *  gflags is automatically imported as a git submodule but it needs to have CMake run on it to be ready for a specific platform
+    * download [CMake](http://www.cmake.org/) windows installer; install
+    * open visual studio developer command prompt (not sure if dev command prompt is necessary)
+    * run `cmake <path to gtest directory>`
+    * this will build a `.sln` and fill up the `/third_party/gflags/include/gflags/` directory with headers
+    * build all
+   * install [NuGet](http://www.nuget.org)
+    * nuget should automatically bring in built versions of zlib and openssl when building grpc.sln (the versions in `/third_party/` are not used).  If it doesn't work use `tools->nuget...->manage...`.  The packages are put in `/vsprojects/packages/`
+
+#C/C++ Test Build Steps
+   * set up dependencies (above)
+   * add `"debug": true,` to the top of build.json.  This is the base file for all build tracking, see [templates](https://github.com/grpc/grpc/tree/master/templates) for more information
+    * `"debug": true,` gets picked up by `/tools/buildgen/plugins/generate_vsprojects.py`.  It tells the script to add visual studio GUIDs to all projects.  Otherwise only the projects that already have GUIDs in build.json will be built
+   * A basic git version of grpc only has templates for non-test items.  run `/templates/vsprojects/generate_debug_projects.sh` to make debug templates/projects.  This runs a regular visual studio buildgen process, which creates the `.sln` file with all of the new debug projects, then uses git diff to find the new project names from the `.sln` that need templates added.  It builds the new templates based on the diff, then re-runs the visual studio buildgen, which builds the vs projects for each of the new debug targets
+    * copy over the `/vsprojects/` folder to your windows build setup (assuming this was built on linux in order to have easy access to python/mako and shell scripts)
+   * run `/templates/vsprojects/build_test_protos.sh`
+    * this builds all `.proto` files in `/test/` in-place.  there might be a better place to put them that mirrors what happens in the linux build process (todo)
+    * each `.proto` file gets built into a `.grpc.pb.cc`, .`grpc.pb.h`, `.pb.cc`, and `.pb.h`.  These are included in each test project in lieu of the `.proto` includes specified in `build.json`.  This substitution is done by `/templates/vsprojects/vcxproj_defs.include`
+    * copy over the `/test/` folder in order to get the new files (assuming this was built on linux in order to have an easy protobuf+grpc plugin installation)
+
 #Testing
+
+This is incomplete (only runs some tests for now), todo.  The above .sln-based buildgen makes more tets but isn't tied in to automatic test running yet.
 
 Use `run_tests.py`, that also supports Windows (with a bit limited experience).
 ```

--- a/vsprojects/cpptest.props
+++ b/vsprojects/cpptest.props
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ImportGroup Label="PropertySheets" />
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..;$(ProjectDir)\..\..\include;$(ProjectDir)\..\..\third_party\protobuf\src;$(ProjectDir)\..\..\third_party\gtest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <WarningLevel>EnableAllWarnings</WarningLevel>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>grpc++_test_util.lib;grpc_test_util.lib;gpr_test_util.lib;gtestd.lib;gflags.lib;shlwapi.lib;gpr.lib;grpc.lib;grpc++.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(ProjectDir)\..\..\third_party\gtest\msvc\gtest\Debug;$(ProjectDir)\..\..\third_party\gflags\lib\Debug;$(ProjectDir)\..\Debug;$(ProjectDir)\..\packages\grpc.dependencies.openssl.1.0.2.2\build\native\lib\$(PlatformToolset)\$(Platform)\$(Configuration)\static;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup />
+</Project>

--- a/vsprojects/global.props
+++ b/vsprojects/global.props
@@ -5,8 +5,8 @@
   <PropertyGroup />
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(ProjectDir)\..\..;$(ProjectDir)\..\..\include;$(ProjectDir)\..\..\third_party\protobuf\src;$(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..;$(ProjectDir)\..\..\include;$(ProjectDir)\..\..\third_party\protobuf\src;$(ProjectDir)\..\packages\grpc.dependencies.openssl.1.0.2.2\build\native\include;$(ProjectDir)\..\..\third_party\gflags\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>EnableAllWarnings</WarningLevel>
     </ClCompile>
   </ItemDefinitionGroup>

--- a/vsprojects/make.bat
+++ b/vsprojects/make.bat
@@ -5,6 +5,7 @@ setlocal
 @rem Set VS variables (uses Visual Studio 2013)
 @call "%VS120COMNTOOLS%\..\..\vc\vcvarsall.bat" x86
 
-nmake /f Grpc.mak %*
+@rem /K: continue on error
+nmake /K /f Grpc.mak %*
 exit /b %ERRORLEVEL%
 endlocal


### PR DESCRIPTION
this isn't fully polished but it gets OK coverage (about 10 c++ tests are not building because of posix includes, and a couple other random ones)

todo
* switch back to using generate_projects.py (parallel version)
* clean up c++ props and split into gtest/gflags props
* Decide if building .proto files in-place with a manual script is the best solution, or if there's another way
* add documentation for grpc.mak building and overall buildgen layout
* get versions of zlib/openssl with pdb files (debug symbols) to get rid of most compile warnings