### PR TITLE
Stop using atexit in tests

### DIFF
--- a/src/core/ext/transport/cronet/transport/cronet_transport.c
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.c
@@ -543,7 +543,7 @@ static void create_grpc_frame(gpr_slice_buffer *write_slice_buffer,
 static void convert_metadata_to_cronet_headers(
     grpc_linked_mdelem *head, const char *host, char **pp_url,
     cronet_bidirectional_stream_header **pp_headers, size_t *p_num_headers,
-    const char ** method) {
+    const char **method) {
   grpc_linked_mdelem *curr = head;
   /* Walk the linked list and get number of header fields */
   size_t num_headers_available = 0;

--- a/test/core/bad_client/bad_client.c
+++ b/test/core/bad_client/bad_client.c
@@ -194,5 +194,6 @@ void grpc_run_bad_client_test(
   gpr_slice_buffer_destroy(&outgoing);
 
   grpc_exec_ctx_finish(&exec_ctx);
+  grpc_test_shutdown();
   grpc_shutdown();
 }

--- a/test/core/bad_ssl/bad_ssl_test.c
+++ b/test/core/bad_ssl/bad_ssl_test.c
@@ -165,6 +165,7 @@ int main(int argc, char **argv) {
   for (i = 3; i <= 4; i++) {
     grpc_init();
     run_test(args[2], i);
+    grpc_test_shutdown();
     grpc_shutdown();
   }
   gpr_free(args[2]);

--- a/test/core/bad_ssl/servers/alpn.c
+++ b/test/core/bad_ssl/servers/alpn.c
@@ -80,6 +80,7 @@ int main(int argc, char **argv) {
   grpc_server_credentials_release(ssl_creds);
 
   bad_ssl_run(server);
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/bad_ssl/servers/cert.c
+++ b/test/core/bad_ssl/servers/cert.c
@@ -42,6 +42,7 @@
 
 #include "test/core/bad_ssl/server_common.h"
 #include "test/core/end2end/data/ssl_test_data.h"
+#include "test/core/util/test_config.h"
 
 /* This server will present an untrusted cert to the connecting client,
  * causing the SSL handshake to fail */
@@ -74,6 +75,7 @@ int main(int argc, char **argv) {
   gpr_slice_unref(key_slice);
 
   bad_ssl_run(server);
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/channel/channel_args_test.c
+++ b/test/core/channel/channel_args_test.c
@@ -140,6 +140,7 @@ int main(int argc, char **argv) {
   test_create();
   test_set_compression_algorithm();
   test_compression_algorithm_states();
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/channel/channel_stack_test.c
+++ b/test/core/channel/channel_stack_test.c
@@ -160,6 +160,7 @@ int main(int argc, char **argv) {
   grpc_test_init(argc, argv);
   grpc_init();
   test_create_channel_stack();
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/client_config/lb_policies_test.c
+++ b/test/core/client_config/lb_policies_test.c
@@ -935,6 +935,7 @@ int main(int argc, char **argv) {
   test_ping();
 
   grpc_exec_ctx_finish(&exec_ctx);
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/client_config/resolvers/dns_resolver_connectivity_test.c
+++ b/test/core/client_config/resolvers/dns_resolver_connectivity_test.c
@@ -126,6 +126,7 @@ int main(int argc, char **argv) {
   GRPC_RESOLVER_UNREF(&exec_ctx, resolver, "test");
   grpc_exec_ctx_finish(&exec_ctx);
 
+  grpc_test_shutdown();
   grpc_shutdown();
   gpr_mu_destroy(&g_mu);
 }

--- a/test/core/client_config/resolvers/dns_resolver_test.c
+++ b/test/core/client_config/resolvers/dns_resolver_test.c
@@ -84,6 +84,7 @@ int main(int argc, char **argv) {
   test_fails(dns, "ipv4://8.8.8.8/8.8.8.8:8888");
 
   grpc_resolver_factory_unref(dns);
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/client_config/resolvers/sockaddr_resolver_test.c
+++ b/test/core/client_config/resolvers/sockaddr_resolver_test.c
@@ -121,6 +121,7 @@ int main(int argc, char **argv) {
 
   grpc_resolver_factory_unref(ipv4);
   grpc_resolver_factory_unref(ipv6);
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/client_config/set_initial_connect_string_test.c
+++ b/test/core/client_config/set_initial_connect_string_test.c
@@ -252,6 +252,7 @@ int main(int argc, char **argv) {
   run_test(test_initial_string_with_redirect, 0);
   run_test(test_initial_string_with_redirect, 1);
 
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/compression/algorithm_test.c
+++ b/test/core/compression/algorithm_test.c
@@ -98,6 +98,7 @@ int main(int argc, char **argv) {
   test_algorithm_mesh();
   test_algorithm_failure();
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/compression/compression_test.c
+++ b/test/core/compression/compression_test.c
@@ -223,6 +223,7 @@ int main(int argc, char **argv) {
   test_compression_algorithm_name();
   test_compression_algorithm_for_level();
   test_compression_enable_disable_algorithm();
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/compression/message_compress_test.c
+++ b/test/core/compression/message_compress_test.c
@@ -302,6 +302,7 @@ int main(int argc, char **argv) {
   test_bad_decompression_data_trailing_garbage();
   test_bad_compression_algorithm();
   test_bad_decompression_algorithm();
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/bad_server_response_test.c
+++ b/test/core/end2end/bad_server_response_test.c
@@ -295,6 +295,7 @@ static void run_test(const char *response_payload,
   cleanup_rpc();
   test_tcp_server_destroy(&test_server);
 
+  grpc_test_shutdown();
   grpc_shutdown();
 }
 

--- a/test/core/end2end/connection_refused_test.c
+++ b/test/core/end2end/connection_refused_test.c
@@ -117,6 +117,7 @@ static void run_test(bool fail_fast) {
   gpr_free(details);
   grpc_metadata_array_destroy(&trailing_metadata_recv);
 
+  grpc_test_shutdown();
   grpc_shutdown();
 }
 

--- a/test/core/end2end/dualstack_socket_test.c
+++ b/test/core/end2end/dualstack_socket_test.c
@@ -349,6 +349,7 @@ int main(int argc, char **argv) {
     }
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_census.c
+++ b/test/core/end2end/fixtures/h2_census.c
@@ -127,6 +127,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_compress.c
+++ b/test/core/end2end/fixtures/h2_compress.c
@@ -131,6 +131,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_fakesec.c
+++ b/test/core/end2end/fixtures/h2_fakesec.c
@@ -157,6 +157,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_fd.c
+++ b/test/core/end2end/fixtures/h2_fd.c
@@ -122,6 +122,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_full+pipe.c
+++ b/test/core/end2end/fixtures/h2_full+pipe.c
@@ -115,6 +115,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_full+trace.c
+++ b/test/core/end2end/fixtures/h2_full+trace.c
@@ -127,6 +127,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_full.c
+++ b/test/core/end2end/fixtures/h2_full.c
@@ -112,6 +112,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_http_proxy.c
+++ b/test/core/end2end/fixtures/h2_http_proxy.c
@@ -123,6 +123,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_load_reporting.c
+++ b/test/core/end2end/fixtures/h2_load_reporting.c
@@ -119,6 +119,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_oauth2.c
+++ b/test/core/end2end/fixtures/h2_oauth2.c
@@ -233,6 +233,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_proxy.c
+++ b/test/core/end2end/fixtures/h2_proxy.c
@@ -130,6 +130,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_sockpair+trace.c
+++ b/test/core/end2end/fixtures/h2_sockpair+trace.c
@@ -165,6 +165,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_sockpair.c
+++ b/test/core/end2end/fixtures/h2_sockpair.c
@@ -149,6 +149,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_sockpair_1byte.c
+++ b/test/core/end2end/fixtures/h2_sockpair_1byte.c
@@ -149,6 +149,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fixtures/h2_ssl.c
+++ b/test/core/end2end/fixtures/h2_ssl.c
@@ -181,6 +181,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   /* Cleanup. */

--- a/test/core/end2end/fixtures/h2_ssl_cert.c
+++ b/test/core/end2end/fixtures/h2_ssl_cert.c
@@ -367,6 +367,7 @@ int main(int argc, char **argv) {
     configs[i].config.tear_down_data(&f);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   /* Cleanup. */

--- a/test/core/end2end/fixtures/h2_ssl_proxy.c
+++ b/test/core/end2end/fixtures/h2_ssl_proxy.c
@@ -215,6 +215,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   /* Cleanup. */

--- a/test/core/end2end/fixtures/h2_uds.c
+++ b/test/core/end2end/fixtures/h2_uds.c
@@ -117,6 +117,7 @@ int main(int argc, char **argv) {
     grpc_end2end_tests(argc, argv, configs[i]);
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/fuzzers/api_fuzzer.c
+++ b/test/core/end2end/fuzzers/api_fuzzer.c
@@ -46,6 +46,7 @@
 #include "src/core/lib/surface/server.h"
 #include "src/core/lib/transport/metadata.h"
 #include "test/core/util/passthru_endpoint.h"
+#include "test/core/util/test_config.h"
 
 ////////////////////////////////////////////////////////////////////////////////
 // logging
@@ -954,6 +955,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
           .type == GRPC_QUEUE_SHUTDOWN);
   grpc_completion_queue_destroy(cq);
 
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/end2end/fuzzers/client_fuzzer.c
+++ b/test/core/end2end/fuzzers/client_fuzzer.c
@@ -40,6 +40,7 @@
 #include "src/core/lib/surface/channel.h"
 #include "test/core/util/memory_counters.h"
 #include "test/core/util/mock_endpoint.h"
+#include "test/core/util/test_config.h"
 
 bool squelch = true;
 bool leak_check = true;
@@ -156,6 +157,7 @@ done:
   if (response_payload_recv != NULL) {
     grpc_byte_buffer_destroy(response_payload_recv);
   }
+  grpc_test_shutdown();
   grpc_shutdown();
   if (leak_check) {
     counters = grpc_memory_counters_snapshot();

--- a/test/core/end2end/fuzzers/server_fuzzer.c
+++ b/test/core/end2end/fuzzers/server_fuzzer.c
@@ -37,6 +37,7 @@
 #include "src/core/lib/surface/server.h"
 #include "test/core/util/memory_counters.h"
 #include "test/core/util/mock_endpoint.h"
+#include "test/core/util/test_config.h"
 
 bool squelch = true;
 bool leak_check = true;
@@ -120,6 +121,7 @@ done:
   }
   grpc_server_destroy(server);
   grpc_completion_queue_destroy(cq);
+  grpc_test_shutdown();
   grpc_shutdown();
   if (leak_check) {
     counters = grpc_memory_counters_snapshot();

--- a/test/core/end2end/goaway_server_test.c
+++ b/test/core/end2end/goaway_server_test.c
@@ -301,6 +301,7 @@ int main(int argc, char **argv) {
   cq_verifier_destroy(cqv);
   grpc_completion_queue_destroy(cq);
 
+  grpc_test_shutdown();
   grpc_shutdown();
   gpr_mu_destroy(&g_mu);
 

--- a/test/core/end2end/invalid_call_argument_test.c
+++ b/test/core/end2end/invalid_call_argument_test.c
@@ -594,6 +594,7 @@ int main(int argc, char **argv) {
   test_send_server_status_twice();
   test_recv_close_on_server_with_invalid_flags();
   test_recv_close_on_server_twice();
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/end2end/multiple_server_queues_test.c
+++ b/test/core/end2end/multiple_server_queues_test.c
@@ -58,6 +58,7 @@ int main(int argc, char **argv) {
   grpc_server_destroy(server);
   grpc_completion_queue_destroy(cq1);
   grpc_completion_queue_destroy(cq2);
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/end2end/no_server_test.c
+++ b/test/core/end2end/no_server_test.c
@@ -104,6 +104,7 @@ int main(int argc, char **argv) {
   gpr_free(details);
   grpc_metadata_array_destroy(&trailing_metadata_recv);
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/fling/client.c
+++ b/test/core/fling/client.c
@@ -250,6 +250,7 @@ int main(int argc, char **argv) {
           gpr_histogram_percentile(histogram, 99.9));
   gpr_histogram_destroy(histogram);
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/fling/server.c
+++ b/test/core/fling/server.c
@@ -325,6 +325,7 @@ int main(int argc, char **argv) {
 
   grpc_server_destroy(server);
   grpc_completion_queue_destroy(cq);
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/http/httpcli_test.c
+++ b/test/core/http/httpcli_test.c
@@ -206,6 +206,7 @@ int main(int argc, char **argv) {
   grpc_pollset_shutdown(&exec_ctx, grpc_polling_entity_pollset(&g_pops),
                         &destroyed);
   grpc_exec_ctx_finish(&exec_ctx);
+  grpc_test_shutdown();
   grpc_shutdown();
 
   gpr_free(grpc_polling_entity_pollset(&g_pops));

--- a/test/core/http/httpscli_test.c
+++ b/test/core/http/httpscli_test.c
@@ -209,6 +209,7 @@ int main(int argc, char **argv) {
   grpc_pollset_shutdown(&exec_ctx, grpc_polling_entity_pollset(&g_pops),
                         &destroyed);
   grpc_exec_ctx_finish(&exec_ctx);
+  grpc_test_shutdown();
   grpc_shutdown();
 
   gpr_free(grpc_polling_entity_pollset(&g_pops));

--- a/test/core/iomgr/combiner_test.c
+++ b/test/core/iomgr/combiner_test.c
@@ -158,6 +158,7 @@ int main(int argc, char **argv) {
   test_execute_one();
   test_execute_finally();
   test_execute_many();
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/iomgr/endpoint_pair_test.c
+++ b/test/core/iomgr/endpoint_pair_test.c
@@ -80,6 +80,7 @@ int main(int argc, char **argv) {
   grpc_closure_init(&destroyed, destroy_pollset, g_pollset);
   grpc_pollset_shutdown(&exec_ctx, g_pollset, &destroyed);
   grpc_exec_ctx_finish(&exec_ctx);
+  grpc_test_shutdown();
   grpc_shutdown();
   gpr_free(g_pollset);
 

--- a/test/core/iomgr/tcp_client_posix_test.c
+++ b/test/core/iomgr/tcp_client_posix_test.c
@@ -207,6 +207,7 @@ int main(int argc, char **argv) {
   grpc_closure_init(&destroyed, destroy_pollset, g_pollset);
   grpc_pollset_shutdown(&exec_ctx, g_pollset, &destroyed);
   grpc_exec_ctx_finish(&exec_ctx);
+  grpc_test_shutdown();
   grpc_shutdown();
   gpr_free(g_pollset);
   return 0;

--- a/test/core/iomgr/tcp_posix_test.c
+++ b/test/core/iomgr/tcp_posix_test.c
@@ -539,6 +539,7 @@ int main(int argc, char **argv) {
   grpc_closure_init(&destroyed, destroy_pollset, g_pollset);
   grpc_pollset_shutdown(&exec_ctx, g_pollset, &destroyed);
   grpc_exec_ctx_finish(&exec_ctx);
+  grpc_test_shutdown();
   grpc_shutdown();
   gpr_free(g_pollset);
 

--- a/test/core/iomgr/tcp_server_posix_test.c
+++ b/test/core/iomgr/tcp_server_posix_test.c
@@ -344,6 +344,7 @@ int main(int argc, char **argv) {
   grpc_closure_init(&destroyed, destroy_pollset, g_pollset);
   grpc_pollset_shutdown(&exec_ctx, g_pollset, &destroyed);
   grpc_exec_ctx_finish(&exec_ctx);
+  grpc_test_shutdown();
   grpc_shutdown();
   gpr_free(g_pollset);
   return 0;

--- a/test/core/security/credentials_test.c
+++ b/test/core/security/credentials_test.c
@@ -1182,6 +1182,7 @@ int main(int argc, char **argv) {
   test_metadata_plugin_success();
   test_metadata_plugin_failure();
   test_get_well_known_google_credentials_file_path();
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/security/fetch_oauth2.c
+++ b/test/core/security/fetch_oauth2.c
@@ -45,6 +45,7 @@
 #include "src/core/lib/iomgr/load_file.h"
 #include "src/core/lib/security/credentials/credentials.h"
 #include "test/core/security/oauth2_utils.h"
+#include "test/core/util/test_config.h"
 
 static grpc_call_credentials *create_refresh_token_creds(
     const char *json_refresh_token_file_path) {
@@ -114,6 +115,7 @@ int main(int argc, char **argv) {
   }
   grpc_call_credentials_release(creds);
   gpr_cmdline_destroy(cl);
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/security/jwt_verifier_test.c
+++ b/test/core/security/jwt_verifier_test.c
@@ -574,6 +574,7 @@ int main(int argc, char **argv) {
   test_jwt_verifier_bad_json_key();
   test_jwt_verifier_bad_signature();
   test_jwt_verifier_bad_format();
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/security/secure_endpoint_test.c
+++ b/test/core/security/secure_endpoint_test.c
@@ -191,6 +191,7 @@ int main(int argc, char **argv) {
   grpc_closure_init(&destroyed, destroy_pollset, g_pollset);
   grpc_pollset_shutdown(&exec_ctx, g_pollset, &destroyed);
   grpc_exec_ctx_finish(&exec_ctx);
+  grpc_test_shutdown();
   grpc_shutdown();
 
   gpr_free(g_pollset);

--- a/test/core/security/security_connector_test.c
+++ b/test/core/security/security_connector_test.c
@@ -414,6 +414,7 @@ int main(int argc, char **argv) {
   test_cn_and_multiple_sans_and_others_ssl_peer_to_auth_context();
   test_default_ssl_roots();
 
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/surface/alarm_test.c
+++ b/test/core/surface/alarm_test.c
@@ -95,6 +95,7 @@ int main(int argc, char **argv) {
   grpc_test_init(argc, argv);
   grpc_init();
   test_alarm();
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/surface/channel_create_test.c
+++ b/test/core/surface/channel_create_test.c
@@ -51,6 +51,7 @@ int main(int argc, char **argv) {
   grpc_test_init(argc, argv);
   grpc_init();
   test_unknown_scheme_target();
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/surface/completion_queue_test.c
+++ b/test/core/surface/completion_queue_test.c
@@ -427,6 +427,7 @@ int main(int argc, char **argv) {
   test_threading(1, 10);
   test_threading(10, 1);
   test_threading(10, 10);
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/surface/concurrent_connectivity_test.c
+++ b/test/core/surface/concurrent_connectivity_test.c
@@ -228,6 +228,7 @@ int main(int argc, char **argv) {
       grpc_closure_create(done_pollset_shutdown, args.pollset));
   grpc_exec_ctx_finish(&exec_ctx);
 
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/surface/invalid_channel_args_test.c
+++ b/test/core/surface/invalid_channel_args_test.c
@@ -146,6 +146,7 @@ int main(int argc, char **argv) {
   test_ssl_name_override_type();
   test_ssl_name_override_failed();
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/surface/lame_client_test.c
+++ b/test/core/surface/lame_client_test.c
@@ -164,6 +164,7 @@ int main(int argc, char **argv) {
   grpc_metadata_array_destroy(&trailing_metadata_recv);
   gpr_free(details);
 
+  grpc_test_shutdown();
   grpc_shutdown();
 
   return 0;

--- a/test/core/surface/secure_channel_create_test.c
+++ b/test/core/surface/secure_channel_create_test.c
@@ -90,6 +90,7 @@ int main(int argc, char **argv) {
   test_security_connector_already_in_arg();
   test_null_creds();
   test_unknown_scheme_target();
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/surface/sequential_connectivity_test.c
+++ b/test/core/surface/sequential_connectivity_test.c
@@ -127,6 +127,7 @@ static void run_test(const test_fixture *fixture) {
   grpc_completion_queue_destroy(server_cq);
   grpc_completion_queue_destroy(cq);
 
+  grpc_test_shutdown();
   grpc_shutdown();
   gpr_free(addr);
 }

--- a/test/core/surface/server_chttp2_test.c
+++ b/test/core/surface/server_chttp2_test.c
@@ -79,6 +79,7 @@ int main(int argc, char **argv) {
   grpc_init();
   test_unparsable_target();
   test_add_same_port_twice();
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/surface/server_test.c
+++ b/test/core/surface/server_test.c
@@ -175,6 +175,7 @@ int main(int argc, char **argv) {
     test_bind_server_to_addrs(dns_addrs, GPR_ARRAY_SIZE(dns_addrs));
   }
 
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/transport/chttp2/hpack_encoder_test.c
+++ b/test/core/transport/chttp2/hpack_encoder_test.c
@@ -231,6 +231,7 @@ int main(int argc, char **argv) {
   TEST(test_basic_headers);
   TEST(test_decode_table_overflow);
   TEST(test_encode_header_size);
+  grpc_test_shutdown();
   grpc_shutdown();
   for (i = 0; i < num_to_delete; i++) {
     gpr_free(to_delete[i]);

--- a/test/core/transport/chttp2/hpack_parser_fuzzer_test.c
+++ b/test/core/transport/chttp2/hpack_parser_fuzzer_test.c
@@ -40,6 +40,8 @@
 
 #include "src/core/ext/transport/chttp2/transport/hpack_parser.h"
 
+#include "test/core/util/test_config.h"
+
 bool squelch = true;
 bool leak_check = true;
 
@@ -55,6 +57,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   parser.on_header = onhdr;
   GRPC_ERROR_UNREF(grpc_chttp2_hpack_parser_parse(&parser, data, data + size));
   grpc_chttp2_hpack_parser_destroy(&parser);
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/transport/chttp2/hpack_parser_test.c
+++ b/test/core/transport/chttp2/hpack_parser_test.c
@@ -222,6 +222,7 @@ int main(int argc, char **argv) {
   grpc_init();
   test_vectors(GRPC_SLICE_SPLIT_MERGE_ALL);
   test_vectors(GRPC_SLICE_SPLIT_ONE_BYTE);
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/transport/chttp2/hpack_table_test.c
+++ b/test/core/transport/chttp2/hpack_table_test.c
@@ -276,6 +276,7 @@ int main(int argc, char **argv) {
   test_static_lookup();
   test_many_additions();
   test_find();
+  grpc_test_shutdown();
   grpc_shutdown();
   return 0;
 }

--- a/test/core/util/port_posix.c
+++ b/test/core/util/port_posix.c
@@ -108,7 +108,7 @@ static void free_chosen_ports(void) {
 
 static void chose_port(int port) {
   if (chosen_ports == NULL) {
-    atexit(free_chosen_ports);
+    grpc_test_before_shutdown(free_chosen_ports);
   }
   num_chosen_ports++;
   chosen_ports = gpr_realloc(chosen_ports, sizeof(int) * num_chosen_ports);

--- a/test/core/util/port_windows.c
+++ b/test/core/util/port_windows.c
@@ -110,7 +110,7 @@ static void free_chosen_ports(void) {
 
 static void chose_port(int port) {
   if (chosen_ports == NULL) {
-    atexit(free_chosen_ports);
+    grpc_test_before_shutdown(free_chosen_ports);
   }
   num_chosen_ports++;
   chosen_ports = gpr_realloc(chosen_ports, sizeof(int) * num_chosen_ports);

--- a/test/core/util/test_config.c
+++ b/test/core/util/test_config.c
@@ -33,6 +33,7 @@
 
 #include "test/core/util/test_config.h"
 
+#include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <signal.h>
 #include <stdbool.h>
@@ -272,6 +273,18 @@ static void install_crash_handler() {
 static void install_crash_handler() {}
 #endif
 
+typedef struct shutdown_handler_list_elem {
+  void (*function)(void);
+  struct shutdown_handler_list_elem *next;
+} shutdown_handler_list_elem;
+
+typedef struct shutdown_handler_list {
+  shutdown_handler_list_elem *head;
+  shutdown_handler_list_elem *tail;
+} shutdown_handler_list;
+
+static shutdown_handler_list shutdown_handlers;
+
 void grpc_test_init(int argc, char **argv) {
   install_crash_handler();
   gpr_log(GPR_DEBUG, "test slowdown: machine=%f build=%f total=%f",
@@ -281,4 +294,30 @@ void grpc_test_init(int argc, char **argv) {
   /* seed rng with pid, so we don't end up with the same random numbers as a
      concurrently running test binary */
   srand(seed());
+  shutdown_handlers.head = shutdown_handlers.tail = NULL;
+}
+
+void grpc_test_before_shutdown(void (*function)(void)) {
+  shutdown_handler_list_elem *elem =
+      gpr_malloc(sizeof(shutdown_handler_list_elem));
+  elem->function = function;
+  elem->next = NULL;
+  if (shutdown_handlers.head == NULL) {
+    shutdown_handlers.head = shutdown_handlers.tail = elem;
+  } else {
+    shutdown_handlers.tail->next = elem;
+    shutdown_handlers.tail = elem;
+  }
+}
+
+void grpc_test_shutdown() {
+  for (shutdown_handler_list_elem *handler = shutdown_handlers.head;
+       handler != NULL; handler = handler->next) {
+    shutdown_handlers.head = handler->next;
+    if (shutdown_handlers.head == NULL) {
+      shutdown_handlers.tail = NULL;
+    }
+    handler->function();
+    gpr_free(handler);
+  }
 }

--- a/test/core/util/test_config.c
+++ b/test/core/util/test_config.c
@@ -311,13 +311,19 @@ void grpc_test_before_shutdown(void (*function)(void)) {
 }
 
 void grpc_test_shutdown() {
+  shutdown_handler_list_elem *prev = NULL;
   for (shutdown_handler_list_elem *handler = shutdown_handlers.head;
        handler != NULL; handler = handler->next) {
+    // Free handler from the previous iteration
+    gpr_free(prev);
+    // Remove handler from the list
     shutdown_handlers.head = handler->next;
     if (shutdown_handlers.head == NULL) {
       shutdown_handlers.tail = NULL;
     }
     handler->function();
-    gpr_free(handler);
+    prev = handler;
   }
+  // Free last handler
+  gpr_free(prev);
 }

--- a/test/core/util/test_config.h
+++ b/test/core/util/test_config.h
@@ -72,6 +72,13 @@ extern double g_fixture_slowdown_factor;
 
 void grpc_test_init(int argc, char **argv);
 
+/* Register a function to be called before grpc_shutdown. This is intended to be
+   a drop-in replacement for atexit. */
+void grpc_test_before_shutdown(void (*function)(void));
+
+/* This should be called before grpc_shutdown in tests. */
+void grpc_test_shutdown();
+
 #ifdef __cplusplus
 }
 #endif /*  __cplusplus */

--- a/test/core/util/test_tcp_server.c
+++ b/test/core/util/test_tcp_server.c
@@ -44,6 +44,7 @@
 #include "src/core/lib/iomgr/sockaddr.h"
 #include "src/core/lib/iomgr/tcp_server.h"
 #include "test/core/util/port.h"
+#include "test/core/util/test_config.h"
 
 static void on_server_destroyed(grpc_exec_ctx *exec_ctx, void *data,
                                 grpc_error *error) {
@@ -119,5 +120,6 @@ void test_tcp_server_destroy(test_tcp_server *server) {
   grpc_exec_ctx_finish(&exec_ctx);
   grpc_pollset_destroy(server->pollset);
   gpr_free(server->pollset);
+  grpc_test_shutdown();
   grpc_shutdown();
 }

--- a/test/cpp/grpclb/grpclb_test.cc
+++ b/test/cpp/grpclb/grpclb_test.cc
@@ -720,6 +720,7 @@ int main(int argc, char **argv) {
   grpc_fake_resolver_init();
   grpc_init();
   const auto result = RUN_ALL_TESTS();
+  grpc_test_shutdown();
   grpc_shutdown();
   return result;
 }


### PR DESCRIPTION
Add `grpc_test_before_shutdown` function to use instead of `atexit`, and add `grpc_test_shutdown` function to trigger the scheduled functions.

Note: Calls to `grpc_test_shutdown` were added with a sed script, so it's possible that some shouldn't actually be there.