### PR TITLE
try fixing invalid_call_argument_test on kokoro

### DIFF
--- a/test/core/end2end/invalid_call_argument_test.c
+++ b/test/core/end2end/invalid_call_argument_test.c
@@ -59,7 +59,7 @@ static void prepare_test(int is_client) {
   g_state.is_client = is_client;
   grpc_metadata_array_init(&g_state.initial_metadata_recv);
   grpc_metadata_array_init(&g_state.trailing_metadata_recv);
-  g_state.deadline = grpc_timeout_seconds_to_deadline(2);
+  g_state.deadline = grpc_timeout_seconds_to_deadline(5);
   g_state.cq = grpc_completion_queue_create_for_next(NULL);
   g_state.cqv = cq_verifier_create(g_state.cq);
   g_state.details = grpc_empty_slice();


### PR DESCRIPTION
Tentative fix for https://github.com/grpc/grpc/issues/11284
(I've tried this workaround before and it didn't seem to work, but now after some changes in C-core, it might be effective).