### PR TITLE
php: fix timeout interop test

### DIFF
--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -273,7 +273,6 @@ PHP_METHOD(Call, startBatch) {
   grpc_byte_buffer *message;
   int cancelled;
   grpc_call_error error;
-  grpc_event event;
   zval *result;
   char *message_str;
   size_t message_len;
@@ -409,14 +408,8 @@ PHP_METHOD(Call, startBatch) {
                          (long)error TSRMLS_CC);
     goto cleanup;
   }
-  event = grpc_completion_queue_pluck(completion_queue, call->wrapped,
-                                      gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
-  if (!event.success) {
-    zend_throw_exception(spl_ce_LogicException,
-                         "The batch failed for some reason",
-                         1 TSRMLS_CC);
-    goto cleanup;
-  }
+  grpc_completion_queue_pluck(completion_queue, call->wrapped,
+                              gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
   for (int i = 0; i < op_num; i++) {
     switch(ops[i].op) {
       case GRPC_OP_SEND_INITIAL_METADATA:

--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -271,7 +271,7 @@ function cancelAfterFirstResponse($stub) {
 }
 
 function timeoutOnSleepingServer($stub) {
-  $call = $stub->FullDuplexCall(array('timeout' => 500000));
+  $call = $stub->FullDuplexCall(array('timeout' => 1000));
   $request = new grpc\testing\StreamingOutputCallRequest();
   $request->setResponseType(grpc\testing\PayloadType::COMPRESSABLE);
   $response_parameters = new grpc\testing\ResponseParameters();


### PR DESCRIPTION
 * The PHP `timeout_on_sleeping_server` interop test (#2063) was incorrectly set to have a timeout of 500ms, should have used 1ms as how the interop test is defined
 * Upon investigation we found that `grpc_completion_queue_pluck` is taking a long time (~200ms) in the `startBatch` call with `GRPC_OP_SEND_INITIAL_METADATA`. Majority of the time might have been spent on negotiating ssl handshake.
 * One option we thought could work is to call `waitForReady()` on the stub to get that work out of the way before the test is run. But because of how codegen is set up, we don't have direct access to the `BaseStub` object for now.
 * Another option, as implemented here, is similar to how [Ruby](https://github.com/grpc/grpc/pull/2937/files#diff-f8508299e0f8e27560854477e0c06d3d) did it, which is to not throw an error when `!event.success`. Verified that the `$call->getStatus()->code` already properly contained the error code `Grpc\STATUS_DEADLINE_EXCEEDED`