### PR TITLE
Proof of concept of a bare-metal soc implementation.

### DIFF
--- a/test/exotic/bare-metal.h
+++ b/test/exotic/bare-metal.h
@@ -1,0 +1,24 @@
+#define GPR_NO_AUTODETECT_PLATFORM
+#define GPR_PLATFORM_STRING "custom"
+#define GPR_GCC_ATOMIC 1
+#define GPR_GCC_TLS 1
+#define GPR_POSIX_STRING 1
+#define GPR_ARCH_32 1
+#define GPR_CPU_CUSTOM 1
+#define GPR_CUSTOM_SOCKET 1
+#define GPR_CUSTOM_SYNC 1
+
+typedef void * gpr_mu;
+typedef void * gpr_cv;
+typedef void * gpr_once;
+#define GPR_ONCE_INIT NULL
+
+typedef void * grpc_pollset;
+typedef void * grpc_pollset_worker;
+typedef void * grpc_pollset_set;
+
+struct grpc_closure;
+typedef struct grpc_closure grpc_closure;
+
+struct grpc_exec_ctx;
+typedef struct grpc_exec_ctx grpc_exec_ctx;

--- a/test/exotic/run-make.sh
+++ b/test/exotic/run-make.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+cd $(dirname $0)/../..
+cwd=`pwd`
+
+# this requires the debian/ubuntu package gcc-arm-none-eabi
+
+export CC=arm-none-eabi-gcc
+export AR="arm-none-eabi-ar rcs"
+export CPPFLAGS="-include $cwd/test/exotic/bare-metal.h"
+
+make $cwd/libs/opt/libgrpc_unsecure.a


### PR DESCRIPTION
This is more work in progress than anything else, and this doesn't compile yet. There's things to clean up in grpc, for instance, the fact we assume that sockaddr exists in the name resolver.

Ideally, we should be able to link a dummy binary with LWIP-like API calls, and leave that as a build test for Jenkins.
