### PR TITLE
Ignore warning LNK4217

### DIFF
--- a/templates/vsprojects/global.props.template
+++ b/templates/vsprojects/global.props.template
@@ -13,6 +13,10 @@
         <PreprocessorDefinitions>_WIN32_WINNT=0x600;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
         <WarningLevel>EnableAllWarnings</WarningLevel>
       </ClCompile>
+      <Link>
+        <!-- LNK4271 pollutes test output. See #4521 -->
+        <AdditionalOptions>/ignore:4217 %(AdditionalOptions)</AdditionalOptions>
+      </Link>
     </ItemDefinitionGroup>
     <ItemGroup />
   </Project>

--- a/vsprojects/global.props
+++ b/vsprojects/global.props
@@ -11,6 +11,10 @@
       <PreprocessorDefinitions>_WIN32_WINNT=0x600;_SCL_SECURE_NO_WARNINGS;_CRT_SECURE_NO_WARNINGS;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>EnableAllWarnings</WarningLevel>
     </ClCompile>
+    <Link>
+      <!-- LNK4271 pollutes test output. See #4521 -->
+      <AdditionalOptions>/ignore:4217 %(AdditionalOptions)</AdditionalOptions>
+    </Link>
   </ItemDefinitionGroup>
   <ItemGroup />
 </Project>


### PR DESCRIPTION
Fixes #4521. Eventually, we should re-enable the warning, but currently it does more harm than good.