### PR TITLE
expose C core version string to C#

### DIFF
--- a/src/csharp/Grpc.Core.Tests/GrpcEnvironmentTest.cs
+++ b/src/csharp/Grpc.Core.Tests/GrpcEnvironmentTest.cs
@@ -69,5 +69,13 @@ namespace Grpc.Core.Tests
 
             Assert.IsFalse(object.ReferenceEquals(env1, env2));
         }
+
+        [Test]
+        public void GetCoreVersionString()
+        {
+            var coreVersion = GrpcEnvironment.GetCoreVersionString();
+            var parts = coreVersion.Split('.');
+            Assert.AreEqual(4, parts.Length);
+        }
     }
 }

--- a/src/csharp/Grpc.Core/GrpcEnvironment.cs
+++ b/src/csharp/Grpc.Core/GrpcEnvironment.cs
@@ -53,6 +53,9 @@ namespace Grpc.Core
         [DllImport("grpc_csharp_ext.dll")]
         static extern void grpcsharp_shutdown();
 
+        [DllImport("grpc_csharp_ext.dll")]
+        static extern IntPtr grpcsharp_version_string();  // returns not-owned const char*
+
         static object staticLock = new object();
         static GrpcEnvironment instance;
 
@@ -161,6 +164,15 @@ namespace Grpc.Core
             {
                 return this.debugStats;
             }
+        }
+
+        /// <summary>
+        /// Gets version of gRPC C core.
+        /// </summary>
+        internal string GetCoreVersionString()
+        {
+            var ptr = grpcsharp_version_string();  // the pointer is not owned
+            return Marshal.PtrToStringAnsi(ptr);
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core/GrpcEnvironment.cs
+++ b/src/csharp/Grpc.Core/GrpcEnvironment.cs
@@ -169,7 +169,7 @@ namespace Grpc.Core
         /// <summary>
         /// Gets version of gRPC C core.
         /// </summary>
-        internal string GetCoreVersionString()
+        internal static string GetCoreVersionString()
         {
             var ptr = grpcsharp_version_string();  // the pointer is not owned
             return Marshal.PtrToStringAnsi(ptr);

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -849,6 +849,11 @@ GPR_EXPORT void GPR_CALLTYPE grpcsharp_redirect_log(grpcsharp_log_func func) {
 
 typedef void(GPR_CALLTYPE *test_callback_funcptr)(gpr_int32 success);
 
+/* Version info */
+GPR_EXPORT char *GPR_CALLTYPE grpcsharp_version_string() {
+  return grpc_version_string();
+}
+
 /* For testing */
 GPR_EXPORT void GPR_CALLTYPE
 grpcsharp_test_callback(test_callback_funcptr callback) {

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -850,7 +850,7 @@ GPR_EXPORT void GPR_CALLTYPE grpcsharp_redirect_log(grpcsharp_log_func func) {
 typedef void(GPR_CALLTYPE *test_callback_funcptr)(gpr_int32 success);
 
 /* Version info */
-GPR_EXPORT char *GPR_CALLTYPE grpcsharp_version_string() {
+GPR_EXPORT const char *GPR_CALLTYPE grpcsharp_version_string() {
   return grpc_version_string();
 }
 


### PR DESCRIPTION
Can be useful for checking we are running against the correct version of C# extension.