### PR TITLE
grpc_set_ssl_roots_override_callback for Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,7 @@ COMMAND_CLASS = {
 }
 
 # Ensure that package data is copied over before any commands have been run:
-credentials_dir = os.path.join(PYTHON_STEM, 'grpc/_adapter/credentials')
+credentials_dir = os.path.join(PYTHON_STEM, 'grpc/_cython/_credentials')
 try:
   os.mkdir(credentials_dir)
 except OSError:
@@ -199,10 +199,8 @@ TEST_LOADER = 'tests:Loader'
 TEST_RUNNER = 'tests:Runner'
 
 PACKAGE_DATA = {
-    'grpc._adapter': [
-        'credentials/roots.pem'
-    ],
     'grpc._cython': [
+        '_credentials/roots.pem',
         '_windows/grpc_c.32.python',
         '_windows/grpc_c.64.python',
     ],

--- a/src/python/grpcio/.gitignore
+++ b/src/python/grpcio/.gitignore
@@ -14,4 +14,4 @@ nosetests.xml
 doc/
 _grpcio_metadata.py
 htmlcov/
-grpc/_adapter/credentials
+grpc/_cython/_credentials

--- a/src/python/grpcio/grpc/_adapter/_low.py
+++ b/src/python/grpcio/grpc/_adapter/_low.py
@@ -27,7 +27,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import pkg_resources
 import threading
 
 from grpc import _grpcio_metadata
@@ -35,7 +34,6 @@ from grpc._cython import cygrpc
 from grpc._adapter import _implementations
 from grpc._adapter import _types
 
-_ROOT_CERTIFICATES_RESOURCE_PATH = 'credentials/roots.pem'
 _USER_AGENT = 'Python-gRPC-{}'.format(_grpcio_metadata.__version__)
 
 ChannelCredentials = cygrpc.ChannelCredentials
@@ -56,9 +54,6 @@ def channel_credentials_ssl(
   pair = None
   if private_key is not None or certificate_chain is not None:
     pair = cygrpc.SslPemKeyCertPair(private_key, certificate_chain)
-  if root_certificates is None:
-    root_certificates = pkg_resources.resource_string(
-      __name__, _ROOT_CERTIFICATES_RESOURCE_PATH)
   return cygrpc.channel_credentials_ssl(root_certificates, pair)
 
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -99,6 +99,11 @@ cdef extern from "grpc/_cython/loader.h":
     GRPC_STATUS_UNAVAILABLE
     GRPC_STATUS_DATA_LOSS
     GRPC_STATUS__DO_NOT_USE
+
+  ctypedef enum grpc_ssl_roots_override_result:
+    GRPC_SSL_ROOTS_OVERRIDE_OK
+    GRPC_SSL_ROOTS_OVERRIDE_FAILED_PERMANENTLY
+    GRPC_SSL_ROOTS_OVERRIDE_FAILED
 
   struct grpc_byte_buffer_reader:
     # We don't care about the internals
@@ -337,6 +342,10 @@ cdef extern from "grpc/_cython/loader.h":
   ctypedef struct grpc_call_credentials:
     # We don't care about the internals (and in fact don't know them)
     pass
+
+  ctypedef void (*grpc_ssl_roots_override_callback)(char **pem_root_certs)
+
+  void grpc_set_ssl_roots_override_callback(grpc_ssl_roots_override_callback cb)
 
   grpc_channel_credentials *grpc_google_default_credentials_create()
   grpc_channel_credentials *grpc_ssl_credentials_create(

--- a/src/python/grpcio/grpc/_cython/_cygrpc/security.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/security.pxd.pxi
@@ -1,4 +1,4 @@
-# Copyright 2015-2016, Google Inc.
+# Copyright 2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,12 +27,6 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include "grpc/_cython/_cygrpc/grpc.pxi"
 
-include "grpc/_cython/_cygrpc/call.pxd.pxi"
-include "grpc/_cython/_cygrpc/channel.pxd.pxi"
-include "grpc/_cython/_cygrpc/credentials.pxd.pxi"
-include "grpc/_cython/_cygrpc/completion_queue.pxd.pxi"
-include "grpc/_cython/_cygrpc/records.pxd.pxi"
-include "grpc/_cython/_cygrpc/security.pxd.pxi"
-include "grpc/_cython/_cygrpc/server.pxd.pxi"
+cdef grpc_ssl_roots_override_result ssl_roots_override_callback(
+    char **pem_root_certs) with gil

--- a/src/python/grpcio/grpc/_cython/_cygrpc/security.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/security.pyx.pxi
@@ -1,4 +1,4 @@
-# Copyright 2015-2016, Google Inc.
+# Copyright 2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,12 +27,18 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include "grpc/_cython/_cygrpc/grpc.pxi"
+from libc.string cimport memcpy
 
-include "grpc/_cython/_cygrpc/call.pxd.pxi"
-include "grpc/_cython/_cygrpc/channel.pxd.pxi"
-include "grpc/_cython/_cygrpc/credentials.pxd.pxi"
-include "grpc/_cython/_cygrpc/completion_queue.pxd.pxi"
-include "grpc/_cython/_cygrpc/records.pxd.pxi"
-include "grpc/_cython/_cygrpc/security.pxd.pxi"
-include "grpc/_cython/_cygrpc/server.pxd.pxi"
+import pkg_resources
+
+
+cdef grpc_ssl_roots_override_result ssl_roots_override_callback(
+    char **pem_root_certs) with gil:
+  temporary_pem_root_certs = pkg_resources.resource_string(
+      'grpc._cython', '_credentials/roots.pem')
+  pem_root_certs[0] = <char *>gpr_malloc(len(temporary_pem_root_certs) + 1)
+  memcpy(
+      pem_root_certs[0], <char *>temporary_pem_root_certs,
+      len(temporary_pem_root_certs))
+  pem_root_certs[0][len(temporary_pem_root_certs)] = '\0'
+  return GRPC_SSL_ROOTS_OVERRIDE_OK

--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
@@ -40,6 +40,7 @@ include "grpc/_cython/_cygrpc/channel.pyx.pxi"
 include "grpc/_cython/_cygrpc/credentials.pyx.pxi"
 include "grpc/_cython/_cygrpc/completion_queue.pyx.pxi"
 include "grpc/_cython/_cygrpc/records.pyx.pxi"
+include "grpc/_cython/_cygrpc/security.pyx.pxi"
 include "grpc/_cython/_cygrpc/server.pyx.pxi"
 
 #
@@ -58,6 +59,8 @@ cdef class _ModuleState:
         raise ImportError('failed to load core gRPC library')
     grpc_init()
     self.is_loaded = True
+    grpc_set_ssl_roots_override_callback(
+        <grpc_ssl_roots_override_callback>ssl_roots_override_callback)
 
   def __dealloc__(self):
     if self.is_loaded:

--- a/src/python/grpcio/tests/unit/beta/_implementations_test.py
+++ b/src/python/grpcio/tests/unit/beta/_implementations_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2016, Google Inc.
+# Copyright 2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -27,12 +27,28 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include "grpc/_cython/_cygrpc/grpc.pxi"
+"""Tests the implementations module of the gRPC Python Beta API."""
 
-include "grpc/_cython/_cygrpc/call.pxd.pxi"
-include "grpc/_cython/_cygrpc/channel.pxd.pxi"
-include "grpc/_cython/_cygrpc/credentials.pxd.pxi"
-include "grpc/_cython/_cygrpc/completion_queue.pxd.pxi"
-include "grpc/_cython/_cygrpc/records.pxd.pxi"
-include "grpc/_cython/_cygrpc/security.pxd.pxi"
-include "grpc/_cython/_cygrpc/server.pxd.pxi"
+import unittest
+
+from grpc.beta import implementations
+from tests.unit import resources
+
+
+class ChannelCredentialsTest(unittest.TestCase):
+
+  def test_runtime_provided_root_certificates(self):
+    channel_credentials = implementations.ssl_channel_credentials(
+        None, None, None)
+    self.assertIsInstance(
+        channel_credentials, implementations.ChannelCredentials)
+  
+  def test_application_provided_root_certificates(self):
+    channel_credentials = implementations.ssl_channel_credentials(
+        resources.test_root_certificates(), None, None)
+    self.assertIsInstance(
+        channel_credentials, implementations.ChannelCredentials)
+
+
+if __name__ == '__main__':
+  unittest.main(verbosity=2)


### PR DESCRIPTION
Not yet passing interop tests but ready to at least begin review.

Since this is my first Cython change @robertwb has graciously agreed to also review.