### PR TITLE
Temporarily increase CI job timeout to 30m

### DIFF
--- a/tools/run_tests/jobset.py
+++ b/tools/run_tests/jobset.py
@@ -206,7 +206,9 @@ class Job(object):
                 do_newline=self._newline_on_success or self._travis)
         if self._bin_hash:
           update_cache.finished(self._spec.identity(), self._bin_hash)
-    elif self._state == _RUNNING and time.time() - self._start > 900:
+    # TODO(jcanizales): Bring timeout back to 900 (15 min) after Cocoapods in the
+    # Jenkins Mac machine has a compiled OpenSSL pod cached.
+    elif self._state == _RUNNING and time.time() - self._start > 1800:
       self._tempfile.seek(0)
       stdout = self._tempfile.read()
       filtered_stdout = filter(lambda x: x in string.printable, stdout.decode(errors='ignore'))


### PR DESCRIPTION
The first time Cocoapods prepares the OpenSSL pod it takes from 15m to 20m, which causes this timeout: https://grpc-testing.appspot.com/job/gRPC_master_unstable/config=opt,language=objc,platform=macos/1169/console

After that step finishes once, I reckon Cocoapods will use the result from its cache and we can bring the timeout down again.