### PR TITLE
Add a macro to support protobuf lite

### DIFF
--- a/include/grpc++/impl/codegen/config_protobuf.h
+++ b/include/grpc++/impl/codegen/config_protobuf.h
@@ -40,8 +40,13 @@
 #endif
 
 #ifndef GRPC_CUSTOM_MESSAGE
+#ifdef GRPC_USE_PROTO_LITE
+#include <google/protobuf/message_lite.h>
+#define GRPC_CUSTOM_MESSAGE ::google::protobuf::MessageLite
+#else
 #include <google/protobuf/message.h>
 #define GRPC_CUSTOM_MESSAGE ::google::protobuf::Message
+#endif
 #endif
 
 #ifndef GRPC_CUSTOM_DESCRIPTOR


### PR DESCRIPTION
Note not all the libraries can be built with the macro defined, namely those related to the command line tool and server reflection.