### PR TITLE
Add OpenCover coverage for C#

### DIFF
--- a/src/csharp/.gitignore
+++ b/src/csharp/.gitignore
@@ -7,6 +7,7 @@ Grpc.v12.suo
 Grpc.sdf
 
 TestResult.xml
+coverage_results.xml
 /TestResults
 .vs/
 *.nupkg

--- a/src/csharp/.nuget/packages.config
+++ b/src/csharp/.nuget/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit.Runners" version="2.6.4" />
+  <package id="OpenCover" version="4.6.166" />
+  <package id="ReportGenerator" version="2.3.2.0" />
 </packages>

--- a/tools/run_tests/build_csharp.sh
+++ b/tools/run_tests/build_csharp.sh
@@ -30,7 +30,7 @@
 
 set -ex
 
-if [ "$CONFIG" = "dbg" ]
+if [ "$CONFIG" = "dbg" ] || [ "$CONFIG" = "gcov" ]
 then
   MSBUILD_CONFIG="Debug"
 else

--- a/tools/run_tests/run_csharp.bat
+++ b/tools/run_tests/run_csharp.bat
@@ -2,13 +2,23 @@
 
 setlocal
 
-@rem enter this directory
+@rem enter src/csharp directory
 cd /d %~dp0\..\..\src\csharp
 
-@rem set UUID variable to a random GUID, we will use it to put TestResults.xml to a dedicated directory, so that parallel test runs don't collide
-for /F %%i in ('powershell -Command "[guid]::NewGuid().ToString()"') do (set UUID=%%i)
+if not "%CONFIG%" == "gcov" (
+  @rem Run tests for assembly passed as 1st arg.
 
-packages\NUnit.Runners.2.6.4\tools\nunit-console-x86.exe /domain:None -labels "%1/bin/Debug/%1.dll" -work test-results/%UUID% || goto :error
+  @rem set UUID variable to a random GUID, we will use it to put TestResults.xml to a dedicated directory, so that parallel test runs don't collide
+  for /F %%i in ('powershell -Command "[guid]::NewGuid().ToString()"') do (set UUID=%%i)
+
+  packages\NUnit.Runners.2.6.4\tools\nunit-console-x86.exe /domain:None -labels "%1/bin/Debug/%1.dll" -work test-results/%UUID% || goto :error
+) else (
+  @rem Run all tests with code coverage
+
+  packages\OpenCover.4.6.166\tools\OpenCover.Console.exe -target:"packages\NUnit.Runners.2.6.4\tools\nunit-console-x86.exe" -targetdir:"." -targetargs:"/domain:None -labels Grpc.Core.Tests/bin/Debug/Grpc.Core.Tests.dll Grpc.IntegrationTesting/bin/Debug/Grpc.IntegrationTesting.dll Grpc.Examples.Tests/bin/Debug/Grpc.Examples.Tests.dll Grpc.HealthCheck.Tests/bin/Debug/Grpc.HealthCheck.Tests.dll" -filter:"+[Grpc.Core]*"  -register:user -output:coverage_results.xml || goto :error
+
+  packages\ReportGenerator.2.3.2.0\tools\ReportGenerator.exe -reports:"coverage_results.xml" -targetdir:"..\..\reports\csharp_coverage" -reporttypes:"Html;TextSummary" || goto :error
+)
 
 endlocal
 

--- a/tools/run_tests/run_csharp.sh
+++ b/tools/run_tests/run_csharp.sh
@@ -49,7 +49,11 @@ export LD_LIBRARY_PATH=$root/libs/$CONFIG
 
 if [ "$CONFIG" = "gcov" ]
 then
-  (cd src/csharp; $NUNIT_CONSOLE -labels "Grpc.Core.Tests/bin/$MSBUILD_CONFIG/Grpc.Core.Tests.dll")
+  (cd src/csharp; $NUNIT_CONSOLE -labels \
+      "Grpc.Core.Tests/bin/$MSBUILD_CONFIG/Grpc.Core.Tests.dll" \
+      "Grpc.Examples.Tests/bin/$MSBUILD_CONFIG/Grpc.Examples.Tests.dll" \
+      "Grpc.HealthCheck.Tests/bin/$MSBUILD_CONFIG/Grpc.HealthCheck.Tests.dll" \
+      "Grpc.IntegrationTesting/bin/$MSBUILD_CONFIG/Grpc.IntegrationTesting.dll")
 
   gcov objs/gcov/src/csharp/ext/*.o
   lcov --base-directory . --directory . -c -o coverage.info

--- a/tools/run_tests/run_csharp.sh
+++ b/tools/run_tests/run_csharp.sh
@@ -34,7 +34,7 @@ CONFIG=${CONFIG:-opt}
 
 NUNIT_CONSOLE="mono packages/NUnit.Runners.2.6.4/tools/nunit-console.exe"
 
-if [ "$CONFIG" = "dbg" ]
+if [ "$CONFIG" = "dbg" ] || [ "$CONFIG" = "gcov" ]
 then
   MSBUILD_CONFIG="Debug"
 else
@@ -45,10 +45,20 @@ fi
 cd $(dirname $0)/../..
 
 root=`pwd`
-cd src/csharp
-
 export LD_LIBRARY_PATH=$root/libs/$CONFIG
 
-$NUNIT_CONSOLE -labels "$1/bin/$MSBUILD_CONFIG/$1.dll"
+if [ "$CONFIG" = "gcov" ]
+then
+  (cd src/csharp; $NUNIT_CONSOLE -labels "Grpc.Core.Tests/bin/$MSBUILD_CONFIG/Grpc.Core.Tests.dll")
+
+  gcov objs/gcov/src/csharp/ext/*.o
+  lcov --base-directory . --directory . -c -o coverage.info
+  lcov -e coverage.info '**/src/csharp/ext/*' -o coverage.info
+  genhtml -o reports/csharp_ext_coverage --num-spaces 2 \
+    -t 'gRPC C# native extension test coverage' coverage.info \
+    --rc genhtml_hi_limit=95 --rc genhtml_med_limit=80 --no-prefix
+else
+  (cd src/csharp; $NUNIT_CONSOLE -labels "$1/bin/$MSBUILD_CONFIG/$1.dll")
+fi
 
 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -342,10 +342,16 @@ class CSharpLanguage(object):
       cmd = 'tools\\run_tests\\run_csharp.bat'
     else:
       cmd = 'tools/run_tests/run_csharp.sh'
-    return [config.job_spec([cmd, assembly],
-            None, shortname=assembly,
-            environ=_FORCE_ENVIRON_FOR_WRAPPERS)
-            for assembly in assemblies]
+
+    if not config.build_config == 'gcov':
+      return [config.job_spec([cmd, assembly],
+              None, shortname=assembly,
+              environ=_FORCE_ENVIRON_FOR_WRAPPERS)
+              for assembly in assemblies]
+    else:
+      # For code coverage we need to run all tests in one suite.
+      return [config.job_spec([cmd], None,
+              environ=_FORCE_ENVIRON_FOR_WRAPPERS)]
 
   def pre_build_steps(self):
     if self.platform == 'windows':

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -343,10 +343,10 @@ class CSharpLanguage(object):
     else:
       cmd = 'tools/run_tests/run_csharp.sh'
 
-    if config.build_config == 'gcov' and self.platform == 'windows':
-      # For C# code coverage we need to:
-      # 1) Run all tests as one suite.
-      # 2) Need to be on Windows.
+    if config.build_config == 'gcov':
+      # On Windows, we only collect C# code coverage.
+      # On Linux, we only collect coverage for native extension.
+      # For code coverage all tests need to run as one suite.
       return [config.job_spec([cmd], None,
               environ=_FORCE_ENVIRON_FOR_WRAPPERS)]
     else:

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -343,15 +343,17 @@ class CSharpLanguage(object):
     else:
       cmd = 'tools/run_tests/run_csharp.sh'
 
-    if not config.build_config == 'gcov':
+    if config.build_config == 'gcov' and self.platform == 'windows':
+      # For C# code coverage we need to:
+      # 1) Run all tests as one suite.
+      # 2) Need to be on Windows.
+      return [config.job_spec([cmd], None,
+              environ=_FORCE_ENVIRON_FOR_WRAPPERS)]
+    else:
       return [config.job_spec([cmd, assembly],
               None, shortname=assembly,
               environ=_FORCE_ENVIRON_FOR_WRAPPERS)
               for assembly in assemblies]
-    else:
-      # For code coverage we need to run all tests in one suite.
-      return [config.job_spec([cmd], None,
-              environ=_FORCE_ENVIRON_FOR_WRAPPERS)]
 
   def pre_build_steps(self):
     if self.platform == 'windows':


### PR DESCRIPTION
Support for generating C# code coverage using OpenCover. 

OpenCover (as well as other code coverage tools I found) only works on Windows. That is a bit problematic because it looks like we wanted to setup the "Coverage" jenkins project as a "simple" (i.e. not matrix) build.

The resulting report is placed into REPO_ROOT/reports/csharp_coverage

Progress on #3773.