### PR TITLE
Node slice leaks

### DIFF
--- a/src/node/ext/call.h
+++ b/src/node/ext/call.h
@@ -58,6 +58,8 @@ v8::Local<v8::Value> ParseMetadata(const grpc_metadata_array *metadata_array);
 bool CreateMetadataArray(v8::Local<v8::Object> metadata,
                          grpc_metadata_array *array);
 
+void DestroyMetadataArray(grpc_metadata_array *array);
+
 /* Wrapper class for grpc_call structs. */
 class Call : public Nan::ObjectWrap {
  public:

--- a/src/node/ext/call_credentials.cc
+++ b/src/node/ext/call_credentials.cc
@@ -211,6 +211,7 @@ NAN_METHOD(PluginCallback) {
   Utf8String details_utf8_str(info[1]);
   char *details = *details_utf8_str;
   grpc_metadata_array array;
+  grpc_metadata_array_init(&array);
   Local<Object> callback_data = Nan::To<Object>(info[3]).ToLocalChecked();
   if (!CreateMetadataArray(Nan::To<Object>(info[2]).ToLocalChecked(),
                            &array)){
@@ -226,6 +227,7 @@ NAN_METHOD(PluginCallback) {
                Nan::New("user_data").ToLocalChecked()
                ).ToLocalChecked().As<External>()->Value();
   cb(user_data, array.metadata, array.count, code, details);
+  DestroyMetadataArray(&array);
 }
 
 NAUV_WORK_CB(SendPluginCallback) {

--- a/src/node/ext/node_grpc.cc
+++ b/src/node/ext/node_grpc.cc
@@ -286,8 +286,10 @@ NAN_METHOD(MetadataKeyIsLegal) {
         "headerKeyIsLegal's argument must be a string");
   }
   Local<String> key = Nan::To<String>(info[0]).ToLocalChecked();
+  grpc_slice slice = CreateSliceFromString(key);
   info.GetReturnValue().Set(static_cast<bool>(
-      grpc_header_key_is_legal(CreateSliceFromString(key))));
+      grpc_header_key_is_legal(slice)));
+  grpc_slice_unref(slice);
 }
 
 NAN_METHOD(MetadataNonbinValueIsLegal) {
@@ -296,8 +298,10 @@ NAN_METHOD(MetadataNonbinValueIsLegal) {
         "metadataNonbinValueIsLegal's argument must be a string");
   }
   Local<String> value = Nan::To<String>(info[0]).ToLocalChecked();
+  grpc_slice slice = CreateSliceFromString(value);
   info.GetReturnValue().Set(static_cast<bool>(
-      grpc_header_nonbin_value_is_legal(CreateSliceFromString(value))));
+      grpc_header_nonbin_value_is_legal(slice)));
+  grpc_slice_unref(slice);
 }
 
 NAN_METHOD(MetadataKeyIsBinary) {
@@ -306,8 +310,10 @@ NAN_METHOD(MetadataKeyIsBinary) {
         "metadataKeyIsLegal's argument must be a string");
   }
   Local<String> key = Nan::To<String>(info[0]).ToLocalChecked();
+  grpc_slice slice = CreateSliceFromString(key);
   info.GetReturnValue().Set(static_cast<bool>(
-      grpc_is_binary_header(CreateSliceFromString(key))));
+      grpc_is_binary_header(slice)));
+  grpc_slice_unref(slice);
 }
 
 static grpc_ssl_roots_override_result get_ssl_roots_override(


### PR DESCRIPTION
This fixes two different memory leaks in the Node.js library. First, when some core libraries were modified to accept `grpc_slice`s instead of bare C strings, the calling code was not modified to unref those slices. Second, metadata arrays that were passed to core were not getting properly deallocated, and the individual metadata value slices were not getting unrefed.

This fixes #10445.