### PR TITLE
Consistent interop cmdline args

### DIFF
--- a/tools/jenkins/grpc_interop_go/build_interop.sh
+++ b/tools/jenkins/grpc_interop_go/build_interop.sh
@@ -34,7 +34,7 @@ set -e
 # Clone just the grpc-go source code without any dependencies.
 # We are cloning from a local git repo that contains the right revision
 # to test instead of using "go get" to download from Github directly.
-git clone --recursive /var/local/jenkins/grpc-go src/gooogle.golang.org/grpc
+git clone --recursive /var/local/jenkins/grpc-go src/google.golang.org/grpc
 
 # copy service account keys if available
 cp -r /var/local/jenkins/service_account $HOME || true

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -56,7 +56,8 @@ _CLOUD_TO_PROD_BASE_ARGS = [
 
 _CLOUD_TO_CLOUD_BASE_ARGS = [
     '--server_host_override=foo.test.google.fr',
-    '--use_tls=true']
+    '--use_tls=true',
+    '--use_test_ca=true']
 
 # TOOD(jtattermusch) wrapped languages use this variable for location
 # of roots.pem. We might want to use GRPC_DEFAULT_SSL_ROOTS_FILE_PATH
@@ -76,8 +77,7 @@ class CXXLanguage:
     return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_test_ca=true'])
+    return self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS
 
   def cloud_to_prod_env(self):
     return {}
@@ -104,8 +104,7 @@ class CSharpLanguage:
     return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_test_ca=true'])
+    return self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS
 
   def cloud_to_prod_env(self):
     return _SSL_CERT_ENV
@@ -132,8 +131,7 @@ class JavaLanguage:
     return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_test_ca=true'])
+    return self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS
 
   def cloud_to_prod_env(self):
     return {}
@@ -158,9 +156,7 @@ class GoLanguage:
     self.safename = str(self)
 
   def cloud_to_prod_args(self):
-    # TODO(jtattermusch) go uses --tls_ca_file instead of --use_test_ca
-    return (self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS +
-            ['--tls_ca_file=""'])
+    return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
     return self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS
@@ -190,8 +186,7 @@ class NodeLanguage:
     return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_test_ca=true'])
+    return self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS
 
   def cloud_to_prod_env(self):
     return _SSL_CERT_ENV
@@ -217,8 +212,7 @@ class PHPLanguage:
     return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_test_ca=true'])
+    return self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS
 
   def cloud_to_prod_env(self):
     return _SSL_CERT_ENV
@@ -242,8 +236,7 @@ class RubyLanguage:
     return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_test_ca=true'])
+    return self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS
 
   def cloud_to_prod_env(self):
     return _SSL_CERT_ENV
@@ -270,8 +263,7 @@ class PythonLanguage:
     return self.client_cmdline_base + _CLOUD_TO_PROD_BASE_ARGS
 
   def cloud_to_cloud_args(self):
-    return (self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS +
-            ['--use_test_ca=true'])
+    return self.client_cmdline_base + _CLOUD_TO_CLOUD_BASE_ARGS
 
   def cloud_to_prod_env(self):
     return _SSL_CERT_ENV


### PR DESCRIPTION
Go now supports --use_test_ca=true cmdline (https://github.com/grpc/grpc-go/pull/406) argument, so all the interop tests can be called with same cmdline args now.