### PR TITLE
don't try to use sched_getcpu() if glibc is < 2.6

### DIFF
--- a/src/core/lib/support/cpu_linux.c
+++ b/src/core/lib/support/cpu_linux.c
@@ -52,8 +52,8 @@ unsigned gpr_cpu_num_cores(void) {
 }
 
 unsigned gpr_cpu_current_cpu(void) {
-#ifdef GPR_MUSL_LIBC_COMPAT
-  // sched_getcpu() is undefined on musl
+#if defined GPR_MUSL_LIBC_COMPAT || !__GLIBC_PREREQ(2,6)
+  // sched_getcpu() is undefined on musl and glibc < 2.6
   return 0;
 #else
   int cpu = sched_getcpu();


### PR DESCRIPTION
In addition to not being available in musl, sched_getcpu() is not
available if the glibc version is less than 2.6.  Fall back to not
determining the correct current CPU if the call is not available,
similar to what is done when musl is used.