### PR TITLE
Add RubyLanguage to benchmarking scenarios

### DIFF
--- a/src/ruby/qps/server.rb
+++ b/src/ruby/qps/server.rb
@@ -88,4 +88,7 @@ class BenchmarkServer
   def get_port
     @port
   end
+  def stop
+    @server.stop
+  end
 end

--- a/src/ruby/qps/worker.rb
+++ b/src/ruby/qps/worker.rb
@@ -55,12 +55,12 @@ class WorkerServiceImpl < Grpc::Testing::WorkerService::Service
     Thread.new {
       bms = ''
       gtss = Grpc::Testing::ServerStatus
-      reqs.each do |req|        
+      reqs.each do |req|
         case req.argtype.to_s
         when 'setup'
           bms = BenchmarkServer.new(req.setup, @server_port)
           q.push(gtss.new(stats: bms.mark(false), port: bms.get_port))
-        when 'mark'         
+        when 'mark'
           q.push(gtss.new(stats: bms.mark(req.mark.reset), cores: cpu_cores))
         end
       end

--- a/tools/run_tests/performance/run_worker_ruby.sh
+++ b/tools/run_tests/performance/run_worker_ruby.sh
@@ -32,14 +32,4 @@ set -ex
 
 cd $(dirname $0)/../../..
 
-# cleanup after previous builds
-ssh "${USER_AT_HOST}" "rm -rf ~/performance_workspace && mkdir -p ~/performance_workspace"
-
-# TODO(jtattermusch): To be sure there are no running processes that would
-# mess with the results, be rough and reboot the slave here
-# and wait for it to come back online.
-ssh "${USER_AT_HOST}" "killall -9 qps_worker mono node ruby || true"
-
-# push the current sources to the slave and unpack it.
-scp ../grpc.tar "${USER_AT_HOST}:~/performance_workspace"
-ssh "${USER_AT_HOST}" "tar -xf ~/performance_workspace/grpc.tar -C ~/performance_workspace"
+ruby src/ruby/qps/worker.rb $@

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -429,8 +429,55 @@ class NodeLanguage:
     return 'node'
 
 
+class RubyLanguage:
+
+  def __init__(self):
+    pass
+    self.safename = str(self)
+
+  def worker_cmdline(self):
+    return ['tools/run_tests/performance/run_worker_ruby.sh']
+
+  def worker_port_offset(self):
+    return 300
+
+  def scenarios(self):
+    # TODO(jtattermusch): add more scenarios
+    secargs = None
+    yield {
+        'name': 'ruby_protobuf_unary_ping_pong',
+        'num_servers': 1,
+        'num_clients': 1,
+        'client_config': {
+          'client_type': 'SYNC_CLIENT',
+          'security_params': secargs,
+          'outstanding_rpcs_per_channel': 1,
+          'client_channels': 1,
+          'async_client_threads': 1,
+          'rpc_type': 'UNARY',
+          'load_params': {
+            'closed_loop': {}
+          },
+          'payload_config': EMPTY_PROTO_PAYLOAD,
+          'histogram_params': HISTOGRAM_PARAMS,
+        },
+        'server_config': {
+          'server_type': 'SYNC_SERVER',
+          'security_params': secargs,
+          'core_limit': 0,
+          'async_server_threads': 1,
+        },
+        'warmup_seconds': WARMUP_SECONDS,
+        'benchmark_seconds': BENCHMARK_SECONDS
+    }
+
+  def __str__(self):
+    return 'ruby'
+
+
 LANGUAGES = {
     'c++' : CXXLanguage(),
     'csharp' : CSharpLanguage(),
     'node' : NodeLanguage(),
+    'ruby' : RubyLanguage()
 }

--- a/tools/run_tests/pre_build_ruby.sh
+++ b/tools/run_tests/pre_build_ruby.sh
@@ -33,7 +33,7 @@ set -ex
 
 export GRPC_CONFIG=${CONFIG:-opt}
 
-# change to grpc's ruby directory
-cd $(dirname $0)/../../src/ruby
+# change to grpc repo root
+cd $(dirname $0)/../..
 
 bundle install


### PR DESCRIPTION
~~Two problems I might need help with:~~
~~-- the ruby qps worker doesn't die when quit_worker RPC is invoked (needs to be kill -9)~~
~~-- after tools/run_tests/run_tests.py -l ruby --build_only, one needs to manually `gem install facter` to be able to run worker.rb~~
