### PR TITLE
Add IWYU export pragmas to grpc++/grpc++.h.

### DIFF
--- a/include/grpc++/grpc++.h
+++ b/include/grpc++/grpc++.h
@@ -51,6 +51,8 @@
 #ifndef GRPCXX_GRPCXX_H
 #define GRPCXX_GRPCXX_H
 
+// Pragma for http://include-what-you-use.org/ tool, tells that following
+// headers are not private for grpc++.h and are part of its interface.
 // IWYU pragma: begin_exports
 #include <grpc/grpc.h>
 

--- a/include/grpc++/grpc++.h
+++ b/include/grpc++/grpc++.h
@@ -51,6 +51,7 @@
 #ifndef GRPCXX_GRPCXX_H
 #define GRPCXX_GRPCXX_H
 
+// IWYU pragma: begin_exports
 #include <grpc/grpc.h>
 
 #include <grpc++/channel.h>
@@ -62,5 +63,6 @@
 #include <grpc++/server_builder.h>
 #include <grpc++/server_context.h>
 #include <grpc++/server_posix.h>
+// IWYU pragma: end_exports
 
 #endif  // GRPCXX_GRPCXX_H


### PR DESCRIPTION
<a href="https://github.com/include-what-you-use/include-what-you-use">IWYU</a> is a C++ tool which ensures that end users explicitly #include every header they need. Without <a href="https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md">pragmas</a> IWYU have no way of distinguishing between 'implementation-specific' headers and headers which are shortcuts for groups of other headers, like grpc++.h.
