### PR TITLE
Make native node module_path unique

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "binary": {
     "module_name": "grpc_node",
-    "module_path": "src/node/extension_binary",
+    "module_path": "src/node/extension_binary/{node_abi}-{platform}-{arch}",
     "host": "https://storage.googleapis.com/",
     "remote_path": "grpc-precompiled-binaries/node/{name}/v{version}",
     "package_name": "{node_abi}-{platform}-{arch}.tar.gz"

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -59,7 +59,7 @@
     },
     "binary": {
       "module_name": "grpc_node",
-      "module_path": "src/node/extension_binary",
+      "module_path": "src/node/extension_binary/{node_abi}-{platform}-{arch}",
       "host": "https://storage.googleapis.com/",
       "remote_path": "grpc-precompiled-binaries/node/{name}/v{version}",
       "package_name": "{node_abi}-{platform}-{arch}.tar.gz"


### PR DESCRIPTION
This change makes the native node module_path unique so that node_modules from multiple platforms could be merged together without overwriting the grpc_node.node module.

Fixes #10558