### PR TITLE
Isolate nullptr to grpc namespace when we must define it ourselves

### DIFF
--- a/include/grpc++/config.h
+++ b/include/grpc++/config.h
@@ -79,6 +79,7 @@
 
 #ifdef GRPC_CXX0X_NO_NULLPTR
 #include <memory>
+namespace grpc {
 const class {
  public:
   template <class T>
@@ -98,6 +99,7 @@ const class {
  private:
   void operator&() const = delete;
 } nullptr = {};
+}
 #endif
 
 #ifndef GRPC_CUSTOM_STRING

--- a/test/cpp/qps/timer.cc
+++ b/test/cpp/qps/timer.cc
@@ -52,7 +52,7 @@ static double time_double(struct timeval* tv) {
 Timer::Result Timer::Sample() {
   struct rusage usage;
   struct timeval tv;
-  gettimeofday(&tv, nullptr);
+  gettimeofday(&tv, NULL);
   getrusage(RUSAGE_SELF, &usage);
 
   Result r;


### PR DESCRIPTION
Also change the one non-namespace use of nullptr to NULL (used as an
argument to a C function anyway)