### PR TITLE
No git clone for distrib tests

### DIFF
--- a/tools/dockerfile/distribtest/csharp_centos7_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_centos7_x64/Dockerfile
@@ -33,6 +33,5 @@ RUN rpm --import "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E03
 RUN yum-config-manager --add-repo http://download.mono-project.com/repo/centos/
 
 RUN yum install -y mono
-RUN yum install -y git
 RUN yum install -y unzip
 RUN yum install -y nuget

--- a/tools/dockerfile/distribtest/csharp_jessie_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_jessie_x64/Dockerfile
@@ -40,4 +40,4 @@ RUN apt-get update && apt-get install -y \
     ca-certificates-mono \
     nuget
 
-RUN apt-get update && apt-get install -y git unzip
+RUN apt-get update && apt-get install -y unzip

--- a/tools/dockerfile/distribtest/csharp_jessie_x86/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_jessie_x86/Dockerfile
@@ -40,4 +40,4 @@ RUN apt-get update && apt-get install -y \
     ca-certificates-mono \
     nuget
 
-RUN apt-get update && apt-get install -y git unzip
+RUN apt-get update && apt-get install -y unzip

--- a/tools/dockerfile/distribtest/csharp_ubuntu1404_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_ubuntu1404_x64/Dockerfile
@@ -37,4 +37,4 @@ RUN apt-get update && apt-get install -y \
     ca-certificates-mono \
     nuget
 
-RUN apt-get update && apt-get install -y git unzip
+RUN apt-get update && apt-get install -y unzip

--- a/tools/dockerfile/distribtest/csharp_ubuntu1504_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_ubuntu1504_x64/Dockerfile
@@ -37,4 +37,4 @@ RUN apt-get update && apt-get install -y \
     ca-certificates-mono \
     nuget
 
-RUN apt-get update && apt-get install -y git unzip
+RUN apt-get update && apt-get install -y unzip

--- a/tools/dockerfile/distribtest/csharp_ubuntu1510_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_ubuntu1510_x64/Dockerfile
@@ -37,4 +37,4 @@ RUN apt-get update && apt-get install -y \
     ca-certificates-mono \
     nuget
 
-RUN apt-get update && apt-get install -y git unzip
+RUN apt-get update && apt-get install -y unzip

--- a/tools/dockerfile/distribtest/csharp_ubuntu1604_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_ubuntu1604_x64/Dockerfile
@@ -34,4 +34,4 @@ RUN apt-get update && apt-get install -y \
     ca-certificates-mono \
     nuget
 
-RUN apt-get update && apt-get install -y git unzip
+RUN apt-get update && apt-get install -y unzip

--- a/tools/dockerfile/distribtest/csharp_wheezy_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_wheezy_x64/Dockerfile
@@ -29,4 +29,4 @@
 
 FROM mono:4.2.2.30
 
-RUN apt-get update && apt-get install -y git unzip
+RUN apt-get update && apt-get install -y unzip

--- a/tools/dockerfile/distribtest/node_centos7_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/node_centos7_x64/Dockerfile
@@ -29,7 +29,6 @@
 
 FROM centos:7
 
-RUN yum install -y git
 RUN yum install -y curl
 
 # Install nvm

--- a/tools/dockerfile/distribtest/node_jessie_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/node_jessie_x64/Dockerfile
@@ -29,7 +29,7 @@
 
 FROM debian:jessie
 
-RUN apt-get update && apt-get install -y curl git
+RUN apt-get update && apt-get install -y curl
 
 # Install nvm
 RUN touch .profile

--- a/tools/dockerfile/distribtest/node_jessie_x86/Dockerfile
+++ b/tools/dockerfile/distribtest/node_jessie_x86/Dockerfile
@@ -29,7 +29,7 @@
 
 FROM 32bit/debian:jessie
 
-RUN apt-get update && apt-get install -y curl git
+RUN apt-get update && apt-get install -y git
 
 # Install nvm
 RUN touch .profile

--- a/tools/dockerfile/distribtest/node_ubuntu1204_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/node_ubuntu1204_x64/Dockerfile
@@ -29,7 +29,7 @@
 
 FROM ubuntu:12.04
 
-RUN apt-get update && apt-get install -y curl git
+RUN apt-get update && apt-get install -y curl
 
 # Install nvm
 RUN touch .profile

--- a/tools/dockerfile/distribtest/node_ubuntu1404_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/node_ubuntu1404_x64/Dockerfile
@@ -29,7 +29,7 @@
 
 FROM ubuntu:14.04
 
-RUN apt-get update && apt-get install -y curl git
+RUN apt-get update && apt-get install -y curl
 
 # Install nvm
 RUN touch .profile

--- a/tools/dockerfile/distribtest/node_ubuntu1504_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/node_ubuntu1504_x64/Dockerfile
@@ -29,7 +29,7 @@
 
 FROM ubuntu:15.04
 
-RUN apt-get update && apt-get install -y curl git
+RUN apt-get update && apt-get install -y curl
 
 # Install nvm
 RUN touch .profile

--- a/tools/dockerfile/distribtest/node_ubuntu1510_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/node_ubuntu1510_x64/Dockerfile
@@ -29,7 +29,7 @@
 
 FROM ubuntu:15.10
 
-RUN apt-get update && apt-get install -y curl git
+RUN apt-get update && apt-get install -y curl
 
 # Install nvm
 RUN touch .profile

--- a/tools/dockerfile/distribtest/node_ubuntu1604_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/node_ubuntu1604_x64/Dockerfile
@@ -29,7 +29,7 @@
 
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y curl git
+RUN apt-get update && apt-get install -y curl
 
 # Install nvm
 RUN touch .profile

--- a/tools/dockerfile/distribtest/python_arch_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_arch_x64/Dockerfile
@@ -30,7 +30,6 @@
 FROM base/archlinux
 
 RUN pacman --noconfirm -Syy
-RUN pacman --noconfirm -S git
 RUN pacman --noconfirm -S python
 RUN pacman --noconfirm -S python-pip
 

--- a/tools/dockerfile/distribtest/python_centos6_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_centos6_x64/Dockerfile
@@ -29,7 +29,6 @@
 
 FROM centos:6
 
-RUN yum install -y git
 RUN yum install -y python
 
 RUN rpm -ivh http://dl.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm

--- a/tools/dockerfile/distribtest/python_centos7_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_centos7_x64/Dockerfile
@@ -29,7 +29,6 @@
 
 FROM centos:7
 
-RUN yum install -y git
 RUN yum install -y python
 RUN yum install -y epel-release
 RUN yum install -y python-pip

--- a/tools/dockerfile/distribtest/python_fedora20_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_fedora20_x64/Dockerfile
@@ -29,9 +29,4 @@
 
 FROM fedora:20
 
-RUN yum clean all
-RUN yum update -y
-RUN yum install -y git
-RUN yum install -y python
-RUN yum install -y python-pip
-
+RUN yum clean all && yum update -y && yum install -y python python-pip

--- a/tools/dockerfile/distribtest/python_fedora21_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_fedora21_x64/Dockerfile
@@ -29,9 +29,4 @@
 
 FROM fedora:21
 
-RUN yum clean all
-RUN yum update -y
-RUN yum install -y git
-RUN yum install -y python
-RUN yum install -y python-pip
-
+RUN yum clean all && yum update -y && yum install -y python python-pip

--- a/tools/dockerfile/distribtest/python_fedora22_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_fedora22_x64/Dockerfile
@@ -29,9 +29,4 @@
 
 FROM fedora:22
 
-RUN yum clean all
-RUN yum update -y
-RUN yum install -y git
-RUN yum install -y python
-RUN yum install -y python-pip
-
+RUN yum clean all && yum update -y && yum install -y python python-pip

--- a/tools/dockerfile/distribtest/python_fedora23_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_fedora23_x64/Dockerfile
@@ -29,9 +29,4 @@
 
 FROM fedora:23
 
-RUN yum clean all
-RUN yum update -y
-RUN yum install -y git
-RUN yum install -y python
-RUN yum install -y python-pip
-
+RUN yum clean all && yum update -y && yum install -y python python-pip

--- a/tools/dockerfile/distribtest/python_jessie_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_jessie_x64/Dockerfile
@@ -29,6 +29,4 @@
 
 FROM debian:jessie
 
-RUN apt-get update
-RUN apt-get install -y git python python-pip
-
+RUN apt-get update && apt-get install -y python python-pip

--- a/tools/dockerfile/distribtest/python_jessie_x86/Dockerfile
+++ b/tools/dockerfile/distribtest/python_jessie_x86/Dockerfile
@@ -29,6 +29,4 @@
 
 FROM 32bit/debian:jessie
 
-RUN apt-get update
-RUN apt-get install -y git python python-pip
-
+RUN apt-get update && apt-get install -y python python-pip

--- a/tools/dockerfile/distribtest/python_opensuse_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_opensuse_x64/Dockerfile
@@ -29,7 +29,5 @@
 
 FROM opensuse:42.1
 
-RUN zypper --non-interactive install git
 RUN zypper --non-interactive install python
 RUN zypper --non-interactive install python-pip
-

--- a/tools/dockerfile/distribtest/python_ubuntu1204_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_ubuntu1204_x64/Dockerfile
@@ -29,8 +29,4 @@
 
 FROM ubuntu:12.04
 
-RUN apt-get update -y
-RUN apt-get install -y git
-RUN apt-get install -y python
-RUN apt-get install -y python-pip
-
+RUN apt-get update -y && apt-get install -y python python-pip

--- a/tools/dockerfile/distribtest/python_ubuntu1404_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_ubuntu1404_x64/Dockerfile
@@ -29,8 +29,4 @@
 
 FROM ubuntu:14.04
 
-RUN apt-get update -y
-RUN apt-get install -y git
-RUN apt-get install -y python
-RUN apt-get install -y python-pip
-
+RUN apt-get update -y && apt-get install -y python python-pip

--- a/tools/dockerfile/distribtest/python_ubuntu1504_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_ubuntu1504_x64/Dockerfile
@@ -29,8 +29,4 @@
 
 FROM ubuntu:15.04
 
-RUN apt-get update -y
-RUN apt-get install -y git
-RUN apt-get install -y python
-RUN apt-get install -y python-pip
-
+RUN apt-get update -y && apt-get install -y python python-pip

--- a/tools/dockerfile/distribtest/python_ubuntu1510_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_ubuntu1510_x64/Dockerfile
@@ -29,8 +29,4 @@
 
 FROM ubuntu:15.10
 
-RUN apt-get update -y
-RUN apt-get install -y git
-RUN apt-get install -y python
-RUN apt-get install -y python-pip
-
+RUN apt-get update -y && apt-get install -y python python-pip

--- a/tools/dockerfile/distribtest/python_ubuntu1604_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_ubuntu1604_x64/Dockerfile
@@ -29,8 +29,4 @@
 
 FROM ubuntu:16.04
 
-RUN apt-get update -y
-RUN apt-get install -y git
-RUN apt-get install -y python
-RUN apt-get install -y python-pip
-
+RUN apt-get update -y && apt-get install -y python python-pip

--- a/tools/dockerfile/distribtest/python_wheezy_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_wheezy_x64/Dockerfile
@@ -29,6 +29,4 @@
 
 FROM debian:wheezy
 
-RUN apt-get update
-RUN apt-get install -y git python python-pip
-
+RUN apt-get update -y && apt-get install -y python python-pip

--- a/tools/dockerfile/distribtest/ruby_centos6_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_centos6_x64/Dockerfile
@@ -29,6 +29,4 @@
 
 FROM centos:6
 
-RUN yum install -y git
 RUN yum install -y ruby
-

--- a/tools/dockerfile/distribtest/ruby_centos7_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_centos7_x64/Dockerfile
@@ -29,6 +29,4 @@
 
 FROM centos:7
 
-RUN yum install -y git
 RUN yum install -y ruby
-

--- a/tools/dockerfile/distribtest/ruby_fedora20_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_fedora20_x64/Dockerfile
@@ -29,8 +29,4 @@
 
 FROM fedora:20
 
-RUN yum clean all
-RUN yum update -y
-RUN yum install -y git
-RUN yum install -y ruby
-
+RUN yum clean all && yum update -y && yum install -y ruby

--- a/tools/dockerfile/distribtest/ruby_fedora21_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_fedora21_x64/Dockerfile
@@ -29,8 +29,4 @@
 
 FROM fedora:21
 
-RUN yum clean all
-RUN yum update -y
-RUN yum install -y git
-RUN yum install -y ruby
-
+RUN yum clean all && yum update -y && yum install -y ruby

--- a/tools/dockerfile/distribtest/ruby_fedora22_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_fedora22_x64/Dockerfile
@@ -29,8 +29,4 @@
 
 FROM fedora:22
 
-RUN yum clean all
-RUN yum update -y
-RUN yum install -y git
-RUN yum install -y ruby
-
+RUN yum clean all && yum update -y && yum install -y ruby

--- a/tools/dockerfile/distribtest/ruby_fedora23_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_fedora23_x64/Dockerfile
@@ -29,8 +29,4 @@
 
 FROM fedora:23
 
-RUN yum clean all
-RUN yum update -y
-RUN yum install -y git
-RUN yum install -y ruby
-
+RUN yum clean all && yum update -y && yum install -y ruby

--- a/tools/dockerfile/distribtest/ruby_jessie_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_jessie_x64/Dockerfile
@@ -29,7 +29,4 @@
 
 FROM debian:jessie
 
-RUN apt-get update
-RUN apt-get install -y git
-RUN apt-get install -y ruby-full
-
+RUN apt-get update && apt-get install -y ruby-full

--- a/tools/dockerfile/distribtest/ruby_jessie_x86/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_jessie_x86/Dockerfile
@@ -29,7 +29,4 @@
 
 FROM 32bit/debian:jessie
 
-RUN apt-get update
-RUN apt-get install -y git
-RUN apt-get install -y ruby-full
-
+RUN apt-get update && apt-get install -y ruby-full

--- a/tools/dockerfile/distribtest/ruby_opensuse_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_opensuse_x64/Dockerfile
@@ -29,6 +29,4 @@
 
 FROM opensuse:42.1
 
-RUN zypper --non-interactive install git
 RUN zypper --non-interactive install ruby
-

--- a/tools/dockerfile/distribtest/ruby_ubuntu1204_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_ubuntu1204_x64/Dockerfile
@@ -29,7 +29,4 @@
 
 FROM ubuntu:12.04
 
-RUN apt-get update -y
-RUN apt-get install -y git
-RUN apt-get install -y ruby-full
-
+RUN apt-get update -y && apt-get install -y ruby-full

--- a/tools/dockerfile/distribtest/ruby_ubuntu1404_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_ubuntu1404_x64/Dockerfile
@@ -29,7 +29,4 @@
 
 FROM ubuntu:14.04
 
-RUN apt-get update -y
-RUN apt-get install -y git
-RUN apt-get install -y ruby-full
-
+RUN apt-get update -y && apt-get install -y ruby-full

--- a/tools/dockerfile/distribtest/ruby_ubuntu1504_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_ubuntu1504_x64/Dockerfile
@@ -29,7 +29,4 @@
 
 FROM ubuntu:15.04
 
-RUN apt-get update -y
-RUN apt-get install -y git
-RUN apt-get install -y ruby-full
-
+RUN apt-get update -y && apt-get install -y ruby-full

--- a/tools/dockerfile/distribtest/ruby_ubuntu1510_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_ubuntu1510_x64/Dockerfile
@@ -29,7 +29,4 @@
 
 FROM ubuntu:15.10
 
-RUN apt-get update -y
-RUN apt-get install -y git
-RUN apt-get install -y ruby-full
-
+RUN apt-get update -y && apt-get install -y ruby-full

--- a/tools/dockerfile/distribtest/ruby_ubuntu1604_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_ubuntu1604_x64/Dockerfile
@@ -29,7 +29,4 @@
 
 FROM ubuntu:16.04
 
-RUN apt-get update -y
-RUN apt-get install -y git
-RUN apt-get install -y ruby-full
-
+RUN apt-get update -y && apt-get install -y ruby-full

--- a/tools/dockerfile/distribtest/ruby_wheezy_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_wheezy_x64/Dockerfile
@@ -29,7 +29,4 @@
 
 FROM debian:wheezy
 
-RUN apt-get update
-RUN apt-get install -y git
-RUN apt-get install -y ruby-full
-
+RUN apt-get update && apt-get install -y ruby-full

--- a/tools/jenkins/build_and_run_docker.sh
+++ b/tools/jenkins/build_and_run_docker.sh
@@ -37,9 +37,6 @@ cd $(dirname $0)/../..
 git_root=$(pwd)
 cd -
 
-# Create a local branch so the child Docker script won't complain
-git branch -f jenkins-docker
-
 # Inputs
 # DOCKERFILE_DIR - Directory in which Dockerfile file is located.
 # DOCKER_RUN_SCRIPT - Script to run under docker (relative to grpc repo root)

--- a/tools/jenkins/docker_run.sh
+++ b/tools/jenkins/docker_run.sh
@@ -33,16 +33,22 @@
 
 set -e
 
-mkdir -p /var/local/git
-git clone --recursive "$EXTERNAL_GIT_ROOT" /var/local/git/grpc
+if [ "$RELATIVE_COPY_PATH" == "" ]
+then
+  mkdir -p /var/local/git
+  git clone --recursive "$EXTERNAL_GIT_ROOT" /var/local/git/grpc
+else
+  mkdir -p "/var/local/git/grpc/$RELATIVE_COPY_PATH"
+  cp -r "$EXTERNAL_GIT_ROOT/$RELATIVE_COPY_PATH/*" "/var/local/git/grpc/$RELATIVE_COPY_PATH"
+fi
 
 if [ -x "$(command -v rvm)" ]
 then
   rvm use ruby-2.1
 fi
 
-cd /var/local/git/grpc
-
 nvm use 4 || true
+
+cd /var/local/git/grpc
 
 $RUN_COMMAND

--- a/tools/jenkins/docker_run.sh
+++ b/tools/jenkins/docker_run.sh
@@ -31,7 +31,7 @@
 # This script is invoked by build_docker_* inside a docker
 # container. You should never need to call this script on your own.
 
-set -e
+set -ex
 
 if [ "$RELATIVE_COPY_PATH" == "" ]
 then
@@ -39,7 +39,7 @@ then
   git clone --recursive "$EXTERNAL_GIT_ROOT" /var/local/git/grpc
 else
   mkdir -p "/var/local/git/grpc/$RELATIVE_COPY_PATH"
-  cp -r "$EXTERNAL_GIT_ROOT/$RELATIVE_COPY_PATH/*" "/var/local/git/grpc/$RELATIVE_COPY_PATH"
+  cp -r "$EXTERNAL_GIT_ROOT/$RELATIVE_COPY_PATH"/* "/var/local/git/grpc/$RELATIVE_COPY_PATH"
 fi
 
 if [ -x "$(command -v rvm)" ]

--- a/tools/run_tests/distribtest_targets.py
+++ b/tools/run_tests/distribtest_targets.py
@@ -38,13 +38,13 @@ def create_docker_jobspec(name, dockerfile_dir, shell_command, environ={},
   """Creates jobspec for a task running under docker."""
   environ = environ.copy()
   environ['RUN_COMMAND'] = shell_command
+  environ['RELATIVE_COPY_PATH'] = 'test/distrib'
 
   docker_args=[]
   for k,v in environ.iteritems():
     docker_args += ['-e', '%s=%s' % (k, v)]
   docker_env = {'DOCKERFILE_DIR': dockerfile_dir,
-                'DOCKER_RUN_SCRIPT': 'tools/jenkins/docker_run.sh',
-                'RELATIVE_COPY_PATH': 'test/distrib'}
+                'DOCKER_RUN_SCRIPT': 'tools/jenkins/docker_run.sh'}
   jobspec = jobset.JobSpec(
           cmdline=['tools/jenkins/build_and_run_docker.sh'] + docker_args,
           environ=docker_env,

--- a/tools/run_tests/distribtest_targets.py
+++ b/tools/run_tests/distribtest_targets.py
@@ -43,7 +43,8 @@ def create_docker_jobspec(name, dockerfile_dir, shell_command, environ={},
   for k,v in environ.iteritems():
     docker_args += ['-e', '%s=%s' % (k, v)]
   docker_env = {'DOCKERFILE_DIR': dockerfile_dir,
-                'DOCKER_RUN_SCRIPT': 'tools/jenkins/docker_run.sh'}
+                'DOCKER_RUN_SCRIPT': 'tools/jenkins/docker_run.sh',
+                'RELATIVE_COPY_PATH': 'test/distrib'}
   jobspec = jobset.JobSpec(
           cmdline=['tools/jenkins/build_and_run_docker.sh'] + docker_args,
           environ=docker_env,


### PR DESCRIPTION
Fixes #5020

-- more docker tasks can now run in parallel
-- git no longer required in distribtest images
-- cleanup of docker images (to handle docker caching correctly)