### PR TITLE
Fixed invalid handling of slice data in interop_server

### DIFF
--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -106,7 +106,9 @@ void MaybeEchoMetadata(ServerContext* context) {
   if (iter != client_metadata.end()) {
     iter = client_metadata.find("user-agent");
     if (iter != client_metadata.end()) {
-      context->AddInitialMetadata(kEchoUserAgentKey, iter->second.data());
+      context->AddInitialMetadata(
+          kEchoUserAgentKey,
+          grpc::string(iter->second.begin(), iter->second.end()));
     }
   }
 }


### PR DESCRIPTION
`iter->second.data()` references raw slice data that may not (and probably will not) be null terminated, causing a buffer overflow error and crashes from memory corruption. A string needs to be created using the appropriate bounds.

Kudos to @muxi for the pair-debugging session.

Fixes #9550 and #9551 