### PR TITLE
Fix compile error - possible uninitialized variable

### DIFF
--- a/src/core/lib/surface/server.c
+++ b/src/core/lib/surface/server.c
@@ -1198,7 +1198,9 @@ void grpc_server_setup_transport(grpc_exec_ctx *exec_ctx, grpc_server *s,
       crm->server_registered_method = rm;
       crm->flags = rm->flags;
       crm->has_host = has_host;
-      crm->host = host;
+      if(has_host)  {
+        crm->host = host;
+      }
       crm->method = method;
     }
     GPR_ASSERT(slots <= UINT32_MAX);

--- a/src/core/lib/surface/server.c
+++ b/src/core/lib/surface/server.c
@@ -1198,7 +1198,7 @@ void grpc_server_setup_transport(grpc_exec_ctx *exec_ctx, grpc_server *s,
       crm->server_registered_method = rm;
       crm->flags = rm->flags;
       crm->has_host = has_host;
-      if(has_host)  {
+      if (has_host) {
         crm->host = host;
       }
       crm->method = method;


### PR DESCRIPTION
`host` is only (guaranteed to be) initialized if `has_host` is `true.`
I'm afraid I'm not able to reproduce the compile error right now or test it again, I hope someone else can have a look at it.