### PR TITLE
Switch install instructions to use https

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -77,7 +77,7 @@ For developers who are interested to contribute, here is how to compile the
 gRPC C Core library.
 
 ```sh
- $ git clone -b $(curl -L http://grpc.io/release) https://github.com/grpc/grpc
+ $ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
  $ cd grpc
  $ git submodule update --init
  $ make

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -95,7 +95,7 @@ on experience with the tools involved.
 
 Builds gRPC C and C++ with boringssl.
 - Install [CMake](https://cmake.org/download/).
-- Install [Active State Perl](http://www.activestate.com/activeperl/) (`choco install activeperl`)
+- Install [Active State Perl](https://www.activestate.com/activeperl/) (`choco install activeperl`)
 - Install [Ninja](https://ninja-build.org/) (`choco install ninja`)
 - Install [Go](https://golang.org/dl/) (`choco install golang`)
 - Install [yasm](http://yasm.tortall.net/) and add it to `PATH` (`choco install yasm`)

--- a/examples/cpp/helloworld/README.md
+++ b/examples/cpp/helloworld/README.md
@@ -12,7 +12,7 @@ following command:
 
 
 ```sh
-$ git clone -b $(curl -L http://grpc.io/release) https://github.com/grpc/grpc
+$ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
 ```
 
 Change your current directory to examples/cpp/helloworld

--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -12,7 +12,7 @@ INSTALL
    ```sh
    $ # Get the gRPC repository
    $ export REPO_ROOT=grpc # REPO root can be any directory of your choice
-   $ git clone -b $(curl -L http://grpc.io/release) https://github.com/grpc/grpc $REPO_ROOT
+   $ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc $REPO_ROOT
    $ cd $REPO_ROOT
 
    $ cd examples/node

--- a/examples/objective-c/helloworld/README.md
+++ b/examples/objective-c/helloworld/README.md
@@ -16,7 +16,7 @@ this repository to your local machine by running the following commands:
 
 
 ```sh
-$ git clone -b $(curl -L http://grpc.io/release) https://github.com/grpc/grpc
+$ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
 $ cd grpc
 $ git submodule update --init
 ```

--- a/examples/php/README.md
+++ b/examples/php/README.md
@@ -17,7 +17,7 @@ INSTALL
  - Clone this repository
 
    ```sh
-   $ git clone -b $(curl -L http://grpc.io/release) https://github.com/grpc/grpc
+   $ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
    ```
 
  - Install composer

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -47,7 +47,7 @@ below.
 # Build from Source
 
 ```sh
- $ git clone -b $(curl -L http://grpc.io/release) https://github.com/grpc/grpc
+ $ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
  $ cd grpc
  $ git submodule update --init
  $ make

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -100,7 +100,7 @@ the `composer` and `protoc` binaries. You can find out how to get these
 Clone this repository
 
 ```sh
-$ git clone -b $(curl -L http://grpc.io/release) https://github.com/grpc/grpc
+$ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
 ```
 
 Build and install the gRPC C core library
@@ -129,7 +129,7 @@ $ sudo make install
 You will need the source code to run tests
 
 ```sh
-$ git clone -b $(curl -L http://grpc.io/release) https://github.com/grpc/grpc
+$ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
 $ cd grpc
 $ git pull --recurse-submodules && git submodule update --init --recursive
 ```

--- a/src/python/grpcio/README.rst
+++ b/src/python/grpcio/README.rst
@@ -46,7 +46,7 @@ package named :code:`python-dev`).
 ::
 
   $ export REPO_ROOT=grpc  # REPO_ROOT can be any directory of your choice
-  $ git clone -b $(curl -L http://grpc.io/release) https://github.com/grpc/grpc $REPO_ROOT
+  $ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc $REPO_ROOT
   $ cd $REPO_ROOT
   $ git submodule update --init
 

--- a/tools/distrib/python/grpcio_tools/README.rst
+++ b/tools/distrib/python/grpcio_tools/README.rst
@@ -53,7 +53,7 @@ GCC-like stuff, but you may end up having a bad time.
 ::
 
   $ export REPO_ROOT=grpc  # REPO_ROOT can be any directory of your choice
-  $ git clone -b $(curl -L http://grpc.io/release) https://github.com/grpc/grpc $REPO_ROOT
+  $ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc $REPO_ROOT
   $ cd $REPO_ROOT
   $ git submodule update --init
 


### PR DESCRIPTION
We used to instruct users to run a shell command that fetches and evaluates an HTTP address. It is vulnerable to MITM attacks.

Fixes #7227 