### PR TITLE
Make behavior of default(Metadata.Entry) sane

### DIFF
--- a/src/csharp/Grpc.Core.Tests/MetadataTest.cs
+++ b/src/csharp/Grpc.Core.Tests/MetadataTest.cs
@@ -129,6 +129,17 @@ namespace Grpc.Core.Tests
         }
 
         [Test]
+        public void Entry_DefaultValue()
+        {
+            var entry = default(Metadata.Entry);
+            Assert.IsNull(entry.Key);
+            Assert.IsNull(entry.Value);
+            Assert.IsNull(entry.ValueBytes);
+            Assert.IsFalse(entry.IsBinary);
+            Assert.AreEqual("[Entry: key=, value=]", entry.ToString());
+        }
+
+        [Test]
         public void IndexOf()
         {
             var metadata = CreateMetadata();

--- a/src/csharp/Grpc.Core/Metadata.cs
+++ b/src/csharp/Grpc.Core/Metadata.cs
@@ -253,7 +253,7 @@ namespace Grpc.Core
                 {
                     if (valueBytes == null)
                     {
-                        return Encoding.GetBytes(value);
+                        return value != null ? Encoding.GetBytes(value) : null;
                     }
 
                     // defensive copy to guarantee immutability
@@ -271,7 +271,11 @@ namespace Grpc.Core
                 get
                 {
                     GrpcPreconditions.CheckState(!IsBinary, "Cannot access string value of a binary metadata entry");
-                    return value ?? Encoding.GetString(valueBytes);
+                    if (value == null)
+                    {
+                        return valueBytes != null ? Encoding.GetString(valueBytes) : null;
+                    }
+                    return value;
                 }
             }
 
@@ -282,7 +286,7 @@ namespace Grpc.Core
             {
                 get
                 {
-                    return value == null;
+                    return key != null && value == null;
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/6713 and adds tests.