### PR TITLE
Remove undefined env

### DIFF
--- a/examples/php/run_greeter_client.sh
+++ b/examples/php/run_greeter_client.sh
@@ -30,5 +30,5 @@
 
 set -e
 cd $(dirname $0)
-php $extension_dir -d extension=grpc.so -d max_execution_time=300 \
+php -d extension=grpc.so -d max_execution_time=300 \
   greeter_client.php $1


### PR DESCRIPTION
Without `determine_extension_dir.sh`, $extension_dir is not define yet.