### PR TITLE
Fixing invalid usage of getProtobufServiceAttrs() function.

### DIFF
--- a/src/node/src/client.js
+++ b/src/node/src/client.js
@@ -815,8 +815,7 @@ exports.waitForClientReady = function(client, deadline, callback) {
  * @return {function(string, Object)} New client constructor
  */
 exports.makeProtobufClientConstructor =  function(service, options) {
-  var method_attrs = common.getProtobufServiceAttrs(service, service.name,
-                                                    options);
+  var method_attrs = common.getProtobufServiceAttrs(service, options);
   var deprecatedArgumentOrder = false;
   if (options) {
     deprecatedArgumentOrder = options.deprecatedArgumentOrder;


### PR DESCRIPTION
getProtobufServiceAttrs(service, options) must be called with 2 arguments.