### PR TITLE
Fix call destruction bug

### DIFF
--- a/src/node/ext/call.cc
+++ b/src/node/ext/call.cc
@@ -515,16 +515,20 @@ void DestroyTag(void *tag) {
   delete tag_struct;
 }
 
+void Call::DestroyCall() {
+  if (this->wrapped_call != NULL) {
+    grpc_call_destroy(this->wrapped_call);
+    this->wrapped_call = NULL;
+  }
+}
+
 Call::Call(grpc_call *call) : wrapped_call(call),
                               pending_batches(0),
                               has_final_op_completed(false) {
 }
 
 Call::~Call() {
-  if (wrapped_call != NULL) {
-    grpc_call_destroy(wrapped_call);
-    wrapped_call = NULL;
-  }
+  DestroyCall();
 }
 
 void Call::Init(Local<Object> exports) {
@@ -570,10 +574,8 @@ void Call::CompleteBatch(bool is_final_op) {
     this->has_final_op_completed = true;
   }
   this->pending_batches--;
-  if (this->has_final_op_completed && this->pending_batches == 0 &&
-      this->wrapped_call != NULL) {
-    grpc_call_destroy(this->wrapped_call);
-    this->wrapped_call = NULL;
+  if (this->has_final_op_completed && this->pending_batches == 0) {
+    this->DestroyCall();
   }
 }
 

--- a/src/node/ext/call.h
+++ b/src/node/ext/call.h
@@ -76,6 +76,8 @@ class Call : public Nan::ObjectWrap {
   Call(const Call &);
   Call &operator=(const Call &);
 
+  void DestroyCall();
+
   static NAN_METHOD(New);
   static NAN_METHOD(StartBatch);
   static NAN_METHOD(Cancel);

--- a/src/node/ext/call.h
+++ b/src/node/ext/call.h
@@ -109,11 +109,14 @@ class Op {
 
 typedef std::vector<unique_ptr<Op>> OpVec;
 struct tag {
-  tag(Nan::Callback *callback, OpVec *ops, Call *call);
+  tag(Nan::Callback *callback, OpVec *ops, Call *call,
+      v8::Local<v8::Value> call_value);
   ~tag();
   Nan::Callback *callback;
   OpVec *ops;
   Call *call;
+  Nan::Persistent<v8::Value, Nan::CopyablePersistentTraits<v8::Value>>
+      call_persist;
 };
 
 v8::Local<v8::Value> GetTagNodeValue(void *tag);

--- a/src/node/ext/channel.cc
+++ b/src/node/ext/channel.cc
@@ -280,7 +280,7 @@ NAN_METHOD(Channel::WatchConnectivityState) {
       channel->wrapped_channel, last_state, MillisecondsToTimespec(deadline),
       GetCompletionQueue(),
       new struct tag(callback,
-                     ops.release(), NULL));
+                     ops.release(), NULL, Nan::Null()));
   CompletionQueueNext();
 }
 

--- a/src/node/ext/server.cc
+++ b/src/node/ext/server.cc
@@ -193,7 +193,7 @@ NAN_METHOD(Server::RequestCall) {
       GetCompletionQueue(),
       GetCompletionQueue(),
       new struct tag(new Callback(info[0].As<Function>()), ops.release(),
-                     NULL));
+                     NULL, Nan::Null()));
   if (error != GRPC_CALL_OK) {
     return Nan::ThrowError(nanErrorWithCode("requestCall failed", error));
   }
@@ -246,7 +246,7 @@ NAN_METHOD(Server::TryShutdown) {
   grpc_server_shutdown_and_notify(
       server->wrapped_server, GetCompletionQueue(),
       new struct tag(new Nan::Callback(info[0].As<Function>()), ops.release(),
-                     NULL));
+                     NULL, Nan::Null()));
   CompletionQueueNext();
 }
 

--- a/src/node/ext/server_uv.cc
+++ b/src/node/ext/server_uv.cc
@@ -118,7 +118,8 @@ void Server::ShutdownServer() {
 
     grpc_server_shutdown_and_notify(
         this->wrapped_server, GetCompletionQueue(),
-        new struct tag(new Callback(**shutdown_callback), ops.release(), NULL));
+        new struct tag(new Callback(**shutdown_callback), ops.release(), NULL,
+                       Nan::Null()));
     grpc_server_cancel_all_calls(this->wrapped_server);
     CompletionQueueNext();
     this->wrapped_server = NULL;


### PR DESCRIPTION
The Node glue code has a mechanism to destroy a call after the last batch has completed. In some cases, the call could get garbage collected before its final batch completed, which would cause errors. This change fixes that by adding a `Persistent` to the tag that keeps the JavaScript-level call object alive as long as it has a pending batch.