### PR TITLE
Disable gcc4.4 C++ tests - DO NOT MERGE INTO V1.0.X

### DIFF
--- a/templates/tools/dockerfile/test/cxx_ubuntu1604_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_ubuntu1604_x64/Dockerfile.template
@@ -39,7 +39,7 @@
   # The clang-3.6 symlink for the default clang version was added
   # to Ubuntu 16.04 recently, so make sure it's installed.
   # Also install clang3.7.
-  RUN apt-get update && apt-get -y install clang-3.6 clang-3.7 && apt-get clean
+  RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib clang-3.6 clang-3.7 && apt-get clean
   
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/test/cxx_ubuntu1604_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_ubuntu1604_x64/Dockerfile
@@ -97,7 +97,7 @@ RUN mkdir /var/local/jenkins
 # The clang-3.6 symlink for the default clang version was added
 # to Ubuntu 16.04 recently, so make sure it's installed.
 # Also install clang3.7.
-RUN apt-get update && apt-get -y install clang-3.6 clang-3.7 && apt-get clean
+RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib clang-3.6 clang-3.7 && apt-get clean
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -332,6 +332,8 @@ class CLanguage(object):
       return ('wheezy', self._gcc_make_options(version_suffix='-4.4'))
     elif compiler == 'gcc4.6':
       return ('wheezy', self._gcc_make_options(version_suffix='-4.6'))
+    elif compiler == 'gcc4.8':
+      return ('ubuntu1604', self._gcc_make_options(version_suffix='-4.8'))
     elif compiler == 'gcc5.3':
       return ('ubuntu1604', [])
     elif compiler == 'clang3.4':
@@ -1061,7 +1063,7 @@ argp.add_argument('--arch',
                   help='Selects architecture to target. For some platforms "default" is the only supported choice.')
 argp.add_argument('--compiler',
                   choices=['default',
-                           'gcc4.4', 'gcc4.6', 'gcc4.9', 'gcc5.3',
+                           'gcc4.4', 'gcc4.6', 'gcc4.8', 'gcc4.9', 'gcc5.3',
                            'clang3.4', 'clang3.5', 'clang3.6', 'clang3.7',
                            'vs2010', 'vs2013', 'vs2015',
                            'python2.7', 'python3.4', 'python3.5', 'python3.6', 'pypy', 'pypy3',

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -181,7 +181,17 @@ def _create_portability_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS)
   # portability C and C++ on x64
   for compiler in ['gcc4.4', 'gcc4.6', 'gcc5.3',
                    'clang3.5', 'clang3.6', 'clang3.7']:
-    test_jobs += _generate_jobs(languages=['c', 'c++'],
+    test_jobs += _generate_jobs(languages=['c'],
+                                configs=['dbg'],
+                                platforms=['linux'],
+                                arch='x64',
+                                compiler=compiler,
+                                labels=['portability'],
+                                extra_args=extra_args,
+                                inner_jobs=inner_jobs)
+  for compiler in ['gcc4.8', 'gcc5.3',
+                   'clang3.5', 'clang3.6', 'clang3.7']:
+    test_jobs += _generate_jobs(languages=['c++'],
                                 configs=['dbg'],
                                 platforms=['linux'],
                                 arch='x64',

--- a/tools/run_tests/tests.json
+++ b/tools/run_tests/tests.json
@@ -3003,6 +3003,7 @@
     ], 
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
+    "exclude_iomgrs": [], 
     "flaky": false, 
     "gtest": false, 
     "language": "c++", 


### PR DESCRIPTION
Since we will be dropping support for non-C++11 compilers, unsupported compiler tests should be disabled. 
