### PR TITLE
php: fix gce testing dockerfile

### DIFF
--- a/tools/dockerfile/grpc_php_base/Dockerfile
+++ b/tools/dockerfile/grpc_php_base/Dockerfile
@@ -75,7 +75,7 @@ RUN mv composer.phar /usr/local/bin/composer
 
 # Download the patched PHP protobuf so that PHP gRPC clients can be generated
 # from proto3 schemas.
-RUN git clone https://github.com/murgatroid99/Protobuf-PHP.git /var/local/git/protobuf-php
+RUN git clone https://github.com/stanley-cheung/Protobuf-PHP.git /var/local/git/protobuf-php
 
 # Install ruby (via RVM) as ruby tools are dependencies for building Protobuf
 # PHP extensions.


### PR DESCRIPTION
Donna sent me this error on our GCE testing suite:

```
PHP Fatal error:  Call to a member function _clientStreamRequest() on string in /var/local/git/grpc/src/php/tests/interop/test.php on line 37
```

Pretty sure that's because we updated codegen a while ago.