### PR TITLE
php: remove callable type hint from BaseStub->_simpleRequest()

### DIFF
--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -216,7 +216,7 @@ class BaseStub
      */
     public function _simpleRequest($method,
                                    $argument,
-                                   callable $deserialize,
+                                   $deserialize,
                                    $metadata = [],
                                    $options = [])
     {


### PR DESCRIPTION
The "callable" type hint in PHP appears to be broken in PHP 5.6.6. It feels unnecessary here, as the required code is generated.

See https://bugs.php.net/bug.php?id=61467&edit=1 for more info.

/cc @Phraxos