### PR TITLE
Objective-C and core end2end tests update for Cronet test

### DIFF
--- a/src/objective-c/tests/CoreCronetEnd2EndTests/CoreCronetEnd2EndTests.m
+++ b/src/objective-c/tests/CoreCronetEnd2EndTests/CoreCronetEnd2EndTests.m
@@ -69,6 +69,8 @@ typedef struct fullstack_secure_fixture_data {
   char *localaddr;
 } fullstack_secure_fixture_data;
 
+static char expected_target[] = "255.255.255.255:65535";
+
 static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
                                                                         grpc_channel_args *client_args, grpc_channel_args *server_args) {
   grpc_end2end_test_fixture f;
@@ -77,7 +79,9 @@ static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
   gpr_malloc(sizeof(fullstack_secure_fixture_data));
   memset(&f, 0, sizeof(f));
   
-  gpr_join_host_port(&ffd->localaddr, "localhost", port);
+  gpr_join_host_port(&ffd->localaddr, "127.0.0.1", port);
+  strcpy(expected_target, ffd->localaddr);
+  f.expected_target = expected_target;
   
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create(NULL);
@@ -124,19 +128,21 @@ static void chttp2_tear_down_secure_fullstack(grpc_end2end_test_fixture *f) {
 }
 
 static void cronet_init_client_simple_ssl_secure_fullstack(
-                                                           grpc_end2end_test_fixture *f, grpc_channel_args *client_args) {
-  grpc_arg ssl_name_override = {GRPC_ARG_STRING,
-    GRPC_SSL_TARGET_NAME_OVERRIDE_ARG,
-    {"foo.test.google.fr"}};
-  
-  grpc_channel_args *new_client_args =
-  grpc_channel_args_copy_and_add(client_args, &ssl_name_override, 1);
-  [Cronet setHttp2Enabled:YES];
-  [Cronet start];
+            grpc_end2end_test_fixture *f, grpc_channel_args *client_args) {
+  static bool done = false;
+  // TODO (makdharma): DO NOT CHECK IN THIS HACK!!!
+  if (!done) {
+    done = true;
+    [Cronet setHttp2Enabled:YES];
+    NSURL *url = [[[NSFileManager defaultManager]
+                   URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+    NSLog(@"Documents directory: %@", url);
+    [Cronet start];
+    [Cronet startNetLogToFile: @"Documents/cronet_netlog.json" logBytes:YES];
+  }
   cronet_engine *cronetEngine = [Cronet getGlobalEngine];
   
-  cronet_init_client_secure_fullstack(f, new_client_args, cronetEngine);
-  grpc_channel_args_destroy(new_client_args);
+  cronet_init_client_secure_fullstack(f, client_args, cronetEngine);
 }
 
 static int fail_server_auth_check(grpc_channel_args *server_args) {

--- a/test/core/end2end/end2end_tests.h
+++ b/test/core/end2end/end2end_tests.h
@@ -50,6 +50,7 @@ struct grpc_end2end_test_fixture {
   grpc_server *server;
   grpc_channel *client;
   void *fixture_data;
+  char *expected_target;
 };
 
 struct grpc_end2end_test_config {

--- a/test/core/end2end/fixtures/h2_census.c
+++ b/test/core/end2end/fixtures/h2_census.c
@@ -66,6 +66,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   return f;
 }

--- a/test/core/end2end/fixtures/h2_compress.c
+++ b/test/core/end2end/fixtures/h2_compress.c
@@ -70,6 +70,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack_compression(
   memset(&f, 0, sizeof(f));
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   return f;
 }

--- a/test/core/end2end/fixtures/h2_fakesec.c
+++ b/test/core/end2end/fixtures/h2_fakesec.c
@@ -61,6 +61,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   return f;
 }

--- a/test/core/end2end/fixtures/h2_fd.c
+++ b/test/core/end2end/fixtures/h2_fd.c
@@ -66,6 +66,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_socketpair(
   memset(&f, 0, sizeof(f));
   f.fixture_data = fixture_data;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   create_sockets(fixture_data->fd_pair);
 

--- a/test/core/end2end/fixtures/h2_full+pipe.c
+++ b/test/core/end2end/fixtures/h2_full+pipe.c
@@ -66,6 +66,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   return f;
 }

--- a/test/core/end2end/fixtures/h2_full+trace.c
+++ b/test/core/end2end/fixtures/h2_full+trace.c
@@ -66,6 +66,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   return f;
 }

--- a/test/core/end2end/fixtures/h2_full.c
+++ b/test/core/end2end/fixtures/h2_full.c
@@ -65,6 +65,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   return f;
 }

--- a/test/core/end2end/fixtures/h2_load_reporting.c
+++ b/test/core/end2end/fixtures/h2_load_reporting.c
@@ -68,6 +68,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_load_reporting(
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   return f;
 }

--- a/test/core/end2end/fixtures/h2_oauth2.c
+++ b/test/core/end2end/fixtures/h2_oauth2.c
@@ -114,6 +114,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   return f;
 }

--- a/test/core/end2end/fixtures/h2_proxy.c
+++ b/test/core/end2end/fixtures/h2_proxy.c
@@ -80,6 +80,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   return f;
 }

--- a/test/core/end2end/fixtures/h2_sockpair+trace.c
+++ b/test/core/end2end/fixtures/h2_sockpair+trace.c
@@ -90,6 +90,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_socketpair(
   memset(&f, 0, sizeof(f));
   f.fixture_data = sfd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   *sfd = grpc_iomgr_create_endpoint_pair("fixture", 65536);
 

--- a/test/core/end2end/fixtures/h2_sockpair.c
+++ b/test/core/end2end/fixtures/h2_sockpair.c
@@ -89,6 +89,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_socketpair(
   memset(&f, 0, sizeof(f));
   f.fixture_data = sfd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   *sfd = grpc_iomgr_create_endpoint_pair("fixture", 65536);
 

--- a/test/core/end2end/fixtures/h2_sockpair_1byte.c
+++ b/test/core/end2end/fixtures/h2_sockpair_1byte.c
@@ -89,6 +89,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_socketpair(
   memset(&f, 0, sizeof(f));
   f.fixture_data = sfd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   *sfd = grpc_iomgr_create_endpoint_pair("fixture", 1);
 

--- a/test/core/end2end/fixtures/h2_ssl.c
+++ b/test/core/end2end/fixtures/h2_ssl.c
@@ -65,6 +65,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   return f;
 }

--- a/test/core/end2end/fixtures/h2_ssl_cert.c
+++ b/test/core/end2end/fixtures/h2_ssl_cert.c
@@ -68,6 +68,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   return f;
 }

--- a/test/core/end2end/fixtures/h2_ssl_proxy.c
+++ b/test/core/end2end/fixtures/h2_ssl_proxy.c
@@ -97,6 +97,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_secure_fullstack(
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   return f;
 }

--- a/test/core/end2end/fixtures/h2_uds.c
+++ b/test/core/end2end/fixtures/h2_uds.c
@@ -71,6 +71,7 @@ static grpc_end2end_test_fixture chttp2_create_fixture_fullstack(
 
   f.fixture_data = ffd;
   f.cq = grpc_completion_queue_create(NULL);
+  f.expected_target = NULL;
 
   return f;
 }

--- a/test/core/end2end/tests/binary_metadata.c
+++ b/test/core/end2end/tests/binary_metadata.c
@@ -250,7 +250,8 @@ static void test_request_response_with_metadata_and_payload(
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr"));
   GPR_ASSERT(was_cancelled == 0);
   GPR_ASSERT(byte_buffer_eq_string(request_payload_recv, "hello world"));
   GPR_ASSERT(byte_buffer_eq_string(response_payload_recv, "hello you"));

--- a/test/core/end2end/tests/call_creds.c
+++ b/test/core/end2end/tests/call_creds.c
@@ -296,7 +296,8 @@ static void request_response_with_payload_and_call_creds(
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr"));
   GPR_ASSERT(was_cancelled == 0);
   GPR_ASSERT(byte_buffer_eq_string(request_payload_recv, "hello world"));
   GPR_ASSERT(byte_buffer_eq_string(response_payload_recv, "hello you"));

--- a/test/core/end2end/tests/compressed_payload.c
+++ b/test/core/end2end/tests/compressed_payload.c
@@ -244,7 +244,8 @@ static void request_for_disabled_algorithm(
   GPR_ASSERT(0 == strcmp(details, expected_details));
   gpr_free(expected_details);
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr"));
 
   gpr_free(details);
   grpc_metadata_array_destroy(&initial_metadata_recv);

--- a/test/core/end2end/tests/disappearing_server.c
+++ b/test/core/end2end/tests/disappearing_server.c
@@ -176,7 +176,8 @@ static void do_request_and_shutdown_server(grpc_end2end_test_fixture *f,
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr:1234"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f->expected_target ? f->expected_target : "foo.test.google.fr:1234"));
   GPR_ASSERT(was_cancelled == 1);
 
   gpr_free(details);

--- a/test/core/end2end/tests/graceful_server_shutdown.c
+++ b/test/core/end2end/tests/graceful_server_shutdown.c
@@ -192,7 +192,8 @@ static void test_early_server_shutdown_finishes_inflight_calls(
 
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr"));
   GPR_ASSERT(was_cancelled == 1);
 
   gpr_free(details);

--- a/test/core/end2end/tests/high_initial_seqno.c
+++ b/test/core/end2end/tests/high_initial_seqno.c
@@ -191,7 +191,8 @@ static void simple_request_body(grpc_end2end_test_fixture f) {
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr:1234"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr:1234"));
   GPR_ASSERT(was_cancelled == 1);
 
   gpr_free(details);

--- a/test/core/end2end/tests/hpack_size.c
+++ b/test/core/end2end/tests/hpack_size.c
@@ -342,7 +342,8 @@ static void simple_request_body(grpc_end2end_test_fixture f, size_t index) {
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr:1234"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr:1234"));
   GPR_ASSERT(was_cancelled == 1);
 
   gpr_free(details);

--- a/test/core/end2end/tests/idempotent_request.c
+++ b/test/core/end2end/tests/idempotent_request.c
@@ -204,7 +204,8 @@ static void simple_request_body(grpc_end2end_test_fixture f) {
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr:1234"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr:1234"));
   GPR_ASSERT(GRPC_INITIAL_METADATA_IDEMPOTENT_REQUEST == call_details.flags);
   GPR_ASSERT(was_cancelled == 1);
 

--- a/test/core/end2end/tests/invoke_large_request.c
+++ b/test/core/end2end/tests/invoke_large_request.c
@@ -229,7 +229,8 @@ static void test_invoke_large_request(grpc_end2end_test_config config) {
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr"));
   GPR_ASSERT(was_cancelled == 1);
 
   gpr_free(details);

--- a/test/core/end2end/tests/large_metadata.c
+++ b/test/core/end2end/tests/large_metadata.c
@@ -229,7 +229,8 @@ static void test_request_with_large_metadata(grpc_end2end_test_config config) {
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr"));
   GPR_ASSERT(was_cancelled == 0);
   GPR_ASSERT(byte_buffer_eq_string(request_payload_recv, "hello world"));
   GPR_ASSERT(contains_metadata(&request_metadata_recv, "key", meta.value));

--- a/test/core/end2end/tests/max_concurrent_streams.c
+++ b/test/core/end2end/tests/max_concurrent_streams.c
@@ -187,7 +187,8 @@ static void simple_request_body(grpc_end2end_test_fixture f) {
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr:1234"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr:1234"));
   GPR_ASSERT(was_cancelled == 1);
 
   gpr_free(details);

--- a/test/core/end2end/tests/max_message_length.c
+++ b/test/core/end2end/tests/max_message_length.c
@@ -203,7 +203,8 @@ static void test_max_message_length(grpc_end2end_test_config config) {
 
   GPR_ASSERT(status != GRPC_STATUS_OK);
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr:1234"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr:1234"));
   GPR_ASSERT(was_cancelled == 1);
   GPR_ASSERT(recv_payload == NULL);
 

--- a/test/core/end2end/tests/network_status_change.c
+++ b/test/core/end2end/tests/network_status_change.c
@@ -214,7 +214,8 @@ static void test_invoke_network_status_change(grpc_end2end_test_config config) {
   // Expected behavior of a RPC when network is lost.
   GPR_ASSERT(status == GRPC_STATUS_UNAVAILABLE);
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr"));
   GPR_ASSERT(was_cancelled == 0);
 
   gpr_free(details);

--- a/test/core/end2end/tests/payload.c
+++ b/test/core/end2end/tests/payload.c
@@ -222,7 +222,8 @@ static void request_response_with_payload(grpc_end2end_test_fixture f) {
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr"));
   GPR_ASSERT(was_cancelled == 0);
   GPR_ASSERT(byte_buffer_eq_string(request_payload_recv, "hello world"));
   GPR_ASSERT(byte_buffer_eq_string(response_payload_recv, "hello you"));

--- a/test/core/end2end/tests/registered_call.c
+++ b/test/core/end2end/tests/registered_call.c
@@ -188,7 +188,8 @@ static void simple_request_body(grpc_end2end_test_fixture f, void *rc) {
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr:1234"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr:1234"));
   GPR_ASSERT(was_cancelled == 1);
 
   gpr_free(details);

--- a/test/core/end2end/tests/request_with_payload.c
+++ b/test/core/end2end/tests/request_with_payload.c
@@ -210,7 +210,8 @@ static void test_invoke_request_with_payload(grpc_end2end_test_config config) {
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr"));
   GPR_ASSERT(was_cancelled == 0);
   GPR_ASSERT(byte_buffer_eq_string(request_payload_recv, "hello world"));
 

--- a/test/core/end2end/tests/server_finishes_request.c
+++ b/test/core/end2end/tests/server_finishes_request.c
@@ -185,7 +185,8 @@ static void simple_request_body(grpc_end2end_test_fixture f) {
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr:1234"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr:1234"));
   GPR_ASSERT(was_cancelled == 1);
 
   gpr_free(details);

--- a/test/core/end2end/tests/shutdown_finishes_calls.c
+++ b/test/core/end2end/tests/shutdown_finishes_calls.c
@@ -173,7 +173,8 @@ static void test_early_server_shutdown_finishes_inflight_calls(
 
   GPR_ASSERT(status == GRPC_STATUS_UNAVAILABLE);
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr"));
   GPR_ASSERT(was_cancelled == 1);
 
   gpr_free(details);

--- a/test/core/end2end/tests/simple_delayed_request.c
+++ b/test/core/end2end/tests/simple_delayed_request.c
@@ -182,7 +182,8 @@ static void simple_delayed_request_body(grpc_end2end_test_config config,
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f->expected_target ? f->expected_target : "foo.test.google.fr"));
   GPR_ASSERT(was_cancelled == 1);
 
   gpr_free(details);

--- a/test/core/end2end/tests/simple_metadata.c
+++ b/test/core/end2end/tests/simple_metadata.c
@@ -234,7 +234,8 @@ static void test_request_response_with_metadata_and_payload(
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr"));
   GPR_ASSERT(was_cancelled == 0);
   GPR_ASSERT(byte_buffer_eq_string(request_payload_recv, "hello world"));
   GPR_ASSERT(byte_buffer_eq_string(response_payload_recv, "hello you"));

--- a/test/core/end2end/tests/simple_request.c
+++ b/test/core/end2end/tests/simple_request.c
@@ -204,7 +204,8 @@ static void simple_request_body(grpc_end2end_test_fixture f) {
   GPR_ASSERT(status == GRPC_STATUS_UNIMPLEMENTED);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr:1234"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr:1234"));
   GPR_ASSERT(0 == call_details.flags);
   GPR_ASSERT(was_cancelled == 1);
 

--- a/test/core/end2end/tests/streaming_error_response.c
+++ b/test/core/end2end/tests/streaming_error_response.c
@@ -247,7 +247,8 @@ static void test(grpc_end2end_test_config config, bool request_status_early) {
   GPR_ASSERT(status == GRPC_STATUS_FAILED_PRECONDITION);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr"));
   GPR_ASSERT(was_cancelled == 1);
 
   gpr_free(details);

--- a/test/core/end2end/tests/trailing_metadata.c
+++ b/test/core/end2end/tests/trailing_metadata.c
@@ -238,7 +238,8 @@ static void test_request_response_with_metadata_and_payload(
   GPR_ASSERT(status == GRPC_STATUS_OK);
   GPR_ASSERT(0 == strcmp(details, "xyz"));
   GPR_ASSERT(0 == strcmp(call_details.method, "/foo"));
-  GPR_ASSERT(0 == strcmp(call_details.host, "foo.test.google.fr"));
+  GPR_ASSERT(0 == strcmp(call_details.host,
+      f.expected_target ? f.expected_target : "foo.test.google.fr"));
   GPR_ASSERT(byte_buffer_eq_string(request_payload_recv, "hello world"));
   GPR_ASSERT(byte_buffer_eq_string(response_payload_recv, "hello you"));
   GPR_ASSERT(contains_metadata(&request_metadata_recv, "key1", "val1"));


### PR DESCRIPTION
Fix for Obj-C Cronet end2end test failure. The unit tests now know to expect the 'host' string that client requests with when Cronet is not used, and expect the server address when Cronet is used (since Cronet framework does not recognize 'host').