### PR TITLE
Add PyPy 5.3.1 to dockerfile and template

### DIFF
--- a/templates/tools/dockerfile/apt_get_pyenv.include
+++ b/templates/tools/dockerfile/apt_get_pyenv.include
@@ -15,4 +15,5 @@ RUN curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/py
 RUN pyenv update
 RUN pyenv install 3.5-dev
 RUN pyenv install 3.6-dev
-RUN pyenv local 3.5-dev 3.6-dev
+RUN pyenv install pypy-5.3.1
+RUN pyenv local 3.5-dev 3.6-dev pypy-5.3.1

--- a/tools/dockerfile/test/python_pyenv_x64/Dockerfile
+++ b/tools/dockerfile/test/python_pyenv_x64/Dockerfile
@@ -95,7 +95,8 @@ RUN curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/py
 RUN pyenv update
 RUN pyenv install 3.5-dev
 RUN pyenv install 3.6-dev
-RUN pyenv local 3.5-dev 3.6-dev
+RUN pyenv install pypy-5.3.1
+RUN pyenv local 3.5-dev 3.6-dev pypy-5.3.1
 
 # Prepare ccache
 RUN ln -s /usr/bin/ccache /usr/local/bin/gcc


### PR DESCRIPTION
In order to integrate PyPy with jenkins setup, we need to have pypy installed on the docker image. The most straightforward way to do so is to add PyPy to the dockerfiles associated with `pyenv`