### PR TITLE
Give existing port_server time to respond

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1055,7 +1055,7 @@ def _start_port_server(port_server_port):
   try:
     version = int(urllib2.urlopen(
         'http://localhost:%d/version_number' % port_server_port,
-        timeout=1).read())
+        timeout=10).read())
     print 'detected port server running version %d' % version
     running = True
   except Exception as e:


### PR DESCRIPTION
Recently seen very often on mac workers:   run_tests.py tries to detect an existing port server, port server doesn't respond in time and run_tests.py fails with trying to start a new port server.

This should alleviate the problem.

```
+ tools/jenkins/run_jenkins.sh
tools/jenkins/run_jenkins.sh: line 40: set: igncr: invalid option name
+ set -ex
+ '[' macos == linux ']'
+ '[' macos == freebsd ']'
+ unset platform
+ python tools/run_tests/run_tests.py -t -l c -c opt -x report.xml -j 2
Traceback (most recent call last):
  File "tools/run_tests/run_tests.py", line 1112, in _start_port_server
    timeout=1).read()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 431, in open
    response = self._open(req, data)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 449, in _open
    '_open', req)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 409, in _call_chain
    result = func(*args)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 1227, in http_open
    return self.do_open(httplib.HTTPConnection, req)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/urllib2.py", line 1197, in do_open
    raise URLError(err)
URLError: <urlopen error timed out>
START: make
PASSED: make [time=95.9sec; retries=0:0]
failed to detect port server: <class 'urllib2.URLError'>
None
starting port_server, with log file /var/folders/g4/3ppgfd8x4274zrnf_tf60_8h0000gn/T/tmpTWGahb
port_server failed to start
port server running on port 32767
Traceback (most recent call last):
  File "/jenkins/workspace/gRPC_master/config/opt/language/c/platform/macos/tools/run_tests/port_server.py", line 157, in <module>
    httpd = BaseHTTPServer.HTTPServer(('', args.port), Handler)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 420, in __init__
    self.server_bind()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/BaseHTTPServer.py", line 108, in server_bind
    SocketServer.TCPServer.server_bind(self)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 434, in server_bind
    self.socket.bind(self.server_address)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
socket.error: [Errno 48] Address already in use

+ TESTS_FAILED=true
```