### PR TITLE
turn on Thread.abort_on_exception in ruby unit tests by default

### DIFF
--- a/src/ruby/spec/spec_helper.rb
+++ b/src/ruby/spec/spec_helper.rb
@@ -67,3 +67,5 @@ RSpec.configure do |config|
 end
 
 RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+
+Thread.abort_on_exception = true


### PR DESCRIPTION
fixes https://github.com/grpc/grpc/issues/6650