### PR TITLE
Export LICENSE.txt in //third_party/nanopb

### DIFF
--- a/third_party/nanopb/BUILD
+++ b/third_party/nanopb/BUILD
@@ -1,4 +1,7 @@
 licenses(["notice"])
+
+exports_files(["LICENSE.txt"])
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(


### PR DESCRIPTION
Same as https://github.com/nanopb/nanopb/commit/4710f9cef63e71f39100183f757d78add0ed7855. Needed to simplify building grpc in TensorFlow.

TensorFlow currently uses a different version of nanopb from gRPC just because of that missing commit. We need to include all licenses in our packaged library.