### PR TITLE
Require very explicit registration of non-SSL hosts.

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall+Tests.h
+++ b/src/objective-c/GRPCClient/GRPCCall+Tests.h
@@ -33,6 +33,8 @@
 
 #import "GRPCCall.h"
 
+// Methods to let tune down the security of gRPC connections for specific hosts. These shouldn't be
+// used in releases, but are sometimes needed for testing.
 @interface GRPCCall (Tests)
 
 // Establish all SSL connections to the provided host using the passed SSL target name and the root
@@ -42,4 +44,6 @@
                 testName:(NSString *)testName
                  forHost:(NSString *)host;
 
+// Establish all connections to the provided host using cleartext instead of SSL.
++ (void)useInsecureConnectionsForHost:(NSString *)host;
 @end

--- a/src/objective-c/GRPCClient/GRPCCall+Tests.h
+++ b/src/objective-c/GRPCClient/GRPCCall+Tests.h
@@ -39,11 +39,16 @@
 
 // Establish all SSL connections to the provided host using the passed SSL target name and the root
 // certificates found in the file at |certsPath|.
-// Must be called before any gRPC call to that host is made.
+//
+// Must be called before any gRPC call to that host is made. It's illegal to pass the same host to
+// more than one invocation of the methods of this category.
 + (void)useTestCertsPath:(NSString *)certsPath
                 testName:(NSString *)testName
                  forHost:(NSString *)host;
 
 // Establish all connections to the provided host using cleartext instead of SSL.
+//
+// Must be called before any gRPC call to that host is made. It's illegal to pass the same host to
+// more than one invocation of the methods of this category.
 + (void)useInsecureConnectionsForHost:(NSString *)host;
 @end

--- a/src/objective-c/GRPCClient/GRPCCall+Tests.m
+++ b/src/objective-c/GRPCClient/GRPCCall+Tests.m
@@ -36,12 +36,18 @@
 #import "private/GRPCHost.h"
 
 @implementation GRPCCall (Tests)
+
 + (void)useTestCertsPath:(NSString *)certsPath
                 testName:(NSString *)testName
                  forHost:(NSString *)host {
   GRPCHost *hostConfig = [GRPCHost hostWithAddress:host];
-  hostConfig.secure = YES;
   hostConfig.pathToCertificates = certsPath;
   hostConfig.hostNameOverride = testName;
 }
+
++ (void)useInsecureConnectionsForHost:(NSString *)host {
+  GRPCHost *hostConfig = [GRPCHost hostWithAddress:host];
+  hostConfig.secure = NO;
+}
+
 @end

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -58,8 +58,10 @@
 // Default initializer.
 - (instancetype)initWithAddress:(NSString *)address {
 
-  // To provide a default port, we try to interpret the address.
-  // TODO(jcanizales): Add unit tests for the types of addresses we want to let pass through.
+  // To provide a default port, we try to interpret the address. If it's just a host name without
+  // scheme and without port, we'll use port 443. If it has a scheme, we pass it untouched to the C
+  // gRPC library.
+  // TODO(jcanizales): Add unit tests for the types of addresses we want to let pass untouched.
   NSURL *hostURL = [NSURL URLWithString:[@"https://" stringByAppendingString:address]];
   if (hostURL && !hostURL.port) {
     address = [hostURL.host stringByAppendingString:@":443"];

--- a/src/objective-c/tests/GRPCClientTests.m
+++ b/src/objective-c/tests/GRPCClientTests.m
@@ -35,6 +35,7 @@
 #import <XCTest/XCTest.h>
 
 #import <GRPCClient/GRPCCall.h>
+#import <GRPCClient/GRPCCall+Tests.h>
 #import <ProtoRPC/ProtoMethod.h>
 #import <RemoteTest/Messages.pbobjc.h>
 #import <RxLibrary/GRXWriteable.h>
@@ -43,8 +44,7 @@
 // These are a few tests similar to InteropTests, but which use the generic gRPC client (GRPCCall)
 // rather than a generated proto library on top of it.
 
-// grpc-test.sandbox.google.com
-static NSString * const kHostAddress = @"http://localhost:5050";
+static NSString * const kHostAddress = @"localhost:5050";
 static NSString * const kPackage = @"grpc.testing";
 static NSString * const kService = @"TestService";
 
@@ -58,6 +58,9 @@ static ProtoMethod *kUnaryCallMethod;
 @implementation GRPCClientTests
 
 - (void)setUp {
+  // Register test server as non-SSL.
+  [GRPCCall useInsecureConnectionsForHost:kHostAddress];
+
   // This method isn't implemented by the remote server.
   kInexistentMethod = [[ProtoMethod alloc] initWithPackage:kPackage
                                                    service:kService

--- a/src/objective-c/tests/InteropTests.h
+++ b/src/objective-c/tests/InteropTests.h
@@ -37,7 +37,7 @@
 // https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md
 
 @interface InteropTests : XCTestCase
-// Returns @"http://localhost:5050".
+// Returns @"localhost:5050".
 // Override in a subclass to perform the same tests against a different address.
 // For interop tests, use @"grpc-test.sandbox.google.com".
 + (NSString *)host;

--- a/src/objective-c/tests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests.m
@@ -35,6 +35,7 @@
 
 #include <grpc/status.h>
 
+#import <GRPCClient/GRPCCall+Tests.h>
 #import <ProtoRPC/ProtoRPC.h>
 #import <RemoteTest/Empty.pbobjc.h>
 #import <RemoteTest/Messages.pbobjc.h>
@@ -75,15 +76,22 @@
 }
 @end
 
+#pragma mark Tests
+
+static NSString * const kLocalCleartextHost = @"localhost:5050";
+
 @implementation InteropTests {
   RMTTestService *_service;
 }
 
 + (NSString *)host {
-  return @"http://localhost:5050";
+  return kLocalCleartextHost;
 }
 
 - (void)setUp {
+  // Register test server as non-SSL.
+  [GRPCCall useInsecureConnectionsForHost:kLocalCleartextHost];
+
   _service = [[RMTTestService alloc] initWithHost:self.class.host];
 }
 


### PR DESCRIPTION
As decided during the library surface review.

The change here also solves #2314 by passing untouched anything except addresses that consist of solely a host name. For those, a default port 443 is appended. I will write some unit tests with those exotic addresses to ensure it.