### PR TITLE
PHP: update codegen, client now extends basestub

### DIFF
--- a/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
+++ b/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
@@ -39,6 +39,14 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase {
   protected static $client;
   protected static $timeout;
 
+  public function testWaitForNotReady() {
+    $this->assertFalse(self::$client->waitForReady(1));
+  }
+
+  public function testWaitForReady() {
+    $this->assertTrue(self::$client->waitForReady(250000));
+  }
+
   public function testSimpleRequest() {
     $div_arg = new math\DivArgs();
     $div_arg->setDividend(7);

--- a/src/php/tests/generated_code/GeneratedCodeTest.php
+++ b/src/php/tests/generated_code/GeneratedCodeTest.php
@@ -35,7 +35,7 @@ require 'AbstractGeneratedCodeTest.php';
 
 class GeneratedCodeTest extends AbstractGeneratedCodeTest {
   public static function setUpBeforeClass() {
-    self::$client = new math\MathClient(new Grpc\BaseStub(
-        getenv('GRPC_TEST_HOST'), []));
+    self::$client = new math\MathClient(
+        getenv('GRPC_TEST_HOST'), []);
   }
 }

--- a/src/php/tests/generated_code/GeneratedCodeWithCallbackTest.php
+++ b/src/php/tests/generated_code/GeneratedCodeWithCallbackTest.php
@@ -35,13 +35,13 @@ require 'AbstractGeneratedCodeTest.php';
 
 class GeneratedCodeWithCallbackTest extends AbstractGeneratedCodeTest {
   public static function setUpBeforeClass() {
-    self::$client = new math\MathClient(new Grpc\BaseStub(
+    self::$client = new math\MathClient(
         getenv('GRPC_TEST_HOST'), ['update_metadata' =>
                                    function($a_hash,
                                             $client = array()) {
                                      $a_copy = $a_hash;
                                      $a_copy['foo'] = ['bar'];
                                      return $a_copy;
-                                   }]));
+                                   }]);
   }
 }


### PR DESCRIPTION
 * See stanley-cheung/Protobuf-PHP#1 
 * Generated client code now extends the `BaseStub` class instead of holding a private instance.
 * Added tests for `waitForReady` introduced in #2877