### PR TITLE
Added scripts to build images and run comp tests

### DIFF
--- a/tools/gcp/comp_test/create_comptest_images.sh
+++ b/tools/gcp/comp_test/create_comptest_images.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Copyright 2017, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# This script invoke run_interop_tests in manual mode to create test cases
+# and docker images.  These test cases are then stored in the docker images
+# and uploaded to Google Container Registry for running version compatibility
+# tests at a later time.
+set -ex
+
+export LANG=en_US.UTF-8
+
+# Enter the gRPC repo root
+cd $(dirname $0)/../../..
+
+_COMMON_FLAGS="--use_docker --manual_run"
+# TODO(yongni): add other tests.
+tools/run_tests/run_interop_tests.py -l java --cloud_to_prod $_COMMON_FLAGS
+
+# Outputs of run_interop_tests.py.
+_DOCKER_IMG_LIST='docker_images'
+_CLIENT_CMDS='interop_client_cmds.sh'
+_REPORT='report.xml'
+
+images=$(cat $_DOCKER_IMG_LIST)
+[ -n "$images" ] || (echo "No image found"; exit 1)
+[ -e "$_CLIENT_CMDS" ] || (echo "$_CLIENT_CMDS not found"; exit 1)
+
+echo "Uploading images: $image"
+tools/gcp/utils/gcr_upload.py --gcr_tag=comp_latest --with_files=$_CLIENT_CMDS \
+  --images=$images
+
+# Clean up
+xargs -I % docker rmi % < $_DOCKER_IMG_LIST

--- a/tools/gcp/comp_test/run_comp_test.py
+++ b/tools/gcp/comp_test/run_comp_test.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python2.7
+# Copyright 2017, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Run tests using images stored in Google Container Registry."""
+
+from __future__ import print_function
+
+import argparse
+import atexit
+import json
+import os
+import shutil
+import subprocess
+
+argp = argparse.ArgumentParser(description='Run interop tests.')
+argp.add_argument('--gcr_path',
+                  default='gcr.io/grpc-testing',
+                  help='Path of docker images in Google Container Registry')
+
+argp.add_argument('--gcr_tag',
+                  default='comp_latest',
+                  help='the tag string of the images to run')
+
+argp.add_argument('--run_files',
+                  default=['interop_client_cmds.sh'],
+                  nargs='+',
+                  help='scripts (in with_file_path) from docker images to invoke')
+
+argp.add_argument('--with_file_path',
+                  default='/var/local/image_info',
+                  help='Directory inside docker image for image_info')
+
+argp.add_argument('--keep',
+                  action='store_true',
+                  help='keep the docker images after finishing the tests.')
+
+
+args = argp.parse_args()
+
+# Images with this prefix are for running comp test.
+_IMAGE_NAME_PREFIX = 'grpc_interop_'
+
+def query_gcr():
+  """Query GCR for comp_test images.
+
+  Images need to be under args.gcr_path, starts with _IMAGE_NAME_PREFIX, and
+  contains args.gcr_tag.
+
+  Returns all the matching images str in the form of
+     <gcr_path>/_IMAGE_NAME_PREFIX_lang:<gcr_tag>
+  as a list.
+  """
+  # Query GCR.
+  output = subprocess.check_output([
+      'gcloud', 'beta', 'container', 'images', 'list',
+      '--repository=%s' % args.gcr_path,
+      '--filter', 'name:%s' % _IMAGE_NAME_PREFIX, '--format=json'])
+
+  # Find images with desired tag.
+  images = []
+  for entry in json.loads(output):
+    output = subprocess.check_output([
+        'gcloud', 'beta', 'container', 'images', 'list-tags', entry['name'],
+        '--filter', 'tags=%s' % args.gcr_tag, '--format=json'])
+    # As long as the result is loadable in json and not empty, we have a match.
+    if json.loads(output):
+      images.append(entry['name'])
+
+  print('Images found: %s' % images)
+  return images
+
+def run_tests_in_image(image):
+  """Download a docker image and run tests stored inside."""
+  image_full = '%s:%s' % (image, args.gcr_tag)
+  print('Pulling image: %s' % image_full)
+
+  output = subprocess.check_output(['gcloud', 'docker', '--', 'pull', image_full])
+  # Register clean up.
+  atexit.register(lambda: subprocess.call(['docker', 'rmi', image_full]))
+
+  output = subprocess.check_output(['docker', 'inspect', image_full])
+  info = json.loads(output)
+  try:
+    original_name = info[0]['Config']['Labels']['original_name']
+  except:
+    print('No info in docker image: %s' % image_full)
+    sys.exit(1)
+
+  with_basename = os.path.basename(args.with_file_path)
+  print('Extracting %s' % args.run_files)
+  # Extract the shell commands for running the test under /tmp/image_info/.
+  cmd = "docker run --rm %s tar -c -C %s %s |tar -x -C /tmp" % (
+      image_full, os.path.dirname(args.with_file_path), with_basename)
+  subprocess.check_call(cmd, shell=True)
+
+  print('Running test')
+  for run_file in args.run_files:
+    with open(os.path.join('/tmp', with_basename, run_file)) as f:
+      for test_line in f:
+        if test_line.startswith('#'):
+          continue
+        # We need to replace the original image name (containing uuid) in the
+        # docker run command with the new gcr based name (image_full).
+        if not original_name in test_line:
+          # this line doesn't use current docker image.
+          continue
+
+        test = test_line.replace(original_name, image_full)
+        print(test)
+        p = subprocess.Popen(test, shell=True, stdout=subprocess.PIPE)
+        print(p.communicate()[0])
+
+        #TODO(yongni): figure out how to present the result.
+
+  # Clean up.
+  shutil.rmtree(os.path.join('/tmp', with_basename))
+
+
+for image in query_gcr():
+  run_tests_in_image(image)

--- a/tools/gcp/utils/gcr_upload.py
+++ b/tools/gcp/utils/gcr_upload.py
@@ -53,7 +53,7 @@ argp.add_argument('--with_files',
                   nargs='+',
                   help='additional files to include in the docker image')
 
-argp.add_argument('--with_file_dest',
+argp.add_argument('--with_file_path',
                   default='/var/local/image_info',
                   help='Destination directory for with_files inside docker image')
 
@@ -77,7 +77,7 @@ def upload_to_gcr(image):
 
   A docker image image_foo:tag_old will be uploaded as
      <gcr_path>/image_foo:<gcr_tag>
-  after inserting extra with_files under with_file_dest in the image.  The
+  after inserting extra with_files under with_file_path in the image.  The
   original image name will be stored as label original_name:"image_foo:tag_old".
   """
   tag_idx = image.find(':')
@@ -96,7 +96,7 @@ def upload_to_gcr(image):
   # context.
   for f in args.with_files:
     shutil.copy(f, temp_dir)
-    lines.append('COPY %s %s/' % (os.path.basename(f), args.with_file_dest))
+    lines.append('COPY %s %s/' % (os.path.basename(f), args.with_file_path))
 
   # Create a Dockerfile.
   with open(os.path.join(temp_dir, 'Dockerfile'), 'w') as f:

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -73,6 +73,12 @@ _SKIP_ADVANCED = ['status_code_and_message',
 
 _TEST_TIMEOUT = 3*60
 
+# Files that could be created from running interop tests.
+_DOCKER_IMG_LIST = 'docker_images'
+_CLIENT_CMDS = 'interop_client_cmds.sh'
+_SERVER_CMDS = 'interop_server_cmds.sh'
+_REPORT = 'report.xml'
+
 class CXXLanguage:
 
   def __init__(self):
@@ -1069,10 +1075,10 @@ try:
   else:
     jobset.message('SUCCESS', 'All tests passed', do_newline=True)
 
-  write_cmdlog_maybe(server_manual_cmd_log, 'interop_server_cmds.sh')
-  write_cmdlog_maybe(client_manual_cmd_log, 'interop_client_cmds.sh')
+  write_cmdlog_maybe(server_manual_cmd_log, _SERVER_CMDS)
+  write_cmdlog_maybe(client_manual_cmd_log, _CLIENT_CMDS)
 
-  report_utils.render_junit_xml_report(resultset, 'report.xml')
+  report_utils.render_junit_xml_report(resultset, _REPORT)
 
   for name, job in resultset.items():
     if "http2" in name:
@@ -1096,9 +1102,12 @@ finally:
 
   dockerjob.finish_jobs([j for j in six.itervalues(server_jobs)])
 
-  for image in six.itervalues(docker_images):
-    if not args.manual_run:
+  if args.manual_run:
+    with open(_DOCKER_IMG_LIST, 'w') as f:
+      f.writelines('\n'.join(six.itervalues(docker_images)))
+    print('Preserving docker images: %s' %
+          ','.join(six.itervalues(docker_images)))
+  else:
+    for image in six.itervalues(docker_images):
       print('Removing docker image %s' % image)
       dockerjob.remove_image(image)
-    else:
-      print('Preserving docker image: %s' % image)


### PR DESCRIPTION
comp_test images are created by running run_interop_test in manual mode and storing the test case scripts inside the created docker image.  The images are uploaded to GCR with comp_xxx tag.  When running comp test, the same set of tests are replayed after downloading the image from GCR and extracting the script.

jtattermusch: I still need some polish work but this is the first crack at putting everything together.