### PR TITLE
adding content-type to the example response

### DIFF
--- a/doc/PROTOCOL-HTTP2.md
+++ b/doc/PROTOCOL-HTTP2.md
@@ -153,6 +153,7 @@ DATA (flags = END_STREAM)
 HEADERS (flags = END_HEADERS)
 :status = 200
 grpc-encoding = gzip
+content-type = application/grpc+proto
 
 DATA
 <Length-Prefixed Message>


### PR DESCRIPTION
This is to bring the Response up to date with the protocol ABNF.

Note: I have not yet contributed a CLA, I am working with my bosses to get a Corporate CLA in place.