### PR TITLE
Write to dummy pads and invalid entries in lock-free stack to prevent valgrind complaints

### DIFF
--- a/src/core/support/stack_lockfree.c
+++ b/src/core/support/stack_lockfree.c
@@ -100,6 +100,7 @@ gpr_stack_lockfree *gpr_stack_lockfree_create(size_t entries) {
   /* Point the head at reserved dummy entry */
   stack->head.contents.index = INVALID_ENTRY_INDEX;
 #ifdef GPR_ARCH_64
+  // Fill in the pad to avoid confusing memcheck tools
   stack->head.contents.pad = 0;
 #endif
   stack->head.contents.aba_ctr = 0;
@@ -120,6 +121,7 @@ int gpr_stack_lockfree_push(gpr_stack_lockfree *stack, int entry) {
   /* First fill in the entry's index and aba ctr for new head */
   newhead.contents.index = (uint16_t)entry;
 #ifdef GPR_ARCH_64
+  // Fill in the pad to avoid confusing memcheck tools
   newhead.contents.pad = 0;
 #endif
 

--- a/src/core/support/stack_lockfree.c
+++ b/src/core/support/stack_lockfree.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -99,8 +99,8 @@ gpr_stack_lockfree *gpr_stack_lockfree_create(size_t entries) {
 
   /* Point the head at reserved dummy entry */
   stack->head.contents.index = INVALID_ENTRY_INDEX;
+  /* Fill in the pad and aba_ctr to avoid confusing memcheck tools */
 #ifdef GPR_ARCH_64
-  // Fill in the pad to avoid confusing memcheck tools
   stack->head.contents.pad = 0;
 #endif
   stack->head.contents.aba_ctr = 0;
@@ -121,7 +121,7 @@ int gpr_stack_lockfree_push(gpr_stack_lockfree *stack, int entry) {
   /* First fill in the entry's index and aba ctr for new head */
   newhead.contents.index = (uint16_t)entry;
 #ifdef GPR_ARCH_64
-  // Fill in the pad to avoid confusing memcheck tools
+  /* Fill in the pad to avoid confusing memcheck tools */
   newhead.contents.pad = 0;
 #endif
 

--- a/src/core/support/stack_lockfree.c
+++ b/src/core/support/stack_lockfree.c
@@ -99,6 +99,10 @@ gpr_stack_lockfree *gpr_stack_lockfree_create(size_t entries) {
 
   /* Point the head at reserved dummy entry */
   stack->head.contents.index = INVALID_ENTRY_INDEX;
+#ifdef GPR_ARCH_64
+  stack->head.contents.pad = 0;
+#endif
+  stack->head.contents.aba_ctr = 0;
   return stack;
 }
 
@@ -115,6 +119,10 @@ int gpr_stack_lockfree_push(gpr_stack_lockfree *stack, int entry) {
 
   /* First fill in the entry's index and aba ctr for new head */
   newhead.contents.index = (uint16_t)entry;
+#ifdef GPR_ARCH_64
+  newhead.contents.pad = 0;
+#endif
+
   /* Also post-increment the aba_ctr */
   curent.atm = gpr_atm_no_barrier_load(&stack->entries[entry].atm);
   newhead.contents.aba_ctr = ++curent.contents.aba_ctr;


### PR DESCRIPTION
Leaving the pad or the INVALID_ENTRY aba_ctr uninitialized causes valgrind to complain since part of the atm read is still uninitialized.

Possibly consider doing this under NDEBUG?
