### PR TITLE
Make ruby library conform to status code spec

### DIFF
--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -403,7 +403,7 @@ module GRPC
       loop_handle_server_calls
     end
 
-    # Sends UNAVAILABLE if there are too many unprocessed jobs
+    # Sends RESOURCE_EXHAUSTED if there are too many unprocessed jobs
     def available?(an_rpc)
       jobs_count, max = @pool.jobs_waiting, @max_waiting_requests
       GRPC.logger.info("waiting: #{jobs_count}, max: #{max}")
@@ -411,7 +411,7 @@ module GRPC
       GRPC.logger.warn("NOT AVAILABLE: too many jobs_waiting: #{an_rpc}")
       noop = proc { |x| x }
       c = ActiveCall.new(an_rpc.call, @cq, noop, noop, an_rpc.deadline)
-      c.send_status(StatusCodes::UNAVAILABLE, '')
+      c.send_status(StatusCodes::RESOURCE_EXHAUSTED, '')
       nil
     end
 

--- a/src/ruby/spec/generic/rpc_server_spec.rb
+++ b/src/ruby/spec/generic/rpc_server_spec.rb
@@ -426,7 +426,7 @@ describe GRPC::RpcServer do
         threads.each(&:join)
       end
 
-      it 'should return UNAVAILABLE on too many jobs', server: true do
+      it 'should return RESOURCE_EXHAUSTED on too many jobs', server: true do
         opts = {
           a_channel_arg: 'an_arg',
           server_override: @server,
@@ -449,7 +449,8 @@ describe GRPC::RpcServer do
             begin
               stub.an_rpc(req)
             rescue GRPC::BadStatus => e
-              one_failed_as_unavailable = e.code == StatusCodes::UNAVAILABLE
+              one_failed_as_unavailable =
+                e.code == StatusCodes::RESOURCE_EXHAUSTED
             end
           end
         end


### PR DESCRIPTION
Specifically, if the server is refusing to handle a call because it has too many outstanding requests, it should send `RESOURCE_EXHAUSTED`, not `UNAVAILABLE`.

This fixes #5993.