### PR TITLE
Exclude qps_test from tsan runs

### DIFF
--- a/build.json
+++ b/build.json
@@ -2488,6 +2488,9 @@
         "gpr",
         "grpc++_test_config"
       ],
+      "exclude_configs": [
+        "tsan"
+      ],
       "platforms": [
         "mac",
         "linux",

--- a/templates/tools/run_tests/tests.json.template
+++ b/templates/tools/run_tests/tests.json.template
@@ -6,6 +6,7 @@ ${json.dumps([{"name": tgt.name,
                "language": tgt.language,
                "platforms": tgt.platforms,
                "ci_platforms": tgt.ci_platforms,
+	       "exclude_configs": tgt.get("exclude_configs", []),
                "flaky": tgt.flaky}
               for tgt in targets
               if tgt.get('run', True) and tgt.build == 'test'],

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -123,20 +123,19 @@ class CLanguage(object):
   def __init__(self, make_target, test_lang):
     self.make_target = make_target
     self.platform = platform_string()
-    with open('tools/run_tests/tests.json') as f:
-      js = json.load(f)
-      self.binaries = [tgt
-                       for tgt in js
-                       if tgt['language'] == test_lang and
-                          platform_string() in tgt['platforms']]
-      self.ci_binaries = [tgt
-                         for tgt in js
-                         if tgt['language'] == test_lang and
-                            platform_string() in tgt['ci_platforms']]
+    self.test_lang = test_lang
 
   def test_specs(self, config, travis):
     out = []
-    for target in (self.ci_binaries if travis else self.binaries):
+    with open('tools/run_tests/tests.json') as f:
+      js = json.load(f)
+      platforms_str = 'ci_platforms' if travis else 'platforms'
+      binaries = [tgt
+                  for tgt in js
+                  if tgt['language'] == self.test_lang and
+                      config.build_config not in tgt['exclude_configs'] and
+                      platform_string() in tgt[platforms_str]]
+    for target in binaries:
       if travis and target['flaky']:
         continue
       if self.platform == 'windows':

--- a/tools/run_tests/tests.json
+++ b/tools/run_tests/tests.json
@@ -8,6 +8,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "alarm_heap_test", 
@@ -25,6 +26,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "alarm_list_test", 
@@ -42,6 +44,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "alarm_test", 
@@ -59,6 +62,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "alpn_test", 
@@ -76,6 +80,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "bin_encoder_test", 
@@ -93,6 +98,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_status_conversion_test", 
@@ -110,6 +116,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_stream_encoder_test", 
@@ -127,6 +134,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_stream_map_test", 
@@ -144,6 +152,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "compression_test", 
@@ -160,6 +169,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "dualstack_socket_test", 
@@ -175,6 +185,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "fd_conservation_posix_test", 
@@ -190,6 +201,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "fd_posix_test", 
@@ -205,6 +217,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "fling_stream_test", 
@@ -220,6 +233,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "fling_test", 
@@ -236,6 +250,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_cmdline_test", 
@@ -253,6 +268,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_env_test", 
@@ -270,6 +286,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_file_test", 
@@ -287,6 +304,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_histogram_test", 
@@ -304,6 +322,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_host_port_test", 
@@ -321,6 +340,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_log_test", 
@@ -338,6 +358,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_slice_buffer_test", 
@@ -355,6 +376,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_slice_test", 
@@ -372,6 +394,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_stack_lockfree_test", 
@@ -389,6 +412,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_string_test", 
@@ -406,6 +430,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_sync_test", 
@@ -423,6 +448,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_thd_test", 
@@ -440,6 +466,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_time_test", 
@@ -457,6 +484,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_tls_test", 
@@ -474,6 +502,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "gpr_useful_test", 
@@ -491,6 +520,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "grpc_auth_context_test", 
@@ -508,6 +538,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "grpc_base64_test", 
@@ -525,6 +556,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "grpc_byte_buffer_reader_test", 
@@ -542,6 +574,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "grpc_channel_stack_test", 
@@ -559,6 +592,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "grpc_completion_queue_test", 
@@ -576,6 +610,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "grpc_credentials_test", 
@@ -593,6 +628,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "grpc_json_token_test", 
@@ -610,6 +646,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "grpc_jwt_verifier_test", 
@@ -627,6 +664,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "grpc_security_connector_test", 
@@ -644,6 +682,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "grpc_stream_op_test", 
@@ -661,6 +700,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "hpack_parser_test", 
@@ -678,6 +718,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "hpack_table_test", 
@@ -695,6 +736,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "httpcli_format_request_test", 
@@ -712,6 +754,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "httpcli_parser_test", 
@@ -728,6 +771,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "httpcli_test", 
@@ -744,6 +788,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "json_rewrite_test", 
@@ -761,6 +806,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "json_test", 
@@ -778,6 +824,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "lame_client_test", 
@@ -795,6 +842,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "message_compress_test", 
@@ -812,6 +860,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "multi_init_test", 
@@ -829,6 +878,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "multiple_server_queues_test", 
@@ -846,6 +896,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "murmur_hash_test", 
@@ -863,6 +914,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "no_server_test", 
@@ -880,6 +932,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "resolve_address_test", 
@@ -897,6 +950,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "secure_endpoint_test", 
@@ -914,6 +968,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "sockaddr_utils_test", 
@@ -930,6 +985,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "tcp_client_posix_test", 
@@ -945,6 +1001,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "tcp_posix_test", 
@@ -960,6 +1017,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "tcp_server_posix_test", 
@@ -976,6 +1034,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "time_averaged_stats_test", 
@@ -993,6 +1052,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "timeout_encoding_test", 
@@ -1010,6 +1070,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "timers_test", 
@@ -1027,6 +1088,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "transport_metadata_test", 
@@ -1044,6 +1106,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "transport_security_test", 
@@ -1058,6 +1121,7 @@
     "ci_platforms": [
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "udp_server_test", 
@@ -1072,6 +1136,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "uri_parser_test", 
@@ -1089,6 +1154,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "async_end2end_test", 
@@ -1105,6 +1171,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "async_streaming_ping_pong_test", 
@@ -1120,6 +1187,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "async_unary_ping_pong_test", 
@@ -1136,6 +1204,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "auth_property_iterator_test", 
@@ -1153,6 +1222,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "channel_arguments_test", 
@@ -1170,6 +1240,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "cli_call_test", 
@@ -1186,6 +1257,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "client_crash_test", 
@@ -1202,6 +1274,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "credentials_test", 
@@ -1219,6 +1292,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "cxx_byte_buffer_test", 
@@ -1236,6 +1310,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "cxx_slice_test", 
@@ -1253,6 +1328,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "cxx_time_test", 
@@ -1270,6 +1346,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "dynamic_thread_pool_test", 
@@ -1287,6 +1364,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "end2end_test", 
@@ -1304,6 +1382,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "fixed_size_thread_pool_test", 
@@ -1321,6 +1400,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "generic_end2end_test", 
@@ -1337,6 +1417,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "interop_test", 
@@ -1353,6 +1434,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "mock_test", 
@@ -1369,6 +1451,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "qps_openloop_test", 
@@ -1383,6 +1466,9 @@
       "linux", 
       "mac", 
       "posix"
+    ], 
+    "exclude_configs": [
+      "tsan"
     ], 
     "flaky": false, 
     "language": "c++", 
@@ -1400,6 +1486,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "secure_auth_context_test", 
@@ -1416,6 +1503,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "server_crash_test", 
@@ -1432,6 +1520,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "status_test", 
@@ -1448,6 +1537,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "sync_streaming_ping_pong_test", 
@@ -1463,6 +1553,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "sync_unary_ping_pong_test", 
@@ -1479,6 +1570,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "thread_stress_test", 
@@ -1496,6 +1588,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c++", 
     "name": "zookeeper_test", 
@@ -1512,6 +1605,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_bad_hostname_test", 
@@ -1528,6 +1622,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_cancel_after_accept_test", 
@@ -1544,6 +1639,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_cancel_after_accept_and_writes_closed_test", 
@@ -1560,6 +1656,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_cancel_after_invoke_test", 
@@ -1576,6 +1673,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_cancel_before_invoke_test", 
@@ -1592,6 +1690,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_cancel_in_a_vacuum_test", 
@@ -1608,6 +1707,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_census_simple_request_test", 
@@ -1624,6 +1724,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_channel_connectivity_test", 
@@ -1640,6 +1741,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_default_host_test", 
@@ -1656,6 +1758,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_disappearing_server_test", 
@@ -1672,6 +1775,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_early_server_shutdown_finishes_inflight_calls_test", 
@@ -1688,6 +1792,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_early_server_shutdown_finishes_tags_test", 
@@ -1704,6 +1809,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_empty_batch_test", 
@@ -1720,6 +1826,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_graceful_server_shutdown_test", 
@@ -1736,6 +1843,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_invoke_large_request_test", 
@@ -1752,6 +1860,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_max_concurrent_streams_test", 
@@ -1768,6 +1877,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_max_message_length_test", 
@@ -1784,6 +1894,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_no_op_test", 
@@ -1800,6 +1911,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_ping_pong_streaming_test", 
@@ -1816,6 +1928,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_registered_call_test", 
@@ -1832,6 +1945,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_request_response_with_binary_metadata_and_payload_test", 
@@ -1848,6 +1962,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_request_response_with_metadata_and_payload_test", 
@@ -1864,6 +1979,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_request_response_with_payload_test", 
@@ -1880,6 +1996,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_request_response_with_payload_and_call_creds_test", 
@@ -1896,6 +2013,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_request_response_with_trailing_metadata_and_payload_test", 
@@ -1912,6 +2030,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_request_with_compressed_payload_test", 
@@ -1928,6 +2047,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_request_with_flags_test", 
@@ -1944,6 +2064,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_request_with_large_metadata_test", 
@@ -1960,6 +2081,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_request_with_payload_test", 
@@ -1976,6 +2098,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_server_finishes_request_test", 
@@ -1992,6 +2115,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_simple_delayed_request_test", 
@@ -2008,6 +2132,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_simple_request_test", 
@@ -2024,6 +2149,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fake_security_simple_request_with_high_initial_sequence_number_test", 
@@ -2041,6 +2167,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_bad_hostname_test", 
@@ -2058,6 +2185,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_cancel_after_accept_test", 
@@ -2075,6 +2203,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_cancel_after_accept_and_writes_closed_test", 
@@ -2092,6 +2221,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_cancel_after_invoke_test", 
@@ -2109,6 +2239,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_cancel_before_invoke_test", 
@@ -2126,6 +2257,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_cancel_in_a_vacuum_test", 
@@ -2143,6 +2275,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_census_simple_request_test", 
@@ -2160,6 +2293,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_channel_connectivity_test", 
@@ -2177,6 +2311,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_default_host_test", 
@@ -2194,6 +2329,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_disappearing_server_test", 
@@ -2211,6 +2347,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_early_server_shutdown_finishes_inflight_calls_test", 
@@ -2228,6 +2365,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_early_server_shutdown_finishes_tags_test", 
@@ -2245,6 +2383,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_empty_batch_test", 
@@ -2262,6 +2401,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_graceful_server_shutdown_test", 
@@ -2279,6 +2419,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_invoke_large_request_test", 
@@ -2296,6 +2437,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_max_concurrent_streams_test", 
@@ -2313,6 +2455,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_max_message_length_test", 
@@ -2330,6 +2473,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_no_op_test", 
@@ -2347,6 +2491,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_ping_pong_streaming_test", 
@@ -2364,6 +2509,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_registered_call_test", 
@@ -2381,6 +2527,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_response_with_binary_metadata_and_payload_test", 
@@ -2398,6 +2545,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_response_with_metadata_and_payload_test", 
@@ -2415,6 +2563,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_response_with_payload_test", 
@@ -2432,6 +2581,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_response_with_payload_and_call_creds_test", 
@@ -2449,6 +2599,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_response_with_trailing_metadata_and_payload_test", 
@@ -2466,6 +2617,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_with_compressed_payload_test", 
@@ -2483,6 +2635,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_with_flags_test", 
@@ -2500,6 +2653,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_with_large_metadata_test", 
@@ -2517,6 +2671,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_with_payload_test", 
@@ -2534,6 +2689,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_server_finishes_request_test", 
@@ -2551,6 +2707,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_simple_delayed_request_test", 
@@ -2568,6 +2725,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_simple_request_test", 
@@ -2585,6 +2743,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_simple_request_with_high_initial_sequence_number_test", 
@@ -2602,6 +2761,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_bad_hostname_test", 
@@ -2619,6 +2779,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_cancel_after_accept_test", 
@@ -2636,6 +2797,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_cancel_after_accept_and_writes_closed_test", 
@@ -2653,6 +2815,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_cancel_after_invoke_test", 
@@ -2670,6 +2833,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_cancel_before_invoke_test", 
@@ -2687,6 +2851,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_cancel_in_a_vacuum_test", 
@@ -2704,6 +2869,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_census_simple_request_test", 
@@ -2721,6 +2887,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_channel_connectivity_test", 
@@ -2738,6 +2905,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_default_host_test", 
@@ -2755,6 +2923,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_disappearing_server_test", 
@@ -2772,6 +2941,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_early_server_shutdown_finishes_inflight_calls_test", 
@@ -2789,6 +2959,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_early_server_shutdown_finishes_tags_test", 
@@ -2806,6 +2977,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_empty_batch_test", 
@@ -2823,6 +2995,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_graceful_server_shutdown_test", 
@@ -2840,6 +3013,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_invoke_large_request_test", 
@@ -2857,6 +3031,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_max_concurrent_streams_test", 
@@ -2874,6 +3049,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_max_message_length_test", 
@@ -2891,6 +3067,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_no_op_test", 
@@ -2908,6 +3085,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_ping_pong_streaming_test", 
@@ -2925,6 +3103,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_registered_call_test", 
@@ -2942,6 +3121,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_response_with_binary_metadata_and_payload_test", 
@@ -2959,6 +3139,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_response_with_metadata_and_payload_test", 
@@ -2976,6 +3157,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_response_with_payload_test", 
@@ -2993,6 +3175,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_response_with_payload_and_call_creds_test", 
@@ -3010,6 +3193,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_response_with_trailing_metadata_and_payload_test", 
@@ -3027,6 +3211,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_with_compressed_payload_test", 
@@ -3044,6 +3229,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_with_flags_test", 
@@ -3061,6 +3247,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_with_large_metadata_test", 
@@ -3078,6 +3265,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_with_payload_test", 
@@ -3095,6 +3283,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_server_finishes_request_test", 
@@ -3112,6 +3301,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_simple_delayed_request_test", 
@@ -3129,6 +3319,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_simple_request_test", 
@@ -3146,6 +3337,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_simple_request_with_high_initial_sequence_number_test", 
@@ -3162,6 +3354,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_bad_hostname_test", 
@@ -3177,6 +3370,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_cancel_after_accept_test", 
@@ -3192,6 +3386,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_cancel_after_accept_and_writes_closed_test", 
@@ -3207,6 +3402,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_cancel_after_invoke_test", 
@@ -3222,6 +3418,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_cancel_before_invoke_test", 
@@ -3237,6 +3434,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_cancel_in_a_vacuum_test", 
@@ -3252,6 +3450,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_census_simple_request_test", 
@@ -3267,6 +3466,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_channel_connectivity_test", 
@@ -3282,6 +3482,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_disappearing_server_test", 
@@ -3297,6 +3498,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_early_server_shutdown_finishes_inflight_calls_test", 
@@ -3312,6 +3514,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_early_server_shutdown_finishes_tags_test", 
@@ -3327,6 +3530,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_empty_batch_test", 
@@ -3342,6 +3546,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_graceful_server_shutdown_test", 
@@ -3357,6 +3562,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_invoke_large_request_test", 
@@ -3372,6 +3578,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_max_concurrent_streams_test", 
@@ -3387,6 +3594,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_max_message_length_test", 
@@ -3402,6 +3610,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_no_op_test", 
@@ -3417,6 +3626,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_ping_pong_streaming_test", 
@@ -3432,6 +3642,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_registered_call_test", 
@@ -3447,6 +3658,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_response_with_binary_metadata_and_payload_test", 
@@ -3462,6 +3674,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_response_with_metadata_and_payload_test", 
@@ -3477,6 +3690,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_response_with_payload_test", 
@@ -3492,6 +3706,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_response_with_payload_and_call_creds_test", 
@@ -3507,6 +3722,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_response_with_trailing_metadata_and_payload_test", 
@@ -3522,6 +3738,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_with_compressed_payload_test", 
@@ -3537,6 +3754,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_with_flags_test", 
@@ -3552,6 +3770,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_with_large_metadata_test", 
@@ -3567,6 +3786,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_with_payload_test", 
@@ -3582,6 +3802,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_server_finishes_request_test", 
@@ -3597,6 +3818,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_simple_delayed_request_test", 
@@ -3612,6 +3834,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_simple_request_test", 
@@ -3627,6 +3850,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_simple_request_with_high_initial_sequence_number_test", 
@@ -3640,6 +3864,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_bad_hostname_test", 
@@ -3651,6 +3876,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_cancel_after_accept_test", 
@@ -3662,6 +3888,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_cancel_after_accept_and_writes_closed_test", 
@@ -3673,6 +3900,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_cancel_after_invoke_test", 
@@ -3684,6 +3912,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_cancel_before_invoke_test", 
@@ -3695,6 +3924,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_cancel_in_a_vacuum_test", 
@@ -3706,6 +3936,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_census_simple_request_test", 
@@ -3717,6 +3948,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_channel_connectivity_test", 
@@ -3728,6 +3960,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_disappearing_server_test", 
@@ -3739,6 +3972,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_early_server_shutdown_finishes_inflight_calls_test", 
@@ -3750,6 +3984,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_early_server_shutdown_finishes_tags_test", 
@@ -3761,6 +3996,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_empty_batch_test", 
@@ -3772,6 +4008,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_graceful_server_shutdown_test", 
@@ -3783,6 +4020,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_invoke_large_request_test", 
@@ -3794,6 +4032,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_max_concurrent_streams_test", 
@@ -3805,6 +4044,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_max_message_length_test", 
@@ -3816,6 +4056,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_no_op_test", 
@@ -3827,6 +4068,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_ping_pong_streaming_test", 
@@ -3838,6 +4080,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_registered_call_test", 
@@ -3849,6 +4092,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_response_with_binary_metadata_and_payload_test", 
@@ -3860,6 +4104,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_response_with_metadata_and_payload_test", 
@@ -3871,6 +4116,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_response_with_payload_test", 
@@ -3882,6 +4128,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_response_with_payload_and_call_creds_test", 
@@ -3893,6 +4140,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_response_with_trailing_metadata_and_payload_test", 
@@ -3904,6 +4152,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_with_compressed_payload_test", 
@@ -3915,6 +4164,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_with_flags_test", 
@@ -3926,6 +4176,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_with_large_metadata_test", 
@@ -3937,6 +4188,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_with_payload_test", 
@@ -3948,6 +4200,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_server_finishes_request_test", 
@@ -3959,6 +4212,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_simple_delayed_request_test", 
@@ -3970,6 +4224,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_simple_request_test", 
@@ -3981,6 +4236,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_simple_request_with_high_initial_sequence_number_test", 
@@ -3992,6 +4248,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_bad_hostname_test", 
@@ -4003,6 +4260,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_cancel_after_accept_test", 
@@ -4014,6 +4272,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_cancel_after_accept_and_writes_closed_test", 
@@ -4025,6 +4284,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_cancel_after_invoke_test", 
@@ -4036,6 +4296,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_cancel_before_invoke_test", 
@@ -4047,6 +4308,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_cancel_in_a_vacuum_test", 
@@ -4058,6 +4320,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_census_simple_request_test", 
@@ -4069,6 +4332,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_channel_connectivity_test", 
@@ -4080,6 +4344,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_default_host_test", 
@@ -4091,6 +4356,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_disappearing_server_test", 
@@ -4102,6 +4368,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_early_server_shutdown_finishes_inflight_calls_test", 
@@ -4113,6 +4380,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_early_server_shutdown_finishes_tags_test", 
@@ -4124,6 +4392,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_empty_batch_test", 
@@ -4135,6 +4404,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_graceful_server_shutdown_test", 
@@ -4146,6 +4416,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_invoke_large_request_test", 
@@ -4157,6 +4428,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_max_concurrent_streams_test", 
@@ -4168,6 +4440,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_max_message_length_test", 
@@ -4179,6 +4452,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_no_op_test", 
@@ -4190,6 +4464,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_ping_pong_streaming_test", 
@@ -4201,6 +4476,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_registered_call_test", 
@@ -4212,6 +4488,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_response_with_binary_metadata_and_payload_test", 
@@ -4223,6 +4500,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_response_with_metadata_and_payload_test", 
@@ -4234,6 +4512,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_response_with_payload_test", 
@@ -4245,6 +4524,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_response_with_payload_and_call_creds_test", 
@@ -4256,6 +4536,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_response_with_trailing_metadata_and_payload_test", 
@@ -4267,6 +4548,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_with_compressed_payload_test", 
@@ -4278,6 +4560,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_with_flags_test", 
@@ -4289,6 +4572,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_with_large_metadata_test", 
@@ -4300,6 +4584,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_with_payload_test", 
@@ -4311,6 +4596,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_server_finishes_request_test", 
@@ -4322,6 +4608,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_simple_delayed_request_test", 
@@ -4333,6 +4620,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_simple_request_test", 
@@ -4344,6 +4632,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_simple_request_with_high_initial_sequence_number_test", 
@@ -4357,6 +4646,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_bad_hostname_test", 
@@ -4373,6 +4663,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_cancel_after_accept_test", 
@@ -4389,6 +4680,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_cancel_after_accept_and_writes_closed_test", 
@@ -4405,6 +4697,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_cancel_after_invoke_test", 
@@ -4421,6 +4714,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_cancel_before_invoke_test", 
@@ -4437,6 +4731,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_cancel_in_a_vacuum_test", 
@@ -4453,6 +4748,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_census_simple_request_test", 
@@ -4469,6 +4765,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_default_host_test", 
@@ -4485,6 +4782,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_disappearing_server_test", 
@@ -4501,6 +4799,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_early_server_shutdown_finishes_inflight_calls_test", 
@@ -4517,6 +4816,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_early_server_shutdown_finishes_tags_test", 
@@ -4533,6 +4833,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_empty_batch_test", 
@@ -4549,6 +4850,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_graceful_server_shutdown_test", 
@@ -4565,6 +4867,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_invoke_large_request_test", 
@@ -4581,6 +4884,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_max_message_length_test", 
@@ -4597,6 +4901,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_no_op_test", 
@@ -4613,6 +4918,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_ping_pong_streaming_test", 
@@ -4629,6 +4935,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_registered_call_test", 
@@ -4645,6 +4952,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_request_response_with_binary_metadata_and_payload_test", 
@@ -4661,6 +4969,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_request_response_with_metadata_and_payload_test", 
@@ -4677,6 +4986,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_request_response_with_payload_test", 
@@ -4693,6 +5003,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_request_response_with_payload_and_call_creds_test", 
@@ -4709,6 +5020,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_request_response_with_trailing_metadata_and_payload_test", 
@@ -4725,6 +5037,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_request_with_large_metadata_test", 
@@ -4741,6 +5054,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_request_with_payload_test", 
@@ -4757,6 +5071,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_server_finishes_request_test", 
@@ -4773,6 +5088,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_simple_delayed_request_test", 
@@ -4789,6 +5105,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_simple_request_test", 
@@ -4805,6 +5122,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_simple_request_with_high_initial_sequence_number_test", 
@@ -4822,6 +5140,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_bad_hostname_test", 
@@ -4839,6 +5158,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_cancel_after_accept_test", 
@@ -4856,6 +5176,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_cancel_after_accept_and_writes_closed_test", 
@@ -4873,6 +5194,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_cancel_after_invoke_test", 
@@ -4890,6 +5212,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_cancel_before_invoke_test", 
@@ -4907,6 +5230,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_cancel_in_a_vacuum_test", 
@@ -4924,6 +5248,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_census_simple_request_test", 
@@ -4941,6 +5266,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_channel_connectivity_test", 
@@ -4958,6 +5284,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_default_host_test", 
@@ -4975,6 +5302,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_disappearing_server_test", 
@@ -4992,6 +5320,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_early_server_shutdown_finishes_inflight_calls_test", 
@@ -5009,6 +5338,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_early_server_shutdown_finishes_tags_test", 
@@ -5026,6 +5356,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_empty_batch_test", 
@@ -5043,6 +5374,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_graceful_server_shutdown_test", 
@@ -5060,6 +5392,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_invoke_large_request_test", 
@@ -5077,6 +5410,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_max_concurrent_streams_test", 
@@ -5094,6 +5428,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_max_message_length_test", 
@@ -5111,6 +5446,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_no_op_test", 
@@ -5128,6 +5464,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_ping_pong_streaming_test", 
@@ -5145,6 +5482,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_registered_call_test", 
@@ -5162,6 +5500,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_request_response_with_binary_metadata_and_payload_test", 
@@ -5179,6 +5518,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_request_response_with_metadata_and_payload_test", 
@@ -5196,6 +5536,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_request_response_with_payload_test", 
@@ -5213,6 +5554,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_request_response_with_payload_and_call_creds_test", 
@@ -5230,6 +5572,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_request_response_with_trailing_metadata_and_payload_test", 
@@ -5247,6 +5590,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_request_with_compressed_payload_test", 
@@ -5264,6 +5608,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_request_with_flags_test", 
@@ -5281,6 +5626,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_request_with_large_metadata_test", 
@@ -5298,6 +5644,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_request_with_payload_test", 
@@ -5315,6 +5662,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_server_finishes_request_test", 
@@ -5332,6 +5680,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_simple_delayed_request_test", 
@@ -5349,6 +5698,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_simple_request_test", 
@@ -5366,6 +5716,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_simple_request_with_high_initial_sequence_number_test", 
@@ -5380,6 +5731,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_bad_hostname_test", 
@@ -5391,6 +5743,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_cancel_after_accept_test", 
@@ -5402,6 +5755,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_cancel_after_accept_and_writes_closed_test", 
@@ -5413,6 +5767,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_cancel_after_invoke_test", 
@@ -5424,6 +5779,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_cancel_before_invoke_test", 
@@ -5435,6 +5791,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_cancel_in_a_vacuum_test", 
@@ -5446,6 +5803,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_census_simple_request_test", 
@@ -5457,6 +5815,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_channel_connectivity_test", 
@@ -5468,6 +5827,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_default_host_test", 
@@ -5479,6 +5839,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_disappearing_server_test", 
@@ -5490,6 +5851,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_early_server_shutdown_finishes_inflight_calls_test", 
@@ -5501,6 +5863,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_early_server_shutdown_finishes_tags_test", 
@@ -5512,6 +5875,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_empty_batch_test", 
@@ -5523,6 +5887,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_graceful_server_shutdown_test", 
@@ -5534,6 +5899,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_invoke_large_request_test", 
@@ -5545,6 +5911,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_max_concurrent_streams_test", 
@@ -5556,6 +5923,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_max_message_length_test", 
@@ -5567,6 +5935,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_no_op_test", 
@@ -5578,6 +5947,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_ping_pong_streaming_test", 
@@ -5589,6 +5959,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_registered_call_test", 
@@ -5600,6 +5971,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_request_response_with_binary_metadata_and_payload_test", 
@@ -5611,6 +5983,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_request_response_with_metadata_and_payload_test", 
@@ -5622,6 +5995,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_request_response_with_payload_test", 
@@ -5633,6 +6007,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_request_response_with_payload_and_call_creds_test", 
@@ -5644,6 +6019,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_request_response_with_trailing_metadata_and_payload_test", 
@@ -5655,6 +6031,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_request_with_compressed_payload_test", 
@@ -5666,6 +6043,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_request_with_flags_test", 
@@ -5677,6 +6055,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_request_with_large_metadata_test", 
@@ -5688,6 +6067,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_request_with_payload_test", 
@@ -5699,6 +6079,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_server_finishes_request_test", 
@@ -5710,6 +6091,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_simple_delayed_request_test", 
@@ -5721,6 +6103,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_simple_request_test", 
@@ -5732,6 +6115,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_poll_simple_request_with_high_initial_sequence_number_test", 
@@ -5745,6 +6129,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_bad_hostname_test", 
@@ -5761,6 +6146,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_cancel_after_accept_test", 
@@ -5777,6 +6163,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_cancel_after_accept_and_writes_closed_test", 
@@ -5793,6 +6180,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_cancel_after_invoke_test", 
@@ -5809,6 +6197,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_cancel_before_invoke_test", 
@@ -5825,6 +6214,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_cancel_in_a_vacuum_test", 
@@ -5841,6 +6231,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_census_simple_request_test", 
@@ -5857,6 +6248,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_default_host_test", 
@@ -5873,6 +6265,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_disappearing_server_test", 
@@ -5889,6 +6282,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_early_server_shutdown_finishes_inflight_calls_test", 
@@ -5905,6 +6299,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_early_server_shutdown_finishes_tags_test", 
@@ -5921,6 +6316,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_empty_batch_test", 
@@ -5937,6 +6333,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_graceful_server_shutdown_test", 
@@ -5953,6 +6350,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_invoke_large_request_test", 
@@ -5969,6 +6367,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_max_message_length_test", 
@@ -5985,6 +6384,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_no_op_test", 
@@ -6001,6 +6401,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_ping_pong_streaming_test", 
@@ -6017,6 +6418,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_registered_call_test", 
@@ -6033,6 +6435,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_request_response_with_binary_metadata_and_payload_test", 
@@ -6049,6 +6452,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_request_response_with_metadata_and_payload_test", 
@@ -6065,6 +6469,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_request_response_with_payload_test", 
@@ -6081,6 +6486,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_request_response_with_payload_and_call_creds_test", 
@@ -6097,6 +6503,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_request_response_with_trailing_metadata_and_payload_test", 
@@ -6113,6 +6520,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_request_with_large_metadata_test", 
@@ -6129,6 +6537,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_request_with_payload_test", 
@@ -6145,6 +6554,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_server_finishes_request_test", 
@@ -6161,6 +6571,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_simple_delayed_request_test", 
@@ -6177,6 +6588,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_simple_request_test", 
@@ -6193,6 +6605,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_fullstack_with_proxy_simple_request_with_high_initial_sequence_number_test", 
@@ -6209,6 +6622,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_bad_hostname_test", 
@@ -6225,6 +6639,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_cancel_after_accept_test", 
@@ -6241,6 +6656,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_cancel_after_accept_and_writes_closed_test", 
@@ -6257,6 +6673,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_cancel_after_invoke_test", 
@@ -6273,6 +6690,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_cancel_before_invoke_test", 
@@ -6289,6 +6707,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_cancel_in_a_vacuum_test", 
@@ -6305,6 +6724,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_census_simple_request_test", 
@@ -6321,6 +6741,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_channel_connectivity_test", 
@@ -6337,6 +6758,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_default_host_test", 
@@ -6353,6 +6775,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_disappearing_server_test", 
@@ -6369,6 +6792,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_early_server_shutdown_finishes_inflight_calls_test", 
@@ -6385,6 +6809,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_early_server_shutdown_finishes_tags_test", 
@@ -6401,6 +6826,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_empty_batch_test", 
@@ -6417,6 +6843,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_graceful_server_shutdown_test", 
@@ -6433,6 +6860,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_invoke_large_request_test", 
@@ -6449,6 +6877,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_max_concurrent_streams_test", 
@@ -6465,6 +6894,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_max_message_length_test", 
@@ -6481,6 +6911,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_no_op_test", 
@@ -6497,6 +6928,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_ping_pong_streaming_test", 
@@ -6513,6 +6945,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_registered_call_test", 
@@ -6529,6 +6962,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_request_response_with_binary_metadata_and_payload_test", 
@@ -6545,6 +6979,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_request_response_with_metadata_and_payload_test", 
@@ -6561,6 +6996,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_request_response_with_payload_test", 
@@ -6577,6 +7013,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_request_response_with_payload_and_call_creds_test", 
@@ -6593,6 +7030,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_request_response_with_trailing_metadata_and_payload_test", 
@@ -6609,6 +7047,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_request_with_compressed_payload_test", 
@@ -6625,6 +7064,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_request_with_flags_test", 
@@ -6641,6 +7081,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_request_with_large_metadata_test", 
@@ -6657,6 +7098,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_request_with_payload_test", 
@@ -6673,6 +7115,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_server_finishes_request_test", 
@@ -6689,6 +7132,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_simple_delayed_request_test", 
@@ -6705,6 +7149,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_simple_request_test", 
@@ -6721,6 +7166,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_simple_ssl_with_oauth2_fullstack_simple_request_with_high_initial_sequence_number_test", 
@@ -6737,6 +7183,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_bad_hostname_test", 
@@ -6753,6 +7200,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_cancel_after_accept_test", 
@@ -6769,6 +7217,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_cancel_after_accept_and_writes_closed_test", 
@@ -6785,6 +7234,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_cancel_after_invoke_test", 
@@ -6801,6 +7251,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_cancel_before_invoke_test", 
@@ -6817,6 +7268,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_cancel_in_a_vacuum_test", 
@@ -6833,6 +7285,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_census_simple_request_test", 
@@ -6849,6 +7302,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_early_server_shutdown_finishes_inflight_calls_test", 
@@ -6865,6 +7319,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_early_server_shutdown_finishes_tags_test", 
@@ -6881,6 +7336,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_empty_batch_test", 
@@ -6897,6 +7353,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_graceful_server_shutdown_test", 
@@ -6913,6 +7370,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_invoke_large_request_test", 
@@ -6929,6 +7387,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_max_concurrent_streams_test", 
@@ -6945,6 +7404,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_max_message_length_test", 
@@ -6961,6 +7421,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_no_op_test", 
@@ -6977,6 +7438,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_ping_pong_streaming_test", 
@@ -6993,6 +7455,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_registered_call_test", 
@@ -7009,6 +7472,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_response_with_binary_metadata_and_payload_test", 
@@ -7025,6 +7489,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_response_with_metadata_and_payload_test", 
@@ -7041,6 +7506,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_response_with_payload_test", 
@@ -7057,6 +7523,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_response_with_payload_and_call_creds_test", 
@@ -7073,6 +7540,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_response_with_trailing_metadata_and_payload_test", 
@@ -7089,6 +7557,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_with_compressed_payload_test", 
@@ -7105,6 +7574,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_with_flags_test", 
@@ -7121,6 +7591,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_with_large_metadata_test", 
@@ -7137,6 +7608,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_with_payload_test", 
@@ -7153,6 +7625,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_server_finishes_request_test", 
@@ -7169,6 +7642,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_simple_request_test", 
@@ -7185,6 +7659,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_simple_request_with_high_initial_sequence_number_test", 
@@ -7201,6 +7676,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_bad_hostname_test", 
@@ -7217,6 +7693,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_cancel_after_accept_test", 
@@ -7233,6 +7710,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_cancel_after_accept_and_writes_closed_test", 
@@ -7249,6 +7727,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_cancel_after_invoke_test", 
@@ -7265,6 +7744,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_cancel_before_invoke_test", 
@@ -7281,6 +7761,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_cancel_in_a_vacuum_test", 
@@ -7297,6 +7778,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_census_simple_request_test", 
@@ -7313,6 +7795,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_early_server_shutdown_finishes_inflight_calls_test", 
@@ -7329,6 +7812,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_early_server_shutdown_finishes_tags_test", 
@@ -7345,6 +7829,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_empty_batch_test", 
@@ -7361,6 +7846,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_graceful_server_shutdown_test", 
@@ -7377,6 +7863,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_invoke_large_request_test", 
@@ -7393,6 +7880,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_max_concurrent_streams_test", 
@@ -7409,6 +7897,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_max_message_length_test", 
@@ -7425,6 +7914,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_no_op_test", 
@@ -7441,6 +7931,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_ping_pong_streaming_test", 
@@ -7457,6 +7948,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_registered_call_test", 
@@ -7473,6 +7965,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_response_with_binary_metadata_and_payload_test", 
@@ -7489,6 +7982,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_response_with_metadata_and_payload_test", 
@@ -7505,6 +7999,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_response_with_payload_test", 
@@ -7521,6 +8016,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_response_with_payload_and_call_creds_test", 
@@ -7537,6 +8033,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_response_with_trailing_metadata_and_payload_test", 
@@ -7553,6 +8050,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_with_compressed_payload_test", 
@@ -7569,6 +8067,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_with_flags_test", 
@@ -7585,6 +8084,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_with_large_metadata_test", 
@@ -7601,6 +8101,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_with_payload_test", 
@@ -7617,6 +8118,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_server_finishes_request_test", 
@@ -7633,6 +8135,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_simple_request_test", 
@@ -7649,6 +8152,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_simple_request_with_high_initial_sequence_number_test", 
@@ -7666,6 +8170,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_bad_hostname_test", 
@@ -7683,6 +8188,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_cancel_after_accept_test", 
@@ -7700,6 +8206,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_cancel_after_accept_and_writes_closed_test", 
@@ -7717,6 +8224,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_cancel_after_invoke_test", 
@@ -7734,6 +8242,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_cancel_before_invoke_test", 
@@ -7751,6 +8260,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_cancel_in_a_vacuum_test", 
@@ -7768,6 +8278,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_census_simple_request_test", 
@@ -7785,6 +8296,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_early_server_shutdown_finishes_inflight_calls_test", 
@@ -7802,6 +8314,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_early_server_shutdown_finishes_tags_test", 
@@ -7819,6 +8332,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_empty_batch_test", 
@@ -7836,6 +8350,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_graceful_server_shutdown_test", 
@@ -7853,6 +8368,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_invoke_large_request_test", 
@@ -7870,6 +8386,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_max_concurrent_streams_test", 
@@ -7887,6 +8404,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_max_message_length_test", 
@@ -7904,6 +8422,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_no_op_test", 
@@ -7921,6 +8440,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_ping_pong_streaming_test", 
@@ -7938,6 +8458,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_registered_call_test", 
@@ -7955,6 +8476,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_response_with_binary_metadata_and_payload_test", 
@@ -7972,6 +8494,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_response_with_metadata_and_payload_test", 
@@ -7989,6 +8512,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_response_with_payload_test", 
@@ -8006,6 +8530,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_response_with_payload_and_call_creds_test", 
@@ -8023,6 +8548,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_response_with_trailing_metadata_and_payload_test", 
@@ -8040,6 +8566,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_with_compressed_payload_test", 
@@ -8057,6 +8584,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_with_flags_test", 
@@ -8074,6 +8602,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_with_large_metadata_test", 
@@ -8091,6 +8620,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_with_payload_test", 
@@ -8108,6 +8638,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_server_finishes_request_test", 
@@ -8125,6 +8656,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_simple_request_test", 
@@ -8142,6 +8674,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_simple_request_with_high_initial_sequence_number_test", 
@@ -8159,6 +8692,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_bad_hostname_unsecure_test", 
@@ -8176,6 +8710,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_cancel_after_accept_unsecure_test", 
@@ -8193,6 +8728,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_cancel_after_accept_and_writes_closed_unsecure_test", 
@@ -8210,6 +8746,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_cancel_after_invoke_unsecure_test", 
@@ -8227,6 +8764,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_cancel_before_invoke_unsecure_test", 
@@ -8244,6 +8782,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_cancel_in_a_vacuum_unsecure_test", 
@@ -8261,6 +8800,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_census_simple_request_unsecure_test", 
@@ -8278,6 +8818,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_channel_connectivity_unsecure_test", 
@@ -8295,6 +8836,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_default_host_unsecure_test", 
@@ -8312,6 +8854,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_disappearing_server_unsecure_test", 
@@ -8329,6 +8872,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_early_server_shutdown_finishes_inflight_calls_unsecure_test", 
@@ -8346,6 +8890,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_early_server_shutdown_finishes_tags_unsecure_test", 
@@ -8363,6 +8908,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_empty_batch_unsecure_test", 
@@ -8380,6 +8926,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_graceful_server_shutdown_unsecure_test", 
@@ -8397,6 +8944,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_invoke_large_request_unsecure_test", 
@@ -8414,6 +8962,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_max_concurrent_streams_unsecure_test", 
@@ -8431,6 +8980,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_max_message_length_unsecure_test", 
@@ -8448,6 +8998,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_no_op_unsecure_test", 
@@ -8465,6 +9016,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_ping_pong_streaming_unsecure_test", 
@@ -8482,6 +9034,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_registered_call_unsecure_test", 
@@ -8499,6 +9052,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_response_with_binary_metadata_and_payload_unsecure_test", 
@@ -8516,6 +9070,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_response_with_metadata_and_payload_unsecure_test", 
@@ -8533,6 +9088,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_response_with_payload_unsecure_test", 
@@ -8550,6 +9106,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_response_with_trailing_metadata_and_payload_unsecure_test", 
@@ -8567,6 +9124,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_with_compressed_payload_unsecure_test", 
@@ -8584,6 +9142,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_with_flags_unsecure_test", 
@@ -8601,6 +9160,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_with_large_metadata_unsecure_test", 
@@ -8618,6 +9178,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_request_with_payload_unsecure_test", 
@@ -8635,6 +9196,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_server_finishes_request_unsecure_test", 
@@ -8652,6 +9214,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_simple_delayed_request_unsecure_test", 
@@ -8669,6 +9232,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_simple_request_unsecure_test", 
@@ -8686,6 +9250,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_simple_request_with_high_initial_sequence_number_unsecure_test", 
@@ -8703,6 +9268,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_bad_hostname_unsecure_test", 
@@ -8720,6 +9286,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_cancel_after_accept_unsecure_test", 
@@ -8737,6 +9304,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_cancel_after_accept_and_writes_closed_unsecure_test", 
@@ -8754,6 +9322,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_cancel_after_invoke_unsecure_test", 
@@ -8771,6 +9340,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_cancel_before_invoke_unsecure_test", 
@@ -8788,6 +9358,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_cancel_in_a_vacuum_unsecure_test", 
@@ -8805,6 +9376,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_census_simple_request_unsecure_test", 
@@ -8822,6 +9394,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_channel_connectivity_unsecure_test", 
@@ -8839,6 +9412,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_default_host_unsecure_test", 
@@ -8856,6 +9430,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_disappearing_server_unsecure_test", 
@@ -8873,6 +9448,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_early_server_shutdown_finishes_inflight_calls_unsecure_test", 
@@ -8890,6 +9466,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_early_server_shutdown_finishes_tags_unsecure_test", 
@@ -8907,6 +9484,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_empty_batch_unsecure_test", 
@@ -8924,6 +9502,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_graceful_server_shutdown_unsecure_test", 
@@ -8941,6 +9520,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_invoke_large_request_unsecure_test", 
@@ -8958,6 +9538,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_max_concurrent_streams_unsecure_test", 
@@ -8975,6 +9556,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_max_message_length_unsecure_test", 
@@ -8992,6 +9574,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_no_op_unsecure_test", 
@@ -9009,6 +9592,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_ping_pong_streaming_unsecure_test", 
@@ -9026,6 +9610,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_registered_call_unsecure_test", 
@@ -9043,6 +9628,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_response_with_binary_metadata_and_payload_unsecure_test", 
@@ -9060,6 +9646,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_response_with_metadata_and_payload_unsecure_test", 
@@ -9077,6 +9664,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_response_with_payload_unsecure_test", 
@@ -9094,6 +9682,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_response_with_trailing_metadata_and_payload_unsecure_test", 
@@ -9111,6 +9700,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_with_compressed_payload_unsecure_test", 
@@ -9128,6 +9718,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_with_flags_unsecure_test", 
@@ -9145,6 +9736,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_with_large_metadata_unsecure_test", 
@@ -9162,6 +9754,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_request_with_payload_unsecure_test", 
@@ -9179,6 +9772,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_server_finishes_request_unsecure_test", 
@@ -9196,6 +9790,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_simple_delayed_request_unsecure_test", 
@@ -9213,6 +9808,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_simple_request_unsecure_test", 
@@ -9230,6 +9826,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_compression_simple_request_with_high_initial_sequence_number_unsecure_test", 
@@ -9246,6 +9843,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_bad_hostname_unsecure_test", 
@@ -9261,6 +9859,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_cancel_after_accept_unsecure_test", 
@@ -9276,6 +9875,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_cancel_after_accept_and_writes_closed_unsecure_test", 
@@ -9291,6 +9891,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_cancel_after_invoke_unsecure_test", 
@@ -9306,6 +9907,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_cancel_before_invoke_unsecure_test", 
@@ -9321,6 +9923,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_cancel_in_a_vacuum_unsecure_test", 
@@ -9336,6 +9939,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_census_simple_request_unsecure_test", 
@@ -9351,6 +9955,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_channel_connectivity_unsecure_test", 
@@ -9366,6 +9971,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_disappearing_server_unsecure_test", 
@@ -9381,6 +9987,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_early_server_shutdown_finishes_inflight_calls_unsecure_test", 
@@ -9396,6 +10003,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_early_server_shutdown_finishes_tags_unsecure_test", 
@@ -9411,6 +10019,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_empty_batch_unsecure_test", 
@@ -9426,6 +10035,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_graceful_server_shutdown_unsecure_test", 
@@ -9441,6 +10051,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_invoke_large_request_unsecure_test", 
@@ -9456,6 +10067,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_max_concurrent_streams_unsecure_test", 
@@ -9471,6 +10083,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_max_message_length_unsecure_test", 
@@ -9486,6 +10099,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_no_op_unsecure_test", 
@@ -9501,6 +10115,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_ping_pong_streaming_unsecure_test", 
@@ -9516,6 +10131,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_registered_call_unsecure_test", 
@@ -9531,6 +10147,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_response_with_binary_metadata_and_payload_unsecure_test", 
@@ -9546,6 +10163,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_response_with_metadata_and_payload_unsecure_test", 
@@ -9561,6 +10179,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_response_with_payload_unsecure_test", 
@@ -9576,6 +10195,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_response_with_trailing_metadata_and_payload_unsecure_test", 
@@ -9591,6 +10211,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_with_compressed_payload_unsecure_test", 
@@ -9606,6 +10227,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_with_flags_unsecure_test", 
@@ -9621,6 +10243,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_with_large_metadata_unsecure_test", 
@@ -9636,6 +10259,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_request_with_payload_unsecure_test", 
@@ -9651,6 +10275,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_server_finishes_request_unsecure_test", 
@@ -9666,6 +10291,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_simple_delayed_request_unsecure_test", 
@@ -9681,6 +10307,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_simple_request_unsecure_test", 
@@ -9696,6 +10323,7 @@
       "mac", 
       "posix"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_simple_request_with_high_initial_sequence_number_unsecure_test", 
@@ -9709,6 +10337,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_bad_hostname_unsecure_test", 
@@ -9720,6 +10349,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_cancel_after_accept_unsecure_test", 
@@ -9731,6 +10361,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_cancel_after_accept_and_writes_closed_unsecure_test", 
@@ -9742,6 +10373,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_cancel_after_invoke_unsecure_test", 
@@ -9753,6 +10385,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_cancel_before_invoke_unsecure_test", 
@@ -9764,6 +10397,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_cancel_in_a_vacuum_unsecure_test", 
@@ -9775,6 +10409,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_census_simple_request_unsecure_test", 
@@ -9786,6 +10421,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_channel_connectivity_unsecure_test", 
@@ -9797,6 +10433,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_disappearing_server_unsecure_test", 
@@ -9808,6 +10445,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_early_server_shutdown_finishes_inflight_calls_unsecure_test", 
@@ -9819,6 +10457,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_early_server_shutdown_finishes_tags_unsecure_test", 
@@ -9830,6 +10469,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_empty_batch_unsecure_test", 
@@ -9841,6 +10481,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_graceful_server_shutdown_unsecure_test", 
@@ -9852,6 +10493,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_invoke_large_request_unsecure_test", 
@@ -9863,6 +10505,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_max_concurrent_streams_unsecure_test", 
@@ -9874,6 +10517,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_max_message_length_unsecure_test", 
@@ -9885,6 +10529,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_no_op_unsecure_test", 
@@ -9896,6 +10541,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_ping_pong_streaming_unsecure_test", 
@@ -9907,6 +10553,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_registered_call_unsecure_test", 
@@ -9918,6 +10565,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_response_with_binary_metadata_and_payload_unsecure_test", 
@@ -9929,6 +10577,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_response_with_metadata_and_payload_unsecure_test", 
@@ -9940,6 +10589,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_response_with_payload_unsecure_test", 
@@ -9951,6 +10601,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_response_with_trailing_metadata_and_payload_unsecure_test", 
@@ -9962,6 +10613,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_with_compressed_payload_unsecure_test", 
@@ -9973,6 +10625,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_with_flags_unsecure_test", 
@@ -9984,6 +10637,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_with_large_metadata_unsecure_test", 
@@ -9995,6 +10649,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_request_with_payload_unsecure_test", 
@@ -10006,6 +10661,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_server_finishes_request_unsecure_test", 
@@ -10017,6 +10673,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_simple_delayed_request_unsecure_test", 
@@ -10028,6 +10685,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_simple_request_unsecure_test", 
@@ -10039,6 +10697,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_uds_posix_with_poll_simple_request_with_high_initial_sequence_number_unsecure_test", 
@@ -10050,6 +10709,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_bad_hostname_unsecure_test", 
@@ -10061,6 +10721,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_cancel_after_accept_unsecure_test", 
@@ -10072,6 +10733,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_cancel_after_accept_and_writes_closed_unsecure_test", 
@@ -10083,6 +10745,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_cancel_after_invoke_unsecure_test", 
@@ -10094,6 +10757,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_cancel_before_invoke_unsecure_test", 
@@ -10105,6 +10769,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_cancel_in_a_vacuum_unsecure_test", 
@@ -10116,6 +10781,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_census_simple_request_unsecure_test", 
@@ -10127,6 +10793,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_channel_connectivity_unsecure_test", 
@@ -10138,6 +10805,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_default_host_unsecure_test", 
@@ -10149,6 +10817,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_disappearing_server_unsecure_test", 
@@ -10160,6 +10829,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_early_server_shutdown_finishes_inflight_calls_unsecure_test", 
@@ -10171,6 +10841,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_early_server_shutdown_finishes_tags_unsecure_test", 
@@ -10182,6 +10853,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_empty_batch_unsecure_test", 
@@ -10193,6 +10865,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_graceful_server_shutdown_unsecure_test", 
@@ -10204,6 +10877,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_invoke_large_request_unsecure_test", 
@@ -10215,6 +10889,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_max_concurrent_streams_unsecure_test", 
@@ -10226,6 +10901,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_max_message_length_unsecure_test", 
@@ -10237,6 +10913,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_no_op_unsecure_test", 
@@ -10248,6 +10925,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_ping_pong_streaming_unsecure_test", 
@@ -10259,6 +10937,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_registered_call_unsecure_test", 
@@ -10270,6 +10949,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_response_with_binary_metadata_and_payload_unsecure_test", 
@@ -10281,6 +10961,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_response_with_metadata_and_payload_unsecure_test", 
@@ -10292,6 +10973,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_response_with_payload_unsecure_test", 
@@ -10303,6 +10985,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_response_with_trailing_metadata_and_payload_unsecure_test", 
@@ -10314,6 +10997,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_with_compressed_payload_unsecure_test", 
@@ -10325,6 +11009,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_with_flags_unsecure_test", 
@@ -10336,6 +11021,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_with_large_metadata_unsecure_test", 
@@ -10347,6 +11033,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_request_with_payload_unsecure_test", 
@@ -10358,6 +11045,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_server_finishes_request_unsecure_test", 
@@ -10369,6 +11057,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_simple_delayed_request_unsecure_test", 
@@ -10380,6 +11069,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_simple_request_unsecure_test", 
@@ -10391,6 +11081,7 @@
     "ci_platforms": [
       "linux"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_poll_simple_request_with_high_initial_sequence_number_unsecure_test", 
@@ -10404,6 +11095,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_bad_hostname_unsecure_test", 
@@ -10420,6 +11112,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_cancel_after_accept_unsecure_test", 
@@ -10436,6 +11129,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_cancel_after_accept_and_writes_closed_unsecure_test", 
@@ -10452,6 +11146,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_cancel_after_invoke_unsecure_test", 
@@ -10468,6 +11163,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_cancel_before_invoke_unsecure_test", 
@@ -10484,6 +11180,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_cancel_in_a_vacuum_unsecure_test", 
@@ -10500,6 +11197,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_census_simple_request_unsecure_test", 
@@ -10516,6 +11214,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_default_host_unsecure_test", 
@@ -10532,6 +11231,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_disappearing_server_unsecure_test", 
@@ -10548,6 +11248,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_early_server_shutdown_finishes_inflight_calls_unsecure_test", 
@@ -10564,6 +11265,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_early_server_shutdown_finishes_tags_unsecure_test", 
@@ -10580,6 +11282,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_empty_batch_unsecure_test", 
@@ -10596,6 +11299,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_graceful_server_shutdown_unsecure_test", 
@@ -10612,6 +11316,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_invoke_large_request_unsecure_test", 
@@ -10628,6 +11333,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_max_message_length_unsecure_test", 
@@ -10644,6 +11350,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_no_op_unsecure_test", 
@@ -10660,6 +11367,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_ping_pong_streaming_unsecure_test", 
@@ -10676,6 +11384,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_registered_call_unsecure_test", 
@@ -10692,6 +11401,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_request_response_with_binary_metadata_and_payload_unsecure_test", 
@@ -10708,6 +11418,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_request_response_with_metadata_and_payload_unsecure_test", 
@@ -10724,6 +11435,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_request_response_with_payload_unsecure_test", 
@@ -10740,6 +11452,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_request_response_with_trailing_metadata_and_payload_unsecure_test", 
@@ -10756,6 +11469,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_request_with_large_metadata_unsecure_test", 
@@ -10772,6 +11486,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_request_with_payload_unsecure_test", 
@@ -10788,6 +11503,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_server_finishes_request_unsecure_test", 
@@ -10804,6 +11520,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_simple_delayed_request_unsecure_test", 
@@ -10820,6 +11537,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_simple_request_unsecure_test", 
@@ -10836,6 +11554,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_fullstack_with_proxy_simple_request_with_high_initial_sequence_number_unsecure_test", 
@@ -10852,6 +11571,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_bad_hostname_unsecure_test", 
@@ -10868,6 +11588,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_cancel_after_accept_unsecure_test", 
@@ -10884,6 +11605,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_cancel_after_accept_and_writes_closed_unsecure_test", 
@@ -10900,6 +11622,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_cancel_after_invoke_unsecure_test", 
@@ -10916,6 +11639,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_cancel_before_invoke_unsecure_test", 
@@ -10932,6 +11656,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_cancel_in_a_vacuum_unsecure_test", 
@@ -10948,6 +11673,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_census_simple_request_unsecure_test", 
@@ -10964,6 +11690,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_early_server_shutdown_finishes_inflight_calls_unsecure_test", 
@@ -10980,6 +11707,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_early_server_shutdown_finishes_tags_unsecure_test", 
@@ -10996,6 +11724,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_empty_batch_unsecure_test", 
@@ -11012,6 +11741,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_graceful_server_shutdown_unsecure_test", 
@@ -11028,6 +11758,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_invoke_large_request_unsecure_test", 
@@ -11044,6 +11775,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_max_concurrent_streams_unsecure_test", 
@@ -11060,6 +11792,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_max_message_length_unsecure_test", 
@@ -11076,6 +11809,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_no_op_unsecure_test", 
@@ -11092,6 +11826,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_ping_pong_streaming_unsecure_test", 
@@ -11108,6 +11843,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_registered_call_unsecure_test", 
@@ -11124,6 +11860,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_response_with_binary_metadata_and_payload_unsecure_test", 
@@ -11140,6 +11877,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_response_with_metadata_and_payload_unsecure_test", 
@@ -11156,6 +11894,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_response_with_payload_unsecure_test", 
@@ -11172,6 +11911,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_response_with_trailing_metadata_and_payload_unsecure_test", 
@@ -11188,6 +11928,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_with_compressed_payload_unsecure_test", 
@@ -11204,6 +11945,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_with_flags_unsecure_test", 
@@ -11220,6 +11962,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_with_large_metadata_unsecure_test", 
@@ -11236,6 +11979,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_request_with_payload_unsecure_test", 
@@ -11252,6 +11996,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_server_finishes_request_unsecure_test", 
@@ -11268,6 +12013,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_simple_request_unsecure_test", 
@@ -11284,6 +12030,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_simple_request_with_high_initial_sequence_number_unsecure_test", 
@@ -11300,6 +12047,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_bad_hostname_unsecure_test", 
@@ -11316,6 +12064,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_cancel_after_accept_unsecure_test", 
@@ -11332,6 +12081,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_cancel_after_accept_and_writes_closed_unsecure_test", 
@@ -11348,6 +12098,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_cancel_after_invoke_unsecure_test", 
@@ -11364,6 +12115,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_cancel_before_invoke_unsecure_test", 
@@ -11380,6 +12132,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_cancel_in_a_vacuum_unsecure_test", 
@@ -11396,6 +12149,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_census_simple_request_unsecure_test", 
@@ -11412,6 +12166,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_early_server_shutdown_finishes_inflight_calls_unsecure_test", 
@@ -11428,6 +12183,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_early_server_shutdown_finishes_tags_unsecure_test", 
@@ -11444,6 +12200,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_empty_batch_unsecure_test", 
@@ -11460,6 +12217,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_graceful_server_shutdown_unsecure_test", 
@@ -11476,6 +12234,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_invoke_large_request_unsecure_test", 
@@ -11492,6 +12251,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_max_concurrent_streams_unsecure_test", 
@@ -11508,6 +12268,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_max_message_length_unsecure_test", 
@@ -11524,6 +12285,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_no_op_unsecure_test", 
@@ -11540,6 +12302,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_ping_pong_streaming_unsecure_test", 
@@ -11556,6 +12319,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_registered_call_unsecure_test", 
@@ -11572,6 +12336,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_response_with_binary_metadata_and_payload_unsecure_test", 
@@ -11588,6 +12353,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_response_with_metadata_and_payload_unsecure_test", 
@@ -11604,6 +12370,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_response_with_payload_unsecure_test", 
@@ -11620,6 +12387,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_response_with_trailing_metadata_and_payload_unsecure_test", 
@@ -11636,6 +12404,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_with_compressed_payload_unsecure_test", 
@@ -11652,6 +12421,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_with_flags_unsecure_test", 
@@ -11668,6 +12438,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_with_large_metadata_unsecure_test", 
@@ -11684,6 +12455,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_request_with_payload_unsecure_test", 
@@ -11700,6 +12472,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_server_finishes_request_unsecure_test", 
@@ -11716,6 +12489,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_simple_request_unsecure_test", 
@@ -11732,6 +12506,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_one_byte_at_a_time_simple_request_with_high_initial_sequence_number_unsecure_test", 
@@ -11749,6 +12524,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_bad_hostname_unsecure_test", 
@@ -11766,6 +12542,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_cancel_after_accept_unsecure_test", 
@@ -11783,6 +12560,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_cancel_after_accept_and_writes_closed_unsecure_test", 
@@ -11800,6 +12578,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_cancel_after_invoke_unsecure_test", 
@@ -11817,6 +12596,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_cancel_before_invoke_unsecure_test", 
@@ -11834,6 +12614,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_cancel_in_a_vacuum_unsecure_test", 
@@ -11851,6 +12632,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_census_simple_request_unsecure_test", 
@@ -11868,6 +12650,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_early_server_shutdown_finishes_inflight_calls_unsecure_test", 
@@ -11885,6 +12668,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_early_server_shutdown_finishes_tags_unsecure_test", 
@@ -11902,6 +12686,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_empty_batch_unsecure_test", 
@@ -11919,6 +12704,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_graceful_server_shutdown_unsecure_test", 
@@ -11936,6 +12722,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_invoke_large_request_unsecure_test", 
@@ -11953,6 +12740,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_max_concurrent_streams_unsecure_test", 
@@ -11970,6 +12758,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_max_message_length_unsecure_test", 
@@ -11987,6 +12776,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_no_op_unsecure_test", 
@@ -12004,6 +12794,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_ping_pong_streaming_unsecure_test", 
@@ -12021,6 +12812,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_registered_call_unsecure_test", 
@@ -12038,6 +12830,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_response_with_binary_metadata_and_payload_unsecure_test", 
@@ -12055,6 +12848,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_response_with_metadata_and_payload_unsecure_test", 
@@ -12072,6 +12866,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_response_with_payload_unsecure_test", 
@@ -12089,6 +12884,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_response_with_trailing_metadata_and_payload_unsecure_test", 
@@ -12106,6 +12902,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_with_compressed_payload_unsecure_test", 
@@ -12123,6 +12920,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_with_flags_unsecure_test", 
@@ -12140,6 +12938,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_with_large_metadata_unsecure_test", 
@@ -12157,6 +12956,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_request_with_payload_unsecure_test", 
@@ -12174,6 +12974,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_server_finishes_request_unsecure_test", 
@@ -12191,6 +12992,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_simple_request_unsecure_test", 
@@ -12208,6 +13010,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "chttp2_socket_pair_with_grpc_trace_simple_request_with_high_initial_sequence_number_unsecure_test", 
@@ -12225,6 +13028,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "connection_prefix_bad_client_test", 
@@ -12242,6 +13046,7 @@
       "posix", 
       "windows"
     ], 
+    "exclude_configs": [], 
     "flaky": false, 
     "language": "c", 
     "name": "initial_settings_frame_bad_client_test", 


### PR DESCRIPTION
The TSAN deadlock detector has some problems that prevents this test
from running successfully.

Issue #2994 has been filed to re-enable these in the future.