### PR TITLE
c#: throw RpcException for failed network sends instead of InvalidOperationException

### DIFF
--- a/src/csharp/Grpc.Core.Tests/Internal/AsyncCallServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/Internal/AsyncCallServerTest.cs
@@ -149,8 +149,7 @@ namespace Grpc.Core.Internal.Tests
 
             var writeTask = responseStream.WriteAsync("request1");
             fakeCall.SendCompletionHandler(false);
-            // TODO(jtattermusch): should we throw a different exception type instead?
-            Assert.ThrowsAsync(typeof(InvalidOperationException), async () => await writeTask);
+            Assert.ThrowsAsync(typeof(RpcException), async () => await writeTask);
 
             fakeCall.ReceivedCloseOnServerHandler(true, cancelled: true);
             AssertFinished(asyncCallServer, fakeCall, finishedTask);

--- a/src/csharp/Grpc.Core.Tests/Internal/AsyncCallTest.cs
+++ b/src/csharp/Grpc.Core.Tests/Internal/AsyncCallTest.cs
@@ -187,8 +187,7 @@ namespace Grpc.Core.Internal.Tests
 
             var writeTask = requestStream.WriteAsync("request1");
             fakeCall.SendCompletionHandler(false);
-            // TODO: maybe IOException or waiting for RPCException is more appropriate here.
-            Assert.ThrowsAsync(typeof(InvalidOperationException), async () => await writeTask);
+            Assert.ThrowsAsync(typeof(RpcException), async () => await writeTask);
 
             fakeCall.UnaryResponseClientHandler(true,
                 CreateClientSideStatus(StatusCode.Internal),

--- a/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs
@@ -2,11 +2,11 @@
 
 // Copyright 2015, Google Inc.
 // All rights reserved.
-// 
+//
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are
 // met:
-// 
+//
 //     * Redistributions of source code must retain the above copyright
 // notice, this list of conditions and the following disclaimer.
 //     * Redistributions in binary form must reproduce the above
@@ -16,7 +16,7 @@
 //     * Neither the name of Google Inc. nor the names of its
 // contributors may be used to endorse or promote products derived from
 // this software without specific prior written permission.
-// 
+//
 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 // "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 // LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -234,10 +234,10 @@ namespace Grpc.Core.Internal
             {
                 try
                 {
-                
+
                     msg = deserializer(payload);
                     return null;
-             
+
                 }
                 catch (Exception e)
                 {
@@ -263,7 +263,7 @@ namespace Grpc.Core.Internal
 
             if (!success)
             {
-                origTcs.SetException(new InvalidOperationException("Send failed"));
+                origTcs.SetException(new RpcException(new Status(StatusCode.Unavailable, "Send failed")));
             }
             else
             {
@@ -283,7 +283,7 @@ namespace Grpc.Core.Internal
 
             if (!success)
             {
-                sendStatusFromServerTcs.SetException(new InvalidOperationException("Error sending status from server."));
+                sendStatusFromServerTcs.SetException(new RpcException(new Status(StatusCode.Unavailable, "Error sending status from server.")));
             }
             else
             {


### PR DESCRIPTION
Currently, gRPC throws an `InvalidOperationException` when it's network sends fail. This communicates the wrong semantics (that you're doing something wrong), and also makes it difficult to handle error scenarios where we actually attempted an invalid operation (like reading trailers before trailers are available).

Because `InvalidOperationException` here communicates the wrong semantics, we can't be sure if an `InvalidOperationException` occurred because we performed an invalid operation, or because of a transient error, without testing for the string "failed send" or "error sending status" which makes for some messy error handling code. If we instead throw an `RpcException`, clients can easily know that the issue occurred within the RPC layer, rather than failing a contract on its part.

This pull request changes them to throw `RpcException`s with `UNAVAILABLE` status, but I'd also considered `INTERNAL`. I feel that unavailable communicates the potential transient nature of communication errors better than internal does (where something is "very broken").

Hope this is reasonable, or you have a better solution. Thanks for your time!

