### PR TITLE
[Build Fixit] Adding bazel build files

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1280,6 +1280,13 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "grpc++_test",
+    language = "c++",
+    public_hdrs = ["include/grpc++/test/server_context_test_spouse.h"],
+    deps = ["//:grpc++"],
+)
+
+grpc_cc_library(
     name = "thrift_util",
     language = "c++",
     public_hdrs = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,6 +33,11 @@ bind(
     actual = "@submodule_gtest//:gtest",
 )
 
+bind(
+    name = "gflags",
+    actual = "@submodule_gflags//:gflags",
+)
+
 new_local_repository(
     name = "submodule_boringssl",
     path = "third_party/boringssl-with-bazel",
@@ -55,4 +60,9 @@ new_local_repository(
     name = "submodule_gtest",
     path = "third_party/googletest",
     build_file = "third_party/gtest.BUILD",
+)
+
+local_repository(
+    name = "submodule_gflags",
+    path = "third_party/gflags",
 )

--- a/test/core/memory_usage/BUILD
+++ b/test/core/memory_usage/BUILD
@@ -1,0 +1,54 @@
+# Copyright 2017, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+licenses(["notice"])  # 3-clause BSD
+
+cc_binary(
+    name = "client",
+    srcs = ["client.c"],
+    deps = ["//test/core/util:grpc_test_util", "//:grpc", "//test/core/util:gpr_test_util", "//:gpr"],
+    testonly = 1,
+    copts = ['-std=c99']
+)
+
+cc_binary(
+    name = "server",
+    srcs = ["server.c"],
+    deps = ["//test/core/end2end:ssl_test_data", "//test/core/util:grpc_test_util", "//:grpc", "//test/core/util:gpr_test_util", "//:gpr"],
+    testonly = 1,
+    copts = ['-std=c99']
+)
+
+cc_test(
+    name = "memory_usage_test",
+    srcs = ["memory_usage_test.c"],
+    deps = ["//test/core/util:grpc_test_util", "//:grpc", "//test/core/util:gpr_test_util", "//:gpr"],
+    copts = ['-std=c99'],
+    data = [":client", ":server"]
+)

--- a/test/cpp/test/BUILD
+++ b/test/cpp/test/BUILD
@@ -1,0 +1,36 @@
+# Copyright 2017, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+licenses(["notice"])  # 3-clause BSD
+
+cc_test(
+    name = "server_context_test_spouse",
+    srcs = ["server_context_test_spouse_test.cc"],
+    deps = ["//external:gtest", "//:grpc++_test", "//test/core/util:grpc_test_util", "//:grpc", "//:grpc++", "//:gpr", "//test/core/util:gpr_test_util"]
+)

--- a/test/cpp/thread_manager/BUILD
+++ b/test/cpp/thread_manager/BUILD
@@ -1,0 +1,36 @@
+# Copyright 2017, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+licenses(["notice"])  # 3-clause BSD
+
+cc_test(
+    name = "thread_manager",
+    srcs = ["thread_manager_test.cc"],
+    deps = ["//external:gflags", "//:grpc", "//:grpc++", "//:gpr", "//test/cpp/util:test_config"]
+)

--- a/test/cpp/util/test_config_cc.cc
+++ b/test/cpp/util/test_config_cc.cc
@@ -36,9 +36,9 @@
 
 // In some distros, gflags is in the namespace google, and in some others,
 // in gflags. This hack is enabling us to find both.
-namespace google {}
+//namespace google {}
 namespace gflags {}
-using namespace google;
+//using namespace google;
 using namespace gflags;
 
 namespace grpc {


### PR DESCRIPTION
core/memory_usage - done
cpp/test - done
cpp/thread_manager - depend on gflags

Include changes to have exeternal:gflags