### PR TITLE
Fix flaky use-after-free in udp_server

### DIFF
--- a/src/core/lib/iomgr/udp_server.c
+++ b/src/core/lib/iomgr/udp_server.c
@@ -485,7 +485,11 @@ void grpc_udp_server_start(grpc_exec_ctx *exec_ctx, grpc_udp_server *s,
                       grpc_schedule_on_exec_ctx);
     grpc_fd_notify_on_write(exec_ctx, sp->emfd, &sp->write_closure);
 
-    s->active_ports++;
+    /* Registered for both read and write callbacks: increment active_ports
+     * twice to account for this, and delay free-ing of memory until both
+     * on_read and on_write have fired. */
+    s->active_ports += 2;
+
     sp = sp->next;
   }
 


### PR DESCRIPTION
Previously if both on_read and on_write were armed, and shutdown occurred, then one would fire first, decrement active_ports, and free the underlying udp_server structure. See the (error != GRPC_ERROR_NONE) handling in on_read or on_write.

This fix sets the active_ports ref count to 2, so that both on_read and on_write must fire or be cancelled before the memory is freed.