### PR TITLE
Make headers a "real" @property

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -169,10 +169,8 @@ extern id const kGRPCTrailersKey;
 //
 // After the call is started, trying to modify this property is an error.
 //
-// For convenience, the property is initialized to an empty NSMutableDictionary, and the setter
-// accepts (and copies) both mutable and immutable dictionaries.
-- (id<GRPCRequestHeaders>)requestHeaders; // nonatomic
-- (void)setRequestHeaders:(NSDictionary *)requestHeaders; // nonatomic, copy
+// The property is initialized to an empty NSMutableDictionary.
+@property(atomic, readonly) id<GRPCRequestHeaders> requestHeaders;
 
 // This dictionary is populated with the HTTP headers received from the server. This happens before
 // any response message is received from the server. It has the same structure as the request

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -130,20 +130,6 @@ NSString * const kGRPCTrailersKey = @"io.grpc.TrailersKey";
   return self;
 }
 
-#pragma mark Metadata
-
-- (id<GRPCRequestHeaders>)requestHeaders {
-  return _requestHeaders;
-}
-
-- (void)setRequestHeaders:(NSDictionary *)requestHeaders {
-  GRPCRequestHeaders *newHeaders = [[GRPCRequestHeaders alloc] initWithCall:self];
-  for (id key in requestHeaders) {
-    newHeaders[key] = requestHeaders[key];
-  }
-  _requestHeaders = newHeaders;
-}
-
 #pragma mark Finish
 
 - (void)finishWithError:(NSError *)errorOrNil {

--- a/src/objective-c/examples/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/examples/RemoteTestClient/RemoteTest.podspec
@@ -15,14 +15,14 @@ Pod::Spec.new do |s|
     ms.source_files = "*.pbobjc.{h,m}"
     ms.header_mappings_dir = "."
     ms.requires_arc = false
-    ms.dependency "Protobuf", "~> 3.0.0-alpha-3"
+    ms.dependency "Protobuf", "~> 3.0.0-alpha-4"
   end
 
   s.subspec "Services" do |ss|
     ss.source_files = "*.pbrpc.{h,m}"
     ss.header_mappings_dir = "."
     ss.requires_arc = true
-    ss.dependency "gRPC", "~> 0.5"
+    ss.dependency "gRPC", "~> 0.7"
     ss.dependency "#{s.name}/Messages"
   end
 end

--- a/src/objective-c/examples/SwiftSample/Bridging-Header.h
+++ b/src/objective-c/examples/SwiftSample/Bridging-Header.h
@@ -39,6 +39,7 @@
 #import <RxLibrary/GRXWriter+Immediate.h>
 #import <GRPCClient/GRPCCall.h>
 #import <ProtoRPC/ProtoMethod.h>
+#import <ProtoRPC/ProtoRPC.h>
 #import <RemoteTest/Test.pbrpc.h>
 
 #endif

--- a/src/objective-c/examples/SwiftSample/Podfile
+++ b/src/objective-c/examples/SwiftSample/Podfile
@@ -1,6 +1,7 @@
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
+pod 'Protobuf', :path => "../../../../third_party/protobuf"
 pod 'gRPC', :path => "../../../.."
 pod 'RemoteTest', :path => "../RemoteTestClient"
 


### PR DESCRIPTION
As found during #3175, Swift really wants Objective-C properties to be defined with the `@property` syntax (or at least won't buy our trick of the setter accepting a superclass of what the getter returns). So this eliminates that part of the API before we go beta. It's actually the last breaking change :)

What we supported before as
```objective-c
call.requestHeaders = @{...};
```
can now be supported as
```objective-c
[call.requestHeaders addEntriesFromDictionary:@{...}];
```
(which is _not yet_ part of `GRPCRequestHeaders`, but is part of `NSMutableDictionary` and can be added without breaking).

It also updates the Swift sample app to set and get metadata, now that doing it is nice.