### PR TITLE
Fix parameter types in function definition.

### DIFF
--- a/src/core/iomgr/tcp_client_windows.c
+++ b/src/core/iomgr/tcp_client_windows.c
@@ -121,7 +121,7 @@ static void on_connect(void *acp, int from_iocp) {
    notification request for the connection, and one timeout alert. */
 void grpc_tcp_client_connect(void (*cb)(void *arg, grpc_endpoint *tcp),
                              void *arg, grpc_pollset_set *interested_parties,
-                             const struct sockaddr *addr, int addr_len,
+                             const struct sockaddr *addr, size_t addr_len,
                              gpr_timespec deadline) {
   SOCKET sock = INVALID_SOCKET;
   BOOL success;
@@ -176,7 +176,7 @@ void grpc_tcp_client_connect(void (*cb)(void *arg, grpc_endpoint *tcp),
 
   socket = grpc_winsocket_create(sock, "client");
   info = &socket->write_info;
-  success = ConnectEx(sock, addr, addr_len, NULL, 0, NULL, &info->overlapped);
+  success = ConnectEx(sock, addr, (int)addr_len, NULL, 0, NULL, &info->overlapped);
 
   /* It wouldn't be unusual to get a success immediately. But we'll still get
      an IOCP notification, so let's ignore it. */

--- a/src/core/iomgr/tcp_server_windows.c
+++ b/src/core/iomgr/tcp_server_windows.c
@@ -156,7 +156,7 @@ void grpc_tcp_server_destroy(grpc_tcp_server *s,
 
 /* Prepare (bind) a recently-created socket for listening. */
 static int prepare_socket(SOCKET sock, const struct sockaddr *addr,
-                          int addr_len) {
+                          size_t addr_len) {
   struct sockaddr_storage sockname_temp;
   socklen_t sockname_len;
 
@@ -169,7 +169,7 @@ static int prepare_socket(SOCKET sock, const struct sockaddr *addr,
     goto error;
   }
 
-  if (bind(sock, addr, addr_len) == SOCKET_ERROR) {
+  if (bind(sock, addr, (int)addr_len) == SOCKET_ERROR) {
     char *addr_str;
     char *utf8_message = gpr_format_message(WSAGetLastError());
     grpc_sockaddr_to_string(&addr_str, addr, 0);
@@ -355,7 +355,7 @@ static void on_accept(void *arg, int from_iocp) {
 }
 
 static int add_socket_to_server(grpc_tcp_server *s, SOCKET sock,
-                                const struct sockaddr *addr, int addr_len) {
+                                const struct sockaddr *addr, size_t addr_len) {
   server_port *sp;
   int port;
   int status;
@@ -402,7 +402,7 @@ static int add_socket_to_server(grpc_tcp_server *s, SOCKET sock,
 }
 
 int grpc_tcp_server_add_port(grpc_tcp_server *s, const void *addr,
-                             int addr_len) {
+                             size_t addr_len) {
   int allocated_port = -1;
   unsigned i;
   SOCKET sock;


### PR DESCRIPTION
Function signature in in tcp_server.h is different from the definitions:

```
3>c:\users\jtattermusch\github\grpc\src\core\iomgr\tcp_server_windows.c(404): warning C4028: formal parameter 3 different from declaration
2>c:\users\jtattermusch\github\grpc\src\core\iomgr\tcp_client_windows.c(125): warning C4028: formal parameter 5 different from declaration
```

This also includes changes from #3393