### PR TITLE
Node performance tests and improvements

### DIFF
--- a/src/node/ext/byte_buffer.cc
+++ b/src/node/ext/byte_buffer.cc
@@ -45,6 +45,7 @@
 namespace grpc {
 namespace node {
 
+using Nan::Callback;
 using Nan::MaybeLocal;
 
 using v8::Function;
@@ -62,7 +63,11 @@ grpc_byte_buffer *BufferToByteBuffer(Local<Value> buffer) {
 }
 
 namespace {
-void delete_buffer(char *data, void *hint) { delete[] data; }
+void delete_buffer(char *data, void *hint) {
+  grpc_slice *slice = static_cast<grpc_slice *>(hint);
+  grpc_slice_unref(*slice);
+  delete slice;
+}
 }
 
 Local<Value> ByteBufferToBuffer(grpc_byte_buffer *buffer) {
@@ -75,31 +80,15 @@ Local<Value> ByteBufferToBuffer(grpc_byte_buffer *buffer) {
     Nan::ThrowError("Error initializing byte buffer reader.");
     return scope.Escape(Nan::Undefined());
   }
-  grpc_slice slice = grpc_byte_buffer_reader_readall(&reader);
-  size_t length = GRPC_SLICE_LENGTH(slice);
-  char *result = new char[length];
-  memcpy(result, GRPC_SLICE_START_PTR(slice), length);
-  grpc_slice_unref(slice);
-  return scope.Escape(MakeFastBuffer(
-      Nan::NewBuffer(result, length, delete_buffer, NULL).ToLocalChecked()));
+  grpc_slice *slice = new grpc_slice;
+  *slice = grpc_byte_buffer_reader_readall(&reader);
+  grpc_byte_buffer_reader_destroy(&reader);
+  char *result = reinterpret_cast<char *>(GRPC_SLICE_START_PTR(*slice));
+  size_t length = GRPC_SLICE_LENGTH(*slice);
+  Local<Value> buf =
+      Nan::NewBuffer(result, length, delete_buffer, slice).ToLocalChecked();
+  return scope.Escape(buf);
 }
 
-Local<Value> MakeFastBuffer(Local<Value> slowBuffer) {
-  Nan::EscapableHandleScope scope;
-  Local<Object> globalObj = Nan::GetCurrentContext()->Global();
-  MaybeLocal<Value> constructorValue = Nan::Get(
-      globalObj, Nan::New("Buffer").ToLocalChecked());
-  Local<Function> bufferConstructor = Local<Function>::Cast(
-      constructorValue.ToLocalChecked());
-  const int argc = 3;
-  Local<Value> consArgs[argc] = {
-    slowBuffer,
-    Nan::New<Number>(::node::Buffer::Length(slowBuffer)),
-    Nan::New<Number>(0)
-  };
-  MaybeLocal<Object> fastBuffer = Nan::NewInstance(bufferConstructor,
-                                                   argc, consArgs);
-  return scope.Escape(fastBuffer.ToLocalChecked());
-}
 }  // namespace node
 }  // namespace grpc

--- a/src/node/ext/byte_buffer.h
+++ b/src/node/ext/byte_buffer.h
@@ -50,10 +50,6 @@ grpc_byte_buffer *BufferToByteBuffer(v8::Local<v8::Value> buffer);
 /* Convert a grpc_byte_buffer to a Node.js Buffer */
 v8::Local<v8::Value> ByteBufferToBuffer(grpc_byte_buffer *buffer);
 
-/* Convert a ::node::Buffer to a fast Buffer, as defined in the Node
-   Buffer documentation */
-v8::Local<v8::Value> MakeFastBuffer(v8::Local<v8::Value> slowBuffer);
-
 }  // namespace node
 }  // namespace grpc
 

--- a/src/node/ext/slice.cc
+++ b/src/node/ext/slice.cc
@@ -37,7 +37,6 @@
 #include <grpc/support/alloc.h>
 
 #include "slice.h"
-#include "byte_buffer.h"
 
 namespace grpc {
 namespace node {
@@ -93,9 +92,9 @@ Local<Value> CreateBufferFromSlice(const grpc_slice slice) {
   Nan::EscapableHandleScope scope;
   grpc_slice *slice_ptr = new grpc_slice;
   *slice_ptr = grpc_slice_ref(slice);
-  return scope.Escape(MakeFastBuffer(Nan::NewBuffer(
+  return scope.Escape(Nan::NewBuffer(
       const_cast<char *>(reinterpret_cast<const char *>(GRPC_SLICE_START_PTR(*slice_ptr))),
-      GRPC_SLICE_LENGTH(*slice_ptr), SliceFreeCallback, slice_ptr).ToLocalChecked()));
+      GRPC_SLICE_LENGTH(*slice_ptr), SliceFreeCallback, slice_ptr).ToLocalChecked());
 }
 
 }  // namespace node

--- a/src/node/performance/benchmark_server.js
+++ b/src/node/performance/benchmark_server.js
@@ -88,6 +88,13 @@ function streamingCall(call) {
   });
 }
 
+function makeUnaryGenericCall(response_size) {
+  var response = zeroBuffer(response_size);
+  return function unaryGenericCall(call, callback) {
+    callback(null, response);
+  };
+}
+
 function makeStreamingGenericCall(response_size) {
   var response = zeroBuffer(response_size);
   return function streamingGenericCall(call) {
@@ -129,6 +136,7 @@ function BenchmarkServer(host, port, tls, generic, response_size) {
   this.port = server.bind(host + ':' + port, server_creds);
   if (generic) {
     server.addService(genericService, {
+      unaryCall: makeUnaryGenericCall(response_size),
       streamingCall: makeStreamingGenericCall(response_size)
     });
   } else {

--- a/src/node/performance/generic_service.js
+++ b/src/node/performance/generic_service.js
@@ -34,8 +34,17 @@
 var _ = require('lodash');
 
 module.exports = {
+  'unaryCall' : {
+    path: '/grpc.testing.BenchmarkService/UnaryCall',
+    requestStream: false,
+    responseStream: false,
+    requestSerialize: _.identity,
+    requestDeserialize: _.identity,
+    responseSerialize: _.identity,
+    responseDeserialize: _.identity
+  },
   'streamingCall' : {
-    path: '/grpc.testing/BenchmarkService',
+    path: '/grpc.testing.BenchmarkService/StreamingCall',
     requestStream: true,
     responseStream: true,
     requestSerialize: _.identity,

--- a/tools/run_tests/performance/build_performance.sh
+++ b/tools/run_tests/performance/build_performance.sh
@@ -61,6 +61,9 @@ do
   "csharp")
     python tools/run_tests/run_tests.py -l $language -c $CONFIG --build_only -j 8 --compiler coreclr
     ;;
+  "node")
+    python tools/run_tests/run_tests.py -l $language -c $CONFIG --build_only -j 8 --iomgr_platform=uv
+    ;;
   *)
     python tools/run_tests/run_tests.py -l $language -c $CONFIG --build_only -j 8
     ;;


### PR DESCRIPTION
There are a few changes here:

 - Add a generic unary method to the Node benchmark server, to run the unary benchmark without serialization overhead. This is the test that the fixes in this PR were tested against. I expect to add this to the automated performance suite in a future PR.

 - Ensure that the Node benchmarks are built to use the libuv TCP stack. This is what the published binaries use.

 - Remove all but one call to `memcpy` in the Node gRPC glue code. That one call is currently necessary to coalesce the `grpc_slice`s that comprise a single message.

 - Remove the call to the JavaScript-level `Buffer` constructor. This does not seem to have any affect on the the API, and it results in a significant performance improvement. If this does turn out to be necessary/desirable, we should try instead calling `Buffer.from` from JavaScript code instead of from C++, to avoid the cost of moving between JavaScript and C++ code.

My measurements indicate that these changes cause a ~1/3 latency decrease in the generic unary benchmark with 1Mb request and response messages.