### PR TITLE
Made insecure channel/stub explicit, in all layers

### DIFF
--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -50,9 +50,8 @@ module GRPC
         return alt_chan
       end
       kw['grpc.primary_user_agent'] = "grpc-ruby/#{VERSION}"
-      return Core::Channel.new(host, kw) if creds.nil?
-      unless creds.is_a?(Core::ChannelCredentials)
-        fail(TypeError, '!ChannelCredentials')
+      unless creds.is_a?(Core::ChannelCredentials) || creds.is_a?(Symbol)
+        fail(TypeError, '!ChannelCredentials or Symbol')
       end
       Core::Channel.new(host, kw, creds)
     end
@@ -68,7 +67,8 @@ module GRPC
     # Minimally, a stub is created with the just the host of the gRPC service
     # it wishes to access, e.g.,
     #
-    # my_stub = ClientStub.new(example.host.com:50505)
+    # my_stub = ClientStub.new(example.host.com:50505,
+    #                          :this_channel_is_insecure)
     #
     # Any arbitrary keyword arguments are treated as channel arguments used to
     # configure the RPC connection to the host.
@@ -86,14 +86,14 @@ module GRPC
     #
     # @param host [String] the host the stub connects to
     # @param q [Core::CompletionQueue] used to wait for events
+    # @param creds [Core::ChannelCredentials|Symbol] the channel credentials, or
+    #     :this_channel_is_insecure
     # @param channel_override [Core::Channel] a pre-created channel
     # @param timeout [Number] the default timeout to use in requests
-    # @param creds [Core::ChannelCredentials] the channel credentials
     # @param kw [KeywordArgs]the channel arguments
-    def initialize(host, q,
+    def initialize(host, q, creds,
                    channel_override: nil,
                    timeout: nil,
-                   creds: nil,
                    propagate_mask: nil,
                    **kw)
       fail(TypeError, '!CompletionQueue') unless q.is_a?(Core::CompletionQueue)

--- a/src/ruby/lib/grpc/generic/service.rb
+++ b/src/ruby/lib/grpc/generic/service.rb
@@ -160,10 +160,12 @@ module GRPC
         route_prefix = service_name
         Class.new(ClientStub) do
           # @param host [String] the host the stub connects to
+          # @param creds [Core::ChannelCredentials|Symbol] The channel
+          #     credentials to use, or :this_channel_is_insecure otherwise
           # @param kw [KeywordArgs] the channel arguments, plus any optional
           #                         args for configuring the client's channel
-          def initialize(host, **kw)
-            super(host, Core::CompletionQueue.new, **kw)
+          def initialize(host, creds, **kw)
+            super(host, Core::CompletionQueue.new, creds, **kw)
           end
 
           # Used define_method to add a method for each rpc_desc.  Each method

--- a/src/ruby/spec/call_spec.rb
+++ b/src/ruby/spec/call_spec.rb
@@ -101,7 +101,7 @@ describe GRPC::Core::Call do
   let(:fake_host) { 'localhost:10101' }
 
   before(:each) do
-    @ch = GRPC::Core::Channel.new(fake_host, nil)
+    @ch = GRPC::Core::Channel.new(fake_host, nil, :this_channel_is_insecure)
   end
 
   describe '#status' do

--- a/src/ruby/spec/channel_spec.rb
+++ b/src/ruby/spec/channel_spec.rb
@@ -45,7 +45,10 @@ describe GRPC::Core::Channel do
 
   shared_examples '#new' do
     it 'take a host name without channel args' do
-      expect { GRPC::Core::Channel.new('dummy_host', nil) }.not_to raise_error
+      blk = proc do
+        GRPC::Core::Channel.new('dummy_host', nil, :this_channel_is_insecure)
+      end
+      expect(&blk).not_to raise_error
     end
 
     it 'does not take a hash with bad keys as channel args' do
@@ -106,13 +109,15 @@ describe GRPC::Core::Channel do
     it_behaves_like '#new'
 
     def construct_with_args(a)
-      proc { GRPC::Core::Channel.new('dummy_host', a) }
+      proc do
+        GRPC::Core::Channel.new('dummy_host', a, :this_channel_is_insecure)
+      end
     end
   end
 
   describe '#create_call' do
     it 'creates a call OK' do
-      ch = GRPC::Core::Channel.new(fake_host, nil)
+      ch = GRPC::Core::Channel.new(fake_host, nil, :this_channel_is_insecure)
 
       deadline = Time.now + 5
 
@@ -123,7 +128,7 @@ describe GRPC::Core::Channel do
     end
 
     it 'raises an error if called on a closed channel' do
-      ch = GRPC::Core::Channel.new(fake_host, nil)
+      ch = GRPC::Core::Channel.new(fake_host, nil, :this_channel_is_insecure)
       ch.close
 
       deadline = Time.now + 5
@@ -136,13 +141,13 @@ describe GRPC::Core::Channel do
 
   describe '#destroy' do
     it 'destroys a channel ok' do
-      ch = GRPC::Core::Channel.new(fake_host, nil)
+      ch = GRPC::Core::Channel.new(fake_host, nil, :this_channel_is_insecure)
       blk = proc { ch.destroy }
       expect(&blk).to_not raise_error
     end
 
     it 'can be called more than once without error' do
-      ch = GRPC::Core::Channel.new(fake_host, nil)
+      ch = GRPC::Core::Channel.new(fake_host, nil, :this_channel_is_insecure)
       blk = proc { ch.destroy }
       blk.call
       expect(&blk).to_not raise_error
@@ -157,13 +162,13 @@ describe GRPC::Core::Channel do
 
   describe '#close' do
     it 'closes a channel ok' do
-      ch = GRPC::Core::Channel.new(fake_host, nil)
+      ch = GRPC::Core::Channel.new(fake_host, nil, :this_channel_is_insecure)
       blk = proc { ch.close }
       expect(&blk).to_not raise_error
     end
 
     it 'can be called more than once without error' do
-      ch = GRPC::Core::Channel.new(fake_host, nil)
+      ch = GRPC::Core::Channel.new(fake_host, nil, :this_channel_is_insecure)
       blk = proc { ch.close }
       blk.call
       expect(&blk).to_not raise_error

--- a/src/ruby/spec/client_server_spec.rb
+++ b/src/ruby/spec/client_server_spec.rb
@@ -397,7 +397,7 @@ describe 'the http client/server' do
     @server = GRPC::Core::Server.new(@server_queue, nil)
     server_port = @server.add_http2_port(server_host, :this_port_is_insecure)
     @server.start
-    @ch = Channel.new("0.0.0.0:#{server_port}", nil)
+    @ch = Channel.new("0.0.0.0:#{server_port}", nil, :this_channel_is_insecure)
   end
 
   after(:example) do

--- a/src/ruby/spec/generic/active_call_spec.rb
+++ b/src/ruby/spec/generic/active_call_spec.rb
@@ -48,7 +48,8 @@ describe GRPC::ActiveCall do
     @server = GRPC::Core::Server.new(@server_queue, nil)
     server_port = @server.add_http2_port(host, :this_port_is_insecure)
     @server.start
-    @ch = GRPC::Core::Channel.new("0.0.0.0:#{server_port}", nil)
+    @ch = GRPC::Core::Channel.new("0.0.0.0:#{server_port}", nil,
+                                  :this_channel_is_insecure)
   end
 
   after(:each) do

--- a/src/ruby/spec/generic/rpc_server_spec.rb
+++ b/src/ruby/spec/generic/rpc_server_spec.rb
@@ -141,7 +141,7 @@ describe GRPC::RpcServer do
     @server = GRPC::Core::Server.new(@server_queue, nil)
     server_port = @server.add_http2_port(server_host, :this_port_is_insecure)
     @host = "localhost:#{server_port}"
-    @ch = GRPC::Core::Channel.new(@host, nil)
+    @ch = GRPC::Core::Channel.new(@host, nil, :this_channel_is_insecure)
   end
 
   describe '#new' do
@@ -355,7 +355,8 @@ describe GRPC::RpcServer do
         req = EchoMsg.new
         blk = proc do
           cq = GRPC::Core::CompletionQueue.new
-          stub = GRPC::ClientStub.new(@host, cq, **client_opts)
+          stub = GRPC::ClientStub.new(@host, cq, :this_channel_is_insecure,
+                                      **client_opts)
           stub.request_response('/unknown', req, marshal, unmarshal)
         end
         expect(&blk).to raise_error GRPC::BadStatus
@@ -369,7 +370,7 @@ describe GRPC::RpcServer do
         @srv.wait_till_running
         req = EchoMsg.new
         n = 5  # arbitrary
-        stub = EchoStub.new(@host, **client_opts)
+        stub = EchoStub.new(@host, :this_channel_is_insecure, **client_opts)
         n.times { expect(stub.an_rpc(req)).to be_a(EchoMsg) }
         @srv.stop
         t.join
@@ -381,7 +382,7 @@ describe GRPC::RpcServer do
         t = Thread.new { @srv.run }
         @srv.wait_till_running
         req = EchoMsg.new
-        stub = EchoStub.new(@host, **client_opts)
+        stub = EchoStub.new(@host, :this_channel_is_insecure, **client_opts)
         expect(stub.an_rpc(req, k1: 'v1', k2: 'v2')).to be_a(EchoMsg)
         wanted_md = [{ 'k1' => 'v1', 'k2' => 'v2' }]
         check_md(wanted_md, service.received_md)
@@ -395,7 +396,7 @@ describe GRPC::RpcServer do
         t = Thread.new { @srv.run }
         @srv.wait_till_running
         req = EchoMsg.new
-        stub = SlowStub.new(@host, **client_opts)
+        stub = SlowStub.new(@host, :this_channel_is_insecure, **client_opts)
         timeout = service.delay + 1.0 # wait for long enough
         resp = stub.an_rpc(req, timeout: timeout, k1: 'v1', k2: 'v2')
         expect(resp).to be_a(EchoMsg)
@@ -411,7 +412,7 @@ describe GRPC::RpcServer do
         t = Thread.new { @srv.run }
         @srv.wait_till_running
         req = EchoMsg.new
-        stub = SlowStub.new(@host, **client_opts)
+        stub = SlowStub.new(@host, :this_channel_is_insecure, **client_opts)
         op = stub.an_rpc(req, k1: 'v1', k2: 'v2', return_op: true)
         Thread.new do  # cancel the call
           sleep 0.1
@@ -431,7 +432,7 @@ describe GRPC::RpcServer do
         threads = [t]
         n.times do
           threads << Thread.new do
-            stub = EchoStub.new(@host, **client_opts)
+            stub = EchoStub.new(@host, :this_channel_is_insecure, **client_opts)
             q << stub.an_rpc(req)
           end
         end
@@ -459,7 +460,7 @@ describe GRPC::RpcServer do
         one_failed_as_unavailable = false
         n.times do
           threads << Thread.new do
-            stub = SlowStub.new(@host, **client_opts)
+            stub = SlowStub.new(@host, :this_channel_is_insecure, **client_opts)
             begin
               stub.an_rpc(req)
             rescue GRPC::BadStatus => e
@@ -499,7 +500,7 @@ describe GRPC::RpcServer do
         t = Thread.new { @srv.run }
         @srv.wait_till_running
         req = EchoMsg.new
-        stub = EchoStub.new(@host, **client_opts)
+        stub = EchoStub.new(@host, :this_channel_is_insecure, **client_opts)
         op = stub.an_rpc(req, k1: 'v1', k2: 'v2', return_op: true)
         expect(op.metadata).to be nil
         expect(op.execute).to be_a(EchoMsg)
@@ -537,7 +538,7 @@ describe GRPC::RpcServer do
         t = Thread.new { @srv.run }
         @srv.wait_till_running
         req = EchoMsg.new
-        stub = FailingStub.new(@host, **client_opts)
+        stub = FailingStub.new(@host, :this_channel_is_insecure, **client_opts)
         blk = proc { stub.an_rpc(req) }
 
         # confirm it raise the expected error
@@ -562,7 +563,7 @@ describe GRPC::RpcServer do
         t = Thread.new { @srv.run }
         @srv.wait_till_running
         req = EchoMsg.new
-        stub = EchoStub.new(@host, **client_opts)
+        stub = EchoStub.new(@host, :this_channel_is_insecure, **client_opts)
         op = stub.an_rpc(req, k1: 'v1', k2: 'v2', return_op: true)
         expect(op.metadata).to be nil
         expect(op.execute).to be_a(EchoMsg)

--- a/src/ruby/spec/generic/service_spec.rb
+++ b/src/ruby/spec/generic/service_spec.rb
@@ -241,7 +241,7 @@ describe GenericService do
     end
 
     describe 'the generated instances' do
-      it 'can be instanciated with just a hostname' do
+      it 'can be instanciated with just a hostname and credentials' do
         s = Class.new do
           include GenericService
           rpc :AnRpc, GoodMsg, GoodMsg
@@ -250,7 +250,10 @@ describe GenericService do
           rpc :ABidiStreamer, stream(GoodMsg), stream(GoodMsg)
         end
         client_class = s.rpc_stub_class
-        expect { client_class.new('fakehostname') }.not_to raise_error
+        blk = proc do
+          client_class.new('fakehostname', :this_channel_is_insecure)
+        end
+        expect(&blk).not_to raise_error
       end
 
       it 'has the methods defined in the service' do
@@ -262,7 +265,7 @@ describe GenericService do
           rpc :ABidiStreamer, stream(GoodMsg), stream(GoodMsg)
         end
         client_class = s.rpc_stub_class
-        o = client_class.new('fakehostname')
+        o = client_class.new('fakehostname', :this_channel_is_insecure)
         expect(o.methods).to include(:an_rpc)
         expect(o.methods).to include(:a_bidi_streamer)
         expect(o.methods).to include(:a_client_streamer)

--- a/src/ruby/spec/pb/health/checker_spec.rb
+++ b/src/ruby/spec/pb/health/checker_spec.rb
@@ -188,7 +188,7 @@ describe Grpc::Health::Checker do
       @server = GRPC::Core::Server.new(@server_queue, nil)
       server_port = @server.add_http2_port(server_host, :this_port_is_insecure)
       @host = "localhost:#{server_port}"
-      @ch = GRPC::Core::Channel.new(@host, nil)
+      @ch = GRPC::Core::Channel.new(@host, nil, :this_channel_is_insecure)
       @client_opts = { channel_override: @ch }
       server_opts = {
         server_override: @server,
@@ -208,7 +208,7 @@ describe Grpc::Health::Checker do
       t = Thread.new { @srv.run }
       @srv.wait_till_running
 
-      stub = CheckerStub.new(@host, **@client_opts)
+      stub = CheckerStub.new(@host, :this_channel_is_insecure, **@client_opts)
       got = stub.check(HCReq.new)
       want = HCResp.new(status: ServingStatus::NOT_SERVING)
       expect(got).to eq(want)
@@ -221,7 +221,7 @@ describe Grpc::Health::Checker do
       t = Thread.new { @srv.run }
       @srv.wait_till_running
       blk = proc do
-        stub = CheckerStub.new(@host, **@client_opts)
+        stub = CheckerStub.new(@host, :this_channel_is_insecure, **@client_opts)
         stub.check(HCReq.new(host: 'unknown', service: 'unknown'))
       end
       expected_msg = /#{StatusCodes::NOT_FOUND}/


### PR DESCRIPTION
This is an API breakage. A few constructors that previously took the credentials as an optional keyword argument now take it as a mandatory positional argument.