### PR TITLE
Run build_ext in build_python step

### DIFF
--- a/tools/run_tests/build_python.sh
+++ b/tools/run_tests/build_python.sh
@@ -46,4 +46,5 @@ tox --notest
 
 $ROOT/.tox/py27/bin/python $ROOT/setup.py build
 $ROOT/.tox/py27/bin/python $ROOT/setup.py build_py
+$ROOT/.tox/py27/bin/python $ROOT/setup.py build_ext --inplace
 $ROOT/.tox/py27/bin/python $ROOT/setup.py gather --test


### PR DESCRIPTION
This might help with the issue seen here:

https://grpc-testing.appspot.com/job/gRPC_master/15549/config=opt,language=python,platform=macos/testReport/junit/(root)/tests/py_test__not_found_test_NotFoundTest/

```
ImportError: dlopen(/jenkins/workspace/gRPC_master/config/opt/language/python/platform/macos/src/python/grpcio/grpc/_cython/cygrpc.so, 2): no suitable image found.  Did find:
	/jenkins/workspace/gRPC_master/config/opt/language/python/platform/macos/src/python/grpcio/grpc/_cython/cygrpc.so: truncated fat file.  file length=2461696, but needed slice goes to 2629760
```