### PR TITLE
Fix metadata credentials

### DIFF
--- a/src/core/lib/security/credentials/plugin/plugin_credentials.c
+++ b/src/core/lib/security/credentials/plugin/plugin_credentials.c
@@ -104,6 +104,8 @@ static void plugin_md_request_metadata_ready(void *request,
         grpc_slice_unref(md_array[i].value);
       }
       gpr_free(md_array);
+    } else if (num_md == 0) {
+      r->cb(&exec_ctx, r->user_data, NULL, 0, GRPC_CREDENTIALS_OK, NULL);
     }
   }
   gpr_free(r);

--- a/src/csharp/Grpc.IntegrationTesting/MetadataCredentialsTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/MetadataCredentialsTest.cs
@@ -103,6 +103,33 @@ namespace Grpc.IntegrationTesting
             client.UnaryCall(new SimpleRequest { }, new CallOptions(credentials: callCredentials));
         }
 
+        [Test]
+        public void MetadataCredentials_InterceptorLeavesMetadataEmpty()
+        {
+            var channelCredentials = ChannelCredentials.Create(TestCredentials.CreateSslCredentials(),
+                CallCredentials.FromInterceptor(new AsyncAuthInterceptor((context, metadata) => TaskUtils.CompletedTask)));
+            channel = new Channel(Host, server.Ports.Single().BoundPort, channelCredentials, options);
+            client = new TestService.TestServiceClient(channel);
+
+            var ex = Assert.Throws<RpcException>(() => client.UnaryCall(new SimpleRequest { }));
+            Assert.AreEqual(StatusCode.Unknown, ex.Status.StatusCode);
+        }
+
+        [Test]
+        public void MetadataCredentials_InterceptorThrows()
+        {
+            var callCredentials = CallCredentials.FromInterceptor(new AsyncAuthInterceptor((context, metadata) =>
+            {
+                throw new Exception("Auth interceptor throws");
+            }));
+            var channelCredentials = ChannelCredentials.Create(TestCredentials.CreateSslCredentials(), callCredentials);
+            channel = new Channel(Host, server.Ports.Single().BoundPort, channelCredentials, options);
+            client = new TestService.TestServiceClient(channel);
+
+            var ex = Assert.Throws<RpcException>(() => client.UnaryCall(new SimpleRequest { }));
+            Assert.AreEqual(StatusCode.Unauthenticated, ex.Status.StatusCode);
+        }
+
         private class FakeTestService : TestService.TestServiceBase
         {
             public override Task<SimpleResponse> UnaryCall(SimpleRequest request, ServerCallContext context)

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -991,7 +991,11 @@ GPR_EXPORT void GPR_CALLTYPE grpcsharp_metadata_credentials_notify_from_plugin(
     grpc_credentials_plugin_metadata_cb cb,
     void *user_data, grpc_metadata_array *metadata,
   grpc_status_code status, const char *error_details) {
-  cb(user_data, metadata->metadata, metadata->count, status, error_details);
+  if (metadata) {
+    cb(user_data, metadata->metadata, metadata->count, status, error_details);
+  } else {
+    cb(user_data, NULL, 0, status, error_details);
+  }
 }
 
 typedef void(GPR_CALLTYPE *grpcsharp_metadata_interceptor_func)(


### PR DESCRIPTION
Fixes #8594.

Added tests to verify the new behavior.

Fixes:
-- allow passing null metadata array to plugin_notify
-- if empty metadata was returned by the callback to plugin credentials, the call hanged (added and extra branch to handle this).