### PR TITLE
Fail with invalid arg when attempt to use call creds on insecure channel

### DIFF
--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -109,6 +109,7 @@ module GRPC
                    timeout: nil,
                    propagate_mask: nil,
                    channel_args: {})
+      @using_insecure_channel = creds.eql?(:this_channel_is_insecure)
       @ch = ClientStub.setup_channel(channel_override, host, creds,
                                      channel_args)
       alt_host = channel_args[Core::Channel::SSL_TARGET]
@@ -445,7 +446,9 @@ module GRPC
                         deadline: nil,
                         parent: nil,
                         credentials: nil)
-
+      if credentials && @using_insecure_channel
+        fail ArgumentError, "can't use credentials on an insecure channel"
+      end
       deadline = from_relative_time(@timeout) if deadline.nil?
       # Provide each new client call with its own completion queue
       call = @ch.create_call(parent, # parent call

--- a/src/ruby/spec/generic/client_stub_spec.rb
+++ b/src/ruby/spec/generic/client_stub_spec.rb
@@ -1,3 +1,4 @@
+
 # Copyright 2015, Google Inc.
 # All rights reserved.
 #
@@ -373,6 +374,30 @@ describe 'ClientStub' do
       end
 
       it_behaves_like 'bidi streaming'
+    end
+  end
+
+  describe 'creating a stub with a channel that is insecure' do
+    it 'attempts to create a call with call creds should fail as invalid' do
+      server_port = create_test_server
+      host = "localhost:#{server_port}"
+      request =  'request'
+      response = 'response'
+      metadata = { k1: 'v1', k2: 'v2' }
+      creds_callback_md = { k3: 'k3' }
+      server_thd = run_request_response(request, response,
+                                        GRPC::Core::StatusCodes::OK,
+                                        metadata.merge(creds_callback_md))
+      @stub = GRPC::ClientStub.new(host, :this_channel_is_insecure)
+
+      dummy_creds_callback = proc { creds_callback_md }
+      call_creds = GRPC::Core::CallCredentials.new(dummy_creds_callback)
+      expect do
+        @stub.request_response(@method, request, noop, noop,
+                               metadata: metadata,
+                               credentials: call_creds)
+      end.to raise_error(ArgumentError)
+      server_thd.kill
     end
   end
 


### PR DESCRIPTION
In creating the test for failing call creds in https://github.com/grpc/grpc/pull/8102, found that call creds on an insecure channel seemed to be silently ignored.

This makes a check for an attempt to do so at the client stub.