### PR TITLE
Fix musl Portability

### DIFF
--- a/src/core/lib/iomgr/ev_epollsig_linux.c
+++ b/src/core/lib/iomgr/ev_epollsig_linux.c
@@ -840,11 +840,6 @@ static grpc_fd *fd_create(int fd, const char *name) {
   char *fd_name;
   gpr_asprintf(&fd_name, "%s fd=%d", name, fd);
   grpc_iomgr_register_object(&new_fd->iomgr_object, fd_name);
-#ifndef NDEBUG
-  if (GRPC_TRACER_ON(grpc_trace_fd_refcount)) {
-    gpr_log(GPR_DEBUG, "FD %d %p create %s", fd, new_fd, fd_name);
-  }
-#endif
   gpr_free(fd_name);
   return new_fd;
 }

--- a/src/core/lib/iomgr/ev_poll_posix.c
+++ b/src/core/lib/iomgr/ev_poll_posix.c
@@ -323,11 +323,6 @@ static grpc_fd *fd_create(int fd, const char *name) {
   gpr_asprintf(&name2, "%s fd=%d", name, fd);
   grpc_iomgr_register_object(&r->iomgr_object, name2);
   gpr_free(name2);
-#ifndef NDEBUG
-  if (GRPC_TRACER_ON(grpc_trace_fd_refcount)) {
-    gpr_log(GPR_DEBUG, "FD %d %p create %s", fd, r, name);
-  }
-#endif
   return r;
 }
 


### PR DESCRIPTION
Fixes #11592.

This fixes the musl crashes. I verified this fix by running:

```
tools/run_tests/run_tests.py --use_docker -t -l c -c dbg --iomgr_platform native --arch x64 --compiler gcc_musl
```

And all tests passed.

I figure a greener build is worth losing some debugging output in this case. However, I am at a complete loss for why these lines cause a crash. If there are any musl experts (@murgatroid99?) who have a clue, I am very curious.

Interestingly enough, just logging any static string will **still** cause the crash