### PR TITLE
Generate massaged method names for Python protos

### DIFF
--- a/src/python/grpcio/tests/health_check/_health_servicer_test.py
+++ b/src/python/grpcio/tests/health_check/_health_servicer_test.py
@@ -49,25 +49,25 @@ class HealthServicerTest(unittest.TestCase):
 
   def test_empty_service(self):
     request = health_pb2.HealthCheckRequest()
-    resp = self.servicer.Check(request, None)
+    resp = self.servicer.check(request, None)
     self.assertEqual(resp.status, health_pb2.HealthCheckResponse.SERVING)
 
   def test_serving_service(self):
     request = health_pb2.HealthCheckRequest(
         service='grpc.test.TestServiceServing')
-    resp = self.servicer.Check(request, None)
+    resp = self.servicer.check(request, None)
     self.assertEqual(resp.status, health_pb2.HealthCheckResponse.SERVING)
 
   def test_unknown_serivce(self):
     request = health_pb2.HealthCheckRequest(
         service='grpc.test.TestServiceUnknown')
-    resp = self.servicer.Check(request, None)
+    resp = self.servicer.check(request, None)
     self.assertEqual(resp.status, health_pb2.HealthCheckResponse.UNKNOWN)
 
   def test_not_serving_service(self):
     request = health_pb2.HealthCheckRequest(
         service='grpc.test.TestServiceNotServing')
-    resp = self.servicer.Check(request, None)
+    resp = self.servicer.check(request, None)
     self.assertEqual(resp.status, health_pb2.HealthCheckResponse.NOT_SERVING)
 
 

--- a/src/python/grpcio/tests/protoc_plugin/protos/service/test_service.proto
+++ b/src/python/grpcio/tests/protoc_plugin/protos/service/test_service.proto
@@ -62,3 +62,34 @@ service TestService {
   rpc HalfDuplexCall(stream StreamingOutputCallRequest)
       returns (stream StreamingOutputCallResponse);
 }
+
+service MassagedNames1 {
+  // -> 'anametest'
+  rpc Anametest(SimpleRequest) returns (SimpleResponse);
+}
+
+service MassagedNames2 {
+  // -> 'nametest'
+  rpc NAMETEST(SimpleRequest) returns (SimpleResponse);
+}
+
+service MassagedNames3 {
+  // -> 'name_test1'
+  rpc NAMETest1(SimpleRequest) returns (SimpleResponse);
+}
+
+service MassagedNames4 {
+  // -> 'name_tes_t1' (we *only* use capital letters to distinguish word
+  // boundaries)
+  rpc NameTEST1(SimpleRequest) returns (SimpleResponse);
+}
+
+service MassagedNames5 {
+  // -> 'name1_test'
+  rpc Name1TEST(SimpleRequest) returns (SimpleResponse);
+}
+
+service MassagedNames6 {
+  // -> 'name_test'
+  rpc NameTest(SimpleRequest) returns (SimpleResponse);
+}

--- a/src/python/grpcio_health_checking/grpc_health/health/v1/health.py
+++ b/src/python/grpcio_health_checking/grpc_health/health/v1/health.py
@@ -41,12 +41,15 @@ class HealthServicer(health_pb2.BetaHealthServicer):
     self._server_status_lock = threading.Lock()
     self._server_status = {}
 
-  def Check(self, request, context):
+  def check(self, request, context):
+    """RPC implementation for checking a server's status.
+
+    See the health.v1.health protobuf file.
+    """
     with self._server_status_lock:
       if request.service not in self._server_status:
-        # TODO(atash): once the Python API has a way of setting the server
-        # status, bring us into conformance with the health check spec by
-        # returning the NOT_FOUND status here.
+        # TODO(atash): once the Python API has been refactored, set the
+        # NOT_FOUND status here.
         raise NotImplementedError()
       else:
         return health_pb2.HealthCheckResponse(


### PR DESCRIPTION
We need to do this before GA; the plan is to add a `snake_case` method option in upstream protobuf (cc @haberman, @nathanielmanistaatgoogle) to override this massaging in cases where it may fail miserably (like where it ends up generating the same name for two different method names).
