### PR TITLE
Fixup nuget packages

### DIFF
--- a/vsprojects/coapp/openssl/managed_targets/grpc.dependencies.openssl.redist.targets
+++ b/vsprojects/coapp/openssl/managed_targets/grpc.dependencies.openssl.redist.targets
@@ -29,8 +29,8 @@
   </PropertyGroup>
   <Choose>
     <!-- Under older versions of Monodevelop, Choose is not supported and is just ignored, which gives us the desired effect. -->
-    <When Condition=" '$(OS)' != 'Unix' ">
-      <ItemGroup Condition=" '$(CopyNativeDependencies)' == 'true' ">
+    <When Condition=" '$(CopyNativeDependencies)' == 'true' ">
+      <ItemGroup>
         <Content Include="$(MSBuildThisFileDirectory)..\..\build\native\bin\$(NativeDependenciesToolset)\$(NativeDependenciesPlatform)\$(NativeDependenciesConfiguration)\dynamic\libeay32.dll">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>

--- a/vsprojects/nuget_package/grpc.native.csharp.targets
+++ b/vsprojects/nuget_package/grpc.native.csharp.targets
@@ -29,8 +29,8 @@
   </PropertyGroup>
   <Choose>
     <!-- Under older versions of Monodevelop, Choose is not supported and is just ignored, which gives us the desired effect. -->
-    <When Condition=" '$(OS)' != 'Unix' ">
-      <ItemGroup Condition=" '$(CopyNativeDependencies)' == 'true' ">
+    <When Condition=" '$(CopyNativeDependencies)' == 'true' ">
+      <ItemGroup>
         <Content Include="$(MSBuildThisFileDirectory)..\..\build\native\bin\$(NativeDependenciesToolset)\$(NativeDependenciesPlatform)\$(NativeDependenciesConfiguration)\grpc_csharp_ext.dll">
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>


### PR DESCRIPTION
A few changes that I forgot to add in #4236, but that actually got uploaded with the new openssl and zlib nuget packages. 
The change unifies the layout of .targets files with change I did to zlib package previously.