### PR TITLE
DocFixit: Python README

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,6 +52,6 @@ gRPC C Core library.
  $ git clone https://github.com/grpc/grpc.git
  $ cd grpc
  $ git submodule update --init
- $ make 
+ $ make
  $ [sudo] make install
 ```

--- a/src/python/grpcio/README.rst
+++ b/src/python/grpcio/README.rst
@@ -35,13 +35,14 @@ package named :code:`python-dev`).
 
 ::
 
-  $ export REPO_ROOT=grpc
+  $ export REPO_ROOT=grpc  # REPO_ROOT can be any directory of your choice
   $ git clone https://github.com/grpc/grpc.git $REPO_ROOT
   $ cd $REPO_ROOT
-  $ pip install .
 
-Note that :code:`$REPO_ROOT` can be assigned to whatever directory name floats
-your fancy.
+  # For the next two commands do `sudo pip install` if you get permission-denied errors
+  $ pip install -rrequirements.txt
+  $ GRPC_PYTHON_BUILD_WITH_CYTHON=1 pip install .
+
 
 Troubleshooting
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
The python installation was not working for me on windows and ubuntu unless I do the following. 

`
 $ sudo pip install -rrequirements.txt
 $ GRPC_PYTHON_BUILD_WITH_CYTHON=1 sudo pip install .
`

I updated the instructions in the README.rst file.

I am getting an error in Mac and I created a separate issue for it: https://github.com/grpc/grpc/issues/5790