### PR TITLE
clang-format all source

### DIFF
--- a/include/grpc++/async_unary_call.h
+++ b/include/grpc++/async_unary_call.h
@@ -121,8 +121,8 @@ class ServerAsyncResponseWriter GRPC_FINAL
     }
     // The response is dropped if the status is not OK.
     if (status.ok()) {
-      finish_buf_.ServerSendStatus(
-          ctx_->trailing_metadata_, finish_buf_.SendMessage(msg));
+      finish_buf_.ServerSendStatus(ctx_->trailing_metadata_,
+                                   finish_buf_.SendMessage(msg));
     } else {
       finish_buf_.ServerSendStatus(ctx_->trailing_metadata_, status);
     }

--- a/include/grpc++/auth_context.h
+++ b/include/grpc++/auth_context.h
@@ -62,6 +62,7 @@ class AuthPropertyIterator
   AuthPropertyIterator();
   AuthPropertyIterator(const grpc_auth_property* property,
                        const grpc_auth_property_iterator* iter);
+
  private:
   friend class SecureAuthContext;
   const grpc_auth_property* property_;
@@ -92,4 +93,3 @@ class AuthContext {
 }  // namespace grpc
 
 #endif  // GRPCXX_AUTH_CONTEXT_H
-

--- a/include/grpc++/byte_buffer.h
+++ b/include/grpc++/byte_buffer.h
@@ -91,8 +91,8 @@ class SerializationTraits<ByteBuffer, void> {
     dest->set_buffer(byte_buffer);
     return Status::OK;
   }
-  static Status Serialize(const ByteBuffer& source, grpc_byte_buffer** buffer, 
-                        bool* own_buffer) {
+  static Status Serialize(const ByteBuffer& source, grpc_byte_buffer** buffer,
+                          bool* own_buffer) {
     *buffer = source.buffer();
     *own_buffer = false;
     return Status::OK;

--- a/include/grpc++/client_context.h
+++ b/include/grpc++/client_context.h
@@ -185,7 +185,9 @@ class ClientContext {
 
   // Get and set census context
   void set_census_context(struct census_context* ccp) { census_context_ = ccp; }
-  struct census_context* census_context() const { return census_context_; }
+  struct census_context* census_context() const {
+    return census_context_;
+  }
 
   void TryCancel();
 

--- a/include/grpc++/dynamic_thread_pool.h
+++ b/include/grpc++/dynamic_thread_pool.h
@@ -55,11 +55,12 @@ class DynamicThreadPool GRPC_FINAL : public ThreadPoolInterface {
 
  private:
   class DynamicThread {
-  public:
-    DynamicThread(DynamicThreadPool *pool);
+   public:
+    DynamicThread(DynamicThreadPool* pool);
     ~DynamicThread();
-  private:
-    DynamicThreadPool *pool_;
+
+   private:
+    DynamicThreadPool* pool_;
     std::unique_ptr<grpc::thread> thd_;
     void ThreadFunc();
   };

--- a/include/grpc++/generic_stub.h
+++ b/include/grpc++/generic_stub.h
@@ -52,8 +52,8 @@ class GenericStub GRPC_FINAL {
 
   // begin a call to a named method
   std::unique_ptr<GenericClientAsyncReaderWriter> Call(
-      ClientContext* context, const grpc::string& method,
-      CompletionQueue* cq, void* tag);
+      ClientContext* context, const grpc::string& method, CompletionQueue* cq,
+      void* tag);
 
  private:
   std::shared_ptr<ChannelInterface> channel_;

--- a/include/grpc++/impl/call.h
+++ b/include/grpc++/impl/call.h
@@ -67,14 +67,10 @@ class WriteOptions {
   WriteOptions(const WriteOptions& other) : flags_(other.flags_) {}
 
   /// Clear all flags.
-  inline void Clear() {
-    flags_ = 0;
-  }
+  inline void Clear() { flags_ = 0; }
 
   /// Returns raw flags bitset.
-  inline gpr_uint32 flags() const {
-    return flags_;
-  }
+  inline gpr_uint32 flags() const { return flags_; }
 
   /// Sets flag for the disabling of compression for the next message write.
   ///
@@ -122,9 +118,7 @@ class WriteOptions {
   /// not go out on the wire immediately.
   ///
   /// \sa GRPC_WRITE_BUFFER_HINT
-  inline bool get_buffer_hint() const {
-    return GetBit(GRPC_WRITE_BUFFER_HINT);
-  }
+  inline bool get_buffer_hint() const { return GetBit(GRPC_WRITE_BUFFER_HINT); }
 
   WriteOptions& operator=(const WriteOptions& rhs) {
     flags_ = rhs.flags_;
@@ -132,17 +126,11 @@ class WriteOptions {
   }
 
  private:
-  void SetBit(const gpr_int32 mask) {
-    flags_ |= mask;
-  }
+  void SetBit(const gpr_int32 mask) { flags_ |= mask; }
 
-  void ClearBit(const gpr_int32 mask) {
-    flags_ &= ~mask;
-  }
+  void ClearBit(const gpr_int32 mask) { flags_ &= ~mask; }
 
-  bool GetBit(const gpr_int32 mask) const {
-    return flags_ & mask;
-  }
+  bool GetBit(const gpr_int32 mask) const { return flags_ & mask; }
 
   gpr_uint32 flags_;
 };

--- a/include/grpc++/impl/grpc_library.h
+++ b/include/grpc++/impl/grpc_library.h
@@ -46,5 +46,4 @@ class GrpcLibrary {
 
 }  // namespace grpc
 
-
 #endif  // GRPCXX_IMPL_GRPC_LIBRARY_H

--- a/include/grpc++/impl/serialization_traits.h
+++ b/include/grpc++/impl/serialization_traits.h
@@ -37,12 +37,12 @@
 namespace grpc {
 
 /// Defines how to serialize and deserialize some type.
-/// 
+///
 /// Used for hooking different message serialization API's into GRPC.
 /// Each SerializationTraits implementation must provide the following
 /// functions:
 ///   static Status Serialize(const Message& msg,
-///                           grpc_byte_buffer** buffer, 
+///                           grpc_byte_buffer** buffer,
 //                            bool* own_buffer);
 ///   static Status Deserialize(grpc_byte_buffer* buffer,
 ///                             Message* msg,
@@ -57,7 +57,7 @@ namespace grpc {
 /// msg. max_message_size is passed in as a bound on the maximum number of
 /// message bytes Deserialize should accept.
 ///
-/// Both functions return a Status, allowing them to explain what went 
+/// Both functions return a Status, allowing them to explain what went
 /// wrong if required.
 template <class Message,
           class UnusedButHereForPartialTemplateSpecialization = void>

--- a/include/grpc++/impl/sync_no_cxx11.h
+++ b/include/grpc++/impl/sync_no_cxx11.h
@@ -38,7 +38,7 @@
 
 namespace grpc {
 
-template<class mutex>
+template <class mutex>
 class lock_guard;
 class condition_variable;
 
@@ -46,6 +46,7 @@ class mutex {
  public:
   mutex() { gpr_mu_init(&mu_); }
   ~mutex() { gpr_mu_destroy(&mu_); }
+
  private:
   ::gpr_mu mu_;
   template <class mutex>
@@ -58,6 +59,7 @@ class lock_guard {
  public:
   lock_guard(mutex &mu) : mu_(mu), locked(true) { gpr_mu_lock(&mu.mu_); }
   ~lock_guard() { unlock_internal(); }
+
  protected:
   void lock_internal() {
     if (!locked) gpr_mu_lock(&mu_.mu_);
@@ -67,6 +69,7 @@ class lock_guard {
     if (locked) gpr_mu_unlock(&mu_.mu_);
     locked = false;
   }
+
  private:
   mutex &mu_;
   bool locked;
@@ -76,7 +79,7 @@ class lock_guard {
 template <class mutex>
 class unique_lock : public lock_guard<mutex> {
  public:
-  unique_lock(mutex &mu) : lock_guard<mutex>(mu) { }
+  unique_lock(mutex &mu) : lock_guard<mutex>(mu) {}
   void lock() { this->lock_internal(); }
   void unlock() { this->unlock_internal(); }
 };
@@ -92,6 +95,7 @@ class condition_variable {
   }
   void notify_one() { gpr_cv_signal(&cv_); }
   void notify_all() { gpr_cv_broadcast(&cv_); }
+
  private:
   gpr_cv cv_;
 };

--- a/include/grpc++/impl/thd_no_cxx11.h
+++ b/include/grpc++/impl/thd_no_cxx11.h
@@ -40,7 +40,8 @@ namespace grpc {
 
 class thread {
  public:
-  template<class T> thread(void (T::*fptr)(), T *obj) {
+  template <class T>
+  thread(void (T::*fptr)(), T *obj) {
     func_ = new thread_function<T>(fptr, obj);
     joined_ = false;
     start();
@@ -53,28 +54,28 @@ class thread {
     gpr_thd_join(thd_);
     joined_ = true;
   }
+
  private:
   void start() {
     gpr_thd_options options = gpr_thd_options_default();
     gpr_thd_options_set_joinable(&options);
-    gpr_thd_new(&thd_, thread_func, (void *) func_, &options);
+    gpr_thd_new(&thd_, thread_func, (void *)func_, &options);
   }
   static void thread_func(void *arg) {
-    thread_function_base *func = (thread_function_base *) arg;
+    thread_function_base *func = (thread_function_base *)arg;
     func->call();
   }
   class thread_function_base {
    public:
-    virtual ~thread_function_base() { }
+    virtual ~thread_function_base() {}
     virtual void call() = 0;
   };
-  template<class T>
+  template <class T>
   class thread_function : public thread_function_base {
    public:
-    thread_function(void (T::*fptr)(), T *obj)
-      : fptr_(fptr)
-      , obj_(obj) { }
+    thread_function(void (T::*fptr)(), T *obj) : fptr_(fptr), obj_(obj) {}
     virtual void call() { (obj_->*fptr_)(); }
+
    private:
     void (T::*fptr_)();
     T *obj_;
@@ -84,8 +85,8 @@ class thread {
   bool joined_;
 
   // Disallow copy and assign.
-  thread(const thread&);
-  void operator=(const thread&);
+  thread(const thread &);
+  void operator=(const thread &);
 };
 
 }  // namespace grpc

--- a/include/grpc++/server.h
+++ b/include/grpc++/server.h
@@ -84,8 +84,9 @@ class Server GRPC_FINAL : public GrpcLibrary, private CallHook {
          int max_message_size);
   // Register a service. This call does not take ownership of the service.
   // The service must exist for the lifetime of the Server instance.
-  bool RegisterService(const grpc::string *host, RpcService* service);
-  bool RegisterAsyncService(const grpc::string *host, AsynchronousService* service);
+  bool RegisterService(const grpc::string* host, RpcService* service);
+  bool RegisterAsyncService(const grpc::string* host,
+                            AsynchronousService* service);
   void RegisterAsyncGenericService(AsyncGenericService* service);
   // Add a listening port. Can be called multiple times.
   int AddListeningPort(const grpc::string& addr, ServerCredentials* creds);

--- a/include/grpc++/server_builder.h
+++ b/include/grpc++/server_builder.h
@@ -76,15 +76,14 @@ class ServerBuilder {
   // The service must exist for the lifetime of the Server instance returned by
   // BuildAndStart().
   // Only matches requests with :authority \a host
-  void RegisterService(const grpc::string& host, 
-                       SynchronousService* service);
+  void RegisterService(const grpc::string& host, SynchronousService* service);
 
   // Register an asynchronous service.
   // This call does not take ownership of the service or completion queue.
   // The service and completion queuemust exist for the lifetime of the Server
   // instance returned by BuildAndStart().
   // Only matches requests with :authority \a host
-  void RegisterAsyncService(const grpc::string& host, 
+  void RegisterAsyncService(const grpc::string& host,
                             AsynchronousService* service);
 
   // Set max message size in bytes.
@@ -117,9 +116,10 @@ class ServerBuilder {
   };
 
   typedef std::unique_ptr<grpc::string> HostString;
-  template <class T> struct NamedService {
+  template <class T>
+  struct NamedService {
     explicit NamedService(T* s) : service(s) {}
-    NamedService(const grpc::string& h, T *s)
+    NamedService(const grpc::string& h, T* s)
         : host(new grpc::string(h)), service(s) {}
     HostString host;
     T* service;
@@ -127,7 +127,8 @@ class ServerBuilder {
 
   int max_message_size_;
   std::vector<std::unique_ptr<NamedService<RpcService>>> services_;
-  std::vector<std::unique_ptr<NamedService<AsynchronousService>>> async_services_;
+  std::vector<std::unique_ptr<NamedService<AsynchronousService>>>
+      async_services_;
   std::vector<Port> ports_;
   std::vector<ServerCompletionQueue*> cqs_;
   std::shared_ptr<ServerCredentials> creds_;

--- a/include/grpc++/stream.h
+++ b/include/grpc++/stream.h
@@ -85,9 +85,7 @@ class WriterInterface {
   // Returns false when the stream has been closed.
   virtual bool Write(const W& msg, const WriteOptions& options) = 0;
 
-  inline bool Write(const W& msg) {
-    return Write(msg, WriteOptions());
-  }
+  inline bool Write(const W& msg) { return Write(msg, WriteOptions()); }
 };
 
 template <class R>
@@ -640,9 +638,8 @@ class ServerAsyncReader GRPC_FINAL : public ServerAsyncStreamingInterface,
     }
     // The response is dropped if the status is not OK.
     if (status.ok()) {
-      finish_ops_.ServerSendStatus(
-          ctx_->trailing_metadata_,
-          finish_ops_.SendMessage(msg));
+      finish_ops_.ServerSendStatus(ctx_->trailing_metadata_,
+                                   finish_ops_.SendMessage(msg));
     } else {
       finish_ops_.ServerSendStatus(ctx_->trailing_metadata_, status);
     }

--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -378,11 +378,11 @@ typedef struct grpc_op {
 
 /** Registers a plugin to be initialized and destroyed with the library.
 
-    The \a init and \a destroy functions will be invoked as part of 
-    \a grpc_init() and \a grpc_shutdown(), respectively. 
+    The \a init and \a destroy functions will be invoked as part of
+    \a grpc_init() and \a grpc_shutdown(), respectively.
     Note that these functions can be invoked an arbitrary number of times
     (and hence so will \a init and \a destroy).
-    It is safe to pass NULL to either argument. Plugins are destroyed in 
+    It is safe to pass NULL to either argument. Plugins are destroyed in
     the reverse order they were initialized. */
 void grpc_register_plugin(void (*init)(void), void (*destroy)(void));
 
@@ -629,8 +629,7 @@ grpc_call_error grpc_server_request_registered_call(
     be specified with args. If no additional configuration is needed, args can
     be NULL. See grpc_channel_args for more. The data in 'args' need only live
     through the invocation of this function. */
-grpc_server *grpc_server_create(const grpc_channel_args *args,
-                                void *reserved);
+grpc_server *grpc_server_create(const grpc_channel_args *args, void *reserved);
 
 /** Register a completion queue with the server. Must be done for any
     notification completion queue that is passed to grpc_server_request_*_call

--- a/include/grpc/status.h
+++ b/include/grpc/status.h
@@ -160,4 +160,4 @@ typedef enum {
 }
 #endif
 
-#endif  /* GRPC_STATUS_H */
+#endif /* GRPC_STATUS_H */

--- a/include/grpc/support/alloc.h
+++ b/include/grpc/support/alloc.h
@@ -55,4 +55,4 @@ void gpr_free_aligned(void *ptr);
 }
 #endif
 
-#endif  /* GRPC_SUPPORT_ALLOC_H */
+#endif /* GRPC_SUPPORT_ALLOC_H */

--- a/include/grpc/support/atm.h
+++ b/include/grpc/support/atm.h
@@ -89,4 +89,4 @@
 #error could not determine platform for atm
 #endif
 
-#endif  /* GRPC_SUPPORT_ATM_H */
+#endif /* GRPC_SUPPORT_ATM_H */

--- a/include/grpc/support/atm_gcc_atomic.h
+++ b/include/grpc/support/atm_gcc_atomic.h
@@ -69,4 +69,4 @@ static __inline int gpr_atm_rel_cas(gpr_atm *p, gpr_atm o, gpr_atm n) {
                                      __ATOMIC_RELAXED);
 }
 
-#endif  /* GRPC_SUPPORT_ATM_GCC_ATOMIC_H */
+#endif /* GRPC_SUPPORT_ATM_GCC_ATOMIC_H */

--- a/include/grpc/support/atm_gcc_sync.h
+++ b/include/grpc/support/atm_gcc_sync.h
@@ -84,4 +84,4 @@ static __inline void gpr_atm_no_barrier_store(gpr_atm *p, gpr_atm value) {
 #define gpr_atm_acq_cas(p, o, n) (__sync_bool_compare_and_swap((p), (o), (n)))
 #define gpr_atm_rel_cas(p, o, n) gpr_atm_acq_cas((p), (o), (n))
 
-#endif  /* GRPC_SUPPORT_ATM_GCC_SYNC_H */
+#endif /* GRPC_SUPPORT_ATM_GCC_SYNC_H */

--- a/include/grpc/support/atm_win32.h
+++ b/include/grpc/support/atm_win32.h
@@ -66,31 +66,31 @@ static __inline int gpr_atm_no_barrier_cas(gpr_atm *p, gpr_atm o, gpr_atm n) {
 /* InterlockedCompareExchangePointerNoFence() not available on vista or
    windows7 */
 #ifdef GPR_ARCH_64
-  return o == (gpr_atm)InterlockedCompareExchangeAcquire64((volatile LONGLONG *) p,
-                                                           (LONGLONG) n, (LONGLONG) o);
+  return o == (gpr_atm)InterlockedCompareExchangeAcquire64(
+                  (volatile LONGLONG *)p, (LONGLONG)n, (LONGLONG)o);
 #else
-  return o == (gpr_atm)InterlockedCompareExchangeAcquire((volatile LONG *) p,
-                                                         (LONG) n, (LONG) o);
+  return o == (gpr_atm)InterlockedCompareExchangeAcquire((volatile LONG *)p,
+                                                         (LONG)n, (LONG)o);
 #endif
 }
 
 static __inline int gpr_atm_acq_cas(gpr_atm *p, gpr_atm o, gpr_atm n) {
 #ifdef GPR_ARCH_64
-  return o == (gpr_atm)InterlockedCompareExchangeAcquire64((volatile LONGLONG *) p,
-                                                           (LONGLONG) n, (LONGLONG) o);
+  return o == (gpr_atm)InterlockedCompareExchangeAcquire64(
+                  (volatile LONGLONG *)p, (LONGLONG)n, (LONGLONG)o);
 #else
-  return o == (gpr_atm)InterlockedCompareExchangeAcquire((volatile LONG *) p,
-                                                         (LONG) n, (LONG) o);
+  return o == (gpr_atm)InterlockedCompareExchangeAcquire((volatile LONG *)p,
+                                                         (LONG)n, (LONG)o);
 #endif
 }
 
 static __inline int gpr_atm_rel_cas(gpr_atm *p, gpr_atm o, gpr_atm n) {
 #ifdef GPR_ARCH_64
-  return o == (gpr_atm)InterlockedCompareExchangeRelease64((volatile LONGLONG *) p,
-                                                           (LONGLONG) n, (LONGLONG) o);
+  return o == (gpr_atm)InterlockedCompareExchangeRelease64(
+                  (volatile LONGLONG *)p, (LONGLONG)n, (LONGLONG)o);
 #else
-  return o == (gpr_atm)InterlockedCompareExchangeRelease((volatile LONG *) p,
-                                                         (LONG) n, (LONG) o);
+  return o == (gpr_atm)InterlockedCompareExchangeRelease((volatile LONG *)p,
+                                                         (LONG)n, (LONG)o);
 #endif
 }
 
@@ -110,17 +110,16 @@ static __inline gpr_atm gpr_atm_full_fetch_add(gpr_atm *p, gpr_atm delta) {
 #ifdef GPR_ARCH_64
   do {
     old = *p;
-  } while (old != (gpr_atm)InterlockedCompareExchange64((volatile LONGLONG *) p,
-                                                        (LONGLONG) old + delta,
-                                                        (LONGLONG) old));
+  } while (old != (gpr_atm)InterlockedCompareExchange64((volatile LONGLONG *)p,
+                                                        (LONGLONG)old + delta,
+                                                        (LONGLONG)old));
 #else
   do {
     old = *p;
-  } while (old != (gpr_atm)InterlockedCompareExchange((volatile LONG *) p,
-                                                      (LONG) old + delta,
-                                                      (LONG) old));
+  } while (old != (gpr_atm)InterlockedCompareExchange(
+                      (volatile LONG *)p, (LONG)old + delta, (LONG)old));
 #endif
   return old;
 }
 
-#endif  /* GRPC_SUPPORT_ATM_WIN32_H */
+#endif /* GRPC_SUPPORT_ATM_WIN32_H */

--- a/include/grpc/support/cmdline.h
+++ b/include/grpc/support/cmdline.h
@@ -94,4 +94,4 @@ char *gpr_cmdline_usage_string(gpr_cmdline *cl, const char *argv0);
 }
 #endif
 
-#endif  /* GRPC_SUPPORT_CMDLINE_H */
+#endif /* GRPC_SUPPORT_CMDLINE_H */

--- a/include/grpc/support/cpu.h
+++ b/include/grpc/support/cpu.h
@@ -54,4 +54,4 @@ unsigned gpr_cpu_current_cpu(void);
 }  // extern "C"
 #endif
 
-#endif  /* GRPC_SUPPORT_CPU_H */
+#endif /* GRPC_SUPPORT_CPU_H */

--- a/include/grpc/support/histogram.h
+++ b/include/grpc/support/histogram.h
@@ -73,4 +73,4 @@ void gpr_histogram_merge_contents(gpr_histogram *histogram,
 }
 #endif
 
-#endif  /* GRPC_SUPPORT_HISTOGRAM_H */
+#endif /* GRPC_SUPPORT_HISTOGRAM_H */

--- a/include/grpc/support/host_port.h
+++ b/include/grpc/support/host_port.h
@@ -61,4 +61,4 @@ int gpr_split_host_port(const char *name, char **host, char **port);
 }
 #endif
 
-#endif  /* GRPC_SUPPORT_HOST_PORT_H */
+#endif /* GRPC_SUPPORT_HOST_PORT_H */

--- a/include/grpc/support/log.h
+++ b/include/grpc/support/log.h
@@ -105,4 +105,4 @@ void gpr_set_log_function(gpr_log_func func);
 }
 #endif
 
-#endif  /* GRPC_SUPPORT_LOG_H */
+#endif /* GRPC_SUPPORT_LOG_H */

--- a/include/grpc/support/log_win32.h
+++ b/include/grpc/support/log_win32.h
@@ -48,4 +48,4 @@ char *gpr_format_message(DWORD messageid);
 }
 #endif
 
-#endif  /* GRPC_SUPPORT_LOG_WIN32_H */
+#endif /* GRPC_SUPPORT_LOG_WIN32_H */

--- a/include/grpc/support/port_platform.h
+++ b/include/grpc/support/port_platform.h
@@ -64,7 +64,8 @@
 #undef GRPC_NOMINMAX_WAS_NOT_DEFINED
 #undef NOMINMAX
 #endif /* GRPC_WIN32_LEAN_AND_MEAN_WAS_NOT_DEFINED */
-#endif /* defined(_WIN64) || defined(WIN64) || defined(_WIN32) || defined(WIN32) */
+#endif /* defined(_WIN64) || defined(WIN64) || defined(_WIN32) || \
+          defined(WIN32) */
 
 /* Override this file with one for your platform if you need to redefine
    things.  */

--- a/include/grpc/support/slice.h
+++ b/include/grpc/support/slice.h
@@ -96,7 +96,7 @@ typedef struct gpr_slice {
 #define GPR_SLICE_LENGTH(slice)                      \
   ((slice).refcount ? (slice).data.refcounted.length \
                     : (slice).data.inlined.length)
-#define GPR_SLICE_SET_LENGTH(slice, newlen)                       \
+#define GPR_SLICE_SET_LENGTH(slice, newlen)                               \
   ((slice).refcount ? ((slice).data.refcounted.length = (size_t)(newlen)) \
                     : ((slice).data.inlined.length = (gpr_uint8)(newlen)))
 #define GPR_SLICE_END_PTR(slice) \

--- a/include/grpc/support/string_util.h
+++ b/include/grpc/support/string_util.h
@@ -58,4 +58,4 @@ int gpr_asprintf(char **strp, const char *format, ...);
 }
 #endif
 
-#endif  /* GRPC_SUPPORT_STRING_UTIL_H */
+#endif /* GRPC_SUPPORT_STRING_UTIL_H */

--- a/include/grpc/support/subprocess.h
+++ b/include/grpc/support/subprocess.h
@@ -36,7 +36,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif	
+#endif
 
 typedef struct gpr_subprocess gpr_subprocess;
 

--- a/include/grpc/support/sync.h
+++ b/include/grpc/support/sync.h
@@ -312,4 +312,4 @@ gpr_intptr gpr_stats_read(const gpr_stats_counter *c);
 }
 #endif
 
-#endif  /* GRPC_SUPPORT_SYNC_H */
+#endif /* GRPC_SUPPORT_SYNC_H */

--- a/include/grpc/support/sync_generic.h
+++ b/include/grpc/support/sync_generic.h
@@ -38,24 +38,18 @@
 #include <grpc/support/atm.h>
 
 /* gpr_event */
-typedef struct {
-  gpr_atm state;
-} gpr_event;
+typedef struct { gpr_atm state; } gpr_event;
 
 #define GPR_EVENT_INIT \
   { 0 }
 
 /* gpr_refcount */
-typedef struct {
-  gpr_atm count;
-} gpr_refcount;
+typedef struct { gpr_atm count; } gpr_refcount;
 
 /* gpr_stats_counter */
-typedef struct {
-  gpr_atm value;
-} gpr_stats_counter;
+typedef struct { gpr_atm value; } gpr_stats_counter;
 
 #define GPR_STATS_INIT \
   { 0 }
 
-#endif  /* GRPC_SUPPORT_SYNC_GENERIC_H */
+#endif /* GRPC_SUPPORT_SYNC_GENERIC_H */

--- a/include/grpc/support/sync_posix.h
+++ b/include/grpc/support/sync_posix.h
@@ -44,4 +44,4 @@ typedef pthread_once_t gpr_once;
 
 #define GPR_ONCE_INIT PTHREAD_ONCE_INIT
 
-#endif  /* GRPC_SUPPORT_SYNC_POSIX_H */
+#endif /* GRPC_SUPPORT_SYNC_POSIX_H */

--- a/include/grpc/support/sync_win32.h
+++ b/include/grpc/support/sync_win32.h
@@ -46,4 +46,4 @@ typedef CONDITION_VARIABLE gpr_cv;
 typedef INIT_ONCE gpr_once;
 #define GPR_ONCE_INIT INIT_ONCE_STATIC_INIT
 
-#endif  /* GRPC_SUPPORT_SYNC_WIN32_H */
+#endif /* GRPC_SUPPORT_SYNC_WIN32_H */

--- a/include/grpc/support/thd.h
+++ b/include/grpc/support/thd.h
@@ -88,4 +88,4 @@ void gpr_thd_join(gpr_thd_id t);
 }
 #endif
 
-#endif  /* GRPC_SUPPORT_THD_H */
+#endif /* GRPC_SUPPORT_THD_H */

--- a/include/grpc/support/time.h
+++ b/include/grpc/support/time.h
@@ -84,7 +84,8 @@ void gpr_time_init(void);
 gpr_timespec gpr_now(gpr_clock_type clock);
 
 /* Convert a timespec from one clock to another */
-gpr_timespec gpr_convert_clock_type(gpr_timespec t, gpr_clock_type target_clock);
+gpr_timespec gpr_convert_clock_type(gpr_timespec t,
+                                    gpr_clock_type target_clock);
 
 /* Return -ve, 0, or +ve according to whether a < b, a == b, or a > b
    respectively.  */

--- a/include/grpc/support/tls.h
+++ b/include/grpc/support/tls.h
@@ -47,7 +47,7 @@
      GPR_TLS_DECL(foo);
    Thread locals always have static scope.
 
-   Initializing a thread local (must be done at library initialization 
+   Initializing a thread local (must be done at library initialization
    time):
      gpr_tls_init(&foo);
 
@@ -58,7 +58,7 @@
      gpr_tls_set(&foo, new_value);
 
    Accessing a thread local:
-     current_value = gpr_tls_get(&foo, value); 
+     current_value = gpr_tls_get(&foo, value);
 
    ALL functions here may be implemented as macros. */
 

--- a/include/grpc/support/tls_gcc.h
+++ b/include/grpc/support/tls_gcc.h
@@ -42,10 +42,14 @@ struct gpr_gcc_thread_local {
 };
 
 #define GPR_TLS_DECL(name) \
-    static __thread struct gpr_gcc_thread_local name = {0}
+  static __thread struct gpr_gcc_thread_local name = {0}
 
-#define gpr_tls_init(tls) do {} while (0)
-#define gpr_tls_destroy(tls) do {} while (0)
+#define gpr_tls_init(tls) \
+  do {                    \
+  } while (0)
+#define gpr_tls_destroy(tls) \
+  do {                       \
+  } while (0)
 #define gpr_tls_set(tls, new_value) (((tls)->value) = (new_value))
 #define gpr_tls_get(tls) ((tls)->value)
 

--- a/include/grpc/support/tls_msvc.h
+++ b/include/grpc/support/tls_msvc.h
@@ -42,10 +42,14 @@ struct gpr_msvc_thread_local {
 };
 
 #define GPR_TLS_DECL(name) \
-    static __declspec(thread) struct gpr_msvc_thread_local name = {0}
+  static __declspec(thread) struct gpr_msvc_thread_local name = {0}
 
-#define gpr_tls_init(tls) do {} while (0)
-#define gpr_tls_destroy(tls) do {} while (0)
+#define gpr_tls_init(tls) \
+  do {                    \
+  } while (0)
+#define gpr_tls_destroy(tls) \
+  do {                       \
+  } while (0)
 #define gpr_tls_set(tls, new_value) (((tls)->value) = (new_value))
 #define gpr_tls_get(tls) ((tls)->value)
 

--- a/include/grpc/support/useful.h
+++ b/include/grpc/support/useful.h
@@ -46,10 +46,10 @@
 #define GPR_ARRAY_SIZE(array) (sizeof(array) / sizeof(*(array)))
 
 #define GPR_SWAP(type, a, b) \
-  do {                   \
-    type x = a;          \
-    a = b;               \
-    b = x;               \
+  do {                       \
+    type x = a;              \
+    a = b;                   \
+    b = x;                   \
   } while (0)
 
 /** Set the \a n-th bit of \a i (a mutable pointer). */
@@ -72,4 +72,4 @@
     0x0f0f0f0f) %                                \
    255)
 
-#endif  /* GRPC_SUPPORT_USEFUL_H */
+#endif /* GRPC_SUPPORT_USEFUL_H */

--- a/src/core/channel/census_filter.h
+++ b/src/core/channel/census_filter.h
@@ -41,4 +41,4 @@
 extern const grpc_channel_filter grpc_client_census_filter;
 extern const grpc_channel_filter grpc_server_census_filter;
 
-#endif  /* GRPC_INTERNAL_CORE_CHANNEL_CENSUS_FILTER_H */
+#endif /* GRPC_INTERNAL_CORE_CHANNEL_CENSUS_FILTER_H */

--- a/src/core/channel/client_channel.c
+++ b/src/core/channel/client_channel.c
@@ -84,8 +84,10 @@ typedef struct {
   grpc_pollset_set pollset_set;
 } channel_data;
 
-/** We create one watcher for each new lb_policy that is returned from a resolver,
-    to watch for state changes from the lb_policy. When a state change is seen, we
+/** We create one watcher for each new lb_policy that is returned from a
+   resolver,
+    to watch for state changes from the lb_policy. When a state change is seen,
+   we
     update the channel, and create a new watcher */
 typedef struct {
   channel_data *chand;
@@ -380,7 +382,8 @@ static void perform_transport_stream_op(grpc_call_element *elem,
           if (lb_policy) {
             grpc_transport_stream_op *op = &calld->waiting_op;
             grpc_pollset *bind_pollset = op->bind_pollset;
-            grpc_metadata_batch *initial_metadata = &op->send_ops->ops[0].data.metadata;
+            grpc_metadata_batch *initial_metadata =
+                &op->send_ops->ops[0].data.metadata;
             GRPC_LB_POLICY_REF(lb_policy, "pick");
             gpr_mu_unlock(&chand->mu_config);
             calld->state = CALL_WAITING_FOR_PICK;
@@ -388,13 +391,14 @@ static void perform_transport_stream_op(grpc_call_element *elem,
             GPR_ASSERT(op->bind_pollset);
             GPR_ASSERT(op->send_ops);
             GPR_ASSERT(op->send_ops->nops >= 1);
-            GPR_ASSERT(
-                op->send_ops->ops[0].type == GRPC_OP_METADATA);
+            GPR_ASSERT(op->send_ops->ops[0].type == GRPC_OP_METADATA);
             gpr_mu_unlock(&calld->mu_state);
 
-            grpc_iomgr_closure_init(&calld->async_setup_task, picked_target, calld);
+            grpc_iomgr_closure_init(&calld->async_setup_task, picked_target,
+                                    calld);
             grpc_lb_policy_pick(lb_policy, bind_pollset, initial_metadata,
-                                &calld->picked_channel, &calld->async_setup_task);
+                                &calld->picked_channel,
+                                &calld->async_setup_task);
 
             GRPC_LB_POLICY_UNREF(lb_policy, "pick");
           } else if (chand->resolver != NULL) {
@@ -430,7 +434,8 @@ static void cc_start_transport_stream_op(grpc_call_element *elem,
   perform_transport_stream_op(elem, op, 0);
 }
 
-static void watch_lb_policy(channel_data *chand, grpc_lb_policy *lb_policy, grpc_connectivity_state current_state);
+static void watch_lb_policy(channel_data *chand, grpc_lb_policy *lb_policy,
+                            grpc_connectivity_state current_state);
 
 static void on_lb_policy_state_changed(void *arg, int iomgr_success) {
   lb_policy_connectivity_watcher *w = arg;
@@ -450,7 +455,8 @@ static void on_lb_policy_state_changed(void *arg, int iomgr_success) {
   gpr_free(w);
 }
 
-static void watch_lb_policy(channel_data *chand, grpc_lb_policy *lb_policy, grpc_connectivity_state current_state) {
+static void watch_lb_policy(channel_data *chand, grpc_lb_policy *lb_policy,
+                            grpc_connectivity_state current_state) {
   lb_policy_connectivity_watcher *w = gpr_malloc(sizeof(*w));
   GRPC_CHANNEL_INTERNAL_REF(chand->master, "watch_lb_policy");
 
@@ -663,7 +669,8 @@ static void init_channel_elem(grpc_channel_element *elem, grpc_channel *master,
   grpc_iomgr_closure_init(&chand->on_config_changed, cc_on_config_changed,
                           chand);
 
-  grpc_connectivity_state_init(&chand->state_tracker, GRPC_CHANNEL_IDLE, "client_channel");
+  grpc_connectivity_state_init(&chand->state_tracker, GRPC_CHANNEL_IDLE,
+                               "client_channel");
 }
 
 /* Destructor for channel_data */
@@ -747,19 +754,20 @@ void grpc_client_channel_watch_connectivity_state(
   gpr_mu_unlock(&chand->mu_config);
 }
 
-grpc_pollset_set *grpc_client_channel_get_connecting_pollset_set(grpc_channel_element *elem) {
+grpc_pollset_set *grpc_client_channel_get_connecting_pollset_set(
+    grpc_channel_element *elem) {
   channel_data *chand = elem->channel_data;
   return &chand->pollset_set;
 }
 
 void grpc_client_channel_add_interested_party(grpc_channel_element *elem,
-                                          grpc_pollset *pollset) {
+                                              grpc_pollset *pollset) {
   channel_data *chand = elem->channel_data;
   grpc_pollset_set_add_pollset(&chand->pollset_set, pollset);
 }
 
 void grpc_client_channel_del_interested_party(grpc_channel_element *elem,
-                                          grpc_pollset *pollset) {
+                                              grpc_pollset *pollset) {
   channel_data *chand = elem->channel_data;
   grpc_pollset_set_del_pollset(&chand->pollset_set, pollset);
 }

--- a/src/core/channel/client_channel.h
+++ b/src/core/channel/client_channel.h
@@ -59,11 +59,12 @@ void grpc_client_channel_watch_connectivity_state(
     grpc_channel_element *elem, grpc_connectivity_state *state,
     grpc_iomgr_closure *on_complete);
 
-grpc_pollset_set *grpc_client_channel_get_connecting_pollset_set(grpc_channel_element *elem);
+grpc_pollset_set *grpc_client_channel_get_connecting_pollset_set(
+    grpc_channel_element *elem);
 
 void grpc_client_channel_add_interested_party(grpc_channel_element *channel,
-                                          grpc_pollset *pollset);
+                                              grpc_pollset *pollset);
 void grpc_client_channel_del_interested_party(grpc_channel_element *channel,
-                                          grpc_pollset *pollset);
+                                              grpc_pollset *pollset);
 
 #endif /* GRPC_INTERNAL_CORE_CHANNEL_CLIENT_CHANNEL_H */

--- a/src/core/channel/compress_filter.c
+++ b/src/core/channel/compress_filter.c
@@ -53,7 +53,7 @@ typedef struct call_data {
   /** Compression algorithm we'll try to use. It may be given by incoming
    * metadata, or by the channel's default compression settings. */
   grpc_compression_algorithm compression_algorithm;
-   /** If true, contents of \a compression_algorithm are authoritative */
+  /** If true, contents of \a compression_algorithm are authoritative */
   int has_compression_algorithm;
 } call_data;
 
@@ -78,7 +78,7 @@ typedef struct channel_data {
  *
  * Returns 1 if the data was actually compress and 0 otherwise. */
 static int compress_send_sb(grpc_compression_algorithm algorithm,
-                             gpr_slice_buffer *slices) {
+                            gpr_slice_buffer *slices) {
   int did_compress;
   gpr_slice_buffer tmp;
   gpr_slice_buffer_init(&tmp);
@@ -93,7 +93,7 @@ static int compress_send_sb(grpc_compression_algorithm algorithm,
 /** For each \a md element from the incoming metadata, filter out the entry for
  * "grpc-encoding", using its value to populate the call data's
  * compression_algorithm field. */
-static grpc_mdelem* compression_md_filter(void *user_data, grpc_mdelem *md) {
+static grpc_mdelem *compression_md_filter(void *user_data, grpc_mdelem *md) {
   grpc_call_element *elem = user_data;
   call_data *calld = elem->call_data;
   channel_data *channeld = elem->channel_data;
@@ -115,10 +115,10 @@ static grpc_mdelem* compression_md_filter(void *user_data, grpc_mdelem *md) {
 
 static int skip_compression(channel_data *channeld, call_data *calld) {
   if (calld->has_compression_algorithm) {
-     if (calld->compression_algorithm == GRPC_COMPRESS_NONE) {
-       return 1;
-     }
-     return 0;  /* we have an actual call-specific algorithm */
+    if (calld->compression_algorithm == GRPC_COMPRESS_NONE) {
+      return 1;
+    }
+    return 0; /* we have an actual call-specific algorithm */
   }
   /* no per-call compression override */
   return channeld->default_compression_algorithm == GRPC_COMPRESS_NONE;
@@ -191,7 +191,7 @@ static void process_send_ops(grpc_call_element *elem,
          * given by GRPC_OP_BEGIN_MESSAGE) */
         calld->remaining_slice_bytes = sop->data.begin_message.length;
         if (sop->data.begin_message.flags & GRPC_WRITE_NO_COMPRESS) {
-          calld->has_compression_algorithm = 1;  /* GPR_TRUE */
+          calld->has_compression_algorithm = 1; /* GPR_TRUE */
           calld->compression_algorithm = GRPC_COMPRESS_NONE;
         }
         break;
@@ -293,7 +293,7 @@ static void init_channel_elem(grpc_channel_element *elem, grpc_channel *master,
                               int is_first, int is_last) {
   channel_data *channeld = elem->channel_data;
   grpc_compression_algorithm algo_idx;
-  const char* supported_algorithms_names[GRPC_COMPRESS_ALGORITHMS_COUNT-1];
+  const char *supported_algorithms_names[GRPC_COMPRESS_ALGORITHMS_COUNT - 1];
   char *accept_encoding_str;
   size_t accept_encoding_str_len;
 
@@ -318,23 +318,19 @@ static void init_channel_elem(grpc_channel_element *elem, grpc_channel *master,
             GRPC_MDSTR_REF(channeld->mdstr_outgoing_compression_algorithm_key),
             grpc_mdstr_from_string(mdctx, algorithm_name, 0));
     if (algo_idx > 0) {
-      supported_algorithms_names[algo_idx-1] = algorithm_name;
+      supported_algorithms_names[algo_idx - 1] = algorithm_name;
     }
   }
 
   /* TODO(dgq): gpr_strjoin_sep could be made to work with statically allocated
    * arrays, as to avoid the heap allocs */
-  accept_encoding_str =
-      gpr_strjoin_sep(supported_algorithms_names,
-                  GPR_ARRAY_SIZE(supported_algorithms_names),
-                  ", ",
-                  &accept_encoding_str_len);
+  accept_encoding_str = gpr_strjoin_sep(
+      supported_algorithms_names, GPR_ARRAY_SIZE(supported_algorithms_names),
+      ", ", &accept_encoding_str_len);
 
-  channeld->mdelem_accept_encoding =
-      grpc_mdelem_from_metadata_strings(
-          mdctx,
-          GRPC_MDSTR_REF(channeld->mdstr_compression_capabilities_key),
-          grpc_mdstr_from_string(mdctx, accept_encoding_str, 0));
+  channeld->mdelem_accept_encoding = grpc_mdelem_from_metadata_strings(
+      mdctx, GRPC_MDSTR_REF(channeld->mdstr_compression_capabilities_key),
+      grpc_mdstr_from_string(mdctx, accept_encoding_str, 0));
   gpr_free(accept_encoding_str);
 
   GPR_ASSERT(!is_last);
@@ -348,8 +344,7 @@ static void destroy_channel_elem(grpc_channel_element *elem) {
   GRPC_MDSTR_UNREF(channeld->mdstr_request_compression_algorithm_key);
   GRPC_MDSTR_UNREF(channeld->mdstr_outgoing_compression_algorithm_key);
   GRPC_MDSTR_UNREF(channeld->mdstr_compression_capabilities_key);
-  for (algo_idx = 0; algo_idx < GRPC_COMPRESS_ALGORITHMS_COUNT;
-       ++algo_idx) {
+  for (algo_idx = 0; algo_idx < GRPC_COMPRESS_ALGORITHMS_COUNT; ++algo_idx) {
     GRPC_MDELEM_UNREF(channeld->mdelem_compression_algorithms[algo_idx]);
   }
   GRPC_MDELEM_UNREF(channeld->mdelem_accept_encoding);

--- a/src/core/channel/compress_filter.h
+++ b/src/core/channel/compress_filter.h
@@ -62,4 +62,4 @@
 
 extern const grpc_channel_filter grpc_compress_filter;
 
-#endif  /* GRPC_INTERNAL_CORE_CHANNEL_COMPRESS_FILTER_H */
+#endif /* GRPC_INTERNAL_CORE_CHANNEL_COMPRESS_FILTER_H */

--- a/src/core/channel/http_client_filter.h
+++ b/src/core/channel/http_client_filter.h
@@ -41,4 +41,4 @@ extern const grpc_channel_filter grpc_http_client_filter;
 
 #define GRPC_ARG_HTTP2_SCHEME "grpc.http2_scheme"
 
-#endif  /* GRPC_INTERNAL_CORE_CHANNEL_HTTP_CLIENT_FILTER_H */
+#endif /* GRPC_INTERNAL_CORE_CHANNEL_HTTP_CLIENT_FILTER_H */

--- a/src/core/channel/http_server_filter.h
+++ b/src/core/channel/http_server_filter.h
@@ -39,4 +39,4 @@
 /* Processes metadata on the client side for HTTP2 transports */
 extern const grpc_channel_filter grpc_http_server_filter;
 
-#endif  /* GRPC_INTERNAL_CORE_CHANNEL_HTTP_SERVER_FILTER_H */
+#endif /* GRPC_INTERNAL_CORE_CHANNEL_HTTP_SERVER_FILTER_H */

--- a/src/core/channel/noop_filter.h
+++ b/src/core/channel/noop_filter.h
@@ -41,4 +41,4 @@
    customize for their own filters */
 extern const grpc_channel_filter grpc_no_op_filter;
 
-#endif  /* GRPC_INTERNAL_CORE_CHANNEL_NOOP_FILTER_H */
+#endif /* GRPC_INTERNAL_CORE_CHANNEL_NOOP_FILTER_H */

--- a/src/core/client_config/resolvers/dns_resolver.c
+++ b/src/core/client_config/resolvers/dns_resolver.c
@@ -219,7 +219,8 @@ static grpc_resolver *dns_create(
   default_host_arg.type = GRPC_ARG_STRING;
   default_host_arg.key = GRPC_ARG_DEFAULT_AUTHORITY;
   default_host_arg.value.string = host;
-  subchannel_factory = grpc_subchannel_factory_add_channel_arg(subchannel_factory, &default_host_arg);
+  subchannel_factory = grpc_subchannel_factory_add_channel_arg(
+      subchannel_factory, &default_host_arg);
 
   gpr_free(host);
   gpr_free(port);

--- a/src/core/client_config/resolvers/zookeeper_resolver.c
+++ b/src/core/client_config/resolvers/zookeeper_resolver.c
@@ -142,7 +142,7 @@ static void zookeeper_next(grpc_resolver *resolver,
   gpr_mu_unlock(&r->mu);
 }
 
-/** Zookeeper global watcher for connection management 
+/** Zookeeper global watcher for connection management
     TODO: better connection management besides logs */
 static void zookeeper_global_watcher(zhandle_t *zookeeper_handle, int type,
                                      int state, const char *path,
@@ -172,7 +172,7 @@ static void zookeeper_watcher(zhandle_t *zookeeper_handle, int type, int state,
   }
 }
 
-/** Callback function after getting all resolved addresses  
+/** Callback function after getting all resolved addresses
     Creates a subchannel for each address */
 static void zookeeper_on_resolved(void *arg,
                                   grpc_resolved_addresses *addresses) {
@@ -249,7 +249,7 @@ static char *zookeeper_parse_address(const char *value, int value_len) {
   grpc_json *cur;
   const char *host;
   const char *port;
-  char* buffer;
+  char *buffer;
   char *address = NULL;
 
   buffer = gpr_malloc(value_len);
@@ -449,7 +449,7 @@ static grpc_resolver *zookeeper_create(
   gpr_mu_init(&r->mu);
   grpc_resolver_init(&r->base, &zookeeper_resolver_vtable);
   r->name = gpr_strdup(path);
-  
+
   r->subchannel_factory = subchannel_factory;
   r->lb_policy_factory = lb_policy_factory;
   grpc_subchannel_factory_ref(subchannel_factory);

--- a/src/core/client_config/subchannel_factory_decorators/add_channel_arg.c
+++ b/src/core/client_config/subchannel_factory_decorators/add_channel_arg.c
@@ -35,9 +35,9 @@
 #include "src/core/client_config/subchannel_factory_decorators/merge_channel_args.h"
 
 grpc_subchannel_factory *grpc_subchannel_factory_add_channel_arg(
-		grpc_subchannel_factory *input, const grpc_arg *arg) {
-	grpc_channel_args args;
-	args.num_args = 1;
-	args.args = (grpc_arg *)arg;
-	return grpc_subchannel_factory_merge_channel_args(input, &args);
+    grpc_subchannel_factory *input, const grpc_arg *arg) {
+  grpc_channel_args args;
+  args.num_args = 1;
+  args.args = (grpc_arg *)arg;
+  return grpc_subchannel_factory_merge_channel_args(input, &args);
 }

--- a/src/core/client_config/subchannel_factory_decorators/add_channel_arg.h
+++ b/src/core/client_config/subchannel_factory_decorators/add_channel_arg.h
@@ -40,6 +40,7 @@
     channel_args by adding a new argument; ownership of input, arg is retained
     by the caller. */
 grpc_subchannel_factory *grpc_subchannel_factory_add_channel_arg(
-		grpc_subchannel_factory *input, const grpc_arg *arg);
+    grpc_subchannel_factory *input, const grpc_arg *arg);
 
-#endif /* GRPC_INTERNAL_CORE_CLIENT_CONFIG_SUBCHANNEL_FACTORY_DECORATORS_ADD_CHANNEL_ARG_H */
+#endif /* GRPC_INTERNAL_CORE_CLIENT_CONFIG_SUBCHANNEL_FACTORY_DECORATORS_ADD_CHANNEL_ARG_H \
+          */

--- a/src/core/client_config/subchannel_factory_decorators/merge_channel_args.c
+++ b/src/core/client_config/subchannel_factory_decorators/merge_channel_args.c
@@ -50,7 +50,7 @@ static void merge_args_factory_ref(grpc_subchannel_factory *scf) {
 static void merge_args_factory_unref(grpc_subchannel_factory *scf) {
   merge_args_factory *f = (merge_args_factory *)scf;
   if (gpr_unref(&f->refs)) {
-  	grpc_subchannel_factory_unref(f->wrapped);
+    grpc_subchannel_factory_unref(f->wrapped);
     grpc_channel_args_destroy(f->merge_args);
     gpr_free(f);
   }
@@ -73,7 +73,7 @@ static const grpc_subchannel_factory_vtable merge_args_factory_vtable = {
     merge_args_factory_create_subchannel};
 
 grpc_subchannel_factory *grpc_subchannel_factory_merge_channel_args(
-		grpc_subchannel_factory *input, const grpc_channel_args *args) {
+    grpc_subchannel_factory *input, const grpc_channel_args *args) {
   merge_args_factory *f = gpr_malloc(sizeof(*f));
   f->base.vtable = &merge_args_factory_vtable;
   gpr_ref_init(&f->refs, 1);

--- a/src/core/client_config/subchannel_factory_decorators/merge_channel_args.h
+++ b/src/core/client_config/subchannel_factory_decorators/merge_channel_args.h
@@ -40,6 +40,7 @@
     channel_args by adding a new argument; ownership of input, args is retained
     by the caller. */
 grpc_subchannel_factory *grpc_subchannel_factory_merge_channel_args(
-		grpc_subchannel_factory *input, const grpc_channel_args *args);
+    grpc_subchannel_factory *input, const grpc_channel_args *args);
 
-#endif /* GRPC_INTERNAL_CORE_CLIENT_CONFIG_SUBCHANNEL_FACTORY_DECORATORS_MERGE_CHANNEL_ARGS_H */
+#endif /* GRPC_INTERNAL_CORE_CLIENT_CONFIG_SUBCHANNEL_FACTORY_DECORATORS_MERGE_CHANNEL_ARGS_H \
+          */

--- a/src/core/compression/algorithm.c
+++ b/src/core/compression/algorithm.c
@@ -35,7 +35,7 @@
 #include <string.h>
 #include <grpc/compression.h>
 
-int grpc_compression_algorithm_parse(const char* name, size_t name_length,
+int grpc_compression_algorithm_parse(const char *name, size_t name_length,
                                      grpc_compression_algorithm *algorithm) {
   /* we use strncmp not only because it's safer (even though in this case it
    * doesn't matter, given that we are comparing against string literals, but

--- a/src/core/debug/trace.c
+++ b/src/core/debug/trace.c
@@ -61,8 +61,8 @@ static void add(const char *beg, const char *end, char ***ss, size_t *ns) {
   size_t np = n + 1;
   char *s = gpr_malloc(end - beg + 1);
   memcpy(s, beg, end - beg);
-  s[end-beg] = 0;
-  *ss = gpr_realloc(*ss, sizeof(char**) * np);
+  s[end - beg] = 0;
+  *ss = gpr_realloc(*ss, sizeof(char **) * np);
   (*ss)[n] = s;
   *ns = np;
 }
@@ -73,7 +73,7 @@ static void split(const char *s, char ***ss, size_t *ns) {
     add(s, s + strlen(s), ss, ns);
   } else {
     add(s, c, ss, ns);
-    split(c+1, ss, ns);
+    split(c + 1, ss, ns);
   }
 }
 
@@ -125,7 +125,7 @@ int grpc_tracer_set_enabled(const char *name, int enabled) {
     }
     if (!found) {
       gpr_log(GPR_ERROR, "Unknown trace var: '%s'", name);
-      return 0;  /* early return */
+      return 0; /* early return */
     }
   }
   return 1;

--- a/src/core/debug/trace.h
+++ b/src/core/debug/trace.h
@@ -40,4 +40,4 @@ void grpc_register_tracer(const char *name, int *flag);
 void grpc_tracer_init(const char *env_var_name);
 void grpc_tracer_shutdown(void);
 
-#endif  /* GRPC_INTERNAL_CORE_DEBUG_TRACE_H */
+#endif /* GRPC_INTERNAL_CORE_DEBUG_TRACE_H */

--- a/src/core/httpcli/format_request.c
+++ b/src/core/httpcli/format_request.c
@@ -43,7 +43,8 @@
 #include <grpc/support/string_util.h>
 #include <grpc/support/useful.h>
 
-static void fill_common_header(const grpc_httpcli_request *request, gpr_strvec *buf) {
+static void fill_common_header(const grpc_httpcli_request *request,
+                               gpr_strvec *buf) {
   size_t i;
   gpr_strvec_add(buf, gpr_strdup(request->path));
   gpr_strvec_add(buf, gpr_strdup(" HTTP/1.0\r\n"));
@@ -52,7 +53,8 @@ static void fill_common_header(const grpc_httpcli_request *request, gpr_strvec *
   gpr_strvec_add(buf, gpr_strdup(request->host));
   gpr_strvec_add(buf, gpr_strdup("\r\n"));
   gpr_strvec_add(buf, gpr_strdup("Connection: close\r\n"));
-  gpr_strvec_add(buf, gpr_strdup("User-Agent: "GRPC_HTTPCLI_USER_AGENT"\r\n"));
+  gpr_strvec_add(buf,
+                 gpr_strdup("User-Agent: " GRPC_HTTPCLI_USER_AGENT "\r\n"));
   /* user supplied headers */
   for (i = 0; i < request->hdr_count; i++) {
     gpr_strvec_add(buf, gpr_strdup(request->hdrs[i].key));

--- a/src/core/httpcli/format_request.h
+++ b/src/core/httpcli/format_request.h
@@ -42,4 +42,4 @@ gpr_slice grpc_httpcli_format_post_request(const grpc_httpcli_request *request,
                                            const char *body_bytes,
                                            size_t body_size);
 
-#endif  /* GRPC_INTERNAL_CORE_HTTPCLI_FORMAT_REQUEST_H */
+#endif /* GRPC_INTERNAL_CORE_HTTPCLI_FORMAT_REQUEST_H */

--- a/src/core/httpcli/parser.h
+++ b/src/core/httpcli/parser.h
@@ -61,4 +61,4 @@ void grpc_httpcli_parser_destroy(grpc_httpcli_parser *parser);
 int grpc_httpcli_parser_parse(grpc_httpcli_parser *parser, gpr_slice slice);
 int grpc_httpcli_parser_eof(grpc_httpcli_parser *parser);
 
-#endif  /* GRPC_INTERNAL_CORE_HTTPCLI_PARSER_H */
+#endif /* GRPC_INTERNAL_CORE_HTTPCLI_PARSER_H */

--- a/src/core/iomgr/alarm.c
+++ b/src/core/iomgr/alarm.c
@@ -105,8 +105,7 @@ void grpc_alarm_list_init(gpr_timespec now) {
 
 void grpc_alarm_list_shutdown(void) {
   int i;
-  while (run_some_expired_alarms(NULL, gpr_inf_future(g_clock_type), NULL,
-                                 0))
+  while (run_some_expired_alarms(NULL, gpr_inf_future(g_clock_type), NULL, 0))
     ;
   for (i = 0; i < NUM_SHARDS; i++) {
     shard_type *shard = &g_shards[i];
@@ -362,7 +361,7 @@ static int run_some_expired_alarms(gpr_mu *drop_mu, gpr_timespec now,
 int grpc_alarm_check(gpr_mu *drop_mu, gpr_timespec now, gpr_timespec *next) {
   GPR_ASSERT(now.clock_type == g_clock_type);
   return run_some_expired_alarms(
-      drop_mu, now, next, 
+      drop_mu, now, next,
       gpr_time_cmp(now, gpr_inf_future(now.clock_type)) != 0);
 }
 

--- a/src/core/iomgr/alarm.h
+++ b/src/core/iomgr/alarm.h
@@ -86,4 +86,4 @@ void grpc_alarm_init(grpc_alarm *alarm, gpr_timespec deadline,
    Requires:  cancel() must happen after add() on a given alarm */
 void grpc_alarm_cancel(grpc_alarm *alarm);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_ALARM_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_ALARM_H */

--- a/src/core/iomgr/alarm_heap.c
+++ b/src/core/iomgr/alarm_heap.c
@@ -66,11 +66,11 @@ static void adjust_downwards(grpc_alarm **first, int i, int length,
     int next_i;
     if (left_child >= length) break;
     right_child = left_child + 1;
-    next_i =
-        right_child < length && gpr_time_cmp(first[left_child]->deadline,
-                                             first[right_child]->deadline) < 0
-            ? right_child
-            : left_child;
+    next_i = right_child < length &&
+                     gpr_time_cmp(first[left_child]->deadline,
+                                  first[right_child]->deadline) < 0
+                 ? right_child
+                 : left_child;
     if (gpr_time_cmp(t->deadline, first[next_i]->deadline) >= 0) break;
     first[i] = first[next_i];
     first[i]->heap_index = i;

--- a/src/core/iomgr/alarm_heap.h
+++ b/src/core/iomgr/alarm_heap.h
@@ -54,4 +54,4 @@ void grpc_alarm_heap_pop(grpc_alarm_heap *heap);
 
 int grpc_alarm_heap_is_empty(grpc_alarm_heap *heap);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_ALARM_HEAP_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_ALARM_HEAP_H */

--- a/src/core/iomgr/alarm_internal.h
+++ b/src/core/iomgr/alarm_internal.h
@@ -59,4 +59,4 @@ gpr_timespec grpc_alarm_list_next_timeout(void);
 
 void grpc_kick_poller(void);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_ALARM_INTERNAL_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_ALARM_INTERNAL_H */

--- a/src/core/iomgr/endpoint.c
+++ b/src/core/iomgr/endpoint.c
@@ -50,7 +50,8 @@ void grpc_endpoint_add_to_pollset(grpc_endpoint *ep, grpc_pollset *pollset) {
   ep->vtable->add_to_pollset(ep, pollset);
 }
 
-void grpc_endpoint_add_to_pollset_set(grpc_endpoint *ep, grpc_pollset_set *pollset_set) {
+void grpc_endpoint_add_to_pollset_set(grpc_endpoint *ep,
+                                      grpc_pollset_set *pollset_set) {
   ep->vtable->add_to_pollset_set(ep, pollset_set);
 }
 

--- a/src/core/iomgr/endpoint.h
+++ b/src/core/iomgr/endpoint.h
@@ -103,10 +103,11 @@ void grpc_endpoint_destroy(grpc_endpoint *ep);
 /* Add an endpoint to a pollset, so that when the pollset is polled, events from
    this endpoint are considered */
 void grpc_endpoint_add_to_pollset(grpc_endpoint *ep, grpc_pollset *pollset);
-void grpc_endpoint_add_to_pollset_set(grpc_endpoint *ep, grpc_pollset_set *pollset_set);
+void grpc_endpoint_add_to_pollset_set(grpc_endpoint *ep,
+                                      grpc_pollset_set *pollset_set);
 
 struct grpc_endpoint {
   const grpc_endpoint_vtable *vtable;
 };
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_ENDPOINT_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_ENDPOINT_H */

--- a/src/core/iomgr/endpoint_pair.h
+++ b/src/core/iomgr/endpoint_pair.h
@@ -44,4 +44,4 @@ typedef struct {
 grpc_endpoint_pair grpc_iomgr_create_endpoint_pair(const char *name,
                                                    size_t read_slice_size);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_ENDPOINT_PAIR_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_ENDPOINT_PAIR_H */

--- a/src/core/iomgr/endpoint_pair_windows.c
+++ b/src/core/iomgr/endpoint_pair_windows.c
@@ -52,21 +52,26 @@ static void create_sockets(SOCKET sv[2]) {
   SOCKADDR_IN addr;
   int addr_len = sizeof(addr);
 
-  lst_sock = WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0, WSA_FLAG_OVERLAPPED);
+  lst_sock = WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                       WSA_FLAG_OVERLAPPED);
   GPR_ASSERT(lst_sock != INVALID_SOCKET);
 
   memset(&addr, 0, sizeof(addr));
   addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
   addr.sin_family = AF_INET;
-  GPR_ASSERT(bind(lst_sock, (struct sockaddr*)&addr, sizeof(addr)) != SOCKET_ERROR);
+  GPR_ASSERT(bind(lst_sock, (struct sockaddr *)&addr, sizeof(addr)) !=
+             SOCKET_ERROR);
   GPR_ASSERT(listen(lst_sock, SOMAXCONN) != SOCKET_ERROR);
-  GPR_ASSERT(getsockname(lst_sock, (struct sockaddr*)&addr, &addr_len) != SOCKET_ERROR);
+  GPR_ASSERT(getsockname(lst_sock, (struct sockaddr *)&addr, &addr_len) !=
+             SOCKET_ERROR);
 
-  cli_sock = WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0, WSA_FLAG_OVERLAPPED);
+  cli_sock = WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                       WSA_FLAG_OVERLAPPED);
   GPR_ASSERT(cli_sock != INVALID_SOCKET);
 
-  GPR_ASSERT(WSAConnect(cli_sock, (struct sockaddr*)&addr, addr_len, NULL, NULL, NULL, NULL) == 0);
-  svr_sock = accept(lst_sock, (struct sockaddr*)&addr, &addr_len);
+  GPR_ASSERT(WSAConnect(cli_sock, (struct sockaddr *)&addr, addr_len, NULL,
+                        NULL, NULL, NULL) == 0);
+  svr_sock = accept(lst_sock, (struct sockaddr *)&addr, &addr_len);
   GPR_ASSERT(svr_sock != INVALID_SOCKET);
 
   closesocket(lst_sock);
@@ -77,7 +82,8 @@ static void create_sockets(SOCKET sv[2]) {
   sv[0] = svr_sock;
 }
 
-grpc_endpoint_pair grpc_iomgr_create_endpoint_pair(const char *name, size_t read_slice_size) {
+grpc_endpoint_pair grpc_iomgr_create_endpoint_pair(const char *name,
+                                                   size_t read_slice_size) {
   SOCKET sv[2];
   grpc_endpoint_pair p;
   create_sockets(sv);

--- a/src/core/iomgr/iocp_windows.c
+++ b/src/core/iomgr/iocp_windows.c
@@ -65,18 +65,17 @@ static void do_iocp_work() {
   LPOVERLAPPED overlapped;
   grpc_winsocket *socket;
   grpc_winsocket_callback_info *info;
-  void(*f)(void *, int) = NULL;
+  void (*f)(void *, int) = NULL;
   void *opaque = NULL;
-  success = GetQueuedCompletionStatus(g_iocp, &bytes,
-                                      &completion_key, &overlapped,
-                                      INFINITE);
+  success = GetQueuedCompletionStatus(g_iocp, &bytes, &completion_key,
+                                      &overlapped, INFINITE);
   /* success = 0 and overlapped = NULL means the deadline got attained.
      Which is impossible. since our wait time is +inf */
   GPR_ASSERT(success || overlapped);
   GPR_ASSERT(completion_key && overlapped);
   if (overlapped == &g_iocp_custom_overlap) {
     gpr_atm_full_fetch_add(&g_custom_events, -1);
-    if (completion_key == (ULONG_PTR) &g_iocp_kick_token) {
+    if (completion_key == (ULONG_PTR)&g_iocp_kick_token) {
       /* We were awoken from a kick. */
       return;
     }
@@ -84,7 +83,7 @@ static void do_iocp_work() {
     abort();
   }
 
-  socket = (grpc_winsocket*) completion_key;
+  socket = (grpc_winsocket *)completion_key;
   if (overlapped == &socket->write_info.overlapped) {
     info = &socket->write_info;
   } else if (overlapped == &socket->read_info.overlapped) {
@@ -121,8 +120,7 @@ static void do_iocp_work() {
 }
 
 static void iocp_loop(void *p) {
-  while (gpr_atm_acq_load(&g_orphans) ||
-         gpr_atm_acq_load(&g_custom_events) ||
+  while (gpr_atm_acq_load(&g_orphans) || gpr_atm_acq_load(&g_custom_events) ||
          !gpr_event_get(&g_shutdown_iocp)) {
     grpc_maybe_call_delayed_callbacks(NULL, 1);
     do_iocp_work();
@@ -134,8 +132,8 @@ static void iocp_loop(void *p) {
 void grpc_iocp_init(void) {
   gpr_thd_id id;
 
-  g_iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE,
-                                  NULL, (ULONG_PTR)NULL, 0);
+  g_iocp =
+      CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, (ULONG_PTR)NULL, 0);
   GPR_ASSERT(g_iocp);
 
   gpr_event_init(&g_iocp_done);
@@ -147,8 +145,7 @@ void grpc_iocp_kick(void) {
   BOOL success;
 
   gpr_atm_full_fetch_add(&g_custom_events, 1);
-  success = PostQueuedCompletionStatus(g_iocp, 0,
-                                       (ULONG_PTR) &g_iocp_kick_token,
+  success = PostQueuedCompletionStatus(g_iocp, 0, (ULONG_PTR)&g_iocp_kick_token,
                                        &g_iocp_custom_overlap);
   GPR_ASSERT(success);
 }
@@ -165,8 +162,8 @@ void grpc_iocp_shutdown(void) {
 void grpc_iocp_add_socket(grpc_winsocket *socket) {
   HANDLE ret;
   if (socket->added_to_iocp) return;
-  ret = CreateIoCompletionPort((HANDLE)socket->socket,
-                               g_iocp, (gpr_uintptr) socket, 0);
+  ret = CreateIoCompletionPort((HANDLE)socket->socket, g_iocp,
+                               (gpr_uintptr)socket, 0);
   if (!ret) {
     char *utf8_message = gpr_format_message(WSAGetLastError());
     gpr_log(GPR_ERROR, "Unable to add socket to iocp: %s", utf8_message);
@@ -189,7 +186,7 @@ void grpc_iocp_socket_orphan(grpc_winsocket *socket) {
    the callback now.
    -) The IOCP hasn't completed yet, and we're queuing it for later. */
 static void socket_notify_on_iocp(grpc_winsocket *socket,
-                                  void(*cb)(void *, int), void *opaque,
+                                  void (*cb)(void *, int), void *opaque,
                                   grpc_winsocket_callback_info *info) {
   int run_now = 0;
   GPR_ASSERT(!info->cb);
@@ -206,13 +203,13 @@ static void socket_notify_on_iocp(grpc_winsocket *socket,
 }
 
 void grpc_socket_notify_on_write(grpc_winsocket *socket,
-                                 void(*cb)(void *, int), void *opaque) {
+                                 void (*cb)(void *, int), void *opaque) {
   socket_notify_on_iocp(socket, cb, opaque, &socket->write_info);
 }
 
-void grpc_socket_notify_on_read(grpc_winsocket *socket,
-                                void(*cb)(void *, int), void *opaque) {
+void grpc_socket_notify_on_read(grpc_winsocket *socket, void (*cb)(void *, int),
+                                void *opaque) {
   socket_notify_on_iocp(socket, cb, opaque, &socket->read_info);
 }
 
-#endif  /* GPR_WINSOCK_SOCKET */
+#endif /* GPR_WINSOCK_SOCKET */

--- a/src/core/iomgr/iocp_windows.h
+++ b/src/core/iomgr/iocp_windows.h
@@ -44,10 +44,10 @@ void grpc_iocp_shutdown(void);
 void grpc_iocp_add_socket(grpc_winsocket *);
 void grpc_iocp_socket_orphan(grpc_winsocket *);
 
-void grpc_socket_notify_on_write(grpc_winsocket *, void(*cb)(void *, int success),
-                                 void *opaque);
+void grpc_socket_notify_on_write(grpc_winsocket *,
+                                 void (*cb)(void *, int success), void *opaque);
 
-void grpc_socket_notify_on_read(grpc_winsocket *, void(*cb)(void *, int success),
-                                void *opaque);
+void grpc_socket_notify_on_read(grpc_winsocket *,
+                                void (*cb)(void *, int success), void *opaque);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_IOCP_WINDOWS_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_IOCP_WINDOWS_H */

--- a/src/core/iomgr/iomgr.h
+++ b/src/core/iomgr/iomgr.h
@@ -77,4 +77,4 @@ void grpc_iomgr_add_callback(grpc_iomgr_closure *closure);
     argument. */
 void grpc_iomgr_add_delayed_callback(grpc_iomgr_closure *iocb, int success);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_IOMGR_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_IOMGR_H */

--- a/src/core/iomgr/iomgr_internal.h
+++ b/src/core/iomgr/iomgr_internal.h
@@ -52,4 +52,4 @@ void grpc_iomgr_unregister_object(grpc_iomgr_object *obj);
 void grpc_iomgr_platform_init(void);
 void grpc_iomgr_platform_shutdown(void);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_IOMGR_INTERNAL_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_IOMGR_INTERNAL_H */

--- a/src/core/iomgr/iomgr_posix.c
+++ b/src/core/iomgr/iomgr_posix.c
@@ -51,4 +51,4 @@ void grpc_iomgr_platform_shutdown(void) {
   grpc_fd_global_shutdown();
 }
 
-#endif  /* GRPC_POSIX_SOCKET */
+#endif /* GRPC_POSIX_SOCKET */

--- a/src/core/iomgr/iomgr_posix.h
+++ b/src/core/iomgr/iomgr_posix.h
@@ -39,4 +39,4 @@
 void grpc_pollset_global_init(void);
 void grpc_pollset_global_shutdown(void);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_IOMGR_POSIX_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_IOMGR_POSIX_H */

--- a/src/core/iomgr/iomgr_windows.c
+++ b/src/core/iomgr/iomgr_windows.c
@@ -68,4 +68,4 @@ void grpc_iomgr_platform_shutdown(void) {
   winsock_shutdown();
 }
 
-#endif  /* GRPC_WINSOCK_SOCKET */
+#endif /* GRPC_WINSOCK_SOCKET */

--- a/src/core/iomgr/pollset_multipoller_with_epoll.c
+++ b/src/core/iomgr/pollset_multipoller_with_epoll.c
@@ -234,8 +234,7 @@ static void multipoll_with_epoll_pollset_destroy(grpc_pollset *pollset) {
 }
 
 static const grpc_pollset_vtable multipoll_with_epoll_pollset = {
-    multipoll_with_epoll_pollset_add_fd,
-    multipoll_with_epoll_pollset_del_fd,
+    multipoll_with_epoll_pollset_add_fd, multipoll_with_epoll_pollset_del_fd,
     multipoll_with_epoll_pollset_maybe_work,
     multipoll_with_epoll_pollset_finish_shutdown,
     multipoll_with_epoll_pollset_destroy};

--- a/src/core/iomgr/pollset_multipoller_with_poll_posix.c
+++ b/src/core/iomgr/pollset_multipoller_with_poll_posix.c
@@ -74,7 +74,7 @@ static void multipoll_with_poll_pollset_add_fd(grpc_pollset *pollset,
   }
   h->fds[h->fd_count++] = fd;
   GRPC_FD_REF(fd, "multipoller");
-exit:  
+exit:
   if (and_unlock_pollset) {
     gpr_mu_unlock(&pollset->mu);
   }
@@ -202,8 +202,7 @@ static void multipoll_with_poll_pollset_destroy(grpc_pollset *pollset) {
 }
 
 static const grpc_pollset_vtable multipoll_with_poll_pollset = {
-    multipoll_with_poll_pollset_add_fd,
-    multipoll_with_poll_pollset_del_fd,
+    multipoll_with_poll_pollset_add_fd, multipoll_with_poll_pollset_del_fd,
     multipoll_with_poll_pollset_maybe_work,
     multipoll_with_poll_pollset_finish_shutdown,
     multipoll_with_poll_pollset_destroy};

--- a/src/core/iomgr/pollset_posix.c
+++ b/src/core/iomgr/pollset_posix.c
@@ -140,10 +140,10 @@ void grpc_pollset_init(grpc_pollset *pollset) {
 void grpc_pollset_add_fd(grpc_pollset *pollset, grpc_fd *fd) {
   gpr_mu_lock(&pollset->mu);
   pollset->vtable->add_fd(pollset, fd, 1);
-  /* the following (enabled only in debug) will reacquire and then release
-     our lock - meaning that if the unlocking flag passed to del_fd above is
-     not respected, the code will deadlock (in a way that we have a chance of
-     debugging) */
+/* the following (enabled only in debug) will reacquire and then release
+   our lock - meaning that if the unlocking flag passed to del_fd above is
+   not respected, the code will deadlock (in a way that we have a chance of
+   debugging) */
 #ifndef NDEBUG
   gpr_mu_lock(&pollset->mu);
   gpr_mu_unlock(&pollset->mu);
@@ -153,10 +153,10 @@ void grpc_pollset_add_fd(grpc_pollset *pollset, grpc_fd *fd) {
 void grpc_pollset_del_fd(grpc_pollset *pollset, grpc_fd *fd) {
   gpr_mu_lock(&pollset->mu);
   pollset->vtable->del_fd(pollset, fd, 1);
-  /* the following (enabled only in debug) will reacquire and then release
-     our lock - meaning that if the unlocking flag passed to del_fd above is
-     not respected, the code will deadlock (in a way that we have a chance of
-     debugging) */
+/* the following (enabled only in debug) will reacquire and then release
+   our lock - meaning that if the unlocking flag passed to del_fd above is
+   not respected, the code will deadlock (in a way that we have a chance of
+   debugging) */
 #ifndef NDEBUG
   gpr_mu_lock(&pollset->mu);
   gpr_mu_unlock(&pollset->mu);

--- a/src/core/iomgr/pollset_posix.h
+++ b/src/core/iomgr/pollset_posix.h
@@ -102,7 +102,8 @@ void grpc_kick_drain(grpc_pollset *p);
    - longer than a millisecond polls are rounded up to the next nearest
      millisecond to avoid spinning
    - infinite timeouts are converted to -1 */
-int grpc_poll_deadline_to_millis_timeout(gpr_timespec deadline, gpr_timespec now);
+int grpc_poll_deadline_to_millis_timeout(gpr_timespec deadline,
+                                         gpr_timespec now);
 
 /* turn a pollset into a multipoller: platform specific */
 typedef void (*grpc_platform_become_multipoller_type)(grpc_pollset *pollset,

--- a/src/core/iomgr/pollset_windows.c
+++ b/src/core/iomgr/pollset_windows.c
@@ -56,8 +56,7 @@ static grpc_pollset_worker *pop_front_worker(grpc_pollset *p) {
     grpc_pollset_worker *w = p->root_worker.next;
     remove_worker(p, w);
     return w;
-  }
-  else {
+  } else {
     return NULL;
   }
 }
@@ -100,7 +99,8 @@ void grpc_pollset_destroy(grpc_pollset *pollset) {
   gpr_mu_destroy(&pollset->mu);
 }
 
-int grpc_pollset_work(grpc_pollset *pollset, grpc_pollset_worker *worker, gpr_timespec deadline) {
+int grpc_pollset_work(grpc_pollset *pollset, grpc_pollset_worker *worker,
+                      gpr_timespec deadline) {
   gpr_timespec now;
   int added_worker = 0;
   now = gpr_now(GPR_CLOCK_MONOTONIC);
@@ -134,8 +134,8 @@ void grpc_pollset_kick(grpc_pollset *p, grpc_pollset_worker *specific_worker) {
   if (specific_worker != NULL) {
     if (specific_worker == GRPC_POLLSET_KICK_BROADCAST) {
       for (specific_worker = p->root_worker.next;
-        specific_worker != &p->root_worker;
-        specific_worker = specific_worker->next) {
+           specific_worker != &p->root_worker;
+           specific_worker = specific_worker->next) {
         gpr_cv_signal(&specific_worker->cv);
       }
       p->kicked_without_pollers = 1;

--- a/src/core/iomgr/resolve_address.h
+++ b/src/core/iomgr/resolve_address.h
@@ -66,4 +66,4 @@ void grpc_resolved_addresses_destroy(grpc_resolved_addresses *addresses);
 grpc_resolved_addresses *grpc_blocking_resolve_address(
     const char *addr, const char *default_port);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_RESOLVE_ADDRESS_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_RESOLVE_ADDRESS_H */

--- a/src/core/iomgr/resolve_address_posix.c
+++ b/src/core/iomgr/resolve_address_posix.c
@@ -105,10 +105,7 @@ grpc_resolved_addresses *grpc_blocking_resolve_address(
   s = getaddrinfo(host, port, &hints, &result);
   if (s != 0) {
     /* Retry if well-known service name is recognized */
-    char *svc[][2] = {
-      {"http", "80"},
-      {"https", "443"}
-    };
+    char *svc[][2] = {{"http", "80"}, {"https", "443"}};
     int i;
     for (i = 0; i < (int)(sizeof(svc) / sizeof(svc[0])); i++) {
       if (strcmp(port, svc[i][0]) == 0) {

--- a/src/core/iomgr/sockaddr.h
+++ b/src/core/iomgr/sockaddr.h
@@ -44,4 +44,4 @@
 #include "src/core/iomgr/sockaddr_posix.h"
 #endif
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_SOCKADDR_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_SOCKADDR_H */

--- a/src/core/iomgr/sockaddr_posix.h
+++ b/src/core/iomgr/sockaddr_posix.h
@@ -41,4 +41,4 @@
 #include <netdb.h>
 #include <unistd.h>
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_SOCKADDR_POSIX_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_SOCKADDR_POSIX_H */

--- a/src/core/iomgr/sockaddr_utils.c
+++ b/src/core/iomgr/sockaddr_utils.c
@@ -206,7 +206,8 @@ int grpc_sockaddr_get_port(const struct sockaddr *addr) {
     case AF_UNIX:
       return 1;
     default:
-      gpr_log(GPR_ERROR, "Unknown socket family %d in grpc_sockaddr_get_port", addr->sa_family);
+      gpr_log(GPR_ERROR, "Unknown socket family %d in grpc_sockaddr_get_port",
+              addr->sa_family);
       return 0;
   }
 }
@@ -220,7 +221,8 @@ int grpc_sockaddr_set_port(const struct sockaddr *addr, int port) {
       ((struct sockaddr_in6 *)addr)->sin6_port = htons(port);
       return 1;
     default:
-      gpr_log(GPR_ERROR, "Unknown socket family %d in grpc_sockaddr_set_port", addr->sa_family);
+      gpr_log(GPR_ERROR, "Unknown socket family %d in grpc_sockaddr_set_port",
+              addr->sa_family);
       return 0;
   }
 }

--- a/src/core/iomgr/sockaddr_utils.h
+++ b/src/core/iomgr/sockaddr_utils.h
@@ -86,4 +86,4 @@ int grpc_sockaddr_to_string(char **out, const struct sockaddr *addr,
 
 char *grpc_sockaddr_to_uri(const struct sockaddr *addr);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_SOCKADDR_UTILS_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_SOCKADDR_UTILS_H */

--- a/src/core/iomgr/sockaddr_win32.h
+++ b/src/core/iomgr/sockaddr_win32.h
@@ -43,4 +43,4 @@
 const char *inet_ntop(int af, const void *src, char *dst, socklen_t size);
 #endif
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_SOCKADDR_WIN32_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_SOCKADDR_WIN32_H */

--- a/src/core/iomgr/socket_utils_posix.h
+++ b/src/core/iomgr/socket_utils_posix.h
@@ -110,4 +110,4 @@ extern int grpc_forbid_dualstack_sockets_for_testing;
 int grpc_create_dualstack_socket(const struct sockaddr *addr, int type,
                                  int protocol, grpc_dualstack_mode *dsmode);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_SOCKET_UTILS_POSIX_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_SOCKET_UTILS_POSIX_H */

--- a/src/core/iomgr/socket_windows.c
+++ b/src/core/iomgr/socket_windows.c
@@ -106,4 +106,4 @@ void grpc_winsocket_destroy(grpc_winsocket *winsocket) {
   gpr_free(winsocket);
 }
 
-#endif  /* GPR_WINSOCK_SOCKET */
+#endif /* GPR_WINSOCK_SOCKET */

--- a/src/core/iomgr/socket_windows.h
+++ b/src/core/iomgr/socket_windows.h
@@ -54,7 +54,7 @@ typedef struct grpc_winsocket_callback_info {
   OVERLAPPED overlapped;
   /* The callback information for the pending operation. May be empty if the
      caller hasn't registered a callback yet. */
-  void(*cb)(void *opaque, int success);
+  void (*cb)(void *opaque, int success);
   void *opaque;
   /* A boolean to describe if the IO Completion Port got a notification for
      that operation. This will happen if the operation completed before the
@@ -118,4 +118,4 @@ void grpc_winsocket_orphan(grpc_winsocket *socket);
    or by grpc_winsocket_orphan if there's no pending operation. */
 void grpc_winsocket_destroy(grpc_winsocket *socket);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_SOCKET_WINDOWS_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_SOCKET_WINDOWS_H */

--- a/src/core/iomgr/tcp_client.h
+++ b/src/core/iomgr/tcp_client.h
@@ -41,7 +41,7 @@
 
 /* Asynchronously connect to an address (specified as (addr, len)), and call
    cb with arg and the completed connection when done (or call cb with arg and
-   NULL on failure). 
+   NULL on failure).
    interested_parties points to a set of pollsets that would be interested
    in this connection being established (in order to continue their work) */
 void grpc_tcp_client_connect(void (*cb)(void *arg, grpc_endpoint *tcp),

--- a/src/core/iomgr/tcp_client_posix.c
+++ b/src/core/iomgr/tcp_client_posix.c
@@ -264,7 +264,8 @@ void grpc_tcp_client_connect(void (*cb)(void *arg, grpc_endpoint *ep),
   ac->write_closure.cb_arg = ac;
 
   gpr_mu_lock(&ac->mu);
-  grpc_alarm_init(&ac->alarm, gpr_convert_clock_type(deadline, GPR_CLOCK_MONOTONIC), 
+  grpc_alarm_init(&ac->alarm,
+                  gpr_convert_clock_type(deadline, GPR_CLOCK_MONOTONIC),
                   tc_on_alarm, ac, gpr_now(GPR_CLOCK_MONOTONIC));
   grpc_fd_notify_on_write(ac->fd, &ac->write_closure);
   gpr_mu_unlock(&ac->mu);

--- a/src/core/iomgr/tcp_posix.c
+++ b/src/core/iomgr/tcp_posix.c
@@ -572,7 +572,8 @@ static void grpc_tcp_add_to_pollset(grpc_endpoint *ep, grpc_pollset *pollset) {
   grpc_pollset_add_fd(pollset, tcp->em_fd);
 }
 
-static void grpc_tcp_add_to_pollset_set(grpc_endpoint *ep, grpc_pollset_set *pollset_set) {
+static void grpc_tcp_add_to_pollset_set(grpc_endpoint *ep,
+                                        grpc_pollset_set *pollset_set) {
   grpc_tcp *tcp = (grpc_tcp *)ep;
   grpc_pollset_set_add_fd(pollset_set, tcp->em_fd);
 }

--- a/src/core/iomgr/tcp_posix.h
+++ b/src/core/iomgr/tcp_posix.h
@@ -56,4 +56,4 @@ extern int grpc_tcp_trace;
 grpc_endpoint *grpc_tcp_create(grpc_fd *fd, size_t read_slice_size,
                                const char *peer_string);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_TCP_POSIX_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_TCP_POSIX_H */

--- a/src/core/iomgr/tcp_server_windows.c
+++ b/src/core/iomgr/tcp_server_windows.c
@@ -79,7 +79,8 @@ struct grpc_tcp_server {
 
   /* active port count: how many ports are actually still listening */
   int active_ports;
-  /* number of iomgr callbacks that have been explicitly scheduled during shutdown */
+  /* number of iomgr callbacks that have been explicitly scheduled during
+   * shutdown */
   int iomgr_callbacks_pending;
 
   /* all listening ports */
@@ -292,7 +293,7 @@ static void on_accept(void *arg, int from_iocp) {
       and act accordingly. */
   transfered_bytes = 0;
   wsa_success = WSAGetOverlappedResult(sock, &info->overlapped,
-                                            &transfered_bytes, FALSE, &flags);
+                                       &transfered_bytes, FALSE, &flags);
   if (!wsa_success) {
     if (sp->shutting_down) {
       /* During the shutdown case, we ARE expecting an error. So that's well,
@@ -309,16 +310,15 @@ static void on_accept(void *arg, int from_iocp) {
     if (!sp->shutting_down) {
       peer_name_string = NULL;
       err = setsockopt(sock, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT,
-                       (char *)&sp->socket->socket,
-                       sizeof(sp->socket->socket));
+                       (char *)&sp->socket->socket, sizeof(sp->socket->socket));
       if (err) {
         char *utf8_message = gpr_format_message(WSAGetLastError());
         gpr_log(GPR_ERROR, "setsockopt error: %s", utf8_message);
         gpr_free(utf8_message);
       }
-      err = getpeername(sock, (struct sockaddr*)&peer_name, &peer_name_len);
+      err = getpeername(sock, (struct sockaddr *)&peer_name, &peer_name_len);
       if (!err) {
-        peer_name_string = grpc_sockaddr_to_uri((struct sockaddr*)&peer_name);
+        peer_name_string = grpc_sockaddr_to_uri((struct sockaddr *)&peer_name);
       } else {
         char *utf8_message = gpr_format_message(WSAGetLastError());
         gpr_log(GPR_ERROR, "getpeername error: %s", utf8_message);

--- a/src/core/iomgr/tcp_windows.c
+++ b/src/core/iomgr/tcp_windows.c
@@ -55,24 +55,22 @@ static int set_non_block(SOCKET sock) {
   int status;
   unsigned long param = 1;
   DWORD ret;
-  status = WSAIoctl(sock, FIONBIO, &param, sizeof(param), NULL, 0, &ret,
-                    NULL, NULL);
+  status =
+      WSAIoctl(sock, FIONBIO, &param, sizeof(param), NULL, 0, &ret, NULL, NULL);
   return status == 0;
 }
 
 static int set_dualstack(SOCKET sock) {
   int status;
   unsigned long param = 0;
-  status = setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
-                      (const char *) &param, sizeof(param));
+  status = setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY, (const char *)&param,
+                      sizeof(param));
   return status == 0;
 }
 
 int grpc_tcp_prepare_socket(SOCKET sock) {
-  if (!set_non_block(sock))
-    return 0;
-  if (!set_dualstack(sock))
-    return 0;
+  if (!set_non_block(sock)) return 0;
+  if (!set_dualstack(sock)) return 0;
   return 1;
 }
 
@@ -100,9 +98,7 @@ typedef struct grpc_tcp {
   char *peer_string;
 } grpc_tcp;
 
-static void tcp_ref(grpc_tcp *tcp) {
-  gpr_ref(&tcp->refcount);
-}
+static void tcp_ref(grpc_tcp *tcp) { gpr_ref(&tcp->refcount); }
 
 static void tcp_unref(grpc_tcp *tcp) {
   if (gpr_unref(&tcp->refcount)) {
@@ -116,7 +112,7 @@ static void tcp_unref(grpc_tcp *tcp) {
 
 /* Asynchronous callback from the IOCP, or the background thread. */
 static void on_read(void *tcpp, int from_iocp) {
-  grpc_tcp *tcp = (grpc_tcp *) tcpp;
+  grpc_tcp *tcp = (grpc_tcp *)tcpp;
   grpc_winsocket *socket = tcp->socket;
   gpr_slice sub;
   gpr_slice *slice = NULL;
@@ -175,9 +171,9 @@ static void on_read(void *tcpp, int from_iocp) {
   cb(opaque, slice, nslices, status);
 }
 
-static void win_notify_on_read(grpc_endpoint *ep,
-                               grpc_endpoint_read_cb cb, void *arg) {
-  grpc_tcp *tcp = (grpc_tcp *) ep;
+static void win_notify_on_read(grpc_endpoint *ep, grpc_endpoint_read_cb cb,
+                               void *arg) {
+  grpc_tcp *tcp = (grpc_tcp *)ep;
   grpc_winsocket *handle = tcp->socket;
   grpc_winsocket_callback_info *info = &handle->read_info;
   int status;
@@ -201,8 +197,8 @@ static void win_notify_on_read(grpc_endpoint *ep,
   buffer.buf = (char *)GPR_SLICE_START_PTR(tcp->read_slice);
 
   /* First let's try a synchronous, non-blocking read. */
-  status = WSARecv(tcp->socket->socket, &buffer, 1, &bytes_read, &flags,
-                   NULL, NULL);
+  status =
+      WSARecv(tcp->socket->socket, &buffer, 1, &bytes_read, &flags, NULL, NULL);
   info->wsa_error = status == 0 ? 0 : WSAGetLastError();
 
   /* Did we get data immediately ? Yay. */
@@ -232,7 +228,7 @@ static void win_notify_on_read(grpc_endpoint *ep,
 
 /* Asynchronous callback from the IOCP, or the background thread. */
 static void on_write(void *tcpp, int from_iocp) {
-  grpc_tcp *tcp = (grpc_tcp *) tcpp;
+  grpc_tcp *tcp = (grpc_tcp *)tcpp;
   grpc_winsocket *handle = tcp->socket;
   grpc_winsocket_callback_info *info = &handle->write_info;
   grpc_endpoint_cb_status status = GRPC_ENDPOINT_CB_OK;
@@ -286,7 +282,7 @@ static grpc_endpoint_write_status win_write(grpc_endpoint *ep,
                                             gpr_slice *slices, size_t nslices,
                                             grpc_endpoint_write_cb cb,
                                             void *arg) {
-  grpc_tcp *tcp = (grpc_tcp *) ep;
+  grpc_tcp *tcp = (grpc_tcp *)ep;
   grpc_winsocket *socket = tcp->socket;
   grpc_winsocket_callback_info *info = &socket->write_info;
   unsigned i;
@@ -309,7 +305,7 @@ static grpc_endpoint_write_status win_write(grpc_endpoint *ep,
   gpr_slice_buffer_addn(&tcp->write_slices, slices, nslices);
 
   if (tcp->write_slices.count > GPR_ARRAY_SIZE(local_buffers)) {
-    buffers = (WSABUF *) gpr_malloc(sizeof(WSABUF) * tcp->write_slices.count);
+    buffers = (WSABUF *)gpr_malloc(sizeof(WSABUF) * tcp->write_slices.count);
     allocated = buffers;
   }
 
@@ -370,15 +366,15 @@ static grpc_endpoint_write_status win_write(grpc_endpoint *ep,
 
 static void win_add_to_pollset(grpc_endpoint *ep, grpc_pollset *ps) {
   grpc_tcp *tcp;
-  (void) ps;
-  tcp = (grpc_tcp *) ep;
+  (void)ps;
+  tcp = (grpc_tcp *)ep;
   grpc_iocp_add_socket(tcp->socket);
 }
 
 static void win_add_to_pollset_set(grpc_endpoint *ep, grpc_pollset_set *pss) {
   grpc_tcp *tcp;
-  (void) pss;
-  tcp = (grpc_tcp *) ep;
+  (void)pss;
+  tcp = (grpc_tcp *)ep;
   grpc_iocp_add_socket(tcp->socket);
 }
 
@@ -389,7 +385,7 @@ static void win_add_to_pollset_set(grpc_endpoint *ep, grpc_pollset_set *pss) {
    callback will happen from another thread, so we need to protect against
    concurrent access of the data structure in that regard. */
 static void win_shutdown(grpc_endpoint *ep) {
-  grpc_tcp *tcp = (grpc_tcp *) ep;
+  grpc_tcp *tcp = (grpc_tcp *)ep;
   int extra_refs = 0;
   gpr_mu_lock(&tcp->mu);
   /* At that point, what may happen is that we're already inside the IOCP
@@ -401,7 +397,7 @@ static void win_shutdown(grpc_endpoint *ep) {
 }
 
 static void win_destroy(grpc_endpoint *ep) {
-  grpc_tcp *tcp = (grpc_tcp *) ep;
+  grpc_tcp *tcp = (grpc_tcp *)ep;
   tcp_unref(tcp);
 }
 
@@ -410,13 +406,12 @@ static char *win_get_peer(grpc_endpoint *ep) {
   return gpr_strdup(tcp->peer_string);
 }
 
-static grpc_endpoint_vtable vtable = {win_notify_on_read, win_write,
-                                      win_add_to_pollset, win_add_to_pollset_set,
-                                      win_shutdown,       win_destroy,
-                                      win_get_peer};
+static grpc_endpoint_vtable vtable = {
+    win_notify_on_read, win_write,   win_add_to_pollset, win_add_to_pollset_set,
+    win_shutdown,       win_destroy, win_get_peer};
 
 grpc_endpoint *grpc_tcp_create(grpc_winsocket *socket, char *peer_string) {
-  grpc_tcp *tcp = (grpc_tcp *) gpr_malloc(sizeof(grpc_tcp));
+  grpc_tcp *tcp = (grpc_tcp *)gpr_malloc(sizeof(grpc_tcp));
   memset(tcp, 0, sizeof(grpc_tcp));
   tcp->base.vtable = &vtable;
   tcp->socket = socket;
@@ -427,4 +422,4 @@ grpc_endpoint *grpc_tcp_create(grpc_winsocket *socket, char *peer_string) {
   return &tcp->base;
 }
 
-#endif  /* GPR_WINSOCK_SOCKET */
+#endif /* GPR_WINSOCK_SOCKET */

--- a/src/core/iomgr/tcp_windows.h
+++ b/src/core/iomgr/tcp_windows.h
@@ -54,4 +54,4 @@ grpc_endpoint *grpc_tcp_create(grpc_winsocket *socket, char *peer_string);
 
 int grpc_tcp_prepare_socket(SOCKET sock);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_TCP_WINDOWS_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_TCP_WINDOWS_H */

--- a/src/core/iomgr/time_averaged_stats.h
+++ b/src/core/iomgr/time_averaged_stats.h
@@ -85,4 +85,4 @@ void grpc_time_averaged_stats_add_sample(grpc_time_averaged_stats *stats,
    value. */
 double grpc_time_averaged_stats_update_average(grpc_time_averaged_stats *stats);
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_TIME_AVERAGED_STATS_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_TIME_AVERAGED_STATS_H */

--- a/src/core/iomgr/udp_server.c
+++ b/src/core/iomgr/udp_server.c
@@ -232,11 +232,11 @@ static int prepare_socket(int fd, const struct sockaddr *addr, int addr_len) {
   }
 
   get_local_ip = 1;
-  rc = setsockopt(fd, IPPROTO_IP, IP_PKTINFO,
-                      &get_local_ip, sizeof(get_local_ip));
+  rc = setsockopt(fd, IPPROTO_IP, IP_PKTINFO, &get_local_ip,
+                  sizeof(get_local_ip));
   if (rc == 0 && addr->sa_family == AF_INET6) {
-    rc = setsockopt(fd, IPPROTO_IPV6, IPV6_RECVPKTINFO,
-                    &get_local_ip, sizeof(get_local_ip));
+    rc = setsockopt(fd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &get_local_ip,
+                    sizeof(get_local_ip));
   }
 
   if (bind(fd, addr, addr_len) < 0) {
@@ -317,8 +317,8 @@ static int add_socket_to_server(grpc_udp_server *s, int fd,
   return port;
 }
 
-int grpc_udp_server_add_port(grpc_udp_server *s, const void *addr,
-                             int addr_len, grpc_udp_server_read_cb read_cb) {
+int grpc_udp_server_add_port(grpc_udp_server *s, const void *addr, int addr_len,
+                             grpc_udp_server_read_cb read_cb) {
   int allocated_port1 = -1;
   int allocated_port2 = -1;
   unsigned i;

--- a/src/core/iomgr/wakeup_fd_eventfd.c
+++ b/src/core/iomgr/wakeup_fd_eventfd.c
@@ -75,8 +75,7 @@ static int eventfd_check_availability(void) {
 }
 
 const grpc_wakeup_fd_vtable grpc_specialized_wakeup_fd_vtable = {
-  eventfd_create, eventfd_consume, eventfd_wakeup, eventfd_destroy,
-  eventfd_check_availability
-};
+    eventfd_create, eventfd_consume, eventfd_wakeup, eventfd_destroy,
+    eventfd_check_availability};
 
 #endif /* GPR_LINUX_EVENTFD */

--- a/src/core/iomgr/wakeup_fd_nospecial.c
+++ b/src/core/iomgr/wakeup_fd_nospecial.c
@@ -43,12 +43,9 @@
 #include "src/core/iomgr/wakeup_fd_posix.h"
 #include <stddef.h>
 
-static int check_availability_invalid(void) {
-  return 0;
-}
+static int check_availability_invalid(void) { return 0; }
 
 const grpc_wakeup_fd_vtable grpc_specialized_wakeup_fd_vtable = {
-  NULL, NULL, NULL, NULL, check_availability_invalid
-};
+    NULL, NULL, NULL, NULL, check_availability_invalid};
 
-#endif  /* GPR_POSIX_NO_SPECIAL_WAKEUP_FD */
+#endif /* GPR_POSIX_NO_SPECIAL_WAKEUP_FD */

--- a/src/core/iomgr/wakeup_fd_pipe.c
+++ b/src/core/iomgr/wakeup_fd_pipe.c
@@ -94,4 +94,4 @@ const grpc_wakeup_fd_vtable grpc_pipe_wakeup_fd_vtable = {
     pipe_init, pipe_consume, pipe_wakeup, pipe_destroy,
     pipe_check_availability};
 
-#endif  /* GPR_POSIX_WAKUP_FD */
+#endif /* GPR_POSIX_WAKUP_FD */

--- a/src/core/iomgr/wakeup_fd_pipe.h
+++ b/src/core/iomgr/wakeup_fd_pipe.h
@@ -38,4 +38,4 @@
 
 extern grpc_wakeup_fd_vtable grpc_pipe_wakeup_fd_vtable;
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_WAKEUP_FD_PIPE_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_WAKEUP_FD_PIPE_H */

--- a/src/core/iomgr/wakeup_fd_posix.c
+++ b/src/core/iomgr/wakeup_fd_posix.c
@@ -53,9 +53,7 @@ void grpc_wakeup_fd_global_init_force_fallback(void) {
   wakeup_fd_vtable = &grpc_pipe_wakeup_fd_vtable;
 }
 
-void grpc_wakeup_fd_global_destroy(void) {
-  wakeup_fd_vtable = NULL;
-}
+void grpc_wakeup_fd_global_destroy(void) { wakeup_fd_vtable = NULL; }
 
 void grpc_wakeup_fd_init(grpc_wakeup_fd *fd_info) {
   wakeup_fd_vtable->init(fd_info);
@@ -73,4 +71,4 @@ void grpc_wakeup_fd_destroy(grpc_wakeup_fd *fd_info) {
   wakeup_fd_vtable->destroy(fd_info);
 }
 
-#endif  /* GPR_POSIX_WAKEUP_FD */
+#endif /* GPR_POSIX_WAKEUP_FD */

--- a/src/core/iomgr/wakeup_fd_posix.h
+++ b/src/core/iomgr/wakeup_fd_posix.h
@@ -96,4 +96,4 @@ void grpc_wakeup_fd_destroy(grpc_wakeup_fd *fd_info);
  * wakeup_fd_nospecial.c if no such implementation exists. */
 extern const grpc_wakeup_fd_vtable grpc_specialized_wakeup_fd_vtable;
 
-#endif  /* GRPC_INTERNAL_CORE_IOMGR_WAKEUP_FD_POSIX_H */
+#endif /* GRPC_INTERNAL_CORE_IOMGR_WAKEUP_FD_POSIX_H */

--- a/src/core/json/json.h
+++ b/src/core/json/json.h
@@ -85,4 +85,4 @@ char* grpc_json_dump_to_string(grpc_json* json, int indent);
 grpc_json* grpc_json_create(grpc_json_type type);
 void grpc_json_destroy(grpc_json* json);
 
-#endif  /* GRPC_INTERNAL_CORE_JSON_JSON_H */
+#endif /* GRPC_INTERNAL_CORE_JSON_JSON_H */

--- a/src/core/json/json_common.h
+++ b/src/core/json/json_common.h
@@ -46,4 +46,4 @@ typedef enum {
   GRPC_JSON_TOP_LEVEL
 } grpc_json_type;
 
-#endif  /* GRPC_INTERNAL_CORE_JSON_JSON_COMMON_H */
+#endif /* GRPC_INTERNAL_CORE_JSON_JSON_COMMON_H */

--- a/src/core/json/json_reader.c
+++ b/src/core/json/json_reader.c
@@ -42,27 +42,26 @@ static void json_reader_string_clear(grpc_json_reader* reader) {
 }
 
 static void json_reader_string_add_char(grpc_json_reader* reader,
-                                             gpr_uint32 c) {
+                                        gpr_uint32 c) {
   reader->vtable->string_add_char(reader->userdata, c);
 }
 
 static void json_reader_string_add_utf32(grpc_json_reader* reader,
-                                              gpr_uint32 utf32) {
+                                         gpr_uint32 utf32) {
   reader->vtable->string_add_utf32(reader->userdata, utf32);
 }
 
-static gpr_uint32
-    grpc_json_reader_read_char(grpc_json_reader* reader) {
+static gpr_uint32 grpc_json_reader_read_char(grpc_json_reader* reader) {
   return reader->vtable->read_char(reader->userdata);
 }
 
 static void json_reader_container_begins(grpc_json_reader* reader,
-                                              grpc_json_type type) {
+                                         grpc_json_type type) {
   reader->vtable->container_begins(reader->userdata, type);
 }
 
-static grpc_json_type
-    grpc_json_reader_container_ends(grpc_json_reader* reader) {
+static grpc_json_type grpc_json_reader_container_ends(
+    grpc_json_reader* reader) {
   return reader->vtable->container_ends(reader->userdata);
 }
 
@@ -101,8 +100,9 @@ void grpc_json_reader_init(grpc_json_reader* reader,
 }
 
 int grpc_json_reader_is_complete(grpc_json_reader* reader) {
-  return ((reader->depth == 0) && ((reader->state == GRPC_JSON_STATE_END) ||
-          (reader->state == GRPC_JSON_STATE_VALUE_END)));
+  return ((reader->depth == 0) &&
+          ((reader->state == GRPC_JSON_STATE_END) ||
+           (reader->state == GRPC_JSON_STATE_VALUE_END)));
 }
 
 grpc_json_reader_status grpc_json_reader_run(grpc_json_reader* reader) {
@@ -143,7 +143,8 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader* reader) {
           case GRPC_JSON_STATE_OBJECT_KEY_STRING:
           case GRPC_JSON_STATE_VALUE_STRING:
             if (c != ' ') return GRPC_JSON_PARSE_ERROR;
-            if (reader->unicode_high_surrogate != 0) return GRPC_JSON_PARSE_ERROR;
+            if (reader->unicode_high_surrogate != 0)
+              return GRPC_JSON_PARSE_ERROR;
             json_reader_string_add_char(reader, c);
             break;
 
@@ -169,7 +170,8 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader* reader) {
         switch (reader->state) {
           case GRPC_JSON_STATE_OBJECT_KEY_STRING:
           case GRPC_JSON_STATE_VALUE_STRING:
-            if (reader->unicode_high_surrogate != 0) return GRPC_JSON_PARSE_ERROR;
+            if (reader->unicode_high_surrogate != 0)
+              return GRPC_JSON_PARSE_ERROR;
             json_reader_string_add_char(reader, c);
             break;
 
@@ -253,7 +255,8 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader* reader) {
 
           /* This is the \\ case. */
           case GRPC_JSON_STATE_STRING_ESCAPE:
-            if (reader->unicode_high_surrogate != 0) return GRPC_JSON_PARSE_ERROR;
+            if (reader->unicode_high_surrogate != 0)
+              return GRPC_JSON_PARSE_ERROR;
             json_reader_string_add_char(reader, '\\');
             if (reader->escaped_string_was_key) {
               reader->state = GRPC_JSON_STATE_OBJECT_KEY_STRING;
@@ -276,7 +279,8 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader* reader) {
             break;
 
           case GRPC_JSON_STATE_OBJECT_KEY_STRING:
-            if (reader->unicode_high_surrogate != 0) return GRPC_JSON_PARSE_ERROR;
+            if (reader->unicode_high_surrogate != 0)
+              return GRPC_JSON_PARSE_ERROR;
             if (c == '"') {
               reader->state = GRPC_JSON_STATE_OBJECT_KEY_END;
               json_reader_set_key(reader);
@@ -288,7 +292,8 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader* reader) {
             break;
 
           case GRPC_JSON_STATE_VALUE_STRING:
-            if (reader->unicode_high_surrogate != 0) return GRPC_JSON_PARSE_ERROR;
+            if (reader->unicode_high_surrogate != 0)
+              return GRPC_JSON_PARSE_ERROR;
             if (c == '"') {
               reader->state = GRPC_JSON_STATE_VALUE_END;
               json_reader_set_string(reader);
@@ -438,7 +443,8 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader* reader) {
                   if (reader->unicode_high_surrogate == 0)
                     return GRPC_JSON_PARSE_ERROR;
                   utf32 = 0x10000;
-                  utf32 += (gpr_uint32)((reader->unicode_high_surrogate - 0xd800) * 0x400);
+                  utf32 += (gpr_uint32)(
+                      (reader->unicode_high_surrogate - 0xd800) * 0x400);
                   utf32 += (gpr_uint32)(reader->unicode_char - 0xdc00);
                   json_reader_string_add_utf32(reader, utf32);
                   reader->unicode_high_surrogate = 0;

--- a/src/core/json/json_reader.h
+++ b/src/core/json/json_reader.h
@@ -157,4 +157,4 @@ void grpc_json_reader_init(grpc_json_reader* reader,
  */
 int grpc_json_reader_is_complete(grpc_json_reader* reader);
 
-#endif  /* GRPC_INTERNAL_CORE_JSON_JSON_READER_H */
+#endif /* GRPC_INTERNAL_CORE_JSON_JSON_READER_H */

--- a/src/core/json/json_string.c
+++ b/src/core/json/json_string.c
@@ -73,7 +73,6 @@ typedef struct {
   size_t allocated;
 } json_writer_userdata;
 
-
 /* This function checks if there's enough space left in the output buffer,
  * and will enlarge it if necessary. We're only allocating chunks of 256
  * bytes at a time (or multiples thereof).
@@ -97,8 +96,8 @@ static void json_writer_output_char(void* userdata, char c) {
   state->free_space--;
 }
 
-static void json_writer_output_string_with_len(void* userdata,
-                                               const char* str, size_t len) {
+static void json_writer_output_string_with_len(void* userdata, const char* str,
+                                               size_t len) {
   json_writer_userdata* state = userdata;
   json_writer_output_check(userdata, len);
   memcpy(state->output + state->string_len, str, len);
@@ -106,8 +105,7 @@ static void json_writer_output_string_with_len(void* userdata,
   state->free_space -= len;
 }
 
-static void json_writer_output_string(void* userdata,
-                                           const char* str) {
+static void json_writer_output_string(void* userdata, const char* str) {
   size_t len = strlen(str);
   json_writer_output_string_with_len(userdata, str, len);
 }
@@ -184,8 +182,7 @@ static gpr_uint32 json_reader_read_char(void* userdata) {
 /* Helper function to create a new grpc_json object and link it into
  * our tree-in-progress inside our opaque structure.
  */
-static grpc_json* json_create_and_link(void* userdata,
-                                       grpc_json_type type) {
+static grpc_json* json_create_and_link(void* userdata, grpc_json_type type) {
   json_reader_userdata* state = userdata;
   grpc_json* json = grpc_json_create(type);
 
@@ -201,7 +198,7 @@ static grpc_json* json_create_and_link(void* userdata,
       json->parent->child = json;
     }
     if (json->parent->type == GRPC_JSON_OBJECT) {
-      json->key = (char*) state->key;
+      json->key = (char*)state->key;
     }
   }
   if (!state->top) {
@@ -261,13 +258,13 @@ static void json_reader_set_key(void* userdata) {
 static void json_reader_set_string(void* userdata) {
   json_reader_userdata* state = userdata;
   grpc_json* json = json_create_and_link(userdata, GRPC_JSON_STRING);
-  json->value = (char*) state->string;
+  json->value = (char*)state->string;
 }
 
 static int json_reader_set_number(void* userdata) {
   json_reader_userdata* state = userdata;
   grpc_json* json = json_create_and_link(userdata, GRPC_JSON_NUMBER);
-  json->value = (char*) state->string;
+  json->value = (char*)state->string;
   return 1;
 }
 
@@ -287,32 +284,25 @@ static void json_reader_set_null(void* userdata) {
 }
 
 static grpc_json_reader_vtable reader_vtable = {
-  json_reader_string_clear,
-  json_reader_string_add_char,
-  json_reader_string_add_utf32,
-  json_reader_read_char,
-  json_reader_container_begins,
-  json_reader_container_ends,
-  json_reader_set_key,
-  json_reader_set_string,
-  json_reader_set_number,
-  json_reader_set_true,
-  json_reader_set_false,
-  json_reader_set_null
-};
+    json_reader_string_clear,     json_reader_string_add_char,
+    json_reader_string_add_utf32, json_reader_read_char,
+    json_reader_container_begins, json_reader_container_ends,
+    json_reader_set_key,          json_reader_set_string,
+    json_reader_set_number,       json_reader_set_true,
+    json_reader_set_false,        json_reader_set_null};
 
 /* And finally, let's define our public API. */
 grpc_json* grpc_json_parse_string_with_len(char* input, size_t size) {
   grpc_json_reader reader;
   json_reader_userdata state;
-  grpc_json *json = NULL;
+  grpc_json* json = NULL;
   grpc_json_reader_status status;
 
   if (!input) return NULL;
 
   state.top = state.current_container = state.current_value = NULL;
   state.string = state.key = NULL;
-  state.string_ptr = state.input = (gpr_uint8*) input;
+  state.string_ptr = state.input = (gpr_uint8*)input;
   state.remaining_input = size;
   grpc_json_reader_init(&reader, &reader_vtable, &state);
 
@@ -333,8 +323,8 @@ grpc_json* grpc_json_parse_string(char* input) {
   return grpc_json_parse_string_with_len(input, UNBOUND_JSON_STRING_LENGTH);
 }
 
-static void json_dump_recursive(grpc_json_writer* writer,
-                                grpc_json* json, int in_object) {
+static void json_dump_recursive(grpc_json_writer* writer, grpc_json* json,
+                                int in_object) {
   while (json) {
     if (in_object) grpc_json_writer_object_key(writer, json->key);
 
@@ -370,10 +360,8 @@ static void json_dump_recursive(grpc_json_writer* writer,
 }
 
 static grpc_json_writer_vtable writer_vtable = {
-  json_writer_output_char,
-  json_writer_output_string,
-  json_writer_output_string_with_len
-};
+    json_writer_output_char, json_writer_output_string,
+    json_writer_output_string_with_len};
 
 char* grpc_json_dump_to_string(grpc_json* json, int indent) {
   grpc_json_writer writer;

--- a/src/core/json/json_writer.c
+++ b/src/core/json/json_writer.c
@@ -41,11 +41,13 @@ static void json_writer_output_char(grpc_json_writer* writer, char c) {
   writer->vtable->output_char(writer->userdata, c);
 }
 
-static void json_writer_output_string(grpc_json_writer* writer, const char* str) {
+static void json_writer_output_string(grpc_json_writer* writer,
+                                      const char* str) {
   writer->vtable->output_string(writer->userdata, str);
 }
 
-static void json_writer_output_string_with_len(grpc_json_writer* writer, const char* str, size_t len) {
+static void json_writer_output_string_with_len(grpc_json_writer* writer,
+                                               const char* str, size_t len) {
   writer->vtable->output_string_with_len(writer->userdata, str, len);
 }
 
@@ -58,8 +60,7 @@ void grpc_json_writer_init(grpc_json_writer* writer, int indent,
   writer->userdata = userdata;
 }
 
-static void json_writer_output_indent(
-    grpc_json_writer* writer) {
+static void json_writer_output_indent(grpc_json_writer* writer) {
   static const char spacesstr[] =
       "                "
       "                "
@@ -99,14 +100,15 @@ static void json_writer_value_end(grpc_json_writer* writer) {
   }
 }
 
-static void json_writer_escape_utf16(grpc_json_writer* writer, gpr_uint16 utf16) {
+static void json_writer_escape_utf16(grpc_json_writer* writer,
+                                     gpr_uint16 utf16) {
   static const char hex[] = "0123456789abcdef";
 
   json_writer_output_string_with_len(writer, "\\u", 2);
   json_writer_output_char(writer, hex[(utf16 >> 12) & 0x0f]);
   json_writer_output_char(writer, hex[(utf16 >> 8) & 0x0f]);
   json_writer_output_char(writer, hex[(utf16 >> 4) & 0x0f]);
-  json_writer_output_char(writer, hex[(utf16) & 0x0f]);
+  json_writer_output_char(writer, hex[(utf16)&0x0f]);
 }
 
 static void json_writer_escape_string(grpc_json_writer* writer,
@@ -173,8 +175,8 @@ static void json_writer_escape_string(grpc_json_writer* writer,
        * Any other range is technically reserved for future usage, so if we
        * don't want the software to break in the future, we have to allow
        * anything else. The first non-unicode character is 0x110000. */
-      if (((utf32 >= 0xd800) && (utf32 <= 0xdfff)) ||
-          (utf32 >= 0x110000)) break;
+      if (((utf32 >= 0xd800) && (utf32 <= 0xdfff)) || (utf32 >= 0x110000))
+        break;
       if (utf32 >= 0x10000) {
         /* If utf32 contains a character that is above 0xffff, it needs to be
          * broken down into a utf-16 surrogate pair. A surrogate pair is first
@@ -194,7 +196,8 @@ static void json_writer_escape_string(grpc_json_writer* writer,
          */
         utf32 -= 0x10000;
         json_writer_escape_utf16(writer, (gpr_uint16)(0xd800 | (utf32 >> 10)));
-        json_writer_escape_utf16(writer, (gpr_uint16)(0xdc00 | (utf32 & 0x3ff)));
+        json_writer_escape_utf16(writer,
+                                 (gpr_uint16)(0xdc00 | (utf32 & 0x3ff)));
       } else {
         json_writer_escape_utf16(writer, (gpr_uint16)utf32);
       }
@@ -204,7 +207,8 @@ static void json_writer_escape_string(grpc_json_writer* writer,
   json_writer_output_char(writer, '"');
 }
 
-void grpc_json_writer_container_begins(grpc_json_writer* writer, grpc_json_type type) {
+void grpc_json_writer_container_begins(grpc_json_writer* writer,
+                                       grpc_json_type type) {
   if (!writer->got_key) json_writer_value_end(writer);
   json_writer_output_indent(writer);
   json_writer_output_char(writer, type == GRPC_JSON_OBJECT ? '{' : '[');
@@ -213,7 +217,8 @@ void grpc_json_writer_container_begins(grpc_json_writer* writer, grpc_json_type 
   writer->depth++;
 }
 
-void grpc_json_writer_container_ends(grpc_json_writer* writer, grpc_json_type type) {
+void grpc_json_writer_container_ends(grpc_json_writer* writer,
+                                     grpc_json_type type) {
   if (writer->indent && !writer->container_empty)
     json_writer_output_char(writer, '\n');
   writer->depth--;
@@ -238,14 +243,16 @@ void grpc_json_writer_value_raw(grpc_json_writer* writer, const char* string) {
   writer->got_key = 0;
 }
 
-void grpc_json_writer_value_raw_with_len(grpc_json_writer* writer, const char* string, size_t len) {
+void grpc_json_writer_value_raw_with_len(grpc_json_writer* writer,
+                                         const char* string, size_t len) {
   if (!writer->got_key) json_writer_value_end(writer);
   json_writer_output_indent(writer);
   json_writer_output_string_with_len(writer, string, len);
   writer->got_key = 0;
 }
 
-void grpc_json_writer_value_string(grpc_json_writer* writer, const char* string) {
+void grpc_json_writer_value_string(grpc_json_writer* writer,
+                                   const char* string) {
   if (!writer->got_key) json_writer_value_end(writer);
   json_writer_output_indent(writer);
   json_writer_escape_string(writer, string);

--- a/src/core/json/json_writer.h
+++ b/src/core/json/json_writer.h
@@ -78,16 +78,20 @@ void grpc_json_writer_init(grpc_json_writer* writer, int indent,
                            grpc_json_writer_vtable* vtable, void* userdata);
 
 /* Signals the beginning of a container. */
-void grpc_json_writer_container_begins(grpc_json_writer* writer, grpc_json_type type);
+void grpc_json_writer_container_begins(grpc_json_writer* writer,
+                                       grpc_json_type type);
 /* Signals the end of a container. */
-void grpc_json_writer_container_ends(grpc_json_writer* writer, grpc_json_type type);
+void grpc_json_writer_container_ends(grpc_json_writer* writer,
+                                     grpc_json_type type);
 /* Writes down an object key for the next value. */
 void grpc_json_writer_object_key(grpc_json_writer* writer, const char* string);
 /* Sets a raw value. Useful for numbers. */
 void grpc_json_writer_value_raw(grpc_json_writer* writer, const char* string);
 /* Sets a raw value with its length. Useful for values like true or false. */
-void grpc_json_writer_value_raw_with_len(grpc_json_writer* writer, const char* string, size_t len);
+void grpc_json_writer_value_raw_with_len(grpc_json_writer* writer,
+                                         const char* string, size_t len);
 /* Sets a string value. It'll be escaped, and utf-8 validated. */
-void grpc_json_writer_value_string(grpc_json_writer* writer, const char* string);
+void grpc_json_writer_value_string(grpc_json_writer* writer,
+                                   const char* string);
 
-#endif  /* GRPC_INTERNAL_CORE_JSON_JSON_WRITER_H */
+#endif /* GRPC_INTERNAL_CORE_JSON_JSON_WRITER_H */

--- a/src/core/profiling/timers.h
+++ b/src/core/profiling/timers.h
@@ -88,7 +88,7 @@ enum grpc_profiling_tags {
   } while (0)
 
 #define GRPC_TIMER_IMPORTANT_MARK(tag, id) \
-  do {                           \
+  do {                                     \
   } while (0)
 
 #define GRPC_TIMER_BEGIN(tag, id) \

--- a/src/core/security/auth_filters.h
+++ b/src/core/security/auth_filters.h
@@ -39,4 +39,4 @@
 extern const grpc_channel_filter grpc_client_auth_filter;
 extern const grpc_channel_filter grpc_server_auth_filter;
 
-#endif  /* GRPC_INTERNAL_CORE_SECURITY_AUTH_FILTERS_H */
+#endif /* GRPC_INTERNAL_CORE_SECURITY_AUTH_FILTERS_H */

--- a/src/core/security/base64.h
+++ b/src/core/security/base64.h
@@ -49,4 +49,4 @@ gpr_slice grpc_base64_decode(const char *b64, int url_safe);
 gpr_slice grpc_base64_decode_with_len(const char *b64, size_t b64_len,
                                       int url_safe);
 
-#endif  /* GRPC_INTERNAL_CORE_SECURITY_BASE64_H */
+#endif /* GRPC_INTERNAL_CORE_SECURITY_BASE64_H */

--- a/src/core/security/client_auth_filter.c
+++ b/src/core/security/client_auth_filter.c
@@ -200,7 +200,7 @@ static void auth_start_transport_op(grpc_call_element *elem,
   channel_data *chand = elem->channel_data;
   grpc_linked_mdelem *l;
   size_t i;
-  grpc_client_security_context* sec_ctx = NULL;
+  grpc_client_security_context *sec_ctx = NULL;
 
   if (calld->security_context_set == 0) {
     calld->security_context_set = 1;
@@ -316,9 +316,11 @@ static void init_channel_elem(grpc_channel_element *elem, grpc_channel *master,
       (grpc_channel_security_connector *)GRPC_SECURITY_CONNECTOR_REF(
           sc, "client_auth_filter");
   chand->md_ctx = metadata_context;
-  chand->authority_string = grpc_mdstr_from_string(chand->md_ctx, ":authority", 0);
+  chand->authority_string =
+      grpc_mdstr_from_string(chand->md_ctx, ":authority", 0);
   chand->path_string = grpc_mdstr_from_string(chand->md_ctx, ":path", 0);
-  chand->error_msg_key = grpc_mdstr_from_string(chand->md_ctx, "grpc-message", 0);
+  chand->error_msg_key =
+      grpc_mdstr_from_string(chand->md_ctx, "grpc-message", 0);
   chand->status_key = grpc_mdstr_from_string(chand->md_ctx, "grpc-status", 0);
 }
 

--- a/src/core/security/credentials.c
+++ b/src/core/security/credentials.c
@@ -793,16 +793,16 @@ void on_simulated_token_fetch_done(void *user_data, int success) {
       (grpc_credentials_metadata_request *)user_data;
   grpc_md_only_test_credentials *c = (grpc_md_only_test_credentials *)r->creds;
   GPR_ASSERT(success);
-  r->cb(r->user_data, c->md_store->entries,
-        c->md_store->num_entries, GRPC_CREDENTIALS_OK);
+  r->cb(r->user_data, c->md_store->entries, c->md_store->num_entries,
+        GRPC_CREDENTIALS_OK);
   grpc_credentials_metadata_request_destroy(r);
 }
 
 static void md_only_test_get_request_metadata(grpc_credentials *creds,
-                                             grpc_pollset *pollset,
-                                             const char *service_url,
-                                             grpc_credentials_metadata_cb cb,
-                                             void *user_data) {
+                                              grpc_pollset *pollset,
+                                              const char *service_url,
+                                              grpc_credentials_metadata_cb cb,
+                                              void *user_data) {
   grpc_md_only_test_credentials *c = (grpc_md_only_test_credentials *)creds;
 
   if (c->is_async) {
@@ -854,10 +854,10 @@ static int access_token_has_request_metadata_only(
 }
 
 static void access_token_get_request_metadata(grpc_credentials *creds,
-                                             grpc_pollset *pollset,
-                                             const char *service_url,
-                                             grpc_credentials_metadata_cb cb,
-                                             void *user_data) {
+                                              grpc_pollset *pollset,
+                                              const char *service_url,
+                                              grpc_credentials_metadata_cb cb,
+                                              void *user_data) {
   grpc_access_token_credentials *c = (grpc_access_token_credentials *)creds;
   cb(user_data, c->access_token_md->entries, 1, GRPC_CREDENTIALS_OK);
 }

--- a/src/core/security/credentials.h
+++ b/src/core/security/credentials.h
@@ -192,8 +192,9 @@ void grpc_flush_cached_google_default_credentials(void);
 
 /* Metadata-only credentials with the specified key and value where
    asynchronicity can be simulated for testing. */
-grpc_credentials *grpc_md_only_test_credentials_create(
-    const char *md_key, const char *md_value, int is_async);
+grpc_credentials *grpc_md_only_test_credentials_create(const char *md_key,
+                                                       const char *md_value,
+                                                       int is_async);
 
 /* Private constructor for jwt credentials from an already parsed json key.
    Takes ownership of the key. */

--- a/src/core/security/credentials_metadata.c
+++ b/src/core/security/credentials_metadata.c
@@ -47,7 +47,8 @@ static void store_ensure_capacity(grpc_credentials_md_store *store) {
 
 grpc_credentials_md_store *grpc_credentials_md_store_create(
     size_t initial_capacity) {
-  grpc_credentials_md_store *store = gpr_malloc(sizeof(grpc_credentials_md_store));
+  grpc_credentials_md_store *store =
+      gpr_malloc(sizeof(grpc_credentials_md_store));
   memset(store, 0, sizeof(grpc_credentials_md_store));
   if (initial_capacity > 0) {
     store->entries = gpr_malloc(initial_capacity * sizeof(grpc_credentials_md));
@@ -98,4 +99,3 @@ void grpc_credentials_md_store_unref(grpc_credentials_md_store *store) {
     gpr_free(store);
   }
 }
-

--- a/src/core/security/google_default_credentials.c
+++ b/src/core/security/google_default_credentials.c
@@ -203,8 +203,8 @@ end:
     /* Blend with default ssl credentials and add a global reference so that it
        can be cached and re-served. */
     grpc_credentials *ssl_creds = grpc_ssl_credentials_create(NULL, NULL);
-    default_credentials = grpc_credentials_ref(grpc_composite_credentials_create(
-        ssl_creds, result));
+    default_credentials = grpc_credentials_ref(
+        grpc_composite_credentials_create(ssl_creds, result));
     GPR_ASSERT(default_credentials != NULL);
     grpc_credentials_unref(ssl_creds);
     grpc_credentials_unref(result);

--- a/src/core/security/json_token.h
+++ b/src/core/security/json_token.h
@@ -115,4 +115,4 @@ grpc_auth_refresh_token grpc_auth_refresh_token_create_from_json(
 /* Destructs the object. */
 void grpc_auth_refresh_token_destruct(grpc_auth_refresh_token *refresh_token);
 
-#endif  /* GRPC_INTERNAL_CORE_SECURITY_JSON_TOKEN_H */
+#endif /* GRPC_INTERNAL_CORE_SECURITY_JSON_TOKEN_H */

--- a/src/core/security/jwt_verifier.h
+++ b/src/core/security/jwt_verifier.h
@@ -133,4 +133,3 @@ grpc_jwt_verifier_status grpc_jwt_claims_check(const grpc_jwt_claims *claims,
                                                const char *audience);
 
 #endif /* GRPC_INTERNAL_CORE_SECURITY_JWT_VERIFIER_H */
-

--- a/src/core/security/secure_endpoint.c
+++ b/src/core/security/secure_endpoint.c
@@ -332,7 +332,7 @@ static void endpoint_add_to_pollset(grpc_endpoint *secure_ep,
 }
 
 static void endpoint_add_to_pollset_set(grpc_endpoint *secure_ep,
-                                    grpc_pollset_set *pollset_set) {
+                                        grpc_pollset_set *pollset_set) {
   secure_endpoint *ep = (secure_endpoint *)secure_ep;
   grpc_endpoint_add_to_pollset_set(ep->wrapped_ep, pollset_set);
 }

--- a/src/core/security/secure_endpoint.h
+++ b/src/core/security/secure_endpoint.h
@@ -46,4 +46,4 @@ grpc_endpoint *grpc_secure_endpoint_create(
     struct tsi_frame_protector *protector, grpc_endpoint *to_wrap,
     gpr_slice *leftover_slices, size_t leftover_nslices);
 
-#endif  /* GRPC_INTERNAL_CORE_SECURITY_SECURE_ENDPOINT_H */
+#endif /* GRPC_INTERNAL_CORE_SECURITY_SECURE_ENDPOINT_H */

--- a/src/core/security/secure_transport_setup.h
+++ b/src/core/security/secure_transport_setup.h
@@ -50,4 +50,4 @@ void grpc_setup_secure_transport(grpc_security_connector *connector,
                                  grpc_secure_transport_setup_done_cb cb,
                                  void *user_data);
 
-#endif  /* GRPC_INTERNAL_CORE_SECURITY_SECURE_TRANSPORT_SETUP_H */
+#endif /* GRPC_INTERNAL_CORE_SECURITY_SECURE_TRANSPORT_SETUP_H */

--- a/src/core/security/security_context.c
+++ b/src/core/security/security_context.c
@@ -204,8 +204,7 @@ int grpc_auth_context_set_peer_identity_property_name(grpc_auth_context *ctx,
   return 1;
 }
 
-int grpc_auth_context_peer_is_authenticated(
-    const grpc_auth_context *ctx) {
+int grpc_auth_context_peer_is_authenticated(const grpc_auth_context *ctx) {
   return ctx->peer_identity_property_name == NULL ? 0 : 1;
 }
 
@@ -326,4 +325,3 @@ grpc_auth_metadata_processor *grpc_find_auth_metadata_processor_in_args(
   }
   return NULL;
 }
-

--- a/src/core/security/security_context.h
+++ b/src/core/security/security_context.h
@@ -112,5 +112,4 @@ grpc_auth_metadata_processor *grpc_auth_metadata_processor_from_arg(
 grpc_auth_metadata_processor *grpc_find_auth_metadata_processor_in_args(
     const grpc_channel_args *args);
 
-#endif  /* GRPC_INTERNAL_CORE_SECURITY_SECURITY_CONTEXT_H */
-
+#endif /* GRPC_INTERNAL_CORE_SECURITY_SECURITY_CONTEXT_H */

--- a/src/core/security/server_auth_filter.c
+++ b/src/core/security/server_auth_filter.c
@@ -212,8 +212,7 @@ static void init_call_elem(grpc_call_element *elem,
 }
 
 /* Destructor for call_data */
-static void destroy_call_elem(grpc_call_element *elem) {
-}
+static void destroy_call_elem(grpc_call_element *elem) {}
 
 /* Constructor for channel_data */
 static void init_channel_elem(grpc_channel_element *elem, grpc_channel *master,

--- a/src/core/statistics/census_interface.h
+++ b/src/core/statistics/census_interface.h
@@ -73,4 +73,4 @@ census_op_id census_tracing_start_op(void);
 /* Ends tracing. Calling this function will invalidate the input op_id. */
 void census_tracing_end_op(census_op_id op_id);
 
-#endif  /* GRPC_INTERNAL_CORE_STATISTICS_CENSUS_INTERFACE_H */
+#endif /* GRPC_INTERNAL_CORE_STATISTICS_CENSUS_INTERFACE_H */

--- a/src/core/statistics/census_log.h
+++ b/src/core/statistics/census_log.h
@@ -88,4 +88,4 @@ size_t census_log_remaining_space(void);
    out-of-space. */
 int census_log_out_of_space_count(void);
 
-#endif  /* GRPC_INTERNAL_CORE_STATISTICS_CENSUS_LOG_H */
+#endif /* GRPC_INTERNAL_CORE_STATISTICS_CENSUS_LOG_H */

--- a/src/core/statistics/census_rpc_stats.c
+++ b/src/core/statistics/census_rpc_stats.c
@@ -85,8 +85,8 @@ static void delete_key(void* key) { gpr_free(key); }
 
 static const census_ht_option ht_opt = {
     CENSUS_HT_POINTER /* key type */, 1999 /* n_of_buckets */,
-    simple_hash /* hash function */, cmp_str_keys /* key comparator */,
-    delete_stats /* data deleter */, delete_key /* key deleter */
+    simple_hash /* hash function */,  cmp_str_keys /* key comparator */,
+    delete_stats /* data deleter */,  delete_key /* key deleter */
 };
 
 static void init_rpc_stats(void* stats) {

--- a/src/core/statistics/census_rpc_stats.h
+++ b/src/core/statistics/census_rpc_stats.h
@@ -98,4 +98,4 @@ void census_stats_store_shutdown(void);
 }
 #endif
 
-#endif  /* GRPC_INTERNAL_CORE_STATISTICS_CENSUS_RPC_STATS_H */
+#endif /* GRPC_INTERNAL_CORE_STATISTICS_CENSUS_RPC_STATS_H */

--- a/src/core/statistics/census_tracing.c
+++ b/src/core/statistics/census_tracing.c
@@ -60,8 +60,11 @@ static void delete_trace_obj(void* obj) {
 }
 
 static const census_ht_option ht_opt = {
-    CENSUS_HT_UINT64 /* key type*/, 571 /* n_of_buckets */, NULL /* hash */,
-    NULL /* compare_keys */, delete_trace_obj /* delete data */,
+    CENSUS_HT_UINT64 /* key type*/,
+    571 /* n_of_buckets */,
+    NULL /* hash */,
+    NULL /* compare_keys */,
+    delete_trace_obj /* delete data */,
     NULL /* delete key */
 };
 

--- a/src/core/statistics/census_tracing.h
+++ b/src/core/statistics/census_tracing.h
@@ -93,4 +93,4 @@ census_trace_obj** census_get_active_ops(int* num_active_ops);
 }
 #endif
 
-#endif  /* GRPC_INTERNAL_CORE_STATISTICS_CENSUS_TRACING_H */
+#endif /* GRPC_INTERNAL_CORE_STATISTICS_CENSUS_TRACING_H */

--- a/src/core/statistics/hash_table.h
+++ b/src/core/statistics/hash_table.h
@@ -128,4 +128,4 @@ typedef void (*census_ht_itr_cb)(census_ht_key key, const void* val_ptr,
    should not invalidate data entries. */
 gpr_uint64 census_ht_for_all(const census_ht* ht, census_ht_itr_cb);
 
-#endif  /* GRPC_INTERNAL_CORE_STATISTICS_HASH_TABLE_H */
+#endif /* GRPC_INTERNAL_CORE_STATISTICS_HASH_TABLE_H */

--- a/src/core/support/cpu_iphone.c
+++ b/src/core/support/cpu_iphone.c
@@ -36,9 +36,7 @@
 #ifdef GPR_CPU_IPHONE
 
 /* Probably 2 instead of 1, but see comment on gpr_cpu_current_cpu. */
-unsigned gpr_cpu_num_cores(void) {
-  return 1;
-}
+unsigned gpr_cpu_num_cores(void) { return 1; }
 
 /* Most code that's using this is using it to shard across work queues. So
    unless profiling shows it's a problem or there appears a way to detect the
@@ -46,8 +44,6 @@ unsigned gpr_cpu_num_cores(void) {
    Note that the interface in cpu.h lets gpr_cpu_num_cores return 0, but doing
    it makes it impossible for gpr_cpu_current_cpu to satisfy its stated range,
    and some code might be relying on it. */
-unsigned gpr_cpu_current_cpu(void) {
-  return 0;
-}
+unsigned gpr_cpu_current_cpu(void) { return 0; }
 
 #endif /* GPR_CPU_IPHONE */

--- a/src/core/support/cpu_linux.c
+++ b/src/core/support/cpu_linux.c
@@ -33,7 +33,7 @@
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
-#endif  /* _GNU_SOURCE */
+#endif /* _GNU_SOURCE */
 
 #include <grpc/support/port_platform.h>
 

--- a/src/core/support/env.h
+++ b/src/core/support/env.h
@@ -57,4 +57,4 @@ void gpr_setenv(const char *name, const char *value);
 }
 #endif
 
-#endif  /* GRPC_INTERNAL_CORE_SUPPORT_ENV_H */
+#endif /* GRPC_INTERNAL_CORE_SUPPORT_ENV_H */

--- a/src/core/support/file.h
+++ b/src/core/support/file.h
@@ -60,4 +60,4 @@ FILE *gpr_tmpfile(const char *prefix, char **tmp_filename);
 }
 #endif
 
-#endif  /* GRPC_INTERNAL_CORE_SUPPORT_FILE_H */
+#endif /* GRPC_INTERNAL_CORE_SUPPORT_FILE_H */

--- a/src/core/support/histogram.c
+++ b/src/core/support/histogram.c
@@ -191,15 +191,18 @@ static double threshold_for_count_below(gpr_histogram *h, double count_below) {
         break;
       }
     }
-    return (bucket_start(h, (double)lower_idx) + bucket_start(h, (double)upper_idx)) / 2.0;
+    return (bucket_start(h, (double)lower_idx) +
+            bucket_start(h, (double)upper_idx)) /
+           2.0;
   } else {
     /* treat values as uniform throughout the bucket, and find where this value
        should lie */
     lower_bound = bucket_start(h, (double)lower_idx);
     upper_bound = bucket_start(h, (double)(lower_idx + 1));
-    return GPR_CLAMP(upper_bound - (upper_bound - lower_bound) *
-                                       (count_so_far - count_below) /
-                                       h->buckets[lower_idx],
+    return GPR_CLAMP(upper_bound -
+                         (upper_bound - lower_bound) *
+                             (count_so_far - count_below) /
+                             h->buckets[lower_idx],
                      h->min_seen, h->max_seen);
   }
 }

--- a/src/core/support/log_linux.c
+++ b/src/core/support/log_linux.c
@@ -93,8 +93,8 @@ void gpr_default_log(gpr_log_func_args *args) {
   }
 
   gpr_asprintf(&prefix, "%s%s.%09d %7tu %s:%d]",
-          gpr_log_severity_string(args->severity), time_buffer,
-          (int)(now.tv_nsec), gettid(), display_file, args->line);
+               gpr_log_severity_string(args->severity), time_buffer,
+               (int)(now.tv_nsec), gettid(), display_file, args->line);
 
   fprintf(stderr, "%-60s %s\n", prefix, args->message);
   gpr_free(prefix);

--- a/src/core/support/murmur_hash.h
+++ b/src/core/support/murmur_hash.h
@@ -41,4 +41,4 @@
 /* compute the hash of key (length len) */
 gpr_uint32 gpr_murmur_hash3(const void *key, size_t len, gpr_uint32 seed);
 
-#endif  /* GRPC_INTERNAL_CORE_SUPPORT_MURMUR_HASH_H */
+#endif /* GRPC_INTERNAL_CORE_SUPPORT_MURMUR_HASH_H */

--- a/src/core/support/slice.c
+++ b/src/core/support/slice.c
@@ -284,7 +284,8 @@ gpr_slice gpr_slice_split_head(gpr_slice *source, size_t split) {
     head.refcount = NULL;
     head.data.inlined.length = (gpr_uint8)split;
     memcpy(head.data.inlined.bytes, source->data.inlined.bytes, split);
-    source->data.inlined.length = (gpr_uint8)(source->data.inlined.length - split);
+    source->data.inlined.length =
+        (gpr_uint8)(source->data.inlined.length - split);
     memmove(source->data.inlined.bytes, source->data.inlined.bytes + split,
             source->data.inlined.length);
   } else if (split < sizeof(head.data.inlined.bytes)) {

--- a/src/core/support/slice_buffer.c
+++ b/src/core/support/slice_buffer.c
@@ -116,7 +116,8 @@ void gpr_slice_buffer_add(gpr_slice_buffer *sb, gpr_slice s) {
           GPR_SLICE_INLINED_SIZE) {
         memcpy(back->data.inlined.bytes + back->data.inlined.length,
                s.data.inlined.bytes, s.data.inlined.length);
-        back->data.inlined.length = (gpr_uint8)(back->data.inlined.length + s.data.inlined.length);
+        back->data.inlined.length =
+            (gpr_uint8)(back->data.inlined.length + s.data.inlined.length);
       } else {
         size_t cp1 = GPR_SLICE_INLINED_SIZE - back->data.inlined.length;
         memcpy(back->data.inlined.bytes + back->data.inlined.length,

--- a/src/core/support/stack_lockfree.c
+++ b/src/core/support/stack_lockfree.c
@@ -67,7 +67,7 @@ typedef union lockfree_node {
 #define ENTRY_ALIGNMENT_BITS 3 /* make sure that entries aligned to 8-bytes */
 #define INVALID_ENTRY_INDEX                        \
   ((1 << 16) - 1) /* reserve this entry as invalid \
-                       */
+                        */
 
 struct gpr_stack_lockfree {
   lockfree_node *entries;
@@ -75,7 +75,7 @@ struct gpr_stack_lockfree {
 
 #ifndef NDEBUG
   /* Bitmap of pushed entries to check for double-push or pop */
-  gpr_atm pushed[(INVALID_ENTRY_INDEX+1)/(8*sizeof(gpr_atm))];
+  gpr_atm pushed[(INVALID_ENTRY_INDEX + 1) / (8 * sizeof(gpr_atm))];
 #endif
 };
 
@@ -123,13 +123,13 @@ int gpr_stack_lockfree_push(gpr_stack_lockfree *stack, int entry) {
 #ifndef NDEBUG
   /* Check for double push */
   {
-    int pushed_index = entry / (8*sizeof(gpr_atm));
-    int pushed_bit = entry % (8*sizeof(gpr_atm));
+    int pushed_index = entry / (8 * sizeof(gpr_atm));
+    int pushed_bit = entry % (8 * sizeof(gpr_atm));
     gpr_atm old_val;
 
     old_val = gpr_atm_no_barrier_fetch_add(&stack->pushed[pushed_index],
-					   (gpr_atm)(1UL << pushed_bit));
-    GPR_ASSERT((old_val & (1UL<<pushed_bit)) == 0);
+                                           (gpr_atm)(1UL << pushed_bit));
+    GPR_ASSERT((old_val & (1UL << pushed_bit)) == 0);
   }
 #endif
 
@@ -161,13 +161,13 @@ int gpr_stack_lockfree_pop(gpr_stack_lockfree *stack) {
 #ifndef NDEBUG
   /* Check for valid pop */
   {
-    int pushed_index = head.contents.index / (8*sizeof(gpr_atm));
-    int pushed_bit = head.contents.index % (8*sizeof(gpr_atm));
+    int pushed_index = head.contents.index / (8 * sizeof(gpr_atm));
+    int pushed_bit = head.contents.index % (8 * sizeof(gpr_atm));
     gpr_atm old_val;
 
     old_val = gpr_atm_no_barrier_fetch_add(&stack->pushed[pushed_index],
-					   -(gpr_atm)(1UL << pushed_bit));
-    GPR_ASSERT((old_val & (1UL<<pushed_bit)) != 0);
+                                           -(gpr_atm)(1UL << pushed_bit));
+    GPR_ASSERT((old_val & (1UL << pushed_bit)) != 0);
   }
 #endif
 

--- a/src/core/support/string.c
+++ b/src/core/support/string.c
@@ -125,7 +125,6 @@ char *gpr_dump_slice(gpr_slice s, gpr_uint32 flags) {
                   flags);
 }
 
-
 int gpr_parse_bytes_to_uint32(const char *buf, size_t len, gpr_uint32 *result) {
   gpr_uint32 out = 0;
   gpr_uint32 new;
@@ -187,9 +186,9 @@ char *gpr_strjoin_sep(const char **strs, size_t nstrs, const char *sep,
   for (i = 0; i < nstrs; i++) {
     out_length += strlen(strs[i]);
   }
-  out_length += 1;  /* null terminator */
+  out_length += 1; /* null terminator */
   if (nstrs > 0) {
-    out_length += sep_len * (nstrs - 1);  /* separators */
+    out_length += sep_len * (nstrs - 1); /* separators */
   }
   out = gpr_malloc(out_length);
   out_length = 0;
@@ -214,10 +213,8 @@ char *gpr_strjoin_sep(const char **strs, size_t nstrs, const char *sep,
  * str.
  *
  * Returns 1 and updates \a begin and \a end. Returns 0 otherwise. */
-static int slice_find_separator_offset(const gpr_slice str,
-                                       const char *sep,
-                                       const size_t read_offset,
-                                       size_t *begin,
+static int slice_find_separator_offset(const gpr_slice str, const char *sep,
+                                       const size_t read_offset, size_t *begin,
                                        size_t *end) {
   size_t i;
   const gpr_uint8 *str_ptr = GPR_SLICE_START_PTR(str) + read_offset;
@@ -255,9 +252,7 @@ void gpr_slice_split(gpr_slice str, const char *sep, gpr_slice_buffer *dst) {
   }
 }
 
-void gpr_strvec_init(gpr_strvec *sv) {
-  memset(sv, 0, sizeof(*sv));
-}
+void gpr_strvec_init(gpr_strvec *sv) { memset(sv, 0, sizeof(*sv)); }
 
 void gpr_strvec_destroy(gpr_strvec *sv) {
   size_t i;
@@ -270,11 +265,11 @@ void gpr_strvec_destroy(gpr_strvec *sv) {
 void gpr_strvec_add(gpr_strvec *sv, char *str) {
   if (sv->count == sv->capacity) {
     sv->capacity = GPR_MAX(sv->capacity + 8, sv->capacity * 2);
-    sv->strs = gpr_realloc(sv->strs, sizeof(char*) * sv->capacity);
+    sv->strs = gpr_realloc(sv->strs, sizeof(char *) * sv->capacity);
   }
   sv->strs[sv->count++] = str;
 }
 
 char *gpr_strvec_flatten(gpr_strvec *sv, size_t *final_length) {
-  return gpr_strjoin((const char**)sv->strs, sv->count, final_length);
+  return gpr_strjoin((const char **)sv->strs, sv->count, final_length);
 }

--- a/src/core/support/string.h
+++ b/src/core/support/string.h
@@ -47,7 +47,7 @@ extern "C" {
 /* String utility functions */
 
 /* Flags for gpr_dump function. */
-#define GPR_DUMP_HEX   0x00000001
+#define GPR_DUMP_HEX 0x00000001
 #define GPR_DUMP_ASCII 0x00000002
 
 /* Converts array buf, of length len, into a C string  according to the flags.
@@ -108,4 +108,4 @@ char *gpr_strvec_flatten(gpr_strvec *strs, size_t *total_length);
 }
 #endif
 
-#endif  /* GRPC_INTERNAL_CORE_SUPPORT_STRING_H */
+#endif /* GRPC_INTERNAL_CORE_SUPPORT_STRING_H */

--- a/src/core/support/string_win32.c
+++ b/src/core/support/string_win32.c
@@ -99,13 +99,9 @@ LPSTR gpr_tchar_to_char(LPCTSTR input) {
   return ret;
 }
 #else
-char *gpr_tchar_to_char(LPTSTR input) {
-  return gpr_strdup(input);
-}
+char *gpr_tchar_to_char(LPTSTR input) { return gpr_strdup(input); }
 
-char *gpr_char_to_tchar(LPTSTR input) {
-  return gpr_strdup(input);
-}
+char *gpr_char_to_tchar(LPTSTR input) { return gpr_strdup(input); }
 #endif
 
 #endif /* GPR_WIN32 */

--- a/src/core/support/string_win32.h
+++ b/src/core/support/string_win32.h
@@ -42,6 +42,6 @@
 LPTSTR gpr_char_to_tchar(LPCSTR input);
 LPSTR gpr_tchar_to_char(LPCTSTR input);
 
-#endif  /* GPR_WIN32 */
+#endif /* GPR_WIN32 */
 
-#endif  /* GRPC_INTERNAL_CORE_SUPPORT_STRING_WIN32_H */
+#endif /* GRPC_INTERNAL_CORE_SUPPORT_STRING_WIN32_H */

--- a/src/core/support/sync_posix.c
+++ b/src/core/support/sync_posix.c
@@ -63,7 +63,8 @@ void gpr_cv_destroy(gpr_cv *cv) { GPR_ASSERT(pthread_cond_destroy(cv) == 0); }
 
 int gpr_cv_wait(gpr_cv *cv, gpr_mu *mu, gpr_timespec abs_deadline) {
   int err = 0;
-  if (gpr_time_cmp(abs_deadline, gpr_inf_future(abs_deadline.clock_type)) == 0) {
+  if (gpr_time_cmp(abs_deadline, gpr_inf_future(abs_deadline.clock_type)) ==
+      0) {
     err = pthread_cond_wait(cv, mu);
   } else {
     struct timespec abs_deadline_ts;

--- a/src/core/support/sync_win32.c
+++ b/src/core/support/sync_win32.c
@@ -83,7 +83,8 @@ int gpr_cv_wait(gpr_cv *cv, gpr_mu *mu, gpr_timespec abs_deadline) {
   int timeout = 0;
   DWORD timeout_max_ms;
   mu->locked = 0;
-  if (gpr_time_cmp(abs_deadline, gpr_inf_future(abs_deadline.clock_type)) == 0) {
+  if (gpr_time_cmp(abs_deadline, gpr_inf_future(abs_deadline.clock_type)) ==
+      0) {
     SleepConditionVariableCS(cv, &mu->cs, INFINITE);
   } else {
     gpr_timespec now = gpr_now(abs_deadline.clock_type);

--- a/src/core/support/thd.c
+++ b/src/core/support/thd.c
@@ -37,9 +37,7 @@
 
 #include <grpc/support/thd.h>
 
-enum {
-  GPR_THD_JOINABLE = 1
-};
+enum { GPR_THD_JOINABLE = 1 };
 
 gpr_thd_options gpr_thd_options_default(void) {
   gpr_thd_options options;

--- a/src/core/support/thd_internal.h
+++ b/src/core/support/thd_internal.h
@@ -36,4 +36,4 @@
 
 /* Internal interfaces between modules within the gpr support library.  */
 
-#endif  /* GRPC_INTERNAL_CORE_SUPPORT_THD_INTERNAL_H */
+#endif /* GRPC_INTERNAL_CORE_SUPPORT_THD_INTERNAL_H */

--- a/src/core/support/thd_posix.c
+++ b/src/core/support/thd_posix.c
@@ -69,9 +69,11 @@ int gpr_thd_new(gpr_thd_id *t, void (*thd_body)(void *arg), void *arg,
 
   GPR_ASSERT(pthread_attr_init(&attr) == 0);
   if (gpr_thd_options_is_detached(options)) {
-    GPR_ASSERT(pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) == 0);
+    GPR_ASSERT(pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) ==
+               0);
   } else {
-    GPR_ASSERT(pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE) == 0);
+    GPR_ASSERT(pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE) ==
+               0);
   }
   thread_started = (pthread_create(&p, &attr, &thread_body, a) == 0);
   GPR_ASSERT(pthread_attr_destroy(&attr) == 0);
@@ -82,12 +84,8 @@ int gpr_thd_new(gpr_thd_id *t, void (*thd_body)(void *arg), void *arg,
   return thread_started;
 }
 
-gpr_thd_id gpr_thd_currentid(void) {
-  return (gpr_thd_id)pthread_self();
-}
+gpr_thd_id gpr_thd_currentid(void) { return (gpr_thd_id)pthread_self(); }
 
-void gpr_thd_join(gpr_thd_id t) {
-  pthread_join((pthread_t)t, NULL);
-}
+void gpr_thd_join(gpr_thd_id t) { pthread_join((pthread_t)t, NULL); }
 
 #endif /* GPR_POSIX_SYNC */

--- a/src/core/support/thd_win32.c
+++ b/src/core/support/thd_win32.c
@@ -105,9 +105,7 @@ int gpr_thd_new(gpr_thd_id *t, void (*thd_body)(void *arg), void *arg,
   return handle != NULL;
 }
 
-gpr_thd_id gpr_thd_currentid(void) {
-  return (gpr_thd_id)g_thd_info;
-}
+gpr_thd_id gpr_thd_currentid(void) { return (gpr_thd_id)g_thd_info; }
 
 void gpr_thd_join(gpr_thd_id t) {
   struct thd_info *info = (struct thd_info *)t;

--- a/src/core/support/time.c
+++ b/src/core/support/time.c
@@ -315,5 +315,6 @@ gpr_timespec gpr_convert_clock_type(gpr_timespec t, gpr_clock_type clock_type) {
     return gpr_time_add(gpr_now(clock_type), t);
   }
 
-  return gpr_time_add(gpr_now(clock_type), gpr_time_sub(t, gpr_now(t.clock_type)));
+  return gpr_time_add(gpr_now(clock_type),
+                      gpr_time_sub(t, gpr_now(t.clock_type)));
 }

--- a/src/core/support/tls_pthread.c
+++ b/src/core/support/tls_pthread.c
@@ -38,7 +38,7 @@
 #include <grpc/support/tls.h>
 
 gpr_intptr gpr_tls_set(struct gpr_pthread_thread_local *tls, gpr_intptr value) {
-  GPR_ASSERT(0 == pthread_setspecific(tls->key, (void*)value));
+  GPR_ASSERT(0 == pthread_setspecific(tls->key, (void *)value));
   return value;
 }
 

--- a/src/core/surface/byte_buffer_queue.h
+++ b/src/core/surface/byte_buffer_queue.h
@@ -59,4 +59,4 @@ int grpc_bbq_empty(grpc_byte_buffer_queue *q);
 void grpc_bbq_push(grpc_byte_buffer_queue *q, grpc_byte_buffer *bb);
 size_t grpc_bbq_bytes(grpc_byte_buffer_queue *q);
 
-#endif  /* GRPC_INTERNAL_CORE_SURFACE_BYTE_BUFFER_QUEUE_H */
+#endif /* GRPC_INTERNAL_CORE_SURFACE_BYTE_BUFFER_QUEUE_H */

--- a/src/core/surface/call.c
+++ b/src/core/surface/call.c
@@ -276,7 +276,8 @@ struct grpc_call {
   /** completion events - for completion queue use */
   grpc_cq_completion completions[MAX_CONCURRENT_COMPLETIONS];
 
-  /** siblings: children of the same parent form a list, and this list is protected under
+  /** siblings: children of the same parent form a list, and this list is
+     protected under
       parent->mu */
   grpc_call *sibling_next;
   grpc_call *sibling_prev;
@@ -398,7 +399,8 @@ grpc_call *grpc_call_create(grpc_channel *channel, grpc_call *parent_call,
     } else {
       call->sibling_next = parent_call->first_child;
       call->sibling_prev = parent_call->first_child->sibling_prev;
-      call->sibling_next->sibling_prev = call->sibling_prev->sibling_next = call;
+      call->sibling_next->sibling_prev = call->sibling_prev->sibling_next =
+          call;
     }
 
     gpr_mu_unlock(&parent_call->mu);
@@ -536,9 +538,8 @@ grpc_compression_algorithm grpc_call_get_compression_algorithm(
   return call->compression_algorithm;
 }
 
-
-static void set_encodings_accepted_by_peer(grpc_call *call,
-                                const gpr_slice accept_encoding_slice) {
+static void set_encodings_accepted_by_peer(
+    grpc_call *call, const gpr_slice accept_encoding_slice) {
   size_t i;
   grpc_compression_algorithm algorithm;
   gpr_slice_buffer accept_encoding_parts;
@@ -1324,7 +1325,7 @@ grpc_call_error grpc_call_cancel_with_status(grpc_call *c,
                                              const char *description,
                                              void *reserved) {
   grpc_call_error r;
-  (void) reserved;
+  (void)reserved;
   lock(c);
   r = cancel_with_status(c, status, description);
   unlock(c);
@@ -1592,7 +1593,7 @@ grpc_call_error grpc_call_start_batch(grpc_call *call, const grpc_op *ops,
         /* Flag validation: currently allow no flags */
         if (op->flags != 0) return GRPC_CALL_ERROR_INVALID_FLAGS;
         req = &reqs[out++];
-	if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
+        if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
         req->op = GRPC_IOREQ_SEND_INITIAL_METADATA;
         req->data.send_metadata.count = op->data.send_initial_metadata.count;
         req->data.send_metadata.metadata =
@@ -1607,7 +1608,7 @@ grpc_call_error grpc_call_start_batch(grpc_call *call, const grpc_op *ops,
           return GRPC_CALL_ERROR_INVALID_MESSAGE;
         }
         req = &reqs[out++];
-	if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
+        if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
         req->op = GRPC_IOREQ_SEND_MESSAGE;
         req->data.send_message = op->data.send_message;
         req->flags = op->flags;
@@ -1619,7 +1620,7 @@ grpc_call_error grpc_call_start_batch(grpc_call *call, const grpc_op *ops,
           return GRPC_CALL_ERROR_NOT_ON_SERVER;
         }
         req = &reqs[out++];
-	if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
+        if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
         req->op = GRPC_IOREQ_SEND_CLOSE;
         req->flags = op->flags;
         break;
@@ -1630,7 +1631,7 @@ grpc_call_error grpc_call_start_batch(grpc_call *call, const grpc_op *ops,
           return GRPC_CALL_ERROR_NOT_ON_CLIENT;
         }
         req = &reqs[out++];
-	if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
+        if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
         req->op = GRPC_IOREQ_SEND_TRAILING_METADATA;
         req->flags = op->flags;
         req->data.send_metadata.count =
@@ -1638,7 +1639,7 @@ grpc_call_error grpc_call_start_batch(grpc_call *call, const grpc_op *ops,
         req->data.send_metadata.metadata =
             op->data.send_status_from_server.trailing_metadata;
         req = &reqs[out++];
-	if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
+        if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
         req->op = GRPC_IOREQ_SEND_STATUS;
         req->data.send_status.code = op->data.send_status_from_server.status;
         req->data.send_status.details =
@@ -1648,7 +1649,7 @@ grpc_call_error grpc_call_start_batch(grpc_call *call, const grpc_op *ops,
                       op->data.send_status_from_server.status_details, 0)
                 : NULL;
         req = &reqs[out++];
-	if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
+        if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
         req->op = GRPC_IOREQ_SEND_CLOSE;
         break;
       case GRPC_OP_RECV_INITIAL_METADATA:
@@ -1658,7 +1659,7 @@ grpc_call_error grpc_call_start_batch(grpc_call *call, const grpc_op *ops,
           return GRPC_CALL_ERROR_NOT_ON_SERVER;
         }
         req = &reqs[out++];
-	if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
+        if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
         req->op = GRPC_IOREQ_RECV_INITIAL_METADATA;
         req->data.recv_metadata = op->data.recv_initial_metadata;
         req->data.recv_metadata->count = 0;
@@ -1668,7 +1669,7 @@ grpc_call_error grpc_call_start_batch(grpc_call *call, const grpc_op *ops,
         /* Flag validation: currently allow no flags */
         if (op->flags != 0) return GRPC_CALL_ERROR_INVALID_FLAGS;
         req = &reqs[out++];
-	if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
+        if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
         req->op = GRPC_IOREQ_RECV_MESSAGE;
         req->data.recv_message = op->data.recv_message;
         req->flags = op->flags;
@@ -1680,26 +1681,26 @@ grpc_call_error grpc_call_start_batch(grpc_call *call, const grpc_op *ops,
           return GRPC_CALL_ERROR_NOT_ON_SERVER;
         }
         req = &reqs[out++];
-	if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
+        if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
         req->op = GRPC_IOREQ_RECV_STATUS;
         req->flags = op->flags;
         req->data.recv_status.set_value = set_status_value_directly;
         req->data.recv_status.user_data = op->data.recv_status_on_client.status;
         req = &reqs[out++];
-	if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
+        if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
         req->op = GRPC_IOREQ_RECV_STATUS_DETAILS;
         req->data.recv_status_details.details =
             op->data.recv_status_on_client.status_details;
         req->data.recv_status_details.details_capacity =
             op->data.recv_status_on_client.status_details_capacity;
         req = &reqs[out++];
-	if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
+        if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
         req->op = GRPC_IOREQ_RECV_TRAILING_METADATA;
         req->data.recv_metadata =
             op->data.recv_status_on_client.trailing_metadata;
         req->data.recv_metadata->count = 0;
         req = &reqs[out++];
-	if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
+        if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
         req->op = GRPC_IOREQ_RECV_CLOSE;
         finish_func = finish_batch_with_close;
         break;
@@ -1707,14 +1708,14 @@ grpc_call_error grpc_call_start_batch(grpc_call *call, const grpc_op *ops,
         /* Flag validation: currently allow no flags */
         if (op->flags != 0) return GRPC_CALL_ERROR_INVALID_FLAGS;
         req = &reqs[out++];
-	if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
+        if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
         req->op = GRPC_IOREQ_RECV_STATUS;
         req->flags = op->flags;
         req->data.recv_status.set_value = set_cancelled_value;
         req->data.recv_status.user_data =
             op->data.recv_close_on_server.cancelled;
         req = &reqs[out++];
-	if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
+        if (out > GRPC_IOREQ_OP_COUNT) return GRPC_CALL_ERROR_BATCH_TOO_BIG;
         req->op = GRPC_IOREQ_RECV_CLOSE;
         finish_func = finish_batch_with_close;
         break;

--- a/src/core/surface/call_log_batch.c
+++ b/src/core/surface/call_log_batch.c
@@ -41,7 +41,7 @@ int grpc_trace_batch = 0;
 
 static void add_metadata(gpr_strvec *b, const grpc_metadata *md, size_t count) {
   size_t i;
-  for(i = 0; i < count; i++) {
+  for (i = 0; i < count; i++) {
     gpr_strvec_add(b, gpr_strdup("\nkey="));
     gpr_strvec_add(b, gpr_strdup(md[i].key));
 
@@ -113,8 +113,9 @@ void grpc_call_log_batch(char *file, int line, gpr_log_severity severity,
   char *tmp;
   size_t i;
   gpr_log(file, line, severity,
-          "grpc_call_start_batch(call=%p, ops=%p, nops=%d, tag=%p)", call, ops, nops, tag);
-  for(i = 0; i < nops; i++) {
+          "grpc_call_start_batch(call=%p, ops=%p, nops=%d, tag=%p)", call, ops,
+          nops, tag);
+  for (i = 0; i < nops; i++) {
     tmp = grpc_op_string(&ops[i]);
     gpr_log(file, line, severity, "ops[%d]: %s", i, tmp);
     gpr_free(tmp);
@@ -123,8 +124,7 @@ void grpc_call_log_batch(char *file, int line, gpr_log_severity severity,
 
 void grpc_server_log_request_call(char *file, int line,
                                   gpr_log_severity severity,
-                                  grpc_server *server,
-                                  grpc_call **call,
+                                  grpc_server *server, grpc_call **call,
                                   grpc_call_details *details,
                                   grpc_metadata_array *initial_metadata,
                                   grpc_completion_queue *cq_bound_to_call,
@@ -133,8 +133,9 @@ void grpc_server_log_request_call(char *file, int line,
   gpr_log(file, line, severity,
           "grpc_server_request_call(server=%p, call=%p, details=%p, "
           "initial_metadata=%p, cq_bound_to_call=%p, cq_for_notification=%p, "
-          "tag=%p)", server, call, details, initial_metadata,
-          cq_bound_to_call, cq_for_notification, tag);
+          "tag=%p)",
+          server, call, details, initial_metadata, cq_bound_to_call,
+          cq_for_notification, tag);
 }
 
 void grpc_server_log_shutdown(char *file, int line, gpr_log_severity severity,

--- a/src/core/surface/channel.c
+++ b/src/core/surface/channel.c
@@ -163,7 +163,7 @@ static grpc_call *grpc_channel_create_call_internal(
     send_metadata[num_metadata++] = authority_mdelem;
   }
 
-  return grpc_call_create(channel, parent_call, propagation_mask, cq, NULL, 
+  return grpc_call_create(channel, parent_call, propagation_mask, cq, NULL,
                           send_metadata, num_metadata, deadline);
 }
 
@@ -179,10 +179,11 @@ grpc_call *grpc_channel_create_call(grpc_channel *channel,
       grpc_mdelem_from_metadata_strings(
           channel->metadata_context, GRPC_MDSTR_REF(channel->path_string),
           grpc_mdstr_from_string(channel->metadata_context, method, 0)),
-      host ?
-      grpc_mdelem_from_metadata_strings(
-          channel->metadata_context, GRPC_MDSTR_REF(channel->authority_string),
-          grpc_mdstr_from_string(channel->metadata_context, host, 0)) : NULL,
+      host ? grpc_mdelem_from_metadata_strings(
+                 channel->metadata_context,
+                 GRPC_MDSTR_REF(channel->authority_string),
+                 grpc_mdstr_from_string(channel->metadata_context, host, 0))
+           : NULL,
       deadline);
 }
 
@@ -193,9 +194,12 @@ void *grpc_channel_register_call(grpc_channel *channel, const char *method,
   rc->path = grpc_mdelem_from_metadata_strings(
       channel->metadata_context, GRPC_MDSTR_REF(channel->path_string),
       grpc_mdstr_from_string(channel->metadata_context, method, 0));
-  rc->authority = host ? grpc_mdelem_from_metadata_strings(
-      channel->metadata_context, GRPC_MDSTR_REF(channel->authority_string),
-      grpc_mdstr_from_string(channel->metadata_context, host, 0)) : NULL;
+  rc->authority =
+      host ? grpc_mdelem_from_metadata_strings(
+                 channel->metadata_context,
+                 GRPC_MDSTR_REF(channel->authority_string),
+                 grpc_mdstr_from_string(channel->metadata_context, host, 0))
+           : NULL;
   gpr_mu_lock(&channel->registered_call_mu);
   rc->next = channel->registered_calls;
   channel->registered_calls = rc;
@@ -210,8 +214,8 @@ grpc_call *grpc_channel_create_registered_call(
   registered_call *rc = registered_call_handle;
   GPR_ASSERT(!reserved);
   return grpc_channel_create_call_internal(
-      channel, parent_call, propagation_mask, completion_queue, 
-      GRPC_MDELEM_REF(rc->path), 
+      channel, parent_call, propagation_mask, completion_queue,
+      GRPC_MDELEM_REF(rc->path),
       rc->authority ? GRPC_MDELEM_REF(rc->authority) : NULL, deadline);
 }
 

--- a/src/core/surface/channel_connectivity.c
+++ b/src/core/surface/channel_connectivity.c
@@ -77,9 +77,10 @@ typedef struct {
 } state_watcher;
 
 static void delete_state_watcher(state_watcher *w) {
-  grpc_channel_element *client_channel_elem =
-      grpc_channel_stack_last_element(grpc_channel_get_channel_stack(w->channel));
-  grpc_client_channel_del_interested_party(client_channel_elem, grpc_cq_pollset(w->cq));
+  grpc_channel_element *client_channel_elem = grpc_channel_stack_last_element(
+      grpc_channel_get_channel_stack(w->channel));
+  grpc_client_channel_del_interested_party(client_channel_elem,
+                                           grpc_cq_pollset(w->cq));
   GRPC_CHANNEL_INTERNAL_UNREF(w->channel, "watch_connectivity");
   gpr_mu_destroy(&w->mu);
   gpr_free(w);
@@ -166,9 +167,9 @@ void grpc_channel_watch_connectivity_state(
   w->tag = tag;
   w->channel = channel;
 
-  grpc_alarm_init(
-      &w->alarm, gpr_convert_clock_type(deadline, GPR_CLOCK_MONOTONIC), 
-      timeout_complete, w, gpr_now(GPR_CLOCK_MONOTONIC));
+  grpc_alarm_init(&w->alarm,
+                  gpr_convert_clock_type(deadline, GPR_CLOCK_MONOTONIC),
+                  timeout_complete, w, gpr_now(GPR_CLOCK_MONOTONIC));
 
   if (client_channel_elem->filter != &grpc_client_channel_filter) {
     gpr_log(GPR_ERROR,
@@ -178,7 +179,8 @@ void grpc_channel_watch_connectivity_state(
     grpc_iomgr_add_delayed_callback(&w->on_complete, 1);
   } else {
     GRPC_CHANNEL_INTERNAL_REF(channel, "watch_connectivity");
-    grpc_client_channel_add_interested_party(client_channel_elem, grpc_cq_pollset(cq));
+    grpc_client_channel_add_interested_party(client_channel_elem,
+                                             grpc_cq_pollset(cq));
     grpc_client_channel_watch_connectivity_state(client_channel_elem, &w->state,
                                                  &w->on_complete);
   }

--- a/src/core/surface/completion_queue.c
+++ b/src/core/surface/completion_queue.c
@@ -167,8 +167,7 @@ void grpc_cq_end_op(grpc_completion_queue *cc, void *tag, int success,
 }
 
 grpc_event grpc_completion_queue_next(grpc_completion_queue *cc,
-                                      gpr_timespec deadline,
-                                      void *reserved) {
+                                      gpr_timespec deadline, void *reserved) {
   grpc_event ret;
   grpc_pollset_worker worker;
   GPR_ASSERT(!reserved);
@@ -272,8 +271,9 @@ grpc_event grpc_completion_queue_pluck(grpc_completion_queue *cc, void *tag,
       break;
     }
     if (!add_plucker(cc, tag, &worker)) {
-      gpr_log(GPR_DEBUG, 
-              "Too many outstanding grpc_completion_queue_pluck calls: maximum is %d",
+      gpr_log(GPR_DEBUG,
+              "Too many outstanding grpc_completion_queue_pluck calls: maximum "
+              "is %d",
               GRPC_MAX_COMPLETION_QUEUE_PLUCKERS);
       gpr_mu_unlock(GRPC_POLLSET_MU(&cc->pollset));
       memset(&ret, 0, sizeof(ret));

--- a/src/core/surface/event_string.h
+++ b/src/core/surface/event_string.h
@@ -39,4 +39,4 @@
 /* Returns a string describing an event. Must be later freed with gpr_free() */
 char *grpc_event_string(grpc_event *ev);
 
-#endif  /* GRPC_INTERNAL_CORE_SURFACE_EVENT_STRING_H */
+#endif /* GRPC_INTERNAL_CORE_SURFACE_EVENT_STRING_H */

--- a/src/core/surface/init.h
+++ b/src/core/surface/init.h
@@ -37,4 +37,4 @@
 void grpc_security_pre_init(void);
 int grpc_is_initialized(void);
 
-#endif  /* GRPC_INTERNAL_CORE_SURFACE_INIT_H */
+#endif /* GRPC_INTERNAL_CORE_SURFACE_INIT_H */

--- a/src/core/surface/init_unsecure.c
+++ b/src/core/surface/init_unsecure.c
@@ -33,5 +33,4 @@
 
 #include "src/core/surface/init.h"
 
-void grpc_security_pre_init(void) {
-}
+void grpc_security_pre_init(void) {}

--- a/src/core/surface/server.c
+++ b/src/core/surface/server.c
@@ -712,7 +712,8 @@ static void init_channel_elem(grpc_channel_element *elem, grpc_channel *master,
   chand->server = NULL;
   chand->channel = NULL;
   chand->path_key = grpc_mdstr_from_string(metadata_context, ":path", 0);
-  chand->authority_key = grpc_mdstr_from_string(metadata_context, ":authority", 0);
+  chand->authority_key =
+      grpc_mdstr_from_string(metadata_context, ":authority", 0);
   chand->next = chand->prev = chand;
   chand->registered_methods = NULL;
   chand->connectivity_state = GRPC_CHANNEL_IDLE;

--- a/src/core/surface/server_create.c
+++ b/src/core/surface/server_create.c
@@ -38,7 +38,7 @@
 
 grpc_server *grpc_server_create(const grpc_channel_args *args, void *reserved) {
   const grpc_channel_filter *filters[] = {&grpc_compress_filter};
-  (void) reserved;
+  (void)reserved;
   return grpc_server_create_from_filters(filters, GPR_ARRAY_SIZE(filters),
                                          args);
 }

--- a/src/core/surface/surface_trace.h
+++ b/src/core/surface/surface_trace.h
@@ -40,10 +40,10 @@
 extern int grpc_surface_trace;
 
 #define GRPC_SURFACE_TRACE_RETURNED_EVENT(cq, event)    \
-  if (grpc_surface_trace) {           \
+  if (grpc_surface_trace) {                             \
     char *_ev = grpc_event_string(event);               \
     gpr_log(GPR_INFO, "RETURN_EVENT[%p]: %s", cq, _ev); \
     gpr_free(_ev);                                      \
   }
 
-#endif  /* GRPC_INTERNAL_CORE_SURFACE_SURFACE_TRACE_H */
+#endif /* GRPC_INTERNAL_CORE_SURFACE_SURFACE_TRACE_H */

--- a/src/core/surface/version.c
+++ b/src/core/surface/version.c
@@ -36,6 +36,4 @@
 
 #include <grpc/grpc.h>
 
-const char *grpc_version_string(void) {
-	return "0.10.1.0";
-}
+const char *grpc_version_string(void) { return "0.10.1.0"; }

--- a/src/core/transport/chttp2/frame_data.c
+++ b/src/core/transport/chttp2/frame_data.c
@@ -92,10 +92,10 @@ grpc_chttp2_parse_error grpc_chttp2_data_parser_parse(
       p->frame_type = *cur;
       switch (p->frame_type) {
         case 0:
-          p->is_frame_compressed = 0;  /* GPR_FALSE */
+          p->is_frame_compressed = 0; /* GPR_FALSE */
           break;
         case 1:
-          p->is_frame_compressed = 1;  /* GPR_TRUE */
+          p->is_frame_compressed = 1; /* GPR_TRUE */
           break;
         default:
           gpr_log(GPR_ERROR, "Bad GRPC frame type 0x%02x", p->frame_type);

--- a/src/core/transport/chttp2/parsing.c
+++ b/src/core/transport/chttp2/parsing.c
@@ -177,10 +177,9 @@ void grpc_chttp2_publish_reads(
           "parsed", transport_parsing, stream_global, max_recv_bytes,
           -(gpr_int64)stream_parsing->incoming_window_delta);
       stream_global->incoming_window -= stream_parsing->incoming_window_delta;
-      GPR_ASSERT(stream_global->max_recv_bytes >= 
-          stream_parsing->incoming_window_delta);
-      stream_global->max_recv_bytes -= 
-          stream_parsing->incoming_window_delta;
+      GPR_ASSERT(stream_global->max_recv_bytes >=
+                 stream_parsing->incoming_window_delta);
+      stream_global->max_recv_bytes -= stream_parsing->incoming_window_delta;
       stream_parsing->incoming_window_delta = 0;
       grpc_chttp2_list_add_writable_stream(transport_global, stream_global);
     }

--- a/src/core/transport/chttp2/stream_lists.c
+++ b/src/core/transport/chttp2/stream_lists.c
@@ -363,7 +363,7 @@ void grpc_chttp2_register_stream(grpc_chttp2_transport *t,
 }
 
 int grpc_chttp2_unregister_stream(grpc_chttp2_transport *t,
-                                   grpc_chttp2_stream *s) {
+                                  grpc_chttp2_stream *s) {
   stream_list_maybe_remove(t, s, GRPC_CHTTP2_LIST_ALL_STREAMS);
   return stream_list_empty(t, GRPC_CHTTP2_LIST_ALL_STREAMS);
 }

--- a/src/core/transport/chttp2/stream_map.c
+++ b/src/core/transport/chttp2/stream_map.c
@@ -123,8 +123,7 @@ void grpc_chttp2_stream_map_move_into(grpc_chttp2_stream_map *src,
     dst->values = gpr_realloc(dst->values, dst->capacity * sizeof(void *));
   }
   memcpy(dst->keys + dst->count, src->keys, src->count * sizeof(gpr_uint32));
-  memcpy(dst->values + dst->count, src->values,
-         src->count * sizeof(void*));
+  memcpy(dst->values + dst->count, src->values, src->count * sizeof(void *));
   dst->count += src->count;
   dst->free += src->free;
   src->count = 0;

--- a/src/core/transport/chttp2/writing.c
+++ b/src/core/transport/chttp2/writing.c
@@ -112,13 +112,18 @@ int grpc_chttp2_unlocking_check_writes(
       }
     }
 
-    if (!stream_global->read_closed && stream_global->unannounced_incoming_window > 0) {
-      stream_writing->announce_window = stream_global->unannounced_incoming_window;
-      GRPC_CHTTP2_FLOWCTL_TRACE_STREAM("write", transport_global, stream_global,
-                                       incoming_window, stream_global->unannounced_incoming_window);
-      GRPC_CHTTP2_FLOWCTL_TRACE_STREAM("write", transport_global, stream_global,
-                                       unannounced_incoming_window, -(gpr_int64)stream_global->unannounced_incoming_window);
-      stream_global->incoming_window += stream_global->unannounced_incoming_window;
+    if (!stream_global->read_closed &&
+        stream_global->unannounced_incoming_window > 0) {
+      stream_writing->announce_window =
+          stream_global->unannounced_incoming_window;
+      GRPC_CHTTP2_FLOWCTL_TRACE_STREAM(
+          "write", transport_global, stream_global, incoming_window,
+          stream_global->unannounced_incoming_window);
+      GRPC_CHTTP2_FLOWCTL_TRACE_STREAM(
+          "write", transport_global, stream_global, unannounced_incoming_window,
+          -(gpr_int64)stream_global->unannounced_incoming_window);
+      stream_global->incoming_window +=
+          stream_global->unannounced_incoming_window;
       stream_global->unannounced_incoming_window = 0;
       grpc_chttp2_list_add_incoming_window_updated(transport_global,
                                                    stream_global);
@@ -179,18 +184,20 @@ static void finalize_outbuf(grpc_chttp2_transport_writing *transport_writing) {
 
   while (
       grpc_chttp2_list_pop_writing_stream(transport_writing, &stream_writing)) {
-    if (stream_writing->sopb.nops > 0 || stream_writing->send_closed != GRPC_DONT_SEND_CLOSED) {
+    if (stream_writing->sopb.nops > 0 ||
+        stream_writing->send_closed != GRPC_DONT_SEND_CLOSED) {
       grpc_chttp2_encode(stream_writing->sopb.ops, stream_writing->sopb.nops,
                          stream_writing->send_closed != GRPC_DONT_SEND_CLOSED,
-                         stream_writing->id, &transport_writing->hpack_compressor,
+                         stream_writing->id,
+                         &transport_writing->hpack_compressor,
                          &transport_writing->outbuf);
       stream_writing->sopb.nops = 0;
     }
     if (stream_writing->announce_window > 0) {
       gpr_slice_buffer_add(
           &transport_writing->outbuf,
-          grpc_chttp2_window_update_create(
-              stream_writing->id, stream_writing->announce_window));
+          grpc_chttp2_window_update_create(stream_writing->id,
+                                           stream_writing->announce_window));
       stream_writing->announce_window = 0;
     }
     if (stream_writing->send_closed == GRPC_SEND_CLOSED_WITH_RST_STREAM) {

--- a/src/core/transport/chttp2_transport.c
+++ b/src/core/transport/chttp2_transport.c
@@ -116,7 +116,7 @@ static void close_from_api(grpc_chttp2_transport_global *transport_global,
 static void add_to_pollset_locked(grpc_chttp2_transport *t,
                                   grpc_pollset *pollset);
 static void add_to_pollset_set_locked(grpc_chttp2_transport *t,
-                                  grpc_pollset_set *pollset_set);
+                                      grpc_pollset_set *pollset_set);
 
 /** Start new streams that have been created if we can */
 static void maybe_start_some_streams(
@@ -368,11 +368,10 @@ static int init_stream(grpc_transport *gt, grpc_stream *gs,
     s->global.outgoing_window =
         t->global.settings[GRPC_PEER_SETTINGS]
                           [GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE];
-    s->global.max_recv_bytes = 
-        s->parsing.incoming_window = 
+    s->global.max_recv_bytes = s->parsing.incoming_window =
         s->global.incoming_window =
-        t->global.settings[GRPC_SENT_SETTINGS]
-                          [GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE];
+            t->global.settings[GRPC_SENT_SETTINGS]
+                              [GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE];
     *t->accepting_stream = s;
     grpc_chttp2_stream_map_add(&t->parsing_stream_map, s->global.id, s);
     s->global.in_stream_map = 1;
@@ -580,7 +579,7 @@ static void maybe_start_some_streams(
     stream_global->incoming_window =
         transport_global->settings[GRPC_SENT_SETTINGS]
                                   [GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE];
-    stream_global->max_recv_bytes = 
+    stream_global->max_recv_bytes =
         GPR_MAX(stream_global->incoming_window, stream_global->max_recv_bytes);
     grpc_chttp2_stream_map_add(
         &TRANSPORT_FROM_GLOBAL(transport_global)->new_stream_map,
@@ -590,7 +589,6 @@ static void maybe_start_some_streams(
     grpc_chttp2_list_add_incoming_window_updated(transport_global,
                                                  stream_global);
     grpc_chttp2_list_add_writable_stream(transport_global, stream_global);
-
   }
   /* cancel out streams that will never be started */
   while (transport_global->next_stream_id >= MAX_CLIENT_STREAM_ID &&
@@ -648,12 +646,14 @@ static void perform_stream_op_locked(
     stream_global->publish_sopb->nops = 0;
     stream_global->publish_state = op->recv_state;
     if (stream_global->max_recv_bytes < op->max_recv_bytes) {
-      GRPC_CHTTP2_FLOWCTL_TRACE_STREAM("op", transport_global, stream_global,
-          max_recv_bytes, op->max_recv_bytes - stream_global->max_recv_bytes);
+      GRPC_CHTTP2_FLOWCTL_TRACE_STREAM(
+          "op", transport_global, stream_global, max_recv_bytes,
+          op->max_recv_bytes - stream_global->max_recv_bytes);
       GRPC_CHTTP2_FLOWCTL_TRACE_STREAM(
           "op", transport_global, stream_global, unannounced_incoming_window,
           op->max_recv_bytes - stream_global->max_recv_bytes);
-      stream_global->unannounced_incoming_window += op->max_recv_bytes - stream_global->max_recv_bytes;
+      stream_global->unannounced_incoming_window +=
+          op->max_recv_bytes - stream_global->max_recv_bytes;
       stream_global->max_recv_bytes = op->max_recv_bytes;
     }
     grpc_chttp2_incoming_metadata_live_op_buffer_end(
@@ -1175,7 +1175,7 @@ static void add_to_pollset_locked(grpc_chttp2_transport *t,
 }
 
 static void add_to_pollset_set_locked(grpc_chttp2_transport *t,
-                                  grpc_pollset_set *pollset_set) {
+                                      grpc_pollset_set *pollset_set) {
   if (t->ep) {
     grpc_endpoint_add_to_pollset_set(t->ep, pollset_set);
   }

--- a/src/core/transport/metadata.c
+++ b/src/core/transport/metadata.c
@@ -133,8 +133,8 @@ static void unlock(grpc_mdctx *ctx) {
      case), since otherwise we can be stuck waiting for a garbage collection
      that will never happen. */
   if (ctx->refs == 0) {
-    /* uncomment if you're having trouble diagnosing an mdelem leak to make
-       things clearer (slows down destruction a lot, however) */
+/* uncomment if you're having trouble diagnosing an mdelem leak to make
+   things clearer (slows down destruction a lot, however) */
 #ifdef GRPC_METADATA_REFCOUNT_DEBUG
     gc_mdtab(ctx);
 #endif
@@ -311,7 +311,8 @@ static void slice_unref(void *p) {
   unlock(ctx);
 }
 
-grpc_mdstr *grpc_mdstr_from_string(grpc_mdctx *ctx, const char *str, int canonicalize_key) {
+grpc_mdstr *grpc_mdstr_from_string(grpc_mdctx *ctx, const char *str,
+                                   int canonicalize_key) {
   if (canonicalize_key) {
     size_t len;
     size_t i;
@@ -522,9 +523,9 @@ grpc_mdelem *grpc_mdelem_from_metadata_strings(grpc_mdctx *ctx,
 
 grpc_mdelem *grpc_mdelem_from_strings(grpc_mdctx *ctx, const char *key,
                                       const char *value) {
-  return grpc_mdelem_from_metadata_strings(ctx,
-                                           grpc_mdstr_from_string(ctx, key, 0),
-                                           grpc_mdstr_from_string(ctx, value, 0));
+  return grpc_mdelem_from_metadata_strings(
+      ctx, grpc_mdstr_from_string(ctx, key, 0),
+      grpc_mdstr_from_string(ctx, value, 0));
 }
 
 grpc_mdelem *grpc_mdelem_from_slices(grpc_mdctx *ctx, gpr_slice key,

--- a/src/core/transport/metadata.h
+++ b/src/core/transport/metadata.h
@@ -95,7 +95,8 @@ size_t grpc_mdctx_get_mdtab_free_test_only(grpc_mdctx *mdctx);
 
 /* Constructors for grpc_mdstr instances; take a variety of data types that
    clients may have handy */
-grpc_mdstr *grpc_mdstr_from_string(grpc_mdctx *ctx, const char *str, int perform_key_canonicalization);
+grpc_mdstr *grpc_mdstr_from_string(grpc_mdctx *ctx, const char *str,
+                                   int perform_key_canonicalization);
 /* Unrefs the slice. */
 grpc_mdstr *grpc_mdstr_from_slice(grpc_mdctx *ctx, gpr_slice slice);
 grpc_mdstr *grpc_mdstr_from_buffer(grpc_mdctx *ctx, const gpr_uint8 *str,
@@ -179,4 +180,4 @@ void grpc_mdctx_unlock(grpc_mdctx *ctx);
 
 #define GRPC_MDSTR_KV_HASH(k_hash, v_hash) (GPR_ROTL((k_hash), 2) ^ (v_hash))
 
-#endif  /* GRPC_INTERNAL_CORE_TRANSPORT_METADATA_H */
+#endif /* GRPC_INTERNAL_CORE_TRANSPORT_METADATA_H */

--- a/src/core/transport/stream_op.c
+++ b/src/core/transport/stream_op.c
@@ -203,8 +203,8 @@ void grpc_metadata_batch_assert_ok(grpc_metadata_batch *batch) {
 #endif /* NDEBUG */
 
 void grpc_metadata_batch_init(grpc_metadata_batch *batch) {
-  batch->list.head = batch->list.tail = batch->garbage.head = batch->garbage.tail =
-      NULL;
+  batch->list.head = batch->list.tail = batch->garbage.head =
+      batch->garbage.tail = NULL;
   batch->deadline = gpr_inf_future(GPR_CLOCK_REALTIME);
 }
 
@@ -288,7 +288,7 @@ void grpc_metadata_batch_merge(grpc_metadata_batch *target,
 }
 
 void grpc_metadata_batch_move(grpc_metadata_batch *dst,
-                               grpc_metadata_batch *src) {
+                              grpc_metadata_batch *src) {
   *dst = *src;
   memset(src, 0, sizeof(grpc_metadata_batch));
 }

--- a/src/core/tsi/fake_transport_security.c
+++ b/src/core/tsi/fake_transport_security.c
@@ -121,7 +121,7 @@ static void store32_little_endian(gpr_uint32 value, unsigned char* buf) {
   buf[3] = (unsigned char)(value >> 24) & 0xFF;
   buf[2] = (unsigned char)(value >> 16) & 0xFF;
   buf[1] = (unsigned char)(value >> 8) & 0xFF;
-  buf[0] = (unsigned char)(value) & 0xFF;
+  buf[0] = (unsigned char)(value)&0xFF;
 }
 
 static void tsi_fake_frame_reset(tsi_fake_frame* frame, int needs_draining) {
@@ -370,7 +370,8 @@ static void fake_protector_destroy(tsi_frame_protector* self) {
 
 static const tsi_frame_protector_vtable frame_protector_vtable = {
     fake_protector_protect, fake_protector_protect_flush,
-    fake_protector_unprotect, fake_protector_destroy, };
+    fake_protector_unprotect, fake_protector_destroy,
+};
 
 /* --- tsi_handshaker methods implementation. ---*/
 
@@ -393,7 +394,8 @@ static tsi_result fake_handshaker_get_bytes_to_send_to_peer(
       next_message_to_send = TSI_FAKE_HANDSHAKE_MESSAGE_MAX;
     }
     if (tsi_tracing_enabled) {
-      gpr_log(GPR_INFO, "%s prepared %s.", impl->is_client ? "Client" : "Server",
+      gpr_log(GPR_INFO, "%s prepared %s.",
+              impl->is_client ? "Client" : "Server",
               tsi_fake_handshake_message_to_string(impl->next_message_to_send));
     }
     impl->next_message_to_send = next_message_to_send;
@@ -493,7 +495,8 @@ static const tsi_handshaker_vtable handshaker_vtable = {
     fake_handshaker_get_result,
     fake_handshaker_extract_peer,
     fake_handshaker_create_frame_protector,
-    fake_handshaker_destroy, };
+    fake_handshaker_destroy,
+};
 
 tsi_handshaker* tsi_create_fake_handshaker(int is_client) {
   tsi_fake_handshaker* impl = calloc(1, sizeof(tsi_fake_handshaker));

--- a/src/core/tsi/fake_transport_security.h
+++ b/src/core/tsi/fake_transport_security.h
@@ -58,4 +58,4 @@ tsi_frame_protector* tsi_create_fake_protector(
 }
 #endif
 
-#endif  /* GRPC_INTERNAL_CORE_TSI_FAKE_TRANSPORT_SECURITY_H */
+#endif /* GRPC_INTERNAL_CORE_TSI_FAKE_TRANSPORT_SECURITY_H */

--- a/src/core/tsi/ssl_transport_security.c
+++ b/src/core/tsi/ssl_transport_security.c
@@ -43,7 +43,7 @@
 #include "src/core/tsi/transport_security.h"
 
 #include <openssl/bio.h>
-#include <openssl/crypto.h>  /* For OPENSSL_free */
+#include <openssl/crypto.h> /* For OPENSSL_free */
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
@@ -53,7 +53,6 @@
 
 #define TSI_SSL_MAX_PROTECTED_FRAME_SIZE_UPPER_BOUND 16384
 #define TSI_SSL_MAX_PROTECTED_FRAME_SIZE_LOWER_BOUND 1024
-
 
 /* Putting a macro like this and littering the source file with #if is really
    bad practice.
@@ -116,7 +115,7 @@ typedef struct {
 /* --- Library Initialization. ---*/
 
 static gpr_once init_openssl_once = GPR_ONCE_INIT;
-static gpr_mu *openssl_mutexes = NULL;
+static gpr_mu* openssl_mutexes = NULL;
 
 static void openssl_locking_cb(int mode, int type, const char* file, int line) {
   if (mode & CRYPTO_LOCK) {
@@ -195,7 +194,7 @@ static void ssl_info_callback(const SSL* ssl, int where, int ret) {
 /* Returns 1 if name looks like an IP address, 0 otherwise.
    This is a very rough heuristic as it does not handle IPV6 or things like:
    0300.0250.00.01, 0xC0.0Xa8.0x0.0x1, 000030052000001, 0xc0.052000001 */
-static int looks_like_ip_address(const char *name) {
+static int looks_like_ip_address(const char* name) {
   size_t i;
   size_t dot_count = 0;
   size_t num_size = 0;
@@ -214,7 +213,6 @@ static int looks_like_ip_address(const char *name) {
   if (dot_count < 3 || num_size == 0) return 0;
   return 1;
 }
-
 
 /* Gets the subject CN from an X509 cert. */
 static tsi_result ssl_get_x509_common_name(X509* cert, unsigned char** utf8,
@@ -630,7 +628,8 @@ static tsi_result build_alpn_protocol_name_list(
   }
   /* Safety check. */
   if ((current < *protocol_name_list) ||
-      ((gpr_uintptr)(current - *protocol_name_list) != *protocol_name_list_length)) {
+      ((gpr_uintptr)(current - *protocol_name_list) !=
+       *protocol_name_list_length)) {
     return TSI_INTERNAL_ERROR;
   }
   return TSI_OK;
@@ -768,7 +767,8 @@ static void ssl_protector_destroy(tsi_frame_protector* self) {
 
 static const tsi_frame_protector_vtable frame_protector_vtable = {
     ssl_protector_protect, ssl_protector_protect_flush, ssl_protector_unprotect,
-    ssl_protector_destroy, };
+    ssl_protector_destroy,
+};
 
 /* --- tsi_handshaker methods implementation. ---*/
 
@@ -948,7 +948,8 @@ static const tsi_handshaker_vtable handshaker_vtable = {
     ssl_handshaker_get_result,
     ssl_handshaker_extract_peer,
     ssl_handshaker_create_frame_protector,
-    ssl_handshaker_destroy, };
+    ssl_handshaker_destroy,
+};
 
 /* --- tsi_ssl_handshaker_factory common methods. --- */
 
@@ -1075,9 +1076,11 @@ static void ssl_client_handshaker_factory_destroy(
   free(impl);
 }
 
-static int client_handshaker_factory_npn_callback(
-    SSL* ssl, unsigned char** out, unsigned char* outlen,
-    const unsigned char* in, unsigned int inlen, void* arg) {
+static int client_handshaker_factory_npn_callback(SSL* ssl, unsigned char** out,
+                                                  unsigned char* outlen,
+                                                  const unsigned char* in,
+                                                  unsigned int inlen,
+                                                  void* arg) {
   tsi_ssl_client_handshaker_factory* factory =
       (tsi_ssl_client_handshaker_factory*)arg;
   return select_protocol_list((const unsigned char**)out, outlen,
@@ -1121,7 +1124,7 @@ static void ssl_server_handshaker_factory_destroy(
 
 static int does_entry_match_name(const char* entry, size_t entry_length,
                                  const char* name) {
-  const char *dot;
+  const char* dot;
   const char* name_subdomain = NULL;
   size_t name_length = strlen(name);
   size_t name_subdomain_length;
@@ -1153,7 +1156,7 @@ static int does_entry_match_name(const char* entry, size_t entry_length,
   if (name_subdomain_length < 2) return 0;
   name_subdomain++; /* Starts after the dot. */
   name_subdomain_length--;
-  entry += 2;       /* Remove *. */
+  entry += 2; /* Remove *. */
   entry_length -= 2;
   dot = strchr(name_subdomain, '.');
   if ((dot == NULL) || (dot == &name_subdomain[name_subdomain_length - 1])) {
@@ -1170,7 +1173,7 @@ static int does_entry_match_name(const char* entry, size_t entry_length,
 static int ssl_server_handshaker_factory_servername_callback(SSL* ssl, int* ap,
                                                              void* arg) {
   tsi_ssl_server_handshaker_factory* impl =
-     (tsi_ssl_server_handshaker_factory*)arg;
+      (tsi_ssl_server_handshaker_factory*)arg;
   size_t i = 0;
   const char* servername = SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name);
   if (servername == NULL || strlen(servername) == 0) {

--- a/src/core/tsi/ssl_transport_security.h
+++ b/src/core/tsi/ssl_transport_security.h
@@ -170,4 +170,4 @@ int tsi_ssl_peer_matches_name(const tsi_peer* peer, const char* name);
 }
 #endif
 
-#endif  /* GRPC_INTERNAL_CORE_TSI_SSL_TRANSPORT_SECURITY_H */
+#endif /* GRPC_INTERNAL_CORE_TSI_SSL_TRANSPORT_SECURITY_H */

--- a/src/core/tsi/transport_security.h
+++ b/src/core/tsi/transport_security.h
@@ -108,4 +108,4 @@ char* tsi_strdup(const char* src); /* Sadly, no strdup in C89. */
 }
 #endif
 
-#endif  /* GRPC_INTERNAL_CORE_TSI_TRANSPORT_SECURITY_H */
+#endif /* GRPC_INTERNAL_CORE_TSI_TRANSPORT_SECURITY_H */

--- a/src/core/tsi/transport_security_interface.h
+++ b/src/core/tsi/transport_security_interface.h
@@ -341,4 +341,4 @@ void tsi_handshaker_destroy(tsi_handshaker* self);
 }
 #endif
 
-#endif  /* GRPC_INTERNAL_CORE_TSI_TRANSPORT_SECURITY_INTERFACE_H */
+#endif /* GRPC_INTERNAL_CORE_TSI_TRANSPORT_SECURITY_INTERFACE_H */

--- a/src/cpp/client/channel.cc
+++ b/src/cpp/client/channel.cc
@@ -98,9 +98,8 @@ void Channel::PerformOpsOnCall(CallOpSetInterface* ops, Call* call) {
 }
 
 void* Channel::RegisterMethod(const char* method) {
-  return grpc_channel_register_call(c_channel_, method,
-                                    host_.empty() ? NULL : host_.c_str(),
-                                    nullptr);
+  return grpc_channel_register_call(
+      c_channel_, method, host_.empty() ? NULL : host_.c_str(), nullptr);
 }
 
 grpc_connectivity_state Channel::GetState(bool try_to_connect) {
@@ -117,6 +116,7 @@ class TagSaver GRPC_FINAL : public CompletionQueueTag {
     delete this;
     return true;
   }
+
  private:
   void* tag_;
 };

--- a/src/cpp/client/channel.h
+++ b/src/cpp/client/channel.h
@@ -58,9 +58,8 @@ class Channel GRPC_FINAL : public GrpcLibrary, public ChannelInterface {
 
   void* RegisterMethod(const char* method) GRPC_OVERRIDE;
   Call CreateCall(const RpcMethod& method, ClientContext* context,
-                          CompletionQueue* cq) GRPC_OVERRIDE;
-  void PerformOpsOnCall(CallOpSetInterface* ops,
-                                Call* call) GRPC_OVERRIDE;
+                  CompletionQueue* cq) GRPC_OVERRIDE;
+  void PerformOpsOnCall(CallOpSetInterface* ops, Call* call) GRPC_OVERRIDE;
 
   grpc_connectivity_state GetState(bool try_to_connect) GRPC_OVERRIDE;
 

--- a/src/cpp/client/secure_credentials.h
+++ b/src/cpp/client/secure_credentials.h
@@ -59,4 +59,3 @@ class SecureCredentials GRPC_FINAL : public Credentials {
 }  // namespace grpc
 
 #endif  // GRPC_INTERNAL_CPP_CLIENT_SECURE_CREDENTIALS_H
-

--- a/src/cpp/common/auth_property_iterator.cc
+++ b/src/cpp/common/auth_property_iterator.cc
@@ -64,8 +64,7 @@ AuthPropertyIterator AuthPropertyIterator::operator++(int) {
   return tmp;
 }
 
-bool AuthPropertyIterator::operator==(
-    const AuthPropertyIterator& rhs) const {
+bool AuthPropertyIterator::operator==(const AuthPropertyIterator& rhs) const {
   if (property_ == nullptr || rhs.property_ == nullptr) {
     return property_ == rhs.property_;
   } else {
@@ -73,8 +72,7 @@ bool AuthPropertyIterator::operator==(
   }
 }
 
-bool AuthPropertyIterator::operator!=(
-    const AuthPropertyIterator& rhs) const {
+bool AuthPropertyIterator::operator!=(const AuthPropertyIterator& rhs) const {
   return !operator==(rhs);
 }
 

--- a/src/cpp/proto/proto_utils.cc
+++ b/src/cpp/proto/proto_utils.cc
@@ -154,7 +154,8 @@ class GrpcBufferReader GRPC_FINAL
 
 namespace grpc {
 
-Status SerializeProto(const grpc::protobuf::Message& msg, grpc_byte_buffer** bp) {
+Status SerializeProto(const grpc::protobuf::Message& msg,
+                      grpc_byte_buffer** bp) {
   GrpcBufferWriter writer(bp);
   return msg.SerializeToZeroCopyStream(&writer)
              ? Status::OK
@@ -172,8 +173,7 @@ Status DeserializeProto(grpc_byte_buffer* buffer, grpc::protobuf::Message* msg,
     decoder.SetTotalBytesLimit(max_message_size, max_message_size);
   }
   if (!msg->ParseFromCodedStream(&decoder)) {
-    return Status(StatusCode::INTERNAL,
-                  msg->InitializationErrorString());
+    return Status(StatusCode::INTERNAL, msg->InitializationErrorString());
   }
   if (!decoder.ConsumedEntireMessage()) {
     return Status(StatusCode::INTERNAL, "Did not read entire message");

--- a/src/cpp/server/create_default_thread_pool.cc
+++ b/src/cpp/server/create_default_thread_pool.cc
@@ -39,9 +39,9 @@
 namespace grpc {
 
 ThreadPoolInterface* CreateDefaultThreadPool() {
-   int cores = gpr_cpu_num_cores();
-   if (!cores) cores = 4;
-   return new DynamicThreadPool(cores);
+  int cores = gpr_cpu_num_cores();
+  if (!cores) cores = 4;
+  return new DynamicThreadPool(cores);
 }
 
 }  // namespace grpc

--- a/src/cpp/server/dynamic_thread_pool.cc
+++ b/src/cpp/server/dynamic_thread_pool.cc
@@ -36,10 +36,10 @@
 #include <grpc++/dynamic_thread_pool.h>
 
 namespace grpc {
-DynamicThreadPool::DynamicThread::DynamicThread(DynamicThreadPool *pool):
-  pool_(pool),
-  thd_(new grpc::thread(&DynamicThreadPool::DynamicThread::ThreadFunc, this)) {
-}
+DynamicThreadPool::DynamicThread::DynamicThread(DynamicThreadPool* pool)
+    : pool_(pool),
+      thd_(new grpc::thread(&DynamicThreadPool::DynamicThread::ThreadFunc,
+                            this)) {}
 DynamicThreadPool::DynamicThread::~DynamicThread() {
   thd_->join();
   thd_.reset();
@@ -57,7 +57,7 @@ void DynamicThreadPool::DynamicThread::ThreadFunc() {
     pool_->shutdown_cv_.notify_one();
   }
 }
-  
+
 void DynamicThreadPool::ThreadFunc() {
   for (;;) {
     // Wait until work is available or we are shutting down.
@@ -65,7 +65,7 @@ void DynamicThreadPool::ThreadFunc() {
     if (!shutdown_ && callbacks_.empty()) {
       // If there are too many threads waiting, then quit this thread
       if (threads_waiting_ >= reserve_threads_) {
-	break;
+        break;
       }
       threads_waiting_++;
       cv_.wait(lock);
@@ -84,9 +84,11 @@ void DynamicThreadPool::ThreadFunc() {
   }
 }
 
-DynamicThreadPool::DynamicThreadPool(int reserve_threads) :
-  shutdown_(false), reserve_threads_(reserve_threads), nthreads_(0),
-  threads_waiting_(0) {
+DynamicThreadPool::DynamicThreadPool(int reserve_threads)
+    : shutdown_(false),
+      reserve_threads_(reserve_threads),
+      nthreads_(0),
+      threads_waiting_(0) {
   for (int i = 0; i < reserve_threads_; i++) {
     grpc::lock_guard<grpc::mutex> lock(mu_);
     nthreads_++;
@@ -96,10 +98,10 @@ DynamicThreadPool::DynamicThreadPool(int reserve_threads) :
 
 void DynamicThreadPool::ReapThreads(std::list<DynamicThread*>* tlist) {
   for (auto t = tlist->begin(); t != tlist->end(); t = tlist->erase(t)) {
-    delete *t;    
+    delete *t;
   }
 }
-  
+
 DynamicThreadPool::~DynamicThreadPool() {
   grpc::unique_lock<grpc::mutex> lock(mu_);
   shutdown_ = true;

--- a/src/cpp/server/secure_server_credentials.cc
+++ b/src/cpp/server/secure_server_credentials.cc
@@ -35,8 +35,8 @@
 
 namespace grpc {
 
-int SecureServerCredentials::AddPortToServer(
-    const grpc::string& addr, grpc_server* server) {
+int SecureServerCredentials::AddPortToServer(const grpc::string& addr,
+                                             grpc_server* server) {
   return grpc_server_add_secure_http2_port(server, addr.c_str(), creds_);
 }
 

--- a/src/cpp/server/server.cc
+++ b/src/cpp/server/server.cc
@@ -230,11 +230,11 @@ Server::~Server() {
   delete sync_methods_;
 }
 
-bool Server::RegisterService(const grpc::string *host, RpcService* service) {
+bool Server::RegisterService(const grpc::string* host, RpcService* service) {
   for (int i = 0; i < service->GetMethodCount(); ++i) {
     RpcServiceMethod* method = service->GetMethod(i);
-    void* tag = grpc_server_register_method(
-        server_, method->name(), host ? host->c_str() : nullptr);
+    void* tag = grpc_server_register_method(server_, method->name(),
+                                            host ? host->c_str() : nullptr);
     if (!tag) {
       gpr_log(GPR_DEBUG, "Attempt to register %s multiple times",
               method->name());

--- a/src/cpp/server/server_builder.cc
+++ b/src/cpp/server/server_builder.cc
@@ -59,14 +59,16 @@ void ServerBuilder::RegisterAsyncService(AsynchronousService* service) {
   async_services_.emplace_back(new NamedService<AsynchronousService>(service));
 }
 
-void ServerBuilder::RegisterService(
-    const grpc::string& addr, SynchronousService* service) {
-  services_.emplace_back(new NamedService<RpcService>(addr, service->service()));
+void ServerBuilder::RegisterService(const grpc::string& addr,
+                                    SynchronousService* service) {
+  services_.emplace_back(
+      new NamedService<RpcService>(addr, service->service()));
 }
 
-void ServerBuilder::RegisterAsyncService(
-    const grpc::string& addr, AsynchronousService* service) {
-  async_services_.emplace_back(new NamedService<AsynchronousService>(addr, service));
+void ServerBuilder::RegisterAsyncService(const grpc::string& addr,
+                                         AsynchronousService* service) {
+  async_services_.emplace_back(
+      new NamedService<AsynchronousService>(addr, service));
 }
 
 void ServerBuilder::RegisterAsyncGenericService(AsyncGenericService* service) {
@@ -119,9 +121,10 @@ std::unique_ptr<Server> ServerBuilder::BuildAndStart() {
       return nullptr;
     }
   }
-  for (auto service = async_services_.begin();
-       service != async_services_.end(); service++) {
-    if (!server->RegisterAsyncService((*service)->host.get(), (*service)->service)) {
+  for (auto service = async_services_.begin(); service != async_services_.end();
+       service++) {
+    if (!server->RegisterAsyncService((*service)->host.get(),
+                                      (*service)->service)) {
       return nullptr;
     }
   }

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -50,7 +50,12 @@ namespace grpc {
 class ServerContext::CompletionOp GRPC_FINAL : public CallOpSetInterface {
  public:
   // initial refs: one in the server context, one in the cq
-  CompletionOp() : has_tag_(false), tag_(nullptr), refs_(2), finalized_(false), cancelled_(0) {}
+  CompletionOp()
+      : has_tag_(false),
+        tag_(nullptr),
+        refs_(2),
+        finalized_(false),
+        cancelled_(0) {}
 
   void FillOps(grpc_op* ops, size_t* nops) GRPC_OVERRIDE;
   bool FinalizeResult(void** tag, bool* status) GRPC_OVERRIDE;

--- a/test/build/protobuf.cc
+++ b/test/build/protobuf.cc
@@ -38,6 +38,4 @@ bool protobuf_test(const google::protobuf::MethodDescriptor *method) {
   return method->client_streaming() || method->server_streaming();
 }
 
-int main() {
-  return 0;
-}
+int main() { return 0; }

--- a/test/core/bad_client/bad_client.c
+++ b/test/core/bad_client/bad_client.c
@@ -150,9 +150,8 @@ void grpc_run_bad_client_test(grpc_bad_client_server_side_validator validator,
     grpc_endpoint_destroy(sfd.client);
   }
   grpc_server_shutdown_and_notify(a.server, a.cq, NULL);
-  GPR_ASSERT(grpc_completion_queue_pluck(a.cq, NULL,
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(1),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 a.cq, NULL, GRPC_TIMEOUT_SECONDS_TO_DEADLINE(1), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(a.server);
   grpc_completion_queue_destroy(a.cq);

--- a/test/core/bad_client/tests/connection_prefix.c
+++ b/test/core/bad_client/tests/connection_prefix.c
@@ -36,9 +36,9 @@
 
 static void verifier(grpc_server *server, grpc_completion_queue *cq) {
   while (grpc_server_has_open_connections(server)) {
-    GPR_ASSERT(
-        grpc_completion_queue_next(cq, GRPC_TIMEOUT_MILLIS_TO_DEADLINE(20),
-                                   NULL).type == GRPC_QUEUE_TIMEOUT);
+    GPR_ASSERT(grpc_completion_queue_next(
+                   cq, GRPC_TIMEOUT_MILLIS_TO_DEADLINE(20), NULL)
+                   .type == GRPC_QUEUE_TIMEOUT);
   }
 }
 

--- a/test/core/bad_client/tests/initial_settings_frame.c
+++ b/test/core/bad_client/tests/initial_settings_frame.c
@@ -38,9 +38,9 @@
 
 static void verifier(grpc_server *server, grpc_completion_queue *cq) {
   while (grpc_server_has_open_connections(server)) {
-    GPR_ASSERT(
-        grpc_completion_queue_next(cq, GRPC_TIMEOUT_MILLIS_TO_DEADLINE(20),
-                                   NULL).type == GRPC_QUEUE_TIMEOUT);
+    GPR_ASSERT(grpc_completion_queue_next(
+                   cq, GRPC_TIMEOUT_MILLIS_TO_DEADLINE(20), NULL)
+                   .type == GRPC_QUEUE_TIMEOUT);
   }
 }
 

--- a/test/core/client_config/uri_parser_test.c
+++ b/test/core/client_config/uri_parser_test.c
@@ -60,7 +60,8 @@ int main(int argc, char **argv) {
   test_succeeds("http://www.google.com:90", "http", "www.google.com:90", "");
   test_succeeds("a192.4-df:foo.coom", "a192.4-df", "", "foo.coom");
   test_succeeds("a+b:foo.coom", "a+b", "", "foo.coom");
-  test_succeeds("zookeeper://127.0.0.1:2181/foo/bar", "zookeeper", "127.0.0.1:2181", "/foo/bar");
+  test_succeeds("zookeeper://127.0.0.1:2181/foo/bar", "zookeeper",
+                "127.0.0.1:2181", "/foo/bar");
   test_fails("xyz");
   test_fails("http://www.google.com?why-are-you-using-queries");
   test_fails("dns:foo.com#fragments-arent-supported-here");

--- a/test/core/compression/compression_test.c
+++ b/test/core/compression/compression_test.c
@@ -70,7 +70,7 @@ static void test_compression_algorithm_parse(void) {
   }
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   test_compression_algorithm_parse();
 
   return 0;

--- a/test/core/compression/message_compress_test.c
+++ b/test/core/compression/message_compress_test.c
@@ -69,8 +69,7 @@ static void assert_passthrough(gpr_slice value,
           "algorithm='%s' uncompressed_split='%s' compressed_split='%s'",
           GPR_SLICE_LENGTH(value), gpr_murmur_hash3(GPR_SLICE_START_PTR(value),
                                                     GPR_SLICE_LENGTH(value), 0),
-          algorithm_name,
-          grpc_slice_split_mode_name(uncompressed_split_mode),
+          algorithm_name, grpc_slice_split_mode_name(uncompressed_split_mode),
           grpc_slice_split_mode_name(compressed_split_mode));
 
   gpr_slice_buffer_init(&input);

--- a/test/core/end2end/cq_verifier.c
+++ b/test/core/end2end/cq_verifier.c
@@ -146,7 +146,7 @@ static int byte_buffer_eq_slice(grpc_byte_buffer *bb, gpr_slice b) {
 
 int byte_buffer_eq_string(grpc_byte_buffer *bb, const char *str) {
   grpc_byte_buffer_reader reader;
-  grpc_byte_buffer* rbb;
+  grpc_byte_buffer *rbb;
   int res;
 
   grpc_byte_buffer_reader_init(&reader, bb);

--- a/test/core/end2end/cq_verifier.h
+++ b/test/core/end2end/cq_verifier.h
@@ -60,6 +60,7 @@ void cq_verify_empty(cq_verifier *v);
 void cq_expect_completion(cq_verifier *v, void *tag, int success);
 
 int byte_buffer_eq_string(grpc_byte_buffer *byte_buffer, const char *string);
-int contains_metadata(grpc_metadata_array *array, const char *key, const char *value);
+int contains_metadata(grpc_metadata_array *array, const char *key,
+                      const char *value);
 
-#endif  /* GRPC_TEST_CORE_END2END_CQ_VERIFIER_H */
+#endif /* GRPC_TEST_CORE_END2END_CQ_VERIFIER_H */

--- a/test/core/end2end/data/ssl_test_data.h
+++ b/test/core/end2end/data/ssl_test_data.h
@@ -38,4 +38,4 @@ extern const char test_root_cert[];
 extern const char test_server1_cert[];
 extern const char test_server1_key[];
 
-#endif  /* GRPC_TEST_CORE_END2END_DATA_SSL_TEST_DATA_H */
+#endif /* GRPC_TEST_CORE_END2END_DATA_SSL_TEST_DATA_H */

--- a/test/core/end2end/dualstack_socket_test.c
+++ b/test/core/end2end/dualstack_socket_test.c
@@ -220,9 +220,8 @@ void test_connect(const char *server_host, const char *client_host, int port,
 
   /* Destroy server. */
   grpc_server_shutdown_and_notify(server, cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(server);
   grpc_completion_queue_shutdown(cq);

--- a/test/core/end2end/fixtures/chttp2_simple_ssl_with_oauth2_fullstack.c
+++ b/test/core/end2end/fixtures/chttp2_simple_ssl_with_oauth2_fullstack.c
@@ -55,8 +55,7 @@ typedef struct fullstack_secure_fixture_data {
 } fullstack_secure_fixture_data;
 
 static const grpc_metadata *find_metadata(const grpc_metadata *md,
-                                          size_t md_count,
-                                          const char *key,
+                                          size_t md_count, const char *key,
                                           const char *value) {
   size_t i;
   for (i = 0; i < md_count; i++) {

--- a/test/core/end2end/fixtures/proxy.c
+++ b/test/core/end2end/fixtures/proxy.c
@@ -177,9 +177,8 @@ static void on_p2s_recv_initial_metadata(void *arg, int success) {
     op.data.send_initial_metadata.count = pc->p2s_initial_metadata.count;
     op.data.send_initial_metadata.metadata = pc->p2s_initial_metadata.metadata;
     refpc(pc, "on_c2p_sent_initial_metadata");
-    err = grpc_call_start_batch(pc->c2p, &op, 1,
-                                new_closure(on_c2p_sent_initial_metadata, pc),
-                                NULL);
+    err = grpc_call_start_batch(
+        pc->c2p, &op, 1, new_closure(on_c2p_sent_initial_metadata, pc), NULL);
     GPR_ASSERT(err == GRPC_CALL_OK);
   }
 
@@ -339,18 +338,16 @@ static void on_new_call(void *arg, int success) {
     op.op = GRPC_OP_RECV_INITIAL_METADATA;
     op.data.recv_initial_metadata = &pc->p2s_initial_metadata;
     refpc(pc, "on_p2s_recv_initial_metadata");
-    err = grpc_call_start_batch(pc->p2s, &op, 1,
-                                new_closure(on_p2s_recv_initial_metadata, pc),
-                                NULL);
+    err = grpc_call_start_batch(
+        pc->p2s, &op, 1, new_closure(on_p2s_recv_initial_metadata, pc), NULL);
     GPR_ASSERT(err == GRPC_CALL_OK);
 
     op.op = GRPC_OP_SEND_INITIAL_METADATA;
     op.data.send_initial_metadata.count = pc->c2p_initial_metadata.count;
     op.data.send_initial_metadata.metadata = pc->c2p_initial_metadata.metadata;
     refpc(pc, "on_p2s_sent_initial_metadata");
-    err = grpc_call_start_batch(pc->p2s, &op, 1,
-                                new_closure(on_p2s_sent_initial_metadata, pc),
-                                NULL);
+    err = grpc_call_start_batch(
+        pc->p2s, &op, 1, new_closure(on_p2s_sent_initial_metadata, pc), NULL);
     GPR_ASSERT(err == GRPC_CALL_OK);
 
     op.op = GRPC_OP_RECV_MESSAGE;
@@ -375,15 +372,15 @@ static void on_new_call(void *arg, int success) {
     op.data.recv_status_on_client.status_details_capacity =
         &pc->p2s_status_details_capacity;
     refpc(pc, "on_p2s_status");
-    err = grpc_call_start_batch(pc->p2s, &op, 1,
-                                new_closure(on_p2s_status, pc), NULL);
+    err = grpc_call_start_batch(pc->p2s, &op, 1, new_closure(on_p2s_status, pc),
+                                NULL);
     GPR_ASSERT(err == GRPC_CALL_OK);
 
     op.op = GRPC_OP_RECV_CLOSE_ON_SERVER;
     op.data.recv_close_on_server.cancelled = &pc->c2p_server_cancelled;
     refpc(pc, "on_c2p_closed");
-    err = grpc_call_start_batch(pc->c2p, &op, 1,
-                                new_closure(on_c2p_closed, pc), NULL);
+    err = grpc_call_start_batch(pc->c2p, &op, 1, new_closure(on_c2p_closed, pc),
+                                NULL);
     GPR_ASSERT(err == GRPC_CALL_OK);
 
     request_call(proxy);

--- a/test/core/end2end/multiple_server_queues_test.c
+++ b/test/core/end2end/multiple_server_queues_test.c
@@ -49,8 +49,8 @@ int main(int argc, char **argv) {
   grpc_server_register_completion_queue(server, cq2, NULL);
   grpc_server_start(server);
   grpc_server_shutdown_and_notify(server, cq2, NULL);
-  grpc_completion_queue_next(
-      cq2, gpr_inf_future(GPR_CLOCK_REALTIME), NULL); /* cue queue hang */
+  grpc_completion_queue_next(cq2, gpr_inf_future(GPR_CLOCK_REALTIME),
+                             NULL); /* cue queue hang */
   grpc_completion_queue_shutdown(cq1);
   grpc_completion_queue_shutdown(cq2);
   grpc_completion_queue_next(cq1, gpr_inf_future(GPR_CLOCK_REALTIME), NULL);

--- a/test/core/end2end/no_server_test.c
+++ b/test/core/end2end/no_server_test.c
@@ -88,8 +88,9 @@ int main(int argc, char **argv) {
   GPR_ASSERT(status == GRPC_STATUS_DEADLINE_EXCEEDED);
 
   grpc_completion_queue_shutdown(cq);
-  while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
-                                    NULL).type != GRPC_QUEUE_SHUTDOWN)
+  while (
+      grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME), NULL)
+          .type != GRPC_QUEUE_SHUTDOWN)
     ;
   grpc_completion_queue_destroy(cq);
   grpc_call_destroy(call);

--- a/test/core/end2end/tests/bad_hostname.c
+++ b/test/core/end2end/tests/bad_hostname.c
@@ -77,9 +77,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;

--- a/test/core/end2end/tests/cancel_after_accept.c
+++ b/test/core/end2end/tests/cancel_after_accept.c
@@ -76,9 +76,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;

--- a/test/core/end2end/tests/cancel_after_accept_and_writes_closed.c
+++ b/test/core/end2end/tests/cancel_after_accept_and_writes_closed.c
@@ -76,9 +76,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;

--- a/test/core/end2end/tests/cancel_after_invoke.c
+++ b/test/core/end2end/tests/cancel_after_invoke.c
@@ -77,9 +77,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;

--- a/test/core/end2end/tests/cancel_before_invoke.c
+++ b/test/core/end2end/tests/cancel_before_invoke.c
@@ -75,9 +75,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;

--- a/test/core/end2end/tests/cancel_in_a_vacuum.c
+++ b/test/core/end2end/tests/cancel_in_a_vacuum.c
@@ -76,9 +76,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;

--- a/test/core/end2end/tests/cancel_test_helpers.h
+++ b/test/core/end2end/tests/cancel_test_helpers.h
@@ -42,7 +42,7 @@ typedef struct {
 } cancellation_mode;
 
 static grpc_call_error wait_for_deadline(grpc_call *call, void *reserved) {
-  (void) reserved;
+  (void)reserved;
   return GRPC_CALL_OK;
 }
 

--- a/test/core/end2end/tests/census_simple_request.c
+++ b/test/core/end2end/tests/census_simple_request.c
@@ -66,9 +66,8 @@ static void *tag(gpr_intptr t) { return (void *)t; }
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -149,9 +148,9 @@ static void test_body(grpc_end2end_test_fixture f) {
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/channel_connectivity.c
+++ b/test/core/end2end/tests/channel_connectivity.c
@@ -48,33 +48,38 @@ static void test_connectivity(grpc_end2end_test_config config) {
   config.init_client(&f, NULL);
 
   /* channels should start life in IDLE, and stay there */
-  GPR_ASSERT(grpc_channel_check_connectivity_state(f.client, 0) == GRPC_CHANNEL_IDLE);
+  GPR_ASSERT(grpc_channel_check_connectivity_state(f.client, 0) ==
+             GRPC_CHANNEL_IDLE);
   gpr_sleep_until(GRPC_TIMEOUT_MILLIS_TO_DEADLINE(100));
-  GPR_ASSERT(grpc_channel_check_connectivity_state(f.client, 0) == GRPC_CHANNEL_IDLE);
+  GPR_ASSERT(grpc_channel_check_connectivity_state(f.client, 0) ==
+             GRPC_CHANNEL_IDLE);
 
   /* start watching for a change */
-  grpc_channel_watch_connectivity_state(
-  	f.client, GRPC_CHANNEL_IDLE, GRPC_TIMEOUT_SECONDS_TO_DEADLINE(3), f.cq, tag(1));
+  grpc_channel_watch_connectivity_state(f.client, GRPC_CHANNEL_IDLE,
+                                        GRPC_TIMEOUT_SECONDS_TO_DEADLINE(3),
+                                        f.cq, tag(1));
   /* nothing should happen */
   cq_verify_empty(cqv);
 
   /* check that we're still in idle, and start connecting */
-  GPR_ASSERT(grpc_channel_check_connectivity_state(f.client, 1) == GRPC_CHANNEL_IDLE);
+  GPR_ASSERT(grpc_channel_check_connectivity_state(f.client, 1) ==
+             GRPC_CHANNEL_IDLE);
 
   /* and now the watch should trigger */
   cq_expect_completion(cqv, tag(1), 1);
   cq_verify(cqv);
   state = grpc_channel_check_connectivity_state(f.client, 0);
-  GPR_ASSERT(state == GRPC_CHANNEL_TRANSIENT_FAILURE || 
+  GPR_ASSERT(state == GRPC_CHANNEL_TRANSIENT_FAILURE ||
              state == GRPC_CHANNEL_CONNECTING);
 
   /* quickly followed by a transition to TRANSIENT_FAILURE */
-  grpc_channel_watch_connectivity_state(
-  	f.client, GRPC_CHANNEL_CONNECTING, GRPC_TIMEOUT_SECONDS_TO_DEADLINE(3), f.cq, tag(2));
+  grpc_channel_watch_connectivity_state(f.client, GRPC_CHANNEL_CONNECTING,
+                                        GRPC_TIMEOUT_SECONDS_TO_DEADLINE(3),
+                                        f.cq, tag(2));
   cq_expect_completion(cqv, tag(2), 1);
   cq_verify(cqv);
   state = grpc_channel_check_connectivity_state(f.client, 0);
-  GPR_ASSERT(state == GRPC_CHANNEL_TRANSIENT_FAILURE || 
+  GPR_ASSERT(state == GRPC_CHANNEL_TRANSIENT_FAILURE ||
              state == GRPC_CHANNEL_CONNECTING);
 
   gpr_log(GPR_DEBUG, "*** STARTING SERVER ***");
@@ -87,13 +92,13 @@ static void test_connectivity(grpc_end2end_test_config config) {
   /* we'll go through some set of transitions (some might be missed), until
      READY is reached */
   while (state != GRPC_CHANNEL_READY) {
-  	grpc_channel_watch_connectivity_state(
-  		f.client, state, GRPC_TIMEOUT_SECONDS_TO_DEADLINE(3), f.cq, tag(3));
-  	cq_expect_completion(cqv, tag(3), 1);
+    grpc_channel_watch_connectivity_state(
+        f.client, state, GRPC_TIMEOUT_SECONDS_TO_DEADLINE(3), f.cq, tag(3));
+    cq_expect_completion(cqv, tag(3), 1);
     cq_verify(cqv);
     state = grpc_channel_check_connectivity_state(f.client, 0);
-  	GPR_ASSERT(state == GRPC_CHANNEL_READY || 
-               state == GRPC_CHANNEL_CONNECTING || 
+    GPR_ASSERT(state == GRPC_CHANNEL_READY ||
+               state == GRPC_CHANNEL_CONNECTING ||
                state == GRPC_CHANNEL_TRANSIENT_FAILURE);
   }
 
@@ -101,8 +106,9 @@ static void test_connectivity(grpc_end2end_test_config config) {
   /* we should go immediately to TRANSIENT_FAILURE */
   gpr_log(GPR_DEBUG, "*** SHUTTING DOWN SERVER ***");
 
-  grpc_channel_watch_connectivity_state(
-  	f.client, GRPC_CHANNEL_READY, GRPC_TIMEOUT_SECONDS_TO_DEADLINE(3), f.cq, tag(4));
+  grpc_channel_watch_connectivity_state(f.client, GRPC_CHANNEL_READY,
+                                        GRPC_TIMEOUT_SECONDS_TO_DEADLINE(3),
+                                        f.cq, tag(4));
 
   grpc_server_shutdown_and_notify(f.server, f.cq, tag(0xdead));
 
@@ -110,7 +116,7 @@ static void test_connectivity(grpc_end2end_test_config config) {
   cq_expect_completion(cqv, tag(0xdead), 1);
   cq_verify(cqv);
   state = grpc_channel_check_connectivity_state(f.client, 0);
-  GPR_ASSERT(state == GRPC_CHANNEL_TRANSIENT_FAILURE || 
+  GPR_ASSERT(state == GRPC_CHANNEL_TRANSIENT_FAILURE ||
              state == GRPC_CHANNEL_CONNECTING);
 
   /* cleanup server */

--- a/test/core/end2end/tests/default_host.c
+++ b/test/core/end2end/tests/default_host.c
@@ -77,9 +77,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -154,9 +153,9 @@ static void simple_request_body(grpc_end2end_test_fixture f) {
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(error == GRPC_CALL_OK);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(error == GRPC_CALL_OK);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);
@@ -220,7 +219,9 @@ static void test_invoke_simple_request(grpc_end2end_test_config config) {
 }
 
 void grpc_end2end_tests(grpc_end2end_test_config config) {
-  if ((config.feature_mask & FEATURE_MASK_SUPPORTS_HOSTNAME_VERIFICATION) != 0) return;
-  if ((config.feature_mask & FEATURE_MASK_SUPPORTS_DELAYED_CONNECTION) == 0) return;
+  if ((config.feature_mask & FEATURE_MASK_SUPPORTS_HOSTNAME_VERIFICATION) != 0)
+    return;
+  if ((config.feature_mask & FEATURE_MASK_SUPPORTS_DELAYED_CONNECTION) == 0)
+    return;
   test_invoke_simple_request(config);
 }

--- a/test/core/end2end/tests/disappearing_server.c
+++ b/test/core/end2end/tests/disappearing_server.c
@@ -134,9 +134,9 @@ static void do_request_and_shutdown_server(grpc_end2end_test_fixture *f,
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f->server, &s, &call_details,
-                                   &request_metadata_recv, f->cq, f->cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f->server, &s, &call_details,
+                               &request_metadata_recv, f->cq, f->cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/early_server_shutdown_finishes_inflight_calls.c
+++ b/test/core/end2end/tests/early_server_shutdown_finishes_inflight_calls.c
@@ -142,9 +142,9 @@ static void test_early_server_shutdown_finishes_inflight_calls(
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/empty_batch.c
+++ b/test/core/end2end/tests/empty_batch.c
@@ -77,9 +77,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;

--- a/test/core/end2end/tests/graceful_server_shutdown.c
+++ b/test/core/end2end/tests/graceful_server_shutdown.c
@@ -149,9 +149,9 @@ static void test_early_server_shutdown_finishes_inflight_calls(
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/invoke_large_request.c
+++ b/test/core/end2end/tests/invoke_large_request.c
@@ -73,9 +73,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -175,9 +174,9 @@ static void test_invoke_large_request(grpc_end2end_test_config config) {
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/max_concurrent_streams.c
+++ b/test/core/end2end/tests/max_concurrent_streams.c
@@ -75,9 +75,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -151,9 +150,9 @@ static void simple_request_body(grpc_end2end_test_fixture f) {
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/max_message_length.c
+++ b/test/core/end2end/tests/max_message_length.c
@@ -75,9 +75,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -171,9 +170,9 @@ static void test_max_message_length(grpc_end2end_test_config config) {
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/no_op.c
+++ b/test/core/end2end/tests/no_op.c
@@ -75,9 +75,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;

--- a/test/core/end2end/tests/ping_pong_streaming.c
+++ b/test/core/end2end/tests/ping_pong_streaming.c
@@ -75,9 +75,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -158,9 +157,9 @@ static void test_pingpong_streaming(grpc_end2end_test_config config,
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(100));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(100));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(100), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/registered_call.c
+++ b/test/core/end2end/tests/registered_call.c
@@ -77,9 +77,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -152,9 +151,9 @@ static void simple_request_body(grpc_end2end_test_fixture f, void *rc) {
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);
@@ -205,9 +204,8 @@ static void simple_request_body(grpc_end2end_test_fixture f, void *rc) {
 static void test_invoke_simple_request(grpc_end2end_test_config config) {
   grpc_end2end_test_fixture f =
       begin_test(config, "test_invoke_simple_request", NULL, NULL);
-  void *rc =
-      grpc_channel_register_call(f.client, "/foo", "foo.test.google.fr:1234",
-                                 NULL);
+  void *rc = grpc_channel_register_call(f.client, "/foo",
+                                        "foo.test.google.fr:1234", NULL);
 
   simple_request_body(f, rc);
   end_test(&f);
@@ -218,9 +216,8 @@ static void test_invoke_10_simple_requests(grpc_end2end_test_config config) {
   int i;
   grpc_end2end_test_fixture f =
       begin_test(config, "test_invoke_10_simple_requests", NULL, NULL);
-  void *rc =
-      grpc_channel_register_call(f.client, "/foo", "foo.test.google.fr:1234",
-                                 NULL);
+  void *rc = grpc_channel_register_call(f.client, "/foo",
+                                        "foo.test.google.fr:1234", NULL);
 
   for (i = 0; i < 10; i++) {
     simple_request_body(f, rc);

--- a/test/core/end2end/tests/request_response_with_binary_metadata_and_payload.c
+++ b/test/core/end2end/tests/request_response_with_binary_metadata_and_payload.c
@@ -75,9 +75,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -195,9 +194,9 @@ static void test_request_response_with_metadata_and_payload(
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/request_response_with_metadata_and_payload.c
+++ b/test/core/end2end/tests/request_response_with_metadata_and_payload.c
@@ -75,9 +75,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -110,10 +109,12 @@ static void test_request_response_with_metadata_and_payload(
   grpc_byte_buffer *response_payload =
       grpc_raw_byte_buffer_create(&response_payload_slice, 1);
   gpr_timespec deadline = five_seconds_time();
-  grpc_metadata meta_c[2] = {{"key1", "val1", 4, 0, {{NULL, NULL, NULL, NULL}}},
-                             {"key2", "val2", 4, 0, {{NULL, NULL, NULL, NULL}}}};
-  grpc_metadata meta_s[2] = {{"KeY3", "val3", 4, 0, {{NULL, NULL, NULL, NULL}}},
-                             {"KeY4", "val4", 4, 0, {{NULL, NULL, NULL, NULL}}}};
+  grpc_metadata meta_c[2] = {
+      {"key1", "val1", 4, 0, {{NULL, NULL, NULL, NULL}}},
+      {"key2", "val2", 4, 0, {{NULL, NULL, NULL, NULL}}}};
+  grpc_metadata meta_s[2] = {
+      {"KeY3", "val3", 4, 0, {{NULL, NULL, NULL, NULL}}},
+      {"KeY4", "val4", 4, 0, {{NULL, NULL, NULL, NULL}}}};
   grpc_end2end_test_fixture f = begin_test(
       config, "test_request_response_with_metadata_and_payload", NULL, NULL);
   cq_verifier *cqv = cq_verifier_create(f.cq);
@@ -177,9 +178,9 @@ static void test_request_response_with_metadata_and_payload(
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/request_response_with_payload.c
+++ b/test/core/end2end/tests/request_response_with_payload.c
@@ -75,9 +75,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -168,9 +167,9 @@ static void request_response_with_payload(grpc_end2end_test_fixture f) {
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/request_response_with_payload_and_call_creds.c
+++ b/test/core/end2end/tests/request_response_with_payload_and_call_creds.c
@@ -68,7 +68,7 @@ static grpc_end2end_test_fixture begin_test(grpc_end2end_test_config config,
     grpc_arg fail_auth_arg = {
         GRPC_ARG_STRING, FAIL_AUTH_CHECK_SERVER_ARG_NAME, {NULL}};
     grpc_channel_args args;
-    args.num_args= 1;
+    args.num_args = 1;
     args.args = &fail_auth_arg;
     config.init_server(&f, &args);
   } else {
@@ -93,9 +93,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -251,9 +250,9 @@ static void request_response_with_payload_and_call_creds(
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/request_response_with_trailing_metadata_and_payload.c
+++ b/test/core/end2end/tests/request_response_with_trailing_metadata_and_payload.c
@@ -75,9 +75,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -110,12 +109,15 @@ static void test_request_response_with_metadata_and_payload(
   grpc_byte_buffer *response_payload =
       grpc_raw_byte_buffer_create(&response_payload_slice, 1);
   gpr_timespec deadline = five_seconds_time();
-  grpc_metadata meta_c[2] = {{"key1", "val1", 4, 0, {{NULL, NULL, NULL, NULL}}},
-                             {"key2", "val2", 4, 0, {{NULL, NULL, NULL, NULL}}}};
-  grpc_metadata meta_s[2] = {{"key3", "val3", 4, 0, {{NULL, NULL, NULL, NULL}}},
-                             {"key4", "val4", 4, 0, {{NULL, NULL, NULL, NULL}}}};
-  grpc_metadata meta_t[2] = {{"key5", "val5", 4, 0, {{NULL, NULL, NULL, NULL}}},
-                             {"key6", "val6", 4, 0, {{NULL, NULL, NULL, NULL}}}};
+  grpc_metadata meta_c[2] = {
+      {"key1", "val1", 4, 0, {{NULL, NULL, NULL, NULL}}},
+      {"key2", "val2", 4, 0, {{NULL, NULL, NULL, NULL}}}};
+  grpc_metadata meta_s[2] = {
+      {"key3", "val3", 4, 0, {{NULL, NULL, NULL, NULL}}},
+      {"key4", "val4", 4, 0, {{NULL, NULL, NULL, NULL}}}};
+  grpc_metadata meta_t[2] = {
+      {"key5", "val5", 4, 0, {{NULL, NULL, NULL, NULL}}},
+      {"key6", "val6", 4, 0, {{NULL, NULL, NULL, NULL}}}};
   grpc_end2end_test_fixture f = begin_test(
       config, "test_request_response_with_metadata_and_payload", NULL, NULL);
   cq_verifier *cqv = cq_verifier_create(f.cq);
@@ -179,9 +181,9 @@ static void test_request_response_with_metadata_and_payload(
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/request_with_compressed_payload.c
+++ b/test/core/end2end/tests/request_with_compressed_payload.c
@@ -80,9 +80,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -132,7 +131,8 @@ static void request_with_payload_template(
   cq_verifier *cqv;
   char str[1024];
 
-  memset(str, 'x', 1023); str[1023] = '\0';
+  memset(str, 'x', 1023);
+  str[1023] = '\0';
   request_payload_slice = gpr_slice_from_copied_string(str);
   request_payload = grpc_raw_byte_buffer_create(&request_payload_slice, 1);
 
@@ -189,9 +189,9 @@ static void request_with_payload_template(
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq,
-                                   f.cq, tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);
@@ -279,8 +279,7 @@ static void test_invoke_request_with_exceptionally_uncompressed_payload(
     grpc_end2end_test_config config) {
   request_with_payload_template(
       config, "test_invoke_request_with_exceptionally_uncompressed_payload",
-      GRPC_WRITE_NO_COMPRESS, GRPC_COMPRESS_GZIP, GRPC_COMPRESS_NONE,
-      NULL);
+      GRPC_WRITE_NO_COMPRESS, GRPC_COMPRESS_GZIP, GRPC_COMPRESS_NONE, NULL);
 }
 
 static void test_invoke_request_with_uncompressed_payload(

--- a/test/core/end2end/tests/request_with_flags.c
+++ b/test/core/end2end/tests/request_with_flags.c
@@ -76,9 +76,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;

--- a/test/core/end2end/tests/request_with_large_metadata.c
+++ b/test/core/end2end/tests/request_with_large_metadata.c
@@ -75,9 +75,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -171,9 +170,9 @@ static void test_request_with_large_metadata(grpc_end2end_test_config config) {
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/request_with_payload.c
+++ b/test/core/end2end/tests/request_with_payload.c
@@ -75,9 +75,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;

--- a/test/core/end2end/tests/server_finishes_request.c
+++ b/test/core/end2end/tests/server_finishes_request.c
@@ -77,9 +77,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -149,9 +148,9 @@ static void simple_request_body(grpc_end2end_test_fixture f) {
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/simple_delayed_request.c
+++ b/test/core/end2end/tests/simple_delayed_request.c
@@ -63,9 +63,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -146,9 +145,9 @@ static void simple_delayed_request_body(grpc_end2end_test_config config,
 
   config.init_server(f, server_args);
 
-  error = grpc_server_request_call(f->server, &s, &call_details,
-                                   &request_metadata_recv, f->cq, f->cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f->server, &s, &call_details,
+                               &request_metadata_recv, f->cq, f->cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/simple_request.c
+++ b/test/core/end2end/tests/simple_request.c
@@ -77,9 +77,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -159,9 +158,9 @@ static void simple_request_body(grpc_end2end_test_fixture f) {
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/end2end/tests/simple_request_with_high_initial_sequence_number.c
+++ b/test/core/end2end/tests/simple_request_with_high_initial_sequence_number.c
@@ -77,9 +77,8 @@ static void drain_cq(grpc_completion_queue *cq) {
 static void shutdown_server(grpc_end2end_test_fixture *f) {
   if (!f->server) return;
   grpc_server_shutdown_and_notify(f->server, f->cq, tag(1000));
-  GPR_ASSERT(grpc_completion_queue_pluck(f->cq, tag(1000),
-                                         GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5),
-                                         NULL)
+  GPR_ASSERT(grpc_completion_queue_pluck(
+                 f->cq, tag(1000), GRPC_TIMEOUT_SECONDS_TO_DEADLINE(5), NULL)
                  .type == GRPC_OP_COMPLETE);
   grpc_server_destroy(f->server);
   f->server = NULL;
@@ -153,9 +152,9 @@ static void simple_request_body(grpc_end2end_test_fixture f) {
   error = grpc_call_start_batch(c, ops, op - ops, tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
-  error = grpc_server_request_call(f.server, &s, &call_details,
-                                   &request_metadata_recv, f.cq, f.cq,
-                                   tag(101));
+  error =
+      grpc_server_request_call(f.server, &s, &call_details,
+                               &request_metadata_recv, f.cq, f.cq, tag(101));
   GPR_ASSERT(GRPC_CALL_OK == error);
   cq_expect_completion(cqv, tag(101), 1);
   cq_verify(cqv);

--- a/test/core/fling/fling_test.c
+++ b/test/core/fling/fling_test.c
@@ -57,22 +57,24 @@ int main(int argc, char **argv) {
     strcpy(root, ".");
   }
   /* start the server */
-  gpr_asprintf(&args[0], "%s/fling_server%s", root, gpr_subprocess_binary_extension());
+  gpr_asprintf(&args[0], "%s/fling_server%s", root,
+               gpr_subprocess_binary_extension());
   args[1] = "--bind";
   gpr_join_host_port(&args[2], "::", port);
   args[3] = "--no-secure";
-  svr = gpr_subprocess_create(4, (const char**)args);
+  svr = gpr_subprocess_create(4, (const char **)args);
   gpr_free(args[0]);
   gpr_free(args[2]);
 
   /* start the client */
-  gpr_asprintf(&args[0], "%s/fling_client%s", root, gpr_subprocess_binary_extension());
+  gpr_asprintf(&args[0], "%s/fling_client%s", root,
+               gpr_subprocess_binary_extension());
   args[1] = "--target";
   gpr_join_host_port(&args[2], "127.0.0.1", port);
   args[3] = "--scenario=ping-pong-request";
   args[4] = "--no-secure";
   args[5] = 0;
-  cli = gpr_subprocess_create(6, (const char**)args);
+  cli = gpr_subprocess_create(6, (const char **)args);
   gpr_free(args[0]);
   gpr_free(args[2]);
 

--- a/test/core/fling/server.c
+++ b/test/core/fling/server.c
@@ -248,7 +248,8 @@ int main(int argc, char **argv) {
     }
     ev = grpc_completion_queue_next(
         cq, gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
-                         gpr_time_from_micros(1000000, GPR_TIMESPAN)), NULL);
+                         gpr_time_from_micros(1000000, GPR_TIMESPAN)),
+        NULL);
     s = ev.tag;
     switch (ev.type) {
       case GRPC_OP_COMPLETE:

--- a/test/core/httpcli/format_request_test.c
+++ b/test/core/httpcli/format_request_test.c
@@ -142,8 +142,7 @@ static void test_format_post_request_content_type_override(void) {
                       "POST /index.html HTTP/1.0\r\n"
                       "Host: example.com\r\n"
                       "Connection: close\r\n"
-                      "User-Agent: " GRPC_HTTPCLI_USER_AGENT
-                      "\r\n"
+                      "User-Agent: " GRPC_HTTPCLI_USER_AGENT "\r\n"
                       "x-yz: abc\r\n"
                       "Content-Type: application/x-www-form-urlencoded\r\n"
                       "Content-Length: 11\r\n"

--- a/test/core/iomgr/udp_server_test.c
+++ b/test/core/iomgr/udp_server_test.c
@@ -49,8 +49,7 @@ static grpc_pollset g_pollset;
 static int g_number_of_reads = 0;
 static int g_number_of_bytes_read = 0;
 
-static void on_connect(void *arg, grpc_endpoint *udp) {
-}
+static void on_connect(void *arg, grpc_endpoint *udp) {}
 
 static void on_read(int fd, grpc_udp_server_cb new_transport_cb, void *cb_arg) {
   char read_buffer[512];
@@ -122,7 +121,8 @@ static void test_receive(int number_of_clients) {
 
   memset(&addr, 0, sizeof(addr));
   addr.ss_family = AF_INET;
-  GPR_ASSERT(grpc_udp_server_add_port(s, (struct sockaddr *)&addr, addr_len, on_read));
+  GPR_ASSERT(
+      grpc_udp_server_add_port(s, (struct sockaddr *)&addr, addr_len, on_read));
 
   svrfd = grpc_udp_server_get_fd(s, 0);
   GPR_ASSERT(svrfd >= 0);

--- a/test/core/json/json_test.c
+++ b/test/core/json/json_test.c
@@ -66,7 +66,7 @@ static testing_pair testing_pairs[] = {
     {"\"\\ud834\\udd1e\"", "\"\\ud834\\udd1e\""},
     /* Testing nested empty containers. */
     {
-     " [ [ ] , { } , [ ] ] ", "[[],{},[]]",
+        " [ [ ] , { } , [ ] ] ", "[[],{},[]]",
     },
     /* Testing escapes and control chars in key strings. */
     {" { \"\x7f\\n\\\\a , b\": 1, \"\": 0 } ",

--- a/test/core/security/auth_context_test.c
+++ b/test/core/security/auth_context_test.c
@@ -151,4 +151,3 @@ int main(int argc, char **argv) {
   test_chained_context();
   return 0;
 }
-

--- a/test/core/security/json_token_test.c
+++ b/test/core/security/json_token_test.c
@@ -263,8 +263,8 @@ static void check_jwt_header(grpc_json *header) {
 
   GPR_ASSERT(kid != NULL);
   GPR_ASSERT(kid->type == GRPC_JSON_STRING);
-  GPR_ASSERT(strcmp(kid->value,
-                    "e6b5137873db8d2ef81e06a47289e6434ec8a165") == 0);
+  GPR_ASSERT(strcmp(kid->value, "e6b5137873db8d2ef81e06a47289e6434ec8a165") ==
+             0);
 }
 
 static void check_jwt_claim(grpc_json *claim, const char *expected_audience,
@@ -298,9 +298,11 @@ static void check_jwt_claim(grpc_json *claim, const char *expected_audience,
 
   GPR_ASSERT(iss != NULL);
   GPR_ASSERT(iss->type == GRPC_JSON_STRING);
-  GPR_ASSERT(strcmp(iss->value,
-          "777-abaslkan11hlb6nmim3bpspl31ud@developer.gserviceaccount.com")
-             ==0);
+  GPR_ASSERT(
+      strcmp(
+          iss->value,
+          "777-abaslkan11hlb6nmim3bpspl31ud@developer.gserviceaccount.com") ==
+      0);
 
   if (expected_scope != NULL) {
     GPR_ASSERT(scope != NULL);

--- a/test/core/security/jwt_verifier_test.c
+++ b/test/core/security/jwt_verifier_test.c
@@ -93,8 +93,7 @@ static const char json_key_str_part3_for_custom_email_issuer[] =
     "com\", \"type\": \"service_account\" }";
 
 static grpc_jwt_verifier_email_domain_key_url_mapping custom_mapping = {
-  "bar.com", "keys.bar.com/jwk"
-};
+    "bar.com", "keys.bar.com/jwk"};
 
 static const char expected_user_data[] = "user data";
 
@@ -153,7 +152,7 @@ static const char expired_claims[] =
     "  \"iss\": \"blah.foo.com\","
     "  \"sub\": \"juju@blah.foo.com\","
     "  \"jti\": \"jwtuniqueid\","
-    "  \"iat\": 100,"  /* Way back in the past... */
+    "  \"iat\": 100," /* Way back in the past... */
     "  \"exp\": 120,"
     "  \"nbf\": 60,"
     "  \"foo\": \"bar\"}";
@@ -316,8 +315,8 @@ static void test_jwt_verifier_google_email_issuer_success(void) {
   GPR_ASSERT(grpc_auth_json_key_is_valid(&key));
   grpc_httpcli_set_override(httpcli_get_google_keys_for_email,
                             httpcli_post_should_not_be_called);
-  jwt =
-      grpc_jwt_encode_and_sign(&key, expected_audience, expected_lifetime, NULL);
+  jwt = grpc_jwt_encode_and_sign(&key, expected_audience, expected_lifetime,
+                                 NULL);
   grpc_auth_json_key_destruct(&key);
   GPR_ASSERT(jwt != NULL);
   grpc_jwt_verifier_verify(verifier, NULL, jwt, expected_audience,
@@ -348,8 +347,8 @@ static void test_jwt_verifier_custom_email_issuer_success(void) {
   GPR_ASSERT(grpc_auth_json_key_is_valid(&key));
   grpc_httpcli_set_override(httpcli_get_custom_keys_for_email,
                             httpcli_post_should_not_be_called);
-  jwt =
-      grpc_jwt_encode_and_sign(&key, expected_audience, expected_lifetime, NULL);
+  jwt = grpc_jwt_encode_and_sign(&key, expected_audience, expected_lifetime,
+                                 NULL);
   grpc_auth_json_key_destruct(&key);
   GPR_ASSERT(jwt != NULL);
   grpc_jwt_verifier_verify(verifier, NULL, jwt, expected_audience,
@@ -359,9 +358,10 @@ static void test_jwt_verifier_custom_email_issuer_success(void) {
   grpc_httpcli_set_override(NULL, NULL);
 }
 
-static int httpcli_get_jwk_set(
-    const grpc_httpcli_request *request, gpr_timespec deadline,
-    grpc_httpcli_response_cb on_response, void *user_data) {
+static int httpcli_get_jwk_set(const grpc_httpcli_request *request,
+                               gpr_timespec deadline,
+                               grpc_httpcli_response_cb on_response,
+                               void *user_data) {
   grpc_httpcli_response response = http_response(200, gpr_strdup(good_jwk_set));
   GPR_ASSERT(request->handshaker == &grpc_httpcli_ssl);
   GPR_ASSERT(strcmp(request->host, "www.googleapis.com") == 0);
@@ -396,8 +396,8 @@ static void test_jwt_verifier_url_issuer_success(void) {
   GPR_ASSERT(grpc_auth_json_key_is_valid(&key));
   grpc_httpcli_set_override(httpcli_get_openid_config,
                             httpcli_post_should_not_be_called);
-  jwt =
-      grpc_jwt_encode_and_sign(&key, expected_audience, expected_lifetime, NULL);
+  jwt = grpc_jwt_encode_and_sign(&key, expected_audience, expected_lifetime,
+                                 NULL);
   grpc_auth_json_key_destruct(&key);
   GPR_ASSERT(jwt != NULL);
   grpc_jwt_verifier_verify(verifier, NULL, jwt, expected_audience,
@@ -436,8 +436,8 @@ static void test_jwt_verifier_url_issuer_bad_config(void) {
   GPR_ASSERT(grpc_auth_json_key_is_valid(&key));
   grpc_httpcli_set_override(httpcli_get_bad_json,
                             httpcli_post_should_not_be_called);
-  jwt =
-      grpc_jwt_encode_and_sign(&key, expected_audience, expected_lifetime, NULL);
+  jwt = grpc_jwt_encode_and_sign(&key, expected_audience, expected_lifetime,
+                                 NULL);
   grpc_auth_json_key_destruct(&key);
   GPR_ASSERT(jwt != NULL);
   grpc_jwt_verifier_verify(verifier, NULL, jwt, expected_audience,
@@ -457,8 +457,8 @@ static void test_jwt_verifier_bad_json_key(void) {
   GPR_ASSERT(grpc_auth_json_key_is_valid(&key));
   grpc_httpcli_set_override(httpcli_get_bad_json,
                             httpcli_post_should_not_be_called);
-  jwt =
-      grpc_jwt_encode_and_sign(&key, expected_audience, expected_lifetime, NULL);
+  jwt = grpc_jwt_encode_and_sign(&key, expected_audience, expected_lifetime,
+                                 NULL);
   grpc_auth_json_key_destruct(&key);
   GPR_ASSERT(jwt != NULL);
   grpc_jwt_verifier_verify(verifier, NULL, jwt, expected_audience,
@@ -503,8 +503,8 @@ static void test_jwt_verifier_bad_signature(void) {
   GPR_ASSERT(grpc_auth_json_key_is_valid(&key));
   grpc_httpcli_set_override(httpcli_get_openid_config,
                             httpcli_post_should_not_be_called);
-  jwt =
-      grpc_jwt_encode_and_sign(&key, expected_audience, expected_lifetime, NULL);
+  jwt = grpc_jwt_encode_and_sign(&key, expected_audience, expected_lifetime,
+                                 NULL);
   grpc_auth_json_key_destruct(&key);
   corrupt_jwt_sig(jwt);
   GPR_ASSERT(jwt != NULL);
@@ -546,7 +546,6 @@ static void test_jwt_verifier_bad_format(void) {
 /* bad signature custom provided email*/
 /* bad key */
 
-
 int main(int argc, char **argv) {
   grpc_test_init(argc, argv);
   test_claims_success();
@@ -562,4 +561,3 @@ int main(int argc, char **argv) {
   test_jwt_verifier_bad_format();
   return 0;
 }
-

--- a/test/core/security/print_google_default_creds_token.c
+++ b/test/core/security/print_google_default_creds_token.c
@@ -49,8 +49,7 @@ typedef struct {
   int is_done;
 } synchronizer;
 
-static void on_metadata_response(void *user_data,
-                                 grpc_credentials_md *md_elems,
+static void on_metadata_response(void *user_data, grpc_credentials_md *md_elems,
                                  size_t num_md,
                                  grpc_credentials_status status) {
   synchronizer *sync = user_data;

--- a/test/core/security/security_connector_test.c
+++ b/test/core/security/security_connector_test.c
@@ -77,9 +77,9 @@ static void test_unauthenticated_ssl_peer(void) {
 }
 
 static int check_identity(const grpc_auth_context *ctx,
-                         const char *expected_property_name,
-                         const char **expected_identities,
-                         size_t num_identities) {
+                          const char *expected_property_name,
+                          const char **expected_identities,
+                          size_t num_identities) {
   grpc_auth_property_iterator it;
   const grpc_auth_property *prop;
   size_t i;
@@ -166,7 +166,8 @@ static void test_cn_and_one_san_ssl_peer_to_auth_context(void) {
   ctx = tsi_ssl_peer_to_auth_context(&peer);
   GPR_ASSERT(ctx != NULL);
   GPR_ASSERT(grpc_auth_context_peer_is_authenticated(ctx));
-  GPR_ASSERT(check_identity(ctx, GRPC_X509_SAN_PROPERTY_NAME, &expected_san, 1));
+  GPR_ASSERT(
+      check_identity(ctx, GRPC_X509_SAN_PROPERTY_NAME, &expected_san, 1));
   GPR_ASSERT(check_transport_security_type(ctx));
   GPR_ASSERT(check_x509_cn(ctx, expected_cn));
 

--- a/test/core/security/verify_jwt.c
+++ b/test/core/security/verify_jwt.c
@@ -120,4 +120,3 @@ int main(int argc, char **argv) {
   gpr_cmdline_destroy(cl);
   return !sync.success;
 }
-

--- a/test/core/statistics/census_log_tests.h
+++ b/test/core/statistics/census_log_tests.h
@@ -48,4 +48,4 @@ void test_multiple_writers();
 void test_performance();
 void test_small_log();
 
-#endif  /* GRPC_TEST_CORE_STATISTICS_CENSUS_LOG_TESTS_H */
+#endif /* GRPC_TEST_CORE_STATISTICS_CENSUS_LOG_TESTS_H */

--- a/test/core/statistics/hash_table_test.c
+++ b/test/core/statistics/hash_table_test.c
@@ -65,8 +65,8 @@ static void free_data(void* data) { gpr_free(data); }
 static void test_create_table(void) {
   /* Create table with uint64 key type */
   census_ht* ht = NULL;
-  census_ht_option ht_options = {CENSUS_HT_UINT64, 1999, NULL,
-                                 NULL,             NULL, NULL};
+  census_ht_option ht_options = {
+      CENSUS_HT_UINT64, 1999, NULL, NULL, NULL, NULL};
   ht = census_ht_create(&ht_options);
   GPR_ASSERT(ht != NULL);
   GPR_ASSERT(census_ht_get_size(ht) == 0);
@@ -97,7 +97,7 @@ static void test_table_with_int_key(void) {
   for (i = 0; i < 20; ++i) {
     census_ht_key key;
     key.val = i;
-    census_ht_insert(ht, key, (void*)(gpr_intptr) i);
+    census_ht_insert(ht, key, (void*)(gpr_intptr)i);
     GPR_ASSERT(census_ht_get_size(ht) == i + 1);
   }
   for (i = 0; i < 20; i++) {
@@ -105,7 +105,7 @@ static void test_table_with_int_key(void) {
     census_ht_key key;
     key.val = i;
     val = census_ht_find(ht, key);
-    GPR_ASSERT(val == (void*)(gpr_intptr) i);
+    GPR_ASSERT(val == (void*)(gpr_intptr)i);
   }
   elements = census_ht_get_all_elements(ht, &num_elements);
   GPR_ASSERT(elements != NULL);
@@ -212,9 +212,9 @@ static void test_table_with_string_key(void) {
   census_ht_option opt = {CENSUS_HT_POINTER, 7,    &hash64,
                           &cmp_str_keys,     NULL, NULL};
   census_ht* ht = census_ht_create(&opt);
-  const char* keys[] = {"k1",    "a",                              "000",
-                        "apple", "banana_a_long_long_long_banana", "%$",
-                        "111",   "foo",                            "b"};
+  const char* keys[] = {
+      "k1", "a",   "000", "apple", "banana_a_long_long_long_banana",
+      "%$", "111", "foo", "b"};
   const int vals[] = {0, 1, 2, 3, 4, 5, 6, 7, 8};
   int i = 0;
   GPR_ASSERT(ht != NULL);

--- a/test/core/support/cmdline_test.c
+++ b/test/core/support/cmdline_test.c
@@ -287,8 +287,9 @@ static void test_usage(void) {
   gpr_cmdline_add_flag(cl, "flag", NULL, &flag);
 
   usage = gpr_cmdline_usage_string(cl, "test");
-  GPR_ASSERT(0 == strcmp(usage,
-    "Usage: test [--str=string] [--x=int] [--flag|--no-flag]\n"));
+  GPR_ASSERT(
+      0 == strcmp(usage,
+                  "Usage: test [--str=string] [--x=int] [--flag|--no-flag]\n"));
   gpr_free(usage);
 
   gpr_cmdline_destroy(cl);

--- a/test/core/support/string_test.c
+++ b/test/core/support/string_test.c
@@ -71,7 +71,7 @@ static void test_dump(void) {
   expect_dump("\x01", 1, GPR_DUMP_HEX | GPR_DUMP_ASCII, "01 '.'");
   expect_dump("\x01\x02", 2, GPR_DUMP_HEX, "01 02");
   expect_dump("\x01\x23\x45\x67\x89\xab\xcd\xef", 8, GPR_DUMP_HEX,
-                 "01 23 45 67 89 ab cd ef");
+              "01 23 45 67 89 ab cd ef");
   expect_dump("ab", 2, GPR_DUMP_HEX | GPR_DUMP_ASCII, "61 62 'ab'");
 }
 
@@ -221,7 +221,7 @@ static void test_strjoin_sep(void) {
 }
 
 static void test_strsplit(void) {
-  gpr_slice_buffer* parts;
+  gpr_slice_buffer *parts;
   gpr_slice str;
 
   LOG_TEST_NAME("test_strsplit");

--- a/test/core/support/thd_test.c
+++ b/test/core/support/thd_test.c
@@ -60,7 +60,7 @@ static void thd_body(void *v) {
   gpr_mu_unlock(&t->mu);
 }
 
-static void thd_body_joinable(void *v) { }
+static void thd_body_joinable(void *v) {}
 
 /* Test that we can create a number of threads and wait for them. */
 static void test(void) {

--- a/test/core/surface/completion_queue_test.c
+++ b/test/core/surface/completion_queue_test.c
@@ -105,8 +105,8 @@ static void test_shutdown_then_next_polling(void) {
 
   cc = grpc_completion_queue_create(NULL);
   grpc_completion_queue_shutdown(cc);
-  event = grpc_completion_queue_next(cc, gpr_inf_past(GPR_CLOCK_REALTIME),
-                                     NULL);
+  event =
+      grpc_completion_queue_next(cc, gpr_inf_past(GPR_CLOCK_REALTIME), NULL);
   GPR_ASSERT(event.type == GRPC_QUEUE_SHUTDOWN);
   grpc_completion_queue_destroy(cc);
 }
@@ -118,8 +118,8 @@ static void test_shutdown_then_next_with_timeout(void) {
 
   cc = grpc_completion_queue_create(NULL);
   grpc_completion_queue_shutdown(cc);
-  event = grpc_completion_queue_next(cc, gpr_inf_future(GPR_CLOCK_REALTIME),
-                                     NULL);
+  event =
+      grpc_completion_queue_next(cc, gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
   GPR_ASSERT(event.type == GRPC_QUEUE_SHUTDOWN);
   grpc_completion_queue_destroy(cc);
 }

--- a/test/core/surface/lame_client_test.c
+++ b/test/core/surface/lame_client_test.c
@@ -64,8 +64,7 @@ int main(int argc, char **argv) {
   cq = grpc_completion_queue_create(NULL);
   call = grpc_channel_create_call(chan, NULL, GRPC_PROPAGATE_DEFAULTS, cq,
                                   "/Foo", "anywhere",
-                                  GRPC_TIMEOUT_SECONDS_TO_DEADLINE(100),
-                                  NULL);
+                                  GRPC_TIMEOUT_SECONDS_TO_DEADLINE(100), NULL);
   GPR_ASSERT(call);
   cqv = cq_verifier_create(cq);
 

--- a/test/core/transport/chttp2/stream_map_test.c
+++ b/test/core/transport/chttp2/stream_map_test.c
@@ -93,7 +93,7 @@ static void test_basic_add_find(size_t n) {
   grpc_chttp2_stream_map_init(&map, 8);
   GPR_ASSERT(0 == grpc_chttp2_stream_map_size(&map));
   for (i = 1; i <= n; i++) {
-    grpc_chttp2_stream_map_add(&map, i, (void *)(gpr_uintptr) i);
+    grpc_chttp2_stream_map_add(&map, i, (void *)(gpr_uintptr)i);
   }
   GPR_ASSERT(n == grpc_chttp2_stream_map_size(&map));
   GPR_ASSERT(NULL == grpc_chttp2_stream_map_find(&map, 0));
@@ -148,7 +148,7 @@ static void test_delete_evens_sweep(size_t n) {
 
   grpc_chttp2_stream_map_init(&map, 8);
   for (i = 1; i <= n; i++) {
-    grpc_chttp2_stream_map_add(&map, i, (void *)(gpr_uintptr) i);
+    grpc_chttp2_stream_map_add(&map, i, (void *)(gpr_uintptr)i);
   }
   for (i = 1; i <= n; i++) {
     if ((i & 1) == 0) {
@@ -170,7 +170,7 @@ static void test_delete_evens_incremental(size_t n) {
 
   grpc_chttp2_stream_map_init(&map, 8);
   for (i = 1; i <= n; i++) {
-    grpc_chttp2_stream_map_add(&map, i, (void *)(gpr_uintptr) i);
+    grpc_chttp2_stream_map_add(&map, i, (void *)(gpr_uintptr)i);
     if ((i & 1) == 0) {
       grpc_chttp2_stream_map_delete(&map, i);
     }

--- a/test/core/util/grpc_profiler.h
+++ b/test/core/util/grpc_profiler.h
@@ -45,4 +45,4 @@ void grpc_profiler_stop();
 }
 #endif /*  __cplusplus */
 
-#endif  /* GRPC_TEST_CORE_UTIL_GRPC_PROFILER_H */
+#endif /* GRPC_TEST_CORE_UTIL_GRPC_PROFILER_H */

--- a/test/core/util/parse_hexstring.h
+++ b/test/core/util/parse_hexstring.h
@@ -38,4 +38,4 @@
 
 gpr_slice parse_hexstring(const char *hexstring);
 
-#endif  /* GRPC_TEST_CORE_UTIL_PARSE_HEXSTRING_H */
+#endif /* GRPC_TEST_CORE_UTIL_PARSE_HEXSTRING_H */

--- a/test/core/util/port.h
+++ b/test/core/util/port.h
@@ -49,4 +49,4 @@ int grpc_pick_unused_port_or_die();
 }
 #endif
 
-#endif  /* GRPC_TEST_CORE_UTIL_PORT_H */
+#endif /* GRPC_TEST_CORE_UTIL_PORT_H */

--- a/test/core/util/port_posix.c
+++ b/test/core/util/port_posix.c
@@ -66,9 +66,7 @@ static int has_port_been_chosen(int port) {
   return 0;
 }
 
-static void free_chosen_ports() {
-  gpr_free(chosen_ports);
-}
+static void free_chosen_ports() { gpr_free(chosen_ports); }
 
 static void chose_port(int port) {
   if (chosen_ports == NULL) {
@@ -206,7 +204,8 @@ int grpc_pick_unused_port(void) {
 
   /* Type of port to first pick in next iteration */
   int is_tcp = 1;
-  int try = 0;
+  int try
+    = 0;
 
   char *env = gpr_getenv("GRPC_TEST_PORT_SERVER");
   if (env) {
@@ -219,7 +218,8 @@ int grpc_pick_unused_port(void) {
 
   for (;;) {
     int port;
-    try++;
+    try
+      ++;
     if (try == 1) {
       port = getpid() % (65536 - 30000) + 30000;
     } else if (try <= NUM_RANDOM_PORTS_TO_PICK) {

--- a/test/core/util/port_windows.c
+++ b/test/core/util/port_windows.c
@@ -63,7 +63,8 @@ static int is_port_available(int *port, int is_tcp) {
   }
 
   /* Reuseaddr lets us start up a server immediately after it exits */
-  if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (const char*)&one, sizeof(one)) < 0) {
+  if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, (const char *)&one,
+                 sizeof(one)) < 0) {
     gpr_log(GPR_ERROR, "setsockopt() failed: %s", strerror(errno));
     closesocket(fd);
     return 0;
@@ -75,14 +76,14 @@ static int is_port_available(int *port, int is_tcp) {
   addr.sin_port = htons(*port);
   if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
     gpr_log(GPR_DEBUG, "bind(port=%d) failed: %s", *port, strerror(errno));
-	closesocket(fd);
+    closesocket(fd);
     return 0;
   }
 
   /* Get the bound port number */
   if (getsockname(fd, (struct sockaddr *)&addr, &alen) < 0) {
     gpr_log(GPR_ERROR, "getsockname() failed: %s", strerror(errno));
-	closesocket(fd);
+    closesocket(fd);
     return 0;
   }
   GPR_ASSERT(alen <= sizeof(addr));
@@ -113,11 +114,13 @@ int grpc_pick_unused_port(void) {
 
   /* Type of port to first pick in next iteration */
   int is_tcp = 1;
-  int try = 0;
+  int try
+    = 0;
 
   for (;;) {
     int port;
-    try++;
+    try
+      ++;
     if (try == 1) {
       port = _getpid() % (65536 - 30000) + 30000;
     } else if (try <= NUM_RANDOM_PORTS_TO_PICK) {

--- a/test/core/util/slice_splitter.h
+++ b/test/core/util/slice_splitter.h
@@ -65,4 +65,4 @@ gpr_slice grpc_slice_merge(gpr_slice *slices, size_t nslices);
 
 const char *grpc_slice_split_mode_name(grpc_slice_split_mode mode);
 
-#endif  /* GRPC_TEST_CORE_UTIL_SLICE_SPLITTER_H */
+#endif /* GRPC_TEST_CORE_UTIL_SLICE_SPLITTER_H */

--- a/test/core/util/test_config.c
+++ b/test/core/util/test_config.c
@@ -78,16 +78,16 @@ void abort_handler(int sig) {
 }
 
 static void install_crash_handler() {
-  SetUnhandledExceptionFilter((LPTOP_LEVEL_EXCEPTION_FILTER) crash_handler);
+  SetUnhandledExceptionFilter((LPTOP_LEVEL_EXCEPTION_FILTER)crash_handler);
   _set_abort_behavior(0, _WRITE_ABORT_MSG);
   _set_abort_behavior(0, _CALL_REPORTFAULT);
   signal(SIGABRT, abort_handler);
 }
 #else
-static void install_crash_handler() { }
+static void install_crash_handler() {}
 #endif
 
-void grpc_test_init(int argc, char **argv) {
+void grpc_test_init(int argc, char** argv) {
   install_crash_handler();
   gpr_log(GPR_DEBUG, "test slowdown: machine=%f build=%f total=%f",
           (double)GRPC_TEST_SLOWDOWN_MACHINE_FACTOR,

--- a/test/cpp/common/auth_property_iterator_test.cc
+++ b/test/cpp/common/auth_property_iterator_test.cc
@@ -61,11 +61,8 @@ class AuthPropertyIteratorTest : public ::testing::Test {
     EXPECT_EQ(1,
               grpc_auth_context_set_peer_identity_property_name(ctx_, "name"));
   }
-  void TearDown() GRPC_OVERRIDE {
-    grpc_auth_context_release(ctx_);
-  }
+  void TearDown() GRPC_OVERRIDE { grpc_auth_context_release(ctx_); }
   grpc_auth_context* ctx_;
-
 };
 
 TEST_F(AuthPropertyIteratorTest, DefaultCtor) {
@@ -100,7 +97,7 @@ TEST_F(AuthPropertyIteratorTest, GeneralTest) {
 }  // namespace
 }  // namespace grpc
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/test/cpp/common/secure_auth_context_test.cc
+++ b/test/cpp/common/secure_auth_context_test.cc
@@ -101,7 +101,7 @@ TEST_F(SecureAuthContextTest, Iterators) {
 }  // namespace
 }  // namespace grpc
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/test/cpp/end2end/client_crash_test.cc
+++ b/test/cpp/end2end/client_crash_test.cc
@@ -77,17 +77,14 @@ class CrashTest : public ::testing::Test {
     addr_stream << "localhost:" << port;
     auto addr = addr_stream.str();
     server_.reset(new SubProcess({
-      g_root + "/client_crash_test_server",
-      "--address=" + addr,
+        g_root + "/client_crash_test_server", "--address=" + addr,
     }));
     GPR_ASSERT(server_);
     return grpc::cpp::test::util::TestService::NewStub(
         CreateChannel(addr, InsecureCredentials(), ChannelArguments()));
   }
 
-  void KillServer() {
-    server_.reset();
-  }
+  void KillServer() { server_.reset(); }
 
  private:
   std::unique_ptr<SubProcess> server_;

--- a/test/cpp/end2end/client_crash_test_server.cc
+++ b/test/cpp/end2end/client_crash_test_server.cc
@@ -58,7 +58,8 @@ using namespace gflags;
 namespace grpc {
 namespace testing {
 
-class ServiceImpl GRPC_FINAL : public ::grpc::cpp::test::util::TestService::Service {
+class ServiceImpl GRPC_FINAL
+    : public ::grpc::cpp::test::util::TestService::Service {
   Status BidiStream(ServerContext* context,
                     ServerReaderWriter<EchoResponse, EchoRequest>* stream)
       GRPC_OVERRIDE {

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -270,7 +270,7 @@ class End2endTest : public ::testing::TestWithParam<bool> {
     // Setup server
     ServerBuilder builder;
     SslServerCredentialsOptions::PemKeyCertPair pkcp = {test_server1_key,
-      test_server1_cert};
+                                                        test_server1_cert};
     SslServerCredentialsOptions ssl_opts;
     ssl_opts.pem_root_certs = "";
     ssl_opts.pem_key_cert_pairs.push_back(pkcp);
@@ -295,8 +295,8 @@ class End2endTest : public ::testing::TestWithParam<bool> {
     ChannelArguments args;
     args.SetSslTargetNameOverride("foo.test.google.fr");
     args.SetString(GRPC_ARG_SECONDARY_USER_AGENT_STRING, "end2end_test");
-    channel_ = CreateChannel(server_address_.str(), SslCredentials(ssl_opts),
-                             args);
+    channel_ =
+        CreateChannel(server_address_.str(), SslCredentials(ssl_opts), args);
   }
 
   void ResetStub(bool use_proxy) {
@@ -874,7 +874,7 @@ TEST_P(End2endTest, HugeResponse) {
 
 namespace {
 void ReaderThreadFunc(ClientReaderWriter<EchoRequest, EchoResponse>* stream,
-                      gpr_event *ev) {
+                      gpr_event* ev) {
   EchoResponse resp;
   gpr_event_set(ev, (void*)1);
   while (stream->Read(&resp)) {
@@ -929,8 +929,8 @@ TEST_F(End2endTest, ChannelState) {
   EXPECT_FALSE(ok);
 
   EXPECT_EQ(GRPC_CHANNEL_IDLE, channel_->GetState(true));
-  EXPECT_TRUE(channel_->WaitForStateChange(
-      GRPC_CHANNEL_IDLE, gpr_inf_future(GPR_CLOCK_REALTIME)));
+  EXPECT_TRUE(channel_->WaitForStateChange(GRPC_CHANNEL_IDLE,
+                                           gpr_inf_future(GPR_CLOCK_REALTIME)));
   EXPECT_EQ(GRPC_CHANNEL_CONNECTING, channel_->GetState(false));
 }
 

--- a/test/cpp/end2end/generic_end2end_test.cc
+++ b/test/cpp/end2end/generic_end2end_test.cc
@@ -68,7 +68,7 @@ namespace grpc {
 namespace testing {
 namespace {
 
-void* tag(int i) { return (void*)(gpr_intptr) i; }
+void* tag(int i) { return (void*)(gpr_intptr)i; }
 
 void verify_ok(CompletionQueue* cq, int i, bool expect_ok) {
   bool ok;
@@ -107,7 +107,8 @@ class GenericEnd2endTest : public ::testing::Test {
     server_address_ << server_host_ << ":" << port;
     // Setup server
     ServerBuilder builder;
-    builder.AddListeningPort(server_address_.str(), InsecureServerCredentials());
+    builder.AddListeningPort(server_address_.str(),
+                             InsecureServerCredentials());
     builder.RegisterAsyncGenericService(&generic_service_);
     srv_cq_ = builder.AddCompletionQueue();
     server_ = builder.BuildAndStart();

--- a/test/cpp/end2end/server_crash_test_client.cc
+++ b/test/cpp/end2end/server_crash_test_client.cc
@@ -60,8 +60,8 @@ using namespace gflags;
 
 int main(int argc, char** argv) {
   ParseCommandLineFlags(&argc, &argv, true);
-  auto stub = grpc::cpp::test::util::TestService::NewStub(
-    grpc::CreateChannel(FLAGS_address, grpc::InsecureCredentials(), grpc::ChannelArguments()));
+  auto stub = grpc::cpp::test::util::TestService::NewStub(grpc::CreateChannel(
+      FLAGS_address, grpc::InsecureCredentials(), grpc::ChannelArguments()));
 
   EchoRequest request;
   EchoResponse response;

--- a/test/cpp/end2end/zookeeper_test.cc
+++ b/test/cpp/end2end/zookeeper_test.cc
@@ -89,8 +89,7 @@ class ZookeeperTest : public ::testing::Test {
     RegisterService("/test/1", value);
 
     // Registers service instance /test/2 in zookeeper
-    value =
-        "{\"host\":\"localhost\",\"port\":\"" + to_string(port2) + "\"}";
+    value = "{\"host\":\"localhost\",\"port\":\"" + to_string(port2) + "\"}";
     RegisterService("/test/2", value);
   }
 
@@ -196,7 +195,7 @@ TEST_F(ZookeeperTest, ZookeeperStateChangeTwoRpc) {
   EXPECT_TRUE(s1.ok());
 
   // Zookeeper state changes
-  gpr_log(GPR_DEBUG, "Zookeeper state change"); 
+  gpr_log(GPR_DEBUG, "Zookeeper state change");
   ChangeZookeeperState();
   // Waits for re-resolving addresses
   // TODO(ctiller): RPC will probably fail if not waiting

--- a/test/cpp/interop/client_helper.h
+++ b/test/cpp/interop/client_helper.h
@@ -67,7 +67,6 @@ class InteropClientContextInspector {
   const ::grpc::ClientContext& context_;
 };
 
-
 }  // namespace testing
 }  // namespace grpc
 

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -134,13 +134,12 @@ void InteropClient::PerformLargeUnary(SimpleRequest* request,
                  grpc::string(kLargeResponseSize, '\0'));
       break;
     case PayloadType::UNCOMPRESSABLE: {
-        std::ifstream rnd_file(kRandomFile);
-        GPR_ASSERT(rnd_file.good());
-        for (int i = 0; i < kLargeResponseSize; i++) {
-          GPR_ASSERT(response->payload().body()[i] == (char)rnd_file.get());
-        }
+      std::ifstream rnd_file(kRandomFile);
+      GPR_ASSERT(rnd_file.good());
+      for (int i = 0; i < kLargeResponseSize; i++) {
+        GPR_ASSERT(response->payload().body()[i] == (char)rnd_file.get());
       }
-      break;
+    } break;
     default:
       GPR_ASSERT(false);
   }
@@ -262,8 +261,8 @@ void InteropClient::DoLargeCompressedUnary() {
     for (const auto compression_type : compression_types) {
       char* log_suffix;
       gpr_asprintf(&log_suffix, "(compression=%s; payload=%s)",
-          CompressionType_Name(compression_type).c_str(),
-          PayloadType_Name(payload_type).c_str());
+                   CompressionType_Name(compression_type).c_str(),
+                   PayloadType_Name(payload_type).c_str());
 
       gpr_log(GPR_INFO, "Sending a large compressed unary rpc %s.", log_suffix);
       SimpleRequest request;
@@ -342,8 +341,8 @@ void InteropClient::DoResponseCompressedStreaming() {
 
       char* log_suffix;
       gpr_asprintf(&log_suffix, "(compression=%s; payload=%s)",
-          CompressionType_Name(compression_type).c_str(),
-          PayloadType_Name(payload_type).c_str());
+                   CompressionType_Name(compression_type).c_str(),
+                   PayloadType_Name(payload_type).c_str());
 
       gpr_log(GPR_INFO, "Receiving response steaming rpc %s.", log_suffix);
 
@@ -553,7 +552,7 @@ void InteropClient::DoStatusWithMessage() {
   ClientContext context;
   SimpleRequest request;
   SimpleResponse response;
-  EchoStatus *requested_status = request.mutable_response_status();
+  EchoStatus* requested_status = request.mutable_response_status();
   requested_status->set_code(grpc::StatusCode::UNKNOWN);
   grpc::string test_msg = "This is a test message";
   requested_status->set_message(test_msg);

--- a/test/cpp/qps/perf_db_client.cc
+++ b/test/cpp/qps/perf_db_client.cc
@@ -44,9 +44,7 @@ void PerfDbClient::setConfigs(const ClientConfig& client_config,
 }
 
 // sets the QPS
-void PerfDbClient::setQps(double qps) {
-  qps_ = qps;
-}
+void PerfDbClient::setQps(double qps) { qps_ = qps; }
 
 // sets the QPS per core
 void PerfDbClient::setQpsPerCore(double qps_per_core) {
@@ -54,10 +52,8 @@ void PerfDbClient::setQpsPerCore(double qps_per_core) {
 }
 
 // sets the 50th, 90th, 95th, 99th and 99.9th percentile latency
-void PerfDbClient::setLatencies(double perc_lat_50,
-                                double perc_lat_90,
-                                double perc_lat_95,
-                                double perc_lat_99,
+void PerfDbClient::setLatencies(double perc_lat_50, double perc_lat_90,
+                                double perc_lat_95, double perc_lat_99,
                                 double perc_lat_99_point_9) {
   perc_lat_50_ = perc_lat_50;
   perc_lat_90_ = perc_lat_90;
@@ -68,7 +64,8 @@ void PerfDbClient::setLatencies(double perc_lat_50,
 
 // sets the server and client, user and system times
 void PerfDbClient::setTimes(double server_system_time, double server_user_time,
-                            double client_system_time, double client_user_time) {
+                            double client_system_time,
+                            double client_user_time) {
   server_system_time_ = server_system_time;
   server_user_time_ = server_user_time;
   client_system_time_ = client_system_time;

--- a/test/cpp/qps/perf_db_client.h
+++ b/test/cpp/qps/perf_db_client.h
@@ -82,9 +82,8 @@ class PerfDbClient {
   void setQpsPerCore(double qps_per_core);
 
   // sets the 50th, 90th, 95th, 99th and 99.9th percentile latency
-  void setLatencies(double perc_lat_50, double perc_lat_90,
-                    double perc_lat_95, double perc_lat_99,
-                    double perc_lat_99_point_9);
+  void setLatencies(double perc_lat_50, double perc_lat_90, double perc_lat_95,
+                    double perc_lat_99, double perc_lat_99_point_9);
 
   // sets the server and client, user and system times
   void setTimes(double server_system_time, double server_user_time,

--- a/test/cpp/qps/qps_interarrival_test.cc
+++ b/test/cpp/qps/qps_interarrival_test.cc
@@ -42,7 +42,7 @@
 using grpc::testing::RandomDist;
 using grpc::testing::InterarrivalTimer;
 
-void RunTest(RandomDist&& r, int threads, std::string title) {
+void RunTest(RandomDist &&r, int threads, std::string title) {
   InterarrivalTimer timer;
   timer.init(r, threads);
   gpr_histogram *h(gpr_histogram_create(0.01, 60e9));

--- a/test/cpp/qps/qps_openloop_test.cc
+++ b/test/cpp/qps/qps_openloop_test.cc
@@ -59,8 +59,8 @@ static void RunQPS() {
   client_config.set_async_client_threads(8);
   client_config.set_rpc_type(UNARY);
   client_config.set_load_type(POISSON);
-  client_config.mutable_load_params()->
-    mutable_poisson()->set_offered_load(1000.0);
+  client_config.mutable_load_params()->mutable_poisson()->set_offered_load(
+      1000.0);
 
   ServerConfig server_config;
   server_config.set_server_type(ASYNC_SERVER);

--- a/test/cpp/util/benchmark_config.cc
+++ b/test/cpp/util/benchmark_config.cc
@@ -37,7 +37,8 @@
 DEFINE_bool(enable_log_reporter, true,
             "Enable reporting of benchmark results through GprLog");
 
-DEFINE_bool(report_metrics_db, false, "True if metrics to be reported to performance database");
+DEFINE_bool(report_metrics_db, false,
+            "True if metrics to be reported to performance database");
 
 DEFINE_string(hashed_id, "", "Hash of the user id");
 
@@ -45,7 +46,8 @@ DEFINE_string(test_name, "", "Name of the test being executed");
 
 DEFINE_string(sys_info, "", "System information");
 
-DEFINE_string(server_address, "localhost:50052", "Address of the performance database server");
+DEFINE_string(server_address, "localhost:50052",
+              "Address of the performance database server");
 
 DEFINE_string(tag, "", "Optional tag for the test");
 
@@ -69,10 +71,10 @@ static std::shared_ptr<Reporter> InitBenchmarkReporters() {
     composite_reporter->add(
         std::unique_ptr<Reporter>(new GprLogReporter("LogReporter")));
   }
-  if(FLAGS_report_metrics_db) {
-    composite_reporter->add(
-      std::unique_ptr<Reporter>(new PerfDbReporter("PerfDbReporter", FLAGS_hashed_id, FLAGS_test_name, 
-        FLAGS_sys_info, FLAGS_server_address, FLAGS_tag)));
+  if (FLAGS_report_metrics_db) {
+    composite_reporter->add(std::unique_ptr<Reporter>(
+        new PerfDbReporter("PerfDbReporter", FLAGS_hashed_id, FLAGS_test_name,
+                           FLAGS_sys_info, FLAGS_server_address, FLAGS_tag)));
   }
 
   return std::shared_ptr<Reporter>(composite_reporter);

--- a/test/cpp/util/byte_buffer_test.cc
+++ b/test/cpp/util/byte_buffer_test.cc
@@ -46,8 +46,7 @@ namespace {
 const char* kContent1 = "hello xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 const char* kContent2 = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy world";
 
-class ByteBufferTest : public ::testing::Test {
-};
+class ByteBufferTest : public ::testing::Test {};
 
 TEST_F(ByteBufferTest, CreateFromSingleSlice) {
   gpr_slice hello = gpr_slice_from_copied_string(kContent1);

--- a/test/cpp/util/cli_call.cc
+++ b/test/cpp/util/cli_call.cc
@@ -49,7 +49,7 @@
 namespace grpc {
 namespace testing {
 namespace {
-void* tag(int i) { return (void*)(gpr_intptr) i; }
+void* tag(int i) { return (void*)(gpr_intptr)i; }
 }  // namespace
 
 Status CliCall::Call(std::shared_ptr<grpc::ChannelInterface> channel,


### PR DESCRIPTION
Our formatting has been wandering further over time. clang-format all
the things (for core/C++) to get things back on track.