### PR TITLE
C#: SafeHandleZeroIsInvalid cleanup

### DIFF
--- a/src/csharp/Grpc.Core/Internal/SafeHandleZeroIsInvalid.cs
+++ b/src/csharp/Grpc.Core/Internal/SafeHandleZeroIsInvalid.cs
@@ -45,22 +45,12 @@ namespace Grpc.Core.Internal
         {
         }
 
-        public SafeHandleZeroIsInvalid(bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
-        {
-        }
-
         public override bool IsInvalid
         {
             get
             {
                 return handle == IntPtr.Zero;
             }
-        }
-
-        protected override bool ReleaseHandle()
-        {
-            // handle is not owned.
-            return true;
         }
     }
 }


### PR DESCRIPTION
Remove unused constructor and a useless override.