### PR TITLE
Compile against Node's version of zlib

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -55,7 +55,8 @@
     'include_dirs': [
       '.',
       'include',
-      '<(node_root_dir)/deps/openssl/openssl/include'
+      '<(node_root_dir)/deps/openssl/openssl/include',
+      '<(node_root_dir)/deps/zlib'
     ],
     'conditions': [
       ['OS != "win"', {

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -57,7 +57,8 @@
       'include_dirs': [
         '.',
         'include',
-        '<(node_root_dir)/deps/openssl/openssl/include'
+        '<(node_root_dir)/deps/openssl/openssl/include',
+        '<(node_root_dir)/deps/zlib'
       ],
       'conditions': [
         ['OS != "win"', {


### PR DESCRIPTION
The Node extension already runs against Node's copy of zlib. We should also compile against it if possible, to avoid potential version mismatches.