### PR TITLE
Disable epollex tests until they work reliably.

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -63,8 +63,8 @@ _FORCE_ENVIRON_FOR_WRAPPERS = {
 }
 
 _POLLING_STRATEGIES = {
-  'linux': ['epollex', 'epollsig', 'poll', 'poll-cv'],
-# TODO(ctiller, sreecha): enable epoll1, epoll-thread-pool
+  'linux': ['epollsig', 'poll', 'poll-cv'],
+# TODO(ctiller, sreecha): enable epoll1, epollex, epoll-thread-pool
   'mac': ['poll'],
 }
 


### PR DESCRIPTION
Related PRs: https://github.com/grpc/grpc/pull/11439 (introduction of epollex), https://github.com/grpc/grpc/pull/11479 (partial fix to tests introduced by #11439) 