### PR TITLE
Fix incorrect header in thd.c

### DIFF
--- a/src/core/lib/support/thd.c
+++ b/src/core/lib/support/thd.c
@@ -33,7 +33,7 @@
 
 /* Posix implementation for gpr threads. */
 
-#include <memory.h>
+#include <string.h>
 
 #include <grpc/support/thd.h>
 


### PR DESCRIPTION
string.h has memset.
Found while building Chromium Android 64-bit with native C/C++ gRPC.