### PR TITLE
Tiny fix to check_include_guards script

### DIFF
--- a/tools/distrib/check_include_guards.py
+++ b/tools/distrib/check_include_guards.py
@@ -97,6 +97,7 @@ class GuardValidator(object):
     match = self.ifndef_re.search(fcontents)
     if not match:
       print 'something drastically wrong with: %s' % fpath
+      return False # failed
     if match.lastindex is None:
       # No ifndef. Request manual addition with hints
       self.fail(fpath, match.re, match.string, '', '', False)


### PR DESCRIPTION
Otherwise, next line will fail with the equivalent of a null pointer exception when trying to access `match.lastindex`