### PR TITLE
Compile Node library on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ htmlcov/
 dist/
 *.egg
 
+# Node installation output
+node_modules/
+src/node/extension_binary/
+
 # gcov coverage data
 reports
 coverage

--- a/binding.gyp
+++ b/binding.gyp
@@ -118,10 +118,17 @@
           # when including the Node headers. The remedy for this is to remove
           # the OpenSSL headers, from the downloaded Node development package,
           # which is typically located in `.node-gyp` in your home directory.
-          'target_name': 'windows_build_warning',
+          'target_name': 'WINDOWS_BUILD_WARNING',
           'actions': [
             {
-              'message': "IMPORTANT: Due to https://github.com/nodejs/node/issues/4932, to build this library on Windows, you must first remove <(node_root_dir)/include/node/openssl/"
+              'action_name': 'WINDOWS_BUILD_WARNING',
+              'inputs': [
+                'package.json'
+              ],
+              'outputs': [
+                'ignore_this_part'
+              ],
+              'action': ['echo', 'IMPORTANT: Due to https://github.com/nodejs/node/issues/4932, to build this library on Windows, you must first remove <(node_root_dir)/include/node/openssl/']
             }
           ]
         },

--- a/binding.gyp
+++ b/binding.gyp
@@ -37,7 +37,6 @@
 # Some of this file is built with the help of
 # https://n8.io/converting-a-c-library-to-gyp/
 {
-  # TODO: Finish windows support
   'target_defaults': {
     'include_dirs': [
       '.',
@@ -64,16 +63,16 @@
           "ws2_32"
         ]
       }, { # OS != "win"
-	  # Empirically, Node only exports ALPN symbols if its major version is >0.
-	  # io.js always reports versions >0 and always exports ALPN symbols.
-	  # Therefore, Node's major version will be truthy if and only if it
-	  # supports ALPN. The output of "node -v" is v[major].[minor].[patch],
-	  # like "v4.1.1" in a recent version. We use cut to split by period and
-	  # take the first field (resulting in "v[major]"), then use cut again
-	  # to take all but the first character, removing the "v".
-	'defines': [
-	  'TSI_OPENSSL_ALPN_SUPPORT=<!(node --version | cut -d. -f1 | cut -c2-)'
-	],
+          # Empirically, Node only exports ALPN symbols if its major version is >0.
+          # io.js always reports versions >0 and always exports ALPN symbols.
+          # Therefore, Node's major version will be truthy if and only if it
+          # supports ALPN. The output of "node -v" is v[major].[minor].[patch],
+          # like "v4.1.1" in a recent version. We use cut to split by period and
+          # take the first field (resulting in "v[major]"), then use cut again
+          # to take all but the first character, removing the "v".
+        'defines': [
+          'TSI_OPENSSL_ALPN_SUPPORT=<!(node --version | cut -d. -f1 | cut -c2-)'
+        ],
         'variables': {
           'config': '<!(echo $CONFIG)'
         },
@@ -110,6 +109,22 @@
   'conditions': [
     ['OS == "win"', {
       'targets': [
+        {
+          # IMPORTANT WINDOWS BUILD INFORMATION
+          # This library does not build on Windows without modifying the Node
+          # development packages that node-gyp downloads in order to build.
+          # Due to https://github.com/nodejs/node/issues/4932, the headers for
+          # BoringSSL conflict with the OpenSSL headers included by default
+          # when including the Node headers. The remedy for this is to remove
+          # the OpenSSL headers, from the downloaded Node development package,
+          # which is typically located in `.node-gyp` in your home directory.
+          'target_name': 'windows_build_warning',
+          'actions': [
+            {
+              'message': "IMPORTANT: Due to https://github.com/nodejs/node/issues/4932, to build this library on Windows, you must first remove <(node_root_dir)/include/node/openssl/"
+            }
+          ]
+        },
         # Only want to compile BoringSSL and zlib under Windows
         {
           'cflags': [
@@ -417,8 +432,7 @@
             'third_party/boringssl/ssl/t1_enc.c',
             'third_party/boringssl/ssl/t1_lib.c',
             'third_party/boringssl/ssl/tls_record.c',
-          ],
-          "include_dirs": [ "third_party/boringssl/include" ]
+          ]
         },
         {
           'cflags': [
@@ -447,8 +461,7 @@
             'third_party/zlib/trees.c',
             'third_party/zlib/uncompr.c',
             'third_party/zlib/zutil.c',
-          ],
-          "include_dirs": [ "third_party/boringssl/include" ]
+          ]
         },
       ]
     }]

--- a/binding.gyp
+++ b/binding.gyp
@@ -37,29 +37,46 @@
 # Some of this file is built with the help of
 # https://n8.io/converting-a-c-library-to-gyp/
 {
-  'variables': {
-    'config': '<!(echo $CONFIG)'
-  },
   # TODO: Finish windows support
   'target_defaults': {
-      # Empirically, Node only exports ALPN symbols if its major version is >0.
-      # io.js always reports versions >0 and always exports ALPN symbols.
-      # Therefore, Node's major version will be truthy if and only if it
-      # supports ALPN. The output of "node -v" is v[major].[minor].[patch],
-      # like "v4.1.1" in a recent version. We use cut to split by period and
-      # take the first field (resulting in "v[major]"), then use cut again
-      # to take all but the first character, removing the "v".
-    'defines': [
-      'TSI_OPENSSL_ALPN_SUPPORT=<!(node --version | cut -d. -f1 | cut -c2-)'
-    ],
     'include_dirs': [
       '.',
       'include'
     ],
     'conditions': [
       ['OS == "win"', {
-        "include_dirs": [ "third_party/boringssl/include" ]
-      }, {
+        "include_dirs": [ "third_party/boringssl/include" ],
+        "defines": [
+          '_WIN32_WINNT=0x0600',
+          'WIN32_LEAN_AND_MEAN',
+          '_HAS_EXCEPTIONS=0',
+          'UNICODE',
+          '_UNICODE',
+          'NOMINMAX',
+          'OPENSSL_NO_ASM'
+        ],
+        "msvs_settings": {
+          'VCCLCompilerTool': {
+            'RuntimeLibrary': 1, # static debug
+          }
+        },
+        "libraries": [
+          "ws2_32"
+        ]
+      }, { # OS != "win"
+	  # Empirically, Node only exports ALPN symbols if its major version is >0.
+	  # io.js always reports versions >0 and always exports ALPN symbols.
+	  # Therefore, Node's major version will be truthy if and only if it
+	  # supports ALPN. The output of "node -v" is v[major].[minor].[patch],
+	  # like "v4.1.1" in a recent version. We use cut to split by period and
+	  # take the first field (resulting in "v[major]"), then use cut again
+	  # to take all but the first character, removing the "v".
+	'defines': [
+	  'TSI_OPENSSL_ALPN_SUPPORT=<!(node --version | cut -d. -f1 | cut -c2-)'
+	],
+        'variables': {
+          'config': '<!(echo $CONFIG)'
+        },
         'include_dirs': [
           '<(node_root_dir)/deps/openssl/openssl/include',
           '<(node_root_dir)/deps/zlib'

--- a/src/node/ext/node_grpc.cc
+++ b/src/node/ext/node_grpc.cc
@@ -112,8 +112,8 @@ void InitCallErrorConstants(Local<Object> exports) {
   Nan::Set(exports, Nan::New("callError").ToLocalChecked(), call_error);
   Local<Value> OK(Nan::New<Uint32, uint32_t>(GRPC_CALL_OK));
   Nan::Set(call_error, Nan::New("OK").ToLocalChecked(), OK);
-  Local<Value> ERROR(Nan::New<Uint32, uint32_t>(GRPC_CALL_ERROR));
-  Nan::Set(call_error, Nan::New("ERROR").ToLocalChecked(), ERROR);
+  Local<Value> CALL_ERROR(Nan::New<Uint32, uint32_t>(GRPC_CALL_ERROR));
+  Nan::Set(call_error, Nan::New("ERROR").ToLocalChecked(), CALL_ERROR);
   Local<Value> NOT_ON_SERVER(
       Nan::New<Uint32, uint32_t>(GRPC_CALL_ERROR_NOT_ON_SERVER));
   Nan::Set(call_error, Nan::New("NOT_ON_SERVER").ToLocalChecked(),

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -39,29 +39,45 @@
   # Some of this file is built with the help of
   # https://n8.io/converting-a-c-library-to-gyp/
   {
-    'variables': {
-      'config': '<!(echo $CONFIG)'
-    },
-    # TODO: Finish windows support
     'target_defaults': {
-        # Empirically, Node only exports ALPN symbols if its major version is >0.
-        # io.js always reports versions >0 and always exports ALPN symbols.
-        # Therefore, Node's major version will be truthy if and only if it
-        # supports ALPN. The output of "node -v" is v[major].[minor].[patch],
-        # like "v4.1.1" in a recent version. We use cut to split by period and
-        # take the first field (resulting in "v[major]"), then use cut again
-        # to take all but the first character, removing the "v".
-      'defines': [
-        'TSI_OPENSSL_ALPN_SUPPORT=<!(node --version | cut -d. -f1 | cut -c2-)'
-      ],
       'include_dirs': [
         '.',
         'include'
       ],
       'conditions': [
         ['OS == "win"', {
-          "include_dirs": [ "third_party/boringssl/include" ]
-        }, {
+          "include_dirs": [ "third_party/boringssl/include" ],
+          "defines": [
+            '_WIN32_WINNT=0x0600',
+            'WIN32_LEAN_AND_MEAN',
+            '_HAS_EXCEPTIONS=0',
+            'UNICODE',
+            '_UNICODE',
+            'NOMINMAX',
+            'OPENSSL_NO_ASM'
+          ],
+          "msvs_settings": {
+            'VCCLCompilerTool': {
+              'RuntimeLibrary': 1, # static debug
+            }
+          },
+          "libraries": [
+            "ws2_32"
+          ]
+        }, { # OS != "win"
+            # Empirically, Node only exports ALPN symbols if its major version is >0.
+            # io.js always reports versions >0 and always exports ALPN symbols.
+            # Therefore, Node's major version will be truthy if and only if it
+            # supports ALPN. The output of "node -v" is v[major].[minor].[patch],
+            # like "v4.1.1" in a recent version. We use cut to split by period and
+            # take the first field (resulting in "v[major]"), then use cut again
+            # to take all but the first character, removing the "v".
+          'defines': [
+            'TSI_OPENSSL_ALPN_SUPPORT=<!(node --version | cut -d. -f1 | cut -c2-)'
+          ],
+          'variables': {
+            'config': '<!(echo $CONFIG)'
+          },
           'include_dirs': [
             '<(node_root_dir)/deps/openssl/openssl/include',
             '<(node_root_dir)/deps/zlib'
@@ -95,6 +111,22 @@
     'conditions': [
       ['OS == "win"', {
         'targets': [
+          {
+            # IMPORTANT WINDOWS BUILD INFORMATION
+            # This library does not build on Windows without modifying the Node
+            # development packages that node-gyp downloads in order to build.
+            # Due to https://github.com/nodejs/node/issues/4932, the headers for
+            # BoringSSL conflict with the OpenSSL headers included by default
+            # when including the Node headers. The remedy for this is to remove
+            # the OpenSSL headers, from the downloaded Node development package,
+            # which is typically located in `.node-gyp` in your home directory.
+            'target_name': 'windows_build_warning',
+            'actions': [
+              {
+                'message': "IMPORTANT: Due to https://github.com/nodejs/node/issues/4932, to build this library on Windows, you must first remove <(node_root_dir)/include/node/openssl/"
+              }
+            ]
+          },
           # Only want to compile BoringSSL and zlib under Windows
           % for module in node_modules:
           % for lib in libs:
@@ -117,8 +149,7 @@
               % for source in lib.src:
               '${source}',
               % endfor
-            ],
-            "include_dirs": [ "third_party/boringssl/include" ]
+            ]
           },
           % endif
           % endfor

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -120,10 +120,17 @@
             # when including the Node headers. The remedy for this is to remove
             # the OpenSSL headers, from the downloaded Node development package,
             # which is typically located in `.node-gyp` in your home directory.
-            'target_name': 'windows_build_warning',
+            'target_name': 'WINDOWS_BUILD_WARNING',
             'actions': [
               {
-                'message': "IMPORTANT: Due to https://github.com/nodejs/node/issues/4932, to build this library on Windows, you must first remove <(node_root_dir)/include/node/openssl/"
+                'action_name': 'WINDOWS_BUILD_WARNING',
+                'inputs': [
+                  'package.json'
+                ],
+                'outputs': [
+                  'ignore_this_part'
+                ],
+                'action': ['echo', 'IMPORTANT: Due to https://github.com/nodejs/node/issues/4932, to build this library on Windows, you must first remove <(node_root_dir)/include/node/openssl/']
               }
             ]
           },


### PR DESCRIPTION
I added a message about the problem with OpenSSL that prints when building on Windows, plus a comment about it in the gyp file, but the message may get lost among the hundreds of lines of compiler warnings and errors. This fixes #3922 and fixes #4702.