### PR TITLE
Fix qps reporting in C# stress client

### DIFF
--- a/src/csharp/Grpc.IntegrationTesting/StressTestClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/StressTestClient.cs
@@ -311,7 +311,7 @@ namespace Grpc.IntegrationTesting
                 var snapshot = histogram.GetSnapshot(true);
                 var elapsedSnapshot = wallClockStopwatch.GetElapsedSnapshot(true);
 
-                return (long) (snapshot.Count / elapsedSnapshot.Seconds);
+                return (long) (snapshot.Count / elapsedSnapshot.TotalSeconds);
             }
         }
     }


### PR DESCRIPTION
Maybe instead of using an integer that goes from 0-59 (and end up in division by zero once a minute), how about using a double that contains the elapsed time? :-)

Thanks for catching this btw.
Fixes #6505