### PR TITLE
Make sure artifacts dir exists

### DIFF
--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -32,6 +32,7 @@ set -ex
 
 cd $(dirname $0)/../..
 
+mkdir -p artifacts/
 cp -r architecture={x86,x64},language=node,platform={windows,linux,macos}/artifacts/* artifacts/ || true
 
 npm pack


### PR DESCRIPTION
in Node's build package script

Fixes
```
cp: target 'artifacts/' is not a directory
+ true
+ npm pack
grpc-0.12.0.tgz
+ cp grpc-0.12.0.tgz artifacts/
cp: cannot create regular file 'artifacts/': Not a directory
+ FAILED=true
```