### PR TITLE
Add default arguments to python interop client

### DIFF
--- a/src/python/grpcio_tests/tests/interop/client.py
+++ b/src/python/grpcio_tests/tests/interop/client.py
@@ -43,11 +43,13 @@ from tests.interop import resources
 def _args():
   parser = argparse.ArgumentParser()
   parser.add_argument(
-      '--server_host', help='the host to which to connect', type=str)
+      '--server_host', help='the host to which to connect', type=str,
+      default="127.0.0.1")
   parser.add_argument(
       '--server_port', help='the port to which to connect', type=int)
   parser.add_argument(
-      '--test_case', help='the test case to execute', type=str)
+      '--test_case', help='the test case to execute', type=str,
+      default="large_unary")
   parser.add_argument(
       '--use_tls', help='require a secure connection', default=False,
       type=resources.parse_bool)
@@ -55,7 +57,7 @@ def _args():
       '--use_test_ca', help='replace platform root CAs with ca.pem',
       default=False, type=resources.parse_bool)
   parser.add_argument(
-      '--server_host_override',
+      '--server_host_override', default="foo.test.google.fr",
       help='the server host to which to claim to connect', type=str)
   parser.add_argument('--oauth_scope', help='scope for OAuth tokens', type=str)
   parser.add_argument(


### PR DESCRIPTION
Standardized python interop client's default args with the same one that c++ uses