### PR TITLE
Add 'node6' to the other spot where it's needed in run_tests.py

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -938,7 +938,7 @@ argp.add_argument('--compiler',
                            'clang3.4', 'clang3.5', 'clang3.6', 'clang3.7',
                            'vs2010', 'vs2013', 'vs2015',
                            'python2.7', 'python3.4',
-                           'node0.12', 'node4', 'node5',
+                           'node0.12', 'node4', 'node5', 'node6',
                            'coreclr'],
                   default='default',
                   help='Selects compiler to use. Allowed values depend on the platform and language.')


### PR DESCRIPTION
Add the other change required to make `run_tests.py` recognize node6 as a valid compiler.