### PR TITLE
fix Rendezvous.exception() does not return None when no exception is raised

### DIFF
--- a/src/python/grpcio/grpc/beta/_client_adaptations.py
+++ b/src/python/grpcio/grpc/beta/_client_adaptations.py
@@ -117,7 +117,7 @@ class _Rendezvous(future.Future, face.Call):
   def exception(self, timeout=None):
     try:
       rpc_error_call = self._future.exception(timeout=timeout)
-      return _abortion_error(rpc_error_call)
+      return rpc_error_call or _abortion_error(rpc_error_call)
     except grpc.FutureTimeoutError:
       raise future.TimeoutError()
     except grpc.FutureCancelledError:


### PR DESCRIPTION
grpc.framework.foundation.future.Future.exception() states :
>     Returns:
>       The exception raised by the computation, or None if the computation did
>         not raise an exception.

grpc.beta._client_adaptations._Rendezvous.exception() fails to implement it correctly.

If the computation does not raise, then rpc_error_call is None, then _abortion_error() raises.