### PR TITLE
Save time when creating matrix workspaces on win and mac

### DIFF
--- a/tools/run_tests/run_tests_in_workspace.sh
+++ b/tools/run_tests/run_tests_in_workspace.sh
@@ -35,11 +35,13 @@
 set -ex
 
 cd $(dirname $0)/../..
+export repo_root=$(pwd)
 
 rm -rf "${WORKSPACE_NAME}"
-# TODO(jtattermusch): clone --recursive fetches the submodules from github.
-# Try avoiding that to save time and network capacity.
-git clone --recursive . "${WORKSPACE_NAME}"
+git clone . "${WORKSPACE_NAME}"
+# clone gRPC submodules, use data from locally cloned submodules where possible
+git submodule foreach 'cd "${repo_root}/${WORKSPACE_NAME}" \
+    && git submodule update --init --reference ${repo_root}/${name} ${name}'
 
 echo "Running run_tests.py in workspace ${WORKSPACE_NAME}" 
 python "${WORKSPACE_NAME}/tools/run_tests/run_tests.py" $@


### PR DESCRIPTION
also use the `git submodule update --reference` trick when running tests in workspaces created by run_tests_matrix.py