### PR TITLE
Borrow Jenkins again to troubleshoot ObjC test failure

### DIFF
--- a/src/objective-c/tests/Tests.xcodeproj/xcshareddata/xcschemes/CronetUnitTests.xcscheme
+++ b/src/objective-c/tests/Tests.xcodeproj/xcshareddata/xcschemes/CronetUnitTests.xcscheme
@@ -21,6 +21,11 @@
                BlueprintName = "CronetUnitTests"
                ReferencedContainer = "container:Tests.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "CronetUnitTests/testInternalError">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
       <AdditionalOptions>


### PR DESCRIPTION
Some experimental code to make Jenkins generate more information when it fails on ObjC tests. Do not merge or close.