### PR TITLE
Add CreateChannelGlobalCallbacks

### DIFF
--- a/include/grpc++/create_channel.h
+++ b/include/grpc++/create_channel.h
@@ -66,6 +66,20 @@ std::shared_ptr<Channel> CreateCustomChannel(
     const std::shared_ptr<ChannelCredentials>& creds,
     const ChannelArguments& args);
 
+/// Global Callbacks for CreateChannel and CreateCustomChannel
+///
+/// Can be set exactly once per application to install hooks whenever
+/// a channel is created.
+class CreateChannelGlobalCallbacks {
+ public:
+  virtual ~CreateChannelGlobalCallbacks() {}
+  /// Called before channel is created.
+  virtual void UpdateArguments(ChannelArguments* args) {}
+};
+/// Set the global callback object for CreateChannel. Can only be called once.
+/// Does not take ownership of callbacks.
+void SetCreateChannelGlobalCallbacks(CreateChannelGlobalCallbacks* callbacks);
+
 }  // namespace grpc
 
 #endif  // GRPCXX_CREATE_CHANNEL_H

--- a/src/cpp/client/create_channel.cc
+++ b/src/cpp/client/create_channel.cc
@@ -37,11 +37,24 @@
 #include <grpc++/create_channel.h>
 #include <grpc++/impl/grpc_library.h>
 #include <grpc++/support/channel_arguments.h>
+#include <grpc/support/log.h>
 
 #include "src/cpp/client/create_channel_internal.h"
 
 namespace grpc {
 class ChannelArguments;
+
+namespace {
+class DefaultGlobalCallbacks final : public CreateChannelGlobalCallbacks {
+ public:
+  ~DefaultGlobalCallbacks() override {}
+  void UpdateArguments(ChannelArguments* args) override {}
+};
+}  // namespace
+
+static DefaultGlobalCallbacks g_default_create_channel_callbacks;
+static CreateChannelGlobalCallbacks* g_create_channel_callbacks =
+    &g_default_create_channel_callbacks;
 
 std::shared_ptr<Channel> CreateChannel(
     const grpc::string& target,
@@ -55,11 +68,21 @@ std::shared_ptr<Channel> CreateCustomChannel(
     const ChannelArguments& args) {
   internal::GrpcLibrary
       init_lib;  // We need to call init in case of a bad creds.
+  ChannelArguments new_args(args);
+  g_create_channel_callbacks->UpdateArguments(&new_args);
   return creds
-             ? creds->CreateChannel(target, args)
+             ? creds->CreateChannel(target, new_args)
              : CreateChannelInternal("", grpc_lame_client_channel_create(
                                              NULL, GRPC_STATUS_INVALID_ARGUMENT,
                                              "Invalid credentials."));
+}
+
+void SetCreateChannelGlobalCallbacks(
+    CreateChannelGlobalCallbacks* create_channel_callbacks) {
+  GPR_ASSERT(g_create_channel_callbacks == &g_default_create_channel_callbacks);
+  GPR_ASSERT(create_channel_callbacks != NULL);
+  GPR_ASSERT(create_channel_callbacks != &g_default_create_channel_callbacks);
+  g_create_channel_callbacks = create_channel_callbacks;
 }
 
 }  // namespace grpc

--- a/src/cpp/common/channel_arguments.cc
+++ b/src/cpp/common/channel_arguments.cc
@@ -133,14 +133,19 @@ void ChannelArguments::SetUserAgentPrefix(
     return;
   }
   bool replaced = false;
+  auto strings_it = strings_.begin();
   for (auto it = args_.begin(); it != args_.end(); ++it) {
     const grpc_arg& arg = *it;
-    if (arg.type == GRPC_ARG_STRING &&
-        grpc::string(arg.key) == GRPC_ARG_PRIMARY_USER_AGENT_STRING) {
-      strings_.push_back(user_agent_prefix + " " + arg.value.string);
-      it->value.string = const_cast<char*>(strings_.back().c_str());
-      replaced = true;
-      break;
+    ++strings_it;
+    if (arg.type == GRPC_ARG_STRING) {
+      if (grpc::string(arg.key) == GRPC_ARG_PRIMARY_USER_AGENT_STRING) {
+        GPR_ASSERT(arg.value.string == strings_it->c_str());
+        *(strings_it) = user_agent_prefix + " " + arg.value.string;
+        it->value.string = const_cast<char*>(strings_it->c_str());
+        replaced = true;
+        break;
+      }
+      ++strings_it;
     }
   }
   if (!replaced) {


### PR DESCRIPTION
Global callbacks for CreateChannel and CreateCustomChannel. Can be set exactly once per application to install hooks whenever a channel is created.