### PR TITLE
Fix clock type mismatch

### DIFF
--- a/test/core/security/oauth2_utils.c
+++ b/test/core/security/oauth2_utils.c
@@ -84,7 +84,7 @@ char *grpc_test_fetch_oauth2_token_with_credentials(grpc_credentials *creds) {
 
   gpr_mu_lock(GRPC_POLLSET_MU(&request.pollset));
   while (!request.is_done)
-    grpc_pollset_work(&request.pollset, gpr_inf_future(GPR_CLOCK_REALTIME));
+    grpc_pollset_work(&request.pollset, gpr_inf_future(GPR_CLOCK_MONOTONIC));
   gpr_mu_unlock(GRPC_POLLSET_MU(&request.pollset));
 
   grpc_pollset_shutdown(&request.pollset, do_nothing, NULL);


### PR DESCRIPTION
This should fix the interop test failures for the oauth2 token related test cases.