### PR TITLE
Restore cronet tests

### DIFF
--- a/src/core/ext/transport/cronet/transport/cronet_transport.c
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.c
@@ -1124,7 +1124,7 @@ static enum e_op_result execute_stream_op(grpc_exec_ctx *exec_ctx,
           if (stream_state->rs.compressed) {
             stream_state->rs.sbs.base.flags |= GRPC_WRITE_INTERNAL_COMPRESS;
           }
-          *((grpc_byte_buffer **)stream_op->recv_message) =
+          *((grpc_byte_buffer **)stream_op->payload->recv_message.recv_message) =
               (grpc_byte_buffer *)&stream_state->rs.sbs;
           grpc_closure_sched(
               exec_ctx, stream_op->payload->recv_message.recv_message_ready,

--- a/src/core/ext/transport/cronet/transport/cronet_transport.c
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.c
@@ -1124,7 +1124,8 @@ static enum e_op_result execute_stream_op(grpc_exec_ctx *exec_ctx,
           if (stream_state->rs.compressed) {
             stream_state->rs.sbs.base.flags |= GRPC_WRITE_INTERNAL_COMPRESS;
           }
-          *((grpc_byte_buffer **)stream_op->payload->recv_message.recv_message) =
+          *((grpc_byte_buffer **)
+                stream_op->payload->recv_message.recv_message) =
               (grpc_byte_buffer *)&stream_state->rs.sbs;
           grpc_closure_sched(
               exec_ctx, stream_op->payload->recv_message.recv_message_ready,

--- a/src/objective-c/tests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests.m
@@ -100,6 +100,15 @@
   return 0;
 }
 
++ (void)setUp {
+#ifdef GRPC_COMPILE_WITH_CRONET
+  // Cronet setup
+  [Cronet setHttp2Enabled:YES];
+  [Cronet start];
+  [GRPCCall useCronetWithEngine:[Cronet getGlobalEngine]];
+#endif
+}
+
 - (void)setUp {
   self.continueAfterFailure = NO;
 


### PR DESCRIPTION
InteropRemoteTestsWithCronet was implicitly disabled by #9247 due to merging conflict (it is still runnable but has not been using Cronet after #9247 merged in on Mar. 28).

This PR reverts this problem and fixed a bug in cronet_transport not detected in the mean time.