### PR TITLE
Make convert clock_type consistent with add/sub when dealing with ext…

### DIFF
--- a/src/core/lib/support/time.c
+++ b/src/core/lib/support/time.c
@@ -42,7 +42,7 @@
 int gpr_time_cmp(gpr_timespec a, gpr_timespec b) {
   int cmp = (a.tv_sec > b.tv_sec) - (a.tv_sec < b.tv_sec);
   GPR_ASSERT(a.clock_type == b.clock_type);
-  if (cmp == 0) {
+  if (cmp == 0 && a.tv_sec != INT64_MAX && a.tv_sec != INT64_MIN) {
     cmp = (a.tv_nsec > b.tv_nsec) - (a.tv_nsec < b.tv_nsec);
   }
   return cmp;

--- a/src/core/lib/support/time.c
+++ b/src/core/lib/support/time.c
@@ -244,15 +244,9 @@ gpr_timespec gpr_convert_clock_type(gpr_timespec t, gpr_clock_type clock_type) {
     return t;
   }
 
-  if (t.tv_nsec == 0) {
-    if (t.tv_sec == INT64_MAX) {
-      t.clock_type = clock_type;
-      return t;
-    }
-    if (t.tv_sec == INT64_MIN) {
-      t.clock_type = clock_type;
-      return t;
-    }
+  if (t.tv_sec == INT64_MAX || t.tv_sec == INT64_MIN) {
+    t.clock_type = clock_type;
+    return t;
   }
 
   if (clock_type == GPR_TIMESPAN) {

--- a/test/core/support/time_test.c
+++ b/test/core/support/time_test.c
@@ -256,11 +256,19 @@ static void test_similar(void) {
 }
 
 static void test_convert_extreme(void) {
-  gpr_timespec realtime_t = {INT64_MAX, 1, GPR_CLOCK_REALTIME};
-  gpr_timespec monotime_t =
-      gpr_convert_clock_type(realtime_t, GPR_CLOCK_MONOTONIC);
-  GPR_ASSERT(monotime_t.tv_sec == realtime_t.tv_sec);
-  GPR_ASSERT(monotime_t.clock_type == GPR_CLOCK_MONOTONIC);
+  gpr_timespec realtime = {INT64_MAX, 1, GPR_CLOCK_REALTIME};
+  gpr_timespec monotime = gpr_convert_clock_type(realtime, GPR_CLOCK_MONOTONIC);
+  GPR_ASSERT(monotime.tv_sec == realtime.tv_sec);
+  GPR_ASSERT(monotime.clock_type == GPR_CLOCK_MONOTONIC);
+}
+
+static void test_cmp_extreme(void) {
+  gpr_timespec t1 = {INT64_MAX, 1, GPR_CLOCK_REALTIME};
+  gpr_timespec t2 = {INT64_MAX, 2, GPR_CLOCK_REALTIME};
+  GPR_ASSERT(gpr_time_cmp(t1, t2) == 0);
+  t1.tv_sec = INT64_MIN;
+  t2.tv_sec = INT64_MIN;
+  GPR_ASSERT(gpr_time_cmp(t1, t2) == 0);
 }
 
 int main(int argc, char *argv[]) {
@@ -272,5 +280,6 @@ int main(int argc, char *argv[]) {
   test_sticky_infinities();
   test_similar();
   test_convert_extreme();
+  test_cmp_extreme();
   return 0;
 }

--- a/test/core/support/time_test.c
+++ b/test/core/support/time_test.c
@@ -255,6 +255,14 @@ static void test_similar(void) {
                                    gpr_time_from_micros(10, GPR_TIMESPAN)));
 }
 
+static void test_convert_extreme(void) {
+  gpr_timespec realtime_t = {INT64_MAX, 1, GPR_CLOCK_REALTIME};
+  gpr_timespec monotime_t =
+      gpr_convert_clock_type(realtime_t, GPR_CLOCK_MONOTONIC);
+  GPR_ASSERT(monotime_t.tv_sec == realtime_t.tv_sec);
+  GPR_ASSERT(monotime_t.clock_type == GPR_CLOCK_MONOTONIC);
+}
+
 int main(int argc, char *argv[]) {
   grpc_test_init(argc, argv);
 
@@ -263,5 +271,6 @@ int main(int argc, char *argv[]) {
   test_overflow();
   test_sticky_infinities();
   test_similar();
+  test_convert_extreme();
   return 0;
 }


### PR DESCRIPTION
…reme values

Add a test case which will fail assertion under current implementation.