### PR TITLE
add a test where a read and a writesdone happen at the same time

### DIFF
--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -818,6 +818,27 @@ TEST_F(End2endTest, HugeResponse) {
   EXPECT_TRUE(s.ok());
 }
 
+namespace {
+void ReaderThreadFunc(ClientReaderWriter<EchoRequest, EchoResponse>* stream) {
+  EchoResponse resp;
+  while (stream->Read(&resp)) {
+    gpr_log(GPR_INFO, "Read message");
+  }
+}
+}  // namespace
+
+// Run a Read and a WritesDone simultaneously.
+TEST_F(End2endTest, SimuReadWritesDone) {
+  ResetStub();
+  ClientContext context;
+  auto stream = stub_->BidiStream(&context);
+  std::thread reader_thread(ReaderThreadFunc, stream.get());
+  stream->WritesDone();
+  Status s = stream->Finish();
+  EXPECT_TRUE(s.ok());
+  reader_thread.join();
+}
+
 }  // namespace testing
 }  // namespace grpc
 


### PR DESCRIPTION
This duplicates a customer's test in the hope of exposing a bug. It fails about 1/1000 now (hanging server causing time-out).  Wrapping the test body in a loop can increase the chance of failure.