### PR TITLE
Added node plugin to grpc-tools npm package, updated build_package_node

### DIFF
--- a/src/node/tools/bin/protoc_plugin.js
+++ b/src/node/tools/bin/protoc_plugin.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/*
+ *
+ * Copyright 2015, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/**
+ * This file is required because package.json cannot reference a file that
+ * is not distributed with the package, and we use node-pre-gyp to distribute
+ * the plugin binary
+ */
+
+'use strict';
+
+var path = require('path');
+var execFile = require('child_process').execFile;
+
+var protoc = path.resolve(__dirname, 'grpc_node_plugin');
+
+execFile(protoc, process.argv.slice(2), function(error, stdout, stderr) {
+  if (error) {
+    throw error;
+  }
+  console.log(stdout);
+  console.log(stderr);
+});

--- a/src/node/tools/package.json
+++ b/src/node/tools/package.json
@@ -16,7 +16,8 @@
     }
   ],
   "bin": {
-    "grpc-tools-protoc": "./bin/protoc.js"
+    "grpc-tools-protoc": "./bin/protoc.js",
+    "grpc-tools-plugin": "./bin/protoc_plugin.js"
   },
   "scripts": {
     "install": "./node_modules/.bin/node-pre-gyp install"
@@ -32,6 +33,7 @@
   "files": [
     "index.js",
     "bin/protoc.js",
+    "bin/protoc_plugin.js",
     "LICENSE"
   ],
   "main": "index.js"

--- a/templates/src/node/tools/package.json.template
+++ b/templates/src/node/tools/package.json.template
@@ -18,7 +18,8 @@
       }
     ],
     "bin": {
-      "grpc-tools-protoc": "./bin/protoc.js"
+      "grpc-tools-protoc": "./bin/protoc.js",
+      "grpc-tools-plugin": "./bin/protoc_plugin.js"
     },
     "scripts": {
       "install": "./node_modules/.bin/node-pre-gyp install"
@@ -34,6 +35,7 @@
     "files": [
       "index.js",
       "bin/protoc.js",
+      "bin/protoc_plugin.js",
       "LICENSE"
     ],
     "main": "index.js"

--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -78,6 +78,7 @@ for arch in {x86,x64}; do
       *)
         node_plat=$plat
     esac
+    rm bin/*
     input_dir="$EXTERNAL_GIT_ROOT/architecture=$arch,language=protoc,platform=$plat/artifacts"
     cp $input_dir/protoc* bin/
     cp $input_dir/grpc_node_plugin* bin/

--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -53,7 +53,7 @@ cd src/node/tools
 npm update
 npm pack
 cp grpc-tools-*.tgz $artifacts/
-tools_version=$(npm list | grep -oP '(?<=grpc-tools@)\\S+')
+tools_version=$(npm list | grep -oP '(?<=grpc-tools@)\S+')
 
 output_dir=$artifacts/grpc-precompiled-binaries/node/grpc-tools/$tools_version
 mkdir -p $output_dir

--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -68,8 +68,8 @@ for arch in {x86,x64}; do
         node_plat=$plat
     esac
     input_dir="$EXTERNAL_GIT_ROOT/architecture=$arch,language=protoc,platform=$plat/artifacts"
-    cp $input_dir/protoc bin/
-    cp $input_dir/grpc_node_plugin bin/
+    cp $input_dir/protoc* bin/
+    cp $input_dir/grpc_node_plugin* bin/
     # For now, this will have to be manually uploaded to a folder with the
     # correct package version
     output_dir=$artifacts/grpc-precompiled-binaries/node/grpc-tools/

--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -35,7 +35,7 @@ set -ex
 
 cd $(dirname $0)/../..
 
-artifacts=$cwd/artifacts
+artifacts=$(pwd)/artifacts
 
 mkdir -p $artifacts
 cp -r $EXTERNAL_GIT_ROOT/architecture={x86,x64},language=node,platform={windows,linux,macos}/artifacts/* $artifacts/ || true

--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -35,10 +35,49 @@ set -ex
 
 cd $(dirname $0)/../..
 
-mkdir -p artifacts/
-cp -r $EXTERNAL_GIT_ROOT/architecture={x86,x64},language=node,platform={windows,linux,macos}/artifacts/* artifacts/ || true
+artifacts=$cwd/artifacts
+
+mkdir -p $artifacts
+cp -r $EXTERNAL_GIT_ROOT/architecture={x86,x64},language=node,platform={windows,linux,macos}/artifacts/* $artifacts/ || true
 
 npm update
 npm pack
 
-cp grpc-*.tgz artifacts/grpc.tgz
+cp grpc-*.tgz $artifacts/grpc.tgz
+
+mkdir -p bin
+
+for arch in {x86,x64}; do
+  case arch in
+    x86)
+      node_arch=ia32
+      ;;
+    *)
+      node_arch=$arch
+      ;;
+  esac
+  for plat in {windows,linux,macos}; do
+    case plat in
+      windows)
+        node_plat=win32
+        ;;
+      macos)
+        node_plat=darwin
+        ;;
+      *)
+        node_plat=$plat
+    esac
+    input_dir="$EXTERNAL_GIT_ROOT/architecture=$arch,language=protoc,platform=$plat/artifacts"
+    cp $input_dir/protoc bin/
+    cp $input_dir/grpc_node_plugin bin/
+    # For now, this will have to be manually uploaded to a folder with the
+    # correct package version
+    output_dir=$artifacts/grpc-precompiled-binaries/node/grpc-tools/
+    tar -czf $output_dir/$node_plat-$node_arch.tar.gz bin/
+  done
+done
+
+cd src/node/tools
+npm update
+npm pack
+cp grpc-tools-*.tgz $artifacts/

--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -77,6 +77,7 @@ for arch in {x86,x64}; do
         ;;
       *)
         node_plat=$plat
+        ;;
     esac
     rm bin/*
     input_dir="$EXTERNAL_GIT_ROOT/architecture=$arch,language=protoc,platform=$plat/artifacts"

--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -72,7 +72,8 @@ for arch in {x86,x64}; do
     cp $input_dir/grpc_node_plugin* bin/
     # For now, this will have to be manually uploaded to a folder with the
     # correct package version
-    output_dir=$artifacts/grpc-precompiled-binaries/node/grpc-tools/
+    output_dir=$artifacts/grpc-precompiled-binaries/node/grpc-tools
+    mkdir -p $output_dir
     tar -czf $output_dir/$node_plat-$node_arch.tar.gz bin/
   done
 done


### PR DESCRIPTION
This makes the gRPC_build_packages job build the grpc-tools npm package and the corresponding binary artifacts. This fixes #5982.