### PR TITLE
Rollback Dockerfile changes

### DIFF
--- a/tools/dockerfile/test/python_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/python_jessie_x64/Dockerfile
@@ -75,8 +75,7 @@ RUN pip install --upgrade google-api-python-client
 RUN apt-get update && apt-get install -y \
     python-all-dev \
     python3-all-dev \
-    python-pip \
-    python3-pip
+    python-pip
 
 # Install Python packages from PyPI
 RUN pip install pip --upgrade

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -146,7 +146,6 @@ fi
 ############################
 # Perform build operations #
 ############################
-$PYTHON -m pip install virtualenv
 
 # Instnatiate the virtualenv, preferring to do so from the relevant python
 # version. Even if these commands fail (e.g. on Windows due to name conflicts)

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -251,15 +251,6 @@ def _create_portability_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS)
                               configs=['dbg'],
                               platforms=['linux'],
                               arch='default',
-                              compiler='python3.4',
-                              labels=['portability'],
-                              extra_args=extra_args,
-                              inner_jobs=inner_jobs)
-
-  test_jobs += _generate_jobs(languages=['python'],
-                              configs=['dbg'],
-                              platforms=['linux'],
-                              arch='default',
                               compiler='python_alpine',
                               labels=['portability'],
                               extra_args=extra_args,


### PR DESCRIPTION
The portability test was the reason I had to add Python3.4 virtualenv/pip, but since we already run Python3.4 tests as part of the standard linux test suite, I think this is redundant and can be removed.