### PR TITLE
Test that http2 settings frames with small max frame sizes are treated as errors

### DIFF
--- a/tools/http2_interop/http2interop.go
+++ b/tools/http2_interop/http2interop.go
@@ -330,6 +330,7 @@ func http2Connect(c net.Conn, sf *SettingsFrame) error {
 	if _, err := c.Write([]byte(Preface)); err != nil {
 		return err
 	}
+
 	if sf == nil {
 		sf = &SettingsFrame{}
 	}

--- a/tools/http2_interop/s6.5.go
+++ b/tools/http2_interop/s6.5.go
@@ -1,0 +1,33 @@
+package http2interop
+
+import (
+	"time"
+)
+
+// Section 6.5 says the minimum SETTINGS_MAX_FRAME_SIZE is 16,384
+func testSmallMaxFrameSize(ctx *HTTP2InteropCtx) error {
+	conn, err := connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	conn.Log = ctx.T.Log
+	conn.SetDeadline(time.Now().Add(defaultTimeout))
+
+	sf := &SettingsFrame{
+		Params: []SettingsParameter{{
+			Identifier: SettingsMaxFrameSize,
+			Value:      1<<14 - 1, // 1 less than the smallest maximum
+		}},
+	}
+
+	if err := http2Connect(conn, sf); err != nil {
+		return err
+	}
+
+	if _, err := expectGoAwaySoon(conn); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/tools/http2_interop/s6.5_test.go
+++ b/tools/http2_interop/s6.5_test.go
@@ -1,0 +1,14 @@
+package http2interop
+
+import (
+	"testing"
+)
+
+func TestSmallMaxFrameSize(t *testing.T) {
+	if *testCase != "experimental" {
+		t.SkipNow()
+	}
+	ctx := InteropCtx(t)
+	err := testSmallMaxFrameSize(ctx)
+	matchError(t, err, "Got goaway frame")
+}

--- a/tools/http2_interop/settings.go
+++ b/tools/http2_interop/settings.go
@@ -29,19 +29,19 @@ const (
 func (si SettingsIdentifier) String() string {
 	switch si {
 	case SettingsHeaderTableSize:
-		return "HEADER_TABLE_SIZE"
+		return "SETTINGS_HEADER_TABLE_SIZE"
 	case SettingsEnablePush:
-		return "ENABLE_PUSH"
+		return "SETTINGS_ENABLE_PUSH"
 	case SettingsMaxConcurrentStreams:
-		return "MAX_CONCURRENT_STREAMS"
+		return "SETTINGS_MAX_CONCURRENT_STREAMS"
 	case SettingsInitialWindowSize:
-		return "INITIAL_WINDOW_SIZE"
+		return "SETTINGS_INITIAL_WINDOW_SIZE"
 	case SettingsMaxFrameSize:
-		return "MAX_FRAME_SIZE"
+		return "SETTINGS_MAX_FRAME_SIZE"
 	case SettingsMaxHeaderListSize:
-		return "MAX_HEADER_LIST_SIZE"
+		return "SETTINGS_MAX_HEADER_LIST_SIZE"
 	default:
-		return fmt.Sprintf("UNKNOWN(%d)", uint16(si))
+		return fmt.Sprintf("SETTINGS_UNKNOWN(%d)", uint16(si))
 	}
 }
 
@@ -82,7 +82,7 @@ func (f *SettingsFrame) UnmarshalPayload(raw []byte) error {
 }
 
 func (f *SettingsFrame) MarshalPayload() ([]byte, error) {
-	raw := make([]byte, 0, len(f.Params)*6)
+	raw := make([]byte, len(f.Params)*6)
 	for i, p := range f.Params {
 		binary.BigEndian.PutUint16(raw[i*6:i*6+2], uint16(p.Identifier))
 		binary.BigEndian.PutUint32(raw[i*6+2:i*6+6], p.Value)
@@ -102,7 +102,6 @@ func (f *SettingsFrame) MarshalBinary() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	header = append(header, payload...)
 
 	return header, nil


### PR DESCRIPTION
The test will need to be enabled for the auto run interop suite once #4233 is fixed.

Longer term, this will need to be a dashboard, rather than a full pass fail kind of test.