### PR TITLE
Fixe cmake template, link some targets to zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -729,6 +729,7 @@ target_include_directories(grpc_cronet
 target_link_libraries(grpc_cronet
   ${_gRPC_BASELIB_LIBRARIES}
   ${_gRPC_SSL_LIBRARIES}
+  ${_gRPC_ZLIB_LIBRARIES}
   gpr
 )
 
@@ -957,6 +958,7 @@ target_include_directories(grpc_unsecure
 
 target_link_libraries(grpc_unsecure
   ${_gRPC_BASELIB_LIBRARIES}
+  ${_gRPC_ZLIB_LIBRARIES}
   gpr
 )
 

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -50,7 +50,7 @@
       deps.append("${_gRPC_SSL_LIBRARIES}")
     if target_dict['name'] in ['grpc++', 'grpc++_unsecure', 'grpc++_codegen_lib']:
       deps.append("${_gRPC_PROTOBUF_LIBRARIES}")
-    elif target_dict['name'] in ['grpc']:
+    elif target_dict['name'] in ['grpc', 'grpc_cronet', 'grpc_unsecure']:
       deps.append("${_gRPC_ZLIB_LIBRARIES}")
     for d in target_dict.get('deps', []):
       deps.append(d)


### PR DESCRIPTION
grpc_cronet/grpc_unsecure needs to be linked against zlib, otherwise
build will fail with cmake and BUILD_SHARED_LIBS=ON.
