### PR TITLE
Don't destroy lock before unlocking

### DIFF
--- a/src/core/ext/lb_policy/grpclb/grpclb.c
+++ b/src/core/ext/lb_policy/grpclb/grpclb.c
@@ -607,6 +607,7 @@ static void glb_rr_connectivity_changed(grpc_exec_ctx *exec_ctx, void *arg,
   rr_connectivity_data *rr_conn_data = arg;
   glb_lb_policy *glb_policy = rr_conn_data->glb_policy;
   gpr_mu_lock(&glb_policy->mu);
+  grpc_lb_policy *maybe_unref = NULL;
 
   if (rr_conn_data->state != GRPC_CHANNEL_SHUTDOWN &&
       !glb_policy->shutting_down) {
@@ -619,11 +620,16 @@ static void glb_rr_connectivity_changed(grpc_exec_ctx *exec_ctx, void *arg,
                                           &rr_conn_data->state,
                                           &rr_conn_data->on_change);
   } else {
-    GRPC_LB_POLICY_WEAK_UNREF(exec_ctx, &glb_policy->base,
-                              "rr_connectivity_cb");
+    /* we need to stash away the current policy to be UNREF'd after releasing
+     * the lock. Otherwise, if the UNREF is the last one, the policy would be
+     * destroyed, alongside the lock, which would result in a use-after-free */
+    maybe_unref = &glb_policy->base;
     gpr_free(rr_conn_data);
   }
   gpr_mu_unlock(&glb_policy->mu);
+  if (maybe_unref != NULL) {
+    GRPC_LB_POLICY_WEAK_UNREF(exec_ctx, maybe_unref, "rr_connectivity_cb");
+  }
 }
 
 static grpc_lb_policy *glb_create(grpc_exec_ctx *exec_ctx,


### PR DESCRIPTION
It may happen that the `GRPC_LB_POLICY_WEAK_UNREF` triggers the destruction of the `glb_policy`, which hosts the mutex wrapped around the `glb_rr_connectivity_changed` function. In that case, the unlock operation will be referrencing freed memory.

This change saves a copy of the potentially disappearing policy to be unref'd outside the lock.