### PR TITLE
Doc Fixit: mention how to get protoc compiler in base INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,6 +32,16 @@ terminal:
  $ [sudo] xcode-select --install
 ```
 
+##Protoc
+
+By default gRPC uses [protocol buffers](https://github.com/google/protobuf),
+you will need the `protoc` compiler to generate stub server and client code.
+
+If you compile from source, see below, the Makefile will automatically try
+and compile the one present in third_party if you cloned the repository
+recursively, and that it detects your system is lacking it.
+
+
 #Build from Source
 
 For developers who are interested to contribute, here is how to compile the

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,9 +37,10 @@ terminal:
 By default gRPC uses [protocol buffers](https://github.com/google/protobuf),
 you will need the `protoc` compiler to generate stub server and client code.
 
-If you compile from source, see below, the Makefile will automatically try
-and compile the one present in third_party if you cloned the repository
-recursively, and that it detects your system is lacking it.
+If you compile gRPC from source, as described below, the Makefile will
+automatically try and compile the `protoc` in third_party if you cloned the
+repository recursively and it detects that you don't already have it
+installed.
 
 
 #Build from Source

--- a/src/node/README.md
+++ b/src/node/README.md
@@ -5,7 +5,7 @@
 Beta
 
 ## PREREQUISITES
-- `node`: This requires `node` to be installed. If you instead have the `nodejs` executable on Debian, you should install the [`nodejs-legacy`](https://packages.debian.org/sid/nodejs-legacy) package.
+- `node`: This requires `node` to be installed, version `0.12` or above. If you instead have the `nodejs` executable on Debian, you should install the [`nodejs-legacy`](https://packages.debian.org/sid/nodejs-legacy) package.
 
 ## INSTALLATION
 


### PR DESCRIPTION
Fixes #5243 