### PR TITLE
PHP: fix shutdown hang issue

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
   <email>grpc-packages@google.com</email>
   <active>yes</active>
  </lead>
- <date>2016-05-19</date>
+ <date>2016-06-30</date>
  <time>16:06:07</time>
  <version>
   <release>0.16.0</release>
@@ -22,7 +22,7 @@
  </stability>
  <license>BSD</license>
  <notes>
-- TBD
+- Fix shutdown hang problem #4017
  </notes>
  <contents>
   <dir baseinstalldir="/" name="/">
@@ -1034,6 +1034,7 @@ Update to wrap gRPC C Core version 0.10.0
    <license>BSD</license>
    <notes>
 - Simplify gRPC PHP installation #4517
+- Wrap gRPC core library version 0.13
    </notes>
   </release>
   <release>
@@ -1063,13 +1064,14 @@ Update to wrap gRPC C Core version 0.10.0
    <date>2016-04-19</date>
    <license>BSD</license>
    <notes>
+- wrap grpc C core version 0.14.0
 - destroy grpc_byte_buffer after startBatch #6096
    </notes>
   </release>
   <release>
    <version>
-    <release>0.14.2</release>
-    <api>0.14.2</api>
+    <release>0.15.0</release>
+    <api>0.15.0</api>
    </version>
    <stability>
     <release>beta</release>
@@ -1079,6 +1081,22 @@ Update to wrap gRPC C Core version 0.10.0
    <license>BSD</license>
    <notes>
 - Updated functions with TSRM macros for ZTS support #6607
+- Load default roots.pem via grpc_set_ssl_roots_override_callback #6848
+   </notes>
+  </release>
+  <release>
+   <version>
+    <release>0.15.1</release>
+    <api>0.15.1</api>
+   </version>
+   <stability>
+    <release>beta</release>
+    <api>beta</api>
+   </stability>
+   <date>2016-06-30</date>
+   <license>BSD</license>
+   <notes>
+- Fix shutdown hang problem #4017
    </notes>
   </release>
  </changelog>

--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -248,6 +248,7 @@ PHP_METHOD(Call, __construct) {
   call->wrapped = grpc_channel_create_call(
       channel->wrapped, NULL, GRPC_PROPAGATE_DEFAULTS, completion_queue, method,
       host_override, deadline->wrapped, NULL);
+  call->owned = true;
 }
 
 /**

--- a/templates/package.xml.template
+++ b/templates/package.xml.template
@@ -12,7 +12,7 @@
     <email>grpc-packages@google.com</email>
     <active>yes</active>
    </lead>
-   <date>2016-05-19</date>
+   <date>2016-06-30</date>
    <time>16:06:07</time>
    <version>
     <release>${settings.php_version.php()}</release>
@@ -24,7 +24,7 @@
    </stability>
    <license>BSD</license>
    <notes>
-  - TBD
+  - Fix shutdown hang problem #4017
    </notes>
    <contents>
     <dir baseinstalldir="/" name="/">
@@ -153,6 +153,7 @@
      <license>BSD</license>
      <notes>
   - Simplify gRPC PHP installation #4517
+  - Wrap gRPC core library version 0.13
      </notes>
     </release>
     <release>
@@ -182,13 +183,14 @@
      <date>2016-04-19</date>
      <license>BSD</license>
      <notes>
+  - wrap grpc C core version 0.14.0
   - destroy grpc_byte_buffer after startBatch #6096
      </notes>
     </release>
     <release>
      <version>
-      <release>0.14.2</release>
-      <api>0.14.2</api>
+      <release>0.15.0</release>
+      <api>0.15.0</api>
      </version>
      <stability>
       <release>beta</release>
@@ -198,6 +200,22 @@
      <license>BSD</license>
      <notes>
   - Updated functions with TSRM macros for ZTS support #6607
+  - Load default roots.pem via grpc_set_ssl_roots_override_callback #6848
+     </notes>
+    </release>
+    <release>
+     <version>
+      <release>0.15.1</release>
+      <api>0.15.1</api>
+     </version>
+     <stability>
+      <release>beta</release>
+      <api>beta</api>
+     </stability>
+     <date>2016-06-30</date>
+     <license>BSD</license>
+     <notes>
+  - Fix shutdown hang problem #4017
      </notes>
     </release>
    </changelog>


### PR DESCRIPTION
Fixes #4017  (Same as $7154 but this is for the `master` branch)

When a PHP script using the gRPC extension exits (after doing anything non-trivial), the process hangs for about 10 seconds before exiting. Turns out, the `grpc_shutdown()` call (called by `PHP_MSHUTDOWN_FUNCTION` was giving out errors because leaked objects were detected, but somehow the logs were suppressed and never made it to stdout. 

Diving inside `grpc_shutdown()` we realize it's `grpc_iomgr_shutdown()` that's giving errors. After some more investigation, we found that the PHP `Call` object was never properly destroyed via `grpc_call_destroy()` because the variable `call->owned` was never properly set to `true`. 