### PR TITLE
Sketch of Mock API for AsyncUnaryCall

### DIFF
--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -39,8 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Interactive.Async, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="System.Interactive.Async">
       <HintPath>..\packages\Ix-Async.1.2.5\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
   </ItemGroup>
@@ -129,6 +128,7 @@
     <Compile Include="Profiling\IProfiler.cs" />
     <Compile Include="Profiling\Profilers.cs" />
     <Compile Include="Internal\DefaultSslRootsOverride.cs" />
+    <Compile Include="Testing\MockAsyncUnaryCall.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Grpc.Core.nuspec" />
@@ -138,6 +138,7 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <Folder Include="Resources\" />
+    <Folder Include="Testing\" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="..\..\..\etc\roots.pem">

--- a/src/csharp/Grpc.Core/Testing/MockAsyncUnaryCall.cs
+++ b/src/csharp/Grpc.Core/Testing/MockAsyncUnaryCall.cs
@@ -1,0 +1,94 @@
+#region Copyright notice and license
+
+// Copyright 2015, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Grpc.Core.Internal;
+using Grpc.Core.Utils;
+
+namespace Grpc.Core.Testing
+{
+    /// <summary>Allows mocking gRPC client objects by implementing the code-generated stub client interface <c>IFooClient</c></summary>
+    public class MockAsyncUnaryCall<TResponse>
+    {
+        ClientSideStatus? clientSideStatus;
+        TaskCompletionSource<Metadata> responseHeadersTcs = new TaskCompletionSource<Metadata>();
+        TaskCompletionSource<TResponse> responseTcs = new TaskCompletionSource<TResponse>();
+        AsyncUnaryCall<TResponse> call;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Grpc.Core.Testing.MockAsyncUnaryCall`1"/> class.
+        /// </summary>
+        public MockAsyncUnaryCall()
+        {
+            // TODO(jtattermusch): implement dispose action functionality
+            this.call = new AsyncUnaryCall<TResponse>(responseTcs.Task, responseHeadersTcs.Task,
+                () => clientSideStatus.Value.Status, () => clientSideStatus.Value.Trailers, () => {});
+        }
+
+        /// <summary>
+        /// Sets the response for this mock call.
+        /// </summary>
+        public void SetResponse(TResponse response)
+        {
+            SetResponse(response, Status.DefaultSuccess, new Metadata(), new Metadata());
+        }
+
+        /// <summary>
+        /// Sets the response for this mock call.
+        /// </summary>
+        public void SetResponse(TResponse response, Status status, Metadata responseHeaders, Metadata responseTrailers)
+        {
+            Preconditions.CheckNotNull(response, "response");
+            Preconditions.CheckNotNull(responseHeaders, "responseHeaders");
+            Preconditions.CheckNotNull(responseTrailers, "responseTrailers");
+
+            responseHeadersTcs.SetResult(responseHeaders);
+            clientSideStatus = new ClientSideStatus(status, responseTrailers);
+            responseTcs.SetResult(response);
+        }
+
+        /// <summary>
+        /// Returns the mock call object.
+        /// </summary>
+        public AsyncUnaryCall<TResponse> Call
+        {
+            get
+            {
+                return call;
+            }
+        }
+    }
+}

--- a/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.csproj
+++ b/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.csproj
@@ -3,8 +3,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>10.0.0</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{143B1C29-C442-4BE0-BF3F-A8F92288AC9F}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Grpc.Examples.Tests</RootNamespace>
@@ -37,16 +35,14 @@
     <AssemblyOriginatorKeyFile>..\keys\Grpc.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Google.Protobuf, Version=3.0.0.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Google.Protobuf.3.0.0-beta2\lib\portable-net45+netcore45+wpa81+wp8\Google.Protobuf.dll</HintPath>
-    </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Interactive.Async, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Google.Protobuf">
+      <HintPath>..\packages\Google.Protobuf.3.0.0-beta2\lib\portable-net45+netcore45+wpa81+wp8\Google.Protobuf.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Interactive.Async">
       <HintPath>..\packages\Ix-Async.1.2.5\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
   </ItemGroup>
@@ -56,6 +52,7 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MathClientServerTests.cs" />
+    <Compile Include="MockMathClientTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/csharp/Grpc.Examples.Tests/MockMathClientTest.cs
+++ b/src/csharp/Grpc.Examples.Tests/MockMathClientTest.cs
@@ -1,0 +1,132 @@
+#region Copyright notice and license
+
+// Copyright 2015, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Utils;
+using Grpc.Core.Testing;
+using NUnit.Framework;
+
+namespace Math.Tests
+{
+    /// <summary>
+    /// Example of mocking a gRPC service client for unit testing purposes.
+    /// </summary>
+    public class MockMathClientTest
+    {
+        FakeMathClient mockClient = new FakeMathClient();
+
+        [Test]
+        public async void MockAsyncUnaryCall()
+        {
+            var expectedResponse = new DivReply
+            {
+                Quotient = 3,
+                Remainder = 1
+            };
+            var mockCall = new MockAsyncUnaryCall<DivReply>();
+            mockCall.SetResponse(expectedResponse);
+
+            mockClient.DivAsyncImpl = (request, options) =>
+            {
+                return mockCall.Call;
+            };
+
+            var response = await mockClient.DivAsync(new DivArgs { Dividend = 10, Divisor = 3 }, new CallOptions());
+            Assert.AreEqual(expectedResponse, response);
+        }
+
+        /// <summary>
+        /// Demonstrates how to create a fake implementation of IMathClient.
+        /// </summary>
+        class FakeMathClient : Math.IMathClient
+        {
+            public Func<DivArgs, CallOptions, DivReply> DivImpl;
+            public Func<DivArgs, CallOptions, AsyncUnaryCall<DivReply>> DivAsyncImpl;
+
+            public DivReply Div(DivArgs request, Metadata headers, DateTime? deadline, CancellationToken cancellationToken)
+            {
+                return Div(request, new CallOptions(headers: headers, deadline: deadline, cancellationToken: cancellationToken));
+            }
+
+            public DivReply Div(DivArgs request, CallOptions options)
+            {
+                return DivImpl(request, options);
+            }
+
+            public AsyncUnaryCall<DivReply> DivAsync(DivArgs request, Metadata headers, DateTime? deadline, CancellationToken cancellationToken)
+            {
+                return DivAsync(request, new CallOptions(headers: headers, deadline: deadline, cancellationToken: cancellationToken));
+            }
+
+            public AsyncUnaryCall<DivReply> DivAsync(DivArgs request, CallOptions options)
+            {
+                return DivAsyncImpl(request, options);
+            }
+
+            public AsyncDuplexStreamingCall<DivArgs, DivReply> DivMany(Metadata headers, DateTime? deadline, CancellationToken cancellationToken)
+            {
+                return DivMany(new CallOptions(headers: headers, deadline: deadline, cancellationToken: cancellationToken));
+            }
+
+            public AsyncDuplexStreamingCall<DivArgs, DivReply> DivMany(CallOptions options)
+            {
+                throw new NotImplementedException();
+            }
+
+            public AsyncServerStreamingCall<Num> Fib(FibArgs request, Metadata headers, DateTime? deadline, CancellationToken cancellationToken)
+            {
+                return Fib(request, new CallOptions(headers: headers, deadline: deadline, cancellationToken: cancellationToken));
+            }
+
+            public AsyncServerStreamingCall<Num> Fib(FibArgs request, CallOptions options)
+            {
+                throw new NotImplementedException();
+            }
+
+            public AsyncClientStreamingCall<Num, Num> Sum(Metadata headers, DateTime? deadline, CancellationToken cancellationToken)
+            {
+                return Sum(new CallOptions(headers: headers, deadline: deadline, cancellationToken: cancellationToken));
+            }
+
+            public AsyncClientStreamingCall<Num, Num> Sum(CallOptions options)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/src/csharp/tests.json
+++ b/src/csharp/tests.json
@@ -33,6 +33,7 @@
     "Grpc.Core.Tests.TimeoutsTest",
     "Grpc.Core.Tests.UserAgentStringTest",
     "Math.Tests.MathClientServerTest",
+    "Math.Tests.MockMathClientTest",
     "Grpc.HealthCheck.Tests.HealthClientServerTest",
     "Grpc.HealthCheck.Tests.HealthServiceImplTest",
     "Grpc.IntegrationTesting.HeaderInterceptorTest",


### PR DESCRIPTION
I've sketched how the public API for mocking client stub interface could look like and added a usage example for "MathService".  This still needs some thought in terms of what to do for streaming call, but I wanted to hear some early feedback from you. Would such API serve your purposes well?

I tried to provide some simple wrapping around AsyncUnaryCall constructor, as its API is fairly low level and exposing it could lead to confusion and reimplementing the same boillerplate by everyone who would use it for testing.

@jskeet  @chrisdunelm 
