### PR TITLE
Expose :authority pseudo-header to Obj-C API.

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -164,6 +164,11 @@ extern id const kGRPCTrailersKey;
 @interface GRPCCall : GRXWriter
 
 /**
+ * The server name for the RPC. If nil, the host name of the service object will be used instead.
+ */
+@property (atomic, readwrite) NSString *serverName;
+
+/**
  * The container of the request headers of an RPC conforms to this protocol, which is a subset of
  * NSMutableDictionary's interface. It will become a NSMutableDictionary later on.
  * The keys of this container are the header names, which per the HTTP standard are case-

--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -165,6 +165,7 @@ extern id const kGRPCTrailersKey;
 
 /**
  * The server name for the RPC. If nil, the host name of the service object will be used instead.
+ * This property must be nil when Cronet transport is enabled.
  */
 @property (atomic, readwrite) NSString *serverName;
 

--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -164,8 +164,8 @@ extern id const kGRPCTrailersKey;
 @interface GRPCCall : GRXWriter
 
 /**
- * The server name for the RPC. If nil, the host name of the service object will be used instead.
- * This property must be nil when Cronet transport is enabled.
+ * The authority for the RPC. If nil, the default authority will be used. This property must be nil
+ * when Cronet transport is enabled.
  */
 @property (atomic, readwrite) NSString *serverName;
 

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -425,7 +425,7 @@ static NSMutableDictionary *callFlags;
   _responseWriteable = [[GRXConcurrentWriteable alloc] initWithWriteable:writeable
                                                            dispatchQueue:_responseQueue];
 
-  _wrappedCall = [[GRPCWrappedCall alloc] initWithHost:_host path:_path];
+  _wrappedCall = [[GRPCWrappedCall alloc] initWithHost:_host serverName:_serverName path:_path];
   NSAssert(_wrappedCall, @"Error allocating RPC objects. Low memory?");
 
   [self sendHeaders:_requestHeaders];

--- a/src/objective-c/GRPCClient/private/GRPCChannel.h
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.h
@@ -62,5 +62,6 @@ struct grpc_channel_credentials;
                                      channelArgs:(nullable NSDictionary *)channelArgs;
 
 - (nullable grpc_call *)unmanagedCallWithPath:(nonnull NSString *)path
+                                   serverName:(nonnull NSString *)serverName
                               completionQueue:(nonnull GRPCCompletionQueue *)queue;
 @end

--- a/src/objective-c/GRPCClient/private/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.m
@@ -183,15 +183,20 @@ static grpc_channel_args *BuildChannelArgs(NSDictionary *dictionary) {
 - (grpc_call *)unmanagedCallWithPath:(NSString *)path
                           serverName:(NSString *)serverName
                      completionQueue:(GRPCCompletionQueue *)queue {
-  grpc_slice host_slice = grpc_slice_from_copied_string(serverName.UTF8String);
+  grpc_slice host_slice;
+  if (serverName) {
+    host_slice = grpc_slice_from_copied_string(serverName.UTF8String);
+  }
   grpc_slice path_slice = grpc_slice_from_copied_string(path.UTF8String);
   grpc_call *call = grpc_channel_create_call(_unmanagedChannel,
                                              NULL, GRPC_PROPAGATE_DEFAULTS,
                                              queue.unmanagedQueue,
                                              path_slice,
-                                             &host_slice,
+                                             serverName ? &host_slice : NULL,
                                              gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
-  grpc_slice_unref(host_slice);
+  if (serverName) {
+    grpc_slice_unref(host_slice);
+  }
   grpc_slice_unref(path_slice);
   return call;
 }

--- a/src/objective-c/GRPCClient/private/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.m
@@ -181,14 +181,17 @@ static grpc_channel_args *BuildChannelArgs(NSDictionary *dictionary) {
 }
 
 - (grpc_call *)unmanagedCallWithPath:(NSString *)path
+                          serverName:(NSString *)serverName
                      completionQueue:(GRPCCompletionQueue *)queue {
+  grpc_slice host_slice = grpc_slice_from_copied_string(serverName.UTF8String);
   grpc_slice path_slice = grpc_slice_from_copied_string(path.UTF8String);
   grpc_call *call = grpc_channel_create_call(_unmanagedChannel,
                                              NULL, GRPC_PROPAGATE_DEFAULTS,
                                              queue.unmanagedQueue,
                                              path_slice,
-                                             NULL, // Passing NULL for host
+                                             &host_slice,
                                              gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
+  grpc_slice_unref(host_slice);
   grpc_slice_unref(path_slice);
   return call;
 }

--- a/src/objective-c/GRPCClient/private/GRPCHost.h
+++ b/src/objective-c/GRPCClient/private/GRPCHost.h
@@ -54,6 +54,7 @@ struct grpc_channel_credentials;
 
 /** Create a grpc_call object to the provided path on this host. */
 - (nullable struct grpc_call *)unmanagedCallWithPath:(NSString *)path
+                                          serverName:(nullable NSString *)serverName
                                      completionQueue:(GRPCCompletionQueue *)queue;
 
 // TODO: There's a race when a new RPC is coming through just as an existing one is getting

--- a/src/objective-c/GRPCClient/private/GRPCHost.h
+++ b/src/objective-c/GRPCClient/private/GRPCHost.h
@@ -54,7 +54,7 @@ struct grpc_channel_credentials;
 
 /** Create a grpc_call object to the provided path on this host. */
 - (nullable struct grpc_call *)unmanagedCallWithPath:(NSString *)path
-                                          serverName:(nullable NSString *)serverName
+                                          serverName:(NSString *)serverName
                                      completionQueue:(GRPCCompletionQueue *)queue;
 
 // TODO: There's a race when a new RPC is coming through just as an existing one is getting

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -120,7 +120,7 @@ static GRPCConnectivityMonitor *connectivityMonitor = nil;
 }
 
 - (nullable grpc_call *)unmanagedCallWithPath:(NSString *)path
-                                   serverName:(nullable NSString *)serverName
+                                   serverName:(NSString *)serverName
                               completionQueue:(GRPCCompletionQueue *)queue {
   GRPCChannel *channel;
   // This is racing -[GRPCHost disconnect].

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -130,8 +130,7 @@ static GRPCConnectivityMonitor *connectivityMonitor = nil;
     }
     channel = _channel;
   }
-  NSString *name = serverName ? serverName : _address;
-  return [channel unmanagedCallWithPath:path serverName:name completionQueue:queue];
+  return [channel unmanagedCallWithPath:path serverName:serverName completionQueue:queue];
 }
 
 - (BOOL)setTLSPEMRootCerts:(nullable NSString *)pemRootCerts

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -120,6 +120,7 @@ static GRPCConnectivityMonitor *connectivityMonitor = nil;
 }
 
 - (nullable grpc_call *)unmanagedCallWithPath:(NSString *)path
+                                   serverName:(nullable NSString *)serverName
                               completionQueue:(GRPCCompletionQueue *)queue {
   GRPCChannel *channel;
   // This is racing -[GRPCHost disconnect].
@@ -129,7 +130,8 @@ static GRPCConnectivityMonitor *connectivityMonitor = nil;
     }
     channel = _channel;
   }
-  return [channel unmanagedCallWithPath:path completionQueue:queue];
+  NSString *name = serverName ? serverName : _address;
+  return [channel unmanagedCallWithPath:path serverName:name completionQueue:queue];
 }
 
 - (BOOL)setTLSPEMRootCerts:(nullable NSString *)pemRootCerts

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
@@ -75,6 +75,7 @@
 @interface GRPCWrappedCall : NSObject
 
 - (instancetype)initWithHost:(NSString *)host
+                  serverName:(nullable NSString *)serverName
                         path:(NSString *)path NS_DESIGNATED_INITIALIZER;
 
 - (void)startBatchWithOperations:(NSArray *)ops errorHandler:(void(^)())errorHandler;

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
@@ -75,7 +75,7 @@
 @interface GRPCWrappedCall : NSObject
 
 - (instancetype)initWithHost:(NSString *)host
-                  serverName:(nullable NSString *)serverName
+                  serverName:(NSString *)serverName
                         path:(NSString *)path NS_DESIGNATED_INITIALIZER;
 
 - (void)startBatchWithOperations:(NSArray *)ops errorHandler:(void(^)())errorHandler;

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
@@ -232,10 +232,11 @@
 }
 
 - (instancetype)init {
-  return [self initWithHost:nil path:nil];
+  return [self initWithHost:nil serverName:nil path:nil];
 }
 
 - (instancetype)initWithHost:(NSString *)host
+                  serverName:(nullable NSString *)serverName
                         path:(NSString *)path {
   if (!path || !host) {
     [NSException raise:NSInvalidArgumentException
@@ -248,7 +249,7 @@
     // queue. Currently we use a singleton queue.
     _queue = [GRPCCompletionQueue completionQueue];
 
-    _call = [[GRPCHost hostWithAddress:host] unmanagedCallWithPath:path completionQueue:_queue];
+    _call = [[GRPCHost hostWithAddress:host] unmanagedCallWithPath:path serverName:serverName completionQueue:_queue];
     if (_call == NULL) {
       return nil;
     }

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
@@ -236,7 +236,7 @@
 }
 
 - (instancetype)initWithHost:(NSString *)host
-                  serverName:(nullable NSString *)serverName
+                  serverName:(NSString *)serverName
                         path:(NSString *)path {
   if (!path || !host) {
     [NSException raise:NSInvalidArgumentException


### PR DESCRIPTION
This exposes the :authority pseudo-header value to the Obj-C API. We have a backend load balancer that performs virtual host routing. This means we need to be able to override the host/authority header. 

This relates to https://github.com/grpc/grpc/pull/10858