### PR TITLE
Update grpc_interop_go dockerfile to use Go 1.5

### DIFF
--- a/tools/dockerfile/grpc_interop_go/Dockerfile
+++ b/tools/dockerfile/grpc_interop_go/Dockerfile
@@ -27,7 +27,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM golang:1.4
+FROM golang:1.5
 
 # Using login shell removes Go from path, so we add it.
 RUN ln -s /usr/src/go/bin/go /usr/local/bin


### PR DESCRIPTION
grpc-go requires Go 1.5 or later.

Fixes grpc/grpc-go#648.