### PR TITLE
Fix race condition in GRPCCall

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -150,7 +150,6 @@ NSString * const kGRPCStatusMetadataKey = @"io.grpc.StatusMetadataKey";
   // If there were still request messages coming, stop them.
   @synchronized(_requestWriter) {
     _requestWriter.state = GRXWriterStateFinished;
-    _requestWriter = nil;
   }
 
   if (errorOrNil) {
@@ -288,9 +287,6 @@ NSString * const kGRPCStatusMetadataKey = @"io.grpc.StatusMetadataKey";
 }
 
 - (void)writesFinishedWithError:(NSError *)errorOrNil {
-  @synchronized(_requestWriter) {
-    _requestWriter = nil;
-  }
   if (errorOrNil) {
     [self cancel];
   } else {

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -250,7 +250,7 @@ NSString * const kGRPCStatusMetadataKey = @"io.grpc.StatusMetadataKey";
     // Resume the request writer.
     GRPCCall *strongSelf = weakSelf;
     if (strongSelf) {
-      @synchronized(_requestWriter) {
+      @synchronized(strongSelf->_requestWriter) {
         strongSelf->_requestWriter.state = GRXWriterStateStarted;
       }
     }

--- a/src/objective-c/RxLibrary/GRXBufferedPipe.h
+++ b/src/objective-c/RxLibrary/GRXBufferedPipe.h
@@ -36,13 +36,11 @@
 #import "GRXWriteable.h"
 #import "GRXWriter.h"
 
-// A buffered pipe is a Writeable that also acts as a Writer (to whichever other writeable is passed
-// to -startWithWriteable:).
+// A buffered pipe is a Writer that also acts as a Writeable.
 // Once it is started, whatever values are written into it (via -writeValue:) will be propagated
 // immediately, unless flow control prevents it.
 // If it is throttled and keeps receiving values, as well as if it receives values before being
-// started, it will buffer them and propagate them in order as soon as its state becomes
-// GRXWriterStateStarted.
+// started, it will buffer them and propagate them in order as soon as its state becomes Started.
 // If it receives an error (via -writesFinishedWithError:), it will drop any buffered values and
 // propagate the error immediately.
 //
@@ -51,6 +49,9 @@
 // pipe will keep buffering all data written to it, your application could run out of memory and
 // crash. If you want to react to flow control signals to prevent that, instead of using this class
 // you can implement an object that conforms to GRXWriter.
+//
+// Thread-safety:
+// The methods of an object of this class should not be called concurrently from different threads.
 @interface GRXBufferedPipe : GRXWriter<GRXWriteable>
 
 // Convenience constructor.

--- a/src/objective-c/RxLibrary/GRXForwardingWriter.h
+++ b/src/objective-c/RxLibrary/GRXForwardingWriter.h
@@ -33,11 +33,17 @@
 
 #import "GRXWriter.h"
 
-// A "proxy" class that simply forwards values, completion, and errors from its
-// input writer to its writeable.
+// A "proxy" class that simply forwards values, completion, and errors from its input writer to its
+// writeable.
 // It is useful as a superclass for pipes that act as a transformation of their
 // input writer, and for classes that represent objects with input and
 // output sequences of values, like an RPC.
+//
+// Thread-safety:
+// All messages sent to this object need to be serialized. When it is started, the writer it wraps
+// is started in the same thread. Manual state changes are propagated to the wrapped writer in the
+// same thread too. Importantly, all messages the wrapped writer sends to its writeable need to be
+// serialized with any message sent to this object.
 @interface GRXForwardingWriter : GRXWriter
 - (instancetype)initWithWriter:(GRXWriter *)writer NS_DESIGNATED_INITIALIZER;
 @end

--- a/src/objective-c/RxLibrary/GRXForwardingWriter.m
+++ b/src/objective-c/RxLibrary/GRXForwardingWriter.m
@@ -48,7 +48,10 @@
 // Designated initializer
 - (instancetype)initWithWriter:(GRXWriter *)writer {
   if (!writer) {
-    [NSException raise:NSInvalidArgumentException format:@"writer can't be nil."];
+    return nil;
+  }
+  if (writer.state != GRXWriterStateNotStarted) {
+    [NSException raise:NSInvalidArgumentException format:@"writer can't be started."];
   }
   if ((self = [super init])) {
     _writer = writer;

--- a/src/objective-c/RxLibrary/GRXForwardingWriter.m
+++ b/src/objective-c/RxLibrary/GRXForwardingWriter.m
@@ -51,7 +51,8 @@
     return nil;
   }
   if (writer.state != GRXWriterStateNotStarted) {
-    [NSException raise:NSInvalidArgumentException format:@"writer can't be started."];
+    [NSException raise:NSInvalidArgumentException
+                format:@"The writer argument must not have already started."];
   }
   if ((self = [super init])) {
     _writer = writer;

--- a/src/objective-c/RxLibrary/GRXImmediateWriter.h
+++ b/src/objective-c/RxLibrary/GRXImmediateWriter.h
@@ -36,10 +36,17 @@
 #import "GRXWriter.h"
 
 // Utility to construct GRXWriter instances from values that are immediately available when
-// required. The returned writers all support pausing and early termination.
+// required.
 //
-// Unless the writeable callback pauses them or stops them early, these writers will do all their
-// interactions with the writeable before the start method returns.
+// Thread-safety:
+//
+// An object of this class shouldn't be messaged concurrently by more than one thread. It will start
+// messaging the writeable before |startWithWriteable:| returns, in the same thread. That is the
+// only place where the writer can be paused or stopped prematurely.
+//
+// If a paused writer of this class is resumed, it will start messaging the writeable, in the same
+// thread, before |setState:| returns. Because the object can't be legally accessed concurrently,
+// that's the only place where it can be paused again (or stopped).
 @interface GRXImmediateWriter : GRXWriter
 
 // Returns a writer that pulls values from the passed NSEnumerator instance and pushes them to

--- a/src/objective-c/RxLibrary/GRXWriter.h
+++ b/src/objective-c/RxLibrary/GRXWriter.h
@@ -65,26 +65,27 @@ typedef NS_ENUM(NSInteger, GRXWriterState) {
   GRXWriterStateFinished
 };
 
-// An object that conforms to this protocol can produce, on demand, a sequence
-// of values. The sequence may be produced asynchronously, and it may consist of
-// any number of elements, including none or an infinite number.
+// An GRXWriter object can produce, on demand, a sequence of values. The sequence may be produced
+// asynchronously, and it may consist of any number of elements, including none or an infinite
+// number.
 //
-// GRXWriter is the active dual of NSEnumerator. The difference between them
-// is thus whether the object plays an active or passive role during usage: A
-// user of NSEnumerator pulls values off it, and passes the values to a writeable.
-// A user of GRXWriter, though, just gives it a writeable, and the
-// GRXWriter instance pushes values to the writeable. This makes this protocol
-// suitable to represent a sequence of future values, as well as collections
-// with internal iteration.
+// GRXWriter is the active dual of NSEnumerator. The difference between them is thus whether the
+// object plays an active or passive role during usage: A user of NSEnumerator pulls values off it,
+// and passes the values to a writeable. A user of GRXWriter, though, just gives it a writeable, and
+// the GRXWriter instance pushes values to the writeable. This makes this protocol suitable to
+// represent a sequence of future values, as well as collections with internal iteration.
 //
-// An instance of GRXWriter can start producing values after a writeable is
-// passed to it. It can also be commanded to finish the sequence immediately
-// (with an optional error). Finally, it can be asked to pause, but the
-// conforming instance is not required to oblige.
+// An instance of GRXWriter can start producing values after a writeable is passed to it. It can
+// also be commanded to finish the sequence immediately (with an optional error). Finally, it can be
+// asked to pause, and resumed later. All GRXWriter objects support pausing and early termination.
 //
-// Unless otherwise indicated by a conforming class, no messages should be sent
-// concurrently to a GRXWriter. I.e., conforming classes aren't required to
-// be thread-safe.
+// Thread-safety:
+//
+// State transitions take immediate effect if the object is used from a single thread. Subclasses
+// might offer stronger guarantees.
+//
+// Unless otherwise indicated by a conforming subclass, no messages should be sent concurrently to a
+// GRXWriter. I.e., conforming classes aren't required to be thread-safe.
 @interface GRXWriter : NSObject
 
 // This property can be used to query the current state of the writer, which
@@ -110,9 +111,5 @@ typedef NS_ENUM(NSInteger, GRXWriterState) {
 //
 // This method might only be called on writers in the Started or Paused
 // state.
-//
-// TODO(jcanizales): Consider adding some guarantee about the immediacy of that
-// stopping. I know I've relied on it in part of the code that uses this, but
-// can't remember the details in the presence of concurrency.
 - (void)finishWithError:(NSError *)errorOrNil;
 @end

--- a/src/objective-c/RxLibrary/GRXWriter.h
+++ b/src/objective-c/RxLibrary/GRXWriter.h
@@ -35,33 +35,28 @@
 
 #import "GRXWriteable.h"
 
+// States of a writer.
 typedef NS_ENUM(NSInteger, GRXWriterState) {
 
-  // The writer has not yet been given a writeable to which it can push its
-  // values. To have an writer transition to the Started state, send it a
-  // startWithWriteable: message.
+  // The writer has not yet been given a writeable to which it can push its values. To have a writer
+  // transition to the Started state, send it a startWithWriteable: message.
   //
-  // An writer's state cannot be manually set to this value.
+  // A writer's state cannot be manually set to this value.
   GRXWriterStateNotStarted,
 
   // The writer might push values to the writeable at any moment.
   GRXWriterStateStarted,
 
-  // The writer is temporarily paused, and won't send any more values to the
-  // writeable unless its state is set back to Started. The writer might still
-  // transition to the Finished state at any moment, and is allowed to send
-  // writesFinishedWithError: to its writeable.
-  //
-  // Not all implementations of writer have to support pausing, and thus
-  // trying to set an writer's state to this value might have no effect.
+  // The writer is temporarily paused, and won't send any more values to the writeable unless its
+  // state is set back to Started. The writer might still transition to the Finished state at any
+  // moment, and is allowed to send writesFinishedWithError: to its writeable.
   GRXWriterStatePaused,
 
   // The writer has released its writeable and won't interact with it anymore.
   //
-  // One seldomly wants to set an writer's state to this value, as its
-  // writeable isn't notified with a writesFinishedWithError: message. Instead, sending
-  // finishWithError: to the writer will make it notify the writeable and then
-  // transition to this state.
+  // One seldomly wants to set a writer's state to this value, as its writeable isn't notified with
+  // a writesFinishedWithError: message. Instead, sending finishWithError: to the writer will make
+  // it notify the writeable and then transition to this state.
   GRXWriterStateFinished
 };
 
@@ -88,28 +83,25 @@ typedef NS_ENUM(NSInteger, GRXWriterState) {
 // GRXWriter. I.e., conforming classes aren't required to be thread-safe.
 @interface GRXWriter : NSObject
 
-// This property can be used to query the current state of the writer, which
-// determines how it might currently use its writeable. Some state transitions can
-// be triggered by setting this property to the corresponding value, and that's
-// useful for advanced use cases like pausing an writer. For more details,
-// see the documentation of the enum.
+// This property can be used to query the current state of the writer, which determines how it might
+// currently use its writeable. Some state transitions can be triggered by setting this property to
+// the corresponding value, and that's useful for advanced use cases like pausing an writer. For
+// more details, see the documentation of the enum further down.
 @property(nonatomic) GRXWriterState state;
 
-// Start sending messages to the writeable. Messages may be sent before the method
-// returns, or they may be sent later in the future. See GRXWriteable.h for the
-// different messages a writeable can receive.
+// Transition to the Started state, and start sending messages to the writeable (a reference to it
+// is retained). Messages to the writeable may be sent before the method returns, or they may be
+// sent later in the future. See GRXWriteable.h for the different messages a writeable can receive.
 //
-// If this writer draws its values from an external source (e.g. from the
-// filesystem or from a server), calling this method will commonly trigger side
-// effects (like network connections).
+// If this writer draws its values from an external source (e.g. from the filesystem or from a
+// server), calling this method will commonly trigger side effects (like network connections).
 //
 // This method might only be called on writers in the NotStarted state.
 - (void)startWithWriteable:(id<GRXWriteable>)writeable;
 
-// Send writesFinishedWithError:errorOrNil immediately to the writeable, and don't send
-// any more messages to it.
+// Send writesFinishedWithError:errorOrNil to the writeable. Then release the reference to it and
+// transition to the Finished state.
 //
-// This method might only be called on writers in the Started or Paused
-// state.
+// This method might only be called on writers in the Started or Paused state.
 - (void)finishWithError:(NSError *)errorOrNil;
 @end


### PR DESCRIPTION
Fixes #2690 

(Although debugging it revealed a bunch of other issues, but they'll be tracked separately).

@DavidPhillipOster to review.

Tested by running the OAuth2 sample app, which luckily was triggering the race condition on more than half the RPCs made.