### PR TITLE
Node: correctly bubble up errors caused by non-serializable writes

### DIFF
--- a/src/node/src/server.js
+++ b/src/node/src/server.js
@@ -127,7 +127,13 @@ function sendUnaryResponse(call, value, serialize, metadata, flags) {
         (new Metadata())._getCoreRepresentation();
     call.metadataSent = true;
   }
-  var message = serialize(value);
+  var message;
+  try {
+    message = serialize(value);
+  } catch (e) {
+    e.code = grpc.status.INTERNAL;
+    handleError(e);
+  }
   message.grpcWriteFlags = flags;
   end_batch[grpc.opType.SEND_MESSAGE] = message;
   end_batch[grpc.opType.SEND_STATUS_FROM_SERVER] = status;
@@ -282,7 +288,9 @@ function _write(chunk, encoding, callback) {
   try {
     message = this.serialize(chunk);
   } catch (e) {
+    e.code = grpc.status.INTERNAL;
     callback(e);
+    return;
   }
   if (_.isFinite(encoding)) {
     /* Attach the encoding if it is a finite number. This is the closest we

--- a/src/node/src/server.js
+++ b/src/node/src/server.js
@@ -133,6 +133,7 @@ function sendUnaryResponse(call, value, serialize, metadata, flags) {
   } catch (e) {
     e.code = grpc.status.INTERNAL;
     handleError(e);
+    return;
   }
   message.grpcWriteFlags = flags;
   end_batch[grpc.opType.SEND_MESSAGE] = message;

--- a/src/node/src/server.js
+++ b/src/node/src/server.js
@@ -278,7 +278,12 @@ function _write(chunk, encoding, callback) {
         (new Metadata())._getCoreRepresentation();
     this.call.metadataSent = true;
   }
-  var message = this.serialize(chunk);
+  var message;
+  try {
+    message = this.serialize(chunk);
+  } catch (e) {
+    callback(e);
+  }
   if (_.isFinite(encoding)) {
     /* Attach the encoding if it is a finite number. This is the closest we
      * can get to checking that it is valid flags */


### PR DESCRIPTION
This fixes #8882.

This will ensure that if a client or server stream tries to send a message that cannot be serialized on an open call, the call will be properly terminated.