### PR TITLE
Improve XML reports for internal_ci.

### DIFF
--- a/tools/run_tests/python_utils/report_utils.py
+++ b/tools/run_tests/python_utils/report_utils.py
@@ -64,6 +64,8 @@ def render_junit_xml_report(resultset, xml_report, suite_package='grpc',
   root = ET.Element('testsuites')
   testsuite = ET.SubElement(root, 'testsuite', id='1', package=suite_package,
                             name=suite_name)
+  failure_count  = 0
+  error_count = 0
   for shortname, results in six.iteritems(resultset):
     for result in results:
       xml_test = ET.SubElement(testsuite, 'testcase', name=shortname)
@@ -73,10 +75,14 @@ def render_junit_xml_report(resultset, xml_report, suite_package='grpc',
                                                                'XML')
       if result.state == 'FAILED':
         ET.SubElement(xml_test, 'failure', message='Failure')
+        failure_count += 1
       elif result.state == 'TIMEOUT':
         ET.SubElement(xml_test, 'error', message='Timeout')
+        error_count += 1
       elif result.state == 'SKIPPED':
         ET.SubElement(xml_test, 'skipped', message='Skipped')
+  testsuite.set('failures', str(failure_count))
+  testsuite.set('errors', str(error_count))
   # ensure the report directory exists
   report_dir = os.path.dirname(os.path.abspath(xml_report))
   if not os.path.exists(report_dir):

--- a/tools/run_tests/python_utils/report_utils.py
+++ b/tools/run_tests/python_utils/report_utils.py
@@ -71,13 +71,12 @@ def render_junit_xml_report(resultset, xml_report, suite_package='grpc',
       xml_test = ET.SubElement(testsuite, 'testcase', name=shortname)
       if result.elapsed_time:
         xml_test.set('time', str(result.elapsed_time))
-      ET.SubElement(xml_test, 'system-out').text = _filter_msg(result.message,
-                                                               'XML')
+      filtered_msg =  _filter_msg(result.message, 'XML')
       if result.state == 'FAILED':
-        ET.SubElement(xml_test, 'failure', message='Failure')
+        ET.SubElement(xml_test, 'failure', message='Failure').text = filtered_msg
         failure_count += 1
       elif result.state == 'TIMEOUT':
-        ET.SubElement(xml_test, 'error', message='Timeout')
+        ET.SubElement(xml_test, 'error', message='Timeout').text = filtered_msg
         error_count += 1
       elif result.state == 'SKIPPED':
         ET.SubElement(xml_test, 'skipped', message='Skipped')


### PR DESCRIPTION
Improve presentation of results in internal_ci.

Problem:
internal_ci UI doesn't display a test target as failing unless the errors/failures attribute is set to nonzero.



