### PR TITLE
PHP: fix jenkins macos build error

### DIFF
--- a/tools/run_tests/build_php.sh
+++ b/tools/run_tests/build_php.sh
@@ -46,3 +46,6 @@ cd ext/grpc
 phpize
 ./configure --enable-grpc=$root
 make
+
+# in some jenkins macos machine, somehow the PHP build script can't find libgrpc.dylib
+export DYLD_LIBRARY_PATH=$(pwd)/libs/$config


### PR DESCRIPTION
```
PHP Warning:  PHP Startup: Unable to load dynamic library '../ext/grpc/modules/grpc.so' - dlopen(../ext/grpc/modules/grpc.so, 9): Library not loaded: libgrpc.dylib
```