### PR TITLE
Fix sanity, uv, and windows builds

### DIFF
--- a/src/core/ext/lb_policy/grpclb/grpclb.c
+++ b/src/core/ext/lb_policy/grpclb/grpclb.c
@@ -1155,8 +1155,8 @@ static void lb_on_response_received(grpc_exec_ctx *exec_ctx, void *arg,
     }
     gpr_mu_unlock(&glb_policy->mu);
   } else { /* empty payload: call cancelled. */
-    /* dispose of the "lb_on_response_received" weak ref taken in
-     * query_for_backends_locked() and reused in every reception loop */
+           /* dispose of the "lb_on_response_received" weak ref taken in
+            * query_for_backends_locked() and reused in every reception loop */
     gpr_mu_unlock(&glb_policy->mu);
     GRPC_LB_POLICY_WEAK_UNREF(exec_ctx, &glb_policy->base,
                               "lb_on_response_received_empty_payload");

--- a/src/core/lib/iomgr/tcp_windows.c
+++ b/src/core/lib/iomgr/tcp_windows.c
@@ -402,6 +402,8 @@ static grpc_resource_user *win_get_resource_user(grpc_endpoint *ep) {
   return tcp->resource_user;
 }
 
+static int win_get_fd(grpc_endpoint *ep) { return -1; }
+
 static grpc_endpoint_vtable vtable = {win_read,
                                       win_write,
                                       win_get_workqueue,
@@ -410,7 +412,8 @@ static grpc_endpoint_vtable vtable = {win_read,
                                       win_shutdown,
                                       win_destroy,
                                       win_get_resource_user,
-                                      win_get_peer};
+                                      win_get_peer,
+                                      win_get_fd};
 
 grpc_endpoint *grpc_tcp_create(grpc_winsocket *socket,
                                grpc_resource_quota *resource_quota,

--- a/src/core/lib/security/transport/secure_endpoint.c
+++ b/src/core/lib/security/transport/secure_endpoint.c
@@ -31,15 +31,20 @@
  *
  */
 
-#include "src/core/lib/security/transport/secure_endpoint.h"
+/* With the addition of a libuv endpoint, sockaddr.h now includes uv.h when
+   using that endpoint. Because of various transitive includes in uv.h,
+   including windows.h on Windows, uv.h must be included before other system
+   headers. Therefore, sockaddr.h must always be included first */
+#include "src/core/lib/iomgr/sockaddr.h"
+
 #include <grpc/slice.h>
 #include <grpc/slice_buffer.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 #include "src/core/lib/debug/trace.h"
-#include "src/core/lib/iomgr/sockaddr.h"
 #include "src/core/lib/profiling/timers.h"
+#include "src/core/lib/security/transport/secure_endpoint.h"
 #include "src/core/lib/security/transport/tsi_error.h"
 #include "src/core/lib/slice/slice_string_helpers.h"
 #include "src/core/lib/support/string.h"


### PR DESCRIPTION
This moves the `sockaddr.h` include in secure_endpoint.c, adds the missing `get_fd` vtable entries in `tcp_uv` and `tcp_windows`, and clang formats everything.