### PR TITLE
Fix Bug from Error Slice Optimization

### DIFF
--- a/src/core/lib/surface/call.c
+++ b/src/core/lib/surface/call.c
@@ -625,7 +625,7 @@ static bool get_final_status_from(
     void (*set_value)(grpc_status_code code, void *user_data),
     void *set_value_user_data, grpc_slice *details) {
   grpc_status_code code;
-  grpc_slice slice;
+  grpc_slice slice = grpc_empty_slice();
   grpc_error_get_status(error, call->send_deadline, &code, &slice, NULL);
   if (code == GRPC_STATUS_OK && !allow_ok_status) {
     return false;


### PR DESCRIPTION
In this codepath, if error is GRPC_ERROR_NONE, then slice will never get set and will be uninitialized, which could cause a crash if details ever got turned into a c string.

I missed this in the original PR.