### PR TITLE
Removed invalid sentence from interop flag description

### DIFF
--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -30,8 +30,7 @@ Clients should accept these arguments:
       [ca.pem](https://github.com/grpc/grpc/blob/master/src/core/lib/tsi/test_creds/ca.pem)
       as the CA root
 * --default_service_account=ACCOUNT_EMAIL
-    * Email of the GCE default service account. Only applicable
-      for compute_engine_creds test.
+    * Email of the GCE default service account.
 * --oauth_scope=SCOPE
     * OAuth scope. For example, "https://www.googleapis.com/auth/xapi.zoo"
 * --service_account_key_file=PATH


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/3744