### PR TITLE
Expose per-call credentials to Python

### DIFF
--- a/src/python/grpcio/grpc/_adapter/_c/types.h
+++ b/src/python/grpcio/grpc/_adapter/_c/types.h
@@ -112,6 +112,8 @@ void pygrpc_Call_dealloc(Call *self);
 PyObject *pygrpc_Call_start_batch(Call *self, PyObject *args, PyObject *kwargs);
 PyObject *pygrpc_Call_cancel(Call *self, PyObject *args, PyObject *kwargs);
 PyObject *pygrpc_Call_peer(Call *self);
+PyObject *pygrpc_Call_set_credentials(Call *self, PyObject *args,
+                                      PyObject *kwargs);
 extern PyTypeObject pygrpc_Call_type;
 
 

--- a/src/python/grpcio/grpc/_adapter/_c/types/call.c
+++ b/src/python/grpcio/grpc/_adapter/_c/types/call.c
@@ -43,6 +43,8 @@ PyMethodDef pygrpc_Call_methods[] = {
     {"start_batch", (PyCFunction)pygrpc_Call_start_batch, METH_KEYWORDS, ""},
     {"cancel", (PyCFunction)pygrpc_Call_cancel, METH_KEYWORDS, ""},
     {"peer", (PyCFunction)pygrpc_Call_peer, METH_NOARGS, ""},
+    {"set_credentials", (PyCFunction)pygrpc_Call_set_credentials, METH_KEYWORDS,
+     ""},
     {NULL}
 };
 const char pygrpc_Call_doc[] = "See grpc._adapter._types.Call.";
@@ -168,4 +170,17 @@ PyObject *pygrpc_Call_peer(Call *self) {
   PyObject *py_peer = PyString_FromString(peer);
   gpr_free(peer);
   return py_peer;
+}
+PyObject *pygrpc_Call_set_credentials(Call *self, PyObject *args,
+                                      PyObject *kwargs) {
+  ClientCredentials *creds;
+  grpc_call_error errcode;
+  static char *keywords[] = {"creds", NULL};
+  if (!PyArg_ParseTupleAndKeywords(
+      args, kwargs, "O!:set_credentials", keywords,
+      &pygrpc_ClientCredentials_type, &creds)) {
+    return NULL;
+  }
+  errcode = grpc_call_set_credentials(self->c_call, creds->c_creds);
+  return PyInt_FromLong(errcode);
 }

--- a/src/python/grpcio/grpc/_adapter/_intermediary_low.py
+++ b/src/python/grpcio/grpc/_adapter/_intermediary_low.py
@@ -163,6 +163,9 @@ class Call(object):
   def cancel(self):
     return self._internal.cancel()
 
+  def set_credentials(self, creds):
+    return self._internal.set_credentials(creds)
+
 
 class Channel(object):
   """Adapter from old _low.Channel interface to new _low.Channel."""

--- a/src/python/grpcio/grpc/_adapter/_low.py
+++ b/src/python/grpcio/grpc/_adapter/_low.py
@@ -78,6 +78,9 @@ class Call(_types.Call):
   def peer(self):
     return self.call.peer()
 
+  def set_credentials(self, creds):
+    return self.call.set_credentials(creds)
+
 
 class Channel(_types.Channel):
 


### PR DESCRIPTION
Just exposes the credentials; the `per_rpc_creds` interop test will eventually cover this.