### PR TITLE
Transitioning from the deprecated TLSv1_2_*method functions to instea…

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1361,8 +1361,10 @@ tsi_result tsi_create_ssl_client_handshaker_factory(
   *factory = nullptr;
   if (pem_root_certs == nullptr) return TSI_INVALID_ARGUMENT;
 
-  ssl_context = SSL_CTX_new(TLSv1_2_method());
-  if (ssl_context == nullptr) {
+  ssl_context = SSL_CTX_new(TLS_method());
+  if (ssl_context == nullptr ||
+      !SSL_CTX_set_min_proto_version(ssl_context, TLS1_2_VERSION) ||
+      !SSL_CTX_set_max_proto_version(ssl_context, TLS1_2_VERSION)) {
     gpr_log(GPR_ERROR, "Could not create ssl context.");
     return TSI_INVALID_ARGUMENT;
   }
@@ -1479,8 +1481,12 @@ tsi_result tsi_create_ssl_server_handshaker_factory_ex(
 
   for (i = 0; i < num_key_cert_pairs; i++) {
     do {
-      impl->ssl_contexts[i] = SSL_CTX_new(TLSv1_2_method());
-      if (impl->ssl_contexts[i] == nullptr) {
+      impl->ssl_contexts[i] = SSL_CTX_new(TLS_method());
+      if (impl->ssl_contexts[i] == nullptr ||
+          !SSL_CTX_set_min_proto_version(impl->ssl_contexts[i],
+                                         TLS1_2_VERSION) ||
+          !SSL_CTX_set_max_proto_version(impl->ssl_contexts[i],
+                                         TLS1_2_VERSION)) {
         gpr_log(GPR_ERROR, "Could not create ssl context.");
         result = TSI_OUT_OF_RESOURCES;
         break;

--- a/test/core/handshake/client_ssl.cc
+++ b/test/core/handshake/client_ssl.cc
@@ -138,9 +138,10 @@ static void server_thread(void* arg) {
   SSL_load_error_strings();
   OpenSSL_add_ssl_algorithms();
 
-  const SSL_METHOD* method = TLSv1_2_server_method();
+  const SSL_METHOD* method = TLS_server_method();
   SSL_CTX* ctx = SSL_CTX_new(method);
-  if (!ctx) {
+  if (!ctx || !SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION) ||
+      !SSL_CTX_set_max_proto_version(ctx, TLS1_2_VERSION)) {
     perror("Unable to create SSL context");
     ERR_print_errors_fp(stderr);
     abort();

--- a/test/core/handshake/server_ssl_common.cc
+++ b/test/core/handshake/server_ssl_common.cc
@@ -143,9 +143,10 @@ bool server_ssl_test(const char* alpn_list[], unsigned int alpn_list_len,
   SSL_load_error_strings();
   OpenSSL_add_ssl_algorithms();
 
-  const SSL_METHOD* method = TLSv1_2_client_method();
+  const SSL_METHOD* method = TLS_client_method();
   SSL_CTX* ctx = SSL_CTX_new(method);
-  if (!ctx) {
+  if (!ctx || !SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION) ||
+      !SSL_CTX_set_max_proto_version(ctx, TLS1_2_VERSION)) {
     perror("Unable to create SSL context");
     ERR_print_errors_fp(stderr);
     abort();


### PR DESCRIPTION
Instead of using TLSv1_2_*method() calls, use TLS_*method as appropriate and follow up with a set_min/max version call in order to ensure we continue to use version 1.2 (and do not default to an older less secure TLS version.)

TLSv1_2_*methods are deprecated in OpenSSL 1.1.

This is part 2 of 2 for addressing https://github.com/grpc/grpc/issues/10589