### PR TITLE
Remove pip install six where it should not be necessary

### DIFF
--- a/test/distrib/python/run_distrib_test.sh
+++ b/test/distrib/python/run_distrib_test.sh
@@ -47,9 +47,6 @@ which $PIP || PIP=pip
 PYTHON=python2
 which $PYTHON || PYTHON=python
 
-# TODO(jtattermusch): this shouldn't be required
-$PIP install --upgrade six
-
 GRPC_PYTHON_BINARIES_REPOSITORY="${BDIST_DIR}" \
     $PIP install \
     ${SDIST_ARCHIVE}

--- a/tools/run_tests/build_artifact_python.sh
+++ b/tools/run_tests/build_artifact_python.sh
@@ -34,7 +34,6 @@ cd $(dirname $0)/../..
 
 if [ "$SKIP_PIP_INSTALL" == "" ]
 then
-  pip install --upgrade six
   pip install --upgrade setuptools
   pip install -rrequirements.txt
 fi


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc/pull/5167.