### PR TITLE
Add STREAM_LENGTH and POOL_SIZE to test_constants

### DIFF
--- a/src/python/src/grpc/_links/_proto_scenarios.py
+++ b/src/python/src/grpc/_links/_proto_scenarios.py
@@ -33,6 +33,7 @@ import abc
 import threading
 
 from grpc._junkdrawer import math_pb2
+from grpc.framework.common import test_constants
 
 
 class ProtoScenario(object):
@@ -219,10 +220,9 @@ class BidirectionallyUnaryScenario(ProtoScenario):
 class BidirectionallyStreamingScenario(ProtoScenario):
   """A scenario that transmits no protocol buffers in either direction."""
 
-  _STREAM_LENGTH = 200
   _REQUESTS = tuple(
       math_pb2.DivArgs(dividend=59 + index, divisor=7 + index)
-      for index in range(_STREAM_LENGTH))
+      for index in range(test_constants.STREAM_LENGTH))
 
   def __init__(self):
     self._lock = threading.Lock()

--- a/src/python/src/grpc/framework/common/test_constants.py
+++ b/src/python/src/grpc/framework/common/test_constants.py
@@ -35,3 +35,9 @@ SHORT_TIMEOUT = 4
 # Absurdly large value for maximum duration in seconds for should-not-time-out
 # RPCs made during tests.
 LONG_TIMEOUT = 3000
+
+# The number of payloads to transmit in streaming tests.
+STREAM_LENGTH = 200
+
+# The size of thread pools to use in tests.
+POOL_SIZE = 10


### PR DESCRIPTION
Only one of these is used, and in only one place, as of this commit,
but they will be used widely after further development.