### PR TITLE
Use recursive cloning

### DIFF
--- a/tools/run_tests/dockerize/docker_run.sh
+++ b/tools/run_tests/dockerize/docker_run.sh
@@ -36,11 +36,7 @@ set -ex
 if [ "$RELATIVE_COPY_PATH" == "" ]
 then
   mkdir -p /var/local/git
-  git clone $EXTERNAL_GIT_ROOT /var/local/git/grpc
-  # clone gRPC submodules, use data from locally cloned submodules where possible
-  (cd ${EXTERNAL_GIT_ROOT} && git submodule foreach 'cd /var/local/git/grpc \
-  && git submodule update --init --reference ${EXTERNAL_GIT_ROOT}/${name} \
-  ${name}')
+  git clone --recursive $EXTERNAL_GIT_ROOT /var/local/git/grpc
 else
   mkdir -p "/var/local/git/grpc/$RELATIVE_COPY_PATH"
   cp -r "$EXTERNAL_GIT_ROOT/$RELATIVE_COPY_PATH"/* "/var/local/git/grpc/$RELATIVE_COPY_PATH"


### PR DESCRIPTION
The manylinux docker image is on CentOS5, and there are no binary versions of git for this platform that support the --reference command.

Either we can build git from source (which negates any timing benefit), or we can try this approach which works well for older versions of git.