### PR TITLE
Update README.md to be render correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 Copyright 2015 Google Inc.
 
-#Documentation
+# Documentation
 
 You can find more detailed documentation and examples in the [doc](doc) and [examples](examples) directories respectively.
 
-#Installation & Testing
+# Installation & Testing
 
 See [INSTALL](INSTALL.md) for installation instructions for various platforms.
 
@@ -19,22 +19,22 @@ See [tools/run_tests](tools/run_tests) for more guidance on how to run various t
 
 See [Performance dashboard](http://performance-dot-grpc-testing.appspot.com/explore?dashboard=5712453606309888) for the performance numbers for v1.0.x.
 
-#Repository Structure & Status
+# Repository Structure & Status
 
-This repository contains source code for gRPC libraries for multiple languages written on top of shared C core library [src/core] (src/core).
+This repository contains source code for gRPC libraries for multiple languages written on top of shared C core library [src/core](src/core).
 
 Libraries in different languages may be in different states of development. We are seeking contributions for all of these libraries.
 
 | Language                | Source                              | Status  |
 |-------------------------|-------------------------------------|---------|
-| Shared C [core library] | [src/core] (src/core)               | 1.0     |
-| C++                     | [src/cpp] (src/cpp)                 | 1.0     |
-| Ruby                    | [src/ruby] (src/ruby)               | 1.0     |
-| NodeJS                  | [src/node] (src/node)               | 1.0     |
-| Python                  | [src/python] (src/python)           | 1.0     |
-| PHP                     | [src/php] (src/php)                 | 1.0     |
-| C#                      | [src/csharp] (src/csharp)           | 1.0     |
-| Objective-C             | [src/objective-c] (src/objective-c) | 1.0     |
+| Shared C [core library] | [src/core](src/core)               | 1.0     |
+| C++                     | [src/cpp](src/cpp)                 | 1.0     |
+| Ruby                    | [src/ruby](src/ruby)               | 1.0     |
+| NodeJS                  | [src/node](src/node)               | 1.0     |
+| Python                  | [src/python](src/python)           | 1.0     |
+| PHP                     | [src/php](src/php)                 | 1.0     |
+| C#                      | [src/csharp](src/csharp)           | 1.0     |
+| Objective-C             | [src/objective-c](src/objective-c) | 1.0     |
 
 <small>
 Java source code is in the [grpc-java] (http://github.com/grpc/grpc-java) repository.
@@ -44,7 +44,7 @@ Go source code is in the [grpc-go] (http://github.com/grpc/grpc-go) repository.
 See [MANIFEST.md](MANIFEST.md) for a listing of top-level items in the
 repository.
 
-#Overview
+# Overview
 
 
 Remote Procedure Calls (RPCs) provide a useful abstraction for building
@@ -54,7 +54,7 @@ These libraries enable communication between clients and servers using any
 combination of the supported languages.
 
 
-##Interface
+## Interface
 
 
 Developers using gRPC typically start with the description of an RPC service
@@ -66,7 +66,7 @@ Interface Definition Language (IDL) for describing both the service interface
 and the structure of the payload messages. It is possible to use other
 alternatives if desired.
 
-###Surface API
+### Surface API
 Starting from an interface definition in a .proto file, gRPC provides
 Protocol Compiler plugins that generate Client- and Server-side APIs.
 gRPC users typically call into these APIs on the Client side and implement
@@ -94,7 +94,7 @@ the client and the server can send a stream of messages to each other. The strea
 messages are delivered in the order they were sent.
 
 
-#Protocol
+# Protocol
 
 The [gRPC protocol](doc/PROTOCOL-HTTP2.md) specifies the abstract requirements for communication between
 clients and servers. A concrete embedding over HTTP/2 completes the picture by


### PR DESCRIPTION
Headlines and links don't render correctly as Markdown due to missing spaces or too many spaces.

@jtattermusch 