### PR TITLE
PHP: use php7_wrapper to reduce duplicated codes(second part)

### DIFF
--- a/src/php/ext/grpc/call.h
+++ b/src/php/ext/grpc/call.h
@@ -48,33 +48,18 @@
 /* Class entry for the Call PHP class */
 extern zend_class_entry *grpc_ce_call;
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Wrapper struct for grpc_call that can be associated with a PHP object */
-typedef struct wrapped_grpc_call {
-  zend_object std;
+PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_call)
   bool owned;
   grpc_call *wrapped;
-} wrapped_grpc_call;
+PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_call)
 
-/* Creates a Call object that wraps the given grpc_call struct */
-zval *grpc_php_wrap_call(grpc_call *wrapped, bool owned TSRMLS_DC);
-
-/* Creates and returns a PHP associative array of metadata from a C array of
- * call metadata */
-zval *grpc_parse_metadata_array(grpc_metadata_array *metadata_array TSRMLS_DC);
+#if PHP_MAJOR_VERSION < 7
 
 #define Z_WRAPPED_GRPC_CALL_P(zv) \
   (wrapped_grpc_call *)zend_object_store_get_object(zv TSRMLS_CC)
 
 #else
-
-/* Wrapper struct for grpc_call that can be associated with a PHP object */
-typedef struct wrapped_grpc_call {
-  bool owned;
-  grpc_call *wrapped;
-  zend_object std;
-} wrapped_grpc_call;
 
 static inline wrapped_grpc_call
 *wrapped_grpc_call_from_obj(zend_object *obj) {
@@ -84,15 +69,14 @@ static inline wrapped_grpc_call
 
 #define Z_WRAPPED_GRPC_CALL_P(zv) wrapped_grpc_call_from_obj(Z_OBJ_P((zv)))
 
-/* Creates a Call object that wraps the given grpc_call struct */
-void grpc_php_wrap_call(grpc_call *wrapped, bool owned, zval *call_object);
+#endif /* PHP_MAJOR_VERSION */
 
 /* Creates and returns a PHP associative array of metadata from a C array of
  * call metadata */
-void grpc_parse_metadata_array(grpc_metadata_array *metadata_array,
-                               zval *array);
+zval *grpc_parse_metadata_array(grpc_metadata_array *metadata_array TSRMLS_DC);
 
-#endif /* PHP_MAJOR_VERSION */
+/* Creates a Call object that wraps the given grpc_call struct */
+zval *grpc_php_wrap_call(grpc_call *wrapped, bool owned TSRMLS_DC);
 
 /* Initializes the Call PHP class */
 void grpc_init_call(TSRMLS_D);

--- a/src/php/ext/grpc/call_credentials.h
+++ b/src/php/ext/grpc/call_credentials.h
@@ -49,25 +49,18 @@
 /* Class entry for the CallCredentials PHP class */
 extern zend_class_entry *grpc_ce_call_credentials;
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Wrapper struct for grpc_call_credentials that can be associated
  * with a PHP object */
-typedef struct wrapped_grpc_call_credentials {
-  zend_object std;
+PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_call_credentials)
   grpc_call_credentials *wrapped;
-} wrapped_grpc_call_credentials;
+PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_call_credentials)
+
+#if PHP_MAJOR_VERSION < 7
 
 #define Z_WRAPPED_GRPC_CALL_CREDS_P(zv) \
   (wrapped_grpc_call_credentials *)zend_object_store_get_object(zv TSRMLS_CC)
-#else
 
-/* Wrapper struct for grpc_call_credentials that can be associated
- * with a PHP object */
-typedef struct wrapped_grpc_call_credentials {
-  grpc_call_credentials *wrapped;
-  zend_object std;
-} wrapped_grpc_call_credentials;
+#else
 
 static inline wrapped_grpc_call_credentials
 *wrapped_grpc_call_creds_from_obj(zend_object *obj) {
@@ -77,7 +70,7 @@ static inline wrapped_grpc_call_credentials
                                                 std));
 }
 
-#define Z_WRAPPED_GRPC_CALL_CREDS_P(zv)           \
+#define Z_WRAPPED_GRPC_CALL_CREDS_P(zv) \
   wrapped_grpc_call_creds_from_obj(Z_OBJ_P((zv)))
 
 #endif /* PHP_MAJOR_VERSION */

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -48,24 +48,17 @@
 /* Class entry for the PHP Channel class */
 extern zend_class_entry *grpc_ce_channel;
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Wrapper struct for grpc_channel that can be associated with a PHP object */
-typedef struct wrapped_grpc_channel {
-  zend_object std;
+PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_channel)
   grpc_channel *wrapped;
-} wrapped_grpc_channel;
+PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_channel)
+
+#if PHP_MAJOR_VERSION < 7
 
 #define Z_WRAPPED_GRPC_CHANNEL_P(zv) \
   (wrapped_grpc_channel *)zend_object_store_get_object(zv TSRMLS_CC)
 
 #else
-
-/* Wrapper struct for grpc_channel that can be associated with a PHP object */
-typedef struct wrapped_grpc_channel {
-  grpc_channel *wrapped;
-  zend_object std;
-} wrapped_grpc_channel;
 
 static inline wrapped_grpc_channel
 *wrapped_grpc_channel_from_obj(zend_object *obj) {
@@ -73,7 +66,7 @@ static inline wrapped_grpc_channel
                                  XtOffsetOf(wrapped_grpc_channel, std));
 }
 
-#define Z_WRAPPED_GRPC_CHANNEL_P(zv)            \
+#define Z_WRAPPED_GRPC_CHANNEL_P(zv) \
   wrapped_grpc_channel_from_obj(Z_OBJ_P((zv)))
 
 #endif /* PHP_MAJOR_VERSION */

--- a/src/php/ext/grpc/channel_credentials.h
+++ b/src/php/ext/grpc/channel_credentials.h
@@ -49,26 +49,18 @@
 /* Class entry for the ChannelCredentials PHP class */
 extern zend_class_entry *grpc_ce_channel_credentials;
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Wrapper struct for grpc_channel_credentials that can be associated
  * with a PHP object */
-typedef struct wrapped_grpc_channel_credentials {
-  zend_object std;
+PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_channel_credentials) 
   grpc_channel_credentials *wrapped;
-} wrapped_grpc_channel_credentials;
+PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_channel_credentials)
+
+#if PHP_MAJOR_VERSION < 7
 
 #define Z_WRAPPED_GRPC_CHANNEL_CREDS_P(zv) \
   (wrapped_grpc_channel_credentials *)zend_object_store_get_object(zv TSRMLS_CC)
 
 #else
-
-/* Wrapper struct for grpc_channel_credentials that can be associated
- * with a PHP object */
-typedef struct wrapped_grpc_channel_credentials {
-  grpc_channel_credentials *wrapped;
-  zend_object std;
-} wrapped_grpc_channel_credentials;
 
 static inline wrapped_grpc_channel_credentials
 *wrapped_grpc_channel_creds_from_obj(zend_object *obj) {
@@ -78,7 +70,7 @@ static inline wrapped_grpc_channel_credentials
      XtOffsetOf(wrapped_grpc_channel_credentials, std));
 }
 
-#define Z_WRAPPED_GRPC_CHANNEL_CREDS_P(zv)            \
+#define Z_WRAPPED_GRPC_CHANNEL_CREDS_P(zv) \
   wrapped_grpc_channel_creds_from_obj(Z_OBJ_P((zv)))
 
 #endif /* PHP_MAJOR_VERSION */

--- a/src/php/ext/grpc/php7_wrapper.h
+++ b/src/php/ext/grpc/php7_wrapper.h
@@ -39,13 +39,45 @@
 
 #define php_grpc_int int
 #define php_grpc_long long
+#define php_grpc_ulong ulong
+#define php_grpc_add_property_string(arg, name, context, b) \
+  add_property_string(arg, name, context, b)
+#define php_grpc_add_property_stringl(res, name, str, len, b) \
+  add_property_stringl(res, name, str, len, b)
+#define php_grpc_add_next_index_stringl(data, str, len, b) \
+  add_next_index_stringl(data, str, len, b)
+
 #define PHP_GRPC_RETURN_STRING(val, dup) RETURN_STRING(val, dup)
+#define PHP_GRPC_MAKE_STD_ZVAL(pzv) MAKE_STD_ZVAL(pzv)
+
+#define PHP_GRPC_WRAP_OBJECT_START(name) \
+  typedef struct name { \
+    zend_object std;
+#define PHP_GRPC_WRAP_OBJECT_END(name) \
+  } name;
 
 #else
 
 #define php_grpc_int size_t
 #define php_grpc_long zend_long
+#define php_grpc_ulong zend_ulong
+#define php_grpc_add_property_string(arg, name, context, b) \
+  add_property_string(arg, name, context)
+#define php_grpc_add_property_stringl(res, name, str, len, b) \
+  add_property_stringl(res, name, str, len)
+#define php_grpc_add_next_index_stringl(data, str, len, b) \
+  add_next_index_stringl(data, str, len)
+
 #define PHP_GRPC_RETURN_STRING(val, dup) RETURN_STRING(val)
+#define PHP_GRPC_MAKE_STD_ZVAL(pzv) \
+  zval _stack_zval_##pzv; \
+  pzv = &(_stack_zval_##pzv)
+
+#define PHP_GRPC_WRAP_OBJECT_START(name) \
+  typedef struct name {
+#define PHP_GRPC_WRAP_OBJECT_END(name) \
+    zend_object std; \
+  } name;
 
 #endif /* PHP_MAJOR_VERSION */
 

--- a/src/php/ext/grpc/server.h
+++ b/src/php/ext/grpc/server.h
@@ -48,24 +48,17 @@
 /* Class entry for the Server PHP class */
 extern zend_class_entry *grpc_ce_server;
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Wrapper struct for grpc_server that can be associated with a PHP object */
-typedef struct wrapped_grpc_server {
-  zend_object std;
+PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_server)
   grpc_server *wrapped;
-} wrapped_grpc_server;
+PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_server)
+
+#if PHP_MAJOR_VERSION < 7
 
 #define Z_WRAPPED_GRPC_SERVER_P(zv) \
   (wrapped_grpc_server *)zend_object_store_get_object(zv TSRMLS_CC)
 
 #else
-
-/* Wrapper struct for grpc_server that can be associated with a PHP object */
-typedef struct wrapped_grpc_server {
-  grpc_server *wrapped;
-  zend_object std;
-} wrapped_grpc_server;
 
 static inline wrapped_grpc_server
 *wrapped_grpc_server_from_obj(zend_object *obj) {
@@ -73,7 +66,7 @@ static inline wrapped_grpc_server
                                 XtOffsetOf(wrapped_grpc_server, std));
 }
 
-#define Z_WRAPPED_GRPC_SERVER_P(zv)             \
+#define Z_WRAPPED_GRPC_SERVER_P(zv) \
   wrapped_grpc_server_from_obj(Z_OBJ_P((zv)))
 
 #endif /* PHP_MAJOR_VERSION */

--- a/src/php/ext/grpc/server_credentials.h
+++ b/src/php/ext/grpc/server_credentials.h
@@ -49,33 +49,26 @@
 /* Class entry for the Server_Credentials PHP class */
 extern zend_class_entry *grpc_ce_server_credentials;
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Wrapper struct for grpc_server_credentials that can be associated with a PHP
  * object */
-typedef struct wrapped_grpc_server_credentials {
-  zend_object std;
+PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_server_credentials)
   grpc_server_credentials *wrapped;
-} wrapped_grpc_server_credentials;
+PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_server_credentials)
+
+#if PHP_MAJOR_VERSION < 7
 
 #define Z_WRAPPED_GRPC_SERVER_CREDS_P(zv) \
   (wrapped_grpc_server_credentials *)zend_object_store_get_object(zv TSRMLS_CC)
 
 #else
 
-typedef struct wrapped_grpc_server_credentials {
-  grpc_server_credentials *wrapped;
-  zend_object std;
-} wrapped_grpc_server_credentials;
-
 static inline wrapped_grpc_server_credentials
 *wrapped_grpc_server_creds_from_obj(zend_object *obj) {
   return (wrapped_grpc_server_credentials*)
-    ((char*)(obj) -
-     XtOffsetOf(wrapped_grpc_server_credentials, std));
+    ((char*)(obj) - XtOffsetOf(wrapped_grpc_server_credentials, std));
 }
 
-#define Z_WRAPPED_GRPC_SERVER_CREDS_P(zv)           \
+#define Z_WRAPPED_GRPC_SERVER_CREDS_P(zv) \
   wrapped_grpc_server_creds_from_obj(Z_OBJ_P((zv)))
 
 #endif /* PHP_MAJOR_VERSION */

--- a/src/php/ext/grpc/timeval.c
+++ b/src/php/ext/grpc/timeval.c
@@ -78,17 +78,6 @@ zend_object_value create_wrapped_grpc_timeval(zend_class_entry *class_type
   return retval;
 }
 
-zval *grpc_php_wrap_timeval(gpr_timespec wrapped TSRMLS_DC) {
-  zval *timeval_object;
-  MAKE_STD_ZVAL(timeval_object);
-  object_init_ex(timeval_object, grpc_ce_timeval);
-  wrapped_grpc_timeval *timeval =
-      (wrapped_grpc_timeval *)zend_object_store_get_object(
-          timeval_object TSRMLS_CC);
-  memcpy(&timeval->wrapped, &wrapped, sizeof(gpr_timespec));
-  return timeval_object;
-}
-
 #else
 
 static zend_object_handlers timeval_ce_handlers;
@@ -111,13 +100,16 @@ zend_object *create_wrapped_grpc_timeval(zend_class_entry *class_type) {
   return &intern->std;
 }
 
-void grpc_php_wrap_timeval(gpr_timespec wrapped, zval *timeval_object) {
+#endif
+
+zval *grpc_php_wrap_timeval(gpr_timespec wrapped TSRMLS_DC) {
+  zval *timeval_object;
+  PHP_GRPC_MAKE_STD_ZVAL(timeval_object);
   object_init_ex(timeval_object, grpc_ce_timeval);
   wrapped_grpc_timeval *timeval = Z_WRAPPED_GRPC_TIMEVAL_P(timeval_object);
   memcpy(&timeval->wrapped, &wrapped, sizeof(gpr_timespec));
+  return timeval_object;
 }
-
-#endif
 
 /**
  * Constructs a new instance of the Timeval class
@@ -156,16 +148,12 @@ PHP_METHOD(Timeval, add) {
   }
   wrapped_grpc_timeval *self = Z_WRAPPED_GRPC_TIMEVAL_P(getThis());
   wrapped_grpc_timeval *other = Z_WRAPPED_GRPC_TIMEVAL_P(other_obj);
-#if PHP_MAJOR_VERSION < 7
-  zval *sum =
+  zval *sum;
+  PHP_GRPC_MAKE_STD_ZVAL(sum);
+  sum =
       grpc_php_wrap_timeval(gpr_time_add(self->wrapped, other->wrapped)
                             TSRMLS_CC);
   RETURN_DESTROY_ZVAL(sum);
-#else
-  grpc_php_wrap_timeval(gpr_time_add(self->wrapped, other->wrapped),
-                        return_value);
-  RETURN_DESTROY_ZVAL(return_value);
-#endif
 }
 
 /**
@@ -186,16 +174,12 @@ PHP_METHOD(Timeval, subtract) {
   }
   wrapped_grpc_timeval *self = Z_WRAPPED_GRPC_TIMEVAL_P(getThis());
   wrapped_grpc_timeval *other = Z_WRAPPED_GRPC_TIMEVAL_P(other_obj);
-#if PHP_MAJOR_VERSION < 7
-  zval *diff =
+  zval *diff;
+  PHP_GRPC_MAKE_STD_ZVAL(diff);
+  diff =
       grpc_php_wrap_timeval(gpr_time_sub(self->wrapped, other->wrapped)
                             TSRMLS_CC);
   RETURN_DESTROY_ZVAL(diff);
-#else
-  grpc_php_wrap_timeval(gpr_time_sub(self->wrapped, other->wrapped),
-                        return_value);
-  RETURN_DESTROY_ZVAL(return_value);
-#endif
 }
 
 /**
@@ -255,13 +239,10 @@ PHP_METHOD(Timeval, similar) {
  * @return Timeval The current time
  */
 PHP_METHOD(Timeval, now) {
-#if PHP_MAJOR_VERSION < 7
-  zval *now = grpc_php_wrap_timeval(gpr_now(GPR_CLOCK_REALTIME) TSRMLS_CC);
+  zval *now;
+  PHP_GRPC_MAKE_STD_ZVAL(now);
+  now = grpc_php_wrap_timeval(gpr_now(GPR_CLOCK_REALTIME) TSRMLS_CC);
   RETURN_DESTROY_ZVAL(now);
-#else
-  grpc_php_wrap_timeval(gpr_now(GPR_CLOCK_REALTIME), return_value);
-  RETURN_DESTROY_ZVAL(return_value);
-#endif
 }
 
 /**
@@ -269,18 +250,13 @@ PHP_METHOD(Timeval, now) {
  * @return Timeval Zero length time interval
  */
 PHP_METHOD(Timeval, zero) {
-#if PHP_MAJOR_VERSION < 7
-  zval *grpc_php_timeval_zero =
+  zval *grpc_php_timeval_zero;
+  PHP_GRPC_MAKE_STD_ZVAL(grpc_php_timeval_zero);
+  grpc_php_timeval_zero =
       grpc_php_wrap_timeval(gpr_time_0(GPR_CLOCK_REALTIME) TSRMLS_CC);
   RETURN_ZVAL(grpc_php_timeval_zero,
               false, /* Copy original before returning? */
               true /* Destroy original before returning */);
-#else
-  grpc_php_wrap_timeval(gpr_time_0(GPR_CLOCK_REALTIME), return_value);
-  RETURN_ZVAL(return_value,
-              false, /* Copy original before returning? */
-              true /* Destroy original before returning */);
-#endif
 }
 
 /**
@@ -288,14 +264,11 @@ PHP_METHOD(Timeval, zero) {
  * @return Timeval Infinite future time value
  */
 PHP_METHOD(Timeval, infFuture) {
-#if PHP_MAJOR_VERSION < 7
-  zval *grpc_php_timeval_inf_future =
+  zval *grpc_php_timeval_inf_future;
+  PHP_GRPC_MAKE_STD_ZVAL(grpc_php_timeval_inf_future);
+  grpc_php_timeval_inf_future =
       grpc_php_wrap_timeval(gpr_inf_future(GPR_CLOCK_REALTIME) TSRMLS_CC);
   RETURN_DESTROY_ZVAL(grpc_php_timeval_inf_future);
-#else
-  grpc_php_wrap_timeval(gpr_inf_future(GPR_CLOCK_REALTIME), return_value);
-  RETURN_DESTROY_ZVAL(return_value);
-#endif
 }
 
 /**
@@ -303,14 +276,11 @@ PHP_METHOD(Timeval, infFuture) {
  * @return Timeval Infinite past time value
  */
 PHP_METHOD(Timeval, infPast) {
-#if PHP_MAJOR_VERSION < 7
-  zval *grpc_php_timeval_inf_past =
+  zval *grpc_php_timeval_inf_past;
+  PHP_GRPC_MAKE_STD_ZVAL(grpc_php_timeval_inf_past);
+  grpc_php_timeval_inf_past =
       grpc_php_wrap_timeval(gpr_inf_past(GPR_CLOCK_REALTIME) TSRMLS_CC);
   RETURN_DESTROY_ZVAL(grpc_php_timeval_inf_past);
-#else
-  grpc_php_wrap_timeval(gpr_inf_past(GPR_CLOCK_REALTIME), return_value);
-  RETURN_DESTROY_ZVAL(return_value);
-#endif
 }
 
 /**

--- a/src/php/ext/grpc/timeval.c
+++ b/src/php/ext/grpc/timeval.c
@@ -56,9 +56,9 @@ zend_class_entry *grpc_ce_timeval;
 
 /* Frees and destroys an instance of wrapped_grpc_call */
 void free_wrapped_grpc_timeval(void *object TSRMLS_DC) {
-    wrapped_grpc_timeval *timeval = (wrapped_grpc_timeval *)object;
-    zend_object_std_dtor(&timeval->std TSRMLS_CC);
-    efree(timeval);
+  wrapped_grpc_timeval *timeval = (wrapped_grpc_timeval *)object;
+  zend_object_std_dtor(&timeval->std TSRMLS_CC);
+  efree(timeval);
 }
 
 /* Initializes an instance of wrapped_grpc_timeval to be associated with an

--- a/src/php/ext/grpc/timeval.h
+++ b/src/php/ext/grpc/timeval.h
@@ -50,22 +50,16 @@
 extern zend_class_entry *grpc_ce_timeval;
 
 /* Wrapper struct for timeval that can be associated with a PHP object */
-#if PHP_MAJOR_VERSION < 7
-
-typedef struct wrapped_grpc_timeval {
-  zend_object std;
+PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_timeval)
   gpr_timespec wrapped;
-} wrapped_grpc_timeval;
+PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_timeval)
+
+#if PHP_MAJOR_VERSION < 7
 
 #define Z_WRAPPED_GRPC_TIMEVAL_P(zv) \
   (wrapped_grpc_timeval *)zend_object_store_get_object(zv TSRMLS_CC)
 
 #else
-
-typedef struct wrapped_grpc_timeval {
-  gpr_timespec wrapped;
-  zend_object std;
-} wrapped_grpc_timeval;
 
 static inline wrapped_grpc_timeval
 *wrapped_grpc_timeval_from_obj(zend_object *obj) {
@@ -73,7 +67,7 @@ static inline wrapped_grpc_timeval
                                  XtOffsetOf(wrapped_grpc_timeval, std));
 }
 
-#define Z_WRAPPED_GRPC_TIMEVAL_P(zv)            \
+#define Z_WRAPPED_GRPC_TIMEVAL_P(zv) \
   wrapped_grpc_timeval_from_obj(Z_OBJ_P((zv)))
 
 #endif /* PHP_MAJOR_VERSION */
@@ -85,10 +79,6 @@ void grpc_init_timeval(TSRMLS_D);
 void grpc_shutdown_timeval(TSRMLS_D);
 
 /* Creates a Timeval object that wraps the given timeval struct */
-#if PHP_MAJOR_VERSION < 7
 zval *grpc_php_wrap_timeval(gpr_timespec wrapped TSRMLS_DC);
-#else
-void grpc_php_wrap_timeval(gpr_timespec wrapped, zval *timeval_object);
-#endif /* PHP_MAJOR_VERSION */
 
 #endif /* NET_GRPC_PHP_GRPC_TIMEVAL_H_ */


### PR DESCRIPTION
First part #7498, the PR is second part and includes:

- Add macro `php_grpc_ulong`

- Add macro `php_grpc_add_property_string`

- Add macro `php_grpc_add_property_stringl`

- Add macro `php_grpc_add_next_index_stringl`

- Add macro `PHP_GRPC_MAKE_STD_ZVAL`

    - use it to unify `grpc_php_wrap_xxx` function on php5 and php7 to one function

    - use it on function to unify `return_value` on php7 to one return value

- Add macro `PHP_GRPC_WRAP_OBJECT_START` and `PHP_GRPC_WRAP_OBJECT_END`

    - use it on each header file to unify `wrapped_grpc_xxx` struct define
