### PR TITLE
Fix SimultaneousReadWritesDone test

### DIFF
--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -904,9 +904,9 @@ TEST_P(End2endTest, SimultaneousReadWritesDone) {
   std::thread reader_thread(ReaderThreadFunc, stream.get(), &ev);
   gpr_event_wait(&ev, gpr_inf_future(GPR_CLOCK_REALTIME));
   stream->WritesDone();
+  reader_thread.join();
   Status s = stream->Finish();
   EXPECT_TRUE(s.ok());
-  reader_thread.join();
 }
 
 TEST_P(End2endTest, ChannelState) {


### PR DESCRIPTION
This test was not observing the contract on the streaming API. In particular, Finish should not be called until the client is sure that there is no more message to be read (as documented in the comments for ClientStreamingInterface::Finish).

We need to improve the documentation for this interface. An issue is filed in #5420 .
