### PR TITLE
PHP: add star when calls zend_parse_parameters function

### DIFF
--- a/src/php/ext/grpc/call_credentials.c
+++ b/src/php/ext/grpc/call_credentials.c
@@ -141,7 +141,7 @@ PHP_METHOD(CallCredentials, createFromPlugin) {
   memset(fci_cache, 0, sizeof(zend_fcall_info_cache));
 
   /* "f" == 1 function */
-  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "f", fci,
+  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "f*", fci,
                             fci_cache,
                             fci->params,
                             fci->param_count) == FAILURE) {


### PR DESCRIPTION
We know that `f` will not set `fci->params` from https://github.com/php/php-src/blob/PHP-5.5/Zend/zend_API.c#L620

So, I think that we should use `*` for saving `fci->params` and `fci->param_count`.

We also know that it need to use `*` from https://github.com/php/php-src/blob/PHP-5.5/Zend/zend_API.c#L620