### PR TITLE
Eliminate jobset timeouts in some circumstances

### DIFF
--- a/tools/buildgen/generate_projects.py
+++ b/tools/buildgen/generate_projects.py
@@ -85,7 +85,7 @@ for template in templates:
       os.close(tf[0])
       cmd.append(test[out])
     cmd.append(root + '/' + f)
-    jobs.append(jobset.JobSpec(cmd, shortname=out))
+    jobs.append(jobset.JobSpec(cmd, shortname=out, timeout_seconds=None))
 
 jobset.run(jobs, maxjobs=multiprocessing.cpu_count())
 

--- a/tools/buildgen/generate_projects.py
+++ b/tools/buildgen/generate_projects.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2.7
 
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/tools/run_tests/jobset.py
+++ b/tools/run_tests/jobset.py
@@ -273,7 +273,9 @@ class Job(object):
         self.result.state = 'PASSED'
         if self._bin_hash:
           update_cache.finished(self._spec.identity(), self._bin_hash)
-    elif self._state == _RUNNING and time.time() - self._start > self._spec.timeout_seconds:
+    elif (self._state == _RUNNING and 
+          self._spec.timeout_seconds is not None and 
+          time.time() - self._start > self._spec.timeout_seconds):
       if self._timeout_retries < self._spec.timeout_retries:
         message('TIMEOUT_FLAKE', '%s [pid=%d]' % (self._spec.shortname, self._process.pid), stdout(), do_newline=True)
         self._timeout_retries += 1

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -764,7 +764,7 @@ if platform_string() == 'windows':
                       _windows_toolset_option(args.compiler),
                       _windows_arch_option(args.arch)] +
                       extra_args,
-                      shell=True, timeout_seconds=90*60)
+                      shell=True, timeout_seconds=None)
       for target in targets]
 else:
   def make_jobspec(cfg, targets, makefile='Makefile'):
@@ -776,7 +776,7 @@ else:
                               'CONFIG=%s' % cfg] +
                              ([] if not args.travis else ['JENKINS_BUILD=1']) +
                              targets,
-                             timeout_seconds=30*60)]
+                             timeout_seconds=None)]
     else:
       return []
 make_targets = {}
@@ -801,7 +801,7 @@ if make_targets:
   make_commands = itertools.chain.from_iterable(make_jobspec(cfg, list(targets), makefile) for cfg in build_configs for (makefile, targets) in make_targets.iteritems())
   build_steps.extend(set(make_commands))
 build_steps.extend(set(
-                   jobset.JobSpec(cmdline, environ=build_step_environ(cfg), timeout_seconds=10*60)
+                   jobset.JobSpec(cmdline, environ=build_step_environ(cfg), timeout_seconds=None)
                    for cfg in build_configs
                    for l in languages
                    for cmdline in l.build_steps()))


### PR DESCRIPTION
There are cases where we truly don't care how long something takes, and
some external timeout will kill truly stuck processes, so let's
eliminate timeouts in those cases