### PR TITLE
docs(npm): make sure the dependency is persisted in package.json

### DIFF
--- a/src/node/README.md
+++ b/src/node/README.md
@@ -11,7 +11,7 @@ Beta
 Install the gRPC NPM package
 
 ```sh
-npm install grpc
+npm install grpc --save
 ```
 
 ## BUILD FROM SOURCE


### PR DESCRIPTION
Saving a few seconds for all the copy & paste fellows that wonder why the package suddenly is missing on deployment.