### PR TITLE
Python test clean-up

### DIFF
--- a/src/python/grpcio_test/grpc_test/_core_over_links_base_interface_test.py
+++ b/src/python/grpcio_test/grpc_test/_core_over_links_base_interface_test.py
@@ -45,11 +45,7 @@ from grpc_test.framework.common import test_constants
 from grpc_test.framework.interfaces.base import test_cases
 from grpc_test.framework.interfaces.base import test_interfaces
 
-_INVOCATION_INITIAL_METADATA = ((b'0', b'abc'), (b'1', b'def'), (b'2', b'ghi'),)
-_SERVICE_INITIAL_METADATA = ((b'3', b'jkl'), (b'4', b'mno'), (b'5', b'pqr'),)
-_SERVICE_TERMINAL_METADATA = ((b'6', b'stu'), (b'7', b'vwx'), (b'8', b'yza'),)
 _CODE = _intermediary_low.Code.OK
-_MESSAGE = b'test message'
 
 
 class _SerializationBehaviors(
@@ -117,16 +113,18 @@ class _Implementation(test_interfaces.Implementation):
     service_grpc_link.stop_gracefully()
 
   def invocation_initial_metadata(self):
-    return _INVOCATION_INITIAL_METADATA
+    return grpc_test_common.INVOCATION_INITIAL_METADATA
 
   def service_initial_metadata(self):
-    return _SERVICE_INITIAL_METADATA
+    return grpc_test_common.SERVICE_INITIAL_METADATA
 
   def invocation_completion(self):
     return utilities.completion(None, None, None)
 
   def service_completion(self):
-    return utilities.completion(_SERVICE_TERMINAL_METADATA, _CODE, _MESSAGE)
+    return utilities.completion(
+        grpc_test_common.SERVICE_TERMINAL_METADATA, _CODE,
+        grpc_test_common.DETAILS)
 
   def metadata_transmitted(self, original_metadata, transmitted_metadata):
     return original_metadata is None or grpc_test_common.metadata_transmitted(
@@ -144,14 +142,6 @@ class _Implementation(test_interfaces.Implementation):
       return False
     else:
       return True
-
-
-def setUpModule():
-  logging.warn('setUpModule!')
-
-
-def tearDownModule():
-  logging.warn('tearDownModule!')
 
 
 def load_tests(loader, tests, pattern):

--- a/src/python/grpcio_test/grpc_test/_crust_over_core_over_links_face_interface_test.py
+++ b/src/python/grpcio_test/grpc_test/_crust_over_core_over_links_face_interface_test.py
@@ -39,11 +39,10 @@ from grpc.framework.core import implementations as core_implementations
 from grpc.framework.crust import implementations as crust_implementations
 from grpc.framework.foundation import logging_pool
 from grpc.framework.interfaces.links import utilities
-from grpc_test import test_common
+from grpc_test import test_common as grpc_test_common
 from grpc_test.framework.common import test_constants
 from grpc_test.framework.interfaces.face import test_cases
 from grpc_test.framework.interfaces.face import test_interfaces
-from grpc_test.framework.interfaces.links import test_utilities
 
 
 class _SerializationBehaviors(
@@ -130,19 +129,19 @@ class _Implementation(test_interfaces.Implementation):
     pool.shutdown(wait=True)
 
   def invocation_metadata(self):
-    return test_common.INVOCATION_INITIAL_METADATA
+    return grpc_test_common.INVOCATION_INITIAL_METADATA
 
   def initial_metadata(self):
-    return test_common.SERVICE_INITIAL_METADATA
+    return grpc_test_common.SERVICE_INITIAL_METADATA
 
   def terminal_metadata(self):
-    return test_common.SERVICE_TERMINAL_METADATA
+    return grpc_test_common.SERVICE_TERMINAL_METADATA
 
   def code(self):
     return _intermediary_low.Code.OK
 
   def details(self):
-    return test_common.DETAILS
+    return grpc_test_common.DETAILS
 
   def metadata_transmitted(self, original_metadata, transmitted_metadata):
     return original_metadata is None or grpc_test_common.metadata_transmitted(

--- a/src/python/grpcio_test/grpc_test/test_common.py
+++ b/src/python/grpcio_test/grpc_test/test_common.py
@@ -31,6 +31,11 @@
 
 import collections
 
+INVOCATION_INITIAL_METADATA = ((b'0', b'abc'), (b'1', b'def'), (b'2', b'ghi'),)
+SERVICE_INITIAL_METADATA = ((b'3', b'jkl'), (b'4', b'mno'), (b'5', b'pqr'),)
+SERVICE_TERMINAL_METADATA = ((b'6', b'stu'), (b'7', b'vwx'), (b'8', b'yza'),)
+DETAILS = b'test details'
+
 
 def metadata_transmitted(original_metadata, transmitted_metadata):
   """Judges whether or not metadata was acceptably transmitted.


### PR DESCRIPTION
Post-Beta I may actually pursue why setUpModule and tearDownModule don't work with the load_tests protocol. If we're lucky maybe it's only a Python 2.x thing?