### PR TITLE
Build for more versions of electron, restrict when a Windows warning is shown

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -507,7 +507,7 @@
         },
       ]
     }],
-    ['OS == "win"', {
+    ['OS == "win" and runtime!="electron"', {
       'targets': [
         {
           # IMPORTANT WINDOWS BUILD INFORMATION
@@ -518,6 +518,8 @@
           # when including the Node headers. The remedy for this is to remove
           # the OpenSSL headers, from the downloaded Node development package,
           # which is typically located in `.node-gyp` in your home directory.
+          #
+          # This is not true of Electron, which does not have OpenSSL headers.
           'target_name': 'WINDOWS_BUILD_WARNING',
           'rules': [
             {

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -205,7 +205,7 @@
           % endfor
         ]
       }],
-      ['OS == "win"', {
+      ['OS == "win" and runtime!="electron"', {
         'targets': [
           {
             # IMPORTANT WINDOWS BUILD INFORMATION
@@ -216,6 +216,8 @@
             # when including the Node headers. The remedy for this is to remove
             # the OpenSSL headers, from the downloaded Node development package,
             # which is typically located in `.node-gyp` in your home directory.
+            #
+            # This is not true of Electron, which does not have OpenSSL headers.
             'target_name': 'WINDOWS_BUILD_WARNING',
             'rules': [
               {

--- a/tools/run_tests/artifacts/build_artifact_node.bat
+++ b/tools/run_tests/artifacts/build_artifact_node.bat
@@ -29,7 +29,7 @@
 
 set node_versions=4.0.0 5.0.0 6.0.0 7.0.0
 
-set electron_versions=1.0.0 1.1.0 1.2.0 1.3.0 1.4.0
+set electron_versions=1.0.0 1.1.0 1.2.0 1.3.0 1.4.0 1.5.0 1.6.0
 
 set PATH=%PATH%;C:\Program Files\nodejs\;%APPDATA%\npm
 

--- a/tools/run_tests/artifacts/build_artifact_node.sh
+++ b/tools/run_tests/artifacts/build_artifact_node.sh
@@ -44,7 +44,7 @@ npm update
 
 node_versions=( 4.0.0 5.0.0 6.0.0 7.0.0 )
 
-electron_versions=( 1.0.0 1.1.0 1.2.0 1.3.0 1.4.0 )
+electron_versions=( 1.0.0 1.1.0 1.2.0 1.3.0 1.4.0 1.5.0 1.6.0 )
 
 for version in ${node_versions[@]}
 do

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -429,7 +429,7 @@ class NodeLanguage(object):
     # we should specify in the compiler argument
     _check_compiler(self.args.compiler, ['default', 'node0.12',
                                          'node4', 'node5', 'node6',
-                                         'node7', 'electron1.3'])
+                                         'node7', 'electron1.3', 'electron1.6'])
     if args.iomgr_platform == "uv":
       self.use_uv = True
     else:
@@ -1178,7 +1178,7 @@ argp.add_argument('--compiler',
                            'vs2013', 'vs2015',
                            'python2.7', 'python3.4', 'python3.5', 'python3.6', 'pypy', 'pypy3', 'python_alpine',
                            'node0.12', 'node4', 'node5', 'node6', 'node7',
-                           'electron1.3',
+                           'electron1.3', 'electron1.6',
                            'coreclr',
                            'cmake'],
                   default='default',

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -287,7 +287,8 @@ def _create_portability_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS)
                               configs=['dbg'],
                               platforms=['linux'],
                               arch='default',
-                              compiler='electron1.3',
+                              compiler='electron1.6',
+                              iomgr_platform='uv',
                               labels=['portability'],
                               extra_args=extra_args,
                               inner_jobs=inner_jobs)


### PR DESCRIPTION
This makes a couple of Electron related changes:

 - Build artifacts for Electron 1.5 and 1.6 and change the portability test to test against 1.6.
 - Modify a warning in the gyp file for building on Windows to not show when building for Electron, because it isn't relevant then.