### PR TITLE
C# logging API

### DIFF
--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -47,7 +47,6 @@
     <Compile Include="IServerStreamWriter.cs" />
     <Compile Include="IAsyncStreamWriter.cs" />
     <Compile Include="IAsyncStreamReader.cs" />
-    <Compile Include="Internal\GrpcLog.cs" />
     <Compile Include="Version.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RpcException.cs" />
@@ -105,6 +104,9 @@
     <Compile Include="VersionInfo.cs" />
     <Compile Include="Internal\CStringSafeHandle.cs" />
     <Compile Include="KeyCertificatePair.cs" />
+    <Compile Include="Logging\ILogger.cs" />
+    <Compile Include="Logging\ConsoleLogger.cs" />
+    <Compile Include="Internal\NativeLogRedirector.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Grpc.Core.nuspec" />
@@ -135,4 +137,7 @@
   </Target>
   <Import Project="..\packages\grpc.dependencies.openssl.redist.1.0.2.2\build\portable-net45\grpc.dependencies.openssl.redist.targets" Condition="Exists('..\packages\grpc.dependencies.openssl.redist.1.0.2.2\build\portable-net45\grpc.dependencies.openssl.redist.targets')" />
   <Import Project="..\packages\grpc.dependencies.zlib.redist.1.2.8.9\build\portable-net45\grpc.dependencies.zlib.redist.targets" Condition="Exists('..\packages\grpc.dependencies.zlib.redist.1.2.8.9\build\portable-net45\grpc.dependencies.zlib.redist.targets')" />
+  <ItemGroup>
+    <Folder Include="Logging\" />
+  </ItemGroup>
 </Project>

--- a/src/csharp/Grpc.Core/Internal/AsyncCall.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCall.cs
@@ -38,6 +38,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core.Internal;
+using Grpc.Core.Logging;
 using Grpc.Core.Utils;
 
 namespace Grpc.Core.Internal
@@ -47,6 +48,8 @@ namespace Grpc.Core.Internal
     /// </summary>
     internal class AsyncCall<TRequest, TResponse> : AsyncCallBase<TRequest, TResponse>
     {
+        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<AsyncCall<TRequest, TResponse>>();
+
         Channel channel;
 
         // Completion of a pending unary response if not null.
@@ -106,7 +109,7 @@ namespace Grpc.Core.Internal
                         }
                         catch (Exception e)
                         {
-                            Console.WriteLine("Exception occured while invoking completion delegate: " + e);
+                            Logger.Error(e, "Exception occured while invoking completion delegate.");
                         }
                     }
                 }

--- a/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs
@@ -38,6 +38,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core.Internal;
+using Grpc.Core.Logging;
 using Grpc.Core.Utils;
 
 namespace Grpc.Core.Internal
@@ -48,6 +49,8 @@ namespace Grpc.Core.Internal
     /// </summary>
     internal abstract class AsyncCallBase<TWrite, TRead>
     {
+        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<AsyncCallBase<TWrite, TRead>>();
+
         readonly Func<TWrite, byte[]> serializer;
         readonly Func<byte[], TRead> deserializer;
 
@@ -233,9 +236,9 @@ namespace Grpc.Core.Internal
                 payload = serializer(msg);
                 return true;
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                Console.WriteLine("Exception occured while trying to serialize message");
+                Logger.Error(e, "Exception occured while trying to serialize message");
                 payload = null;
                 return false;
             }
@@ -248,9 +251,9 @@ namespace Grpc.Core.Internal
                 msg = deserializer(payload);
                 return true;
             } 
-            catch (Exception)
+            catch (Exception e)
             {
-                Console.WriteLine("Exception occured while trying to deserialize message");
+                Logger.Error(e, "Exception occured while trying to deserialize message.");
                 msg = default(TRead);
                 return false;
             }
@@ -264,7 +267,7 @@ namespace Grpc.Core.Internal
             }
             catch (Exception e)
             {
-                Console.WriteLine("Exception occured while invoking completion delegate: " + e);
+                Logger.Error(e, "Exception occured while invoking completion delegate.");
             }
         }
 

--- a/src/csharp/Grpc.Core/Internal/CompletionRegistry.cs
+++ b/src/csharp/Grpc.Core/Internal/CompletionRegistry.cs
@@ -35,6 +35,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using Grpc.Core.Logging;
 using Grpc.Core.Utils;
 
 namespace Grpc.Core.Internal
@@ -45,6 +46,8 @@ namespace Grpc.Core.Internal
 
     internal class CompletionRegistry
     {
+        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<CompletionRegistry>();
+
         readonly GrpcEnvironment environment;
         readonly ConcurrentDictionary<IntPtr, OpCompletionDelegate> dict = new ConcurrentDictionary<IntPtr, OpCompletionDelegate>();
 
@@ -81,7 +84,7 @@ namespace Grpc.Core.Internal
             }
             catch (Exception e)
             {
-                Console.WriteLine("Exception occured while invoking completion delegate: " + e);
+                Logger.Error(e, "Exception occured while invoking completion delegate.");
             }
             finally
             {

--- a/src/csharp/Grpc.Core/Internal/GrpcThreadPool.cs
+++ b/src/csharp/Grpc.Core/Internal/GrpcThreadPool.cs
@@ -36,7 +36,7 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Grpc.Core.Internal;
+using Grpc.Core.Logging;
 
 namespace Grpc.Core.Internal
 {
@@ -45,6 +45,8 @@ namespace Grpc.Core.Internal
     /// </summary>
     internal class GrpcThreadPool
     {
+        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<GrpcThreadPool>();
+
         readonly GrpcEnvironment environment;
         readonly object myLock = new object();
         readonly List<Thread> threads = new List<Thread>();
@@ -82,7 +84,7 @@ namespace Grpc.Core.Internal
             {
                 cq.Shutdown();
 
-                Console.WriteLine("Waiting for GRPC threads to finish.");
+                Logger.Info("Waiting for GRPC threads to finish.");
                 foreach (var thread in threads)
                 {
                     thread.Join();
@@ -129,12 +131,12 @@ namespace Grpc.Core.Internal
                     }
                     catch (Exception e)
                     {
-                        Console.WriteLine("Exception occured while invoking completion delegate: " + e);
+                        Logger.Error(e, "Exception occured while invoking completion delegate");
                     }
                 }
             }
             while (ev.type != GRPCCompletionType.Shutdown);
-            Console.WriteLine("Completion queue has shutdown successfully, thread " + Thread.CurrentThread.Name + " exiting.");
+            Logger.Info("Completion queue has shutdown successfully, thread {0} exiting.", Thread.CurrentThread.Name);
         }
     }
 }

--- a/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
@@ -37,6 +37,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core.Internal;
+using Grpc.Core.Logging;
 using Grpc.Core.Utils;
 
 namespace Grpc.Core.Internal
@@ -50,6 +51,8 @@ namespace Grpc.Core.Internal
         where TRequest : class
         where TResponse : class
     {
+        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<UnaryServerCallHandler<TRequest, TResponse>>();
+
         readonly Method<TRequest, TResponse> method;
         readonly UnaryServerMethod<TRequest, TResponse> handler;
 
@@ -85,7 +88,7 @@ namespace Grpc.Core.Internal
             } 
             catch (Exception e)
             {
-                Console.WriteLine("Exception occured in handler: " + e);
+                Logger.Error(e, "Exception occured in handler.");
                 status = HandlerUtils.StatusFromException(e);
             }
             try
@@ -104,6 +107,8 @@ namespace Grpc.Core.Internal
         where TRequest : class
         where TResponse : class
     {
+        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<ServerStreamingServerCallHandler<TRequest, TResponse>>();
+
         readonly Method<TRequest, TResponse> method;
         readonly ServerStreamingServerMethod<TRequest, TResponse> handler;
 
@@ -138,7 +143,7 @@ namespace Grpc.Core.Internal
             }
             catch (Exception e)
             {
-                Console.WriteLine("Exception occured in handler: " + e);
+                Logger.Error(e, "Exception occured in handler.");
                 status = HandlerUtils.StatusFromException(e);
             }
 
@@ -158,6 +163,8 @@ namespace Grpc.Core.Internal
         where TRequest : class
         where TResponse : class
     {
+        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<ClientStreamingServerCallHandler<TRequest, TResponse>>();
+
         readonly Method<TRequest, TResponse> method;
         readonly ClientStreamingServerMethod<TRequest, TResponse> handler;
 
@@ -196,7 +203,7 @@ namespace Grpc.Core.Internal
             }
             catch (Exception e)
             {
-                Console.WriteLine("Exception occured in handler: " + e);
+                Logger.Error(e, "Exception occured in handler.");
                 status = HandlerUtils.StatusFromException(e);
             }
 
@@ -216,6 +223,8 @@ namespace Grpc.Core.Internal
         where TRequest : class
         where TResponse : class
     {
+        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<DuplexStreamingServerCallHandler<TRequest, TResponse>>();
+
         readonly Method<TRequest, TResponse> method;
         readonly DuplexStreamingServerMethod<TRequest, TResponse> handler;
 
@@ -246,7 +255,7 @@ namespace Grpc.Core.Internal
             }
             catch (Exception e)
             {
-                Console.WriteLine("Exception occured in handler: " + e);
+                Logger.Error(e, "Exception occured in handler.");
                 status = HandlerUtils.StatusFromException(e);
             }
             try

--- a/src/csharp/Grpc.Core/Logging/ConsoleLogger.cs
+++ b/src/csharp/Grpc.Core/Logging/ConsoleLogger.cs
@@ -1,0 +1,103 @@
+#region Copyright notice and license
+
+// Copyright 2015, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+namespace Grpc.Core.Logging
+{
+    /// <summary>Logger that logs to System.Console.</summary>
+    public class ConsoleLogger : ILogger
+    {
+        readonly Type forType;
+        readonly string forTypeString;
+
+        public ConsoleLogger() : this(null)
+        {
+        }
+
+        private ConsoleLogger(Type forType)
+        {
+            this.forType = forType;
+            this.forTypeString = forType != null ? forType.FullName + " " : "";
+        }
+
+        public ILogger ForType<T>()
+        {
+            if (typeof(T) == forType)
+            {
+                return this;
+            }
+            return new ConsoleLogger(typeof(T));
+        }
+
+        public void Debug(string message, params object[] formatArgs)
+        {
+            Log("D", message, formatArgs);
+        }
+
+        public void Info(string message, params object[] formatArgs)
+        {
+            Log("I", message, formatArgs);
+        }
+
+        public void Warning(string message, params object[] formatArgs)
+        {
+            Log("W", message, formatArgs);
+        }
+
+        public void Warning(Exception exception, string message, params object[] formatArgs)
+        {
+            Log("W", message + " " + exception, formatArgs);
+        }
+
+        public void Error(string message, params object[] formatArgs)
+        {
+            Log("E", message, formatArgs);
+        }
+
+        public void Error(Exception exception, string message, params object[] formatArgs)
+        {
+            Log("E", message + " " + exception, formatArgs);
+        }
+
+        private void Log(string severityString, string message, object[] formatArgs)
+        {
+            Console.Error.WriteLine("{0}{1} {2}{3}",
+                severityString,
+                DateTime.Now,
+                forTypeString,
+                string.Format(message, formatArgs));
+        }
+    }
+}

--- a/src/csharp/Grpc.Core/Logging/ILogger.cs
+++ b/src/csharp/Grpc.Core/Logging/ILogger.cs
@@ -32,38 +32,26 @@
 #endregion
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Threading.Tasks;
 
-namespace Grpc.Core.Utils
+namespace Grpc.Core.Logging
 {
-    public static class BenchmarkUtil
+    /// <summary>For logging messages.</summary>
+    public interface ILogger
     {
-        /// <summary>
-        /// Runs a simple benchmark preceded by warmup phase.
-        /// </summary>
-        public static void RunBenchmark(int warmupIterations, int benchmarkIterations, Action action)
-        {
-            var logger = GrpcEnvironment.Logger;
-            
-            logger.Info("Warmup iterations: {0}", warmupIterations);
-            for (int i = 0; i < warmupIterations; i++)
-            {
-                action();
-            }
+        /// <summary>Returns a logger associated with the specified type.</summary>
+        ILogger ForType<T>();
 
-            logger.Info("Benchmark iterations: {0}", benchmarkIterations);
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
-            for (int i = 0; i < benchmarkIterations; i++)
-            {
-                action();
-            }
-            stopwatch.Stop();
-            logger.Info("Elapsed time: {0}ms", stopwatch.ElapsedMilliseconds);
-            logger.Info("Ops per second: {0}", (int)((double)benchmarkIterations  * 1000 / stopwatch.ElapsedMilliseconds));
-        }
+        void Debug(string message, params object[] formatArgs);
+
+        void Info(string message, params object[] formatArgs);
+
+        void Warning(string message, params object[] formatArgs);
+
+        void Warning(Exception exception, string message, params object[] formatArgs);
+
+        void Error(string message, params object[] formatArgs);
+
+        void Error(Exception exception, string message, params object[] formatArgs);
     }
 }

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -38,6 +38,7 @@ using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Grpc.Core.Internal;
+using Grpc.Core.Logging;
 using Grpc.Core.Utils;
 
 namespace Grpc.Core
@@ -51,6 +52,8 @@ namespace Grpc.Core
         /// Pass this value as port to have the server choose an unused listening port for you.
         /// </summary>
         public const int PickUnusedPort = 0;
+
+        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<Server>();
 
         readonly GrpcEnvironment environment;
         readonly List<ChannelOption> options;
@@ -233,7 +236,7 @@ namespace Grpc.Core
             }
             catch (Exception e)
             {
-                Console.WriteLine("Exception while handling RPC: " + e);
+                Logger.Warning(e, "Exception while handling RPC.");
             }
         }
 

--- a/src/csharp/Grpc.IntegrationTesting/SslCredentialsTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/SslCredentialsTest.cs
@@ -62,7 +62,7 @@ namespace Grpc.IntegrationTesting
                 File.ReadAllText(TestCredentials.ServerCertChainPath),
                 File.ReadAllText(TestCredentials.ServerPrivateKeyPath));
 
-            var serverCredentials = new SslServerCredentials(new [] { keyCertPair }, rootCert);
+            var serverCredentials = new SslServerCredentials(new[] { keyCertPair }, rootCert);
             var clientCredentials = new SslCredentials(rootCert, keyCertPair);
 
             server = new Server();
@@ -93,6 +93,5 @@ namespace Grpc.IntegrationTesting
             var response = client.UnaryCall(SimpleRequest.CreateBuilder().SetResponseSize(10).Build());
             Assert.AreEqual(10, response.Payload.Body.Length);
         }
-
     }
 }


### PR DESCRIPTION
This is based on #2645, which needs to be merged first.

Provides logging API that can redirect logs to a custom user-specified logger. Also gets rid of ugly Console.WriteLine in Grpc.Core.

Fixes #1991