### PR TITLE
Removed unnecessary call references

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
@@ -66,7 +66,7 @@ cdef class Channel:
     if host is not None:
       host_c_string = host
     cdef Call operation_call = Call()
-    operation_call.references = [self, method, host, queue]
+    operation_call.references = [self]
     cdef grpc_call *parent_call = NULL
     if parent is not None:
       parent_call = parent.c_call


### PR DESCRIPTION
Addresses #7090

Method/host are innocuous but superfluous given that the c-core copies them:

https://github.com/grpc/grpc/blob/master/src/core/lib/transport/metadata.c#L360
(This function gets called on the inputs)

Keeping a reference to the queue causes problems because it prevents the queue from getting pumped when it goes out of scope, which in turn calls ```Py_Decref(tag)```, which in turn allows the channel to be properly shutdown.  Even if the queue goes out of user scope while the call is in flight, holding the reference is useless because the queue is needed to get the result of the call.

Note that without this fix, running in a loop in gdb would cause the segfault to occur < 3min.  After the fix, 10+min of looping did not segfault.
