### PR TITLE
Install instructions are not correct

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,6 @@
 [submodule "third_party/protobuf"]
 	path = third_party/protobuf
 	url = https://github.com/google/protobuf.git
-	branch = v3.0.0-alpha-4.1
 [submodule "third_party/gflags"]
 	path = third_party/gflags
 	url = https://github.com/gflags/gflags.git

--- a/INSTALL
+++ b/INSTALL
@@ -26,7 +26,7 @@ OR
 
  $ git clone https://github.com/grpc/grpc.git
  $ cd grpc
- $ git submodule update --init
+ $ git submodule update --init --recursive
  $ make 
  $ [sudo] make install
 


### PR DESCRIPTION
Currently `INSTALL` does not tell to recursively update all submodules, so you'd fail on to compile the library with the following error:

```
We couldn't find protoc 3.0.0+ installed on your system. While this
won't prevent grpc from working, you won't be able to compile
and run any meaningful code with it.

Please download and install protobuf 3.0.0+ from:

   https://github.com/google/protobuf/releases

Once you've done so, or if you think this message is in error,
you can re-run this check by doing:

   make verify-install
```

This trivial patch fixes the install instructions.