### PR TITLE
fix: while using eventfd, a random fd will be closed when error occurs during creating eventfd

### DIFF
--- a/src/core/lib/iomgr/wakeup_fd_eventfd.cc
+++ b/src/core/lib/iomgr/wakeup_fd_eventfd.cc
@@ -32,12 +32,11 @@
 #include "src/core/lib/profiling/timers.h"
 
 static grpc_error* eventfd_create(grpc_wakeup_fd* fd_info) {
-  int efd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
-  if (efd < 0) {
+  fd_info->read_fd = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+  fd_info->write_fd = -1;
+  if (fd_info->read_fd < 0) {
     return GRPC_OS_ERROR(errno, "eventfd");
   }
-  fd_info->read_fd = efd;
-  fd_info->write_fd = -1;
   return GRPC_ERROR_NONE;
 }
 


### PR DESCRIPTION
read_fd should have a certain value when create error occurs, because `polling_island_delete()` will be invoked when error occurs, and a random fd will be closed. in my practice, a working fd might closed due to the magic random value.