### PR TITLE
Make xctool work on the release branch too.

### DIFF
--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -530,8 +530,12 @@ Pod::Spec.new do |s|
     ss.header_mappings_dir = '.'
     # This isn't officially supported in Cocoapods. We've asked for an alternative:
     # https://github.com/CocoaPods/CocoaPods/issues/4386
-    ss.xcconfig = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/Headers/Private/gRPC" ' +
-                                             '"$(PODS_ROOT)/Headers/Private/gRPC/include"' }
+    ss.xcconfig = {
+      'USE_HEADERMAP' => 'NO',
+      'ALWAYS_SEARCH_USER_PATHS' => 'NO',
+      'USER_HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/Headers/Private/gRPC"',
+      'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/Headers/Private/gRPC/include"'
+    }
 
     ss.requires_arc = false
     ss.libraries = 'z'

--- a/templates/gRPC.podspec.template
+++ b/templates/gRPC.podspec.template
@@ -88,8 +88,12 @@
       ss.header_mappings_dir = '.'
       # This isn't officially supported in Cocoapods. We've asked for an alternative:
       # https://github.com/CocoaPods/CocoaPods/issues/4386
-      ss.xcconfig = { 'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/Headers/Private/gRPC" ' +
-                                               '"$(PODS_ROOT)/Headers/Private/gRPC/include"' }
+      ss.xcconfig = {
+        'USE_HEADERMAP' => 'NO',
+        'ALWAYS_SEARCH_USER_PATHS' => 'NO',
+        'USER_HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/Headers/Private/gRPC"',
+        'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/Headers/Private/gRPC/include"'
+      }
 
       ss.requires_arc = false
       ss.libraries = 'z'


### PR DESCRIPTION
Which also eliminates a flood of warnings for people using the latest XCode. This is just a cherrypick of #3990.