### PR TITLE
requiring tmpdir to resolve undefined method error

### DIFF
--- a/src/ruby/spec/pb/health/checker_spec.rb
+++ b/src/ruby/spec/pb/health/checker_spec.rb
@@ -31,6 +31,7 @@ require 'grpc'
 require 'grpc/health/v1alpha/health'
 require 'grpc/health/checker'
 require 'open3'
+require 'tmpdir'
 
 def can_run_codegen_check
   system('which grpc_ruby_plugin') && system('which protoc')


### PR DESCRIPTION
This fixes the error ""undefined method `mktmpdir' for Dir:Class"  when running checker_spec.rb.  adding require 'tmpdir' to resolve this issue. 