### PR TITLE
ruby bundle install work around to build packages on mac

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w( src/ruby/bin src/ruby/lib src/ruby/pb )
   s.platform      = Gem::Platform::RUBY
 
-  s.add_dependency 'google-protobuf', '~> 3.1.0'
+  s.add_dependency 'google-protobuf', '~> 3.1'
   s.add_dependency 'googleauth',      '~> 0.5.1'
 
   s.add_development_dependency 'bundler',            '~> 1.9'

--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -102,7 +102,6 @@ $CFLAGS << ' -std=c99 '
 $CFLAGS << ' -Wall '
 $CFLAGS << ' -Wextra '
 $CFLAGS << ' -pedantic '
-$CFLAGS << ' -Werror '
 $CFLAGS << ' -Wno-format '
 
 output = File.join('grpc', 'grpc_c')

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -29,7 +29,7 @@
     s.require_paths = %w( src/ruby/bin src/ruby/lib src/ruby/pb )
     s.platform      = Gem::Platform::RUBY
 
-    s.add_dependency 'google-protobuf', '~> 3.1.0'
+    s.add_dependency 'google-protobuf', '~> 3.1'
     s.add_dependency 'googleauth',      '~> 0.5.1'
 
     s.add_development_dependency 'bundler',            '~> 1.9'

--- a/tools/run_tests/artifacts/build_artifact_ruby.sh
+++ b/tools/run_tests/artifacts/build_artifact_ruby.sh
@@ -52,7 +52,15 @@ fi
 set +ex
 rvm use default
 gem install bundler --update
-bundle install
+
+if [ "$SYSTEM" == "Darwin" ] ; then
+  # Workaround for crash during bundle install
+  # See suggestion in https://github.com/bundler/bundler/issues/3692
+  BUNDLE_SPECIFIC_PLATFORM=true bundle install
+else
+  bundle install
+fi
+
 set -ex
 
 rake gem:native

--- a/tools/run_tests/artifacts/build_artifact_ruby.sh
+++ b/tools/run_tests/artifacts/build_artifact_ruby.sh
@@ -53,13 +53,7 @@ set +ex
 rvm use default
 gem install bundler --update
 
-if [ "$SYSTEM" == "Darwin" ] ; then
-  # Workaround for crash during bundle install
-  # See suggestion in https://github.com/bundler/bundler/issues/3692
-  BUNDLE_SPECIFIC_PLATFORM=true bundle install
-else
-  bundle install
-fi
+tools/run_tests/helper_scripts/bundle_install_wrapper.sh
 
 set -ex
 

--- a/tools/run_tests/helper_scripts/bundle_install_wrapper.sh
+++ b/tools/run_tests/helper_scripts/bundle_install_wrapper.sh
@@ -31,10 +31,10 @@
 
 set -ex
 
-export GRPC_CONFIG=${CONFIG:-opt}
-
 # change to grpc repo root
 cd $(dirname $0)/../../..
+
+SYSTEM=`uname | cut -f 1 -d_`
 
 if [ "$SYSTEM" == "Darwin" ] ; then
   # Workaround for crash during bundle install

--- a/tools/run_tests/helper_scripts/bundle_install_wrapper.sh
+++ b/tools/run_tests/helper_scripts/bundle_install_wrapper.sh
@@ -36,4 +36,11 @@ export GRPC_CONFIG=${CONFIG:-opt}
 # change to grpc repo root
 cd $(dirname $0)/../../..
 
-tools/run_tests/helper_scripts/bundle_install_wrapper.sh
+if [ "$SYSTEM" == "Darwin" ] ; then
+  # Workaround for crash during bundle install
+  # See suggestion in https://github.com/bundler/bundler/issues/3692
+  BUNDLE_SPECIFIC_PLATFORM=true bundle install
+else
+  bundle install
+fi
+


### PR DESCRIPTION
After running `gem update --system` on mac workers, successfully ran the ruby artifact script on them after this change.