### PR TITLE
PHP: use real artifact name in jenkins test

### DIFF
--- a/test/distrib/php/run_distrib_test.sh
+++ b/test/distrib/php/run_distrib_test.sh
@@ -32,8 +32,9 @@ set -ex
 
 cd $(dirname $0)
 
-cp -r $EXTERNAL_GIT_ROOT/input_artifacts/grpc-php.tgz .
+cp -r $EXTERNAL_GIT_ROOT/input_artifacts/grpc-*.tgz .
 
-pecl install grpc-php.tgz
+find . -regextype sed -regex ".*/grpc-[0-9].*.tgz" | cut -b3- | \
+    xargs pecl install
 
 php -d extension=grpc.so -d max_execution_time=300 distribtest.php

--- a/tools/run_tests/build_artifact_php.sh
+++ b/tools/run_tests/build_artifact_php.sh
@@ -37,4 +37,4 @@ mkdir -p artifacts
 
 pear package
 
-cp -r grpc-*.tgz artifacts/grpc-php.tgz
+cp -r grpc-*.tgz artifacts/


### PR DESCRIPTION
Don't rename the PHP artifact to a version-less `grpc-php.tgz`