### PR TITLE
remove skipIf from TypeSmokeTest (issue 7672)

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_cython/cygrpc_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/cygrpc_test.py
@@ -114,9 +114,6 @@ class TypeSmokeTest(unittest.TestCase):
         lambda ignored_a, ignored_b: None, b'')
     del plugin
 
-  @unittest.skipIf(
-    platform.python_implementation() == "PyPy",
-    'TODO(issue 7672): figure out why this fails on PyPy')
   def testCallCredentialsFromPluginUpDown(self):
     plugin = cygrpc.CredentialsMetadataPlugin(_metadata_plugin_callback, b'')
     call_credentials = cygrpc.call_credentials_metadata_plugin(plugin)


### PR DESCRIPTION
remove skipIfStatement from
TypeSmokeTest.testCallCredentialsFromPluginUpDown since the test passes
on PyPy variants 5.3.0 and newer since these variants have improved
compatibility support for the C-Extensions.

To be merged after [Add PyPy 5.3.1 to dockerfile and template](https://github.com/grpc/grpc/pull/7763)