### PR TITLE
remove log statements that showing contents of messages

### DIFF
--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -188,7 +188,6 @@ module GRPC
     # marshalled.
     def remote_send(req, marshalled = false)
       # TODO(murgatroid99): ensure metadata was sent
-      GRPC.logger.debug("sending #{req}, marshalled? #{marshalled}")
       payload = marshalled ? req : @marshal.call(req)
       @call.run_batch(SEND_MESSAGE => payload)
     end
@@ -225,11 +224,8 @@ module GRPC
         @call.metadata = batch_result.metadata
         @metadata_received = true
       end
-      GRPC.logger.debug("received req: #{batch_result}")
       unless batch_result.nil? || batch_result.message.nil?
-        GRPC.logger.debug("received req.to_s: #{batch_result.message}")
         res = @unmarshal.call(batch_result.message)
-        GRPC.logger.debug("received_req (unmarshalled): #{res.inspect}")
         return res
       end
       GRPC.logger.debug('found nil; the final response has been sent')

--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -391,7 +391,6 @@ module GRPC
 
       # allow the metadata to be accessed from the call
       an_rpc.call.metadata = an_rpc.metadata  # attaches md to call for handlers
-      GRPC.logger.debug("call md is #{an_rpc.metadata}")
       connect_md = nil
       unless @connect_md_proc.nil?
         connect_md = @connect_md_proc.call(an_rpc.method, an_rpc.metadata)


### PR DESCRIPTION
Removes log statements that were found to be a bottleneck with large messages in https://github.com/grpc/grpc/issues/7852, and that should probably be removed for info leaking too.