### PR TITLE
fix problem of grpc_httpcli_(get|post)

### DIFF
--- a/src/core/lib/http/httpcli.c
+++ b/src/core/lib/http/httpcli.c
@@ -187,6 +187,10 @@ static void on_handshake_done(grpc_exec_ctx *exec_ctx, void *arg,
   internal_request *req = arg;
 
   if (!ep) {
+    //req->ep freed in security_handshake_done(handshake.c), so set NULL to ep for avoiding double free
+    //(when req->next_address == req->addresses->naddrs).
+    // otherwise ep initialized again in grpc_tcp_client_connect, so no harmful to do it here.
+    req->ep = NULL;
     next_address(exec_ctx, req,
                  GRPC_ERROR_CREATE("Unexplained handshake failure"));
     return;

--- a/src/core/lib/security/transport/secure_endpoint.c
+++ b/src/core/lib/security/transport/secure_endpoint.c
@@ -210,7 +210,9 @@ static void on_read(grpc_exec_ctx *exec_ctx, void *user_data,
   gpr_slice_buffer_reset_and_unref(&ep->source_buffer);
 
   if (result != TSI_OK) {
-    gpr_slice_buffer_reset_and_unref(ep->read_buffer);
+    if (result != TSI_REMOTE_PEER_CLOSED) { /* let callback to process last read buffer */
+      gpr_slice_buffer_reset_and_unref(ep->read_buffer);
+    }
     call_read_cb(exec_ctx, ep, grpc_set_tsi_error_result(
                                    GRPC_ERROR_CREATE("Unwrap failed"), result));
     return;

--- a/src/core/lib/tsi/ssl_transport_security.c
+++ b/src/core/lib/tsi/ssl_transport_security.c
@@ -434,7 +434,11 @@ static tsi_result do_ssl_read(SSL *ssl, unsigned char *unprotected_bytes,
   read_from_ssl =
       SSL_read(ssl, unprotected_bytes, (int)*unprotected_bytes_size);
   if (read_from_ssl == 0) {
-    gpr_log(GPR_ERROR, "SSL_read returned 0 unexpectedly.");
+    int err = SSL_get_error(ssl, read_from_ssl);
+    gpr_log(GPR_ERROR, "SSL_read returned 0(%d) unexpectedly.", err);
+    if (err == SSL_ERROR_ZERO_RETURN) {
+      return TSI_REMOTE_PEER_CLOSED;
+    }
     return TSI_INTERNAL_ERROR;
   }
   if (read_from_ssl < 0) {

--- a/src/core/lib/tsi/transport_security.c
+++ b/src/core/lib/tsi/transport_security.c
@@ -73,6 +73,8 @@ const char *tsi_result_to_string(tsi_result result) {
       return "TSI_HANDSHAKE_IN_PROGRESS";
     case TSI_OUT_OF_RESOURCES:
       return "TSI_OUT_OF_RESOURCES";
+    case TSI_REMOTE_PEER_CLOSED:
+      return "TSI_REMOTE_PEER_CLOSED";
     default:
       return "UNKNOWN";
   }

--- a/src/core/lib/tsi/transport_security_interface.h
+++ b/src/core/lib/tsi/transport_security_interface.h
@@ -56,7 +56,8 @@ typedef enum {
   TSI_NOT_FOUND = 9,
   TSI_PROTOCOL_FAILURE = 10,
   TSI_HANDSHAKE_IN_PROGRESS = 11,
-  TSI_OUT_OF_RESOURCES = 12
+  TSI_OUT_OF_RESOURCES = 12,
+  TSI_REMOTE_PEER_CLOSED = 13
 } tsi_result;
 
 typedef enum {


### PR DESCRIPTION
this pull request aims to fix problem of grpc_httpcli_(get|post) API, detail for each commit is following:

https://github.com/grpc/grpc/commit/3891dc425596c6323e6865592d9c6f3ed4b1e8df: some web server (e.g. amazon s3) closes connection after all payload sent, but when remote peer of secure connection closed, grpc seems to clear corresponding read buffer immediately, even if it contains valid contents. this behavior causes truncated body in response. this commit is fix for the problem.
https://github.com/grpc/grpc/commit/ded06cae8b909dee3d5de1d724add6ba2b3c758d: fix for #8207. 
