### PR TITLE
Fix memory leak reading from python ByteBuffer.

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/records.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/records.pyx.pxi
@@ -274,6 +274,7 @@ cdef class ByteBuffer:
           data_slice_length = gpr_slice_length(data_slice)
           with gil:
             result += (<char *>data_slice_pointer)[:data_slice_length]
+          gpr_slice_unref(data_slice)
       with nogil:
         grpc_byte_buffer_reader_destroy(&reader)
       return bytes(result)


### PR DESCRIPTION
Fixes #5913.

`grpc_byte_buffer_reader_next` is documented as 'Caller is responsible
for calling gpr_slice_unref on the result', but that wasn't happening.