### PR TITLE
Change the default logger to the NullLogger.

### DIFF
--- a/src/csharp/Grpc.Core/GrpcEnvironment.cs
+++ b/src/csharp/Grpc.Core/GrpcEnvironment.cs
@@ -47,7 +47,6 @@ namespace Grpc.Core
     /// </summary>
     public class GrpcEnvironment
     {
-        const LogLevel DefaultLogLevel = LogLevel.Info;
         const int MinDefaultThreadPoolSize = 4;
 
         static object staticLock = new object();
@@ -58,7 +57,7 @@ namespace Grpc.Core
         static readonly HashSet<Channel> registeredChannels = new HashSet<Channel>();
         static readonly HashSet<Server> registeredServers = new HashSet<Server>();
 
-        static ILogger logger = new LogLevelFilterLogger(new ConsoleLogger(), DefaultLogLevel);
+        static ILogger logger = new NullLogger();
 
         readonly object myLock = new object();
         readonly GrpcThreadPool threadPool;


### PR DESCRIPTION
It's unconventional for code to log to the console in .NET.
Even now the logging is reduced, it's still present - especially
in shutdown. This would fix #7361.