### PR TITLE
Test Py35 and Py36 by default on Jenkins

### DIFF
--- a/templates/tools/dockerfile/apt_get_pyenv.include
+++ b/templates/tools/dockerfile/apt_get_pyenv.include
@@ -11,8 +11,12 @@ RUN apt-get update && apt-get install -y ${'\\'}
   zlib1g-dev && apt-get clean
 
 # Install Pyenv and dev Python versions 3.5 and 3.6
-RUN curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
-RUN pyenv update
+ENV PYENV_ROOT $HOME/.pyenv
+ENV PATH $PYENV_ROOT/bin:$PATH
+RUN git clone https://github.com/yyuu/pyenv.git $PYENV_ROOT
+RUN echo "export PYENV_ROOT=$PYENV_ROOT" >> /etc/profile
+RUN echo 'export PATH=$PYENV_ROOT/bin:$PATH' >> /etc/profile
+RUN echo 'eval "$(pyenv init -)"' >> /etc/profile
 RUN pyenv install 3.5-dev
 RUN pyenv install 3.6-dev
-RUN pyenv local 3.5-dev 3.6-dev
+RUN pyenv local system 3.5-dev 3.6-dev

--- a/tools/dockerfile/test/python_pyenv_x64/Dockerfile
+++ b/tools/dockerfile/test/python_pyenv_x64/Dockerfile
@@ -91,11 +91,15 @@ RUN apt-get update && apt-get install -y \
   zlib1g-dev && apt-get clean
 
 # Install Pyenv and dev Python versions 3.5 and 3.6
-RUN curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
-RUN pyenv update
+ENV PYENV_ROOT $HOME/.pyenv
+ENV PATH $PYENV_ROOT/bin:$PATH
+RUN git clone https://github.com/yyuu/pyenv.git $PYENV_ROOT
+RUN echo "export PYENV_ROOT=$PYENV_ROOT" >> /etc/profile
+RUN echo 'export PATH=$PYENV_ROOT/bin:$PATH' >> /etc/profile
+RUN echo 'eval "$(pyenv init -)"' >> /etc/profile
 RUN pyenv install 3.5-dev
 RUN pyenv install 3.6-dev
-RUN pyenv local 3.5-dev 3.6-dev
+RUN pyenv local system 3.5-dev 3.6-dev
 
 # Prepare ccache
 RUN ln -s /usr/bin/ccache /usr/local/bin/gcc

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -425,7 +425,7 @@ class PythonLanguage(object):
     return 'tools/dockerfile/test/python_%s_%s' % (self.python_manager_name(), _docker_arch_suffix(self.args.arch))
 
   def python_manager_name(self):
-    return 'pyenv' if self.args.compiler in ['python3.5', 'python3.6'] else 'jessie'
+    return 'pyenv'
 
   def _get_pythons(self, args):
     if args.arch == 'x86':
@@ -466,7 +466,7 @@ class PythonLanguage(object):
       if os.name == 'nt':
         return (python27_config,)
       else:
-        return (python27_config, python34_config,)
+        return (python27_config, python34_config, python35_config, python36_config,)
     elif args.compiler == 'python2.7':
       return (python27_config,)
     elif args.compiler == 'python3.4':


### PR DESCRIPTION
@thunderboltsid noted that we'd still need to make a small number of changes for tests to run under Python 3.5+, e.g. [this](https://github.com/grpc/grpc/blob/master/src/python/grpcio_tests/tests/unit/_channel_ready_future_test.py#L81) becoming something more mocky and less breaky.
