### PR TITLE
Made deadline tests accept INTERNAL status

### DIFF
--- a/src/node/interop/interop_client.js
+++ b/src/node/interop/interop_client.js
@@ -264,7 +264,9 @@ function timeoutOnSleepingServer(client, done) {
     payload: {body: zeroBuffer(27182)}
   });
   call.on('error', function(error) {
-    assert.strictEqual(error.code, grpc.status.DEADLINE_EXCEEDED);
+
+    assert(error.code === grpc.status.DEADLINE_EXCEEDED ||
+        error.code === grpc.status.INTERNAL);
     done();
   });
 }

--- a/src/node/test/surface_test.js
+++ b/src/node/test/surface_test.js
@@ -784,7 +784,8 @@ describe('Other conditions', function() {
           client.clientStream(function(err, value) {
             try {
               assert(err);
-              assert.strictEqual(err.code, grpc.status.DEADLINE_EXCEEDED);
+              assert(err.code === grpc.status.DEADLINE_EXCEEDED ||
+                  err.code === grpc.status.INTERNAL);
             } finally {
               callback(err, value);
               done();
@@ -809,7 +810,8 @@ describe('Other conditions', function() {
               null, {parent: parent, propagate_flags: deadline_flags});
           child.on('error', function(err) {
             assert(err);
-            assert.strictEqual(err.code, grpc.status.DEADLINE_EXCEEDED);
+            assert(err.code === grpc.status.DEADLINE_EXCEEDED ||
+                err.code === grpc.status.INTERNAL);
             done();
           });
         };


### PR DESCRIPTION
#2685 says that clients should be expected to occasionally receive an INTERNAL status when expecting DEADLINE_EXCEEDED. This modifies the Node tests to reflect that. Fixes #2957.