### PR TITLE
Use snake_case names for default rpc method implementations

### DIFF
--- a/src/ruby/lib/grpc/generic/service.rb
+++ b/src/ruby/lib/grpc/generic/service.rb
@@ -110,7 +110,7 @@ module GRPC
         rpc_descs[name] = RpcDesc.new(name, input, output,
                                       marshal_class_method,
                                       unmarshal_class_method)
-        define_method(name) do
+        define_method(GenericService.underscore(name.to_s).to_sym) do
           fail GRPC::BadStatus, GRPC::Core::StatusCodes::UNIMPLEMENTED
         end
       end


### PR DESCRIPTION
This is what `GRPC::Pool::add_rpc_descs_for` expects. Fixes #9033.