### PR TITLE
Update performance JSON schema

### DIFF
--- a/tools/run_tests/performance/scenario_result_schema.json
+++ b/tools/run_tests/performance/scenario_result_schema.json
@@ -107,6 +107,11 @@
         "name": "timeSystem",
         "type": "FLOAT",
         "mode": "NULLABLE"
+      },
+      {
+        "name": "cqpollcount",
+        "type": "INTEGER",
+        "mode": "NULLABLE"
       }
     ]
   },
@@ -128,6 +133,11 @@
       {
         "name": "timeSystem",
         "type": "FLOAT",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "cqpollcount",
+        "type": "INTEGER",
         "mode": "NULLABLE"
       }
     ]
@@ -194,6 +204,16 @@
       },
       {
         "name": "latency999",
+        "type": "FLOAT",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "clientpollsperrequest",
+        "type": "FLOAT",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "serverpollsperrequest",
         "type": "FLOAT",
         "mode": "NULLABLE"
       }


### PR DESCRIPTION
These are the missing fields causing uploads to BQ to fail. Will I have to manually add these fields to the schema in BQ or will updating the JSON automatically update the schema in BQ?