### PR TITLE
Update Name of Python Negative Interop Test

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -406,7 +406,7 @@ class PythonLanguage:
 
   def client_cmd_http2interop(self, args):
     return [ 'py27/bin/python',
-              'src/python/grpcio_tests/tests/http2/_negative_http2_client.py',
+              'src/python/grpcio_tests/tests/http2/negative_http2_client.py',
            ] + args
 
   def cloud_to_prod_env(self):


### PR DESCRIPTION
s/_negative_http2_client/negative_http2_client

The leading underscore was removed in #9348