### PR TITLE
Move manylinux1 precompiler definitions into port_platform.h

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -114,6 +114,38 @@
 #define GPR_WIN32_ATOMIC 1
 #define GPR_MSVC_TLS 1
 #endif
+#elif defined(GPR_MANYLINUX1)
+// TODO(atash): manylinux1 is just another __linux__ but with ancient
+// libraries; it should be integrated with the `__linux__` definitions below.
+#define GPR_PLATFORM_STRING "manylinux"
+#define GPR_POSIX_CRASH_HANDLER 1
+#define GPR_CPU_LINUX 1
+#define GPR_GCC_ATOMIC 1
+#define GPR_GCC_TLS 1
+#define GPR_LINUX 1
+#define GPR_LINUX_LOG 1
+#define GPR_POSIX_SOCKET 1
+#define GPR_POSIX_WAKEUP_FD 1
+#define GPR_POSIX_SOCKETADDR 1
+#define GPR_POSIX_NO_SPECIAL_WAKEUP_FD 1
+#define GPR_POSIX_SOCKETUTILS 1
+#define GPR_HAVE_UNIX_SOCKET 1
+#define GPR_HAVE_IP_PKTINFO 1
+#define GPR_HAVE_IPV6_RECVPKTINFO 1
+#define GPR_LINUX_ENV 1
+#define GPR_POSIX_FILE 1
+#define GPR_POSIX_TMPFILE 1
+#define GPR_POSIX_STRING 1
+#define GPR_POSIX_SUBPROCESS 1
+#define GPR_POSIX_SYNC 1
+#define GPR_POSIX_TIME 1
+#define GPR_GETPID_IN_UNISTD_H 1
+#define GPR_HAVE_MSG_NOSIGNAL 1
+#ifdef _LP64
+#define GPR_ARCH_64 1
+#else /* _LP64 */
+#define GPR_ARCH_32 1
+#endif /* _LP64 */
 #elif defined(ANDROID) || defined(__ANDROID__)
 #define GPR_PLATFORM_STRING "android"
 #define GPR_ANDROID 1

--- a/tools/run_tests/artifact_targets.py
+++ b/tools/run_tests/artifact_targets.py
@@ -113,37 +113,7 @@ class PythonArtifact:
       # defines ourselves.
       # TODO(atash) get better platform-detection support in core so we don't
       # need to do this manually...
-      environ['CFLAGS'] = " ".join([
-        '-DGPR_NO_AUTODETECT_PLATFORM',
-        '-DGPR_PLATFORM_STRING=\\"manylinux\\"',
-        '-DGPR_POSIX_CRASH_HANDLER=1',
-        '-DGPR_CPU_LINUX=1',
-        '-DGPR_GCC_ATOMIC=1',
-        '-DGPR_GCC_TLS=1',
-        '-DGPR_LINUX=1',
-        '-DGPR_LINUX_LOG=1',
-        #'-DGPR_LINUX_MULTIPOLL_WITH_EPOLL=1',
-        '-DGPR_POSIX_SOCKET=1',
-        '-DGPR_POSIX_WAKEUP_FD=1',
-        '-DGPR_POSIX_SOCKETADDR=1',
-        #'-DGPR_LINUX_EVENTFD=1',
-        '-DGPR_POSIX_NO_SPECIAL_WAKEUP_FD=1',
-        #'-DGPR_LINUX_SOCKETUTILS=1',
-        '-DGPR_POSIX_SOCKETUTILS=1',
-        '-DGPR_HAVE_UNIX_SOCKET=1',
-        '-DGPR_HAVE_IP_PKTINFO=1',
-        '-DGPR_HAVE_IPV6_RECVPKTINFO=1',
-        '-DGPR_LINUX_ENV=1',
-        '-DGPR_POSIX_FILE=1',
-        '-DGPR_POSIX_TMPFILE=1',
-        '-DGPR_POSIX_STRING=1',
-        '-DGPR_POSIX_SUBPROCESS=1',
-        '-DGPR_POSIX_SYNC=1',
-        '-DGPR_POSIX_TIME=1',
-        '-DGPR_GETPID_IN_UNISTD_H=1',
-        '-DGPR_HAVE_MSG_NOSIGNAL=1',
-        '-DGPR_ARCH_{arch}=1'.format(arch=('32' if self.arch == 'x86' else '64')),
-      ])
+      environ['CFLAGS'] = '-DGPR_MANYLINUX1=1'
       return create_docker_jobspec(self.name,
           'tools/dockerfile/grpc_artifact_python_manylinux_%s' % self.arch,
           'tools/run_tests/build_artifact_python.sh',


### PR DESCRIPTION
Moves the `manylinux1` precompiler definitions into `port_platform.h`.

I'll unmark `DO NOT MERGE` after seeing the distrib test results on Jenkins.

cc @nicolasnoble (I'ma assign you after seeing results, so please take a quick look to short-circuit anything I'm doing)
cc @jtattermusch 

<sup>EDIT: now following [this build](https://grpc-testing.appspot.com/view/Artifacts/job/gRPC_build_artifacts/730/)</sup>