### PR TITLE
PHP: implement custom_metadata interop, status_code_and_message, unimplemented_method tests

### DIFF
--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -569,7 +569,11 @@ function _makeStub($args)
         $opts['update_metadata'] = $update_metadata;
     }
 
-    $stub = new grpc\testing\TestServiceClient($server_address, $opts);
+    if ($test_case == 'unimplemented_method') {
+      $stub = new grpc\testing\UnimplementedServiceClient($server_address, $opts);
+    } else {
+      $stub = new grpc\testing\TestServiceClient($server_address, $opts);
+    }
 
     return $stub;
 }

--- a/src/php/tests/interop/messages.proto
+++ b/src/php/tests/interop/messages.proto
@@ -1,5 +1,5 @@
 
-// Copyright 2015, Google Inc.
+// Copyright 2015-2016, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,9 +41,6 @@ enum PayloadType {
 
   // Uncompressable binary format.
   UNCOMPRESSABLE = 1;
-
-  // Randomly chosen from all other formats defined in this enum.
-  RANDOM = 2;
 }
 
 // A block of data, to simply increase gRPC message size.
@@ -52,6 +49,13 @@ message Payload {
   optional PayloadType type = 1 [default = COMPRESSABLE];
   // Primary contents of payload.
   optional bytes body = 2;
+}
+
+// A protobuf representation for grpc status. This is used by test
+// clients to specify a status that the server should attempt to return.
+message EchoStatus {
+  optional int32 code = 1;
+  optional string message = 2;
 }
 
 // Unary request.
@@ -72,6 +76,12 @@ message SimpleRequest {
 
   // Whether SimpleResponse should include OAuth scope.
   optional bool fill_oauth_scope = 5;
+
+  // Whether to request the server to compress the response.
+  optional bool request_compressed_response = 6;
+
+  // Whether server should return a given status
+  optional EchoStatus response_status = 7;
 }
 
 // Unary response, as configured by the request.
@@ -123,10 +133,30 @@ message StreamingOutputCallRequest {
 
   // Optional input payload sent along with the request.
   optional Payload payload = 3;
+
+  // Whether to request the server to compress the response.
+  optional bool request_compressed_response = 6;
+
+  // Whether server should return a given status
+  optional EchoStatus response_status = 7;
 }
 
 // Server-streaming response, as configured by the request and parameters.
 message StreamingOutputCallResponse {
   // Payload to increase response size.
   optional Payload payload = 1;
+}
+
+// For reconnect interop test only.
+// Client tells server what reconnection parameters it used.
+message ReconnectParams {
+  optional int32 max_reconnect_backoff_ms = 1;
+}
+
+// For reconnect interop test only.
+// Server tells client whether its reconnects are following the spec and the
+// reconnect backoffs it saw.
+message ReconnectInfo {
+  optional bool passed = 1;
+  repeated int32 backoff_ms = 2;
 }

--- a/src/php/tests/interop/test.proto
+++ b/src/php/tests/interop/test.proto
@@ -68,4 +68,7 @@ service TestService {
   // first request.
   rpc HalfDuplexCall(stream StreamingOutputCallRequest)
       returns (stream StreamingOutputCallResponse);
+
+  // An unimplemented method on the server
+  rpc UnimplementedCall(grpc.testing.EmptyMessage) returns (grpc.testing.EmptyMessage);
 }

--- a/src/php/tests/interop/test.proto
+++ b/src/php/tests/interop/test.proto
@@ -1,5 +1,5 @@
 
-// Copyright 2015, Google Inc.
+// Copyright 2015-2016, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -68,7 +68,11 @@ service TestService {
   // first request.
   rpc HalfDuplexCall(stream StreamingOutputCallRequest)
       returns (stream StreamingOutputCallResponse);
+}
 
-  // An unimplemented method on the server
+// A simple service NOT implemented at servers so clients can test for
+// that case.
+service UnimplementedService {
+  // A call that no server should implement
   rpc UnimplementedCall(grpc.testing.EmptyMessage) returns (grpc.testing.EmptyMessage);
 }

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -252,7 +252,7 @@ class PHPLanguage:
     return {}
 
   def unimplemented_test_cases(self):
-    return _SKIP_ADVANCED + _SKIP_COMPRESSION
+    return _SKIP_COMPRESSION
 
   def unimplemented_test_cases_server(self):
     return []


### PR DESCRIPTION
Implement `custom_metadata` interop test for PHP. Fixes #6579 