### PR TITLE
Pin Bazel version to 0.4.4 in Dockerfile

### DIFF
--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -72,6 +72,13 @@ RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
 RUN apt-get -y update
 RUN apt-get -y install bazel
 
+# Pin Bazel to 0.4.4
+# Installing Bazel via apt-get first is required before installing 0.4.4 to
+# allow gRPC to build without errors. See https://github.com/grpc/grpc/issues/10553
+RUN curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.4.4/bazel-0.4.4-installer-linux-x86_64.sh
+RUN chmod +x ./bazel-0.4.4-installer-linux-x86_64.sh
+RUN ./bazel-0.4.4-installer-linux-x86_64.sh
+
 RUN mkdir -p /var/local/jenkins
 
 # Define the default command.


### PR DESCRIPTION
Fixes #10553  

Please see my comment in #10553 about why I install Bazel with `apt-get` and then install 0.4.4. I'd like to avoid doing this and if you have any ideas why this interaction makes `tools/jenkins/run_bazel_basic.sh` pass, then hopefully we can come up with a better workaround. Otherwise, I'll create an issue on Bazel's GH.

Also, pinning the Bazel version is a quick fix, but would we want to test building gRPC at the lastest Bazel version in the long term?