### PR TITLE
Prevent out of disk space error on internal_ci

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_linux_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_linux_rc
@@ -33,6 +33,10 @@
 # Need to increase open files limit for c tests
 ulimit -n 32768
 
+# Move docker's storage location to scratch disk so we don't run out of space.
+echo 'DOCKER_OPTS="${DOCKER_OPTS} --graph=/tmpfs/docker"' | sudo tee --append /etc/default/docker
+sudo service docker restart
+
 # Download Docker images from DockerHub
 export DOCKERHUB_ORGANIZATION=grpctesting
 


### PR DESCRIPTION
Turns out we are not running out of disk space on internal_ci because the scratch disk is too small, but because docker's storage is under /var  which is mounted on the root filesystem with little free space.
Moving docker's --graph under /tmpfs  should help.