### PR TITLE
Remove undefined reference warning in Ruby build

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -92,7 +92,6 @@ if grpc_config == 'gcov'
 end
 
 $LDFLAGS << ' -Wl,-wrap,memcpy' if RUBY_PLATFORM =~ /linux/
-$LDFLAGS << ' -Wl,--no-undefined' if RUBY_PLATFORM =~ /linux/
 $LDFLAGS << ' -static' if windows
 
 $CFLAGS << ' -std=c99 '


### PR DESCRIPTION
I don't think that warning was a good idea; it appears to have broken some builds.