### PR TITLE
Changing the Host header of HTTP CONNECT proxy request.

### DIFF
--- a/src/core/ext/client_config/http_connect_handshaker.h
+++ b/src/core/ext/client_config/http_connect_handshaker.h
@@ -34,14 +34,20 @@
 #ifndef GRPC_CORE_EXT_CLIENT_CONFIG_HTTP_CONNECT_HANDSHAKER_H
 #define GRPC_CORE_EXT_CLIENT_CONFIG_HTTP_CONNECT_HANDSHAKER_H
 
+#include <stdbool.h>
+
 #include "src/core/lib/channel/handshaker.h"
 
-/// Does NOT take ownership of \a proxy_server or \a server_name.
-grpc_handshaker* grpc_http_connect_handshaker_create(const char* proxy_server,
-                                                     const char* server_name);
+/// Does NOT take ownership of \a server_name or \a authority. These two
+/// arguments will be the same most of the time except for load balanced
+/// connections to backends where the \a server_name is the IP address of the
+/// backend and \authority, the default authority of the channel.
+grpc_handshaker* grpc_http_connect_handshaker_create(const char *server_name,
+                                                     const char *authority);
 
-/// Returns the name of the proxy to use, or NULL if no proxy is configured.
-/// Caller takes ownership of result.
-char* grpc_get_http_proxy_server();
+/// Returns true if an http proxy is configured. If \a proxy_server is not NULL,
+/// it will be set with the configured proxy server (if any) which the caller
+/// takes ownership of.
+bool grpc_is_http_proxy_configured(char **proxy_server);
 
 #endif /* GRPC_CORE_EXT_CLIENT_CONFIG_HTTP_CONNECT_HANDSHAKER_H */

--- a/src/core/ext/transport/chttp2/client/insecure/channel_create.c
+++ b/src/core/ext/transport/chttp2/client/insecure/channel_create.c
@@ -190,12 +190,10 @@ static grpc_subchannel *client_channel_factory_create_subchannel(
   c->base.vtable = &connector_vtable;
   gpr_ref_init(&c->refs, 1);
   c->handshake_mgr = grpc_handshake_manager_create();
-  char *proxy_name = grpc_get_http_proxy_server();
-  if (proxy_name != NULL) {
-    grpc_handshake_manager_add(
-        c->handshake_mgr,
-        grpc_http_connect_handshaker_create(proxy_name, args->server_name));
-    gpr_free(proxy_name);
+  if (grpc_is_http_proxy_configured(NULL)) {
+    grpc_handshake_manager_add(c->handshake_mgr,
+                               grpc_http_connect_handshaker_create(
+                                   args->server_name, args->server_name));
   }
   args->args = final_args;
   s = grpc_subchannel_create(exec_ctx, &c->base, args);

--- a/src/core/ext/transport/chttp2/client/secure/secure_channel_create.c
+++ b/src/core/ext/transport/chttp2/client/secure/secure_channel_create.c
@@ -252,12 +252,10 @@ static grpc_subchannel *client_channel_factory_create_subchannel(
   c->base.vtable = &connector_vtable;
   c->security_connector = f->security_connector;
   c->handshake_mgr = grpc_handshake_manager_create();
-  char *proxy_name = grpc_get_http_proxy_server();
-  if (proxy_name != NULL) {
-    grpc_handshake_manager_add(
-        c->handshake_mgr,
-        grpc_http_connect_handshaker_create(proxy_name, args->server_name));
-    gpr_free(proxy_name);
+  if (grpc_is_http_proxy_configured(NULL)) {
+    grpc_handshake_manager_add(c->handshake_mgr,
+                               grpc_http_connect_handshaker_create(
+                                   args->server_name, args->server_name));
   }
   gpr_mu_init(&c->mu);
   gpr_ref_init(&c->refs, 1);


### PR DESCRIPTION
The Host header should be set to the authority of the server that we
want to connect to as opposed to the name of the proxy server.

Given this change, I also added a small optimization to the proxy
configuration check so that we don't have to do an additional
malloc/free if we don't need to.
