### PR TITLE
Introduce framework independent replacement for CompletedTask

### DIFF
--- a/src/csharp/Grpc.Auth/GoogleAuthInterceptors.cs
+++ b/src/csharp/Grpc.Auth/GoogleAuthInterceptors.cs
@@ -76,7 +76,7 @@ namespace Grpc.Auth
             return new AsyncAuthInterceptor((context, metadata) =>
             {
                 metadata.Add(CreateBearerTokenHeader(accessToken));
-                return Task.FromResult<object>(null);
+                return TaskUtils.CompletedTask;
             });
         }
 

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Logging\LogLevel.cs" />
     <Compile Include="Logging\LogLevelFilterLogger.cs" />
     <Compile Include="Internal\RequestCallContextSafeHandle.cs" />
+    <Compile Include="Utils\TaskUtils.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Grpc.Core.nuspec" />

--- a/src/csharp/Grpc.Core/Internal/AsyncCall.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCall.cs
@@ -265,7 +265,7 @@ namespace Grpc.Core.Internal
                     // the halfclose has already been done implicitly, so just return
                     // completed task here.
                     halfcloseRequested = true;
-                    return Task.FromResult<object>(null);
+                    return TaskUtils.CompletedTask;
                 }
                 call.StartSendCloseFromClient(HandleSendFinished);
 

--- a/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
@@ -296,7 +296,7 @@ namespace Grpc.Core.Internal
         private Task UnimplementedMethod(IAsyncStreamReader<byte[]> requestStream, IServerStreamWriter<byte[]> responseStream, ServerCallContext ctx)
         {
             ctx.Status = new Status(StatusCode.Unimplemented, "");
-            return Task.FromResult<object>(null);
+            return TaskUtils.CompletedTask;
         }
 
         public Task HandleCall(ServerRpcNew newRpc, CompletionQueueSafeHandle cq)

--- a/src/csharp/Grpc.Core/Utils/TaskUtils.cs
+++ b/src/csharp/Grpc.Core/Utils/TaskUtils.cs
@@ -1,0 +1,59 @@
+#region Copyright notice and license
+
+// Copyright 2015, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+
+namespace Grpc.Core.Utils
+{
+    /// <summary>
+    /// Utility methods for task parallel library.
+    /// </summary>
+    public static class TaskUtils
+    {
+        /// <summary>
+        /// Framework independent equivalent of <c>Task.CompletedTask</c>.
+        /// </summary>
+        public static Task CompletedTask
+        {
+            get
+            {
+#if NETSTANDARD1_5
+                return Task.CompletedTask;
+#else
+                return Task.FromResult<object>(null);  // for .NET45, emulate the functionality
+#endif
+            }
+        }
+    }
+}

--- a/src/csharp/Grpc.IntegrationTesting/InterarrivalTimers.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InterarrivalTimers.cs
@@ -69,7 +69,7 @@ namespace Grpc.IntegrationTesting
 
         public Task WaitForNextAsync()
         {
-            return Task.FromResult<object>(null);
+            return TaskUtils.CompletedTask;
         }
     }
 


### PR DESCRIPTION
Based on #8438 (only the last commit is new).

Task.CompletedTask is only available starting from .NET4.6.  Introduce a wrapper that uses CompletedTask on netstandard15 and fall back to a less efficient replacement on .NET45