### PR TITLE
Run start_port_server.py in performance profiling

### DIFF
--- a/tools/jenkins/run_performance_profile_hourly.sh
+++ b/tools/jenkins/run_performance_profile_hourly.sh
@@ -32,6 +32,8 @@ set -ex
 
 cd $(dirname $0)/../..
 
+./tools/run_tests/start_port_server.py || true
+
 CPUS=`python -c 'import multiprocessing; print multiprocessing.cpu_count()'`
 
 make CONFIG=opt memory_profile_test memory_profile_client memory_profile_server -j $CPUS


### PR DESCRIPTION
There were a few failures in https://grpc-testing.appspot.com/view/Performance/job/gRPC_performance_profile_master/ after I restarted the performance VMs. 
```
+ bins/opt/memory_profile_test
gRPC tests require a helper port server to allocate ports used 
during the test.

This server is not currently running.

To start it, run tools/run_tests/start_port_server.py
```
The hourly profile job relies on `start_port_server.py` to have already been executed before and probably shouldn't. 