### PR TITLE
Use single quotes for JSON string

### DIFF
--- a/src/python/grpcio/grpc/framework/interfaces/face/face.py
+++ b/src/python/grpcio/grpc/framework/interfaces/face/face.py
@@ -119,7 +119,7 @@ class AbortionError(six.with_metaclass(abc.ABCMeta, Exception)):
     self.details = details
 
   def __str__(self):
-    return '%s(code=%s, details="%s")' % (
+    return "%s(code=%s, details='%s')" % (
         self.__class__.__name__, self.code, self.details)
 
 


### PR DESCRIPTION
This means that the double quotes in the JSON string don't need to be
escaped.

Before: AbortionError(code=..., details="{"created":...
After:  AbortionError(code=..., details='{"created":...