### PR TITLE
Fixed a couple of memory leaks in Node library

### DIFF
--- a/src/node/ext/byte_buffer.cc
+++ b/src/node/ext/byte_buffer.cc
@@ -77,7 +77,7 @@ Handle<Value> ByteBufferToBuffer(grpc_byte_buffer *buffer) {
     memcpy(result + offset, GPR_SLICE_START_PTR(next), GPR_SLICE_LENGTH(next));
     offset += GPR_SLICE_LENGTH(next);
   }
-  return NanEscapeScope(MakeFastBuffer(NanNewBufferHandle(result, length)));
+  return NanEscapeScope(MakeFastBuffer(NanBufferUse(result, length)));
 }
 
 Handle<Value> MakeFastBuffer(Handle<Value> slowBuffer) {

--- a/src/node/ext/call.cc
+++ b/src/node/ext/call.cc
@@ -172,6 +172,9 @@ Handle<Value> Op::GetOpType() const {
   return NanEscapeScope(NanNew<String>(GetTypeString()));
 }
 
+Op::~Op() {
+}
+
 class SendMetadataOp : public Op {
  public:
   Handle<Value> GetNodeValue() const {
@@ -325,7 +328,7 @@ class ReadMessageOp : public Op {
   }
   ~ReadMessageOp() {
     if (recv_message != NULL) {
-      gpr_free(recv_message);
+      grpc_byte_buffer_destroy(recv_message);
     }
   }
   Handle<Value> GetNodeValue() const {

--- a/src/node/ext/call.h
+++ b/src/node/ext/call.h
@@ -88,6 +88,7 @@ struct Resources {
 
 class Op {
  public:
+  virtual ~Op();
   virtual v8::Handle<v8::Value> GetNodeValue() const = 0;
   virtual bool ParseOp(v8::Handle<v8::Value> value, grpc_op *out,
                        shared_ptr<Resources> resources) = 0;
@@ -98,7 +99,6 @@ class Op {
 };
 
 typedef std::vector<unique_ptr<Op>> OpVec;
-
 struct tag {
   tag(NanCallback *callback, OpVec *ops,
       shared_ptr<Resources> resources);


### PR DESCRIPTION
We got a report last week that there seemed to be a memory leak when receiving messages. These changes appear to plug most of that leak.