### PR TITLE
Add build requirements

### DIFF
--- a/src/python/README.md
+++ b/src/python/README.md
@@ -50,6 +50,20 @@ Please read our online documentation for a [Quick Start][] and a [detailed examp
 
 BUILDING FROM SOURCE
 ---------------------
+
+**Linux (Debian):**
+
+- Several standard development tools are required to build from source: 
+```
+$ sudo apt-get install git make gcc dh-autoreconf python-dev
+```
+
+- In addition, you'll need to install the latest version of tox from pip:
+```
+$ sudo apt-get install pip
+$ sudo pip install tox
+```
+
 - Clone this repository
 
 - Initialize the git submodules


### PR DESCRIPTION
Give users the prereqs for the build steps, to short-circuit the "make, fail, install more prereqs, repeat" loop in the case they are building on a machine that doesn't yet have the prereqs installed.