### PR TITLE
Fix Windows warning in binding.gyp for Win10 console

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -519,9 +519,10 @@
           # the OpenSSL headers, from the downloaded Node development package,
           # which is typically located in `.node-gyp` in your home directory.
           'target_name': 'WINDOWS_BUILD_WARNING',
-          'actions': [
+          'rules': [
             {
-              'action_name': 'WINDOWS_BUILD_WARNING',
+              'rule_name': 'WINDOWS_BUILD_WARNING',
+              'extension': 'S',
               'inputs': [
                 'package.json'
               ],

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -217,9 +217,10 @@
             # the OpenSSL headers, from the downloaded Node development package,
             # which is typically located in `.node-gyp` in your home directory.
             'target_name': 'WINDOWS_BUILD_WARNING',
-            'actions': [
+            'rules': [
               {
-                'action_name': 'WINDOWS_BUILD_WARNING',
+                'rule_name': 'WINDOWS_BUILD_WARNING',
+                'extension': 'S',
                 'inputs': [
                   'package.json'
                 ],


### PR DESCRIPTION
According to #10458, this modification is needed to correctly display the warning about OpenSSL include paths in the Windows 10 console.