### PR TITLE
convert snake case protos package names to camel case in ruby modules

### DIFF
--- a/src/compiler/ruby_generator.cc
+++ b/src/compiler/ruby_generator.cc
@@ -124,6 +124,40 @@ grpc::string SnakeCaseToCamelCase(grpc::string input) {
   return output;
 }
 
+// The following functions are copied directly from the source for the protoc ruby generator
+// to ensure compatibility ('int i' changed to 'uint i' is the only change).
+// See https://github.com/google/protobuf/blob/master/src/google/protobuf/compiler/ruby/ruby_generator.cc#L250
+// TODO: keep up to date with protoc code generation, though this behavior isn't expected to change
+bool IsLower(char ch) { return ch >= 'a' && ch <= 'z'; }
+
+char ToUpper(char ch) { return IsLower(ch) ? (ch - 'a' + 'A') : ch; }
+
+
+// Package names in protobuf are snake_case by convention, but Ruby module
+// names must be PascalCased.
+//
+//   foo_bar_baz -> FooBarBaz
+std::string PackageToModule(const std::string& name) {
+  bool next_upper = true;
+  std::string result;
+  result.reserve(name.size());
+
+  for (uint i = 0; i < name.size(); i++) {
+    if (name[i] == '_') {
+      next_upper = true;
+    } else {
+      if (next_upper) {
+        result.push_back(ToUpper(name[i]));
+      } else {
+        result.push_back(name[i]);
+      }
+      next_upper = false;
+    }
+  }
+
+  return result;
+}
+// end copying of protoc generator for ruby code
 
 grpc::string GetServices(const FileDescriptor *file) {
   grpc::string output;
@@ -166,7 +200,7 @@ grpc::string GetServices(const FileDescriptor *file) {
     std::vector<grpc::string> modules = Split(file->package(), '.');
     for (size_t i = 0; i < modules.size(); ++i) {
       std::map<grpc::string, grpc::string> module_vars =
-          ListToDict({"module.name", SnakeCaseToCamelCase(modules[i]), });
+          ListToDict({"module.name", PackageToModule(modules[i]), });
       out.Print(module_vars, "module $module.name$\n");
       out.Indent();
     }

--- a/src/compiler/ruby_generator.cc
+++ b/src/compiler/ruby_generator.cc
@@ -115,6 +115,16 @@ void PrintService(const ServiceDescriptor *service, const grpc::string &package,
 
 }  // namespace
 
+grpc::string SnakeCaseToCamelCase(grpc::string input) {
+  grpc::string output;
+  std::vector<grpc::string> words = Split(input, '_');
+  for(size_t i = 0; i < words.size(); i++) {
+    output.append(CapitalizeFirst(words[i]));
+  }
+  return output;
+}
+
+
 grpc::string GetServices(const FileDescriptor *file) {
   grpc::string output;
   {
@@ -156,7 +166,7 @@ grpc::string GetServices(const FileDescriptor *file) {
     std::vector<grpc::string> modules = Split(file->package(), '.');
     for (size_t i = 0; i < modules.size(); ++i) {
       std::map<grpc::string, grpc::string> module_vars =
-          ListToDict({"module.name", CapitalizeFirst(modules[i]), });
+          ListToDict({"module.name", SnakeCaseToCamelCase(modules[i]), });
       out.Print(module_vars, "module $module.name$\n");
       out.Indent();
     }

--- a/src/compiler/ruby_generator.cc
+++ b/src/compiler/ruby_generator.cc
@@ -115,17 +115,8 @@ void PrintService(const ServiceDescriptor *service, const grpc::string &package,
 
 }  // namespace
 
-grpc::string SnakeCaseToCamelCase(grpc::string input) {
-  grpc::string output;
-  std::vector<grpc::string> words = Split(input, '_');
-  for(size_t i = 0; i < words.size(); i++) {
-    output.append(CapitalizeFirst(words[i]));
-  }
-  return output;
-}
-
 // The following functions are copied directly from the source for the protoc ruby generator
-// to ensure compatibility ('int i' changed to 'uint i' is the only change).
+// to ensure compatibility (with the exception of int and string type changes).
 // See https://github.com/google/protobuf/blob/master/src/google/protobuf/compiler/ruby/ruby_generator.cc#L250
 // TODO: keep up to date with protoc code generation, though this behavior isn't expected to change
 bool IsLower(char ch) { return ch >= 'a' && ch <= 'z'; }
@@ -137,9 +128,9 @@ char ToUpper(char ch) { return IsLower(ch) ? (ch - 'a' + 'A') : ch; }
 // names must be PascalCased.
 //
 //   foo_bar_baz -> FooBarBaz
-std::string PackageToModule(const std::string& name) {
+grpc::string PackageToModule(const grpc::string& name) {
   bool next_upper = true;
-  std::string result;
+  grpc::string result;
   result.reserve(name.size());
 
   for (uint i = 0; i < name.size(); i++) {


### PR DESCRIPTION
First attempt to fix https://github.com/grpc/grpc/issues/8257. 

Tested this with example protos files, tweaking the package names to use a similar pattern as used in the issue, and saw this work, but I think the c++ might need some tweaks.