### PR TITLE
added grpc_resolved_address_to_string

### DIFF
--- a/src/core/lib/iomgr/resolve_address.h
+++ b/src/core/lib/iomgr/resolve_address.h
@@ -65,8 +65,16 @@ void grpc_resolve_address(const char *addr, const char *default_port,
 void grpc_resolved_addresses_destroy(grpc_resolved_addresses *addresses);
 
 /* Resolve addr in a blocking fashion. Returns NULL on failure. On success,
-   result must be freed with grpc_resolved_addresses_destroy. */
+   result must be freed with grpc_resolved_addresses_destroy. Use default_port
+   if a port isn't designated in addr, otherwise use the port in addr. */
 extern grpc_resolved_addresses *(*grpc_blocking_resolve_address)(
     const char *name, const char *default_port);
+
+/* Return the textual representation of \a address as a "host:port" string.
+ *
+ * The caller is responsible for freeing the returned string.
+ *
+ * IPv6 addresses will be returned between square brackets, ie, as [...]:port */
+char *grpc_resolved_address_to_string(grpc_resolved_address *address);
 
 #endif /* GRPC_CORE_LIB_IOMGR_RESOLVE_ADDRESS_H */

--- a/src/core/lib/iomgr/resolve_address_windows.c
+++ b/src/core/lib/iomgr/resolve_address_windows.c
@@ -37,6 +37,7 @@
 #include "src/core/lib/iomgr/resolve_address.h"
 #include "src/core/lib/iomgr/sockaddr.h"
 
+#include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
 
@@ -164,6 +165,38 @@ void grpc_resolve_address(const char *name, const char *default_port,
   r->cb = cb;
   r->arg = arg;
   grpc_executor_enqueue(&r->request_closure, 1);
+}
+
+char *grpc_resolved_address_to_string(grpc_resolved_address *address) {
+  const struct sockaddr *sa = (struct sockaddr *)address->addr;
+  const bool is_ipv6 = sa->sa_family == AF_INET6;
+  const socklen_t addr_str_len = is_ipv6 ? INET6_ADDRSTRLEN : INET_ADDRSTRLEN;
+  char *addr_str = gpr_malloc(addr_str_len);
+  char port_str[6];
+  int err = getnameinfo(sa, (socklen_t)address->len, addr_str, addr_str_len,
+                        port_str, 6, NI_NUMERICHOST | NI_NUMERICSERV);
+  if (err != 0) {
+    gpr_log(GPR_ERROR, "Failed to convert address to string: %s",
+            gai_strerror(err));
+    return NULL;
+  }
+
+  char *hostport;
+  size_t hostport_len;
+  char *hostport_format;
+  if (is_ipv6) {
+    hostport_len = addr_str_len + 1 /* : */ + 2 /* square brackets */ +
+                   6 /* port */ + 1 /* terminator */;
+    hostport_format = "[%s]:%s";
+  } else {
+    hostport_len = addr_str_len + 1 /* : */ + 6 /* port */ + 1 /* terminator */;
+    hostport_format = "%s:%s";
+  }
+  hostport = gpr_malloc(hostport_len);
+  snprintf(hostport, hostport_len, hostport_format, addr_str, port_str);
+  gpr_free(addr_str);
+
+  return hostport;
 }
 
 #endif


### PR DESCRIPTION
Rationale: grpclb needs to assemble a target URI over the resolved addresses it receives as input. The functionality seemed generic enough as to expose it publicly.