### PR TITLE
Add go support to run_interop_tests.py

### DIFF
--- a/tools/jenkins/grpc_interop_go/Dockerfile
+++ b/tools/jenkins/grpc_interop_go/Dockerfile
@@ -1,0 +1,36 @@
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+FROM golang:1.4
+
+# Using login shell removes Go from path, so we add it.
+RUN ln -s /usr/src/go/bin/go /usr/local/bin
+
+# Define the default command.
+CMD ["bash"]

--- a/tools/jenkins/grpc_interop_go/build_interop.sh
+++ b/tools/jenkins/grpc_interop_go/build_interop.sh
@@ -37,6 +37,8 @@ set -e
 git clone --recursive /var/local/jenkins/grpc-go src/gooogle.golang.org/grpc
 
 # Get dependencies from GitHub
+# NOTE: once grpc-go dependencies change, this needs to be updated manually
+# but we don't expect this to happen any time soon.
 go get github.com/golang/protobuf/proto
 go get golang.org/x/net/context
 go get golang.org/x/net/trace

--- a/tools/jenkins/grpc_interop_go/build_interop.sh
+++ b/tools/jenkins/grpc_interop_go/build_interop.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Builds Go interop server and client in a base image.
+set -e
+
+# Clone just the grpc-go source code without any dependencies.
+# We are cloning from a local git repo that contains the right revision
+# to test instead of using "go get" to download from Github directly.
+git clone --recursive /var/local/jenkins/grpc-go src/gooogle.golang.org/grpc
+
+# Get dependencies from GitHub
+go get github.com/golang/protobuf/proto
+go get golang.org/x/net/context
+go get golang.org/x/net/trace
+go get golang.org/x/oauth2
+go get google.golang.org/cloud
+
+# Build the interop client and server
+(cd src/google.golang.org/grpc/interop/client && go install)
+(cd src/google.golang.org/grpc/interop/server && go install)

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -61,8 +61,9 @@ _CLOUD_TO_CLOUD_BASE_ARGS = [
 # supported by C core SslCredentials instead.
 _SSL_CERT_ENV = { 'SSL_CERT_FILE':'/usr/local/share/grpc/roots.pem' }
 
-# TODO(jtatttermusch) unify usage of --use_tls and --use_tls=true
-# TODO(jtatttermusch) unify usage of --use_prod_roots and --use_test_ca
+# TODO(jtattermusch) unify usage of --use_tls and --use_tls=true
+# TODO(jtattermusch) unify usage of --use_prod_roots and --use_test_ca
+# TODO(jtattermusch) go uses --tls_ca_file instead of --use_test_ca
 
 
 class CXXLanguage:
@@ -140,6 +141,32 @@ class JavaLanguage:
     return 'java'
 
 
+class GoLanguage:
+
+  def __init__(self):
+    self.client_cmdline_base = ['go', 'run', 'client.go']
+    # TODO: this relies on running inside docker
+    self.client_cwd = '/go/src/google.golang.org/grpc/interop/client'
+    self.server_cwd = '/go/src/google.golang.org/grpc/interop/server'
+
+  def cloud_to_prod_args(self):
+    return (self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS +
+            ['--use_tls=true', '--tls_ca_file=""'])
+
+  def cloud_to_cloud_args(self):
+    return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
+            ['--use_tls=true'])
+
+  def cloud_to_prod_env(self):
+    return None
+
+  def server_args(self):
+    return ['go', 'run', 'server.go', '--use_tls=true']
+
+  def __str__(self):
+    return 'go'
+
+
 class NodeLanguage:
 
   def __init__(self):
@@ -215,6 +242,7 @@ class RubyLanguage:
 _LANGUAGES = {
     'c++' : CXXLanguage(),
     'csharp' : CSharpLanguage(),
+    'go' : GoLanguage(),
     'java' : JavaLanguage(),
     'node' : NodeLanguage(),
     'php' :  PHPLanguage(),
@@ -223,7 +251,7 @@ _LANGUAGES = {
 
 # languages supported as cloud_to_cloud servers
 # TODO(jtattermusch): enable other languages as servers as well
-_SERVERS = ['c++', 'node', 'csharp', 'java']
+_SERVERS = ['c++', 'node', 'csharp', 'java', 'go']
 
 # TODO(jtattermusch): add empty_stream once PHP starts supporting it.
 # TODO(jtattermusch): add timeout_on_sleeping_server once java starts supporting it.


### PR DESCRIPTION
This adds go support to tests run by https://grpc-testing.appspot.com/job/gRPC_interop_master/.

I tested by running run_interop_tests.py locally and everything seems to work fine.

