### PR TITLE
Make event order consistent, and make 'end' and 'error' mutually exclusive

### DIFF
--- a/src/node/test/surface_test.js
+++ b/src/node/test/surface_test.js
@@ -179,8 +179,8 @@ describe('Server.prototype.addProtoService', function() {
       call.on('data', function(value) {
         assert.fail('No messages expected');
       });
-      call.on('status', function(status) {
-        assert.strictEqual(status.code, grpc.status.UNIMPLEMENTED);
+      call.on('error', function(err) {
+        assert.strictEqual(err.code, grpc.status.UNIMPLEMENTED);
         done();
       });
     });
@@ -189,8 +189,8 @@ describe('Server.prototype.addProtoService', function() {
       call.on('data', function(value) {
         assert.fail('No messages expected');
       });
-      call.on('status', function(status) {
-        assert.strictEqual(status.code, grpc.status.UNIMPLEMENTED);
+      call.on('error', function(err) {
+        assert.strictEqual(err.code, grpc.status.UNIMPLEMENTED);
         done();
       });
       call.end();


### PR DESCRIPTION
This PR has two different but related changes. The first makes the order in which events are emitted consistent across call types: first the `metadata` event is emitted, then later the `error` event is emitted if there is an error, and finally the `status` event is emitted. This has the effect of ensuring that the same event, `status` is consistently emitted after everything else in every call. This fixes #7705.

The second change ensures that the `end` and the `error` events are mutually exclusive. Since `error` events could already happen at any time, it was already theoretically possible to have `error` events without `end` events. But when handling completed calls that finished with non-OK status, we were always emitting both. According to #8954, some common libraries expect the former behavior, and this change ensures that that is always the case.