### PR TITLE
Let tracing be enabled before starting an RPC

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -103,6 +103,11 @@ NSString * const kGRPCTrailersKey = @"io.grpc.TrailersKey";
 
 @synthesize state = _state;
 
+// TODO(jcanizales): If grpc_init is idempotent, this should be changed from load to initialize.
++ (void)load {
+  grpc_init();
+}
+
 - (instancetype)init {
   return [self initWithHost:nil path:nil requestsWriter:nil];
 }

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
@@ -245,11 +245,6 @@
   }
 
   if (self = [super init]) {
-    static dispatch_once_t initialization;
-    dispatch_once(&initialization, ^{
-      grpc_init();
-    });
-
     // Each completion queue consumes one thread. There's a trade to be made between creating and
     // consuming too many threads and having contention of multiple calls in a single completion
     // queue. Currently we use a singleton queue.


### PR DESCRIPTION
By calling grpc_init on [GRPCCall load], instead of lazily.

Solves #7822 by letting users call [`grpc_tracer_set_enabled`](https://github.com/grpc/grpc/blob/master/include/grpc/grpc.h#L386) before firing the first RPC.