### PR TITLE
Corrected version number of Grpc.Tools in the bat file for the C# example

### DIFF
--- a/examples/csharp/helloworld/generate_protos.bat
+++ b/examples/csharp/helloworld/generate_protos.bat
@@ -34,7 +34,7 @@ setlocal
 @rem enter this directory
 cd /d %~dp0
 
-set TOOLS_PATH=packages\Grpc.Tools.1.0.0\tools\windows_x86
+set TOOLS_PATH=packages\Grpc.Tools.1.0.1\tools\windows_x86
 
 %TOOLS_PATH%\protoc.exe -I../../protos --csharp_out Greeter  ../../protos/helloworld.proto --grpc_out Greeter --plugin=protoc-gen-grpc=%TOOLS_PATH%\grpc_csharp_plugin.exe
 


### PR DESCRIPTION
As per the following line, it is 1.0.1 now: https://github.com/grpc/grpc/blob/6ff81e91c9577a52252460fb029fbbf990cfc7b6/examples/csharp/helloworld/Greeter/packages.config#L7