### PR TITLE
Fix building go interop image

### DIFF
--- a/tools/dockerfile/interoptest/grpc_interop_go/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_go/build_interop.sh
@@ -36,18 +36,11 @@ set -e
 # to test instead of using "go get" to download from Github directly.
 git clone --recursive /var/local/jenkins/grpc-go src/google.golang.org/grpc
 
+# Get all gRPC Go dependencies
+(cd src/google.golang.org/grpc && go get -t .)
+
 # copy service account keys if available
 cp -r /var/local/jenkins/service_account $HOME || true
-
-# Get dependencies from GitHub
-# NOTE: once grpc-go dependencies change, this needs to be updated manually
-# but we don't expect this to happen any time soon.
-go get github.com/golang/protobuf/proto
-go get golang.org/x/net/context
-go get golang.org/x/net/trace
-go get golang.org/x/oauth2
-go get golang.org/x/oauth2/google
-go get google.golang.org/cloud
 
 # Build the interop client and server
 (cd src/google.golang.org/grpc/interop/client && go install)


### PR DESCRIPTION
Fixes #8264 and should prevent future breakages because go dependencies are no longer manually listed in the script that builds go interop docker image.