### PR TITLE
Remove a duplicated gpr_free

### DIFF
--- a/src/core/ext/transport/cronet/transport/cronet_transport.c
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.c
@@ -655,8 +655,6 @@ static void convert_metadata_to_cronet_headers(
     headers[num_headers].key = key;
     headers[num_headers].value = value;
     num_headers++;
-    gpr_free(key);
-    gpr_free(value);
     if (curr == NULL) {
       break;
     }


### PR DESCRIPTION
#9430 is only partly restored after its revert. This PR fixes that by removing two extra gpr_free.