### PR TITLE
Misc changes to stress test scripts

### DIFF
--- a/tools/run_tests/stress_test/configs/asan.json
+++ b/tools/run_tests/stress_test/configs/asan.json
@@ -11,13 +11,13 @@
     "baseTemplates": {
       "default": {
         "wrapperScriptPath": "/var/local/git/grpc/tools/gcp/stress_test/run_client.py",
-        "pollIntervalSecs": 60,
+        "pollIntervalSecs": 120,
         "clientArgs": {
           "num_channels_per_server":5,
           "num_stubs_per_channel":10,
           "test_cases": "empty_unary:1,large_unary:1,client_streaming:1,server_streaming:1,empty_stream:1",
           "metrics_port": 8081,
-          "metrics_collection_interval_secs":60
+          "metrics_collection_interval_secs":120
         },
         "metricsPort": 8081,
         "metricsArgs": {
@@ -66,7 +66,7 @@
       "stress-client-asan": {
         "clientTemplate": "cxx_client_asan",
         "dockerImage": "grpc_stress_cxx_asan",
-        "numInstances": 20,
+        "numInstances": 5,
         "serverPodSpec": "stress-server-asan"
       }
     }

--- a/tools/run_tests/stress_test/configs/opt.json
+++ b/tools/run_tests/stress_test/configs/opt.json
@@ -66,7 +66,7 @@
       "stress-client-opt": {
         "clientTemplate": "cxx_client_opt",
         "dockerImage": "grpc_stress_cxx_opt",
-        "numInstances": 10,
+        "numInstances": 15,
         "serverPodSpec": "stress-server-opt"
       }
     }

--- a/tools/run_tests/stress_test/configs/tsan.json
+++ b/tools/run_tests/stress_test/configs/tsan.json
@@ -11,13 +11,13 @@
     "baseTemplates": {
       "default": {
         "wrapperScriptPath": "/var/local/git/grpc/tools/gcp/stress_test/run_client.py",
-        "pollIntervalSecs": 60,
+        "pollIntervalSecs": 120,
         "clientArgs": {
           "num_channels_per_server":5,
           "num_stubs_per_channel":10,
           "test_cases": "empty_unary:1,large_unary:1,client_streaming:1,server_streaming:1,empty_stream:1",
           "metrics_port": 8081,
-          "metrics_collection_interval_secs":60
+          "metrics_collection_interval_secs":120
         },
         "metricsPort": 8081,
         "metricsArgs": {
@@ -66,7 +66,7 @@
       "stress-client-tsan": {
         "clientTemplate": "cxx_client_tsan",
         "dockerImage": "grpc_stress_cxx_tsan",
-        "numInstances": 20,
+        "numInstances": 5,
         "serverPodSpec": "stress-server-tsan"
       }
     }


### PR DESCRIPTION
Added a few misc changes

- Increased the bigquery timeout to 30 seconds from 10 seconds (default). It turns out that the intermittent query failures I have been seeing in BigQuery are due to timeouts. 

- Added --tear_down option to run_tests_on_gke flag so that one could manually cleanup the tests (for example, currently the framework does not delete any pods if the tests fail. This is by-design so that we can investigate what went wrong. In such cases, this --tear_down flag is helpful to cleanup once we are done with our investigation)

- Tweaked the settings in the config files (tsan and asan seem to have too many stress clients).