### PR TITLE
List Sanity tests in a config file, not a shell script

### DIFF
--- a/tools/distrib/check_copyright.py
+++ b/tools/distrib/check_copyright.py
@@ -136,7 +136,10 @@ for filename in subprocess.check_output('git ls-tree -r --name-only -r HEAD',
   else:
     log(args.skips, 'skip', filename)
     continue
-  text = load(filename)
+  try:
+    text = load(filename)
+  except:
+    continue
   m = re.search(re_license, text)
   if m:
     gdict = m.groupdict()

--- a/tools/run_tests/check_cache_mk.sh
+++ b/tools/run_tests/check_cache_mk.sh
@@ -32,32 +32,8 @@
 
 set -e
 
-export TEST=true
-
-cd `dirname $0`/../..
-
-submodules=`mktemp /tmp/submXXXXXX`
-want_submodules=`mktemp /tmp/submXXXXXX`
-
-git submodule | awk '{ print $1 }' | sort > $submodules
-cat << EOF | awk '{ print $1 }' | sort > $want_submodules
- 9f897b25800d2f54f5c442ef01a60721aeca6d87 third_party/boringssl (version_for_cocoapods_1.0-67-g9f897b2)
- 05b155ff59114735ec8cd089f669c4c3d8f59029 third_party/gflags (v2.1.0-45-g05b155f)
- c99458533a9b4c743ed51537e25989ea55944908 third_party/googletest (release-1.7.0)
- 8fce8933649ce09c1661ff2b5b7f6eb79badd251 third_party/protobuf (v3.0.0-alpha-4-1-g8fce893)
- 50893291621658f355bc5b4d450a8d06a563053d third_party/zlib (v1.2.8)
-EOF
-
-diff -u $submodules $want_submodules
-
-rm $submodules $want_submodules
-
 if [ -f cache.mk ] ; then
   echo "Please don't commit cache.mk"
   exit 1
 fi
 
-./tools/buildgen/generate_projects.sh
-./tools/distrib/check_copyright.py
-./tools/distrib/clang_format_code.sh
-./tools/distrib/check_trailing_newlines.sh

--- a/tools/run_tests/check_submodules.sh
+++ b/tools/run_tests/check_submodules.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# Copyright 2015-2016, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+set -e
+
+export TEST=true
+
+cd `dirname $0`/../..
+
+submodules=`mktemp /tmp/submXXXXXX`
+want_submodules=`mktemp /tmp/submXXXXXX`
+
+git submodule | awk '{ print $1 }' | sort > $submodules
+cat << EOF | awk '{ print $1 }' | sort > $want_submodules
+ 9f897b25800d2f54f5c442ef01a60721aeca6d87 third_party/boringssl (version_for_cocoapods_1.0-67-g9f897b2)
+ 05b155ff59114735ec8cd089f669c4c3d8f59029 third_party/gflags (v2.1.0-45-g05b155f)
+ c99458533a9b4c743ed51537e25989ea55944908 third_party/googletest (release-1.7.0)
+ 8fce8933649ce09c1661ff2b5b7f6eb79badd251 third_party/protobuf (v3.0.0-alpha-4-1-g8fce893)
+ 50893291621658f355bc5b4d450a8d06a563053d third_party/zlib (v1.2.8)
+EOF
+
+diff -u $submodules $want_submodules
+
+rm $submodules $want_submodules
+

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -96,7 +96,7 @@ class SimpleConfig(object):
     return jobset.JobSpec(cmdline=cmdline,
                           shortname=shortname,
                           environ=actual_environ,
-                          timeout_seconds=self.timeout_multiplier * timeout_seconds,
+                          timeout_seconds=(self.timeout_multiplier * timeout_seconds if timeout_seconds else None),
                           hash_targets=hash_targets
                               if self.allow_hashing else None,
                           flake_retries=5 if args.allow_flakes else 0,
@@ -441,8 +441,10 @@ class ObjCLanguage(object):
 class Sanity(object):
 
   def test_specs(self, config, args):
-    return [config.job_spec(['tools/run_tests/run_sanity.sh'], None, timeout_seconds=15*60),
-            config.job_spec(['tools/run_tests/check_sources_and_headers.py'], None)]
+    import yaml
+    with open('tools/run_tests/sanity_tests.yaml', 'r') as f:
+      return [config.job_spec([cmd], None, timeout_seconds=None, environ={'TEST': 'true'})
+              for cmd in yaml.load(f)]
 
   def pre_build_steps(self):
     return []

--- a/tools/run_tests/sanity_tests.yaml
+++ b/tools/run_tests/sanity_tests.yaml
@@ -1,0 +1,9 @@
+# a set of tests that are run in parallel for sanity tests
+- tools/run_tests/check_sources_and_headers.py
+- tools/run_tests/check_submodules.sh
+- tools/run_tests/check_cache_mk.sh
+- tools/buildgen/generate_projects.sh
+- tools/distrib/check_copyright.py
+- tools/distrib/clang_format_code.sh
+- tools/distrib/check_trailing_newlines.sh
+


### PR DESCRIPTION
Build on #4783 

Allows parallelization of sanity tests, and better error reporting