### PR TITLE
fix metadata-related memory leaks in ruby

### DIFF
--- a/src/ruby/ext/grpc/rb_call.h
+++ b/src/ruby/ext/grpc/rb_call.h
@@ -56,6 +56,8 @@ VALUE grpc_rb_md_ary_to_h(grpc_metadata_array *md_ary);
 void grpc_rb_md_ary_convert(VALUE md_ary_hash,
                             grpc_metadata_array *md_ary);
 
+void grpc_rb_metadata_array_destroy_including_entries(grpc_metadata_array *md_ary);
+
 /* grpc_rb_eCallError is the ruby class of the exception thrown during call
    operations. */
 extern VALUE grpc_rb_eCallError;

--- a/src/ruby/ext/grpc/rb_call_credentials.c
+++ b/src/ruby/ext/grpc/rb_call_credentials.c
@@ -124,7 +124,7 @@ static void grpc_rb_call_credentials_callback_with_gil(void *param) {
   error_details = StringValueCStr(details);
   params->callback(params->user_data, md_ary.metadata, md_ary.count, status,
                    error_details);
-  grpc_metadata_array_destroy(&md_ary);
+  grpc_rb_metadata_array_destroy_including_entries(&md_ary);
   gpr_free(params);
 }
 


### PR DESCRIPTION
prompted by https://github.com/GoogleCloudPlatform/google-cloud-ruby/issues/1421

running below under a build from tip of `v12x` branch:
 
```
require "google/cloud/datastore

  datastore = Google::Cloud::Datastore.new(...)
  
  task = datastore.entity "...", "..." do |t|
    t["email"] = "...."
    t["name"] = "..."
    t["enabled"] = ...
  end

  datastore.save task
```

with `valgrind memcheck leak-check-full` showed:

```
==4306== 52 bytes in 1 blocks are definitely lost in loss record 11,167 of 19,348
==4306==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==4306==    by 0xD810AB2: gpr_malloc (alloc.c:71)
==4306==    by 0xD7E333D: grpc_slice_malloc (slice.c:243)
==4306==    by 0xD7E320B: grpc_slice_from_copied_buffer (slice.c:200)
==4306==    by 0xD7C84C0: grpc_rb_md_ary_fill_hash_cb (rb_call.c:396)
==4306==    by 0x4F01EC8: hash_foreach_iter (hash.c:356)
==4306==    by 0x4FD7C7A: st_general_foreach (st.c:1465)
==4306==    by 0x4FD7C7A: st_foreach_check (st.c:1536)
==4306==    by 0x4F01E6E: hash_foreach_call (hash.c:395)
==4306==    by 0x4EE5297: rb_ensure (eval.c:926)
==4306==    by 0x4F04345: rb_hash_foreach (hash.c:412)
==4306==    by 0xD7C8B17: grpc_rb_md_ary_convert (rb_call.c:495)
==4306==    by 0xD7C92CD: grpc_run_batch_stack_fill_ops (rb_call.c:672)

...

 ==4306== 126 bytes in 2 blocks are definitely lost in loss record 15,017 of 19,348
 ==4306==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
 ==4306==    by 0xD810AB2: gpr_malloc (alloc.c:71)
 ==4306==    by 0xD7E333D: grpc_slice_malloc (slice.c:243)
 ==4306==    by 0xD7E320B: grpc_slice_from_copied_buffer (slice.c:200)
 ==4306==    by 0xD7C881F: grpc_rb_md_ary_fill_hash_cb (rb_call.c:431)
 ==4306==    by 0x4F01EC8: hash_foreach_iter (hash.c:356)
 ==4306==    by 0x4FD7C7A: st_general_foreach (st.c:1465)
 ==4306==    by 0x4FD7C7A: st_foreach_check (st.c:1536)
 ==4306==    by 0x4F01E6E: hash_foreach_call (hash.c:395)
 ==4306==    by 0x4EE5297: rb_ensure (eval.c:926)
 ==4306==    by 0x4F04345: rb_hash_foreach (hash.c:412)
 ==4306==    by 0xD7C8B17: grpc_rb_md_ary_convert (rb_call.c:495)
 ==4306==    by 0xD7C92CD: grpc_run_batch_stack_fill_ops (rb_call.c:672)

...

 ==4306== 249 bytes in 2 blocks are definitely lost in loss record 16,724 of 19,348
 ==4306==    at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
 ==4306==    by 0xD810AB2: gpr_malloc (alloc.c:71)
 ==4306==    by 0xD7E333D: grpc_slice_malloc (slice.c:243)
 ==4306==    by 0xD7E320B: grpc_slice_from_copied_buffer (slice.c:200)
 ==4306==    by 0xD7C881F: grpc_rb_md_ary_fill_hash_cb (rb_call.c:431)
 ==4306==    by 0x4F01EC8: hash_foreach_iter (hash.c:356)
 ==4306==    by 0x4FD7C7A: st_general_foreach (st.c:1465)
 ==4306==    by 0x4FD7C7A: st_foreach_check (st.c:1536)
 ==4306==    by 0x4F01E6E: hash_foreach_call (hash.c:395)
 ==4306==    by 0x4EE5297: rb_ensure (eval.c:926)
 ==4306==    by 0x4F04345: rb_hash_foreach (hash.c:412)
 ==4306==    by 0xD7C8B17: grpc_rb_md_ary_convert (rb_call.c:495)
 ==4306==    by 0xD7CAAE2: grpc_rb_call_credentials_callback_with_gil (rb_call_credentials.c:1
```