### PR TITLE
Use a custom NSMutableDictionary subclass for request headers

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -231,3 +231,20 @@ extern id const kGRPCTrailersKey;
 
 // TODO(jcanizales): Let specify a deadline. As a category of GRXWriter?
 @end
+
+#pragma mark Backwards compatibiity
+
+/** This protocol is kept for backwards compatibility with existing code. */
+@protocol GRPCRequestHeaders <NSObject>
+@property(nonatomic, readonly) NSUInteger count;
+
+- (id)objectForKeyedSubscript:(NSString *)key;
+- (void)setObject:(id)obj forKeyedSubscript:(NSString *)key;
+
+- (void)removeAllObjects;
+- (void)removeObjectForKey:(NSString *)key;
+@end
+
+/** This is only needed for backwards-compatibility. */
+@interface NSMutableDictionary (GRPCRequestHeaders) <GRPCRequestHeaders>
+@end

--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -50,6 +50,8 @@
 #import <Foundation/Foundation.h>
 #import <RxLibrary/GRXWriter.h>
 
+#include <AvailabilityMacros.h>
+
 #pragma mark gRPC errors
 
 /** Domain of NSError objects produced by gRPC. */
@@ -235,6 +237,7 @@ extern id const kGRPCTrailersKey;
 #pragma mark Backwards compatibiity
 
 /** This protocol is kept for backwards compatibility with existing code. */
+DEPRECATED_MSG_ATTRIBUTE("Use NSDictionary or NSMutableDictionary instead.")
 @protocol GRPCRequestHeaders <NSObject>
 @property(nonatomic, readonly) NSUInteger count;
 
@@ -245,6 +248,9 @@ extern id const kGRPCTrailersKey;
 - (void)removeObjectForKey:(NSString *)key;
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated"
 /** This is only needed for backwards-compatibility. */
 @interface NSMutableDictionary (GRPCRequestHeaders) <GRPCRequestHeaders>
 @end
+#pragma clang diagnostic pop

--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -161,6 +161,9 @@ extern id const kGRPCTrailersKey;
 
 #pragma mark GRPCCall
 
+/** Represents a single gRPC remote call. */
+@interface GRPCCall : GRXWriter
+
 /**
  * The container of the request headers of an RPC conforms to this protocol, which is a subset of
  * NSMutableDictionary's interface. It will become a NSMutableDictionary later on.
@@ -170,21 +173,6 @@ extern id const kGRPCTrailersKey;
  * A header value is a NSString object (with only ASCII characters), unless the header name has the
  * suffix "-bin", in which case the value has to be a NSData object.
  */
-@protocol GRPCRequestHeaders <NSObject>
-
-@property(nonatomic, readonly) NSUInteger count;
-
-- (id)objectForKeyedSubscript:(NSString *)key;
-- (void)setObject:(id)obj forKeyedSubscript:(NSString *)key;
-
-- (void)removeAllObjects;
-- (void)removeObjectForKey:(NSString *)key;
-
-@end
-
-/** Represents a single gRPC remote call. */
-@interface GRPCCall : GRXWriter
-
 /**
  * These HTTP headers will be passed to the server as part of this call. Each HTTP header is a
  * name-value pair with string names and either string or binary values.
@@ -200,7 +188,7 @@ extern id const kGRPCTrailersKey;
  *
  * The property is initialized to an empty NSMutableDictionary.
  */
-@property(atomic, readonly) id<GRPCRequestHeaders> requestHeaders;
+@property(atomic, readonly) NSMutableDictionary *requestHeaders;
 
 /**
  * This dictionary is populated with the HTTP headers received from the server. This happens before

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -221,7 +221,7 @@ NSString * const kGRPCTrailersKey = @"io.grpc.TrailersKey";
 
 #pragma mark Send headers
 
-- (void)sendHeaders:(id<GRPCRequestHeaders>)headers {
+- (void)sendHeaders:(NSDictionary *)headers {
   // TODO(jcanizales): Add error handlers for async failures
   [_wrappedCall startBatchWithOperations:@[[[GRPCOpSendMetadata alloc] initWithMetadata:headers
                                                                                 handler:nil]]];

--- a/src/objective-c/GRPCClient/private/GRPCRequestHeaders.h
+++ b/src/objective-c/GRPCClient/private/GRPCRequestHeaders.h
@@ -32,21 +32,14 @@
  */
 
 #import <Foundation/Foundation.h>
-#include <grpc/grpc.h>
 
 #import "../GRPCCall.h"
 
-@interface GRPCRequestHeaders : NSObject<GRPCRequestHeaders>
-
-@property(nonatomic, readonly) NSUInteger count;
-@property(nonatomic, readonly) grpc_metadata *grpc_metadataArray;
+@interface GRPCRequestHeaders : NSMutableDictionary
 
 - (instancetype)initWithCall:(GRPCCall *)call;
 
-- (id)objectForKeyedSubscript:(NSString *)key;
-- (void)setObject:(id)obj forKeyedSubscript:(NSString *)key;
-
-- (void)removeAllObjects;
-- (void)removeObjectForKey:(NSString *)key;
+- (instancetype)initWithCall:(GRPCCall *)call
+                     storage:(NSMutableDictionary *)storage NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
@@ -45,7 +45,7 @@
 
 @interface GRPCOpSendMetadata : GRPCOperation
 
-- (instancetype)initWithMetadata:(GRPCRequestHeaders *)metadata
+- (instancetype)initWithMetadata:(NSDictionary *)metadata
                          handler:(void(^)())handler NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
@@ -65,7 +65,7 @@
   return [self initWithMetadata:nil handler:nil];
 }
 
-- (instancetype)initWithMetadata:(GRPCRequestHeaders *)metadata handler:(void (^)())handler {
+- (instancetype)initWithMetadata:(NSDictionary *)metadata handler:(void (^)())handler {
   if (self = [super init]) {
     _op.op = GRPC_OP_SEND_INITIAL_METADATA;
     _op.data.send_initial_metadata.count = metadata.count;


### PR DESCRIPTION
This is needed for the pull requests that ease integration with auth libraries (Issue #2089). I want it in 0.12 because it's a deprecation; even if it's not a breaking change, the sooner people get the warning the better.