### PR TITLE
Allow extra docker args to be passed to build_interop_image.sh

### DIFF
--- a/tools/jenkins/build_interop_image.sh
+++ b/tools/jenkins/build_interop_image.sh
@@ -33,6 +33,13 @@
 
 set -x
 
+# Params:
+#  INTEROP_IMAGE - name of tag of the final interop image
+#  BASE_NAME - base name used to locate the base Dockerfile and build script
+#  TTY_FLAG - optional -t flag to make docker allocate tty
+#  BUILD_INTEROP_DOCKER_EXTRA_ARGS - optional args to be passed to the
+#    docker run command
+
 cd `dirname $0`/../..
 GRPC_ROOT=`pwd`
 MOUNT_ARGS="-v $GRPC_ROOT:/var/local/jenkins/grpc:ro"
@@ -54,11 +61,6 @@ else
 fi
 
 mkdir -p /tmp/ccache
-
-# Params:
-#  INTEROP_IMAGE - name of tag of the final interop image
-#  BASE_NAME - base name used to locate the base Dockerfile and build script
-#  TTY_FLAG - optional -t flag to make docker allocate tty.
 
 # Mount service account dir if available.
 # If service_directory does not contain the service account JSON file,
@@ -84,6 +86,7 @@ CONTAINER_NAME="build_${BASE_NAME}_$(uuidgen)"
   -e CCACHE_DIR=/tmp/ccache \
   -i $TTY_FLAG \
   $MOUNT_ARGS \
+  $BUILD_INTEROP_DOCKER_EXTRA_ARGS \
   -v /tmp/ccache:/tmp/ccache \
   --name=$CONTAINER_NAME \
   $BASE_IMAGE \

--- a/tools/jenkins/grpc_interop_php/Dockerfile
+++ b/tools/jenkins/grpc_interop_php/Dockerfile
@@ -87,12 +87,6 @@ RUN /bin/bash -l -c "gem install bundler --no-ri --no-rdoc"
 
 # Install dependencies
 
-RUN /bin/bash -l -c "echo 'deb http://packages.dotdeb.org wheezy-php55 all' \
-    >> /etc/apt/sources.list.d/dotdeb.list"
-RUN /bin/bash -l -c "echo 'deb-src http://packages.dotdeb.org wheezy-php55 all' \
-    >> /etc/apt/sources.list.d/dotdeb.list"
-RUN wget http://www.dotdeb.org/dotdeb.gpg -O- | apt-key add -
-
 RUN apt-get update && apt-get install -y \
     git php5 php5-dev phpunit unzip
 
@@ -101,8 +95,6 @@ RUN apt-get update && apt-get install -y \
 #
 # rake: a ruby version of make used to build the PHP Protobuf extension
 RUN /bin/bash -l -c "rvm all do gem install ronn rake"
-
-ENV DEBIAN_FRONTEND noniteractive
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php


### PR DESCRIPTION
Background:

I was running into an issue when running the `run_interop_tests.py` script, trying to run the `-l php -s node` interop test. When the `tools/jenkins/grpc_interop_php/build_interop.sh` script is executed, there is a step in the PHP build script which needs to run the command `composer install`, which in turns needs to do a `git clone` to pull in a GitHub repo. That command fails sometimes when we exceed the GitHub rate limit. Here's the error:

```
Failed to clone the git@github.com:stanley-cheung/Protobuf-PHP.git repository, try running
in interactive mode so that you can enter your GitHub credentials
[RuntimeException]
```

The `composer install` command (PHP specific) can read from the file `$HOME/.composer/auth.json` which contains a personal GitHub auth token. If we can mount this file to the `docker run` command, then the error can be bypassed.

Here in this PR I propose we allow the `MOUNT_FLAGS` param to be passed to the `tools/jenkins/build_interop_image.sh` script via environment variable. Then I can invoke my `-l php -s node` interop test this way, and the error goes away

```
MOUNT_ARGS="-v $HOME/.composer/auth.json:/root/.composer/auth.json:ro" \
tools/run_tests/run_interop_tests.py -l php -s node --use_docker -t -j 8
```

I prefer this way rather than adding this `$HOME/.composer/auth.json` logic into the script because that is highly PHP and environment specific.

I also removed some outdated PHP pre-req in the base Dockerfile