### PR TITLE
Don't crate GRPC_OS_ERROR with a non-static string

### DIFF
--- a/src/core/lib/iomgr/error.c
+++ b/src/core/lib/iomgr/error.c
@@ -769,7 +769,7 @@ grpc_error *grpc_os_error(const char *file, int line, int err,
               GRPC_ERROR_INT_ERRNO, err),
           GRPC_ERROR_STR_OS_ERROR,
           grpc_slice_from_static_string(strerror(err))),
-      GRPC_ERROR_STR_SYSCALL, grpc_slice_from_static_string(call_name));
+      GRPC_ERROR_STR_SYSCALL, grpc_slice_from_copied_string(call_name));
 }
 
 #ifdef GPR_WINDOWS

--- a/src/core/lib/iomgr/ev_epoll_linux.c
+++ b/src/core/lib/iomgr/ev_epoll_linux.c
@@ -418,7 +418,7 @@ static void polling_island_add_fds_locked(polling_island *pi, grpc_fd **fds,
             &err_msg,
             "epoll_ctl (epoll_fd: %d) add fd: %d failed with error: %d (%s)",
             pi->epoll_fd, fds[i]->fd, errno, strerror(errno));
-        append_error(error, GRPC_OS_ERROR(errno, err_msg), err_desc);
+        append_error(error, GRPC_OS_ERROR(errno, err_desc), err_msg);
         gpr_free(err_msg);
       }
 
@@ -456,7 +456,7 @@ static void polling_island_add_wakeup_fd_locked(polling_island *pi,
                  "error: %d (%s)",
                  pi->epoll_fd, GRPC_WAKEUP_FD_GET_READ_FD(&global_wakeup_fd),
                  errno, strerror(errno));
-    append_error(error, GRPC_OS_ERROR(errno, err_msg), err_desc);
+    append_error(error, GRPC_OS_ERROR(errno, err_desc), err_msg);
     gpr_free(err_msg);
   }
 }
@@ -477,7 +477,7 @@ static void polling_island_remove_all_fds_locked(polling_island *pi,
                    "epoll_ctl (epoll_fd: %d) delete fds[%zu]: %d failed with "
                    "error: %d (%s)",
                    pi->epoll_fd, i, pi->fds[i]->fd, errno, strerror(errno));
-      append_error(error, GRPC_OS_ERROR(errno, err_msg), err_desc);
+      append_error(error, GRPC_OS_ERROR(errno, err_desc), err_msg);
       gpr_free(err_msg);
     }
 
@@ -507,7 +507,7 @@ static void polling_island_remove_fd_locked(polling_island *pi, grpc_fd *fd,
           &err_msg,
           "epoll_ctl (epoll_fd: %d) del fd: %d failed with error: %d (%s)",
           pi->epoll_fd, fd->fd, errno, strerror(errno));
-      append_error(error, GRPC_OS_ERROR(errno, err_msg), err_desc);
+      append_error(error, GRPC_OS_ERROR(errno, err_desc), err_msg);
       gpr_free(err_msg);
     }
   }
@@ -1435,7 +1435,7 @@ static void pollset_work_and_unlock(grpc_exec_ctx *exec_ctx,
         gpr_asprintf(&err_msg,
                      "epoll_wait() epoll fd: %d failed with error: %d (%s)",
                      epoll_fd, errno, strerror(errno));
-        append_error(error, GRPC_OS_ERROR(errno, err_msg), err_desc);
+        append_error(error, GRPC_OS_ERROR(errno, err_desc), err_msg);
       } else {
         /* We were interrupted. Save an interation by doing a zero timeout
            epoll_wait to see if there are any other events of interest */

--- a/src/core/lib/iomgr/ev_epoll_linux.c
+++ b/src/core/lib/iomgr/ev_epoll_linux.c
@@ -418,7 +418,7 @@ static void polling_island_add_fds_locked(polling_island *pi, grpc_fd **fds,
             &err_msg,
             "epoll_ctl (epoll_fd: %d) add fd: %d failed with error: %d (%s)",
             pi->epoll_fd, fds[i]->fd, errno, strerror(errno));
-        append_error(error, GRPC_OS_ERROR(errno, err_desc), err_msg);
+        append_error(error, GRPC_OS_ERROR(errno, err_msg), err_desc);
         gpr_free(err_msg);
       }
 
@@ -456,7 +456,7 @@ static void polling_island_add_wakeup_fd_locked(polling_island *pi,
                  "error: %d (%s)",
                  pi->epoll_fd, GRPC_WAKEUP_FD_GET_READ_FD(&global_wakeup_fd),
                  errno, strerror(errno));
-    append_error(error, GRPC_OS_ERROR(errno, err_desc), err_msg);
+    append_error(error, GRPC_OS_ERROR(errno, err_msg), err_desc);
     gpr_free(err_msg);
   }
 }
@@ -477,7 +477,7 @@ static void polling_island_remove_all_fds_locked(polling_island *pi,
                    "epoll_ctl (epoll_fd: %d) delete fds[%zu]: %d failed with "
                    "error: %d (%s)",
                    pi->epoll_fd, i, pi->fds[i]->fd, errno, strerror(errno));
-      append_error(error, GRPC_OS_ERROR(errno, err_desc), err_msg);
+      append_error(error, GRPC_OS_ERROR(errno, err_msg), err_desc);
       gpr_free(err_msg);
     }
 
@@ -507,7 +507,7 @@ static void polling_island_remove_fd_locked(polling_island *pi, grpc_fd *fd,
           &err_msg,
           "epoll_ctl (epoll_fd: %d) del fd: %d failed with error: %d (%s)",
           pi->epoll_fd, fd->fd, errno, strerror(errno));
-      append_error(error, GRPC_OS_ERROR(errno, err_desc), err_msg);
+      append_error(error, GRPC_OS_ERROR(errno, err_msg), err_desc);
       gpr_free(err_msg);
     }
   }
@@ -1435,7 +1435,7 @@ static void pollset_work_and_unlock(grpc_exec_ctx *exec_ctx,
         gpr_asprintf(&err_msg,
                      "epoll_wait() epoll fd: %d failed with error: %d (%s)",
                      epoll_fd, errno, strerror(errno));
-        append_error(error, GRPC_OS_ERROR(errno, err_desc), err_msg);
+        append_error(error, GRPC_OS_ERROR(errno, err_msg), err_desc);
       } else {
         /* We were interrupted. Save an interation by doing a zero timeout
            epoll_wait to see if there are any other events of interest */


### PR DESCRIPTION
The second argument to `GRPC_OS_ERROR` eventually becomes `call_name` [here](https://github.com/grpc/grpc/blob/master/src/core/lib/iomgr/error.c#L772), which expects a static string. 