### PR TITLE
Provide CQ per client call in Ruby to avoid pluck limits

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'googleauth',      '~> 0.5.1'
 
   s.add_development_dependency 'bundler',            '~> 1.9'
+  s.add_development_dependency 'facter',             '~> 2.4'
   s.add_development_dependency 'logging',            '~> 2.0'
   s.add_development_dependency 'simplecov',          '~> 0.9'
   s.add_development_dependency 'rake',               '~> 10.4'

--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -85,7 +85,8 @@ module GRPC
     # when present, this is the default timeout used for calls
     #
     # @param host [String] the host the stub connects to
-    # @param q [Core::CompletionQueue] used to wait for events
+    # @param q [Core::CompletionQueue] used to wait for events - now deprecated
+    #        since each new active call gets its own separately
     # @param creds [Core::ChannelCredentials|Symbol] the channel credentials, or
     #     :this_channel_is_insecure
     # @param channel_override [Core::Channel] a pre-created channel
@@ -97,7 +98,6 @@ module GRPC
                    propagate_mask: nil,
                    **kw)
       fail(TypeError, '!CompletionQueue') unless q.is_a?(Core::CompletionQueue)
-      @queue = q
       @ch = ClientStub.setup_channel(channel_override, host, creds, **kw)
       alt_host = kw[Core::Channel::SSL_TARGET]
       @host = alt_host.nil? ? host : alt_host
@@ -458,14 +458,17 @@ module GRPC
       if deadline.nil?
         deadline = from_relative_time(timeout.nil? ? @timeout : timeout)
       end
-      call = @ch.create_call(@queue,
+      # Provide each new client call with its own completion queue
+      call_queue = Core::CompletionQueue.new
+      call = @ch.create_call(call_queue,
                              parent, # parent call
                              @propagate_mask, # propagation options
                              method,
                              nil, # host use nil,
                              deadline)
       call.set_credentials! credentials unless credentials.nil?
-      ActiveCall.new(call, @queue, marshal, unmarshal, deadline, started: false)
+      ActiveCall.new(call, call_queue, marshal, unmarshal, deadline,
+                     started: false)
     end
   end
 end

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -37,6 +37,7 @@
     s.add_dependency 'googleauth',      '~> 0.5.1'
 
     s.add_development_dependency 'bundler',            '~> 1.9'
+    s.add_development_dependency 'facter',             '~> 2.4'
     s.add_development_dependency 'logging',            '~> 2.0'
     s.add_development_dependency 'simplecov',          '~> 0.9'
     s.add_development_dependency 'rake',               '~> 10.4'


### PR DESCRIPTION
This mimics CQ usage in the C++ sync API.

Fixes #6045 
