### PR TITLE
Check for the correct number of orphan callbacks in udp_server_test

### DIFF
--- a/test/core/iomgr/udp_server_test.c
+++ b/test/core/iomgr/udp_server_test.c
@@ -131,8 +131,9 @@ static void test_no_op_with_port_and_start(void) {
   grpc_udp_server_destroy(&exec_ctx, s, NULL);
   grpc_exec_ctx_finish(&exec_ctx);
 
-  /* The server had a single FD, which should have been orphaned. */
-  GPR_ASSERT(g_number_of_orphan_calls == 1);
+  /* The server had a single FD, which is orphaned once in *
+   * deactivated_all_ports, and once in grpc_udp_server_destroy. */
+  GPR_ASSERT(g_number_of_orphan_calls == 2);
 }
 
 static void test_receive(int number_of_clients) {
@@ -196,8 +197,9 @@ static void test_receive(int number_of_clients) {
   grpc_udp_server_destroy(&exec_ctx, s, NULL);
   grpc_exec_ctx_finish(&exec_ctx);
 
-  /* The server had a single FD, which should have been orphaned. */
-  GPR_ASSERT(g_number_of_orphan_calls == 1);
+  /* The server had a single FD, which is orphaned once in *
+   * deactivated_all_ports, and once in grpc_udp_server_destroy. */
+  GPR_ASSERT(g_number_of_orphan_calls == 2);
 }
 
 static void destroy_pollset(grpc_exec_ctx *exec_ctx, void *p,


### PR DESCRIPTION
Backporting test fix from internal repository.