### PR TITLE
Backport #11624: Objective C memory leak GRPCOpSendMetadata

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
@@ -90,6 +90,10 @@
 }
 
 - (void)dealloc {
+  for (int i = 0; i < _op.data.send_initial_metadata.count; i++) {
+    grpc_slice_unref(_op.data.send_initial_metadata.metadata[i].key);
+    grpc_slice_unref(_op.data.send_initial_metadata.metadata[i].value);
+  }
   gpr_free(_op.data.send_initial_metadata.metadata);
 }
 


### PR DESCRIPTION
Metadata elements slices need to be unreffed when the object is dealloced.

Backports #11624 

Fixes #11494