### PR TITLE
Increase timeout for builing ruby artifact

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -180,7 +180,8 @@ class RubyArtifact:
     # We are using a custom workspace instead.
     return create_jobspec(self.name,
                           ['tools/run_tests/artifacts/build_artifact_ruby.sh'],
-                          use_workspace=True)
+                          use_workspace=True,
+                          timeout_seconds=45*60)
 
 
 class CSharpExtArtifact:


### PR DESCRIPTION
it seems to be timing out on kokoro (because of the Dockerfile build that happens as part of it).