### PR TITLE
Fixed proto method without package naming in ObjC.

### DIFF
--- a/src/objective-c/ProtoRPC/ProtoMethod.m
+++ b/src/objective-c/ProtoRPC/ProtoMethod.m
@@ -46,7 +46,7 @@
 }
 
 - (NSString *)HTTPPath {
-  if (_package) {
+  if (_package != nil && _package.length > 0) {
     return [NSString stringWithFormat:@"/%@.%@/%@", _package, _service, _method];
   } else {
     return [NSString stringWithFormat:@"/%@/%@", _service, _method];

--- a/src/objective-c/ProtoRPC/ProtoMethod.m
+++ b/src/objective-c/ProtoRPC/ProtoMethod.m
@@ -46,7 +46,7 @@
 }
 
 - (NSString *)HTTPPath {
-  if (_package != nil && _package.length > 0) {
+  if (_package && _package.length > 0) {
     return [NSString stringWithFormat:@"/%@.%@/%@", _package, _service, _method];
   } else {
     return [NSString stringWithFormat:@"/%@/%@", _service, _method];


### PR DESCRIPTION
Generating Objective-C protobuf messages without a declared package will yield an empty string for the package name in the generated `.pbrpc.h` file.  Currently [only a non-nil reference is being checked](https://github.com/grpc/grpc/blob/93205e63352c614cc47b5cd0342cc1a06797de2f/src/objective-c/ProtoRPC/ProtoMethod.m#L49).  So given a service named `Echo` and method `Send`, the HTTP path it attempts to use is `.Echo/Send` instead of `Echo/Send`.  Instead the code should likely follow the example of the grpc-java and [treat the absence of a package as an empty string](https://github.com/grpc/grpc-java/blob/509c7e7335cf8a563ff1df6dddefb6eafb0c5f98/compiler/src/java_plugin/cpp/java_generator.cpp#L774).