### PR TITLE
PHP: support per message compression disable

### DIFF
--- a/src/php/lib/Grpc/AbstractCall.php
+++ b/src/php/lib/Grpc/AbstractCall.php
@@ -92,20 +92,4 @@ abstract class AbstractCall {
     }
     return call_user_func($this->deserialize, $value);
   }
-
-  /**
-   * Get the list of Grpc Write Flags
-   * @param array $options an array of options
-   * @return The list of Grpc Write Flags contained in the input
-   */
-  protected static function getGrpcWriteFlags($options) {
-    $grpc_write_flags = [];
-    foreach ([WRITE_BUFFER_HINT,
-              WRITE_NO_COMPRESS] as $flag) {
-      if (in_array($flag, $options)) {
-        $grpc_write_flags[] = $flag;
-      }
-    }
-    return $grpc_write_flags;
-  }
 }

--- a/src/php/lib/Grpc/AbstractCall.php
+++ b/src/php/lib/Grpc/AbstractCall.php
@@ -92,4 +92,20 @@ abstract class AbstractCall {
     }
     return call_user_func($this->deserialize, $value);
   }
+
+  /**
+   * Get the list of Grpc Write Flags
+   * @param array $options an array of options
+   * @return The list of Grpc Write Flags contained in the input
+   */
+  protected static function getGrpcWriteFlags($options) {
+    $grpc_write_flags = [];
+    foreach ([WRITE_BUFFER_HINT,
+              WRITE_NO_COMPRESS] as $flag) {
+      if (in_array($flag, $options)) {
+        $grpc_write_flags[] = $flag;
+      }
+    }
+    return $grpc_write_flags;
+  }
 }

--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -168,7 +168,8 @@ class BaseStub {
   public function _simpleRequest($method,
                                  $argument,
                                  callable $deserialize,
-                                 $metadata = array()) {
+                                 $metadata = array(),
+                                 $options = array()) {
     list($actual_metadata, $timeout)  = $this->_extract_timeout_from_metadata($metadata);
     $call = new UnaryCall($this->channel, $method, $deserialize, $timeout);
     $jwt_aud_uri = $this->_get_jwt_aud_uri($method);
@@ -177,7 +178,7 @@ class BaseStub {
                                         $actual_metadata,
                                         $jwt_aud_uri);
     }
-    $call->start($argument, $actual_metadata);
+    $call->start($argument, $actual_metadata, $options);
     return $call;
   }
 
@@ -193,7 +194,6 @@ class BaseStub {
    * @return ClientStreamingSurfaceActiveCall The active call object
    */
   public function _clientStreamRequest($method,
-                                       $arguments,
                                        callable $deserialize,
                                        $metadata = array()) {
     list($actual_metadata, $timeout)  = $this->_extract_timeout_from_metadata($metadata);
@@ -204,7 +204,7 @@ class BaseStub {
                                         $actual_metadata,
                                         $jwt_aud_uri);
     }
-    $call->start($arguments, $actual_metadata);
+    $call->start($actual_metadata);
     return $call;
   }
 
@@ -221,7 +221,8 @@ class BaseStub {
   public function _serverStreamRequest($method,
                                        $argument,
                                        callable $deserialize,
-                                       $metadata = array()) {
+                                       $metadata = array(),
+                                       $options = array()) {
     list($actual_metadata, $timeout)  = $this->_extract_timeout_from_metadata($metadata);
     $call = new ServerStreamingCall($this->channel, $method, $deserialize, $timeout);
     $jwt_aud_uri = $this->_get_jwt_aud_uri($method);
@@ -230,7 +231,7 @@ class BaseStub {
                                         $actual_metadata,
                                         $jwt_aud_uri);
     }
-    $call->start($argument, $actual_metadata);
+    $call->start($argument, $actual_metadata, $options);
     return $call;
   }
 

--- a/src/php/lib/Grpc/BidiStreamingCall.php
+++ b/src/php/lib/Grpc/BidiStreamingCall.php
@@ -66,9 +66,14 @@ class BidiStreamingCall extends AbstractCall {
    * Write a single message to the server. This cannot be called after
    * writesDone is called.
    * @param ByteBuffer $data The data to write
+   * @param array $options an array of options
    */
-  public function write($data) {
-    $this->call->startBatch([OP_SEND_MESSAGE => $data->serialize()]);
+  public function write($data, $options = array()) {
+    $message_array = ['message' => $data->serialize()];
+    if ($grpc_write_flags = self::getGrpcWriteFlags($options)) {
+      $message_array['flags'] = $grpc_write_flags;
+    }
+    $this->call->startBatch([OP_SEND_MESSAGE => $message_array]);
   }
 
   /**
@@ -86,7 +91,7 @@ class BidiStreamingCall extends AbstractCall {
   public function getStatus() {
     $status_event = $this->call->startBatch([
         OP_RECV_STATUS_ON_CLIENT => true
-                                              ]);
+    ]);
     return $status_event->status;
   }
 }

--- a/src/php/lib/Grpc/BidiStreamingCall.php
+++ b/src/php/lib/Grpc/BidiStreamingCall.php
@@ -66,12 +66,13 @@ class BidiStreamingCall extends AbstractCall {
    * Write a single message to the server. This cannot be called after
    * writesDone is called.
    * @param ByteBuffer $data The data to write
-   * @param array $options an array of options
+   * @param array $options an array of options, possible keys:
+   *              'flags' => a number
    */
   public function write($data, $options = array()) {
     $message_array = ['message' => $data->serialize()];
-    if ($grpc_write_flags = self::getGrpcWriteFlags($options)) {
-      $message_array['flags'] = $grpc_write_flags;
+    if (isset($options['flags'])) {
+      $message_array['flags'] = $options['flags'];
     }
     $this->call->startBatch([OP_SEND_MESSAGE => $message_array]);
   }

--- a/src/php/lib/Grpc/ClientStreamingCall.php
+++ b/src/php/lib/Grpc/ClientStreamingCall.php
@@ -50,12 +50,13 @@ class ClientStreamingCall extends AbstractCall {
    * Write a single message to the server. This cannot be called after
    * wait is called.
    * @param ByteBuffer $data The data to write
-   * @param array $options an array of options
+   * @param array $options an array of options, possible keys:
+   *              'flags' => a number
    */
   public function write($data, $options = array()) {
     $message_array = ['message' => $data->serialize()];
-    if ($grpc_write_flags = self::getGrpcWriteFlags($options)) {
-      $message_array['flags'] = $grpc_write_flags;
+    if (isset($options['flags'])) {
+      $message_array['flags'] = $options['flags'];
     }
     $this->call->startBatch([OP_SEND_MESSAGE => $message_array]);
   }

--- a/src/php/lib/Grpc/ServerStreamingCall.php
+++ b/src/php/lib/Grpc/ServerStreamingCall.php
@@ -40,14 +40,19 @@ namespace Grpc;
 class ServerStreamingCall extends AbstractCall {
   /**
    * Start the call
-   * @param $arg The argument to send
+   * @param $data The data to send
    * @param array $metadata Metadata to send with the call, if applicable
+   * @param array $options an array of options
    */
-  public function start($arg, $metadata = array()) {
+  public function start($data, $metadata = array(), $options = array()) {
+    $message_array = ['message' => $data->serialize()];
+    if ($grpc_write_flags = self::getGrpcWriteFlags($options)) {
+      $message_array['flags'] = $grpc_write_flags;
+    }
     $event = $this->call->startBatch([
         OP_SEND_INITIAL_METADATA => $metadata,
         OP_RECV_INITIAL_METADATA => true,
-        OP_SEND_MESSAGE => $arg->serialize(),
+        OP_SEND_MESSAGE => $message_array,
         OP_SEND_CLOSE_FROM_CLIENT => true]);
     $this->metadata = $event->metadata;
   }
@@ -71,7 +76,7 @@ class ServerStreamingCall extends AbstractCall {
   public function getStatus() {
     $status_event = $this->call->startBatch([
         OP_RECV_STATUS_ON_CLIENT => true
-                                              ]);
+    ]);
     return $status_event->status;
   }
 }

--- a/src/php/lib/Grpc/ServerStreamingCall.php
+++ b/src/php/lib/Grpc/ServerStreamingCall.php
@@ -42,12 +42,13 @@ class ServerStreamingCall extends AbstractCall {
    * Start the call
    * @param $data The data to send
    * @param array $metadata Metadata to send with the call, if applicable
-   * @param array $options an array of options
+   * @param array $options an array of options, possible keys:
+   *              'flags' => a number
    */
   public function start($data, $metadata = array(), $options = array()) {
     $message_array = ['message' => $data->serialize()];
-    if ($grpc_write_flags = self::getGrpcWriteFlags($options)) {
-      $message_array['flags'] = $grpc_write_flags;
+    if (isset($options['flags'])) {
+      $message_array['flags'] = $options['flags'];
     }
     $event = $this->call->startBatch([
         OP_SEND_INITIAL_METADATA => $metadata,

--- a/src/php/lib/Grpc/UnaryCall.php
+++ b/src/php/lib/Grpc/UnaryCall.php
@@ -42,12 +42,13 @@ class UnaryCall extends AbstractCall {
    * Start the call
    * @param $data The data to send
    * @param array $metadata Metadata to send with the call, if applicable
-   * @param array $options an array of options
+   * @param array $options an array of options, possible keys:
+   *              'flags' => a number
    */
   public function start($data, $metadata = array(), $options = array()) {
     $message_array = ['message' => $data->serialize()];
-    if ($grpc_write_flags = self::getGrpcWriteFlags($options)) {
-      $message_array['flags'] = $grpc_write_flags;
+    if (isset($options['flags'])) {
+      $message_array['flags'] = $options['flags'];
     }
     $event = $this->call->startBatch([
         OP_SEND_INITIAL_METADATA => $metadata,

--- a/src/php/lib/Grpc/UnaryCall.php
+++ b/src/php/lib/Grpc/UnaryCall.php
@@ -40,14 +40,19 @@ namespace Grpc;
 class UnaryCall extends AbstractCall {
   /**
    * Start the call
-   * @param $arg The argument to send
+   * @param $data The data to send
    * @param array $metadata Metadata to send with the call, if applicable
+   * @param array $options an array of options
    */
-  public function start($arg, $metadata = array()) {
+  public function start($data, $metadata = array(), $options = array()) {
+    $message_array = ['message' => $data->serialize()];
+    if ($grpc_write_flags = self::getGrpcWriteFlags($options)) {
+      $message_array['flags'] = $grpc_write_flags;
+    }
     $event = $this->call->startBatch([
         OP_SEND_INITIAL_METADATA => $metadata,
         OP_RECV_INITIAL_METADATA => true,
-        OP_SEND_MESSAGE => $arg->serialize(),
+        OP_SEND_MESSAGE => $message_array,
         OP_SEND_CLOSE_FROM_CLIENT => true]);
     $this->metadata = $event->metadata;
   }

--- a/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
+++ b/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
@@ -51,6 +51,18 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase {
     $this->assertTrue(is_string(self::$client->getTarget()));
   }
 
+  public function testWriteFlags() {
+    $div_arg = new math\DivArgs();
+    $div_arg->setDividend(7);
+    $div_arg->setDivisor(4);
+    $call = self::$client->Div($div_arg, array(), array('flags' => Grpc\WRITE_NO_COMPRESS));
+    $this->assertTrue(is_string($call->getPeer()));
+    list($response, $status) = $call->wait();
+    $this->assertSame(1, $response->getQuotient());
+    $this->assertSame(3, $response->getRemainder());
+    $this->assertSame(\Grpc\STATUS_OK, $status->code);
+  }
+
   public function testSimpleRequest() {
     $div_arg = new math\DivArgs();
     $div_arg->setDividend(7);

--- a/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
+++ b/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
@@ -79,15 +79,13 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase {
   }
 
   public function testClientStreaming() {
-    $num_iter = function() {
-      for ($i = 0; $i < 7; $i++) {
-        $num = new math\Num();
-        $num->setNum($i);
-        yield $num;
-      }
-    };
-    $call = self::$client->Sum($num_iter());
+    $call = self::$client->Sum();
     $this->assertTrue(is_string($call->getPeer()));
+    for ($i = 0; $i < 7; $i++) {
+      $num = new math\Num();
+      $num->setNum($i);
+      $call->write($num);
+    }
     list($response, $status) = $call->wait();
     $this->assertSame(21, $response->getNum());
     $this->assertSame(\Grpc\STATUS_OK, $status->code);

--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -251,6 +251,19 @@ function pingPong($stub) {
 }
 
 /**
+ * Run the cancel_after_begin test.
+ * Passes when run against the Node server as of 2015-08-28
+ * @param $stub Stub object that has service methods.
+ */
+function cancelAfterBegin($stub) {
+  $call = $stub->StreamingInputCall();
+  $call->cancel();
+  list($result, $status) = $call->wait();
+  hardAssert($status->code === Grpc\STATUS_CANCELLED,
+             'Call status was not CANCELLED');
+}
+
+/**
  * Run the cancel_after_first_response test.
  * Passes when run against the Node server as of 2015-04-30
  * @param $stub Stub object that has service methods.
@@ -357,6 +370,9 @@ switch ($args['test_case']) {
   case 'ping_pong':
     pingPong($stub);
     break;
+  case 'cancel_after_begin':
+    cancelAfterBegin($stub);
+    break;
   case 'cancel_after_first_response':
     cancelAfterFirstResponse($stub);
     break;
@@ -372,11 +388,6 @@ switch ($args['test_case']) {
   case 'jwt_token_creds':
     jwtTokenCreds($stub, $args);
     break;
-  case 'cancel_after_begin':
-    // Currently unimplementable with the current API design
-    // Specifically, in the ClientStreamingCall->start() method, the
-    // messages are sent immediately after metadata is sent. There is
-    // currently no way to cancel before messages are sent.
   default:
     echo "Unsupported test case $args[test_case]\n";
     exit(1);

--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -173,7 +173,11 @@ function clientStreaming($stub) {
         return $request;
       }, $request_lengths);
 
-  list($result, $status) = $stub->StreamingInputCall($requests)->wait();
+  $call = $stub->StreamingInputCall();
+  foreach ($requests as $request) {
+    $call->write($request);
+  }
+  list($result, $status) = $call->wait();
   hardAssert($status->code === Grpc\STATUS_OK, 'Call did not complete successfully');
   hardAssert($result->getAggregatedPayloadSize() === 74922,
               'aggregated_payload_size was incorrect');
@@ -374,5 +378,6 @@ switch ($args['test_case']) {
     // messages are sent immediately after metadata is sent. There is
     // currently no way to cancel before messages are sent.
   default:
+    echo "Unsupported test case $args[test_case]\n";
     exit(1);
 }

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -91,6 +91,51 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
     unset($server_call);
   }
 
+  public function testMessageWriteFlags() {
+    $deadline = Grpc\Timeval::infFuture();
+    $req_text = 'message_write_flags_test';
+    $status_text = 'xyz';
+    $call = new Grpc\Call($this->channel,
+                          'dummy_method',
+                          $deadline);
+
+    $event = $call->startBatch([
+        Grpc\OP_SEND_INITIAL_METADATA => [],
+        Grpc\OP_SEND_MESSAGE => ['message' => $req_text,
+                                 'flags' => Grpc\WRITE_NO_COMPRESS],
+        Grpc\OP_SEND_CLOSE_FROM_CLIENT => true
+                                       ]);
+
+    $this->assertTrue($event->send_metadata);
+    $this->assertTrue($event->send_close);
+
+    $event = $this->server->requestCall();
+    $this->assertSame('dummy_method', $event->method);
+    $server_call = $event->call;
+
+    $event = $server_call->startBatch([
+        Grpc\OP_SEND_INITIAL_METADATA => [],
+        Grpc\OP_SEND_STATUS_FROM_SERVER => [
+            'metadata' => [],
+            'code' => Grpc\STATUS_OK,
+            'details' => $status_text
+        ],
+    ]);
+
+    $event = $call->startBatch([
+        Grpc\OP_RECV_INITIAL_METADATA => true,
+        Grpc\OP_RECV_STATUS_ON_CLIENT => true
+                                 ]);
+
+    $status = $event->status;
+    $this->assertSame([], $status->metadata);
+    $this->assertSame(Grpc\STATUS_OK, $status->code);
+    $this->assertSame($status_text, $status->details);
+
+    unset($call);
+    unset($server_call);
+  }
+
   public function testClientServerFullRequestResponse() {
     $deadline = Grpc\Timeval::infFuture();
     $req_text = 'client_server_full_request_response';
@@ -104,7 +149,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
     $event = $call->startBatch([
         Grpc\OP_SEND_INITIAL_METADATA => [],
         Grpc\OP_SEND_CLOSE_FROM_CLIENT => true,
-        Grpc\OP_SEND_MESSAGE => $req_text
+        Grpc\OP_SEND_MESSAGE => ['message' => $req_text],
                                        ]);
 
     $this->assertTrue($event->send_metadata);
@@ -117,7 +162,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase{
 
     $event = $server_call->startBatch([
         Grpc\OP_SEND_INITIAL_METADATA => [],
-        Grpc\OP_SEND_MESSAGE => $reply_text,
+        Grpc\OP_SEND_MESSAGE => ['message' => $reply_text],
         Grpc\OP_SEND_STATUS_FROM_SERVER => [
             'metadata' => [],
             'code' => Grpc\STATUS_OK,

--- a/src/php/tests/unit_tests/SecureEndToEndTest.php
+++ b/src/php/tests/unit_tests/SecureEndToEndTest.php
@@ -107,6 +107,53 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase{
     unset($server_call);
   }
 
+  public function testMessageWriteFlags() {
+    $deadline = Grpc\Timeval::infFuture();
+    $req_text = 'message_write_flags_test';
+    $status_text = 'xyz';
+    $call = new Grpc\Call($this->channel,
+                          'dummy_method',
+                          $deadline,
+                          $this->host_override);
+
+    $event = $call->startBatch([
+        Grpc\OP_SEND_INITIAL_METADATA => [],
+        Grpc\OP_SEND_MESSAGE => ['message' => $req_text,
+                                 'flags' => Grpc\WRITE_NO_COMPRESS],
+        Grpc\OP_SEND_CLOSE_FROM_CLIENT => true
+                                       ]);
+
+    $this->assertTrue($event->send_metadata);
+    $this->assertTrue($event->send_close);
+
+    $event = $this->server->requestCall();
+    $this->assertSame('dummy_method', $event->method);
+    $server_call = $event->call;
+
+    $event = $server_call->startBatch([
+        Grpc\OP_SEND_INITIAL_METADATA => [],
+        Grpc\OP_SEND_STATUS_FROM_SERVER => [
+            'metadata' => [],
+            'code' => Grpc\STATUS_OK,
+            'details' => $status_text
+        ],
+    ]);
+
+    $event = $call->startBatch([
+        Grpc\OP_RECV_INITIAL_METADATA => true,
+        Grpc\OP_RECV_STATUS_ON_CLIENT => true
+    ]);
+
+    $this->assertSame([], $event->metadata);
+    $status = $event->status;
+    $this->assertSame([], $status->metadata);
+    $this->assertSame(Grpc\STATUS_OK, $status->code);
+    $this->assertSame($status_text, $status->details);
+
+    unset($call);
+    unset($server_call);
+  }
+
   public function testClientServerFullRequestResponse() {
     $deadline = Grpc\Timeval::infFuture();
     $req_text = 'client_server_full_request_response';
@@ -121,7 +168,7 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase{
     $event = $call->startBatch([
         Grpc\OP_SEND_INITIAL_METADATA => [],
         Grpc\OP_SEND_CLOSE_FROM_CLIENT => true,
-        Grpc\OP_SEND_MESSAGE => $req_text
+        Grpc\OP_SEND_MESSAGE => ['message' => $req_text]
                                        ]);
 
     $this->assertTrue($event->send_metadata);
@@ -134,7 +181,7 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase{
 
     $event = $server_call->startBatch([
         Grpc\OP_SEND_INITIAL_METADATA => [],
-        Grpc\OP_SEND_MESSAGE => $reply_text,
+        Grpc\OP_SEND_MESSAGE => ['message' => $reply_text],
         Grpc\OP_SEND_STATUS_FROM_SERVER => [
             'metadata' => [],
             'code' => Grpc\STATUS_OK,


### PR DESCRIPTION
 * Fixes #2580
 * Needs stanley-cheung/Protobuf-PHP#2 for the codegen for client stub
 * C extension work: `OP_SEND_MESSAGE` now takes an array with key `array('message' => <a string>, 'flags' => <an array of options>)`, instead of just a string
 * `UnaryCall` and `ServerStreaming` `->start()` method now takes an additional `$options` array, which can carry the per-message compression disable write flags
 * `ClientStreaming` has an API change:
   * Instead of `start($arguments, $metadata)` which sends the metadata, goes through the array of `$arguments` and sends each of them, and closes the client, all together,
   * We now `start($metadata)` which just sends the metadata
   * Introduced a new method `write($data, $options)` which can be called by the client per message. This is also consistent with BidiStreaming
 * `BidiStreaming->write()` now takes an additional `$options` array
 * Updated unit tests, genereated code tests and interop tests