### PR TITLE
Skip exit_test until flake is fixed

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_exit_test.py
+++ b/src/python/grpcio_tests/tests/unit/_exit_test.py
@@ -84,6 +84,7 @@ def wait(process):
   process.wait()
 
 
+@unittest.skip('https://github.com/grpc/grpc/issues/7311')
 class ExitTest(unittest.TestCase):
 
   def test_unstarted_server(self):


### PR DESCRIPTION
Until #7311 is resolved, I'm disabling this test.  I've been unable to reproduce it locally, and increasing the test timeout didn't work either, so I suspect the exit scenarios are truly hanging but this is going to require a thorough investigation.