### PR TITLE
Make wakeup fds register with iomgr also

### DIFF
--- a/src/core/iomgr/wakeup_fd_posix.c
+++ b/src/core/iomgr/wakeup_fd_posix.c
@@ -54,6 +54,7 @@ void grpc_wakeup_fd_global_init(void) {
 void grpc_wakeup_fd_global_destroy(void) { wakeup_fd_vtable = NULL; }
 
 void grpc_wakeup_fd_init(grpc_wakeup_fd *fd_info) {
+  grpc_iomgr_register_object(&fd_info->iomgr_object, "wakeup_fd");
   wakeup_fd_vtable->init(fd_info);
 }
 
@@ -67,6 +68,7 @@ void grpc_wakeup_fd_wakeup(grpc_wakeup_fd *fd_info) {
 
 void grpc_wakeup_fd_destroy(grpc_wakeup_fd *fd_info) {
   wakeup_fd_vtable->destroy(fd_info);
+  grpc_iomgr_unregister_object(&fd_info->iomgr_object);
 }
 
 #endif /* GPR_POSIX_WAKEUP_FD */

--- a/src/core/iomgr/wakeup_fd_posix.h
+++ b/src/core/iomgr/wakeup_fd_posix.h
@@ -62,6 +62,8 @@
 #ifndef GRPC_INTERNAL_CORE_IOMGR_WAKEUP_FD_POSIX_H
 #define GRPC_INTERNAL_CORE_IOMGR_WAKEUP_FD_POSIX_H
 
+#include "src/core/iomgr/iomgr_internal.h"
+
 void grpc_wakeup_fd_global_init(void);
 void grpc_wakeup_fd_global_destroy(void);
 
@@ -83,6 +85,7 @@ typedef struct grpc_wakeup_fd_vtable {
 struct grpc_wakeup_fd {
   int read_fd;
   int write_fd;
+  grpc_iomgr_object iomgr_object;
 };
 
 extern int grpc_allow_specialized_wakeup_fd;


### PR DESCRIPTION
Prevent iomgr shutdown until all wakeup fds have been destroyed.

Dovetails with #5530 to eliminate a race, but introduces a memory leak.