### PR TITLE
Minor version bump

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,7 @@ else:
 
 setuptools.setup(
     name='grpcio',
-    version='0.12.0b6',
+    version='0.12.0b7',
     license=LICENSE,
     ext_modules=CYTHON_EXTENSION_MODULES,
     packages=list(PACKAGES),


### PR DESCRIPTION
Because versions must be bumped to drop anything into a PyPI-like repository (in this case TestPyPI).