### PR TITLE
tune gogc in go benchmarks

### DIFF
--- a/tools/run_tests/performance/run_worker_go.sh
+++ b/tools/run_tests/performance/run_worker_go.sh
@@ -34,4 +34,9 @@ cd $(dirname $0)/../../..
 
 export GOPATH=$(pwd)/../gopath
 
+// Use a larger heap to reduce frequency of GC mark phases, roughly without increasing their time.
+// See https://software.intel.com/en-us/blogs/2014/05/10/debugging-performance-issues-in-go-programs.
+// This value determined experimentally, may have a different ideal in different environments.
+export GOGC=500
+
 ${GOPATH}/bin/worker $@

--- a/tools/run_tests/performance/run_worker_go.sh
+++ b/tools/run_tests/performance/run_worker_go.sh
@@ -34,9 +34,9 @@ cd $(dirname $0)/../../..
 
 export GOPATH=$(pwd)/../gopath
 
-// Use a larger heap to reduce frequency of GC mark phases, roughly without increasing their time.
-// See https://software.intel.com/en-us/blogs/2014/05/10/debugging-performance-issues-in-go-programs.
-// This value determined experimentally, may have a different ideal in different environments.
+# Use a larger heap to reduce frequency of GC mark phases, roughly without increasing their time.
+# See https://software.intel.com/en-us/blogs/2014/05/10/debugging-performance-issues-in-go-programs.
+# This value determined experimentally, may have a different ideal in different environments.
 export GOGC=500
 
 ${GOPATH}/bin/worker $@


### PR DESCRIPTION
This is another change to the benchmarks themselves. Tried increasing GOGC to 500 and saw maybe a around 20-30% throughput increase on 3 experimental machines. 

This is more of an FYI, as I'm not sure we want to change this setting. I'd prefer to set this in the actual benchmark worker, but for some reason this env variable it doesn't seem to have an effect when done there (maybe it's checked on program startup?), so this sets it in the script that start up the perf worker.

Watching how it does in actual perf workers in https://grpc-testing.appspot.com/job/gRPC_performance_adhoc/build?delay=0sec

cc @iamqizhao @ctiller 
