### PR TITLE
Fix compilation with VS2010

### DIFF
--- a/src/core/compression/algorithm.c
+++ b/src/core/compression/algorithm.c
@@ -101,6 +101,7 @@ grpc_compression_algorithm grpc_compression_algorithm_for_level(
     default:
       /* we shouldn't be making it here */
       abort();
+      return GRPC_COMPRESS_NONE;
   }
 }
 
@@ -116,6 +117,7 @@ grpc_compression_level grpc_compression_level_for_algorithm(
     }
   }
   abort();
+  return GRPC_COMPRESS_LEVEL_NONE;
 }
 
 void grpc_compression_options_init(grpc_compression_options *opts) {

--- a/src/core/surface/byte_buffer.c
+++ b/src/core/surface/byte_buffer.c
@@ -97,4 +97,5 @@ size_t grpc_byte_buffer_length(grpc_byte_buffer *bb) {
   }
   gpr_log(GPR_ERROR, "should never reach here");
   abort();
+  return 0;
 }

--- a/src/core/surface/call.c
+++ b/src/core/surface/call.c
@@ -436,6 +436,7 @@ static grpc_cq_completion *allocate_completion(grpc_call *call) {
   }
   gpr_log(GPR_ERROR, "should never reach here");
   abort();
+  return NULL;
 }
 
 static void done_completion(grpc_exec_ctx *exec_ctx, void *call,


### PR DESCRIPTION
prevent compiler from complaining that functions don't return a value.