### PR TITLE
Cleaning up our Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,11 +229,29 @@ prefix ?= /usr/local
 PROTOC ?= protoc
 DTRACE ?= dtrace
 CONFIG ?= opt
-CC ?= $(CC_$(CONFIG))
-CXX ?= $(CXX_$(CONFIG))
-LD ?= $(LD_$(CONFIG))
+# Doing X ?= Y is the same as:
+# ifeq ($(origin X), undefined)
+#  X = Y
+# endif
+# but some variables, such as CC, CXX, LD or AR, have defaults.
+# So instead of using ?= on them, we need to check their origin.
+# See:
+#  https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
+#  https://www.gnu.org/software/make/manual/html_node/Flavors.html#index-_003f_003d
+#  https://www.gnu.org/software/make/manual/html_node/Origin-Function.html
+ifeq ($(origin CC), default)
+CC = $(CC_$(CONFIG))
+endif
+ifeq ($(origin CXX), default)
+CXX = $(CXX_$(CONFIG))
+endif
+ifeq ($(origin LD), default)
+LD = $(LD_$(CONFIG))
+endif
 LDXX ?= $(LDXX_$(CONFIG))
-AR ?= ar
+ifeq ($(origin AR), default)
+AR = ar
+endif
 ifeq ($(SYSTEM),Linux)
 STRIP ?= strip --strip-unneeded
 else

--- a/Makefile
+++ b/Makefile
@@ -226,26 +226,26 @@ DEFINES_mutrace = _DEBUG DEBUG
 
 prefix ?= /usr/local
 
-PROTOC = protoc
-DTRACE = dtrace
+PROTOC ?= protoc
+DTRACE ?= dtrace
 CONFIG ?= opt
-CC = $(CC_$(CONFIG))
-CXX = $(CXX_$(CONFIG))
-LD = $(LD_$(CONFIG))
-LDXX = $(LDXX_$(CONFIG))
-AR = ar
+CC ?= $(CC_$(CONFIG))
+CXX ?= $(CXX_$(CONFIG))
+LD ?= $(LD_$(CONFIG))
+LDXX ?= $(LDXX_$(CONFIG))
+AR ?= ar
 ifeq ($(SYSTEM),Linux)
-STRIP = strip --strip-unneeded
+STRIP ?= strip --strip-unneeded
 else
 ifeq ($(SYSTEM),Darwin)
-STRIP = strip -x
+STRIP ?= strip -x
 else
-STRIP = strip
+STRIP ?= strip
 endif
 endif
-INSTALL = install
-RM = rm -f
-PKG_CONFIG = pkg-config
+INSTALL ?= install
+RM ?= rm -f
+PKG_CONFIG ?= pkg-config
 
 ifndef VALID_CONFIG_$(CONFIG)
 $(error Invalid CONFIG value '$(CONFIG)')
@@ -266,10 +266,10 @@ HAS_CXX11 = $(shell $(CXX11_CHECK_CMD) 2> /dev/null && echo true || echo false)
 # cross-compiling, you can override these variables from GNU make's
 # command line: make CC=cross-gcc HOST_CC=gcc
 
-HOST_CC = $(CC)
-HOST_CXX = $(CXX)
-HOST_LD = $(LD)
-HOST_LDXX = $(LDXX)
+HOST_CC ?= $(CC)
+HOST_CXX ?= $(CXX)
+HOST_LD ?= $(LD)
+HOST_LDXX ?= $(LDXX)
 
 ifdef EXTRA_DEFINES
 DEFINES += $(EXTRA_DEFINES)
@@ -400,14 +400,6 @@ else
 IS_GIT_FOLDER = true
 endif
 
-ifeq ($(SYSTEM),Linux)
-OPENSSL_REQUIRES_DL = true
-endif
-
-ifeq ($(SYSTEM),Darwin)
-OPENSSL_REQUIRES_DL = true
-endif
-
 ifeq ($(HAS_PKG_CONFIG),true)
 OPENSSL_ALPN_CHECK_CMD = $(PKG_CONFIG) --atleast-version=1.0.2 openssl
 OPENSSL_NPN_CHECK_CMD = $(PKG_CONFIG) --atleast-version=1.0.1 openssl
@@ -425,11 +417,6 @@ OPENSSL_ALPN_CHECK_CMD = $(CC) $(CFLAGS) $(CPPFLAGS) -o $(TMPOUT) test/build/ope
 OPENSSL_NPN_CHECK_CMD = $(CC) $(CFLAGS) $(CPPFLAGS) -o $(TMPOUT) test/build/openssl-npn.c $(addprefix -l, $(OPENSSL_LIBS)) $(LDFLAGS)
 ZLIB_CHECK_CMD = $(CC) $(CFLAGS) $(CPPFLAGS) -o $(TMPOUT) test/build/zlib.c -lz $(LDFLAGS)
 PROTOBUF_CHECK_CMD = $(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $(TMPOUT) test/build/protobuf.cc -lprotobuf $(LDFLAGS)
-
-ifeq ($(OPENSSL_REQUIRES_DL),true)
-OPENSSL_ALPN_CHECK_CMD += -ldl
-OPENSSL_NPN_CHECK_CMD += -ldl
-endif
 
 endif # HAS_PKG_CONFIG
 
@@ -594,9 +581,6 @@ OPENSSL_DEP += $(LIBDIR)/$(CONFIG)/libboringssl.a
 OPENSSL_MERGE_LIBS += $(LIBDIR)/$(CONFIG)/libboringssl.a
 # need to prefix these to ensure overriding system libraries
 CPPFLAGS := -Ithird_party/boringssl/include $(CPPFLAGS)
-ifeq ($(OPENSSL_REQUIRES_DL),true)
-LIBS_SECURE = dl
-endif # OPENSSL_REQUIRES_DL
 else # EMBED_OPENSSL=false
 ifeq ($(HAS_PKG_CONFIG),true)
 OPENSSL_PKG_CONFIG = true
@@ -616,10 +600,7 @@ ifeq ($(HAS_SYSTEM_OPENSSL_NPN),true)
 CPPFLAGS += -DTSI_OPENSSL_ALPN_SUPPORT=0
 LIBS_SECURE = $(OPENSSL_LIBS)
 endif # HAS_SYSTEM_OPENSSL_NPN
-ifeq ($(OPENSSL_REQUIRES_DL),true)
-LIBS_SECURE += dl
 PC_LIBS_SECURE = $(addprefix -l, $(LIBS_SECURE))
-endif # OPENSSL_REQUIRES_DL=true
 endif # EMBED_OPENSSL
 endif # NO_SECURE
 

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -133,11 +133,29 @@
   PROTOC ?= protoc
   DTRACE ?= dtrace
   CONFIG ?= opt
-  CC ?= $(CC_$(CONFIG))
-  CXX ?= $(CXX_$(CONFIG))
-  LD ?= $(LD_$(CONFIG))
+  # Doing X ?= Y is the same as:
+  # ifeq ($(origin X), undefined)
+  #  X = Y
+  # endif
+  # but some variables, such as CC, CXX, LD or AR, have defaults.
+  # So instead of using ?= on them, we need to check their origin.
+  # See:
+  #  https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html
+  #  https://www.gnu.org/software/make/manual/html_node/Flavors.html#index-_003f_003d
+  #  https://www.gnu.org/software/make/manual/html_node/Origin-Function.html
+  ifeq ($(origin CC), default)
+  CC = $(CC_$(CONFIG))
+  endif
+  ifeq ($(origin CXX), default)
+  CXX = $(CXX_$(CONFIG))
+  endif
+  ifeq ($(origin LD), default)
+  LD = $(LD_$(CONFIG))
+  endif
   LDXX ?= $(LDXX_$(CONFIG))
-  AR ?= ar
+  ifeq ($(origin AR), default)
+  AR = ar
+  endif
   ifeq ($(SYSTEM),Linux)
   STRIP ?= strip --strip-unneeded
   else

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -130,26 +130,26 @@
 
   prefix ?= /usr/local
 
-  PROTOC = protoc
-  DTRACE = dtrace
+  PROTOC ?= protoc
+  DTRACE ?= dtrace
   CONFIG ?= opt
-  CC = $(CC_$(CONFIG))
-  CXX = $(CXX_$(CONFIG))
-  LD = $(LD_$(CONFIG))
-  LDXX = $(LDXX_$(CONFIG))
-  AR = ar
+  CC ?= $(CC_$(CONFIG))
+  CXX ?= $(CXX_$(CONFIG))
+  LD ?= $(LD_$(CONFIG))
+  LDXX ?= $(LDXX_$(CONFIG))
+  AR ?= ar
   ifeq ($(SYSTEM),Linux)
-  STRIP = strip --strip-unneeded
+  STRIP ?= strip --strip-unneeded
   else
   ifeq ($(SYSTEM),Darwin)
-  STRIP = strip -x
+  STRIP ?= strip -x
   else
-  STRIP = strip
+  STRIP ?= strip
   endif
   endif
-  INSTALL = install
-  RM = rm -f
-  PKG_CONFIG = pkg-config
+  INSTALL ?= install
+  RM ?= rm -f
+  PKG_CONFIG ?= pkg-config
 
   ifndef VALID_CONFIG_$(CONFIG)
   $(error Invalid CONFIG value '$(CONFIG)')
@@ -170,10 +170,10 @@
   # cross-compiling, you can override these variables from GNU make's
   # command line: make CC=cross-gcc HOST_CC=gcc
 
-  HOST_CC = $(CC)
-  HOST_CXX = $(CXX)
-  HOST_LD = $(LD)
-  HOST_LDXX = $(LDXX)
+  HOST_CC ?= $(CC)
+  HOST_CXX ?= $(CXX)
+  HOST_LD ?= $(LD)
+  HOST_LDXX ?= $(LDXX)
 
   ifdef EXTRA_DEFINES
   DEFINES += $(EXTRA_DEFINES)
@@ -315,14 +315,6 @@
   IS_GIT_FOLDER = true
   endif
 
-  ifeq ($(SYSTEM),Linux)
-  OPENSSL_REQUIRES_DL = true
-  endif
-
-  ifeq ($(SYSTEM),Darwin)
-  OPENSSL_REQUIRES_DL = true
-  endif
-
   ifeq ($(HAS_PKG_CONFIG),true)
   OPENSSL_ALPN_CHECK_CMD = $(PKG_CONFIG) --atleast-version=1.0.2 openssl
   OPENSSL_NPN_CHECK_CMD = $(PKG_CONFIG) --atleast-version=1.0.1 openssl
@@ -340,11 +332,6 @@
   OPENSSL_NPN_CHECK_CMD = $(CC) $(CFLAGS) $(CPPFLAGS) -o $(TMPOUT) test/build/openssl-npn.c $(addprefix -l, $(OPENSSL_LIBS)) $(LDFLAGS)
   ZLIB_CHECK_CMD = $(CC) $(CFLAGS) $(CPPFLAGS) -o $(TMPOUT) test/build/zlib.c -lz $(LDFLAGS)
   PROTOBUF_CHECK_CMD = $(CXX) $(CXXFLAGS) $(CPPFLAGS) -o $(TMPOUT) test/build/protobuf.cc -lprotobuf $(LDFLAGS)
-
-  ifeq ($(OPENSSL_REQUIRES_DL),true)
-  OPENSSL_ALPN_CHECK_CMD += -ldl
-  OPENSSL_NPN_CHECK_CMD += -ldl
-  endif
 
   endif # HAS_PKG_CONFIG
 
@@ -509,9 +496,6 @@
   OPENSSL_MERGE_LIBS += $(LIBDIR)/$(CONFIG)/libboringssl.a
   # need to prefix these to ensure overriding system libraries
   CPPFLAGS := -Ithird_party/boringssl/include $(CPPFLAGS)
-  ifeq ($(OPENSSL_REQUIRES_DL),true)
-  LIBS_SECURE = dl
-  endif # OPENSSL_REQUIRES_DL
   else # EMBED_OPENSSL=false
   ifeq ($(HAS_PKG_CONFIG),true)
   OPENSSL_PKG_CONFIG = true
@@ -531,10 +515,7 @@
   CPPFLAGS += -DTSI_OPENSSL_ALPN_SUPPORT=0
   LIBS_SECURE = $(OPENSSL_LIBS)
   endif # HAS_SYSTEM_OPENSSL_NPN
-  ifeq ($(OPENSSL_REQUIRES_DL),true)
-  LIBS_SECURE += dl
   PC_LIBS_SECURE = $(addprefix -l, $(LIBS_SECURE))
-  endif # OPENSSL_REQUIRES_DL=true
   endif # EMBED_OPENSSL
   endif # NO_SECURE
 


### PR DESCRIPTION
 -) Adding question marks to important tools so they can be overriden from environment variables.
 -) Removing all traces of -ldl since BoringSSL doesn't implement OpenSSL's DSO and doesn't require it.