### PR TITLE
ssl_channel_credentials to use None by default

### DIFF
--- a/src/python/grpcio/grpc/beta/implementations.py
+++ b/src/python/grpcio/grpc/beta/implementations.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -61,15 +61,16 @@ class ChannelCredentials(object):
     self._low_credentials = low_credentials
 
 
-def ssl_channel_credentials(root_certificates, private_key, certificate_chain):
+def ssl_channel_credentials(root_certificates=None, private_key=None,
+                            certificate_chain=None):
   """Creates a ChannelCredentials for use with an SSL-enabled Channel.
 
   Args:
-    root_certificates: The PEM-encoded root certificates or None to ask for
+    root_certificates: The PEM-encoded root certificates or unset to ask for
       them to be retrieved from a default location.
-    private_key: The PEM-encoded private key to use or None if no private key
+    private_key: The PEM-encoded private key to use or unset if no private key
       should be used.
-    certificate_chain: The PEM-encoded certificate chain to use or None if no
+    certificate_chain: The PEM-encoded certificate chain to use or unset if no
       certificate chain should be used.
 
   Returns:

--- a/src/python/grpcio/tests/interop/_secure_interop_test.py
+++ b/src/python/grpcio/tests/interop/_secure_interop_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -56,7 +56,7 @@ class SecureInteropTest(
     self.stub = test_pb2.beta_create_TestService_stub(
         test_utilities.not_really_secure_channel(
             '[::]', port, implementations.ssl_channel_credentials(
-                resources.test_root_certificates(), None, None),
+                resources.test_root_certificates()),
                 _SERVER_HOST_OVERRIDE))
 
   def tearDown(self):

--- a/src/python/grpcio/tests/interop/client.py
+++ b/src/python/grpcio/tests/interop/client.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -94,7 +94,7 @@ def _stub(args):
 
     channel = test_utilities.not_really_secure_channel(
         args.server_host, args.server_port,
-        implementations.ssl_channel_credentials(root_certificates, None, None),
+        implementations.ssl_channel_credentials(root_certificates),
         args.server_host_override)
     stub = test_pb2.beta_create_TestService_stub(
         channel, metadata_transformer=metadata_transformer)

--- a/src/python/grpcio/tests/unit/beta/_beta_features_test.py
+++ b/src/python/grpcio/tests/unit/beta/_beta_features_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -180,7 +180,7 @@ class BetaFeaturesTest(unittest.TestCase):
     port = self._server.add_secure_port('[::]:0', server_credentials)
     self._server.start()
     self._channel_credentials = implementations.ssl_channel_credentials(
-        resources.test_root_certificates(), None, None)
+        resources.test_root_certificates())
     self._call_credentials = implementations.metadata_call_credentials(
         _metadata_plugin)
     channel = test_utilities.not_really_secure_channel(
@@ -293,7 +293,7 @@ class ContextManagementAndLifecycleTest(unittest.TestCase):
     self._server_credentials = implementations.ssl_server_credentials(
         [(resources.private_key(), resources.certificate_chain(),),])
     self._channel_credentials = implementations.ssl_channel_credentials(
-        resources.test_root_certificates(), None, None)
+        resources.test_root_certificates())
     self._stub_options = implementations.stub_options(
         thread_pool_size=test_constants.POOL_SIZE)
 

--- a/src/python/grpcio/tests/unit/beta/_face_interface_test.py
+++ b/src/python/grpcio/tests/unit/beta/_face_interface_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -92,7 +92,7 @@ class _Implementation(test_interfaces.Implementation):
     port = server.add_secure_port('[::]:0', server_credentials)
     server.start()
     channel_credentials = implementations.ssl_channel_credentials(
-        resources.test_root_certificates(), None, None)
+        resources.test_root_certificates())
     channel = test_utilities.not_really_secure_channel(
         'localhost', port, channel_credentials, _SERVER_HOST_OVERRIDE)
     stub_options = implementations.stub_options(

--- a/src/python/grpcio/tests/unit/beta/_implementations_test.py
+++ b/src/python/grpcio/tests/unit/beta/_implementations_test.py
@@ -38,14 +38,13 @@ from tests.unit import resources
 class ChannelCredentialsTest(unittest.TestCase):
 
   def test_runtime_provided_root_certificates(self):
-    channel_credentials = implementations.ssl_channel_credentials(
-        None, None, None)
+    channel_credentials = implementations.ssl_channel_credentials()
     self.assertIsInstance(
         channel_credentials, implementations.ChannelCredentials)
   
   def test_application_provided_root_certificates(self):
     channel_credentials = implementations.ssl_channel_credentials(
-        resources.test_root_certificates(), None, None)
+        resources.test_root_certificates())
     self.assertIsInstance(
         channel_credentials, implementations.ChannelCredentials)
 


### PR DESCRIPTION
Since the default behavior is quite sane, support just calling ssl_channel_credentials() without explicitly specifying ssl_channel_credentials(None, None, None).

This changes the pattern ssl_channel_credentials(server_crt, None, None) to ssl_channel_credentials(server_crt)

This closes https://github.com/grpc/grpc/issues/5696