### PR TITLE
Fix compilation on windows

### DIFF
--- a/test/core/census/tag_set_test.c
+++ b/test/core/census/tag_set_test.c
@@ -319,9 +319,10 @@ static void replace_add_delete_test(void) {
   census_tag_set_destroy(cts2);
 }
 
+#define BUF_SIZE 200
+
 // test encode/decode.
 static void encode_decode_test(void) {
-  const size_t BUF_SIZE = 200;
   char buffer[BUF_SIZE];
   struct census_tag_set *cts =
       census_tag_set_create(NULL, basic_tags, BASIC_TAG_COUNT, NULL);


### PR DESCRIPTION
C core doesn't compile on windows on master branch.

```
c:\jenkins\workspace\gRPC_master\config\dbg\language\c\platform\windows\vsprojects\\..\test\core\census\tag_set_test.c(325): error C2057: expected constant expression [c:\jenkins\workspace\gRPC_master\config\dbg\language\c\platform\windows\vsprojects\vcxproj\test\tag_set_test\tag_set_test.vcxproj]
         c:\jenkins\workspace\gRPC_master\config\dbg\language\c\platform\windows\vsprojects\\..\test\core\census\tag_set_test.c(325): error C2466: cannot allocate an array of constant size 0 [c:\jenkins\workspace\gRPC_master\config\dbg\language\c\platform\windows\vsprojects\vcxproj\test\tag_set_test\tag_set_test.vcxproj]
         c:\jenkins\workspace\gRPC_master\config\dbg\language\c\platform\windows\vsprojects\\..\test\core\census\tag_set_test.c(325): error C2133: 'buffer' : unknown size [c:\jenkins\workspace\gRPC_master\config\dbg\language\c\platform\windows\vsprojects\vcxproj\test\tag_set_test\tag_set_test.vcxproj]
```