### PR TITLE
Don't do .Wait() in async context.

### DIFF
--- a/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
@@ -131,7 +131,7 @@ namespace Grpc.IntegrationTesting
             var channel = new Channel(options.ServerHost, options.ServerPort, credentials, channelOptions);
             TestService.TestServiceClient client = new TestService.TestServiceClient(channel);
             await RunTestCaseAsync(client, options);
-            channel.ShutdownAsync().Wait();
+            await channel.ShutdownAsync();
         }
 
         private async Task RunTestCaseAsync(TestService.TestServiceClient client, ClientOptions options)


### PR DESCRIPTION
Failing to use await can result in deadlock. This is likely to be the cause of shutdown hangs in #3347.