### PR TITLE
Make the Node library build and run on Mac

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -73,16 +73,6 @@
          ]
         ]
       }],
-      ['OS=="mac"', {
-        'xcode_settings': {
-          'MACOSX_DEPLOYMENT_TARGET': '10.9',
-          'OTHER_CFLAGS': [
-            '-fno-strict-aliasing',
-            '-std=c++11',
-            '-stdlib=libc++'
-          ]
-        }
-      }]
     ]
   },
   'targets': [
@@ -133,6 +123,16 @@
         'src/core/support/time_precise.c',
         'src/core/support/time_win32.c',
         'src/core/support/tls_pthread.c',
+      ],
+      "conditions": [
+        ['OS == "mac"', {
+          'xcode_settings': {
+            'MACOSX_DEPLOYMENT_TARGET': '10.9',
+            'OTHER_CFLAGS': [
+              '-stdlib=libc++'
+            ]
+          }
+        }]
       ],
     },
     {
@@ -291,6 +291,16 @@
         'src/core/census/initialize.c',
         'src/core/census/operation.c',
         'src/core/census/tracing.c',
+      ],
+      "conditions": [
+        ['OS == "mac"', {
+          'xcode_settings': {
+            'MACOSX_DEPLOYMENT_TARGET': '10.9',
+            'OTHER_CFLAGS': [
+              '-stdlib=libc++'
+            ]
+          }
+        }]
       ],
     },
     {

--- a/binding.gyp
+++ b/binding.gyp
@@ -73,6 +73,16 @@
          ]
         ]
       }],
+      ['OS=="mac"', {
+        'xcode_settings': {
+          'MACOSX_DEPLOYMENT_TARGET': '10.9',
+          'OTHER_CFLAGS': [
+            '-fno-strict-aliasing',
+            '-std=c++11',
+            '-stdlib=libc++'
+          ]
+        }
+      }]
     ]
   },
   'targets': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -137,10 +137,7 @@
       "conditions": [
         ['OS == "mac"', {
           'xcode_settings': {
-            'MACOSX_DEPLOYMENT_TARGET': '10.9',
-            'OTHER_CFLAGS': [
-              '-stdlib=libc++'
-            ]
+            'MACOSX_DEPLOYMENT_TARGET': '10.9'
           }
         }]
       ],
@@ -305,10 +302,7 @@
       "conditions": [
         ['OS == "mac"', {
           'xcode_settings': {
-            'MACOSX_DEPLOYMENT_TARGET': '10.9',
-            'OTHER_CFLAGS': [
-              '-stdlib=libc++'
-            ]
+            'MACOSX_DEPLOYMENT_TARGET': '10.9'
           }
         }]
       ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -54,7 +54,8 @@
     ],
     'include_dirs': [
       '.',
-      'include'
+      'include',
+      '<(node_root_dir)/deps/openssl/openssl/include'
     ],
     'conditions': [
       ['OS != "win"', {
@@ -73,6 +74,15 @@
          ]
         ]
       }],
+      ["target_arch=='ia32'", {
+          "include_dirs": [ "<(node_root_dir)/deps/openssl/config/piii" ]
+      }],
+      ["target_arch=='x64'", {
+          "include_dirs": [ "<(node_root_dir)/deps/openssl/config/k8" ]
+      }],
+      ["target_arch=='arm'", {
+          "include_dirs": [ "<(node_root_dir)/deps/openssl/config/arm" ]
+      }]
     ]
   },
   'targets': [

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -75,16 +75,6 @@
            ]
           ]
         }],
-        ['OS=="mac"', {
-          'xcode_settings': {
-            'MACOSX_DEPLOYMENT_TARGET': '10.9',
-            'OTHER_CFLAGS': [
-              '-fno-strict-aliasing',
-              '-std=c++11',
-              '-stdlib=libc++'
-            ]
-          }
-        }]
       ]
     },
     'targets': [
@@ -103,6 +93,16 @@
           % for source in lib.src:
           '${source}',
           % endfor
+        ],
+        "conditions": [
+          ['OS == "mac"', {
+            'xcode_settings': {
+              'MACOSX_DEPLOYMENT_TARGET': '10.9',
+              'OTHER_CFLAGS': [
+                '-stdlib=libc++'
+              ]
+            }
+          }]
         ],
       },
       % endif

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -75,6 +75,16 @@
            ]
           ]
         }],
+        ['OS=="mac"', {
+          'xcode_settings': {
+            'MACOSX_DEPLOYMENT_TARGET': '10.9',
+            'OTHER_CFLAGS': [
+              '-fno-strict-aliasing',
+              '-std=c++11',
+              '-stdlib=libc++'
+            ]
+          }
+        }]
       ]
     },
     'targets': [

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -56,7 +56,8 @@
       ],
       'include_dirs': [
         '.',
-        'include'
+        'include',
+        '<(node_root_dir)/deps/openssl/openssl/include'
       ],
       'conditions': [
         ['OS != "win"', {
@@ -75,6 +76,15 @@
            ]
           ]
         }],
+        ["target_arch=='ia32'", {
+            "include_dirs": [ "<(node_root_dir)/deps/openssl/config/piii" ]
+        }],
+        ["target_arch=='x64'", {
+            "include_dirs": [ "<(node_root_dir)/deps/openssl/config/k8" ]
+        }],
+        ["target_arch=='arm'", {
+            "include_dirs": [ "<(node_root_dir)/deps/openssl/config/arm" ]
+        }]
       ]
     },
     'targets': [

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -107,10 +107,7 @@
         "conditions": [
           ['OS == "mac"', {
             'xcode_settings': {
-              'MACOSX_DEPLOYMENT_TARGET': '10.9',
-              'OTHER_CFLAGS': [
-                '-stdlib=libc++'
-              ]
+              'MACOSX_DEPLOYMENT_TARGET': '10.9'
             }
           }]
         ],


### PR DESCRIPTION
This fixes #3918. It also makes the Node library compile against Node's copy of OpenSSL, to avoid version incompatibilities between system OpenSSL (which we were compiling against before) and Node's OpenSSL (which we link against).