### PR TITLE
(experiment. Do not merge) may fix mac failures

### DIFF
--- a/src/cpp/thread_manager/thread_manager.cc
+++ b/src/cpp/thread_manager/thread_manager.cc
@@ -83,14 +83,11 @@ void ThreadManager::MarkAsCompleted(WorkerThread* thd) {
 }
 
 void ThreadManager::CleanupCompletedThreads() {
-  std::list<WorkerThread*> completed_threads;
-  {
-    // swap out the completed threads list: allows other threads to clean up
-    // more quickly
-    std::unique_lock<std::mutex> lock(list_mu_);
-    completed_threads.swap(completed_threads_);
+  std::unique_lock<std::mutex> lock(list_mu_);
+  for (auto thd = completed_threads_.begin(); thd != completed_threads_.end();
+       thd = completed_threads_.erase(thd)) {
+    delete *thd;
   }
-  for (auto thd : completed_threads) delete thd;
 }
 
 void ThreadManager::Initialize() {

--- a/src/cpp/thread_manager/thread_manager.cc
+++ b/src/cpp/thread_manager/thread_manager.cc
@@ -31,6 +31,8 @@ ThreadManager::WorkerThread::WorkerThread(ThreadManager* thd_mgr)
   thd_.detach();
 }
 
+ThreadManager::WorkerThread::~WorkerThread() {}
+
 void ThreadManager::WorkerThread::Run() {
   thd_mgr_->MainWorkLoop();
   thd_mgr_->MarkAsCompleted(this);

--- a/src/cpp/thread_manager/thread_manager.cc
+++ b/src/cpp/thread_manager/thread_manager.cc
@@ -28,12 +28,12 @@ namespace grpc {
 
 ThreadManager::WorkerThread::WorkerThread(ThreadManager* thd_mgr)
     : thd_mgr_(thd_mgr), thd_(&ThreadManager::WorkerThread::Run, this) {
-  thd_.detach();
 }
 
 ThreadManager::WorkerThread::~WorkerThread() {}
 
 void ThreadManager::WorkerThread::Run() {
+  thd_.detach();
   thd_mgr_->MainWorkLoop();
   thd_mgr_->MarkAsCompleted(this);
 }

--- a/src/cpp/thread_manager/thread_manager.cc
+++ b/src/cpp/thread_manager/thread_manager.cc
@@ -71,6 +71,8 @@ void ThreadManager::MarkAsCompleted(WorkerThread* thd) {
   if (num_threads_ == 0) {
     shutdown_cv_.notify_one();
   }
+
+  delete thd;
 }
 
 void ThreadManager::Initialize() {

--- a/src/cpp/thread_manager/thread_manager.cc
+++ b/src/cpp/thread_manager/thread_manager.cc
@@ -34,6 +34,7 @@ ThreadManager::WorkerThread::~WorkerThread() {}
 
 void ThreadManager::WorkerThread::Run() {
   thd_.detach();
+  GPR_ASSERT(!thd_.joinable());
   thd_mgr_->MainWorkLoop();
   thd_mgr_->MarkAsCompleted(this);
 }

--- a/src/cpp/thread_manager/thread_manager.h
+++ b/src/cpp/thread_manager/thread_manager.h
@@ -108,7 +108,6 @@ class ThreadManager {
   void MainWorkLoop();
 
   void MarkAsCompleted(WorkerThread* thd);
-  void CleanupCompletedThreads();
 
   // Protects shutdown_, num_pollers_ and num_threads_
   // TODO: sreek - Change num_pollers and num_threads_ to atomics
@@ -127,9 +126,6 @@ class ThreadManager {
   // The total number of threads (includes threads includes the threads that are
   // currently polling i.e num_pollers_)
   int num_threads_;
-
-  std::mutex list_mu_;
-  std::list<WorkerThread*> completed_threads_;
 };
 
 }  // namespace grpc

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -1752,7 +1752,9 @@ std::vector<TestScenario> CreateTestScenarios(bool test_disable_blocking,
     messages.push_back(big_msg);
   }
 
-  for (auto health_check_service : {false, true}) {
+  /* TODO(sreek) - Disable health check service for now until we debug issue
+   * https://github.com/grpc/grpc/issues/11223 */
+  for (auto health_check_service : {false}) {
     for (auto cred = credentials_types.begin(); cred != credentials_types.end();
          ++cred) {
       for (auto msg = messages.begin(); msg != messages.end(); msg++) {


### PR DESCRIPTION
The sporadic thread.join() failures in mac end2end tests are happening because `WorkerThread` destructor (in `src\cpp\thread_manager\thread_manager.c`) is being called twice - in some cases (whats even more alarming is that the destructor seems to recursively call itself a second time - as per the call stack).

Undoing one of the recent changes to `thread_manager` to see if it fixes the mac failures
