### PR TITLE
Support coreclr platform detection

### DIFF
--- a/src/csharp/Grpc.Core/Internal/PlatformApis.cs
+++ b/src/csharp/Grpc.Core/Internal/PlatformApis.cs
@@ -53,12 +53,18 @@ namespace Grpc.Core.Internal
 
         static PlatformApis()
         {
+#if DNXCORE50
+            isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            isMacOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+            isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+#else
             var platform = Environment.OSVersion.Platform;
 
             // PlatformID.MacOSX is never returned, commonly used trick is to identify Mac is by using uname.
             isMacOSX = (platform == PlatformID.Unix && GetUname() == "Darwin");
             isLinux = (platform == PlatformID.Unix && !isMacOSX);
             isWindows = (platform == PlatformID.Win32NT || platform == PlatformID.Win32S || platform == PlatformID.Win32Windows);
+#endif
             isMono = Type.GetType("Mono.Runtime") != null;
         }
 


### PR DESCRIPTION
Coreclr uses different platform detection primitives to full .NET