### PR TITLE
Do not use string_ref for output params.

### DIFF
--- a/include/grpc++/security/auth_metadata_processor.h
+++ b/include/grpc++/security/auth_metadata_processor.h
@@ -45,7 +45,7 @@ namespace grpc {
 class AuthMetadataProcessor {
  public:
   typedef std::multimap<grpc::string_ref, grpc::string_ref> InputMetadata;
-  typedef std::multimap<grpc::string, grpc::string_ref> OutputMetadata;
+  typedef std::multimap<grpc::string, grpc::string> OutputMetadata;
 
   virtual ~AuthMetadataProcessor() {}
 

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -136,9 +136,9 @@ class TestAuthMetadataProcessor : public AuthMetadataProcessor {
     if (auth_md_value.ends_with(kGoodGuy)) {
       context->AddProperty(kIdentityPropName, kGoodGuy);
       context->SetPeerIdentityPropertyName(kIdentityPropName);
-      consumed_auth_metadata->insert(
-          std::make_pair(string(auth_md->first.data(), auth_md->first.length()),
-                         auth_md->second));
+      consumed_auth_metadata->insert(std::make_pair(
+          string(auth_md->first.data(), auth_md->first.length()),
+          string(auth_md->second.data(), auth_md->second.length())));
       return Status::OK;
     } else {
       return Status(StatusCode::UNAUTHENTICATED,


### PR DESCRIPTION
It is very much unsafe to do so as the string_ref could point on a stack
variable of the callee.

It is an API breakage for a very new API. I really hope it's OK because it's a bad one.