### PR TITLE
make grpc_pollset_set_create for windows match the header

### DIFF
--- a/src/core/iomgr/pollset_set_windows.c
+++ b/src/core/iomgr/pollset_set_windows.c
@@ -37,7 +37,7 @@
 
 #include "src/core/iomgr/pollset_set_windows.h"
 
-grpc_pollset_set* grpc_pollset_set_create(pollset_set) { return NULL; }
+grpc_pollset_set* grpc_pollset_set_create(void) { return NULL; }
 
 void grpc_pollset_set_destroy(grpc_pollset_set* pollset_set) {}
 


### PR DESCRIPTION
Fixes #5708.

In pollset_set.h  the   function signature is `grpc_pollset_set *grpc_pollset_set_create(void);`