### PR TITLE
Fixing Ruby's Rakefile - high version number was hardcoded.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -83,7 +83,7 @@ task 'dlls' do
   env += 'EMBED_ZLIB=true '
   env += 'BUILDDIR=/tmp '
   env += "V=#{verbose} "
-  out = '/tmp/libs/opt/grpc-0.dll'
+  out = '/tmp/libs/opt/grpc-1.dll'
 
   w64 = { cross: 'x86_64-w64-mingw32', out: 'grpc_c.64.ruby' }
   w32 = { cross: 'i686-w64-mingw32', out: 'grpc_c.32.ruby' }


### PR DESCRIPTION
Fixes https://grpc-testing.appspot.com/view/Artifacts/job/gRPC_build_artifacts/1325/architecture=x64,language=ruby,platform=linux/console