### PR TITLE
Ruby distribtests on Linux

### DIFF
--- a/test/distrib/ruby/Gemfile
+++ b/test/distrib/ruby/Gemfile
@@ -1,0 +1,11 @@
+# -*- ruby -*-
+# encoding: utf-8
+
+source 'https://rubygems.org/'
+
+# TODO(jtattermusch): don't hardcode the absolute path the local gem source
+source "file:///var/local/git/grpc/gem_source" do
+  gem 'grpc'
+end
+
+gemspec

--- a/test/distrib/ruby/distribtest.gemspec
+++ b/test/distrib/ruby/distribtest.gemspec
@@ -1,0 +1,19 @@
+# -*- ruby -*-
+# encoding: utf-8
+
+Gem::Specification.new do |s|
+  s.name          = 'distribtest'
+  s.version       = '0.0.1'
+  s.authors       = ['gRPC Authors']
+  s.email         = 'jtattermusch@google.com'
+  s.homepage      = 'https://github.com/grpc/grpc'
+  s.summary       = 'gRPC Distribution test'
+
+  s.files         = ['distribtest.rb']
+  s.executables   = ['distribtest.rb']
+  s.platform      = Gem::Platform::RUBY
+
+  s.add_dependency 'grpc', '>=0'
+
+  s.add_development_dependency 'bundler', '~> 1.7'
+end

--- a/test/distrib/ruby/distribtest.rb
+++ b/test/distrib/ruby/distribtest.rb
@@ -1,5 +1,6 @@
-#!/bin/bash
-# Copyright 2015-2016, Google Inc.
+#!/usr/bin/env ruby
+
+# Copyright 2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,17 +29,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set -ex
+require 'grpc'
 
-cd $(dirname $0)
+# This code doesn't do much but makes sure the native extension is loaded
+# which is what we are testing here.
+ch = GRPC::Core::Channel.new('localhost:1000', nil, :this_channel_is_insecure)
+ch.destroy
 
-# Create an indexed local gem source with gRPC gems to test
-GEM_SOURCE=../../../gem_source
-mkdir -p ${GEM_SOURCE}/gems
-cp -r $EXTERNAL_GIT_ROOT/input_artifacts/*.gem ${GEM_SOURCE}/gems
-gem install builder
-gem generate_index --directory ${GEM_SOURCE}
-
-bundle install
-
-bundle exec ./distribtest.rb
+puts "Success!"

--- a/tools/dockerfile/distribtest/ruby_centos6_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_centos6_x64/Dockerfile
@@ -30,3 +30,5 @@
 FROM centos:6
 
 RUN yum install -y ruby
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_centos6_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_centos6_x64/Dockerfile
@@ -29,6 +29,13 @@
 
 FROM centos:6
 
-RUN yum install -y ruby
+RUN yum install -y curl
 
-RUN gem install bundler
+RUN yum install -y tar which
+
+# Install rvm
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+RUN \curl -sSL https://get.rvm.io | bash -s stable --ruby
+
+RUN /bin/bash -l -c "echo '. /etc/profile.d/rvm.sh' >> ~/.bashrc"
+RUN /bin/bash -l -c "gem install --update bundler"

--- a/tools/dockerfile/distribtest/ruby_centos7_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_centos7_x64/Dockerfile
@@ -30,3 +30,5 @@
 FROM centos:7
 
 RUN yum install -y ruby
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_fedora20_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_fedora20_x64/Dockerfile
@@ -30,3 +30,5 @@
 FROM fedora:20
 
 RUN yum clean all && yum update -y && yum install -y ruby
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_fedora21_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_fedora21_x64/Dockerfile
@@ -30,3 +30,5 @@
 FROM fedora:21
 
 RUN yum clean all && yum update -y && yum install -y ruby
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_fedora22_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_fedora22_x64/Dockerfile
@@ -30,3 +30,5 @@
 FROM fedora:22
 
 RUN yum clean all && yum update -y && yum install -y ruby
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_fedora23_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_fedora23_x64/Dockerfile
@@ -30,3 +30,5 @@
 FROM fedora:23
 
 RUN yum clean all && yum update -y && yum install -y ruby
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_jessie_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_jessie_x64/Dockerfile
@@ -30,3 +30,5 @@
 FROM debian:jessie
 
 RUN apt-get update && apt-get install -y ruby-full
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_jessie_x86/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_jessie_x86/Dockerfile
@@ -30,3 +30,5 @@
 FROM 32bit/debian:jessie
 
 RUN apt-get update && apt-get install -y ruby-full
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_opensuse_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_opensuse_x64/Dockerfile
@@ -29,6 +29,17 @@
 
 FROM opensuse:42.1
 
-RUN zypper --non-interactive install ruby
+RUN zypper --non-interactive install curl
 
-RUN gem install bundler
+RUN zypper --non-interactive install tar which
+
+RUN zypper --non-interactive install ca-certificates-mozilla
+
+# Install rvm
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+RUN \curl -sSL https://get.rvm.io | bash -s stable --ruby
+
+# OpenSUSE is a bit crazy and ignores .bashrc for login shell.
+RUN /bin/bash -l -c "echo '. /etc/profile.d/rvm.sh' >> ~/.profile"
+
+RUN /bin/bash -l -c 'gem install --update bundler'

--- a/tools/dockerfile/distribtest/ruby_opensuse_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_opensuse_x64/Dockerfile
@@ -30,3 +30,5 @@
 FROM opensuse:42.1
 
 RUN zypper --non-interactive install ruby
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_ubuntu1204_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_ubuntu1204_x64/Dockerfile
@@ -30,3 +30,5 @@
 FROM ubuntu:12.04
 
 RUN apt-get update -y && apt-get install -y ruby-full
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_ubuntu1204_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_ubuntu1204_x64/Dockerfile
@@ -29,6 +29,11 @@
 
 FROM ubuntu:12.04
 
-RUN apt-get update -y && apt-get install -y ruby-full
+RUN apt-get update -y && apt-get install -y curl
 
-RUN gem install bundler
+# Install rvm
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+RUN \curl -sSL https://get.rvm.io | bash -s stable --ruby
+
+RUN /bin/bash -l -c "echo '. /etc/profile.d/rvm.sh' >> ~/.bashrc"
+RUN /bin/bash -l -c "gem install --update bundler"

--- a/tools/dockerfile/distribtest/ruby_ubuntu1404_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_ubuntu1404_x64/Dockerfile
@@ -29,6 +29,11 @@
 
 FROM ubuntu:14.04
 
-RUN apt-get update -y && apt-get install -y ruby-full
+RUN apt-get update -y && apt-get install -y curl
 
-RUN gem install bundler
+# Install rvm
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+RUN \curl -sSL https://get.rvm.io | bash -s stable --ruby
+
+RUN /bin/bash -l -c "echo '. /etc/profile.d/rvm.sh' >> ~/.bashrc"
+RUN /bin/bash -l -c "gem install --update bundler"

--- a/tools/dockerfile/distribtest/ruby_ubuntu1404_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_ubuntu1404_x64/Dockerfile
@@ -30,3 +30,5 @@
 FROM ubuntu:14.04
 
 RUN apt-get update -y && apt-get install -y ruby-full
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_ubuntu1504_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_ubuntu1504_x64/Dockerfile
@@ -30,3 +30,5 @@
 FROM ubuntu:15.04
 
 RUN apt-get update -y && apt-get install -y ruby-full
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_ubuntu1510_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_ubuntu1510_x64/Dockerfile
@@ -30,3 +30,5 @@
 FROM ubuntu:15.10
 
 RUN apt-get update -y && apt-get install -y ruby-full
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_ubuntu1604_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_ubuntu1604_x64/Dockerfile
@@ -30,3 +30,5 @@
 FROM ubuntu:16.04
 
 RUN apt-get update -y && apt-get install -y ruby-full
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_wheezy_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_wheezy_x64/Dockerfile
@@ -30,3 +30,5 @@
 FROM debian:wheezy
 
 RUN apt-get update && apt-get install -y ruby-full
+
+RUN gem install bundler

--- a/tools/dockerfile/distribtest/ruby_wheezy_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_wheezy_x64/Dockerfile
@@ -29,6 +29,13 @@
 
 FROM debian:wheezy
 
-RUN apt-get update && apt-get install -y ruby-full
+RUN apt-get update && apt-get install -y curl
 
-RUN gem install bundler
+RUN apt-get update && apt-get install -y procps
+
+# Install rvm
+RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+RUN \curl -sSL https://get.rvm.io | bash -s stable --ruby
+
+RUN /bin/bash -l -c "echo '. /etc/profile.d/rvm.sh' >> ~/.bashrc"
+RUN /bin/bash -l -c "gem install --update bundler"


### PR DESCRIPTION
-- currently not passing because it tries to install protobuf (needs to be compiled and we don't install the tools in our images)
-- add gem install bundler for images that we'll get working the soonest.