### PR TITLE
Force 32bit uname when building artifacts

### DIFF
--- a/tools/run_tests/artifact_targets.py
+++ b/tools/run_tests/artifact_targets.py
@@ -97,9 +97,13 @@ class PythonArtifact:
       raise Exception('Not supported yet.')
     else:
       if self.platform == 'linux':
+        environ = {}
+        if self.arch == 'x86':
+          environ['SETARCH_CMD'] = 'linux32'
         return create_docker_jobspec(self.name,
             'tools/dockerfile/grpc_artifact_linux_%s' % self.arch,
-            'tools/run_tests/build_artifact_python.sh')
+            'tools/run_tests/build_artifact_python.sh',
+            environ=environ)
       else:
         return create_jobspec(self.name,
                               ['tools/run_tests/build_artifact_python.sh'])
@@ -127,7 +131,7 @@ class RubyArtifact:
       if self.platform == 'linux':
         environ = {}
         if self.arch == 'x86':
-          environ['SETARCH_CMD'] = 'i386'
+          environ['SETARCH_CMD'] = 'linux32'
         return create_docker_jobspec(self.name,
             'tools/dockerfile/grpc_artifact_linux_%s' % self.arch,
             'tools/run_tests/build_artifact_ruby.sh',

--- a/tools/run_tests/build_artifact_python.sh
+++ b/tools/run_tests/build_artifact_python.sh
@@ -37,7 +37,7 @@ pip install --upgrade setuptools
 
 pip install -rrequirements.txt
 
-GRPC_PYTHON_BUILD_WITH_CYTHON=1 python setup.py \
+GRPC_PYTHON_BUILD_WITH_CYTHON=1 ${SETARCH_CMD} python setup.py \
     bdist_wheel \
     sdist \
     bdist_egg_grpc_custom

--- a/tools/run_tests/build_artifact_ruby.sh
+++ b/tools/run_tests/build_artifact_ruby.sh
@@ -32,7 +32,7 @@ set -ex
 
 cd $(dirname $0)/../..
 
-bundle install
+${SETARCH_CMD} bundle install
 
 ${SETARCH_CMD} rake native gem
 


### PR DESCRIPTION
This successfully forces python to build artifacts with "i686" in their name and metadata.
This doesn't quite help for ruby, but at least changing the ruby script to stay consistent.