### PR TITLE
Allows for reports to be generated locally when invoking run_tests.py.

### DIFF
--- a/tools/jenkins/build_docker_and_run_tests.sh
+++ b/tools/jenkins/build_docker_and_run_tests.sh
@@ -80,6 +80,7 @@ then
 fi
 
 docker cp "$CONTAINER_NAME:/var/local/git/grpc/reports.zip" $git_root || true
+rm -rf reports
 unzip $git_root/reports.zip -d $git_root || true
 rm -f reports.zip
 


### PR DESCRIPTION
Basically nukes the former reports directory, so that if it already exists, you can run it again in the case you're using run_tests on your local machine instead of Jenkins.