### PR TITLE
Fix beta-adaptation Rendezvous exception()

### DIFF
--- a/src/python/grpcio/grpc/beta/_client_adaptations.py
+++ b/src/python/grpcio/grpc/beta/_client_adaptations.py
@@ -117,7 +117,10 @@ class _Rendezvous(future.Future, face.Call):
   def exception(self, timeout=None):
     try:
       rpc_error_call = self._future.exception(timeout=timeout)
-      return _abortion_error(rpc_error_call)
+      if rpc_error_call is None:
+        return None
+      else:
+        return _abortion_error(rpc_error_call)
     except grpc.FutureTimeoutError:
       raise future.TimeoutError()
     except grpc.FutureCancelledError:

--- a/src/python/grpcio/tests/unit/beta/_beta_features_test.py
+++ b/src/python/grpcio/tests/unit/beta/_beta_features_test.py
@@ -239,6 +239,7 @@ class BetaFeaturesTest(unittest.TestCase):
     self._servicer.block_until_serviced()
     self.assertIsNotNone(self._servicer.peer())
     self.assertEqual(_RESPONSE, response_future.result())
+    self.assertIsNone(response_future.exception())
     invocation_metadata = [(metadatum.key, metadatum.value) for metadatum in
                            self._servicer._invocation_metadata]
     self.assertIn(


### PR DESCRIPTION
The exception() method of a Future is documented [1] to return None if
the call completed without raising.  The futures returned from the beta
API used to work this way.  Since the beta API was changed to wrap the
GA API, this broke because the wrapper tried to do exception-type
conversion on the result of the call without checking if there had been
an exception.

This change fixes the beta API _Rendezvous to restore the previous
behaviour.

[1] https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Future.exception