### PR TITLE
Reintroduce `@class ProtoRPC;` in ProtoService.h

### DIFF
--- a/src/objective-c/ProtoRPC/ProtoService.h
+++ b/src/objective-c/ProtoRPC/ProtoService.h
@@ -34,6 +34,7 @@
 #import <Foundation/Foundation.h>
 
 @class GRPCProtoCall;
+@class ProtoRPC;
 @protocol GRXWriteable;
 @class GRXWriter;
 


### PR DESCRIPTION
I thought we had already done it?

Some people importing the header for a generated service rely on `ProtoRPC` being declared by it (transitively).