### PR TITLE
PHP: use php7_wrapper to reduce duplicated codes(third part)

### DIFF
--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -59,17 +59,14 @@
 
 zend_class_entry *grpc_ce_call;
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Frees and destroys an instance of wrapped_grpc_call */
-void free_wrapped_grpc_call(void *object TSRMLS_DC) {
-  wrapped_grpc_call *call = (wrapped_grpc_call *)object;
-  if (call->owned && call->wrapped != NULL) {
-    grpc_call_destroy(call->wrapped);
+PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_call)
+  if (p->owned && p->wrapped != NULL) {
+    grpc_call_destroy(p->wrapped);
   }
-  zend_object_std_dtor(&call->std TSRMLS_CC);
-  efree(call);
-}
+PHP_GRPC_FREE_WRAPPED_FUNC_END()
+
+#if PHP_MAJOR_VERSION < 7
 
 /* Initializes an instance of wrapped_grpc_call to be associated with an object
  * of a class specified by class_type */
@@ -93,15 +90,6 @@ zend_object_value create_wrapped_grpc_call(zend_class_entry *class_type
 #else
 
 static zend_object_handlers call_ce_handlers;
-
-/* Frees and destroys an instance of wrapped_grpc_call */
-static void free_wrapped_grpc_call(zend_object *object) {
-  wrapped_grpc_call *call = wrapped_grpc_call_from_obj(object);
-  if (call->owned && call->wrapped != NULL) {
-    grpc_call_destroy(call->wrapped);
-  }
-  zend_object_std_dtor(&call->std);
-}
 
 /* Initializes an instance of wrapped_grpc_call to be associated with an
  * object of a class specified by class_type */

--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -58,6 +58,9 @@
 #include "byte_buffer.h"
 
 zend_class_entry *grpc_ce_call;
+#if PHP_MAJOR_VERSION >= 7
+static zend_object_handlers call_ce_handlers;
+#endif
 
 /* Frees and destroys an instance of wrapped_grpc_call */
 PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_call)
@@ -66,44 +69,32 @@ PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_call)
   }
 PHP_GRPC_FREE_WRAPPED_FUNC_END()
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Initializes an instance of wrapped_grpc_call to be associated with an object
  * of a class specified by class_type */
-zend_object_value create_wrapped_grpc_call(zend_class_entry *class_type
-                                               TSRMLS_DC) {
-  zend_object_value retval;
+php_grpc_zend_object create_wrapped_grpc_call(zend_class_entry *class_type
+                                              TSRMLS_DC) {
   wrapped_grpc_call *intern;
-
+#if PHP_MAJOR_VERSION < 7
+  zend_object_value retval;
   intern = (wrapped_grpc_call *)emalloc(sizeof(wrapped_grpc_call));
   memset(intern, 0, sizeof(wrapped_grpc_call));
-
+#else
+  intern = ecalloc(1, sizeof(wrapped_grpc_call) +
+                   zend_object_properties_size(class_type));
+#endif
   zend_object_std_init(&intern->std, class_type TSRMLS_CC);
   object_properties_init(&intern->std, class_type);
+#if PHP_MAJOR_VERSION < 7
   retval.handle = zend_objects_store_put(
       intern, (zend_objects_store_dtor_t)zend_objects_destroy_object,
       free_wrapped_grpc_call, NULL TSRMLS_CC);
   retval.handlers = zend_get_std_object_handlers();
   return retval;
-}
-
 #else
-
-static zend_object_handlers call_ce_handlers;
-
-/* Initializes an instance of wrapped_grpc_call to be associated with an
- * object of a class specified by class_type */
-zend_object *create_wrapped_grpc_call(zend_class_entry *class_type) {
-  wrapped_grpc_call *intern;
-  intern = ecalloc(1, sizeof(wrapped_grpc_call) +
-                   zend_object_properties_size(class_type));
-  zend_object_std_init(&intern->std, class_type);
-  object_properties_init(&intern->std, class_type);
   intern->std.handlers = &call_ce_handlers;
   return &intern->std;
-}
-
 #endif
+}
 
 /* Creates and returns a PHP array object with the data in a
  * grpc_metadata_array. Returns NULL on failure */

--- a/src/php/ext/grpc/call_credentials.c
+++ b/src/php/ext/grpc/call_credentials.c
@@ -53,18 +53,14 @@
 
 zend_class_entry *grpc_ce_call_credentials;
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Frees and destroys an instance of wrapped_grpc_call_credentials */
-void free_wrapped_grpc_call_credentials(void *object TSRMLS_DC) {
-  wrapped_grpc_call_credentials *creds =
-      (wrapped_grpc_call_credentials *)object;
-  if (creds->wrapped != NULL) {
-    grpc_call_credentials_release(creds->wrapped);
+PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_call_credentials)
+  if (p->wrapped != NULL) {
+    grpc_call_credentials_release(p->wrapped);
   }
-  zend_object_std_dtor(&creds->std TSRMLS_CC);
-  efree(creds);
-}
+PHP_GRPC_FREE_WRAPPED_FUNC_END()
+
+#if PHP_MAJOR_VERSION < 7
 
 /* Initializes an instance of wrapped_grpc_call_credentials to be
  * associated with an object of a class specified by class_type */
@@ -89,16 +85,6 @@ zend_object_value create_wrapped_grpc_call_credentials(
 #else
 
 static zend_object_handlers call_credentials_ce_handlers;
-
-/* Frees and destroys an instance of wrapped_grpc_call_credentials */
-static void free_wrapped_grpc_call_credentials(zend_object *object) {
-  wrapped_grpc_call_credentials *creds =
-    wrapped_grpc_call_creds_from_obj(object);
-  if (creds->wrapped != NULL) {
-    grpc_call_credentials_release(creds->wrapped);
-  }
-  zend_object_std_dtor(&creds->std);
-}
 
 /* Initializes an instance of wrapped_grpc_call_credentials to be
  * associated with an object of a class specified by class_type */

--- a/src/php/ext/grpc/call_credentials.c
+++ b/src/php/ext/grpc/call_credentials.c
@@ -52,6 +52,9 @@
 #include <grpc/grpc_security.h>
 
 zend_class_entry *grpc_ce_call_credentials;
+#if PHP_MAJOR_VERSION >= 7
+static zend_object_handlers call_credentials_ce_handlers;
+#endif
 
 /* Frees and destroys an instance of wrapped_grpc_call_credentials */
 PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_call_credentials)
@@ -60,46 +63,33 @@ PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_call_credentials)
   }
 PHP_GRPC_FREE_WRAPPED_FUNC_END()
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Initializes an instance of wrapped_grpc_call_credentials to be
  * associated with an object of a class specified by class_type */
-zend_object_value create_wrapped_grpc_call_credentials(
+php_grpc_zend_object create_wrapped_grpc_call_credentials(
     zend_class_entry *class_type TSRMLS_DC) {
-  zend_object_value retval;
   wrapped_grpc_call_credentials *intern;
-
+#if PHP_MAJOR_VERSION < 7
+  zend_object_value retval;
   intern = (wrapped_grpc_call_credentials *)emalloc(
       sizeof(wrapped_grpc_call_credentials));
   memset(intern, 0, sizeof(wrapped_grpc_call_credentials));
-
+#else
+  intern = ecalloc(1, sizeof(wrapped_grpc_call_credentials) +
+                   zend_object_properties_size(class_type));
+#endif
   zend_object_std_init(&intern->std, class_type TSRMLS_CC);
   object_properties_init(&intern->std, class_type);
+#if PHP_MAJOR_VERSION < 7
   retval.handle = zend_objects_store_put(
       intern, (zend_objects_store_dtor_t)zend_objects_destroy_object,
       free_wrapped_grpc_call_credentials, NULL TSRMLS_CC);
   retval.handlers = zend_get_std_object_handlers();
   return retval;
-}
-
 #else
-
-static zend_object_handlers call_credentials_ce_handlers;
-
-/* Initializes an instance of wrapped_grpc_call_credentials to be
- * associated with an object of a class specified by class_type */
-zend_object *create_wrapped_grpc_call_credentials(zend_class_entry
-                                                  *class_type) {
-  wrapped_grpc_call_credentials *intern;
-  intern = ecalloc(1, sizeof(wrapped_grpc_call_credentials) +
-                   zend_object_properties_size(class_type));
-  zend_object_std_init(&intern->std, class_type);
-  object_properties_init(&intern->std, class_type);
   intern->std.handlers = &call_credentials_ce_handlers;
   return &intern->std;
-}
-
 #endif
+}
 
 zval *grpc_php_wrap_call_credentials(grpc_call_credentials
                                      *wrapped TSRMLS_DC) {

--- a/src/php/ext/grpc/call_credentials.h
+++ b/src/php/ext/grpc/call_credentials.h
@@ -63,7 +63,7 @@ PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_call_credentials)
 #else
 
 static inline wrapped_grpc_call_credentials
-*wrapped_grpc_call_creds_from_obj(zend_object *obj) {
+*wrapped_grpc_call_credentials_from_obj(zend_object *obj) {
   return
     (wrapped_grpc_call_credentials*)((char*)(obj) -
                                      XtOffsetOf(wrapped_grpc_call_credentials,
@@ -71,7 +71,7 @@ static inline wrapped_grpc_call_credentials
 }
 
 #define Z_WRAPPED_GRPC_CALL_CREDS_P(zv) \
-  wrapped_grpc_call_creds_from_obj(Z_OBJ_P((zv)))
+  wrapped_grpc_call_credentials_from_obj(Z_OBJ_P((zv)))
 
 #endif /* PHP_MAJOR_VERSION */
 

--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -57,17 +57,14 @@
 
 zend_class_entry *grpc_ce_channel;
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Frees and destroys an instance of wrapped_grpc_channel */
-void free_wrapped_grpc_channel(void *object TSRMLS_DC) {
-  wrapped_grpc_channel *channel = (wrapped_grpc_channel *)object;
-  if (channel->wrapped != NULL) {
-    grpc_channel_destroy(channel->wrapped);
+PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_channel)
+  if (p->wrapped != NULL) {
+    grpc_channel_destroy(p->wrapped);
   }
-  zend_object_std_dtor(&channel->std TSRMLS_CC);
-  efree(channel);
-}
+PHP_GRPC_FREE_WRAPPED_FUNC_END()
+
+#if PHP_MAJOR_VERSION < 7
 
 /* Initializes an instance of wrapped_grpc_channel to be associated with an
  * object of a class specified by class_type */
@@ -89,15 +86,6 @@ zend_object_value create_wrapped_grpc_channel(zend_class_entry *class_type
 #else
 
 static zend_object_handlers channel_ce_handlers;
-
-/* Frees and destroys an instance of wrapped_grpc_channel */
-static void free_wrapped_grpc_channel(zend_object *object) {
-  wrapped_grpc_channel *channel = wrapped_grpc_channel_from_obj(object);
-  if (channel->wrapped != NULL) {
-    grpc_channel_destroy(channel->wrapped);
-  }
-  zend_object_std_dtor(&channel->std);
-}
 
 /* Initializes an instance of wrapped_grpc_channel to be associated with an
  * object of a class specified by class_type */

--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -56,6 +56,9 @@
 #include "timeval.h"
 
 zend_class_entry *grpc_ce_channel;
+#if PHP_MAJOR_VERSION >= 7
+static zend_object_handlers channel_ce_handlers;
+#endif
 
 /* Frees and destroys an instance of wrapped_grpc_channel */
 PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_channel)
@@ -64,42 +67,32 @@ PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_channel)
   }
 PHP_GRPC_FREE_WRAPPED_FUNC_END()
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Initializes an instance of wrapped_grpc_channel to be associated with an
  * object of a class specified by class_type */
-zend_object_value create_wrapped_grpc_channel(zend_class_entry *class_type
-                                                  TSRMLS_DC) {
-  zend_object_value retval;
+php_grpc_zend_object create_wrapped_grpc_channel(zend_class_entry *class_type
+                                                 TSRMLS_DC) {
   wrapped_grpc_channel *intern;
+#if PHP_MAJOR_VERSION < 7
+  zend_object_value retval;
   intern = (wrapped_grpc_channel *)emalloc(sizeof(wrapped_grpc_channel));
   memset(intern, 0, sizeof(wrapped_grpc_channel));
+#else
+  intern = ecalloc(1, sizeof(wrapped_grpc_channel) +
+                   zend_object_properties_size(class_type));
+#endif
   zend_object_std_init(&intern->std, class_type TSRMLS_CC);
   object_properties_init(&intern->std, class_type);
+#if PHP_MAJOR_VERSION < 7
   retval.handle = zend_objects_store_put(
       intern, (zend_objects_store_dtor_t)zend_objects_destroy_object,
       free_wrapped_grpc_channel, NULL TSRMLS_CC);
   retval.handlers = zend_get_std_object_handlers();
   return retval;
-}
-
 #else
-
-static zend_object_handlers channel_ce_handlers;
-
-/* Initializes an instance of wrapped_grpc_channel to be associated with an
- * object of a class specified by class_type */
-zend_object *create_wrapped_grpc_channel(zend_class_entry *class_type) {
-  wrapped_grpc_channel *intern;
-  intern = ecalloc(1, sizeof(wrapped_grpc_channel) +
-                   zend_object_properties_size(class_type));
-  zend_object_std_init(&intern->std, class_type);
-  object_properties_init(&intern->std, class_type);
   intern->std.handlers = &channel_ce_handlers;
   return &intern->std;
-}
-
 #endif
+}
 
 void php_grpc_read_args_array(zval *args_array,
                               grpc_channel_args *args TSRMLS_DC) {

--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -63,18 +63,14 @@ static grpc_ssl_roots_override_result get_ssl_roots_override(
   return GRPC_SSL_ROOTS_OVERRIDE_OK;
 }
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Frees and destroys an instance of wrapped_grpc_channel_credentials */
-void free_wrapped_grpc_channel_credentials(void *object TSRMLS_DC) {
-  wrapped_grpc_channel_credentials *creds =
-      (wrapped_grpc_channel_credentials *)object;
-  if (creds->wrapped != NULL) {
-    grpc_channel_credentials_release(creds->wrapped);
+PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_channel_credentials)
+  if (p->wrapped != NULL) {
+    grpc_channel_credentials_release(p->wrapped);
   }
-  zend_object_std_dtor(&creds->std TSRMLS_CC);
-  efree(creds);
-}
+PHP_GRPC_FREE_WRAPPED_FUNC_END()
+
+#if PHP_MAJOR_VERSION < 7
 
 /* Initializes an instance of wrapped_grpc_channel_credentials to be
  * associated with an object of a class specified by class_type */
@@ -99,16 +95,6 @@ zend_object_value create_wrapped_grpc_channel_credentials(
 #else
 
 static zend_object_handlers channel_credentials_ce_handlers;
-
-/* Frees and destroys an instance of wrapped_grpc_channel_credentials */
-static void free_wrapped_grpc_channel_credentials(zend_object *object) {
-  wrapped_grpc_channel_credentials *creds =
-    wrapped_grpc_channel_creds_from_obj(object);
-  if (creds->wrapped != NULL) {
-    grpc_channel_credentials_release(creds->wrapped);
-  }
-  zend_object_std_dtor(&creds->std);
-}
 
 /* Initializes an instance of wrapped_grpc_channel_credentials to be
  * associated with an object of a class specified by class_type */

--- a/src/php/ext/grpc/channel_credentials.h
+++ b/src/php/ext/grpc/channel_credentials.h
@@ -63,15 +63,14 @@ PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_channel_credentials)
 #else
 
 static inline wrapped_grpc_channel_credentials
-*wrapped_grpc_channel_creds_from_obj(zend_object *obj) {
+*wrapped_grpc_channel_credentials_from_obj(zend_object *obj) {
   return
     (wrapped_grpc_channel_credentials *)
-    ((char*)(obj) -
-     XtOffsetOf(wrapped_grpc_channel_credentials, std));
+    ((char*)(obj) - XtOffsetOf(wrapped_grpc_channel_credentials, std));
 }
 
 #define Z_WRAPPED_GRPC_CHANNEL_CREDS_P(zv) \
-  wrapped_grpc_channel_creds_from_obj(Z_OBJ_P((zv)))
+  wrapped_grpc_channel_credentials_from_obj(Z_OBJ_P((zv)))
 
 #endif /* PHP_MAJOR_VERSION */
 

--- a/src/php/ext/grpc/php7_wrapper.h
+++ b/src/php/ext/grpc/php7_wrapper.h
@@ -56,6 +56,14 @@
 #define PHP_GRPC_WRAP_OBJECT_END(name) \
   } name;
 
+#define PHP_GRPC_FREE_WRAPPED_FUNC_START(klass) \
+  void free_##klass(void *object TSRMLS_DC) { \
+    klass *p = (klass *)object;
+#define PHP_GRPC_FREE_WRAPPED_FUNC_END() \
+    zend_object_std_dtor(&p->std TSRMLS_CC); \
+    efree(p); \
+  }
+
 #else
 
 #define php_grpc_int size_t
@@ -78,6 +86,16 @@
 #define PHP_GRPC_WRAP_OBJECT_END(name) \
     zend_object std; \
   } name;
+
+#define WRAPPED_OBJECT_FROM_OBJ(klass, obj) \
+          klass##_from_obj(obj);
+
+#define PHP_GRPC_FREE_WRAPPED_FUNC_START(klass) \
+  static void free_##klass(zend_object *object) { \
+    klass *p = WRAPPED_OBJECT_FROM_OBJ(klass, object)
+#define PHP_GRPC_FREE_WRAPPED_FUNC_END() \
+    zend_object_std_dtor(&p->std); \
+  }
 
 #endif /* PHP_MAJOR_VERSION */
 

--- a/src/php/ext/grpc/php7_wrapper.h
+++ b/src/php/ext/grpc/php7_wrapper.h
@@ -40,6 +40,7 @@
 #define php_grpc_int int
 #define php_grpc_long long
 #define php_grpc_ulong ulong
+#define php_grpc_zend_object zend_object_value
 #define php_grpc_add_property_string(arg, name, context, b) \
   add_property_string(arg, name, context, b)
 #define php_grpc_add_property_stringl(res, name, str, len, b) \
@@ -56,9 +57,9 @@
 #define PHP_GRPC_WRAP_OBJECT_END(name) \
   } name;
 
-#define PHP_GRPC_FREE_WRAPPED_FUNC_START(klass) \
-  void free_##klass(void *object TSRMLS_DC) { \
-    klass *p = (klass *)object;
+#define PHP_GRPC_FREE_WRAPPED_FUNC_START(class_object) \
+  void free_##class_object(void *object TSRMLS_DC) { \
+    class_object *p = (class_object *)object;
 #define PHP_GRPC_FREE_WRAPPED_FUNC_END() \
     zend_object_std_dtor(&p->std TSRMLS_CC); \
     efree(p); \
@@ -69,6 +70,7 @@
 #define php_grpc_int size_t
 #define php_grpc_long zend_long
 #define php_grpc_ulong zend_ulong
+#define php_grpc_zend_object zend_object*
 #define php_grpc_add_property_string(arg, name, context, b) \
   add_property_string(arg, name, context)
 #define php_grpc_add_property_stringl(res, name, str, len, b) \
@@ -87,12 +89,12 @@
     zend_object std; \
   } name;
 
-#define WRAPPED_OBJECT_FROM_OBJ(klass, obj) \
-          klass##_from_obj(obj);
+#define WRAPPED_OBJECT_FROM_OBJ(class_object, obj) \
+  class_object##_from_obj(obj);
 
-#define PHP_GRPC_FREE_WRAPPED_FUNC_START(klass) \
-  static void free_##klass(zend_object *object) { \
-    klass *p = WRAPPED_OBJECT_FROM_OBJ(klass, object)
+#define PHP_GRPC_FREE_WRAPPED_FUNC_START(class_object) \
+  static void free_##class_object(zend_object *object) { \
+    class_object *p = WRAPPED_OBJECT_FROM_OBJ(class_object, object)
 #define PHP_GRPC_FREE_WRAPPED_FUNC_END() \
     zend_object_std_dtor(&p->std); \
   }

--- a/src/php/ext/grpc/server.c
+++ b/src/php/ext/grpc/server.c
@@ -58,21 +58,18 @@
 
 zend_class_entry *grpc_ce_server;
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Frees and destroys an instance of wrapped_grpc_server */
-void free_wrapped_grpc_server(void *object TSRMLS_DC) {
-  wrapped_grpc_server *server = (wrapped_grpc_server *)object;
-  if (server->wrapped != NULL) {
-    grpc_server_shutdown_and_notify(server->wrapped, completion_queue, NULL);
-    grpc_server_cancel_all_calls(server->wrapped);
+PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_server)
+  if (p->wrapped != NULL) {
+    grpc_server_shutdown_and_notify(p->wrapped, completion_queue, NULL);
+    grpc_server_cancel_all_calls(p->wrapped);
     grpc_completion_queue_pluck(completion_queue, NULL,
                                 gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
-    grpc_server_destroy(server->wrapped);
+    grpc_server_destroy(p->wrapped);
   }
-  zend_object_std_dtor(&server->std TSRMLS_CC);
-  efree(server);
-}
+PHP_GRPC_FREE_WRAPPED_FUNC_END()
+
+#if PHP_MAJOR_VERSION < 7
 
 /* Initializes an instance of wrapped_grpc_call to be associated with an object
  * of a class specified by class_type */
@@ -96,19 +93,6 @@ zend_object_value create_wrapped_grpc_server(zend_class_entry *class_type
 #else
 
 static zend_object_handlers server_ce_handlers;
-
-/* Frees and destroys an instance of wrapped_grpc_server */
-static void free_wrapped_grpc_server(zend_object *object) {
-  wrapped_grpc_server *server = wrapped_grpc_server_from_obj(object);
-  if (server->wrapped != NULL) {
-    grpc_server_shutdown_and_notify(server->wrapped, completion_queue, NULL);
-    grpc_server_cancel_all_calls(server->wrapped);
-    grpc_completion_queue_pluck(completion_queue, NULL,
-                                gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
-    grpc_server_destroy(server->wrapped);
-  }
-  zend_object_std_dtor(&server->std);
-}
 
 /* Initializes an instance of wrapped_grpc_call to be associated with an object
  * of a class specified by class_type */

--- a/src/php/ext/grpc/server_credentials.c
+++ b/src/php/ext/grpc/server_credentials.c
@@ -51,18 +51,14 @@
 
 zend_class_entry *grpc_ce_server_credentials;
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Frees and destroys an instace of wrapped_grpc_server_credentials */
-void free_wrapped_grpc_server_credentials(void *object TSRMLS_DC) {
-  wrapped_grpc_server_credentials *creds =
-      (wrapped_grpc_server_credentials *)object;
-  if (creds->wrapped != NULL) {
-    grpc_server_credentials_release(creds->wrapped);
+PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_server_credentials)
+  if (p->wrapped != NULL) {
+    grpc_server_credentials_release(p->wrapped);
   }
-  zend_object_std_dtor(&creds->std TSRMLS_CC);
-  efree(creds);
-}
+PHP_GRPC_FREE_WRAPPED_FUNC_END()
+
+#if PHP_MAJOR_VERSION < 7
 
 /* Initializes an instace of wrapped_grpc_server_credentials to be associated
  * with an object of a class specified by class_type */
@@ -87,16 +83,6 @@ zend_object_value create_wrapped_grpc_server_credentials(
 #else
 
 static zend_object_handlers server_credentials_ce_handlers;
-
-/* Frees and destroys an instace of wrapped_grpc_server_credentials */
-static void free_wrapped_grpc_server_credentials(zend_object *object) {
-  wrapped_grpc_server_credentials *creds =
-    wrapped_grpc_server_creds_from_obj(object);
-  if (creds->wrapped != NULL) {
-    grpc_server_credentials_release(creds->wrapped);
-  }
-  zend_object_std_dtor(&creds->std);
-}
 
 /* Initializes an instace of wrapped_grpc_server_credentials to be associated
  * with an object of a class specified by class_type */

--- a/src/php/ext/grpc/server_credentials.h
+++ b/src/php/ext/grpc/server_credentials.h
@@ -63,13 +63,13 @@ PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_server_credentials)
 #else
 
 static inline wrapped_grpc_server_credentials
-*wrapped_grpc_server_creds_from_obj(zend_object *obj) {
+*wrapped_grpc_server_credentials_from_obj(zend_object *obj) {
   return (wrapped_grpc_server_credentials*)
     ((char*)(obj) - XtOffsetOf(wrapped_grpc_server_credentials, std));
 }
 
 #define Z_WRAPPED_GRPC_SERVER_CREDS_P(zv) \
-  wrapped_grpc_server_creds_from_obj(Z_OBJ_P((zv)))
+  wrapped_grpc_server_credentials_from_obj(Z_OBJ_P((zv)))
 
 #endif /* PHP_MAJOR_VERSION */
 

--- a/src/php/ext/grpc/timeval.c
+++ b/src/php/ext/grpc/timeval.c
@@ -52,14 +52,11 @@
 
 zend_class_entry *grpc_ce_timeval;
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Frees and destroys an instance of wrapped_grpc_call */
-void free_wrapped_grpc_timeval(void *object TSRMLS_DC) {
-  wrapped_grpc_timeval *timeval = (wrapped_grpc_timeval *)object;
-  zend_object_std_dtor(&timeval->std TSRMLS_CC);
-  efree(timeval);
-}
+PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_timeval)
+PHP_GRPC_FREE_WRAPPED_FUNC_END()
+
+#if PHP_MAJOR_VERSION < 7
 
 /* Initializes an instance of wrapped_grpc_timeval to be associated with an
  * object of a class specified by class_type */
@@ -81,12 +78,6 @@ zend_object_value create_wrapped_grpc_timeval(zend_class_entry *class_type
 #else
 
 static zend_object_handlers timeval_ce_handlers;
-
-/* Frees and destroys an instance of wrapped_grpc_call */
-static void free_wrapped_grpc_timeval(zend_object *object) {
-  wrapped_grpc_timeval *timeval = wrapped_grpc_timeval_from_obj(object);
-  zend_object_std_dtor(&timeval->std);
-}
 
 /* Initializes an instance of wrapped_grpc_timeval to be associated with an
  * object of a class specified by class_type */

--- a/src/php/ext/grpc/timeval.c
+++ b/src/php/ext/grpc/timeval.c
@@ -51,47 +51,40 @@
 #include <grpc/support/time.h>
 
 zend_class_entry *grpc_ce_timeval;
+#if PHP_MAJOR_VERSION >= 7
+static zend_object_handlers timeval_ce_handlers;
+#endif
 
 /* Frees and destroys an instance of wrapped_grpc_call */
 PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_timeval)
 PHP_GRPC_FREE_WRAPPED_FUNC_END()
 
-#if PHP_MAJOR_VERSION < 7
-
 /* Initializes an instance of wrapped_grpc_timeval to be associated with an
  * object of a class specified by class_type */
-zend_object_value create_wrapped_grpc_timeval(zend_class_entry *class_type
-                                                  TSRMLS_DC) {
-  zend_object_value retval;
+php_grpc_zend_object create_wrapped_grpc_timeval(zend_class_entry *class_type
+                                                 TSRMLS_DC) {
   wrapped_grpc_timeval *intern;
+#if PHP_MAJOR_VERSION < 7
+  zend_object_value retval;
   intern = (wrapped_grpc_timeval *)emalloc(sizeof(wrapped_grpc_timeval));
   memset(intern, 0, sizeof(wrapped_grpc_timeval));
+#else
+  intern = ecalloc(1, sizeof(wrapped_grpc_timeval) +
+                   zend_object_properties_size(class_type));
+#endif
   zend_object_std_init(&intern->std, class_type TSRMLS_CC);
   object_properties_init(&intern->std, class_type);
+#if PHP_MAJOR_VERSION < 7
   retval.handle = zend_objects_store_put(
       intern, (zend_objects_store_dtor_t)zend_objects_destroy_object,
       free_wrapped_grpc_timeval, NULL TSRMLS_CC);
   retval.handlers = zend_get_std_object_handlers();
   return retval;
-}
-
 #else
-
-static zend_object_handlers timeval_ce_handlers;
-
-/* Initializes an instance of wrapped_grpc_timeval to be associated with an
- * object of a class specified by class_type */
-zend_object *create_wrapped_grpc_timeval(zend_class_entry *class_type) {
-  wrapped_grpc_timeval *intern;
-  intern = ecalloc(1, sizeof(wrapped_grpc_timeval) +
-                   zend_object_properties_size(class_type));
-  zend_object_std_init(&intern->std, class_type);
-  object_properties_init(&intern->std, class_type);
   intern->std.handlers = &timeval_ce_handlers;
   return &intern->std;
-}
-
 #endif
+}
 
 zval *grpc_php_wrap_timeval(gpr_timespec wrapped TSRMLS_DC) {
   zval *timeval_object;


### PR DESCRIPTION
First part #7498 and second part #7532 , the PR includes:

- Add macro `PHP_GRPC_FREE_WRAPPED_FUNC_START` and `PHP_GRPC_FREE_WRAPPED_FUNC_END`

    - use it to unify `free_wrapped_grpc_xxx` function on php5 and php7 to one macro function

- Rename `wrapped_grpc_call_creds_from_obj` to `wrapped_grpc_call_credentials_from_obj`, etc, because macro `PHP_GRPC_FREE_WRAPPED_FUNC_START` on php7 need to use it

@stanley-cheung Please review to use the macro that make understand code difficulty? Thanks.