### PR TITLE
Remove a stale ruby method

### DIFF
--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -516,7 +516,7 @@ module GRPC
 
     # MultiReqView limits access to an ActiveCall's methods for use in
     # server client_streamer handlers.
-    MultiReqView = view_class(:cancelled?, :deadline, :each_queued_msg,
+    MultiReqView = view_class(:cancelled?, :deadline,
                               :each_remote_read, :metadata, :output_metadata,
                               :send_initial_metadata,
                               :metadata_to_send,


### PR DESCRIPTION
An attempt to use the method in a test failed with:

```
NoMethodError: undefined method `each_queued_msg' for #<GRPC::ActiveCall:0x0000000173bb20>
```