### PR TITLE
Enable Ruby Mac artifact build

### DIFF
--- a/tools/run_tests/artifact_targets.py
+++ b/tools/run_tests/artifact_targets.py
@@ -228,4 +228,5 @@ def targets():
           [PythonArtifact('linux', 'x86'),
            PythonArtifact('linux', 'x64'),
            RubyArtifact('linux', 'x86'),
-           RubyArtifact('linux', 'x64')])
+           RubyArtifact('linux', 'x64'),
+           RubyArtifact('macos', 'x64')])


### PR DESCRIPTION
Note that this does not necessarily build the `universal.x86_64` gem.

This fixes #4701.