### PR TITLE
update to use new nuget client in tests

### DIFF
--- a/src/csharp/.nuget/packages.config
+++ b/src/csharp/.nuget/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit.ConsoleRunner" version="3.2.0" />
-  <package id="OpenCover" version="4.6.519" />
-  <package id="ReportGenerator" version="2.4.4.0" />
-</packages>

--- a/src/csharp/Grpc.Core.Tests/packages.config
+++ b/src/csharp/Grpc.Core.Tests/packages.config
@@ -4,4 +4,7 @@
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.2.0" targetFramework="net45" />
   <package id="NUnitLite" version="3.2.0" targetFramework="net45" />
+  <package id="NUnit.ConsoleRunner" version="3.2.0" />
+  <package id="OpenCover" version="4.6.519" />
+  <package id="ReportGenerator" version="2.4.4.0" />
 </packages>

--- a/src/csharp/Grpc.Core.Tests/project.json
+++ b/src/csharp/Grpc.Core.Tests/project.json
@@ -54,8 +54,12 @@
     },
     "Newtonsoft.Json": "8.0.3",
     "NUnit": "3.2.0",
-    "NUnitLite": "3.2.0-*"
+    "NUnitLite": "3.2.0-*",
+    "NUnit.ConsoleRunner": "3.2.0",
+    "OpenCover": "4.6.519",
+    "ReportGenerator": "2.4.4.0"
   },
+
   "frameworks": {
     "net45": { },
     "netstandard1.5": {

--- a/src/csharp/Grpc.Core.Tests/project.json
+++ b/src/csharp/Grpc.Core.Tests/project.json
@@ -59,7 +59,6 @@
     "OpenCover": "4.6.519",
     "ReportGenerator": "2.4.4.0"
   },
-
   "frameworks": {
     "net45": { },
     "netstandard1.5": {

--- a/src/csharp/Grpc.Examples.MathClient/packages.config
+++ b/src/csharp/Grpc.Examples.MathClient/packages.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+</packages>

--- a/src/csharp/Grpc.Examples.MathServer/packages.config
+++ b/src/csharp/Grpc.Examples.MathServer/packages.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+</packages>

--- a/src/csharp/Grpc.IntegrationTesting.QpsWorker/packages.config
+++ b/src/csharp/Grpc.IntegrationTesting.QpsWorker/packages.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+</packages>

--- a/src/csharp/Grpc.IntegrationTesting.StressClient/packages.config
+++ b/src/csharp/Grpc.IntegrationTesting.StressClient/packages.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+</packages>

--- a/templates/src/csharp/Grpc.Core.Tests/project.json.template
+++ b/templates/src/csharp/Grpc.Core.Tests/project.json.template
@@ -8,7 +8,10 @@
       },
       "Newtonsoft.Json": "8.0.3",
       "NUnit": "3.2.0",
-      "NUnitLite": "3.2.0-*"
+      "NUnitLite": "3.2.0-*",
+      "NUnit.ConsoleRunner": "3.2.0",
+      "OpenCover": "4.6.519",
+      "ReportGenerator": "2.4.4.0"
     },
     "frameworks": {
       "net45": { },

--- a/tools/run_tests/pre_build_csharp.bat
+++ b/tools/run_tests/pre_build_csharp.bat
@@ -38,8 +38,21 @@ cd /d %~dp0\..\..
 set NUGET=C:\nuget\nuget.exe
 
 if exist %NUGET% (
+  @rem Restore Grpc packages by packages since Nuget client 3.4.4 doesnt support restore
+  @rem by solution
   %NUGET% restore vsprojects/grpc_csharp_ext.sln || goto :error
-  %NUGET% restore src/csharp/Grpc.sln || goto :error
+  %NUGET% restore src/csharp/Grpc.Auth -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Core -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Core.Tests -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Examples.MathClient -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Examples.MathServer -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Examples -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.HealthCheck.Tests -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.HealthCheck -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting.Client -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting.QpsWorker -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting.StressClient -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting -PackagesDirectory src/csharp/packages || goto :error
 )
 
 endlocal

--- a/tools/run_tests/pre_build_csharp.bat
+++ b/tools/run_tests/pre_build_csharp.bat
@@ -40,19 +40,56 @@ set NUGET=C:\nuget\nuget.exe
 if exist %NUGET% (
   @rem Restore Grpc packages by packages since Nuget client 3.4.4 doesnt support restore
   @rem by solution
+  @rem Moving into each directory to let the restores work with both nuget 3.4 and 2.8
   %NUGET% restore vsprojects/grpc_csharp_ext.sln || goto :error
-  %NUGET% restore src/csharp/Grpc.Auth -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
-  %NUGET% restore src/csharp/Grpc.Core -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
-  %NUGET% restore src/csharp/Grpc.Core.Tests -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
-  %NUGET% restore src/csharp/Grpc.Examples.MathClient -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
-  %NUGET% restore src/csharp/Grpc.Examples.MathServer -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
-  %NUGET% restore src/csharp/Grpc.Examples -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
-  %NUGET% restore src/csharp/Grpc.HealthCheck.Tests -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
-  %NUGET% restore src/csharp/Grpc.HealthCheck -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
-  %NUGET% restore src/csharp/Grpc.IntegrationTesting.Client -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
-  %NUGET% restore src/csharp/Grpc.IntegrationTesting.QpsWorker -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
-  %NUGET% restore src/csharp/Grpc.IntegrationTesting.StressClient -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
-  %NUGET% restore src/csharp/Grpc.IntegrationTesting -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
+
+  cd src/csharp/Grpc.Auth || goto :error
+  %NUGET% restore -PackagesDirectory ../packages || goto :error
+  cd ..
+
+  cd src/csharp/Grpc.Core || goto :error
+  %NUGET% restore -PackagesDirectory ../packages || goto :error
+  cd ..
+
+  cd src/csharp/Grpc.Core.Tests || goto :error
+  %NUGET% restore -PackagesDirectory ../packages || goto :error
+  cd ..
+
+  cd src/csharp/Grpc.Examples.MathClient || goto :error
+  %NUGET% restore -PackagesDirectory ../packages || goto :error
+  cd ..
+
+  cd src/csharp/Grpc.Examples.MathServer || goto :error
+  %NUGET% restore -PackagesDirectory ../packages || goto :error
+  cd ..
+
+  cd src/csharp/Grpc.Examples || goto :error
+  %NUGET% restore -PackagesDirectory ../packages || goto :error
+  cd ..
+
+  cd src/csharp/Grpc.HealthCheck.Tests || goto :error
+  %NUGET% restore -PackagesDirectory ../packages || goto :error
+  cd ..
+
+  cd src/csharp/Grpc.HealthCheck || goto :error
+  %NUGET% restore -PackagesDirectory ../packages || goto :error
+  cd ..
+
+  cd src/csharp/Grpc.IntegrationTesting.Client || goto :error
+  %NUGET% restore -PackagesDirectory ../packages || goto :error
+  cd ..
+
+  cd src/csharp/Grpc.IntegrationTesting.QpsWorker || goto :error
+  %NUGET% restore -PackagesDirectory ../packages || goto :error
+  cd ..
+
+  cd src/csharp/Grpc.IntegrationTesting.StressClient || goto :error
+  %NUGET% restore -PackagesDirectory ../packages || goto :error
+  cd ..
+
+  cd src/csharp/Grpc.IntegrationTesting || goto :error
+  %NUGET% restore -PackagesDirectory ../packages || goto :error
+  cd ..
 )
 
 endlocal

--- a/tools/run_tests/pre_build_csharp.bat
+++ b/tools/run_tests/pre_build_csharp.bat
@@ -43,53 +43,56 @@ if exist %NUGET% (
   @rem Moving into each directory to let the restores work with both nuget 3.4 and 2.8
   %NUGET% restore vsprojects/grpc_csharp_ext.sln || goto :error
 
-  cd src/csharp/Grpc.Auth || goto :error
+  cd src/csharp
+
+  cd Grpc.Auth || goto :error
   %NUGET% restore -PackagesDirectory ../packages || goto :error
   cd ..
 
-  cd src/csharp/Grpc.Core || goto :error
+  cd Grpc.Core || goto :error
   %NUGET% restore -PackagesDirectory ../packages || goto :error
   cd ..
 
-  cd src/csharp/Grpc.Core.Tests || goto :error
+  cd Grpc.Core.Tests || goto :error
   %NUGET% restore -PackagesDirectory ../packages || goto :error
   cd ..
 
-  cd src/csharp/Grpc.Examples.MathClient || goto :error
+  cd Grpc.Examples.MathClient || goto :error
   %NUGET% restore -PackagesDirectory ../packages || goto :error
   cd ..
 
-  cd src/csharp/Grpc.Examples.MathServer || goto :error
+  cd Grpc.Examples.MathServer || goto :error
   %NUGET% restore -PackagesDirectory ../packages || goto :error
   cd ..
 
-  cd src/csharp/Grpc.Examples || goto :error
+  cd Grpc.Examples || goto :error
   %NUGET% restore -PackagesDirectory ../packages || goto :error
   cd ..
 
-  cd src/csharp/Grpc.HealthCheck.Tests || goto :error
+  cd Grpc.HealthCheck.Tests || goto :error
   %NUGET% restore -PackagesDirectory ../packages || goto :error
   cd ..
 
-  cd src/csharp/Grpc.HealthCheck || goto :error
+  cd Grpc.HealthCheck || goto :error
   %NUGET% restore -PackagesDirectory ../packages || goto :error
   cd ..
 
-  cd src/csharp/Grpc.IntegrationTesting.Client || goto :error
+  cd Grpc.IntegrationTesting.Client || goto :error
   %NUGET% restore -PackagesDirectory ../packages || goto :error
   cd ..
 
-  cd src/csharp/Grpc.IntegrationTesting.QpsWorker || goto :error
+  cd Grpc.IntegrationTesting.QpsWorker || goto :error
   %NUGET% restore -PackagesDirectory ../packages || goto :error
   cd ..
 
-  cd src/csharp/Grpc.IntegrationTesting.StressClient || goto :error
+  cd Grpc.IntegrationTesting.StressClient || goto :error
   %NUGET% restore -PackagesDirectory ../packages || goto :error
   cd ..
 
-  cd src/csharp/Grpc.IntegrationTesting || goto :error
+  cd Grpc.IntegrationTesting || goto :error
   %NUGET% restore -PackagesDirectory ../packages || goto :error
-  cd ..
+
+  cd /d %~dp0\..\.. || goto :error
 )
 
 endlocal

--- a/tools/run_tests/pre_build_csharp.bat
+++ b/tools/run_tests/pre_build_csharp.bat
@@ -41,18 +41,18 @@ if exist %NUGET% (
   @rem Restore Grpc packages by packages since Nuget client 3.4.4 doesnt support restore
   @rem by solution
   %NUGET% restore vsprojects/grpc_csharp_ext.sln || goto :error
-  %NUGET% restore src/csharp/Grpc.Auth -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.Core -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.Core.Tests -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.Examples.MathClient -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.Examples.MathServer -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.Examples -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.HealthCheck.Tests -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.HealthCheck -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.IntegrationTesting.Client -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.IntegrationTesting.QpsWorker -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.IntegrationTesting.StressClient -PackagesDirectory src/csharp/packages || goto :error
-  %NUGET% restore src/csharp/Grpc.IntegrationTesting -PackagesDirectory src/csharp/packages || goto :error
+  %NUGET% restore src/csharp/Grpc.Auth -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
+  %NUGET% restore src/csharp/Grpc.Core -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
+  %NUGET% restore src/csharp/Grpc.Core.Tests -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
+  %NUGET% restore src/csharp/Grpc.Examples.MathClient -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
+  %NUGET% restore src/csharp/Grpc.Examples.MathServer -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
+  %NUGET% restore src/csharp/Grpc.Examples -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
+  %NUGET% restore src/csharp/Grpc.HealthCheck.Tests -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
+  %NUGET% restore src/csharp/Grpc.HealthCheck -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting.Client -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting.QpsWorker -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting.StressClient -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
+  %NUGET% restore src/csharp/Grpc.IntegrationTesting -PackagesDirectory src/csharp/packages -SolutionDirectory src/csharp || goto :error
 )
 
 endlocal

--- a/tools/run_tests/pre_build_csharp.sh
+++ b/tools/run_tests/pre_build_csharp.sh
@@ -39,16 +39,16 @@ if [ -x "$(command -v nuget)" ]
 then
   # Restoring Nuget packages by packages rather than by solution because of
   # inability to restore by solution with Nuget client 3.4.4
-  nuget restore Grpc.Auth -PackagesDirectory ./packages
-  nuget restore Grpc.Core.Tests -PackagesDirectory ./packages
-  nuget restore Grpc.Core -PackagesDirectory ./packages
-  nuget restore Grpc.Examples.MathClient -PackagesDirectory ./packages
-  nuget restore Grpc.Examples.MathServer -PackagesDirectory ./packages
-  nuget restore Grpc.Examples -PackagesDirectory ./packages
-  nuget restore Grpc.HealthCheck.Tests -PackagesDirectory ./packages
-  nuget restore Grpc.HealthCheck -PackagesDirectory ./packages
-  nuget restore Grpc.IntegrationTesting.Client -PackagesDirectory ./packages
-  nuget restore Grpc.IntegrationTesting.QpsWorker -PackagesDirectory ./packages
-  nuget restore Grpc.IntegrationTesting.StressClient -PackagesDirectory ./packages
-  nuget restore Grpc.IntegrationTesting -PackagesDirectory ./packages
+  nuget restore Grpc.Auth -PackagesDirectory ./packages -SolutionDirectory .
+  nuget restore Grpc.Core.Tests -PackagesDirectory ./packages -SolutionDirectory .
+  nuget restore Grpc.Core -PackagesDirectory ./packages -SolutionDirectory .
+  nuget restore Grpc.Examples.MathClient -PackagesDirectory ./packages -SolutionDirectory .
+  nuget restore Grpc.Examples.MathServer -PackagesDirectory ./packages -SolutionDirectory .
+  nuget restore Grpc.Examples -PackagesDirectory ./packages -SolutionDirectory .
+  nuget restore Grpc.HealthCheck.Tests -PackagesDirectory ./packages -SolutionDirectory .
+  nuget restore Grpc.HealthCheck -PackagesDirectory ./packages -SolutionDirectory .
+  nuget restore Grpc.IntegrationTesting.Client -PackagesDirectory ./packages -SolutionDirectory .
+  nuget restore Grpc.IntegrationTesting.QpsWorker -PackagesDirectory ./packages -SolutionDirectory .
+  nuget restore Grpc.IntegrationTesting.StressClient -PackagesDirectory ./packages -SolutionDirectory .
+  nuget restore Grpc.IntegrationTesting -PackagesDirectory ./packages -SolutionDirectory .
 fi

--- a/tools/run_tests/pre_build_csharp.sh
+++ b/tools/run_tests/pre_build_csharp.sh
@@ -37,5 +37,18 @@ root=`pwd`
 
 if [ -x "$(command -v nuget)" ]
 then
-  nuget restore Grpc.sln
+  # Restoring Nuget packages by packages rather than by solution because of
+  # inability to restore by solution with Nuget client 3.4.4
+  nuget restore Grpc.Auth -PackagesDirectory ./packages
+  nuget restore Grpc.Core.Tests -PackagesDirectory ./packages
+  nuget restore Grpc.Core -PackagesDirectory ./packages
+  nuget restore Grpc.Examples.MathClient -PackagesDirectory ./packages
+  nuget restore Grpc.Examples.MathServer -PackagesDirectory ./packages
+  nuget restore Grpc.Examples -PackagesDirectory ./packages
+  nuget restore Grpc.HealthCheck.Tests -PackagesDirectory ./packages
+  nuget restore Grpc.HealthCheck -PackagesDirectory ./packages
+  nuget restore Grpc.IntegrationTesting.Client -PackagesDirectory ./packages
+  nuget restore Grpc.IntegrationTesting.QpsWorker -PackagesDirectory ./packages
+  nuget restore Grpc.IntegrationTesting.StressClient -PackagesDirectory ./packages
+  nuget restore Grpc.IntegrationTesting -PackagesDirectory ./packages
 fi

--- a/tools/run_tests/pre_build_csharp.sh
+++ b/tools/run_tests/pre_build_csharp.sh
@@ -39,16 +39,52 @@ if [ -x "$(command -v nuget)" ]
 then
   # Restoring Nuget packages by packages rather than by solution because of
   # inability to restore by solution with Nuget client 3.4.4
-  nuget restore Grpc.Auth -PackagesDirectory ./packages -SolutionDirectory .
-  nuget restore Grpc.Core.Tests -PackagesDirectory ./packages -SolutionDirectory .
-  nuget restore Grpc.Core -PackagesDirectory ./packages -SolutionDirectory .
-  nuget restore Grpc.Examples.MathClient -PackagesDirectory ./packages -SolutionDirectory .
-  nuget restore Grpc.Examples.MathServer -PackagesDirectory ./packages -SolutionDirectory .
-  nuget restore Grpc.Examples -PackagesDirectory ./packages -SolutionDirectory .
-  nuget restore Grpc.HealthCheck.Tests -PackagesDirectory ./packages -SolutionDirectory .
-  nuget restore Grpc.HealthCheck -PackagesDirectory ./packages -SolutionDirectory .
-  nuget restore Grpc.IntegrationTesting.Client -PackagesDirectory ./packages -SolutionDirectory .
-  nuget restore Grpc.IntegrationTesting.QpsWorker -PackagesDirectory ./packages -SolutionDirectory .
-  nuget restore Grpc.IntegrationTesting.StressClient -PackagesDirectory ./packages -SolutionDirectory .
-  nuget restore Grpc.IntegrationTesting -PackagesDirectory ./packages -SolutionDirectory .
+  # Moving into each directory to let the restores work with nuget 3.4 and 2.8
+  cd Grpc.Auth
+  nuget restore -PackagesDirectory ../packages
+  cd ..
+
+  cd Grpc.Core.Tests
+  nuget restore -PackagesDirectory ../packages
+  cd ..
+
+  cd Grpc.Core
+  nuget restore -PackagesDirectory ../packages
+  cd ..
+
+  cd Grpc.Examples.MathClient
+  nuget restore -PackagesDirectory ../packages
+  cd ..
+
+  cd Grpc.Examples.MathServer
+  nuget restore -PackagesDirectory ../packages
+  cd ..
+
+  cd Grpc.Examples
+  nuget restore -PackagesDirectory ../packages
+  cd ..
+
+  cd Grpc.HealthCheck.Tests
+  nuget restore -PackagesDirectory ../packages
+  cd ..
+
+  cd Grpc.HealthCheck
+  nuget restore -PackagesDirectory ../packages
+  cd ..
+
+  cd Grpc.IntegrationTesting.Client
+  nuget restore -PackagesDirectory ../packages
+  cd ..
+
+  cd Grpc.IntegrationTesting.QpsWorker
+  nuget restore -PackagesDirectory ../packages
+  cd ..
+
+  cd Grpc.IntegrationTesting.StressClient
+  nuget restore -PackagesDirectory ../packages
+  cd ..
+
+  cd Grpc.IntegrationTesting
+  nuget restore -PackagesDirectory ../packages
+  cd ..
 fi


### PR DESCRIPTION
Attempt to migrate the tests over to the new nuget client, which doesn't support solution package restores anymore.