### PR TITLE
Add Cronet core tests to Jenkins

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -882,6 +882,7 @@ Pod::Spec.new do |s|
                       'test/core/end2end/end2end_test_utils.c',
                       'test/core/end2end/tests/*.{c,h}',
                       'test/core/end2end/data/*.{c,h}',
+                      'test/core/util/debugger_macros.c',
                       'test/core/util/test_config.{c,h}',
                       'test/core/util/port.h',
                       'test/core/util/port_posix.c',

--- a/src/objective-c/tests/CoreCronetEnd2EndTests/CoreCronetEnd2EndTests.m
+++ b/src/objective-c/tests/CoreCronetEnd2EndTests/CoreCronetEnd2EndTests.m
@@ -206,7 +206,7 @@ static char *roots_filename;
              inDomains:NSUserDomainMask] lastObject];
   NSLog(@"Documents directory: %@", url);
   [Cronet start];
-  [Cronet startNetLogToFile:@"Documents/cronet_netlog.json" logBytes:YES];
+  [Cronet startNetLogToFile:@"cronet_netlog.json" logBytes:YES];
 }
 
 // The tearDown() function is run after all test cases finish running

--- a/src/objective-c/tests/Tests.xcodeproj/xcshareddata/xcschemes/AllTests.xcscheme
+++ b/src/objective-c/tests/Tests.xcodeproj/xcshareddata/xcschemes/AllTests.xcscheme
@@ -49,6 +49,16 @@
                </Test>
             </SkippedTests>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5E8A5DA31D3840B4000F8BC4"
+               BuildableName = "CoreCronetEnd2EndTests.xctest"
+               BlueprintName = "CoreCronetEnd2EndTests"
+               ReferencedContainer = "container:Tests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -90,15 +100,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "63423F431B150A5F006CF63C"
-            BuildableName = "AllTests.xctest"
-            BlueprintName = "AllTests"
-            ReferencedContainer = "container:Tests.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -178,6 +178,7 @@
                         'test/core/end2end/end2end_test_utils.c',
                         'test/core/end2end/tests/*.{c,h}',
                         'test/core/end2end/data/*.{c,h}',
+                        'test/core/util/debugger_macros.c',
                         'test/core/util/test_config.{c,h}',
                         'test/core/util/port.h',
                         'test/core/util/port_posix.c',

--- a/test/core/end2end/tests/simple_delayed_request.c
+++ b/test/core/end2end/tests/simple_delayed_request.c
@@ -104,6 +104,7 @@ static void simple_delayed_request_body(grpc_end2end_test_config config,
   int was_cancelled = 2;
 
   config.init_client(f, client_args);
+  config.init_server(f, server_args);
 
   c = grpc_channel_create_call(
       f->client, NULL, GRPC_PROPAGATE_DEFAULTS, f->cq,
@@ -142,8 +143,6 @@ static void simple_delayed_request_body(grpc_end2end_test_config config,
   op++;
   error = grpc_call_start_batch(c, ops, (size_t)(op - ops), tag(1), NULL);
   GPR_ASSERT(GRPC_CALL_OK == error);
-
-  config.init_server(f, server_args);
 
   error =
       grpc_server_request_call(f->server, &s, &call_details,


### PR DESCRIPTION
This PR put Cronet core tests into jenkins macos objc test.

@ctiller - Could you take a look at simple_delayed_request.c? The original version fails as Cronet starts with the connection attempt at `grpc_call_start_batch`(line 143) before `init_server`. That triggers CONNECTION_REFUSED.