### PR TITLE
Skip split_definitions_test if PyPy is used as an interpreter

### DIFF
--- a/src/python/grpcio_tests/tests/protoc_plugin/_split_definitions_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/_split_definitions_test.py
@@ -42,6 +42,7 @@ import sys
 import tempfile
 import threading
 import unittest
+import platform
 
 import grpc
 from grpc_tools import protoc
@@ -150,6 +151,8 @@ class CommonTestMixin(object):
         self.assertEqual(expected_response, response)
 
 
+@unittest.skipIf(platform.python_implementation() == "PyPy",
+                 "Skip test if run with PyPy")
 class SameSeparateTest(unittest.TestCase, SeparateTestMixin):
 
     def setUp(self):
@@ -191,6 +194,8 @@ class SameSeparateTest(unittest.TestCase, SeparateTestMixin):
         shutil.rmtree(self.directory)
 
 
+@unittest.skipIf(platform.python_implementation() == "PyPy",
+                 "Skip test if run with PyPy")
 class SameCommonTest(unittest.TestCase, CommonTestMixin):
 
     def setUp(self):
@@ -228,6 +233,8 @@ class SameCommonTest(unittest.TestCase, CommonTestMixin):
         shutil.rmtree(self.directory)
 
 
+@unittest.skipIf(platform.python_implementation() == "PyPy",
+                 "Skip test if run with PyPy")
 class SplitCommonTest(unittest.TestCase, CommonTestMixin):
 
     def setUp(self):
@@ -277,6 +284,8 @@ class SplitCommonTest(unittest.TestCase, CommonTestMixin):
         shutil.rmtree(self.directory)
 
 
+@unittest.skipIf(platform.python_implementation() == "PyPy",
+                 "Skip test if run with PyPy")
 class SplitSeparateTest(unittest.TestCase, SeparateTestMixin):
 
     def setUp(self):


### PR DESCRIPTION
Skip SameSeparateTest, SameCommonTest, SplitCommonTest, and
SplitSeparateTest if the interpreter is PyPy.