### PR TITLE
fix problem of grpc_httpcli_(get|post)

### DIFF
--- a/src/core/lib/http/httpcli.c
+++ b/src/core/lib/http/httpcli.c
@@ -187,6 +187,10 @@ static void on_handshake_done(grpc_exec_ctx *exec_ctx, void *arg,
   internal_request *req = arg;
 
   if (!ep) {
+    //req->ep freed in security_handshake_done(handshake.c), so set NULL to ep for avoiding double free
+    //(when req->next_address == req->addresses->naddrs).
+    // otherwise ep initialized again in grpc_tcp_client_connect, so no harmful to do it here.
+    req->ep = NULL;
     next_address(exec_ctx, req,
                  GRPC_ERROR_CREATE("Unexplained handshake failure"));
     return;

--- a/src/core/lib/http/httpcli.c
+++ b/src/core/lib/http/httpcli.c
@@ -236,7 +236,10 @@ static void next_address(grpc_exec_ctx *exec_ctx, internal_request *req,
 static void on_resolved(grpc_exec_ctx *exec_ctx, void *arg, grpc_error *error) {
   internal_request *req = arg;
   if (error != GRPC_ERROR_NONE) {
-    finish(exec_ctx, req, error);
+    //on_resolved called from grpc_exec_ctx_flush (via resolve_address_impl), which unrefs error.
+    //but finish also register exec_ctx queue with this error pointer, then error unrefs twice.
+    //so refer error here to run correctly.
+    finish(exec_ctx, req, GRPC_ERROR_REF(error));
     return;
   }
   req->next_address = 0;

--- a/src/core/lib/security/transport/secure_endpoint.c
+++ b/src/core/lib/security/transport/secure_endpoint.c
@@ -175,6 +175,10 @@ static void on_read(grpc_exec_ctx *exec_ctx, void *user_data,
       if (result != TSI_OK) {
         gpr_log(GPR_ERROR, "Decryption error: %s",
                 tsi_result_to_string(result));
+        if (result == TSI_REMOTE_PEER_CLOSED) {
+            /* when remote peer closed case, some data may received on first ssl_read */
+            cur += unprotected_buffer_size_written;
+        }
         break;
       }
       message_bytes += processed_message_size;
@@ -210,7 +214,7 @@ static void on_read(grpc_exec_ctx *exec_ctx, void *user_data,
   gpr_slice_buffer_reset_and_unref(&ep->source_buffer);
 
   if (result != TSI_OK) {
-    if (result != TSI_REMOTE_PEER_CLOSED) { /* let callback to process last read buffer */
+    if (result != TSI_REMOTE_PEER_CLOSED) {
       gpr_slice_buffer_reset_and_unref(ep->read_buffer);
     }
     call_read_cb(exec_ctx, ep, grpc_set_tsi_error_result(

--- a/src/core/lib/security/transport/secure_endpoint.c
+++ b/src/core/lib/security/transport/secure_endpoint.c
@@ -210,7 +210,9 @@ static void on_read(grpc_exec_ctx *exec_ctx, void *user_data,
   gpr_slice_buffer_reset_and_unref(&ep->source_buffer);
 
   if (result != TSI_OK) {
-    gpr_slice_buffer_reset_and_unref(ep->read_buffer);
+    if (result != TSI_REMOTE_PEER_CLOSED) { /* let callback to process last read buffer */
+      gpr_slice_buffer_reset_and_unref(ep->read_buffer);
+    }
     call_read_cb(exec_ctx, ep, grpc_set_tsi_error_result(
                                    GRPC_ERROR_CREATE("Unwrap failed"), result));
     return;

--- a/src/core/lib/tsi/ssl_transport_security.c
+++ b/src/core/lib/tsi/ssl_transport_security.c
@@ -435,7 +435,7 @@ static tsi_result do_ssl_read(SSL *ssl, unsigned char *unprotected_bytes,
       SSL_read(ssl, unprotected_bytes, (int)*unprotected_bytes_size);
   if (read_from_ssl == 0) {
     int err = SSL_get_error(ssl, read_from_ssl);
-    gpr_log(GPR_ERROR, "SSL_read returned 0(%d) unexpectedly.", err);
+    gpr_log(GPR_ERROR, "SSL_read returned 0 unexpectedly. %d", err);
     if (err == SSL_ERROR_ZERO_RETURN) {
       return TSI_REMOTE_PEER_CLOSED;
     }
@@ -832,7 +832,13 @@ static tsi_result ssl_protector_unprotect(
 
   /* First, try to read remaining data from ssl. */
   result = do_ssl_read(impl->ssl, unprotected_bytes, unprotected_bytes_size);
-  if (result != TSI_OK) return result;
+  if (result != TSI_OK) {
+    if (result == TSI_REMOTE_PEER_CLOSED) {
+        /* if remote peer closed, prevent caller to proceed pointer */
+        *unprotected_bytes_size = 0;
+    }
+    return result;
+  }
   if (*unprotected_bytes_size == output_bytes_size) {
     /* We have read everything we could and cannot process any more input. */
     *protected_frames_bytes_size = 0;
@@ -858,6 +864,9 @@ static tsi_result ssl_protector_unprotect(
   if (result == TSI_OK) {
     /* Don't forget to output the total number of bytes read. */
     *unprotected_bytes_size += output_bytes_offset;
+  } else if (result == TSI_REMOTE_PEER_CLOSED) {
+    /* When fails by remote peer closed, first ssl_read may read something from server */
+    *unprotected_bytes_size = output_bytes_offset;
   }
   return result;
 }

--- a/src/core/lib/tsi/ssl_transport_security.c
+++ b/src/core/lib/tsi/ssl_transport_security.c
@@ -434,7 +434,11 @@ static tsi_result do_ssl_read(SSL *ssl, unsigned char *unprotected_bytes,
   read_from_ssl =
       SSL_read(ssl, unprotected_bytes, (int)*unprotected_bytes_size);
   if (read_from_ssl == 0) {
-    gpr_log(GPR_ERROR, "SSL_read returned 0 unexpectedly.");
+    int err = SSL_get_error(ssl, read_from_ssl);
+    gpr_log(GPR_ERROR, "SSL_read returned 0(%d) unexpectedly.", err);
+    if (err == SSL_ERROR_ZERO_RETURN) {
+      return TSI_REMOTE_PEER_CLOSED;
+    }
     return TSI_INTERNAL_ERROR;
   }
   if (read_from_ssl < 0) {

--- a/src/core/lib/tsi/transport_security.c
+++ b/src/core/lib/tsi/transport_security.c
@@ -73,6 +73,8 @@ const char *tsi_result_to_string(tsi_result result) {
       return "TSI_HANDSHAKE_IN_PROGRESS";
     case TSI_OUT_OF_RESOURCES:
       return "TSI_OUT_OF_RESOURCES";
+    case TSI_REMOTE_PEER_CLOSED:
+      return "TSI_REMOTE_PEER_CLOSED";
     default:
       return "UNKNOWN";
   }

--- a/src/core/lib/tsi/transport_security_interface.h
+++ b/src/core/lib/tsi/transport_security_interface.h
@@ -56,7 +56,8 @@ typedef enum {
   TSI_NOT_FOUND = 9,
   TSI_PROTOCOL_FAILURE = 10,
   TSI_HANDSHAKE_IN_PROGRESS = 11,
-  TSI_OUT_OF_RESOURCES = 12
+  TSI_OUT_OF_RESOURCES = 12,
+  TSI_REMOTE_PEER_CLOSED = 13
 } tsi_result;
 
 typedef enum {


### PR DESCRIPTION
reopen of https://github.com/grpc/grpc/pull/8243 because of noticing additional bug
https://github.com/grpc/grpc/commit/5edfb703ae27208627958cbe484d00b7583ff79f: add missed reference when name resolve causes error, which raise assertion on gpr_unref

@ctiller sorry for late reply, and I saw the comment on previous pull request, so I try to add test for these fix. but I cannot finish make test_c correctly, even with plain v1.0.x HEAD(dc2111ec70c2545fd811ebb7e52157e0d848ccf2). am I missing something to run test correctly?

what I try is: 
1. make container for running test, by executing run_tests.py with --use_docker option
2. mount my source tree in the container like following:
```
docker run -ti --rm -v `pwd`:/grpc cxx_jessie_x64_{sha1 hash} bash
```
3. run make clean test_c, which should contain http(s)cli_test.

then I got this (without my fix)
```
*******************************
Caught signal 6
/grpc/bins/opt/dualstack_socket_test[0x4f3f33]
/lib/x86_64-linux-gnu/libpthread.so.0(+0xf8d0)[0x7fd2e873f8d0]
/lib/x86_64-linux-gnu/libc.so.6(gsignal+0x37)[0x7fd2e83ba067]
/lib/x86_64-linux-gnu/libc.so.6(abort+0x148)[0x7fd2e83bb448]
/grpc/bins/opt/dualstack_socket_test[0x4048fd]
/grpc/bins/opt/dualstack_socket_test[0x4039a8]
/grpc/bins/opt/dualstack_socket_test[0x4034ff]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf5)[0x7fd2e83a6b45]
/grpc/bins/opt/dualstack_socket_test[0x4035a6]
Aborted
test dualstack_socket_test failed
Makefile:1480: recipe for target 'test_c' failed
make: *** [test_c] Error 1
```

also I got following error, when I run httpscli_test individually with same environment.
```
E1124 08:47:46.277677713       6 security_connector.c:665]   load_file: {"created":"@1479977266.277451937","description":"Failed to load file","file":"src/core/lib/iomgr/load_file.c","file_line":82,"filename":"/usr/local/share/grpc/roots.pem","referenced_errors":[{"created":"@1479977266.277449787","description":"OS Error","errno":2,"file":"src/core/lib/iomgr/load_file.c","file_line":58,"os_error":"No such file or directory","syscall":"fopen"}]}
E1124 08:47:46.277713464       6 httpcli_security_connector.c:175] Could not get default pem root certs.
E1124 08:47:46.277742055       6 httpscli_test.c:63]         assertion failed: response->status == 200



*******************************
Caught signal 6
./bins/opt/httpscli_test[0x4f1523]
/lib/x86_64-linux-gnu/libpthread.so.0(+0xf8d0)[0x7f89afb048d0]
/lib/x86_64-linux-gnu/libc.so.6(gsignal+0x37)[0x7f89af77f067]
/lib/x86_64-linux-gnu/libc.so.6(abort+0x148)[0x7f89af780448]
./bins/opt/httpscli_test[0x403c8f]
./bins/opt/httpscli_test[0x40b0e4]
./bins/opt/httpscli_test[0x465723]
./bins/opt/httpscli_test[0x4035ba]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf5)[0x7f89af76bb45]
./bins/opt/httpscli_test[0x403a23]
Aborted
```

any ideas?