### PR TITLE
Fix unhandled std::system_error exception in DynamicThreadPool

### DIFF
--- a/src/cpp/server/dynamic_thread_pool.cc
+++ b/src/cpp/server/dynamic_thread_pool.cc
@@ -123,8 +123,13 @@ void DynamicThreadPool::Add(const std::function<void()>& callback) {
   // Increase pool size or notify as needed
   if (threads_waiting_ == 0) {
     // Kick off a new thread
-    nthreads_++;
-    new DynamicThread(this);
+    try {
+      new DynamicThread(this);
+      nthreads_++;
+    }
+    catch (...) {
+
+    }
   } else {
     cv_.notify_one();
   }

--- a/src/cpp/thread_manager/thread_manager.cc
+++ b/src/cpp/thread_manager/thread_manager.cc
@@ -130,11 +130,16 @@ bool ThreadManager::MaybeContinueAsPoller() {
 void ThreadManager::MaybeCreatePoller() {
   std::unique_lock<std::mutex> lock(mu_);
   if (!shutdown_ && num_pollers_ < min_pollers_) {
-    num_pollers_++;
-    num_threads_++;
 
     // Create a new thread (which ends up calling the MainWorkLoop() function
-    new WorkerThread(this);
+    try {
+      new WorkerThread(this);
+      num_pollers_++;
+      num_threads_++;
+    }
+    catch(...) {
+
+    }
   }
 }
 


### PR DESCRIPTION
On systems with limited resources, DynamicThreadPool will end-up crashing the server as soon as the system will throw an unhandled instance of 'std::system_error', "Resource temporarily unavailable", being unable to allocate a new thread.
This fix prevents the server from crashing by handling the exception.

A crash with a sample stress tester:

>  [New Thread 0x7e7ff3a0 (LWP 7198)]
> terminate called after throwing an instance of 'std::system_error'
>   what():  Resource temporarily unavailable
> 
> Program received signal SIGABRT, Aborted.
> [Switching to Thread 0x7e7ff3a0 (LWP 7198)]
> __libc_do_syscall () at ../ports/sysdeps/unix/sysv/linux/arm/libc-do-syscall.S:44
> 44	in ../ports/sysdeps/unix/sysv/linux/arm/libc-do-syscall.S
> (gdb) bt
> #0  __libc_do_syscall () at ../ports/sysdeps/unix/sysv/linux/arm/libc-do-syscall.S:44
> #1  0x76d7fee6 in __GI_raise (sig=sig@entry=6) at ../nptl/sysdeps/unix/sysv/linux/raise.c:56
> #2  0x76d80bee in __GI_abort () at abort.c:89
> #3  0x76f31cb8 in __gnu_cxx::__verbose_terminate_handler() () from /usr/lib/arm-linux-gnueabihf/libstdc++.so.6
> #4  0x76f306e4 in ?? () from /usr/lib/arm-linux-gnueabihf/libstdc++.so.6