### PR TITLE
Unify use_tls usage in interop tests

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -51,18 +51,17 @@ _DEFAULT_SERVER_PORT=8080
 _CLOUD_TO_PROD_BASE_ARGS = [
     '--server_host_override=grpc-test.sandbox.google.com',
     '--server_host=grpc-test.sandbox.google.com',
-    '--server_port=443']
+    '--server_port=443',
+    '--use_tls=true']
 
 _CLOUD_TO_CLOUD_BASE_ARGS = [
-    '--server_host_override=foo.test.google.fr']
+    '--server_host_override=foo.test.google.fr',
+    '--use_tls=true']
 
 # TOOD(jtattermusch) wrapped languages use this variable for location
 # of roots.pem. We might want to use GRPC_DEFAULT_SSL_ROOTS_FILE_PATH
 # supported by C core SslCredentials instead.
 _SSL_CERT_ENV = { 'SSL_CERT_FILE':'/usr/local/share/grpc/roots.pem' }
-
-# TODO(jtattermusch) unify usage of --use_tls and --use_tls=true
-# TODO(jtattermusch) go uses --tls_ca_file instead of --use_test_ca
 
 
 class CXXLanguage:
@@ -74,12 +73,11 @@ class CXXLanguage:
     self.safename = 'cxx'
 
   def cloud_to_prod_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS +
-            ['--use_tls=true'])
+    return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
     return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_tls=true', '--use_test_ca=true'])
+            ['--use_test_ca=true'])
 
   def cloud_to_prod_env(self):
     return {}
@@ -103,12 +101,11 @@ class CSharpLanguage:
     self.safename = str(self)
 
   def cloud_to_prod_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS +
-            ['--use_tls=true'])
+    return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
     return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_tls=true', '--use_test_ca=true'])
+            ['--use_test_ca=true'])
 
   def cloud_to_prod_env(self):
     return _SSL_CERT_ENV
@@ -132,12 +129,11 @@ class JavaLanguage:
     self.safename = str(self)
 
   def cloud_to_prod_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS +
-            ['--use_tls=true'])
+    return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
     return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_tls=true', '--use_test_ca=true'])
+            ['--use_test_ca=true'])
 
   def cloud_to_prod_env(self):
     return {}
@@ -162,12 +158,12 @@ class GoLanguage:
     self.safename = str(self)
 
   def cloud_to_prod_args(self):
+    # TODO(jtattermusch) go uses --tls_ca_file instead of --use_test_ca
     return (self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS +
-            ['--use_tls=true', '--tls_ca_file=""'])
+            ['--tls_ca_file=""'])
 
   def cloud_to_cloud_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_tls=true'])
+    return self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS
 
   def cloud_to_prod_env(self):
     return {}
@@ -191,12 +187,11 @@ class NodeLanguage:
     self.safename = str(self)
 
   def cloud_to_prod_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS +
-            ['--use_tls=true'])
+    return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
     return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_tls=true', '--use_test_ca=true'])
+            ['--use_test_ca=true'])
 
   def cloud_to_prod_env(self):
     return _SSL_CERT_ENV
@@ -219,12 +214,11 @@ class PHPLanguage:
     self.safename = str(self)
 
   def cloud_to_prod_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS +
-            ['--use_tls=true'])
+    return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
     return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_tls=true', '--use_test_ca=true'])
+            ['--use_test_ca=true'])
 
   def cloud_to_prod_env(self):
     return _SSL_CERT_ENV
@@ -245,12 +239,11 @@ class RubyLanguage:
     self.safename = str(self)
 
   def cloud_to_prod_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS +
-            ['--use_tls=true'])
+    return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
     return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_tls=true', '--use_test_ca=true'])
+            ['--use_test_ca=true'])
 
   def cloud_to_prod_env(self):
     return _SSL_CERT_ENV
@@ -274,12 +267,11 @@ class PythonLanguage:
     self.safename = str(self)
 
   def cloud_to_prod_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS +
-            ['--use_tls=true'])
+    return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
     return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_tls=true', '--use_test_ca=true'])
+            ['--use_test_ca=true'])
 
   def cloud_to_prod_env(self):
     return _SSL_CERT_ENV


### PR DESCRIPTION
All languages now understand the --use_tls=true argument, so making its usage language agnostic.