### PR TITLE
Use millis instead of micros in seconds_timeout and reduce a large deadline.

### DIFF
--- a/test/core/iomgr/udp_server_test.c
+++ b/test/core/iomgr/udp_server_test.c
@@ -135,7 +135,7 @@ static void test_receive(int number_of_clients) {
   gpr_mu_lock(GRPC_POLLSET_MU(&g_pollset));
 
   for (i = 0; i < number_of_clients; i++) {
-    deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(4000);
+    deadline = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(10);
 
     number_of_reads_before = g_number_of_reads;
     /* Create a socket, send a packet to the UDP server. */

--- a/test/core/util/test_config.h
+++ b/test/core/util/test_config.h
@@ -56,7 +56,7 @@ extern double g_fixture_slowdown_factor;
 
 #define GRPC_TIMEOUT_SECONDS_TO_DEADLINE(x)                                \
   gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),                               \
-               gpr_time_from_micros(GRPC_TEST_SLOWDOWN_FACTOR * 1e6 * (x), \
+               gpr_time_from_millis(GRPC_TEST_SLOWDOWN_FACTOR * 1e3 * (x), \
                                     GPR_TIMESPAN))
 
 #define GRPC_TIMEOUT_MILLIS_TO_DEADLINE(x)                                 \


### PR DESCRIPTION
Fixes #3009.