### PR TITLE
cmake buildfile improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,8 +91,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
 if (MSVC)
   add_definitions(-D_WIN32_WINNT=0x600 -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
-  # needed to compile boringssl
-  add_definitions(/wd4464 /wd4623 /wd4668 /wd4701 /wd4702 /wd4777 /wd5027)
   # needed to compile protobuf
   add_definitions(/wd4065 /wd4506)
   # TODO(jtattermusch): revisit C4267 occurrences throughout the code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10831,13 +10831,6 @@ endif (gRPC_BUILD_TESTS)
 
 
 
-if (gRPC_INSTALL)
-  install(EXPORT gRPCTargets
-    DESTINATION ${CMAKE_INSTALL_CMAKEDIR}
-    NAMESPACE gRPC::
-  )
-endif()
-
 foreach(_config gRPCConfig gRPCConfigVersion)
   configure_file(tools/cmake/${_config}.cmake.in
     ${_config}.cmake @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,8 @@ if(WIN32)
   set(_gRPC_PLATFORM_WINDOWS ON)
 endif()
 
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+
 if (MSVC)
   add_definitions(-D_WIN32_WINNT=0x600 -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
   # needed to compile boringssl
@@ -3321,7 +3323,7 @@ target_link_libraries(qps
 
 endif (gRPC_BUILD_TESTS)
 
-add_library(grpc_csharp_ext
+add_library(grpc_csharp_ext SHARED
   src/csharp/ext/grpc_csharp_ext.c
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,6 +90,7 @@ endif()
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
 if (MSVC)
+  include(cmake/msvc_static_runtime.cmake)
   add_definitions(-D_WIN32_WINNT=0x600 -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
   # needed to compile protobuf
   add_definitions(/wd4065 /wd4506)

--- a/cmake/msvc_static_runtime.cmake
+++ b/cmake/msvc_static_runtime.cmake
@@ -1,0 +1,14 @@
+option(gRPC_MSVC_STATIC_RUNTIME "Link with static msvc runtime libraries" OFF)
+
+if(gRPC_MSVC_STATIC_RUNTIME)
+  # switch from dynamic to static linking of msvcrt
+  foreach(flag_var
+    CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+    CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+
+    if(${flag_var} MATCHES "/MD")
+    string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+    endif(${flag_var} MATCHES "/MD")
+  endforeach(flag_var)
+endif()
+

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -129,6 +129,9 @@
   if(WIN32)
     set(_gRPC_PLATFORM_WINDOWS ON)
   endif()
+  
+  ## Some libraries are shared even with BUILD_SHARED_LIBRARIES=OFF
+  set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
   if (MSVC)
     add_definitions(-D_WIN32_WINNT=0x600 -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
@@ -428,7 +431,7 @@
   % endfor
 
   <%def name="cc_library(lib)">
-  add_library(${lib.name}
+  add_library(${lib.name}${' SHARED' if lib.get('dll', None) == 'only' else ''}
   % for src in lib.src:
   % if not proto_re.match(src):
     ${src}

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -135,8 +135,6 @@
 
   if (MSVC)
     add_definitions(-D_WIN32_WINNT=0x600 -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
-    # needed to compile boringssl
-    add_definitions(/wd4464 /wd4623 /wd4668 /wd4701 /wd4702 /wd4777 /wd5027)
     # needed to compile protobuf
     add_definitions(/wd4065 /wd4506)
     # TODO(jtattermusch): revisit C4267 occurrences throughout the code

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -134,6 +134,7 @@
   set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
   if (MSVC)
+    include(cmake/msvc_static_runtime.cmake)
     add_definitions(-D_WIN32_WINNT=0x600 -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS)
     # needed to compile protobuf
     add_definitions(/wd4065 /wd4506)

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -554,13 +554,6 @@
   endif()
   </%def>
 
-  if (gRPC_INSTALL)
-    install(EXPORT gRPCTargets
-      DESTINATION <%text>${CMAKE_INSTALL_CMAKEDIR}</%text>
-      NAMESPACE gRPC::
-    )
-  endif()
-
   foreach(_config gRPCConfig gRPCConfigVersion)
     configure_file(tools/cmake/<%text>${_config}</%text>.cmake.in
       <%text>${_config}</%text>.cmake @ONLY)


### PR DESCRIPTION
-- declare grpc_csharp_ext as a shared library (which statically links all its dependencies)
-- remove some unnecessary silence-warning flags
-- add support of static runtime linking on MSVC++
-- fix #8729 