### PR TITLE
Let ServerContext own the initial_metadata array for sync calls

### DIFF
--- a/include/grpc++/impl/codegen/server_context.h
+++ b/include/grpc++/impl/codegen/server_context.h
@@ -213,8 +213,7 @@ class ServerContext {
 
   void BeginCompletionOp(Call* call);
 
-  ServerContext(gpr_timespec deadline, grpc_metadata* metadata,
-                size_t metadata_count);
+  ServerContext(gpr_timespec deadline, grpc_metadata_array* arr);
 
   void set_call(grpc_call* call) { call_ = call; }
 

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -189,8 +189,7 @@ class Server::SyncRequest final : public CompletionQueueTag {
     explicit CallData(Server* server, SyncRequest* mrd)
         : cq_(mrd->cq_),
           call_(mrd->call_, server, &cq_, server->max_receive_message_size()),
-          ctx_(mrd->deadline_, mrd->request_metadata_.metadata,
-               mrd->request_metadata_.count),
+          ctx_(mrd->deadline_, &mrd->request_metadata_),
           has_request_payload_(mrd->has_request_payload_),
           request_payload_(mrd->request_payload_),
           method_(mrd->method_) {


### PR DESCRIPTION
Previously the metadata pointer of the metadata array is swapped to the call_data of the next call.
Now the ownership goes to the MetadataMap of the ServerContext and the other array is cleared.