### PR TITLE
Speedup bm_fullstack_trickle

### DIFF
--- a/test/cpp/microbenchmarks/bm_fullstack_trickle.cc
+++ b/test/cpp/microbenchmarks/bm_fullstack_trickle.cc
@@ -222,6 +222,7 @@ static void TrickleCQNext(TrickledCHTTP2* fixture, void** t, bool* ok,
     switch (fixture->cq()->AsyncNext(t, ok, gpr_now(GPR_CLOCK_MONOTONIC))) {
       case CompletionQueue::TIMEOUT:
         fixture->Step(iteration != -1);
+        g_now = gpr_time_add(g_now, gpr_time_from_millis(1, GPR_TIMESPAN));
         break;
       case CompletionQueue::SHUTDOWN:
         GPR_ASSERT(false);
@@ -229,7 +230,6 @@ static void TrickleCQNext(TrickledCHTTP2* fixture, void** t, bool* ok,
       case CompletionQueue::GOT_EVENT:
         return;
     }
-    g_now = gpr_time_add(g_now, gpr_time_from_micros(100, GPR_TIMESPAN));
   }
 }
 

--- a/test/cpp/microbenchmarks/bm_fullstack_trickle.cc
+++ b/test/cpp/microbenchmarks/bm_fullstack_trickle.cc
@@ -42,6 +42,15 @@ DEFINE_int32(
 DEFINE_int32(warmup_max_time_seconds, 10,
              "Maximum number of seconds to run warmup loop");
 
+static gpr_timespec g_now;
+
+extern gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
+
+static gpr_timespec now_impl(gpr_clock_type clock_type) {
+  GPR_ASSERT(clock_type != GPR_TIMESPAN);
+  return g_now;
+}
+
 namespace grpc {
 namespace testing {
 
@@ -210,9 +219,7 @@ static void TrickleCQNext(TrickledCHTTP2* fixture, void** t, bool* ok,
                           int64_t iteration) {
   while (true) {
     fixture->Log(iteration);
-    switch (fixture->cq()->AsyncNext(
-        t, ok, gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
-                            gpr_time_from_micros(100, GPR_TIMESPAN)))) {
+    switch (fixture->cq()->AsyncNext(t, ok, gpr_now(GPR_CLOCK_MONOTONIC))) {
       case CompletionQueue::TIMEOUT:
         fixture->Step(iteration != -1);
         break;
@@ -222,6 +229,7 @@ static void TrickleCQNext(TrickledCHTTP2* fixture, void** t, bool* ok,
       case CompletionQueue::GOT_EVENT:
         return;
     }
+    g_now = gpr_time_add(g_now, gpr_time_from_micros(100, GPR_TIMESPAN));
   }
 }
 
@@ -420,5 +428,6 @@ BENCHMARK(BM_PumpUnbalancedUnary_Trickle)->Apply(UnaryTrickleArgs);
 int main(int argc, char** argv) {
   ::benchmark::Initialize(&argc, argv);
   ::google::ParseCommandLineFlags(&argc, &argv, false);
+  gpr_now_impl = now_impl;
   ::benchmark::RunSpecifiedBenchmarks();
 }


### PR DESCRIPTION
This mock out gpr_now_impl and synthetically pushes time forward based on the messages going through