### PR TITLE
Use traditional Bourne shell syntax for piping stdout and stderr

### DIFF
--- a/test/cpp/qps/qps-sweep.sh
+++ b/test/cpp/qps/qps-sweep.sh
@@ -72,7 +72,7 @@ for secure in true false; do
     --server_type=ASYNC_GENERIC_SERVER --outstanding_rpcs_per_channel=$deep \
     --client_channels=$wide --bbuf_req_size=0 --bbuf_resp_size=0 \
     --async_client_threads=0 --async_server_threads=0 --secure_test=$secure \
-    --num_servers=1 --num_clients=0 |& tee /tmp/qps-test.$$
+    --num_servers=1 --num_clients=0 2>&1 | tee /tmp/qps-test.$$
 
   # Scenario 2b: QPS with a single server core
   "$bins"/opt/qps_driver --rpc_type=STREAMING --client_type=ASYNC_CLIENT \


### PR DESCRIPTION
BSD platforms (such as Mac) are likely to have /bin/sh refer to traditional Bourne shell syntax, not Bash syntax. Change "|&" to "2>&1 |" since that's the traditional way to redirect stdout and stderr to a pipe