### PR TITLE
Removing coveralls badge, as we're no longer using it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://grpc-testing.appspot.com/job/gRPC_master/badge/icon)](https://grpc-testing.appspot.com/job/gRPC_master)
-[![Coverage Status](https://img.shields.io/coveralls/grpc/grpc.svg)](https://coveralls.io/r/grpc/grpc?branch=master)
 
 [gRPC - An RPC library and framework](http://github.com/grpc/grpc)
 ===================================


### PR DESCRIPTION
This is mainly to see if the hook works properly.