### PR TITLE
Fixed data races for trace variables

### DIFF
--- a/src/core/channel/channel_stack.c
+++ b/src/core/channel/channel_stack.c
@@ -32,12 +32,13 @@
  */
 
 #include "src/core/channel/channel_stack.h"
+#include <grpc/support/atm.h>
 #include <grpc/support/log.h>
 
 #include <stdlib.h>
 #include <string.h>
 
-int grpc_trace_channel = 0;
+gpr_atm grpc_trace_channel = 0;
 
 /* Memory layouts.
 

--- a/src/core/channel/channel_stack.h
+++ b/src/core/channel/channel_stack.h
@@ -44,6 +44,7 @@
 #include <stddef.h>
 
 #include <grpc/grpc.h>
+#include <grpc/support/atm.h>
 #include <grpc/support/log.h>
 #include "src/core/debug/trace.h"
 #include "src/core/transport/transport.h"
@@ -199,9 +200,9 @@ void grpc_call_log_op(char *file, int line, gpr_log_severity severity,
 void grpc_call_element_send_cancel(grpc_exec_ctx *exec_ctx,
                                    grpc_call_element *cur_elem);
 
-extern int grpc_trace_channel;
+extern gpr_atm grpc_trace_channel;
 
 #define GRPC_CALL_LOG_OP(sev, elem, op) \
-  if (grpc_trace_channel) grpc_call_log_op(sev, elem, op)
+  if (GRPC_TRACE_ENABLED(grpc_trace_channel)) grpc_call_log_op(sev, elem, op)
 
 #endif /* GRPC_INTERNAL_CORE_CHANNEL_CHANNEL_STACK_H */

--- a/src/core/client_config/lb_policies/round_robin.h
+++ b/src/core/client_config/lb_policies/round_robin.h
@@ -36,7 +36,7 @@
 
 #include "src/core/client_config/lb_policy.h"
 
-extern int grpc_lb_round_robin_trace;
+extern gpr_atm grpc_lb_round_robin_trace;
 
 #include "src/core/client_config/lb_policy_factory.h"
 

--- a/src/core/debug/trace.h
+++ b/src/core/debug/trace.h
@@ -34,10 +34,13 @@
 #ifndef GRPC_INTERNAL_CORE_DEBUG_TRACE_H
 #define GRPC_INTERNAL_CORE_DEBUG_TRACE_H
 
+#include <grpc/support/atm.h>
 #include <grpc/support/port_platform.h>
 
-void grpc_register_tracer(const char *name, int *flag);
+void grpc_register_tracer(const char *name, gpr_atm *flag);
 void grpc_tracer_init(const char *env_var_name);
 void grpc_tracer_shutdown(void);
+
+#define GRPC_TRACE_ENABLED(tracer) gpr_atm_acq_load(&(tracer))
 
 #endif /* GRPC_INTERNAL_CORE_DEBUG_TRACE_H */

--- a/src/core/iomgr/tcp_client_posix.c
+++ b/src/core/iomgr/tcp_client_posix.c
@@ -42,6 +42,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include "src/core/debug/trace.h"
 #include "src/core/iomgr/alarm.h"
 #include "src/core/iomgr/iomgr_posix.h"
 #include "src/core/iomgr/pollset_posix.h"
@@ -54,7 +55,7 @@
 #include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 
-extern int grpc_tcp_trace;
+extern gpr_atm grpc_tcp_trace;
 
 typedef struct {
   gpr_mu mu;
@@ -94,7 +95,7 @@ error:
 static void tc_on_alarm(grpc_exec_ctx *exec_ctx, void *acp, int success) {
   int done;
   async_connect *ac = acp;
-  if (grpc_tcp_trace) {
+  if (GRPC_TRACE_ENABLED(grpc_tcp_trace)) {
     gpr_log(GPR_DEBUG, "CLIENT_CONNECT: %s: on_alarm: success=%d", ac->addr_str,
             success);
   }
@@ -121,7 +122,7 @@ static void on_writable(grpc_exec_ctx *exec_ctx, void *acp, int success) {
   grpc_closure *closure = ac->closure;
   grpc_fd *fd;
 
-  if (grpc_tcp_trace) {
+  if (GRPC_TRACE_ENABLED(grpc_tcp_trace)) {
     gpr_log(GPR_DEBUG, "CLIENT_CONNECT: %s: on_writable: success=%d",
             ac->addr_str, success);
   }
@@ -284,7 +285,7 @@ void grpc_tcp_client_connect(grpc_exec_ctx *exec_ctx, grpc_closure *closure,
   ac->write_closure.cb = on_writable;
   ac->write_closure.cb_arg = ac;
 
-  if (grpc_tcp_trace) {
+  if (GRPC_TRACE_ENABLED(grpc_tcp_trace)) {
     gpr_log(GPR_DEBUG, "CLIENT_CONNECT: %s: asynchronously connecting",
             ac->addr_str);
   }

--- a/src/core/iomgr/tcp_posix.c
+++ b/src/core/iomgr/tcp_posix.c
@@ -67,7 +67,7 @@ typedef GPR_MSG_IOVLEN_TYPE msg_iovlen_type;
 typedef size_t msg_iovlen_type;
 #endif
 
-int grpc_tcp_trace = 0;
+gpr_atm grpc_tcp_trace = 0;
 
 typedef struct {
   grpc_endpoint base;
@@ -154,7 +154,7 @@ static void tcp_destroy(grpc_exec_ctx *exec_ctx, grpc_endpoint *ep) {
 static void call_read_cb(grpc_exec_ctx *exec_ctx, grpc_tcp *tcp, int success) {
   grpc_closure *cb = tcp->read_cb;
 
-  if (grpc_tcp_trace) {
+  if (GRPC_TRACE_ENABLED(grpc_tcp_trace)) {
     size_t i;
     gpr_log(GPR_DEBUG, "read: success=%d", success);
     for (i = 0; i < tcp->incoming_buffer->count; i++) {
@@ -388,7 +388,7 @@ static void tcp_write(grpc_exec_ctx *exec_ctx, grpc_endpoint *ep,
   grpc_tcp *tcp = (grpc_tcp *)ep;
   flush_result status;
 
-  if (grpc_tcp_trace) {
+  if (GRPC_TRACE_ENABLED(grpc_tcp_trace)) {
     size_t i;
 
     for (i = 0; i < buf->count; i++) {

--- a/src/core/iomgr/tcp_posix.h
+++ b/src/core/iomgr/tcp_posix.h
@@ -47,9 +47,11 @@
 #include "src/core/iomgr/endpoint.h"
 #include "src/core/iomgr/fd_posix.h"
 
+#include <grpc/support/atm.h>
+
 #define GRPC_TCP_DEFAULT_READ_SLICE_SIZE 8192
 
-extern int grpc_tcp_trace;
+extern gpr_atm grpc_tcp_trace;
 
 /* Create a tcp endpoint given a file desciptor and a read slice size.
    Takes ownership of fd. */

--- a/src/core/iomgr/tcp_server_posix.c
+++ b/src/core/iomgr/tcp_server_posix.c
@@ -55,6 +55,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
+#include "src/core/debug/trace.h"
 #include "src/core/iomgr/pollset_posix.h"
 #include "src/core/iomgr/resolve_address.h"
 #include "src/core/iomgr/sockaddr_utils.h"
@@ -333,7 +334,7 @@ static void on_read(grpc_exec_ctx *exec_ctx, void *arg, int success) {
     addr_str = grpc_sockaddr_to_uri((struct sockaddr *)&addr);
     gpr_asprintf(&name, "tcp-server-connection:%s", addr_str);
 
-    if (grpc_tcp_trace) {
+    if (GRPC_TRACE_ENABLED(grpc_tcp_trace)) {
       gpr_log(GPR_DEBUG, "SERVER_CONNECT: incoming connection: %s", addr_str);
     }
 

--- a/src/core/security/secure_endpoint.c
+++ b/src/core/security/secure_endpoint.c
@@ -34,6 +34,7 @@
 #include "src/core/security/secure_endpoint.h"
 #include "src/core/support/string.h"
 #include <grpc/support/alloc.h>
+#include <grpc/support/atm.h>
 #include <grpc/support/log.h>
 #include <grpc/support/slice_buffer.h>
 #include <grpc/support/slice.h>
@@ -65,7 +66,7 @@ typedef struct {
   gpr_refcount ref;
 } secure_endpoint;
 
-int grpc_trace_secure_endpoint = 0;
+gpr_atm grpc_trace_secure_endpoint = 0;
 
 static void destroy(grpc_exec_ctx *exec_ctx, secure_endpoint *secure_ep) {
   secure_endpoint *ep = secure_ep;

--- a/src/core/security/secure_endpoint.h
+++ b/src/core/security/secure_endpoint.h
@@ -35,11 +35,12 @@
 #define GRPC_INTERNAL_CORE_SECURITY_SECURE_ENDPOINT_H
 
 #include "src/core/iomgr/endpoint.h"
+#include <grpc/support/atm.h>
 #include <grpc/support/slice.h>
 
 struct tsi_frame_protector;
 
-extern int grpc_trace_secure_endpoint;
+extern gpr_atm grpc_trace_secure_endpoint;
 
 /* Takes ownership of protector and to_wrap, and refs leftover_slices. */
 grpc_endpoint *grpc_secure_endpoint_create(

--- a/src/core/surface/api_trace.c
+++ b/src/core/surface/api_trace.c
@@ -33,4 +33,4 @@
 
 #include "src/core/surface/api_trace.h"
 
-int grpc_api_trace = 0;
+gpr_atm grpc_api_trace = 0;

--- a/src/core/surface/api_trace.h
+++ b/src/core/surface/api_trace.h
@@ -37,7 +37,7 @@
 #include "src/core/debug/trace.h"
 #include <grpc/support/log.h>
 
-extern int grpc_api_trace;
+extern gpr_atm grpc_api_trace;
 
 /* Provide unwrapping macros because we're in C89 and variadic macros weren't
    introduced until C99... */
@@ -58,7 +58,7 @@ extern int grpc_api_trace;
 /* Due to the limitations of C89's preprocessor, the arity of the var-arg list
    'nargs' must be specified. */
 #define GRPC_API_TRACE(fmt, nargs, args)                      \
-  if (grpc_api_trace) {                                       \
+  if (GRPC_TRACE_ENABLED(grpc_api_trace)) {                   \
     gpr_log(GPR_INFO, fmt GRPC_API_TRACE_UNWRAP##nargs args); \
   }
 

--- a/src/core/surface/call.h
+++ b/src/core/surface/call.h
@@ -36,6 +36,7 @@
 
 #include "src/core/channel/channel_stack.h"
 #include "src/core/channel/context.h"
+#include "src/core/debug/trace.h"
 #include "src/core/surface/api_trace.h"
 #include "src/core/surface/surface_trace.h"
 #include <grpc/grpc.h>
@@ -155,17 +156,19 @@ void grpc_call_context_set(grpc_call *call, grpc_context_index elem,
 void *grpc_call_context_get(grpc_call *call, grpc_context_index elem);
 
 #define GRPC_CALL_LOG_BATCH(sev, call, ops, nops, tag) \
-  if (grpc_api_trace) grpc_call_log_batch(sev, call, ops, nops, tag)
+  if (GRPC_TRACE_ENABLED(grpc_api_trace))              \
+  grpc_call_log_batch(sev, call, ops, nops, tag)
 
 #define GRPC_SERVER_LOG_REQUEST_CALL(sev, server, call, details,             \
                                      initial_metadata, cq_bound_to_call,     \
                                      cq_for_notifications, tag)              \
-  if (grpc_api_trace)                                                        \
+  if (GRPC_TRACE_ENABLED(grpc_api_trace))                                    \
   grpc_server_log_request_call(sev, server, call, details, initial_metadata, \
                                cq_bound_to_call, cq_for_notifications, tag)
 
 #define GRPC_SERVER_LOG_SHUTDOWN(sev, server, cq, tag) \
-  if (grpc_api_trace) grpc_server_log_shutdown(sev, server, cq, tag)
+  if (GRPC_TRACE_ENABLED(grpc_api_trace))              \
+  grpc_server_log_shutdown(sev, server, cq, tag)
 
 gpr_uint8 grpc_call_is_client(grpc_call *call);
 

--- a/src/core/surface/surface_trace.h
+++ b/src/core/surface/surface_trace.h
@@ -39,7 +39,7 @@
 #include <grpc/support/log.h>
 
 #define GRPC_SURFACE_TRACE_RETURNED_EVENT(cq, event)    \
-  if (grpc_api_trace) {                                 \
+  if (GRPC_TRACE_ENABLED(grpc_api_trace)) {             \
     char *_ev = grpc_event_string(event);               \
     gpr_log(GPR_INFO, "RETURN_EVENT[%p]: %s", cq, _ev); \
     gpr_free(_ev);                                      \

--- a/src/core/transport/chttp2/frame_settings.c
+++ b/src/core/transport/chttp2/frame_settings.c
@@ -232,7 +232,7 @@ grpc_chttp2_parse_error grpc_chttp2_settings_parser_parse(
                     (int)transport_parsing->initial_window_update);
           }
           parser->incoming_settings[parser->id] = parser->value;
-          if (grpc_http_trace) {
+          if (GRPC_TRACE_ENABLED(grpc_http_trace)) {
             gpr_log(GPR_DEBUG, "CHTTP2:%s: got setting %d = %d",
                     transport_parsing->is_client ? "CLI" : "SVR", parser->id,
                     parser->value);

--- a/src/core/transport/chttp2/internal.h
+++ b/src/core/transport/chttp2/internal.h
@@ -598,8 +598,8 @@ void grpc_chttp2_parsing_become_skip_parser(
 #define GRPC_CHTTP2_CLIENT_CONNECT_STRLEN \
   (sizeof(GRPC_CHTTP2_CLIENT_CONNECT_STRING) - 1)
 
-extern int grpc_http_trace;
-extern int grpc_flowctl_trace;
+extern gpr_atm grpc_http_trace;
+extern gpr_atm grpc_flowctl_trace;
 
 #define GRPC_CHTTP2_IF_TRACING(stmt) \
   if (!(grpc_http_trace))            \

--- a/src/core/transport/chttp2_transport.c
+++ b/src/core/transport/chttp2_transport.c
@@ -57,8 +57,8 @@
 
 #define MAX_CLIENT_STREAM_ID 0x7fffffffu
 
-int grpc_http_trace = 0;
-int grpc_flowctl_trace = 0;
+gpr_atm grpc_http_trace = 0;
+gpr_atm grpc_flowctl_trace = 0;
 
 #define TRANSPORT_FROM_WRITING(tw)                                        \
   ((grpc_chttp2_transport *)((char *)(tw)-offsetof(grpc_chttp2_transport, \

--- a/src/core/transport/chttp2_transport.h
+++ b/src/core/transport/chttp2_transport.h
@@ -37,8 +37,8 @@
 #include "src/core/iomgr/endpoint.h"
 #include "src/core/transport/transport.h"
 
-extern int grpc_http_trace;
-extern int grpc_flowctl_trace;
+extern gpr_atm grpc_http_trace;
+extern gpr_atm grpc_flowctl_trace;
 
 grpc_transport *grpc_create_chttp2_transport(
     grpc_exec_ctx *exec_ctx, const grpc_channel_args *channel_args,

--- a/src/core/transport/connectivity_state.c
+++ b/src/core/transport/connectivity_state.c
@@ -32,6 +32,7 @@
  */
 
 #include "src/core/transport/connectivity_state.h"
+#include "src/core/debug/trace.h"
 
 #include <string.h>
 
@@ -39,7 +40,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 
-int grpc_connectivity_state_trace = 0;
+gpr_atm grpc_connectivity_state_trace = 0;
 
 const char *grpc_connectivity_state_name(grpc_connectivity_state state) {
   switch (state) {
@@ -87,7 +88,7 @@ void grpc_connectivity_state_destroy(grpc_exec_ctx *exec_ctx,
 
 grpc_connectivity_state grpc_connectivity_state_check(
     grpc_connectivity_state_tracker *tracker) {
-  if (grpc_connectivity_state_trace) {
+  if (GRPC_TRACE_ENABLED(grpc_connectivity_state_trace)) {
     gpr_log(GPR_DEBUG, "CONWATCH: %s: get %s", tracker->name,
             grpc_connectivity_state_name(tracker->current_state));
   }
@@ -97,7 +98,7 @@ grpc_connectivity_state grpc_connectivity_state_check(
 int grpc_connectivity_state_notify_on_state_change(
     grpc_exec_ctx *exec_ctx, grpc_connectivity_state_tracker *tracker,
     grpc_connectivity_state *current, grpc_closure *notify) {
-  if (grpc_connectivity_state_trace) {
+  if (GRPC_TRACE_ENABLED(grpc_connectivity_state_trace)) {
     gpr_log(GPR_DEBUG, "CONWATCH: %s: from %s [cur=%s] notify=%p",
             tracker->name, grpc_connectivity_state_name(*current),
             grpc_connectivity_state_name(tracker->current_state), notify);
@@ -141,7 +142,7 @@ void grpc_connectivity_state_set(grpc_exec_ctx *exec_ctx,
                                  grpc_connectivity_state state,
                                  const char *reason) {
   grpc_connectivity_state_watcher *w;
-  if (grpc_connectivity_state_trace) {
+  if (GRPC_TRACE_ENABLED(grpc_connectivity_state_trace)) {
     gpr_log(GPR_DEBUG, "SET: %s: %s --> %s [%s]", tracker->name,
             grpc_connectivity_state_name(tracker->current_state),
             grpc_connectivity_state_name(state), reason);

--- a/src/core/transport/connectivity_state.h
+++ b/src/core/transport/connectivity_state.h
@@ -55,7 +55,7 @@ typedef struct {
   char *name;
 } grpc_connectivity_state_tracker;
 
-extern int grpc_connectivity_state_trace;
+extern gpr_atm grpc_connectivity_state_trace;
 
 void grpc_connectivity_state_init(grpc_connectivity_state_tracker *tracker,
                                   grpc_connectivity_state init_state,

--- a/src/core/tsi/transport_security.c
+++ b/src/core/tsi/transport_security.c
@@ -38,7 +38,7 @@
 
 /* --- Tracing. --- */
 
-int tsi_tracing_enabled = 0;
+gpr_atm tsi_tracing_enabled = 0;
 
 /* --- Utils. --- */
 

--- a/src/core/tsi/transport_security.h
+++ b/src/core/tsi/transport_security.h
@@ -36,11 +36,13 @@
 
 #include "src/core/tsi/transport_security_interface.h"
 
+#include <grpc/support/atm.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-extern int tsi_tracing_enabled;
+extern gpr_atm tsi_tracing_enabled;
 
 /* Base for tsi_frame_protector implementations.
    See transport_security_interface.h for documentation. */

--- a/src/core/tsi/transport_security_interface.h
+++ b/src/core/tsi/transport_security_interface.h
@@ -37,6 +37,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <grpc/support/atm.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -64,7 +66,7 @@ const char *tsi_result_to_string(tsi_result result);
 /* --- tsi tracing --- */
 
 /* Set this early to avoid races */
-extern int tsi_tracing_enabled;
+extern gpr_atm tsi_tracing_enabled;
 
 /* --- tsi_frame_protector object ---
 


### PR DESCRIPTION
Fixes #3596, amongst others (any code reading trace variables while the DNS resolver thread is initializing).