### PR TITLE
Add --compiler python3.4 option to run_tests.py (enable running test using python3)

### DIFF
--- a/tools/dockerfile/grpc_interop_python/build_interop.sh
+++ b/tools/dockerfile/grpc_interop_python/build_interop.sh
@@ -39,8 +39,4 @@ cp -r /var/local/jenkins/service_account $HOME || true
 
 cd /var/local/git/grpc
 
-make
-
-# build Python interop client and server
-CONFIG=opt ./tools/run_tests/build_python.sh
-
+tools/run_tests/run_tests.py -l python -c opt --build_only

--- a/tools/run_tests/build_python.sh
+++ b/tools/run_tests/build_python.sh
@@ -33,6 +33,8 @@ set -ex
 # change to grpc repo root
 cd $(dirname $0)/../..
 
+TOX_PYTHON_ENV="$1"
+
 ROOT=`pwd`
 export LD_LIBRARY_PATH=$ROOT/libs/$CONFIG
 export DYLD_LIBRARY_PATH=$ROOT/libs/$CONFIG
@@ -47,9 +49,9 @@ then
   export GRPC_PYTHON_ENABLE_CYTHON_TRACING=1
 fi
 
-tox --notest
+tox -e ${TOX_PYTHON_ENV} --notest
 
-$ROOT/.tox/py27/bin/python $ROOT/setup.py build
-$ROOT/.tox/py27/bin/python $ROOT/setup.py build_py
-$ROOT/.tox/py27/bin/python $ROOT/setup.py build_ext --inplace
-$ROOT/.tox/py27/bin/python $ROOT/setup.py gather --test
+$ROOT/.tox/${TOX_PYTHON_ENV}/bin/python $ROOT/setup.py build
+$ROOT/.tox/${TOX_PYTHON_ENV}/bin/python $ROOT/setup.py build_py
+$ROOT/.tox/${TOX_PYTHON_ENV}/bin/python $ROOT/setup.py build_ext --inplace
+$ROOT/.tox/${TOX_PYTHON_ENV}/bin/python $ROOT/setup.py gather --test

--- a/tools/run_tests/run_python.sh
+++ b/tools/run_tests/run_python.sh
@@ -33,6 +33,8 @@ set -ex
 # change to grpc repo root
 cd $(dirname $0)/../..
 
+TOX_PYTHON_ENV="$1"
+
 ROOT=`pwd`
 export LD_LIBRARY_PATH=$ROOT/libs/$CONFIG
 export DYLD_LIBRARY_PATH=$ROOT/libs/$CONFIG
@@ -45,9 +47,9 @@ export GRPC_PYTHON_USE_PRECOMPILED_BINARIES=0
 if [ "$CONFIG" = "gcov" ]
 then
   export GRPC_PYTHON_ENABLE_CYTHON_TRACING=1
-  tox
+  tox -e ${TOX_PYTHON_ENV}
 else
-  $ROOT/.tox/py27/bin/python $ROOT/setup.py test_lite
+  $ROOT/.tox/${TOX_PYTHON_ENV}/bin/python $ROOT/setup.py test_lite
 fi
 
 mkdir -p $ROOT/reports

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # GRPC Python tox (test environment) settings
 [tox]
 skipsdist = true
-envlist = py27
+envlist = py27,py34
 
 [testenv]
 setenv =


### PR DESCRIPTION
Enable running unit tests using both python2.7 and python3.4.

`run_tests.py -l python` or `run_tests.py -l python --compiler python2.7`  builds and runs all the test using python2.7 (e.g. python2.7 stays the default).

`run_tests.py -l python --compiler python3.4`  builds and runs using python 3.4   (Currently, the build succeeds, but many of the tests fail. Fixing the tests in not the objective in this PR).