### PR TITLE
replace uses of iteritems with six.iteritems

### DIFF
--- a/src/python/grpcio/grpc/framework/alpha/_face_utilities.py
+++ b/src/python/grpcio/grpc/framework/alpha/_face_utilities.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,6 +29,8 @@
 
 import abc
 import collections
+
+import six
 
 # face_interfaces is referenced from specification in this module.
 from grpc.framework.common import cardinality
@@ -111,7 +113,7 @@ def break_down_invocation(service_name, method_descriptions):
   face_cardinalities = {}
   request_serializers = {}
   response_deserializers = {}
-  for name, method_description in method_descriptions.iteritems():
+  for name, method_description in six.iteritems(method_descriptions):
     qualified_name = _qualified_name(service_name, name)
     method_cardinality = method_description.cardinality()
     cardinalities[name] = method_description.cardinality()
@@ -139,7 +141,7 @@ def break_down_service(service_name, method_descriptions):
   implementations = {}
   request_deserializers = {}
   response_serializers = {}
-  for name, method_description in method_descriptions.iteritems():
+  for name, method_description in six.iteritems(method_descriptions):
     qualified_name = _qualified_name(service_name, name)
     method_cardinality = method_description.cardinality()
     if method_cardinality is interfaces.Cardinality.UNARY_UNARY:

--- a/src/python/grpcio/grpc/framework/alpha/_reexport.py
+++ b/src/python/grpcio/grpc/framework/alpha/_reexport.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -26,6 +26,8 @@
 # THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import six
 
 from grpc.framework.common import cardinality
 from grpc.framework.face import exceptions as face_exceptions
@@ -181,7 +183,7 @@ def common_cardinality(early_adopter_cardinality):
 
 def common_cardinalities(early_adopter_cardinalities):
   common_cardinalities = {}
-  for name, early_adopter_cardinality in early_adopter_cardinalities.iteritems():
+  for name, early_adopter_cardinality in six.iteritems(early_adopter_cardinalities):
     common_cardinalities[name] = _EARLY_ADOPTER_CARDINALITY_TO_COMMON_CARDINALITY[
         early_adopter_cardinality]
   return common_cardinalities

--- a/src/python/grpcio/grpc/framework/crust/implementations.py
+++ b/src/python/grpcio/grpc/framework/crust/implementations.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """Entry points into the Crust layer of RPC Framework."""
+
+import six
 
 from grpc.framework.common import cardinality
 from grpc.framework.common import style
@@ -271,7 +273,7 @@ class _DynamicStub(face.DynamicStub):
 
 def _adapt_method_implementations(method_implementations, pool):
   adapted_implementations = {}
-  for name, method_implementation in method_implementations.iteritems():
+  for name, method_implementation in six.iteritems(method_implementations):
     if method_implementation.style is style.Service.INLINE:
       if method_implementation.cardinality is cardinality.Cardinality.UNARY_UNARY:
         adapted_implementations[name] = _service.adapt_inline_unary_unary(

--- a/src/python/grpcio/grpc/framework/face/implementations.py
+++ b/src/python/grpcio/grpc/framework/face/implementations.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -28,6 +28,8 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """Entry points into the Face layer of RPC Framework."""
+
+import six
 
 from grpc.framework.common import cardinality
 from grpc.framework.common import style
@@ -228,7 +230,7 @@ class _DynamicStub(interfaces.DynamicStub):
 
 def _adapt_method_implementations(method_implementations, pool):
   adapted_implementations = {}
-  for name, method_implementation in method_implementations.iteritems():
+  for name, method_implementation in six.iteritems(method_implementations):
     if method_implementation.style is style.Service.INLINE:
       if method_implementation.cardinality is cardinality.Cardinality.UNARY_UNARY:
         adapted_implementations[name] = _service.adapt_inline_value_in_value_out(

--- a/src/python/grpcio/tests/unit/_core_over_links_base_interface_test.py
+++ b/src/python/grpcio/tests/unit/_core_over_links_base_interface_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -35,6 +35,8 @@ import random
 import time
 import unittest
 
+import six
+
 from grpc._adapter import _intermediary_low
 from grpc._links import invocation
 from grpc._links import service
@@ -68,7 +70,7 @@ def _serialization_behaviors_from_serializations(serializations):
   request_deserializers = {}
   response_serializers = {}
   response_deserializers = {}
-  for (group, method), serialization in serializations.iteritems():
+  for (group, method), serialization in six.iteritems(serializations):
     request_serializers[group, method] = serialization.serialize_request
     request_deserializers[group, method] = serialization.deserialize_request
     response_serializers[group, method] = serialization.serialize_response

--- a/src/python/grpcio/tests/unit/_crust_over_core_over_links_face_interface_test.py
+++ b/src/python/grpcio/tests/unit/_crust_over_core_over_links_face_interface_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -32,6 +32,8 @@
 import collections
 import unittest
 
+import six
+
 from grpc._adapter import _intermediary_low
 from grpc._links import invocation
 from grpc._links import service
@@ -59,7 +61,7 @@ def _serialization_behaviors_from_test_methods(test_methods):
   request_deserializers = {}
   response_serializers = {}
   response_deserializers = {}
-  for (group, method), test_method in test_methods.iteritems():
+  for (group, method), test_method in six.iteritems(test_methods):
     request_serializers[group, method] = test_method.serialize_request
     request_deserializers[group, method] = test_method.deserialize_request
     response_serializers[group, method] = test_method.serialize_response
@@ -108,7 +110,7 @@ class _Implementation(test_interfaces.Implementation):
     # _digest.TestServiceDigest.
     cardinalities = {
         method: method_object.cardinality()
-        for (group, method), method_object in methods.iteritems()}
+        for (group, method), method_object in six.iteritems(methods)}
     dynamic_stub = crust_implementations.dynamic_stub(
         invocation_end_link, group, cardinalities, pool)
 

--- a/src/python/grpcio/tests/unit/beta/_face_interface_test.py
+++ b/src/python/grpcio/tests/unit/beta/_face_interface_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -32,6 +32,8 @@
 import collections
 import unittest
 
+import six
+
 from grpc.beta import implementations
 from grpc.beta import interfaces
 from tests.unit import resources
@@ -57,7 +59,7 @@ def _serialization_behaviors_from_test_methods(test_methods):
   request_deserializers = {}
   response_serializers = {}
   response_deserializers = {}
-  for (group, method), test_method in test_methods.iteritems():
+  for (group, method), test_method in six.iteritems(test_methods):
     request_serializers[group, method] = test_method.serialize_request
     request_deserializers[group, method] = test_method.deserialize_request
     response_serializers[group, method] = test_method.serialize_response
@@ -79,7 +81,7 @@ class _Implementation(test_interfaces.Implementation):
     # _digest.TestServiceDigest.
     cardinalities = {
         method: method_object.cardinality()
-        for (group, method), method_object in methods.iteritems()}
+        for (group, method), method_object in six.iteritems(methods)}
 
     server_options = implementations.server_options(
         request_deserializers=serialization_behaviors.request_deserializers,

--- a/src/python/grpcio/tests/unit/framework/_crust_over_core_face_interface_test.py
+++ b/src/python/grpcio/tests/unit/framework/_crust_over_core_face_interface_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,6 +31,8 @@
 
 import collections
 import unittest
+
+import six
 
 from grpc.framework.core import implementations as core_implementations
 from grpc.framework.crust import implementations as crust_implementations
@@ -66,7 +68,7 @@ class _Implementation(test_interfaces.Implementation):
     # _digest.TestServiceDigest.
     cardinalities = {
         method: method_object.cardinality()
-        for (group, method), method_object in methods.iteritems()}
+        for (group, method), method_object in six.iteritems(methods)}
     dynamic_stub = crust_implementations.dynamic_stub(
         invocation_end_link, group, cardinalities, pool)
 

--- a/src/python/grpcio/tests/unit/framework/face/testing/blocking_invocation_inline_service_test_case.py
+++ b/src/python/grpcio/tests/unit/framework/face/testing/blocking_invocation_inline_service_test_case.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -32,6 +32,8 @@
 # unittest is referenced from specification in this module.
 import abc
 import unittest  # pylint: disable=unused-import
+
+import six
 
 from grpc.framework.face import exceptions
 from tests.unit.framework.common import test_constants
@@ -72,7 +74,7 @@ class BlockingInvocationInlineServiceTestCase(
 
   def testSuccessfulUnaryRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -83,7 +85,7 @@ class BlockingInvocationInlineServiceTestCase(
 
   def testSuccessfulUnaryRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -95,7 +97,7 @@ class BlockingInvocationInlineServiceTestCase(
 
   def testSuccessfulStreamRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -106,7 +108,7 @@ class BlockingInvocationInlineServiceTestCase(
 
   def testSuccessfulStreamRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -118,7 +120,7 @@ class BlockingInvocationInlineServiceTestCase(
 
   def testSequentialInvocations(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         first_request = test_messages.request()
         second_request = test_messages.request()
@@ -135,7 +137,7 @@ class BlockingInvocationInlineServiceTestCase(
 
   def testExpiredUnaryRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -146,7 +148,7 @@ class BlockingInvocationInlineServiceTestCase(
 
   def testExpiredUnaryRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -158,7 +160,7 @@ class BlockingInvocationInlineServiceTestCase(
 
   def testExpiredStreamRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -169,7 +171,7 @@ class BlockingInvocationInlineServiceTestCase(
 
   def testExpiredStreamRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -181,7 +183,7 @@ class BlockingInvocationInlineServiceTestCase(
 
   def testFailedUnaryRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -191,7 +193,7 @@ class BlockingInvocationInlineServiceTestCase(
 
   def testFailedUnaryRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -202,7 +204,7 @@ class BlockingInvocationInlineServiceTestCase(
 
   def testFailedStreamRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -212,7 +214,7 @@ class BlockingInvocationInlineServiceTestCase(
 
   def testFailedStreamRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 

--- a/src/python/grpcio/tests/unit/framework/face/testing/digest.py
+++ b/src/python/grpcio/tests/unit/framework/face/testing/digest.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,6 +31,8 @@
 
 import collections
 import threading
+
+import six
 
 # testing_control, interfaces, and testing_service are referenced from
 # specification in this module.
@@ -368,7 +370,7 @@ def _assemble(
   events = {}
   adaptations = {}
   messages = {}
-  for name, scenario in scenarios.iteritems():
+  for name, scenario in six.iteritems(scenarios):
     if name in names:
       raise ValueError('Repeated name "%s"!' % name)
 

--- a/src/python/grpcio/tests/unit/framework/face/testing/event_invocation_synchronous_event_service_test_case.py
+++ b/src/python/grpcio/tests/unit/framework/face/testing/event_invocation_synchronous_event_service_test_case.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,6 +31,8 @@
 
 import abc
 import unittest
+
+import six
 
 from grpc.framework.face import interfaces
 from tests.unit.framework.common import test_constants
@@ -72,7 +74,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testSuccessfulUnaryRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
         callback = testing_callback.Callback()
@@ -87,7 +89,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testSuccessfulUnaryRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
         callback = testing_callback.Callback()
@@ -102,7 +104,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testSuccessfulStreamRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
         callback = testing_callback.Callback()
@@ -120,7 +122,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testSuccessfulStreamRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
         callback = testing_callback.Callback()
@@ -138,7 +140,7 @@ class EventInvocationSynchronousEventServiceTestCase(
   def testSequentialInvocations(self):
     # pylint: disable=cell-var-from-loop
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         first_request = test_messages.request()
         second_request = test_messages.request()
@@ -163,7 +165,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testExpiredUnaryRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
         callback = testing_callback.Callback()
@@ -178,7 +180,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testExpiredUnaryRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
         callback = testing_callback.Callback()
@@ -193,7 +195,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testExpiredStreamRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_unary_messages_sequences)):
       for unused_test_messages in test_messages_sequence:
         callback = testing_callback.Callback()
 
@@ -206,7 +208,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testExpiredStreamRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
         callback = testing_callback.Callback()
@@ -221,7 +223,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testFailedUnaryRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
         callback = testing_callback.Callback()
@@ -237,7 +239,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testFailedUnaryRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
         callback = testing_callback.Callback()
@@ -253,7 +255,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testFailedStreamRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
         callback = testing_callback.Callback()
@@ -272,7 +274,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testFailedStreamRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
         callback = testing_callback.Callback()
@@ -289,7 +291,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testParallelInvocations(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         first_request = test_messages.request()
         first_callback = testing_callback.Callback()
@@ -316,7 +318,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testCancelledUnaryRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
         callback = testing_callback.Callback()
@@ -332,7 +334,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testCancelledUnaryRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
         callback = testing_callback.Callback()
@@ -347,7 +349,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testCancelledStreamRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
         callback = testing_callback.Callback()
@@ -364,7 +366,7 @@ class EventInvocationSynchronousEventServiceTestCase(
 
   def testCancelledStreamRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_stream_messages_sequences)):
       for unused_test_messages in test_messages_sequence:
         callback = testing_callback.Callback()
 

--- a/src/python/grpcio/tests/unit/framework/face/testing/future_invocation_asynchronous_event_service_test_case.py
+++ b/src/python/grpcio/tests/unit/framework/face/testing/future_invocation_asynchronous_event_service_test_case.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -33,6 +33,8 @@ import abc
 import contextlib
 import threading
 import unittest
+
+import six
 
 from grpc.framework.face import exceptions
 from grpc.framework.foundation import future
@@ -105,7 +107,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testSuccessfulUnaryRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -117,7 +119,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testSuccessfulUnaryRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -129,7 +131,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testSuccessfulStreamRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
         request_iterator = _PauseableIterator(iter(requests))
@@ -145,7 +147,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testSuccessfulStreamRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
         request_iterator = _PauseableIterator(iter(requests))
@@ -161,7 +163,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testSequentialInvocations(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         first_request = test_messages.request()
         second_request = test_messages.request()
@@ -180,7 +182,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testExpiredUnaryRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -195,7 +197,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testExpiredUnaryRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -207,7 +209,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testExpiredStreamRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -222,7 +224,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testExpiredStreamRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -234,7 +236,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testFailedUnaryRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -253,7 +255,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testFailedUnaryRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -268,7 +270,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testFailedStreamRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -287,7 +289,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testFailedStreamRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -302,7 +304,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testParallelInvocations(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         first_request = test_messages.request()
         second_request = test_messages.request()
@@ -324,7 +326,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testCancelledUnaryRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -338,7 +340,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testCancelledUnaryRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -352,7 +354,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testCancelledStreamRequestUnaryResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -366,7 +368,7 @@ class FutureInvocationAsynchronousEventServiceTestCase(
 
   def testCancelledStreamRequestStreamResponse(self):
     for name, test_messages_sequence in (
-        self.digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self.digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 

--- a/src/python/grpcio/tests/unit/framework/interfaces/face/_blocking_invocation_inline_service.py
+++ b/src/python/grpcio/tests/unit/framework/interfaces/face/_blocking_invocation_inline_service.py
@@ -34,6 +34,8 @@ import itertools
 import unittest
 from concurrent import futures
 
+import six
+
 # test_interfaces is referenced from specification in this module.
 from grpc.framework.foundation import logging_pool
 from grpc.framework.interfaces.face import face
@@ -81,7 +83,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testSuccessfulUnaryRequestUnaryResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -92,7 +94,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testSuccessfulUnaryRequestStreamResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -104,7 +106,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testSuccessfulStreamRequestUnaryResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -115,7 +117,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testSuccessfulStreamRequestStreamResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self._digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -127,7 +129,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testSequentialInvocations(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         first_request = test_messages.request()
         second_request = test_messages.request()
@@ -145,7 +147,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
   def testParallelInvocations(self):
     pool = logging_pool.pool(test_constants.PARALLELISM)
     for (group, method), test_messages_sequence in (
-        self._digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = []
         response_futures = []
@@ -167,7 +169,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
   def testWaitingForSomeButNotAllParallelInvocations(self):
     pool = logging_pool.pool(test_constants.PARALLELISM)
     for (group, method), test_messages_sequence in (
-        self._digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = []
         response_futures_to_indices = {}
@@ -205,7 +207,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testExpiredUnaryRequestUnaryResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -216,7 +218,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testExpiredUnaryRequestStreamResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -228,7 +230,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testExpiredStreamRequestUnaryResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -239,7 +241,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testExpiredStreamRequestStreamResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self._digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -251,7 +253,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testFailedUnaryRequestUnaryResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -261,7 +263,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testFailedUnaryRequestStreamResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -272,7 +274,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testFailedStreamRequestUnaryResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -282,7 +284,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testFailedStreamRequestStreamResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self._digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 

--- a/src/python/grpcio/tests/unit/framework/interfaces/face/_digest.py
+++ b/src/python/grpcio/tests/unit/framework/interfaces/face/_digest.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -31,6 +31,8 @@
 
 import collections
 import threading
+
+import six
 
 # test_control, _service, and test_interfaces are referenced from specification
 # in this module.
@@ -363,7 +365,7 @@ def _assemble(
   events = {}
   adaptations = {}
   messages = {}
-  for identifier, scenario in scenarios.iteritems():
+  for identifier, scenario in six.iteritems(scenarios):
     if identifier in identifiers:
       raise ValueError('Repeated identifier "(%s, %s)"!' % identifier)
 

--- a/src/python/grpcio/tests/unit/framework/interfaces/face/_future_invocation_asynchronous_event_service.py
+++ b/src/python/grpcio/tests/unit/framework/interfaces/face/_future_invocation_asynchronous_event_service.py
@@ -36,6 +36,8 @@ import threading
 import unittest
 from concurrent import futures
 
+import six
+
 # test_interfaces is referenced from specification in this module.
 from grpc.framework.foundation import logging_pool
 from grpc.framework.interfaces.face import face
@@ -141,7 +143,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testSuccessfulUnaryRequestUnaryResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
         callback = _Callback()
@@ -156,7 +158,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testSuccessfulUnaryRequestStreamResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -168,7 +170,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testSuccessfulStreamRequestUnaryResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
         request_iterator = _PauseableIterator(iter(requests))
@@ -188,7 +190,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testSuccessfulStreamRequestStreamResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self._digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
         request_iterator = _PauseableIterator(iter(requests))
@@ -204,7 +206,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testSequentialInvocations(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         first_request = test_messages.request()
         second_request = test_messages.request()
@@ -223,7 +225,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testParallelInvocations(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         first_request = test_messages.request()
         second_request = test_messages.request()
@@ -239,7 +241,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
         test_messages.verify(second_request, second_response, self)
 
     for (group, method), test_messages_sequence in (
-        self._digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = []
         response_futures = []
@@ -259,7 +261,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
   def testWaitingForSomeButNotAllParallelInvocations(self):
     pool = logging_pool.pool(test_constants.PARALLELISM)
     for (group, method), test_messages_sequence in (
-        self._digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = []
         response_futures_to_indices = {}
@@ -281,7 +283,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testCancelledUnaryRequestUnaryResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
         callback = _Callback()
@@ -298,7 +300,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testCancelledUnaryRequestStreamResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -312,7 +314,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testCancelledStreamRequestUnaryResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
         callback = _Callback()
@@ -329,7 +331,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testCancelledStreamRequestStreamResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self._digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -343,7 +345,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testExpiredUnaryRequestUnaryResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
         callback = _Callback()
@@ -360,7 +362,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testExpiredUnaryRequestStreamResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -372,7 +374,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testExpiredStreamRequestUnaryResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
         callback = _Callback()
@@ -389,7 +391,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testExpiredStreamRequestStreamResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self._digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 
@@ -401,7 +403,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testFailedUnaryRequestUnaryResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
         callback = _Callback()
@@ -423,7 +425,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testFailedUnaryRequestStreamResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.unary_stream_messages_sequences.iteritems()):
+        six.iteritems(self._digest.unary_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         request = test_messages.request()
 
@@ -438,7 +440,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testFailedStreamRequestUnaryResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.stream_unary_messages_sequences.iteritems()):
+        six.iteritems(self._digest.stream_unary_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
         callback = _Callback()
@@ -460,7 +462,7 @@ class TestCase(test_coverage.Coverage, unittest.TestCase):
 
   def testFailedStreamRequestStreamResponse(self):
     for (group, method), test_messages_sequence in (
-        self._digest.stream_stream_messages_sequences.iteritems()):
+        six.iteritems(self._digest.stream_stream_messages_sequences)):
       for test_messages in test_messages_sequence:
         requests = test_messages.requests()
 

--- a/src/python/grpcio/tests/unit/test_common.py
+++ b/src/python/grpcio/tests/unit/test_common.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -30,6 +30,8 @@
 """Common code used throughout tests of gRPC."""
 
 import collections
+
+import six
 
 INVOCATION_INITIAL_METADATA = ((b'0', b'abc'), (b'1', b'def'), (b'2', b'ghi'),)
 SERVICE_INITIAL_METADATA = ((b'3', b'jkl'), (b'4', b'mno'), (b'5', b'pqr'),)
@@ -65,7 +67,7 @@ def metadata_transmitted(original_metadata, transmitted_metadata):
     key, value = tuple(key_value_pair)
     transmitted[key].append(value)
 
-  for key, values in original.iteritems():
+  for key, values in six.iteritems(original):
     transmitted_values = transmitted[key]
     transmitted_iterator = iter(transmitted_values)
     try:


### PR DESCRIPTION
re #5648 , #282 

replace `dict_instance.iteritems()` with `six.iteritems(dict_instance)` to be python 2/3 compatible.