### PR TITLE
Backport #11606: Expose :authority pseudo-header to Obj-C API

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -179,6 +179,11 @@ extern id const kGRPCTrailersKey;
 @interface GRPCCall : GRXWriter
 
 /**
+ * The server name for the RPC. If nil, the host name of the service object will be used instead.
+ */
+@property (atomic, readwrite) NSString *serverName;
+
+/**
  * The container of the request headers of an RPC conforms to this protocol, which is a subset of
  * NSMutableDictionary's interface. It will become a NSMutableDictionary later on.
  * The keys of this container are the header names, which per the HTTP standard are case-

--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -180,6 +180,7 @@ extern id const kGRPCTrailersKey;
 
 /**
  * The server name for the RPC. If nil, the host name of the service object will be used instead.
+ * This property must be nil when Cronet transport is enabled.
  */
 @property (atomic, readwrite) NSString *serverName;
 

--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -179,8 +179,8 @@ extern id const kGRPCTrailersKey;
 @interface GRPCCall : GRXWriter
 
 /**
- * The server name for the RPC. If nil, the host name of the service object will be used instead.
- * This property must be nil when Cronet transport is enabled.
+ * The authority for the RPC. If nil, the default authority will be used. This property must be nil
+ * when Cronet transport is enabled.
  */
 @property (atomic, readwrite) NSString *serverName;
 

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -440,7 +440,7 @@ static NSMutableDictionary *callFlags;
   _responseWriteable = [[GRXConcurrentWriteable alloc] initWithWriteable:writeable
                                                            dispatchQueue:_responseQueue];
 
-  _wrappedCall = [[GRPCWrappedCall alloc] initWithHost:_host path:_path];
+  _wrappedCall = [[GRPCWrappedCall alloc] initWithHost:_host serverName:_serverName path:_path];
   NSAssert(_wrappedCall, @"Error allocating RPC objects. Low memory?");
 
   [self sendHeaders:_requestHeaders];

--- a/src/objective-c/GRPCClient/private/GRPCChannel.h
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.h
@@ -77,5 +77,6 @@ struct grpc_channel_credentials;
                                      channelArgs:(nullable NSDictionary *)channelArgs;
 
 - (nullable grpc_call *)unmanagedCallWithPath:(nonnull NSString *)path
+                                   serverName:(nonnull NSString *)serverName
                               completionQueue:(nonnull GRPCCompletionQueue *)queue;
 @end

--- a/src/objective-c/GRPCClient/private/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.m
@@ -196,14 +196,17 @@ static grpc_channel_args *BuildChannelArgs(NSDictionary *dictionary) {
 }
 
 - (grpc_call *)unmanagedCallWithPath:(NSString *)path
+                          serverName:(NSString *)serverName
                      completionQueue:(GRPCCompletionQueue *)queue {
+  grpc_slice host_slice = grpc_slice_from_copied_string(serverName.UTF8String);
   grpc_slice path_slice = grpc_slice_from_copied_string(path.UTF8String);
   grpc_call *call = grpc_channel_create_call(_unmanagedChannel,
                                              NULL, GRPC_PROPAGATE_DEFAULTS,
                                              queue.unmanagedQueue,
                                              path_slice,
-                                             NULL, // Passing NULL for host
+                                             &host_slice,
                                              gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
+  grpc_slice_unref(host_slice);
   grpc_slice_unref(path_slice);
   return call;
 }

--- a/src/objective-c/GRPCClient/private/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.m
@@ -198,15 +198,20 @@ static grpc_channel_args *BuildChannelArgs(NSDictionary *dictionary) {
 - (grpc_call *)unmanagedCallWithPath:(NSString *)path
                           serverName:(NSString *)serverName
                      completionQueue:(GRPCCompletionQueue *)queue {
-  grpc_slice host_slice = grpc_slice_from_copied_string(serverName.UTF8String);
+  grpc_slice host_slice;
+  if (serverName) {
+    host_slice = grpc_slice_from_copied_string(serverName.UTF8String);
+  }
   grpc_slice path_slice = grpc_slice_from_copied_string(path.UTF8String);
   grpc_call *call = grpc_channel_create_call(_unmanagedChannel,
                                              NULL, GRPC_PROPAGATE_DEFAULTS,
                                              queue.unmanagedQueue,
                                              path_slice,
-                                             &host_slice,
+                                             serverName ? &host_slice : NULL,
                                              gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
-  grpc_slice_unref(host_slice);
+  if (serverName) {
+    grpc_slice_unref(host_slice);
+  }
   grpc_slice_unref(path_slice);
   return call;
 }

--- a/src/objective-c/GRPCClient/private/GRPCHost.h
+++ b/src/objective-c/GRPCClient/private/GRPCHost.h
@@ -69,6 +69,7 @@ struct grpc_channel_credentials;
 
 /** Create a grpc_call object to the provided path on this host. */
 - (nullable struct grpc_call *)unmanagedCallWithPath:(NSString *)path
+                                          serverName:(nullable NSString *)serverName
                                      completionQueue:(GRPCCompletionQueue *)queue;
 
 // TODO: There's a race when a new RPC is coming through just as an existing one is getting

--- a/src/objective-c/GRPCClient/private/GRPCHost.h
+++ b/src/objective-c/GRPCClient/private/GRPCHost.h
@@ -69,7 +69,7 @@ struct grpc_channel_credentials;
 
 /** Create a grpc_call object to the provided path on this host. */
 - (nullable struct grpc_call *)unmanagedCallWithPath:(NSString *)path
-                                          serverName:(nullable NSString *)serverName
+                                          serverName:(NSString *)serverName
                                      completionQueue:(GRPCCompletionQueue *)queue;
 
 // TODO: There's a race when a new RPC is coming through just as an existing one is getting

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -145,8 +145,7 @@ static GRPCConnectivityMonitor *connectivityMonitor = nil;
     }
     channel = _channel;
   }
-  NSString *name = serverName ? serverName : _address;
-  return [channel unmanagedCallWithPath:path serverName:name completionQueue:queue];
+  return [channel unmanagedCallWithPath:path serverName:serverName completionQueue:queue];
 }
 
 - (BOOL)setTLSPEMRootCerts:(nullable NSString *)pemRootCerts

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -135,6 +135,7 @@ static GRPCConnectivityMonitor *connectivityMonitor = nil;
 }
 
 - (nullable grpc_call *)unmanagedCallWithPath:(NSString *)path
+                                   serverName:(nullable NSString *)serverName
                               completionQueue:(GRPCCompletionQueue *)queue {
   GRPCChannel *channel;
   // This is racing -[GRPCHost disconnect].
@@ -144,7 +145,8 @@ static GRPCConnectivityMonitor *connectivityMonitor = nil;
     }
     channel = _channel;
   }
-  return [channel unmanagedCallWithPath:path completionQueue:queue];
+  NSString *name = serverName ? serverName : _address;
+  return [channel unmanagedCallWithPath:path serverName:name completionQueue:queue];
 }
 
 - (BOOL)setTLSPEMRootCerts:(nullable NSString *)pemRootCerts

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -135,7 +135,7 @@ static GRPCConnectivityMonitor *connectivityMonitor = nil;
 }
 
 - (nullable grpc_call *)unmanagedCallWithPath:(NSString *)path
-                                   serverName:(nullable NSString *)serverName
+                                   serverName:(NSString *)serverName
                               completionQueue:(GRPCCompletionQueue *)queue {
   GRPCChannel *channel;
   // This is racing -[GRPCHost disconnect].

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
@@ -90,6 +90,7 @@
 @interface GRPCWrappedCall : NSObject
 
 - (instancetype)initWithHost:(NSString *)host
+                  serverName:(nullable NSString *)serverName
                         path:(NSString *)path NS_DESIGNATED_INITIALIZER;
 
 - (void)startBatchWithOperations:(NSArray *)ops errorHandler:(void(^)())errorHandler;

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.h
@@ -90,7 +90,7 @@
 @interface GRPCWrappedCall : NSObject
 
 - (instancetype)initWithHost:(NSString *)host
-                  serverName:(nullable NSString *)serverName
+                  serverName:(NSString *)serverName
                         path:(NSString *)path NS_DESIGNATED_INITIALIZER;
 
 - (void)startBatchWithOperations:(NSArray *)ops errorHandler:(void(^)())errorHandler;

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
@@ -251,10 +251,11 @@
 }
 
 - (instancetype)init {
-  return [self initWithHost:nil path:nil];
+  return [self initWithHost:nil serverName:nil path:nil];
 }
 
 - (instancetype)initWithHost:(NSString *)host
+                  serverName:(nullable NSString *)serverName
                         path:(NSString *)path {
   if (!path || !host) {
     [NSException raise:NSInvalidArgumentException
@@ -267,7 +268,7 @@
     // queue. Currently we use a singleton queue.
     _queue = [GRPCCompletionQueue completionQueue];
 
-    _call = [[GRPCHost hostWithAddress:host] unmanagedCallWithPath:path completionQueue:_queue];
+    _call = [[GRPCHost hostWithAddress:host] unmanagedCallWithPath:path serverName:serverName completionQueue:_queue];
     if (_call == NULL) {
       return nil;
     }

--- a/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
+++ b/src/objective-c/GRPCClient/private/GRPCWrappedCall.m
@@ -255,7 +255,7 @@
 }
 
 - (instancetype)initWithHost:(NSString *)host
-                  serverName:(nullable NSString *)serverName
+                  serverName:(NSString *)serverName
                         path:(NSString *)path {
   if (!path || !host) {
     [NSException raise:NSInvalidArgumentException


### PR DESCRIPTION
Backports #11606 to v1.4.x for the next release.