### PR TITLE
Update some Node dependencies to more recent versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "protobufjs": "^4.0.0"
   },
   "devDependencies": {
-    "async": "^0.9.0",
+    "async": "^1.5.1",
     "google-auth-library": "^0.9.2",
     "istanbul": "^0.3.21",
     "jsdoc": "^3.3.2",
     "jshint": "^2.5.0",
     "minimist": "^1.1.0",
-    "mocha": "~1.21.0",
+    "mocha": "^2.3.4",
     "mocha-jenkins-reporter": "^0.1.9",
     "mustache": "^2.0.0",
     "poisson-process": "^0.2.1"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "protobufjs": "^4.0.0"
   },
   "devDependencies": {
-    "async": "^1.5.1",
+    "async": "^1.5.0",
     "google-auth-library": "^0.9.2",
     "istanbul": "^0.3.21",
     "jsdoc": "^3.3.2",

--- a/src/node/interop/async_delay_queue.js
+++ b/src/node/interop/async_delay_queue.js
@@ -36,8 +36,8 @@
 var _ = require('lodash');
 
 /**
- * This class represents a queue of callbacks that must happen sequentially, each
- * with a specific delay after the previous event.
+ * This class represents a queue of callbacks that must happen sequentially,
+ * each with a specific delay after the previous event.
  */
 function AsyncDelayQueue() {
   this.queue = [];

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -33,13 +33,13 @@
       "protobufjs": "^4.0.0"
     },
     "devDependencies": {
-      "async": "^0.9.0",
+      "async": "^1.5.1",
       "google-auth-library": "^0.9.2",
       "istanbul": "^0.3.21",
       "jsdoc": "^3.3.2",
       "jshint": "^2.5.0",
       "minimist": "^1.1.0",
-      "mocha": "~1.21.0",
+      "mocha": "^2.3.4",
       "mocha-jenkins-reporter": "^0.1.9",
       "mustache": "^2.0.0",
       "poisson-process": "^0.2.1"

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -33,7 +33,7 @@
       "protobufjs": "^4.0.0"
     },
     "devDependencies": {
-      "async": "^1.5.1",
+      "async": "^1.5.0",
       "google-auth-library": "^0.9.2",
       "istanbul": "^0.3.21",
       "jsdoc": "^3.3.2",


### PR DESCRIPTION
Hopefully, this will help mitigate #4607 by reducing the number of warning messages