### PR TITLE
make explicit type conversion to avoid build break on gcc 5.2.1

### DIFF
--- a/src/core/transport/chttp2/timeout_encoding.c
+++ b/src/core/transport/chttp2/timeout_encoding.c
@@ -159,22 +159,22 @@ int grpc_chttp2_decode_timeout(const char *buffer, gpr_timespec *timeout) {
   /* decode unit specifier */
   switch (*p) {
     case 'n':
-      *timeout = gpr_time_from_nanos(x, GPR_TIMESPAN);
+      *timeout = gpr_time_from_nanos((long)x, GPR_TIMESPAN);
       break;
     case 'u':
-      *timeout = gpr_time_from_micros(x, GPR_TIMESPAN);
+      *timeout = gpr_time_from_micros((long)x, GPR_TIMESPAN);
       break;
     case 'm':
-      *timeout = gpr_time_from_millis(x, GPR_TIMESPAN);
+      *timeout = gpr_time_from_millis((long)x, GPR_TIMESPAN);
       break;
     case 'S':
-      *timeout = gpr_time_from_seconds(x, GPR_TIMESPAN);
+      *timeout = gpr_time_from_seconds((long)x, GPR_TIMESPAN);
       break;
     case 'M':
-      *timeout = gpr_time_from_minutes(x, GPR_TIMESPAN);
+      *timeout = gpr_time_from_minutes((long)x, GPR_TIMESPAN);
       break;
     case 'H':
-      *timeout = gpr_time_from_hours(x, GPR_TIMESPAN);
+      *timeout = gpr_time_from_hours((long)x, GPR_TIMESPAN);
       break;
     default:
       return 0;


### PR DESCRIPTION
My environment:
  Ubuntu 15.10
  gcc 5.2.1

Run 'make' and then got an error:
[C]       Compiling src/core/transport/chttp2/timeout_encoding.c
src/core/transport/chttp2/timeout_encoding.c: In function `grpc_chttp2_decode_timeout':
src/core/transport/chttp2/timeout_encoding.c:162:38: error: conversion to `long int' from `gpr_uint32 {aka unsigned int}' may change the sign of the result [-Werror=sign-conversion]
       *timeout = gpr_time_from_nanos(x, GPR_TIMESPAN);
                                      ^
I don't know why others can build successfully...