### PR TITLE
Fix path where we check for ruby coverage report

### DIFF
--- a/tools/run_tests/post_tests_ruby.sh
+++ b/tools/run_tests/post_tests_ruby.sh
@@ -43,4 +43,4 @@ genhtml $tmp2 --output-directory $out
 rm $tmp2
 rm $tmp1
 
-cp -rv $root/src/ruby/coverage $root/reports/ruby
+cp -rv $root/coverage $root/reports/ruby


### PR DESCRIPTION
This fixes #3770. Actually, this worked before, but stopped working when the Rakefile moved to the root directory.