### PR TITLE
Fix arguments for calls to Ruby's `Time.at`

### DIFF
--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -220,7 +220,7 @@ static VALUE grpc_rb_time_val_to_time(VALUE self) {
                        time_const);
   real_time = gpr_convert_clock_type(*time_const, GPR_CLOCK_REALTIME);
   return rb_funcall(rb_cTime, id_at, 2, INT2NUM(real_time.tv_sec),
-                    INT2NUM(real_time.tv_nsec));
+                    INT2NUM(real_time.tv_nsec / 1000));
 }
 
 /* Invokes inspect on the ctime version of the time val. */

--- a/src/ruby/ext/grpc/rb_server.c
+++ b/src/ruby/ext/grpc/rb_server.c
@@ -218,7 +218,7 @@ static VALUE grpc_rb_server_request_call(VALUE self) {
       grpc_rb_sNewServerRpc, rb_str_new2(st.details.method),
       rb_str_new2(st.details.host),
       rb_funcall(rb_cTime, id_at, 2, INT2NUM(deadline.tv_sec),
-                 INT2NUM(deadline.tv_nsec)),
+                 INT2NUM(deadline.tv_nsec / 1000)),
       grpc_rb_md_ary_to_h(&st.md_ary), grpc_rb_wrap_call(call, call_queue),
       NULL);
   grpc_request_call_stack_cleanup(&st);


### PR DESCRIPTION
`Time.at` takes microseconds as a second arg, not nanoseconds. Fixes conversion of deadline time on the server-side.

Before the fix (some added logging included):

```
I0708 11:59:31.918294000 140735315193856 parsing.c:655] HTTP:1:HDR:SVR: grpc-timeout: 4580m
I0708 11:59:31.918298000 140735315193856 timeout_encoding.c:175] Incoming timeout (from_millis): 4580
I0708 11:59:31.918303000 140735315193856 timeout_encoding.c:177] timeout(from_millis)=gpr_timespec { tv_sec: 4, tv_nsec: 580000000, clock_type: 3 }, 
I0708 11:59:31.918307000 140735315193856 incoming_metadata.c:74] deadline=gpr_timespec { tv_sec: 7, tv_nsec: 823605568, clock_type: 0 }, 
I0708 11:59:31.918549000 140735315193856 rb_server.c:264] deadline(NewServerRpc REALTIME)=gpr_timespec { tv_sec: 1467993576, tv_nsec: 498305614, clock_type: 1 }, 
Deadline is 2016-07-08 12:07:54 -0400 (in 502.385435 secs)
```

After the fix:

```
I0708 12:06:02.430514000 140735315193856 parsing.c:655] HTTP:3:HDR:SVR: grpc-timeout: 5S
I0708 12:06:02.430522000 140735315193856 timeout_encoding.c:180] Incoming timeout (from_seconds): 5
I0708 12:06:02.430528000 140735315193856 timeout_encoding.c:182] timeout(from_seconds)=gpr_timespec { tv_sec: 5, tv_nsec: 0, clock_type: 3 }, 
I0708 12:06:02.430536000 140735315193856 incoming_metadata.c:74] deadline=gpr_timespec { tv_sec: 12, tv_nsec: 915133952, clock_type: 0 }, 
I0708 12:06:02.431128000 140735315193856 rb_server.c:264] deadline(NewServerRpc REALTIME)=gpr_timespec { tv_sec: 1467993967, tv_nsec: 430533854, clock_type: 1 }, 
Deadline is 2016-07-08 12:06:07 -0400 (in 4.998415 secs)
```