### PR TITLE
Use https://grpc.io consistently as the canonical URL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "type": "library",
   "description": "gRPC library for PHP",
   "keywords": ["rpc"],
-  "homepage": "http://grpc.io",
+  "homepage": "https://grpc.io",
   "license": "Apache-2.0",
   "require": {
     "php": ">=5.5.0"

--- a/doc/PROTOCOL-WEB.md
+++ b/doc/PROTOCOL-WEB.md
@@ -3,14 +3,14 @@
 gRPC-Web provides a JS client library that supports the same API
 as gRPC-Node to access a gRPC service. Due to browser limitation,
 the Web client library implements a different protocol than the
-[native gRPC protocol](http://www.grpc.io/docs/guides/wire.html).
+[native gRPC protocol](https://grpc.io/docs/guides/wire.html).
 This protocol is designed to make it easy for a proxy to translate
 between the protocols as this is the most likely deployment model.
 
 This document lists the differences between the two protocols.
 To help tracking future revisions, this document describes a delta
 with the protocol details specified in the
-[native gRPC protocol](http://www.grpc.io/docs/guides/wire.html).
+[native gRPC protocol](https://grpc.io/docs/guides/wire.html).
 
 # Design goals
 
@@ -31,7 +31,7 @@ web-specific features such as CORS, XSRF
 * become optional (in 1-2 years) when browsers are able to speak the native
 gRPC protocol via the new [whatwg fetch/streams API](https://github.com/whatwg/fetch)
 
-# Protocol differences vs [gRPC over HTTP2](http://www.grpc.io/docs/guides/wire.html)
+# Protocol differences vs [gRPC over HTTP2](https://grpc.io/docs/guides/wire.html)
 
 Content-Type
 
@@ -53,14 +53,14 @@ HTTP wire protocols
 
 ---
 
-HTTP/2 related behavior (specified in [gRPC over HTTP2](http://www.grpc.io/docs/guides/wire.html))
+HTTP/2 related behavior (specified in [gRPC over HTTP2](https://grpc.io/docs/guides/wire.html))
 
 1. stream-id is not supported or used
 2. go-away is not supported or used
 
 ---
 
-Message framing (vs. [http2-transport-mapping](http://www.grpc.io/docs/guides/wire.html#http2-transport-mapping))
+Message framing (vs. [http2-transport-mapping](https://grpc.io/docs/guides/wire.html#http2-transport-mapping))
 
 1. Response status encoded as part of the response body
   * Key-value pairs encoded as a HTTP/1 headers block (without the terminating newline), per https://tools.ietf.org/html/rfc7230#section-3.2
@@ -86,7 +86,7 @@ in the body.
 User Agent
 
 * Do NOT use User-Agent header (which is to be set by browsers, by default)
-* Use X-User-Agent: grpc-web-javascript/0.1 (follow the same format as specified in [gRPC over HTTP2](http://www.grpc.io/docs/guides/wire.html))
+* Use X-User-Agent: grpc-web-javascript/0.1 (follow the same format as specified in [gRPC over HTTP2](https://grpc.io/docs/guides/wire.html))
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,7 +9,7 @@ Examples for Go and Java gRPC live in their own repositories:
 * [Android Java](https://github.com/grpc/grpc-java/tree/master/examples/android)
 * [Go](https://github.com/grpc/grpc-go/tree/master/examples)
 
-For more comprehensive documentation, including an [overview](http://www.grpc.io/docs/) and tutorials that use this example code, visit [grpc.io](http://www.grpc.io/docs/).
+For more comprehensive documentation, including an [overview](https://grpc.io/docs/) and tutorials that use this example code, visit [grpc.io](https://grpc.io/docs/).
 
 ## Quick start
 

--- a/examples/csharp/helloworld-from-cli/README.md
+++ b/examples/csharp/helloworld-from-cli/README.md
@@ -49,4 +49,4 @@ Tutorial
 You can find a more detailed tutorial about Grpc in [gRPC Basics: C#][]
 
 [helloworld.proto]:../../protos/helloworld.proto
-[gRPC Basics: C#]:http://www.grpc.io/docs/tutorials/basic/csharp.html
+[gRPC Basics: C#]:https://grpc.io/docs/tutorials/basic/csharp.html

--- a/examples/csharp/helloworld/README.md
+++ b/examples/csharp/helloworld/README.md
@@ -64,4 +64,4 @@ You can find a more detailed tutorial in [gRPC Basics: C#][]
 
 [helloworld-from-cli]:../helloworld-from-cli/README.md
 [helloworld.proto]:../../protos/helloworld.proto
-[gRPC Basics: C#]:http://www.grpc.io/docs/tutorials/basic/csharp.html
+[gRPC Basics: C#]:https://grpc.io/docs/tutorials/basic/csharp.html

--- a/examples/csharp/route_guide/README.md
+++ b/examples/csharp/route_guide/README.md
@@ -3,4 +3,4 @@
 The files in this folder are the samples used in [gRPC Basics: C#][],
 a detailed tutorial for using gRPC in C#.
 
-[gRPC Basics: C#]:http://www.grpc.io/docs/tutorials/basic/csharp.html
+[gRPC Basics: C#]:https://grpc.io/docs/tutorials/basic/csharp.html

--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -47,4 +47,4 @@ TUTORIAL
 You can find a more detailed tutorial in [gRPC Basics: Node.js][]
 
 [Install gRPC Node]:../../src/node
-[gRPC Basics: Node.js]:http://www.grpc.io/docs/tutorials/basic/node.html
+[gRPC Basics: Node.js]:https://grpc.io/docs/tutorials/basic/node.html

--- a/examples/node/dynamic_codegen/route_guide/README.md
+++ b/examples/node/dynamic_codegen/route_guide/README.md
@@ -2,4 +2,4 @@
 
 The files in this folder are the samples used in [gRPC Basics: Node.js][], a detailed tutorial for using gRPC in Node.js.
 
-[gRPC Basics: Node.js]:http://www.grpc.io/docs/tutorials/basic/node.html
+[gRPC Basics: Node.js]:https://grpc.io/docs/tutorials/basic/node.html

--- a/examples/node/static_codegen/route_guide/README.md
+++ b/examples/node/static_codegen/route_guide/README.md
@@ -2,4 +2,4 @@
 
 The files in this folder are the samples used in [gRPC Basics: Node.js][], a detailed tutorial for using gRPC in Node.js.
 
-[gRPC Basics: Node.js]:http://www.grpc.io/docs/tutorials/basic/node.html
+[gRPC Basics: Node.js]:https://grpc.io/docs/tutorials/basic/node.html

--- a/examples/objective-c/auth_sample/AuthTestService.podspec
+++ b/examples/objective-c/auth_sample/AuthTestService.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version  = "0.0.1"
   s.license  = "Apache License, Version 2.0"
   s.authors  = { 'gRPC contributors' => 'grpc-io@googlegroups.com' }
-  s.homepage = "http://www.grpc.io/"
+  s.homepage = "https://grpc.io/"
   s.summary = "AuthTestService example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 

--- a/examples/objective-c/auth_sample/README.md
+++ b/examples/objective-c/auth_sample/README.md
@@ -1,3 +1,3 @@
 # OAuth2 on gRPC: Objective-C
 
-This is the supporting code for the tutorial "[OAuth2 on gRPC: Objective-C](http://www.grpc.io/docs/tutorials/auth/oauth2-objective-c.html)."
+This is the supporting code for the tutorial "[OAuth2 on gRPC: Objective-C](https://grpc.io/docs/tutorials/auth/oauth2-objective-c.html)."

--- a/examples/objective-c/helloworld/HelloWorld.podspec
+++ b/examples/objective-c/helloworld/HelloWorld.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version  = "0.0.1"
   s.license  = "Apache License, Version 2.0"
   s.authors  = { 'gRPC contributors' => 'grpc-io@googlegroups.com' }
-  s.homepage = "http://www.grpc.io/"
+  s.homepage = "https://grpc.io/"
   s.summary = "HelloWorld example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 

--- a/examples/objective-c/helloworld/README.md
+++ b/examples/objective-c/helloworld/README.md
@@ -55,4 +55,4 @@ responds with a `HLWHelloResponse`, which contains a string that is then output 
 
 ## Tutorial
 
-You can find a more detailed tutorial in [gRPC Basics: Objective-C](http://www.grpc.io/docs/tutorials/basic/objective-c.html).
+You can find a more detailed tutorial in [gRPC Basics: Objective-C](https://grpc.io/docs/tutorials/basic/objective-c.html).

--- a/examples/objective-c/route_guide/README.md
+++ b/examples/objective-c/route_guide/README.md
@@ -1,4 +1,4 @@
 # gRPC Basics: Objective-C
 
-This is the supporting code for the tutorial "[gRPC Basics: Objective-C](http://www.grpc.io/docs/tutorials/basic/objective-c.html)."
+This is the supporting code for the tutorial "[gRPC Basics: Objective-C](https://grpc.io/docs/tutorials/basic/objective-c.html)."
 

--- a/examples/objective-c/route_guide/RouteGuide.podspec
+++ b/examples/objective-c/route_guide/RouteGuide.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version  = "0.0.1"
   s.license  = "Apache License, Version 2.0"
   s.authors  = { 'gRPC contributors' => 'grpc-io@googlegroups.com' }
-  s.homepage = "http://www.grpc.io/"
+  s.homepage = "https://grpc.io/"
   s.summary = "RouteGuide example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 

--- a/examples/php/README.md
+++ b/examples/php/README.md
@@ -60,4 +60,4 @@ TUTORIAL
 You can find a more detailed tutorial in [gRPC Basics: PHP][]
 
 [Node]:https://github.com/grpc/grpc/tree/master/examples/node
-[gRPC Basics: PHP]:http://www.grpc.io/docs/tutorials/basic/php.html
+[gRPC Basics: PHP]:https://grpc.io/docs/tutorials/basic/php.html

--- a/examples/php/route_guide/README.md
+++ b/examples/php/route_guide/README.md
@@ -3,4 +3,4 @@
 The files in this folder are the samples used in [gRPC Basics: PHP][],
 a detailed tutorial for using gRPC in PHP.
 
-[gRPC Basics: PHP]:http://www.grpc.io/docs/tutorials/basic/php.html
+[gRPC Basics: PHP]:https://grpc.io/docs/tutorials/basic/php.html

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,1 +1,1 @@
-[This code's documentation lives on the grpc.io site.](http://www.grpc.io/docs/quickstart/python.html)
+[This code's documentation lives on the grpc.io site.](https://grpc.io/docs/quickstart/python.html)

--- a/examples/python/helloworld/README.md
+++ b/examples/python/helloworld/README.md
@@ -1,1 +1,1 @@
-[This code's documentation lives on the grpc.io site.](http://www.grpc.io/docs/quickstart/python.html)
+[This code's documentation lives on the grpc.io site.](https://grpc.io/docs/quickstart/python.html)

--- a/examples/python/multiplex/README.md
+++ b/examples/python/multiplex/README.md
@@ -1,3 +1,3 @@
 An example showing two stubs sharing a channel and two servicers sharing a server.
 
-More complete documentation lives at [grpc.io](http://www.grpc.io/docs/tutorials/basic/python.html).
+More complete documentation lives at [grpc.io](https://grpc.io/docs/tutorials/basic/python.html).

--- a/examples/python/route_guide/README.md
+++ b/examples/python/route_guide/README.md
@@ -1,1 +1,1 @@
-[This code's documentation lives on the grpc.io site.](http://www.grpc.io/docs/tutorials/basic/python.html)
+[This code's documentation lives on the grpc.io site.](https://grpc.io/docs/tutorials/basic/python.html)

--- a/examples/ruby/README.md
+++ b/examples/ruby/README.md
@@ -60,4 +60,4 @@ You can find a more detailed tutorial in [gRPC Basics: Ruby][]
 [helloworld.proto]:../protos/helloworld.proto
 [RVM]:https://www.rvm.io/
 [Install gRPC ruby]:../../src/ruby#installation
-[gRPC Basics: Ruby]:http://www.grpc.io/docs/tutorials/basic/ruby.html
+[gRPC Basics: Ruby]:https://grpc.io/docs/tutorials/basic/ruby.html

--- a/examples/ruby/route_guide/README.md
+++ b/examples/ruby/route_guide/README.md
@@ -3,4 +3,4 @@
 The files in this folder are the samples used in [gRPC Basics: Ruby][],
 a detailed tutorial for using gRPC in Ruby.
 
-[gRPC Basics: Ruby]:http://www.grpc.io/docs/tutorials/basic/ruby.html
+[gRPC Basics: Ruby]:https://grpc.io/docs/tutorials/basic/ruby.html

--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   version = '1.5.0-dev'
   s.version  = version
   s.summary  = 'Core cross-platform gRPC library, written in C'
-  s.homepage = 'http://www.grpc.io'
+  s.homepage = 'https://grpc.io'
   s.license  = 'Apache License, Version 2.0'
   s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
 

--- a/gRPC-ProtoRPC.podspec
+++ b/gRPC-ProtoRPC.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   version = '1.5.0-dev'
   s.version  = version
   s.summary  = 'RPC library for Protocol Buffers, based on gRPC'
-  s.homepage = 'http://www.grpc.io'
+  s.homepage = 'https://grpc.io'
   s.license  = 'Apache License, Version 2.0'
   s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
 

--- a/gRPC-RxLibrary.podspec
+++ b/gRPC-RxLibrary.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   version = '1.5.0-dev'
   s.version  = version
   s.summary  = 'Reactive Extensions library for iOS/OSX.'
-  s.homepage = 'http://www.grpc.io'
+  s.homepage = 'https://grpc.io'
   s.license  = 'Apache License, Version 2.0'
   s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
 

--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   version = '1.5.0-dev'
   s.version  = version
   s.summary  = 'gRPC client library for iOS/OSX'
-  s.homepage = 'http://www.grpc.io'
+  s.homepage = 'https://grpc.io'
   s.license  = 'Apache License, Version 2.0'
   s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
 

--- a/include/grpc++/grpc++.h
+++ b/include/grpc++/grpc++.h
@@ -21,7 +21,7 @@
 /// The gRPC C++ API mainly consists of the following classes:
 /// <br>
 /// - grpc::Channel, which represents the connection to an endpoint. See [the
-/// gRPC Concepts page](http://www.grpc.io/docs/guides/concepts.html) for more
+/// gRPC Concepts page](https://grpc.io/docs/guides/concepts.html) for more
 /// details. Channels are created by the factory function grpc::CreateChannel.
 ///
 /// - grpc::CompletionQueue, the producer-consumer queue used for all

--- a/include/grpc++/impl/codegen/client_context.h
+++ b/include/grpc++/impl/codegen/client_context.h
@@ -275,7 +275,7 @@ class ClientContext {
   /// client’s identity, role, or whether it is authorized to make a particular
   /// call.
   ///
-  /// \see  http://www.grpc.io/docs/guides/auth.html
+  /// \see  https://grpc.io/docs/guides/auth.html
   void set_credentials(const std::shared_ptr<CallCredentials>& creds) {
     creds_ = creds;
   }

--- a/include/grpc++/security/credentials.h
+++ b/include/grpc++/security/credentials.h
@@ -41,7 +41,7 @@ class SecureCallCredentials;
 /// It can make various assertions, e.g., about the client’s identity, role
 /// for all the calls on that channel.
 ///
-/// \see http://www.grpc.io/docs/guides/auth.html
+/// \see https://grpc.io/docs/guides/auth.html
 class ChannelCredentials : private GrpcLibraryCodegen {
  public:
   ChannelCredentials();
@@ -67,7 +67,7 @@ class ChannelCredentials : private GrpcLibraryCodegen {
 /// A call credentials object encapsulates the state needed by a client to
 /// authenticate with a server for a given call on a channel.
 ///
-/// \see http://www.grpc.io/docs/guides/auth.html
+/// \see https://grpc.io/docs/guides/auth.html
 class CallCredentials : private GrpcLibraryCodegen {
  public:
   CallCredentials();

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.0-dev",
   "author": "Google Inc.",
   "description": "gRPC Library for Node",
-  "homepage": "http://www.grpc.io/",
+  "homepage": "https://grpc.io/",
   "repository": {
     "type": "git",
     "url": "https://github.com/grpc/grpc.git"

--- a/setup.py
+++ b/setup.py
@@ -281,7 +281,7 @@ setuptools.setup(
   description='HTTP/2-based RPC framework',
   author='The gRPC Authors',
   author_email='grpc-io@googlegroups.com',
-  url='http://www.grpc.io',
+  url='https://grpc.io',
   license=LICENSE,
   long_description=open(README).read(),
   ext_modules=CYTHON_EXTENSION_MODULES,

--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -60,14 +60,14 @@ You can find out how to build and run our simplest gRPC C++ example in our
 [C++ quick start](../../examples/cpp).
 
 For more detailed documentation on using gRPC in C++ , see our main
-documentation site at [grpc.io](http://grpc.io), specifically:
+documentation site at [grpc.io](https://grpc.io), specifically:
 
-* [Overview](http://www.grpc.io/docs/): An introduction to gRPC with a simple
+* [Overview](https://grpc.io/docs/): An introduction to gRPC with a simple
   Hello World example in all our supported languages, including C++.
-* [gRPC Basics - C++](http://www.grpc.io/docs/tutorials/basic/c.html):
+* [gRPC Basics - C++](https://grpc.io/docs/tutorials/basic/c.html):
   A tutorial that steps you through creating a simple gRPC C++ example
   application.
-* [Asynchronous Basics - C++](http://www.grpc.io/docs/tutorials/async/helloasync-cpp.html):
+* [Asynchronous Basics - C++](https://grpc.io/docs/tutorials/async/helloasync-cpp.html):
   A tutorial that shows you how to use gRPC C++'s asynchronous/non-blocking
   APIs.
 

--- a/src/csharp/README.md
+++ b/src/csharp/README.md
@@ -80,6 +80,6 @@ THE NATIVE DEPENDENCY
 
 Internally, gRPC C# uses a native library written in C (gRPC C core) and invokes its functionality via P/Invoke. The fact that a native library is used should be fully transparent to the users and just installing the `Grpc.Core` NuGet package is the only step needed to use gRPC C# on all supported platforms.
 
-[API Reference]: http://www.grpc.io/grpc/csharp/
+[API Reference]: https://grpc.io/grpc/csharp/
 [Helloworld Example]: ../../examples/csharp/helloworld
-[RouteGuide Tutorial]: http://www.grpc.io/docs/tutorials/basic/csharp.html 
+[RouteGuide Tutorial]: https://grpc.io/docs/tutorials/basic/csharp.html 

--- a/src/node/tools/package.json
+++ b/src/node/tools/package.json
@@ -3,7 +3,7 @@
   "version": "1.5.0-dev",
   "author": "Google Inc.",
   "description": "Tools for developing with gRPC on Node.js",
-  "homepage": "http://www.grpc.io/",
+  "homepage": "https://grpc.io/",
   "repository": {
     "type": "git",
     "url": "https://github.com/grpc/grpc.git"

--- a/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
+++ b/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |s|
     The generated code will have a dependency on the gRPC Objective-C Proto runtime of the same
     version. The runtime can be obtained as the "gRPC-ProtoRPC" pod.
   DESC
-  s.homepage = 'http://www.grpc.io'
+  s.homepage = 'https://grpc.io'
   s.license  = {
     :type => 'Apache License, Version 2.0',
     :text => <<-LICENSE

--- a/src/objective-c/examples/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/examples/RemoteTestClient/RemoteTest.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version  = '0.0.1'
   s.license  = 'Apache License, Version 2.0'
   s.authors  = { 'gRPC contributors' => 'grpc-io@googlegroups.com' }
-  s.homepage = 'http://www.grpc.io/'
+  s.homepage = 'https://grpc.io/'
   s.summary = 'RemoteTest example'
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 

--- a/src/objective-c/tests/RemoteTestClient/RemoteTest.podspec
+++ b/src/objective-c/tests/RemoteTestClient/RemoteTest.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
   s.version  = "0.0.1"
   s.license  = "Apache License, Version 2.0"
   s.authors  = { 'gRPC contributors' => 'grpc-io@googlegroups.com' }
-  s.homepage = "http://www.grpc.io/"
+  s.homepage = "https://grpc.io/"
   s.summary = "RemoteTest example"
   s.source = { :git => 'https://github.com/grpc/grpc.git' }
 

--- a/src/python/grpcio_health_checking/setup.py
+++ b/src/python/grpcio_health_checking/setup.py
@@ -46,7 +46,7 @@ setuptools.setup(
     description='Standard Health Checking Service for gRPC',
     author='The gRPC Authors',
     author_email='grpc-io@googlegroups.com',
-    url='http://www.grpc.io',
+    url='https://grpc.io',
     license='Apache License 2.0',
     package_dir=PACKAGE_DIRECTORIES,
     packages=setuptools.find_packages('.'),

--- a/src/python/grpcio_reflection/setup.py
+++ b/src/python/grpcio_reflection/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
     description='Standard Protobuf Reflection Service for gRPC',
     author='The gRPC Authors',
     author_email='grpc-io@googlegroups.com',
-    url='http://www.grpc.io',
+    url='https://grpc.io',
     package_dir=PACKAGE_DIRECTORIES,
     packages=setuptools.find_packages('.'),
     install_requires=INSTALL_REQUIRES,

--- a/src/ruby/README.md
+++ b/src/ruby/README.md
@@ -68,5 +68,5 @@ Directory structure is the layout for [ruby extensions][]
 
 [ruby extensions]:http://guides.rubygems.org/gems-with-extensions/
 [rubydoc]: http://www.rubydoc.info/gems/grpc
-[grpc.io]: http://www.grpc.io/docs/quickstart/ruby.html
+[grpc.io]: https://grpc.io/docs/quickstart/ruby.html
 [Debian jessie-backports]:http://backports.debian.org/Instructions/

--- a/templates/composer.json.template
+++ b/templates/composer.json.template
@@ -5,7 +5,7 @@
     "type": "library",
     "description": "gRPC library for PHP",
     "keywords": ["rpc"],
-    "homepage": "http://grpc.io",
+    "homepage": "https://grpc.io",
     "license": "Apache-2.0",
     "require": {
       "php": ">=5.5.0"

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -52,7 +52,7 @@
     version = '${settings.version}'
     s.version  = version
     s.summary  = 'Core cross-platform gRPC library, written in C'
-    s.homepage = 'http://www.grpc.io'
+    s.homepage = 'https://grpc.io'
     s.license  = 'Apache License, Version 2.0'
     s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
 

--- a/templates/gRPC-ProtoRPC.podspec.template
+++ b/templates/gRPC-ProtoRPC.podspec.template
@@ -26,7 +26,7 @@
     version = '${settings.version}'
     s.version  = version
     s.summary  = 'RPC library for Protocol Buffers, based on gRPC'
-    s.homepage = 'http://www.grpc.io'
+    s.homepage = 'https://grpc.io'
     s.license  = 'Apache License, Version 2.0'
     s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
 

--- a/templates/gRPC-RxLibrary.podspec.template
+++ b/templates/gRPC-RxLibrary.podspec.template
@@ -26,7 +26,7 @@
     version = '${settings.version}'
     s.version  = version
     s.summary  = 'Reactive Extensions library for iOS/OSX.'
-    s.homepage = 'http://www.grpc.io'
+    s.homepage = 'https://grpc.io'
     s.license  = 'Apache License, Version 2.0'
     s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
 

--- a/templates/gRPC.podspec.template
+++ b/templates/gRPC.podspec.template
@@ -25,7 +25,7 @@
     version = '${settings.version}'
     s.version  = version
     s.summary  = 'gRPC client library for iOS/OSX'
-    s.homepage = 'http://www.grpc.io'
+    s.homepage = 'https://grpc.io'
     s.license  = 'Apache License, Version 2.0'
     s.authors  = { 'The gRPC contributors' => 'grpc-packages@google.com' }
 

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -5,7 +5,7 @@
     "version": "${settings.node_version}",
     "author": "Google Inc.",
     "description": "gRPC Library for Node",
-    "homepage": "http://www.grpc.io/",
+    "homepage": "https://grpc.io/",
     "repository": {
       "type": "git",
       "url": "https://github.com/grpc/grpc.git"

--- a/templates/src/node/tools/package.json.template
+++ b/templates/src/node/tools/package.json.template
@@ -5,7 +5,7 @@
     "version": "${settings.node_version}",
     "author": "Google Inc.",
     "description": "Tools for developing with gRPC on Node.js",
-    "homepage": "http://www.grpc.io/",
+    "homepage": "https://grpc.io/",
     "repository": {
       "type": "git",
       "url": "https://github.com/grpc/grpc.git"

--- a/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
@@ -53,7 +53,7 @@
       The generated code will have a dependency on the gRPC Objective-C Proto runtime of the same
       version. The runtime can be obtained as the "gRPC-ProtoRPC" pod.
     DESC
-    s.homepage = 'http://www.grpc.io'
+    s.homepage = 'https://grpc.io'
     s.license  = {
       :type => 'Apache License, Version 2.0',
       :text => <<-LICENSE

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -191,7 +191,7 @@ setuptools.setup(
   description='Protobuf code generator for gRPC',
   author='The gRPC Authors',
   author_email='grpc-io@googlegroups.com',
-  url='http://www.grpc.io',
+  url='https://grpc.io',
   license='Apache License 2.0',
   ext_modules=extension_modules(),
   packages=setuptools.find_packages('.'),

--- a/tools/run_tests/performance/README.md
+++ b/tools/run_tests/performance/README.md
@@ -1,7 +1,7 @@
 # Overview of performance test suite, with steps for manual runs:
 
 For design of the tests, see
-http://www.grpc.io/docs/guides/benchmarking.html.
+https://grpc.io/docs/guides/benchmarking.html.
 
 ## Pre-reqs for running these manually:
 In general the benchmark workers and driver build scripts expect


### PR DESCRIPTION
This PR changes instances of http://www.grpc.io and http://grpc.io in use in various places of repository to the canonical nice URL https://grpc.io.