### PR TITLE
Pinning the llvm repository on 3.8.

### DIFF
--- a/tools/dockerfile/grpc_clang_format/Dockerfile
+++ b/tools/dockerfile/grpc_clang_format/Dockerfile
@@ -30,8 +30,8 @@
 FROM ubuntu:wily
 RUN apt-get update
 RUN apt-get -y install wget
-RUN echo deb http://llvm.org/apt/wily/ llvm-toolchain-wily main >> /etc/apt/sources.list
-RUN echo deb-src http://llvm.org/apt/wily/ llvm-toolchain-wily main >> /etc/apt/sources.list
+RUN echo deb http://llvm.org/apt/wily/ llvm-toolchain-wily-3.8 main >> /etc/apt/sources.list
+RUN echo deb-src http://llvm.org/apt/wily/ llvm-toolchain-wily-3.8 main >> /etc/apt/sources.list
 RUN wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key| apt-key add -
 RUN apt-get update
 RUN apt-get -y install clang-format-3.8


### PR DESCRIPTION
cc @ctiller - llvm-toolchain-wily contains clang-format, and not a "stable" clang-format-3.8.