### PR TITLE
convert uint to int in generator

### DIFF
--- a/src/compiler/ruby_generator.cc
+++ b/src/compiler/ruby_generator.cc
@@ -133,7 +133,7 @@ grpc::string PackageToModule(const grpc::string& name) {
   grpc::string result;
   result.reserve(name.size());
 
-  for (uint i = 0; i < name.size(); i++) {
+  for (int i = 0; i < name.size(); i++) {
     if (name[i] == '_') {
       next_upper = true;
     } else {


### PR DESCRIPTION
fixes windows build of ruby protoc generator. tested build on local windows machine