### PR TITLE
Expand error handling to ignore all errors printing output

### DIFF
--- a/tools/run_tests/jobset.py
+++ b/tools/run_tests/jobset.py
@@ -96,12 +96,12 @@ def message(tag, msg, explanatory_text=None, do_newline=False):
     return
   message.old_tag = tag
   message.old_msg = msg
-  if platform.system() == 'Windows' or not sys.stdout.isatty():
-    if explanatory_text:
-      print explanatory_text
-    print '%s: %s' % (tag, msg)
-    return
   try:
+    if platform.system() == 'Windows' or not sys.stdout.isatty():
+      if explanatory_text:
+        print explanatory_text
+      print '%s: %s' % (tag, msg)
+      return
     sys.stdout.write('%s%s%s\x1b[%d;%dm%s\x1b[0m: %s%s' % (
         _BEGINNING_OF_LINE,
         _CLEAR_LINE,


### PR DESCRIPTION
Working around a failure seen on one of our macs:

https://grpc-testing.appspot.com/job/gRPC_master/config=opt,language=c,platform=macos/lastBuild/consoleFull