### PR TITLE
Client-side keepalive fixes

### DIFF
--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -198,14 +198,14 @@ typedef struct {
 #define GRPC_ARG_HTTP2_WRITE_BUFFER_SIZE "grpc.http2.write_buffer_size"
 /** After a duration of this time the client pings the server to see if the
     transport is still alive. Int valued, seconds. */
-#define GRPC_ARG_HTTP2_KEEPALIVE_TIME "grpc.http2.keepalive_time"
+#define GRPC_ARG_KEEPALIVE_TIME_S "grpc.keepalive_time"
 /** After waiting for a duration of this time, if the client does not receive
     the ping ack, it will close the transport. Int valued, seconds. */
-#define GRPC_ARG_HTTP2_KEEPALIVE_TIMEOUT "grpc.http2.keepalive_timeout"
+#define GRPC_ARG_KEEPALIVE_TIMEOUT_S "grpc.keepalive_timeout"
 /** Is it permissible to send keepalive pings without any outstanding streams.
     Int valued, 0(false)/1(true). */
-#define GRPC_ARG_HTTP2_KEEPALIVE_PERMIT_WITHOUT_CALLS \
-  "grpc.http2.keepalive_permit_without_calls"
+#define GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS \
+  "grpc.keepalive_permit_without_calls"
 /** Default authority to pass if none specified on call construction. A string.
  * */
 #define GRPC_ARG_DEFAULT_AUTHORITY "grpc.default_authority"

--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -198,10 +198,10 @@ typedef struct {
 #define GRPC_ARG_HTTP2_WRITE_BUFFER_SIZE "grpc.http2.write_buffer_size"
 /** After a duration of this time the client pings the server to see if the
     transport is still alive. Int valued, seconds. */
-#define GRPC_ARG_KEEPALIVE_TIME_S "grpc.keepalive_time"
+#define GRPC_ARG_CLIENT_KEEPALIVE_TIME_S "grpc.client_keepalive_time"
 /** After waiting for a duration of this time, if the client does not receive
     the ping ack, it will close the transport. Int valued, seconds. */
-#define GRPC_ARG_KEEPALIVE_TIMEOUT_S "grpc.keepalive_timeout"
+#define GRPC_ARG_CLIENT_KEEPALIVE_TIMEOUT_S "grpc.client_keepalive_timeout"
 /** Is it permissible to send keepalive pings without any outstanding streams.
     Int valued, 0(false)/1(true). */
 #define GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS \

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.c
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.c
@@ -69,12 +69,13 @@
 #define MAX_WRITE_BUFFER_SIZE (64 * 1024 * 1024)
 #define DEFAULT_MAX_HEADER_LIST_SIZE (16 * 1024)
 
-#define DEFAULT_KEEPALIVE_TIME_S INT_MAX
-#define DEFAULT_KEEPALIVE_TIMEOUT_S 20
+#define DEFAULT_CLIENT_KEEPALIVE_TIME_S INT_MAX
+#define DEFAULT_CLIENT_KEEPALIVE_TIMEOUT_S 20
 #define DEFAULT_KEEPALIVE_PERMIT_WITHOUT_CALLS false
 
-static int g_default_keepalive_time_s = DEFAULT_KEEPALIVE_TIME_S;
-static int g_default_keepalive_timeout_s = DEFAULT_KEEPALIVE_TIMEOUT_S;
+static int g_default_client_keepalive_time_s = DEFAULT_CLIENT_KEEPALIVE_TIME_S;
+static int g_default_client_keepalive_timeout_s =
+    DEFAULT_CLIENT_KEEPALIVE_TIMEOUT_S;
 static bool g_default_keepalive_permit_without_calls =
     DEFAULT_KEEPALIVE_PERMIT_WITHOUT_CALLS;
 
@@ -350,13 +351,15 @@ static void init_transport(grpc_exec_ctx *exec_ctx, grpc_chttp2_transport *t,
 
   /* client-side keepalive setting */
   t->keepalive_time =
-      g_default_keepalive_time_s == INT_MAX
+      g_default_client_keepalive_time_s == INT_MAX
           ? gpr_inf_future(GPR_TIMESPAN)
-          : gpr_time_from_seconds(g_default_keepalive_time_s, GPR_TIMESPAN);
+          : gpr_time_from_seconds(g_default_client_keepalive_time_s,
+                                  GPR_TIMESPAN);
   t->keepalive_timeout =
-      g_default_keepalive_timeout_s == INT_MAX
+      g_default_client_keepalive_timeout_s == INT_MAX
           ? gpr_inf_future(GPR_TIMESPAN)
-          : gpr_time_from_seconds(g_default_keepalive_timeout_s, GPR_TIMESPAN);
+          : gpr_time_from_seconds(g_default_client_keepalive_timeout_s,
+                                  GPR_TIMESPAN);
   t->keepalive_permit_without_calls = g_default_keepalive_permit_without_calls;
 
   if (channel_args) {
@@ -406,19 +409,21 @@ static void init_transport(grpc_exec_ctx *exec_ctx, grpc_chttp2_transport *t,
                  strcmp(channel_args->args[i].key, GRPC_ARG_HTTP2_BDP_PROBE)) {
         t->enable_bdp_probe = grpc_channel_arg_get_integer(
             &channel_args->args[i], (grpc_integer_options){1, 0, 1});
-      } else if (0 ==
-                 strcmp(channel_args->args[i].key, GRPC_ARG_KEEPALIVE_TIME_S)) {
+      } else if (0 == strcmp(channel_args->args[i].key,
+                             GRPC_ARG_CLIENT_KEEPALIVE_TIME_S)) {
         const int value = grpc_channel_arg_get_integer(
             &channel_args->args[i],
-            (grpc_integer_options){g_default_keepalive_time_s, 1, INT_MAX});
+            (grpc_integer_options){g_default_client_keepalive_time_s, 1,
+                                   INT_MAX});
         t->keepalive_time = value == INT_MAX
                                 ? gpr_inf_future(GPR_TIMESPAN)
                                 : gpr_time_from_seconds(value, GPR_TIMESPAN);
       } else if (0 == strcmp(channel_args->args[i].key,
-                             GRPC_ARG_KEEPALIVE_TIMEOUT_S)) {
+                             GRPC_ARG_CLIENT_KEEPALIVE_TIMEOUT_S)) {
         const int value = grpc_channel_arg_get_integer(
             &channel_args->args[i],
-            (grpc_integer_options){g_default_keepalive_timeout_s, 0, INT_MAX});
+            (grpc_integer_options){g_default_client_keepalive_timeout_s, 0,
+                                   INT_MAX});
         t->keepalive_timeout = value == INT_MAX
                                    ? gpr_inf_future(GPR_TIMESPAN)
                                    : gpr_time_from_seconds(value, GPR_TIMESPAN);
@@ -2110,14 +2115,16 @@ void grpc_chttp2_config_default_keepalive_args(grpc_channel_args *args) {
   size_t i;
   if (args) {
     for (i = 0; i < args->num_args; i++) {
-      if (0 == strcmp(args->args[i].key, GRPC_ARG_KEEPALIVE_TIME_S)) {
-        g_default_keepalive_time_s = grpc_channel_arg_get_integer(
+      if (0 == strcmp(args->args[i].key, GRPC_ARG_CLIENT_KEEPALIVE_TIME_S)) {
+        g_default_client_keepalive_time_s = grpc_channel_arg_get_integer(
+            &args->args[i], (grpc_integer_options){
+                                g_default_client_keepalive_time_s, 1, INT_MAX});
+      } else if (0 == strcmp(args->args[i].key,
+                             GRPC_ARG_CLIENT_KEEPALIVE_TIMEOUT_S)) {
+        g_default_client_keepalive_timeout_s = grpc_channel_arg_get_integer(
             &args->args[i],
-            (grpc_integer_options){g_default_keepalive_time_s, 1, INT_MAX});
-      } else if (0 == strcmp(args->args[i].key, GRPC_ARG_KEEPALIVE_TIMEOUT_S)) {
-        g_default_keepalive_timeout_s = grpc_channel_arg_get_integer(
-            &args->args[i],
-            (grpc_integer_options){g_default_keepalive_timeout_s, 0, INT_MAX});
+            (grpc_integer_options){g_default_client_keepalive_timeout_s, 0,
+                                   INT_MAX});
         ;
       } else if (0 == strcmp(args->args[i].key,
                              GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS)) {

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.c
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.c
@@ -2125,7 +2125,6 @@ void grpc_chttp2_config_default_keepalive_args(grpc_channel_args *args) {
             &args->args[i],
             (grpc_integer_options){g_default_client_keepalive_timeout_s, 0,
                                    INT_MAX});
-        ;
       } else if (0 == strcmp(args->args[i].key,
                              GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS)) {
         g_default_keepalive_permit_without_calls =

--- a/src/core/ext/transport/chttp2/transport/frame_ping.c
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.c
@@ -101,17 +101,17 @@ grpc_error *grpc_chttp2_ping_parser_parse(grpc_exec_ctx *exec_ctx, void *parser,
   if (p->byte == 8) {
     GPR_ASSERT(is_last);
     if (p->is_ack) {
-      if (!g_disable_ping_ack) {
-        grpc_chttp2_ack_ping(exec_ctx, t, p->opaque_8bytes);
-      }
+      grpc_chttp2_ack_ping(exec_ctx, t, p->opaque_8bytes);
     } else {
-      if (t->ping_ack_count == t->ping_ack_capacity) {
-        t->ping_ack_capacity = GPR_MAX(t->ping_ack_capacity * 3 / 2, 3);
-        t->ping_acks = gpr_realloc(
-            t->ping_acks, t->ping_ack_capacity * sizeof(*t->ping_acks));
+      if (!g_disable_ping_ack) {
+        if (t->ping_ack_count == t->ping_ack_capacity) {
+          t->ping_ack_capacity = GPR_MAX(t->ping_ack_capacity * 3 / 2, 3);
+          t->ping_acks = gpr_realloc(
+              t->ping_acks, t->ping_ack_capacity * sizeof(*t->ping_acks));
+        }
+        t->ping_acks[t->ping_ack_count++] = p->opaque_8bytes;
+        grpc_chttp2_initiate_write(exec_ctx, t, false, "ping response");
       }
-      t->ping_acks[t->ping_ack_count++] = p->opaque_8bytes;
-      grpc_chttp2_initiate_write(exec_ctx, t, false, "ping response");
     }
   }
 

--- a/src/core/ext/transport/chttp2/transport/frame_ping.h
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.h
@@ -53,4 +53,7 @@ grpc_error *grpc_chttp2_ping_parser_parse(grpc_exec_ctx *exec_ctx, void *parser,
                                           grpc_chttp2_stream *s,
                                           grpc_slice slice, int is_last);
 
+/* Test-only function for disabling ping ack */
+void grpc_set_disable_ping_ack(bool disable_ping_ack);
+
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_FRAME_PING_H */

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -827,4 +827,8 @@ void grpc_chttp2_fail_pending_writes(grpc_exec_ctx *exec_ctx,
 
 uint32_t grpc_chttp2_target_incoming_window(grpc_chttp2_transport *t);
 
+/** Set the default keepalive configurations, must only be called at
+    initialization */
+void grpc_chttp2_config_default_keepalive_args(grpc_channel_args *args);
+
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_INTERNAL_H */

--- a/test/core/end2end/tests/keepalive_timeout.c
+++ b/test/core/end2end/tests/keepalive_timeout.c
@@ -111,10 +111,10 @@ static void test_keepalive_timeout(grpc_end2end_test_config config) {
   gpr_timespec deadline = five_seconds_time();
 
   grpc_arg keepalive_args[] = {{.type = GRPC_ARG_INTEGER,
-                                .key = GRPC_ARG_KEEPALIVE_TIME_S,
+                                .key = GRPC_ARG_CLIENT_KEEPALIVE_TIME_S,
                                 .value.integer = 2},
                                {.type = GRPC_ARG_INTEGER,
-                                .key = GRPC_ARG_KEEPALIVE_TIMEOUT_S,
+                                .key = GRPC_ARG_CLIENT_KEEPALIVE_TIMEOUT_S,
                                 .value.integer = 0},
                                {.type = GRPC_ARG_INTEGER,
                                 .key = GRPC_ARG_HTTP2_BDP_PROBE,

--- a/test/core/end2end/tests/keepalive_timeout.c
+++ b/test/core/end2end/tests/keepalive_timeout.c
@@ -41,6 +41,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 #include <grpc/support/useful.h>
+#include "src/core/ext/transport/chttp2/transport/frame_ping.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/support/env.h"
@@ -109,13 +110,15 @@ static void test_keepalive_timeout(grpc_end2end_test_config config) {
       grpc_raw_byte_buffer_create(&response_payload_slice, 1);
   gpr_timespec deadline = five_seconds_time();
 
-  grpc_arg keepalive_args[2];
-  keepalive_args[0].type = GRPC_ARG_INTEGER;
-  keepalive_args[0].key = GRPC_ARG_HTTP2_KEEPALIVE_TIME;
-  keepalive_args[0].value.integer = 2;
-  keepalive_args[1].type = GRPC_ARG_INTEGER;
-  keepalive_args[1].key = GRPC_ARG_HTTP2_KEEPALIVE_TIMEOUT;
-  keepalive_args[1].value.integer = 0;
+  grpc_arg keepalive_args[] = {{.type = GRPC_ARG_INTEGER,
+                                .key = GRPC_ARG_KEEPALIVE_TIME_S,
+                                .value.integer = 2},
+                               {.type = GRPC_ARG_INTEGER,
+                                .key = GRPC_ARG_KEEPALIVE_TIMEOUT_S,
+                                .value.integer = 0},
+                               {.type = GRPC_ARG_INTEGER,
+                                .key = GRPC_ARG_HTTP2_BDP_PROBE,
+                                .value.integer = 1}};
 
   grpc_channel_args *client_args = NULL;
   client_args = grpc_channel_args_copy_and_add(client_args, keepalive_args, 2);
@@ -133,6 +136,9 @@ static void test_keepalive_timeout(grpc_end2end_test_config config) {
   grpc_status_code status;
   grpc_call_error error;
   grpc_slice details;
+
+  /* Disable ping ack to trigger the keepalive timeout */
+  grpc_set_disable_ping_ack(true);
 
   c = grpc_channel_create_call(
       f.client, NULL, GRPC_PROPAGATE_DEFAULTS, f.cq,


### PR DESCRIPTION
Address offline discussions:
- Add test-only function `grpc_set_disable_ping_ack()` for the keepalive_timeout test
- Remove `HTTP2` in keepalive arg keys, add time units.
- Add internal function `grpc_chttp2_config_default_keepalive_args()`