### PR TITLE
Stress test fixes

### DIFF
--- a/include/grpc++/impl/codegen/call.h
+++ b/include/grpc++/impl/codegen/call.h
@@ -281,10 +281,9 @@ class CallOpRecvMessage {
     if (message_ == nullptr) return;
     if (recv_buf_) {
       if (*status) {
-        got_message = true;
-        *status = SerializationTraits<R>::Deserialize(recv_buf_, message_,
-                                                      max_message_size)
-                      .ok();
+        got_message = *status = SerializationTraits<R>::Deserialize(
+                                    recv_buf_, message_, max_message_size)
+                                    .ok();
       } else {
         got_message = false;
         g_core_codegen_interface->grpc_byte_buffer_destroy(recv_buf_);

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -321,7 +321,8 @@ struct grpc_chttp2_transport {
     /** is a thread currently parsing */
     bool parsing_active;
 
-    grpc_chttp2_executor_action_header *pending_actions;
+    grpc_chttp2_executor_action_header *pending_actions_head;
+    grpc_chttp2_executor_action_header *pending_actions_tail;
   } executor;
 
   /** is the transport destroying itself? */


### PR DESCRIPTION
- properly fail a Read() on a stream if we fail to parse a protobuf
- fix an ordering problem with the chttp2 transport global lock, whereby
  a sequence of two operations could be swapped - this resulted in
  slices being returned to the upper layers in the wrong order,
  corrupting data

Fixes #6370