### PR TITLE
Add auth interop test support to run_interop_tests.py

### DIFF
--- a/tools/jenkins/build_interop_image.sh
+++ b/tools/jenkins/build_interop_image.sh
@@ -35,12 +35,12 @@ set -x
 
 cd `dirname $0`/../..
 GRPC_ROOT=`pwd`
-MOUNT_ARGS="-v $GRPC_ROOT:/var/local/jenkins/grpc"
+MOUNT_ARGS="-v $GRPC_ROOT:/var/local/jenkins/grpc:ro"
 
 GRPC_JAVA_ROOT=`cd ../grpc-java && pwd`
 if [ "$GRPC_JAVA_ROOT" != "" ]
 then
-  MOUNT_ARGS+=" -v $GRPC_JAVA_ROOT:/var/local/jenkins/grpc-java"
+  MOUNT_ARGS+=" -v $GRPC_JAVA_ROOT:/var/local/jenkins/grpc-java:ro"
 else
   echo "WARNING: grpc-java not found, it won't be mounted to the docker container."
 fi
@@ -48,7 +48,7 @@ fi
 GRPC_GO_ROOT=`cd ../grpc-go && pwd`
 if [ "$GRPC_GO_ROOT" != "" ]
 then
-  MOUNT_ARGS+=" -v $GRPC_GO_ROOT:/var/local/jenkins/grpc-go"
+  MOUNT_ARGS+=" -v $GRPC_GO_ROOT:/var/local/jenkins/grpc-go:ro"
 else
   echo "WARNING: grpc-go not found, it won't be mounted to the docker container."
 fi
@@ -59,6 +59,14 @@ mkdir -p /tmp/ccache
 #  INTEROP_IMAGE - name of tag of the final interop image
 #  BASE_NAME - base name used to locate the base Dockerfile and build script
 #  TTY_FLAG - optional -t flag to make docker allocate tty.
+
+# Mount service account dir if available.
+# If service_directory does not contain the service account JSON file,
+# some of the tests will fail.
+if [ -e $HOME/service_account ]
+then
+  MOUNT_ARGS+=" -v $HOME/service_account:/var/local/jenkins/service_account:ro"
+fi
 
 # Use image name based on Dockerfile checksum
 BASE_IMAGE=${BASE_NAME}_base:`sha1sum tools/jenkins/$BASE_NAME/Dockerfile | cut -f1 -d\ `

--- a/tools/jenkins/grpc_interop_csharp/build_interop.sh
+++ b/tools/jenkins/grpc_interop_csharp/build_interop.sh
@@ -34,6 +34,9 @@ set -e
 mkdir -p /var/local/git
 git clone --recursive /var/local/jenkins/grpc /var/local/git/grpc
 
+# copy service account keys if available
+cp -r /var/local/jenkins/service_account $HOME || true
+
 cd /var/local/git/grpc
 
 make install-certs

--- a/tools/jenkins/grpc_interop_cxx/build_interop.sh
+++ b/tools/jenkins/grpc_interop_cxx/build_interop.sh
@@ -34,6 +34,9 @@ set -e
 mkdir -p /var/local/git
 git clone --recursive /var/local/jenkins/grpc /var/local/git/grpc
 
+# copy service account keys if available
+cp -r /var/local/jenkins/service_account $HOME || true
+
 cd /var/local/git/grpc
 
 make install-certs

--- a/tools/jenkins/grpc_interop_go/build_interop.sh
+++ b/tools/jenkins/grpc_interop_go/build_interop.sh
@@ -36,6 +36,9 @@ set -e
 # to test instead of using "go get" to download from Github directly.
 git clone --recursive /var/local/jenkins/grpc-go src/gooogle.golang.org/grpc
 
+# copy service account keys if available
+cp -r /var/local/jenkins/service_account $HOME || true
+
 # Get dependencies from GitHub
 # NOTE: once grpc-go dependencies change, this needs to be updated manually
 # but we don't expect this to happen any time soon.

--- a/tools/jenkins/grpc_interop_java/build_interop.sh
+++ b/tools/jenkins/grpc_interop_java/build_interop.sh
@@ -34,6 +34,9 @@ set -e
 mkdir -p /var/local/git
 git clone --recursive --depth 1 /var/local/jenkins/grpc-java /var/local/git/grpc-java
 
+# copy service account keys if available
+cp -r /var/local/jenkins/service_account $HOME || true
+
 cd /var/local/git/grpc-java
 
 ./gradlew :grpc-interop-testing:installDist -PskipCodegen=true

--- a/tools/jenkins/grpc_interop_node/build_interop.sh
+++ b/tools/jenkins/grpc_interop_node/build_interop.sh
@@ -34,6 +34,9 @@ set -e
 mkdir -p /var/local/git
 git clone --recursive /var/local/jenkins/grpc /var/local/git/grpc
 
+# copy service account keys if available
+cp -r /var/local/jenkins/service_account $HOME || true
+
 cd /var/local/git/grpc
 nvm use 0.12
 nvm alias default 0.12  # prevent the need to run 'nvm use' in every shell

--- a/tools/jenkins/grpc_interop_php/build_interop.sh
+++ b/tools/jenkins/grpc_interop_php/build_interop.sh
@@ -34,6 +34,9 @@ set -e
 mkdir -p /var/local/git
 git clone --recursive /var/local/jenkins/grpc /var/local/git/grpc
 
+# copy service account keys if available
+cp -r /var/local/jenkins/service_account $HOME || true
+
 cd /var/local/git/grpc
 rvm --default use ruby-2.1
 

--- a/tools/jenkins/grpc_interop_ruby/build_interop.sh
+++ b/tools/jenkins/grpc_interop_ruby/build_interop.sh
@@ -34,6 +34,9 @@ set -e
 mkdir -p /var/local/git
 git clone --recursive /var/local/jenkins/grpc /var/local/git/grpc
 
+# copy service account keys if available
+cp -r /var/local/jenkins/service_account $HOME || true
+
 cd /var/local/git/grpc
 rvm --default use ruby-2.1
 

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -82,7 +82,7 @@ class CXXLanguage:
             ['--use_tls=true'])
 
   def cloud_to_prod_env(self):
-    return None
+    return {}
 
   def server_args(self):
     return ['bins/opt/interop_server', '--use_tls=true']
@@ -132,7 +132,7 @@ class JavaLanguage:
             ['--use_tls=true', '--use_test_ca=true'])
 
   def cloud_to_prod_env(self):
-    return None
+    return {}
 
   def server_args(self):
     return ['./run-test-server.sh', '--use_tls=true']
@@ -158,7 +158,7 @@ class GoLanguage:
             ['--use_tls=true'])
 
   def cloud_to_prod_env(self):
-    return None
+    return {}
 
   def server_args(self):
     return ['go', 'run', 'server.go', '--use_tls=true']
@@ -260,6 +260,9 @@ _TEST_CASES = ['large_unary', 'empty_unary', 'ping_pong',
                'client_streaming', 'server_streaming',
                'cancel_after_begin', 'cancel_after_first_response']
 
+_AUTH_TEST_CASES = ['compute_engine_creds', 'jwt_token_creds',
+                    'oauth2_auth_token', 'per_rpc_creds']
+
 
 def docker_run_cmdline(cmdline, image, docker_args=[], cwd=None, environ=None):
   """Wraps given cmdline array to create 'docker run' cmdline from it."""
@@ -288,22 +291,54 @@ def bash_login_cmdline(cmdline):
   return ['bash', '-l', '-c', ' '.join(cmdline)]
 
 
-def cloud_to_prod_jobspec(language, test_case, docker_image=None):
+def add_auth_options(language, test_case, cmdline, env):
+  """Returns (cmdline, env) tuple with cloud_to_prod_auth test options."""
+
+  language = str(language)
+  cmdline = list(cmdline)
+  env = env.copy()
+
+  # TODO(jtattermusch): this file path only works inside docker
+  key_filepath = '/root/service_account/stubbyCloudTestingTest-ee3fce360ac5.json'
+  oauth_scope_arg = '--oauth_scope=https://www.googleapis.com/auth/xapi.zoo'
+  key_file_arg = '--service_account_key_file=%s' % key_filepath
+  default_account_arg = '--default_service_account=830293263384-compute@developer.gserviceaccount.com'
+
+  if test_case in ['jwt_token_creds', 'per_rpc_creds', 'oauth2_auth_token']:
+    if language in ['csharp', 'node', 'php', 'ruby']:
+      env['GOOGLE_APPLICATION_CREDENTIALS'] = key_filepath
+    else:
+      cmdline += [key_file_arg]
+
+  if test_case in ['per_rpc_creds', 'oauth2_auth_token']:
+    cmdline += [oauth_scope_arg]
+
+  if test_case == 'compute_engine_creds':
+    cmdline += [oauth_scope_arg, default_account_arg]
+
+  return (cmdline, env)
+
+
+def cloud_to_prod_jobspec(language, test_case, docker_image=None, auth=False):
   """Creates jobspec for cloud-to-prod interop test"""
-  cmdline = bash_login_cmdline(language.cloud_to_prod_args() +
-                               ['--test_case=%s' % test_case])
+  cmdline = language.cloud_to_prod_args() + ['--test_case=%s' % test_case]
   cwd = language.client_cwd
   environ = language.cloud_to_prod_env()
+  if auth:
+    cmdline, environ = add_auth_options(language, test_case, cmdline, environ)
+  cmdline = bash_login_cmdline(cmdline)
+
   if docker_image:
     cmdline = docker_run_cmdline(cmdline, image=docker_image, cwd=cwd, environ=environ)
     cwd = None
     environ = None
 
+  suite_name='cloud_to_prod_auth' if auth else 'cloud_to_prod'
   test_job = jobset.JobSpec(
           cmdline=cmdline,
           cwd=cwd,
           environ=environ,
-          shortname="cloud_to_prod:%s:%s" % (language, test_case),
+          shortname="%s:%s:%s" % (suite_name, language, test_case),
           timeout_seconds=2*60,
           flake_retries=5 if args.allow_flakes else 0,
           timeout_retries=2 if args.allow_flakes else 0)
@@ -382,6 +417,11 @@ argp.add_argument('--cloud_to_prod',
                   action='store_const',
                   const=True,
                   help='Run cloud_to_prod tests.')
+argp.add_argument('--cloud_to_prod_auth',
+                  default=False,
+                  action='store_const',
+                  const=True,
+                  help='Run cloud_to_prod_auth tests.')
 argp.add_argument('-s', '--server',
                   choices=['all'] + sorted(_SERVERS),
                   action='append',
@@ -474,6 +514,14 @@ try:
       for test_case in _TEST_CASES:
         test_job = cloud_to_prod_jobspec(language, test_case,
                                          docker_image=docker_images.get(str(language)))
+        jobs.append(test_job)
+
+  if args.cloud_to_prod_auth:
+    for language in languages:
+      for test_case in _AUTH_TEST_CASES:
+        test_job = cloud_to_prod_jobspec(language, test_case,
+                                         docker_image=docker_images.get(str(language)),
+                                         auth=True)
         jobs.append(test_job)
 
   for server in args.override_server:


### PR DESCRIPTION
enable running interop tests: compute_engine_creds, jwt_token_creds, oauth2_auth_token, per_rpc_creds.

these tests will be run if --cloud_to_prod_auth flag is used.

Jenkins will not run these test by default, because it turns out many of auth tests are currently broken (I filed separate issues for some of the breakages). 

Fixes #3633.

