### PR TITLE
Add python-dev and python3-dev to prerequisites

### DIFF
--- a/src/python/README.md
+++ b/src/python/README.md
@@ -8,7 +8,7 @@ Beta : Core behavior well-used and proven; bugs lurk off the beaten path.
 
 PREREQUISITES
 -------------
-- Python 2.7, virtualenv, pip
+- python-virtualenv, python-pip, python3-pip, python-dev, python3-dev
 - [homebrew][] on Mac OS X.  These simplify the installation of the gRPC C core.
 
 INSTALLATION


### PR DESCRIPTION
Remedies a problem found by @hsaliak.