### PR TITLE
PHP: expose per-call host override option

### DIFF
--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -244,15 +244,9 @@ PHP_METHOD(Call, __construct) {
   wrapped_grpc_timeval *deadline =
       (wrapped_grpc_timeval *)zend_object_store_get_object(
           deadline_obj TSRMLS_CC);
-  if (host_override != NULL) {
-    call->wrapped = grpc_channel_create_call(
-        channel->wrapped, NULL, GRPC_PROPAGATE_DEFAULTS, completion_queue, method,
-        host_override, deadline->wrapped, NULL);
-  } else {
-    call->wrapped = grpc_channel_create_call(
-        channel->wrapped, NULL, GRPC_PROPAGATE_DEFAULTS, completion_queue, method,
-        NULL, deadline->wrapped, NULL);
-  }
+  call->wrapped = grpc_channel_create_call(
+      channel->wrapped, NULL, GRPC_PROPAGATE_DEFAULTS, completion_queue, method,
+      host_override, deadline->wrapped, NULL);
 }
 
 /**

--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -141,9 +141,6 @@ PHP_METHOD(Channel, __construct) {
   HashTable *array_hash;
   zval **creds_obj = NULL;
   wrapped_grpc_credentials *creds = NULL;
-  zval **override_obj;
-  char *override;
-  int override_len;
   /* "s|a" == 1 string, 1 optional array */
   if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|a", &target,
                             &target_length, &args_array) == FAILURE) {
@@ -151,8 +148,6 @@ PHP_METHOD(Channel, __construct) {
                          "Channel expects a string and an array", 1 TSRMLS_CC);
     return;
   }
-  override = target;
-  override_len = target_length;
   if (args_array == NULL) {
     channel->wrapped = grpc_insecure_channel_create(target, NULL, NULL);
   } else {
@@ -169,19 +164,6 @@ PHP_METHOD(Channel, __construct) {
           *creds_obj TSRMLS_CC);
       zend_hash_del(array_hash, "credentials", 12);
     }
-    if (zend_hash_find(array_hash, GRPC_SSL_TARGET_NAME_OVERRIDE_ARG,
-                       sizeof(GRPC_SSL_TARGET_NAME_OVERRIDE_ARG),
-                       (void **)&override_obj) == SUCCESS) {
-      if (Z_TYPE_PP(override_obj) != IS_STRING) {
-        zend_throw_exception(spl_ce_InvalidArgumentException,
-                             GRPC_SSL_TARGET_NAME_OVERRIDE_ARG
-                             " must be a string",
-                             1 TSRMLS_CC);
-        return;
-      }
-      override = Z_STRVAL_PP(override_obj);
-      override_len = Z_STRLEN_PP(override_obj);
-    }
     php_grpc_read_args_array(args_array, &args);
     if (creds == NULL) {
       channel->wrapped = grpc_insecure_channel_create(target, &args, NULL);
@@ -192,8 +174,8 @@ PHP_METHOD(Channel, __construct) {
     }
     efree(args.args);
   }
-  channel->target = ecalloc(override_len + 1, sizeof(char));
-  memcpy(channel->target, override, override_len);
+  channel->target = ecalloc(target_length + 1, sizeof(char));
+  memcpy(channel->target, target, target_length);
 }
 
 /**

--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -64,7 +64,6 @@ void free_wrapped_grpc_channel(void *object TSRMLS_DC) {
   if (channel->wrapped != NULL) {
     grpc_channel_destroy(channel->wrapped);
   }
-  efree(channel->target);
   efree(channel);
 }
 
@@ -174,8 +173,6 @@ PHP_METHOD(Channel, __construct) {
     }
     efree(args.args);
   }
-  channel->target = ecalloc(target_length + 1, sizeof(char));
-  memcpy(channel->target, target, target_length);
 }
 
 /**

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -53,7 +53,6 @@ typedef struct wrapped_grpc_channel {
   zend_object std;
 
   grpc_channel *wrapped;
-  char *target;
 } wrapped_grpc_channel;
 
 /* Initializes the Channel class */

--- a/src/php/tests/unit_tests/SecureEndToEndTest.php
+++ b/src/php/tests/unit_tests/SecureEndToEndTest.php
@@ -40,13 +40,15 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase{
         file_get_contents(dirname(__FILE__) . '/../data/server1.key'),
         file_get_contents(dirname(__FILE__) . '/../data/server1.pem'));
     $this->server = new Grpc\Server();
-    $port = $this->server->addSecureHttp2Port('0.0.0.0:0',
+    $this->port = $this->server->addSecureHttp2Port('0.0.0.0:0',
                                               $server_credentials);
     $this->server->start();
+    $this->host_override = 'foo.test.google.fr';
     $this->channel = new Grpc\Channel(
-        'localhost:' . $port,
+        'localhost:' . $this->port,
         [
-            'grpc.ssl_target_name_override' => 'foo.test.google.fr',
+            'grpc.ssl_target_name_override' => $this->host_override,
+            'grpc.default_authority' => $this->host_override,
             'credentials' => $credentials
          ]);
   }
@@ -61,7 +63,8 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase{
     $status_text = 'xyz';
     $call = new Grpc\Call($this->channel,
                           'dummy_method',
-                          $deadline);
+                          $deadline,
+                          $this->host_override);
 
     $event = $call->startBatch([
         Grpc\OP_SEND_INITIAL_METADATA => [],
@@ -112,7 +115,8 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase{
 
     $call = new Grpc\Call($this->channel,
                           'dummy_method',
-                          $deadline);
+                          $deadline,
+                          $this->host_override);
 
     $event = $call->startBatch([
         Grpc\OP_SEND_INITIAL_METADATA => [],


### PR DESCRIPTION
 * the PHP `Call` object now takes the 4th optional string argument as `host_override`
 * the `Channel` object no longer cares about the ssl_target_name_override option
 * updated tests
 * unit tests and generated code continue to pass
 * fixes #2641 