### PR TITLE
Fix windows linkage in Python grpcio-tools

### DIFF
--- a/tools/distrib/python/grpcio_tools/README.rst
+++ b/tools/distrib/python/grpcio_tools/README.rst
@@ -46,7 +46,9 @@ From Source
 ~~~~~~~~~~~
 
 Building from source requires that you have the Python headers (usually a
-package named :code:`python-dev`) and Cython installed.
+package named :code:`python-dev`) and Cython installed. It further requires a
+GCC-like compiler to go smoothly; you can probably get it to work without
+GCC-like stuff, but you may end up having a bad time.
 
 ::
 


### PR DESCRIPTION
Python has `msvcr90.dll` listed as one of its dependencies, and yet runs perfectly fine without it. In the meanwhile, MinGW compiles in `msvcrt.dll`, which (from what little I could tell through the opacity of Windows debugging) had conflicts with `msvcr90.dll` within the same `.pyd`, which caused... problems. Thank you, `distutils`, for having strange and unnecessary compilation flags that we can't easily turn off thrust upon us.

Or, if Microsoft updated vcpython27, that'd also have been nice. Or, if `ld` had a way of nixing files from its argument list. Or... `<whining amount="excessive"/>`