### PR TITLE
fix docker -p flag for interop tests

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_http2/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_http2/Dockerfile.template
@@ -33,7 +33,7 @@
   
   <%include file="../../go_path.include"/>
   <%include file="../../python_deps.include"/>
-  RUN pip install twisted h2 hyper
+  RUN pip install twisted h2==2.6.1 hyper
 
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_http2/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_http2/Dockerfile
@@ -47,7 +47,7 @@ RUN pip install pip --upgrade
 RUN pip install virtualenv
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.2.0 six==1.10.0
 
-RUN pip install twisted h2 hyper
+RUN pip install twisted h2==2.6.1 hyper
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -728,8 +728,7 @@ def server_jobspec(language, docker_image, insecure=False, manual_cmd_log=None):
     ]
 
   else:
-    portstr = str(_DEFAULT_SERVER_PORT)
-    docker_args += ['-p', '%s:%s'%(portstr, portstr)]
+    docker_args += ['-p', str(_DEFAULT_SERVER_PORT)]
 
   docker_cmdline = docker_run_cmdline(cmdline,
                                       image=docker_image,


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/10374.

This undoes a change from https://github.com/grpc/grpc/commit/996a6734235ac21cb6a6222425fadc93706c93c3. The `-p port:port` flag tells Docker to map the container port to a specific host port. This constrains exactly one container to listen on the port, so when any server container runs after another server container has already started, it fails to bind.