### PR TITLE
For GRPCOperation's, ensure finish _handler can only be called once

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
@@ -54,7 +54,9 @@
 
 - (void)finish {
   if (_handler) {
-    _handler();
+    void(^handler)() = _handler;
+    _handler = nil;
+    handler();
   }
 }
 @end

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Release it when called, so weak ptrs needn't be used with it, and the call won't be released until the finish handler is called.

When the connectivityMonitor determines the connection has been lost, pull the host disconnect call. Creates an unreliable connection when connectivity is restored. Calling finishWithError: is sufficient.