### PR TITLE
Make Python reports go where they're supposed to

### DIFF
--- a/src/python/grpcio_test/setup.py
+++ b/src/python/grpcio_test/setup.py
@@ -67,6 +67,7 @@ _SETUP_REQUIRES = (
     'pytest-cov>=2.0',
     'pytest-xdist>=1.11',
     'pytest-timeout>=0.5',
+    'pytest-html>=1.7',
 )
 
 _INSTALL_REQUIRES = (

--- a/tools/run_tests/run_python.sh
+++ b/tools/run_tests/run_python.sh
@@ -40,4 +40,6 @@ export DYLD_LIBRARY_PATH=$ROOT/libs/$CONFIG
 export PATH=$ROOT/bins/$CONFIG:$ROOT/bins/$CONFIG/protobuf:$PATH
 source "python"$PYVER"_virtual_environment"/bin/activate
 
-"python"$PYVER $GRPCIO_TEST/setup.py test -a "-n8 --cov=grpc --junitxml=./report.xml --timeout=300 -v --boxed --timeout_method=thread"
+mkdir -p reports
+
+"python"$PYVER $GRPCIO_TEST/setup.py test -a "-n8 --cov=grpc --html=$ROOT/reports/report.html --junitxml=$ROOT/report.xml --timeout=300 -v --boxed --timeout_method=thread"


### PR DESCRIPTION
As long as I'm waiting on my machine to do a Jenkins run, I might as well make Jenkins do a Jenkins run.