### PR TITLE
Fixing environments where pkg-config isn't installed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,34 +268,21 @@ INCLUDES = . include $(GENDIR)
 LDFLAGS += -Llibs/$(CONFIG)
 
 ifeq ($(SYSTEM),Darwin)
-ifneq ($(wildcard /usr/local/ssl/include),)
-INCLUDES += /usr/local/ssl/include
-endif
-ifneq ($(wildcard /opt/local/include),)
-INCLUDES += /opt/local/include
-endif
-ifneq ($(wildcard /usr/local/include),)
-INCLUDES += /usr/local/include
-endif
-LIBS = m z
-ifneq ($(wildcard /usr/local/ssl/lib),)
-LDFLAGS += -L/usr/local/ssl/lib
-endif
-ifneq ($(wildcard /opt/local/lib),)
-LDFLAGS += -L/opt/local/lib
-endif
-ifneq ($(wildcard /usr/local/lib),)
-LDFLAGS += -L/usr/local/lib
-endif
+LIBS += m
 endif
 
 ifeq ($(SYSTEM),Linux)
-LIBS = rt m z pthread
+LIBS += rt m pthread
 LDFLAGS += -pthread
 endif
 
 ifeq ($(SYSTEM),MINGW32)
-LIBS = m z pthread
+LIBS += m pthread
+LDFLAGS += -pthread
+endif
+
+ifeq ($(SYSTEM),FreeBSD)
+LIBS += pthread
 LDFLAGS += -pthread
 endif
 
@@ -386,6 +373,39 @@ OPENSSL_NPN_CHECK_CMD = $(PKG_CONFIG) --atleast-version=1.0.1 openssl
 ZLIB_CHECK_CMD = $(PKG_CONFIG) --exists zlib
 PROTOBUF_CHECK_CMD = $(PKG_CONFIG) --atleast-version=3.0.0-alpha-3 protobuf
 else # HAS_PKG_CONFIG
+
+ifeq ($(SYSTEM),Darwin)
+ifneq ($(wildcard /usr/local/ssl/include),)
+INCLUDES += /usr/local/ssl/include
+endif
+ifneq ($(wildcard /opt/local/include),)
+INCLUDES += /opt/local/include
+endif
+ifneq ($(wildcard /usr/local/include),)
+INCLUDES += /usr/local/include
+endif
+ifneq ($(wildcard /usr/local/ssl/lib),)
+LDFLAGS += -L/usr/local/ssl/lib
+endif
+ifneq ($(wildcard /opt/local/lib),)
+LDFLAGS += -L/opt/local/lib
+endif
+ifneq ($(wildcard /usr/local/lib),)
+LDFLAGS += -L/usr/local/lib
+endif
+endif
+
+ifeq ($(SYSTEM),Linux)
+LIBS += z
+endif
+
+ifeq ($(SYSTEM),MINGW32)
+LIBS += z
+endif
+
+ifeq ($(SYSTEM),FreeBSD)
+LIBS += z
+endif
 
 ifeq ($(SYSTEM),MINGW32)
 OPENSSL_LIBS = ssl32 eay32

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -282,34 +282,21 @@ INCLUDES = . include $(GENDIR)
 LDFLAGS += -Llibs/$(CONFIG)
 
 ifeq ($(SYSTEM),Darwin)
-ifneq ($(wildcard /usr/local/ssl/include),)
-INCLUDES += /usr/local/ssl/include
-endif
-ifneq ($(wildcard /opt/local/include),)
-INCLUDES += /opt/local/include
-endif
-ifneq ($(wildcard /usr/local/include),)
-INCLUDES += /usr/local/include
-endif
-LIBS = m z
-ifneq ($(wildcard /usr/local/ssl/lib),)
-LDFLAGS += -L/usr/local/ssl/lib
-endif
-ifneq ($(wildcard /opt/local/lib),)
-LDFLAGS += -L/opt/local/lib
-endif
-ifneq ($(wildcard /usr/local/lib),)
-LDFLAGS += -L/usr/local/lib
-endif
+LIBS += m
 endif
 
 ifeq ($(SYSTEM),Linux)
-LIBS = rt m z pthread
+LIBS += rt m pthread
 LDFLAGS += -pthread
 endif
 
 ifeq ($(SYSTEM),MINGW32)
-LIBS = m z pthread
+LIBS += m pthread
+LDFLAGS += -pthread
+endif
+
+ifeq ($(SYSTEM),FreeBSD)
+LIBS += pthread
 LDFLAGS += -pthread
 endif
 
@@ -411,6 +398,39 @@ OPENSSL_NPN_CHECK_CMD = $(PKG_CONFIG) --atleast-version=1.0.1 openssl
 ZLIB_CHECK_CMD = $(PKG_CONFIG) --exists zlib
 PROTOBUF_CHECK_CMD = $(PKG_CONFIG) --atleast-version=3.0.0-alpha-3 protobuf
 else # HAS_PKG_CONFIG
+
+ifeq ($(SYSTEM),Darwin)
+ifneq ($(wildcard /usr/local/ssl/include),)
+INCLUDES += /usr/local/ssl/include
+endif
+ifneq ($(wildcard /opt/local/include),)
+INCLUDES += /opt/local/include
+endif
+ifneq ($(wildcard /usr/local/include),)
+INCLUDES += /usr/local/include
+endif
+ifneq ($(wildcard /usr/local/ssl/lib),)
+LDFLAGS += -L/usr/local/ssl/lib
+endif
+ifneq ($(wildcard /opt/local/lib),)
+LDFLAGS += -L/opt/local/lib
+endif
+ifneq ($(wildcard /usr/local/lib),)
+LDFLAGS += -L/usr/local/lib
+endif
+endif
+
+ifeq ($(SYSTEM),Linux)
+LIBS += z
+endif
+
+ifeq ($(SYSTEM),MINGW32)
+LIBS += z
+endif
+
+ifeq ($(SYSTEM),FreeBSD)
+LIBS += z
+endif
 
 ifeq ($(SYSTEM),MINGW32)
 OPENSSL_LIBS = ssl32 eay32


### PR DESCRIPTION
Depending on the presence of pkg-config, we're not necessarily doing the right thing in the Makefile. Zlib is a pkg-config dependency, but libm, libpthread, librt aren't.