### PR TITLE
Split Node health check code into a separate package and make it use static codegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   "files": [
     "LICENSE",
     "src/node/README.md",
-    "src/node/health_check",
     "src/proto",
     "etc",
     "src/node/index.js",

--- a/src/node/test/health_test.js
+++ b/src/node/test/health_test.js
@@ -35,15 +35,19 @@
 
 var assert = require('assert');
 
-var health = require('../health_check/health.js');
+var health = require('../health_check/health');
+
+var health_messages = require('../health_check/v1/health_pb');
+
+var ServingStatus = health_messages.HealthCheckResponse.ServingStatus;
 
 var grpc = require('../');
 
 describe('Health Checking', function() {
   var statusMap = {
-    '': 'SERVING',
-    'grpc.test.TestServiceNotServing': 'NOT_SERVING',
-    'grpc.test.TestServiceServing': 'SERVING'
+    '': ServingStatus.SERVING,
+    'grpc.test.TestServiceNotServing': ServingStatus.NOT_SERVING,
+    'grpc.test.TestServiceServing': ServingStatus.SERVING
   };
   var healthServer;
   var healthImpl;
@@ -51,7 +55,7 @@ describe('Health Checking', function() {
   before(function() {
     healthServer = new grpc.Server();
     healthImpl = new health.Implementation(statusMap);
-    healthServer.addProtoService(health.service, healthImpl);
+    healthServer.addService(health.service, healthImpl);
     var port_num = healthServer.bind('0.0.0.0:0',
                                      grpc.ServerCredentials.createInsecure());
     healthServer.start();
@@ -62,43 +66,51 @@ describe('Health Checking', function() {
     healthServer.forceShutdown();
   });
   it('should say an enabled service is SERVING', function(done) {
-    healthClient.check({service: ''}, function(err, response) {
+    var request = new health_messages.HealthCheckRequest();
+    request.setService('');
+    healthClient.check(request, function(err, response) {
       assert.ifError(err);
-      assert.strictEqual(response.status, 'SERVING');
+      assert.strictEqual(response.getStatus(), ServingStatus.SERVING);
       done();
     });
   });
   it('should say that a disabled service is NOT_SERVING', function(done) {
-    healthClient.check({service: 'grpc.test.TestServiceNotServing'},
-                       function(err, response) {
-                         assert.ifError(err);
-                         assert.strictEqual(response.status, 'NOT_SERVING');
-                         done();
-                       });
+    var request = new health_messages.HealthCheckRequest();
+    request.setService('grpc.test.TestServiceNotServing');
+    healthClient.check(request, function(err, response) {
+      assert.ifError(err);
+      assert.strictEqual(response.getStatus(), ServingStatus.NOT_SERVING);
+      done();
+    });
   });
   it('should say that an enabled service is SERVING', function(done) {
-    healthClient.check({service: 'grpc.test.TestServiceServing'},
-                       function(err, response) {
-                         assert.ifError(err);
-                         assert.strictEqual(response.status, 'SERVING');
-                         done();
-                       });
+    var request = new health_messages.HealthCheckRequest();
+    request.setService('grpc.test.TestServiceServing');
+    healthClient.check(request, function(err, response) {
+      assert.ifError(err);
+      assert.strictEqual(response.getStatus(), ServingStatus.SERVING);
+      done();
+    });
   });
   it('should get NOT_FOUND if the service is not registered', function(done) {
-    healthClient.check({service: 'not_registered'}, function(err, response) {
+    var request = new health_messages.HealthCheckRequest();
+    request.setService('not_registered');
+    healthClient.check(request, function(err, response) {
       assert(err);
       assert.strictEqual(err.code, grpc.status.NOT_FOUND);
       done();
     });
   });
   it('should get a different response if the status changes', function(done) {
-    healthClient.check({service: 'transient'}, function(err, response) {
+    var request = new health_messages.HealthCheckRequest();
+    request.setService('transient');
+    healthClient.check(request, function(err, response) {
       assert(err);
       assert.strictEqual(err.code, grpc.status.NOT_FOUND);
-      healthImpl.setStatus('transient', 'SERVING');
-      healthClient.check({service: 'transient'}, function(err, response) {
+      healthImpl.setStatus('transient', ServingStatus.SERVING);
+      healthClient.check(request, function(err, response) {
         assert.ifError(err);
-        assert.strictEqual(response.status, 'SERVING');
+        assert.strictEqual(response.getStatus(), ServingStatus.SERVING);
         done();
       });
     });

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -61,7 +61,6 @@
     "files": [
       "LICENSE",
       "src/node/README.md",
-      "src/node/health_check",
       "src/proto",
       "etc",
       "src/node/index.js",

--- a/templates/src/node/health_check/package.json.template
+++ b/templates/src/node/health_check/package.json.template
@@ -1,0 +1,31 @@
+%YAML 1.2
+--- |
+  {
+    "name": "grpc-health-check",
+    "version": "${settings.node_version}",
+    "author": "Google Inc.",
+    "description": "Health check service for use with gRPC",
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/grpc/grpc.git"
+    },
+    "bugs": "https://github.com/grpc/grpc/issues",
+    "contributors": [
+      {
+        "name": "Michael Lumish",
+        "email": "mlumish@google.com"
+      }
+    ],
+    "dependencies": {
+      "grpc": "^0.15.0",
+      "lodash": "^3.9.3",
+      "google-protobuf": "^3.0.0-alpha.5"
+    },
+    "files": {
+      "LICENSE",
+      "health.js",
+      "v1"
+    },
+    "main": "src/node/index.js",
+    "license": "BSD-3-Clause"
+  }


### PR DESCRIPTION
This fixes #7158.

This is technically an API breakage, but I doubt anyone is currently using the part that's getting broken. Just loading it is somewhat obscure.