### PR TITLE
Critical: dont eat run_tests.py errors on test failure

### DIFF
--- a/tools/run_tests/dockerize/build_docker_and_run_tests.sh
+++ b/tools/run_tests/dockerize/build_docker_and_run_tests.sh
@@ -61,6 +61,7 @@ CONTAINER_NAME="run_tests_$(uuidgen)"
 docker_instance_git_root=/var/local/jenkins/grpc
 
 # Run tests inside docker
+DOCKER_EXIT_CODE=0
 docker run \
   -e "RUN_TESTS_COMMAND=$RUN_TESTS_COMMAND" \
   -e "config=$config" \
@@ -81,7 +82,7 @@ docker run \
   -w /var/local/git/grpc \
   --name=$CONTAINER_NAME \
   $DOCKER_IMAGE_NAME \
-  bash -l "/var/local/jenkins/grpc/$DOCKER_RUN_SCRIPT" || DOCKER_FAILED="true"
+  bash -l "/var/local/jenkins/grpc/$DOCKER_RUN_SCRIPT" || DOCKER_EXIT_CODE=$?
 
 # use unique name for reports.zip to prevent clash between concurrent
 # run_tests.py runs 
@@ -93,7 +94,4 @@ rm -f ${TEMP_REPORTS_ZIP}
 # remove the container, possibly killing it first
 docker rm -f $CONTAINER_NAME || true
 
-if [ "$DOCKER_FAILED" != "" ] && [ "$XML_REPORT" == "" ]
-then
-  exit 1
-fi
+exit $DOCKER_EXIT_CODE

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1423,7 +1423,7 @@ else:
   exit_code = 0
   if BuildAndRunError.BUILD in errors:
     exit_code |= 1
-  if BuildAndRunError.TEST in errors and not args.travis:
+  if BuildAndRunError.TEST in errors:
     exit_code |= 2
   if BuildAndRunError.POST_TEST in errors:
     exit_code |= 4


### PR DESCRIPTION
Please review and merge ASAP.

I've missed that run_tests.py actually eats the exitcode under some circumstances, which made sense with the old jenkins setup but now it has bitten us. Test runner scripts indeed are dangerous business.

Current situation (with -x report.xml enabled):
-- run_tests_matrix.py correctly recognizes that run_tests.py was failed if the error happens during a build (which is what made me think that things work alright when I was testing the script locally).
-- **run_tests_matrix.py  still shows "PASSED" if a test fails after building successfully**

 