### PR TITLE
Fix handling of streams waiting for concurrency

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.c
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.c
@@ -1622,8 +1622,10 @@ void grpc_chttp2_mark_stream_closed(grpc_exec_ctx *exec_ctx,
     if (s->id != 0) {
       remove_stream(exec_ctx, t, s->id,
                     removal_error(GRPC_ERROR_REF(error), s, "Stream removed"));
+    } else {
+      /* Purge streams waiting on concurrency still waiting for id assignment */
+      grpc_chttp2_list_remove_waiting_for_concurrency(t, s);
     }
-    grpc_chttp2_list_remove_waiting_for_concurrency(t, s);
     GRPC_CHTTP2_STREAM_UNREF(exec_ctx, s, "chttp2");
   }
   GRPC_ERROR_UNREF(error);

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.c
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.c
@@ -1623,6 +1623,7 @@ void grpc_chttp2_mark_stream_closed(grpc_exec_ctx *exec_ctx,
       remove_stream(exec_ctx, t, s->id,
                     removal_error(GRPC_ERROR_REF(error), s, "Stream removed"));
     }
+    grpc_chttp2_list_remove_waiting_for_concurrency(t, s);
     GRPC_CHTTP2_STREAM_UNREF(exec_ctx, s, "chttp2");
   }
   GRPC_ERROR_UNREF(error);

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -496,6 +496,8 @@ void grpc_chttp2_list_add_waiting_for_concurrency(grpc_chttp2_transport *t,
                                                   grpc_chttp2_stream *s);
 int grpc_chttp2_list_pop_waiting_for_concurrency(grpc_chttp2_transport *t,
                                                  grpc_chttp2_stream **s);
+void grpc_chttp2_list_remove_waiting_for_concurrency(grpc_chttp2_transport *t,
+                                                     grpc_chttp2_stream *s);
 
 void grpc_chttp2_list_add_stalled_by_transport(grpc_chttp2_transport *t,
                                                grpc_chttp2_stream *s);

--- a/src/core/ext/transport/chttp2/transport/stream_lists.c
+++ b/src/core/ext/transport/chttp2/transport/stream_lists.c
@@ -158,6 +158,11 @@ int grpc_chttp2_list_pop_waiting_for_concurrency(grpc_chttp2_transport *t,
   return stream_list_pop(t, s, GRPC_CHTTP2_LIST_WAITING_FOR_CONCURRENCY);
 }
 
+void grpc_chttp2_list_remove_waiting_for_concurrency(grpc_chttp2_transport *t,
+                                                     grpc_chttp2_stream *s) {
+  stream_list_maybe_remove(t, s, GRPC_CHTTP2_LIST_WAITING_FOR_CONCURRENCY);
+}
+
 void grpc_chttp2_list_add_stalled_by_transport(grpc_chttp2_transport *t,
                                                grpc_chttp2_stream *s) {
   stream_list_add(t, s, GRPC_CHTTP2_LIST_STALLED_BY_TRANSPORT);


### PR DESCRIPTION
Failure scenario:
Under load, a stream is added to the "waiting for concurrency list" due to the load. The associated call times out (`deadline_timer`) and it's cancelled (`UNREF destroy`). However, the stream is still in the waiting for concurrency list, which is processed in `maybe_start_processing`, popping it after it's been destroyed. Trace:

```
CALL_STACK 0x6220004bfab8:0x6220004bf100   REF 1->2 chttp2
CALL_STACK 0x6220004bfab8:0x6220004bf100   REF 2->3 deadline_timer
CALL_STACK 0x6220004bfab8:0x6220004bf100   REF 3->4 completion
CALL_STACK 0x6220004bfab8:0x6220004bf100   REF 4->5 perform_stream_op
Added 0x6220004bfab8 to CONCURRENCY_LIST
CALL_STACK 0x6220004bfab8:0x6220004bf100 UNREF 5->4 perform_stream_op
CALL_STACK 0x6220004bfab8:0x6220004bf100   REF 4->5 perform_stream_op
CALL_STACK 0x6220004bfab8:0x6220004bf100 UNREF 5->4 deadline_timer
REMOVE STREAM 0x6220004bfab8 , id: 0
CALL_STACK 0x6220004bfab8:0x6220004bf100 UNREF 4->3 chttp2
CALL_STACK 0x6220004bfab8:0x6220004bf100 UNREF 3->2 perform_stream_op
CALL_STACK 0x6220004bfab8:0x6220004bf100 UNREF 2->1 completion
CALL_STACK 0x6220004bfab8:0x6220004bf100 UNREF 1->0 destroy
Popped 0x6220004bfab8 from CONCURRENCY_LIST
maybe_start processing 0x6220004bfab8
CALL_STACK 0x6220004bfab8:0x6220004bf100   REF 0->1 chttp2_writing:become
```

This change makes sure the waiting for concurrency list is purged when the stream is closed.

---

Tests are failing with known issues:
- Performance PR: #8967 (fix at #8969)

