### PR TITLE
Add instructions to install libgflags-dev, libgtest-dev, clang and libc++-dev

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,6 +22,12 @@ refer to these documents
  $ [sudo] apt-get install build-essential autoconf libtool
 ```
 
+If you plan to build from source and run tests, install the following as well:
+```sh
+ $ [sudo] apt-get install libgflags-dev libgtest-dev
+ $ [sudo] apt-get install clang libc++-dev
+```
+
 ## Mac OSX
 
 For a Mac system, git is not available by default. You will first need to


### PR DESCRIPTION
I find myself scrambling to find these package names whenever I try to get gRPC repo on a new machine. So I am updating the INSTALL instructions.

Moreover, we used to have this info in an earlier version of this doc but they seem to have been removed (perhaps accidentally)
