### PR TITLE
PHP: add PHP7 to various Jenkins tests and update dockerfile

### DIFF
--- a/src/php/bin/determine_extension_dir.sh
+++ b/src/php/bin/determine_extension_dir.sh
@@ -29,11 +29,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 set -e
 default_extension_dir=$(php-config --extension-dir)
-if command -v brew > /dev/null && \
-   brew ls --versions | grep php5[56]-grpc > /dev/null; then
-  # the grpc php extension was installed by homebrew
-  :
-elif [ ! -e $default_extension_dir/grpc.so ]; then
+if [ ! -e $default_extension_dir/grpc.so ]; then
   # the grpc extension is not found in the default PHP extension dir
   # try the source modules directory
   module_dir=../ext/grpc/modules

--- a/templates/tools/dockerfile/interoptest/grpc_interop_php/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_php/Dockerfile.template
@@ -46,11 +46,6 @@
   RUN curl -sS https://getcomposer.org/installer | php
   RUN mv composer.phar /usr/local/bin/composer
   
-  # As an attempt to work around #4212, try to prefetch Protobuf-PHP dependency
-  # into composer cache to prevent "composer install" from cloning on each build.
-  RUN git clone --mirror https://github.com/stanley-cheung/Protobuf-PHP.git ${'\\'}
-    /root/.composer/cache/vcs/git-github.com-stanley-cheung-Protobuf-PHP.git/
-  
   # Download the patched PHP protobuf so that PHP gRPC clients can be generated
   # from proto3 schemas.
   RUN git clone https://github.com/stanley-cheung/Protobuf-PHP.git /var/local/git/protobuf-php

--- a/templates/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile.template
@@ -31,9 +31,7 @@
   
   FROM debian:jessie
   
-  <%include file="../../apt_get_basic.include"/>
+  <%include file="../../php7_deps.include"/>
   <%include file="../../ruby_deps.include"/>
-  <%include file="../../php_deps.include"/>
   <%include file="../../run_tests_addons.include"/>
   <%include file="../../php_common_deps.include"/>
-  

--- a/templates/tools/dockerfile/php7_deps.include
+++ b/templates/tools/dockerfile/php7_deps.include
@@ -1,0 +1,45 @@
+#=================
+# PHP7 dependencies
+
+# Install Git and basic packages.
+RUN apt-get update && apt-get install -y ${'\\'}
+  autoconf ${'\\'}
+  automake ${'\\'}
+  build-essential ${'\\'}
+  ccache ${'\\'}
+  curl ${'\\'}
+  git ${'\\'}
+  libcurl4-openssl-dev ${'\\'}
+  libgmp-dev ${'\\'}
+  libgmp3-dev ${'\\'}
+  libssl-dev ${'\\'}
+  libtool ${'\\'}
+  libxml2-dev ${'\\'}
+  pkg-config ${'\\'}
+  re2c ${'\\'}
+  time ${'\\'}
+  unzip ${'\\'}
+  wget ${'\\'}
+  zip && apt-get clean
+
+# Install other dependencies
+RUN ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
+RUN wget http://ftp.gnu.org/gnu/bison/bison-2.6.4.tar.gz -O /var/local/bison-2.6.4.tar.gz
+RUN cd /var/local ${'\\'}
+  && tar -zxvf bison-2.6.4.tar.gz ${'\\'}
+  && cd /var/local/bison-2.6.4 ${'\\'}
+  && ./configure ${'\\'}
+  && make ${'\\'}
+  && make install
+
+# Compile PHP7 from source
+RUN git clone https://github.com/php/php-src /var/local/git/php-src
+RUN cd /var/local/git/php-src ${'\\'}
+  && git checkout PHP-7.0.9 ${'\\'}
+  && ./buildconf --force ${'\\'}
+  && ./configure ${'\\'}
+  --with-gmp ${'\\'}
+  --with-openssl ${'\\'}
+  --with-zlib ${'\\'}
+  && make ${'\\'}
+  && make install

--- a/templates/tools/dockerfile/php_common_deps.include
+++ b/templates/tools/dockerfile/php_common_deps.include
@@ -1,0 +1,21 @@
+# ronn: a ruby tool used to convert markdown to man pages, used during the
+# install of Protobuf extensions
+#
+# rake: a ruby version of make used to build the PHP Protobuf extension
+RUN /bin/bash -l -c "rvm all do gem install ronn rake"
+
+# Install composer
+RUN curl -sS https://getcomposer.org/installer | php
+RUN mv composer.phar /usr/local/bin/composer
+
+# Download the patched PHP protobuf so that PHP gRPC clients can be generated
+# from proto3 schemas.
+RUN git clone https://github.com/stanley-cheung/Protobuf-PHP.git /var/local/git/protobuf-php
+
+RUN /bin/bash -l -c "rvm use ruby-2.1 ${'\\'}
+  && cd /var/local/git/protobuf-php ${'\\'}
+  && rvm all do rake pear:package version=1.0 ${'\\'}
+  && pear install Protobuf-1.0.tgz"
+
+# Define the default command.
+CMD ["bash"]

--- a/templates/tools/dockerfile/php_deps.include
+++ b/templates/tools/dockerfile/php_deps.include
@@ -3,11 +3,5 @@
 
 # Install dependencies
 
-RUN /bin/bash -l -c "echo 'deb http://packages.dotdeb.org wheezy-php55 all' ${'\\'}
-    >> /etc/apt/sources.list.d/dotdeb.list"
-RUN /bin/bash -l -c "echo 'deb-src http://packages.dotdeb.org wheezy-php55 all' ${'\\'}
-    >> /etc/apt/sources.list.d/dotdeb.list"
-RUN wget http://www.dotdeb.org/dotdeb.gpg -O- | apt-key add -
-
 RUN apt-get update && apt-get install -y ${'\\'}
     git php5 php5-dev phpunit unzip

--- a/templates/tools/dockerfile/stress_test/grpc_interop_stress_php/Dockerfile.template
+++ b/templates/tools/dockerfile/stress_test/grpc_interop_stress_php/Dockerfile.template
@@ -47,11 +47,6 @@
   RUN curl -sS https://getcomposer.org/installer | php
   RUN mv composer.phar /usr/local/bin/composer
   
-  # As an attempt to work around #4212, try to prefetch Protobuf-PHP dependency
-  # into composer cache to prevent "composer install" from cloning on each build.
-  RUN git clone --mirror https://github.com/stanley-cheung/Protobuf-PHP.git ${'\\'}
-    /root/.composer/cache/vcs/git-github.com-stanley-cheung-Protobuf-PHP.git/
-  
   # Download the patched PHP protobuf so that PHP gRPC clients can be generated
   # from proto3 schemas.
   RUN git clone https://github.com/stanley-cheung/Protobuf-PHP.git /var/local/git/protobuf-php

--- a/templates/tools/dockerfile/test/php7_jessie_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/php7_jessie_x64/Dockerfile.template
@@ -1,6 +1,6 @@
 %YAML 1.2
 --- |
-  # Copyright 2016, Google Inc.
+  # Copyright 2015, Google Inc.
   # All rights reserved.
   #
   # Redistribution and use in source and binary forms, with or without
@@ -31,9 +31,8 @@
   
   FROM debian:jessie
   
-  <%include file="../../apt_get_basic.include"/>
-  <%include file="../../ruby_deps.include"/>
-  <%include file="../../php_deps.include"/>
+  <%include file="../../php7_deps.include"/>
+  <%include file="../../python_deps.include"/>
   <%include file="../../run_tests_addons.include"/>
-  <%include file="../../php_common_deps.include"/>
-  
+  # Define the default command.
+  CMD ["bash"]

--- a/templates/tools/dockerfile/test/php7_jessie_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/php7_jessie_x64/Dockerfile.template
@@ -1,6 +1,6 @@
 %YAML 1.2
 --- |
-  # Copyright 2015, Google Inc.
+  # Copyright 2016, Google Inc.
   # All rights reserved.
   #
   # Redistribution and use in source and binary forms, with or without

--- a/tools/dockerfile/interoptest/grpc_interop_php/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_php/Dockerfile
@@ -122,11 +122,6 @@ RUN /bin/bash -l -c "rvm all do gem install ronn rake"
 RUN curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer
 
-# As an attempt to work around #4212, try to prefetch Protobuf-PHP dependency
-# into composer cache to prevent "composer install" from cloning on each build.
-RUN git clone --mirror https://github.com/stanley-cheung/Protobuf-PHP.git \
-  /root/.composer/cache/vcs/git-github.com-stanley-cheung-Protobuf-PHP.git/
-
 # Download the patched PHP protobuf so that PHP gRPC clients can be generated
 # from proto3 schemas.
 RUN git clone https://github.com/stanley-cheung/Protobuf-PHP.git /var/local/git/protobuf-php

--- a/tools/dockerfile/interoptest/grpc_interop_php/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_php/Dockerfile
@@ -98,12 +98,6 @@ RUN /bin/bash -l -c "gem install bundler --no-ri --no-rdoc"
 
 # Install dependencies
 
-RUN /bin/bash -l -c "echo 'deb http://packages.dotdeb.org wheezy-php55 all' \
-    >> /etc/apt/sources.list.d/dotdeb.list"
-RUN /bin/bash -l -c "echo 'deb-src http://packages.dotdeb.org wheezy-php55 all' \
-    >> /etc/apt/sources.list.d/dotdeb.list"
-RUN wget http://www.dotdeb.org/dotdeb.gpg -O- | apt-key add -
-
 RUN apt-get update && apt-get install -y \
     git php5 php5-dev phpunit unzip
 

--- a/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
@@ -29,39 +29,51 @@
 
 FROM debian:jessie
 
+#=================
+# PHP7 dependencies
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
-  autotools-dev \
+  automake \
   build-essential \
-  bzip2 \
   ccache \
   curl \
-  gcc \
-  gcc-multilib \
   git \
-  golang \
-  gyp \
-  lcov \
-  libc6 \
-  libc6-dbg \
-  libc6-dev \
-  libgtest-dev \
+  libcurl4-openssl-dev \
+  libgmp-dev \
+  libgmp3-dev \
+  libssl-dev \
   libtool \
-  make \
-  perl \
-  strace \
-  python-dev \
-  python-setuptools \
-  python-yaml \
-  telnet \
+  libxml2-dev \
+  pkg-config \
+  re2c \
+  time \
   unzip \
   wget \
   zip && apt-get clean
 
-#================
-# Build profiling
-RUN apt-get update && apt-get install -y time && apt-get clean
+# Install other dependencies
+RUN ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
+RUN wget http://ftp.gnu.org/gnu/bison/bison-2.6.4.tar.gz -O /var/local/bison-2.6.4.tar.gz
+RUN cd /var/local \
+  && tar -zxvf bison-2.6.4.tar.gz \
+  && cd /var/local/bison-2.6.4 \
+  && ./configure \
+  && make \
+  && make install
+
+# Compile PHP7 from source
+RUN git clone https://github.com/php/php-src /var/local/git/php-src
+RUN cd /var/local/git/php-src \
+  && git checkout PHP-7.0.9 \
+  && ./buildconf --force \
+  && ./configure \
+  --with-gmp \
+  --with-openssl \
+  --with-zlib \
+  && make \
+  && make install
 
 #==================
 # Ruby dependencies
@@ -77,14 +89,6 @@ RUN /bin/bash -l -c "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
 RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
 RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.1' >> ~/.bashrc"
 RUN /bin/bash -l -c "gem install bundler --no-ri --no-rdoc"
-
-#=================
-# PHP dependencies
-
-# Install dependencies
-
-RUN apt-get update && apt-get install -y \
-    git php5 php5-dev phpunit unzip
 
 # Prepare ccache
 RUN ln -s /usr/bin/ccache /usr/local/bin/gcc

--- a/tools/dockerfile/interoptest/grpc_interop_php7/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_php7/build_interop.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright 2016, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Builds PHP interop server and client in a base image.
+set -ex
+
+mkdir -p /var/local/git
+git clone --recursive /var/local/jenkins/grpc /var/local/git/grpc
+
+# copy service account keys if available
+cp -r /var/local/jenkins/service_account $HOME || true
+
+cd /var/local/git/grpc
+rvm --default use ruby-2.1
+
+# gRPC core and protobuf need to be installed
+make install
+
+(cd src/php/ext/grpc && phpize && ./configure && make)
+
+(cd third_party/protobuf && make install)
+
+(cd src/php && composer install)
+
+(cd src/php && protoc-gen-php -i tests/interop/ -o tests/interop/ tests/interop/test.proto)

--- a/tools/dockerfile/stress_test/grpc_interop_stress_php/Dockerfile
+++ b/tools/dockerfile/stress_test/grpc_interop_stress_php/Dockerfile
@@ -127,11 +127,6 @@ RUN /bin/bash -l -c "rvm all do gem install ronn rake"
 RUN curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer
 
-# As an attempt to work around #4212, try to prefetch Protobuf-PHP dependency
-# into composer cache to prevent "composer install" from cloning on each build.
-RUN git clone --mirror https://github.com/stanley-cheung/Protobuf-PHP.git \
-  /root/.composer/cache/vcs/git-github.com-stanley-cheung-Protobuf-PHP.git/
-
 # Download the patched PHP protobuf so that PHP gRPC clients can be generated
 # from proto3 schemas.
 RUN git clone https://github.com/stanley-cheung/Protobuf-PHP.git /var/local/git/protobuf-php

--- a/tools/dockerfile/stress_test/grpc_interop_stress_php/Dockerfile
+++ b/tools/dockerfile/stress_test/grpc_interop_stress_php/Dockerfile
@@ -103,12 +103,6 @@ RUN pip install --upgrade google-api-python-client
 
 # Install dependencies
 
-RUN /bin/bash -l -c "echo 'deb http://packages.dotdeb.org wheezy-php55 all' \
-    >> /etc/apt/sources.list.d/dotdeb.list"
-RUN /bin/bash -l -c "echo 'deb-src http://packages.dotdeb.org wheezy-php55 all' \
-    >> /etc/apt/sources.list.d/dotdeb.list"
-RUN wget http://www.dotdeb.org/dotdeb.gpg -O- | apt-key add -
-
 RUN apt-get update && apt-get install -y \
     git php5 php5-dev phpunit unzip
 

--- a/tools/dockerfile/test/multilang_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/multilang_jessie_x64/Dockerfile
@@ -100,12 +100,6 @@ RUN /bin/bash -l -c "nvm alias default 4"
 
 # Install dependencies
 
-RUN /bin/bash -l -c "echo 'deb http://packages.dotdeb.org wheezy-php55 all' \
-    >> /etc/apt/sources.list.d/dotdeb.list"
-RUN /bin/bash -l -c "echo 'deb-src http://packages.dotdeb.org wheezy-php55 all' \
-    >> /etc/apt/sources.list.d/dotdeb.list"
-RUN wget http://www.dotdeb.org/dotdeb.gpg -O- | apt-key add -
-
 RUN apt-get update && apt-get install -y \
     git php5 php5-dev phpunit unzip
 

--- a/tools/dockerfile/test/php7_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/php7_jessie_x64/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2016, Google Inc.
+# Copyright 2015, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -29,62 +29,66 @@
 
 FROM debian:jessie
 
+#=================
+# PHP7 dependencies
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
-  autotools-dev \
+  automake \
   build-essential \
-  bzip2 \
   ccache \
   curl \
-  gcc \
-  gcc-multilib \
   git \
-  golang \
-  gyp \
-  lcov \
-  libc6 \
-  libc6-dbg \
-  libc6-dev \
-  libgtest-dev \
+  libcurl4-openssl-dev \
+  libgmp-dev \
+  libgmp3-dev \
+  libssl-dev \
   libtool \
-  make \
-  perl \
-  strace \
-  python-dev \
-  python-setuptools \
-  python-yaml \
-  telnet \
+  libxml2-dev \
+  pkg-config \
+  re2c \
+  time \
   unzip \
   wget \
   zip && apt-get clean
 
-#================
-# Build profiling
-RUN apt-get update && apt-get install -y time && apt-get clean
+# Install other dependencies
+RUN ln -sf /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h
+RUN wget http://ftp.gnu.org/gnu/bison/bison-2.6.4.tar.gz -O /var/local/bison-2.6.4.tar.gz
+RUN cd /var/local \
+  && tar -zxvf bison-2.6.4.tar.gz \
+  && cd /var/local/bison-2.6.4 \
+  && ./configure \
+  && make \
+  && make install
 
-#==================
-# Ruby dependencies
+# Compile PHP7 from source
+RUN git clone https://github.com/php/php-src /var/local/git/php-src
+RUN cd /var/local/git/php-src \
+  && git checkout PHP-7.0.9 \
+  && ./buildconf --force \
+  && ./configure \
+  --with-gmp \
+  --with-openssl \
+  --with-zlib \
+  && make \
+  && make install
 
-# Install rvm
-RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
-RUN \curl -sSL https://get.rvm.io | bash -s stable
-
-# Install Ruby 2.1
-RUN /bin/bash -l -c "rvm install ruby-2.1"
-RUN /bin/bash -l -c "rvm use --default ruby-2.1"
-RUN /bin/bash -l -c "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
-RUN /bin/bash -l -c "echo 'export PATH=/usr/local/rvm/bin:$PATH' >> ~/.bashrc"
-RUN /bin/bash -l -c "echo 'rvm --default use ruby-2.1' >> ~/.bashrc"
-RUN /bin/bash -l -c "gem install bundler --no-ri --no-rdoc"
-
-#=================
-# PHP dependencies
+#====================
+# Python dependencies
 
 # Install dependencies
 
 RUN apt-get update && apt-get install -y \
-    git php5 php5-dev phpunit unzip
+    python-all-dev \
+    python3-all-dev \
+    python-pip
+
+# Install Python packages from PyPI
+RUN pip install pip --upgrade
+RUN pip install virtualenv
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.0.0a2 six==1.10.0
 
 # Prepare ccache
 RUN ln -s /usr/bin/ccache /usr/local/bin/gcc
@@ -97,25 +101,5 @@ RUN ln -s /usr/bin/ccache /usr/local/bin/clang++
 
 RUN mkdir /var/local/jenkins
 
-# ronn: a ruby tool used to convert markdown to man pages, used during the
-# install of Protobuf extensions
-#
-# rake: a ruby version of make used to build the PHP Protobuf extension
-RUN /bin/bash -l -c "rvm all do gem install ronn rake"
-
-# Install composer
-RUN curl -sS https://getcomposer.org/installer | php
-RUN mv composer.phar /usr/local/bin/composer
-
-# Download the patched PHP protobuf so that PHP gRPC clients can be generated
-# from proto3 schemas.
-RUN git clone https://github.com/stanley-cheung/Protobuf-PHP.git /var/local/git/protobuf-php
-
-RUN /bin/bash -l -c "rvm use ruby-2.1 \
-  && cd /var/local/git/protobuf-php \
-  && rvm all do rake pear:package version=1.0 \
-  && pear install Protobuf-1.0.tgz"
-
 # Define the default command.
 CMD ["bash"]
-

--- a/tools/dockerfile/test/php7_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/php7_jessie_x64/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2015, Google Inc.
+# Copyright 2016, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/tools/dockerfile/test/php_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/php_jessie_x64/Dockerfile
@@ -83,12 +83,6 @@ RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.0.0a2 six==1.10.0
 
 # Install dependencies
 
-RUN /bin/bash -l -c "echo 'deb http://packages.dotdeb.org wheezy-php55 all' \
-    >> /etc/apt/sources.list.d/dotdeb.list"
-RUN /bin/bash -l -c "echo 'deb-src http://packages.dotdeb.org wheezy-php55 all' \
-    >> /etc/apt/sources.list.d/dotdeb.list"
-RUN wget http://www.dotdeb.org/dotdeb.gpg -O- | apt-key add -
-
 RUN apt-get update && apt-get install -y \
     git php5 php5-dev phpunit unzip
 

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -268,6 +268,31 @@ class PHPLanguage:
     return 'php'
 
 
+class PHP7Language:
+
+  def __init__(self):
+    self.client_cwd = None
+    self.safename = str(self)
+
+  def client_cmd(self, args):
+    return ['src/php/bin/interop_client.sh'] + args
+
+  def cloud_to_prod_env(self):
+    return {}
+
+  def global_env(self):
+    return {}
+
+  def unimplemented_test_cases(self):
+    return _SKIP_COMPRESSION
+
+  def unimplemented_test_cases_server(self):
+    return []
+
+  def __str__(self):
+    return 'php7'
+
+
 class RubyLanguage:
 
   def __init__(self):
@@ -346,6 +371,7 @@ _LANGUAGES = {
     'java' : JavaLanguage(),
     'node' : NodeLanguage(),
     'php' :  PHPLanguage(),
+    'php7' :  PHP7Language(),
     'ruby' : RubyLanguage(),
     'python' : PythonLanguage(),
 }
@@ -409,7 +435,7 @@ def auth_options(language, test_case):
   default_account_arg = '--default_service_account=830293263384-compute@developer.gserviceaccount.com'
 
   if test_case in ['jwt_token_creds', 'per_rpc_creds', 'oauth2_auth_token']:
-    if language in ['csharp', 'node', 'php', 'python', 'ruby']:
+    if language in ['csharp', 'node', 'php', 'php7', 'python', 'ruby']:
       env['GOOGLE_APPLICATION_CREDENTIALS'] = key_filepath
     else:
       cmdargs += [key_file_arg]

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -378,6 +378,42 @@ class PhpLanguage(object):
     return 'php'
 
 
+class Php7Language(object):
+
+  def configure(self, config, args):
+    self.config = config
+    self.args = args
+    _check_compiler(self.args.compiler, ['default'])
+
+  def test_specs(self):
+    return [self.config.job_spec(['src/php/bin/run_tests.sh'], None,
+                                  environ=_FORCE_ENVIRON_FOR_WRAPPERS)]
+
+  def pre_build_steps(self):
+    return []
+
+  def make_targets(self):
+    return ['static_c', 'shared_c']
+
+  def make_options(self):
+    return []
+
+  def build_steps(self):
+    return [['tools/run_tests/build_php.sh']]
+
+  def post_tests_steps(self):
+    return [['tools/run_tests/post_tests_php.sh']]
+
+  def makefile_name(self):
+    return 'Makefile'
+
+  def dockerfile_dir(self):
+    return 'tools/dockerfile/test/php7_jessie_%s' % _docker_arch_suffix(self.args.arch)
+
+  def __str__(self):
+    return 'php7'
+
+
 class PythonConfig(collections.namedtuple('PythonConfig', [
     'name', 'build', 'run'])):
   """Tuple of commands (named s.t. 'what it says on the tin' applies)"""
@@ -746,6 +782,7 @@ _LANGUAGES = {
     'c': CLanguage('c', 'c'),
     'node': NodeLanguage(),
     'php': PhpLanguage(),
+    'php7': Php7Language(),
     'python': PythonLanguage(),
     'ruby': RubyLanguage(),
     'csharp': CSharpLanguage(),


### PR DESCRIPTION
 - Added PHP7 as a new test configuration to Jenkins Basic test and Interop tests
     - PHP7 is being compiled from source in the dockerfile for now
     - Refactored some common dependencies shared with the base `grpc_interop_php` dockerfile
     - Added `php7` as a separate language to the `run_tests` and `run_interop_tests` runners because a totally different base docker image is needed
 - Removed a previous `git clone` hack to the `Protobuf-PHP` repo
 - Removed an outdated step modifying the `dotdeb.list` file before `apt-get install`
 - Removed a check to expect extension to be installed by homebrew
 - Will add `php7` to the actual Jenkins project configuration after code is merged (I tested that manually and tests are all green)
 - To run these locally
     - `./tools/run_tests/run_tests.py -l php7 --use_docker`
     - `./tools/run_tests/run_interop_tests.py -l php7 -s all --use_docker -t -j 8`
     - `./tools/run_tests/run_interop_tests.py -l php7 --cloud_to_prod --use_docker -t -j 8`
     - `./tools/run_tests/run_interop_tests.py -l php7 --cloud_to_prod_auth --use_docker -t -j 8`
 - Fixes #6366 