### PR TITLE
Specify google-protobuf version in node example package.json

### DIFF
--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "async": "^1.5.2",
     "grpc": "0.13.0",
-    "google-protobuf": "*",
+    "google-protobuf": "^3.0.0-alpha.5",
     "lodash": "^4.6.1",
     "minimist": "^1.2.0"
   }


### PR DESCRIPTION
to fix the example code 'npm install' failure.