### PR TITLE
Add interop test for Cacheable Unary Calls

### DIFF
--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -67,13 +67,17 @@ of POST, and that server sets appropriate cache control headers for the response
 to be cached by a proxy. This interop test requires that the server is behind
 a caching proxy. Use of current timestamp in the request prevents accidental
 cache matches left over from previous tests.
+Note that client adds a `x-user-ip` header with value `1.2.3.4` to the request.
+This is done since some proxys such as GFE will not cache requests from
+localhost.
 
 Server features:
 * [CacheableUnaryCall][]
 
 Procedure:
  1. Client calls CacheableUnaryCall with `SimpleRequest` request with payload
-    set to current timestamp.
+    set to current timestamp. Timestamp format is irrelevant, and resolution is
+    in nanoseconds.
  2. Client calls CacheableUnaryCall with `SimpleRequest` request again
     immediately with the same payload as the previous request.
 
@@ -965,13 +969,12 @@ for the `SimpleRequest.response_type`. If the server does not support the
 ### CacheableUnaryCall
 
 Server gets the default SimpleRequest proto as the request. The content of the
-request are ignored. It returns the SimpleResponse proto with the payload set 
-to current timestamp string.  In addition it adds
+request is ignored. It returns the SimpleResponse proto with the payload set
+to current timestamp.  The timestamp is an integer representing current time
+with nanosecond resolution. In addition it adds
   1. cache control headers such that the response can be cached by proxies in
      the response path. Server should be behind a caching proxy for this test
-     to pass.
-  2. adds a `x-user-ip` header with `1.2.3.4` to the response. This is done
-     since some proxys such as GFE will not cache requests from localhost.
+     to pass. Currently we set the max-age to 60 seconds.
 
 ### CompressedResponse
 [CompressedResponse]: #compressedresponse

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -70,6 +70,10 @@ cache matches left over from previous tests.
 Note that client adds a `x-user-ip` header with value `1.2.3.4` to the request.
 This is done since some proxys such as GFE will not cache requests from
 localhost.
+Note also that the client request needs to marked as cacheable. For now this is
+achieved by setting the cacheable flag in the request context to 'true'.Longer
+term this will be automatically set via method options specified in the proto
+file.
 
 Server features:
 * [CacheableUnaryCall][]

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -82,7 +82,7 @@ Procedure:
     request context. Longer term this should be driven by the method option
     specified in the proto file itself.
  2. Client calls CacheableUnaryCall with `SimpleRequest` request again
-    immediately with the same payload as the previous request. Cacheable flat is
+    immediately with the same payload as the previous request. Cacheable flag is
     also set for this request's context.
 
 Client asserts:

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -964,9 +964,9 @@ for the `SimpleRequest.response_type`. If the server does not support the
 
 ### CacheableUnaryCall
 
-Server gets the default Empty proto as the request. It returns the
-SimpleResponse proto with the payload set to current timestamp string.
-In addition it adds
+Server gets the default SimpleRequest proto as the request. The content of the
+request are ignored. It returns the SimpleResponse proto with the payload set 
+to current timestamp string.  In addition it adds
   1. cache control headers such that the response can be cached by proxies in
      the response path. Server should be behind a caching proxy for this test
      to pass.

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -64,7 +64,7 @@ ensure that the proto serialized to zero bytes.*
 
 This test verifies that gRPC requests marked as cacheable use GET verb instead
 of POST, and that server sets appropriate cache control headers for the response
-to be cached by a proxy. This interop test requires that the server is behind
+to be cached by a proxy. This test requires that the server is behind
 a caching proxy. Use of current timestamp in the request prevents accidental
 cache matches left over from previous tests.
 

--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -60,6 +60,27 @@ Client asserts:
 *It may be possible to use UnaryCall instead of EmptyCall, but it is harder to
 ensure that the proto serialized to zero bytes.*
 
+### cacheable_unary
+
+This test verifies that gRPC requests marked as cacheable use GET verb instead
+of POST, and that server sets appropriate cache control headers for the response
+to be cached by a proxy. This interop test requires that the server is behind
+a caching proxy. It is NOT expected to pass if client is accessing the server
+directly.
+
+Server features:
+* [CacheableUnaryCall][]
+
+Procedure:
+ 1. Client calls CacheableUnaryCall twice, and compares the two responses.
+ The server generates a unique response (timestamp) for each request.
+ If the second response was delivered from cache, then both responses will
+ be the same.
+
+Client asserts:
+* call was successful
+* responses are the same.
+
 ### large_unary
 
 This test verifies unary calls succeed in sending messages, and touches on flow

--- a/src/proto/grpc/testing/test.proto
+++ b/src/proto/grpc/testing/test.proto
@@ -47,6 +47,11 @@ service TestService {
   // One request followed by one response.
   rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
 
+  // One request followed by one response. Response has cache control
+  // headers set such that a caching HTTP proxy (such as GFE) can
+  // satisfy subsequent requests.
+  rpc CacheableUnaryCall(SimpleRequest) returns (SimpleResponse);
+
   // One request followed by a sequence of responses (streamed download).
   // The server returns the payload with client desired type and sizes.
   rpc StreamingOutputCall(StreamingOutputCallRequest)

--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -148,6 +148,8 @@ int main(int argc, char** argv) {
     client.DoStatusWithMessage();
   } else if (FLAGS_test_case == "custom_metadata") {
     client.DoCustomMetadata();
+  } else if (FLAGS_test_case == "cacheable_unary") {
+    client.DoCacheableUnary();
   } else if (FLAGS_test_case == "all") {
     client.DoEmpty();
     client.DoLargeUnary();
@@ -165,6 +167,7 @@ int main(int argc, char** argv) {
     client.DoEmptyStream();
     client.DoStatusWithMessage();
     client.DoCustomMetadata();
+    client.DoCacheableUnary();
     // service_account_creds and jwt_token_creds can only run with ssl.
     if (FLAGS_use_tls) {
       grpc::string json_key = GetServiceAccountJsonKey();
@@ -176,6 +179,7 @@ int main(int argc, char** argv) {
     // compute_engine_creds only runs in GCE.
   } else {
     const char* testcases[] = {"all",
+                               "cacheable_unary",
                                "cancel_after_begin",
                                "cancel_after_first_response",
                                "client_compressed_streaming",

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -849,7 +849,7 @@ bool InteropClient::DoCacheableUnary() {
   gpr_log(GPR_DEBUG, "Sending RPC with cacheable response");
 
   // Create request with current timestamp
-  gpr_timespec ts = gpr_now(GPR_CLOCK_REALTIME);
+  gpr_timespec ts = gpr_now(GPR_CLOCK_PRECISE);
   std::string timestamp = std::to_string(ts.tv_nsec);
   SimpleRequest request;
   request.mutable_payload()->set_body(timestamp.c_str(), timestamp.size());

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -850,7 +850,7 @@ bool InteropClient::DoCacheableUnary() {
 
   // Create request with current timestamp
   gpr_timespec ts = gpr_now(GPR_CLOCK_PRECISE);
-  std::string timestamp = std::to_string(ts.tv_nsec);
+  std::string timestamp = std::to_string((long long unsigned)ts.tv_nsec);
   SimpleRequest request;
   request.mutable_payload()->set_body(timestamp.c_str(), timestamp.size());
 

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -848,10 +848,11 @@ bool InteropClient::DoStatusWithMessage() {
 bool InteropClient::DoCacheableUnary() {
   gpr_log(GPR_DEBUG, "Sending RPC with cacheable response");
 
+  // Create request with current timestamp
+  gpr_timespec ts = gpr_now(GPR_CLOCK_REALTIME);
+  std::string timestamp = std::to_string(ts.tv_nsec);
   SimpleRequest request;
-  request.set_response_size(16);
-  grpc::string payload(16, '\0');
-  request.mutable_payload()->set_body(payload.c_str(), 16);
+  request.mutable_payload()->set_body(timestamp.c_str(), timestamp.size());
 
   // Request 1
   ClientContext context1;
@@ -878,7 +879,7 @@ bool InteropClient::DoCacheableUnary() {
   if (!AssertStatusOk(s2)) {
     return false;
   }
-  gpr_log(GPR_DEBUG, "response 1 payload: %s",
+  gpr_log(GPR_DEBUG, "response 2 payload: %s",
           response2.payload().body().c_str());
 
   // Check that the body is same for both requests. It will be the same if the

--- a/test/cpp/interop/interop_client.h
+++ b/test/cpp/interop/interop_client.h
@@ -79,6 +79,7 @@ class InteropClient {
   bool DoEmptyStream();
   bool DoStatusWithMessage();
   bool DoCustomMetadata();
+  bool DoCacheableUnary();
   // Auth tests.
   // username is a string containing the user email
   bool DoJwtTokenCreds(const grpc::string& username);

--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -159,7 +159,7 @@ class TestServiceImpl : public TestService::Service {
     gpr_timespec ts = gpr_now(GPR_CLOCK_REALTIME);
     std::string timestamp = std::to_string(ts.tv_nsec);
     response->mutable_payload()->set_body(timestamp.c_str(), timestamp.size());
-    context->AddInitialMetadata("Cache-Control", "max-age=100000, public");
+    context->AddInitialMetadata("cache-control", "max-age=100000, public");
     return Status::OK;
   }
 

--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -159,7 +159,7 @@ class TestServiceImpl : public TestService::Service {
     gpr_timespec ts = gpr_now(GPR_CLOCK_REALTIME);
     std::string timestamp = std::to_string(ts.tv_nsec);
     response->mutable_payload()->set_body(timestamp.c_str(), timestamp.size());
-    context->AddInitialMetadata("cache-control", "max-age=100000, public");
+    context->AddInitialMetadata("cache-control", "max-age=60, public");
     return Status::OK;
   }
 

--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -157,7 +157,7 @@ class TestServiceImpl : public TestService::Service {
   Status CacheableUnaryCall(ServerContext* context, const SimpleRequest* request,
                    SimpleResponse* response) {
     gpr_timespec ts = gpr_now(GPR_CLOCK_PRECISE);
-    std::string timestamp = std::to_string(ts.tv_nsec);
+    std::string timestamp = std::to_string((long long unsigned)ts.tv_nsec);
     response->mutable_payload()->set_body(timestamp.c_str(), timestamp.size());
     context->AddInitialMetadata("cache-control", "max-age=60, public");
     return Status::OK;

--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -156,7 +156,7 @@ class TestServiceImpl : public TestService::Service {
   // Response contains current timestamp. We ignore everything in the request.
   Status CacheableUnaryCall(ServerContext* context, const SimpleRequest* request,
                    SimpleResponse* response) {
-    gpr_timespec ts = gpr_now(GPR_CLOCK_REALTIME);
+    gpr_timespec ts = gpr_now(GPR_CLOCK_PRECISE);
     std::string timestamp = std::to_string(ts.tv_nsec);
     response->mutable_payload()->set_body(timestamp.c_str(), timestamp.size());
     context->AddInitialMetadata("cache-control", "max-age=60, public");

--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -47,6 +47,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/useful.h>
 
+#include "src/core/lib/support/string.h"
 #include "src/core/lib/transport/byte_stream.h"
 #include "src/proto/grpc/testing/empty.grpc.pb.h"
 #include "src/proto/grpc/testing/messages.grpc.pb.h"
@@ -149,6 +150,16 @@ class TestServiceImpl : public TestService::Service {
   Status EmptyCall(ServerContext* context, const grpc::testing::Empty* request,
                    grpc::testing::Empty* response) {
     MaybeEchoMetadata(context);
+    return Status::OK;
+  }
+
+  // Response contains current timestamp. We ignore everything in the request.
+  Status CacheableUnaryCall(ServerContext* context, const SimpleRequest* request,
+                   SimpleResponse* response) {
+    gpr_timespec ts = gpr_now(GPR_CLOCK_REALTIME);
+    std::string timestamp = std::to_string(ts.tv_nsec);
+    response->mutable_payload()->set_body(timestamp.c_str(), timestamp.size());
+    context->AddInitialMetadata("Cache-Control", "max-age=100000, public");
     return Status::OK;
   }
 


### PR DESCRIPTION
modified interop test spec doc
added CacheableUnaryCall to test.proto
modified server and client implmenentations to support new method