### PR TITLE
Use sys.executable instead of hard coding python binary string

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -732,7 +732,7 @@ def _start_port_server(port_server_port):
     print 'starting port_server'
     port_log = open('portlog.txt', 'w')
     port_server = subprocess.Popen(
-        ['python2.7', 'tools/run_tests/port_server.py', '-p', '%d' % port_server_port],
+        [sys.executable, 'tools/run_tests/port_server.py', '-p', '%d' % port_server_port],
         stderr=subprocess.STDOUT,
         stdout=port_log)
     # ensure port server is up


### PR DESCRIPTION
This is necessary to get the right binary on Windows

Fixes #3636