### PR TITLE
Remove bad error return in census_initialize

### DIFF
--- a/src/core/census/initialize.c
+++ b/src/core/census/initialize.c
@@ -37,9 +37,7 @@ static int features_enabled = CENSUS_FEATURE_NONE;
 
 int census_initialize(int features) {
   if (features_enabled != CENSUS_FEATURE_NONE) {
-    return 1;
-  }
-  if (features == CENSUS_FEATURE_NONE) {
+    // Must have been a previous call to census_initialize; return error
     return 1;
   }
   features_enabled = features;


### PR DESCRIPTION
This removes the error message from src/core/surface/init.c where it calls:

 if (census_initialize(census_supported())) { /* enable all features. */
   gpr_log(GPR_ERROR, "Could not initialize census.");

In the case where census_supported() == CENSUS_FEATURE_NONE (the current default), you would get the error message, which is incorrect behavior.