### PR TITLE
Fix duplicated NULL pointer check

### DIFF
--- a/src/core/tsi/transport_security.c
+++ b/src/core/tsi/transport_security.c
@@ -101,7 +101,7 @@ tsi_result tsi_frame_protector_protect_flush(
     tsi_frame_protector *self, unsigned char *protected_output_frames,
     size_t *protected_output_frames_size, size_t *still_pending_size) {
   if (self == NULL || protected_output_frames == NULL ||
-      protected_output_frames == NULL || still_pending_size == NULL) {
+      protected_output_frames_size == NULL || still_pending_size == NULL) {
     return TSI_INVALID_ARGUMENT;
   }
   return self->vtable->protect_flush(self, protected_output_frames,


### PR DESCRIPTION
`protected_output_frames` was checked two times while `protected_output_frames_size` was not checked