### PR TITLE
Ignore a couple of errors in the Node express benchmark

### DIFF
--- a/src/node/performance/benchmark_server_express.js
+++ b/src/node/performance/benchmark_server_express.js
@@ -46,7 +46,7 @@ var EventEmitter = require('events');
 var util = require('util');
 
 var express = require('express');
-var bodyParser = require('body-parser')
+var bodyParser = require('body-parser');
 
 function unaryCall(req, res) {
   var reqObj = req.body;
@@ -56,7 +56,7 @@ function unaryCall(req, res) {
 
 function BenchmarkServer(host, port, tls, generic, response_size) {
   var app = express();
-  app.use(bodyParser.json())
+  app.use(bodyParser.json());
   app.put('/serviceProto.BenchmarkService.service/unaryCall', unaryCall);
   this.input_host = host;
   this.input_port = port;


### PR DESCRIPTION
The Node express QPS benchmark appears to have been failing for a while. This change makes the client ignore a couple of errors that I don't understand how to eliminate. The QPS reported by the test is now the number of *successful* queries that the client makes per second.