### PR TITLE
Bump version of gRPC.podspec to 0.11

### DIFF
--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -45,8 +45,8 @@ Pod::Spec.new do |s|
   # s.source = { :git => 'https://github.com/grpc/grpc.git',
   #              :tag => 'release-0_11_0-objectivec-0.11.0' }
 
-  s.ios.deployment_target = '6.0'
-  s.osx.deployment_target = '10.8'
+  s.ios.deployment_target = '7.1'
+  s.osx.deployment_target = '10.9'
   s.requires_arc = true
 
   objc_dir = 'src/objective-c'

--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -36,14 +36,14 @@
 
 Pod::Spec.new do |s|
   s.name     = 'gRPC'
-  s.version  = '0.7.0'
+  s.version  = '0.11.0'
   s.summary  = 'gRPC client library for iOS/OSX'
   s.homepage = 'http://www.grpc.io'
   s.license  = 'New BSD'
   s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
 
   # s.source = { :git => 'https://github.com/grpc/grpc.git',
-  #              :tag => 'release-0_10_0-objectivec-0.6.0' }
+  #              :tag => 'release-0_11_0-objectivec-0.11.0' }
 
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
@@ -585,6 +585,6 @@ Pod::Spec.new do |s|
 
     ss.dependency 'gRPC/GRPCClient'
     ss.dependency 'gRPC/RxLibrary'
-    ss.dependency 'Protobuf', '~> 3.0.0-alpha-3'
+    ss.dependency 'Protobuf', '~> 3.0.0-alpha-4'
   end
 end


### PR DESCRIPTION
Technically unnecessary, but for consistency with the other beta releases.

This assumes the protobuf release will be tagged "`v3.0.0-alpha-4.1`", per [this branch](https://github.com/google/protobuf/blob/v3.0.0-alpha-4.1/Protobuf.podspec). @TeBoring, if you plan to use another tag (`v3.0.0-beta-1`?), let me know to change this accordingly.

CC: @nicolasnoble for info about the Protobuf commit to point the submodule to.