### PR TITLE
Use 2 clients for 32core throughput scenarios.

### DIFF
--- a/tools/jenkins/run_full_performance.sh
+++ b/tools/jenkins/run_full_performance.sh
@@ -49,7 +49,7 @@ tools/run_tests/run_performance_tests.py \
     --netperf \
     --category scalable \
     --bq_result_table performance_test.performance_experiment_32core \
-    --remote_worker_host grpc-performance-server-32core grpc-performance-client-32core \
+    --remote_worker_host grpc-performance-server-32core grpc-performance-client-32core grpc-performance-client2-32core \
     || EXIT_CODE=1
 
 exit $EXIT_CODE


### PR DESCRIPTION
the `grpc-performance-client2-32core` worker should be ready.