### PR TITLE
Objective C: kSCNetworkReachabilityFlagsIsWWAN is only available on iOS

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCReachabilityFlagNames.xmacro.h
+++ b/src/objective-c/GRPCClient/private/GRPCReachabilityFlagNames.xmacro.h
@@ -54,7 +54,9 @@
        GRPC_XMACRO_ITEM.
 #endif
 
+#if TARGET_OS_IPHONE
 GRPC_XMACRO_ITEM(isCell, IsWWAN)
+#endif
 GRPC_XMACRO_ITEM(reachable, Reachable)
 GRPC_XMACRO_ITEM(transientConnection, TransientConnection)
 GRPC_XMACRO_ITEM(connectionRequired, ConnectionRequired)


### PR DESCRIPTION
Mac does not have this flag, it is specific to an iOS target.