### PR TITLE
Remove non-manylinux linux .whl artifacts

### DIFF
--- a/tools/run_tests/artifact_targets.py
+++ b/tools/run_tests/artifact_targets.py
@@ -119,6 +119,7 @@ class PythonArtifact:
       # need to do this manually...
       environ['CFLAGS'] = '-DGPR_MANYLINUX1=1'
       environ['BUILD_HEALTH_CHECKING'] = 'TRUE'
+      environ['BUILD_MANYLINUX_WHEEL'] = 'TRUE'
       return create_docker_jobspec(self.name,
           'tools/dockerfile/grpc_artifact_python_manylinux_%s' % self.arch,
           'tools/run_tests/build_artifact_python.sh',

--- a/tools/run_tests/build_artifact_python.sh
+++ b/tools/run_tests/build_artifact_python.sh
@@ -62,13 +62,15 @@ CFLAGS="$CFLAGS -fno-wrapv" ${SETARCH_CMD} \
   ${PYTHON} tools/distrib/python/grpcio_tools/setup.py bdist_wheel
 
 mkdir -p artifacts
-if command -v ${AUDITWHEEL}
+if [ "$BUILD_MANYLINUX_WHEEL" != "" ]
 then
   for wheel in dist/*.whl; do
     ${AUDITWHEEL} repair $wheel -w artifacts/
+    rm $wheel
   done
   for wheel in tools/distrib/python/grpcio_tools/dist/*.whl; do
     ${AUDITWHEEL} repair $wheel -w artifacts/
+    rm $wheel
   done
 fi
 


### PR DESCRIPTION
These crowd the artifact build, and we also want to avoid the distrib tests using these wheels.