### PR TITLE
Update c# docs for release 0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Libraries in different languages are in different state of development. We are s
    * Ruby Library: [src/ruby] (src/ruby) : Early adopter ready - Alpha.
    * NodeJS Library: [src/node] (src/node) : Early adopter ready - Alpha.
    * Python Library: [src/python] (src/python) : Early adopter ready - Alpha.
-   * C# Library: [src/csharp] (src/csharp) : Early adopter ready - Alpha.
+   * C# Library: [src/csharp] (src/csharp) : Beta.
    * Objective-C Library: [src/objective-c] (src/objective-c): Early adopter ready - Alpha.
    * PHP Library: [src/php] (src/php) : Pre-Alpha.
 

--- a/examples/csharp/helloworld/README.md
+++ b/examples/csharp/helloworld/README.md
@@ -3,49 +3,52 @@ gRPC in 3 minutes (C#)
 
 BACKGROUND
 -------------
-For this sample, we've already generated the server and client stubs from `helloworld.proto`. 
-Example projects depend on NuGet packages `Grpc` and `Google.ProtocolBuffers` which have been already added to the project for you.
+For this sample, we've already generated the server and client stubs from [helloworld.proto][].
+
+Example projects depend on the [Grpc](https://www.nuget.org/packages/Grpc/)
+and [Google.Protobuf](https://www.nuget.org/packages/Google.Protobuf/) NuGet packages
+which have been already added to the project for you.
 
 PREREQUISITES
 -------------
 **Windows**
 - .NET 4.5+
-- VS 2013 (with NuGet plugin installed)
+- Visual Studio 2013 or 2015
 
-**Linux (Mono)**
+**Linux**
 - Mono
-- Monodevelop 5.9 with NuGet Add-in installed (older versions might work)
+- Monodevelop 5.9 with NuGet Add-in installed
 
-**MacOS (Mono)**
+**Mac OS X**
 - Xamarin Studio (with NuGet plugin installed)
+- [homebrew][]
 
 BUILD
 -------
 
 **Windows**
-- Clone this repository.
 
 - Open solution `Greeter.sln` with Visual Studio
 
 - Build the solution (this will automatically download NuGet dependencies)
 
-**Linux (Mono)**
-- Clone this repository.
+**Linux (Debian)**
 
-- Install gRPC C Core using instructions in https://github.com/grpc/homebrew-grpc
+- Install gRPC C core and C# native extension using [How to use gRPC C#][] instructions
 
-- gRPC C# depends on native shared library `libgrpc_csharp_ext.so`. To make it visible
-  to Mono runtime, follow instructions in [Using gRPC C# on Linux](https://github.com/grpc/grpc/tree/master/src/csharp#usage-linux-mono)
+- Open solution `Greeter.sln` in MonoDevelop.
 
-- Open solution `Greeter.sln` in MonoDevelop (you need to manually restore dependencies by using `mono nuget.exe restore` if you don't have NuGet add-in)
+- Build the solution (you need to manually restore dependencies by using `mono nuget.exe restore` if you don't have NuGet add-in)
 
-- Build the solution.
+**Mac OS X**
 
-**MacOS (Mono)**
-- See [Using gRPC C# on MacOS](https://github.com/grpc/grpc/tree/master/src/csharp#usage-macos-mono) for more info
-  on MacOS support.
+- Install gRPC C core and C# native extension using [How to use gRPC C#][] instructions
 
-Try it! 
+- Open solution `Greeter.sln` with Xamarin Studio
+
+- Build the solution (this will automatically download NuGet dependencies)
+
+Try it!
 -------
 
 - Run the server
@@ -69,4 +72,9 @@ On Linux or Mac, use `mono GreeterServer.exe` and `mono GreeterClient.exe` to ru
 Tutorial
 --------
 
-You can find a more detailed tutorial in [gRPC Basics: C#](route_guide/README.md)
+You can find a more detailed tutorial in [gRPC Basics: C#][]
+
+[homebrew]:http://brew.sh
+[helloworld.proto]:../../protos/helloworld.proto
+[How to use gRPC C#]:../../../src/csharp#how-to-use
+[gRPC Basics: C#]:http://www.grpc.io/docs/tutorials/basic/csharp.html

--- a/src/csharp/README.md
+++ b/src/csharp/README.md
@@ -6,12 +6,19 @@ A C# implementation of gRPC.
 Status
 ------
 
-Alpha : Ready for early adopters.
+Beta
 
-Usage: Windows
+PREREQUISITES
 --------------
 
-- Prerequisites: .NET Framework 4.5+, Visual Studio 2013 with NuGet extension installed (VS2015 should work).
+- Windows: .NET Framework 4.5+, Visual Studio 2013 or 2015.
+- Linux: Mono 3.2.8+, MonoDevelop 5.9 with NuGet add-in installed.
+- Mac OS X: [homebrew][], Xamarin Studio with NuGet add-in installed.
+
+HOW TO USE
+--------------
+
+**Windows**
 
 - Open Visual Studio and start a new project/solution.
 
@@ -19,48 +26,43 @@ Usage: Windows
   That will also pull all the transitive dependencies (including the native libraries that
   gRPC C# is internally using).
 
-- Helloworld project example can be found in https://github.com/grpc/grpc/tree/master/examples/csharp.
+**Linux (Debian)**
 
-Usage: Linux (Mono)
---------------
+- Add [Debian jessie-backports][] to your `sources.list` file. Example:
 
-- Prerequisites: Mono 3.2.8+, MonoDevelop 5.9 with NuGet add-in installed.
+  ```sh
+  echo "deb http://http.debian.net/debian jessie-backports main" | \
+  sudo tee -a /etc/apt/sources.list
+  ```
 
-- Install Linuxbrew and gRPC C Core using instructions in https://github.com/grpc/homebrew-grpc
+- Install the gRPC Debian package
 
-- gRPC C# depends on native shared library libgrpc_csharp_ext.so (Unix flavor of grpc_csharp_ext.dll).
-  This library will be installed to `~/.linuxbrew/lib` by the previous step.
-  To make it visible to mono, you need to:
+  ```sh
+  sudo apt-get update
+  sudo apt-get install libgrpc0
+  ```
 
-  - (preferred approach) add `libgrpc_csharp_ext.so` to `/etc/ld.so.cache` by running:
+- gRPC C# depends on native shared library `libgrpc_csharp_ext.so` (Unix flavor of grpc_csharp_ext.dll).
+  This library is not part of the base gRPC debian package and needs to be installed manually from
+  a `.deb` file. Download the debian package `libgrpc_csharp_ext` from corresponding gRPC release on GitHub
+  and install it using `dpkg`.
 
-    ```sh
-    $ echo "$HOME/.linuxbrew/lib" | sudo tee /etc/ld.so.conf.d/zzz_brew_lib.conf
-    $ sudo ldconfig
-    ```
-
-  - (adhoc approach) set `LD_LIBRARY_PATH` environment variable to point to directory containing `libgrpc_csharp_ext.so`:
-
-    ```sh
-    $ export LD_LIBRARY_PATH=$HOME/.linuxbrew/lib:${LD_LIBRARY_PATH}
-    ```
-  - (if you are contributor) installing gRPC from sources using `sudo make install_grpc_csharp_ext` also works.
+  ```sh
+  # choose version corresponding to libgrpc you've installed.
+  wget https://github.com/grpc/grpc/releases/download/release-0_11_0/libgrpc-csharp-ext0_0.11.0.0-1_amd64.deb
+  dpkg -i libgrpc-csharp-ext0_0.11.0.0-1_amd64.deb
+  ```
 
 - Open MonoDevelop and start a new project/solution.
 
 - Add NuGet package `Grpc` as a dependency (Project -> Add NuGet packages).
 
-- Helloworld project example can be found in https://github.com/grpc/grpc/tree/master/examples/csharp.
-
-Usage: MacOS (Mono)
---------------
+**Mac OS X**
 
 - WARNING: As of now gRPC C# only works on 64bit version of Mono (because we don't compile
   the native extension for C# in 32bit mode yet). That means your development experience
   with Xamarin Studio on MacOS will not be great, as you won't be able to run your
   code directly from Xamarin Studio (which requires 32bit version of Mono).
-
-- Prerequisites: Xamarin Studio with NuGet add-in installed.
 
 - Install Homebrew and gRPC C Core using instructions in https://github.com/grpc/homebrew-grpc
 
@@ -73,35 +75,27 @@ Usage: MacOS (Mono)
 - *You will be able to build your project in Xamarin Studio, but to run or test it,
   you will need to run it under 64-bit version of Mono.*
 
-- Helloworld project example can be found in https://github.com/grpc/grpc/tree/master/examples/csharp.
-
-Building: Windows
+BUILD FROM SOURCE
 -----------------
 
 You only need to go through these steps if you are planning to develop gRPC C#.
 If you are a user of gRPC C#, go to Usage section above.
 
-- Prerequisites for development: NET Framework 4.5+, Visual Studio 2013 (with NuGet and NUnit extensions installed).
+**Windows**
 
-- The grpc_csharp_ext native library needs to be built so you can build the Grpc C# solution. You can 
+- The grpc_csharp_ext native library needs to be built so you can build the gRPC C# solution. You can 
   either build the native solution in `vsprojects/grpc.sln` from Visual Studio manually, or you can use
   a convenience batch script that builds everything for you.
 
   ```
+  > REM From src/csharp directory
   > buildall.bat
   ```
 
-- Open Grpc.sln using Visual Studio 2013. NuGet dependencies will be restored
+- Open Grpc.sln using Visual Studio. NuGet dependencies will be restored
   upon build (you need to have NuGet add-in installed).
 
-
-Building: Linux (Mono)
-----------------------
-
-You only need to go through these steps if you are planning to develop gRPC C#.
-If you are a user of gRPC C#, go to Usage section above.
-
-- Prerequisites for development: Mono 3.2.8+, MonoDevelop 5.9 with NuGet and NUnit add-ins installed.
+**Linux**
 
   ```sh
   $ sudo apt-get install mono-devel
@@ -123,8 +117,8 @@ don't support NuGet add-in.
 
 - Build the solution & run all the tests from test view.
 
-Tests
------
+RUNNING TESTS
+-------------
 
 gRPC C# is using NUnit as the testing framework.
 
@@ -136,12 +130,25 @@ Then you should be able to run all the test from the Test View.
 
 After building the solution, you can also run the tests from command line 
 using nunit-console tool.
+
 ```sh
 # from Grpc.Core.Test/bin/Debug directory
 $ nunit-console Grpc.Core.Tests.dll
 ```
 
-Contents
+gRPC team uses a Python script to simplify facilitate running tests for
+different languages.
+
+```
+tools/run_tests/run_tests.py -l csharp
+```
+
+DOCUMENTATION
+-------------
+- the gRPC C# reference documentation is available online at [grpc.io][]
+- Helloworld project example can be found in https://github.com/grpc/grpc/tree/master/examples/csharp/helloworld.
+
+CONTENTS
 --------
 
 - ext:
@@ -159,7 +166,7 @@ Contents
 - Grpc.IntegrationTesting:
   Cross-language gRPC implementation testing (interop testing).
 
-Troubleshooting
+TROUBLESHOOTING
 ---------------
 
 ### Problem: Unable to load DLL 'grpc_csharp_ext.dll'
@@ -170,8 +177,11 @@ Internally, gRPC C# uses a native library written in C (gRPC C core) and invokes
 
 - If you are running your application that is using gRPC on Windows machine that doesn't have Visual Studio installed, you might need to install [Visual C++ 2013 redistributable](https://www.microsoft.com/en-us/download/details.aspx?id=40784) that contains some system .dll libraries that `grpc_csharp_ext.dll` depends on (see #905 for more details).
 
-- On Linux (or Docker), you need to first install gRPC C core and `libgrpc_csharp_ext.so` shared libraries. Currently, the libraries can be installed by `make install_grpc_csharp_ext` or using Linuxbrew (a Debian package is coming soon). Installation on a machine where your application is going to be deployed is no different. 
+- On Linux (or Docker), you need to first install gRPC C core and `libgrpc_csharp_ext.so` shared libraries.
+  See [How to Use](#how-to-use) section for details how to install it.
+  Installation on a machine where your application is going to be deployed is no different.
 
-- On Mac, you need to first install gRPC C core and `libgrpc_csharp_ext.dylib` shared libraries using Homebrew. See above for installation instruction. Installation on a machine where your application is going to be deployed is no different. 
+- On Mac, you need to first install gRPC C core and `libgrpc_csharp_ext.dylib` shared libraries using Homebrew. See above for installation instruction.
+  Installation on a machine where your application is going to be deployed is no different.
 
 - Possible cause for the problem is that the `grpc_csharp_ext` library is installed, but it has different bitness (32/64bit) than your C# runtime (in case you are using mono) or C# application.

--- a/src/csharp/README.md
+++ b/src/csharp/README.md
@@ -24,7 +24,7 @@ HOW TO USE
 
 - Add NuGet package `Grpc` as a dependency (Project options -> Manage NuGet Packages).
   That will also pull all the transitive dependencies (including the native libraries that
-  gRPC C# is internally using).
+  gRPC C# is using internally).
 
 **Linux (Debian)**
 
@@ -48,7 +48,7 @@ HOW TO USE
   and install it using `dpkg`.
 
   ```sh
-  # choose version corresponding to libgrpc you've installed.
+  # choose version corresponding to the version of libgrpc you've installed.
   wget https://github.com/grpc/grpc/releases/download/release-0_11_0/libgrpc-csharp-ext0_0.11.0.0-1_amd64.deb
   dpkg -i libgrpc-csharp-ext0_0.11.0.0-1_amd64.deb
   ```
@@ -64,9 +64,15 @@ HOW TO USE
   with Xamarin Studio on MacOS will not be great, as you won't be able to run your
   code directly from Xamarin Studio (which requires 32bit version of Mono).
 
-- Install Homebrew and gRPC C Core using instructions in https://github.com/grpc/homebrew-grpc
+- Install [homebrew][]. Run the following command to install gRPC C# native dependencies.
 
-- Install 64-bit version of mono with command `brew install mono` (assumes you've already installed Homebrew).
+  ```sh
+  $ curl -fsSL https://goo.gl/getgrpc | bash -
+  ```
+  This will download and run the [gRPC install script][], then install the latest version of gRPC C core and native C# extension.
+  It also installs Protocol Buffers compiler (_protoc_) and the gRPC _protoc_ plugin for ruby.
+
+- Install 64-bit version of mono with command `brew install mono`.
 
 - Open Xamarin Studio and start a new project/solution.
 
@@ -146,7 +152,7 @@ tools/run_tests/run_tests.py -l csharp
 DOCUMENTATION
 -------------
 - the gRPC C# reference documentation is available online at [grpc.io][]
-- Helloworld project example can be found in https://github.com/grpc/grpc/tree/master/examples/csharp/helloworld.
+- [Helloworld example][]
 
 CONTENTS
 --------
@@ -185,3 +191,9 @@ Internally, gRPC C# uses a native library written in C (gRPC C core) and invokes
   Installation on a machine where your application is going to be deployed is no different.
 
 - Possible cause for the problem is that the `grpc_csharp_ext` library is installed, but it has different bitness (32/64bit) than your C# runtime (in case you are using mono) or C# application.
+
+[homebrew]:http://brew.sh
+[gRPC install script]:https://raw.githubusercontent.com/grpc/homebrew-grpc/master/scripts/install
+[grpc.io]: http://www.grpc.io/docs/installation/csharp.html
+[Debian jessie-backports]:http://backports.debian.org/Instructions/
+[Helloworld example]:../../examples/csharp/helloworld


### PR DESCRIPTION
-- change C# status to beta
-- change installation instructions on Linux (use debian packages).
-- make the readme.md style more similar to ruby's readme.
-- lots of nits

Missing:
route guide example for C# on grpc.io is out of date and needs to be updated. 