### PR TITLE
Initial ruby fork support

### DIFF
--- a/src/ruby/ext/grpc/rb_fork.c
+++ b/src/ruby/ext/grpc/rb_fork.c
@@ -1,0 +1,65 @@
+/*
+ *
+ * Copyright 2017, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <ruby/ruby.h>
+
+#include <grpc/fork.h>
+#include "rb_grpc.h"
+
+/* grpc_rb_cFork is the ruby module that exposes fork() callbacks. */
+static VALUE grpc_rb_cFork = Qnil;
+
+static VALUE grpc_rb_prefork(VALUE self) {
+  grpc_prefork();
+  return Qnil;
+}
+
+static VALUE grpc_rb_postfork_parent(VALUE self) {
+  // Reserved for possible future use
+  return Qnil;
+}
+
+static VALUE grpc_rb_postfork_child(VALUE self) {
+  grpc_postfork_child();
+  return Qnil;
+}
+
+void Init_grpc_fork() {
+  grpc_rb_cFork =
+      rb_define_module_under(grpc_rb_mGrpcCore, "Fork");
+
+  /* Define module-scope fork handlers */
+  rb_define_module_function(grpc_rb_cFork, "prefork", grpc_rb_prefork, 0);
+  rb_define_module_function(grpc_rb_cFork, "postfork_parent", grpc_rb_postfork_parent, 0);
+  rb_define_module_function(grpc_rb_cFork, "postfork_child", grpc_rb_postfork_child, 0);
+}

--- a/src/ruby/ext/grpc/rb_fork.h
+++ b/src/ruby/ext/grpc/rb_fork.h
@@ -1,0 +1,42 @@
+/*
+ *
+ * Copyright 2015, Google Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef GRPC_RB_SERVER_H_
+#define GRPC_RB_SERVER_H_
+
+#include <ruby/ruby.h>
+
+/* Initializes the Fork module. */
+void Init_grpc_fork();
+
+#endif /* GRPC_RB_SERVER_H_ */

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -46,6 +46,7 @@
 #include "rb_call_credentials.h"
 #include "rb_channel.h"
 #include "rb_channel_credentials.h"
+#include "rb_fork.h"
 #include "rb_loader.h"
 #include "rb_server.h"
 #include "rb_server_credentials.h"
@@ -329,6 +330,7 @@ void Init_grpc_c() {
   Init_grpc_call();
   Init_grpc_call_credentials();
   Init_grpc_channel_credentials();
+  Init_grpc_fork();
   Init_grpc_server();
   Init_grpc_server_credentials();
   Init_grpc_status_codes();

--- a/src/ruby/lib/grpc/fork.rb
+++ b/src/ruby/lib/grpc/fork.rb
@@ -1,0 +1,128 @@
+# Copyright 2017, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require_relative 'grpc'
+
+module GRPC
+  # Provides calls to allow forking
+  class Fork
+    def self.prefork
+      GRPC::Core::Fork.prefork
+    end
+
+    def self.postfork_parent
+      GRPC::Core::Fork.postfork_parent
+    end
+
+    def self.postfork_child
+      GRPC::Core::Fork.postfork_child
+    end
+  end
+
+  # Class containing details of a forked process
+  class ForkedServerProcess
+    def initialize(child_pid, wr)
+      @child_pid = child_pid
+      @wr = wr
+    end
+
+    def shutdown
+      @wr.write('\n')
+      @wr.flush
+      Process.waitpid(@child_pid)
+      @wr.close
+    end
+  end
+
+  # Similar to regular server, but forks processes for parallelism
+  class PreforkServer
+    extend ::Forwardable
+
+    def_delegators :@server, :wait_till_running, :handle, :add_http2_port
+
+    # Default process pool count
+    DEFAULT_PROCESS_COUNT = 10
+
+    def initialize(process_count:DEFAULT_PROCESS_COUNT,
+                   pool_size:GRPC::RpcServer::DEFAULT_POOL_SIZE,
+                   max_waiting_requests:\
+                      GRPC::RpcServer::DEFAULT_MAX_WAITING_REQUESTS,
+                   poll_period:GRPC::RpcServer::DEFAULT_POLL_PERIOD,
+                   connect_md_proc:nil,
+                   server_args:{})
+      @process_count = process_count
+      @server = GRPC::RpcServer.new(pool_size: pool_size,
+                                    max_waiting_requests: max_waiting_requests,
+                                    poll_period: poll_period,
+                                    connect_md_proc: connect_md_proc,
+                                    server_args: server_args)
+      @child_processes = []
+    end
+
+    def run
+      (@process_count - 1).times do
+        rd, wr = IO.pipe
+        Fork.prefork
+        child_pid = fork
+        if !child_pid.nil?
+          Fork.postfork_parent
+          rd.close
+          @child_processes.push(ForkedServerProcess.new(child_pid, wr))
+        else
+          begin
+            Fork.postfork_child
+            wr.close
+            server_thread = Thread.new { @server.run_till_terminated }
+            rd.read(1)
+            rd.close
+            @server.stop
+            server_thread.join
+          rescue => e # rubocop:disable HandleExceptions
+            GRPC.logger.error(e.message)
+            GRPC.logger.error(e.backtrace.join("\n"))
+          ensure
+            # Avoid calling exit handlers from the child process
+            Kernal.exit!
+          end
+        end
+      end
+      # Run a server in the parent process as well.  This is neccesary,
+      # the parent process is the only one that can shutdown() a shared
+      # listening socket (by design)
+      @server.run
+    end
+
+    def stop
+      @server.stop
+      @child_processes.each(&:shutdown)
+    end
+
+    alias_method :run_till_terminated, :run
+  end
+end

--- a/src/ruby/spec/client_forked_server_spec.rb
+++ b/src/ruby/spec/client_forked_server_spec.rb
@@ -1,0 +1,82 @@
+# Copyright 2017, Google Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+require 'grpc'
+require 'grpc/fork'
+
+# Generic test service
+module Echo
+  # Generic service
+  class Service
+    include GRPC::GenericService
+
+    self.marshal_class_method = :try_convert
+    self.unmarshal_class_method = :try_convert
+    self.service_name = 'EchoTest'
+
+    rpc :Echo, String, String
+  end
+
+  Stub = Service.rpc_stub_class
+end
+
+# Generic test servicer
+class EchoServer < Echo::Service
+  def echo(echo_req, _unused_call)
+    echo_req
+  end
+end
+
+describe 'the http client/prefork server' do
+  before(:example) do
+    server_host = '0.0.0.0:0'
+    @server = GRPC::PreforkServer.new
+    @server_port = @server.add_http2_port(server_host, :this_port_is_insecure)
+    @server.handle(EchoServer)
+    @server_thd = Thread.new { @server.run_till_terminated }
+  end
+
+  after(:example) do
+    @server.stop
+    @server_thd.join
+  end
+
+  it 'basic GRPC message delivery is OK' do
+    @server.wait_till_running
+    # Establish 100 seperate connections, a connection is always serviced by
+    # the same subprocess
+    100.times do |i|
+      stub = Echo::Stub.new("0.0.0.0:#{@server_port}",
+                            :this_channel_is_insecure,
+                            channel_args: { 'channel_idx' => i })
+      message = stub.echo('hello', deadline: Time.now + 5)
+      expect(message).to eq('hello')
+    end
+  end
+end


### PR DESCRIPTION
Provides an API for a prefork server, as well as prefork/postfork calls to allow an application to fork.

Depends on #10155