### PR TITLE
Fix python compute_engine_creds and oauth2_auth_token interop tests.

### DIFF
--- a/src/python/grpcio_test/grpc_interop/client.py
+++ b/src/python/grpcio_test/grpc_interop/client.py
@@ -71,12 +71,17 @@ def _oauth_access_token(args):
 def _stub(args):
   if args.oauth_scope:
     if args.test_case == 'oauth2_auth_token':
+      # TODO(jtattermusch): This testcase sets the auth metadata key-value
+      # manually, which also means that the user would need to do the same
+      # thing every time he/she would like to use and out of band oauth token.
+      # The transformer function that produces the metadata key-value from
+      # the access token should be provided by gRPC auth library.
       access_token = _oauth_access_token(args)
       metadata_transformer = lambda x: [
-          ('Authorization', 'Bearer %s' % access_token)]
+          ('authorization', 'Bearer %s' % access_token)]
     else:
       metadata_transformer = lambda x: [
-          ('Authorization', 'Bearer %s' % _oauth_access_token(args))]
+          ('authorization', 'Bearer %s' % _oauth_access_token(args))]
   else:
     metadata_transformer = lambda x: []
   if args.use_tls:

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -350,7 +350,7 @@ def add_auth_options(language, test_case, cmdline, env):
   default_account_arg = '--default_service_account=830293263384-compute@developer.gserviceaccount.com'
 
   if test_case in ['jwt_token_creds', 'per_rpc_creds', 'oauth2_auth_token']:
-    if language in ['csharp', 'node', 'php', 'ruby']:
+    if language in ['csharp', 'node', 'php', 'python', 'ruby']:
       env['GOOGLE_APPLICATION_CREDENTIALS'] = key_filepath
     else:
       cmdline += [key_file_arg]


### PR DESCRIPTION
-- grpc metadata keys need to be lowercase
-- switched python to use GOOGLE_APPLICATION_CREDENTIALS credentials 

This also reveals some issues with python auth story:
-- user needs to implement metadata_transformer
-- there seems to be no metadata key checking/downcasing logic in python

It would be good to have issues for these, if we don't have them already.

Partially fixes #3842.