### PR TITLE
Fix building of protoc artifacts on Windows.

### DIFF
--- a/tools/run_tests/build_artifact_protoc.bat
+++ b/tools/run_tests/build_artifact_protoc.bat
@@ -32,12 +32,8 @@ mkdir artifacts
 setlocal
 cd third_party/protobuf
 
-powershell -Command "Invoke-WebRequest https://googlemock.googlecode.com/files/gmock-1.7.0.zip -OutFile gmock.zip"
-powershell -Command "Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::ExtractToDirectory('gmock.zip', '.');"
-rename gmock-1.7.0 gmock
-
 cd cmake
-cmake -G "%generator%" || goto :error
+cmake -G "%generator%" -Dprotobuf_BUILD_TESTS=OFF || goto :error
 endlocal
 
 call vsprojects/build_plugins.bat || goto :error


### PR DESCRIPTION
The link https://googlemock.googlecode.com/files/gmock-1.7.0.zip is dead. We could also update the link, but disabling the protobuf tests speeds up building and we only need the protoc artifacts anyway.

In this build, the windows protoc artifacts have been build successfully:
https://googlemock.googlecode.com/files/gmock-1.7.0.zip

CC @apolcyn 