### PR TITLE
ruby mac build environment updates

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'logging',            '~> 2.0'
   s.add_development_dependency 'simplecov',          '~> 0.9'
   s.add_development_dependency 'rake',               '~> 10.4'
-  s.add_development_dependency 'rake-compiler',      '~> 0.9'
+  s.add_development_dependency 'rake-compiler',      '~> 1.0'
   s.add_development_dependency 'rake-compiler-dock', '~> 0.5.1'
   s.add_development_dependency 'rspec',              '~> 3.2'
   s.add_development_dependency 'rubocop',            '~> 0.30.0'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -37,7 +37,7 @@
     s.add_development_dependency 'logging',            '~> 2.0'
     s.add_development_dependency 'simplecov',          '~> 0.9'
     s.add_development_dependency 'rake',               '~> 10.4'
-    s.add_development_dependency 'rake-compiler',      '~> 0.9'
+    s.add_development_dependency 'rake-compiler',      '~> 1.0'
     s.add_development_dependency 'rake-compiler-dock', '~> 0.5.1'
     s.add_development_dependency 'rspec',              '~> 3.2'
     s.add_development_dependency 'rubocop',            '~> 0.30.0'

--- a/tools/distrib/build_ruby_environment_macos.sh
+++ b/tools/distrib/build_ruby_environment_macos.sh
@@ -34,7 +34,7 @@ rm -rf ~/.rake-compiler
 
 CROSS_RUBY=`mktemp tmpfile.XXXXXXXX`
 
-curl https://raw.githubusercontent.com/rake-compiler/rake-compiler/v0.9.5/tasks/bin/cross-ruby.rake > $CROSS_RUBY
+curl https://raw.githubusercontent.com/rake-compiler/rake-compiler/v1.0.3/tasks/bin/cross-ruby.rake > $CROSS_RUBY
 
 patch $CROSS_RUBY << EOF
 --- cross-ruby.rake	2016-02-05 16:26:53.000000000 -0800
@@ -53,7 +53,8 @@ EOF
 
 MAKE="make -j8"
 
-for v in 2.3.0 2.2.2 2.1.5 2.0.0-p645 ; do
+for v in 2.4.0 2.3.0 2.2.2 2.1.5 2.0.0-p645 ; do
+  ccache -c
   rake -f $CROSS_RUBY cross-ruby VERSION=$v HOST=x86_64-darwin11
 done
 


### PR DESCRIPTION
Previously stuck on errors like:
```
#error RUBY_EXEC_PREFIX must be defined
```
happening during `build_ruby_environment_macos.sh` `rake cross` for ruby 2.2 or 2.1.5

`build_ruby_environment_macos.sh` and `rake gem:native` ran successfully for macs on ruby 2.4 with these changes.