### PR TITLE
Fix Profilers for coreclr

### DIFF
--- a/src/csharp/Grpc.Core/Profiling/Profilers.cs
+++ b/src/csharp/Grpc.Core/Profiling/Profilers.cs
@@ -1,6 +1,6 @@
 #region Copyright notice and license
 
-// Copyright 2015, Google Inc.
+// Copyright 2015-2016, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without

--- a/src/csharp/Grpc.Core/Profiling/Profilers.cs
+++ b/src/csharp/Grpc.Core/Profiling/Profilers.cs
@@ -111,7 +111,7 @@ namespace Grpc.Core.Profiling
 
         public void Dump(string filepath)
         {
-            using (var stream = new StreamWriter(filepath))
+            using (var stream = File.CreateText(filepath))
             {
                 Dump(stream);
             }


### PR DESCRIPTION
Coreclr doesn't support the StreamWriter(string) constructor.
Use File.CreateText() instead, which is equivalent and supported on all platforms.