### PR TITLE
Make Travis builds finish as soon as a case fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - TEST=objc
     - JOBS=1
   matrix:
+    fast_finish: true
     - SCHEME="RxLibraryUnitTests" WORKSPACE="Tests.xcworkspace"
       TEST_PATH="src/objective-c/tests" BUILD_ONLY="false"
       INTEROP_SERVER="false"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
     - TEST=objc
     - JOBS=1
   matrix:
-    fast_finish: true
     - SCHEME="RxLibraryUnitTests" WORKSPACE="Tests.xcworkspace"
       TEST_PATH="src/objective-c/tests" BUILD_ONLY="false"
       INTEROP_SERVER="false"
@@ -36,6 +35,8 @@ env:
     - SCHEME="SwiftSample" WORKSPACE="SwiftSample.xcworkspace"
       TEST_PATH="src/objective-c/examples/SwiftSample" BUILD_ONLY="true"
       INTEROP_SERVER="false"
+matrix:
+  fast_finish: true
 before_install:
   # Until Travis upgrades from Cocoapods 0.39, we need to do it here.
   - pod --version


### PR DESCRIPTION
This will help reduce the load.

Taken from https://docs.travis-ci.com/user/customizing-the-build/#Fast-Finishing