### PR TITLE
Affirm metadata transmission in a common function

### DIFF
--- a/src/python/grpcio_test/grpc_test/_links/_transmission_test.py
+++ b/src/python/grpcio_test/grpc_test/_links/_transmission_test.py
@@ -35,6 +35,7 @@ from grpc._adapter import _intermediary_low
 from grpc._links import invocation
 from grpc._links import service
 from grpc.framework.interfaces.links import links
+from grpc_test import test_common
 from grpc_test._links import _proto_scenarios
 from grpc_test.framework.common import test_constants
 from grpc_test.framework.interfaces.links import test_cases
@@ -94,12 +95,11 @@ class TransmissionTest(test_cases.TransmissionTest, unittest.TestCase):
     return _intermediary_low.Code.OK, 'An exuberant test "details" message!'
 
   def assertMetadataTransmitted(self, original_metadata, transmitted_metadata):
-    # we need to filter out any additional metadata added in transmitted_metadata
-    # since implementations are allowed to add to what is sent (in any position)
-    keys, _ = zip(*original_metadata)
-    self.assertSequenceEqual(
-        original_metadata,
-        [x for x in transmitted_metadata if x[0] in keys])
+    self.assertTrue(
+        test_common.metadata_transmitted(
+            original_metadata, transmitted_metadata),
+        '%s erroneously transmitted as %s' % (
+            original_metadata, transmitted_metadata))
 
 
 class RoundTripTest(unittest.TestCase):

--- a/src/python/grpcio_test/grpc_test/test_common.py
+++ b/src/python/grpcio_test/grpc_test/test_common.py
@@ -1,0 +1,71 @@
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Common code used throughout tests of gRPC."""
+
+import collections
+
+
+def metadata_transmitted(original_metadata, transmitted_metadata):
+  """Judges whether or not metadata was acceptably transmitted.
+
+  gRPC is allowed to insert key-value pairs into the metadata values given by
+  applications and to reorder key-value pairs with different keys but it is not
+  allowed to alter existing key-value pairs or to reorder key-value pairs with
+  the same key.
+
+  Args:
+    original_metadata: A metadata value used in a test of gRPC.
+    transmitted_metadata: A metadata value corresponding to original_metadata
+      after having been transmitted via gRPC.
+
+  Returns:
+     A boolean indicating whether transmitted_metadata accurately reflects
+      original_metadata after having been transmitted via gRPC.
+  """
+  original = collections.defaultdict(list)
+  for key, value in original_metadata:
+    original[key].append(value)
+  transmitted = collections.defaultdict(list)
+  for key, value in transmitted_metadata:
+    transmitted[key].append(value)
+
+  for key, values in original.iteritems():
+    transmitted_values = transmitted[key]
+    transmitted_iterator = iter(transmitted_values)
+    try:
+      for value in values:
+        while True:
+          transmitted_value = next(transmitted_iterator)
+          if value == transmitted_value:
+            break
+    except StopIteration:
+      return False
+  else:
+    return True


### PR DESCRIPTION
This introduces grpc.test_common for gRPC-specific test code and fixes #2570.

@ctiller please review and confirm the claim "gRPC is allowed to insert key-value pairs into the metadata values given by applications but it is not allowed to reorder or alter existing key-value pairs".