### PR TITLE
Fix race in setting handler in tests.

### DIFF
--- a/src/csharp/Grpc.Core.Tests/AppDomainUnloadTest.cs
+++ b/src/csharp/Grpc.Core.Tests/AppDomainUnloadTest.cs
@@ -72,16 +72,16 @@ namespace Grpc.Core.Tests
             public AppDomainTestClass()
             {
                 var helper = new MockServiceHelper(Host);
-                var server = helper.GetServer();
-                server.Start();
-                var channel = helper.GetChannel();
-
                 var readyToShutdown = new TaskCompletionSource<object>();
                 helper.DuplexStreamingHandler = new DuplexStreamingServerMethod<string, string>(async (requestStream, responseStream, context) =>
                 {
                     readyToShutdown.SetResult(null);
                     await requestStream.ToListAsync();
                 });
+
+                var server = helper.GetServer();
+                server.Start();
+                var channel = helper.GetChannel();
 
                 var call = Calls.AsyncDuplexStreamingCall(helper.CreateDuplexStreamingCall());
                 readyToShutdown.Task.Wait();  // make sure handler is running

--- a/src/csharp/Grpc.Core.Tests/UserAgentStringTest.cs
+++ b/src/csharp/Grpc.Core.Tests/UserAgentStringTest.cs
@@ -63,10 +63,6 @@ namespace Grpc.Core.Tests
         public void DefaultUserAgentString()
         {
             helper = new MockServiceHelper(Host);
-            server = helper.GetServer();
-            server.Start();
-            channel = helper.GetChannel();
-
             helper.UnaryHandler = new UnaryServerMethod<string, string>((request, context) =>
             {
                 var userAgentString = context.RequestHeaders.First(m => (m.Key == "user-agent")).Value;
@@ -75,6 +71,11 @@ namespace Grpc.Core.Tests
                 Assert.IsTrue(parts[1].StartsWith("grpc-c/"));
                 return Task.FromResult("PASS");
             });
+
+            server = helper.GetServer();
+            server.Start();
+            channel = helper.GetChannel();
+
             Assert.AreEqual("PASS", Calls.BlockingUnaryCall(helper.CreateUnaryCall(), ""));
         }
 
@@ -83,11 +84,6 @@ namespace Grpc.Core.Tests
         {
             helper = new MockServiceHelper(Host,
                 channelOptions: new[] { new ChannelOption(ChannelOptions.PrimaryUserAgentString, "XYZ") });
-            server = helper.GetServer();
-            server.Start();
-            channel = helper.GetChannel();
-            
-            channel = helper.GetChannel();
             helper.UnaryHandler = new UnaryServerMethod<string, string>((request, context) =>
             {
                 var userAgentString = context.RequestHeaders.First(m => (m.Key == "user-agent")).Value;
@@ -95,6 +91,11 @@ namespace Grpc.Core.Tests
                 Assert.AreEqual("XYZ", parts[0]);
                 return Task.FromResult("PASS");
             });
+
+            server = helper.GetServer();
+            server.Start();
+            channel = helper.GetChannel();
+
             Assert.AreEqual("PASS", Calls.BlockingUnaryCall(helper.CreateUnaryCall(), ""));
         }
     }


### PR DESCRIPTION
Fixes #10671.

Sometimes, the MockServiceHelper's default handler gets triggered instead of the one we set. I don't fully understand why is that, but this change definitely helps reducing test flakiness (based on quite extensive local testing). The change is only in tests, so it can't really break anything.

