### PR TITLE
Use a singleton completion queue

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCCompletionQueue.m
+++ b/src/objective-c/GRPCClient/private/GRPCCompletionQueue.m
@@ -41,7 +41,12 @@ const int64_t kGRPCCompletionQueueDefaultTimeoutSecs = 60;
 @implementation GRPCCompletionQueue
 
 + (instancetype)completionQueue {
-  return [[self alloc] init];
+  static GRPCCompletionQueue *singleton = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    singleton = [[self alloc] init];
+  });
+  return singleton;
 }
 
 - (instancetype)init {


### PR DESCRIPTION
Fixes #5692.

In my tests, this also fixes #5593, which means #5724 can be reverted. @gresrun should confirm on his side before reverting.

CC: @jtattermusch @ctiller 