### PR TITLE
PHP: add some phpt test cases for PHP extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,11 @@ Pods/
 
 # Artifacts directory
 artifacts/
+
+# Temporary file of PHP extension test
+src/php/ext/grpc/tests/*.diff
+src/php/ext/grpc/tests/*.exp
+src/php/ext/grpc/tests/*.log
+src/php/ext/grpc/tests/*.out
+src/php/ext/grpc/tests/*.php
+src/php/ext/grpc/tests/*.sh

--- a/src/php/ext/grpc/tests/Call_cancel_basic.phpt
+++ b/src/php/ext/grpc/tests/Call_cancel_basic.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test cancel of Call : basic functionality
+--FILE--
+<?php
+$channel = new Grpc\Channel('localhost:1234', []);
+$call = new Grpc\Call($channel, '/hello', Grpc\Timeval::infFuture());
+$call->cancel();
+var_dump($call);
+?>
+===DONE===
+--EXPECTF--
+%s
+object(Grpc\Call)#2 (1) {
+  ["channel"]=>
+  object(Grpc\Channel)#1 (0) {
+  }
+}
+===DONE===

--- a/src/php/ext/grpc/tests/Call_construct_basic.phpt
+++ b/src/php/ext/grpc/tests/Call_construct_basic.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test new Call() : basic functionality
+--FILE--
+<?php
+$channel = new Grpc\Channel('localhost:1234', []);
+$call = new Grpc\Call($channel, '/hello', Grpc\Timeval::infFuture());
+var_dump($call);
+?>
+===DONE===
+--EXPECTF--
+%s
+object(Grpc\Call)#2 (1) {
+  ["channel"]=>
+  object(Grpc\Channel)#1 (0) {
+  }
+}
+===DONE===

--- a/src/php/ext/grpc/tests/Call_construct_error.phpt
+++ b/src/php/ext/grpc/tests/Call_construct_error.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test new Call() : error conditions 
+--FILE--
+<?php
+var_dump(new Grpc\Call());
+?>
+===DONE===
+--EXPECTF--
+%s
+
+Warning: Grpc\Call::__construct() expects at least 3 parameters, 0 given in %s on line %d
+
+Fatal error: Uncaught exception 'InvalidArgumentException' with message 'Call expects a Channel, a String, a Timeval and an optional String' in %s:%d
+Stack trace:
+#0 %s(%d): Grpc\Call->__construct()
+#1 {main}
+  thrown in %s on line %d

--- a/src/php/ext/grpc/tests/Call_getPeer_basic.phpt
+++ b/src/php/ext/grpc/tests/Call_getPeer_basic.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test getPeer of Call : basic functionality
+--FILE--
+<?php
+$channel = new Grpc\Channel('localhost:1234', []);
+$call = new Grpc\Call($channel, '/hello', Grpc\Timeval::infFuture());
+var_dump($call->getPeer());
+?>
+===DONE===
+--EXPECTF--
+%s
+string(14) "localhost:%d"
+===DONE===

--- a/src/php/ext/grpc/tests/ChannelCredentials_createInsecure_basic.phpt
+++ b/src/php/ext/grpc/tests/ChannelCredentials_createInsecure_basic.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test createInsecure of ChannelCredentials : basic functionality
+--FILE--
+<?php
+$cred = Grpc\ChannelCredentials::createInsecure();
+var_dump($cred);
+?>
+===DONE===
+--EXPECTF--
+%s
+NULL
+===DONE===

--- a/src/php/ext/grpc/tests/ChannelCredentials_createSsl_basic.phpt
+++ b/src/php/ext/grpc/tests/ChannelCredentials_createSsl_basic.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test createSsl of ChannelCredentials : basic functionality
+--FILE--
+<?php
+$cred = Grpc\ChannelCredentials::createSsl(null, null, null);
+var_dump($cred);
+?>
+===DONE===
+--EXPECTF--
+%s
+object(Grpc\ChannelCredentials)#1 (0) {
+}
+===DONE===

--- a/src/php/ext/grpc/tests/Channel_close_basic.phpt
+++ b/src/php/ext/grpc/tests/Channel_close_basic.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test close of Channel : basic functionality
+--FILE--
+<?php
+$channel = new Grpc\Channel('localhost:0', ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
+$channel->close();
+var_dump($channel);
+?>
+===DONE===
+--EXPECTF--
+%s
+object(Grpc\Channel)#1 (0) {
+}
+===DONE===

--- a/src/php/ext/grpc/tests/Channel_construct_basic.phpt
+++ b/src/php/ext/grpc/tests/Channel_construct_basic.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test new Channel() : basic functionality
+--FILE--
+<?php
+$channel = new Grpc\Channel('localhost:0', ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
+var_dump($channel);
+?>
+===DONE===
+--EXPECTF--
+%s
+object(Grpc\Channel)#1 (0) {
+}
+===DONE===

--- a/src/php/ext/grpc/tests/Channel_construct_error.phpt
+++ b/src/php/ext/grpc/tests/Channel_construct_error.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test new Channel() : error conditions 
+--FILE--
+<?php
+var_dump(new Grpc\Channel());
+?>
+===DONE===
+--EXPECTF--
+%s
+
+Warning: Grpc\Channel::__construct() expects exactly 2 parameters, %d given in %s on line %d
+
+Fatal error: Uncaught exception 'InvalidArgumentException' with message 'Channel expects a string and an array' in %s:%d
+Stack trace:
+#0 %s(%d): Grpc\Channel->__construct()
+#1 {main}
+  thrown in %s on line %d

--- a/src/php/ext/grpc/tests/Channel_getConnectivityState_basic.phpt
+++ b/src/php/ext/grpc/tests/Channel_getConnectivityState_basic.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test getConnectivityState of Channel : basic functionality
+--FILE--
+<?php
+$channel = new Grpc\Channel('localhost:0', ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
+$state = $channel->getConnectivityState(true);
+var_dump($state);
+?>
+===DONE===
+--EXPECTF--
+%s
+int(0)
+===DONE===

--- a/src/php/ext/grpc/tests/Channel_getTarget_basic.phpt
+++ b/src/php/ext/grpc/tests/Channel_getTarget_basic.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test getTarget of Channel : basic functionality
+--FILE--
+<?php
+$channel = new Grpc\Channel('localhost:8888', ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
+$target = $channel->getTarget();
+var_dump($target);
+?>
+===DONE===
+--EXPECTF--
+%s
+string(14) "localhost:8888"
+===DONE===

--- a/src/php/ext/grpc/tests/Channel_watchConnectivityState_basic.phpt
+++ b/src/php/ext/grpc/tests/Channel_watchConnectivityState_basic.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test watchConnectivityState of Channel : basic functionality
+--FILE--
+<?php
+$channel = new Grpc\Channel('localhost:0', ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
+$time = new Grpc\Timeval(1000);
+$state = $channel->watchConnectivityState(123, $time);
+unset($time);
+var_dump($state);
+?>
+===DONE===
+--EXPECTF--
+%s
+bool(true)
+===DONE===

--- a/src/php/ext/grpc/tests/ServerCredentials_createSsl_error.phpt
+++ b/src/php/ext/grpc/tests/ServerCredentials_createSsl_error.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test createSsl of ServerCredentials : error conditions 
+--FILE--
+<?php
+var_dump(Grpc\ServerCredentials::createSsl());
+?>
+===DONE===
+--EXPECTF--
+%s
+
+Warning: Grpc\ServerCredentials::createSsl() expects exactly 3 parameters, %d given in %s on line %d
+
+Fatal error: Uncaught exception 'InvalidArgumentException' with message 'createSsl expects 3 strings' in %s:%d
+Stack trace:
+#0 %s(%d): Grpc\ServerCredentials::createSsl()
+#1 {main}
+  thrown in %s on line %d

--- a/src/php/ext/grpc/tests/Server_addHttp2Port_basic.phpt
+++ b/src/php/ext/grpc/tests/Server_addHttp2Port_basic.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test addHttp2Port of Server : basic functionality
+--FILE--
+<?php
+$server = new Grpc\Server([]);
+$port = $server->addHttp2Port("127.0.0.1:1234");
+var_dump($port);
+?>
+===DONE===
+--EXPECTF--
+%s
+int(1234)
+===DONE===

--- a/src/php/ext/grpc/tests/Server_construct_basic.phpt
+++ b/src/php/ext/grpc/tests/Server_construct_basic.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Test new Server() : basic functionality
+--FILE--
+<?php
+$server = new Grpc\Server([]);
+var_dump($server);
+?>
+===DONE===
+--EXPECTF--
+%s
+object(Grpc\Server)#1 (0) {
+}
+===DONE===

--- a/src/php/ext/grpc/tests/Server_construct_error.phpt
+++ b/src/php/ext/grpc/tests/Server_construct_error.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test new Server() : error conditions 
+--FILE--
+<?php
+var_dump(new Grpc\Server('hello'));
+?>
+===DONE===
+--EXPECTF--
+%s
+
+Warning: Grpc\Server::__construct() expects parameter 1 to be array, string given in %s on line %d
+
+Fatal error: Uncaught exception 'InvalidArgumentException' with message 'Server expects an array' in %s:%d
+Stack trace:
+#0 %s(%d): Grpc\Server->__construct('hello')
+#1 {main}
+  thrown in %s on line %d

--- a/src/php/ext/grpc/tests/Timeval_add_basic.phpt
+++ b/src/php/ext/grpc/tests/Timeval_add_basic.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test add of Timeval : basic functionality
+--FILE--
+<?php
+$b = new Grpc\Timeval(1000);
+$e = new Grpc\Timeval(1000);
+$time = $e->add($b);
+var_dump($time);
+?>
+===DONE===
+--EXPECTF--
+%s
+object(Grpc\Timeval)#3 (0) {
+}
+===DONE===

--- a/src/php/ext/grpc/tests/Timeval_compare_basic.phpt
+++ b/src/php/ext/grpc/tests/Timeval_compare_basic.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test compare of Timeval : basic functionality
+--FILE--
+<?php
+$b = new Grpc\Timeval(1234);
+$e = new Grpc\Timeval(5678);
+$result = Grpc\Timeval::compare($b, $e);
+var_dump($result);
+var_dump(Grpc\Timeval::compare($e, $b));
+var_dump(Grpc\Timeval::compare($b, new Grpc\Timeval(1234)));
+?>
+===DONE===
+--EXPECTF--
+%s
+int(-1)
+int(1)
+int(0)
+===DONE===

--- a/src/php/ext/grpc/tests/Timeval_construct_basic.phpt
+++ b/src/php/ext/grpc/tests/Timeval_construct_basic.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test new Timeval() : basic functionality
+--FILE--
+<?php
+var_dump(new Grpc\Timeval(1234));
+var_dump(new Grpc\Timeval(123.456));
+?>
+===DONE===
+--EXPECTF--
+%s
+object(Grpc\Timeval)#1 (0) {
+}
+object(Grpc\Timeval)#1 (0) {
+}
+===DONE===

--- a/src/php/ext/grpc/tests/Timeval_construct_error.phpt
+++ b/src/php/ext/grpc/tests/Timeval_construct_error.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test new Timeval() : error conditions 
+--FILE--
+<?php
+var_dump(new Grpc\Timeval('hello'));
+?>
+===DONE===
+--EXPECTF--
+%s
+
+Warning: Grpc\Timeval::__construct() expects parameter 1 to be long, string given in %s on line %d
+
+Fatal error: Uncaught exception 'InvalidArgumentException' with message 'Timeval expects a long' in %s:%d
+Stack trace:
+#0 %s(%d): Grpc\Timeval->__construct('hello')
+#1 {main}
+  thrown in %s on line %d

--- a/src/php/ext/grpc/tests/Timeval_infFuture_basic.phpt
+++ b/src/php/ext/grpc/tests/Timeval_infFuture_basic.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test infFuture of Timeval : basic functionality
+--FILE--
+<?php
+var_dump(Grpc\Timeval::infFuture());
+?>
+===DONE===
+--EXPECTF--
+%s
+object(Grpc\Timeval)#1 (0) {
+}
+===DONE===

--- a/src/php/ext/grpc/tests/Timeval_infPast_basic.phpt
+++ b/src/php/ext/grpc/tests/Timeval_infPast_basic.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test infPast of Timeval : basic functionality
+--FILE--
+<?php
+var_dump(Grpc\Timeval::infPast());
+?>
+===DONE===
+--EXPECTF--
+%s
+object(Grpc\Timeval)#1 (0) {
+}
+===DONE===

--- a/src/php/ext/grpc/tests/Timeval_now_basic.phpt
+++ b/src/php/ext/grpc/tests/Timeval_now_basic.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test now of Timeval : basic functionality
+--FILE--
+<?php
+var_dump(Grpc\Timeval::now());
+?>
+===DONE===
+--EXPECTF--
+%s
+object(Grpc\Timeval)#1 (0) {
+}
+===DONE===

--- a/src/php/ext/grpc/tests/Timeval_similar_basic.phpt
+++ b/src/php/ext/grpc/tests/Timeval_similar_basic.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Test similar of Timeval : basic functionality
+--FILE--
+<?php
+$a = new Grpc\Timeval(1234);
+$b = new Grpc\Timeval(1234);
+$c = new Grpc\Timeval(1500);
+$d = new Grpc\Timeval(200);
+var_dump(Grpc\Timeval::similar($a, $b, $c));
+var_dump(Grpc\Timeval::similar($a, $c, $b));
+var_dump(Grpc\Timeval::similar($c, $a, $d));
+?>
+===DONE===
+--EXPECTF--
+%s
+bool(true)
+bool(true)
+bool(false)
+===DONE===

--- a/src/php/ext/grpc/tests/Timeval_sleepUntil_basic.phpt
+++ b/src/php/ext/grpc/tests/Timeval_sleepUntil_basic.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test sleepUntil of Timeval : basic functionality
+--FILE--
+<?php
+$b = microtime(true);
+$now = Grpc\Timeval::now();
+$time = new Grpc\Timeval(100);
+$a = $now->add($time);
+$a->sleepUntil();
+$e = microtime(true);
+var_dump($e - $b);
+?>
+===DONE===
+--EXPECTF--
+%s
+float(%f)
+===DONE===

--- a/src/php/ext/grpc/tests/Timeval_subtract_basic.phpt
+++ b/src/php/ext/grpc/tests/Timeval_subtract_basic.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test subtract of Timeval : basic functionality
+--FILE--
+<?php
+$b = new Grpc\Timeval(1234);
+$e = new Grpc\Timeval(5678);
+$time = $e->subtract($b);
+var_dump($time);
+?>
+===DONE===
+--EXPECTF--
+%s
+object(Grpc\Timeval)#3 (0) {
+}
+===DONE===

--- a/src/php/ext/grpc/tests/Timeval_zero_basic.phpt
+++ b/src/php/ext/grpc/tests/Timeval_zero_basic.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Test zero of Timeval : basic functionality
+--FILE--
+<?php
+var_dump(Grpc\Timeval::zero());
+?>
+===DONE===
+--EXPECTF--
+%s
+object(Grpc\Timeval)#1 (0) {
+}
+===DONE===

--- a/src/php/ext/grpc/tests/grpc-basic.phpt
+++ b/src/php/ext/grpc/tests/grpc-basic.phpt
@@ -4,7 +4,11 @@ Check for grpc presence
 <?php if (!extension_loaded("grpc")) print "skip"; ?>
 --FILE--
 <?php 
-echo "grpc extension is available";
+echo "grpc extension is available"."\n";
 ?>
+===DONE===
 --EXPECT--
+%s
 grpc extension is available
+
+===DONE===


### PR DESCRIPTION
But because when I run `php` command, the command line will output:

    D0716 16:59:58.117281000 140735164002304 ev_posix.c:106] Using polling engine: poll

So, each phpt file have `%s` in its expect result.

If this log not exists after, should delete `%s` in each phpt file.