### PR TITLE
Connect to "localhost" from interop clients.

### DIFF
--- a/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
@@ -56,7 +56,7 @@ namespace Grpc.IntegrationTesting
     {
         private class ClientOptions
         {
-            [Option("server_host", Default = "127.0.0.1")]
+            [Option("server_host", Default = "localhost")]
             public string ServerHost { get; set; }
 
             [Option("server_host_override", Default = TestCredentials.DefaultHostOverride)]

--- a/src/python/grpcio_tests/tests/interop/client.py
+++ b/src/python/grpcio_tests/tests/interop/client.py
@@ -45,7 +45,7 @@ def _args():
         '--server_host',
         help='the host to which to connect',
         type=str,
-        default="127.0.0.1")
+        default="localhost")
     parser.add_argument(
         '--server_port', help='the port to which to connect', type=int)
     parser.add_argument(

--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -51,7 +51,7 @@ DEFINE_bool(use_tls, false, "Whether to use tls.");
 DEFINE_string(custom_credentials_type, "", "User provided credentials type.");
 DEFINE_bool(use_test_ca, false, "False to use SSL roots for google");
 DEFINE_int32(server_port, 0, "Server port.");
-DEFINE_string(server_host, "127.0.0.1", "Server host to connect to");
+DEFINE_string(server_host, "localhost", "Server host to connect to");
 DEFINE_string(server_host_override, "foo.test.google.fr",
               "Override the server host which is sent in HTTP header");
 DEFINE_string(

--- a/test/cpp/interop/http2_client.cc
+++ b/test/cpp/interop/http2_client.cc
@@ -223,7 +223,7 @@ bool Http2Client::DoMaxStreams() {
 }  // namespace grpc
 
 DEFINE_int32(server_port, 0, "Server port.");
-DEFINE_string(server_host, "127.0.0.1", "Server host to connect to");
+DEFINE_string(server_host, "localhost", "Server host to connect to");
 DEFINE_string(test_case, "rst_after_header",
               "Configure different test cases. Valid options are:\n\n"
               "goaway\n"

--- a/test/cpp/interop/reconnect_interop_client.cc
+++ b/test/cpp/interop/reconnect_interop_client.cc
@@ -48,7 +48,7 @@
 
 DEFINE_int32(server_control_port, 0, "Server port for control rpcs.");
 DEFINE_int32(server_retry_port, 0, "Server port for testing reconnection.");
-DEFINE_string(server_host, "127.0.0.1", "Server host to connect to");
+DEFINE_string(server_host, "localhost", "Server host to connect to");
 DEFINE_int32(max_reconnect_backoff_ms, 0,
              "Maximum backoff time, or 0 for default.");
 


### PR DESCRIPTION
This is for compatibility with IPv6-only environments; see the Google
bug b/32531998.

Note that InteropClient.cs and http2_client.cc don't appear to be tested
by our internal branch, but I've included them for consistency.