### PR TITLE
fix bazel build for osx

### DIFF
--- a/third_party/cares/cares.BUILD
+++ b/third_party/cares/cares.BUILD
@@ -1,3 +1,8 @@
+config_setting(
+    name = "darwin",
+    values = {"cpu": "darwin"},
+)
+
 cc_library(
     name = "ares",
     srcs = [
@@ -53,7 +58,6 @@ cc_library(
     ],
     hdrs = [
         "ares_build.h",
-        "config_linux/ares_config.h",
         "cares/ares.h",
         "cares/ares_data.h",
         "cares/ares_dns.h",
@@ -75,12 +79,17 @@ cc_library(
         "cares/bitncmp.h",
         "cares/config-win32.h",
         "cares/setup_once.h",
-    ],
+    ] + select({
+        ":darwin": ["config_darwin/ares_config.h"],
+        "//conditions:default": ["config_linux/ares_config.h"],
+    }),
     includes = [
         ".",
-        "config_linux",
-        "cares",
-    ],
+        "cares"
+    ] + select({
+        ":darwin": ["config_darwin"],
+        "//conditions:default": ["config_linux"],
+    }),
     linkstatic = 1,
     visibility = [
         "//visibility:public",


### PR DESCRIPTION
add config setting for building c-ares on osx