### PR TITLE
Clear alarms in jobset.py when finished running jobs

### DIFF
--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -473,6 +473,8 @@ class Jobset(object):
     while self._running:
       if self.cancelled(): pass  # poll cancellation
       self.reap()
+    if platform_string() != 'windows':
+      signal.alarm(0)
     return not self.cancelled() and self._failures == 0
 
 


### PR DESCRIPTION
Potentially fixes #10388

Addresses a possible race condition where a signal alarm persists after its signal handler is terminated.