### PR TITLE
Better port selection

### DIFF
--- a/src/core/client_config/connector.c
+++ b/src/core/client_config/connector.c
@@ -47,3 +47,7 @@ void grpc_connector_connect(grpc_connector *connector,
                             grpc_iomgr_closure *notify) {
   connector->vtable->connect(connector, in_args, out_args, notify);
 }
+
+void grpc_connector_shutdown(grpc_connector *connector) {
+  connector->vtable->shutdown(connector);
+}

--- a/src/core/client_config/connector.h
+++ b/src/core/client_config/connector.h
@@ -70,6 +70,9 @@ typedef struct {
 struct grpc_connector_vtable {
   void (*ref)(grpc_connector *connector);
   void (*unref)(grpc_connector *connector);
+  /** Implementation of grpc_connector_shutdown */
+  void (*shutdown)(grpc_connector *connector);
+  /** Implementation of grpc_connector_connect */
   void (*connect)(grpc_connector *connector,
                   const grpc_connect_in_args *in_args,
                   grpc_connect_out_args *out_args, grpc_iomgr_closure *notify);
@@ -77,9 +80,12 @@ struct grpc_connector_vtable {
 
 void grpc_connector_ref(grpc_connector *connector);
 void grpc_connector_unref(grpc_connector *connector);
+/** Connect using the connector: max one outstanding call at a time */
 void grpc_connector_connect(grpc_connector *connector,
                             const grpc_connect_in_args *in_args,
                             grpc_connect_out_args *out_args,
                             grpc_iomgr_closure *notify);
+/** Cancel any pending connection */
+void grpc_connector_shutdown(grpc_connector *connector);
 
 #endif

--- a/src/core/client_config/subchannel.c
+++ b/src/core/client_config/subchannel.c
@@ -439,6 +439,10 @@ void grpc_subchannel_process_transport_op(grpc_subchannel *c,
   if (cancel_alarm) {
     grpc_alarm_cancel(&c->alarm);
   }
+
+  if (op->disconnect) {
+    grpc_connector_shutdown(c->connector);
+  }
 }
 
 static void on_state_changed(void *p, int iomgr_success) {

--- a/src/core/client_config/subchannel.h
+++ b/src/core/client_config/subchannel.h
@@ -43,6 +43,7 @@ typedef struct grpc_subchannel grpc_subchannel;
 typedef struct grpc_subchannel_call grpc_subchannel_call;
 typedef struct grpc_subchannel_args grpc_subchannel_args;
 
+#define GRPC_SUBCHANNEL_REFCOUNT_DEBUG
 #ifdef GRPC_SUBCHANNEL_REFCOUNT_DEBUG
 #define GRPC_SUBCHANNEL_REF(p, r) \
   grpc_subchannel_ref((p), __FILE__, __LINE__, (r))

--- a/src/core/iomgr/fd_posix.c
+++ b/src/core/iomgr/fd_posix.c
@@ -213,10 +213,9 @@ void grpc_fd_orphan(grpc_fd *fd, grpc_iomgr_closure *on_done,
                     const char *reason) {
   fd->on_done_closure = on_done;
   shutdown(fd->fd, SHUT_RDWR);
-  REF_BY(fd, 1, reason); /* remove active status, but keep referenced */
   gpr_mu_lock(&fd->watcher_mu);
+  REF_BY(fd, 1, reason); /* remove active status, but keep referenced */
   if (!has_watchers(fd)) {
-    GPR_ASSERT(!fd->closed);
     fd->closed = 1;
     close(fd->fd);
     if (fd->on_done_closure) {

--- a/src/core/iomgr/iomgr.c
+++ b/src/core/iomgr/iomgr.c
@@ -34,15 +34,17 @@
 #include "src/core/iomgr/iomgr.h"
 
 #include <stdlib.h>
+#include <string.h>
 
-#include "src/core/iomgr/iomgr_internal.h"
-#include "src/core/iomgr/alarm_internal.h"
-#include "src/core/support/string.h"
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/thd.h>
+
+#include "src/core/iomgr/iomgr_internal.h"
+#include "src/core/iomgr/alarm_internal.h"
+#include "src/core/support/string.h"
 
 static gpr_mu g_mu;
 static gpr_cv g_rcv;
@@ -178,6 +180,8 @@ void grpc_iomgr_shutdown(void) {
     }
   }
   gpr_mu_unlock(&g_mu);
+
+  memset(&g_root_object, 0, sizeof(g_root_object));
 
   grpc_kick_poller();
   gpr_event_wait(&g_background_callback_executor_done,

--- a/src/core/iomgr/pollset_multipoller_with_epoll.c
+++ b/src/core/iomgr/pollset_multipoller_with_epoll.c
@@ -72,7 +72,7 @@ static void finally_add_fd(grpc_pollset *pollset, grpc_fd *fd) {
      to this pollset whilst adding, but that should be benign. */
   GPR_ASSERT(grpc_fd_begin_poll(fd, pollset, 0, 0, &watcher) == 0);
   if (watcher.fd != NULL) {
-    ev.events = EPOLLIN | EPOLLOUT | EPOLLET;
+    ev.events = (uint32_t)(EPOLLIN | EPOLLOUT | EPOLLET);
     ev.data.ptr = fd;
     err = epoll_ctl(h->epoll_fd, EPOLL_CTL_ADD, fd->fd, &ev);
     if (err < 0) {

--- a/src/core/support/string.c
+++ b/src/core/support/string.c
@@ -101,7 +101,7 @@ static void asciidump(dump_out *out, const char *buf, size_t len) {
     dump_out_append(out, '\'');
   }
   for (cur = beg; cur != end; ++cur) {
-    dump_out_append(out, isprint(*cur) ? *(char *)cur : '.');
+    dump_out_append(out, (char)(isprint(*cur) ? *(char *)cur : '.'));
   }
   if (!out_was_empty) {
     dump_out_append(out, '\'');

--- a/src/core/surface/channel_create.c
+++ b/src/core/surface/channel_create.c
@@ -88,6 +88,8 @@ static void connected(void *arg, grpc_endpoint *tcp) {
   grpc_iomgr_add_callback(notify);
 }
 
+static void connector_shutdown(grpc_connector *con) {}
+
 static void connector_connect(grpc_connector *con,
                               const grpc_connect_in_args *args,
                               grpc_connect_out_args *result,
@@ -103,7 +105,7 @@ static void connector_connect(grpc_connector *con,
 }
 
 static const grpc_connector_vtable connector_vtable = {
-    connector_ref, connector_unref, connector_connect};
+    connector_ref, connector_unref, connector_shutdown, connector_connect};
 
 typedef struct {
   grpc_subchannel_factory base;

--- a/src/core/transport/chttp2/parsing.c
+++ b/src/core/transport/chttp2/parsing.c
@@ -486,7 +486,7 @@ static int init_skip_frame_parser(
     transport_parsing->hpack_parser.on_header_user_data = NULL;
     transport_parsing->hpack_parser.is_boundary = is_eoh;
     transport_parsing->hpack_parser.is_eof =
-        is_eoh ? transport_parsing->header_eof : 0;
+        (gpr_uint8)(is_eoh ? transport_parsing->header_eof : 0);
   } else {
     transport_parsing->parser = skip_parser;
   }
@@ -696,7 +696,7 @@ static int init_header_frame_parser(
   transport_parsing->hpack_parser.on_header_user_data = transport_parsing;
   transport_parsing->hpack_parser.is_boundary = is_eoh;
   transport_parsing->hpack_parser.is_eof =
-      is_eoh ? transport_parsing->header_eof : 0;
+      (gpr_uint8)(is_eoh ? transport_parsing->header_eof : 0);
   if (!is_continuation && (transport_parsing->incoming_frame_flags &
                            GRPC_CHTTP2_FLAG_HAS_PRIORITY)) {
     grpc_chttp2_hpack_parser_set_has_priority(&transport_parsing->hpack_parser);

--- a/test/core/util/port_posix.c
+++ b/test/core/util/port_posix.c
@@ -126,6 +126,7 @@ static void free_chosen_ports() {
     for (i = 0; i < num_chosen_ports; i++) {
       free_port_using_server(env, chosen_ports[i]);
     }
+    gpr_free(env);
   }
 
   gpr_free(chosen_ports); 

--- a/test/core/util/port_posix.c
+++ b/test/core/util/port_posix.c
@@ -194,6 +194,9 @@ static int is_port_available(int *port, int is_tcp) {
 typedef struct portreq {
   grpc_pollset pollset;
   int port;
+  int retries;
+  char *server;
+  grpc_httpcli_context *ctx;
 } portreq;
 
 static void got_port_from_server(void *arg,
@@ -201,6 +204,19 @@ static void got_port_from_server(void *arg,
   size_t i;
   int port = 0;
   portreq *pr = arg;
+  if (!response || response->status != 200) {
+    grpc_httpcli_request req;
+    memset(&req, 0, sizeof(req));
+    GPR_ASSERT(pr->retries < 10);
+    pr->retries++;
+    req.host = pr->server;
+    req.path = "/get";
+    gpr_log(GPR_DEBUG, "failed port pick from server: retrying");
+    sleep(1);
+    grpc_httpcli_get(pr->ctx, &pr->pollset, &req, GRPC_TIMEOUT_SECONDS_TO_DEADLINE(10), 
+                     got_port_from_server, pr);
+    return;
+  }
   GPR_ASSERT(response);
   GPR_ASSERT(response->status == 200);
   for (i = 0; i < response->body_length; i++) {
@@ -225,6 +241,8 @@ static int pick_port_using_server(char *server) {
   memset(&req, 0, sizeof(req));
   grpc_pollset_init(&pr.pollset);
   pr.port = -1;
+  pr.server = server;
+  pr.ctx = &context;
 
   req.host = server;
   req.path = "/get";

--- a/test/core/util/port_posix.c
+++ b/test/core/util/port_posix.c
@@ -80,8 +80,6 @@ static void destroy_pollset_and_shutdown(void *p) {
 static void freed_port_from_server(void *arg,
                                    const grpc_httpcli_response *response) {
   freereq *pr = arg;
-  GPR_ASSERT(response);
-  GPR_ASSERT(response->status == 200);
   gpr_mu_lock(GRPC_POLLSET_MU(&pr->pollset));
   pr->done = 1;
   grpc_pollset_kick(&pr->pollset, NULL);


### PR DESCRIPTION
- avoid IANA and Linux ephemeral port ranges
- support dropping allocated ports
- aggressively try to reclaim ports if we reach exhaustion
- set SO_REUSEADDR on test port binds