### PR TITLE
Change GIL aquire functions to make it c-core thread safe

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/security.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/security.pxd.pxi
@@ -29,4 +29,4 @@
 
 
 cdef grpc_ssl_roots_override_result ssl_roots_override_callback(
-    char **pem_root_certs) with gil
+    char **pem_root_certs) nogil

--- a/src/python/grpcio/grpc/_cython/_cygrpc/security.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/security.pyx.pxi
@@ -33,12 +33,14 @@ import pkg_resources
 
 
 cdef grpc_ssl_roots_override_result ssl_roots_override_callback(
-    char **pem_root_certs) with gil:
-  temporary_pem_root_certs = pkg_resources.resource_string(
-      __name__.rstrip('.cygrpc'), '_credentials/roots.pem')
-  pem_root_certs[0] = <char *>gpr_malloc(len(temporary_pem_root_certs) + 1)
-  memcpy(
-      pem_root_certs[0], <char *>temporary_pem_root_certs,
-      len(temporary_pem_root_certs))
-  pem_root_certs[0][len(temporary_pem_root_certs)] = '\0'
+    char **pem_root_certs) nogil:
+  with gil:
+    temporary_pem_root_certs = pkg_resources.resource_string(
+        __name__.rstrip('.cygrpc'), '_credentials/roots.pem')
+    pem_root_certs[0] = <char *>gpr_malloc(len(temporary_pem_root_certs) + 1)
+    memcpy(
+        pem_root_certs[0], <char *>temporary_pem_root_certs,
+        len(temporary_pem_root_certs))
+    pem_root_certs[0][len(temporary_pem_root_certs)] = '\0'
+
   return GRPC_SSL_ROOTS_OVERRIDE_OK

--- a/tools/dockerfile/grpc_artifact_python_manylinux_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux_x64/Dockerfile
@@ -39,7 +39,7 @@ RUN yum update -y
 RUN yum remove -y git
 RUN yum install -y curl-devel expat-devel gettext-devel openssl-devel zlib-devel gcc
 RUN cd /usr/src && \
-  wget https://kernel.org/pub/software/scm/git/git-2.0.5.tar.gz && \
+  curl -O -L https://kernel.org/pub/software/scm/git/git-2.0.5.tar.gz && \
   tar xzf git-2.0.5.tar.gz
 RUN cd /usr/src/git-2.0.5 && \
   make prefix=/usr/local/git all && \

--- a/tools/dockerfile/grpc_artifact_python_manylinux_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux_x86/Dockerfile
@@ -39,7 +39,7 @@ RUN yum update -y
 RUN yum remove -y git
 RUN yum install -y curl-devel expat-devel gettext-devel openssl-devel zlib-devel gcc
 RUN cd /usr/src && \
-  wget https://kernel.org/pub/software/scm/git/git-2.0.5.tar.gz && \
+  curl -O -L https://kernel.org/pub/software/scm/git/git-2.0.5.tar.gz && \
   tar xzf git-2.0.5.tar.gz
 RUN cd /usr/src/git-2.0.5 && \
   make prefix=/usr/local/git all && \


### PR DESCRIPTION
The ```with gil``` function modifier indicates that it should be called with the GIL, but when this gets called from a c-core thread, it doesn't have GIL.

Using the ```with gil``` assumes the GIL has not yet been acquired.

Cython ends up mapping this to the following c code:
https://docs.python.org/2/c-api/init.html#non-python-created-threads 

Which is what we want.

Tested against the reporter docker file and it succeeded, we should proceed with a new RC and verify.