### PR TITLE
Switch chttp2 to use an atomic to manage the global lock

### DIFF
--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -315,7 +315,7 @@ struct grpc_chttp2_transport {
     gpr_mu mu;
 
     /** is a thread currently in the global lock */
-    bool global_active;
+    gpr_atm global_active_atm;
     /** is a thread currently writing */
     bool writing_active;
     /** is a thread currently parsing */

--- a/test/core/util/test_config.c
+++ b/test/core/util/test_config.c
@@ -210,7 +210,7 @@ static void install_crash_handler() {
 #include <stdio.h>
 #include <string.h>
 
-static char g_alt_stack[MINSIGSTKSZ];
+static char g_alt_stack[GPR_MAX(MINSIGSTKSZ, 65536)];
 
 #define MAX_FRAMES 32
 

--- a/test/cpp/qps/client.h
+++ b/test/cpp/qps/client.h
@@ -40,6 +40,7 @@
 
 #include <grpc++/support/byte_buffer.h>
 #include <grpc++/support/slice.h>
+#include <grpc++/support/channel_arguments.h>
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 
@@ -280,7 +281,7 @@ class ClientImpl : public Client {
         create_stub_(create_stub) {
     for (int i = 0; i < config.client_channels(); i++) {
       channels_[i].init(config.server_targets(i % config.server_targets_size()),
-                        config, create_stub_);
+                        config, create_stub_, i);
     }
 
     ClientRequestCreator<RequestType> create_req(&request_,
@@ -303,14 +304,16 @@ class ClientImpl : public Client {
     }
     void init(const grpc::string& target, const ClientConfig& config,
               std::function<std::unique_ptr<StubType>(std::shared_ptr<Channel>)>
-                  create_stub) {
+                  create_stub, int shard) {
       // We have to use a 2-phase init like this with a default
       // constructor followed by an initializer function to make
       // old compilers happy with using this in std::vector
+      ChannelArguments args;
+      args.SetInt("shard", shard);
       channel_ = CreateTestChannel(
           target, config.security_params().server_host_override(),
           config.has_security_params(),
-          !config.security_params().use_test_ca());
+          !config.security_params().use_test_ca(), std::shared_ptr<CallCredentials>(), args);
       stub_ = create_stub(channel_);
     }
     Channel* get_channel() { return channel_.get(); }

--- a/test/cpp/qps/client.h
+++ b/test/cpp/qps/client.h
@@ -39,8 +39,8 @@
 #include <vector>
 
 #include <grpc++/support/byte_buffer.h>
-#include <grpc++/support/slice.h>
 #include <grpc++/support/channel_arguments.h>
+#include <grpc++/support/slice.h>
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 
@@ -304,16 +304,17 @@ class ClientImpl : public Client {
     }
     void init(const grpc::string& target, const ClientConfig& config,
               std::function<std::unique_ptr<StubType>(std::shared_ptr<Channel>)>
-                  create_stub, int shard) {
+                  create_stub,
+              int shard) {
       // We have to use a 2-phase init like this with a default
       // constructor followed by an initializer function to make
       // old compilers happy with using this in std::vector
       ChannelArguments args;
-      args.SetInt("shard", shard);
+      args.SetInt("shard_to_ensure_no_subchannel_merges", shard);
       channel_ = CreateTestChannel(
           target, config.security_params().server_host_override(),
-          config.has_security_params(),
-          !config.security_params().use_test_ca(), std::shared_ptr<CallCredentials>(), args);
+          config.has_security_params(), !config.security_params().use_test_ca(),
+          std::shared_ptr<CallCredentials>(), args);
       stub_ = create_stub(channel_);
     }
     Channel* get_channel() { return channel_.get(); }


### PR DESCRIPTION
Built on #6368

Saves some passes through the transport mutex, improving latency and contention