### PR TITLE
Four small Python bugfixes

### DIFF
--- a/src/python/grpcio/grpc/_links/service.py
+++ b/src/python/grpcio/grpc/_links/service.py
@@ -239,7 +239,7 @@ class _Kernel(object):
       elif not rpc_state.premetadataed:
         if (ticket.terminal_metadata is not None or
             ticket.payload is not None or
-            ticket.termination is links.Ticket.Termination.COMPLETION or
+            ticket.termination is not None or
             ticket.code is not None or
             ticket.message is not None):
           call.premetadata()

--- a/src/python/grpcio/grpc/framework/core/_reception.py
+++ b/src/python/grpcio/grpc/framework/core/_reception.py
@@ -42,6 +42,7 @@ _REMOTE_TICKET_TERMINATION_TO_LOCAL_OUTCOME = {
     links.Ticket.Termination.TRANSMISSION_FAILURE:
         base.Outcome.TRANSMISSION_FAILURE,
     links.Ticket.Termination.LOCAL_FAILURE: base.Outcome.REMOTE_FAILURE,
+    links.Ticket.Termination.REMOTE_FAILURE: base.Outcome.LOCAL_FAILURE,
 }
 
 
@@ -70,9 +71,10 @@ class ReceptionManager(_interfaces.ReceptionManager):
 
   def _abort(self, outcome):
     self._aborted = True
-    self._termination_manager.abort(outcome)
-    self._transmission_manager.abort(outcome)
-    self._expiration_manager.terminate()
+    if self._termination_manager.outcome is None:
+      self._termination_manager.abort(outcome)
+      self._transmission_manager.abort(None)
+      self._expiration_manager.terminate()
 
   def _sequence_failure(self, ticket):
     """Determines a just-arrived ticket's sequential legitimacy.


### PR DESCRIPTION
(1) In grpc._links.service._Kernel.add_ticket, premetadata() the call
if it has not already been premetadataed for any non-None ticket
termination, not just links.Ticket.Termination.COMPLETION.

(2) In grpc.framework.core._reception, add an entry to
_REMOTE_TICKET_TERMINATION_TO_LOCAL_OUTCOME for REMOTE_FAILURE.
REMOTE_FAILURE on a received ticket indicates the remote side of the
operation blaming the local side for operation abortion.

(3) In grpc.framework.core._reception.ReceptionManager._abort, only
abort the operation's other managers if the operation has not already
terminated, as indicated by the "outcome" attribute of the
TerminationManager.

(4) In grpc.framework.core._reception.ReceptionManager._abort, don't
transmit the outcome to the other side of the operation. Either it came
from the other side in the first place and to send it back would be
telling the other side something it already knows, or it arose from a
network failure and there's no confidence that it would reach the other
side.