### PR TITLE
Windows fixes for run_tests_in_workspace.sh

### DIFF
--- a/tools/run_tests/run_tests_in_workspace.sh
+++ b/tools/run_tests/run_tests_in_workspace.sh
@@ -42,5 +42,5 @@ rm -rf "${WORKSPACE_NAME}"
 git clone --recursive . "${WORKSPACE_NAME}"
 
 echo "Running run_tests.py in workspace ${WORKSPACE_NAME}" 
-"${WORKSPACE_NAME}/tools/run_tests/run_tests.py" $@
+python "${WORKSPACE_NAME}/tools/run_tests/run_tests.py" $@
 


### PR DESCRIPTION
Without this, wrong python version is selected on Windows and the build fails with `from six.moves import urllib`