### PR TITLE
Change argument validation in Server#addService

### DIFF
--- a/src/node/src/server.js
+++ b/src/node/src/server.js
@@ -728,7 +728,7 @@ var defaultHandler = {
  *     method implementation for the provided service.
  */
 Server.prototype.addService = function(service, implementation) {
-  if (!_.isObjectLike(service) || !_.isObjectLike(implementation)) {
+  if (!_.isObject(service) || !_.isObject(implementation)) {
     throw new Error('addService requires two objects as arguments');
   }
   if (_.keys(service).length === 0) {


### PR DESCRIPTION
We're trying to avoid using lodash 4-specific functions, mainly for compatibility with internal usage. The check there is mostly just a sanity check anyway, so either of the functions is good enough.