### PR TITLE
Add cmake option to compile using protobuf-lite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,13 @@ add_subdirectory(${ZLIB_ROOT_DIR} third_party/zlib)
 set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -std=c11")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
+if (GRPC_USE_PROTO_LITE)
+  set(PROTOBUF_LIBRARY_NAME "libprotobuf-lite")
+  add_definitions("-DGRPC_USE_PROTO_LITE")
+else()
+  set(PROTOBUF_LIBRARY_NAME "libprotobuf")
+endif()
+
   
 add_library(gpr
   src/core/lib/profiling/basic_timers.c
@@ -742,7 +749,7 @@ target_include_directories(grpc++
 
 target_link_libraries(grpc++
   ssl
-  libprotobuf
+  ${PROTOBUF_LIBRARY_NAME}
   grpc
 )
 
@@ -809,7 +816,7 @@ target_include_directories(grpc++_unsecure
 )
 
 target_link_libraries(grpc++_unsecure
-  libprotobuf
+  ${PROTOBUF_LIBRARY_NAME}
   gpr
   grpc_unsecure
   grpc

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -47,7 +47,7 @@
     if target_dict.get('secure', False):
       deps = ["ssl"]
     if target_dict['name'] in ['grpc++', 'grpc++_unsecure', 'grpc++_codegen_lib']:
-      deps.append("libprotobuf")
+      deps.append("${PROTOBUF_LIBRARY_NAME}")
     elif target_dict['name'] in ['grpc']:
       deps.append("zlibstatic")
     for d in target_dict.get('deps', []):
@@ -87,6 +87,13 @@
 
   set(CMAKE_C_FLAGS   "<%text>${CMAKE_C_FLAGS}</%text>   -std=c11")
   set(CMAKE_CXX_FLAGS "<%text>${CMAKE_CXX_FLAGS}</%text> -std=c++11")
+
+  if (GRPC_USE_PROTO_LITE)
+    set(PROTOBUF_LIBRARY_NAME "libprotobuf-lite")
+    add_definitions("-DGRPC_USE_PROTO_LITE")
+  else()
+    set(PROTOBUF_LIBRARY_NAME "libprotobuf")
+  endif()
 
   % for lib in libs:
   % if lib.build in ["all", "protoc", "tool"]:


### PR DESCRIPTION
After this change specifying -DGRPC_USE_PROTO_LITE=On at the cmake
command line will cause gRPC to use the protobuf-lite runtime what
can result in a major size improvement.