### PR TITLE
Fixes leak in test_cancel_after_client_done & cancel_after_accept

### DIFF
--- a/src/core/lib/surface/call.c
+++ b/src/core/lib/surface/call.c
@@ -984,12 +984,12 @@ static void continue_receiving_slices(grpc_exec_ctx *exec_ctx,
       call->receiving_message = 0;
       grpc_byte_stream_destroy(exec_ctx, call->receiving_stream);
       call->receiving_stream = NULL;
-      if (gpr_unref(&bctl->steps_to_complete)) {
-        post_batch_completion(exec_ctx, bctl);
-      }
       if (call->status[STATUS_FROM_API_OVERRIDE].code != GRPC_STATUS_OK) {
         grpc_byte_buffer_destroy(*call->receiving_buffer);
         *call->receiving_buffer = NULL;
+      }
+      if (gpr_unref(&bctl->steps_to_complete)) {
+        post_batch_completion(exec_ctx, bctl);
       }
       return;
     }

--- a/src/core/lib/surface/call.c
+++ b/src/core/lib/surface/call.c
@@ -987,6 +987,10 @@ static void continue_receiving_slices(grpc_exec_ctx *exec_ctx,
       if (gpr_unref(&bctl->steps_to_complete)) {
         post_batch_completion(exec_ctx, bctl);
       }
+      if (call->status[STATUS_FROM_API_OVERRIDE].code != GRPC_STATUS_OK) {
+        grpc_byte_buffer_destroy(*call->receiving_buffer);
+        *call->receiving_buffer = NULL;
+      }
       return;
     }
     if (grpc_byte_stream_next(exec_ctx, call->receiving_stream,


### PR DESCRIPTION
under high load, the op->data.recv_message of a GRPC_OP_RECV grpc_op may
not receive an instance of grpc_byte_buffer in time, staying NULL.
However, it's this client code that's responsible for destroying said
byte_buffer, which is allocated by surface/call.c

When a call is cancelled, the batch containing the GRPC_OP_RECV will
"succeed", meaning that the client code will proceed and go over
the grpc_byte_buffer_destroy it must perform over the call-provided byte
buffers. However, the actual reception of data inside call.c is still
ongoing even post-cancellation, the byte buffer getting created and
"propagated up" to the client code, but too late, as the execution flow
has already gone over grpc_byte_buffer_destroy. So it leaks.

This fix makes sure to check internally if the call has been cancelled
and frees the byte buffer accordingly.