### PR TITLE
Tune down number of channels for qps_test

### DIFF
--- a/test/cpp/qps/qps_test.cc
+++ b/test/cpp/qps/qps_test.cc
@@ -53,8 +53,8 @@ static void RunQPS() {
   ClientConfig client_config;
   client_config.set_client_type(ASYNC_CLIENT);
   client_config.set_enable_ssl(false);
-  client_config.set_outstanding_rpcs_per_channel(10);
-  client_config.set_client_channels(800);
+  client_config.set_outstanding_rpcs_per_channel(1000);
+  client_config.set_client_channels(8);
   client_config.set_payload_size(1);
   client_config.set_async_client_threads(8);
   client_config.set_rpc_type(UNARY);


### PR DESCRIPTION
Acting to stabilize Jenkins.

ASAN/TSAN just can't give us the connect rate we require for this test to complete within its time bounds on Jenkins with 800 channels.