### PR TITLE
Move static value grpc::string_ref::npos definition to cc file

### DIFF
--- a/include/grpc++/support/string_ref.h
+++ b/include/grpc++/support/string_ref.h
@@ -53,7 +53,7 @@ class string_ref {
   typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
 
   // constants
-  const static size_t npos = size_t(-1);
+  const static size_t npos;
 
   // construct/copy.
   string_ref() : data_(nullptr), length_(0) {}

--- a/src/cpp/util/string_ref.cc
+++ b/src/cpp/util/string_ref.cc
@@ -39,7 +39,7 @@
 
 namespace grpc {
 
-const size_t string_ref::npos;
+const size_t string_ref::npos = size_t(-1);
 
 string_ref& string_ref::operator=(const string_ref& rhs) {
   data_ = rhs.data_;


### PR DESCRIPTION
A static variable must be defined in one place