### PR TITLE
Fix run_tests.py reporting for multiple test runs

### DIFF
--- a/tools/run_tests/jobset.py
+++ b/tools/run_tests/jobset.py
@@ -384,7 +384,8 @@ class Jobset(object):
                 self._travis,
                 self._add_env)
       self._running.add(job)
-      self.resultset[job.GetSpec().shortname] = []
+      if not self.resultset.has_key(job.GetSpec().shortname):
+        self.resultset[job.GetSpec().shortname] = []
     return True
 
   def reap(self):


### PR DESCRIPTION
if run_tests.py is run with -n X, newer results overwrite the old ones.
As a result, the flakiness rate is not reported correctly.
I expect people to use  run_tests.py -n X pretty heavily during the fixit, so I think it's worth fixing this problem.