### PR TITLE
PHP: fix pecl extension after cc files are added

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -13,9 +13,11 @@ if test "$PHP_GRPC" != "no"; then
 
   LIBS="-lpthread $LIBS"
 
+  CFLAGS="-Wall -Werror -Wno-parentheses-equality -Wno-unused-value -std=c11"
+  CXXFLAGS="-std=c++11"
   GRPC_SHARED_LIBADD="-lpthread $GRPC_SHARED_LIBADD"
+  PHP_REQUIRE_CXX()
   PHP_ADD_LIBRARY(pthread)
-
   PHP_ADD_LIBRARY(dl,,GRPC_SHARED_LIBADD)
   PHP_ADD_LIBRARY(dl)
 
@@ -688,9 +690,8 @@ if test "$PHP_GRPC" != "no"; then
     third_party/cares/cares/inet_net_pton.c \
     third_party/cares/cares/inet_ntop.c \
     third_party/cares/cares/windows_port.c \
-    , $ext_shared, , -Wall -Werror \
-    -Wno-parentheses-equality -Wno-unused-value -std=c11 \
-    -fvisibility=hidden -DOPENSSL_NO_ASM -D_GNU_SOURCE -DWIN32_LEAN_AND_MEAN \
+    , $ext_shared, , -fvisibility=hidden \
+    -DOPENSSL_NO_ASM -D_GNU_SOURCE -DWIN32_LEAN_AND_MEAN \
     -D_HAS_EXCEPTIONS=0 -DNOMINMAX)
 
   PHP_ADD_BUILD_DIR($ext_builddir/src/php/ext/grpc)

--- a/templates/config.m4.template
+++ b/templates/config.m4.template
@@ -15,9 +15,11 @@
 
     LIBS="-lpthread $LIBS"
 
+    CFLAGS="-Wall -Werror -Wno-parentheses-equality -Wno-unused-value -std=c11"
+    CXXFLAGS="-std=c++11"
     GRPC_SHARED_LIBADD="-lpthread $GRPC_SHARED_LIBADD"
+    PHP_REQUIRE_CXX()
     PHP_ADD_LIBRARY(pthread)
-
     PHP_ADD_LIBRARY(dl,,GRPC_SHARED_LIBADD)
     PHP_ADD_LIBRARY(dl)
 
@@ -43,9 +45,8 @@
       % endfor
       % endif
       % endfor
-      , $ext_shared, , -Wall -Werror ${"\\"}
-      -Wno-parentheses-equality -Wno-unused-value -std=c11 ${"\\"}
-      -fvisibility=hidden -DOPENSSL_NO_ASM -D_GNU_SOURCE -DWIN32_LEAN_AND_MEAN ${"\\"}
+      , $ext_shared, , -fvisibility=hidden ${"\\"}
+      -DOPENSSL_NO_ASM -D_GNU_SOURCE -DWIN32_LEAN_AND_MEAN ${"\\"}
       -D_HAS_EXCEPTIONS=0 -DNOMINMAX)
 
     PHP_ADD_BUILD_DIR($ext_builddir/src/php/ext/grpc)


### PR DESCRIPTION
Fixes #11193 

A `.cc` file has been added via dependency to the gRPC PHP Extension. Need to update the `config.m4` files to properly compile those files.
