### PR TITLE
Remove 'read-notifier pollset' concept

### DIFF
--- a/src/core/lib/iomgr/ev_epoll_linux.c
+++ b/src/core/lib/iomgr/ev_epoll_linux.c
@@ -153,10 +153,6 @@ struct grpc_fd {
   struct grpc_fd *freelist_next;
   grpc_closure *on_done_closure;
 
-  /* The pollset that last noticed that the fd is readable. The actual type
-   * stored in this is (grpc_pollset *) */
-  gpr_atm read_notifier_pollset;
-
   grpc_iomgr_object iomgr_object;
 };
 
@@ -972,7 +968,6 @@ static grpc_fd *fd_create(int fd, const char *name) {
   new_fd->orphaned = false;
   grpc_lfev_init(&new_fd->read_closure);
   grpc_lfev_init(&new_fd->write_closure);
-  gpr_atm_no_barrier_store(&new_fd->read_notifier_pollset, (gpr_atm)NULL);
 
   new_fd->freelist_next = NULL;
   new_fd->on_done_closure = NULL;
@@ -1055,12 +1050,6 @@ static void fd_orphan(grpc_exec_ctx *exec_ctx, grpc_fd *fd,
   }
   GRPC_LOG_IF_ERROR("fd_orphan", GRPC_ERROR_REF(error));
   GRPC_ERROR_UNREF(error);
-}
-
-static grpc_pollset *fd_get_read_notifier_pollset(grpc_exec_ctx *exec_ctx,
-                                                  grpc_fd *fd) {
-  gpr_atm notifier = gpr_atm_acq_load(&fd->read_notifier_pollset);
-  return (grpc_pollset *)notifier;
 }
 
 static bool fd_is_shutdown(grpc_fd *fd) {
@@ -1272,17 +1261,8 @@ static int poll_deadline_to_millis_timeout(gpr_timespec deadline,
   return millis >= 1 ? millis : 1;
 }
 
-static void fd_become_readable(grpc_exec_ctx *exec_ctx, grpc_fd *fd,
-                               grpc_pollset *notifier) {
+static void fd_become_readable(grpc_exec_ctx *exec_ctx, grpc_fd *fd) {
   grpc_lfev_set_ready(exec_ctx, &fd->read_closure);
-
-  /* Note, it is possible that fd_become_readable might be called twice with
-     different 'notifier's when an fd becomes readable and it is in two epoll
-     sets (This can happen briefly during polling island merges). In such cases
-     it does not really matter which notifer is set as the read_notifier_pollset
-     (They would both point to the same polling island anyway) */
-  /* Use release store to match with acquire load in fd_get_read_notifier */
-  gpr_atm_rel_store(&fd->read_notifier_pollset, (gpr_atm)notifier);
 }
 
 static void fd_become_writable(grpc_exec_ctx *exec_ctx, grpc_fd *fd) {
@@ -1477,7 +1457,7 @@ static void pollset_work_and_unlock(grpc_exec_ctx *exec_ctx,
         int read_ev = ep_ev[i].events & (EPOLLIN | EPOLLPRI);
         int write_ev = ep_ev[i].events & EPOLLOUT;
         if (read_ev || cancel) {
-          fd_become_readable(exec_ctx, fd, pollset);
+          fd_become_readable(exec_ctx, fd);
         }
         if (write_ev || cancel) {
           fd_become_writable(exec_ctx, fd);
@@ -1878,7 +1858,6 @@ static const grpc_event_engine_vtable vtable = {
     .fd_is_shutdown = fd_is_shutdown,
     .fd_notify_on_read = fd_notify_on_read,
     .fd_notify_on_write = fd_notify_on_write,
-    .fd_get_read_notifier_pollset = fd_get_read_notifier_pollset,
     .fd_get_workqueue = fd_get_workqueue,
 
     .pollset_init = pollset_init,

--- a/src/core/lib/iomgr/ev_poll_posix.c
+++ b/src/core/lib/iomgr/ev_poll_posix.c
@@ -117,9 +117,6 @@ struct grpc_fd {
   grpc_closure *on_done_closure;
 
   grpc_iomgr_object iomgr_object;
-
-  /* The pollset that last noticed and notified that the fd is readable */
-  grpc_pollset *read_notifier_pollset;
 };
 
 static grpc_wakeup_fd global_wakeup_fd;
@@ -143,8 +140,7 @@ static uint32_t fd_begin_poll(grpc_fd *fd, grpc_pollset *pollset,
    if got_read or got_write are 1, also does the become_{readable,writable} as
    appropriate. */
 static void fd_end_poll(grpc_exec_ctx *exec_ctx, grpc_fd_watcher *rec,
-                        int got_read, int got_write,
-                        grpc_pollset *read_notifier_pollset);
+                        int got_read, int got_write);
 
 /* Return 1 if this fd is orphaned, 0 otherwise */
 static bool fd_is_orphaned(grpc_fd *fd);
@@ -330,7 +326,6 @@ static grpc_fd *fd_create(int fd, const char *name) {
   r->on_done_closure = NULL;
   r->closed = 0;
   r->released = 0;
-  r->read_notifier_pollset = NULL;
 
   char *name2;
   gpr_asprintf(&name2, "%s fd=%d", name, fd);
@@ -344,18 +339,6 @@ static grpc_fd *fd_create(int fd, const char *name) {
 
 static bool fd_is_orphaned(grpc_fd *fd) {
   return (gpr_atm_acq_load(&fd->refst) & 1) == 0;
-}
-
-/* Return the read-notifier pollset */
-static grpc_pollset *fd_get_read_notifier_pollset(grpc_exec_ctx *exec_ctx,
-                                                  grpc_fd *fd) {
-  grpc_pollset *notifier = NULL;
-
-  gpr_mu_lock(&fd->mu);
-  notifier = fd->read_notifier_pollset;
-  gpr_mu_unlock(&fd->mu);
-
-  return notifier;
 }
 
 static grpc_error *pollset_kick_locked(grpc_fd_watcher *watcher) {
@@ -497,11 +480,6 @@ static int set_ready_locked(grpc_exec_ctx *exec_ctx, grpc_fd *fd,
   }
 }
 
-static void set_read_notifier_pollset_locked(
-    grpc_exec_ctx *exec_ctx, grpc_fd *fd, grpc_pollset *read_notifier_pollset) {
-  fd->read_notifier_pollset = read_notifier_pollset;
-}
-
 static void fd_shutdown(grpc_exec_ctx *exec_ctx, grpc_fd *fd, grpc_error *why) {
   gpr_mu_lock(&fd->mu);
   /* only shutdown once */
@@ -591,8 +569,7 @@ static uint32_t fd_begin_poll(grpc_fd *fd, grpc_pollset *pollset,
 }
 
 static void fd_end_poll(grpc_exec_ctx *exec_ctx, grpc_fd_watcher *watcher,
-                        int got_read, int got_write,
-                        grpc_pollset *read_notifier_pollset) {
+                        int got_read, int got_write) {
   int was_polling = 0;
   int kick = 0;
   grpc_fd *fd = watcher->fd;
@@ -627,9 +604,6 @@ static void fd_end_poll(grpc_exec_ctx *exec_ctx, grpc_fd_watcher *watcher,
   if (got_read) {
     if (set_ready_locked(exec_ctx, fd, &fd->read_closure)) {
       kick = 1;
-    }
-    if (read_notifier_pollset != NULL) {
-      set_read_notifier_pollset_locked(exec_ctx, fd, read_notifier_pollset);
     }
   }
   if (got_write) {
@@ -994,16 +968,16 @@ static grpc_error *pollset_work(grpc_exec_ctx *exec_ctx, grpc_pollset *pollset,
 
         for (i = 2; i < pfd_count; i++) {
           if (watchers[i].fd == NULL) {
-            fd_end_poll(exec_ctx, &watchers[i], 0, 0, NULL);
+            fd_end_poll(exec_ctx, &watchers[i], 0, 0);
           } else {
             // Wake up all the file descriptors, if we have an invalid one
             // we can identify it on the next pollset_work()
-            fd_end_poll(exec_ctx, &watchers[i], 1, 1, pollset);
+            fd_end_poll(exec_ctx, &watchers[i], 1, 1);
           }
         }
       } else if (r == 0) {
         for (i = 2; i < pfd_count; i++) {
-          fd_end_poll(exec_ctx, &watchers[i], 0, 0, NULL);
+          fd_end_poll(exec_ctx, &watchers[i], 0, 0);
         }
       } else {
         if (pfds[0].revents & POLLIN_CHECK) {
@@ -1017,10 +991,10 @@ static grpc_error *pollset_work(grpc_exec_ctx *exec_ctx, grpc_pollset *pollset,
         }
         for (i = 2; i < pfd_count; i++) {
           if (watchers[i].fd == NULL) {
-            fd_end_poll(exec_ctx, &watchers[i], 0, 0, NULL);
+            fd_end_poll(exec_ctx, &watchers[i], 0, 0);
           } else {
             fd_end_poll(exec_ctx, &watchers[i], pfds[i].revents & POLLIN_CHECK,
-                        pfds[i].revents & POLLOUT_CHECK, pollset);
+                        pfds[i].revents & POLLOUT_CHECK);
           }
         }
       }
@@ -1541,7 +1515,6 @@ static const grpc_event_engine_vtable vtable = {
     .fd_is_shutdown = fd_is_shutdown,
     .fd_notify_on_read = fd_notify_on_read,
     .fd_notify_on_write = fd_notify_on_write,
-    .fd_get_read_notifier_pollset = fd_get_read_notifier_pollset,
     .fd_get_workqueue = fd_get_workqueue,
 
     .pollset_init = pollset_init,

--- a/src/core/lib/iomgr/ev_posix.h
+++ b/src/core/lib/iomgr/ev_posix.h
@@ -58,8 +58,6 @@ typedef struct grpc_event_engine_vtable {
                              grpc_closure *closure);
   bool (*fd_is_shutdown)(grpc_fd *fd);
   grpc_workqueue *(*fd_get_workqueue)(grpc_fd *fd);
-  grpc_pollset *(*fd_get_read_notifier_pollset)(grpc_exec_ctx *exec_ctx,
-                                                grpc_fd *fd);
 
   void (*pollset_init)(grpc_pollset *pollset, gpr_mu **mu);
   void (*pollset_shutdown)(grpc_exec_ctx *exec_ctx, grpc_pollset *pollset,
@@ -161,10 +159,6 @@ void grpc_fd_notify_on_read(grpc_exec_ctx *exec_ctx, grpc_fd *fd,
 /* Exactly the same semantics as above, except based on writable events.  */
 void grpc_fd_notify_on_write(grpc_exec_ctx *exec_ctx, grpc_fd *fd,
                              grpc_closure *closure);
-
-/* Return the read notifier pollset from the fd */
-grpc_pollset *grpc_fd_get_read_notifier_pollset(grpc_exec_ctx *exec_ctx,
-                                                grpc_fd *fd);
 
 /* pollset_posix functions */
 


### PR DESCRIPTION
read-notifier pollsets are not used any more. Remove dead-code from polling engines