### PR TITLE
Properly use uint64_t not unsigned int64_t

### DIFF
--- a/src/core/lib/support/time_precise.c
+++ b/src/core/lib/support/time_precise.c
@@ -31,7 +31,7 @@ static void gpr_get_cycle_counter(int64_t int *clk) {
 // ----------------------------------------------------------------
 #elif defined(__x86_64__) || defined(__amd64__)
 static void gpr_get_cycle_counter(int64_t *clk) {
-  unsigned int64_t low, high;
+  uint64_t low, high;
   __asm__ volatile("rdtsc" : "=a"(low), "=d"(high));
   *clk = (int64_t)(high << 32) | (int64_t)low;
 }


### PR DESCRIPTION
PR #11559 had a mistake that was not tested since it was inside a #ifdef that is not in our regular PR build. This fixes that. (And I confirmed by building in config basicprof that the new code indeed works.)