### PR TITLE
Add special dunder methods to generated Python documentation

### DIFF
--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -58,6 +58,7 @@ CONF_PY_ADDENDUM = """
 extensions.append('sphinx.ext.napoleon')
 napoleon_google_docstring = True
 napoleon_numpy_docstring = True
+napoleon_include_special_with_doc = True
 
 html_theme = 'sphinx_rtd_theme'
 """

--- a/tools/distrib/python/docgen.py
+++ b/tools/distrib/python/docgen.py
@@ -70,7 +70,6 @@ environment.update({
 })
 
 subprocess_arguments_list = [
-    {'args': ['make'], 'cwd': PROJECT_ROOT},
     {'args': ['virtualenv', VIRTUALENV_DIR], 'env': environment},
     {'args': [VIRTUALENV_PIP_PATH, 'install', '-r', REQUIREMENTS_PATH],
      'env': environment},


### PR DESCRIPTION
Also removes an old-now-spurious `make` invocation from the docgen.py helper script.

Fixes #7015.

If desired this can be cherry-picked back onto the 1.0 branch as GA polish.