### PR TITLE
Don't set -ex for nvm functions

### DIFF
--- a/test/distrib/node/run_distrib_test.sh
+++ b/test/distrib/node/run_distrib_test.sh
@@ -30,11 +30,11 @@
 
 NODE_VERSION=$1
 source ~/.nvm/nvm.sh
-set -ex
 
 cd $(dirname $0)
 
 nvm install $NODE_VERSION
+set -ex
 
 npm install -g node-static
 

--- a/test/distrib/node/run_distrib_test.sh
+++ b/test/distrib/node/run_distrib_test.sh
@@ -38,13 +38,10 @@ set -ex
 
 npm install -g node-static
 
-# Kill off existing static servers
-kill -9 $(ps aux | grep '[n]ode .*static' | awk '{print $2}') || true
-
 STATIC_SERVER=127.0.0.1
-STATIC_PORT=8080
+STATIC_PORT=$$
 
-# Serves the input_artifacts directory statically at localhost:8080
+# Serves the input_artifacts directory statically at localhost:
 static "$EXTERNAL_GIT_ROOT/input_artifacts" -a $STATIC_SERVER -p $STATIC_PORT &
 STATIC_PID=$!
 

--- a/tools/run_tests/build_artifact_node.sh
+++ b/tools/run_tests/build_artifact_node.sh
@@ -30,9 +30,9 @@
 
 NODE_TARGET_ARCH=$1
 source ~/.nvm/nvm.sh
-set -ex
 
 nvm use 4
+set -ex
 
 cd $(dirname $0)/../..
 

--- a/tools/run_tests/build_node.sh
+++ b/tools/run_tests/build_node.sh
@@ -31,9 +31,9 @@
 
 NODE_VERSION=$1
 source ~/.nvm/nvm.sh
-set -ex
 
 nvm use $NODE_VERSION
+set -ex
 
 CONFIG=${CONFIG:-opt}
 

--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -29,9 +29,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 source ~/.nvm/nvm.sh
-set -ex
 
 nvm use 4
+set -ex
 
 cd $(dirname $0)/../..
 

--- a/tools/run_tests/pre_build_node.sh
+++ b/tools/run_tests/pre_build_node.sh
@@ -31,9 +31,9 @@
 
 NODE_VERSION=$1
 source ~/.nvm/nvm.sh
-set -ex
 
 nvm use $NODE_VERSION
+set -ex
 
 export GRPC_CONFIG=${CONFIG:-opt}
 

--- a/tools/run_tests/run_node.sh
+++ b/tools/run_tests/run_node.sh
@@ -30,9 +30,9 @@
 
 NODE_VERSION=$1
 source ~/.nvm/nvm.sh
-set -ex
 
 nvm use $NODE_VERSION
+set -ex
 
 CONFIG=${CONFIG:-opt}
 


### PR DESCRIPTION
The `nvm` commands are functions, so `set -ex` appears to apply recursively to them, and they do not appear to be intended to work with `set -e`. Also, `set -x` generates tons of hard-to-read error logs. This should fix the node distrib test errors.