### PR TITLE
Add helpers for creating channel args.

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel_factory.c
+++ b/src/core/ext/filters/client_channel/client_channel_factory.c
@@ -17,6 +17,7 @@
  */
 
 #include "src/core/ext/filters/client_channel/client_channel_factory.h"
+#include "src/core/lib/channel/channel_args.h"
 
 void grpc_client_channel_factory_ref(grpc_client_channel_factory* factory) {
   factory->vtable->ref(factory);
@@ -63,10 +64,6 @@ static const grpc_arg_pointer_vtable factory_arg_vtable = {
 
 grpc_arg grpc_client_channel_factory_create_channel_arg(
     grpc_client_channel_factory* factory) {
-  grpc_arg arg;
-  arg.type = GRPC_ARG_POINTER;
-  arg.key = GRPC_ARG_CLIENT_CHANNEL_FACTORY;
-  arg.value.pointer.p = factory;
-  arg.value.pointer.vtable = &factory_arg_vtable;
-  return arg;
+  return grpc_channel_arg_pointer_create(GRPC_ARG_CLIENT_CHANNEL_FACTORY,
+                                         factory, &factory_arg_vtable);
 }

--- a/src/core/ext/filters/client_channel/client_channel_plugin.c
+++ b/src/core/ext/filters/client_channel/client_channel_plugin.c
@@ -54,10 +54,8 @@ static bool set_default_host_if_unset(grpc_exec_ctx *exec_ctx,
   char *default_authority = grpc_get_default_authority(
       exec_ctx, grpc_channel_stack_builder_get_target(builder));
   if (default_authority != NULL) {
-    grpc_arg arg;
-    arg.type = GRPC_ARG_STRING;
-    arg.key = GRPC_ARG_DEFAULT_AUTHORITY;
-    arg.value.string = default_authority;
+    grpc_arg arg = grpc_channel_arg_string_create(GRPC_ARG_DEFAULT_AUTHORITY,
+                                                  default_authority);
     grpc_channel_args *new_args = grpc_channel_args_copy_and_add(args, &arg, 1);
     grpc_channel_stack_builder_set_channel_arguments(exec_ctx, builder,
                                                      new_args);

--- a/src/core/ext/filters/client_channel/http_proxy.c
+++ b/src/core/ext/filters/client_channel/http_proxy.c
@@ -80,10 +80,9 @@ static bool proxy_mapper_map_name(grpc_exec_ctx* exec_ctx,
     grpc_uri_destroy(uri);
     return false;
   }
-  grpc_arg new_arg;
-  new_arg.key = GRPC_ARG_HTTP_CONNECT_SERVER;
-  new_arg.type = GRPC_ARG_STRING;
-  new_arg.value.string = uri->path[0] == '/' ? uri->path + 1 : uri->path;
+  grpc_arg new_arg = grpc_channel_arg_string_create(
+      GRPC_ARG_HTTP_CONNECT_SERVER,
+      uri->path[0] == '/' ? uri->path + 1 : uri->path);
   *new_args = grpc_channel_args_copy_and_add(args, &new_arg, 1);
   grpc_uri_destroy(uri);
   return true;

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.c
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.c
@@ -974,10 +974,8 @@ static grpc_lb_policy *glb_create(grpc_exec_ctx *exec_ctx,
 
   // Make sure that GRPC_ARG_LB_POLICY_NAME is set in channel args,
   // since we use this to trigger the client_load_reporting filter.
-  grpc_arg new_arg;
-  new_arg.key = GRPC_ARG_LB_POLICY_NAME;
-  new_arg.type = GRPC_ARG_STRING;
-  new_arg.value.string = "grpclb";
+  grpc_arg new_arg =
+      grpc_channel_arg_string_create(GRPC_ARG_LB_POLICY_NAME, "grpclb");
   static const char *args_to_remove[] = {GRPC_ARG_LB_POLICY_NAME};
   glb_policy->args = grpc_channel_args_copy_and_add_and_remove(
       args->args, args_to_remove, GPR_ARRAY_SIZE(args_to_remove), &new_arg, 1);

--- a/src/core/ext/filters/client_channel/lb_policy_factory.c
+++ b/src/core/ext/filters/client_channel/lb_policy_factory.c
@@ -138,12 +138,8 @@ static const grpc_arg_pointer_vtable lb_addresses_arg_vtable = {
 
 grpc_arg grpc_lb_addresses_create_channel_arg(
     const grpc_lb_addresses* addresses) {
-  grpc_arg arg;
-  arg.type = GRPC_ARG_POINTER;
-  arg.key = GRPC_ARG_LB_ADDRESSES;
-  arg.value.pointer.p = (void*)addresses;
-  arg.value.pointer.vtable = &lb_addresses_arg_vtable;
-  return arg;
+  return grpc_channel_arg_pointer_create(
+      GRPC_ARG_LB_ADDRESSES, (void*)addresses, &lb_addresses_arg_vtable);
 }
 
 grpc_lb_addresses* grpc_lb_addresses_find_channel_arg(

--- a/src/core/ext/filters/client_channel/subchannel.c
+++ b/src/core/ext/filters/client_channel/subchannel.c
@@ -819,10 +819,7 @@ const char *grpc_get_subchannel_address_uri_arg(const grpc_channel_args *args) {
 }
 
 grpc_arg grpc_create_subchannel_address_arg(const grpc_resolved_address *addr) {
-  grpc_arg new_arg;
-  new_arg.key = GRPC_ARG_SUBCHANNEL_ADDRESS;
-  new_arg.type = GRPC_ARG_STRING;
-  new_arg.value.string =
-      addr->len > 0 ? grpc_sockaddr_to_uri(addr) : gpr_strdup("");
-  return new_arg;
+  return grpc_channel_arg_string_create(
+      GRPC_ARG_SUBCHANNEL_ADDRESS,
+      addr->len > 0 ? grpc_sockaddr_to_uri(addr) : gpr_strdup(""));
 }

--- a/src/core/ext/filters/load_reporting/load_reporting.c
+++ b/src/core/ext/filters/load_reporting/load_reporting.c
@@ -50,11 +50,7 @@ static bool maybe_add_load_reporting_filter(grpc_exec_ctx *exec_ctx,
 }
 
 grpc_arg grpc_load_reporting_enable_arg() {
-  grpc_arg arg;
-  arg.type = GRPC_ARG_INTEGER;
-  arg.key = GRPC_ARG_ENABLE_LOAD_REPORTING;
-  arg.value.integer = 1;
-  return arg;
+  return grpc_channel_arg_integer_create(GRPC_ARG_ENABLE_LOAD_REPORTING, 1);
 }
 
 /* Plugin registration */

--- a/src/core/ext/transport/chttp2/client/insecure/channel_create.c
+++ b/src/core/ext/transport/chttp2/client/insecure/channel_create.c
@@ -54,11 +54,9 @@ static grpc_channel *client_channel_factory_create_channel(
     return NULL;
   }
   // Add channel arg containing the server URI.
-  grpc_arg arg;
-  arg.type = GRPC_ARG_STRING;
-  arg.key = GRPC_ARG_SERVER_URI;
-  arg.value.string =
-      grpc_resolver_factory_add_default_prefix_if_needed(exec_ctx, target);
+  grpc_arg arg = grpc_channel_arg_string_create(
+      GRPC_ARG_SERVER_URI,
+      grpc_resolver_factory_add_default_prefix_if_needed(exec_ctx, target));
   const char *to_remove[] = {GRPC_ARG_SERVER_URI};
   grpc_channel_args *new_args =
       grpc_channel_args_copy_and_add_and_remove(args, to_remove, 1, &arg, 1);

--- a/src/core/ext/transport/chttp2/client/insecure/channel_create_posix.c
+++ b/src/core/ext/transport/chttp2/client/insecure/channel_create_posix.c
@@ -41,10 +41,8 @@ grpc_channel *grpc_insecure_channel_create_from_fd(
   GRPC_API_TRACE("grpc_insecure_channel_create(target=%p, fd=%d, args=%p)", 3,
                  (target, fd, args));
 
-  grpc_arg default_authority_arg;
-  default_authority_arg.type = GRPC_ARG_STRING;
-  default_authority_arg.key = GRPC_ARG_DEFAULT_AUTHORITY;
-  default_authority_arg.value.string = "test.authority";
+  grpc_arg default_authority_arg = grpc_channel_arg_string_create(
+      GRPC_ARG_DEFAULT_AUTHORITY, "test.authority");
   grpc_channel_args *final_args =
       grpc_channel_args_copy_and_add(args, &default_authority_arg, 1);
 

--- a/src/core/ext/transport/chttp2/client/secure/secure_channel_create.c
+++ b/src/core/ext/transport/chttp2/client/secure/secure_channel_create.c
@@ -163,11 +163,9 @@ static grpc_channel *client_channel_factory_create_channel(
     return NULL;
   }
   // Add channel arg containing the server URI.
-  grpc_arg arg;
-  arg.type = GRPC_ARG_STRING;
-  arg.key = GRPC_ARG_SERVER_URI;
-  arg.value.string =
-      grpc_resolver_factory_add_default_prefix_if_needed(exec_ctx, target);
+  grpc_arg arg = grpc_channel_arg_string_create(
+      GRPC_ARG_SERVER_URI,
+      grpc_resolver_factory_add_default_prefix_if_needed(exec_ctx, target));
   const char *to_remove[] = {GRPC_ARG_SERVER_URI};
   grpc_channel_args *new_args =
       grpc_channel_args_copy_and_add_and_remove(args, to_remove, 1, &arg, 1);

--- a/src/core/lib/channel/channel_args.c
+++ b/src/core/lib/channel/channel_args.c
@@ -373,3 +373,29 @@ bool grpc_channel_args_want_minimal_stack(const grpc_channel_args *args) {
   return grpc_channel_arg_get_bool(
       grpc_channel_args_find(args, GRPC_ARG_MINIMAL_STACK), false);
 }
+
+grpc_arg grpc_channel_arg_string_create(char *name, char *value) {
+  grpc_arg arg;
+  arg.type = GRPC_ARG_STRING;
+  arg.key = name;
+  arg.value.string = value;
+  return arg;
+}
+
+grpc_arg grpc_channel_arg_integer_create(char *name, int value) {
+  grpc_arg arg;
+  arg.type = GRPC_ARG_INTEGER;
+  arg.key = name;
+  arg.value.integer = value;
+  return arg;
+}
+
+grpc_arg grpc_channel_arg_pointer_create(
+    char *name, void *value, const grpc_arg_pointer_vtable *vtable) {
+  grpc_arg arg;
+  arg.type = GRPC_ARG_POINTER;
+  arg.key = name;
+  arg.value.pointer.p = value;
+  arg.value.pointer.vtable = vtable;
+  return arg;
+}

--- a/src/core/lib/channel/channel_args.h
+++ b/src/core/lib/channel/channel_args.h
@@ -112,4 +112,10 @@ int grpc_channel_arg_get_integer(const grpc_arg *arg,
 
 bool grpc_channel_arg_get_bool(const grpc_arg *arg, bool default_value);
 
+// Helpers for creating channel args.
+grpc_arg grpc_channel_arg_string_create(char *name, char *value);
+grpc_arg grpc_channel_arg_integer_create(char *name, int value);
+grpc_arg grpc_channel_arg_pointer_create(char *name, void *value,
+                                         const grpc_arg_pointer_vtable *vtable);
+
 #endif /* GRPC_CORE_LIB_CHANNEL_CHANNEL_ARGS_H */

--- a/src/core/lib/http/httpcli.c
+++ b/src/core/lib/http/httpcli.c
@@ -25,6 +25,7 @@
 #include <grpc/support/string_util.h>
 #include <grpc/support/useful.h>
 
+#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/http/format_request.h"
 #include "src/core/lib/http/parser.h"
 #include "src/core/lib/iomgr/endpoint.h"
@@ -215,11 +216,9 @@ static void next_address(grpc_exec_ctx *exec_ctx, internal_request *req,
   addr = &req->addresses->addrs[req->next_address++];
   grpc_closure_init(&req->connected, on_connected, req,
                     grpc_schedule_on_exec_ctx);
-  grpc_arg arg;
-  arg.key = GRPC_ARG_RESOURCE_QUOTA;
-  arg.type = GRPC_ARG_POINTER;
-  arg.value.pointer.p = req->resource_quota;
-  arg.value.pointer.vtable = grpc_resource_quota_arg_vtable();
+  grpc_arg arg = grpc_channel_arg_pointer_create(
+      GRPC_ARG_RESOURCE_QUOTA, req->resource_quota,
+      grpc_resource_quota_arg_vtable());
   grpc_channel_args args = {1, &arg};
   grpc_tcp_client_connect(exec_ctx, &req->connected, &req->ep,
                           req->context->pollset_set, &args, addr,

--- a/src/core/lib/iomgr/socket_factory_posix.c
+++ b/src/core/lib/iomgr/socket_factory_posix.c
@@ -20,6 +20,7 @@
 
 #ifdef GRPC_POSIX_SOCKET
 
+#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/iomgr/socket_factory_posix.h"
 
 #include <grpc/impl/codegen/grpc_types.h>
@@ -84,12 +85,8 @@ static const grpc_arg_pointer_vtable socket_factory_arg_vtable = {
     socket_factory_arg_copy, socket_factory_arg_destroy, socket_factory_cmp};
 
 grpc_arg grpc_socket_factory_to_arg(grpc_socket_factory *factory) {
-  grpc_arg arg;
-  arg.type = GRPC_ARG_POINTER;
-  arg.key = GRPC_ARG_SOCKET_FACTORY;
-  arg.value.pointer.vtable = &socket_factory_arg_vtable;
-  arg.value.pointer.p = factory;
-  return arg;
+  return grpc_channel_arg_pointer_create(GRPC_ARG_SOCKET_FACTORY, factory,
+                                         &socket_factory_arg_vtable);
 }
 
 #endif

--- a/src/core/lib/iomgr/socket_mutator.c
+++ b/src/core/lib/iomgr/socket_mutator.c
@@ -18,6 +18,8 @@
 
 #include "src/core/lib/iomgr/socket_mutator.h"
 
+#include "src/core/lib/channel/channel_args.h"
+
 #include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/useful.h>
@@ -74,10 +76,6 @@ static const grpc_arg_pointer_vtable socket_mutator_arg_vtable = {
     socket_mutator_arg_copy, socket_mutator_arg_destroy, socket_mutator_cmp};
 
 grpc_arg grpc_socket_mutator_to_arg(grpc_socket_mutator *mutator) {
-  grpc_arg arg;
-  arg.type = GRPC_ARG_POINTER;
-  arg.key = GRPC_ARG_SOCKET_MUTATOR;
-  arg.value.pointer.vtable = &socket_mutator_arg_vtable;
-  arg.value.pointer.p = mutator;
-  return arg;
+  return grpc_channel_arg_pointer_create(GRPC_ARG_SOCKET_MUTATOR, mutator,
+                                         &socket_mutator_arg_vtable);
 }

--- a/src/core/lib/security/context/security_context.c
+++ b/src/core/lib/security/context/security_context.c
@@ -18,6 +18,7 @@
 
 #include <string.h>
 
+#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/security/context/security_context.h"
 #include "src/core/lib/support/string.h"
 #include "src/core/lib/surface/api_trace.h"
@@ -304,13 +305,8 @@ static const grpc_arg_pointer_vtable auth_context_pointer_vtable = {
     auth_context_pointer_cmp};
 
 grpc_arg grpc_auth_context_to_arg(grpc_auth_context *p) {
-  grpc_arg arg;
-  memset(&arg, 0, sizeof(grpc_arg));
-  arg.type = GRPC_ARG_POINTER;
-  arg.key = GRPC_AUTH_CONTEXT_ARG;
-  arg.value.pointer.p = p;
-  arg.value.pointer.vtable = &auth_context_pointer_vtable;
-  return arg;
+  return grpc_channel_arg_pointer_create(GRPC_AUTH_CONTEXT_ARG, p,
+                                         &auth_context_pointer_vtable);
 }
 
 grpc_auth_context *grpc_auth_context_from_arg(const grpc_arg *arg) {

--- a/src/core/lib/security/credentials/credentials.c
+++ b/src/core/lib/security/credentials/credentials.c
@@ -159,12 +159,8 @@ static const grpc_arg_pointer_vtable credentials_pointer_vtable = {
 
 grpc_arg grpc_channel_credentials_to_arg(
     grpc_channel_credentials *credentials) {
-  grpc_arg result;
-  result.type = GRPC_ARG_POINTER;
-  result.key = GRPC_ARG_CHANNEL_CREDENTIALS;
-  result.value.pointer.vtable = &credentials_pointer_vtable;
-  result.value.pointer.p = credentials;
-  return result;
+  return grpc_channel_arg_pointer_create(
+      GRPC_ARG_CHANNEL_CREDENTIALS, credentials, &credentials_pointer_vtable);
 }
 
 grpc_channel_credentials *grpc_channel_credentials_from_arg(
@@ -260,13 +256,8 @@ static const grpc_arg_pointer_vtable cred_ptr_vtable = {
     server_credentials_pointer_cmp};
 
 grpc_arg grpc_server_credentials_to_arg(grpc_server_credentials *p) {
-  grpc_arg arg;
-  memset(&arg, 0, sizeof(grpc_arg));
-  arg.type = GRPC_ARG_POINTER;
-  arg.key = GRPC_SERVER_CREDENTIALS_ARG;
-  arg.value.pointer.p = p;
-  arg.value.pointer.vtable = &cred_ptr_vtable;
-  return arg;
+  return grpc_channel_arg_pointer_create(GRPC_SERVER_CREDENTIALS_ARG, p,
+                                         &cred_ptr_vtable);
 }
 
 grpc_server_credentials *grpc_server_credentials_from_arg(const grpc_arg *arg) {

--- a/src/core/lib/security/credentials/fake/fake_credentials.c
+++ b/src/core/lib/security/credentials/fake/fake_credentials.c
@@ -78,11 +78,8 @@ grpc_server_credentials *grpc_fake_transport_security_server_credentials_create(
 }
 
 grpc_arg grpc_fake_transport_expected_targets_arg(char *expected_targets) {
-  grpc_arg arg;
-  arg.type = GRPC_ARG_STRING;
-  arg.key = GRPC_ARG_FAKE_SECURITY_EXPECTED_TARGETS;
-  arg.value.string = expected_targets;
-  return arg;
+  return grpc_channel_arg_string_create(GRPC_ARG_FAKE_SECURITY_EXPECTED_TARGETS,
+                                        expected_targets);
 }
 
 const char *grpc_fake_transport_get_expected_targets(

--- a/src/core/lib/security/credentials/ssl/ssl_credentials.c
+++ b/src/core/lib/security/credentials/ssl/ssl_credentials.c
@@ -52,11 +52,8 @@ static grpc_security_status ssl_create_security_connector(
     grpc_channel_args **new_args) {
   grpc_ssl_credentials *c = (grpc_ssl_credentials *)creds;
   grpc_security_status status = GRPC_SECURITY_OK;
-  size_t i = 0;
   const char *overridden_target_name = NULL;
-  grpc_arg new_arg;
-
-  for (i = 0; args && i < args->num_args; i++) {
+  for (size_t i = 0; args && i < args->num_args; i++) {
     grpc_arg *arg = &args->args[i];
     if (strcmp(arg->key, GRPC_SSL_TARGET_NAME_OVERRIDE_ARG) == 0 &&
         arg->type == GRPC_ARG_STRING) {
@@ -69,9 +66,8 @@ static grpc_security_status ssl_create_security_connector(
   if (status != GRPC_SECURITY_OK) {
     return status;
   }
-  new_arg.type = GRPC_ARG_STRING;
-  new_arg.key = GRPC_ARG_HTTP2_SCHEME;
-  new_arg.value.string = "https";
+  grpc_arg new_arg =
+      grpc_channel_arg_string_create(GRPC_ARG_HTTP2_SCHEME, "https");
   *new_args = grpc_channel_args_copy_and_add(args, &new_arg, 1);
   return status;
 }

--- a/src/core/lib/security/transport/lb_targets_info.c
+++ b/src/core/lib/security/transport/lb_targets_info.c
@@ -37,12 +37,9 @@ static const grpc_arg_pointer_vtable server_to_balancer_names_vtable = {
 
 grpc_arg grpc_lb_targets_info_create_channel_arg(
     grpc_slice_hash_table *targets_info) {
-  grpc_arg arg;
-  arg.type = GRPC_ARG_POINTER;
-  arg.key = GRPC_ARG_LB_SECURE_NAMING_MAP;
-  arg.value.pointer.p = targets_info;
-  arg.value.pointer.vtable = &server_to_balancer_names_vtable;
-  return arg;
+  return grpc_channel_arg_pointer_create(GRPC_ARG_LB_SECURE_NAMING_MAP,
+                                         targets_info,
+                                         &server_to_balancer_names_vtable);
 }
 
 grpc_slice_hash_table *grpc_lb_targets_info_find_in_args(

--- a/src/core/lib/security/transport/security_connector.c
+++ b/src/core/lib/security/transport/security_connector.c
@@ -191,12 +191,8 @@ static const grpc_arg_pointer_vtable connector_pointer_vtable = {
     connector_pointer_cmp};
 
 grpc_arg grpc_security_connector_to_arg(grpc_security_connector *sc) {
-  grpc_arg result;
-  result.type = GRPC_ARG_POINTER;
-  result.key = GRPC_ARG_SECURITY_CONNECTOR;
-  result.value.pointer.vtable = &connector_pointer_vtable;
-  result.value.pointer.p = sc;
-  return result;
+  return grpc_channel_arg_pointer_create(GRPC_ARG_SECURITY_CONNECTOR, sc,
+                                         &connector_pointer_vtable);
 }
 
 grpc_security_connector *grpc_security_connector_from_arg(const grpc_arg *arg) {


### PR DESCRIPTION
One question here: Is it okay for the files in src/lib/iomgr to include a file in src/lib/channel?  If not, I can revert those files and leave them constructing the channel args manually.