### PR TITLE
add ruby cpu timer and usage timing in benchmarks

### DIFF
--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -50,6 +50,7 @@
 #include "rb_server.h"
 #include "rb_server_credentials.h"
 #include "rb_compression_options.h"
+#include "rb_usage_timer.h"
 
 static VALUE grpc_rb_cTimeVal = Qnil;
 
@@ -334,4 +335,5 @@ void Init_grpc_c() {
   Init_grpc_status_codes();
   Init_grpc_time_consts();
   Init_grpc_compression_options();
+  Init_grpc_usage_timer();
 }

--- a/src/ruby/ext/grpc/rb_usage_timer.c
+++ b/src/ruby/ext/grpc/rb_usage_timer.c
@@ -92,8 +92,8 @@ static VALUE grpc_rb_usage_timer_reset(VALUE self) {
   gettimeofday(&usage_timer->start_wall_time, NULL);
   getrusage(RUSAGE_SELF, &usage_timer->start_cpu_time);
 
-  usage_timer->last_sample_wall_time = usage_timer->last_sample_wall_time;
-  usage_timer->last_sample_cpu_time = usage_timer->last_sample_cpu_time;
+  usage_timer->last_sample_wall_time = usage_timer->start_wall_time;
+  usage_timer->last_sample_cpu_time = usage_timer->start_cpu_time;
 
   return self;
 }

--- a/src/ruby/ext/grpc/rb_usage_timer.c
+++ b/src/ruby/ext/grpc/rb_usage_timer.c
@@ -1,0 +1,162 @@
+/*
+ *
+ * Copyright 2015, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <ruby/ruby.h>
+
+#include "rb_grpc_imports.generated.h"
+#include "rb_usage_timer.h"
+
+#include <grpc/grpc.h>
+
+#include <grpc/support/time.h>
+#include <grpc/impl/codegen/alloc.h>
+#include <sys/resource.h>
+#include <sys/time.h>
+
+#include "rb_grpc.h"
+
+typedef struct grpc_rb_usage_timer {
+  struct timeval start_wall_time;
+  struct rusage start_cpu_time;
+  struct timeval last_sample_wall_time;
+  struct rusage last_sample_cpu_time;
+} grpc_rb_usage_timer;
+
+/* Timer class for getting elapsed wall, user, and system times. */
+
+static VALUE grpc_rb_cUsageTimer = Qnil;
+
+static void grpc_rb_usage_timer_free(void *p) {
+  xfree(p);
+}
+
+/* Ruby recognized data type for the UsageTimer class. */
+static rb_data_type_t grpc_rb_usage_timer_data_type = {
+    "grpc_usage_timer",
+    {NULL,
+     grpc_rb_usage_timer_free,
+     GRPC_RB_MEMSIZE_UNAVAILABLE,
+     {NULL, NULL}},
+    NULL,
+    NULL,
+#ifdef RUBY_TYPED_FREE_IMMEDIATELY
+    RUBY_TYPED_FREE_IMMEDIATELY
+#endif
+};
+
+/* Allocates UsageTimer instances. */
+static VALUE grpc_rb_usage_timer_alloc(VALUE cls) {
+  grpc_rb_usage_timer *usage_timer =
+      gpr_malloc(sizeof(grpc_rb_usage_timer));
+
+  return TypedData_Wrap_Struct(cls, &grpc_rb_usage_timer_data_type, usage_timer);
+}
+
+/* Resets the wall, and cpu times to the current elapsed times. */
+static VALUE grpc_rb_usage_timer_reset(VALUE self) {
+  grpc_rb_usage_timer* usage_timer = NULL;
+
+  TypedData_Get_Struct(self, grpc_rb_usage_timer,
+                       &grpc_rb_usage_timer_data_type, usage_timer);
+
+  gettimeofday(&usage_timer->start_wall_time, NULL);
+  getrusage(RUSAGE_SELF, &usage_timer->start_cpu_time);
+
+  usage_timer->last_sample_wall_time = usage_timer->last_sample_wall_time;
+  usage_timer->last_sample_cpu_time = usage_timer->last_sample_cpu_time;
+
+  return self;
+}
+
+/* Calculates the differences between time vals in seconds */
+static double grpc_rb_time_diff(struct timeval earlier_time_val, struct timeval later_time_val) {
+  struct timeval diff;
+
+  diff.tv_sec = later_time_val.tv_sec - earlier_time_val.tv_sec;
+  diff.tv_usec = later_time_val.tv_usec - earlier_time_val.tv_usec;
+
+  return diff.tv_sec + diff.tv_usec * 1e-6;
+}
+
+/* Sample the wall, user, and system time. Returns a hash containing the elapsed
+ * time of each type since the last reset, or object creation. */
+static VALUE grpc_rb_usage_timer_sample(VALUE self) {
+  grpc_rb_usage_timer* usage_timer = NULL;
+  double elapsed_wall_time;
+  double elapsed_user_time;
+  double elapsed_system_time;
+  VALUE time_sample_hash = Qnil;
+
+  TypedData_Get_Struct(self, grpc_rb_usage_timer,
+                       &grpc_rb_usage_timer_data_type, usage_timer);
+
+  gettimeofday(&usage_timer->last_sample_wall_time, NULL);
+  getrusage(RUSAGE_SELF, &usage_timer->last_sample_cpu_time);
+
+  elapsed_wall_time = grpc_rb_time_diff(usage_timer->start_wall_time, usage_timer->last_sample_wall_time);
+  elapsed_user_time = grpc_rb_time_diff(usage_timer->start_cpu_time.ru_utime, usage_timer->last_sample_cpu_time.ru_utime);
+  elapsed_system_time = grpc_rb_time_diff(usage_timer->start_cpu_time.ru_stime, usage_timer->last_sample_cpu_time.ru_stime);
+
+  time_sample_hash = rb_hash_new();
+
+  rb_hash_aset(time_sample_hash, rb_str_new2("wall_time"), rb_float_new(elapsed_wall_time));
+  rb_hash_aset(time_sample_hash, rb_str_new2("user_time"), rb_float_new(elapsed_user_time));
+  rb_hash_aset(time_sample_hash, rb_str_new2("system_time"), rb_float_new(elapsed_system_time));
+
+  return time_sample_hash;
+}
+
+/* Initilize UsageTimer class and start the timers. */
+static VALUE grpc_rb_usage_timer_init(VALUE self) {
+  grpc_rb_usage_timer_reset(self);
+
+  return self;
+}
+
+void Init_grpc_usage_timer() {
+  grpc_rb_cUsageTimer = rb_define_class_under(
+      grpc_rb_mGrpcCore, "UsageTimer", rb_cObject);
+
+  /* Allocates an object managed by the ruby runtime. */
+  rb_define_alloc_func(grpc_rb_cUsageTimer,
+                       grpc_rb_usage_timer_alloc);
+
+  rb_define_method(grpc_rb_cUsageTimer, "initialize",
+                   grpc_rb_usage_timer_init, 0);
+
+  rb_define_method(grpc_rb_cUsageTimer, "reset",
+                   grpc_rb_usage_timer_reset, 0);
+
+  rb_define_method(grpc_rb_cUsageTimer, "sample",
+                   grpc_rb_usage_timer_sample, 0);
+}

--- a/src/ruby/ext/grpc/rb_usage_timer.h
+++ b/src/ruby/ext/grpc/rb_usage_timer.h
@@ -1,0 +1,44 @@
+/*
+ *
+ * Copyright 2015, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef GRPC_RB_TIME_USAGE_H_
+#define GRPC_RB_TIME_USAGE_H_
+
+#include <ruby/ruby.h>
+
+#include <grpc/grpc.h>
+
+/* Initializes the usage timer ruby class. */
+void Init_grpc_usage_timer();
+
+#endif /* GRPC_RB_TIME_USAGE_H_ */

--- a/src/ruby/qps/client.rb
+++ b/src/ruby/qps/client.rb
@@ -153,11 +153,12 @@ class BenchmarkClient
       sum_of_squares: @histogram.sum_of_squares,
       count: @histogram.count
     )
+    time_samples = @timer.sample
+
     if reset
       @histogram = Histogram.new(@histres, @histmax)
       @timer.reset
     end
-    time_samples = @timer.sample
 
     Grpc::Testing::ClientStats.new(
       latencies: lat,

--- a/src/ruby/qps/server.rb
+++ b/src/ruby/qps/server.rb
@@ -82,15 +82,14 @@ class BenchmarkServer
     t.abort_on_exception
   end
   def mark(reset)
-    @timer.reset if reset
     time_samples = @timer.sample
 
-    s = Grpc::Testing::ServerStats.new(
+    @timer.reset if reset
+
+    Grpc::Testing::ServerStats.new(
       time_elapsed: time_samples['wall_time'],
       time_user: time_samples['user_time'],
       time_system: time_samples['system_time'])
-
-    s
   end
   def get_port
     @port

--- a/src/ruby/qps/server.rb
+++ b/src/ruby/qps/server.rb
@@ -74,16 +74,22 @@ class BenchmarkServer
     @server = GRPC::RpcServer.new
     @port = @server.add_http2_port("0.0.0.0:" + port.to_s, cred)
     @server.handle(BenchmarkServiceImpl.new)
-    @start_time = Time.now
+    @timer = GRPC::Core::UsageTimer.new
+
     t = Thread.new {
       @server.run
     }
     t.abort_on_exception
   end
   def mark(reset)
-    s = Grpc::Testing::ServerStats.new(time_elapsed:
-                                       (Time.now-@start_time).to_f)
-    @start_time = Time.now if reset
+    @timer.reset if reset
+    time_samples = @timer.sample
+
+    s = Grpc::Testing::ServerStats.new(
+      time_elapsed: time_samples['wall_time'],
+      time_user: time_samples['user_time'],
+      time_system: time_samples['system_time'])
+
     s
   end
   def get_port

--- a/src/ruby/spec/usage_timer_spec.rb
+++ b/src/ruby/spec/usage_timer_spec.rb
@@ -30,12 +30,12 @@
 require 'grpc'
 
 describe GRPC::Core::UsageTimer do
-  it "can be initialized without error" do
+  it 'can be initialized without error' do
     expect { GRPC::Core::UsageTimer.new }.to_not raise_error
   end
 
-  describe "main call pattern" do
-    it "samples the user time, system time, and wall time" do
+  describe 'main call pattern' do
+    it 'samples the user time, system time, and wall time' do
       usage_timer = GRPC::Core::UsageTimer.new
 
       samples = usage_timer.sample
@@ -45,21 +45,23 @@ describe GRPC::Core::UsageTimer do
       expect(samples['system_time']).to be_instance_of(Float)
     end
 
-    it "can be reset without error" do
+    it 'can be reset without error' do
       usage_timer = GRPC::Core::UsageTimer.new
       expect { usage_timer.reset }.to_not raise_error
     end
 
-    it "consecutive samples can only increase" do
+    it 'consecutive samples can only increase' do
       usage_timer = GRPC::Core::UsageTimer.new
 
       first_sample = usage_timer.sample
       second_sample = usage_timer.sample
 
-      expect(second_sample['wall_time'] >= first_sample['wall_time']).to be true
-      expect(second_sample['user_time'] >= first_sample['user_time']).to be true
-      expect(second_sample['system_time'] >= first_sample['system_time']).to be true
+      expect(second_sample['wall_time'] >=
+               first_sample['wall_time']).to be true
+      expect(second_sample['user_time'] >=
+               first_sample['user_time']).to be true
+      expect(second_sample['system_time'] >=
+               first_sample['system_time']).to be true
     end
   end
 end
-

--- a/src/ruby/spec/usage_timer_spec.rb
+++ b/src/ruby/spec/usage_timer_spec.rb
@@ -1,0 +1,65 @@
+# Copyright 2015, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'grpc'
+
+describe GRPC::Core::UsageTimer do
+  it "can be initialized without error" do
+    expect { GRPC::Core::UsageTimer.new }.to_not raise_error
+  end
+
+  describe "main call pattern" do
+    it "samples the user time, system time, and wall time" do
+      usage_timer = GRPC::Core::UsageTimer.new
+
+      samples = usage_timer.sample
+
+      expect(samples['wall_time']).to be_instance_of(Float)
+      expect(samples['user_time']).to be_instance_of(Float)
+      expect(samples['system_time']).to be_instance_of(Float)
+    end
+
+    it "can be reset without error" do
+      usage_timer = GRPC::Core::UsageTimer.new
+      expect { usage_timer.reset }.to_not raise_error
+    end
+
+    it "consecutive samples can only increase" do
+      usage_timer = GRPC::Core::UsageTimer.new
+
+      first_sample = usage_timer.sample
+      second_sample = usage_timer.sample
+
+      expect(second_sample['wall_time'] >= first_sample['wall_time']).to be true
+      expect(second_sample['user_time'] >= first_sample['user_time']).to be true
+      expect(second_sample['system_time'] >= first_sample['system_time']).to be true
+    end
+  end
+end
+


### PR DESCRIPTION
This adds a UsageTimer ruby class, and cpu user and system timing in the benchmarks. I tested it manually using ruby sleep method, and results made sense when compared it to unix time command.

When used in the benchmarks, results also seem to make sense, with the client and server user and system times being very large next to the wall times, especially on the server side doing more in parrallel.

Meant to be similar to a ruby version of the c++ UsageTimer in tests/cpp/qps/usage_timer.h, and using a similar usage of it in the benchmark "mark" methods.

Note that this adds it the timer to the public classes, but could change this to be used only for tests
