### PR TITLE
update path to build_artifacts_ruby.sh in jenkins script

### DIFF
--- a/tools/jenkins/build_artifacts.sh
+++ b/tools/jenkins/build_artifacts.sh
@@ -40,7 +40,7 @@ curr_platform="$platform"
 unset platform  # variable named 'platform' breaks the windows build
 
 if [ "$curr_platform" == "linux" ] && [ "$language" == "ruby" ] ; then
-  ./tools/run_tests/build_artifact_ruby.sh
+  ./tools/run_tests/artifacts/build_artifact_ruby.sh
 else
   python tools/run_tests/task_runner.py -f artifact $language $curr_platform $architecture
 fi


### PR DESCRIPTION
fixes https://github.com/grpc/grpc/issues/9354

new build running on https://grpc-testing.appspot.com/job/gRPC_build_artifacts/2597/
(failed)

fixes file not found error, but from the log, waiting on mingw fixes in https://github.com/grpc/grpc/pull/8957
```
make: *** No rule to make target `/tmp/libs/opt/grpc-1.dll'.  Stop.
rake aborted!
```