### PR TITLE
Remove deprecated V8 function call in Node library

### DIFF
--- a/src/node/ext/call.cc
+++ b/src/node/ext/call.cc
@@ -613,8 +613,8 @@ NAN_METHOD(Call::New) {
         return Nan::ThrowTypeError("Call's fourth argument must be a string");
       }
       call = new Call(wrapped_call);
-      info.This()->SetHiddenValue(Nan::New("channel_").ToLocalChecked(),
-                                  channel_object);
+      Nan::Set(info.This(), Nan::New("channel_").ToLocalChecked(),
+               channel_object);
     }
     call->Wrap(info.This());
     info.GetReturnValue().Set(info.This());


### PR DESCRIPTION
This should fix the problems reported in #8193 and #8166.