### PR TITLE
Prevent warnings on dictionaries w/o string keys

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -241,11 +241,11 @@ DEPRECATED_MSG_ATTRIBUTE("Use NSDictionary or NSMutableDictionary instead.")
 @protocol GRPCRequestHeaders <NSObject>
 @property(nonatomic, readonly) NSUInteger count;
 
-- (id)objectForKeyedSubscript:(NSString *)key;
-- (void)setObject:(id)obj forKeyedSubscript:(NSString *)key;
+- (id)objectForKeyedSubscript:(id)key;
+- (void)setObject:(id)obj forKeyedSubscript:(id)key;
 
 - (void)removeAllObjects;
-- (void)removeObjectForKey:(NSString *)key;
+- (void)removeObjectForKey:(id)key;
 @end
 
 #pragma clang diagnostic push


### PR DESCRIPTION
Because the category makes the protocol apply to all `NSMutableDictionaries`, it can't assume keys are `NSString`. Because these types are covariant, the change is not breaking.

Original author: @Scott84 