### PR TITLE
cpp examples missing gpr assert

### DIFF
--- a/examples/cpp/helloworld/greeter_async_client.cc
+++ b/examples/cpp/helloworld/greeter_async_client.cc
@@ -36,6 +36,7 @@
 #include <string>
 
 #include <grpc++/grpc++.h>
+#include <grpc/support/log.h>
 
 #include "helloworld.grpc.pb.h"
 

--- a/examples/cpp/helloworld/greeter_async_client2.cc
+++ b/examples/cpp/helloworld/greeter_async_client2.cc
@@ -36,6 +36,7 @@
 #include <string>
 
 #include <grpc++/grpc++.h>
+#include <grpc/support/log.h>
 #include <thread>
 
 #include "helloworld.grpc.pb.h"

--- a/examples/cpp/helloworld/greeter_async_server.cc
+++ b/examples/cpp/helloworld/greeter_async_server.cc
@@ -37,6 +37,7 @@
 #include <thread>
 
 #include <grpc++/grpc++.h>
+#include <grpc/support/log.h>
 
 #include "helloworld.grpc.pb.h"
 


### PR DESCRIPTION
When I try to run `make` from `examples/cpp/helloworld`, I got these errors

```
g++ -std=c++11 -I/usr/local/include -pthread  -c -o greeter_async_client2.o greeter_async_client2.c\
c
greeter_async_client2.cc: In member function ‘void GreeterClient::AsyncCompleteRpc()’:
greeter_async_client2.cc:92:26: error: ‘GPR_ASSERT’ was not declared in this scope
             GPR_ASSERT(ok);
                          ^
make: *** [greeter_async_client2.o] Error 1
```

Is this because of #7559 ?