### PR TITLE
PHP: update package.xml after fixes

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
   <email>grpc-packages@google.com</email>
   <active>yes</active>
  </lead>
- <date>2016-04-19</date>
+ <date>2016-05-18</date>
  <time>16:06:07</time>
  <version>
   <release>0.14.2</release>
@@ -22,7 +22,7 @@
  </stability>
  <license>BSD</license>
  <notes>
-- destroy grpc_byte_buffer after startBatch #6096
+- Updated functions with TSRM macros for ZTS support #6607
  </notes>
  <contents>
   <dir baseinstalldir="/" name="/">
@@ -1014,8 +1014,8 @@ Update to wrap gRPC C Core version 0.10.0
   </release>
   <release>
    <version>
-    <release>0.14.2</release>
-    <api>0.14.2</api>
+    <release>0.14.0</release>
+    <api>0.14.0</api>
    </version>
    <stability>
     <release>beta</release>
@@ -1025,6 +1025,21 @@ Update to wrap gRPC C Core version 0.10.0
    <license>BSD</license>
    <notes>
 - destroy grpc_byte_buffer after startBatch #6096
+   </notes>
+  </release>
+  <release>
+   <version>
+    <release>0.14.2</release>
+    <api>0.14.2</api>
+   </version>
+   <stability>
+    <release>beta</release>
+    <api>beta</api>
+   </stability>
+   <date>2016-05-18</date>
+   <license>BSD</license>
+   <notes>
+- Updated functions with TSRM macros for ZTS support #6607
    </notes>
   </release>
  </changelog>

--- a/templates/package.xml.template
+++ b/templates/package.xml.template
@@ -12,7 +12,7 @@
     <email>grpc-packages@google.com</email>
     <active>yes</active>
    </lead>
-   <date>2016-04-19</date>
+   <date>2016-05-18</date>
    <time>16:06:07</time>
    <version>
     <release>${settings.php_version.php()}</release>
@@ -24,7 +24,7 @@
    </stability>
    <license>BSD</license>
    <notes>
-  - destroy grpc_byte_buffer after startBatch #6096
+  - Updated functions with TSRM macros for ZTS support #6607
    </notes>
    <contents>
     <dir baseinstalldir="/" name="/">
@@ -172,8 +172,8 @@
     </release>
     <release>
      <version>
-      <release>${settings.php_version.php()}</release>
-      <api>${settings.php_version.php()}</api>
+      <release>0.14.0</release>
+      <api>0.14.0</api>
      </version>
      <stability>
       <release>beta</release>
@@ -183,6 +183,21 @@
      <license>BSD</license>
      <notes>
   - destroy grpc_byte_buffer after startBatch #6096
+     </notes>
+    </release>
+    <release>
+     <version>
+      <release>${settings.php_version.php()}</release>
+      <api>${settings.php_version.php()}</api>
+     </version>
+     <stability>
+      <release>beta</release>
+      <api>beta</api>
+     </stability>
+     <date>2016-05-18</date>
+     <license>BSD</license>
+     <notes>
+  - Updated functions with TSRM macros for ZTS support #6607
      </notes>
     </release>
    </changelog>


### PR DESCRIPTION
This is for the `release-0_14` branch. This is needed after the fix in #6607. And we need a new section for the next release anyways.