### PR TITLE
Fix some memory leaks in UV TCP code

### DIFF
--- a/src/core/lib/iomgr/resolve_address_uv.c
+++ b/src/core/lib/iomgr/resolve_address_uv.c
@@ -54,7 +54,7 @@ static int retry_named_port_failure(int status, request *r,
         int retry_status;
         uv_getaddrinfo_t *req = gpr_malloc(sizeof(uv_getaddrinfo_t));
         req->data = r;
-        r->port = svc[i][1];
+        r->port = gpr_strdup(svc[i][1]);
         retry_status = uv_getaddrinfo(uv_default_loop(), req, getaddrinfo_cb,
                                       r->host, r->port, r->hints);
         if (retry_status < 0 || getaddrinfo_cb == NULL) {
@@ -127,6 +127,8 @@ static void getaddrinfo_callback(uv_getaddrinfo_t *req, int status,
   GRPC_CLOSURE_SCHED(&exec_ctx, r->on_done, error);
   grpc_exec_ctx_finish(&exec_ctx);
   gpr_free(r->hints);
+  gpr_free(r->host);
+  gpr_free(r->port);
   gpr_free(r);
   uv_freeaddrinfo(res);
 }

--- a/src/core/lib/iomgr/tcp_server_uv.c
+++ b/src/core/lib/iomgr/tcp_server_uv.c
@@ -234,6 +234,7 @@ static void on_connect(uv_stream_t *server, int status) {
     sp->server->on_accept_cb(&exec_ctx, sp->server->on_accept_cb_arg, ep, NULL,
                              acceptor);
     grpc_exec_ctx_finish(&exec_ctx);
+    gpr_free(peer_name_string);
   }
 }
 

--- a/src/core/lib/iomgr/tcp_uv.c
+++ b/src/core/lib/iomgr/tcp_uv.c
@@ -67,6 +67,8 @@ typedef struct {
 static void tcp_free(grpc_exec_ctx *exec_ctx, grpc_tcp *tcp) {
   grpc_slice_unref_internal(exec_ctx, tcp->read_slice);
   grpc_resource_user_unref(exec_ctx, tcp->resource_user);
+  gpr_free(tcp->handle);
+  gpr_free(tcp->peer_string);
   gpr_free(tcp);
 }
 


### PR DESCRIPTION
This fixes a couple of memory leaks in our UV TCP code. This change comes from an attempt to solve #10879 using Asan. Asan no longer reports any issues with those tests, but the failures persist.