### PR TITLE
add installation of scipy and numpy in linux perf worker init

### DIFF
--- a/tools/gce/linux_performance_worker_init.sh
+++ b/tools/gce/linux_performance_worker_init.sh
@@ -166,3 +166,5 @@ echo 4096 | sudo tee /proc/sys/kernel/perf_event_mlock_kb
 # on benchmarks
 git clone -v https://github.com/brendangregg/FlameGraph ~/FlameGraph
 
+# Install scipy and numpy for benchmarking scripts
+sudo apt-get install python-scipy python-numpy


### PR DESCRIPTION
Ended up being able to install scipy on 32-core workers with `pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose` as in https://www.scipy.org/install.html, but ran into build issues when installing on 8-core workers. Installing through the debian package seems most simple.

scipy should be installed on all the linux perf workers now