### PR TITLE
Make http2 interop tests always pass, and instead give a report

### DIFF
--- a/tools/http2_interop/http2interop_test.go
+++ b/tools/http2_interop/http2interop_test.go
@@ -68,7 +68,7 @@ func (ctx *HTTP2InteropCtx) Close() error {
 	return nil
 }
 
-func TestClientShortSettings(t *testing.T) {
+func TestSoonClientShortSettings(t *testing.T) {
 	defer Report(t)
 	if *testCase != "framing" {
 		t.SkipNow()
@@ -80,7 +80,7 @@ func TestClientShortSettings(t *testing.T) {
 	}
 }
 
-func TestShortPreface(t *testing.T) {
+func TestSoonShortPreface(t *testing.T) {
 	defer Report(t)
 	if *testCase != "framing" {
 		t.SkipNow()
@@ -92,7 +92,7 @@ func TestShortPreface(t *testing.T) {
 	}
 }
 
-func TestUnknownFrameType(t *testing.T) {
+func TestSoonUnknownFrameType(t *testing.T) {
 	defer Report(t)
 	if *testCase != "framing" {
 		t.SkipNow()
@@ -103,7 +103,7 @@ func TestUnknownFrameType(t *testing.T) {
 	}
 }
 
-func TestClientPrefaceWithStreamId(t *testing.T) {
+func TestSoonClientPrefaceWithStreamId(t *testing.T) {
 	defer Report(t)
 	if *testCase != "framing" {
 		t.SkipNow()
@@ -113,7 +113,7 @@ func TestClientPrefaceWithStreamId(t *testing.T) {
 	matchError(t, err, "EOF")
 }
 
-func TestTLSApplicationProtocol(t *testing.T) {
+func TestSoonTLSApplicationProtocol(t *testing.T) {
 	defer Report(t)
 	if *testCase != "tls" {
 		t.SkipNow()
@@ -123,7 +123,7 @@ func TestTLSApplicationProtocol(t *testing.T) {
 	matchError(t, err, "EOF", "broken pipe")
 }
 
-func TestTLSMaxVersion(t *testing.T) {
+func TestSoonTLSMaxVersion(t *testing.T) {
 	defer Report(t)
 	if *testCase != "tls" {
 		t.SkipNow()
@@ -135,7 +135,7 @@ func TestTLSMaxVersion(t *testing.T) {
 	matchError(t, err, "EOF", "server selected unsupported protocol")
 }
 
-func TestTLSBadCipherSuites(t *testing.T) {
+func TestSoonTLSBadCipherSuites(t *testing.T) {
 	defer Report(t)
 	if *testCase != "tls" {
 		t.SkipNow()

--- a/tools/http2_interop/http2interop_test.go
+++ b/tools/http2_interop/http2interop_test.go
@@ -3,6 +3,7 @@ package http2interop
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -68,6 +69,7 @@ func (ctx *HTTP2InteropCtx) Close() error {
 }
 
 func TestClientShortSettings(t *testing.T) {
+	defer Report(t)()
 	if *testCase != "framing" {
 		t.SkipNow()
 	}
@@ -79,6 +81,7 @@ func TestClientShortSettings(t *testing.T) {
 }
 
 func TestShortPreface(t *testing.T) {
+	defer Report(t)()
 	if *testCase != "framing" {
 		t.SkipNow()
 	}
@@ -90,6 +93,7 @@ func TestShortPreface(t *testing.T) {
 }
 
 func TestUnknownFrameType(t *testing.T) {
+	defer Report(t)()
 	if *testCase != "framing" {
 		t.SkipNow()
 	}
@@ -100,6 +104,7 @@ func TestUnknownFrameType(t *testing.T) {
 }
 
 func TestClientPrefaceWithStreamId(t *testing.T) {
+	defer Report(t)()
 	if *testCase != "framing" {
 		t.SkipNow()
 	}
@@ -109,6 +114,7 @@ func TestClientPrefaceWithStreamId(t *testing.T) {
 }
 
 func TestTLSApplicationProtocol(t *testing.T) {
+	defer Report(t)()
 	if *testCase != "tls" {
 		t.SkipNow()
 	}
@@ -118,6 +124,7 @@ func TestTLSApplicationProtocol(t *testing.T) {
 }
 
 func TestTLSMaxVersion(t *testing.T) {
+	defer Report(t)()
 	if *testCase != "tls" {
 		t.SkipNow()
 	}
@@ -129,6 +136,7 @@ func TestTLSMaxVersion(t *testing.T) {
 }
 
 func TestTLSBadCipherSuites(t *testing.T) {
+	defer Report(t)()
 	if *testCase != "tls" {
 		t.SkipNow()
 	}
@@ -151,5 +159,10 @@ func matchError(t *testing.T, err error, matches ...string) {
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	os.Exit(m.Run())
+	m.Run()
+	if err := json.NewEncoder(os.Stderr).Encode(&allCaseInfos); err != nil {
+		fmt.Println("Failed to encode", err)
+	}
+	// Always pass
+	os.Exit(0)
 }

--- a/tools/http2_interop/http2interop_test.go
+++ b/tools/http2_interop/http2interop_test.go
@@ -69,7 +69,7 @@ func (ctx *HTTP2InteropCtx) Close() error {
 }
 
 func TestClientShortSettings(t *testing.T) {
-	defer Report(t)()
+	defer Report(t)
 	if *testCase != "framing" {
 		t.SkipNow()
 	}
@@ -81,7 +81,7 @@ func TestClientShortSettings(t *testing.T) {
 }
 
 func TestShortPreface(t *testing.T) {
-	defer Report(t)()
+	defer Report(t)
 	if *testCase != "framing" {
 		t.SkipNow()
 	}
@@ -93,7 +93,7 @@ func TestShortPreface(t *testing.T) {
 }
 
 func TestUnknownFrameType(t *testing.T) {
-	defer Report(t)()
+	defer Report(t)
 	if *testCase != "framing" {
 		t.SkipNow()
 	}
@@ -104,7 +104,7 @@ func TestUnknownFrameType(t *testing.T) {
 }
 
 func TestClientPrefaceWithStreamId(t *testing.T) {
-	defer Report(t)()
+	defer Report(t)
 	if *testCase != "framing" {
 		t.SkipNow()
 	}
@@ -114,7 +114,7 @@ func TestClientPrefaceWithStreamId(t *testing.T) {
 }
 
 func TestTLSApplicationProtocol(t *testing.T) {
-	defer Report(t)()
+	defer Report(t)
 	if *testCase != "tls" {
 		t.SkipNow()
 	}
@@ -124,7 +124,7 @@ func TestTLSApplicationProtocol(t *testing.T) {
 }
 
 func TestTLSMaxVersion(t *testing.T) {
-	defer Report(t)()
+	defer Report(t)
 	if *testCase != "tls" {
 		t.SkipNow()
 	}
@@ -136,7 +136,7 @@ func TestTLSMaxVersion(t *testing.T) {
 }
 
 func TestTLSBadCipherSuites(t *testing.T) {
-	defer Report(t)()
+	defer Report(t)
 	if *testCase != "tls" {
 		t.SkipNow()
 	}
@@ -160,9 +160,24 @@ func matchError(t *testing.T, err error, matches ...string) {
 func TestMain(m *testing.M) {
 	flag.Parse()
 	m.Run()
+	var fatal bool
+	var any bool
+	for _, ci := range allCaseInfos.Cases {
+		if ci.Skipped {
+			continue
+		}
+		any = true
+		if !ci.Passed && ci.Fatal {
+			fatal = true
+		}
+	}
+
 	if err := json.NewEncoder(os.Stderr).Encode(&allCaseInfos); err != nil {
 		fmt.Println("Failed to encode", err)
 	}
-	// Always pass
-	os.Exit(0)
+	var code int
+	if !any || fatal {
+		code = 1
+	}
+	os.Exit(code)
 }

--- a/tools/http2_interop/s6.5.go
+++ b/tools/http2_interop/s6.5.go
@@ -11,7 +11,6 @@ func testSmallMaxFrameSize(ctx *HTTP2InteropCtx) error {
 		return err
 	}
 	defer conn.Close()
-	conn.Log = ctx.T.Log
 	conn.SetDeadline(time.Now().Add(defaultTimeout))
 
 	sf := &SettingsFrame{

--- a/tools/http2_interop/s6.5_test.go
+++ b/tools/http2_interop/s6.5_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 )
 
-func TestSmallMaxFrameSize(t *testing.T) {
-	if *testCase != "experimental" {
+func TestSoonSmallMaxFrameSize(t *testing.T) {
+	defer Report(t)
+	if *testCase != "framing" {
 		t.SkipNow()
 	}
 	ctx := InteropCtx(t)

--- a/tools/http2_interop/testsuite.go
+++ b/tools/http2_interop/testsuite.go
@@ -1,0 +1,44 @@
+package http2interop
+
+import (
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// When a test is skipped or fails, runtime.Goexit() is called which destroys the callstack.
+// This means the name of the test case is lost, so we need to grab a copy of pc before.
+func Report(t testing.TB) func() {
+	pc, _, _, ok := runtime.Caller(1)
+	if !ok {
+		t.Fatal("Can't get caller info")
+	}
+	return func() {
+		fn := runtime.FuncForPC(pc)
+		fullName := fn.Name()
+		name := strings.Split(fullName, ".")[1]
+		allCaseInfos.lock.Lock()
+		defer allCaseInfos.lock.Unlock()
+		allCaseInfos.Cases = append(allCaseInfos.Cases, &caseInfo{
+			Name:    name,
+			Passed:  !t.Failed(),
+			Skipped: t.Skipped(),
+		})
+	}
+}
+
+type caseInfo struct {
+	Name    string `json:"name"`
+	Passed  bool   `json:"passed"`
+	Skipped bool   `json:"skipped"`
+}
+
+type caseInfos struct {
+	lock  sync.Mutex
+	Cases []*caseInfo `json:"cases"`
+}
+
+var (
+	allCaseInfos = caseInfos{}
+)

--- a/tools/http2_interop/testsuite.go
+++ b/tools/http2_interop/testsuite.go
@@ -1,6 +1,7 @@
 package http2interop
 
 import (
+	"path"
 	"runtime"
 	"strings"
 	"sync"
@@ -9,29 +10,40 @@ import (
 
 // When a test is skipped or fails, runtime.Goexit() is called which destroys the callstack.
 // This means the name of the test case is lost, so we need to grab a copy of pc before.
-func Report(t testing.TB) func() {
-	pc, _, _, ok := runtime.Caller(1)
-	if !ok {
-		t.Fatal("Can't get caller info")
-	}
-	return func() {
+func Report(t testing.TB) {
+	// If the goroutine panics, Fatal()s, or Skip()s, the function name is at the 3rd callstack
+	// layer.  On success, its at 1st.  Since it's hard to check which happened, just try both.
+	pcs := make([]uintptr, 10)
+	total := runtime.Callers(1, pcs)
+	var name string
+	for _, pc := range pcs[:total] {
 		fn := runtime.FuncForPC(pc)
 		fullName := fn.Name()
-		name := strings.Split(fullName, ".")[1]
-		allCaseInfos.lock.Lock()
-		defer allCaseInfos.lock.Unlock()
-		allCaseInfos.Cases = append(allCaseInfos.Cases, &caseInfo{
-			Name:    name,
-			Passed:  !t.Failed(),
-			Skipped: t.Skipped(),
-		})
+		if strings.HasPrefix(path.Ext(fullName), ".Test") {
+			// Skip the leading .
+			name = string([]byte(path.Ext(fullName))[1:])
+			break
+		}
 	}
+	if name == "" {
+		return
+	}
+
+	allCaseInfos.lock.Lock()
+	defer allCaseInfos.lock.Unlock()
+	allCaseInfos.Cases = append(allCaseInfos.Cases, &caseInfo{
+		Name:    name,
+		Passed:  !t.Failed() && !t.Skipped(),
+		Skipped: t.Skipped(),
+		Fatal:   t.Failed() && !strings.HasPrefix(name, "TestSoon"),
+	})
 }
 
 type caseInfo struct {
 	Name    string `json:"name"`
 	Passed  bool   `json:"passed"`
-	Skipped bool   `json:"skipped"`
+	Skipped bool   `json:"skipped,omitempty"`
+	Fatal   bool   `json:"fatal,omitempty"`
 }
 
 type caseInfos struct {

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -661,9 +661,6 @@ try:
           
     if args.http2_interop:
       for test_case in _HTTP2_TEST_CASES:
-        if server_name == "go":
-          # TODO(carl-mastrangelo): Reenable after https://github.com/grpc/grpc-go/issues/434
-          continue 
         test_job = cloud_to_cloud_jobspec(http2Interop,
                                           test_case,
                                           server_name,


### PR DESCRIPTION
This change makes http2 interop tests always pass.  In a subsequent PR, I will be updating the report generation to output a percent success bar, to show how compliant servers are.  This nicely solves the cloud to prod tests, the Go tests, and any other tests added for servers that are not yet compliant.

