### PR TITLE
Try to prevent PHP interop flake

### DIFF
--- a/tools/jenkins/grpc_interop_php/Dockerfile
+++ b/tools/jenkins/grpc_interop_php/Dockerfile
@@ -100,5 +100,19 @@ RUN /bin/bash -l -c "rvm all do gem install ronn rake"
 RUN curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer
 
+# Download the patched PHP protobuf so that PHP gRPC clients can be generated
+# from proto3 schemas.
+RUN git clone https://github.com/stanley-cheung/Protobuf-PHP.git /var/local/git/protobuf-php
+
+RUN /bin/bash -l -c "rvm use ruby-2.1 \
+  && cd /var/local/git/protobuf-php \
+  && rvm all do rake pear:package version=1.0 \
+  && pear install Protobuf-1.0.tgz"
+
+# As an attempt to work around #4212, try to prefetch Protobuf-PHP dependency
+# into composer cache to prevent "composer install" from cloning on each build.
+RUN git clone --mirror https://github.com/stanley-cheung/Protobuf-PHP.git \
+  /root/.composer/cache/vcs/git-github.com-stanley-cheung-Protobuf-PHP.git/
+
 # Define the default command.
 CMD ["bash"]

--- a/tools/jenkins/grpc_interop_php/build_interop.sh
+++ b/tools/jenkins/grpc_interop_php/build_interop.sh
@@ -29,7 +29,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 # Builds PHP interop server and client in a base image.
-set -e
+set -ex
 
 mkdir -p /var/local/git
 git clone --recursive /var/local/jenkins/grpc /var/local/git/grpc
@@ -45,17 +45,9 @@ make install-certs
 # gRPC core and protobuf need to be installed
 make install
 
-# Download the patched PHP protobuf so that PHP gRPC clients can be generated
-# from proto3 schemas.
-git clone https://github.com/stanley-cheung/Protobuf-PHP.git /var/local/git/protobuf-php
-
 (cd src/php/ext/grpc && phpize && ./configure && make)
 
 (cd third_party/protobuf && make install)
-
-(cd /var/local/git/protobuf-php \
-  && rvm all do rake pear:package version=1.0 \
-  && pear install Protobuf-1.0.tgz)
 
 (cd src/php && composer install)
 


### PR DESCRIPTION
Attempt to fix #4212.

Even if it turns out not helping the issue, it should at least speed up building the PHP docker image by caching actions that don't need to be re-run on each build.