### PR TITLE
Make run_jenkins script forward arguments to run_tests.py

### DIFF
--- a/tools/jenkins/run_jenkins.sh
+++ b/tools/jenkins/run_jenkins.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # Copyright 2015, Google Inc.
 # All rights reserved.
 #
@@ -31,8 +31,6 @@
 # This script is invoked by Jenkins and triggers a test run based on
 # env variable settings.
 #
-# Bootstrap into bash
-[ -z $1 ] && exec bash $0 bootstrapped
 # Setting up rvm environment BEFORE we set -ex.
 [[ -s /etc/profile.d/rvm.sh ]] && . /etc/profile.d/rvm.sh
 # To prevent cygwin bash complaining about empty lines ending with \r
@@ -56,11 +54,11 @@ if [ "$platform" == "linux" ]
 then
   echo "building $language on Linux"
 
-  ./tools/run_tests/run_tests.py --use_docker -t -l $language -c $config -x report.xml || true
+  ./tools/run_tests/run_tests.py --use_docker -t -l $language -c $config -x report.xml $@ || true
 
 elif [ "$platform" == "interop" ]
 then
-  python tools/run_tests/run_interops.py --language=$language
+  python tools/run_tests/run_interops.py --language=$language $@
 elif [ "$platform" == "windows" ]
 then
   echo "building $language on Windows"
@@ -72,19 +70,19 @@ then
   /cygdrive/c/nuget/nuget.exe restore vsprojects/grpc.sln
   /cygdrive/c/nuget/nuget.exe restore src/csharp/Grpc.sln
 
-  python tools/run_tests/run_tests.py -t -l $language -x report.xml || true
+  python tools/run_tests/run_tests.py -t -l $language -x report.xml $@ || true
 
 elif [ "$platform" == "macos" ]
 then
   echo "building $language on MacOS"
 
-  ./tools/run_tests/run_tests.py -t -l $language -c $config -x report.xml || true
+  ./tools/run_tests/run_tests.py -t -l $language -c $config -x report.xml $@ || true
 
 elif [ "$platform" == "freebsd" ]
 then
   echo "building $language on FreeBSD"
 
-  MAKE=gmake ./tools/run_tests/run_tests.py -t -l $language -c $config -x report.xml || true
+  MAKE=gmake ./tools/run_tests/run_tests.py -t -l $language -c $config -x report.xml $@ || true
 else
   echo "Unknown platform $platform"
   exit 1


### PR DESCRIPTION
This is to allow customizing the run_jenkins environment per-project from Jenkins itself