### PR TITLE
make cygrpc importable on py3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ from setuptools.command import egg_info
 # Redirect the manifest template from MANIFEST.in to PYTHON-MANIFEST.in.
 egg_info.manifest_maker.template = 'PYTHON-MANIFEST.in'
 
+PY3 = sys.version_info.major == 3
 PYTHON_STEM = './src/python/grpcio'
 CORE_INCLUDE = ('./include', '.',)
 BORINGSSL_INCLUDE = ('./third_party/boringssl/include',)
@@ -103,7 +104,11 @@ if "linux" in sys.platform:
   LDFLAGS += ('-Wl,-wrap,memcpy',)
 if "linux" in sys.platform or "darwin" in sys.platform:
   CFLAGS += ('-fvisibility=hidden',)
-  DEFINE_MACROS += (('PyMODINIT_FUNC', '__attribute__((visibility ("default"))) void'),)
+
+  pymodinit_type = 'PyObject*' if PY3 else 'void'
+
+  pymodinit = '__attribute__((visibility ("default"))) {}'.format(pymodinit_type)
+  DEFINE_MACROS += (('PyMODINIT_FUNC', pymodinit),)
 
 
 def cython_extensions(package_names, module_names, extra_sources, include_dirs,


### PR DESCRIPTION
Previously, importing `grpc._cython.cygrpc` on python 3.x would crash the interpreter.

The cause was that the `PyMODINIT_FUNC` macro was overwritten in a python2-specific way. In the python2 C API, PyMODINIT_FUNC should be `void`, whereas in python3 the module initialization function returns a `PyObject*` pointing to the module, as described in the [python3 C porting docs](https://docs.python.org/3/howto/cporting.html#module-initialization-and-state).