### PR TITLE
Undo wrong NULLing in grpclb

### DIFF
--- a/src/core/ext/lb_policy/grpclb/grpclb.c
+++ b/src/core/ext/lb_policy/grpclb/grpclb.c
@@ -768,7 +768,6 @@ static void glb_shutdown(grpc_exec_ctx *exec_ctx, grpc_lb_policy *pol) {
    * while holding glb_policy->mu: lb_on_server_status_received, invoked due to
    * the cancel, needs to acquire that same lock */
   grpc_call *lb_call = glb_policy->lb_call;
-  glb_policy->lb_call = NULL;
   gpr_mu_unlock(&glb_policy->mu);
 
   /* glb_policy->lb_call and this local lb_call must be consistent at this point


### PR DESCRIPTION
Setting it to NULL was a bad idea: if the call is cancelled in line 778, `lb_on_server_status_received` will be invoked with a NULL `glb_policy->lb_call` which is a no-no.

Note that this is only triggered when it's the client triggering the disconnection from the LB as a result of the gRPC LB policy shutting down. The case we currently test with the existing unittests is when it's the *LB* shutting down first. This other path of execution was found during internal integration testing. There's already a TODO in the external grpclb_test.cc file to also include this (and many other scenarios).