### PR TITLE
Fix a bug where OP_CANCEL is completed prematurely

### DIFF
--- a/src/core/ext/transport/cronet/transport/cronet_transport.c
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.c
@@ -886,6 +886,10 @@ static bool op_can_be_run(grpc_transport_stream_op_batch *curr_op,
                !stream_state->state_op_done[OP_RECV_MESSAGE]) {
       CRONET_LOG(GPR_DEBUG, "Because");
       result = false;
+    } else if (curr_op->cancel_stream &&
+               !stream_state->state_callback_received[OP_CANCELED]) {
+      CRONET_LOG(GPR_DEBUG, "Because");
+      result = false;
     } else if (curr_op->recv_trailing_metadata) {
       /* We aren't done with trailing metadata yet */
       if (!stream_state->state_op_done[OP_RECV_TRAILING_METADATA]) {


### PR DESCRIPTION
When an OP_CANCEL is issued, the associated ON_COMPLETE callback may be called prematurely because op_can_be_run function did not check if the callback for OP_CANCEL is received. This may cause on_canceled callback to run after grpc's transport stream is destroyed, thus accessing invalid memory. 