### PR TITLE
Fix small message streaming ping-pong write count regression

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.c
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.c
@@ -2554,7 +2554,7 @@ static void incoming_byte_stream_update_flow_control(grpc_exec_ctx *exec_ctx,
                                    add_max_recv_bytes);
     if ((int64_t)s->incoming_window_delta + (int64_t)initial_window_size -
             (int64_t)s->announce_window >
-        2 * (int64_t)initial_window_size) {
+        (int64_t)initial_window_size / 2) {
       write_type = GRPC_CHTTP2_STREAM_WRITE_PIGGYBACK;
     }
     grpc_chttp2_become_writable(exec_ctx, t, s, write_type,

--- a/src/core/ext/transport/chttp2/transport/parsing.c
+++ b/src/core/ext/transport/chttp2/transport/parsing.c
@@ -418,7 +418,10 @@ static grpc_error *update_incoming_window(grpc_exec_ctx *exec_ctx,
 
     GRPC_CHTTP2_FLOW_DEBIT_STREAM_INCOMING_WINDOW_DELTA("parse", t, s,
                                                         incoming_frame_size);
-    if ((int64_t)s->incoming_window_delta - (int64_t)s->announce_window <= 0) {
+    if ((int64_t)s->incoming_window_delta - (int64_t)s->announce_window <=
+        -(int64_t)t->settings[GRPC_SENT_SETTINGS]
+                             [GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE] /
+            2) {
       grpc_chttp2_become_writable(exec_ctx, t, s,
                                   GRPC_CHTTP2_STREAM_WRITE_INITIATE_UNCOVERED,
                                   "window-update-required");


### PR DESCRIPTION
Gets us back to 2.x writes per message pair for short messages.

Trickle diff:
```
Performance differences noted:
Benchmark                                      cpu_time    real_time    writes_per_iteration
---------------------------------------------  ----------  -----------  ----------------------
BM_PumpStreamServerToClient_Trickle/1/64       +115%       +18%         -41%
BM_PumpStreamServerToClient_Trickle/256k/256k                           -5%
BM_PumpStreamServerToClient_Trickle/256k/2M                             -34%
BM_PumpStreamServerToClient_Trickle/32k/256k                            -44%
BM_PumpStreamServerToClient_Trickle/32k/32k                             -7%
BM_PumpStreamServerToClient_Trickle/4k/32k                              -46%
BM_PumpStreamServerToClient_Trickle/512/4k                              -38%
BM_PumpStreamServerToClient_Trickle/512/64     +5%         +84%
BM_PumpStreamServerToClient_Trickle/64/512                              -20%
BM_PumpStreamServerToClient_Trickle/8/512                               -11%
BM_PumpStreamServerToClient_Trickle/8/64                                -31%
```