### PR TITLE
Remove deprecated macros from C-core API.

### DIFF
--- a/doc/core/pending_api_cleanups.md
+++ b/doc/core/pending_api_cleanups.md
@@ -11,9 +11,4 @@ This file lists all pending backward-compatibility changes that should
 be cleaned up the next time we are going to bump the major version
 number:
 
-- remove `GRPC_ARG_MAX_MESSAGE_LENGTH` channel arg from
-  `include/grpc/impl/codegen/grpc_types.h` (commit `af00d8b`)
-- remove `ServerBuilder::SetMaxMessageSize()` method from
-  `include/grpc++/server_builder.h` (commit `6980362`)
-- remove `GRPC_INITIAL_METADATA_IGNORE_CONNECTIVITY` macro from
-  `include/grpc/impl/codegen/grpc_types.h` (commit `59c9f90`)
+(none currently)

--- a/doc/core/pending_api_cleanups.md
+++ b/doc/core/pending_api_cleanups.md
@@ -11,4 +11,7 @@ This file lists all pending backward-compatibility changes that should
 be cleaned up the next time we are going to bump the major version
 number:
 
-(none currently)
+- remove `GRPC_ARG_MAX_MESSAGE_LENGTH` channel arg from
+  `include/grpc/impl/codegen/grpc_types.h` (commit `af00d8b`)
+  (cannot be done until after next grpc release, so that TensorFlow can
+  use the same code both internally and externally)

--- a/doc/cpp/pending_api_cleanups.md
+++ b/doc/cpp/pending_api_cleanups.md
@@ -11,5 +11,7 @@ This file lists all pending backward-compatibility changes that should
 be cleaned up the next time we are going to bump the major version
 number:
 
+- remove `ServerBuilder::SetMaxMessageSize()` method from
+  `include/grpc++/server_builder.h` (commit `6980362`)
 - remove `ClientContext::set_fail_fast()` method from
   `include/grpc++/impl/codegen/client_context.h` (commit `9477724`)

--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -151,6 +151,8 @@ typedef struct {
 /** Maximum message length that the channel can receive. Int valued, bytes.
     -1 means unlimited. */
 #define GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH "grpc.max_receive_message_length"
+/** \deprecated For backward compatibility. */
+#define GRPC_ARG_MAX_MESSAGE_LENGTH GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH
 /** Maximum message length that the channel can send. Int valued, bytes.
     -1 means unlimited. */
 #define GRPC_ARG_MAX_SEND_MESSAGE_LENGTH "grpc.max_send_message_length"

--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -151,8 +151,6 @@ typedef struct {
 /** Maximum message length that the channel can receive. Int valued, bytes.
     -1 means unlimited. */
 #define GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH "grpc.max_receive_message_length"
-/** \deprecated For backward compatibility. */
-#define GRPC_ARG_MAX_MESSAGE_LENGTH GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH
 /** Maximum message length that the channel can send. Int valued, bytes.
     -1 means unlimited. */
 #define GRPC_ARG_MAX_SEND_MESSAGE_LENGTH "grpc.max_send_message_length"
@@ -271,9 +269,6 @@ typedef enum grpc_call_error {
 #define GRPC_INITIAL_METADATA_IDEMPOTENT_REQUEST (0x00000010u)
 /** Signal that the call should not return UNAVAILABLE before it has started */
 #define GRPC_INITIAL_METADATA_WAIT_FOR_READY (0x00000020u)
-/** DEPRECATED: for backward compatibility */
-#define GRPC_INITIAL_METADATA_IGNORE_CONNECTIVITY \
-  GRPC_INITIAL_METADATA_WAIT_FOR_READY
 /** Signal that the call is cacheable. GRPC is free to use GET verb */
 #define GRPC_INITIAL_METADATA_CACHEABLE_REQUEST (0x00000040u)
 /** Signal that GRPC_INITIAL_METADATA_WAIT_FOR_READY was explicitly set


### PR DESCRIPTION
Now that the C-core API has been bumped to version 2.