### PR TITLE
Make Node not segfault when it receives a compressed message

### DIFF
--- a/src/node/ext/byte_buffer.cc
+++ b/src/node/ext/byte_buffer.cc
@@ -78,6 +78,7 @@ Local<Value> ByteBufferToBuffer(grpc_byte_buffer *buffer) {
   size_t length = GPR_SLICE_LENGTH(slice);
   char *result = new char[length];
   memcpy(result, GPR_SLICE_START_PTR(slice), length);
+  gpr_slice_unref(slice);
   return scope.Escape(MakeFastBuffer(
       Nan::NewBuffer(result, length, delete_buffer, NULL).ToLocalChecked()));
 }

--- a/src/node/ext/byte_buffer.cc
+++ b/src/node/ext/byte_buffer.cc
@@ -38,7 +38,6 @@
 #include "grpc/grpc.h"
 #include "grpc/byte_buffer_reader.h"
 #include "grpc/support/slice.h"
-#include "grpc/support/log.h"
 
 #include "byte_buffer.h"
 
@@ -73,7 +72,6 @@ Local<Value> ByteBufferToBuffer(grpc_byte_buffer *buffer) {
   if (buffer == NULL) {
     return scope.Escape(Nan::Null());
   }
-  gpr_log(GPR_DEBUG, "Compressed size: %d", grpc_byte_buffer_length(buffer));
   grpc_byte_buffer_reader reader;
   grpc_byte_buffer_reader_init(&reader, buffer);
   gpr_slice slice = grpc_byte_buffer_reader_readall(&reader);


### PR DESCRIPTION
This is a fix for a problem that I discovered while investigating #5355. I was unable to reproduce that issue, so I suspect that intervening core changes both introduced this failure and fixed the other one.