### PR TITLE
Fix for using gem build/install

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.files += Dir.glob('include/grpc/**/*')
   s.test_files = Dir.glob('src/ruby/spec/**/*')
   s.bindir = 'src/ruby/bin'
-  s.require_paths = %w( src/ruby/bin src/ruby/lib src/ruby/pb )
+  s.require_paths = %w( src/ruby/lib src/ruby/bin src/ruby/pb )
   s.platform      = Gem::Platform::RUBY
 
   s.add_dependency 'google-protobuf', '~> 3.1'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -26,7 +26,7 @@
     s.files += Dir.glob('include/grpc/**/*')
     s.test_files = Dir.glob('src/ruby/spec/**/*')
     s.bindir = 'src/ruby/bin'
-    s.require_paths = %w( src/ruby/bin src/ruby/lib src/ruby/pb )
+    s.require_paths = %w( src/ruby/lib src/ruby/bin src/ruby/pb )
     s.platform      = Gem::Platform::RUBY
 
     s.add_dependency 'google-protobuf', '~> 3.1'


### PR DESCRIPTION
When pre-compiled assets are missing for the current platform, and you run gem install, the compiled native extensions are placed in the first require paths folder. This differs from rake-compiler task, where they are always placed in lib.

Setting the lib path as the first require path will ensure the compiled library is placed in the correct folder.

Fixes: https://github.com/grpc/grpc/issues/9998