### PR TITLE
Fix fedora21 distribtests for python and ruby

### DIFF
--- a/tools/dockerfile/distribtest/python_fedora21_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_fedora21_x64/Dockerfile
@@ -29,4 +29,9 @@
 
 FROM fedora:21
 
+# Make yum work properly under docker when using overlay storage driver.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1213602#c9
+# https://github.com/docker/docker/issues/10180
+RUN yum install -y yum-plugin-ovl
+
 RUN yum clean all && yum update -y && yum install -y python python-pip

--- a/tools/dockerfile/distribtest/ruby_fedora21_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_fedora21_x64/Dockerfile
@@ -29,6 +29,11 @@
 
 FROM fedora:21
 
+# Make yum work properly under docker when using overlay storage driver.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1213602#c9
+# https://github.com/docker/docker/issues/10180
+RUN yum install -y yum-plugin-ovl
+
 RUN yum clean all && yum update -y && yum install -y ruby
 
 RUN gem install bundler


### PR DESCRIPTION
Fixes the `Rpmdb checksum is invalid: dCDPT(pkg checksums): grub2.x86_64 1:2.02-0.13.fc21 - u` docker build failure on fedora21.

https://grpc-testing.appspot.com/view/Artifacts/job/gRPC_distribtest/72/architecture=x64,language=ruby,platform=linux/
https://grpc-testing.appspot.com/view/Artifacts/job/gRPC_distribtest/72/architecture=x64,language=python,platform=linux/console

