### PR TITLE
Remove bad node portability targets

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -195,15 +195,6 @@ def _create_portability_test_jobs(extra_args=[]):
                               compiler='coreclr',
                               labels=['portability'],
                               extra_args=extra_args)
-  
-  for compiler in ['node5', 'node0.12']:
-    test_jobs += _generate_jobs(languages=['node'],
-                                configs=['dbg'],
-                                platforms=['linux'],
-                                arch='default',
-                                compiler=compiler,
-                                labels=['portability'],
-                                extra_args=extra_args)
   return test_jobs  
 
 


### PR DESCRIPTION
node0.12 and node5 are currently not supported by run_tests.py script (in the master branch), so there's no point of running them.

This only affects tests run by run_tests_matrix.py