### PR TITLE
Add project.json dependencies in Grpc.sln

### DIFF
--- a/src/csharp/Grpc.Auth/Grpc.Auth.project.json
+++ b/src/csharp/Grpc.Auth/Grpc.Auth.project.json
@@ -1,8 +1,13 @@
-{
+﻿{
   "frameworks": {
-    "net45": { }
+    "net45": {}
   },
   "runtimes": {
-    "win": { }
+    "win": {}
+  },
+  "dependencies": {
+    "BouncyCastle.Crypto.dll": "1.8.1",
+    "Google.Apis.Core": "1.13.1",
+    "Newtonsoft.Json": "7.0.1"
   }
 }

--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.project.json
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.project.json
@@ -4,5 +4,10 @@
   },
   "runtimes": {
     "win": { }
+  },
+  "dependencies": {
+    "Newtonsoft.Json": "7.0.1",
+    "NUnit": "3.2.0",
+    "NUnitLite": "3.2.0"
   }
 }

--- a/src/csharp/Grpc.Core/Grpc.Core.project.json
+++ b/src/csharp/Grpc.Core/Grpc.Core.project.json
@@ -4,5 +4,8 @@
   },
   "runtimes": {
     "win": { }
+  },
+  "dependencies": {
+    "Ix-Async": "1.2.5"
   }
 }

--- a/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.project.json
+++ b/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.project.json
@@ -4,5 +4,11 @@
   },
   "runtimes": {
     "win": { }
+  },
+  "dependencies": {
+    "Google.Protobuf": "3.0.0-beta3",
+    "Ix-Async": "1.2.5",
+    "NUnit": "3.2.0",
+    "NUnitLite": "3.2.0"
   }
 }

--- a/src/csharp/Grpc.Examples/Grpc.Examples.project.json
+++ b/src/csharp/Grpc.Examples/Grpc.Examples.project.json
@@ -4,5 +4,9 @@
   },
   "runtimes": {
     "win": { }
+  },
+  "dependencies": {
+    "Google.Protobuf": "3.0.0-beta3",
+    "Ix-Async": "1.2.5"
   }
 }

--- a/src/csharp/Grpc.HealthCheck.Tests/Grpc.HealthCheck.Tests.project.json
+++ b/src/csharp/Grpc.HealthCheck.Tests/Grpc.HealthCheck.Tests.project.json
@@ -4,5 +4,10 @@
   },
   "runtimes": {
     "win": { }
+  },
+  "dependencies": {
+    "Google.Protobuf": "3.0.0-beta3",
+    "NUnit": "3.2.0",
+    "NUnitLite": "3.2.0"
   }
 }

--- a/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.project.json
+++ b/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.project.json
@@ -4,5 +4,9 @@
   },
   "runtimes": {
     "win": { }
+  },
+  "dependencies": {
+    "Google.Protobuf": "3.0.0-beta3",
+    "Ix-Async": "1.2.5"
   }
 }

--- a/src/csharp/Grpc.IntegrationTesting.Client/Grpc.IntegrationTesting.Client.project.json
+++ b/src/csharp/Grpc.IntegrationTesting.Client/Grpc.IntegrationTesting.Client.project.json
@@ -1,8 +1,13 @@
-{
+﻿{
   "frameworks": {
-    "net45": { }
+    "net45": {}
   },
   "runtimes": {
-    "win": { }
+    "win": {}
+  },
+  "dependencies": {
+    "BouncyCastle.Crypto.dll": "1.8.1",
+    "Google.Apis.Core": "1.13.1",
+    "Newtonsoft.Json": "7.0.1"
   }
 }

--- a/src/csharp/Grpc.IntegrationTesting.Server/Grpc.IntegrationTesting.Server.project.json
+++ b/src/csharp/Grpc.IntegrationTesting.Server/Grpc.IntegrationTesting.Server.project.json
@@ -1,8 +1,13 @@
-{
+﻿{
   "frameworks": {
-    "net45": { }
+    "net45": {}
   },
   "runtimes": {
-    "win": { }
+    "win": {}
+  },
+  "dependencies": {
+    "BouncyCastle.Crypto.dll": "1.8.1",
+    "Google.Apis.Core": "1.13.1",
+    "Newtonsoft.Json": "7.0.1"
   }
 }

--- a/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.project.json
+++ b/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.project.json
@@ -1,8 +1,19 @@
-{
+﻿{
   "frameworks": {
-    "net45": { }
+    "net45": {}
   },
   "runtimes": {
-    "win": { }
+    "win": {}
+  },
+  "dependencies": {
+    "BouncyCastle.Crypto.dll": "1.8.1",
+    "CommandLineParser": "1.9.71",
+    "Google.Apis.Core": "1.13.1",
+    "Google.Protobuf": "3.0.0-beta3",
+    "Ix-Async": "1.2.5",
+    "Moq": "4.2.1510.2205",
+    "Newtonsoft.Json": "7.0.1",
+    "NUnit": "3.2.0",
+    "NUnitLite": "3.2.0"
   }
 }


### PR DESCRIPTION
ref Issue #7106 7106 @jtattermusch 
This allows building Grpc.sln in VS2015.
I still can build in VS2013, but I don't entirely trust my test - I didn't test in a clean environment.
We are now maintaining duplicate "project definitions": .csproj and project.json. But I don't know of any way to avoid it.
I had to drop the reference to Google.Apis.Auth in four of the *.project.json files due to some mysterious version conflict on my machine, but the solution still builds and all unit tests pass.