### PR TITLE
Fix test filtering for C/C++ 

### DIFF
--- a/tools/jenkins/run_c_cpp_test.sh
+++ b/tools/jenkins/run_c_cpp_test.sh
@@ -35,10 +35,12 @@ set -ex
 # Enter the gRPC repo root
 cd $(dirname $0)/../..
 
-AFFECTS_C_CPP=`python -c 'import sys; \
+AFFECTS_C_CPP=`python -c 'import os; \
+               import sys; \
                sys.path.insert(0, "tools/run_tests/python_utils"); \
                import filter_pull_request_tests as filter; \
-               print(filter.affects_c_cpp("origin/$ghprbTargetBranch"))'`
+               github_target_branch = os.environ.get("ghprbTargetBranch"); \
+               print(filter.affects_c_cpp("origin/%s" % github_target_branch))'`
 
 if [ $AFFECTS_C_CPP == "False" ] ; then
   echo "This pull request does not affect C/C++. Tests do not need to be run."


### PR DESCRIPTION
Python embedded into a shell script can't access environment variables with `$var`