### PR TITLE
PHP: remove explicit version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "grpc/grpc",
   "type": "library",
   "description": "gRPC library for PHP",
-  "version": "0.15.0",
   "keywords": ["rpc"],
   "homepage": "http://grpc.io",
   "license": "BSD-3-Clause",

--- a/templates/composer.json.template
+++ b/templates/composer.json.template
@@ -4,7 +4,6 @@
     "name": "grpc/grpc",
     "type": "library",
     "description": "gRPC library for PHP",
-    "version": "${settings.php_version.php()}",
     "keywords": ["rpc"],
     "homepage": "http://grpc.io",
     "license": "BSD-3-Clause",


### PR DESCRIPTION
For our PHP package over at Packagist: https://packagist.org/packages/grpc/grpc it appears that we cannot get our tags/releases to be auto-updated in Packagist. After some research apparently we have to remove explicitly naming our releases in our `composer.json` file and have Packagist automatically pulls in tags/releases from our GitHub repo.