### PR TITLE
Stop outputting log lines from Node library by default

### DIFF
--- a/src/node/src/metadata.js
+++ b/src/node/src/metadata.js
@@ -59,7 +59,6 @@ function normalizeKey(key) {
 function validate(key, value) {
   if (_.endsWith(key, '-bin')) {
     if (!(value instanceof Buffer)) {
-      console.log(value.constructor.toString());
       throw new Error('keys that end with \'-bin\' must have Buffer values');
     }
   } else {

--- a/src/node/src/server.js
+++ b/src/node/src/server.js
@@ -597,10 +597,6 @@ function Server(options) {
       throw new Error('Server is already running');
     }
     this.started = true;
-    console.log('Server starting');
-    _.each(handlers, function(handler, handler_name) {
-      console.log('Serving', handler_name);
-    });
     server.start();
     /**
      * Handles the SERVER_RPC_NEW event. If there is a handler associated with

--- a/src/node/test/async_test.js
+++ b/src/node/test/async_test.js
@@ -86,7 +86,6 @@ describe('Async functionality', function() {
       });
 
       readStream.on('error', function (error) {
-        console.log(error);
       });
     });
 

--- a/src/node/test/credentials_test.js
+++ b/src/node/test/credentials_test.js
@@ -71,7 +71,7 @@ var fakeSuccessfulGoogleCredentials = {
 var fakeFailingGoogleCredentials = {
   getRequestMetadata: function(service_url, callback) {
     setTimeout(function() {
-      callback(new Error("Authorization failure"));
+      callback(new Error('Authorization failure'));
     }, 0);
   }
 };


### PR DESCRIPTION
This was interfering with my ability to output structured test result reports.