### PR TITLE
Fix windows build

### DIFF
--- a/src/core/iomgr/tcp_server_windows.c
+++ b/src/core/iomgr/tcp_server_windows.c
@@ -96,7 +96,6 @@ grpc_tcp_server *grpc_tcp_server_create(void) {
   grpc_tcp_server *s = gpr_malloc(sizeof(grpc_tcp_server));
   gpr_mu_init(&s->mu);
   s->active_ports = 0;
-  s->iomgr_callbacks_pending = 0;
   s->on_accept_cb = NULL;
   s->on_accept_cb_arg = NULL;
   s->ports = gpr_malloc(sizeof(server_port) * INIT_PORT_CAP);

--- a/tools/run_tests/port_server.py
+++ b/tools/run_tests/port_server.py
@@ -37,7 +37,6 @@ import os
 import socket
 import sys
 import time
-import yaml
 
 argp = argparse.ArgumentParser(description='Server for httpcli_test')
 argp.add_argument('-p', '--port', default=12345, type=int)
@@ -118,6 +117,9 @@ class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
       self.end_headers()
       self.wfile.write(_MY_VERSION)
     elif self.path == '/dump':
+      # yaml module is not installed on Macs and Windows machines by default
+      # so we import it lazily (/dump action is only used for debugging)
+      import yaml
       self.send_response(200)
       self.send_header('Content-Type', 'text/plain')
       self.end_headers()


### PR DESCRIPTION
Remove reference to nonexistent field s->iomgr_callbacks_pending, which prevents grpc_csharp_ext from compiling.

Also includes #3392