### PR TITLE
Add //external:zlib as dependency of grpc_unsecure target

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1241,6 +1241,7 @@ cc_library(
   deps = [
     ":gpr",
     "//external:nanopb",
+    "//external:zlib",
   ],
   copts = [
     "-std=gnu99",

--- a/templates/BUILD.template
+++ b/templates/BUILD.template
@@ -55,7 +55,8 @@
         target_dict['name'] == 'grpc++' or
         target_dict['name'] == 'grpc++_codegen_lib'):
       deps.append("//external:protobuf_clib")
-    elif target_dict['name'] == 'grpc':
+    elif (target_dict['name'] == 'grpc' or
+          target_dict['name'] == 'grpc_unsecure'):
       deps.append("//external:zlib")
     for d in target_dict.get('deps', []):
       if d.find('//') == 0 or d[0] == ':':


### PR DESCRIPTION
When I was building grpc on Windows for TensorFlow, zlib was required by `grpc++_unsecure` target. There is already a [PR](https://github.com/tensorflow/tensorflow/pull/4454) to add this dependency in TF repo, it's better to also add it in original repo to keep the minimal difference between the BUILD files.
