### PR TITLE
Modified CSharp Interop Test to Conform with Spec

### DIFF
--- a/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
@@ -583,7 +583,6 @@ namespace Grpc.IntegrationTesting
             var e = Assert.Throws<RpcException>(() => client.UnimplementedCall(new Empty()));
 
             Assert.AreEqual(StatusCode.Unimplemented, e.Status.StatusCode);
-            Assert.AreEqual("", e.Status.Detail);
             Console.WriteLine("Passed!");
         }
 


### PR DESCRIPTION
Removed the check on the status detail returned when a csharp client tries to call a method that the server has not yet implemented.

The test used to verify that the returned detail was an empty string. However, some server languages (like python) return messages (like "Method not found!"), thus the test now only verifies the returned status code is UNIMPLEMENTED.

This conforms to the definition of the test found in https://github.com/grpc/grpc/blob/master/doc/interop-test-descriptions.md