### PR TITLE
Memory usage tweaks

### DIFF
--- a/src/core/lib/surface/channel.c
+++ b/src/core/lib/surface/channel.c
@@ -200,16 +200,13 @@ size_t grpc_channel_get_call_size_estimate(grpc_channel *channel) {
          (which is common) - which tends to help most allocators reuse memory
       2. a small amount of allowed growth over the estimate without hitting
          the arena size doubling case, reducing overall memory usage */
-  size_t est = ((size_t)gpr_atm_no_barrier_load(&channel->call_size_estimate) +
-                2 * ROUND_UP_SIZE) &
-               ~(size_t)(ROUND_UP_SIZE - 1);
-  gpr_log(GPR_DEBUG, "est: %d", (int)est);
-  return est;
+  return ((size_t)gpr_atm_no_barrier_load(&channel->call_size_estimate) +
+          2 * ROUND_UP_SIZE) &
+         ~(size_t)(ROUND_UP_SIZE - 1);
 }
 
 void grpc_channel_update_call_size_estimate(grpc_channel *channel,
                                             size_t size) {
-  gpr_log(GPR_DEBUG, "used: %d", (int)size);
   size_t cur = (size_t)gpr_atm_no_barrier_load(&channel->call_size_estimate);
   if (cur < size) {
     /* size grew: update estimate */

--- a/test/core/memory_usage/client.c
+++ b/test/core/memory_usage/client.c
@@ -237,6 +237,11 @@ int main(int argc, char **argv) {
       0, grpc_slice_from_static_string("Reflector/GetAfterSvrCreation"));
 
   // warmup period
+  for (int i = 0; i < warmup_iterations; i++) {
+    send_snapshot_request(
+        0, grpc_slice_from_static_string("Reflector/SimpleSnapshot"));
+  }
+
   for (call_idx = 0; call_idx < warmup_iterations; ++call_idx) {
     init_ping_pong_request(call_idx + 1);
   }


### PR DESCRIPTION
- Improve estimation to give a more reliable slop space in the arena
- Improve measurement by issuing sufficient throw-away calls on a channel to allow call size estimation to settle