### PR TITLE
Only slow down tracing tests if stdout isatty

### DIFF
--- a/test/core/end2end/fixtures/chttp2_socket_pair_with_grpc_trace.c
+++ b/test/core/end2end/fixtures/chttp2_socket_pair_with_grpc_trace.c
@@ -148,7 +148,11 @@ int main(int argc, char **argv) {
   /* force tracing on, with a value to force many
      code paths in trace.c to be taken */
   gpr_setenv("GRPC_TRACE", "doesnt-exist,http,all");
+#ifdef GPR_POSIX_SOCKET
+  g_fixture_slowdown_factor = isatty(STDOUT_FILENO) ? 10.0 : 1.0;
+#else
   g_fixture_slowdown_factor = 10.0;
+#endif
 
   grpc_test_init(argc, argv);
   grpc_init();


### PR DESCRIPTION
Fixes a timeout seen on Jenkins MSAN runs.