### PR TITLE
Use proper shortname for sanity tests

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -411,8 +411,8 @@ class ObjCLanguage(object):
 class Sanity(object):
 
   def test_specs(self, config, travis):
-    return [config.job_spec('tools/run_tests/run_sanity.sh', None),
-            config.job_spec('tools/run_tests/check_sources_and_headers.py', None)]
+    return [config.job_spec(['tools/run_tests/run_sanity.sh'], None),
+            config.job_spec(['tools/run_tests/check_sources_and_headers.py'], None)]
 
   def pre_build_steps(self):
     return []


### PR DESCRIPTION
For sanity tests, the test shortname is reported as just `t`, because jobspec param is not a list.

An example:
https://grpc-testing.appspot.com/job/gRPC_pull_requests/3955/