### PR TITLE
Compiles with npm install --debug option.

### DIFF
--- a/src/node/ext/node_grpc.cc
+++ b/src/node/ext/node_grpc.cc
@@ -261,10 +261,10 @@ void InitLogConstants(Local<Object> exports) {
   Nan::HandleScope scope;
   Local<Object> log_verbosity = Nan::New<Object>();
   Nan::Set(exports, Nan::New("logVerbosity").ToLocalChecked(), log_verbosity);
-  Local<Value> DEBUG(Nan::New<Uint32, uint32_t>(GPR_LOG_SEVERITY_DEBUG));
-  Nan::Set(log_verbosity, Nan::New("DEBUG").ToLocalChecked(), DEBUG);
-  Local<Value> INFO(Nan::New<Uint32, uint32_t>(GPR_LOG_SEVERITY_INFO));
-  Nan::Set(log_verbosity, Nan::New("INFO").ToLocalChecked(), INFO);
+  Local<Value> LOG_DEBUG(Nan::New<Uint32, uint32_t>(GPR_LOG_SEVERITY_DEBUG));
+  Nan::Set(log_verbosity, Nan::New("DEBUG").ToLocalChecked(), LOG_DEBUG);
+  Local<Value> LOG_INFO(Nan::New<Uint32, uint32_t>(GPR_LOG_SEVERITY_INFO));
+  Nan::Set(log_verbosity, Nan::New("INFO").ToLocalChecked(), LOG_INFO);
   Local<Value> LOG_ERROR(Nan::New<Uint32, uint32_t>(GPR_LOG_SEVERITY_ERROR));
   Nan::Set(log_verbosity, Nan::New("ERROR").ToLocalChecked(), LOG_ERROR);
 }


### PR DESCRIPTION
When running `npm install --debug` on Node v6.5.0, the DEBUG constant is #define'd in C. The following code is then affected (line 260 of node_gprc.cc)

```
void InitLogConstants(Local<Object> exports) {
  Nan::HandleScope scope;
  Local<Object> log_verbosity = Nan::New<Object>();
  Nan::Set(exports, Nan::New("logVerbosity").ToLocalChecked(), log_verbosity);
  Local<Value> DEBUG(Nan::New<Uint32, uint32_t>(GPR_LOG_SEVERITY_DEBUG));
  Nan::Set(log_verbosity, Nan::New("DEBUG").ToLocalChecked(), DEBUG);
  Local<Value> INFO(Nan::New<Uint32, uint32_t>(GPR_LOG_SEVERITY_INFO));
  Nan::Set(log_verbosity, Nan::New("INFO").ToLocalChecked(), INFO);
  Local<Value> LOG_ERROR(Nan::New<Uint32, uint32_t>(GPR_LOG_SEVERITY_ERROR));
  Nan::Set(log_verbosity, Nan::New("ERROR").ToLocalChecked(), LOG_ERROR);
}
```

This is easy to fix by aliasing DEBUG to LOG_DEBUG and INFO to LOG_INFO, which this PR accomplishes.