### PR TITLE
Don't start a server if there's unbound ports

### DIFF
--- a/src/csharp/Grpc.Core.Tests/ServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ServerTest.cs
@@ -32,6 +32,7 @@
 #endregion
 
 using System;
+using System.IO;
 using System.Linq;
 using Grpc.Core;
 using Grpc.Core.Internal;
@@ -77,6 +78,21 @@ namespace Grpc.Core.Tests
             Assert.Greater(boundPort.BoundPort, 0);
 
             server.Start();
+            server.ShutdownAsync().Wait();
+        }
+
+        [Test]
+        public void StartThrowsWithUnboundPorts()
+        {
+            int twiceBoundPort = 9999;
+            Server server = new Server
+            {
+                Ports = {
+                    new ServerPort("localhost", twiceBoundPort, ServerCredentials.Insecure),
+                    new ServerPort("localhost", twiceBoundPort, ServerCredentials.Insecure)
+                }
+            };
+            Assert.Throws(typeof(IOException), () => server.Start());
             server.ShutdownAsync().Wait();
         }
 


### PR DESCRIPTION
Tentative fix for https://github.com/grpc/grpc/issues/10918.