### PR TITLE
Fix handling of libgrpc_csharp_ext.so

### DIFF
--- a/debian/libgrpc-dev.install
+++ b/debian/libgrpc-dev.install
@@ -3,3 +3,4 @@ usr/lib/libgpr.a
 usr/lib/libgpr.so
 usr/lib/libgrpc.a
 usr/lib/libgrpc.so
+usr/lib/libgrpc_csharp_ext.so

--- a/debian/libgrpc0-cil.install
+++ b/debian/libgrpc0-cil.install
@@ -1,1 +1,1 @@
-usr/lib/libgrpc_csharp_ext.so*
+usr/lib/libgrpc_csharp_ext.so.*


### PR DESCRIPTION
Include the bare .so symlink in the -dev package, not the library
package

This is for part of #3199 and #3087