### PR TITLE
Set O_NONBLOCK on grpc_server_add_insecure_channel_from_fd

### DIFF
--- a/src/core/ext/transport/chttp2/client/insecure/channel_create_posix.c
+++ b/src/core/ext/transport/chttp2/client/insecure/channel_create_posix.c
@@ -61,7 +61,7 @@ grpc_channel *grpc_insecure_channel_create_from_fd(
   grpc_channel_args *final_args =
       grpc_channel_args_copy_and_add(args, &default_authority_arg, 1);
 
-  GPR_ASSERT(GRPC_LOG_IF_ERROR("set_socket_non_blocking",
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("grpc_set_socket_nonblocking",
                                grpc_set_socket_nonblocking(fd, 1)));
 
   grpc_endpoint *client = grpc_tcp_client_create_from_fd(

--- a/src/core/ext/transport/chttp2/client/insecure/channel_create_posix.c
+++ b/src/core/ext/transport/chttp2/client/insecure/channel_create_posix.c
@@ -42,6 +42,7 @@
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
+#include "src/core/lib/iomgr/socket_utils_posix.h"
 #include "src/core/lib/iomgr/tcp_client_posix.h"
 #include "src/core/lib/iomgr/tcp_posix.h"
 #include "src/core/lib/surface/api_trace.h"

--- a/src/core/ext/transport/chttp2/client/insecure/channel_create_posix.c
+++ b/src/core/ext/transport/chttp2/client/insecure/channel_create_posix.c
@@ -38,8 +38,6 @@
 
 #ifdef GPR_SUPPORT_CHANNELS_FROM_FD
 
-#include <fcntl.h>
-
 #include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/iomgr/endpoint.h"
@@ -63,8 +61,8 @@ grpc_channel *grpc_insecure_channel_create_from_fd(
   grpc_channel_args *final_args =
       grpc_channel_args_copy_and_add(args, &default_authority_arg, 1);
 
-  int flags = fcntl(fd, F_GETFL, 0);
-  GPR_ASSERT(fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0);
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("set_socket_non_blocking",
+                               grpc_set_socket_nonblocking(fd, 1)));
 
   grpc_endpoint *client = grpc_tcp_client_create_from_fd(
       &exec_ctx, grpc_fd_create(fd, "client"), args, "fd-client");

--- a/src/core/ext/transport/chttp2/server/insecure/server_chttp2_posix.c
+++ b/src/core/ext/transport/chttp2/server/insecure/server_chttp2_posix.c
@@ -58,7 +58,6 @@ void grpc_server_add_insecure_channel_from_fd(grpc_server *server,
   char *name;
   gpr_asprintf(&name, "fd:%d", fd);
 
-
   GPR_ASSERT(GRPC_LOG_IF_ERROR("grpc_set_socket_nonblocking",
                                grpc_set_socket_nonblocking(fd, 1)));
 

--- a/src/core/ext/transport/chttp2/server/insecure/server_chttp2_posix.c
+++ b/src/core/ext/transport/chttp2/server/insecure/server_chttp2_posix.c
@@ -38,6 +38,8 @@
 
 #ifdef GPR_SUPPORT_CHANNELS_FROM_FD
 
+#include <fcntl.h>
+
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
 
@@ -56,6 +58,9 @@ void grpc_server_add_insecure_channel_from_fd(grpc_server *server,
   grpc_exec_ctx exec_ctx = GRPC_EXEC_CTX_INIT;
   char *name;
   gpr_asprintf(&name, "fd:%d", fd);
+
+  int flags = fcntl(fd, F_GETFL, 0);
+  GPR_ASSERT(fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0);
 
   grpc_resource_quota *resource_quota = grpc_resource_quota_from_channel_args(
       grpc_server_get_channel_args(server));

--- a/src/core/ext/transport/chttp2/server/insecure/server_chttp2_posix.c
+++ b/src/core/ext/transport/chttp2/server/insecure/server_chttp2_posix.c
@@ -38,8 +38,6 @@
 
 #ifdef GPR_SUPPORT_CHANNELS_FROM_FD
 
-#include <fcntl.h>
-
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
 
@@ -47,6 +45,7 @@
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
+#include "src/core/lib/iomgr/socket_utils_posix.h"
 #include "src/core/lib/iomgr/tcp_posix.h"
 #include "src/core/lib/surface/completion_queue.h"
 #include "src/core/lib/surface/server.h"
@@ -59,8 +58,9 @@ void grpc_server_add_insecure_channel_from_fd(grpc_server *server,
   char *name;
   gpr_asprintf(&name, "fd:%d", fd);
 
-  int flags = fcntl(fd, F_GETFL, 0);
-  GPR_ASSERT(fcntl(fd, F_SETFL, flags | O_NONBLOCK) == 0);
+
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("set_socket_non_blocking",
+                               grpc_set_socket_nonblocking(fd, 1)));
 
   grpc_resource_quota *resource_quota = grpc_resource_quota_from_channel_args(
       grpc_server_get_channel_args(server));

--- a/src/core/ext/transport/chttp2/server/insecure/server_chttp2_posix.c
+++ b/src/core/ext/transport/chttp2/server/insecure/server_chttp2_posix.c
@@ -59,7 +59,7 @@ void grpc_server_add_insecure_channel_from_fd(grpc_server *server,
   gpr_asprintf(&name, "fd:%d", fd);
 
 
-  GPR_ASSERT(GRPC_LOG_IF_ERROR("set_socket_non_blocking",
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("grpc_set_socket_nonblocking",
                                grpc_set_socket_nonblocking(fd, 1)));
 
   grpc_resource_quota *resource_quota = grpc_resource_quota_from_channel_args(


### PR DESCRIPTION
Otherwise, if someone passes a file descriptor where it is not set yet, the server will block. It matches the grpc_insecure_channel_create_from_fd, where we already set the flag.
