### PR TITLE
Fix C++ filter API header.

### DIFF
--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -40,6 +40,10 @@
 #include <grpc/status.h>
 #include <grpc/support/time.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /// Opaque representation of an error.
 /// Errors are refcounted objects that represent the result of an operation.
 /// Ownership laws:
@@ -203,5 +207,9 @@ bool grpc_log_if_error(const char *what, grpc_error *error, const char *file,
                        int line);
 #define GRPC_LOG_IF_ERROR(what, error) \
   grpc_log_if_error((what), (error), __FILE__, __LINE__)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* GRPC_CORE_LIB_IOMGR_ERROR_H */

--- a/src/cpp/common/channel_filter.h
+++ b/src/cpp/common/channel_filter.h
@@ -42,6 +42,7 @@
 #include <vector>
 
 #include "src/core/lib/channel/channel_stack.h"
+#include "src/core/lib/security/context/security_context.h"
 #include "src/core/lib/surface/channel_init.h"
 #include "src/core/lib/transport/metadata_batch.h"
 
@@ -53,11 +54,6 @@
 ///   RegisterChannelFilter<MyChannelDataSubclass, MyCallDataSubclass>(
 ///       "name-of-filter", GRPC_SERVER_CHANNEL, INT_MAX, nullptr);
 /// \endcode
-
-/// Forward declaration to avoid including the file
-/// "src/core/lib/security/context/security_context.h"
-struct grpc_client_security_context;
-struct grpc_server_security_context;
 
 namespace grpc {
 


### PR DESCRIPTION
This fixes the following build problem:

```
.../grpc/src/core/lib/security/context/security_context.h:105:3: error: typedef redefinition with different types ('struct grpc_client_security_context' vs 'grpc_client_security_context')
} grpc_client_security_context;
  ^
.../grpc/src/cpp/common/channel_filter.h:59:8: note: previous definition is here
struct grpc_client_security_context;
```