### PR TITLE
Don't assert if we're not able to set CPU affinity

### DIFF
--- a/test/cpp/qps/limit_cores.cc
+++ b/test/cpp/qps/limit_cores.cc
@@ -68,9 +68,9 @@ int LimitCores(const int* cores, int cores_size) {
       cores_set++;
     }
   }
-  GPR_ASSERT(sched_setaffinity(0, size, cpup) == 0);
+  bool affinity_set = (sched_setaffinity(0, size, cpup) == 0);
   CPU_FREE(cpup);
-  return cores_set;
+  return affinity_set ? cores_set : num_cores;
 }
 
 }  // namespace testing


### PR DESCRIPTION
Instead just act like we never attempted to set affinity and return the total number of cores available. This will still give the correct statistics in the end. Motivated by downstream targets that may lack this feature.

Cc: @markdroth 
