### PR TITLE
Print out some cli error message for getservices

### DIFF
--- a/test/cpp/util/grpc_tool.cc
+++ b/test/cpp/util/grpc_tool.cc
@@ -321,6 +321,7 @@ bool GrpcTool::ListServices(int argc, const char** argv,
 
   std::vector<grpc::string> service_list;
   if (!desc_db.GetServices(&service_list)) {
+    fprintf(stderr, "Received an error when querying services endpoint.\n");
     return false;
   }
 


### PR DESCRIPTION
Currently, when you call grpc_cli ls on an endpoint that does not have service reflection, the cli just silently ends without printing out any error or message.

This PR should fix that.