### PR TITLE
Change perf script timeout mechanism

### DIFF
--- a/tools/jenkins/run_performance.sh
+++ b/tools/jenkins/run_performance.sh
@@ -50,7 +50,7 @@ PID2=$!
 #
 # Put a timeout on these tests
 #
-((sleep 900; kill $$ && killall qps_worker && rm -f /tmp/qps-test.$$ )&)
+((sleep 900; kill $PID1; kill $PID2; rm -f /tmp/qps-test.$$; kill $$ )&)
 
 export QPS_WORKERS="localhost:10000,localhost:10010"
 


### PR DESCRIPTION
Probably a bad idea to do a delayed killall qps_workers on a machine given that the same machine is used in many tests.