### PR TITLE
Include "libgrpc_csharp_ext.so" symlink in C# package

### DIFF
--- a/debian/libgrpc-csharp-ext0.install
+++ b/debian/libgrpc-csharp-ext0.install
@@ -1,1 +1,1 @@
-usr/lib/libgrpc_csharp_ext.so.*
+usr/lib/libgrpc_csharp_ext.so*


### PR DESCRIPTION
The symlink is needed for mono/.NET core to correctly pick up the grpc_csharp_ext library.