### PR TITLE
Fix building of interop_server and interop_client on Windows

### DIFF
--- a/test/core/end2end/data/ssl_test_data.h
+++ b/test/core/end2end/data/ssl_test_data.h
@@ -34,6 +34,10 @@
 #ifndef GRPC_TEST_CORE_END2END_DATA_SSL_TEST_DATA_H
 #define GRPC_TEST_CORE_END2END_DATA_SSL_TEST_DATA_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern const char test_root_cert[];
 extern const char test_server1_cert[];
 extern const char test_server1_key[];
@@ -41,5 +45,9 @@ extern const char test_self_signed_client_cert[];
 extern const char test_self_signed_client_key[];
 extern const char test_signed_client_cert[];
 extern const char test_signed_client_key[];
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* GRPC_TEST_CORE_END2END_DATA_SSL_TEST_DATA_H */

--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -34,8 +34,6 @@
 #include <memory>
 #include <unordered_map>
 
-#include <unistd.h>
-
 #include <gflags/gflags.h>
 #include <grpc++/channel.h>
 #include <grpc++/client_context.h>

--- a/test/cpp/interop/client_helper.cc
+++ b/test/cpp/interop/client_helper.cc
@@ -33,8 +33,6 @@
 
 #include "test/cpp/interop/client_helper.h"
 
-#include <unistd.h>
-
 #include <fstream>
 #include <memory>
 #include <sstream>

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -31,7 +31,6 @@
  *
  */
 
-#include <unistd.h>
 #include <cinttypes>
 #include <fstream>
 #include <memory>
@@ -43,6 +42,7 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
+#include <grpc/support/time.h>
 #include <grpc/support/useful.h>
 
 #include "src/core/lib/transport/byte_stream.h"
@@ -618,7 +618,9 @@ bool InteropClient::DoResponseStreamingWithSlowConsumer() {
     GPR_ASSERT(response.payload().body() ==
                grpc::string(kResponseMessageSize, '\0'));
     gpr_log(GPR_DEBUG, "received message %d", i);
-    usleep(kReceiveDelayMilliSeconds * 1000);
+    gpr_sleep_until(gpr_time_add(
+        gpr_now(GPR_CLOCK_REALTIME),
+        gpr_time_from_millis(kReceiveDelayMilliSeconds, GPR_CLOCK_REALTIME)));
     ++i;
   }
 

--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -31,8 +31,6 @@
  *
  */
 
-#include <unistd.h>
-
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -45,6 +43,7 @@
 #include <grpc++/server_context.h>
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
+#include <grpc/support/time.h>
 #include <grpc/support/useful.h>
 
 #include "src/core/lib/support/string.h"
@@ -348,6 +347,7 @@ void grpc::testing::interop::RunServer(
   std::unique_ptr<Server> server(builder.BuildAndStart());
   gpr_log(GPR_INFO, "Server listening on %s", server_address.str().c_str());
   while (!gpr_atm_no_barrier_load(&g_got_sigint)) {
-    sleep(5);
+    gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
+                                 gpr_time_from_seconds(5, GPR_CLOCK_REALTIME)));
   }
 }

--- a/test/cpp/interop/interop_server_bootstrap.cc
+++ b/test/cpp/interop/interop_server_bootstrap.cc
@@ -32,7 +32,6 @@
  */
 
 #include <signal.h>
-#include <unistd.h>
 
 #include "test/cpp/interop/server_helper.h"
 #include "test/cpp/util/test_config.h"


### PR DESCRIPTION
-- eliminate the use of unitstd.h (not available on windows)
-- make sure "test_server1_key" and similar symbols don't get mangled when compiled with MSVC++

With this change, interop_client and interop_server build successfully on windows (with cmake).