### PR TITLE
Fix hardening-induced build problem

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 grpc (1.0.0-1) unstable; urgency=medium
 
   * New upstream release
+  * debian/rules: disable pie hardening as it conflicts with upstream's pic
+    hardening in the Makefile
 
  -- Andrew Pollock <apollock@debian.org>  Fri, 02 Sep 2016 14:27:15 +1000
 

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@
 DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/default.mk
 
-export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all,-pie
 
 # package maintainers to append CFLAGS
 #export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic

--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all,-pie
 #export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
 override_dh_auto_build:
-	make shared_c prefix=/usr V=1
+	make shared_c prefix=/usr
 
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))

--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 #export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
 override_dh_auto_build:
-	make shared_c prefix=/usr
+	make shared_c prefix=/usr V=1
 
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))


### PR DESCRIPTION
Disabling PIE because it conflicts with built-in PIC