### PR TITLE
Reduce running time of internally run fuzzers

### DIFF
--- a/tools/internal_ci/linux/grpc_fuzzer_api.sh
+++ b/tools/internal_ci/linux/grpc_fuzzer_api.sh
@@ -38,4 +38,4 @@ git submodule update --init
 # download fuzzer docker image from dockerhub
 export DOCKERHUB_ORGANIZATION=grpctesting
 # runtime 23 * 60 mins
-config=asan-trace-cmp runtime=86400 tools/jenkins/run_fuzzer.sh api_fuzzer
+config=asan-trace-cmp runtime=82800 tools/jenkins/run_fuzzer.sh api_fuzzer

--- a/tools/internal_ci/linux/grpc_fuzzer_hpack_parser.sh
+++ b/tools/internal_ci/linux/grpc_fuzzer_hpack_parser.sh
@@ -37,6 +37,5 @@ git submodule update --init
 
 # download fuzzer docker image from dockerhub
 export DOCKERHUB_ORGANIZATION=grpctesting
-# runtime 23 * 60 mins
 config=asan-trace-cmp tools/jenkins/run_fuzzer.sh hpack_parser_fuzzer_test
 

--- a/tools/internal_ci/linux/grpc_fuzzer_http_request.sh
+++ b/tools/internal_ci/linux/grpc_fuzzer_http_request.sh
@@ -37,6 +37,5 @@ git submodule update --init
 
 # download fuzzer docker image from dockerhub
 export DOCKERHUB_ORGANIZATION=grpctesting
-# runtime 23 * 60 mins
 config=asan-trace-cmp tools/jenkins/run_fuzzer.sh http_request_fuzzer_test
 

--- a/tools/internal_ci/linux/grpc_fuzzer_json.sh
+++ b/tools/internal_ci/linux/grpc_fuzzer_json.sh
@@ -37,6 +37,5 @@ git submodule update --init
 
 # download fuzzer docker image from dockerhub
 export DOCKERHUB_ORGANIZATION=grpctesting
-# runtime 23 * 60 mins
 config=asan-trace-cmp tools/jenkins/run_fuzzer.sh json_fuzzer_test
 

--- a/tools/internal_ci/linux/grpc_fuzzer_nanopb_response.sh
+++ b/tools/internal_ci/linux/grpc_fuzzer_nanopb_response.sh
@@ -37,5 +37,4 @@ git submodule update --init
 
 # download fuzzer docker image from dockerhub
 export DOCKERHUB_ORGANIZATION=grpctesting
-# runtime 23 * 60 mins
 config=asan-trace-cmp tools/jenkins/run_fuzzer.sh nanopb_fuzzer_response_test

--- a/tools/internal_ci/linux/grpc_fuzzer_server.sh
+++ b/tools/internal_ci/linux/grpc_fuzzer_server.sh
@@ -38,4 +38,4 @@ git submodule update --init
 # download fuzzer docker image from dockerhub
 export DOCKERHUB_ORGANIZATION=grpctesting
 # runtime 23 * 60 mins
-config=asan-trace-cmp runtime=86400 tools/jenkins/run_fuzzer.sh server_fuzzer
+config=asan-trace-cmp runtime=82800 tools/jenkins/run_fuzzer.sh server_fuzzer

--- a/tools/internal_ci/linux/grpc_fuzzer_uri.sh
+++ b/tools/internal_ci/linux/grpc_fuzzer_uri.sh
@@ -37,5 +37,4 @@ git submodule update --init
 
 # download fuzzer docker image from dockerhub
 export DOCKERHUB_ORGANIZATION=grpctesting
-# runtime 23 * 60 mins
 config=asan-trace-cmp tools/jenkins/run_fuzzer.sh uri_fuzzer_test

--- a/tools/internal_ci/linux/grpc_master.sh
+++ b/tools/internal_ci/linux/grpc_master.sh
@@ -40,6 +40,9 @@ gcc --version || true
 clang --version || true
 docker --version || true
 
+# Need to increase open files limit for c tests
+ulimit -n 2000
+
 git submodule update --init
 
 tools/run_tests/run_tests.py -l c -t -x sponge_log.xml || FAILED="true"


### PR DESCRIPTION
Cleaning up issues from copy/pasting. Also increasing ulimit -n because our c tests open a lot of files.  