### PR TITLE
PHP: fix build failure on mac

### DIFF
--- a/tools/run_tests/build_php.sh
+++ b/tools/run_tests/build_php.sh
@@ -37,6 +37,7 @@ cd $(dirname $0)/../..
 
 root=`pwd`
 export GRPC_LIB_SUBDIR=libs/$CONFIG
+export CFLAGS="-Wno-parentheses-equality"
 
 # build php
 cd src/php


### PR DESCRIPTION
PHP build is failing on jenkins new macos-node2. https://grpc-testing.appspot.com/job/gRPC_master/2791/config=dbg,language=php,platform=macos/console

Looks like a similar issue to one I encountered when I was setting up macos homebrew testing on Jenkins: https://github.com/grpc/grpc/blob/master/tools/jenkins/run_distribution.sh#L102