### PR TITLE
Add Python3.5 to portability tests

### DIFF
--- a/templates/tools/dockerfile/apt_get_pyenv.include
+++ b/templates/tools/dockerfile/apt_get_pyenv.include
@@ -12,11 +12,25 @@ RUN apt-get update && apt-get install -y ${'\\'}
 
 # Install Pyenv and dev Python versions 3.5 and 3.6
 RUN curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
-ENV PATH /root/.pyenv/bin:$PATH
+ENV PATH /root/.pyenv/bin:/root/.pyenv/shims:$PATH
 RUN eval "$(pyenv init -)"
 RUN eval "$(pyenv virtualenv-init -)"
 RUN pyenv update
+RUN pyenv install 2.7-dev
 RUN pyenv install 3.5-dev
 RUN pyenv install 3.6-dev
 RUN pyenv install pypy-5.3.1
-RUN pyenv local 3.5-dev 3.6-dev pypy-5.3.1
+# 2.7-dev first on the list, so that python points to python2.7 because some of our
+# testing Python files are not 3.x compatible.
+RUN pyenv local 2.7-dev 3.5-dev 3.6-dev pypy-5.3.1
+
+RUN python2.7 -m pip install futures==2.2.0 protobuf==3.0.0a2 six==1.10.0 virtualenv
+RUN python3.5 -m pip install futures==2.2.0 protobuf==3.0.0a2 six==1.10.0 virtualenv
+RUN python3.6 -m pip install futures==2.2.0 protobuf==3.0.0a2 six==1.10.0 virtualenv
+RUN pypy -m pip install futures==2.2.0 enum34==1.0.4 protobuf==3.0.0a2 six==1.10.0 virtualenv
+
+# Export PATH changes to ~/.bashrc, so alternative Python versions are recognized when
+# running tests in this container. "ENV PATH /root/.pyenv/bin:/root/.pyenv/shims:$PATH"
+# does not accomplish this.
+RUN /bin/bash -l -c "echo 'export PATH=/root/.pyenv/shims:$PATH' >> ~/.bashrc"
+RUN /bin/bash -l -c "echo 'export PATH=/root/.pyenv/bin:$PATH' >> ~/.bashrc"

--- a/tools/dockerfile/test/python_pyenv_x64/Dockerfile
+++ b/tools/dockerfile/test/python_pyenv_x64/Dockerfile
@@ -96,14 +96,28 @@ RUN apt-get update && apt-get install -y \
 
 # Install Pyenv and dev Python versions 3.5 and 3.6
 RUN curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
-ENV PATH /root/.pyenv/bin:$PATH
+ENV PATH /root/.pyenv/bin:/root/.pyenv/shims:$PATH
 RUN eval "$(pyenv init -)"
 RUN eval "$(pyenv virtualenv-init -)"
 RUN pyenv update
+RUN pyenv install 2.7-dev
 RUN pyenv install 3.5-dev
 RUN pyenv install 3.6-dev
 RUN pyenv install pypy-5.3.1
-RUN pyenv local 3.5-dev 3.6-dev pypy-5.3.1
+# 2.7-dev first on the list, so that python points to python2.7 because some of our
+# testing Python files are not 3.x compatible.
+RUN pyenv local 2.7-dev 3.5-dev 3.6-dev pypy-5.3.1
+
+RUN python2.7 -m pip install futures==2.2.0 protobuf==3.0.0a2 six==1.10.0 virtualenv
+RUN python3.5 -m pip install futures==2.2.0 protobuf==3.0.0a2 six==1.10.0 virtualenv
+RUN python3.6 -m pip install futures==2.2.0 protobuf==3.0.0a2 six==1.10.0 virtualenv
+RUN pypy -m pip install futures==2.2.0 enum34==1.0.4 protobuf==3.0.0a2 six==1.10.0 virtualenv
+
+# Export PATH changes to ~/.bashrc, so alternative Python versions are recognized when
+# running tests in this container. "ENV PATH /root/.pyenv/bin:/root/.pyenv/shims:$PATH"
+# does not accomplish this.
+RUN /bin/bash -l -c "echo 'export PATH=/root/.pyenv/shims:$PATH' >> ~/.bashrc"
+RUN /bin/bash -l -c "echo 'export PATH=/root/.pyenv/bin:$PATH' >> ~/.bashrc"
 
 # Prepare ccache
 RUN ln -s /usr/bin/ccache /usr/local/bin/gcc

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -623,7 +623,7 @@ class PythonLanguage(object):
     return 'tools/dockerfile/test/python_%s_%s' % (self.python_manager_name(), _docker_arch_suffix(self.args.arch))
 
   def python_manager_name(self):
-    if self.args.compiler in ['python3.5', 'python3.6']:
+    if self.args.compiler in ['default', 'python3.5', 'python3.6']:
       return 'pyenv'
     elif self.args.compiler == 'python_alpine':
       return 'alpine'
@@ -673,7 +673,7 @@ class PythonLanguage(object):
       if os.name == 'nt':
         return (python27_config,)
       else:
-        return (python27_config, python34_config,)
+        return (python27_config, python34_config, python36_config,)
     elif args.compiler == 'python2.7':
       return (python27_config,)
     elif args.compiler == 'python3.4':

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -247,23 +247,15 @@ def _create_portability_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS)
                               extra_args=extra_args + ['--build_only'],
                               inner_jobs=inner_jobs)
 
-  test_jobs += _generate_jobs(languages=['python'],
-                              configs=['dbg'],
-                              platforms=['linux'],
-                              arch='default',
-                              compiler='python3.4',
-                              labels=['portability'],
-                              extra_args=extra_args,
-                              inner_jobs=inner_jobs)
-
-  test_jobs += _generate_jobs(languages=['python'],
-                              configs=['dbg'],
-                              platforms=['linux'],
-                              arch='default',
-                              compiler='python_alpine',
-                              labels=['portability'],
-                              extra_args=extra_args,
-                              inner_jobs=inner_jobs)
+  for compiler in ['python3.4', 'python3.5', 'python_alpine']:
+    test_jobs += _generate_jobs(languages=['python'],
+                                configs=['dbg'],
+                                platforms=['linux'],
+                                arch='default',
+                                compiler=compiler,
+                                labels=['portability'],
+                                extra_args=extra_args,
+                                inner_jobs=inner_jobs)
 
   test_jobs += _generate_jobs(languages=['csharp'],
                               configs=['dbg'],


### PR DESCRIPTION
Portability testing python3.5 without `--build_only` flag worked fine locally. Built using #10113. 