### PR TITLE
Objective C: import GRPCCompletionQueue.h in GRPCChannel.m

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.m
@@ -32,6 +32,7 @@
  */
 
 #import "GRPCChannel.h"
+#import "GRPCCompletionQueue.h"
 
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>


### PR DESCRIPTION
`GRPCCompletionQueue` was only forward declared in `GRPCChannel.h`, but its properties are used by `GRPCChannel.m`

Without this, I get a compile error:
```
grpc/src/objective-c/GRPCClient/private/GRPCChannel.m:160:41: Property 'unmanagedQueue' cannot 
be found in forward class object 'GRPCCompletionQueue'
```

CC @jcanizales 