### PR TITLE
Fix interop Python test invocation

### DIFF
--- a/src/python/grpcio/tests/_loader.py
+++ b/src/python/grpcio/tests/_loader.py
@@ -34,14 +34,6 @@ import unittest
 
 import coverage
 
-# Some global spooky-action-at-a-distance hackery to get around
-# system-installation issues where the google namespace is defaulted to the
-# system even though the egg is higher priority on sys.path. This inverts the
-# path priority on package module paths thus giving any installed eggs higher
-# priority and having little effect otherwise.
-import google
-google.__path__.reverse()
-
 TEST_MODULE_REGEX = r'^.*_test$'
 
 

--- a/src/python/grpcio/tox.ini
+++ b/src/python/grpcio/tox.ini
@@ -15,8 +15,5 @@ commands =
     coverage html --include='grpc/*' --omit='grpc/framework/alpha/*','grpc/early_adopter/*','grpc/framework/base/*','grpc/framework/face/*','grpc/_adapter/fore.py','grpc/_adapter/rear.py'
     coverage report --include='grpc/*' --omit='grpc/framework/alpha/*','grpc/early_adopter/*','grpc/framework/base/*','grpc/framework/face/*','grpc/_adapter/fore.py','grpc/_adapter/rear.py'
 deps =
-    cython
-    coverage
-    oauth2client
-    protobuf
+    -rrequirements.txt
 passenv = *

--- a/tools/jenkins/grpc_interop_python/Dockerfile
+++ b/tools/jenkins/grpc_interop_python/Dockerfile
@@ -75,6 +75,7 @@ RUN ln -s /usr/bin/ccache /usr/local/bin/clang++
 # Install Python requisites
 RUN /bin/bash -l -c "pip install --upgrade pip"
 RUN /bin/bash -l -c "pip install virtualenv"
+RUN /bin/bash -l -c "pip install tox"
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/run_tests/build_python.sh
+++ b/tools/run_tests/build_python.sh
@@ -45,3 +45,5 @@ export GRPC_PYTHON_ENABLE_CYTHON_TRACING=1
 
 cd $GRPCIO
 tox --notest
+
+$GRPCIO/.tox/py27/bin/python $GRPCIO/setup.py build

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -267,7 +267,7 @@ class PythonLanguage:
 
   def client_cmd(self, args):
     return [
-        'python2.7_virtual_environment/bin/python',
+        'src/python/grpcio/.tox/py27/bin/python',
         'src/python/grpcio/setup.py',
         'run_interop',
         '--client',
@@ -279,7 +279,7 @@ class PythonLanguage:
 
   def server_cmd(self, args):
     return [
-        'python2.7_virtual_environment/bin/python',
+        'src/python/grpcio/.tox/py27/bin/python',
         'src/python/grpcio/setup.py',
         'run_interop',
         '--server',


### PR DESCRIPTION
Fixes #4317.

Fixes a fix that was missing a fix in said fix. The ideal fix would fix a `tox` command fixating on the interop server and client.

tl;dr: I'm a moose.

cc @nathanielmanistaatgoogle
cc @jcanizales 