### PR TITLE
It is a bad idea to have a map with string_refs as output params.

### DIFF
--- a/include/grpc++/security/auth_metadata_processor.h
+++ b/include/grpc++/security/auth_metadata_processor.h
@@ -45,7 +45,7 @@ namespace grpc {
 class AuthMetadataProcessor {
  public:
   typedef std::multimap<grpc::string_ref, grpc::string_ref> InputMetadata;
-  typedef std::multimap<grpc::string, grpc::string_ref> OutputMetadata;
+  typedef std::multimap<grpc::string, grpc::string> OutputMetadata;
 
   virtual ~AuthMetadataProcessor() {}
 

--- a/include/grpc++/security/credentials.h
+++ b/include/grpc++/security/credentials.h
@@ -180,7 +180,7 @@ class MetadataCredentialsPlugin {
   // Gets the auth metatada produced by this plugin.
   virtual Status GetMetadata(
       grpc::string_ref service_url,
-      std::multimap<grpc::string, grpc::string_ref>* metadata) = 0;
+      std::multimap<grpc::string, grpc::string>* metadata) = 0;
 };
 
 std::shared_ptr<Credentials> MetadataCredentialsFromPlugin(

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -173,7 +173,7 @@ void MetadataCredentialsPluginWrapper::GetMetadata(
 void MetadataCredentialsPluginWrapper::InvokePlugin(
     const char* service_url, grpc_credentials_plugin_metadata_cb cb,
     void* user_data) {
-  std::multimap<grpc::string, grpc::string_ref> metadata;
+  std::multimap<grpc::string, grpc::string> metadata;
   Status status = plugin_->GetMetadata(service_url, &metadata);
   std::vector<grpc_metadata> md;
   for (auto it = metadata.begin(); it != metadata.end(); ++it) {

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -121,7 +121,7 @@ class TestMetadataCredentialsPlugin : public MetadataCredentialsPlugin {
   bool IsBlocking() const GRPC_OVERRIDE { return is_blocking_; }
 
   Status GetMetadata(grpc::string_ref service_url,
-                     std::multimap<grpc::string, grpc::string_ref>* metadata)
+                     std::multimap<grpc::string, grpc::string>* metadata)
       GRPC_OVERRIDE {
     EXPECT_GT(service_url.length(), 0UL);
     EXPECT_TRUE(metadata != nullptr);
@@ -175,9 +175,9 @@ class TestAuthMetadataProcessor : public AuthMetadataProcessor {
     if (auth_md_value == kGoodGuy) {
       context->AddProperty(kIdentityPropName, kGoodGuy);
       context->SetPeerIdentityPropertyName(kIdentityPropName);
-      consumed_auth_metadata->insert(
-          std::make_pair(string(auth_md->first.data(), auth_md->first.length()),
-                         auth_md->second));
+      consumed_auth_metadata->insert(std::make_pair(
+          string(auth_md->first.data(), auth_md->first.length()),
+          string(auth_md->second.data(), auth_md->second.length())));
       return Status::OK;
     } else {
       return Status(StatusCode::UNAUTHENTICATED,


### PR DESCRIPTION
This is very much unsafe as the string_ref could point on a stack
variable of the callee.