### PR TITLE
Fix test coverage reporting

### DIFF
--- a/templates/tools/dockerfile/test/multilang_jessie_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/multilang_jessie_x64/Dockerfile.template
@@ -38,6 +38,10 @@
   <%include file="../../php_deps.include"/>
   <%include file="../../ruby_deps.include"/>
   <%include file="../../python_deps.include"/>
+  # Install coverage for Python test coverage reporting
+  RUN pip install coverage
+  ENV PATH ~/.local/bin:$PATH
+
   <%include file="../../run_tests_addons.include"/>
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/test/multilang_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/multilang_jessie_x64/Dockerfile
@@ -135,6 +135,10 @@ RUN pip install pip --upgrade
 RUN pip install virtualenv
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.2.0 six==1.10.0
 
+# Install coverage for Python test coverage reporting
+RUN pip install coverage
+ENV PATH ~/.local/bin:$PATH
+
 # Prepare ccache
 RUN ln -s /usr/bin/ccache /usr/local/bin/gcc
 RUN ln -s /usr/bin/ccache /usr/local/bin/g++

--- a/tools/run_tests/helper_scripts/post_tests_python.sh
+++ b/tools/run_tests/helper_scripts/post_tests_python.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2015, Google Inc.
+# Copyright 2017, Google Inc.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -32,15 +32,8 @@ set -ex
 
 if [ "$CONFIG" != "gcov" ] ; then exit ; fi
 
-root=$(readlink -f $(dirname $0)/../../..)
-out=$root/reports/php_ext_coverage
-tmp1=$(mktemp)
-tmp2=$(mktemp)
-cd $root
-lcov --capture --directory . --output-file $tmp1
-lcov --extract $tmp1 "$root/src/php/ext/grpc/*" --output-file $tmp2
-genhtml $tmp2 --output-directory $out
-rm $tmp2
-rm $tmp1
+# change to directory of Python coverage files
+cd $(dirname $0)/../../../src/python/grpcio_tests/
 
-# todo(mattkwong): generate coverage report for php and copy to reports/php
+coverage combine .
+coverage html -i -d ./../../../reports/python

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -614,7 +614,10 @@ class PythonLanguage(object):
     return [config.build for config in self.pythons]
 
   def post_tests_steps(self):
-    return []
+    if self.config != 'gcov':
+      return []
+    else:
+      return [['tools/run_tests/helper_scripts/post_tests_python.sh']]
 
   def makefile_name(self):
     return 'Makefile'
@@ -1270,7 +1273,9 @@ if any(language.make_options() for language in languages):
     print('languages with custom make options cannot be built simultaneously with other languages')
     sys.exit(1)
   else:
-    language_make_options = next(iter(languages)).make_options()
+    # Combining make options is not clean and just happens to work. It allows C/C++ and C# to build
+    # together, and is only used under gcov. All other configs should build languages individually.
+    language_make_options = list(set([make_option for lang in languages for make_option in lang.make_options()]))
 
 if args.use_docker:
   if not args.travis:


### PR DESCRIPTION
Changes:
- Install coverage tool for generating Python coverage reports
- `src/php/coverage` is not being generated so removed `cp -rv $root/src/php/coverage $root/reports/php` and added todo
- Combine make options to support running C# and C/C++ together