### PR TITLE
Remove the runtime dependency on the logging gem.

### DIFF
--- a/src/ruby/grpc.gemspec
+++ b/src/ruby/grpc.gemspec
@@ -30,10 +30,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'google-protobuf', '~> 3.0.0alpha.1.1'
   s.add_dependency 'googleauth', '~> 0.4'
-  s.add_dependency 'logging', '~> 2.0'
 
-  s.add_development_dependency 'simplecov', '~> 0.9'
   s.add_development_dependency 'bundler', '~> 1.9'
+  s.add_development_dependency 'logging', '~> 2.0'
+  s.add_development_dependency 'simplecov', '~> 0.9'
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'rake-compiler', '~> 0.9'
   s.add_development_dependency 'rspec', '~> 3.2'

--- a/src/ruby/lib/grpc/logconfig.rb
+++ b/src/ruby/lib/grpc/logconfig.rb
@@ -27,17 +27,32 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-require 'logging'
-
 # GRPC contains the General RPC module.
 module GRPC
-  extend Logging.globally
+  # DefaultLogger is a module included in GRPC if no other logging is set up for
+  # it.  See ../spec/spec_helpers an example of where other logging is added.
+  module DefaultLogger
+    def logger
+      LOGGER
+    end
+
+    private
+
+    # NoopLogger implements the methods of Ruby's conventional logging interface
+    # that are actually used internally within gRPC with a noop implementation.
+    class NoopLogger
+      def info(_ignored)
+      end
+
+      def debug(_ignored)
+      end
+
+      def warn(_ignored)
+      end
+    end
+
+    LOGGER = NoopLogger.new
+  end
+
+  include DefaultLogger unless method_defined?(:logger)
 end
-
-Logging.logger.root.appenders = Logging.appenders.stdout
-Logging.logger.root.level = :info
-
-# TODO: provide command-line configuration for logging
-Logging.logger['GRPC'].level = :info
-Logging.logger['GRPC::ActiveCall'].level = :info
-Logging.logger['GRPC::BidiCall'].level = :info

--- a/src/ruby/spec/spec_helper.rb
+++ b/src/ruby/spec/spec_helper.rb
@@ -47,11 +47,23 @@ require 'rspec'
 require 'logging'
 require 'rspec/logging_helper'
 
+# GRPC is the general RPC module
+#
+# Configure its logging for fine-grained log control during test runs
+module GRPC
+  extend Logging.globally
+end
+Logging.logger.root.appenders = Logging.appenders.stdout
+Logging.logger.root.level = :info
+Logging.logger['GRPC'].level = :info
+Logging.logger['GRPC::ActiveCall'].level = :info
+Logging.logger['GRPC::BidiCall'].level = :info
+
 # Configure RSpec to capture log messages for each test. The output from the
 # logs will be stored in the @log_output variable. It is a StringIO instance.
 RSpec.configure do |config|
   include RSpec::LoggingHelper
-  config.capture_log_messages
+  config.capture_log_messages  # comment this out to see logs during test runs
 end
 
 RSpec::Expectations.configuration.warn_about_potential_false_positives = false


### PR DESCRIPTION
- allows users of GRPC to use the logging implementation of their choosing
- provides a noop logger as a default.

Resolves #2532 
