### PR TITLE
run_tests_matrix: ignore the number of failed skipped tests

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -415,8 +415,8 @@ if __name__ == "__main__":
                                        maxjobs=args.jobs)
   # Merge skipped tests into results to show skipped tests on report.xml
   if skipped_jobs:
-    skipped_results = jobset.run(skipped_jobs,
-                                 skip_jobs=True)
+    ignored_num_skipped_failures, skipped_results = jobset.run(
+        skipped_jobs, skip_jobs=True)
     resultset.update(skipped_results)
   report_utils.render_junit_xml_report(resultset, 'report_%s' % _REPORT_SUFFIX,
                                        suite_name='aggregate_tests')


### PR DESCRIPTION
This fix is required for [some of @thunderboltsid's work](https://github.com/grpc/grpc/pull/10114) to produce passing test results.