### PR TITLE
Fixing a reported ruby crash when using ruby_vm_at_exit.

### DIFF
--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -302,6 +302,16 @@ void Init_grpc_c() {
     return;
   }
 
+  /* ruby_vm_at_exit doesn't seem to be working. It would crash once every
+   * blue moon, and some users are getting it repeatedly. See the discussions
+   *  - https://github.com/grpc/grpc/pull/5337
+   *  - https://bugs.ruby-lang.org/issues/12095
+   *
+   * In order to still be able to handle the (unlikely) situation where the
+   * extension is loaded by a first Ruby VM that is subsequently destroyed,
+   * then loaded again by another VM within the same process, we need to
+   * schedule our initialization and destruction only once.
+   */
   gpr_once_init(&g_once_init, grpc_ruby_once_init);
 
   grpc_rb_mGRPC = rb_define_module("GRPC");

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -289,15 +289,20 @@ VALUE sym_code = Qundef;
 VALUE sym_details = Qundef;
 VALUE sym_metadata = Qundef;
 
+static gpr_once g_once_init = GPR_ONCE_INIT;
+
+static void grpc_ruby_once_init() {
+  grpc_init();
+  atexit(grpc_rb_shutdown);
+}
+
 void Init_grpc_c() {
   if (!grpc_rb_load_core()) {
     rb_raise(rb_eLoadError, "Couldn't find or load gRPC's dynamic C core");
     return;
   }
 
-  grpc_init();
-
-  atexit(grpc_rb_shutdown);
+  gpr_once_init(&g_once_init, grpc_ruby_once_init);
 
   grpc_rb_mGRPC = rb_define_module("GRPC");
   grpc_rb_mGrpcCore = rb_define_module_under(grpc_rb_mGRPC, "Core");

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -269,8 +269,7 @@ static void Init_grpc_time_consts() {
   id_tv_nsec = rb_intern("tv_nsec");
 }
 
-static void grpc_rb_shutdown(VALUE val) {
-  (void)val;
+static void grpc_rb_shutdown(void) {
   grpc_shutdown();
 }
 
@@ -298,7 +297,7 @@ void Init_grpc_c() {
 
   grpc_init();
 
-  rb_set_end_proc(grpc_rb_shutdown, Qnil);
+  atexit(grpc_rb_shutdown);
 
   grpc_rb_mGRPC = rb_define_module("GRPC");
   grpc_rb_mGrpcCore = rb_define_module_under(grpc_rb_mGRPC, "Core");

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -269,20 +269,10 @@ static void Init_grpc_time_consts() {
   id_tv_nsec = rb_intern("tv_nsec");
 }
 
-/*
-   TODO: find an alternative to ruby_vm_at_exit that is ok in Ruby 2.0 where
-   RUBY_TYPED_FREE_IMMEDIATELY is not defined.
-
-   At the moment, registering a function using ruby_vm_at_exit segfaults in Ruby
-   2.0.  This is not an issue with the gRPC handler.  More likely, this was an
-   in issue with 2.0 that got resolved in 2.1 and has not been backported.
-*/
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
-static void grpc_rb_shutdown(ruby_vm_t *vm) {
-  (void)vm;
+static void grpc_rb_shutdown(VALUE val) {
+  (void)val;
   grpc_shutdown();
 }
-#endif
 
 /* Initialize the GRPC module structs */
 
@@ -308,10 +298,7 @@ void Init_grpc_c() {
 
   grpc_init();
 
-/* TODO: find alternative to ruby_vm_at_exit that is ok in Ruby 2.0 */
-#ifdef RUBY_TYPED_FREE_IMMEDIATELY
-  ruby_vm_at_exit(grpc_rb_shutdown);
-#endif
+  rb_set_end_proc(grpc_rb_shutdown, Qnil);
 
   grpc_rb_mGRPC = rb_define_module("GRPC");
   grpc_rb_mGrpcCore = rb_define_module_under(grpc_rb_mGRPC, "Core");


### PR DESCRIPTION
@blowmage for the confirmation this actually fixes the problems.