### PR TITLE
Avoid TSAN race reports due to FD freelist

### DIFF
--- a/src/core/iomgr/fd_posix.c
+++ b/src/core/iomgr/fd_posix.c
@@ -93,6 +93,7 @@ static grpc_fd *alloc_fd(int fd) {
   }
 
   gpr_atm_rel_store(&r->refst, 1);
+  gpr_mu_lock(&r->mu);
   r->shutdown = 0;
   r->read_closure = CLOSURE_NOT_READY;
   r->write_closure = CLOSURE_NOT_READY;
@@ -104,6 +105,7 @@ static grpc_fd *alloc_fd(int fd) {
   r->on_done_closure = NULL;
   r->closed = 0;
   r->released = 0;
+  gpr_mu_unlock(&r->mu);
   return r;
 }
 

--- a/src/core/surface/completion_queue.c
+++ b/src/core/surface/completion_queue.c
@@ -94,7 +94,7 @@ static void on_pollset_shutdown_done(grpc_exec_ctx *exec_ctx, void *cc,
 void grpc_cq_global_init(void) { gpr_mu_init(&g_freelist_mu); }
 
 void grpc_cq_global_shutdown(void) {
-  gpr_mu_destroy(&g_freelist_mu);
+  gpr_mu_lock(&g_freelist_mu);
   while (g_freelist) {
     grpc_completion_queue *next = g_freelist->next_free;
     grpc_pollset_destroy(POLLSET_FROM_CQ(g_freelist));
@@ -104,6 +104,8 @@ void grpc_cq_global_shutdown(void) {
     gpr_free(g_freelist);
     g_freelist = next;
   }
+  gpr_mu_unlock(&g_freelist_mu);
+  gpr_mu_destroy(&g_freelist_mu);
 }
 
 struct grpc_cq_alarm {


### PR DESCRIPTION
There are TSAN-reported races caused by freelist management. A
solution (though possibly not the best) is to lock the FD while making
changes to it during allocate. Possibly a better one is to lock it and make
all needed changes before deallocate, but that's for a later time.

I believe that this arises when there are multiple threads and trips
through the freelist. Thread 1 inspects the FD under lock, thread 2 deallocates
the FD at a later time and just puts it into the freelist (under freelist lock),
and thread 3 takes the FD back from the freelist and starts editing it. The
problem is that there is no happens-before relationship between threads 1
and 2 implied by the application-visible set of locks.