### PR TITLE
Remove unnecessary require_relative in Ruby gem

### DIFF
--- a/src/ruby/lib/grpc/grpc.rb
+++ b/src/ruby/lib/grpc/grpc.rb
@@ -34,6 +34,6 @@ begin
   if File.directory?(distrib_lib_dir)
     require_relative "#{distrib_lib_dir}/grpc_c"
   else
-    require_relative 'grpc_c'
+    require 'grpc/grpc_c'
   end
 end


### PR DESCRIPTION
`require-relative` breaks Rubygems' ability to use the arch-specific
directory in `extensions`. When building grpc extensions from source,
we're left with a lot of intermediate object files and a duplicate
shared object file as well. This space can be reclaimed by finding these
object files inside the `gems` subdirectory of the installation
location, while leaving the shared object file in the `extensions`
subdirectory. See the comments at
https://github.com/rubygems/rubygems/issues/926 for more on this
behavior, which has been present in Rubygems for years.

By using `require` instead, those of us who build from source can
reclaim space consumed by duplicate and intermediate files, which
amounts to a savings of 46MB (in a build of 1.3.2 on Alpine
Linux). This is helpful when trying to minimize the size of a Docker
image.

I'm unclear on whether or not the reclaiming of this space can be
automated as part of the build process. If so, it may be worth
considering as a separate effort.