### PR TITLE
Makefile.template and Makefile: avoid stripping too heavily on MSYS2 / MINGW32 platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,10 +292,17 @@ AR = libtool -no_warning_for_no_symbols -o
 endif
 STRIP ?= strip -x
 else
+ifeq ($(SYSTEM),MINGW32)
+ifeq ($(origin AR), default)
+AR = ar rcs
+endif
+STRIP ?= strip --strip-unneeded
+else
 ifeq ($(origin AR), default)
 AR = ar rcs
 endif
 STRIP ?= strip
+endif
 endif
 endif
 INSTALL ?= install

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -182,10 +182,17 @@
   endif
   STRIP ?= strip -x
   else
+  ifeq ($(SYSTEM),MINGW32)
+  ifeq ($(origin AR), default)
+  AR = ar rcs
+  endif
+  STRIP ?= strip --strip-unneeded
+  else
   ifeq ($(origin AR), default)
   AR = ar rcs
   endif
   STRIP ?= strip
+  endif
   endif
   endif
   INSTALL ?= install


### PR DESCRIPTION
Fixed by using --strip-unneeded also on MINGW32, similar to Linux. Fixes https://github.com/grpc/grpc/issues/6136 