### PR TITLE
Upgrade Protobuf.js 6 code to work with 6.8

### DIFF
--- a/src/node/src/protobuf_js_6_common.js
+++ b/src/node/src/protobuf_js_6_common.js
@@ -64,7 +64,7 @@ exports.deserializeCls = function deserializeCls(cls, options) {
    * @return {cls} The resulting object
    */
   return function deserialize(arg_buf) {
-    return cls.decode(arg_buf).toObject(conversion_options);
+    return cls.toObject(cls.decode(arg_buf), conversion_options);
   };
 };
 


### PR DESCRIPTION
There were (unfortunately) breaking changes that affected us in Protobuf.js 6.8, but it's simple enough to account for them without breaking compatibility with 6.7 (what we were using before). This fixes #11484.