### PR TITLE
Rewrote handling of default resolver prefix

### DIFF
--- a/src/core/ext/client_config/client_config_plugin.c
+++ b/src/core/ext/client_config/client_config_plugin.c
@@ -43,10 +43,6 @@
 #include "src/core/ext/client_config/subchannel_index.h"
 #include "src/core/lib/surface/channel_init.h"
 
-#ifndef GRPC_DEFAULT_NAME_PREFIX
-#define GRPC_DEFAULT_NAME_PREFIX "dns:///"
-#endif
-
 static bool append_filter(grpc_channel_stack_builder *builder, void *arg) {
   return grpc_channel_stack_builder_append_filter(
       builder, (const grpc_channel_filter *)arg, NULL, NULL);
@@ -79,7 +75,7 @@ static bool set_default_host_if_unset(grpc_channel_stack_builder *builder,
 
 void grpc_client_config_init(void) {
   grpc_lb_policy_registry_init();
-  grpc_resolver_registry_init(GRPC_DEFAULT_NAME_PREFIX);
+  grpc_resolver_registry_init();
   grpc_subchannel_index_init();
   grpc_channel_init_register_stage(GRPC_CLIENT_CHANNEL, INT_MIN,
                                    set_default_host_if_unset, NULL);

--- a/src/core/ext/client_config/resolver_registry.h
+++ b/src/core/ext/client_config/resolver_registry.h
@@ -36,8 +36,11 @@
 
 #include "src/core/ext/client_config/resolver_factory.h"
 
-void grpc_resolver_registry_init(const char *default_prefix);
+void grpc_resolver_registry_init();
 void grpc_resolver_registry_shutdown(void);
+
+/** Set the default URI prefix to \a default_prefix. */
+void grpc_resolver_registry_set_default_prefix(const char *default_prefix);
 
 /** Register a resolver type.
     URI's of \a scheme will be resolved with the given resolver.

--- a/test/core/surface/channel_create_test.c
+++ b/test/core/surface/channel_create_test.c
@@ -40,7 +40,7 @@ void test_unknown_scheme_target(void) {
   grpc_channel *chan;
   /* avoid default prefix */
   grpc_resolver_registry_shutdown();
-  grpc_resolver_registry_init("");
+  grpc_resolver_registry_init();
 
   chan = grpc_insecure_channel_create("blah://blah", NULL, NULL);
   GPR_ASSERT(chan != NULL);

--- a/test/core/surface/secure_channel_create_test.c
+++ b/test/core/surface/secure_channel_create_test.c
@@ -46,7 +46,7 @@ void test_unknown_scheme_target(void) {
   grpc_channel *chan;
   grpc_channel_credentials *creds;
   grpc_resolver_registry_shutdown();
-  grpc_resolver_registry_init("");
+  grpc_resolver_registry_init();
 
   creds = grpc_fake_transport_security_credentials_create();
   chan = grpc_secure_channel_create(creds, "blah://blah", NULL, NULL);


### PR DESCRIPTION
Salient point: the choice of 32 as the max length of a default prefix... :/ 