### PR TITLE
Update node protobuf dependency to 3.0.0 where applicable. Also update example dependency to grpc 1.0.0

### DIFF
--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "dependencies": {
     "async": "^1.5.2",
-    "google-protobuf": "^3.0.0-alpha.5",
-    "grpc": "^0.14.0",
+    "google-protobuf": "^3.0.0",
+    "grpc": "^1.0.0",
     "lodash": "^4.6.1",
     "minimist": "^1.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "async": "^1.5.0",
     "google-auth-library": "^0.9.2",
-    "google-protobuf": "^3.0.0-alpha.5",
+    "google-protobuf": "^3.0.0",
     "istanbul": "^0.3.21",
     "jsdoc": "^3.3.2",
     "jshint": "^2.5.0",

--- a/src/node/health_check/package.json
+++ b/src/node/health_check/package.json
@@ -15,9 +15,9 @@
     }
   ],
   "dependencies": {
-    "grpc": "^0.15.0",
+    "grpc": "^1.0.0-pre1",
     "lodash": "^3.9.3",
-    "google-protobuf": "^3.0.0-alpha.5"
+    "google-protobuf": "^3.0.0"
   },
   "files": [
     "LICENSE",

--- a/src/node/health_check/package.json
+++ b/src/node/health_check/package.json
@@ -15,7 +15,7 @@
     }
   ],
   "dependencies": {
-    "grpc": "^1.0.0-pre1",
+    "grpc": "^1.0.0-pre2",
     "lodash": "^3.9.3",
     "google-protobuf": "^3.0.0"
   },

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -37,7 +37,7 @@
     "devDependencies": {
       "async": "^1.5.0",
       "google-auth-library": "^0.9.2",
-      "google-protobuf": "^3.0.0-alpha.5",
+      "google-protobuf": "^3.0.0",
       "istanbul": "^0.3.21",
       "jsdoc": "^3.3.2",
       "jshint": "^2.5.0",

--- a/templates/src/node/health_check/package.json.template
+++ b/templates/src/node/health_check/package.json.template
@@ -17,9 +17,9 @@
       }
     ],
     "dependencies": {
-      "grpc": "^0.15.0",
+      "grpc": "^${settings.node_version}",
       "lodash": "^3.9.3",
-      "google-protobuf": "^3.0.0-alpha.5"
+      "google-protobuf": "^3.0.0"
     },
     "files": [
       "LICENSE",


### PR DESCRIPTION
This also makes the health-check package dependency match the version of gRPC that it's published along with.