### PR TITLE
Allows for multiple services in a single proto file.

### DIFF
--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -221,17 +221,17 @@ void PrintMethodImplementations(Printer *printer,
                                 {"package", service->file()->package()}};
 
     printer.Print(vars,
-                  "static NSString *const kPackageName = @\"$package$\";\n");
+                  "static NSString *const kPackageName_$package$ = @\"$package$\";\n");
     printer.Print(
-        vars, "static NSString *const kServiceName = @\"$service_name$\";\n\n");
+        vars, "static NSString *const kServiceName_$service_name$ = @\"$service_name$\";\n\n");
 
     printer.Print(vars, "@implementation $service_class$\n\n");
 
     printer.Print("// Designated initializer\n");
     printer.Print("- (instancetype)initWithHost:(NSString *)host {\n");
-    printer.Print(
+    printer.Print(vars,
         "  return (self = [super initWithHost:host"
-        " packageName:kPackageName serviceName:kServiceName]);\n");
+        " packageName:kPackageName_$package$ serviceName:kServiceName_$service_name$]);\n");
     printer.Print("}\n\n");
     printer.Print(
         "// Override superclass initializer to disallow different"


### PR DESCRIPTION
Prevents kPackageName/kServiceName redefinition.