### PR TITLE
Fix PHP pecl package build on Mac

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2825,7 +2825,6 @@ php_config_m4:
   - grpc
   - gpr
   - boringssl
-  - z
   headers:
   - src/php/ext/grpc/byte_buffer.h
   - src/php/ext/grpc/call.h

--- a/config.m4
+++ b/config.m4
@@ -533,22 +533,73 @@ if test "$PHP_GRPC" != "no"; then
     third_party/boringssl/ssl/t1_enc.c \
     third_party/boringssl/ssl/t1_lib.c \
     third_party/boringssl/ssl/tls_record.c \
-    third_party/zlib/adler32.c \
-    third_party/zlib/compress.c \
-    third_party/zlib/crc32.c \
-    third_party/zlib/deflate.c \
-    third_party/zlib/gzclose.c \
-    third_party/zlib/gzlib.c \
-    third_party/zlib/gzread.c \
-    third_party/zlib/gzwrite.c \
-    third_party/zlib/infback.c \
-    third_party/zlib/inffast.c \
-    third_party/zlib/inflate.c \
-    third_party/zlib/inftrees.c \
-    third_party/zlib/trees.c \
-    third_party/zlib/uncompr.c \
-    third_party/zlib/zutil.c \
     , $ext_shared, , -Wall -Werror -std=c11 \
     -fvisibility=hidden -DOPENSSL_NO_ASM -D_GNU_SOURCE -DWIN32_LEAN_AND_MEAN \
     -D_HAS_EXCEPTIONS=0 -DNOMINMAX)
+
+  PHP_ADD_BUILD_DIR($ext_builddir/src/php/ext/grpc)
+
+  PHP_ADD_BUILD_DIR($ext_builddir/src/boringssl)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/census)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/channel)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/client_config)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/client_config/lb_policies)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/client_config/resolvers)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/compression)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/debug)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/httpcli)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/iomgr)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/json)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/profiling)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/proto/grpc/lb/v0)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/security)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/support)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/surface)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/transport)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/transport/chttp2)
+  PHP_ADD_BUILD_DIR($ext_builddir/src/core/tsi)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/aes)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/asn1)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/base64)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/bio)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/bn)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/bn/asm)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/buf)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/bytestring)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/chacha)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/cipher)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/cmac)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/conf)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/curve25519)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/des)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/dh)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/digest)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/dsa)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/ec)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/ecdh)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/ecdsa)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/engine)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/err)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/evp)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/hkdf)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/hmac)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/lhash)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/md4)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/md5)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/modes)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/obj)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/pem)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/pkcs8)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/poly1305)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/rand)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/rc4)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/rsa)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/sha)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/stack)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/x509)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/crypto/x509v3)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/ssl)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/boringssl/ssl/pqueue)
+  PHP_ADD_BUILD_DIR($ext_builddir/third_party/nanopb)
 fi

--- a/package.xml
+++ b/package.xml
@@ -856,32 +856,6 @@
     <file baseinstalldir="/" name="third_party/boringssl/ssl/t1_enc.c" role="src" />
     <file baseinstalldir="/" name="third_party/boringssl/ssl/t1_lib.c" role="src" />
     <file baseinstalldir="/" name="third_party/boringssl/ssl/tls_record.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/crc32.h" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/deflate.h" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/gzguts.h" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/inffast.h" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/inffixed.h" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/inflate.h" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/inftrees.h" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/trees.h" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/zconf.h" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/zlib.h" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/zutil.h" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/adler32.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/compress.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/crc32.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/deflate.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/gzclose.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/gzlib.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/gzread.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/gzwrite.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/infback.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/inffast.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/inflate.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/inftrees.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/trees.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/uncompr.c" role="src" />
-    <file baseinstalldir="/" name="third_party/zlib/zutil.c" role="src" />
   </dir>
  </contents>
  <dependencies>

--- a/templates/config.m4.template
+++ b/templates/config.m4.template
@@ -41,4 +41,18 @@
       , $ext_shared, , -Wall -Werror -std=c11 ${"\\"}
       -fvisibility=hidden -DOPENSSL_NO_ASM -D_GNU_SOURCE -DWIN32_LEAN_AND_MEAN ${"\\"}
       -D_HAS_EXCEPTIONS=0 -DNOMINMAX)
+
+    PHP_ADD_BUILD_DIR($ext_builddir/src/php/ext/grpc)
+  <%
+    dirs = {}
+    for lib in libs:
+      if lib.name in php_config_m4.get('deps', []):
+        for source in lib.src:
+          dirs[source[:source.rfind('/')]] = 1
+    dirs = dirs.keys()
+    dirs.sort()
+  %>
+    % for dir in dirs:
+    PHP_ADD_BUILD_DIR($ext_builddir/${dir})
+    % endfor
   fi

--- a/templates/package.xml.template
+++ b/templates/package.xml.template
@@ -12,7 +12,7 @@
     <email>grpc-packages@google.com</email>
     <active>yes</active>
    </lead>
-   <%! from time import strftime %><date>${"%Y-%m-%d" | strftime}</date>
+   <date>2016-02-24</date>
    <time>16:06:07</time>
    <version>
     <release>0.8.0</release>
@@ -149,7 +149,7 @@
       <release>beta</release>
       <api>beta</api>
      </stability>
-     <date>${"%Y-%m-%d" | strftime}</date>
+     <date>2016-02-24</date>
      <license>BSD</license>
      <notes>
   - Simplify gRPC PHP installation #4517

--- a/tools/run_tests/artifact_targets.py
+++ b/tools/run_tests/artifact_targets.py
@@ -254,10 +254,14 @@ class PHPArtifact:
     return []
 
   def build_jobspec(self):
-    return create_docker_jobspec(
-        self.name,
-        'tools/dockerfile/grpc_artifact_linux_{}'.format(self.arch),
-        'tools/run_tests/build_artifact_php.sh')
+    if self.platform == 'linux':
+      return create_docker_jobspec(
+          self.name,
+          'tools/dockerfile/grpc_artifact_linux_{}'.format(self.arch),
+          'tools/run_tests/build_artifact_php.sh')
+    else:
+      return create_jobspec(self.name,
+                            ['tools/run_tests/build_artifact_php.sh'])
 
 class ProtocArtifact:
   """Builds protoc and protoc-plugin artifacts"""

--- a/tools/run_tests/distribtest_targets.py
+++ b/tools/run_tests/distribtest_targets.py
@@ -201,7 +201,7 @@ class RubyDistribTest(object):
 class PHPDistribTest(object):
   """Tests PHP package"""
 
-  def __init__(self, platform, arch, docker_suffix):
+  def __init__(self, platform, arch, docker_suffix=None):
     self.name = 'php_%s_%s_%s' % (platform, arch, docker_suffix)
     self.platform = platform
     self.arch = arch
@@ -212,14 +212,18 @@ class PHPDistribTest(object):
     return []
 
   def build_jobspec(self):
-    if not self.platform == 'linux':
+    if self.platform == 'linux':
+      return create_docker_jobspec(self.name,
+                                   'tools/dockerfile/distribtest/php_%s_%s' % (
+                                       self.docker_suffix,
+                                       self.arch),
+                                   'test/distrib/php/run_distrib_test.sh')
+    elif self.platform == 'macos':
+      return create_jobspec(self.name,
+          ['test/distrib/php/run_distrib_test.sh'],
+          environ={'EXTERNAL_GIT_ROOT': '../../..'})
+    else:
       raise Exception("Not supported yet.")
-
-    return create_docker_jobspec(self.name,
-          'tools/dockerfile/distribtest/php_%s_%s' % (
-              self.docker_suffix,
-              self.arch),
-          'test/distrib/php/run_distrib_test.sh')
 
   def __str__(self):
     return self.name
@@ -271,6 +275,7 @@ def targets():
           NodeDistribTest('macos', 'x64', None, '5'),
           NodeDistribTest('linux', 'x86', 'jessie', '4'),
           PHPDistribTest('linux', 'x64', 'jessie'),
+          PHPDistribTest('macos', 'x64'),
           ] + [
             NodeDistribTest('linux', 'x64', os, version)
             for os in ('wheezy', 'jessie', 'ubuntu1204', 'ubuntu1404',


### PR DESCRIPTION
 * For issue #4517 
 * After PR #5249 we moved to one single PHP Pecl package for installation. After that, Mac installation fails because `pecl install` cannot find the source files. Need to add these macros `PHP_ADD_BUILD_DIR` to the `config.m4` file.
 * Also removed the `zlib` dependency for now. Couldn't get it to compile properly on Mac. Doesn't seem to create problem on linux or mac if I leave it out.
 * Fixes #5403 In the `package.xml` file, if the package date is not the current date, the `pear package` command throws a warning, not an error though. 
 * Fixes some jenkins script to have proper artifacts and distribtest targets for PHP+Mac