### PR TITLE
Enable Mac OS X 10.6 compilation

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -234,6 +234,7 @@
 #define GPR_ARCH_32 1
 #endif /* _LP64 */
 #elif defined(__APPLE__)
+#include <Availability.h>
 #include <TargetConditionals.h>
 #ifndef _BSD_SOURCE
 #define _BSD_SOURCE
@@ -246,8 +247,18 @@
 #define GPR_PTHREAD_TLS 1
 #else /* TARGET_OS_IPHONE */
 #define GPR_PLATFORM_STRING "osx"
+#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+#if __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_7
+#define GPR_CPU_IPHONE 1
+#define GPR_PTHREAD_TLS 1
+#else /* __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_7 */
 #define GPR_CPU_POSIX 1
 #define GPR_GCC_TLS 1
+#endif
+#else /* __MAC_OS_X_VERSION_MIN_REQUIRED */
+#define GPR_CPU_POSIX 1
+#define GPR_GCC_TLS 1
+#endif
 #define GPR_POSIX_CRASH_HANDLER 1
 #endif
 #define GPR_GCC_ATOMIC 1


### PR DESCRIPTION
Mac OS X 10.6 is an important Python target, and doesn't support `__thread`.

This should enable us to remove some Python setup hackery *and* proactively protect ourselves from users with older Mac OS X versions (for which valid Python installs exist) being unable to install our Mac OS X wheels, falling instead to the source distributions (something which I've already experienced...).

However... using e.g. `cpu_iphone.c` as opposed to addressing the `__thread` in `cpu_posix.c` is a question for discussion.