### PR TITLE
fix protobufjs 6 support

### DIFF
--- a/src/node/src/protobuf_js_6_common.js
+++ b/src/node/src/protobuf_js_6_common.js
@@ -49,7 +49,7 @@ exports.deserializeCls = function deserializeCls(cls, options) {
    * @return {cls} The resulting object
    */
   return function deserialize(arg_buf) {
-    return cls.decode(arg_buf).toObject(conversion_options);
+    return cls.decode(arg_buf);
   };
 };
 


### PR DESCRIPTION
This addresses:

> Error: Failed to parse server response

as this method does not exist as of protobufjs 6.8.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/11480)
<!-- Reviewable:end -->
