### PR TITLE
Small changes to tools/ Python scripts

### DIFF
--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -46,6 +46,7 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/grpc/grpc.git',
                :tag => "release-#{version.gsub(/\./, '_')}-objectivec-#{version}" }
 
+
   s.ios.deployment_target = '7.1'
   s.osx.deployment_target = '10.9'
   s.requires_arc = true

--- a/tools/buildgen/generate_projects.py
+++ b/tools/buildgen/generate_projects.py
@@ -55,7 +55,7 @@ for root, dirs, files in os.walk('templates'):
       out = out_dir + '/' + os.path.splitext(f)[0]
       if not os.path.exists(out_dir):
         os.makedirs(out_dir)
-      cmd = ['python', 'tools/buildgen/mako_renderer.py']
+      cmd = ['python2.7', 'tools/buildgen/mako_renderer.py']
       for plugin in plugins:
         cmd.append('-p')
         cmd.append(plugin)

--- a/tools/buildgen/generate_projects.py
+++ b/tools/buildgen/generate_projects.py
@@ -34,6 +34,7 @@ import os
 import shutil
 import sys
 import tempfile
+import multiprocessing
 sys.path.append(os.path.join(os.path.dirname(sys.argv[0]), '..', 'run_tests'))
 
 assert sys.argv[1:], 'run generate_projects.sh instead of this directly'
@@ -73,7 +74,7 @@ for root, dirs, files in os.walk('templates'):
       cmd.append(root + '/' + f)
       jobs.append(jobset.JobSpec(cmd, shortname=out))
 
-jobset.run(jobs)
+jobset.run(jobs, maxjobs=multiprocessing.cpu_count())
 
 if test is not None:
   for s, g in test.iteritems():

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -728,7 +728,7 @@ def _start_port_server(port_server_port):
   if not running:
     port_log = open('portlog.txt', 'w')
     port_server = subprocess.Popen(
-        ['python', 'tools/run_tests/port_server.py', '-p', '%d' % port_server_port],
+        ['python2.7', 'tools/run_tests/port_server.py', '-p', '%d' % port_server_port],
         stderr=subprocess.STDOUT,
         stdout=port_log)
     # ensure port server is up


### PR DESCRIPTION
1) Explicit Python version for port_server, in the same way that it's specified in the shebang line. This matters in cases where the default Python version isn't a 2.x one (ie, Arch Linux).
2) Idem for generate_projects.py
3) Limited number of concurrent jobs in generate_projects.py. The current 31 python subprocesses (some of them heavy) are hard to handle by old-ish hardware. Now limiting to the number of available cores (as the mako rendering is cpu-bound).

