### PR TITLE
Merged some codes to the common function for maintainability in time.c file

### DIFF
--- a/src/core/lib/support/time.c
+++ b/src/core/lib/support/time.c
@@ -80,103 +80,62 @@ gpr_timespec gpr_inf_past(gpr_clock_type type) {
   return out;
 }
 
-/* TODO(ctiller): consider merging _nanos, _micros, _millis into a single
-   function for maintainability. Similarly for _seconds, _minutes, and _hours */
+static gpr_timespec get_timespec_by_different_second_unit(int64_t t, int64_t n,
+                                                          gpr_clock_type type) {
+  gpr_timespec out;
+  if (t == INT64_MAX) {
+    out = gpr_inf_future(type);
+  } else if (t == INT64_MIN) {
+    out = gpr_inf_past(type);
+  } else {
+    if (t >= 0) {
+      out.tv_sec = t / n;
+    } else {
+      out.tv_sec = (-((n - 1) - (t + n)) / n) - 1;
+    }
+    out.tv_nsec = (int32_t)((t - out.tv_sec * n) * GPR_NS_PER_SEC / n);
+    out.clock_type = type;
+  }
+  return out;
+}
+
+static gpr_timespec get_timespec_by_hour_or_minute_unit(int64_t t, int64_t n,
+                                                        gpr_clock_type type) {
+  gpr_timespec out;
+  if (t >= INT64_MAX / n) {
+    out = gpr_inf_future(type);
+  } else if (t <= INT64_MIN / n) {
+    out = gpr_inf_past(type);
+  } else {
+    out.tv_sec = t * n;
+    out.tv_nsec = 0;
+    out.clock_type = type;
+  }
+  return out;
+}
 
 gpr_timespec gpr_time_from_nanos(int64_t ns, gpr_clock_type type) {
-  gpr_timespec result;
-  result.clock_type = type;
-  if (ns == INT64_MAX) {
-    result = gpr_inf_future(type);
-  } else if (ns == INT64_MIN) {
-    result = gpr_inf_past(type);
-  } else if (ns >= 0) {
-    result.tv_sec = ns / GPR_NS_PER_SEC;
-    result.tv_nsec = (int32_t)(ns - result.tv_sec * GPR_NS_PER_SEC);
-  } else {
-    /* Calculation carefully formulated to avoid any possible under/overflow. */
-    result.tv_sec = (-(999999999 - (ns + GPR_NS_PER_SEC)) / GPR_NS_PER_SEC) - 1;
-    result.tv_nsec = (int32_t)(ns - result.tv_sec * GPR_NS_PER_SEC);
-  }
-  return result;
+  return get_timespec_by_different_second_unit(ns, GPR_NS_PER_SEC, type);
 }
 
 gpr_timespec gpr_time_from_micros(int64_t us, gpr_clock_type type) {
-  gpr_timespec result;
-  result.clock_type = type;
-  if (us == INT64_MAX) {
-    result = gpr_inf_future(type);
-  } else if (us == INT64_MIN) {
-    result = gpr_inf_past(type);
-  } else if (us >= 0) {
-    result.tv_sec = us / 1000000;
-    result.tv_nsec = (int32_t)((us - result.tv_sec * 1000000) * 1000);
-  } else {
-    /* Calculation carefully formulated to avoid any possible under/overflow. */
-    result.tv_sec = (-(999999 - (us + 1000000)) / 1000000) - 1;
-    result.tv_nsec = (int32_t)((us - result.tv_sec * 1000000) * 1000);
-  }
-  return result;
+  return get_timespec_by_different_second_unit(us, GPR_US_PER_SEC, type);
 }
 
 gpr_timespec gpr_time_from_millis(int64_t ms, gpr_clock_type type) {
-  gpr_timespec result;
-  result.clock_type = type;
-  if (ms == INT64_MAX) {
-    result = gpr_inf_future(type);
-  } else if (ms == INT64_MIN) {
-    result = gpr_inf_past(type);
-  } else if (ms >= 0) {
-    result.tv_sec = ms / 1000;
-    result.tv_nsec = (int32_t)((ms - result.tv_sec * 1000) * 1000000);
-  } else {
-    /* Calculation carefully formulated to avoid any possible under/overflow. */
-    result.tv_sec = (-(999 - (ms + 1000)) / 1000) - 1;
-    result.tv_nsec = (int32_t)((ms - result.tv_sec * 1000) * 1000000);
-  }
-  return result;
+  return get_timespec_by_different_second_unit(ms, GPR_MS_PER_SEC, type);
 }
 
 gpr_timespec gpr_time_from_seconds(int64_t s, gpr_clock_type type) {
-  gpr_timespec result;
-  result.clock_type = type;
-  if (s == INT64_MAX) {
-    result = gpr_inf_future(type);
-  } else if (s == INT64_MIN) {
-    result = gpr_inf_past(type);
-  } else {
-    result.tv_sec = s;
-    result.tv_nsec = 0;
-  }
-  return result;
+  return get_timespec_by_different_second_unit(s, 1, type);
 }
 
 gpr_timespec gpr_time_from_minutes(int64_t m, gpr_clock_type type) {
-  gpr_timespec result;
-  result.clock_type = type;
-  if (m >= INT64_MAX / 60) {
-    result = gpr_inf_future(type);
-  } else if (m <= INT64_MIN / 60) {
-    result = gpr_inf_past(type);
-  } else {
-    result.tv_sec = m * 60;
-    result.tv_nsec = 0;
-  }
-  return result;
+  return get_timespec_by_hour_or_minute_unit(m, 60, type);
 }
 
 gpr_timespec gpr_time_from_hours(int64_t h, gpr_clock_type type) {
-  gpr_timespec result;
-  result.clock_type = type;
-  if (h >= INT64_MAX / 3600) {
-    result = gpr_inf_future(type);
-  } else if (h <= INT64_MIN / 3600) {
-    result = gpr_inf_past(type);
-  } else {
-    result.tv_sec = h * 3600;
-    result.tv_nsec = 0;
-  }
-  return result;
+  return get_timespec_by_hour_or_minute_unit(h, 3600, type);
 }
 
 gpr_timespec gpr_time_add(gpr_timespec a, gpr_timespec b) {

--- a/src/core/lib/support/time.c
+++ b/src/core/lib/support/time.c
@@ -92,8 +92,9 @@ static gpr_timespec to_seconds_from_sub_second_time(int64_t time_in_units,
     if (time_in_units >= 0) {
       out.tv_sec = time_in_units / units_per_sec;
     } else {
-      out.tv_sec = (-((units_per_sec - 1) -
-                      (time_in_units + units_per_sec)) / units_per_sec) - 1;
+      out.tv_sec = (-((units_per_sec - 1) - (time_in_units + units_per_sec)) /
+                    units_per_sec) -
+                   1;
     }
     out.tv_nsec = (int32_t)((time_in_units - out.tv_sec * units_per_sec) *
                             GPR_NS_PER_SEC / units_per_sec);


### PR DESCRIPTION
Try to solve `TODO(ctiller): consider merging _nanos, _micros, _millis into a single    function for maintainability. Similarly for _seconds, _minutes, and _hours`, I use `macro` to unify some similar codes.

But still retain `gpr_time_from_nanos` and so on functions. 