### PR TITLE
interop-test-descriptions.md: correct proto for custom_metadata

### DIFF
--- a/doc/interop-test-descriptions.md
+++ b/doc/interop-test-descriptions.md
@@ -716,7 +716,9 @@ Procedure:
 
     ```
     {
-      response_size: 314159
+      response_parameters:{
+        size: 314159
+      }
       payload:{
         body: 271828 bytes of zeros
       }


### PR DESCRIPTION
The custom_metadata test description should use response_parameters for the FullDuplexCall. 