### PR TITLE
Implement Node Unimplemented Method Interop Test

### DIFF
--- a/src/node/interop/interop_client.js
+++ b/src/node/interop/interop_client.js
@@ -375,11 +375,21 @@ function statusCodeAndMessage(client, done) {
   duplex.end();
 }
 
-function unimplementedMethod(client, done) {
+// NOTE: the client param to this function is from UnimplementedService
+function unimplementedService(client, done) {
   client.unimplementedCall({}, function(err, resp) {
     assert(err);
     assert.strictEqual(err.code, grpc.status.UNIMPLEMENTED);
     assert(!err.message);
+    done();
+  });
+}
+
+// NOTE: the client param to this function is from TestService
+function unimplementedMethod(client, done) {
+  client.unimplementedCall({}, function(err, resp) {
+    assert(err);
+    assert.strictEqual(err.code, grpc.status.UNIMPLEMENTED);
     done();
   });
 }
@@ -527,8 +537,10 @@ var test_cases = {
                     Client: testProto.TestService},
   status_code_and_message: {run: statusCodeAndMessage,
                             Client: testProto.TestService},
-  unimplemented_method: {run: unimplementedMethod,
+  unimplemented_service: {run: unimplementedService,
                          Client: testProto.UnimplementedService},
+  unimplemented_method: {run: unimplementedMethod,
+                         Client: testProto.TestService},
   compute_engine_creds: {run: computeEngineCreds,
                          Client: testProto.TestService,
                          getCreds: getApplicationCreds},

--- a/src/node/test/interop_sanity_test.js
+++ b/src/node/test/interop_sanity_test.js
@@ -98,6 +98,10 @@ describe('Interop tests', function() {
     interop_client.runTest(port, name_override, 'status_code_and_message',
                            true, true, done);
   });
+  it('should pass unimplemented_service', function(done) {
+    interop_client.runTest(port, name_override, 'unimplemented_service',
+                           true, true, done);
+  });
   it('should pass unimplemented_method', function(done) {
     interop_client.runTest(port, name_override, 'unimplemented_method',
                            true, true, done);


### PR DESCRIPTION
Rename unimplemented_method -> unimplemented_service.

Add code for the real unimplemented_method, which calls TestService/UnimplementedCall instead of UnimplementedService/UnimplementedCall.

Rationale: there is a slight difference between calling an unimplemented method on an unimplemented service, and calling an unimplemented method on a service that has implemented other methods.

Keeping the testing functions separate for now, because I plan on adding checks on the error details.

I ran the full interop test suite locally and everything passes.