### PR TITLE
change ruby default unimplemented ruby server handler to have two aguments

### DIFF
--- a/src/ruby/lib/grpc/generic/service.rb
+++ b/src/ruby/lib/grpc/generic/service.rb
@@ -110,7 +110,7 @@ module GRPC
         rpc_descs[name] = RpcDesc.new(name, input, output,
                                       marshal_class_method,
                                       unmarshal_class_method)
-        define_method(GenericService.underscore(name.to_s).to_sym) do
+        define_method(GenericService.underscore(name.to_s).to_sym) do |_, _|
           fail GRPC::BadStatus.new_status_exception(
             GRPC::Core::StatusCodes::UNIMPLEMENTED)
         end


### PR DESCRIPTION
fixes https://github.com/grpc/grpc/issues/9188

default method handler should fail with bad status "unimplemented" exception but was getting a "wrong number of arguments" error

cc @ncteisen 