### PR TITLE
Test KVO compliance for call.responseHeaders

### DIFF
--- a/src/objective-c/tests/GRPCClientTests.m
+++ b/src/objective-c/tests/GRPCClientTests.m
@@ -53,6 +53,37 @@ static ProtoMethod *kInexistentMethod;
 static ProtoMethod *kEmptyCallMethod;
 static ProtoMethod *kUnaryCallMethod;
 
+// This is an observer class for testing that responseMetadata is KVO-compliant
+
+@interface PassthroughObserver : NSObject
+
+- (instancetype) initWithCallback:(void (^)(NSString*, id, NSDictionary*))callback;
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change
+                       context:(void *)context;
+@end
+
+@implementation PassthroughObserver {
+  void (^_callback)(NSString*, id, NSDictionary*);
+}
+
+- (instancetype)initWithCallback:(void (^)(NSString *, id, NSDictionary *))callback {
+  self = [super init];
+  if (self) {
+    _callback = callback;
+  }
+  return self;
+  
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+  _callback(keyPath, object, change);
+  [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+}
+
+@end
+
 @interface GRPCClientTests : XCTestCase
 @end
 
@@ -181,6 +212,37 @@ static ProtoMethod *kUnaryCallMethod;
   [call startWithWriteable:responsesWriteable];
 
   [self waitForExpectationsWithTimeout:4 handler:nil];
+}
+
+- (void)testResponseMetadataKVO {
+  __weak XCTestExpectation *response = [self expectationWithDescription:@"Empty response received."];
+  __weak XCTestExpectation *completion = [self expectationWithDescription:@"Empty RPC completed."];
+  __weak XCTestExpectation *metadata = [self expectationWithDescription:@"Metadata changed."];
+  
+  PassthroughObserver *observer = [[PassthroughObserver alloc] initWithCallback:^(NSString *keypath, id object, NSDictionary * change) {
+    if (keypath == @"responseHeaders") {
+      [expectation fulfill];
+    }
+  }]
+  
+  GRPCCall *call = [[GRPCCall alloc] initWithHost:kHostAddress
+                                             path:kEmptyCallMethod.HTTPPath
+                                   requestsWriter:[GRXWriter writerWithValue:[NSData data]]];
+  
+  [call addObserver:observer forKeyPath:@"responseHeaders" options:0 context:NULL];
+  
+  id<GRXWriteable> responsesWriteable = [[GRXWriteable alloc] initWithValueHandler:^(NSData *value) {
+    XCTAssertNotNil(value, @"nil value received as response.");
+    XCTAssertEqual([value length], 0, @"Non-empty response received: %@", value);
+    [response fulfill];
+  } completionHandler:^(NSError *errorOrNil) {
+    XCTAssertNil(errorOrNil, @"Finished with unexpected error: %@", errorOrNil);
+    [completion fulfill];
+  }];
+  
+  [call startWithWriteable:responsesWriteable];
+  
+  [self waitForExpectationsWithTimeout:8 handler:nil];
 }
 
 @end

--- a/src/objective-c/tests/GRPCClientTests.m
+++ b/src/objective-c/tests/GRPCClientTests.m
@@ -79,7 +79,7 @@ static ProtoMethod *kUnaryCallMethod;
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
   _callback(keyPath, object, change);
-  [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+  [object removeObserver:self forKeyPath:keyPath];
 }
 
 @end
@@ -219,15 +219,15 @@ static ProtoMethod *kUnaryCallMethod;
   __weak XCTestExpectation *completion = [self expectationWithDescription:@"Empty RPC completed."];
   __weak XCTestExpectation *metadata = [self expectationWithDescription:@"Metadata changed."];
   
-  PassthroughObserver *observer = [[PassthroughObserver alloc] initWithCallback:^(NSString *keypath, id object, NSDictionary * change) {
-    if (keypath == @"responseHeaders") {
-      [expectation fulfill];
-    }
-  }]
-  
   GRPCCall *call = [[GRPCCall alloc] initWithHost:kHostAddress
                                              path:kEmptyCallMethod.HTTPPath
                                    requestsWriter:[GRXWriter writerWithValue:[NSData data]]];
+  
+  PassthroughObserver *observer = [[PassthroughObserver alloc] initWithCallback:^(NSString *keypath, id object, NSDictionary * change) {
+    if ([keypath isEqual: @"responseHeaders"]) {
+      [metadata fulfill];
+    }
+  }];
   
   [call addObserver:observer forKeyPath:@"responseHeaders" options:0 context:NULL];
   


### PR DESCRIPTION
This fixes #2913.

@jtattermusch You can reassign this if you want. I just had to assign it to somebody.