### PR TITLE
Remove the duplicated file: core_codegen.h in BUILD

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -841,7 +841,6 @@ cc_library(
     "src/cpp/common/secure_auth_context.h",
     "src/cpp/server/secure_server_credentials.h",
     "src/cpp/client/create_channel_internal.h",
-    "src/cpp/common/core_codegen.h",
     "src/cpp/common/create_auth_context.h",
     "src/cpp/server/dynamic_thread_pool.h",
     "src/cpp/server/thread_pool_interface.h",


### PR DESCRIPTION
grpc project is failed to build using the bazel for there is a  the duplicated file: core_codegen.h in the BUILD file.

```
$ bazel build //grpc:grpc_unsecure
ERROR: /home/liushaohui/workspace/computing/grpc/BUILD:836:1: Label '//grpc:src/cpp/common/core_codegen.h' is duplicated in the 'srcs' attribute of rule 'grpc++'.
ERROR: no such package 'grpc': Package 'grpc' contains errors.
INFO: Elapsed time: 0.131s
```
