### PR TITLE
Node test coverage reporting

### DIFF
--- a/src/node/.istanbul.yml
+++ b/src/node/.istanbul.yml
@@ -1,0 +1,6 @@
+reporting:
+    watermarks:
+        statements: [80, 95]
+        lines: [80, 95]
+        functions: [80, 95]
+        branches: [80, 95]

--- a/src/node/binding.gyp
+++ b/src/node/binding.gyp
@@ -1,4 +1,7 @@
 {
+  "variables" : {
+    'config': '<!(echo $CONFIG)'
+  },
   "targets" : [
     {
       'include_dirs': [
@@ -22,6 +25,18 @@
             'pkg_config_grpc': '<!(pkg-config --exists grpc >/dev/null 2>&1 && echo true || echo false)'
           },
           'conditions': [
+            ['config=="gcov"', {
+              'cflags': [
+                '-ftest-coverage',
+                '-fprofile-arcs',
+                '-O0'
+              ],
+              'ldflags': [
+                '-ftest-coverage',
+                '-fprofile-arcs'
+              ]
+            }
+           ],
             ['pkg_config_grpc == "true"', {
               'link_settings': {
                 'libraries': [

--- a/src/node/package.json
+++ b/src/node/package.json
@@ -21,8 +21,9 @@
   },
   "scripts": {
     "lint": "node ./node_modules/jshint/bin/jshint src test examples interop index.js",
-    "test": "node ./node_modules/mocha/bin/mocha && npm run-script lint",
-    "gen_docs": "./node_modules/.bin/jsdoc -c jsdoc_conf.json"
+    "test": "./node_modules/.bin/mocha && npm run-script lint",
+    "gen_docs": "./node_modules/.bin/jsdoc -c jsdoc_conf.json",
+    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha"
   },
   "dependencies": {
     "bindings": "^1.2.0",
@@ -33,6 +34,7 @@
   "devDependencies": {
     "async": "^0.9.0",
     "google-auth-library": "^0.9.2",
+    "istanbul": "^0.3.21",
     "jsdoc": "^3.3.2",
     "jshint": "^2.5.0",
     "minimist": "^1.1.0",

--- a/tools/run_tests/run_node.sh
+++ b/tools/run_tests/run_node.sh
@@ -37,6 +37,19 @@ cd $(dirname $0)/../..
 
 root=`pwd`
 
+cd $root/src/node
+
 export LD_LIBRARY_PATH=$root/libs/$CONFIG
 
-$root/src/node/node_modules/mocha/bin/mocha --timeout 8000 $root/src/node/test
+if [ "$CONFIG" = "gcov" ]
+then
+  ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- \
+    --timeout 8000
+  cd build
+  gcov Release/obj.target/grpc/ext/*.o
+  lcov --base-directory . --directory . -c -o coverage.info
+  genhtml -o ../ext_coverage --num-spaces 2 -t 'Node gRPC test coverage' \
+    coverage.info
+else
+  ./node_modules/mocha/bin/mocha --timeout 8000
+fi


### PR DESCRIPTION
Makes `run_tests.py -l node -c gcov` generate HTML coverage reports for the Node extension and Node code in `src/node/ext_coverage` and `src/node/coverage` respectively. This fixes #944.