### PR TITLE
Fixes a TypeError in GRPC::Core::Channel#connectivity_state

### DIFF
--- a/src/ruby/ext/grpc/rb_channel.c
+++ b/src/ruby/ext/grpc/rb_channel.c
@@ -198,7 +198,7 @@ static VALUE grpc_rb_channel_get_connectivity_state(int argc, VALUE *argv,
     return Qnil;
   }
   return LONG2NUM(
-      grpc_channel_check_connectivity_state(ch, (int)try_to_connect));
+      grpc_channel_check_connectivity_state(ch, RTEST(try_to_connect)));
 }
 
 /* Watch for a change in connectivity state.

--- a/src/ruby/ext/grpc/rb_channel.c
+++ b/src/ruby/ext/grpc/rb_channel.c
@@ -175,11 +175,13 @@ static VALUE grpc_rb_channel_init(int argc, VALUE *argv, VALUE self) {
 
 /*
   call-seq:
-    insecure_channel = Channel:new("myhost:8080", {'arg1': 'value1'})
-    creds = ...
-    secure_channel = Channel:new("myhost:443", {'arg1': 'value1'}, creds)
+    ch.connectivity_state       -> state
+    ch.connectivity_state(true) -> state
 
-  Creates channel instances. */
+  Indicates the current state of the channel, whose value is one of the
+  constants defined in GRPC::Core::ConnectivityStates.
+
+  It also tries to connect if the chennel is idle in the second form. */
 static VALUE grpc_rb_channel_get_connectivity_state(int argc, VALUE *argv,
                                                     VALUE self) {
   VALUE try_to_connect = Qfalse;
@@ -195,7 +197,7 @@ static VALUE grpc_rb_channel_get_connectivity_state(int argc, VALUE *argv,
     rb_raise(rb_eRuntimeError, "closed!");
     return Qnil;
   }
-  return NUM2LONG(
+  return LONG2NUM(
       grpc_channel_check_connectivity_state(ch, (int)try_to_connect));
 }
 

--- a/src/ruby/spec/channel_spec.rb
+++ b/src/ruby/spec/channel_spec.rb
@@ -153,6 +153,21 @@ describe GRPC::Core::Channel do
     end
   end
 
+  describe '#connectivity_state' do
+    it 'returns an enum' do
+      ch = GRPC::Core::Channel.new(fake_host, nil, :this_channel_is_insecure)
+      valid_states = [
+        GRPC::Core::ConnectivityStates::IDLE,
+        GRPC::Core::ConnectivityStates::CONNECTING,
+        GRPC::Core::ConnectivityStates::READY,
+        GRPC::Core::ConnectivityStates::TRANSIENT_FAILURE,
+        GRPC::Core::ConnectivityStates::FATAL_FAILURE,
+      ]
+
+      expect(valid_states).to include(ch.connectivity_state)
+    end
+  end
+
   describe '::SSL_TARGET' do
     it 'is a symbol' do
       expect(GRPC::Core::Channel::SSL_TARGET).to be_a(Symbol)

--- a/src/ruby/spec/channel_spec.rb
+++ b/src/ruby/spec/channel_spec.rb
@@ -166,6 +166,11 @@ describe GRPC::Core::Channel do
 
       expect(valid_states).to include(ch.connectivity_state)
     end
+
+    it 'takes an optional parameter' do
+      ch = GRPC::Core::Channel.new(fake_host, nil, :this_channel_is_insecure)
+      ch.connectivity_state(true)
+    end
   end
 
   describe '::SSL_TARGET' do

--- a/src/ruby/spec/channel_spec.rb
+++ b/src/ruby/spec/channel_spec.rb
@@ -161,7 +161,7 @@ describe GRPC::Core::Channel do
         GRPC::Core::ConnectivityStates::CONNECTING,
         GRPC::Core::ConnectivityStates::READY,
         GRPC::Core::ConnectivityStates::TRANSIENT_FAILURE,
-        GRPC::Core::ConnectivityStates::FATAL_FAILURE,
+        GRPC::Core::ConnectivityStates::FATAL_FAILURE
       ]
 
       expect(valid_states).to include(ch.connectivity_state)


### PR DESCRIPTION
The method used to always raise a TypeError:

>  no implicit conversion of false into Integer

This change also corrects the rdoc of the method.