### PR TITLE
s/inline/__inline/. Visual studio incompatiblity (v1.4.x backport)

### DIFF
--- a/src/core/ext/census/intrusive_hash_map.c
+++ b/src/core/ext/census/intrusive_hash_map.c
@@ -37,7 +37,7 @@
 extern bool hm_index_compare(const hm_index *A, const hm_index *B);
 
 /* Simple hashing function that takes lower 32 bits. */
-static inline uint32_t chunked_vector_hasher(uint64_t key) {
+static __inline uint32_t chunked_vector_hasher(uint64_t key) {
   return (uint32_t)key;
 }
 
@@ -45,8 +45,8 @@ static inline uint32_t chunked_vector_hasher(uint64_t key) {
 static const size_t VECTOR_CHUNK_SIZE = (1 << 20) / sizeof(void *);
 
 /* Helper functions which return buckets from the chunked vector. */
-static inline void **get_mutable_bucket(const chunked_vector *buckets,
-                                        uint32_t index) {
+static __inline void **get_mutable_bucket(const chunked_vector *buckets,
+                                          uint32_t index) {
   if (index < VECTOR_CHUNK_SIZE) {
     return &buckets->first_[index];
   }
@@ -54,7 +54,8 @@ static inline void **get_mutable_bucket(const chunked_vector *buckets,
   return &buckets->rest_[rest_index][index % VECTOR_CHUNK_SIZE];
 }
 
-static inline void *get_bucket(const chunked_vector *buckets, uint32_t index) {
+static __inline void *get_bucket(const chunked_vector *buckets,
+                                 uint32_t index) {
   if (index < VECTOR_CHUNK_SIZE) {
     return buckets->first_[index];
   }
@@ -63,7 +64,7 @@ static inline void *get_bucket(const chunked_vector *buckets, uint32_t index) {
 }
 
 /* Helper function. */
-static inline size_t RestSize(const chunked_vector *vec) {
+static __inline size_t RestSize(const chunked_vector *vec) {
   return (vec->size_ <= VECTOR_CHUNK_SIZE)
              ? 0
              : (vec->size_ - VECTOR_CHUNK_SIZE - 1) / VECTOR_CHUNK_SIZE + 1;
@@ -222,9 +223,9 @@ hm_item *intrusive_hash_map_erase(intrusive_hash_map *hash_map, uint64_t key) {
  * array_size-1. Returns true if it is a new hm_item and false if the hm_item
  * already existed.
  */
-static inline bool intrusive_hash_map_internal_insert(chunked_vector *buckets,
-                                                      uint32_t hash_mask,
-                                                      hm_item *item) {
+static __inline bool intrusive_hash_map_internal_insert(chunked_vector *buckets,
+                                                        uint32_t hash_mask,
+                                                        hm_item *item) {
   const uint64_t key = item->key;
   uint32_t index = chunked_vector_hasher(key) & hash_mask;
   hm_item **slot = (hm_item **)get_mutable_bucket(buckets, index);

--- a/src/core/ext/census/intrusive_hash_map.h
+++ b/src/core/ext/census/intrusive_hash_map.h
@@ -101,7 +101,7 @@ typedef struct hm_index {
 
 /* Returns true if two hm_indices point to the same object within the hash map
  * and false otherwise. */
-inline bool hm_index_compare(const hm_index *A, const hm_index *B) {
+__inline bool hm_index_compare(const hm_index *A, const hm_index *B) {
   return (A->item == B->item && A->bucket_index == B->bucket_index);
 }
 

--- a/test/core/census/intrusive_hash_map_test.c
+++ b/test/core/census/intrusive_hash_map_test.c
@@ -49,7 +49,7 @@ static const uint32_t kInitialLog2Size = 4;
 typedef struct object { uint64_t val; } object;
 
 /* Helper function to allocate and initialize object. */
-static inline object *make_new_object(uint64_t val) {
+static __inline object *make_new_object(uint64_t val) {
   object *obj = (object *)gpr_malloc(sizeof(object));
   obj->val = val;
   return obj;
@@ -63,7 +63,7 @@ typedef struct ptr_item {
 
 /* Helper function that creates a new hash map item.  It is up to the user to
  * free the item that was allocated. */
-static inline ptr_item *make_ptr_item(uint64_t key, uint64_t value) {
+static __inline ptr_item *make_ptr_item(uint64_t key, uint64_t value) {
   ptr_item *new_item = (ptr_item *)gpr_malloc(sizeof(ptr_item));
   new_item->IHM_key = key;
   new_item->IHM_hash_link = NULL;


### PR DESCRIPTION
MS Visual studio '13 and before don't understand inline
and throw Error C2054.
Reference: https://msdn.microsoft.com/en-us/library/bw1hbe6y.aspx