### PR TITLE
node: upgrade to protobuf.js 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ py34/
 node_modules
 src/node/extension_binary/
 
+# NPM debug
+npm-debug.log
+
 # gcov coverage data
 reports
 coverage

--- a/package.json
+++ b/package.json
@@ -32,9 +32,10 @@
   "dependencies": {
     "arguejs": "^0.2.3",
     "lodash": "^4.15.0",
+    "long": "^3.2.0",
     "nan": "^2.0.0",
     "node-pre-gyp": "^0.6.0",
-    "protobufjs": "^5.0.0"
+    "protobufjs": "^6.0.0"
   },
   "devDependencies": {
     "async": "^2.0.1",
@@ -48,7 +49,7 @@
     "jshint": "^2.5.0",
     "minimist": "^1.1.0",
     "mocha": "^3.0.2",
-    "mocha-jenkins-reporter": "^0.2.3",
+    "mocha-jenkins-reporter": "^0.3.0",
     "poisson-process": "^0.2.1"
   },
   "engines": {

--- a/src/node/index.js
+++ b/src/node/index.js
@@ -55,73 +55,109 @@ var grpc = require('./src/grpc_extension');
 grpc.setDefaultRootsPem(fs.readFileSync(SSL_ROOTS_PATH, 'ascii'));
 
 /**
- * Load a gRPC object from an existing ProtoBuf.Reflect object.
- * @param {ProtoBuf.Reflect.Namespace} value The ProtoBuf object to load.
+ * Build a GRPC tree from an existing ProtoBuf.Root object.
+ * @param {ProtoBuf.Root} value The ProtoBuf root object to transform.
  * @param {Object=} options Options to apply to the loaded object
- * @return {Object<string, *>} The resulting gRPC object
+ * @return {Object=} The resultant GRPC tree.
  */
 exports.loadObject = function loadObject(value, options) {
-  var result = {};
-  if (value.className === 'Namespace') {
-    _.each(value.children, function(child) {
-      result[child.name] = loadObject(child, options);
-    });
-    return result;
-  } else if (value.className === 'Service') {
-    return client.makeProtobufClientConstructor(value, options);
-  } else if (value.className === 'Message' || value.className === 'Enum') {
-    return value.build();
-  } else {
+  if (!value) {
     return value;
   }
+  options = options || {};
+
+  if (value.methods && Object.keys(value.methods).length) {
+    value.resolveAll();
+    return client.makeProtobufClientConstructor(value, options);
+  }
+
+  var result = {};
+
+  if (value.fields && value.encode) {
+    result = common.makeMessageConstructor(value, options);
+  }
+
+  if (value.nested) {
+    for (let name in value.nested) {
+      if (!value.nested.hasOwnProperty(name)) {
+        continue;
+      }
+      result[name] = loadObject(value.nested[name], options);
+    }
+  }
+
+  return result;
 };
 
 var loadObject = exports.loadObject;
 
 /**
+ * Compat: apply a ProtoBuf.JS 5 {root, file} object
+ * to a ProtoBuf.Root.
+ * @param {Object=} filename Filename object.
+ * @param {ProtoBuf.Root=} ProtoBuf.Root to apply to.
+ * @return {string} The filename to pass to ProtoBuf.load()
+ */
+function applyProtoRoot(filename, root) {
+  if (_.isString(filename)) {
+    return filename;
+  }
+  filename.root = path.resolve(filename.root) + '/';
+  root.resolvePath = function(originPath, importPath, alreadyNormalized) {
+    return ProtoBuf.util.path.resolve(filename.root,
+      importPath,
+      alreadyNormalized);
+  };
+  return filename.file;
+}
+
+/**
  * Load a gRPC object from a .proto file. The options object can provide the
  * following options:
- * - convertFieldsToCamelCase: Loads this file with that option on protobuf.js
- *   set as specified. See
- *   https://github.com/dcodeIO/protobuf.js/wiki/Advanced-options for details
  * - binaryAsBase64: deserialize bytes values as base64 strings instead of
  *   Buffers. Defaults to false
+ * - enumsAsStrings: deserialize enum values as strings instead of numeric
+ *   values. Defaults to false.
  * - longsAsStrings: deserialize long values as strings instead of objects.
- *   Defaults to true
- * - deprecatedArgumentOrder: Use the beta method argument order for client
- *   methods, with optional arguments after the callback. Defaults to false.
- *   This option is only a temporary stopgap measure to smooth an API breakage.
- *   It is deprecated, and new code should not use it.
- * @param {string|{root: string, file: string}} filename The file to load
- * @param {string=} format The file format to expect. Must be either 'proto' or
- *     'json'. Defaults to 'proto'
+ *   Defaults to true.
+ * @param {string} filename The file to load
+ * @param {string=} format Unused.
  * @param {Object=} options Options to apply to the loaded file
- * @return {Object<string, *>} The resulting gRPC object
+ * @return {ProtoBuf.Root=} ProtoBuf.Root with services filled.
  */
 exports.load = function load(filename, format, options) {
-  if (!format) {
-    format = 'proto';
+  var rootNs = new ProtoBuf.Root();
+  rootNs.loadSync(applyProtoRoot(filename, rootNs));
+  return loadObject(rootNs);
+};
+
+/**
+ * Load a gRPC object from a .proto file asynchronously. The options object
+ * can provide the following options:
+ * - binaryAsBase64: deserialize bytes values as base64 strings instead of
+ *   Buffers. Defaults to false
+ * - enumsAsStrings: deserialize enum values as strings instead of numeric
+ *   values. Defaults to false.
+ * - longsAsStrings: deserialize long values as strings instead of objects.
+ *   Defaults to true
+ * @param {string|{root: string, file: string}} filename The file to load
+ * @param {Object=} options Options to apply to the loaded file
+ * @param {function(?Error, ProtoBuf.Root=)} callback Callback function for
+ *   result.
+ * @return {undefined}
+ */
+exports.loadAsync = function loadAsync(filename, options, callback) {
+  if (typeof options === 'function') {
+    callback = options;
+    options = undefined;
   }
-  var convertFieldsToCamelCaseOriginal = ProtoBuf.convertFieldsToCamelCase;
-  if(options && options.hasOwnProperty('convertFieldsToCamelCase')) {
-    ProtoBuf.convertFieldsToCamelCase = options.convertFieldsToCamelCase;
-  }
-  var builder;
-  try {
-    switch(format) {
-      case 'proto':
-      builder = ProtoBuf.loadProtoFile(filename);
-      break;
-      case 'json':
-      builder = ProtoBuf.loadJsonFile(filename);
-      break;
-      default:
-      throw new Error('Unrecognized format "' + format + '"');
+  var rootNs = new ProtoBuf.Root();
+  rootNs.load(applyProtoRoot(filename, rootNs), function(err, res) {
+    if (err) {
+      return callback(err, undefined);
     }
-  } finally {
-    ProtoBuf.convertFieldsToCamelCase = convertFieldsToCamelCaseOriginal;
-  }
-  return loadObject(builder.ns, options);
+    return callback(null, loadObject(res, options));
+  });
 };
 
 var log_template = _.template(

--- a/src/node/interop/interop_client.js
+++ b/src/node/interop/interop_client.js
@@ -110,8 +110,8 @@ function emptyUnary(client, done) {
  */
 function largeUnary(client, done) {
   var arg = {
-    response_type: 'COMPRESSABLE',
-    response_size: 314159,
+    responseType: 'COMPRESSABLE',
+    responseSize: 314159,
     payload: {
       body: zeroBuffer(271828)
     }
@@ -135,7 +135,7 @@ function largeUnary(client, done) {
 function clientStreaming(client, done) {
   var call = client.streamingInputCall(function(err, resp) {
     assert.ifError(err);
-    assert.strictEqual(resp.aggregated_payload_size, 74922);
+    assert.strictEqual(resp.aggregatedPayloadSize, 74922);
     if (done) {
       done();
     }
@@ -155,8 +155,8 @@ function clientStreaming(client, done) {
  */
 function serverStreaming(client, done) {
   var arg = {
-    response_type: 'COMPRESSABLE',
-    response_parameters: [
+    responseType: 'COMPRESSABLE',
+    responseParameters: [
       {size: 31415},
       {size: 9},
       {size: 2653},
@@ -169,7 +169,7 @@ function serverStreaming(client, done) {
     assert(resp_index < 4);
     assert.strictEqual(value.payload.type, 'COMPRESSABLE');
     assert.strictEqual(value.payload.body.length,
-                       arg.response_parameters[resp_index].size);
+                       arg.responseParameters[resp_index].size);
     resp_index += 1;
   });
   call.on('end', function() {
@@ -191,7 +191,7 @@ function serverStreaming(client, done) {
  */
 function pingPong(client, done) {
   var payload_sizes = [27182, 8, 1828, 45904];
-  var response_sizes = [31415, 9, 2653, 58979];
+  var responseSizes = [31415, 9, 2653, 58979];
   var call = client.fullDuplexCall();
   call.on('status', function(status) {
     assert.strictEqual(status.code, grpc.status.OK);
@@ -201,23 +201,23 @@ function pingPong(client, done) {
   });
   var index = 0;
   call.write({
-      response_type: 'COMPRESSABLE',
-      response_parameters: [
-        {size: response_sizes[index]}
+      responseType: 'COMPRESSABLE',
+      responseParameters: [
+        {size: responseSizes[index]}
       ],
       payload: {body: zeroBuffer(payload_sizes[index])}
   });
   call.on('data', function(response) {
     assert.strictEqual(response.payload.type, 'COMPRESSABLE');
-    assert.equal(response.payload.body.length, response_sizes[index]);
+    assert.equal(response.payload.body.length, responseSizes[index]);
     index += 1;
     if (index === 4) {
       call.end();
     } else {
       call.write({
-        response_type: 'COMPRESSABLE',
-        response_parameters: [
-          {size: response_sizes[index]}
+        responseType: 'COMPRESSABLE',
+        responseParameters: [
+          {size: responseSizes[index]}
         ],
         payload: {body: zeroBuffer(payload_sizes[index])}
       });
@@ -268,8 +268,8 @@ function cancelAfterBegin(client, done) {
 function cancelAfterFirstResponse(client, done) {
   var call = client.fullDuplexCall();
   call.write({
-      response_type: 'COMPRESSABLE',
-      response_parameters: [
+      responseType: 'COMPRESSABLE',
+      responseParameters: [
         {size: 31415}
       ],
       payload: {body: zeroBuffer(27182)}
@@ -305,8 +305,8 @@ function customMetadata(client, done) {
   metadata.set(ECHO_INITIAL_KEY, 'test_initial_metadata_value');
   metadata.set(ECHO_TRAILING_KEY, new Buffer('ababab', 'hex'));
   var arg = {
-    response_type: 'COMPRESSABLE',
-    response_size: 314159,
+    responseType: 'COMPRESSABLE',
+    responseSize: 314159,
     payload: {
       body: zeroBuffer(271828)
     }
@@ -354,7 +354,7 @@ function customMetadata(client, done) {
 function statusCodeAndMessage(client, done) {
   done = multiDone(done, 2);
   var arg = {
-    response_status: {
+    responseStatus: {
       code: 2,
       message: 'test status message'
     }
@@ -406,13 +406,13 @@ function unimplementedMethod(client, done) {
  */
 function authTest(expected_user, scope, client, done) {
   var arg = {
-    response_type: 'COMPRESSABLE',
-    response_size: 314159,
+    responseType: 'COMPRESSABLE',
+    responseSize: 314159,
     payload: {
       body: zeroBuffer(271828)
     },
-    fill_username: true,
-    fill_oauth_scope: true
+    fillUsername: true,
+    fillOauthScope: true
   };
   client.unaryCall(arg, function(err, resp) {
     assert.ifError(err);
@@ -420,7 +420,7 @@ function authTest(expected_user, scope, client, done) {
     assert.strictEqual(resp.payload.body.length, 314159);
     assert.strictEqual(resp.username, expected_user);
     if (scope) {
-      assert(scope.indexOf(resp.oauth_scope) > -1);
+      assert(scope.indexOf(resp.oauthScope) > -1);
     }
     if (done) {
       done();
@@ -433,7 +433,7 @@ function computeEngineCreds(client, done, extra) {
 }
 
 function serviceAccountCreds(client, done, extra) {
-  authTest(SERVICE_ACCOUNT_EMAIL, extra.oauth_scope, client, done);
+  authTest(SERVICE_ACCOUNT_EMAIL, extra.oauthScope, client, done);
 }
 
 function jwtTokenCreds(client, done, extra) {
@@ -442,13 +442,13 @@ function jwtTokenCreds(client, done, extra) {
 
 function oauth2Test(client, done, extra) {
   var arg = {
-    fill_username: true,
-    fill_oauth_scope: true
+    fillUsername: true,
+    fillOauthScope: true
   };
   client.unaryCall(arg, function(err, resp) {
     assert.ifError(err);
     assert.strictEqual(resp.username, SERVICE_ACCOUNT_EMAIL);
-    assert(extra.oauth_scope.indexOf(resp.oauth_scope) > -1);
+    assert(extra.oauthScope.indexOf(resp.oauthScope) > -1);
     if (done) {
       done();
     }
@@ -459,10 +459,10 @@ function perRpcAuthTest(client, done, extra) {
   (new GoogleAuth()).getApplicationDefault(function(err, credential) {
     assert.ifError(err);
     var arg = {
-      fill_username: true,
-      fill_oauth_scope: true
+      fillUsername: true,
+      fillOauthScope: true
     };
-    var scope = extra.oauth_scope;
+    var scope = extra.oauthScope;
     if (credential.createScopedRequired() && scope) {
       credential = credential.createScoped(scope);
     }
@@ -470,7 +470,7 @@ function perRpcAuthTest(client, done, extra) {
     client.unaryCall(arg, {credentials: creds}, function(err, resp) {
       assert.ifError(err);
       assert.strictEqual(resp.username, SERVICE_ACCOUNT_EMAIL);
-      assert(extra.oauth_scope.indexOf(resp.oauth_scope) > -1);
+      assert(extra.oauthScope.indexOf(resp.oauthScope) > -1);
       if (done) {
         done();
       }
@@ -602,7 +602,7 @@ function runTest(address, host_override, test_case, tls, test_ca, done, extra) {
   };
 
   if (test.getCreds) {
-    test.getCreds(extra.oauth_scope, function(err, new_creds) {
+    test.getCreds(extra.oauthScope, function(err, new_creds) {
       assert.ifError(err);
       execute(err, grpc.credentials.combineChannelCredentials(
           creds, new_creds));
@@ -621,7 +621,7 @@ if (require.main === module) {
   });
   var extra_args = {
     service_account: argv.default_service_account,
-    oauth_scope: argv.oauth_scope
+    oauthScope: argv.oauth_scope
   };
   runTest(argv.server_host + ':' + argv.server_port, argv.server_host_override,
           argv.test_case, argv.use_tls === 'true', argv.use_test_ca === 'true',

--- a/src/node/interop/interop_server.js
+++ b/src/node/interop/interop_server.js
@@ -110,13 +110,13 @@ function handleEmpty(call, callback) {
 function handleUnary(call, callback) {
   echoHeader(call);
   var req = call.request;
-  if (req.response_status) {
-    var status = req.response_status;
+  if (req.responseStatus) {
+    var status = req.responseStatus;
     status.metadata = getEchoTrailer(call);
     callback(status);
     return;
   }
-  var payload = getPayload(req.response_type, req.response_size);
+  var payload = getPayload(req.responseType, req.responseSize);
   callback(null, {payload: payload},
            getEchoTrailer(call));
 }
@@ -134,7 +134,7 @@ function handleStreamingInput(call, callback) {
     aggregate_size += value.payload.body.length;
   });
   call.on('end', function() {
-    callback(null, {aggregated_payload_size: aggregate_size},
+    callback(null, {aggregatedPayloadSize: aggregate_size},
              getEchoTrailer(call));
   });
 }
@@ -153,11 +153,11 @@ function handleStreamingOutput(call) {
     call.emit('error', status);
     return;
   }
-  _.each(req.response_parameters, function(resp_param) {
+  _.each(req.responseParameters, function(resp_param) {
     delay_queue.add(function(next) {
-      call.write({payload: getPayload(req.response_type, resp_param.size)});
+      call.write({payload: getPayload(req.responseType, resp_param.size)});
       next();
-    }, resp_param.interval_us);
+    }, resp_param.intervalUs);
   });
   delay_queue.add(function(next) {
     call.end(getEchoTrailer(call));
@@ -174,17 +174,17 @@ function handleFullDuplex(call) {
   echoHeader(call);
   var delay_queue = new AsyncDelayQueue();
   call.on('data', function(value) {
-    if (value.response_status) {
-      var status = value.response_status;
+    if (value.responseStatus) {
+      var status = value.responseStatus;
       status.metadata = getEchoTrailer(call);
       call.emit('error', status);
       return;
     }
-    _.each(value.response_parameters, function(resp_param) {
+    _.each(value.responseParameters, function(resp_param) {
       delay_queue.add(function(next) {
-        call.write({payload: getPayload(value.response_type, resp_param.size)});
+        call.write({payload: getPayload(value.responseType, resp_param.size)});
         next();
-      }, resp_param.interval_us);
+      }, resp_param.intervalUs);
     });
   });
   call.on('end', function() {

--- a/src/node/test/surface_test.js
+++ b/src/node/test/surface_test.js
@@ -41,7 +41,7 @@ var ProtoBuf = require('protobufjs');
 
 var grpc = require('..');
 
-var math_proto = ProtoBuf.loadProtoFile(__dirname +
+var math_proto = ProtoBuf.loadSync(__dirname +
     '/../../proto/math/math.proto');
 
 var mathService = math_proto.lookup('math.Math');
@@ -85,11 +85,6 @@ describe('File loader', function() {
   it('Should load a json file with the json format', function() {
     assert.doesNotThrow(function() {
       grpc.load(__dirname + '/test_service.json', 'json');
-    });
-  });
-  it('Should fail to load a file with an unknown format', function() {
-    assert.throws(function() {
-      grpc.load(__dirname + '/test_service.proto', 'fake_format');
     });
   });
 });
@@ -283,7 +278,7 @@ describe('Echo service', function() {
   var server;
   var client;
   before(function() {
-    var test_proto = ProtoBuf.loadProtoFile(__dirname + '/echo_service.proto');
+    var test_proto = ProtoBuf.loadSync(__dirname + '/echo_service.proto');
     var echo_service = test_proto.lookup('EchoService');
     server = new grpc.Server();
     server.addProtoService(echo_service, {
@@ -406,7 +401,7 @@ describe('Echo metadata', function() {
   var server;
   var metadata;
   before(function() {
-    var test_proto = ProtoBuf.loadProtoFile(__dirname + '/test_service.proto');
+    var test_proto = ProtoBuf.loadSync(__dirname + '/test_service.proto');
     var test_service = test_proto.lookup('TestService');
     server = new grpc.Server();
     server.addProtoService(test_service, {
@@ -507,7 +502,7 @@ describe('Client malformed response handling', function() {
   var client;
   var badArg = new Buffer([0xFF]);
   before(function() {
-    var test_proto = ProtoBuf.loadProtoFile(__dirname + '/test_service.proto');
+    var test_proto = ProtoBuf.loadSync(__dirname + '/test_service.proto');
     var test_service = test_proto.lookup('TestService');
     var malformed_test_service = {
       unary: {
@@ -614,7 +609,7 @@ describe('Server serialization failure handling', function() {
   var client;
   var server;
   before(function() {
-    var test_proto = ProtoBuf.loadProtoFile(__dirname + '/test_service.proto');
+    var test_proto = ProtoBuf.loadSync(__dirname + '/test_service.proto');
     var test_service = test_proto.lookup('TestService');
     var malformed_test_service = {
       unary: {
@@ -677,7 +672,9 @@ describe('Server serialization failure handling', function() {
     server.start();
   });
   after(function() {
-    server.forceShutdown();
+    if (server) {
+      server.forceShutdown();
+    }
   });
   it('should get an INTERNAL status with a unary call', function(done) {
     client.unary({}, function(err, data) {
@@ -721,7 +718,7 @@ describe('Other conditions', function() {
   var server;
   var port;
   before(function() {
-    var test_proto = ProtoBuf.loadProtoFile(__dirname + '/test_service.proto');
+    var test_proto = ProtoBuf.loadSync(__dirname + '/test_service.proto');
     test_service = test_proto.lookup('TestService');
     server = new grpc.Server();
     var trailer_metadata = new grpc.Metadata();
@@ -1067,7 +1064,7 @@ describe('Call propagation', function() {
   var client;
   var server;
   before(function() {
-    var test_proto = ProtoBuf.loadProtoFile(__dirname + '/test_service.proto');
+    var test_proto = ProtoBuf.loadSync(__dirname + '/test_service.proto');
     test_service = test_proto.lookup('TestService');
     server = new grpc.Server();
     server.addProtoService(test_service, {

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -34,9 +34,10 @@
     "dependencies": {
       "arguejs": "^0.2.3",
       "lodash": "^4.15.0",
+      "long": "^3.2.0",
       "nan": "^2.0.0",
       "node-pre-gyp": "^0.6.0",
-      "protobufjs": "^5.0.0"
+      "protobufjs": "^6.0.0"
     },
     "devDependencies": {
       "async": "^2.0.1",
@@ -50,7 +51,7 @@
       "jshint": "^2.5.0",
       "minimist": "^1.1.0",
       "mocha": "^3.0.2",
-      "mocha-jenkins-reporter": "^0.2.3",
+      "mocha-jenkins-reporter": "^0.3.0",
       "poisson-process": "^0.2.1"
     },
     "engines": {


### PR DESCRIPTION
WIP. Still need to fix some tests.

Fixes #8991.

~~Causes some API surface changes (async load, grpc `loadObject` returns a `ProtoBuf.Root` and is intended to be used with `lookup`).~~

Code is in place to ease the transition from old GRPC code targeting Protobuf.JS 5 internally and Protobuf.JS 6 GRPC code.