### PR TITLE
PHP: stop requiring google/protobuf PHP implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,11 +6,14 @@
   "homepage": "http://grpc.io",
   "license": "BSD-3-Clause",
   "require": {
-    "php": ">=5.5.0",
-    "google/protobuf": "^v3.3.0"
+    "php": ">=5.5.0"
   },
   "require-dev": {
     "google/auth": "v0.9"
+  },
+  "suggest": {
+    "ext-protobuf": "For better performance, install the protobuf C extension.",
+    "google/protobuf": "To get started using grpc quickly, install the native protobuf library."
   },
   "autoload": {
     "psr-4": {

--- a/examples/php/composer.json
+++ b/examples/php/composer.json
@@ -2,7 +2,8 @@
   "name": "grpc/grpc-demo",
   "description": "gRPC example for PHP",
   "require": {
-    "grpc/grpc": "^v1.1.0"
+    "grpc/grpc": "^v1.3.0",
+    "google/protobuf": "^v3.3.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -174,6 +174,28 @@ $ sudo make install
 ```
 
 
+### Protobuf Runtime library
+
+There are two protobuf runtime libraries to choose from. They are idenfical in terms of APIs offered.
+
+1. C implementation (for better performance)
+
+``` sh
+$ sudo pecl install protobuf
+```
+
+2. PHP implementation (for easier installation)
+
+
+Add this to your `composer.json` file:
+
+```
+  "require": {
+    "google/protobuf": "^v3.3.0"
+  }
+``` 
+
+
 ### PHP Protoc Plugin
 
 You need the gRPC PHP protoc plugin to generate the client stub classes.

--- a/src/php/tests/qps/composer.json
+++ b/src/php/tests/qps/composer.json
@@ -1,7 +1,8 @@
 {
   "minimum-stability": "dev",
   "require": {
-    "grpc/grpc": "dev-master"
+    "grpc/grpc": "dev-master",
+    "google/protobuf": "^v3.3.0"
   },
   "autoload": {
     "psr-4": {

--- a/templates/composer.json.template
+++ b/templates/composer.json.template
@@ -8,11 +8,14 @@
     "homepage": "http://grpc.io",
     "license": "BSD-3-Clause",
     "require": {
-      "php": ">=5.5.0",
-      "google/protobuf": "^v3.3.0"
+      "php": ">=5.5.0"
     },
     "require-dev": {
       "google/auth": "v0.9"
+    },
+    "suggest": {
+      "ext-protobuf": "For better performance, install the protobuf C extension.",
+      "google/protobuf": "To get started using grpc quickly, install the native protobuf library."
     },
     "autoload": {
       "psr-4": {


### PR DESCRIPTION
Fixes #11112 

After this fix, users will have to explicit make a choice which Protobuf runtime libraries to use, either the C-implementation (`sudo pecl install protobuf`) or the PHP-implementation (add `google/protobuf` to the `composer.json` file).

We find that the current C-implementation of protobuf performs 10x better than the PHP-implementation at this point.