### PR TITLE
Build tests with generic iOS device

### DIFF
--- a/src/objective-c/tests/build_one_example.sh
+++ b/src/objective-c/tests/build_one_example.sh
@@ -57,4 +57,4 @@ xcodebuild \
     build \
     -workspace *.xcworkspace \
     -scheme $SCHEME \
-    -destination name="iPhone 6" | xcpretty
+    -sdk iphoneos | xcpretty


### PR DESCRIPTION
Build tests on generic iOS devices instead of emulator. This helps capture problems that only appears on ARM architecture (e.g. #10689).