### PR TITLE
PHP: fix interop stub construction after codegen change

### DIFF
--- a/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
+++ b/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
@@ -47,6 +47,10 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase {
     $this->assertTrue(self::$client->waitForReady(250000));
   }
 
+  public function testGetTarget() {
+    $this->assertTrue(is_string(self::$client->getTarget()));
+  }
+
   public function testSimpleRequest() {
     $div_arg = new math\DivArgs();
     $div_arg->setDividend(7);

--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -368,6 +368,11 @@ switch ($args['test_case']) {
   case 'jwt_token_creds':
     jwtTokenCreds($stub, $args);
     break;
+  case 'cancel_after_begin':
+    // Currently unimplementable with the current API design
+    // Specifically, in the ClientStreamingCall->start() method, the
+    // messages are sent immediately after metadata is sent. There is
+    // currently no way to cancel before messages are sent.
   default:
     exit(1);
 }

--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -332,11 +332,7 @@ if (in_array($args['test_case'], array(
   $opts['update_metadata'] = $auth->getUpdateMetadataFunc();
 }
 
-$internal_stub = new Grpc\BaseStub($server_address, $opts);
-hardAssert(is_string($internal_stub->getTarget()),
-           'Unexpected target URI value');
-
-$stub = new grpc\testing\TestServiceClient($internal_stub);
+$stub = new grpc\testing\TestServiceClient($server_address, $opts);
 
 echo "Connecting to $server_address\n";
 echo "Running test case $args[test_case]\n";


### PR DESCRIPTION
One more place to fix after #3017