### PR TITLE
Fix formatting of census.h

### DIFF
--- a/include/grpc/census.h
+++ b/include/grpc/census.h
@@ -506,8 +506,8 @@ extern census_aggregation_ops census_agg_window;
     construction via census_define_view(). */
 typedef struct {
   const census_aggregation_ops *ops;
-  const void
-      *create_arg; /* Argument to be used for aggregation initialization. */
+  const void *
+      create_arg; /* Argument to be used for aggregation initialization. */
 } census_aggregation;
 
 /** A census view type. Opaque. */


### PR DESCRIPTION
Currently format check on master is failing.

```
code -t grpc_clang_format /clang_format_all_the_things.sh
--- /local-code/include/grpc/census.h	2016-01-22 23:59:49.674731098 +0000
+++ /tmp/tmp.1iGikaX9E2	2016-01-23 03:44:29.351560241 +0000
@@ -506,8 +506,8 @@
     construction via census_define_view(). */
 typedef struct {
   const census_aggregation_ops *ops;
-  const void
-      *create_arg; /* Argument to be used for aggregation initialization. */
+  const void *
+      create_arg; /* Argument to be used for aggregation initialization. */
 } census_aggregation;
 
 /** A census view type. Opaque. */

FAILED: tools/distrib/clang_format_code.sh [ret=1, pid=4509]
```