### PR TITLE
Add necessary build-from-source command to documentation

### DIFF
--- a/src/python/grpcio/README.rst
+++ b/src/python/grpcio/README.rst
@@ -48,6 +48,7 @@ package named :code:`python-dev`).
   $ export REPO_ROOT=grpc  # REPO_ROOT can be any directory of your choice
   $ git clone https://github.com/grpc/grpc.git $REPO_ROOT
   $ cd $REPO_ROOT
+  $ git submodule update --init
 
   # For the next two commands do `sudo pip install` if you get permission-denied errors
   $ pip install -rrequirements.txt


### PR DESCRIPTION
Adds a command that allows the instructions to be used to install gRPC Python
from scratch.