### PR TITLE
Reduce pre-generated key count

### DIFF
--- a/test/cpp/microbenchmarks/bm_fullstack.cc
+++ b/test/cpp/microbenchmarks/bm_fullstack.cc
@@ -221,7 +221,7 @@ class InProcessCHTTP2 : public EndpointPairFixture {
  * CONTEXT MUTATORS
  */
 
-static const int kPregenerateKeyCount = 10000000;
+static const int kPregenerateKeyCount = 100000;
 
 template <class F>
 auto MakeVector(size_t length, F f) -> std::vector<decltype(f())> {


### PR DESCRIPTION
Doesn't affect benchmark accuracy, but makes startup time substantially
faster, and hopefully eliminates occurences like this:
https://grpc-testing.appspot.com/job/gRPC_master_linux/642/testReport/junit/(root)/c++_linux_dbg/bins_dbg_bm_fullstack_GRPC_POLL_STRATEGY_epoll/