### PR TITLE
Add timespan support for win32 gpr_cv_wait.

### DIFF
--- a/include/grpc/impl/codegen/sync.h
+++ b/include/grpc/impl/codegen/sync.h
@@ -115,7 +115,8 @@ GPR_API void gpr_cv_destroy(gpr_cv *cv);
 /* Atomically release *mu and wait on *cv.  When the calling thread is woken
    from *cv or the deadline abs_deadline is exceeded, execute gpr_mu_lock(mu)
    and return whether the deadline was exceeded.  Use
-   abs_deadline==gpr_inf_future for no deadline.  May return even when not
+   abs_deadline==gpr_inf_future for no deadline.  abs_deadline can be either
+   an absolute deadline, or a GPR_TIMESPAN.  May return even when not
    woken explicitly.  Requires:  *mu and *cv initialized; the calling thread
    holds an exclusive lock on *mu.  */
 GPR_API int gpr_cv_wait(gpr_cv *cv, gpr_mu *mu, gpr_timespec abs_deadline);

--- a/src/core/support/sync_win32.c
+++ b/src/core/support/sync_win32.c
@@ -87,6 +87,7 @@ int gpr_cv_wait(gpr_cv *cv, gpr_mu *mu, gpr_timespec abs_deadline) {
       0) {
     SleepConditionVariableCS(cv, &mu->cs, INFINITE);
   } else {
+    abs_deadline = gpr_convert_clock_type(abs_deadline, GPR_CLOCK_REALTIME);
     gpr_timespec now = gpr_now(abs_deadline.clock_type);
     int64_t now_ms = (int64_t)now.tv_sec * 1000 + now.tv_nsec / 1000000;
     int64_t deadline_ms =


### PR DESCRIPTION
This makes the windows behavior match that on linux. Also updated the comment in sync.h to explicitly describe this behavior. 