### PR TITLE
Fix scope problem when GPR_SUPPORT_CHANNELS_FROM_FD is not defined

### DIFF
--- a/src/cpp/server/server_posix.cc
+++ b/src/cpp/server/server_posix.cc
@@ -42,8 +42,8 @@ namespace grpc {
 void AddInsecureChannelFromFd(Server* server, int fd) {
   grpc_server_add_insecure_channel_from_fd(
       server->c_server(), server->completion_queue()->cq(), fd);
+}
 
 #endif  // GPR_SUPPORT_CHANNELS_FROM_FD
-}
 
 }  // namespace grpc


### PR DESCRIPTION
Compilation fails when GPR_SUPPORT_CHANNELS_FROM_FD is not defined.

This is (at least) preventing successful builds on Windows (tested with VS2015 msbuild).