### PR TITLE
Fix stack-use-after-scope in call.c

### DIFF
--- a/src/core/lib/surface/call.c
+++ b/src/core/lib/surface/call.c
@@ -1367,6 +1367,9 @@ static grpc_call_error call_start_batch(grpc_exec_ctx *exec_ctx,
   int num_completion_callbacks_needed = 1;
   grpc_call_error error = GRPC_CALL_OK;
 
+  // sent_initial_metadata guards against variable reuse.
+  grpc_metadata compression_md;
+
   GPR_TIMER_BEGIN("grpc_call_start_batch", 0);
 
   GRPC_CALL_LOG_BATCH(GPR_INFO, call, ops, nops, notify_tag);
@@ -1412,8 +1415,7 @@ static grpc_call_error call_start_batch(grpc_exec_ctx *exec_ctx,
           goto done_with_error;
         }
         /* process compression level */
-        grpc_metadata compression_md;
-        memset(&compression_md, 0, sizeof(grpc_metadata));
+        memset(&compression_md, 0, sizeof(compression_md));
         size_t additional_metadata_count = 0;
         grpc_compression_level effective_compression_level;
         bool level_set = false;


### PR DESCRIPTION
AddressSanitizer detects stack-use-after-scope bug.
This means that variable was used at a point when compiler assume that it's
dead.

Here compression_md lifetime is limited by switch scope. However implementation
of execute_op below will access it outside the scope.