### PR TITLE
Expose incoming compression algorithm in ClientContext

### DIFF
--- a/include/grpc++/impl/codegen/client_context.h
+++ b/include/grpc++/impl/codegen/client_context.h
@@ -208,6 +208,9 @@ class ClientContext {
     return trailing_metadata_;
   }
 
+  /// Return the incoming compression algorithm
+  grpc_compression_algorithm GetIncomingCompressionAlgorithm();
+
   /// Set the deadline for the client call.
   ///
   /// \warning This method should only be called before invoking the rpc.

--- a/src/core/lib/surface/call.c
+++ b/src/core/lib/surface/call.c
@@ -465,7 +465,7 @@ static void set_incoming_compression_algorithm(
   call->incoming_compression_algorithm = algo;
 }
 
-grpc_compression_algorithm grpc_call_test_only_get_compression_algorithm(
+grpc_compression_algorithm grpc_call_get_compression_algorithm(
     grpc_call *call) {
   grpc_compression_algorithm algorithm;
   gpr_mu_lock(&call->mu);

--- a/src/core/lib/surface/call.h
+++ b/src/core/lib/surface/call.h
@@ -119,6 +119,9 @@ void *grpc_call_context_get(grpc_call *call, grpc_context_index elem);
 
 uint8_t grpc_call_is_client(grpc_call *call);
 
+/* Return the compression algorithm from \a call. */
+grpc_compression_algorithm grpc_call_get_compression_algorithm(grpc_call *call);
+
 /* Return an appropriate compression algorithm for the requested compression \a
  * level in the context of \a call. */
 grpc_compression_algorithm grpc_call_compression_for_level(

--- a/src/core/lib/surface/call_test_only.h
+++ b/src/core/lib/surface/call_test_only.h
@@ -40,12 +40,6 @@
 extern "C" {
 #endif
 
-/** Return the compression algorithm from \a call.
- *
- * \warning This function should \b only be used in test code. */
-grpc_compression_algorithm grpc_call_test_only_get_compression_algorithm(
-    grpc_call *call);
-
 /** Return the message flags from \a call.
  *
  * \warning This function should \b only be used in test code. */

--- a/src/cpp/client/client_context.cc
+++ b/src/cpp/client/client_context.cc
@@ -43,6 +43,8 @@
 #include <grpc++/server_context.h>
 #include <grpc++/support/time.h>
 
+#include "src/core/lib/surface/call.h"
+
 namespace grpc {
 
 class DefaultGlobalClientCallbacks final
@@ -104,6 +106,10 @@ void ClientContext::set_call(grpc_call* call,
   if (call_canceled_) {
     grpc_call_cancel(call_, nullptr);
   }
+}
+
+grpc_compression_algorithm ClientContext::GetIncomingCompressionAlgorithm() {
+  return grpc_call_get_compression_algorithm(call_);
 }
 
 void ClientContext::set_compression_algorithm(

--- a/test/cpp/interop/client_helper.h
+++ b/test/cpp/interop/client_helper.h
@@ -38,6 +38,7 @@
 
 #include <grpc++/channel.h>
 
+#include "src/core/lib/surface/call.h"
 #include "src/core/lib/surface/call_test_only.h"
 
 namespace grpc {
@@ -57,7 +58,7 @@ class InteropClientContextInspector {
 
   // Inspector methods, able to peek inside ClientContext, follow.
   grpc_compression_algorithm GetCallCompressionAlgorithm() const {
-    return grpc_call_test_only_get_compression_algorithm(context_.call_);
+    return grpc_call_get_compression_algorithm(context_.call_);
   }
 
   uint32_t GetMessageFlags() const {

--- a/test/cpp/interop/server_helper.cc
+++ b/test/cpp/interop/server_helper.cc
@@ -38,6 +38,7 @@
 #include <gflags/gflags.h>
 #include <grpc++/security/server_credentials.h>
 
+#include "src/core/lib/surface/call.h"
 #include "src/core/lib/surface/call_test_only.h"
 #include "test/core/end2end/data/ssl_test_data.h"
 
@@ -65,7 +66,7 @@ InteropServerContextInspector::InteropServerContextInspector(
 
 grpc_compression_algorithm
 InteropServerContextInspector::GetCallCompressionAlgorithm() const {
-  return grpc_call_test_only_get_compression_algorithm(context_.call_);
+  return grpc_call_get_compression_algorithm(context_.call_);
 }
 
 uint32_t InteropServerContextInspector::GetEncodingsAcceptedByClient() const {


### PR DESCRIPTION
I'm working on a GRPC proxy and we would like to know the compression algorithm that GRPC server will use before receiving first message. The grpc-encoding was filtered from initial metadata. So exposing compression algorithm in ClientContext.
