### PR TITLE
PHP: update package.xml to prepare for 0.6.1 release

### DIFF
--- a/src/php/ext/grpc/package.xml
+++ b/src/php/ext/grpc/package.xml
@@ -10,10 +10,10 @@
   <email>grpc-packages@google.com</email>
   <active>yes</active>
  </lead>
- <date>2015-09-24</date>
- <time>09:51:04</time>
+ <date>2015-10-07</date>
+ <time>13:40:54</time>
  <version>
-  <release>0.6.0</release>
+  <release>0.6.1</release>
   <api>0.6.0</api>
  </version>
  <stability>
@@ -22,12 +22,7 @@
  </stability>
  <license>BSD</license>
  <notes>
-- support per message compression disable
-- expose per-call host override option
-- expose connectivity API
-- expose channel target and call peer
-- add user-agent
-- update to wrap gRPC C core library beta version 0.11.0
+- fixed undefined constant fatal error when run with apache/nginx #2275
  </notes>
  <contents>
   <dir baseinstalldir="/" name="/">
@@ -44,7 +39,7 @@
    <file baseinstalldir="/" md5sum="6988d6e97c19c8f8e3eb92371cf8246b" name="credentials.h" role="src" />
    <file baseinstalldir="/" md5sum="38a1bc979d810c36ebc2a52d4b7b5319" name="CREDITS" role="doc" />
    <file baseinstalldir="/" md5sum="3f35b472bbdef5a788cd90617d7d0847" name="LICENSE" role="doc" />
-   <file baseinstalldir="/" md5sum="6a550516a1423def0786851c76f87c85" name="php_grpc.c" role="src" />
+   <file baseinstalldir="/" md5sum="b77f1f3941aaf7a21090b493e9f26037" name="php_grpc.c" role="src" />
    <file baseinstalldir="/" md5sum="673b07859d9f69232f8a754c56780686" name="php_grpc.h" role="src" />
    <file baseinstalldir="/" md5sum="7533a6d3ea02c78cad23a9651de0825d" name="README.md" role="doc" />
    <file baseinstalldir="/" md5sum="3e4e960454ebb2fc7b78a840493f5315" name="server.c" role="src" />
@@ -116,6 +111,21 @@ Update to wrap gRPC C Core version 0.10.0
 - expose channel target and call peer
 - add user-agent
 - update to wrap gRPC C core library beta version 0.11.0
+   </notes>
+  </release>
+  <release>
+   <version>
+    <release>0.6.1</release>
+    <api>0.6.0</api>
+   </version>
+   <stability>
+    <release>beta</release>
+    <api>beta</api>
+   </stability>
+   <date>2015-10-07</date>
+   <license>BSD</license>
+   <notes>
+- fixed undefined constant fatal error when run with apache/nginx #2275
    </notes>
   </release>
  </changelog>

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -150,7 +150,7 @@ PHP_MINIT_FUNCTION(grpc) {
                          CONST_CS | CONST_PERSISTENT);
   REGISTER_LONG_CONSTANT("Grpc\\STATUS_INVALID_ARGUMENT",
                          GRPC_STATUS_INVALID_ARGUMENT,
-                        CONST_CS | CONST_PERSISTENT);
+                         CONST_CS | CONST_PERSISTENT);
   REGISTER_LONG_CONSTANT("Grpc\\STATUS_DEADLINE_EXCEEDED",
                          GRPC_STATUS_DEADLINE_EXCEEDED,
                          CONST_CS | CONST_PERSISTENT);
@@ -173,7 +173,8 @@ PHP_MINIT_FUNCTION(grpc) {
                          CONST_CS | CONST_PERSISTENT);
   REGISTER_LONG_CONSTANT("Grpc\\STATUS_ABORTED", GRPC_STATUS_ABORTED,
                          CONST_CS | CONST_PERSISTENT);
-  REGISTER_LONG_CONSTANT("Grpc\\STATUS_OUT_OF_RANGE", GRPC_STATUS_OUT_OF_RANGE,
+  REGISTER_LONG_CONSTANT("Grpc\\STATUS_OUT_OF_RANGE",
+                         GRPC_STATUS_OUT_OF_RANGE,
                          CONST_CS | CONST_PERSISTENT);
   REGISTER_LONG_CONSTANT("Grpc\\STATUS_UNIMPLEMENTED",
                          GRPC_STATUS_UNIMPLEMENTED,
@@ -202,7 +203,8 @@ PHP_MINIT_FUNCTION(grpc) {
                          GRPC_OP_RECV_INITIAL_METADATA,
                          CONST_CS | CONST_PERSISTENT);
   REGISTER_LONG_CONSTANT("Grpc\\OP_RECV_MESSAGE",
-                         GRPC_OP_RECV_MESSAGE, CONST_CS | CONST_PERSISTENT);
+                         GRPC_OP_RECV_MESSAGE,
+                         CONST_CS | CONST_PERSISTENT);
   REGISTER_LONG_CONSTANT("Grpc\\OP_RECV_STATUS_ON_CLIENT",
                          GRPC_OP_RECV_STATUS_ON_CLIENT,
                          CONST_CS | CONST_PERSISTENT);
@@ -212,11 +214,14 @@ PHP_MINIT_FUNCTION(grpc) {
 
   /* Register connectivity state constants */
   REGISTER_LONG_CONSTANT("Grpc\\CHANNEL_IDLE",
-                         GRPC_CHANNEL_IDLE, CONST_CS | CONST_PERSISTENT);
+                         GRPC_CHANNEL_IDLE,
+                         CONST_CS | CONST_PERSISTENT);
   REGISTER_LONG_CONSTANT("Grpc\\CHANNEL_CONNECTING",
-                         GRPC_CHANNEL_CONNECTING, CONST_CS | CONST_PERSISTENT);
+                         GRPC_CHANNEL_CONNECTING,
+                         CONST_CS | CONST_PERSISTENT);
   REGISTER_LONG_CONSTANT("Grpc\\CHANNEL_READY",
-                         GRPC_CHANNEL_READY, CONST_CS | CONST_PERSISTENT);
+                         GRPC_CHANNEL_READY,
+                         CONST_CS | CONST_PERSISTENT);
   REGISTER_LONG_CONSTANT("Grpc\\CHANNEL_TRANSIENT_FAILURE",
                          GRPC_CHANNEL_TRANSIENT_FAILURE,
                          CONST_CS | CONST_PERSISTENT);


### PR DESCRIPTION
 * PHP extension release 0.6.1, which contains the bug fix for #2275 
 * updated `package.xml`
 * some whitespace fixes in the `php_grpc.c` file