### PR TITLE
Accept --use_tls=true and --use_test_ca=true in python interop tests

### DIFF
--- a/src/python/grpcio_test/grpc_interop/client.py
+++ b/src/python/grpcio_test/grpc_interop/client.py
@@ -49,11 +49,11 @@ def _args():
   parser.add_argument(
       '--test_case', help='the test case to execute', type=str)
   parser.add_argument(
-      '--use_tls', help='require a secure connection', dest='use_tls',
-      action='store_true')
+      '--use_tls', help='require a secure connection', default=False,
+      type=resources.parse_bool)
   parser.add_argument(
       '--use_test_ca', help='replace platform root CAs with ca.pem',
-      action='store_true')
+      default=False, type=resources.parse_bool)
   parser.add_argument(
       '--server_host_override',
       help='the server host to which to claim to connect', type=str)

--- a/src/python/grpcio_test/grpc_interop/resources.py
+++ b/src/python/grpcio_test/grpc_interop/resources.py
@@ -29,6 +29,7 @@
 
 """Constants and functions for data used in interoperability testing."""
 
+import argparse
 import os
 
 import pkg_resources
@@ -54,3 +55,11 @@ def private_key():
 def certificate_chain():
   return pkg_resources.resource_string(
       __name__, _CERTIFICATE_CHAIN_RESOURCE_PATH)
+
+
+def parse_bool(value):
+  if value == 'true':
+    return True
+  if value == 'false':
+    return False
+  raise argparse.ArgumentTypeError('Only true/false allowed')

--- a/src/python/grpcio_test/grpc_interop/server.py
+++ b/src/python/grpcio_test/grpc_interop/server.py
@@ -46,8 +46,8 @@ def serve():
   parser.add_argument(
       '--port', help='the port on which to serve', type=int)
   parser.add_argument(
-      '--use_tls', help='require a secure connection', dest='use_tls',
-      action='store_true')
+      '--use_tls', help='require a secure connection',
+      default=False, type=resources.parse_bool)
   args = parser.parse_args()
 
   if args.use_tls:

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -275,17 +275,17 @@ class PythonLanguage:
 
   def cloud_to_prod_args(self):
     return (self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS +
-            ['--use_tls'])
+            ['--use_tls=true'])
 
   def cloud_to_cloud_args(self):
     return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_tls', '--use_test_ca'])
+            ['--use_tls=true', '--use_test_ca=true'])
 
   def cloud_to_prod_env(self):
     return _SSL_CERT_ENV
 
   def server_args(self):
-    return ['python2.7_virtual_environment/bin/python', '-m', 'grpc_interop.server', '--use_tls']
+    return ['python2.7_virtual_environment/bin/python', '-m', 'grpc_interop.server', '--use_tls=true']
 
   def global_env(self):
     return {'LD_LIBRARY_PATH': 'libs/opt'}


### PR DESCRIPTION
Spec requires accepting  bool flags in --use_tls=BOOL form & and the command line interface needs to be consistent across languages.