### PR TITLE
Method to expose the resource quota of a resource user

### DIFF
--- a/src/core/lib/iomgr/resource_quota.c
+++ b/src/core/lib/iomgr/resource_quota.c
@@ -695,6 +695,11 @@ grpc_resource_user *grpc_resource_user_create(
   return resource_user;
 }
 
+grpc_resource_quota *grpc_resource_user_quota(
+    grpc_resource_user *resource_user) {
+  return resource_user->resource_quota;
+}
+
 static void ru_ref_by(grpc_resource_user *resource_user, gpr_atm amount) {
   GPR_ASSERT(amount > 0);
   GPR_ASSERT(gpr_atm_no_barrier_fetch_add(&resource_user->refs, amount) != 0);

--- a/src/core/lib/iomgr/resource_quota.h
+++ b/src/core/lib/iomgr/resource_quota.h
@@ -88,8 +88,12 @@ typedef struct grpc_resource_user grpc_resource_user;
 
 grpc_resource_user *grpc_resource_user_create(
     grpc_resource_quota *resource_quota, const char *name);
+
+/* Returns a borrowed reference to the underlying resource quota for this
+   resource user. */
 grpc_resource_quota *grpc_resource_user_quota(
     grpc_resource_user *resource_user);
+
 void grpc_resource_user_ref(grpc_resource_user *resource_user);
 void grpc_resource_user_unref(grpc_exec_ctx *exec_ctx,
                               grpc_resource_user *resource_user);

--- a/src/core/lib/iomgr/resource_quota.h
+++ b/src/core/lib/iomgr/resource_quota.h
@@ -88,6 +88,8 @@ typedef struct grpc_resource_user grpc_resource_user;
 
 grpc_resource_user *grpc_resource_user_create(
     grpc_resource_quota *resource_quota, const char *name);
+grpc_resource_quota *grpc_resource_user_quota(
+    grpc_resource_user *resource_user);
 void grpc_resource_user_ref(grpc_resource_user *resource_user);
 void grpc_resource_user_unref(grpc_exec_ctx *exec_ctx,
                               grpc_resource_user *resource_user);


### PR DESCRIPTION
I have code that will get the resource_user from an endpoint, get the quota from that resource_user, and then pass the quota to grpc_tcp_create(). I need to be able to get the quota from the resource_user.
