### PR TITLE
changed ix-async dependencies to System.Interactive.Async version 3.0.0

### DIFF
--- a/src/csharp/.nuget/packages.config
+++ b/src/csharp/.nuget/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit.ConsoleRunner" version="3.2.0" />
-  <package id="OpenCover" version="4.6.519" />
-  <package id="ReportGenerator" version="2.4.4.0" />
-</packages>

--- a/src/csharp/Grpc.Auth/project.json
+++ b/src/csharp/Grpc.Auth/project.json
@@ -32,9 +32,9 @@
         "net45"
       ],
       "dependencies": {
-        "Microsoft.NETCore.Portable.Compatibility": "1.0.1-rc2-24027",
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "System.Threading.Tasks": "4.0.11-rc2-24027"
+        "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+        "NETStandard.Library": "1.6.0",
+        "System.Threading.Tasks": "4.0.11"
       }
     }
   }

--- a/src/csharp/Grpc.Core.Tests/AppDomainUnloadTest.cs
+++ b/src/csharp/Grpc.Core.Tests/AppDomainUnloadTest.cs
@@ -40,7 +40,7 @@ namespace Grpc.Core.Tests
 {
     public class AppDomainUnloadTest
     {
-#if NETSTANDARD1_5
+#if NETCOREAPP1_0
         [Test]
         [Ignore("Not supported for CoreCLR")]
         public void AppDomainUnloadHookCanCleanupAbandonedCall()

--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
@@ -40,7 +40,7 @@
       <HintPath>..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System.Interactive.Async">
-      <HintPath>..\packages\Ix-Async.1.2.5\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="nunitlite">
       <HintPath>..\packages\NUnitLite.3.2.0\lib\net45\nunitlite.dll</HintPath>

--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
@@ -40,7 +40,9 @@
       <HintPath>..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System.Interactive.Async">
-      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <!-- Support package restores in solution or project directories -->
+      <HintPath Condition="Exists('..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath Condition="Exists('.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="nunitlite">
       <HintPath>..\packages\NUnitLite.3.2.0\lib\net45\nunitlite.dll</HintPath>

--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
@@ -41,8 +41,8 @@
     </Reference>
     <Reference Include="System.Interactive.Async">
       <!-- Support package restores in solution or project directories -->
-      <HintPath Condition="Exists('..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
-      <HintPath Condition="Exists('.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="nunitlite">
       <HintPath>..\packages\NUnitLite.3.2.0\lib\net45\nunitlite.dll</HintPath>

--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
@@ -41,8 +41,8 @@
     </Reference>
     <Reference Include="System.Interactive.Async">
       <!-- Support package restores in solution or project directories -->
-      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
-      <HintPath>.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>.\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="nunitlite">
       <HintPath>..\packages\NUnitLite.3.2.0\lib\net45\nunitlite.dll</HintPath>

--- a/src/csharp/Grpc.Core.Tests/NUnitMain.cs
+++ b/src/csharp/Grpc.Core.Tests/NUnitMain.cs
@@ -49,7 +49,7 @@ namespace Grpc.Core.Tests
         {
             // Make logger immune to NUnit capturing stdout and stderr to workaround https://github.com/nunit/nunit/issues/1406.
             GrpcEnvironment.SetLogger(new TextWriterLogger(Console.Error));
-#if NETSTANDARD1_5
+#if NETCOREAPP1_0
             return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
 #else
             return new AutoRun().Execute(args);

--- a/src/csharp/Grpc.Core.Tests/SanityTest.cs
+++ b/src/csharp/Grpc.Core.Tests/SanityTest.cs
@@ -46,7 +46,7 @@ namespace Grpc.Core.Tests
     public class SanityTest
     {
         // TODO: make sanity test work for CoreCLR as well
-#if !NETSTANDARD1_5
+#if !NETCOREAPP1_0
         /// <summary>
         /// Because we depend on a native library, sometimes when things go wrong, the
         /// entire NUnit test process crashes. To be able to track down problems better,

--- a/src/csharp/Grpc.Core.Tests/SanityTest.cs
+++ b/src/csharp/Grpc.Core.Tests/SanityTest.cs
@@ -43,10 +43,9 @@ using NUnit.Framework;
 
 namespace Grpc.Core.Tests
 {
+	#if !NETCOREAPP1_0
     public class SanityTest
     {
-        // TODO: make sanity test work for CoreCLR as well
-#if !NETCOREAPP1_0
         /// <summary>
         /// Because we depend on a native library, sometimes when things go wrong, the
         /// entire NUnit test process crashes. To be able to track down problems better,
@@ -100,7 +99,7 @@ namespace Grpc.Core.Tests
         private string ReadTestsJson()
         {
             var assemblyDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var testsJsonFile = Path.Combine(assemblyDir, "..", "..", "..", "tests.json");
+            var testsJsonFile = Path.Combine(assemblyDir, "..", "..", "..", "..", "..", "tests.json");
             return File.ReadAllText(testsJsonFile);
         }
 
@@ -123,6 +122,6 @@ namespace Grpc.Core.Tests
             }
             return result;
         }
-#endif
     }
+	#endif
 }

--- a/src/csharp/Grpc.Core.Tests/SanityTest.cs
+++ b/src/csharp/Grpc.Core.Tests/SanityTest.cs
@@ -43,9 +43,10 @@ using NUnit.Framework;
 
 namespace Grpc.Core.Tests
 {
-	#if !NETCOREAPP1_0
     public class SanityTest
     {
+		// TODO: make sanity test work for CoreCLR as well
+#if !NETCOREAPP1_0
         /// <summary>
         /// Because we depend on a native library, sometimes when things go wrong, the
         /// entire NUnit test process crashes. To be able to track down problems better,
@@ -122,6 +123,6 @@ namespace Grpc.Core.Tests
             }
             return result;
         }
+#endif
     }
-	#endif
 }

--- a/src/csharp/Grpc.Core.Tests/packages.config
+++ b/src/csharp/Grpc.Core.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Ix-Async" version="1.2.5" targetFramework="net45" />
+  <package id="System.Interactive.Async" version="3.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.2.0" targetFramework="net45" />
   <package id="NUnitLite" version="3.2.0" targetFramework="net45" />

--- a/src/csharp/Grpc.Core.Tests/packages.config
+++ b/src/csharp/Grpc.Core.Tests/packages.config
@@ -4,4 +4,7 @@
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.2.0" targetFramework="net45" />
   <package id="NUnitLite" version="3.2.0" targetFramework="net45" />
+  <package id="NUnit.ConsoleRunner" version="3.2.0" />
+  <package id="OpenCover" version="4.6.519" />
+  <package id="ReportGenerator" version="2.4.4.0" />
 </packages>

--- a/src/csharp/Grpc.Core.Tests/project.json
+++ b/src/csharp/Grpc.Core.Tests/project.json
@@ -54,20 +54,17 @@
     },
     "Newtonsoft.Json": "8.0.3",
     "NUnit": "3.2.0",
-    "NUnitLite": "3.2.0-*",
-    "NUnit.ConsoleRunner": "3.2.0",
-    "OpenCover": "4.6.519",
-    "ReportGenerator": "2.4.4.0"
+    "NUnitLite": "3.2.0-*"
   },
-
   "frameworks": {
     "net45": { },
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "imports": [
         "portable-net45"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "Microsoft.NETCore.App": "1.0.0",
+        "NETStandard.Library": "1.6.0"
       }
     }
   },

--- a/src/csharp/Grpc.Core.Tests/project.json
+++ b/src/csharp/Grpc.Core.Tests/project.json
@@ -54,8 +54,12 @@
     },
     "Newtonsoft.Json": "8.0.3",
     "NUnit": "3.2.0",
-    "NUnitLite": "3.2.0-*"
+    "NUnitLite": "3.2.0-*",
+    "NUnit.ConsoleRunner": "3.2.0",
+    "OpenCover": "4.6.519",
+    "ReportGenerator": "2.4.4.0"
   },
+
   "frameworks": {
     "net45": { },
     "netstandard1.5": {

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -40,7 +40,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Interactive.Async">
-      <HintPath>..\packages\Ix-Async.1.2.5\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -41,8 +41,8 @@
     <Reference Include="System" />
     <Reference Include="System.Interactive.Async">
       <!-- Support package restores in solution or project directories -->
-      <HintPath Condition="Exists('..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
-      <HintPath Condition="Exists('.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -40,7 +40,9 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Interactive.Async">
-      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <!-- Support package restores in solution or project directories -->
+      <HintPath Condition="Exists('..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath Condition="Exists('.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -41,8 +41,8 @@
     <Reference Include="System" />
     <Reference Include="System.Interactive.Async">
       <!-- Support package restores in solution or project directories -->
-      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
-      <HintPath>.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>.\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -41,8 +41,8 @@
     <Reference Include="System" />
     <Reference Include="System.Interactive.Async">
       <!-- Support package restores in solution or project directories -->
-      <HintPath>..\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
       <HintPath>.\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csharp/Grpc.Core/Grpc.Core.nuspec
+++ b/src/csharp/Grpc.Core/Grpc.Core.nuspec
@@ -15,7 +15,7 @@
     <copyright>Copyright 2015, Google Inc.</copyright>
     <tags>gRPC RPC Protocol HTTP/2</tags>
     <dependencies>
-      <dependency id="Ix-Async" version="1.2.5" />
+      <dependency id="System.Interactive.Async" version="3.0.0" />
     </dependencies>
   </metadata>
   <files>

--- a/src/csharp/Grpc.Core/packages.config
+++ b/src/csharp/Grpc.Core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Ix-Async" version="1.2.5" targetFramework="net45" />
+  <package id="System.Interactive.Async" version="3.0.0" targetFramework="net45" />
 </packages>

--- a/src/csharp/Grpc.Core/project.json
+++ b/src/csharp/Grpc.Core/project.json
@@ -31,7 +31,7 @@
     "xmlDoc": true
   },
   "dependencies": {
-    "Ix-Async": "1.2.5"
+    "System.Interactive.Async": "3.0.0"
   },
   "frameworks": {
     "net45": { },

--- a/src/csharp/Grpc.Core/project.json
+++ b/src/csharp/Grpc.Core/project.json
@@ -40,8 +40,8 @@
         "portable-net45"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "System.Threading.Thread": "4.0.0-rc2-24027"
+        "NETStandard.Library": "1.6.0",
+        "System.Threading.Thread": "4.0.0"
       }
     }
   }

--- a/src/csharp/Grpc.Core/project.json
+++ b/src/csharp/Grpc.Core/project.json
@@ -31,7 +31,7 @@
     "xmlDoc": true
   },
   "dependencies": {
-    "System.Interactive.Async": "3.0.0"
+    "Ix-Async": "1.2.5"
   },
   "frameworks": {
     "net45": { },

--- a/src/csharp/Grpc.Examples.MathClient/project.json
+++ b/src/csharp/Grpc.Examples.MathClient/project.json
@@ -42,6 +42,11 @@
       }
     }
   },
+  "runtimes": {
+    "win7-x64": { },
+    "debian.8-x64": { },
+    "osx.10.11-x64": { }
+  },
 
   "dependencies": {
     "Grpc.Examples": {
@@ -50,12 +55,13 @@
   },
   "frameworks": {
     "net45": { },
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "imports": [
         "portable-net45"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "Microsoft.NETCore.App": "1.0.0",
+        "NETStandard.Library": "1.6.0"
       }
     }
   }

--- a/src/csharp/Grpc.Examples.MathClient/project.json
+++ b/src/csharp/Grpc.Examples.MathClient/project.json
@@ -42,11 +42,6 @@
       }
     }
   },
-  "runtimes": {
-    "win7-x64": { },
-    "debian.8-x64": { },
-    "osx.10.11-x64": { }
-  },
 
   "dependencies": {
     "Grpc.Examples": {

--- a/src/csharp/Grpc.Examples.MathServer/project.json
+++ b/src/csharp/Grpc.Examples.MathServer/project.json
@@ -42,6 +42,11 @@
       }
     }
   },
+  "runtimes": {
+    "win7-x64": { },
+    "debian.8-x64": { },
+    "osx.10.11-x64": { }
+  },
 
   "dependencies": {
     "Grpc.Examples": {
@@ -50,12 +55,13 @@
   },
   "frameworks": {
     "net45": { },
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "imports": [
         "portable-net45"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "Microsoft.NETCore.App": "1.0.0",
+        "NETStandard.Library": "1.6.0"
       }
     }
   }

--- a/src/csharp/Grpc.Examples.MathServer/project.json
+++ b/src/csharp/Grpc.Examples.MathServer/project.json
@@ -42,11 +42,6 @@
       }
     }
   },
-  "runtimes": {
-    "win7-x64": { },
-    "debian.8-x64": { },
-    "osx.10.11-x64": { }
-  },
 
   "dependencies": {
     "Grpc.Examples": {

--- a/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.csproj
+++ b/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.csproj
@@ -43,7 +43,7 @@
       <HintPath>..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System.Interactive.Async">
-      <HintPath>..\packages\Ix-Async.1.2.5\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="nunitlite">
       <HintPath>..\packages\NUnitLite.3.2.0\lib\net45\nunitlite.dll</HintPath>

--- a/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.csproj
+++ b/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.csproj
@@ -44,8 +44,8 @@
     </Reference>
     <Reference Include="System.Interactive.Async">
       <!-- Support package restores in solution or project directories -->
-      <HintPath Condition="Exists('..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
-      <HintPath Condition="Exists('.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="nunitlite">
       <HintPath>..\packages\NUnitLite.3.2.0\lib\net45\nunitlite.dll</HintPath>

--- a/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.csproj
+++ b/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.csproj
@@ -44,8 +44,8 @@
     </Reference>
     <Reference Include="System.Interactive.Async">
       <!-- Support package restores in solution or project directories -->
-      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
-      <HintPath>.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>.\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="nunitlite">
       <HintPath>..\packages\NUnitLite.3.2.0\lib\net45\nunitlite.dll</HintPath>

--- a/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.csproj
+++ b/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.csproj
@@ -43,7 +43,9 @@
       <HintPath>..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System.Interactive.Async">
-      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <!-- Support package restores in solution or project directories -->
+      <HintPath Condition="Exists('..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath Condition="Exists('.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="nunitlite">
       <HintPath>..\packages\NUnitLite.3.2.0\lib\net45\nunitlite.dll</HintPath>

--- a/src/csharp/Grpc.Examples.Tests/NUnitMain.cs
+++ b/src/csharp/Grpc.Examples.Tests/NUnitMain.cs
@@ -49,7 +49,7 @@ namespace Grpc.Examples.Tests
         {
             // Make logger immune to NUnit capturing stdout and stderr to workaround https://github.com/nunit/nunit/issues/1406.
             GrpcEnvironment.SetLogger(new TextWriterLogger(Console.Error));
-#if NETSTANDARD1_5
+#if NETCOREAPP1_0
             return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
 #else
             return new AutoRun().Execute(args);

--- a/src/csharp/Grpc.Examples.Tests/packages.config
+++ b/src/csharp/Grpc.Examples.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.Protobuf" version="3.0.0-beta3" targetFramework="net45" />
-  <package id="Ix-Async" version="1.2.5" targetFramework="net45" />
+  <package id="System.Interactive.Async" version="3.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.2.0" targetFramework="net45" />
   <package id="NUnitLite" version="3.2.0" targetFramework="net45" />
 </packages>

--- a/src/csharp/Grpc.Examples.Tests/project.json
+++ b/src/csharp/Grpc.Examples.Tests/project.json
@@ -57,12 +57,13 @@
   },
   "frameworks": {
     "net45": { },
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "imports": [
         "portable-net45"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "Microsoft.NETCore.App": "1.0.0",
+        "NETStandard.Library": "1.6.0"
       }
     }
   }

--- a/src/csharp/Grpc.Examples/Grpc.Examples.csproj
+++ b/src/csharp/Grpc.Examples/Grpc.Examples.csproj
@@ -48,7 +48,7 @@
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.Interactive.Async, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Ix-Async.1.2.5\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csharp/Grpc.Examples/Grpc.Examples.csproj
+++ b/src/csharp/Grpc.Examples/Grpc.Examples.csproj
@@ -49,8 +49,8 @@
     <Reference Include="System.Interactive.Async, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <!-- Support package restores in solution or project directories -->
-      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
-      <HintPath>.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>.\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csharp/Grpc.Examples/Grpc.Examples.csproj
+++ b/src/csharp/Grpc.Examples/Grpc.Examples.csproj
@@ -49,8 +49,8 @@
     <Reference Include="System.Interactive.Async, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <!-- Support package restores in solution or project directories -->
-      <HintPath Condition="Exists('..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
-      <HintPath Condition="Exists('.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csharp/Grpc.Examples/Grpc.Examples.csproj
+++ b/src/csharp/Grpc.Examples/Grpc.Examples.csproj
@@ -48,7 +48,9 @@
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.Interactive.Async, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <!-- Support package restores in solution or project directories -->
+      <HintPath Condition="Exists('..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath Condition="Exists('.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/src/csharp/Grpc.Examples/packages.config
+++ b/src/csharp/Grpc.Examples/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.Protobuf" version="3.0.0-beta3" targetFramework="net45" />
-  <package id="Ix-Async" version="1.2.5" targetFramework="net45" />
+  <package id="System.Interactive.Async" version="3.0.0" targetFramework="net45" />
   <package id="NUnit" version="3.2.0" targetFramework="net45" />
 </packages>

--- a/src/csharp/Grpc.Examples/project.json
+++ b/src/csharp/Grpc.Examples/project.json
@@ -1,11 +1,6 @@
 {
   "buildOptions": {
   },
-  "runtimes": {
-    "win7-x64": { },
-    "debian.8-x64": { },
-    "osx.10.11-x64": { }
-  },
 
   "dependencies": {
     "Grpc.Core": {
@@ -25,7 +20,7 @@
         "portable-net45"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "NETStandard.Library": "1.6.0"
       }
     }
   }

--- a/src/csharp/Grpc.Examples/project.json
+++ b/src/csharp/Grpc.Examples/project.json
@@ -1,6 +1,11 @@
 {
   "buildOptions": {
   },
+  "runtimes": {
+    "win7-x64": { },
+    "debian.8-x64": { },
+    "osx.10.11-x64": { }
+  },
 
   "dependencies": {
     "Grpc.Core": {

--- a/src/csharp/Grpc.HealthCheck.Tests/NUnitMain.cs
+++ b/src/csharp/Grpc.HealthCheck.Tests/NUnitMain.cs
@@ -49,7 +49,7 @@ namespace Grpc.HealthCheck.Tests
         {
             // Make logger immune to NUnit capturing stdout and stderr to workaround https://github.com/nunit/nunit/issues/1406.
             GrpcEnvironment.SetLogger(new TextWriterLogger(Console.Error));
-#if NETSTANDARD1_5
+#if NETCOREAPP1_0
             return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
 #else
             return new AutoRun().Execute(args);

--- a/src/csharp/Grpc.HealthCheck.Tests/project.json
+++ b/src/csharp/Grpc.HealthCheck.Tests/project.json
@@ -57,12 +57,13 @@
   },
   "frameworks": {
     "net45": { },
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "imports": [
         "portable-net45"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "Microsoft.NETCore.App": "1.0.0",
+        "NETStandard.Library": "1.6.0"
       }
     }
   }

--- a/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.csproj
+++ b/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.csproj
@@ -46,7 +46,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Interactive.Async, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Ix-Async.1.2.5\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.csproj
+++ b/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.csproj
@@ -47,8 +47,8 @@
     <Reference Include="System.Interactive.Async, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <!-- Support package restores in solution or project directories -->
-      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
-      <HintPath>.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>.\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.csproj
+++ b/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.csproj
@@ -46,7 +46,9 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Interactive.Async, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <!-- Support package restores in solution or project directories -->
+      <HintPath Condition="Exists('..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath Condition="Exists('.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.csproj
+++ b/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.csproj
@@ -47,8 +47,8 @@
     <Reference Include="System.Interactive.Async, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <!-- Support package restores in solution or project directories -->
-      <HintPath Condition="Exists('..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
-      <HintPath Condition="Exists('.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.nuspec
+++ b/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.nuspec
@@ -16,7 +16,7 @@
 	<dependencies>
 	  <dependency id="Google.Protobuf" version="$ProtobufVersion$" />
 	  <dependency id="Grpc.Core" version="$version$" />
-	  <dependency id="Ix-Async" version="1.2.3" />
+	  <dependency id="System.Interactive.Async" version="3.0.0" />
     </dependencies>
   </metadata>
   <files>

--- a/src/csharp/Grpc.HealthCheck/packages.config
+++ b/src/csharp/Grpc.HealthCheck/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.Protobuf" version="3.0.0-beta3" targetFramework="net45" />
-  <package id="Ix-Async" version="1.2.5" targetFramework="net45" />
+  <package id="System.Interactive.Async" version="3.0.0" targetFramework="net45" />
 </packages>

--- a/src/csharp/Grpc.HealthCheck/project.json
+++ b/src/csharp/Grpc.HealthCheck/project.json
@@ -37,7 +37,7 @@
         "portable-net45"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "NETStandard.Library": "1.6.0"
       }
     }
   }

--- a/src/csharp/Grpc.IntegrationTesting.Client/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.Client/project.json
@@ -57,13 +57,14 @@
   },
   "frameworks": {
     "net45": { },
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "imports": [
         "portable-net45",
         "net45"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "Microsoft.NETCore.App": "1.0.0",
+        "NETStandard.Library": "1.6.0"
       }
     }
   }

--- a/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json
@@ -44,6 +44,11 @@
       }
     }
   },
+  "runtimes": {
+    "win7-x64": { },
+    "debian.8-x64": { },
+    "osx.10.11-x64": { }
+  },
 
   "dependencies": {
     "Grpc.IntegrationTesting": {
@@ -52,13 +57,14 @@
   },
   "frameworks": {
     "net45": { },
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "imports": [
         "portable-net45",
         "net45"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "Microsoft.NETCore.App": "1.0.0",
+        "NETStandard.Library": "1.6.0"
       }
     }
   }

--- a/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json
@@ -44,11 +44,6 @@
       }
     }
   },
-  "runtimes": {
-    "win7-x64": { },
-    "debian.8-x64": { },
-    "osx.10.11-x64": { }
-  },
 
   "dependencies": {
     "Grpc.IntegrationTesting": {

--- a/src/csharp/Grpc.IntegrationTesting.Server/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.Server/project.json
@@ -57,13 +57,14 @@
   },
   "frameworks": {
     "net45": { },
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "imports": [
         "portable-net45",
         "net45"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "Microsoft.NETCore.App": "1.0.0",
+        "NETStandard.Library": "1.6.0"
       }
     }
   }

--- a/src/csharp/Grpc.IntegrationTesting.StressClient/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.StressClient/project.json
@@ -44,6 +44,11 @@
       }
     }
   },
+  "runtimes": {
+    "win7-x64": { },
+    "debian.8-x64": { },
+    "osx.10.11-x64": { }
+  },
 
   "dependencies": {
     "Grpc.IntegrationTesting": {
@@ -52,13 +57,14 @@
   },
   "frameworks": {
     "net45": { },
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "imports": [
         "portable-net45",
         "net45"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027"
+        "Microsoft.NETCore.App": "1.0.0",
+        "NETStandard.Library": "1.6.0"
       }
     }
   }

--- a/src/csharp/Grpc.IntegrationTesting.StressClient/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.StressClient/project.json
@@ -44,11 +44,6 @@
       }
     }
   },
-  "runtimes": {
-    "win7-x64": { },
-    "debian.8-x64": { },
-    "osx.10.11-x64": { }
-  },
 
   "dependencies": {
     "Grpc.IntegrationTesting": {

--- a/src/csharp/Grpc.IntegrationTesting/GeneratedClientTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/GeneratedClientTest.cs
@@ -49,7 +49,7 @@ namespace Grpc.IntegrationTesting
         TestService.TestServiceClient unimplementedClient = new UnimplementedTestServiceClient();
 
         // TODO: replace Moq by some mocking library with CoreCLR support.
-#if !NETSTANDARD1_5
+#if !NETCOREAPP1_0
         [Test]
         public void ExpandedParamOverloadCanBeMocked()
         {

--- a/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
+++ b/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
@@ -70,7 +70,7 @@
       <HintPath>..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System.Interactive.Async">
-      <HintPath>..\packages\Ix-Async.1.2.5\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="nunitlite">
       <HintPath>..\packages\NUnitLite.3.2.0\lib\net45\nunitlite.dll</HintPath>

--- a/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
+++ b/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
@@ -70,7 +70,9 @@
       <HintPath>..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System.Interactive.Async">
-      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <!-- Support package restores in solution or project directories -->
+      <HintPath Condition="Exists('..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath Condition="Exists('.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="nunitlite">
       <HintPath>..\packages\NUnitLite.3.2.0\lib\net45\nunitlite.dll</HintPath>

--- a/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
+++ b/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
@@ -71,8 +71,8 @@
     </Reference>
     <Reference Include="System.Interactive.Async">
       <!-- Support package restores in solution or project directories -->
-      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
-      <HintPath>.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>.\packages\System.Interactive.Async\3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="nunitlite">
       <HintPath>..\packages\NUnitLite.3.2.0\lib\net45\nunitlite.dll</HintPath>

--- a/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
+++ b/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
@@ -71,8 +71,8 @@
     </Reference>
     <Reference Include="System.Interactive.Async">
       <!-- Support package restores in solution or project directories -->
-      <HintPath Condition="Exists('..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
-      <HintPath Condition="Exists('.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll')">.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>..\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
+      <HintPath>.\packages\System.Interactive.Async.3.0.0\lib\net45\System.Interactive.Async.dll</HintPath>
     </Reference>
     <Reference Include="nunitlite">
       <HintPath>..\packages\NUnitLite.3.2.0\lib\net45\nunitlite.dll</HintPath>

--- a/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
@@ -145,7 +145,7 @@ namespace Grpc.IntegrationTesting
 
             if (options.TestCase == "jwt_token_creds")
             {
-#if !NETSTANDARD1_5
+#if !NETCOREAPP1_0
                 var googleCredential = await GoogleCredential.GetApplicationDefaultAsync();
                 Assert.IsTrue(googleCredential.IsCreateScopedRequired);
                 credentials = ChannelCredentials.Create(credentials, googleCredential.ToCallCredentials());
@@ -157,7 +157,7 @@ namespace Grpc.IntegrationTesting
 
             if (options.TestCase == "compute_engine_creds")
             {
-#if !NETSTANDARD1_5
+#if !NETCOREAPP1_0
                 var googleCredential = await GoogleCredential.GetApplicationDefaultAsync();
                 Assert.IsFalse(googleCredential.IsCreateScopedRequired);
                 credentials = ChannelCredentials.Create(credentials, googleCredential.ToCallCredentials());
@@ -395,7 +395,7 @@ namespace Grpc.IntegrationTesting
 
         public static async Task RunOAuth2AuthTokenAsync(TestService.TestServiceClient client, string oauthScope)
         {
-#if !NETSTANDARD1_5
+#if !NETCOREAPP1_0
             Console.WriteLine("running oauth2_auth_token");
             ITokenAccess credential = (await GoogleCredential.GetApplicationDefaultAsync()).CreateScoped(new[] { oauthScope });
             string oauth2Token = await credential.GetAccessTokenForRequestAsync();
@@ -421,7 +421,7 @@ namespace Grpc.IntegrationTesting
 
         public static async Task RunPerRpcCredsAsync(TestService.TestServiceClient client, string oauthScope)
         {
-#if !NETSTANDARD1_5
+#if !NETCOREAPP1_0
             Console.WriteLine("running per_rpc_creds");
             ITokenAccess googleCredential = await GoogleCredential.GetApplicationDefaultAsync();
 
@@ -731,7 +731,7 @@ namespace Grpc.IntegrationTesting
         // extracts the client_email field from service account file used for auth test cases
         private static string GetEmailFromServiceAccountFile()
         {
-#if !NETSTANDARD1_5
+#if !NETCOREAPP1_0
             string keyFile = Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS");
             Assert.IsNotNull(keyFile);
             var jobject = JObject.Parse(File.ReadAllText(keyFile));

--- a/src/csharp/Grpc.IntegrationTesting/NUnitMain.cs
+++ b/src/csharp/Grpc.IntegrationTesting/NUnitMain.cs
@@ -49,7 +49,7 @@ namespace Grpc.IntegrationTesting
         {
             // Make logger immune to NUnit capturing stdout and stderr to workaround https://github.com/nunit/nunit/issues/1406.
             GrpcEnvironment.SetLogger(new TextWriterLogger(Console.Error));
-#if NETSTANDARD1_5
+#if NETCOREAPP1_0
             return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
 #else
             return new AutoRun().Execute(args);

--- a/src/csharp/Grpc.IntegrationTesting/packages.config
+++ b/src/csharp/Grpc.IntegrationTesting/packages.config
@@ -5,7 +5,7 @@
   <package id="Google.Apis.Auth" version="1.11.1" targetFramework="net45" />
   <package id="Google.Apis.Core" version="1.11.1" targetFramework="net45" />
   <package id="Google.Protobuf" version="3.0.0-beta3" targetFramework="net45" />
-  <package id="Ix-Async" version="1.2.5" targetFramework="net45" />
+  <package id="System.Interactive.Async" version="3.0.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.2.0" targetFramework="net45" />

--- a/src/csharp/Grpc.IntegrationTesting/project.json
+++ b/src/csharp/Grpc.IntegrationTesting/project.json
@@ -72,14 +72,15 @@
         "System.IO": ""
       }
     },
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "imports": [
         "portable-net45",
         "net45"
       ],
       "dependencies": {
-        "NETStandard.Library": "1.5.0-rc2-24027",
-        "System.Linq.Expressions": "4.0.11-rc2-24027"
+        "Microsoft.NETCore.App": "1.0.0",
+        "NETStandard.Library": "1.6.0",
+        "System.Linq.Expressions": "4.1.0"
       }
     }
   }

--- a/templates/src/csharp/Grpc.Auth/project.json.template
+++ b/templates/src/csharp/Grpc.Auth/project.json.template
@@ -34,9 +34,9 @@
           "net45"
         ],
         "dependencies": {
-          "Microsoft.NETCore.Portable.Compatibility": "1.0.1-rc2-24027",
-          "NETStandard.Library": "1.5.0-rc2-24027",
-          "System.Threading.Tasks": "4.0.11-rc2-24027"
+          "Microsoft.NETCore.Portable.Compatibility": "1.0.1",
+          "NETStandard.Library": "1.6.0",
+          "System.Threading.Tasks": "4.0.11"
         }
       }
     }

--- a/templates/src/csharp/Grpc.Core.Tests/project.json.template
+++ b/templates/src/csharp/Grpc.Core.Tests/project.json.template
@@ -12,12 +12,13 @@
     },
     "frameworks": {
       "net45": { },
-      "netstandard1.5": {
+      "netcoreapp1.0": {
         "imports": [
           "portable-net45"
         ],
         "dependencies": {
-          "NETStandard.Library": "1.5.0-rc2-24027"
+          "Microsoft.NETCore.App": "1.0.0",
+          "NETStandard.Library": "1.6.0"
         }
       }
     },

--- a/templates/src/csharp/Grpc.Core/project.json.template
+++ b/templates/src/csharp/Grpc.Core/project.json.template
@@ -33,7 +33,7 @@
       "xmlDoc": true
     },
     "dependencies": {
-      "Ix-Async": "1.2.5"
+      "System.Interactive.Async": "3.0.0"
     },
     "frameworks": {
       "net45": { },

--- a/templates/src/csharp/Grpc.Core/project.json.template
+++ b/templates/src/csharp/Grpc.Core/project.json.template
@@ -42,8 +42,8 @@
           "portable-net45"
         ],
         "dependencies": {
-          "NETStandard.Library": "1.5.0-rc2-24027",
-          "System.Threading.Thread": "4.0.0-rc2-24027"
+          "NETStandard.Library": "1.6.0",
+          "System.Threading.Thread": "4.0.0"
         }
       }
     }

--- a/templates/src/csharp/Grpc.Examples.MathClient/project.json.template
+++ b/templates/src/csharp/Grpc.Examples.MathClient/project.json.template
@@ -1,7 +1,7 @@
 %YAML 1.2
 --- |
   {
-    <%include file="../build_options.include" args="executable=True,includeRuntimes=False"/>
+    <%include file="../build_options.include" args="executable=True"/>
     "dependencies": {
       "Grpc.Examples": {
         "target": "project"
@@ -9,12 +9,13 @@
     },
     "frameworks": {
       "net45": { },
-      "netstandard1.5": {
+      "netcoreapp1.0": {
         "imports": [
           "portable-net45"
         ],
         "dependencies": {
-          "NETStandard.Library": "1.5.0-rc2-24027"
+          "Microsoft.NETCore.App": "1.0.0",
+          "NETStandard.Library": "1.6.0"
         }
       }
     }

--- a/templates/src/csharp/Grpc.Examples.MathClient/project.json.template
+++ b/templates/src/csharp/Grpc.Examples.MathClient/project.json.template
@@ -1,7 +1,7 @@
 %YAML 1.2
 --- |
   {
-    <%include file="../build_options.include" args="executable=True"/>
+    <%include file="../build_options.include" args="executable=True,includeRuntimes=False"/>
     "dependencies": {
       "Grpc.Examples": {
         "target": "project"

--- a/templates/src/csharp/Grpc.Examples.MathServer/project.json.template
+++ b/templates/src/csharp/Grpc.Examples.MathServer/project.json.template
@@ -1,7 +1,7 @@
 %YAML 1.2
 --- |
   {
-    <%include file="../build_options.include" args="executable=True,includeRuntimes=False"/>
+    <%include file="../build_options.include" args="executable=True"/>
     "dependencies": {
       "Grpc.Examples": {
         "target": "project"
@@ -9,12 +9,13 @@
     },
     "frameworks": {
       "net45": { },
-      "netstandard1.5": {
+      "netcoreapp1.0": {
         "imports": [
           "portable-net45"
         ],
         "dependencies": {
-          "NETStandard.Library": "1.5.0-rc2-24027"
+          "Microsoft.NETCore.App": "1.0.0",
+          "NETStandard.Library": "1.6.0"
         }
       }
     }

--- a/templates/src/csharp/Grpc.Examples.MathServer/project.json.template
+++ b/templates/src/csharp/Grpc.Examples.MathServer/project.json.template
@@ -1,7 +1,7 @@
 %YAML 1.2
 --- |
   {
-    <%include file="../build_options.include" args="executable=True"/>
+    <%include file="../build_options.include" args="executable=True,includeRuntimes=False"/>
     "dependencies": {
       "Grpc.Examples": {
         "target": "project"

--- a/templates/src/csharp/Grpc.Examples.Tests/project.json.template
+++ b/templates/src/csharp/Grpc.Examples.Tests/project.json.template
@@ -11,12 +11,13 @@
     },
     "frameworks": {
       "net45": { },
-      "netstandard1.5": {
+      "netcoreapp1.0": {
         "imports": [
           "portable-net45"
         ],
         "dependencies": {
-          "NETStandard.Library": "1.5.0-rc2-24027"
+          "Microsoft.NETCore.App": "1.0.0",
+          "NETStandard.Library": "1.6.0"
         }
       }
     }

--- a/templates/src/csharp/Grpc.Examples/project.json.template
+++ b/templates/src/csharp/Grpc.Examples/project.json.template
@@ -20,7 +20,7 @@
           "portable-net45"
         ],
         "dependencies": {
-          "NETStandard.Library": "1.5.0-rc2-24027"
+          "NETStandard.Library": "1.6.0"
         }
       }
     }

--- a/templates/src/csharp/Grpc.HealthCheck.Tests/project.json.template
+++ b/templates/src/csharp/Grpc.HealthCheck.Tests/project.json.template
@@ -11,12 +11,13 @@
     },
     "frameworks": {
       "net45": { },
-      "netstandard1.5": {
+      "netcoreapp1.0": {
         "imports": [
           "portable-net45"
         ],
         "dependencies": {
-          "NETStandard.Library": "1.5.0-rc2-24027"
+          "Microsoft.NETCore.App": "1.0.0",
+          "NETStandard.Library": "1.6.0"
         }
       }
     }

--- a/templates/src/csharp/Grpc.HealthCheck/project.json.template
+++ b/templates/src/csharp/Grpc.HealthCheck/project.json.template
@@ -39,7 +39,7 @@
           "portable-net45"
         ],
         "dependencies": {
-          "NETStandard.Library": "1.5.0-rc2-24027"
+          "NETStandard.Library": "1.6.0"
         }
       }
     }

--- a/templates/src/csharp/Grpc.IntegrationTesting.Client/project.json.template
+++ b/templates/src/csharp/Grpc.IntegrationTesting.Client/project.json.template
@@ -9,13 +9,14 @@
     },
     "frameworks": {
       "net45": { },
-      "netstandard1.5": {
+      "netcoreapp1.0": {
         "imports": [
           "portable-net45",
           "net45"
         ],
         "dependencies": {
-          "NETStandard.Library": "1.5.0-rc2-24027"
+          "Microsoft.NETCore.App": "1.0.0",
+          "NETStandard.Library": "1.6.0"
         }
       }
     }

--- a/templates/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json.template
+++ b/templates/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json.template
@@ -1,7 +1,7 @@
 %YAML 1.2
 --- |
   {
-    <%include file="../build_options.include" args="executable=True,includeData=True,includeRuntimes=False"/>
+    <%include file="../build_options.include" args="executable=True,includeData=True"/>
     "dependencies": {
       "Grpc.IntegrationTesting": {
         "target": "project"
@@ -9,13 +9,14 @@
     },
     "frameworks": {
       "net45": { },
-      "netstandard1.5": {
+      "netcoreapp1.0": {
         "imports": [
           "portable-net45",
           "net45"
         ],
         "dependencies": {
-          "NETStandard.Library": "1.5.0-rc2-24027"
+          "Microsoft.NETCore.App": "1.0.0",
+          "NETStandard.Library": "1.6.0"
         }
       }
     }

--- a/templates/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json.template
+++ b/templates/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json.template
@@ -1,7 +1,7 @@
 %YAML 1.2
 --- |
   {
-    <%include file="../build_options.include" args="executable=True,includeData=True"/>
+    <%include file="../build_options.include" args="executable=True,includeData=True,includeRuntimes=False"/>
     "dependencies": {
       "Grpc.IntegrationTesting": {
         "target": "project"

--- a/templates/src/csharp/Grpc.IntegrationTesting.Server/project.json.template
+++ b/templates/src/csharp/Grpc.IntegrationTesting.Server/project.json.template
@@ -9,13 +9,14 @@
     },
     "frameworks": {
       "net45": { },
-      "netstandard1.5": {
+      "netcoreapp1.0": {
         "imports": [
           "portable-net45",
           "net45"
         ],
         "dependencies": {
-          "NETStandard.Library": "1.5.0-rc2-24027"
+          "Microsoft.NETCore.App": "1.0.0",
+          "NETStandard.Library": "1.6.0"
         }
       }
     }

--- a/templates/src/csharp/Grpc.IntegrationTesting.StressClient/project.json.template
+++ b/templates/src/csharp/Grpc.IntegrationTesting.StressClient/project.json.template
@@ -1,7 +1,7 @@
 %YAML 1.2
 --- |
   {
-    <%include file="../build_options.include" args="executable=True,includeData=True,includeRuntimes=False"/>
+    <%include file="../build_options.include" args="executable=True,includeData=True"/>
     "dependencies": {
       "Grpc.IntegrationTesting": {
         "target": "project"
@@ -9,13 +9,14 @@
     },
     "frameworks": {
       "net45": { },
-      "netstandard1.5": {
+      "netcoreapp1.0": {
         "imports": [
           "portable-net45",
           "net45"
         ],
         "dependencies": {
-          "NETStandard.Library": "1.5.0-rc2-24027"
+          "Microsoft.NETCore.App": "1.0.0",
+          "NETStandard.Library": "1.6.0"
         }
       }
     }

--- a/templates/src/csharp/Grpc.IntegrationTesting.StressClient/project.json.template
+++ b/templates/src/csharp/Grpc.IntegrationTesting.StressClient/project.json.template
@@ -1,7 +1,7 @@
 %YAML 1.2
 --- |
   {
-    <%include file="../build_options.include" args="executable=True,includeData=True"/>
+    <%include file="../build_options.include" args="executable=True,includeData=True,includeRuntimes=False"/>
     "dependencies": {
       "Grpc.IntegrationTesting": {
         "target": "project"

--- a/templates/src/csharp/Grpc.IntegrationTesting/project.json.template
+++ b/templates/src/csharp/Grpc.IntegrationTesting/project.json.template
@@ -24,14 +24,15 @@
           "System.IO": ""
         }
       },
-      "netstandard1.5": {
+      "netcoreapp1.0": {
         "imports": [
           "portable-net45",
           "net45"
         ],
         "dependencies": {
-          "NETStandard.Library": "1.5.0-rc2-24027",
-          "System.Linq.Expressions": "4.0.11-rc2-24027"
+          "Microsoft.NETCore.App": "1.0.0",
+          "NETStandard.Library": "1.6.0",
+          "System.Linq.Expressions": "4.1.0"
         }
       }
     }

--- a/templates/src/csharp/build_options.include
+++ b/templates/src/csharp/build_options.include
@@ -1,4 +1,4 @@
-<%page args="executable=False,includeData=False"/>\
+<%page args="executable=False,includeData=False,includeRuntimes=True"/>\
 "buildOptions": {
   % if executable:
     "emitEntryPoint": true
@@ -51,6 +51,8 @@
       }
     }
   },
+  %endif
+  % if includeRuntimes:
   "runtimes": {
     "win7-x64": { },
     "debian.8-x64": { },

--- a/templates/src/csharp/build_options.include
+++ b/templates/src/csharp/build_options.include
@@ -1,4 +1,4 @@
-<%page args="executable=False,includeData=False,includeRuntimes=True"/>\
+<%page args="executable=False,includeData=False"/>\
 "buildOptions": {
   % if executable:
     "emitEntryPoint": true
@@ -51,8 +51,6 @@
       }
     }
   },
-  %endif
-  % if includeRuntimes:
   "runtimes": {
     "win7-x64": { },
     "debian.8-x64": { },

--- a/templates/tools/dockerfile/csharp_deps.include
+++ b/templates/tools/dockerfile/csharp_deps.include
@@ -14,3 +14,5 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y ${'\\'}
     ca-certificates-mono ${'\\'}
     nuget ${'\\'}
     && apt-get clean
+
+RUN nuget update -self

--- a/templates/tools/dockerfile/csharp_deps.include
+++ b/templates/tools/dockerfile/csharp_deps.include
@@ -15,4 +15,8 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y ${'\\'}
     nuget ${'\\'}
     && apt-get clean
 
-RUN nuget update -self
+# Install dotnet SDK based on https://www.microsoft.com/net/core#debian
+RUN apt-get update && apt-get install -y curl libunwind8 gettext
+RUN curl -sSL -o dotnet.tar.gz https://go.microsoft.com/fwlink/?LinkID=809130
+RUN mkdir -p /opt/dotnet && tar zxf dotnet.tar.gz -C /opt/dotnet
+RUN ln -s /opt/dotnet/dotnet /usr/local/bin

--- a/templates/tools/dockerfile/test/csharp_coreclr_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/csharp_coreclr_x64/Dockerfile.template
@@ -34,12 +34,6 @@
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../csharp_deps.include"/>
   
-  # Install dotnet SDK based on https://www.microsoft.com/net/core#debian
-  RUN apt-get update && apt-get install -y curl libunwind8 gettext
-  RUN curl -sSL -o dotnet.tar.gz https://go.microsoft.com/fwlink/?LinkID=809130
-  RUN mkdir -p /opt/dotnet && tar zxf dotnet.tar.gz -C /opt/dotnet
-  RUN ln -s /opt/dotnet/dotnet /usr/local/bin
-  
   # Trigger the population of the local package cache
   ENV NUGET_XMLDOC_MODE skip
   RUN mkdir warmup ${'\\'}

--- a/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
@@ -80,6 +80,8 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     nuget \
     && apt-get clean
 
+RUN nuget update -self
+
 # Prepare ccache
 RUN ln -s /usr/bin/ccache /usr/local/bin/gcc
 RUN ln -s /usr/bin/ccache /usr/local/bin/g++

--- a/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
@@ -80,7 +80,11 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     nuget \
     && apt-get clean
 
-RUN nuget update -self
+# Install dotnet SDK based on https://www.microsoft.com/net/core#debian
+RUN apt-get update && apt-get install -y curl libunwind8 gettext
+RUN curl -sSL -o dotnet.tar.gz https://go.microsoft.com/fwlink/?LinkID=809130
+RUN mkdir -p /opt/dotnet && tar zxf dotnet.tar.gz -C /opt/dotnet
+RUN ln -s /opt/dotnet/dotnet /usr/local/bin
 
 # Prepare ccache
 RUN ln -s /usr/bin/ccache /usr/local/bin/gcc

--- a/tools/dockerfile/stress_test/grpc_interop_stress_csharp/Dockerfile
+++ b/tools/dockerfile/stress_test/grpc_interop_stress_csharp/Dockerfile
@@ -97,5 +97,7 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     nuget \
     && apt-get clean
 
+RUN nuget update -self
+
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/stress_test/grpc_interop_stress_csharp/Dockerfile
+++ b/tools/dockerfile/stress_test/grpc_interop_stress_csharp/Dockerfile
@@ -97,7 +97,11 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     nuget \
     && apt-get clean
 
-RUN nuget update -self
+# Install dotnet SDK based on https://www.microsoft.com/net/core#debian
+RUN apt-get update && apt-get install -y curl libunwind8 gettext
+RUN curl -sSL -o dotnet.tar.gz https://go.microsoft.com/fwlink/?LinkID=809130
+RUN mkdir -p /opt/dotnet && tar zxf dotnet.tar.gz -C /opt/dotnet
+RUN ln -s /opt/dotnet/dotnet /usr/local/bin
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/test/csharp_coreclr_x64/Dockerfile
+++ b/tools/dockerfile/test/csharp_coreclr_x64/Dockerfile
@@ -80,6 +80,8 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     nuget \
     && apt-get clean
 
+RUN nuget update -self
+
 
 # Install dotnet SDK based on https://www.microsoft.com/net/core#debian
 RUN apt-get update && apt-get install -y curl libunwind8 gettext

--- a/tools/dockerfile/test/csharp_coreclr_x64/Dockerfile
+++ b/tools/dockerfile/test/csharp_coreclr_x64/Dockerfile
@@ -80,14 +80,12 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     nuget \
     && apt-get clean
 
-RUN nuget update -self
-
-
 # Install dotnet SDK based on https://www.microsoft.com/net/core#debian
 RUN apt-get update && apt-get install -y curl libunwind8 gettext
 RUN curl -sSL -o dotnet.tar.gz https://go.microsoft.com/fwlink/?LinkID=809130
 RUN mkdir -p /opt/dotnet && tar zxf dotnet.tar.gz -C /opt/dotnet
 RUN ln -s /opt/dotnet/dotnet /usr/local/bin
+
 
 # Trigger the population of the local package cache
 ENV NUGET_XMLDOC_MODE skip

--- a/tools/dockerfile/test/csharp_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/csharp_jessie_x64/Dockerfile
@@ -80,6 +80,8 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     nuget \
     && apt-get clean
 
+RUN nuget update -self
+
 # Prepare ccache
 RUN ln -s /usr/bin/ccache /usr/local/bin/gcc
 RUN ln -s /usr/bin/ccache /usr/local/bin/g++

--- a/tools/dockerfile/test/csharp_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/csharp_jessie_x64/Dockerfile
@@ -80,7 +80,11 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     nuget \
     && apt-get clean
 
-RUN nuget update -self
+# Install dotnet SDK based on https://www.microsoft.com/net/core#debian
+RUN apt-get update && apt-get install -y curl libunwind8 gettext
+RUN curl -sSL -o dotnet.tar.gz https://go.microsoft.com/fwlink/?LinkID=809130
+RUN mkdir -p /opt/dotnet && tar zxf dotnet.tar.gz -C /opt/dotnet
+RUN ln -s /opt/dotnet/dotnet /usr/local/bin
 
 # Prepare ccache
 RUN ln -s /usr/bin/ccache /usr/local/bin/gcc

--- a/tools/dockerfile/test/multilang_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/multilang_jessie_x64/Dockerfile
@@ -80,6 +80,8 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     nuget \
     && apt-get clean
 
+RUN nuget update -self
+
 #=================
 # C++ dependencies
 RUN apt-get update && apt-get -y install libgflags-dev libgtest-dev libc++-dev clang && apt-get clean

--- a/tools/dockerfile/test/multilang_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/multilang_jessie_x64/Dockerfile
@@ -80,7 +80,11 @@ RUN apt-get update && apt-get -y dist-upgrade && apt-get install -y \
     nuget \
     && apt-get clean
 
-RUN nuget update -self
+# Install dotnet SDK based on https://www.microsoft.com/net/core#debian
+RUN apt-get update && apt-get install -y curl libunwind8 gettext
+RUN curl -sSL -o dotnet.tar.gz https://go.microsoft.com/fwlink/?LinkID=809130
+RUN mkdir -p /opt/dotnet && tar zxf dotnet.tar.gz -C /opt/dotnet
+RUN ln -s /opt/dotnet/dotnet /usr/local/bin
 
 #=================
 # C++ dependencies

--- a/tools/run_tests/build_csharp.sh
+++ b/tools/run_tests/build_csharp.sh
@@ -34,4 +34,6 @@ cd $(dirname $0)/../../src/csharp
 
 # TODO: @apolcyn, make gcov code coverage work, with replacement for
 # previous NativeDependenciesConfigurationUnix arg to xbuild
-dotnet build --configuration $MSBUILD_CONFIG **/project.json
+
+# All non-coreclr builds use net45 framework currently
+dotnet build -f net45 --configuration $MSBUILD_CONFIG **/project.json

--- a/tools/run_tests/build_csharp.sh
+++ b/tools/run_tests/build_csharp.sh
@@ -32,5 +32,6 @@ set -ex
 
 cd $(dirname $0)/../../src/csharp
 
-# overriding NativeDependenciesConfigurationUnix is needed to make gcov code coverage work.
-xbuild /p:Configuration=$MSBUILD_CONFIG /p:NativeDependenciesConfigurationUnix=$CONFIG Grpc.sln
+# TODO: @apolcyn, make gcov code coverage work, with replacement for
+# previous NativeDependenciesConfigurationUnix arg to xbuild
+dotnet build --configuration $MSBUILD_CONFIG **/project.json

--- a/tools/run_tests/build_csharp.sh
+++ b/tools/run_tests/build_csharp.sh
@@ -36,4 +36,4 @@ cd $(dirname $0)/../../src/csharp
 # previous NativeDependenciesConfigurationUnix arg to xbuild
 
 # All non-coreclr builds use net45 framework currently
-dotnet build -f net45 --configuration $MSBUILD_CONFIG **/project.json
+dotnet build -f net45 --output . --configuration $MSBUILD_CONFIG **/project.json

--- a/tools/run_tests/build_csharp_coreclr.sh
+++ b/tools/run_tests/build_csharp_coreclr.sh
@@ -35,4 +35,4 @@ cd $(dirname $0)/../../src/csharp
 # TODO(jtattermusch): introduce caching
 dotnet restore .
 
-dotnet build -f netstandard1.5 --configuration $MSBUILD_CONFIG '**/project.json'
+dotnet build --configuration $MSBUILD_CONFIG '**/project.json'

--- a/tools/run_tests/pre_build_csharp.bat
+++ b/tools/run_tests/pre_build_csharp.bat
@@ -37,22 +37,12 @@ cd /d %~dp0\..\..
 @rem Location of nuget.exe
 set NUGET=C:\nuget\nuget.exe
 
-if exist %NUGET% (
-  @rem Restore Grpc packages by packages since Nuget client 3.4.4 doesnt support restore
-  @rem by solution
-  %NUGET% restore vsprojects/grpc_csharp_ext.sln || goto :error
-  %NUGET% restore src/csharp/Grpc.Auth -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.Core -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.Core.Tests -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.Examples.MathClient -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.Examples.MathServer -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.Examples -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.HealthCheck.Tests -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.HealthCheck -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.IntegrationTesting.Client -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.IntegrationTesting.QpsWorker -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.IntegrationTesting.StressClient -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.IntegrationTesting -PackagesDirectory src/csharp/packages || goto :error
+where dotnet
+if ERRORLEVEL 1 (
+  ECHO dotnet cli not found, ensure to this is ran with dotnet cli on PATH 
+) ELSE (
+  cd src/csharp || goto :error
+  dotnet restore . || goto :error
 )
 
 endlocal

--- a/tools/run_tests/pre_build_csharp.bat
+++ b/tools/run_tests/pre_build_csharp.bat
@@ -34,15 +34,18 @@ setlocal
 @rem enter repo root
 cd /d %~dp0\..\..
 
-@rem Location of dotnet.exe
-set DOTNET=C:\dotnet\dotnet
+@rem Location of dotnet.exe and nuget.exe
+set NUGET=C:\nuget\nuget.exe
+set DOTNET=C:\dotnet\dotnet.exe
 
-cd src/csharp || goto :error
+if exist %NUGET% (
+  %NUGET% restore vsprojects/grpc_csharp_ext.sln || goto :error
+)
 
-if EXIST %DOTNET% (
+if exist %DOTNET% (
+  cd src/csharp || goto :error
   %DOTNET% restore || goto :error
-) ELSE (
-  dotnet restore || goto :error
+  cd ../.. || goto :error
 )
 
 endlocal

--- a/tools/run_tests/pre_build_csharp.bat
+++ b/tools/run_tests/pre_build_csharp.bat
@@ -41,7 +41,6 @@ if exist %NUGET% (
   @rem Restore Grpc packages by packages since Nuget client 3.4.4 doesnt support restore
   @rem by solution
   %NUGET% restore vsprojects/grpc_csharp_ext.sln || goto :error
-  %NUGET% restore src/csharp/Grpc.sln || goto :error
   %NUGET% restore src/csharp/Grpc.Auth -PackagesDirectory src/csharp/packages || goto :error
   %NUGET% restore src/csharp/Grpc.Core -PackagesDirectory src/csharp/packages || goto :error
   %NUGET% restore src/csharp/Grpc.Core.Tests -PackagesDirectory src/csharp/packages || goto :error

--- a/tools/run_tests/pre_build_csharp.bat
+++ b/tools/run_tests/pre_build_csharp.bat
@@ -38,8 +38,22 @@ cd /d %~dp0\..\..
 set NUGET=C:\nuget\nuget.exe
 
 if exist %NUGET% (
+  @rem Restore Grpc packages by packages since Nuget client 3.4.4 doesnt support restore
+  @ by solution
   %NUGET% restore vsprojects/grpc_csharp_ext.sln || goto :error
   %NUGET% restore src/csharp/Grpc.sln || goto :error
+  %NUGET% restore src/csharp/Grpc.Auth -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Core -PackagesDirectory ./packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Core.Tests -PackagesDirectory ./packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Examples.MathClient -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Examples.MathServer -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Examples -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.HealthCheck.Tests -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.HealthCheck -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting.Client -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting.QpsWorker -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting.StressClient -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting -PackagesDirectory src/csharp/packages || goto :error
 )
 
 endlocal

--- a/tools/run_tests/pre_build_csharp.bat
+++ b/tools/run_tests/pre_build_csharp.bat
@@ -34,8 +34,8 @@ setlocal
 @rem enter repo root
 cd /d %~dp0\..\..
 
-@rem Location of nuget.exe
-set DOTNET=~/dotnet-cli/dotnet
+@rem Location of dotnet.exe
+set DOTNET=C:\dotnet\dotnet
 
 cd src/csharp || goto :error
 

--- a/tools/run_tests/pre_build_csharp.bat
+++ b/tools/run_tests/pre_build_csharp.bat
@@ -39,12 +39,12 @@ set NUGET=C:\nuget\nuget.exe
 
 if exist %NUGET% (
   @rem Restore Grpc packages by packages since Nuget client 3.4.4 doesnt support restore
-  @ by solution
+  @rem by solution
   %NUGET% restore vsprojects/grpc_csharp_ext.sln || goto :error
   %NUGET% restore src/csharp/Grpc.sln || goto :error
   %NUGET% restore src/csharp/Grpc.Auth -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.Core -PackagesDirectory ./packages || goto :error
-  %NUGET% restore src/csharp/Grpc.Core.Tests -PackagesDirectory ./packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Core -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Core.Tests -PackagesDirectory src/csharp/packages || goto :error
   %NUGET% restore src/csharp/Grpc.Examples.MathClient -PackagesDirectory src/csharp/packages || goto :error
   %NUGET% restore src/csharp/Grpc.Examples.MathServer -PackagesDirectory src/csharp/packages || goto :error
   %NUGET% restore src/csharp/Grpc.Examples -PackagesDirectory src/csharp/packages || goto :error

--- a/tools/run_tests/pre_build_csharp.bat
+++ b/tools/run_tests/pre_build_csharp.bat
@@ -35,14 +35,14 @@ setlocal
 cd /d %~dp0\..\..
 
 @rem Location of nuget.exe
-set NUGET=C:\nuget\nuget.exe
+set DOTNET=~/dotnet-cli/dotnet
 
-where dotnet
-if ERRORLEVEL 1 (
-  ECHO dotnet cli not found, ensure to this is ran with dotnet cli on PATH 
+cd src/csharp || goto :error
+
+if EXIST %DOTNET% (
+  %DOTNET% restore || goto :error
 ) ELSE (
-  cd src/csharp || goto :error
-  dotnet restore . || goto :error
+  dotnet restore || goto :error
 )
 
 endlocal

--- a/tools/run_tests/pre_build_csharp.sh
+++ b/tools/run_tests/pre_build_csharp.sh
@@ -35,20 +35,10 @@ cd $(dirname $0)/../../src/csharp
 
 root=`pwd`
 
-if [ -x "$(command -v nuget)" ]
+if [ -x "$(command -v dotnet)" ]
 then
-  # Restoring Nuget packages by packages rather than by solution because of
-  # inability to restore by solution with Nuget client 3.4.4
-  nuget restore Grpc.Auth -PackagesDirectory ./packages
-  nuget restore Grpc.Core.Tests -PackagesDirectory ./packages
-  nuget restore Grpc.Core -PackagesDirectory ./packages
-  nuget restore Grpc.Examples.MathClient -PackagesDirectory ./packages
-  nuget restore Grpc.Examples.MathServer -PackagesDirectory ./packages
-  nuget restore Grpc.Examples -PackagesDirectory ./packages
-  nuget restore Grpc.HealthCheck.Tests -PackagesDirectory ./packages
-  nuget restore Grpc.HealthCheck -PackagesDirectory ./packages
-  nuget restore Grpc.IntegrationTesting.Client -PackagesDirectory ./packages
-  nuget restore Grpc.IntegrationTesting.QpsWorker -PackagesDirectory ./packages
-  nuget restore Grpc.IntegrationTesting.StressClient -PackagesDirectory ./packages
-  nuget restore Grpc.IntegrationTesting -PackagesDirectory ./packages
+  dotnet restore
+else
+  echo "dotnet cli not found, ensure this is ran with dotnet cli on PATH"
+  exit -1
 fi

--- a/tools/run_tests/pre_build_csharp.sh
+++ b/tools/run_tests/pre_build_csharp.sh
@@ -37,5 +37,18 @@ root=`pwd`
 
 if [ -x "$(command -v nuget)" ]
 then
-  nuget restore Grpc.sln
+  # Restoring Nuget packages by packages rather than by solution because of
+  # inability to restore by solution with Nuget client 3.4.4
+  nuget restore Grpc.Auth -PackagesDirectory ./packages
+  nuget restore Grpc.Core.Tests -PackagesDirectory ./packages
+  nuget restore Grpc.Core -PackagesDirectory ./packages
+  nuget restore Grpc.Examples.MathClient -PackagesDirectory ./packages
+  nuget restore Grpc.Examples.MathServer -PackagesDirectory ./packages
+  nuget restore Grpc.Examples -PackagesDirectory ./packages
+  nuget restore Grpc.HealthCheck.Tests -PackagesDirectory ./packages
+  nuget restore Grpc.HealthCheck -PackagesDirectory ./packages
+  nuget restore Grpc.IntegrationTesting.Client -PackagesDirectory ./packages
+  nuget restore Grpc.IntegrationTesting.QpsWorker -PackagesDirectory ./packages
+  nuget restore Grpc.IntegrationTesting.StressClient -PackagesDirectory ./packages
+  nuget restore Grpc.IntegrationTesting -PackagesDirectory ./packages
 fi

--- a/tools/run_tests/pre_build_csharp.sh
+++ b/tools/run_tests/pre_build_csharp.sh
@@ -35,7 +35,12 @@ cd $(dirname $0)/../../src/csharp
 
 root=`pwd`
 
-if [ -x "$(command -v dotnet)" ]
+echo "pre build csharp"
+
+if [ -e ~/dotnet-cli/dotnet ]
+then
+  ~/dotnet-cli/dotnet restore
+elif [ -x "$(command -v dotnet)" ]
 then
   dotnet restore
 else

--- a/tools/run_tests/pre_build_csharp.sh
+++ b/tools/run_tests/pre_build_csharp.sh
@@ -35,15 +35,13 @@ cd $(dirname $0)/../../src/csharp
 
 root=`pwd`
 
-echo "pre build csharp"
-
-if [ -e ~/dotnet-cli/dotnet ]
+if [ -e /usr/local/bin/dotnet ]
 then
-  ~/dotnet-cli/dotnet restore
+  /usr/local/bin/dotnet restore
 elif [ -x "$(command -v dotnet)" ]
 then
   dotnet restore
 else
-  echo "dotnet cli not found, ensure this is ran with dotnet cli on PATH"
+  echo "dotnet cli not found"
   exit -1
 fi

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -551,25 +551,23 @@ class CSharpLanguage(object):
     assembly_subdir = 'bin/%s' % msbuild_config
     assembly_extension = '.exe'
 
-    # Assembly subdirs for build outputs. Using wildcards in osx
-    # version to run tests on osx 10.10 and 10.11
     if self.args.compiler == 'coreclr':
       if self.platform == 'linux':
         assembly_subdir += '/netstandard1.5/debian.8-x64'
         assembly_extension = ''
       elif self.platform == 'mac':
-        assembly_subdir += '/netstandard1.5/osx.10.*-x64'
+        assembly_subdir += '/netstandard1.5/osx.10.11-x64'
         assembly_extension = ''
       else:
         assembly_subdir += '/netstandard1.5/win7-x64'
       runtime_cmd = []
     else:
       if self.platform == 'linux':
-        assembly_subdir += '/net45/debian.8-x64'
+        assembly_subdir += '/net45'
       elif self.platform == 'mac':
-        assembly_subdir += '/net45/osx.10.*-x64'
+        assembly_subdir += '/net45'
       else:
-        assembly_subdir += '/net45/win7-x64'
+        assembly_subdir += '/net45'
 
       nunit_args += ['--noresult', '--workers=1']
       if self.platform == 'windows':

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -551,12 +551,14 @@ class CSharpLanguage(object):
     assembly_subdir = 'bin/%s' % msbuild_config
     assembly_extension = '.exe'
 
+    # Assembly subdirs for build outputs. Using wildcards in osx
+    # version to run tests on osx 10.10 and 10.11
     if self.args.compiler == 'coreclr':
       if self.platform == 'linux':
         assembly_subdir += '/netstandard1.5/debian.8-x64'
         assembly_extension = ''
       elif self.platform == 'mac':
-        assembly_subdir += '/netstandard1.5/osx.10.11-x64'
+        assembly_subdir += '/netstandard1.5/osx.10.*-x64'
         assembly_extension = ''
       else:
         assembly_subdir += '/netstandard1.5/win7-x64'
@@ -565,7 +567,7 @@ class CSharpLanguage(object):
       if self.platform == 'linux':
         assembly_subdir += '/net45/debian.8-x64'
       elif self.platform == 'mac':
-        assembly_subdir += '/net45/osx.10.11-x64'
+        assembly_subdir += '/net45/osx.10.*-x64'
       else:
         assembly_subdir += '/net45/win7-x64'
 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -562,6 +562,13 @@ class CSharpLanguage(object):
         assembly_subdir += '/netstandard1.5/win7-x64'
       runtime_cmd = []
     else:
+      if self.platform == 'linux':
+        assembly_subdir += '/net45/debian.8-x64'
+      elif self.platform == 'mac':
+        assembly_subdir += '/net45/osx.10.11-x64'
+      else:
+        assembly_subdir += '/net45/win7-x64'
+
       nunit_args += ['--noresult', '--workers=1']
       if self.platform == 'windows':
         runtime_cmd = []

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -563,11 +563,11 @@ class CSharpLanguage(object):
       runtime_cmd = []
     else:
       if self.platform == 'linux':
-        assembly_subdir += '/net45'
+        assembly_subdir += '/net45/debian.8-x64'
       elif self.platform == 'mac':
-        assembly_subdir += '/net45'
+        assembly_subdir += '/net45/osx.10.*-x64'
       else:
-        assembly_subdir += '/net45'
+        assembly_subdir += '/net45/win7-x64'
 
       nunit_args += ['--noresult', '--workers=1']
       if self.platform == 'windows':


### PR DESCRIPTION
This is a first attempt to fix https://github.com/grpc/grpc/issues/7103.

I think that it would be best to make that change now rather than later.

Ran into Nuget issues locally when running tests and building on OSX, but saw this build and restore packages on Windows and MonoDevelop on linux. 

One issue seems to be that System.Interactive.Async relies on Nuget client being greater than 2.12. When the available version is less than 2.12, then the package seems to fail to restore during the run_tests.py script, or just when building with Xamarin Studio's default Nuget client on mac.  When Nuget client is updated to the latest version, then it fails wby trying to look for a seemingly updated MSBuild.exe

