### PR TITLE
Add Clearer Error Message to BoringSSL Build Generation

### DIFF
--- a/src/boringssl/gen_build_yaml.py
+++ b/src/boringssl/gen_build_yaml.py
@@ -164,5 +164,10 @@ try:
 
   print yaml.dump(g.yaml)
 
+except OSError as err:
+  type, value, traceback = sys.exc_info()
+  raise RuntimeError, (
+      "Verify that you have go in your PATH", type, value), traceback
+
 finally:
   shutil.rmtree('src')


### PR DESCRIPTION
When build.yaml is updated, tools/buildgen/generate_projects.sh must be called. This calls src/boringssl/gen_build_yaml.py, which in turn calls third_party/boringssl/util/generate_build_files.py.

[Line 466](https://github.com/google/boringssl/blob/c880e42ba1c8032d4cdde2aba0541d8a9d9fa2e9/util/generate_build_files.py#L466) uses go to generate an error file. If someone does't have go downloaded, or doesn't have go in their PATH variable, then calling tools/buildgen/generate_projects.sh leads to a cryptic error message:

```
Traceback (most recent call last):
  File "src/boringssl/gen_build_yaml.py", line 163, in <module>
    generate_build_files.main([g])
  File "/usr/local/google/home/ncteisen/Desktop/grpc/third_party/boringssl/util/generate_build_files.py", line 468, in main
    stdout=err_data)
  File "/usr/lib/python2.7/subprocess.py", line 535, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 522, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 710, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```

This pull request makes the error message cleared by prompting the use to make sure they have go installed and reachable.