### PR TITLE
clang-format and include guard fix

### DIFF
--- a/src/core/ext/census/intrusive_hash_map.h
+++ b/src/core/ext/census/intrusive_hash_map.h
@@ -147,4 +147,4 @@ void intrusive_hash_map_clear(intrusive_hash_map *hash_map,
 void intrusive_hash_map_free(intrusive_hash_map *hash_map,
                              void (*free_object)(void *));
 
-#endif // GRPC_CORE_EXT_CENSUS_INTRUSIVE_HASH_MAP_H
+#endif /* GRPC_CORE_EXT_CENSUS_INTRUSIVE_HASH_MAP_H */

--- a/src/core/ext/census/intrusive_hash_map_internal.h
+++ b/src/core/ext/census/intrusive_hash_map_internal.h
@@ -43,4 +43,4 @@ typedef struct intrusive_hash_map {
   chunked_vector buckets;
 } intrusive_hash_map;
 
-#endif // GRPC_CORE_EXT_CENSUS_INTRUSIVE_HASH_MAP_INTERNAL_H
+#endif /* GRPC_CORE_EXT_CENSUS_INTRUSIVE_HASH_MAP_INTERNAL_H */


### PR DESCRIPTION
linux master is broken because of this.