### PR TITLE
Build the Node health-check package in the build_packages script

### DIFF
--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -49,7 +49,12 @@ cp grpc-*.tgz $artifacts/grpc.tgz
 
 mkdir -p bin
 
-cd src/node/tools
+cd $base/src/node/health_check
+npm update
+npm pack
+cp grpc-health-check-*.tgz $artifacts/
+
+cd $base/src/node/tools
 npm update
 npm pack
 cp grpc-tools-*.tgz $artifacts/


### PR DESCRIPTION
The script should build all of the node packages that need to be published, but it doesn't currently build the health-check package, which was recently created.