### PR TITLE
Prevent XCode 7 from showing spurious warnings

### DIFF
--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -566,8 +566,12 @@ Pod::Spec.new do |s|
     ss.header_mappings_dir = '.'
     # This isn't officially supported in Cocoapods. We've asked for an alternative:
     # https://github.com/CocoaPods/CocoaPods/issues/4386
-    ss.xcconfig = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/Headers/Private/gRPC" ' +
-                                             '"$(PODS_ROOT)/Headers/Private/gRPC/include"' }
+    ss.xcconfig = {
+      'USE_HEADERMAP' => 'NO',
+      'ALWAYS_SEARCH_USER_PATHS' => 'NO',
+      'USER_HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/Headers/Private/gRPC"',
+      'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/Headers/Private/gRPC/include"'
+    }
 
     ss.requires_arc = false
     ss.libraries = 'z'

--- a/templates/gRPC.podspec.template
+++ b/templates/gRPC.podspec.template
@@ -88,8 +88,12 @@
       ss.header_mappings_dir = '.'
       # This isn't officially supported in Cocoapods. We've asked for an alternative:
       # https://github.com/CocoaPods/CocoaPods/issues/4386
-      ss.xcconfig = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/Headers/Private/gRPC" ' +
-                                               '"$(PODS_ROOT)/Headers/Private/gRPC/include"' }
+      ss.xcconfig = {
+        'USE_HEADERMAP' => 'NO',
+        'ALWAYS_SEARCH_USER_PATHS' => 'NO',
+        'USER_HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/Headers/Private/gRPC"',
+        'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/Headers/Private/gRPC/include"'
+      }
 
       ss.requires_arc = false
       ss.libraries = 'z'


### PR DESCRIPTION
Without this, the new XCode shows hundreds of warnings because the header locations confuse it.

~~This will hopefully make xctool work on Travis too (crossing fingers!)~~ It does :)