### PR TITLE
Drop unnecessary future division import

### DIFF
--- a/src/python/grpcio/tests/unit/_rpc_test.py
+++ b/src/python/grpcio/tests/unit/_rpc_test.py
@@ -29,8 +29,6 @@
 
 """Test of gRPC Python's application-layer API."""
 
-from __future__ import division
-
 import itertools
 import threading
 import unittest


### PR DESCRIPTION
We only ever use floor division (//) in the module.