### PR TITLE
Have the tests preferably use the protoc compiled by make.

### DIFF
--- a/src/objective-c/generated_libraries/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/generated_libraries/RemoteTestClient/RemoteTest.podspec
@@ -8,7 +8,10 @@ Pod::Spec.new do |s|
 
   # Run protoc with the Objective-C and gRPC plugins to generate protocol messages and gRPC clients.
   s.prepare_command = <<-CMD
-    protoc --plugin=protoc-gen-grpc=../../../../bins/$CONFIG/grpc_objective_c_plugin --objc_out=. --grpc_out=. *.proto
+    BINDIR=../../../../bins/$CONFIG
+    PROTOC=$BINDIR/protobuf/protoc
+    PLUGIN=$BINDIR/grpc_objective_c_plugin
+    $PROTOC --plugin=protoc-gen-grpc=$PLUGIN --objc_out=. --grpc_out=. *.proto
   CMD
 
   s.subspec "Messages" do |ms|

--- a/src/objective-c/generated_libraries/RouteGuideClient/RouteGuide.podspec
+++ b/src/objective-c/generated_libraries/RouteGuideClient/RouteGuide.podspec
@@ -8,7 +8,10 @@ Pod::Spec.new do |s|
 
   # Run protoc with the Objective-C and gRPC plugins to generate protocol messages and gRPC clients.
   s.prepare_command = <<-CMD
-    protoc --plugin=protoc-gen-grpc=../../../../bins/$CONFIG/grpc_objective_c_plugin --objc_out=. --grpc_out=. *.proto
+    BINDIR=../../../../bins/$CONFIG
+    PROTOC=$BINDIR/protobuf/protoc
+    PLUGIN=$BINDIR/grpc_objective_c_plugin
+    $PROTOC --plugin=protoc-gen-grpc=$PLUGIN --objc_out=. --grpc_out=. *.proto
   CMD
 
   s.subspec "Messages" do |ms|

--- a/src/objective-c/tests/build_tests.sh
+++ b/src/objective-c/tests/build_tests.sh
@@ -32,10 +32,29 @@ set -e
 
 cd $(dirname $0)
 
-hash protoc 2>/dev/null || { echo >&2 "protoc needs to be installed."; exit 1; }
 hash pod 2>/dev/null || { echo >&2 "Cocoapods needs to be installed."; exit 1; }
 hash xcodebuild 2>/dev/null || { echo >&2 "XCode command-line tools need to be installed."; exit 1; }
 
-# The local test server needs to be compiled before this because pod install of
-# gRPC renames some C gRPC files and not the server's code references to them.
+BINDIR=../../../bins/$CONFIG
+
+if [ ! -f $BINDIR/protobuf/protoc ]; then
+    hash protoc 2>/dev/null || {
+        echo >&2 "Can't find protoc. Make sure run_tests.py is making" \
+                 "grpc_objective_c_plugin before calling this script."
+        exit 1
+    }
+    # When protoc is already installed, make doesn't compile one. Put a link
+    # there so the podspecs can do codegen using that path.
+    mkdir -p $BINDIR/protobuf
+    ln -s `which protoc` $BINDIR/protobuf/protoc
+fi
+
+[ -f $BINDIR/interop_server ] || {
+    echo >&2 "Can't find the test server. Make sure run_tests.py is making" \
+             "interop_server before calling this script. It needs to be done" \
+             "before because pod install of gRPC renames some C gRPC files" \
+             "and not the server's code references to them."
+    exit 1
+}
+
 pod install

--- a/src/objective-c/tests/build_tests.sh
+++ b/src/objective-c/tests/build_tests.sh
@@ -28,12 +28,18 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# Don't run this script standalone. Instead, run from the repository root:
+# ./tools/run_tests/run_tests.py -l objc
+
 set -e
 
 cd $(dirname $0)
 
 hash pod 2>/dev/null || { echo >&2 "Cocoapods needs to be installed."; exit 1; }
-hash xcodebuild 2>/dev/null || { echo >&2 "XCode command-line tools need to be installed."; exit 1; }
+hash xcodebuild 2>/dev/null || {
+    echo >&2 "XCode command-line tools need to be installed."
+    exit 1
+}
 
 BINDIR=../../../bins/$CONFIG
 

--- a/src/objective-c/tests/build_tests.sh
+++ b/src/objective-c/tests/build_tests.sh
@@ -32,6 +32,10 @@ set -e
 
 cd $(dirname $0)
 
+hash protoc 2>/dev/null || { echo >&2 "protoc needs to be installed."; exit 1; }
+hash pod 2>/dev/null || { echo >&2 "Cocoapods needs to be installed."; exit 1; }
+hash xcodebuild 2>/dev/null || { echo >&2 "XCode command-line tools need to be installed."; exit 1; }
+
 # The local test server needs to be compiled before this because pod install of
 # gRPC renames some C gRPC files and not the server's code references to them.
 #

--- a/src/objective-c/tests/build_tests.sh
+++ b/src/objective-c/tests/build_tests.sh
@@ -38,6 +38,4 @@ hash xcodebuild 2>/dev/null || { echo >&2 "XCode command-line tools need to be i
 
 # The local test server needs to be compiled before this because pod install of
 # gRPC renames some C gRPC files and not the server's code references to them.
-#
-# Suppress error output because Cocoapods issue #3823 causes a flooding warning.
-pod install 2>/dev/null
+pod install

--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -28,6 +28,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+# Don't run this script standalone. Instead, run from the repository root:
+# ./tools/run_tests/run_tests.py -l objc
+
 set -e
 
 cd $(dirname $0)


### PR DESCRIPTION
If a `protoc` is already installed on the machine, `make <plugin>` won't build one.

Now that Cocoapods is installed in the Jenkins Mac machine, this should make [the tests](https://grpc-testing.appspot.com/job/gRPC_master_unstable/config=opt,language=objc,platform=macos/) green.

Hopefully final step for closing issue #2119! :)