### PR TITLE
Set primary user agent in C# channel

### DIFF
--- a/src/csharp/Grpc.Core.Tests/ClientServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ClientServerTest.cs
@@ -219,7 +219,7 @@ namespace Grpc.Core.Tests
             var headers = new Metadata
             {
                 new Metadata.Entry("asciiHeader", "abcdefg"),
-                new Metadata.Entry("binaryHeader-bin", new byte[] { 1, 2, 3, 0, 0xff } ),
+                new Metadata.Entry("binaryHeader-bin", new byte[] { 1, 2, 3, 0, 0xff }),
             };
             var internalCall = new Call<string, string>(ServiceName, EchoMethod, channel, headers);
             var call = Calls.AsyncUnaryCall(internalCall, "ABC", CancellationToken.None);

--- a/src/csharp/Grpc.Core/AsyncDuplexStreamingCall.cs
+++ b/src/csharp/Grpc.Core/AsyncDuplexStreamingCall.cs
@@ -56,7 +56,6 @@ namespace Grpc.Core
             this.getTrailersFunc = getTrailersFunc;
             this.disposeAction = disposeAction;
         }
-        
 
         /// <summary>
         /// Async stream to read streaming responses.

--- a/src/csharp/Grpc.Core/ChannelOptions.cs
+++ b/src/csharp/Grpc.Core/ChannelOptions.cs
@@ -115,41 +115,49 @@ namespace Grpc.Core
         }
     }
 
+    /// <summary>
+    /// Defines names of supported channel options.
+    /// </summary>
     public static class ChannelOptions
     {
-        // Override SSL target check. Only to be used for testing.
+        /// <summary>Override SSL target check. Only to be used for testing.</summary>
         public const string SslTargetNameOverride = "grpc.ssl_target_name_override";
 
-        // Enable census for tracing and stats collection
+        /// <summary>Enable census for tracing and stats collection</summary>
         public const string Census = "grpc.census";
 
-        // Maximum number of concurrent incoming streams to allow on a http2 connection
+        /// <summary>Maximum number of concurrent incoming streams to allow on a http2 connection</summary>
         public const string MaxConcurrentStreams = "grpc.max_concurrent_streams";
 
-        // Maximum message length that the channel can receive
+        /// <summary>Maximum message length that the channel can receive</summary>
         public const string MaxMessageLength = "grpc.max_message_length";
 
-        // Initial sequence number for http2 transports
+        /// <summary>Initial sequence number for http2 transports</summary>
         public const string Http2InitialSequenceNumber = "grpc.http2.initial_sequence_number";
+
+        /// <summary>Primary user agent: goes at the start of the user-agent metadata</summary>
+        public const string PrimaryUserAgentString = "grpc.primary_user_agent";
+
+        /// <summary> Secondary user agent: goes at the end of the user-agent metadata</summary>
+        public const string SecondaryUserAgentString = "grpc.secondary_user_agent";
 
         /// <summary>
         /// Creates native object for a collection of channel options.
         /// </summary>
         /// <returns>The native channel arguments.</returns>
-        internal static ChannelArgsSafeHandle CreateChannelArgs(IEnumerable<ChannelOption> options)
+        internal static ChannelArgsSafeHandle CreateChannelArgs(List<ChannelOption> options)
         {
-            if (options == null)
+            if (options == null || options.Count == 0)
             {
                 return ChannelArgsSafeHandle.CreateNull();
             }
-            var optionList = new List<ChannelOption>(options);  // It's better to do defensive copy
             ChannelArgsSafeHandle nativeArgs = null;
             try
             {
-                nativeArgs = ChannelArgsSafeHandle.Create(optionList.Count);
-                for (int i = 0; i < optionList.Count; i++)
+                nativeArgs = ChannelArgsSafeHandle.Create(options.Count);
+                for (int i = 0; i < options.Count; i++)
                 {
-                    var option = optionList[i];
+                    var option = options[i];
                     if (option.Type == ChannelOption.OptionType.Integer)
                     {
                         nativeArgs.SetInteger(i, option.Name, option.IntValue);

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Internal\BatchContextSafeHandle.cs" />
     <Compile Include="ChannelOptions.cs" />
     <Compile Include="AsyncUnaryCall.cs" />
+    <Compile Include="VersionInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Grpc.Core.nuspec" />

--- a/src/csharp/Grpc.Core/Internal/MetadataArraySafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/MetadataArraySafeHandle.cs
@@ -88,7 +88,7 @@ namespace Grpc.Core.Internal
             ulong count = grpcsharp_metadata_array_count(metadataArray).ToUInt64();
 
             var metadata = new Metadata();
-            for (ulong i = 0; i < count; i ++)
+            for (ulong i = 0; i < count; i++)
             {
                 var index = new UIntPtr(i);
                 string key = Marshal.PtrToStringAnsi(grpcsharp_metadata_array_get_key(metadataArray, index));

--- a/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
@@ -179,7 +179,6 @@ namespace Grpc.Core.Internal
             var requestStream = new ServerRequestStream<TRequest, TResponse>(asyncCall);
             var responseStream = new ServerResponseStream<TRequest, TResponse>(asyncCall);
 
-
             Status status;
             var context = HandlerUtils.NewContext(newRpc);
             try

--- a/src/csharp/Grpc.Core/Metadata.cs
+++ b/src/csharp/Grpc.Core/Metadata.cs
@@ -225,7 +225,6 @@ namespace Grpc.Core
             {
                 return string.Format("[Entry: key={0}, value={1}]", Key, Value);
             }
-            
         }
     }
 }

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -53,6 +53,7 @@ namespace Grpc.Core
         public const int PickUnusedPort = 0;
 
         readonly GrpcEnvironment environment;
+        readonly List<ChannelOption> options;
         readonly ServerSafeHandle handle;
         readonly object myLock = new object();
 
@@ -69,7 +70,8 @@ namespace Grpc.Core
         public Server(IEnumerable<ChannelOption> options = null)
         {
             this.environment = GrpcEnvironment.GetInstance();
-            using (var channelArgs = ChannelOptions.CreateChannelArgs(options))
+            this.options = options != null ? new List<ChannelOption>(options) : new List<ChannelOption>();
+            using (var channelArgs = ChannelOptions.CreateChannelArgs(this.options))
             {
                 this.handle = ServerSafeHandle.NewServer(environment.CompletionQueue, channelArgs);
             }

--- a/src/csharp/Grpc.Core/ServerCallContext.cs
+++ b/src/csharp/Grpc.Core/ServerCallContext.cs
@@ -45,16 +45,14 @@ namespace Grpc.Core
     {
         // TODO(jtattermusch): expose method to send initial metadata back to client
 
-        // TODO(jtattermusch): allow setting status and trailing metadata to send after handler completes.
-
         private readonly string method;
         private readonly string host;
         private readonly DateTime deadline;
         private readonly Metadata requestHeaders;
         private readonly CancellationToken cancellationToken;
+        private readonly Metadata responseTrailers = new Metadata();
 
         private Status status = Status.DefaultSuccess;
-        private readonly Metadata responseTrailers = new Metadata();
 
         public ServerCallContext(string method, string host, DateTime deadline, Metadata requestHeaders, CancellationToken cancellationToken)
         {
@@ -127,6 +125,7 @@ namespace Grpc.Core
             {
                 return this.status;
             }
+
             set
             {
                 status = value;

--- a/src/csharp/Grpc.Core/Version.cs
+++ b/src/csharp/Grpc.Core/Version.cs
@@ -2,4 +2,4 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 // The current version of gRPC C#.
-[assembly: AssemblyVersion("0.6.0.*")]
+[assembly: AssemblyVersion(Grpc.Core.VersionInfo.CurrentVersion + ".*")]

--- a/src/csharp/Grpc.Core/VersionInfo.cs
+++ b/src/csharp/Grpc.Core/VersionInfo.cs
@@ -1,0 +1,15 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Grpc.Core
+{
+    public static class VersionInfo
+    {
+        /// <summary>
+        /// Current version of gRPC
+        /// </summary>
+        public const string CurrentVersion = "0.6.0";
+    }
+}
+
+

--- a/src/csharp/Grpc.Core/VersionInfo.cs
+++ b/src/csharp/Grpc.Core/VersionInfo.cs
@@ -11,5 +11,3 @@ namespace Grpc.Core
         public const string CurrentVersion = "0.6.0";
     }
 }
-
-

--- a/src/csharp/Grpc.HealthCheck/Settings.StyleCop
+++ b/src/csharp/Grpc.HealthCheck/Settings.StyleCop
@@ -1,0 +1,10 @@
+<StyleCopSettings Version="105">
+  <SourceFileList>
+    <SourceFile>Health.cs</SourceFile>
+    <Settings>
+    <GlobalSettings>
+      <BooleanProperty Name="RulesEnabledByDefault">False</BooleanProperty>
+    </GlobalSettings>
+    </Settings>
+  </SourceFileList>
+</StyleCopSettings>

--- a/src/csharp/Grpc.IntegrationTesting.Client/Grpc.IntegrationTesting.Client.csproj
+++ b/src/csharp/Grpc.IntegrationTesting.Client/Grpc.IntegrationTesting.Client.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProductVersion>10.0.0</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{3D166931-BA2D-416E-95A3-D36E8F6E90B9}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>Grpc.IntegrationTesting.Client</RootNamespace>
@@ -47,6 +45,10 @@
     <ProjectReference Include="..\Grpc.IntegrationTesting\Grpc.IntegrationTesting.csproj">
       <Project>{C61154BA-DD4A-4838-8420-0162A28925E0}</Project>
       <Name>Grpc.IntegrationTesting</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Grpc.Core\Grpc.Core.csproj">
+      <Project>{CCC4440E-49F7-4790-B0AF-FEABB0837AE7}</Project>
+      <Name>Grpc.Core</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csharp/Grpc.IntegrationTesting.Server/Grpc.IntegrationTesting.Server.csproj
+++ b/src/csharp/Grpc.IntegrationTesting.Server/Grpc.IntegrationTesting.Server.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProductVersion>10.0.0</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{A654F3B8-E859-4E6A-B30D-227527DBEF0D}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <RootNamespace>Grpc.IntegrationTesting.Server</RootNamespace>
@@ -47,6 +45,10 @@
     <ProjectReference Include="..\Grpc.IntegrationTesting\Grpc.IntegrationTesting.csproj">
       <Project>{C61154BA-DD4A-4838-8420-0162A28925E0}</Project>
       <Name>Grpc.IntegrationTesting</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Grpc.Core\Grpc.Core.csproj">
+      <Project>{CCC4440E-49F7-4790-B0AF-FEABB0837AE7}</Project>
+      <Name>Grpc.Core</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
@@ -399,7 +399,7 @@ namespace Grpc.IntegrationTesting
                 .SetFillOauthScope(true)
                 .Build();
 
-            var response = client.UnaryCall(request, headers: new Metadata { new Metadata.Entry("Authorization", "Bearer " + oauth2Token) } );
+            var response = client.UnaryCall(request, headers: new Metadata { new Metadata.Entry("Authorization", "Bearer " + oauth2Token) });
 
             Assert.AreEqual(AuthScopeResponse, response.OauthScope);
             Assert.AreEqual(ServiceAccountUser, response.Username);


### PR DESCRIPTION
Makes sure user agent string grpc-csharp/x.x.x is added to all client channels (unless user overrides it manually).

-- fixes #2519 
-- also a bit of code style cleanup an fixing stylecop issues

