### PR TITLE
Fix _channel_test.ChannelTest.test_multiple_channels_lonely_connectivity

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,8 +108,13 @@ if "linux" in sys.platform or "darwin" in sys.platform:
 
 def cython_extensions(package_names, module_names, extra_sources, include_dirs,
                       libraries, define_macros, build_with_cython=False):
+  # Set compiler directives linetrace argument only if we care about tracing;
+  # this is due to Cython having different behavior between linetrace being
+  # False and linetrace being unset. See issue xxx/yyy#zzzz.
+  cython_compiler_directives = {}
   if ENABLE_CYTHON_TRACING:
     define_macros = define_macros + [('CYTHON_TRACE_NOGIL', 1)]
+    cython_compiler_directives['linetrace'] = True
   file_extension = 'pyx' if build_with_cython else 'c'
   module_files = [os.path.join(PYTHON_STEM,
                                name.replace('.', '/') + '.' + file_extension)
@@ -129,7 +134,7 @@ def cython_extensions(package_names, module_names, extra_sources, include_dirs,
     return Cython.Build.cythonize(
         extensions,
         include_path=include_dirs,
-        compiler_directives={'linetrace': bool(ENABLE_CYTHON_TRACING)})
+        compiler_directives=cython_compiler_directives)
   else:
     return extensions
 

--- a/src/python/grpcio/grpc/_adapter/_low.py
+++ b/src/python/grpcio/grpc/_adapter/_low.py
@@ -182,6 +182,9 @@ class CompletionQueue(_types.CompletionQueue):
   def shutdown(self):
     self.completion_queue.shutdown()
 
+  def __del__(self):
+    self.completion_queue.close()
+
 
 class Call(_types.Call):
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pyx.pxi
@@ -132,7 +132,7 @@ cdef class CompletionQueue:
     while self.poll().type != GRPC_QUEUE_SHUTDOWN:
       pass
 
-  def __dealloc__(self):
+  def close(self):
     cdef gpr_timespec c_deadline = gpr_inf_future(GPR_CLOCK_REALTIME)
     if self.c_completion_queue != NULL:
       # Ensure shutdown
@@ -144,3 +144,6 @@ cdef class CompletionQueue:
             self.c_completion_queue, c_deadline, NULL)
         self._interpret_event(event)
       grpc_completion_queue_destroy(self.c_completion_queue)
+
+  def __dealloc__(self):
+    pass

--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
@@ -128,6 +128,7 @@ cdef class Server:
   cdef notify_shutdown_complete(self):
     # called only by a completion queue on receiving our shutdown operation tag
     self.is_shutdown = True
+    self.backup_shutdown_queue.close()
 
   def cancel_all_calls(self):
     if not self.is_shutting_down:

--- a/src/python/grpcio/tests/unit/_cython/_channel_test.py
+++ b/src/python/grpcio/tests/unit/_cython/_channel_test.py
@@ -34,7 +34,7 @@ import unittest
 from grpc._cython import cygrpc
 
 # TODO(nathaniel): This should be at least one hundred. Why not one thousand?
-_PARALLELISM = 4
+_PARALLELISM = 100
 
 
 def _channel_and_completion_queue():
@@ -44,10 +44,10 @@ def _channel_and_completion_queue():
 
 
 def _connectivity_loop(channel, completion_queue):
-  for _ in range(100):
+  for _ in range(50):
     connectivity = channel.check_connectivity_state(True)
     channel.watch_connectivity_state(
-        connectivity, cygrpc.Timespec(time.time() + 0.2), completion_queue,
+        connectivity, cygrpc.Timespec(time.time() + 0.05), completion_queue,
         None)
     completion_queue.poll(deadline=cygrpc.Timespec(float('+inf')))
 
@@ -56,6 +56,7 @@ def _create_loop_destroy():
   channel, completion_queue = _channel_and_completion_queue()
   _connectivity_loop(channel, completion_queue)
   completion_queue.shutdown()
+  completion_queue.close()
 
 
 def _in_parallel(behavior, arguments):

--- a/tools/run_tests/build_python.sh
+++ b/tools/run_tests/build_python.sh
@@ -40,7 +40,11 @@ export PATH=$ROOT/bins/$CONFIG:$ROOT/bins/$CONFIG/protobuf:$PATH
 export CFLAGS="-I$ROOT/include -std=gnu99"
 export LDFLAGS="-L$ROOT/libs/$CONFIG"
 export GRPC_PYTHON_BUILD_WITH_CYTHON=1
-export GRPC_PYTHON_ENABLE_CYTHON_TRACING=1
+
+if [ "$CONFIG" = "gcov" ]
+then
+  export GRPC_PYTHON_ENABLE_CYTHON_TRACING=1
+fi
 
 tox --notest
 


### PR DESCRIPTION
I still need to see if I can find a Cython-related issue regarding the `linetrace` compiler directive; other than that this fixes one of our flakes.