### PR TITLE
Removing cipher suites blacklisted in HTTP2.

### DIFF
--- a/src/core/lib/security/transport/security_connector.c
+++ b/src/core/lib/security/transport/security_connector.c
@@ -79,8 +79,7 @@ void grpc_set_ssl_roots_override_callback(grpc_ssl_roots_override_callback cb) {
 /* Defines the cipher suites that we accept by default. All these cipher suites
    are compliant with HTTP2. */
 #define GRPC_SSL_CIPHER_SUITES                                            \
-  "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-" \
-  "SHA384:ECDHE-RSA-AES256-GCM-SHA384"
+  "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384"
 
 static gpr_once cipher_suites_once = GPR_ONCE_INIT;
 static const char *cipher_suites = NULL;


### PR DESCRIPTION
See http://httpwg.org/specs/rfc7540.html#BadCipherSuites