### PR TITLE
PHP: fix empty_stream interop test

### DIFF
--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -256,15 +256,11 @@ function pingPong($stub) {
  * @param $stub Stub object that has service methods.
  */
 function emptyStream($stub) {
-  // for the current PHP implementation, $call->read() will wait
-  // forever for a server response if the server is not sending any.
-  // so this test is imeplemented as a timeout to indicate the absence
-  // of receiving any response from the server
-  $call = $stub->FullDuplexCall(array('timeout' => 100000));
+  $call = $stub->FullDuplexCall();
   $call->writesDone();
   hardAssert($call->read() === null, 'Server returned too many responses');
   hardAssert($call->getStatus()->code === Grpc\STATUS_OK,
-              'Call did not complete successfully');
+             'Call did not complete successfully');
 }
 
 /**


### PR DESCRIPTION
 * Depends on PR #3818. Do not merge before that PR.
 * Fixes #3762 and #3812 
 * Because of synchronous nature of PHP, when the user actively calls `$call->read()` on a BidiStreaming call, it will wait forever if the server does not send any message. So for this empty_stream interop test, I had implemented the `read()` call to timeout after 0.1s.
 * This works well against the Node server, Go server and CSharp server and we actually got a `STATUS_OK` `status_code` back. However, against the Ruby server, and the `cloud_to_prod` server, they actually return a `STATUS_DEADLINE_EXCEEDED` `status_code`
 * So now I re-ordered the sequence of the interop test to call `read()` first before `writesDone()`. This now in turn makes all servers return the status `STATUS_DEADLINE_EXCEEDED`.
