### PR TITLE
Fixing usage of the BUILDDIR variable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,11 @@ SYSTEM = MINGW32
 endif
 
 
+MAKEFILE_PATH = $(abspath $(lastword $(MAKEFILE_LIST)))
 ifndef BUILDDIR
-BUILDDIR = .
+BUILDDIR_ABSOLUTE = $(patsubst %/,%,$(dir $(MAKEFILE_PATH)))
+else
+BUILDDIR_ABSOLUTE = $(abspath $(BUILDDIR))
 endif
 
 HAS_GCC = $(shell which gcc > /dev/null 2> /dev/null && echo true || echo false)
@@ -76,10 +79,10 @@ endif
 endif
 
 
-BINDIR = $(BUILDDIR)/bins
-OBJDIR = $(BUILDDIR)/objs
-LIBDIR = $(BUILDDIR)/libs
-GENDIR = $(BUILDDIR)/gens
+BINDIR = $(BUILDDIR_ABSOLUTE)/bins
+OBJDIR = $(BUILDDIR_ABSOLUTE)/objs
+LIBDIR = $(BUILDDIR_ABSOLUTE)/libs
+GENDIR = $(BUILDDIR_ABSOLUTE)/gens
 
 # Configurations
 
@@ -4189,13 +4192,13 @@ $(LIBDIR)/$(CONFIG)/libgrpc.a: $(ZLIB_DEP) $(OPENSSL_DEP) $(LIBGRPC_OBJS)
 	$(Q) mkdir -p `dirname $@`
 	$(Q) rm -f $(LIBDIR)/$(CONFIG)/libgrpc.a
 	$(Q) $(AR) rcs $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBGRPC_OBJS)
-	$(Q) rm -rf tmp-merge-grpc
-	$(Q) mkdir tmp-merge-grpc
-	$(Q) ( cd tmp-merge-grpc ; $(AR) x ../$(LIBDIR)/$(CONFIG)/libgrpc.a )
-	$(Q) for l in $(OPENSSL_MERGE_LIBS) ; do ( cd tmp-merge-grpc ; ar x ../$${l} ) ; done
-	$(Q) rm -f $(LIBDIR)/$(CONFIG)/libgrpc.a tmp-merge-grpc/__.SYMDEF*
-	$(Q) ar rcs $(LIBDIR)/$(CONFIG)/libgrpc.a tmp-merge-grpc/*
-	$(Q) rm -rf tmp-merge-grpc
+	$(Q) rm -rf $(BUILDDIR_ABSOLUTE)/tmp-merge-grpc
+	$(Q) mkdir $(BUILDDIR_ABSOLUTE)/tmp-merge-grpc
+	$(Q) ( cd $(BUILDDIR_ABSOLUTE)/tmp-merge-grpc ; $(AR) x $(LIBDIR)/$(CONFIG)/libgrpc.a )
+	$(Q) for l in $(OPENSSL_MERGE_LIBS) ; do ( cd $(BUILDDIR_ABSOLUTE)/tmp-merge-grpc ; ar x $${l} ) ; done
+	$(Q) rm -f $(LIBDIR)/$(CONFIG)/libgrpc.a $(BUILDDIR_ABSOLUTE)/tmp-merge-grpc/__.SYMDEF*
+	$(Q) ar rcs $(LIBDIR)/$(CONFIG)/libgrpc.a $(BUILDDIR_ABSOLUTE)/tmp-merge-grpc/*
+	$(Q) rm -rf $(BUILDDIR_ABSOLUTE)/tmp-merge-grpc
 ifeq ($(SYSTEM),Darwin)
 	$(Q) ranlib $(LIBDIR)/$(CONFIG)/libgrpc.a
 endif

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -65,8 +65,11 @@
   endif
 
 
+  MAKEFILE_PATH = $(abspath $(lastword $(MAKEFILE_LIST)))
   ifndef BUILDDIR
-  BUILDDIR = .
+  BUILDDIR_ABSOLUTE = $(patsubst %/,%,$(dir $(MAKEFILE_PATH)))
+  else
+  BUILDDIR_ABSOLUTE = $(abspath $(BUILDDIR))
   endif
 
   HAS_GCC = $(shell which gcc > /dev/null 2> /dev/null && echo true || echo false)
@@ -92,10 +95,10 @@
   endif
 
 
-  BINDIR = $(BUILDDIR)/bins
-  OBJDIR = $(BUILDDIR)/objs
-  LIBDIR = $(BUILDDIR)/libs
-  GENDIR = $(BUILDDIR)/gens
+  BINDIR = $(BUILDDIR_ABSOLUTE)/bins
+  OBJDIR = $(BUILDDIR_ABSOLUTE)/objs
+  LIBDIR = $(BUILDDIR_ABSOLUTE)/libs
+  GENDIR = $(BUILDDIR_ABSOLUTE)/gens
 
   # Configurations
 
@@ -1599,13 +1602,13 @@
   	$(Q) $(AR) rcs $(LIBDIR)/$(CONFIG)/lib${lib.name}.a $(LIB${lib.name.upper()}_OBJS)
   % if lib.get('baselib', False):
   % if lib.get('secure', 'check') == True:
-  	$(Q) rm -rf tmp-merge-${lib.name}
-  	$(Q) mkdir tmp-merge-${lib.name}
-  	$(Q) ( cd tmp-merge-${lib.name} ; $(AR) x ../$(LIBDIR)/$(CONFIG)/lib${lib.name}.a )
-  	$(Q) for l in $(OPENSSL_MERGE_LIBS) ; do ( cd tmp-merge-${lib.name} ; <%text>ar x ../$${l}</%text> ) ; done
-  	$(Q) rm -f $(LIBDIR)/$(CONFIG)/lib${lib.name}.a tmp-merge-${lib.name}/__.SYMDEF*
-  	$(Q) ar rcs $(LIBDIR)/$(CONFIG)/lib${lib.name}.a tmp-merge-${lib.name}/*
-  	$(Q) rm -rf tmp-merge-${lib.name}
+  	$(Q) rm -rf $(BUILDDIR_ABSOLUTE)/tmp-merge-${lib.name}
+  	$(Q) mkdir $(BUILDDIR_ABSOLUTE)/tmp-merge-${lib.name}
+  	$(Q) ( cd $(BUILDDIR_ABSOLUTE)/tmp-merge-${lib.name} ; $(AR) x $(LIBDIR)/$(CONFIG)/lib${lib.name}.a )
+  	$(Q) for l in $(OPENSSL_MERGE_LIBS) ; do ( cd $(BUILDDIR_ABSOLUTE)/tmp-merge-${lib.name} ; <%text>ar x $${l}</%text> ) ; done
+  	$(Q) rm -f $(LIBDIR)/$(CONFIG)/lib${lib.name}.a $(BUILDDIR_ABSOLUTE)/tmp-merge-${lib.name}/__.SYMDEF*
+  	$(Q) ar rcs $(LIBDIR)/$(CONFIG)/lib${lib.name}.a $(BUILDDIR_ABSOLUTE)/tmp-merge-${lib.name}/*
+  	$(Q) rm -rf $(BUILDDIR_ABSOLUTE)/tmp-merge-${lib.name}
   % endif
   % endif
   ifeq ($(SYSTEM),Darwin)


### PR DESCRIPTION
Now both using absolute and relative directory for that variable should work.

  BUILDDIR=/tmp/build-grpc make
  BUILDDIR=../build-grpc make