### PR TITLE
Dont generate package directories in C# protoc plugin output

### DIFF
--- a/src/compiler/csharp_generator_helpers.h
+++ b/src/compiler/csharp_generator_helpers.h
@@ -41,7 +41,7 @@ namespace grpc_csharp_generator {
 
 inline bool ServicesFilename(const grpc::protobuf::FileDescriptor *file,
                              grpc::string *file_name_or_error) {
-  *file_name_or_error = grpc_generator::FileNameInUpperCamel(file) + "Grpc.cs";
+  *file_name_or_error = grpc_generator::FileNameInUpperCamel(file, false) + "Grpc.cs";
   return true;
 }
 

--- a/src/compiler/generator_helpers.h
+++ b/src/compiler/generator_helpers.h
@@ -125,14 +125,21 @@ inline grpc::string LowerUnderscoreToUpperCamel(grpc::string str) {
   return result;
 }
 
-inline grpc::string FileNameInUpperCamel(const grpc::protobuf::FileDescriptor *file) {
+inline grpc::string FileNameInUpperCamel(const grpc::protobuf::FileDescriptor *file,
+                                         bool include_package_path) {
   std::vector<grpc::string> tokens = tokenize(StripProto(file->name()), "/");
   grpc::string result = "";
-  for (unsigned int i = 0; i < tokens.size() - 1; i++) {
-    result += tokens[i] + "/";
+  if (include_package_path) {
+    for (unsigned int i = 0; i < tokens.size() - 1; i++) {
+      result += tokens[i] + "/";
+    }
   }
   result += LowerUnderscoreToUpperCamel(tokens.back());
   return result;
+}
+
+inline grpc::string FileNameInUpperCamel(const grpc::protobuf::FileDescriptor *file) {
+  return FileNameInUpperCamel(file, true);
 }
 
 enum MethodType {


### PR DESCRIPTION
Protoc for C# doesn't generate output directories for packages. grpc_csharp_plugin needs have the same behavior to prevent user confusion.