### PR TITLE
Test fix php interop test composer install git clone problem 

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -535,10 +535,10 @@ def build_interop_image_jobspec(language, tag=None):
     env['TTY_FLAG'] = '-t'
   # This env variable is used to get around the github rate limit
   # error when running the PHP `composer install` command
-  # TODO(stanleycheung): find a more elegant way to do this
-  if language.safename == 'php' and os.path.exists('/home/jenkins/.composer/auth.json'):
+  host_file = '%s/.composer/auth.json' % os.environ['HOME']
+  if language.safename == 'php' and os.path.exists(host_file):
     env['BUILD_INTEROP_DOCKER_EXTRA_ARGS'] = \
-      '-v /home/jenkins/.composer/auth.json:/root/.composer/auth.json:ro'
+      '-v %s:/root/.composer/auth.json:ro' % host_file
   build_job = jobset.JobSpec(
           cmdline=['tools/jenkins/build_interop_image.sh'],
           environ=env,

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -536,9 +536,9 @@ def build_interop_image_jobspec(language, tag=None):
   # This env variable is used to get around the github rate limit
   # error when running the PHP `composer install` command
   # TODO(stanleycheung): find a more elegant way to do this
-  if language.safename == 'php' and os.path.exists('/var/local/.composer/auth.json'):
+  if language.safename == 'php' and os.path.exists('/home/jenkins/.composer/auth.json'):
     env['BUILD_INTEROP_DOCKER_EXTRA_ARGS'] = \
-      '-v /var/local/.composer/auth.json:/root/.composer/auth.json:ro'
+      '-v /home/jenkins/.composer/auth.json:/root/.composer/auth.json:ro'
   build_job = jobset.JobSpec(
           cmdline=['tools/jenkins/build_interop_image.sh'],
           environ=env,


### PR DESCRIPTION
- Fixes #4212 
- Previous fix #3818 and #3859. The path to the `auth.json` file in the host jenkins instance (currently grpc-canary-interop1) has been changed from `/var/local/.composer/auth.json` to `/home/jenkins/.composer/auth.json`.
- With this file properly mounted into the docker image, the `git clone stanley-cheung/Protobuf-PHP` command spawned by the `composer install` command shouldn't fail anymore 