### PR TITLE
Cleanup of our Bazel workspace.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,17 +15,17 @@ bind(
 
 bind(
     name = "protobuf",
-    actual = "@submodule_protobuf//:protobuf",
+    actual = "@com_google_protobuf//:protobuf",
 )
 
 bind(
     name = "protobuf_clib",
-    actual = "@submodule_protobuf//:protoc_lib",
+    actual = "@com_google_protobuf//:protoc_lib",
 )
 
 bind(
     name = "protocol_compiler",
-    actual = "@submodule_protobuf//:protoc",
+    actual = "@com_google_protobuf//:protoc",
 )
 
 bind(
@@ -48,9 +48,8 @@ bind(
     actual = "@com_github_gflags_gflags//:gflags",
 )
 
-new_local_repository(
+local_repository(
     name = "submodule_boringssl",
-    build_file = "third_party/boringssl-with-bazel/BUILD",
     path = "third_party/boringssl-with-bazel",
 )
 
@@ -60,9 +59,8 @@ new_local_repository(
     path = "third_party/zlib",
 )
 
-new_local_repository(
-    name = "submodule_protobuf",
-    build_file = "third_party/protobuf/BUILD",
+local_repository(
+    name = "com_google_protobuf",
     path = "third_party/protobuf",
 )
 
@@ -83,10 +81,9 @@ git_repository(
     remote = "https://github.com/makdharma/mongoose.git"
 )
 
-new_local_repository(
+local_repository(
     name = "submodule_benchmark",
     path = "third_party/benchmark",
-    build_file = "third_party/benchmark.BUILD",
 )
 
 new_local_repository(


### PR DESCRIPTION
Also fixes #10553. Better than pinning it to 0.4.4 that is.

cc @matt-kwong - we might want to update to 0.4.5. I still believe the pinning is a good thing, but we can now go a bit higher than being stuck to 0.4.4.