### PR TITLE
Fix ObjC memory leak problem

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.m
@@ -182,12 +182,15 @@ static grpc_channel_args *BuildChannelArgs(NSDictionary *dictionary) {
 
 - (grpc_call *)unmanagedCallWithPath:(NSString *)path
                      completionQueue:(GRPCCompletionQueue *)queue {
-  return grpc_channel_create_call(_unmanagedChannel,
-                                  NULL, GRPC_PROPAGATE_DEFAULTS,
-                                  queue.unmanagedQueue,
-                                  grpc_slice_from_copied_string(path.UTF8String),
-                                  NULL, // Passing NULL for host
-                                  gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
+  grpc_slice path_slice = grpc_slice_from_copied_string(path.UTF8String);
+  grpc_call *call = grpc_channel_create_call(_unmanagedChannel,
+                                             NULL, GRPC_PROPAGATE_DEFAULTS,
+                                             queue.unmanagedQueue,
+                                             path_slice,
+                                             NULL, // Passing NULL for host
+                                             gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
+  grpc_slice_unref(path_slice);
+  return call;
 }
 
 @end


### PR DESCRIPTION
The `method` parameter of `grpc_channel_create_call` is reffed in this function and then owned by C core. ObjC should release the ownership and unref it after this API call.

Fixes #11486 and #11494.