### PR TITLE
Fix build error of SwiftSample project on Xcode 7.3 (Swift 2.2)

### DIFF
--- a/src/objective-c/examples/SwiftSample/ViewController.swift
+++ b/src/objective-c/examples/SwiftSample/ViewController.swift
@@ -71,7 +71,7 @@ class ViewController: UIViewController {
       NSLog("2. Response trailers: \(RPC.responseTrailers)")
     }
 
-    RPC.requestHeaders["My-Header"] = "My value"
+    RPC.requestHeaders.setObject("My value", forKey: "My-Header")
 
     RPC.start()
 
@@ -84,7 +84,7 @@ class ViewController: UIViewController {
 
     let call = GRPCCall(host: RemoteHost, path: method.HTTPPath, requestsWriter: requestsWriter)
 
-    call.requestHeaders["My-Header"] = "My value"
+    call.requestHeaders.setObject("My value", forKey: "My-Header")
 
     call.startWithWriteable(GRXWriteable { response, error in
       if let response = response as? NSData {


### PR DESCRIPTION
This PR fixes the compile error below:

```swift
var RPC : ProtoRPC!
RPC = service.RPCToUnaryCallWithRequest(request) { ... }

// Error: Cannot assign through subscript: subscript is get-only
RPC.requestHeaders["My-Header"] = "My value"
```