### PR TITLE
Update protobuf version used for nanopb compiler

### DIFF
--- a/tools/codegen/core/gen_nano_proto.sh
+++ b/tools/codegen/core/gen_nano_proto.sh
@@ -83,7 +83,7 @@ popd
 
 # this should be the same version as the submodule we compile against
 # ideally we'd update this as a template to ensure that
-pip install protobuf==3.0.0
+pip install protobuf==3.2.0
 
 pushd "$(dirname $INPUT_PROTO)" > /dev/null
 


### PR DESCRIPTION
While we are still using 3.1.0 in submodules, I've verified both 3.1.0 and 3.2.0 generate no changes with respect to the currently generated files.