### PR TITLE
Include <sys/socket.h> for AF_INET

### DIFF
--- a/src/core/tsi/ssl_transport_security.c
+++ b/src/core/tsi/ssl_transport_security.c
@@ -45,6 +45,7 @@
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>
+#include <sys/socket.h>
 #endif
 
 #include <grpc/support/alloc.h>


### PR DESCRIPTION
Compilation fails on FreeBSD because not all POSIX compliant systems end up including `AF_INET` from other header files transitively.

`AF_INET` and `AF_INET6` should be provided by `<sys/socket.h>`.

This PR fixes one of the root causes leading to #9721, though I consider this a more general POSIX correctness issue rather than a FreeBSD-specific issue.