### PR TITLE
Fix python opensuse distribtest

### DIFF
--- a/tools/dockerfile/distribtest/python_opensuse_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_opensuse_x64/Dockerfile
@@ -31,3 +31,10 @@ FROM opensuse:42.1
 
 RUN zypper --non-interactive install python
 RUN zypper --non-interactive install python-pip
+
+# "which" command required by python's run_distrib_test.sh
+RUN zypper --non-interactive install which
+
+# Without this, pip won't be able to connect to
+# https://pypi.python.org/simple/
+RUN zypper --non-interactive install ca-certificates-mozilla


### PR DESCRIPTION
`PASSED: distribtest.python_linux_x64_opensuse [time=15.5sec; retries=0:0]`