### PR TITLE
Disable Nagle's algorithm in libuv endpoints

### DIFF
--- a/src/core/lib/iomgr/tcp_uv.c
+++ b/src/core/lib/iomgr/tcp_uv.c
@@ -315,6 +315,8 @@ grpc_endpoint *grpc_tcp_create(uv_tcp_t *handle, char *peer_string) {
     gpr_log(GPR_DEBUG, "Creating TCP endpoint %p", tcp);
   }
 
+  uv_tcp_nodelay(handle, 1);
+
   memset(tcp, 0, sizeof(grpc_tcp));
   tcp->base.vtable = &vtable;
   tcp->handle = handle;

--- a/src/core/lib/iomgr/tcp_uv.c
+++ b/src/core/lib/iomgr/tcp_uv.c
@@ -315,6 +315,7 @@ grpc_endpoint *grpc_tcp_create(uv_tcp_t *handle, char *peer_string) {
     gpr_log(GPR_DEBUG, "Creating TCP endpoint %p", tcp);
   }
 
+  /* Disable Nagle's Algorithm */
   uv_tcp_nodelay(handle, 1);
 
   memset(tcp, 0, sizeof(grpc_tcp));


### PR DESCRIPTION
This fixes the weird latency spike we saw after the libuv endpoint change was submitted.