### PR TITLE
Sync java options in example protos

### DIFF
--- a/examples/protos/helloworld.proto
+++ b/examples/protos/helloworld.proto
@@ -29,7 +29,9 @@
 
 syntax = "proto3";
 
-option java_package = "io.grpc.examples";
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.helloworld";
+option java_outer_classname = "HelloWorldProto";
 option objc_class_prefix = "HLW";
 
 package helloworld;

--- a/examples/protos/helloworld.proto
+++ b/examples/protos/helloworld.proto
@@ -1,4 +1,4 @@
-// Copyright 2015, Google Inc.
+// Copyright 2016, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/examples/protos/helloworld.proto
+++ b/examples/protos/helloworld.proto
@@ -1,4 +1,4 @@
-// Copyright 2016, Google Inc.
+// Copyright 2015-2016, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/examples/protos/route_guide.proto
+++ b/examples/protos/route_guide.proto
@@ -29,7 +29,9 @@
 
 syntax = "proto3";
 
-option java_package = "ex.grpc";
+option java_multiple_files = true;
+option java_package = "io.grpc.examples.routeguide";
+option java_outer_classname = "RouteGuideProto";
 option objc_class_prefix = "RTG";
 
 package routeguide;

--- a/examples/protos/route_guide.proto
+++ b/examples/protos/route_guide.proto
@@ -1,4 +1,4 @@
-// Copyright 2015, Google Inc.
+// Copyright 2016, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/examples/protos/route_guide.proto
+++ b/examples/protos/route_guide.proto
@@ -1,4 +1,4 @@
-// Copyright 2016, Google Inc.
+// Copyright 2015-2016, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
This makes the protos identical between this repository and the java
repository.

Fixes grpc/grpc-java#1381