### PR TITLE
Using "/usr/bin/env python" in run_tests.py

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # Copyright 2015, Google Inc.
 # All rights reserved.
 #


### PR DESCRIPTION
After #7265, run_tests.py can work on python3. Hence, we can use "/usr/bin/env python" instead of "/usr/bin/env python2.7" in run_tests.py.
