### PR TITLE
Objective-C: Add ChannelCredentials to gRPC Call

### DIFF
--- a/src/core/lib/iomgr/ev_posix.c
+++ b/src/core/lib/iomgr/ev_posix.c
@@ -44,7 +44,6 @@
 static const grpc_event_engine_vtable *g_event_engine;
 
 grpc_poll_function_type grpc_poll_function = poll;
-grpc_wakeup_fd grpc_global_wakeup_fd;
 
 void grpc_event_engine_init(void) {
   if ((g_event_engine = grpc_init_poll_and_epoll_posix())) {

--- a/src/objective-c/GRPCClient/GRPCCall+ChannelCredentials.h
+++ b/src/objective-c/GRPCClient/GRPCCall+ChannelCredentials.h
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -31,44 +31,26 @@
  *
  */
 
-#import <Foundation/Foundation.h>
+#import "GRPCCall.h"
 
-#include <grpc/grpc.h>
-
-@class GRPCCompletionQueue;
-struct grpc_channel_credentials;
-
+/** Helpers for setting TLS Trusted Roots, Client Certificates, and Private Key */
+@interface GRPCCall (ChannelCredentials)
 
 /**
- * Each separate instance of this class represents at least one TCP connection to the provided host.
+ * Use the provided @c pemRootCert as the set of trusted root Certificate Authorities for @c host.
  */
-@interface GRPCChannel : NSObject
-
-@property(nonatomic, readonly, nonnull) struct grpc_channel *unmanagedChannel;
-
-- (nullable instancetype)init NS_UNAVAILABLE;
-
++ (BOOL)setTLSPEMRootCerts:(nullable NSString *)pemRootCert
+                   forHost:(nonnull NSString *)host
+                     error:(NSError **)errorPtr;
 /**
- * Creates a secure channel to the specified @c host using default credentials and channel
- * arguments. If certificates could not be found to create a secure channel, then @c nil is
- * returned.
+ * Configures @c host with TLS/SSL Client Credentials and optionally trusted root Certificate
+ * Authorities. If @c pemRootCerts is nil, the default CA Certificates bundled with gRPC will be
+ * used.
  */
-+ (nullable GRPCChannel *)secureChannelWithHost:(nonnull NSString *)host;
++ (BOOL)setTLSPEMRootCerts:(nullable NSString *)pemRootCerts
+            withPrivateKey:(nullable NSString *)pemPrivateKey
+             withCertChain:(nullable NSString *)pemCertChain
+                   forHost:(nonnull NSString *)host
+                     error:(NSError **)errorPtr;
 
-/**
- * Creates a secure channel to the specified @c host using the specified @c credentials and
- * @c channelArgs. Only in tests should @c GRPC_SSL_TARGET_NAME_OVERRIDE_ARG channel arg be set.
- */
-+ (nonnull GRPCChannel *)secureChannelWithHost:(nonnull NSString *)host
-    credentials:(nonnull struct grpc_channel_credentials *)credentials
-    channelArgs:(nullable NSDictionary *)channelArgs;
-
-/**
- * Creates an insecure channel to the specified @c host using the specified @c channelArgs.
- */
-+ (nonnull GRPCChannel *)insecureChannelWithHost:(nonnull NSString *)host
-                                     channelArgs:(nullable NSDictionary *)channelArgs;
-
-- (nullable grpc_call *)unmanagedCallWithPath:(nonnull NSString *)path
-                              completionQueue:(nonnull GRPCCompletionQueue *)queue;
 @end

--- a/src/objective-c/GRPCClient/GRPCCall+Tests.m
+++ b/src/objective-c/GRPCClient/GRPCCall+Tests.m
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -43,8 +43,16 @@
   if (!host || !certsPath || !testName) {
     [NSException raise:NSInvalidArgumentException format:@"host, path and name must be provided."];
   }
+  NSError *error = nil;
+  NSString *certs = [NSString stringWithContentsOfFile:certsPath
+                                                      encoding:NSUTF8StringEncoding
+                                                      error:&error];
+  if (error != nil) {
+      [NSException raise:[error localizedDescription] format:@"failed to load certs"];
+  }
+
   GRPCHost *hostConfig = [GRPCHost hostWithAddress:host];
-  hostConfig.pathToCertificates = certsPath;
+  [hostConfig setTLSPEMRootCerts:certs withPrivateKey:nil withCertChain:nil error:nil];
   hostConfig.hostNameOverride = testName;
 }
 

--- a/src/objective-c/GRPCClient/private/GRPCHost.h
+++ b/src/objective-c/GRPCClient/private/GRPCHost.h
@@ -37,23 +37,28 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class GRPCCompletionQueue;
 struct grpc_call;
+struct grpc_channel_credentials;
 
 @interface GRPCHost : NSObject
 
 @property(nonatomic, readonly) NSString *address;
 @property(nonatomic, copy, nullable) NSString *userAgentPrefix;
+@property(nonatomic, nullable) struct grpc_channel_credentials *channelCreds;
 
 /** The following properties should only be modified for testing: */
 
 @property(nonatomic, getter=isSecure) BOOL secure;
 
-@property(nonatomic, copy, nullable) NSString *pathToCertificates;
 @property(nonatomic, copy, nullable) NSString *hostNameOverride;
 
 - (nullable instancetype)init NS_UNAVAILABLE;
 /** Host objects initialized with the same address are the same. */
 + (nullable instancetype)hostWithAddress:(NSString *)address;
 - (nullable instancetype)initWithAddress:(NSString *)address NS_DESIGNATED_INITIALIZER;
+- (BOOL)setTLSPEMRootCerts:(nullable NSString *)pemRootCerts
+            withPrivateKey:(nullable NSString *)pemPrivateKey
+             withCertChain:(nullable NSString *)pemCertChain
+                     error:(NSError **)errorPtr;
 
 /** Create a grpc_call object to the provided path on this host. */
 - (nullable struct grpc_call *)unmanagedCallWithPath:(NSString *)path

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -34,6 +34,7 @@
 #import "GRPCHost.h"
 
 #include <grpc/grpc.h>
+#include <grpc/grpc_security.h>
 #import <GRPCClient/GRPCCall.h>
 #import <GRPCClient/GRPCCall+ChannelArg.h>
 
@@ -54,6 +55,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (nullable instancetype)hostWithAddress:(NSString *)address {
   return [[self alloc] initWithAddress:address];
+}
+
+- (void)dealloc {
+  if (_channelCreds != nil) {
+    grpc_channel_credentials_release(_channelCreds);
+  }
 }
 
 // Default initializer.
@@ -105,6 +112,75 @@ NS_ASSUME_NONNULL_BEGIN
   return [channel unmanagedCallWithPath:path completionQueue:queue];
 }
 
+- (BOOL)setTLSPEMRootCerts:(nullable NSString *)pemRootCerts
+            withPrivateKey:(nullable NSString *)pemPrivateKey
+             withCertChain:(nullable NSString *)pemCertChain
+                     error:(NSError **)errorPtr {
+  static NSData *kDefaultRootsASCII;
+  static NSError *kDefaultRootsError;
+  static dispatch_once_t loading;
+  dispatch_once(&loading, ^{
+    NSString *defaultPath = @"gRPCCertificates.bundle/roots"; // .pem
+    // Do not use NSBundle.mainBundle, as it's nil for tests of library projects.
+    NSBundle *bundle = [NSBundle bundleForClass:self.class];
+    NSString *path = [bundle pathForResource:defaultPath ofType:@"pem"];
+    NSError *error;
+    // Files in PEM format can have non-ASCII characters in their comments (e.g. for the name of the
+    // issuer). Load them as UTF8 and produce an ASCII equivalent.
+    NSString *contentInUTF8 = [NSString stringWithContentsOfFile:path
+                                                        encoding:NSUTF8StringEncoding
+                                                           error:&error];
+    if (contentInUTF8 == nil) {
+      kDefaultRootsError = error;
+      return;
+    }
+    kDefaultRootsASCII = [contentInUTF8 dataUsingEncoding:NSASCIIStringEncoding
+                                     allowLossyConversion:YES];
+  });
+
+  NSData *rootsASCII;
+  if (pemRootCerts != nil) {
+    rootsASCII = [pemRootCerts dataUsingEncoding:NSASCIIStringEncoding
+                     allowLossyConversion:YES];
+  } else {
+    if (kDefaultRootsASCII == nil) {
+      if (errorPtr) {
+        *errorPtr = kDefaultRootsError;
+      }
+      NSAssert(kDefaultRootsASCII, @"Could not read gRPCCertificates.bundle/roots.pem. This file, "
+               "with the root certificates, is needed to establish secure (TLS) connections. "
+               "Because the file is distributed with the gRPC library, this error is usually a sign "
+               "that the library wasn't configured correctly for your project. Error: %@",
+                kDefaultRootsError);
+      return NO;
+    }
+    rootsASCII = kDefaultRootsASCII;
+  }
+
+  grpc_channel_credentials *creds;
+  if (pemPrivateKey == nil && pemCertChain == nil) {
+    creds = grpc_ssl_credentials_create(rootsASCII.bytes, NULL, NULL);
+  } else {
+    grpc_ssl_pem_key_cert_pair key_cert_pair;
+    NSData *privateKeyASCII = [pemPrivateKey dataUsingEncoding:NSASCIIStringEncoding
+                                       allowLossyConversion:YES];
+    NSData *certChainASCII = [pemCertChain dataUsingEncoding:NSASCIIStringEncoding
+                                     allowLossyConversion:YES];
+    key_cert_pair.private_key = privateKeyASCII.bytes;
+    key_cert_pair.cert_chain = certChainASCII.bytes;
+    creds = grpc_ssl_credentials_create(rootsASCII.bytes, &key_cert_pair, NULL);
+  }
+
+  @synchronized(self) {
+    if (_channelCreds != nil) {
+      grpc_channel_credentials_release(_channelCreds);
+    }
+    _channelCreds = creds;
+  }
+
+  return YES;
+}
+
 - (NSDictionary *)channelArgs {
   NSMutableDictionary *args = [NSMutableDictionary dictionary];
 
@@ -125,9 +201,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (GRPCChannel *)newChannel {
   NSDictionary *args = [self channelArgs];
   if (_secure) {
-    return [GRPCChannel secureChannelWithHost:_address
-                           pathToCertificates:_pathToCertificates
-                                  channelArgs:args];
+      GRPCChannel *channel;
+      @synchronized(self) {
+        if (_channelCreds == nil) {
+          [self setTLSPEMRootCerts:nil withPrivateKey:nil withCertChain:nil error:nil];
+        }
+        channel = [GRPCChannel secureChannelWithHost:_address
+                                          credentials:_channelCreds
+                                          channelArgs:args];
+      }
+      return channel;
   } else {
     return [GRPCChannel insecureChannelWithHost:_address channelArgs:args];
   }
@@ -144,9 +227,6 @@ NS_ASSUME_NONNULL_BEGIN
     _channel = nil;
   }
 }
-
-// TODO(jcanizales): Don't let set |secure| to |NO| if |pathToCertificates| or |hostNameOverride|
-// have been set. Don't let set either of the latter if |secure| has been set to |NO|.
 
 @end
 


### PR DESCRIPTION
New properties on `GRPCHost` (`pemRootCerts`, `pemPrivateKey`, `pemCertChain`) allow the channel credentials to be constructed with support for TLS Client certificates.  `GRPCHost` uses these properties when creating a `GRPCChannel`.

The `pathToCertificates` property has been removed, but support for loading the root certificates from the bundle has been updated to support the new interface.

Two notes:
1) I've not been able to run the test cases yet.  I couldn't get the `./tools/run_tests/run_tests.py -l objc` working (see also #5591 )
2) From looking at the other language bindings, it's not clear if the `forHost` pattern is common (i'm most familiar with the grpc-go code)..  Is this pattern wanted for the ObjectiveC bindings?  I tried to follow how OAuth / User-Agent setting was done so far.

