### PR TITLE
resource_quota.c: Fix compiler errors in gcc4.4 and 4.6

### DIFF
--- a/src/core/lib/iomgr/resource_quota.c
+++ b/src/core/lib/iomgr/resource_quota.c
@@ -166,8 +166,11 @@ static void rq_step(grpc_exec_ctx *exec_ctx, void *rq, grpc_error *error) {
   do {
     if (rq_alloc(exec_ctx, resource_quota)) goto done;
   } while (rq_reclaim_from_per_user_free_pool(exec_ctx, resource_quota));
-  rq_reclaim(exec_ctx, resource_quota, false) ||
-      rq_reclaim(exec_ctx, resource_quota, true);
+
+  if (!rq_reclaim(exec_ctx, resource_quota, false)) {
+    rq_reclaim(exec_ctx, resource_quota, true);
+  }
+
 done:
   grpc_resource_quota_internal_unref(exec_ctx, resource_quota);
 }


### PR DESCRIPTION
Getting "Value computed is not used" error. Portability tests are failing on gcc4.4 and 4.6.  Example: 
https://grpc-testing.appspot.com/job/gRPC_portability_pull_requests_linux/707/testReport/junit/(root)/aggregate_tests/run_tests_c_linux_dbg_x64_gcc4_6/