### PR TITLE
Convert vars to float before operating on them in bm_diff.py

### DIFF
--- a/tools/profiling/microbenchmarks/bm_diff.py
+++ b/tools/profiling/microbenchmarks/bm_diff.py
@@ -51,7 +51,7 @@ for row in bm_json.expand_json(js_old_ctr, js_old_opt):
   old[row['cpp_name']] = row
 
 def changed_ratio(n, o):
-  return float(n-o)/float(o)
+  return (float(n)-float(o))/float(o)
 
 def min_change(pct):
   return lambda n, o: abs(changed_ratio(n,o)) > pct/100.0


### PR DESCRIPTION
In https://grpc-testing.appspot.com/job/gRPC_performance_pull_requests/9917/console:
```
Traceback (most recent call last):
  File "tools/profiling/microbenchmarks/bm_diff.py", line 76, in <module>
    if chk(n[fld], o[fld]):
  File "tools/profiling/microbenchmarks/bm_diff.py", line 57, in <lambda>
    return lambda n, o: abs(changed_ratio(n,o)) > pct/100.0
  File "tools/profiling/microbenchmarks/bm_diff.py", line 54, in changed_ratio
    return float(n-o)/float(o)
TypeError: unsupported operand type(s) for -: 'unicode' and 'unicode'
Traceback (most recent call last):
  File "tools/run_tests/run_microbenchmark.py", line 261, in <module>
    '%s.old.opt.json' % bm_name]).strip()
  File "/usr/lib/python2.7/subprocess.py", line 574, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command '['tools/profiling/microbenchmarks/bm_diff.py', 'bm_fullstack_unary_ping_pong.counters.json', 'bm_fullstack_unary_ping_pong.opt.json', 'bm_fullstack_unary_ping_pong.old.counters.json', 'bm_fullstack_unary_ping_pong.old.opt.json']' returned non-zero exit status 1
```
This change converts the unicode to floats before subtracting them.