### PR TITLE
Prevent occasional AppDomainUnloadedException from nunit

### DIFF
--- a/tools/run_tests/run_csharp.bat
+++ b/tools/run_tests/run_csharp.bat
@@ -8,7 +8,7 @@ cd /d %~dp0\..\..\src\csharp
 @rem set UUID variable to a random GUID, we will use it to put TestResults.xml to a dedicated directory, so that parallel test runs don't collide
 for /F %%i in ('powershell -Command "[guid]::NewGuid().ToString()"') do (set UUID=%%i)
 
-packages\NUnit.Runners.2.6.4\tools\nunit-console-x86.exe -labels "%1/bin/Debug/%1.dll" -work test-results/%UUID% || goto :error
+packages\NUnit.Runners.2.6.4\tools\nunit-console-x86.exe /domain:None -labels "%1/bin/Debug/%1.dll" -work test-results/%UUID% || goto :error
 
 endlocal
 


### PR DESCRIPTION
NUnit tests sometimes fail with AppDomainUnloadedException because grpc native logger hook outlives the NUnit tests and the test appdomain gets unloaded as soon as the last test finishes.