### PR TITLE
Fix NativeExtensions for coreclr

### DIFF
--- a/src/csharp/Grpc.Core/Internal/NativeExtension.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeExtension.cs
@@ -106,7 +106,7 @@ namespace Grpc.Core.Internal
 
         private static string GetExecutingAssemblyDirectory()
         {
-            return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            return Path.GetDirectoryName(typeof(NativeExtension).GetTypeInfo().Assembly.Location);
         }
 
         private static string GetPlatformString()


### PR DESCRIPTION
Coreclr doesn't support Assembly.GetExecutingAssembly(),
use TypeInfo.Assembly instead, which is supported on all platforms.