### PR TITLE
Stop using SSL_CERT_FILE env for C# interop tests

### DIFF
--- a/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
@@ -137,7 +137,11 @@ namespace Grpc.IntegrationTesting
 
         private async Task<ChannelCredentials> CreateCredentialsAsync()
         {
-            var credentials = options.UseTls.Value ? TestCredentials.CreateTestClientCredentials(options.UseTestCa.Value) : ChannelCredentials.Insecure;
+            var credentials = ChannelCredentials.Insecure;
+            if (options.UseTls.Value)
+            {
+                credentials = options.UseTestCa.Value ? TestCredentials.CreateSslCredentials() : new SslCredentials();
+            }
 
             if (options.TestCase == "jwt_token_creds")
             {

--- a/src/csharp/Grpc.IntegrationTesting/InteropClientServerTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClientServerTest.cs
@@ -59,7 +59,7 @@ namespace Grpc.IntegrationTesting
             server = new Server
             {
                 Services = { TestService.BindService(new TestServiceImpl()) },
-                Ports = { { Host, ServerPort.PickUnused, TestCredentials.CreateTestServerCredentials() } }
+                Ports = { { Host, ServerPort.PickUnused, TestCredentials.CreateSslServerCredentials() } }
             };
             server.Start();
 
@@ -68,7 +68,7 @@ namespace Grpc.IntegrationTesting
                 new ChannelOption(ChannelOptions.SslTargetNameOverride, TestCredentials.DefaultHostOverride)
             };
             int port = server.Ports.Single().BoundPort;
-            channel = new Channel(Host, port, TestCredentials.CreateTestClientCredentials(true), options);
+            channel = new Channel(Host, port, TestCredentials.CreateSslCredentials(), options);
             client = TestService.NewClient(channel);
         }
 

--- a/src/csharp/Grpc.IntegrationTesting/InteropServer.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropServer.cs
@@ -102,7 +102,7 @@ namespace Grpc.IntegrationTesting
             int port = options.Port;
             if (options.UseTls.Value)
             {
-                server.Ports.Add(host, port, TestCredentials.CreateTestServerCredentials());
+                server.Ports.Add(host, port, TestCredentials.CreateSslServerCredentials());
             }
             else
             {

--- a/src/csharp/Grpc.IntegrationTesting/TestCredentials.cs
+++ b/src/csharp/Grpc.IntegrationTesting/TestCredentials.cs
@@ -51,26 +51,15 @@ namespace Grpc.IntegrationTesting
         public const string DefaultHostOverride = "foo.test.google.fr";
 
         public const string ClientCertAuthorityPath = "data/ca.pem";
-        public const string ClientCertAuthorityEnvName = "SSL_CERT_FILE";
-
         public const string ServerCertChainPath = "data/server1.pem";
         public const string ServerPrivateKeyPath = "data/server1.key";
 
-        public static SslCredentials CreateTestClientCredentials(bool useTestCa)
+        public static SslCredentials CreateSslCredentials()
         {
-            string caPath = ClientCertAuthorityPath;
-            if (!useTestCa)
-            {
-                caPath = Environment.GetEnvironmentVariable(ClientCertAuthorityEnvName);
-                if (string.IsNullOrEmpty(caPath))
-                {
-                    throw new ArgumentException("CA path environment variable is not set.");
-                }
-            }
-            return new SslCredentials(File.ReadAllText(caPath));
+            return new SslCredentials(File.ReadAllText(ClientCertAuthorityPath));
         }
 
-        public static SslServerCredentials CreateTestServerCredentials()
+        public static SslServerCredentials CreateSslServerCredentials()
         {
             var keyCertPair = new KeyCertificatePair(
                 File.ReadAllText(ServerCertChainPath),


### PR DESCRIPTION
Fixes #3916.