### PR TITLE
Initialize GIL at startup

### DIFF
--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
@@ -47,14 +47,14 @@ include "_cygrpc/server.pyx.pxi"
 #
 # initialize gRPC
 #
-
-
 cdef extern from "Python.h":
 
-  int Py_AtExit(void(*func)())
+  int PyEval_InitThreads()
 
-
-def _initialize():
+cdef _initialize():
+  # We have Python callbacks called by c-core threads, this ensures the GIL
+  # is initialized.
+  PyEval_InitThreads()
   grpc_set_ssl_roots_override_callback(
           <grpc_ssl_roots_override_callback>ssl_roots_override_callback)
 


### PR DESCRIPTION
According to the documentation here:
http://cython.readthedocs.io/en/latest/src/userguide/external_C_code.html#acquiring-the-gil

The last change should have had no effect, so I guess I just got lucky that it didn't reproduce on the new build.

In the same documentation, this is the "proper" fix.