### PR TITLE
Added timeout to port server

### DIFF
--- a/tools/run_tests/port_server.py
+++ b/tools/run_tests/port_server.py
@@ -42,7 +42,7 @@ import time
 # increment this number whenever making a change to ensure that
 # the changes are picked up by running CI servers
 # note that all changes must be backwards compatible
-_MY_VERSION = 8
+_MY_VERSION = 9
 
 
 if len(sys.argv) == 2 and sys.argv[1] == 'dump_version':
@@ -110,6 +110,11 @@ keep_running = True
 
 
 class Handler(BaseHTTPServer.BaseHTTPRequestHandler):
+  
+  def setup(self):
+    # If the client is unreachable for 5 seconds, close the connection
+    self.timeout = 5
+    BaseHTTPServer.BaseHTTPRequestHandler.setup(self)
 
   def do_GET(self):
     global keep_running

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1094,10 +1094,6 @@ def _shut_down_legacy_server(legacy_server_port):
 
 
 def _start_port_server(port_server_port):
-  # Temporary patch to switch the port_server port
-  # see https://github.com/grpc/grpc/issues/7145
-  _shut_down_legacy_server(32767)
-
   # check if a compatible port server is running
   # if incompatible (version mismatch) ==> start a new one
   # if not running ==> start a new one


### PR DESCRIPTION
Second attempt at fixing #7145

I've confirmed that establishing a tcp connection without sending an http request will block the port_server from servicing requests.  This adds a socket timeout.