### PR TITLE
Untrack Generated node_modules Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ py27/
 py34/
 
 # Node installation output
-^node_modules
+node_modules
 src/node/extension_binary/
 
 # gcov coverage data


### PR DESCRIPTION
I figure, since node_modules is generated by npm install, it should not be a tracked file.