### PR TITLE
Implement NodeJS client interceptor framework

### DIFF
--- a/src/node/index.js
+++ b/src/node/index.js
@@ -243,6 +243,13 @@ exports.getClientChannel = client.getClientChannel;
 
 exports.waitForClientReady = client.waitForClientReady;
 
+exports.InterceptorProvider = client.InterceptorProvider;
+exports.StatusBuilder = client.StatusBuilder;
+exports.ListenerBuilder = client.ListenerBuilder;
+exports.RequesterBuilder = client.RequesterBuilder;
+exports.InterceptingCall = client.InterceptingCall;
+exports.MethodType = client.MethodType;
+
 /**
  * @memberof grpc
  * @alias grpc.closeClient

--- a/src/node/src/client_batches.js
+++ b/src/node/src/client_batches.js
@@ -1,0 +1,586 @@
+/*
+ *
+ * Copyright 2015, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+/**
+ * Client Batches module
+ *
+ * Defines the batch types a client can process and provides methods to wire
+ * inbound and outbound batch logic into a call.
+ * @module
+ */
+'use strict';
+
+var _ = require('lodash');
+var constants = require('./constants');
+var grpc = require('./grpc_extension');
+var Metadata = require('./metadata');
+
+var BATCH_TYPE = {
+  UNARY: 0,
+  METADATA: 1,
+  CLOSE: 2,
+  SEND_STREAMING: 3,
+  RECV_STREAMING: 4,
+  STATUS: 5,
+  SEND_SYNC: 6,
+  RECV_SYNC: 7
+};
+
+var ACTIONS = {};
+ACTIONS[BATCH_TYPE.UNARY] = _registerUnaryBatch;
+ACTIONS[BATCH_TYPE.METADATA] = _registerMetadataBatch;
+ACTIONS[BATCH_TYPE.RECV_SYNC] = _registerRecvSync;
+ACTIONS[BATCH_TYPE.SEND_STREAMING] = _registerSendStreaming;
+ACTIONS[BATCH_TYPE.CLOSE] = _registerClose;
+ACTIONS[BATCH_TYPE.SEND_SYNC] = _registerSendSync;
+ACTIONS[BATCH_TYPE.STATUS] = _registerStatus;
+ACTIONS[BATCH_TYPE.RECV_STREAMING] = _registerRecvStreaming;
+
+/**
+ * A container for the properties of a batch definition
+ * @param {number[]} batch_ops The operations performed by the batch
+ * @param {number[]} trigger_ops The operations which can trigger the
+ * execution of a batch. Useful for determining when to start batches which
+ * only include receive operations.
+ * @param {function} outbound_handler Runs when all the outbound operations are
+ * ready.
+ * @param {function} inbound_handler Runs when all the inbound operations are
+ * @constructor
+ */
+function BatchDefinition(batch_ops, trigger_ops, outbound_handler,
+                         inbound_handler) {
+  this.batch_ops = batch_ops;
+  this.trigger_ops = trigger_ops;
+  this.outbound_handler = outbound_handler;
+  this.inbound_handler = inbound_handler;
+}
+
+/**
+ * Returns the appropriate batch handler (inbound or outbound)
+ * @param {boolean} is_outbound
+ * @returns {function}
+ */
+BatchDefinition.prototype.getHandler = function(is_outbound) {
+  return is_outbound ? this.outbound_handler : this.inbound_handler;
+};
+
+/**
+ * A list of batch definitions, used to group the batches for each
+ * RPC type and maintain the state of each operation.
+ * @constructor
+ */
+function BatchRegistry() {
+  this.batches = [];
+}
+
+/**
+ * Create a batch definition and add it to the registry
+ * @param {number[]} batch_ops The operations performed by the batch
+ * @param {number[]} trigger_ops The operations which can trigger the
+ * execution of a batch. Useful for determining when to start batches which
+ * only include receive operations.
+ * @param {function} outbound_handler Runs when all the outbound operations are
+ * ready.
+ * @param {function} inbound_handler Runs when all the inbound operations are
+ * ready.
+ */
+BatchRegistry.prototype.add = function(batch_ops, trigger_ops, outbound_handler,
+                                       inbound_handler) {
+  var definition = new BatchDefinition(batch_ops, trigger_ops, outbound_handler,
+    inbound_handler);
+  this.batches.push(definition);
+};
+
+/**
+ * Populate a BatchRegistry with a set of batch handlers linked to a given
+ * EventEmitter and the consumer's callback.
+ * @param {EventEmitter} emitter Sends events to the consumer on batch
+ * completion.
+ * @param {BatchRegistry} batch_registry A container for the batch handlers
+ * @param {number[]} batch_types A list of batch types to handle
+ * @param {object} options
+ * @param {function} callback The consumer's callback, executed when batches
+ * complete
+ */
+function registerBatches(emitter, batch_registry, batch_types, options,
+                          callback) {
+  _.each(batch_types, function(batch_type) {
+    ACTIONS[batch_type](emitter, batch_registry, options, callback);
+  });
+}
+
+/**
+ * Create handlers for the unary batch logic and add them to a registry
+ * @param {EventEmitter} emitter Sends events to the consumer on batch
+ * completion.
+ * @param {BatchRegistry} batch_registry A container for the batch handlers
+ * @param {object} options
+ * @param {function} callback The consumer's callback, executed when batches
+ * complete
+ * @private
+ */
+function _registerUnaryBatch(emitter, batch_registry, options, callback) {
+  var handle_inbound = function(batch) {
+    var metadata = batch[grpc.opType.RECV_INITIAL_METADATA];
+    var message = batch[grpc.opType.RECV_MESSAGE];
+    var status = batch[grpc.opType.RECV_STATUS_ON_CLIENT];
+    var error;
+    emitter.emit('metadata', metadata);
+    if (status.code !== constants.status.OK) {
+      error = new Error(status.details);
+      error.code = status.code;
+      error.metadata = status.metadata;
+      callback(error);
+    } else {
+      callback(null, message);
+    }
+    emitter.emit('status', status);
+  };
+
+  var handle_outbound = function(batch, call, listener) {
+    var raw_message = batch[grpc.opType.SEND_MESSAGE];
+    var message = options.method_descriptor.serialize(raw_message);
+    if (options) {
+      message.grpcWriteFlags = options.flags;
+    }
+    var raw_metadata = batch[grpc.opType.SEND_INITIAL_METADATA];
+    var metadata = raw_metadata._getCoreRepresentation();
+    batch[grpc.opType.SEND_MESSAGE] = message;
+    batch[grpc.opType.SEND_INITIAL_METADATA] = metadata;
+    batch[grpc.opType.SEND_CLOSE_FROM_CLIENT] = true;
+    batch[grpc.opType.RECV_INITIAL_METADATA] = true;
+    batch[grpc.opType.RECV_MESSAGE] = true;
+    batch[grpc.opType.RECV_STATUS_ON_CLIENT] = true;
+
+    call.startBatch(batch, function(err, response) {
+      response.status.metadata = Metadata._fromCoreRepresentation(
+        response.status.metadata);
+      var status = response.status;
+      var deserialized;
+      if (status.code === constants.status.OK) {
+        if (err) {
+          // Got a batch error, but OK status. Something went wrong
+          callback(err);
+          return;
+        } else {
+          try {
+            deserialized = options.method_descriptor.deserialize(response.read);
+          } catch (e) {
+            /* Change status to indicate bad server response. This will result
+             * in passing an error to the callback */
+            status = {
+              code: constants.status.INTERNAL,
+              details: 'Failed to parse server response'
+            };
+          }
+        }
+      }
+      response.metadata = Metadata._fromCoreRepresentation(response.metadata);
+      listener.onReceiveMetadata(response.metadata);
+      listener.onReceiveMessage(deserialized);
+      listener.onReceiveStatus(status);
+    });
+  };
+
+  var batch_ops = [
+    grpc.opType.SEND_INITIAL_METADATA,
+    grpc.opType.SEND_MESSAGE,
+    grpc.opType.SEND_CLOSE_FROM_CLIENT,
+    grpc.opType.RECV_INITIAL_METADATA,
+    grpc.opType.RECV_MESSAGE,
+    grpc.opType.RECV_STATUS_ON_CLIENT
+  ];
+
+  batch_registry.add(batch_ops, batch_ops, handle_outbound, handle_inbound);
+}
+
+/**
+ * Create handlers for the metadata batch logic and add them to a registry
+ * @param {EventEmitter} emitter Sends events to the consumer on batch
+ * completion.
+ * @param {BatchRegistry} batch_registry A container for the batch handlers
+ * @private
+ */
+function _registerMetadataBatch(emitter, batch_registry) {
+
+  var handle_inbound = function(batch) {
+    var metadata = batch[grpc.opType.RECV_INITIAL_METADATA];
+    emitter.emit('metadata', metadata);
+  };
+
+  var handle_outbound = function(batch, call, listener) {
+    var metadata_batch = {};
+    var raw_metadata = batch[grpc.opType.SEND_INITIAL_METADATA];
+    var metadata = raw_metadata._getCoreRepresentation();
+    metadata_batch[grpc.opType.SEND_INITIAL_METADATA] = metadata;
+    metadata_batch[grpc.opType.RECV_INITIAL_METADATA] = true;
+    call.startBatch(metadata_batch, function(err, response) {
+      if (err) {
+        // The call has stopped for some reason. A non-OK status will arrive
+        // in the other batch.
+        return;
+      }
+      response.metadata = Metadata._fromCoreRepresentation(response.metadata);
+      listener.onReceiveMetadata(response.metadata);
+    });
+  };
+
+  var batch_ops = [
+    grpc.opType.SEND_INITIAL_METADATA,
+    grpc.opType.RECV_INITIAL_METADATA
+  ];
+
+  batch_registry.add(batch_ops, batch_ops, handle_outbound, handle_inbound);
+}
+
+/**
+ * Create handlers for the synchronous message receive batch logic and
+ * add them to a registry.
+ * @param {EventEmitter} emitter Sends events to the consumer on batch
+ * completion.
+ * @param {BatchRegistry} batch_registry A container for the batch handlers
+ * @param {object} options
+ * @param {function} callback The consumer's callback, executed when batches
+ * complete
+ * @private
+ */
+function _registerRecvSync(emitter, batch_registry, options, callback) {
+  var handle_inbound = function(batch) {
+    var message = batch[grpc.opType.RECV_MESSAGE];
+    var status = batch[grpc.opType.RECV_STATUS_ON_CLIENT];
+    var error;
+    if (status.code !== constants.status.OK) {
+      error = new Error(status.details);
+      error.code = status.code;
+      error.metadata = status.metadata;
+      callback(error);
+    } else {
+      callback(null, message);
+    }
+    emitter.emit('status', status);
+  };
+
+  var handle_outbound = function(batch, call, listener) {
+    var client_batch = {};
+    client_batch[grpc.opType.RECV_MESSAGE] = true;
+    client_batch[grpc.opType.RECV_STATUS_ON_CLIENT] = true;
+    call.startBatch(client_batch, function(err, response) {
+      response.status.metadata = Metadata._fromCoreRepresentation(
+        response.status.metadata);
+      var status = response.status;
+      var deserialized;
+      if (status.code === constants.status.OK) {
+        if (err) {
+          // Got a batch error, but OK status. Something went wrong
+          callback(err);
+          return;
+        } else {
+          try {
+            deserialized = options.method_descriptor.deserialize(response.read);
+          } catch (e) {
+            /* Change status to indicate bad server response. This will result
+             * in passing an error to the callback */
+            status = {
+              code: constants.status.INTERNAL,
+              details: 'Failed to parse server response'
+            };
+          }
+        }
+      }
+      listener.onReceiveMessage(deserialized);
+      listener.onReceiveStatus(status);
+    });
+  };
+
+  var batch_ops = [
+    grpc.opType.RECV_MESSAGE,
+    grpc.opType.RECV_STATUS_ON_CLIENT
+  ];
+
+  var trigger_ops = [
+    grpc.opType.SEND_INITIAL_METADATA,
+    grpc.opType.RECV_MESSAGE,
+    grpc.opType.RECV_STATUS_ON_CLIENT
+  ];
+
+  batch_registry.add(batch_ops, trigger_ops, handle_outbound, handle_inbound);
+}
+
+/**
+ * Create handlers for the stream message send batch logic and add them to a
+ * registry.
+ * @param {EventEmitter} emitter Sends events to the consumer on batch
+ * completion.
+ * @param {BatchRegistry} batch_registry A container for the batch handlers
+ * @param {object} options
+ * @private
+ */
+function _registerSendStreaming(emitter, batch_registry, options) {
+
+  var handle_outbound = function(batch, call, listener, context) {
+    var message;
+    var chunk = batch[grpc.opType.SEND_MESSAGE];
+    var callback = context.callback;
+    var encoding = context.encoding;
+    if (emitter.writeFailed) {
+      /* Once a write fails, just call the callback immediately to let the
+         caller flush any pending writes. */
+      callback();
+    }
+    try {
+      message = options.method_descriptor.serialize(chunk);
+    } catch (e) {
+      /* Sending this error to the server and emitting it immediately on the
+       client may put the call in a slightly weird state on the client side,
+       but passing an object that causes a serialization failure is a misuse
+       of the API anyway, so that's OK. The primary purpose here is to give the
+       programmer a useful error and to stop the stream properly */
+      call.cancelWithStatus(constants.status.INTERNAL, 'Serialization failure');
+      if (callback) {
+        callback(e);
+      }
+    }
+    if (_.isFinite(encoding)) {
+      /* Attach the encoding if it is a finite number. This is the closest we
+       * can get to checking that it is valid flags */
+      message.grpcWriteFlags = encoding;
+    } else {
+      message.grpcWriteFlags = options.flags;
+    }
+    var streaming_batch = {};
+    streaming_batch[grpc.opType.SEND_MESSAGE] = message;
+    call.startBatch(streaming_batch, function(err, event) {
+      if (err) {
+        /* Assume that the call is complete and that writing failed because a
+           status was received. In that case, set a flag to discard all future
+           writes */
+        emitter.writeFailed = true;
+        return;
+      }
+      if (callback) {
+        callback();
+      }
+    });
+  };
+  var batch_ops = [
+    grpc.opType.SEND_MESSAGE
+  ];
+
+  batch_registry.add(batch_ops, batch_ops, handle_outbound);
+}
+
+/**
+ * Create handlers for the client-close batch logic and add them to a registry.
+ * @param {EventEmitter} emitter Sends events to the consumer on batch
+ * completion.
+ * @param {BatchRegistry} batch_registry A container for the batch handlers
+ * @private
+ */
+function _registerClose(emitter, batch_registry) {
+  var handle_outbound = function(batch, call) {
+    var end_batch = {};
+    end_batch[grpc.opType.SEND_CLOSE_FROM_CLIENT] = true;
+    call.startBatch(end_batch, function() {});
+  };
+
+  var batch_ops = [
+    grpc.opType.SEND_CLOSE_FROM_CLIENT
+  ];
+
+  batch_registry.add(batch_ops, batch_ops, handle_outbound);
+}
+
+/**
+ * Create handlers for the synchronous message send logic and add them to a
+ * registry.
+ * @param {EventEmitter} emitter Sends events to the consumer on batch
+ * completion.
+ * @param {BatchRegistry} batch_registry A container for the batch handlers
+ * @param {object} options
+ * @private
+ */
+function _registerSendSync(emitter, batch_registry, options) {
+
+  var handle_inbound = function(batch) {
+    var metadata = batch[grpc.opType.RECV_INITIAL_METADATA];
+    emitter.emit('metadata', metadata);
+  };
+
+  var handle_outbound = function(batch, call, listener) {
+    var start_batch = {};
+    var raw_message = batch[grpc.opType.SEND_MESSAGE];
+    var message = options.method_descriptor.serialize(raw_message);
+    if (options) {
+      message.grpcWriteFlags = options.flags;
+    }
+    var raw_metadata = batch[grpc.opType.SEND_INITIAL_METADATA];
+    var metadata = raw_metadata._getCoreRepresentation();
+    start_batch[grpc.opType.SEND_INITIAL_METADATA] = metadata;
+    start_batch[grpc.opType.SEND_MESSAGE] = message;
+    start_batch[grpc.opType.SEND_CLOSE_FROM_CLIENT] = true;
+    start_batch[grpc.opType.RECV_INITIAL_METADATA] = true;
+    call.startBatch(start_batch, function(err, response) {
+      if (err) {
+        // The call has stopped for some reason. A non-OK status will arrive
+        // in the other batch.
+        return;
+      }
+      response.metadata = Metadata._fromCoreRepresentation(response.metadata);
+      listener.onReceiveMetadata(response.metadata);
+    });
+  };
+
+  var batch_ops = [
+    grpc.opType.SEND_INITIAL_METADATA,
+    grpc.opType.RECV_INITIAL_METADATA,
+    grpc.opType.SEND_MESSAGE,
+    grpc.opType.SEND_CLOSE_FROM_CLIENT
+  ];
+
+  batch_registry.add(batch_ops, batch_ops, handle_outbound, handle_inbound);
+}
+
+/**
+ * Create handlers for the status receive batch logic and add them to a
+ * registry.
+ * @param {EventEmitter} emitter Sends events to the consumer on batch
+ * completion.
+ * @param {BatchRegistry} batch_registry A container for the batch handlers
+ * @private
+ */
+function _registerStatus(emitter, batch_registry) {
+  var handle_inbound = function(batch) {
+    var status = batch[grpc.opType.RECV_STATUS_ON_CLIENT];
+    emitter._receiveStatus(status);
+  };
+
+  var handle_outbound = function(batch, call, listener) {
+    var status_batch = {};
+    status_batch[grpc.opType.RECV_STATUS_ON_CLIENT] = true;
+    call.startBatch(status_batch, function(err, response) {
+      if (err) {
+        emitter.emit('error', err);
+        return;
+      }
+      response.status.metadata = Metadata._fromCoreRepresentation(
+        response.status.metadata);
+      listener.onReceiveStatus(response.status);
+    });
+  };
+
+  var batch_ops = [
+    grpc.opType.RECV_STATUS_ON_CLIENT
+  ];
+
+  var trigger_ops = [
+    grpc.opType.SEND_INITIAL_METADATA,
+    grpc.opType.RECV_STATUS_ON_CLIENT
+  ];
+
+  batch_registry.add(batch_ops, trigger_ops, handle_outbound, handle_inbound);
+}
+
+/**
+ * Create handlers for the streaming message receive batch logic and add them
+ * to a registry.
+ * @param {EventEmitter} emitter Sends events to the consumer on batch
+ * completion.
+ * @param {BatchRegistry} batch_registry A container for the batch handlers
+ * @param {object} options
+ * @private
+ */
+function _registerRecvStreaming(emitter, batch_registry, options) {
+  var getCallback = function(stream, call, listener) {
+    return function(err, response) {
+      if (err) {
+        // Something has gone wrong. Stop reading and wait for status
+        stream.finished = true;
+        stream._readsDone();
+        return;
+      }
+      var context = {
+        stream: stream,
+        call: call,
+        listener: listener
+      };
+      var data = response.read;
+      var deserialized;
+      try {
+        deserialized = options.method_descriptor.deserialize(data);
+      } catch (e) {
+        stream._readsDone({code: constants.status.INTERNAL,
+          details: 'Failed to parse server response'});
+        return;
+      }
+      if (data === null) {
+        stream._readsDone();
+        return;
+      }
+      listener.recvMessageWithContext(context, deserialized);
+    };
+  };
+  var handle_inbound = function(batch, context) {
+    var message = batch[grpc.opType.RECV_MESSAGE];
+    var stream_obj = context.stream;
+    var call = context.call;
+    var listener = context.listener;
+    if (stream_obj.push(message) && message !== null) {
+      var read_batch = {};
+      read_batch[grpc.opType.RECV_MESSAGE] = true;
+      call.startBatch(read_batch, getCallback(context.stream, call, listener));
+    } else {
+      stream_obj.reading = false;
+    }
+  };
+
+  var handle_outbound = function(batch, call, listener, context) {
+    context.call = call;
+    context.listener = listener;
+    var read_batch = {};
+    read_batch[grpc.opType.RECV_MESSAGE] = true;
+    call.startBatch(read_batch, getCallback(context.stream, call, listener));
+  };
+
+  var batch_ops = [
+    grpc.opType.RECV_MESSAGE
+  ];
+
+  var trigger_ops = [
+    grpc.opType.RECV_MESSAGE
+  ];
+
+  batch_registry.add(batch_ops, trigger_ops, handle_outbound, handle_inbound);
+}
+
+module.exports.registerBatches = registerBatches;
+module.exports.BATCH_TYPE = BATCH_TYPE;
+module.exports.BatchRegistry = BatchRegistry;

--- a/src/node/src/client_interceptors.js
+++ b/src/node/src/client_interceptors.js
@@ -1,0 +1,1082 @@
+/*
+ *
+ * Copyright 2015, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/**
+ * Client Interceptors
+ *
+ * This module describes the interceptor framework for clients.
+ * An interceptor is a function which takes an options object and a nextCall
+ * function and returns an InterceptingCall:
+ *
+ * var interceptor = function(options, nextCall) {
+ *   return new InterceptingCall(nextCall(options));
+ * }
+ *
+ * The interceptor function must return an InterceptingCall object. Returning
+ * `new InterceptingCall(nextCall(options))` will satisfy the contract (but
+ * provide no interceptor functionality). `nextCall` is a function which will
+ * run the next interceptor in the chain.
+ *
+ * To implement interceptor functionality, create a requester and pass it to
+ * the InterceptingCall constructor:
+ *
+ * return new InterceptingCall(nextCall(options), requester);
+ *
+ * A requester is a POJO with zero or more of the following methods:
+ *
+ * `start(metadata, listener, next)`
+ * * To continue, call next(metadata, listener). Listeners are described
+ * * below.
+ *
+ * `sendMessage(message, next)`
+ * * To continue, call next(message).
+ *
+ * `halfClose(next)`
+ * * To continue, call next().
+ *
+ * `cancel(message, next)`
+ * * To continue, call next().
+ *
+ * A listener is a POJO with one or more of the following methods:
+ *
+ * `onReceiveMetadata(metadata, next)`
+ * * To continue, call next(metadata)
+ *
+ * `onReceiveMessage(message, next)`
+ * * To continue, call next(message)
+ *
+ * `onReceiveStatus(status, next)`
+ * * To continue, call next(status)
+ *
+ * A listener is passed into the requester's `start` method. This provided
+ * listener implements all the inbound interceptor methods, which can be called
+ * to short-circuit the gRPC call.
+ *
+ * Three usage patterns are supported for listeners:
+ * 1) Pass the listener along without modification: `next(metadata, listener)`.
+ *   In this case the interceptor declines to intercept any inbound operations.
+ * 2) Create a new listener with one or more inbound interceptor methods and
+ *   pass it to `next`. In this case the interceptor will fire on the inbound
+ *   operations implemented in the new listener.
+ * 3) Store the listener to make direct inbound calls on later. This effectively
+ *   short-circuits the interceptor stack.
+ *
+ * Do not modify the listener passed in. Either pass it along unmodified or call
+ * methods on it to short-circuit the interceptor stack.
+ *
+ * To intercept errors, implement the `onReceiveStatus` method and test for
+ * `status.code !== grpc.status.OK`.
+ *
+ * To intercept trailers, examine `status.metadata` in the `onReceiveStatus`
+ * method.
+ *
+ * This is a trivial implementation of all interceptor methods:
+ * var interceptor = function(options, nextCall) {
+ *   return new InterceptingCall(nextCall(options), {
+ *     start: function(metadata, listener, next) {
+ *       next(metadata, {
+ *         onReceiveMetadata: function (metadata, next) {
+ *           next(metadata);
+ *         },
+ *         onReceiveMessage: function (message, next) {
+ *           next(message);
+ *         },
+ *         onReceiveStatus: function (status, next) {
+ *           next(status);
+ *         },
+ *       });
+ *     },
+ *     sendMessage: function(message, next) {
+ *       next(message);
+ *     },
+ *     halfClose: function(next) {
+ *       next();
+ *     },
+ *     cancel: function(message, next) {
+ *       next();
+ *     }
+ *   });
+ * };
+ *
+ * This is an interceptor with a single method:
+ * var interceptor = function(options, nextCall) {
+ *   return new InterceptingCall(nextCall(options), {
+ *     sendMessage: function(message, next) {
+ *       next(message);
+ *     }
+ *   });
+ * };
+ *
+ * Builders are provided for convenience: StatusBuilder, ListenerBuilder,
+ * and RequesterBuilder
+ *
+ * gRPC client operations use this mapping to interceptor methods:
+ *
+ * grpc.opType.SEND_INITIAL_METADATA -> start
+ * grpc.opType.SEND_MESSAGE -> sendMessage
+ * grpc.opType.SEND_CLOSE_FROM_CLIENT -> halfClose
+ * grpc.opType.RECV_INITIAL_METADATA -> onReceiveMetadata
+ * grpc.opType.RECV_MESSAGE -> onReceiveMessage
+ * grpc.opType.RECV_STATUS_ON_CLIENT -> onReceiveStatus
+ *
+ * @module
+ */
+
+'use strict';
+
+var _ = require('lodash');
+var grpc = require('./grpc_extension');
+
+var OUTBOUND_OPS = [
+  grpc.opType.SEND_INITIAL_METADATA,
+  grpc.opType.SEND_MESSAGE,
+  grpc.opType.SEND_CLOSE_FROM_CLIENT
+];
+
+var INBOUND_OPS = [
+  grpc.opType.RECV_INITIAL_METADATA,
+  grpc.opType.RECV_MESSAGE,
+  grpc.opType.RECV_STATUS_ON_CLIENT
+];
+
+/**
+ * A custom error thrown when interceptor configuration fails
+ * @param {string} message The error message
+ * @param {object} [extra]
+ * @constructor
+ */
+var InterceptorConfigurationError =
+  function InterceptorConfigurationError(message, extra) {
+    Error.captureStackTrace(this, this.constructor);
+    this.name = this.constructor.name;
+    this.message = message;
+    this.extra = extra;
+  };
+
+require('util').inherits(InterceptorConfigurationError, Error);
+
+/**
+ * A builder for gRPC status objects
+ * @constructor
+ */
+function StatusBuilder() {
+  this.code = null;
+  this.details = null;
+  this.metadata = null;
+}
+
+/**
+ * Adds a status code to the builder
+ * @param {number} code The status code
+ * @return {StatusBuilder}
+ */
+StatusBuilder.prototype.withCode = function(code) {
+  this.code = code;
+  return this;
+};
+
+/**
+ * Adds details to the builder
+ * @param {string} details A status message
+ * @return {StatusBuilder}
+ */
+StatusBuilder.prototype.withDetails = function(details) {
+  this.details = details;
+  return this;
+};
+
+/**
+ * Adds metadata to the builder
+ * @param {Metadata} metadata The gRPC status metadata
+ * @return {StatusBuilder}
+ */
+StatusBuilder.prototype.withMetadata = function(metadata) {
+  this.metadata = metadata;
+  return this;
+};
+
+/**
+ * Builds the status object
+ * @return {object} A gRPC status
+ */
+StatusBuilder.prototype.build = function() {
+  var status = {};
+  if (this.code !== undefined) {
+    status.code = this.code;
+  }
+  if (this.details) {
+    status.details = this.details;
+  }
+  if (this.metadata) {
+    status.metadata = this.metadata;
+  }
+  return status;
+};
+
+/**
+ * A builder for listener interceptors
+ * @constructor
+ */
+function ListenerBuilder() {
+  this.metadata = null;
+  this.message = null;
+  this.status = null;
+}
+
+/**
+ * Adds an onReceiveMetadata method to the builder
+ * @param {Function} on_receive_metadata A listener method for receiving
+ * metadata
+ * @return {ListenerBuilder}
+ */
+ListenerBuilder.prototype.withOnReceiveMetadata =
+  function(on_receive_metadata) {
+    this.metadata = on_receive_metadata;
+    return this;
+  };
+
+/**
+ * Adds an onReceiveMessage method to the builder
+ * @param {Function} on_receive_message A listener method for receiving messages
+ * @return {ListenerBuilder}
+ */
+ListenerBuilder.prototype.withOnReceiveMessage = function(on_receive_message) {
+  this.message = on_receive_message;
+  return this;
+};
+
+/**
+ * Adds an onReceiveStatus method to the builder
+ * @param {Function} on_receive_status A listener method for receiving status
+ * @return {ListenerBuilder}
+ */
+ListenerBuilder.prototype.withOnReceiveStatus = function(on_receive_status) {
+  this.status = on_receive_status;
+  return this;
+};
+
+/**
+ * Builds the call listener
+ * @return {object}
+ */
+ListenerBuilder.prototype.build = function() {
+  var self = this;
+  var listener = {};
+  listener.onReceiveMetadata = self.metadata;
+  listener.onReceiveMessage = self.message;
+  listener.onReceiveStatus = self.status;
+  return listener;
+};
+
+/**
+ * A builder for the outbound methods of an interceptor
+ * @constructor
+ */
+function RequesterBuilder() {
+  this.start = null;
+  this.message = null;
+  this.half_close = null;
+  this.cancel = null;
+}
+
+/**
+ * Add a `start` interceptor
+ * @param {Function} start A requester method for handling `start`
+ * @return {RequesterBuilder}
+ */
+RequesterBuilder.prototype.withStart = function(start) {
+  this.start = start;
+  return this;
+};
+
+/**
+ * Add a `sendMessage` interceptor
+ * @param {Function} send_message A requester method for handling `sendMessage`
+ * @return {RequesterBuilder}
+ */
+RequesterBuilder.prototype.withSendMessage = function(send_message) {
+  this.message = send_message;
+  return this;
+};
+
+/**
+ * Add a `halfClose` interceptor
+ * @param {Function} half_close A requester method for handling `halfClose`
+ * @return {RequesterBuilder}
+ */
+RequesterBuilder.prototype.withHalfClose = function(half_close) {
+  this.half_close = half_close;
+  return this;
+};
+
+/**
+ * Add a `cancel` interceptor
+ * @param {Function} cancel A requester method for handling `cancel`
+ * @return {RequesterBuilder}
+ */
+RequesterBuilder.prototype.withCancel = function(cancel) {
+  this.cancel = cancel;
+  return this;
+};
+
+/**
+ * Builds the requester's interceptor methods
+ * @return {object}
+ */
+RequesterBuilder.prototype.build = function() {
+  var interceptor = {};
+  interceptor.start = this.start;
+  interceptor.sendMessage = this.message;
+  interceptor.halfClose = this.half_close;
+  interceptor.cancel = this.cancel;
+  return interceptor;
+};
+
+/**
+ * A simple type for determining whether an interceptor applies to a given gRPC
+ * method.
+ * @param {function} get_interceptor Takes a MethodDescriptor and returns an
+ * interceptor (if it applies to the method)
+ * @constructor
+ */
+var InterceptorProvider = function(get_interceptor) {
+  this.get_interceptor = get_interceptor;
+};
+
+/**
+ * Determines if an interceptor applies to a given method
+ * @param {MethodDescriptor} method_descriptor
+ * @returns {function|undefined} Either an interceptor function, or a falsey
+ * value indicating the interceptor does not apply.
+ */
+InterceptorProvider.prototype.getInterceptorForMethod =
+  function(method_descriptor) {
+    return this.get_interceptor(method_descriptor);
+  };
+
+/**
+ * Transforms a list of interceptor providers into interceptors
+ * @param {object[]} providers The interceptor providers
+ * @param {MethodDescriptor} method_descriptor
+ * @return {null|function[]} An array of interceptors or null
+ */
+var resolveInterceptorProviders = function(providers, method_descriptor) {
+  if (!_.isArray(providers)) {
+    return null;
+  }
+  return _.flatMap(providers, function(provider) {
+    if (!_.isFunction(provider.getInterceptorForMethod)) {
+      throw new InterceptorConfigurationError(
+        'InterceptorProviders must implement `getInterceptorForMethod`');
+    }
+    var interceptor = provider.getInterceptorForMethod(method_descriptor);
+    return interceptor ? [interceptor] : [];
+  });
+};
+
+/**
+ * Resolves interceptor options at call invocation time
+ * @param {object} options The call options passed to a gRPC call
+ * @param {function[]} [options.interceptors] An array of interceptors
+ * @param {object[]} [options.interceptor_providers] An array of providers
+ * @param {MethodDescriptor} method_descriptor
+ * @return {null|function[]} The resulting interceptors
+ */
+var resolveInterceptorOptions = function(options, method_descriptor) {
+  var provided = resolveInterceptorProviders(options.interceptor_providers,
+    method_descriptor);
+  var interceptor_options = [
+    options.interceptors,
+    provided
+  ];
+  var too_many_options = _.every(interceptor_options, function(interceptors) {
+    return _.isArray(interceptors);
+  });
+  if (too_many_options) {
+    throw new InterceptorConfigurationError(
+      'Both interceptors and interceptor_providers were passed as options ' +
+      'to the call invocation. Only one of these is allowed.');
+  }
+  return _.find(interceptor_options, function(interceptors) {
+      return _.isArray(interceptors);
+    }) || null;
+};
+
+/**
+ * Process call options and the interceptor override layers to get the final set
+ * of interceptors
+ * @param {object} call_options The options passed to the gRPC call
+ * @param {function[]} constructor_interceptors Interceptors passed to the
+ * client constructor
+ * @param {MethodDescriptor} method_descriptor Details of the gRPC call method
+ * @return {Function[]|null} The final set of interceptors
+ */
+var processInterceptorLayers = function(call_options,
+                                        constructor_interceptors,
+                                        method_descriptor) {
+  var calltime_interceptors = resolveInterceptorOptions(call_options,
+    method_descriptor);
+  var interceptor_overrides = [
+    calltime_interceptors,
+    constructor_interceptors
+  ];
+  return _resolveInterceptorOverrides(interceptor_overrides);
+};
+
+/**
+ * A chain-able gRPC call proxy which will delegate to an optional requester
+ * object. By default, interceptor methods will chain to next_call. If a
+ * requester is provided which implements an interceptor method, that
+ * requester method will be executed as part of the chain.
+ * @param {InterceptingCall|null} next_call The next call in the chain
+ * @param {object} [requester] An object containing optional delegate methods
+ * @constructor
+ */
+function InterceptingCall(next_call, requester) {
+  _validateRequester(requester);
+  this.next_call = next_call;
+  this.requester = requester;
+}
+
+/**
+ * Get the next method in the chain or a no-op function if we are at the end
+ * of the chain
+ * @param {string} method_name
+ * @return {Function} The next method in the chain
+ * @private
+ */
+InterceptingCall.prototype._getNextCall = function(method_name) {
+  return this.next_call ?
+    this.next_call[method_name].bind(this.next_call) :
+    function(){};
+};
+
+/**
+ * Call the next method in the chain. This will either be on the next
+ * InterceptingCall (next_call), or the requester if the requester
+ * implements the method.
+ * @param {string} method_name The name of the interceptor method
+ * @param {array} [args] Payload arguments for the operation
+ * @param {function} [next] The next InterceptingCall's method
+ * @return {*}
+ * @private
+ */
+InterceptingCall.prototype._callNext = function(method_name, args, next) {
+  var args_array = args || [];
+  var next_call = next ? next : this._getNextCall(method_name);
+  if (this.requester && this.requester[method_name]) {
+    var delegate_args = _.concat(args_array, next_call);
+    return this.requester[method_name].apply(this.requester, delegate_args);
+  } else {
+    return next_call.apply(null, args_array);
+  }
+};
+
+/**
+ * Starts a call through the outbound interceptor chain and adds an element to
+ * the reciprocal inbound listener chain.
+ * @param {Metadata} metadata The outgoing metadata
+ * @param {object} listener An intercepting listener for inbound ops
+ */
+InterceptingCall.prototype.start = function(metadata, listener) {
+  var self = this;
+
+  _validateListener(listener);
+
+  // If the listener provided is an InterceptingListener, use it. Otherwise, we
+  // must be at the end of the listener chain, and any listener operations
+  // should be terminated in an EndListener.
+  var next_listener = _getInterceptingListener(listener, new EndListener());
+
+  // Build the next method in the interceptor chain
+  var next = function(metadata, current_listener) {
+    // If there is a next call in the chain, run it. Otherwise do nothing.
+    if (self.next_call) {
+      // Wire together any listener provided with the next listener
+      var listener = _getInterceptingListener(current_listener, next_listener);
+      self.next_call.start(metadata, listener);
+    }
+  };
+  this._callNext('start', [metadata, next_listener], next);
+};
+
+/**
+ * Pass a message through the interceptor chain
+ * @param {object} message
+ */
+InterceptingCall.prototype.sendMessage = function(message) {
+  this._callNext('sendMessage', [message]);
+};
+
+/**
+ * Run a close operation through the interceptor chain
+ */
+InterceptingCall.prototype.halfClose = function() {
+  this._callNext('halfClose');
+};
+
+/**
+ * Run a cancel operation through the interceptor chain
+ */
+InterceptingCall.prototype.cancel = function() {
+  this._callNext('cancel');
+};
+
+/**
+ * Run a cancelWithStatus operation through the interceptor chain
+ * @param {object} status
+ * @param {string} message
+ */
+InterceptingCall.prototype.cancelWithStatus = function(status, message) {
+  this._callNext('cancelWithStatus', [status, message]);
+};
+
+/**
+ * Pass a getPeer call down to the base gRPC call (should not be intercepted)
+ * @return {object}
+ */
+InterceptingCall.prototype.getPeer = function() {
+  return this._callNext('getPeer');
+};
+
+/**
+ * For streaming calls, we need to transparently pass the stream's context
+ * through the interceptor chain. Passes the context between InterceptingCalls
+ * but hides it from any requester implementations.
+ * @param {object} context Carries objects needed for streaming operations
+ * @param {object} message The message to send
+ */
+InterceptingCall.prototype.sendMessageWithContext = function(context, message) {
+  var next = this.next_call ?
+    this.next_call.sendMessageWithContext.bind(this.next_call, context) :
+    context;
+  this._callNext('sendMessage', [message], next);
+};
+
+/**
+ * For receiving streaming messages, we need to seed the base interceptor with
+ * the streaming context to create a RECV_MESSAGE batch.
+ * @param {object} context Carries objects needed for streaming operations
+ */
+InterceptingCall.prototype.recvMessageWithContext = function(context) {
+  this._callNext('recvMessageWithContext', [context]);
+};
+
+/**
+ * A chain-able listener object which will delegate to a custom listener when
+ * appropriate.
+ * @param {InterceptingListener|null} next_listener The next
+ * InterceptingListener in the chain
+ * @param {object|null} delegate A custom listener object which may implement
+ * specific operations
+ * @constructor
+ */
+function InterceptingListener(next_listener, delegate) {
+  this.delegate = delegate || {};
+  this.next_listener = next_listener;
+}
+
+/**
+ * Get the next method in the chain or a no-op function if we are at the end
+ * of the chain.
+ * @param {string} method_name
+ * @return {Function} The next method in the chain
+ * @private
+ */
+InterceptingListener.prototype._getNextListener = function(method_name) {
+  return this.next_listener ?
+    this.next_listener[method_name].bind(this.next_listener) :
+    function(){};
+};
+
+/**
+ * Call the next method in the chain. This will either be on the next
+ * InterceptingListener (next_listener), or the requester if the requester
+ * implements the method.
+ * @param {string} method_name The name of the interceptor method
+ * @param {array} [args] Payload arguments for the operation
+ * @param {function} [next] The next InterceptingListener's method
+ * @return {*}
+ * @private
+ */
+InterceptingListener.prototype._callNext = function(method_name, args, next) {
+  var args_array = args || [];
+  var next_listener = next ? next : this._getNextListener(method_name);
+  if (this.delegate && this.delegate[method_name]) {
+    var delegate_args = _.concat(args_array, next_listener);
+    return this.delegate[method_name].apply(this.delegate, delegate_args);
+  } else {
+    return next_listener.apply(null, args_array);
+  }
+};
+/**
+ * Inbound metadata receiver
+ * @param {Metadata} metadata
+ */
+InterceptingListener.prototype.onReceiveMetadata = function(metadata) {
+  this._callNext('onReceiveMetadata', [metadata]);
+};
+
+/**
+ * Inbound message receiver
+ * @param {object} message
+ */
+InterceptingListener.prototype.onReceiveMessage = function(message) {
+  this._callNext('onReceiveMessage', [message]);
+};
+
+/**
+ * When intercepting streaming message, we need to pass the streaming context
+ * transparently along the chain. Hides the context from the delegate listener
+ * methods.
+ * @param {object} context Carries objects needed for streaming operations
+ * @param {object} message The message received
+ */
+InterceptingListener.prototype.recvMessageWithContext = function(context,
+                                                                 message) {
+  var fallback = this.next_listener.recvMessageWithContext;
+  var next_method = this.next_listener ?
+    fallback.bind(this.next_listener, context) :
+    context;
+  if (this.delegate.onReceiveMessage) {
+    this.delegate.onReceiveMessage(message, next_method, context);
+  } else {
+    next_method(message);
+  }
+};
+
+/**
+ * Inbound status receiver
+ * @param {object} status
+ */
+InterceptingListener.prototype.onReceiveStatus = function(status) {
+  this._callNext('onReceiveStatus', [status]);
+};
+
+/**
+ * A dead-end listener used to terminate a call chain. Used when an interceptor
+ * creates a branch chain, when the branch returns the listener chain will
+ * terminate here.
+ * @constructor
+ */
+function EndListener() {}
+EndListener.prototype.onReceiveMetadata = function(){};
+EndListener.prototype.onReceiveMessage = function(){};
+EndListener.prototype.onReceiveStatus = function(){};
+
+/**
+ * Creates a proxy for a gRPC call object which routes all operations through
+ * a chain of interceptors.
+ * @param {function} call_constructor Used to create the underlying gRPC call
+ * @param {function[]} interceptors A list of interceptors in order
+ * @param {BatchRegistry} registry A registry of the client batches used in the
+ * call
+ * @param {object} options The call options
+ * @returns {InterceptingCall}
+ */
+function getInterceptingCall(call_constructor, interceptors, registry,
+                              options) {
+  var interceptor_base = _getOutboundBatchingInterceptor(
+    call_constructor, registry);
+  var interceptor_top = _getInboundBatchingInterceptor(
+    registry);
+  var all_interceptors = _.concat(interceptor_top, interceptors,
+    interceptor_base);
+  return _chainInterceptors(all_interceptors, options);
+}
+
+
+/**
+ * Returns a base interceptor for outbound operations which will construct
+ * the underlying gRPC call and run startBatch on it after the batch's
+ * operations have passed through the interceptor chain.
+ * @param {function} call_constructor
+ * @param {BatchRegistry} registry
+ * @return {Function}
+ */
+function _getOutboundBatchingInterceptor(call_constructor, registry) {
+  return function(options) {
+    var ops_received = {};
+    var response_listener;
+    var call = call_constructor(options);
+    var handler = function(batch, handle, context) {
+      handle(batch, call, response_listener, context);
+    };
+    return new InterceptingCall(null, {
+      start: function (metadata, listener) {
+        response_listener = listener;
+        var op = grpc.opType.SEND_INITIAL_METADATA;
+        ops_received = _handleOutboundOperations(op, metadata, ops_received,
+          registry, handler);
+      },
+      sendMessage: function (message, context) {
+        var op = grpc.opType.SEND_MESSAGE;
+        ops_received = _handleOutboundOperations(op, message, ops_received,
+          registry, handler, context);
+      },
+      halfClose: function () {
+        var op = grpc.opType.SEND_CLOSE_FROM_CLIENT;
+        ops_received = _handleOutboundOperations(op, null, ops_received,
+          registry, handler);
+      },
+      recvMessageWithContext: function(context) {
+        var op = grpc.opType.RECV_MESSAGE;
+        _handleOutboundOperations(op, null, ops_received, registry, handler,
+          context);
+      },
+      cancel: function() {
+        call.cancel();
+      },
+      cancelWithStatus: function(status, message) {
+        call.cancelWithStatus(status, message);
+      },
+      getPeer: function() {
+        return call.getPeer();
+      }
+    });
+  };
+}
+
+/**
+ * Creates a base inbound interceptor which will run callbacks for each batch
+ * after their inbound operations have passed through the interceptor chain.
+ * @param {BatchRegistry} registry
+ * @return {Function}
+ */
+function _getInboundBatchingInterceptor(registry) {
+  return function(options, nextCall) {
+    var ops_received = {};
+    var handler = function(batch, handle, context) {
+      handle(batch, context);
+    };
+    return new InterceptingCall(nextCall(options), {
+      start: function (metadata, listener, next) {
+        next(metadata, {
+          onReceiveMetadata: function (metadata) {
+            var op = grpc.opType.RECV_INITIAL_METADATA;
+            ops_received = _handleInboundOperations(op, metadata, ops_received,
+              registry, handler);
+          },
+          onReceiveMessage: function (message, next, context) {
+            var op = grpc.opType.RECV_MESSAGE;
+            ops_received = _handleInboundOperations(op, message, ops_received,
+              registry, handler, context);
+          },
+          onReceiveStatus: function (status) {
+            var op = grpc.opType.RECV_STATUS_ON_CLIENT;
+            ops_received = _handleInboundOperations(op, status, ops_received,
+              registry, handler);
+          },
+          recvMessageWithContext: function(context, message) {
+            var op = grpc.opType.RECV_MESSAGE;
+            _handleInboundOperations(op, message, ops_received, registry,
+              handler, context);
+          },
+        });
+      }
+    });
+  };
+}
+
+/**
+ * Chain a list of interceptors together and return the top InterceptingCall
+ * @param {function[]} interceptors
+ * @param {object} options Call options
+ * @return {InterceptingCall}
+ */
+function _chainInterceptors(interceptors, options) {
+  var newCall = function(interceptors) {
+    if (interceptors.length === 0) {
+      return function(options) {};
+    }
+    var head_interceptor = _.head(interceptors);
+    var rest_interceptors = _.tail(interceptors);
+    return function(options) {
+      return head_interceptor(options, newCall(rest_interceptors));
+    };
+  };
+  var nextCall = newCall(interceptors)(options);
+  return new InterceptingCall(nextCall);
+}
+
+/**
+ * Wraps a plain listener object in an InterceptingListener if it isn't an
+ * InterceptingListener already.
+ * @param {InterceptingListener|object|null} current_listener
+ * @param {InterceptingListener|EndListener} next_listener
+ * @return {InterceptingListener|null}
+ * @private
+ */
+function _getInterceptingListener(current_listener, next_listener) {
+  if (!_isInterceptingListener(current_listener)) {
+    return new InterceptingListener(next_listener, current_listener);
+  }
+  return current_listener;
+}
+
+/**
+ * Test if the listener exists and is an InterceptingListener
+ * @param listener
+ * @return {boolean}
+ * @private
+ */
+function _isInterceptingListener(listener) {
+  return listener && listener.constructor.name === 'InterceptingListener';
+}
+
+/**
+ * Checks that methods attached to an inbound interceptor match the API
+ * @param {object} listener An interceptor listener
+ * @private
+ */
+function _validateListener(listener) {
+  var inbound_methods = [
+    'onReceiveMetadata',
+    'onReceiveMessage',
+    'onReceiveStatus'
+  ];
+  _.forOwn(listener, function(value, key) {
+    if (!_.includes(inbound_methods, key) && _.isFunction(value)) {
+      var message = key + ' is not a valid interceptor listener method. ' +
+        'Valid methods: ' + JSON.stringify(inbound_methods);
+      throw new InterceptorConfigurationError(message);
+    }
+  });
+}
+
+/**
+ * Checks that methods attached to a requester match the API
+ * @param {object} requester A candidate interceptor requester
+ * @private
+ */
+function _validateRequester(requester) {
+  var outbound_methods = [
+    'start',
+    'sendMessage',
+    'halfClose',
+    'cancel',
+    'cancelWithStatus'
+  ];
+  var internal_methods = [
+    'getPeer',
+    'recvMessageWithContext'
+  ];
+  var valid = function(key) {
+    return _.includes(outbound_methods, key) ||
+      _.includes(internal_methods, key);
+  };
+  _.forOwn(requester, function(value, key) {
+    if (!valid(key)) {
+      var message = key + ' is not a valid interceptor requester method. ' +
+        'Valid methods: ' + JSON.stringify(outbound_methods);
+      throw new InterceptorConfigurationError(message);
+    }
+  });
+}
+
+/**
+ * Filters a list of operations
+ * @param {number[]} op_candidates A list to filter
+ * @param {number[]} ops_allowed The allowed operations
+ * @return {number[]}
+ * @private
+ */
+function _filterOps(op_candidates, ops_allowed) {
+  return _.filter(op_candidates, function(op) {
+    return _.includes(ops_allowed, op);
+  });
+}
+
+/**
+ * Returns only the inbound operations from a list of ops
+ * @param {number[]} ops The operations to filter
+ * @return {number[]}
+ * @private
+ */
+function _getInboundOps(ops) {
+  return _filterOps(ops, INBOUND_OPS);
+}
+
+/**
+ * Returns only the outbound operations from a list of ops
+ * @param {number[]} ops The operations to filter
+ * @return {number[]}
+ * @private
+ */
+function _getOutboundOps(ops) {
+  return _filterOps(ops, OUTBOUND_OPS);
+}
+
+/**
+ * For each batch, run a handler function
+ * @param {BatchDefinition[]} batch_definitions Batch definitions to handle
+ * @param {object} ops_received The completed operations
+ * @param {boolean} is_outbound Whether to handle inbound or outbound operations
+ * @param {function} handler A closure with the values needed to handle
+ * the batch
+ * @param {object} [context] The optional streaming context object
+ * @private
+ */
+function _handleBatches(batch_definitions, ops_received, is_outbound,
+                           handler, context) {
+  _.each(batch_definitions, function(definition) {
+    var batch_values = _.map(definition.batch_ops, function(op) {
+      return ops_received[op];
+    });
+    var batch = _.zipObject(definition.batch_ops, batch_values);
+    var base_handler = definition.getHandler(is_outbound);
+    handler(batch, base_handler, context);
+  });
+}
+
+/**
+ * Record the completion of an operation's interceptor chain and the result
+ * value
+ * @param {number} op
+ * @param {*} op_value
+ * @param {object} ops_received
+ * @return {object}
+ * @private
+ */
+function _saveOperation(op, op_value, ops_received) {
+  if (op !== null && op !== undefined) {
+    ops_received[op] = op_value;
+  }
+  return ops_received;
+}
+
+/**
+ * Find the batches for which all their operations have completed their
+ * interception chains and start or resolve them.
+ * @param {number} op The operation just completed
+ * @param {*} op_value The operation's value
+ * @param {object} ops_received An aggregation of all operations completed
+ * @param {BatchRegistry} registry The batch registry
+ * @param {boolean} is_outbound Whether to handle inboud or outbound operations
+ * @param {function} handler A closure with the values needed to handle
+ * the batch.
+ * @param {object} [context] An optional streaming context
+ * @return {Object}
+ * @private
+ */
+function _handleOperations(op, op_value, ops_received, registry, is_outbound,
+                          handler, context) {
+  ops_received = _saveOperation(op, op_value, ops_received);
+  var ops_complete = _.map(_.keys(ops_received), function(op) {
+    return parseInt(op);
+  });
+
+  var op_filter = is_outbound ? _getOutboundOps : _getInboundOps;
+  var batches = _.filter(registry.batches, function(batch) {
+    // Skip the batch if this operation cannot trigger the handler
+    if (!_.includes(batch.trigger_ops, op)) {
+      return false;
+    }
+    // Skip the batch if it has no handler
+    if (!batch.getHandler(is_outbound)) {
+      return false;
+    }
+    // The batch is complete if all the required operations are complete
+    var ops_required = op_filter(batch.batch_ops);
+    var required_and_complete = _.intersection(ops_complete, ops_required);
+    return _.isEqual(required_and_complete, ops_required);
+  });
+
+  _handleBatches(batches, ops_received, is_outbound, handler, context);
+  return ops_received;
+}
+
+/**
+ * Starts batches whose outbound operations have completed their interceptor
+ * chains.
+ * @param {number} op The operation just completed
+ * @param {*} value The value of the operation just completed
+ * @param {object} ops_received An aggregation of all operations completed
+ * @param {BatchRegistry} registry The batch registry
+ * @param {function} handler A closure with the values needed to handle
+ * the batch
+ * @param {object} [context] An optional streaming context
+ * @returns {Object}
+ * @private
+ */
+function _handleOutboundOperations(op, value, ops_received, registry,
+                                 handler, context) {
+  return _handleOperations(op, value, ops_received, registry, true, handler,
+    context);
+}
+
+/**
+ * Resolves batches whose inbound operations have completed their interceptor
+ * chains.
+ * @param {number} op The operation just completed
+ * @param {*} value The value of the operation just completed
+ * @param {object} ops_received An aggregation of all operations completed
+ * @param {BatchRegistry} registry The batch registry
+ * @param {function} handler A closure with the values needed to handle
+ * the batch
+ * @param {object} [context] An optional streaming context
+ * @returns {Object}
+ * @private
+ */
+function _handleInboundOperations(op, value, ops_received, registry,
+                                handler, context) {
+  return _handleOperations(op, value, ops_received, registry, false, handler,
+    context);
+}
+
+/**
+ * Chooses the first valid array of interceptors or returns null
+ * @param {function[][]} interceptor_lists A list of interceptor lists in
+ * descending override priority order
+ * @return {function[]|null} The resulting interceptors
+ * @private
+ */
+function _resolveInterceptorOverrides(interceptor_lists) {
+  return _.find(interceptor_lists, function(interceptor_list) {
+      return _.isArray(interceptor_list);
+    }) || null;
+}
+
+exports.processInterceptorLayers = processInterceptorLayers;
+exports.resolveInterceptorProviders = resolveInterceptorProviders;
+
+exports.InterceptorProvider = InterceptorProvider;
+exports.InterceptingCall = InterceptingCall;
+exports.ListenerBuilder = ListenerBuilder;
+exports.RequesterBuilder = RequesterBuilder;
+exports.StatusBuilder = StatusBuilder;
+
+exports.InterceptorConfigurationError = InterceptorConfigurationError;
+
+exports.getInterceptingCall = getInterceptingCall;
+

--- a/src/node/test/client_interceptors_test.js
+++ b/src/node/test/client_interceptors_test.js
@@ -1,0 +1,1629 @@
+/*
+ *
+ * Copyright 2015, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+'use strict';
+
+var _ = require('lodash');
+var assert = require('assert');
+var grpc = require('..');
+var grpc_client = require('../src/client.js');
+var Metadata = require('../src/metadata');
+
+var insecureCreds = grpc.credentials.createInsecure();
+
+var echo_proto = grpc.load(__dirname + '/echo_service.proto');
+var echo_service = echo_proto.EchoService.service;
+
+var StatusBuilder = grpc_client.StatusBuilder;
+var ListenerBuilder = grpc_client.ListenerBuilder;
+var InterceptingCall = grpc_client.InterceptingCall;
+var RequesterBuilder = grpc_client.RequesterBuilder;
+
+var InterceptorProvider = grpc_client.InterceptorProvider;
+
+var CallRegistry = function(done, expectation, is_ordered) {
+  this.call_map = {};
+  this.call_array = [];
+  this.done = done;
+  this.expectation = expectation;
+  this.expectation_is_array = _.isArray(this.expectation);
+  this.is_ordered = is_ordered;
+};
+
+CallRegistry.prototype.addCall = function(call_name) {
+  if (this.expectation_is_array) {
+    this.call_array.push(call_name);
+  } else {
+    if (!this.call_map[call_name]) {
+      this.call_map[call_name] = 0;
+    }
+    this.call_map[call_name]++;
+  }
+  this.maybeCallDone();
+};
+
+CallRegistry.prototype.maybeCallDone = function() {
+  if (this.expectation_is_array) {
+    if (this.is_ordered) {
+      if (this.expectation && _.isEqual(this.expectation, this.call_array)) {
+        this.done();
+      }
+    } else {
+      var intersection = _.intersectionWith(this.expectation, this.call_array,
+        _.isEqual);
+      if (intersection.length === this.expectation.length) {
+        this.done();
+      }
+    }
+  } else if (this.expectation && _.isEqual(this.expectation, this.call_map)) {
+    this.done();
+  }
+};
+
+
+describe('Client interceptors', function() {
+  var echo_server;
+  var echo_port;
+  var client;
+
+  function startServer() {
+    echo_server = new grpc.Server();
+    echo_server.addService(echo_service, {
+      echo: function(call, callback) {
+        call.sendMetadata(call.metadata);
+        if (call.request.value === 'error') {
+          var status = {
+            code: 2,
+            message: 'test status message'
+          };
+          status.metadata = call.metadata;
+          callback(status, null);
+          return;
+        }
+        callback(null, call.request);
+      },
+      echoClientStream: function(call, callback){
+        call.sendMetadata(call.metadata);
+        var payload;
+        var err = null;
+        call.on('data', function(data) {
+          if (data.value === 'error') {
+            err = {
+              code: 2,
+              message: 'test status message'
+            };
+            err.metadata = call.metadata;
+            return;
+          }
+          payload = data;
+        });
+        call.on('end', function() {
+          callback(err, payload, call.metadata);
+        });
+      },
+      echoServerStream: function(call) {
+        call.sendMetadata(call.metadata);
+        if (call.request.value === 'error') {
+          var status = {
+            code: 2,
+            message: 'test status message'
+          };
+          status.metadata = call.metadata;
+          call.emit('error', status);
+          return;
+        }
+        call.write(call.request);
+        call.end(call.metadata);
+      },
+      echoBidiStream: function(call) {
+        call.sendMetadata(call.metadata);
+        call.on('data', function(data) {
+          if (data.value === 'error') {
+            var status = {
+              code: 2,
+              message: 'test status message'
+            };
+            call.emit('error', status);
+            return;
+          }
+          call.write(data);
+        });
+        call.on('end', function() {
+          call.end(call.metadata);
+        });
+      }
+    });
+    var server_credentials = grpc.ServerCredentials.createInsecure();
+    echo_port = echo_server.bind('localhost:0', server_credentials);
+    echo_server.start();
+  }
+
+  function stopServer() {
+    echo_server.forceShutdown();
+  }
+
+  function resetClient() {
+    var EchoClient = grpc_client.makeClientConstructor(echo_service);
+    client = new EchoClient('localhost:' + echo_port, insecureCreds);
+  }
+
+  before(function() {
+    startServer();
+  });
+  beforeEach(function() {
+    resetClient();
+  });
+  after(function() {
+    stopServer();
+  });
+  describe('pass calls through when no interceptors provided', function() {
+    it('with unary call', function(done) {
+      var expected_value = 'foo';
+      var message = {value: expected_value};
+      client.echo(message, function(err, response) {
+        assert.strictEqual(response.value, expected_value);
+        done();
+      });
+      assert(_.isEqual(grpc_client.getClientInterceptors(client), {
+        echo: [],
+        echoClientStream: [],
+        echoServerStream: [],
+        echoBidiStream: []
+      }));
+    });
+  });
+
+  describe('execute downstream interceptors when a new call is made outbound',
+    function() {
+      var registry;
+      var options;
+      var stored_listener;
+      var stored_metadata;
+      var interceptor_a = function(options, nextCall) {
+        options.call_number = 1;
+        registry.addCall('construct a ' + options.call_number);
+        return new InterceptingCall(nextCall(options), {
+          start: function(metadata, listener, next) {
+            registry.addCall('start a ' + options.call_number);
+            stored_listener = listener;
+            stored_metadata = metadata;
+            next(metadata, listener);
+          },
+          sendMessage: function(message, next) {
+            registry.addCall('send a ' + options.call_number);
+            var options2 = _.clone(options);
+            options2.call_number = 2;
+            var second_call = nextCall(options2);
+            second_call.start(stored_metadata, stored_listener);
+            second_call.sendMessage(message);
+            second_call.halfClose();
+            next(message);
+          },
+          halfClose: function(next) {
+            registry.addCall('close a ' + options.call_number);
+            next();
+          }
+        });
+      };
+
+      var interceptor_b = function(options, nextCall) {
+        registry.addCall('construct b ' + options.call_number);
+        return new InterceptingCall(nextCall(options), {
+          start: function(metadata, listener, next) {
+            registry.addCall('start b ' + options.call_number);
+            next(metadata, listener);
+          },
+          sendMessage: function(message, next) {
+            registry.addCall('send b ' + options.call_number);
+            next(message);
+          },
+          halfClose: function(next) {
+            registry.addCall('close b ' + options.call_number);
+            next();
+          }
+        });
+      };
+
+      // Prevents async 'cancelled' status from server breaking later tests
+      var cleanup_interceptor = function(options, nextCall) {
+        return new InterceptingCall(nextCall(options), {
+          start: function(metadata, listener, next) {
+            next(metadata, {
+              onReceiveStatus: function(status, next) {
+                next({code: 0});
+              }
+            });
+          }
+        });
+      };
+
+      options = {
+        interceptors: [interceptor_a, interceptor_b, cleanup_interceptor]
+      };
+
+      var expected_calls = [
+        'construct a 1',
+        'construct b 1',
+        'start a 1',
+        'start b 1',
+        'send a 1',
+        'construct b 2',
+        'start b 2',
+        'send b 2',
+        'close b 2',
+        'send b 1',
+        'close a 1',
+        'close b 1',
+        'response'
+      ];
+
+      it('with unary call', function(done) {
+        registry = new CallRegistry( done, expected_calls, true);
+        var message = {};
+        message.value = 'foo';
+        client.echo(message, options, function(err, response){
+          if (!err) {
+            registry.addCall('response');
+          }
+        });
+      });
+      it('with client streaming call', function(done) {
+        registry = new CallRegistry( done, expected_calls, true);
+        var message = {};
+        message.value = 'foo';
+        var stream = client.echoClientStream(options, function(err, response) {
+          if (!err) {
+            registry.addCall('response');
+          }
+        });
+        stream.write(message);
+        stream.end();
+      });
+      it('with server streaming call', function(done) {
+        registry = new CallRegistry( done, expected_calls, true);
+        var message = {};
+        message.value = 'foo';
+        var stream = client.echoServerStream(message, options);
+        stream.on('data', function(data) {
+          registry.addCall('response');
+        });
+      });
+      it('with bidi streaming call', function(done) {
+        registry = new CallRegistry( done, expected_calls, true);
+        var message = {};
+        message.value = 'foo';
+        var stream = client.echoBidiStream(options);
+        stream.on('data', function(data) {
+          registry.addCall('response');
+        });
+        stream.write(message);
+        stream.end();
+      });
+    });
+
+
+  describe('execute downstream interceptors when a new call is made inbound',
+    function() {
+      var registry;
+      var interceptor_a = function(options, nextCall) {
+        return new InterceptingCall(nextCall(options), {
+          start: function(metadata, listener, next) {
+            next(metadata, {
+              onReceiveMetadata: function() {},
+              onReceiveMessage: function(message, next) {
+                registry.addCall('interceptor_a');
+                var second_call = nextCall(options);
+                second_call.start(metadata, listener);
+                second_call.sendMessage(message);
+                second_call.halfClose();
+              },
+              onReceiveStatus: function() {}
+            });
+          }
+        });
+      };
+
+      var interceptor_b = function(options, nextCall) {
+        return new InterceptingCall(nextCall(options), {
+          start: function(metadata, listener, next) {
+            next(metadata, {
+              onReceiveMessage: function(message, next) {
+                registry.addCall('interceptor_b');
+                next(message);
+              }
+            });
+          }
+        });
+      };
+
+      var options = {
+        interceptors: [interceptor_a, interceptor_b]
+      };
+
+      var expected_calls = ['interceptor_b', 'interceptor_a',
+            'interceptor_b', 'response'];
+      it('with unary call', function(done) {
+        registry = new CallRegistry(done, expected_calls, true);
+        var message = {};
+        message.value = 'foo';
+        client.echo(message, options, function(err) {
+          if (!err) {
+            registry.addCall('response');
+          }
+        });
+      });
+      it('with client streaming call', function(done) {
+        registry = new CallRegistry(done, expected_calls, true);
+        var message = {};
+        message.value = 'foo';
+        var stream = client.echoClientStream(options, function(err, response) {
+          if (!err) {
+            registry.addCall('response');
+          }
+        });
+        stream.write(message);
+        stream.end();
+      });
+    });
+
+  it('will delay operations and short circuit unary requests', function(done) {
+    var registry = new CallRegistry(done, ['foo_miss', 'foo_hit', 'bar_miss',
+      'foo_hit_done', 'foo_miss_done', 'bar_miss_done']);
+    var cache = {};
+    var _getCachedResponse = function(value) {
+      return cache[value];
+    };
+    var _store = function(key, value) {
+      cache[key] = value;
+    };
+
+    var interceptor = function(options, nextCall) {
+      var savedMetadata;
+      var startNext;
+      var storedListener;
+      var storedMessage;
+      var messageNext;
+      var requester = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          savedMetadata = metadata;
+          storedListener = listener;
+          startNext = next;
+        })
+        .withSendMessage(function(message, next) {
+          storedMessage = message;
+          messageNext = next;
+        })
+        .withHalfClose(function(next) {
+          var cachedValue = _getCachedResponse(storedMessage.value);
+          if (cachedValue) {
+            var cachedMessage = {};
+            cachedMessage.value = cachedValue;
+            registry.addCall(storedMessage.value + '_hit');
+            storedListener.onReceiveMetadata(new Metadata());
+            storedListener.onReceiveMessage(cachedMessage);
+            storedListener.onReceiveStatus(
+              (new StatusBuilder()).withCode(grpc.status.OK).build());
+          } else {
+            registry.addCall(storedMessage.value + '_miss');
+            var newListener = (new ListenerBuilder()).withOnReceiveMessage(
+              function(message, next) {
+                _store(storedMessage.value, message.value);
+                next(message);
+              }).build();
+            startNext(savedMetadata, newListener);
+            messageNext(storedMessage);
+            next();
+          }
+        })
+        .withCancel(function(message, next) {
+          next();
+        }).build();
+
+      return new InterceptingCall(nextCall(options), requester);
+    };
+
+    var options = {
+      interceptors: [interceptor]
+    };
+
+    var foo_message = {};
+    foo_message.value = 'foo';
+    client.echo(foo_message, options, function(err, response){
+      assert.equal(response.value, 'foo');
+      registry.addCall('foo_miss_done');
+      client.echo(foo_message, options, function(err, response){
+        assert.equal(response.value, 'foo');
+        registry.addCall('foo_hit_done');
+      });
+    });
+
+    var bar_message = {};
+    bar_message.value = 'bar';
+    client.echo(bar_message, options, function(err, response) {
+      assert.equal(response.value, 'bar');
+      registry.addCall('bar_miss_done');
+    });
+  });
+
+  it('can retry failed messages and handle eventual success', function(done) {
+    var registry = new CallRegistry(done,
+      ['retry_foo_1', 'retry_foo_2', 'retry_foo_3', 'foo_result',
+        'retry_bar_1', 'bar_result']);
+    var maxRetries = 3;
+    var retry_interceptor = function(options, nextCall) {
+      var savedMetadata;
+      var savedSendMessage;
+      var savedReceiveMessage;
+      var savedMessageNext;
+      var requester = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          savedMetadata = metadata;
+          var new_listener = (new ListenerBuilder())
+            .withOnReceiveMessage(function(message, next) {
+              savedReceiveMessage = message;
+              savedMessageNext = next;
+            })
+            .withOnReceiveStatus(function(status, next) {
+                var retries = 0;
+                var retry = function(message, metadata) {
+                  retries++;
+                  var newCall = nextCall(options);
+                  var receivedMessage;
+                  newCall.start(metadata, {
+                    onReceiveMessage: function(message) {
+                      receivedMessage = message;
+                    },
+                    onReceiveStatus: function(status) {
+                      registry.addCall('retry_' + savedMetadata.get('name') +
+                        '_' + retries);
+                      if (status.code !== grpc.status.OK) {
+                        if (retries <= maxRetries) {
+                          retry(message, metadata);
+                        } else {
+                          savedMessageNext(receivedMessage);
+                          next(status);
+                        }
+                      } else {
+                        registry.addCall('success_call');
+                        var new_status = (new StatusBuilder())
+                          .withCode(grpc.status.OK).build();
+                        savedMessageNext(receivedMessage);
+                        next(new_status);
+                      }
+                    }
+                  });
+                  newCall.sendMessage(message);
+                  newCall.halfClose();
+                };
+                if (status.code !== grpc.status.OK) {
+                  // Change the message we're sending only for test purposes
+                  // so the server will respond without error
+                  var newMessage = (savedMetadata.get('name')[0] === 'bar') ?
+                    {value: 'bar'} : savedSendMessage;
+                  retry(newMessage, savedMetadata);
+                } else {
+                  savedMessageNext(savedReceiveMessage);
+                  next(status);
+                }
+              }
+            ).build();
+          next(metadata, new_listener);
+        })
+        .withSendMessage(function(message, next) {
+          savedSendMessage = message;
+          next(message);
+        }).build();
+      return new InterceptingCall(nextCall(options), requester);
+    };
+
+    var options = {
+      interceptors: [retry_interceptor]
+    };
+
+    // Make a call which the server will return a non-OK status for
+    var foo_message = {value: 'error'};
+    var foo_metadata = new Metadata();
+    foo_metadata.set('name', 'foo');
+    client.echo(foo_message, foo_metadata, options, function(err, response) {
+      assert.strictEqual(err.code, 2);
+      registry.addCall('foo_result');
+    });
+
+    // Make a call which will fail the first time and succeed on the first
+    // retry
+    var bar_message = {value: 'error'};
+    var bar_metadata = new Metadata();
+    bar_metadata.set('name', 'bar');
+    client.echo(bar_message, bar_metadata, options, function(err, response) {
+      assert.strictEqual(response.value, 'bar');
+      registry.addCall('bar_result');
+    });
+  });
+
+  it('can retry and preserve interceptor order on success', function(done) {
+    var registry = new CallRegistry(done,
+      ['interceptor_c', 'retry_interceptor', 'fail_call', 'interceptor_c',
+        'success_call', 'interceptor_a', 'result'], true);
+    var interceptor_a = function(options, nextCall) {
+      var requester = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          var new_listener = (new ListenerBuilder())
+            .withOnReceiveMessage(function(message, next) {
+              registry.addCall('interceptor_a');
+              next(message);
+            }).build();
+          next(metadata, new_listener);
+        }).build();
+      return new InterceptingCall(nextCall(options), requester);
+    };
+
+    var retry_interceptor = function(options, nextCall) {
+      var savedMetadata;
+      var savedMessage;
+      var savedMessageNext;
+      var sendMessageNext;
+      var originalMessage;
+      var startNext;
+      var originalListener;
+      var requester = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          startNext = next;
+          savedMetadata = metadata;
+          originalListener = listener;
+          var new_listener = (new ListenerBuilder())
+            .withOnReceiveMessage(function(message, next) {
+              savedMessage = message;
+              savedMessageNext = next;
+            })
+            .withOnReceiveStatus(function(status, next) {
+              var retries = 0;
+              var maxRetries = 1;
+              var receivedMessage;
+              var retry = function(message, metadata) {
+                retries++;
+                var new_call = nextCall(options);
+                new_call.start(metadata, {
+                  onReceiveMessage: function(message) {
+                    receivedMessage = message;
+                  },
+                  onReceiveStatus: function(status) {
+                    if (status.code !== grpc.status.OK) {
+                      if (retries <= maxRetries) {
+                        retry(message, metadata);
+                      } else {
+                        savedMessageNext(receivedMessage);
+                        next(status);
+                      }
+                    } else {
+                      registry.addCall('success_call');
+                      var new_status = (new StatusBuilder())
+                        .withCode(grpc.status.OK).build();
+                      savedMessageNext(receivedMessage);
+                      next(new_status);
+                    }
+                  }
+                });
+                new_call.sendMessage(message);
+                new_call.halfClose();
+              };
+              registry.addCall('retry_interceptor');
+              if (status.code !== grpc.status.OK) {
+                registry.addCall('fail_call');
+                var newMessage = {value: 'foo'};
+                retry(newMessage, savedMetadata);
+              } else {
+                savedMessageNext(savedMessage);
+                next(status);
+              }
+            }).build();
+          next(metadata, new_listener);
+        })
+        .withSendMessage(function(message, next) {
+          sendMessageNext = next;
+          originalMessage = message;
+          next(message);
+        })
+        .build();
+      return new InterceptingCall(nextCall(options), requester);
+    };
+
+    var interceptor_c = function(options, nextCall) {
+      var requester = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          var new_listener = (new ListenerBuilder())
+            .withOnReceiveMessage(function(message, next) {
+              registry.addCall('interceptor_c');
+              next(message);
+            }).build();
+          next(metadata, new_listener);
+        }).build();
+      return new InterceptingCall(nextCall(options), requester);
+    };
+
+    var options = {
+      interceptors: [interceptor_a, retry_interceptor, interceptor_c]
+    };
+
+    var message = {value: 'error'};
+    client.echo(message, options, function(err, response) {
+      assert.strictEqual(response.value, 'foo');
+      registry.addCall('result');
+    });
+  });
+
+  describe('handle interceptor errors', function() {
+    var foo_interceptor = function(options, nextCall) {
+      var savedListener;
+      var outbound = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          savedListener = listener;
+          next(metadata, listener);
+        })
+        .withSendMessage(function(message, next) {
+          savedListener.onReceiveMetadata(new Metadata());
+          savedListener.onReceiveMessage({value: 'failed'});
+          var error_status = (new StatusBuilder())
+            .withCode(16)
+            .withDetails('Error in foo interceptor')
+            .build();
+          savedListener.onReceiveStatus(error_status);
+        }).build();
+      return new grpc_client.InterceptingCall(nextCall(options), outbound);
+    };
+    var options = { interceptors: [foo_interceptor] };
+
+    it('with unary call', function(done) {
+      var message = {};
+      client.echo(message, options, function(err, response) {
+        assert.strictEqual(err.code, 16);
+        assert.strictEqual(err.message, 'Error in foo interceptor');
+        done();
+      });
+    });
+  });
+
+  describe('implement fallbacks for streaming RPCs', function() {
+
+    var fallback_response = {value: 'fallback'};
+    var savedMessage;
+    var savedMessageNext;
+    var interceptor = function(options, nextCall) {
+      var requester = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          var new_listener = (new ListenerBuilder())
+            .withOnReceiveMessage(function(message, next) {
+              savedMessage = message;
+              savedMessageNext = next;
+            })
+            .withOnReceiveStatus(function(status, next) {
+              if (status.code !== grpc.status.OK) {
+                savedMessageNext(fallback_response);
+                next((new StatusBuilder()).withCode(grpc.status.OK));
+              } else {
+                savedMessageNext(savedMessage);
+                next(status);
+              }
+            }).build();
+          next(metadata, new_listener);
+        }).build();
+      return new InterceptingCall(nextCall(options), requester);
+    };
+    var options = {
+      interceptors: [interceptor]
+    };
+    it('with client streaming call', function(done) {
+      var registry = new CallRegistry(done, ['foo_result', 'fallback_result']);
+      var stream = client.echoClientStream(options, function (err, response) {
+        assert.strictEqual(response.value, 'foo');
+        registry.addCall('foo_result');
+      });
+      stream.write({value: 'foo'});
+      stream.end();
+
+      stream = client.echoClientStream(options, function(err, response) {
+        assert.strictEqual(response.value, 'fallback');
+        registry.addCall('fallback_result');
+      });
+      stream.write({value: 'error'});
+      stream.end();
+    });
+  });
+
+  describe('allows the call options to be modified for downstream interceptors',
+    function() {
+      var done;
+      var method_name;
+      var method_path_last;
+      var interceptor_a = function(options, nextCall) {
+        options.deadline = 10;
+        return new InterceptingCall(nextCall(options));
+      };
+      var interceptor_b = function(options, nextCall) {
+        assert.equal(options.method_descriptor.path, '/EchoService/' +
+          method_path_last);
+        assert.equal(options.method_descriptor.name, method_name);
+        assert.equal(options.deadline, 10);
+        done();
+        return new InterceptingCall(nextCall(options));
+      };
+
+      var options = {
+        interceptors: [interceptor_a, interceptor_b],
+        deadline: 100
+      };
+
+      it('with unary call', function(cb) {
+        done = cb;
+        var metadata = new Metadata();
+        var message = {};
+        method_name = 'echo';
+        method_path_last = 'Echo';
+
+        client.echo(message, metadata, options, function(){});
+      });
+
+      it('with client streaming call', function(cb) {
+        done = cb;
+        var metadata = new Metadata();
+        method_name = 'echoClientStream';
+        method_path_last = 'EchoClientStream';
+
+        client.echoClientStream(metadata, options, function() {});
+      });
+
+      it('with server streaming call', function(cb) {
+        done = cb;
+        var metadata = new Metadata();
+        var message = {};
+        method_name = 'echoServerStream';
+        method_path_last = 'EchoServerStream';
+
+        client.echoServerStream(message, metadata, options);
+      });
+
+      it('with bidi streaming call', function(cb) {
+        done = cb;
+        var metadata = new Metadata();
+        method_name = 'echoBidiStream';
+        method_path_last = 'EchoBidiStream';
+
+        client.echoBidiStream(metadata, options);
+      });
+    });
+
+  describe('pass accurate MethodDescriptors', function() {
+    var registry;
+    var initial_value = 'broken';
+    var expected_value = 'working';
+    var interceptor = function(options, nextCall) {
+      registry.addCall({
+        name: options.method_descriptor.name,
+        type: options.method_descriptor.method_type
+      });
+      var outbound = (new RequesterBuilder())
+        .withSendMessage(function(message, next) {
+          message.value = expected_value;
+          next(message);
+        }).build();
+      return new InterceptingCall(nextCall(options), outbound);
+    };
+
+    var options = { interceptors: [interceptor] };
+
+    it('with unary call', function(done) {
+      var unary_descriptor = {
+        name: 'echo',
+        type: grpc_client.MethodType.UNARY
+      };
+      registry = new CallRegistry(done, [
+        unary_descriptor,
+        'result_unary'
+      ]);
+
+      var metadata = new Metadata();
+
+      var message = {value: initial_value};
+
+      client.echo(message, metadata, options, function(err, response){
+        assert.equal(response.value, expected_value);
+        registry.addCall('result_unary');
+      });
+
+    });
+    it('with client streaming call', function(done) {
+
+      var client_stream_descriptor = {
+        name: 'echoClientStream',
+        type: grpc_client.MethodType.CLIENT_STREAMING
+      };
+      registry = new CallRegistry(done, [
+        client_stream_descriptor,
+        'result_client_stream'
+      ]);
+      var metadata = new Metadata();
+      var message = {value: initial_value};
+      var client_stream = client.echoClientStream(metadata, options,
+        function(err, response) {
+          assert.strictEqual(response.value, expected_value);
+          registry.addCall('result_client_stream');
+        });
+      client_stream.write(message);
+      client_stream.end();
+
+    });
+    it('with server streaming call', function(done) {
+      var server_stream_descriptor = {
+        name: 'echoServerStream',
+        type: grpc_client.MethodType.SERVER_STREAMING
+      };
+      registry = new CallRegistry(done, [
+        server_stream_descriptor,
+        'result_server_stream'
+      ]);
+
+      var metadata = new Metadata();
+      var message = {value: initial_value};
+      var server_stream = client.echoServerStream(message, metadata, options);
+      server_stream.on('data', function(data) {
+        assert.strictEqual(data.value, expected_value);
+        registry.addCall('result_server_stream');
+      });
+
+    });
+    it('with bidi streaming call', function(done) {
+      var bidi_stream_descriptor = {
+        name: 'echoBidiStream',
+        type: grpc_client.MethodType.BIDI_STREAMING
+      };
+      registry = new CallRegistry(done, [
+        bidi_stream_descriptor,
+        'result_bidi_stream'
+      ]);
+
+      var metadata = new Metadata();
+      var message = {value: initial_value};
+      var bidi_stream = client.echoBidiStream(metadata, options);
+      bidi_stream.on('data', function(data) {
+        assert.strictEqual(data.value, expected_value);
+        registry.addCall('result_bidi_stream');
+      });
+      bidi_stream.write(message);
+      bidi_stream.end();
+    });
+  });
+
+  it('uses interceptors passed to the client constructor', function(done) {
+    var registry = new CallRegistry(done, {
+      'constructor_interceptor_a_echo': 1,
+      'constructor_interceptor_b_echoServerStream': 1,
+      'invocation_interceptor': 1,
+      'result_unary': 1,
+      'result_stream': 1,
+      'result_invocation': 1
+    });
+
+    var constructor_interceptor_a = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          registry.addCall('constructor_interceptor_a_' +
+            options.method_descriptor.name);
+          next(metadata, listener);
+        }).build();
+      return new InterceptingCall(nextCall(options), outbound);
+    };
+    var constructor_interceptor_b = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          registry.addCall('constructor_interceptor_b_' +
+            options.method_descriptor.name);
+          next(metadata, listener);
+        }).build();
+      return new InterceptingCall(nextCall(options), outbound);
+    };
+    var invocation_interceptor = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          registry.addCall('invocation_interceptor');
+          next(metadata, listener);
+        }).build();
+      return new InterceptingCall(nextCall(options), outbound);
+    };
+
+    var interceptor_providers = [
+      new InterceptorProvider(function(method_descriptor) {
+        if (method_descriptor.method_type === grpc_client.MethodType.UNARY) {
+          return constructor_interceptor_a;
+        }
+      }),
+      new InterceptorProvider(function(method_descriptor) {
+        var t = method_descriptor.method_type;
+        if (t === grpc_client.MethodType.SERVER_STREAMING) {
+          return constructor_interceptor_b;
+        }
+      })
+    ];
+    var constructor_options = {
+      interceptor_providers: interceptor_providers
+    };
+    var IntClient = grpc_client.makeClientConstructor(echo_service);
+    var int_client = new IntClient('localhost:' + echo_port, insecureCreds,
+      constructor_options);
+    var message = {};
+    int_client.echo(message, function() {
+      registry.addCall('result_unary');
+    });
+    var stream = int_client.echoServerStream(message);
+    stream.on('data', function() {
+      registry.addCall('result_stream');
+    });
+
+    var options = { interceptors: [invocation_interceptor] };
+    int_client.echo(message, options, function() {
+      registry.addCall('result_invocation');
+    });
+
+    assert(_.isEqual(grpc_client.getClientInterceptors(int_client), {
+      echo: [constructor_interceptor_a],
+      echoClientStream: [],
+      echoServerStream: [constructor_interceptor_b],
+      echoBidiStream: []
+    }));
+  });
+
+  it('will reject conflicting interceptor options at invocation',
+    function(done) {
+      try {
+        client.echo('message', {
+          interceptors: [],
+          interceptor_providers: []
+        }, function () {});
+      } catch (e) {
+        assert.equal(e.name, 'InterceptorConfigurationError');
+        done();
+      }
+    });
+
+  it('will resolve interceptor providers at invocation', function(done) {
+    var constructor_interceptor = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withStart(function() {
+          assert(false);
+        }).build();
+      return new InterceptingCall(nextCall(options), outbound);
+    };
+    var invocation_interceptor = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withStart(function() {
+          done();
+        }).build();
+      return new InterceptingCall(nextCall(options), outbound);
+    };
+    var constructor_interceptor_providers = [
+      new InterceptorProvider(function() {
+        return constructor_interceptor;
+      })
+    ];
+    var invocation_interceptor_providers = [
+      new InterceptorProvider(function() {
+        return invocation_interceptor;
+      })
+    ];
+    var constructor_options = {
+      interceptor_providers: constructor_interceptor_providers
+    };
+    var IntClient = grpc_client.makeClientConstructor(echo_service);
+    var int_client = new IntClient('localhost:' + echo_port, insecureCreds,
+      constructor_options);
+    var message = {};
+    var options = { interceptor_providers: invocation_interceptor_providers };
+    int_client.echo(message, options, function() {});
+  });
+
+  describe('trigger a stack of interceptors in nested order', function() {
+    var registry;
+    var expected_calls = ['constructA', 'constructB', 'outboundA', 'outboundB',
+      'inboundB', 'inboundA'];
+    var interceptor_a = function(options, nextCall) {
+      registry.addCall('constructA');
+      var outbound = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          registry.addCall('outboundA');
+          var new_listener = (new ListenerBuilder()).withOnReceiveMessage(
+            function(message, next) {
+              registry.addCall('inboundA');
+              next(message);
+            }).build();
+          next(metadata, new_listener);
+        }).build();
+      return new grpc_client.InterceptingCall(nextCall(options),
+        outbound);
+    };
+    var interceptor_b = function(options, nextCall) {
+      registry.addCall('constructB');
+      var outbound = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          registry.addCall('outboundB');
+          var new_listener = (new ListenerBuilder()).withOnReceiveMessage(
+            function(message, next) {
+              registry.addCall('inboundB');
+              next(message);
+            }).build();
+          next(metadata, new_listener);
+        }).build();
+      return new grpc_client.InterceptingCall(nextCall(options),
+        outbound);
+    };
+    var options = { interceptors: [interceptor_a, interceptor_b] };
+    var metadata = new Metadata();
+    var message = {};
+
+    it('with unary call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      client.echo(message, metadata, options, function(){});
+    });
+
+    it('with client streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      var client_stream = client.echoClientStream(metadata, options,
+        function() {});
+      client_stream.write(message);
+      client_stream.end();
+    });
+
+    it('with server streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      var stream = client.echoServerStream(message, metadata, options);
+      stream.on('data', function() {});
+    });
+
+    it('with bidi streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      var bidi_stream = client.echoBidiStream(metadata, options);
+      bidi_stream.on('data', function(){});
+      bidi_stream.write(message);
+      bidi_stream.end();
+    });
+  });
+
+  describe('trigger interceptors horizontally', function() {
+    var expected_calls = [
+      'interceptor_a_start',
+      'interceptor_b_start',
+      'interceptor_a_send',
+      'interceptor_b_send'
+    ];
+    var registry;
+    var interceptor_a = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          registry.addCall('interceptor_a_start');
+          next(metadata, listener);
+        })
+        .withSendMessage(function(message, next) {
+          registry.addCall('interceptor_a_send');
+          next(message);
+        }).build();
+      return new grpc_client.InterceptingCall(nextCall(options),
+        outbound);
+    };
+    var interceptor_b = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          registry.addCall('interceptor_b_start');
+          next(metadata, listener);
+        })
+        .withSendMessage(function(message, next) {
+          registry.addCall('interceptor_b_send');
+          next(message);
+        }).build();
+      return new grpc_client.InterceptingCall(nextCall(options),
+        outbound);
+    };
+
+    var options = { interceptors: [interceptor_a, interceptor_b] };
+    var metadata = new Metadata();
+    var message = {};
+
+    it('with unary call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      client.echo(message, metadata, options, function(){});
+    });
+
+    it('with client streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      var client_stream = client.echoClientStream(metadata, options,
+        function() {});
+      client_stream.write(message);
+      client_stream.end();
+    });
+
+    it('with server streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      var stream = client.echoServerStream(message, metadata, options);
+      stream.on('data', function() {});
+    });
+
+    it('with bidi streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      var bidi_stream = client.echoBidiStream(metadata, options);
+      bidi_stream.on('data', function(){});
+      bidi_stream.write(message);
+      bidi_stream.end();
+    });
+  });
+
+  describe('trigger when sending metadata', function() {
+    var registry;
+
+    var message = {};
+    var key_names = ['original', 'foo', 'bar'];
+    var keys = {
+      original: 'originalkey',
+      foo: 'fookey',
+      bar: 'barkey'
+    };
+    var values = {
+      original: 'originalvalue',
+      foo: 'foovalue',
+      bar: 'barvalue'
+    };
+    var expected_calls = ['foo', 'bar', 'response'];
+    var foo_interceptor = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          metadata.add(keys.foo, values.foo);
+          registry.addCall('foo');
+          next(metadata, listener);
+        }).build();
+      return new InterceptingCall(nextCall(options), outbound);
+    };
+    var bar_interceptor = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          metadata.add(keys.bar, values.bar);
+          registry.addCall('bar');
+          next(metadata, listener);
+        }).build();
+      return new InterceptingCall(nextCall(options), outbound);
+    };
+    var options = { interceptors: [foo_interceptor, bar_interceptor] };
+
+    it('with unary call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      var metadata = new Metadata();
+      metadata.add(keys.original, values.original);
+
+      var unary_call = client.echo(message, metadata, options, function () {});
+      unary_call.on('metadata', function (metadata) {
+        var has_expected_values = _.every(key_names, function (key_name) {
+          return _.isEqual(metadata.get(keys[key_name]), [values[key_name]]);
+        });
+        assert(has_expected_values);
+        registry.addCall('response');
+      });
+    });
+    it('with client streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      var metadata = new Metadata();
+      metadata.add(keys.original, values.original);
+
+      var client_stream = client.echoClientStream(metadata, options,
+        function () {
+        });
+      client_stream.write(message);
+      client_stream.on('metadata', function (metadata) {
+        var has_expected_values = _.every(key_names, function (key_name) {
+          return _.isEqual(metadata.get(keys[key_name]), [values[key_name]]);
+        });
+        assert(has_expected_values);
+        registry.addCall('response');
+      });
+      client_stream.end();
+    });
+    it('with server streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      var metadata = new Metadata();
+      metadata.add(keys.original, values.original);
+      var server_stream = client.echoServerStream(message, metadata, options);
+      server_stream.on('metadata', function (metadata) {
+        var has_expected_values = _.every(key_names, function (key_name) {
+          return _.isEqual(metadata.get(keys[key_name]), [values[key_name]]);
+        });
+        assert(has_expected_values);
+        registry.addCall('response');
+      });
+      server_stream.on('data', function() { });
+    });
+    it('with bidi streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      var metadata = new Metadata();
+      metadata.add(keys.original, values.original);
+      var bidi_stream = client.echoBidiStream(metadata, options);
+      bidi_stream.on('metadata', function(metadata) {
+        var has_expected_values = _.every(key_names, function(key_name) {
+          return _.isEqual(metadata.get(keys[key_name]),[values[key_name]]);
+        });
+        assert(has_expected_values);
+        bidi_stream.end();
+        registry.addCall('response');
+      });
+      bidi_stream.on('data', function() { });
+      bidi_stream.write(message);
+      bidi_stream.end();
+    });
+  });
+
+  describe('trigger when sending messages', function() {
+    var registry;
+    var originalValue = 'foo';
+    var expectedValue = 'bar';
+    var foo_interceptor = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withSendMessage(function(message, next) {
+          assert.strictEqual(message.value, originalValue);
+          registry.addCall('messageIntercepted');
+          next({value: expectedValue});
+        }).build();
+      return new grpc_client.InterceptingCall(nextCall(options),
+        outbound);
+    };
+    var expected_calls = ['messageIntercepted', 'response'];
+    var options = { interceptors: [foo_interceptor] };
+    var metadata = new Metadata();
+
+    it('with unary call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      var message = {value: originalValue};
+
+      client.echo(message, metadata, options, function (err, response) {
+        assert.strictEqual(response.value, expectedValue);
+        registry.addCall('response');
+      });
+    });
+    it('with client streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      var message = {value: originalValue};
+      var client_stream = client.echoClientStream(metadata, options,
+        function (err, response) {
+          assert.strictEqual(response.value, expectedValue);
+          registry.addCall('response');
+        });
+      client_stream.write(message);
+      client_stream.end();
+    });
+    it('with server streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      var message = {value: originalValue};
+      var server_stream = client.echoServerStream(message, metadata, options);
+      server_stream.on('data', function (data) {
+        assert.strictEqual(data.value, expectedValue);
+        registry.addCall('response');
+      });
+    });
+    it('with bidi streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls, true);
+      var message = {value: originalValue};
+      var bidi_stream = client.echoBidiStream(metadata, options);
+      bidi_stream.on('data', function(data) {
+        assert.strictEqual(data.value, expectedValue);
+        registry.addCall('response');
+      });
+      bidi_stream.write(message);
+      bidi_stream.end();
+    });
+  });
+
+  describe('trigger when client closes the call', function() {
+    var registry;
+    var expected_calls = [
+      'response', 'halfClose'
+    ];
+    var message = {};
+    var foo_interceptor = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withHalfClose(function(next) {
+          registry.addCall('halfClose');
+          next();
+        }).build();
+      return new grpc_client.InterceptingCall(nextCall(options),
+        outbound);
+    };
+    var options = { interceptors: [foo_interceptor] };
+    it('with unary call', function(done) {
+      registry = new CallRegistry(done, expected_calls);
+      client.echo(message, options, function (err, response) {
+        if (!err) {
+          registry.addCall('response');
+        }
+      });
+    });
+    it('with client streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls);
+      var client_stream = client.echoClientStream(options,
+        function(err, response) {});
+      client_stream.write(message, function(err) {
+        if (!err) {
+          registry.addCall('response');
+        }
+      });
+      client_stream.end();
+    });
+    it('with server streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls);
+      var server_stream = client.echoServerStream(message, options);
+      server_stream.on('data', function (data) {
+        registry.addCall('response');
+      });
+    });
+    it('with bidi streaming call', function(done) {
+      registry = new CallRegistry(done, expected_calls);
+      var bidi_stream = client.echoBidiStream(options);
+      bidi_stream.on('data', function(data) {
+        registry.addCall('response');
+      });
+      bidi_stream.write(message);
+      bidi_stream.end();
+    });
+  });
+
+  describe('trigger when the stream is canceled', function() {
+    var done;
+    var message = {};
+    var foo_interceptor = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withCancel(function(next) {
+          done();
+          next();
+        }).build();
+      return new grpc_client.InterceptingCall(nextCall(options),
+        outbound);
+    };
+    var options = { interceptors: [foo_interceptor] };
+
+    it('with unary call', function(cb) {
+      done = cb;
+      var stream = client.echo(message, options, function() {});
+      stream.cancel();
+    });
+
+    it('with client streaming call', function(cb) {
+      done = cb;
+      var stream = client.echoClientStream(options, function() {});
+      stream.cancel();
+    });
+    it('with server streaming call', function(cb) {
+      done = cb;
+      var stream = client.echoServerStream(message, options);
+      stream.cancel();
+    });
+    it('with bidi streaming call', function(cb) {
+      done = cb;
+      var stream = client.echoBidiStream(options);
+      stream.cancel();
+    });
+  });
+
+  describe('trigger when receiving metadata', function() {
+    var message = {};
+    var expectedKey = 'foo';
+    var expectedValue = 'bar';
+    var foo_interceptor = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          var new_listener = (new ListenerBuilder()).withOnReceiveMetadata(
+            function(metadata, next) {
+              metadata.add(expectedKey, expectedValue);
+              next(metadata);
+            }).build();
+          next(metadata, new_listener);
+        }).build();
+      return new grpc_client.InterceptingCall(nextCall(options), outbound);
+    };
+    var options = { interceptors: [foo_interceptor] };
+    it('with unary call', function(done) {
+      var metadata = new Metadata();
+      var unary_call = client.echo(message, metadata, options, function () {});
+      unary_call.on('metadata', function (metadata) {
+        assert.strictEqual(metadata.get(expectedKey)[0], expectedValue);
+        done();
+      });
+    });
+    it('with client streaming call', function(done) {
+      var metadata = new Metadata();
+      var client_stream = client.echoClientStream(metadata, options,
+        function () {});
+      client_stream.write(message);
+      client_stream.on('metadata', function (metadata) {
+        assert.strictEqual(metadata.get(expectedKey)[0], expectedValue);
+        done();
+      });
+      client_stream.end();
+    });
+    it('with server streaming call', function(done) {
+      var metadata = new Metadata();
+      var server_stream = client.echoServerStream(message, metadata, options);
+      server_stream.on('metadata', function (metadata) {
+        assert.strictEqual(metadata.get(expectedKey)[0], expectedValue);
+        done();
+      });
+      server_stream.on('data', function() { });
+    });
+    it('with bidi streaming call', function(done) {
+      var metadata = new Metadata();
+      var bidi_stream = client.echoBidiStream(metadata, options);
+      bidi_stream.on('metadata', function(metadata) {
+        assert.strictEqual(metadata.get(expectedKey)[0], expectedValue);
+        bidi_stream.end();
+        done();
+      });
+      bidi_stream.on('data', function() { });
+      bidi_stream.write(message);
+    });
+  });
+
+  describe('trigger when sending messages', function() {
+    var originalValue = 'foo';
+    var expectedValue = 'bar';
+    var foo_interceptor = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          var new_listener = (new ListenerBuilder()).withOnReceiveMessage(
+            function(message, next) {
+              if (!message) {
+                next(message);
+                return;
+              }
+              assert.strictEqual(message.value, originalValue);
+              message.value = expectedValue;
+              next(message);
+            }).build();
+          next(metadata, new_listener);
+        }).build();
+      return new grpc_client.InterceptingCall(nextCall(options),
+        outbound);
+    };
+    var options = { interceptors: [foo_interceptor] };
+    var metadata = new Metadata();
+    it('with unary call', function(done) {
+      var message = {value: originalValue};
+      client.echo(message, metadata, options, function (err, response) {
+        assert.strictEqual(response.value, expectedValue);
+        done();
+      });
+    });
+    it('with client streaming call', function(done) {
+      var message = {value: originalValue};
+      var client_stream = client.echoClientStream(metadata, options,
+        function(err, response) {
+          assert.strictEqual(response.value, expectedValue);
+          done();
+        });
+      client_stream.write(message);
+      client_stream.end();
+    });
+    it('with server streaming call', function(done) {
+      var message = {value: originalValue};
+      var server_stream = client.echoServerStream(message, metadata, options);
+      server_stream.on('data', function (data) {
+        assert.strictEqual(data.value, expectedValue);
+        done();
+      });
+    });
+    it('with bidi streaming call', function(done) {
+      var message = {value: originalValue};
+      var bidi_stream = client.echoBidiStream(metadata, options);
+      bidi_stream.on('data', function(data) {
+        assert.strictEqual(data.value, expectedValue);
+        done();
+      });
+      bidi_stream.write(message);
+      bidi_stream.end();
+    });
+  });
+
+  describe('trigger when receiving status', function() {
+    var expectedStatus = 'foo';
+    var foo_interceptor = function(options, nextCall) {
+      var outbound = (new RequesterBuilder())
+        .withStart(function(metadata, listener, next) {
+          var new_listener = (new ListenerBuilder()).withOnReceiveStatus(
+            function(status, next) {
+              assert.strictEqual(status.code, 2);
+              assert.strictEqual(status.details, 'test status message');
+              var new_status = {
+                code: 1,
+                details: expectedStatus,
+                metadata: {}
+              };
+              next(new_status);
+            }).build();
+          next(metadata, new_listener);
+        }).build();
+      return new grpc_client.InterceptingCall(nextCall(options),
+        outbound);
+    };
+    var options = { interceptors: [foo_interceptor] };
+    var metadata = new Metadata();
+    it('with unary call', function(done) {
+      var message = {value: 'error'};
+      var unary_call = client.echo(message, metadata, options, function () {
+      });
+      unary_call.on('status', function (status) {
+        assert.strictEqual(status.code, 1);
+        assert.strictEqual(status.details, expectedStatus);
+        done();
+      });
+    });
+    it('with client streaming call', function(done) {
+      var message = {value: 'error'};
+      var client_stream = client.echoClientStream(metadata, options,
+        function () {
+        });
+      client_stream.on('status', function (status) {
+        assert.strictEqual(status.code, 1);
+        assert.strictEqual(status.details, expectedStatus);
+        done();
+      });
+      client_stream.write(message);
+      client_stream.end();
+    });
+
+    it('with server streaming call', function(done) {
+      var message = {value: 'error'};
+      var server_stream = client.echoServerStream(message, metadata, options);
+      server_stream.on('error', function (err) {
+      });
+      server_stream.on('data', function (data) {
+      });
+      server_stream.on('status', function (status) {
+        assert.strictEqual(status.code, 1);
+        assert.strictEqual(status.details, expectedStatus);
+        done();
+      });
+    });
+
+    it('with bidi streaming call', function(done) {
+      var message = {value: 'error'};
+      var bidi_stream = client.echoBidiStream(metadata, options);
+      bidi_stream.on('error', function(err) {});
+      bidi_stream.on('data', function(data) {});
+      bidi_stream.on('status', function(status) {
+        assert.strictEqual(status.code, 1);
+        assert.strictEqual(status.details, expectedStatus);
+        done();
+      });
+      bidi_stream.write(message);
+      bidi_stream.end();
+    });
+  });
+});

--- a/src/node/test/echo_service.proto
+++ b/src/node/test/echo_service.proto
@@ -21,4 +21,10 @@ message EchoMessage {
 
 service EchoService {
   rpc Echo (EchoMessage) returns (EchoMessage);
+
+  rpc EchoClientStream (stream EchoMessage) returns (EchoMessage);
+
+  rpc EchoServerStream (EchoMessage) returns (stream EchoMessage);
+
+  rpc EchoBidiStream (stream EchoMessage) returns (stream EchoMessage);
 }


### PR DESCRIPTION
Client interceptors for NodeJS as described in
https://github.com/grpc/proposal/pull/14

- Adds a client_interceptors module.
- Wraps the `grpc.Call` startBatch and cancel methods to trigger
  interceptors.
- Centralizes client-side serialization and deserialization to provide
  interceptors with useful messages.
- Adds interceptor builders and providers to manage configuration.
- Extensive tests.