### PR TITLE
only use lowercase metadata keys in headers

### DIFF
--- a/src/csharp/Grpc.Core.Tests/ClientServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ClientServerTest.cs
@@ -209,8 +209,8 @@ namespace Grpc.Core.Tests
         {
             var headers = new Metadata
             {
-                new Metadata.Entry("asciiHeader", "abcdefg"),
-                new Metadata.Entry("binaryHeader-bin", new byte[] { 1, 2, 3, 0, 0xff }),
+                new Metadata.Entry("ascii-header", "abcdefg"),
+                new Metadata.Entry("binary-header-bin", new byte[] { 1, 2, 3, 0, 0xff }),
             };
             var internalCall = new Call<string, string>(ServiceName, EchoMethod, channel, headers);
             var call = Calls.AsyncUnaryCall(internalCall, "ABC", CancellationToken.None);

--- a/src/csharp/Grpc.Examples.Tests/MathClientServerTests.cs
+++ b/src/csharp/Grpc.Examples.Tests/MathClientServerTests.cs
@@ -65,7 +65,7 @@ namespace math.Tests
             // for header support.
             client.HeaderInterceptor = (metadata) =>
             {
-                metadata.Add(new Metadata.Entry("customHeader", "abcdef"));
+                metadata.Add(new Metadata.Entry("custom-header", "abcdef"));
             };
         }
 


### PR DESCRIPTION
Fix what was broken by #2601.