### PR TITLE
Add more test cases to end2end test. 

### DIFF
--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -62,7 +62,6 @@ using std::chrono::system_clock;
 
 namespace grpc {
 namespace testing {
-
 namespace {
 
 const char* kServerCancelAfterReads = "cancel_after_reads";
@@ -693,7 +692,6 @@ TEST_P(End2endTest, RequestStreamServerEarlyCancelTest) {
   EXPECT_EQ(s.error_code(), StatusCode::CANCELLED);
 }
 
-namespace {
 void ReaderThreadFunc(ClientReaderWriter<EchoRequest, EchoResponse>* stream,
                       gpr_event* ev) {
   EchoResponse resp;
@@ -702,7 +700,6 @@ void ReaderThreadFunc(ClientReaderWriter<EchoRequest, EchoResponse>* stream,
     gpr_log(GPR_INFO, "Read message");
   }
 }
-}  // namespace
 
 // Run a Read and a WritesDone simultaneously.
 TEST_P(End2endTest, SimultaneousReadWritesDone) {


### PR DESCRIPTION
Test can be with or without proxy and with and without tls. 
Now each test is in one of the three suites:
End2endTest uses no proxy but tests tls and plain text..
SecureEnd2endTest uses no proxy but uses tls.
ProxyEnd2endTest tests exercise the full matrix.