### PR TITLE
ObjC: Update Sample

### DIFF
--- a/src/objective-c/examples/Sample/Podfile
+++ b/src/objective-c/examples/Sample/Podfile
@@ -1,8 +1,9 @@
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
+pod 'Protobuf', :path => "../../../../third_party/protobuf"
 pod 'gRPC', :path => "../../../.."
-pod 'RemoteTest', :path => "../../generated_libraries/RemoteTestClient"
+pod 'RemoteTest', :path => "../RemoteTestClient"
 
 target 'Sample' do
 end

--- a/src/objective-c/examples/Sample/Sample/ViewController.m
+++ b/src/objective-c/examples/Sample/Sample/ViewController.m
@@ -34,7 +34,7 @@
 #import "ViewController.h"
 
 #import <GRPCClient/GRPCCall.h>
-#import <GRPCClient/GRPCMethodName.h>
+#import <ProtoRPC/ProtoMethod.h>
 #import <RemoteTest/Messages.pbobjc.h>
 #import <RemoteTest/Test.pbrpc.h>
 #import <RxLibrary/GRXWriter+Immediate.h>
@@ -66,14 +66,14 @@
 
   // Same example call using the generic gRPC client library:
 
-  GRPCMethodName *method = [[GRPCMethodName alloc] initWithPackage:@"grpc.testing"
-                                                         interface:@"TestService"
-                                                            method:@"UnaryCall"];
+  ProtoMethod *method = [[ProtoMethod alloc] initWithPackage:@"grpc.testing"
+                                                     service:@"TestService"
+                                                      method:@"UnaryCall"];
 
-  id<GRXWriter> requestsWriter = [GRXWriter writerWithValue:[request data]];
+  GRXWriter *requestsWriter = [GRXWriter writerWithValue:[request data]];
 
   GRPCCall *call = [[GRPCCall alloc] initWithHost:kRemoteHost
-                                           method:method
+                                             path:method.HTTPPath
                                    requestsWriter:requestsWriter];
 
   id<GRXWriteable> responsesWriteable = [[GRXWriteable alloc] initWithValueHandler:^(NSData *value) {

--- a/src/objective-c/generated_libraries/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/generated_libraries/RemoteTestClient/RemoteTest.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.prepare_command = <<-CMD
     BINDIR=../../../../bins/$CONFIG
     PROTOC=$BINDIR/protobuf/protoc
-    PLUGIN=$BINDIR/grpc_objective_c_plugin
+    PLUGIN=$BINDIR/opt/grpc_objective_c_plugin
     $PROTOC --plugin=protoc-gen-grpc=$PLUGIN --objc_out=. --grpc_out=. *.proto
   CMD
 

--- a/src/objective-c/generated_libraries/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/generated_libraries/RemoteTestClient/RemoteTest.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.prepare_command = <<-CMD
     BINDIR=../../../../bins/$CONFIG
     PROTOC=$BINDIR/protobuf/protoc
-    PLUGIN=$BINDIR/opt/grpc_objective_c_plugin
+    PLUGIN=$BINDIR/grpc_objective_c_plugin
     $PROTOC --plugin=protoc-gen-grpc=$PLUGIN --objc_out=. --grpc_out=. *.proto
   CMD
 


### PR DESCRIPTION
Addresses #3371 

----------------------------

* Uses the new `ProtoMethod` instead of the missing `GRPCMethodName`
* ~~Points the `RemoteTest` podspec to use the new path for the `grpc_objective_c_plugin` plugin~~
* Update objc sample Podfile to use example projects