### PR TITLE
Node server shutdown improvements

### DIFF
--- a/src/node/ext/call.cc
+++ b/src/node/ext/call.cc
@@ -217,7 +217,7 @@ class SendMetadataOp : public Op {
   bool IsFinalOp() {
     return false;
   }
-  void OnComplete() {
+  void OnComplete(bool success) {
   }
  protected:
   std::string GetTypeString() const {
@@ -262,7 +262,7 @@ class SendMessageOp : public Op {
   bool IsFinalOp() {
     return false;
   }
-  void OnComplete() {
+  void OnComplete(bool success) {
   }
  protected:
   std::string GetTypeString() const {
@@ -284,7 +284,7 @@ class SendClientCloseOp : public Op {
   bool IsFinalOp() {
     return false;
   }
-  void OnComplete() {
+  void OnComplete(bool success) {
   }
  protected:
   std::string GetTypeString() const {
@@ -355,7 +355,7 @@ class SendServerStatusOp : public Op {
   bool IsFinalOp() {
     return true;
   }
-  void OnComplete() {
+  void OnComplete(bool success) {
   }
  protected:
   std::string GetTypeString() const {
@@ -389,7 +389,7 @@ class GetMetadataOp : public Op {
   bool IsFinalOp() {
     return false;
   }
-  void OnComplete() {
+  void OnComplete(bool success) {
   }
 
  protected:
@@ -423,7 +423,7 @@ class ReadMessageOp : public Op {
   bool IsFinalOp() {
     return false;
   }
-  void OnComplete() {
+  void OnComplete(bool success) {
   }
 
  protected:
@@ -466,7 +466,7 @@ class ClientStatusOp : public Op {
   bool IsFinalOp() {
     return true;
   }
-  void OnComplete() {
+  void OnComplete(bool success) {
   }
  protected:
   std::string GetTypeString() const {
@@ -492,7 +492,7 @@ class ServerCloseResponseOp : public Op {
   bool IsFinalOp() {
     return false;
   }
-  void OnComplete() {
+  void OnComplete(bool success) {
   }
 
  protected:
@@ -532,11 +532,12 @@ void CompleteTag(void *tag, const char *error_message) {
     Local<Value> argv[] = {Nan::Error(error_message)};
     callback->Call(1, argv);
   }
+  bool success = (error_message == NULL);
   bool is_final_op = false;
   for (vector<unique_ptr<Op> >::iterator it = tag_struct->ops->begin();
        it != tag_struct->ops->end(); ++it) {
     Op *op_ptr = it->get();
-    op_ptr->OnComplete();
+    op_ptr->OnComplete(success);
     if (op_ptr->IsFinalOp()) {
       is_final_op = true;
     }

--- a/src/node/ext/call.cc
+++ b/src/node/ext/call.cc
@@ -217,6 +217,8 @@ class SendMetadataOp : public Op {
   bool IsFinalOp() {
     return false;
   }
+  void OnComplete() {
+  }
  protected:
   std::string GetTypeString() const {
     return "send_metadata";
@@ -260,6 +262,8 @@ class SendMessageOp : public Op {
   bool IsFinalOp() {
     return false;
   }
+  void OnComplete() {
+  }
  protected:
   std::string GetTypeString() const {
     return "send_message";
@@ -279,6 +283,8 @@ class SendClientCloseOp : public Op {
   }
   bool IsFinalOp() {
     return false;
+  }
+  void OnComplete() {
   }
  protected:
   std::string GetTypeString() const {
@@ -349,6 +355,8 @@ class SendServerStatusOp : public Op {
   bool IsFinalOp() {
     return true;
   }
+  void OnComplete() {
+  }
  protected:
   std::string GetTypeString() const {
     return "send_status";
@@ -381,6 +389,8 @@ class GetMetadataOp : public Op {
   bool IsFinalOp() {
     return false;
   }
+  void OnComplete() {
+  }
 
  protected:
   std::string GetTypeString() const {
@@ -412,6 +422,8 @@ class ReadMessageOp : public Op {
   }
   bool IsFinalOp() {
     return false;
+  }
+  void OnComplete() {
   }
 
  protected:
@@ -454,6 +466,8 @@ class ClientStatusOp : public Op {
   bool IsFinalOp() {
     return true;
   }
+  void OnComplete() {
+  }
  protected:
   std::string GetTypeString() const {
     return "status";
@@ -477,6 +491,8 @@ class ServerCloseResponseOp : public Op {
   }
   bool IsFinalOp() {
     return false;
+  }
+  void OnComplete() {
   }
 
  protected:
@@ -517,15 +533,16 @@ void CompleteTag(void *tag, const char *error_message) {
     callback->Call(1, argv);
   }
   bool is_final_op = false;
-  if (tag_struct->call == NULL) {
-    return;
-  }
   for (vector<unique_ptr<Op> >::iterator it = tag_struct->ops->begin();
        it != tag_struct->ops->end(); ++it) {
     Op *op_ptr = it->get();
+    op_ptr->OnComplete();
     if (op_ptr->IsFinalOp()) {
       is_final_op = true;
     }
+  }
+  if (tag_struct->call == NULL) {
+    return;
   }
   tag_struct->call->CompleteBatch(is_final_op);
 }

--- a/src/node/ext/call.h
+++ b/src/node/ext/call.h
@@ -123,13 +123,9 @@ struct tag {
       call_persist;
 };
 
-v8::Local<v8::Value> GetTagNodeValue(void *tag);
-
-Nan::Callback *GetTagCallback(void *tag);
-
 void DestroyTag(void *tag);
 
-void CompleteTag(void *tag);
+void CompleteTag(void *tag, const char *error_message);
 
 }  // namespace node
 }  // namespace grpc

--- a/src/node/ext/call.h
+++ b/src/node/ext/call.h
@@ -106,7 +106,7 @@ class Op {
   virtual ~Op();
   v8::Local<v8::Value> GetOpType() const;
   virtual bool IsFinalOp() = 0;
-  virtual void OnComplete() = 0;
+  virtual void OnComplete(bool success) = 0;
 
  protected:
   virtual std::string GetTypeString() const = 0;

--- a/src/node/ext/call.h
+++ b/src/node/ext/call.h
@@ -106,6 +106,7 @@ class Op {
   virtual ~Op();
   v8::Local<v8::Value> GetOpType() const;
   virtual bool IsFinalOp() = 0;
+  virtual void OnComplete() = 0;
 
  protected:
   virtual std::string GetTypeString() const = 0;

--- a/src/node/ext/completion_queue_threadpool.cc
+++ b/src/node/ext/completion_queue_threadpool.cc
@@ -148,9 +148,7 @@ void CompletionQueueAsyncWorker::HandleOKCallback() {
   Nan::HandleScope scope;
   current_threads -= 1;
   TryAddWorker();
-  Nan::Callback *callback = GetTagCallback(result.tag);
-  Local<Value> argv[] = {Nan::Null(), GetTagNodeValue(result.tag)};
-  callback->Call(2, argv);
+  CompleteTag(result.tag, NULL);
 
   DestroyTag(result.tag);
 }
@@ -159,10 +157,7 @@ void CompletionQueueAsyncWorker::HandleErrorCallback() {
   Nan::HandleScope scope;
   current_threads -= 1;
   TryAddWorker();
-  Nan::Callback *callback = GetTagCallback(result.tag);
-  Local<Value> argv[] = {Nan::Error(ErrorMessage())};
-
-  callback->Call(1, argv);
+  CompleteTag(result.tag, ErrorMessage());
 
   DestroyTag(result.tag);
 }

--- a/src/node/ext/completion_queue_uv.cc
+++ b/src/node/ext/completion_queue_uv.cc
@@ -61,17 +61,13 @@ void drain_completion_queue(uv_prepare_t *handle) {
         queue, gpr_inf_past(GPR_CLOCK_MONOTONIC), NULL);
 
     if (event.type == GRPC_OP_COMPLETE) {
-      Nan::Callback *callback = grpc::node::GetTagCallback(event.tag);
+      const char *error_message;
       if (event.success) {
-        Local<Value> argv[] = {Nan::Null(),
-                             grpc::node::GetTagNodeValue(event.tag)};
-        callback->Call(2, argv);
+        error_message = NULL;
       } else {
-        Local<Value> argv[] = {Nan::Error(
-            "The async function encountered an error")};
-        callback->Call(1, argv);
+        error_message = "The async function encountered an error";
       }
-      grpc::node::CompleteTag(event.tag);
+      CompleteTag(event.tag, error_message);
       grpc::node::DestroyTag(event.tag);
       pending_batches--;
       if (pending_batches == 0) {

--- a/src/node/ext/server.cc
+++ b/src/node/ext/server.cc
@@ -117,6 +117,8 @@ class NewCallOp : public Op {
   bool IsFinalOp() {
     return false;
   }
+  void OnComplete() {
+  }
 
   grpc_call *call;
   grpc_call_details details;
@@ -124,6 +126,32 @@ class NewCallOp : public Op {
 
  protected:
   std::string GetTypeString() const { return "new_call"; }
+};
+
+class TryShutdownOp: public Op {
+ public:
+  TryShutdownOp(Server *server, Local<Value> server_value) : server(server) {
+    server_persist.Reset(server_value);
+  }
+  Local<Value> GetNodeValue() const {
+    EscapableHandleScope scope;
+    return scope.Escape(Nan::New(server_persist));
+  }
+  bool ParseOp(Local<Value> value, grpc_op *out) {
+    return true;
+  }
+  bool IsFinalOp() {
+    return false;
+  }
+  void OnComplete() {
+    server->DestroyWrappedServer();
+  }
+ protected:
+  std::string GetTypeString() const { return "try_shutdown"; }
+ private:
+  Server *server;
+  Nan::Persistent<v8::Value, Nan::CopyablePersistentTraits<v8::Value>>
+      server_persist;
 };
 
 void Server::Init(Local<Object> exports) {
@@ -145,6 +173,13 @@ void Server::Init(Local<Object> exports) {
 bool Server::HasInstance(Local<Value> val) {
   HandleScope scope;
   return Nan::New(fun_tpl)->HasInstance(val);
+}
+
+void Server::DestroyWrappedServer() {
+  if (this->wrapped_server != NULL) {
+    grpc_server_destroy(this->wrapped_server);
+    this->wrapped_server = NULL;
+  }
 }
 
 NAN_METHOD(Server::New) {
@@ -242,7 +277,9 @@ NAN_METHOD(Server::TryShutdown) {
     return Nan::ThrowTypeError("tryShutdown can only be called on a Server");
   }
   Server *server = ObjectWrap::Unwrap<Server>(info.This());
+  TryShutdownOp *op = new TryShutdownOp(server, info.This());
   unique_ptr<OpVec> ops(new OpVec());
+  ops->push_back(unique_ptr<Op>(op));
   grpc_server_shutdown_and_notify(
       server->wrapped_server, GetCompletionQueue(),
       new struct tag(new Nan::Callback(info[0].As<Function>()), ops.release(),

--- a/src/node/ext/server.cc
+++ b/src/node/ext/server.cc
@@ -277,6 +277,12 @@ NAN_METHOD(Server::TryShutdown) {
     return Nan::ThrowTypeError("tryShutdown can only be called on a Server");
   }
   Server *server = ObjectWrap::Unwrap<Server>(info.This());
+  if (server->wrapped_server == NULL) {
+    // Server is already shut down. Call callback immediately.
+    Nan::Callback callback(info[0].As<Function>());
+    callback.Call(0, {});
+    return;
+  }
   TryShutdownOp *op = new TryShutdownOp(server, info.This());
   unique_ptr<OpVec> ops(new OpVec());
   ops->push_back(unique_ptr<Op>(op));

--- a/src/node/ext/server.cc
+++ b/src/node/ext/server.cc
@@ -117,7 +117,7 @@ class NewCallOp : public Op {
   bool IsFinalOp() {
     return false;
   }
-  void OnComplete() {
+  void OnComplete(bool success) {
   }
 
   grpc_call *call;
@@ -143,8 +143,10 @@ class TryShutdownOp: public Op {
   bool IsFinalOp() {
     return false;
   }
-  void OnComplete() {
-    server->DestroyWrappedServer();
+  void OnComplete(bool success) {
+    if (success) {
+      server->DestroyWrappedServer();
+    }
   }
  protected:
   std::string GetTypeString() const { return "try_shutdown"; }

--- a/src/node/ext/server.h
+++ b/src/node/ext/server.h
@@ -53,6 +53,8 @@ class Server : public Nan::ObjectWrap {
      JavaScript constructor */
   static bool HasInstance(v8::Local<v8::Value> val);
 
+  void DestroyWrappedServer();
+
  private:
   explicit Server(grpc_server *server);
   ~Server();

--- a/src/node/ext/server_uv.cc
+++ b/src/node/ext/server_uv.cc
@@ -76,7 +76,9 @@ class ServerShutdownOp : public Op {
   bool IsFinalOp() {
     return false;
   }
-  void OnComplete() {
+  void OnComplete(bool success) {
+    /* Because cancel_all_calls was called, we assume that shutdown_and_notify
+       completes successfully */
     grpc_server_destroy(server);
   }
 

--- a/src/node/ext/server_uv.cc
+++ b/src/node/ext/server_uv.cc
@@ -67,7 +67,7 @@ class ServerShutdownOp : public Op {
   }
 
   Local<Value> GetNodeValue() const {
-    return Nan::New<External>(reinterpret_cast<void *>(server));
+    return Nan::Null();
   }
 
   bool ParseOp(Local<Value> value, grpc_op *out) {
@@ -77,6 +77,7 @@ class ServerShutdownOp : public Op {
     return false;
   }
   void OnComplete() {
+    grpc_server_destroy(server);
   }
 
   grpc_server *server;
@@ -96,13 +97,6 @@ NAN_METHOD(ServerShutdownCallback) {
   if (!info[0]->IsNull()) {
     return Nan::ThrowError("forceShutdown failed somehow");
   }
-  MaybeLocal<Object> maybe_result = Nan::To<Object>(info[1]);
-  Local<Object> result = maybe_result.ToLocalChecked();
-  Local<Value> server_val = Nan::Get(
-      result, Nan::New("shutdown").ToLocalChecked()).ToLocalChecked();
-  Local<External> server_extern = server_val.As<External>();
-  grpc_server *server = reinterpret_cast<grpc_server *>(server_extern->Value());
-  grpc_server_destroy(server);
 }
 
 void Server::ShutdownServer() {

--- a/src/node/ext/server_uv.cc
+++ b/src/node/ext/server_uv.cc
@@ -76,6 +76,8 @@ class ServerShutdownOp : public Op {
   bool IsFinalOp() {
     return false;
   }
+  void OnComplete() {
+  }
 
   grpc_server *server;
 
@@ -104,6 +106,7 @@ NAN_METHOD(ServerShutdownCallback) {
 }
 
 void Server::ShutdownServer() {
+  Nan::HandleScope scope;
   if (this->wrapped_server != NULL) {
     if (shutdown_callback == NULL) {
       Local<FunctionTemplate>callback_tpl =


### PR DESCRIPTION
The main change here is to ensure that the wrapped core server object is destroyed when the JS-level server is shutdown, no matter how it was shutdown. Previously, the wrapped server would be destroyed and set to NULL in the destructor or if `forceShutdown` was called, but not if `tryShutdown` was called. This fixes that.

In order to do that, I refactored some completion handling logic into `CompleteTag`, from the completion queue wrapping code.

This also fixes #10557.