### PR TITLE
Remove the extra comma

### DIFF
--- a/examples/php/composer.json
+++ b/examples/php/composer.json
@@ -2,6 +2,6 @@
   "name": "grpc/grpc-demo",
   "description": "gRPC example for PHP",
   "require": {
-    "grpc/grpc": "v1.0.0",
+    "grpc/grpc": "v1.0.0"
   }
 }


### PR DESCRIPTION
```
[Seld\JsonLint\ParsingException]
  "./composer.json" does not contain valid JSON
  Parse error on line 5:
  .../grpc": "v1.0.0",  }}
  ---------------------^
  Expected: 'STRING' - It appears you have an extra trailing comma
```