### PR TITLE
Refactor C# building in run_tests.py (revert a revert)

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -478,7 +478,8 @@ class CSharpLanguage(object):
       _check_compiler(self.args.compiler, ['default'])
       if self.platform == 'mac':
         # On Mac, official distribution of mono is 32bit.
-        self._make_options = ['EMBED_OPENSSL=true', 'EMBED_ZLIB=true',
+        # TODO(jtattermusch): EMBED_ZLIB=true currently breaks the mac build
+        self._make_options = ['EMBED_OPENSSL=true'
                               'CFLAGS=-arch i386', 'LDFLAGS=-arch i386']
       else:
         self._make_options = ['EMBED_OPENSSL=true', 'EMBED_ZLIB=true']

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -512,7 +512,7 @@ class CSharpLanguage(object):
 
   def make_targets(self):
     # For Windows, this target doesn't really build anything,
-    # everything is build by buildall script later.
+    # everything is built by buildall script later.
     if self.platform == 'windows':
       return []
     else:
@@ -521,9 +521,10 @@ class CSharpLanguage(object):
   def make_options(self):
     if self.platform == 'mac':
       # On Mac, official distribution of mono is 32bit.
-      return ['CFLAGS=-arch i386', 'LDFLAGS=-arch i386']
+      return ['EMBED_OPENSSL=true', 'EMBED_ZLIB=true',
+              'CFLAGS=-arch i386', 'LDFLAGS=-arch i386']
     else:
-      return []
+      return ['EMBED_OPENSSL=true', 'EMBED_ZLIB=true']
 
   def build_steps(self):
     if self.platform == 'windows':

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -120,7 +120,12 @@ def get_c_tests(travis, test_lang) :
 
 def _check_compiler(compiler, supported_compilers):
   if compiler not in supported_compilers:
-    raise Exception('Compiler %s not supported.' % compiler)
+    raise Exception('Compiler %s not supported (on this platform).' % compiler)
+
+
+def _check_arch(arch, supported_archs):
+  if arch not in supported_archs:
+    raise Exception('Architecture %s not supported.' % arch)
 
 
 def _is_use_docker_child():
@@ -465,6 +470,8 @@ class CSharpLanguage(object):
     self.config = config
     self.args = args
     if self.platform == 'windows':
+      # Explicitly choosing between x86 and x64 arch doesn't work yet
+      _check_arch(self.args.arch, ['default'])
       self._make_options = [_windows_toolset_option(self.args.compiler),
                             _windows_arch_option(self.args.arch)]
     else:

--- a/vsprojects/build_vs2010.bat
+++ b/vsprojects/build_vs2010.bat
@@ -1,5 +1,5 @@
 @rem Convenience wrapper that runs specified gRPC target using msbuild
-@rem Usage: build.bat TARGET_NAME
+@rem Usage: build_vs2010.bat TARGET_NAME
 
 setlocal
 @rem Set VS variables (uses Visual Studio 2010)

--- a/vsprojects/build_vs2013.bat
+++ b/vsprojects/build_vs2013.bat
@@ -1,5 +1,5 @@
 @rem Convenience wrapper that runs specified gRPC target using msbuild
-@rem Usage: build.bat TARGET_NAME
+@rem Usage: build_vs2013.bat TARGET_NAME
 
 setlocal
 @rem Set VS variables (uses Visual Studio 2013)

--- a/vsprojects/build_vs2015.bat
+++ b/vsprojects/build_vs2015.bat
@@ -1,5 +1,5 @@
 @rem Convenience wrapper that runs specified gRPC target using msbuild
-@rem Usage: build.bat TARGET_NAME
+@rem Usage: build_vs2015.bat TARGET_NAME
 
 setlocal
 @rem Set VS variables (uses Visual Studio 2015)


### PR DESCRIPTION
Reverts revert of #5963, but this time doesn't break the C# build on mac.