### PR TITLE
Connectivity state FATAL_FAILURE doesn't exist; it is SHUTDOWN

### DIFF
--- a/doc/connectivity-semantics-and-api.md
+++ b/doc/connectivity-semantics-and-api.md
@@ -101,7 +101,7 @@ corresponding reasons. Empty cells denote disallowed transitions.
     <td>Shutdown triggered by application.</td>
   </tr>
   <tr>
-    <th>FATAL_FAILURE</th>
+    <th>SHUTDOWN</th>
     <td></td>
     <td></td>
     <td></td>


### PR DESCRIPTION
In a previous version of the document we used FATAL_FAILURE instead of
SHUTDOWN. This was changed when there was no case that would cause a
fatal failure other than shutdown. However, one reference to the old
name was missed.