### PR TITLE
Distribute roots.pem with the Node package

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "src/core",
     "test/proto",
     "include",
+    "etc",
     "binding.gyp"
   ],
   "main": "src/node/index.js",

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -33,6 +33,14 @@
 
 'use strict';
 
+var path = require('path');
+
+var SSL_ROOTS_PATH = path.resolve(__dirname, '..', '..', 'etc', 'roots.pem');
+
+if (!process.env.GRPC_DEFAULT_SSL_ROOTS_FILE_PATH) {
+  process.env.GRPC_DEFAULT_SSL_ROOTS_FILE_PATH = SSL_ROOTS_PATH;
+}
+
 var _ = require('lodash');
 
 var ProtoBuf = require('protobufjs');


### PR DESCRIPTION
Now that the Node package doesn't depend on the build install, it can't expect the roots.pem file to be installed in the default location. So, we distribute it in the package and default to loading it if the environment variable is not explicitly set. This fixes #3805.