### PR TITLE
Fix ruby:{python,csharp,csharpcoreclr}_server behavior

### DIFF
--- a/src/ruby/pb/test/client.rb
+++ b/src/ruby/pb/test/client.rb
@@ -575,7 +575,7 @@ class NamedTests
     seen_correct_exception = false
     begin
       resp = @stub.full_duplex_call([duplex_req])
-      resp.next # triggers initial req to be sent
+      resp.each { |r| }
     rescue GRPC::Unknown => e
       if e.details != message
         fail AssertionError,


### PR DESCRIPTION
The new advanced interop tests for ruby failed these tests:

tests.cloud_to_cloud:ruby:python_server:status_code_and_message
tests.cloud_to_cloud:ruby:csharpcoreclr_server:status_code_and_message
tests.cloud_to_cloud:ruby:csharp_server:status_code_and_message

This fixes that.