### PR TITLE
C#: don't require Channel.ShutdownAsync() and Server.ShutdownAsync() to be able to exit.

### DIFF
--- a/src/csharp/Grpc.Core.Tests/AppDomainUnloadTest.cs
+++ b/src/csharp/Grpc.Core.Tests/AppDomainUnloadTest.cs
@@ -1,0 +1,97 @@
+#region Copyright notice and license
+
+// Copyright 2015, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Internal;
+using Grpc.Core.Utils;
+using NUnit.Framework;
+
+namespace Grpc.Core.Tests
+{
+    public class AppDomainUnloadTest
+    {
+        [Test]
+        public void AppDomainUnloadHookCanCleanupAbandonedCall()
+        {
+            var setup = new AppDomainSetup
+            {
+                ApplicationBase = AppDomain.CurrentDomain.BaseDirectory
+            };
+            var childDomain = AppDomain.CreateDomain("test", null, setup);
+            var remoteObj = childDomain.CreateInstance(typeof(AppDomainTestClass).Assembly.GetName().Name, typeof(AppDomainTestClass).FullName);
+
+            // Try to unload the appdomain once we've created a server and a channel inside the appdomain.
+            AppDomain.Unload(childDomain);
+        }
+
+        public class AppDomainTestClass
+        {
+            const string Host = "127.0.0.1";
+
+            /// <summary>
+            /// Creates a server and a channel and initiates a call. The code is invoked from inside of an AppDomain
+            /// to test if AppDomain.Unload() work if Grpc is being used.
+            /// </summary>
+            public AppDomainTestClass()
+            {
+                AppDomain.CurrentDomain.DomainUnload += (object sender, EventArgs e) =>
+                {
+                    var shutdownChannelsTask = GrpcEnvironment.ShutdownChannelsAsync();
+                    var killServersTask = GrpcEnvironment.KillServersAsync();
+                    Task.WaitAll(shutdownChannelsTask, killServersTask);
+                };
+
+                var helper = new MockServiceHelper(Host);
+                var server = helper.GetServer();
+                server.Start();
+                var channel = helper.GetChannel();
+
+                var readyToShutdown = new TaskCompletionSource<object>();
+                helper.DuplexStreamingHandler = new DuplexStreamingServerMethod<string, string>(async (requestStream, responseStream, context) =>
+                {
+                    readyToShutdown.SetResult(null);
+                    await requestStream.ToListAsync();
+                });
+
+                var call = Calls.AsyncDuplexStreamingCall(helper.CreateDuplexStreamingCall());
+                readyToShutdown.Task.Wait();  // make sure handler is running
+            }
+        }
+    }
+}

--- a/src/csharp/Grpc.Core.Tests/AppDomainUnloadTest.cs
+++ b/src/csharp/Grpc.Core.Tests/AppDomainUnloadTest.cs
@@ -70,13 +70,6 @@ namespace Grpc.Core.Tests
             /// </summary>
             public AppDomainTestClass()
             {
-                AppDomain.CurrentDomain.DomainUnload += (object sender, EventArgs e) =>
-                {
-                    var shutdownChannelsTask = GrpcEnvironment.ShutdownChannelsAsync();
-                    var killServersTask = GrpcEnvironment.KillServersAsync();
-                    Task.WaitAll(shutdownChannelsTask, killServersTask);
-                };
-
                 var helper = new MockServiceHelper(Host);
                 var server = helper.GetServer();
                 server.Start();

--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="ShutdownHookServerTest.cs" />
     <Compile Include="ShutdownHookPendingCallTest.cs" />
     <Compile Include="ShutdownHookClientTest.cs" />
+    <Compile Include="AppDomainUnloadTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
@@ -86,8 +86,9 @@
     <Compile Include="NUnitMain.cs" />
     <Compile Include="Internal\FakeNativeCall.cs" />
     <Compile Include="Internal\AsyncCallServerTest.cs" />
-    <Compile Include="ShutdownHookTest.cs" />
     <Compile Include="ShutdownHookServerTest.cs" />
+    <Compile Include="ShutdownHookPendingCallTest.cs" />
+    <Compile Include="ShutdownHookClientTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="NUnitMain.cs" />
     <Compile Include="Internal\FakeNativeCall.cs" />
     <Compile Include="Internal\AsyncCallServerTest.cs" />
+    <Compile Include="ShutdownHookTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Internal\FakeNativeCall.cs" />
     <Compile Include="Internal\AsyncCallServerTest.cs" />
     <Compile Include="ShutdownHookTest.cs" />
+    <Compile Include="ShutdownHookServerTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/csharp/Grpc.Core.Tests/GrpcEnvironmentTest.cs
+++ b/src/csharp/Grpc.Core.Tests/GrpcEnvironmentTest.cs
@@ -49,7 +49,7 @@ namespace Grpc.Core.Tests
             {
                 Assert.IsNotNull(env.CompletionQueues.ElementAt(i));
             }
-            GrpcEnvironment.Release();
+            GrpcEnvironment.ReleaseAsync().Wait();
         }
 
         [Test]
@@ -58,8 +58,8 @@ namespace Grpc.Core.Tests
             var env1 = GrpcEnvironment.AddRef();
             var env2 = GrpcEnvironment.AddRef();
             Assert.AreSame(env1, env2);
-            GrpcEnvironment.Release();
-            GrpcEnvironment.Release();
+            GrpcEnvironment.ReleaseAsync().Wait();
+            GrpcEnvironment.ReleaseAsync().Wait();
         }
 
         [Test]
@@ -68,10 +68,10 @@ namespace Grpc.Core.Tests
             Assert.AreEqual(0, GrpcEnvironment.GetRefCount());
 
             var env1 = GrpcEnvironment.AddRef();
-            GrpcEnvironment.Release();
+            GrpcEnvironment.ReleaseAsync().Wait();
 
             var env2 = GrpcEnvironment.AddRef();
-            GrpcEnvironment.Release();
+            GrpcEnvironment.ReleaseAsync().Wait();
 
             Assert.AreNotSame(env1, env2);
         }
@@ -80,7 +80,7 @@ namespace Grpc.Core.Tests
         public void ReleaseWithoutAddRef()
         {
             Assert.AreEqual(0, GrpcEnvironment.GetRefCount());
-            Assert.Throws(typeof(InvalidOperationException), () => GrpcEnvironment.Release());
+            Assert.ThrowsAsync(typeof(InvalidOperationException), async () => await GrpcEnvironment.ReleaseAsync());
         }
 
         [Test]

--- a/src/csharp/Grpc.Core.Tests/Internal/CompletionQueueSafeHandleTest.cs
+++ b/src/csharp/Grpc.Core.Tests/Internal/CompletionQueueSafeHandleTest.cs
@@ -48,7 +48,7 @@ namespace Grpc.Core.Internal.Tests
             GrpcEnvironment.AddRef();
             var cq = CompletionQueueSafeHandle.Create();
             cq.Dispose();
-            GrpcEnvironment.Release();
+            GrpcEnvironment.ReleaseAsync().Wait();
         }
 
         [Test]
@@ -59,7 +59,7 @@ namespace Grpc.Core.Internal.Tests
             cq.Shutdown();
             var ev = cq.Next();
             cq.Dispose();
-            GrpcEnvironment.Release();
+            GrpcEnvironment.ReleaseAsync().Wait();
             Assert.AreEqual(CompletionQueueEvent.CompletionType.Shutdown, ev.type);
             Assert.AreNotEqual(IntPtr.Zero, ev.success);
             Assert.AreEqual(IntPtr.Zero, ev.tag);

--- a/src/csharp/Grpc.Core.Tests/PInvokeTest.cs
+++ b/src/csharp/Grpc.Core.Tests/PInvokeTest.cs
@@ -65,7 +65,7 @@ namespace Grpc.Core.Tests
                     cq.Dispose();
                 });
 
-            GrpcEnvironment.Release();
+            GrpcEnvironment.ReleaseAsync().Wait();
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core.Tests/ShutdownHookClientTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ShutdownHookClientTest.cs
@@ -43,16 +43,12 @@ using NUnit.Framework;
 
 namespace Grpc.Core.Tests
 {
-    public class ShutdownHookTest
+    public class ShutdownHookClientTest
     {
         const string Host = "127.0.0.1";
 
-        /// <summary>
-        /// Make sure that a non-shutdown channel can be cleaned up using
-        /// a <c>AppDomain.ProcessExit</c> hook.
-        /// </summary>
         [Test]
-        public void AppDomainProcessExitHook()
+        public void ProcessExitHookCanCleanupAbandonedChannels()
         {
             var channel = new Channel(Host, 1000, ChannelCredentials.Insecure);
             var channel2 = new Channel(Host, 1001, ChannelCredentials.Insecure);
@@ -61,11 +57,6 @@ namespace Grpc.Core.Tests
                 GrpcEnvironment.ShutdownChannelsAsync().Wait();
             };
         }
-
-        // TODO: test what happens if there's a pending completion in the cq (destroy on non-empty cq)
-
         // TODO: test what happens if there's an appdomain unload 
-
-        // TODO: tests involving a server...
     }
 }

--- a/src/csharp/Grpc.Core.Tests/ShutdownHookClientTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ShutdownHookClientTest.cs
@@ -52,11 +52,6 @@ namespace Grpc.Core.Tests
         {
             var channel = new Channel(Host, 1000, ChannelCredentials.Insecure);
             var channel2 = new Channel(Host, 1001, ChannelCredentials.Insecure);
-            AppDomain.CurrentDomain.ProcessExit += (object sender, EventArgs e) =>
-            {
-                GrpcEnvironment.ShutdownChannelsAsync().Wait();
-            };
         }
-        // TODO: test what happens if there's an appdomain unload 
     }
 }

--- a/src/csharp/Grpc.Core.Tests/ShutdownHookPendingCallTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ShutdownHookPendingCallTest.cs
@@ -50,13 +50,6 @@ namespace Grpc.Core.Tests
         [Test]
         public void ProcessExitHookCanCleanupAbandonedCall()
         {
-            AppDomain.CurrentDomain.ProcessExit += (object sender, EventArgs e) =>
-            {
-                var shutdownChannelsTask = GrpcEnvironment.ShutdownChannelsAsync();
-                var killServersTask = GrpcEnvironment.KillServersAsync();
-                Task.WaitAll(shutdownChannelsTask, killServersTask);
-            };
-
             var helper = new MockServiceHelper(Host);
             var server = helper.GetServer();
             server.Start();

--- a/src/csharp/Grpc.Core.Tests/ShutdownHookServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ShutdownHookServerTest.cs
@@ -43,22 +43,26 @@ using NUnit.Framework;
 
 namespace Grpc.Core.Tests
 {
-    public class ShutdownHookTest
+    public class ShutdownHookServerTest
     {
         const string Host = "127.0.0.1";
 
         /// <summary>
-        /// Make sure that a non-shutdown channel can be cleaned up using
+        /// Make sure that a non-shutdown server can be cleaned up using
         /// a <c>AppDomain.ProcessExit</c> hook.
         /// </summary>
         [Test]
         public void AppDomainProcessExitHook()
         {
-            var channel = new Channel(Host, 1000, ChannelCredentials.Insecure);
+            var helper = new MockServiceHelper(Host);
+            var server = helper.GetServer();
+            server.Start();
             AppDomain.CurrentDomain.ProcessExit += (object sender, EventArgs e) =>
             {
-                // TODO: expose API to shutdown all channels.
-                channel.ShutdownAsync();
+                // TODO: expose API for killing all servers
+                // TODO: expose API for closing all channels
+                server.KillAsync();
+                GrpcEnvironment.ReleaseAsync();
             };
         }
 

--- a/src/csharp/Grpc.Core.Tests/ShutdownHookServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ShutdownHookServerTest.cs
@@ -53,12 +53,6 @@ namespace Grpc.Core.Tests
             var helper = new MockServiceHelper(Host);
             var server = helper.GetServer();
             server.Start();
-            AppDomain.CurrentDomain.ProcessExit += (object sender, EventArgs e) =>
-            {
-                var shutdownChannelsTask = GrpcEnvironment.ShutdownChannelsAsync();
-                var killServersTask = GrpcEnvironment.KillServersAsync();
-                Task.WaitAll(shutdownChannelsTask, killServersTask);
-            };
         }
     }
 }

--- a/src/csharp/Grpc.Core.Tests/ShutdownHookServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ShutdownHookServerTest.cs
@@ -59,10 +59,9 @@ namespace Grpc.Core.Tests
             server.Start();
             AppDomain.CurrentDomain.ProcessExit += (object sender, EventArgs e) =>
             {
-                // TODO: expose API for killing all servers
-                // TODO: expose API for closing all channels
-                server.KillAsync();
-                GrpcEnvironment.ReleaseAsync();
+                var shutdownChannelsTask = GrpcEnvironment.ShutdownChannelsAsync();
+                var killServersTask = GrpcEnvironment.KillServersAsync();
+                Task.WaitAll(shutdownChannelsTask, killServersTask);
             };
         }
 

--- a/src/csharp/Grpc.Core.Tests/ShutdownHookTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ShutdownHookTest.cs
@@ -1,0 +1,70 @@
+#region Copyright notice and license
+
+// Copyright 2015, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Internal;
+using Grpc.Core.Utils;
+using NUnit.Framework;
+
+namespace Grpc.Core.Tests
+{
+    public class ShutdownHookTest
+    {
+        const string Host = "127.0.0.1";
+
+        /// <summary>
+        /// Make sure that a non-shutdown channel can be cleaned up using
+        /// a <c>AppDomain.ProcessExit</c> hook.
+        /// </summary>
+        [Test]
+        public void AppDomainProcessExitHook()
+        {
+            var channel = new Channel(Host, 1000, ChannelCredentials.Insecure);
+            AppDomain.CurrentDomain.DomainUnload += (object sender, EventArgs e) =>
+            {
+                Console.WriteLine("DomainUnload");
+                channel.ShutdownAsync();
+            };
+            AppDomain.CurrentDomain.ProcessExit += (object sender, EventArgs e) =>
+            {
+                Console.WriteLine("ProcessExit");
+                channel.ShutdownAsync();
+            };
+        }
+    }
+}

--- a/src/csharp/Grpc.Core.Tests/ShutdownHookTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ShutdownHookTest.cs
@@ -55,10 +55,10 @@ namespace Grpc.Core.Tests
         public void AppDomainProcessExitHook()
         {
             var channel = new Channel(Host, 1000, ChannelCredentials.Insecure);
+            var channel2 = new Channel(Host, 1001, ChannelCredentials.Insecure);
             AppDomain.CurrentDomain.ProcessExit += (object sender, EventArgs e) =>
             {
-                // TODO: expose API to shutdown all channels.
-                channel.ShutdownAsync();
+                GrpcEnvironment.ShutdownChannelsAsync().Wait();
             };
         }
 

--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -220,7 +220,7 @@ namespace Grpc.Core
 
             handle.Dispose();
 
-            await Task.Run(() => GrpcEnvironment.Release()).ConfigureAwait(false);
+            await GrpcEnvironment.ReleaseAsync().ConfigureAwait(false);
         }
 
         internal ChannelSafeHandle Handle

--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -88,6 +88,7 @@ namespace Grpc.Core
                     this.handle = ChannelSafeHandle.CreateInsecure(target, nativeChannelArgs);
                 }
             }
+            GrpcEnvironment.RegisterChannel(this);
         }
 
         /// <summary>
@@ -209,6 +210,7 @@ namespace Grpc.Core
                 GrpcPreconditions.CheckState(!shutdownRequested);
                 shutdownRequested = true;
             }
+            GrpcEnvironment.UnregisterChannel(this);
 
             shutdownTokenSource.Cancel();
 

--- a/src/csharp/Grpc.Core/Internal/GrpcThreadPool.cs
+++ b/src/csharp/Grpc.Core/Internal/GrpcThreadPool.cs
@@ -128,7 +128,7 @@ namespace Grpc.Core.Internal
             var cq = completionQueues.ElementAt(cqIndex);
 
             var thread = new Thread(new ThreadStart(() => RunHandlerLoop(cq)));
-            thread.IsBackground = false;
+            thread.IsBackground = true;
             thread.Name = string.Format("grpc {0} (cq {1})", threadIndex, cqIndex);
             thread.Start();
 

--- a/src/csharp/Grpc.Core/Internal/GrpcThreadPool.cs
+++ b/src/csharp/Grpc.Core/Internal/GrpcThreadPool.cs
@@ -114,6 +114,21 @@ namespace Grpc.Core.Internal
             });
         }
 
+        /// <summary>
+        /// Returns true if there is at least one thread pool thread that hasn't
+        /// already stopped.
+        /// Threads can either stop because all completion queues shut down or
+        /// because all foreground threads have already shutdown and process is
+        /// going to exit.
+        /// </summary>
+        internal bool IsAlive
+        {
+            get
+            {
+                return threads.Any(t => t.ThreadState != ThreadState.Stopped);
+            }
+        }
+
         internal IReadOnlyCollection<CompletionQueueSafeHandle> CompletionQueues
         {
             get

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -169,7 +169,7 @@ namespace Grpc.Core
             await shutdownTcs.Task.ConfigureAwait(false);
             DisposeHandle();
 
-            await Task.Run(() => GrpcEnvironment.Release()).ConfigureAwait(false);
+            await GrpcEnvironment.ReleaseAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace Grpc.Core
             await shutdownTcs.Task.ConfigureAwait(false);
             DisposeHandle();
 
-            await Task.Run(() => GrpcEnvironment.Release()).ConfigureAwait(false);
+            await GrpcEnvironment.ReleaseAsync().ConfigureAwait(false);
         }
 
         internal void AddCallReference(object call)

--- a/src/csharp/tests.json
+++ b/src/csharp/tests.json
@@ -25,6 +25,7 @@
     "Grpc.Core.Tests.ResponseHeadersTest",
     "Grpc.Core.Tests.SanityTest",
     "Grpc.Core.Tests.ServerTest",
+    "Grpc.Core.Tests.ShutdownHookServerTest",
     "Grpc.Core.Tests.ShutdownHookTest",
     "Grpc.Core.Tests.ShutdownTest",
     "Grpc.Core.Tests.TimeoutsTest",

--- a/src/csharp/tests.json
+++ b/src/csharp/tests.json
@@ -25,6 +25,7 @@
     "Grpc.Core.Tests.ResponseHeadersTest",
     "Grpc.Core.Tests.SanityTest",
     "Grpc.Core.Tests.ServerTest",
+    "Grpc.Core.Tests.ShutdownHookTest",
     "Grpc.Core.Tests.ShutdownTest",
     "Grpc.Core.Tests.TimeoutsTest",
     "Grpc.Core.Tests.UserAgentStringTest"

--- a/src/csharp/tests.json
+++ b/src/csharp/tests.json
@@ -7,6 +7,7 @@
     "Grpc.Core.Internal.Tests.CompletionQueueSafeHandleTest",
     "Grpc.Core.Internal.Tests.MetadataArraySafeHandleTest",
     "Grpc.Core.Internal.Tests.TimespecTest",
+    "Grpc.Core.Tests.AppDomainUnloadTest",
     "Grpc.Core.Tests.CallCredentialsTest",
     "Grpc.Core.Tests.CallOptionsTest",
     "Grpc.Core.Tests.ChannelCredentialsTest",

--- a/src/csharp/tests.json
+++ b/src/csharp/tests.json
@@ -25,8 +25,9 @@
     "Grpc.Core.Tests.ResponseHeadersTest",
     "Grpc.Core.Tests.SanityTest",
     "Grpc.Core.Tests.ServerTest",
+    "Grpc.Core.Tests.ShutdownHookClientTest",
+    "Grpc.Core.Tests.ShutdownHookPendingCallTest",
     "Grpc.Core.Tests.ShutdownHookServerTest",
-    "Grpc.Core.Tests.ShutdownHookTest",
     "Grpc.Core.Tests.ShutdownTest",
     "Grpc.Core.Tests.TimeoutsTest",
     "Grpc.Core.Tests.UserAgentStringTest"


### PR DESCRIPTION
Currently the GrpcThreadPool uses foreground threads that prevent the application from exiting if the user doesn't explicitly shutdown all the channels and servers. That is also problematic if gRPC is running in an appdomain that gets unloaded. This PR allows shutdown in both cases by modifying the shutdown logic and registering AppDomain.ProcessExit and AppDomain.DomainUnload hooks.

-- add GrpcEnvironment.ShutdownChannelsAsync() and GrpcEnvironment.KillServersAsync() to make shutting down all channels and servers simpler.

-- add tests that verify that appdomain unloading works

-- add tests that verify that process can exit if not required

-- it is still strongly recommended that users shutdown all their channels (and especially servers) before letting the last foreground thread to finish. The auto-shutdown procedure essentially leaves all the unfinished calls as they are and tries to shutdown anyway.

This should fix #6601, #6315 and #6316.