### PR TITLE
Add Java OkHttp client to interop tests

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -218,7 +218,7 @@ class JavaOkHttpClient:
     return {}
 
   def unimplemented_test_cases(self):
-    return _SKIP_COMPRESSION
+    return _SKIP_COMPRESSION + _SKIP_DATA_FRAME_PADDING
 
   def __str__(self):
     return 'javaokhttp'

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -202,6 +202,28 @@ class JavaLanguage:
     return 'java'
 
 
+class JavaOkHttpClient:
+
+  def __init__(self):
+    self.client_cwd = '../grpc-java'
+    self.safename = 'java'
+
+  def client_cmd(self, args):
+    return ['./run-test-client.sh', '--use_okhttp=true'] + args
+
+  def cloud_to_prod_env(self):
+    return {}
+
+  def global_env(self):
+    return {}
+
+  def unimplemented_test_cases(self):
+    return _SKIP_COMPRESSION
+
+  def __str__(self):
+    return 'javaokhttp'
+
+
 class GoLanguage:
 
   def __init__(self):
@@ -489,6 +511,7 @@ _LANGUAGES = {
     'csharpcoreclr' : CSharpCoreCLRLanguage(),
     'go' : GoLanguage(),
     'java' : JavaLanguage(),
+    'javaokhttp' : JavaOkHttpClient(),
     'node' : NodeLanguage(),
     'php' :  PHPLanguage(),
     'php7' :  PHP7Language(),


### PR DESCRIPTION
This adds the Java OkHttp transport (used for Android) to the interop test suite. This is intended to help catch issues such as https://github.com/grpc/grpc-java/issues/3032 in the future.

These tests depend on the pending changes to gRPC Java in PRs https://github.com/grpc/grpc-java/pull/3037 and https://github.com/grpc/grpc-java/pull/3036.