### PR TITLE
Fix ChannelOptions.MaxMessageSize value

### DIFF
--- a/src/csharp/Grpc.Core/ChannelOptions.cs
+++ b/src/csharp/Grpc.Core/ChannelOptions.cs
@@ -151,7 +151,14 @@ namespace Grpc.Core
         public const string MaxConcurrentStreams = "grpc.max_concurrent_streams";
 
         /// <summary>Maximum message length that the channel can receive</summary>
-        public const string MaxMessageLength = "grpc.max_message_length";
+        public const string MaxReceiveMessageLength = "grpc.max_receive_message_length";
+
+        /// <summary>Maximum message length that the channel can send</summary>
+        public const string MaxSendMessageLength = "grpc.max_send_message_length";
+
+        /// <summary>Obsolete, for backward compatibility only.</summary>
+        [Obsolete("Use MaxReceiveMessageLength instead.")]
+        public const string MaxMessageLength = MaxReceiveMessageLength;
 
         /// <summary>Initial sequence number for http2 transports</summary>
         public const string Http2InitialSequenceNumber = "grpc.http2.initial_sequence_number";


### PR DESCRIPTION
In C core, the value has changed to grpc.max_receive_message_length and now the channel option "grpc.max_message_length" doesn't exist. Reflecting the C core changes in C#.

https://github.com/grpc/grpc/blob/4776102ea4c967e339f3ba040a6fe5c24e8acf2d/include/grpc/impl/codegen/grpc_types.h#L159