### PR TITLE
Lowered six dependency version to 1.5.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    'six>=1.10',
+    'six>=1.5.2',
     'enum34>=1.0.4',
     'futures>=2.2.0',
     # TODO(atash): eventually split the grpcio package into a metapackage
@@ -175,10 +175,11 @@ INSTALL_REQUIRES = (
     'protobuf>=3.0.0a3',
 )
 
-SETUP_REQUIRES = (
+SETUP_REQUIRES = INSTALL_REQUIRES + (
     'sphinx>=1.3',
-    'sphinx_rtd_theme>=0.1.8'
-) + INSTALL_REQUIRES
+    'sphinx_rtd_theme>=0.1.8',
+    'six>=1.10',
+)
 
 COMMAND_CLASS = {
     'doc': commands.SphinxDocumentation,


### PR DESCRIPTION
Addresses
https://github.com/GoogleCloudPlatform/gcloud-python/issues/1928

Note that sphinx is the offending library that caused us to abandon https://github.com/grpc/grpc/pull/5284

Sphinx is only a setup dependency, so I was able to work around it.