### PR TITLE
Nodejs examples: add return after calling callback(err)

### DIFF
--- a/examples/node/dynamic_codegen/route_guide/route_guide_client.js
+++ b/examples/node/dynamic_codegen/route_guide/route_guide_client.js
@@ -55,6 +55,7 @@ function runGetFeature(callback) {
   function featureCallback(error, feature) {
     if (error) {
       callback(error);
+      return;
     }
     if (feature.name === '') {
       console.log('Found no feature at ' +
@@ -117,13 +118,17 @@ function runRecordRoute(callback) {
     string: 'db_path'
   });
   fs.readFile(path.resolve(argv.db_path), function(err, data) {
-    if (err) callback(err);
+    if (err) {
+      callback(err);
+      return;
+    }
     var feature_list = JSON.parse(data);
 
     var num_points = 10;
     var call = client.recordRoute(function(error, stats) {
       if (error) {
         callback(error);
+        return;
       }
       console.log('Finished trip with', stats.point_count, 'points');
       console.log('Passed', stats.feature_count, 'features');

--- a/examples/node/static_codegen/route_guide/route_guide_client.js
+++ b/examples/node/static_codegen/route_guide/route_guide_client.js
@@ -56,6 +56,7 @@ function runGetFeature(callback) {
   function featureCallback(error, feature) {
     if (error) {
       callback(error);
+      return;
     }
     var latitude = feature.getLocation().getLatitude();
     var longitude = feature.getLocation().getLongitude();
@@ -115,7 +116,10 @@ function runRecordRoute(callback) {
     string: 'db_path'
   });
   fs.readFile(path.resolve(argv.db_path), function(err, data) {
-    if (err) callback(err);
+    if (err) {
+      callback(err);
+      return;
+    }
     // Transform the loaded features to Feature objects
     var feature_list = _.map(JSON.parse(data), function(value) {
       var feature = new messages.Feature();
@@ -131,6 +135,7 @@ function runRecordRoute(callback) {
     var call = client.recordRoute(function(error, stats) {
       if (error) {
         callback(error);
+        return;
       }
       console.log('Finished trip with', stats.getPointCount(), 'points');
       console.log('Passed', stats.getFeatureCount(), 'features');


### PR DESCRIPTION
Hi there,
the nodejs route_guide examples had a couple of `callback(err)` calls not followed by a `return;`.
This would not stop the code after `callback(err)` from running and may cause other errors (ie: [parse errors](https://github.com/grpc/grpc/blob/master/examples/node/dynamic_codegen/route_guide/route_guide_client.js#L121) or [an empty data set](https://github.com/grpc/grpc/blob/master/examples/node/dynamic_codegen/route_guide/route_guide_client.js#L158))

I may be wrong and I may have missed something, so let me know if that's the case :)