### PR TITLE
Allow git submodule update to fall back submodule update --init.

### DIFF
--- a/tools/run_tests/dockerize/docker_run.sh
+++ b/tools/run_tests/dockerize/docker_run.sh
@@ -40,7 +40,7 @@ then
   # clone gRPC submodules, use data from locally cloned submodules where possible
   (cd ${EXTERNAL_GIT_ROOT} && git submodule foreach 'cd /var/local/git/grpc \
   && git submodule update --init --reference ${EXTERNAL_GIT_ROOT}/${name} \
-  ${name}')
+  ${name}' || (cd /var/local/git/grpc && git submodule update --init))
 else
   mkdir -p "/var/local/git/grpc/$RELATIVE_COPY_PATH"
   cp -r "$EXTERNAL_GIT_ROOT/$RELATIVE_COPY_PATH"/* "/var/local/git/grpc/$RELATIVE_COPY_PATH"


### PR DESCRIPTION
In certain docker images, like python manylinux, the git version
has issues with the --reference flag.

Fixes:
#9029

Build:
https://grpc-testing.appspot.com/view/Artifacts/job/gRPC_build_artifacts/2384/