### PR TITLE
Reducing JUnit's report size.

### DIFF
--- a/tools/run_tests/jobset.py
+++ b/tools/run_tests/jobset.py
@@ -189,6 +189,10 @@ class Job(object):
       self._tempfile.seek(0)
       stdout = self._tempfile.read()
       filtered_stdout = filter(lambda x: x in string.printable, stdout.decode(errors='ignore'))
+      # TODO: looks like jenkins master is slow because parsing the junit results XMLs is not
+      # implemented efficiently. This is an experiment to workaround the issue by making sure
+      # results.xml file is small enough.
+      filtered_stdout = filtered_stdout[-128:]
       if self._xml_test is not None:
         self._xml_test.set('time', str(elapsed))
         ET.SubElement(self._xml_test, 'system-out').text = filtered_stdout


### PR DESCRIPTION
We need to backport #2919  to the release branch as well to prevent master being overloaded by https://grpc-testing.appspot.com/job/gRPC_release-0_10