### PR TITLE
Coreclr compatible DefaultSslRootsOverride.cs

### DIFF
--- a/src/csharp/Grpc.Core/Internal/DefaultSslRootsOverride.cs
+++ b/src/csharp/Grpc.Core/Internal/DefaultSslRootsOverride.cs
@@ -56,7 +56,7 @@ namespace Grpc.Core.Internal
         {
             lock (staticLock)
             {
-                var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(RootsPemResourceName);
+                var stream = typeof(DefaultSslRootsOverride).GetTypeInfo().Assembly.GetManifestResourceStream(RootsPemResourceName);
                 if (stream == null)
                 {
                     throw new IOException(string.Format("Error loading the embedded resource \"{0}\"", RootsPemResourceName));   


### PR DESCRIPTION
Coreclr doesn't support Assembly.GetExecutingAssembly().
Use TypeInfo.Assembly instead, which is supported on all platform.