### PR TITLE
Don't start a server if there's unbound ports (for v1.4.x branch)

### DIFF
--- a/src/csharp/Grpc.Core.Tests/ServerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ServerTest.cs
@@ -32,6 +32,7 @@
 #endregion
 
 using System;
+using System.IO;
 using System.Linq;
 using Grpc.Core;
 using Grpc.Core.Internal;
@@ -77,6 +78,21 @@ namespace Grpc.Core.Tests
             Assert.Greater(boundPort.BoundPort, 0);
 
             server.Start();
+            server.ShutdownAsync().Wait();
+        }
+
+        [Test]
+        public void StartThrowsWithUnboundPorts()
+        {
+            int twiceBoundPort = 9999;
+            Server server = new Server(new[] { new ChannelOption(ChannelOptions.SoReuseport, 0) })
+            {
+                Ports = {
+                    new ServerPort("localhost", twiceBoundPort, ServerCredentials.Insecure),
+                    new ServerPort("localhost", twiceBoundPort, ServerCredentials.Insecure)
+                }
+            };
+            Assert.Throws(typeof(IOException), () => server.Start());
             server.ShutdownAsync().Wait();
         }
 

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -326,9 +326,11 @@ namespace Grpc.Core
         {
             lock (myLock)
             {
-                if (!ports.All((port) => port.BoundPort != 0))
+                var unboundPort = ports.FirstOrDefault(port => port.BoundPort == 0);
+                if (unboundPort != null)
                 {
-                    throw new IOException("Failed to bind some of ports exposed by the server.");
+                    throw new IOException(
+                        string.Format("Failed to bind port \"{0}:{1}\"", unboundPort.Host, unboundPort.Port));
                 }
             }
         }


### PR DESCRIPTION
Tentative fix for #10918 