### PR TITLE
Bring Node coverage up to 95%

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -54,6 +54,24 @@
     'include_dirs': [
       '.',
       'include'
+    ],
+    'conditions': [
+      ['OS != "win"', {
+        'conditions': [
+          ['config=="gcov"', {
+            'cflags': [
+              '-ftest-coverage',
+              '-fprofile-arcs',
+              '-O0'
+            ],
+            'ldflags': [
+              '-ftest-coverage',
+              '-fprofile-arcs'
+            ]
+          }
+         ]
+        ]
+      }],
     ]
   },
   'targets': [
@@ -278,22 +296,6 @@
         '-g'
       ],
       "conditions": [
-        ['OS != "win"', {
-          'conditions': [
-            ['config=="gcov"', {
-              'cflags': [
-                '-ftest-coverage',
-                '-fprofile-arcs',
-                '-O0'
-              ],
-              'ldflags': [
-                '-ftest-coverage',
-                '-fprofile-arcs'
-              ]
-            }
-           ]
-          ]
-        }],
         ['OS == "mac"', {
           'xcode_settings': {
             'MACOSX_DEPLOYMENT_TARGET': '10.9',

--- a/src/node/ext/call.cc
+++ b/src/node/ext/call.cc
@@ -712,7 +712,11 @@ NAN_METHOD(Call::CancelWithStatus) {
   Call *call = ObjectWrap::Unwrap<Call>(info.This());
   grpc_status_code code = static_cast<grpc_status_code>(
       Nan::To<uint32_t>(info[0]).FromJust());
-  Utf8String details(info[0]);
+  if (code == GRPC_STATUS_OK) {
+    return Nan::ThrowRangeError(
+        "cancelWithStatus cannot be called with OK status");
+  }
+  Utf8String details(info[1]);
   grpc_call_cancel_with_status(call->wrapped_call, code, *details, NULL);
 }
 

--- a/src/node/ext/call.cc
+++ b/src/node/ext/call.cc
@@ -83,6 +83,18 @@ using v8::Value;
 Callback *Call::constructor;
 Persistent<FunctionTemplate> Call::fun_tpl;
 
+/**
+ * Helper function for throwing errors with a grpc_call_error value.
+ * Modified from the answer by Gus Goose to
+ * http://stackoverflow.com/questions/31794200.
+ */
+Local<Value> nanErrorWithCode(const char *msg, grpc_call_error code) {
+  EscapableHandleScope scope;
+  Local<Object> err = Nan::Error(msg).As<Object>();
+  Nan::Set(err, Nan::New("code").ToLocalChecked(), Nan::New<Uint32>(code));
+  return scope.Escape(err);
+}
+
 bool EndsWith(const char *str, const char *substr) {
   return strcmp(str+strlen(str)-strlen(substr), substr) == 0;
 }

--- a/src/node/ext/call.h
+++ b/src/node/ext/call.h
@@ -53,18 +53,7 @@ using std::shared_ptr;
 
 typedef Nan::Persistent<v8::Value, Nan::CopyablePersistentTraits<v8::Value>> PersistentValue;
 
-/**
- * Helper function for throwing errors with a grpc_call_error value.
- * Modified from the answer by Gus Goose to
- * http://stackoverflow.com/questions/31794200.
- */
-inline v8::Local<v8::Value> nanErrorWithCode(const char *msg,
-                                             grpc_call_error code) {
-  Nan::EscapableHandleScope scope;
-    v8::Local<v8::Object> err = Nan::Error(msg).As<v8::Object>();
-    Nan::Set(err, Nan::New("code").ToLocalChecked(), Nan::New<v8::Uint32>(code));
-    return scope.Escape(err);
-}
+v8::Local<v8::Value> nanErrorWithCode(const char *msg, grpc_call_error code);
 
 v8::Local<v8::Value> ParseMetadata(const grpc_metadata_array *metadata_array);
 

--- a/src/node/ext/call_credentials.cc
+++ b/src/node/ext/call_credentials.cc
@@ -126,16 +126,9 @@ NAN_METHOD(CallCredentials::New) {
     info.GetReturnValue().Set(info.This());
     return;
   } else {
-    const int argc = 1;
-    Local<Value> argv[argc] = {info[0]};
-    MaybeLocal<Object> maybe_instance = constructor->GetFunction()->NewInstance(
-        argc, argv);
-    if (maybe_instance.IsEmpty()) {
-      // There's probably a pending exception
-      return;
-    } else {
-      info.GetReturnValue().Set(maybe_instance.ToLocalChecked());
-    }
+    // This should never be called directly
+    return Nan::ThrowTypeError(
+        "CallCredentials can only be created with the provided functions");
   }
 }
 

--- a/src/node/ext/channel.h
+++ b/src/node/ext/channel.h
@@ -41,6 +41,11 @@
 namespace grpc {
 namespace node {
 
+bool ParseChannelArgs(v8::Local<v8::Value> args_val,
+                      grpc_channel_args **channel_args_ptr);
+
+void DeallocateChannelArgs(grpc_channel_args *channel_args);
+
 /* Wrapper class for grpc_channel structs */
 class Channel : public Nan::ObjectWrap {
  public:

--- a/src/node/ext/channel_credentials.cc
+++ b/src/node/ext/channel_credentials.cc
@@ -127,16 +127,9 @@ NAN_METHOD(ChannelCredentials::New) {
     info.GetReturnValue().Set(info.This());
     return;
   } else {
-    const int argc = 1;
-    Local<Value> argv[argc] = {info[0]};
-    MaybeLocal<Object> maybe_instance = constructor->GetFunction()->NewInstance(
-        argc, argv);
-    if (maybe_instance.IsEmpty()) {
-      // There's probably a pending exception
-      return;
-    } else {
-      info.GetReturnValue().Set(maybe_instance.ToLocalChecked());
-    }
+    // This should never be called directly
+    return Nan::ThrowTypeError(
+        "ChannelCredentials can only be created with the provided functions");
   }
 }
 

--- a/src/node/ext/server_credentials.cc
+++ b/src/node/ext/server_credentials.cc
@@ -117,7 +117,7 @@ NAN_METHOD(ServerCredentials::New) {
   if (info.IsConstructCall()) {
     if (!info[0]->IsExternal()) {
       return Nan::ThrowTypeError(
-          "ServerCredentials can only be created with the provide functions");
+          "ServerCredentials can only be created with the provided functions");
     }
     Local<External> ext = info[0].As<External>();
     grpc_server_credentials *creds_value =
@@ -126,16 +126,9 @@ NAN_METHOD(ServerCredentials::New) {
     credentials->Wrap(info.This());
     info.GetReturnValue().Set(info.This());
   } else {
-    const int argc = 1;
-    Local<Value> argv[argc] = {info[0]};
-    MaybeLocal<Object> maybe_instance = constructor->GetFunction()->NewInstance(
-        argc, argv);
-    if (maybe_instance.IsEmpty()) {
-      // There's probably a pending exception
-      return;
-    } else {
-      info.GetReturnValue().Set(maybe_instance.ToLocalChecked());
-    }
+    // This should never be called directly
+    return Nan::ThrowTypeError(
+        "ServerCredentials can only be created with the provided functions");
   }
 }
 

--- a/src/node/interop/interop_client.js
+++ b/src/node/interop/interop_client.js
@@ -35,7 +35,6 @@
 
 var fs = require('fs');
 var path = require('path');
-var _ = require('lodash');
 var grpc = require('..');
 var testProto = grpc.load({
   root: __dirname + '/../../..',

--- a/src/node/src/client.js
+++ b/src/node/src/client.js
@@ -661,6 +661,7 @@ exports.waitForClientReady = function(client, deadline, callback) {
   var checkState = function(err) {
     if (err) {
       callback(new Error('Failed to connect before the deadline'));
+      return;
     }
     var new_state = client.$channel.getConnectivityState(true);
     if (new_state === grpc.connectivityState.READY) {

--- a/src/node/src/common.js
+++ b/src/node/src/common.js
@@ -87,14 +87,9 @@ exports.fullyQualifiedName = function fullyQualifiedName(value) {
     return '';
   }
   var name = value.name;
-  if (value.className === 'Service.RPCMethod') {
-    name = _.capitalize(name);
-  }
-  if (value.hasOwnProperty('parent')) {
-    var parent_name = fullyQualifiedName(value.parent);
-    if (parent_name !== '') {
-      name = parent_name + '.' + name;
-    }
+  var parent_name = fullyQualifiedName(value.parent);
+  if (parent_name !== '') {
+    name = parent_name + '.' + name;
   }
   return name;
 };

--- a/src/node/src/credentials.js
+++ b/src/node/src/credentials.js
@@ -99,6 +99,9 @@ exports.createFromMetadataGenerator = function(metadata_generator) {
         if (error.hasOwnProperty('code')) {
           code = error.code;
         }
+        if (!metadata) {
+          metadata = new Metadata();
+        }
       }
       callback(code, message, metadata._getCoreRepresentation());
     });

--- a/src/node/test/call_test.js
+++ b/src/node/test/call_test.js
@@ -107,6 +107,12 @@ describe('call', function() {
         new grpc.Call(channel, 'method', 'now');
       }, TypeError);
     });
+    it('should succeed without the new keyword', function() {
+      assert.doesNotThrow(function() {
+        var call = grpc.Call(channel, 'method', new Date());
+        assert(call instanceof grpc.Call);
+      });
+    });
   });
   describe('deadline', function() {
     it('should time out immediately with negative deadline', function(done) {

--- a/src/node/test/call_test.js
+++ b/src/node/test/call_test.js
@@ -108,6 +108,17 @@ describe('call', function() {
       }, TypeError);
     });
   });
+  describe('deadline', function() {
+    it('should time out immediately with negative deadline', function(done) {
+      var call = new grpc.Call(channel, 'method', -Infinity);
+      var batch = {};
+      batch[grpc.opType.RECV_STATUS_ON_CLIENT] = true;
+      call.startBatch(batch, function(err, response) {
+        assert.strictEqual(response.status.code, grpc.status.DEADLINE_EXCEEDED);
+        done();
+      });
+    });
+  });
   describe('startBatch', function() {
     it('should fail without an object and a function', function() {
       var call = new grpc.Call(channel, 'method', getDeadline(1));
@@ -190,6 +201,43 @@ describe('call', function() {
       assert.doesNotThrow(function() {
         call.cancel();
       });
+    });
+  });
+  describe('cancelWithStatus', function() {
+    it('should reject anything other than an integer and a string', function() {
+      assert.doesNotThrow(function() {
+        var call = new grpc.Call(channel, 'method', getDeadline(1));
+        call.cancelWithStatus(1, 'details');
+      });
+      assert.throws(function() {
+        var call = new grpc.Call(channel, 'method', getDeadline(1));
+        call.cancelWithStatus();
+      });
+      assert.throws(function() {
+        var call = new grpc.Call(channel, 'method', getDeadline(1));
+        call.cancelWithStatus('');
+      });
+      assert.throws(function() {
+        var call = new grpc.Call(channel, 'method', getDeadline(1));
+        call.cancelWithStatus(5, {});
+      });
+    });
+    it('should reject the OK status code', function() {
+      assert.throws(function() {
+        var call = new grpc.Call(channel, 'method', getDeadline(1));
+        call.cancelWithStatus(0, 'details');
+      });
+    });
+    it('should result in the call ending with a status', function(done) {
+      var call = new grpc.Call(channel, 'method', getDeadline(1));
+      var batch = {};
+      batch[grpc.opType.RECV_STATUS_ON_CLIENT] = true;
+      call.startBatch(batch, function(err, response) {
+        assert.strictEqual(response.status.code, 5);
+        assert.strictEqual(response.status.details, 'details');
+        done();
+      });
+      call.cancelWithStatus(5, 'details');
     });
   });
   describe('getPeer', function() {

--- a/src/node/test/channel_test.js
+++ b/src/node/test/channel_test.js
@@ -155,7 +155,6 @@ describe('channel', function() {
       deadline.setSeconds(deadline.getSeconds() + 1);
       channel.watchConnectivityState(old_state, deadline, function(err, value) {
         assert(err);
-        console.log('Callback from watchConnectivityState');
         done();
       });
     });

--- a/src/node/test/channel_test.js
+++ b/src/node/test/channel_test.js
@@ -104,6 +104,12 @@ describe('channel', function() {
         new grpc.Channel('hostname', insecureCreds, {'key' : new Date()});
       });
     });
+    it('should succeed without the new keyword', function() {
+      assert.doesNotThrow(function() {
+        var channel = grpc.Channel('hostname', insecureCreds);
+        assert(channel instanceof grpc.Channel);
+      });
+    });
   });
   describe('close', function() {
     var channel;

--- a/src/node/test/credentials_test.js
+++ b/src/node/test/credentials_test.js
@@ -169,6 +169,24 @@ describe('client credentials', function() {
       done();
     });
   });
+  it.skip('should propagate errors that the updater emits', function(done) {
+    var metadataUpdater = function(service_url, callback) {
+      var error = new Error('Authentication error');
+      error.code = grpc.status.UNAUTHENTICATED;
+      callback(error);
+    };
+    var creds = grpc.credentials.createFromMetadataGenerator(metadataUpdater);
+    var combined_creds = grpc.credentials.combineChannelCredentials(
+        client_ssl_creds, creds);
+    var client = new Client('localhost:' + port, combined_creds,
+                            client_options);
+    client.unary({}, function(err, data) {
+      assert(err);
+      assert.strictEqual(err.message, 'Authentication error');
+      assert.strictEqual(err.code, grpc.status.UNAUTHENTICATED);
+      done();
+    });
+  });
   describe('Per-rpc creds', function() {
     var client;
     var updater_creds;

--- a/src/node/test/credentials_test.js
+++ b/src/node/test/credentials_test.js
@@ -214,7 +214,7 @@ describe('client credentials', function() {
       assert.ifError(err);
     });
     call.on('metadata', function(metadata) {
-      assert.deepStrictEqual(metadata.get('authorization'), ['success']);
+      assert.deepEqual(metadata.get('authorization'), ['success']);
       done();
     });
   });

--- a/src/node/test/interop_sanity_test.js
+++ b/src/node/test/interop_sanity_test.js
@@ -71,7 +71,7 @@ describe('Interop tests', function() {
     interop_client.runTest(port, name_override, 'server_streaming', true, true,
                            done);
   });
-  it.only('should pass ping_pong', function(done) {
+  it('should pass ping_pong', function(done) {
     interop_client.runTest(port, name_override, 'ping_pong', true, true, done);
   });
   it('should pass empty_stream', function(done) {

--- a/src/node/test/surface_test.js
+++ b/src/node/test/surface_test.js
@@ -382,7 +382,8 @@ describe('Other conditions', function() {
       unary: function(call, cb) {
         var req = call.request;
         if (req.error) {
-          cb(new Error('Requested error'), null, trailer_metadata);
+          cb({code: grpc.status.UNKNOWN,
+              details: 'Requested error'}, null, trailer_metadata);
         } else {
           cb(null, {count: 1}, trailer_metadata);
         }
@@ -407,7 +408,8 @@ describe('Other conditions', function() {
       serverStream: function(stream) {
         var req = stream.request;
         if (req.error) {
-          var err = new Error('Requested error');
+          var err = {code: grpc.status.UNKNOWN,
+                     details: 'Requested error'};
           err.metadata = trailer_metadata;
           stream.emit('error', err);
         } else {

--- a/src/node/test/surface_test.js
+++ b/src/node/test/surface_test.js
@@ -365,6 +365,18 @@ describe('Echo metadata', function() {
       done();
     });
   });
+  it('properly handles duplicate values', function(done) {
+    var dup_metadata = metadata.clone();
+    dup_metadata.add('key', 'value2');
+    var call = client.unary({}, function(err, data) {assert.ifError(err); },
+                            dup_metadata);
+    call.on('metadata', function(resp_metadata) {
+      // Two arrays are equal iff their symmetric difference is empty
+      assert.deepEqual(_.xor(dup_metadata.get('key'), resp_metadata.get('key')),
+                       []);
+      done();
+    });
+  });
 });
 describe('Other conditions', function() {
   var test_service;

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -56,6 +56,24 @@
       'include_dirs': [
         '.',
         'include'
+      ],
+      'conditions': [
+        ['OS != "win"', {
+          'conditions': [
+            ['config=="gcov"', {
+              'cflags': [
+                '-ftest-coverage',
+                '-fprofile-arcs',
+                '-O0'
+              ],
+              'ldflags': [
+                '-ftest-coverage',
+                '-fprofile-arcs'
+              ]
+            }
+           ]
+          ]
+        }],
       ]
     },
     'targets': [
@@ -95,22 +113,6 @@
           '-g'
         ],
         "conditions": [
-          ['OS != "win"', {
-            'conditions': [
-              ['config=="gcov"', {
-                'cflags': [
-                  '-ftest-coverage',
-                  '-fprofile-arcs',
-                  '-O0'
-                ],
-                'ldflags': [
-                  '-ftest-coverage',
-                  '-fprofile-arcs'
-                ]
-              }
-             ]
-            ]
-          }],
           ['OS == "mac"', {
             'xcode_settings': {
               'MACOSX_DEPLOYMENT_TARGET': '10.9',

--- a/tools/run_tests/run_node.sh
+++ b/tools/run_tests/run_node.sh
@@ -45,7 +45,8 @@ then
   gcov Release/obj.target/grpc/ext/*.o
   lcov --base-directory . --directory . -c -o coverage.info
   genhtml -o ../reports/node_ext_coverage --num-spaces 2 \
-    -t 'Node gRPC test coverage' coverage.info
+    -t 'Node gRPC test coverage' coverage.info --rc genhtml_hi_limit=95 \
+    --rc genhtml_med_limit=80
   echo '<html><head><meta http-equiv="refresh" content="0;URL=lcov-report/index.html"></head></html>' > \
     ../reports/node_coverage/index.html
 else


### PR DESCRIPTION
Two tests are skipped due to #3803. When that is resolved and those tests are added back to the run, the Node tests will have 95% coverage on `src/node/ext`, `src/node/src`, `src/node/index.js`, and `src/node/health_check`.

Fixes #3776.