### PR TITLE
Enable running C# benchmarks on Windows

### DIFF
--- a/tools/jenkins/run_full_performance.sh
+++ b/tools/jenkins/run_full_performance.sh
@@ -52,4 +52,12 @@ tools/run_tests/run_performance_tests.py \
     --remote_worker_host grpc-performance-server-32core grpc-performance-client-32core grpc-performance-client2-32core \
     || EXIT_CODE=1
 
+# selected scenarios on Windows
+tools/run_tests/run_performance_tests.py \
+    -l csharp \
+    --category scalable \
+    --bq_result_table performance_test.performance_experiment_windows \
+    --remote_worker_host grpc-performance-windows1 grpc-performance-windows2 \
+    || EXIT_CODE=1
+
 exit $EXIT_CODE

--- a/tools/run_tests/performance/build_performance.sh
+++ b/tools/run_tests/performance/build_performance.sh
@@ -37,10 +37,14 @@ CONFIG=${CONFIG:-opt}
 
 # build C++ qps worker & driver always - we need at least the driver to
 # run any of the scenarios.
-# TODO(jtattermusch): not embedding OpenSSL breaks the C# build because
-# grpc_csharp_ext needs OpenSSL embedded and some intermediate files from
-# this build will be reused.
-make CONFIG=${CONFIG} EMBED_OPENSSL=true EMBED_ZLIB=true qps_worker qps_json_driver -j8
+# TODO(jtattermusch): C++ worker and driver are not buildable on Windows yet
+if [ "$OSTYPE" != "msys" ]
+then
+  # TODO(jtattermusch): not embedding OpenSSL breaks the C# build because
+  # grpc_csharp_ext needs OpenSSL embedded and some intermediate files from
+  # this build will be reused.
+  make CONFIG=${CONFIG} EMBED_OPENSSL=true EMBED_ZLIB=true qps_worker qps_json_driver -j8
+fi
 
 for language in $@
 do
@@ -55,10 +59,10 @@ do
     tools/run_tests/performance/build_performance_go.sh
     ;;
   "csharp")
-    tools/run_tests/run_tests.py -l $language -c $CONFIG --build_only -j 8 --compiler coreclr
+    python tools/run_tests/run_tests.py -l $language -c $CONFIG --build_only -j 8 --compiler coreclr
     ;;
   *)
-    tools/run_tests/run_tests.py -l $language -c $CONFIG --build_only -j 8
+    python tools/run_tests/run_tests.py -l $language -c $CONFIG --build_only -j 8
     ;;
   esac
 done


### PR DESCRIPTION
Building C++ qps_worker is tricky, so for now this only builds C# worker.

I've setup two 8 core windows workers: grpc-performance-windows1 & grpc-performance-windows2. With some minor changes, run_performance_tests.py script can run benchmarks on them.