### PR TITLE
minor fixes to string_ref

### DIFF
--- a/include/grpc++/support/string_ref.h
+++ b/include/grpc++/support/string_ref.h
@@ -31,8 +31,8 @@
  *
  */
 
-#ifndef GRPCXX_STRING_REF_H
-#define GRPCXX_STRING_REF_H
+#ifndef GRPCXX_SUPPORT_STRING_REF_H
+#define GRPCXX_SUPPORT_STRING_REF_H
 
 #include <iterator>
 #include <iosfwd>
@@ -44,6 +44,8 @@ namespace grpc {
 // This class is a non owning reference to a string.
 // It should be a strict subset of the upcoming std::string_ref. See:
 // http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3442.html
+// The constexpr is dropped or replaced with const for legacy compiler
+// compatibility.
 class string_ref {
  public:
   // types
@@ -115,6 +117,4 @@ std::ostream& operator<<(std::ostream& stream, const string_ref& string);
 
 }  // namespace grpc
 
-#endif  // GRPCXX_STRING_REF_H
-
-
+#endif  // GRPCXX_SUPPORT_STRING_REF_H

--- a/src/cpp/util/string_ref.cc
+++ b/src/cpp/util/string_ref.cc
@@ -80,7 +80,7 @@ size_t string_ref::find(string_ref s) const {
 }
 
 size_t string_ref::find(char c) const {
-  auto it = std::find_if(cbegin(), cend(), [c](char cc) { return cc == c; });
+  auto it = std::find(cbegin(), cend(), c);
   return it == cend() ? npos : std::distance(cbegin(), it);
 }
 

--- a/test/cpp/util/string_ref_test.cc
+++ b/test/cpp/util/string_ref_test.cc
@@ -100,8 +100,8 @@ TEST_F(StringRefTest, Assignment) {
 TEST_F(StringRefTest, Iterator) {
   string_ref s(kTestString);
   size_t i = 0;
-  for (char c : s) {
-    EXPECT_EQ(kTestString[i++], c);
+  for (auto it = s.cbegin(); it != s.cend(); ++it) {
+    EXPECT_EQ(kTestString[i++], *it);
   }
   EXPECT_EQ(strlen(kTestString), i);
 }


### PR DESCRIPTION
- header guard format
- add comment on constexpr
- remove lambda
- remove range based loop in test

The latter two fix #3091.