### PR TITLE
Add test_lite custom command for parallel test running.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -165,6 +165,7 @@ COMMAND_CLASS = {
     'build_tagged_ext': precompiled.BuildTaggedExt,
     'gather': commands.Gather,
     'run_interop': commands.RunInterop,
+    'test_lite': commands.TestLite
 }
 
 # Ensure that package data is copied over before any commands have been run:

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -264,6 +264,41 @@ class Gather(setuptools.Command):
       self.distribution.fetch_build_eggs(self.distribution.tests_require)
 
 
+class TestLite(setuptools.Command):
+  """Command to run tests without fetching or building anything."""
+
+  description = 'run tests without fetching or building anything.'
+  user_options = []
+
+  def initialize_options(self):
+    pass
+
+  def finalize_options(self):
+    # distutils requires this override.
+    pass
+
+  def run(self):
+    self._add_eggs_to_path()
+
+    import tests
+    loader = tests.Loader()
+    loader.loadTestsFromNames(['tests'])
+    runner = tests.Runner()
+    result = runner.run(loader.suite)
+    if not result.wasSuccessful():
+      sys.exit(1)
+
+  def _add_eggs_to_path(self):
+    """Adds all egg files under .eggs to sys.path"""
+    import pkg_resources
+    eggs_dir = os.path.join(PYTHON_STEM, '../../../.eggs')
+    eggs = [os.path.join(eggs_dir, filename)
+            for filename in os.listdir(eggs_dir)
+            if filename.endswith('.egg')]
+    for egg in eggs:
+      sys.path.insert(0, pkg_resources.normalize_path(egg))
+
+
 class RunInterop(test.test):
 
   description = 'run interop test client/server'

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -286,10 +286,11 @@ class TestLite(setuptools.Command):
     runner = tests.Runner()
     result = runner.run(loader.suite)
     if not result.wasSuccessful():
-      sys.exit(1)
+      sys.exit('Test failure')
 
   def _add_eggs_to_path(self):
     """Adds all egg files under .eggs to sys.path"""
+    # TODO(jtattemusch): there has to be a cleaner way to do this
     import pkg_resources
     eggs_dir = os.path.join(PYTHON_STEM, '../../../.eggs')
     eggs = [os.path.join(eggs_dir, filename)

--- a/tools/run_tests/run_python.sh
+++ b/tools/run_tests/run_python.sh
@@ -46,7 +46,7 @@ if [ "$CONFIG" = "gcov" ]
 then
   tox
 else
-  $ROOT/.tox/py27/bin/python $ROOT/setup.py test
+  $ROOT/.tox/py27/bin/python $ROOT/setup.py test_lite
 fi
 
 mkdir -p $ROOT/reports


### PR DESCRIPTION
Allows running multiple tests in parallel (by preventing interference between egg fetches or build steps).

Fixes https://github.com/grpc/grpc/issues/5568.

