### PR TITLE
Cleanup C# profiling code

### DIFF
--- a/src/csharp/Grpc.Core/Internal/CallSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/CallSafeHandle.cs
@@ -76,11 +76,8 @@ namespace Grpc.Core.Internal
 
         public void StartUnary(BatchContextSafeHandle ctx, byte[] payload, MetadataArraySafeHandle metadataArray, WriteFlags writeFlags)
         {
-            using (Profilers.ForCurrentThread().NewScope("CallSafeHandle.StartUnary"))
-            {
-                Native.grpcsharp_call_start_unary(this, ctx, payload, new UIntPtr((ulong)payload.Length), metadataArray, writeFlags)
-                    .CheckOk();
-            }
+            Native.grpcsharp_call_start_unary(this, ctx, payload, new UIntPtr((ulong)payload.Length), metadataArray, writeFlags)
+                .CheckOk();
         }
 
         public void StartClientStreaming(UnaryResponseClientHandler callback, MetadataArraySafeHandle metadataArray)

--- a/src/csharp/Grpc.Core/Internal/ChannelSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/ChannelSafeHandle.cs
@@ -65,16 +65,13 @@ namespace Grpc.Core.Internal
 
         public CallSafeHandle CreateCall(CallSafeHandle parentCall, ContextPropagationFlags propagationMask, CompletionQueueSafeHandle cq, string method, string host, Timespec deadline, CallCredentialsSafeHandle credentials)
         {
-            using (Profilers.ForCurrentThread().NewScope("ChannelSafeHandle.CreateCall"))
+            var result = Native.grpcsharp_channel_create_call(this, parentCall, propagationMask, cq, method, host, deadline);
+            if (credentials != null)
             {
-                var result = Native.grpcsharp_channel_create_call(this, parentCall, propagationMask, cq, method, host, deadline);
-                if (credentials != null)
-                {
-                    result.SetCredentials(credentials);
-                }
-                result.Initialize(cq);
-                return result;
+                result.SetCredentials(credentials);
             }
+            result.Initialize(cq);
+            return result;
         }
 
         public ChannelState CheckConnectivityState(bool tryToConnect)

--- a/src/csharp/Grpc.Core/Internal/CompletionQueueSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/CompletionQueueSafeHandle.cs
@@ -70,10 +70,7 @@ namespace Grpc.Core.Internal
 
         public CompletionQueueEvent Pluck(IntPtr tag)
         {
-            using (Profilers.ForCurrentThread().NewScope("CompletionQueueSafeHandle.Pluck"))
-            {
-                return Native.grpcsharp_completion_queue_pluck(this, tag);
-            }
+            return Native.grpcsharp_completion_queue_pluck(this, tag);
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core/Internal/MetadataArraySafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/MetadataArraySafeHandle.cs
@@ -48,22 +48,19 @@ namespace Grpc.Core.Internal
             
         public static MetadataArraySafeHandle Create(Metadata metadata)
         {
-            using (Profilers.ForCurrentThread().NewScope("MetadataArraySafeHandle.Create"))
+            if (metadata.Count == 0)
             {
-                if (metadata.Count == 0)
-                {
-                    return new MetadataArraySafeHandle();
-                }
-
-                // TODO(jtattermusch): we might wanna check that the metadata is readonly 
-                var metadataArray = Native.grpcsharp_metadata_array_create(new UIntPtr((ulong)metadata.Count));
-                for (int i = 0; i < metadata.Count; i++)
-                {
-                    var valueBytes = metadata[i].GetSerializedValueUnsafe();
-                    Native.grpcsharp_metadata_array_add(metadataArray, metadata[i].Key, valueBytes, new UIntPtr((ulong)valueBytes.Length));
-                }
-                return metadataArray;
+                return new MetadataArraySafeHandle();
             }
+
+            // TODO(jtattermusch): we might wanna check that the metadata is readonly
+            var metadataArray = Native.grpcsharp_metadata_array_create(new UIntPtr((ulong)metadata.Count));
+            for (int i = 0; i < metadata.Count; i++)
+            {
+                var valueBytes = metadata[i].GetSerializedValueUnsafe();
+                Native.grpcsharp_metadata_array_add(metadataArray, metadata[i].Key, valueBytes, new UIntPtr((ulong)valueBytes.Length));
+            }
+            return metadataArray;
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core/Profiling/Profilers.cs
+++ b/src/csharp/Grpc.Core/Profiling/Profilers.cs
@@ -80,7 +80,7 @@ namespace Grpc.Core.Profiling
         ProfilerEntry[] entries;
         int count;
 
-        public BasicProfiler() : this(1024*1024)
+        public BasicProfiler() : this(20*1024*1024)
         {
         }
 


### PR DESCRIPTION
-- get rid of some no-longer useful profiling points
-- when analyzing async performance, assigning profilers to threadpool threads proved out to be very useful. Setup the building pieces in GrpcThreadPool (but of course no profiling happens by default).