### PR TITLE
Fix minor error in Node generated documentation

### DIFF
--- a/src/node/src/grpc_extension.js
+++ b/src/node/src/grpc_extension.js
@@ -31,6 +31,13 @@
  *
  */
 
+/**
+ * @module
+ * @private
+ */
+
+'use strict';
+
 var binary = require('node-pre-gyp/lib/pre-binding');
 var path = require('path');
 var binding_path =


### PR DESCRIPTION
Without this, a spurious and slightly confusing page was getting added to the generated documentation.