### PR TITLE
Move Test Dependencies from CONTRIBUTING to INSTALL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,31 +12,7 @@ In order to protect both you and ourselves, you will need to sign the
 
 ### Technical requirements
 
-You will need several tools to work with this repository. In addition to all of
-the packages described in the [INSTALL](INSTALL.md) file, you will also need
-python, and the mako template renderer. To install the latter, using pip, one
-should simply be able to do `pip install mako`.
-
-In order to run all of the tests we provide, you will need valgrind and clang.
-More specifically, under debian, you will need the package libc++-dev to
-properly run all the tests.
-
-Compiling and running grpc C++ tests depend on protobuf 3.0.0, gtest and gflags.
-Although gflags is provided in third_party, you will need to manually install
-that dependency on your system to run these tests. Under a Debian or Ubuntu
-system, you can install the gtests and gflags packages using apt-get:
-
-```sh
- $ [sudo] apt-get install libgflags-dev libgtest-dev
-```
-
-If you are planning to work on any of the languages other than C and C++, you
-will also need their appropriate development environments.
-
-If you want to work under Windows, we recommend the use of Visual Studio 2013.
-The [Community or Express editions](http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx)
-are free and suitable for developing with grpc. Note however that our test
-environment and tools are available for Unix environments only at the moment.
+Make sure you have followed all of the steps in [INSTALL](INSTALL.md).
 
 ## Testing your changes
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ refer to these documents
 ##Linux
 
 ```sh
- $ [sudo] apt-get install build-essential autoconf libtool
+ $ [sudo] apt-get install build-essential autoconf libtool libgflags-dev
 ```
 
 ##Mac OSX

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,7 +57,8 @@ gRPC C Core library.
 ```
 
 Note that if you are interested in contributing, you must install some extra
-dependencies to run the test suites. All of these can be found in [CONTRIBUTING](CONTRIBUTING.md)
+dependencies to run the test suites. All of these can be found in the Requirements 
+for Running Tests section below.
 
 ##Windows
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -56,6 +56,9 @@ gRPC C Core library.
  $ [sudo] make install
 ```
 
+Note that if you are interested in contributing, you must install some extra
+dependencies to run the test suites. All of these can be found in [CONTRIBUTING](CONTRIBUTING.md)
+
 ##Windows
 
 There are several ways to build under Windows, of varying complexity depending

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ refer to these documents
 ##Linux
 
 ```sh
- $ [sudo] apt-get install build-essential autoconf libtool libgflags-dev
+ $ [sudo] apt-get install build-essential autoconf libtool
 ```
 
 ##Mac OSX
@@ -110,3 +110,30 @@ This approach requires having [msys2](https://msys2.github.io/) installed.
   generate "projects" for your compiler.
 - Build with your compiler of choice. The generated build files should have the
   protobuf3 dependency baked in.
+  
+#Requirements for Running Tests
+
+Running all of the gRPC tests requires installing a few more dependencies. You will
+need python, and the mako template renderer. To install the latter, using pip, one
+should simply be able to do `pip install mako`.
+
+In order to run all of the tests we provide, you will need valgrind and clang.
+More specifically, under debian, you will need the package libc++-dev to
+properly run all the tests.
+
+Compiling and running grpc C++ tests depend on protobuf 3.0.0, gtest and gflags.
+Although gflags is provided in third_party, you will need to manually install
+that dependency on your system to run these tests. Under a Debian or Ubuntu
+system, you can install the gtests and gflags packages using apt-get:
+
+```sh
+ $ [sudo] apt-get install libgflags-dev libgtest-dev
+```
+
+If you are planning to work on any of the languages other than C and C++, you
+will also need their appropriate development environments.
+
+If you want to work under Windows, we recommend the use of Visual Studio 2013.
+The [Community or Express editions](http://www.visualstudio.com/en-us/downloads/download-visual-studio-vs.aspx)
+are free and suitable for developing with grpc. Note however that our test
+environment and tools are available for Unix environments only at the moment.


### PR DESCRIPTION
This changes makes it easier for people to install all of the needed dependencies to run the gRPC tests. I had trouble finding this when I first installed the requirements.

This resolves #8582