### PR TITLE
Add csharp check to return val of byte_buffer_reader_init

### DIFF
--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -253,8 +253,9 @@ GPR_EXPORT intptr_t GPR_CALLTYPE grpcsharp_batch_context_recv_message_length(
   if (!ctx->recv_message) {
     return -1;
   }
-  /* TODO(issue:#7206): check return value of grpc_byte_buffer_reader_init. */
-  grpc_byte_buffer_reader_init(&reader, ctx->recv_message);
+
+  GPR_ASSERT(grpc_byte_buffer_reader_init(&reader, ctx->recv_message));
+
   return (intptr_t)grpc_byte_buffer_length(reader.buffer_out);
 }
 
@@ -268,8 +269,7 @@ GPR_EXPORT void GPR_CALLTYPE grpcsharp_batch_context_recv_message_to_buffer(
   gpr_slice slice;
   size_t offset = 0;
 
-  /* TODO(issue:#7206): check return value of grpc_byte_buffer_reader_init. */
-  grpc_byte_buffer_reader_init(&reader, ctx->recv_message);
+  GPR_ASSERT(grpc_byte_buffer_reader_init(&reader, ctx->recv_message));
 
   while (grpc_byte_buffer_reader_next(&reader, &slice)) {
     size_t len = GPR_SLICE_LENGTH(slice);


### PR DESCRIPTION
This fixes https://github.com/grpc/grpc/issues/7206

Using GPR_ASSERT here rather than returning an error code to the c# wrapper. The wrapper already checks for a null recv_message buffer and avoids trying to read anything from it in that case, so I'm thinking that it should be a fatal error if any byte_buffer_reader_init calls fail.