### PR TITLE
Introduce auth interceptor context for C# 

### DIFF
--- a/src/csharp/Grpc.Core/CallCredentials.cs
+++ b/src/csharp/Grpc.Core/CallCredentials.cs
@@ -41,14 +41,6 @@ using Grpc.Core.Utils;
 namespace Grpc.Core
 {
     /// <summary>
-    /// Asynchronous authentication interceptor for <see cref="CallCredentials"/>.
-    /// </summary>
-    /// <param name="authUri">URL of a service to which current remote call needs to authenticate</param>
-    /// <param name="metadata">Metadata to populate with entries that will be added to outgoing call's headers.</param>
-    /// <returns></returns>
-    public delegate Task AsyncAuthInterceptor(string authUri, Metadata metadata);
-
-    /// <summary>
     /// Client-side call credentials. Provide authorization with per-call granularity.
     /// </summary>
     public abstract class CallCredentials

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -48,6 +48,7 @@
   <ItemGroup>
     <Compile Include="AsyncDuplexStreamingCall.cs" />
     <Compile Include="AsyncServerStreamingCall.cs" />
+    <Compile Include="AsyncAuthInterceptor.cs" />
     <Compile Include="CallCredentials.cs" />
     <Compile Include="IClientStreamWriter.cs" />
     <Compile Include="Internal\NativeMetadataCredentialsPlugin.cs" />
@@ -155,7 +156,5 @@
   <Import Project="..\packages\grpc.dependencies.openssl.redist.1.0.2.2\build\portable-net45\grpc.dependencies.openssl.redist.targets" Condition="Exists('..\packages\grpc.dependencies.openssl.redist.1.0.2.2\build\portable-net45\grpc.dependencies.openssl.redist.targets')" />
   <Import Project="..\packages\grpc.dependencies.zlib.redist.1.2.8.9\build\portable-net45\grpc.dependencies.zlib.redist.targets" Condition="Exists('..\packages\grpc.dependencies.zlib.redist.1.2.8.9\build\portable-net45\grpc.dependencies.zlib.redist.targets')" />
   <ItemGroup />
-  <ItemGroup>
-    <Folder Include="Profiling\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
@@ -38,7 +38,7 @@ using Grpc.Core.Utils;
 
 namespace Grpc.Core.Internal
 {
-    internal delegate void NativeMetadataInterceptor(IntPtr statePtr, IntPtr serviceUrlPtr, IntPtr callbackPtr, IntPtr userDataPtr, bool isDestroy);
+    internal delegate void NativeMetadataInterceptor(IntPtr statePtr, IntPtr serviceUrlPtr, IntPtr methodNamePtr, IntPtr callbackPtr, IntPtr userDataPtr, bool isDestroy);
 
     internal class NativeMetadataCredentialsPlugin
     {
@@ -71,7 +71,7 @@ namespace Grpc.Core.Internal
             get { return credentials; }
         }
 
-        private void NativeMetadataInterceptorHandler(IntPtr statePtr, IntPtr serviceUrlPtr, IntPtr callbackPtr, IntPtr userDataPtr, bool isDestroy)
+        private void NativeMetadataInterceptorHandler(IntPtr statePtr, IntPtr serviceUrlPtr, IntPtr methodNamePtr, IntPtr callbackPtr, IntPtr userDataPtr, bool isDestroy)
         {
             if (isDestroy)
             {
@@ -81,8 +81,9 @@ namespace Grpc.Core.Internal
 
             try
             {
-                string serviceUrl = Marshal.PtrToStringAnsi(serviceUrlPtr);
-                StartGetMetadata(serviceUrl, callbackPtr, userDataPtr);
+                var context = new AuthInterceptorContext(Marshal.PtrToStringAnsi(serviceUrlPtr),
+                                                         Marshal.PtrToStringAnsi(methodNamePtr));
+                StartGetMetadata(context, callbackPtr, userDataPtr);
             }
             catch (Exception e)
             {
@@ -91,12 +92,12 @@ namespace Grpc.Core.Internal
             }
         }
 
-        private async void StartGetMetadata(string serviceUrl, IntPtr callbackPtr, IntPtr userDataPtr)
+        private async void StartGetMetadata(AuthInterceptorContext context, IntPtr callbackPtr, IntPtr userDataPtr)
         {
             try
             {
                 var metadata = new Metadata();
-                await interceptor(serviceUrl, metadata);
+                await interceptor(context, metadata);
 
                 using (var metadataArray = MetadataArraySafeHandle.Create(metadata))
                 {

--- a/src/csharp/Grpc.IntegrationTesting/MetadataCredentialsTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/MetadataCredentialsTest.cs
@@ -67,7 +67,7 @@ namespace Grpc.IntegrationTesting
                 new ChannelOption(ChannelOptions.SslTargetNameOverride, TestCredentials.DefaultHostOverride)
             };
 
-            var asyncAuthInterceptor = new AsyncAuthInterceptor(async (authUri, metadata) =>
+            var asyncAuthInterceptor = new AsyncAuthInterceptor(async (context, metadata) =>
             {
                 await Task.Delay(100);  // make sure the operation is asynchronous.
                 metadata.Add("authorization", "SECRET_TOKEN");

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -927,7 +927,8 @@ GPR_EXPORT void GPR_CALLTYPE grpcsharp_metadata_credentials_notify_from_plugin(
 }
 
 typedef void(GPR_CALLTYPE *grpcsharp_metadata_interceptor_func)(
-  void *state, const char *service_url, grpc_credentials_plugin_metadata_cb cb,
+  void *state, const char *service_url, const char *method_name,
+  grpc_credentials_plugin_metadata_cb cb,
   void *user_data, gpr_int32 is_destroy);
 
 static void grpcsharp_get_metadata_handler(
@@ -935,13 +936,13 @@ static void grpcsharp_get_metadata_handler(
     grpc_credentials_plugin_metadata_cb cb, void *user_data) {
   grpcsharp_metadata_interceptor_func interceptor =
       (grpcsharp_metadata_interceptor_func)(gpr_intptr)state;
-  interceptor(state, context.service_url, cb, user_data, 0);
+  interceptor(state, context.service_url, context.method_name, cb, user_data, 0);
 }
 
 static void grpcsharp_metadata_credentials_destroy_handler(void *state) {
   grpcsharp_metadata_interceptor_func interceptor =
       (grpcsharp_metadata_interceptor_func)(gpr_intptr)state;
-  interceptor(state, NULL, NULL, NULL, 1);
+  interceptor(state, NULL, NULL, NULL, NULL, 1);
 }
 
 GPR_EXPORT grpc_call_credentials *GPR_CALLTYPE grpcsharp_metadata_credentials_create_from_plugin(


### PR DESCRIPTION
To ensure future API stability with respect to #4154. (populating AuthInterceptorContext with new properties is an additive API change).