### PR TITLE
Thread manager fixes/refactoring

### DIFF
--- a/include/grpc++/server_builder.h
+++ b/include/grpc++/server_builder.h
@@ -195,10 +195,7 @@ class ServerBuilder {
 
   struct SyncServerSettings {
     SyncServerSettings()
-        : num_cqs(1),
-          min_pollers(1),
-          max_pollers(2),
-          cq_timeout_msec(10000) {}
+        : num_cqs(1), min_pollers(1), max_pollers(2), cq_timeout_msec(10000) {}
 
     // Number of server completion queues to create to listen to incoming RPCs.
     int num_cqs;

--- a/include/grpc++/server_builder.h
+++ b/include/grpc++/server_builder.h
@@ -197,8 +197,8 @@ class ServerBuilder {
     SyncServerSettings()
         : num_cqs(1),
           min_pollers(1),
-          max_pollers(INT_MAX),
-          cq_timeout_msec(1000) {}
+          max_pollers(2),
+          cq_timeout_msec(10000) {}
 
     // Number of server completion queues to create to listen to incoming RPCs.
     int num_cqs;

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -330,7 +330,17 @@ class Server::SyncRequestThreadManager : public ThreadManager {
 
   void Shutdown() override {
     server_cq_->Shutdown();
-ThreadManager::Shutdown();
+    ThreadManager::Shutdown();
+  }
+
+  void Wait() override {
+    ThreadManager::Wait();
+    // Drain any pending items from the queue
+    void* tag;
+    bool ok;
+    while (server_cq_->Next(&tag, &ok)) {
+      // Do nothing
+    }
   }
 
   void Start() {

--- a/src/cpp/thread_manager/thread_manager.cc
+++ b/src/cpp/thread_manager/thread_manager.cc
@@ -159,15 +159,15 @@ void ThreadManager::MainWorkLoop() {
         // Take the lock again to check post conditions
         lock.lock();
         // If we're shutdown, we should finish at this point.
-        // If not, there's a chance that we'll exceed the max poller count: that
-        // is explicitly ok - we'll decrease after one poll timeout, and prevent
-        // some thrashing starting up and shutting down threads
         if (shutdown_) done = true;
         break;
     }
     // If we decided to finish the thread, break out of the while loop
     if (done) break;
     // ... otherwise increase poller count and continue
+    // There's a chance that we'll exceed the max poller count: that is
+    // explicitly ok - we'll decrease after one poll timeout, and prevent
+    // some thrashing starting up and shutting down threads
     num_pollers_++;
   };
 

--- a/src/cpp/thread_manager/thread_manager.h
+++ b/src/cpp/thread_manager/thread_manager.h
@@ -122,10 +122,6 @@ class ThreadManager {
   // The main funtion in ThreadManager
   void MainWorkLoop();
 
-  // Create a new poller if the number of current pollers is less than the
-  // minimum number of pollers needed (i.e min_pollers).
-  void MaybeCreatePoller();
-
   void MarkAsCompleted(WorkerThread* thd);
   void CleanupCompletedThreads();
 

--- a/src/cpp/thread_manager/thread_manager.h
+++ b/src/cpp/thread_manager/thread_manager.h
@@ -96,7 +96,7 @@ class ThreadManager {
 
   // A blocking call that returns only after the ThreadManager has shutdown and
   // all the threads have drained all the outstanding work
-  void Wait();
+  virtual void Wait();
 
  private:
   // Helper wrapper class around std::thread. This takes a ThreadManager object
@@ -125,10 +125,6 @@ class ThreadManager {
   // Create a new poller if the number of current pollers is less than the
   // minimum number of pollers needed (i.e min_pollers).
   void MaybeCreatePoller();
-
-  // Returns true if the current thread can resume as a poller. i.e if the
-  // current number of pollers is less than the max_pollers.
-  bool MaybeContinueAsPoller(bool work_found);
 
   void MarkAsCompleted(WorkerThread* thd);
   void CleanupCompletedThreads();

--- a/src/cpp/thread_manager/thread_manager.h
+++ b/src/cpp/thread_manager/thread_manager.h
@@ -89,7 +89,7 @@ class ThreadManager {
   // Mark the ThreadManager as shutdown and begin draining the work. This is a
   // non-blocking call and the caller should call Wait(), a blocking call which
   // returns only once the shutdown is complete
-  void Shutdown();
+  virtual void Shutdown();
 
   // Has Shutdown() been called
   bool IsShutdown();
@@ -128,7 +128,7 @@ class ThreadManager {
 
   // Returns true if the current thread can resume as a poller. i.e if the
   // current number of pollers is less than the max_pollers.
-  bool MaybeContinueAsPoller();
+  bool MaybeContinueAsPoller(bool work_found);
 
   void MarkAsCompleted(WorkerThread* thd);
   void CleanupCompletedThreads();


### PR DESCRIPTION
- Fix a case whereby we waited one full cq timeout before ending a thread
- Pull down max_pollers to a more reasonable number
- Increase CQ timeout to avoid thrashing (since we can now)
- Avoid holding a lock whilst spawning threads (this was leading to large contention)
- Be lazier about getting below max threads to avoid thrashing
- Combine control logic into one function to make it easier to inspect at a glance