### PR TITLE
s/CURRENT_TIMESTAMP/_DATE/ in BQ, for caching

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -81,7 +81,7 @@ def get_flaky_tests(limit=None):
     FROM
       [grpc-testing:jenkins_test_results.aggregate_results]
     WHERE
-      timestamp >= DATE_ADD(DATE(CURRENT_TIMESTAMP()), -1, "WEEK")
+      timestamp >= DATE_ADD(CURRENT_DATE(), -1, "WEEK")
       AND NOT REGEXP_MATCH(job_name, '.*portability.*')
       AND REGEXP_MATCH(job_name, '.*master.*')
     GROUP BY


### PR DESCRIPTION
We seems to be hitting a concurrent query limit, likely due to querying BQ from Jenkins. This PR tries to make results be cacheable so that they aren't subject to the quota (according to https://cloud.google.com/bigquery/quota-policy: "Concurrent rate limit for interactive queries under on-demand pricing: 50 concurrent queries. Queries that return cached results, or queries configured using the dryRun property, do not count against this limit.")

Previously, the use of `CURRENT_TIMESTAMP` prevented caching of results, according to https://cloud.google.com/bigquery/querying-data#query-caching:

> Query results are not cached:
(...)
If the query uses non-deterministic functions; for example, date and time functions such as CURRENT_TIMESTAMP() and NOW(), and other functions such as CURRENT_USER() return different values depending on when a query is executed
