### PR TITLE
Improvements to java benchmark integration.

### DIFF
--- a/tools/run_tests/performance/remote_host_prepare.sh
+++ b/tools/run_tests/performance/remote_host_prepare.sh
@@ -38,9 +38,12 @@ ssh "${USER_AT_HOST}" "rm -rf ~/performance_workspace && mkdir -p ~/performance_
 # TODO(jtattermusch): To be sure there are no running processes that would
 # mess with the results, be rough and reboot the slave here
 # and wait for it to come back online.
-# TODO(jtattermusch): Kill all java QpsWorkers, but killall java
 # could also kill jenkins.
 ssh "${USER_AT_HOST}" "killall -9 qps_worker mono node ruby || true"
+
+# Kill all java LoadWorker processes. We can't just killall java
+# as one of the processes might be jenkins.
+ssh "${USER_AT_HOST}" 'kill -9 $(jps | grep LoadWorker | cut -f1 -d" ") || true'
 
 # push the current sources to the slave and unpack it.
 scp ../grpc.tar "${USER_AT_HOST}:~/performance_workspace"

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -89,7 +89,7 @@ def create_qpsworker_job(language, shortname=None,
   jobspec = jobset.JobSpec(
       cmdline=cmdline,
       shortname=shortname,
-      timeout_seconds=15*60)
+      timeout_seconds=30*60)
   return QpsWorkerJob(jobspec, language, host_and_port)
 
 


### PR DESCRIPTION
-- makes sure all java LoadWorkers on remote host are killed before the test starts.
-- make sure qpsworker timeout is high enough