### PR TITLE
Fix PHP pecl install problem on Mac

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -533,7 +533,8 @@ if test "$PHP_GRPC" != "no"; then
     third_party/boringssl/ssl/t1_enc.c \
     third_party/boringssl/ssl/t1_lib.c \
     third_party/boringssl/ssl/tls_record.c \
-    , $ext_shared, , -Wall -Werror -std=c11 \
+    , $ext_shared, , -Wall -Werror \
+    -Wno-parentheses-equality -Wno-unused-value -std=c11 \
     -fvisibility=hidden -DOPENSSL_NO_ASM -D_GNU_SOURCE -DWIN32_LEAN_AND_MEAN \
     -D_HAS_EXCEPTIONS=0 -DNOMINMAX)
 

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
   <email>grpc-packages@google.com</email>
   <active>yes</active>
  </lead>
- <date>2016-02-25</date>
+ <date>2016-02-24</date>
  <time>16:06:07</time>
  <version>
   <release>0.8.0</release>
@@ -963,7 +963,7 @@ Update to wrap gRPC C Core version 0.10.0
     <release>beta</release>
     <api>beta</api>
    </stability>
-   <date>2016-02-25</date>
+   <date>2016-02-24</date>
    <license>BSD</license>
    <notes>
 - Simplify gRPC PHP installation #4517

--- a/templates/config.m4.template
+++ b/templates/config.m4.template
@@ -38,7 +38,8 @@
       % endfor
       % endif
       % endfor
-      , $ext_shared, , -Wall -Werror -std=c11 ${"\\"}
+      , $ext_shared, , -Wall -Werror ${"\\"}
+      -Wno-parentheses-equality -Wno-unused-value -std=c11 ${"\\"}
       -fvisibility=hidden -DOPENSSL_NO_ASM -D_GNU_SOURCE -DWIN32_LEAN_AND_MEAN ${"\\"}
       -D_HAS_EXCEPTIONS=0 -DNOMINMAX)
 


### PR DESCRIPTION
Cont #5407 

In some subset of Jenkins Mac machines, the new PHP Pecl package is installing with errors. Need to add these CFLAGS to ignore the warnings for now. Some happen in our code which can be fixed later. Some happens in boringssl so not sure how much we can do there.