### PR TITLE
Improve perf smoke test stability

### DIFF
--- a/tools/jenkins/run_performance.sh
+++ b/tools/jenkins/run_performance.sh
@@ -42,15 +42,10 @@ config=opt
 
 make CONFIG=$config qps_worker qps_driver -j8
 
-bins/$config/qps_worker -driver_port 10000 &
-PID1=$!
-bins/$config/qps_worker -driver_port 10010 &
-PID2=$!
-
 #
 # Put a timeout on these tests
 #
-((sleep 900; kill $$ && killall qps_worker && rm -f /tmp/qps-test.$$ )&)
+((sleep 900; killall qps_worker && rm -f /tmp/qps-test.$$ && kill $$)&)
 
 export QPS_WORKERS="localhost:10000,localhost:10010"
 
@@ -71,38 +66,52 @@ halfcores=`expr $cores / 2`
 
 for secure in true false; do
   # Scenario 1: generic async streaming ping-pong (contentionless latency)
+  bins/$config/qps_worker -driver_port 10000 &
+  bins/$config/qps_worker -driver_port 10010 &
   bins/$config/qps_driver --rpc_type=STREAMING --client_type=ASYNC_CLIENT \
     --server_type=ASYNC_GENERIC_SERVER --outstanding_rpcs_per_channel=1 \
     --client_channels=1 --bbuf_req_size=0 --bbuf_resp_size=0 \
     --async_client_threads=1 --async_server_threads=1 --secure_test=$secure \
     --num_servers=1 --num_clients=1 \
     --server_core_limit=$halfcores --client_core_limit=0
-
+  bins/$config/qps_driver --quit=true
+  
   # Scenario 2: generic async streaming "unconstrained" (QPS)
+  bins/$config/qps_worker -driver_port 10000 &
+  bins/$config/qps_worker -driver_port 10010 &
   bins/$config/qps_driver --rpc_type=STREAMING --client_type=ASYNC_CLIENT \
     --server_type=ASYNC_GENERIC_SERVER --outstanding_rpcs_per_channel=$deep \
     --client_channels=$wide --bbuf_req_size=0 --bbuf_resp_size=0 \
     --async_client_threads=0 --async_server_threads=0 --secure_test=$secure \
     --num_servers=1 --num_clients=0 \
     --server_core_limit=$halfcores --client_core_limit=0 |& tee /tmp/qps-test.$$
+  bins/$config/qps_driver --quit=true
 
   # Scenario 2b: QPS with a single server core
+  bins/$config/qps_worker -driver_port 10000 &
+  bins/$config/qps_worker -driver_port 10010 &
   bins/$config/qps_driver --rpc_type=STREAMING --client_type=ASYNC_CLIENT \
     --server_type=ASYNC_GENERIC_SERVER --outstanding_rpcs_per_channel=$deep \
     --client_channels=$wide --bbuf_req_size=0 --bbuf_resp_size=0 \
     --async_client_threads=0 --async_server_threads=0 --secure_test=$secure \
     --num_servers=1 --num_clients=0 --server_core_limit=1 --client_core_limit=0
+  bins/$config/qps_driver --quit=true
 
   # Scenario 2c: protobuf-based QPS
+  bins/$config/qps_worker -driver_port 10000 &
+  bins/$config/qps_worker -driver_port 10010 &
   bins/$config/qps_driver --rpc_type=STREAMING --client_type=ASYNC_CLIENT \
     --server_type=ASYNC_SERVER --outstanding_rpcs_per_channel=$deep \
     --client_channels=$wide --simple_req_size=0 --simple_resp_size=0 \
     --async_client_threads=0 --async_server_threads=0 --secure_test=$secure \
     --num_servers=1 --num_clients=0 \
     --server_core_limit=$halfcores --client_core_limit=0
+  bins/$config/qps_driver --quit=true
 
   # Scenario 3: Latency at sub-peak load (all clients equally loaded)
   for loadfactor in 0.7; do
+    bins/$config/qps_worker -driver_port 10000 &
+    bins/$config/qps_worker -driver_port 10010 &
     bins/$config/qps_driver --rpc_type=STREAMING --client_type=ASYNC_CLIENT \
       --server_type=ASYNC_GENERIC_SERVER --outstanding_rpcs_per_channel=$deep \
       --client_channels=$wide --bbuf_req_size=0 --bbuf_resp_size=0 \
@@ -110,27 +119,31 @@ for secure in true false; do
       --num_servers=1 --num_clients=0 --poisson_load=`awk -v lf=$loadfactor \
       '$5 == "QPS:" {print int(lf * $6); exit}' /tmp/qps-test.$$` \
       --server_core_limit=$halfcores --client_core_limit=0
+    bins/$config/qps_driver --quit=true
   done
 
   rm /tmp/qps-test.$$
 
   # Scenario 4: Single-channel bidirectional throughput test (like TCP_STREAM).
+  bins/$config/qps_worker -driver_port 10000 &
+  bins/$config/qps_worker -driver_port 10010 &
   bins/$config/qps_driver --rpc_type=STREAMING --client_type=ASYNC_CLIENT \
     --server_type=ASYNC_GENERIC_SERVER --outstanding_rpcs_per_channel=$deep \
     --client_channels=1 --bbuf_req_size=$big --bbuf_resp_size=$big \
     --async_client_threads=1 --async_server_threads=1 --secure_test=$secure \
     --num_servers=1 --num_clients=1 \
     --server_core_limit=$halfcores --client_core_limit=0
+  bins/$config/qps_driver --quit=true
 
   # Scenario 5: Sync unary ping-pong with protobufs
+  bins/$config/qps_worker -driver_port 10000 &
+  bins/$config/qps_worker -driver_port 10010 &
   bins/$config/qps_driver --rpc_type=UNARY --client_type=SYNC_CLIENT \
     --server_type=SYNC_SERVER --outstanding_rpcs_per_channel=1 \
     --client_channels=1 --simple_req_size=0 --simple_resp_size=0 \
     --secure_test=$secure --num_servers=1 --num_clients=1 \
     --server_core_limit=$halfcores --client_core_limit=0
-
+  bins/$config/qps_driver --quit=true
 done
-
-bins/$config/qps_driver --quit=true
 
 wait


### PR DESCRIPTION
Right now, perf smoke tests are broken (even though the perf tests integrated into basic tests are running), and this may be because we have issues related to keeping the workers alive from test to test. This stability problem needs a longer-term solution, but for now we need to be able to have green smoke tests.
