### PR TITLE
Fix varargs compiler warning in a test

### DIFF
--- a/test/core/channel/minimal_stack_is_minimal_test.c
+++ b/test/core/channel/minimal_stack_is_minimal_test.c
@@ -44,7 +44,7 @@
 // use CHECK_STACK instead
 static int check_stack(const char *file, int line, const char *transport_name,
                        grpc_channel_args *init_args,
-                       grpc_channel_stack_type channel_stack_type, ...);
+                       unsigned channel_stack_type, ...);
 
 // arguments: const char *transport_name   - the name of the transport type to
 //                                           simulate
@@ -111,7 +111,7 @@ int main(int argc, char **argv) {
 
 static int check_stack(const char *file, int line, const char *transport_name,
                        grpc_channel_args *init_args,
-                       grpc_channel_stack_type channel_stack_type, ...) {
+                       unsigned channel_stack_type, ...) {
   // create dummy channel stack
   grpc_channel_stack_builder *builder = grpc_channel_stack_builder_create();
   grpc_transport_vtable fake_transport_vtable = {.name = transport_name};
@@ -125,8 +125,8 @@ static int check_stack(const char *file, int line, const char *transport_name,
     grpc_exec_ctx exec_ctx = GRPC_EXEC_CTX_INIT;
     grpc_channel_stack_builder_set_channel_arguments(&exec_ctx, builder,
                                                      channel_args);
-    GPR_ASSERT(
-        grpc_channel_init_create_stack(&exec_ctx, builder, channel_stack_type));
+    GPR_ASSERT(grpc_channel_init_create_stack(
+        &exec_ctx, builder, (grpc_channel_stack_type)channel_stack_type));
     grpc_exec_ctx_finish(&exec_ctx);
   }
 


### PR DESCRIPTION
I'm seeing builds of core tests right now under sanitizer configs with clang <i>3.9</i> installed (our `cxx_jessie_x64` docker file has clang 3.8), fail with:

```
test/core/channel/minimal_stack_is_minimal_test.c:137:18: error: passing an object that undergoes default argument promotion to 'va_start' has undefined behavior [-Werror,-Wvarargs]
  va_start(args, channel_stack_type);
                 ^
test/core/channel/minimal_stack_is_minimal_test.c:114:48: note: parameter of type 'grpc_channel_stack_type' is declared here
                       grpc_channel_stack_type channel_stack_type, ...) {
                                               ^
1 error generated.
```