### PR TITLE
allow choosing config of ruby package builds from environment variable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -100,13 +100,15 @@ desc 'Build the native gem file under rake_compiler_dock'
 task 'gem:native' do
   verbose = ENV['V'] || '0'
 
+  grpc_config = ENV['GRPC_CONFIG'] || 'opt'
+
   if RUBY_PLATFORM =~ /darwin/
     FileUtils.touch 'grpc_c.32.ruby'
     FileUtils.touch 'grpc_c.64.ruby'
-    system "rake cross native gem RUBY_CC_VERSION=2.3.0:2.2.2:2.1.5:2.0.0 V=#{verbose}"
+    system "rake cross native gem RUBY_CC_VERSION=2.3.0:2.2.2:2.1.5:2.0.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
   else
     Rake::Task['dlls'].execute
-    docker_for_windows "bundle && rake cross native gem RUBY_CC_VERSION=2.3.0:2.2.2:2.1.5:2.0.0 V=#{verbose}"
+    docker_for_windows "bundle && rake cross native gem RUBY_CC_VERSION=2.3.0:2.2.2:2.1.5:2.0.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
   end
 end
 

--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -91,6 +91,10 @@ if grpc_config == 'gcov'
   $LDFLAGS << ' -fprofile-arcs -ftest-coverage -rdynamic'
 end
 
+if grpc_config == 'dbg'
+  $CFLAGS << ' -O0'
+end
+
 $LDFLAGS << ' -Wl,-wrap,memcpy' if RUBY_PLATFORM =~ /linux/
 $LDFLAGS << ' -static' if windows
 


### PR DESCRIPTION
Used these changes to build a ruby package with symbols gdb.
Assuming we'd want -O0 on but can change that.

One little bit of info that may have been known but hung me up when checking build results:  I guess the opt shared lib builds are "not stripped" according to `file`, after running `strip -x`...