### PR TITLE
Build csharp packages with strong name signing

### DIFF
--- a/src/csharp/Grpc.Auth/project.json
+++ b/src/csharp/Grpc.Auth/project.json
@@ -15,7 +15,6 @@
   "buildOptions": {
     "define": [ "SIGNED" ],
     "keyFile": "../keys/Grpc.snk",
-    "publicSign": true,
     "xmlDoc": true,
     "compile": {
       "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/src/csharp/Grpc.Core.Tests/project.json
+++ b/src/csharp/Grpc.Core.Tests/project.json
@@ -7,7 +7,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]
@@ -26,7 +25,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/src/csharp/Grpc.Core/project.json
+++ b/src/csharp/Grpc.Core/project.json
@@ -27,7 +27,6 @@
     "embed": [ "../../../etc/roots.pem" ],
     "define": [ "SIGNED" ],
     "keyFile": "../keys/Grpc.snk",
-    "publicSign": true,
     "xmlDoc": true
   },
   "dependencies": {

--- a/src/csharp/Grpc.Examples.MathClient/project.json
+++ b/src/csharp/Grpc.Examples.MathClient/project.json
@@ -7,7 +7,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]
@@ -26,7 +25,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/src/csharp/Grpc.Examples.MathServer/project.json
+++ b/src/csharp/Grpc.Examples.MathServer/project.json
@@ -7,7 +7,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]
@@ -26,7 +25,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/src/csharp/Grpc.Examples.Tests/project.json
+++ b/src/csharp/Grpc.Examples.Tests/project.json
@@ -7,7 +7,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]
@@ -26,7 +25,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/src/csharp/Grpc.HealthCheck.Tests/project.json
+++ b/src/csharp/Grpc.HealthCheck.Tests/project.json
@@ -7,7 +7,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]
@@ -26,7 +25,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/src/csharp/Grpc.HealthCheck/project.json
+++ b/src/csharp/Grpc.HealthCheck/project.json
@@ -15,7 +15,6 @@
   "buildOptions": {
     "define": [ "SIGNED" ],
     "keyFile": "../keys/Grpc.snk",
-    "publicSign": true,
     "xmlDoc": true,
     "compile": {
       "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/src/csharp/Grpc.IntegrationTesting.Client/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.Client/project.json
@@ -7,7 +7,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]
@@ -29,7 +28,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.QpsWorker/project.json
@@ -7,7 +7,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]
@@ -29,7 +28,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/src/csharp/Grpc.IntegrationTesting.Server/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.Server/project.json
@@ -7,7 +7,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]
@@ -29,7 +28,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/src/csharp/Grpc.IntegrationTesting.StressClient/project.json
+++ b/src/csharp/Grpc.IntegrationTesting.StressClient/project.json
@@ -7,7 +7,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]
@@ -29,7 +28,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/src/csharp/Grpc.IntegrationTesting/project.json
+++ b/src/csharp/Grpc.IntegrationTesting/project.json
@@ -7,7 +7,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]
@@ -29,7 +28,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/src/csharp/build_packages_dotnetcli.bat
+++ b/src/csharp/build_packages_dotnetcli.bat
@@ -1,0 +1,79 @@
+@rem Copyright 2016, Google Inc.
+@rem All rights reserved.
+@rem
+@rem Redistribution and use in source and binary forms, with or without
+@rem modification, are permitted provided that the following conditions are
+@rem met:
+@rem
+@rem     * Redistributions of source code must retain the above copyright
+@rem notice, this list of conditions and the following disclaimer.
+@rem     * Redistributions in binary form must reproduce the above
+@rem copyright notice, this list of conditions and the following disclaimer
+@rem in the documentation and/or other materials provided with the
+@rem distribution.
+@rem     * Neither the name of Google Inc. nor the names of its
+@rem contributors may be used to endorse or promote products derived from
+@rem this software without specific prior written permission.
+@rem
+@rem THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+@rem "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+@rem LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+@rem A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+@rem OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+@rem SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+@rem LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+@rem DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+@rem THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+@rem (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+@rem OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+@rem Current package versions
+set VERSION=1.0.1
+set PROTOBUF_VERSION=3.0.0
+
+@rem Adjust the location of nuget.exe
+set NUGET=C:\nuget\nuget.exe
+set DOTNET=C:\dotnet\dotnet.exe
+
+set -ex
+
+mkdir -p ..\..\artifacts\
+
+@rem Collect the artifacts built by the previous build step if running on Jenkins
+@rem TODO(jtattermusch): is there a better way to do this?
+xcopy /Y /I ..\..\architecture=x86,language=csharp,platform=windows\artifacts\* nativelibs\windows_x86\
+xcopy /Y /I ..\..\architecture=x64,language=csharp,platform=windows\artifacts\* nativelibs\windows_x64\
+xcopy /Y /I ..\..\architecture=x86,language=csharp,platform=linux\artifacts\* nativelibs\linux_x86\
+xcopy /Y /I ..\..\architecture=x64,language=csharp,platform=linux\artifacts\* nativelibs\linux_x64\
+xcopy /Y /I ..\..\architecture=x86,language=csharp,platform=macos\artifacts\* nativelibs\macosx_x86\
+xcopy /Y /I ..\..\architecture=x64,language=csharp,platform=macos\artifacts\* nativelibs\macosx_x64\
+
+@rem Collect protoc artifacts built by the previous build step
+xcopy /Y /I ..\..\architecture=x86,language=protoc,platform=windows\artifacts\* protoc_plugins\windows_x86\
+xcopy /Y /I ..\..\architecture=x64,language=protoc,platform=windows\artifacts\* protoc_plugins\windows_x64\
+xcopy /Y /I ..\..\architecture=x86,language=protoc,platform=linux\artifacts\* protoc_plugins\linux_x86\
+xcopy /Y /I ..\..\architecture=x64,language=protoc,platform=linux\artifacts\* protoc_plugins\linux_x64\
+xcopy /Y /I ..\..\architecture=x86,language=protoc,platform=macos\artifacts\* protoc_plugins\macosx_x86\
+xcopy /Y /I ..\..\architecture=x64,language=protoc,platform=macos\artifacts\* protoc_plugins\macosx_x64\
+
+%DOTNET% restore . || goto :error
+
+%DOTNET% pack --configuration Release Grpc.Core\project.json --output ..\..\artifacts || goto :error
+%DOTNET% pack --configuration Release Grpc.Auth\project.json --output ..\..\artifacts || goto :error
+%DOTNET% pack --configuration Release Grpc.HealthCheck\project.json --output ..\..\artifacts || goto :error
+
+%NUGET% pack Grpc.nuspec -Version "1.0.1" -OutputDirectory ..\..\artifacts || goto :error
+%NUGET% pack Grpc.Tools.nuspec -Version "1.0.1" -OutputDirectory ..\..\artifacts 
+
+@rem copy resulting nuget packages to artifacts directory
+xcopy /Y /I *.nupkg ..\..\artifacts\ || goto :error
+
+@rem create a zipfile with the artifacts as well
+powershell -Command "Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::CreateFromDirectory('..\..\artifacts', 'csharp_nugets_windows_dotnetcli.zip');"
+xcopy /Y /I csharp_nugets_windows_dotnetcli.zip ..\..\artifacts\ || goto :error
+
+goto :EOF
+
+:error
+echo Failed!
+exit /b %errorlevel%

--- a/templates/src/csharp/Grpc.Auth/project.json.template
+++ b/templates/src/csharp/Grpc.Auth/project.json.template
@@ -17,7 +17,6 @@
     "buildOptions": {
       "define": [ "SIGNED" ],
       "keyFile": "../keys/Grpc.snk",
-      "publicSign": true,
       "xmlDoc": true,
       "compile": {
         "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/templates/src/csharp/Grpc.Core/project.json.template
+++ b/templates/src/csharp/Grpc.Core/project.json.template
@@ -29,7 +29,6 @@
       "embed": [ "../../../etc/roots.pem" ],
       "define": [ "SIGNED" ],
       "keyFile": "../keys/Grpc.snk",
-      "publicSign": true,
       "xmlDoc": true
     },
     "dependencies": {

--- a/templates/src/csharp/Grpc.HealthCheck/project.json.template
+++ b/templates/src/csharp/Grpc.HealthCheck/project.json.template
@@ -17,7 +17,6 @@
     "buildOptions": {
       "define": [ "SIGNED" ],
       "keyFile": "../keys/Grpc.snk",
-      "publicSign": true,
       "xmlDoc": true,
       "compile": {
         "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/templates/src/csharp/build_options.include
+++ b/templates/src/csharp/build_options.include
@@ -10,7 +10,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]
@@ -34,7 +33,6 @@
       "buildOptions": {
         "define": [ "SIGNED" ],
         "keyFile": "../keys/Grpc.snk",
-        "publicSign": true,
         "xmlDoc": true,
         "compile": {
           "includeFiles": [ "../Grpc.Core/Version.cs" ]

--- a/tools/run_tests/package_targets.py
+++ b/tools/run_tests/package_targets.py
@@ -81,14 +81,7 @@ class CSharpPackage:
       self.labels += ['windows']
 
   def pre_build_jobspecs(self):
-    if 'windows' in self.labels:
-      return [create_jobspec('prebuild_%s' % self.name,
-                             ['tools\\run_tests\\pre_build_csharp.bat'],
-                             shell=True,
-                             flake_retries=5,
-                             timeout_retries=2)]
-    else:
-      return []
+    return [] # now using dotnet cli to build all packages
 
   def build_jobspec(self):
     if self.use_dotnet_cli:
@@ -98,7 +91,7 @@ class CSharpPackage:
           'src/csharp/build_packages_dotnetcli.sh')
     else:
       return create_jobspec(self.name,
-                            ['build_packages.bat'],
+                            ['build_packages_dotnetcli.bat'],
                             cwd='src\\csharp',
                             shell=True)
 

--- a/tools/run_tests/package_targets.py
+++ b/tools/run_tests/package_targets.py
@@ -71,27 +71,50 @@ def create_jobspec(name, cmdline, environ=None, cwd=None, shell=False,
 class CSharpPackage:
   """Builds C# nuget packages."""
 
-  def __init__(self, use_dotnet_cli=False):
+  def __init__(self, linux=False, use_dotnet_cli=True):
+    self.linux = linux
     self.use_dotnet_cli = use_dotnet_cli
-    self.name = 'csharp_package_dotnetcli' if use_dotnet_cli else 'csharp_package'
+
     self.labels = ['package', 'csharp']
+
     if use_dotnet_cli:
-      self.labels += ['linux']
+      if linux:
+        self.name = 'csharp_package_dotnetcli_linux'
+	self.labels += ['linux']
+      else:
+        self.name = 'csharp_package_dotnetcli_windows'
+        self.labels += ['windows']
     else:
-      self.labels += ['windows']
+      # official packages built with dotnet cli rather than nuget pack
+      self.name = 'csharp_package_obsolete'
+      self.labels += ['obsolete']
+
 
   def pre_build_jobspecs(self):
-    return [] # now using dotnet cli to build all packages
+    # The older, obsolete build uses nuget only instead of dotnet cli
+    if 'obsolete' in self.labels:
+      return [create_jobspec('prebuild_%s' % self.name,
+                             ['tools\\run_tests\\pre_build_csharp.bat'],
+                             shell=True,
+                             flake_retries=5,
+                             timeout_retries=2)]
+    else:
+      return []
 
   def build_jobspec(self):
-    if self.use_dotnet_cli:
+    if self.use_dotnet_cli and self.linux:
       return create_docker_jobspec(
           self.name,
           'tools/dockerfile/test/csharp_coreclr_x64',
           'src/csharp/build_packages_dotnetcli.sh')
-    else:
+    elif self.use_dotnet_cli:
       return create_jobspec(self.name,
                             ['build_packages_dotnetcli.bat'],
+                            cwd='src\\csharp',
+                            shell=True)
+    else:
+      return create_jobspec(self.name,
+                            ['build_packages.bat'],
                             cwd='src\\csharp',
                             shell=True)
 
@@ -170,7 +193,8 @@ class PHPPackage:
 def targets():
   """Gets list of supported targets"""
   return [CSharpPackage(),
-          CSharpPackage(use_dotnet_cli=True),
+          CSharpPackage(linux=True),
+          CSharpPackage(use_dotnet_cli=False),
           NodePackage(),
           RubyPackage(),
           PythonPackage(),


### PR DESCRIPTION
fixes https://github.com/grpc/grpc/issues/8557

It seems that strong-name signing does work with the dotnet cli on linux or mac (AFAIK it doesn't work on mono or coreclr).

This changes the "official" package build to use dotnet cli on windows rather than linux, in order for strong name signing to work, also changes the project.json files to turn it on.

This also keeps the old package targets that use only "nuget pack", but puts them under the label "obsolete". build_packages job would only build linux dotnetcli and windows dotnetcli as is now.

I'm seeing this is preferred before the next release.

cc @jtattermusch @jskeet 