### PR TITLE
Better client-side ending for QPS tests

### DIFF
--- a/test/cpp/qps/client.h
+++ b/test/cpp/qps/client.h
@@ -169,6 +169,7 @@ class Client {
   // Must call AwaitThreadsCompletion before destructor to avoid a race
   // between destructor and invocation of virtual ThreadFunc
   void AwaitThreadsCompletion() {
+    gpr_atm_rel_store(&thread_pool_done_, static_cast<gpr_atm>(1));
     DestroyMultithreading();
     std::unique_lock<std::mutex> g(thread_completion_mu_);
     while (threads_remaining_ != 0) {
@@ -180,6 +181,7 @@ class Client {
   bool closed_loop_;
 
   void StartThreads(size_t num_threads) {
+    gpr_atm_rel_store(&thread_pool_done_, static_cast<gpr_atm>(0));
     threads_remaining_ = num_threads;
     for (size_t i = 0; i < num_threads; i++) {
       threads_.emplace_back(new Thread(this, i));
@@ -241,16 +243,11 @@ class Client {
   class Thread {
    public:
     Thread(Client* client, size_t idx)
-        : done_(false),
-          client_(client),
+        : client_(client),
           idx_(idx),
           impl_(&Thread::ThreadFunc, this) {}
 
     ~Thread() {
-      {
-        std::lock_guard<std::mutex> g(mu_);
-        done_ = true;
-      }
       impl_.join();
     }
 
@@ -280,11 +277,14 @@ class Client {
         if (entry.used()) {
           histogram_.Add(entry.value());
         }
+	bool done = false;
         if (!thread_still_ok) {
           gpr_log(GPR_ERROR, "Finishing client thread due to RPC error");
-          done_ = true;
+          done = true;
         }
-        if (done_) {
+	done = done || (gpr_atm_acq_load(&client_->thread_pool_done_) !=
+			static_cast<gpr_atm>(0));
+        if (done) {
           client_->CompleteThread();
           return;
         }
@@ -292,7 +292,6 @@ class Client {
     }
 
     std::mutex mu_;
-    bool done_;
     Histogram histogram_;
     Client* client_;
     const size_t idx_;
@@ -305,6 +304,7 @@ class Client {
   InterarrivalTimer interarrival_timer_;
   std::vector<gpr_timespec> next_time_;
 
+  gpr_atm thread_pool_done_;
   std::mutex thread_completion_mu_;
   size_t threads_remaining_;
   std::condition_variable threads_complete_;

--- a/test/cpp/qps/client.h
+++ b/test/cpp/qps/client.h
@@ -244,13 +244,9 @@ class Client {
   class Thread {
    public:
     Thread(Client* client, size_t idx)
-        : client_(client),
-          idx_(idx),
-          impl_(&Thread::ThreadFunc, this) {}
+        : client_(client), idx_(idx), impl_(&Thread::ThreadFunc, this) {}
 
-    ~Thread() {
-      impl_.join();
-    }
+    ~Thread() { impl_.join(); }
 
     void BeginSwap(Histogram* n) {
       std::lock_guard<std::mutex> g(mu_);
@@ -278,13 +274,13 @@ class Client {
         if (entry.used()) {
           histogram_.Add(entry.value());
         }
-	bool done = false;
+        bool done = false;
         if (!thread_still_ok) {
           gpr_log(GPR_ERROR, "Finishing client thread due to RPC error");
           done = true;
         }
-	done = done || (gpr_atm_acq_load(&client_->thread_pool_done_) !=
-			static_cast<gpr_atm>(0));
+        done = done || (gpr_atm_acq_load(&client_->thread_pool_done_) !=
+                        static_cast<gpr_atm>(0));
         if (done) {
           client_->CompleteThread();
           return;

--- a/test/cpp/qps/client.h
+++ b/test/cpp/qps/client.h
@@ -179,6 +179,7 @@ class Client {
 
  protected:
   bool closed_loop_;
+  gpr_atm thread_pool_done_;
 
   void StartThreads(size_t num_threads) {
     gpr_atm_rel_store(&thread_pool_done_, static_cast<gpr_atm>(0));
@@ -304,7 +305,6 @@ class Client {
   InterarrivalTimer interarrival_timer_;
   std::vector<gpr_timespec> next_time_;
 
-  gpr_atm thread_pool_done_;
   std::mutex thread_completion_mu_;
   size_t threads_remaining_;
   std::condition_variable threads_complete_;

--- a/test/cpp/qps/client_sync.cc
+++ b/test/cpp/qps/client_sync.cc
@@ -79,10 +79,29 @@ class SynchronousClient
   virtual ~SynchronousClient(){};
 
  protected:
-  void WaitToIssue(int thread_idx) {
+  // WaitToIssue returns false if we realize that we need to break out
+  bool WaitToIssue(int thread_idx) {
     if (!closed_loop_) {
-      gpr_sleep_until(NextIssueTime(thread_idx));
+      gpr_timespec next_issue_time = NextIssueTime(thread_idx);
+      // Avoid sleeping for too long continuously because we might
+      // need to terminate before then. This is an issue since
+      // exponential distribution can occasionally produce bad outliers
+      while (true) {
+	gpr_timespec one_sec_delay =
+	  gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
+		       gpr_time_from_seconds(1, GPR_TIMESPAN));
+	if (gpr_time_cmp(next_issue_time, one_sec_delay) <= 0) {
+	  gpr_sleep_until(next_issue_time);
+	  return true;
+	} else {
+	  gpr_sleep_until(one_sec_delay);
+	  if (gpr_atm_acq_load(&thread_pool_done_) != static_cast<gpr_atm>(0)) {
+	    return false;
+	  }
+	}
+      }
     }
+    return true;
   }
 
   size_t num_threads_;
@@ -101,7 +120,9 @@ class SynchronousUnaryClient GRPC_FINAL : public SynchronousClient {
   ~SynchronousUnaryClient() {}
 
   bool ThreadFunc(HistogramEntry* entry, size_t thread_idx) GRPC_OVERRIDE {
-    WaitToIssue(thread_idx);
+    if (!WaitToIssue(thread_idx)) {
+      return true;
+    }
     auto* stub = channels_[thread_idx % channels_.size()].get_stub();
     double start = UsageTimer::Now();
     GPR_TIMER_SCOPE("SynchronousUnaryClient::ThreadFunc", 0);
@@ -144,7 +165,9 @@ class SynchronousStreamingClient GRPC_FINAL : public SynchronousClient {
   }
 
   bool ThreadFunc(HistogramEntry* entry, size_t thread_idx) GRPC_OVERRIDE {
-    WaitToIssue(thread_idx);
+    if (!WaitToIssue(thread_idx)) {
+      return true;
+    }
     GPR_TIMER_SCOPE("SynchronousStreamingClient::ThreadFunc", 0);
     double start = UsageTimer::Now();
     if (stream_[thread_idx]->Write(request_) &&

--- a/test/cpp/qps/client_sync.cc
+++ b/test/cpp/qps/client_sync.cc
@@ -87,18 +87,18 @@ class SynchronousClient
       // need to terminate before then. This is an issue since
       // exponential distribution can occasionally produce bad outliers
       while (true) {
-	gpr_timespec one_sec_delay =
-	  gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
-		       gpr_time_from_seconds(1, GPR_TIMESPAN));
-	if (gpr_time_cmp(next_issue_time, one_sec_delay) <= 0) {
-	  gpr_sleep_until(next_issue_time);
-	  return true;
-	} else {
-	  gpr_sleep_until(one_sec_delay);
-	  if (gpr_atm_acq_load(&thread_pool_done_) != static_cast<gpr_atm>(0)) {
-	    return false;
-	  }
-	}
+        gpr_timespec one_sec_delay =
+            gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
+                         gpr_time_from_seconds(1, GPR_TIMESPAN));
+        if (gpr_time_cmp(next_issue_time, one_sec_delay) <= 0) {
+          gpr_sleep_until(next_issue_time);
+          return true;
+        } else {
+          gpr_sleep_until(one_sec_delay);
+          if (gpr_atm_acq_load(&thread_pool_done_) != static_cast<gpr_atm>(0)) {
+            return false;
+          }
+        }
       }
     }
     return true;

--- a/test/cpp/qps/client_sync.cc
+++ b/test/cpp/qps/client_sync.cc
@@ -82,12 +82,12 @@ class SynchronousClient
   // WaitToIssue returns false if we realize that we need to break out
   bool WaitToIssue(int thread_idx) {
     if (!closed_loop_) {
-      gpr_timespec next_issue_time = NextIssueTime(thread_idx);
+      const gpr_timespec next_issue_time = NextIssueTime(thread_idx);
       // Avoid sleeping for too long continuously because we might
       // need to terminate before then. This is an issue since
       // exponential distribution can occasionally produce bad outliers
       while (true) {
-        gpr_timespec one_sec_delay =
+        const gpr_timespec one_sec_delay =
             gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
                          gpr_time_from_seconds(1, GPR_TIMESPAN));
         if (gpr_time_cmp(next_issue_time, one_sec_delay) <= 0) {


### PR DESCRIPTION
With lots of threads, I've seen this take as long as 2 hours to actually terminate an open-loop client test and even several minutes to terminate a closed-loop test. This change does two things: parallelize shutdown notification/detection at client threads, and never allow an open-loop test to sleep for more than a second during termination (since exponential dist will occasionally produce truly heavy tails).
