### PR TITLE
Don't fail a build on failure to kill a docker instance

### DIFF
--- a/tools/jenkins/run_jenkins.sh
+++ b/tools/jenkins/run_jenkins.sh
@@ -89,8 +89,9 @@ then
     bash -l /var/local/jenkins/grpc/tools/jenkins/docker_run_jenkins.sh || DOCKER_FAILED="true"
 
   DOCKER_CID=`cat docker.cid`
-  docker kill $DOCKER_CID
+  docker kill $DOCKER_CID || true
   docker cp $DOCKER_CID:/var/local/git/grpc/report.xml $git_root
+  # TODO(ctiller): why?
   sleep 4
   docker rm $DOCKER_CID || true
 elif [ "$platform" == "interop" ]


### PR DESCRIPTION
It's quite ok for a docker instance to already be dead.

This ought to fix the problem we've been having with a failure to copy report.xml at the end of a test.

@jtattermusch - heads up