### PR TITLE
Fix grpclb LB policy pick method to return 0 upon error.

### DIFF
--- a/src/core/ext/client_config/lb_policy.h
+++ b/src/core/ext/client_config/lb_policy.h
@@ -142,15 +142,18 @@ void grpc_lb_policy_weak_unref(grpc_exec_ctx *exec_ctx, grpc_lb_policy *policy);
 void grpc_lb_policy_init(grpc_lb_policy *policy,
                          const grpc_lb_policy_vtable *vtable);
 
-/** Find an appropriate target for this call, based on \a pick_args.
-    Picking can be synchronous or asynchronous. In the synchronous case, when a
-    pick is readily available, it'll be returned in \a target and a non-zero
-    value will be returned.
-    In the asynchronous case, zero is returned and \a on_complete will be called
-    once \a target and \a user_data have been set. Any IO should be done under
-    \a pick_args->pollent. The opaque \a user_data output argument corresponds
-    to information that may need be propagated from the LB policy. It may be
-    NULL. Errors are signaled by receiving a NULL \a *target. */
+/** Finds an appropriate subchannel for a call, based on \a pick_args.
+
+    \a target will be set to the selected subchannel, or NULL on failure.
+    Upon success, \a user_data will be set to whatever opaque information
+    may need to be propagated from the LB policy, or NULL if not needed.
+
+    If the pick succeeds and a result is known immediately, a non-zero
+    value will be returned.  Otherwise, \a on_complete will be invoked
+    once the pick is complete with its error argument set to indicate
+    success or failure.
+
+    Any I/O should be done under \a pick_args->pollent. */
 int grpc_lb_policy_pick(grpc_exec_ctx *exec_ctx, grpc_lb_policy *policy,
                         const grpc_lb_policy_pick_args *pick_args,
                         grpc_connected_subchannel **target, void **user_data,

--- a/src/core/ext/lb_policy/grpclb/grpclb.c
+++ b/src/core/ext/lb_policy/grpclb/grpclb.c
@@ -761,7 +761,7 @@ static int glb_pick(grpc_exec_ctx *exec_ctx, grpc_lb_policy *pol,
         GRPC_ERROR_CREATE("No mdelem storage for the LB token. Load reporting "
                           "won't work without it. Failing"),
         NULL);
-    return 1;
+    return 0;
   }
 
   glb_lb_policy *glb_policy = (glb_lb_policy *)pol;


### PR DESCRIPTION
I noticed this while working on the service config change.

The client_channel code will sometimes invoke the on_complete callback itself when the pick returns non-zero (see the `continue_picking()` function).  This means that the pick API should never return non-zero if it calls the on_complete callback itself.  And since the only way of signalling an error is to pass it to the on_complete callback, this means that non-zero should never be returned on error.  I've attempted to clarify the comments documenting the method.