### PR TITLE
Async void is illegal in ASP.NET and DNXcore

### DIFF
--- a/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
@@ -87,7 +87,7 @@ namespace Grpc.Core.Internal
             }
         }
 
-        private async void StartGetMetadata(AuthInterceptorContext context, IntPtr callbackPtr, IntPtr userDataPtr)
+        private async Task StartGetMetadata(AuthInterceptorContext context, IntPtr callbackPtr, IntPtr userDataPtr)
         {
             try
             {


### PR DESCRIPTION
Tentative fix for #6119.
From my experiments it also seems that `async void` is problematic when using dnx-style projects.