### PR TITLE
Made ruby plugin support empty package names

### DIFF
--- a/src/compiler/ruby_generator.cc
+++ b/src/compiler/ruby_generator.cc
@@ -98,8 +98,8 @@ void PrintService(const ServiceDescriptor *service, const grpc::string &package,
   out->Print("self.marshal_class_method = :encode\n");
   out->Print("self.unmarshal_class_method = :decode\n");
   std::map<grpc::string, grpc::string> pkg_vars =
-      ListToDict({"service_full_namename", service->full_name()});
-  out->Print(pkg_vars, "self.service_name = '$pkg.name$.$service.name$'\n");
+      ListToDict({"service_full_name", service->full_name()});
+  out->Print(pkg_vars, "self.service_name = '$service_full_name$'\n");
   out->Print("\n");
   for (int i = 0; i < service->method_count(); ++i) {
     PrintMethod(service->method(i), package, out);

--- a/src/compiler/ruby_generator.cc
+++ b/src/compiler/ruby_generator.cc
@@ -98,7 +98,7 @@ void PrintService(const ServiceDescriptor *service, const grpc::string &package,
   out->Print("self.marshal_class_method = :encode\n");
   out->Print("self.unmarshal_class_method = :decode\n");
   std::map<grpc::string, grpc::string> pkg_vars =
-      ListToDict({"service.name", service->name(), "pkg.name", package, });
+      ListToDict({"service_full_namename", service->full_name()});
   out->Print(pkg_vars, "self.service_name = '$pkg.name$.$service.name$'\n");
   out->Print("\n");
   for (int i = 0; i < service->method_count(); ++i) {


### PR DESCRIPTION
This fixes #4984.

I'm pretty sure this is the only case where having an empty package actually could cause a problem. Other places use a function that explicitly removes leading periods.