### PR TITLE
Extend the deadline of objc-examples-build to 30 minutes

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -706,7 +706,7 @@ class ObjCLanguage(object):
                                  shortname='objc-tests',
                                  environ=_FORCE_ENVIRON_FOR_WRAPPERS),
             self.config.job_spec(['src/objective-c/tests/build_example_test.sh'],
-                                 timeout_seconds=15*60,
+                                 timeout_seconds=30*60,
                                  shortname='objc-examples-build',
                                  environ=_FORCE_ENVIRON_FOR_WRAPPERS)]
 


### PR DESCRIPTION
objc-examples-build on Jenkins are failing partly due to the mac computers slowing down when load is high, which produce timeout on objc-examples-build. Doubling the timeout may well solve this problem.

The build period of grpc_master_test is also extended to 1 hr.