### PR TITLE
Removing pessimizing moves.

### DIFF
--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -200,7 +200,7 @@ class AsyncEnd2endTest : public ::testing::TestWithParam<bool> {
   void ResetStub() {
     std::shared_ptr<Channel> channel =
         CreateChannel(server_address_.str(), InsecureCredentials());
-    stub_ = std::move(grpc::cpp::test::util::TestService::NewStub(channel));
+    stub_ = grpc::cpp::test::util::TestService::NewStub(channel);
   }
 
   void SendRpc(int num_rpcs) {
@@ -751,8 +751,7 @@ TEST_P(AsyncEnd2endTest, UnimplementedRpc) {
   std::shared_ptr<Channel> channel =
       CreateChannel(server_address_.str(), InsecureCredentials());
   std::unique_ptr<grpc::cpp::test::util::UnimplementedService::Stub> stub;
-  stub =
-      std::move(grpc::cpp::test::util::UnimplementedService::NewStub(channel));
+  stub = grpc::cpp::test::util::UnimplementedService::NewStub(channel);
   EchoRequest send_request;
   EchoResponse recv_response;
   Status recv_status;

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -380,7 +380,7 @@ class End2endTest : public ::testing::TestWithParam<bool> {
       channel_ = CreateChannel(proxyaddr.str(), InsecureCredentials());
     }
 
-    stub_ = std::move(grpc::cpp::test::util::TestService::NewStub(channel_));
+    stub_ = grpc::cpp::test::util::TestService::NewStub(channel_);
   }
 
   bool is_server_started_;
@@ -1080,8 +1080,7 @@ TEST_F(End2endTest, ChannelState) {
 TEST_F(End2endTest, NonExistingService) {
   ResetChannel();
   std::unique_ptr<grpc::cpp::test::util::UnimplementedService::Stub> stub;
-  stub =
-      std::move(grpc::cpp::test::util::UnimplementedService::NewStub(channel_));
+  stub = grpc::cpp::test::util::UnimplementedService::NewStub(channel_);
 
   EchoRequest request;
   EchoResponse response;

--- a/test/cpp/end2end/mock_test.cc
+++ b/test/cpp/end2end/mock_test.cc
@@ -245,7 +245,7 @@ class MockTest : public ::testing::Test {
   void ResetStub() {
     std::shared_ptr<Channel> channel =
         CreateChannel(server_address_.str(), InsecureCredentials());
-    stub_ = std::move(grpc::cpp::test::util::TestService::NewStub(channel));
+    stub_ = grpc::cpp::test::util::TestService::NewStub(channel);
   }
 
   std::unique_ptr<grpc::cpp::test::util::TestService::Stub> stub_;

--- a/test/cpp/end2end/shutdown_test.cc
+++ b/test/cpp/end2end/shutdown_test.cc
@@ -94,7 +94,7 @@ class ShutdownTest : public ::testing::Test {
   void ResetStub() {
     string target = "dns:localhost:" + to_string(port_);
     channel_ = CreateChannel(target, InsecureCredentials());
-    stub_ = std::move(grpc::cpp::test::util::TestService::NewStub(channel_));
+    stub_ = grpc::cpp::test::util::TestService::NewStub(channel_);
   }
 
   string to_string(const int number) {


### PR DESCRIPTION
These have been reported by a (very recent) build of clang and its new -Wpessimizing-move option.