### PR TITLE
Remove extraneous semicolons.

### DIFF
--- a/include/grpc++/impl/codegen/async_unary_call.h
+++ b/include/grpc++/impl/codegen/async_unary_call.h
@@ -154,7 +154,7 @@ class ClientAsyncResponseReader final
 
   // disable operator new
   static void* operator new(std::size_t size);
-  static void* operator new(std::size_t size, void* p) { return p; };
+  static void* operator new(std::size_t size, void* p) { return p; }
 
   SneakyCallOpSet<CallOpSendInitialMetadata, CallOpSendMessage,
                   CallOpClientSendClose>

--- a/include/grpc++/impl/codegen/completion_queue.h
+++ b/include/grpc++/impl/codegen/completion_queue.h
@@ -182,7 +182,7 @@ class CompletionQueue : private GrpcLibraryCodegen {
   void RegisterAvalanching() {
     gpr_atm_no_barrier_fetch_add(&avalanches_in_flight_,
                                  static_cast<gpr_atm>(1));
-  };
+  }
   void CompleteAvalanching();
 
  protected:


### PR DESCRIPTION
Fixes compilation if building with -Wextra-semi.