### PR TITLE
Fixing msan issue in client_ssl.c

### DIFF
--- a/test/core/handshake/client_ssl.c
+++ b/test/core/handshake/client_ssl.c
@@ -104,7 +104,8 @@ static int alpn_select_cb(SSL *ssl, const uint8_t **out, uint8_t *out_len,
   bool grpc_exp_seen = false;
   bool h2_seen = false;
   const char *inp = (const char *)in;
-  for (int i = 0; i < (int)in_len; ++i) {
+  const char *in_end = inp + in_len;
+  while (inp < in_end) {
     const size_t length = (size_t)*inp++;
     if (length == strlen("grpc-exp") && strncmp(inp, "grpc-exp", length) == 0) {
       grpc_exp_seen = true;
@@ -117,6 +118,7 @@ static int alpn_select_cb(SSL *ssl, const uint8_t **out, uint8_t *out_len,
     inp += length;
   }
 
+  GPR_ASSERT(inp == in_end);
   GPR_ASSERT(grpc_exp_seen);
   GPR_ASSERT(h2_seen);
 


### PR DESCRIPTION
See this error (somehow triggered by a new version of boringssl):
https://grpc-testing.appspot.com/job/gRPC_pull_requests_msan_c/1154/testReport/junit/(root)/c_linux_msan/bins_msan_handshake_client_GRPC_POLL_STRATEGY_poll_cv/
In the alpn callback, `in_len` is the size of the `in` buffer and not the number of alpn elements.