### PR TITLE
Winduntoo support.

### DIFF
--- a/src/core/lib/iomgr/tcp_client_posix.c
+++ b/src/core/lib/iomgr/tcp_client_posix.c
@@ -86,8 +86,9 @@ static grpc_error *prepare_socket(const grpc_resolved_address *addr, int fd,
   err = grpc_set_socket_cloexec(fd, 1);
   if (err != GRPC_ERROR_NONE) goto error;
   if (!grpc_is_unix_socket(addr)) {
-    err = grpc_set_socket_low_latency(fd, 1);
-    if (err != GRPC_ERROR_NONE) goto error;
+    /* We're going to ignore the potential error on this one, because it's not
+       a fatal problem per-se. */
+    grpc_set_socket_low_latency(fd, 1);
   }
   err = grpc_set_socket_no_sigpipe_if_possible(fd);
   if (err != GRPC_ERROR_NONE) goto error;

--- a/src/core/lib/iomgr/tcp_server_posix.c
+++ b/src/core/lib/iomgr/tcp_server_posix.c
@@ -336,8 +336,9 @@ static grpc_error *prepare_socket(int fd, const grpc_resolved_address *addr,
   err = grpc_set_socket_cloexec(fd, 1);
   if (err != GRPC_ERROR_NONE) goto error;
   if (!grpc_is_unix_socket(addr)) {
-    err = grpc_set_socket_low_latency(fd, 1);
-    if (err != GRPC_ERROR_NONE) goto error;
+    /* We're going to ignore the potential error on this one, because it's not
+       a fatal problem per-se. */
+    grpc_set_socket_low_latency(fd, 1);
     err = grpc_set_socket_reuse_addr(fd, 1);
     if (err != GRPC_ERROR_NONE) goto error;
   }


### PR DESCRIPTION
Things to consider to make grpc binaries to run under Windows' Ubuntu layer:

-) epoll_create1 and epoll_wait work under that layer, but not epoll_pwait.
-) TCP_NODELAY can't be set.
