### PR TITLE
Fix build breakage

### DIFF
--- a/src/core/surface/version.c
+++ b/src/core/surface/version.c
@@ -36,4 +36,6 @@
 
 #include <grpc/grpc.h>
 
-const char *grpc_version_string(void) { return "0.10.1.0"; }
+const char *grpc_version_string(void) {
+	return "0.10.1.0";
+}


### PR DESCRIPTION
This file should not have been clang-formatted.