### PR TITLE
Fix chttp2 ping parser

### DIFF
--- a/src/core/ext/transport/chttp2/transport/frame_ping.c
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.c
@@ -91,7 +91,7 @@ grpc_error *grpc_chttp2_ping_parser_parse(grpc_exec_ctx *exec_ctx, void *parser,
   grpc_chttp2_ping_parser *p = parser;
 
   while (p->byte != 8 && cur != end) {
-    p->opaque_8bytes |= (((uint64_t)*cur) << (8 * p->byte));
+    p->opaque_8bytes |= (((uint64_t)*cur) << (56 - 8 * p->byte));
     cur++;
     p->byte++;
   }


### PR DESCRIPTION
The chttp2 ping parser parsed the opaque data in reversed order, then the PING response carried the reversed opaque data. This was not caught by our tests, since both the test server and client are using the same parser, and the reversed opaque data in the PING response was reversed back to the correct order by the ping initializer.

cc @yang-g: this should be the reason why our clients could not work with other servers.