### PR TITLE
Allow overriding hostname used for CN validation

### DIFF
--- a/src/python/grpcio/grpc/beta/implementations.py
+++ b/src/python/grpcio/grpc/beta/implementations.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -196,19 +196,22 @@ def insecure_channel(host, port):
   return Channel(intermediary_low_channel._internal, intermediary_low_channel)  # pylint: disable=protected-access
 
 
-def secure_channel(host, port, channel_credentials):
+def secure_channel(host, port, channel_credentials, server_host_override=None):
   """Creates a secure Channel to a remote host.
 
   Args:
     host: The name of the remote host to which to connect.
     port: The port of the remote host to which to connect.
     channel_credentials: A ChannelCredentials.
+    server_host_override: The target name used for SSL host name checking.
+      If not specified the 'host' argument will be used.
 
   Returns:
     A secure Channel to the remote host through which RPCs may be conducted.
   """
   intermediary_low_channel = _intermediary_low.Channel(
-      '%s:%d' % (host, port), channel_credentials._low_credentials)
+      '%s:%d' % (host, port), channel_credentials._low_credentials,
+      server_host_override)
   return Channel(intermediary_low_channel._internal, intermediary_low_channel)  # pylint: disable=protected-access
 
 


### PR DESCRIPTION
This is often needed to support connecting via UNIX sockets, IP-address and so on.

This closes https://github.com/grpc/grpc/issues/5697