### PR TITLE
Run nuget restore on mac as well

### DIFF
--- a/tools/run_tests/pre_build_csharp.sh
+++ b/tools/run_tests/pre_build_csharp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/tools/run_tests/pre_build_csharp.sh
+++ b/tools/run_tests/pre_build_csharp.sh
@@ -35,6 +35,11 @@ cd $(dirname $0)/../../src/csharp
 
 root=`pwd`
 
+if [ -x "$(command -v nuget)" ]
+then
+  nuget restore Grpc.sln
+fi
+
 if [ -n "$NUGET" ]
 then
   $NUGET restore Grpc.sln


### PR DESCRIPTION
NUGET env variable is only set under docker, so this makes sure nuget packages get properly restored on mac workers as well.