### PR TITLE
Make servers and stubs context managers

### DIFF
--- a/src/python/grpcio/grpc/beta/_stub.py
+++ b/src/python/grpcio/grpc/beta/_stub.py
@@ -49,6 +49,12 @@ class _AutoIntermediary(object):
   def __getattr__(self, attr):
     return getattr(self._delegate, attr)
 
+  def __enter__(self):
+    return self
+
+  def __exit__(self, exc_type, exc_val, exc_tb):
+    return False
+
   def __del__(self):
     self._on_deletion()
 


### PR DESCRIPTION
Have some good ideas on how optional-use-of-a-stub-as-a-context-manager might work but not certain enough to want to implement them right away.