### PR TITLE
Add a NullLogger in the C# implementation

### DIFF
--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -59,6 +59,7 @@
     <Compile Include="IServerStreamWriter.cs" />
     <Compile Include="IAsyncStreamWriter.cs" />
     <Compile Include="IAsyncStreamReader.cs" />
+    <Compile Include="Logging\NullLogger.cs" />
     <Compile Include="ServerPort.cs" />
     <Compile Include="Version.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/csharp/Grpc.Core/Logging/NullLogger.cs
+++ b/src/csharp/Grpc.Core/Logging/NullLogger.cs
@@ -1,0 +1,122 @@
+﻿#region Copyright notice and license
+
+// Copyright 2016, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+
+namespace Grpc.Core.Logging
+{
+    /// <summary>
+    /// Logger which doesn't log any information anywhere.
+    /// </summary>
+    public sealed class NullLogger : ILogger
+    {
+        /// <summary>
+        /// As with all logging calls on this logger, this method is a no-op.
+        /// </summary>
+        public void Debug(string message)
+        {
+        }
+
+        /// <summary>
+        /// As with all logging calls on this logger, this method is a no-op.
+        /// </summary>
+        public void Debug(string format, params object[] formatArgs)
+        {
+        }
+
+        /// <summary>
+        /// As with all logging calls on this logger, this method is a no-op.
+        /// </summary>
+        public void Error(string message)
+        {
+        }
+
+        /// <summary>
+        /// As with all logging calls on this logger, this method is a no-op.
+        /// </summary>
+        public void Error(Exception exception, string message)
+        {
+        }
+
+        /// <summary>
+        /// As with all logging calls on this logger, this method is a no-op.
+        /// </summary>
+        public void Error(string format, params object[] formatArgs)
+        {
+        }
+
+        /// <summary>
+        /// Returns a reference to the instance on which the method is called, as
+        /// instances aren't associated with specific types.
+        /// </summary>
+        public ILogger ForType<T>()
+        {
+            return this;
+        }
+
+        /// <summary>
+        /// As with all logging calls on this logger, this method is a no-op.
+        /// </summary>
+        public void Info(string message)
+        {
+        }
+
+        /// <summary>
+        /// As with all logging calls on this logger, this method is a no-op.
+        /// </summary>
+        public void Info(string format, params object[] formatArgs)
+        {
+        }
+
+        /// <summary>
+        /// As with all logging calls on this logger, this method is a no-op.
+        /// </summary>
+        public void Warning(string message)
+        {
+        }
+
+        /// <summary>
+        /// As with all logging calls on this logger, this method is a no-op.
+        /// </summary>
+        public void Warning(Exception exception, string message)
+        {
+        }
+
+        /// <summary>
+        /// As with all logging calls on this logger, this method is a no-op.
+        /// </summary>
+        public void Warning(string format, params object[] formatArgs)
+        {
+        }
+    }
+}


### PR DESCRIPTION
I'd argue that at this stage, this should probably be the default. Further options to consider:

- Make it a singleton, or at least expose a static property with a single instance?
- Allow SetLogger(null) to use the NullLogger?

(Should be assigned to @jtattermusch.)