### PR TITLE
Use Jessie instead of Ubuntu Dockerfile for GCC-4.8 tests

### DIFF
--- a/templates/tools/dockerfile/test/cxx_jessie_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_jessie_x64/Dockerfile.template
@@ -37,5 +37,9 @@
   <%include file="../../clang_update.include"/>
   <%include file="../../run_tests_addons.include"/>
   <%include file="../../libuv_install.include"/>
+
+  # Install gcc-4.8 and other relevant items
+  RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib && apt-get clean
+
   # Define the default command.
   CMD ["bash"]

--- a/templates/tools/dockerfile/test/cxx_jessie_x86/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_jessie_x86/Dockerfile.template
@@ -35,5 +35,9 @@
   <%include file="../../python_deps.include"/>
   <%include file="../../cxx_deps.include"/>
   <%include file="../../run_tests_addons.include"/>
+
+  # Install gcc-4.8 and other relevant items
+  RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib && apt-get clean
+
   # Define the default command.
   CMD ["bash"]

--- a/templates/tools/dockerfile/test/cxx_ubuntu1604_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_ubuntu1604_x64/Dockerfile.template
@@ -39,7 +39,7 @@
   # The clang-3.6 symlink for the default clang version was added
   # to Ubuntu 16.04 recently, so make sure it's installed.
   # Also install clang3.7.
-  RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib clang-3.6 clang-3.7 && apt-get clean
+  RUN apt-get update && apt-get -y install clang-3.6 clang-3.7 && apt-get clean
   
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/test/cxx_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_jessie_x64/Dockerfile
@@ -129,5 +129,9 @@ RUN mkdir /var/local/jenkins
 #================
 # libuv
 RUN cd /tmp     && wget http://dist.libuv.org/dist/v1.9.1/libuv-v1.9.1.tar.gz     && tar -xf libuv-v1.9.1.tar.gz     && cd libuv-v1.9.1     && sh autogen.sh && ./configure --prefix=/usr && make && make install
+
+# Install gcc-4.8 and other relevant items
+RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib && apt-get clean
+
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/test/cxx_jessie_x86/Dockerfile
+++ b/tools/dockerfile/test/cxx_jessie_x86/Dockerfile
@@ -93,5 +93,9 @@ RUN ln -s /usr/bin/ccache /usr/local/bin/clang++
 
 RUN mkdir /var/local/jenkins
 
+
+# Install gcc-4.8 and other relevant items
+RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib && apt-get clean
+
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/test/cxx_ubuntu1604_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_ubuntu1604_x64/Dockerfile
@@ -97,7 +97,7 @@ RUN mkdir /var/local/jenkins
 # The clang-3.6 symlink for the default clang version was added
 # to Ubuntu 16.04 recently, so make sure it's installed.
 # Also install clang3.7.
-RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib clang-3.6 clang-3.7 && apt-get clean
+RUN apt-get update && apt-get -y install clang-3.6 clang-3.7 && apt-get clean
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -333,7 +333,7 @@ class CLanguage(object):
     elif compiler == 'gcc4.6':
       return ('wheezy', self._gcc_make_options(version_suffix='-4.6'))
     elif compiler == 'gcc4.8':
-      return ('ubuntu1604', self._gcc_make_options(version_suffix='-4.8'))
+      return ('jessie', self._gcc_make_options(version_suffix='-4.8'))
     elif compiler == 'gcc5.3':
       return ('ubuntu1604', [])
     elif compiler == 'clang3.4':


### PR DESCRIPTION
I noticed using Ubuntu for GCC-4.8 testing caused a lot of test failures in portability, so I'm testing if Jessie is the better Docker image to use.