### PR TITLE
Support external nanopb location in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,9 @@ project(${PACKAGE_NAME} C CXX)
 if(NOT BORINGSSL_ROOT_DIR)
   set(BORINGSSL_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/boringssl)
 endif()
+if (NOT NANOPB_ROOT_DIR)
+  set(NANOPB_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/nanopb)
+endif()
 if(NOT PROTOBUF_ROOT_DIR)
   set(PROTOBUF_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/protobuf)
 endif()
@@ -292,9 +295,9 @@ add_library(grpc
   src/core/ext/transport/chttp2/client/insecure/channel_create_posix.c
   src/core/ext/lb_policy/grpclb/load_balancer_api.c
   src/core/ext/lb_policy/grpclb/proto/grpc/lb/v1/load_balancer.pb.c
-  third_party/nanopb/pb_common.c
-  third_party/nanopb/pb_decode.c
-  third_party/nanopb/pb_encode.c
+  ${NANOPB_ROOT_DIR}/pb_common.c
+  ${NANOPB_ROOT_DIR}/pb_decode.c
+  ${NANOPB_ROOT_DIR}/pb_encode.c
   src/core/ext/lb_policy/pick_first/pick_first.c
   src/core/ext/lb_policy/round_robin/round_robin.c
   src/core/ext/resolver/dns/native/dns_resolver.c
@@ -653,9 +656,9 @@ add_library(grpc_unsecure
   src/core/ext/load_reporting/load_reporting_filter.c
   src/core/ext/lb_policy/grpclb/load_balancer_api.c
   src/core/ext/lb_policy/grpclb/proto/grpc/lb/v1/load_balancer.pb.c
-  third_party/nanopb/pb_common.c
-  third_party/nanopb/pb_decode.c
-  third_party/nanopb/pb_encode.c
+  ${NANOPB_ROOT_DIR}/pb_common.c
+  ${NANOPB_ROOT_DIR}/pb_decode.c
+  ${NANOPB_ROOT_DIR}/pb_encode.c
   src/core/ext/lb_policy/pick_first/pick_first.c
   src/core/ext/lb_policy/round_robin/round_robin.c
   src/core/ext/census/context.c

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -53,6 +53,9 @@
     for d in target_dict.get('deps', []):
       deps.append(d)
     return deps
+
+  def get_srcs(target_srcs):
+    return [s.replace('third_party/nanopb', '${NANOPB_ROOT_DIR}') for s in target_srcs]
   %>
 
   cmake_minimum_required(VERSION 2.8)
@@ -66,6 +69,9 @@
 
   if(NOT BORINGSSL_ROOT_DIR)
     set(BORINGSSL_ROOT_DIR <%text>${CMAKE_CURRENT_SOURCE_DIR}</%text>/third_party/boringssl)
+  endif()
+  if (NOT NANOPB_ROOT_DIR)
+    set(NANOPB_ROOT_DIR <%text>${CMAKE_CURRENT_SOURCE_DIR}</%text>/third_party/nanopb)
   endif()
   if(NOT PROTOBUF_ROOT_DIR)
     set(PROTOBUF_ROOT_DIR <%text>${CMAKE_CURRENT_SOURCE_DIR}</%text>/third_party/protobuf)
@@ -95,7 +101,7 @@
 
   <%def name="cc_library(lib)">
   add_library(${lib.name}
-  % for src in lib.src:
+  % for src in get_srcs(lib.src):
     ${src}
   % endfor
   )
@@ -120,7 +126,7 @@
 
   <%def name="cc_binary(tgt)">
   add_executable(${tgt.name}
-  % for src in tgt.src:
+  % for src in get_srcs(tgt.src):
     ${src}
   % endfor
   )


### PR DESCRIPTION
The cmake based build system already had options to specify external
location for most third_party library. This CL add this support for
nanopb as well (last library without support for this) so gRPC can be
build using cmake without having to put any code into the gRPC
third_party directory.
