### PR TITLE
Make timestamp format in C# logs more similar to C core

### DIFF
--- a/src/csharp/Grpc.Core/Logging/ConsoleLogger.cs
+++ b/src/csharp/Grpc.Core/Logging/ConsoleLogger.cs
@@ -1,6 +1,6 @@
 #region Copyright notice and license
 
-// Copyright 2015, Google Inc.
+// Copyright 2015-2016, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -33,12 +33,16 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace Grpc.Core.Logging
 {
     /// <summary>Logger that logs to System.Console.</summary>
     public class ConsoleLogger : ILogger
     {
+        // Format similar enough to C core log format except nanosecond precision is not supported.
+        const string DateTimeFormatString = "MMdd HH:mm:ss.ffffff";
+
         readonly Type forType;
         readonly string forTypeString;
 
@@ -142,7 +146,7 @@ namespace Grpc.Core.Logging
         {
             Console.Error.WriteLine("{0}{1} {2}{3}",
                 severityString,
-                DateTime.Now,
+                DateTime.Now.ToString(DateTimeFormatString, CultureInfo.InvariantCulture),
                 forTypeString,
                 message);
         }


### PR DESCRIPTION
this has been requested to ease up C# debugging (we need better precision than just seconds).