### PR TITLE
Add csharp check to return val of byte_buffer_reader_init

### DIFF
--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -253,8 +253,9 @@ GPR_EXPORT intptr_t GPR_CALLTYPE grpcsharp_batch_context_recv_message_length(
   if (!ctx->recv_message) {
     return -1;
   }
-  /* TODO(issue:#7206): check return value of grpc_byte_buffer_reader_init. */
-  grpc_byte_buffer_reader_init(&reader, ctx->recv_message);
+
+  GPR_ASSERT(grpc_byte_buffer_reader_init(&reader, ctx->recv_message));
+
   return (intptr_t)grpc_byte_buffer_length(reader.buffer_out);
 }
 
@@ -268,8 +269,7 @@ GPR_EXPORT void GPR_CALLTYPE grpcsharp_batch_context_recv_message_to_buffer(
   gpr_slice slice;
   size_t offset = 0;
 
-  /* TODO(issue:#7206): check return value of grpc_byte_buffer_reader_init. */
-  grpc_byte_buffer_reader_init(&reader, ctx->recv_message);
+  GPR_ASSERT(grpc_byte_buffer_reader_init(&reader, ctx->recv_message));
 
   while (grpc_byte_buffer_reader_next(&reader, &slice)) {
     size_t len = GPR_SLICE_LENGTH(slice);


### PR DESCRIPTION
Retried for CLA issues.

This was merged into master last week, but I think I should have merged this into v1.0.x as well. Here is the PR for the master branch from last week: #7372.

This adds a check to the new return value of byte_buffer_reader_init in Csharp. It uses GPR_ASSERT to fail if the return value is bad, since the wrapper already tries to avoid reading from null messages at all.