### PR TITLE
Add peer_cert method to Ruby call object

### DIFF
--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -214,6 +214,28 @@ static VALUE grpc_rb_call_get_peer(VALUE self) {
   return res;
 }
 
+/* Called to obtain the x509 cert of an authenticated peer. */
+static VALUE grpc_rb_call_get_peer_cert(VALUE self) {
+  grpc_call *call = NULL;
+  VALUE res = Qnil;
+  grpc_auth_context *ctx = NULL;
+  // char *peer_cert = NULL;
+  TypedData_Get_Struct(self, grpc_call, &grpc_call_data_type, call);
+
+  ctx = grpc_call_auth_context(call);
+
+  grpc_auth_property_iterator it =
+      grpc_auth_context_find_properties_by_name(ctx, GRPC_X509_PEM_CERT_PROPERTY_NAME);
+  const grpc_auth_property *prop = grpc_auth_property_iterator_next(&it);
+  if (prop == NULL) {
+    return Qnil;
+  }
+
+  res = rb_str_new2(prop->value);
+
+  return res;
+}
+
 /*
   call-seq:
   status = call.status
@@ -861,6 +883,7 @@ void Init_grpc_call() {
   rb_define_method(grpc_rb_cCall, "run_batch", grpc_rb_call_run_batch, 4);
   rb_define_method(grpc_rb_cCall, "cancel", grpc_rb_call_cancel, 0);
   rb_define_method(grpc_rb_cCall, "peer", grpc_rb_call_get_peer, 0);
+  rb_define_method(grpc_rb_cCall, "peer_cert", grpc_rb_call_get_peer_cert, 0);
   rb_define_method(grpc_rb_cCall, "status", grpc_rb_call_get_status, 0);
   rb_define_method(grpc_rb_cCall, "status=", grpc_rb_call_set_status, 1);
   rb_define_method(grpc_rb_cCall, "metadata", grpc_rb_call_get_metadata, 0);

--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -227,14 +227,16 @@ static VALUE grpc_rb_call_get_peer_cert(VALUE self) {
     return Qnil;
   }
 
-  grpc_auth_property_iterator it =
-      grpc_auth_context_find_properties_by_name(ctx, GRPC_X509_PEM_CERT_PROPERTY_NAME);
-  const grpc_auth_property *prop = grpc_auth_property_iterator_next(&it);
-  if (prop == NULL) {
-    return Qnil;
-  }
+  {
+    grpc_auth_property_iterator it =
+        grpc_auth_context_find_properties_by_name(ctx, GRPC_X509_PEM_CERT_PROPERTY_NAME);
+    const grpc_auth_property *prop = grpc_auth_property_iterator_next(&it);
+    if (prop == NULL) {
+      return Qnil;
+    }
 
-  res = rb_str_new2(prop->value);
+    res = rb_str_new2(prop->value);
+  }
 
   grpc_auth_context_release(ctx);
 

--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -219,10 +219,13 @@ static VALUE grpc_rb_call_get_peer_cert(VALUE self) {
   grpc_call *call = NULL;
   VALUE res = Qnil;
   grpc_auth_context *ctx = NULL;
-  // char *peer_cert = NULL;
   TypedData_Get_Struct(self, grpc_call, &grpc_call_data_type, call);
 
   ctx = grpc_call_auth_context(call);
+
+  if (!ctx || !grpc_auth_context_peer_is_authenticated(ctx)) {
+    return Qnil;
+  }
 
   grpc_auth_property_iterator it =
       grpc_auth_context_find_properties_by_name(ctx, GRPC_X509_PEM_CERT_PROPERTY_NAME);
@@ -232,6 +235,8 @@ static VALUE grpc_rb_call_get_peer_cert(VALUE self) {
   }
 
   res = rb_str_new2(prop->value);
+
+  grpc_auth_context_release(ctx);
 
   return res;
 }

--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -59,7 +59,8 @@ module GRPC
     include Core::CallOps
     extend Forwardable
     attr_reader(:deadline)
-    def_delegators :@call, :cancel, :metadata, :write_flag, :write_flag=, :peer, :peer_cert
+    def_delegators :@call, :cancel, :metadata, :write_flag, :write_flag=,
+                   :peer, :peer_cert
 
     # client_invoke begins a client invocation.
     #

--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -59,7 +59,7 @@ module GRPC
     include Core::CallOps
     extend Forwardable
     attr_reader(:deadline)
-    def_delegators :@call, :cancel, :metadata, :write_flag, :write_flag=
+    def_delegators :@call, :cancel, :metadata, :write_flag, :write_flag=, :peer, :peer_cert
 
     # client_invoke begins a client invocation.
     #
@@ -472,7 +472,7 @@ module GRPC
     # SingleReqView limits access to an ActiveCall's methods for use in server
     # handlers that receive just one request.
     SingleReqView = view_class(:cancelled, :deadline, :metadata,
-                               :output_metadata)
+                               :output_metadata, :peer, :peer_cert)
 
     # MultiReqView limits access to an ActiveCall's methods for use in
     # server client_streamer handlers.


### PR DESCRIPTION
A quick PR to continue the conversation from here:

https://groups.google.com/forum/#!topic/grpc-io/58nxrxi5xUA

This adds a `peer_cert` method to the Ruby call object, which can be used by the server handler to authorize the client's access. It also allows `peer` and `peer_cert` to be used from the `ActiveCall::SingleReqView` passed as the second argument to a handler method.

`peer_cert` probably makes more sense as a more generic method for pulling property values from the call's auth context, rather than a specific method hardcoded for cert. That would work fine for our purposes, and I'm glad to change this out if that seems more acceptable.