### PR TITLE
Simplify PHP installation

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,11 +10,11 @@
   <email>grpc-packages@google.com</email>
   <active>yes</active>
  </lead>
- <date>2016-02-24</date>
+ <date>2016-03-01</date>
  <time>16:06:07</time>
  <version>
-  <release>0.8.0</release>
-  <api>0.8.0</api>
+  <release>0.9.0</release>
+  <api>0.9.0</api>
  </version>
  <stability>
   <release>beta</release>
@@ -22,7 +22,7 @@
  </stability>
  <license>BSD</license>
  <notes>
-- Simplify gRPC PHP installation #4517
+- Increase unit test code coverage #5225
  </notes>
  <contents>
   <dir baseinstalldir="/" name="/">
@@ -967,6 +967,21 @@ Update to wrap gRPC C Core version 0.10.0
    <license>BSD</license>
    <notes>
 - Simplify gRPC PHP installation #4517
+   </notes>
+  </release>
+  <release>
+   <version>
+    <release>0.9.0</release>
+    <api>0.9.0</api>
+   </version>
+   <stability>
+    <release>beta</release>
+    <api>beta</api>
+   </stability>
+   <date>2016-03-01</date>
+   <license>BSD</license>
+   <notes>
+- Increase unit test code coverage #5225
    </notes>
   </release>
  </changelog>

--- a/package.xml
+++ b/package.xml
@@ -13,8 +13,8 @@
  <date>2016-03-01</date>
  <time>16:06:07</time>
  <version>
-  <release>0.9.0</release>
-  <api>0.9.0</api>
+  <release>0.14.0</release>
+  <api>0.14.0</api>
  </version>
  <stability>
   <release>beta</release>
@@ -971,8 +971,8 @@ Update to wrap gRPC C Core version 0.10.0
   </release>
   <release>
    <version>
-    <release>0.9.0</release>
-    <api>0.9.0</api>
+    <release>0.14.0</release>
+    <api>0.14.0</api>
    </version>
    <stability>
     <release>beta</release>

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -33,44 +33,11 @@ $ sudo mv phpunit.phar /usr/local/bin/phpunit
 
 ## Quick Install
 
-**Linux (Debian):**
-
-Add [Debian jessie-backports][] to your `sources.list` file. Example:
-
-```sh
-echo "deb http://http.debian.net/debian jessie-backports main" | \
-sudo tee -a /etc/apt/sources.list
-```
-
-Install the gRPC Debian package
-
-```sh
-sudo apt-get update
-sudo apt-get install libgrpc-dev
-```
-
 Install the gRPC PHP extension
 
 ```sh
 sudo pecl install grpc-beta
 ```
-
-**Mac OS X:**
-
-Install [homebrew][]. Example:
-
-```sh
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-```
-
-Install the gRPC core library and the PHP extension in one step
-
-```sh
-$ curl -fsSL https://goo.gl/getgrpc | bash -s php
-```
-
-This will download and run the [gRPC install script][] and compile the gRPC PHP extension.
-
 
 ## Build from Source
 
@@ -297,7 +264,4 @@ Connect to `localhost/math_client.php` in your browser, or run this from command
 $ curl localhost/math_client.php
 ```
 
-[homebrew]:http://brew.sh
-[gRPC install script]:https://raw.githubusercontent.com/grpc/homebrew-grpc/master/scripts/install
 [Node]:https://github.com/grpc/grpc/tree/master/src/node/examples
-[Debian jessie-backports]:http://backports.debian.org/Instructions/

--- a/templates/package.xml.template
+++ b/templates/package.xml.template
@@ -15,8 +15,8 @@
    <date>2016-03-01</date>
    <time>16:06:07</time>
    <version>
-    <release>0.9.0</release>
-    <api>0.9.0</api>
+    <release>0.14.0</release>
+    <api>0.14.0</api>
    </version>
    <stability>
     <release>beta</release>
@@ -157,8 +157,8 @@
     </release>
     <release>
      <version>
-      <release>0.9.0</release>
-      <api>0.9.0</api>
+      <release>0.14.0</release>
+      <api>0.14.0</api>
      </version>
      <stability>
       <release>beta</release>

--- a/templates/package.xml.template
+++ b/templates/package.xml.template
@@ -12,11 +12,11 @@
     <email>grpc-packages@google.com</email>
     <active>yes</active>
    </lead>
-   <date>2016-02-24</date>
+   <date>2016-03-01</date>
    <time>16:06:07</time>
    <version>
-    <release>0.8.0</release>
-    <api>0.8.0</api>
+    <release>0.9.0</release>
+    <api>0.9.0</api>
    </version>
    <stability>
     <release>beta</release>
@@ -24,7 +24,7 @@
    </stability>
    <license>BSD</license>
    <notes>
-  - Simplify gRPC PHP installation #4517
+  - Increase unit test code coverage #5225
    </notes>
    <contents>
     <dir baseinstalldir="/" name="/">
@@ -153,6 +153,21 @@
      <license>BSD</license>
      <notes>
   - Simplify gRPC PHP installation #4517
+     </notes>
+    </release>
+    <release>
+     <version>
+      <release>0.9.0</release>
+      <api>0.9.0</api>
+     </version>
+     <stability>
+      <release>beta</release>
+      <api>beta</api>
+     </stability>
+     <date>2016-03-01</date>
+     <license>BSD</license>
+     <notes>
+  - Increase unit test code coverage #5225
      </notes>
     </release>
    </changelog>


### PR DESCRIPTION
 * This should be the final piece to issue #4517 "PHP installation is too complex"
 * Updated `README.md`. Got rid of `libgrpc-dev` and `homebrew` as dependencies. Now in both linux and mac, all we need is `sudo pecl install grpc-beta`
 * Bump the version to 0.9.0 for the next release