### PR TITLE
Dont concatenate strings when status is OK

### DIFF
--- a/src/csharp/Grpc.Core/Internal/CallError.cs
+++ b/src/csharp/Grpc.Core/Internal/CallError.cs
@@ -72,7 +72,10 @@ namespace Grpc.Core.Internal
         /// </summary>
         public static void CheckOk(this CallError callError)
         {
-            GrpcPreconditions.CheckState(callError == CallError.OK, "Call error: " + callError);
+            if (callError != CallError.OK)
+            {
+                throw new InvalidOperationException("Call error: " + callError);
+            }
         }
     }
 }


### PR DESCRIPTION
I started implementing some microbenchmarks for C# and this is my first finding. Looks like microbenchmarks are a good thing after all.

C# was concatenating two strings and creating a new string object after EVERY operation we ever invoked on a call. :-)