### PR TITLE
Service-side read without allowance

### DIFF
--- a/src/python/grpcio_test/grpc_test/framework/interfaces/links/test_cases.py
+++ b/src/python/grpcio_test/grpc_test/framework/interfaces/links/test_cases.py
@@ -303,16 +303,9 @@ class TransmissionTest(object):
         invocation_message, links.Ticket.Termination.COMPLETION)
     self._invocation_link.accept_ticket(original_invocation_ticket)
 
-    # TODO(nathaniel): This shouldn't be necessary. Detecting the end of the
-    # invocation-side ticket sequence shouldn't require granting allowance for
-    # another payload.
     self._service_mate.block_until_tickets_satisfy(
         at_least_n_payloads_received_predicate(1))
     service_operation_id = self._service_mate.tickets()[0].operation_id
-    self._service_link.accept_ticket(
-        links.Ticket(
-            service_operation_id, 0, None, None, links.Ticket.Subscription.FULL,
-            None, 1, None, None, None, None, None, None))
 
     self._service_mate.block_until_tickets_satisfy(terminated)
     self._assert_is_valid_invocation_sequence(
@@ -321,7 +314,7 @@ class TransmissionTest(object):
         invocation_terminal_metadata, links.Ticket.Termination.COMPLETION)
 
     original_service_ticket = links.Ticket(
-        service_operation_id, 1, None, None, links.Ticket.Subscription.FULL,
+        service_operation_id, 0, None, None, links.Ticket.Subscription.FULL,
         timeout, 0, service_initial_metadata, service_payload,
         service_terminal_metadata, service_code, service_message,
         links.Ticket.Termination.COMPLETION)


### PR DESCRIPTION
This compensates for the abstraction mismatch described in #2916.