### PR TITLE
re-enable ruby tests on mac

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -645,18 +645,11 @@ class RubyLanguage(object):
     _check_compiler(self.args.compiler, ['default'])
 
   def test_specs(self):
-    #TODO(apolcyn) turn mac ruby tests back on once ruby 2.4 issues done
-    if platform_string() == 'mac':
-      print('skipping ruby test_specs on mac until running on 2.4')
-      return []
     return [self.config.job_spec(['tools/run_tests/helper_scripts/run_ruby.sh'],
                                  timeout_seconds=10*60,
                                  environ=_FORCE_ENVIRON_FOR_WRAPPERS)]
 
   def pre_build_steps(self):
-    if platform_string() == 'mac':
-      print('skipping ruby pre_build_steps on mac until running on 2.4')
-      return []
     return [['tools/run_tests/helper_scripts/pre_build_ruby.sh']]
 
   def make_targets(self):
@@ -666,15 +659,9 @@ class RubyLanguage(object):
     return []
 
   def build_steps(self):
-    if platform_string() == 'mac':
-      print('skipping ruby build_steps on mac until running on 2.4')
-      return []
     return [['tools/run_tests/helper_scripts/build_ruby.sh']]
 
   def post_tests_steps(self):
-    if platform_string() == 'mac':
-      print('skipping ruby post_test_steps on mac until running on 2.4')
-      return []
     return [['tools/run_tests/helper_scripts/post_tests_ruby.sh']]
 
   def makefile_name(self):


### PR DESCRIPTION
revert https://github.com/grpc/grpc/pull/9589 since `google-protobuf` 3.2 gem now out