### PR TITLE
Return normalized IPv4 addresses from grpc_sockaddr_to_uri().

### DIFF
--- a/src/core/iomgr/sockaddr_utils.c
+++ b/src/core/iomgr/sockaddr_utils.c
@@ -170,6 +170,11 @@ int grpc_sockaddr_to_string(char **out, const struct sockaddr *addr,
 char *grpc_sockaddr_to_uri(const struct sockaddr *addr) {
   char *temp;
   char *result;
+  struct sockaddr_in addr_normalized;
+
+  if (grpc_sockaddr_is_v4mapped(addr, &addr_normalized)) {
+    addr = (const struct sockaddr *)&addr_normalized;
+  }
 
   switch (addr->sa_family) {
     case AF_INET:


### PR DESCRIPTION
Users of the high-level API should not care whether we're using AF_INET
or AF_INET6 sockets internally.

Fixes #1132