### PR TITLE
Add per-language homebrew testing for Mac on Jenkins

### DIFF
--- a/tools/jenkins/run_distribution.sh
+++ b/tools/jenkins/run_distribution.sh
@@ -39,19 +39,19 @@ if [ "$platform" == "linux" ]; then
     sha1=$(sha1sum tools/jenkins/grpc_linuxbrew/Dockerfile | cut -f1 -d\ )
     DOCKER_IMAGE_NAME=grpc_linuxbrew_$sha1
 
+    # build docker image, contains all pre-requisites
     docker build -t $DOCKER_IMAGE_NAME tools/jenkins/grpc_linuxbrew
-
-    supported="python nodejs ruby php"
 
     if [ "$language" == "core" ]; then
       command="curl -fsSL https://goo.gl/getgrpc | bash -"
-    elif [[ "$supported" =~ "$language" ]]; then
+    elif [[ "python nodejs ruby php" =~ "$language" ]]; then
       command="curl -fsSL https://goo.gl/getgrpc | bash -s $language"
     else
       echo "unsupported language $language"
       exit 1
     fi
 
+    # run per-language homebrew installation script
     docker run $DOCKER_IMAGE_NAME bash -l \
       -c "nvm use 0.12; \
           npm set unsafe-perm true; \
@@ -66,26 +66,81 @@ if [ "$platform" == "linux" ]; then
 elif [ "$platform" == "macos" ]; then
 
   if [ "$dist_channel" == "homebrew" ]; then
-    which brew # TODO: for debug, can be removed later
+    # system installed homebrew, don't interfere
     brew list -l
-    dir=/tmp/homebrew-test-$language
-    rm -rf $dir
-    mkdir -p $dir
-    git clone https://github.com/Homebrew/homebrew.git $dir
-    cd $dir
-    # TODO: Uncomment these when the general structure of the script is verified
-    # PATH=$dir/bin:$PATH brew tap homebrew/dupes
-    # PATH=$dir/bin:$PATH brew install zlib
-    # PATH=$dir/bin:$PATH brew install openssl
-    # PATH=$dir/bin:$PATH brew tap grpc/grpc
-    # PATH=$dir/bin:$PATH brew install --without-python google-protobuf
-    # PATH=$dir/bin:$PATH brew install grpc
-    PATH=$dir/bin:$PATH brew list -l
+
+    # Set up temp directories for test installation of homebrew
+    brew_root=/tmp/homebrew-test-$language
+    rm -rf $brew_root
+    mkdir -p $brew_root
+    git clone https://github.com/Homebrew/homebrew.git $brew_root
+
+    # Install grpc via homebrew
+    #
+    # The temp $PATH env variable makes sure we are operating at the right copy of
+    # temp homebrew installation, and do not interfere with the system's main brew
+    # installation.
+    #
+    # TODO: replace the next section with the actual homebrew installation script
+    # i.e. curl -fsSL https://goo.gl/getgrpc | bash -s $language
+    # need to resolve a bunch of environment and privilege issue on the jenkins
+    # mac machine itself
+    local OLD_PATH=$PATH
+    local PATH=$brew_root/bin:$PATH
+    cd $brew_root
+    brew tap homebrew/dupes
+    brew install zlib
+    brew install openssl
+    brew tap grpc/grpc
+    brew install --without-python google-protobuf
+    brew install grpc
     brew list -l
+
+    # Install per-language modules/extensions on top of core grpc
+    #
+    # If a command below needs root access, the binary had been added to
+    # /etc/sudoers. This step needs to be repeated if we add more mac instances
+    # to our jenkins project.
+    #
+    # Examples (lines that needed to be added to /etc/sudoers):
+    # + Defaults        env_keep += "CFLAGS CXXFLAGS LDFLAGS enable_grpc"
+    # + jenkinsnode1 ALL=(ALL) NOPASSWD: /usr/bin/pecl, /usr/local/bin/pip,
+    # +   /usr/local/bin/npm
+    case $language in
+      *core*) ;;
+      *python*)
+        sudo CFLAGS=-I$brew_root/include LDFLAGS=-L$brew_root/lib pip install grpcio
+        pip list | grep grpcio
+        echo 'y' | sudo pip uninstall grpcio
+        ;;
+      *nodejs*)
+        sudo CXXFLAGS=-I$brew_root/include LDFLAGS=-L$brew_root/lib npm install grpc
+        npm list | grep grpc
+        sudo npm uninstall grpc
+        ;;
+      *ruby*)
+        gem install grpc -- --with-grpc-dir=$brew_root
+        gem list | grep grpc
+        gem uninstall grpc
+        ;;
+      *php*)
+        sudo enable_grpc=$brew_root CFLAGS="-Wno-parentheses-equality" pecl install grpc-alpha
+        pecl list | grep grpc
+        sudo pecl uninstall grpc
+        ;;
+      *)
+        echo "Unsupported language $language"
+        exit 1
+        ;;
+    esac
+
+    # clean up
     cd ~/ 
-    rm -rf $dir
-    echo $PATH # TODO: for debug, can be removed later
-    brew list -l # TODO: for debug, can be removed later
+    rm -rf $brew_root
+
+    # Make sure the system brew installation is still unaffected
+    local PATH=$OLD_PATH
+    brew list -l
 
   else
     echo "Unsupported $platform dist_channel $dist_channel"


### PR DESCRIPTION
Cont #1883 

Added per-language testing to homebrew on the macos instancen on Jenkins.

Because we cannot easily blow away a test instance, we have to be careful not to interfere with the base installation of homebrew already on the machine. The strategy I have chosen:

 * create a separate `/tmp/homebrew-test-$language` homebrew installation per language per test run
 * use the temporary environment variable `PATH=$brew_root/bin:$PATH` to make sure each copy operates within its own homebrew installation and don't interfere with each other
 * per-language: install the grpc module/extension on top of the core grpc library (installed by homebrew), and then uninstall it.
 * remove the `/tmp/homebrew-test-$language` homebrew installation after each run

It's a bit non-ideal that we duplicate most of the logic of the script `homebrew-grpc/script/install` here but on the other hand, we cannot really safely run the `goo.gl/getgrpc` script as-is because of the slightly different user/root privilege in the macos machine. 

Some of the per-language commands, like `npm`, `pecl`, and `pip`, need `root` access in this mac machine. To skip entering password, I added those commands into the `/etc/sudoers` file. That means that if we do add more mac machine to this Jenkins project, we need to re-do these steps.