### PR TITLE
Add arm_arch.h back in BoringSSL.podspec, to fix compilation for devices

### DIFF
--- a/src/objective-c/BoringSSL.podspec
+++ b/src/objective-c/BoringSSL.podspec
@@ -109,8 +109,6 @@ Pod::Spec.new do |s|
   s.subspec 'Interface' do |ss|
     ss.header_mappings_dir = 'include/openssl'
     ss.source_files = 'include/openssl/*.h'
-    # Doesn't compile correctly; but doesn't seem to be needed:
-    ss.exclude_files = 'include/openssl/arm_arch.h'
   end
   s.subspec 'Implementation' do |ss|
     ss.header_mappings_dir = '.'
@@ -147,6 +145,11 @@ Pod::Spec.new do |s|
       #include "ssl.h"
       #include "crypto.h"
       #include "aes.h"
+      /* The following macros are defined by base.h. The latter is the first file included by the
+         other headers. */
+      #if defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
+      #  include "arm_arch.h"
+      #endif
       #include "asn1.h"
       #include "asn1_mac.h"
       #include "asn1t.h"


### PR DESCRIPTION
Fixes the problem helpfully reported by @aa57779111 in #6207.