### PR TITLE
Add <string.h> to test_config.c

### DIFF
--- a/test/core/util/test_config.c
+++ b/test/core/util/test_config.c
@@ -37,6 +37,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>


### PR DESCRIPTION
strcmp at line 284 is implicit declaration