### PR TITLE
Add benchmarks for high RTT environment

### DIFF
--- a/tools/gce/create_linux_performance_worker.sh
+++ b/tools/gce/create_linux_performance_worker.sh
@@ -41,8 +41,8 @@ cd $(dirname $0)
 CLOUD_PROJECT=grpc-testing
 ZONE=us-central1-b  # this zone allows 32core machines
 
-INSTANCE_NAME="${1:-apolcyn-test-2core}"
-MACHINE_TYPE=n1-standard-2
+INSTANCE_NAME="${1:-grpc-performance-server1}"
+MACHINE_TYPE=n1-standard-8
 
 gcloud compute instances create $INSTANCE_NAME \
     --project="$CLOUD_PROJECT" \

--- a/tools/jenkins/run_high_latency_performance.sh
+++ b/tools/jenkins/run_high_latency_performance.sh
@@ -31,6 +31,9 @@
 # This script is invoked by Jenkins and runs high latency performance test suite.
 set -ex
 
+BQ_DATASET=${1:-performance_test}
+BQ_TABLE=${2:-performance_high_latency}
+
 # Enter the gRPC repo root
 cd $(dirname $0)/../..
 
@@ -41,7 +44,7 @@ tools/run_tests/run_performance_tests.py \
     --netperf \
     --category sweep \
     -r .*unary.*ping_pong* \
-    --bq_result_table apolcyn_test.performance_high_latency \
+    --bq_result_table "${BQ_DATASET}.${BQ_TABLE}" \
     --remote_worker_host grpc-performance-2core grpc-performance-asia-east-2core \
     --xml_report report_high_latency_2core.xml \
     || EXIT_CODE=1

--- a/tools/jenkins/run_high_latency_performance.sh
+++ b/tools/jenkins/run_high_latency_performance.sh
@@ -28,7 +28,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-# This script is invoked by Jenkins and runs full performance test suite.
+# This script is invoked by Jenkins and runs high latency performance test suite.
 set -ex
 
 # Enter the gRPC repo root

--- a/tools/jenkins/run_high_latency_performance.sh
+++ b/tools/jenkins/run_high_latency_performance.sh
@@ -34,6 +34,9 @@ set -ex
 BQ_DATASET=${1:-performance_test}
 BQ_TABLE=${2:-performance_high_latency}
 
+# by default run single stream unary only
+SCENARIO_REGEX=${3:-.*unary.*ping_pong*}
+
 # Enter the gRPC repo root
 cd $(dirname $0)/../..
 
@@ -43,7 +46,7 @@ tools/run_tests/run_performance_tests.py \
     -l go c++ java \
     --netperf \
     --category sweep \
-    -r .*unary.*ping_pong* \
+    -r "${SCENARIO_REGEX}" \
     --bq_result_table "${BQ_DATASET}.${BQ_TABLE}" \
     --remote_worker_host grpc-performance-2core grpc-performance-asia-east-2core \
     --xml_report report_high_latency_2core.xml \

--- a/tools/jenkins/run_high_latency_performance.sh
+++ b/tools/jenkins/run_high_latency_performance.sh
@@ -38,7 +38,7 @@ cd $(dirname $0)/../..
 # Attempt to see performance of flow control over netpertf latency.
 # NOTE: focusing on single stream tests
 tools/run_tests/run_performance_tests.py \
-    -l go \
+    -l go c++ java \
     --netperf \
     --category sweep \
     -r .*unary.*ping_pong* \

--- a/tools/jenkins/run_high_latency_performance.sh
+++ b/tools/jenkins/run_high_latency_performance.sh
@@ -35,8 +35,7 @@ set -ex
 cd $(dirname $0)/../..
 
 # Run performance tests on machines that are far away from each other.
-# Attempt to see performance of flow control over netpertf latency.
-# NOTE: focusing on single stream tests
+# Attempt to see performance of flow control over high netperf latency.
 tools/run_tests/run_performance_tests.py \
     -l go c++ java \
     --netperf \

--- a/tools/jenkins/run_high_latency_performance.sh
+++ b/tools/jenkins/run_high_latency_performance.sh
@@ -31,11 +31,11 @@
 # This script is invoked by Jenkins and runs high latency performance test suite.
 set -ex
 
-BQ_DATASET=${1:-performance_test}
-BQ_TABLE=${2:-performance_high_latency}
+BQ_DATASET=${BQ_DATASET:-performance_test}
+BQ_TABLE=${BQ_TABLE:-performance_high_latency}
 
 # by default run single stream unary only
-SCENARIO_REGEX=${3:-.*unary.*ping_pong*}
+SCENARIO_REGEX=${SCENARIO_REGEX:-.*unary.*ping_pong*}
 
 # Enter the gRPC repo root
 cd $(dirname $0)/../..

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -645,20 +645,18 @@ class GoLanguage:
       yield _ping_pong_scenario(
           'go_generic_sync_streaming_ping_pong_%s' % secstr, rpc_type='STREAMING',
           client_type='SYNC_CLIENT', server_type='ASYNC_GENERIC_SERVER',
-          use_generic_payload=True, async_server_threads=1,
+          use_generic_payload=True,
           secure=secure,
           categories=smoketest_categories)
 
       yield _ping_pong_scenario(
           'go_protobuf_sync_streaming_ping_pong_%s' % secstr, rpc_type='STREAMING',
           client_type='SYNC_CLIENT', server_type='SYNC_SERVER',
-          async_server_threads=1,
           secure=secure)
 
       yield _ping_pong_scenario(
           'go_protobuf_sync_unary_ping_pong_%s' % secstr, rpc_type='UNARY',
           client_type='SYNC_CLIENT', server_type='SYNC_SERVER',
-          async_server_threads=1,
           secure=secure,
           categories=smoketest_categories)
 
@@ -687,6 +685,19 @@ class GoLanguage:
           unconstrained_client='async', use_generic_payload=True,
           secure=secure,
           categories=[SCALABLE])
+
+      for size in geometric_progression(1, 1024*1024*1024+1, 8):
+        for rpc_type in ['unary', 'streaming']:
+          yield _ping_pong_scenario(
+              'go_protobuf_sync_%s_ping_pong_%s_%sdb' % (rpc_type, secstr, size),
+              rpc_type=rpc_type.upper(),
+              client_type='SYNC_CLIENT',
+              server_type='SYNC_SERVER',
+              req_size=size,
+              resp_size=size,
+              secure=secure,
+              categories=[SWEEP])
+
 
       # TODO(jtattermusch): add scenarios go vs C++
 

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -716,7 +716,7 @@ class GoLanguage:
       for size in geometric_progression(1, 1024*1024*1024+1, 8):
         for rpc_type in ['unary', 'streaming']:
           yield _ping_pong_scenario(
-              'go_protobuf_sync_%s_ping_pong_%s_%sdb' % (rpc_type, secstr, size),
+              'go_protobuf_sync_%s_ping_pong_%s_%db' % (rpc_type, secstr, size),
               rpc_type=rpc_type.upper(),
               client_type='SYNC_CLIENT',
               server_type='SYNC_SERVER',

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -630,7 +630,7 @@ class JavaLanguage:
           secure=secure, warmup_seconds=JAVA_WARMUP_SECONDS)
 
       for rpc_type in ['unary', 'streaming']:
-          for size in geometric_progression(1, 1024*1024*1024+1, 8):
+          for size in geometric_progression(1, 1024*1024*32+1, 8):
               yield _ping_pong_scenario(
                   'java_protobuf_async_%s_ping_pong_%s_%db' % (rpc_type, secstr, size),
                   rpc_type=rpc_type.upper(),
@@ -713,7 +713,7 @@ class GoLanguage:
           secure=secure,
           categories=[SCALABLE])
 
-      for size in geometric_progression(1, 1024*1024*1024+1, 8):
+      for size in geometric_progression(1, 1024*1024*32+1, 8):
         for rpc_type in ['unary', 'streaming']:
           yield _ping_pong_scenario(
               'go_protobuf_sync_%s_ping_pong_%s_%db' % (rpc_type, secstr, size),
@@ -724,6 +724,19 @@ class GoLanguage:
               resp_size=size,
               secure=secure,
               categories=[SWEEP])
+
+      for rpc_type in ['unary', 'streaming']:
+        for size in geometric_progression(1, 1024*1024*32+1, 8):
+            yield _ping_pong_scenario(
+                'go_protobuf_sync_%s_qps_unconstrained_%s_%db' % (rpc_type, secstr, size),
+                rpc_type=rpc_type.upper(),
+                req_size=size,
+                resp_size=size,
+                client_type='SYNC_CLIENT',
+                server_type='SYNC_SERVER',
+                unconstrained_client='async',
+                secure=secure,
+                categories=[SWEEP])
 
 
       # TODO(jtattermusch): add scenarios go vs C++

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -246,6 +246,18 @@ class CXXLanguage:
 
       for rpc_type in ['unary', 'streaming']:
         for synchronicity in ['sync', 'async']:
+          for size in geometric_progression(1, 1024*1024*1024+1, 8):
+              yield _ping_pong_scenario(
+                  'cpp_protobuf_%s_%s_ping_pong_%s_%db' % (synchronicity, rpc_type, secstr, size),
+                  rpc_type=rpc_type.upper(),
+                  req_size=size,
+                  resp_size=size,
+                  client_type='%s_CLIENT' % synchronicity.upper(),
+                  server_type='%s_SERVER' % synchronicity.upper(),
+                  async_server_threads=1,
+                  secure=secure,
+                  categories=[SWEEP])
+
           yield _ping_pong_scenario(
               'cpp_protobuf_%s_%s_ping_pong_%s' % (synchronicity, rpc_type, secstr),
               rpc_type=rpc_type.upper(),

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -636,10 +636,11 @@ class JavaLanguage:
                   rpc_type=rpc_type.upper(),
                   req_size=size,
                   resp_size=size,
-                  client_type='ASYNC_CLIENT' % synchronicity.upper(),
-                  server_type='ASYNC_SERVER' % synchronicity.upper(),
+                  client_type='ASYNC_CLIENT',
+                  server_type='ASYNC_SERVER',
                   async_server_threads=1,
                   secure=secure,
+                  warmup_seconds=JAVA_WARMUP_SECONDS,
                   categories=[SWEEP])
 
 

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -629,6 +629,20 @@ class JavaLanguage:
           async_server_threads=1,
           secure=secure, warmup_seconds=JAVA_WARMUP_SECONDS)
 
+      for rpc_type in ['unary', 'streaming']:
+          for size in geometric_progression(1, 1024*1024*1024+1, 8):
+              yield _ping_pong_scenario(
+                  'java_protobuf_async_%s_ping_pong_%s_%db' % (rpc_type, secstr, size),
+                  rpc_type=rpc_type.upper(),
+                  req_size=size,
+                  resp_size=size,
+                  client_type='ASYNC_CLIENT' % synchronicity.upper(),
+                  server_type='ASYNC_SERVER' % synchronicity.upper(),
+                  async_server_threads=1,
+                  secure=secure,
+                  categories=[SWEEP])
+
+
       # TODO(jtattermusch): add scenarios java vs C++
 
   def __str__(self):


### PR DESCRIPTION
added jenkins job: https://grpc-testing.appspot.com/job/gRPC_performance_high_latency/. This uses two 2-core machines, one in us-central zone and other in asia-east zone - netperf latency appears about 150-160ms. Mostly for testing flow control perf.

see go results with different message sizes in https://gist.github.com/apolcyn/8519af7d3db3c5c6f5b08873cc5f11b6

Currently testing unary ping pong with equal request/response size, but probably could add some more.

also gets rid of `async_server_threads=1` in go since it's ignored