### PR TITLE
Update server_crash_test to account for longer reconnect timeouts

### DIFF
--- a/test/cpp/end2end/server_crash_test.cc
+++ b/test/cpp/end2end/server_crash_test.cc
@@ -138,7 +138,7 @@ TEST_F(CrashTest, ResponseStream) {
   auto server = CreateServerAndClient("response");
 
   gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
-                               gpr_time_from_seconds(5, GPR_TIMESPAN)));
+                               gpr_time_from_seconds(60, GPR_TIMESPAN)));
   KillClient();
   server->Shutdown();
   GPR_ASSERT(HadOneResponseStream());
@@ -148,7 +148,7 @@ TEST_F(CrashTest, BidiStream) {
   auto server = CreateServerAndClient("bidi");
 
   gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
-                               gpr_time_from_seconds(5, GPR_TIMESPAN)));
+                               gpr_time_from_seconds(60, GPR_TIMESPAN)));
   KillClient();
   server->Shutdown();
   GPR_ASSERT(HadOneBidiStream());


### PR DESCRIPTION
Fixes:

https://grpc-testing.appspot.com/job/gRPC_master_linux/702/testReport/junit/(root)/c++_linux_dbg/bins_dbg_server_crash_test___gtest_filter_CrashTest_ResponseStream__GRPC_POLL_STRATEGY_epoll/