### PR TITLE
Fix missing return after callback in a function

### DIFF
--- a/src/node/src/client.js
+++ b/src/node/src/client.js
@@ -152,6 +152,7 @@ function _write(chunk, encoding, callback) {
     /* Once a write fails, just call the callback immediately to let the caller
        flush any pending writes. */
     setImmediate(callback);
+    return;
   }
   try {
     message = this.serialize(chunk);

--- a/src/node/src/client.js
+++ b/src/node/src/client.js
@@ -165,6 +165,7 @@ function _write(chunk, encoding, callback) {
     this.call.cancelWithStatus(constants.status.INTERNAL,
                                'Serialization failure');
     callback(e);
+    return;
   }
   if (_.isFinite(encoding)) {
     /* Attach the encoding if it is a finite number. This is the closest we


### PR DESCRIPTION
This fixes a bug that was reported in #11514.