### PR TITLE
Implement tsi_init and tsi_destroy in transport security interface.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1276,12 +1276,14 @@ grpc_cc_library(
     srcs = [
         "src/core/tsi/fake_transport_security.c",
         "src/core/tsi/ssl_transport_security.c",
+        "src/core/tsi/gts_transport_security.c",
         "src/core/tsi/transport_security.c",
         "src/core/tsi/transport_security_adapter.c",
     ],
     hdrs = [
         "src/core/tsi/fake_transport_security.h",
         "src/core/tsi/ssl_transport_security.h",
+        "src/core/tsi/gts_transport_security.h",
         "src/core/tsi/ssl_types.h",
         "src/core/tsi/transport_security.h",
         "src/core/tsi/transport_security_adapter.h",

--- a/build.yaml
+++ b/build.yaml
@@ -863,6 +863,7 @@ filegroups:
 - name: tsi
   headers:
   - src/core/tsi/fake_transport_security.h
+  - src/core/tsi/gts_transport_security.h
   - src/core/tsi/ssl_transport_security.h
   - src/core/tsi/ssl_types.h
   - src/core/tsi/transport_security.h
@@ -870,6 +871,7 @@ filegroups:
   - src/core/tsi/transport_security_interface.h
   src:
   - src/core/tsi/fake_transport_security.c
+  - src/core/tsi/gts_transport_security.c
   - src/core/tsi/ssl_transport_security.c
   - src/core/tsi/transport_security.c
   - src/core/tsi/transport_security_adapter.c

--- a/src/core/lib/surface/init_secure.c
+++ b/src/core/lib/surface/init_secure.c
@@ -36,7 +36,14 @@
 #include "src/core/lib/security/context/security_context.h"
 #endif
 
+static gpr_once tsi_once_var = GPR_ONCE_INIT;
+
+static void register_tsi_plugin(void) {
+  grpc_register_plugin(tsi_init, tsi_destroy);
+}
+
 void grpc_security_pre_init(void) {
+  gpr_once_init(&tsi_once_var, register_tsi_plugin);
   grpc_register_tracer("secure_endpoint", &grpc_trace_secure_endpoint);
   grpc_register_tracer("transport_security", &tsi_tracing_enabled);
 #ifndef NDEBUG

--- a/src/core/tsi/gts_transport_security.c
+++ b/src/core/tsi/gts_transport_security.c
@@ -1,0 +1,36 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpc/support/alloc.h>
+#include "src/core/tsi/gts_transport_security.h"
+
+static gts_shared_resource* gts_resource = NULL;
+
+gts_shared_resource** gts_get_shared_resource(void) { return &gts_resource; }
+
+void gts_destroy() {
+  if (gts_resource == NULL) {
+    return;
+  }
+  grpc_completion_queue_destroy(gts_resource->gts_cq);
+  grpc_channel_destroy(gts_resource->gts_channel);
+  gpr_thd_join(gts_resource->gts_thread_id);
+  gpr_mu_destroy(&gts_resource->gts_mu);
+  gpr_free(gts_resource);
+}
+

--- a/src/core/tsi/gts_transport_security.h
+++ b/src/core/tsi/gts_transport_security.h
@@ -1,0 +1,42 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GRPC_CORE_TSI_GTS_TRANSPORT_SECURITY_H
+#define GRPC_CORE_TSI_GTS_TRANSPORT_SECURITY_H
+
+#include <grpc/grpc.h>
+#include <grpc/support/sync.h>
+#include <grpc/support/thd.h>
+
+typedef struct gts_shared_resource {
+  gpr_thd_id gts_thread_id;
+  grpc_channel* gts_channel;
+  grpc_completion_queue* gts_cq;
+  gpr_mu gts_mu;
+} gts_shared_resource;
+
+/* This method returns the address of gts_shared_resource object shared by all
+   TSI handshakes. */
+gts_shared_resource** gts_get_shared_resource(void);
+
+/* This method destroys the shared gts_shared_resource object used in GTS
+   implementation. */
+void gts_destroy(void);
+
+#endif  // GRPC_CORE_TSI_GTS_TRANSPORT_SECURITY_H
+

--- a/src/core/tsi/transport_security.h
+++ b/src/core/tsi/transport_security.h
@@ -111,6 +111,9 @@ tsi_result tsi_construct_allocated_string_peer_property(
 tsi_result tsi_construct_string_peer_property_from_cstring(
     const char *name, const char *value, tsi_peer_property *property);
 
+/* Destroy plugin registration funcion. */
+void tsi_register_destroy_plugin(void (*destroy)(void));
+
 /* Utils. */
 char *tsi_strdup(const char *src); /* Sadly, no strdup in C89. */
 


### PR DESCRIPTION
This branch achieves following two goals: 1) provide implementation of tsi_init() and tsi_destroy() to initialize and destroy tsi-specific shared objects, and register them as a plugin; 2) provide implementation of gts_destroy() to destroy gts-specific shared objects, including a shared channel and completion queue to the handshaker service.

@markdroth, @yang-g, Would you please review the PR? 