### PR TITLE
Fixing win x64 build with vs2015

### DIFF
--- a/src/core/security/credentials.c
+++ b/src/core/security/credentials.c
@@ -179,8 +179,8 @@ void grpc_server_credentials_set_auth_metadata_processor(
   GRPC_API_TRACE(
       "grpc_server_credentials_set_auth_metadata_processor("
       "creds=%p, "
-      "processor=grpc_auth_metadata_processor { process: %lx, state: %p })",
-      3, (creds, (unsigned long)processor.process, processor.state));
+      "processor=grpc_auth_metadata_processor { process: %p, state: %p })",
+      3, (creds, (void*)(gpr_intptr)processor.process, processor.state));
   if (creds == NULL) return;
   if (creds->processor.destroy != NULL && creds->processor.state != NULL) {
     creds->processor.destroy(creds->processor.state);

--- a/src/core/surface/init.c
+++ b/src/core/surface/init.c
@@ -82,8 +82,8 @@ static grpc_plugin g_all_of_the_plugins[MAX_PLUGINS];
 static int g_number_of_plugins = 0;
 
 void grpc_register_plugin(void (*init)(void), void (*destroy)(void)) {
-  GRPC_API_TRACE("grpc_register_plugin(init=%lx, destroy=%lx)", 2,
-                 ((unsigned long)init, (unsigned long)destroy));
+  GRPC_API_TRACE("grpc_register_plugin(init=%p, destroy=%p)", 2,
+      ((void*)(gpr_intptr)init, (void*)(gpr_intptr)destroy));
   GPR_ASSERT(g_number_of_plugins != MAX_PLUGINS);
   g_all_of_the_plugins[g_number_of_plugins].init = init;
   g_all_of_the_plugins[g_number_of_plugins].destroy = destroy;

--- a/test/core/support/alloc_test.c
+++ b/test/core/support/alloc_test.c
@@ -48,8 +48,8 @@ static void test_custom_allocs() {
   gpr_allocation_functions fns = {fake_malloc, fake_realloc, fake_free};
 
   gpr_set_allocation_functions(fns);
-  GPR_ASSERT((void *)0xdeadbeef == gpr_malloc(0xdeadbeef));
-  GPR_ASSERT((void *)0xcafed00d == gpr_realloc(0, 0xcafed00d));
+  GPR_ASSERT((void*)(size_t)0xdeadbeef == gpr_malloc(0xdeadbeef));
+  GPR_ASSERT((void*)(size_t)0xcafed00d == gpr_realloc(0, 0xcafed00d));
 
   gpr_free(&addr_to_free);
   GPR_ASSERT(addr_to_free == 0xdeadd00d);

--- a/test/core/transport/connectivity_state_test.c
+++ b/test/core/transport/connectivity_state_test.c
@@ -39,7 +39,7 @@
 
 #include "test/core/util/test_config.h"
 
-#define THE_ARG ((void *)0xcafebabe)
+#define THE_ARG ((void *)(size_t)0xcafebabe)
 
 int g_counter;
 


### PR DESCRIPTION
After this, x64 should build with vs2015.

Basically couple more fixes related to sizeof(long) == 4 on windows.

