### PR TITLE
PHP: Fix warning when the options is not array

### DIFF
--- a/src/php/lib/Grpc/AbstractCall.php
+++ b/src/php/lib/Grpc/AbstractCall.php
@@ -64,7 +64,7 @@ abstract class AbstractCall
         $deserialize,
         $options = []
     ) {
-        if (array_key_exists('timeout', $options) &&
+        if (isset($options['timeout']) &&
             is_numeric($timeout = $options['timeout'])
         ) {
             $now = Timeval::now();
@@ -77,7 +77,7 @@ abstract class AbstractCall
         $this->deserialize = $deserialize;
         $this->metadata = null;
         $this->trailing_metadata = null;
-        if (array_key_exists('call_credentials_callback', $options) &&
+        if (isset($options['call_credentials_callback']) &&
             is_callable($call_credentials_callback =
                 $options['call_credentials_callback'])
         ) {


### PR DESCRIPTION
For the commit: d58199b1d0e0d5d9e8ea55bbef18e175018f618d

When `options` is not `array` will generate warning: 
https://grpc-testing.appspot.com/job/gRPC_interop_pull_requests/7963/testReport/junit/(root)/tests/cloud_to_prod_auth_default_php_jwt_token_creds/
https://grpc-testing.appspot.com/job/gRPC_interop_pull_requests/7963/testReport/junit/(root)/tests/cloud_to_prod_auth_default_php7_jwt_token_creds/

So either uses `isset` or sets `array` param, but I personally prefer to use `isset`.