### PR TITLE
Improve C++11 conformance

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -84,8 +84,8 @@ void PrintIncludes(Printer *printer, const std::vector<grpc::string> &headers,
     }
   }
 
-  for (auto i = headers.begin(); i != headers.end(); i++) {
-    vars["h"] = *i;
+  for (auto i : headers) {
+    vars["h"] = i;
     printer->Print(vars, "#include $l$$h$$r$\n");
   }
 }
@@ -151,8 +151,8 @@ grpc::string GetHeaderIncludes(File *file, const Parameters &params) {
     if (!file->package().empty()) {
       std::vector<grpc::string> parts = file->package_parts();
 
-      for (auto part = parts.begin(); part != parts.end(); part++) {
-        vars["part"] = *part;
+      for (auto part : parts) {
+        vars["part"] = part;
         printer->Print(vars, "namespace $part$ {\n");
       }
       printer->Print(vars, "\n");
@@ -1045,8 +1045,8 @@ grpc::string GetSourceIncludes(File *file, const Parameters &params) {
     if (!file->package().empty()) {
       std::vector<grpc::string> parts = file->package_parts();
 
-      for (auto part = parts.begin(); part != parts.end(); part++) {
-        vars["part"] = *part;
+      for (auto part : parts) {
+        vars["part"] = part;
         printer->Print(vars, "namespace $part$ {\n");
       }
     }
@@ -1363,9 +1363,9 @@ grpc::string GetSourceEpilogue(File *file, const Parameters & /*params*/) {
   if (!file->package().empty()) {
     std::vector<grpc::string> parts = file->package_parts();
 
-    for (auto part = parts.begin(); part != parts.end(); part++) {
+    for (auto part : parts) {
       temp.append("}  // namespace ");
-      temp.append(*part);
+      temp.append(part);
       temp.append("\n");
     }
     temp.append("\n");

--- a/src/compiler/cpp_plugin.cc
+++ b/src/compiler/cpp_plugin.cc
@@ -199,10 +199,9 @@ class CppGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
     if (!parameter.empty()) {
       std::vector<grpc::string> parameters_list =
           grpc_generator::tokenize(parameter, ",");
-      for (auto parameter_string = parameters_list.begin();
-           parameter_string != parameters_list.end(); parameter_string++) {
+      for (auto parameter_string : parameters_list) {
         std::vector<grpc::string> param =
-            grpc_generator::tokenize(*parameter_string, "=");
+            grpc_generator::tokenize(parameter_string, "=");
         if (param[0] == "services_namespace") {
           generator_parameters.services_namespace = param[1];
         } else if (param[0] == "use_system_headers") {
@@ -211,13 +210,13 @@ class CppGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
           } else if (param[1] == "false") {
             generator_parameters.use_system_headers = false;
           } else {
-            *error = grpc::string("Invalid parameter: ") + *parameter_string;
+            *error = grpc::string("Invalid parameter: ") + parameter_string;
             return false;
           }
         } else if (param[0] == "grpc_search_path") {
           generator_parameters.grpc_search_path = param[1];
         } else {
-          *error = grpc::string("Unknown parameter: ") + *parameter_string;
+          *error = grpc::string("Unknown parameter: ") + parameter_string;
           return false;
         }
       }

--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -97,9 +97,8 @@ void GenerateDocCommentBodyImpl(grpc::protobuf::io::Printer *printer,
   // Note that we can't remove leading or trailing whitespace as *that's*
   // relevant in markdown too.
   // (We don't skip "just whitespace" lines, either.)
-  for (std::vector<grpc::string>::iterator it = lines.begin();
-       it != lines.end(); ++it) {
-    grpc::string line = *it;
+  for (auto it : lines) {
+    grpc::string line = it;
     if (line.empty()) {
       last_was_empty = true;
     } else {
@@ -107,7 +106,7 @@ void GenerateDocCommentBodyImpl(grpc::protobuf::io::Printer *printer,
         printer->Print("///\n");
       }
       last_was_empty = false;
-      printer->Print("/// $line$\n", "line", *it);
+      printer->Print("/// $line$\n", "line", it);
     }
   }
   printer->Print("/// </summary>\n");

--- a/src/compiler/generator_helpers.h
+++ b/src/compiler/generator_helpers.h
@@ -255,7 +255,7 @@ inline void GetComment(const grpc::protobuf::FileDescriptor *desc,
 inline grpc::string GenerateCommentsWithPrefix(
     const std::vector<grpc::string> &in, const grpc::string &prefix) {
   std::ostringstream oss;
-  for (const auto& elem : in) {
+  for (const auto &elem : in) {
     if (elem.empty()) {
       oss << prefix << "\n";
     } else if (elem[0] == ' ') {

--- a/src/compiler/generator_helpers.h
+++ b/src/compiler/generator_helpers.h
@@ -255,8 +255,7 @@ inline void GetComment(const grpc::protobuf::FileDescriptor *desc,
 inline grpc::string GenerateCommentsWithPrefix(
     const std::vector<grpc::string> &in, const grpc::string &prefix) {
   std::ostringstream oss;
-  for (auto it = in.begin(); it != in.end(); it++) {
-    const grpc::string &elem = *it;
+  for (const auto& elem : in) {
     if (elem.empty()) {
       oss << prefix << "\n";
     } else if (elem[0] == ' ') {

--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -73,11 +73,11 @@ static void PrintAllComments(const DescriptorType *desc, Printer *printer) {
     return;
   }
   printer->Print("/**\n");
-  for (auto it = comments.begin(); it != comments.end(); ++it) {
+  for (auto comment : comments) {
     printer->Print(" * ");
-    size_t start_pos = it->find_first_not_of(' ');
+    size_t start_pos = comment.find_first_not_of(' ');
     if (start_pos != grpc::string::npos) {
-      printer->Print(it->c_str() + start_pos);
+      printer->Print(comment.c_str() + start_pos);
     }
     printer->Print("\n");
   }

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -212,11 +212,10 @@ void PrivateGenerator::PrintAllComments(const DescriptorType* descriptor) {
     return;
   }
   out->Print("\"\"\"");
-  for (StringVector::iterator it = comments.begin(); it != comments.end();
-       ++it) {
-    size_t start_pos = it->find_first_not_of(' ');
+  for (auto comment : comments) {
+    size_t start_pos = comment.find_first_not_of(' ');
     if (start_pos != grpc::string::npos) {
-      out->Print(it->c_str() + start_pos);
+      out->Print(comment.c_str() + start_pos);
     }
     out->Print("\n");
   }

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -204,11 +204,11 @@ void MetadataCredentialsPluginWrapper::InvokePlugin(
   Status status = plugin_->GetMetadata(context.service_url, context.method_name,
                                        cpp_channel_auth_context, &metadata);
   std::vector<grpc_metadata> md;
-  for (auto it = metadata.begin(); it != metadata.end(); ++it) {
+  for (auto it : metadata) {
     grpc_metadata md_entry;
-    md_entry.key = it->first.c_str();
-    md_entry.value = it->second.data();
-    md_entry.value_length = it->second.size();
+    md_entry.key = it.first.c_str();
+    md_entry.value = it.second.data();
+    md_entry.value_length = it.second.size();
     md_entry.flags = 0;
     md.push_back(md_entry);
   }

--- a/src/cpp/common/channel_arguments.cc
+++ b/src/cpp/common/channel_arguments.cc
@@ -53,26 +53,26 @@ ChannelArguments::ChannelArguments(const ChannelArguments& other)
   args_.reserve(other.args_.size());
   auto list_it_dst = strings_.begin();
   auto list_it_src = other.strings_.begin();
-  for (auto a = other.args_.begin(); a != other.args_.end(); ++a) {
+  for (auto a : other.args_) {
     grpc_arg ap;
-    ap.type = a->type;
-    GPR_ASSERT(list_it_src->c_str() == a->key);
+    ap.type = a.type;
+    GPR_ASSERT(list_it_src->c_str() == a.key);
     ap.key = const_cast<char*>(list_it_dst->c_str());
     ++list_it_src;
     ++list_it_dst;
-    switch (a->type) {
+    switch (a.type) {
       case GRPC_ARG_INTEGER:
-        ap.value.integer = a->value.integer;
+        ap.value.integer = a.value.integer;
         break;
       case GRPC_ARG_STRING:
-        GPR_ASSERT(list_it_src->c_str() == a->value.string);
+        GPR_ASSERT(list_it_src->c_str() == a.value.string);
         ap.value.string = const_cast<char*>(list_it_dst->c_str());
         ++list_it_src;
         ++list_it_dst;
         break;
       case GRPC_ARG_POINTER:
-        ap.value.pointer = a->value.pointer;
-        ap.value.pointer.p = a->value.pointer.vtable->copy(ap.value.pointer.p);
+        ap.value.pointer = a.value.pointer;
+        ap.value.pointer.p = a.value.pointer.vtable->copy(ap.value.pointer.p);
         break;
     }
     args_.push_back(ap);
@@ -99,12 +99,11 @@ void ChannelArguments::SetUserAgentPrefix(
     return;
   }
   bool replaced = false;
-  for (auto it = args_.begin(); it != args_.end(); ++it) {
-    const grpc_arg& arg = *it;
+  for (auto& arg : args_) {
     if (arg.type == GRPC_ARG_STRING &&
         grpc::string(arg.key) == GRPC_ARG_PRIMARY_USER_AGENT_STRING) {
       strings_.push_back(user_agent_prefix + " " + arg.value.string);
-      it->value.string = const_cast<char*>(strings_.back().c_str());
+      arg.value.string = const_cast<char*>(strings_.back().c_str());
       replaced = true;
       break;
     }

--- a/src/cpp/ext/proto_server_reflection.cc
+++ b/src/cpp/ext/proto_server_reflection.cc
@@ -117,9 +117,9 @@ Status ProtoServerReflection::ListService(ServerContext* context,
   if (services_ == nullptr) {
     return Status(StatusCode::NOT_FOUND, "Services not found.");
   }
-  for (auto it = services_->begin(); it != services_->end(); ++it) {
+  for (auto it : *services_) {
     ServiceResponse* service_response = response->add_service();
-    service_response->set_name(*it);
+    service_response->set_name(it);
   }
   return Status::OK;
 }
@@ -197,8 +197,8 @@ Status ProtoServerReflection::GetAllExtensionNumbers(
 
   std::vector<const protobuf::FieldDescriptor*> extensions;
   descriptor_pool_->FindAllExtensions(desc, &extensions);
-  for (auto it = extensions.begin(); it != extensions.end(); it++) {
-    response->add_extension_number((*it)->number());
+  for (auto it : extensions) {
+    response->add_extension_number((it)->number());
   }
   response->set_base_type_name(type);
   return Status::OK;

--- a/src/cpp/server/secure_server_credentials.cc
+++ b/src/cpp/server/secure_server_credentials.cc
@@ -82,22 +82,20 @@ void AuthMetadataProcessorAyncWrapper::InvokeProcessor(
                                       &response_metadata);
 
   std::vector<grpc_metadata> consumed_md;
-  for (auto it = consumed_metadata.begin(); it != consumed_metadata.end();
-       ++it) {
+  for (auto it : consumed_metadata) {
     grpc_metadata md_entry;
-    md_entry.key = it->first.c_str();
-    md_entry.value = it->second.data();
-    md_entry.value_length = it->second.size();
+    md_entry.key = it.first.c_str();
+    md_entry.value = it.second.data();
+    md_entry.value_length = it.second.size();
     md_entry.flags = 0;
     consumed_md.push_back(md_entry);
   }
   std::vector<grpc_metadata> response_md;
-  for (auto it = response_metadata.begin(); it != response_metadata.end();
-       ++it) {
+  for (auto it : response_metadata) {
     grpc_metadata md_entry;
-    md_entry.key = it->first.c_str();
-    md_entry.value = it->second.data();
-    md_entry.value_length = it->second.size();
+    md_entry.key = it.first.c_str();
+    md_entry.value = it.second.data();
+    md_entry.value_length = it.second.size();
     md_entry.flags = 0;
     response_md.push_back(md_entry);
   }
@@ -124,10 +122,9 @@ void SecureServerCredentials::SetAuthMetadataProcessor(
 std::shared_ptr<ServerCredentials> SslServerCredentials(
     const SslServerCredentialsOptions& options) {
   std::vector<grpc_ssl_pem_key_cert_pair> pem_key_cert_pairs;
-  for (auto key_cert_pair = options.pem_key_cert_pairs.begin();
-       key_cert_pair != options.pem_key_cert_pairs.end(); key_cert_pair++) {
-    grpc_ssl_pem_key_cert_pair p = {key_cert_pair->private_key.c_str(),
-                                    key_cert_pair->cert_chain.c_str()};
+  for (auto key_cert_pair : options.pem_key_cert_pairs) {
+    grpc_ssl_pem_key_cert_pair p = {key_cert_pair.private_key.c_str(),
+                                    key_cert_pair.cert_chain.c_str()};
     pem_key_cert_pairs.push_back(p);
   }
   grpc_server_credentials* c_creds = grpc_ssl_server_credentials_create_ex(

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -989,7 +989,7 @@ class AsyncEnd2endServerTryCancelTest : public AsyncEnd2endTest {
       expected_server_cq_result = false;
     }
 
-    std::thread* server_try_cancel_thd = NULL;
+    std::thread* server_try_cancel_thd = nullptr;
 
     auto verif = Verifier(GetParam().disable_blocking);
 
@@ -1025,7 +1025,7 @@ class AsyncEnd2endServerTryCancelTest : public AsyncEnd2endTest {
       }
     }
 
-    if (server_try_cancel_thd != NULL) {
+    if (server_try_cancel_thd != nullptr) {
       server_try_cancel_thd->join();
       delete server_try_cancel_thd;
     }
@@ -1250,7 +1250,7 @@ class AsyncEnd2endServerTryCancelTest : public AsyncEnd2endTest {
       expected_cq_result = false;
     }
 
-    std::thread* server_try_cancel_thd = NULL;
+    std::thread* server_try_cancel_thd = nullptr;
 
     auto verif = Verifier(GetParam().disable_blocking);
 
@@ -1330,7 +1330,7 @@ class AsyncEnd2endServerTryCancelTest : public AsyncEnd2endTest {
       EXPECT_EQ(verif.Next(cq_.get(), ignore_cq_result), 8);
     }
 
-    if (server_try_cancel_thd != NULL) {
+    if (server_try_cancel_thd != nullptr) {
       server_try_cancel_thd->join();
       delete server_try_cancel_thd;
     }

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -352,15 +352,13 @@ void ServerWait(Server* server, int* notify) {
 }
 TEST_P(AsyncEnd2endTest, WaitAndShutdownTest) {
   int notify = 0;
-  std::thread* wait_thread =
-      new std::thread(&ServerWait, server_.get(), &notify);
+  std::thread wait_thread(&ServerWait, server_.get(), &notify);
   ResetStub();
   SendRpc(1);
   EXPECT_EQ(0, notify);
   server_->Shutdown();
-  wait_thread->join();
+  wait_thread.join();
   EXPECT_EQ(1, notify);
-  delete wait_thread;
 }
 
 TEST_P(AsyncEnd2endTest, ShutdownThenWait) {

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -656,25 +656,23 @@ TEST_P(End2endTest, SimpleRpcWithCustomeUserAgentPrefix) {
 
 TEST_P(End2endTest, MultipleRpcsWithVariedBinaryMetadataValue) {
   ResetStub();
-  std::vector<std::thread*> threads;
+  std::vector<std::thread> threads;
   for (int i = 0; i < 10; ++i) {
-    threads.push_back(new std::thread(SendRpc, stub_.get(), 10, true));
+    threads.emplace_back(SendRpc, stub_.get(), 10, true);
   }
   for (int i = 0; i < 10; ++i) {
-    threads[i]->join();
-    delete threads[i];
+    threads[i].join();
   }
 }
 
 TEST_P(End2endTest, MultipleRpcs) {
   ResetStub();
-  std::vector<std::thread*> threads;
+  std::vector<std::thread> threads;
   for (int i = 0; i < 10; ++i) {
-    threads.push_back(new std::thread(SendRpc, stub_.get(), 10, false));
+    threads.emplace_back(SendRpc, stub_.get(), 10, false);
   }
   for (int i = 0; i < 10; ++i) {
-    threads[i]->join();
-    delete threads[i];
+    threads[i].join();
   }
 }
 
@@ -1058,13 +1056,12 @@ TEST_P(ProxyEnd2endTest, SimpleRpcWithEmptyMessages) {
 
 TEST_P(ProxyEnd2endTest, MultipleRpcs) {
   ResetStub();
-  std::vector<std::thread*> threads;
+  std::vector<std::thread> threads;
   for (int i = 0; i < 10; ++i) {
-    threads.push_back(new std::thread(SendRpc, stub_.get(), 10, false));
+    threads.emplace_back(SendRpc, stub_.get(), 10, false);
   }
   for (int i = 0; i < 10; ++i) {
-    threads[i]->join();
-    delete threads[i];
+    threads[i].join();
   }
 }
 

--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -194,7 +194,7 @@ Status TestServiceImpl::RequestStream(ServerContext* context,
     return Status::CANCELLED;
   }
 
-  std::thread* server_try_cancel_thd = NULL;
+  std::thread* server_try_cancel_thd = nullptr;
   if (server_try_cancel == CANCEL_DURING_PROCESSING) {
     server_try_cancel_thd =
         new std::thread(&TestServiceImpl::ServerTryCancel, this, context);
@@ -212,7 +212,7 @@ Status TestServiceImpl::RequestStream(ServerContext* context,
   }
   gpr_log(GPR_INFO, "Read: %d messages", num_msgs_read);
 
-  if (server_try_cancel_thd != NULL) {
+  if (server_try_cancel_thd != nullptr) {
     server_try_cancel_thd->join();
     delete server_try_cancel_thd;
     return Status::CANCELLED;
@@ -248,7 +248,7 @@ Status TestServiceImpl::ResponseStream(ServerContext* context,
   }
 
   EchoResponse response;
-  std::thread* server_try_cancel_thd = NULL;
+  std::thread* server_try_cancel_thd = nullptr;
   if (server_try_cancel == CANCEL_DURING_PROCESSING) {
     server_try_cancel_thd =
         new std::thread(&TestServiceImpl::ServerTryCancel, this, context);
@@ -259,7 +259,7 @@ Status TestServiceImpl::ResponseStream(ServerContext* context,
     writer->Write(response);
   }
 
-  if (server_try_cancel_thd != NULL) {
+  if (server_try_cancel_thd != nullptr) {
     server_try_cancel_thd->join();
     delete server_try_cancel_thd;
     return Status::CANCELLED;
@@ -295,7 +295,7 @@ Status TestServiceImpl::BidiStream(
     return Status::CANCELLED;
   }
 
-  std::thread* server_try_cancel_thd = NULL;
+  std::thread* server_try_cancel_thd = nullptr;
   if (server_try_cancel == CANCEL_DURING_PROCESSING) {
     server_try_cancel_thd =
         new std::thread(&TestServiceImpl::ServerTryCancel, this, context);
@@ -307,7 +307,7 @@ Status TestServiceImpl::BidiStream(
     stream->Write(response);
   }
 
-  if (server_try_cancel_thd != NULL) {
+  if (server_try_cancel_thd != nullptr) {
     server_try_cancel_thd->join();
     delete server_try_cancel_thd;
     return Status::CANCELLED;

--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -244,7 +244,7 @@ class CommonStressTestAsyncServer
     }
     for (int i = 0; i < kNumAsyncServerThreads; i++) {
       server_threads_.emplace_back(&CommonStressTestAsyncServer::ProcessRpcs,
-				   this);
+                                   this);
     }
   }
   void TearDown() override {

--- a/test/cpp/qps/client.h
+++ b/test/cpp/qps/client.h
@@ -163,10 +163,9 @@ class Client {
 
     MaybeStartRequests();
 
-    // avoid std::vector for old compilers that expect a copy constructor
     if (reset) {
-      Histogram* to_merge = new Histogram[threads_.size()];
-      StatusHistogram* to_merge_status = new StatusHistogram[threads_.size()];
+      std::vector<Histogram> to_merge(threads_.size());
+      std::vector<StatusHistogram> to_merge_status(threads_.size());
 
       for (size_t i = 0; i < threads_.size(); i++) {
         threads_[i]->BeginSwap(&to_merge[i], &to_merge_status[i]);
@@ -177,8 +176,6 @@ class Client {
         latencies.Merge(to_merge[i]);
         MergeStatusHistogram(to_merge_status[i], &statuses);
       }
-      delete[] to_merge;
-      delete[] to_merge_status;
       timer_result = timer->Mark();
     } else {
       // merge snapshots of each thread histogram

--- a/test/cpp/qps/client_async.cc
+++ b/test/cpp/qps/client_async.cc
@@ -177,7 +177,6 @@ class AsyncClient : public ClientImpl<StubType, RequestType> {
       shutdown_state_.emplace_back(new PerThreadShutdownState());
     }
 
-    using namespace std::placeholders;
     int t = 0;
     for (int ch = 0; ch < config.client_channels(); ch++) {
       for (int i = 0; i < config.outstanding_rpcs_per_channel(); i++) {

--- a/test/cpp/qps/client_sync.cc
+++ b/test/cpp/qps/client_sync.cc
@@ -138,10 +138,7 @@ class SynchronousUnaryClient final : public SynchronousClient {
 class SynchronousStreamingClient final : public SynchronousClient {
  public:
   SynchronousStreamingClient(const ClientConfig& config)
-      : SynchronousClient(config) {
-    context_ = new grpc::ClientContext[num_threads_];
-    stream_ = new std::unique_ptr<
-        grpc::ClientReaderWriter<SimpleRequest, SimpleResponse>>[num_threads_];
+    : SynchronousClient(config), context_(num_threads_), stream_(num_threads_) {
     for (size_t thread_idx = 0; thread_idx < num_threads_; thread_idx++) {
       auto* stub = channels_[thread_idx % channels_.size()].get_stub();
       stream_[thread_idx] = stub->StreamingCall(&context_[thread_idx]);
@@ -161,8 +158,6 @@ class SynchronousStreamingClient final : public SynchronousClient {
         }
       }
     }
-    delete[] stream_;
-    delete[] context_;
   }
 
   bool ThreadFunc(HistogramEntry* entry, size_t thread_idx) override {
@@ -182,9 +177,8 @@ class SynchronousStreamingClient final : public SynchronousClient {
  private:
   // These are both conceptually std::vector but cannot be for old compilers
   // that expect contained classes to support copy constructors
-  grpc::ClientContext* context_;
-  std::unique_ptr<grpc::ClientReaderWriter<SimpleRequest, SimpleResponse>>*
-      stream_;
+  std::vector<grpc::ClientContext> context_;
+  std::vector<std::unique_ptr<grpc::ClientReaderWriter<SimpleRequest, SimpleResponse>>> stream_;
 };
 
 std::unique_ptr<Client> CreateSynchronousUnaryClient(

--- a/test/cpp/qps/client_sync.cc
+++ b/test/cpp/qps/client_sync.cc
@@ -138,7 +138,9 @@ class SynchronousUnaryClient final : public SynchronousClient {
 class SynchronousStreamingClient final : public SynchronousClient {
  public:
   SynchronousStreamingClient(const ClientConfig& config)
-    : SynchronousClient(config), context_(num_threads_), stream_(num_threads_) {
+      : SynchronousClient(config),
+        context_(num_threads_),
+        stream_(num_threads_) {
     for (size_t thread_idx = 0; thread_idx < num_threads_; thread_idx++) {
       auto* stub = channels_[thread_idx % channels_.size()].get_stub();
       stream_[thread_idx] = stub->StreamingCall(&context_[thread_idx]);
@@ -178,7 +180,9 @@ class SynchronousStreamingClient final : public SynchronousClient {
   // These are both conceptually std::vector but cannot be for old compilers
   // that expect contained classes to support copy constructors
   std::vector<grpc::ClientContext> context_;
-  std::vector<std::unique_ptr<grpc::ClientReaderWriter<SimpleRequest, SimpleResponse>>> stream_;
+  std::vector<
+      std::unique_ptr<grpc::ClientReaderWriter<SimpleRequest, SimpleResponse>>>
+      stream_;
 };
 
 std::unique_ptr<Client> CreateSynchronousUnaryClient(

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -183,7 +183,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
     int warmup_seconds, int benchmark_seconds, int spawn_local_worker_count) {
   // Log everything from the driver
   gpr_set_log_verbosity(GPR_LOG_SEVERITY_DEBUG);
-  
+
   // ClientContext allocations (all are destroyed at scope exit)
   list<ClientContext> contexts;
   auto alloc_context = [](list<ClientContext>* contexts) {

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -262,10 +262,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
   workers.resize(num_clients + num_servers);
 
   // Start servers
-  using runsc::ServerData;
-  // servers is array rather than std::vector to avoid gcc-4.4 issues
-  // where class contained in std::vector must have a copy constructor
-  auto* servers = new ServerData[num_servers];
+  std::vector<runsc::ServerData> servers(num_servers);
   for (size_t i = 0; i < num_servers; i++) {
     gpr_log(GPR_INFO, "Starting server on %s (worker #%" PRIuPTR ")",
             workers[i].c_str(), i);
@@ -328,10 +325,7 @@ std::unique_ptr<ScenarioResult> RunScenario(
   // Targets are all set by now
   result_client_config = client_config;
   // Start clients
-  using runsc::ClientData;
-  // clients is array rather than std::vector to avoid gcc-4.4 issues
-  // where class contained in std::vector must have a copy constructor
-  auto* clients = new ClientData[num_clients];
+  std::vector<runsc::ClientData> clients(num_clients);
   size_t channels_allocated = 0;
   for (size_t i = 0; i < num_clients; i++) {
     const auto& worker = workers[i + num_servers];
@@ -501,7 +495,6 @@ std::unique_ptr<ScenarioResult> RunScenario(
               s.error_message().c_str());
     }
   }
-  delete[] clients;
 
   merged_latencies.FillProto(result->mutable_latencies());
   for (std::unordered_map<int, int64_t>::iterator it = merged_statuses.begin();
@@ -543,8 +536,6 @@ std::unique_ptr<ScenarioResult> RunScenario(
               s.error_message().c_str());
     }
   }
-
-  delete[] servers;
 
   postprocess_scenario_result(result.get());
   return result;

--- a/test/cpp/util/config_grpc_cli.h
+++ b/test/cpp/util/config_grpc_cli.h
@@ -77,7 +77,7 @@ namespace compiler {
 typedef GRPC_CUSTOM_DISKSOURCETREE DiskSourceTree;
 typedef GRPC_CUSTOM_IMPORTER Importer;
 typedef GRPC_CUSTOM_MULTIFILEERRORCOLLECTOR MultiFileErrorCollector;
-}  // namespace importer
+}  // namespace compiler
 
 }  // namespace protobuf
 }  // namespace grpc


### PR DESCRIPTION
Eliminate unnecessary uses of new[]/delete[] that can be replaced with vector
Also start eliminating uses of plain-old delete that are not helpful
Eliminate namespaces that were just used to hide local templates or lambdas
