### PR TITLE
Run test server locally

### DIFF
--- a/src/objective-c/generated_libraries/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/generated_libraries/RemoteTestClient/RemoteTest.podspec
@@ -8,10 +8,7 @@ Pod::Spec.new do |s|
 
   # Run protoc with the Objective-C and gRPC plugins to generate protocol messages and gRPC clients.
   s.prepare_command = <<-CMD
-    cd ../../../..
-    make CONFIG=dbg grpc_objective_c_plugin
-    cd -
-    protoc --plugin=protoc-gen-grpc=../../../../bins/dbg/grpc_objective_c_plugin --objc_out=. --grpc_out=. *.proto
+    protoc --plugin=protoc-gen-grpc=../../../../bins/$CONFIG/grpc_objective_c_plugin --objc_out=. --grpc_out=. *.proto
   CMD
 
   s.subspec "Messages" do |ms|

--- a/src/objective-c/generated_libraries/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/generated_libraries/RemoteTestClient/RemoteTest.podspec
@@ -9,9 +9,9 @@ Pod::Spec.new do |s|
   # Run protoc with the Objective-C and gRPC plugins to generate protocol messages and gRPC clients.
   s.prepare_command = <<-CMD
     cd ../../../..
-    make grpc_objective_c_plugin
+    make CONFIG=dbg grpc_objective_c_plugin
     cd -
-    protoc --plugin=protoc-gen-grpc=../../../../bins/opt/grpc_objective_c_plugin --objc_out=. --grpc_out=. *.proto
+    protoc --plugin=protoc-gen-grpc=../../../../bins/dbg/grpc_objective_c_plugin --objc_out=. --grpc_out=. *.proto
   CMD
 
   s.subspec "Messages" do |ms|

--- a/src/objective-c/generated_libraries/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/generated_libraries/RemoteTestClient/RemoteTest.podspec
@@ -9,8 +9,7 @@ Pod::Spec.new do |s|
   # Run protoc with the Objective-C and gRPC plugins to generate protocol messages and gRPC clients.
   s.prepare_command = <<-CMD
     cd ../../../..
-    # TODO(jcanizales): Make only Objective-C plugin.
-    make plugins
+    make grpc_objective_c_plugin
     cd -
     protoc --plugin=protoc-gen-grpc=../../../../bins/opt/grpc_objective_c_plugin --objc_out=. --grpc_out=. *.proto
   CMD

--- a/src/objective-c/generated_libraries/RouteGuideClient/RouteGuide.podspec
+++ b/src/objective-c/generated_libraries/RouteGuideClient/RouteGuide.podspec
@@ -8,10 +8,7 @@ Pod::Spec.new do |s|
 
   # Run protoc with the Objective-C and gRPC plugins to generate protocol messages and gRPC clients.
   s.prepare_command = <<-CMD
-    cd ../../../..
-    make CONFIG=dbg grpc_objective_c_plugin
-    cd -
-    protoc --plugin=protoc-gen-grpc=../../../../bins/dbg/grpc_objective_c_plugin --objc_out=. --grpc_out=. *.proto
+    protoc --plugin=protoc-gen-grpc=../../../../bins/$CONFIG/grpc_objective_c_plugin --objc_out=. --grpc_out=. *.proto
   CMD
 
   s.subspec "Messages" do |ms|

--- a/src/objective-c/generated_libraries/RouteGuideClient/RouteGuide.podspec
+++ b/src/objective-c/generated_libraries/RouteGuideClient/RouteGuide.podspec
@@ -9,9 +9,9 @@ Pod::Spec.new do |s|
   # Run protoc with the Objective-C and gRPC plugins to generate protocol messages and gRPC clients.
   s.prepare_command = <<-CMD
     cd ../../../..
-    make grpc_objective_c_plugin
+    make CONFIG=dbg grpc_objective_c_plugin
     cd -
-    protoc --plugin=protoc-gen-grpc=../../../../bins/opt/grpc_objective_c_plugin --objc_out=. --grpc_out=. *.proto
+    protoc --plugin=protoc-gen-grpc=../../../../bins/dbg/grpc_objective_c_plugin --objc_out=. --grpc_out=. *.proto
   CMD
 
   s.subspec "Messages" do |ms|

--- a/src/objective-c/generated_libraries/RouteGuideClient/RouteGuide.podspec
+++ b/src/objective-c/generated_libraries/RouteGuideClient/RouteGuide.podspec
@@ -9,8 +9,7 @@ Pod::Spec.new do |s|
   # Run protoc with the Objective-C and gRPC plugins to generate protocol messages and gRPC clients.
   s.prepare_command = <<-CMD
     cd ../../../..
-    # TODO(jcanizales): Make only Objective-C plugin.
-    make plugins
+    make grpc_objective_c_plugin
     cd -
     protoc --plugin=protoc-gen-grpc=../../../../bins/opt/grpc_objective_c_plugin --objc_out=. --grpc_out=. *.proto
   CMD

--- a/src/objective-c/tests/GRPCClientTests.m
+++ b/src/objective-c/tests/GRPCClientTests.m
@@ -43,7 +43,8 @@
 // These are a few tests similar to InteropTests, but which use the generic gRPC client (GRPCCall)
 // rather than a generated proto library on top of it.
 
-static NSString * const kHostAddress = @"grpc-test.sandbox.google.com";
+// grpc-test.sandbox.google.com
+static NSString * const kHostAddress = @"http://localhost:5050";
 static NSString * const kPackage = @"grpc.testing";
 static NSString * const kService = @"TestService";
 

--- a/src/objective-c/tests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests.m
@@ -83,8 +83,10 @@
   RMTTestService *_service;
 }
 
+// grpc-test.sandbox.google.com
+
 - (void)setUp {
-  _service = [[RMTTestService alloc] initWithHost:@"grpc-test.sandbox.google.com"];
+  _service = [[RMTTestService alloc] initWithHost:@"http://localhost:5050"];
 }
 
 // Tests as described here: https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md

--- a/src/objective-c/tests/Tests.xcodeproj/xcshareddata/xcschemes/AllTests.xcscheme
+++ b/src/objective-c/tests/Tests.xcodeproj/xcshareddata/xcschemes/AllTests.xcscheme
@@ -39,6 +39,12 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "GRPCClientTests/testConnectionToRemoteServer">
+               </Test>
+               <Test
+                  Identifier = "GRPCClientTests/testMetadata">
+               </Test>
+               <Test
                   Identifier = "LocalClearTextTests">
                </Test>
                <Test

--- a/src/objective-c/tests/build_tests.sh
+++ b/src/objective-c/tests/build_tests.sh
@@ -32,19 +32,8 @@ set -e
 
 cd $(dirname $0)
 
-# Run the tests server.
-../../../bins/$CONFIG/interop_server --port=5050 &
-# Kill it when this script exits.
-trap 'kill -9 `jobs -p`' EXIT
-
-# xcodebuild is very verbose. We filter its output and tell Bash to fail if any
-# element of the pipe fails.
-# TODO(jcanizales): Use xctool instead? Issue #2540.
-set -o pipefail
-XCODEBUILD_FILTER='(^===|^\*\*|\bfatal\b|\berror\b|\bwarning\b|\bfail)'
-xcodebuild \
-    -workspace Tests.xcworkspace \
-    -scheme AllTests \
-    -destination name="iPhone 6" \
-    test \
-    | egrep "$XCODEBUILD_FILTER" -
+# The local test server needs to be compiled before this because pod install of
+# gRPC renames some C gRPC files and not the server's code references to them.
+#
+# Suppress error output because Cocoapods issue #3823 causes a flooding warning.
+pod install 2>/dev/null

--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -39,9 +39,8 @@ cd ../../..
 [ -f bins/dbg/interop_server ] || make CONFIG=dbg interop_server
 cd -
 
-# TODO(jcanizales): Remove when Cocoapods issue #3823 is resolved.
-export COCOAPODS_DISABLE_DETERMINISTIC_UUIDS=YES
-pod install
+# Suppress error output because Cocoapods issue #3823 causes a flooding warning.
+pod install 2>/dev/null
 
 # Run the server.
 ../../../bins/dbg/interop_server --port=5050 &

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -311,10 +311,10 @@ class ObjCLanguage(object):
                             environ=_FORCE_ENVIRON_FOR_WRAPPERS)]
 
   def make_targets(self):
-    return []
+    return ['grpc_objective_c_plugin', 'interop_server']
 
   def build_steps(self):
-    return []
+    return [['src/objective-c/tests/build_tests.sh']]
 
   def supports_multi_config(self):
     return False

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -304,6 +304,25 @@ class CSharpLanguage(object):
     return 'csharp'
 
 
+class ObjCLanguage(object):
+
+  def test_specs(self, config, travis):
+    return [config.job_spec(['src/objective-c/tests/run_tests.sh'], None,
+                            environ=_FORCE_ENVIRON_FOR_WRAPPERS)]
+
+  def make_targets(self):
+    return []
+
+  def build_steps(self):
+    return []
+
+  def supports_multi_config(self):
+    return False
+
+  def __str__(self):
+    return 'objc'
+
+
 class Sanity(object):
 
   def test_specs(self, config, travis):
@@ -369,6 +388,7 @@ _LANGUAGES = {
     'python': PythonLanguage(),
     'ruby': RubyLanguage(),
     'csharp': CSharpLanguage(),
+    'objc' : ObjCLanguage(),
     'sanity': Sanity(),
     'build': Build(),
     }


### PR DESCRIPTION
Part of #2119.

This makes `src/objective-c/tests/run_tests.sh` ready to be used by Jenkins.

Things still pending:

* Find a local server that runs SSL (`interop/server.cc` declares but doesn't use the `use_ssl` flag?)
* Find a way to test metadata locally (the current way is to send a bogus access token, but a local server has no way of knowing it's bogus).
* Separate these tests from tests against the interop server running remotely: The OAuth2 test, for example, can't be done locally.
* #2581