### PR TITLE
php grpc extension requirement

### DIFF
--- a/src/php/composer.json
+++ b/src/php/composer.json
@@ -8,6 +8,7 @@
   "version": "1.1.0",
   "require": {
     "php": ">=5.5.0",
+    "ext-grpc": "*",
     "stanley-cheung/protobuf-php": "v0.6"
   },
   "require-dev": {


### PR DESCRIPTION
Composer can require that certain modules are installed as part of package dependencies, this PR allows grpc to take advantage of that. This will cut down on confusion when users install the package and are greeted with errors because of the missing module.

[Citing composer for versioning](https://getcomposer.org/doc/02-libraries.md#platform-packages):
Versioning can be quite inconsistent here, so it's often a good idea to just set the constraint to `*`

Happy to use a more specific version.