### PR TITLE
combine calls to run batch on unary requests and responses

### DIFF
--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -210,14 +210,14 @@ module GRPC
       nil
     end
 
-    def server_unary_response(req, marshalled: false, trailing_metadata: {},
+    def server_unary_response(req, trailing_metadata: {},
                               code: Core::StatusCodes::OK, details: 'OK')
       @send_initial_md_mutex.synchronize do
         ops = {}
         ops[SEND_INITIAL_METADATA] = @metadata_to_send unless @metadata_sent
-        @metadata_sent = true unless @metadata_sent
+        @metadata_sent = true
 
-        payload = marshalled ? req : @marshal.call(req)
+        payload = @marshal.call(req)
         ops[SEND_MESSAGE] = payload
         ops[SEND_STATUS_FROM_SERVER] = Struct::Status.new(
           code, details, trailing_metadata)

--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -102,7 +102,7 @@ module GRPC
     #     been received. Should always be true for server calls
     def initialize(call, marshal, unmarshal, deadline, started: true,
                    metadata_received: false, metadata_to_send: nil)
-      fail(TypeError, '!Core::Call') unless call.is_a? Core::Call
+      #fail(TypeError, '!Core::Call') unless call.is_a? Core::Call
       @call = call
       @deadline = deadline
       @marshal = marshal

--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -168,6 +168,7 @@ module GRPC
 
       # return the operation view of the active_call; define #execute as a
       # new method for this instance that invokes #request_response.
+      c.merge_metadata_to_send(metadata)
       op = c.operation
       op.define_singleton_method(:execute) do
         c.request_response(req, metadata: metadata)
@@ -231,9 +232,10 @@ module GRPC
 
       # return the operation view of the active_call; define #execute as a
       # new method for this instance that invokes #client_streamer.
+      c.merge_metadata_to_send(metadata)
       op = c.operation
       op.define_singleton_method(:execute) do
-        c.client_streamer(requests, metadata: metadata)
+        c.client_streamer(requests)
       end
       op
     end
@@ -309,9 +311,10 @@ module GRPC
 
       # return the operation view of the active_call; define #execute
       # as a new method for this instance that invokes #server_streamer
+      c.merge_metadata_to_send(metadata)
       op = c.operation
       op.define_singleton_method(:execute) do
-        c.server_streamer(req, metadata: metadata, &blk)
+        c.server_streamer(req, &blk)
       end
       op
     end
@@ -417,15 +420,15 @@ module GRPC
                           deadline: deadline,
                           parent: parent,
                           credentials: credentials)
-
       return c.bidi_streamer(requests, metadata: metadata,
                              &blk) unless return_op
 
       # return the operation view of the active_call; define #execute
       # as a new method for this instance that invokes #bidi_streamer
+      c.merge_metadata_to_send(metadata)
       op = c.operation
       op.define_singleton_method(:execute) do
-        c.bidi_streamer(requests, metadata: metadata, &blk)
+        c.bidi_streamer(requests, &blk)
       end
       op
     end
@@ -445,7 +448,6 @@ module GRPC
                         deadline: nil,
                         parent: nil,
                         credentials: nil)
-
       deadline = from_relative_time(@timeout) if deadline.nil?
       # Provide each new client call with its own completion queue
       call = @ch.create_call(parent, # parent call

--- a/src/ruby/lib/grpc/generic/rpc_desc.rb
+++ b/src/ruby/lib/grpc/generic/rpc_desc.rb
@@ -119,7 +119,7 @@ module GRPC
       # Send back a UNKNOWN status to the client
       GRPC.logger.warn("failed handler: #{active_call}; sending status:UNKNOWN")
       GRPC.logger.warn(e)
-      send_status(active_call, UNKNOWN, 'no reason given')
+      send_status(active_call, UNKNOWN, 'unkown error handling call on server')
     end
 
     def assert_arity_matches(mth)

--- a/src/ruby/spec/generic/client_stub_spec.rb
+++ b/src/ruby/spec/generic/client_stub_spec.rb
@@ -186,9 +186,7 @@ describe 'ClientStub' do
                                    metadata: { k1: 'v1', k2: 'v2' },
                                    deadline: from_relative_time(2))
         expect(op).to be_a(GRPC::ActiveCall::Operation)
-        result = op.execute
-        op.wait # make sure op has been completed
-        result
+        op.execute
       end
 
       it_behaves_like 'request response'
@@ -248,9 +246,7 @@ describe 'ClientStub' do
         op = stub.client_streamer(@method, @sent_msgs, noop, noop,
                                   return_op: true, metadata: @metadata)
         expect(op).to be_a(GRPC::ActiveCall::Operation)
-        result = op.execute
-        op.wait # make sure op has been completed
-        result
+        op.execute
       end
 
       it_behaves_like 'client streaming'
@@ -293,7 +289,6 @@ describe 'ClientStub' do
         expect { e.collect { |r| r } }.to raise_error(GRPC::BadStatus)
         th.join
       end
-
     end
 
     describe 'without a call operation' do
@@ -308,16 +303,12 @@ describe 'ClientStub' do
     end
 
     describe 'via a call operation' do
-      after(:each) do
-        @op.wait # make sure op has been completed
-      end
-
       def get_responses(stub)
-        @op = stub.server_streamer(@method, @sent_msg, noop, noop,
+        op = stub.server_streamer(@method, @sent_msg, noop, noop,
                                   return_op: true,
                                   metadata: { k1: 'v1', k2: 'v2' })
-        expect(@op).to be_a(GRPC::ActiveCall::Operation)
-        e = @op.execute
+        expect(op).to be_a(GRPC::ActiveCall::Operation)
+        e = op.execute
         expect(e).to be_a(Enumerator)
         e
       end
@@ -372,15 +363,11 @@ describe 'ClientStub' do
     end
 
     describe 'via a call operation' do
-      after(:each) do
-        @op.wait # make sure op has been completed
-      end
-
       def get_responses(stub)
-        @op = stub.bidi_streamer(@method, @sent_msgs, noop, noop,
+        op = stub.bidi_streamer(@method, @sent_msgs, noop, noop,
                                 return_op: true)
-        expect(@op).to be_a(GRPC::ActiveCall::Operation)
-        e = @op.execute
+        expect(op).to be_a(GRPC::ActiveCall::Operation)
+        e = op.execute
         expect(e).to be_a(Enumerator)
         e
       end

--- a/src/ruby/spec/generic/client_stub_spec.rb
+++ b/src/ruby/spec/generic/client_stub_spec.rb
@@ -186,7 +186,9 @@ describe 'ClientStub' do
                                    metadata: { k1: 'v1', k2: 'v2' },
                                    deadline: from_relative_time(2))
         expect(op).to be_a(GRPC::ActiveCall::Operation)
-        op.execute
+        result = op.execute
+        op.wait # make sure op has been completed
+        result
       end
 
       it_behaves_like 'request response'
@@ -246,7 +248,9 @@ describe 'ClientStub' do
         op = stub.client_streamer(@method, @sent_msgs, noop, noop,
                                   return_op: true, metadata: @metadata)
         expect(op).to be_a(GRPC::ActiveCall::Operation)
-        op.execute
+        result = op.execute
+        op.wait # make sure op has been completed
+        result
       end
 
       it_behaves_like 'client streaming'
@@ -289,6 +293,7 @@ describe 'ClientStub' do
         expect { e.collect { |r| r } }.to raise_error(GRPC::BadStatus)
         th.join
       end
+
     end
 
     describe 'without a call operation' do
@@ -303,12 +308,16 @@ describe 'ClientStub' do
     end
 
     describe 'via a call operation' do
+      after(:each) do
+        @op.wait # make sure op has been completed
+      end
+
       def get_responses(stub)
-        op = stub.server_streamer(@method, @sent_msg, noop, noop,
+        @op = stub.server_streamer(@method, @sent_msg, noop, noop,
                                   return_op: true,
                                   metadata: { k1: 'v1', k2: 'v2' })
-        expect(op).to be_a(GRPC::ActiveCall::Operation)
-        e = op.execute
+        expect(@op).to be_a(GRPC::ActiveCall::Operation)
+        e = @op.execute
         expect(e).to be_a(Enumerator)
         e
       end
@@ -363,11 +372,15 @@ describe 'ClientStub' do
     end
 
     describe 'via a call operation' do
+      after(:each) do
+        @op.wait # make sure op has been completed
+      end
+
       def get_responses(stub)
-        op = stub.bidi_streamer(@method, @sent_msgs, noop, noop,
+        @op = stub.bidi_streamer(@method, @sent_msgs, noop, noop,
                                 return_op: true)
-        expect(op).to be_a(GRPC::ActiveCall::Operation)
-        e = op.execute
+        expect(@op).to be_a(GRPC::ActiveCall::Operation)
+        e = @op.execute
         expect(e).to be_a(Enumerator)
         e
       end

--- a/src/ruby/spec/generic/client_stub_spec.rb
+++ b/src/ruby/spec/generic/client_stub_spec.rb
@@ -180,30 +180,44 @@ describe 'ClientStub' do
     end
 
     describe 'via a call operation' do
-      def get_response(stub)
+      def get_response(stub, run_start_call_first: false)
         op = stub.request_response(@method, @sent_msg, noop, noop,
                                    return_op: true,
                                    metadata: { k1: 'v1', k2: 'v2' },
                                    deadline: from_relative_time(2))
         expect(op).to be_a(GRPC::ActiveCall::Operation)
-        op.execute
+        op.start_call if run_start_call_first
+        result = op.execute
+        op.wait # make sure wait doesn't hang
+        result
       end
 
       it_behaves_like 'request response'
+
+      it 'sends metadata to the server ok when running start_call first' do
+        server_port = create_test_server
+        host = "localhost:#{server_port}"
+        th = run_request_response(@sent_msg, @resp, @pass,
+                                  k1: 'v1', k2: 'v2')
+        stub = GRPC::ClientStub.new(host, :this_channel_is_insecure)
+        expect(get_response(stub)).to eq(@resp)
+        th.join
+      end
     end
   end
 
   describe '#client_streamer' do
-    shared_examples 'client streaming' do
-      before(:each) do
-        server_port = create_test_server
-        host = "localhost:#{server_port}"
-        @stub = GRPC::ClientStub.new(host, :this_channel_is_insecure)
-        @metadata = { k1: 'v1', k2: 'v2' }
-        @sent_msgs = Array.new(3) { |i| 'msg_' + (i + 1).to_s }
-        @resp = 'a_reply'
-      end
+    before(:each) do
+      Thread.abort_on_exception = true
+      server_port = create_test_server
+      host = "localhost:#{server_port}"
+      @stub = GRPC::ClientStub.new(host, :this_channel_is_insecure)
+      @metadata = { k1: 'v1', k2: 'v2' }
+      @sent_msgs = Array.new(3) { |i| 'msg_' + (i + 1).to_s }
+      @resp = 'a_reply'
+    end
 
+    shared_examples 'client streaming' do
       it 'should send requests to/receive a reply from a server' do
         th = run_client_streamer(@sent_msgs, @resp, @pass)
         expect(get_response(@stub)).to eq(@resp)
@@ -242,24 +256,33 @@ describe 'ClientStub' do
     end
 
     describe 'via a call operation' do
-      def get_response(stub)
+      def get_response(stub, run_start_call_first: false)
         op = stub.client_streamer(@method, @sent_msgs, noop, noop,
                                   return_op: true, metadata: @metadata)
         expect(op).to be_a(GRPC::ActiveCall::Operation)
-        op.execute
+        op.start_call if run_start_call_first
+        result = op.execute
+        op.wait # make sure wait doesn't hang
+        result
       end
 
       it_behaves_like 'client streaming'
+
+      it 'sends metadata to the server ok when running start_call first' do
+        th = run_client_streamer(@sent_msgs, @resp, @pass, **@metadata)
+        expect(get_response(@stub, run_start_call_first: true)).to eq(@resp)
+        th.join
+      end
     end
   end
 
   describe '#server_streamer' do
-    shared_examples 'server streaming' do
-      before(:each) do
-        @sent_msg = 'a_msg'
-        @replys = Array.new(3) { |i| 'reply_' + (i + 1).to_s }
-      end
+    before(:each) do
+      @sent_msg = 'a_msg'
+      @replys = Array.new(3) { |i| 'reply_' + (i + 1).to_s }
+    end
 
+    shared_examples 'server streaming' do
       it 'should send a request to/receive replies from a server' do
         server_port = create_test_server
         host = "localhost:#{server_port}"
@@ -303,29 +326,44 @@ describe 'ClientStub' do
     end
 
     describe 'via a call operation' do
-      def get_responses(stub)
-        op = stub.server_streamer(@method, @sent_msg, noop, noop,
-                                  return_op: true,
-                                  metadata: { k1: 'v1', k2: 'v2' })
-        expect(op).to be_a(GRPC::ActiveCall::Operation)
-        e = op.execute
+      after(:each) do
+        @op.wait # make sure wait doesn't hang
+      end
+      def get_responses(stub, run_start_call_first: false)
+        @op = stub.server_streamer(@method, @sent_msg, noop, noop,
+                                   return_op: true,
+                                   metadata: { k1: 'v1', k2: 'v2' })
+        expect(@op).to be_a(GRPC::ActiveCall::Operation)
+        @op.start_call if run_start_call_first
+        e = @op.execute
         expect(e).to be_a(Enumerator)
         e
       end
 
       it_behaves_like 'server streaming'
+
+      it 'should send metadata to the server ok when start_call is run first' do
+        server_port = create_test_server
+        host = "localhost:#{server_port}"
+        th = run_server_streamer(@sent_msg, @replys, @fail,
+                                 k1: 'v1', k2: 'v2')
+        stub = GRPC::ClientStub.new(host, :this_channel_is_insecure)
+        e = get_responses(stub, run_start_call_first: true)
+        expect { e.collect { |r| r } }.to raise_error(GRPC::BadStatus)
+        th.join
+      end
     end
   end
 
   describe '#bidi_streamer' do
-    shared_examples 'bidi streaming' do
-      before(:each) do
-        @sent_msgs = Array.new(3) { |i| 'msg_' + (i + 1).to_s }
-        @replys = Array.new(3) { |i| 'reply_' + (i + 1).to_s }
-        server_port = create_test_server
-        @host = "localhost:#{server_port}"
-      end
+    before(:each) do
+      @sent_msgs = Array.new(3) { |i| 'msg_' + (i + 1).to_s }
+      @replys = Array.new(3) { |i| 'reply_' + (i + 1).to_s }
+      server_port = create_test_server
+      @host = "localhost:#{server_port}"
+    end
 
+    shared_examples 'bidi streaming' do
       it 'supports sending all the requests first', bidi: true do
         th = run_bidi_streamer_handle_inputs_first(@sent_msgs, @replys,
                                                    @pass)
@@ -363,16 +401,29 @@ describe 'ClientStub' do
     end
 
     describe 'via a call operation' do
-      def get_responses(stub)
-        op = stub.bidi_streamer(@method, @sent_msgs, noop, noop,
-                                return_op: true)
-        expect(op).to be_a(GRPC::ActiveCall::Operation)
-        e = op.execute
+      after(:each) do
+        @op.wait # make sure wait doesn't hang
+      end
+      def get_responses(stub, run_start_call_first: false)
+        @op = stub.bidi_streamer(@method, @sent_msgs, noop, noop,
+                                 return_op: true)
+        expect(@op).to be_a(GRPC::ActiveCall::Operation)
+        @op.start_call if run_start_call_first
+        e = @op.execute
         expect(e).to be_a(Enumerator)
         e
       end
 
       it_behaves_like 'bidi streaming'
+
+      it 'can run start_call before executing the call' do
+        th = run_bidi_streamer_handle_inputs_first(@sent_msgs, @replys,
+                                                   @pass)
+        stub = GRPC::ClientStub.new(@host, :this_channel_is_insecure)
+        e = get_responses(stub, run_start_call_first: true)
+        expect(e.collect { |r| r }).to eq(@replys)
+        th.join
+      end
     end
   end
 

--- a/src/ruby/spec/generic/rpc_desc_spec.rb
+++ b/src/ruby/spec/generic/rpc_desc_spec.rb
@@ -48,7 +48,7 @@ describe GRPC::RpcDesc do
     @bidi_streamer = RpcDesc.new('ss', Stream.new(Object.new),
                                  Stream.new(Object.new), 'encode', 'decode')
     @bs_code = INTERNAL
-    @no_reason = 'no reason given'
+    @no_reason = 'unkown error handling call on server'
     @ok_response = Object.new
   end
 

--- a/src/ruby/spec/generic/rpc_server_spec.rb
+++ b/src/ruby/spec/generic/rpc_server_spec.rb
@@ -462,6 +462,7 @@ describe GRPC::RpcServer do
           'connect_k1' => 'connect_v1'
         }
         wanted_md.each do |key, value|
+          puts "key: #{key}"
           expect(op.metadata[key]).to eq(value)
         end
         @srv.stop


### PR DESCRIPTION
Combining run batch requests seems to have good improvement in unary call latency and qps. Testing on a single 8-core ubuntu host, single sequential unary latency seemed to improve by about 20%. Haven't seen benchmarks on different machines, but guessing it would be more noticeable in that case.