### PR TITLE
Add slice/slice_buffer to :gpr BUILD target

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -105,6 +105,8 @@ cc_library(
     "src/core/lib/support/wrap_memcpy.c",
   ],
   hdrs = [
+    "include/grpc/slice.h",
+    "include/grpc/slice_buffer.h",
     "include/grpc/support/alloc.h",
     "include/grpc/support/atm.h",
     "include/grpc/support/atm_gcc_atomic.h",


### PR DESCRIPTION
Consuming GRPC into bazel was broken without these lines.