### PR TITLE
Removed function introducing dependency on proto in .h

### DIFF
--- a/test/cpp/interop/client_helper.cc
+++ b/test/cpp/interop/client_helper.cc
@@ -65,8 +65,6 @@ DECLARE_string(default_service_account);
 DECLARE_string(service_account_key_file);
 DECLARE_string(oauth_scope);
 
-using grpc::testing::CompressionType;
-
 namespace grpc {
 namespace testing {
 
@@ -140,20 +138,6 @@ std::shared_ptr<ChannelInterface> CreateChannelForTestCase(
   } else {
     return CreateTestChannel(host_port, FLAGS_server_host_override,
                              FLAGS_enable_ssl, FLAGS_use_prod_roots);
-  }
-}
-
-CompressionType GetInteropCompressionTypeFromCompressionAlgorithm(
-    grpc_compression_algorithm algorithm) {
-  switch (algorithm) {
-    case GRPC_COMPRESS_NONE:
-      return CompressionType::NONE;
-    case GRPC_COMPRESS_GZIP:
-      return CompressionType::GZIP;
-    case GRPC_COMPRESS_DEFLATE:
-      return CompressionType::DEFLATE;
-    default:
-      GPR_ASSERT(false);
   }
 }
 

--- a/test/cpp/interop/client_helper.h
+++ b/test/cpp/interop/client_helper.h
@@ -39,8 +39,6 @@
 #include <grpc++/config.h>
 #include <grpc++/channel_interface.h>
 
-#include "test/proto/messages.grpc.pb.h"
-
 namespace grpc {
 namespace testing {
 
@@ -50,10 +48,6 @@ grpc::string GetOauth2AccessToken();
 
 std::shared_ptr<ChannelInterface> CreateChannelForTestCase(
     const grpc::string& test_case);
-
-grpc::testing::CompressionType
-GetInteropCompressionTypeFromCompressionAlgorithm(
-    grpc_compression_algorithm algorithm);
 
 class InteropClientContextInspector {
  public:

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -67,6 +67,20 @@ const int kResponseMessageSize = 1030;
 const int kReceiveDelayMilliSeconds = 20;
 const int kLargeRequestSize = 271828;
 const int kLargeResponseSize = 314159;
+
+CompressionType GetInteropCompressionTypeFromCompressionAlgorithm(
+    grpc_compression_algorithm algorithm) {
+  switch (algorithm) {
+    case GRPC_COMPRESS_NONE:
+      return CompressionType::NONE;
+    case GRPC_COMPRESS_GZIP:
+      return CompressionType::GZIP;
+    case GRPC_COMPRESS_DEFLATE:
+      return CompressionType::DEFLATE;
+    default:
+      GPR_ASSERT(false);
+  }
+}
 }  // namespace
 
 InteropClient::InteropClient(std::shared_ptr<ChannelInterface> channel)


### PR DESCRIPTION
Not a good idea to depend on a generated proto .h file in a .h... also unnecessary in this case.