### PR TITLE
Make handlers optional at server construction

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -1207,25 +1207,23 @@ def secure_channel(target, credentials, options=None):
   return _channel.Channel(target, options, credentials._credentials)
 
 
-def server(generic_rpc_handlers, thread_pool, options=None):
+def server(thread_pool, handlers=None):
   """Creates a Server with which RPCs can be serviced.
 
-  The GenericRpcHandlers passed to this function needn't be the only
-  GenericRpcHandlers that will be used to serve RPCs; others may be added later
-  by calling add_generic_rpc_handlers any time before the returned server is
-  started.
-
   Args:
-    generic_rpc_handlers: Some number of GenericRpcHandlers that will be used
-      to service RPCs after the returned Server is started.
     thread_pool: A futures.ThreadPoolExecutor to be used by the returned Server
       to service RPCs.
+    handlers: An optional sequence of GenericRpcHandlers to be used to service
+      RPCs after the returned Server is started. These handlers need not be the
+      only handlers the returned Server will use to service RPCs; other
+      handlers may later be added to the returned Server by calling its
+      add_generic_rpc_handlers method any time before it is started.
 
   Returns:
     A Server with which RPCs can be serviced.
   """
   from grpc import _server
-  return _server.Server(generic_rpc_handlers, thread_pool)
+  return _server.Server(thread_pool, () if handlers is None else handlers)
 
 
 ###################################  __all__  #################################

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -731,7 +731,7 @@ def _start(state):
 
 class Server(grpc.Server):
 
-  def __init__(self, generic_handlers, thread_pool):
+  def __init__(self, thread_pool, generic_handlers):
     completion_queue = cygrpc.CompletionQueue()
     server = cygrpc.Server()
     server.register_completion_queue(completion_queue)

--- a/src/python/grpcio/grpc/beta/_server_adaptations.py
+++ b/src/python/grpcio/grpc/beta/_server_adaptations.py
@@ -371,4 +371,5 @@ def server(
         _DEFAULT_POOL_SIZE if thread_pool_size is None else thread_pool_size)
   else:
     effective_thread_pool = thread_pool
-  return _Server(grpc.server((generic_rpc_handler,), effective_thread_pool))
+  return _Server(
+      grpc.server(effective_thread_pool, handlers=(generic_rpc_handler,)))

--- a/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
@@ -171,7 +171,7 @@ def _CreateService():
       return servicer_methods.HalfDuplexCall(request_iter, context)
 
   server = grpc.server(
-      (), futures.ThreadPoolExecutor(max_workers=test_constants.POOL_SIZE))
+      futures.ThreadPoolExecutor(max_workers=test_constants.POOL_SIZE))
   getattr(service_pb2, ADD_SERVICER_TO_SERVER_IDENTIFIER)(Servicer(), server)
   port = server.add_insecure_port('[::]:0')
   server.start()
@@ -192,7 +192,7 @@ def _CreateIncompleteService():
     pass
 
   server = grpc.server(
-      (), futures.ThreadPoolExecutor(max_workers=test_constants.POOL_SIZE))
+      futures.ThreadPoolExecutor(max_workers=test_constants.POOL_SIZE))
   getattr(service_pb2, ADD_SERVICER_TO_SERVER_IDENTIFIER)(Servicer(), server)
   port = server.add_insecure_port('[::]:0')
   server.start()

--- a/src/python/grpcio_tests/tests/unit/_channel_connectivity_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_connectivity_test.py
@@ -104,7 +104,7 @@ class ChannelConnectivityTest(unittest.TestCase):
         grpc.ChannelConnectivity.READY, fifth_connectivities)
 
   def test_immediately_connectable_channel_connectivity(self):
-    server = _server.Server((), futures.ThreadPoolExecutor(max_workers=0))
+    server = _server.Server(futures.ThreadPoolExecutor(max_workers=0), ())
     port = server.add_insecure_port('[::]:0')
     server.start()
     first_callback = _Callback()
@@ -143,7 +143,7 @@ class ChannelConnectivityTest(unittest.TestCase):
         grpc.ChannelConnectivity.SHUTDOWN, fourth_connectivities)
 
   def test_reachable_then_unreachable_channel_connectivity(self):
-    server = _server.Server((), futures.ThreadPoolExecutor(max_workers=0))
+    server = _server.Server(futures.ThreadPoolExecutor(max_workers=0), ())
     port = server.add_insecure_port('[::]:0')
     server.start()
     callback = _Callback()

--- a/src/python/grpcio_tests/tests/unit/_channel_ready_future_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_ready_future_test.py
@@ -78,7 +78,7 @@ class ChannelReadyFutureTest(unittest.TestCase):
     self.assertFalse(ready_future.running())
 
   def test_immediately_connectable_channel_connectivity(self):
-    server = _server.Server((), futures.ThreadPoolExecutor(max_workers=0))
+    server = _server.Server(futures.ThreadPoolExecutor(max_workers=0), ())
     port = server.add_insecure_port('[::]:0')
     server.start()
     channel = grpc.insecure_channel('localhost:{}'.format(port))

--- a/src/python/grpcio_tests/tests/unit/_compression_test.py
+++ b/src/python/grpcio_tests/tests/unit/_compression_test.py
@@ -88,7 +88,8 @@ class CompressionTest(unittest.TestCase):
 
   def setUp(self):
     self._server_pool = logging_pool.pool(test_constants.THREAD_CONCURRENCY)
-    self._server = grpc.server((_GenericHandler(),), self._server_pool)
+    self._server = grpc.server(
+        self._server_pool, handlers=(_GenericHandler(),))
     self._port = self._server.add_insecure_port('[::]:0')
     self._server.start()
 

--- a/src/python/grpcio_tests/tests/unit/_empty_message_test.py
+++ b/src/python/grpcio_tests/tests/unit/_empty_message_test.py
@@ -103,7 +103,8 @@ class EmptyMessageTest(unittest.TestCase):
 
   def setUp(self):
     self._server_pool = logging_pool.pool(test_constants.THREAD_CONCURRENCY)
-    self._server = grpc.server((_GenericHandler(),), self._server_pool)
+    self._server = grpc.server(
+        self._server_pool, handlers=(_GenericHandler(),))
     port = self._server.add_insecure_port('[::]:0')
     self._server.start()
     self._channel = grpc.insecure_channel('localhost:%d' % port)

--- a/src/python/grpcio_tests/tests/unit/_metadata_code_details_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_code_details_test.py
@@ -189,7 +189,7 @@ class MetadataCodeDetailsTest(unittest.TestCase):
     self._servicer = _Servicer()
     self._server_pool = logging_pool.pool(test_constants.THREAD_CONCURRENCY)
     self._server = grpc.server(
-        (_generic_handler(self._servicer),), self._server_pool)
+        self._server_pool, handlers=(_generic_handler(self._servicer),))
     port = self._server.add_insecure_port('[::]:0')
     self._server.start()
 

--- a/src/python/grpcio_tests/tests/unit/_metadata_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_test.py
@@ -161,8 +161,8 @@ class MetadataTest(unittest.TestCase):
 
   def setUp(self):
     self._server_pool = logging_pool.pool(test_constants.THREAD_CONCURRENCY)
-    self._server = grpc.server((_GenericHandler(weakref.proxy(self)),),
-                               self._server_pool)
+    self._server = grpc.server(
+        self._server_pool, handlers=(_GenericHandler(weakref.proxy(self)),))
     port = self._server.add_insecure_port('[::]:0')
     self._server.start()
     self._channel = grpc.insecure_channel('localhost:%d' % port,

--- a/src/python/grpcio_tests/tests/unit/_rpc_test.py
+++ b/src/python/grpcio_tests/tests/unit/_rpc_test.py
@@ -184,7 +184,7 @@ class RPCTest(unittest.TestCase):
     self._handler = _Handler(self._control)
     self._server_pool = logging_pool.pool(test_constants.THREAD_CONCURRENCY)
 
-    self._server = grpc.server((), self._server_pool)
+    self._server = grpc.server(self._server_pool)
     port = self._server.add_insecure_port('[::]:0')
     self._server.add_generic_rpc_handlers((_GenericHandler(self._handler),))
     self._server.start()


### PR DESCRIPTION
This fixes [issue 7062](https://github.com/grpc/grpc/issues/7062) and is the master version of what was merged into `release-0_15` in [pull request 7148](https://github.com/grpc/grpc/pull/7148). (Two different commits because `_compression_test.py` was in conflict between the branches.)