### PR TITLE
Improving local test coverage with options.

### DIFF
--- a/tools/run_tests/run_lcov.sh
+++ b/tools/run_tests/run_lcov.sh
@@ -33,9 +33,10 @@ set -ex
 out=$(readlink -f ${1:-coverage})
 
 root=$(readlink -f $(dirname $0)/../..)
+shift
 tmp=$(mktemp)
 cd $root
-tools/run_tests/run_tests.py -c gcov -l c c++ || true
+tools/run_tests/run_tests.py -c gcov -l c c++ $@ || true
 lcov --capture --directory . --output-file $tmp
 genhtml $tmp --output-directory $out
 rm $tmp


### PR DESCRIPTION
So one can do

`./tools/run_tests/run_lcov.sh coverage -rjson`

for instance.