### PR TITLE
PHP: fix inconsistent array notation

### DIFF
--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -152,7 +152,7 @@ class BaseStub {
       $timeout = $metadata['timeout'];
       unset($metadata_copy['timeout']);
     }
-    return array($metadata_copy, $timeout);
+    return [$metadata_copy, $timeout];
   }
 
   /**
@@ -162,7 +162,7 @@ class BaseStub {
    * @throw InvalidArgumentException if key contains invalid characters
    */
   private function _validate_and_normalize_metadata($metadata) {
-    $metadata_copy = array();
+    $metadata_copy = [];
     foreach ($metadata as $key => $value) {
       if (!preg_match('/^[A-Za-z\d_-]+$/', $key)) {
         throw new \InvalidArgumentException(
@@ -189,8 +189,8 @@ class BaseStub {
   public function _simpleRequest($method,
                                  $argument,
                                  callable $deserialize,
-                                 $metadata = array(),
-                                 $options = array()) {
+                                 $metadata = [],
+                                 $options = []) {
     list($actual_metadata, $timeout)  = $this->_extract_timeout_from_metadata($metadata);
     $call = new UnaryCall($this->channel, $method, $deserialize, $timeout);
     $jwt_aud_uri = $this->_get_jwt_aud_uri($method);
@@ -217,7 +217,7 @@ class BaseStub {
    */
   public function _clientStreamRequest($method,
                                        callable $deserialize,
-                                       $metadata = array()) {
+                                       $metadata = []) {
     list($actual_metadata, $timeout)  = $this->_extract_timeout_from_metadata($metadata);
     $call = new ClientStreamingCall($this->channel, $method, $deserialize, $timeout);
     $jwt_aud_uri = $this->_get_jwt_aud_uri($method);
@@ -244,8 +244,8 @@ class BaseStub {
   public function _serverStreamRequest($method,
                                        $argument,
                                        callable $deserialize,
-                                       $metadata = array(),
-                                       $options = array()) {
+                                       $metadata = [],
+                                       $options = []) {
     list($actual_metadata, $timeout)  = $this->_extract_timeout_from_metadata($metadata);
     $call = new ServerStreamingCall($this->channel, $method, $deserialize, $timeout);
     $jwt_aud_uri = $this->_get_jwt_aud_uri($method);
@@ -269,7 +269,7 @@ class BaseStub {
    */
   public function _bidiRequest($method,
                                callable $deserialize,
-                               $metadata = array()) {
+                               $metadata = []) {
     list($actual_metadata, $timeout)  = $this->_extract_timeout_from_metadata($metadata);
     $call = new BidiStreamingCall($this->channel, $method, $deserialize, $timeout);
     $jwt_aud_uri = $this->_get_jwt_aud_uri($method);

--- a/src/php/lib/Grpc/BidiStreamingCall.php
+++ b/src/php/lib/Grpc/BidiStreamingCall.php
@@ -42,7 +42,7 @@ class BidiStreamingCall extends AbstractCall {
    * Start the call
    * @param array $metadata Metadata to send with the call, if applicable
    */
-  public function start($metadata = array()) {
+  public function start($metadata = []) {
     $this->call->startBatch([OP_SEND_INITIAL_METADATA => $metadata]);
   }
 
@@ -69,7 +69,7 @@ class BidiStreamingCall extends AbstractCall {
    * @param array $options an array of options, possible keys:
    *              'flags' => a number
    */
-  public function write($data, $options = array()) {
+  public function write($data, $options = []) {
     $message_array = ['message' => $data->serialize()];
     if (isset($options['flags'])) {
       $message_array['flags'] = $options['flags'];

--- a/src/php/lib/Grpc/ClientStreamingCall.php
+++ b/src/php/lib/Grpc/ClientStreamingCall.php
@@ -42,7 +42,7 @@ class ClientStreamingCall extends AbstractCall {
    * Start the call.
    * @param array $metadata Metadata to send with the call, if applicable
    */
-  public function start($metadata = array()) {
+  public function start($metadata = []) {
     $this->call->startBatch([OP_SEND_INITIAL_METADATA => $metadata]);
   }
 
@@ -53,7 +53,7 @@ class ClientStreamingCall extends AbstractCall {
    * @param array $options an array of options, possible keys:
    *              'flags' => a number
    */
-  public function write($data, $options = array()) {
+  public function write($data, $options = []) {
     $message_array = ['message' => $data->serialize()];
     if (isset($options['flags'])) {
       $message_array['flags'] = $options['flags'];
@@ -72,6 +72,6 @@ class ClientStreamingCall extends AbstractCall {
         OP_RECV_MESSAGE => true,
         OP_RECV_STATUS_ON_CLIENT => true]);
     $this->metadata = $event->metadata;
-    return array($this->deserializeResponse($event->message), $event->status);
+    return [$this->deserializeResponse($event->message), $event->status];
   }
 }

--- a/src/php/lib/Grpc/ServerStreamingCall.php
+++ b/src/php/lib/Grpc/ServerStreamingCall.php
@@ -45,7 +45,7 @@ class ServerStreamingCall extends AbstractCall {
    * @param array $options an array of options, possible keys:
    *              'flags' => a number
    */
-  public function start($data, $metadata = array(), $options = array()) {
+  public function start($data, $metadata = [], $options = []) {
     $message_array = ['message' => $data->serialize()];
     if (isset($options['flags'])) {
       $message_array['flags'] = $options['flags'];

--- a/src/php/lib/Grpc/UnaryCall.php
+++ b/src/php/lib/Grpc/UnaryCall.php
@@ -45,7 +45,7 @@ class UnaryCall extends AbstractCall {
    * @param array $options an array of options, possible keys:
    *              'flags' => a number
    */
-  public function start($data, $metadata = array(), $options = array()) {
+  public function start($data, $metadata = [], $options = []) {
     $message_array = ['message' => $data->serialize()];
     if (isset($options['flags'])) {
       $message_array['flags'] = $options['flags'];
@@ -66,6 +66,6 @@ class UnaryCall extends AbstractCall {
     $event = $this->call->startBatch([
         OP_RECV_MESSAGE => true,
         OP_RECV_STATUS_ON_CLIENT => true]);
-    return array($this->deserializeResponse($event->message), $event->status);
+    return [$this->deserializeResponse($event->message), $event->status];
   }
 }


### PR DESCRIPTION
Minor coding style consistency fix: use `[]` notation for array instead of `array()`

The `[]` notation was [introduced in PHP 5.4](https://wiki.php.net/rfc/shortsyntaxforarrays) and is the recommended coding style since [PSR-2](http://www.php-fig.org/psr/psr-2/). We are supporting only PHP 5.5 or above anyways. 
