### PR TITLE
Make a couple of fixes to distribution build and tests

### DIFF
--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -38,6 +38,7 @@ cd $(dirname $0)/../..
 mkdir -p artifacts/
 cp -r $EXTERNAL_GIT_ROOT/architecture={x86,x64},language=node,platform={windows,linux,macos}/artifacts/* artifacts/ || true
 
+npm update
 npm pack
 
 cp grpc-*.tgz artifacts/grpc.tgz

--- a/tools/run_tests/distribtest_targets.py
+++ b/tools/run_tests/distribtest_targets.py
@@ -240,7 +240,6 @@ def targets():
           RubyDistribTest('linux', 'x64', 'ubuntu1504'),
           RubyDistribTest('linux', 'x64', 'ubuntu1510'),
           RubyDistribTest('linux', 'x64', 'ubuntu1604'),
-          NodeDistribTest('macos', 'x64', None, '0.10'),
           NodeDistribTest('macos', 'x64', None, '0.12'),
           NodeDistribTest('macos', 'x64', None, '3'),
           NodeDistribTest('macos', 'x64', None, '4'),


### PR DESCRIPTION
The `npm update` there will ensure that node-pre-gyp is bundled with the package.