### PR TITLE
Fix invalid tests.json

### DIFF
--- a/src/python/grpcio_tests/tests/tests.json
+++ b/src/python/grpcio_tests/tests/tests.json
@@ -25,7 +25,7 @@
   "_implementations_test.CallCredentialsTest",
   "_implementations_test.ChannelCredentialsTest",
   "_insecure_interop_test.InsecureInteropTest",
-  "_invalid_metadata_test.InvalidMetadataTest"
+  "_invalid_metadata_test.InvalidMetadataTest",
   "_logging_pool_test.LoggingPoolTest",
   "_metadata_code_details_test.MetadataCodeDetailsTest",
   "_metadata_test.MetadataTest",


### PR DESCRIPTION
Add a comma delimiter for "_invalid_metadata_test.InvalidMetadataTest".