### PR TITLE
Cleanup in C# tests

### DIFF
--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
@@ -77,7 +77,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
@@ -68,6 +68,7 @@
     <Compile Include="ChannelOptionsTest.cs" />
     <Compile Include="Internal\TimespecTest.cs" />
     <Compile Include="TimeoutsTest.cs" />
+    <Compile Include="NUnitVersionTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
@@ -28,8 +28,24 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="nunit.core">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.util">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="NUnit.VisualStudio.TestAdapter">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Interactive.Async">

--- a/src/csharp/Grpc.Core.Tests/NUnitVersionTest.cs
+++ b/src/csharp/Grpc.Core.Tests/NUnitVersionTest.cs
@@ -1,0 +1,79 @@
+#region Copyright notice and license
+
+// Copyright 2015, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Internal;
+using Grpc.Core.Utils;
+using NUnit.Framework;
+
+namespace Grpc.Core.Tests
+{
+    /// <summary>
+    /// Tests if the version of nunit-console used is sufficient to run async tests.
+    /// </summary>
+    public class NUnitVersionTest
+    {
+        private int testRunCount = 0;
+
+        [TestFixtureTearDown]
+        public void Cleanup()
+        {
+            if (testRunCount != 2)
+            {
+                Console.Error.WriteLine("You are using and old version of NUnit that doesn't support async tests and skips them instead. " +
+                "This test has failed to indicate that.");
+                Console.Error.Flush();
+                Environment.Exit(1);
+            }
+        }
+
+        [Test]
+        public void NUnitVersionTest1()
+        {
+            testRunCount++;
+        }
+
+        // Old version of NUnit will skip this test
+        [Test]
+        public async Task NUnitVersionTest2()
+        {
+            testRunCount ++;
+            await Task.Delay(10);
+        }
+
+
+    }
+}

--- a/src/csharp/Grpc.Core.Tests/packages.config
+++ b/src/csharp/Grpc.Core.Tests/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Ix-Async" version="1.2.3" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/src/csharp/Grpc.Examples.Tests/MathClientServerTests.cs
+++ b/src/csharp/Grpc.Examples.Tests/MathClientServerTests.cs
@@ -108,123 +108,105 @@ namespace math.Tests
         }
 
         [Test]
-        public void DivAsync()
+        public async Task DivAsync()
         {
-            Task.Run(async () =>
-            {
-                DivReply response = await client.DivAsync(new DivArgs.Builder { Dividend = 10, Divisor = 3 }.Build());
-                Assert.AreEqual(3, response.Quotient);
-                Assert.AreEqual(1, response.Remainder);
-            }).Wait();
+            DivReply response = await client.DivAsync(new DivArgs.Builder { Dividend = 10, Divisor = 3 }.Build());
+            Assert.AreEqual(3, response.Quotient);
+            Assert.AreEqual(1, response.Remainder);
         }
 
         [Test]
-        public void Fib()
+        public async Task Fib()
         {
-            Task.Run(async () =>
+            using (var call = client.Fib(new FibArgs.Builder { Limit = 6 }.Build()))
             {
-                using (var call = client.Fib(new FibArgs.Builder { Limit = 6 }.Build()))
-                {
-                    var responses = await call.ResponseStream.ToList();
-                    CollectionAssert.AreEqual(new List<long> { 1, 1, 2, 3, 5, 8 },
-                        responses.ConvertAll((n) => n.Num_));
-                }
-            }).Wait();
+                var responses = await call.ResponseStream.ToList();
+                CollectionAssert.AreEqual(new List<long> { 1, 1, 2, 3, 5, 8 },
+                    responses.ConvertAll((n) => n.Num_));
+            }
         }
 
         [Test]
-        public void FibWithCancel()
+        public async Task FibWithCancel()
         {
-            Task.Run(async () =>
+            var cts = new CancellationTokenSource();
+
+            using (var call = client.Fib(new FibArgs.Builder { Limit = 0 }.Build(), 
+                cancellationToken: cts.Token))
             {
-                var cts = new CancellationTokenSource();
+                List<long> responses = new List<long>();
 
-                using (var call = client.Fib(new FibArgs.Builder { Limit = 0 }.Build(), 
-                    cancellationToken: cts.Token))
+                try
                 {
-                    List<long> responses = new List<long>();
-
-                    try
+                    while (await call.ResponseStream.MoveNext())
                     {
-                        while (await call.ResponseStream.MoveNext())
+                        if (responses.Count == 0)
                         {
-                            if (responses.Count == 0)
-                            {
-                                cts.CancelAfter(500);  // make sure we cancel soon
-                            }
-                            responses.Add(call.ResponseStream.Current.Num_);
+                            cts.CancelAfter(500);  // make sure we cancel soon
                         }
-                        Assert.Fail();
+                        responses.Add(call.ResponseStream.Current.Num_);
                     }
-                    catch (RpcException e)
-                    {
-                        Assert.IsTrue(responses.Count > 0);
-                        Assert.AreEqual(StatusCode.Cancelled, e.Status.StatusCode);
-                    }
+                    Assert.Fail();
                 }
-            }).Wait();
+                catch (RpcException e)
+                {
+                    Assert.IsTrue(responses.Count > 0);
+                    Assert.AreEqual(StatusCode.Cancelled, e.Status.StatusCode);
+                }
+            }
         }
 
         [Test]
-        public void FibWithDeadline()
+        public async Task FibWithDeadline()
         {
-            Task.Run(async () =>
+            using (var call = client.Fib(new FibArgs.Builder { Limit = 0 }.Build(), 
+                deadline: DateTime.UtcNow.AddMilliseconds(500)))
             {
-                using (var call = client.Fib(new FibArgs.Builder { Limit = 0 }.Build(), 
-                    deadline: DateTime.UtcNow.AddMilliseconds(500)))
+                try
                 {
-                    try
-                    {
-                        await call.ResponseStream.ToList();
-                        Assert.Fail();
-                    }
-                    catch (RpcException e)
-                    {
-                        Assert.AreEqual(StatusCode.DeadlineExceeded, e.Status.StatusCode);
-                    }
+                    await call.ResponseStream.ToList();
+                    Assert.Fail();
                 }
-            }).Wait();
+                catch (RpcException e)
+                {
+                    Assert.AreEqual(StatusCode.DeadlineExceeded, e.Status.StatusCode);
+                }
+            }
         }
 
         // TODO: test Fib with limit=0 and cancellation
         [Test]
-        public void Sum()
+        public async Task Sum()
         {
-            Task.Run(async () =>
+            using (var call = client.Sum())
             {
-                using (var call = client.Sum())
-                {
-                    var numbers = new List<long> { 10, 20, 30 }.ConvertAll(
-                             n => Num.CreateBuilder().SetNum_(n).Build());
+                var numbers = new List<long> { 10, 20, 30 }.ConvertAll(
+                            n => Num.CreateBuilder().SetNum_(n).Build());
 
-                    await call.RequestStream.WriteAll(numbers);
-                    var result = await call.ResponseAsync;
-                    Assert.AreEqual(60, result.Num_);
-                }
-            }).Wait();
+                await call.RequestStream.WriteAll(numbers);
+                var result = await call.ResponseAsync;
+                Assert.AreEqual(60, result.Num_);
+            }
         }
 
         [Test]
-        public void DivMany()
+        public async Task DivMany()
         {
-            Task.Run(async () =>
+            var divArgsList = new List<DivArgs>
             {
-                var divArgsList = new List<DivArgs>
-                {
-                    new DivArgs.Builder { Dividend = 10, Divisor = 3 }.Build(),
-                    new DivArgs.Builder { Dividend = 100, Divisor = 21 }.Build(),
-                    new DivArgs.Builder { Dividend = 7, Divisor = 2 }.Build()
-                };
+                new DivArgs.Builder { Dividend = 10, Divisor = 3 }.Build(),
+                new DivArgs.Builder { Dividend = 100, Divisor = 21 }.Build(),
+                new DivArgs.Builder { Dividend = 7, Divisor = 2 }.Build()
+            };
 
-                using (var call = client.DivMany())
-                {
-                    await call.RequestStream.WriteAll(divArgsList);
-                    var result = await call.ResponseStream.ToList();
+            using (var call = client.DivMany())
+            {
+                await call.RequestStream.WriteAll(divArgsList);
+                var result = await call.ResponseStream.ToList();
 
-                    CollectionAssert.AreEqual(new long[] { 3, 4, 3 }, result.ConvertAll((divReply) => divReply.Quotient));
-                    CollectionAssert.AreEqual(new long[] { 1, 16, 1 }, result.ConvertAll((divReply) => divReply.Remainder));
-                }
-            }).Wait();
+                CollectionAssert.AreEqual(new long[] { 3, 4, 3 }, result.ConvertAll((divReply) => divReply.Quotient));
+                CollectionAssert.AreEqual(new long[] { 1, 16, 1 }, result.ConvertAll((divReply) => divReply.Remainder));
+            }
         }
     }
 }

--- a/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
@@ -130,12 +130,12 @@ namespace Grpc.IntegrationTesting
                     client.HeaderInterceptor = OAuth2InterceptorFactory.Create(credential);
                 }
 
-                RunTestCase(options.testCase, client);
+                RunTestCaseAsync(options.testCase, client).Wait();
             }
             GrpcEnvironment.Shutdown();
         }
 
-        private void RunTestCase(string testCase, TestService.TestServiceClient client)
+        private async Task RunTestCaseAsync(string testCase, TestService.TestServiceClient client)
         {
             switch (testCase)
             {
@@ -146,16 +146,16 @@ namespace Grpc.IntegrationTesting
                     RunLargeUnary(client);
                     break;
                 case "client_streaming":
-                    RunClientStreaming(client);
+                    await RunClientStreamingAsync(client);
                     break;
                 case "server_streaming":
-                    RunServerStreaming(client);
+                    await RunServerStreamingAsync(client);
                     break;
                 case "ping_pong":
-                    RunPingPong(client);
+                    await RunPingPongAsync(client);
                     break;
                 case "empty_stream":
-                    RunEmptyStream(client);
+                    await RunEmptyStreamAsync(client);
                     break;
                 case "service_account_creds":
                     RunServiceAccountCreds(client);
@@ -170,10 +170,10 @@ namespace Grpc.IntegrationTesting
                     RunPerRpcCreds(client);
                     break;
                 case "cancel_after_begin":
-                    RunCancelAfterBegin(client);
+                    await RunCancelAfterBeginAsync(client);
                     break;
                 case "cancel_after_first_response":
-                    RunCancelAfterFirstResponse(client);
+                    await RunCancelAfterFirstResponseAsync(client);
                     break;
                 case "benchmark_empty_unary":
                     RunBenchmarkEmptyUnary(client);
@@ -207,118 +207,106 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static void RunClientStreaming(TestService.ITestServiceClient client)
+        public static async Task RunClientStreamingAsync(TestService.ITestServiceClient client)
         {
-            Task.Run(async () =>
+            Console.WriteLine("running client_streaming");
+
+            var bodySizes = new List<int> { 27182, 8, 1828, 45904 }.ConvertAll((size) => StreamingInputCallRequest.CreateBuilder().SetPayload(CreateZerosPayload(size)).Build());
+
+            using (var call = client.StreamingInputCall())
             {
-                Console.WriteLine("running client_streaming");
+                await call.RequestStream.WriteAll(bodySizes);
 
-                var bodySizes = new List<int> { 27182, 8, 1828, 45904 }.ConvertAll((size) => StreamingInputCallRequest.CreateBuilder().SetPayload(CreateZerosPayload(size)).Build());
-
-                using (var call = client.StreamingInputCall())
-                {
-                    await call.RequestStream.WriteAll(bodySizes);
-
-                    var response = await call.ResponseAsync;
-                    Assert.AreEqual(74922, response.AggregatedPayloadSize);
-                }
-                Console.WriteLine("Passed!");
-            }).Wait();
+                var response = await call.ResponseAsync;
+                Assert.AreEqual(74922, response.AggregatedPayloadSize);
+            }
+            Console.WriteLine("Passed!");
         }
 
-        public static void RunServerStreaming(TestService.ITestServiceClient client)
+        public static async Task RunServerStreamingAsync(TestService.ITestServiceClient client)
         {
-            Task.Run(async () =>
+            Console.WriteLine("running server_streaming");
+
+            var bodySizes = new List<int> { 31415, 9, 2653, 58979 };
+
+            var request = StreamingOutputCallRequest.CreateBuilder()
+            .SetResponseType(PayloadType.COMPRESSABLE)
+            .AddRangeResponseParameters(bodySizes.ConvertAll(
+                (size) => ResponseParameters.CreateBuilder().SetSize(size).Build()))
+            .Build();
+
+            using (var call = client.StreamingOutputCall(request))
             {
-                Console.WriteLine("running server_streaming");
+                var responseList = await call.ResponseStream.ToList();
+                foreach (var res in responseList)
+                {
+                    Assert.AreEqual(PayloadType.COMPRESSABLE, res.Payload.Type);
+                }
+                CollectionAssert.AreEqual(bodySizes, responseList.ConvertAll((item) => item.Payload.Body.Length));
+            }
+            Console.WriteLine("Passed!");
+        }
 
-                var bodySizes = new List<int> { 31415, 9, 2653, 58979 };
+        public static async Task RunPingPongAsync(TestService.ITestServiceClient client)
+        {
+            Console.WriteLine("running ping_pong");
 
-                var request = StreamingOutputCallRequest.CreateBuilder()
+            using (var call = client.FullDuplexCall())
+            {
+                await call.RequestStream.WriteAsync(StreamingOutputCallRequest.CreateBuilder()
                 .SetResponseType(PayloadType.COMPRESSABLE)
-                .AddRangeResponseParameters(bodySizes.ConvertAll(
-                    (size) => ResponseParameters.CreateBuilder().SetSize(size).Build()))
-                .Build();
+                .AddResponseParameters(ResponseParameters.CreateBuilder().SetSize(31415))
+                .SetPayload(CreateZerosPayload(27182)).Build());
 
-                using (var call = client.StreamingOutputCall(request))
-                {
-                    var responseList = await call.ResponseStream.ToList();
-                    foreach (var res in responseList)
-                    {
-                        Assert.AreEqual(PayloadType.COMPRESSABLE, res.Payload.Type);
-                    }
-                    CollectionAssert.AreEqual(bodySizes, responseList.ConvertAll((item) => item.Payload.Body.Length));
-                }
-                Console.WriteLine("Passed!");
-            }).Wait();
+                Assert.IsTrue(await call.ResponseStream.MoveNext());
+                Assert.AreEqual(PayloadType.COMPRESSABLE, call.ResponseStream.Current.Payload.Type);
+                Assert.AreEqual(31415, call.ResponseStream.Current.Payload.Body.Length);
+
+                await call.RequestStream.WriteAsync(StreamingOutputCallRequest.CreateBuilder()
+                            .SetResponseType(PayloadType.COMPRESSABLE)
+                            .AddResponseParameters(ResponseParameters.CreateBuilder().SetSize(9))
+                            .SetPayload(CreateZerosPayload(8)).Build());
+
+                Assert.IsTrue(await call.ResponseStream.MoveNext());
+                Assert.AreEqual(PayloadType.COMPRESSABLE, call.ResponseStream.Current.Payload.Type);
+                Assert.AreEqual(9, call.ResponseStream.Current.Payload.Body.Length);
+
+                await call.RequestStream.WriteAsync(StreamingOutputCallRequest.CreateBuilder()
+                            .SetResponseType(PayloadType.COMPRESSABLE)
+                            .AddResponseParameters(ResponseParameters.CreateBuilder().SetSize(2653))
+                            .SetPayload(CreateZerosPayload(1828)).Build());
+
+                Assert.IsTrue(await call.ResponseStream.MoveNext());
+                Assert.AreEqual(PayloadType.COMPRESSABLE, call.ResponseStream.Current.Payload.Type);
+                Assert.AreEqual(2653, call.ResponseStream.Current.Payload.Body.Length);
+
+                await call.RequestStream.WriteAsync(StreamingOutputCallRequest.CreateBuilder()
+                            .SetResponseType(PayloadType.COMPRESSABLE)
+                            .AddResponseParameters(ResponseParameters.CreateBuilder().SetSize(58979))
+                            .SetPayload(CreateZerosPayload(45904)).Build());
+
+                Assert.IsTrue(await call.ResponseStream.MoveNext());
+                Assert.AreEqual(PayloadType.COMPRESSABLE, call.ResponseStream.Current.Payload.Type);
+                Assert.AreEqual(58979, call.ResponseStream.Current.Payload.Body.Length);
+
+                await call.RequestStream.CompleteAsync();
+
+                Assert.IsFalse(await call.ResponseStream.MoveNext());
+            }
+            Console.WriteLine("Passed!");
         }
 
-        public static void RunPingPong(TestService.ITestServiceClient client)
+        public static async Task RunEmptyStreamAsync(TestService.ITestServiceClient client)
         {
-            Task.Run(async () =>
+            Console.WriteLine("running empty_stream");
+            using (var call = client.FullDuplexCall())
             {
-                Console.WriteLine("running ping_pong");
+                await call.RequestStream.CompleteAsync();
 
-                using (var call = client.FullDuplexCall())
-                {
-                    await call.RequestStream.WriteAsync(StreamingOutputCallRequest.CreateBuilder()
-                    .SetResponseType(PayloadType.COMPRESSABLE)
-                    .AddResponseParameters(ResponseParameters.CreateBuilder().SetSize(31415))
-                    .SetPayload(CreateZerosPayload(27182)).Build());
-
-                    Assert.IsTrue(await call.ResponseStream.MoveNext());
-                    Assert.AreEqual(PayloadType.COMPRESSABLE, call.ResponseStream.Current.Payload.Type);
-                    Assert.AreEqual(31415, call.ResponseStream.Current.Payload.Body.Length);
-
-                    await call.RequestStream.WriteAsync(StreamingOutputCallRequest.CreateBuilder()
-                              .SetResponseType(PayloadType.COMPRESSABLE)
-                              .AddResponseParameters(ResponseParameters.CreateBuilder().SetSize(9))
-                              .SetPayload(CreateZerosPayload(8)).Build());
-
-                    Assert.IsTrue(await call.ResponseStream.MoveNext());
-                    Assert.AreEqual(PayloadType.COMPRESSABLE, call.ResponseStream.Current.Payload.Type);
-                    Assert.AreEqual(9, call.ResponseStream.Current.Payload.Body.Length);
-
-                    await call.RequestStream.WriteAsync(StreamingOutputCallRequest.CreateBuilder()
-                              .SetResponseType(PayloadType.COMPRESSABLE)
-                              .AddResponseParameters(ResponseParameters.CreateBuilder().SetSize(2653))
-                              .SetPayload(CreateZerosPayload(1828)).Build());
-
-                    Assert.IsTrue(await call.ResponseStream.MoveNext());
-                    Assert.AreEqual(PayloadType.COMPRESSABLE, call.ResponseStream.Current.Payload.Type);
-                    Assert.AreEqual(2653, call.ResponseStream.Current.Payload.Body.Length);
-
-                    await call.RequestStream.WriteAsync(StreamingOutputCallRequest.CreateBuilder()
-                              .SetResponseType(PayloadType.COMPRESSABLE)
-                              .AddResponseParameters(ResponseParameters.CreateBuilder().SetSize(58979))
-                              .SetPayload(CreateZerosPayload(45904)).Build());
-
-                    Assert.IsTrue(await call.ResponseStream.MoveNext());
-                    Assert.AreEqual(PayloadType.COMPRESSABLE, call.ResponseStream.Current.Payload.Type);
-                    Assert.AreEqual(58979, call.ResponseStream.Current.Payload.Body.Length);
-
-                    await call.RequestStream.CompleteAsync();
-
-                    Assert.IsFalse(await call.ResponseStream.MoveNext());
-                }
-                Console.WriteLine("Passed!");
-            }).Wait();
-        }
-
-        public static void RunEmptyStream(TestService.ITestServiceClient client)
-        {
-            Task.Run(async () =>
-            {
-                Console.WriteLine("running empty_stream");
-                using (var call = client.FullDuplexCall())
-                {
-                    await call.RequestStream.CompleteAsync();
-
-                    var responseList = await call.ResponseStream.ToList();
-                    Assert.AreEqual(0, responseList.Count);
-                }
-                Console.WriteLine("Passed!");
-            }).Wait();
+                var responseList = await call.ResponseStream.ToList();
+                Assert.AreEqual(0, responseList.Count);
+            }
+            Console.WriteLine("Passed!");
         }
 
         public static void RunServiceAccountCreds(TestService.ITestServiceClient client)
@@ -406,65 +394,59 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static void RunCancelAfterBegin(TestService.ITestServiceClient client)
+        public static async Task RunCancelAfterBeginAsync(TestService.ITestServiceClient client)
         {
-            Task.Run(async () =>
+            Console.WriteLine("running cancel_after_begin");
+
+            var cts = new CancellationTokenSource();
+            using (var call = client.StreamingInputCall(cancellationToken: cts.Token))
             {
-                Console.WriteLine("running cancel_after_begin");
+                // TODO(jtattermusch): we need this to ensure call has been initiated once we cancel it.
+                await Task.Delay(1000);
+                cts.Cancel();
 
-                var cts = new CancellationTokenSource();
-                using (var call = client.StreamingInputCall(cancellationToken: cts.Token))
+                try
                 {
-                    // TODO(jtattermusch): we need this to ensure call has been initiated once we cancel it.
-                    await Task.Delay(1000);
-                    cts.Cancel();
-
-                    try
-                    {
-                        var response = await call.ResponseAsync;
-                        Assert.Fail();
-                    }
-                    catch (RpcException e)
-                    {
-                        Assert.AreEqual(StatusCode.Cancelled, e.Status.StatusCode);
-                    }
+                    var response = await call.ResponseAsync;
+                    Assert.Fail();
                 }
-                Console.WriteLine("Passed!");
-            }).Wait();
+                catch (RpcException e)
+                {
+                    Assert.AreEqual(StatusCode.Cancelled, e.Status.StatusCode);
+                }
+            }
+            Console.WriteLine("Passed!");
         }
 
-        public static void RunCancelAfterFirstResponse(TestService.ITestServiceClient client)
+        public static async Task RunCancelAfterFirstResponseAsync(TestService.ITestServiceClient client)
         {
-            Task.Run(async () =>
+            Console.WriteLine("running cancel_after_first_response");
+
+            var cts = new CancellationTokenSource();
+            using (var call = client.FullDuplexCall(cancellationToken: cts.Token))
             {
-                Console.WriteLine("running cancel_after_first_response");
+                await call.RequestStream.WriteAsync(StreamingOutputCallRequest.CreateBuilder()
+                    .SetResponseType(PayloadType.COMPRESSABLE)
+                    .AddResponseParameters(ResponseParameters.CreateBuilder().SetSize(31415))
+                    .SetPayload(CreateZerosPayload(27182)).Build());
 
-                var cts = new CancellationTokenSource();
-                using (var call = client.FullDuplexCall(cancellationToken: cts.Token))
+                Assert.IsTrue(await call.ResponseStream.MoveNext());
+                Assert.AreEqual(PayloadType.COMPRESSABLE, call.ResponseStream.Current.Payload.Type);
+                Assert.AreEqual(31415, call.ResponseStream.Current.Payload.Body.Length);
+
+                cts.Cancel();
+
+                try
                 {
-                    await call.RequestStream.WriteAsync(StreamingOutputCallRequest.CreateBuilder()
-                        .SetResponseType(PayloadType.COMPRESSABLE)
-                        .AddResponseParameters(ResponseParameters.CreateBuilder().SetSize(31415))
-                        .SetPayload(CreateZerosPayload(27182)).Build());
-
-                    Assert.IsTrue(await call.ResponseStream.MoveNext());
-                    Assert.AreEqual(PayloadType.COMPRESSABLE, call.ResponseStream.Current.Payload.Type);
-                    Assert.AreEqual(31415, call.ResponseStream.Current.Payload.Body.Length);
-
-                    cts.Cancel();
-
-                    try
-                    {
-                        await call.ResponseStream.MoveNext();
-                        Assert.Fail();
-                    }
-                    catch (RpcException e)
-                    {
-                        Assert.AreEqual(StatusCode.Cancelled, e.Status.StatusCode);
-                    }
+                    await call.ResponseStream.MoveNext();
+                    Assert.Fail();
                 }
-                Console.WriteLine("Passed!");
-            }).Wait();
+                catch (RpcException e)
+                {
+                    Assert.AreEqual(StatusCode.Cancelled, e.Status.StatusCode);
+                }
+            }
+            Console.WriteLine("Passed!");
         }
 
         // This is not an official interop test, but it's useful.

--- a/src/csharp/Grpc.IntegrationTesting/InteropClientServerTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClientServerTest.cs
@@ -89,39 +89,39 @@ namespace Grpc.IntegrationTesting
         }
 
         [Test]
-        public void ClientStreaming()
+        public async Task ClientStreaming()
         {
-            InteropClient.RunClientStreaming(client);
+            await InteropClient.RunClientStreamingAsync(client);
         }
 
         [Test]
-        public void ServerStreaming()
+        public async Task ServerStreaming()
         {
-            InteropClient.RunServerStreaming(client);
+            await InteropClient.RunServerStreamingAsync(client);
         }
 
         [Test]
-        public void PingPong()
+        public async Task PingPong()
         {
-            InteropClient.RunPingPong(client);
+            await InteropClient.RunPingPongAsync(client);
         }
 
         [Test]
-        public void EmptyStream()
+        public async Task EmptyStream()
         {
-            InteropClient.RunEmptyStream(client);
+            await InteropClient.RunEmptyStreamAsync(client);
         }
 
         [Test]
-        public void CancelAfterBegin()
+        public async Task CancelAfterBegin()
         {
-            InteropClient.RunCancelAfterBegin(client);
+            await InteropClient.RunCancelAfterBeginAsync(client);
         }
 
         [Test]
-        public void CancelAfterFirstResponse()
+        public async Task CancelAfterFirstResponse()
         {
-            InteropClient.RunCancelAfterFirstResponse(client);
+            await InteropClient.RunCancelAfterFirstResponseAsync(client);
         }
     }
 }

--- a/tools/run_tests/run_csharp.sh
+++ b/tools/run_tests/run_csharp.sh
@@ -32,6 +32,8 @@ set -ex
 
 CONFIG=${CONFIG:-opt}
 
+NUNIT_CONSOLE="mono packages/NUnit.Runners.2.6.4/tools/nunit-console.exe"
+
 if [ "$CONFIG" = "dbg" ]
 then
   MSBUILD_CONFIG="Debug"
@@ -46,6 +48,7 @@ root=`pwd`
 cd src/csharp
 
 export LD_LIBRARY_PATH=$root/libs/$CONFIG
-nunit-console -labels "$1/bin/$MSBUILD_CONFIG/$1.dll"
+
+$NUNIT_CONSOLE -labels "$1/bin/$MSBUILD_CONFIG/$1.dll"
 
 


### PR DESCRIPTION
Declare tests that are naturally running in async context run in async test method - that makes the test code much cleaner.