### PR TITLE
Don't get dependencies for Node grpc-health-check package build

### DIFF
--- a/tools/run_tests/build_package_node.sh
+++ b/tools/run_tests/build_package_node.sh
@@ -50,7 +50,6 @@ cp grpc-*.tgz $artifacts/grpc.tgz
 mkdir -p bin
 
 cd $base/src/node/health_check
-npm update
 npm pack
 cp grpc-health-check-*.tgz $artifacts/
 


### PR DESCRIPTION
This should fix the Node package build.