### PR TITLE
Define __dir__ on Python _DynamicStub instances.

### DIFF
--- a/src/python/grpcio/grpc/beta/_client_adaptations.py
+++ b/src/python/grpcio/grpc/beta/_client_adaptations.py
@@ -543,6 +543,9 @@ class _DynamicStub(face.DynamicStub):
     else:
       raise AttributeError('_DynamicStub object has no attribute "%s"!' % attr)
 
+  def __dir__(self):
+    return self._cardinalities.keys()
+
   def __enter__(self):
     return self
 


### PR DESCRIPTION
A minor point of annoyance I've found when working with GRPC's generated Python code is that `dir()`, doesn't produce useful output for stubs, because attribute accesses are dynamically dispatched based on the contents of `self._cardinalities`.  This becomes most notable in fancy shells like IPython, which use the output of `__dir__` to generate autocomplete suggestions.

This patch makes `_DynamicStub.__dir__` return the list of attributes that the user is likely to be actually interested in, namely the list of keys available in `self._cardinalities`.

I'm happy to add a test for this if it's an acceptable change, though someone may have to show me the right place to add such a test.