### PR TITLE
dont create extra threads in server handlers for ruby bidi streams

### DIFF
--- a/src/ruby/qps/server.rb
+++ b/src/ruby/qps/server.rb
@@ -49,16 +49,7 @@ class BenchmarkServiceImpl < Grpc::Testing::BenchmarkService::Service
     sr.new(payload: pl.new(body: nulls(req.response_size)))
   end
   def streaming_call(reqs)
-    q = EnumeratorQueue.new(self)
-    Thread.new {
-      sr = Grpc::Testing::SimpleResponse
-      pl = Grpc::Testing::Payload
-      reqs.each do |req|
-        q.push(sr.new(payload: pl.new(body: nulls(req.response_size))))
-      end
-      q.push(self)
-    }
-    q.each_item
+    PingPongEnumerator.new(reqs).each_item
   end
 end
 


### PR DESCRIPTION
Changing the server-side handler in ruby benchmarks for bidi calls to not create the extra thread appears to improve qps by around 15 to 20%, at least when comparing benchmarks ran with client and server on the same host.

Thinking that this general approach for the ping pong could be a suggestion for back-and-forth bidi calls, so this also changes the examples and interop tests. Trying to merge this to v1.0.x, mostly because of the change to examples, but I could also move this to master.

