### PR TITLE
PHP: use a macro to specify extension src dir

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -5,9 +5,9 @@ if test "$PHP_GRPC" != "no"; then
   dnl Write more examples of tests here...
 
   dnl # --with-grpc -> add include path
-  PHP_ADD_INCLUDE(../../grpc/include)
-  PHP_ADD_INCLUDE(../../grpc/src/php/ext/grpc)
-  PHP_ADD_INCLUDE(../../grpc/third_party/boringssl/include)
+  PHP_ADD_INCLUDE(PHP_EXT_SRCDIR()/include)
+  PHP_ADD_INCLUDE(PHP_EXT_SRCDIR()/src/php/ext/grpc)
+  PHP_ADD_INCLUDE(PHP_EXT_SRCDIR()/third_party/boringssl/include)
 
   LIBS="-lpthread $LIBS"
 

--- a/templates/config.m4.template
+++ b/templates/config.m4.template
@@ -7,9 +7,9 @@
     dnl Write more examples of tests here...
 
     dnl # --with-grpc -> add include path
-    PHP_ADD_INCLUDE(../../grpc/include)
-    PHP_ADD_INCLUDE(../../grpc/src/php/ext/grpc)
-    PHP_ADD_INCLUDE(../../grpc/third_party/boringssl/include)
+    PHP_ADD_INCLUDE(PHP_EXT_SRCDIR()/include)
+    PHP_ADD_INCLUDE(PHP_EXT_SRCDIR()/src/php/ext/grpc)
+    PHP_ADD_INCLUDE(PHP_EXT_SRCDIR()/third_party/boringssl/include)
 
     LIBS="-lpthread $LIBS"
 


### PR DESCRIPTION
Fixes #9281 

Now the following 2 scenarios *should* both work

1. I build the PHP extension and get a `grpc-1.1.0.tgz` file. `pecl install grpc-1.1.0.tgz` should continue to work. This should be the same thing as `pecl install grpc` after I upload the .tgz file to pecl. (Coz `pecl install grpc` first downloads the .tgz file and then installs it)

2.  I download the `grpc-1.1.0.tgz` file by doing `pecl download grpc`. Unzip the .tgz file. Then do `phpize`, `./configure`, `make`, `sudo make install` to install the extension manually. Previous this does not work because the `PHP_ADD_INCLUDE` macro in the `config.m4` file is using a relative path to search for headers.