### PR TITLE
Allow fixtures to specify slowdown factors, use it for grpc_trace tests

### DIFF
--- a/test/core/end2end/fixtures/chttp2_socket_pair_with_grpc_trace.c
+++ b/test/core/end2end/fixtures/chttp2_socket_pair_with_grpc_trace.c
@@ -148,6 +148,7 @@ int main(int argc, char **argv) {
   /* force tracing on, with a value to force many
      code paths in trace.c to be taken */
   gpr_setenv("GRPC_TRACE", "doesnt-exist,http,all");
+  g_fixture_slowdown_factor = 10.0;
 
   grpc_test_init(argc, argv);
   grpc_init();

--- a/test/core/util/test_config.c
+++ b/test/core/util/test_config.c
@@ -38,6 +38,8 @@
 #include <stdlib.h>
 #include <signal.h>
 
+double g_fixture_slowdown_factor = 1.0;
+
 #if GPR_GETPID_IN_UNISTD_H
 #include <unistd.h>
 static int seed(void) { return getpid(); }

--- a/test/core/util/test_config.h
+++ b/test/core/util/test_config.h
@@ -48,8 +48,11 @@ extern "C" {
 #define GRPC_TEST_SLOWDOWN_MACHINE_FACTOR 1.0
 #endif
 
-#define GRPC_TEST_SLOWDOWN_FACTOR \
-  (GRPC_TEST_SLOWDOWN_BUILD_FACTOR * GRPC_TEST_SLOWDOWN_MACHINE_FACTOR)
+extern double g_fixture_slowdown_factor;
+
+#define GRPC_TEST_SLOWDOWN_FACTOR                                        \
+  (GRPC_TEST_SLOWDOWN_BUILD_FACTOR * GRPC_TEST_SLOWDOWN_MACHINE_FACTOR * \
+   g_fixture_slowdown_factor)
 
 #define GRPC_TIMEOUT_SECONDS_TO_DEADLINE(x)                                \
   gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),                               \


### PR DESCRIPTION
Fixes #2381 