### PR TITLE
Cap fling tests by time not rpcs processed

### DIFF
--- a/test/core/fling/client.c
+++ b/test/core/fling/client.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/test/core/fling/client.c
+++ b/test/core/fling/client.c
@@ -201,13 +201,16 @@ int main(int argc, char **argv) {
 
   sc.init();
 
-  for (i = 0; i < 1000; i++) {
+  gpr_timespec end_warmup = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(3);
+  gpr_timespec end_profiling = GRPC_TIMEOUT_SECONDS_TO_DEADLINE(30);
+  
+  while (gpr_time_cmp(gpr_now(end_warmup.clock_type), end_warmup) < 0) {
     sc.do_one_step();
   }
 
   gpr_log(GPR_INFO, "start profiling");
   grpc_profiler_start("client.prof");
-  for (i = 0; i < 100000; i++) {
+  while (gpr_time_cmp(gpr_now(end_profiling.clock_type), end_profiling) < 0) {
     start = now();
     sc.do_one_step();
     stop = now();

--- a/test/core/support/avl_test.c
+++ b/test/core/support/avl_test.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Built on #4780 

We are timing out on some configurations... this makes the tests robust forever.