### PR TITLE
Fix windows benchmarks and upload all 3 reports

### DIFF
--- a/tools/jenkins/run_full_performance.sh
+++ b/tools/jenkins/run_full_performance.sh
@@ -41,7 +41,11 @@ tools/run_tests/run_performance_tests.py \
     --category scalable \
     --bq_result_table performance_test.performance_experiment \
     --remote_worker_host grpc-performance-server-8core grpc-performance-client-8core grpc-performance-client2-8core \
+    --xml_report report_8core.xml \
     || EXIT_CODE=1
+
+# prevent pushing leftover build files to remote hosts in the next step.
+git clean -fdxq --exclude='report*.xml'
 
 # scalability with 32cores (and upload to a different BQ table)
 tools/run_tests/run_performance_tests.py \
@@ -50,7 +54,11 @@ tools/run_tests/run_performance_tests.py \
     --category scalable \
     --bq_result_table performance_test.performance_experiment_32core \
     --remote_worker_host grpc-performance-server-32core grpc-performance-client-32core grpc-performance-client2-32core \
+    --xml_report report_32core.xml \
     || EXIT_CODE=1
+
+# prevent pushing leftover build files to remote hosts in the next step.
+git clean -fdxq --exclude='report*.xml'
 
 # selected scenarios on Windows
 tools/run_tests/run_performance_tests.py \
@@ -58,6 +66,7 @@ tools/run_tests/run_performance_tests.py \
     --category scalable \
     --bq_result_table performance_test.performance_experiment_windows \
     --remote_worker_host grpc-performance-windows1 grpc-performance-windows2 \
+    --xml_report report_windows.xml \
     || EXIT_CODE=1
 
 exit $EXIT_CODE

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -403,6 +403,8 @@ argp.add_argument('--netperf',
                   action='store_const',
                   const=True,
                   help='Run netperf benchmark as one of the scenarios.')
+argp.add_argument('-x', '--xml_report', default='report.xml', type=str,
+                  help='Name of XML report file to generate.')
 
 args = argp.parse_args()
 
@@ -473,7 +475,7 @@ for scenario in scenarios:
       qps_workers_killed += finish_qps_workers(scenario.workers)
 
 
-report_utils.render_junit_xml_report(merged_resultset, 'report.xml',
+report_utils.render_junit_xml_report(merged_resultset, args.xml_report,
                                      suite_name='benchmarks')
 
 if total_scenario_failures > 0 or qps_workers_killed > 0:


### PR DESCRIPTION
-- the windows benchmarks are failing to run because the tar file pushed to the windows workers contains some symlinks that fail to extract (git clean should get rid of them)

-- currently each run of run_performance_tests.py generates a report.xml that gets later rewritten. 