### PR TITLE
Load default roots.pem in Ruby via grpc_set_ssl_roots_override_callback

### DIFF
--- a/src/ruby/ext/grpc/rb_channel_credentials.c
+++ b/src/ruby/ext/grpc/rb_channel_credentials.c
@@ -254,6 +254,7 @@ static grpc_ssl_roots_override_result get_ssl_roots_override(
 static VALUE grpc_rb_set_default_roots_pem(VALUE self, VALUE roots) {
   char *roots_ptr = StringValueCStr(roots);
   size_t length = strlen(roots_ptr);
+  (void)self;
   pem_root_certs = gpr_malloc((length + 1) * sizeof(char));
   memcpy(pem_root_certs, roots_ptr, length + 1);
   return Qnil;

--- a/src/ruby/lib/grpc.rb
+++ b/src/ruby/lib/grpc.rb
@@ -28,9 +28,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ssl_roots_path = File.expand_path('../../../../etc/roots.pem', __FILE__)
-unless ENV['GRPC_DEFAULT_SSL_ROOTS_FILE_PATH']
-  ENV['GRPC_DEFAULT_SSL_ROOTS_FILE_PATH'] = ssl_roots_path
-end
 
 require_relative 'grpc/errors'
 require_relative 'grpc/grpc'
@@ -42,3 +39,11 @@ require_relative 'grpc/generic/active_call'
 require_relative 'grpc/generic/client_stub'
 require_relative 'grpc/generic/service'
 require_relative 'grpc/generic/rpc_server'
+
+begin
+  file = File.open(ssl_roots_path)
+  roots = file.read
+  GRPC::Core::ChannelCredentials.set_default_roots_pem roots
+ensure
+  file.close
+end


### PR DESCRIPTION
This fixes #5709.