### PR TITLE
Disable ccache for ubuntu-14.04/clang3.4 docker config

### DIFF
--- a/templates/tools/dockerfile/run_tests_addons.include
+++ b/templates/tools/dockerfile/run_tests_addons.include
@@ -1,7 +1,2 @@
 <%include file="ccache_setup.include"/>
-#======================
-# Zookeeper dependencies
-# TODO(jtattermusch): is zookeeper still needed?
-RUN apt-get install -y libzookeeper-mt-dev
-
-RUN mkdir /var/local/jenkins
+<%include file="run_tests_addons_nocache.include"/>

--- a/templates/tools/dockerfile/run_tests_addons_nocache.include
+++ b/templates/tools/dockerfile/run_tests_addons_nocache.include
@@ -1,0 +1,6 @@
+#======================
+# Zookeeper dependencies
+# TODO(jtattermusch): is zookeeper still needed?
+RUN apt-get install -y libzookeeper-mt-dev
+
+RUN mkdir /var/local/jenkins

--- a/templates/tools/dockerfile/test/cxx_ubuntu1404_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_ubuntu1404_x64/Dockerfile.template
@@ -33,7 +33,6 @@
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../cxx_deps.include"/>
-  <%include file="../../run_tests_addons.include"/>
+  <%include file="../../run_tests_addons_nocache.include"/>
   # Define the default command.
   CMD ["bash"]
-  

--- a/tools/dockerfile/test/cxx_ubuntu1404_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_ubuntu1404_x64/Dockerfile
@@ -68,12 +68,12 @@ RUN apt-get update && apt-get install -y time && apt-get clean
 RUN apt-get update && apt-get -y install libgflags-dev libgtest-dev libc++-dev clang && apt-get clean
 
 # Prepare ccache
-RUN ln -s /usr/bin/ccache /usr/local/bin/gcc
-RUN ln -s /usr/bin/ccache /usr/local/bin/g++
-RUN ln -s /usr/bin/ccache /usr/local/bin/cc
-RUN ln -s /usr/bin/ccache /usr/local/bin/c++
-RUN ln -s /usr/bin/ccache /usr/local/bin/clang
-RUN ln -s /usr/bin/ccache /usr/local/bin/clang++
+#RUN ln -s /usr/bin/ccache /usr/local/bin/gcc
+#RUN ln -s /usr/bin/ccache /usr/local/bin/g++
+#RUN ln -s /usr/bin/ccache /usr/local/bin/cc
+#RUN ln -s /usr/bin/ccache /usr/local/bin/c++
+#RUN ln -s /usr/bin/ccache /usr/local/bin/clang
+#RUN ln -s /usr/bin/ccache /usr/local/bin/clang++
 
 #======================
 # Zookeeper dependencies

--- a/tools/dockerfile/test/cxx_ubuntu1404_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_ubuntu1404_x64/Dockerfile
@@ -67,14 +67,6 @@ RUN apt-get update && apt-get install -y time && apt-get clean
 # C++ dependencies
 RUN apt-get update && apt-get -y install libgflags-dev libgtest-dev libc++-dev clang && apt-get clean
 
-# Prepare ccache
-#RUN ln -s /usr/bin/ccache /usr/local/bin/gcc
-#RUN ln -s /usr/bin/ccache /usr/local/bin/g++
-#RUN ln -s /usr/bin/ccache /usr/local/bin/cc
-#RUN ln -s /usr/bin/ccache /usr/local/bin/c++
-#RUN ln -s /usr/bin/ccache /usr/local/bin/clang
-#RUN ln -s /usr/bin/ccache /usr/local/bin/clang++
-
 #======================
 # Zookeeper dependencies
 # TODO(jtattermusch): is zookeeper still needed?


### PR DESCRIPTION
ccache isn't working there. Disabling it allows the build to work properly.

Fixes #1929 

