### PR TITLE
Verbosely log flow control failures due to buggy implementations

### DIFF
--- a/src/core/ext/transport/chttp2/transport/parsing.c
+++ b/src/core/ext/transport/chttp2/transport/parsing.c
@@ -381,16 +381,38 @@ static grpc_error *update_incoming_window(grpc_exec_ctx *exec_ctx,
         s->incoming_window_delta +
             t->settings[GRPC_ACKED_SETTINGS]
                        [GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE]) {
-      char *msg;
-      gpr_asprintf(&msg,
-                   "frame of size %d overflows incoming window of %" PRId64,
-                   t->incoming_frame_size,
-                   s->incoming_window_delta +
-                       t->settings[GRPC_ACKED_SETTINGS]
-                                  [GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE]);
-      grpc_error *err = GRPC_ERROR_CREATE(msg);
-      gpr_free(msg);
-      return err;
+      if (incoming_frame_size <=
+          s->incoming_window_delta +
+              t->settings[GRPC_SENT_SETTINGS]
+                         [GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE]) {
+        gpr_log(
+            GPR_ERROR,
+            "Incoming frame of size %d exceeds incoming window size of %" PRId64
+            ".\n"
+            "The (un-acked, future) window size would be %" PRId64
+            " which is not exceeded.\n"
+            "This would usually cause a disconnection, but allowing it due to "
+            "broken HTTP2 implementations in the wild.\n"
+            "See (for example) https://github.com/netty/netty/issues/6520.",
+            t->incoming_frame_size,
+            s->incoming_window_delta +
+                t->settings[GRPC_ACKED_SETTINGS]
+                           [GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE],
+            s->incoming_window_delta +
+                t->settings[GRPC_SENT_SETTINGS]
+                           [GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE]);
+      } else {
+        char *msg;
+        gpr_asprintf(&msg,
+                     "frame of size %d overflows incoming window of %" PRId64,
+                     t->incoming_frame_size,
+                     s->incoming_window_delta +
+                         t->settings[GRPC_ACKED_SETTINGS]
+                                    [GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE]);
+        grpc_error *err = GRPC_ERROR_CREATE(msg);
+        gpr_free(msg);
+        return err;
+      }
     }
 
     GRPC_CHTTP2_FLOW_DEBIT_STREAM_INCOMING_WINDOW_DELTA("parse", t, s,


### PR DESCRIPTION
gRPC C core will occasionally disconnect peers due to flow control failures. Those flow control failures are due to acting on initial window size from settings frames BEFORE acking that settings frame.

Don't fail in these cases, but do verbosely log on them.

Fixes #9956, calls out https://github.com/netty/netty/issues/6520 as a known broken implementation in-the-wild that we need to interop with.