### PR TITLE
Populate server_name for sockaddr resolver

### DIFF
--- a/src/core/ext/resolver/sockaddr/sockaddr_resolver.c
+++ b/src/core/ext/resolver/sockaddr/sockaddr_resolver.c
@@ -222,7 +222,7 @@ static grpc_resolver *sockaddr_create(
     if (errors_found) break;
   }
 
-  r->target_name = gpr_dump_slice(path_slice, GPR_DUMP_ASCII);
+  r->target_name = gpr_strdup(args->uri->path);
   gpr_slice_buffer_destroy(&path_parts);
   gpr_slice_unref(path_slice);
   if (errors_found) {

--- a/src/core/ext/resolver/sockaddr/sockaddr_resolver.c
+++ b/src/core/ext/resolver/sockaddr/sockaddr_resolver.c
@@ -53,10 +53,10 @@ typedef struct {
   gpr_refcount refs;
   /** load balancing policy name */
   char *lb_policy_name;
-
+  /** the path component of the uri passed in */
+  char *target_name;
   /** the addresses that we've 'resolved' */
   grpc_lb_addresses *addresses;
-
   /** mutex guarding the rest of the state */
   gpr_mu mu;
   /** have we published? */
@@ -121,7 +121,8 @@ static void sockaddr_maybe_finish_next_locked(grpc_exec_ctx *exec_ctx,
   if (r->next_completion != NULL && !r->published) {
     r->published = true;
     *r->target_result = grpc_resolver_result_create(
-        "", grpc_lb_addresses_copy(r->addresses, NULL /* user_data_copy */),
+        r->target_name,
+        grpc_lb_addresses_copy(r->addresses, NULL /* user_data_copy */),
         r->lb_policy_name, NULL);
     grpc_exec_ctx_sched(exec_ctx, r->next_completion, GRPC_ERROR_NONE, NULL);
     r->next_completion = NULL;
@@ -133,6 +134,7 @@ static void sockaddr_destroy(grpc_exec_ctx *exec_ctx, grpc_resolver *gr) {
   gpr_mu_destroy(&r->mu);
   grpc_lb_addresses_destroy(r->addresses, NULL /* user_data_destroy */);
   gpr_free(r->lb_policy_name);
+  gpr_free(r->target_name);
   gpr_free(r);
 }
 
@@ -220,10 +222,12 @@ static grpc_resolver *sockaddr_create(
     if (errors_found) break;
   }
 
+  r->target_name = gpr_dump_slice(path_slice, GPR_DUMP_ASCII);
   gpr_slice_buffer_destroy(&path_parts);
   gpr_slice_unref(path_slice);
   if (errors_found) {
     gpr_free(r->lb_policy_name);
+    gpr_free(r->target_name);
     grpc_lb_addresses_destroy(r->addresses, NULL /* user_data_destroy */);
     gpr_free(r);
     return NULL;

--- a/test/core/client_config/resolvers/sockaddr_resolver_test.c
+++ b/test/core/client_config/resolvers/sockaddr_resolver_test.c
@@ -70,16 +70,15 @@ static void test_succeeds(grpc_resolver_factory *factory, const char *string) {
 
   on_resolution_arg on_res_arg;
   memset(&on_res_arg, 0, sizeof(on_res_arg));
-  on_res_arg.expected_server_name = gpr_strdup(uri->path);
+  on_res_arg.expected_server_name = uri->path;
   grpc_closure *on_resolution =
       grpc_closure_create(on_resolution_cb, &on_res_arg);
 
   grpc_resolver_next(&exec_ctx, resolver, &on_res_arg.resolver_result,
                      on_resolution);
   GRPC_RESOLVER_UNREF(&exec_ctx, resolver, "test_succeeds");
-  grpc_uri_destroy(uri);
   grpc_exec_ctx_finish(&exec_ctx);
-  gpr_free(on_res_arg.expected_server_name);
+  grpc_uri_destroy(uri);
 }
 
 static void test_fails(grpc_resolver_factory *factory, const char *string) {

--- a/tools/run_tests/tests.json
+++ b/tools/run_tests/tests.json
@@ -80102,63 +80102,6 @@
   }, 
   {
     "args": [
-      "test/core/nanopb/corpus_response/1b5e3e31c209db047776625d63dad60b99c4f8c4"
-    ], 
-    "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 0.1, 
-    "exclude_configs": [
-      "tsan"
-    ], 
-    "flaky": false, 
-    "language": "c", 
-    "name": "nanopb_fuzzer_response_test_one_entry", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": false
-  }, 
-  {
-    "args": [
-      "test/core/nanopb/corpus_response/1feac2e01f6059e5c46b77174a2928e267af23a7"
-    ], 
-    "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 0.1, 
-    "exclude_configs": [
-      "tsan"
-    ], 
-    "flaky": false, 
-    "language": "c", 
-    "name": "nanopb_fuzzer_response_test_one_entry", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": false
-  }, 
-  {
-    "args": [
-      "test/core/nanopb/corpus_response/215424c0703ac1beb18fca2991ab53cef780bdc8"
-    ], 
-    "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 0.1, 
-    "exclude_configs": [
-      "tsan"
-    ], 
-    "flaky": false, 
-    "language": "c", 
-    "name": "nanopb_fuzzer_response_test_one_entry", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": false
-  }, 
-  {
-    "args": [
       "test/core/nanopb/corpus_response/23121c5f633db5d7c1a9f2225240754246fee513"
     ], 
     "ci_platforms": [
@@ -80179,25 +80122,6 @@
   {
     "args": [
       "test/core/nanopb/corpus_response/235548307ee9f2b0855fded42a871990d9ade956"
-    ], 
-    "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 0.1, 
-    "exclude_configs": [
-      "tsan"
-    ], 
-    "flaky": false, 
-    "language": "c", 
-    "name": "nanopb_fuzzer_response_test_one_entry", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": false
-  }, 
-  {
-    "args": [
-      "test/core/nanopb/corpus_response/269795add2208946182ff8063b838409ae181147"
     ], 
     "ci_platforms": [
       "linux"
@@ -80331,25 +80255,6 @@
   {
     "args": [
       "test/core/nanopb/corpus_response/37dfead09389fcd9b9d24ef817a0fed13d8ff2b0"
-    ], 
-    "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 0.1, 
-    "exclude_configs": [
-      "tsan"
-    ], 
-    "flaky": false, 
-    "language": "c", 
-    "name": "nanopb_fuzzer_response_test_one_entry", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": false
-  }, 
-  {
-    "args": [
-      "test/core/nanopb/corpus_response/4326c9dd45537b770f238d868b67ae7fa4dd4339"
     ], 
     "ci_platforms": [
       "linux"
@@ -80577,25 +80482,6 @@
   }, 
   {
     "args": [
-      "test/core/nanopb/corpus_response/72f663484806227ace334de56e87749ada1b14bf"
-    ], 
-    "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 0.1, 
-    "exclude_configs": [
-      "tsan"
-    ], 
-    "flaky": false, 
-    "language": "c", 
-    "name": "nanopb_fuzzer_response_test_one_entry", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": false
-  }, 
-  {
-    "args": [
       "test/core/nanopb/corpus_response/73285d7a70d73b517648067520d921e4477dbbfa"
     ], 
     "ci_platforms": [
@@ -80805,25 +80691,6 @@
   }, 
   {
     "args": [
-      "test/core/nanopb/corpus_response/938e80d928c7f03d1a7ed3d0b4ff4d21619c3b9f"
-    ], 
-    "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 0.1, 
-    "exclude_configs": [
-      "tsan"
-    ], 
-    "flaky": false, 
-    "language": "c", 
-    "name": "nanopb_fuzzer_response_test_one_entry", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": false
-  }, 
-  {
-    "args": [
       "test/core/nanopb/corpus_response/95cd94c858e5e97f7df4a5eb7552e5e0d5ce1ec4"
     ], 
     "ci_platforms": [
@@ -80938,25 +80805,6 @@
   }, 
   {
     "args": [
-      "test/core/nanopb/corpus_response/a7e1da726cc81cfccb82d7ef608ee20614ead21d"
-    ], 
-    "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 0.1, 
-    "exclude_configs": [
-      "tsan"
-    ], 
-    "flaky": false, 
-    "language": "c", 
-    "name": "nanopb_fuzzer_response_test_one_entry", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": false
-  }, 
-  {
-    "args": [
       "test/core/nanopb/corpus_response/a8a62a7ebb7d68b211ae319e082575935c07d188"
     ], 
     "ci_platforms": [
@@ -81052,44 +80900,6 @@
   }, 
   {
     "args": [
-      "test/core/nanopb/corpus_response/b7c2a1c12efc817db4365b0fb2335e42d5cc0c85"
-    ], 
-    "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 0.1, 
-    "exclude_configs": [
-      "tsan"
-    ], 
-    "flaky": false, 
-    "language": "c", 
-    "name": "nanopb_fuzzer_response_test_one_entry", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": false
-  }, 
-  {
-    "args": [
-      "test/core/nanopb/corpus_response/be5555929bb0f93603b6c477c7a4be8abf61185e"
-    ], 
-    "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 0.1, 
-    "exclude_configs": [
-      "tsan"
-    ], 
-    "flaky": false, 
-    "language": "c", 
-    "name": "nanopb_fuzzer_response_test_one_entry", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": false
-  }, 
-  {
-    "args": [
       "test/core/nanopb/corpus_response/c1eed32e1e353737987da851ad760312ea8e557c"
     ], 
     "ci_platforms": [
@@ -81129,44 +80939,6 @@
   {
     "args": [
       "test/core/nanopb/corpus_response/c4f87a6290aee1acfc1f26083974ce94621fca64"
-    ], 
-    "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 0.1, 
-    "exclude_configs": [
-      "tsan"
-    ], 
-    "flaky": false, 
-    "language": "c", 
-    "name": "nanopb_fuzzer_response_test_one_entry", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": false
-  }, 
-  {
-    "args": [
-      "test/core/nanopb/corpus_response/c732c562f3c10288fad0bf08c1bb3ab811eb1f17"
-    ], 
-    "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 0.1, 
-    "exclude_configs": [
-      "tsan"
-    ], 
-    "flaky": false, 
-    "language": "c", 
-    "name": "nanopb_fuzzer_response_test_one_entry", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": false
-  }, 
-  {
-    "args": [
-      "test/core/nanopb/corpus_response/cf0bafaa2f3484da47779377f12630191303bbb9"
     ], 
     "ci_platforms": [
       "linux"
@@ -81242,25 +81014,6 @@
   }, 
   {
     "args": [
-      "test/core/nanopb/corpus_response/e1c260578eaefc679b41f3bc84eac2aa9e4c805f"
-    ], 
-    "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 0.1, 
-    "exclude_configs": [
-      "tsan"
-    ], 
-    "flaky": false, 
-    "language": "c", 
-    "name": "nanopb_fuzzer_response_test_one_entry", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": false
-  }, 
-  {
-    "args": [
       "test/core/nanopb/corpus_response/e53e789a4c175c6a2c468472f1047d0fe8db1177"
     ], 
     "ci_platforms": [
@@ -81281,25 +81034,6 @@
   {
     "args": [
       "test/core/nanopb/corpus_response/e67fe6794e755ea801272980f2c272edb027f6dc"
-    ], 
-    "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 0.1, 
-    "exclude_configs": [
-      "tsan"
-    ], 
-    "flaky": false, 
-    "language": "c", 
-    "name": "nanopb_fuzzer_response_test_one_entry", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": false
-  }, 
-  {
-    "args": [
-      "test/core/nanopb/corpus_response/e94711da6ea4a9c8fed17ddc5597552f4f81b2fd"
     ], 
     "ci_platforms": [
       "linux"


### PR DESCRIPTION
Simply use the path of the uri given to the resolver upon creation. This change is mainly motivated by the use of the sockaddr resolver in the grpclb tests.