### PR TITLE
Fix #9355

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -118,7 +118,7 @@ class PythonArtifact:
           environ=environ,
           timeout_seconds=60*60)
     elif self.platform == 'windows':
-      if 'Python27' in self.py_version or 'Python34' in self.py_version:
+      if 'Python2' in self.py_version or 'Python3' in self.py_version:
         environ['EXT_COMPILER'] = 'mingw32'
       else:
         environ['EXT_COMPILER'] = 'msvc'


### PR DESCRIPTION
Now that we're building for Windows on Python 3.6, Python35 needs to be matched to the correct compiler.

Though... Why are we even considering MSVC to begin with? It will *almost* (in the mathematician's sense of almost, as in choose a random number between zero and infinity, what are the chances it's the number 42?) never work.