### PR TITLE
Uses require_relative to load protobuf messages.

### DIFF
--- a/src/compiler/ruby_generator.cc
+++ b/src/compiler/ruby_generator.cc
@@ -155,7 +155,7 @@ grpc::string GetServices(const FileDescriptor *file) {
     std::map<grpc::string, grpc::string> dep_vars = ListToDict({
         "dep.name", MessagesRequireName(file),
     });
-    out.Print(dep_vars, "require '$dep.name$'\n");
+    out.Print(dep_vars, "require_relative '$dep.name$'\n");
 
     // Write out services within the modules
     out.Print("\n");


### PR DESCRIPTION
This assumes message files generated by protoc will live alongside - or at least relative - to the grpc-generated services, and avoids having to do any load path manipulation in order to accommodate the common use case.

Fixes https://github.com/grpc/grpc/issues/6164.
