### PR TITLE
PHP: require grpc extension to be installed before composer package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
   "license": "BSD-3-Clause",
   "require": {
     "php": ">=5.5.0",
+    "ext-grpc": "*",
     "google/protobuf": "v3.1.0-alpha-1"
   },
   "require-dev": {

--- a/examples/php/composer.json
+++ b/examples/php/composer.json
@@ -2,6 +2,7 @@
   "name": "grpc/grpc-demo",
   "description": "gRPC example for PHP",
   "require": {
+    "ext-grpc": "*",
     "grpc/grpc": "v1.0.0"
   }
 }

--- a/src/php/composer.json
+++ b/src/php/composer.json
@@ -8,6 +8,7 @@
   "version": "1.1.0",
   "require": {
     "php": ">=5.5.0",
+    "ext-grpc": "*",
     "google/protobuf": "v3.1.0-alpha-1"
   },
   "require-dev": {

--- a/templates/composer.json.template
+++ b/templates/composer.json.template
@@ -9,6 +9,7 @@
     "license": "BSD-3-Clause",
     "require": {
       "php": ">=5.5.0",
+      "ext-grpc": "*",
       "google/protobuf": "v3.1.0-alpha-1"
     },
     "require-dev": {

--- a/templates/src/php/composer.json.template
+++ b/templates/src/php/composer.json.template
@@ -10,6 +10,7 @@
     "version": "${settings.php_version.php_composer()}",
     "require": {
       "php": ">=5.5.0",
+      "ext-grpc": "*",
       "google/protobuf": "v3.1.0-alpha-1"
     },
     "require-dev": {

--- a/tools/dockerfile/interoptest/grpc_interop_php/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_php/build_interop.sh
@@ -46,6 +46,6 @@ make install
 
 (cd third_party/protobuf && make install)
 
-(cd src/php && composer install)
+(cd src/php && php -d extension=ext/grpc/modules/grpc.so /usr/local/bin/composer install)
 
 (cd src/php && ./bin/generate_proto_php.sh)

--- a/tools/dockerfile/interoptest/grpc_interop_php7/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_php7/build_interop.sh
@@ -46,6 +46,6 @@ make install
 
 (cd third_party/protobuf && make install)
 
-(cd src/php && composer install)
+(cd src/php && php -d extension=ext/grpc/modules/grpc.so /usr/local/bin/composer install)
 
 (cd src/php && ./bin/generate_proto_php.sh)

--- a/tools/dockerfile/stress_test/grpc_interop_stress_php/build_interop_stress.sh
+++ b/tools/dockerfile/stress_test/grpc_interop_stress_php/build_interop_stress.sh
@@ -48,6 +48,6 @@ make install
 
 (cd third_party/protobuf && make install)
 
-(cd src/php && composer install)
+(cd src/php && php -d extension=ext/grpc/modules/grpc.so /usr/local/bin/composer install)
 
 (cd src/php && ./bin/generate_proto_php.sh)


### PR DESCRIPTION
An update to #8196 