### PR TITLE
Updated zookeper resolver to new LB API

### DIFF
--- a/src/core/client_config/resolvers/zookeeper_resolver.c
+++ b/src/core/client_config/resolvers/zookeeper_resolver.c
@@ -182,6 +182,7 @@ static void zookeeper_on_resolved(void *arg,
   grpc_lb_policy *lb_policy;
   size_t i;
   if (addresses != NULL) {
+    grpc_lb_policy_args lb_policy_args;
     config = grpc_client_config_create();
     subchannels = gpr_malloc(sizeof(grpc_subchannel *) * addresses->naddrs);
     for (i = 0; i < addresses->naddrs; i++) {
@@ -191,8 +192,10 @@ static void zookeeper_on_resolved(void *arg,
       subchannels[i] = grpc_subchannel_factory_create_subchannel(
           r->subchannel_factory, &args);
     }
+    lb_policy_args.subchannels = subchannels;
+    lb_policy_args.num_subchannels = addresses->naddrs;
     lb_policy =
-        grpc_lb_policy_create(r->lb_policy_name, subchannels, addresses->naddrs);
+        grpc_lb_policy_create(r->lb_policy_name, &lb_policy_args);
     grpc_client_config_set_lb_policy(config, lb_policy);
     GRPC_LB_POLICY_UNREF(lb_policy, "construction");
     grpc_resolved_addresses_destroy(addresses);

--- a/test/core/end2end/dualstack_socket_test.c
+++ b/test/core/end2end/dualstack_socket_test.c
@@ -267,7 +267,7 @@ void test_connect(const char *server_host, const char *client_host, int port,
 int external_dns_works(const char *host) {
   grpc_resolved_addresses *res = grpc_blocking_resolve_address(host, "80");
   if (res != NULL) {
-    gpr_free(res);
+    grpc_resolved_addresses_destroy(res);
     return 1;
   }
   return 0;


### PR DESCRIPTION
Includes #3334, currently outstanding PR (so that tests for this one pass cleanly).