### PR TITLE
Bugfix: correct circular arg ref

### DIFF
--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -170,7 +170,7 @@ module GRPC
                          deadline: nil,
                          timeout: nil,
                          return_op: false,
-                         parent: parent,
+                         parent: nil,
                          **kw)
       c = new_active_call(method, marshal, unmarshal,
                           deadline: deadline,


### PR DESCRIPTION
Fixes an invalid reference in a keyword arg.
This shows up as a ruby level warning in ruby 2.2