### PR TITLE
Add UpdateActions to the interop client helper

### DIFF
--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -99,6 +99,7 @@ DEFINE_bool(do_not_abort_on_transient_failures, false,
 
 using grpc::testing::CreateChannelForTestCase;
 using grpc::testing::GetServiceAccountJsonKey;
+using grpc::testing::UpdateActions;
 
 int main(int argc, char** argv) {
   grpc::testing::InitTest(&argc, &argv, true);
@@ -164,6 +165,8 @@ int main(int argc, char** argv) {
       std::bind(&grpc::testing::InteropClient::DoUnimplementedService, &client);
   // actions["cacheable_unary"] =
   //    std::bind(&grpc::testing::InteropClient::DoCacheableUnary, &client);
+
+  UpdateActions(&actions);
 
   if (FLAGS_test_case == "all") {
     for (const auto& action : actions) {

--- a/test/cpp/interop/client_helper.cc
+++ b/test/cpp/interop/client_helper.cc
@@ -89,6 +89,9 @@ grpc::string GetOauth2AccessToken() {
   return access_token;
 }
 
+void UpdateActions(
+    std::unordered_map<grpc::string, std::function<bool()>>* actions) {}
+
 std::shared_ptr<Channel> CreateChannelForTestCase(
     const grpc::string& test_case) {
   GPR_ASSERT(FLAGS_server_port);

--- a/test/cpp/interop/client_helper.h
+++ b/test/cpp/interop/client_helper.h
@@ -35,6 +35,7 @@
 #define GRPC_TEST_CPP_INTEROP_CLIENT_HELPER_H
 
 #include <memory>
+#include <unordered_map>
 
 #include <grpc++/channel.h>
 
@@ -46,6 +47,9 @@ namespace testing {
 grpc::string GetServiceAccountJsonKey();
 
 grpc::string GetOauth2AccessToken();
+
+void UpdateActions(
+    std::unordered_map<grpc::string, std::function<bool()>>* actions);
 
 std::shared_ptr<Channel> CreateChannelForTestCase(
     const grpc::string& test_case);


### PR DESCRIPTION
Add `UpdateActions` to the interop client helper, so that the helper can modify the list of supported test cases.