### PR TITLE
Add individual sanitizer suites to Kokoro

### DIFF
--- a/tools/internal_ci/README.md
+++ b/tools/internal_ci/README.md
@@ -1,4 +1,4 @@
-#Internal continuous integration
+# Internal continuous integration
 
 gRPC's externally facing testing is managed by Jenkins CI (see `tools/jenkins`
 directory). Nevertheless, some of the tests are better suited for being run

--- a/tools/internal_ci/linux/sanitizer/grpc_c_asan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_c_asan.cfg
@@ -30,7 +30,7 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_portability.sh"
+build_file: "grpc/tools/internal_ci/linux/sanitizer/grpc_c_asan.sh"
 timeout_mins: 1440
 action {
   define_artifacts {

--- a/tools/internal_ci/linux/sanitizer/grpc_c_asan.sh
+++ b/tools/internal_ci/linux/sanitizer/grpc_c_asan.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2017, Google Inc.
 # All rights reserved.
 #
@@ -27,13 +28,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Config file for the internal CI (in protobuf text format)
+set -ex
 
-# Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_portability.sh"
-timeout_mins: 1440
-action {
-  define_artifacts {
-    regex: "**/*sponge_log.xml"
-  }
-}
+# change to grpc repo root
+cd $(dirname $0)/../../../..
+
+git submodule update --init
+
+# download docker images from dockerhub
+export DOCKERHUB_ORGANIZATION=grpctesting
+tools/run_tests/run_tests_matrix.py -f c asan

--- a/tools/internal_ci/linux/sanitizer/grpc_c_msan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_c_msan.cfg
@@ -1,4 +1,3 @@
-#!/bin/bash
 # Copyright 2017, Google Inc.
 # All rights reserved.
 #
@@ -28,13 +27,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-set -ex
+# Config file for the internal CI (in protobuf text format)
 
-# change to grpc repo root
-cd $(dirname $0)/../../..
-
-git submodule update --init
-
-# download docker images from dockerhub
-export DOCKERHUB_ORGANIZATION=grpctesting
-tools/run_tests/run_tests_matrix.py -f sanitizers linux
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/sanitizer/grpc_c_msan.sh"
+timeout_mins: 1440
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+  }
+}

--- a/tools/internal_ci/linux/sanitizer/grpc_c_msan.sh
+++ b/tools/internal_ci/linux/sanitizer/grpc_c_msan.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2017, Google Inc.
 # All rights reserved.
 #
@@ -27,13 +28,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Config file for the internal CI (in protobuf text format)
+set -ex
 
-# Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_portability.sh"
-timeout_mins: 1440
-action {
-  define_artifacts {
-    regex: "**/*sponge_log.xml"
-  }
-}
+# change to grpc repo root
+cd $(dirname $0)/../../../..
+
+git submodule update --init
+
+# download docker images from dockerhub
+export DOCKERHUB_ORGANIZATION=grpctesting
+tools/run_tests/run_tests_matrix.py -f c msan

--- a/tools/internal_ci/linux/sanitizer/grpc_c_tsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_c_tsan.cfg
@@ -30,7 +30,7 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_master_sanitizers.sh"
+build_file: "grpc/tools/internal_ci/linux/sanitizer/grpc_c_tsan.sh"
 timeout_mins: 1440
 action {
   define_artifacts {

--- a/tools/internal_ci/linux/sanitizer/grpc_c_tsan.sh
+++ b/tools/internal_ci/linux/sanitizer/grpc_c_tsan.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2017, Google Inc.
 # All rights reserved.
 #
@@ -27,13 +28,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Config file for the internal CI (in protobuf text format)
+set -ex
 
-# Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_portability.sh"
-timeout_mins: 1440
-action {
-  define_artifacts {
-    regex: "**/*sponge_log.xml"
-  }
-}
+# change to grpc repo root
+cd $(dirname $0)/../../../..
+
+git submodule update --init
+
+# download docker images from dockerhub
+export DOCKERHUB_ORGANIZATION=grpctesting
+tools/run_tests/run_tests_matrix.py -f c tsan

--- a/tools/internal_ci/linux/sanitizer/grpc_cpp_asan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_cpp_asan.cfg
@@ -30,7 +30,7 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_portability.sh"
+build_file: "grpc/tools/internal_ci/linux/sanitizer/grpc_cpp_asan.sh"
 timeout_mins: 1440
 action {
   define_artifacts {

--- a/tools/internal_ci/linux/sanitizer/grpc_cpp_asan.sh
+++ b/tools/internal_ci/linux/sanitizer/grpc_cpp_asan.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2017, Google Inc.
 # All rights reserved.
 #
@@ -27,13 +28,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Config file for the internal CI (in protobuf text format)
+set -ex
 
-# Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_portability.sh"
-timeout_mins: 1440
-action {
-  define_artifacts {
-    regex: "**/*sponge_log.xml"
-  }
-}
+# change to grpc repo root
+cd $(dirname $0)/../../../..
+
+git submodule update --init
+
+# download docker images from dockerhub
+export DOCKERHUB_ORGANIZATION=grpctesting
+tools/run_tests/run_tests_matrix.py -f cpp asan

--- a/tools/internal_ci/linux/sanitizer/grpc_cpp_tsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_cpp_tsan.cfg
@@ -30,7 +30,7 @@
 # Config file for the internal CI (in protobuf text format)
 
 # Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_portability.sh"
+build_file: "grpc/tools/internal_ci/linux/sanitizer/grpc_cpp_tsan.sh"
 timeout_mins: 1440
 action {
   define_artifacts {

--- a/tools/internal_ci/linux/sanitizer/grpc_cpp_tsan.sh
+++ b/tools/internal_ci/linux/sanitizer/grpc_cpp_tsan.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright 2017, Google Inc.
 # All rights reserved.
 #
@@ -27,13 +28,13 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Config file for the internal CI (in protobuf text format)
+set -ex
 
-# Location of the continuous shell script in repository.
-build_file: "grpc/tools/internal_ci/linux/grpc_portability.sh"
-timeout_mins: 1440
-action {
-  define_artifacts {
-    regex: "**/*sponge_log.xml"
-  }
-}
+# change to grpc repo root
+cd $(dirname $0)/../../../..
+
+git submodule update --init
+
+# download docker images from dockerhub
+export DOCKERHUB_ORGANIZATION=grpctesting
+tools/run_tests/run_tests_matrix.py -f cpp tsan


### PR DESCRIPTION
Shard sanitizer tests on Kokoro to match Jenkins and a couple nit fixes.

Portability tests are timing out, so maxing out timeout timer. These can be better tuned once we set the `--inner_jobs` flag in Kokoro configs. 