### PR TITLE
Allow protobufjs objects to be used for client calls

### DIFF
--- a/src/node/src/common.js
+++ b/src/node/src/common.js
@@ -84,7 +84,12 @@ exports.serializeCls = function serializeCls(Cls) {
    * @return {Buffer} The serialized object
    */
   return function serialize(arg) {
-    return new Buffer(new Cls(arg).encode().toBuffer());
+    // maybe we already have a protobufjs object?
+    if (!(arg instanceof Cls)) {
+      // nope - create one
+      arg = new Cls(arg);
+    }
+    return new Buffer(arg.encode().toBuffer());
   };
 };
 


### PR DESCRIPTION
Allows clients to use protobufjs objects when making rpc calls.
