### PR TITLE
Don't fail when generating report.xml on gcc4.4 

### DIFF
--- a/tools/run_tests/report_utils.py
+++ b/tools/run_tests/report_utils.py
@@ -47,7 +47,7 @@ def _filter_msg(msg, output_format):
     # that make XML report unparseable.
     filtered_msg = filter(
         lambda x: x in string.printable and x != '\f' and x != '\v',
-        msg.decode(errors='ignore'))
+        msg.decode('UTF-8', 'ignore'))
     if output_format == 'HTML':
       filtered_msg = filtered_msg.replace('"', '&quot;')
     return filtered_msg


### PR DESCRIPTION
Because debian squeezy on has python2.6 and we are running gcc4.4 under that image, allow run_tests.py to pass under python 2.6.

Fixes
https://grpc-testing.appspot.com/job/gRPC_portability_master/459/language=c,scenario=linux_x64_gcc4.4/console
```
File "/var/local/git/grpc/tools/run_tests/report_utils.py", line 50, in _filter_msg
    msg.decode(errors='ignore'))
TypeError: decode() takes no keyword arguments
```