### PR TITLE
wait for write loop to finish at end of ruby read loop, on client side calls

### DIFF
--- a/src/ruby/lib/grpc/generic/bidi_call.rb
+++ b/src/ruby/lib/grpc/generic/bidi_call.rb
@@ -208,6 +208,10 @@ module GRPC
       GRPC.logger.debug('bidi-read-loop: finished')
       @reads_complete = true
       finished
+      # Make sure that the write loop is done done before finishing the call.
+      # Note that blocking is ok at this point because we've already received
+      # a status
+      @enq_th.join if is_client
     end
   end
 end


### PR DESCRIPTION
Safe shutdowns at the ends of ruby benchmarks rely on all client side calls finishing before shutting down the server. But currently, joining the client side streaming call threads doesn't guarantee that the calls are done, as the spawned write loop finishes on its own time.