### PR TITLE
Check on *target, not target

### DIFF
--- a/src/core/ext/lb_policy/grpclb/grpclb.c
+++ b/src/core/ext/lb_policy/grpclb/grpclb.c
@@ -182,10 +182,10 @@ static void wrapped_rr_closure(grpc_exec_ctx *exec_ctx, void *arg,
                       NULL);
 
   if (wc_arg->rr_policy != NULL) {
-    /* if target is NULL, no pick has been made by the RR policy (eg, all
+    /* if *target is NULL, no pick has been made by the RR policy (eg, all
      * addresses failed to connect). There won't be any user_data/token
      * available */
-    if (wc_arg->target != NULL) {
+    if (*wc_arg->target != NULL) {
       if (wc_arg->lb_token != NULL) {
         initial_metadata_add_lb_token(wc_arg->initial_metadata,
                                       wc_arg->lb_token_mdelem_storage,


### PR DESCRIPTION
`wc_arg->target` is a `**`. Therefore, the check for a valid pick should be on the dereferenced pointer, not on the `**`, which will always be true.