### PR TITLE
Improvements to kokoro macos build

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -15,6 +15,12 @@
 
 # Source this rc script to prepare the environment for macos builds
 
+ulimit -n 1000
+
+# show current limits
+ulimit -a
+
+
 # required to build protobuf
 brew install gflags
 
@@ -35,9 +41,11 @@ pod repo update  # needed by python
 
 # python
 brew install coreutils  # we need grealpath
-#wget -q https://bootstrap.pypa.io/get-pip.py
-#sudo python get-pip.py
 sudo pip install virtualenv
 sudo pip install -U six tox setuptools
+
+# python 3.4
+wget https://www.python.org/ftp/python/3.4.4/python-3.4.4-macosx10.6.pkg
+sudo installer -pkg python-3.4.4-macosx10.6.pkg -target /
 
 git submodule update --init

--- a/tools/internal_ci/macos/grpc_master.sh
+++ b/tools/internal_ci/macos/grpc_master.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
-tools/run_tests/run_tests_matrix.py -f basictests macos --internal_ci || FAILED="true"
+tools/run_tests/run_tests_matrix.py -f basictests macos --internal_ci -j 2 --inner_jobs 4 || FAILED="true"
 
 # kill port_server.py to prevent the build from hanging
 ps aux | grep port_server\\.py | awk '{print $2}' | xargs kill -9


### PR DESCRIPTION
-- should make python build green
-- increase ulimit to decrease number of C++ tests failing with "too many open files". `ulimit` command can only raise the limit so much, more setting and reboot would be necessary to raise further.