### PR TITLE
Python minor sundry clean-up

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -211,15 +211,19 @@ SETUP_REQUIRES = INSTALL_REQUIRES + (
     'sphinx_rtd_theme>=0.1.8',
     'six>=1.10',
 )
-if BUILD_WITH_CYTHON:
-  sys.stderr.write(
-    "You requested a Cython build via GRPC_PYTHON_BUILD_WITH_CYTHON, "
-    "but do not have Cython installed. We won't stop you from using "
-    "other commands, but the extension files will fail to build.\n")
-elif need_cython:
-  sys.stderr.write(
-      'We could not find Cython. Setup may take 10-20 minutes.\n')
-  SETUP_REQUIRES += ('cython>=0.23',)
+
+try:
+  import Cython
+except ImportError:
+  if BUILD_WITH_CYTHON:
+    sys.stderr.write(
+      "You requested a Cython build via GRPC_PYTHON_BUILD_WITH_CYTHON, "
+      "but do not have Cython installed. We won't stop you from using "
+      "other commands, but the extension files will fail to build.\n")
+  elif need_cython:
+    sys.stderr.write(
+        'We could not find Cython. Setup may take 10-20 minutes.\n')
+    SETUP_REQUIRES += ('cython>=0.23',)
 
 COMMAND_CLASS = {
     'doc': commands.SphinxDocumentation,

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -196,8 +196,7 @@ bool GetModuleAndMessagePath(const Descriptor* type,
        ++path_iter) {
     message_type += (*path_iter)->name() + ".";
   }
-  // no pop_back prior to C++11
-  message_type.resize(message_type.size() - 1);
+  message_type.pop_back();
   *out = module + message_type;
   return true;
 }


### PR DESCRIPTION
The setup.py file's intended behavior was to attempt to import Cython and _then_ determine whether or not things have failed. The generator's use of `.resize` instead of `.pop_back` was for an incorrect reason (and I have to wonder what I was thinking when I wrote that given that I've been using `pop_back` since before `-std=c++0x` was a thing).
