### PR TITLE
Make Node examples package self-contained

### DIFF
--- a/examples/node/greeter_client.js
+++ b/examples/node/greeter_client.js
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,7 +33,7 @@
 
 var PROTO_PATH = __dirname + '/helloworld.proto';
 
-var grpc = require('../../');
+var grpc = require('grpc');
 var hello_proto = grpc.load(PROTO_PATH).helloworld;
 
 function main() {

--- a/examples/node/greeter_server.js
+++ b/examples/node/greeter_server.js
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -33,7 +33,7 @@
 
 var PROTO_PATH = __dirname + '/helloworld.proto';
 
-var grpc = require('../../');
+var grpc = require('grpc');
 var hello_proto = grpc.load(PROTO_PATH).helloworld;
 
 /**

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "grpc-examples",
+  "version": "0.1.0",
+  "dependencies": {
+    "grpc": "0.12.0"
+  }
+}

--- a/examples/node/route_guide/route_guide_client.js
+++ b/examples/node/route_guide/route_guide_client.js
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,13 +30,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
- 
+
 var async = require('async');
 var fs = require('fs');
 var parseArgs = require('minimist');
 var path = require('path');
 var _ = require('lodash');
-var grpc = require('../../../');
+var grpc = require('grpc');
 var routeguide = grpc.load(__dirname + '/route_guide.proto').routeguide;
 var client = new routeguide.RouteGuide('localhost:50051',
                                        grpc.Credentials.createInsecure());

--- a/examples/node/route_guide/route_guide_server.js
+++ b/examples/node/route_guide/route_guide_server.js
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,12 +30,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
- 
+
 var fs = require('fs');
 var parseArgs = require('minimist');
 var path = require('path');
 var _ = require('lodash');
-var grpc = require('../../../');
+var grpc = require('grpc');
 var routeguide = grpc.load(__dirname + '/route_guide.proto').routeguide;
 
 var COORD_FACTOR = 1e7;


### PR DESCRIPTION
This makes grpc install under the examples, instead of using the repo itself. This makes it easier to test installation and to use the examples.