### PR TITLE
fix for issue 5548. Deprecated old classes and created subclasses.

### DIFF
--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -94,7 +94,7 @@ void PrintSimpleSignature(Printer *printer, const MethodDescriptor *method,
 void PrintAdvancedSignature(Printer *printer, const MethodDescriptor *method,
                             map< ::grpc::string, ::grpc::string> vars) {
   vars["method_name"] = "RPCTo" + vars["method_name"];
-  vars["return_type"] = "ProtoRPC *";
+  vars["return_type"] = "GRPCProtoRPC *";
   PrintMethodSignature(printer, method, vars);
 }
 
@@ -199,7 +199,7 @@ void PrintMethodImplementations(Printer *printer,
         " marshalling and parsing.\n");
     printer.Print(vars,
                   "@interface $service_class$ :"
-                  " ProtoService<$service_class$>\n");
+                  " GRPCProtoService<$service_class$>\n");
     printer.Print(
         "- (instancetype)initWithHost:(NSString *)host"
         " NS_DESIGNATED_INITIALIZER;\n");

--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -94,7 +94,7 @@ void PrintSimpleSignature(Printer *printer, const MethodDescriptor *method,
 void PrintAdvancedSignature(Printer *printer, const MethodDescriptor *method,
                             map< ::grpc::string, ::grpc::string> vars) {
   vars["method_name"] = "RPCTo" + vars["method_name"];
-  vars["return_type"] = "GRPCProtoRPC *";
+  vars["return_type"] = "GRPCProtoCall *";
   PrintMethodSignature(printer, method, vars);
 }
 

--- a/src/objective-c/ProtoRPC/ProtoMethod.h
+++ b/src/objective-c/ProtoRPC/ProtoMethod.h
@@ -51,7 +51,7 @@ __attribute__((deprecated("Please use GRPCProtoMethod.")))
 @end
 
 /**
- * This subclass is empty now. Eventually we'll remove ProtoService class
+ * This subclass is empty now. Eventually we'll remove ProtoMethod class
  * to avoid potential naming conflict
  */
 @interface GRPCProtoMethod : ProtoMethod

--- a/src/objective-c/ProtoRPC/ProtoMethod.h
+++ b/src/objective-c/ProtoRPC/ProtoMethod.h
@@ -37,6 +37,7 @@
  * A fully-qualified proto service method name. Full qualification is needed because a gRPC endpoint
  * can implement multiple services.
  */
+__attribute__((deprecated("Please use GRPCProtoMethod.")))
 @interface ProtoMethod : NSObject
 @property(nonatomic, readonly) NSString *package;
 @property(nonatomic, readonly) NSString *service;
@@ -47,4 +48,12 @@
 - (instancetype)initWithPackage:(NSString *)package
                         service:(NSString *)service
                          method:(NSString *)method;
+@end
+
+/**
+ * This subclass is empty now. Eventually we'll remove ProtoService class
+ * to avoid potential naming conflict
+ */
+@interface GRPCProtoMethod : ProtoMethod
+
 @end

--- a/src/objective-c/ProtoRPC/ProtoMethod.m
+++ b/src/objective-c/ProtoRPC/ProtoMethod.m
@@ -53,3 +53,7 @@
   }
 }
 @end
+
+@implementation GRPCProtoMethod
+
+@end

--- a/src/objective-c/ProtoRPC/ProtoRPC.h
+++ b/src/objective-c/ProtoRPC/ProtoRPC.h
@@ -36,7 +36,7 @@
 
 #import "ProtoMethod.h"
 
-__attribute__((deprecated("Please use GRPCProtoRPC.")))
+__attribute__((deprecated("Please use GRPCProtoCall.")))
 @interface ProtoRPC : GRPCCall
 
 - (instancetype)initWithHost:(NSString *)host
@@ -49,9 +49,9 @@ __attribute__((deprecated("Please use GRPCProtoRPC.")))
 @end
 
 /**
- * This subclass is empty now. Eventually we'll remove ProtoService class
+ * This subclass is empty now. Eventually we'll remove ProtoRPC class
  * to avoid potential naming conflict
  */
-@interface GRPCProtoRPC : ProtoRPC
+@interface GRPCProtoCall : ProtoRPC
 
 @end

--- a/src/objective-c/ProtoRPC/ProtoRPC.h
+++ b/src/objective-c/ProtoRPC/ProtoRPC.h
@@ -36,13 +36,22 @@
 
 #import "ProtoMethod.h"
 
+__attribute__((deprecated("Please use GRPCProtoRPC.")))
 @interface ProtoRPC : GRPCCall
 
 - (instancetype)initWithHost:(NSString *)host
-                      method:(ProtoMethod *)method
+                      method:(GRPCProtoMethod *)method
               requestsWriter:(GRXWriter *)requestsWriter
                responseClass:(Class)responseClass
           responsesWriteable:(id<GRXWriteable>)responsesWriteable NS_DESIGNATED_INITIALIZER;
 
 - (void)start;
+@end
+
+/**
+ * This subclass is empty now. Eventually we'll remove ProtoService class
+ * to avoid potential naming conflict
+ */
+@interface GRPCProtoRPC : ProtoRPC
+
 @end

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -118,6 +118,6 @@ static NSError *ErrorForBadProto(id proto, Class expectedClass, NSError *parsing
 }
 @end
 
-@implementation GRPCProtoRPC
+@implementation GRPCProtoCall
 
 @end

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -70,7 +70,7 @@ static NSError *ErrorForBadProto(id proto, Class expectedClass, NSError *parsing
 
 // Designated initializer
 - (instancetype)initWithHost:(NSString *)host
-                      method:(ProtoMethod *)method
+                      method:(GRPCProtoMethod *)method
               requestsWriter:(GRXWriter *)requestsWriter
                responseClass:(Class)responseClass
           responsesWriteable:(id<GRXWriteable>)responsesWriteable {
@@ -116,4 +116,8 @@ static NSError *ErrorForBadProto(id proto, Class expectedClass, NSError *parsing
   // Break retain cycles.
   _responseWriteable = nil;
 }
+@end
+
+@implementation GRPCProtoRPC
+
 @end

--- a/src/objective-c/ProtoRPC/ProtoService.h
+++ b/src/objective-c/ProtoRPC/ProtoService.h
@@ -33,7 +33,7 @@
 
 #import <Foundation/Foundation.h>
 
-@class GRPCProtoRPC;
+@class GRPCProtoCall;
 @protocol GRXWriteable;
 @class GRXWriter;
 
@@ -44,7 +44,7 @@ __attribute__((deprecated("Please use GRPCProtoService.")))
                  packageName:(NSString *)packageName
                  serviceName:(NSString *)serviceName NS_DESIGNATED_INITIALIZER;
 
-- (GRPCProtoRPC *)RPCToMethod:(NSString *)method
+- (GRPCProtoCall *)RPCToMethod:(NSString *)method
            requestsWriter:(GRXWriter *)requestsWriter
   	        responseClass:(Class)responseClass
   	   responsesWriteable:(id<GRXWriteable>)responsesWriteable;

--- a/src/objective-c/ProtoRPC/ProtoService.h
+++ b/src/objective-c/ProtoRPC/ProtoService.h
@@ -33,17 +33,28 @@
 
 #import <Foundation/Foundation.h>
 
-@class ProtoRPC;
+@class GRPCProtoRPC;
 @protocol GRXWriteable;
 @class GRXWriter;
 
+
+__attribute__((deprecated("Please use GRPCProtoService.")))
 @interface ProtoService : NSObject
 - (instancetype)initWithHost:(NSString *)host
                  packageName:(NSString *)packageName
                  serviceName:(NSString *)serviceName NS_DESIGNATED_INITIALIZER;
 
-- (ProtoRPC *)RPCToMethod:(NSString *)method
+- (GRPCProtoRPC *)RPCToMethod:(NSString *)method
            requestsWriter:(GRXWriter *)requestsWriter
   	        responseClass:(Class)responseClass
   	   responsesWriteable:(id<GRXWriteable>)responsesWriteable;
+@end
+
+
+/**
+ * This subclass is empty now. Eventually we'll remove ProtoService class
+ * to avoid potential naming conflict
+ */
+@interface GRPCProtoService : ProtoService
+
 @end

--- a/src/objective-c/ProtoRPC/ProtoService.m
+++ b/src/objective-c/ProtoRPC/ProtoService.m
@@ -79,3 +79,7 @@
                      responsesWriteable:responsesWriteable];
 }
 @end
+
+@implementation GRPCProtoService
+
+@end


### PR DESCRIPTION
Fixes #5548.

Deprecated ProtoRPC, ProtoMethod, ProtoService and created subclasses with GRPC prefix. Eventually we'll remove the Proto* versions and only keep the GRPC* versions.