### PR TITLE
Fix Grpc.HealthCheck and Grpc.Reflection packages

### DIFF
--- a/src/csharp/Grpc.Examples/project.json
+++ b/src/csharp/Grpc.Examples/project.json
@@ -9,12 +9,7 @@
     "Google.Protobuf": "3.0.0"
   },
   "frameworks": {
-    "net45": {
-      "frameworkAssemblies": {
-        "System.Runtime": "",
-        "System.IO": ""
-      }
-    },
+    "net45": {},
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/src/csharp/Grpc.HealthCheck/project.json
+++ b/src/csharp/Grpc.HealthCheck/project.json
@@ -25,12 +25,7 @@
     "Google.Protobuf": "3.0.0"
   },
   "frameworks": {
-    "net45": {
-      "frameworkAssemblies": {
-        "System.Runtime": "",
-        "System.IO": ""
-      }
-    },
+    "net45": {},
     "netstandard1.5": {
       "dependencies": {
         "NETStandard.Library": "1.6.0"

--- a/src/csharp/Grpc.IntegrationTesting/project.json
+++ b/src/csharp/Grpc.IntegrationTesting/project.json
@@ -62,10 +62,7 @@
   },
   "frameworks": {
     "net45": {
-      "frameworkAssemblies": {
-        "System.Runtime": "",
-        "System.IO": ""
-      }
+      "frameworkAssemblies": {}
     },
     "netcoreapp1.0": {
       "imports": [

--- a/src/csharp/Grpc.Reflection/project.json
+++ b/src/csharp/Grpc.Reflection/project.json
@@ -25,12 +25,7 @@
     "Google.Protobuf": "3.0.0"
   },
   "frameworks": {
-    "net45": {
-      "frameworkAssemblies": {
-        "System.Runtime": "",
-        "System.IO": ""
-      }
-    },
+    "net45": {},
     "netstandard1.5": {
       "dependencies": {
         "NETStandard.Library": "1.6.0"

--- a/templates/src/csharp/Grpc.Examples/project.json.template
+++ b/templates/src/csharp/Grpc.Examples/project.json.template
@@ -9,12 +9,7 @@
       "Google.Protobuf": "3.0.0"
     },
     "frameworks": {
-      "net45": {
-        "frameworkAssemblies": {
-          "System.Runtime": "",
-          "System.IO": ""
-        }
-      },
+      "net45": {},
       "netcoreapp1.0": {
         "dependencies": {
           "Microsoft.NETCore.App": {

--- a/templates/src/csharp/Grpc.HealthCheck/project.json.template
+++ b/templates/src/csharp/Grpc.HealthCheck/project.json.template
@@ -27,12 +27,7 @@
       "Google.Protobuf": "3.0.0"
     },
     "frameworks": {
-      "net45": {
-        "frameworkAssemblies": {
-          "System.Runtime": "",
-          "System.IO": ""
-        }
-      },
+      "net45": {},
       "netstandard1.5": {
         "dependencies": {
           "NETStandard.Library": "1.6.0"

--- a/templates/src/csharp/Grpc.IntegrationTesting/project.json.template
+++ b/templates/src/csharp/Grpc.IntegrationTesting/project.json.template
@@ -17,10 +17,7 @@
     },
     "frameworks": {
       "net45": {
-        "frameworkAssemblies": {
-          "System.Runtime": "",
-          "System.IO": ""
-        }
+        "frameworkAssemblies": {}
       },
       "netcoreapp1.0": {
         "imports": [

--- a/templates/src/csharp/Grpc.Reflection/project.json.template
+++ b/templates/src/csharp/Grpc.Reflection/project.json.template
@@ -27,12 +27,7 @@
       "Google.Protobuf": "3.0.0"
     },
     "frameworks": {
-      "net45": {
-        "frameworkAssemblies": {
-          "System.Runtime": "",
-          "System.IO": ""
-        }
-      },
+      "net45": {},
       "netstandard1.5": {
         "dependencies": {
           "NETStandard.Library": "1.6.0"


### PR DESCRIPTION
Currently installing Grpc.HealthCheck and Grpc.Reflection packages into a fresh .NET 4.5.2 console application in VS2015 fails with an error:
`Failed to add reference. The package 'Grpc.HealthCheck' tried to add a framework reference to 'System.Runtime' which was not found in the GAC. This is possibly a bug in the package. Please contact the package owners for assistance.`

Removing frameworkAssemblies sections for net45 target should fix this.
