### PR TITLE
Bug Fix in CSharp Interop Client

### DIFF
--- a/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
@@ -520,12 +520,12 @@ namespace Grpc.IntegrationTesting
                 };
 
                 var call = client.FullDuplexCall(headers: CreateTestMetadata());
-                var responseHeaders = await call.ResponseHeadersAsync;
 
                 await call.RequestStream.WriteAsync(request);
                 await call.RequestStream.CompleteAsync();
                 await call.ResponseStream.ToListAsync();
 
+                var responseHeaders = await call.ResponseHeadersAsync;
                 var responseTrailers = call.GetTrailers();
 
                 Assert.AreEqual("test_initial_metadata_value", responseHeaders.First((entry) => entry.Key == "x-grpc-test-echo-initial").Value);


### PR DESCRIPTION
The custom_metadata interop test was hanging when a call was made from a csharp client to a c++ server. This was because the c++ FullDuplex server method would wait for the first write from the client, while the csharp client called await on the response headers before sending the client request.

Once this PR, #7201, and #8234 are merged in, c++ will no longed have to skip any client or server methods. 