### PR TITLE
throw grpc failed instead of invalid op on generic failure

### DIFF
--- a/src/csharp/Grpc.Core.Tests/Internal/AsyncCallServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/Internal/AsyncCallServerTest.cs
@@ -149,8 +149,7 @@ namespace Grpc.Core.Internal.Tests
 
             var writeTask = responseStream.WriteAsync("request1");
             fakeCall.SendCompletionHandler(false);
-            // TODO(jtattermusch): should we throw a different exception type instead?
-            Assert.ThrowsAsync(typeof(InvalidOperationException), async () => await writeTask);
+            Assert.ThrowsAsync(typeof(GrpcOperationFailedException), async () => await writeTask);
 
             fakeCall.ReceivedCloseOnServerHandler(true, cancelled: true);
             AssertFinished(asyncCallServer, fakeCall, finishedTask);

--- a/src/csharp/Grpc.Core.Tests/Internal/AsyncCallTest.cs
+++ b/src/csharp/Grpc.Core.Tests/Internal/AsyncCallTest.cs
@@ -187,8 +187,7 @@ namespace Grpc.Core.Internal.Tests
 
             var writeTask = requestStream.WriteAsync("request1");
             fakeCall.SendCompletionHandler(false);
-            // TODO: maybe IOException or waiting for RPCException is more appropriate here.
-            Assert.ThrowsAsync(typeof(InvalidOperationException), async () => await writeTask);
+            Assert.ThrowsAsync(typeof(GrpcOperationFailedException), async () => await writeTask);
 
             fakeCall.UnaryResponseClientHandler(true,
                 CreateClientSideStatus(StatusCode.Internal),

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Internal\CallError.cs" />
     <Compile Include="Logging\LogLevel.cs" />
     <Compile Include="Logging\LogLevelFilterLogger.cs" />
+    <Compile Include="GrpcOperationFailedException.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Grpc.Core.nuspec" />

--- a/src/csharp/Grpc.Core/GrpcOperationFailedException.cs
+++ b/src/csharp/Grpc.Core/GrpcOperationFailedException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+namespace Grpc.Core
+{
+    public class GrpcOperationFailedException : InvalidOperationException
+    {
+        public GrpcOperationFailedException()
+        {
+        }
+        
+        public GrpcOperationFailedException(string message) : base(message)
+        {
+        }
+        
+        public GrpcOperationFailedException(string message, Exception inner) : base(message, inner)
+        {
+        }
+    }
+}
+

--- a/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs
@@ -234,7 +234,6 @@ namespace Grpc.Core.Internal
             {
                 try
                 {
-                
                     msg = deserializer(payload);
                     return null;
              
@@ -263,7 +262,7 @@ namespace Grpc.Core.Internal
 
             if (!success)
             {
-                origTcs.SetException(new InvalidOperationException("Send failed"));
+                origTcs.SetException(new GrpcOperationFailedException("Send failed"));
             }
             else
             {
@@ -283,7 +282,7 @@ namespace Grpc.Core.Internal
 
             if (!success)
             {
-                sendStatusFromServerTcs.SetException(new InvalidOperationException("Error sending status from server."));
+                sendStatusFromServerTcs.SetException(new GrpcOperationFailedException("Error sending status from server."));
             }
             else
             {


### PR DESCRIPTION
It looks like there's been some desire to change the use of invalid operation exception on certain failures.

Making and throwing a new type here that extends InvalidOperationException to not make a breaking change. (under assumption users might currently `catch InvalidOperationException`).

This is mostly an initial idea to change it. I doesn't seem common to extend something other than Exception. Another idea was adding something new as the inner exception of InvalidOperationException, but seeing how this looked.

cc @jtattermusch @jskeet 