### PR TITLE
PHP: change the php ssl server credentials API so that a server can have multiple key/cert pairs

### DIFF
--- a/src/php/ext/grpc/server_credentials.c
+++ b/src/php/ext/grpc/server_credentials.c
@@ -31,6 +31,7 @@
 #include <zend_exceptions.h>
 #include <zend_hash.h>
 
+#include <grpc/support/alloc.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 
@@ -46,8 +47,8 @@ PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_server_credentials)
   }
 PHP_GRPC_FREE_WRAPPED_FUNC_END()
 
-/* Initializes an instace of wrapped_grpc_server_credentials to be
- * associated with an object of a class specified by class_type */
+/* Initializes an instace of wrapped_grpc_server_credentials to be associated
+ * with an object of a class specified by class_type */
 php_grpc_zend_object create_wrapped_grpc_server_credentials(
     zend_class_entry *class_type TSRMLS_DC) {
   PHP_GRPC_ALLOC_CLASS_OBJECT(wrapped_grpc_server_credentials);
@@ -70,34 +71,98 @@ zval *grpc_php_wrap_server_credentials(grpc_server_credentials
 
 /**
  * Create SSL credentials.
- * @param string pem_root_certs PEM encoding of the server root certificates
- * @param string pem_private_key PEM encoding of the client's private key
- * @param string pem_cert_chain PEM encoding of the client's certificate chain
+ * @param string $pem_root_certs PEM encoding of the server root certificates
+ * @param array $array The array of PEM encoding of the client's certificates
+ * @param bool $force_client_auth If request the client certificate (optional)
  * @return Credentials The new SSL credentials object
  */
 PHP_METHOD(ServerCredentials, createSsl) {
   char *pem_root_certs = 0;
-  grpc_ssl_pem_key_cert_pair pem_key_cert_pair;
-
   php_grpc_int root_certs_length = 0;
-  php_grpc_int private_key_length;
-  php_grpc_int cert_chain_length;
+  zend_bool force_client_auth = 0;
+  grpc_ssl_pem_key_cert_pair* pem_key_cert_pairs;
+  int key_cert_pair_count;
+  zval *array;
+  HashTable *array_hash;
+  HashTable *inner_hash;
+  php_grpc_ulong index;
 
-  /* "s!ss" == 1 nullable string, 2 strings */
-  /* TODO: support multiple key cert pairs. */
-  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s!ss", &pem_root_certs,
-                            &root_certs_length, &pem_key_cert_pair.private_key,
-                            &private_key_length, &pem_key_cert_pair.cert_chain,
-                            &cert_chain_length) == FAILURE) {
+  zval *value;
+  zval *private_key_value;
+  zval *cert_chain_value;
+
+  /* "s!a|b" == 1 nullable string, 1 array, 1 optional bool */
+  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s!a|b",
+                            &pem_root_certs, &root_certs_length, &array,
+                            &force_client_auth) == FAILURE) {
     zend_throw_exception(spl_ce_InvalidArgumentException,
-                         "createSsl expects 3 strings", 1 TSRMLS_CC);
+                         "createSsl expects 1 string, 1 array and "
+                         "1 optional bool", 1 TSRMLS_CC);
     return;
   }
-  /* TODO: add a client_certificate_request field in ServerCredentials and pass
-   * it as the last parameter. */
+
+  array_hash = Z_ARRVAL_P(array);
+  key_cert_pair_count = zend_hash_num_elements(array_hash);
+  if (key_cert_pair_count == 0) {
+    zend_throw_exception(spl_ce_InvalidArgumentException,
+                         "expects 1 array with 1 elem at least",
+                         1 TSRMLS_CC);
+  }
+
+  /* Default to not requesting the client certificate */
+  grpc_ssl_client_certificate_request_type client_certificate_request =
+    GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE;
+  if (force_client_auth) {
+    client_certificate_request =
+      GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY;
+  }
+  pem_key_cert_pairs = gpr_malloc(sizeof(grpc_ssl_pem_key_cert_pair) *
+                                  key_cert_pair_count);
+
+  char *key = NULL;
+  int key_type;
+  PHP_GRPC_HASH_FOREACH_LONG_KEY_VAL_START(array_hash, key, key_type, index,
+                                           value)
+    if (key_type != HASH_KEY_IS_LONG || key != NULL) {
+      zend_throw_exception(spl_ce_InvalidArgumentException,
+                           "keys must be integers", 1 TSRMLS_CC);
+      gpr_free(pem_key_cert_pairs);
+      return;
+    }
+    if (Z_TYPE_P(value) != IS_ARRAY) {
+      zend_throw_exception(spl_ce_InvalidArgumentException,
+                          "expected an array", 1 TSRMLS_CC);
+      gpr_free(pem_key_cert_pairs);
+      return;
+    }
+
+    inner_hash = Z_ARRVAL_P(value);
+    if (php_grpc_zend_hash_find(inner_hash, "private_key", sizeof("private_key"),
+                       (void**)&private_key_value) != SUCCESS ||
+        Z_TYPE_P(private_key_value) != IS_STRING) {
+      zend_throw_exception(spl_ce_InvalidArgumentException,
+                           "expected a string", 1 TSRMLS_CC);
+      gpr_free(pem_key_cert_pairs);
+      return;
+    }
+    if (php_grpc_zend_hash_find(inner_hash, "cert_chain", sizeof("cert_chain"),
+                       (void**)&cert_chain_value) != SUCCESS ||
+        Z_TYPE_P(cert_chain_value) != IS_STRING) {
+      zend_throw_exception(spl_ce_InvalidArgumentException,
+                           "expected a string", 1 TSRMLS_CC);
+      gpr_free(pem_key_cert_pairs);
+      return;
+    }
+
+    pem_key_cert_pairs[index].private_key = Z_STRVAL_P(private_key_value);
+    pem_key_cert_pairs[index].cert_chain = Z_STRVAL_P(cert_chain_value);
+  PHP_GRPC_HASH_FOREACH_END()
+
   grpc_server_credentials *creds = grpc_ssl_server_credentials_create_ex(
-      pem_root_certs, &pem_key_cert_pair, 1,
-      GRPC_SSL_DONT_REQUEST_CLIENT_CERTIFICATE, NULL);
+      pem_root_certs, pem_key_cert_pairs, key_cert_pair_count,
+      client_certificate_request, NULL);
+  gpr_free(pem_key_cert_pairs);
+
   zval *creds_object = grpc_php_wrap_server_credentials(creds TSRMLS_CC);
   RETURN_DESTROY_ZVAL(creds_object);
 }

--- a/src/php/tests/unit_tests/CallCredentials2Test.php
+++ b/src/php/tests/unit_tests/CallCredentials2Test.php
@@ -21,12 +21,15 @@ class CallCredentials2Test extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $credentials = Grpc\ChannelCredentials::createSsl(
-            file_get_contents(dirname(__FILE__).'/../data/ca.pem'));
+        $ca = file_get_contents(dirname(__FILE__).'/../data/ca.pem');
+        $key = file_get_contents(dirname(__FILE__).'/../data/server1.key');
+        $pem = file_get_contents(dirname(__FILE__).'/../data/server1.pem');
+
+        $credentials = Grpc\ChannelCredentials::createSsl($ca);
         $server_credentials = Grpc\ServerCredentials::createSsl(
             null,
-            file_get_contents(dirname(__FILE__).'/../data/server1.key'),
-            file_get_contents(dirname(__FILE__).'/../data/server1.pem'));
+            [['private_key' => $key,
+              'cert_chain' => $pem, ]]);
         $this->server = new Grpc\Server();
         $this->port = $this->server->addSecureHttp2Port('0.0.0.0:0',
                                               $server_credentials);
@@ -66,7 +69,7 @@ class CallCredentials2Test extends PHPUnit_Framework_TestCase
                               $this->host_override);
 
         $call_credentials = Grpc\CallCredentials::createFromPlugin(
-            array($this, 'callbackFunc'));
+            [$this, 'callbackFunc']);
         $call->setCredentials($call_credentials);
 
         $event = $call->startBatch([

--- a/src/php/tests/unit_tests/CallCredentialsTest.php
+++ b/src/php/tests/unit_tests/CallCredentialsTest.php
@@ -21,8 +21,11 @@ class CallCredentialsTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->credentials = Grpc\ChannelCredentials::createSsl(
-            file_get_contents(dirname(__FILE__).'/../data/ca.pem'));
+        $ca = file_get_contents(dirname(__FILE__).'/../data/ca.pem');
+        $key = file_get_contents(dirname(__FILE__).'/../data/server1.key');
+        $pem = file_get_contents(dirname(__FILE__).'/../data/server1.pem');
+
+        $this->credentials = Grpc\ChannelCredentials::createSsl($ca);
         $this->call_credentials = Grpc\CallCredentials::createFromPlugin(
             [$this, 'callbackFunc']);
         $this->credentials = Grpc\ChannelCredentials::createComposite(
@@ -31,8 +34,8 @@ class CallCredentialsTest extends PHPUnit_Framework_TestCase
         );
         $server_credentials = Grpc\ServerCredentials::createSsl(
             null,
-            file_get_contents(dirname(__FILE__).'/../data/server1.key'),
-            file_get_contents(dirname(__FILE__).'/../data/server1.pem'));
+            [['private_key' => $key,
+              'cert_chain' => $pem, ]]);
         $this->server = new Grpc\Server();
         $this->port = $this->server->addSecureHttp2Port('0.0.0.0:0',
                                               $server_credentials);

--- a/src/php/tests/unit_tests/SecureEndToEndTest.php
+++ b/src/php/tests/unit_tests/SecureEndToEndTest.php
@@ -20,12 +20,15 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $credentials = Grpc\ChannelCredentials::createSsl(
-            file_get_contents(dirname(__FILE__).'/../data/ca.pem'));
+        $ca = file_get_contents(dirname(__FILE__).'/../data/ca.pem');
+        $key = file_get_contents(dirname(__FILE__).'/../data/server1.key');
+        $pem = file_get_contents(dirname(__FILE__).'/../data/server1.pem');
+
+        $credentials = Grpc\ChannelCredentials::createSsl($ca);
         $server_credentials = Grpc\ServerCredentials::createSsl(
             null,
-            file_get_contents(dirname(__FILE__).'/../data/server1.key'),
-            file_get_contents(dirname(__FILE__).'/../data/server1.pem'));
+            [['private_key' => $key,
+              'cert_chain' => $pem, ]]);
         $this->server = new Grpc\Server();
         $this->port = $this->server->addSecureHttp2Port('0.0.0.0:0',
                                               $server_credentials);

--- a/src/php/tests/unit_tests/ServerCredentialsTest.php
+++ b/src/php/tests/unit_tests/ServerCredentialsTest.php
@@ -1,0 +1,111 @@
+<?php
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+class ServerCredentialsTest extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->ca_data =
+            file_get_contents(dirname(__FILE__).'/../data/ca.pem');
+        $this->key_data =
+            file_get_contents(dirname(__FILE__).'/../data/server1.key');
+        $this->pem_data =
+            file_get_contents(dirname(__FILE__).'/../data/server1.pem');
+    }
+
+    public function tearDown()
+    {
+    }
+
+    public function testCreateSslWithStrAndArray()
+    {
+        $server_creds = Grpc\ServerCredentials::createSsl($this->ca_data,
+            [['private_key' => $this->key_data,
+              'cert_chain' => $this->pem_data, ]]);
+        $this->assertNotNull($server_creds);
+    }
+
+    public function testCreateSslWithStrAndArrayAndBool()
+    {
+        $server_creds = Grpc\ServerCredentials::createSsl($this->ca_data,
+            [['private_key' => $this->key_data,
+              'cert_chain' => $this->pem_data, ]], true);
+        $this->assertNotNull($server_creds);
+    }
+
+    public function testCreateSslWithNullAndArray()
+    {
+        $server_creds = Grpc\ServerCredentials::createSsl(null,
+            [['private_key' => $this->key_data,
+              'cert_chain' => $this->pem_data, ]]);
+        $this->assertNotNull($server_creds);
+    }
+
+    public function testCreateSslWithArrays()
+    {
+        $server_creds = Grpc\ServerCredentials::createSsl(null,
+            [['private_key' => $this->key_data,
+              'cert_chain' => $this->pem_data, ],
+             ['private_key' => $this->key_data,
+              'cert_chain' => $this->pem_data, ], ]);
+        $this->assertNotNull($server_creds);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCreateSslWithStrNotArray()
+    {
+        $server_creds = Grpc\ServerCredentials::createSsl($this->ca_data,
+                                                          'not_array');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCreateSslWithNullArray()
+    {
+        $server_creds = Grpc\ServerCredentials::createSsl('test', []);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCreateSslWithNullArrayAndNotBool()
+    {
+        $server_creds = Grpc\ServerCredentials::createSsl($this->ca_data, [],
+                                                          'test');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCreateSslWithNotArrayOfArray()
+    {
+        $server_creds = Grpc\ServerCredentials::createSsl(null, ['test']);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCreateSslWithNotCertChainOfArray()
+    {
+        $server_creds = Grpc\ServerCredentials::createSsl(null,
+            [['private_key' => $this->key_data]]);
+    }
+}


### PR DESCRIPTION
Fixed #1122.
The same as #7566 because it have conflict.
