### PR TITLE
Node fix auth interop

### DIFF
--- a/src/node/interop/interop_client.js
+++ b/src/node/interop/interop_client.js
@@ -298,7 +298,9 @@ function authTest(expected_user, scope, client, done) {
       assert.strictEqual(resp.payload.type, 'COMPRESSABLE');
       assert.strictEqual(resp.payload.body.length, 314159);
       assert.strictEqual(resp.username, expected_user);
-      assert.strictEqual(resp.oauth_scope, AUTH_SCOPE_RESPONSE);
+      if (scope) {
+        assert.strictEqual(resp.oauth_scope, AUTH_SCOPE_RESPONSE);
+      }
       if (done) {
         done();
       }
@@ -335,7 +337,7 @@ function oauth2Test(expected_user, scope, per_rpc, client, done) {
           if (done) {
             done();
           }
-        });
+        }, client_metadata);
       };
       if (per_rpc) {
         updateMetadata('', {}, makeTestCall);

--- a/src/node/src/client.js
+++ b/src/node/src/client.js
@@ -548,8 +548,8 @@ exports.makeClientConstructor = function(methods, serviceName) {
     }
     options['grpc.primary_user_agent'] = 'grpc-node/' + version;
     this.channel = new grpc.Channel(address, credentials, options);
-    // Extract the DNS name from the address string
-    address = address.replace(/(\w+:\/\/+)?([^:]+)(:\d+)?\/?$/, '$2');
+    // Remove the optional DNS scheme, trailing port, and trailing backslash
+    address = address.replace(/^(dns:\/{3})?([^:\/]+)(:\d+)?\/?$/, '$2');
     this.server_address = address;
     this.auth_uri = 'https://' + this.server_address + '/' + serviceName;
     this.updateMetadata = updateMetadata;

--- a/src/node/src/client.js
+++ b/src/node/src/client.js
@@ -549,7 +549,7 @@ exports.makeClientConstructor = function(methods, serviceName) {
     options['grpc.primary_user_agent'] = 'grpc-node/' + version;
     this.channel = new grpc.Channel(address, credentials, options);
     // Extract the DNS name from the address string
-    address = address.replace(/(\w+:\/\/)?([^:]+)(:\d+)?\/?$/, '$2');
+    address = address.replace(/(\w+:\/\/+)?([^:]+)(:\d+)?\/?$/, '$2');
     this.server_address = address;
     this.auth_uri = 'https://' + this.server_address + '/' + serviceName;
     this.updateMetadata = updateMetadata;

--- a/src/node/src/client.js
+++ b/src/node/src/client.js
@@ -523,7 +523,7 @@ var requester_makers = {
  * requestSerialize: function to serialize request objects
  * responseDeserialize: function to deserialize response objects
  * @param {Object} methods An object mapping method names to method attributes
- * @param {string} serviceName The name of the service
+ * @param {string} serviceName The fully qualified name of the service
  * @return {function(string, Object)} New client constructor
  */
 exports.makeClientConstructor = function(methods, serviceName) {
@@ -548,8 +548,10 @@ exports.makeClientConstructor = function(methods, serviceName) {
     }
     options['grpc.primary_user_agent'] = 'grpc-node/' + version;
     this.channel = new grpc.Channel(address, credentials, options);
-    this.server_address = address.replace(/\/$/, '');
-    this.auth_uri = this.server_address + '/' + serviceName;
+    // Extract the DNS name from the address string
+    address = address.replace(/(\w+:\/\/)?([^:]+)(:\d+)?\/?$/, '$2');
+    this.server_address = address;
+    this.auth_uri = 'https://' + this.server_address + '/' + serviceName;
     this.updateMetadata = updateMetadata;
   }
 
@@ -587,7 +589,8 @@ exports.makeClientConstructor = function(methods, serviceName) {
  */
 exports.makeProtobufClientConstructor =  function(service) {
   var method_attrs = common.getProtobufServiceAttrs(service, service.name);
-  var Client = exports.makeClientConstructor(method_attrs);
+  var Client = exports.makeClientConstructor(
+      method_attrs, common.fullyQualifiedName(service));
   Client.service = service;
   return Client;
 };


### PR DESCRIPTION
 - Fixes `jwt_token_creds` by changing how `auth_uri` is calculated, and by checking the response oauth scope only if one was sent.
 - Fixes `per_rpc_creds` by properly passing metadata to the call.