### PR TITLE
Reuse BatchContextSafeHandle objects by pooling them

### DIFF
--- a/src/csharp/Grpc.Core/GrpcEnvironment.cs
+++ b/src/csharp/Grpc.Core/GrpcEnvironment.cs
@@ -253,6 +253,14 @@ namespace Grpc.Core
             }
         }
 
+        internal GrpcThreadPool ThreadPool
+        {
+            get
+            {
+                return this.threadPool;
+            }
+        }
+
         internal bool IsAlive
         {
             get

--- a/src/csharp/Grpc.Core/Internal/AsyncCall.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCall.cs
@@ -407,7 +407,7 @@ namespace Grpc.Core.Internal
             var credentials = details.Options.Credentials;
             using (var nativeCredentials = credentials != null ? credentials.ToNativeCredentials() : null)
             {
-                var result = details.Channel.Handle.CreateCall(
+                var result = details.Channel.Handle.CreateCall(details.Channel.Environment,
                              parentCall, ContextPropagationToken.DefaultMask, cq,
                              details.Method, details.Host, Timespec.FromDateTime(details.Options.Deadline.Value), nativeCredentials);
                 return result;

--- a/src/csharp/Grpc.Core/Internal/AsyncCallServer.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCallServer.cs
@@ -59,7 +59,7 @@ namespace Grpc.Core.Internal
 
         public void Initialize(CallSafeHandle call, CompletionQueueSafeHandle completionQueue)
         {
-            call.Initialize(completionQueue);
+            call.Initialize(server.Environment, completionQueue);
 
             server.AddCallReference(this);
             InitializeInternal(call);

--- a/src/csharp/Grpc.Core/Internal/BatchContextSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/BatchContextSafeHandle.cs
@@ -101,6 +101,11 @@ namespace Grpc.Core.Internal
         {
             return Native.grpcsharp_batch_context_recv_close_on_server_cancelled(this) != 0;
         }
+
+        public void Reset()
+        {
+            Native.grpcsharp_batch_context_reset(this);
+        }
             
         protected override bool ReleaseHandle()
         {

--- a/src/csharp/Grpc.Core/Internal/BatchContextSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/BatchContextSafeHandle.cs
@@ -32,9 +32,8 @@
 #endregion
 
 using System;
-using System.Runtime.InteropServices;
-using System.Text;
-using Grpc.Core;
+using System.Threading;
+using Grpc.Core.Utils;
 
 namespace Grpc.Core.Internal
 {
@@ -44,6 +43,8 @@ namespace Grpc.Core.Internal
     internal class BatchContextSafeHandle : SafeHandleZeroIsInvalid
     {
         static readonly NativeMethods Native = NativeMethods.Get();
+
+        SimpleObjectPool<BatchContextSafeHandle> pool;
 
         private BatchContextSafeHandle()
         {
@@ -60,6 +61,12 @@ namespace Grpc.Core.Internal
             {
                 return handle;
             }
+        }
+
+        public void SetPool(SimpleObjectPool<BatchContextSafeHandle> pool)
+        {
+            GrpcPreconditions.CheckNotNull(pool);
+            this.pool = pool;
         }
 
         // Gets data of recv_initial_metadata completion.
@@ -105,6 +112,19 @@ namespace Grpc.Core.Internal
         public void Reset()
         {
             Native.grpcsharp_batch_context_reset(this);
+        }
+
+        public void Recycle()
+        {
+            if (pool != null && object.ReferenceEquals(Thread.CurrentThread, pool.Thread))
+            {
+                Reset();
+                pool.Return(this);
+            }
+            else
+            {
+                Dispose();
+            }
         }
             
         protected override bool ReleaseHandle()

--- a/src/csharp/Grpc.Core/Internal/ChannelSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/ChannelSafeHandle.cs
@@ -63,14 +63,14 @@ namespace Grpc.Core.Internal
             return Native.grpcsharp_secure_channel_create(credentials, target, channelArgs);
         }
 
-        public CallSafeHandle CreateCall(CallSafeHandle parentCall, ContextPropagationFlags propagationMask, CompletionQueueSafeHandle cq, string method, string host, Timespec deadline, CallCredentialsSafeHandle credentials)
+        public CallSafeHandle CreateCall(GrpcEnvironment environment, CallSafeHandle parentCall, ContextPropagationFlags propagationMask, CompletionQueueSafeHandle cq, string method, string host, Timespec deadline, CallCredentialsSafeHandle credentials)
         {
             var result = Native.grpcsharp_channel_create_call(this, parentCall, propagationMask, cq, method, host, deadline);
             if (credentials != null)
             {
                 result.SetCredentials(credentials);
             }
-            result.Initialize(cq);
+            result.Initialize(environment, cq);
             return result;
         }
 

--- a/src/csharp/Grpc.Core/Internal/CompletionRegistry.cs
+++ b/src/csharp/Grpc.Core/Internal/CompletionRegistry.cs
@@ -108,7 +108,7 @@ namespace Grpc.Core.Internal
             {
                 if (ctx != null)
                 {
-                    ctx.Dispose();
+                    ctx.Recycle();
                 }
             }
         }

--- a/src/csharp/Grpc.Core/Internal/NativeMethods.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMethods.cs
@@ -65,6 +65,7 @@ namespace Grpc.Core.Internal
         public readonly Delegates.grpcsharp_batch_context_recv_status_on_client_details_delegate grpcsharp_batch_context_recv_status_on_client_details;
         public readonly Delegates.grpcsharp_batch_context_recv_status_on_client_trailing_metadata_delegate grpcsharp_batch_context_recv_status_on_client_trailing_metadata;
         public readonly Delegates.grpcsharp_batch_context_recv_close_on_server_cancelled_delegate grpcsharp_batch_context_recv_close_on_server_cancelled;
+        public readonly Delegates.grpcsharp_batch_context_reset_delegate grpcsharp_batch_context_reset;
         public readonly Delegates.grpcsharp_batch_context_destroy_delegate grpcsharp_batch_context_destroy;
 
         public readonly Delegates.grpcsharp_request_call_context_create_delegate grpcsharp_request_call_context_create;
@@ -182,6 +183,7 @@ namespace Grpc.Core.Internal
             this.grpcsharp_batch_context_recv_status_on_client_details = GetMethodDelegate<Delegates.grpcsharp_batch_context_recv_status_on_client_details_delegate>(library);
             this.grpcsharp_batch_context_recv_status_on_client_trailing_metadata = GetMethodDelegate<Delegates.grpcsharp_batch_context_recv_status_on_client_trailing_metadata_delegate>(library);
             this.grpcsharp_batch_context_recv_close_on_server_cancelled = GetMethodDelegate<Delegates.grpcsharp_batch_context_recv_close_on_server_cancelled_delegate>(library);
+            this.grpcsharp_batch_context_reset = GetMethodDelegate<Delegates.grpcsharp_batch_context_reset_delegate>(library);
             this.grpcsharp_batch_context_destroy = GetMethodDelegate<Delegates.grpcsharp_batch_context_destroy_delegate>(library);
 
             this.grpcsharp_request_call_context_create = GetMethodDelegate<Delegates.grpcsharp_request_call_context_create_delegate>(library);
@@ -324,6 +326,7 @@ namespace Grpc.Core.Internal
             public delegate IntPtr grpcsharp_batch_context_recv_status_on_client_details_delegate(BatchContextSafeHandle ctx, out UIntPtr detailsLength);
             public delegate IntPtr grpcsharp_batch_context_recv_status_on_client_trailing_metadata_delegate(BatchContextSafeHandle ctx);
             public delegate int grpcsharp_batch_context_recv_close_on_server_cancelled_delegate(BatchContextSafeHandle ctx);
+            public delegate void grpcsharp_batch_context_reset_delegate(BatchContextSafeHandle ctx);
             public delegate void grpcsharp_batch_context_destroy_delegate(IntPtr ctx);
 
             public delegate RequestCallContextSafeHandle grpcsharp_request_call_context_create_delegate();

--- a/src/csharp/Grpc.Core/Internal/SimpleObjectPool.cs
+++ b/src/csharp/Grpc.Core/Internal/SimpleObjectPool.cs
@@ -1,0 +1,103 @@
+#region Copyright notice and license
+
+// Copyright 2015, Google Inc.
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+// 
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.Threading;
+using System.Collections.Generic;
+using Grpc.Core.Utils;
+
+namespace Grpc.Core.Internal
+{
+    /// <summary>
+    /// Simple queue-based pool of objects. Methods are NOT threadsafe!
+    /// </summary>
+    internal class SimpleObjectPool<T> where T : IDisposable
+    {
+        readonly Thread thread;
+        readonly Func<T> itemFactory;
+        readonly Queue<T> queue;
+        readonly int capacity;
+        bool disposed;
+
+        public SimpleObjectPool(Thread thread, Func<T> itemFactory, int capacity)
+        {
+            this.thread = thread;
+            this.itemFactory = itemFactory;
+            this.queue = new Queue<T>(capacity);
+            this.capacity = capacity;
+        }
+
+        public Thread Thread
+        {
+            get { return thread; }
+        }
+
+        public T Lease()
+        {
+            GrpcPreconditions.CheckState(!disposed);
+
+            if (queue.Count > 0)
+            {
+                return queue.Dequeue();
+            }
+            return itemFactory();
+        }
+
+        public void Return(T item)
+        {
+            GrpcPreconditions.CheckState(!disposed);
+
+            if (queue.Count < capacity)
+            {
+                queue.Enqueue(item);
+            }
+            else 
+            {
+                item.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!disposed)
+            {
+                disposed = true;
+
+                while (queue.Count > 0)
+                {
+                    queue.Dequeue().Dispose();
+                }
+            }
+        }
+    }
+}

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -216,6 +216,14 @@ namespace Grpc.Core
             activeCallCounter.Decrement();
         }
 
+        internal GrpcEnvironment Environment
+        {
+            get
+            {
+                return this.environment;
+            }
+        }
+
         /// <summary>
         /// Shuts down the server.
         /// </summary>

--- a/src/csharp/Grpc.Microbenchmarks/SendMessageBenchmark.cs
+++ b/src/csharp/Grpc.Microbenchmarks/SendMessageBenchmark.cs
@@ -68,7 +68,8 @@ namespace Grpc.Microbenchmarks
         private void ThreadBody(int iterations, int payloadSize)
         {
             // TODO(jtattermusch): parametrize by number of pending completions.
-            // TODO(jtattermusch): parametrize by cached/non-cached BatchContextSafeHandle
+            
+            environment.ThreadPool.BatchContextPools.Value = new SimpleObjectPool<BatchContextSafeHandle>(Thread.CurrentThread, () => BatchContextSafeHandle.Create(), 1000);
 
             var completionRegistry = new CompletionRegistry(environment);
             var cq = CompletionQueueSafeHandle.CreateAsync(completionRegistry);

--- a/src/csharp/Grpc.Microbenchmarks/SendMessageBenchmark.cs
+++ b/src/csharp/Grpc.Microbenchmarks/SendMessageBenchmark.cs
@@ -72,7 +72,7 @@ namespace Grpc.Microbenchmarks
 
             var completionRegistry = new CompletionRegistry(environment);
             var cq = CompletionQueueSafeHandle.CreateAsync(completionRegistry);
-            var call = CreateFakeCall(cq);
+            var call = CreateFakeCall(environment, cq);
 
             var sendCompletionHandler = new SendCompletionHandler((success) => { });
             var payload = new byte[payloadSize];
@@ -91,9 +91,9 @@ namespace Grpc.Microbenchmarks
             cq.Dispose();
         }
 
-        private static CallSafeHandle CreateFakeCall(CompletionQueueSafeHandle cq)
+        private static CallSafeHandle CreateFakeCall(GrpcEnvironment environment, CompletionQueueSafeHandle cq)
         {
-            var call = CallSafeHandle.CreateFake(new IntPtr(0xdead), cq);
+            var call = CallSafeHandle.CreateFake(new IntPtr(0xdead), environment, cq);
             bool success = false;
             while (!success)
             {

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -212,10 +212,7 @@ void grpcsharp_metadata_array_move(grpc_metadata_array *dest,
 }
 
 GPR_EXPORT void GPR_CALLTYPE
-grpcsharp_batch_context_destroy(grpcsharp_batch_context *ctx) {
-  if (!ctx) {
-    return;
-  }
+grpcsharp_batch_context_reset(grpcsharp_batch_context *ctx) {
   grpcsharp_metadata_array_destroy_metadata_including_entries(
       &(ctx->send_initial_metadata));
 
@@ -231,7 +228,15 @@ grpcsharp_batch_context_destroy(grpcsharp_batch_context *ctx) {
   grpcsharp_metadata_array_destroy_metadata_only(
       &(ctx->recv_status_on_client.trailing_metadata));
   grpc_slice_unref(ctx->recv_status_on_client.status_details);
+  memset(ctx, 0, sizeof(grpcsharp_batch_context));
+}
 
+GPR_EXPORT void GPR_CALLTYPE
+grpcsharp_batch_context_destroy(grpcsharp_batch_context *ctx) {
+  if (!ctx) {
+    return;
+  }
+  grpcsharp_batch_context_reset(ctx);
   gpr_free(ctx);
 }
 


### PR DESCRIPTION
- add a thread local pool that allows reusing BatchContextSafeHandle objects for multiple batch operations (creating and disposing puts unnecessary load on garbage collector). The underlying native object also gets reused.
- the batch context safe handle objects only get reused if they've been leased and returned by the same GrpcThreadPool thread. In practice, that should be fine as async operations' beginning and end usually stick to a single completion queue (which in turn gets assign a single gRPC thread pool thread).
- the pool capacity is exposed as "expert-only" on GrpcEnvironment.
- enable batch context pooling in SendMessageBenchmark (there's a 2x improvement for 12 threads)