### PR TITLE
Fix build node package

### DIFF
--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -86,6 +86,7 @@ for arch in {x86,x64}; do
     cp $input_dir/protoc* bin/
     cp $input_dir/grpc_node_plugin* bin/
     mkdir -p bin/google/protobuf
+    mkdir -p bin/google/protobuf/compiler  # needed for plugin.proto
     for proto in "${well_known_protos[@]}"; do
       cp $base/third_party/protobuf/src/google/protobuf/$proto.proto bin/google/protobuf/$proto.proto
     done


### PR DESCRIPTION
Fixes 
```
+ mkdir -p bin/google/protobuf
+ for proto in '"${well_known_protos[@]}"'
+ cp /var/local/git/grpc/third_party/protobuf/src/google/protobuf/any.proto bin/google/protobuf/any.proto
+ for proto in '"${well_known_protos[@]}"'
+ cp /var/local/git/grpc/third_party/protobuf/src/google/protobuf/api.proto bin/google/protobuf/api.proto
+ for proto in '"${well_known_protos[@]}"'
+ cp /var/local/git/grpc/third_party/protobuf/src/google/protobuf/compiler/plugin.proto bin/google/protobuf/compiler/plugin.proto
cp: cannot create regular file 'bin/google/protobuf/compiler/plugin.proto': No such file or directory
+ FAILED=true
+ '[' artifacts '!=' '' ']'
+ docker cp build_and_run_docker_c9a9ffd5-3665-48a4-98f0-066edd74d81b:/var/local/git/grpc/artifacts /home/jenkins/workspace/gRPC_build_packages/platform/linux
+ docker rm -f build_and_run_docker_c9a9ffd5-3665-48a4-98f0-066edd74d81b
build_and_run_docker_c9a9ffd5-3665-48a4-98f0-066edd74d81b
+ '[' true '!=' '' ']'
+ exit 1

FAILED: build_package.node_package [ret=1, pid=17397]
```