### PR TITLE
Use open-source defaults to propagate Python plugin configuration

### DIFF
--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -66,6 +66,9 @@ using std::vector;
 
 namespace grpc_python_generator {
 
+GeneratorConfiguration::GeneratorConfiguration()
+    : grpc_package_root("grpc"), beta_package_root("grpc.beta") {}
+
 PythonGrpcGenerator::PythonGrpcGenerator(const GeneratorConfiguration& config)
     : config_(config) {}
 

--- a/src/compiler/python_generator.h
+++ b/src/compiler/python_generator.h
@@ -43,6 +43,7 @@ namespace grpc_python_generator {
 // Data pertaining to configuration of the generator with respect to anything
 // that may be used internally at Google.
 struct GeneratorConfiguration {
+  GeneratorConfiguration();
   grpc::string grpc_package_root;
   grpc::string beta_package_root;
 };

--- a/src/compiler/python_plugin.cc
+++ b/src/compiler/python_plugin.cc
@@ -38,8 +38,6 @@
 
 int main(int argc, char* argv[]) {
   grpc_python_generator::GeneratorConfiguration config;
-  config.grpc_package_root = "grpc";
-  config.beta_package_root = "grpc.beta";
   grpc_python_generator::PythonGrpcGenerator generator(config);
   return grpc::protobuf::compiler::PluginMain(argc, argv, &generator);
 }

--- a/tools/distrib/python/grpcio_tools/grpc/tools/main.cc
+++ b/tools/distrib/python/grpcio_tools/grpc/tools/main.cc
@@ -45,7 +45,6 @@ int protoc_main(int argc, char* argv[]) {
 
   // gRPC Python
   grpc_python_generator::GeneratorConfiguration grpc_py_config;
-  grpc_py_config.beta_package_root = "grpc.beta";
   grpc_python_generator::PythonGrpcGenerator grpc_py_generator(grpc_py_config);
   cli.RegisterGenerator("--grpc_python_out", &grpc_py_generator,
                         "Generate Python source file.");


### PR DESCRIPTION
Since we rely on C++11 *anyway*, we may as well use defaults to ensure that
changes to the Python plugin that touch path configuration variables don't
break import paths in grpcio-tools.

~~Potential~~ fix for #7101.