### PR TITLE
Check the version of system c-ares

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -506,7 +506,7 @@ OPENSSL_ALPN_CHECK_CMD = $(PKG_CONFIG) --atleast-version=1.0.2 openssl
 OPENSSL_NPN_CHECK_CMD = $(PKG_CONFIG) --atleast-version=1.0.1 openssl
 ZLIB_CHECK_CMD = $(PKG_CONFIG) --exists zlib
 PROTOBUF_CHECK_CMD = $(PKG_CONFIG) --atleast-version=3.0.0 protobuf
-CARES_CHECK_CMD = $(PKG_CONFIG) --exists libcares
+CARES_CHECK_CMD = $(PKG_CONFIG) --atleast-version=1.11.0 libcares
 else # HAS_PKG_CONFIG
 
 ifeq ($(SYSTEM),MINGW32)

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -427,7 +427,7 @@
   OPENSSL_NPN_CHECK_CMD = $(PKG_CONFIG) --atleast-version=1.0.1 openssl
   ZLIB_CHECK_CMD = $(PKG_CONFIG) --exists zlib
   PROTOBUF_CHECK_CMD = $(PKG_CONFIG) --atleast-version=3.0.0 protobuf
-  CARES_CHECK_CMD = $(PKG_CONFIG) --exists libcares
+  CARES_CHECK_CMD = $(PKG_CONFIG) --atleast-version=1.11.0 libcares
   else # HAS_PKG_CONFIG
 
   ifeq ($(SYSTEM),MINGW32)

--- a/test/build/c-ares.c
+++ b/test/build/c-ares.c
@@ -33,6 +33,10 @@
 
 #include <ares.h>
 
+#if (ARES_VERSION < 0x010b00)
+  ARES_VERSION should not be smaller than 1.11.0
+#endif
+
 int main(void) {
   ares_channel channelptr;
 


### PR DESCRIPTION
Use the embedded c-ares if the system c-ares is older than 1.11.0. 