### PR TITLE
rename native object wrapping native credentials from Credentials to SecurityOptions

### DIFF
--- a/src/csharp/Grpc.Core.Tests/ChannelTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ChannelTest.cs
@@ -50,13 +50,13 @@ namespace Grpc.Core.Tests
         [Test]
         public void Constructor_RejectsInvalidParams()
         {
-            Assert.Throws(typeof(ArgumentNullException), () => new Channel(null, Credentials.Insecure));
+            Assert.Throws(typeof(ArgumentNullException), () => new Channel(null, SecurityOptions.Insecure));
         }
 
         [Test]
         public void State_IdleAfterCreation()
         {
-            using (var channel = new Channel("localhost", Credentials.Insecure))
+            using (var channel = new Channel("localhost", SecurityOptions.Insecure))
             {
                 Assert.AreEqual(ChannelState.Idle, channel.State);
             }
@@ -65,7 +65,7 @@ namespace Grpc.Core.Tests
         [Test]
         public void WaitForStateChangedAsync_InvalidArgument()
         {
-            using (var channel = new Channel("localhost", Credentials.Insecure))
+            using (var channel = new Channel("localhost", SecurityOptions.Insecure))
             {
                 Assert.Throws(typeof(ArgumentException), () => channel.WaitForStateChangedAsync(ChannelState.FatalFailure));
             }
@@ -74,7 +74,7 @@ namespace Grpc.Core.Tests
         [Test]
         public void ResolvedTarget()
         {
-            using (var channel = new Channel("127.0.0.1", Credentials.Insecure))
+            using (var channel = new Channel("127.0.0.1", SecurityOptions.Insecure))
             {
                 Assert.IsTrue(channel.ResolvedTarget.Contains("127.0.0.1"));
             }
@@ -83,7 +83,7 @@ namespace Grpc.Core.Tests
         [Test]
         public void Dispose_IsIdempotent()
         {
-            var channel = new Channel("localhost", Credentials.Insecure);
+            var channel = new Channel("localhost", SecurityOptions.Insecure);
             channel.Dispose();
             channel.Dispose();
         }

--- a/src/csharp/Grpc.Core.Tests/MockServiceHelper.cs
+++ b/src/csharp/Grpc.Core.Tests/MockServiceHelper.cs
@@ -135,7 +135,7 @@ namespace Grpc.Core.Tests
                 server = new Server
                 {
                     Services = { serviceDefinition },
-                    Ports = { { Host, ServerPort.PickUnused, ServerCredentials.Insecure } }
+                    Ports = { { Host, ServerPort.PickUnused, ServerSecurityOptions.Insecure } }
                 };
             }
             return server;
@@ -148,7 +148,7 @@ namespace Grpc.Core.Tests
         {
             if (channel == null)
             {
-                channel = new Channel(Host, GetServer().Ports.Single().BoundPort, Credentials.Insecure);
+                channel = new Channel(Host, GetServer().Ports.Single().BoundPort, SecurityOptions.Insecure);
             }
             return channel;
         }

--- a/src/csharp/Grpc.Core.Tests/ServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ServerTest.cs
@@ -47,7 +47,7 @@ namespace Grpc.Core.Tests
         {
             Server server = new Server
             {
-                Ports = { new ServerPort("localhost", ServerPort.PickUnused, ServerCredentials.Insecure) }
+                Ports = { new ServerPort("localhost", ServerPort.PickUnused, ServerSecurityOptions.Insecure) }
             };
             server.Start();
             server.ShutdownAsync().Wait();
@@ -59,7 +59,7 @@ namespace Grpc.Core.Tests
         {
             Server server = new Server
             {
-                Ports = { new ServerPort("localhost", ServerPort.PickUnused, ServerCredentials.Insecure) }
+                Ports = { new ServerPort("localhost", ServerPort.PickUnused, ServerSecurityOptions.Insecure) }
             };
 
             var boundPort = server.Ports.Single();
@@ -76,10 +76,10 @@ namespace Grpc.Core.Tests
         {
             Server server = new Server
             {
-                Ports = { new ServerPort("localhost", ServerPort.PickUnused, ServerCredentials.Insecure) }
+                Ports = { new ServerPort("localhost", ServerPort.PickUnused, ServerSecurityOptions.Insecure) }
             };
             server.Start();
-            Assert.Throws(typeof(InvalidOperationException), () => server.Ports.Add("localhost", 9999, ServerCredentials.Insecure));
+            Assert.Throws(typeof(InvalidOperationException), () => server.Ports.Add("localhost", 9999, ServerSecurityOptions.Insecure));
             Assert.Throws(typeof(InvalidOperationException), () => server.Services.Add(ServerServiceDefinition.CreateBuilder("serviceName").Build()));
 
             server.ShutdownAsync().Wait();

--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -32,8 +32,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
 
 using Grpc.Core.Internal;
@@ -60,16 +58,16 @@ namespace Grpc.Core
         /// Port will default to 80 for an unsecure channel and to 443 for a secure channel.
         /// </summary>
         /// <param name="target">Target of the channel.</param>
-        /// <param name="credentials">Credentials to secure the channel.</param>
+        /// <param name="securityOptions">Security options used to secure the channel.</param>
         /// <param name="options">Channel options.</param>
-        public Channel(string target, Credentials credentials, IEnumerable<ChannelOption> options = null)
+        public Channel(string target, SecurityOptions securityOptions, IEnumerable<ChannelOption> options = null)
         {
             this.target = Preconditions.CheckNotNull(target, "target");
             this.environment = GrpcEnvironment.GetInstance();
             this.options = options != null ? new List<ChannelOption>(options) : new List<ChannelOption>();
 
             EnsureUserAgentChannelOption(this.options);
-            using (CredentialsSafeHandle nativeCredentials = credentials.ToNativeCredentials())
+            using (CredentialsSafeHandle nativeCredentials = securityOptions.ToNativeCredentials())
             using (ChannelArgsSafeHandle nativeChannelArgs = ChannelOptions.CreateChannelArgs(this.options))
             {
                 if (nativeCredentials != null)
@@ -88,10 +86,10 @@ namespace Grpc.Core
         /// </summary>
         /// <param name="host">The name or IP address of the host.</param>
         /// <param name="port">The port.</param>
-        /// <param name="credentials">Credentials to secure the channel.</param>
+        /// <param name="securityOptions">Security options used to secure the channel.</param>
         /// <param name="options">Channel options.</param>
-        public Channel(string host, int port, Credentials credentials, IEnumerable<ChannelOption> options = null) :
-            this(string.Format("{0}:{1}", host, port), credentials, options)
+        public Channel(string host, int port, SecurityOptions securityOptions, IEnumerable<ChannelOption> options = null) :
+            this(string.Format("{0}:{1}", host, port), securityOptions, options)
         {
         }
 

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -78,7 +78,6 @@
     <Compile Include="Utils\AsyncStreamExtensions.cs" />
     <Compile Include="Utils\BenchmarkUtil.cs" />
     <Compile Include="Internal\CredentialsSafeHandle.cs" />
-    <Compile Include="Credentials.cs" />
     <Compile Include="Internal\ChannelArgsSafeHandle.cs" />
     <Compile Include="Internal\AsyncCompletion.cs" />
     <Compile Include="Internal\AsyncCallBase.cs" />
@@ -86,7 +85,6 @@
     <Compile Include="Internal\AsyncCall.cs" />
     <Compile Include="Utils\Preconditions.cs" />
     <Compile Include="Internal\ServerCredentialsSafeHandle.cs" />
-    <Compile Include="ServerCredentials.cs" />
     <Compile Include="Metadata.cs" />
     <Compile Include="Internal\MetadataArraySafeHandle.cs" />
     <Compile Include="ClientBase.cs" />
@@ -116,6 +114,8 @@
     <Compile Include="CompressionLevel.cs" />
     <Compile Include="WriteOptions.cs" />
     <Compile Include="ContextPropagationToken.cs" />
+    <Compile Include="SecurityOptions.cs" />
+    <Compile Include="SeverSecurityOptions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Grpc.Core.nuspec" />

--- a/src/csharp/Grpc.Core/SecurityOptions.cs
+++ b/src/csharp/Grpc.Core/SecurityOptions.cs
@@ -37,17 +37,18 @@ using Grpc.Core.Internal;
 namespace Grpc.Core
 {
     /// <summary>
-    /// Client-side credentials. Used for creation of a secure channel.
+    /// Base class for providers of channel security options. Subclasses can be used to
+    /// create secure channels.
     /// </summary>
-    public abstract class Credentials
+    public abstract class SecurityOptions
     {
-        static readonly Credentials InsecureInstance = new InsecureCredentialsImpl();
+        static readonly SecurityOptions InsecureInstance = new InsecureImpl();
 
         /// <summary>
-        /// Returns instance of credential that provides no security and 
+        /// Returns <c>SecurityOptions</c> object that provides no security and 
         /// will result in creating an unsecure channel with no encryption whatsoever.
         /// </summary>
-        public static Credentials Insecure
+        public static SecurityOptions Insecure
         {
             get
             {
@@ -56,13 +57,13 @@ namespace Grpc.Core
         }
 
         /// <summary>
-        /// Creates native object for the credentials. May return null if insecure channel
+        /// Creates native credentials object representing this instance. May return null if insecure channel
         /// should be created.
         /// </summary>
         /// <returns>The native credentials.</returns>
         internal abstract CredentialsSafeHandle ToNativeCredentials();
 
-        private sealed class InsecureCredentialsImpl : Credentials
+        private sealed class InsecureImpl : SecurityOptions
         {
             internal override CredentialsSafeHandle ToNativeCredentials()
             {
@@ -72,36 +73,36 @@ namespace Grpc.Core
     }
 
     /// <summary>
-    /// Client-side SSL credentials.
+    /// Client-side SSL options. <c>Channel</c> created with these options will be secured by SSL.
     /// </summary>
-    public sealed class SslCredentials : Credentials
+    public sealed class SslOptions : SecurityOptions
     {
         readonly string rootCertificates;
         readonly KeyCertificatePair keyCertificatePair;
 
         /// <summary>
-        /// Creates client-side SSL credentials loaded from
+        /// Creates client-side SSL options loaded from
         /// disk file pointed to by the GRPC_DEFAULT_SSL_ROOTS_FILE_PATH environment variable.
         /// If that fails, gets the roots certificates from a well known place on disk.
         /// </summary>
-        public SslCredentials() : this(null, null)
+        public SslOptions() : this(null, null)
         {
         }
 
         /// <summary>
-        /// Creates client-side SSL credentials from
+        /// Creates client-side SSL options from
         /// a string containing PEM encoded root certificates.
         /// </summary>
-        public SslCredentials(string rootCertificates) : this(rootCertificates, null)
+        public SslOptions(string rootCertificates) : this(rootCertificates, null)
         {
         }
             
         /// <summary>
-        /// Creates client-side SSL credentials.
+        /// Creates client-side SSL options.
         /// </summary>
         /// <param name="rootCertificates">string containing PEM encoded server root certificates.</param>
         /// <param name="keyCertificatePair">a key certificate pair.</param>
-        public SslCredentials(string rootCertificates, KeyCertificatePair keyCertificatePair)
+        public SslOptions(string rootCertificates, KeyCertificatePair keyCertificatePair)
         {
             this.rootCertificates = rootCertificates;
             this.keyCertificatePair = keyCertificatePair;

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -192,11 +192,11 @@ namespace Grpc.Core
         {
             lock (myLock)
             {
-                Preconditions.CheckNotNull(serverPort.Credentials, "serverPort");
+                Preconditions.CheckNotNull(serverPort.SecurityOptions, "serverPort.SecurityOptions");
                 Preconditions.CheckState(!startRequested);
                 var address = string.Format("{0}:{1}", serverPort.Host, serverPort.Port);
                 int boundPort;
-                using (var nativeCredentials = serverPort.Credentials.ToNativeCredentials())
+                using (var nativeCredentials = serverPort.SecurityOptions.ToNativeCredentials())
                 {
                     if (nativeCredentials != null)
                     {
@@ -334,10 +334,10 @@ namespace Grpc.Core
             /// </summary>
             /// <param name="host">the host</param>
             /// <param name="port">the port. If zero, an unused port is chosen automatically.</param>
-            /// <param name="credentials">credentials to use to secure this port.</param>
-            public int Add(string host, int port, ServerCredentials credentials)
+            /// <param name="securityOptions">Options to use to secure this port.</param>
+            public int Add(string host, int port, ServerSecurityOptions securityOptions)
             {
-                return Add(new ServerPort(host, port, credentials));
+                return Add(new ServerPort(host, port, securityOptions));
             }
 
             public IEnumerator<ServerPort> GetEnumerator()

--- a/src/csharp/Grpc.Core/ServerPort.cs
+++ b/src/csharp/Grpc.Core/ServerPort.cs
@@ -50,7 +50,7 @@ namespace Grpc.Core
 
         readonly string host;
         readonly int port;
-        readonly ServerCredentials credentials;
+        readonly ServerSecurityOptions securityOptions;
         readonly int boundPort;
 
         /// <summary>
@@ -59,12 +59,12 @@ namespace Grpc.Core
         /// <returns>The port on which server will be listening.</returns>
         /// <param name="host">the host</param>
         /// <param name="port">the port. If zero, an unused port is chosen automatically.</param>
-        /// <param name="credentials">credentials to use to secure this port.</param>
-        public ServerPort(string host, int port, ServerCredentials credentials)
+        /// <param name="securityOptions">Options to use to secure this port.</param>
+        public ServerPort(string host, int port, ServerSecurityOptions securityOptions)
         {
             this.host = Preconditions.CheckNotNull(host, "host");
             this.port = port;
-            this.credentials = Preconditions.CheckNotNull(credentials, "credentials");
+            this.securityOptions = Preconditions.CheckNotNull(securityOptions, "securityOptions");
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace Grpc.Core
         {
             this.host = serverPort.host;
             this.port = serverPort.port;
-            this.credentials = serverPort.credentials;
+            this.securityOptions = serverPort.securityOptions;
             this.boundPort = boundPort;
         }
 
@@ -96,12 +96,12 @@ namespace Grpc.Core
             }
         }
 
-        /// <value>The server credentials.</value>
-        public ServerCredentials Credentials
+        /// <value>The server security options.</value>
+        public ServerSecurityOptions SecurityOptions
         {
             get
             {
-                return credentials;
+                return securityOptions;
             }
         }
 

--- a/src/csharp/Grpc.Core/SeverSecurityOptions.cs
+++ b/src/csharp/Grpc.Core/SeverSecurityOptions.cs
@@ -39,17 +39,17 @@ using Grpc.Core.Utils;
 namespace Grpc.Core
 {
     /// <summary>
-    /// Server side credentials.
+    /// Server side security options.
     /// </summary>
-    public abstract class ServerCredentials
+    public abstract class ServerSecurityOptions
     {
-        static readonly ServerCredentials InsecureInstance = new InsecureServerCredentialsImpl();
+        static readonly ServerSecurityOptions InsecureInstance = new InsecureImpl();
 
         /// <summary>
-        /// Returns instance of credential that provides no security and 
+        /// Returns instance of <c>ServerSecurityOptions</c> that provides no security and 
         /// will result in creating an unsecure server port with no encryption whatsoever.
         /// </summary>
-        public static ServerCredentials Insecure
+        public static ServerSecurityOptions Insecure
         {
             get
             {
@@ -58,12 +58,12 @@ namespace Grpc.Core
         }
 
         /// <summary>
-        /// Creates native object for the credentials.
+        /// Creates native object for the security options.
         /// </summary>
         /// <returns>The native credentials.</returns>
         internal abstract ServerCredentialsSafeHandle ToNativeCredentials();
 
-        private sealed class InsecureServerCredentialsImpl : ServerCredentials
+        private sealed class InsecureImpl : ServerSecurityOptions
         {
             internal override ServerCredentialsSafeHandle ToNativeCredentials()
             {
@@ -73,21 +73,21 @@ namespace Grpc.Core
     }
 
     /// <summary>
-    /// Server-side SSL credentials.
+    /// Server-side SSL security options.
     /// </summary>
-    public class SslServerCredentials : ServerCredentials
+    public class SslServerOptions : ServerSecurityOptions
     {
         readonly IList<KeyCertificatePair> keyCertificatePairs;
         readonly string rootCertificates;
         readonly bool forceClientAuth;
 
         /// <summary>
-        /// Creates server-side SSL credentials.
+        /// Creates server-side SSL options.
         /// </summary>
         /// <param name="keyCertificatePairs">Key-certificates to use.</param>
         /// <param name="rootCertificates">PEM encoded client root certificates used to authenticate client.</param>
         /// <param name="forceClientAuth">If true, client will be rejected unless it proves its unthenticity using against rootCertificates.</param>
-        public SslServerCredentials(IEnumerable<KeyCertificatePair> keyCertificatePairs, string rootCertificates, bool forceClientAuth)
+        public SslServerOptions(IEnumerable<KeyCertificatePair> keyCertificatePairs, string rootCertificates, bool forceClientAuth)
         {
             this.keyCertificatePairs = new List<KeyCertificatePair>(keyCertificatePairs).AsReadOnly();
             Preconditions.CheckArgument(this.keyCertificatePairs.Count > 0,
@@ -102,12 +102,12 @@ namespace Grpc.Core
         }
 
         /// <summary>
-        /// Creates server-side SSL credentials.
-        /// This constructor should be use if you do not wish to autheticate client
+        /// Creates server-side SSL options.
+        /// This constructor should be used if you do not wish to autheticate client
         /// using client root certificates.
         /// </summary>
         /// <param name="keyCertificatePairs">Key-certificates to use.</param>
-        public SslServerCredentials(IEnumerable<KeyCertificatePair> keyCertificatePairs) : this(keyCertificatePairs, null, false)
+        public SslServerOptions(IEnumerable<KeyCertificatePair> keyCertificatePairs) : this(keyCertificatePairs, null, false)
         {
         }
 

--- a/src/csharp/Grpc.Examples.MathClient/MathClient.cs
+++ b/src/csharp/Grpc.Examples.MathClient/MathClient.cs
@@ -39,7 +39,7 @@ namespace math
     {
         public static void Main(string[] args)
         {
-            using (Channel channel = new Channel("127.0.0.1", 23456, Credentials.Insecure))
+            using (Channel channel = new Channel("127.0.0.1", 23456, SecurityOptions.Insecure))
             {
                 Math.IMathClient client = new Math.MathClient(channel);
                 MathExamples.DivExample(client);

--- a/src/csharp/Grpc.Examples.MathServer/MathServer.cs
+++ b/src/csharp/Grpc.Examples.MathServer/MathServer.cs
@@ -46,7 +46,7 @@ namespace math
             Server server = new Server
             {
                 Services = { Math.BindService(new MathServiceImpl()) },
-                Ports = { { Host, Port, ServerCredentials.Insecure } }
+                Ports = { { Host, Port, ServerSecurityOptions.Insecure } }
             };
             server.Start();
 

--- a/src/csharp/Grpc.Examples.Tests/MathClientServerTests.cs
+++ b/src/csharp/Grpc.Examples.Tests/MathClientServerTests.cs
@@ -58,10 +58,10 @@ namespace math.Tests
             server = new Server
             {
                 Services = { Math.BindService(new MathServiceImpl()) },
-                Ports = { { Host, ServerPort.PickUnused, ServerCredentials.Insecure } }
+                Ports = { { Host, ServerPort.PickUnused, ServerSecurityOptions.Insecure } }
             };
             server.Start();
-            channel = new Channel(Host, server.Ports.Single().BoundPort, Credentials.Insecure);
+            channel = new Channel(Host, server.Ports.Single().BoundPort, SecurityOptions.Insecure);
             client = Math.NewClient(channel);
         }
 

--- a/src/csharp/Grpc.HealthCheck.Tests/HealthClientServerTest.cs
+++ b/src/csharp/Grpc.HealthCheck.Tests/HealthClientServerTest.cs
@@ -60,10 +60,10 @@ namespace Grpc.HealthCheck.Tests
             server = new Server
             {
                 Services = { Grpc.Health.V1Alpha.Health.BindService(serviceImpl) },
-                Ports = { { Host, ServerPort.PickUnused, ServerCredentials.Insecure } }
+                Ports = { { Host, ServerPort.PickUnused, ServerSecurityOptions.Insecure } }
             };
             server.Start();
-            channel = new Channel(Host, server.Ports.Single().BoundPort, Credentials.Insecure);
+            channel = new Channel(Host, server.Ports.Single().BoundPort, SecurityOptions.Insecure);
 
             client = Grpc.Health.V1Alpha.Health.NewClient(channel);
         }

--- a/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
+++ b/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
@@ -38,38 +38,6 @@
     <AssemblyOriginatorKeyFile>C:\keys\Grpc.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BouncyCastle.Crypto, Version=1.7.4137.9688, Culture=neutral, PublicKeyToken=a4292a325f69b123, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
-    </Reference>
-    <Reference Include="Google.Apis.Auth, Version=1.9.3.19379, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Google.Apis.Auth.1.9.3\lib\net40\Google.Apis.Auth.dll</HintPath>
-    </Reference>
-    <Reference Include="Google.Apis.Auth.PlatformServices, Version=1.9.3.19383, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Google.Apis.Auth.1.9.3\lib\net40\Google.Apis.Auth.PlatformServices.dll</HintPath>
-    </Reference>
-    <Reference Include="Google.Apis.Core, Version=1.9.3.19379, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Google.Apis.Core.1.9.3\lib\portable-net40+sl50+win+wpa81+wp80\Google.Apis.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
@@ -82,15 +50,37 @@
     </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="BouncyCastle.Crypto">
+      <HintPath>..\packages\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Apis.Auth">
+      <HintPath>..\packages\Google.Apis.Auth.1.9.3\lib\net40\Google.Apis.Auth.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Apis.Auth.PlatformServices">
+      <HintPath>..\packages\Google.Apis.Auth.1.9.3\lib\net40\Google.Apis.Auth.PlatformServices.dll</HintPath>
+    </Reference>
+    <Reference Include="Google.Apis.Core">
+      <HintPath>..\packages\Google.Apis.Core.1.9.3\lib\portable-net40+sl50+win+wpa81+wp80\Google.Apis.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
+      <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Extensions">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="System.Net.Http.Primitives">
       <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Grpc.Core\Version.cs">
@@ -103,9 +93,9 @@
     <Compile Include="TestServiceImpl.cs" />
     <Compile Include="InteropServer.cs" />
     <Compile Include="InteropClient.cs" />
-    <Compile Include="TestCredentials.cs" />
     <Compile Include="TestGrpc.cs" />
-    <Compile Include="SslCredentialsTest.cs" />
+    <Compile Include="SslOptionsTest.cs" />
+    <Compile Include="TestSecurityOptions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
@@ -58,7 +58,7 @@ namespace Grpc.IntegrationTesting
         {
             public bool help;
             public string serverHost = "127.0.0.1";
-            public string serverHostOverride = TestCredentials.DefaultHostOverride;
+            public string serverHostOverride = TestSecurityOptions.DefaultHostOverride;
             public int? serverPort;
             public string testCase = "large_unary";
             public bool useTls;
@@ -103,11 +103,7 @@ namespace Grpc.IntegrationTesting
 
         private async Task Run()
         {
-            Credentials credentials = null;
-            if (options.useTls)
-            {
-                credentials = TestCredentials.CreateTestClientCredentials(options.useTestCa);
-            }
+            var securityOptions = options.useTls ? TestSecurityOptions.CreateTestClientSecurityOptions(options.useTestCa) : SecurityOptions.Insecure;
 
             List<ChannelOption> channelOptions = null;
             if (!string.IsNullOrEmpty(options.serverHostOverride))
@@ -118,7 +114,7 @@ namespace Grpc.IntegrationTesting
                 };
             }
 
-            using (Channel channel = new Channel(options.serverHost, options.serverPort.Value, credentials, channelOptions))
+            using (Channel channel = new Channel(options.serverHost, options.serverPort.Value, securityOptions, channelOptions))
             {
                 TestService.TestServiceClient client = new TestService.TestServiceClient(channel);
                 await RunTestCaseAsync(options.testCase, client);

--- a/src/csharp/Grpc.IntegrationTesting/InteropClientServerTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClientServerTest.cs
@@ -59,16 +59,16 @@ namespace Grpc.IntegrationTesting
             server = new Server
             {
                 Services = { TestService.BindService(new TestServiceImpl()) },
-                Ports = { { Host, ServerPort.PickUnused, TestCredentials.CreateTestServerCredentials() } }
+                Ports = { { Host, ServerPort.PickUnused, TestSecurityOptions.CreateTestServerSecurityOptions() } }
             };
             server.Start();
 
             var options = new List<ChannelOption>
             {
-                new ChannelOption(ChannelOptions.SslTargetNameOverride, TestCredentials.DefaultHostOverride)
+                new ChannelOption(ChannelOptions.SslTargetNameOverride, TestSecurityOptions.DefaultHostOverride)
             };
             int port = server.Ports.Single().BoundPort;
-            channel = new Channel(Host, port, TestCredentials.CreateTestClientCredentials(true), options);
+            channel = new Channel(Host, port, TestSecurityOptions.CreateTestClientSecurityOptions(true), options);
             client = TestService.NewClient(channel);
         }
 

--- a/src/csharp/Grpc.IntegrationTesting/InteropServer.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropServer.cs
@@ -97,11 +97,11 @@ namespace Grpc.IntegrationTesting
             int port = options.port.Value;
             if (options.useTls)
             {
-                server.Ports.Add(host, port, TestCredentials.CreateTestServerCredentials());
+                server.Ports.Add(host, port, TestSecurityOptions.CreateTestServerSecurityOptions());
             }
             else
             {
-                server.Ports.Add(host, options.port.Value, ServerCredentials.Insecure);
+                server.Ports.Add(host, options.port.Value, ServerSecurityOptions.Insecure);
             }
             Console.WriteLine("Running server on " + string.Format("{0}:{1}", host, port));
             server.Start();


### PR DESCRIPTION
Two different concepts are currently named "credential(s)":
* auth credentials (from Google.Apis.Auth) - e.g. GoogleCredential
* native credentials objects used to pass SSL params to C core.

This leads to user confusion. This PR is renaming Credentials wrapping the native grpc_credentials object to SecurityOptions. (and similarly for the server-side case).