### PR TITLE
C#: Add unstarted server test

### DIFF
--- a/src/csharp/Grpc.Core.Tests/ServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ServerTest.cs
@@ -95,6 +95,14 @@ namespace Grpc.Core.Tests
         }
 
         [Test]
+        public void UnstartedServerCanBeShutdown()
+        {
+            var server = new Server();
+            server.ShutdownAsync().Wait();
+            Assert.Throws(typeof(InvalidOperationException), () => server.Start());
+        }
+
+        [Test]
         public void UnstartedServerDoesNotPreventShutdown()
         {
             // just create a server, don't start it, and make sure it doesn't prevent shutdown.

--- a/src/csharp/Grpc.Core.Tests/ServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ServerTest.cs
@@ -93,5 +93,12 @@ namespace Grpc.Core.Tests
 
             server.ShutdownAsync().Wait();
         }
+
+        [Test]
+        public void UnstartedServerDoesNotPreventShutdown()
+        {
+            // just create a server, don't start it, and make sure it doesn't prevent shutdown.
+            var server = new Server();
+        }
     }
 }

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -140,6 +140,7 @@ namespace Grpc.Core
             lock (myLock)
             {
                 GrpcPreconditions.CheckState(!startRequested);
+                GrpcPreconditions.CheckState(!shutdownRequested);
                 startRequested = true;
                 
                 handle.Start();
@@ -203,7 +204,6 @@ namespace Grpc.Core
         {
             lock (myLock)
             {
-                GrpcPreconditions.CheckState(startRequested);
                 GrpcPreconditions.CheckState(!shutdownRequested);
                 shutdownRequested = true;
             }
@@ -215,7 +215,6 @@ namespace Grpc.Core
             {
                 handle.CancelAllCalls();
             }
-
             await ShutdownCompleteOrEnvironmentDeadAsync().ConfigureAwait(false);
 
             DisposeHandle();


### PR DESCRIPTION
As a side effect of changing C# shutdown logic, this behavior now works fine. Adding a test to make sure it stays so.