### PR TITLE
PHP: proto3 api change

### DIFF
--- a/src/php/lib/Grpc/AbstractCall.php
+++ b/src/php/lib/Grpc/AbstractCall.php
@@ -131,6 +131,8 @@ abstract class AbstractCall
         // Proto3 implementation
         if (method_exists($data, 'encode')) {
             return $data->encode();
+        } else if (method_exists($data, 'serializeToString')) {
+            return $data->serializeToString();
         }
 
         // Protobuf-PHP implementation
@@ -154,7 +156,11 @@ abstract class AbstractCall
         if (is_array($this->deserialize)) {
             list($className, $deserializeFunc) = $this->deserialize;
             $obj = new $className();
-            $obj->$deserializeFunc($value);
+            if (method_exists($obj, $deserializeFunc)) {
+                $obj->$deserializeFunc($value);
+            } else {
+                $obj->mergeFromString($value);
+            }
 
             return $obj;
         }


### PR DESCRIPTION
In google/protobuf#2795, in the PHP Proto3 implementation, the encode/decode methods are going to be renamed to serializeToString/mergeFromString. That change is going to make it into the next release 3.3.0. We need to defensively handle these cases because the grpc library can be used alongside multiple versions of protobuf.