### PR TITLE
Fix and test Bazel build rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1277,6 +1277,9 @@ grpc_cc_library(
         "src/cpp/server/thread_pool_interface.h",
         "src/cpp/thread_manager/thread_manager.h",
     ],
+    external_deps = [
+        "nanopb",
+    ],
     language = "c++",
     public_hdrs = [
         "include/grpc++/alarm.h",
@@ -1328,7 +1331,7 @@ grpc_cc_library(
         "include/grpc++/support/time.h",
     ],
     deps = [
-        "grpc",
+        "grpc_base",
         "grpc++_codegen_base",
     ],
 )

--- a/BUILD
+++ b/BUILD
@@ -35,7 +35,8 @@ exports_files(["LICENSE"])
 
 package(default_visibility = ["//visibility:public"])
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_proto_plugin")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_library",
+     "grpc_proto_plugin", "grpc_cc_libraries")
 
 # This should be updated along with build.yaml
 g_stands_for = "gentle"
@@ -163,7 +164,7 @@ grpc_cc_library(
     standalone = True,
     deps = [
         "gpr",
-        "grpc++_base",
+        "grpc++_base_unsecure",
         "grpc++_codegen_base",
         "grpc++_codegen_base_src",
         "grpc_unsecure",
@@ -1231,8 +1232,12 @@ grpc_cc_library(
     ],
 )
 
-grpc_cc_library(
-    name = "grpc++_base",
+grpc_cc_libraries(
+    name_list = ["grpc++_base", "grpc++_base_unsecure"],
+    additional_dep_list = [
+        ["grpc", ],
+        ["grpc_unsecure", ],
+    ],
     srcs = [
         "src/cpp/client/channel_cc.cc",
         "src/cpp/client/client_context.cc",
@@ -1267,7 +1272,7 @@ grpc_cc_library(
         "src/cpp/util/status.cc",
         "src/cpp/util/string_ref.cc",
         "src/cpp/util/time_cc.cc",
-    ],
+        ],
     hdrs = [
         "src/cpp/client/create_channel_internal.h",
         "src/cpp/common/channel_filter.h",
@@ -1276,10 +1281,7 @@ grpc_cc_library(
         "src/cpp/server/health/health.pb.h",
         "src/cpp/server/thread_pool_interface.h",
         "src/cpp/thread_manager/thread_manager.h",
-    ],
-    external_deps = [
-        "nanopb",
-    ],
+        ],
     language = "c++",
     public_hdrs = [
         "include/grpc++/alarm.h",
@@ -1329,9 +1331,8 @@ grpc_cc_library(
         "include/grpc++/support/stub_options.h",
         "include/grpc++/support/sync_stream.h",
         "include/grpc++/support/time.h",
-    ],
+        ],
     deps = [
-        "grpc_base",
         "grpc++_codegen_base",
     ],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,17 +15,17 @@ bind(
 
 bind(
     name = "protobuf",
-    actual = "@submodule_protobuf//:protobuf",
+    actual = "@com_google_protobuf//:protobuf",
 )
 
 bind(
     name = "protobuf_clib",
-    actual = "@submodule_protobuf//:protoc_lib",
+    actual = "@com_google_protobuf//:protoc_lib",
 )
 
 bind(
     name = "protocol_compiler",
-    actual = "@submodule_protobuf//:protoc",
+    actual = "@com_google_protobuf//:protoc",
 )
 
 bind(
@@ -48,9 +48,8 @@ bind(
     actual = "@com_github_gflags_gflags//:gflags",
 )
 
-new_local_repository(
+local_repository(
     name = "submodule_boringssl",
-    build_file = "third_party/boringssl-with-bazel/BUILD",
     path = "third_party/boringssl-with-bazel",
 )
 
@@ -61,7 +60,7 @@ new_local_repository(
 )
 
 new_local_repository(
-    name = "submodule_protobuf",
+    name = "com_google_protobuf",
     build_file = "third_party/protobuf/BUILD",
     path = "third_party/protobuf",
 )

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -35,12 +35,12 @@ load(":cc_grpc_library.bzl", "cc_grpc_library")
 
 proto_library(
     name = "well_known_protos_list",
-    srcs = ["@submodule_protobuf//:well_known_protos"],
+    srcs = ["@com_google_protobuf//:well_known_protos"],
 )
 
 cc_grpc_library(
     name = "well_known_protos",
     srcs = "well_known_protos_list",
-    deps = [],
     proto_only = True,
+    deps = [],
 )

--- a/bazel/cc_grpc_library.bzl
+++ b/bazel/cc_grpc_library.bzl
@@ -14,7 +14,7 @@ def cc_grpc_library(name, srcs, deps, proto_only, well_known_protos, use_externa
         the compiled code of any message that the services depend on.
       well_known_protos: The target from protobuf library that exports well
         known protos. Currently it will only work if the value is
-        "@submodule_protobuf//:well_known_protos"
+        "@com_google_protobuf//:well_known_protos"
       use_external: When True the grpc deps are prefixed with //external. This
         allows grpc to be used as a dependency in other bazel projects.
       **kwargs: rest of arguments, e.g., compatible_with and visibility.

--- a/bazel/generate_cc.bzl
+++ b/bazel/generate_cc.bzl
@@ -35,10 +35,10 @@ def generate_cc_impl(ctx):
   well_known_proto_files = []
   if ctx.attr.well_known_protos:
     f = ctx.attr.well_known_protos.files.to_list()[0].dirname
-    if f != "external/submodule_protobuf/src/google/protobuf":
-      print("Error: Only @submodule_protobuf//:well_known_protos is supported")
+    if f != "external/com_google_protobuf/src/google/protobuf":
+      print("Error: Only @com_google_protobuf//:well_known_protos is supported")
     else:
-      # f points to "external/submodule_protobuf/src/google/protobuf"
+      # f points to "external/com_google_protobuf/src/google/protobuf"
       # add -I argument to protoc so it knows where to look for the proto files.
       arguments += ["-I{0}".format(f + "/../..")]
       well_known_proto_files = [f for f in ctx.attr.well_known_protos.files]

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -49,6 +49,19 @@ def grpc_cc_library(name, srcs = [], public_hdrs = [], hdrs = [], external_deps 
     ]
   )
 
+def grpc_cc_libraries(name_list, additional_dep_list, srcs = [], public_hdrs = [], hdrs = [], external_deps = [], deps = [], standalone = False, language="C++"):
+  for i in range(len(name_list)):
+    grpc_cc_library(
+      name = name_list[i],
+      srcs = srcs,
+      hdrs = hdrs,
+      public_hdrs = public_hdrs,
+      deps = deps + additional_dep_list[i],
+      external_deps = external_deps,
+      standalone = standalone,
+      language = language
+    )
+
 def grpc_proto_plugin(name, srcs = [], deps = []):
   native.cc_binary(
     name = name,

--- a/src/core/ext/filters/http/message_compress/message_compress_filter.c
+++ b/src/core/ext/filters/http/message_compress/message_compress_filter.c
@@ -49,8 +49,6 @@
 #include "src/core/lib/support/string.h"
 #include "src/core/lib/transport/static_metadata.h"
 
-int grpc_compression_trace = 0;
-
 #define INITIAL_METADATA_UNSEEN 0
 #define HAS_COMPRESSION_ALGORITHM 2
 #define NO_COMPRESSION_ALGORITHM 4

--- a/src/core/lib/surface/call.c
+++ b/src/core/lib/surface/call.c
@@ -245,6 +245,7 @@ struct grpc_call {
 };
 
 int grpc_call_error_trace = 0;
+int grpc_compression_trace = 0;
 
 #define CALL_STACK_FROM_CALL(call) ((grpc_call_stack *)((call) + 1))
 #define CALL_FROM_CALL_STACK(call_stack) (((grpc_call *)(call_stack)) - 1)

--- a/src/core/lib/surface/server.c
+++ b/src/core/lib/surface/server.c
@@ -1033,8 +1033,6 @@ grpc_server *grpc_server_create(const grpc_channel_args *args, void *reserved) {
 
   grpc_server *server = gpr_zalloc(sizeof(grpc_server));
 
-  GPR_ASSERT(grpc_is_initialized() && "call grpc_init()");
-
   gpr_mu_init(&server->mu_global);
   gpr_mu_init(&server->mu_call);
   gpr_cv_init(&server->starting_cv);

--- a/src/proto/grpc/status/BUILD
+++ b/src/proto/grpc/status/BUILD
@@ -37,7 +37,5 @@ grpc_proto_library(
     name = "status_proto",
     srcs = ["status.proto"],
     has_services = False,
-    well_known_protos = "@submodule_protobuf//:well_known_protos",
+    well_known_protos = "@com_google_protobuf//:well_known_protos",
 )
-
-

--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -29,6 +29,15 @@
 
 licenses(["notice"])  # 3-clause BSD
 
+# The following builds a shared-object to confirm that grpc++_unsecure
+# builds properly. Build-only is sufficient here
+cc_binary(
+    name = "testso.so",
+    srcs = [],
+    deps = ["//:grpc++_unsecure"],
+    linkshared = 1,
+)
+
 cc_library(
     name = "test_config",
     srcs = [

--- a/tools/grpcz/BUILD
+++ b/tools/grpcz/BUILD
@@ -33,30 +33,31 @@ package(default_visibility = ["//visibility:public"])
 
 load("//:bazel/grpc_build_system.bzl", "grpc_proto_library")
 
-grpc_proto_library (
+grpc_proto_library(
     name = "monitoring_proto",
     srcs = [
         "monitoring.proto",
     ],
+    well_known_protos = "@com_google_protobuf//:well_known_protos",
     deps = [
         ":census_proto",
     ],
-    well_known_protos = "@submodule_protobuf//:well_known_protos",
 )
 
-grpc_proto_library (
+grpc_proto_library(
     name = "census_proto",
     srcs = [
         "census.proto",
     ],
-    well_known_protos = "@submodule_protobuf//:well_known_protos",
+    well_known_protos = "@com_google_protobuf//:well_known_protos",
 )
 
 cc_binary(
     name = "grpcz_client",
-    srcs = ["grpcz_client.cc",],
+    srcs = ["grpcz_client.cc"],
     deps = [
-        "//external:gflags",
         "monitoring_proto",
+        "//external:gflags",
+        "@mongoose_repo//:mongoose_lib",
     ],
 )


### PR DESCRIPTION
Fixes #9714 by eliminating multiple-instantiation of the same files.

Also cleans up other bazel issues re assumed name of protobuf module
