### PR TITLE
Rolls back of #9458

### DIFF
--- a/tools/jenkins/run_interop.sh
+++ b/tools/jenkins/run_interop.sh
@@ -37,5 +37,3 @@ export LANG=en_US.UTF-8
 cd $(dirname $0)/../..
 
 tools/run_tests/run_interop_tests.py -l all -s all --cloud_to_prod --cloud_to_prod_auth --use_docker --http2_interop -t -j 12 $@ || true
-tools/run_tests/run_interop_tests.py -l java --use_docker --http2_badserver_interop $@ || true
-tools/run_tests/run_interop_tests.py -l python --use_docker --http2_badserver_interop $@ || true


### PR DESCRIPTION
Rolls back #9458 and disables new HTTP2 interop tests.

The original interop tests have been masked, and I want to see a jenkins run with out the new tests.