### PR TITLE
Add automated PHP-to-C++ performance testing

### DIFF
--- a/tools/gce/linux_performance_worker_init.sh
+++ b/tools/gce/linux_performance_worker_init.sh
@@ -130,7 +130,7 @@ gem install bundler
 
 # PHP dependencies
 
-sudo apt-get install -y php5 php5-dev phpunit php-pear zlib1g-dev
+sudo apt-get install -y php5 php5-dev phpunit php-pear unzip zlib1g-dev
 curl -sS https://getcomposer.org/installer | php
 sudo mv composer.phar /usr/local/bin/composer
 

--- a/tools/gce/linux_performance_worker_init.sh
+++ b/tools/gce/linux_performance_worker_init.sh
@@ -130,7 +130,7 @@ gem install bundler
 
 # PHP dependencies
 
-sudo apt-get install -y php5 php5-dev phpunit php-pear unzip zlib1g-dev
+sudo apt-get install -y php php-dev phpunit php-pear unzip zlib1g-dev
 curl -sS https://getcomposer.org/installer | php
 sudo mv composer.phar /usr/local/bin/composer
 

--- a/tools/gce/linux_performance_worker_init.sh
+++ b/tools/gce/linux_performance_worker_init.sh
@@ -128,6 +128,12 @@ ruby -v
 # Install bundler (prerequisite for gRPC Ruby)
 gem install bundler
 
+# PHP dependencies
+
+sudo apt-get install -y php5 php5-dev phpunit php-pear zlib1g-dev
+curl -sS https://getcomposer.org/installer | php
+sudo mv composer.phar /usr/local/bin/composer
+
 # Java dependencies - nothing as we already have Java JDK 8
 
 # Go dependencies

--- a/tools/run_tests/performance/run_worker_php.sh
+++ b/tools/run_tests/performance/run_worker_php.sh
@@ -31,7 +31,14 @@
 source ~/.rvm/scripts/rvm
 set -ex
 
-cd $(dirname $0)/../../..
+repo=$(dirname $0)/../../..
+
+# First set up all dependences needed for PHP QPS test
+cd $repo
+cd src/php/tests/qps
+curl -sS https://getcomposer.org/installer | php
+php composer.phar install
 
 # The proxy worker for PHP is implemented in Ruby
+cd $repo
 ruby src/ruby/qps/proxy-worker.rb $@

--- a/tools/run_tests/performance/run_worker_php.sh
+++ b/tools/run_tests/performance/run_worker_php.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright 2017, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+source ~/.rvm/scripts/rvm
+set -ex
+
+cd $(dirname $0)/../../..
+
+# The proxy worker for PHP is implemented in Ruby
+ruby src/ruby/qps/proxy-worker.rb $@

--- a/tools/run_tests/performance/run_worker_php.sh
+++ b/tools/run_tests/performance/run_worker_php.sh
@@ -40,3 +40,4 @@ composer install
 # The proxy worker for PHP is implemented in Ruby
 cd ../../../..
 ruby src/ruby/qps/proxy-worker.rb $@
+

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -822,7 +822,7 @@ class PhpLanguage:
         server_language='c++', async_server_threads=1)
 
   def __str__(self):
-    return 'ruby'
+    return 'php'
 
 
 class JavaLanguage:

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -798,6 +798,33 @@ class RubyLanguage:
     return 'ruby'
 
 
+class PhpLanguage:
+
+  def __init__(self):
+    pass
+    self.safename = str(self)
+
+  def worker_cmdline(self):
+    return ['tools/run_tests/performance/run_worker_php.sh']
+
+  def worker_port_offset(self):
+    return 800
+
+  def scenarios(self):
+    yield _ping_pong_scenario(
+        'php_to_cpp_protobuf_sync_unary_ping_pong', rpc_type='UNARY',
+        client_type='SYNC_CLIENT', server_type='SYNC_SERVER',
+        server_language='c++', async_server_threads=1)
+
+    yield _ping_pong_scenario(
+        'php_to_cpp_protobuf_sync_streaming_ping_pong', rpc_type='STREAMING',
+        client_type='SYNC_CLIENT', server_type='SYNC_SERVER',
+        server_language='c++', async_server_threads=1)
+
+  def __str__(self):
+    return 'ruby'
+
+
 class JavaLanguage:
 
   def __init__(self):
@@ -995,6 +1022,7 @@ LANGUAGES = {
     'node' : NodeLanguage(),
     'node_express': NodeExpressLanguage(),
     'ruby' : RubyLanguage(),
+    'php' : PhpLanguage(),
     'java' : JavaLanguage(),
     'python' : PythonLanguage(),
     'go' : GoLanguage(),


### PR DESCRIPTION
Enable automated performance testing at master for PHP client against C++ server; this uses the default PHP for Ubuntu 16.04 (PHP7).
