### PR TITLE
Actually fail on benchmark scenario failure.

### DIFF
--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -361,5 +361,6 @@ try:
     sys.exit(1)
 except:
   traceback.print_exc()
+  raise
 finally:
   finish_qps_workers(qpsworker_jobs)


### PR DESCRIPTION
Just found out that if one of the scenarios fails, the run_performance_tests.py script still returns success.
(sys.exit throws an exception in python and by mistake we weren't rethrowing it).