### PR TITLE
Extend payload test to send larger random bodies

### DIFF
--- a/test/core/end2end/cq_verifier.c
+++ b/test/core/end2end/cq_verifier.c
@@ -128,7 +128,7 @@ static gpr_slice merge_slices(gpr_slice *slices, size_t nslices) {
   return out;
 }
 
-static int byte_buffer_eq_slice(grpc_byte_buffer *bb, gpr_slice b) {
+int byte_buffer_eq_slice(grpc_byte_buffer *bb, gpr_slice b) {
   gpr_slice a;
   int ok;
 

--- a/test/core/end2end/cq_verifier.c
+++ b/test/core/end2end/cq_verifier.c
@@ -128,20 +128,35 @@ static gpr_slice merge_slices(gpr_slice *slices, size_t nslices) {
   return out;
 }
 
-int byte_buffer_eq_slice(grpc_byte_buffer *bb, gpr_slice b) {
+int raw_byte_buffer_eq_slice(grpc_byte_buffer *rbb, gpr_slice b) {
   gpr_slice a;
   int ok;
 
-  if (!bb) return 0;
+  if (!rbb) return 0;
 
-  a = merge_slices(bb->data.raw.slice_buffer.slices,
-                   bb->data.raw.slice_buffer.count);
+  a = merge_slices(rbb->data.raw.slice_buffer.slices,
+                   rbb->data.raw.slice_buffer.count);
   ok = GPR_SLICE_LENGTH(a) == GPR_SLICE_LENGTH(b) &&
        0 == memcmp(GPR_SLICE_START_PTR(a), GPR_SLICE_START_PTR(b),
                    GPR_SLICE_LENGTH(a));
   gpr_slice_unref(a);
   gpr_slice_unref(b);
   return ok;
+}
+
+int byte_buffer_eq_slice(grpc_byte_buffer *bb, gpr_slice b) {
+  grpc_byte_buffer_reader reader;
+  grpc_byte_buffer *rbb;
+  int res;
+
+  GPR_ASSERT(grpc_byte_buffer_reader_init(&reader, bb) &&
+             "Couldn't init byte buffer reader");
+  rbb = grpc_raw_byte_buffer_from_reader(&reader);
+  res = raw_byte_buffer_eq_slice(rbb, b);
+  grpc_byte_buffer_reader_destroy(&reader);
+  grpc_byte_buffer_destroy(rbb);
+
+  return res;
 }
 
 int byte_buffer_eq_string(grpc_byte_buffer *bb, const char *str) {
@@ -152,7 +167,7 @@ int byte_buffer_eq_string(grpc_byte_buffer *bb, const char *str) {
   GPR_ASSERT(grpc_byte_buffer_reader_init(&reader, bb) &&
              "Couldn't init byte buffer reader");
   rbb = grpc_raw_byte_buffer_from_reader(&reader);
-  res = byte_buffer_eq_slice(rbb, gpr_slice_from_copied_string(str));
+  res = raw_byte_buffer_eq_slice(rbb, gpr_slice_from_copied_string(str));
   grpc_byte_buffer_reader_destroy(&reader);
   grpc_byte_buffer_destroy(rbb);
 

--- a/test/core/end2end/cq_verifier.h
+++ b/test/core/end2end/cq_verifier.h
@@ -61,6 +61,7 @@ void cq_verify_empty(cq_verifier *v);
    the event. */
 void cq_expect_completion(cq_verifier *v, void *tag, bool success);
 
+int byte_buffer_eq_slice(grpc_byte_buffer *bb, gpr_slice b);
 int byte_buffer_eq_string(grpc_byte_buffer *byte_buffer, const char *string);
 int contains_metadata(grpc_metadata_array *array, const char *key,
                       const char *value);

--- a/test/core/end2end/tests/payload.c
+++ b/test/core/end2end/tests/payload.c
@@ -99,13 +99,13 @@ static void end_test(grpc_end2end_test_fixture *f) {
 
 /* Creates and returns a gpr_slice of specified length, containing random
  * alphanumeric characters. */
-static gpr_slice generate_random_slice(int length_bytes) {
-  int i;
+static gpr_slice generate_random_slice(size_t length_bytes) {
+  size_t i;
   gpr_slice slice = gpr_slice_malloc(length_bytes);
-  static const char alphanum[] = "abcdefghijklmnopqrstuvwxyz01234567890";
+  static const uint8_t alphanum[] = "abcdefghijklmnopqrstuvwxyz01234567890";
   for (i = 0; i < length_bytes; ++i) {
     *(GPR_SLICE_START_PTR(slice) + i) =
-        alphanum[rand() % (sizeof(alphanum) - 1)];
+        alphanum[rand() % (int)(sizeof(alphanum) - 1)];
   }
   return slice;
 }
@@ -114,7 +114,7 @@ static void request_response_with_payload(grpc_end2end_test_fixture f) {
   /* Create large request and response bodies. These are big enough to require
    * multiple round trips to deliver to the peer, and their exact contents of
    * will be verified on completion. */
-  int payload_size_bytes = 1024 * 1024; /* 1 MB */
+  size_t payload_size_bytes = 1024 * 1024; /* 1 MB */
   gpr_slice request_payload_slice = generate_random_slice(payload_size_bytes);
   gpr_slice response_payload_slice = generate_random_slice(payload_size_bytes);
 

--- a/test/core/end2end/tests/payload.c
+++ b/test/core/end2end/tests/payload.c
@@ -102,9 +102,10 @@ static gpr_slice generate_random_slice() {
   size_t i;
   static const char chars[] = "abcdefghijklmnopqrstuvwxyz1234567890";
   char output[1024 * 1024]; /* 1 MB */
-  for (i = 0; i < 1024 * 1024; ++i) {
+  for (i = 0; i < 1024 * 1024 - 1; ++i) {
     output[i] = chars[rand() % (int)(sizeof(chars) - 1)];
   }
+  output[1024 * 1024 - 1] = '\0';
   return gpr_slice_from_copied_string(output);
 }
 

--- a/test/core/end2end/tests/payload.c
+++ b/test/core/end2end/tests/payload.c
@@ -97,26 +97,23 @@ static void end_test(grpc_end2end_test_fixture *f) {
   grpc_completion_queue_destroy(f->cq);
 }
 
-/* Creates and returns a gpr_slice of specified length, containing random
- * alphanumeric characters. */
-static gpr_slice generate_random_slice(size_t length_bytes) {
+/* Creates and returns a gpr_slice containing random alphanumeric characters. */
+static gpr_slice generate_random_slice() {
   size_t i;
-  gpr_slice slice = gpr_slice_malloc(length_bytes);
-  static const uint8_t alphanum[] = "abcdefghijklmnopqrstuvwxyz01234567890";
-  for (i = 0; i < length_bytes; ++i) {
-    *(GPR_SLICE_START_PTR(slice) + i) =
-        alphanum[rand() % (int)(sizeof(alphanum) - 1)];
+  static const char chars[] = "abcdefghijklmnopqrstuvwxyz1234567890";
+  char output[1024 * 1024]; /* 1 MB */
+  for (i = 0; i < 1024 * 1024; ++i) {
+    output[i] = chars[rand() % (int)(sizeof(chars) - 1)];
   }
-  return slice;
+  return gpr_slice_from_copied_string(output);
 }
 
 static void request_response_with_payload(grpc_end2end_test_fixture f) {
   /* Create large request and response bodies. These are big enough to require
    * multiple round trips to deliver to the peer, and their exact contents of
    * will be verified on completion. */
-  size_t payload_size_bytes = 1024 * 1024; /* 1 MB */
-  gpr_slice request_payload_slice = generate_random_slice(payload_size_bytes);
-  gpr_slice response_payload_slice = generate_random_slice(payload_size_bytes);
+  gpr_slice request_payload_slice = generate_random_slice();
+  gpr_slice response_payload_slice = generate_random_slice();
 
   grpc_call *c;
   grpc_call *s;


### PR DESCRIPTION
The payload end2end test now sends large (1 MB) request and response bodies with random contents. The intention is to expose transport bugs which a small (i.e. single packet), or repeating ("xxxxx...") body does not.

@ctiller  - mind taking a look at this? There's a bug somewhere: the chttp2 tests fail with this change (received payload slice != expected) but only when the randomly generated string starts to get substantial. If I generate random strings of length 10 it seems to pass every time, choose a length of 1024 * 1024 and it fails every time, length of say 100 is flaky. I guess I'm misunderstanding how to create/use gpr_slices but not sure.