### PR TITLE
Embed mock SSL data into ssl_server_fuzzer.c and add fuzzer options

### DIFF
--- a/test/core/security/BUILD
+++ b/test/core/security/BUILD
@@ -34,7 +34,7 @@ load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
 grpc_fuzzer(
   name = "ssl_server_fuzzer",
   srcs = ["ssl_server_fuzzer.c"],
-  deps = ["//:gpr", "//:grpc", "//test/core/util:grpc_test_util"],
+  deps = ["//:gpr", "//:grpc", "//test/core/util:grpc_test_util", "//test/core/end2end:ssl_test_data"],
   corpus = "corpus",
   copts = ["-std=c99"],
 )

--- a/test/core/security/ssl_server_fuzzer.c
+++ b/test/core/security/ssl_server_fuzzer.c
@@ -47,11 +47,6 @@ bool squelch = true;
 // Turning this on will fail the leak check.
 bool leak_check = false;
 
-#define SSL_CERT_PATH "src/core/lib/tsi/test_creds/server1.pem"
-#define SSL_KEY_PATH "src/core/lib/tsi/test_creds/server1.key"
-#define SSL_CA_PATH "src/core/lib/tsi/test_creds/ca.pem"
-
-
 static void discard_write(grpc_slice slice) {}
 
 static void dont_log(gpr_log_func_args *args) {}

--- a/test/core/security/ssl_server_fuzzer.c
+++ b/test/core/security/ssl_server_fuzzer.c
@@ -38,6 +38,7 @@
 #include "src/core/lib/iomgr/load_file.h"
 #include "src/core/lib/security/credentials/credentials.h"
 #include "src/core/lib/security/transport/security_connector.h"
+#include "test/core/end2end/data/ssl_test_data.h"
 #include "test/core/util/memory_counters.h"
 #include "test/core/util/mock_endpoint.h"
 
@@ -49,6 +50,7 @@ bool leak_check = false;
 #define SSL_CERT_PATH "src/core/lib/tsi/test_creds/server1.pem"
 #define SSL_KEY_PATH "src/core/lib/tsi/test_creds/server1.key"
 #define SSL_CA_PATH "src/core/lib/tsi/test_creds/ca.pem"
+
 
 static void discard_write(grpc_slice slice) {}
 
@@ -88,12 +90,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   // Load key pair and establish server SSL credentials.
   grpc_ssl_pem_key_cert_pair pem_key_cert_pair;
   grpc_slice ca_slice, cert_slice, key_slice;
-  GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
-                               grpc_load_file(SSL_CA_PATH, 1, &ca_slice)));
-  GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
-                               grpc_load_file(SSL_CERT_PATH, 1, &cert_slice)));
-  GPR_ASSERT(GRPC_LOG_IF_ERROR("load_file",
-                               grpc_load_file(SSL_KEY_PATH, 1, &key_slice)));
+  ca_slice = grpc_slice_from_static_string(test_root_cert);
+  cert_slice = grpc_slice_from_static_string(test_server1_cert);
+  key_slice = grpc_slice_from_static_string(test_server1_key);
   const char *ca_cert = (const char *)GRPC_SLICE_START_PTR(ca_slice);
   pem_key_cert_pair.private_key = (const char *)GRPC_SLICE_START_PTR(key_slice);
   pem_key_cert_pair.cert_chain = (const char *)GRPC_SLICE_START_PTR(cert_slice);

--- a/tools/fuzzer/options/api_fuzzer.options
+++ b/tools/fuzzer/options/api_fuzzer.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+max_len = 2048
+dict = api_fuzzer.dictionary

--- a/tools/fuzzer/options/client_fuzzer.options
+++ b/tools/fuzzer/options/client_fuzzer.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+max_len = 2048
+dict = hpack.dictionary

--- a/tools/fuzzer/options/fuzzer.options
+++ b/tools/fuzzer/options/fuzzer.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 512

--- a/tools/fuzzer/options/fuzzer_response.options
+++ b/tools/fuzzer/options/fuzzer_response.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 128

--- a/tools/fuzzer/options/fuzzer_serverlist.options
+++ b/tools/fuzzer/options/fuzzer_serverlist.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 128

--- a/tools/fuzzer/options/hpack_parser_fuzzer_test.options
+++ b/tools/fuzzer/options/hpack_parser_fuzzer_test.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+max_len = 512
+dict = hpack.dictionary

--- a/tools/fuzzer/options/percent_decode_fuzzer.options
+++ b/tools/fuzzer/options/percent_decode_fuzzer.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 32

--- a/tools/fuzzer/options/percent_encode_fuzzer.options
+++ b/tools/fuzzer/options/percent_encode_fuzzer.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 32

--- a/tools/fuzzer/options/request_fuzzer.options
+++ b/tools/fuzzer/options/request_fuzzer.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+max_len = 2048
+

--- a/tools/fuzzer/options/response_fuzzer.options
+++ b/tools/fuzzer/options/response_fuzzer.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+max_len = 2048
+

--- a/tools/fuzzer/options/server_fuzzer.options
+++ b/tools/fuzzer/options/server_fuzzer.options
@@ -1,0 +1,3 @@
+[libfuzzer]
+max_len = 2048
+dict = hpack.dictionary

--- a/tools/fuzzer/options/ssl_server_fuzzer.options
+++ b/tools/fuzzer/options/ssl_server_fuzzer.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 2048

--- a/tools/fuzzer/options/uri_fuzzer_test.options
+++ b/tools/fuzzer/options/uri_fuzzer_test.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 128


### PR DESCRIPTION
Remaking this pull request since I accidently put gRPC's commit history into my PR when I ran a script meant to address a different issue =/