### PR TITLE
googletest uses https like all the other submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,4 +14,4 @@
 	url = https://github.com/gflags/gflags.git
 [submodule "third_party/googletest"]
 	path = third_party/googletest
-	url = git://github.com/google/googletest
+	url = https://github.com/google/googletest.git


### PR DESCRIPTION
The merged change #3050 is causing a fetch error on our build slaves, possibly because they don't have authentication or access to use the `git://` protocol:

My assertion may be incorrect, but notably one of those things is not like the others: all the other submodules use HTTPS, and this one uses `git://` - so simply for the sake of consistency it makes sense to use the https protocol here.
```
5:18:10 Submodule 'third_party/gflags' (https://github.com/gflags/gflags.git) registered for path 'third_party/gflags'
15:18:10 Submodule 'third_party/googletest' (git://github.com/google/googletest) registered for path 'third_party/googletest'
15:18:10 Submodule 'third_party/openssl' (https://github.com/openssl/openssl.git) registered for path 'third_party/openssl'
15:18:10 Submodule 'third_party/protobuf' (https://github.com/google/protobuf.git) registered for path 'third_party/protobuf'
15:18:10 Submodule 'third_party/zlib' (https://github.com/madler/zlib) registered for path 'third_party/zlib'
```



