### PR TITLE
run_lcov.sh fix

### DIFF
--- a/tools/run_tests/run_lcov.sh
+++ b/tools/run_tests/run_lcov.sh
@@ -33,7 +33,7 @@ set -ex
 out=$(readlink -f ${1:-coverage})
 
 root=$(readlink -f $(dirname $0)/../..)
-shift
+shift || true
 tmp=$(mktemp)
 cd $root
 tools/run_tests/run_tests.py -c gcov -l c c++ $@ || true


### PR DESCRIPTION
So that it can be invoked with no arguments