### PR TITLE
Drop Python interop tests' "make install-certs"

### DIFF
--- a/tools/dockerfile/grpc_interop_python/build_interop.sh
+++ b/tools/dockerfile/grpc_interop_python/build_interop.sh
@@ -39,7 +39,6 @@ cp -r /var/local/jenkins/service_account $HOME || true
 
 cd /var/local/git/grpc
 
-make install-certs
 make
 
 # build Python interop client and server


### PR DESCRIPTION
This should have been included in #5100.