### PR TITLE
Flush platform stuff after timer events

### DIFF
--- a/src/core/lib/iomgr/iomgr.c
+++ b/src/core/lib/iomgr/iomgr.c
@@ -108,6 +108,7 @@ void grpc_iomgr_shutdown(void) {
                          NULL)) {
       gpr_mu_unlock(&g_mu);
       grpc_exec_ctx_flush(&exec_ctx);
+      grpc_iomgr_platform_flush();
       gpr_mu_lock(&g_mu);
       continue;
     }


### PR DESCRIPTION
It can happen that a timer event causes something to be queued to an
IOCP, which means that on Windows we need to flush that queue each time
a timer event fires during shutdown.