### PR TITLE
Delete gpr_log(GPR_DEBUG, ...) in release branch

### DIFF
--- a/src/core/lib/iomgr/ev_posix.c
+++ b/src/core/lib/iomgr/ev_posix.c
@@ -103,7 +103,6 @@ static void try_engine(const char *engine) {
     if (is(engine, g_factories[i].name)) {
       if ((g_event_engine = g_factories[i].factory())) {
         g_poll_strategy_name = g_factories[i].name;
-        gpr_log(GPR_DEBUG, "Using polling engine: %s", g_factories[i].name);
         return;
       }
     }


### PR DESCRIPTION
When I run `php -v`, it output the follow contents:

    ➜  unit_tests git:(master) ✗ php -v
    D0716 08:35:25.383509000 140735164002304 ev_posix.c:106] Using polling engine: poll
    PHP 5.6.20 (cli) (built: Mar 31 2016 17:14:52)
    Copyright (c) 1997-2016 The PHP Group
    Zend Engine v2.6.0, Copyright (c) 1998-2016 Zend Technologies
        with Xdebug v2.3.3, Copyright (c) 2002-2015, by Derick Rethans
    ➜  unit_tests git:(master) ✗

So, I think it should not be used in release branch.