### PR TITLE
Enable Python Negative HTTP2 Test

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -474,8 +474,7 @@ _HTTP2_TEST_CASES = ['tls', 'framing']
 _HTTP2_BADSERVER_TEST_CASES = ['rst_after_header', 'rst_after_data', 'rst_during_data',
                      'goaway', 'ping', 'max_streams']
 
-# TODO: Add python once the tests are fixed.
-_LANGUAGES_FOR_HTTP2_BADSERVER_TESTS = ['java', 'go']
+_LANGUAGES_FOR_HTTP2_BADSERVER_TESTS = ['java', 'go', 'python']
 
 DOCKER_WORKDIR_ROOT = '/var/local/git/grpc'
 


### PR DESCRIPTION
#9698 has been fixed (quite magically), and now these can go back in Jenkins