### PR TITLE
Better URI parsing errors detection

### DIFF
--- a/src/core/ext/client_channel/http_proxy.c
+++ b/src/core/ext/client_channel/http_proxy.c
@@ -46,7 +46,7 @@
 char* grpc_get_http_proxy_server() {
   char* uri_str = gpr_getenv("http_proxy");
   if (uri_str == NULL) return NULL;
-  grpc_uri* uri = grpc_uri_parse(uri_str, false /* suppress_errors */);
+  grpc_uri* uri = grpc_uri_parse(uri_str, false /* suppress_errors */, NULL);
   char* proxy_name = NULL;
   if (uri == NULL || uri->authority == NULL) {
     gpr_log(GPR_ERROR, "cannot parse value of 'http_proxy' env var");

--- a/src/core/ext/client_channel/resolver_registry.c
+++ b/src/core/ext/client_channel/resolver_registry.c
@@ -74,6 +74,10 @@ void grpc_resolver_registry_set_default_prefix(
   strcpy(g_default_resolver_prefix, default_resolver_prefix);
 }
 
+const char *grpc_resolver_registry_get_default_prefix() {
+  return g_default_resolver_prefix;
+}
+
 void grpc_register_resolver_type(grpc_resolver_factory *factory) {
   int i;
   for (i = 0; i < g_number_of_resolvers; i++) {

--- a/src/core/ext/client_channel/resolver_registry.c
+++ b/src/core/ext/client_channel/resolver_registry.c
@@ -114,16 +114,16 @@ static grpc_resolver_factory *resolve_factory(const char *target,
   grpc_resolver_factory *factory = NULL;
 
   GPR_ASSERT(uri != NULL);
-  *uri = grpc_uri_parse(target, 1);
+  *uri = grpc_uri_parse(target, true, NULL);
   factory = lookup_factory_by_uri(*uri);
   if (factory == NULL) {
     grpc_uri_destroy(*uri);
     gpr_asprintf(canonical_target, "%s%s", g_default_resolver_prefix, target);
-    *uri = grpc_uri_parse(*canonical_target, 1);
+    *uri = grpc_uri_parse(*canonical_target, true, NULL);
     factory = lookup_factory_by_uri(*uri);
     if (factory == NULL) {
-      grpc_uri_destroy(grpc_uri_parse(target, 0));
-      grpc_uri_destroy(grpc_uri_parse(*canonical_target, 0));
+      grpc_uri_destroy(grpc_uri_parse(target, false, NULL));
+      grpc_uri_destroy(grpc_uri_parse(*canonical_target, false, NULL));
       gpr_log(GPR_ERROR, "don't know how to resolve '%s' or '%s'", target,
               *canonical_target);
     }

--- a/src/core/ext/client_channel/resolver_registry.h
+++ b/src/core/ext/client_channel/resolver_registry.h
@@ -43,6 +43,9 @@ void grpc_resolver_registry_shutdown(void);
 /** Set the default URI prefix to \a default_prefix. */
 void grpc_resolver_registry_set_default_prefix(const char *default_prefix);
 
+/** Return the default URI prefix */
+const char *grpc_resolver_registry_get_default_prefix();
+
 /** Register a resolver type.
     URI's of \a scheme will be resolved with the given resolver.
     If \a priority is greater than zero, then the resolver will be eligible

--- a/src/core/ext/client_channel/subchannel.c
+++ b/src/core/ext/client_channel/subchannel.c
@@ -789,7 +789,7 @@ grpc_call_stack *grpc_subchannel_call_get_call_stack(
 }
 
 static void grpc_uri_to_sockaddr(char *uri_str, grpc_resolved_address *addr) {
-  grpc_uri *uri = grpc_uri_parse(uri_str, 0 /* suppress_errors */);
+  grpc_uri *uri = grpc_uri_parse(uri_str, false /* suppress_errors */, NULL);
   GPR_ASSERT(uri != NULL);
   if (strcmp(uri->scheme, "ipv4") == 0) {
     GPR_ASSERT(parse_ipv4(uri, addr));

--- a/src/core/ext/client_channel/uri_parser.h
+++ b/src/core/ext/client_channel/uri_parser.h
@@ -50,8 +50,19 @@ typedef struct {
   char *fragment;
 } grpc_uri;
 
-/** parse a uri, return NULL on failure */
-grpc_uri *grpc_uri_parse(const char *uri_text, int suppress_errors);
+typedef enum {
+  GRPC_URI_SECTION_NONE = 0,
+  GRPC_URI_SECTION_SCHEME,
+  GRPC_URI_SECTION_AUTHORITY,
+  GRPC_URI_SECTION_PATH,
+  GRPC_URI_SECTION_QUERY,
+  GRPC_URI_SECTION_FRAGMENT
+} grpc_uri_section;
+
+/** parse a uri, return NULL on failure and set \a error_section (if not NULL)
+ * to the lefmost part of the URI that failed parsing */
+grpc_uri *grpc_uri_parse(const char *uri_text, int suppress_errors,
+                         grpc_uri_section *error_section);
 
 /** return the part of a query string after the '=' in "?key=xxx&...", or NULL
  * if key is not present */

--- a/src/core/ext/lb_policy/grpclb/grpclb.c
+++ b/src/core/ext/lb_policy/grpclb/grpclb.c
@@ -778,7 +778,7 @@ static grpc_lb_policy *glb_create(grpc_exec_ctx *exec_ctx,
   arg = grpc_channel_args_find(args->args, GRPC_ARG_SERVER_URI);
   GPR_ASSERT(arg != NULL);
   GPR_ASSERT(arg->type == GRPC_ARG_STRING);
-  grpc_uri *uri = grpc_uri_parse(arg->value.string, true);
+  grpc_uri *uri = grpc_uri_parse(arg->value.string, true, NULL);
   GPR_ASSERT(uri->path[0] != '\0');
   glb_policy->server_name =
       gpr_strdup(uri->path[0] == '/' ? uri->path + 1 : uri->path);

--- a/src/core/ext/transport/chttp2/client/secure/secure_channel_create.c
+++ b/src/core/ext/transport/chttp2/client/secure/secure_channel_create.c
@@ -39,6 +39,8 @@
 #include <grpc/support/string_util.h>
 
 #include "src/core/ext/client_channel/client_channel.h"
+#include "src/core/ext/client_channel/resolver_registry.h"
+#include "src/core/ext/client_channel/uri_parser.h"
 #include "src/core/ext/transport/chttp2/client/chttp2_connector.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/security/credentials/credentials.h"
@@ -66,14 +68,37 @@ static grpc_channel *client_channel_factory_create_channel(
     const char *target, grpc_client_channel_type type,
     const grpc_channel_args *args) {
   // Add channel arg containing the server URI.
+  // Firstly, let's make sure \a target is a valid URI.
+  grpc_uri *target_uri = NULL;
+  char *target_uri_str = NULL;
+  grpc_uri_section uri_section = GRPC_URI_SECTION_NONE;
+  if ((target_uri = grpc_uri_parse(target, true /* suppress errors */,
+                                   &uri_section)) == NULL) {
+    if (uri_section == GRPC_URI_SECTION_SCHEME) {
+      // If the parsing error was due to the lack of scheme, try to fix that by
+      // prepending the default resolver prefix.
+      gpr_asprintf(&target_uri_str, "%s%s",
+                   grpc_resolver_registry_get_default_prefix(), target);
+      // try again...
+      if ((target_uri = grpc_uri_parse(
+               target_uri_str, true /* suppress errors */, NULL)) == NULL) {
+        gpr_free(target_uri_str);
+        return NULL;
+      }
+    } else {
+      return NULL;
+    }
+  }
+  grpc_uri_destroy(target_uri);
   grpc_arg arg;
   arg.type = GRPC_ARG_STRING;
   arg.key = GRPC_ARG_SERVER_URI;
-  arg.value.string = (char *)target;
+  arg.value.string = target_uri_str;
   grpc_channel_args *new_args = grpc_channel_args_copy_and_add(args, &arg, 1);
   grpc_channel *channel = grpc_channel_create(exec_ctx, target, new_args,
                                               GRPC_CLIENT_CHANNEL, NULL);
   grpc_channel_args_destroy(exec_ctx, new_args);
+  gpr_free(target_uri_str);
   return channel;
 }
 

--- a/test/core/client_channel/resolvers/dns_resolver_connectivity_test.c
+++ b/test/core/client_channel/resolvers/dns_resolver_connectivity_test.c
@@ -66,7 +66,7 @@ static grpc_error *my_resolve_address(const char *name, const char *addr,
 static grpc_resolver *create_resolver(grpc_exec_ctx *exec_ctx,
                                       const char *name) {
   grpc_resolver_factory *factory = grpc_resolver_factory_lookup("dns");
-  grpc_uri *uri = grpc_uri_parse(name, 0);
+  grpc_uri *uri = grpc_uri_parse(name, false, NULL);
   GPR_ASSERT(uri);
   grpc_resolver_args args;
   memset(&args, 0, sizeof(args));

--- a/test/core/client_channel/resolvers/dns_resolver_test.c
+++ b/test/core/client_channel/resolvers/dns_resolver_test.c
@@ -40,7 +40,7 @@
 
 static void test_succeeds(grpc_resolver_factory *factory, const char *string) {
   grpc_exec_ctx exec_ctx = GRPC_EXEC_CTX_INIT;
-  grpc_uri *uri = grpc_uri_parse(string, 0);
+  grpc_uri *uri = grpc_uri_parse(string, false, NULL);
   grpc_resolver_args args;
   grpc_resolver *resolver;
   gpr_log(GPR_DEBUG, "test: '%s' should be valid for '%s'", string,
@@ -57,7 +57,7 @@ static void test_succeeds(grpc_resolver_factory *factory, const char *string) {
 
 static void test_fails(grpc_resolver_factory *factory, const char *string) {
   grpc_exec_ctx exec_ctx = GRPC_EXEC_CTX_INIT;
-  grpc_uri *uri = grpc_uri_parse(string, 0);
+  grpc_uri *uri = grpc_uri_parse(string, false, NULL);
   grpc_resolver_args args;
   grpc_resolver *resolver;
   gpr_log(GPR_DEBUG, "test: '%s' should be invalid for '%s'", string,

--- a/test/core/client_channel/resolvers/sockaddr_resolver_test.c
+++ b/test/core/client_channel/resolvers/sockaddr_resolver_test.c
@@ -54,7 +54,7 @@ void on_resolution_cb(grpc_exec_ctx *exec_ctx, void *arg, grpc_error *error) {
 
 static void test_succeeds(grpc_resolver_factory *factory, const char *string) {
   grpc_exec_ctx exec_ctx = GRPC_EXEC_CTX_INIT;
-  grpc_uri *uri = grpc_uri_parse(string, 0);
+  grpc_uri *uri = grpc_uri_parse(string, false, NULL);
   grpc_resolver_args args;
   grpc_resolver *resolver;
   gpr_log(GPR_DEBUG, "test: '%s' should be valid for '%s'", string,
@@ -80,7 +80,7 @@ static void test_succeeds(grpc_resolver_factory *factory, const char *string) {
 
 static void test_fails(grpc_resolver_factory *factory, const char *string) {
   grpc_exec_ctx exec_ctx = GRPC_EXEC_CTX_INIT;
-  grpc_uri *uri = grpc_uri_parse(string, 0);
+  grpc_uri *uri = grpc_uri_parse(string, false, NULL);
   grpc_resolver_args args;
   grpc_resolver *resolver;
   gpr_log(GPR_DEBUG, "test: '%s' should be invalid for '%s'", string,

--- a/test/core/client_channel/uri_fuzzer_test.c
+++ b/test/core/client_channel/uri_fuzzer_test.c
@@ -48,7 +48,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   s[size] = 0;
 
   grpc_uri *x;
-  if ((x = grpc_uri_parse(s, 1))) {
+  if ((x = grpc_uri_parse(s, true, NULL))) {
     grpc_uri_destroy(x);
   }
   gpr_free(s);


### PR DESCRIPTION
Which is then used to prepend target names without a URI scheme for its use in the `GRPC_ARG_SERVER_URI` channel arg.