### PR TITLE
Fixing the doc to warn of the dangers for overriding the target name …

### DIFF
--- a/include/grpc++/support/channel_arguments.h
+++ b/include/grpc++/support/channel_arguments.h
@@ -70,7 +70,8 @@ class ChannelArguments {
   void SetChannelArgs(grpc_channel_args* channel_args) const;
 
   // gRPC specific channel argument setters
-  /// Set target name override for SSL host name checking.
+  /// Set target name override for SSL host name checking. This option is for
+  /// testing only and should never be used in production.
   void SetSslTargetNameOverride(const grpc::string& name);
   // TODO(yangg) add flow control options
   /// Set the compression algorithm for the channel.


### PR DESCRIPTION
…when using SSL.