### PR TITLE
PHP: fix interop tests breakage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,15 +5,9 @@
   "keywords": ["rpc"],
   "homepage": "http://grpc.io",
   "license": "BSD-3-Clause",
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/stanley-cheung/Protobuf-PHP"
-    }
-  ],
   "require": {
     "php": ">=5.5.0",
-    "datto/protobuf-php": "dev-master"
+    "stanley-cheung/protobuf-php": "dev-master"
   },
   "require-dev": {
     "google/auth": "v0.9"

--- a/examples/php/composer.json
+++ b/examples/php/composer.json
@@ -2,12 +2,6 @@
   "name": "grpc/grpc-demo",
   "description": "gRPC example for PHP",
   "minimum-stability": "dev",
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/stanley-cheung/Protobuf-PHP"
-    }
-  ],
   "require": {
     "grpc/grpc": "v0.15.0"
   }

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -148,7 +148,7 @@ Alternatively, you can download `protoc` binaries from [the protocol buffers Git
 You need to install `protoc-gen-php` to generate stub class `.php` files from service definition `.proto` files.
 
 ```sh
-$ cd grpc/src/php/vendor/datto/protobuf-php # if you had run `composer install` in the previous step
+$ cd grpc/src/php/vendor/stanley-cheung/protobuf-php # if you had run `composer install` in the previous step
 
 OR
 

--- a/src/php/composer.json
+++ b/src/php/composer.json
@@ -6,15 +6,9 @@
   "homepage": "http://grpc.io",
   "license": "BSD-3-Clause",
   "version": "1.0.0",
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/stanley-cheung/Protobuf-PHP"
-    }
-  ],
   "require": {
     "php": ">=5.5.0",
-    "datto/protobuf-php": "dev-master",
+    "stanley-cheung/protobuf-php": "dev-master",
     "google/auth": "v0.7"
   },
   "autoload": {

--- a/templates/composer.json.template
+++ b/templates/composer.json.template
@@ -7,15 +7,9 @@
     "keywords": ["rpc"],
     "homepage": "http://grpc.io",
     "license": "BSD-3-Clause",
-    "repositories": [
-      {
-        "type": "vcs",
-        "url": "https://github.com/stanley-cheung/Protobuf-PHP"
-      }
-    ],
     "require": {
       "php": ">=5.5.0",
-      "datto/protobuf-php": "dev-master"
+      "stanley-cheung/protobuf-php": "dev-master"
     },
     "require-dev": {
       "google/auth": "v0.9"


### PR DESCRIPTION
We published `stanley-cheung/protobuf-php` as a standalone package on Packagist because we no longer want to wait for the upstream repo `datto/protobuf-php` to merge our change. This breaks the interop tests.