### PR TITLE
Kokoro macos build fixes

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -42,6 +42,7 @@ gem install bundler
 # cocoapods
 export LANG=en_US.UTF-8
 gem install cocoapods
+gem install xcpretty
 pod repo update  # needed by python
 
 # python
@@ -52,5 +53,8 @@ sudo pip install -U six tox setuptools
 # python 3.4
 wget -q https://www.python.org/ftp/python/3.4.4/python-3.4.4-macosx10.6.pkg
 sudo installer -pkg python-3.4.4-macosx10.6.pkg -target /
+
+# set xcode version for Obj-C tests
+sudo xcode-select -switch /Applications/Xcode_8.2.1.app/Contents/Developer
 
 git submodule update --init

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -15,7 +15,12 @@
 
 # Source this rc script to prepare the environment for macos builds
 
-ulimit -n 1000
+sudo launchctl limit maxfiles unlimited unlimited
+
+# show current maxfiles
+launchctl limit maxfiles
+
+ulimit -n 10000
 
 # show current limits
 ulimit -a


### PR DESCRIPTION
- set max open files number to higher number to prevent C++ tests for reaching the limit
- objC tests not longer hang indefinitely (because of simulator issue).  ObjC examples test not passing yet, but improvements are significant enough that it's worth merging the progress.