### PR TITLE
Make python jessie x86 distribtest pass

### DIFF
--- a/tools/dockerfile/distribtest/python_jessie_x86/Dockerfile
+++ b/tools/dockerfile/distribtest/python_jessie_x86/Dockerfile
@@ -30,3 +30,8 @@
 FROM 32bit/debian:jessie
 
 RUN apt-get update && apt-get install -y python python-pip
+
+# docker is running on a 64-bit machine, so we need to
+# override "uname -m" to report i686 instead of x86_64, otherwise
+# python will choose a wrong binary package to install.
+ENTRYPOINT ["linux32"]


### PR DESCRIPTION
This fix might be considered a grey zone, but I actually think it's fair as on a real 32bit machine things should work.

`PASSED: distribtest.python_linux_x86_jessie [time=16.4sec; retries=0:0]`