### PR TITLE
Enable `pip` caching

### DIFF
--- a/tools/jenkins/build_docker_and_run_tests.sh
+++ b/tools/jenkins/build_docker_and_run_tests.sh
@@ -37,7 +37,12 @@ cd `dirname $0`/../..
 git_root=`pwd`
 cd -
 
+# Ensure existence of ccache directory
 mkdir -p /tmp/ccache
+
+# Ensure existence of the home directory for XDG caches (e.g. what pip uses for
+# its cache location now that --download-cache is deprecated).
+mkdir -p /tmp/xdg-cache-home
 
 # Create a local branch so the child Docker script won't complain
 git branch -f jenkins-docker
@@ -57,9 +62,11 @@ docker run \
   -e "config=$config" \
   -e "arch=$arch" \
   -e CCACHE_DIR=/tmp/ccache \
+  -e XDG_CACHE_HOME=/tmp/xdg-cache-home \
   -i $TTY_FLAG \
   -v "$git_root:/var/local/jenkins/grpc" \
   -v /tmp/ccache:/tmp/ccache \
+  -v /tmp/xdg-cache-home:/tmp/xdg-cache-home \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -v $(which docker):/bin/docker \
   -w /var/local/git/grpc \

--- a/tools/jenkins/docker_run_tests.sh
+++ b/tools/jenkins/docker_run_tests.sh
@@ -36,6 +36,10 @@ set -e
 export CONFIG=$config
 export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer-3.5
 
+# Ensure that programs depending on current-user-ownership of cache directories
+# are satisfied (it's being mounted from outside the image).
+chown `whoami` $XDG_CACHE_HOME
+
 mkdir -p /var/local/git
 git clone --recursive /var/local/jenkins/grpc /var/local/git/grpc
 

--- a/tools/jenkins/grpc_jenkins_slave/Dockerfile
+++ b/tools/jenkins/grpc_jenkins_slave/Dockerfile
@@ -126,10 +126,11 @@ RUN /bin/bash -l -c "gem install bundler --no-ri --no-rdoc"
 RUN apt-get update && apt-get install -y \
     python-all-dev \
     python3-all-dev \
-    python-pip \
-    python-virtualenv
+    python-pip
 
 # Install Python packages from PyPI
+RUN pip install pip --upgrade
+RUN pip install virtualenv
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.0.0a2
 
 # For sanity test

--- a/tools/run_tests/build_python.sh
+++ b/tools/run_tests/build_python.sh
@@ -39,9 +39,6 @@ GRPCIO=$ROOT/src/python/grpcio
 GRPCIO_TEST=$ROOT/src/python/grpcio_test
 GRPCIO_HEALTH_CHECKING=$ROOT/src/python/grpcio_health_checking
 
-#
-# Dependency steps.
-#
 install_grpcio_deps() {
   cd $GRPCIO
   pip install -r requirements.txt
@@ -50,14 +47,7 @@ install_grpcio_test_deps() {
   cd $GRPCIO_TEST
   pip install -r requirements.txt
 }
-#
-# End dependency steps.
-#
 
-#
-# Install steps. Requires that the `pip` command is appropriate (i.e. that the
-# virtual environment has been activated).
-#
 install_grpcio() {
   CFLAGS="-I$ROOT/include -std=c89" LDFLAGS=-L$ROOT/libs/$CONFIG GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install $GRPCIO
 }
@@ -67,9 +57,6 @@ install_grpcio_test() {
 install_grpcio_health_checking() {
   pip install $GRPCIO_HEALTH_CHECKING
 }
-#
-# End install steps.
-#
 
 # Cleans the environment of previous installations
 clean_grpcio_all() {

--- a/tools/run_tests/build_python.sh
+++ b/tools/run_tests/build_python.sh
@@ -39,6 +39,46 @@ GRPCIO=$ROOT/src/python/grpcio
 GRPCIO_TEST=$ROOT/src/python/grpcio_test
 GRPCIO_HEALTH_CHECKING=$ROOT/src/python/grpcio_health_checking
 
+#
+# Dependency steps.
+#
+install_grpcio_deps() {
+  cd $GRPCIO
+  pip install -r requirements.txt
+}
+install_grpcio_test_deps() {
+  cd $GRPCIO_TEST
+  pip install -r requirements.txt
+}
+#
+# End dependency steps.
+#
+
+#
+# Install steps. Requires that the `pip` command is appropriate (i.e. that the
+# virtual environment has been activated).
+#
+install_grpcio() {
+  CFLAGS="-I$ROOT/include -std=c89" LDFLAGS=-L$ROOT/libs/$CONFIG GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install $GRPCIO
+}
+install_grpcio_test() {
+  pip install $GRPCIO_TEST
+}
+install_grpcio_health_checking() {
+  pip install $GRPCIO_HEALTH_CHECKING
+}
+#
+# End install steps.
+#
+
+# Cleans the environment of previous installations
+clean_grpcio_all() {
+  (yes | pip uninstall grpcio) || true
+  (yes | pip uninstall grpcio_test) || true
+  (yes | pip uninstall grpcio_health_checking) || true
+}
+
+# Builds the testing environment.
 make_virtualenv() {
   virtualenv_name="python"$1"_virtual_environment"
   if [ ! -d $virtualenv_name ]
@@ -48,33 +88,29 @@ make_virtualenv() {
     source $virtualenv_name/bin/activate
 
     # Install grpcio
-    cd $GRPCIO
-    pip install -r requirements.txt
-    CFLAGS="-I$ROOT/include -std=c89" LDFLAGS=-L$ROOT/libs/$CONFIG GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install $GRPCIO
+    install_grpcio_deps
+    install_grpcio
 
     # Install grpcio_test
-    cd $GRPCIO_TEST
-    pip install -r requirements.txt
-    pip install $GRPCIO_TEST
+    install_grpcio_test_deps
+    install_grpcio_test
 
     # Install grpcio_health_checking
-    pip install $GRPCIO_HEALTH_CHECKING
+    install_grpcio_health_checking
   else
     source $virtualenv_name/bin/activate
     # Uninstall and re-install the packages we care about. Don't use
     # --force-reinstall or --ignore-installed to avoid propagating this
     # unnecessarily to dependencies. Don't use --no-deps to avoid missing
     # dependency upgrades.
-    (yes | pip uninstall grpcio) || true
-    (yes | pip uninstall grpcio_test) || true
-    (yes | pip uninstall grpcio_health_checking) || true
-    (CFLAGS="-I$ROOT/include -std=c89" LDFLAGS=-L$ROOT/libs/$CONFIG GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install $GRPCIO) || (
+    clean_grpcio_all
+    install_grpcio || (
       # Fall back to rebuilding the entire environment
       rm -rf $virtualenv_name
       make_virtualenv $1
     )
-    pip install $GRPCIO_TEST
-    pip install $GRPCIO_HEALTH_CHECKING
+    install_grpcio_test
+    install_grpcio_health_checking
   fi
 }
 


### PR DESCRIPTION
@nathanielmanistaatgoogle I threw in a little clean-up refactoring in build_python.sh in prep for whatever comes of future efforts to split external dependency build steps from gRPC build steps.

Somewhat fixes #3623 (but there'll be more on that front for everyone's general build-flakiness-due-to-network-snafus). The basic requirement, as with any caching solution, is that at least one of the previous builds with the same version requirements succeeded.

Tagged DNM to watch what happens on Jenkins.