### PR TITLE
Avoid static initialization of the kIdentity block

### DIFF
--- a/src/objective-c/RxLibrary/transformations/GRXMappingWriter.m
+++ b/src/objective-c/RxLibrary/transformations/GRXMappingWriter.m
@@ -33,10 +33,6 @@
 
 #import "GRXMappingWriter.h"
 
-static id (^kIdentity)(id value) = ^id(id value) {
-  return value;
-};
-
 @interface GRXForwardingWriter () <GRXWriteable>
 @end
 
@@ -51,7 +47,9 @@ static id (^kIdentity)(id value) = ^id(id value) {
 // Designated initializer
 - (instancetype)initWithWriter:(GRXWriter *)writer map:(id (^)(id value))map {
   if ((self = [super initWithWriter:writer])) {
-    _map = map ?: kIdentity;
+    _map = map ?: ^id(id value) {
+      return value;
+    };
   }
   return self;
 }


### PR DESCRIPTION
Unlike other Objective-C objects, there's no hard reason why the compiler wouldn't be able to initialize a block statically (as it does with `NSString` literals). And it certainly doesn't complain about it (like it does with other object initializers). But as I haven't been able to find confirmation of this, and we're seeing a weird crash occur near this code, let's play it safe.