### PR TITLE
Accept [GRXWriter writerWithContainer:nil] for consistency with the rest

### DIFF
--- a/src/objective-c/RxLibrary/private/GRXNSFastEnumerator.m
+++ b/src/objective-c/RxLibrary/private/GRXNSFastEnumerator.m
@@ -59,7 +59,6 @@
 
 // Designated initializer.
 - (instancetype)initWithContainer:(id<NSFastEnumeration>)container {
-  NSAssert(container, @"container can't be nil");
   if ((self = [super init])) {
     _container = container;
   }


### PR DESCRIPTION
The other two enumerators accept `nil`, resulting in empty enumerators. That works with this one as well.