### PR TITLE
Add egg-info to python distribution

### DIFF
--- a/PYTHON-MANIFEST.in
+++ b/PYTHON-MANIFEST.in
@@ -1,6 +1,7 @@
 recursive-include src/python/grpcio/grpc *.c *.h *.py *.pyx *.pxd *.pxi *.python *.pem
 recursive-exclude src/python/grpcio/grpc/_cython *.so *.pyd
 graft src/python/grpcio/tests
+graft src/python/grpcio/grpcio.egg-info
 graft src/core
 graft src/boringssl
 graft include/grpc


### PR DESCRIPTION
Various files, including the PKG-INFO were getting dropped from the egg-info directory.  When you try to add a specific version of grpcio as a dependency of another package, easy_install couldn't identify the version and the build failed.