### PR TITLE
Simplify manual running of interop tests

### DIFF
--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -476,13 +476,13 @@ def run(cmdlines,
         skip_jobs=False,
         quiet_success=False):
   if skip_jobs:
-    results = {}
+    resultset = {}
     skipped_job_result = JobResult()
     skipped_job_result.state = 'SKIPPED'
     for job in cmdlines:
       message('SKIPPED', job.shortname, do_newline=True)
-      results[job.shortname] = [skipped_job_result]
-    return results
+      resultset[job.shortname] = [skipped_job_result]
+    return 0, resultset
   js = Jobset(check_cancelled,
               maxjobs if maxjobs is not None else _DEFAULT_MAX_JOBS,
               newline_on_success, travis, stop_on_failure, add_env,

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -501,6 +501,28 @@ def docker_run_cmdline(cmdline, image, docker_args=[], cwd=None, environ=None):
   return docker_cmdline
 
 
+def manual_cmdline(docker_cmdline):
+  """Returns docker cmdline adjusted for manual invocation."""
+  print_cmdline = []
+  for item in docker_cmdline:
+    if item.startswith('--name='):
+      continue
+    # add quotes when necessary
+    if any(character.isspace() for character in item):
+      item = "\"%s\"" % item
+    print_cmdline.append(item)
+  return ' '.join(print_cmdline)
+
+
+def write_cmdlog_maybe(cmdlog, filename):
+  """Returns docker cmdline adjusted for manual invocation."""
+  if cmdlog:
+    with open(filename, 'w') as logfile:
+      logfile.write('#!/bin/bash\n')
+      logfile.writelines("%s\n" % line for line in cmdlog)
+    print('Command log written to file %s' % filename)
+
+
 def bash_cmdline(cmdline):
   """Creates bash -c cmdline from args list."""
   # Use login shell:
@@ -551,7 +573,8 @@ def _job_kill_handler(job):
 
 
 def cloud_to_prod_jobspec(language, test_case, server_host_name,
-                          server_host_detail, docker_image=None, auth=False):
+                          server_host_detail, docker_image=None, auth=False,
+                          manual_cmd_log=None):
   """Creates jobspec for cloud-to-prod interop test"""
   container_name = None
   cmdargs = [
@@ -576,7 +599,9 @@ def cloud_to_prod_jobspec(language, test_case, server_host_name,
                                  cwd=cwd,
                                  environ=environ,
                                  docker_args=['--net=host',
-                                              '--name', container_name])
+                                              '--name=%s' % container_name])
+    if manual_cmd_log is not None:
+      manual_cmd_log.append(manual_cmdline(cmdline))
     cwd = None
     environ = None
 
@@ -597,7 +622,8 @@ def cloud_to_prod_jobspec(language, test_case, server_host_name,
 
 
 def cloud_to_cloud_jobspec(language, test_case, server_name, server_host,
-                           server_port, docker_image=None, insecure=False):
+                           server_port, docker_image=None, insecure=False,
+                           manual_cmd_log=None):
   """Creates jobspec for cloud-to-cloud interop test"""
   interop_only_options = [
       '--server_host_override=foo.test.google.fr',
@@ -628,7 +654,9 @@ def cloud_to_cloud_jobspec(language, test_case, server_name, server_host,
                                  environ=environ,
                                  cwd=cwd,
                                  docker_args=['--net=host',
-                                              '--name', container_name])
+                                              '--name=%s' % container_name])
+    if manual_cmd_log is not None:
+      manual_cmd_log.append(manual_cmdline(cmdline))
     cwd = None
 
   test_job = jobset.JobSpec(
@@ -646,7 +674,7 @@ def cloud_to_cloud_jobspec(language, test_case, server_name, server_host,
   return test_job
 
 
-def server_jobspec(language, docker_image, insecure=False):
+def server_jobspec(language, docker_image, insecure=False, manual_cmd_log=None):
   """Create jobspec for running a server"""
   container_name = dockerjob.random_name('interop_server_%s' % language.safename)
   cmdline = bash_cmdline(
@@ -676,7 +704,9 @@ def server_jobspec(language, docker_image, insecure=False):
                                       cwd=language.server_cwd,
                                       environ=environ,
                                       docker_args=port_args +
-                                        ['--name', container_name])
+                                        ['--name=%s' % container_name])
+  if manual_cmd_log is not None:
+      manual_cmd_log.append(manual_cmdline(docker_cmdline))
   server_job = jobset.JobSpec(
           cmdline=docker_cmdline,
           environ=environ,
@@ -806,6 +836,14 @@ argp.add_argument('--allow_flakes',
                   action='store_const',
                   const=True,
                   help='Allow flaky tests to show as passing (re-runs failed tests up to five times)')
+argp.add_argument('--manual_run',
+                  default=False,
+                  action='store_const',
+                  const=True,
+                  help='Prepare things for running interop tests manually. ' +
+                  'Preserve docker images after building them and skip '
+                  'actually running the tests. Only print commands to run by ' +
+                  'hand.')
 argp.add_argument('--http2_interop',
                   default=False,
                   action='store_const',
@@ -836,6 +874,10 @@ if args.use_docker:
     print('because only the committed changes in the current branch will be')
     print('copied to the docker environment.')
     time.sleep(5)
+
+if args.manual_run and not args.use_docker:
+  print('--manual_run is only supported with --use_docker option enabled.')
+  sys.exit(1)
 
 if not args.use_docker and servers:
   print('Running interop servers is only supported with --use_docker option enabled.')
@@ -887,24 +929,36 @@ if args.use_docker:
         dockerjob.remove_image(image, skip_nonexistent=True)
       sys.exit(1)
 
+server_manual_cmd_log = [] if args.manual_run else None
+client_manual_cmd_log = [] if args.manual_run else None
+
 # Start interop servers.
-server_jobs={}
-server_addresses={}
+server_jobs = {}
+server_addresses = {}
 try:
   for s in servers:
     lang = str(s)
     spec = server_jobspec(_LANGUAGES[lang], docker_images.get(lang),
-                          args.insecure)
-    job = dockerjob.DockerJob(spec)
-    server_jobs[lang] = job
-    server_addresses[lang] = ('localhost', job.mapped_port(_DEFAULT_SERVER_PORT))
+                          args.insecure, manual_cmd_log=server_manual_cmd_log)
+    if not args.manual_run:
+      job = dockerjob.DockerJob(spec)
+      server_jobs[lang] = job
+      server_addresses[lang] = ('localhost', job.mapped_port(_DEFAULT_SERVER_PORT))
+    else:
+      # don't run the server, set server port to a placeholder value
+      server_addresses[lang] = ('localhost', '${SERVER_PORT}')
 
   if args.http2_badserver_interop:
     # launch a HTTP2 server emulator that creates edge cases
     lang = str(http2InteropServer)
-    spec = server_jobspec(http2InteropServer, docker_images.get(lang))
-    job = dockerjob.DockerJob(spec)
-    server_jobs[lang] = job
+    spec = server_jobspec(http2InteropServer, docker_images.get(lang),
+                          manual_cmd_log=server_manual_cmd_log)
+    if not args.manual_run:
+      job = dockerjob.DockerJob(spec)
+      server_jobs[lang] = job
+    else:
+      # don't run the server, set server port to a placeholder value
+      server_addresses[lang] = ('localhost', '${SERVER_PORT}')
 
   jobs = []
   if args.cloud_to_prod:
@@ -918,7 +972,8 @@ try:
               test_job = cloud_to_prod_jobspec(
                   language, test_case, server_host_name,
                   prod_servers[server_host_name],
-                  docker_image=docker_images.get(str(language)))
+                  docker_image=docker_images.get(str(language)),
+                  manual_cmd_log=client_manual_cmd_log)
               jobs.append(test_job)
 
       if args.http2_interop:
@@ -926,7 +981,8 @@ try:
           test_job = cloud_to_prod_jobspec(
               http2Interop, test_case, server_host_name,
               prod_servers[server_host_name],
-              docker_image=docker_images.get(str(http2Interop)))
+              docker_image=docker_images.get(str(http2Interop)),
+              manual_cmd_log=client_manual_cmd_log)
           jobs.append(test_job)
 
   if args.cloud_to_prod_auth:
@@ -939,7 +995,8 @@ try:
             test_job = cloud_to_prod_jobspec(
                 language, test_case, server_host_name,
                 prod_servers[server_host_name],
-                docker_image=docker_images.get(str(language)), auth=True)
+                docker_image=docker_images.get(str(language)), auth=True,
+                manual_cmd_log=client_manual_cmd_log)
             jobs.append(test_job)
 
   for server in args.override_server:
@@ -963,7 +1020,8 @@ try:
                                               server_host,
                                               server_port,
                                               docker_image=docker_images.get(str(language)),
-                                              insecure=args.insecure)
+                                              insecure=args.insecure,
+                                              manual_cmd_log=client_manual_cmd_log)
             jobs.append(test_job)
 
     if args.http2_interop:
@@ -977,7 +1035,8 @@ try:
                                           server_host,
                                           server_port,
                                           docker_image=docker_images.get(str(http2Interop)),
-                                          insecure=args.insecure)
+                                          insecure=args.insecure,
+                                          manual_cmd_log=client_manual_cmd_log)
         jobs.append(test_job)
 
   if args.http2_badserver_interop:
@@ -988,7 +1047,8 @@ try:
                                           str(http2InteropServer),
                                           'localhost',
                                           _DEFAULT_SERVER_PORT,
-                                          docker_image=docker_images.get(str(language)))
+                                          docker_image=docker_images.get(str(language)),
+                                          manual_cmd_log=client_manual_cmd_log)
         jobs.append(test_job)
 
   if not jobs:
@@ -997,12 +1057,19 @@ try:
       dockerjob.remove_image(image, skip_nonexistent=True)
     sys.exit(1)
 
+  if args.manual_run:
+    print('All tests will skipped --manual_run option is active.')
+
   num_failures, resultset = jobset.run(jobs, newline_on_success=True,
-                                       maxjobs=args.jobs)
+                                       maxjobs=args.jobs,
+                                       skip_jobs=args.manual_run)
   if num_failures:
     jobset.message('FAILED', 'Some tests failed', do_newline=True)
   else:
     jobset.message('SUCCESS', 'All tests passed', do_newline=True)
+
+  write_cmdlog_maybe(server_manual_cmd_log, 'interop_server_cmds.sh')
+  write_cmdlog_maybe(client_manual_cmd_log, 'interop_client_cmds.sh')
 
   report_utils.render_junit_xml_report(resultset, 'report.xml')
 
@@ -1029,5 +1096,8 @@ finally:
   dockerjob.finish_jobs([j for j in server_jobs.itervalues()])
 
   for image in docker_images.itervalues():
-    print('Removing docker image %s' % image)
-    dockerjob.remove_image(image)
+    if not args.manual_run:
+      print('Removing docker image %s' % image)
+      dockerjob.remove_image(image)
+    else:
+      print('Preserving docker image: %s' % image)


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/10016

Added `--manual_run` option to `run_interop_tests.py` with the following behavior:
- builds all necessary interop docker images and leaves them around for later use (attention, they can accumulate over time)
- skips running tests, but generates `interop_server_cmds.sh` and `interop_client_cmds.sh` files with a massages version of docker commands that can be used to actually run the interop tests.

Sample output:
```
$ tools/run_tests/run_interop_tests.py -l java -s csharp --use_docker --manual_run
Seen --use_docker flag, will run interop tests under docker.

IMPORTANT: The changes you are testing need to be locally committed
because only the committed changes in the current branch will be
copied to the docker environment.
START: Building interop docker images.
PASSED: build_docker_java [time=31.3sec; retries=0:0]
PASSED: build_docker_csharp [time=58.8sec; retries=0:0]
SUCCESS: All docker images built successfully.
All tests will skipped --manual_run option is active.
SKIPPED: cloud_to_cloud:java:csharp_server:large_unary
SKIPPED: cloud_to_cloud:java:csharp_server:empty_unary
SKIPPED: cloud_to_cloud:java:csharp_server:ping_pong
SKIPPED: cloud_to_cloud:java:csharp_server:empty_stream
SKIPPED: cloud_to_cloud:java:csharp_server:client_streaming
SKIPPED: cloud_to_cloud:java:csharp_server:server_streaming
SKIPPED: cloud_to_cloud:java:csharp_server:cancel_after_begin
SKIPPED: cloud_to_cloud:java:csharp_server:cancel_after_first_response
SKIPPED: cloud_to_cloud:java:csharp_server:timeout_on_sleeping_server
SKIPPED: cloud_to_cloud:java:csharp_server:custom_metadata
SKIPPED: cloud_to_cloud:java:csharp_server:status_code_and_message
SKIPPED: cloud_to_cloud:java:csharp_server:unimplemented_method
SKIPPED: cloud_to_cloud:java:csharp_server:unimplemented_service
SUCCESS: All tests passed
Command log written to file interop_server_cmds.sh
Command log written to file interop_client_cmds.sh
Preserving docker image: grpc_interop_java:6de83e66-7793-41d8-a13a-367a92ad1ec0
Preserving docker image: grpc_interop_csharp:5bbeb172-8c74-41ba-a263-55a07e0174dc
```