### PR TITLE
Fix the atomic counter for max idle timer

### DIFF
--- a/src/core/ext/filters/max_age/max_age_filter.cc
+++ b/src/core/ext/filters/max_age/max_age_filter.cc
@@ -89,7 +89,7 @@ typedef struct channel_data {
 /* Increase the nubmer of active calls. Before the increasement, if there are no
    calls, the max_idle_timer should be cancelled. */
 static void increase_call_count(grpc_exec_ctx* exec_ctx, channel_data* chand) {
-  if (gpr_atm_full_fetch_add(&chand->call_count, 1) == 0) {
+  if (gpr_atm_full_fetch_add(&chand->call_count, 2) == 0) {
     grpc_timer_cancel(exec_ctx, &chand->max_idle_timer);
   }
 }
@@ -97,12 +97,20 @@ static void increase_call_count(grpc_exec_ctx* exec_ctx, channel_data* chand) {
 /* Decrease the nubmer of active calls. After the decrement, if there are no
    calls, the max_idle_timer should be started. */
 static void decrease_call_count(grpc_exec_ctx* exec_ctx, channel_data* chand) {
-  if (gpr_atm_full_fetch_add(&chand->call_count, -1) == 1) {
+  while (gpr_atm_full_fetch_add(&chand->call_count, -1) == 2) {
     GRPC_CHANNEL_STACK_REF(chand->channel_stack, "max_age max_idle_timer");
     grpc_timer_init(exec_ctx, &chand->max_idle_timer,
                     grpc_exec_ctx_now(exec_ctx) + chand->max_connection_idle,
                     &chand->close_max_idle_channel);
+    if (gpr_atm_rel_cas(&chand->call_count, 1, 0)) {
+      return;
+    }
+    grpc_timer_cancel(exec_ctx, &chand->max_idle_timer);
+    GRPC_CHANNEL_STACK_UNREF(exec_ctx, chand->channel_stack,
+                             "max_age max_idle_timer");
+    gpr_atm_full_fetch_add(&chand->call_count, 1);
   }
+  gpr_atm_full_fetch_add(&chand->call_count, -1);
 }
 
 static void start_max_idle_timer_after_init(grpc_exec_ctx* exec_ctx, void* arg,
@@ -156,6 +164,7 @@ static void start_max_age_grace_timer_after_goaway_op(grpc_exec_ctx* exec_ctx,
 static void close_max_idle_channel(grpc_exec_ctx* exec_ctx, void* arg,
                                    grpc_error* error) {
   channel_data* chand = (channel_data*)arg;
+  gpr_atm_no_barrier_fetch_add(&chand->call_count, 2);
   if (error == GRPC_ERROR_NONE) {
     /* Prevent the max idle timer from being set again */
     gpr_atm_no_barrier_fetch_add(&chand->call_count, 1);
@@ -355,9 +364,9 @@ static grpc_error* init_channel_elem(grpc_exec_ctx* exec_ctx,
                        GRPC_ERROR_NONE);
   }
 
-  /* Initialize the number of calls as 1, so that the max_idle_timer will not
+  /* Initialize the number of calls as 2, so that the max_idle_timer will not
      start until start_max_idle_timer_after_init is invoked. */
-  gpr_atm_rel_store(&chand->call_count, 1);
+  gpr_atm_rel_store(&chand->call_count, 2);
   if (chand->max_connection_idle != GRPC_MILLIS_INF_FUTURE) {
     GRPC_CHANNEL_STACK_REF(chand->channel_stack,
                            "max_age start_max_idle_timer_after_init");


### PR DESCRIPTION
The previous implementation seems faulty:
Assume we have one active call.
- When it ends, `decrease_call_count` will be invoked,  `gpr_atm_full_fetch_add` decreases `call_count` from 1 to 0.
- At this time, a new call arrives,  `increase_call_count` is called, `gpr_atm_full_fetch_add` sees that `call_count` is 0. It then cancels the timer.
- `decrease_call_count` then continues its operation, and uses `grpc_timer_init` to set up the timer.

After these operations, there is an active call, but the max_idle timer is set.

The new implementation turns `call_count` from 2 to 1, which can be seen as a transient state. In this state, no one else can set or cancel the timer (`call_count` is an odd number in this state, the timer can be set or canceled only when `call_count` is 2 or 0).
After setting the timer, `decrease_call_count` checks if `call_count` is still 1:
- If it is 1, there's no other active call, and the timer should stay set.
- If it's not 1, someone else may have established a new call, we need to cancel the timer, and try decreasing `call_count` again.