### PR TITLE
Add //external:zlib to grpc_unsecure deps

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1216,6 +1216,7 @@ cc_library(
     ".",
   ],
   deps = [
+    "//external:zlib",
     ":gpr",
     "//external:nanopb",
   ],

--- a/templates/BUILD.template
+++ b/templates/BUILD.template
@@ -53,7 +53,8 @@
         target_dict['name'] == 'grpc++' or
         target_dict['name'] == 'grpc++_codegen_lib'):
       deps.append("//external:protobuf_clib")
-    elif target_dict['name'] == 'grpc':
+    elif (target_dict['name'] == 'grpc' or
+          target_dict['name'] == 'grpc_unsecure'):
       deps.append("//external:zlib")
     for d in target_dict.get('deps', []):
       if d.find('//') == 0 or d[0] == ':':


### PR DESCRIPTION
The grpc_unsecure rule has message_compress.c in its srcs list.
This file depends on zlib.h and such dependency should be covered
by the BUILD file.
