### PR TITLE
Add a case to cover multiple adds of generic service

### DIFF
--- a/test/cpp/end2end/generic_end2end_test.cc
+++ b/test/cpp/end2end/generic_end2end_test.cc
@@ -102,6 +102,10 @@ class GenericEnd2endTest : public ::testing::Test {
     builder.AddListeningPort(server_address_.str(),
                              InsecureServerCredentials());
     builder.RegisterAsyncGenericService(&generic_service_);
+    // Include a second call to RegisterAsyncGenericService to make sure that
+    // we get an error in the log, since it is not allowed to have 2 async
+    // generic services
+    builder.RegisterAsyncGenericService(&generic_service_);
     srv_cq_ = builder.AddCompletionQueue();
     server_ = builder.BuildAndStart();
   }


### PR DESCRIPTION
This will add an error in the log and cover a few lines in server_builder.cc