### PR TITLE
Increase Node's per-test timeout and Ruby's overall test timeout

### DIFF
--- a/tools/run_tests/run_node.bat
+++ b/tools/run_tests/run_node.bat
@@ -29,4 +29,4 @@
 
 set JUNIT_REPORT_PATH=src\node\reports.xml
 set JUNIT_REPORT_STACK=1
-.\node_modules\.bin\mocha.cmd --reporter mocha-jenkins-reporter src\node\test
+.\node_modules\.bin\mocha.cmd --reporter mocha-jenkins-reporter --timeout 8000 src\node\test

--- a/tools/run_tests/run_node.sh
+++ b/tools/run_tests/run_node.sh
@@ -41,10 +41,13 @@ cd $(dirname $0)/../..
 
 root=`pwd`
 
+test_directory='src/node/test'
+timeout=8000
+
 if [ "$CONFIG" = "gcov" ]
 then
   ./node_modules/.bin/istanbul cover --dir reports/node_coverage \
-    -x **/interop/* ./node_modules/.bin/_mocha -- --timeout 8000 src/node/test
+    -x **/interop/* ./node_modules/.bin/_mocha -- --timeout $timeout $test_directory
   cd build
   gcov Release/obj.target/grpc/ext/*.o
   lcov --base-directory . --directory . -c -o coverage.info
@@ -55,5 +58,7 @@ then
   echo '<html><head><meta http-equiv="refresh" content="0;URL=lcov-report/index.html"></head></html>' > \
     ../reports/node_coverage/index.html
 else
-  JUNIT_REPORT_PATH=src/node/reports.xml JUNIT_REPORT_STACK=1 ./node_modules/.bin/mocha --reporter mocha-jenkins-reporter src/node/test
+  JUNIT_REPORT_PATH=src/node/reports.xml JUNIT_REPORT_STACK=1 \
+    ./node_modules/.bin/mocha --timeout $timeout \
+    --reporter mocha-jenkins-reporter $test_directory
 fi

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -334,13 +334,14 @@ class RubyLanguage(object):
 
   def test_specs(self, config, args):
     return [config.job_spec(['tools/run_tests/run_ruby.sh'], None,
+                            timeout_seconds=10*60,
                             environ=_FORCE_ENVIRON_FOR_WRAPPERS)]
 
   def pre_build_steps(self):
     return [['tools/run_tests/pre_build_ruby.sh']]
 
   def make_targets(self, test_regex):
-    return ['static_c']
+    return []
 
   def make_options(self):
     return []
@@ -1197,4 +1198,3 @@ else:
   if BuildAndRunError.POST_TEST in errors:
     exit_code |= 4
   sys.exit(exit_code)
-


### PR DESCRIPTION
This should fix #3598 and #5294.

This also removes a now-irrelevant make target from the Ruby test build.