### PR TITLE
Fix missing file in grpcio-tools sdist

### DIFF
--- a/tools/distrib/python/grpcio_tools/MANIFEST.in
+++ b/tools/distrib/python/grpcio_tools/MANIFEST.in
@@ -1,3 +1,4 @@
+include grpc_version.py
 include protoc_deps.py
 include protoc_lib_deps.py
 graft grpc

--- a/tools/run_tests/build_artifact_python.sh
+++ b/tools/run_tests/build_artifact_python.sh
@@ -59,7 +59,11 @@ ${SETARCH_CMD} ${PYTHON} setup.py  \
 ${SETARCH_CMD} ${PYTHON} setup.py  \
     bdist_wheel
 
-# Build gRPC tools package
+# Build gRPC tools package source distribution
+${SETARCH_CMD} ${PYTHON} tools/distrib/python/grpcio_tools/setup.py  \
+    sdist
+
+# Build gRPC tools package binary distribution
 ${PYTHON} tools/distrib/python/make_grpcio_tools.py
 CFLAGS="$CFLAGS -fno-wrapv" ${SETARCH_CMD} \
   ${PYTHON} tools/distrib/python/grpcio_tools/setup.py bdist_wheel


### PR DESCRIPTION
Given that this was one of the Important Reasons I'd gone down the use-the-Python-environment-as-much-as-possible-route, you'd have thought that I'd remember to build the source distribution.