### PR TITLE
UserResource does not reference tcp endpoint on windows

### DIFF
--- a/src/core/lib/iomgr/tcp_windows.c
+++ b/src/core/lib/iomgr/tcp_windows.c
@@ -423,7 +423,7 @@ grpc_endpoint *grpc_tcp_create(grpc_winsocket *socket,
   tcp->base.vtable = &vtable;
   tcp->socket = socket;
   gpr_mu_init(&tcp->mu);
-  gpr_ref_init(&tcp->refcount, 2);
+  gpr_ref_init(&tcp->refcount, 1);
   grpc_closure_init(&tcp->on_read, on_read, tcp);
   grpc_closure_init(&tcp->on_write, on_write, tcp);
   tcp->peer_string = gpr_strdup(peer_string);


### PR DESCRIPTION
Fixes #8697

Initial refcount was increased to 2 in #8553, then RU api has changed in #8641. It looks like RU doesn't have a reference to tcp endpoint on windows anymore, so initial refcount should be dropped back to 1.
Please doublecheck, I could be wrong.

CC @ctiller 