### PR TITLE
Don't track allocations if we are not going to use the tracking results

### DIFF
--- a/test/cpp/microbenchmarks/helpers.h
+++ b/test/cpp/microbenchmarks/helpers.h
@@ -55,7 +55,9 @@ class Library {
 
  private:
   Library() {
+#ifdef GPR_LOW_LEVEL_COUNTERS
     grpc_memory_counters_init();
+#endif
     init_lib_.init();
     rq_ = grpc_resource_quota_create("bm");
   }


### PR DESCRIPTION
Should remove some errant assignment of CPU time to allocations