### PR TITLE
Fix the namespace detection pattern.

### DIFF
--- a/src/node/src/protobuf_js_6_common.js
+++ b/src/node/src/protobuf_js_6_common.js
@@ -144,7 +144,9 @@ exports.loadObject = function loadObject(value, options) {
     return client.makeClientConstructor(service_attrs);
   }
 
-  if (value.hasOwnProperty('nested')) {
+  // Types also has 'nested' fields as the property, but the contents are
+  // simply undefined.
+  if (value.hasOwnProperty('nested') && value.nested !== undefined) {
     // It's a namespace or root object
     _.each(value.nested, function(nested, name) {
       result[name] = loadObject(nested, options);

--- a/src/node/test/common_test.js
+++ b/src/node/test/common_test.js
@@ -201,7 +201,11 @@ describe('Proto message enum serialize and deserialize', function() {
     assert.deepEqual(numberDeserialized, {enum_value: 2});
   });
 });
-describe('loadObject', function() {
+// This should be tested only with protobuf.js 6.x
+var describe6 =
+    protobuf_js_6_common.isProbablyProtobufJs6(messages_proto) ?
+        describe : describe.skip;
+describe6('loadObject', function() {
   var loaded = protobuf_js_6_common.loadObject(messages_proto);
   it('should return the loaded object for non-namespaces', function() {
     assert(loaded.LongValues instanceof ProtoBuf.Type);

--- a/src/node/test/common_test.js
+++ b/src/node/test/common_test.js
@@ -201,3 +201,22 @@ describe('Proto message enum serialize and deserialize', function() {
     assert.deepEqual(numberDeserialized, {enum_value: 2});
   });
 });
+describe('loadObject', function() {
+  var loaded = protobuf_js_6_common.loadObject(messages_proto);
+  it('should return the loaded object for non-namespaces', function() {
+    assert(loaded.LongValues instanceof ProtoBuf.Type);
+    assert.equal(loaded.LongValues.name, 'LongValues');
+
+    assert(loaded.SequenceValues instanceof ProtoBuf.Type);
+    assert.equal(loaded.SequenceValues.name, 'SequenceValues');
+
+    assert(loaded.OneOfValues instanceof ProtoBuf.Type);
+    assert.equal(loaded.OneOfValues.name, 'OneOfValues');
+
+    assert(loaded.TestEnum instanceof ProtoBuf.Enum);
+    assert.equal(loaded.TestEnum.name, 'TestEnum');
+
+    assert(loaded.EnumValues instanceof ProtoBuf.Type);
+    assert.equal(loaded.EnumValues.name, 'EnumValues');
+  });
+});


### PR DESCRIPTION
As I tried with protobufjs 6.7.3, message types (Type) also has
'nested' field, but the value is undefined. It should check
this pattern too, otherwise non-namespace ones become an empty
object. That causes the failure of googleapis/gax-nodejs#135