### PR TITLE
Load default roots.pem in PHP via grpc_set_ssl_roots_override_callback

### DIFF
--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -56,6 +56,10 @@ class BaseStub
      */
     public function __construct($hostname, $opts, $channel = null)
     {
+        $ssl_roots = file_get_contents(
+            dirname(__FILE__).'/../../../../etc/roots.pem');
+        ChannelCredentials::setDefaultRootsPem($ssl_roots);
+
         $this->hostname = $hostname;
         $this->update_metadata = null;
         if (isset($opts['update_metadata'])) {

--- a/tools/dockerfile/interoptest/grpc_interop_php/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_php/build_interop.sh
@@ -40,8 +40,6 @@ cp -r /var/local/jenkins/service_account $HOME || true
 cd /var/local/git/grpc
 rvm --default use ruby-2.1
 
-make install-certs
-
 # gRPC core and protobuf need to be installed
 make install
 


### PR DESCRIPTION
Attempts to fixs this #5711.