### PR TITLE
Fix jenkins linux image in create script

### DIFF
--- a/tools/gce/create_linux_worker.sh
+++ b/tools/gce/create_linux_worker.sh
@@ -43,8 +43,8 @@ gcloud compute instances create $INSTANCE_NAME \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
     --machine-type n1-standard-8 \
-    --image-family=ubuntu-1510 \
-    --image-project=ubuntu-os-cloud \
+    --image=ubuntu-1510 \
+    --image-project=grpc-testing \
     --boot-disk-size 1000
 
 echo 'Created GCE instance, waiting 60 seconds for it to come online.'


### PR DESCRIPTION
The public ubuntu 15.10 image has been deprecated on gcloud. I created a clone of it in our grpc-testing project. Updating the create_linux_worker script