### PR TITLE
Use openssl headers when ssl provider is package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ if("${gRPC_SSL_PROVIDER}" STREQUAL "module")
     add_subdirectory(${BORINGSSL_ROOT_DIR} third_party/boringssl)
     if(TARGET ssl)
       set(_gRPC_SSL_LIBRARIES ssl)
+      set(_gRPC_SSL_INCLUDE_DIR ${BORINGSSL_ROOT_DIR}/include)
     endif()
   else()
       message(WARNING "gRPC_SSL_PROVIDER is \"module\" but BORINGSSL_ROOT_DIR is wrong")
@@ -245,6 +246,7 @@ elseif("${gRPC_SSL_PROVIDER}" STREQUAL "package")
   find_package(OpenSSL)
   if(TARGET OpenSSL::SSL)
     set(_gRPC_SSL_LIBRARIES OpenSSL::SSL)
+    set(_gRPC_SSL_INCLUDE_DIR ${OPENSSL_INCLUDE_DIR})
   endif()
   set(_gRPC_FIND_SSL "if(NOT OpenSSL_FOUND)\n  find_package(OpenSSL)\nendif()")
 endif()
@@ -829,7 +831,7 @@ endif()
 target_include_directories(gpr
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -921,7 +923,7 @@ endif()
 target_include_directories(gpr_test_util
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -1208,7 +1210,7 @@ endif()
 target_include_directories(grpc
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -1507,7 +1509,7 @@ endif()
 target_include_directories(grpc_cronet
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -1743,7 +1745,7 @@ endif()
 target_include_directories(grpc_test_util
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -1837,7 +1839,7 @@ endif()
 target_include_directories(grpc_test_util_unsecure
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -2098,7 +2100,7 @@ endif()
 target_include_directories(grpc_unsecure
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -2188,7 +2190,7 @@ endif()
 target_include_directories(reconnect_server
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -2232,7 +2234,7 @@ endif()
 target_include_directories(test_tcp_server
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -2318,7 +2320,7 @@ endif()
 target_include_directories(grpc++
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -2705,7 +2707,7 @@ endif()
 target_include_directories(grpc++_cronet
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -2878,7 +2880,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(grpc++_error_details
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -2945,7 +2947,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(grpc++_proto_reflection_desc_db
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -3008,7 +3010,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(grpc++_reflection
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -3068,7 +3070,7 @@ endif()
 target_include_directories(grpc++_test_config
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -3148,7 +3150,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(grpc++_test_util
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -3292,7 +3294,7 @@ endif()
 target_include_directories(grpc++_unsecure
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -3446,7 +3448,7 @@ endif()
 target_include_directories(grpc_benchmark
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -3507,7 +3509,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(grpc_cli_libs
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -3569,7 +3571,7 @@ endif()
 target_include_directories(grpc_plugin_support
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -3649,7 +3651,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(http2_client_main
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -3706,7 +3708,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(interop_client_helper
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -3778,7 +3780,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(interop_client_main
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -3831,7 +3833,7 @@ endif()
 target_include_directories(interop_server_helper
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -3902,7 +3904,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(interop_server_lib
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -3955,7 +3957,7 @@ endif()
 target_include_directories(interop_server_main
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -4045,7 +4047,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(qps
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -4093,7 +4095,7 @@ endif()
 target_include_directories(grpc_csharp_ext
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -4190,7 +4192,7 @@ endif()
 target_include_directories(ares
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -4230,7 +4232,7 @@ endif()
 target_include_directories(bad_client_test
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -4273,7 +4275,7 @@ endif()
 target_include_directories(bad_ssl_test_server
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -4372,7 +4374,7 @@ endif()
 target_include_directories(end2end_tests
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -4471,7 +4473,7 @@ endif()
 target_include_directories(end2end_nosec_tests
   PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${ZLIB_INCLUDE_DIR}
   PRIVATE ${BENCHMARK}/include
@@ -4504,7 +4506,7 @@ add_executable(alarm_test
 target_include_directories(alarm_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4535,7 +4537,7 @@ add_executable(algorithm_test
 target_include_directories(algorithm_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4566,7 +4568,7 @@ add_executable(alloc_test
 target_include_directories(alloc_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4595,7 +4597,7 @@ add_executable(alpn_test
 target_include_directories(alpn_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4626,7 +4628,7 @@ add_executable(arena_test
 target_include_directories(arena_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4655,7 +4657,7 @@ add_executable(bad_server_response_test
 target_include_directories(bad_server_response_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4687,7 +4689,7 @@ add_executable(bdp_estimator_test
 target_include_directories(bdp_estimator_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4718,7 +4720,7 @@ add_executable(bin_decoder_test
 target_include_directories(bin_decoder_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4747,7 +4749,7 @@ add_executable(bin_encoder_test
 target_include_directories(bin_encoder_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4776,7 +4778,7 @@ add_executable(census_context_test
 target_include_directories(census_context_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4807,7 +4809,7 @@ add_executable(census_intrusive_hash_map_test
 target_include_directories(census_intrusive_hash_map_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4838,7 +4840,7 @@ add_executable(census_resource_test
 target_include_directories(census_resource_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4869,7 +4871,7 @@ add_executable(census_trace_context_test
 target_include_directories(census_trace_context_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4900,7 +4902,7 @@ add_executable(channel_create_test
 target_include_directories(channel_create_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4930,7 +4932,7 @@ add_executable(check_epollexclusive
 target_include_directories(check_epollexclusive
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4967,7 +4969,7 @@ add_executable(chttp2_hpack_encoder_test
 target_include_directories(chttp2_hpack_encoder_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -4998,7 +5000,7 @@ add_executable(chttp2_stream_map_test
 target_include_directories(chttp2_stream_map_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5029,7 +5031,7 @@ add_executable(chttp2_varint_test
 target_include_directories(chttp2_varint_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5060,7 +5062,7 @@ add_executable(combiner_test
 target_include_directories(combiner_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5091,7 +5093,7 @@ add_executable(compression_test
 target_include_directories(compression_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5122,7 +5124,7 @@ add_executable(concurrent_connectivity_test
 target_include_directories(concurrent_connectivity_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5153,7 +5155,7 @@ add_executable(connection_refused_test
 target_include_directories(connection_refused_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5184,7 +5186,7 @@ add_executable(dns_resolver_connectivity_test
 target_include_directories(dns_resolver_connectivity_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5215,7 +5217,7 @@ add_executable(dns_resolver_test
 target_include_directories(dns_resolver_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5247,7 +5249,7 @@ add_executable(dualstack_socket_test
 target_include_directories(dualstack_socket_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5279,7 +5281,7 @@ add_executable(endpoint_pair_test
 target_include_directories(endpoint_pair_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5310,7 +5312,7 @@ add_executable(error_test
 target_include_directories(error_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5342,7 +5344,7 @@ add_executable(ev_epollsig_linux_test
 target_include_directories(ev_epollsig_linux_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5374,7 +5376,7 @@ add_executable(fake_resolver_test
 target_include_directories(fake_resolver_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5406,7 +5408,7 @@ add_executable(fd_conservation_posix_test
 target_include_directories(fd_conservation_posix_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5439,7 +5441,7 @@ add_executable(fd_posix_test
 target_include_directories(fd_posix_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5471,7 +5473,7 @@ add_executable(fling_client
 target_include_directories(fling_client
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5502,7 +5504,7 @@ add_executable(fling_server
 target_include_directories(fling_server
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5534,7 +5536,7 @@ add_executable(fling_stream_test
 target_include_directories(fling_stream_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5567,7 +5569,7 @@ add_executable(fling_test
 target_include_directories(fling_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5598,7 +5600,7 @@ add_executable(gen_hpack_tables
 target_include_directories(gen_hpack_tables
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5634,7 +5636,7 @@ add_executable(gen_legal_metadata_characters
 target_include_directories(gen_legal_metadata_characters
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5668,7 +5670,7 @@ add_executable(gen_percent_encoding_tables
 target_include_directories(gen_percent_encoding_tables
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5704,7 +5706,7 @@ add_executable(goaway_server_test
 target_include_directories(goaway_server_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5736,7 +5738,7 @@ add_executable(gpr_avl_test
 target_include_directories(gpr_avl_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5765,7 +5767,7 @@ add_executable(gpr_backoff_test
 target_include_directories(gpr_backoff_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5794,7 +5796,7 @@ add_executable(gpr_cmdline_test
 target_include_directories(gpr_cmdline_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5823,7 +5825,7 @@ add_executable(gpr_cpu_test
 target_include_directories(gpr_cpu_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5852,7 +5854,7 @@ add_executable(gpr_env_test
 target_include_directories(gpr_env_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5881,7 +5883,7 @@ add_executable(gpr_histogram_test
 target_include_directories(gpr_histogram_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5910,7 +5912,7 @@ add_executable(gpr_host_port_test
 target_include_directories(gpr_host_port_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5939,7 +5941,7 @@ add_executable(gpr_log_test
 target_include_directories(gpr_log_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5968,7 +5970,7 @@ add_executable(gpr_mpscq_test
 target_include_directories(gpr_mpscq_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -5997,7 +5999,7 @@ add_executable(gpr_spinlock_test
 target_include_directories(gpr_spinlock_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6055,7 +6057,7 @@ add_executable(gpr_string_test
 target_include_directories(gpr_string_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6084,7 +6086,7 @@ add_executable(gpr_sync_test
 target_include_directories(gpr_sync_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6113,7 +6115,7 @@ add_executable(gpr_thd_test
 target_include_directories(gpr_thd_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6142,7 +6144,7 @@ add_executable(gpr_time_test
 target_include_directories(gpr_time_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6171,7 +6173,7 @@ add_executable(gpr_tls_test
 target_include_directories(gpr_tls_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6200,7 +6202,7 @@ add_executable(gpr_useful_test
 target_include_directories(gpr_useful_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6229,7 +6231,7 @@ add_executable(grpc_auth_context_test
 target_include_directories(grpc_auth_context_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6260,7 +6262,7 @@ add_executable(grpc_b64_test
 target_include_directories(grpc_b64_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6291,7 +6293,7 @@ add_executable(grpc_byte_buffer_reader_test
 target_include_directories(grpc_byte_buffer_reader_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6322,7 +6324,7 @@ add_executable(grpc_channel_args_test
 target_include_directories(grpc_channel_args_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6353,7 +6355,7 @@ add_executable(grpc_channel_stack_test
 target_include_directories(grpc_channel_stack_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6384,7 +6386,7 @@ add_executable(grpc_completion_queue_test
 target_include_directories(grpc_completion_queue_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6415,7 +6417,7 @@ add_executable(grpc_completion_queue_threading_test
 target_include_directories(grpc_completion_queue_threading_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6445,7 +6447,7 @@ add_executable(grpc_create_jwt
 target_include_directories(grpc_create_jwt
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6483,7 +6485,7 @@ add_executable(grpc_credentials_test
 target_include_directories(grpc_credentials_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6514,7 +6516,7 @@ add_executable(grpc_fetch_oauth2
 target_include_directories(grpc_fetch_oauth2
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6545,7 +6547,7 @@ add_executable(grpc_invalid_channel_args_test
 target_include_directories(grpc_invalid_channel_args_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6577,7 +6579,7 @@ add_executable(grpc_json_token_test
 target_include_directories(grpc_json_token_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6609,7 +6611,7 @@ add_executable(grpc_jwt_verifier_test
 target_include_directories(grpc_jwt_verifier_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6639,7 +6641,7 @@ add_executable(grpc_print_google_default_creds_token
 target_include_directories(grpc_print_google_default_creds_token
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6676,7 +6678,7 @@ add_executable(grpc_security_connector_test
 target_include_directories(grpc_security_connector_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6706,7 +6708,7 @@ add_executable(grpc_verify_jwt
 target_include_directories(grpc_verify_jwt
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6744,7 +6746,7 @@ add_executable(handshake_client
 target_include_directories(handshake_client
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6778,7 +6780,7 @@ add_executable(handshake_server
 target_include_directories(handshake_server
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6811,7 +6813,7 @@ add_executable(hpack_parser_test
 target_include_directories(hpack_parser_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6842,7 +6844,7 @@ add_executable(hpack_table_test
 target_include_directories(hpack_table_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6873,7 +6875,7 @@ add_executable(http_parser_test
 target_include_directories(http_parser_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6904,7 +6906,7 @@ add_executable(httpcli_format_request_test
 target_include_directories(httpcli_format_request_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6936,7 +6938,7 @@ add_executable(httpcli_test
 target_include_directories(httpcli_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -6969,7 +6971,7 @@ add_executable(httpscli_test
 target_include_directories(httpscli_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7001,7 +7003,7 @@ add_executable(init_test
 target_include_directories(init_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7032,7 +7034,7 @@ add_executable(invalid_call_argument_test
 target_include_directories(invalid_call_argument_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7063,7 +7065,7 @@ add_executable(json_rewrite
 target_include_directories(json_rewrite
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7092,7 +7094,7 @@ add_executable(json_rewrite_test
 target_include_directories(json_rewrite_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7123,7 +7125,7 @@ add_executable(json_stream_error_test
 target_include_directories(json_stream_error_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7154,7 +7156,7 @@ add_executable(json_test
 target_include_directories(json_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7185,7 +7187,7 @@ add_executable(lame_client_test
 target_include_directories(lame_client_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7216,7 +7218,7 @@ add_executable(lb_policies_test
 target_include_directories(lb_policies_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7247,7 +7249,7 @@ add_executable(load_file_test
 target_include_directories(load_file_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7278,7 +7280,7 @@ add_executable(memory_profile_client
 target_include_directories(memory_profile_client
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7309,7 +7311,7 @@ add_executable(memory_profile_server
 target_include_directories(memory_profile_server
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7341,7 +7343,7 @@ add_executable(memory_profile_test
 target_include_directories(memory_profile_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7373,7 +7375,7 @@ add_executable(message_compress_test
 target_include_directories(message_compress_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7404,7 +7406,7 @@ add_executable(minimal_stack_is_minimal_test
 target_include_directories(minimal_stack_is_minimal_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7435,7 +7437,7 @@ add_executable(mlog_test
 target_include_directories(mlog_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7466,7 +7468,7 @@ add_executable(multiple_server_queues_test
 target_include_directories(multiple_server_queues_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7497,7 +7499,7 @@ add_executable(murmur_hash_test
 target_include_directories(murmur_hash_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7526,7 +7528,7 @@ add_executable(no_server_test
 target_include_directories(no_server_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7557,7 +7559,7 @@ add_executable(num_external_connectivity_watchers_test
 target_include_directories(num_external_connectivity_watchers_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7588,7 +7590,7 @@ add_executable(parse_address_test
 target_include_directories(parse_address_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7619,7 +7621,7 @@ add_executable(percent_encoding_test
 target_include_directories(percent_encoding_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7651,7 +7653,7 @@ add_executable(pollset_set_test
 target_include_directories(pollset_set_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7684,7 +7686,7 @@ add_executable(resolve_address_posix_test
 target_include_directories(resolve_address_posix_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7716,7 +7718,7 @@ add_executable(resolve_address_test
 target_include_directories(resolve_address_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7747,7 +7749,7 @@ add_executable(resource_quota_test
 target_include_directories(resource_quota_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7778,7 +7780,7 @@ add_executable(secure_channel_create_test
 target_include_directories(secure_channel_create_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7809,7 +7811,7 @@ add_executable(secure_endpoint_test
 target_include_directories(secure_endpoint_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7840,7 +7842,7 @@ add_executable(sequential_connectivity_test
 target_include_directories(sequential_connectivity_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7871,7 +7873,7 @@ add_executable(server_chttp2_test
 target_include_directories(server_chttp2_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7902,7 +7904,7 @@ add_executable(server_test
 target_include_directories(server_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7933,7 +7935,7 @@ add_executable(slice_buffer_test
 target_include_directories(slice_buffer_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7964,7 +7966,7 @@ add_executable(slice_hash_table_test
 target_include_directories(slice_hash_table_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -7995,7 +7997,7 @@ add_executable(slice_string_helpers_test
 target_include_directories(slice_string_helpers_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8026,7 +8028,7 @@ add_executable(slice_test
 target_include_directories(slice_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8057,7 +8059,7 @@ add_executable(sockaddr_resolver_test
 target_include_directories(sockaddr_resolver_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8088,7 +8090,7 @@ add_executable(sockaddr_utils_test
 target_include_directories(sockaddr_utils_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8120,7 +8122,7 @@ add_executable(socket_utils_test
 target_include_directories(socket_utils_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8152,7 +8154,7 @@ add_executable(status_conversion_test
 target_include_directories(status_conversion_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8183,7 +8185,7 @@ add_executable(stream_owned_slice_test
 target_include_directories(stream_owned_slice_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8215,7 +8217,7 @@ add_executable(tcp_client_posix_test
 target_include_directories(tcp_client_posix_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8247,7 +8249,7 @@ add_executable(tcp_client_uv_test
 target_include_directories(tcp_client_uv_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8279,7 +8281,7 @@ add_executable(tcp_posix_test
 target_include_directories(tcp_posix_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8312,7 +8314,7 @@ add_executable(tcp_server_posix_test
 target_include_directories(tcp_server_posix_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8344,7 +8346,7 @@ add_executable(tcp_server_uv_test
 target_include_directories(tcp_server_uv_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8375,7 +8377,7 @@ add_executable(time_averaged_stats_test
 target_include_directories(time_averaged_stats_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8406,7 +8408,7 @@ add_executable(timeout_encoding_test
 target_include_directories(timeout_encoding_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8437,7 +8439,7 @@ add_executable(timer_heap_test
 target_include_directories(timer_heap_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8468,7 +8470,7 @@ add_executable(timer_list_test
 target_include_directories(timer_list_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8499,7 +8501,7 @@ add_executable(transport_connectivity_state_test
 target_include_directories(transport_connectivity_state_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8530,7 +8532,7 @@ add_executable(transport_metadata_test
 target_include_directories(transport_metadata_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8561,7 +8563,7 @@ add_executable(transport_pid_controller_test
 target_include_directories(transport_pid_controller_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8593,7 +8595,7 @@ add_executable(transport_security_test
 target_include_directories(transport_security_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8626,7 +8628,7 @@ add_executable(udp_server_test
 target_include_directories(udp_server_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8658,7 +8660,7 @@ add_executable(uri_parser_test
 target_include_directories(uri_parser_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8690,7 +8692,7 @@ add_executable(wakeup_fd_cv_test
 target_include_directories(wakeup_fd_cv_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8724,7 +8726,7 @@ add_executable(alarm_cpp_test
 target_include_directories(alarm_cpp_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8766,7 +8768,7 @@ add_executable(async_end2end_test
 target_include_directories(async_end2end_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8808,7 +8810,7 @@ add_executable(auth_property_iterator_test
 target_include_directories(auth_property_iterator_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8851,7 +8853,7 @@ add_executable(bm_arena
 target_include_directories(bm_arena
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8897,7 +8899,7 @@ add_executable(bm_call_create
 target_include_directories(bm_call_create
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8943,7 +8945,7 @@ add_executable(bm_chttp2_hpack
 target_include_directories(bm_chttp2_hpack
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -8989,7 +8991,7 @@ add_executable(bm_chttp2_transport
 target_include_directories(bm_chttp2_transport
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9035,7 +9037,7 @@ add_executable(bm_closure
 target_include_directories(bm_closure
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9081,7 +9083,7 @@ add_executable(bm_cq
 target_include_directories(bm_cq
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9127,7 +9129,7 @@ add_executable(bm_cq_multiple_threads
 target_include_directories(bm_cq_multiple_threads
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9173,7 +9175,7 @@ add_executable(bm_error
 target_include_directories(bm_error
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9219,7 +9221,7 @@ add_executable(bm_fullstack_streaming_ping_pong
 target_include_directories(bm_fullstack_streaming_ping_pong
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9265,7 +9267,7 @@ add_executable(bm_fullstack_streaming_pump
 target_include_directories(bm_fullstack_streaming_pump
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9311,7 +9313,7 @@ add_executable(bm_fullstack_trickle
 target_include_directories(bm_fullstack_trickle
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9357,7 +9359,7 @@ add_executable(bm_fullstack_unary_ping_pong
 target_include_directories(bm_fullstack_unary_ping_pong
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9403,7 +9405,7 @@ add_executable(bm_metadata
 target_include_directories(bm_metadata
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9449,7 +9451,7 @@ add_executable(bm_pollset
 target_include_directories(bm_pollset
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9494,7 +9496,7 @@ add_executable(channel_arguments_test
 target_include_directories(channel_arguments_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9533,7 +9535,7 @@ add_executable(channel_filter_test
 target_include_directories(channel_filter_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9572,7 +9574,7 @@ add_executable(cli_call_test
 target_include_directories(cli_call_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9616,7 +9618,7 @@ add_executable(client_crash_test
 target_include_directories(client_crash_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9659,7 +9661,7 @@ add_executable(client_crash_test_server
 target_include_directories(client_crash_test_server
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9701,7 +9703,7 @@ add_executable(client_lb_end2end_test
 target_include_directories(client_lb_end2end_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9778,7 +9780,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(codegen_test_full
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9853,7 +9855,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(codegen_test_minimal
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9891,7 +9893,7 @@ add_executable(credentials_test
 target_include_directories(credentials_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9930,7 +9932,7 @@ add_executable(cxx_byte_buffer_test
 target_include_directories(cxx_byte_buffer_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -9971,7 +9973,7 @@ add_executable(cxx_slice_test
 target_include_directories(cxx_slice_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10012,7 +10014,7 @@ add_executable(cxx_string_ref_test
 target_include_directories(cxx_string_ref_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10050,7 +10052,7 @@ add_executable(cxx_time_test
 target_include_directories(cxx_time_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10091,7 +10093,7 @@ add_executable(end2end_test
 target_include_directories(end2end_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10140,7 +10142,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(error_details_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10178,7 +10180,7 @@ add_executable(filter_end2end_test
 target_include_directories(filter_end2end_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10220,7 +10222,7 @@ add_executable(generic_end2end_test
 target_include_directories(generic_end2end_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10269,7 +10271,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(golden_file_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10308,7 +10310,7 @@ add_executable(grpc_cli
 target_include_directories(grpc_cli
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10347,7 +10349,7 @@ add_executable(grpc_cpp_plugin
 target_include_directories(grpc_cpp_plugin
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10385,7 +10387,7 @@ add_executable(grpc_csharp_plugin
 target_include_directories(grpc_csharp_plugin
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10423,7 +10425,7 @@ add_executable(grpc_node_plugin
 target_include_directories(grpc_node_plugin
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10461,7 +10463,7 @@ add_executable(grpc_objective_c_plugin
 target_include_directories(grpc_objective_c_plugin
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10499,7 +10501,7 @@ add_executable(grpc_php_plugin
 target_include_directories(grpc_php_plugin
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10537,7 +10539,7 @@ add_executable(grpc_python_plugin
 target_include_directories(grpc_python_plugin
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10575,7 +10577,7 @@ add_executable(grpc_ruby_plugin
 target_include_directories(grpc_ruby_plugin
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10630,7 +10632,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(grpc_tool_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10682,7 +10684,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(grpclb_api_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10729,7 +10731,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(grpclb_end2end_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10778,7 +10780,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(grpclb_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10820,7 +10822,7 @@ add_executable(health_service_end2end_test
 target_include_directories(health_service_end2end_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10862,7 +10864,7 @@ add_executable(http2_client
 target_include_directories(http2_client
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10905,7 +10907,7 @@ add_executable(hybrid_end2end_test
 target_include_directories(hybrid_end2end_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10947,7 +10949,7 @@ add_executable(interop_client
 target_include_directories(interop_client
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -10993,7 +10995,7 @@ add_executable(interop_server
 target_include_directories(interop_server
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11041,7 +11043,7 @@ add_executable(interop_test
 target_include_directories(interop_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11084,7 +11086,7 @@ add_executable(json_run_localhost
 target_include_directories(json_run_localhost
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11128,7 +11130,7 @@ add_executable(memory_test
 target_include_directories(memory_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11176,7 +11178,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(metrics_client
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11216,7 +11218,7 @@ add_executable(mock_test
 target_include_directories(mock_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11258,7 +11260,7 @@ add_executable(noop-benchmark
 target_include_directories(noop-benchmark
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11295,7 +11297,7 @@ add_executable(proto_server_reflection_test
 target_include_directories(proto_server_reflection_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11339,7 +11341,7 @@ add_executable(proto_utils_test
 target_include_directories(proto_utils_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11378,7 +11380,7 @@ add_executable(qps_interarrival_test
 target_include_directories(qps_interarrival_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11422,7 +11424,7 @@ add_executable(qps_json_driver
 target_include_directories(qps_json_driver
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11467,7 +11469,7 @@ add_executable(qps_openloop_test
 target_include_directories(qps_openloop_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11512,7 +11514,7 @@ add_executable(qps_worker
 target_include_directories(qps_worker
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11577,7 +11579,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(reconnect_interop_client
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11641,7 +11643,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(reconnect_interop_server
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11686,7 +11688,7 @@ add_executable(secure_auth_context_test
 target_include_directories(secure_auth_context_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11729,7 +11731,7 @@ add_executable(secure_sync_unary_ping_pong_test
 target_include_directories(secure_sync_unary_ping_pong_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11773,7 +11775,7 @@ add_executable(server_builder_plugin_test
 target_include_directories(server_builder_plugin_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11829,7 +11831,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(server_builder_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11871,7 +11873,7 @@ add_executable(server_context_test_spouse_test
 target_include_directories(server_context_test_spouse_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11913,7 +11915,7 @@ add_executable(server_crash_test
 target_include_directories(server_crash_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11956,7 +11958,7 @@ add_executable(server_crash_test_client
 target_include_directories(server_crash_test_client
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -11998,7 +12000,7 @@ add_executable(shutdown_test
 target_include_directories(shutdown_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12040,7 +12042,7 @@ add_executable(status_test
 target_include_directories(status_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12082,7 +12084,7 @@ add_executable(streaming_throughput_test
 target_include_directories(streaming_throughput_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12156,7 +12158,7 @@ protobuf_generate_grpc_cpp(
 target_include_directories(stress_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12199,7 +12201,7 @@ add_executable(thread_manager_test
 target_include_directories(thread_manager_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12239,7 +12241,7 @@ add_executable(thread_stress_test
 target_include_directories(thread_stress_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12282,7 +12284,7 @@ add_executable(writes_per_rpc_test
 target_include_directories(writes_per_rpc_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12323,7 +12325,7 @@ add_executable(public_headers_must_be_c89
 target_include_directories(public_headers_must_be_c89
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12352,7 +12354,7 @@ add_executable(badreq_bad_client_test
 target_include_directories(badreq_bad_client_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12385,7 +12387,7 @@ add_executable(connection_prefix_bad_client_test
 target_include_directories(connection_prefix_bad_client_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12418,7 +12420,7 @@ add_executable(head_of_line_blocking_bad_client_test
 target_include_directories(head_of_line_blocking_bad_client_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12451,7 +12453,7 @@ add_executable(headers_bad_client_test
 target_include_directories(headers_bad_client_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12484,7 +12486,7 @@ add_executable(initial_settings_frame_bad_client_test
 target_include_directories(initial_settings_frame_bad_client_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12517,7 +12519,7 @@ add_executable(large_metadata_bad_client_test
 target_include_directories(large_metadata_bad_client_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12550,7 +12552,7 @@ add_executable(server_registered_method_bad_client_test
 target_include_directories(server_registered_method_bad_client_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12583,7 +12585,7 @@ add_executable(simple_request_bad_client_test
 target_include_directories(simple_request_bad_client_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12616,7 +12618,7 @@ add_executable(unknown_frame_bad_client_test
 target_include_directories(unknown_frame_bad_client_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12649,7 +12651,7 @@ add_executable(window_overflow_bad_client_test
 target_include_directories(window_overflow_bad_client_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12683,7 +12685,7 @@ add_executable(bad_ssl_cert_server
 target_include_directories(bad_ssl_cert_server
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12717,7 +12719,7 @@ add_executable(bad_ssl_cert_test
 target_include_directories(bad_ssl_cert_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12749,7 +12751,7 @@ add_executable(h2_census_test
 target_include_directories(h2_census_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12781,7 +12783,7 @@ add_executable(h2_compress_test
 target_include_directories(h2_compress_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12813,7 +12815,7 @@ add_executable(h2_fakesec_test
 target_include_directories(h2_fakesec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12846,7 +12848,7 @@ add_executable(h2_fd_test
 target_include_directories(h2_fd_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12879,7 +12881,7 @@ add_executable(h2_full_test
 target_include_directories(h2_full_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12912,7 +12914,7 @@ add_executable(h2_full+pipe_test
 target_include_directories(h2_full+pipe_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12945,7 +12947,7 @@ add_executable(h2_full+trace_test
 target_include_directories(h2_full+trace_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -12977,7 +12979,7 @@ add_executable(h2_full+workarounds_test
 target_include_directories(h2_full+workarounds_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13009,7 +13011,7 @@ add_executable(h2_http_proxy_test
 target_include_directories(h2_http_proxy_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13041,7 +13043,7 @@ add_executable(h2_load_reporting_test
 target_include_directories(h2_load_reporting_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13073,7 +13075,7 @@ add_executable(h2_oauth2_test
 target_include_directories(h2_oauth2_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13105,7 +13107,7 @@ add_executable(h2_proxy_test
 target_include_directories(h2_proxy_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13137,7 +13139,7 @@ add_executable(h2_sockpair_test
 target_include_directories(h2_sockpair_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13169,7 +13171,7 @@ add_executable(h2_sockpair+trace_test
 target_include_directories(h2_sockpair+trace_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13201,7 +13203,7 @@ add_executable(h2_sockpair_1byte_test
 target_include_directories(h2_sockpair_1byte_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13233,7 +13235,7 @@ add_executable(h2_ssl_test
 target_include_directories(h2_ssl_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13265,7 +13267,7 @@ add_executable(h2_ssl_cert_test
 target_include_directories(h2_ssl_cert_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13297,7 +13299,7 @@ add_executable(h2_ssl_proxy_test
 target_include_directories(h2_ssl_proxy_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13330,7 +13332,7 @@ add_executable(h2_uds_test
 target_include_directories(h2_uds_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13363,7 +13365,7 @@ add_executable(h2_census_nosec_test
 target_include_directories(h2_census_nosec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13395,7 +13397,7 @@ add_executable(h2_compress_nosec_test
 target_include_directories(h2_compress_nosec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13428,7 +13430,7 @@ add_executable(h2_fd_nosec_test
 target_include_directories(h2_fd_nosec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13461,7 +13463,7 @@ add_executable(h2_full_nosec_test
 target_include_directories(h2_full_nosec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13494,7 +13496,7 @@ add_executable(h2_full+pipe_nosec_test
 target_include_directories(h2_full+pipe_nosec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13527,7 +13529,7 @@ add_executable(h2_full+trace_nosec_test
 target_include_directories(h2_full+trace_nosec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13559,7 +13561,7 @@ add_executable(h2_full+workarounds_nosec_test
 target_include_directories(h2_full+workarounds_nosec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13591,7 +13593,7 @@ add_executable(h2_http_proxy_nosec_test
 target_include_directories(h2_http_proxy_nosec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13623,7 +13625,7 @@ add_executable(h2_load_reporting_nosec_test
 target_include_directories(h2_load_reporting_nosec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13655,7 +13657,7 @@ add_executable(h2_proxy_nosec_test
 target_include_directories(h2_proxy_nosec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13687,7 +13689,7 @@ add_executable(h2_sockpair_nosec_test
 target_include_directories(h2_sockpair_nosec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13719,7 +13721,7 @@ add_executable(h2_sockpair+trace_nosec_test
 target_include_directories(h2_sockpair+trace_nosec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13751,7 +13753,7 @@ add_executable(h2_sockpair_1byte_nosec_test
 target_include_directories(h2_sockpair_1byte_nosec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13784,7 +13786,7 @@ add_executable(h2_uds_nosec_test
 target_include_directories(h2_uds_nosec_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13818,7 +13820,7 @@ add_executable(api_fuzzer_one_entry
 target_include_directories(api_fuzzer_one_entry
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13850,7 +13852,7 @@ add_executable(client_fuzzer_one_entry
 target_include_directories(client_fuzzer_one_entry
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13882,7 +13884,7 @@ add_executable(hpack_parser_fuzzer_test_one_entry
 target_include_directories(hpack_parser_fuzzer_test_one_entry
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13914,7 +13916,7 @@ add_executable(http_request_fuzzer_test_one_entry
 target_include_directories(http_request_fuzzer_test_one_entry
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13946,7 +13948,7 @@ add_executable(http_response_fuzzer_test_one_entry
 target_include_directories(http_response_fuzzer_test_one_entry
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -13978,7 +13980,7 @@ add_executable(json_fuzzer_test_one_entry
 target_include_directories(json_fuzzer_test_one_entry
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -14010,7 +14012,7 @@ add_executable(nanopb_fuzzer_response_test_one_entry
 target_include_directories(nanopb_fuzzer_response_test_one_entry
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -14042,7 +14044,7 @@ add_executable(nanopb_fuzzer_serverlist_test_one_entry
 target_include_directories(nanopb_fuzzer_serverlist_test_one_entry
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -14074,7 +14076,7 @@ add_executable(percent_decode_fuzzer_one_entry
 target_include_directories(percent_decode_fuzzer_one_entry
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -14106,7 +14108,7 @@ add_executable(percent_encode_fuzzer_one_entry
 target_include_directories(percent_encode_fuzzer_one_entry
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -14138,7 +14140,7 @@ add_executable(server_fuzzer_one_entry
 target_include_directories(server_fuzzer_one_entry
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -14170,7 +14172,7 @@ add_executable(ssl_server_fuzzer_one_entry
 target_include_directories(ssl_server_fuzzer_one_entry
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}
@@ -14202,7 +14204,7 @@ add_executable(uri_fuzzer_test_one_entry
 target_include_directories(uri_fuzzer_test_one_entry
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
-  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
   PRIVATE ${PROTOBUF_ROOT_DIR}/src
   PRIVATE ${BENCHMARK_ROOT_DIR}/include
   PRIVATE ${ZLIB_ROOT_DIR}


### PR DESCRIPTION
It looks like that even though CMakeLists.txt has an option to use precompiled ssl, all targets where explicitly set to use boringssl headers. This hopefully fixes that. 