### PR TITLE
Disabled deprecation warnings in Node build

### DIFF
--- a/src/node/binding.gyp
+++ b/src/node/binding.gyp
@@ -11,7 +11,8 @@
         '-pedantic',
         '-g',
         '-zdefs',
-        '-Werror'
+        '-Werror',
+        '-Wno-error=deprecated-declarations'
       ],
       'ldflags': [
         '-g'


### PR DESCRIPTION
We have a dependency on a C++ library with a relatively wide version range (NAN), which apparently deprecates functions sometimes. We should not break our clients just because they upgrade to an otherwise compatible version of their dependencies. This fixes #2752.