### PR TITLE
Fix clean up logic when failing to add a secure port.

### DIFF
--- a/src/core/security/server_secure_chttp2.c
+++ b/src/core/security/server_secure_chttp2.c
@@ -191,7 +191,6 @@ int grpc_server_add_secure_http2_port(grpc_server *server, const char *addr,
     gpr_log(GPR_ERROR,
             "Unable to create secure server with credentials of type %s.",
             creds->type);
-    // UNREF sc
     goto error;
   }
   sc->channel_args = grpc_server_get_channel_args(server);
@@ -199,7 +198,6 @@ int grpc_server_add_secure_http2_port(grpc_server *server, const char *addr,
   /* resolve address */
   resolved = grpc_blocking_resolve_address(addr, "https");
   if (!resolved) {
-    // UNREF sc
     goto error;
   }
   state = gpr_malloc(sizeof(*state));
@@ -207,9 +205,6 @@ int grpc_server_add_secure_http2_port(grpc_server *server, const char *addr,
   grpc_closure_init(&state->destroy_closure, destroy_done, state);
   tcp = grpc_tcp_server_create(&state->destroy_closure);
   if (!tcp) {
-    // UNREF sc
-    // destroy resolved
-    // free state
     goto error;
   }
 
@@ -217,7 +212,6 @@ int grpc_server_add_secure_http2_port(grpc_server *server, const char *addr,
   state->tcp = tcp;
   state->sc = sc;
   state->creds = grpc_server_credentials_ref(creds);
-
   state->is_shutdown = 0;
   gpr_mu_init(&state->mu);
   gpr_ref_init(&state->refcount, 1);
@@ -238,7 +232,6 @@ int grpc_server_add_secure_http2_port(grpc_server *server, const char *addr,
   if (count == 0) {
     gpr_log(GPR_ERROR, "No address added out of total %d resolved",
             resolved->naddrs);
-    // UNREF tcp
     goto error;
   }
   if (count != resolved->naddrs) {

--- a/test/core/surface/server_chttp2_test.c
+++ b/test/core/surface/server_chttp2_test.c
@@ -32,7 +32,14 @@
  */
 
 #include <grpc/grpc.h>
+#include <grpc/grpc_security.h>
+#include <grpc/support/alloc.h>
+#include <grpc/support/host_port.h>
 #include <grpc/support/log.h>
+#include <grpc/support/time.h>
+#include "src/core/security/credentials.h"
+#include "src/core/tsi/fake_transport_security.h"
+#include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
 
 void test_unparsable_target(void) {
@@ -40,10 +47,31 @@ void test_unparsable_target(void) {
   GPR_ASSERT(port == 0);
 }
 
+void test_add_same_port_twice() {
+  int port = grpc_pick_unused_port_or_die();
+  char *addr = NULL;
+  grpc_completion_queue *cq = grpc_completion_queue_create(NULL);
+  grpc_server *server = grpc_server_create(NULL, NULL);
+  grpc_server_credentials *fake_creds =
+      grpc_fake_transport_security_server_credentials_create();
+  gpr_join_host_port(&addr, "localhost", port);
+  GPR_ASSERT(grpc_server_add_secure_http2_port(server, addr, fake_creds));
+  GPR_ASSERT(grpc_server_add_secure_http2_port(server, addr, fake_creds) == 0);
+
+  grpc_server_credentials_release(fake_creds);
+  gpr_free(addr);
+  grpc_server_shutdown_and_notify(server, cq, NULL);
+  grpc_completion_queue_pluck(cq, NULL, gpr_inf_future(GPR_CLOCK_REALTIME),
+                              NULL);
+  grpc_server_destroy(server);
+  grpc_completion_queue_destroy(cq);
+}
+
 int main(int argc, char **argv) {
   grpc_test_init(argc, argv);
   grpc_init();
   test_unparsable_target();
+  test_add_same_port_twice();
   grpc_shutdown();
   return 0;
 }


### PR DESCRIPTION
tcp_server destroy callback triggers a security_state unref and calls security_connector_shutdown. When tcp_server is not NULL, we do not manually delete those two. To rely on the tcp_server destroy logic, we need to init the security state earlier than adding ports.

Add a test which tries to add the same port twice and make sure the second does not crash.

This is the right fix for #4951 