### PR TITLE
fix build on macOS sierra by adding OSATOMIC_USE_INLINED=1 flag to compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,7 @@ CXXFLAGS += -std=c++11
 else
 CXXFLAGS += -std=c++0x
 endif
-CPPFLAGS += -g -Wall -Wextra -Werror -Wno-long-long -Wno-unused-parameter
+CPPFLAGS += -g -Wall -Wextra -Werror -Wno-long-long -Wno-unused-parameter -DOSATOMIC_USE_INLINED=1
 LDFLAGS += -g
 
 CPPFLAGS += $(CPPFLAGS_$(CONFIG))

--- a/build.yaml
+++ b/build.yaml
@@ -3794,7 +3794,7 @@ defaults:
     CPPFLAGS: -Ithird_party/boringssl/include -fvisibility=hidden -DOPENSSL_NO_ASM
       -D_GNU_SOURCE -DWIN32_LEAN_AND_MEAN -D_HAS_EXCEPTIONS=0 -DNOMINMAX
   global:
-    CPPFLAGS: -g -Wall -Wextra -Werror -Wno-long-long -Wno-unused-parameter
+    CPPFLAGS: -g -Wall -Wextra -Werror -Wno-long-long -Wno-unused-parameter -DOSATOMIC_USE_INLINED=1
     LDFLAGS: -g
   zlib:
     CFLAGS: -Wno-sign-conversion -Wno-conversion -Wno-unused-value -Wno-implicit-function-declaration


### PR DESCRIPTION
When calling the Make Command on macOS sierra I had errors due to `OSAtomic*` functions deprecation such as:

```
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/usr/include/libkern/OSAtomicDeprecated.h:645:9: note: 'OSAtomicCompareAndSwap64Barrier' has been
      explicitly marked deprecated here
bool    OSAtomicCompareAndSwap64Barrier( int64_t __oldValue, int64_t __newValue,
        ^
```

I followed the SDK header file and saw this comment :

```
/*! @header
 * These are deprecated legacy interfaces for atomic operations.
 * The C11 interfaces in <stdatomic.h> resp. C++11 interfaces in <atomic>
 * should be used instead.
 *
 * Define OSATOMIC_USE_INLINED=1 to get inline implementations of these
 * interfaces in terms of the <stdatomic.h> resp. <atomic> primitives.
 * This is intended as a transition convenience, direct use of those primitives
 * is preferred.
 */
```

So I added the flag to the build to inline to the new functions.

I could then build using `make`
