### PR TITLE
Fix Go perftests and a few other fixes.

### DIFF
--- a/tools/jenkins/run_performance.sh
+++ b/tools/jenkins/run_performance.sh
@@ -34,4 +34,4 @@ set -ex
 # Enter the gRPC repo root
 cd $(dirname $0)/../..
 
-tools/run_tests/run_performance_tests.py -l c++ node ruby csharp python go
+tools/run_tests/run_performance_tests.py -l c++ node ruby csharp python go --netperf

--- a/tools/jenkins/run_performance.sh
+++ b/tools/jenkins/run_performance.sh
@@ -34,4 +34,4 @@ set -ex
 # Enter the gRPC repo root
 cd $(dirname $0)/../..
 
-tools/run_tests/run_performance_tests.py -l c++ node ruby csharp python go --netperf --category smoketest
+tools/run_tests/run_performance_tests.py -l c++ node ruby csharp python --netperf --category smoketest

--- a/tools/jenkins/run_performance.sh
+++ b/tools/jenkins/run_performance.sh
@@ -34,4 +34,4 @@ set -ex
 # Enter the gRPC repo root
 cd $(dirname $0)/../..
 
-tools/run_tests/run_performance_tests.py -l c++ node ruby csharp python go --netperf
+tools/run_tests/run_performance_tests.py -l c++ node ruby csharp python go --netperf --category smoketest

--- a/tools/jenkins/run_performance.sh
+++ b/tools/jenkins/run_performance.sh
@@ -34,4 +34,4 @@ set -ex
 # Enter the gRPC repo root
 cd $(dirname $0)/../..
 
-tools/run_tests/run_performance_tests.py -l c++ node ruby csharp python
+tools/run_tests/run_performance_tests.py -l c++ node ruby csharp python go

--- a/tools/run_tests/performance/run_worker_go.sh
+++ b/tools/run_tests/performance/run_worker_go.sh
@@ -32,4 +32,6 @@ set -ex
 
 cd $(dirname $0)/../../..
 
-../gopath/bin/worker $@
+export GOPATH=$(pwd)/../gopath
+
+${GOPATH}/bin/worker $@

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -137,6 +137,17 @@ def create_netperf_jobspec(server_host='localhost', client_host=None,
   cmd = 'NETPERF_SERVER_HOST="%s" ' % server_host
   if bq_result_table:
     cmd += 'BQ_RESULT_TABLE="%s" ' % bq_result_table
+  if client_host:
+    # If netperf is running remotely, the env variables populated by Jenkins
+    # won't be available on the client, but we need them for uploading results
+    # to BigQuery.
+    jenkins_job_name = os.getenv('JOB_NAME')
+    if jenkins_job_name:
+      cmd += 'JOB_NAME="%s" ' % jenkins_job_name
+    jenkins_build_number = os.getenv('BUILD_NUMBER')
+    if jenkins_build_number:
+      cmd += 'BUILD_NUMBER="%s" ' % jenkins_build_number
+
   cmd += 'tools/run_tests/performance/run_netperf.sh'
   if client_host:
     user_at_host = '%s@%s' % (_REMOTE_HOST_USERNAME, client_host)


### PR DESCRIPTION
-- GOPATH needs to be set for Go worker to correctly detect test certificates
-- run go as part of smoketest
-- run netperf as part of smoketest
-- fix #6533