### PR TITLE
Objective-C: Update Test Podfile for CocoaPods 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
     - TEST=objc
     - JOBS=1
 before_install:
+  - gem install cocoapods -v '1.0.0.beta.4'
   - brew install gflags
   # Pod install does this too, but we don't want the output.
   - pod repo update --silent

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
   - pushd src/objective-c/tests
   # Needs to be verbose, or otherwise OpenSSL's prepare_command makes Travis
   # time out:
+  - pod --version
   - pod install --verbose
   - popd
 before_script:

--- a/src/objective-c/tests/Podfile
+++ b/src/objective-c/tests/Podfile
@@ -1,31 +1,33 @@
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 
-pod 'Protobuf', :path => "../../../third_party/protobuf"
-pod 'BoringSSL', :podspec => ".."
-pod 'gRPC', :path => "../../.."
-pod 'RemoteTest', :path => "RemoteTestClient"
-
-link_with 'AllTests',
-          'RxLibraryUnitTests',
-          'InteropTests',
-          'InteropTestsLocalSSL',
-          'InteropTestsLocalCleartext'
+def shared_pods
+	pod 'Protobuf', :path => "../../../third_party/protobuf"
+	pod 'BoringSSL', :podspec => ".."
+	pod 'gRPC', :path => "../../.."
+	pod 'RemoteTest', :path => "RemoteTestClient"
+end
 
 target 'Tests' do
+	shared_pods
 end
 
 target 'AllTests' do
+	shared_pods
 end
 
 target 'RxLibraryUnitTests' do
+	shared_pods
 end
 
 target 'InteropTestsRemote' do
+	shared_pods
 end
 
 target 'InteropTestsLocalSSL' do
+	shared_pods
 end
 
 target 'InteropTestsLocalCleartext' do
+	shared_pods
 end

--- a/src/objective-c/tests/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/tests/RemoteTestClient/RemoteTest.podspec
@@ -2,6 +2,10 @@ Pod::Spec.new do |s|
   s.name     = "RemoteTest"
   s.version  = "0.0.1"
   s.license  = "New BSD"
+  s.authors  = { 'gRPC contributors' => 'grpc-io@googlegroups.com' }
+  s.homepage = "http://www.grpc.io/"
+  s.summary = "RemoteTest example"
+  s.source = { :git => 'https://github.com/grpc/grpc.git' }
 
   s.ios.deployment_target = '7.1'
   s.osx.deployment_target = '10.9'


### PR DESCRIPTION
* `authors`, `homepage`, `summary`,  and `source` are now required fields in Podfile
* `link_with` was removed from Podspecs