### PR TITLE
Allow directly specifiying connection path

### DIFF
--- a/src/python/grpcio/grpc/beta/implementations.py
+++ b/src/python/grpcio/grpc/beta/implementations.py
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2015-2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -187,12 +187,13 @@ def insecure_channel(host, port):
   Args:
     host: The name of the remote host to which to connect.
     port: The port of the remote host to which to connect.
+      If None only the 'host' part will be used.
 
   Returns:
     A Channel to the remote host through which RPCs may be conducted.
   """
   intermediary_low_channel = _intermediary_low.Channel(
-      '%s:%d' % (host, port), None)
+      '%s:%d' % (host, port) if port else host, None)
   return Channel(intermediary_low_channel._internal, intermediary_low_channel)  # pylint: disable=protected-access
 
 
@@ -202,13 +203,15 @@ def secure_channel(host, port, channel_credentials):
   Args:
     host: The name of the remote host to which to connect.
     port: The port of the remote host to which to connect.
+      If None only the 'host' part will be used.
     channel_credentials: A ChannelCredentials.
 
   Returns:
     A secure Channel to the remote host through which RPCs may be conducted.
   """
   intermediary_low_channel = _intermediary_low.Channel(
-      '%s:%d' % (host, port), channel_credentials._low_credentials)
+      '%s:%d' % (host, port) if port else host,
+      channel_credentials._low_credentials)
   return Channel(intermediary_low_channel._internal, intermediary_low_channel)  # pylint: disable=protected-access
 
 


### PR DESCRIPTION
Make insecure_channel / secure_channel accept port=None and only use the
'host' argument. This enables using UNIX sockets without mangling the
path of the socket.

The API would be clearer if port somehow was optional (like passing a (host, port) tuple like a lot of other Python libraries are using) but to maintain compatibility with the current users this solution is proposed.

This provides relief for https://github.com/grpc/grpc/issues/4974