### PR TITLE
Temporarily disable qps tsan tests 

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2450,6 +2450,8 @@ targets:
   - gpr_test_util
   - gpr
   - grpc++_test_config
+  exclude_configs:
+  - tsan
   platforms:
   - mac
   - linux
@@ -2469,6 +2471,8 @@ targets:
   - gpr_test_util
   - gpr
   - grpc++_test_config
+  exclude_configs:
+  - tsan
   platforms:
   - mac
   - linux

--- a/tools/run_tests/tests.json
+++ b/tools/run_tests/tests.json
@@ -2296,7 +2296,9 @@
       "posix"
     ], 
     "cpu_cost": 10, 
-    "exclude_configs": [], 
+    "exclude_configs": [
+      "tsan"
+    ], 
     "flaky": false, 
     "gtest": false, 
     "language": "c++", 
@@ -2315,7 +2317,9 @@
       "posix"
     ], 
     "cpu_cost": 10, 
-    "exclude_configs": [], 
+    "exclude_configs": [
+      "tsan"
+    ], 
     "flaky": false, 
     "gtest": false, 
     "language": "c++", 


### PR DESCRIPTION
They are exposing a tsan internal error until we upgrade tsan .

@jtattermusch has approved for this to be merged without his presence since it is urgent. It does need review and passing tests, however.