### PR TITLE
fix_interop_server_arg

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -662,7 +662,7 @@ argp.add_argument('--prod_servers',
                         'cloud_to_prod_auth tests against.'))
 argp.add_argument('-s', '--server',
                   choices=['all'] + sorted(_SERVERS),
-                  action='append',
+                  nargs='+',
                   help='Run cloud_to_cloud servers in a separate docker ' +
                        'image. Servers can only be started automatically if ' +
                        '--use_docker option is enabled.',


### PR DESCRIPTION
Currently command like this is broken:
+ tools/run_tests/run_interop_tests.py -l c++ csharp java node php php7 ruby python -s c++ csharp --cloud_to_prod --cloud_to_prod_auth --use_docker --http2_interop -t -j 12

usage: run_interop_tests.py [-h]
                            [-l {all,c++,csharp,go,java,node,php,php7,python,ruby} [{all,c++,csharp,go,java,node,php,php7,python,ruby} ...]]
                            [-j JOBS] [--cloud_to_prod] [--cloud_to_prod_auth]
                            [--prod_servers {cloud_gateway_v4,gateway_v4,default,cloud_gateway_v2,cloud_gateway,gateway_v2} [{cloud_gateway_v4,gateway_v4,default,cloud_gateway_v2,cloud_gateway,gateway_v2} ...]]
                            [-s {all,c++,csharp,go,java,node,python,ruby}]
                            [--override_server OVERRIDE_SERVER] [-t]
                            [--use_docker] [--allow_flakes] [--http2_interop]
run_interop_tests.py: error: unrecognized arguments: csharp

Note that the -s command can't take multiple choices like -l.
This will fix it.