### PR TITLE
Fix C# build on mac

### DIFF
--- a/tools/jenkins/run_jenkins.sh
+++ b/tools/jenkins/run_jenkins.sh
@@ -69,6 +69,9 @@ elif [ "$platform" == "macos" ]
 then
   echo "building $language on MacOS"
 
+  # Prevent msbuild from picking up "platform" env variable, which would break the build
+  unset platform
+
   ./tools/run_tests/run_tests.py -t -l $language -c $config -x report.xml -j 3 $@ || TESTS_FAILED="true"
 
 elif [ "$platform" == "freebsd" ]


### PR DESCRIPTION
Fixes

```
Project "/jenkins/workspace/gRPC_master/config/dbg/language/csharp/platform/macos/src/csharp/Grpc.sln" (default target(s)):
	Target ValidateSolutionConfiguration:
/jenkins/workspace/gRPC_master/config/dbg/language/csharp/platform/macos/src/csharp/Grpc.sln: error : Invalid solution configuration and platform: "Debug|macos".
	Task "Error" execution -- FAILED
```

https://grpc-testing.appspot.com/job/gRPC_master/14578/config=dbg,language=csharp,platform=macos/console