### PR TITLE
Upgrade go docker image to golang:1.5

### DIFF
--- a/templates/tools/dockerfile/go_path.include
+++ b/templates/tools/dockerfile/go_path.include
@@ -1,2 +1,2 @@
 # Using login shell removes Go from path, so we add it.
-RUN ln -s /usr/src/go/bin/go /usr/local/bin
+RUN ln -s /usr/local/go/bin/go /usr/local/bin

--- a/templates/tools/dockerfile/stress_test/grpc_interop_stress_go/Dockerfile.template
+++ b/templates/tools/dockerfile/stress_test/grpc_interop_stress_go/Dockerfile.template
@@ -29,7 +29,7 @@
   # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   
-  FROM golang:1.4
+  FROM golang:1.5
   
   <%include file="../../gcp_api_libraries.include"/>
   <%include file="../../go_path.include"/>

--- a/tools/dockerfile/grpc_interop_go/Dockerfile
+++ b/tools/dockerfile/grpc_interop_go/Dockerfile
@@ -27,10 +27,10 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM golang:1.4
+FROM golang:1.5
 
 # Using login shell removes Go from path, so we add it.
-RUN ln -s /usr/src/go/bin/go /usr/local/bin
+RUN ln -s /usr/local/go/bin/go /usr/local/bin
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/grpc_interop_http2/Dockerfile
+++ b/tools/dockerfile/grpc_interop_http2/Dockerfile
@@ -27,10 +27,10 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM golang:1.4
+FROM golang:1.5
 
 # Using login shell removes Go from path, so we add it.
-RUN ln -s /usr/src/go/bin/go /usr/local/bin
+RUN ln -s /usr/local/go/bin/go /usr/local/bin
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/stress_test/grpc_interop_stress_go/Dockerfile
+++ b/tools/dockerfile/stress_test/grpc_interop_stress_go/Dockerfile
@@ -27,7 +27,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM golang:1.4
+FROM golang:1.5
 
 # Google Cloud platform API libraries
 RUN apt-get update && apt-get install -y python-pip && apt-get clean
@@ -35,7 +35,7 @@ RUN pip install --upgrade google-api-python-client
 
 
 # Using login shell removes Go from path, so we add it.
-RUN ln -s /usr/src/go/bin/go /usr/local/bin
+RUN ln -s /usr/local/go/bin/go /usr/local/bin
 
 # Define the default command.
 CMD ["bash"]


### PR DESCRIPTION
Fixes grpc/grpc-go#648

Replaces https://github.com/grpc/grpc/pull/6244.

