### PR TITLE
Resolve races on initial metadata

### DIFF
--- a/include/grpc++/impl/codegen/async_stream.h
+++ b/include/grpc++/impl/codegen/async_stream.h
@@ -118,24 +118,20 @@ class ClientAsyncReader GRPC_FINAL : public ClientAsyncReaderInterface<R> {
     GPR_ASSERT(!context_->initial_metadata_received_);
 
     meta_ops_.set_output_tag(tag);
-    meta_ops_.RecvInitialMetadata(context_);
+    meta_ops_.RecvInitialMetadataLocked(context_);
     call_.PerformOps(&meta_ops_);
   }
 
   void Read(R* msg, void* tag) GRPC_OVERRIDE {
     read_ops_.set_output_tag(tag);
-    if (!context_->initial_metadata_received_) {
-      read_ops_.RecvInitialMetadata(context_);
-    }
+    read_ops_.RecvInitialMetadataLockedChecked(context_);
     read_ops_.RecvMessage(msg);
     call_.PerformOps(&read_ops_);
   }
 
   void Finish(Status* status, void* tag) GRPC_OVERRIDE {
     finish_ops_.set_output_tag(tag);
-    if (!context_->initial_metadata_received_) {
-      finish_ops_.RecvInitialMetadata(context_);
-    }
+    finish_ops_.RecvInitialMetadataLockedChecked(context_);
     finish_ops_.ClientRecvStatus(context_, status);
     call_.PerformOps(&finish_ops_);
   }
@@ -180,7 +176,7 @@ class ClientAsyncWriter GRPC_FINAL : public ClientAsyncWriterInterface<W> {
     GPR_ASSERT(!context_->initial_metadata_received_);
 
     meta_ops_.set_output_tag(tag);
-    meta_ops_.RecvInitialMetadata(context_);
+    meta_ops_.RecvInitialMetadataLocked(context_);
     call_.PerformOps(&meta_ops_);
   }
 
@@ -199,9 +195,7 @@ class ClientAsyncWriter GRPC_FINAL : public ClientAsyncWriterInterface<W> {
 
   void Finish(Status* status, void* tag) GRPC_OVERRIDE {
     finish_ops_.set_output_tag(tag);
-    if (!context_->initial_metadata_received_) {
-      finish_ops_.RecvInitialMetadata(context_);
-    }
+    finish_ops_.RecvInitialMetadataLockedChecked(context_);
     finish_ops_.ClientRecvStatus(context_, status);
     call_.PerformOps(&finish_ops_);
   }
@@ -246,15 +240,13 @@ class ClientAsyncReaderWriter GRPC_FINAL
     GPR_ASSERT(!context_->initial_metadata_received_);
 
     meta_ops_.set_output_tag(tag);
-    meta_ops_.RecvInitialMetadata(context_);
+    meta_ops_.RecvInitialMetadataLocked(context_);
     call_.PerformOps(&meta_ops_);
   }
 
   void Read(R* msg, void* tag) GRPC_OVERRIDE {
     read_ops_.set_output_tag(tag);
-    if (!context_->initial_metadata_received_) {
-      read_ops_.RecvInitialMetadata(context_);
-    }
+    read_ops_.RecvInitialMetadataLockedChecked(context_);
     read_ops_.RecvMessage(msg);
     call_.PerformOps(&read_ops_);
   }
@@ -274,9 +266,7 @@ class ClientAsyncReaderWriter GRPC_FINAL
 
   void Finish(Status* status, void* tag) GRPC_OVERRIDE {
     finish_ops_.set_output_tag(tag);
-    if (!context_->initial_metadata_received_) {
-      finish_ops_.RecvInitialMetadata(context_);
-    }
+    finish_ops_.RecvInitialMetadataLockedChecked(context_);
     finish_ops_.ClientRecvStatus(context_, status);
     call_.PerformOps(&finish_ops_);
   }

--- a/include/grpc++/impl/codegen/async_unary_call.h
+++ b/include/grpc++/impl/codegen/async_unary_call.h
@@ -78,16 +78,14 @@ class ClientAsyncResponseReader GRPC_FINAL
 
     collection_->meta_buf_.SetCollection(collection_);
     collection_->meta_buf_.set_output_tag(tag);
-    collection_->meta_buf_.RecvInitialMetadata(context_);
+    collection_->meta_buf_.RecvInitialMetadataLocked(context_);
     call_.PerformOps(&collection_->meta_buf_);
   }
 
   void Finish(R* msg, Status* status, void* tag) {
     collection_->finish_buf_.SetCollection(collection_);
     collection_->finish_buf_.set_output_tag(tag);
-    if (!context_->initial_metadata_received_) {
-      collection_->finish_buf_.RecvInitialMetadata(context_);
-    }
+    collection_->finish_buf_.RecvInitialMetadataLockedChecked(context_);
     collection_->finish_buf_.RecvMessage(msg);
     collection_->finish_buf_.ClientRecvStatus(context_, status);
     call_.PerformOps(&collection_->finish_buf_);


### PR DESCRIPTION
This function introduces locked and checked versions of RecvInitialMetadata to resolve races that are reported by tsan running at desktop. FWIW, I do not believe that I have seen these errors at Jenkins.

These locked versions must be applied any time that there is a possibility that there may be operations that affect initial metadata (e.g., Read, RecvInitialMetadata, Finish) on different threads. This is essentially any case except for synchronous unary calls. That said, I have never seen these races trigger except for synchronous streams. That said, that could just be because our testing for async is not as good as our testing for sync. 

Note that this does not resolve ASAN flakes. The goal of this is just to resolve TSAN flakes.