### PR TITLE
Remove gmock protobuf dependency from cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,13 @@ if(NOT ZLIB_ROOT_DIR)
   set(ZLIB_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/zlib)
 endif()
 
+# Building the protobuf tests require gmock what is not part of a standard protobuf checkout.
+# Disable them unless they are explicitly requested from the cmake command line (when we assume
+# gmock is downloaded to the right location inside protobuf).
+if(NOT protobuf_BUILD_TESTS)
+  set(protobuf_BUILD_TESTS OFF CACHE BOOL "Build protobuf tests")
+endif()
+
 add_subdirectory(${BORINGSSL_ROOT_DIR} third_party/boringssl)
 add_subdirectory(${PROTOBUF_ROOT_DIR}/cmake third_party/protobuf)
 add_subdirectory(${ZLIB_ROOT_DIR} third_party/zlib)

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -74,6 +74,13 @@
     set(ZLIB_ROOT_DIR <%text>${CMAKE_CURRENT_SOURCE_DIR}</%text>/third_party/zlib)
   endif()
 
+  # Building the protobuf tests require gmock what is not part of a standard protobuf checkout.
+  # Disable them unless they are explicitly requested from the cmake command line (when we assume
+  # gmock is downloaded to the right location inside protobuf).
+  if(NOT protobuf_BUILD_TESTS)
+    set(protobuf_BUILD_TESTS OFF CACHE BOOL "Build protobuf tests")
+  endif()
+
   add_subdirectory(<%text>${BORINGSSL_ROOT_DIR}</%text> third_party/boringssl)
   add_subdirectory(<%text>${PROTOBUF_ROOT_DIR}</%text>/cmake third_party/protobuf)
   add_subdirectory(<%text>${ZLIB_ROOT_DIR}</%text> third_party/zlib)


### PR DESCRIPTION
A full build of protobuf depends on gmock even though it is not part of
a standrad checkout. This CL explicitly disable the build of the
protobuf tests to get rid of this dependency.

If somebody want to build the protobuf tests then they have to download
gmock to the protobuf directory and specify -Dprotobuf_BUILD_TESTS=ON
to the cmake command line.

Fixes https://github.com/grpc/grpc/issues/7233