### PR TITLE
C#: add per_rpc_creds and oauth2_auth_token interop tests

### DIFF
--- a/src/csharp/Grpc.Auth/GoogleCredential.cs
+++ b/src/csharp/Grpc.Auth/GoogleCredential.cs
@@ -35,8 +35,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Google.Apis.Auth.OAuth2;
+using Google.Apis.Auth.OAuth2.Responses;
 using Newtonsoft.Json.Linq;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Security;
@@ -98,6 +101,19 @@ namespace Grpc.Auth
                     Key = privateKey
                 });
             return new GoogleCredential(serviceCredential);
+        }
+
+        public Task<bool> RequestAccessTokenAsync(CancellationToken taskCancellationToken)
+        {
+            return credential.RequestAccessTokenAsync(taskCancellationToken);
+        }
+
+        public TokenResponse Token
+        {
+            get
+            {
+                return credential.Token;
+            }
         }
 
         internal ServiceCredential InternalCredential

--- a/src/csharp/Grpc.Core.Tests/Internal/MetadataArraySafeHandleTest.cs
+++ b/src/csharp/Grpc.Core.Tests/Internal/MetadataArraySafeHandleTest.cs
@@ -51,7 +51,8 @@ namespace Grpc.Core.Internal.Tests
         [Test]
         public void CreateAndDestroy()
         {
-            var metadata = new Metadata {
+            var metadata = new Metadata
+            {
                 new Metadata.Entry("host", "somehost"),
                 new Metadata.Entry("header2", "header value"),
             };

--- a/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
+++ b/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
@@ -32,20 +32,33 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Google.Apis.Auth.PlatformServices">
+    <Reference Include="Google.Apis.Auth, Version=1.9.1.12395, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Google.Apis.Auth.1.9.1\lib\net40\Google.Apis.Auth.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.9.1.12399, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Google.Apis.Auth.1.9.1\lib\net40\Google.Apis.Auth.PlatformServices.dll</HintPath>
     </Reference>
-    <Reference Include="Google.Apis.Core">
+    <Reference Include="Google.Apis.Core, Version=1.9.1.12394, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Google.Apis.Core.1.9.1\lib\portable-net40+sl50+win+wpa81+wp80\Google.Apis.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks">
+    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -63,16 +76,15 @@
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Extensions">
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives">
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Net.Http.2.2.28\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Grpc.Core\Version.cs">

--- a/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
@@ -135,7 +135,7 @@ namespace Grpc.IntegrationTesting
             GrpcEnvironment.Shutdown();
         }
 
-        private void RunTestCase(string testCase, TestService.ITestServiceClient client)
+        private void RunTestCase(string testCase, TestService.TestServiceClient client)
         {
             switch (testCase)
             {
@@ -162,6 +162,12 @@ namespace Grpc.IntegrationTesting
                     break;
                 case "compute_engine_creds":
                     RunComputeEngineCreds(client);
+                    break;
+                case "oauth2_auth_token":
+                    RunOAuth2AuthToken(client);
+                    break;
+                case "per_rpc_creds":
+                    RunPerRpcCreds(client);
                     break;
                 case "cancel_after_begin":
                     RunCancelAfterBegin(client);
@@ -352,6 +358,51 @@ namespace Grpc.IntegrationTesting
             Assert.AreEqual(314159, response.Payload.Body.Length);
             Assert.AreEqual(AuthScopeResponse, response.OauthScope);
             Assert.AreEqual(ComputeEngineUser, response.Username);
+            Console.WriteLine("Passed!");
+        }
+
+        public static void RunOAuth2AuthToken(TestService.TestServiceClient client)
+        {
+            Console.WriteLine("running oauth2_auth_token");
+            var credential = GoogleCredential.GetApplicationDefault().CreateScoped(new[] { AuthScope });
+            Assert.IsTrue(credential.RequestAccessTokenAsync(CancellationToken.None).Result);
+            string oauth2Token = credential.Token.AccessToken;
+
+            // Intercept calls with an OAuth2 token obtained out-of-band.
+            client.HeaderInterceptor = new MetadataInterceptorDelegate((metadata) =>
+            {
+                metadata.Add(new Metadata.Entry("Authorization", "Bearer " + oauth2Token));
+            });
+
+            var request = SimpleRequest.CreateBuilder()
+                .SetFillUsername(true)
+                .SetFillOauthScope(true)
+                .Build();
+
+            var response = client.UnaryCall(request);
+
+            Assert.AreEqual(AuthScopeResponse, response.OauthScope);
+            Assert.AreEqual(ServiceAccountUser, response.Username);
+            Console.WriteLine("Passed!");
+        }
+
+        public static void RunPerRpcCreds(TestService.TestServiceClient client)
+        {
+            Console.WriteLine("running per_rpc_creds");
+
+            var credential = GoogleCredential.GetApplicationDefault().CreateScoped(new[] { AuthScope });
+            Assert.IsTrue(credential.RequestAccessTokenAsync(CancellationToken.None).Result);
+            string oauth2Token = credential.Token.AccessToken;
+
+            var request = SimpleRequest.CreateBuilder()
+                .SetFillUsername(true)
+                .SetFillOauthScope(true)
+                .Build();
+
+            var response = client.UnaryCall(request, headers: new Metadata { new Metadata.Entry("Authorization", "Bearer " + oauth2Token) } );
+
+            Assert.AreEqual(AuthScopeResponse, response.OauthScope);
+            Assert.AreEqual(ServiceAccountUser, response.Username);
             Console.WriteLine("Passed!");
         }
 


### PR DESCRIPTION
Tested locally, interop test infrastructure doesn't support these tests yet.