### PR TITLE
Revert "Reduce memory bloat (each server cq is very expensive)"

### DIFF
--- a/include/grpc++/server_builder.h
+++ b/include/grpc++/server_builder.h
@@ -187,7 +187,7 @@ class ServerBuilder {
 
   struct SyncServerSettings {
     SyncServerSettings()
-        : num_cqs(1),
+        : num_cqs(GPR_MAX(gpr_cpu_num_cores(), 4)),
           min_pollers(1),
           max_pollers(INT_MAX),
           cq_timeout_msec(1000) {}


### PR DESCRIPTION
Reverts grpc/grpc#8893

We're holding commits until Python starts working again (I understand this got a green, but there's no way of telling if the integration with anything that got submitted after the tests ran caused a fault).