### PR TITLE
Csharp serverside abstractclass v2

### DIFF
--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -82,7 +82,7 @@ std::string GetServerInterfaceName(const ServiceDescriptor* service) {
 }
 
 std::string GetServerClassName(const ServiceDescriptor* service) {
-  return service->name() + "Base";
+  return service->name();
 }
 
 std::string GetCSharpMethodType(MethodType method_type) {
@@ -295,7 +295,9 @@ void GenerateClientInterface(Printer* out, const ServiceDescriptor *service) {
 void GenerateServerInterface(Printer* out, const ServiceDescriptor *service) {
   out->Print("// server-side interface\n");
   out->Print("[System.Obsolete(\"Service implementations should inherit"
-      " from the generated abstract base class instead.\")]\n");
+      " from the generated abstract base class $classname$ instead.\")]\n",
+      "classname",
+      GetServerClassName(service));
   out->Print("public interface $name$\n", "name",
              GetServerInterfaceName(service));
   out->Print("{\n");

--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -66,7 +66,7 @@ namespace grpc_csharp_generator {
 namespace {
 
 std::string GetServiceClassName(const ServiceDescriptor* service) {
-  return service->name();
+  return service->name() + "Grpc";
 }
 
 std::string GetClientInterfaceName(const ServiceDescriptor* service) {

--- a/src/csharp/Grpc.Examples.MathClient/MathClient.cs
+++ b/src/csharp/Grpc.Examples.MathClient/MathClient.cs
@@ -40,7 +40,7 @@ namespace Math
         public static void Main(string[] args)
         {
             var channel = new Channel("127.0.0.1", 23456, ChannelCredentials.Insecure);
-            Math.IMathClient client = new Math.MathClient(channel);
+            MathGrpc.IMathClient client = new MathGrpc.MathClient(channel);
             MathExamples.DivExample(client);
 
             MathExamples.DivAsyncExample(client).Wait();

--- a/src/csharp/Grpc.Examples.MathServer/MathServer.cs
+++ b/src/csharp/Grpc.Examples.MathServer/MathServer.cs
@@ -45,7 +45,7 @@ namespace Math
         {
             Server server = new Server
             {
-                Services = { Math.BindService(new MathServiceImpl()) },
+                Services = { MathGrpc.BindService(new MathServiceImpl()) },
                 Ports = { { Host, Port, ServerCredentials.Insecure } }
             };
             server.Start();

--- a/src/csharp/Grpc.Examples.Tests/MathClientServerTests.cs
+++ b/src/csharp/Grpc.Examples.Tests/MathClientServerTests.cs
@@ -50,19 +50,19 @@ namespace Math.Tests
         const string Host = "localhost";
         Server server;
         Channel channel;
-        Math.MathClient client;
+        MathGrpc.MathClient client;
 
         [TestFixtureSetUp]
         public void Init()
         {
             server = new Server
             {
-                Services = { Math.BindService(new MathServiceImpl()) },
+                Services = { MathGrpc.BindService(new MathServiceImpl()) },
                 Ports = { { Host, ServerPort.PickUnused, ServerCredentials.Insecure } }
             };
             server.Start();
             channel = new Channel(Host, server.Ports.Single().BoundPort, ChannelCredentials.Insecure);
-            client = Math.NewClient(channel);
+            client = MathGrpc.NewClient(channel);
         }
 
         [TestFixtureTearDown]

--- a/src/csharp/Grpc.Examples/MathExamples.cs
+++ b/src/csharp/Grpc.Examples/MathExamples.cs
@@ -38,19 +38,19 @@ namespace Math
 {
     public static class MathExamples
     {
-        public static void DivExample(Math.IMathClient client)
+        public static void DivExample(MathGrpc.IMathClient client)
         {
             DivReply result = client.Div(new DivArgs { Dividend = 10, Divisor = 3 });
             Console.WriteLine("Div Result: " + result);
         }
 
-        public static async Task DivAsyncExample(Math.IMathClient client)
+        public static async Task DivAsyncExample(MathGrpc.IMathClient client)
         {
             DivReply result = await client.DivAsync(new DivArgs { Dividend = 4, Divisor = 5 });
             Console.WriteLine("DivAsync Result: " + result);
         }
 
-        public static async Task FibExample(Math.IMathClient client)
+        public static async Task FibExample(MathGrpc.IMathClient client)
         {
             using (var call = client.Fib(new FibArgs { Limit = 5 }))
             {
@@ -59,7 +59,7 @@ namespace Math
             }
         }
 
-        public static async Task SumExample(Math.IMathClient client)
+        public static async Task SumExample(MathGrpc.IMathClient client)
         {
             var numbers = new List<Num>
             {
@@ -75,7 +75,7 @@ namespace Math
             }
         }
 
-        public static async Task DivManyExample(Math.IMathClient client)
+        public static async Task DivManyExample(MathGrpc.IMathClient client)
         {
             var divArgsList = new List<DivArgs>
             {
@@ -90,7 +90,7 @@ namespace Math
             }
         }
 
-        public static async Task DependendRequestsExample(Math.IMathClient client)
+        public static async Task DependendRequestsExample(MathGrpc.IMathClient client)
         {
             var numbers = new List<Num>
             {

--- a/src/csharp/Grpc.Examples/MathGrpc.cs
+++ b/src/csharp/Grpc.Examples/MathGrpc.cs
@@ -67,12 +67,38 @@ namespace Math {
     }
 
     // server-side interface
+    [System.Obsolete("Service implementations should inherit from the generated abstract base class instead.")]
     public interface IMath
     {
       Task<global::Math.DivReply> Div(global::Math.DivArgs request, ServerCallContext context);
       Task DivMany(IAsyncStreamReader<global::Math.DivArgs> requestStream, IServerStreamWriter<global::Math.DivReply> responseStream, ServerCallContext context);
       Task Fib(global::Math.FibArgs request, IServerStreamWriter<global::Math.Num> responseStream, ServerCallContext context);
       Task<global::Math.Num> Sum(IAsyncStreamReader<global::Math.Num> requestStream, ServerCallContext context);
+    }
+
+    // server-side abstract class
+    public abstract class MathBase
+    {
+      public virtual Task<global::Math.DivReply> Div(global::Math.DivArgs request, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual Task DivMany(IAsyncStreamReader<global::Math.DivArgs> requestStream, IServerStreamWriter<global::Math.DivReply> responseStream, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual Task Fib(global::Math.FibArgs request, IServerStreamWriter<global::Math.Num> responseStream, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual Task<global::Math.Num> Sum(IAsyncStreamReader<global::Math.Num> requestStream, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
     }
 
     // client stub
@@ -135,6 +161,16 @@ namespace Math {
 
     // creates service definition that can be registered with a server
     public static ServerServiceDefinition BindService(IMath serviceImpl)
+    {
+      return ServerServiceDefinition.CreateBuilder(__ServiceName)
+          .AddMethod(__Method_Div, serviceImpl.Div)
+          .AddMethod(__Method_DivMany, serviceImpl.DivMany)
+          .AddMethod(__Method_Fib, serviceImpl.Fib)
+          .AddMethod(__Method_Sum, serviceImpl.Sum).Build();
+    }
+
+    // creates service definition that can be registered with a server
+    public static ServerServiceDefinition BindService(MathBase serviceImpl)
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_Div, serviceImpl.Div)

--- a/src/csharp/Grpc.Examples/MathGrpc.cs
+++ b/src/csharp/Grpc.Examples/MathGrpc.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Grpc.Core;
 
 namespace Math {
-  public static class Math
+  public static class MathGrpc
   {
     static readonly string __ServiceName = "math.Math";
 
@@ -67,7 +67,7 @@ namespace Math {
     }
 
     // server-side interface
-    [System.Obsolete("Service implementations should inherit from the generated abstract base class instead.")]
+    [System.Obsolete("Service implementations should inherit from the generated abstract base class Math instead.")]
     public interface IMath
     {
       Task<global::Math.DivReply> Div(global::Math.DivArgs request, ServerCallContext context);
@@ -77,7 +77,7 @@ namespace Math {
     }
 
     // server-side abstract class
-    public abstract class MathBase
+    public abstract class Math
     {
       public virtual Task<global::Math.DivReply> Div(global::Math.DivArgs request, ServerCallContext context)
       {
@@ -170,7 +170,7 @@ namespace Math {
     }
 
     // creates service definition that can be registered with a server
-    public static ServerServiceDefinition BindService(MathBase serviceImpl)
+    public static ServerServiceDefinition BindService(Math serviceImpl)
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_Div, serviceImpl.Div)

--- a/src/csharp/Grpc.Examples/MathServiceImpl.cs
+++ b/src/csharp/Grpc.Examples/MathServiceImpl.cs
@@ -43,14 +43,14 @@ namespace Math
     /// <summary>
     /// Implementation of MathService server
     /// </summary>
-    public class MathServiceImpl : Math.IMath
+    public class MathServiceImpl : Math.MathBase
     {
-        public Task<DivReply> Div(DivArgs request, ServerCallContext context)
+        public override Task<DivReply> Div(DivArgs request, ServerCallContext context)
         {
             return Task.FromResult(DivInternal(request));
         }
 
-        public async Task Fib(FibArgs request, IServerStreamWriter<Num> responseStream, ServerCallContext context)
+        public override async Task Fib(FibArgs request, IServerStreamWriter<Num> responseStream, ServerCallContext context)
         {
             if (request.Limit <= 0)
             {
@@ -72,7 +72,7 @@ namespace Math
             }
         }
 
-        public async Task<Num> Sum(IAsyncStreamReader<Num> requestStream, ServerCallContext context)
+        public override async Task<Num> Sum(IAsyncStreamReader<Num> requestStream, ServerCallContext context)
         {
             long sum = 0;
             await requestStream.ForEachAsync(async num =>
@@ -82,7 +82,7 @@ namespace Math
             return new Num { Num_ = sum };
         }
 
-        public async Task DivMany(IAsyncStreamReader<DivArgs> requestStream, IServerStreamWriter<DivReply> responseStream, ServerCallContext context)
+        public override async Task DivMany(IAsyncStreamReader<DivArgs> requestStream, IServerStreamWriter<DivReply> responseStream, ServerCallContext context)
         {
             await requestStream.ForEachAsync(async divArgs => await responseStream.WriteAsync(DivInternal(divArgs)));
         }

--- a/src/csharp/Grpc.Examples/MathServiceImpl.cs
+++ b/src/csharp/Grpc.Examples/MathServiceImpl.cs
@@ -43,7 +43,7 @@ namespace Math
     /// <summary>
     /// Implementation of MathService server
     /// </summary>
-    public class MathServiceImpl : Math.MathBase
+    public class MathServiceImpl : MathGrpc.Math
     {
         public override Task<DivReply> Div(DivArgs request, ServerCallContext context)
         {

--- a/src/csharp/Grpc.HealthCheck.Tests/HealthClientServerTest.cs
+++ b/src/csharp/Grpc.HealthCheck.Tests/HealthClientServerTest.cs
@@ -49,7 +49,7 @@ namespace Grpc.HealthCheck.Tests
         const string Host = "localhost";
         Server server;
         Channel channel;
-        Grpc.Health.V1.Health.IHealthClient client;
+        Grpc.Health.V1.HealthGrpc.IHealthClient client;
         Grpc.HealthCheck.HealthServiceImpl serviceImpl;
 
         [TestFixtureSetUp]
@@ -59,13 +59,13 @@ namespace Grpc.HealthCheck.Tests
 
             server = new Server
             {
-                Services = { Grpc.Health.V1.Health.BindService(serviceImpl) },
+                Services = { Grpc.Health.V1.HealthGrpc.BindService(serviceImpl) },
                 Ports = { { Host, ServerPort.PickUnused, ServerCredentials.Insecure } }
             };
             server.Start();
             channel = new Channel(Host, server.Ports.Single().BoundPort, ChannelCredentials.Insecure);
 
-            client = Grpc.Health.V1.Health.NewClient(channel);
+            client = Grpc.Health.V1.HealthGrpc.NewClient(channel);
         }
 
         [TestFixtureTearDown]

--- a/src/csharp/Grpc.HealthCheck/HealthGrpc.cs
+++ b/src/csharp/Grpc.HealthCheck/HealthGrpc.cs
@@ -38,9 +38,20 @@ namespace Grpc.Health.V1 {
     }
 
     // server-side interface
+    [System.Obsolete("Service implementations should inherit from the generated abstract base class instead.")]
     public interface IHealth
     {
       Task<global::Grpc.Health.V1.HealthCheckResponse> Check(global::Grpc.Health.V1.HealthCheckRequest request, ServerCallContext context);
+    }
+
+    // server-side abstract class
+    public abstract class HealthBase
+    {
+      public virtual Task<global::Grpc.Health.V1.HealthCheckResponse> Check(global::Grpc.Health.V1.HealthCheckRequest request, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
     }
 
     // client stub
@@ -73,6 +84,13 @@ namespace Grpc.Health.V1 {
 
     // creates service definition that can be registered with a server
     public static ServerServiceDefinition BindService(IHealth serviceImpl)
+    {
+      return ServerServiceDefinition.CreateBuilder(__ServiceName)
+          .AddMethod(__Method_Check, serviceImpl.Check).Build();
+    }
+
+    // creates service definition that can be registered with a server
+    public static ServerServiceDefinition BindService(HealthBase serviceImpl)
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_Check, serviceImpl.Check).Build();

--- a/src/csharp/Grpc.HealthCheck/HealthGrpc.cs
+++ b/src/csharp/Grpc.HealthCheck/HealthGrpc.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Grpc.Core;
 
 namespace Grpc.Health.V1 {
-  public static class Health
+  public static class HealthGrpc
   {
     static readonly string __ServiceName = "grpc.health.v1.Health";
 
@@ -38,14 +38,14 @@ namespace Grpc.Health.V1 {
     }
 
     // server-side interface
-    [System.Obsolete("Service implementations should inherit from the generated abstract base class instead.")]
+    [System.Obsolete("Service implementations should inherit from the generated abstract base class Health instead.")]
     public interface IHealth
     {
       Task<global::Grpc.Health.V1.HealthCheckResponse> Check(global::Grpc.Health.V1.HealthCheckRequest request, ServerCallContext context);
     }
 
     // server-side abstract class
-    public abstract class HealthBase
+    public abstract class Health
     {
       public virtual Task<global::Grpc.Health.V1.HealthCheckResponse> Check(global::Grpc.Health.V1.HealthCheckRequest request, ServerCallContext context)
       {
@@ -90,7 +90,7 @@ namespace Grpc.Health.V1 {
     }
 
     // creates service definition that can be registered with a server
-    public static ServerServiceDefinition BindService(HealthBase serviceImpl)
+    public static ServerServiceDefinition BindService(Health serviceImpl)
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_Check, serviceImpl.Check).Build();

--- a/src/csharp/Grpc.HealthCheck/HealthServiceImpl.cs
+++ b/src/csharp/Grpc.HealthCheck/HealthServiceImpl.cs
@@ -51,7 +51,7 @@ namespace Grpc.HealthCheck
     /// server.AddServiceDefinition(Grpc.Health.V1.Health.BindService(serviceImpl));
     /// </code>
     /// </summary>
-    public class HealthServiceImpl : Grpc.Health.V1.Health.IHealth
+    public class HealthServiceImpl : Grpc.Health.V1.Health.HealthBase
     {
         private readonly object myLock = new object();
         private readonly Dictionary<string, HealthCheckResponse.Types.ServingStatus> statusMap = 
@@ -99,7 +99,7 @@ namespace Grpc.HealthCheck
         /// <param name="request">The check request.</param>
         /// <param name="context">The call context.</param>
         /// <returns>The asynchronous response.</returns>
-        public Task<HealthCheckResponse> Check(HealthCheckRequest request, ServerCallContext context)
+        public override Task<HealthCheckResponse> Check(HealthCheckRequest request, ServerCallContext context)
         {
             lock (myLock)
             {

--- a/src/csharp/Grpc.HealthCheck/HealthServiceImpl.cs
+++ b/src/csharp/Grpc.HealthCheck/HealthServiceImpl.cs
@@ -51,7 +51,7 @@ namespace Grpc.HealthCheck
     /// server.AddServiceDefinition(Grpc.Health.V1.Health.BindService(serviceImpl));
     /// </code>
     /// </summary>
-    public class HealthServiceImpl : Grpc.Health.V1.Health.HealthBase
+    public class HealthServiceImpl : Grpc.Health.V1.HealthGrpc.Health
     {
         private readonly object myLock = new object();
         private readonly Dictionary<string, HealthCheckResponse.Types.ServingStatus> statusMap = 

--- a/src/csharp/Grpc.IntegrationTesting/BenchmarkServiceImpl.cs
+++ b/src/csharp/Grpc.IntegrationTesting/BenchmarkServiceImpl.cs
@@ -44,7 +44,7 @@ namespace Grpc.Testing
     /// <summary>
     /// Implementation of BenchmarkService server
     /// </summary>
-    public class BenchmarkServiceImpl : BenchmarkService.IBenchmarkService
+    public class BenchmarkServiceImpl : BenchmarkService.BenchmarkServiceBase
     {
         private readonly int responseSize;
 
@@ -53,13 +53,13 @@ namespace Grpc.Testing
             this.responseSize = responseSize;
         }
 
-        public Task<SimpleResponse> UnaryCall(SimpleRequest request, ServerCallContext context)
+        public override Task<SimpleResponse> UnaryCall(SimpleRequest request, ServerCallContext context)
         {
             var response = new SimpleResponse { Payload = CreateZerosPayload(responseSize) };
             return Task.FromResult(response);
         }
 
-        public async Task StreamingCall(IAsyncStreamReader<SimpleRequest> requestStream, IServerStreamWriter<SimpleResponse> responseStream, ServerCallContext context)
+        public override async Task StreamingCall(IAsyncStreamReader<SimpleRequest> requestStream, IServerStreamWriter<SimpleResponse> responseStream, ServerCallContext context)
         {
             await requestStream.ForEachAsync(async request =>
             {

--- a/src/csharp/Grpc.IntegrationTesting/BenchmarkServiceImpl.cs
+++ b/src/csharp/Grpc.IntegrationTesting/BenchmarkServiceImpl.cs
@@ -44,7 +44,7 @@ namespace Grpc.Testing
     /// <summary>
     /// Implementation of BenchmarkService server
     /// </summary>
-    public class BenchmarkServiceImpl : BenchmarkService.BenchmarkServiceBase
+    public class BenchmarkServiceImpl : BenchmarkServiceGrpc.BenchmarkService
     {
         private readonly int responseSize;
 

--- a/src/csharp/Grpc.IntegrationTesting/ClientRunners.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ClientRunners.cs
@@ -88,7 +88,7 @@ namespace Grpc.IntegrationTesting
         readonly int payloadSize;
         readonly Histogram histogram;
 
-        readonly BenchmarkService.IBenchmarkServiceClient client;
+        readonly BenchmarkServiceGrpc.IBenchmarkServiceClient client;
         readonly Task runnerTask;
         readonly CancellationTokenSource stoppedCts;
         readonly WallClockStopwatch wallClockStopwatch = new WallClockStopwatch();
@@ -100,7 +100,7 @@ namespace Grpc.IntegrationTesting
             this.histogram = new Histogram(histogramParams.Resolution, histogramParams.MaxPossible);
 
             this.stoppedCts = new CancellationTokenSource();
-            this.client = BenchmarkService.NewClient(channel);
+            this.client = BenchmarkServiceGrpc.NewClient(channel);
             this.runnerTask = Task.Factory.StartNew(Run, TaskCreationOptions.LongRunning);
         }
 

--- a/src/csharp/Grpc.IntegrationTesting/HeaderInterceptorTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/HeaderInterceptorTest.cs
@@ -48,20 +48,20 @@ namespace Grpc.IntegrationTesting
         const string Host = "localhost";
         Server server;
         Channel channel;
-        TestService.TestServiceClient client;
+        TestServiceGrpc.TestServiceClient client;
 
         [TestFixtureSetUp]
         public void Init()
         {
             server = new Server
             {
-                Services = { TestService.BindService(new TestServiceImpl()) },
+                Services = { TestServiceGrpc.BindService(new TestServiceImpl()) },
                 Ports = { { Host, ServerPort.PickUnused, ServerCredentials.Insecure } }
             };
             server.Start();
 
             channel = new Channel(Host, server.Ports.Single().BoundPort, ChannelCredentials.Insecure);
-            client = TestService.NewClient(channel);
+            client = TestServiceGrpc.NewClient(channel);
         }
 
         [TestFixtureTearDown]

--- a/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
@@ -161,7 +161,7 @@ namespace Grpc.IntegrationTesting
 
         private async Task RunTestCaseAsync(Channel channel, ClientOptions options)
         {
-            var client = new TestService.TestServiceClient(channel);
+            var client = new TestServiceGrpc.TestServiceClient(channel);
             switch (options.TestCase)
             {
                 case "empty_unary":
@@ -210,14 +210,14 @@ namespace Grpc.IntegrationTesting
                     await RunStatusCodeAndMessageAsync(client);
                     break;
                 case "unimplemented_method":
-                    RunUnimplementedMethod(new UnimplementedService.UnimplementedServiceClient(channel));
+                    RunUnimplementedMethod(new UnimplementedServiceGrpc.UnimplementedServiceClient(channel));
                     break;
                 default:
                     throw new ArgumentException("Unknown test case " + options.TestCase);
             }
         }
 
-        public static void RunEmptyUnary(TestService.ITestServiceClient client)
+        public static void RunEmptyUnary(TestServiceGrpc.ITestServiceClient client)
         {
             Console.WriteLine("running empty_unary");
             var response = client.EmptyCall(new Empty());
@@ -225,7 +225,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static void RunLargeUnary(TestService.ITestServiceClient client)
+        public static void RunLargeUnary(TestServiceGrpc.ITestServiceClient client)
         {
             Console.WriteLine("running large_unary");
             var request = new SimpleRequest
@@ -241,7 +241,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static async Task RunClientStreamingAsync(TestService.ITestServiceClient client)
+        public static async Task RunClientStreamingAsync(TestServiceGrpc.ITestServiceClient client)
         {
             Console.WriteLine("running client_streaming");
 
@@ -257,7 +257,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static async Task RunServerStreamingAsync(TestService.ITestServiceClient client)
+        public static async Task RunServerStreamingAsync(TestServiceGrpc.ITestServiceClient client)
         {
             Console.WriteLine("running server_streaming");
 
@@ -281,7 +281,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static async Task RunPingPongAsync(TestService.ITestServiceClient client)
+        public static async Task RunPingPongAsync(TestServiceGrpc.ITestServiceClient client)
         {
             Console.WriteLine("running ping_pong");
 
@@ -338,7 +338,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static async Task RunEmptyStreamAsync(TestService.ITestServiceClient client)
+        public static async Task RunEmptyStreamAsync(TestServiceGrpc.ITestServiceClient client)
         {
             Console.WriteLine("running empty_stream");
             using (var call = client.FullDuplexCall())
@@ -351,7 +351,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static void RunComputeEngineCreds(TestService.TestServiceClient client, string defaultServiceAccount, string oauthScope)
+        public static void RunComputeEngineCreds(TestServiceGrpc.TestServiceClient client, string defaultServiceAccount, string oauthScope)
         {
             Console.WriteLine("running compute_engine_creds");
 
@@ -375,7 +375,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static void RunJwtTokenCreds(TestService.TestServiceClient client)
+        public static void RunJwtTokenCreds(TestServiceGrpc.TestServiceClient client)
         {
             Console.WriteLine("running jwt_token_creds");
            
@@ -396,7 +396,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static async Task RunOAuth2AuthTokenAsync(TestService.TestServiceClient client, string oauthScope)
+        public static async Task RunOAuth2AuthTokenAsync(TestServiceGrpc.TestServiceClient client, string oauthScope)
         {
             Console.WriteLine("running oauth2_auth_token");
             ITokenAccess credential = (await GoogleCredential.GetApplicationDefaultAsync()).CreateScoped(new[] { oauthScope });
@@ -417,7 +417,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static async Task RunPerRpcCredsAsync(TestService.TestServiceClient client, string oauthScope)
+        public static async Task RunPerRpcCredsAsync(TestServiceGrpc.TestServiceClient client, string oauthScope)
         {
             Console.WriteLine("running per_rpc_creds");
             ITokenAccess googleCredential = await GoogleCredential.GetApplicationDefaultAsync();
@@ -434,7 +434,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static async Task RunCancelAfterBeginAsync(TestService.ITestServiceClient client)
+        public static async Task RunCancelAfterBeginAsync(TestServiceGrpc.ITestServiceClient client)
         {
             Console.WriteLine("running cancel_after_begin");
 
@@ -451,7 +451,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static async Task RunCancelAfterFirstResponseAsync(TestService.ITestServiceClient client)
+        public static async Task RunCancelAfterFirstResponseAsync(TestServiceGrpc.ITestServiceClient client)
         {
             Console.WriteLine("running cancel_after_first_response");
 
@@ -477,7 +477,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static async Task RunTimeoutOnSleepingServerAsync(TestService.ITestServiceClient client)
+        public static async Task RunTimeoutOnSleepingServerAsync(TestServiceGrpc.ITestServiceClient client)
         {
             Console.WriteLine("running timeout_on_sleeping_server");
 
@@ -499,7 +499,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static async Task RunCustomMetadataAsync(TestService.ITestServiceClient client)
+        public static async Task RunCustomMetadataAsync(TestServiceGrpc.ITestServiceClient client)
         {
             Console.WriteLine("running custom_metadata");
             {
@@ -546,7 +546,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static async Task RunStatusCodeAndMessageAsync(TestService.ITestServiceClient client)
+        public static async Task RunStatusCodeAndMessageAsync(TestServiceGrpc.ITestServiceClient client)
         {
             Console.WriteLine("running status_code_and_message");
             var echoStatus = new EchoStatus
@@ -580,7 +580,7 @@ namespace Grpc.IntegrationTesting
             Console.WriteLine("Passed!");
         }
 
-        public static void RunUnimplementedMethod(UnimplementedService.IUnimplementedServiceClient client)
+        public static void RunUnimplementedMethod(UnimplementedServiceGrpc.IUnimplementedServiceClient client)
         {
             Console.WriteLine("running unimplemented_method");
             var e = Assert.Throws<RpcException>(() => client.UnimplementedCall(new Empty()));

--- a/src/csharp/Grpc.IntegrationTesting/InteropClientServerTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClientServerTest.cs
@@ -51,14 +51,14 @@ namespace Grpc.IntegrationTesting
         const string Host = "localhost";
         Server server;
         Channel channel;
-        TestService.ITestServiceClient client;
+        TestServiceGrpc.ITestServiceClient client;
 
         [TestFixtureSetUp]
         public void Init()
         {
             server = new Server
             {
-                Services = { TestService.BindService(new TestServiceImpl()) },
+                Services = { TestServiceGrpc.BindService(new TestServiceImpl()) },
                 Ports = { { Host, ServerPort.PickUnused, TestCredentials.CreateSslServerCredentials() } }
             };
             server.Start();
@@ -69,7 +69,7 @@ namespace Grpc.IntegrationTesting
             };
             int port = server.Ports.Single().BoundPort;
             channel = new Channel(Host, port, TestCredentials.CreateSslCredentials(), options);
-            client = TestService.NewClient(channel);
+            client = TestServiceGrpc.NewClient(channel);
         }
 
         [TestFixtureTearDown]
@@ -148,7 +148,7 @@ namespace Grpc.IntegrationTesting
         [Test]
         public void UnimplementedMethod()
         {
-            InteropClient.RunUnimplementedMethod(UnimplementedService.NewClient(channel));
+            InteropClient.RunUnimplementedMethod(UnimplementedServiceGrpc.NewClient(channel));
         }
     }
 }

--- a/src/csharp/Grpc.IntegrationTesting/InteropServer.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropServer.cs
@@ -95,7 +95,7 @@ namespace Grpc.IntegrationTesting
         {
             var server = new Server
             {
-                Services = { TestService.BindService(new TestServiceImpl()) }
+                Services = { TestServiceGrpc.BindService(new TestServiceImpl()) }
             };
 
             string host = "0.0.0.0";

--- a/src/csharp/Grpc.IntegrationTesting/MetadataCredentialsTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/MetadataCredentialsTest.cs
@@ -50,21 +50,21 @@ namespace Grpc.IntegrationTesting
         const string Host = "localhost";
         Server server;
         Channel channel;
-        TestService.ITestServiceClient client;
+        TestServiceGrpc.ITestServiceClient client;
         List<ChannelOption> options;
-        Mock<TestService.ITestService> serviceMock;
+        Mock<TestServiceGrpc.ITestService> serviceMock;
         AsyncAuthInterceptor asyncAuthInterceptor;
 
         [SetUp]
         public void Init()
         {
-            serviceMock = new Mock<TestService.ITestService>();
+            serviceMock = new Mock<TestServiceGrpc.ITestService>();
             serviceMock.Setup(m => m.UnaryCall(It.IsAny<SimpleRequest>(), It.IsAny<ServerCallContext>()))
                 .Returns(new Func<SimpleRequest, ServerCallContext, Task<SimpleResponse>>(UnaryCallHandler));
 
             server = new Server
             {
-                Services = { TestService.BindService(serviceMock.Object) },
+                Services = { TestServiceGrpc.BindService(serviceMock.Object) },
                 Ports = { { Host, ServerPort.PickUnused, TestCredentials.CreateSslServerCredentials() } }
             };
             server.Start();
@@ -94,7 +94,7 @@ namespace Grpc.IntegrationTesting
             var channelCredentials = ChannelCredentials.Create(TestCredentials.CreateSslCredentials(),
                 CallCredentials.FromInterceptor(asyncAuthInterceptor));
             channel = new Channel(Host, server.Ports.Single().BoundPort, channelCredentials, options);
-            client = TestService.NewClient(channel);
+            client = TestServiceGrpc.NewClient(channel);
 
             client.UnaryCall(new SimpleRequest {});
         }
@@ -103,7 +103,7 @@ namespace Grpc.IntegrationTesting
         public void MetadataCredentials_PerCall()
         {
             channel = new Channel(Host, server.Ports.Single().BoundPort, TestCredentials.CreateSslCredentials(), options);
-            client = TestService.NewClient(channel);
+            client = TestServiceGrpc.NewClient(channel);
 
             var callCredentials = CallCredentials.FromInterceptor(asyncAuthInterceptor);
             client.UnaryCall(new SimpleRequest { }, new CallOptions(credentials: callCredentials));

--- a/src/csharp/Grpc.IntegrationTesting/QpsWorker.cs
+++ b/src/csharp/Grpc.IntegrationTesting/QpsWorker.cs
@@ -98,7 +98,7 @@ namespace Grpc.IntegrationTesting
                 
             var server = new Server
             {
-                Services = { WorkerService.BindService(workerServiceImpl) },
+                Services = { WorkerServiceGrpc.BindService(workerServiceImpl) },
                 Ports = { new ServerPort(host, options.DriverPort, ServerCredentials.Insecure )}
             };
             int boundPort = server.Ports.Single().BoundPort;

--- a/src/csharp/Grpc.IntegrationTesting/ServerRunners.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ServerRunners.cs
@@ -64,7 +64,7 @@ namespace Grpc.IntegrationTesting
             int responseSize = config.PayloadConfig != null ? config.PayloadConfig.SimpleParams.RespSize : 0;
             var server = new Server
             {
-                Services = { BenchmarkService.BindService(new BenchmarkServiceImpl(responseSize)) },
+                Services = { BenchmarkServiceGrpc.BindService(new BenchmarkServiceImpl(responseSize)) },
                 Ports = { new ServerPort("[::]", config.Port, credentials) }
             };
 

--- a/src/csharp/Grpc.IntegrationTesting/ServicesGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ServicesGrpc.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Grpc.Core;
 
 namespace Grpc.Testing {
-  public static class BenchmarkService
+  public static class BenchmarkServiceGrpc
   {
     static readonly string __ServiceName = "grpc.testing.BenchmarkService";
 
@@ -47,7 +47,7 @@ namespace Grpc.Testing {
     }
 
     // server-side interface
-    [System.Obsolete("Service implementations should inherit from the generated abstract base class instead.")]
+    [System.Obsolete("Service implementations should inherit from the generated abstract base class BenchmarkService instead.")]
     public interface IBenchmarkService
     {
       Task<global::Grpc.Testing.SimpleResponse> UnaryCall(global::Grpc.Testing.SimpleRequest request, ServerCallContext context);
@@ -55,7 +55,7 @@ namespace Grpc.Testing {
     }
 
     // server-side abstract class
-    public abstract class BenchmarkServiceBase
+    public abstract class BenchmarkService
     {
       public virtual Task<global::Grpc.Testing.SimpleResponse> UnaryCall(global::Grpc.Testing.SimpleRequest request, ServerCallContext context)
       {
@@ -116,7 +116,7 @@ namespace Grpc.Testing {
     }
 
     // creates service definition that can be registered with a server
-    public static ServerServiceDefinition BindService(BenchmarkServiceBase serviceImpl)
+    public static ServerServiceDefinition BindService(BenchmarkService serviceImpl)
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_UnaryCall, serviceImpl.UnaryCall)
@@ -130,7 +130,7 @@ namespace Grpc.Testing {
     }
 
   }
-  public static class WorkerService
+  public static class WorkerServiceGrpc
   {
     static readonly string __ServiceName = "grpc.testing.WorkerService";
 
@@ -194,7 +194,7 @@ namespace Grpc.Testing {
     }
 
     // server-side interface
-    [System.Obsolete("Service implementations should inherit from the generated abstract base class instead.")]
+    [System.Obsolete("Service implementations should inherit from the generated abstract base class WorkerService instead.")]
     public interface IWorkerService
     {
       Task RunServer(IAsyncStreamReader<global::Grpc.Testing.ServerArgs> requestStream, IServerStreamWriter<global::Grpc.Testing.ServerStatus> responseStream, ServerCallContext context);
@@ -204,7 +204,7 @@ namespace Grpc.Testing {
     }
 
     // server-side abstract class
-    public abstract class WorkerServiceBase
+    public abstract class WorkerService
     {
       public virtual Task RunServer(IAsyncStreamReader<global::Grpc.Testing.ServerArgs> requestStream, IServerStreamWriter<global::Grpc.Testing.ServerStatus> responseStream, ServerCallContext context)
       {
@@ -307,7 +307,7 @@ namespace Grpc.Testing {
     }
 
     // creates service definition that can be registered with a server
-    public static ServerServiceDefinition BindService(WorkerServiceBase serviceImpl)
+    public static ServerServiceDefinition BindService(WorkerService serviceImpl)
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_RunServer, serviceImpl.RunServer)

--- a/src/csharp/Grpc.IntegrationTesting/ServicesGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ServicesGrpc.cs
@@ -47,10 +47,26 @@ namespace Grpc.Testing {
     }
 
     // server-side interface
+    [System.Obsolete("Service implementations should inherit from the generated abstract base class instead.")]
     public interface IBenchmarkService
     {
       Task<global::Grpc.Testing.SimpleResponse> UnaryCall(global::Grpc.Testing.SimpleRequest request, ServerCallContext context);
       Task StreamingCall(IAsyncStreamReader<global::Grpc.Testing.SimpleRequest> requestStream, IServerStreamWriter<global::Grpc.Testing.SimpleResponse> responseStream, ServerCallContext context);
+    }
+
+    // server-side abstract class
+    public abstract class BenchmarkServiceBase
+    {
+      public virtual Task<global::Grpc.Testing.SimpleResponse> UnaryCall(global::Grpc.Testing.SimpleRequest request, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual Task StreamingCall(IAsyncStreamReader<global::Grpc.Testing.SimpleRequest> requestStream, IServerStreamWriter<global::Grpc.Testing.SimpleResponse> responseStream, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
     }
 
     // client stub
@@ -93,6 +109,14 @@ namespace Grpc.Testing {
 
     // creates service definition that can be registered with a server
     public static ServerServiceDefinition BindService(IBenchmarkService serviceImpl)
+    {
+      return ServerServiceDefinition.CreateBuilder(__ServiceName)
+          .AddMethod(__Method_UnaryCall, serviceImpl.UnaryCall)
+          .AddMethod(__Method_StreamingCall, serviceImpl.StreamingCall).Build();
+    }
+
+    // creates service definition that can be registered with a server
+    public static ServerServiceDefinition BindService(BenchmarkServiceBase serviceImpl)
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_UnaryCall, serviceImpl.UnaryCall)
@@ -170,12 +194,38 @@ namespace Grpc.Testing {
     }
 
     // server-side interface
+    [System.Obsolete("Service implementations should inherit from the generated abstract base class instead.")]
     public interface IWorkerService
     {
       Task RunServer(IAsyncStreamReader<global::Grpc.Testing.ServerArgs> requestStream, IServerStreamWriter<global::Grpc.Testing.ServerStatus> responseStream, ServerCallContext context);
       Task RunClient(IAsyncStreamReader<global::Grpc.Testing.ClientArgs> requestStream, IServerStreamWriter<global::Grpc.Testing.ClientStatus> responseStream, ServerCallContext context);
       Task<global::Grpc.Testing.CoreResponse> CoreCount(global::Grpc.Testing.CoreRequest request, ServerCallContext context);
       Task<global::Grpc.Testing.Void> QuitWorker(global::Grpc.Testing.Void request, ServerCallContext context);
+    }
+
+    // server-side abstract class
+    public abstract class WorkerServiceBase
+    {
+      public virtual Task RunServer(IAsyncStreamReader<global::Grpc.Testing.ServerArgs> requestStream, IServerStreamWriter<global::Grpc.Testing.ServerStatus> responseStream, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual Task RunClient(IAsyncStreamReader<global::Grpc.Testing.ClientArgs> requestStream, IServerStreamWriter<global::Grpc.Testing.ClientStatus> responseStream, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual Task<global::Grpc.Testing.CoreResponse> CoreCount(global::Grpc.Testing.CoreRequest request, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual Task<global::Grpc.Testing.Void> QuitWorker(global::Grpc.Testing.Void request, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
     }
 
     // client stub
@@ -248,6 +298,16 @@ namespace Grpc.Testing {
 
     // creates service definition that can be registered with a server
     public static ServerServiceDefinition BindService(IWorkerService serviceImpl)
+    {
+      return ServerServiceDefinition.CreateBuilder(__ServiceName)
+          .AddMethod(__Method_RunServer, serviceImpl.RunServer)
+          .AddMethod(__Method_RunClient, serviceImpl.RunClient)
+          .AddMethod(__Method_CoreCount, serviceImpl.CoreCount)
+          .AddMethod(__Method_QuitWorker, serviceImpl.QuitWorker).Build();
+    }
+
+    // creates service definition that can be registered with a server
+    public static ServerServiceDefinition BindService(WorkerServiceBase serviceImpl)
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_RunServer, serviceImpl.RunServer)

--- a/src/csharp/Grpc.IntegrationTesting/SslCredentialsTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/SslCredentialsTest.cs
@@ -53,7 +53,7 @@ namespace Grpc.IntegrationTesting
         const string Host = "localhost";
         Server server;
         Channel channel;
-        TestService.ITestServiceClient client;
+        TestServiceGrpc.ITestServiceClient client;
 
         [TestFixtureSetUp]
         public void Init()
@@ -68,7 +68,7 @@ namespace Grpc.IntegrationTesting
 
             server = new Server
             {
-                Services = { TestService.BindService(new TestServiceImpl()) },
+                Services = { TestServiceGrpc.BindService(new TestServiceImpl()) },
                 Ports = { { Host, ServerPort.PickUnused, serverCredentials } }
             };
             server.Start();
@@ -79,7 +79,7 @@ namespace Grpc.IntegrationTesting
             };
 
             channel = new Channel(Host, server.Ports.Single().BoundPort, clientCredentials, options);
-            client = TestService.NewClient(channel);
+            client = TestServiceGrpc.NewClient(channel);
         }
 
         [TestFixtureTearDown]

--- a/src/csharp/Grpc.IntegrationTesting/TestGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/TestGrpc.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Grpc.Core;
 
 namespace Grpc.Testing {
-  public static class TestService
+  public static class TestServiceGrpc
   {
     static readonly string __ServiceName = "grpc.testing.TestService";
 
@@ -90,7 +90,7 @@ namespace Grpc.Testing {
     }
 
     // server-side interface
-    [System.Obsolete("Service implementations should inherit from the generated abstract base class instead.")]
+    [System.Obsolete("Service implementations should inherit from the generated abstract base class TestService instead.")]
     public interface ITestService
     {
       Task<global::Grpc.Testing.Empty> EmptyCall(global::Grpc.Testing.Empty request, ServerCallContext context);
@@ -102,7 +102,7 @@ namespace Grpc.Testing {
     }
 
     // server-side abstract class
-    public abstract class TestServiceBase
+    public abstract class TestService
     {
       public virtual Task<global::Grpc.Testing.Empty> EmptyCall(global::Grpc.Testing.Empty request, ServerCallContext context)
       {
@@ -237,7 +237,7 @@ namespace Grpc.Testing {
     }
 
     // creates service definition that can be registered with a server
-    public static ServerServiceDefinition BindService(TestServiceBase serviceImpl)
+    public static ServerServiceDefinition BindService(TestService serviceImpl)
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_EmptyCall, serviceImpl.EmptyCall)
@@ -255,7 +255,7 @@ namespace Grpc.Testing {
     }
 
   }
-  public static class UnimplementedService
+  public static class UnimplementedServiceGrpc
   {
     static readonly string __ServiceName = "grpc.testing.UnimplementedService";
 
@@ -284,14 +284,14 @@ namespace Grpc.Testing {
     }
 
     // server-side interface
-    [System.Obsolete("Service implementations should inherit from the generated abstract base class instead.")]
+    [System.Obsolete("Service implementations should inherit from the generated abstract base class UnimplementedService instead.")]
     public interface IUnimplementedService
     {
       Task<global::Grpc.Testing.Empty> UnimplementedCall(global::Grpc.Testing.Empty request, ServerCallContext context);
     }
 
     // server-side abstract class
-    public abstract class UnimplementedServiceBase
+    public abstract class UnimplementedService
     {
       public virtual Task<global::Grpc.Testing.Empty> UnimplementedCall(global::Grpc.Testing.Empty request, ServerCallContext context)
       {
@@ -336,7 +336,7 @@ namespace Grpc.Testing {
     }
 
     // creates service definition that can be registered with a server
-    public static ServerServiceDefinition BindService(UnimplementedServiceBase serviceImpl)
+    public static ServerServiceDefinition BindService(UnimplementedService serviceImpl)
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_UnimplementedCall, serviceImpl.UnimplementedCall).Build();
@@ -349,7 +349,7 @@ namespace Grpc.Testing {
     }
 
   }
-  public static class ReconnectService
+  public static class ReconnectServiceGrpc
   {
     static readonly string __ServiceName = "grpc.testing.ReconnectService";
 
@@ -390,7 +390,7 @@ namespace Grpc.Testing {
     }
 
     // server-side interface
-    [System.Obsolete("Service implementations should inherit from the generated abstract base class instead.")]
+    [System.Obsolete("Service implementations should inherit from the generated abstract base class ReconnectService instead.")]
     public interface IReconnectService
     {
       Task<global::Grpc.Testing.Empty> Start(global::Grpc.Testing.Empty request, ServerCallContext context);
@@ -398,7 +398,7 @@ namespace Grpc.Testing {
     }
 
     // server-side abstract class
-    public abstract class ReconnectServiceBase
+    public abstract class ReconnectService
     {
       public virtual Task<global::Grpc.Testing.Empty> Start(global::Grpc.Testing.Empty request, ServerCallContext context)
       {
@@ -469,7 +469,7 @@ namespace Grpc.Testing {
     }
 
     // creates service definition that can be registered with a server
-    public static ServerServiceDefinition BindService(ReconnectServiceBase serviceImpl)
+    public static ServerServiceDefinition BindService(ReconnectService serviceImpl)
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_Start, serviceImpl.Start)

--- a/src/csharp/Grpc.IntegrationTesting/TestGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/TestGrpc.cs
@@ -90,6 +90,7 @@ namespace Grpc.Testing {
     }
 
     // server-side interface
+    [System.Obsolete("Service implementations should inherit from the generated abstract base class instead.")]
     public interface ITestService
     {
       Task<global::Grpc.Testing.Empty> EmptyCall(global::Grpc.Testing.Empty request, ServerCallContext context);
@@ -98,6 +99,41 @@ namespace Grpc.Testing {
       Task<global::Grpc.Testing.StreamingInputCallResponse> StreamingInputCall(IAsyncStreamReader<global::Grpc.Testing.StreamingInputCallRequest> requestStream, ServerCallContext context);
       Task FullDuplexCall(IAsyncStreamReader<global::Grpc.Testing.StreamingOutputCallRequest> requestStream, IServerStreamWriter<global::Grpc.Testing.StreamingOutputCallResponse> responseStream, ServerCallContext context);
       Task HalfDuplexCall(IAsyncStreamReader<global::Grpc.Testing.StreamingOutputCallRequest> requestStream, IServerStreamWriter<global::Grpc.Testing.StreamingOutputCallResponse> responseStream, ServerCallContext context);
+    }
+
+    // server-side abstract class
+    public abstract class TestServiceBase
+    {
+      public virtual Task<global::Grpc.Testing.Empty> EmptyCall(global::Grpc.Testing.Empty request, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual Task<global::Grpc.Testing.SimpleResponse> UnaryCall(global::Grpc.Testing.SimpleRequest request, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual Task StreamingOutputCall(global::Grpc.Testing.StreamingOutputCallRequest request, IServerStreamWriter<global::Grpc.Testing.StreamingOutputCallResponse> responseStream, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual Task<global::Grpc.Testing.StreamingInputCallResponse> StreamingInputCall(IAsyncStreamReader<global::Grpc.Testing.StreamingInputCallRequest> requestStream, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual Task FullDuplexCall(IAsyncStreamReader<global::Grpc.Testing.StreamingOutputCallRequest> requestStream, IServerStreamWriter<global::Grpc.Testing.StreamingOutputCallResponse> responseStream, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual Task HalfDuplexCall(IAsyncStreamReader<global::Grpc.Testing.StreamingOutputCallRequest> requestStream, IServerStreamWriter<global::Grpc.Testing.StreamingOutputCallResponse> responseStream, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
     }
 
     // client stub
@@ -200,6 +236,18 @@ namespace Grpc.Testing {
           .AddMethod(__Method_HalfDuplexCall, serviceImpl.HalfDuplexCall).Build();
     }
 
+    // creates service definition that can be registered with a server
+    public static ServerServiceDefinition BindService(TestServiceBase serviceImpl)
+    {
+      return ServerServiceDefinition.CreateBuilder(__ServiceName)
+          .AddMethod(__Method_EmptyCall, serviceImpl.EmptyCall)
+          .AddMethod(__Method_UnaryCall, serviceImpl.UnaryCall)
+          .AddMethod(__Method_StreamingOutputCall, serviceImpl.StreamingOutputCall)
+          .AddMethod(__Method_StreamingInputCall, serviceImpl.StreamingInputCall)
+          .AddMethod(__Method_FullDuplexCall, serviceImpl.FullDuplexCall)
+          .AddMethod(__Method_HalfDuplexCall, serviceImpl.HalfDuplexCall).Build();
+    }
+
     // creates a new client
     public static TestServiceClient NewClient(Channel channel)
     {
@@ -236,9 +284,20 @@ namespace Grpc.Testing {
     }
 
     // server-side interface
+    [System.Obsolete("Service implementations should inherit from the generated abstract base class instead.")]
     public interface IUnimplementedService
     {
       Task<global::Grpc.Testing.Empty> UnimplementedCall(global::Grpc.Testing.Empty request, ServerCallContext context);
+    }
+
+    // server-side abstract class
+    public abstract class UnimplementedServiceBase
+    {
+      public virtual Task<global::Grpc.Testing.Empty> UnimplementedCall(global::Grpc.Testing.Empty request, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
     }
 
     // client stub
@@ -271,6 +330,13 @@ namespace Grpc.Testing {
 
     // creates service definition that can be registered with a server
     public static ServerServiceDefinition BindService(IUnimplementedService serviceImpl)
+    {
+      return ServerServiceDefinition.CreateBuilder(__ServiceName)
+          .AddMethod(__Method_UnimplementedCall, serviceImpl.UnimplementedCall).Build();
+    }
+
+    // creates service definition that can be registered with a server
+    public static ServerServiceDefinition BindService(UnimplementedServiceBase serviceImpl)
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_UnimplementedCall, serviceImpl.UnimplementedCall).Build();
@@ -324,10 +390,26 @@ namespace Grpc.Testing {
     }
 
     // server-side interface
+    [System.Obsolete("Service implementations should inherit from the generated abstract base class instead.")]
     public interface IReconnectService
     {
       Task<global::Grpc.Testing.Empty> Start(global::Grpc.Testing.Empty request, ServerCallContext context);
       Task<global::Grpc.Testing.ReconnectInfo> Stop(global::Grpc.Testing.Empty request, ServerCallContext context);
+    }
+
+    // server-side abstract class
+    public abstract class ReconnectServiceBase
+    {
+      public virtual Task<global::Grpc.Testing.Empty> Start(global::Grpc.Testing.Empty request, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
+      public virtual Task<global::Grpc.Testing.ReconnectInfo> Stop(global::Grpc.Testing.Empty request, ServerCallContext context)
+      {
+        throw new RpcException(new Status(StatusCode.Unimplemented, ""));
+      }
+
     }
 
     // client stub
@@ -380,6 +462,14 @@ namespace Grpc.Testing {
 
     // creates service definition that can be registered with a server
     public static ServerServiceDefinition BindService(IReconnectService serviceImpl)
+    {
+      return ServerServiceDefinition.CreateBuilder(__ServiceName)
+          .AddMethod(__Method_Start, serviceImpl.Start)
+          .AddMethod(__Method_Stop, serviceImpl.Stop).Build();
+    }
+
+    // creates service definition that can be registered with a server
+    public static ServerServiceDefinition BindService(ReconnectServiceBase serviceImpl)
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_Start, serviceImpl.Start)

--- a/src/csharp/Grpc.IntegrationTesting/TestServiceImpl.cs
+++ b/src/csharp/Grpc.IntegrationTesting/TestServiceImpl.cs
@@ -45,7 +45,7 @@ namespace Grpc.Testing
     /// <summary>
     /// Implementation of TestService server
     /// </summary>
-    public class TestServiceImpl : TestService.TestServiceBase
+    public class TestServiceImpl : TestServiceGrpc.TestService
     {
         public override Task<Empty> EmptyCall(Empty request, ServerCallContext context)
         {

--- a/src/csharp/Grpc.IntegrationTesting/TestServiceImpl.cs
+++ b/src/csharp/Grpc.IntegrationTesting/TestServiceImpl.cs
@@ -45,14 +45,14 @@ namespace Grpc.Testing
     /// <summary>
     /// Implementation of TestService server
     /// </summary>
-    public class TestServiceImpl : TestService.ITestService
+    public class TestServiceImpl : TestService.TestServiceBase
     {
-        public Task<Empty> EmptyCall(Empty request, ServerCallContext context)
+        public override Task<Empty> EmptyCall(Empty request, ServerCallContext context)
         {
             return Task.FromResult(new Empty());
         }
 
-        public async Task<SimpleResponse> UnaryCall(SimpleRequest request, ServerCallContext context)
+        public override async Task<SimpleResponse> UnaryCall(SimpleRequest request, ServerCallContext context)
         {
             await EnsureEchoMetadataAsync(context);
             EnsureEchoStatus(request.ResponseStatus, context);
@@ -61,7 +61,7 @@ namespace Grpc.Testing
             return response;
         }
 
-        public async Task StreamingOutputCall(StreamingOutputCallRequest request, IServerStreamWriter<StreamingOutputCallResponse> responseStream, ServerCallContext context)
+        public override async Task StreamingOutputCall(StreamingOutputCallRequest request, IServerStreamWriter<StreamingOutputCallResponse> responseStream, ServerCallContext context)
         {
             await EnsureEchoMetadataAsync(context);
             EnsureEchoStatus(request.ResponseStatus, context);
@@ -73,7 +73,7 @@ namespace Grpc.Testing
             }
         }
 
-        public async Task<StreamingInputCallResponse> StreamingInputCall(IAsyncStreamReader<StreamingInputCallRequest> requestStream, ServerCallContext context)
+        public override async Task<StreamingInputCallResponse> StreamingInputCall(IAsyncStreamReader<StreamingInputCallRequest> requestStream, ServerCallContext context)
         {
             await EnsureEchoMetadataAsync(context);
 
@@ -85,7 +85,7 @@ namespace Grpc.Testing
             return new StreamingInputCallResponse { AggregatedPayloadSize = sum };
         }
 
-        public async Task FullDuplexCall(IAsyncStreamReader<StreamingOutputCallRequest> requestStream, IServerStreamWriter<StreamingOutputCallResponse> responseStream, ServerCallContext context)
+        public override async Task FullDuplexCall(IAsyncStreamReader<StreamingOutputCallRequest> requestStream, IServerStreamWriter<StreamingOutputCallResponse> responseStream, ServerCallContext context)
         {
             await EnsureEchoMetadataAsync(context);
 
@@ -100,7 +100,7 @@ namespace Grpc.Testing
             });
         }
 
-        public async Task HalfDuplexCall(IAsyncStreamReader<StreamingOutputCallRequest> requestStream, IServerStreamWriter<StreamingOutputCallResponse> responseStream, ServerCallContext context)
+        public override async Task HalfDuplexCall(IAsyncStreamReader<StreamingOutputCallRequest> requestStream, IServerStreamWriter<StreamingOutputCallResponse> responseStream, ServerCallContext context)
         {
             throw new NotImplementedException();
         }

--- a/src/csharp/Grpc.IntegrationTesting/WorkerServiceImpl.cs
+++ b/src/csharp/Grpc.IntegrationTesting/WorkerServiceImpl.cs
@@ -45,7 +45,7 @@ namespace Grpc.Testing
     /// <summary>
     /// Implementation of WorkerService server
     /// </summary>
-    public class WorkerServiceImpl : WorkerService.IWorkerService
+    public class WorkerServiceImpl : WorkerService.WorkerServiceBase
     {
         readonly Action stopRequestHandler;
 
@@ -54,7 +54,7 @@ namespace Grpc.Testing
             this.stopRequestHandler = GrpcPreconditions.CheckNotNull(stopRequestHandler);
         }
         
-        public async Task RunServer(IAsyncStreamReader<ServerArgs> requestStream, IServerStreamWriter<ServerStatus> responseStream, ServerCallContext context)
+        public override async Task RunServer(IAsyncStreamReader<ServerArgs> requestStream, IServerStreamWriter<ServerStatus> responseStream, ServerCallContext context)
         {
             GrpcPreconditions.CheckState(await requestStream.MoveNext());
             var serverConfig = requestStream.Current.Setup;
@@ -78,7 +78,7 @@ namespace Grpc.Testing
             await runner.StopAsync();
         }
 
-        public async Task RunClient(IAsyncStreamReader<ClientArgs> requestStream, IServerStreamWriter<ClientStatus> responseStream, ServerCallContext context)
+        public override async Task RunClient(IAsyncStreamReader<ClientArgs> requestStream, IServerStreamWriter<ClientStatus> responseStream, ServerCallContext context)
         {
             GrpcPreconditions.CheckState(await requestStream.MoveNext());
             var clientConfig = requestStream.Current.Setup;
@@ -100,12 +100,12 @@ namespace Grpc.Testing
             await runner.StopAsync();
         }
 
-        public Task<CoreResponse> CoreCount(CoreRequest request, ServerCallContext context)
+        public override Task<CoreResponse> CoreCount(CoreRequest request, ServerCallContext context)
         {
             return Task.FromResult(new CoreResponse { Cores = Environment.ProcessorCount });
         }
 
-        public Task<Void> QuitWorker(Void request, ServerCallContext context)
+        public override Task<Void> QuitWorker(Void request, ServerCallContext context)
         {
             stopRequestHandler();
             return Task.FromResult(new Void());

--- a/src/csharp/Grpc.IntegrationTesting/WorkerServiceImpl.cs
+++ b/src/csharp/Grpc.IntegrationTesting/WorkerServiceImpl.cs
@@ -45,7 +45,7 @@ namespace Grpc.Testing
     /// <summary>
     /// Implementation of WorkerService server
     /// </summary>
-    public class WorkerServiceImpl : WorkerService.WorkerServiceBase
+    public class WorkerServiceImpl : WorkerServiceGrpc.WorkerService
     {
         readonly Action stopRequestHandler;
 


### PR DESCRIPTION
Same as #5751  but with extra changes to get the idea how the resulting code looks like:
- serverside abstract class doesn't have "Base" suffix
- "Grpc" suffix added to the "umbrella" class that represents a service  (public static class Health -> public static class HealthGrpc).

One of the problems with the "Grpc" suffix seems to be that many people like to add suffix "Service" to their service names (which seems to be against protobuf code style, but still), in which case the resulting class name ("TestServiceGrpc") looks a bit weird.

@jskeet , @chrisdunelm   