### PR TITLE
handle empty string for qps workers in driver and dont quit them after netperf test

### DIFF
--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -101,7 +101,7 @@ static std::unordered_map<string, std::deque<int>> get_hosts_and_cores(
 
 static deque<string> get_workers(const string& name) {
   char* env = gpr_getenv(name.c_str());
-  if (!env) return deque<string>();
+  if (!env || strlen(env) == 0) return deque<string>();
 
   deque<string> out;
   char* p = env;

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -465,7 +465,7 @@ for scenario in scenarios:
       for worker in scenario.workers:
         worker.start()
       jobs = [scenario.jobspec]
-      if len(scenario.workers) > 0:
+      if scenario.workers:
         jobs.append(create_quit_jobspec(scenario.workers, remote_host=args.remote_driver_host))
       scenario_failures, resultset = jobset.run(jobs, newline_on_success=True, maxjobs=1)
       total_scenario_failures += scenario_failures

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -464,9 +464,10 @@ for scenario in scenarios:
     try:
       for worker in scenario.workers:
         worker.start()
-      scenario_failures, resultset = jobset.run([scenario.jobspec,
-                                                create_quit_jobspec(scenario.workers, remote_host=args.remote_driver_host)],
-                                                newline_on_success=True, maxjobs=1)
+      jobs = [scenario.jobspec]
+      if len(scenario.workers) > 0:
+        jobs.append(create_quit_jobspec(scenario.workers, remote_host=args.remote_driver_host))
+      scenario_failures, resultset = jobset.run(jobs, newline_on_success=True, maxjobs=1)
       total_scenario_failures += scenario_failures
       merged_resultset = dict(itertools.chain(merged_resultset.iteritems(),
                                               resultset.iteritems()))


### PR DESCRIPTION
fixes https://github.com/grpc/grpc/issues/8967#event-882988054

It looks like main issue is that `QPS_WORKERS= bins/opt/qps_json_driver --quit` hangs.

Also it's probably best to skip the quit job when there aren't any workers.