### PR TITLE
Make podspec lint pass for submitting ObjC beta to Cocoapods

### DIFF
--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -36,14 +36,15 @@
 
 Pod::Spec.new do |s|
   s.name     = 'gRPC'
-  s.version  = '0.11.0'
+  version = '0.11.1'
+  s.version  = version
   s.summary  = 'gRPC client library for iOS/OSX'
   s.homepage = 'http://www.grpc.io'
   s.license  = 'New BSD'
   s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
 
-  # s.source = { :git => 'https://github.com/grpc/grpc.git',
-  #              :tag => 'release-0_11_0-objectivec-0.11.0' }
+  s.source = { :git => 'https://github.com/grpc/grpc.git',
+               :tag => "release-#{version.gsub(/\./, '_')}-objectivec-#{version}" }
 
   s.ios.deployment_target = '7.1'
   s.osx.deployment_target = '10.9'

--- a/include/grpc/support/port_platform.h
+++ b/include/grpc/support/port_platform.h
@@ -174,8 +174,6 @@
 #endif /* _LP64 */
 #elif defined(__APPLE__)
 #include <TargetConditionals.h>
-/* Provides IPV6_RECVPKTINFO */
-#define __APPLE_USE_RFC_3542
 #ifndef _BSD_SOURCE
 #define _BSD_SOURCE
 #endif

--- a/src/core/iomgr/udp_server.c
+++ b/src/core/iomgr/udp_server.c
@@ -235,7 +235,7 @@ static int prepare_socket(int fd, const struct sockaddr *addr, int addr_len) {
   rc = setsockopt(fd, IPPROTO_IP, IP_PKTINFO, &get_local_ip,
                   sizeof(get_local_ip));
   if (rc == 0 && addr->sa_family == AF_INET6) {
-#if !TARGET_OS_IPHONE
+#if !defined(__APPLE__)
     rc = setsockopt(fd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &get_local_ip,
                     sizeof(get_local_ip));
 #endif

--- a/templates/gRPC.podspec.template
+++ b/templates/gRPC.podspec.template
@@ -63,14 +63,16 @@
   %>
   Pod::Spec.new do |s|
     s.name     = 'gRPC'
-    s.version  = '0.11.0'
+    version = '0.11.1'
+    s.version  = version
     s.summary  = 'gRPC client library for iOS/OSX'
     s.homepage = 'http://www.grpc.io'
     s.license  = 'New BSD'
     s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
-  
-    # s.source = { :git => 'https://github.com/grpc/grpc.git',
-    #              :tag => 'release-0_11_0-objectivec-0.11.0' }
+
+    s.source = { :git => 'https://github.com/grpc/grpc.git',
+                 :tag => "release-#{version.gsub(/\./, '_')}-objectivec-#{version}" }
+
   
     s.ios.deployment_target = '7.1'
     s.osx.deployment_target = '10.9'


### PR DESCRIPTION
Updates the version number, and fixes https://github.com/grpc/grpc/issues/3041 for OS X (follow up on issue https://github.com/grpc/grpc/issues/3041).