### PR TITLE
Ignore unused variables in ruby compilation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -77,7 +77,7 @@ task 'dlls' do
   grpc_config = ENV['GRPC_CONFIG'] || 'opt'
   verbose = ENV['V'] || '0'
 
-  env = 'CPPFLAGS="-D_WIN32_WINNT=0x600 -DUNICODE -D_UNICODE" '
+  env = 'CPPFLAGS="-D_WIN32_WINNT=0x600 -DUNICODE -D_UNICODE -Wno-unused-variable -Wno-unused-result" '
   env += 'LDFLAGS=-static '
   env += 'SYSTEM=MINGW32 '
   env += 'EMBED_ZLIB=true '


### PR DESCRIPTION
In the interests of the 0.15 release, I've ignored unused variables.  Fixes for these warnings would need to be done by the owner, because I'm not entirely sure how these results/variables should be used.

```
src/core/lib/iomgr/iocp_windows.c: In function 'grpc_iocp_work':
src/core/lib/iomgr/iocp_windows.c:83:17: error: unused variable 'closure' [-Werror=unused-variable]
   grpc_closure *closure = NULL;
                 ^
cc1: all warnings being treated as errors
make: *** [/tmp/objs/opt/src/core/lib/iomgr/iocp_windows.o] Error 1
make: *** Waiting for unfinished jobs....
src/core/lib/iomgr/pollset_windows.c: In function 'grpc_pollset_shutdown':
src/core/lib/iomgr/pollset_windows.c:110:20: error: ignoring return value of 'grpc_pollset_kick', declared with attribute warn_unused_result [-Werror=unused-result]
   grpc_pollset_kick(pollset, GRPC_POLLSET_KICK_BROADCAST);
                    ^
src/core/lib/iomgr/pollset_windows.c: In function 'grpc_pollset_kick':
src/core/lib/iomgr/pollset_windows.c:232:24: error: ignoring return value of 'grpc_pollset_kick', declared with attribute warn_unused_result [-Werror=unused-result]
       grpc_pollset_kick(p, specific_worker);
                        ^
cc1: all warnings being treated as errors
make: *** [/tmp/objs/opt/src/core/lib/iomgr/pollset_windows.o] Error 1
src/core/lib/iomgr/tcp_server_windows.c: In function 'prepare_socket':
src/core/lib/iomgr/tcp_server_windows.c:227:15: error: unused variable 'final_error' [-Werror=unused-variable]
   grpc_error *final_error = grpc_error_set_int(
```