### PR TITLE
Restrict number of iterations for UnaryCallPerformance test

### DIFF
--- a/src/csharp/Grpc.Core.Tests/ClientServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ClientServerTest.cs
@@ -210,7 +210,7 @@ namespace Grpc.Core.Tests
             });
 
             var callDetails = helper.CreateUnaryCall();
-            BenchmarkUtil.RunBenchmark(100, 100,
+            BenchmarkUtil.RunBenchmark(1, 10,
                                        () => { Calls.BlockingUnaryCall(callDetails, "ABC"); });
         }
             


### PR DESCRIPTION
Because unit tests are running with GRPC_TRACE=api, lots of logs are generated by this test, which makes the testsuite timeout.

Fixes #3604.

Fixes #3836.