### PR TITLE
Fix class name on documentation

### DIFF
--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -84,7 +84,7 @@ module GRPC
     # channel:
     #
     # - :channel_override
-    # when present, this must be a pre-created GRPC::Channel.  If it's
+    # when present, this must be a pre-created GRPC::Core::Channel.  If it's
     # present the host and arbitrary keyword arg areignored, and the RPC
     # connection uses this channel.
     #


### PR DESCRIPTION
```
require 'grpc' # => true
GRPC::Channel # => NameError: uninitialized constant GRPC::Channel
GRPC::Core::Channel # => GRPC::Core::Channel
```