### PR TITLE
Only run built binaries

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -143,7 +143,10 @@ class CLanguage(object):
         binary = 'vsprojects/test_bin/%s.exe' % (target['name'])
       else:
         binary = 'bins/%s/%s' % (config.build_config, target['name'])
-      out.append(config.job_spec([binary], [binary]))
+      if os.path.isfile(binary):
+        out.append(config.job_spec([binary], [binary]))
+      else:
+        print "\nWARNING: binary not found, skipping", binary
     return sorted(out)
 
   def make_targets(self):
@@ -482,12 +485,6 @@ build_steps.extend(set(
                    for cfg in build_configs
                    for l in languages
                    for cmdline in l.build_steps()))
-one_run = set(
-    spec
-    for config in run_configs
-    for language in languages
-    for spec in language.test_specs(config, args.travis)
-    if re.search(args.regex, spec.shortname))
 
 runs_per_test = args.runs_per_test
 forever = args.forever
@@ -583,6 +580,12 @@ def _build_and_run(
   _start_port_server(port_server_port)
   try:
     infinite_runs = runs_per_test == 0
+    one_run = set(
+      spec
+      for config in run_configs
+      for language in languages
+      for spec in language.test_specs(config, args.travis)
+      if re.search(args.regex, spec.shortname))
     # When running on travis, we want out test runs to be as similar as possible
     # for reproducibility purposes.
     if travis:


### PR DESCRIPTION
Sample output:
```
PASSED: make [time=78.3sec]
WARNING: binary not found, skipping bins/opt/zookeeper_test
SUCCESS: All tests passed
```