### PR TITLE
PHP: wrap connectivity state API

### DIFF
--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -230,6 +230,8 @@ PHP_METHOD(Channel, getConnectivityState) {
  * Watch the connectivity state of the channel until it changed
  * @param long The previous connectivity state of the channel
  * @param Timeval The deadline this function should wait until
+ * @return bool If the connectivity state changes from last_state
+ *              before deadline
  */
 PHP_METHOD(Channel, watchConnectivityState) {
   wrapped_grpc_channel *channel =
@@ -255,11 +257,9 @@ PHP_METHOD(Channel, watchConnectivityState) {
       completion_queue, NULL,
       gpr_inf_future(GPR_CLOCK_REALTIME));
   if (!event.success) {
-    zend_throw_exception(spl_ce_LogicException,
-        "watchConnectivityState failed",
-        1 TSRMLS_CC);
+    RETURN_BOOL(0);
   }
-  return;
+  RETURN_BOOL(1);
 }
 
 /**

--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -205,6 +205,26 @@ PHP_METHOD(Channel, getTarget) {
 }
 
 /**
+ * Get the connectivity state of the channel
+ * @param bool (optional) try to connect on the channel
+ * @return long The grpc connectivity state
+ */
+PHP_METHOD(Channel, getConnectivityState) {
+  wrapped_grpc_channel *channel =
+      (wrapped_grpc_channel *)zend_object_store_get_object(getThis() TSRMLS_CC);
+  bool try_to_connect;
+  /* "|b" == 1 optional bool */
+  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|b", &try_to_connect) ==
+      FAILURE) {
+    zend_throw_exception(spl_ce_InvalidArgumentException,
+                         "getConnectivityState expects a bool", 1 TSRMLS_CC);
+    return;
+  }
+  RETURN_LONG(grpc_channel_check_connectivity_state(channel->wrapped,
+                                                    (int)try_to_connect));
+}
+
+/**
  * Close the channel
  */
 PHP_METHOD(Channel, close) {
@@ -219,6 +239,7 @@ PHP_METHOD(Channel, close) {
 static zend_function_entry channel_methods[] = {
     PHP_ME(Channel, __construct, NULL, ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
     PHP_ME(Channel, getTarget, NULL, ZEND_ACC_PUBLIC)
+    PHP_ME(Channel, getConnectivityState, NULL, ZEND_ACC_PUBLIC)
     PHP_ME(Channel, close, NULL, ZEND_ACC_PUBLIC)
     PHP_FE_END};
 

--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -256,10 +256,7 @@ PHP_METHOD(Channel, watchConnectivityState) {
   grpc_event event = grpc_completion_queue_pluck(
       completion_queue, NULL,
       gpr_inf_future(GPR_CLOCK_REALTIME));
-  if (!event.success) {
-    RETURN_BOOL(0);
-  }
-  RETURN_BOOL(1);
+  RETURN_BOOL(event.success);
 }
 
 /**

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -183,6 +183,18 @@ PHP_MINIT_FUNCTION(grpc) {
   REGISTER_LONG_CONSTANT("Grpc\\OP_RECV_CLOSE_ON_SERVER",
                          GRPC_OP_RECV_CLOSE_ON_SERVER, CONST_CS);
 
+  /* Register connectivity state constants */
+  REGISTER_LONG_CONSTANT("Grpc\\CHANNEL_IDLE",
+                         GRPC_CHANNEL_IDLE, CONST_CS);
+  REGISTER_LONG_CONSTANT("Grpc\\CHANNEL_CONNECTING",
+                         GRPC_CHANNEL_CONNECTING, CONST_CS);
+  REGISTER_LONG_CONSTANT("Grpc\\CHANNEL_READY",
+                         GRPC_CHANNEL_READY, CONST_CS);
+  REGISTER_LONG_CONSTANT("Grpc\\CHANNEL_TRANSIENT_FAILURE",
+                         GRPC_CHANNEL_TRANSIENT_FAILURE, CONST_CS);
+  REGISTER_LONG_CONSTANT("Grpc\\CHANNEL_FATAL_FAILURE",
+                         GRPC_CHANNEL_FATAL_FAILURE, CONST_CS);
+
   grpc_init_call(TSRMLS_C);
   grpc_init_channel(TSRMLS_C);
   grpc_init_server(TSRMLS_C);

--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -75,6 +75,14 @@ class BaseStub {
   }
 
   /**
+   * @param $try_to_connect bool
+   * @return int The grpc connectivity state
+   */
+  public function getConnectivityState($try_to_connect = false) {
+    return $this->channel->getConnectivityState($try_to_connect);
+  }
+
+  /**
    * Close the communication channel associated with this stub
    */
   public function close() {

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -158,13 +158,30 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
     $this->assertTrue($this->channel->getConnectivityState() == Grpc\CHANNEL_IDLE);
   }
 
-  public function testWatchConnectivityState() {
-    $old_state = $this->channel->getConnectivityState(true);
-    $deadline = microtime(true) * 1000000 + 500000;
-    $this->channel->watchConnectivityState(
-        $old_state,
-        new Grpc\Timeval($deadline));
+  public function testWatchConnectivityStateFailed() {
+    $idle_state = $this->channel->getConnectivityState(true);
+    $this->assertTrue($idle_state == Grpc\CHANNEL_IDLE);
+
+    $now = Grpc\Timeval::now();
+    $delta = new Grpc\Timeval(1);
+    $deadline = $now->add($delta);
+
+    $this->assertFalse($this->channel->watchConnectivityState(
+        $idle_state, $deadline));
+  }
+
+  public function testWatchConnectivityStateSuccess() {
+    $idle_state = $this->channel->getConnectivityState(true);
+    $this->assertTrue($idle_state == Grpc\CHANNEL_IDLE);
+
+    $now = Grpc\Timeval::now();
+    $delta = new Grpc\Timeval(100000);
+    $deadline = $now->add($delta);
+
+    $this->assertTrue($this->channel->watchConnectivityState(
+        $idle_state, $deadline));
+
     $new_state = $this->channel->getConnectivityState();
-    $this->assertTrue($old_state != $new_state);
+    $this->assertTrue($idle_state != $new_state);
   }
 }

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -154,14 +154,17 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
     $this->assertTrue(is_string($this->channel->getTarget()));
   }
 
-  /**
-   * @medium
-   */
   public function testGetConnectivityState() {
-    $old_state = Grpc\CHANNEL_IDLE;
-    $this->assertTrue($this->channel->getConnectivityState() == $old_state);
-    $this->assertTrue($this->channel->getConnectivityState(true) == $old_state);
-    usleep(500000);
-    $this->assertTrue($this->channel->getConnectivityState() != $old_state);
+    $this->assertTrue($this->channel->getConnectivityState() == Grpc\CHANNEL_IDLE);
+  }
+
+  public function testWatchConnectivityState() {
+    $old_state = $this->channel->getConnectivityState(true);
+    $deadline = microtime(true) * 1000000 + 500000;
+    $this->channel->watchConnectivityState(
+        $old_state,
+        new Grpc\Timeval($deadline));
+    $new_state = $this->channel->getConnectivityState();
+    $this->assertTrue($old_state != $new_state);
   }
 }

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -175,7 +175,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
     $this->assertTrue($idle_state == Grpc\CHANNEL_IDLE);
 
     $now = Grpc\Timeval::now();
-    $delta = new Grpc\Timeval(100000);
+    $delta = new Grpc\Timeval(3000000); // should finish well before
     $deadline = $now->add($delta);
 
     $this->assertTrue($this->channel->watchConnectivityState(
@@ -183,5 +183,20 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
 
     $new_state = $this->channel->getConnectivityState();
     $this->assertTrue($idle_state != $new_state);
+  }
+
+  public function testWatchConnectivityStateDoNothing() {
+    $idle_state = $this->channel->getConnectivityState();
+    $this->assertTrue($idle_state == Grpc\CHANNEL_IDLE);
+
+    $now = Grpc\Timeval::now();
+    $delta = new Grpc\Timeval(100000);
+    $deadline = $now->add($delta);
+
+    $this->assertFalse($this->channel->watchConnectivityState(
+        $idle_state, $deadline));
+
+    $new_state = $this->channel->getConnectivityState();
+    $this->assertTrue($new_state == Grpc\CHANNEL_IDLE);
   }
 }

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -153,4 +153,15 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
   public function testGetTarget() {
     $this->assertTrue(is_string($this->channel->getTarget()));
   }
+
+  /**
+   * @medium
+   */
+  public function testGetConnectivityState() {
+    $old_state = Grpc\CHANNEL_IDLE;
+    $this->assertTrue($this->channel->getConnectivityState() == $old_state);
+    $this->assertTrue($this->channel->getConnectivityState(true) == $old_state);
+    usleep(500000);
+    $this->assertTrue($this->channel->getConnectivityState() != $old_state);
+  }
 }


### PR DESCRIPTION
For #2511 
 * wrapped `getConnectivityState` and `watchConnectivityState` API
 * expose `watchForReady` method in `BaseStub` class