### PR TITLE
Bundle node-pre-gyp with the node package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,12 @@
     "test": "./node_modules/.bin/mocha src/node/test && npm run-script lint",
     "gen_docs": "./node_modules/.bin/jsdoc -c src/node/jsdoc_conf.json",
     "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha src/node/test",
-    "preinstall": "npm install node-pre-gyp",
-    "install": "./node_modules/.bin/node-pre-gyp install --fallback-to-build"
+    "install": "node-pre-gyp install --fallback-to-build"
   },
+  "bundledDependencies": ["node-pre-gyp"],
   "dependencies": {
     "lodash": "^3.9.3",
     "nan": "^2.0.0",
-    "node-pre-gyp": "^0.6.19",
     "protobufjs": "^4.0.0"
   },
   "devDependencies": {

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -25,13 +25,12 @@
       "test": "./node_modules/.bin/mocha src/node/test && npm run-script lint",
       "gen_docs": "./node_modules/.bin/jsdoc -c src/node/jsdoc_conf.json",
       "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha src/node/test",
-      "preinstall": "npm install node-pre-gyp",
-      "install": "./node_modules/.bin/node-pre-gyp install --fallback-to-build"
+      "install": "node-pre-gyp install --fallback-to-build"
     },
+    "bundledDependencies": ["node-pre-gyp"],
     "dependencies": {
       "lodash": "^3.9.3",
       "nan": "^2.0.0",
-      "node-pre-gyp": "^0.6.19",
       "protobufjs": "^4.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
This fixes a failure that was occurring with when installing node-pre-gyp in the preinstall hook in newer versions of npm.