### PR TITLE
Correct behavior for interop test timeout flakes.

### DIFF
--- a/tools/jenkins/run_interop.sh
+++ b/tools/jenkins/run_interop.sh
@@ -34,4 +34,4 @@ set -ex
 # Enter the gRPC repo root
 cd $(dirname $0)/../..
 
-tools/run_tests/run_interop_tests.py -l all -s all --cloud_to_prod --cloud_to_prod_auth --use_docker -t -j 8 $@ || true
+tools/run_tests/run_interop_tests.py -l all -s all --cloud_to_prod --cloud_to_prod_auth --use_docker -t -j 12 $@ || true

--- a/tools/run_tests/jobset.py
+++ b/tools/run_tests/jobset.py
@@ -272,6 +272,8 @@ class Job(object):
         message('TIMEOUT_FLAKE', self._spec.shortname, stdout, do_newline=True)
         self._timeout_retries += 1
         self.result.retries = self._timeout_retries + self._retries
+        if self._spec.kill_handler:
+          self._spec.kill_handler(self)
         self._process.terminate()
         self.start()
       else:

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -383,7 +383,7 @@ def cloud_to_prod_jobspec(language, test_case, docker_image=None, auth=False):
           cwd=cwd,
           environ=environ,
           shortname='%s:%s:%s' % (suite_name, language, test_case),
-          timeout_seconds=2*60,
+          timeout_seconds=90,
           flake_retries=5 if args.allow_flakes else 0,
           timeout_retries=2 if args.allow_flakes else 0,
           kill_handler=_job_kill_handler)
@@ -419,7 +419,7 @@ def cloud_to_cloud_jobspec(language, test_case, server_name, server_host,
           environ=environ,
           shortname='cloud_to_cloud:%s:%s_server:%s' % (language, server_name,
                                                  test_case),
-          timeout_seconds=2*60,
+          timeout_seconds=90,
           flake_retries=5 if args.allow_flakes else 0,
           timeout_retries=2 if args.allow_flakes else 0,
           kill_handler=_job_kill_handler)

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -344,6 +344,11 @@ def add_auth_options(language, test_case, cmdline, env):
 def _job_kill_handler(job):
   if job._spec.container_name:
     dockerjob.docker_kill(job._spec.container_name)
+    # When the job times out and we decide to kill it,
+    # we need to wait a before restarting the job
+    # to prevent "container name already in use" error.
+    # TODO(jtattermusch): figure out a cleaner way to to this.
+    time.sleep(2)
 
 
 def cloud_to_prod_jobspec(language, test_case, docker_image=None, auth=False):


### PR DESCRIPTION
When an interop test times out and the --allow_flakes option is used, restarting the job fails with the error
```
Error response from daemon: Conflict. The name "interop_client_node_2165b2c2-2b38-469f-a171-7d3aa4519840" is already in use by container 2acb0e927374. You have to delete (or rename) that container to be able to reuse that name
```

This PR fixes this behavior.