### PR TITLE
Improve python artifact building

### DIFF
--- a/tools/internal_ci/windows/grpc_build_artifacts.bat
+++ b/tools/internal_ci/windows/grpc_build_artifacts.bat
@@ -12,6 +12,13 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 
+@rem Move python installation from _32bit to _32bits where they are expected python artifact builder
+@rem TODO(jtattermusch): get rid of this hack
+rename C:\Python27_32bit Python27_32bits
+rename C:\Python34_32bit Python34_32bits
+rename C:\Python35_32bit Python35_32bits
+rename C:\Python36_32bit Python36_32bits
+
 @rem make sure msys binaries are preferred over cygwin binaries
 @rem set path to python 2.7
 set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -148,9 +148,7 @@ class PythonArtifact:
       return create_jobspec(self.name,
                             ['tools\\run_tests\\artifacts\\build_artifact_python.bat',
                              self.py_version,
-                             '32' if self.arch == 'x86' else '64',
-                             dir
-                            ],
+                             '32' if self.arch == 'x86' else '64'],
                             environ=environ,
                             use_workspace=True)
     else:

--- a/tools/run_tests/artifacts/build_artifact_python.bat
+++ b/tools/run_tests/artifacts/build_artifact_python.bat
@@ -21,16 +21,8 @@ pip install -rrequirements.txt
 
 set GRPC_PYTHON_BUILD_WITH_CYTHON=1
 
-@rem Multiple builds are running simultaneously, so to avoid distutils
-@rem file collisions, we build everything in a tmp directory
-@rem TODO(jtattermusch): it doesn't look like builds are actually running in parallel in the same dir
 mkdir -p %ARTIFACTS_OUT%
 set ARTIFACT_DIR=%cd%\%ARTIFACTS_OUT%
-set BUILD_DIR=C:\Windows\Temp\pygrpc-%3\
-mkdir %BUILD_DIR%
-xcopy /s/e/q %cd%\* %BUILD_DIR%
-pushd %BUILD_DIR%
-
 
 @rem Set up gRPC Python tools
 python tools\distrib\python\make_grpcio_tools.py
@@ -49,16 +41,11 @@ pushd tools\distrib\python\grpcio_tools
 python setup.py bdist_wheel || goto :error
 popd
 
-
 xcopy /Y /I /S dist\* %ARTIFACT_DIR% || goto :error
 xcopy /Y /I /S tools\distrib\python\grpcio_tools\dist\* %ARTIFACT_DIR% || goto :error
-
-popd
-rmdir /s /q %BUILD_DIR%
 
 goto :EOF
 
 :error
 popd
-rmdir /s /q %BUILD_DIR%
 exit /b 1

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -23,16 +23,8 @@ export PYTHON=${PYTHON:-python}
 export PIP=${PIP:-pip}
 export AUDITWHEEL=${AUDITWHEEL:-auditwheel}
 
-# Because multiple builds run in parallel, some distutils file
-# operations may collide.  To avoid this, each build is run in
-# a temp directory
-# TODO(jtattermusch): it doesn't look like builds are actually running in parallel in the same dir
 mkdir -p "${ARTIFACTS_OUT}"
 ARTIFACT_DIR="$PWD/${ARTIFACTS_OUT}"
-BUILD_DIR=`mktemp -d "${TMPDIR:-/tmp}/pygrpc.XXXXXX"`
-trap "rm -rf $BUILD_DIR" EXIT
-cp -r * "$BUILD_DIR"
-cd "$BUILD_DIR"
 
 # Build the source distribution first because MANIFEST.in cannot override
 # exclusion of built shared objects among package resources (for some


### PR DESCRIPTION
- fix Python35_32bits & Python36_32bits artifact on Kokoro windows (by fixing the search path for python)
- get rid of copying to temporary directory before building (it's unnecessary since building in workspaces is supported by task_runner.py)