### PR TITLE
Reduce the number of unnecessary allocations

### DIFF
--- a/include/grpc++/impl/codegen/async_unary_call.h
+++ b/include/grpc++/impl/codegen/async_unary_call.h
@@ -65,7 +65,7 @@ class ClientAsyncResponseReader GRPC_FINAL
                             const W& request)
       : context_(context),
         call_(channel->CreateCall(method, context, cq)),
-        collection_(new CallOpSetCollection) {
+        collection_(std::make_shared<CallOpSetCollection>()) {
     collection_->init_buf_.SetCollection(collection_);
     collection_->init_buf_.SendInitialMetadata(
         context->send_initial_metadata_, context->initial_metadata_flags());


### PR DESCRIPTION
_This code change was done by Sanjay. I am proxying for him_

Reduced some allocations in grpc:

* pollset_work: combine two mallocs into one, and avoid malloc
entirely if number of file descriptors fits in on-stack arrays.

* Use std::make_shared for creating a reference-counted
CallOpSetCollection.  This allows a single allocation to be used for
both the CallOpSetCollection and its reference count.
