### PR TITLE
Update PROTOCOL-WEB.md

### DIFF
--- a/doc/PROTOCOL-WEB.md
+++ b/doc/PROTOCOL-WEB.md
@@ -60,14 +60,14 @@ HTTP/2 related behavior (specified in [gRPC over HTTP2](http://www.grpc.io/docs/
 Message framing (vs. [http2-transport-mapping](http://www.grpc.io/docs/guides/wire.html#http2-transport-mapping))
 
 1. Response status encoded as part of the response body
-  * Key-value pairs encoded in the HTTP/2 [literal header format](https://tools.ietf.org/html/rfc7541#section-6.2) as a single header block.
+  * Key-value pairs encoded as a HTTP/1 headers block (without the terminating newline).
 2. 8th (MSB) bit of the 1st gRPC frame byte
   * 0: data
   * 1: trailers
 3. Trailers must be the last message of the response, as enforced
 by the implementation
 4. Trailers-only responses: no change to the gRPC protocol spec.
-Trailers will be sent together with response headers, with no message
+Trailers may be sent together with response headers, with no message
 in the body.
 
 ---


### PR DESCRIPTION
1. Clarify about trailer-only responses
2. Switch to http/1.1 header block format for in-body trailer encoding
3. Clarify how compatibility is supported (using U-A and Server headers respectively)