### PR TITLE
Update standard Linux worker spec

### DIFF
--- a/tools/gce/create_linux_worker.sh
+++ b/tools/gce/create_linux_worker.sh
@@ -42,7 +42,7 @@ INSTANCE_NAME="${1:-grpc-jenkins-worker1}"
 gcloud compute instances create $INSTANCE_NAME \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
-    --machine-type n1-highmem-8 \
+    --machine-type n1-standard-16 \
     --image=ubuntu-1510 \
     --image-project=grpc-testing \
     --boot-disk-size 1000


### PR DESCRIPTION
I upgraded all of the linuxexperiment workers to have more CPU cores and higher RAM to allow for running more tests in parallel. These changes allow for much faster Linux testing times and should be kept imo. 