### PR TITLE
add all runtime nodes back into testing packages

### DIFF
--- a/src/csharp/Grpc.Examples.MathClient/project.json
+++ b/src/csharp/Grpc.Examples.MathClient/project.json
@@ -42,6 +42,11 @@
       }
     }
   },
+  "runtimes": {
+    "win7-x64": { },
+    "debian.8-x64": { },
+    "osx.10.11-x64": { }
+  },
 
   "dependencies": {
     "Grpc.Examples": {

--- a/src/csharp/Grpc.Examples.MathServer/project.json
+++ b/src/csharp/Grpc.Examples.MathServer/project.json
@@ -42,6 +42,11 @@
       }
     }
   },
+  "runtimes": {
+    "win7-x64": { },
+    "debian.8-x64": { },
+    "osx.10.11-x64": { }
+  },
 
   "dependencies": {
     "Grpc.Examples": {

--- a/src/csharp/Grpc.Examples/project.json
+++ b/src/csharp/Grpc.Examples/project.json
@@ -20,11 +20,12 @@
         "System.IO": ""
       }
     },
-    "netstandard1.5": {
+    "netcoreapp1.0": {
       "imports": [
         "portable-net45"
       ],
       "dependencies": {
+        "Microsoft.NETCore.App": "1.0.0",
         "NETStandard.Library": "1.6.0"
       }
     }

--- a/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json
@@ -44,6 +44,11 @@
       }
     }
   },
+  "runtimes": {
+    "win7-x64": { },
+    "debian.8-x64": { },
+    "osx.10.11-x64": { }
+  },
 
   "dependencies": {
     "Grpc.IntegrationTesting": {

--- a/src/csharp/Grpc.IntegrationTesting.StressClient/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.StressClient/project.json
@@ -44,6 +44,11 @@
       }
     }
   },
+  "runtimes": {
+    "win7-x64": { },
+    "debian.8-x64": { },
+    "osx.10.11-x64": { }
+  },
 
   "dependencies": {
     "Grpc.IntegrationTesting": {

--- a/templates/src/csharp/Grpc.Examples.MathClient/project.json.template
+++ b/templates/src/csharp/Grpc.Examples.MathClient/project.json.template
@@ -1,7 +1,7 @@
 %YAML 1.2
 --- |
   {
-    <%include file="../build_options.include" args="executable=True,includeRuntimes=False"/>
+    <%include file="../build_options.include" args="executable=True"/>
     "dependencies": {
       "Grpc.Examples": {
         "target": "project"

--- a/templates/src/csharp/Grpc.Examples.MathServer/project.json.template
+++ b/templates/src/csharp/Grpc.Examples.MathServer/project.json.template
@@ -1,7 +1,7 @@
 %YAML 1.2
 --- |
   {
-    <%include file="../build_options.include" args="executable=True,includeRuntimes=False"/>
+    <%include file="../build_options.include" args="executable=True"/>
     "dependencies": {
       "Grpc.Examples": {
         "target": "project"

--- a/templates/src/csharp/Grpc.Examples/project.json.template
+++ b/templates/src/csharp/Grpc.Examples/project.json.template
@@ -15,11 +15,12 @@
           "System.IO": ""
         }
       },
-      "netstandard1.5": {
+      "netcoreapp1.0": {
         "imports": [
           "portable-net45"
         ],
         "dependencies": {
+          "Microsoft.NETCore.App": "1.0.0",
           "NETStandard.Library": "1.6.0"
         }
       }

--- a/templates/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json.template
+++ b/templates/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json.template
@@ -1,7 +1,7 @@
 %YAML 1.2
 --- |
   {
-    <%include file="../build_options.include" args="executable=True,includeData=True,includeRuntimes=False"/>
+    <%include file="../build_options.include" args="executable=True,includeData=True"/>
     "dependencies": {
       "Grpc.IntegrationTesting": {
         "target": "project"

--- a/templates/src/csharp/Grpc.IntegrationTesting.StressClient/project.json.template
+++ b/templates/src/csharp/Grpc.IntegrationTesting.StressClient/project.json.template
@@ -1,7 +1,7 @@
 %YAML 1.2
 --- |
   {
-    <%include file="../build_options.include" args="executable=True,includeData=True,includeRuntimes=False"/>
+    <%include file="../build_options.include" args="executable=True,includeData=True"/>
     "dependencies": {
       "Grpc.IntegrationTesting": {
         "target": "project"

--- a/templates/src/csharp/build_options.include
+++ b/templates/src/csharp/build_options.include
@@ -1,4 +1,4 @@
-<%page args="executable=False,includeData=False,includeRuntimes=True"/>\
+<%page args="executable=False,includeData=False"/>\
 "buildOptions": {
   % if executable:
     "emitEntryPoint": true
@@ -52,10 +52,8 @@
     }
   },
   %endif
-  % if includeRuntimes:
   "runtimes": {
     "win7-x64": { },
     "debian.8-x64": { },
     "osx.10.11-x64": { }
   },
-  % endif


### PR DESCRIPTION
This reverts a workaround made in https://github.com/grpc/grpc/pull/7623, of taking the runtime nodes out of certain project.json files in order to build and run tests, and fixes the breaking of the build_csharp_coreclr.sh that was made in this change as a result. 

Changing the Grpc.Examples project to target netcoreapp1.0 instead of netstandard1.5 seems to fix the issue.

cc @jtattermusch 
cc @jskeet 