### PR TITLE
Improvements to C++ filter API

### DIFF
--- a/src/core/lib/iomgr/closure.h
+++ b/src/core/lib/iomgr/closure.h
@@ -26,6 +26,10 @@
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/support/mpscq.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct grpc_closure;
 typedef struct grpc_closure grpc_closure;
 
@@ -195,6 +199,10 @@ void grpc_closure_list_sched(grpc_exec_ctx *exec_ctx,
                              grpc_closure_list *closure_list);
 #define GRPC_CLOSURE_LIST_SCHED(exec_ctx, closure_list) \
   grpc_closure_list_sched(exec_ctx, closure_list)
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* GRPC_CORE_LIB_IOMGR_CLOSURE_H */

--- a/test/cpp/common/channel_filter_test.cc
+++ b/test/cpp/common/channel_filter_test.cc
@@ -28,7 +28,7 @@ class MyChannelData : public ChannelData {
  public:
   MyChannelData() {}
 
-  grpc_error* Init(grpc_exec_ctx* exec_ctx,
+  grpc_error* Init(grpc_exec_ctx* exec_ctx, grpc_channel_element* elem,
                    grpc_channel_element_args* args) override {
     (void)args->channel_args;  // Make sure field is available.
     return GRPC_ERROR_NONE;
@@ -39,7 +39,7 @@ class MyCallData : public CallData {
  public:
   MyCallData() {}
 
-  grpc_error* Init(grpc_exec_ctx* exec_ctx, ChannelData* channel_data,
+  grpc_error* Init(grpc_exec_ctx* exec_ctx, grpc_call_element* elem,
                    const grpc_call_element_args* args) override {
     (void)args->path;  // Make sure field is available.
     return GRPC_ERROR_NONE;

--- a/test/cpp/end2end/filter_end2end_test.cc
+++ b/test/cpp/end2end/filter_end2end_test.cc
@@ -100,7 +100,8 @@ int GetCallCounterValue() {
 
 class ChannelDataImpl : public ChannelData {
  public:
-  grpc_error* Init(grpc_exec_ctx* exec_ctx, grpc_channel_element_args* args) {
+  grpc_error* Init(grpc_exec_ctx* exec_ctx, grpc_channel_element* elem,
+                   grpc_channel_element_args* args) {
     IncrementConnectionCounter();
     return GRPC_ERROR_NONE;
   }


### PR DESCRIPTION
- Make sure all C-core parameters are passed into C++ methods.
- Add Destroy() methods for ChannelData and CallData.
- Use C++-style casts.
- Allow ChannelData and CallData to be instantiated directly, for filters that only need to customize one of the two.
- Add 'extern "C"' to iomgr/closure.h, which is used in C++ filters.

Note that this will require changes to some of our internal filter code when we import it (mainly due to the argument changes for the Init() methods).