### PR TITLE
Mention pkg-config as a Linux build dependency

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,7 @@ refer to these documents
 ##Linux
 
 ```sh
- $ [sudo] apt-get install build-essential autoconf libtool
+ $ [sudo] apt-get install build-essential autoconf libtool pkg-config
 ```
 
 ##Mac OSX


### PR DESCRIPTION
Background in https://github.com/grpc/grpc/issues/10058

Without pkg-config, `make` fails with a generic error message pointing to INSTALL. But INSTALL does not clearly state pkg-config as a Linux build dependency.