### PR TITLE
fix building ruby package

### DIFF
--- a/tools/run_tests/build_package_ruby.sh
+++ b/tools/run_tests/build_package_ruby.sh
@@ -59,6 +59,7 @@ for arch in {x86,x64}; do
     input_dir="$EXTERNAL_GIT_ROOT/architecture=$arch,language=protoc,platform=$plat/artifacts"
     output_dir="$base/src/ruby/tools/bin/${ruby_arch}-${plat}"
     mkdir -p $output_dir/google/protobuf
+    mkdir -p $output_dir/google/protobuf/compiler  # needed for plugin.proto
     cp $input_dir/protoc* $output_dir/
     cp $input_dir/grpc_ruby_plugin* $output_dir/
     for proto in "${well_known_protos[@]}"; do


### PR DESCRIPTION
Same fix as #7033

```
+ for arch in '{x86,x64}'
+ case $arch in
+ ruby_arch=x86
+ for plat in '{windows,linux,macos}'
+ input_dir=/var/local/jenkins/grpc/architecture=x86,language=protoc,platform=windows/artifacts
+ output_dir=/var/local/git/grpc/src/ruby/tools/bin/x86-windows
+ mkdir -p /var/local/git/grpc/src/ruby/tools/bin/x86-windows/google/protobuf
+ cp /var/local/jenkins/grpc/architecture=x86,language=protoc,platform=windows/artifacts/protoc.exe /var/local/git/grpc/src/ruby/tools/bin/x86-windows/
+ cp /var/local/jenkins/grpc/architecture=x86,language=protoc,platform=windows/artifacts/grpc_ruby_plugin.exe /var/local/git/grpc/src/ruby/tools/bin/x86-windows/
+ for proto in '"${well_known_protos[@]}"'
+ cp /var/local/git/grpc/third_party/protobuf/src/google/protobuf/any.proto /var/local/git/grpc/src/ruby/tools/bin/x86-windows/google/protobuf/any.proto
+ for proto in '"${well_known_protos[@]}"'
+ cp /var/local/git/grpc/third_party/protobuf/src/google/protobuf/api.proto /var/local/git/grpc/src/ruby/tools/bin/x86-windows/google/protobuf/api.proto
+ for proto in '"${well_known_protos[@]}"'
+ cp /var/local/git/grpc/third_party/protobuf/src/google/protobuf/compiler/plugin.proto /var/local/git/grpc/src/ruby/tools/bin/x86-windows/google/protobuf/compiler/plugin.proto
cp: cannot create regular file '/var/local/git/grpc/src/ruby/tools/bin/x86-windows/google/protobuf/compiler/plugin.proto': No such file or directory
+ FAILED=true
+ '[' artifacts '!=' '' ']'
+ docker cp build_and_run_docker_9c2ea48b-7f69-424c-bf57-52d594dc4e00:/var/local/git/grpc/artifacts /home/jenkins/workspace/gRPC_build_packages/platform/linux
+ docker rm -f build_and_run_docker_9c2ea48b-7f69-424c-bf57-52d594dc4e00
build_and_run_docker_9c2ea48b-7f69-424c-bf57-52d594dc4e00
+ '[' true '!=' '' ']'
+ exit 1

FAILED: build_package.ruby_package [ret=1, pid=23750]
```