### PR TITLE
PHP: add call getTrailingMetadata API

### DIFF
--- a/src/php/lib/Grpc/AbstractCall.php
+++ b/src/php/lib/Grpc/AbstractCall.php
@@ -39,6 +39,7 @@ abstract class AbstractCall
     protected $call;
     protected $deserialize;
     protected $metadata;
+    protected $trailing_metadata;
 
     /**
      * Create a new Call wrapper object.
@@ -66,6 +67,7 @@ abstract class AbstractCall
         $this->call = new Call($channel, $method, $deadline);
         $this->deserialize = $deserialize;
         $this->metadata = null;
+        $this->trailing_metadata = null;
         if (isset($options['call_credentials_callback']) &&
             is_callable($call_credentials_callback =
                         $options['call_credentials_callback'])) {
@@ -81,6 +83,14 @@ abstract class AbstractCall
     public function getMetadata()
     {
         return $this->metadata;
+    }
+
+    /**
+     * @return The trailing metadata sent by the server.
+     */
+    public function getTrailingMetadata()
+    {
+        return $this->trailing_metadata;
     }
 
     /**

--- a/src/php/lib/Grpc/BidiStreamingCall.php
+++ b/src/php/lib/Grpc/BidiStreamingCall.php
@@ -112,6 +112,7 @@ class BidiStreamingCall extends AbstractCall
             OP_RECV_STATUS_ON_CLIENT => true,
         ]);
 
+        $this->trailing_metadata = $status_event->status->metadata;
         return $status_event->status;
     }
 }

--- a/src/php/lib/Grpc/ClientStreamingCall.php
+++ b/src/php/lib/Grpc/ClientStreamingCall.php
@@ -86,6 +86,8 @@ class ClientStreamingCall extends AbstractCall
         ]);
         $this->metadata = $event->metadata;
 
-        return [$this->deserializeResponse($event->message), $event->status];
+        $status = $event->status;
+        $this->trailing_metadata = $status->metadata;
+        return [$this->deserializeResponse($event->message), $status];
     }
 }

--- a/src/php/lib/Grpc/ServerStreamingCall.php
+++ b/src/php/lib/Grpc/ServerStreamingCall.php
@@ -91,6 +91,7 @@ class ServerStreamingCall extends AbstractCall
             OP_RECV_STATUS_ON_CLIENT => true,
         ]);
 
+        $this->trailing_metadata = $status_event->status->metadata;
         return $status_event->status;
     }
 }

--- a/src/php/lib/Grpc/UnaryCall.php
+++ b/src/php/lib/Grpc/UnaryCall.php
@@ -75,6 +75,8 @@ class UnaryCall extends AbstractCall
             OP_RECV_STATUS_ON_CLIENT => true,
         ]);
 
-        return [$this->deserializeResponse($event->message), $event->status];
+        $status = $event->status;
+        $this->trailing_metadata = $status->metadata;
+        return [$this->deserializeResponse($event->message), $status];
     }
 }


### PR DESCRIPTION
Now you can call `$call->getTrailingMetadata()` on all 4 types of calls we support.

Fixes #6580 