### PR TITLE
Node: Don't depend on cares npm package

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -569,7 +569,6 @@
     }]
   ],
   'targets': [
-
     {
       'cflags': [
         '-std=c99',
@@ -648,7 +647,6 @@
       'type': 'static_library',
       'dependencies': [
         'gpr',
-        'node_modules/cares/deps/cares/cares.gyp:cares',
       ],
       'sources': [
         'src/core/lib/surface/init.c',
@@ -951,7 +949,6 @@
       "dependencies": [
         "grpc",
         "gpr",
-        "node_modules/cares/deps/cares/cares.gyp:cares",
       ]
     },
     {

--- a/binding.gyp
+++ b/binding.gyp
@@ -535,6 +535,10 @@
             }
           ]
         },
+      ]
+    }],
+    ['OS == "win"', {
+      'targets': [
         # Only want to compile zlib under Windows
         {
           'cflags': [

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "lodash": "^4.15.0",
     "nan": "^2.0.0",
     "node-pre-gyp": "^0.6.0",
-    "protobufjs": "^6.7.0",
-    "cares": "^1.1.5"
+    "protobufjs": "^6.7.0"
   },
   "devDependencies": {
     "async": "^2.0.1",

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -233,6 +233,10 @@
               }
             ]
           },
+        ]
+      }],
+      ['OS == "win"', {
+        'targets': [
           # Only want to compile zlib under Windows
           % for module in node_modules:
           % for lib in libs:

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -264,13 +264,6 @@
       }]
     ],
     'targets': [
-  <%
-      for lib in libs:
-        if 'grpc' in lib.transitive_deps or lib.name == 'grpc':
-          lib.deps.append('node_modules/cares/deps/cares/cares.gyp:cares')
-      for module in node_modules:
-        module.deps.append('node_modules/cares/deps/cares/cares.gyp:cares')
-  %>
       % for module in node_modules:
       % for lib in libs:
       % if lib.name in module.transitive_deps and lib.name not in ('boringssl', 'z'):

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -36,8 +36,7 @@
       "lodash": "^4.15.0",
       "nan": "^2.0.0",
       "node-pre-gyp": "^0.6.0",
-      "protobufjs": "^6.7.0",
-      "cares": "^1.1.5"
+      "protobufjs": "^6.7.0"
     },
     "devDependencies": {
       "async": "^2.0.1",


### PR DESCRIPTION
This fixes the Node 32 bit Linux artifact build: https://grpc-testing.appspot.com/view/Artifacts/job/gRPC_build_artifacts/3256/

This also should fix Windows build, which was broken by #10652.