### PR TITLE
Add pkgconfig results to LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -746,6 +746,7 @@ ifneq ($(LDFLAGS_PROTOBUF_PKG_CONFIG),)
 LDFLAGS_PROTOBUF_PKG_CONFIG += $(shell $(PKG_CONFIG) --libs-only-L protobuf | sed s/L/Wl,-rpath,/)
 endif
 endif
+LDFLAGS := $(LDFLAGS_PROTOBUF_PKG_CONFIG) $(LDFLAGS)
 else
 PC_LIBS_GRPCXX = -lprotobuf
 endif

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -640,6 +640,7 @@
   LDFLAGS_PROTOBUF_PKG_CONFIG += $(shell $(PKG_CONFIG) --libs-only-L protobuf | sed s/L/Wl,-rpath,/)
   endif
   endif
+  LDFLAGS := $(LDFLAGS_PROTOBUF_PKG_CONFIG) $(LDFLAGS)
   else
   PC_LIBS_GRPCXX = -lprotobuf
   endif


### PR DESCRIPTION
Without this patch, the linker doesn't find `-lprotobuf` when protobuf
is installed to a location that is not on the linker's default search
path.
### How to reproduce:
- install protobuf 3 to non-standard location
  
  ```
  sudo apt-get install -qq -y autoconf automake libtool curl make g++ unzip
  git clone https://github.com/google/protobuf.git
  cd protobuf
  ./autogen.sh
  mkdir -p $HOME/install
  ./configure --prefix=$HOME/install
  make
  make install  # no sudo required for installing to home dir
  ```
- set up environment variables properly
  
  ```
  export PATH=$HOME/install/bin:$PATH
  export CMAKE_PREFIX_PATH=$HOME/install:$CMAKE_PREFIX_PATH
  export CPATH=$HOME/install:$CPATH
  export LD_LIBRARY_PATH=$HOME/install/lib:$LD_LIBRARY_PATH
  export PKG_CONFIG_PATH=$HOME/install/lib/pkgconfig:$PKG_CONFIG_PATH
  ```
- try to build grpc normally
  
  ```
  git clone https://github.com/grpc/grpc.git
  cd grpc
  git submodule update --init
  V=1 make
  ```
### Without this patch, the build fails:

```
echo " HAS_PKG_CONFIG = true, HAS_SYSTEM_OPENSSL_NPN = true, HAS_SYSTEM_ZLIB = true, HAS_SYSTEM_PROTOBUF = true, HAS_PROTOC = true, HAS_VALID_PROTOC = true," | tr , '\n' >cache.mk
mkdir -p `dirname /home/martin/odil/src/grpc/bins/opt/grpc_cpp_plugin`
c++ -g  -fPIC -Llibs/opt -pthread    /home/martin/odil/src/grpc/objs/opt/src/compiler/cpp_plugin.o /home/martin/odil/src/grpc/libs/opt/libgrpc_plugin_support.a  -lprotoc -lprotobuf -ldl -lrt -lm -lpthread -lz -lprotoc -lprotobuf -o /home/martin/odil/src/grpc/bins/opt/grpc_cpp_plugin
/usr/bin/ld: cannot find -lprotoc
collect2: error: ld returned 1 exit status
make: *** [/home/martin/odil/src/grpc/bins/opt/grpc_cpp_plugin] Error 1
```

The bug is both present at current master and `v1.0.0`.
