### PR TITLE
update auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,10 @@
   ],
   "require": {
     "php": ">=5.5.0",
-    "datto/protobuf-php": "dev-master",
-    "google/auth": "v0.7"
+    "datto/protobuf-php": "dev-master"
+  },
+  "require-dev": {
+    "google/auth": "v0.9"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
We are currently running auth 0.9 in [gcloud-php](https://github.com/GoogleCloudPlatform/gcloud-php) and would like to update gRPC to match.

The only usage I found of the auth module was in [interop_client.php](https://github.com/grpc/grpc/blob/master/src/php/tests/interop/interop_client.php). As is such, I moved the dependency to require-dev since it is only being used in tests.

