### PR TITLE
PHP: make ChannelCredentials::createInsecure explicit

### DIFF
--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -154,16 +154,20 @@ PHP_METHOD(Channel, __construct) {
     array_hash = Z_ARRVAL_P(args_array);
     if (zend_hash_find(array_hash, "credentials", sizeof("credentials"),
                        (void **)&creds_obj) == SUCCESS) {
-      if (zend_get_class_entry(*creds_obj TSRMLS_CC) !=
+      if (Z_TYPE_P(*creds_obj) == IS_NULL) {
+        creds = NULL;
+        zend_hash_del(array_hash, "credentials", 12);
+      } else if (zend_get_class_entry(*creds_obj TSRMLS_CC) !=
           grpc_ce_channel_credentials) {
         zend_throw_exception(spl_ce_InvalidArgumentException,
                              "credentials must be a ChannelCredentials object",
                              1 TSRMLS_CC);
         return;
+      } else {
+        creds = (wrapped_grpc_channel_credentials *)zend_object_store_get_object(
+            *creds_obj TSRMLS_CC);
+        zend_hash_del(array_hash, "credentials", 12);
       }
-      creds = (wrapped_grpc_channel_credentials *)zend_object_store_get_object(
-          *creds_obj TSRMLS_CC);
-      zend_hash_del(array_hash, "credentials", 12);
     }
     php_grpc_read_args_array(args_array, &args);
     if (creds == NULL) {

--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -169,12 +169,22 @@ PHP_METHOD(ChannelCredentials, createComposite) {
   RETURN_DESTROY_ZVAL(creds_object);
 }
 
+/**
+ * Create insecure channel credentials
+ * @return null
+ */
+PHP_METHOD(ChannelCredentials, createInsecure) {
+  RETURN_NULL();
+}
+
 static zend_function_entry channel_credentials_methods[] = {
   PHP_ME(ChannelCredentials, createDefault, NULL,
          ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
   PHP_ME(ChannelCredentials, createSsl, NULL,
          ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
   PHP_ME(ChannelCredentials, createComposite, NULL,
+         ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
+  PHP_ME(ChannelCredentials, createInsecure, NULL,
          ZEND_ACC_PUBLIC | ZEND_ACC_STATIC)
   PHP_FE_END};
 

--- a/src/php/ext/grpc/package.xml
+++ b/src/php/ext/grpc/package.xml
@@ -10,8 +10,8 @@
   <email>grpc-packages@google.com</email>
   <active>yes</active>
  </lead>
- <date>2015-12-15</date>
- <time>13:49:29</time>
+ <date>2015-12-16</date>
+ <time>12:56:11</time>
  <version>
   <release>0.7.0</release>
   <api>0.7.0</api>
@@ -25,6 +25,7 @@
 - Breaking change to Credentials class (removed) #3765
 - Replaced by ChannelCredentials and CallCredentials class #3765
 - New plugin based metadata auth API #4394
+- Explicit ChannelCredentials::createInsecure() call
  </notes>
  <contents>
   <dir baseinstalldir="/" name="/">
@@ -34,9 +35,9 @@
    <file baseinstalldir="/" md5sum="44c56bd9912d2538cbd6059e3e0452b6" name="call.h" role="src" />
    <file baseinstalldir="/" md5sum="ff90f6c03ed44b5f4170bf3259a6704e" name="call_credentials.c" role="src" />
    <file baseinstalldir="/" md5sum="3c3860e1d84f43cb6b2fbaa8d2ae1ab7" name="call_credentials.h" role="src" />
-   <file baseinstalldir="/" md5sum="00b44de389fbafa68afe8173045940af" name="channel.c" role="src" />
+   <file baseinstalldir="/" md5sum="aee9b63f790522aec2c682055240cc61" name="channel.c" role="src" />
    <file baseinstalldir="/" md5sum="ed4b00c0cf3702b115d0cfa87450dc09" name="channel.h" role="src" />
-   <file baseinstalldir="/" md5sum="d6e32503492b22bca1baf119d6c5e373" name="channel_credentials.c" role="src" />
+   <file baseinstalldir="/" md5sum="1a51c76d0b7b7d3ab570ed7d60c2ea46" name="channel_credentials.c" role="src" />
    <file baseinstalldir="/" md5sum="a86250e03f610ce6c2c7595a84e08821" name="channel_credentials.h" role="src" />
    <file baseinstalldir="/" md5sum="55ab7a42f9dd9bfc7e28a61cfc5fca63" name="completion_queue.c" role="src" />
    <file baseinstalldir="/" md5sum="f10b5bb232d74a6878e829e2e76cdaa2" name="completion_queue.h" role="src" />
@@ -141,12 +142,13 @@ Update to wrap gRPC C Core version 0.10.0
     <release>beta</release>
     <api>beta</api>
    </stability>
-   <date>2015-12-15</date>
+   <date>2015-12-16</date>
    <license>BSD</license>
    <notes>
 - Breaking change to Credentials class (removed) #3765
 - Replaced by ChannelCredentials and CallCredentials class #3765
 - New plugin based metadata auth API #4394
+- Explicit ChannelCredentials::createInsecure() call
    </notes>
   </release>
  </changelog>

--- a/src/php/lib/Grpc/AbstractCall.php
+++ b/src/php/lib/Grpc/AbstractCall.php
@@ -114,4 +114,15 @@ abstract class AbstractCall
 
         return call_user_func($this->deserialize, $value);
     }
+
+    /**
+     * Set the CallCredentials for the underlying Call.
+     *
+     * @param CallCredentials $call_credentials The CallCredentials
+     *                                          object
+     */
+    public function setCallCredentials($call_credentials)
+    {
+        $this->call->setCredentials($call_credentials);
+    }
 }

--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -72,6 +72,11 @@ class BaseStub
         }
         $opts['grpc.primary_user_agent'] .=
             'grpc-php/'.$package_config['version'];
+        if (!array_key_exists('credentials', $opts)) {
+            throw new \Exception("The opts['credentials'] key is now ".
+                                 'required. Please see one of the '.
+                                 'ChannelCredentials::create methods');
+        }
         $this->channel = new Channel($hostname, $opts);
     }
 

--- a/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
+++ b/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
@@ -111,7 +111,9 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidMethodName()
     {
-        $invalid_client = new DummyInvalidClient('host', []);
+        $invalid_client = new DummyInvalidClient('host', [
+            'credentials' => Grpc\ChannelCredentials::createInsecure(),
+        ]);
         $div_arg = new math\DivArgs();
         $invalid_client->InvalidUnaryCall($div_arg);
     }

--- a/src/php/tests/generated_code/GeneratedCodeTest.php
+++ b/src/php/tests/generated_code/GeneratedCodeTest.php
@@ -38,10 +38,12 @@ class GeneratedCodeTest extends AbstractGeneratedCodeTest
     public function setUp()
     {
         self::$client = new math\MathClient(
-        getenv('GRPC_TEST_HOST'), []);
+            getenv('GRPC_TEST_HOST'), [
+                'credentials' => Grpc\ChannelCredentials::createInsecure(),
+            ]);
     }
 
-    public static function tearDownAfterClass()
+    public function tearDown()
     {
         self::$client->close();
     }

--- a/src/php/tests/generated_code/GeneratedCodeWithCallbackTest.php
+++ b/src/php/tests/generated_code/GeneratedCodeWithCallbackTest.php
@@ -39,7 +39,8 @@ class GeneratedCodeWithCallbackTest extends AbstractGeneratedCodeTest
     {
         self::$client = new math\MathClient(
         getenv('GRPC_TEST_HOST'),
-        ['update_metadata' => function ($a_hash,
+        ['credentials' => Grpc\ChannelCredentials::createInsecure(),
+         'update_metadata' => function ($a_hash,
                                         $client = []) {
                                 $a_copy = $a_hash;
                                 $a_copy['foo'] = ['bar'];
@@ -48,7 +49,7 @@ class GeneratedCodeWithCallbackTest extends AbstractGeneratedCodeTest
                               }]);
     }
 
-    public static function tearDownAfterClass()
+    public function tearDown()
     {
         self::$client->close();
     }

--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -438,6 +438,8 @@ if ($use_tls) {
     }
     $opts['credentials'] = $ssl_credentials;
     $opts['grpc.ssl_target_name_override'] = $host_override;
+} else {
+    $opts['credentials'] = Grpc\ChannelCredentials::createInsecure();
 }
 
 if (in_array($test_case, ['service_account_creds',


### PR DESCRIPTION
 * Make ```ChannelCredentials::createInsecure()``` explicit
 * Now ```$opts['credentials']``` is required to create a ```BaseStub```. So at least client needs to be created with ```$opts['credentials'] = Grpc\ChannelCredentials::createInsecure();```