### PR TITLE
Show skipped tests not showing up in Jenkins UI

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -301,7 +301,9 @@ if __name__ == "__main__":
       print('No tests will be skipped.')
     else:
       print('These tests will be skipped:')
-      skipped_jobs = [job for job in jobs if job not in relevant_jobs]
+      skipped_jobs = list(set(jobs) - set(relevant_jobs))
+      # Sort by shortnames to make printing of skipped tests consistent
+      skipped_jobs.sort(key=lambda job: job.shortname)
       for job in list(skipped_jobs):
         print('  %s' % job.shortname)
     jobs = relevant_jobs


### PR DESCRIPTION
Before, skipped_tests would always be an empty list becuase `skipped_jobs = [job for job in jobs if job not in relevant_jobs]` did not find the skipped jobs. The reason for this is jobset.JobSpec doesn't have an \_\_eq__ function to compare objects (at least this is why I think it didn't work). Hashing it to a set makes finding the difference possible. 