### PR TITLE
PHP: stress test client

### DIFF
--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -388,141 +388,148 @@ function timeoutOnSleepingServer($stub)
              'Call status was not DEADLINE_EXCEEDED');
 }
 
-$args = getopt('', ['server_host:', 'server_port:', 'test_case:',
-                    'use_tls::', 'use_test_ca::',
-                    'server_host_override:', 'oauth_scope:',
-                    'default_service_account:', ]);
-if (!array_key_exists('server_host', $args)) {
-    throw new Exception('Missing argument: --server_host is required');
-}
-if (!array_key_exists('server_port', $args)) {
-    throw new Exception('Missing argument: --server_port is required');
-}
-if (!array_key_exists('test_case', $args)) {
-    throw new Exception('Missing argument: --test_case is required');
-}
-
-if ($args['server_port'] == 443) {
-    $server_address = $args['server_host'];
-} else {
-    $server_address = $args['server_host'].':'.$args['server_port'];
-}
-
-$test_case = $args['test_case'];
-
-$host_override = 'foo.test.google.fr';
-if (array_key_exists('server_host_override', $args)) {
-    $host_override = $args['server_host_override'];
-}
-
-$use_tls = false;
-if (array_key_exists('use_tls', $args) &&
-    $args['use_tls'] != 'false') {
-    $use_tls = true;
-}
-
-$use_test_ca = false;
-if (array_key_exists('use_test_ca', $args) &&
-    $args['use_test_ca'] != 'false') {
-    $use_test_ca = true;
-}
-
-$opts = [];
-
-if ($use_tls) {
-    if ($use_test_ca) {
-        $ssl_credentials = Grpc\ChannelCredentials::createSsl(
-            file_get_contents(dirname(__FILE__).'/../data/ca.pem'));
-    } else {
-        $ssl_credentials = Grpc\ChannelCredentials::createSsl();
+function interop_main($args)
+{
+    if (!array_key_exists('server_host', $args)) {
+        throw new Exception('Missing argument: --server_host is required');
     }
-    $opts['credentials'] = $ssl_credentials;
-    $opts['grpc.ssl_target_name_override'] = $host_override;
-} else {
-    $opts['credentials'] = Grpc\ChannelCredentials::createInsecure();
-}
+    if (!array_key_exists('server_port', $args)) {
+        throw new Exception('Missing argument: --server_port is required');
+    }
+    if (!array_key_exists('test_case', $args)) {
+        throw new Exception('Missing argument: --test_case is required');
+    }
 
-if (in_array($test_case, ['service_account_creds',
-    'compute_engine_creds', 'jwt_token_creds', ])) {
-    if ($test_case == 'jwt_token_creds') {
-        $auth_credentials = ApplicationDefaultCredentials::getCredentials();
+    if ($args['server_port'] == 443) {
+        $server_address = $args['server_host'];
     } else {
+        $server_address = $args['server_host'].':'.$args['server_port'];
+    }
+
+    $test_case = $args['test_case'];
+
+    $host_override = 'foo.test.google.fr';
+    if (array_key_exists('server_host_override', $args)) {
+        $host_override = $args['server_host_override'];
+    }
+
+    $use_tls = false;
+    if (array_key_exists('use_tls', $args) &&
+        $args['use_tls'] != 'false') {
+        $use_tls = true;
+    }
+
+    $use_test_ca = false;
+    if (array_key_exists('use_test_ca', $args) &&
+        $args['use_test_ca'] != 'false') {
+        $use_test_ca = true;
+    }
+
+    $opts = [];
+
+    if ($use_tls) {
+        if ($use_test_ca) {
+            $ssl_credentials = Grpc\ChannelCredentials::createSsl(
+                file_get_contents(dirname(__FILE__).'/../data/ca.pem'));
+        } else {
+            $ssl_credentials = Grpc\ChannelCredentials::createSsl();
+        }
+        $opts['credentials'] = $ssl_credentials;
+        $opts['grpc.ssl_target_name_override'] = $host_override;
+    } else {
+        $opts['credentials'] = Grpc\ChannelCredentials::createInsecure();
+    }
+
+    if (in_array($test_case, ['service_account_creds',
+                              'compute_engine_creds', 'jwt_token_creds', ])) {
+        if ($test_case == 'jwt_token_creds') {
+            $auth_credentials = ApplicationDefaultCredentials::getCredentials();
+        } else {
+            $auth_credentials = ApplicationDefaultCredentials::getCredentials(
+                $args['oauth_scope']
+            );
+        }
+        $opts['update_metadata'] = $auth_credentials->getUpdateMetadataFunc();
+    }
+
+    if ($test_case == 'oauth2_auth_token') {
         $auth_credentials = ApplicationDefaultCredentials::getCredentials(
             $args['oauth_scope']
         );
+        $token = $auth_credentials->fetchAuthToken();
+        $update_metadata =
+            function ($metadata,
+                      $authUri = null,
+                      ClientInterface $client = null) use ($token) {
+                $metadata_copy = $metadata;
+                $metadata_copy[CredentialsLoader::AUTH_METADATA_KEY] =
+                    [sprintf('%s %s',
+                             $token['token_type'],
+                             $token['access_token'])];
+
+                return $metadata_copy;
+            };
+        $opts['update_metadata'] = $update_metadata;
     }
-    $opts['update_metadata'] = $auth_credentials->getUpdateMetadataFunc();
+
+    $stub = new grpc\testing\TestServiceClient($server_address, $opts);
+
+    echo "Connecting to $server_address\n";
+    echo "Running test case $test_case\n";
+
+    switch ($test_case) {
+        case 'empty_unary':
+            emptyUnary($stub);
+            break;
+        case 'large_unary':
+            largeUnary($stub);
+            break;
+        case 'client_streaming':
+            clientStreaming($stub);
+            break;
+        case 'server_streaming':
+            serverStreaming($stub);
+            break;
+        case 'ping_pong':
+            pingPong($stub);
+            break;
+        case 'empty_stream':
+            emptyStream($stub);
+            break;
+        case 'cancel_after_begin':
+            cancelAfterBegin($stub);
+            break;
+        case 'cancel_after_first_response':
+            cancelAfterFirstResponse($stub);
+            break;
+        case 'timeout_on_sleeping_server':
+            timeoutOnSleepingServer($stub);
+            break;
+        case 'service_account_creds':
+            serviceAccountCreds($stub, $args);
+            break;
+        case 'compute_engine_creds':
+            computeEngineCreds($stub, $args);
+            break;
+        case 'jwt_token_creds':
+            jwtTokenCreds($stub, $args);
+            break;
+        case 'oauth2_auth_token':
+            oauth2AuthToken($stub, $args);
+            break;
+        case 'per_rpc_creds':
+            perRpcCreds($stub, $args);
+            break;
+        default:
+            echo "Unsupported test case $test_case\n";
+            exit(1);
+    }
 }
 
-if ($test_case == 'oauth2_auth_token') {
-    $auth_credentials = ApplicationDefaultCredentials::getCredentials(
-        $args['oauth_scope']
-    );
-    $token = $auth_credentials->fetchAuthToken();
-    $update_metadata =
-        function ($metadata,
-                  $authUri = null,
-                  ClientInterface $client = null) use ($token) {
-            $metadata_copy = $metadata;
-            $metadata_copy[CredentialsLoader::AUTH_METADATA_KEY] =
-                [sprintf('%s %s',
-                         $token['token_type'],
-                         $token['access_token'])];
-
-            return $metadata_copy;
-        };
-    $opts['update_metadata'] = $update_metadata;
-}
-
-$stub = new grpc\testing\TestServiceClient($server_address, $opts);
-
-echo "Connecting to $server_address\n";
-echo "Running test case $test_case\n";
-
-switch ($test_case) {
-    case 'empty_unary':
-        emptyUnary($stub);
-        break;
-    case 'large_unary':
-        largeUnary($stub);
-        break;
-    case 'client_streaming':
-        clientStreaming($stub);
-        break;
-    case 'server_streaming':
-        serverStreaming($stub);
-        break;
-    case 'ping_pong':
-        pingPong($stub);
-        break;
-    case 'empty_stream':
-        emptyStream($stub);
-        break;
-    case 'cancel_after_begin':
-        cancelAfterBegin($stub);
-        break;
-    case 'cancel_after_first_response':
-        cancelAfterFirstResponse($stub);
-        break;
-    case 'timeout_on_sleeping_server':
-        timeoutOnSleepingServer($stub);
-        break;
-    case 'service_account_creds':
-        serviceAccountCreds($stub, $args);
-        break;
-    case 'compute_engine_creds':
-        computeEngineCreds($stub, $args);
-        break;
-    case 'jwt_token_creds':
-        jwtTokenCreds($stub, $args);
-        break;
-    case 'oauth2_auth_token':
-        oauth2AuthToken($stub, $args);
-        break;
-    case 'per_rpc_creds':
-        perRpcCreds($stub, $args);
-        break;
-    default:
-        echo "Unsupported test case $test_case\n";
-        exit(1);
+if (isset($_SERVER['PHP_SELF']) && preg_match('/interop_client/', $_SERVER['PHP_SELF'])) {
+    $args = getopt('', ['server_host:', 'server_port:', 'test_case:',
+                        'use_tls::', 'use_test_ca::',
+                        'server_host_override:', 'oauth_scope:',
+                        'default_service_account:', ]);
+    interop_main($args);
 }

--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -388,7 +388,7 @@ function timeoutOnSleepingServer($stub)
              'Call status was not DEADLINE_EXCEEDED');
 }
 
-function interop_main($args)
+function _makeStub($args)
 {
     if (!array_key_exists('server_host', $args)) {
         throw new Exception('Missing argument: --server_host is required');
@@ -474,7 +474,15 @@ function interop_main($args)
 
     $stub = new grpc\testing\TestServiceClient($server_address, $opts);
 
-    echo "Connecting to $server_address\n";
+    return $stub;
+}
+
+function interop_main($args, $stub = false) {
+    if (!$stub) {
+        $stub = _makeStub($args);
+    }
+
+    $test_case = $args['test_case'];
     echo "Running test case $test_case\n";
 
     switch ($test_case) {
@@ -524,6 +532,8 @@ function interop_main($args)
             echo "Unsupported test case $test_case\n";
             exit(1);
     }
+
+    return $stub;
 }
 
 if (isset($_SERVER['PHP_SELF']) && preg_match('/interop_client/', $_SERVER['PHP_SELF'])) {

--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -1,7 +1,7 @@
 <?php
 /*
  *
- * Copyright 2015, Google Inc.
+ * Copyright 2015-2016, Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/php/tests/interop/metrics_client.php
+++ b/src/php/tests/interop/metrics_client.php
@@ -1,7 +1,7 @@
 <?php
 
-$args = getopt('', ['metric_server_address:', 'total_only::']);
-$parts = explode(':', $args['metric_server_address']);
+$args = getopt('', ['metrics_server_address:', 'total_only::']);
+$parts = explode(':', $args['metrics_server_address']);
 $server_host = $parts[0];
 $server_port = (count($parts) == 2) ? $parts[1] : '';
 

--- a/src/php/tests/interop/metrics_client.php
+++ b/src/php/tests/interop/metrics_client.php
@@ -1,4 +1,36 @@
 <?php
+/*
+ *
+ * Copyright 2016, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
 
 $args = getopt('', ['metrics_server_address:', 'total_only::']);
 $parts = explode(':', $args['metrics_server_address']);

--- a/src/php/tests/interop/metrics_client.php
+++ b/src/php/tests/interop/metrics_client.php
@@ -1,0 +1,17 @@
+<?php
+
+$args = getopt('', ['metric_server_address:', 'total_only::']);
+$parts = explode(':', $args['metric_server_address']);
+$server_host = $parts[0];
+$server_port = (count($parts) == 2) ? $parts[1] : '';
+
+$socket = socket_create(AF_INET, SOCK_STREAM, 0);
+if (@!socket_connect($socket, $server_host, $server_port)) {
+  echo "Cannot connect to merics server...\n";
+  exit(1);
+}
+socket_write($socket, 'qps');
+while ($out = socket_read($socket, 1024)) {
+  echo "$out\n";
+}
+socket_close($socket);

--- a/src/php/tests/interop/stress_client.php
+++ b/src/php/tests/interop/stress_client.php
@@ -1,0 +1,83 @@
+<?php
+
+include_once('interop_client.php');
+
+function stress_main($args) {
+  mt_srand();
+  set_time_limit(0);
+
+  // open socket to listen as metrics server
+  $socket = socket_create(AF_INET, SOCK_STREAM, 0);
+  socket_set_option($socket, SOL_SOCKET, SO_REUSEADDR, 1);
+  if (@!socket_bind($socket, 'localhost', $args['metrics_port'])) {
+    echo "Cannot create socket for metrics server...\n";
+    exit(1);
+  }
+  socket_listen($socket);
+  socket_set_nonblock($socket);
+
+  $start_time = microtime(true);
+  $count = 0;
+  $deadline = $args['test_duration_secs'] ?
+              ($start_time + $args['test_duration_secs']) : false;
+  $num_test_cases = count($args['test_cases']);
+
+  while (true) {
+    $current_time = microtime(true);
+    if ($deadline && $current_time > $deadline) {
+      break;
+    }
+    if ($client_connection = socket_accept($socket)) {
+      // there is an incoming request, respond with qps metrics
+      $input = socket_read($client_connection, 1024);
+      $qps = round($count / ($current_time - $start_time));
+      socket_write($client_connection, "qps: $qps");
+      socket_close($client_connection);
+    } else {
+      // do actual work, run one interop test case
+      $args['test_case'] =
+          $args['test_cases'][mt_rand(0, $num_test_cases - 1)];
+      @interop_main($args);
+      $count++;
+    }
+  }
+  socket_close($socket);
+  echo "Number of interop tests run in $args[test_duration_secs] seconds: $count.\n";
+}
+
+// process command line arguments
+$raw_args = getopt('',
+  ['server_addresses::',
+   'test_cases:',
+   'metrics_port::',
+   'test_duration_secs::',
+   'num_channels_per_server::',
+   'num_stubs_per_channel::']);
+
+$args = [];
+
+if (empty($raw_args['server_addresses'])) {
+  $args['server_host'] = 'localhost';
+  $args['server_port'] = '8080';
+} else {
+  $parts = explode(':', $raw_args['server_addresses']);
+  $args['server_host'] = $parts[0];
+  $args['server_port'] = (count($parts) == 2) ? $parts[1] : '';
+}
+
+$args['metrics_port'] = empty($raw_args['metrics_port']) ?
+  '8081' : $args['metrics_port'];
+
+$args['test_duration_secs'] = empty($raw_args['test_duration_secs']) ||
+  $raw_args['test_duration_secs'] == -1 ?
+  false : $raw_args['test_duration_secs'];
+
+$test_cases = [];
+$test_case_strs = explode(',', $raw_args['test_cases']);
+foreach ($test_case_strs as $test_case_str) {
+  $parts = explode(':', $test_case_str);
+  $test_cases = array_merge($test_cases, array_fill(0, $parts[1], $parts[0]));
+}
+$args['test_cases'] = $test_cases;
+
+stress_main($args);

--- a/src/php/tests/interop/stress_client.php
+++ b/src/php/tests/interop/stress_client.php
@@ -1,4 +1,36 @@
 <?php
+/*
+ *
+ * Copyright 2016, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
 
 include_once('interop_client.php');
 

--- a/src/php/tests/interop/stress_client.php
+++ b/src/php/tests/interop/stress_client.php
@@ -21,6 +21,7 @@ function stress_main($args) {
   $deadline = $args['test_duration_secs'] ?
               ($start_time + $args['test_duration_secs']) : false;
   $num_test_cases = count($args['test_cases']);
+  $stub = false;
 
   while (true) {
     $current_time = microtime(true);
@@ -37,7 +38,7 @@ function stress_main($args) {
       // do actual work, run one interop test case
       $args['test_case'] =
           $args['test_cases'][mt_rand(0, $num_test_cases - 1)];
-      @interop_main($args);
+      $stub = @interop_main($args, $stub);
       $count++;
     }
   }


### PR DESCRIPTION
Fixes #5989 

- Wrapped main routine in `interop_client.php` in a main function and don't execute it if the file is being included from the stress client script
- The stress test client can be launched from command line with a command like this: `php tests/interop/stress_client.php --test_cases=empty_unary:2,large_unary:1,empty_stream:7`
- The metrics client can be launched form command line (from a different process) with a command like this: `php metrics_client.php --metric_server_address=localhost:8081`
- The flags `--num_channels_per_server` and `--num_stubs_per_channel` have not been implemented yet.