### PR TITLE
Dont silence realtime output from run_tests.py --use_docker

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1298,7 +1298,9 @@ if args.use_docker:
   if not args.travis:
     env['TTY_FLAG'] = '-t'  # enables Ctrl-C when not on Jenkins.
 
-  run_shell_command('tools/run_tests/dockerize/build_docker_and_run_tests.sh', env=env)
+  subprocess.check_call('tools/run_tests/dockerize/build_docker_and_run_tests.sh',
+                        shell=True,
+                        env=env)
   sys.exit(0)
 
 _check_arch_option(args.arch)


### PR DESCRIPTION
Partially revert the change from #9733 

The problem is that  when --use_docker option is used, run_tests.py scripts basically morphs into build_docker_and_run_tests.sh. So using subprocess.check_output basically eats the output you really want to see in the console (progress of running tests etc.).

Try running `tools/run_tests/run_tests.py -l ANY_LANGUAGE --use_docker` and you will see that once the docker image is built, the output stops being printed in realtime (pretty annoying when running locally).
