### PR TITLE
Prevent failed docker builds from accumulating

### DIFF
--- a/tools/gce_setup/shared_startup_funcs.sh
+++ b/tools/gce_setup/shared_startup_funcs.sh
@@ -448,7 +448,7 @@ grpc_dockerfile_install() {
   }
 
   # TODO(temiola): maybe make cache/no-cache a func option?
-  sudo docker build $cache_opt -t $image_label $dockerfile_dir || {
+  sudo docker build --force-rm=true $cache_opt -t $image_label $dockerfile_dir || {
     echo "$FUNCNAME:: build of $image_label <- $dockerfile_dir"
     return 1
   }


### PR DESCRIPTION
By default docker does not clean up temporary images when the build
fails to allow the user to inspect the state of the container to
determine what went wrong. Those images don't help us at all and just
accumulate until disk usage is 100%.

@nicolasnoble @jtattermusch FYI, since I think some other scripts could benefit from this.