### PR TITLE
Use a custom exception in test_control

### DIFF
--- a/src/python/grpcio_test/grpc_test/framework/common/test_control.py
+++ b/src/python/grpcio_test/grpc_test/framework/common/test_control.py
@@ -34,6 +34,14 @@ import contextlib
 import threading
 
 
+class Defect(Exception):
+  """Simulates a programming defect raised into in a system under test.
+
+  Use of a standard exception type is too easily misconstrued as an actual
+  defect in either the test infrastructure or the system under test.
+  """
+
+
 class Control(object):
   """An object that accepts program control from a system under test.
 
@@ -62,7 +70,7 @@ class PauseFailControl(Control):
   def control(self):
     with self._condition:
       if self._fail:
-        raise ValueError()
+        raise Defect()
 
       while self._paused:
         self._condition.wait()


### PR DESCRIPTION
Use of ValueError is too easily misconstrued as an actual defect in the
system under test.