### PR TITLE
Remove the testonly attribute

### DIFF
--- a/test/core/fling/BUILD
+++ b/test/core/fling/BUILD
@@ -35,7 +35,6 @@ cc_binary(
     name = "client",
     srcs = ["client.c"],
     deps = ["//:grpc", "//test/core/util:grpc_test_util", "//:gpr", "//test/core/util:gpr_test_util", "//test/core/end2end:ssl_test_data"],
-    testonly = 1,
     copts = ['-std=c99']
 )
 
@@ -43,7 +42,6 @@ cc_binary(
     name = "server",
     srcs = ["server.c"],
     deps = ["//:grpc", "//test/core/util:grpc_test_util", "//:gpr", "//test/core/util:gpr_test_util", "//test/core/end2end:ssl_test_data"],
-    testonly = 1,
     copts = ['-std=c99']
 )
 

--- a/test/core/json/BUILD
+++ b/test/core/json/BUILD
@@ -43,7 +43,6 @@ cc_binary(
     name = "json_rewrite",
     srcs = ["json_rewrite.c"],
     deps = ["//:grpc", "//test/core/util:grpc_test_util", "//:gpr", "//test/core/util:gpr_test_util"],
-    testonly = 1,
     copts = ['-std=c99']
 )
 


### PR DESCRIPTION
All the `cc_binary` targets in `test` folder are defaulted to `testonly`.