### PR TITLE
Pass an iterator rather than an iterable in _not_found_test

### DIFF
--- a/src/python/grpcio_tests/tests/unit/beta/_not_found_test.py
+++ b/src/python/grpcio_tests/tests/unit/beta/_not_found_test.py
@@ -62,7 +62,7 @@ class NotFoundTest(unittest.TestCase):
 
     def test_future_stream_unary_not_found(self):
         rpc_future = self._generic_stub.future_stream_unary(
-            'grupe', 'mevvod', [b'def'], test_constants.LONG_TIMEOUT)
+            'grupe', 'mevvod', iter([b'def']), test_constants.LONG_TIMEOUT)
         with self.assertRaises(face.LocalError) as exception_assertion_context:
             rpc_future.result()
         self.assertIs(exception_assertion_context.exception.code,


### PR DESCRIPTION
Fixes [issue 9309](https://github.com/grpc/grpc/issues/9309).