### PR TITLE
Ensure that no #includes are inside of a namespace.

### DIFF
--- a/test/cpp/qps/limit_cores.cc
+++ b/test/cpp/qps/limit_cores.cc
@@ -72,13 +72,16 @@ int LimitCores(const int* cores, int cores_size) {
   CPU_FREE(cpup);
   return cores_set;
 }
-#else
 
+}  // namespace testing
+}  // namespace grpc
+#else
 namespace grpc {
 namespace testing {
 
 // LimitCores is not currently supported for non-Linux platforms
 int LimitCores(const int*, int) { return gpr_cpu_num_cores(); }
-#endif
+
 }  // namespace testing
 }  // namespace grpc
+#endif

--- a/test/cpp/qps/limit_cores.cc
+++ b/test/cpp/qps/limit_cores.cc
@@ -37,14 +37,15 @@
 #include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 
-namespace grpc {
-namespace testing {
-
 #ifdef GPR_CPU_LINUX
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
 #include <sched.h>
+
+namespace grpc {
+namespace testing {
+
 int LimitCores(const int* cores, int cores_size) {
   const int num_cores = gpr_cpu_num_cores();
   int cores_set = 0;
@@ -72,6 +73,10 @@ int LimitCores(const int* cores, int cores_size) {
   return cores_set;
 }
 #else
+
+namespace grpc {
+namespace testing {
+
 // LimitCores is not currently supported for non-Linux platforms
 int LimitCores(const int*, int) { return gpr_cpu_num_cores(); }
 #endif


### PR DESCRIPTION
Via David Jones. Thanks!

> Previously, was #included to grpc::testing. This really is an error,
> but it managed to work. Building with C++ modules makes this a much stricter
> error, since #inclusions are translated to modular imports.