### PR TITLE
Let's use \Grpc\Exeption\GrpcException

### DIFF
--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -34,6 +34,8 @@
 
 namespace Grpc;
 
+use Grpc\Exception\GrpcException;
+
 /**
  * Base class for generated client stubs. Stub methods are expected to call
  * _simpleRequest or _streamRequest and return the result.
@@ -53,6 +55,7 @@ class BaseStub
      * metadata array, and returns an updated metadata array
      *  - 'grpc.primary_user_agent': (optional) a user-agent string
      * @param $channel Channel An already created Channel object
+     * @throws GrpcException
      */
     public function __construct($hostname, $opts, $channel = null)
     {
@@ -78,13 +81,13 @@ class BaseStub
         $opts['grpc.primary_user_agent'] .=
             'grpc-php/'.$package_config['version'];
         if (!array_key_exists('credentials', $opts)) {
-            throw new \Exception("The opts['credentials'] key is now ".
+            throw new GrpcException("The opts['credentials'] key is now ".
                                  'required. Please see one of the '.
                                  'ChannelCredentials::create methods');
         }
         if ($channel) {
             if (!is_a($channel, 'Channel')) {
-                throw new \Exception('The channel argument is not a'.
+                throw new GrpcException('The channel argument is not a'.
                                      'Channel object');
             }
             $this->channel = $channel;
@@ -115,7 +118,7 @@ class BaseStub
      * @param $timeout in microseconds
      *
      * @return bool true if channel is ready
-     * @throw Exception if channel is in FATAL_ERROR state
+     * @throw GrpcException if channel is in FATAL_ERROR state
      */
     public function waitForReady($timeout)
     {
@@ -147,7 +150,7 @@ class BaseStub
             return true;
         }
         if ($new_state == \Grpc\CHANNEL_FATAL_FAILURE) {
-            throw new \Exception('Failed to connect to server');
+            throw new GrpcException('Failed to connect to server');
         }
 
         return false;

--- a/src/php/lib/Grpc/Exception/GrpcException.php
+++ b/src/php/lib/Grpc/Exception/GrpcException.php
@@ -1,0 +1,43 @@
+<?php
+/*
+ *
+ * Copyright 2015, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+namespace Grpc\Exception;
+
+/**
+ * Common Grpc Exception
+ * @package Grpc\Exception
+ */
+class GrpcException extends \Exception
+{
+}


### PR DESCRIPTION
Let's use \Grpc\Exeption\GrpcException except common \Exception. I project it is better catch particularly GrpcException than common \Exception. 
