### PR TITLE
Fix testInternalError that caused Jenkins hang for a long time

### DIFF
--- a/src/objective-c/tests/CronetUnitTests/CronetUnitTests.m
+++ b/src/objective-c/tests/CronetUnitTests/CronetUnitTests.m
@@ -34,7 +34,6 @@
 #import <XCTest/XCTest.h>
 #import <netinet/in.h>
 #import <sys/socket.h>
-#import <sys/fcntl.h>
 
 #import <Cronet/Cronet.h>
 #import <grpc/grpc.h>
@@ -197,7 +196,6 @@ unsigned int parse_h2_length(const char *field) {
   s_addr.sin_family = AF_INET;
   s_addr.sin_addr.s_addr = htonl(INADDR_ANY);
   s_addr.sin_port = htons(port);
-  GPR_ASSERT(-1 != fcntl(sl, F_SETFL, fcntl(sl, F_GETFL, 0) | O_NONBLOCK));
   GPR_ASSERT(0 == bind(sl, (struct sockaddr *)&s_addr, sizeof(s_addr)));
   GPR_ASSERT(0 == listen(sl, 5));
 
@@ -240,10 +238,6 @@ unsigned int parse_h2_length(const char *field) {
 
   dispatch_async(
       dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        fd_set fs;
-        FD_ZERO(&fs);
-        FD_SET(sl, &fs);
-        select(sl + 1, &fs, NULL, NULL, NULL);
         int s = accept(sl, NULL, NULL);
         GPR_ASSERT(s >= 0);
 
@@ -331,17 +325,18 @@ unsigned int parse_h2_length(const char *field) {
   __weak XCTestExpectation *expectation =
       [self expectationWithDescription:@"Coalescing"];
 
+  int sl = socket(AF_INET, SOCK_STREAM, 0);
+  GPR_ASSERT(sl >= 0);
+  struct sockaddr_in s_addr;
+  memset(&s_addr, 0, sizeof(s_addr));
+  s_addr.sin_family = AF_INET;
+  s_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+  s_addr.sin_port = htons(port);
+  GPR_ASSERT(0 == bind(sl, (struct sockaddr *)&s_addr, sizeof(s_addr)));
+  GPR_ASSERT(0 == listen(sl, 5));
+
   dispatch_async(
       dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        int sl = socket(AF_INET, SOCK_STREAM, 0);
-        GPR_ASSERT(sl >= 0);
-        struct sockaddr_in s_addr;
-        memset(&s_addr, 0, sizeof(s_addr));
-        s_addr.sin_family = AF_INET;
-        s_addr.sin_addr.s_addr = htonl(INADDR_ANY);
-        s_addr.sin_port = htons(port);
-        GPR_ASSERT(0 == bind(sl, (struct sockaddr *)&s_addr, sizeof(s_addr)));
-        GPR_ASSERT(0 == listen(sl, 5));
         int s = accept(sl, NULL, NULL);
         GPR_ASSERT(s >= 0);
         struct timeval tv;
@@ -395,9 +390,6 @@ unsigned int parse_h2_length(const char *field) {
         close(sl);
         [expectation fulfill];
       });
-
-  // Guarantees that server is listening to the port before client connects.
-  sleep(1);
 
   memset(ops, 0, sizeof(ops));
   op = ops;


### PR DESCRIPTION
The original testInternalError test opens one thread to create a TLS server and connect to the server with a gRPC client on main thread. The program may hang in the case where main thread attempts to connect before the server is created. In this case, client will act as expected (return `Internal` error code due to connection refused) but server thread will be stuck at `accept` since no thread is connecting to it. 

The changes in this PR put server in listening mode in the main thread, thus guaranteeing that client's connection happens after server listen.