### PR TITLE
Disable yapf

### DIFF
--- a/tools/run_tests/sanity/sanity_tests.yaml
+++ b/tools/run_tests/sanity/sanity_tests.yaml
@@ -12,6 +12,5 @@
 - script: tools/distrib/check_trailing_newlines.sh
 - script: tools/distrib/check_nanopb_output.sh
 - script: tools/distrib/check_include_guards.py
-- script: tools/distrib/yapf_code.sh
 - script: tools/distrib/python/check_grpcio_tools.py
 


### PR DESCRIPTION
It's causing sanity errors on Master inconsistently. For example, commit cf7587e066fe777ee87dad40faee5d211931932f looks green (https://grpc-testing.appspot.com/job/gRPC_master_linux/1350/) but a local run shows yapf in:
```
        modified:   src/python/grpcio/commands.py
        modified:   src/python/grpcio/grpc/__init__.py
        modified:   src/python/grpcio/grpc/_channel.py
        modified:   src/python/grpcio/grpc/_common.py
        modified:   src/python/grpcio/grpc/_plugin_wrapping.py
        modified:   src/python/grpcio/grpc/_server.py
        modified:   src/python/grpcio/grpc/_utilities.py
        modified:   src/python/grpcio/grpc/beta/_client_adaptations.py
        modified:   src/python/grpcio/grpc/beta/_connectivity_channel.py
        modified:   src/python/grpcio/grpc/beta/_server_adaptations.py
        modified:   src/python/grpcio/grpc/framework/interfaces/base/utilities.py
        modified:   src/python/grpcio/grpc/framework/interfaces/face/face.py
        modified:   src/python/grpcio/support.py
        modified:   src/python/grpcio_health_checking/setup.py
        modified:   src/python/grpcio_reflection/setup.py
        modified:   src/python/grpcio_tests/setup.py
        modified:   src/python/grpcio_tests/tests/_result.py
        modified:   src/python/grpcio_tests/tests/interop/_secure_intraop_test.py
        modified:   src/python/grpcio_tests/tests/interop/client.py
        modified:   src/python/grpcio_tests/tests/interop/methods.py
        modified:   src/python/grpcio_tests/tests/protoc_plugin/_python_plugin_test.py
        modified:   src/python/grpcio_tests/tests/reflection/_reflection_servicer_test.py
        modified:   src/python/grpcio_tests/tests/stress/client.py
        modified:   src/python/grpcio_tests/tests/unit/_api_test.py
        modified:   src/python/grpcio_tests/tests/unit/_channel_args_test.py
        modified:   src/python/grpcio_tests/tests/unit/_cython/_cancel_many_calls_test.py
        modified:   src/python/grpcio_tests/tests/unit/_cython/_channel_test.py
        modified:   src/python/grpcio_tests/tests/unit/_cython/_read_some_but_not_all_respon
ses_test.py
        modified:   src/python/grpcio_tests/tests/unit/_invocation_defects_test.py
        modified:   src/python/grpcio_tests/tests/unit/_metadata_code_details_test.py
        modified:   src/python/grpcio_tests/tests/unit/_rpc_test.py
        modified:   src/python/grpcio_tests/tests/unit/beta/_beta_features_test.py
        modified:   src/python/grpcio_tests/tests/unit/beta/_face_interface_test.py
        modified:   src/python/grpcio_tests/tests/unit/beta/test_utilities.py
        modified:   src/python/grpcio_tests/tests/unit/framework/interfaces/face/_digest.py
        modified:   src/python/grpcio_tests/tests/unit/framework/interfaces/face/_invocation
.py
        modified:   src/python/grpcio_tests/tests/unit/test_common.py
        modified:   tools/run_tests/sanity/sanity_tests.yaml
```

That is, yapf shows inconsistent behavior over time (is it changing settings/version automatically?)