### PR TITLE
Fix cygrpc test

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_cython/cygrpc_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/cygrpc_test.py
@@ -281,8 +281,8 @@ class ServerClientMixin(object):
     ], server_call_tag)
     self.assertEqual(cygrpc.CallError.ok, server_start_batch_result)
 
-    client_event = client_event_future.result()
     server_event = self.server_completion_queue.poll(cygrpc_deadline)
+    client_event = client_event_future.result()
 
     self.assertEqual(6, len(client_event.batch_operations))
     found_client_op_types = set()


### PR DESCRIPTION
Should unblock #6737

With #6737, ```start_batch``` will no longer put data on the wire.  This should not impact any external API because the server and client will never call ```grpc_completion_queue_next()``` on the same thread.  

@ctiller 