### PR TITLE
Expand gtest suites into individual run_tests tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1954,6 +1954,7 @@ targets:
   - linux
   - posix
 - name: alarm_cpp_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -1966,6 +1967,7 @@ targets:
   - gpr_test_util
   - gpr
 - name: async_end2end_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2012,6 +2014,7 @@ targets:
   - linux
   - posix
 - name: auth_property_iterator_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2024,6 +2027,7 @@ targets:
   - gpr_test_util
   - gpr
 - name: channel_arguments_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2033,6 +2037,7 @@ targets:
   - grpc
   - gpr
 - name: cli_call_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2045,6 +2050,7 @@ targets:
   - gpr_test_util
   - gpr
 - name: client_crash_test
+  gtest: true
   cpu_cost: 0.1
   build: test
   language: c++
@@ -2075,6 +2081,7 @@ targets:
   - gpr_test_util
   - gpr
 - name: credentials_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2084,6 +2091,7 @@ targets:
   - grpc
   - gpr
 - name: cxx_byte_buffer_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2095,6 +2103,7 @@ targets:
   - gpr_test_util
   - gpr
 - name: cxx_slice_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2106,6 +2115,7 @@ targets:
   - gpr_test_util
   - gpr
 - name: cxx_string_ref_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2113,6 +2123,7 @@ targets:
   deps:
   - grpc++
 - name: cxx_time_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2124,6 +2135,7 @@ targets:
   - gpr_test_util
   - gpr
 - name: end2end_test
+  gtest: true
   cpu_cost: 0.5
   build: test
   language: c++
@@ -2154,6 +2166,7 @@ targets:
   - linux
   - posix
 - name: generic_end2end_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2230,6 +2243,7 @@ targets:
   vs_config_type: Application
   vs_project_guid: '{069E9D05-B78B-4751-9252-D21EBAE7DE8E}'
 - name: grpclb_api_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2241,6 +2255,7 @@ targets:
   - grpc++
   - grpc
 - name: hybrid_end2end_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2320,6 +2335,7 @@ targets:
   - gpr
   - grpc++_test_config
 - name: mock_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2455,6 +2471,7 @@ targets:
   - gpr
   - grpc++_test_config
 - name: secure_auth_context_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2484,6 +2501,7 @@ targets:
   - linux
   - posix
 - name: server_crash_test
+  gtest: true
   cpu_cost: 0.1
   build: test
   language: c++
@@ -2514,6 +2532,7 @@ targets:
   - gpr_test_util
   - gpr
 - name: shutdown_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2537,6 +2556,7 @@ targets:
   - gpr_test_util
   - gpr
 - name: streaming_throughput_test
+  gtest: true
   build: test
   language: c++
   src:
@@ -2613,6 +2633,7 @@ targets:
   - linux
   - posix
 - name: thread_stress_test
+  gtest: true
   cpu_cost: 100
   build: test
   language: c++
@@ -2626,6 +2647,7 @@ targets:
   - gpr_test_util
   - gpr
 - name: zookeeper_test
+  gtest: true
   build: test
   run: false
   language: c++

--- a/templates/tools/run_tests/tests.json.template
+++ b/templates/tools/run_tests/tests.json.template
@@ -3,11 +3,12 @@
   <%!
   import json
   %>
-  
+
   ${json.dumps([{"name": tgt.name,
                  "language": tgt.language,
                  "platforms": tgt.platforms,
                  "ci_platforms": tgt.ci_platforms,
+                 "gtest": tgt.gtest,
                  "exclude_configs": tgt.get("exclude_configs", []),
                  "args": [],
                  "flaky": tgt.flaky,

--- a/tools/buildgen/build-cleaner.py
+++ b/tools/buildgen/build-cleaner.py
@@ -40,6 +40,7 @@ TEST = (os.environ.get('TEST', 'false') == 'true')
 _TOP_LEVEL_KEYS = ['settings', 'proto_deps', 'filegroups', 'libs', 'targets', 'vspackages']
 _ELEM_KEYS = [
     'name',
+    'gtest',
     'cpu_cost',
     'flaky',
     'build',
@@ -98,4 +99,3 @@ for filename in sys.argv[1:]:
   else:
     with open(filename, 'w') as f:
       f.write(output)
-

--- a/tools/buildgen/plugins/expand_bin_attrs.py
+++ b/tools/buildgen/plugins/expand_bin_attrs.py
@@ -52,6 +52,7 @@ def mako_plugin(dictionary):
     tgt['ci_platforms'] = sorted(tgt.get('ci_platforms', tgt['platforms']))
     tgt['boringssl'] = tgt.get('boringssl', False)
     tgt['zlib'] = tgt.get('zlib', False)
+    tgt['gtest'] = tgt.get('gtest', False)
 
   libs = dictionary.get('libs')
   for lib in libs:

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -161,6 +161,10 @@ class CLanguage(object):
         binary = 'bins/%s/%s' % (self.config.build_config, target['name'])
       if os.path.isfile(binary):
         if 'gtest' in target and target['gtest']:
+          # here we parse the output of --gtest_list_tests to build up a
+          # complete list of the tests contained in a binary
+          # for each test, we then add a job to run, filtering for just that
+          # test
           with open(os.devnull, 'w') as fnull:
             tests = subprocess.check_output([binary, '--gtest_list_tests'],
                                             stderr=fnull)

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -160,12 +160,34 @@ class CLanguage(object):
       else:
         binary = 'bins/%s/%s' % (self.config.build_config, target['name'])
       if os.path.isfile(binary):
-        cmdline = [binary] + target['args']
-        out.append(self.config.job_spec(cmdline, [binary],
-                                        shortname=' '.join(cmdline),
-                                        cpu_cost=target['cpu_cost'],
-                                        environ={'GRPC_DEFAULT_SSL_ROOTS_FILE_PATH':
-                                                 _ROOT + '/src/core/tsi/test_creds/ca.pem'}))
+        if 'gtest' in target and target['gtest']:
+          with open(os.devnull, 'w') as fnull:
+            tests = subprocess.check_output([binary, '--gtest_list_tests'],
+                                            stderr=fnull)
+          base = None
+          for line in tests.split('\n'):
+            i = line.find('#')
+            if i >= 0: line = line[:i]
+            if not line: continue
+            if line[0] != ' ':
+              base = line
+            else:
+              assert base is not None
+              assert line[1] == ' '
+              test = base + line[2:]
+              cmdline = [binary] + ['--gtest_filter=%s' % test]
+              out.append(self.config.job_spec(cmdline, [binary],
+                                              shortname='%s:%s' % (binary, test),
+                                              cpu_cost=target['cpu_cost'],
+                                              environ={'GRPC_DEFAULT_SSL_ROOTS_FILE_PATH':
+                                                       _ROOT + '/src/core/tsi/test_creds/ca.pem'}))
+        else:
+          cmdline = [binary] + target['args']
+          out.append(self.config.job_spec(cmdline, [binary],
+                                          shortname=' '.join(cmdline),
+                                          cpu_cost=target['cpu_cost'],
+                                          environ={'GRPC_DEFAULT_SSL_ROOTS_FILE_PATH':
+                                                   _ROOT + '/src/core/tsi/test_creds/ca.pem'}))
       elif self.args.regex == '.*' or self.platform == 'windows':
         print '\nWARNING: binary not found, skipping', binary
     return sorted(out)

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -174,11 +174,11 @@ class CLanguage(object):
             if i >= 0: line = line[:i]
             if not line: continue
             if line[0] != ' ':
-              base = line
+              base = line.strip()
             else:
               assert base is not None
               assert line[1] == ' '
-              test = base + line[2:]
+              test = base + line.strip()
               cmdline = [binary] + ['--gtest_filter=%s' % test]
               out.append(self.config.job_spec(cmdline, [binary],
                                               shortname='%s:%s' % (binary, test),

--- a/tools/run_tests/tests.json
+++ b/tools/run_tests/tests.json
@@ -12,6 +12,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "alarm_test", 
     "platforms": [
@@ -32,6 +33,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "algorithm_test", 
     "platforms": [
@@ -52,6 +54,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "alloc_test", 
     "platforms": [
@@ -72,6 +75,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "alpn_test", 
     "platforms": [
@@ -92,6 +96,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "bin_encoder_test", 
     "platforms": [
@@ -112,6 +117,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "census_context_test", 
     "platforms": [
@@ -132,6 +138,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "channel_create_test", 
     "platforms": [
@@ -152,6 +159,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "chttp2_hpack_encoder_test", 
     "platforms": [
@@ -172,6 +180,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "chttp2_status_conversion_test", 
     "platforms": [
@@ -192,6 +201,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "chttp2_stream_map_test", 
     "platforms": [
@@ -212,6 +222,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "chttp2_varint_test", 
     "platforms": [
@@ -232,6 +243,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "compression_test", 
     "platforms": [
@@ -252,6 +264,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "dns_resolver_test", 
     "platforms": [
@@ -271,6 +284,7 @@
     "cpu_cost": 0.1, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "dualstack_socket_test", 
     "platforms": [
@@ -290,6 +304,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "endpoint_pair_test", 
     "platforms": [
@@ -309,6 +324,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "fd_conservation_posix_test", 
     "platforms": [
@@ -327,6 +343,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "fd_posix_test", 
     "platforms": [
@@ -345,6 +362,7 @@
     "cpu_cost": 2, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "fling_stream_test", 
     "platforms": [
@@ -363,6 +381,7 @@
     "cpu_cost": 2, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "fling_test", 
     "platforms": [
@@ -382,6 +401,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_avl_test", 
     "platforms": [
@@ -402,6 +422,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_cmdline_test", 
     "platforms": [
@@ -422,6 +443,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_cpu_test", 
     "platforms": [
@@ -442,6 +464,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_env_test", 
     "platforms": [
@@ -462,6 +485,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_histogram_test", 
     "platforms": [
@@ -482,6 +506,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_host_port_test", 
     "platforms": [
@@ -502,6 +527,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_load_file_test", 
     "platforms": [
@@ -522,6 +548,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_log_test", 
     "platforms": [
@@ -542,6 +569,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_slice_buffer_test", 
     "platforms": [
@@ -562,6 +590,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_slice_test", 
     "platforms": [
@@ -582,6 +611,7 @@
     "cpu_cost": 10, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_stack_lockfree_test", 
     "platforms": [
@@ -602,6 +632,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_string_test", 
     "platforms": [
@@ -622,6 +653,7 @@
     "cpu_cost": 10, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_sync_test", 
     "platforms": [
@@ -642,6 +674,7 @@
     "cpu_cost": 10, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_thd_test", 
     "platforms": [
@@ -662,6 +695,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_time_test", 
     "platforms": [
@@ -682,6 +716,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_tls_test", 
     "platforms": [
@@ -702,6 +737,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "gpr_useful_test", 
     "platforms": [
@@ -722,6 +758,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "grpc_auth_context_test", 
     "platforms": [
@@ -742,6 +779,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "grpc_b64_test", 
     "platforms": [
@@ -762,6 +800,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "grpc_byte_buffer_reader_test", 
     "platforms": [
@@ -782,6 +821,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "grpc_channel_args_test", 
     "platforms": [
@@ -802,6 +842,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "grpc_channel_stack_test", 
     "platforms": [
@@ -822,6 +863,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "grpc_completion_queue_test", 
     "platforms": [
@@ -842,6 +884,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "grpc_credentials_test", 
     "platforms": [
@@ -862,6 +905,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "grpc_invalid_channel_args_test", 
     "platforms": [
@@ -881,6 +925,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "grpc_json_token_test", 
     "platforms": [
@@ -900,6 +945,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "grpc_jwt_verifier_test", 
     "platforms": [
@@ -920,6 +966,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "grpc_security_connector_test", 
     "platforms": [
@@ -940,6 +987,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "hpack_parser_test", 
     "platforms": [
@@ -960,6 +1008,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "hpack_table_test", 
     "platforms": [
@@ -980,6 +1029,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "httpcli_format_request_test", 
     "platforms": [
@@ -1000,6 +1050,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "httpcli_parser_test", 
     "platforms": [
@@ -1019,6 +1070,7 @@
     "cpu_cost": 0.5, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "httpcli_test", 
     "platforms": [
@@ -1035,6 +1087,7 @@
     "cpu_cost": 0.5, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "httpscli_test", 
     "platforms": [
@@ -1052,6 +1105,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "init_test", 
     "platforms": [
@@ -1072,6 +1126,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "invalid_call_argument_test", 
     "platforms": [
@@ -1092,6 +1147,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "json_rewrite_test", 
     "platforms": [
@@ -1112,6 +1168,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "json_stream_error_test", 
     "platforms": [
@@ -1132,6 +1189,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "json_test", 
     "platforms": [
@@ -1152,6 +1210,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "lame_client_test", 
     "platforms": [
@@ -1172,6 +1231,7 @@
     "cpu_cost": 0.1, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "lb_policies_test", 
     "platforms": [
@@ -1192,6 +1252,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "message_compress_test", 
     "platforms": [
@@ -1212,6 +1273,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "mlog_test", 
     "platforms": [
@@ -1232,6 +1294,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "multiple_server_queues_test", 
     "platforms": [
@@ -1252,6 +1315,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "murmur_hash_test", 
     "platforms": [
@@ -1272,6 +1336,7 @@
     "cpu_cost": 0.1, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "no_server_test", 
     "platforms": [
@@ -1292,6 +1357,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "resolve_address_test", 
     "platforms": [
@@ -1312,6 +1378,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "secure_channel_create_test", 
     "platforms": [
@@ -1332,6 +1399,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "secure_endpoint_test", 
     "platforms": [
@@ -1352,6 +1420,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "server_chttp2_test", 
     "platforms": [
@@ -1372,6 +1441,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "server_test", 
     "platforms": [
@@ -1392,6 +1462,7 @@
     "cpu_cost": 0.1, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "set_initial_connect_string_test", 
     "platforms": [
@@ -1412,6 +1483,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "sockaddr_resolver_test", 
     "platforms": [
@@ -1432,6 +1504,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "sockaddr_utils_test", 
     "platforms": [
@@ -1451,6 +1524,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "socket_utils_test", 
     "platforms": [
@@ -1469,6 +1543,7 @@
     "cpu_cost": 0.5, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "tcp_client_posix_test", 
     "platforms": [
@@ -1487,6 +1562,7 @@
     "cpu_cost": 0.5, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "tcp_posix_test", 
     "platforms": [
@@ -1505,6 +1581,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "tcp_server_posix_test", 
     "platforms": [
@@ -1524,6 +1601,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "time_averaged_stats_test", 
     "platforms": [
@@ -1544,6 +1622,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "timeout_encoding_test", 
     "platforms": [
@@ -1564,6 +1643,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "timer_heap_test", 
     "platforms": [
@@ -1584,6 +1664,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "timer_list_test", 
     "platforms": [
@@ -1604,6 +1685,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "timers_test", 
     "platforms": [
@@ -1624,6 +1706,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "transport_connectivity_state_test", 
     "platforms": [
@@ -1644,6 +1727,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "transport_metadata_test", 
     "platforms": [
@@ -1663,6 +1747,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "transport_security_test", 
     "platforms": [
@@ -1681,6 +1766,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "udp_server_test", 
     "platforms": [
@@ -1700,6 +1786,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "uri_parser_test", 
     "platforms": [
@@ -1719,6 +1806,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "workqueue_test", 
     "platforms": [
@@ -1738,6 +1826,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "alarm_cpp_test", 
     "platforms": [
@@ -1758,6 +1847,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "async_end2end_test", 
     "platforms": [
@@ -1777,6 +1867,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c++", 
     "name": "async_streaming_ping_pong_test", 
     "platforms": [
@@ -1795,6 +1886,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c++", 
     "name": "async_unary_ping_pong_test", 
     "platforms": [
@@ -1814,6 +1906,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "auth_property_iterator_test", 
     "platforms": [
@@ -1834,6 +1927,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "channel_arguments_test", 
     "platforms": [
@@ -1854,6 +1948,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "cli_call_test", 
     "platforms": [
@@ -1873,6 +1968,7 @@
     "cpu_cost": 0.1, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "client_crash_test", 
     "platforms": [
@@ -1892,6 +1988,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "credentials_test", 
     "platforms": [
@@ -1912,6 +2009,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "cxx_byte_buffer_test", 
     "platforms": [
@@ -1932,6 +2030,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "cxx_slice_test", 
     "platforms": [
@@ -1952,6 +2051,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "cxx_string_ref_test", 
     "platforms": [
@@ -1972,6 +2072,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "cxx_time_test", 
     "platforms": [
@@ -1992,6 +2093,7 @@
     "cpu_cost": 0.5, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "end2end_test", 
     "platforms": [
@@ -2011,6 +2113,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c++", 
     "name": "generic_async_streaming_ping_pong_test", 
     "platforms": [
@@ -2030,6 +2133,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "generic_end2end_test", 
     "platforms": [
@@ -2050,6 +2154,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "grpclb_api_test", 
     "platforms": [
@@ -2070,6 +2175,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "hybrid_end2end_test", 
     "platforms": [
@@ -2089,6 +2195,7 @@
     "cpu_cost": 0.1, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c++", 
     "name": "interop_test", 
     "platforms": [
@@ -2108,6 +2215,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "mock_test", 
     "platforms": [
@@ -2127,6 +2235,7 @@
     "cpu_cost": 10, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c++", 
     "name": "qps_openloop_test", 
     "platforms": [
@@ -2145,6 +2254,7 @@
     "cpu_cost": 10, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c++", 
     "name": "qps_test", 
     "platforms": [
@@ -2164,6 +2274,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "secure_auth_context_test", 
     "platforms": [
@@ -2183,6 +2294,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c++", 
     "name": "secure_sync_unary_ping_pong_test", 
     "platforms": [
@@ -2201,6 +2313,7 @@
     "cpu_cost": 0.1, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "server_crash_test", 
     "platforms": [
@@ -2220,6 +2333,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "shutdown_test", 
     "platforms": [
@@ -2240,6 +2354,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c++", 
     "name": "status_test", 
     "platforms": [
@@ -2259,6 +2374,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "streaming_throughput_test", 
     "platforms": [
@@ -2277,6 +2393,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c++", 
     "name": "sync_streaming_ping_pong_test", 
     "platforms": [
@@ -2295,6 +2412,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c++", 
     "name": "sync_unary_ping_pong_test", 
     "platforms": [
@@ -2314,6 +2432,7 @@
     "cpu_cost": 100, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": true, 
     "language": "c++", 
     "name": "thread_stress_test", 
     "platforms": [
@@ -2334,6 +2453,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c89", 
     "name": "public_headers_must_be_c89", 
     "platforms": [
@@ -2354,6 +2474,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "badreq_bad_client_test", 
     "platforms": [
@@ -2374,6 +2495,7 @@
     "cpu_cost": 0.2, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "connection_prefix_bad_client_test", 
     "platforms": [
@@ -2394,6 +2516,7 @@
     "cpu_cost": 0.2, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "headers_bad_client_test", 
     "platforms": [
@@ -2414,6 +2537,7 @@
     "cpu_cost": 0.2, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "initial_settings_frame_bad_client_test", 
     "platforms": [
@@ -2434,6 +2558,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "server_registered_method_bad_client_test", 
     "platforms": [
@@ -2454,6 +2579,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "simple_request_bad_client_test", 
     "platforms": [
@@ -2474,6 +2600,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "unknown_frame_bad_client_test", 
     "platforms": [
@@ -2494,6 +2621,7 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "window_overflow_bad_client_test", 
     "platforms": [
@@ -2513,6 +2641,7 @@
     "cpu_cost": 0.1, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "bad_ssl_alpn_test", 
     "platforms": [
@@ -2531,6 +2660,7 @@
     "cpu_cost": 0.1, 
     "exclude_configs": [], 
     "flaky": false, 
+    "gtest": false, 
     "language": "c", 
     "name": "bad_ssl_cert_test", 
     "platforms": [


### PR DESCRIPTION
This will allow tracking individual test status in some of the large suites that we have in C++ land currently.