### PR TITLE
limit total number of threads

### DIFF
--- a/src/cpp/thread_manager/thread_manager.cc
+++ b/src/cpp/thread_manager/thread_manager.cc
@@ -135,7 +135,7 @@ void ThreadManager::MainWorkLoop() {
       case TIMEOUT:
         // If we timed out and we have more pollers than we need (or we are
         // shutdown), finish this thread
-        if (shutdown_ || num_pollers_ > max_pollers_) done = true;
+        if (shutdown_ || num_threads_ > min_pollers_) done = true;
         break;
       case SHUTDOWN:
         // If the thread manager is shutdown, finish this thread
@@ -144,7 +144,7 @@ void ThreadManager::MainWorkLoop() {
       case WORK_FOUND:
         // If we got work and there are now insufficient pollers, start a new
         // one
-        if (!shutdown_ && num_pollers_ < min_pollers_) {
+        if (!shutdown_ && num_threads_ < max_pollers_) {
           num_pollers_++;
           num_threads_++;
           // Drop lock before spawning thread to avoid contention


### PR DESCRIPTION
I asked a question about number of threads limit in https://groups.google.com/forum/#!topic/grpc-io/hbWKGtG9cJU and I modified it limit the total number of threads. 

I think an easier way to use and understand the MAX_POLLERS /MIN_POLLERS options is to treat them as the limit of total number of threads instead of idle threads. In this way, we can limit the number of threads and also reduce the work on creating/destroying threads. When setting MAX_POLLERS equal to MIN_POLLERS, we can use it as a  fixed-size threadpool. 