### PR TITLE
PHP: added README notes for RHEL 6/7 users

### DIFF
--- a/src/php/README.md
+++ b/src/php/README.md
@@ -13,12 +13,24 @@ shared C library.
 * `phpunit` (optional)
 
 **Install PHP and PECL on Ubuntu/Debian:**
+
+For PHP5:
+
 ```sh
-$ sudo apt-get install php5 php5-dev php-pear
+$ sudo apt-get install php5 php5-dev php-pear phpunit
+```
 
-OR
+For PHP7:
 
-$ sudo apt-get install php7.0 php7.0-dev php-pear
+```sh
+$ sudo apt-get install php7.0 php7.0-dev php-pear phpunit
+```
+
+**Install PHP and PECL on CentOS/RHEL 7:**
+```sh
+$ sudo rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+$ sudo rpm -Uvh https://mirror.webtatic.com/yum/el7/webtatic-release.rpm
+$ sudo yum install php56w php56w-devel php-pear phpunit gcc zlib-devel
 ```
 
 **Install PECL on Mac:**
@@ -51,6 +63,10 @@ sudo pecl install grpc
 This will compile and install the gRPC PHP extension into the standard PHP
 extension directory. You should be able to run the [unit tests](#unit-tests),
 with the PHP extension installed.
+
+Note: For users on CentOS/RHEL 6, unfortunately this step won't work. Please
+follow the instructions below to compile the extension from source.
+
 
 **Update php.ini**
 


### PR DESCRIPTION
Reference issue #9365 

The issue with CentOS/RHEL 6 is that it comes standard with gcc 4.4 and not -std=c11. When I try to use std=c99 in the pecl extension, I run into issues with openssl/boringssl. Even when I upgrade gcc to 4.8, for some reason the pecl command doesn't seem to be able to use that properly.

Here's at least something I can verify that it works
 - `sudo pecl install grpc` on CentOS/RHEL 7
 - compile from source on CentOS/RHEL 6

So I am tabling this for now and added a note for CentOS/RHEL 6 users to compile the PHP extension from source instead for now.