### PR TITLE
Fix various php bugs

### DIFF
--- a/src/php/bin/generate_proto_php.sh
+++ b/src/php/bin/generate_proto_php.sh
@@ -39,12 +39,13 @@ protoc --proto_path=src/proto/math \
 
 # replace the Empty message with EmptyMessage
 # because Empty is a PHP reserved word
+output_file=$(mktemp)
 sed 's/message Empty/message EmptyMessage/g' \
-  src/proto/grpc/testing/empty.proto > empty.proto
-mv empty.proto ./src/proto/grpc/testing
+  src/proto/grpc/testing/empty.proto > $output_file
+mv $output_file ./src/proto/grpc/testing/empty.proto
 sed 's/grpc\.testing\.Empty/grpc\.testing\.EmptyMessage/g' \
-  src/proto/grpc/testing/test.proto > test.proto
-mv test.proto ./src/proto/grpc/testing
+  src/proto/grpc/testing/test.proto > $output_file
+mv $output_file ./src/proto/grpc/testing/test.proto
 
 protoc --proto_path=. \
        --php_out=src/php/tests/interop \
@@ -56,9 +57,9 @@ protoc --proto_path=. \
 
 # change it back
 sed 's/message EmptyMessage/message Empty/g' \
-  src/proto/grpc/testing/empty.proto > empty.proto
-mv empty.proto ./src/proto/grpc/testing
+  src/proto/grpc/testing/empty.proto > $output_file
+mv $output_file ./src/proto/grpc/testing/empty.proto
 sed 's/grpc\.testing\.EmptyMessage/grpc\.testing\.Empty/g' \
-  src/proto/grpc/testing/test.proto > test.proto
-mv test.proto ./src/proto/grpc/testing
+  src/proto/grpc/testing/test.proto > $output_file
+mv $output_file ./src/proto/grpc/testing/test.proto
 

--- a/src/php/bin/generate_proto_php.sh
+++ b/src/php/bin/generate_proto_php.sh
@@ -39,10 +39,12 @@ protoc --proto_path=src/proto/math \
 
 # replace the Empty message with EmptyMessage
 # because Empty is a PHP reserved word
-sed -i 's/message Empty/message EmptyMessage/g' \
-    src/proto/grpc/testing/empty.proto
-sed -i 's/grpc\.testing\.Empty/grpc\.testing\.EmptyMessage/g' \
-    src/proto/grpc/testing/test.proto
+sed 's/message Empty/message EmptyMessage/g' \
+  src/proto/grpc/testing/empty.proto > empty.proto
+mv empty.proto ./src/proto/grpc/testing
+sed 's/grpc\.testing\.Empty/grpc\.testing\.EmptyMessage/g' \
+  src/proto/grpc/testing/test.proto > test.proto
+mv test.proto ./src/proto/grpc/testing
 
 protoc --proto_path=. \
        --php_out=src/php/tests/interop \
@@ -53,7 +55,10 @@ protoc --proto_path=. \
        src/proto/grpc/testing/test.proto
 
 # change it back
-sed -i 's/message EmptyMessage/message Empty/g' \
-    src/proto/grpc/testing/empty.proto
-sed -i 's/grpc\.testing\.EmptyMessage/grpc\.testing\.Empty/g' \
-    src/proto/grpc/testing/test.proto
+sed 's/message EmptyMessage/message Empty/g' \
+  src/proto/grpc/testing/empty.proto > empty.proto
+mv empty.proto ./src/proto/grpc/testing
+sed 's/grpc\.testing\.EmptyMessage/grpc\.testing\.Empty/g' \
+  src/proto/grpc/testing/test.proto > test.proto
+mv test.proto ./src/proto/grpc/testing
+

--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -271,7 +271,7 @@ class BaseStub
      * @return ClientStreamingSurfaceActiveCall The active call object
      */
     public function _clientStreamRequest($method,
-                                         callable $deserialize,
+                                         $deserialize,
                                          array $metadata = [],
                                          array $options = [])
     {
@@ -307,7 +307,7 @@ class BaseStub
      */
     public function _serverStreamRequest($method,
                                          $argument,
-                                         callable $deserialize,
+                                         $deserialize,
                                          array $metadata = [],
                                          array $options = [])
     {
@@ -340,7 +340,7 @@ class BaseStub
      * @return BidiStreamingSurfaceActiveCall The active call object
      */
     public function _bidiRequest($method,
-                                 callable $deserialize,
+                                 $deserialize,
                                  array $metadata = [],
                                  array $options = [])
     {


### PR DESCRIPTION
Found during some manual testing

1. `sed -i` does not work consistently across macOS and linux

2. The `callable` hint in the argument list is causing trouble in the new way we pass the protobuf deserialize function after we switch protobuf implementation.