### PR TITLE
Fix clang-format in master.

### DIFF
--- a/test/core/end2end/tests/authority_not_supported.c
+++ b/test/core/end2end/tests/authority_not_supported.c
@@ -98,7 +98,8 @@ static void end_test(grpc_end2end_test_fixture *f) {
 /* Request/response with metadata and payload.*/
 static void test_with_authority_header(grpc_end2end_test_config config) {
   grpc_call *c;
-  grpc_slice request_payload_slice = grpc_slice_from_copied_string("hello world");
+  grpc_slice request_payload_slice =
+      grpc_slice_from_copied_string("hello world");
   grpc_byte_buffer *request_payload =
       grpc_raw_byte_buffer_create(&request_payload_slice, 1);
   gpr_timespec deadline = five_seconds_time();


### PR DESCRIPTION
Looks like this was broken in #8343.