### PR TITLE
PHP: need additional cli flags in scripts

### DIFF
--- a/src/php/bin/interop_client.sh
+++ b/src/php/bin/interop_client.sh
@@ -31,5 +31,5 @@
 set -e
 cd $(dirname $0)
 source ./determine_extension_dir.sh
-php $extension_dir \
+php $extension_dir -d max_execution_time=300 \
   ../tests/interop/interop_client.php $@ 1>&2

--- a/src/php/bin/run_gen_code_test.sh
+++ b/src/php/bin/run_gen_code_test.sh
@@ -32,7 +32,7 @@ set -e
 cd $(dirname $0)
 source ./determine_extension_dir.sh
 export GRPC_TEST_HOST=localhost:50051
-php $extension_dir $(which phpunit) -v --debug --strict \
+php $extension_dir -d max_execution_time=300 $(which phpunit) -v --debug --strict \
   ../tests/generated_code/GeneratedCodeTest.php
-php $extension_dir $(which phpunit) -v --debug --strict \
+php $extension_dir -d max_execution_time=300 $(which phpunit) -v --debug --strict \
   ../tests/generated_code/GeneratedCodeWithCallbackTest.php

--- a/src/php/bin/run_tests.sh
+++ b/src/php/bin/run_tests.sh
@@ -37,5 +37,5 @@ cd src/php/bin
 source ./determine_extension_dir.sh
 # in some jenkins macos machine, somehow the PHP build script can't find libgrpc.dylib
 export DYLD_LIBRARY_PATH=$root/libs/$config
-php $extension_dir $(which phpunit) -v --debug --strict \
+php $extension_dir -d max_execution_time=300 $(which phpunit) -v --debug --strict \
   ../tests/unit_tests


### PR DESCRIPTION
For some reason, after we have the `libgrpc-dev` debian package, we need this extra command line flags to be passed into the `php` executable.