### PR TITLE
fix the namespacing for php docs on client classes

### DIFF
--- a/src/compiler/php_generator.cc
+++ b/src/compiler/php_generator.cc
@@ -118,7 +118,7 @@ void PrintService(const ServiceDescriptor *service, Printer *out) {
   out->Print(
       "/**\n * @param string $$hostname hostname\n"
       " * @param array $$opts channel options\n"
-      " * @param Grpc\\Channel $$channel (optional) re-use channel "
+      " * @param \\Grpc\\Channel $$channel (optional) re-use channel "
       "object\n */\n"
       "public function __construct($$hostname, $$opts, "
       "$$channel = null) {\n");


### PR DESCRIPTION
the `$channel` param needs a starting `\` to correctly denote its namespace, since the outputted class now has a namespace.