### PR TITLE
Make GCC 7.1.1 happy

### DIFF
--- a/src/core/ext/transport/chttp2/transport/bin_decoder.c
+++ b/src/core/ext/transport/chttp2/transport/bin_decoder.c
@@ -117,7 +117,7 @@ bool grpc_base64_decode_partial(struct grpc_base64_decode_context *ctx) {
       if (!input_is_valid(ctx->input_cur, input_tail)) return false;
       switch (input_tail) {
         case 3:
-          ctx->output_cur[1] = COMPOSE_OUTPUT_BYTE_1(ctx->input_cur);
+          ctx->output_cur[1] = COMPOSE_OUTPUT_BYTE_1(ctx->input_cur); // fallthrough
         case 2:
           ctx->output_cur[0] = COMPOSE_OUTPUT_BYTE_0(ctx->input_cur);
       }

--- a/src/core/ext/transport/chttp2/transport/varint.c
+++ b/src/core/ext/transport/chttp2/transport/varint.c
@@ -36,13 +36,13 @@ void grpc_chttp2_hpack_write_varint_tail(uint32_t tail_value, uint8_t* target,
                                          uint32_t tail_length) {
   switch (tail_length) {
     case 5:
-      target[4] = (uint8_t)((tail_value >> 28) | 0x80);
+      target[4] = (uint8_t)((tail_value >> 28) | 0x80); // fallthrough
     case 4:
-      target[3] = (uint8_t)((tail_value >> 21) | 0x80);
+      target[3] = (uint8_t)((tail_value >> 21) | 0x80); // fallthrough
     case 3:
-      target[2] = (uint8_t)((tail_value >> 14) | 0x80);
+      target[2] = (uint8_t)((tail_value >> 14) | 0x80); // fallthrough
     case 2:
-      target[1] = (uint8_t)((tail_value >> 7) | 0x80);
+      target[1] = (uint8_t)((tail_value >> 7) | 0x80); // fallthrough
     case 1:
       target[0] = (uint8_t)((tail_value) | 0x80);
   }

--- a/src/core/ext/transport/cronet/transport/cronet_transport.c
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.c
@@ -649,7 +649,7 @@ static void create_grpc_frame(grpc_slice_buffer *write_slice_buffer,
   uint8_t *p = (uint8_t *)write_buffer;
   /* Append 5 byte header */
   /* Compressed flag */
-  *p++ = (flags & GRPC_WRITE_INTERNAL_COMPRESS) ? 1 : 0;
+  *p++ = (uint8_t)((flags & GRPC_WRITE_INTERNAL_COMPRESS) ? 1 : 0);
   /* Message length */
   *p++ = (uint8_t)(length >> 24);
   *p++ = (uint8_t)(length >> 16);

--- a/src/core/lib/json/json_reader.c
+++ b/src/core/lib/json/json_reader.c
@@ -176,7 +176,7 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader *reader) {
             success = (uint32_t)json_reader_set_number(reader);
             if (!success) return GRPC_JSON_PARSE_ERROR;
             json_reader_string_clear(reader);
-            reader->state = GRPC_JSON_STATE_VALUE_END;
+            reader->state = GRPC_JSON_STATE_VALUE_END; // fallthrough
           /* The missing break here is intentional. */
 
           case GRPC_JSON_STATE_VALUE_END:

--- a/src/core/lib/support/murmur_hash.c
+++ b/src/core/lib/support/murmur_hash.c
@@ -61,9 +61,9 @@ uint32_t gpr_murmur_hash3(const void *key, size_t len, uint32_t seed) {
   /* tail */
   switch (len & 3) {
     case 3:
-      k1 ^= ((uint32_t)tail[2]) << 16;
+      k1 ^= ((uint32_t)tail[2]) << 16; // fallthrough
     case 2:
-      k1 ^= ((uint32_t)tail[1]) << 8;
+      k1 ^= ((uint32_t)tail[1]) << 8; // fallthrough
     case 1:
       k1 ^= tail[0];
       k1 *= c1;

--- a/src/core/tsi/ssl_transport_security.c
+++ b/src/core/tsi/ssl_transport_security.c
@@ -131,6 +131,9 @@ static void init_openssl(void) {
   for (i = 0; i < CRYPTO_num_locks(); i++) {
     gpr_mu_init(&openssl_mutexes[i]);
   }
+  // make gcc 7.1.1 happy
+  (void) openssl_locking_cb;
+  (void) openssl_thread_id_cb;
   CRYPTO_set_locking_callback(openssl_locking_cb);
   CRYPTO_set_id_callback(openssl_thread_id_cb);
 }
@@ -1282,7 +1285,7 @@ tsi_result tsi_create_ssl_client_handshaker_factory(
   *factory = NULL;
   if (pem_root_certs == NULL) return TSI_INVALID_ARGUMENT;
 
-  ssl_context = SSL_CTX_new(TLSv1_2_method());
+  ssl_context = SSL_CTX_new(TLS_method());
   if (ssl_context == NULL) {
     gpr_log(GPR_ERROR, "Could not create ssl context.");
     return TSI_INVALID_ARGUMENT;
@@ -1390,7 +1393,7 @@ tsi_result tsi_create_ssl_server_handshaker_factory_ex(
 
   for (i = 0; i < num_key_cert_pairs; i++) {
     do {
-      impl->ssl_contexts[i] = SSL_CTX_new(TLSv1_2_method());
+      impl->ssl_contexts[i] = SSL_CTX_new(TLS_method());
       if (impl->ssl_contexts[i] == NULL) {
         gpr_log(GPR_ERROR, "Could not create ssl context.");
         result = TSI_OUT_OF_RESOURCES;


### PR DESCRIPTION
Fix https://github.com/grpc/grpc/issues/11376 and several other warnings:
```
src/core/lib/security/credentials/jwt/jwt_verifier.c: In function ‘pkey_from_jwk’:
src/core/lib/security/credentials/jwt/jwt_verifier.c:483:10: error: dereferencing pointer to incomplete type ‘RSA {aka struct rsa_st}’
       rsa->n =
          ^~
make: *** [Makefile:2496: /home/cholerae/cxcode/grpc/objs/opt/src/core/lib/security/credentials/jwt/jwt_verifier.o] Error 1
[cholerae@x240s grpc]$ vim src/core/lib/security/credentials/jwt/jwt_verifier.c
[cholerae@x240s grpc]$ make
[MAKE]    Generating cache.mk
[C]       Compiling src/core/lib/security/credentials/jwt/jwt_verifier.c
src/core/lib/security/credentials/jwt/jwt_verifier.c: In function ‘pkey_from_jwk’:
src/core/lib/security/credentials/jwt/jwt_verifier.c:484:25: error: ‘r’ undeclared (first use in this function)
       if (!RSA_set0_key(r, bignum_from_base64(exec_ctx, validate_string_field(key_prop, "n")), NULL, NULL)) {
                         ^
src/core/lib/security/credentials/jwt/jwt_verifier.c:484:25: note: each undeclared identifier is reported only once for each function it appears in
src/core/lib/security/credentials/jwt/jwt_verifier.c:493:10: error: dereferencing pointer to incomplete type ‘RSA {aka struct rsa_st}’
   if (rsa->e == NULL || rsa->n == NULL) {
          ^~
```
See https://github.com/openssl/openssl/issues/1491

```
src/core/tsi/ssl_transport_security.c: In function ‘tsi_create_ssl_client_handshaker_factory’:
src/core/tsi/ssl_transport_security.c:1285:3: error: ‘TLSv1_2_method’ is deprecated [-Werror=deprecated-declarations]
   ssl_context = SSL_CTX_new(TLSv1_2_method());
   ^~~~~~~~~~~
In file included from /usr/include/openssl/opensslconf.h:42:0,
                 from /usr/include/openssl/ct.h:13,
                 from /usr/include/openssl/ssl.h:61,
                 from src/core/tsi/ssl_transport_security.c:45:
/usr/include/openssl/ssl.h:1629:1: note: declared here
 DEPRECATEDIN_1_1_0(__owur const SSL_METHOD *TLSv1_2_method(void)) /* TLSv1.2 */
 ^
src/core/tsi/ssl_transport_security.c: In function ‘tsi_create_ssl_server_handshaker_factory_ex’:
src/core/tsi/ssl_transport_security.c:1393:7: error: ‘TLSv1_2_method’ is deprecated [-Werror=deprecated-declarations]
       impl->ssl_contexts[i] = SSL_CTX_new(TLSv1_2_method());
       ^~~~
In file included from /usr/include/openssl/opensslconf.h:42:0,
                 from /usr/include/openssl/ct.h:13,
                 from /usr/include/openssl/ssl.h:61,
                 from src/core/tsi/ssl_transport_security.c:45:
/usr/include/openssl/ssl.h:1629:1: note: declared here
 DEPRECATEDIN_1_1_0(__owur const SSL_METHOD *TLSv1_2_method(void)) /* TLSv1.2 */
 ^
At top level:
```

```
src/core/tsi/ssl_transport_security.c:118:22: error: ‘openssl_thread_id_cb’ defined but not used [-Werror=unused-function]
 static unsigned long openssl_thread_id_cb(void) {
                      ^~~~~~~~~~~~~~~~~~~~
src/core/tsi/ssl_transport_security.c:110:13: error: ‘openssl_locking_cb’ defined but not used [-Werror=unused-function]
 static void openssl_locking_cb(int mode, int type, const char *file, int line) {
             ^~~~~~~~~~~~~~~~~~
```
Don't know why.

```
src/core/ext/transport/cronet/transport/cronet_transport.c: In function ‘create_grpc_frame’:
src/core/ext/transport/cronet/transport/cronet_transport.c:652:10: error: conversion to ‘uint8_t {aka unsigned char}’ from ‘int’ may alter its value [-Werror=conversion]
   *p++ = (flags & GRPC_WRITE_INTERNAL_COMPRESS) ? (uint8_t)(1) : (uint8_t)(0);
          ^
```

I'm using fedora 26 and GCC 7.1.1.


Signed-off-by: Cholerae Hu <huyingqian@pingcap.com>