### PR TITLE
Support falling back on older secure_getenv/getenv versions on older glibc

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -153,18 +153,13 @@
 #if __GLIBC_PREREQ(2, 10)
 #define GPR_LINUX_SOCKETUTILS 1
 #endif
-#if __GLIBC_PREREQ(2, 17)
+#endif
 #define GPR_LINUX_ENV 1
-#endif
-#endif
 #ifndef GPR_LINUX_EVENTFD
 #define GPR_POSIX_NO_SPECIAL_WAKEUP_FD 1
 #endif
 #ifndef GPR_LINUX_SOCKETUTILS
 #define GPR_POSIX_SOCKETUTILS
-#endif
-#ifndef GPR_LINUX_ENV
-#define GPR_POSIX_ENV 1
 #endif
 #define GPR_POSIX_FILE 1
 #define GPR_POSIX_STRING 1

--- a/src/core/support/env_linux.c
+++ b/src/core/support/env_linux.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/core/support/env_linux.c
+++ b/src/core/support/env_linux.c
@@ -61,7 +61,7 @@ char *__attribute__((weak)) __secure_getenv(const char *name);
 char *gpr_getenv(const char *name) {
   static char *(*getenv_func)(const char *) = secure_getenv;
   /* Check to see which getenv variant is supported (go from most
-   * to least secure */
+   * to least secure) */
   if (getenv_func == NULL) {
     getenv_func = __secure_getenv;
     if (getenv_func == NULL) {

--- a/src/core/support/env_linux.c
+++ b/src/core/support/env_linux.c
@@ -49,11 +49,19 @@
 
 #include "src/core/support/string.h"
 
+/* Declare weak symbols for versions of secure_getenv that *may* be
+ * on a users machine. Older libc's call this __secure_getenv, even
+ * older don't support the functionality.
+ *
+ * If a symbol is not present, these will be equal to NULL.
+ */
 char *__attribute__((weak)) secure_getenv(const char *name);
 char *__attribute__((weak)) __secure_getenv(const char *name);
 
 char *gpr_getenv(const char *name) {
   static char *(*getenv_func)(const char *) = secure_getenv;
+  /* Check to see which getenv variant is supported (go from most
+   * to least secure */
   if (getenv_func == NULL) {
     getenv_func = __secure_getenv;
     if (getenv_func == NULL) {


### PR DESCRIPTION
@jboeuf, @jtattermusch thoughts