### PR TITLE
Fix race in poll() based pollset

### DIFF
--- a/src/core/iomgr/pollset_multipoller_with_poll_posix.c
+++ b/src/core/iomgr/pollset_multipoller_with_poll_posix.c
@@ -137,8 +137,8 @@ static void multipoll_with_poll_pollset_maybe_work_and_unlock(
 
   for (i = 2; i < pfd_count; i++) {
     grpc_fd *fd = watchers[i].fd;
-    pfds[i].events = (short)grpc_fd_begin_poll(fd, pollset, worker,
-                                               POLLIN, POLLOUT, &watchers[i]);
+    pfds[i].events = (short)grpc_fd_begin_poll(fd, pollset, worker, POLLIN,
+                                               POLLOUT, &watchers[i]);
     GRPC_FD_UNREF(fd, "multipoller_start");
   }
 

--- a/src/core/iomgr/pollset_multipoller_with_poll_posix.c
+++ b/src/core/iomgr/pollset_multipoller_with_poll_posix.c
@@ -122,6 +122,7 @@ static void multipoll_with_poll_pollset_maybe_work_and_unlock(
     } else {
       h->fds[fd_count++] = h->fds[i];
       watchers[pfd_count].fd = h->fds[i];
+      GRPC_FD_REF(watchers[pfd_count].fd, "multipoller_start");
       pfds[pfd_count].fd = h->fds[i]->fd;
       pfds[pfd_count].revents = 0;
       pfd_count++;
@@ -135,8 +136,10 @@ static void multipoll_with_poll_pollset_maybe_work_and_unlock(
   gpr_mu_unlock(&pollset->mu);
 
   for (i = 2; i < pfd_count; i++) {
-    pfds[i].events = (short)grpc_fd_begin_poll(watchers[i].fd, pollset, worker,
+    grpc_fd *fd = watchers[i].fd;
+    pfds[i].events = (short)grpc_fd_begin_poll(fd, pollset, worker,
                                                POLLIN, POLLOUT, &watchers[i]);
+    GRPC_FD_UNREF(fd, "multipoller_start");
   }
 
   /* TODO(vpai): Consider first doing a 0 timeout poll here to avoid


### PR DESCRIPTION
It was possible for entries in watchers[] to be deleted by another thread before we called begin_poll.

I'd like to do something nicer than this eventually... but that'll be easier once we've got the polling loop cleaned up (which is currently WIP)

CC @vjpai 