### PR TITLE
Revert global_env usage for build_interop_image job

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -481,7 +481,7 @@ def build_interop_image_jobspec(language, tag=None):
   # This env variable is used to get around the github rate limit
   # error when running the PHP `composer install` command
   # TODO(stanleycheung): find a more elegant way to do this
-  if language.safename == 'php':
+  if language.safename == 'php' and os.path.exists('/var/local/.composer/auth.json'):
     env['BUILD_INTEROP_DOCKER_EXTRA_ARGS'] = \
       "-v /var/local/.composer/auth.json:/root/.composer/auth.json:ro"
   build_job = jobset.JobSpec(


### PR DESCRIPTION
Addressing this comment: https://github.com/grpc/grpc/pull/3848#discussion_r42193612

Currently we decided to just add a PHP specific section for the `build_interop_image.sh` job. We should probably find a cleaner way to do this later.

Also, reference the origin of this PHP specific env var: #3818 