### PR TITLE
Update debian install instructions

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -11,12 +11,12 @@ wiki pages:
 
 On Linux (Debian):
 
- Note: you will need to add the Debian 'testing' distribution to your sources
+ Note: you will need to add the Debian 'jessie-backports' distribution to your sources
  file first.
 
  Add the following line to your `/etc/apt/sources.list` file:
 
-   deb http://ftp.us.debian.org/debian testing main contrib non-free
+   deb http://http.debian.net/debian jessie-backports main
 
  Install the gRPC library:
 

--- a/src/node/README.md
+++ b/src/node/README.md
@@ -11,10 +11,10 @@ Beta
 
 **Linux (Debian):**
 
-Add [Debian testing][] to your `sources.list` file. Example:
+Add [Debian jessie-backports][] to your `sources.list` file. Example:
 
 ```sh
-echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" | \
+echo "deb http://http.debian.net/debian jessie-backports main" | \
 sudo tee -a /etc/apt/sources.list
 ```
 
@@ -113,4 +113,4 @@ An object with factory methods for creating credential objects for servers.
 
 [homebrew]:http://brew.sh
 [gRPC install script]:https://raw.githubusercontent.com/grpc/homebrew-grpc/master/scripts/install
-[Debian testing]:https://www.debian.org/releases/stretch/
+[Debian jessie-backports]:http://backports.debian.org/Instructions/

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -32,10 +32,10 @@ $ sudo php -d detect_unicode=0 go-pear.phar
 
 **Linux (Debian):**
 
-Add [Debian testing][] to your `sources.list` file. Example:
+Add [Debian jessie-backports][] to your `sources.list` file. Example:
 
 ```sh
-echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" | \
+echo "deb http://http.debian.net/debian jessie-backports main" | \
 sudo tee -a /etc/apt/sources.list
 ```
 
@@ -167,4 +167,4 @@ $ ./bin/run_gen_code_test.sh
 [homebrew]:http://brew.sh
 [gRPC install script]:https://raw.githubusercontent.com/grpc/homebrew-grpc/master/scripts/install
 [Node]:https://github.com/grpc/grpc/tree/master/src/node/examples
-[Debian testing]:https://www.debian.org/releases/stretch/
+[Debian jessie-backports]:http://backports.debian.org/Instructions/

--- a/src/python/README.md
+++ b/src/python/README.md
@@ -16,10 +16,10 @@ INSTALLATION
 
 **Linux (Debian):**
 
-Add [Debian testing][] to your `sources.list` file. Example:
+Add [Debian jessie-backports][] to your `sources.list` file. Example:
 
 ```sh
-echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" | \
+echo "deb http://http.debian.net/debian jessie-backports main" | \
 sudo tee -a /etc/apt/sources.list
 ```
 
@@ -92,4 +92,4 @@ $ ../../tools/distrib/python/submit.py
 [gRPC install script]:https://raw.githubusercontent.com/grpc/homebrew-grpc/master/scripts/install
 [Quick Start]:http://www.grpc.io/docs/tutorials/basic/python.html
 [detailed example]:http://www.grpc.io/docs/installation/python.html
-[Debian testing]:https://www.debian.org/releases/stretch/
+[Debian jessie-backports]:http://backports.debian.org/Instructions/

--- a/src/ruby/README.md
+++ b/src/ruby/README.md
@@ -19,10 +19,10 @@ INSTALLATION
 
 **Linux (Debian):**
 
-Add [Debian testing][] to your `sources.list` file. Example:
+Add [Debian jessie-backports][] to your `sources.list` file. Example:
 
 ```sh
-echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" | \
+echo "deb http://http.debian.net/debian jessie-backports main" | \
 sudo tee -a /etc/apt/sources.list
 ```
 
@@ -99,4 +99,4 @@ Directory structure is the layout for [ruby extensions][]
 [ruby extensions]:http://guides.rubygems.org/gems-with-extensions/
 [rubydoc]: http://www.rubydoc.info/gems/grpc
 [grpc.io]: http://www.grpc.io/docs/installation/ruby.html
-[Debian testing]:https://www.debian.org/releases/stretch/
+[Debian jessie-backports]:http://backports.debian.org/Instructions/


### PR DESCRIPTION
The `libgrpc-dev` debian package made it into `jessie-backports`! There's no need for manipulating `sources.list` file before installing our package.

Previously #3142 