### PR TITLE
Compilation without ALPN support does not work

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -131,13 +131,13 @@
       }, {
         'conditions': [
           ["target_arch=='ia32'", {
-              "include_dirs": [ "<(node_root_dir)/deps/openssl/config/piii" ]
+             "include_dirs": [ "<(node_root_dir)/deps/openssl/config/piii" ]
           }],
           ["target_arch=='x64'", {
-              "include_dirs": [ "<(node_root_dir)/deps/openssl/config/k8" ]
+             "include_dirs": [ "<(node_root_dir)/deps/openssl/config/k8" ]
           }],
           ["target_arch=='arm'", {
-              "include_dirs": [ "<(node_root_dir)/deps/openssl/config/arm" ]
+             "include_dirs": [ "<(node_root_dir)/deps/openssl/config/arm" ]
           }],
           ['grpc_alpn=="true"', {
             'defines': [

--- a/binding.gyp
+++ b/binding.gyp
@@ -130,6 +130,15 @@
         ]
       }, {
         'conditions': [
+          ["target_arch=='ia32'", {
+              "include_dirs": [ "<(node_root_dir)/deps/openssl/config/piii" ]
+          }],
+          ["target_arch=='x64'", {
+              "include_dirs": [ "<(node_root_dir)/deps/openssl/config/k8" ]
+          }],
+          ["target_arch=='arm'", {
+              "include_dirs": [ "<(node_root_dir)/deps/openssl/config/arm" ]
+          }],
           ['grpc_alpn=="true"', {
             'defines': [
               'TSI_OPENSSL_ALPN_SUPPORT=1'
@@ -142,17 +151,6 @@
         ],
         'include_dirs': [
           '<(node_root_dir)/deps/openssl/openssl/include',
-        ],
-        'conditions': [
-         ["target_arch=='ia32'", {
-             "include_dirs": [ "<(node_root_dir)/deps/openssl/config/piii" ]
-         }],
-         ["target_arch=='x64'", {
-             "include_dirs": [ "<(node_root_dir)/deps/openssl/config/k8" ]
-         }],
-         ["target_arch=='arm'", {
-             "include_dirs": [ "<(node_root_dir)/deps/openssl/config/arm" ]
-         }]
         ]
       }],
       ['OS == "win"', {

--- a/templates/binding.gyp.template
+++ b/templates/binding.gyp.template
@@ -120,6 +120,15 @@
           ]
         }, {
           'conditions': [
+            ["target_arch=='ia32'", {
+               "include_dirs": [ "<(node_root_dir)/deps/openssl/config/piii" ]
+            }],
+            ["target_arch=='x64'", {
+               "include_dirs": [ "<(node_root_dir)/deps/openssl/config/k8" ]
+            }],
+            ["target_arch=='arm'", {
+               "include_dirs": [ "<(node_root_dir)/deps/openssl/config/arm" ]
+            }],
             ['grpc_alpn=="true"', {
               'defines': [
                 'TSI_OPENSSL_ALPN_SUPPORT=1'
@@ -132,17 +141,6 @@
           ],
           'include_dirs': [
             '<(node_root_dir)/deps/openssl/openssl/include',
-          ],
-          'conditions': [
-           ["target_arch=='ia32'", {
-               "include_dirs": [ "<(node_root_dir)/deps/openssl/config/piii" ]
-           }],
-           ["target_arch=='x64'", {
-               "include_dirs": [ "<(node_root_dir)/deps/openssl/config/k8" ]
-           }],
-           ["target_arch=='arm'", {
-               "include_dirs": [ "<(node_root_dir)/deps/openssl/config/arm" ]
-           }]
           ]
         }],
         ['OS == "win"', {


### PR DESCRIPTION
Regarding the fix in #9962. There is a bug in the pull request, some of the JSON attributes override each other, causing the fix to not work at all. 

```
  'conditions': [
          ['grpc_alpn=="true"', {
            'defines': [
              'TSI_OPENSSL_ALPN_SUPPORT=1'
            ],
          }, {
            'defines': [
              'TSI_OPENSSL_ALPN_SUPPORT=0'
            ],
          }]
        ],
        'include_dirs': [
          '<(node_root_dir)/deps/openssl/openssl/include',
        ],
        'conditions': [
         ["target_arch=='ia32'", {
             "include_dirs": [ "<(node_root_dir)/deps/openssl/config/piii" ]
         }],
         ["target_arch=='x64'", {
             "include_dirs": [ "<(node_root_dir)/deps/openssl/config/k8" ]
         }],
         ["target_arch=='arm'", {
             "include_dirs": [ "<(node_root_dir)/deps/openssl/config/arm" ]
         }]
```

the "conditions" attributes override each other, meaning the ALPN fix is ignored.