### PR TITLE
attach trailing metadata to ruby bidi call op when it's received

### DIFF
--- a/src/ruby/lib/grpc/generic/bidi_call.rb
+++ b/src/ruby/lib/grpc/generic/bidi_call.rb
@@ -200,6 +200,7 @@ module GRPC
             if is_client
               batch_result = @call.run_batch(RECV_STATUS_ON_CLIENT => nil)
               @call.status = batch_result.status
+              @call.trailing_metadata = @call.status.metadata if @call.status
               batch_result.check_status
               GRPC.logger.debug("bidi-read-loop: done status #{@call.status}")
             end


### PR DESCRIPTION
cc @ncteisen, should allow custom metadata interop test in ruby.

It gets attached at the end of the rest of the client call types but isn't at the end of the bidi call.