### PR TITLE
Add support for Trailers-Only responses.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.c
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.c
@@ -1403,6 +1403,8 @@ static void perform_stream_op_locked(grpc_exec_ctx *exec_ctx, void *stream_op,
         op_payload->recv_initial_metadata.recv_initial_metadata_ready;
     s->recv_initial_metadata =
         op_payload->recv_initial_metadata.recv_initial_metadata;
+    s->trailing_metadata_available =
+        op_payload->recv_initial_metadata.trailing_metadata_available;
     grpc_chttp2_maybe_complete_recv_initial_metadata(exec_ctx, t, s);
   }
 

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.c
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.c
@@ -93,7 +93,7 @@ grpc_error *grpc_chttp2_rst_stream_parser_parse(grpc_exec_ctx *exec_ctx,
                       (((uint32_t)p->reason_bytes[2]) << 8) |
                       (((uint32_t)p->reason_bytes[3]));
     grpc_error *error = GRPC_ERROR_NONE;
-    if (reason != GRPC_HTTP2_NO_ERROR || s->header_frames_received < 2) {
+    if (reason != GRPC_HTTP2_NO_ERROR || s->metadata_buffer[1].size == 0) {
       char *message;
       gpr_asprintf(&message, "Received RST_STREAM with error code %d", reason);
       error = grpc_error_set_int(

--- a/src/core/ext/transport/chttp2/transport/hpack_encoder.h
+++ b/src/core/ext/transport/chttp2/transport/hpack_encoder.h
@@ -85,6 +85,8 @@ typedef struct {
 
 void grpc_chttp2_encode_header(grpc_exec_ctx *exec_ctx,
                                grpc_chttp2_hpack_compressor *c,
+                               grpc_mdelem **extra_headers,
+                               size_t extra_headers_size,
                                grpc_metadata_batch *metadata,
                                const grpc_encode_header_options *options,
                                grpc_slice_buffer *outbuf);

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -447,6 +447,7 @@ struct grpc_chttp2_stream {
 
   grpc_metadata_batch *recv_initial_metadata;
   grpc_closure *recv_initial_metadata_ready;
+  bool *trailing_metadata_available;
   grpc_byte_stream **recv_message;
   grpc_closure *recv_message_ready;
   grpc_metadata_batch *recv_trailing_metadata;

--- a/src/core/ext/transport/chttp2/transport/writing.c
+++ b/src/core/ext/transport/chttp2/transport/writing.c
@@ -162,6 +162,20 @@ static uint32_t target_write_size(grpc_chttp2_transport *t) {
   return 1024 * 1024;
 }
 
+// Returns true if initial_metadata contains only default headers.
+//
+// TODO(roth): The fact that we hard-code these particular headers here
+// is fairly ugly.  Need some better way to know which headers are
+// default, maybe via a bit in the static metadata table?
+static bool is_default_initial_metadata(grpc_metadata_batch *initial_metadata) {
+  int num_default_fields =
+      (initial_metadata->idx.named.status != NULL) +
+      (initial_metadata->idx.named.content_type != NULL) +
+      (initial_metadata->idx.named.grpc_encoding != NULL) +
+      (initial_metadata->idx.named.grpc_accept_encoding != NULL);
+  return (size_t)num_default_fields == initial_metadata->list.count;
+}
+
 grpc_chttp2_begin_write_result grpc_chttp2_begin_write(
     grpc_exec_ctx *exec_ctx, grpc_chttp2_transport *t) {
   grpc_chttp2_stream *s;
@@ -218,31 +232,59 @@ grpc_chttp2_begin_write_result grpc_chttp2_begin_write(
         t->is_client ? "CLIENT" : "SERVER", s->id, sent_initial_metadata,
         s->send_initial_metadata != NULL, s->announce_window));
 
+    grpc_mdelem *extra_headers_for_trailing_metadata[2];
+    size_t num_extra_headers_for_trailing_metadata = 0;
+
     /* send initial metadata if it's available */
-    if (!sent_initial_metadata && s->send_initial_metadata) {
-      grpc_encode_header_options hopt = {
-          .stream_id = s->id,
-          .is_eof = false,
-          .use_true_binary_metadata =
-              t->settings
-                  [GRPC_PEER_SETTINGS]
-                  [GRPC_CHTTP2_SETTINGS_GRPC_ALLOW_TRUE_BINARY_METADATA] != 0,
-          .max_frame_size = t->settings[GRPC_PEER_SETTINGS]
-                                       [GRPC_CHTTP2_SETTINGS_MAX_FRAME_SIZE],
-          .stats = &s->stats.outgoing};
-      grpc_chttp2_encode_header(exec_ctx, &t->hpack_compressor,
-                                s->send_initial_metadata, &hopt, &t->outbuf);
+    if (!sent_initial_metadata && s->send_initial_metadata != NULL) {
+      // We skip this on the server side if there is no custom initial
+      // metadata, there are no messages to send, and we are also sending
+      // trailing metadata.  This results in a Trailers-Only response,
+      // which is required for retries, as per:
+      // https://github.com/grpc/proposal/blob/master/A6-client-retries.md#when-retries-are-valid
+      if (t->is_client || s->fetching_send_message != NULL ||
+          s->flow_controlled_buffer.length != 0 ||
+          s->send_trailing_metadata == NULL ||
+          !is_default_initial_metadata(s->send_initial_metadata)) {
+        grpc_encode_header_options hopt = {
+            .stream_id = s->id,
+            .is_eof = false,
+            .use_true_binary_metadata =
+                t->settings
+                    [GRPC_PEER_SETTINGS]
+                    [GRPC_CHTTP2_SETTINGS_GRPC_ALLOW_TRUE_BINARY_METADATA] != 0,
+            .max_frame_size = t->settings[GRPC_PEER_SETTINGS]
+                                         [GRPC_CHTTP2_SETTINGS_MAX_FRAME_SIZE],
+            .stats = &s->stats.outgoing};
+        grpc_chttp2_encode_header(exec_ctx, &t->hpack_compressor, NULL, 0,
+                                  s->send_initial_metadata, &hopt, &t->outbuf);
+        now_writing = true;
+        t->ping_state.pings_before_data_required =
+            t->ping_policy.max_pings_without_data;
+        if (!t->is_client) {
+          t->ping_recv_state.last_ping_recv_time =
+              gpr_inf_past(GPR_CLOCK_MONOTONIC);
+          t->ping_recv_state.ping_strikes = 0;
+        }
+      } else {
+        GRPC_CHTTP2_IF_TRACING(
+            gpr_log(GPR_INFO, "not sending initial_metadata (Trailers-Only)"));
+        // When sending Trailers-Only, we need to move the :status and
+        // content-type headers to the trailers.
+        if (s->send_initial_metadata->idx.named.status != NULL) {
+          extra_headers_for_trailing_metadata
+              [num_extra_headers_for_trailing_metadata++] =
+                  &s->send_initial_metadata->idx.named.status->md;
+        }
+        if (s->send_initial_metadata->idx.named.content_type != NULL) {
+          extra_headers_for_trailing_metadata
+              [num_extra_headers_for_trailing_metadata++] =
+                  &s->send_initial_metadata->idx.named.content_type->md;
+        }
+      }
       s->send_initial_metadata = NULL;
       s->sent_initial_metadata = true;
       sent_initial_metadata = true;
-      now_writing = true;
-      t->ping_state.pings_before_data_required =
-          t->ping_policy.max_pings_without_data;
-      if (!t->is_client) {
-        t->ping_recv_state.last_ping_recv_time =
-            gpr_inf_past(GPR_CLOCK_MONOTONIC);
-        t->ping_recv_state.ping_strikes = 0;
-      }
     }
     /* send any window updates */
     if (s->announce_window > 0) {
@@ -320,6 +362,7 @@ grpc_chttp2_begin_write_result grpc_chttp2_begin_write(
       if (s->send_trailing_metadata != NULL &&
           s->fetching_send_message == NULL &&
           s->flow_controlled_buffer.length == 0) {
+        GRPC_CHTTP2_IF_TRACING(gpr_log(GPR_INFO, "sending trailing_metadata"));
         if (grpc_metadata_batch_is_empty(s->send_trailing_metadata)) {
           grpc_chttp2_encode_data(s->id, &s->flow_controlled_buffer, 0, true,
                                   &s->stats.outgoing, &t->outbuf);
@@ -337,6 +380,8 @@ grpc_chttp2_begin_write_result grpc_chttp2_begin_write(
                              [GRPC_CHTTP2_SETTINGS_MAX_FRAME_SIZE],
               .stats = &s->stats.outgoing};
           grpc_chttp2_encode_header(exec_ctx, &t->hpack_compressor,
+                                    extra_headers_for_trailing_metadata,
+                                    num_extra_headers_for_trailing_metadata,
                                     s->send_trailing_metadata, &hopt,
                                     &t->outbuf);
         }

--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -165,6 +165,10 @@ struct grpc_transport_stream_op_batch_payload {
     uint32_t *recv_flags;
     /** Should be enqueued when initial metadata is ready to be processed. */
     grpc_closure *recv_initial_metadata_ready;
+    // If not NULL, will be set to true if trailing metadata is
+    // immediately available.  This may be a signal that we received a
+    // Trailers-Only response.
+    bool *trailing_metadata_available;
   } recv_initial_metadata;
 
   struct {

--- a/test/core/transport/chttp2/hpack_encoder_test.c
+++ b/test/core/transport/chttp2/hpack_encoder_test.c
@@ -95,7 +95,8 @@ static void verify(grpc_exec_ctx *exec_ctx, size_t window_available, bool eof,
       .max_frame_size = 16384,
       .stats = &stats,
   };
-  grpc_chttp2_encode_header(exec_ctx, &g_compressor, &b, &hopt, &output);
+  grpc_chttp2_encode_header(exec_ctx, &g_compressor, NULL, 0, &b, &hopt,
+                            &output);
   merged = grpc_slice_merge(output.slices, output.count);
   grpc_slice_buffer_destroy_internal(exec_ctx, &output);
   grpc_metadata_batch_destroy(exec_ctx, &b);
@@ -213,7 +214,8 @@ static void verify_table_size_change_match_elem_size(grpc_exec_ctx *exec_ctx,
                                      .use_true_binary_metadata = false,
                                      .max_frame_size = 16384,
                                      .stats = &stats};
-  grpc_chttp2_encode_header(exec_ctx, &g_compressor, &b, &hopt, &output);
+  grpc_chttp2_encode_header(exec_ctx, &g_compressor, NULL, 0, &b, &hopt,
+                            &output);
   grpc_slice_buffer_destroy_internal(exec_ctx, &output);
   grpc_metadata_batch_destroy(exec_ctx, &b);
 

--- a/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
@@ -82,7 +82,7 @@ static void BM_HpackEncoderEncodeHeader(benchmark::State &state) {
         (size_t)state.range(1),
         &stats,
     };
-    grpc_chttp2_encode_header(&exec_ctx, &c, &b, &hopt, &outbuf);
+    grpc_chttp2_encode_header(&exec_ctx, &c, NULL, 0, &b, &hopt, &outbuf);
     if (!logged_representative_output && state.iterations() > 3) {
       logged_representative_output = true;
       for (size_t i = 0; i < outbuf.count; i++) {


### PR DESCRIPTION
Fixes #9883.  Replacement for #10906.

- When receiving a Trailers-Only response, return the metadata as
  trailing metadata instead of initial metadata.
- Send Trailers-Only response when we have no non-default initial metadata,
  no message to send, and trailing metadata to send.

I'm not crazy about the way this is detecting non-default initial metadata, but I don't see a better solution right now.  Suggestions welcome.