### PR TITLE
Fix run_tests.py propagation of make options under docker

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -254,9 +254,7 @@ class CLanguage(object):
 
   def _compiler_options(self, use_docker, compiler):
     """Returns docker distro and make options to use for given compiler."""
-    if _is_use_docker_child():
-      return ("already_under_docker", [])
-    if not use_docker:
+    if not use_docker and not _is_use_docker_child():
       _check_compiler(compiler, ['default'])
 
     if compiler == 'gcc4.9' or compiler == 'default':


### PR DESCRIPTION
It turns out that for c/c++ the make options are not used inside the docker image.

Pretty stupid bug that should be fixed soon, found it when playing with https://github.com/grpc/grpc/pull/6265.