### PR TITLE
Drop support for io.js, fix minor issue with node extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "poisson-process": "^0.2.1"
   },
   "engines": {
-    "node": ">=1.1.0"
+    "node": ">=4"
   },
   "binary": {
     "module_name": "grpc_node",

--- a/src/node/ext/server_uv.cc
+++ b/src/node/ext/server_uv.cc
@@ -47,12 +47,12 @@ namespace grpc {
 namespace node {
 
 using Nan::Callback;
+using Nan::MaybeLocal;
 
 using v8::External;
 using v8::Function;
 using v8::FunctionTemplate;
 using v8::Local;
-using v8::MaybeLocal;
 using v8::Object;
 using v8::Value;
 

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -54,7 +54,7 @@
       "poisson-process": "^0.2.1"
     },
     "engines": {
-      "node": ">=1.1.0"
+      "node": ">=4"
     },
     "binary": {
       "module_name": "grpc_node",

--- a/tools/run_tests/artifacts/build_artifact_node.bat
+++ b/tools/run_tests/artifacts/build_artifact_node.bat
@@ -27,7 +27,7 @@
 @rem (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 @rem OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set node_versions=1.1.0 2.0.0 3.0.0 4.0.0 5.0.0 6.0.0 7.0.0
+set node_versions=4.0.0 5.0.0 6.0.0 7.0.0
 
 set electron_versions=1.0.0 1.1.0 1.2.0 1.3.0 1.4.0
 

--- a/tools/run_tests/artifacts/build_artifact_node.sh
+++ b/tools/run_tests/artifacts/build_artifact_node.sh
@@ -42,7 +42,7 @@ mkdir -p artifacts
 
 npm update
 
-node_versions=( 1.1.0 2.0.0 3.0.0 4.0.0 5.0.0 6.0.0 7.0.0 )
+node_versions=( 4.0.0 5.0.0 6.0.0 7.0.0 )
 
 electron_versions=( 1.0.0 1.1.0 1.2.0 1.3.0 1.4.0 )
 


### PR DESCRIPTION
io.js has not been maintained since late 2015, so I don't think it's reasonable to continue officially supporting it. Plus, it appears to have different behavior when handling errors in the stream module, which is making it difficult to get identical behavior to Node.

This should fix #10146.