### PR TITLE
Remove experimental prefix

### DIFF
--- a/include/grpc++/channel_arguments.h
+++ b/include/grpc++/channel_arguments.h
@@ -57,11 +57,10 @@ class ChannelArguments {
   // grpc specific channel argument setters
   // Set target name override for SSL host name checking.
   void SetSslTargetNameOverride(const grpc::string& name);
-  // TODO(yangg) add flow control options
+  // TODO(yangg) add flow control optionsc
 
   // Set the compression algorithm for the channel.
-  void _Experimental_SetCompressionAlgorithm(
-      grpc_compression_algorithm algorithm);
+  void SetCompressionAlgorithm(grpc_compression_algorithm algorithm);
 
   // Generic channel argument setters. Only for advanced use cases.
   void SetInt(const grpc::string& key, int value);

--- a/include/grpc++/channel_arguments.h
+++ b/include/grpc++/channel_arguments.h
@@ -57,7 +57,7 @@ class ChannelArguments {
   // grpc specific channel argument setters
   // Set target name override for SSL host name checking.
   void SetSslTargetNameOverride(const grpc::string& name);
-  // TODO(yangg) add flow control optionsc
+  // TODO(yangg) add flow control options
 
   // Set the compression algorithm for the channel.
   void SetCompressionAlgorithm(grpc_compression_algorithm algorithm);

--- a/include/grpc++/client_context.h
+++ b/include/grpc++/client_context.h
@@ -110,12 +110,11 @@ class ClientContext {
     creds_ = creds;
   }
 
-  grpc_compression_algorithm _experimental_get_compression_algorithm() const {
+  grpc_compression_algorithm get_compression_algorithm() const {
     return compression_algorithm_;
   }
 
-  void _experimental_set_compression_algorithm(
-      grpc_compression_algorithm algorithm);
+  void set_compression_algorithm(grpc_compression_algorithm algorithm);
 
   std::shared_ptr<const AuthContext> auth_context() const;
 

--- a/src/cpp/client/channel_arguments.cc
+++ b/src/cpp/client/channel_arguments.cc
@@ -37,7 +37,7 @@
 
 namespace grpc {
 
-void ChannelArguments::_Experimental_SetCompressionAlgorithm(
+void ChannelArguments::SetCompressionAlgorithm(
     grpc_compression_algorithm algorithm) {
   SetInt(GRPC_COMPRESSION_ALGORITHM_ARG, algorithm);
 }

--- a/src/cpp/client/client_context.cc
+++ b/src/cpp/client/client_context.cc
@@ -79,7 +79,7 @@ void ClientContext::set_call(grpc_call* call,
   }
 }
 
-void ClientContext::_experimental_set_compression_algorithm(
+void ClientContext::set_compression_algorithm(
     grpc_compression_algorithm algorithm) {
   char* algorithm_name = NULL;
   if (!grpc_compression_algorithm_name(algorithm, &algorithm_name)) {

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -273,7 +273,7 @@ static void SendRpc(grpc::cpp::test::util::TestService::Stub* stub,
 
   for (int i = 0; i < num_rpcs; ++i) {
     ClientContext context;
-    context._experimental_set_compression_algorithm(GRPC_COMPRESS_GZIP);
+    context.set_compression_algorithm(GRPC_COMPRESS_GZIP);
     Status s = stub->Echo(&context, request, &response);
     EXPECT_EQ(response.message(), request.message());
     EXPECT_TRUE(s.ok());

--- a/test/cpp/end2end/generic_end2end_test.cc
+++ b/test/cpp/end2end/generic_end2end_test.cc
@@ -227,7 +227,7 @@ TEST_F(GenericEnd2endTest, SimpleBidiStreaming) {
   GenericServerContext srv_ctx;
   GenericServerAsyncReaderWriter srv_stream(&srv_ctx);
 
-  cli_ctx._experimental_set_compression_algorithm(GRPC_COMPRESS_GZIP);
+  cli_ctx.set_compression_algorithm(GRPC_COMPRESS_GZIP);
   send_request.set_message("Hello");
   std::unique_ptr<GenericClientAsyncReaderWriter> cli_stream =
       generic_stub_->Call(&cli_ctx, kMethodName, &cli_cq_, tag(1));


### PR DESCRIPTION
Meditating on this, it seems like _experimental was a bad idea.
Let's just make the API's we have as obvious as possible.
Also: _Experimental is a reserved token in C++, so we can't take it.