### PR TITLE
Create .zip file with C# nuget packages

### DIFF
--- a/src/csharp/build_packages.bat
+++ b/src/csharp/build_packages.bat
@@ -49,6 +49,10 @@ endlocal
 @rem copy resulting nuget packages to artifacts directory
 xcopy /Y /I *.nupkg ..\..\artifacts\
 
+@rem create a zipfile with the artifacts as well
+powershell -Command "Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::CreateFromDirectory('..\..\artifacts', 'csharp_nugets.zip');"
+xcopy /Y /I csharp_nugets.zip ..\..\artifacts\
+
 goto :EOF
 
 :error

--- a/templates/src/csharp/build_packages.bat.template
+++ b/templates/src/csharp/build_packages.bat.template
@@ -53,7 +53,7 @@
   
   @rem create a zipfile with the artifacts as well
   powershell -Command "Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::CreateFromDirectory('..\..\artifacts', 'csharp_nugets.zip');"
-  xcopy /Y /I csharp_nugets.zip ..\..\artifacts{"\\"}
+  xcopy /Y /I csharp_nugets.zip ..\..\artifacts${"\\"}
   
   goto :EOF
   

--- a/templates/src/csharp/build_packages.bat.template
+++ b/templates/src/csharp/build_packages.bat.template
@@ -51,6 +51,10 @@
   @rem copy resulting nuget packages to artifacts directory
   xcopy /Y /I *.nupkg ..\..\artifacts${"\\"}
   
+  @rem create a zipfile with the artifacts as well
+  powershell -Command "Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::CreateFromDirectory('..\..\artifacts', 'csharp_nugets.zip');"
+  xcopy /Y /I csharp_nugets.zip ..\..\artifacts\
+  
   goto :EOF
   
   :error

--- a/templates/src/csharp/build_packages.bat.template
+++ b/templates/src/csharp/build_packages.bat.template
@@ -53,7 +53,7 @@
   
   @rem create a zipfile with the artifacts as well
   powershell -Command "Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::CreateFromDirectory('..\..\artifacts', 'csharp_nugets.zip');"
-  xcopy /Y /I csharp_nugets.zip ..\..\artifacts\
+  xcopy /Y /I csharp_nugets.zip ..\..\artifacts{"\\"}
   
   goto :EOF
   


### PR DESCRIPTION
Once C# nugets are built, also create a zip (this will eventually simplify the testing chain).