### PR TITLE
Deflake end2end_test

### DIFF
--- a/src/core/iomgr/pollset_posix.c
+++ b/src/core/iomgr/pollset_posix.c
@@ -354,6 +354,7 @@ static void basic_do_promote(grpc_exec_ctx *exec_ctx, void *args, int success) {
   if (pollset->shutting_down) {
     /* We don't care about this pollset anymore. */
     if (pollset->in_flight_cbs == 0 && !pollset->called_shutdown) {
+      pollset->called_shutdown = 1;
       finish_shutdown(exec_ctx, pollset);
     }
   } else if (grpc_fd_is_orphaned(fd)) {

--- a/src/core/transport/chttp2_transport.c
+++ b/src/core/transport/chttp2_transport.c
@@ -1136,7 +1136,7 @@ static void recv_data(grpc_exec_ctx *exec_ctx, void *tp, int success) {
     grpc_chttp2_publish_reads(exec_ctx, &t->global, &t->parsing);
     t->parsing_active = 0;
   }
-  if (!success || i != t->read_buffer.count) {
+  if (!success || i != t->read_buffer.count || t->closed) {
     drop_connection(exec_ctx, t);
     read_error_locked(exec_ctx, t);
   } else if (!t->closed) {

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -683,8 +683,12 @@ TEST_P(End2endTest, RequestStreamServerEarlyCancelTest) {
   auto stream = stub_->RequestStream(&context, &response);
   request.set_message("hello");
   int send_messages = 20;
-  while (send_messages > 0) {
+  while (send_messages > 10) {
     EXPECT_TRUE(stream->Write(request));
+    send_messages--;
+  }
+  while (send_messages > 0) {
+    stream->Write(request);
     send_messages--;
   }
   stream->WritesDone();


### PR DESCRIPTION
Fixes a couple of bugs causing the end2end_test to be flaky especially after the plaintext tests were added. 

There is one more asan flake and it will be solved in a separate PR.