### PR TITLE
Bazel build rule for //test/cpp/util:grpc_cli

### DIFF
--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -34,8 +34,8 @@ licenses(["notice"])  # 3-clause BSD
 cc_binary(
     name = "testso.so",
     srcs = [],
-    deps = ["//:grpc++_unsecure"],
     linkshared = 1,
+    deps = ["//:grpc++_unsecure"],
 )
 
 cc_library(
@@ -104,5 +104,29 @@ cc_test(
     ],
 )
 
-
-
+cc_binary(
+    name = "grpc_cli",
+    srcs = [
+        "cli_call.cc",
+        "cli_call.h",
+        "cli_credentials.cc",
+        "cli_credentials.h",
+        "config_grpc_cli.h",
+        "grpc_cli.cc",
+        "grpc_tool.cc",
+        "grpc_tool.h",
+        "proto_file_parser.cc",
+        "proto_file_parser.h",
+        "proto_reflection_descriptor_database.cc",
+        "proto_reflection_descriptor_database.h",
+        "service_describer.cc",
+        "service_describer.h",
+        "test_config.h",
+        "test_config_cc.cc",
+    ],
+    deps = [
+        "//:grpc++",
+        "//external:gflags",
+        "//src/proto/grpc/reflection/v1alpha:reflection_proto",
+    ],
+)


### PR DESCRIPTION
Cheers,

Here's a small patchset that makes it possible to build `grpc_cli` using Bazel.

First, to be able to use gflags's Bazel rules, this pulls in the current gflags master.

Then, some Bazel rules seem to have been missing references to some code. This became obvious once grpc_cli was being built.

Next, grpc_cli requires knowledge of the reflection service. Therefore, there's now a rule to build this library from the relevant proto. I've tagged it as `//visibility:public`; let me know if you'd like to restrict this for some reason.

Finally, there's a commit which adds a `cc_binary()` rule for building `grpc_cli` itself.

It could be a bit hacky as I've done this in my spare time; happy to add to the patchset (and perhaps squash resulting commits as required). If you'd prefer an internal CL, feel free to reach out to me internally and let me know where to contribute. I'll adapt the patches accordingly.

Tested only on amd64 Debian with Bazel 0.4.3 (latest stable). I have not tried to build with any other build system except Bazel.