### PR TITLE
Re-enable explicit specification of server port for qps worker

### DIFF
--- a/test/cpp/qps/qps_driver.cc
+++ b/test/cpp/qps/qps_driver.cc
@@ -165,6 +165,13 @@ static void QpsDriver() {
     server_config.mutable_security_params()->CopyFrom(security);
   }
 
+  // Make sure that if we are performing a generic (bytebuf) test
+  // that we are also using async streaming
+  GPR_ASSERT(!client_config.payload_config().has_bytebuf_params() ||
+             (client_config.client_type() == ASYNC_CLIENT &&
+              client_config.rpc_type() == STREAMING &&
+              server_config.server_type() == ASYNC_SERVER));
+
   const auto result = RunScenario(
       client_config, FLAGS_num_clients, server_config, FLAGS_num_servers,
       FLAGS_warmup_seconds, FLAGS_benchmark_seconds, FLAGS_local_workers);

--- a/test/cpp/qps/qps_worker.cc
+++ b/test/cpp/qps/qps_worker.cc
@@ -197,7 +197,7 @@ class WorkerServiceImpl GRPC_FINAL : public WorkerService::Service {
     if (!args.has_setup()) {
       return Status(StatusCode::INVALID_ARGUMENT, "");
     }
-    if (server_port_) {
+    if (server_port_ != 0) {
       args.mutable_setup()->set_port(server_port_);
     }
     auto server = CreateServer(args.setup());

--- a/test/cpp/qps/qps_worker.cc
+++ b/test/cpp/qps/qps_worker.cc
@@ -51,11 +51,11 @@
 #include <grpc/support/host_port.h>
 #include <grpc/support/log.h>
 
+#include "src/proto/grpc/testing/services.pb.h"
 #include "test/core/util/grpc_profiler.h"
 #include "test/cpp/qps/client.h"
 #include "test/cpp/qps/server.h"
 #include "test/cpp/util/create_test_channel.h"
-#include "src/proto/grpc/testing/services.pb.h"
 
 namespace grpc {
 namespace testing {
@@ -97,7 +97,8 @@ static std::unique_ptr<Server> CreateServer(const ServerConfig& config) {
 
 class WorkerServiceImpl GRPC_FINAL : public WorkerService::Service {
  public:
-  explicit WorkerServiceImpl() : acquired_(false) {}
+  explicit WorkerServiceImpl(int server_port)
+      : acquired_(false), server_port_(server_port) {}
 
   Status RunClient(ServerContext* ctx,
                    ServerReaderWriter<ClientStatus, ClientArgs>* stream)
@@ -196,6 +197,9 @@ class WorkerServiceImpl GRPC_FINAL : public WorkerService::Service {
     if (!args.has_setup()) {
       return Status(StatusCode::INVALID_ARGUMENT, "");
     }
+    if (server_port_) {
+      args.mutable_setup()->set_port(server_port_);
+    }
     auto server = CreateServer(args.setup());
     if (!server) {
       return Status(StatusCode::INVALID_ARGUMENT, "");
@@ -219,10 +223,11 @@ class WorkerServiceImpl GRPC_FINAL : public WorkerService::Service {
 
   std::mutex mu_;
   bool acquired_;
+  int server_port_;
 };
 
-QpsWorker::QpsWorker(int driver_port) {
-  impl_.reset(new WorkerServiceImpl());
+QpsWorker::QpsWorker(int driver_port, int server_port) {
+  impl_.reset(new WorkerServiceImpl(server_port));
 
   char* server_address = NULL;
   gpr_join_host_port(&server_address, "::", driver_port);

--- a/test/cpp/qps/qps_worker.h
+++ b/test/cpp/qps/qps_worker.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/test/cpp/qps/qps_worker.h
+++ b/test/cpp/qps/qps_worker.h
@@ -46,7 +46,7 @@ class WorkerServiceImpl;
 
 class QpsWorker {
  public:
-  explicit QpsWorker(int driver_port);
+  explicit QpsWorker(int driver_port, int server_port = 0);
   ~QpsWorker();
 
  private:

--- a/test/cpp/qps/worker.cc
+++ b/test/cpp/qps/worker.cc
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/test/cpp/qps/worker.cc
+++ b/test/cpp/qps/worker.cc
@@ -44,6 +44,7 @@
 #include "test/cpp/util/test_config.h"
 
 DEFINE_int32(driver_port, 0, "Port for communication with driver");
+DEFINE_int32(server_port, 0, "Port for operation as a server");
 
 static bool got_sigint = false;
 
@@ -53,7 +54,7 @@ namespace grpc {
 namespace testing {
 
 static void RunServer() {
-  QpsWorker worker(FLAGS_driver_port);
+  QpsWorker worker(FLAGS_driver_port, FLAGS_server_port);
 
   while (!got_sigint) {
     gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),


### PR DESCRIPTION
This flag was needed in some test scenarios.

Also add in a check that we don't try to use generic testing for sync or unary.