### PR TITLE
Allow custom server handler mapping for C#.

### DIFF
--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -94,7 +94,6 @@
     <Compile Include="Metadata.cs" />
     <Compile Include="Internal\MetadataArraySafeHandle.cs" />
     <Compile Include="ClientBase.cs" />
-    <Compile Include="Internal\ServerCalls.cs" />
     <Compile Include="ServerMethods.cs" />
     <Compile Include="Internal\ClientRequestStream.cs" />
     <Compile Include="Internal\ClientResponseStream.cs" />
@@ -138,6 +137,9 @@
     <Compile Include="Internal\CallError.cs" />
     <Compile Include="Logging\LogLevel.cs" />
     <Compile Include="Logging\LogLevelFilterLogger.cs" />
+    <Compile Include="IHandlerRegistry.cs" />
+    <Compile Include="ServerCallDetails.cs" />
+    <Compile Include="ServerCalls.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Grpc.Core.nuspec" />

--- a/src/csharp/Grpc.Core/IHandlerRegistry.cs
+++ b/src/csharp/Grpc.Core/IHandlerRegistry.cs
@@ -1,0 +1,53 @@
+﻿#region Copyright notice and license
+
+// Copyright 2016, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using Grpc.Core.Internal;
+
+namespace Grpc.Core
+{
+    /// <summary>
+    /// Registry that maps method names to server-side handlers.
+    /// </summary>
+    public interface IHandlerRegistry
+    {
+        /// <summary>
+        /// Looks up the method handler based on method name.
+        /// </summary>
+        /// <returns>The handler that will be invoked by the server. <c>null</c> indicates that corresponding handler wasn't found.</returns>
+        /// <param name="method">Full name of method including the service name.</param>
+        /// <param name="host">The host set for this given server call.</param>
+        AsyncServerMethodHandler LookupHandler(string method, string host);
+    }
+}

--- a/src/csharp/Grpc.Core/ServerCallDetails.cs
+++ b/src/csharp/Grpc.Core/ServerCallDetails.cs
@@ -1,6 +1,6 @@
-#region Copyright notice and license
+﻿#region Copyright notice and license
 
-// Copyright 2015, Google Inc.
+// Copyright 2016, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -32,40 +32,41 @@
 #endregion
 
 using System;
-using System.Threading;
 using System.Threading.Tasks;
-using Grpc.Core;
+using Grpc.Core.Internal;
 
-namespace Grpc.Core.Internal
+namespace Grpc.Core
 {
-    internal static class ServerCalls
+    /// <summary>
+    /// Details about server-side call invocation. The class itself is visible,
+    /// but contents are marked as internal to make the instances opaque.
+    /// Users should never need to create instances of this class.
+    /// </summary>
+    public class ServerCallDetails
     {
-        public static IServerCallHandler UnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, UnaryServerMethod<TRequest, TResponse> handler)
-            where TRequest : class
-            where TResponse : class
+        readonly ServerRpcNew serverRpcNew;
+        readonly CompletionQueueSafeHandle cq;
+
+        internal ServerCallDetails(ServerRpcNew serverRpcNew, CompletionQueueSafeHandle cq)
         {
-            return new UnaryServerCallHandler<TRequest, TResponse>(method, handler);
+            this.serverRpcNew = serverRpcNew;
+            this.cq = cq;
         }
 
-        public static IServerCallHandler ClientStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, ClientStreamingServerMethod<TRequest, TResponse> handler)
-            where TRequest : class
-            where TResponse : class
+        internal ServerRpcNew ServerRpcNew
         {
-            return new ClientStreamingServerCallHandler<TRequest, TResponse>(method, handler);
+            get
+            {
+                return this.serverRpcNew;
+            }
         }
 
-        public static IServerCallHandler ServerStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, ServerStreamingServerMethod<TRequest, TResponse> handler)
-            where TRequest : class
-            where TResponse : class
+        internal CompletionQueueSafeHandle CompletionQueue
         {
-            return new ServerStreamingServerCallHandler<TRequest, TResponse>(method, handler);
-        }
-
-        public static IServerCallHandler DuplexStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TRequest, TResponse> handler)
-            where TRequest : class
-            where TResponse : class
-        {
-            return new DuplexStreamingServerCallHandler<TRequest, TResponse>(method, handler);
+            get
+            {
+                return this.cq;
+            }
         }
     }
 }

--- a/src/csharp/Grpc.Core/ServerCalls.cs
+++ b/src/csharp/Grpc.Core/ServerCalls.cs
@@ -1,0 +1,92 @@
+#region Copyright notice and license
+
+// Copyright 2015, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Internal;
+
+namespace Grpc.Core
+{
+    /// <summary>
+    /// A server-side handler.
+    /// </summary>
+    public delegate Task AsyncServerMethodHandler(ServerCallDetails callDetails);
+
+    /// <summary>
+    /// Helper methods for invoking server-side method handlers of selected method type (e.g. client streaming).
+    /// </summary>
+    public static class ServerCalls
+    {
+        /// <summary>
+        /// Returns a delegate that invokes a simple call handler.
+        /// </summary>
+        public static AsyncServerMethodHandler UnaryCall<TRequest, TResponse>(Method<TRequest, TResponse> method, UnaryServerMethod<TRequest, TResponse> handler)
+            where TRequest : class
+            where TResponse : class
+        {
+            return new AsyncServerMethodHandler((serverCallDetails) => ServerCallHandler.HandleUnaryCallAsync(method, handler, serverCallDetails));
+        }
+
+        /// <summary>
+        /// Returns a delegate that invokes a client-streaming call handler.
+        /// </summary>
+        public static AsyncServerMethodHandler ClientStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, ClientStreamingServerMethod<TRequest, TResponse> handler)
+            where TRequest : class
+            where TResponse : class
+        {
+            return new AsyncServerMethodHandler((serverCallDetails) => ServerCallHandler.HandleClientStreamingCallAsync(method, handler, serverCallDetails));
+        }
+
+        /// <summary>
+        /// Returns a delegate that invokes a server streaming call handler.
+        /// </summary>
+        public static AsyncServerMethodHandler ServerStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, ServerStreamingServerMethod<TRequest, TResponse> handler)
+            where TRequest : class
+            where TResponse : class
+        {
+            return new AsyncServerMethodHandler((serverCallDetails) => ServerCallHandler.HandleServerStreamingCallAsync(method, handler, serverCallDetails));
+        }
+
+        /// <summary>
+        /// Returns a delegate that invokes a duplex streaming call handler.
+        /// </summary>
+        public static AsyncServerMethodHandler DuplexStreamingCall<TRequest, TResponse>(Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TRequest, TResponse> handler)
+            where TRequest : class
+            where TResponse : class
+        {
+            return new AsyncServerMethodHandler((serverCallDetails) => ServerCallHandler.HandleDuplexStreamingCallAsync(method, handler, serverCallDetails));
+        }
+    }
+}

--- a/src/csharp/Grpc.Core/ServerServiceDefinition.cs
+++ b/src/csharp/Grpc.Core/ServerServiceDefinition.cs
@@ -45,14 +45,14 @@ namespace Grpc.Core
     /// </summary>
     public class ServerServiceDefinition
     {
-        readonly ReadOnlyDictionary<string, IServerCallHandler> callHandlers;
+        readonly ReadOnlyDictionary<string, AsyncServerMethodHandler> callHandlers;
 
-        private ServerServiceDefinition(Dictionary<string, IServerCallHandler> callHandlers)
+        private ServerServiceDefinition(Dictionary<string, AsyncServerMethodHandler> callHandlers)
         {
-            this.callHandlers = new ReadOnlyDictionary<string, IServerCallHandler>(callHandlers);
+            this.callHandlers = new ReadOnlyDictionary<string, AsyncServerMethodHandler>(callHandlers);
         }
 
-        internal IDictionary<string, IServerCallHandler> CallHandlers
+        internal IDictionary<string, AsyncServerMethodHandler> CallHandlers
         {
             get
             {
@@ -74,7 +74,7 @@ namespace Grpc.Core
         /// </summary>
         public class Builder
         {
-            readonly Dictionary<string, IServerCallHandler> callHandlers = new Dictionary<string, IServerCallHandler>();
+            readonly Dictionary<string, AsyncServerMethodHandler> callHandlers = new Dictionary<string, AsyncServerMethodHandler>();
 
             /// <summary>
             /// Creates a new instance of builder.


### PR DESCRIPTION
Adds FallbackHandlerRegistry  property to Server.  If a method is not found in the list of registered services and fallback handler registry is set, the registry will be used to lookup handler based on the full method name and host.
That allows:
-- choosing a handler for a call dynamically
-- dispatching server-side call based on the "host" property of a server-side call (previously not possible)

-- also refactoring and cleanup of ServerCallHandler.cs code.
