### PR TITLE
Remove one range-based for and do appropriate static casts on nullptr

### DIFF
--- a/test/cpp/client/credentials_test.cc
+++ b/test/cpp/client/credentials_test.cc
@@ -47,7 +47,7 @@ class CredentialsTest : public ::testing::Test {
 
 TEST_F(CredentialsTest, InvalidServiceAccountCreds) {
   std::shared_ptr<Credentials> bad1 = ServiceAccountCredentials("", "", 1);
-  EXPECT_EQ(nullptr, bad1.get());
+  EXPECT_EQ(static_cast<Credentials *>(nullptr), bad1.get());
 }
 
 }  // namespace testing

--- a/test/cpp/common/secure_auth_context_test.cc
+++ b/test/cpp/common/secure_auth_context_test.cc
@@ -92,21 +92,21 @@ TEST_F(SecureAuthContextTest, Iterators) {
   EXPECT_EQ("bar", p2.second);
   ++iter;
   EXPECT_EQ(context.end(), iter);
-  // Range-based for loop test.
+
   int i = 0;
-  for (auto p : context) {
+  for (auto p = context.begin(); p != context.end(); p++) {
     switch (i++) {
       case 0:
-        EXPECT_EQ("name", p.first);
-        EXPECT_EQ("chapi", p.second);
+        EXPECT_EQ("name", (*p).first);
+        EXPECT_EQ("chapi", (*p).second);
         break;
       case 1:
-        EXPECT_EQ("name", p.first);
-        EXPECT_EQ("chapo", p.second);
+        EXPECT_EQ("name", (*p).first);
+        EXPECT_EQ("chapo", (*p).second);
         break;
       case 2:
-        EXPECT_EQ("foo", p.first);
-        EXPECT_EQ("bar", p.second);
+        EXPECT_EQ("foo", (*p).first);
+        EXPECT_EQ("bar", (*p).second);
         break;
       default:
         EXPECT_TRUE(0);

--- a/test/cpp/common/secure_auth_context_test.cc
+++ b/test/cpp/common/secure_auth_context_test.cc
@@ -92,26 +92,6 @@ TEST_F(SecureAuthContextTest, Iterators) {
   EXPECT_EQ("bar", p2.second);
   ++iter;
   EXPECT_EQ(context.end(), iter);
-
-  int i = 0;
-  for (auto p = context.begin(); p != context.end(); p++) {
-    switch (i++) {
-      case 0:
-        EXPECT_EQ("name", (*p).first);
-        EXPECT_EQ("chapi", (*p).second);
-        break;
-      case 1:
-        EXPECT_EQ("name", (*p).first);
-        EXPECT_EQ("chapo", (*p).second);
-        break;
-      case 2:
-        EXPECT_EQ("foo", (*p).first);
-        EXPECT_EQ("bar", (*p).second);
-        break;
-      default:
-        EXPECT_TRUE(0);
-    }
-  }
 }
 
 }  // namespace

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -508,7 +508,7 @@ TEST_F(End2endTest, DiffPackageServices) {
 // rpc and stream should fail on bad credentials.
 TEST_F(End2endTest, BadCredentials) {
   std::shared_ptr<Credentials> bad_creds = ServiceAccountCredentials("", "", 1);
-  EXPECT_EQ(nullptr, bad_creds.get());
+  EXPECT_EQ(static_cast<Credentials *>(nullptr), bad_creds.get());
   std::shared_ptr<ChannelInterface> channel =
       CreateChannel(server_address_.str(), bad_creds, ChannelArguments());
   std::unique_ptr<grpc::cpp::test::util::TestService::Stub> stub(


### PR DESCRIPTION
to support gcc-4.4
