### PR TITLE
Replacing grpc_max_auth_token_lifetime by an accessor.

### DIFF
--- a/include/grpc/grpc_security.h
+++ b/include/grpc/grpc_security.h
@@ -200,7 +200,7 @@ GRPC_API grpc_call_credentials *grpc_composite_call_credentials_create(
 GRPC_API grpc_call_credentials *grpc_google_compute_engine_credentials_create(
     void *reserved);
 
-extern const gpr_timespec grpc_max_auth_token_lifetime;
+GRPC_API gpr_timespec grpc_max_auth_token_lifetime();
 
 /* Creates a JWT credentials object. May return NULL if the input is invalid.
    - json_key is the JSON key string containing the client's private key.

--- a/src/core/security/google_default_credentials.c
+++ b/src/core/security/google_default_credentials.c
@@ -157,7 +157,7 @@ static grpc_call_credentials *create_default_creds_from_path(char *creds_path) {
   if (grpc_auth_json_key_is_valid(&key)) {
     result =
         grpc_service_account_jwt_access_credentials_create_from_auth_json_key(
-            key, grpc_max_auth_token_lifetime);
+            key, grpc_max_auth_token_lifetime());
     goto end;
   }
 

--- a/src/core/security/json_token.c
+++ b/src/core/security/json_token.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/core/security/json_token.c
+++ b/src/core/security/json_token.c
@@ -49,7 +49,13 @@
 /* --- Constants. --- */
 
 /* 1 hour max. */
-const gpr_timespec grpc_max_auth_token_lifetime = {3600, 0, GPR_TIMESPAN};
+gpr_timespec grpc_max_auth_token_lifetime() {
+  gpr_timespec out;
+  out.tv_sec = 3600;
+  out.tv_nsec = 0;
+  out.clock_type = GPR_TIMESPAN;
+  return out;
+}
 
 #define GRPC_JWT_RSA_SHA256_ALGORITHM "RS256"
 #define GRPC_JWT_TYPE "JWT"
@@ -211,9 +217,9 @@ static char *encoded_jwt_claim(const grpc_auth_json_key *json_key,
   gpr_timespec expiration = gpr_time_add(now, token_lifetime);
   char now_str[GPR_LTOA_MIN_BUFSIZE];
   char expiration_str[GPR_LTOA_MIN_BUFSIZE];
-  if (gpr_time_cmp(token_lifetime, grpc_max_auth_token_lifetime) > 0) {
+  if (gpr_time_cmp(token_lifetime, grpc_max_auth_token_lifetime()) > 0) {
     gpr_log(GPR_INFO, "Cropping token lifetime to maximum allowed value.");
-    expiration = gpr_time_add(now, grpc_max_auth_token_lifetime);
+    expiration = gpr_time_add(now, grpc_max_auth_token_lifetime());
   }
   int64_ttoa(now.tv_sec, now_str);
   int64_ttoa(expiration.tv_sec, expiration_str);

--- a/test/core/security/create_jwt.c
+++ b/test/core/security/create_jwt.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/test/core/security/create_jwt.c
+++ b/test/core/security/create_jwt.c
@@ -62,7 +62,7 @@ void create_jwt(const char *json_key_file_path, const char *service_url,
   }
   jwt = grpc_jwt_encode_and_sign(
       &key, service_url == NULL ? GRPC_JWT_OAUTH2_AUDIENCE : service_url,
-      grpc_max_auth_token_lifetime, scope);
+      grpc_max_auth_token_lifetime(), scope);
   grpc_auth_json_key_destruct(&key);
   if (jwt == NULL) {
     fprintf(stderr, "Could not create JWT.\n");

--- a/test/core/security/credentials_test.c
+++ b/test/core/security/credentials_test.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/test/core/security/credentials_test.c
+++ b/test/core/security/credentials_test.c
@@ -734,7 +734,7 @@ static void validate_jwt_encode_and_sign_params(
                     "777-abaslkan11hlb6nmim3bpspl31ud@developer."
                     "gserviceaccount.com") == 0);
   if (scope != NULL) GPR_ASSERT(strcmp(scope, test_scope) == 0);
-  GPR_ASSERT(!gpr_time_cmp(token_lifetime, grpc_max_auth_token_lifetime));
+  GPR_ASSERT(!gpr_time_cmp(token_lifetime, grpc_max_auth_token_lifetime()));
 }
 
 static char *encode_and_sign_jwt_success(const grpc_auth_json_key *json_key,
@@ -794,7 +794,7 @@ static void test_jwt_creds_success(void) {
                                             NULL};
   grpc_call_credentials *jwt_creds =
       grpc_service_account_jwt_access_credentials_create(
-          json_key_string, grpc_max_auth_token_lifetime, NULL);
+          json_key_string, grpc_max_auth_token_lifetime(), NULL);
 
   /* First request: jwt_encode_and_sign should be called. */
   grpc_jwt_encode_and_sign_set_override(encode_and_sign_jwt_success);
@@ -832,7 +832,7 @@ static void test_jwt_creds_signing_failure(void) {
                                             NULL};
   grpc_call_credentials *jwt_creds =
       grpc_service_account_jwt_access_credentials_create(
-          json_key_string, grpc_max_auth_token_lifetime, NULL);
+          json_key_string, grpc_max_auth_token_lifetime(), NULL);
 
   grpc_jwt_encode_and_sign_set_override(encode_and_sign_jwt_failure);
   grpc_call_credentials_get_request_metadata(

--- a/test/core/security/json_token_test.c
+++ b/test/core/security/json_token_test.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/test/core/security/json_token_test.c
+++ b/test/core/security/json_token_test.c
@@ -330,7 +330,7 @@ static void check_jwt_claim(grpc_json *claim, const char *expected_audience,
   issue_time.tv_sec = strtol(iat->value, NULL, 10);
 
   parsed_lifetime = gpr_time_sub(expiration, issue_time);
-  GPR_ASSERT(parsed_lifetime.tv_sec == grpc_max_auth_token_lifetime.tv_sec);
+  GPR_ASSERT(parsed_lifetime.tv_sec == grpc_max_auth_token_lifetime.tv_sec());
 }
 
 static void check_jwt_signature(const char *b64_signature, RSA *rsa_key,
@@ -361,12 +361,12 @@ static void check_jwt_signature(const char *b64_signature, RSA *rsa_key,
 static char *service_account_creds_jwt_encode_and_sign(
     const grpc_auth_json_key *key) {
   return grpc_jwt_encode_and_sign(key, GRPC_JWT_OAUTH2_AUDIENCE,
-                                  grpc_max_auth_token_lifetime, test_scope);
+                                  grpc_max_auth_token_lifetime(), test_scope);
 }
 
 static char *jwt_creds_jwt_encode_and_sign(const grpc_auth_json_key *key) {
   return grpc_jwt_encode_and_sign(key, test_service_url,
-                                  grpc_max_auth_token_lifetime, NULL);
+                                  grpc_max_auth_token_lifetime(), NULL);
 }
 
 static void service_account_creds_check_jwt_claim(grpc_json *claim) {


### PR DESCRIPTION
Fixing #4981.