### PR TITLE
Removing credentials assert in server_auth_filter.

### DIFF
--- a/src/core/lib/security/transport/server_auth_filter.c
+++ b/src/core/lib/security/transport/server_auth_filter.c
@@ -158,7 +158,7 @@ static void auth_on_recv(grpc_exec_ctx *exec_ctx, void *user_data,
   call_data *calld = elem->call_data;
   channel_data *chand = elem->channel_data;
   if (error == GRPC_ERROR_NONE) {
-    if (chand->creds->processor.process != NULL) {
+    if (chand->creds != NULL && chand->creds->processor.process != NULL) {
       calld->md = metadata_batch_to_md_array(calld->recv_initial_metadata);
       chand->creds->processor.process(
           chand->creds->processor.state, calld->auth_context,
@@ -242,7 +242,6 @@ static grpc_error *init_channel_elem(grpc_exec_ctx *exec_ctx,
 
   GPR_ASSERT(!args->is_last);
   GPR_ASSERT(auth_context != NULL);
-  GPR_ASSERT(creds != NULL);
 
   /* initialize members */
   chand->auth_context =


### PR DESCRIPTION
This will allow other transports with built-in security to use this
filter.