### PR TITLE
Add timeouts to Python test harness

### DIFF
--- a/src/python/grpcio_test/setup.py
+++ b/src/python/grpcio_test/setup.py
@@ -61,6 +61,7 @@ _SETUP_REQUIRES = (
     'pytest>=2.6',
     'pytest-cov>=2.0',
     'pytest-xdist>=1.11',
+    'pytest-timeout>=0.5',
 )
 
 _INSTALL_REQUIRES = (

--- a/tools/run_tests/run_python.sh
+++ b/tools/run_tests/run_python.sh
@@ -47,4 +47,4 @@ source "python"$PYVER"_virtual_environment"/bin/activate
 "python"$PYVER -m grpc_test._core_over_links_base_interface_test
 "python"$PYVER -m grpc_test.framework.core._base_interface_test
 
-"python"$PYVER $GRPCIO_TEST/setup.py test -a "-n8 --cov=grpc --junitxml=./report.xml"
+"python"$PYVER $GRPCIO_TEST/setup.py test -a "-n8 --cov=grpc --junitxml=./report.xml --timeout=300"


### PR DESCRIPTION
We should timeout well before `run_tests` wants to time us out, thus allowing us to always report timeout-failures instead of the report getting lost in the aether.