### PR TITLE
Fix ServerTryCancel in Async end2end tests (similar to pull request # 5523)

### DIFF
--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -807,7 +807,11 @@ class AsyncEnd2endServerTryCancelTest : public AsyncEnd2endTest {
     EXPECT_FALSE(context->IsCancelled());
     context->TryCancel();
     gpr_log(GPR_INFO, "Server called TryCancel()");
-    EXPECT_TRUE(context->IsCancelled());
+    while (!context->IsCancelled()) {
+      gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
+                                   gpr_time_from_micros(1000, GPR_TIMESPAN)));
+    }
+    gpr_log(GPR_INFO, "RPC Cancelled on the server");
   }
 
   // Helper for testing client-streaming RPCs which are cancelled on the server.

--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -331,6 +331,7 @@ void TestServiceImpl::ServerTryCancel(ServerContext* context) {
     gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
                                  gpr_time_from_micros(1000, GPR_TIMESPAN)));
   }
+  gpr_log(GPR_INFO, "RPC Cancelled on the server");
 }
 
 }  // namespace testing

--- a/test/cpp/interop/reconnect_interop_client.cc
+++ b/test/cpp/interop/reconnect_interop_client.cc
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/test/cpp/interop/reconnect_interop_server.cc
+++ b/test/cpp/interop/reconnect_interop_server.cc
@@ -30,7 +30,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
- 
+
 // Test description at doc/connection-backoff-interop-test-description.md
 
 #include <signal.h>


### PR DESCRIPTION
- Fixing the Async end2end tests as well (similar to https://github.com/grpc/grpc/pull/5523)
- The changes in `reconnect_interop_client.cc` are a result of copyright and clang_format_code checks.