### PR TITLE
Add new cmdline options to C# codegen.

### DIFF
--- a/src/compiler/config.h
+++ b/src/compiler/config.h
@@ -68,6 +68,11 @@
 #define GRPC_CUSTOM_PLUGINMAIN ::google::protobuf::compiler::PluginMain
 #endif
 
+#ifndef GRPC_CUSTOM_PARSEGENERATORPARAMETER
+#include <google/protobuf/compiler/code_generator.h>
+#define GRPC_CUSTOM_PARSEGENERATORPARAMETER ::google::protobuf::compiler::ParseGeneratorParameter
+#endif
+
 namespace grpc {
 namespace protobuf {
 typedef GRPC_CUSTOM_DESCRIPTOR Descriptor;
@@ -81,6 +86,11 @@ static inline int PluginMain(int argc, char* argv[],
                              const CodeGenerator* generator) {
   return GRPC_CUSTOM_PLUGINMAIN(argc, argv, generator);
 }
+static inline void ParseGeneratorParameter(const string& parameter,
+    std::vector<std::pair<string, string> >* options) {
+  GRPC_CUSTOM_PARSEGENERATORPARAMETER(parameter, options);
+}
+
 }  // namespace compiler
 namespace io {
 typedef GRPC_CUSTOM_PRINTER Printer;

--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -566,7 +566,8 @@ void GenerateService(Printer* out, const ServiceDescriptor *service,
 
 }  // anonymous namespace
 
-grpc::string GetServices(const FileDescriptor *file) {
+grpc::string GetServices(const FileDescriptor *file, bool generate_client,
+                         bool generate_server) {
   grpc::string output;
   {
     // Scope the output stream so it closes and finalizes output to the string.
@@ -594,7 +595,7 @@ grpc::string GetServices(const FileDescriptor *file) {
     out.Print("namespace $namespace$ {\n", "namespace", GetFileNamespace(file));
     out.Indent();
     for (int i = 0; i < file->service_count(); i++) {
-      GenerateService(&out, file->service(i), true, true);
+      GenerateService(&out, file->service(i), generate_client, generate_server);
     }
     out.Outdent();
     out.Print("}\n");

--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -123,6 +123,10 @@ std::string GetMethodRequestParamMaybe(const MethodDescriptor *method,
   return GetClassName(method->input_type()) + " request, ";
 }
 
+std::string GetAccessLevel(bool internal_access) {
+  return internal_access ? "internal" : "public";
+}
+
 std::string GetMethodReturnTypeClient(const MethodDescriptor *method) {
   switch (GetMethodType(method)) {
     case METHODTYPE_NO_STREAMING:
@@ -528,8 +532,10 @@ void GenerateNewStubMethods(Printer* out, const ServiceDescriptor *service) {
 }
 
 void GenerateService(Printer* out, const ServiceDescriptor *service,
-                     bool generate_client, bool generate_server) {
-  out->Print("public static class $classname$\n", "classname",
+                     bool generate_client, bool generate_server,
+                     bool internal_access) {
+  out->Print("$access_level$ static class $classname$\n", "access_level",
+             GetAccessLevel(internal_access), "classname",
              GetServiceClassName(service));
   out->Print("{\n");
   out->Indent();
@@ -567,7 +573,7 @@ void GenerateService(Printer* out, const ServiceDescriptor *service,
 }  // anonymous namespace
 
 grpc::string GetServices(const FileDescriptor *file, bool generate_client,
-                         bool generate_server) {
+                         bool generate_server, bool internal_access) {
   grpc::string output;
   {
     // Scope the output stream so it closes and finalizes output to the string.
@@ -595,7 +601,8 @@ grpc::string GetServices(const FileDescriptor *file, bool generate_client,
     out.Print("namespace $namespace$ {\n", "namespace", GetFileNamespace(file));
     out.Indent();
     for (int i = 0; i < file->service_count(); i++) {
-      GenerateService(&out, file->service(i), generate_client, generate_server);
+      GenerateService(&out, file->service(i), generate_client, generate_server,
+                      internal_access);
     }
     out.Outdent();
     out.Print("}\n");

--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -527,7 +527,8 @@ void GenerateNewStubMethods(Printer* out, const ServiceDescriptor *service) {
   out->Print("\n");
 }
 
-void GenerateService(Printer* out, const ServiceDescriptor *service) {
+void GenerateService(Printer* out, const ServiceDescriptor *service,
+                     bool generate_client, bool generate_server) {
   out->Print("public static class $classname$\n", "classname",
              GetServiceClassName(service));
   out->Print("{\n");
@@ -542,13 +543,22 @@ void GenerateService(Printer* out, const ServiceDescriptor *service) {
     GenerateStaticMethodField(out, service->method(i));
   }
   GenerateServiceDescriptorProperty(out, service);
-  GenerateClientInterface(out, service);
-  GenerateServerInterface(out, service);
-  GenerateServerClass(out, service);
-  GenerateClientStub(out, service);
-  GenerateBindServiceMethod(out, service, false);
-  GenerateBindServiceMethod(out, service, true);
-  GenerateNewStubMethods(out, service);
+
+  if (generate_client) {
+    GenerateClientInterface(out, service);
+  }
+  if (generate_server) {
+    GenerateServerInterface(out, service);
+    GenerateServerClass(out, service);
+  }
+  if (generate_client) {
+    GenerateClientStub(out, service);
+    GenerateNewStubMethods(out, service);
+  }
+  if (generate_server) {
+    GenerateBindServiceMethod(out, service, false);
+    GenerateBindServiceMethod(out, service, true);
+  }
 
   out->Outdent();
   out->Print("}\n");
@@ -584,7 +594,7 @@ grpc::string GetServices(const FileDescriptor *file) {
     out.Print("namespace $namespace$ {\n", "namespace", GetFileNamespace(file));
     out.Indent();
     for (int i = 0; i < file->service_count(); i++) {
-      GenerateService(&out, file->service(i));
+      GenerateService(&out, file->service(i), true, true);
     }
     out.Outdent();
     out.Print("}\n");

--- a/src/compiler/csharp_generator.h
+++ b/src/compiler/csharp_generator.h
@@ -41,7 +41,8 @@
 namespace grpc_csharp_generator {
 
 grpc::string GetServices(const grpc::protobuf::FileDescriptor *file,
-                         bool generate_client, bool generate_server);
+                         bool generate_client, bool generate_server,
+                         bool internal_access);
 
 }  // namespace grpc_csharp_generator
 

--- a/src/compiler/csharp_generator.h
+++ b/src/compiler/csharp_generator.h
@@ -40,7 +40,8 @@
 
 namespace grpc_csharp_generator {
 
-grpc::string GetServices(const grpc::protobuf::FileDescriptor *file);
+grpc::string GetServices(const grpc::protobuf::FileDescriptor *file,
+                         bool generate_client, bool generate_server);
 
 }  // namespace grpc_csharp_generator
 

--- a/src/compiler/csharp_plugin.cc
+++ b/src/compiler/csharp_plugin.cc
@@ -53,11 +53,14 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
 
     bool generate_client = true;
     bool generate_server = true;
+    bool internal_access = false;
     for (size_t i = 0; i < options.size(); i++) {
       if (options[i].first == "no_client") {
         generate_client = false;
       } else if (options[i].first == "no_server") {
         generate_server = false;
+      } else if (options[i].first == "internal_access") {
+        internal_access = true;
       } else {
         *error = "Unknown generator option: " + options[i].first;
         return false;
@@ -66,7 +69,8 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
 
     grpc::string code = grpc_csharp_generator::GetServices(file,
                                                            generate_client,
-                                                           generate_server);
+                                                           generate_server,
+                                                           internal_access);
     if (code.size() == 0) {
       return true;  // don't generate a file if there are no services
     }

--- a/src/compiler/csharp_plugin.cc
+++ b/src/compiler/csharp_plugin.cc
@@ -51,7 +51,22 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     std::vector<std::pair<grpc::string, grpc::string> > options;
     grpc::protobuf::compiler::ParseGeneratorParameter(parameter, &options);
 
-    grpc::string code = grpc_csharp_generator::GetServices(file);
+    bool generate_client = true;
+    bool generate_server = true;
+    for (size_t i = 0; i < options.size(); i++) {
+      if (options[i].first == "no_client") {
+        generate_client = false;
+      } else if (options[i].first == "no_server") {
+        generate_server = false;
+      } else {
+        *error = "Unknown generator option: " + options[i].first;
+        return false;
+      }
+    }
+
+    grpc::string code = grpc_csharp_generator::GetServices(file,
+                                                           generate_client,
+                                                           generate_server);
     if (code.size() == 0) {
       return true;  // don't generate a file if there are no services
     }

--- a/src/compiler/csharp_plugin.cc
+++ b/src/compiler/csharp_plugin.cc
@@ -48,6 +48,9 @@ class CSharpGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
                 const grpc::string &parameter,
                 grpc::protobuf::compiler::GeneratorContext *context,
                 grpc::string *error) const {
+    std::vector<std::pair<grpc::string, grpc::string> > options;
+    grpc::protobuf::compiler::ParseGeneratorParameter(parameter, &options);
+
     grpc::string code = grpc_csharp_generator::GetServices(file);
     if (code.size() == 0) {
       return true;  // don't generate a file if there are no services

--- a/src/csharp/Grpc.Examples/MathGrpc.cs
+++ b/src/csharp/Grpc.Examples/MathGrpc.cs
@@ -168,6 +168,12 @@ namespace Math {
       }
     }
 
+    // creates a new client
+    public static MathClient NewClient(Channel channel)
+    {
+      return new MathClient(channel);
+    }
+
     // creates service definition that can be registered with a server
     #pragma warning disable 0618
     public static ServerServiceDefinition BindService(IMath serviceImpl)
@@ -190,12 +196,6 @@ namespace Math {
           .AddMethod(__Method_DivMany, serviceImpl.DivMany)
           .AddMethod(__Method_Fib, serviceImpl.Fib)
           .AddMethod(__Method_Sum, serviceImpl.Sum).Build();
-    }
-
-    // creates a new client
-    public static MathClient NewClient(Channel channel)
-    {
-      return new MathClient(channel);
     }
 
   }

--- a/src/csharp/Grpc.HealthCheck/HealthGrpc.cs
+++ b/src/csharp/Grpc.HealthCheck/HealthGrpc.cs
@@ -97,6 +97,12 @@ namespace Grpc.Health.V1 {
       }
     }
 
+    // creates a new client
+    public static HealthClient NewClient(Channel channel)
+    {
+      return new HealthClient(channel);
+    }
+
     // creates service definition that can be registered with a server
     #pragma warning disable 0618
     public static ServerServiceDefinition BindService(IHealth serviceImpl)
@@ -113,12 +119,6 @@ namespace Grpc.Health.V1 {
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_Check, serviceImpl.Check).Build();
-    }
-
-    // creates a new client
-    public static HealthClient NewClient(Channel channel)
-    {
-      return new HealthClient(channel);
     }
 
   }

--- a/src/csharp/Grpc.IntegrationTesting/MetricsGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/MetricsGrpc.cs
@@ -121,6 +121,12 @@ namespace Grpc.Testing {
       }
     }
 
+    // creates a new client
+    public static MetricsServiceClient NewClient(Channel channel)
+    {
+      return new MetricsServiceClient(channel);
+    }
+
     // creates service definition that can be registered with a server
     #pragma warning disable 0618
     public static ServerServiceDefinition BindService(IMetricsService serviceImpl)
@@ -139,12 +145,6 @@ namespace Grpc.Testing {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_GetAllGauges, serviceImpl.GetAllGauges)
           .AddMethod(__Method_GetGauge, serviceImpl.GetGauge).Build();
-    }
-
-    // creates a new client
-    public static MetricsServiceClient NewClient(Channel channel)
-    {
-      return new MetricsServiceClient(channel);
     }
 
   }

--- a/src/csharp/Grpc.IntegrationTesting/ServicesGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ServicesGrpc.cs
@@ -120,6 +120,12 @@ namespace Grpc.Testing {
       }
     }
 
+    // creates a new client
+    public static BenchmarkServiceClient NewClient(Channel channel)
+    {
+      return new BenchmarkServiceClient(channel);
+    }
+
     // creates service definition that can be registered with a server
     #pragma warning disable 0618
     public static ServerServiceDefinition BindService(IBenchmarkService serviceImpl)
@@ -138,12 +144,6 @@ namespace Grpc.Testing {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_UnaryCall, serviceImpl.UnaryCall)
           .AddMethod(__Method_StreamingCall, serviceImpl.StreamingCall).Build();
-    }
-
-    // creates a new client
-    public static BenchmarkServiceClient NewClient(Channel channel)
-    {
-      return new BenchmarkServiceClient(channel);
     }
 
   }
@@ -320,6 +320,12 @@ namespace Grpc.Testing {
       }
     }
 
+    // creates a new client
+    public static WorkerServiceClient NewClient(Channel channel)
+    {
+      return new WorkerServiceClient(channel);
+    }
+
     // creates service definition that can be registered with a server
     #pragma warning disable 0618
     public static ServerServiceDefinition BindService(IWorkerService serviceImpl)
@@ -342,12 +348,6 @@ namespace Grpc.Testing {
           .AddMethod(__Method_RunClient, serviceImpl.RunClient)
           .AddMethod(__Method_CoreCount, serviceImpl.CoreCount)
           .AddMethod(__Method_QuitWorker, serviceImpl.QuitWorker).Build();
-    }
-
-    // creates a new client
-    public static WorkerServiceClient NewClient(Channel channel)
-    {
-      return new WorkerServiceClient(channel);
     }
 
   }

--- a/src/csharp/Grpc.IntegrationTesting/TestGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/TestGrpc.cs
@@ -227,6 +227,12 @@ namespace Grpc.Testing {
       }
     }
 
+    // creates a new client
+    public static TestServiceClient NewClient(Channel channel)
+    {
+      return new TestServiceClient(channel);
+    }
+
     // creates service definition that can be registered with a server
     #pragma warning disable 0618
     public static ServerServiceDefinition BindService(ITestService serviceImpl)
@@ -253,12 +259,6 @@ namespace Grpc.Testing {
           .AddMethod(__Method_StreamingInputCall, serviceImpl.StreamingInputCall)
           .AddMethod(__Method_FullDuplexCall, serviceImpl.FullDuplexCall)
           .AddMethod(__Method_HalfDuplexCall, serviceImpl.HalfDuplexCall).Build();
-    }
-
-    // creates a new client
-    public static TestServiceClient NewClient(Channel channel)
-    {
-      return new TestServiceClient(channel);
     }
 
   }
@@ -350,6 +350,12 @@ namespace Grpc.Testing {
       }
     }
 
+    // creates a new client
+    public static UnimplementedServiceClient NewClient(Channel channel)
+    {
+      return new UnimplementedServiceClient(channel);
+    }
+
     // creates service definition that can be registered with a server
     #pragma warning disable 0618
     public static ServerServiceDefinition BindService(IUnimplementedService serviceImpl)
@@ -366,12 +372,6 @@ namespace Grpc.Testing {
     {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_UnimplementedCall, serviceImpl.UnimplementedCall).Build();
-    }
-
-    // creates a new client
-    public static UnimplementedServiceClient NewClient(Channel channel)
-    {
-      return new UnimplementedServiceClient(channel);
     }
 
   }
@@ -498,6 +498,12 @@ namespace Grpc.Testing {
       }
     }
 
+    // creates a new client
+    public static ReconnectServiceClient NewClient(Channel channel)
+    {
+      return new ReconnectServiceClient(channel);
+    }
+
     // creates service definition that can be registered with a server
     #pragma warning disable 0618
     public static ServerServiceDefinition BindService(IReconnectService serviceImpl)
@@ -516,12 +522,6 @@ namespace Grpc.Testing {
       return ServerServiceDefinition.CreateBuilder(__ServiceName)
           .AddMethod(__Method_Start, serviceImpl.Start)
           .AddMethod(__Method_Stop, serviceImpl.Stop).Build();
-    }
-
-    // creates a new client
-    public static ReconnectServiceClient NewClient(Channel channel)
-    {
-      return new ReconnectServiceClient(channel);
     }
 
   }


### PR DESCRIPTION
Adds these gRPC C# codegen options:
- "no_client"  disables generating client-side stubs
- "no_server" disables generating server-side stubs
- "internal_access" generated the entire service class with "internal" visibility (same name of option as in protobuf C#).

Fixes #6077.
Fixes #1999.

