### PR TITLE
increase max thread pool size in benchmarks and fix shutdown ordering

### DIFF
--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -125,10 +125,10 @@ module GRPC
         return if @running_state != :running
         transition_running_state(:stopping)
       end
-      @pool.shutdown
-      @pool.wait_for_termination(@poll_period)
       deadline = from_relative_time(@poll_period)
       @server.close(deadline)
+      @pool.shutdown
+      @pool.wait_for_termination(@poll_period)
     end
 
     def running_state

--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -54,6 +54,7 @@ module GRPC
     DEFAULT_MAX_WAITING_REQUESTS = 60
 
     # Default poll period is 1s
+    # Used for grpc server shutdown and thread pool shutdown timeouts
     DEFAULT_POLL_PERIOD = 1
 
     # Signal check period is 0.25s
@@ -124,10 +125,10 @@ module GRPC
         return if @running_state != :running
         transition_running_state(:stopping)
       end
+      @pool.shutdown
+      @pool.wait_for_termination(@poll_period)
       deadline = from_relative_time(@poll_period)
       @server.close(deadline)
-      @pool.shutdown
-      @pool.wait_for_termination
     end
 
     def running_state

--- a/src/ruby/qps/server.rb
+++ b/src/ruby/qps/server.rb
@@ -63,7 +63,9 @@ class BenchmarkServer
       cred = :this_port_is_insecure
     end
     # Make sure server can handle the large number of calls in benchmarks
-    @server = GRPC::RpcServer.new(pool_size: 100, max_waiting_requests: 100)
+    # TODO: @apolcyn, if scenario config increases total outstanding
+    # calls then will need to increase the pool size too
+    @server = GRPC::RpcServer.new(pool_size: 1024, max_waiting_requests: 1024)
     @port = @server.add_http2_port("0.0.0.0:" + port.to_s, cred)
     @server.handle(BenchmarkServiceImpl.new)
     @start_time = Time.now


### PR DESCRIPTION
Should fix the ruby benchmark crashes on master. Works on https://github.com/grpc/grpc/pull/8511 (which stops hitting the issue seen in https://github.com/grpc/grpc/issues/8404 because it runs unary calls on one core batch). Increases the thread pool size to handle the larger 64 channel, 16 outstanding call scenario, and reorders the shutdown sequence since it was causing errors in these benchmarks.