### PR TITLE
Add New Low Level Counter: Stall Counts 

### DIFF
--- a/src/core/ext/transport/chttp2/transport/stream_lists.c
+++ b/src/core/ext/transport/chttp2/transport/stream_lists.c
@@ -20,6 +20,11 @@
 
 #include <grpc/support/log.h>
 
+#ifdef GPR_LOW_LEVEL_COUNTERS
+gpr_atm g_transport_stalls_count;
+gpr_atm g_stream_stalls_count;
+#endif
+
 /* core list management */
 
 static bool stream_list_empty(grpc_chttp2_transport *t,
@@ -150,6 +155,9 @@ void grpc_chttp2_list_remove_waiting_for_concurrency(grpc_chttp2_transport *t,
 
 void grpc_chttp2_list_add_stalled_by_transport(grpc_chttp2_transport *t,
                                                grpc_chttp2_stream *s) {
+#ifdef GPR_LOW_LEVEL_COUNTERS
+  __atomic_fetch_add(&g_transport_stalls_count, 1, __ATOMIC_RELAXED);
+#endif
   stream_list_add(t, s, GRPC_CHTTP2_LIST_STALLED_BY_TRANSPORT);
 }
 
@@ -165,6 +173,9 @@ void grpc_chttp2_list_remove_stalled_by_transport(grpc_chttp2_transport *t,
 
 void grpc_chttp2_list_add_stalled_by_stream(grpc_chttp2_transport *t,
                                             grpc_chttp2_stream *s) {
+#ifdef GPR_LOW_LEVEL_COUNTERS
+  __atomic_fetch_add(&g_stream_stalls_count, 1, __ATOMIC_RELAXED);
+#endif
   stream_list_add(t, s, GRPC_CHTTP2_LIST_STALLED_BY_STREAM);
 }
 

--- a/test/cpp/microbenchmarks/helpers.cc
+++ b/test/cpp/microbenchmarks/helpers.cc
@@ -49,6 +49,14 @@ void TrackCounters::AddToLabel(std::ostream &out, benchmark::State &state) {
       << " allocs/iter:"
       << ((double)(counters_at_end.total_allocs_absolute -
                    counters_at_start_.total_allocs_absolute) /
+          (double)state.iterations())
+      << " trans_stalls/iter:"
+      << ((double)(gpr_atm_no_barrier_load(&g_transport_stalls_count) -
+                   transport_stalls_at_start_) /
+          (double)state.iterations())
+      << " stream_stalls/iter:"
+      << ((double)(gpr_atm_no_barrier_load(&g_stream_stalls_count) -
+                   stream_stalls_at_start_) /
           (double)state.iterations());
 #endif
 }

--- a/test/cpp/microbenchmarks/helpers.h
+++ b/test/cpp/microbenchmarks/helpers.h
@@ -58,6 +58,8 @@ extern "C" gpr_atm gpr_mu_locks;
 extern "C" gpr_atm gpr_counter_atm_cas;
 extern "C" gpr_atm gpr_counter_atm_add;
 extern "C" gpr_atm gpr_now_call_count;
+extern "C" gpr_atm g_transport_stalls_count;
+extern "C" gpr_atm g_stream_stalls_count;
 #endif
 
 class TrackCounters {
@@ -74,6 +76,10 @@ class TrackCounters {
       gpr_atm_no_barrier_load(&gpr_counter_atm_add);
   const size_t now_calls_at_start_ =
       gpr_atm_no_barrier_load(&gpr_now_call_count);
+  const size_t transport_stalls_at_start_ =
+      gpr_atm_no_barrier_load(&g_transport_stalls_count);
+  const size_t stream_stalls_at_start_ =
+      gpr_atm_no_barrier_load(&g_stream_stalls_count);
   grpc_memory_counters counters_at_start_ = grpc_memory_counters_snapshot();
 #endif
 };


### PR DESCRIPTION
This will be useful as we tweak flow control. The trickle benchmark is more useful for BDP estimator optimization