### PR TITLE
Capture name change of CocoaPods generated target

### DIFF
--- a/src/objective-c/tests/Podfile
+++ b/src/objective-c/tests/Podfile
@@ -86,7 +86,7 @@ post_install do |installer|
     # CocoaPods creates duplicated library targets of gRPC-Core when the test targets include
     # non-default subspecs of gRPC-Core. All of these library targets start with prefix 'gRPC-Core.'
     # and require the same error suppresion.
-    if target.name == 'gRPC-Core' or target.name.start_with?('gRPC-Core.') 
+    if target.name == 'gRPC-Core' or target.name.start_with?('gRPC-Core.') or target.name.start_with?('gRPC-Core-')
       target.build_configurations.each do |config|
         # TODO(zyc): Remove this setting after the issue is resolved
         # GPR_UNREACHABLE_CODE causes "Control may reach end of non-void

--- a/src/objective-c/tests/Podfile
+++ b/src/objective-c/tests/Podfile
@@ -84,9 +84,9 @@ post_install do |installer|
     end
 
     # CocoaPods creates duplicated library targets of gRPC-Core when the test targets include
-    # non-default subspecs of gRPC-Core. All of these library targets start with prefix 'gRPC-Core.'
+    # non-default subspecs of gRPC-Core. All of these library targets start with prefix 'gRPC-Core'
     # and require the same error suppresion.
-    if target.name == 'gRPC-Core' or target.name.start_with?('gRPC-Core.') or target.name.start_with?('gRPC-Core-')
+    if target.name.start_with?('gRPC-Core')
       target.build_configurations.each do |config|
         # TODO(zyc): Remove this setting after the issue is resolved
         # GPR_UNREACHABLE_CODE causes "Control may reach end of non-void


### PR DESCRIPTION
When CocoaPods is upgraded to v1.1 the name of a target generated by CocoaPods became `gRPC-Core-072e2d32`. It was not captured by post_install steps suppressing GCC_WARN_ABOUT_RETURN_TYPE due to the name change, so the compiler complains.

This PR fixes this error so that CocoaPods v1.1.x can be used.

The name change might be a bug of CocoaPods though (@jcanizales how do you think?). I am going to send them a report and see what they say.