### PR TITLE
Filter Protobuf nullable warnings

### DIFF
--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -51,4 +51,5 @@ xcodebuild \
     -scheme AllTests \
     -destination name="iPhone 6" \
     test \
-    | egrep "$XCODEBUILD_FILTER" -
+    | egrep "$XCODEBUILD_FILTER" \
+    | egrep -v "(GPBDictionary|GPBArray)" -


### PR DESCRIPTION
`GPBArray` and `GPBDictionary` leave a flood of warnings due to wrongly-specified nullability of parameters. Until the next version of Protobuf is released (which fixes it), we don't want to be bothered.