### PR TITLE
Add well known protos to Node and Ruby tools packages

### DIFF
--- a/src/compiler/node_generator.cc
+++ b/src/compiler/node_generator.cc
@@ -74,8 +74,16 @@ grpc::string GetJSMessageFilename(const grpc::string& filename) {
 
 // Given a filename like foo/bar/baz.proto, returns the root directory
 // path ../../
-grpc::string GetRootPath(const grpc::string& filename) {
-  size_t slashes = std::count(filename.begin(), filename.end(), '/');
+grpc::string GetRootPath(const grpc::string& from_filename,
+                         const grpc::string& to_filename) {
+  if (to_filename.find("google/protobuf") == 0) {
+    // Well-known types (.proto files in the google/protobuf directory) are
+    // assumed to come from the 'google-protobuf' npm package.  We may want to
+    // generalize this exception later by letting others put generated code in
+    // their own npm packages.
+    return "google-protobuf/";
+  }
+  size_t slashes = std::count(from_filename.begin(), from_filename.end(), '/');
   if (slashes == 0) {
     return "./";
   }
@@ -90,7 +98,7 @@ grpc::string GetRootPath(const grpc::string& filename) {
 // from_file, assuming that both paths are relative to the same directory
 grpc::string GetRelativePath(const grpc::string& from_file,
                              const grpc::string& to_file) {
-  return GetRootPath(from_file) + to_file;
+  return GetRootPath(from_file, to_file) + to_file;
 }
 
 /* Finds all message types used in all services in the file, and returns them

--- a/src/node/tools/package.json
+++ b/src/node/tools/package.json
@@ -34,6 +34,7 @@
     "index.js",
     "bin/protoc.js",
     "bin/protoc_plugin.js",
+    "bin/google/protobuf",
     "LICENSE"
   ],
   "main": "index.js"

--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -81,7 +81,7 @@ for arch in {x86,x64}; do
         node_plat=$plat
         ;;
     esac
-    rm bin/*
+    rm -r bin/*
     input_dir="$EXTERNAL_GIT_ROOT/architecture=$arch,language=protoc,platform=$plat/artifacts"
     cp $input_dir/protoc* bin/
     cp $input_dir/grpc_node_plugin* bin/

--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -58,6 +58,8 @@ tools_version=$(npm list | grep -oP '(?<=grpc-tools@)\S+')
 output_dir=$artifacts/grpc-precompiled-binaries/node/grpc-tools/v$tools_version
 mkdir -p $output_dir
 
+well_known_protos=( any api compiler/plugin descriptor duration empty field_mask source_context struct timestamp type wrappers )
+
 for arch in {x86,x64}; do
   case arch in
     x86)
@@ -83,6 +85,10 @@ for arch in {x86,x64}; do
     input_dir="$EXTERNAL_GIT_ROOT/architecture=$arch,language=protoc,platform=$plat/artifacts"
     cp $input_dir/protoc* bin/
     cp $input_dir/grpc_node_plugin* bin/
+    mkdir -p bin/google/protobuf
+    for proto in "${well_known_protos[@]}"; do
+      cp $base/third_party/protobuf/src/google/protobuf/$proto.proto bin/google/protobuf/
+    done
     tar -czf $output_dir/$node_plat-$node_arch.tar.gz bin/
   done
 done

--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -87,7 +87,7 @@ for arch in {x86,x64}; do
     cp $input_dir/grpc_node_plugin* bin/
     mkdir -p bin/google/protobuf
     for proto in "${well_known_protos[@]}"; do
-      cp $base/third_party/protobuf/src/google/protobuf/$proto.proto bin/google/protobuf/
+      cp $base/third_party/protobuf/src/google/protobuf/$proto.proto bin/google/protobuf/$proto.proto
     done
     tar -czf $output_dir/$node_plat-$node_arch.tar.gz bin/
   done

--- a/tools/run_tests/build_package_ruby.sh
+++ b/tools/run_tests/build_package_ruby.sh
@@ -40,6 +40,8 @@ mkdir -p artifacts/
 # and we only collect them here to deliver them to the distribtest phase.
 cp -r $EXTERNAL_GIT_ROOT/architecture={x86,x64},language=ruby,platform={windows,linux,macos}/artifacts/* artifacts/ || true
 
+well_known_protos=( any api compiler/plugin descriptor duration empty field_mask source_context struct timestamp type wrappers )
+
 # TODO: all the artifact builder configurations generate a grpc-VERSION.gem
 # source distribution package, and only one of them will end up
 # in the artifacts/ directory. They should be all equivalent though.
@@ -56,9 +58,12 @@ for arch in {x86,x64}; do
   for plat in {windows,linux,macos}; do
     input_dir="$EXTERNAL_GIT_ROOT/architecture=$arch,language=protoc,platform=$plat/artifacts"
     output_dir="$base/src/ruby/tools/bin/${ruby_arch}-${plat}"
-    mkdir -p $output_dir
+    mkdir -p $output_dir/google/protobuf
     cp $input_dir/protoc* $output_dir/
     cp $input_dir/grpc_ruby_plugin* $output_dir/
+    for proto in "${well_known_protos[@]}"; do
+      cp $base/third_party/protobuf/src/google/protobuf/$proto.proto $output_dir/google/protobuf/
+    done
   done
 done
 

--- a/tools/run_tests/build_package_ruby.sh
+++ b/tools/run_tests/build_package_ruby.sh
@@ -62,7 +62,7 @@ for arch in {x86,x64}; do
     cp $input_dir/protoc* $output_dir/
     cp $input_dir/grpc_ruby_plugin* $output_dir/
     for proto in "${well_known_protos[@]}"; do
-      cp $base/third_party/protobuf/src/google/protobuf/$proto.proto $output_dir/google/protobuf/
+      cp $base/third_party/protobuf/src/google/protobuf/$proto.proto $output_dir/google/protobuf/$proto.proto
     done
   done
 done


### PR DESCRIPTION
This fixes #6739 and #6740. When the tools package is built during our artifact build, the well known protos are copied from third_party/protobuf.

Note, depending on something (protoc compilation options, possibly), users may need to explicitly specify the path containing `google/protobuf` in the proto_path for the Node code generation to work with these.