### PR TITLE
Add docstrings to generated beta elements

### DIFF
--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -236,6 +236,10 @@ bool PrintBetaServicer(const ServiceDescriptor* service,
              service->name());
   {
     IndentScope raii_class_indent(out);
+    out->Print("\"\"\"The Beta API is deprecated for 0.15.0 and later.\n"
+    "\nIt is recommended to use the GA API (classes and functions in this\n"
+    "file not marked beta) for all further purposes. This class was generated\n"
+     "only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0.\"\"\"\n");
     PrintAllComments(service, out);
     for (int i = 0; i < service->method_count(); ++i) {
       auto meth = service->method(i);
@@ -259,6 +263,10 @@ bool PrintBetaStub(const ServiceDescriptor* service,
   out->Print("class Beta$Service$Stub(object):\n", "Service", service->name());
   {
     IndentScope raii_class_indent(out);
+    out->Print("\"\"\"The Beta API is deprecated for 0.15.0 and later.\n"
+    "\nIt is recommended to use the GA API (classes and functions in this\n"
+    "file not marked beta) for all further purposes. This class was generated\n"
+     "only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0.\"\"\"\n");
     PrintAllComments(service, out);
     for (int i = 0; i < service->method_count(); ++i) {
       const MethodDescriptor* meth = service->method(i);
@@ -287,6 +295,11 @@ bool PrintBetaServerFactory(const grpc::string& package_qualified_service_name,
              "Service", service->name());
   {
     IndentScope raii_create_server_indent(out);
+    out->Print("\"\"\"The Beta API is deprecated for 0.15.0 and later.\n"
+    "\nIt is recommended to use the GA API (classes and functions in this\n"
+    "file not marked beta) for all further purposes. This function was\n"
+    "generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"
+    "\"\"\"\n");
     map<grpc::string, grpc::string> method_implementation_constructors;
     map<grpc::string, grpc::string> input_message_modules_and_classes;
     map<grpc::string, grpc::string> output_message_modules_and_classes;
@@ -381,6 +394,11 @@ bool PrintBetaStubFactory(const grpc::string& package_qualified_service_name,
              " metadata_transformer=None, pool=None, pool_size=None):\n");
   {
     IndentScope raii_create_server_indent(out);
+    out->Print("\"\"\"The Beta API is deprecated for 0.15.0 and later.\n"
+    "\nIt is recommended to use the GA API (classes and functions in this\n"
+    "file not marked beta) for all further purposes. This function was\n"
+    "generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"
+    "\"\"\"\n");
     map<grpc::string, grpc::string> method_cardinalities;
     map<grpc::string, grpc::string> input_message_modules_and_classes;
     map<grpc::string, grpc::string> output_message_modules_and_classes;


### PR DESCRIPTION
Add docstrings to generated methods stating Beta methods are there just
to ease transition from releases before 0.15.0 to releases including and
after 0.15.0

- PrintBetaServicer
- PrintBetaStub
- PrintBetaServerFactory
- PrintBetaStubFactory