### PR TITLE
Fix warnings with GCC 7.

### DIFF
--- a/include/grpc++/impl/codegen/call.h
+++ b/include/grpc++/impl/codegen/call.h
@@ -424,7 +424,7 @@ class CallOpClientSendClose {
 
 class CallOpServerSendStatus {
  public:
-  CallOpServerSendStatus() : send_status_available_(false) {}
+  CallOpServerSendStatus() : send_status_available_(false), send_status_code_(GRPC_STATUS_OK) {}
 
   void ServerSendStatus(
       const std::multimap<grpc::string, grpc::string>& trailing_metadata,
@@ -500,7 +500,7 @@ class CallOpRecvInitialMetadata {
 
 class CallOpClientRecvStatus {
  public:
-  CallOpClientRecvStatus() : recv_status_(nullptr) {}
+  CallOpClientRecvStatus() : recv_status_(nullptr), status_code_(GRPC_STATUS_OK) {}
 
   void ClientRecvStatus(ClientContext* context, Status* status) {
     metadata_map_ = &context->trailing_metadata_;
@@ -573,7 +573,7 @@ class CallOpSet : public CallOpSetInterface,
                   public Op5,
                   public Op6 {
  public:
-  CallOpSet() : return_tag_(this) {}
+  CallOpSet() : return_tag_(this), call_(nullptr) {}
   void FillOps(grpc_call* call, grpc_op* ops, size_t* nops) override {
     this->Op1::AddOp(ops, nops);
     this->Op2::AddOp(ops, nops);

--- a/src/core/ext/transport/chttp2/transport/bin_decoder.c
+++ b/src/core/ext/transport/chttp2/transport/bin_decoder.c
@@ -118,6 +118,7 @@ bool grpc_base64_decode_partial(struct grpc_base64_decode_context *ctx) {
       switch (input_tail) {
         case 3:
           ctx->output_cur[1] = COMPOSE_OUTPUT_BYTE_1(ctx->input_cur);
+	/* fallthrough */
         case 2:
           ctx->output_cur[0] = COMPOSE_OUTPUT_BYTE_0(ctx->input_cur);
       }

--- a/src/core/ext/transport/chttp2/transport/varint.c
+++ b/src/core/ext/transport/chttp2/transport/varint.c
@@ -37,12 +37,16 @@ void grpc_chttp2_hpack_write_varint_tail(uint32_t tail_value, uint8_t* target,
   switch (tail_length) {
     case 5:
       target[4] = (uint8_t)((tail_value >> 28) | 0x80);
+    /* fallthrough */
     case 4:
       target[3] = (uint8_t)((tail_value >> 21) | 0x80);
+    /* fallthrough */
     case 3:
       target[2] = (uint8_t)((tail_value >> 14) | 0x80);
+    /* fallthrough */
     case 2:
       target[1] = (uint8_t)((tail_value >> 7) | 0x80);
+    /* fallthrough */
     case 1:
       target[0] = (uint8_t)((tail_value) | 0x80);
   }

--- a/src/core/ext/transport/cronet/transport/cronet_transport.c
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.c
@@ -649,7 +649,7 @@ static void create_grpc_frame(grpc_slice_buffer *write_slice_buffer,
   uint8_t *p = (uint8_t *)write_buffer;
   /* Append 5 byte header */
   /* Compressed flag */
-  *p++ = (flags & GRPC_WRITE_INTERNAL_COMPRESS) ? 1 : 0;
+  *p++ = (uint8_t) ((flags & GRPC_WRITE_INTERNAL_COMPRESS) ? 1 : 0);
   /* Message length */
   *p++ = (uint8_t)(length >> 24);
   *p++ = (uint8_t)(length >> 16);

--- a/src/core/lib/json/json_reader.c
+++ b/src/core/lib/json/json_reader.c
@@ -177,7 +177,7 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader *reader) {
             if (!success) return GRPC_JSON_PARSE_ERROR;
             json_reader_string_clear(reader);
             reader->state = GRPC_JSON_STATE_VALUE_END;
-          /* The missing break here is intentional. */
+          /* fallthrough */
 
           case GRPC_JSON_STATE_VALUE_END:
           case GRPC_JSON_STATE_OBJECT_KEY_BEGIN:

--- a/src/core/lib/support/murmur_hash.c
+++ b/src/core/lib/support/murmur_hash.c
@@ -62,8 +62,10 @@ uint32_t gpr_murmur_hash3(const void *key, size_t len, uint32_t seed) {
   switch (len & 3) {
     case 3:
       k1 ^= ((uint32_t)tail[2]) << 16;
+    /* fallthrough */
     case 2:
       k1 ^= ((uint32_t)tail[1]) << 8;
+    /* fallthrough */
     case 1:
       k1 ^= tail[0];
       k1 *= c1;


### PR DESCRIPTION
This fixes various warnings that I got with GCC 7.1.1.

Note that the changes to  src/core/tsi/ssl_transport_security.c are only relevant for OpenSSL 1.1 (#10589); this change alone will not let it compile with OpenSSL 1.1, but it will compile after #11495 and #11496 are merged.