### PR TITLE
Plain log message should not be treated as format string

### DIFF
--- a/src/csharp/Grpc.Core/Logging/ConsoleLogger.cs
+++ b/src/csharp/Grpc.Core/Logging/ConsoleLogger.cs
@@ -79,48 +79,72 @@ namespace Grpc.Core.Logging
         }
 
         /// <summary>Logs a message with severity Debug.</summary>
-        public void Debug(string message, params object[] formatArgs)
+        public void Debug(string message)
         {
-            Log("D", message, formatArgs);
+            Log("D", message);
+        }
+
+        /// <summary>Logs a formatted message with severity Debug.</summary>
+        public void Debug(string format, params object[] formatArgs)
+        {
+            Debug(string.Format(format, formatArgs));
         }
 
         /// <summary>Logs a message with severity Info.</summary>
-        public void Info(string message, params object[] formatArgs)
+        public void Info(string message)
         {
-            Log("I", message, formatArgs);
+            Log("I", message);
+        }
+
+        /// <summary>Logs a formatted message with severity Info.</summary>
+        public void Info(string format, params object[] formatArgs)
+        {
+            Info(string.Format(format, formatArgs));
         }
 
         /// <summary>Logs a message with severity Warning.</summary>
-        public void Warning(string message, params object[] formatArgs)
+        public void Warning(string message)
         {
-            Log("W", message, formatArgs);
+            Log("W", message);
+        }
+
+        /// <summary>Logs a formatted message with severity Warning.</summary>
+        public void Warning(string format, params object[] formatArgs)
+        {
+            Warning(string.Format(format, formatArgs));
         }
 
         /// <summary>Logs a message and an associated exception with severity Warning.</summary>
-        public void Warning(Exception exception, string message, params object[] formatArgs)
+        public void Warning(Exception exception, string message)
         {
-            Log("W", message + " " + exception, formatArgs);
+            Warning(message + " " + exception);
         }
 
         /// <summary>Logs a message with severity Error.</summary>
-        public void Error(string message, params object[] formatArgs)
+        public void Error(string message)
         {
-            Log("E", message, formatArgs);
+            Log("E", message);
+        }
+
+        /// <summary>Logs a formatted message with severity Error.</summary>
+        public void Error(string format, params object[] formatArgs)
+        {
+            Error(string.Format(format, formatArgs));
         }
 
         /// <summary>Logs a message and an associated exception with severity Error.</summary>
-        public void Error(Exception exception, string message, params object[] formatArgs)
+        public void Error(Exception exception, string message)
         {
-            Log("E", message + " " + exception, formatArgs);
+            Error(message + " " + exception);
         }
 
-        private void Log(string severityString, string message, object[] formatArgs)
+        private void Log(string severityString, string message)
         {
             Console.Error.WriteLine("{0}{1} {2}{3}",
                 severityString,
                 DateTime.Now,
                 forTypeString,
-                string.Format(message, formatArgs));
+                message);
         }
     }
 }

--- a/src/csharp/Grpc.Core/Logging/ILogger.cs
+++ b/src/csharp/Grpc.Core/Logging/ILogger.cs
@@ -43,21 +43,33 @@ namespace Grpc.Core.Logging
         ILogger ForType<T>();
 
         /// <summary>Logs a message with severity Debug.</summary>
-        void Debug(string message, params object[] formatArgs);
+        void Debug(string message);
+
+        /// <summary>Logs a formatted message with severity Debug.</summary>
+        void Debug(string format, params object[] formatArgs);
 
         /// <summary>Logs a message with severity Info.</summary>
-        void Info(string message, params object[] formatArgs);
+        void Info(string message);
+
+        /// <summary>Logs a formatted message with severity Info.</summary>
+        void Info(string format, params object[] formatArgs);
 
         /// <summary>Logs a message with severity Warning.</summary>
-        void Warning(string message, params object[] formatArgs);
+        void Warning(string message);
+
+        /// <summary>Logs a formatted message with severity Warning.</summary>
+        void Warning(string format, params object[] formatArgs);
 
         /// <summary>Logs a message and an associated exception with severity Warning.</summary>
-        void Warning(Exception exception, string message, params object[] formatArgs);
+        void Warning(Exception exception, string message);
 
         /// <summary>Logs a message with severity Error.</summary>
-        void Error(string message, params object[] formatArgs);
+        void Error(string message);
+
+        /// <summary>Logs a formatted message with severity Error.</summary>
+        void Error(string format, params object[] formatArgs);
 
         /// <summary>Logs a message and an associated exception with severity Error.</summary>
-        void Error(Exception exception, string message, params object[] formatArgs);
+        void Error(Exception exception, string message);
     }
 }


### PR DESCRIPTION
A problem with ILogger interface design results msg in  `logger.Info(msg)` being treated as a formatting string. This is a fix.

Also, this PR drops the `void Warning(Exception exception, string message, params object[] formatArgs)` overload because combination of exception and formatted message string turns out not  to make much sense. Dropping this overload is basically an API breakage, but ILogger is a cellar API for advanced use and it is pretty unlikely someone was already using that specific overload (and if so, the fix is trivial for her).
