### PR TITLE
Improve grpc_chttp2_decode_timeout implementation

### DIFF
--- a/src/core/transport/chttp2/timeout_encoding.c
+++ b/src/core/transport/chttp2/timeout_encoding.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/test/core/transport/chttp2/timeout_encoding_test.c
+++ b/test/core/transport/chttp2/timeout_encoding_test.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/test/core/transport/chttp2/timeout_encoding_test.c
+++ b/test/core/transport/chttp2/timeout_encoding_test.c
@@ -130,12 +130,9 @@ void test_decoding(void) {
                     gpr_time_from_seconds(1000 * 1000 * 1000, GPR_TIMESPAN));
   assert_decodes_as("1000000000000000000000u",
                     gpr_inf_future(GPR_CLOCK_REALTIME));
-  assert_decodes_as("1000000001S",
-                    gpr_inf_future(GPR_CLOCK_REALTIME));
-  assert_decodes_as("2000000001S",
-                      gpr_inf_future(GPR_CLOCK_REALTIME));
-  assert_decodes_as("9999999999S",
-                      gpr_inf_future(GPR_CLOCK_REALTIME));
+  assert_decodes_as("1000000001S", gpr_inf_future(GPR_CLOCK_REALTIME));
+  assert_decodes_as("2000000001S", gpr_inf_future(GPR_CLOCK_REALTIME));
+  assert_decodes_as("9999999999S", gpr_inf_future(GPR_CLOCK_REALTIME));
 }
 
 void test_decoding_fails(void) {

--- a/test/core/transport/chttp2/timeout_encoding_test.c
+++ b/test/core/transport/chttp2/timeout_encoding_test.c
@@ -126,8 +126,16 @@ void test_decoding(void) {
   decode_suite('S', gpr_time_from_seconds);
   decode_suite('M', gpr_time_from_minutes);
   decode_suite('H', gpr_time_from_hours);
+  assert_decodes_as("1000000000S",
+                    gpr_time_from_seconds(1000 * 1000 * 1000, GPR_TIMESPAN));
   assert_decodes_as("1000000000000000000000u",
                     gpr_inf_future(GPR_CLOCK_REALTIME));
+  assert_decodes_as("1000000001S",
+                    gpr_inf_future(GPR_CLOCK_REALTIME));
+  assert_decodes_as("2000000001S",
+                      gpr_inf_future(GPR_CLOCK_REALTIME));
+  assert_decodes_as("9999999999S",
+                      gpr_inf_future(GPR_CLOCK_REALTIME));
 }
 
 void test_decoding_fails(void) {


### PR DESCRIPTION
Fixes the linux portion of #4767  (by making x safely castable to long on 32bit).

Changes grpc_chttp2_decode_timeout logic to only accept values [0, 1000000000] and makes the code a bit more readable.
One thing worth noting is that the spec says that TimeoutValue can be at most 8 digits (https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md), but the code is happy to encode and decode values that don't satisfy that:

`assert_encodes_as(gpr_time_from_seconds(1000000000, GPR_TIMESPAN),
                    "1000000000S");`

Should we update the spec?

