### PR TITLE
Compile on musl libc

### DIFF
--- a/src/core/ext/census/grpc_plugin.c
+++ b/src/core/ext/census/grpc_plugin.c
@@ -31,10 +31,11 @@
  *
  */
 
-#include <limits.h>
 #include <string.h>
 
 #include <grpc/census.h>
+
+#include <limits.h>
 
 #include "src/core/ext/census/grpc_filter.h"
 #include "src/core/lib/channel/channel_stack_builder.h"

--- a/src/core/ext/client_channel/client_channel_plugin.c
+++ b/src/core/ext/client_channel/client_channel_plugin.c
@@ -31,11 +31,11 @@
  *
  */
 
-#include <limits.h>
 #include <stdbool.h>
 #include <string.h>
 
 #include <grpc/support/alloc.h>
+#include <limits.h>
 
 #include "src/core/ext/client_channel/client_channel.h"
 #include "src/core/ext/client_channel/lb_policy_registry.h"

--- a/src/core/ext/load_reporting/load_reporting.c
+++ b/src/core/ext/load_reporting/load_reporting.c
@@ -31,10 +31,10 @@
  *
  */
 
-#include <limits.h>
 #include <string.h>
 
 #include <grpc/support/alloc.h>
+#include <limits.h>
 #include <grpc/support/sync.h>
 
 #include "src/core/ext/load_reporting/load_reporting.h"

--- a/src/core/lib/iomgr/tcp_posix.c
+++ b/src/core/lib/iomgr/tcp_posix.c
@@ -68,7 +68,11 @@
 #ifdef GRPC_MSG_IOVLEN_TYPE
 typedef GRPC_MSG_IOVLEN_TYPE msg_iovlen_type;
 #else
+#ifdef __GLIBC__
 typedef size_t msg_iovlen_type;
+#else
+typedef int msg_iovlen_type;
+#endif
 #endif
 
 int grpc_tcp_trace = 0;

--- a/src/core/lib/support/cpu_linux.c
+++ b/src/core/lib/support/cpu_linux.c
@@ -43,6 +43,7 @@
 #include <sched.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/syscall.h>
 
 #include <grpc/support/cpu.h>
 #include <grpc/support/log.h>
@@ -65,6 +66,18 @@ unsigned gpr_cpu_num_cores(void) {
   gpr_once_init(&once, init_num_cpus);
   return (unsigned)ncpus;
 }
+
+#ifndef __GLIBC__
+static int sched_getcpu() {
+    int c;
+    int s = (int) syscall(SYS_getcpu, &c, NULL, NULL);
+    if (s == -1) {
+        return s;
+    } else {
+        return c;
+    }
+}
+#endif
 
 unsigned gpr_cpu_current_cpu(void) {
   int cpu = sched_getcpu();

--- a/src/core/lib/support/wrap_memcpy.c
+++ b/src/core/lib/support/wrap_memcpy.c
@@ -41,7 +41,10 @@
 
 #ifdef __linux__
 #ifdef __x86_64__
+
+#ifdef __GLIBC__
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
+#endif
 void *__wrap_memcpy(void *destination, const void *source, size_t num) {
   return memcpy(destination, source, num);
 }

--- a/src/core/lib/surface/init_secure.c
+++ b/src/core/lib/surface/init_secure.c
@@ -33,10 +33,10 @@
 
 #include "src/core/lib/surface/init.h"
 
-#include <limits.h>
 #include <string.h>
 
 #include "src/core/lib/debug/trace.h"
+#include <limits.h>
 #include "src/core/lib/security/credentials/credentials.h"
 #include "src/core/lib/security/transport/auth_filters.h"
 #include "src/core/lib/security/transport/secure_endpoint.h"


### PR DESCRIPTION
A set of strawman patches to enable compilation with musl libc, some are of very dubious quality.

Related to #8899.