### PR TITLE
update windows nuget packge restores for latest nuget client

### DIFF
--- a/tools/run_tests/pre_build_csharp.bat
+++ b/tools/run_tests/pre_build_csharp.bat
@@ -38,8 +38,22 @@ cd /d %~dp0\..\..
 set NUGET=C:\nuget\nuget.exe
 
 if exist %NUGET% (
+  @rem Restore Grpc packages by packages since Nuget client 3.4.4 doesnt support restore
+  @rem by solution
   %NUGET% restore vsprojects/grpc_csharp_ext.sln || goto :error
   %NUGET% restore src/csharp/Grpc.sln || goto :error
+  %NUGET% restore src/csharp/Grpc.Auth -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Core -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Core.Tests -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Examples.MathClient -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Examples.MathServer -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Examples -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.HealthCheck.Tests -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.HealthCheck -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting.Client -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting.QpsWorker -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting.StressClient -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting -PackagesDirectory src/csharp/packages || goto :error
 )
 
 endlocal


### PR DESCRIPTION
This should fix the csharp builds on jenkins windows workers. Will see in the tests...

In order to bring in a new dependency in https://github.com/grpc/grpc/pull/7519, I needed to update the nuget client on jenkins workers because the previous nuget client versions (at 2.8.6), were too old to bring in the new dependency. 

Unfortunately the new nuget client has breaking changes that break the way csharp currently restores its nuget packages, so basic tests are failing on windows (where the client was updated so far).