### PR TITLE
Fixes gRPC ObjC plugin's upper camel conversion

### DIFF
--- a/src/compiler/objective_c_generator_helpers.h
+++ b/src/compiler/objective_c_generator_helpers.h
@@ -46,8 +46,12 @@ using ::grpc::protobuf::FileDescriptor;
 using ::grpc::protobuf::ServiceDescriptor;
 using ::grpc::string;
 
-inline string MessageHeaderName(const FileDescriptor *file) {
-  return google::protobuf::compiler::objectivec::FilePath(file) + ".pbobjc.h";
+inline string MessageHeaderName(const FileDescriptor *file, bool dash_as_separator) {
+  if (dash_as_separator) {
+    return google::protobuf::compiler::objectivec::FilePath(file) + ".pbobjc.h";
+  } else {
+    return grpc_generator::FileNameInUpperCamel(file) + ".pbobjc.h";
+  }
 }
 
 inline string ServiceClassName(const ServiceDescriptor *service) {

--- a/src/compiler/objective_c_generator_helpers.h
+++ b/src/compiler/objective_c_generator_helpers.h
@@ -46,7 +46,8 @@ using ::grpc::protobuf::FileDescriptor;
 using ::grpc::protobuf::ServiceDescriptor;
 using ::grpc::string;
 
-inline string MessageHeaderName(const FileDescriptor *file, bool dash_as_separator) {
+inline string MessageHeaderName(const FileDescriptor *file,
+                                bool dash_as_separator) {
   if (dash_as_separator) {
     return google::protobuf::compiler::objectivec::FilePath(file) + ".pbobjc.h";
   } else {

--- a/src/compiler/objective_c_generator_helpers.h
+++ b/src/compiler/objective_c_generator_helpers.h
@@ -46,13 +46,8 @@ using ::grpc::protobuf::FileDescriptor;
 using ::grpc::protobuf::ServiceDescriptor;
 using ::grpc::string;
 
-inline string MessageHeaderName(const FileDescriptor *file,
-                                bool dash_as_separator) {
-  if (dash_as_separator) {
-    return google::protobuf::compiler::objectivec::FilePath(file) + ".pbobjc.h";
-  } else {
-    return grpc_generator::FileNameInUpperCamel(file) + ".pbobjc.h";
-  }
+inline string MessageHeaderName(const FileDescriptor *file) {
+  return google::protobuf::compiler::objectivec::FilePath(file) + ".pbobjc.h";
 }
 
 inline string ServiceClassName(const ServiceDescriptor *service) {

--- a/src/compiler/objective_c_generator_helpers.h
+++ b/src/compiler/objective_c_generator_helpers.h
@@ -38,6 +38,8 @@
 #include "src/compiler/config.h"
 #include "src/compiler/generator_helpers.h"
 
+#include <google/protobuf/compiler/objectivec/objectivec_helpers.h>
+
 namespace grpc_objective_c_generator {
 
 using ::grpc::protobuf::FileDescriptor;
@@ -45,7 +47,7 @@ using ::grpc::protobuf::ServiceDescriptor;
 using ::grpc::string;
 
 inline string MessageHeaderName(const FileDescriptor *file) {
-  return grpc_generator::FileNameInUpperCamel(file) + ".pbobjc.h";
+  return google::protobuf::compiler::objectivec::FilePath(file) + ".pbobjc.h";
 }
 
 inline string ServiceClassName(const ServiceDescriptor *service) {

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -32,6 +32,10 @@
  */
 
 // Generates Objective C gRPC service interface out of Protobuf IDL.
+// For legacy reason, output filename of this plugin is by default in uppercamel
+// case with dash "-" treated as character and preserved in the output file
+// name. If normal upper camel case (dash treated as word separator) is desired,
+// use plugin option "filename-dash-as-separator".
 
 #include <memory>
 

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -59,8 +59,16 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
       return true;
     }
 
-    ::grpc::string file_name =
-        google::protobuf::compiler::objectivec::FilePath(file);
+    ::grpc::string file_name;
+
+    // Simple parameter parsing as we have only one parameter.
+    // TODO(mxyan): Complete parameter parsing.
+    bool dash_as_separator = (0 == parameter.compare("--filename-dash-as-separator"));
+    if (dash_as_separator) {
+      file_name = google::protobuf::compiler::objectivec::FilePath(file);
+    } else {
+      file_name = grpc_generator::FileNameInUpperCamel(file);
+    }
     ::grpc::string prefix = file->options().objc_class_prefix();
 
     {
@@ -78,7 +86,7 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
       ::grpc::string proto_imports;
       for (int i = 0; i < file->dependency_count(); i++) {
         ::grpc::string header =
-            grpc_objective_c_generator::MessageHeaderName(file->dependency(i));
+            grpc_objective_c_generator::MessageHeaderName(file->dependency(i), dash_as_separator);
         const grpc::protobuf::FileDescriptor *dependency = file->dependency(i);
         if (IsProtobufLibraryBundledProtoFile(dependency)) {
           ::grpc::string base_name = header;

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -59,7 +59,8 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
       return true;
     }
 
-    ::grpc::string file_name = google::protobuf::compiler::objectivec::FilePath(file);
+    ::grpc::string file_name =
+        google::protobuf::compiler::objectivec::FilePath(file);
     ::grpc::string prefix = file->options().objc_class_prefix();
 
     {

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -63,7 +63,7 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
 
     // Simple parameter parsing as we have only one parameter.
     // TODO(mxyan): Complete parameter parsing.
-    bool dash_as_separator = (0 == parameter.compare("--filename-dash-as-separator"));
+    bool dash_as_separator = (0 == parameter.compare("filename-dash-as-separator"));
     if (dash_as_separator) {
       file_name = google::protobuf::compiler::objectivec::FilePath(file);
     } else {

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -32,10 +32,6 @@
  */
 
 // Generates Objective C gRPC service interface out of Protobuf IDL.
-// For legacy reason, output filename of this plugin is by default in uppercamel
-// case with dash "-" treated as character and preserved in the output file
-// name. If normal upper camel case (dash treated as word separator) is desired,
-// use plugin option "filename-dash-as-separator".
 
 #include <memory>
 
@@ -63,17 +59,8 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
       return true;
     }
 
-    ::grpc::string file_name;
-
-    // Simple parameter parsing as we have only one parameter.
-    // TODO(mxyan): Complete parameter parsing.
-    bool dash_as_separator =
-        (0 == parameter.compare("filename-dash-as-separator"));
-    if (dash_as_separator) {
-      file_name = google::protobuf::compiler::objectivec::FilePath(file);
-    } else {
-      file_name = grpc_generator::FileNameInUpperCamel(file);
-    }
+    ::grpc::string file_name =
+        google::protobuf::compiler::objectivec::FilePath(file);
     ::grpc::string prefix = file->options().objc_class_prefix();
 
     {
@@ -90,8 +77,8 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
       // and import the files in the .pbrpc.m
       ::grpc::string proto_imports;
       for (int i = 0; i < file->dependency_count(); i++) {
-        ::grpc::string header = grpc_objective_c_generator::MessageHeaderName(
-            file->dependency(i), dash_as_separator);
+        ::grpc::string header =
+            grpc_objective_c_generator::MessageHeaderName(file->dependency(i));
         const grpc::protobuf::FileDescriptor *dependency = file->dependency(i);
         if (IsProtobufLibraryBundledProtoFile(dependency)) {
           ::grpc::string base_name = header;

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -59,7 +59,7 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
       return true;
     }
 
-    ::grpc::string file_name = grpc_generator::FileNameInUpperCamel(file);
+    ::grpc::string file_name = google::protobuf::compiler::objectivec::FilePath(file);
     ::grpc::string prefix = file->options().objc_class_prefix();
 
     {

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -63,7 +63,8 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
 
     // Simple parameter parsing as we have only one parameter.
     // TODO(mxyan): Complete parameter parsing.
-    bool dash_as_separator = (0 == parameter.compare("filename-dash-as-separator"));
+    bool dash_as_separator =
+        (0 == parameter.compare("filename-dash-as-separator"));
     if (dash_as_separator) {
       file_name = google::protobuf::compiler::objectivec::FilePath(file);
     } else {
@@ -85,8 +86,8 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
       // and import the files in the .pbrpc.m
       ::grpc::string proto_imports;
       for (int i = 0; i < file->dependency_count(); i++) {
-        ::grpc::string header =
-            grpc_objective_c_generator::MessageHeaderName(file->dependency(i), dash_as_separator);
+        ::grpc::string header = grpc_objective_c_generator::MessageHeaderName(
+            file->dependency(i), dash_as_separator);
         const grpc::protobuf::FileDescriptor *dependency = file->dependency(i);
         if (IsProtobufLibraryBundledProtoFile(dependency)) {
           ::grpc::string base_name = header;

--- a/src/objective-c/tests/PluginTest/imported-with-dash.proto
+++ b/src/objective-c/tests/PluginTest/imported-with-dash.proto
@@ -1,32 +1,16 @@
-// Copyright 2017, Google Inc.
-// All rights reserved.
+// Copyright 2017 gRPC authors.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//     * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 syntax = "proto3";
 
 package grpc.testing;

--- a/src/objective-c/tests/PluginTest/imported-with-dash.proto
+++ b/src/objective-c/tests/PluginTest/imported-with-dash.proto
@@ -1,4 +1,4 @@
-// Copyright 2015, Google Inc.
+// Copyright 2017, Google Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -27,13 +27,12 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// An integration test service that covers all the method signature permutations
-// of unary/streaming requests/responses.
 syntax = "proto3";
 
 package grpc.testing;
 
 option objc_class_prefix = "RMT";
 
-service DummyService {
+message TestMessageImported {
+  int32 dummy = 1;
 }

--- a/src/objective-c/tests/PluginTest/test-dash-filename.proto
+++ b/src/objective-c/tests/PluginTest/test-dash-filename.proto
@@ -1,0 +1,45 @@
+// Copyright 2017, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// An integration test service that covers all the method signature permutations
+// of unary/streaming requests/responses.
+syntax = "proto3";
+
+package grpc.testing;
+
+option objc_class_prefix = "RMT";
+
+import "imported-with-dash.proto";
+
+message TestMessage {
+  int32 dummy = 1;
+}
+
+service DummyService {
+}

--- a/src/objective-c/tests/PluginTest/test-dash-filename.proto
+++ b/src/objective-c/tests/PluginTest/test-dash-filename.proto
@@ -1,34 +1,16 @@
-// Copyright 2017, Google Inc.
-// All rights reserved.
+// Copyright 2017 gRPC authors.
 //
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//     * Redistributions of source code must retain the above copyright
-// notice, this list of conditions and the following disclaimer.
-//     * Redistributions in binary form must reproduce the above
-// copyright notice, this list of conditions and the following disclaimer
-// in the documentation and/or other materials provided with the
-// distribution.
-//     * Neither the name of Google Inc. nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-// An integration test service that covers all the method signature permutations
-// of unary/streaming requests/responses.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 syntax = "proto3";
 
 package grpc.testing;

--- a/src/objective-c/tests/RemoteTestClient/test-dash-filename.proto
+++ b/src/objective-c/tests/RemoteTestClient/test-dash-filename.proto
@@ -1,0 +1,72 @@
+// Copyright 2015, Google Inc.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// An integration test service that covers all the method signature permutations
+// of unary/streaming requests/responses.
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+import "messages.proto";
+
+package grpc.testing;
+
+option objc_class_prefix = "RMT";
+
+// A simple service to test the various types of RPCs and experiment with
+// performance with various types of payload.
+service TestService {
+  // One empty request followed by one empty response.
+  rpc EmptyCall(google.protobuf.Empty) returns (google.protobuf.Empty);
+
+  // One request followed by one response.
+  rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
+
+  // One request followed by a sequence of responses (streamed download).
+  // The server returns the payload with client desired type and sizes.
+  rpc StreamingOutputCall(StreamingOutputCallRequest)
+      returns (stream StreamingOutputCallResponse);
+
+  // A sequence of requests followed by one response (streamed upload).
+  // The server returns the aggregated size of client payload as the result.
+  rpc StreamingInputCall(stream StreamingInputCallRequest)
+      returns (StreamingInputCallResponse);
+
+  // A sequence of requests with each request served by the server immediately.
+  // As one request could lead to multiple responses, this interface
+  // demonstrates the idea of full duplexing.
+  rpc FullDuplexCall(stream StreamingOutputCallRequest)
+      returns (stream StreamingOutputCallResponse);
+
+  // A sequence of requests followed by a sequence of responses.
+  // The server buffers all the client requests and then serves them in order. A
+  // stream of responses are returned to the client when the server starts with
+  // first request.
+  rpc HalfDuplexCall(stream StreamingOutputCallRequest)
+      returns (stream StreamingOutputCallResponse);
+}

--- a/src/objective-c/tests/RemoteTestClient/test-dash-filename.proto
+++ b/src/objective-c/tests/RemoteTestClient/test-dash-filename.proto
@@ -31,42 +31,9 @@
 // of unary/streaming requests/responses.
 syntax = "proto3";
 
-import "google/protobuf/empty.proto";
-import "messages.proto";
-
 package grpc.testing;
 
 option objc_class_prefix = "RMT";
 
-// A simple service to test the various types of RPCs and experiment with
-// performance with various types of payload.
-service TestService {
-  // One empty request followed by one empty response.
-  rpc EmptyCall(google.protobuf.Empty) returns (google.protobuf.Empty);
-
-  // One request followed by one response.
-  rpc UnaryCall(SimpleRequest) returns (SimpleResponse);
-
-  // One request followed by a sequence of responses (streamed download).
-  // The server returns the payload with client desired type and sizes.
-  rpc StreamingOutputCall(StreamingOutputCallRequest)
-      returns (stream StreamingOutputCallResponse);
-
-  // A sequence of requests followed by one response (streamed upload).
-  // The server returns the aggregated size of client payload as the result.
-  rpc StreamingInputCall(stream StreamingInputCallRequest)
-      returns (StreamingInputCallResponse);
-
-  // A sequence of requests with each request served by the server immediately.
-  // As one request could lead to multiple responses, this interface
-  // demonstrates the idea of full duplexing.
-  rpc FullDuplexCall(stream StreamingOutputCallRequest)
-      returns (stream StreamingOutputCallResponse);
-
-  // A sequence of requests followed by a sequence of responses.
-  // The server buffers all the client requests and then serves them in order. A
-  // stream of responses are returned to the client when the server starts with
-  // first request.
-  rpc HalfDuplexCall(stream StreamingOutputCallRequest)
-      returns (stream StreamingOutputCallResponse);
+service DummyService {
 }

--- a/src/objective-c/tests/build_tests.sh
+++ b/src/objective-c/tests/build_tests.sh
@@ -52,3 +52,26 @@ rm -f RemoteTestClient/*.{h,m}
 
 echo "TIME:  $(date)"
 pod install
+
+# Verify the output proto name
+[ -e ./RemoteTestClient/Test-dash-filename.pbrpc.h ] || {
+    echo >&2 "protoc outputs wrong filename."
+    exit 1
+}
+
+# Verify the output proto name when dash is treated as separator
+PROTOC=../../../bins/$CONFIG/protobuf/protoc
+PLUGIN=../../../bins/$CONFIG/grpc_objective_c_plugin
+
+eval $PROTOC \
+    --plugin=protoc-gen-grpc=$PLUGIN \
+    --objc_out=RemoteTestClient \
+    --grpc_out=filename-dash-as-separator:RemoteTestClient \
+    -I RemoteTestClient \
+    -I ../../../third_party/protobuf/src \
+    RemoteTestClient/*.proto
+
+[ -e ./RemoteTestClient/TestDashFilename.pbrpc.h ] || {
+    echo >&2 "protoc outputs wring filename. 2"
+    exit 1
+}

--- a/src/objective-c/tests/build_tests.sh
+++ b/src/objective-c/tests/build_tests.sh
@@ -53,25 +53,3 @@ rm -f RemoteTestClient/*.{h,m}
 echo "TIME:  $(date)"
 pod install
 
-# Verify the output proto name
-[ -e ./RemoteTestClient/Test-dash-filename.pbrpc.h ] || {
-    echo >&2 "protoc outputs wrong filename."
-    exit 1
-}
-
-# Verify the output proto name when dash is treated as separator
-PROTOC=../../../bins/$CONFIG/protobuf/protoc
-PLUGIN=../../../bins/$CONFIG/grpc_objective_c_plugin
-
-eval $PROTOC \
-    --plugin=protoc-gen-grpc=$PLUGIN \
-    --objc_out=RemoteTestClient \
-    --grpc_out=filename-dash-as-separator:RemoteTestClient \
-    -I RemoteTestClient \
-    -I ../../../third_party/protobuf/src \
-    RemoteTestClient/*.proto
-
-[ -e ./RemoteTestClient/TestDashFilename.pbrpc.h ] || {
-    echo >&2 "protoc outputs wring filename. 2"
-    exit 1
-}

--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -38,6 +38,38 @@ cd $(dirname $0)
 # Run the tests server.
 
 BINDIR=../../../bins/$CONFIG
+PROTOC=$BINDIR/protobuf/protoc
+PLUGIN=$BINDIR/grpc_objective_c_plugin
+
+rm -rf PluginTest/*pb*
+
+# Verify the output proto filename
+eval $PROTOC \
+    --plugin=protoc-gen-grpc=$PLUGIN \
+    --objc_out=PluginTest \
+    --grpc_out=PluginTest \
+    -I PluginTest \
+    -I ../../../third_party/protobuf/src \
+    PluginTest/*.proto
+
+[ -e ./PluginTest/TestDashFilename.pbrpc.h ] || {
+    echo >&2 "protoc outputs wrong filename."
+    exit 1
+}
+
+# Verify names of the imported protos in generated code
+[ "`cat PluginTest/TestDashFilename.pbrpc.h |
+    egrep '#import ".*\.pb(objc|rpc)\.h"$' |
+    egrep '-'`" ] && {
+    echo >&2 "protoc generated import with wrong filename."
+    exit 1
+}
+[ "`cat PluginTest/TestDashFilename.pbrpc.m |
+    egrep '#import ".*\.pb(objc|rpc)\.m"$' |
+    egrep '-'`" ] && {
+    echo >&2 "protoc generated import with wrong filename."
+    exit 1
+}
 
 [ -f $BINDIR/interop_server ] || {
     echo >&2 "Can't find the test server. Make sure run_tests.py is making" \


### PR DESCRIPTION
`grpc_objective_c_plugin`'s output file name was not correct when dash (`-`) was included in the source proto file's filename. This PR uses Protocol Buffer's native upper camel conversion function instead of a custom one to resolve this problem.

Manually tested OK. With a proto file named `test-test-test.proto`, current version of `grpc_objective_c_plugin` generates `Test-test-test.pbrpc.{m,h}`. After the patch, `TestTestTest.pbrpc.{m,h}` was generated.