### PR TITLE
Corrects logconfig from #2956

### DIFF
--- a/src/ruby/lib/grpc/logconfig.rb
+++ b/src/ruby/lib/grpc/logconfig.rb
@@ -54,5 +54,6 @@ module GRPC
     LOGGER = NoopLogger.new
   end
 
-  include DefaultLogger unless method_defined?(:logger)
+  # Inject the noop #logger if no module-level logger method has been injected.
+  extend DefaultLogger unless methods.include?(:logger)
 end


### PR DESCRIPTION
Corrects the way the default logger method is added, bugfix from #2956 