### PR TITLE
Fix C# nuget package building

### DIFF
--- a/src/csharp/build_packages.bat
+++ b/src/csharp/build_packages.bat
@@ -5,6 +5,9 @@ set VERSION=0.7.0
 set CORE_VERSION=0.11.0
 set PROTOBUF_VERSION=3.0.0-alpha4
 
+@rem Packages that depend on prerelease packages (like Google.Protobuf) need to have prerelease suffix as well.
+set VERSION_WITH_BETA=0.7.0-beta
+
 @rem Adjust the location of nuget.exe
 set NUGET=C:\nuget\nuget.exe
 
@@ -20,7 +23,7 @@ endlocal
 %NUGET% pack ..\..\vsprojects\nuget_package\grpc.native.csharp_ext.nuspec -Version %CORE_VERSION% || goto :error
 %NUGET% pack Grpc.Auth\Grpc.Auth.nuspec -Symbols -Version %VERSION% || goto :error
 %NUGET% pack Grpc.Core\Grpc.Core.nuspec -Symbols -Version %VERSION% -Properties GrpcNativeCsharpExtVersion=%CORE_VERSION% || goto :error
-%NUGET% pack Grpc.HealthCheck\Grpc.HealthCheck.nuspec -Symbols -Version %VERSION% -Properties ProtobufVersion=%PROTOBUF_VERSION% || goto :error
+%NUGET% pack Grpc.HealthCheck\Grpc.HealthCheck.nuspec -Symbols -Version %VERSION_WITH_BETA% -Properties ProtobufVersion=%PROTOBUF_VERSION% || goto :error
 %NUGET% pack Grpc.Tools.nuspec -Version %VERSION% || goto :error
 %NUGET% pack Grpc.nuspec -Version %VERSION% || goto :error
 

--- a/vsprojects/nuget_package/buildall.bat
+++ b/vsprojects/nuget_package/buildall.bat
@@ -39,7 +39,7 @@ endlocal
 goto :eof
 
 :build
-msbuild /P:Platform=%1 /P:Configuration=%2 /P:PlatformToolset=%3 /P:OutDir=..\nuget_package\output\%3\%1\%2\ /P:IntDir=..\nuget_package\tmp\%3\%1\%2\ ..\grpc_csharp_ext.sln || goto :eof
+msbuild /P:Platform=%1 /P:Configuration=%2 /P:PlatformToolset=%3 /P:OutDir=..\..\nuget_package\output\%3\%1\%2\ /P:IntDir=..\..\nuget_package\tmp\%3\%1\%2\ ..\grpc_csharp_ext.sln || goto :eof
 goto :eof
 
 

--- a/vsprojects/nuget_package/grpc.native.csharp_ext.nuspec
+++ b/vsprojects/nuget_package/grpc.native.csharp_ext.nuspec
@@ -2,21 +2,21 @@
 <package>
   <metadata>
     <id>grpc.native.csharp_ext</id>
-    <version>0.10.0</version>
+    <version>$version$</version>
     <authors>Google Inc.</authors>
     <owners>grpc-packages</owners>
     <licenseUrl>https://github.com/grpc/grpc/blob/master/LICENSE</licenseUrl>
     <projectUrl>http://github.com/grpc/grpc</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Native extension needed by gRPC C# library. This is not the package you are looking for, it is only meant to be used as a dependency.</description>
-    <releaseNotes>Release of gRPC C core 0.10.0 libraries.</releaseNotes>
+    <releaseNotes>Release of gRPC C core $version$ libraries.</releaseNotes>
     <copyright>Copyright 2015</copyright>
     <title>gRPC C# Native Extension</title>
     <summary>Native library required by gRPC C#</summary>
     <tags>gRPC native</tags>
 	<dependencies>
       <dependency id="grpc.dependencies.zlib.redist" version="1.2.8.9" />
-	  <dependency id="grpc.dependencies.openssl.redist" version="1.0.2.2" />
+	  <dependency id="grpc.dependencies.openssl.redist" version="1.0.2.3" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Nuget package building was partially broken by #3119.
This fixed that and adds some other minor fixes.