### PR TITLE
Interop test update

### DIFF
--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -120,11 +120,10 @@ int main(int argc, char** argv) {
     grpc::string json_key = GetServiceAccountJsonKey();
     client.DoJwtTokenCreds(json_key);
   } else if (FLAGS_test_case == "oauth2_auth_token") {
-    grpc::string json_key = GetServiceAccountJsonKey();
-    client.DoOauth2AuthToken(json_key, FLAGS_oauth_scope);
+    client.DoOauth2AuthToken(FLAGS_default_service_account, FLAGS_oauth_scope);
   } else if (FLAGS_test_case == "per_rpc_creds") {
     grpc::string json_key = GetServiceAccountJsonKey();
-    client.DoPerRpcCreds(json_key, FLAGS_oauth_scope);
+    client.DoPerRpcCreds(json_key);
   } else if (FLAGS_test_case == "status_code_and_message") {
     client.DoStatusWithMessage();
   } else if (FLAGS_test_case == "all") {
@@ -143,8 +142,9 @@ int main(int argc, char** argv) {
     if (FLAGS_enable_ssl) {
       grpc::string json_key = GetServiceAccountJsonKey();
       client.DoJwtTokenCreds(json_key);
-      client.DoOauth2AuthToken(json_key, FLAGS_oauth_scope);
-      client.DoPerRpcCreds(json_key, FLAGS_oauth_scope);
+      client.DoOauth2AuthToken(
+          FLAGS_default_service_account, FLAGS_oauth_scope);
+      client.DoPerRpcCreds(json_key);
     }
     // compute_engine_creds only runs in GCE.
   } else {

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -204,7 +204,7 @@ void InteropClient::DoOauth2AuthToken(const grpc::string& username,
 
 void InteropClient::DoPerRpcCreds(const grpc::string& json_key) {
   gpr_log(GPR_INFO,
-          "Sending a unary rpc with per-rpc raw oauth2 access token ...");
+          "Sending a unary rpc with per-rpc JWT access token ...");
   SimpleRequest request;
   SimpleResponse response;
   request.set_fill_username(true);
@@ -222,7 +222,7 @@ void InteropClient::DoPerRpcCreds(const grpc::string& json_key) {
   AssertOkOrPrintErrorStatus(s);
   GPR_ASSERT(!response.username().empty());
   GPR_ASSERT(json_key.find(response.username()) != grpc::string::npos);
-  gpr_log(GPR_INFO, "Unary with per-rpc oauth2 access token done.");
+  gpr_log(GPR_INFO, "Unary with per-rpc JWT access token done.");
 }
 
 void InteropClient::DoJwtTokenCreds(const grpc::string& username) {

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -196,35 +196,32 @@ void InteropClient::DoOauth2AuthToken(const grpc::string& username,
   AssertOkOrPrintErrorStatus(s);
   GPR_ASSERT(!response.username().empty());
   GPR_ASSERT(!response.oauth_scope().empty());
-  GPR_ASSERT(username.find(response.username()) != grpc::string::npos);
+  GPR_ASSERT(username == response.username());
   const char* oauth_scope_str = response.oauth_scope().c_str();
   GPR_ASSERT(oauth_scope.find(oauth_scope_str) != grpc::string::npos);
   gpr_log(GPR_INFO, "Unary with oauth2 access token credentials done.");
 }
 
-void InteropClient::DoPerRpcCreds(const grpc::string& username,
-                                  const grpc::string& oauth_scope) {
+void InteropClient::DoPerRpcCreds(const grpc::string& json_key) {
   gpr_log(GPR_INFO,
           "Sending a unary rpc with per-rpc raw oauth2 access token ...");
   SimpleRequest request;
   SimpleResponse response;
   request.set_fill_username(true);
-  request.set_fill_oauth_scope(true);
   std::unique_ptr<TestService::Stub> stub(TestService::NewStub(channel_));
 
   ClientContext context;
-  grpc::string access_token = GetOauth2AccessToken();
-  std::shared_ptr<Credentials> creds = AccessTokenCredentials(access_token);
+  std::chrono::seconds token_lifetime = std::chrono::hours(1);
+  std::shared_ptr<Credentials> creds =
+      ServiceAccountJWTAccessCredentials(json_key, token_lifetime.count());
+
   context.set_credentials(creds);
 
   Status s = stub->UnaryCall(&context, request, &response);
 
   AssertOkOrPrintErrorStatus(s);
   GPR_ASSERT(!response.username().empty());
-  GPR_ASSERT(!response.oauth_scope().empty());
-  GPR_ASSERT(username.find(response.username()) != grpc::string::npos);
-  const char* oauth_scope_str = response.oauth_scope().c_str();
-  GPR_ASSERT(oauth_scope.find(oauth_scope_str) != grpc::string::npos);
+  GPR_ASSERT(json_key.find(response.username()) != grpc::string::npos);
   gpr_log(GPR_INFO, "Unary with per-rpc oauth2 access token done.");
 }
 

--- a/test/cpp/interop/interop_client.h
+++ b/test/cpp/interop/interop_client.h
@@ -68,12 +68,11 @@ class InteropClient {
   void DoJwtTokenCreds(const grpc::string& username);
   void DoComputeEngineCreds(const grpc::string& default_service_account,
                             const grpc::string& oauth_scope);
-  // username is a string containing the user email
+  // username the GCE default service account email
   void DoOauth2AuthToken(const grpc::string& username,
                          const grpc::string& oauth_scope);
   // username is a string containing the user email
-  void DoPerRpcCreds(const grpc::string& username,
-                     const grpc::string& oauth_scope);
+  void DoPerRpcCreds(const grpc::string& json_key);
 
  private:
   void PerformLargeUnary(SimpleRequest* request, SimpleResponse* response);

--- a/tools/gce_setup/grpc_docker.sh
+++ b/tools/gce_setup/grpc_docker.sh
@@ -530,7 +530,20 @@ grpc_cloud_prod_auth_test_args() {
 
   [[ -n $1 ]] && {  # client_type
     case $1 in
-      cxx|go|java|node|php|python|ruby|csharp_mono)
+      go|java|node|php|python|ruby|csharp_mono)
+        grpc_client_platform='Docker'
+        grpc_gen_test_cmd+="_gen_$1_cmd"
+        declare -F $grpc_gen_test_cmd >> /dev/null || {
+          echo "-f: test_func for $1 => $grpc_gen_test_cmd is not defined" 1>&2
+          return 2
+        }
+        shift
+        ;;
+      cxx)
+        if [ "$test_case" == "oauth2_auth_token" ]
+        then
+          test_command="compute_engine_creds"
+        fi
         grpc_client_platform='Docker'
         grpc_gen_test_cmd+="_gen_$1_cmd"
         declare -F $grpc_gen_test_cmd >> /dev/null || {

--- a/tools/gce_setup/grpc_docker.sh
+++ b/tools/gce_setup/grpc_docker.sh
@@ -542,7 +542,7 @@ grpc_cloud_prod_auth_test_args() {
       cxx)
         if [ "$test_case" == "oauth2_auth_token" ]
         then
-          test_command="compute_engine_creds"
+          grpc_gen_test_cmd="grpc_cloud_prod_auth_compute_engine_creds"
         fi
         grpc_client_platform='Docker'
         grpc_gen_test_cmd+="_gen_$1_cmd"


### PR DESCRIPTION
In sync with spec change #3198.

@donnadionne I tested oauth2_auth_token case and it passed. per_rpc_creds failed but jwt_token_creds failed as well, I guess it is because of the key file change.