### PR TITLE
Run Android interops on Firebase

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_android_java/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_android_java/Dockerfile.template
@@ -1,0 +1,78 @@
+%YAML 1.2
+--- |
+  # Copyright 2017 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  FROM debian:jessie
+
+  # Install JDK 8 and Git
+  RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && ${'\\'}
+    echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list && ${'\\'}
+    echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list && ${'\\'}
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
+  RUN apt-get update && apt-get -y install ${'\\'}
+        git ${'\\'}
+        libapr1 ${'\\'}
+        oracle-java8-installer ${'\\'}
+        && ${'\\'}
+      apt-get clean && rm -r /var/cache/oracle-jdk8-installer/
+  ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+  ENV PATH $PATH:$JAVA_HOME/bin
+
+  # Install protobuf
+  RUN apt-get update && apt-get install -y ${'\\'}
+        autoconf ${'\\'}
+        build-essential ${'\\'}
+        curl ${'\\'}
+        gcc ${'\\'}
+        libtool ${'\\'}
+        unzip ${'\\'}
+        && ${'\\'}
+      apt-get clean
+  WORKDIR /
+  RUN git clone https://github.com/google/protobuf.git
+  WORKDIR /protobuf
+  RUN git checkout v3.3.1 && ${'\\'}
+    ./autogen.sh && ${'\\'}
+    ./configure && ${'\\'}
+    make && ${'\\'}
+    make check && ${'\\'}
+    make install
+
+  # Install gcloud command line tools
+  ENV CLOUD_SDK_REPO "cloud-sdk-jessie"
+  RUN echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && ${'\\'}
+    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && ${'\\'}
+    apt-get update && apt-get install -y google-cloud-sdk && apt-get clean && ${'\\'}
+    gcloud config set component_manager/disable_update_check true
+
+  # Download and install grpc-java
+  WORKDIR /
+  RUN git clone https://github.com/grpc/grpc-java.git
+  WORKDIR /grpc-java
+  RUN ./gradlew install
+
+  # Setup the Android SDK licenses
+  ENV ANDROID_HOME "/grpc-java/android-interop-testing/.android"
+  RUN mkdir -p "<%text>${ANDROID_HOME}</%text>/licenses"
+  RUN echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "<%text>${ANDROID_HOME}</%text>/licenses/android-sdk-license"
+  RUN echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "<%text>${ANDROID_HOME}</%text>/licenses/android-sdk-preview-license"
+
+  # Build the Android interop apks
+  WORKDIR /grpc-java/android-interop-testing
+  RUN ../gradlew assembleDebug
+  RUN ../gradlew assembleDebugAndroidTest
+
+  # Define the default command.
+  CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_android_java/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_android_java/Dockerfile
@@ -1,0 +1,76 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:jessie
+
+# Install JDK 8 and Git
+RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
+  echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list && \
+  echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list && \
+  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
+RUN apt-get update && apt-get -y install \
+      git \
+      libapr1 \
+      oracle-java8-installer \
+      && \
+    apt-get clean && rm -r /var/cache/oracle-jdk8-installer/
+ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
+ENV PATH $PATH:$JAVA_HOME/bin
+
+# Install protobuf
+RUN apt-get update && apt-get install -y \
+      autoconf \
+      build-essential \
+      curl \
+      gcc \
+      libtool \
+      unzip \
+      && \
+    apt-get clean
+WORKDIR /
+RUN git clone https://github.com/google/protobuf.git
+WORKDIR /protobuf
+RUN git checkout v3.3.1 && \
+  ./autogen.sh && \
+  ./configure && \
+  make && \
+  make check && \
+  make install
+
+# Install gcloud command line tools
+ENV CLOUD_SDK_REPO "cloud-sdk-jessie"
+RUN echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+  curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+  apt-get update && apt-get install -y google-cloud-sdk && apt-get clean && \
+  gcloud config set component_manager/disable_update_check true
+
+# Download and install grpc-java
+WORKDIR /
+RUN git clone https://github.com/grpc/grpc-java.git
+WORKDIR /grpc-java
+RUN ./gradlew install
+
+# Setup the Android SDK licenses
+ENV ANDROID_HOME "/grpc-java/android-interop-testing/.android"
+RUN mkdir -p "${ANDROID_HOME}/licenses"
+RUN echo -e "\n8933bad161af4178b1185d1a37fbf41ea5269c55" > "${ANDROID_HOME}/licenses/android-sdk-license"
+RUN echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "${ANDROID_HOME}/licenses/android-sdk-preview-license"
+
+# Build the Android interop apks
+WORKDIR /grpc-java/android-interop-testing
+RUN ../gradlew assembleDebug
+RUN ../gradlew assembleDebugAndroidTest
+
+# Define the default command.
+CMD ["bash"]

--- a/tools/run_tests/interop/android/android_interop_helper.sh
+++ b/tools/run_tests/interop/android/android_interop_helper.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Helper that runs inside the docker container and builds the APKs and
+# invokes Firebase Test Lab via gcloud.
+
+SERVICE_KEY=$1
+
+gcloud auth activate-service-account --key-file=$SERVICE_KEY || exit 1
+gcloud config set project grpc-testing || exit 1
+
+rm -rf grpc-java
+git clone https://github.com/grpc/grpc-java.git
+cd grpc-java
+./gradlew install || exit 1
+cd android-interop-testing
+../gradlew assembleDebug
+../gradlew assembleDebugAndroidTest
+
+gcloud firebase test android run \
+  --type instrumentation \
+  --app app/build/outputs/apk/app-debug.apk \
+  --test app/build/outputs/apk/app-debug-androidTest.apk \
+  --device model=Nexus6,version=21,locale=en,orientation=portrait

--- a/tools/run_tests/interop/android/run_android_tests_on_firebase.sh
+++ b/tools/run_tests/interop/android/run_android_tests_on_firebase.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Builds the gRPC Android instrumented interop tests inside a docker container
+# and runs them on Firebase Test Lab
+
+DOCKERFILE=tools/dockerfile/interoptest/grpc_interop_android_java/Dockerfile
+DOCKER_TAG=android_interop_test
+SERVICE_KEY=~/android-interops-service-key.json
+HELPER=$(pwd)/tools/run_tests/interop/android/android_interop_helper.sh
+
+docker build -t $DOCKER_TAG -f $DOCKERFILE .
+
+docker run --interactive --rm \
+  --volume="$SERVICE_KEY":/service-key.json:ro \
+  --volume="$HELPER":/android_interop_helper.sh:ro \
+  $DOCKER_TAG \
+      /bin/bash -c "/android_interop_helper.sh /service-key.json"


### PR DESCRIPTION
This builds the android instrumented unit tests and runs them on Firebase Test Lab. This will be hooked up to [Jenkins](https://grpc-testing.appspot.com/job/gRPC%20Android%20Firebase/), e.g., https://grpc-testing.appspot.com/job/gRPC%20Android%20Firebase/11/console (running off this branch).

These scripts live alongside the existing interop tests but are completely separate. Putting them here rather than in grpc-java because (a) all of the other interops are already here (b) some of the architecture in the future likely should shared with the other interops and (c) eventually, we could be using the same setup to run tests for Android NDK.