### PR TITLE
Fix C build in Visual Studio (internal_ci)

### DIFF
--- a/tools/run_tests/helper_scripts/pre_build_c.bat
+++ b/tools/run_tests/helper_scripts/pre_build_c.bat
@@ -34,12 +34,16 @@ setlocal
 @rem enter repo root
 cd /d %~dp0\..\..\..
 
-@rem Location of nuget.exe
-set NUGET=C:\nuget\nuget.exe
+@rem Default location of nuget.exe (on Jenkins)
+set NUGET=C:\nuget\nuget.exes
 
-if exist %NUGET% (
-  %NUGET% restore vsprojects/grpc.sln || goto :error
+if NOT exist %NUGET% (
+  set NUGET=nuget
+  @rem Download nuget if not on path
+  %NUGET% || wget https://dist.nuget.org/win-x86-commandline/v2.8.6/nuget.exe
 )
+
+%NUGET% restore vsprojects/grpc.sln || goto :error
 
 endlocal
 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1055,11 +1055,10 @@ def _check_arch_option(arch):
 
 def _windows_build_bat(compiler):
   """Returns name of build.bat for selected compiler."""
-  # For CoreCLR, fall back to the default compiler for C core
-  if compiler == 'default' or compiler == 'vs2013':
-    return 'vsprojects\\build_vs2013.bat'
-  elif compiler == 'vs2015':
+  if compiler == 'default' or compiler == 'vs2015':
     return 'vsprojects\\build_vs2015.bat'
+  elif compiler == 'vs2013':
+    return 'vsprojects\\build_vs2013.bat'
   else:
     print('Compiler %s not supported.' % compiler)
     sys.exit(1)
@@ -1067,11 +1066,10 @@ def _windows_build_bat(compiler):
 
 def _windows_toolset_option(compiler):
   """Returns msbuild PlatformToolset for selected compiler."""
-  # For CoreCLR, fall back to the default compiler for C core
-  if compiler == 'default' or compiler == 'vs2013' or compiler == 'coreclr':
-    return '/p:PlatformToolset=v120'
-  elif compiler == 'vs2015':
+  if compiler == 'default' or compiler == 'vs2015':
     return '/p:PlatformToolset=v140'
+  elif compiler == 'vs2013':
+    return '/p:PlatformToolset=v120'
   else:
     print('Compiler %s not supported.' % compiler)
     sys.exit(1)


### PR DESCRIPTION
- switch default C and C++ build from VS2013 to VS2015 (this would probably happen anyway sooner or later, current cmake build is using VS2015)
- download nuget.exe to be able to restore vsprojects/grpc.sln (C build)