### PR TITLE
attempt to reconnect when c# connect async reaches idle state

### DIFF
--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -209,8 +209,15 @@ namespace Grpc.Core
                 {
                     throw new OperationCanceledException("Channel has reached Shutdown state.");
                 }
-                await WaitForStateChangedAsync(currentState, deadline).ConfigureAwait(false);
-                currentState = GetConnectivityState(false);
+                if (currentState == ChannelState.Idle)
+                {
+                    currentState = GetConnectivityState(true);
+                }
+                else
+                {
+                    await WaitForStateChangedAsync(currentState, deadline).ConfigureAwait(false);
+                    currentState = GetConnectivityState(false);
+                }
             }
         }
 


### PR DESCRIPTION
fixes https://github.com/grpc/grpc/issues/8167

I'm not sure exactly why it reaches "idle" state when it does, but the fact that it can reach this terminal state and stay there I think is an issue. Left out the repro case, but could include a variation of it if preferred, PLMK.