### PR TITLE
PHP: unify the version of google/auth

### DIFF
--- a/src/php/composer.json
+++ b/src/php/composer.json
@@ -9,7 +9,7 @@
   "require": {
     "php": ">=5.5.0",
     "stanley-cheung/protobuf-php": "dev-master",
-    "google/auth": "v0.7"
+    "google/auth": "v0.9"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
For v1.0.x branch, unify all versions of google/auth, include `composer.json`, `templates/composer.json.templae` and `src/php/composer.json`.