### PR TITLE
Fixed stream ref issue on exhausted outgoing flow ctrl window

### DIFF
--- a/src/core/ext/transport/chttp2/transport/writing.c
+++ b/src/core/ext/transport/chttp2/transport/writing.c
@@ -76,10 +76,10 @@ static void update_list(grpc_exec_ctx *exec_ctx, grpc_chttp2_transport *t,
 
 static bool stream_ref_if_not_destroyed(gpr_refcount *r) {
   gpr_atm count;
-retry:
-  count = gpr_atm_acq_load(&r->count);
-  if (count == 0) return false;
-  if (!gpr_atm_rel_cas(&r->count, count, count + 1)) goto retry;
+  do {
+    count = gpr_atm_acq_load(&r->count);
+    if (count == 0) return false;
+  } while (!gpr_atm_rel_cas(&r->count, count, count + 1));
   return true;
 }
 

--- a/src/core/ext/transport/chttp2/transport/writing.c
+++ b/src/core/ext/transport/chttp2/transport/writing.c
@@ -200,9 +200,8 @@ bool grpc_chttp2_begin_write(grpc_exec_ctx *exec_ctx,
         } else {
           grpc_chttp2_encode_header(
               exec_ctx, &t->hpack_compressor, s->id, s->send_trailing_metadata,
-              true,
-              t->settings[GRPC_ACKED_SETTINGS]
-                         [GRPC_CHTTP2_SETTINGS_MAX_FRAME_SIZE],
+              true, t->settings[GRPC_ACKED_SETTINGS]
+                               [GRPC_CHTTP2_SETTINGS_MAX_FRAME_SIZE],
               &s->stats.outgoing, &t->outbuf);
         }
         s->send_trailing_metadata = NULL;

--- a/src/core/ext/transport/chttp2/transport/writing.c
+++ b/src/core/ext/transport/chttp2/transport/writing.c
@@ -74,6 +74,15 @@ static void update_list(grpc_exec_ctx *exec_ctx, grpc_chttp2_transport *t,
   GRPC_ERROR_UNREF(error);
 }
 
+static bool stream_ref_if_not_destroyed(gpr_refcount *r) {
+  gpr_atm count;
+retry:
+  count = gpr_atm_acq_load(&r->count);
+  if (count == 0) return false;
+  if (!gpr_atm_rel_cas(&r->count, count, count + 1)) goto retry;
+  return true;
+}
+
 bool grpc_chttp2_begin_write(grpc_exec_ctx *exec_ctx,
                              grpc_chttp2_transport *t) {
   grpc_chttp2_stream *s;
@@ -101,8 +110,11 @@ bool grpc_chttp2_begin_write(grpc_exec_ctx *exec_ctx,
 
   if (t->outgoing_window > 0) {
     while (grpc_chttp2_list_pop_stalled_by_transport(t, &s)) {
-      grpc_chttp2_become_writable(exec_ctx, t, s, false,
-                                  "transport.read_flow_control");
+      if (!t->closed && grpc_chttp2_list_add_writable_stream(t, s) &&
+          stream_ref_if_not_destroyed(&s->refcount->refs)) {
+        grpc_chttp2_initiate_write(exec_ctx, t, false,
+                                   "transport.read_flow_control");
+      }
     }
   }
 
@@ -188,8 +200,9 @@ bool grpc_chttp2_begin_write(grpc_exec_ctx *exec_ctx,
         } else {
           grpc_chttp2_encode_header(
               exec_ctx, &t->hpack_compressor, s->id, s->send_trailing_metadata,
-              true, t->settings[GRPC_ACKED_SETTINGS]
-                               [GRPC_CHTTP2_SETTINGS_MAX_FRAME_SIZE],
+              true,
+              t->settings[GRPC_ACKED_SETTINGS]
+                         [GRPC_CHTTP2_SETTINGS_MAX_FRAME_SIZE],
               &s->stats.outgoing, &t->outbuf);
         }
         s->send_trailing_metadata = NULL;


### PR DESCRIPTION
The bug arises in the following scenario:

1. Outgoing flow control window is depleted, which causes the http2 stream to stall.
1. Eventually, a flow control window updates arrives while there's contention on the stream's lock.
1. This which MAY result in an invalid intertwining of callback invocations, triggering the bug.

The fix avoid incrementing the ref count of a defunct stream. The stream destruction function, which will eventually be invoked, would take care of removing the stream from the transport's lists.