### PR TITLE
Security connector fixes for 0.12 branch

### DIFF
--- a/src/core/client_config/connector.h
+++ b/src/core/client_config/connector.h
@@ -65,6 +65,9 @@ typedef struct {
   /** any additional filters (owned by the caller of connect) */
   const grpc_channel_filter **filters;
   size_t num_filters;
+
+  /** channel arguments (to be passed to the filters) */
+  const grpc_channel_args *channel_args;
 } grpc_connect_out_args;
 
 struct grpc_connector_vtable {

--- a/src/core/client_config/subchannel.c
+++ b/src/core/client_config/subchannel.c
@@ -493,7 +493,8 @@ static void publish_transport(grpc_exec_ctx *exec_ctx, grpc_subchannel *c) {
   con = gpr_malloc(channel_stack_size);
   stk = CHANNEL_STACK_FROM_CONNECTION(con);
   grpc_channel_stack_init(exec_ctx, 1, connection_destroy, con, filters,
-                          num_filters, c->args, "CONNECTED_SUBCHANNEL", stk);
+                          num_filters, c->connecting_result.channel_args,
+                          "CONNECTED_SUBCHANNEL", stk);
   grpc_connected_channel_bind_transport(stk, c->connecting_result.transport);
   gpr_free((void *)c->connecting_result.filters);
   memset(&c->connecting_result, 0, sizeof(c->connecting_result));

--- a/src/core/httpcli/httpcli_security_connector.c
+++ b/src/core/httpcli/httpcli_security_connector.c
@@ -68,7 +68,7 @@ static void httpcli_ssl_do_handshake(grpc_exec_ctx *exec_ctx,
   tsi_result result = TSI_OK;
   tsi_handshaker *handshaker;
   if (c->handshaker_factory == NULL) {
-    cb(exec_ctx, user_data, GRPC_SECURITY_ERROR, NULL);
+    cb(exec_ctx, user_data, GRPC_SECURITY_ERROR, NULL, NULL);
     return;
   }
   result = tsi_ssl_handshaker_factory_create_handshaker(
@@ -76,17 +76,17 @@ static void httpcli_ssl_do_handshake(grpc_exec_ctx *exec_ctx,
   if (result != TSI_OK) {
     gpr_log(GPR_ERROR, "Handshaker creation failed with error %s.",
             tsi_result_to_string(result));
-    cb(exec_ctx, user_data, GRPC_SECURITY_ERROR, NULL);
+    cb(exec_ctx, user_data, GRPC_SECURITY_ERROR, NULL, NULL);
   } else {
     grpc_do_security_handshake(exec_ctx, handshaker, sc, nonsecure_endpoint, cb,
                                user_data);
   }
 }
 
-static grpc_security_status httpcli_ssl_check_peer(grpc_security_connector *sc,
-                                                   tsi_peer peer,
-                                                   grpc_security_check_cb cb,
-                                                   void *user_data) {
+static void httpcli_ssl_check_peer(grpc_exec_ctx *exec_ctx,
+                                   grpc_security_connector *sc, tsi_peer peer,
+                                   grpc_security_peer_check_cb cb,
+                                   void *user_data) {
   grpc_httpcli_ssl_channel_security_connector *c =
       (grpc_httpcli_ssl_channel_security_connector *)sc;
   grpc_security_status status = GRPC_SECURITY_OK;
@@ -99,7 +99,7 @@ static grpc_security_status httpcli_ssl_check_peer(grpc_security_connector *sc,
     status = GRPC_SECURITY_ERROR;
   }
   tsi_peer_destruct(&peer);
-  return status;
+  cb(exec_ctx, user_data, status, NULL);
 }
 
 static grpc_security_connector_vtable httpcli_ssl_vtable = {
@@ -149,7 +149,8 @@ typedef struct {
 
 static void on_secure_transport_setup_done(grpc_exec_ctx *exec_ctx, void *rp,
                                            grpc_security_status status,
-                                           grpc_endpoint *secure_endpoint) {
+                                           grpc_endpoint *secure_endpoint,
+                                           grpc_auth_context *auth_context) {
   on_done_closure *c = rp;
   if (status != GRPC_SECURITY_OK) {
     gpr_log(GPR_ERROR, "Secure transport setup failed with error %d.", status);

--- a/src/core/httpcli/httpcli_security_connector.c
+++ b/src/core/httpcli/httpcli_security_connector.c
@@ -84,7 +84,8 @@ static void httpcli_ssl_do_handshake(grpc_exec_ctx *exec_ctx,
 }
 
 static void httpcli_ssl_check_peer(grpc_exec_ctx *exec_ctx,
-                                   grpc_security_connector *sc, tsi_peer peer,
+                                   grpc_security_connector *sc,
+                                   tsi_peer peer,
                                    grpc_security_peer_check_cb cb,
                                    void *user_data) {
   grpc_httpcli_ssl_channel_security_connector *c =
@@ -98,8 +99,8 @@ static void httpcli_ssl_check_peer(grpc_exec_ctx *exec_ctx,
             c->secure_peer_name);
     status = GRPC_SECURITY_ERROR;
   }
-  tsi_peer_destruct(&peer);
   cb(exec_ctx, user_data, status, NULL);
+  tsi_peer_destruct(&peer);
 }
 
 static grpc_security_connector_vtable httpcli_ssl_vtable = {

--- a/src/core/security/client_auth_filter.c
+++ b/src/core/security/client_auth_filter.c
@@ -250,27 +250,13 @@ static void auth_start_transport_op(grpc_exec_ctx *exec_ctx,
       }
     }
     if (calld->host != NULL) {
-      grpc_security_status status;
       const char *call_host = grpc_mdstr_as_c_string(calld->host);
       calld->op = *op; /* Copy op (originates from the caller's stack). */
-      status = grpc_channel_security_connector_check_call_host(
-          exec_ctx, chand->security_connector, call_host, on_host_checked,
-          elem);
-      if (status != GRPC_SECURITY_OK) {
-        if (status == GRPC_SECURITY_ERROR) {
-          char *error_msg;
-          gpr_asprintf(&error_msg,
-                       "Invalid host %s set in :authority metadata.",
-                       call_host);
-          bubble_up_error(exec_ctx, elem, GRPC_STATUS_INVALID_ARGUMENT,
-                          error_msg);
-          gpr_free(error_msg);
-        }
-        return; /* early exit */
-      }
+      grpc_channel_security_connector_check_call_host(
+          exec_ctx, chand->security_connector, call_host, chand->auth_context,
+          on_host_checked, elem);
+      return; /* early exit */
     }
-    send_security_metadata(exec_ctx, elem, op);
-    return; /* early exit */
   }
 
   /* pass control down the stack */

--- a/src/core/security/credentials.c
+++ b/src/core/security/credentials.c
@@ -881,7 +881,7 @@ static grpc_security_status fake_transport_security_create_security_connector(
     grpc_channel_credentials *c, grpc_call_credentials *call_creds,
     const char *target, const grpc_channel_args *args,
     grpc_channel_security_connector **sc, grpc_channel_args **new_args) {
-  *sc = grpc_fake_channel_security_connector_create(call_creds, 1);
+  *sc = grpc_fake_channel_security_connector_create(call_creds);
   return GRPC_SECURITY_OK;
 }
 

--- a/src/core/security/handshake.c
+++ b/src/core/security/handshake.c
@@ -35,6 +35,7 @@
 
 #include <string.h>
 
+#include "src/core/security/security_context.h"
 #include "src/core/security/secure_endpoint.h"
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
@@ -56,6 +57,7 @@ typedef struct {
   void *user_data;
   grpc_closure on_handshake_data_sent_to_peer;
   grpc_closure on_handshake_data_received_from_peer;
+  grpc_auth_context *auth_context;
 } grpc_security_handshake;
 
 static void on_handshake_data_received_from_peer(grpc_exec_ctx *exec_ctx,
@@ -96,7 +98,8 @@ static void security_handshake_done(grpc_exec_ctx *exec_ctx,
     security_connector_remove_handshake(h);
   }
   if (is_success) {
-    h->cb(exec_ctx, h->user_data, GRPC_SECURITY_OK, h->secure_endpoint);
+    h->cb(exec_ctx, h->user_data, GRPC_SECURITY_OK, h->secure_endpoint,
+          h->auth_context);
   } else {
     if (h->secure_endpoint != NULL) {
       grpc_endpoint_shutdown(exec_ctx, h->secure_endpoint);
@@ -104,19 +107,21 @@ static void security_handshake_done(grpc_exec_ctx *exec_ctx,
     } else {
       grpc_endpoint_destroy(exec_ctx, h->wrapped_endpoint);
     }
-    h->cb(exec_ctx, h->user_data, GRPC_SECURITY_ERROR, NULL);
+    h->cb(exec_ctx, h->user_data, GRPC_SECURITY_ERROR, NULL, NULL);
   }
   if (h->handshaker != NULL) tsi_handshaker_destroy(h->handshaker);
   if (h->handshake_buffer != NULL) gpr_free(h->handshake_buffer);
   gpr_slice_buffer_destroy(&h->left_overs);
   gpr_slice_buffer_destroy(&h->outgoing);
   gpr_slice_buffer_destroy(&h->incoming);
+  GRPC_AUTH_CONTEXT_UNREF(h->auth_context, "handshake");
   GRPC_SECURITY_CONNECTOR_UNREF(h->connector, "handshake");
   gpr_free(h);
 }
 
 static void on_peer_checked(grpc_exec_ctx *exec_ctx, void *user_data,
-                            grpc_security_status status) {
+                            grpc_security_status status,
+                            grpc_auth_context *auth_context) {
   grpc_security_handshake *h = user_data;
   tsi_frame_protector *protector;
   tsi_result result;
@@ -125,6 +130,7 @@ static void on_peer_checked(grpc_exec_ctx *exec_ctx, void *user_data,
     security_handshake_done(exec_ctx, h, 0);
     return;
   }
+  h->auth_context = GRPC_AUTH_CONTEXT_REF(auth_context, "handshake");
   result =
       tsi_handshaker_create_frame_protector(h->handshaker, NULL, &protector);
   if (result != TSI_OK) {
@@ -143,7 +149,6 @@ static void on_peer_checked(grpc_exec_ctx *exec_ctx, void *user_data,
 }
 
 static void check_peer(grpc_exec_ctx *exec_ctx, grpc_security_handshake *h) {
-  grpc_security_status peer_status;
   tsi_peer peer;
   tsi_result result = tsi_handshaker_extract_peer(h->handshaker, &peer);
 
@@ -153,15 +158,8 @@ static void check_peer(grpc_exec_ctx *exec_ctx, grpc_security_handshake *h) {
     security_handshake_done(exec_ctx, h, 0);
     return;
   }
-  peer_status = grpc_security_connector_check_peer(h->connector, peer,
-                                                   on_peer_checked, h);
-  if (peer_status == GRPC_SECURITY_ERROR) {
-    gpr_log(GPR_ERROR, "Peer check failed.");
-    security_handshake_done(exec_ctx, h, 0);
-    return;
-  } else if (peer_status == GRPC_SECURITY_OK) {
-    on_peer_checked(exec_ctx, h, peer_status);
-  }
+  grpc_security_connector_check_peer(exec_ctx, h->connector, peer,
+                                     on_peer_checked, h);
 }
 
 static void send_handshake_bytes_to_peer(grpc_exec_ctx *exec_ctx,

--- a/src/core/security/security_connector.h
+++ b/src/core/security/security_connector.h
@@ -239,7 +239,7 @@ const tsi_peer_property *tsi_peer_get_property_by_name(const tsi_peer *peer,
 
 /* Exposed for testing only. */
 grpc_auth_context *tsi_ssl_peer_to_auth_context(const tsi_peer *peer);
-tsi_peer tsi_shallow_peer_from_auth_context(
+tsi_peer tsi_shallow_peer_from_ssl_auth_context(
     const grpc_auth_context *auth_context);
 void tsi_shallow_peer_destruct(tsi_peer *peer);
 

--- a/src/core/surface/channel_create.c
+++ b/src/core/surface/channel_create.c
@@ -104,6 +104,7 @@ static void connected(grpc_exec_ctx *exec_ctx, void *arg, int success) {
     grpc_chttp2_transport_start_reading(exec_ctx, c->result->transport, NULL,
                                         0);
     GPR_ASSERT(c->result->transport);
+    c->result->channel_args = c->args.channel_args;
     c->result->filters = gpr_malloc(sizeof(grpc_channel_filter *));
     c->result->filters[0] = &grpc_http_client_filter;
     c->result->num_filters = 1;

--- a/src/core/surface/secure_channel_create.c
+++ b/src/core/surface/secure_channel_create.c
@@ -93,6 +93,7 @@ static void on_secure_handshake_done(grpc_exec_ctx *exec_ctx, void *arg,
                                      grpc_auth_context *auth_context) {
   connector *c = arg;
   grpc_closure *notify;
+  grpc_channel_args *args_copy = NULL;
   gpr_mu_lock(&c->mu);
   if (c->connecting_endpoint == NULL) {
     memset(c->result, 0, sizeof(*c->result));
@@ -103,18 +104,17 @@ static void on_secure_handshake_done(grpc_exec_ctx *exec_ctx, void *arg,
     c->connecting_endpoint = NULL;
     gpr_mu_unlock(&c->mu);
   } else {
+    grpc_arg auth_context_arg;
     c->connecting_endpoint = NULL;
     gpr_mu_unlock(&c->mu);
-    {
-      grpc_arg auth_context_arg = grpc_auth_context_to_arg(auth_context);
-      grpc_channel_args *args_copy = grpc_channel_args_copy_and_add(
-          c->args.channel_args, &auth_context_arg, 1);
-      c->result->transport = grpc_create_chttp2_transport(
-          exec_ctx, args_copy, secure_endpoint, 1);
-      grpc_channel_args_destroy(args_copy);
-    }
+    c->result->transport = grpc_create_chttp2_transport(
+        exec_ctx, c->args.channel_args, secure_endpoint, 1);
     grpc_chttp2_transport_start_reading(exec_ctx, c->result->transport, NULL,
                                         0);
+    auth_context_arg = grpc_auth_context_to_arg(auth_context);
+    args_copy = grpc_channel_args_copy_and_add(c->args.channel_args,
+                                               &auth_context_arg, 1);
+    c->result->channel_args = args_copy;
     c->result->filters = gpr_malloc(sizeof(grpc_channel_filter *) * 2);
     c->result->filters[0] = &grpc_http_client_filter;
     c->result->filters[1] = &grpc_client_auth_filter;
@@ -122,7 +122,9 @@ static void on_secure_handshake_done(grpc_exec_ctx *exec_ctx, void *arg,
   }
   notify = c->notify;
   c->notify = NULL;
+  /* look at c->args which are connector args. */
   notify->cb(exec_ctx, notify->cb_arg, 1);
+  if (args_copy != NULL) grpc_channel_args_destroy(args_copy);
 }
 
 static void on_initial_connect_string_sent(grpc_exec_ctx *exec_ctx, void *arg,

--- a/test/core/security/security_connector_test.c
+++ b/test/core/security/security_connector_test.c
@@ -60,8 +60,39 @@ static int check_transport_security_type(const grpc_auth_context *ctx) {
   return 1;
 }
 
+static int check_peer_property(const tsi_peer *peer,
+                               const tsi_peer_property *expected) {
+  size_t i;
+  for (i = 0; i < peer->property_count; i++) {
+    const tsi_peer_property *prop = &peer->properties[i];
+    if ((strcmp(prop->name, expected->name) == 0) &&
+        (prop->value.length == expected->value.length) &&
+        (memcmp(prop->value.data, expected->value.data,
+                expected->value.length) == 0)) {
+      return 1;
+    }
+  }
+  return 0; /* Not found... */
+}
+
+static int check_ssl_peer_equivalence(const tsi_peer *original,
+                                      const tsi_peer *reconstructed) {
+  /* The reconstructed peer only has CN and SAN properties. */
+  size_t i;
+  for (i = 0; i < original->property_count; i++) {
+    const tsi_peer_property *prop = &original->properties[i];
+    if ((strcmp(prop->name, TSI_X509_SUBJECT_COMMON_NAME_PEER_PROPERTY) == 0) ||
+        (strcmp(prop->name, TSI_X509_SUBJECT_ALTERNATIVE_NAME_PEER_PROPERTY) ==
+         0)) {
+      if (!check_peer_property(reconstructed, prop)) return 0;
+    }
+  }
+  return 1;
+}
+
 static void test_unauthenticated_ssl_peer(void) {
   tsi_peer peer;
+  tsi_peer rpeer;
   grpc_auth_context *ctx;
   GPR_ASSERT(tsi_construct_peer(1, &peer) == TSI_OK);
   GPR_ASSERT(tsi_construct_string_peer_property_from_cstring(
@@ -72,6 +103,10 @@ static void test_unauthenticated_ssl_peer(void) {
   GPR_ASSERT(!grpc_auth_context_peer_is_authenticated(ctx));
   GPR_ASSERT(check_transport_security_type(ctx));
 
+  rpeer = tsi_shallow_peer_from_ssl_auth_context(ctx);
+  GPR_ASSERT(check_ssl_peer_equivalence(&peer, &rpeer));
+
+  tsi_shallow_peer_destruct(&rpeer);
   tsi_peer_destruct(&peer);
   GRPC_AUTH_CONTEXT_UNREF(ctx, "test");
 }
@@ -128,6 +163,7 @@ static int check_x509_cn(const grpc_auth_context *ctx,
 
 static void test_cn_only_ssl_peer_to_auth_context(void) {
   tsi_peer peer;
+  tsi_peer rpeer;
   grpc_auth_context *ctx;
   const char *expected_cn = "cn1";
   GPR_ASSERT(tsi_construct_peer(2, &peer) == TSI_OK);
@@ -144,12 +180,17 @@ static void test_cn_only_ssl_peer_to_auth_context(void) {
   GPR_ASSERT(check_transport_security_type(ctx));
   GPR_ASSERT(check_x509_cn(ctx, expected_cn));
 
+  rpeer = tsi_shallow_peer_from_ssl_auth_context(ctx);
+  GPR_ASSERT(check_ssl_peer_equivalence(&peer, &rpeer));
+
+  tsi_shallow_peer_destruct(&rpeer);
   tsi_peer_destruct(&peer);
   GRPC_AUTH_CONTEXT_UNREF(ctx, "test");
 }
 
 static void test_cn_and_one_san_ssl_peer_to_auth_context(void) {
   tsi_peer peer;
+  tsi_peer rpeer;
   grpc_auth_context *ctx;
   const char *expected_cn = "cn1";
   const char *expected_san = "san1";
@@ -171,12 +212,17 @@ static void test_cn_and_one_san_ssl_peer_to_auth_context(void) {
   GPR_ASSERT(check_transport_security_type(ctx));
   GPR_ASSERT(check_x509_cn(ctx, expected_cn));
 
+  rpeer = tsi_shallow_peer_from_ssl_auth_context(ctx);
+  GPR_ASSERT(check_ssl_peer_equivalence(&peer, &rpeer));
+
+  tsi_shallow_peer_destruct(&rpeer);
   tsi_peer_destruct(&peer);
   GRPC_AUTH_CONTEXT_UNREF(ctx, "test");
 }
 
 static void test_cn_and_multiple_sans_ssl_peer_to_auth_context(void) {
   tsi_peer peer;
+  tsi_peer rpeer;
   grpc_auth_context *ctx;
   const char *expected_cn = "cn1";
   const char *expected_sans[] = {"san1", "san2", "san3"};
@@ -202,6 +248,10 @@ static void test_cn_and_multiple_sans_ssl_peer_to_auth_context(void) {
   GPR_ASSERT(check_transport_security_type(ctx));
   GPR_ASSERT(check_x509_cn(ctx, expected_cn));
 
+  rpeer = tsi_shallow_peer_from_ssl_auth_context(ctx);
+  GPR_ASSERT(check_ssl_peer_equivalence(&peer, &rpeer));
+
+  tsi_shallow_peer_destruct(&rpeer);
   tsi_peer_destruct(&peer);
   GRPC_AUTH_CONTEXT_UNREF(ctx, "test");
 }
@@ -209,6 +259,7 @@ static void test_cn_and_multiple_sans_ssl_peer_to_auth_context(void) {
 static void test_cn_and_multiple_sans_and_others_ssl_peer_to_auth_context(
     void) {
   tsi_peer peer;
+  tsi_peer rpeer;
   grpc_auth_context *ctx;
   const char *expected_cn = "cn1";
   const char *expected_sans[] = {"san1", "san2", "san3"};
@@ -238,6 +289,10 @@ static void test_cn_and_multiple_sans_and_others_ssl_peer_to_auth_context(
   GPR_ASSERT(check_transport_security_type(ctx));
   GPR_ASSERT(check_x509_cn(ctx, expected_cn));
 
+  rpeer = tsi_shallow_peer_from_ssl_auth_context(ctx);
+  GPR_ASSERT(check_ssl_peer_equivalence(&peer, &rpeer));
+
+  tsi_shallow_peer_destruct(&rpeer);
   tsi_peer_destruct(&peer);
   GRPC_AUTH_CONTEXT_UNREF(ctx, "test");
 }

--- a/test/core/security/security_connector_test.c
+++ b/test/core/security/security_connector_test.c
@@ -242,6 +242,8 @@ static void test_cn_and_multiple_sans_and_others_ssl_peer_to_auth_context(
   GRPC_AUTH_CONTEXT_UNREF(ctx, "test");
 }
 
+/* TODO(jboeuf): Unit-test tsi_shallow_peer_from_auth_context. */
+
 int main(int argc, char **argv) {
   grpc_test_init(argc, argv);
   grpc_init();


### PR DESCRIPTION
Backporting security connector fixes from master to 0.12. See the following PRs:
- #4523
- #4533 

It's worth having these in the release.