### PR TITLE
Correct a constructor call in ruby credentials test

### DIFF
--- a/src/ruby/spec/channel_credentials_spec.rb
+++ b/src/ruby/spec/channel_credentials_spec.rb
@@ -20,7 +20,7 @@ describe GRPC::Core::ChannelCredentials do
 
   def load_test_certs
     test_root = File.join(File.dirname(__FILE__), 'testdata')
-    files = ['ca.pem', 'server1.pem', 'server1.key']
+    files = ['ca.pem', 'server1.key', 'server1.pem']
     files.map { |f| File.open(File.join(test_root, f)).read }
   end
 


### PR DESCRIPTION
pointed out by  a comment in https://github.com/grpc/grpc/pull/10529#pullrequestreview-44137221.

credentials in this test aren't actually used, so the currently incorrect order is working, but looks like a sort of doc issue