### PR TITLE
Changed to a more portable Node version check in binding.gyp

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -46,10 +46,11 @@
       # io.js always reports versions >0 and always exports ALPN symbols.
       # Therefore, Node's major version will be truthy if and only if it
       # supports ALPN. The output of "node -v" is v[major].[minor].[patch],
-      # like "v4.1.1" in a recent version. We use grep to extract just the
-      # major version. "4", would be the output for the example.
+      # like "v4.1.1" in a recent version. We use cut to split by period and
+      # take the first field (resulting in "v[major]"), then use cut again
+      # to take all but the first character, removing the "v".
     'defines': [
-      'TSI_OPENSSL_ALPN_SUPPORT=<!(node -v | grep -oP "(?<=v)(\d+)(?=\.\d+\.\d+)")'
+      'TSI_OPENSSL_ALPN_SUPPORT=<!(node --version | cut -d. -f1 | cut -c2-)'
     ],
     'include_dirs': [
       '.',

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -48,10 +48,11 @@
         # io.js always reports versions >0 and always exports ALPN symbols.
         # Therefore, Node's major version will be truthy if and only if it
         # supports ALPN. The output of "node -v" is v[major].[minor].[patch],
-        # like "v4.1.1" in a recent version. We use grep to extract just the
-        # major version. "4", would be the output for the example.
+        # like "v4.1.1" in a recent version. We use cut to split by period and
+        # take the first field (resulting in "v[major]"), then use cut again
+        # to take all but the first character, removing the "v".
       'defines': [
-        'TSI_OPENSSL_ALPN_SUPPORT=<!(node -v | grep -oP "(?<=v)(\d+)(?=\.\d+\.\d+)")'
+        'TSI_OPENSSL_ALPN_SUPPORT=<!(node --version | cut -d. -f1 | cut -c2-)'
       ],
       'include_dirs': [
         '.',


### PR DESCRIPTION
This changes to a Node version check that is as portable as possible, using only coreutils, to make sure it works on OS X, other Linux distros, and other shells. This fixes #3874.