### PR TITLE
Perform quit operations in a useful order in Node perf tests

### DIFF
--- a/src/node/performance/worker_service_impl.js
+++ b/src/node/performance/worker_service_impl.js
@@ -55,9 +55,8 @@ module.exports = function WorkerServiceImpl(benchmark_impl, server) {
   }
 
   this.quitWorker = function quitWorker(call, callback) {
-    server.tryShutdown(function() {
-      callback(null, {});
-    });
+    callback(null, {});
+    server.tryShutdown(function() {});
   };
 
   this.runClient = function runClient(call) {


### PR DESCRIPTION
This fixes #8968.

It turns out that waiting to respond to the `quit` method until after the server has finished shutting down is not a good strategy.