### PR TITLE
Upgraded lodash to 4+

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "bundledDependencies": ["node-pre-gyp"],
   "dependencies": {
     "arguejs": "^0.2.3",
-    "lodash": "^3.9.3",
+    "lodash": "^4.15.0",
     "nan": "^2.0.0",
     "protobufjs": "^4.0.0"
   },

--- a/src/node/src/common.js
+++ b/src/node/src/common.js
@@ -141,7 +141,7 @@ exports.getProtobufServiceAttrs = function getProtobufServiceAttrs(service,
     binaryAsBase64 = options.binaryAsBase64;
     longsAsStrings = options.longsAsStrings;
   }
-  return _.object(_.map(service.children, function(method) {
+  return _.fromPairs(_.map(service.children, function(method) {
     return [_.camelCase(method.name), {
       path: prefix + method.name,
       requestStream: method.requestStream,


### PR DESCRIPTION
Hola people!

Was playing around with grpc on node and realized it requires an older version of lodash -- in the spirit of keeping everything updated I'm sending this.

* `package.json` is updated
* `_.object` became `_.fromPairs` ([ref](https://github.com/lodash/lodash/wiki/Changelog#v400))

Ran `npm test` and everything seems fine -- let me know if any issue! :)

```
~/projects/grpc (master ✘) ✹✭ ᐅ npm test

> grpc@1.1.0-dev test /home/odino/projects/grpc
> mocha src/node/test && npm run-script lint



  Async functionality
    ✓ should not hang

...
...
...

  203 passing (5s)
  2 pending


> grpc@1.1.0-dev lint /home/odino/projects/grpc
> node ./node_modules/jshint/bin/jshint src/node/src src/node/test src/node/interop src/node/index.js --exclude-path=src/node/.jshintignore
```