### PR TITLE
Implement core_count RPC for Node.JS

### DIFF
--- a/src/node/performance/worker_service_impl.js
+++ b/src/node/performance/worker_service_impl.js
@@ -33,6 +33,7 @@
 
 'use strict';
 
+var os = require('os');
 var BenchmarkClient = require('./benchmark_client');
 var BenchmarkServer = require('./benchmark_server');
 
@@ -129,4 +130,8 @@ exports.runServer = function runServer(call) {
       call.end();
     });
   });
+};
+
+exports.coreCount = function coreCount(call, callback) {
+  callback(null, {cores: os.cpus().length});
 };


### PR DESCRIPTION
The master version of control.proto and services.proto were updated and this should be implemented, though it's not of particular use right now. Let me know if it's off-base.
