### PR TITLE
fix failures on sweep job to to perf

### DIFF
--- a/tools/jenkins/run_performance_flamegraphs.sh
+++ b/tools/jenkins/run_performance_flamegraphs.sh
@@ -34,23 +34,26 @@ set -ex
 # Enter the gRPC repo root
 cd $(dirname $0)/../..
 
-# scalability with 32cores c++ benchmarks
-tools/run_tests/run_performance_tests.py \
-    -l c++ \
-    --category scalable \
-    --remote_worker_host grpc-performance-server-32core grpc-performance-client-32core grpc-performance-client2-32core \
-    --perf_args "record -F 97 --call-graph dwarf" \
-    --flame_graph_reports cpp_flamegraphs \
-    || EXIT_CODE=1
-
 # scalability with 32cores go benchmarks
 tools/run_tests/run_performance_tests.py \
     -l go \
     --category scalable \
     --remote_worker_host grpc-performance-server-32core grpc-performance-client-32core grpc-performance-client2-32core \
-    --perf_args "record -F 97 -g" \
+    --perf_args "record -c 1000 -g" \
     --flame_graph_reports go_flamegraphs \
     || EXIT_CODE=1
+
+export CONFIG=mutrace
+
+# scalability with 32cores c++ benchmarks
+tools/run_tests/run_performance_tests.py \
+    -l c++ \
+    --category scalable \
+    --remote_worker_host grpc-performance-server-32core grpc-performance-client-32core grpc-performance-client2-32core \
+    --perf_args "record -c 1000 -g" \
+    --flame_graph_reports cpp_flamegraphs \
+    || EXIT_CODE=1
+
 
 exit $EXIT_CODE
 

--- a/tools/jenkins/run_sweep_performance.sh
+++ b/tools/jenkins/run_sweep_performance.sh
@@ -43,7 +43,7 @@ tools/run_tests/run_performance_tests.py \
     --category sweep \
     --bq_result_table performance_test.performance_experiment_32core \
     --remote_worker_host ${SERVER_HOST} ${CLIENT_HOST1} ${CLIENT_HOST2} \
-    --perf_args "record -F 97 --call-graph dwarf" \
+    --perf_args "record -F 19 --call-graph dwarf" \
     || EXIT_CODE=1
 
 exit $EXIT_CODE

--- a/tools/jenkins/run_sweep_performance.sh
+++ b/tools/jenkins/run_sweep_performance.sh
@@ -43,7 +43,6 @@ tools/run_tests/run_performance_tests.py \
     --category sweep \
     --bq_result_table performance_test.performance_experiment_32core \
     --remote_worker_host ${SERVER_HOST} ${CLIENT_HOST1} ${CLIENT_HOST2} \
-    --perf_args "record -F 19 --call-graph dwarf" \
     || EXIT_CODE=1
 
 exit $EXIT_CODE

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -58,6 +58,8 @@ os.chdir(_ROOT)
 
 _REMOTE_HOST_USERNAME = 'jenkins'
 
+_BUILD_CONFIG = os.environ.get('CONFIG') or 'opt'
+
 
 class QpsWorkerJob:
   """Encapsulates a qps worker server job."""
@@ -135,7 +137,7 @@ def create_scenario_jobspec(scenario_json, workers, remote_host=None,
 def create_quit_jobspec(workers, remote_host=None):
   """Runs quit using QPS driver."""
   # setting QPS_WORKERS env variable here makes sure it works with SSH too.
-  cmd = 'QPS_WORKERS="%s" bins/opt/qps_json_driver --quit' % ','.join(w.host_and_port for w in workers)
+  cmd = 'QPS_WORKERS="%s" bins/%s/qps_json_driver --quit' % (','.join(w.host_and_port for w in workers), _BUILD_CONFIG)
   if remote_host:
     user_at_host = '%s@%s' % (_REMOTE_HOST_USERNAME, remote_host)
     cmd = 'ssh %s "cd ~/performance_workspace/grpc/ && "%s' % (user_at_host, pipes.quote(cmd))
@@ -246,7 +248,7 @@ def build_on_remote_hosts(hosts, languages=scenario_config.LANGUAGES.keys(), bui
         jobset.JobSpec(
             cmdline=['tools/run_tests/performance/remote_host_build.sh'] + languages,
             shortname='remote_host_build.%s' % host,
-            environ = {'USER_AT_HOST': user_at_host, 'CONFIG': 'opt'},
+            environ = {'USER_AT_HOST': user_at_host, 'CONFIG': _BUILD_CONFIG},
             timeout_seconds=build_timeout))
   if build_local:
     # Build locally as well
@@ -254,7 +256,7 @@ def build_on_remote_hosts(hosts, languages=scenario_config.LANGUAGES.keys(), bui
         jobset.JobSpec(
             cmdline=['tools/run_tests/performance/build_performance.sh'] + languages,
             shortname='local_build',
-            environ = {'CONFIG': 'opt'},
+            environ = {'CONFIG': _BUILD_CONFIG},
             timeout_seconds=build_timeout))
   jobset.message('START', 'Building.', do_newline=True)
   num_failures, _ = jobset.run(


### PR DESCRIPTION
on sweeps right now, it looks like configurations that make clients use more cpu are having issues with perf:
```
Permission error mapping pages.
Consider increasing /proc/sys/kernel/perf_event_mlock_kb,
or try again with a smaller value of -m/--mmap_pages.
(current value: 4294967295,0)

FAILED: qps_worker_c++_1 [ret=255, pid=21574]
```

right now the linux perf worker init script sets:
```
echo 4096 | sudo tee /proc/sys/kernel/perf_event_mlock_kb
```

this lowers perf arg `-F 97` to `-F 19`, mostly as a trial

I think we could also just increase `perf_event_mlock_kb`  in the init script to be big enough, like 2^33