### PR TITLE
Fix Go Docker Backport

### DIFF
--- a/tools/dockerfile/interoptest/grpc_interop_go/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_go/build_interop.sh
@@ -37,7 +37,7 @@ set -e
 git clone --recursive /var/local/jenkins/grpc-go src/google.golang.org/grpc
 
 # Get all gRPC Go dependencies
-(cd src/google.golang.org/grpc && go get -t .)
+(cd src/google.golang.org/grpc && make deps && make testdeps)
 
 # copy service account keys if available
 cp -r /var/local/jenkins/service_account $HOME || true


### PR DESCRIPTION
This backports a previous fix to go docker, #8845, to v1.0.x

This closes #9011