### PR TITLE
Readable output from run_tests.py on windows

### DIFF
--- a/tools/run_tests/jobset.py
+++ b/tools/run_tests/jobset.py
@@ -139,16 +139,16 @@ def message(tag, msg, explanatory_text=None, do_newline=False):
       if explanatory_text:
         print(explanatory_text)
       print('%s: %s' % (tag, msg))
-      return
-    sys.stdout.write('%s%s%s\x1b[%d;%dm%s\x1b[0m: %s%s' % (
-        _BEGINNING_OF_LINE,
-        _CLEAR_LINE,
-        '\n%s' % explanatory_text if explanatory_text is not None else '',
-        _COLORS[_TAG_COLOR[tag]][1],
-        _COLORS[_TAG_COLOR[tag]][0],
-        tag,
-        msg,
-        '\n' if do_newline or explanatory_text is not None else ''))
+    else:
+      sys.stdout.write('%s%s%s\x1b[%d;%dm%s\x1b[0m: %s%s' % (
+          _BEGINNING_OF_LINE,
+          _CLEAR_LINE,
+          '\n%s' % explanatory_text if explanatory_text is not None else '',
+          _COLORS[_TAG_COLOR[tag]][1],
+          _COLORS[_TAG_COLOR[tag]][0],
+          tag,
+          msg,
+          '\n' if do_newline or explanatory_text is not None else ''))
     sys.stdout.flush()
   except:
     pass
@@ -406,7 +406,7 @@ class Jobset(object):
         self.resultset[job.GetSpec().shortname].append(job.result)
         self._running.remove(job)
       if dead: return
-      if (not self._travis):
+      if not self._travis and platform_string() != 'windows':
         rstr = '' if self._remaining is None else '%d queued, ' % self._remaining
         if self._remaining is not None and self._completed > 0:
           now = time.time()


### PR DESCRIPTION
1. flush after writing each message
2. Prevents spamming of windows console with "WAITING" messages.

```
WAITING: ETA 34.5 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 34.6 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 34.7 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 34.8 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 34.9 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 35.0 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 35.1 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 35.2 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 35.3 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 35.4 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 35.5 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 35.6 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 35.7 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 35.8 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 35.9 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 36.0 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 36.1 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 36.2 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 36.3 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
WAITING: ETA 36.4 sec; 0 queued, 1 jobs running, 2 complete, 0 failed
```