### PR TITLE
Do not call grpc_init() for per-call-completion-queues created by a C++ sync server

### DIFF
--- a/include/grpc++/impl/codegen/grpc_library.h
+++ b/include/grpc++/impl/codegen/grpc_library.h
@@ -51,18 +51,26 @@ extern GrpcLibraryInterface* g_glip;
 /// Classes that require gRPC to be initialized should inherit from this class.
 class GrpcLibraryCodegen {
  public:
-  GrpcLibraryCodegen() {
-    GPR_CODEGEN_ASSERT(g_glip &&
-                       "gRPC library not initialized. See "
-                       "grpc::internal::GrpcLibraryInitializer.");
-    g_glip->init();
+  GrpcLibraryCodegen(bool call_grpc_init = true) : grpc_init_called_(false) {
+    if (call_grpc_init) {
+      GPR_CODEGEN_ASSERT(g_glip &&
+                         "gRPC library not initialized. See "
+                         "grpc::internal::GrpcLibraryInitializer.");
+      g_glip->init();
+      grpc_init_called_ = true;
+    }
   }
   virtual ~GrpcLibraryCodegen() {
-    GPR_CODEGEN_ASSERT(g_glip &&
-                       "gRPC library not initialized. See "
-                       "grpc::internal::GrpcLibraryInitializer.");
-    g_glip->shutdown();
+    if (grpc_init_called_) {
+      GPR_CODEGEN_ASSERT(g_glip &&
+                         "gRPC library not initialized. See "
+                         "grpc::internal::GrpcLibraryInitializer.");
+      g_glip->shutdown();
+    }
   }
+
+ private:
+  bool grpc_init_called_;
 };
 
 }  // namespace grpc

--- a/src/cpp/common/completion_queue_cc.cc
+++ b/src/cpp/common/completion_queue_cc.cc
@@ -43,7 +43,8 @@ namespace grpc {
 
 static internal::GrpcLibraryInitializer g_gli_initializer;
 
-CompletionQueue::CompletionQueue(grpc_completion_queue* take) : cq_(take) {
+CompletionQueue::CompletionQueue(grpc_completion_queue* take)
+    : GrpcLibraryCodegen(false), cq_(take) {
   InitialAvalanching();
 }
 

--- a/src/cpp/common/completion_queue_cc.cc
+++ b/src/cpp/common/completion_queue_cc.cc
@@ -43,6 +43,10 @@ namespace grpc {
 
 static internal::GrpcLibraryInitializer g_gli_initializer;
 
+// 'CompletionQueue' constructor can safely call GrpcLibraryCodegen(false) here
+// i.e not have GrpcLibraryCodegen call grpc_init(). This is because, to create
+// a 'grpc_completion_queue' instance (which is being passed as the input to
+// this constructor), one must have already called grpc_init().
 CompletionQueue::CompletionQueue(grpc_completion_queue* take)
     : GrpcLibraryCodegen(false), cq_(take) {
   InitialAvalanching();

--- a/test/cpp/microbenchmarks/bm_cq.cc
+++ b/test/cpp/microbenchmarks/bm_cq.cc
@@ -59,6 +59,17 @@ static void BM_CreateDestroyCpp(benchmark::State& state) {
 }
 BENCHMARK(BM_CreateDestroyCpp);
 
+/* Create cq using a different constructor */
+static void BM_CreateDestroyCpp2(benchmark::State& state) {
+  TrackCounters track_counters;
+  while (state.KeepRunning()) {
+    grpc_completion_queue* core_cq = grpc_completion_queue_create(NULL);
+    CompletionQueue cq(core_cq);
+  }
+  track_counters.Finish(state);
+}
+BENCHMARK(BM_CreateDestroyCpp2);
+
 static void BM_CreateDestroyCore(benchmark::State& state) {
   TrackCounters track_counters;
   while (state.KeepRunning()) {


### PR DESCRIPTION
Issue: #9261

Before this PR, every C++ `CompletionQueue` object creation ended up calling [`grpc_init`](https://github.com/grpc/grpc/blob/master/src/core/lib/surface/init.c#L176)  which acquires a mutex `g_init_mu` to increment the number of grpc-init invocations.

This is ok if the number of completion queues being created was small. However, in case of C++ Synchronous server, a completion queue is create for *every call*. This ends up making `g_init_mu` one of top created mutexes in sync servers.

This PR makes calling `grpc_init` optional when creating C++ `CompletionQueue` objects. It is always set to `true` by default but if a C++ `CompletionQueue`  is being created by passing a `grpc_completion_queue *` pointer i.e the following constructor (which is what Sync C++ server calls when creating a per-call completion queue), it is okay to NOT call `grpc_init`.

``` C++
class CompletionQueue : private GrpcLibraryCodegen {
 ..
  explicit CompletionQueue(grpc_completion_queue* take);
..
}
```

This change is safe because if we got a `grpc_completion_queue *` structure, we MUST have already called `grpc_init()`.

__Benchmark results__
I added a new benchmark BM_CreateDestroyCpp2 (didn't previously include it as a part of the PR because I thought it is trivial - but on a second thought, i think it is a good idea :))

Locks are down from 3 to 1

On master (with BM_CreateDestroyCpp2 temporarily ported):
``` 
sreek@sreek-dev:~/workspace/grpc (master) $ bins/counters/bm_cq --benchmark_filter=BM_CreateDestroyCpp2
Run on (12 X 3501 MHz CPU s)
2017-03-29 10:54:34
Benchmark                     Time           CPU Iterations
-----------------------------------------------------------
BM_CreateDestroyCpp2        215 ns        215 ns    3230778 locks/iter:3 atm_cas/iter:0 atm_add/iter:3 allocs/iter:1
```

On this PR branch:
```
sreek@sreek-dev:~/workspace/grpc (init-free-cq) $ bins/counters/bm_cq --benchmark_filter=BM_CreateDestroyCpp2
Run on (12 X 3501 MHz CPU s)
2017-03-29 10:56:15
Benchmark                     Time           CPU Iterations
-----------------------------------------------------------
BM_CreateDestroyCpp2        160 ns        160 ns    4413813 locks/iter:1 atm_cas/iter:0 atm_add/iter:3 allocs/iter:1
```