### PR TITLE
Remove binary tags, restrict tag characters to ASCII

### DIFF
--- a/include/grpc/census.h
+++ b/include/grpc/census.h
@@ -80,18 +80,18 @@ CENSUSAPI int census_enabled(void);
   metrics will be recorded. Keys are unique within a context. */
 typedef struct census_context census_context;
 
-/* A tag is a key:value pair. The key is a non-empty, printable (UTF-8
-   encoded), nil-terminated string. The value is a binary string, that may be
-   printable. There are limits on the sizes of both keys and values (see
-   CENSUS_MAX_TAG_KB_LEN definition below), and the number of tags that can be
-   propagated (CENSUS_MAX_PROPAGATED_TAGS). Users should also remember that
-   some systems may have limits on, e.g., the number of bytes that can be
-   transmitted as metadata, and that larger tags means more memory consumed
-   and time in processing. */
+/* A tag is a key:value pair. Both keys and values are nil-terminated strings,
+   containing printable ASCII characters (decimal 32-126). Keys must be at
+   least one character in length. Both keys and values can have at most
+   CENSUS_MAX_TAG_KB_LEN characters (including the terminating nil). The
+   maximum number of tags that can be propagated is
+   CENSUS_MAX_PROPAGATED_TAGS. Users should also remember that some systems
+   may have limits on, e.g., the number of bytes that can be transmitted as
+   metadata, and that larger tags means more memory consumed and time in
+   processing. */
 typedef struct {
   const char *key;
   const char *value;
-  size_t value_len;
   uint8_t flags;
 } census_tag;
 
@@ -103,28 +103,25 @@ typedef struct {
 /* Tag flags. */
 #define CENSUS_TAG_PROPAGATE 1 /* Tag should be propagated over RPC */
 #define CENSUS_TAG_STATS 2     /* Tag will be used for statistics aggregation */
-#define CENSUS_TAG_BINARY 4    /* Tag value is not printable */
-#define CENSUS_TAG_RESERVED 8  /* Reserved for internal use. */
-/* Flag values 8,16,32,64,128 are reserved for future/internal use. Clients
+#define CENSUS_TAG_RESERVED 4  /* Reserved for internal use. */
+/* Flag values 4,8,16,32,64,128 are reserved for future/internal use. Clients
    should not use or rely on their values. */
 
 #define CENSUS_TAG_IS_PROPAGATED(flags) (flags & CENSUS_TAG_PROPAGATE)
 #define CENSUS_TAG_IS_STATS(flags) (flags & CENSUS_TAG_STATS)
-#define CENSUS_TAG_IS_BINARY(flags) (flags & CENSUS_TAG_BINARY)
 
 /* An instance of this structure is kept by every context, and records the
    basic information associated with the creation of that context. */
 typedef struct {
-  int n_propagated_tags;        /* number of propagated printable tags */
-  int n_propagated_binary_tags; /* number of propagated binary tags */
-  int n_local_tags;             /* number of non-propagated (local) tags */
-  int n_deleted_tags;           /* number of tags that were deleted */
-  int n_added_tags;             /* number of tags that were added */
-  int n_modified_tags;          /* number of tags that were modified */
-  int n_invalid_tags;           /* number of tags with bad keys or values (e.g.
-                                   longer than CENSUS_MAX_TAG_KV_LEN) */
-  int n_ignored_tags;           /* number of tags ignored because of
-                                   CENSUS_MAX_PROPAGATED_TAGS limit. */
+  int n_propagated_tags; /* number of propagated tags */
+  int n_local_tags;      /* number of non-propagated (local) tags */
+  int n_deleted_tags;    /* number of tags that were deleted */
+  int n_added_tags;      /* number of tags that were added */
+  int n_modified_tags;   /* number of tags that were modified */
+  int n_invalid_tags;    /* number of tags with bad keys or values (e.g.
+                            longer than CENSUS_MAX_TAG_KV_LEN) */
+  int n_ignored_tags;    /* number of tags ignored because of
+                            CENSUS_MAX_PROPAGATED_TAGS limit. */
 } census_context_status;
 
 /* Create a new context, adding and removing tags from an existing context.
@@ -132,10 +129,10 @@ typedef struct {
    to add as many tags in a single operation as is practical for the client.
    @param base Base context to build upon. Can be NULL.
    @param tags A set of tags to be added/changed/deleted. Tags with keys that
-   are in 'tags', but not 'base', are added to the tag set. Keys that are in
+   are in 'tags', but not 'base', are added to the context. Keys that are in
    both 'tags' and 'base' will have their value/flags modified. Tags with keys
-   in both, but with NULL or zero-length values, will be deleted from the tag
-   set. Tags with invalid (too long or short) keys or values will be ignored.
+   in both, but with NULL values, will be deleted from the context. Tags with
+   invalid (too long or short) keys or values will be ignored.
    If adding a tag will result in more than CENSUS_MAX_PROPAGATED_TAGS in either
    binary or non-binary tags, they will be ignored, as will deletions of
    tags that don't exist.
@@ -185,32 +182,19 @@ CENSUSAPI int census_context_get_tag(const census_context *context,
    for use by RPC systems only, for purposes of transmitting/receiving contexts.
    */
 
-/* Encode a context into a buffer. The propagated tags are encoded into the
-   buffer in two regions: one for printable tags, and one for binary tags.
+/* Encode a context into a buffer.
    @param context context to be encoded
-   @param buffer pointer to buffer. This address will be used to encode the
-                 printable tags.
+   @param buffer buffer into which the context will be encoded.
    @param buf_size number of available bytes in buffer.
-   @param print_buf_size Will be set to the number of bytes consumed by
-                         printable tags.
-   @param bin_buf_size Will be set to the number of bytes used to encode the
-                       binary tags.
-   @return A pointer to the binary tag's encoded, or NULL if the buffer was
-           insufficiently large to hold the encoded tags. Thus, if successful,
-           printable tags are encoded into
-           [buffer, buffer + *print_buf_size) and binary tags into
-           [returned-ptr, returned-ptr + *bin_buf_size) (and the returned
-           pointer should be buffer + *print_buf_size) */
-CENSUSAPI char *census_context_encode(const census_context *context,
-                                      char *buffer, size_t buf_size,
-                                      size_t *print_buf_size,
-                                      size_t *bin_buf_size);
+   @return The number of buffer bytes consumed for the encoded context, or
+           zero if the buffer was of insufficient size. */
+CENSUSAPI size_t census_context_encode(const census_context *context,
+                                       char *buffer, size_t buf_size);
 
-/* Decode context buffers encoded with census_context_encode(). Returns NULL
+/* Decode context buffer encoded with census_context_encode(). Returns NULL
    if there is an error in parsing either buffer. */
-CENSUSAPI census_context *census_context_decode(const char *buffer, size_t size,
-                                                const char *bin_buffer,
-                                                size_t bin_size);
+CENSUSAPI census_context *census_context_decode(const char *buffer,
+                                                size_t size);
 
 /* Distributed traces can have a number of options. */
 enum census_trace_mask_values {

--- a/src/python/grpcio/grpc/_cython/imports.generated.h
+++ b/src/python/grpcio/grpc/_cython/imports.generated.h
@@ -91,10 +91,10 @@ extern census_context_next_tag_type census_context_next_tag_import;
 typedef int(*census_context_get_tag_type)(const census_context *context, const char *key, census_tag *tag);
 extern census_context_get_tag_type census_context_get_tag_import;
 #define census_context_get_tag census_context_get_tag_import
-typedef char *(*census_context_encode_type)(const census_context *context, char *buffer, size_t buf_size, size_t *print_buf_size, size_t *bin_buf_size);
+typedef size_t(*census_context_encode_type)(const census_context *context, char *buffer, size_t buf_size);
 extern census_context_encode_type census_context_encode_import;
 #define census_context_encode census_context_encode_import
-typedef census_context *(*census_context_decode_type)(const char *buffer, size_t size, const char *bin_buffer, size_t bin_size);
+typedef census_context *(*census_context_decode_type)(const char *buffer, size_t size);
 extern census_context_decode_type census_context_decode_import;
 #define census_context_decode census_context_decode_import
 typedef int(*census_trace_mask_type)(const census_context *context);

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.h
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.h
@@ -91,10 +91,10 @@ extern census_context_next_tag_type census_context_next_tag_import;
 typedef int(*census_context_get_tag_type)(const census_context *context, const char *key, census_tag *tag);
 extern census_context_get_tag_type census_context_get_tag_import;
 #define census_context_get_tag census_context_get_tag_import
-typedef char *(*census_context_encode_type)(const census_context *context, char *buffer, size_t buf_size, size_t *print_buf_size, size_t *bin_buf_size);
+typedef size_t(*census_context_encode_type)(const census_context *context, char *buffer, size_t buf_size);
 extern census_context_encode_type census_context_encode_import;
 #define census_context_encode census_context_encode_import
-typedef census_context *(*census_context_decode_type)(const char *buffer, size_t size, const char *bin_buffer, size_t bin_size);
+typedef census_context *(*census_context_decode_type)(const char *buffer, size_t size);
 extern census_context_decode_type census_context_decode_import;
 #define census_context_decode census_context_decode_import
 typedef int(*census_trace_mask_type)(const census_context *context);

--- a/test/core/census/context_test.c
+++ b/test/core/census/context_test.c
@@ -196,6 +196,22 @@ static void invalid_test(void) {
   context = census_context_create(NULL, &tag, 1, &status);
   GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
   census_context_destroy(context);
+  // invalid key character
+  key[0] = 31;  // 32 (' ') is the first valid character value
+  key[1] = 0;
+  GPR_ASSERT(strlen(key) == 1);
+  context = census_context_create(NULL, &tag, 1, &status);
+  GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
+  census_context_destroy(context);
+  // invalid value character
+  key[0] = ' ';
+  value[5] = 127;  // 127 (DEL) is ('~' + 1)
+  value[8] = 0;
+  GPR_ASSERT(strlen(key) == 1);
+  GPR_ASSERT(strlen(value) == 8);
+  context = census_context_create(NULL, &tag, 1, &status);
+  GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
+  census_context_destroy(context);
 }
 
 // Make a copy of a context

--- a/test/core/census/context_test.c
+++ b/test/core/census/context_test.c
@@ -42,60 +42,48 @@
 #include <string.h>
 #include "test/core/util/test_config.h"
 
-static uint8_t one_byte_val = 7;
-static uint32_t four_byte_val = 0x12345678;
-static uint64_t eight_byte_val = 0x1234567890abcdef;
-
-// A set of tags Used to create a basic context for testing. Each tag has a
-// unique set of flags. Note that replace_add_delete_test() relies on specific
-// offsets into this array - if you add or delete entries, you will also need
-// to change the test.
+// A set of tags Used to create a basic context for testing. Note that
+// replace_add_delete_test() relies on specific offsets into this array - if
+// you add or delete entries, you will also need to change the test.
 #define BASIC_TAG_COUNT 8
 static census_tag basic_tags[BASIC_TAG_COUNT] = {
-    /* 0 */ {"key0", "printable", 10, 0},
-    /* 1 */ {"k1", "a", 2, CENSUS_TAG_PROPAGATE},
-    /* 2 */ {"k2", "longer printable string", 24, CENSUS_TAG_STATS},
-    /* 3 */ {"key_three", (char *)&one_byte_val, 1, CENSUS_TAG_BINARY},
-    /* 4 */ {"really_long_key_4", "random", 7,
+    /* 0 */ {"key0", "tag value", 0},
+    /* 1 */ {"k1", "a", CENSUS_TAG_PROPAGATE},
+    /* 2 */ {"k2", "a longer tag value supercalifragilisticexpialiadocious",
+             CENSUS_TAG_STATS},
+    /* 3 */ {"key_three", "", 0},
+    /* 4 */ {"a_really_really_really_really_long_key_4", "random",
              CENSUS_TAG_PROPAGATE | CENSUS_TAG_STATS},
-    /* 5 */ {"k5", (char *)&four_byte_val, 4,
-             CENSUS_TAG_PROPAGATE | CENSUS_TAG_BINARY},
-    /* 6 */ {"k6", (char *)&eight_byte_val, 8,
-             CENSUS_TAG_STATS | CENSUS_TAG_BINARY},
-    /* 7 */ {"k7", (char *)&four_byte_val, 4,
-             CENSUS_TAG_PROPAGATE | CENSUS_TAG_STATS | CENSUS_TAG_BINARY}};
+    /* 5 */ {"k5", "v5", CENSUS_TAG_PROPAGATE},
+    /* 6 */ {"k6", "v6", CENSUS_TAG_STATS},
+    /* 7 */ {"k7", "v7", CENSUS_TAG_PROPAGATE | CENSUS_TAG_STATS}};
 
 // Set of tags used to modify the basic context. Note that
 // replace_add_delete_test() relies on specific offsets into this array - if
 // you add or delete entries, you will also need to change the test. Other
 // tests that rely on specific instances have XXX_XXX_OFFSET definitions (also
 // change the defines below if you add/delete entires).
-#define MODIFY_TAG_COUNT 11
+#define MODIFY_TAG_COUNT 10
 static census_tag modify_tags[MODIFY_TAG_COUNT] = {
 #define REPLACE_VALUE_OFFSET 0
-    /* 0 */ {"key0", "replace printable", 18, 0},  // replaces tag value only
+    /* 0 */ {"key0", "replace key0", 0},  // replaces tag value only
 #define ADD_TAG_OFFSET 1
-    /* 1 */ {"new_key", "xyzzy", 6, CENSUS_TAG_STATS},  // new tag
+    /* 1 */ {"new_key", "xyzzy", CENSUS_TAG_STATS},  // new tag
 #define DELETE_TAG_OFFSET 2
-    /* 2 */ {"k5", NULL, 5,
-             0},  // should delete tag, despite bogus value length
-    /* 3 */ {"k6", "foo", 0, 0},  // should delete tag, despite bogus value
-    /* 4 */ {"k6", "foo", 0, 0},  // try deleting already-deleted tag
-    /* 5 */ {"non-existent", NULL, 0, 0},  // another non-existent tag
-#define REPLACE_FLAG_OFFSET 6
-    /* 6 */ {"k1", "a", 2, 0},                   // change flags only
-    /* 7 */ {"k7", "bar", 4, CENSUS_TAG_STATS},  // change flags and value
-    /* 8 */ {"k2", (char *)&eight_byte_val, 8,
-             CENSUS_TAG_BINARY | CENSUS_TAG_PROPAGATE},  // more flags change
-                                                         // non-binary -> binary
-    /* 9 */ {"k6", "bar", 4, 0},  // add back tag, with different value
-    /* 10 */ {"foo", "bar", 4, CENSUS_TAG_PROPAGATE},  // another new tag
+    /* 2 */ {"k5", NULL, 0},            // should delete tag
+    /* 3 */ {"k5", NULL, 0},            // try deleting already-deleted tag
+    /* 4 */ {"non-existent", NULL, 0},  // delete non-existent tag
+#define REPLACE_FLAG_OFFSET 5
+    /* 5 */ {"k1", "a", 0},                    // change flags only
+    /* 6 */ {"k7", "bar", CENSUS_TAG_STATS},   // change flags and value
+    /* 7 */ {"k2", "", CENSUS_TAG_PROPAGATE},  // more value and flags change
+    /* 8 */ {"k5", "bar", 0},  // add back tag, with different value
+    /* 9 */ {"foo", "bar", CENSUS_TAG_PROPAGATE},  // another new tag
 };
 
 // Utility function to compare tags. Returns true if all fields match.
 static bool compare_tag(const census_tag *t1, const census_tag *t2) {
-  return (strcmp(t1->key, t2->key) == 0 && t1->value_len == t2->value_len &&
-          memcmp(t1->value, t2->value, t1->value_len) == 0 &&
+  return (strcmp(t1->key, t2->key) == 0 && strcmp(t1->value, t2->value) == 0 &&
           t1->flags == t2->flags);
 }
 
@@ -111,7 +99,7 @@ static void empty_test(void) {
   struct census_context *context = census_context_create(NULL, NULL, 0, NULL);
   GPR_ASSERT(context != NULL);
   const census_context_status *status = census_context_get_status(context);
-  census_context_status expected = {0, 0, 0, 0, 0, 0, 0, 0};
+  census_context_status expected = {0, 0, 0, 0, 0, 0, 0};
   GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
   census_context_destroy(context);
 }
@@ -121,7 +109,7 @@ static void basic_test(void) {
   const census_context_status *status;
   struct census_context *context =
       census_context_create(NULL, basic_tags, BASIC_TAG_COUNT, &status);
-  census_context_status expected = {2, 2, 4, 0, 8, 0, 0, 0};
+  census_context_status expected = {4, 4, 0, 8, 0, 0, 0};
   GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
   census_context_iterator it;
   census_context_initialize_iterator(context, &it);
@@ -161,15 +149,18 @@ static void invalid_test(void) {
   memset(key, 'k', 299);
   key[299] = 0;
   char value[300];
-  memset(value, 'v', 300);
-  census_tag tag = {key, value, 3, CENSUS_TAG_BINARY};
+  memset(value, 'v', 299);
+  value[299] = 0;
+  census_tag tag = {key, value, 0};
   // long keys, short value. Key lengths (including terminator) should be
   // <= 255 (CENSUS_MAX_TAG_KV_LEN)
+  value[3] = 0;
+  GPR_ASSERT(strlen(value) == 3);
   GPR_ASSERT(strlen(key) == 299);
   const census_context_status *status;
   struct census_context *context =
       census_context_create(NULL, &tag, 1, &status);
-  census_context_status expected = {0, 0, 0, 0, 0, 0, 1, 0};
+  census_context_status expected = {0, 0, 0, 0, 0, 1, 0};
   GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
   census_context_destroy(context);
   key[CENSUS_MAX_TAG_KV_LEN] = 0;
@@ -180,24 +171,28 @@ static void invalid_test(void) {
   key[CENSUS_MAX_TAG_KV_LEN - 1] = 0;
   GPR_ASSERT(strlen(key) == CENSUS_MAX_TAG_KV_LEN - 1);
   context = census_context_create(NULL, &tag, 1, &status);
-  census_context_status expected2 = {0, 0, 1, 0, 1, 0, 0, 0};
+  census_context_status expected2 = {0, 1, 0, 1, 0, 0, 0};
   GPR_ASSERT(memcmp(status, &expected2, sizeof(expected2)) == 0);
   census_context_destroy(context);
   // now try with long values
-  tag.value_len = 300;
+  value[3] = 'v';
+  GPR_ASSERT(strlen(value) == 299);
   context = census_context_create(NULL, &tag, 1, &status);
   GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
   census_context_destroy(context);
-  tag.value_len = CENSUS_MAX_TAG_KV_LEN + 1;
+  value[CENSUS_MAX_TAG_KV_LEN] = 0;
+  GPR_ASSERT(strlen(value) == CENSUS_MAX_TAG_KV_LEN);
   context = census_context_create(NULL, &tag, 1, &status);
   GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
   census_context_destroy(context);
-  tag.value_len = CENSUS_MAX_TAG_KV_LEN;
+  value[CENSUS_MAX_TAG_KV_LEN - 1] = 0;
+  GPR_ASSERT(strlen(value) == CENSUS_MAX_TAG_KV_LEN - 1);
   context = census_context_create(NULL, &tag, 1, &status);
   GPR_ASSERT(memcmp(status, &expected2, sizeof(expected2)) == 0);
   census_context_destroy(context);
   // 0 length key.
   key[0] = 0;
+  GPR_ASSERT(strlen(key) == 0);
   context = census_context_create(NULL, &tag, 1, &status);
   GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
   census_context_destroy(context);
@@ -210,7 +205,7 @@ static void copy_test(void) {
   const census_context_status *status;
   struct census_context *context2 =
       census_context_create(context, NULL, 0, &status);
-  census_context_status expected = {2, 2, 4, 0, 0, 0, 0, 0};
+  census_context_status expected = {4, 4, 0, 0, 0, 0, 0};
   GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
   for (int i = 0; i < BASIC_TAG_COUNT; i++) {
     census_tag tag;
@@ -228,7 +223,7 @@ static void replace_value_test(void) {
   const census_context_status *status;
   struct census_context *context2 = census_context_create(
       context, modify_tags + REPLACE_VALUE_OFFSET, 1, &status);
-  census_context_status expected = {2, 2, 4, 0, 0, 1, 0, 0};
+  census_context_status expected = {4, 4, 0, 0, 1, 0, 0};
   GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
   census_tag tag;
   GPR_ASSERT(census_context_get_tag(
@@ -245,7 +240,7 @@ static void replace_flags_test(void) {
   const census_context_status *status;
   struct census_context *context2 = census_context_create(
       context, modify_tags + REPLACE_FLAG_OFFSET, 1, &status);
-  census_context_status expected = {1, 2, 5, 0, 0, 1, 0, 0};
+  census_context_status expected = {3, 5, 0, 0, 1, 0, 0};
   GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
   census_tag tag;
   GPR_ASSERT(census_context_get_tag(
@@ -262,7 +257,7 @@ static void delete_tag_test(void) {
   const census_context_status *status;
   struct census_context *context2 = census_context_create(
       context, modify_tags + DELETE_TAG_OFFSET, 1, &status);
-  census_context_status expected = {2, 1, 4, 1, 0, 0, 0, 0};
+  census_context_status expected = {3, 4, 1, 0, 0, 0, 0};
   GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
   census_tag tag;
   GPR_ASSERT(census_context_get_tag(
@@ -278,7 +273,7 @@ static void add_tag_test(void) {
   const census_context_status *status;
   struct census_context *context2 =
       census_context_create(context, modify_tags + ADD_TAG_OFFSET, 1, &status);
-  census_context_status expected = {2, 2, 5, 0, 1, 0, 0, 0};
+  census_context_status expected = {4, 5, 0, 1, 0, 0, 0};
   GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
   census_tag tag;
   GPR_ASSERT(census_context_get_tag(context2, modify_tags[ADD_TAG_OFFSET].key,
@@ -295,24 +290,24 @@ static void replace_add_delete_test(void) {
   const census_context_status *status;
   struct census_context *context2 =
       census_context_create(context, modify_tags, MODIFY_TAG_COUNT, &status);
-  census_context_status expected = {2, 1, 6, 2, 3, 4, 0, 2};
+  census_context_status expected = {3, 7, 1, 3, 4, 0, 0};
   GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
   // validate context contents. Use specific indices into the two arrays
   // holding tag values.
   GPR_ASSERT(validate_tag(context2, &basic_tags[3]));
   GPR_ASSERT(validate_tag(context2, &basic_tags[4]));
+  GPR_ASSERT(validate_tag(context2, &basic_tags[6]));
   GPR_ASSERT(validate_tag(context2, &modify_tags[0]));
   GPR_ASSERT(validate_tag(context2, &modify_tags[1]));
+  GPR_ASSERT(validate_tag(context2, &modify_tags[5]));
   GPR_ASSERT(validate_tag(context2, &modify_tags[6]));
   GPR_ASSERT(validate_tag(context2, &modify_tags[7]));
   GPR_ASSERT(validate_tag(context2, &modify_tags[8]));
   GPR_ASSERT(validate_tag(context2, &modify_tags[9]));
-  GPR_ASSERT(validate_tag(context2, &modify_tags[10]));
   GPR_ASSERT(!validate_tag(context2, &basic_tags[0]));
   GPR_ASSERT(!validate_tag(context2, &basic_tags[1]));
   GPR_ASSERT(!validate_tag(context2, &basic_tags[2]));
   GPR_ASSERT(!validate_tag(context2, &basic_tags[5]));
-  GPR_ASSERT(!validate_tag(context2, &basic_tags[6]));
   GPR_ASSERT(!validate_tag(context2, &basic_tags[7]));
   census_context_destroy(context);
   census_context_destroy(context2);
@@ -325,21 +320,15 @@ static void encode_decode_test(void) {
   char buffer[BUF_SIZE];
   struct census_context *context =
       census_context_create(NULL, basic_tags, BASIC_TAG_COUNT, NULL);
-  size_t print_bsize;
-  size_t bin_bsize;
   // Test with too small a buffer
-  GPR_ASSERT(census_context_encode(context, buffer, 2, &print_bsize,
-                                   &bin_bsize) == NULL);
-  char *b_buffer = census_context_encode(context, buffer, BUF_SIZE,
-                                         &print_bsize, &bin_bsize);
-  GPR_ASSERT(b_buffer != NULL && print_bsize > 0 && bin_bsize > 0 &&
-             print_bsize + bin_bsize <= BUF_SIZE &&
-             b_buffer == buffer + print_bsize);
-  census_context *context2 =
-      census_context_decode(buffer, print_bsize, b_buffer, bin_bsize);
+  GPR_ASSERT(census_context_encode(context, buffer, 2) == 0);
+  // Test with sufficient buffer
+  size_t buf_used = census_context_encode(context, buffer, BUF_SIZE);
+  GPR_ASSERT(buf_used != 0);
+  census_context *context2 = census_context_decode(buffer, buf_used);
   GPR_ASSERT(context2 != NULL);
   const census_context_status *status = census_context_get_status(context2);
-  census_context_status expected = {2, 2, 0, 0, 0, 0, 0, 0};
+  census_context_status expected = {4, 0, 0, 0, 0, 0, 0};
   GPR_ASSERT(memcmp(status, &expected, sizeof(expected)) == 0);
   for (int i = 0; i < BASIC_TAG_COUNT; i++) {
     census_tag tag;


### PR DESCRIPTION
This PR removes support for binary tags. We were going to use these for tracing support, but are going to make these a custom structure inside the context, and use protos for encoding (this will be a future PR).

Also add restrictions on allowable tag key and values to be printable ASCII.