### PR TITLE
Don't bother with full build in java docker

### DIFF
--- a/tools/dockerfile/grpc_interop_java/Dockerfile
+++ b/tools/dockerfile/grpc_interop_java/Dockerfile
@@ -51,7 +51,7 @@ ENV PATH $PATH:$JAVA_HOME/bin
 # Trigger download of as many Gradle artifacts as possible.
 RUN git clone --recursive --depth 1 https://github.com/grpc/grpc-java.git && \
   cd grpc-java && \
-  ./gradlew build -PskipCodegen=true && \
+  ./gradlew :grpc-interop-testing:installDist -PskipCodegen=true && \
   rm -r "$(pwd)"
 
 # Define the default command.


### PR DESCRIPTION
The command in the docker image is just to prepare a cache to reduce
download for later builds. We only run installDist in build_interop.sh,
so don't bother with full build.

Fixes grpc/grpc-java#1370