### PR TITLE
Provide marginally better debug information for client side auth problems

### DIFF
--- a/src/core/security/client_auth_filter.c
+++ b/src/core/security/client_auth_filter.c
@@ -77,6 +77,7 @@ typedef struct {
 
 static void bubble_up_error(grpc_call_element *elem, const char *error_msg) {
   call_data *calld = elem->call_data;
+  gpr_log(GPR_ERROR, "Client side authentication failure: %s", error_msg);
   grpc_transport_stream_op_add_cancellation(&calld->op,
                                             GRPC_STATUS_UNAUTHENTICATED);
   grpc_call_next_op(elem, &calld->op);


### PR DESCRIPTION
The correct thing to do is move this string into the status response: this will take a little longer however.

Built on #2777, which needs to be merged first.

Partial fix for #2458.