### PR TITLE
Changing Linux worker creation script.

### DIFF
--- a/tools/gce/create_linux_worker.sh
+++ b/tools/gce/create_linux_worker.sh
@@ -42,7 +42,7 @@ INSTANCE_NAME="${1:-grpc-jenkins-worker1}"
 gcloud compute instances create $INSTANCE_NAME \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
-    --machine-type n1-standard-8 \
+    --machine-type n1-highmem-8 \
     --image=ubuntu-1510 \
     --image-project=grpc-testing \
     --boot-disk-size 1000

--- a/tools/gce/linux_worker_init.sh
+++ b/tools/gce/linux_worker_init.sh
@@ -34,6 +34,14 @@
 
 set -ex
 
+# Create some swap space
+sudo dd if=/dev/zero of=/swap bs=1024 count=10485760
+sudo chmod 600 /swap
+sudo mkswap /swap
+sudo sed -i '$ a\/swap none swap sw 0 0' /etc/fstab
+sudo swapon -a
+
+# Typical apt-get maintenance
 sudo apt-get update
 
 # Install JRE


### PR DESCRIPTION
I have already re-created the slaves with it. Investigation of the issues ended up showing that the kernel was in nearline memory usage, hence creating extremely high, non-preemptible kernel CPU usage. Culprit also very likely the absence of swap space. Linux really doesn't like this. Adding some amount of swap will usually make the kernel swap algorithm happier.

The changes to the script are:

-) Switched to highmem machines (58G instead of 30G)
-) Added 10G of file swap