### PR TITLE
Shrink a stack-allocated array to avoid giant frame

### DIFF
--- a/src/core/lib/iomgr/tcp_posix.c
+++ b/src/core/lib/iomgr/tcp_posix.c
@@ -284,7 +284,7 @@ static void tcp_read(grpc_exec_ctx *exec_ctx, grpc_endpoint *ep,
 }
 
 /* returns true if done, false if pending; if returning true, *error is set */
-#define MAX_WRITE_IOVEC 1024
+#define MAX_WRITE_IOVEC 1000
 static bool tcp_flush(grpc_tcp *tcp, grpc_error **error) {
   struct msghdr msg;
   struct iovec iov[MAX_WRITE_IOVEC];


### PR DESCRIPTION
Some compilers don't like stack frames above a certain size, and this array size is too big (since #6737). There is no reason for it to be a power of 2, so slight shrinkage to help make it fit.

Cc @ctiller @markdroth 
