### PR TITLE
Make grpcio-tools compile targeting Mac OS X 10.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -211,15 +211,23 @@ SETUP_REQUIRES = INSTALL_REQUIRES + (
     'sphinx_rtd_theme>=0.1.8',
     'six>=1.10',
 )
-if BUILD_WITH_CYTHON:
-  sys.stderr.write(
-    "You requested a Cython build via GRPC_PYTHON_BUILD_WITH_CYTHON, "
-    "but do not have Cython installed. We won't stop you from using "
-    "other commands, but the extension files will fail to build.\n")
-elif need_cython:
-  sys.stderr.write(
-      'We could not find Cython. Setup may take 10-20 minutes.\n')
-  SETUP_REQUIRES += ('cython>=0.23',)
+
+try:
+  import Cython
+  has_cython = True
+except ImportError:
+  has_cython = False
+
+if not has_cython:
+  if BUILD_WITH_CYTHON:
+    sys.stderr.write(
+      "You requested a Cython build via GRPC_PYTHON_BUILD_WITH_CYTHON, "
+      "but do not have Cython installed. We won't stop you from using "
+      "other commands, but the extension files will fail to build.\n")
+  elif need_cython:
+    sys.stderr.write(
+        'We could not find Cython. Setup may take 10-20 minutes.\n')
+    SETUP_REQUIRES += ('cython>=0.23',)
 
 COMMAND_CLASS = {
     'doc': commands.SphinxDocumentation,

--- a/src/compiler/generator_helpers.h
+++ b/src/compiler/generator_helpers.h
@@ -255,7 +255,8 @@ inline void GetComment(const grpc::protobuf::FileDescriptor *desc,
 inline grpc::string GenerateCommentsWithPrefix(
     const std::vector<grpc::string> &in, const grpc::string &prefix) {
   std::ostringstream oss;
-  for (auto it = in.begin(); it != in.end(); it++) {
+  for (std::vector<grpc::string>::const_iterator it = in.begin();
+       it != in.end(); it++) {
     const grpc::string &elem = *it;
     if (elem.empty()) {
       oss << prefix << "\n";

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -69,7 +69,7 @@ BUILD_WITH_CYTHON = os.environ.get('GRPC_PYTHON_BUILD_WITH_CYTHON', False)
 EXTRA_ENV_COMPILE_ARGS = os.environ.get('GRPC_PYTHON_CFLAGS', None)
 EXTRA_ENV_LINK_ARGS = os.environ.get('GRPC_PYTHON_LDFLAGS', None)
 if EXTRA_ENV_COMPILE_ARGS is None:
-  EXTRA_ENV_COMPILE_ARGS = '-std=c++11'
+  EXTRA_ENV_COMPILE_ARGS = ''
   if 'win32' in sys.platform:
     if sys.version_info < (3, 5):
       # We use define flags here and don't directly add to DEFINE_MACROS below to
@@ -118,19 +118,6 @@ if "win32" in sys.platform:
     DEFINE_MACROS += (('MS_WIN64', 1),)
 elif "linux" in sys.platform or "darwin" in sys.platform:
   DEFINE_MACROS += (('HAVE_PTHREAD', 1),)
-
-# By default, Python3 distutils enforces compatibility of
-# c plugins (.so files) with the OSX version Python3 was built with.
-# For Python3.4, this is OSX 10.6, but we need Thread Local Support (__thread)
-if 'darwin' in sys.platform and PY3:
-  mac_target = sysconfig.get_config_var('MACOSX_DEPLOYMENT_TARGET')
-  if mac_target and (pkg_resources.parse_version(mac_target) <
-		     pkg_resources.parse_version('10.9.0')):
-    os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
-    os.environ['_PYTHON_HOST_PLATFORM'] = re.sub(
-        r'macosx-[0-9]+\.[0-9]+-(.+)',
-        r'macosx-10.9-\1',
-        util.get_platform())
 
 def package_data():
   tools_path = GRPC_PYTHON_TOOLS_PACKAGE.replace('.', os.path.sep)

--- a/tools/run_tests/build_python.sh
+++ b/tools/run_tests/build_python.sh
@@ -160,6 +160,7 @@ $VENV_PYTHON -m pip install --upgrade pip
 # TODO(https://github.com/pypa/setuptools/issues/709) get the latest setuptools
 $VENV_PYTHON -m pip install setuptools==25.1.1
 $VENV_PYTHON -m pip install cython
+$VENV_PYTHON -m pip install -rrequirements.txt
 pip_install_dir $ROOT
 $VENV_PYTHON $ROOT/tools/distrib/python/make_grpcio_tools.py
 pip_install_dir $ROOT/tools/distrib/python/grpcio_tools

--- a/tools/run_tests/build_python.sh
+++ b/tools/run_tests/build_python.sh
@@ -109,7 +109,7 @@ VENV_RELATIVE_PYTHON=${3:-$(venv_relative_python)}
 TOOLCHAIN=${4:-$(toolchain)}
 
 ROOT=`pwd`
-export CFLAGS="-I$ROOT/include -std=gnu99 -fno-wrapv $CFLAGS"
+export CFLAGS="-I$ROOT/include -fno-wrapv $CFLAGS"
 export GRPC_PYTHON_BUILD_WITH_CYTHON=1
 export LANG=en_US.UTF-8
 
@@ -133,7 +133,7 @@ fi
 # Perform build operations #
 ############################
 
-# Instnatiate the virtualenv, preferring to do so from the relevant python
+# Instantiate the virtualenv, preferring to do so from the relevant python
 # version. Even if these commands fail (e.g. on Windows due to name conflicts)
 # it's possible that the virtualenv is still usable and we trust the tester to
 # be able to 'figure it out' instead of us e.g. doing potentially expensive and


### PR DESCRIPTION
Also C++98-ify's the Python plug-in code and removes the C++11 requirement from grpcio-tools builds. Such changes aren't strictly necessary but improve compatibility in any case.

This combined with #6791 and #7196 will enable us to remove the Mac OS X 10.6-specific hackery in Python setup code and improve our wheel compatibility (which is currently... not good).

It's for discussion whether or not we consider the potential wheel compatibility issues to be GA blockers or not. The effort necessary to fix them appear minimal, and the gains arguably pretty high.
