### PR TITLE
Make a better educated guess about CPU costs of a benchmark

### DIFF
--- a/test/cpp/qps/gen_build_yaml.py
+++ b/test/cpp/qps/gen_build_yaml.py
@@ -63,8 +63,7 @@ def guess_cpu(scenario_json):
   server = threads_of_type(scenario_json, 'server_config/async_server_threads')
   # make an arbitrary guess if set to auto-detect
   # about the size of the jenkins instances we have for unit tests
-  if client == 0: client = 16
-  if server == 0: server = 16
+  if client == 0 or server == 0: return 'capacity'
   return (scenario_json['num_clients'] * client +
           scenario_json['num_servers'] * server)
 

--- a/test/cpp/qps/gen_build_yaml.py
+++ b/test/cpp/qps/gen_build_yaml.py
@@ -63,8 +63,8 @@ def guess_cpu(scenario_json):
   server = threads_of_type(scenario_json, 'server_config/async_server_threads')
   # make an arbitrary guess if set to auto-detect
   # about the size of the jenkins instances we have for unit tests
-  if client == 0: client = 8
-  if server == 0: server = 8
+  if client == 0: client = 16
+  if server == 0: server = 16
   return (scenario_json['num_clients'] * client +
           scenario_json['num_servers'] * server)
 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -242,6 +242,9 @@ class CLanguage(object):
               target['name'])
         else:
           binary = 'bins/%s/%s' % (self.config.build_config, target['name'])
+        cpu_cost = target['cpu_cost']
+        if cpu_cost == 'capacity':
+          cpu_cost = multiprocessing.cpu_count()
         if os.path.isfile(binary):
           if 'gtest' in target and target['gtest']:
             # here we parse the output of --gtest_list_tests to build up a
@@ -265,7 +268,7 @@ class CLanguage(object):
                 cmdline = [binary] + ['--gtest_filter=%s' % test]
                 out.append(self.config.job_spec(cmdline,
                                                 shortname='%s --gtest_filter=%s %s' % (binary, test, shortname_ext),
-                                                cpu_cost=target['cpu_cost'],
+                                                cpu_cost=cpu_cost,
                                                 environ=env))
           else:
             cmdline = [binary] + target['args']
@@ -274,7 +277,7 @@ class CLanguage(object):
                                                           pipes.quote(arg)
                                                           for arg in cmdline) +
                                                       shortname_ext,
-                                            cpu_cost=target['cpu_cost'],
+                                            cpu_cost=cpu_cost,
                                             flaky=target.get('flaky', False),
                                             timeout_seconds=target.get('timeout_seconds', _DEFAULT_TIMEOUT_SECONDS),
                                             environ=env))

--- a/tools/run_tests/tests.json
+++ b/tools/run_tests/tests.json
@@ -36783,7 +36783,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -36825,7 +36825,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -36846,7 +36846,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -36888,7 +36888,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -36909,7 +36909,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -36951,7 +36951,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -36972,7 +36972,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37014,7 +37014,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37035,7 +37035,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37077,7 +37077,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37098,7 +37098,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37140,7 +37140,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37182,7 +37182,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37203,7 +37203,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37245,7 +37245,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37266,7 +37266,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37308,7 +37308,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37329,7 +37329,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37371,7 +37371,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37392,7 +37392,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37434,7 +37434,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37455,7 +37455,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 8, 
+    "cpu_cost": 16, 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 

--- a/tools/run_tests/tests.json
+++ b/tools/run_tests/tests.json
@@ -36783,7 +36783,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -36804,7 +36804,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 1, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -36825,7 +36825,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -36846,7 +36846,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -36888,7 +36888,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -36909,7 +36909,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -36951,7 +36951,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -36972,7 +36972,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37014,7 +37014,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37035,7 +37035,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37077,7 +37077,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37098,7 +37098,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37140,7 +37140,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37161,7 +37161,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 1, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37182,7 +37182,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37203,7 +37203,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37245,7 +37245,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37266,7 +37266,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37308,7 +37308,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37329,7 +37329,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37371,7 +37371,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37392,7 +37392,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37434,7 +37434,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 
@@ -37455,7 +37455,7 @@
     "ci_platforms": [
       "linux"
     ], 
-    "cpu_cost": 16, 
+    "cpu_cost": "capacity", 
     "defaults": "boringssl", 
     "exclude_configs": [], 
     "flaky": false, 


### PR DESCRIPTION
I don't think this will actually fix anything, but it should bring Jenkins and our local runs into line.

Since we were guessing 8 CPU's on 16 core machines, Jenkins would schedule two qps_tests concurrently, whereas on our workstations we'd only get one (12 cores).