### PR TITLE
Enable C++ negative http2 test

### DIFF
--- a/test/cpp/interop/http2_client.h
+++ b/test/cpp/interop/http2_client.h
@@ -70,8 +70,11 @@ class Http2Client {
 
   void MaxStreamsWorker(std::shared_ptr<grpc::Channel> channel);
   bool AssertStatusCode(const Status& s, StatusCode expected_code);
+  Status SendUnaryCall(SimpleResponse* response);
+  SimpleRequest BuildDefaultRequest();
   ServiceStub serviceStub_;
   std::shared_ptr<Channel> channel_;
+  SimpleRequest defaultRequest_;
 };
 
 }  // namespace testing

--- a/tools/dockerfile/interoptest/grpc_interop_cxx/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx/build_interop.sh
@@ -47,3 +47,6 @@ make install-certs
 
 # build C++ interop client & server
 make interop_client interop_server
+
+# build C++ http2 client
+make http2_client

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -77,10 +77,14 @@ class CXXLanguage:
   def __init__(self):
     self.client_cwd = None
     self.server_cwd = None
+    self.http2_cwd = None
     self.safename = 'cxx'
 
   def client_cmd(self, args):
     return ['bins/opt/interop_client'] + args
+
+  def client_cmd_http2interop(self, args):
+    return ['bins/opt/http2_client'] + args
 
   def cloud_to_prod_env(self):
     return {}
@@ -474,7 +478,7 @@ _HTTP2_TEST_CASES = ['tls', 'framing']
 _HTTP2_BADSERVER_TEST_CASES = ['rst_after_header', 'rst_after_data', 'rst_during_data',
                      'goaway', 'ping', 'max_streams']
 
-_LANGUAGES_FOR_HTTP2_BADSERVER_TESTS = ['java', 'go', 'python']
+_LANGUAGES_FOR_HTTP2_BADSERVER_TESTS = ['java', 'go', 'python', 'c++']
 
 DOCKER_WORKDIR_ROOT = '/var/local/git/grpc'
 


### PR DESCRIPTION
Include the C++ negative http2 interop tests in Jenkins.

Also addresses a couple potential flakiness issues exposed earlier in the Java and Python tests: the client now does a sleep between calls in the goaway test, and enables wait for ready on the channel.