### PR TITLE
Add thread initializer hooks

### DIFF
--- a/include/grpc/support/thd.h
+++ b/include/grpc/support/thd.h
@@ -84,6 +84,19 @@ GPRAPI gpr_thd_id gpr_thd_currentid(void);
    Calling this on a detached thread has unpredictable results. */
 GPRAPI void gpr_thd_join(gpr_thd_id t);
 
+/* Provides hooks for a custom thread initializer.
+   init() is called from the parent thread, and set() from the child
+   thread. */
+typedef struct gpr_thd_ctx_vtable {
+  void *(*init)(void);
+  void (*set)(void *ctx);
+  void (*destroy)(void *ctx);
+} gpr_thd_ctx_vtable;
+
+/* Registers a custom thread initializer.  Should only be
+   called on grpc_init(). */
+GPRAPI void gpr_thd_set_ctx_vtable(gpr_thd_ctx_vtable *vtable);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/core/lib/support/thd_windows.c
+++ b/src/core/lib/support/thd_windows.c
@@ -114,4 +114,7 @@ void gpr_thd_join(gpr_thd_id t) {
   destroy_thread(info);
 }
 
+// Thread context is currently only implemented on posix
+void gpr_thd_set_ctx_vtable(gpr_thd_ctx_vtable *vtable) { GPR_ASSERT(0); }
+
 #endif /* GPR_WINDOWS */


### PR DESCRIPTION
This is needed for environments that need to propagate thread local storage to threads that they spawn.