### PR TITLE
Fix naming issue in stress_test

### DIFF
--- a/test/cpp/interop/stress_test.cc
+++ b/test/cpp/interop/stress_test.cc
@@ -41,6 +41,7 @@
 #include <grpc/support/time.h>
 #include <grpc++/create_channel.h>
 #include <grpc++/grpc++.h>
+#include <grpc++/impl/thd.h>
 
 #include "test/cpp/interop/interop_client.h"
 #include "test/cpp/interop/stress_interop_client.h"
@@ -80,7 +81,6 @@ DEFINE_string(test_cases, "",
 
 using std::make_pair;
 using std::pair;
-using std::thread;
 using std::vector;
 
 using grpc::testing::kTestCaseList;
@@ -202,7 +202,7 @@ int main(int argc, char** argv) {
 
   gpr_log(GPR_INFO, "Starting test(s)..");
 
-  vector<std::thread> test_threads;
+  vector<grpc::thread> test_threads;
   int thread_idx = 0;
   for (auto it = server_addresses.begin(); it != server_addresses.end(); it++) {
     StressTestInteropClient* client = new StressTestInteropClient(
@@ -210,7 +210,7 @@ int main(int argc, char** argv) {
         FLAGS_sleep_duration_ms);
 
     test_threads.emplace_back(
-        std::thread(&StressTestInteropClient::MainLoop, client));
+        grpc::thread(&StressTestInteropClient::MainLoop, client));
   }
 
   for (auto it = test_threads.begin(); it != test_threads.end(); it++) {

--- a/test/cpp/interop/stress_test.cc
+++ b/test/cpp/interop/stress_test.cc
@@ -202,7 +202,7 @@ int main(int argc, char** argv) {
 
   gpr_log(GPR_INFO, "Starting test(s)..");
 
-  vector<thread> test_threads;
+  vector<std::thread> test_threads;
   int thread_idx = 0;
   for (auto it = server_addresses.begin(); it != server_addresses.end(); it++) {
     StressTestInteropClient* client = new StressTestInteropClient(
@@ -210,7 +210,7 @@ int main(int argc, char** argv) {
         FLAGS_sleep_duration_ms);
 
     test_threads.emplace_back(
-        thread(&StressTestInteropClient::MainLoop, client));
+        std::thread(&StressTestInteropClient::MainLoop, client));
   }
 
   for (auto it = test_threads.begin(); it != test_threads.end(); it++) {


### PR DESCRIPTION
(via ahh@google.com)
Under some configurations gRPC includes google3 base headers.  google3
has a namespace "thread" which mixes poorly with unqualified use of the
type std::thread; adding that namespace to various google3 headers
breaks this test.