### PR TITLE
Make use of --build_only apparent in the reports

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -102,6 +102,8 @@ def _generate_jobs(languages, configs, platforms, iomgr_platform = 'native',
           name += '_%s_%s' % (arch, compiler)
           runtests_args += ['--arch', arch,
                             '--compiler', compiler]
+        if '--build_only' in extra_args:
+          name += '_buildonly'
         for extra_env in extra_envs:
           name += '_%s_%s' % (extra_env, extra_envs[extra_env])
 


### PR DESCRIPTION
Currently, some jobs (e.g. portability on PRs) run with --build_only flags, but it's not apparent from the test results page and that can create confusion. With this change the "_buildonly" suffix will appear in the reports.