### PR TITLE
Added exception handling for ImportError

### DIFF
--- a/src/boringssl/gen_build_yaml.py
+++ b/src/boringssl/gen_build_yaml.py
@@ -38,7 +38,11 @@ boring_ssl_root = os.path.abspath(os.path.join(
     '../../third_party/boringssl'))
 sys.path.append(os.path.join(boring_ssl_root, 'util'))
 
-import generate_build_files
+try:
+  import generate_build_files
+except ImportError:
+  print yaml.dump({})
+  sys.exit()
 
 def map_dir(filename):
   if filename[0:4] == 'src/':


### PR DESCRIPTION
The import path munging does not succeed in some environments and we get an ImportError in those cases. Added exception handling to generate an empty yaml file in those cases.