### PR TITLE
Removed "<:" bigram confusing gcc 4.4

### DIFF
--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -117,7 +117,7 @@ class Proxy : public ::grpc::cpp::test::util::TestService::Service {
   }
 
  private:
-  std::unique_ptr<::grpc::cpp::test::util::TestService::Stub> stub_;
+  std::unique_ptr< ::grpc::cpp::test::util::TestService::Stub> stub_;
 };
 
 class TestServiceImpl : public ::grpc::cpp::test::util::TestService::Service {


### PR DESCRIPTION
Resulted in error:

```test/cpp/end2end/end2end_test.cc:120: error: ‘<::’ cannot begin a template-argument list
test/cpp/end2end/end2end_test.cc:120: note: ‘<:’ is an alternate spelling for ‘[’. Insert whitespace between ‘<’ and ‘::’
test/cpp/end2end/end2end_test.cc:120: note: (if you use ‘-fpermissive’ G++ will accept your code)
make: *** [objs/opt/test/cpp/end2end/end2end_test.o] Error 1```