### PR TITLE
Fix run_tests script for Mac

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -75,8 +75,9 @@ _FORCE_ENVIRON_FOR_WRAPPERS = {
 
 
 _POLLING_STRATEGIES = {
-  'linux': ['epollsig', 'poll', 'poll-cv']
+  'linux': ['epollsig', 'poll', 'poll-cv'],
 # TODO(ctiller, sreecha): enable epoll1, epollex, epoll-thread-pool
+  'mac': ['poll'],
 }
 
 


### PR DESCRIPTION
PR #11010 broke run_tests for non-travis Mac tests (e.g., Mac desktop) . This is a fix-forward.

