### PR TITLE
Update namespace of C# routeguide example

### DIFF
--- a/examples/csharp/route_guide/RouteGuide/RouteGuide.cs
+++ b/examples/csharp/route_guide/RouteGuide/RouteGuide.cs
@@ -7,7 +7,7 @@ using pb = global::Google.Protobuf;
 using pbc = global::Google.Protobuf.Collections;
 using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
-namespace Examples {
+namespace Routeguide {
 
   namespace Proto {
 
@@ -23,29 +23,29 @@ namespace Examples {
       static RouteGuide() {
         byte[] descriptorData = global::System.Convert.FromBase64String(
             string.Concat(
-              "ChFyb3V0ZV9ndWlkZS5wcm90bxIIZXhhbXBsZXMiLAoFUG9pbnQSEAoIbGF0", 
-              "aXR1ZGUYASABKAUSEQoJbG9uZ2l0dWRlGAIgASgFIkUKCVJlY3RhbmdsZRIb", 
-              "CgJsbxgBIAEoCzIPLmV4YW1wbGVzLlBvaW50EhsKAmhpGAIgASgLMg8uZXhh", 
-              "bXBsZXMuUG9pbnQiOgoHRmVhdHVyZRIMCgRuYW1lGAEgASgJEiEKCGxvY2F0", 
-              "aW9uGAIgASgLMg8uZXhhbXBsZXMuUG9pbnQiPwoJUm91dGVOb3RlEiEKCGxv", 
-              "Y2F0aW9uGAEgASgLMg8uZXhhbXBsZXMuUG9pbnQSDwoHbWVzc2FnZRgCIAEo", 
-              "CSJiCgxSb3V0ZVN1bW1hcnkSEwoLcG9pbnRfY291bnQYASABKAUSFQoNZmVh", 
-              "dHVyZV9jb3VudBgCIAEoBRIQCghkaXN0YW5jZRgDIAEoBRIUCgxlbGFwc2Vk", 
-              "X3RpbWUYBCABKAUy9QEKClJvdXRlR3VpZGUSMgoKR2V0RmVhdHVyZRIPLmV4", 
-              "YW1wbGVzLlBvaW50GhEuZXhhbXBsZXMuRmVhdHVyZSIAEjoKDExpc3RGZWF0", 
-              "dXJlcxITLmV4YW1wbGVzLlJlY3RhbmdsZRoRLmV4YW1wbGVzLkZlYXR1cmUi", 
-              "ADABEjoKC1JlY29yZFJvdXRlEg8uZXhhbXBsZXMuUG9pbnQaFi5leGFtcGxl", 
-              "cy5Sb3V0ZVN1bW1hcnkiACgBEjsKCVJvdXRlQ2hhdBITLmV4YW1wbGVzLlJv", 
-              "dXRlTm90ZRoTLmV4YW1wbGVzLlJvdXRlTm90ZSIAKAEwAUIPCgdleC5ncnBj", 
-              "ogIDUlRHYgZwcm90bzM="));
+              "ChFyb3V0ZV9ndWlkZS5wcm90bxIKcm91dGVndWlkZSIsCgVQb2ludBIQCghs", 
+              "YXRpdHVkZRgBIAEoBRIRCglsb25naXR1ZGUYAiABKAUiSQoJUmVjdGFuZ2xl", 
+              "Eh0KAmxvGAEgASgLMhEucm91dGVndWlkZS5Qb2ludBIdCgJoaRgCIAEoCzIR", 
+              "LnJvdXRlZ3VpZGUuUG9pbnQiPAoHRmVhdHVyZRIMCgRuYW1lGAEgASgJEiMK", 
+              "CGxvY2F0aW9uGAIgASgLMhEucm91dGVndWlkZS5Qb2ludCJBCglSb3V0ZU5v", 
+              "dGUSIwoIbG9jYXRpb24YASABKAsyES5yb3V0ZWd1aWRlLlBvaW50Eg8KB21l", 
+              "c3NhZ2UYAiABKAkiYgoMUm91dGVTdW1tYXJ5EhMKC3BvaW50X2NvdW50GAEg", 
+              "ASgFEhUKDWZlYXR1cmVfY291bnQYAiABKAUSEAoIZGlzdGFuY2UYAyABKAUS", 
+              "FAoMZWxhcHNlZF90aW1lGAQgASgFMoUCCgpSb3V0ZUd1aWRlEjYKCkdldEZl", 
+              "YXR1cmUSES5yb3V0ZWd1aWRlLlBvaW50GhMucm91dGVndWlkZS5GZWF0dXJl", 
+              "IgASPgoMTGlzdEZlYXR1cmVzEhUucm91dGVndWlkZS5SZWN0YW5nbGUaEy5y", 
+              "b3V0ZWd1aWRlLkZlYXR1cmUiADABEj4KC1JlY29yZFJvdXRlEhEucm91dGVn", 
+              "dWlkZS5Qb2ludBoYLnJvdXRlZ3VpZGUuUm91dGVTdW1tYXJ5IgAoARI/CglS", 
+              "b3V0ZUNoYXQSFS5yb3V0ZWd1aWRlLlJvdXRlTm90ZRoVLnJvdXRlZ3VpZGUu", 
+              "Um91dGVOb3RlIgAoATABQg8KB2V4LmdycGOiAgNSVEdiBnByb3RvMw=="));
         descriptor = pbr::FileDescriptor.InternalBuildGeneratedFileFrom(descriptorData,
             new pbr::FileDescriptor[] { },
             new pbr::GeneratedCodeInfo(null, new pbr::GeneratedCodeInfo[] {
-              new pbr::GeneratedCodeInfo(typeof(global::Examples.Point), new[]{ "Latitude", "Longitude" }, null, null, null),
-              new pbr::GeneratedCodeInfo(typeof(global::Examples.Rectangle), new[]{ "Lo", "Hi" }, null, null, null),
-              new pbr::GeneratedCodeInfo(typeof(global::Examples.Feature), new[]{ "Name", "Location" }, null, null, null),
-              new pbr::GeneratedCodeInfo(typeof(global::Examples.RouteNote), new[]{ "Location", "Message" }, null, null, null),
-              new pbr::GeneratedCodeInfo(typeof(global::Examples.RouteSummary), new[]{ "PointCount", "FeatureCount", "Distance", "ElapsedTime" }, null, null, null)
+              new pbr::GeneratedCodeInfo(typeof(global::Routeguide.Point), new[]{ "Latitude", "Longitude" }, null, null, null),
+              new pbr::GeneratedCodeInfo(typeof(global::Routeguide.Rectangle), new[]{ "Lo", "Hi" }, null, null, null),
+              new pbr::GeneratedCodeInfo(typeof(global::Routeguide.Feature), new[]{ "Name", "Location" }, null, null, null),
+              new pbr::GeneratedCodeInfo(typeof(global::Routeguide.RouteNote), new[]{ "Location", "Message" }, null, null, null),
+              new pbr::GeneratedCodeInfo(typeof(global::Routeguide.RouteSummary), new[]{ "PointCount", "FeatureCount", "Distance", "ElapsedTime" }, null, null, null)
             }));
       }
       #endregion
@@ -59,7 +59,7 @@ namespace Examples {
     public static pb::MessageParser<Point> Parser { get { return _parser; } }
 
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Examples.Proto.RouteGuide.Descriptor.MessageTypes[0]; }
+      get { return global::Routeguide.Proto.RouteGuide.Descriptor.MessageTypes[0]; }
     }
 
     pbr::MessageDescriptor pb::IMessage.Descriptor {
@@ -187,7 +187,7 @@ namespace Examples {
     public static pb::MessageParser<Rectangle> Parser { get { return _parser; } }
 
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Examples.Proto.RouteGuide.Descriptor.MessageTypes[1]; }
+      get { return global::Routeguide.Proto.RouteGuide.Descriptor.MessageTypes[1]; }
     }
 
     pbr::MessageDescriptor pb::IMessage.Descriptor {
@@ -210,8 +210,8 @@ namespace Examples {
     }
 
     public const int LoFieldNumber = 1;
-    private global::Examples.Point lo_;
-    public global::Examples.Point Lo {
+    private global::Routeguide.Point lo_;
+    public global::Routeguide.Point Lo {
       get { return lo_; }
       set {
         lo_ = value;
@@ -219,8 +219,8 @@ namespace Examples {
     }
 
     public const int HiFieldNumber = 2;
-    private global::Examples.Point hi_;
-    public global::Examples.Point Hi {
+    private global::Routeguide.Point hi_;
+    public global::Routeguide.Point Hi {
       get { return hi_; }
       set {
         hi_ = value;
@@ -282,13 +282,13 @@ namespace Examples {
       }
       if (other.lo_ != null) {
         if (lo_ == null) {
-          lo_ = new global::Examples.Point();
+          lo_ = new global::Routeguide.Point();
         }
         Lo.MergeFrom(other.Lo);
       }
       if (other.hi_ != null) {
         if (hi_ == null) {
-          hi_ = new global::Examples.Point();
+          hi_ = new global::Routeguide.Point();
         }
         Hi.MergeFrom(other.Hi);
       }
@@ -303,14 +303,14 @@ namespace Examples {
             break;
           case 10: {
             if (lo_ == null) {
-              lo_ = new global::Examples.Point();
+              lo_ = new global::Routeguide.Point();
             }
             input.ReadMessage(lo_);
             break;
           }
           case 18: {
             if (hi_ == null) {
-              hi_ = new global::Examples.Point();
+              hi_ = new global::Routeguide.Point();
             }
             input.ReadMessage(hi_);
             break;
@@ -327,7 +327,7 @@ namespace Examples {
     public static pb::MessageParser<Feature> Parser { get { return _parser; } }
 
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Examples.Proto.RouteGuide.Descriptor.MessageTypes[2]; }
+      get { return global::Routeguide.Proto.RouteGuide.Descriptor.MessageTypes[2]; }
     }
 
     pbr::MessageDescriptor pb::IMessage.Descriptor {
@@ -359,8 +359,8 @@ namespace Examples {
     }
 
     public const int LocationFieldNumber = 2;
-    private global::Examples.Point location_;
-    public global::Examples.Point Location {
+    private global::Routeguide.Point location_;
+    public global::Routeguide.Point Location {
       get { return location_; }
       set {
         location_ = value;
@@ -425,7 +425,7 @@ namespace Examples {
       }
       if (other.location_ != null) {
         if (location_ == null) {
-          location_ = new global::Examples.Point();
+          location_ = new global::Routeguide.Point();
         }
         Location.MergeFrom(other.Location);
       }
@@ -444,7 +444,7 @@ namespace Examples {
           }
           case 18: {
             if (location_ == null) {
-              location_ = new global::Examples.Point();
+              location_ = new global::Routeguide.Point();
             }
             input.ReadMessage(location_);
             break;
@@ -461,7 +461,7 @@ namespace Examples {
     public static pb::MessageParser<RouteNote> Parser { get { return _parser; } }
 
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Examples.Proto.RouteGuide.Descriptor.MessageTypes[3]; }
+      get { return global::Routeguide.Proto.RouteGuide.Descriptor.MessageTypes[3]; }
     }
 
     pbr::MessageDescriptor pb::IMessage.Descriptor {
@@ -484,8 +484,8 @@ namespace Examples {
     }
 
     public const int LocationFieldNumber = 1;
-    private global::Examples.Point location_;
-    public global::Examples.Point Location {
+    private global::Routeguide.Point location_;
+    public global::Routeguide.Point Location {
       get { return location_; }
       set {
         location_ = value;
@@ -556,7 +556,7 @@ namespace Examples {
       }
       if (other.location_ != null) {
         if (location_ == null) {
-          location_ = new global::Examples.Point();
+          location_ = new global::Routeguide.Point();
         }
         Location.MergeFrom(other.Location);
       }
@@ -574,7 +574,7 @@ namespace Examples {
             break;
           case 10: {
             if (location_ == null) {
-              location_ = new global::Examples.Point();
+              location_ = new global::Routeguide.Point();
             }
             input.ReadMessage(location_);
             break;
@@ -595,7 +595,7 @@ namespace Examples {
     public static pb::MessageParser<RouteSummary> Parser { get { return _parser; } }
 
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::Examples.Proto.RouteGuide.Descriptor.MessageTypes[4]; }
+      get { return global::Routeguide.Proto.RouteGuide.Descriptor.MessageTypes[4]; }
     }
 
     pbr::MessageDescriptor pb::IMessage.Descriptor {

--- a/examples/csharp/route_guide/RouteGuide/RouteGuideGrpc.cs
+++ b/examples/csharp/route_guide/RouteGuide/RouteGuideGrpc.cs
@@ -7,39 +7,39 @@ using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
 
-namespace Examples {
+namespace Routeguide {
   public static class RouteGuide
   {
-    static readonly string __ServiceName = "examples.RouteGuide";
+    static readonly string __ServiceName = "routeguide.RouteGuide";
 
-    static readonly Marshaller<global::Examples.Point> __Marshaller_Point = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Examples.Point.Parser.ParseFrom);
-    static readonly Marshaller<global::Examples.Feature> __Marshaller_Feature = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Examples.Feature.Parser.ParseFrom);
-    static readonly Marshaller<global::Examples.Rectangle> __Marshaller_Rectangle = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Examples.Rectangle.Parser.ParseFrom);
-    static readonly Marshaller<global::Examples.RouteSummary> __Marshaller_RouteSummary = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Examples.RouteSummary.Parser.ParseFrom);
-    static readonly Marshaller<global::Examples.RouteNote> __Marshaller_RouteNote = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Examples.RouteNote.Parser.ParseFrom);
+    static readonly Marshaller<global::Routeguide.Point> __Marshaller_Point = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Routeguide.Point.Parser.ParseFrom);
+    static readonly Marshaller<global::Routeguide.Feature> __Marshaller_Feature = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Routeguide.Feature.Parser.ParseFrom);
+    static readonly Marshaller<global::Routeguide.Rectangle> __Marshaller_Rectangle = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Routeguide.Rectangle.Parser.ParseFrom);
+    static readonly Marshaller<global::Routeguide.RouteSummary> __Marshaller_RouteSummary = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Routeguide.RouteSummary.Parser.ParseFrom);
+    static readonly Marshaller<global::Routeguide.RouteNote> __Marshaller_RouteNote = Marshallers.Create((arg) => global::Google.Protobuf.MessageExtensions.ToByteArray(arg), global::Routeguide.RouteNote.Parser.ParseFrom);
 
-    static readonly Method<global::Examples.Point, global::Examples.Feature> __Method_GetFeature = new Method<global::Examples.Point, global::Examples.Feature>(
+    static readonly Method<global::Routeguide.Point, global::Routeguide.Feature> __Method_GetFeature = new Method<global::Routeguide.Point, global::Routeguide.Feature>(
         MethodType.Unary,
         __ServiceName,
         "GetFeature",
         __Marshaller_Point,
         __Marshaller_Feature);
 
-    static readonly Method<global::Examples.Rectangle, global::Examples.Feature> __Method_ListFeatures = new Method<global::Examples.Rectangle, global::Examples.Feature>(
+    static readonly Method<global::Routeguide.Rectangle, global::Routeguide.Feature> __Method_ListFeatures = new Method<global::Routeguide.Rectangle, global::Routeguide.Feature>(
         MethodType.ServerStreaming,
         __ServiceName,
         "ListFeatures",
         __Marshaller_Rectangle,
         __Marshaller_Feature);
 
-    static readonly Method<global::Examples.Point, global::Examples.RouteSummary> __Method_RecordRoute = new Method<global::Examples.Point, global::Examples.RouteSummary>(
+    static readonly Method<global::Routeguide.Point, global::Routeguide.RouteSummary> __Method_RecordRoute = new Method<global::Routeguide.Point, global::Routeguide.RouteSummary>(
         MethodType.ClientStreaming,
         __ServiceName,
         "RecordRoute",
         __Marshaller_Point,
         __Marshaller_RouteSummary);
 
-    static readonly Method<global::Examples.RouteNote, global::Examples.RouteNote> __Method_RouteChat = new Method<global::Examples.RouteNote, global::Examples.RouteNote>(
+    static readonly Method<global::Routeguide.RouteNote, global::Routeguide.RouteNote> __Method_RouteChat = new Method<global::Routeguide.RouteNote, global::Routeguide.RouteNote>(
         MethodType.DuplexStreaming,
         __ServiceName,
         "RouteChat",
@@ -49,31 +49,31 @@ namespace Examples {
     // service descriptor
     public static global::Google.Protobuf.Reflection.ServiceDescriptor Descriptor
     {
-      get { return global::Examples.Proto.RouteGuide.Descriptor.Services[0]; }
+      get { return global::Routeguide.Proto.RouteGuide.Descriptor.Services[0]; }
     }
 
     // client interface
     public interface IRouteGuideClient
     {
-      global::Examples.Feature GetFeature(global::Examples.Point request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
-      global::Examples.Feature GetFeature(global::Examples.Point request, CallOptions options);
-      AsyncUnaryCall<global::Examples.Feature> GetFeatureAsync(global::Examples.Point request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
-      AsyncUnaryCall<global::Examples.Feature> GetFeatureAsync(global::Examples.Point request, CallOptions options);
-      AsyncServerStreamingCall<global::Examples.Feature> ListFeatures(global::Examples.Rectangle request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
-      AsyncServerStreamingCall<global::Examples.Feature> ListFeatures(global::Examples.Rectangle request, CallOptions options);
-      AsyncClientStreamingCall<global::Examples.Point, global::Examples.RouteSummary> RecordRoute(Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
-      AsyncClientStreamingCall<global::Examples.Point, global::Examples.RouteSummary> RecordRoute(CallOptions options);
-      AsyncDuplexStreamingCall<global::Examples.RouteNote, global::Examples.RouteNote> RouteChat(Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
-      AsyncDuplexStreamingCall<global::Examples.RouteNote, global::Examples.RouteNote> RouteChat(CallOptions options);
+      global::Routeguide.Feature GetFeature(global::Routeguide.Point request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
+      global::Routeguide.Feature GetFeature(global::Routeguide.Point request, CallOptions options);
+      AsyncUnaryCall<global::Routeguide.Feature> GetFeatureAsync(global::Routeguide.Point request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
+      AsyncUnaryCall<global::Routeguide.Feature> GetFeatureAsync(global::Routeguide.Point request, CallOptions options);
+      AsyncServerStreamingCall<global::Routeguide.Feature> ListFeatures(global::Routeguide.Rectangle request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
+      AsyncServerStreamingCall<global::Routeguide.Feature> ListFeatures(global::Routeguide.Rectangle request, CallOptions options);
+      AsyncClientStreamingCall<global::Routeguide.Point, global::Routeguide.RouteSummary> RecordRoute(Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
+      AsyncClientStreamingCall<global::Routeguide.Point, global::Routeguide.RouteSummary> RecordRoute(CallOptions options);
+      AsyncDuplexStreamingCall<global::Routeguide.RouteNote, global::Routeguide.RouteNote> RouteChat(Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken));
+      AsyncDuplexStreamingCall<global::Routeguide.RouteNote, global::Routeguide.RouteNote> RouteChat(CallOptions options);
     }
 
     // server-side interface
     public interface IRouteGuide
     {
-      Task<global::Examples.Feature> GetFeature(global::Examples.Point request, ServerCallContext context);
-      Task ListFeatures(global::Examples.Rectangle request, IServerStreamWriter<global::Examples.Feature> responseStream, ServerCallContext context);
-      Task<global::Examples.RouteSummary> RecordRoute(IAsyncStreamReader<global::Examples.Point> requestStream, ServerCallContext context);
-      Task RouteChat(IAsyncStreamReader<global::Examples.RouteNote> requestStream, IServerStreamWriter<global::Examples.RouteNote> responseStream, ServerCallContext context);
+      Task<global::Routeguide.Feature> GetFeature(global::Routeguide.Point request, ServerCallContext context);
+      Task ListFeatures(global::Routeguide.Rectangle request, IServerStreamWriter<global::Routeguide.Feature> responseStream, ServerCallContext context);
+      Task<global::Routeguide.RouteSummary> RecordRoute(IAsyncStreamReader<global::Routeguide.Point> requestStream, ServerCallContext context);
+      Task RouteChat(IAsyncStreamReader<global::Routeguide.RouteNote> requestStream, IServerStreamWriter<global::Routeguide.RouteNote> responseStream, ServerCallContext context);
     }
 
     // client stub
@@ -82,52 +82,52 @@ namespace Examples {
       public RouteGuideClient(Channel channel) : base(channel)
       {
       }
-      public global::Examples.Feature GetFeature(global::Examples.Point request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      public global::Routeguide.Feature GetFeature(global::Routeguide.Point request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
         var call = CreateCall(__Method_GetFeature, new CallOptions(headers, deadline, cancellationToken));
         return Calls.BlockingUnaryCall(call, request);
       }
-      public global::Examples.Feature GetFeature(global::Examples.Point request, CallOptions options)
+      public global::Routeguide.Feature GetFeature(global::Routeguide.Point request, CallOptions options)
       {
         var call = CreateCall(__Method_GetFeature, options);
         return Calls.BlockingUnaryCall(call, request);
       }
-      public AsyncUnaryCall<global::Examples.Feature> GetFeatureAsync(global::Examples.Point request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      public AsyncUnaryCall<global::Routeguide.Feature> GetFeatureAsync(global::Routeguide.Point request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
         var call = CreateCall(__Method_GetFeature, new CallOptions(headers, deadline, cancellationToken));
         return Calls.AsyncUnaryCall(call, request);
       }
-      public AsyncUnaryCall<global::Examples.Feature> GetFeatureAsync(global::Examples.Point request, CallOptions options)
+      public AsyncUnaryCall<global::Routeguide.Feature> GetFeatureAsync(global::Routeguide.Point request, CallOptions options)
       {
         var call = CreateCall(__Method_GetFeature, options);
         return Calls.AsyncUnaryCall(call, request);
       }
-      public AsyncServerStreamingCall<global::Examples.Feature> ListFeatures(global::Examples.Rectangle request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      public AsyncServerStreamingCall<global::Routeguide.Feature> ListFeatures(global::Routeguide.Rectangle request, Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
         var call = CreateCall(__Method_ListFeatures, new CallOptions(headers, deadline, cancellationToken));
         return Calls.AsyncServerStreamingCall(call, request);
       }
-      public AsyncServerStreamingCall<global::Examples.Feature> ListFeatures(global::Examples.Rectangle request, CallOptions options)
+      public AsyncServerStreamingCall<global::Routeguide.Feature> ListFeatures(global::Routeguide.Rectangle request, CallOptions options)
       {
         var call = CreateCall(__Method_ListFeatures, options);
         return Calls.AsyncServerStreamingCall(call, request);
       }
-      public AsyncClientStreamingCall<global::Examples.Point, global::Examples.RouteSummary> RecordRoute(Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      public AsyncClientStreamingCall<global::Routeguide.Point, global::Routeguide.RouteSummary> RecordRoute(Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
         var call = CreateCall(__Method_RecordRoute, new CallOptions(headers, deadline, cancellationToken));
         return Calls.AsyncClientStreamingCall(call);
       }
-      public AsyncClientStreamingCall<global::Examples.Point, global::Examples.RouteSummary> RecordRoute(CallOptions options)
+      public AsyncClientStreamingCall<global::Routeguide.Point, global::Routeguide.RouteSummary> RecordRoute(CallOptions options)
       {
         var call = CreateCall(__Method_RecordRoute, options);
         return Calls.AsyncClientStreamingCall(call);
       }
-      public AsyncDuplexStreamingCall<global::Examples.RouteNote, global::Examples.RouteNote> RouteChat(Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
+      public AsyncDuplexStreamingCall<global::Routeguide.RouteNote, global::Routeguide.RouteNote> RouteChat(Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken))
       {
         var call = CreateCall(__Method_RouteChat, new CallOptions(headers, deadline, cancellationToken));
         return Calls.AsyncDuplexStreamingCall(call);
       }
-      public AsyncDuplexStreamingCall<global::Examples.RouteNote, global::Examples.RouteNote> RouteChat(CallOptions options)
+      public AsyncDuplexStreamingCall<global::Routeguide.RouteNote, global::Routeguide.RouteNote> RouteChat(CallOptions options)
       {
         var call = CreateCall(__Method_RouteChat, options);
         return Calls.AsyncDuplexStreamingCall(call);

--- a/examples/csharp/route_guide/RouteGuide/RouteGuideUtil.cs
+++ b/examples/csharp/route_guide/RouteGuide/RouteGuideUtil.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Examples
+namespace Routeguide
 {
     /// <summary>
     /// Utility methods for the route guide example.

--- a/examples/csharp/route_guide/RouteGuideClient/Program.cs
+++ b/examples/csharp/route_guide/RouteGuideClient/Program.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Examples
+namespace Routeguide
 {
     class Program
     {

--- a/examples/csharp/route_guide/RouteGuideServer/Program.cs
+++ b/examples/csharp/route_guide/RouteGuideServer/Program.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Examples
+namespace Routeguide
 {
     class Program
     {

--- a/examples/csharp/route_guide/RouteGuideServer/RouteGuideImpl.cs
+++ b/examples/csharp/route_guide/RouteGuideServer/RouteGuideImpl.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 using Grpc.Core.Utils;
 
-namespace Examples
+namespace Routeguide
 {
     /// <summary>
     /// Example implementation of RouteGuide server.


### PR DESCRIPTION
Package of routeguide.proto has changed from examples to routeguide recently.
This PR regenerates the generated C# files and updates the routeguide example.