### PR TITLE
Fix bugs that were causing auth interop tests to fail

### DIFF
--- a/src/node/interop/interop_client.js
+++ b/src/node/interop/interop_client.js
@@ -44,7 +44,7 @@ var assert = require('assert');
 
 var AUTH_SCOPE = 'https://www.googleapis.com/auth/xapi.zoo';
 var AUTH_SCOPE_RESPONSE = 'xapi.zoo';
-var AUTH_USER = ('155450119199-3psnrh1sdr3d8cpj1v46naggf81mhdnk' +
+var AUTH_USER = ('155450119199-vefjjaekcc6cmsd5914v6lqufunmh9ue' +
     '@developer.gserviceaccount.com');
 var COMPUTE_ENGINE_USER = ('155450119199-r5aaqa2vqoa9g5mv2m6s3m1l293rlmel' +
     '@developer.gserviceaccount.com');
@@ -321,7 +321,7 @@ function oauth2Test(expected_user, scope, per_rpc, client, done) {
     credential.getAccessToken(function(err, token) {
       assert.ifError(err);
       var updateMetadata = function(authURI, metadata, callback) {
-        metadata.Add('authorization', 'Bearer ' + token);
+        metadata.add('authorization', 'Bearer ' + token);
         callback(null, metadata);
       };
       var makeTestCall = function(error, client_metadata) {
@@ -336,10 +336,10 @@ function oauth2Test(expected_user, scope, per_rpc, client, done) {
         }, client_metadata);
       };
       if (per_rpc) {
-        updateMetadata('', {}, makeTestCall);
+        updateMetadata('', new grpc.Metadata(), makeTestCall);
       } else {
         client.$updateMetadata = updateMetadata;
-        makeTestCall(null, {});
+        makeTestCall(null, new grpc.Metadata());
       }
     });
   });

--- a/src/node/src/client.js
+++ b/src/node/src/client.js
@@ -637,7 +637,7 @@ exports.makeClientConstructor = function(methods, serviceName) {
     // Remove the optional DNS scheme, trailing port, and trailing backslash
     address = address.replace(/^(dns:\/{3})?([^:\/]+)(:\d+)?\/?$/, '$2');
     this.$server_address = address;
-    this.$auth_uri = 'https://' + this.server_address + '/' + serviceName;
+    this.$auth_uri = 'https://' + this.$server_address + '/' + serviceName;
     this.$updateMetadata = updateMetadata;
   }
 


### PR DESCRIPTION
Also, change the hard-coded `AUTH_USER`, because something happened to the old service account token.