### PR TITLE
Add a GrpcLibraryInitializer to client_context.cc

### DIFF
--- a/src/cpp/client/client_context.cc
+++ b/src/cpp/client/client_context.cc
@@ -24,6 +24,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 
+#include <grpc++/impl/grpc_library.h>
 #include <grpc++/security/credentials.h>
 #include <grpc++/server_context.h>
 #include <grpc++/support/time.h>
@@ -38,6 +39,7 @@ class DefaultGlobalClientCallbacks final
   void Destructor(ClientContext* context) override {}
 };
 
+static internal::GrpcLibraryInitializer g_gli_initializer;
 static DefaultGlobalClientCallbacks g_default_client_callbacks;
 static ClientContext::GlobalCallbacks* g_client_callbacks =
     &g_default_client_callbacks;


### PR DESCRIPTION
It's feasible that a program be written/linked such that it only use
ClientContext from grpc++, which could end up with the other instances
of GrpcLibraryInitializer not ending up in the final binary.  Add a
GrpcLibraryInitializer to client_context.cc to ensure that the library
is initialized.  The primary side-effect of the library not being
initialized when only using a ClientContext is that the destructor for
ClientContext indirectly ends up trying to call through
g_core_codegen_interface when destructing its metadata, which is null.