### PR TITLE
Allows for multiple services in a single proto file.

### DIFF
--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -219,19 +219,16 @@ void PrintMethodImplementations(Printer *printer,
     map< ::grpc::string,::grpc::string> vars = {{"service_name", service->name()},
                                 {"service_class", ServiceClassName(service)},
                                 {"package", service->file()->package()}};
-
-    printer.Print(vars,
-                  "static NSString *const kPackageName = @\"$package$\";\n");
     printer.Print(
-        vars, "static NSString *const kServiceName = @\"$service_name$\";\n\n");
+        vars, "static NSString *const kServiceName_$service_name$ = @\"$service_name$\";\n\n");
 
     printer.Print(vars, "@implementation $service_class$\n\n");
 
     printer.Print("// Designated initializer\n");
     printer.Print("- (instancetype)initWithHost:(NSString *)host {\n");
-    printer.Print(
+    printer.Print(vars,
         "  return (self = [super initWithHost:host"
-        " packageName:kPackageName serviceName:kServiceName]);\n");
+        " packageName:kPackageName serviceName:kServiceName_$service_name$]);\n");
     printer.Print("}\n\n");
     printer.Print(
         "// Override superclass initializer to disallow different"

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -95,9 +95,10 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
       ::grpc::string imports = ::grpc::string("#import \"") + file_name +
         ".pbrpc.h\"\n\n"
         "#import <ProtoRPC/ProtoRPC.h>\n"
-        "#import <RxLibrary/GRXWriter+Immediate.h>\n";
+        "#import <RxLibrary/GRXWriter+Immediate.h>\n\n";
 
-      ::grpc::string definitions;
+      ::grpc::string definitions = "static NSString *const kPackageName = @\"" +
+        file->package() + "\";\n";
       for (int i = 0; i < file->service_count(); i++) {
         const grpc::protobuf::ServiceDescriptor *service = file->service(i);
         definitions += grpc_objective_c_generator::GetSource(service);


### PR DESCRIPTION
Avoids kPackageName/kServiceName redefinition.
