### PR TITLE
Truncate Python target triple for custom bdists

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -7,6 +7,7 @@ settings:
   '#3': Use "-preN" suffixes to identify pre-release versions
   '#4': Per-language overrides are possible with (eg) ruby_version tag here
   '#5': See the expand_version.py for all the quirks here
+  python_version: 0.13.0-pre2
   ruby_version: 0.13.0-pre1.1
   version: 0.13.0-pre1
 filegroups:

--- a/build.yaml
+++ b/build.yaml
@@ -8,7 +8,6 @@ settings:
   '#4': Per-language overrides are possible with (eg) ruby_version tag here
   '#5': See the expand_version.py for all the quirks here
   python_version: 0.13.0-pre2
-  ruby_version: 0.13.0-pre1.1
   version: 0.13.0-pre1
 filegroups:
 - name: census

--- a/src/python/grpcio/grpc_version.py
+++ b/src/python/grpcio/grpc_version.py
@@ -29,4 +29,4 @@
 
 # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio/grpc_version.py.template`!!!
 
-VERSION='0.13.0rc1'
+VERSION='0.13.0rc2'

--- a/src/ruby/lib/grpc/version.rb
+++ b/src/ruby/lib/grpc/version.rb
@@ -29,5 +29,5 @@
 
 # GRPC contains the General RPC module.
 module GRPC
-  VERSION = '0.13.0.pre1.1'
+  VERSION = '0.13.0.pre1'
 end


### PR DESCRIPTION
One hack deserves another hack, I guess.