### PR TITLE
Python distribution Smoketest

### DIFF
--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -52,6 +52,10 @@ import support
 
 PYTHON_STEM = os.path.dirname(os.path.abspath(__file__))
 
+BINARIES_REPOSITORY = os.environ.get(
+    'GRPC_PYTHON_BINARIES_REPOSITORY',
+    'https://storage.googleapis.com/grpc-precompiled-binaries/python/')
+
 CONF_PY_ADDENDUM = """
 extensions.append('sphinx.ext.napoleon')
 napoleon_google_docstring = True
@@ -78,10 +82,7 @@ def _get_grpc_custom_bdist_egg(decorated_basename, target_egg_basename):
   from six.moves.urllib import request
   decorated_path = decorated_basename + '.egg'
   try:
-    url = (
-        'https://storage.googleapis.com/grpc-precompiled-binaries/'
-        'python/{target}'
-            .format(target=decorated_path))
+    url = BINARIES_REPOSITORY + '/{target}'.format(target=decorated_path)
     egg_data = request.urlopen(url).read()
   except IOError as error:
     raise CommandError(

--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
@@ -31,6 +31,7 @@ cimport cpython
 
 import pkg_resources
 import os.path
+import sys
 
 # TODO(atash): figure out why the coverage tool gets confused about the Cython
 # coverage plugin when the following files don't have a '.pxi' suffix.
@@ -50,10 +51,11 @@ cdef class _ModuleState:
   cdef bint is_loaded
 
   def __cinit__(self):
-    filename = pkg_resources.resource_filename(
-        'grpc._cython', '_windows/grpc_c.64.python')
-    if not pygrpc_load_core(filename):
-      raise ImportError('failed to load core gRPC library')
+    if 'win32' in sys.platform:
+      filename = pkg_resources.resource_filename(
+          'grpc._cython', '_windows/grpc_c.64.python')
+      if not pygrpc_load_core(filename):
+        raise ImportError('failed to load core gRPC library')
     grpc_init()
     self.is_loaded = True
 

--- a/test/distrib/python/distribtest.py
+++ b/test/distrib/python/distribtest.py
@@ -1,0 +1,7 @@
+from grpc.beta import implementations
+
+# This code doesn't do much but makes sure the native extension is loaded
+# which is what we are testing here.
+channel = implementations.insecure_channel('localhost', 1000)
+del channel
+print 'Success!'

--- a/test/distrib/python/run_distrib_test.sh
+++ b/test/distrib/python/run_distrib_test.sh
@@ -32,5 +32,27 @@ set -ex
 
 cd $(dirname $0)
 
-pip install "$EXTERNAL_GIT_ROOT/input_artifacts/grpcio-0.12.0b6.tar.gz"
+# TODO(jtattermusch): replace the version number
+SDIST_ARCHIVE="$EXTERNAL_GIT_ROOT/input_artifacts/grpcio-0.12.0b8.tar.gz"
+BDIST_DIR="file://$EXTERNAL_GIT_ROOT/input_artifacts"
 
+if [ ! -f "${SDIST_ARCHIVE}" ]
+then
+  echo "Archive ${SDIST_ARCHIVE} does not exist."
+  exit 1
+fi
+
+# TODO(jtattermusch): this shouldn't be required
+pip install --upgrade six
+
+# TODO(jtattermusch): if these don't get preinstalled, pip tries to install them
+# with --use-grpc-custom-bdist option, which obviously fails.
+pip install --upgrade enum34
+pip install --upgrade futures
+
+GRPC_PYTHON_BINARIES_REPOSITORY="${BDIST_DIR}" \
+    pip install \
+    "${SDIST_ARCHIVE}" \
+    --install-option="--use-grpc-custom-bdist"
+
+python distribtest.py


### PR DESCRIPTION
-- add support for overriding location of binary dist packages
-- don't die on missing win32 resources
-- add python distrib test

Current limitations:
-- has passed successfully on debian jessie x64, not tested yet with other docker images
-- there are some TODOs in run_distrib_test.sh for further polishing