### PR TITLE
Removing memcpy's wrapper for windows-ruby.

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -92,7 +92,8 @@ if grpc_config == 'gcov'
   $LDFLAGS << ' -fprofile-arcs -ftest-coverage -rdynamic'
 end
 
-$LDFLAGS << ' -Wl,-wrap,memcpy'
+$LDFLAGS << ' -Wl,-wrap,memcpy' if RUBY_PLATFORM =~ /linux/
+$LDFLAGS << ' -static' if windows
 
 $CFLAGS << ' -std=c99 '
 $CFLAGS << ' -Wall '


### PR DESCRIPTION
Also, apparently, -static went lost in the merge at some point. Let's avoid depending on weird mingw dlls that aren't widely installed.