### PR TITLE
Add 64bit Android support

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -117,7 +117,11 @@
 #elif defined(ANDROID) || defined(__ANDROID__)
 #define GPR_PLATFORM_STRING "android"
 #define GPR_ANDROID 1
+#ifdef _LP64
+#define GPR_ARCH_64 1
+#else /* _LP64 */
 #define GPR_ARCH_32 1
+#endif /* _LP64 */
 #define GPR_CPU_LINUX 1
 #define GPR_GCC_SYNC 1
 #define GPR_GCC_TLS 1


### PR DESCRIPTION
Since Android Lollipop (5.0) Android has 64bit support. This config
change is needed to support these configurations. The code have been
tested with AArch64 and no other changes needed to get the helloworld
example working.