### PR TITLE
Mitigate Python build directory naming conflict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ libs
 objs
 
 # Python items
+python_build/
 .coverage*
 .eggs
 .tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,9 @@
 [coverage:run]
 plugins = Cython.Coverage
 
+[build]
+build_base=python_build
+
 [build_ext]
 inplace=1
 


### PR DESCRIPTION
On Mac and Windows, the default directory name conflicts with the `BUILD` file we have. This is relevant to people building from source.