### PR TITLE
Change flaky test query to not exclude Kokoro results

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -83,7 +83,6 @@ def get_flaky_tests(limit=None):
     WHERE
       timestamp >= DATE_ADD(DATE(CURRENT_TIMESTAMP()), -1, "WEEK")
       AND NOT REGEXP_MATCH(job_name, '.*portability.*')
-      AND REGEXP_MATCH(job_name, '.*master.*')
     GROUP BY
       test_name
     HAVING


### PR DESCRIPTION
Since we only upload test results from master Jenkins job, this predicate doesn't filter any Jenkins results. It only filters Kokoro-uploaded results. 

CC @ctiller 