### PR TITLE
Add ability to download precompiled Ruby extension instead of building it locally

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 require 'mkmf'
+require 'net/http'
+require 'grpc/version'
+require 'pp'
 
 LIBDIR = RbConfig::CONFIG['libdir']
 INCLUDEDIR = RbConfig::CONFIG['includedir']
@@ -54,39 +57,84 @@ LIB_DIRS = [
   LIBDIR
 ]
 
-fail 'libdl not found' unless have_library('dl', 'dlopen')
-fail 'zlib not found' unless have_library('z', 'inflate')
+build_from_source = ENV['GRPC_RUBY_BUILD_FROM_SOURCE']
+publish_binary = ENV['GRPC_RUBY_PUBLISH_BINARY']
 
-grpc_root = File.expand_path(File.join(File.dirname(__FILE__), '../../../..'))
+# see https://www.ruby-lang.org/en/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/
+abi = "#{RbConfig::CONFIG['MAJOR']}.#{RbConfig::CONFIG['MINOR']}.0"
+ruby_version = RbConfig::CONFIG['RUBY_PROGRAM_VERSION']
+local_platform = Gem::Platform.local
+ext = RbConfig::CONFIG['DLEXT']
+target_os = RbConfig::CONFIG['target_os']
+target_cpu = RbConfig::CONFIG['target_cpu']
+# These describe the expected location of the file online
+remote_path = "grpc-precompiled-binaries/ruby/grpc/v#{GRPC::VERSION}"
+remote_name = "#{abi}-#{RbConfig::CONFIG['target_os']}-#{RbConfig::CONFIG['target_cpu']}.#{ext}"
 
-grpc_config = ENV['GRPC_CONFIG'] || 'opt'
-
-if ENV.key?('GRPC_LIB_DIR')
-  grpc_lib_dir = File.join(grpc_root, ENV['GRPC_LIB_DIR'])
+if build_from_source
+  download_success = false
 else
-  grpc_lib_dir = File.join(File.join(grpc_root, 'libs'), grpc_config)
+  begin
+    print "Attempting to download precompiled extension\n"
+    print "From storage.googleapis.com/#{remote_path}/#{remote_name}\n"
+    Net::HTTP.start('storage.googleapis.com') do |http|
+      http.request_get("/#{remote_path}/#{remote_name}") do |resp|
+        resp.value()
+        open("grpc.#{ext}", 'wb') do |ext_bin_file|
+          resp.read_body do |segment|
+            ext_bin_file.write(segment)
+          end
+        end
+      end
+    end
+    print "Downloaded precompiled extension\n"
+    download_success = true
+  rescue Net::HTTPExceptions => e
+    download_success = false
+  end
 end
 
-unless File.exist?(File.join(grpc_lib_dir, 'libgrpc.a'))
-  print "Building internal gRPC\n"
-  system("make -C #{grpc_root} static_c CONFIG=#{grpc_config}")
+if download_success
+  # Create dummy makefile
+  open('Makefile', 'w') do |makefile|
+    makefile.write("all:\n\ttrue\n\ninstall:\n\ttrue")
+  end
+  $makefile_created = true
+else
+  fail 'libdl not found' unless have_library('dl', 'dlopen')
+  fail 'zlib not found' unless have_library('z', 'inflate')
+
+  grpc_root = File.expand_path(File.join(File.dirname(__FILE__), '../../../..'))
+
+  grpc_config = ENV['GRPC_CONFIG'] || 'opt'
+
+  if ENV.key?('GRPC_LIB_DIR')
+    grpc_lib_dir = File.join(grpc_root, ENV['GRPC_LIB_DIR'])
+  else
+    grpc_lib_dir = File.join(File.join(grpc_root, 'libs'), grpc_config)
+  end
+
+  unless File.exist?(File.join(grpc_lib_dir, 'libgrpc.a'))
+    print "Building internal gRPC\n"
+    system("make -C #{grpc_root} static_c CONFIG=#{grpc_config}")
+  end
+
+  $CFLAGS << ' -I' + File.join(grpc_root, 'include')
+  $LDFLAGS << ' ' + File.join(grpc_lib_dir, 'libgrpc.a')
+  $LDFLAGS << ' ' + File.join(grpc_lib_dir, 'libgpr.a')
+  if grpc_config == 'gcov'
+    $CFLAGS << ' -O0 -fprofile-arcs -ftest-coverage'
+    $LDFLAGS << ' -fprofile-arcs -ftest-coverage -rdynamic'
+  end
+
+  $CFLAGS << ' -std=c99 '
+  $CFLAGS << ' -Wall '
+  $CFLAGS << ' -Wextra '
+  $CFLAGS << ' -pedantic '
+  $CFLAGS << ' -Werror '
+
+  $LDFLAGS << ' -lssl '
+  $LDFLAGS << ' -lcrypto '
+
+  create_makefile('grpc/grpc')
 end
-
-$CFLAGS << ' -I' + File.join(grpc_root, 'include')
-$LDFLAGS << ' ' + File.join(grpc_lib_dir, 'libgrpc.a')
-$LDFLAGS << ' ' + File.join(grpc_lib_dir, 'libgpr.a')
-if grpc_config == 'gcov'
-  $CFLAGS << ' -O0 -fprofile-arcs -ftest-coverage'
-  $LDFLAGS << ' -fprofile-arcs -ftest-coverage -rdynamic'
-end
-
-$CFLAGS << ' -std=c99 '
-$CFLAGS << ' -Wall '
-$CFLAGS << ' -Wextra '
-$CFLAGS << ' -pedantic '
-$CFLAGS << ' -Werror '
-
-$LDFLAGS << ' -lssl '
-$LDFLAGS << ' -lcrypto '
-
-create_makefile('grpc/grpc')

--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -58,7 +58,6 @@ LIB_DIRS = [
 ]
 
 build_from_source = ENV['GRPC_RUBY_BUILD_FROM_SOURCE']
-publish_binary = ENV['GRPC_RUBY_PUBLISH_BINARY']
 
 # see https://www.ruby-lang.org/en/news/2013/12/21/ruby-version-policy-changes-with-2-1-0/
 abi = "#{RbConfig::CONFIG['MAJOR']}.#{RbConfig::CONFIG['MINOR']}.0"


### PR DESCRIPTION
Ruby's implementation of this is similar to Node's: It attempts to download the precompiled extension from the `grpc-precompiled-binaries` Google Cloud bucket, using a URL specified by Ruby version, library version, operating system, and CPU bitness (x86 vs x86_64). If the download fails, it falls back to building from source. The download attempt can be skipped by setting the environment variable `GRPC_RUBY_BUILD_FROM_SOURCE` to anything.

This also adds a rake target `stage_publish_binary` that copies the binary to a directory under `tmp/` that matches the remote path it would attempt to download from.

This fixes #4701.