### PR TITLE
Change the grpc_resolved_address len to socklen_t

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy_factory.c
+++ b/src/core/ext/filters/client_channel/lb_policy_factory.c
@@ -77,7 +77,7 @@ void grpc_lb_addresses_set_address(grpc_lb_addresses* addresses, size_t index,
   if (user_data != NULL) GPR_ASSERT(addresses->user_data_vtable != NULL);
   grpc_lb_address* target = &addresses->addresses[index];
   memcpy(target->address.addr, address, address_len);
-  target->address.len = address_len;
+  target->address.len = (socklen_t)address_len;
   target->is_balancer = is_balancer;
   target->balancer_name = gpr_strdup(balancer_name);
   target->user_data = user_data;

--- a/src/core/lib/iomgr/resolve_address.h
+++ b/src/core/lib/iomgr/resolve_address.h
@@ -35,6 +35,7 @@
 #define GRPC_CORE_LIB_IOMGR_RESOLVE_ADDRESS_H
 
 #include <stddef.h>
+#include <sys/socket.h>
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/pollset_set.h"
 
@@ -42,7 +43,7 @@
 
 typedef struct {
   char addr[GRPC_MAX_SOCKADDR_SIZE];
-  size_t len;
+  socklen_t len;
 } grpc_resolved_address;
 
 typedef struct {

--- a/src/core/lib/iomgr/socket_utils_linux.c
+++ b/src/core/lib/iomgr/socket_utils_linux.c
@@ -51,7 +51,7 @@ int grpc_accept4(int sockfd, grpc_resolved_address *resolved_addr, int nonblock,
   flags |= nonblock ? SOCK_NONBLOCK : 0;
   flags |= cloexec ? SOCK_CLOEXEC : 0;
   return accept4(sockfd, (struct sockaddr *)resolved_addr->addr,
-                 (socklen_t *)&resolved_addr->len, flags);
+                 &resolved_addr->len, flags);
 }
 
 #endif

--- a/src/core/lib/iomgr/socket_utils_posix.c
+++ b/src/core/lib/iomgr/socket_utils_posix.c
@@ -50,7 +50,7 @@ int grpc_accept4(int sockfd, grpc_resolved_address *resolved_addr, int nonblock,
   GPR_ASSERT(sizeof(socklen_t) <= sizeof(size_t));
   GPR_ASSERT(resolved_addr->len <= (socklen_t)-1);
   fd = accept(sockfd, (struct sockaddr *)resolved_addr->addr,
-              (socklen_t *)&resolved_addr->len);
+              &resolved_addr->len);
   if (fd >= 0) {
     if (nonblock) {
       flags = fcntl(fd, F_GETFL, 0);

--- a/src/core/lib/iomgr/tcp_client_posix.c
+++ b/src/core/lib/iomgr/tcp_client_posix.c
@@ -294,7 +294,7 @@ static void tcp_client_connect_impl(grpc_exec_ctx *exec_ctx,
   do {
     GPR_ASSERT(addr->len < ~(socklen_t)0);
     err =
-        connect(fd, (const struct sockaddr *)addr->addr, (socklen_t)addr->len);
+        connect(fd, (const struct sockaddr *)addr->addr, addr->len);
   } while (err < 0 && errno == EINTR);
 
   addr_str = grpc_sockaddr_to_uri(addr);

--- a/src/core/lib/iomgr/tcp_server_posix.c
+++ b/src/core/lib/iomgr/tcp_server_posix.c
@@ -428,7 +428,7 @@ grpc_error *grpc_tcp_server_add_port(grpc_tcp_server *s,
     for (sp = s->head; sp; sp = sp->next) {
       sockname_temp.len = sizeof(struct sockaddr_storage);
       if (0 == getsockname(sp->fd, (struct sockaddr *)&sockname_temp.addr,
-                           (socklen_t *)&sockname_temp.len)) {
+                           &sockname_temp.len)) {
         int used_port = grpc_sockaddr_get_port(&sockname_temp);
         if (used_port > 0) {
           memcpy(&sockname_temp, addr, sizeof(grpc_resolved_address));

--- a/src/core/lib/iomgr/tcp_server_utils_posix_common.c
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_common.c
@@ -184,7 +184,7 @@ grpc_error *grpc_tcp_server_prepare_socket(int fd,
   if (err != GRPC_ERROR_NONE) goto error;
 
   GPR_ASSERT(addr->len < ~(socklen_t)0);
-  if (bind(fd, (struct sockaddr *)addr->addr, (socklen_t)addr->len) < 0) {
+  if (bind(fd, (struct sockaddr *)addr->addr, addr->len) < 0) {
     err = GRPC_OS_ERROR(errno, "bind");
     goto error;
   }
@@ -197,7 +197,7 @@ grpc_error *grpc_tcp_server_prepare_socket(int fd,
   sockname_temp.len = sizeof(struct sockaddr_storage);
 
   if (getsockname(fd, (struct sockaddr *)sockname_temp.addr,
-                  (socklen_t *)&sockname_temp.len) < 0) {
+                  &sockname_temp.len) < 0) {
     err = GRPC_OS_ERROR(errno, "getsockname");
     goto error;
   }

--- a/src/core/lib/iomgr/tcp_server_utils_posix_ifaddrs.c
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_ifaddrs.c
@@ -81,12 +81,12 @@ static grpc_error *get_unused_port(int *port) {
   if (dsmode == GRPC_DSMODE_IPV4) {
     grpc_sockaddr_make_wildcard4(0, &wild);
   }
-  if (bind(fd, (const struct sockaddr *)wild.addr, (socklen_t)wild.len) != 0) {
+  if (bind(fd, (const struct sockaddr *)wild.addr, wild.len) != 0) {
     err = GRPC_OS_ERROR(errno, "bind");
     close(fd);
     return err;
   }
-  if (getsockname(fd, (struct sockaddr *)wild.addr, (socklen_t *)&wild.len) !=
+  if (getsockname(fd, (struct sockaddr *)wild.addr, &wild.len) !=
       0) {
     err = GRPC_OS_ERROR(errno, "getsockname");
     close(fd);

--- a/src/core/lib/iomgr/udp_server.c
+++ b/src/core/lib/iomgr/udp_server.c
@@ -272,8 +272,7 @@ static int bind_socket(grpc_socket_factory *socket_factory, int sockfd,
                        const grpc_resolved_address *addr) {
   return (socket_factory != NULL)
              ? grpc_socket_factory_bind(socket_factory, sockfd, addr)
-             : bind(sockfd, (struct sockaddr *)addr->addr,
-                    (socklen_t)addr->len);
+             : bind(sockfd, (struct sockaddr *)addr->addr, addr->len);
 }
 
 /* Prepare a recently-created socket for listening. */
@@ -319,7 +318,7 @@ static int prepare_socket(grpc_socket_factory *socket_factory, int fd,
   sockname_temp.len = sizeof(struct sockaddr_storage);
 
   if (getsockname(fd, (struct sockaddr *)sockname_temp.addr,
-                  (socklen_t *)&sockname_temp.len) < 0) {
+                  &sockname_temp.len) < 0) {
     goto error;
   }
 
@@ -456,7 +455,7 @@ int grpc_udp_server_add_port(grpc_udp_server *s,
     for (sp = s->head; sp; sp = sp->next) {
       sockname_temp.len = sizeof(struct sockaddr_storage);
       if (0 == getsockname(sp->fd, (struct sockaddr *)sockname_temp.addr,
-                           (socklen_t *)&sockname_temp.len)) {
+                           &sockname_temp.len)) {
         port = grpc_sockaddr_get_port(&sockname_temp);
         if (port > 0) {
           allocated_addr = gpr_malloc(sizeof(grpc_resolved_address));

--- a/src/core/lib/iomgr/unix_sockets_posix.c
+++ b/src/core/lib/iomgr/unix_sockets_posix.c
@@ -70,7 +70,8 @@ grpc_error *grpc_resolve_unix_domain_address(const char *name,
   un = (struct sockaddr_un *)(*addrs)->addrs->addr;
   un->sun_family = AF_UNIX;
   strcpy(un->sun_path, name);
-  (*addrs)->addrs->len = strlen(un->sun_path) + sizeof(un->sun_family) + 1;
+  (*addrs)->addrs->len =
+      (socklen_t)(strlen(un->sun_path) + sizeof(un->sun_family) + 1);
   return GRPC_ERROR_NONE;
 }
 

--- a/test/core/iomgr/tcp_client_posix_test.c
+++ b/test/core/iomgr/tcp_client_posix_test.c
@@ -110,7 +110,7 @@ void test_succeeds(void) {
   svr_fd = socket(AF_INET, SOCK_STREAM, 0);
   GPR_ASSERT(svr_fd >= 0);
   GPR_ASSERT(
-      0 == bind(svr_fd, (struct sockaddr *)addr, (socklen_t)resolved_addr.len));
+      0 == bind(svr_fd, (struct sockaddr *)addr, resolved_addr.len));
   GPR_ASSERT(0 == listen(svr_fd, 1));
 
   gpr_mu_lock(g_mu);
@@ -119,7 +119,7 @@ void test_succeeds(void) {
 
   /* connect to it */
   GPR_ASSERT(getsockname(svr_fd, (struct sockaddr *)addr,
-                         (socklen_t *)&resolved_addr.len) == 0);
+                         &resolved_addr.len) == 0);
   grpc_closure_init(&done, must_succeed, NULL, grpc_schedule_on_exec_ctx);
   grpc_tcp_client_connect(&exec_ctx, &done, &g_connecting, g_pollset_set, NULL,
                           &resolved_addr, gpr_inf_future(GPR_CLOCK_REALTIME));
@@ -127,8 +127,7 @@ void test_succeeds(void) {
   /* await the connection */
   do {
     resolved_addr.len = sizeof(addr);
-    r = accept(svr_fd, (struct sockaddr *)addr,
-               (socklen_t *)&resolved_addr.len);
+    r = accept(svr_fd, (struct sockaddr *)addr, &resolved_addr.len);
   } while (r == -1 && errno == EINTR);
   GPR_ASSERT(r >= 0);
   close(r);

--- a/test/core/iomgr/tcp_server_posix_test.c
+++ b/test/core/iomgr/tcp_server_posix_test.c
@@ -261,7 +261,7 @@ static grpc_error *tcp_connect(grpc_exec_ctx *exec_ctx, const test_addr *remote,
     return GRPC_OS_ERROR(errno, "Failed to create socket");
   }
   gpr_log(GPR_DEBUG, "start connect to %s", remote->str);
-  if (connect(clifd, remote_addr, (socklen_t)remote->addr.len) != 0) {
+  if (connect(clifd, remote_addr, remote->addr.len) != 0) {
     gpr_mu_unlock(g_mu);
     close(clifd);
     return GRPC_OS_ERROR(errno, "connect");
@@ -410,7 +410,7 @@ static void test_connect(size_t num_connects,
         GPR_ASSERT(fd >= 0);
         dst.addr.len = sizeof(dst.addr.addr);
         GPR_ASSERT(getsockname(fd, (struct sockaddr *)dst.addr.addr,
-                               (socklen_t *)&dst.addr.len) == 0);
+                               &dst.addr.len) == 0);
         GPR_ASSERT(dst.addr.len <= sizeof(dst.addr.addr));
         test_addr_init_str(&dst);
         gpr_log(GPR_INFO, "(%d, %d) fd %d family %s listening on %s", port_num,

--- a/test/core/iomgr/tcp_server_uv_test.c
+++ b/test/core/iomgr/tcp_server_uv_test.c
@@ -278,7 +278,7 @@ static void test_connect(unsigned n) {
     on_connect_result result;
     on_connect_result_init(&result);
     tcp_connect(&exec_ctx, (struct sockaddr *)addr,
-                (socklen_t)resolved_addr.len, &result);
+                resolved_addr.len, &result);
     GPR_ASSERT(result.port_index == 0);
     GPR_ASSERT(result.server == s);
     if (weak_ref.server == NULL) {
@@ -288,7 +288,7 @@ static void test_connect(unsigned n) {
 
     on_connect_result_init(&result);
     tcp_connect(&exec_ctx, (struct sockaddr *)addr1,
-                (socklen_t)resolved_addr1.len, &result);
+                resolved_addr1.len, &result);
     GPR_ASSERT(result.port_index == 1);
     GPR_ASSERT(result.server == s);
     grpc_tcp_server_unref(&exec_ctx, result.server);

--- a/test/core/iomgr/udp_server_test.c
+++ b/test/core/iomgr/udp_server_test.c
@@ -115,7 +115,7 @@ static int test_socket_factory_bind(grpc_socket_factory *factory, int sockfd,
                                     const grpc_resolved_address *addr) {
   test_socket_factory *f = (test_socket_factory *)factory;
   f->number_of_bind_calls++;
-  return bind(sockfd, (struct sockaddr *)addr->addr, (socklen_t)addr->len);
+  return bind(sockfd, (struct sockaddr *)addr->addr, addr->len);
 }
 
 static int test_socket_factory_compare(grpc_socket_factory *a,
@@ -258,7 +258,7 @@ static void test_receive(int number_of_clients) {
   svrfd = grpc_udp_server_get_fd(s, 0);
   GPR_ASSERT(svrfd >= 0);
   GPR_ASSERT(getsockname(svrfd, (struct sockaddr *)addr,
-                         (socklen_t *)&resolved_addr.len) == 0);
+                         &resolved_addr.len) == 0);
   GPR_ASSERT(resolved_addr.len <= sizeof(struct sockaddr_storage));
 
   pollsets[0] = g_pollset;
@@ -274,7 +274,7 @@ static void test_receive(int number_of_clients) {
     clifd = socket(addr->ss_family, SOCK_DGRAM, 0);
     GPR_ASSERT(clifd >= 0);
     GPR_ASSERT(connect(clifd, (struct sockaddr *)addr,
-                       (socklen_t)resolved_addr.len) == 0);
+                       resolved_addr.len) == 0);
     GPR_ASSERT(5 == write(clifd, "hello", 5));
     while (g_number_of_reads == number_of_reads_before &&
            gpr_time_cmp(deadline, gpr_now(deadline.clock_type)) > 0) {


### PR DESCRIPTION
Fix the issue that can't getsockname and peer_name on big Endian system such as mips64.

The socket APIs accept/getsockname take the socklen_t pointer as a parameter.
If we cast a size_t value to a socklen_t pointer, the initialized value will be
lost on big endian system and those APIs will not give back the sockaddr to
caller.