### PR TITLE
Undo updating npm in node artifact builds

### DIFF
--- a/tools/run_tests/artifacts/build_artifact_node.bat
+++ b/tools/run_tests/artifacts/build_artifact_node.bat
@@ -35,8 +35,6 @@ set PATH=%PATH%;C:\Program Files\nodejs\;%APPDATA%\npm
 
 del /f /q BUILD || rmdir build /s /q
 
-call npm update -g npm
-
 call npm update || goto :error
 
 mkdir -p %ARTIFACTS_OUT%

--- a/tools/run_tests/artifacts/build_artifact_node.sh
+++ b/tools/run_tests/artifacts/build_artifact_node.sh
@@ -34,8 +34,6 @@ source ~/.nvm/nvm.sh
 nvm use 4
 set -ex
 
-npm update -g npm
-
 cd $(dirname $0)/../../..
 
 rm -rf build || true


### PR DESCRIPTION
In retrospect, that's global, so we shouldn't touch it in the build.