### PR TITLE
Make oauth2 easy

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall+OAuth2.h
+++ b/src/objective-c/GRPCClient/GRPCCall+OAuth2.h
@@ -1,0 +1,49 @@
+/*
+ *
+ * Copyright 2015, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#import "GRPCCall.h"
+
+// Helpers for setting and reading headers compatible with OAuth2.
+@interface GRPCCall (OAuth2)
+
+// Setting this property is equivalent to setting "Bearer <passed token>" as the value of the
+// request header with key "authorization" (the authorization header). Setting it to nil removes the
+// authorization header from the request.
+// The value obtained by getting the property is the OAuth2 bearer token if the authorization header
+// of the request has the form "Bearer <token>", or nil otherwise.
+@property(atomic, copy) NSString *oauth2_accessToken;
+
+// Returns the value (if any) of the "www-authenticate" response header (the challenge header).
+@property(atomic, readonly) NSString *oauth2_challengeHeader;
+
+@end

--- a/src/objective-c/GRPCClient/GRPCCall+OAuth2.h
+++ b/src/objective-c/GRPCClient/GRPCCall+OAuth2.h
@@ -41,9 +41,9 @@
 // authorization header from the request.
 // The value obtained by getting the property is the OAuth2 bearer token if the authorization header
 // of the request has the form "Bearer <token>", or nil otherwise.
-@property(atomic, copy) NSString *oauth2_accessToken;
+@property(atomic, copy) NSString *oauth2AccessToken;
 
 // Returns the value (if any) of the "www-authenticate" response header (the challenge header).
-@property(atomic, readonly) NSString *oauth2_challengeHeader;
+@property(atomic, readonly) NSString *oauth2ChallengeHeader;
 
 @end

--- a/src/objective-c/GRPCClient/GRPCCall+OAuth2.m
+++ b/src/objective-c/GRPCClient/GRPCCall+OAuth2.m
@@ -39,7 +39,7 @@ static NSString * const kChallengeHeader = @"www-authenticate";
 
 @implementation GRPCCall (OAuth2)
 
-- (NSString *)oauth2_accessToken {
+- (NSString *)oauth2AccessToken {
   NSString *headerValue = self.requestMetadata[kAuthorizationHeader];
   if ([headerValue hasPrefix:kBearerPrefix]) {
     return [headerValue substringFromIndex:kBearerPrefix.length];
@@ -48,7 +48,7 @@ static NSString * const kChallengeHeader = @"www-authenticate";
   }
 }
 
-- (void)setOauth2_accessToken:(NSString *)token {
+- (void)setOauth2AccessToken:(NSString *)token {
   if (token) {
     self.requestMetadata[kAuthorizationHeader] = [kBearerPrefix stringByAppendingString:token];
   } else {
@@ -56,7 +56,7 @@ static NSString * const kChallengeHeader = @"www-authenticate";
   }
 }
 
-- (NSString *)oauth2_challengeHeader {
+- (NSString *)oauth2ChallengeHeader {
   return self.responseMetadata[kChallengeHeader];
 }
 

--- a/src/objective-c/GRPCClient/GRPCCall+OAuth2.m
+++ b/src/objective-c/GRPCClient/GRPCCall+OAuth2.m
@@ -1,0 +1,63 @@
+/*
+ *
+ * Copyright 2015, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#import "GRPCCall+OAuth2.h"
+
+static NSString * const kAuthorizationHeader = @"authorization";
+static NSString * const kBearerPrefix = @"Bearer ";
+static NSString * const kChallengeHeader = @"www-authenticate";
+
+@implementation GRPCCall (OAuth2)
+
+- (NSString *)oauth2_accessToken {
+  NSString *headerValue = self.requestMetadata[kAuthorizationHeader];
+  if ([headerValue hasPrefix:kBearerPrefix]) {
+    return [headerValue substringFromIndex:kBearerPrefix.length];
+  } else {
+    return nil;
+  }
+}
+
+- (void)setOauth2_accessToken:(NSString *)token {
+  if (token) {
+    self.requestMetadata[kAuthorizationHeader] = [kBearerPrefix stringByAppendingString:token];
+  } else {
+    [self.requestMetadata removeObjectForKey:kAuthorizationHeader];
+  }
+}
+
+- (NSString *)oauth2_challengeHeader {
+  return self.responseMetadata[kChallengeHeader];
+}
+
+@end

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -78,12 +78,12 @@
     if (cachedHost) {
       return cachedHost;
     }
-  }
 
-  if ((self = [super init])) {
-    _address = address;
-    _secure = YES;
-    hostCache[address] = self;
+    if ((self = [super init])) {
+      _address = address;
+      _secure = YES;
+      hostCache[address] = self;
+    }
   }
   return self;
 }

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -78,6 +78,7 @@
     if (cachedHost) {
       return cachedHost;
     }
+  }
 
   if ((self = [super init])) {
     _address = address;

--- a/src/objective-c/tests/GRPCClientTests.m
+++ b/src/objective-c/tests/GRPCClientTests.m
@@ -161,7 +161,7 @@ static ProtoMethod *kUnaryCallMethod;
                                              path:kUnaryCallMethod.HTTPPath
                                    requestsWriter:requestsWriter];
 
-  call.oauth2_accessToken = @"bogusToken";
+  call.oauth2AccessToken = @"bogusToken";
 
   id<GRXWriteable> responsesWriteable = [[GRXWriteable alloc] initWithValueHandler:^(NSData *value) {
     XCTFail(@"Received unexpected response: %@", value);
@@ -170,7 +170,7 @@ static ProtoMethod *kUnaryCallMethod;
     XCTAssertEqual(errorOrNil.code, 16, @"Finished with unexpected error: %@", errorOrNil);
     XCTAssertEqualObjects(call.responseMetadata, errorOrNil.userInfo[kGRPCStatusMetadataKey],
                           @"Metadata in the NSError object and call object differ.");
-    NSString *challengeHeader = call.oauth2_challengeHeader;
+    NSString *challengeHeader = call.oauth2ChallengeHeader;
     XCTAssertGreaterThan(challengeHeader.length, 0,
                          @"No challenge in response headers %@", call.responseMetadata);
     [expectation fulfill];

--- a/src/objective-c/tests/GRPCClientTests.m
+++ b/src/objective-c/tests/GRPCClientTests.m
@@ -35,6 +35,7 @@
 #import <XCTest/XCTest.h>
 
 #import <GRPCClient/GRPCCall.h>
+#import <GRPCClient/GRPCCall+OAuth2.h>
 #import <GRPCClient/GRPCCall+Tests.h>
 #import <ProtoRPC/ProtoMethod.h>
 #import <RemoteTest/Messages.pbobjc.h>
@@ -160,7 +161,7 @@ static ProtoMethod *kUnaryCallMethod;
                                              path:kUnaryCallMethod.HTTPPath
                                    requestsWriter:requestsWriter];
 
-  call.requestMetadata[@"Authorization"] = @"Bearer bogusToken";
+  call.oauth2_accessToken = @"bogusToken";
 
   id<GRXWriteable> responsesWriteable = [[GRXWriteable alloc] initWithValueHandler:^(NSData *value) {
     XCTFail(@"Received unexpected response: %@", value);
@@ -169,7 +170,7 @@ static ProtoMethod *kUnaryCallMethod;
     XCTAssertEqual(errorOrNil.code, 16, @"Finished with unexpected error: %@", errorOrNil);
     XCTAssertEqualObjects(call.responseMetadata, errorOrNil.userInfo[kGRPCStatusMetadataKey],
                           @"Metadata in the NSError object and call object differ.");
-    NSString *challengeHeader = call.responseMetadata[@"www-authenticate"];
+    NSString *challengeHeader = call.oauth2_challengeHeader;
     XCTAssertGreaterThan(challengeHeader.length, 0,
                          @"No challenge in response headers %@", call.responseMetadata);
     [expectation fulfill];


### PR DESCRIPTION
This is the first step towards fixing issue #2089. It just adds a bit of syntax sugar to encapsulate the specific headers format specified by OAuth2.

Reviewer: @DavidPhillipOster

Tested by running `./tools/run_tests/run_tests.py -t -l objc` from the repo root.