### PR TITLE
Run C# QpsWorker on all cores

### DIFF
--- a/src/csharp/Grpc.IntegrationTesting/QpsWorker.cs
+++ b/src/csharp/Grpc.IntegrationTesting/QpsWorker.cs
@@ -76,6 +76,11 @@ namespace Grpc.IntegrationTesting
 
         private async Task RunAsync()
         {
+            // (ThreadPoolSize == ProcessorCount) gives best throughput in benchmarks
+            // and doesn't seem to harm performance even when server and client
+            // are running on the same machine.
+            GrpcEnvironment.SetThreadPoolSize(Environment.ProcessorCount);
+
             string host = "0.0.0.0";
             int port = options.DriverPort;
 


### PR DESCRIPTION
Based on #8396  (only last commit added).

By default, set gRPC thread pool size to only processorCount / 2. For benchmarks, it's useful to override this to squeeze out some extra performance.

