### PR TITLE
Reduce the number of threads so that this test works on x86 systems

### DIFF
--- a/test/core/support/thd_test.c
+++ b/test/core/support/thd_test.c
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/test/core/support/thd_test.c
+++ b/test/core/support/thd_test.c
@@ -41,6 +41,8 @@
 #include <grpc/support/time.h>
 #include "test/core/util/test_config.h"
 
+#define NUM_THREADS 300
+
 struct test {
   gpr_mu mu;
   int n;
@@ -79,15 +81,14 @@ static void test_options(void) {
 static void test(void) {
   int i;
   gpr_thd_id thd;
-  gpr_thd_id thds[300];
+  gpr_thd_id thds[NUM_THREADS];
   struct test t;
-  int n = 300;
   gpr_thd_options options = gpr_thd_options_default();
   gpr_mu_init(&t.mu);
   gpr_cv_init(&t.done_cv);
-  t.n = n;
+  t.n = NUM_THREADS;
   t.is_done = 0;
-  for (i = 0; i != n; i++) {
+  for (i = 0; i < NUM_THREADS; i++) {
     GPR_ASSERT(gpr_thd_new(&thd, &thd_body, &t, NULL));
   }
   gpr_mu_lock(&t.mu);
@@ -97,10 +98,10 @@ static void test(void) {
   gpr_mu_unlock(&t.mu);
   GPR_ASSERT(t.n == 0);
   gpr_thd_options_set_joinable(&options);
-  for (i = 0; i < n; i++) {
+  for (i = 0; i < NUM_THREADS; i++) {
     GPR_ASSERT(gpr_thd_new(&thds[i], &thd_body_joinable, NULL, &options));
   }
-  for (i = 0; i < n; i++) {
+  for (i = 0; i < NUM_THREADS; i++) {
     gpr_thd_join(thds[i]);
   }
 }

--- a/test/core/support/thd_test.c
+++ b/test/core/support/thd_test.c
@@ -79,9 +79,9 @@ static void test_options(void) {
 static void test(void) {
   int i;
   gpr_thd_id thd;
-  gpr_thd_id thds[1000];
+  gpr_thd_id thds[300];
   struct test t;
-  int n = 1000;
+  int n = 300;
   gpr_thd_options options = gpr_thd_options_default();
   gpr_mu_init(&t.mu);
   gpr_cv_init(&t.done_cv);


### PR DESCRIPTION
This fixes https://github.com/grpc/grpc/issues/5413 .

`gpr_thd_new` was failing to create 1000 threads on x86 systems because of memory limit (I saw that the thread's max stack size as per `getrlimit(RLIMIT_STACK)` is 8MB. So clearly, on x86 systems, it cannot create 1000 threads unless the per-thread stack limit is reduced).

Rather than reducing the thread stack limit size, I thought it is better to just reduce the number of threads being created to 300 from 1000. The test is still semantically the same (unless I am missing something :))..
