### PR TITLE
(CoreCLR support) Improvements to nugets generated by dotnet CLI.

### DIFF
--- a/src/csharp/Grpc.Auth/project.json
+++ b/src/csharp/Grpc.Auth/project.json
@@ -12,6 +12,12 @@
     "requireLicenseAcceptance": false,
     "tags": [ "gRPC RPC Protocol HTTP/2 Auth OAuth2" ],
   },
+  "buildOptions": {
+    "define": [ "SIGNED" ],
+    "keyFile": "../keys/Grpc.snk",
+    "publicSign": true,
+    "xmlDoc": true
+  },
   "dependencies": {
     "Grpc.Core": "0.16.0-dev",
     "Google.Apis.Auth": "1.11.1"

--- a/src/csharp/Grpc.Core.Tests/project.json
+++ b/src/csharp/Grpc.Core.Tests/project.json
@@ -5,6 +5,10 @@
   "configurations": {
     "Debug": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "mappings": {
             "nativelibs/windows_x64/grpc_csharp_ext.dll": "../../../vsprojects/x64/Debug/grpc_csharp_ext.dll",
@@ -17,6 +21,10 @@
     },
     "Release": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "mappings": {
             "nativelibs/windows_x64/grpc_csharp_ext.dll": "../../../vsprojects/x64/Release/grpc_csharp_ext.dll",

--- a/src/csharp/Grpc.Core/project.json
+++ b/src/csharp/Grpc.Core/project.json
@@ -23,7 +23,11 @@
   },
   "shared": "Version.cs",
   "buildOptions": {
-    "embed": [ "../../../etc/roots.pem" ]
+    "embed": [ "../../../etc/roots.pem" ],
+    "define": [ "SIGNED" ],
+    "keyFile": "../keys/Grpc.snk",
+    "publicSign": true,
+    "xmlDoc": true
   },
   "dependencies": {
     "Ix-Async": "1.2.5"

--- a/src/csharp/Grpc.Core/project.json
+++ b/src/csharp/Grpc.Core/project.json
@@ -21,6 +21,7 @@
       "build/native/bin/macosx_x64/": "../nativelibs/macosx_x64/libgrpc_csharp_ext.dylib"
     }
   },
+  "shared": "Version.cs",
   "buildOptions": {
     "embed": [ "../../../etc/roots.pem" ]
   },

--- a/src/csharp/Grpc.Examples.MathClient/project.json
+++ b/src/csharp/Grpc.Examples.MathClient/project.json
@@ -5,6 +5,10 @@
   "configurations": {
     "Debug": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "mappings": {
             "nativelibs/windows_x64/grpc_csharp_ext.dll": "../../../vsprojects/x64/Debug/grpc_csharp_ext.dll",
@@ -17,6 +21,10 @@
     },
     "Release": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "mappings": {
             "nativelibs/windows_x64/grpc_csharp_ext.dll": "../../../vsprojects/x64/Release/grpc_csharp_ext.dll",

--- a/src/csharp/Grpc.Examples.MathServer/project.json
+++ b/src/csharp/Grpc.Examples.MathServer/project.json
@@ -5,6 +5,10 @@
   "configurations": {
     "Debug": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "mappings": {
             "nativelibs/windows_x64/grpc_csharp_ext.dll": "../../../vsprojects/x64/Debug/grpc_csharp_ext.dll",
@@ -17,6 +21,10 @@
     },
     "Release": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "mappings": {
             "nativelibs/windows_x64/grpc_csharp_ext.dll": "../../../vsprojects/x64/Release/grpc_csharp_ext.dll",

--- a/src/csharp/Grpc.Examples.Tests/project.json
+++ b/src/csharp/Grpc.Examples.Tests/project.json
@@ -5,6 +5,10 @@
   "configurations": {
     "Debug": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "mappings": {
             "nativelibs/windows_x64/grpc_csharp_ext.dll": "../../../vsprojects/x64/Debug/grpc_csharp_ext.dll",
@@ -17,6 +21,10 @@
     },
     "Release": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "mappings": {
             "nativelibs/windows_x64/grpc_csharp_ext.dll": "../../../vsprojects/x64/Release/grpc_csharp_ext.dll",

--- a/src/csharp/Grpc.HealthCheck.Tests/project.json
+++ b/src/csharp/Grpc.HealthCheck.Tests/project.json
@@ -5,6 +5,10 @@
   "configurations": {
     "Debug": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "mappings": {
             "nativelibs/windows_x64/grpc_csharp_ext.dll": "../../../vsprojects/x64/Debug/grpc_csharp_ext.dll",
@@ -17,6 +21,10 @@
     },
     "Release": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "mappings": {
             "nativelibs/windows_x64/grpc_csharp_ext.dll": "../../../vsprojects/x64/Release/grpc_csharp_ext.dll",

--- a/src/csharp/Grpc.HealthCheck/project.json
+++ b/src/csharp/Grpc.HealthCheck/project.json
@@ -12,6 +12,12 @@
     "requireLicenseAcceptance": false,
     "tags": [ "gRPC health check" ]
   },
+  "buildOptions": {
+    "define": [ "SIGNED" ],
+    "keyFile": "../keys/Grpc.snk",
+    "publicSign": true,
+    "xmlDoc": true
+  },
   "dependencies": {
     "Grpc.Core": "0.16.0-dev",
     "Google.Protobuf": "3.0.0-beta3"

--- a/src/csharp/Grpc.IntegrationTesting.Client/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.Client/project.json
@@ -5,6 +5,10 @@
   "configurations": {
     "Debug": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "include": "data/*",
           "mappings": {
@@ -18,6 +22,10 @@
     },
     "Release": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "include": "data/*",
           "mappings": {

--- a/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json
@@ -5,6 +5,10 @@
   "configurations": {
     "Debug": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "include": "data/*",
           "mappings": {
@@ -18,6 +22,10 @@
     },
     "Release": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "include": "data/*",
           "mappings": {

--- a/src/csharp/Grpc.IntegrationTesting.Server/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.Server/project.json
@@ -5,6 +5,10 @@
   "configurations": {
     "Debug": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "include": "data/*",
           "mappings": {
@@ -18,6 +22,10 @@
     },
     "Release": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "include": "data/*",
           "mappings": {

--- a/src/csharp/Grpc.IntegrationTesting.StressClient/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.StressClient/project.json
@@ -5,6 +5,10 @@
   "configurations": {
     "Debug": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "include": "data/*",
           "mappings": {
@@ -18,6 +22,10 @@
     },
     "Release": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "include": "data/*",
           "mappings": {

--- a/src/csharp/Grpc.IntegrationTesting/project.json
+++ b/src/csharp/Grpc.IntegrationTesting/project.json
@@ -5,6 +5,10 @@
   "configurations": {
     "Debug": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "include": "data/*",
           "mappings": {
@@ -18,6 +22,10 @@
     },
     "Release": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           "include": "data/*",
           "mappings": {

--- a/templates/src/csharp/Grpc.Auth/project.json.template
+++ b/templates/src/csharp/Grpc.Auth/project.json.template
@@ -14,6 +14,12 @@
       "requireLicenseAcceptance": false,
       "tags": [ "gRPC RPC Protocol HTTP/2 Auth OAuth2" ],
     },
+    "buildOptions": {
+      "define": [ "SIGNED" ],
+      "keyFile": "../keys/Grpc.snk",
+      "publicSign": true,
+      "xmlDoc": true
+    },
     "dependencies": {
       "Grpc.Core": "${settings.csharp_version}",
       "Google.Apis.Auth": "1.11.1"

--- a/templates/src/csharp/Grpc.Core/project.json.template
+++ b/templates/src/csharp/Grpc.Core/project.json.template
@@ -25,7 +25,11 @@
     },
     "shared": "Version.cs",
     "buildOptions": {
-      "embed": [ "../../../etc/roots.pem" ]
+      "embed": [ "../../../etc/roots.pem" ],
+      "define": [ "SIGNED" ],
+      "keyFile": "../keys/Grpc.snk",
+      "publicSign": true,
+      "xmlDoc": true
     },
     "dependencies": {
       "Ix-Async": "1.2.5"

--- a/templates/src/csharp/Grpc.Core/project.json.template
+++ b/templates/src/csharp/Grpc.Core/project.json.template
@@ -23,6 +23,7 @@
         "build/native/bin/macosx_x64/": "../nativelibs/macosx_x64/libgrpc_csharp_ext.dylib"
       }
     },
+    "shared": "Version.cs",
     "buildOptions": {
       "embed": [ "../../../etc/roots.pem" ]
     },

--- a/templates/src/csharp/Grpc.HealthCheck/project.json.template
+++ b/templates/src/csharp/Grpc.HealthCheck/project.json.template
@@ -14,6 +14,12 @@
       "requireLicenseAcceptance": false,
       "tags": [ "gRPC health check" ]
     },
+    "buildOptions": {
+      "define": [ "SIGNED" ],
+      "keyFile": "../keys/Grpc.snk",
+      "publicSign": true,
+      "xmlDoc": true
+    },
     "dependencies": {
       "Grpc.Core": "${settings.csharp_version}",
       "Google.Protobuf": "3.0.0-beta3"

--- a/templates/src/csharp/build_options.include
+++ b/templates/src/csharp/build_options.include
@@ -8,6 +8,10 @@
   "configurations": {
     "Debug": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           % if includeData:
           "include": "data/*",
@@ -23,6 +27,10 @@
     },
     "Release": {
       "buildOptions": {
+        "define": [ "SIGNED" ],
+        "keyFile": "../keys/Grpc.snk",
+        "publicSign": true,
+        "xmlDoc": true,
         "copyToOutput": {
           % if includeData:
           "include": "data/*",

--- a/templates/tools/dockerfile/test/csharp_coreclr_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/csharp_coreclr_x64/Dockerfile.template
@@ -29,7 +29,7 @@
   # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
   # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   
-  FROM microsoft/dotnet:1.0.0-preview1
+  FROM microsoft/dotnet:1.0.0-preview2-sdk
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../run_tests_addons.include"/>

--- a/tools/dockerfile/test/csharp_coreclr_x64/Dockerfile
+++ b/tools/dockerfile/test/csharp_coreclr_x64/Dockerfile
@@ -27,7 +27,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-FROM microsoft/dotnet:1.0.0-preview1
+FROM microsoft/dotnet:1.0.0-preview2-sdk
 
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \

--- a/tools/run_tests/build_csharp_coreclr.sh
+++ b/tools/run_tests/build_csharp_coreclr.sh
@@ -36,7 +36,3 @@ cd $(dirname $0)/../../src/csharp
 dotnet restore .
 
 dotnet build -f netstandard1.5 --configuration $MSBUILD_CONFIG '**/project.json'
-
-# Grpc.IntegrationTesting doesn't get built by the previous command for some reason.
-# TODO(jtattermusch): get rid of the hack
-dotnet build -f netstandard1.5 --configuration $MSBUILD_CONFIG Grpc.IntegrationTesting/project.json

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -522,7 +522,7 @@ class CSharpLanguage(object):
       if self.platform == 'linux':
         assembly_subdir += '/netstandard1.5/debian.8-x64'
         assembly_extension = ''
-      if self.platform == 'mac':
+      elif self.platform == 'mac':
         assembly_subdir += '/netstandard1.5/osx.10.11-x64'
         assembly_extension = ''
       else:


### PR DESCRIPTION
Progress toward getting dotnet CLI generated nugets on par with nugets generated from .nuspec files.
-- share Version.cs file with assembly properties across all projects
-- sign assemblies for all projects
-- generate xml docs for all projects

Also update coreclr docker image to newly released dotnet SDK preview2 (and some associated fixes).