### PR TITLE
Added verbose option to run_interop_test to ease tracing the commands…

### DIFF
--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -208,6 +208,11 @@ class JobSpec(object):
   def __repr__(self):
     return 'JobSpec(shortname=%s, cmdline=%s)' % (self.shortname, self.cmdline)
 
+  def __str__(self):
+    return '%s: %s %s' % (self.shortname,
+                          ' '.join('%s=%s' % kv for kv in self.environ.items()),
+                          ' '.join(self.cmdline))
+
 
 class JobResult(object):
   def __init__(self):

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -888,6 +888,10 @@ argp.add_argument('-t', '--travis',
                   default=False,
                   action='store_const',
                   const=True)
+argp.add_argument('-v', '--verbose',
+                  default=False,
+                  action='store_const',
+                  const=True)
 argp.add_argument('--use_docker',
                   default=False,
                   action='store_const',
@@ -989,6 +993,9 @@ if args.use_docker:
 
   if build_jobs:
     jobset.message('START', 'Building interop docker images.', do_newline=True)
+    if args.verbose:
+      print('Jobs to run: \n%s\n' % '\n'.join(str(j) for j in build_jobs))
+
     num_failures, _ = jobset.run(
         build_jobs, newline_on_success=True, maxjobs=args.jobs)
     if num_failures == 0:
@@ -1163,6 +1170,9 @@ try:
 
   if args.manual_run:
     print('All tests will skipped --manual_run option is active.')
+
+  if args.verbose:
+    print('Jobs to run: \n%s\n' % '\n'.join(str(job) for job in jobs))
 
   num_failures, resultset = jobset.run(jobs, newline_on_success=True,
                                        maxjobs=args.jobs,


### PR DESCRIPTION
… invoked

Sample output

yongni@canaan:~/github/grpc/tools/run_tests$ ./run_interop_tests.py -l java --use_docker -v --cloud_to_prod --manual_run
Seen --use_docker flag, will run interop tests under docker.

IMPORTANT: The changes you are testing need to be locally committed
because only the committed changes in the current branch will be
copied to the docker environment.
START: Building interop docker images.
**Jobs to run: 
build_docker_java: TTY_FLAG=-t INTEROP_IMAGE=grpc_interop_java:c902c076-12fa-46ce-9032-f045e584045b BASE_NAME=grpc_interop_java tools/run_tests/dockerize/build_interop_image.sh**

PASSED: build_docker_java [time=37.3sec; retries=0:0]
SUCCESS: All docker images built successfully.
All tests will skipped --manual_run option is active.
**Jobs to run: 
cloud_to_prod:default:java:large_unary:  docker run -i --rm=true -w /var/local/git/grpc/../grpc-java --net=host --name=interop_client_java_84ee44de-8c4d-4d85-97f6-f0cc28862134 grpc_interop_java:c902c076-12fa-46ce-9032-f045e584045b bash -c ./run-test-client.sh --server_host=216.239.32.254 --server_host_override=grpc-test.sandbox.googleapis.com --server_port=443 --use_tls=true --test_case=large_unary
cloud_to_prod:default:java:empty_unary:  docker run -i --rm=true -w /var/local/git/grpc/../grpc-java --net=host --name=interop_client_java_64244d49-b815-4977-9134-c18aa5464369 grpc_interop_java:c902c076-12fa-46ce-9032-f045e584045b bash -c ./run-test-client.sh --server_host=216.239.32.254 --server_host_override=grpc-test.sandbox.googleapis.com --server_port=443 --use_tls=true --test_case=empty_unary
cloud_to_prod:default:java:ping_pong:  docker run -i --rm=true -w /var/local/git/grpc/../grpc-java --net=host --name=interop_client_java_806df682-d426-4c48-bcc9-874b9e3e74dd grpc_interop_java:c902c076-12fa-46ce-9032-f045e584045b bash -c ./run-test-client.sh --server_host=216.239.32.254 --server_host_override=grpc-test.sandbox.googleapis.com --server_port=443 --use_tls=true --test_case=ping_pong
cloud_to_prod:default:java:empty_stream:  docker run -i --rm=true -w /var/local/git/grpc/../grpc-java --net=host --name=interop_client_java_803f4db4-fb90-4286-86e8-676bb40b3629 grpc_interop_java:c902c076-12fa-46ce-9032-f045e584045b bash -c ./run-test-client.sh --server_host=216.239.32.254 --server_host_override=grpc-test.sandbox.googleapis.com --server_port=443 --use_tls=true --test_case=empty_stream
cloud_to_prod:default:java:client_streaming:  docker run -i --rm=true -w /var/local/git/grpc/../grpc-java --net=host --name=interop_client_java_62800952-f465-4f4f-8208-cfb74bbbf3c6 grpc_interop_java:c902c076-12fa-46ce-9032-f045e584045b bash -c ./run-test-client.sh --server_host=216.239.32.254 --server_host_override=grpc-test.sandbox.googleapis.com --server_port=443 --use_tls=true --test_case=client_streaming
cloud_to_prod:default:java:server_streaming:  docker run -i --rm=true -w /var/local/git/grpc/../grpc-java --net=host --name=interop_client_java_6ae44bf2-7363-40aa-a558-aa7e92df45b6 grpc_interop_java:c902c076-12fa-46ce-9032-f045e584045b bash -c ./run-test-client.sh --server_host=216.239.32.254 --server_host_override=grpc-test.sandbox.googleapis.com --server_port=443 --use_tls=true --test_case=server_streaming
cloud_to_prod:default:java:cancel_after_begin:  docker run -i --rm=true -w /var/local/git/grpc/../grpc-java --net=host --name=interop_client_java_4019fa09-85ad-4f06-bcd1-940b124e62ce grpc_interop_java:c902c076-12fa-46ce-9032-f045e584045b bash -c ./run-test-client.sh --server_host=216.239.32.254 --server_host_override=grpc-test.sandbox.googleapis.com --server_port=443 --use_tls=true --test_case=cancel_after_begin
cloud_to_prod:default:java:cancel_after_first_response:  docker run -i --rm=true -w /var/local/git/grpc/../grpc-java --net=host --name=interop_client_java_9bfac72c-e29f-46f0-b555-357dde29e34d grpc_interop_java:c902c076-12fa-46ce-9032-f045e584045b bash -c ./run-test-client.sh --server_host=216.239.32.254 --server_host_override=grpc-test.sandbox.googleapis.com --server_port=443 --use_tls=true --test_case=cancel_after_first_response
cloud_to_prod:default:java:timeout_on_sleeping_server:  docker run -i --rm=true -w /var/local/git/grpc/../grpc-java --net=host --name=interop_client_java_150d2b41-6c20-4d0b-8af3-f98233c702be grpc_interop_java:c902c076-12fa-46ce-9032-f045e584045b bash -c ./run-test-client.sh --server_host=216.239.32.254 --server_host_override=grpc-test.sandbox.googleapis.com --server_port=443 --use_tls=true --test_case=timeout_on_sleeping_server**

SKIPPED: cloud_to_prod:default:java:large_unary
SKIPPED: cloud_to_prod:default:java:empty_unary
SKIPPED: cloud_to_prod:default:java:ping_pong
SKIPPED: cloud_to_prod:default:java:empty_stream
SKIPPED: cloud_to_prod:default:java:client_streaming
SKIPPED: cloud_to_prod:default:java:server_streaming
SKIPPED: cloud_to_prod:default:java:cancel_after_begin
SKIPPED: cloud_to_prod:default:java:cancel_after_first_response
SKIPPED: cloud_to_prod:default:java:timeout_on_sleeping_server
SUCCESS: All tests passed
Command log written to file interop_client_cmds.sh
Preserving docker image: grpc_interop_java:c902c076-12fa-46ce-9032-f045e584045b
