### PR TITLE
Use Server mode for GC in C# QpsWorker

### DIFF
--- a/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json
@@ -67,5 +67,10 @@
         }
       }
     }
+  },
+  "runtimeOptions": {
+    "configProperties": {
+      "System.GC.Server": true
+    }
   }
 }

--- a/templates/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json.template
+++ b/templates/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json.template
@@ -20,5 +20,10 @@
           }
         }
       }
+    },
+    "runtimeOptions": {
+      "configProperties": {
+        "System.GC.Server": true
+      }
     }
   }


### PR DESCRIPTION
I've run some benchmarks locally and servermode GC seems to nearly double the throughput.

Looks like we should do some GC related optimizations in the near future.