### PR TITLE
Raise on unexpected metadata values

### DIFF
--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -359,7 +359,7 @@ static int grpc_rb_md_ary_fill_hash_cb(VALUE key, VALUE val, VALUE md_ary_obj) {
       md_ary->metadata[md_ary->count].value_length = value_len;
       md_ary->count += 1;
     }
-  } else {
+  } else if (TYPE(val) == T_STRING) {
     value_str = RSTRING_PTR(val);
     value_len = RSTRING_LEN(val);
     if (!grpc_is_binary_header(key_str, key_len) &&
@@ -373,6 +373,10 @@ static int grpc_rb_md_ary_fill_hash_cb(VALUE key, VALUE val, VALUE md_ary_obj) {
     md_ary->metadata[md_ary->count].value = value_str;
     md_ary->metadata[md_ary->count].value_length = value_len;
     md_ary->count += 1;
+  } else {
+    rb_raise(rb_eArgError,
+               "Header values must be of type string or array");
+    return ST_STOP;
   }
 
   return ST_CONTINUE;


### PR DESCRIPTION
The existing implementation was causing segmentation fault because
src/ruby/ext/grpc/rb_call.c:358 was trying to convert any value type other than
Array to String. The Array type is handled in first `if`.

This change will cause the Ruby code that sends non-string values to fail
with a better message: `ArgumentError: Header values must be of type string or array`

Before this fix, when I was sending metadata which value type was different than Array or String to `client_streamer`, e.g. `client_streamer(@method, @sent_messages, noop, noop, remote_op: true, some_key => true)`, this would cause a segmentation fail:
```
ClientStub
  #client_streamer
    via a call operation
      behaves like client streaming
/Users/rafaelsales/data/ws/grpc/src/ruby/lib/grpc/generic/active_call.rb:83: [BUG] Segmentation fault at 0x00000000000000
ruby 2.2.2p95 (2015-04-13 revision 50295) [x86_64-darwin14]

-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:
     * ~/Library/Logs/CrashReporter
     * /Library/Logs/CrashReporter
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.

-- Control frame information -----------------------------------------------
c:0044 p:---- s:0191 e:000190 CFUNC  :run_batch
c:0043 p:0105 s:0184 e:000183 METHOD /Users/rafaelsales/data/ws/grpc/src/ruby/lib/grpc/generic/active_call.rb:83
c:0042 p:0040 s:0177 e:000176 METHOD /Users/rafaelsales/data/ws/grpc/src/ruby/lib/grpc/generic/active_call.rb:456
c:0041 p:0020 s:0173 e:000172 METHOD /Users/rafaelsales/data/ws/grpc/src/ruby/lib/grpc/generic/active_call.rb:345
c:0040 p:0018 s:0166 e:000165 LAMBDA /Users/rafaelsales/data/ws/grpc/src/ruby/lib/grpc/generic/client_stub.rb:238 [FINISH]
c:0039 p:0057 s:0164 e:000163 METHOD /Users/rafaelsales/data/ws/grpc/src/ruby/spec/generic/client_stub_spec.rb:244
```

With the implementation of this PR, we now get a proper validation error like the one below, which is easier to understand why the error occurred:
![](https://dl.dropboxusercontent.com/spa/9kycf4oxo6l3hcj/m67mbrug.png)