### PR TITLE
fail benchmarks with errors in a child rpc thread

### DIFF
--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -147,11 +147,11 @@ module GRPC
 
     def_delegators :@server, :add_http2_port
 
-    # Default thread pool size is 3
-    DEFAULT_POOL_SIZE = 3
+    # Default thread pool size is 100
+    DEFAULT_POOL_SIZE = 100
 
-    # Default max_waiting_requests size is 20
-    DEFAULT_MAX_WAITING_REQUESTS = 20
+    # Default max_waiting_requests size is 100
+    DEFAULT_MAX_WAITING_REQUESTS = 100
 
     # Default poll period is 1s
     DEFAULT_POLL_PERIOD = 1

--- a/src/ruby/qps/client.rb
+++ b/src/ruby/qps/client.rb
@@ -89,12 +89,14 @@ class BenchmarkClient
                    payload: gtp.new(type: gtpt::COMPRESSABLE,
                                     body: nulls(simple_params.req_size)))
 
+    @child_threads = []
+
     (0..config.client_channels-1).each do |chan|
       gtbss = Grpc::Testing::BenchmarkService::Stub
       st = config.server_targets
       stub = gtbss.new(st[chan % st.length], cred, **opts)
       (0..config.outstanding_rpcs_per_channel-1).each do |r|
-        Thread.new {
+        @child_threads << Thread.new {
           case config.load_params.load.to_s
           when 'closed_loop'
             waiter = nil
@@ -162,5 +164,8 @@ class BenchmarkClient
   end
   def shutdown
     @done = true
+    @child_threads.each do |thread|
+      thread.join
+    end
   end
 end

--- a/src/ruby/qps/worker.rb
+++ b/src/ruby/qps/worker.rb
@@ -83,8 +83,8 @@ class WorkerServiceImpl < Grpc::Testing::WorkerService::Service
                                                    client.mark(req.mark.reset)))
         end
       end
-      q.push(self)
       client.shutdown
+      q.push(self)
     }
     q.each_item
   end
@@ -118,6 +118,10 @@ def main
       options['server_port'] = v
     end
   end.parse!
+
+  # Configure any errors with client or server child threads to surface
+  Thread.abort_on_exception = true
+  
   s = GRPC::RpcServer.new
   s.add_http2_port("0.0.0.0:" + options['driver_port'].to_s,
                    :this_port_is_insecure)


### PR DESCRIPTION
this also increases the size of the default thread pool and queue size mostly just to make sure there's enough room for the large amount of calls in the benchmark tests, but planning on using a third party thread pool in a separate PR.

I'm not sure if this would be best in v1.0.x or master. Putting it here since it makes a big change to the thread pool, but we might want it in v1.0.x, since it affects the benchmark results.