### PR TITLE
Remove the section for b64 encoded trailers.

### DIFF
--- a/doc/PROTOCOL-WEB.md
+++ b/doc/PROTOCOL-WEB.md
@@ -103,10 +103,6 @@ to security policies with XHR
   * While the server runtime will always base64-encode and flush gRPC messages
   atomically the client library should not assume base64 padding always
   happens at the boundary of message frames. That is, the implementation may send base64-encoded "chunks" with potential padding whenever the runtime needs to flush a byte buffer.
-3. For binary trailers, when the content-type is set to
-application/grpc-web-text, the extra base64 encoding specified
-in [gRPC over HTTP2](http://www.grpc.io/docs/guides/wire.html)
-for binary custom metadata is skipped.
 
 # Other features
 


### PR DESCRIPTION
Remove the section for b64 encoded trailers. As gRPC-Web uses CRLF to separate the trailers in the trailers frame, a binary trailer need to reserve in a base64 encoded format for their values. This cannot be skipped even base64 is applied on the whole trailers frame per client's request via content-type: application/grpc-web-text.