### PR TITLE
Fix memory leak in latest 1.1.* branch

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -39,11 +39,7 @@
 {
   'variables': {
     'runtime%': 'node',
-    # UV integration in C core is disabled by default while bugs are ironed
-    # out. It can be re-enabled for one build by setting the npm config
-    # variable grpc_uv to true, and it can be re-enabled permanently by
-    # setting it to true here.
-    'grpc_uv%': 'false'
+    'grpc_uv%': 'true'
   },
   'target_defaults': {
     'include_dirs': [
@@ -56,8 +52,6 @@
     'conditions': [
       ['runtime=="node" and grpc_uv=="true"', {
         'defines': [
-          # Disabling this while bugs are ironed out. Uncomment this to
-          # re-enable libuv integration in C core.
           'GRPC_UV'
         ]
       }],

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -41,11 +41,7 @@
   {
     'variables': {
       'runtime%': 'node',
-      # UV integration in C core is disabled by default while bugs are ironed
-      # out. It can be re-enabled for one build by setting the npm config
-      # variable grpc_uv to true, and it can be re-enabled permanently by
-      # setting it to true here.
-      'grpc_uv%': 'false'
+      'grpc_uv%': 'true'
     },
     'target_defaults': {
       'include_dirs': [
@@ -58,8 +54,6 @@
       'conditions': [
         ['runtime=="node" and grpc_uv=="true"', {
           'defines': [
-            # Disabling this while bugs are ironed out. Uncomment this to
-            # re-enable libuv integration in C core.
             'GRPC_UV'
           ]
         }],


### PR DESCRIPTION
See https://github.com/grpc/grpc/issues/10445

This commit reverts the faulty commit https://github.com/grpc/grpc/commit/6f62c0adca4921c8d0e75ec5b9886280ead5b7f1 which introduced the memory leak for the 1.1.* branch.

The memory leak still exists for the 1.2.* branch, however the changes in `1.2.*` are far more complicated and a quick fix is not possible.