### PR TITLE
Fetch c# global logger before every use

### DIFF
--- a/src/csharp/Grpc.Core.Tests/GrpcEnvironmentTest.cs
+++ b/src/csharp/Grpc.Core.Tests/GrpcEnvironmentTest.cs
@@ -98,16 +98,20 @@ namespace Grpc.Core.Tests
         {
             // Note this relies partially on NullLogger and TextWriterLoggerImplementations, 
             // in that their ForType methods return instances of their same types.
+            GlobalLoggerProxy<Channel> globalLoggerProxyForChannel = new GlobalLoggerProxy<Channel>();
+            GlobalLoggerProxy<Server> globalLoggerProxyForServer = new GlobalLoggerProxy<Server>();
+
             NullLogger nullLogger = new NullLogger();
             GrpcEnvironment.SetLogger(nullLogger);
 
-            Assert.IsInstanceOf<NullLogger>(GrpcEnvironment.GetLoggerForType<Channel>());
+            Assert.IsInstanceOf<NullLogger>(globalLoggerProxyForChannel.GetLogger());
+            Assert.IsInstanceOf<NullLogger>(globalLoggerProxyForServer.GetLogger());
 
             TextWriterLogger textWriterLogger = new TextWriterLogger(new StringWriter());
             GrpcEnvironment.SetLogger(textWriterLogger);
 
-            Assert.IsInstanceOf<TextWriterLogger>(GrpcEnvironment.GetLoggerForType<Channel>());
-            Assert.IsInstanceOf<TextWriterLogger>(GrpcEnvironment.GetLoggerForType<Server>());
+            Assert.IsInstanceOf<TextWriterLogger>(globalLoggerProxyForChannel.GetLogger());
+            Assert.IsInstanceOf<TextWriterLogger>(globalLoggerProxyForServer.GetLogger());
         }
     }
 }

--- a/src/csharp/Grpc.Core.Tests/GrpcEnvironmentTest.cs
+++ b/src/csharp/Grpc.Core.Tests/GrpcEnvironmentTest.cs
@@ -32,8 +32,10 @@
 #endregion
 
 using System;
+using System.IO;
 using System.Linq;
 using Grpc.Core;
+using Grpc.Core.Logging;
 using NUnit.Framework;
 
 namespace Grpc.Core.Tests
@@ -89,6 +91,23 @@ namespace Grpc.Core.Tests
             var coreVersion = GrpcEnvironment.GetCoreVersionString();
             var parts = coreVersion.Split('.');
             Assert.AreEqual(3, parts.Length);
+        }
+
+        [Test]
+        public void ChangingTheGlobalLogger()
+        {
+            // Note this relies partially on NullLogger and TextWriterLoggerImplementations, 
+            // in that their ForType methods return instances of their same types.
+            NullLogger nullLogger = new NullLogger();
+            GrpcEnvironment.SetLogger(nullLogger);
+
+            Assert.IsInstanceOf<NullLogger>(GrpcEnvironment.GetLoggerForType<Channel>());
+
+            TextWriterLogger textWriterLogger = new TextWriterLogger(new StringWriter());
+            GrpcEnvironment.SetLogger(textWriterLogger);
+
+            Assert.IsInstanceOf<TextWriterLogger>(GrpcEnvironment.GetLoggerForType<Channel>());
+            Assert.IsInstanceOf<TextWriterLogger>(GrpcEnvironment.GetLoggerForType<Server>());
         }
     }
 }

--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -57,6 +57,8 @@ namespace Grpc.Core
         readonly ChannelSafeHandle handle;
         readonly Dictionary<string, ChannelOption> options;
 
+        GlobalLoggerProxy<Channel> globalLoggerProxy = new GlobalLoggerProxy<Channel>();
+
         bool shutdownRequested;
 
         /// <summary>
@@ -237,8 +239,8 @@ namespace Grpc.Core
             var activeCallCount = activeCallCounter.Count;
             if (activeCallCount > 0)
             {
-                ILogger Logger = GrpcEnvironment.GetLoggerForType<Channel>();
-                Logger.Warning("Channel shutdown was called but there are still {0} active calls for that channel.", activeCallCount);
+                globalLoggerProxy.GetLogger().Warning(
+                    "Channel shutdown was called but there are still {0} active calls for that channel.", activeCallCount);
             }
 
             handle.Dispose();

--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -237,7 +237,7 @@ namespace Grpc.Core
             var activeCallCount = activeCallCounter.Count;
             if (activeCallCount > 0)
             {
-                ILogger Logger = GrpcEnvironment.Logger.ForType<Channel>();
+                ILogger Logger = GrpcEnvironment.GetLoggerForType<Channel>();
                 Logger.Warning("Channel shutdown was called but there are still {0} active calls for that channel.", activeCallCount);
             }
 

--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -47,8 +47,6 @@ namespace Grpc.Core
     /// </summary>
     public class Channel
     {
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<Channel>();
-
         readonly object myLock = new object();
         readonly AtomicCounter activeCallCounter = new AtomicCounter();
         readonly CancellationTokenSource shutdownTokenSource = new CancellationTokenSource();
@@ -239,6 +237,7 @@ namespace Grpc.Core
             var activeCallCount = activeCallCounter.Count;
             if (activeCallCount > 0)
             {
+                ILogger Logger = GrpcEnvironment.Logger.ForType<Channel>();
                 Logger.Warning("Channel shutdown was called but there are still {0} active calls for that channel.", activeCallCount);
             }
 

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -58,6 +58,8 @@
     <Compile Include="IServerStreamWriter.cs" />
     <Compile Include="IAsyncStreamWriter.cs" />
     <Compile Include="IAsyncStreamReader.cs" />
+    <Compile Include="Logging\GlobalLoggerProxy.cs" />
+    <Compile Include="Logging\LoggerChangedEventArgs.cs" />
     <Compile Include="Logging\TextWriterLogger.cs" />
     <Compile Include="Logging\NullLogger.cs" />
     <Compile Include="ServerPort.cs" />

--- a/src/csharp/Grpc.Core/Internal/AsyncCall.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCall.cs
@@ -61,6 +61,9 @@ namespace Grpc.Core.Internal
         // Set after status is received. Used for both unary and streaming response calls.
         ClientSideStatus? finishedStatus;
 
+        GlobalLoggerProxy<AsyncCall<TRequest, TResponse>> globalLoggerProxy 
+            = new GlobalLoggerProxy<AsyncCall<TRequest, TResponse>>();
+
         public AsyncCall(CallInvocationDetails<TRequest, TResponse> callDetails)
             : base(callDetails.RequestMarshaller.Serializer, callDetails.ResponseMarshaller.Deserializer)
         {
@@ -119,8 +122,7 @@ namespace Grpc.Core.Internal
                     }
                     catch (Exception e)
                     {
-                        ILogger AsyncCallLogger = GrpcEnvironment.GetLoggerForType<AsyncCall<TRequest, TResponse>>();
-                        AsyncCallLogger.Error(e, "Exception occured while invoking completion delegate.");
+                        globalLoggerProxy.GetLogger().Error(e, "Exception occured while invoking completion delegate.");
                     }
                 }
                     

--- a/src/csharp/Grpc.Core/Internal/AsyncCall.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCall.cs
@@ -121,7 +121,8 @@ namespace Grpc.Core.Internal
                     }
                     catch (Exception e)
                     {
-                        Logger.Error(e, "Exception occured while invoking completion delegate.");
+                        ILogger AsyncCallLogger = GrpcEnvironment.Logger.ForType<AsyncCall<TRequest, TResponse>>();
+                        AsyncCallLogger.Error(e, "Exception occured while invoking completion delegate.");
                     }
                 }
                     

--- a/src/csharp/Grpc.Core/Internal/AsyncCall.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCall.cs
@@ -44,8 +44,6 @@ namespace Grpc.Core.Internal
     /// </summary>
     internal class AsyncCall<TRequest, TResponse> : AsyncCallBase<TRequest, TResponse>
     {
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<AsyncCall<TRequest, TResponse>>();
-
         readonly CallInvocationDetails<TRequest, TResponse> details;
         readonly INativeCall injectedNativeCall;  // for testing
 
@@ -121,7 +119,7 @@ namespace Grpc.Core.Internal
                     }
                     catch (Exception e)
                     {
-                        ILogger AsyncCallLogger = GrpcEnvironment.Logger.ForType<AsyncCall<TRequest, TResponse>>();
+                        ILogger AsyncCallLogger = GrpcEnvironment.GetLoggerForType<AsyncCall<TRequest, TResponse>>();
                         AsyncCallLogger.Error(e, "Exception occured while invoking completion delegate.");
                     }
                 }

--- a/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs
@@ -52,7 +52,6 @@ namespace Grpc.Core.Internal
     /// </summary>
     internal abstract class AsyncCallBase<TWrite, TRead>
     {
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<AsyncCallBase<TWrite, TRead>>();
         protected static readonly Status DeserializeResponseFailureStatus = new Status(StatusCode.Internal, "Failed to deserialize response message.");
 
         readonly Func<TWrite, byte[]> serializer;

--- a/src/csharp/Grpc.Core/Internal/CompletionRegistry.cs
+++ b/src/csharp/Grpc.Core/Internal/CompletionRegistry.cs
@@ -49,6 +49,8 @@ namespace Grpc.Core.Internal
         readonly GrpcEnvironment environment;
         readonly ConcurrentDictionary<IntPtr, OpCompletionDelegate> dict = new ConcurrentDictionary<IntPtr, OpCompletionDelegate>();
 
+        static GlobalLoggerProxy<CompletionRegistry> GlobalLoggerProxy = new GlobalLoggerProxy<CompletionRegistry>();
+
         public CompletionRegistry(GrpcEnvironment environment)
         {
             this.environment = environment;
@@ -82,8 +84,7 @@ namespace Grpc.Core.Internal
             }
             catch (Exception e)
             {
-                ILogger Logger = GrpcEnvironment.GetLoggerForType<CompletionRegistry>();
-                Logger.Error(e, "Exception occured while invoking completion delegate.");
+                GlobalLoggerProxy.GetLogger().Error(e, "Exception occured while invoking completion delegate.");
             }
             finally
             {

--- a/src/csharp/Grpc.Core/Internal/CompletionRegistry.cs
+++ b/src/csharp/Grpc.Core/Internal/CompletionRegistry.cs
@@ -46,8 +46,6 @@ namespace Grpc.Core.Internal
 
     internal class CompletionRegistry
     {
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<CompletionRegistry>();
-
         readonly GrpcEnvironment environment;
         readonly ConcurrentDictionary<IntPtr, OpCompletionDelegate> dict = new ConcurrentDictionary<IntPtr, OpCompletionDelegate>();
 
@@ -84,6 +82,7 @@ namespace Grpc.Core.Internal
             }
             catch (Exception e)
             {
+                ILogger Logger = GrpcEnvironment.Logger.ForType<CompletionRegistry>();
                 Logger.Error(e, "Exception occured while invoking completion delegate.");
             }
             finally

--- a/src/csharp/Grpc.Core/Internal/CompletionRegistry.cs
+++ b/src/csharp/Grpc.Core/Internal/CompletionRegistry.cs
@@ -82,7 +82,7 @@ namespace Grpc.Core.Internal
             }
             catch (Exception e)
             {
-                ILogger Logger = GrpcEnvironment.Logger.ForType<CompletionRegistry>();
+                ILogger Logger = GrpcEnvironment.GetLoggerForType<CompletionRegistry>();
                 Logger.Error(e, "Exception occured while invoking completion delegate.");
             }
             finally

--- a/src/csharp/Grpc.Core/Internal/GrpcThreadPool.cs
+++ b/src/csharp/Grpc.Core/Internal/GrpcThreadPool.cs
@@ -56,6 +56,8 @@ namespace Grpc.Core.Internal
 
         IReadOnlyCollection<CompletionQueueSafeHandle> completionQueues;
 
+        GlobalLoggerProxy<GrpcThreadPool> globalLoggerProxy = new GlobalLoggerProxy<GrpcThreadPool>();
+
         /// <summary>
         /// Creates a thread pool threads polling on a set of completions queues.
         /// </summary>
@@ -168,8 +170,7 @@ namespace Grpc.Core.Internal
                     }
                     catch (Exception e)
                     {
-                        ILogger Logger = GrpcEnvironment.GetLoggerForType<GrpcThreadPool>();
-                        Logger.Error(e, "Exception occured while invoking completion delegate");
+                        globalLoggerProxy.GetLogger().Error(e, "Exception occured while invoking completion delegate");
                     }
                 }
             }

--- a/src/csharp/Grpc.Core/Internal/GrpcThreadPool.cs
+++ b/src/csharp/Grpc.Core/Internal/GrpcThreadPool.cs
@@ -46,8 +46,6 @@ namespace Grpc.Core.Internal
     /// </summary>
     internal class GrpcThreadPool
     {
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<GrpcThreadPool>();
-
         readonly GrpcEnvironment environment;
         readonly object myLock = new object();
         readonly List<Thread> threads = new List<Thread>();
@@ -170,6 +168,7 @@ namespace Grpc.Core.Internal
                     }
                     catch (Exception e)
                     {
+                        ILogger Logger = GrpcEnvironment.Logger.ForType<GrpcThreadPool>();
                         Logger.Error(e, "Exception occured while invoking completion delegate");
                     }
                 }

--- a/src/csharp/Grpc.Core/Internal/GrpcThreadPool.cs
+++ b/src/csharp/Grpc.Core/Internal/GrpcThreadPool.cs
@@ -168,7 +168,7 @@ namespace Grpc.Core.Internal
                     }
                     catch (Exception e)
                     {
-                        ILogger Logger = GrpcEnvironment.Logger.ForType<GrpcThreadPool>();
+                        ILogger Logger = GrpcEnvironment.GetLoggerForType<GrpcThreadPool>();
                         Logger.Error(e, "Exception occured while invoking completion delegate");
                     }
                 }

--- a/src/csharp/Grpc.Core/Internal/NativeExtension.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeExtension.cs
@@ -49,6 +49,8 @@ namespace Grpc.Core.Internal
 
         readonly NativeMethods nativeMethods;
 
+        GlobalLoggerProxy<NativeExtension> globalLoggerProxy = new GlobalLoggerProxy<NativeExtension>();
+
         private NativeExtension()
         {
             this.nativeMethods = new NativeMethods(Load());
@@ -59,7 +61,7 @@ namespace Grpc.Core.Internal
 
             DefaultSslRootsOverride.Override(this.nativeMethods);
 
-            GrpcEnvironment.GetLoggerForType<NativeExtension>().Debug("gRPC native library loaded successfully.");
+            globalLoggerProxy.GetLogger().Debug("gRPC native library loaded successfully.");
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core/Internal/NativeExtension.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeExtension.cs
@@ -59,7 +59,7 @@ namespace Grpc.Core.Internal
 
             DefaultSslRootsOverride.Override(this.nativeMethods);
 
-            GrpcEnvironment.Logger.ForType<NativeExtension>().Debug("gRPC native library loaded successfully.");
+            GrpcEnvironment.GetLoggerForType<NativeExtension>().Debug("gRPC native library loaded successfully.");
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core/Internal/NativeExtension.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeExtension.cs
@@ -44,7 +44,6 @@ namespace Grpc.Core.Internal
     /// </summary>
     internal sealed class NativeExtension
     {
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<NativeExtension>();
         static readonly object staticLock = new object();
         static volatile NativeExtension instance;
 
@@ -60,7 +59,7 @@ namespace Grpc.Core.Internal
 
             DefaultSslRootsOverride.Override(this.nativeMethods);
 
-            Logger.Debug("gRPC native library loaded successfully.");
+            GrpcEnvironment.Logger.ForType<NativeExtension>().Debug("gRPC native library loaded successfully.");
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
@@ -50,6 +50,8 @@ namespace Grpc.Core.Internal
         NativeMetadataInterceptor nativeInterceptor;
         CallCredentialsSafeHandle credentials;
 
+        GlobalLoggerProxy<NativeMetadataCredentialsPlugin> globalLoggerProxy = new GlobalLoggerProxy<NativeMetadataCredentialsPlugin>();
+
         public NativeMetadataCredentialsPlugin(AsyncAuthInterceptor interceptor)
         {
             this.interceptor = GrpcPreconditions.CheckNotNull(interceptor, "interceptor");
@@ -82,7 +84,7 @@ namespace Grpc.Core.Internal
             catch (Exception e)
             {
                 Native.grpcsharp_metadata_credentials_notify_from_plugin(callbackPtr, userDataPtr, MetadataArraySafeHandle.Create(Metadata.Empty), StatusCode.Unknown, GetMetadataExceptionMsg);
-                GrpcEnvironment.GetLoggerForType<NativeMetadataCredentialsPlugin>().Error(e, GetMetadataExceptionMsg);
+                globalLoggerProxy.GetLogger().Error(e, GetMetadataExceptionMsg);
             }
         }
 
@@ -101,7 +103,7 @@ namespace Grpc.Core.Internal
             catch (Exception e)
             {
                 Native.grpcsharp_metadata_credentials_notify_from_plugin(callbackPtr, userDataPtr, MetadataArraySafeHandle.Create(Metadata.Empty), StatusCode.Unknown, GetMetadataExceptionMsg);
-                GrpcEnvironment.GetLoggerForType<NativeMetadataCredentialsPlugin>().Error(e, GetMetadataExceptionMsg);
+                globalLoggerProxy.GetLogger().Error(e, GetMetadataExceptionMsg);
             }
         }
     }

--- a/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
@@ -82,7 +82,7 @@ namespace Grpc.Core.Internal
             catch (Exception e)
             {
                 Native.grpcsharp_metadata_credentials_notify_from_plugin(callbackPtr, userDataPtr, MetadataArraySafeHandle.Create(Metadata.Empty), StatusCode.Unknown, GetMetadataExceptionMsg);
-                GrpcEnvironment.Logger.ForType<NativeMetadataCredentialsPlugin>().Error(e, GetMetadataExceptionMsg);
+                GrpcEnvironment.GetLoggerForType<NativeMetadataCredentialsPlugin>().Error(e, GetMetadataExceptionMsg);
             }
         }
 
@@ -101,7 +101,7 @@ namespace Grpc.Core.Internal
             catch (Exception e)
             {
                 Native.grpcsharp_metadata_credentials_notify_from_plugin(callbackPtr, userDataPtr, MetadataArraySafeHandle.Create(Metadata.Empty), StatusCode.Unknown, GetMetadataExceptionMsg);
-                GrpcEnvironment.Logger.ForType<NativeMetadataCredentialsPlugin>().Error(e, GetMetadataExceptionMsg);
+                GrpcEnvironment.GetLoggerForType<NativeMetadataCredentialsPlugin>().Error(e, GetMetadataExceptionMsg);
             }
         }
     }

--- a/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
@@ -43,7 +43,6 @@ namespace Grpc.Core.Internal
     internal class NativeMetadataCredentialsPlugin
     {
         const string GetMetadataExceptionMsg = "Exception occured in metadata credentials plugin.";
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<NativeMetadataCredentialsPlugin>();
         static readonly NativeMethods Native = NativeMethods.Get();
 
         AsyncAuthInterceptor interceptor;
@@ -83,7 +82,7 @@ namespace Grpc.Core.Internal
             catch (Exception e)
             {
                 Native.grpcsharp_metadata_credentials_notify_from_plugin(callbackPtr, userDataPtr, MetadataArraySafeHandle.Create(Metadata.Empty), StatusCode.Unknown, GetMetadataExceptionMsg);
-                Logger.Error(e, GetMetadataExceptionMsg);
+                GrpcEnvironment.Logger.ForType<NativeMetadataCredentialsPlugin>().Error(e, GetMetadataExceptionMsg);
             }
         }
 
@@ -102,7 +101,7 @@ namespace Grpc.Core.Internal
             catch (Exception e)
             {
                 Native.grpcsharp_metadata_credentials_notify_from_plugin(callbackPtr, userDataPtr, MetadataArraySafeHandle.Create(Metadata.Empty), StatusCode.Unknown, GetMetadataExceptionMsg);
-                Logger.Error(e, GetMetadataExceptionMsg);
+                GrpcEnvironment.Logger.ForType<NativeMetadataCredentialsPlugin>().Error(e, GetMetadataExceptionMsg);
             }
         }
     }

--- a/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
@@ -54,6 +54,9 @@ namespace Grpc.Core.Internal
         readonly Method<TRequest, TResponse> method;
         readonly UnaryServerMethod<TRequest, TResponse> handler;
 
+        GlobalLoggerProxy<UnaryServerCallHandler<TRequest, TResponse>> globalLoggerProxy 
+            = new GlobalLoggerProxy<UnaryServerCallHandler<TRequest, TResponse>>();
+
         public UnaryServerCallHandler(Method<TRequest, TResponse> method, UnaryServerMethod<TRequest, TResponse> handler)
         {
             this.method = method;
@@ -87,8 +90,7 @@ namespace Grpc.Core.Internal
             {
                 if (!(e is RpcException))
                 {
-                    ILogger Logger = GrpcEnvironment.GetLoggerForType<UnaryServerCallHandler<TRequest, TResponse>>();
-                    Logger.Warning(e, "Exception occured in handler.");
+                    globalLoggerProxy.GetLogger().Warning(e, "Exception occured in handler.");
                 }
                 status = HandlerUtils.StatusFromException(e);
             }
@@ -111,6 +113,9 @@ namespace Grpc.Core.Internal
     {
         readonly Method<TRequest, TResponse> method;
         readonly ServerStreamingServerMethod<TRequest, TResponse> handler;
+
+        GlobalLoggerProxy<ServerStreamingServerCallHandler<TRequest, TResponse>> globalLoggerProxy 
+            = new GlobalLoggerProxy<ServerStreamingServerCallHandler<TRequest, TResponse>>();
 
         public ServerStreamingServerCallHandler(Method<TRequest, TResponse> method, ServerStreamingServerMethod<TRequest, TResponse> handler)
         {
@@ -143,8 +148,7 @@ namespace Grpc.Core.Internal
             {
                 if (!(e is RpcException))
                 {
-                    ILogger Logger = GrpcEnvironment.GetLoggerForType<ServerStreamingServerCallHandler<TRequest, TResponse>>();
-                    Logger.Warning(e, "Exception occured in handler.");
+                    globalLoggerProxy.GetLogger().Warning(e, "Exception occured in handler.");
                 }
                 status = HandlerUtils.StatusFromException(e);
             }
@@ -168,6 +172,8 @@ namespace Grpc.Core.Internal
     {
         readonly Method<TRequest, TResponse> method;
         readonly ClientStreamingServerMethod<TRequest, TResponse> handler;
+
+        GlobalLoggerProxy<ClientStreamingServerCallHandler<TRequest, TResponse>> globalLoggerProxy = new GlobalLoggerProxy<ClientStreamingServerCallHandler<TRequest, TResponse>>();
 
         public ClientStreamingServerCallHandler(Method<TRequest, TResponse> method, ClientStreamingServerMethod<TRequest, TResponse> handler)
         {
@@ -200,8 +206,7 @@ namespace Grpc.Core.Internal
             {
                 if (!(e is RpcException))
                 {
-                    ILogger Logger = GrpcEnvironment.GetLoggerForType<ClientStreamingServerCallHandler<TRequest, TResponse>>();
-                    Logger.Warning(e, "Exception occured in handler.");
+                    globalLoggerProxy.GetLogger().Warning(e, "Exception occured in handler.");
                 }
                 status = HandlerUtils.StatusFromException(e);
             }
@@ -225,6 +230,8 @@ namespace Grpc.Core.Internal
     {
         readonly Method<TRequest, TResponse> method;
         readonly DuplexStreamingServerMethod<TRequest, TResponse> handler;
+
+        GlobalLoggerProxy<DuplexStreamingServerCallHandler<TRequest, TResponse>> globalLoggerProxy = new GlobalLoggerProxy<DuplexStreamingServerCallHandler<TRequest,TResponse>>();
 
         public DuplexStreamingServerCallHandler(Method<TRequest, TResponse> method, DuplexStreamingServerMethod<TRequest, TResponse> handler)
         {
@@ -255,8 +262,7 @@ namespace Grpc.Core.Internal
             {
                 if (!(e is RpcException))
                 {
-                    ILogger Logger = GrpcEnvironment.GetLoggerForType<DuplexStreamingServerCallHandler<TRequest, TResponse>>();
-                    Logger.Warning(e, "Exception occured in handler.");
+                    globalLoggerProxy.GetLogger().Warning(e, "Exception occured in handler.");
                 }
                 status = HandlerUtils.StatusFromException(e);
             }

--- a/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
@@ -87,7 +87,7 @@ namespace Grpc.Core.Internal
             {
                 if (!(e is RpcException))
                 {
-                    ILogger Logger = GrpcEnvironment.Logger.ForType<UnaryServerCallHandler<TRequest, TResponse>>();
+                    ILogger Logger = GrpcEnvironment.GetLoggerForType<UnaryServerCallHandler<TRequest, TResponse>>();
                     Logger.Warning(e, "Exception occured in handler.");
                 }
                 status = HandlerUtils.StatusFromException(e);
@@ -143,7 +143,7 @@ namespace Grpc.Core.Internal
             {
                 if (!(e is RpcException))
                 {
-                    ILogger Logger = GrpcEnvironment.Logger.ForType<ServerStreamingServerCallHandler<TRequest, TResponse>>();
+                    ILogger Logger = GrpcEnvironment.GetLoggerForType<ServerStreamingServerCallHandler<TRequest, TResponse>>();
                     Logger.Warning(e, "Exception occured in handler.");
                 }
                 status = HandlerUtils.StatusFromException(e);
@@ -200,7 +200,7 @@ namespace Grpc.Core.Internal
             {
                 if (!(e is RpcException))
                 {
-                    ILogger Logger = GrpcEnvironment.Logger.ForType<ClientStreamingServerCallHandler<TRequest, TResponse>>();
+                    ILogger Logger = GrpcEnvironment.GetLoggerForType<ClientStreamingServerCallHandler<TRequest, TResponse>>();
                     Logger.Warning(e, "Exception occured in handler.");
                 }
                 status = HandlerUtils.StatusFromException(e);
@@ -255,7 +255,7 @@ namespace Grpc.Core.Internal
             {
                 if (!(e is RpcException))
                 {
-                    ILogger Logger = GrpcEnvironment.Logger.ForType<DuplexStreamingServerCallHandler<TRequest, TResponse>>();
+                    ILogger Logger = GrpcEnvironment.GetLoggerForType<DuplexStreamingServerCallHandler<TRequest, TResponse>>();
                     Logger.Warning(e, "Exception occured in handler.");
                 }
                 status = HandlerUtils.StatusFromException(e);

--- a/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
@@ -51,8 +51,6 @@ namespace Grpc.Core.Internal
         where TRequest : class
         where TResponse : class
     {
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<UnaryServerCallHandler<TRequest, TResponse>>();
-
         readonly Method<TRequest, TResponse> method;
         readonly UnaryServerMethod<TRequest, TResponse> handler;
 
@@ -89,6 +87,7 @@ namespace Grpc.Core.Internal
             {
                 if (!(e is RpcException))
                 {
+                    ILogger Logger = GrpcEnvironment.Logger.ForType<UnaryServerCallHandler<TRequest, TResponse>>();
                     Logger.Warning(e, "Exception occured in handler.");
                 }
                 status = HandlerUtils.StatusFromException(e);
@@ -110,8 +109,6 @@ namespace Grpc.Core.Internal
         where TRequest : class
         where TResponse : class
     {
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<ServerStreamingServerCallHandler<TRequest, TResponse>>();
-
         readonly Method<TRequest, TResponse> method;
         readonly ServerStreamingServerMethod<TRequest, TResponse> handler;
 
@@ -146,6 +143,7 @@ namespace Grpc.Core.Internal
             {
                 if (!(e is RpcException))
                 {
+                    ILogger Logger = GrpcEnvironment.Logger.ForType<ServerStreamingServerCallHandler<TRequest, TResponse>>();
                     Logger.Warning(e, "Exception occured in handler.");
                 }
                 status = HandlerUtils.StatusFromException(e);
@@ -168,8 +166,6 @@ namespace Grpc.Core.Internal
         where TRequest : class
         where TResponse : class
     {
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<ClientStreamingServerCallHandler<TRequest, TResponse>>();
-
         readonly Method<TRequest, TResponse> method;
         readonly ClientStreamingServerMethod<TRequest, TResponse> handler;
 
@@ -204,6 +200,7 @@ namespace Grpc.Core.Internal
             {
                 if (!(e is RpcException))
                 {
+                    ILogger Logger = GrpcEnvironment.Logger.ForType<ClientStreamingServerCallHandler<TRequest, TResponse>>();
                     Logger.Warning(e, "Exception occured in handler.");
                 }
                 status = HandlerUtils.StatusFromException(e);
@@ -226,8 +223,6 @@ namespace Grpc.Core.Internal
         where TRequest : class
         where TResponse : class
     {
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<DuplexStreamingServerCallHandler<TRequest, TResponse>>();
-
         readonly Method<TRequest, TResponse> method;
         readonly DuplexStreamingServerMethod<TRequest, TResponse> handler;
 
@@ -260,6 +255,7 @@ namespace Grpc.Core.Internal
             {
                 if (!(e is RpcException))
                 {
+                    ILogger Logger = GrpcEnvironment.Logger.ForType<DuplexStreamingServerCallHandler<TRequest, TResponse>>();
                     Logger.Warning(e, "Exception occured in handler.");
                 }
                 status = HandlerUtils.StatusFromException(e);

--- a/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
+++ b/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
@@ -59,12 +59,13 @@ namespace Grpc.Core.Internal
         readonly string libraryPath;
         readonly IntPtr handle;
 
+        GlobalLoggerProxy<UnmanagedLibrary> globalLoggerProxy = new GlobalLoggerProxy<UnmanagedLibrary>();
+
         public UnmanagedLibrary(string[] libraryPathAlternatives)
         {
             this.libraryPath = FirstValidLibraryPath(libraryPathAlternatives);
 
-            ILogger Logger = GrpcEnvironment.GetLoggerForType<UnmanagedLibrary>();
-            Logger.Debug("Attempting to load native library \"{0}\"", this.libraryPath);
+            globalLoggerProxy.GetLogger().Debug("Attempting to load native library \"{0}\"", this.libraryPath);
 
             this.handle = PlatformSpecificLoadLibrary(this.libraryPath);
 

--- a/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
+++ b/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
@@ -52,8 +52,6 @@ namespace Grpc.Core.Internal
     /// </summary>
     internal class UnmanagedLibrary
     {
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<UnmanagedLibrary>();
-
         // flags for dlopen
         const int RTLD_LAZY = 1;
         const int RTLD_GLOBAL = 8;
@@ -65,6 +63,7 @@ namespace Grpc.Core.Internal
         {
             this.libraryPath = FirstValidLibraryPath(libraryPathAlternatives);
 
+            ILogger Logger = GrpcEnvironment.Logger.ForType<UnmanagedLibrary>();
             Logger.Debug("Attempting to load native library \"{0}\"", this.libraryPath);
 
             this.handle = PlatformSpecificLoadLibrary(this.libraryPath);

--- a/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
+++ b/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
@@ -63,7 +63,7 @@ namespace Grpc.Core.Internal
         {
             this.libraryPath = FirstValidLibraryPath(libraryPathAlternatives);
 
-            ILogger Logger = GrpcEnvironment.Logger.ForType<UnmanagedLibrary>();
+            ILogger Logger = GrpcEnvironment.GetLoggerForType<UnmanagedLibrary>();
             Logger.Debug("Attempting to load native library \"{0}\"", this.libraryPath);
 
             this.handle = PlatformSpecificLoadLibrary(this.libraryPath);

--- a/src/csharp/Grpc.Core/Logging/GlobalLoggerProxy.cs
+++ b/src/csharp/Grpc.Core/Logging/GlobalLoggerProxy.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Grpc.Core.Logging
+{
+    internal class GlobalLoggerProxy<T>
+    {
+        private ILogger logger;
+
+        internal GlobalLoggerProxy()
+        {
+            this.logger = GrpcEnvironment.Logger.ForType<T>();
+            GrpcEnvironment.LoggerChangedEvent += logger_changed_event_handler;
+        }
+
+        internal ILogger GetLogger()
+        {
+            return logger;
+        }
+
+        private void logger_changed_event_handler(object sender, LoggerChangedEventArgs args)
+        {
+            this.logger = args.newLogger.ForType<T>();
+        }
+    }
+}

--- a/src/csharp/Grpc.Core/Logging/LoggerChangedEventArgs.cs
+++ b/src/csharp/Grpc.Core/Logging/LoggerChangedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Grpc.Core.Logging
+{
+    internal class LoggerChangedEventArgs : EventArgs
+    {
+        public readonly ILogger newLogger; 
+
+        public LoggerChangedEventArgs(ILogger newLogger)
+        {
+            this.newLogger = newLogger;
+        }
+    }
+}

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -66,6 +66,7 @@ namespace Grpc.Core
         bool startRequested;
         volatile bool shutdownRequested;
 
+        GlobalLoggerProxy<Server> globalLoggerProxy = new GlobalLoggerProxy<Server>();
 
         /// <summary>
         /// Creates a new server.
@@ -301,8 +302,7 @@ namespace Grpc.Core
             var activeCallCount = activeCallCounter.Count;
             if (activeCallCount > 0)
             {
-                ILogger Logger = GrpcEnvironment.GetLoggerForType<Server>();
-                Logger.Warning("Server shutdown has finished but there are still {0} active calls for that server.", activeCallCount);
+                globalLoggerProxy.GetLogger().Warning("Server shutdown has finished but there are still {0} active calls for that server.", activeCallCount);
             }
             handle.Dispose();
         }
@@ -323,8 +323,7 @@ namespace Grpc.Core
             }
             catch (Exception e)
             {
-                ILogger Logger = GrpcEnvironment.GetLoggerForType<Server>();
-                Logger.Warning(e, "Exception while handling RPC.");
+                globalLoggerProxy.GetLogger().Warning(e, "Exception while handling RPC.");
             }
         }
 

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -301,7 +301,7 @@ namespace Grpc.Core
             var activeCallCount = activeCallCounter.Count;
             if (activeCallCount > 0)
             {
-                ILogger Logger = GrpcEnvironment.Logger.ForType<Server>();
+                ILogger Logger = GrpcEnvironment.GetLoggerForType<Server>();
                 Logger.Warning("Server shutdown has finished but there are still {0} active calls for that server.", activeCallCount);
             }
             handle.Dispose();
@@ -323,7 +323,7 @@ namespace Grpc.Core
             }
             catch (Exception e)
             {
-                ILogger Logger = GrpcEnvironment.Logger.ForType<Server>();
+                ILogger Logger = GrpcEnvironment.GetLoggerForType<Server>();
                 Logger.Warning(e, "Exception while handling RPC.");
             }
         }

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -48,7 +48,6 @@ namespace Grpc.Core
     public class Server
     {
         const int InitialAllowRpcTokenCountPerCq = 10;
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<Server>();
 
         readonly AtomicCounter activeCallCounter = new AtomicCounter();
 
@@ -302,6 +301,7 @@ namespace Grpc.Core
             var activeCallCount = activeCallCounter.Count;
             if (activeCallCount > 0)
             {
+                ILogger Logger = GrpcEnvironment.Logger.ForType<Server>();
                 Logger.Warning("Server shutdown has finished but there are still {0} active calls for that server.", activeCallCount);
             }
             handle.Dispose();
@@ -323,6 +323,7 @@ namespace Grpc.Core
             }
             catch (Exception e)
             {
+                ILogger Logger = GrpcEnvironment.Logger.ForType<Server>();
                 Logger.Warning(e, "Exception while handling RPC.");
             }
         }
@@ -332,7 +333,7 @@ namespace Grpc.Core
         /// </summary>
         private void HandleNewServerRpc(bool success, BatchContextSafeHandle ctx, CompletionQueueSafeHandle cq)
         {
-			Task.Run(() => AllowOneRpc(cq));
+            Task.Run(() => AllowOneRpc(cq));
 
             if (success)
             {

--- a/src/csharp/Grpc.IntegrationTesting/ClientRunners.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ClientRunners.cs
@@ -59,6 +59,8 @@ namespace Grpc.IntegrationTesting
         // Profilers to use for clients.
         static readonly BlockingCollection<BasicProfiler> profilers = new BlockingCollection<BasicProfiler>();
 
+        static GlobalLoggerProxy<ClientRunners> GlobalLoggerProxy = new GlobalLoggerProxy<ClientRunners>();
+
         internal static void AddProfiler(BasicProfiler profiler)
         {
             GrpcPreconditions.CheckNotNull(profiler);
@@ -70,21 +72,21 @@ namespace Grpc.IntegrationTesting
         /// </summary>
         public static IClientRunner CreateStarted(ClientConfig config)
         {
-            ILogger Logger = GrpcEnvironment.GetLoggerForType<ClientRunners>();
+            ILogger logger = GlobalLoggerProxy.GetLogger();
 
-            Logger.Debug("ClientConfig: {0}", config);
+            logger.Debug("ClientConfig: {0}", config);
 
             if (config.AsyncClientThreads != 0)
             {
-                Logger.Warning("ClientConfig.AsyncClientThreads is not supported for C#. Ignoring the value");
+                logger.Warning("ClientConfig.AsyncClientThreads is not supported for C#. Ignoring the value");
             }
             if (config.CoreLimit != 0)
             {
-                Logger.Warning("ClientConfig.CoreLimit is not supported for C#. Ignoring the value");
+                logger.Warning("ClientConfig.CoreLimit is not supported for C#. Ignoring the value");
             }
             if (config.CoreList.Count > 0)
             {
-                Logger.Warning("ClientConfig.CoreList is not supported for C#. Ignoring the value");
+                logger.Warning("ClientConfig.CoreList is not supported for C#. Ignoring the value");
             }
 
             var channels = CreateChannels(config.ClientChannels, config.ServerTargets, config.SecurityParams);

--- a/src/csharp/Grpc.IntegrationTesting/ClientRunners.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ClientRunners.cs
@@ -56,8 +56,6 @@ namespace Grpc.IntegrationTesting
     /// </summary>
     public class ClientRunners
     {
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<ClientRunners>();
-
         // Profilers to use for clients.
         static readonly BlockingCollection<BasicProfiler> profilers = new BlockingCollection<BasicProfiler>();
 
@@ -72,6 +70,8 @@ namespace Grpc.IntegrationTesting
         /// </summary>
         public static IClientRunner CreateStarted(ClientConfig config)
         {
+            ILogger Logger = GrpcEnvironment.Logger.ForType<ClientRunners>();
+
             Logger.Debug("ClientConfig: {0}", config);
 
             if (config.AsyncClientThreads != 0)

--- a/src/csharp/Grpc.IntegrationTesting/ClientRunners.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ClientRunners.cs
@@ -70,7 +70,7 @@ namespace Grpc.IntegrationTesting
         /// </summary>
         public static IClientRunner CreateStarted(ClientConfig config)
         {
-            ILogger Logger = GrpcEnvironment.Logger.ForType<ClientRunners>();
+            ILogger Logger = GrpcEnvironment.GetLoggerForType<ClientRunners>();
 
             Logger.Debug("ClientConfig: {0}", config);
 

--- a/src/csharp/Grpc.IntegrationTesting/ServerRunners.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ServerRunners.cs
@@ -53,26 +53,28 @@ namespace Grpc.IntegrationTesting
     /// </summary>
     public class ServerRunners
     {
+        static GlobalLoggerProxy<ServerRunners> GlobalLoggerProxy = new GlobalLoggerProxy<ServerRunners>();
+
         /// <summary>
         /// Creates a started server runner.
         /// </summary>
         public static IServerRunner CreateStarted(ServerConfig config)
         {
-            ILogger Logger = GrpcEnvironment.GetLoggerForType<ServerRunners>();
-            Logger.Debug("ServerConfig: {0}", config);
+            ILogger logger = GlobalLoggerProxy.GetLogger();
+            logger.Debug("ServerConfig: {0}", config);
             var credentials = config.SecurityParams != null ? TestCredentials.CreateSslServerCredentials() : ServerCredentials.Insecure;
 
             if (config.AsyncServerThreads != 0)
             {
-                Logger.Warning("ServerConfig.AsyncServerThreads is not supported for C#. Ignoring the value");
+                logger.Warning("ServerConfig.AsyncServerThreads is not supported for C#. Ignoring the value");
             }
             if (config.CoreLimit != 0)
             {
-                Logger.Warning("ServerConfig.CoreLimit is not supported for C#. Ignoring the value");
+                logger.Warning("ServerConfig.CoreLimit is not supported for C#. Ignoring the value");
             }
             if (config.CoreList.Count > 0)
             {
-                Logger.Warning("ServerConfig.CoreList is not supported for C#. Ignoring the value");
+                logger.Warning("ServerConfig.CoreList is not supported for C#. Ignoring the value");
             }
 
             ServerServiceDefinition service = null;

--- a/src/csharp/Grpc.IntegrationTesting/ServerRunners.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ServerRunners.cs
@@ -53,13 +53,12 @@ namespace Grpc.IntegrationTesting
     /// </summary>
     public class ServerRunners
     {
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<ServerRunners>();
-
         /// <summary>
         /// Creates a started server runner.
         /// </summary>
         public static IServerRunner CreateStarted(ServerConfig config)
         {
+            ILogger Logger = GrpcEnvironment.Logger.ForType<ServerRunners>();
             Logger.Debug("ServerConfig: {0}", config);
             var credentials = config.SecurityParams != null ? TestCredentials.CreateSslServerCredentials() : ServerCredentials.Insecure;
 

--- a/src/csharp/Grpc.IntegrationTesting/ServerRunners.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ServerRunners.cs
@@ -58,7 +58,7 @@ namespace Grpc.IntegrationTesting
         /// </summary>
         public static IServerRunner CreateStarted(ServerConfig config)
         {
-            ILogger Logger = GrpcEnvironment.Logger.ForType<ServerRunners>();
+            ILogger Logger = GrpcEnvironment.GetLoggerForType<ServerRunners>();
             Logger.Debug("ServerConfig: {0}", config);
             var credentials = config.SecurityParams != null ? TestCredentials.CreateSslServerCredentials() : ServerCredentials.Insecure;
 

--- a/src/csharp/Grpc.IntegrationTesting/StressTestClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/StressTestClient.cs
@@ -51,6 +51,8 @@ namespace Grpc.IntegrationTesting
     {
         const double SecondsToNanos = 1e9;
 
+        GlobalLoggerProxy<StressTestClient> globalLoggerProxy = new GlobalLoggerProxy<StressTestClient>();
+
         private class ClientOptions
         {
             [Option("server_addresses", Default = "localhost:8080")]
@@ -151,8 +153,8 @@ namespace Grpc.IntegrationTesting
 
         async Task RunBodyAsync(TestService.TestServiceClient client)
         {
-            ILogger Logger = GrpcEnvironment.GetLoggerForType<StressTestClient>();
-            Logger.Info("Starting stress test client thread.");
+            ILogger logger = globalLoggerProxy.GetLogger();
+            logger.Info("Starting stress test client thread.");
             while (!finishedTokenSource.Token.IsCancellationRequested)
             {
                 var testCase = testCaseGenerator.GetNext();
@@ -164,7 +166,7 @@ namespace Grpc.IntegrationTesting
                 stopwatch.Stop();
                 histogram.AddObservation(stopwatch.Elapsed.TotalSeconds * SecondsToNanos);
             }
-            Logger.Info("Stress test client thread finished.");
+            logger.Info("Stress test client thread finished.");
         }
 
         async Task RunTestCaseAsync(TestService.TestServiceClient client, string testCase)

--- a/src/csharp/Grpc.IntegrationTesting/StressTestClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/StressTestClient.cs
@@ -49,7 +49,6 @@ namespace Grpc.IntegrationTesting
 {
     public class StressTestClient
     {
-        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<StressTestClient>();
         const double SecondsToNanos = 1e9;
 
         private class ClientOptions
@@ -152,6 +151,7 @@ namespace Grpc.IntegrationTesting
 
         async Task RunBodyAsync(TestService.TestServiceClient client)
         {
+            ILogger Logger = GrpcEnvironment.Logger.ForType<StressTestClient>();
             Logger.Info("Starting stress test client thread.");
             while (!finishedTokenSource.Token.IsCancellationRequested)
             {

--- a/src/csharp/Grpc.IntegrationTesting/StressTestClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/StressTestClient.cs
@@ -151,7 +151,7 @@ namespace Grpc.IntegrationTesting
 
         async Task RunBodyAsync(TestService.TestServiceClient client)
         {
-            ILogger Logger = GrpcEnvironment.Logger.ForType<StressTestClient>();
+            ILogger Logger = GrpcEnvironment.GetLoggerForType<StressTestClient>();
             Logger.Info("Starting stress test client thread.");
             while (!finishedTokenSource.Token.IsCancellationRequested)
             {


### PR DESCRIPTION
This allows the global logger change to take effect without reloading the actual classes, like the test runners look to be doing (https://github.com/grpc/grpc/blob/master/src/csharp/Grpc.Core.Tests/NUnitMain.cs), which I think would be preferred.

cc @jtattermusch @jskeet 
