### PR TITLE
Remove one pessimizing std::move

### DIFF
--- a/test/cpp/end2end/streaming_throughput_test.cc
+++ b/test/cpp/end2end/streaming_throughput_test.cc
@@ -145,7 +145,7 @@ class End2endTest : public ::testing::Test {
   void ResetStub() {
     std::shared_ptr<Channel> channel = CreateChannel(
         server_address_.str(), InsecureCredentials());
-    stub_ = std::move(grpc::cpp::test::util::TestService::NewStub(channel));
+    stub_ = grpc::cpp::test::util::TestService::NewStub(channel);
   }
 
   std::unique_ptr<grpc::cpp::test::util::TestService::Stub> stub_;


### PR DESCRIPTION
Followup to PR #3191 and #3214 
