### PR TITLE
Change grpcio_tools to grpcio-tools

### DIFF
--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -184,7 +184,7 @@ def extension_modules():
     return extensions
 
 setuptools.setup(
-  name='grpcio_tools',
+  name='grpcio-tools',
   version=grpc_version.VERSION,
   license='3-clause BSD',
   ext_modules=extension_modules(),


### PR DESCRIPTION
This should address the difference in how we ask users to install `grpcio-tools` and the files the user ends up downloading from PyPI.

Marked DNM: needs a quick package test.

---

Failures: #9185, #9186