### PR TITLE
PHP Fixing is_a check for Channel

### DIFF
--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -87,7 +87,7 @@ class BaseStub
                                  'ChannelCredentials::create methods');
         }
         if ($channel) {
-            if (!is_a($channel, 'Channel')) {
+            if (!is_a($channel, 'Grpc\Channel')) {
                 throw new \Exception('The channel argument is not a'.
                                      'Channel object');
             }


### PR DESCRIPTION
php ```is_a``` function expects fully qualified class name to validate.
Fixing implementation to use ```Grpc\Channel``` instead of ```Channel```