### PR TITLE
Avoid TSAN reported lock cycle

### DIFF
--- a/test/core/iomgr/tcp_server_posix_test.c
+++ b/test/core/iomgr/tcp_server_posix_test.c
@@ -118,8 +118,11 @@ static void on_connect(grpc_exec_ctx *exec_ctx, void *arg, grpc_endpoint *tcp,
   grpc_endpoint_shutdown(exec_ctx, tcp);
   grpc_endpoint_destroy(exec_ctx, tcp);
 
+  on_connect_result temp_result;
+  on_connect_result_set(&temp_result, acceptor);
+
   gpr_mu_lock(g_mu);
-  on_connect_result_set(&g_result, acceptor);
+  g_result = temp_result;
   g_nconnects++;
   GPR_ASSERT(
       GRPC_LOG_IF_ERROR("pollset_kick", grpc_pollset_kick(g_pollset, NULL)));


### PR DESCRIPTION
https://grpc-testing.appspot.com/job/gRPC_master_sanitizers_linux/lastCompletedBuild/testReport/(root)/c_linux_tsan/bins_tsan_tcp_server_posix_test_GRPC_POLL_STRATEGY_epoll/