### PR TITLE
Format changes to python protoc generation

### DIFF
--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -147,7 +147,8 @@ class IndentScope {
 // END FORMATTING BOILERPLATE //
 ////////////////////////////////
 
-// TODO(protobuf team): Export `ModuleName` from protobuf's
+// TODO(https://github.com/google/protobuf/issues/888):
+// Export `ModuleName` from protobuf's
 // `src/google/protobuf/compiler/python/python_generator.cc` file.
 grpc::string ModuleName(const grpc::string& filename) {
   grpc::string basename = StripProto(filename);
@@ -156,8 +157,23 @@ grpc::string ModuleName(const grpc::string& filename) {
   return basename + "_pb2";
 }
 
+// TODO(https://github.com/google/protobuf/issues/888):
+// Export `ModuleAlias` from protobuf's
+// `src/google/protobuf/compiler/python/python_generator.cc` file.
+grpc::string ModuleAlias(const grpc::string& filename) {
+  grpc::string module_name = ModuleName(filename);
+  // We can't have dots in the module name, so we replace each with _dot_.
+  // But that could lead to a collision between a.b and a_dot_b, so we also
+  // duplicate each underscore.
+  module_name = StringReplace(module_name, "_", "__");
+  module_name = StringReplace(module_name, ".", "_dot_");
+  return module_name;
+}
+
+
 bool GetModuleAndMessagePath(const Descriptor* type,
-                             pair<grpc::string, grpc::string>* out) {
+                             const ServiceDescriptor* service,
+                             grpc::string* out) {
   const Descriptor* path_elem_type = type;
   vector<const Descriptor*> message_path;
   do {
@@ -170,7 +186,9 @@ bool GetModuleAndMessagePath(const Descriptor* type,
         file_name.find_last_of(".proto") == file_name.size() - 1)) {
     return false;
   }
-  grpc::string module = ModuleName(file_name);
+  grpc::string service_file_name = service->file()->name();
+  grpc::string module = service_file_name == file_name ?
+          "" : ModuleAlias(file_name) + ".";
   grpc::string message_type;
   for (auto path_iter = message_path.rbegin();
        path_iter != message_path.rend(); ++path_iter) {
@@ -178,7 +196,7 @@ bool GetModuleAndMessagePath(const Descriptor* type,
   }
   // no pop_back prior to C++11
   message_type.resize(message_type.size() - 1);
-  *out = make_pair(module, message_type);
+  *out = module + message_type;
   return true;
 }
 
@@ -210,7 +228,7 @@ static void PrintAllComments(const DescriptorType* desc, Printer* printer) {
 
 bool PrintBetaServicer(const ServiceDescriptor* service,
                        Printer* out) {
-  out->Print("\n");
+  out->Print("\n\n");
   out->Print("class Beta$Service$Servicer(object):\n", "Service",
              service->name());
   {
@@ -234,7 +252,7 @@ bool PrintBetaServicer(const ServiceDescriptor* service,
 
 bool PrintBetaStub(const ServiceDescriptor* service,
                    Printer* out) {
-  out->Print("\n");
+  out->Print("\n\n");
   out->Print("class Beta$Service$Stub(object):\n", "Service", service->name());
   {
     IndentScope raii_class_indent(out);
@@ -244,7 +262,7 @@ bool PrintBetaStub(const ServiceDescriptor* service,
       grpc::string arg_name = meth->client_streaming() ?
           "request_iterator" : "request";
       auto methdict = ListToDict({"Method", meth->name(), "ArgName", arg_name});
-      out->Print(methdict, "def $Method$(self, $ArgName$, timeout):\n");
+      out->Print(methdict, "def $Method$(self, $ArgName$, timeout, metadata=None, with_call=False, protocol_options=None):\n");
       {
         IndentScope raii_method_indent(out);
         PrintAllComments(meth, out);
@@ -260,38 +278,31 @@ bool PrintBetaStub(const ServiceDescriptor* service,
 
 bool PrintBetaServerFactory(const grpc::string& package_qualified_service_name,
                             const ServiceDescriptor* service, Printer* out) {
-  out->Print("\n");
+  out->Print("\n\n");
   out->Print("def beta_create_$Service$_server(servicer, pool=None, "
              "pool_size=None, default_timeout=None, maximum_timeout=None):\n",
              "Service", service->name());
   {
     IndentScope raii_create_server_indent(out);
     map<grpc::string, grpc::string> method_implementation_constructors;
-    map<grpc::string, pair<grpc::string, grpc::string>>
-        input_message_modules_and_classes;
-    map<grpc::string, pair<grpc::string, grpc::string>>
-        output_message_modules_and_classes;
+    map<grpc::string, grpc::string> input_message_modules_and_classes;
+    map<grpc::string, grpc::string> output_message_modules_and_classes;
     for (int i = 0; i < service->method_count(); ++i) {
       const MethodDescriptor* method = service->method(i);
       const grpc::string method_implementation_constructor =
           grpc::string(method->client_streaming() ? "stream_" : "unary_") +
           grpc::string(method->server_streaming() ? "stream_" : "unary_") +
           "inline";
-      pair<grpc::string, grpc::string> input_message_module_and_class;
-      if (!GetModuleAndMessagePath(method->input_type(),
+      grpc::string input_message_module_and_class;
+      if (!GetModuleAndMessagePath(method->input_type(), service,
                                    &input_message_module_and_class)) {
         return false;
       }
-      pair<grpc::string, grpc::string> output_message_module_and_class;
-      if (!GetModuleAndMessagePath(method->output_type(),
+      grpc::string output_message_module_and_class;
+      if (!GetModuleAndMessagePath(method->output_type(), service,
                                    &output_message_module_and_class)) {
         return false;
       }
-      // Import the modules that define the messages used in RPCs.
-      out->Print("import $Module$\n", "Module",
-                 input_message_module_and_class.first);
-      out->Print("import $Module$\n", "Module",
-                 output_message_module_and_class.first);
       method_implementation_constructors.insert(
           make_pair(method->name(), method_implementation_constructor));
       input_message_modules_and_classes.insert(
@@ -307,13 +318,11 @@ bool PrintBetaServerFactory(const grpc::string& package_qualified_service_name,
          name_and_input_module_class_pair++) {
       IndentScope raii_indent(out);
       out->Print("(\'$PackageQualifiedServiceName$\', \'$MethodName$\'): "
-                 "$InputTypeModule$.$InputTypeClass$.FromString,\n",
+                 "$InputTypeModuleAndClass$.FromString,\n",
                  "PackageQualifiedServiceName", package_qualified_service_name,
                  "MethodName", name_and_input_module_class_pair->first,
-                 "InputTypeModule",
-                 name_and_input_module_class_pair->second.first,
-                 "InputTypeClass",
-                 name_and_input_module_class_pair->second.second);
+                 "InputTypeModuleAndClass",
+                 name_and_input_module_class_pair->second);
     }
     out->Print("}\n");
     out->Print("response_serializers = {\n");
@@ -324,13 +333,11 @@ bool PrintBetaServerFactory(const grpc::string& package_qualified_service_name,
          name_and_output_module_class_pair++) {
       IndentScope raii_indent(out);
       out->Print("(\'$PackageQualifiedServiceName$\', \'$MethodName$\'): "
-                 "$OutputTypeModule$.$OutputTypeClass$.SerializeToString,\n",
+                 "$OutputTypeModuleAndClass$.SerializeToString,\n",
                  "PackageQualifiedServiceName", package_qualified_service_name,
                  "MethodName", name_and_output_module_class_pair->first,
-                 "OutputTypeModule",
-                 name_and_output_module_class_pair->second.first,
-                 "OutputTypeClass",
-                 name_and_output_module_class_pair->second.second);
+                 "OutputTypeModuleAndClass",
+                 name_and_output_module_class_pair->second);
     }
     out->Print("}\n");
     out->Print("method_implementations = {\n");
@@ -366,37 +373,30 @@ bool PrintBetaStubFactory(const grpc::string& package_qualified_service_name,
   map<grpc::string, grpc::string> dict = ListToDict({
         "Service", service->name(),
       });
-  out->Print("\n");
+  out->Print("\n\n");
   out->Print(dict, "def beta_create_$Service$_stub(channel, host=None,"
              " metadata_transformer=None, pool=None, pool_size=None):\n");
   {
     IndentScope raii_create_server_indent(out);
     map<grpc::string, grpc::string> method_cardinalities;
-    map<grpc::string, pair<grpc::string, grpc::string>>
-        input_message_modules_and_classes;
-    map<grpc::string, pair<grpc::string, grpc::string>>
-        output_message_modules_and_classes;
+    map<grpc::string, grpc::string> input_message_modules_and_classes;
+    map<grpc::string, grpc::string> output_message_modules_and_classes;
     for (int i = 0; i < service->method_count(); ++i) {
       const MethodDescriptor* method = service->method(i);
       const grpc::string method_cardinality =
           grpc::string(method->client_streaming() ? "STREAM" : "UNARY") +
           "_" +
-	  grpc::string(method->server_streaming() ? "STREAM" : "UNARY");
-      pair<grpc::string, grpc::string> input_message_module_and_class;
-      if (!GetModuleAndMessagePath(method->input_type(),
+          grpc::string(method->server_streaming() ? "STREAM" : "UNARY");
+      grpc::string input_message_module_and_class;
+      if (!GetModuleAndMessagePath(method->input_type(), service,
                                    &input_message_module_and_class)) {
         return false;
       }
-      pair<grpc::string, grpc::string> output_message_module_and_class;
-      if (!GetModuleAndMessagePath(method->output_type(),
+      grpc::string output_message_module_and_class;
+      if (!GetModuleAndMessagePath(method->output_type(), service,
                                    &output_message_module_and_class)) {
         return false;
       }
-      // Import the modules that define the messages used in RPCs.
-      out->Print("import $Module$\n", "Module",
-                 input_message_module_and_class.first);
-      out->Print("import $Module$\n", "Module",
-                 output_message_module_and_class.first);
       method_cardinalities.insert(
           make_pair(method->name(), method_cardinality));
       input_message_modules_and_classes.insert(
@@ -412,13 +412,11 @@ bool PrintBetaStubFactory(const grpc::string& package_qualified_service_name,
          name_and_input_module_class_pair++) {
       IndentScope raii_indent(out);
       out->Print("(\'$PackageQualifiedServiceName$\', \'$MethodName$\'): "
-                 "$InputTypeModule$.$InputTypeClass$.SerializeToString,\n",
+                 "$InputTypeModuleAndClass$.SerializeToString,\n",
                  "PackageQualifiedServiceName", package_qualified_service_name,
                  "MethodName", name_and_input_module_class_pair->first,
-                 "InputTypeModule",
-                 name_and_input_module_class_pair->second.first,
-                 "InputTypeClass",
-                 name_and_input_module_class_pair->second.second);
+                 "InputTypeModuleAndClass",
+                 name_and_input_module_class_pair->second);
     }
     out->Print("}\n");
     out->Print("response_deserializers = {\n");
@@ -429,13 +427,11 @@ bool PrintBetaStubFactory(const grpc::string& package_qualified_service_name,
          name_and_output_module_class_pair++) {
       IndentScope raii_indent(out);
       out->Print("(\'$PackageQualifiedServiceName$\', \'$MethodName$\'): "
-                 "$OutputTypeModule$.$OutputTypeClass$.FromString,\n",
+                 "$OutputTypeModuleAndClass$.FromString,\n",
                  "PackageQualifiedServiceName", package_qualified_service_name,
                  "MethodName", name_and_output_module_class_pair->first,
-                 "OutputTypeModule",
-                 name_and_output_module_class_pair->second.first,
-                 "OutputTypeClass",
-                 name_and_output_module_class_pair->second.second);
+                 "OutputTypeModuleAndClass",
+                 name_and_output_module_class_pair->second);
     }
     out->Print("}\n");
     out->Print("cardinalities = {\n");
@@ -463,8 +459,6 @@ bool PrintBetaStubFactory(const grpc::string& package_qualified_service_name,
 
 bool PrintPreamble(const FileDescriptor* file,
                    const GeneratorConfiguration& config, Printer* out) {
-  out->Print("import abc\n");
-  out->Print("import six\n");
   out->Print("from $Package$ import implementations as beta_implementations\n",
              "Package", config.beta_package_root);
   out->Print("from $Package$ import interfaces as beta_interfaces\n",


### PR DESCRIPTION
This addresses #2481, #6413, #3867, #5107.

Note that ideally we wouldn't have to duplicate ModuleAlias from the protoc code, but we are already duplicating ModuleName, so I think we push that off to a separate PR.

These changes pass the new rigorous tests.



