### PR TITLE
Change expected error code in Python negative interop client

### DIFF
--- a/src/python/grpcio_tests/tests/http2/negative_http2_client.py
+++ b/src/python/grpcio_tests/tests/http2/negative_http2_client.py
@@ -82,20 +82,22 @@ def _goaway(stub):
 
 def _rst_after_header(stub):
     resp_future = stub.UnaryCall.future(_SIMPLE_REQUEST)
-    _validate_status_code_and_details(resp_future, grpc.StatusCode.UNAVAILABLE,
-                                      "")
+    _validate_status_code_and_details(resp_future, grpc.StatusCode.INTERNAL,
+                                      "Received RST_STREAM with error code 0")
 
 
 def _rst_during_data(stub):
     resp_future = stub.UnaryCall.future(_SIMPLE_REQUEST)
-    _validate_status_code_and_details(resp_future, grpc.StatusCode.UNKNOWN, "")
+    _validate_status_code_and_details(resp_future, grpc.StatusCode.INTERNAL,
+                                      "Received RST_STREAM with error code 0")
 
 
 def _rst_after_data(stub):
     resp_future = stub.UnaryCall.future(_SIMPLE_REQUEST)
     _validate_payload_type_and_length(
         next(resp_future), messages_pb2.COMPRESSABLE, _RESPONSE_SIZE)
-    _validate_status_code_and_details(resp_future, grpc.StatusCode.UNKNOWN, "")
+    _validate_status_code_and_details(resp_future, grpc.StatusCode.INTERNAL,
+                                      "Received RST_STREAM with error code 0")
 
 
 def _ping(stub):
@@ -159,6 +161,7 @@ def _args():
 def _stub(server_host, server_port):
     target = '{}:{}'.format(server_host, server_port)
     channel = grpc.insecure_channel(target)
+    grpc.channel_ready_future(channel).result()
     return test_pb2.TestServiceStub(channel)
 
 


### PR DESCRIPTION
The test now expects to receive StatusCode.INTERNAL when it receives a
RST_STREAM from the server.

This is a subsequent fix following from #9142, which was a bug in the c core that caused RST_STREAM(0) to fail with UNKNOWN instead of INTERNAL

