### PR TITLE
Adding platform and abi tags in our node-pre-gyp.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "binary": {
     "module_name": "grpc_node",
-    "module_path": "src/node/extension_binary",
+    "module_path": "src/node/extension_binary/{node_abi}-{platform}-{arch}",
     "host": "https://storage.googleapis.com/",
     "remote_path": "grpc-precompiled-binaries/node/{name}/v{version}",
     "package_name": "{node_abi}-{platform}-{arch}.tar.gz"

--- a/templates/package.json.template
+++ b/templates/package.json.template
@@ -58,7 +58,7 @@
     },
     "binary": {
       "module_name": "grpc_node",
-      "module_path": "src/node/extension_binary",
+      "module_path": "src/node/extension_binary/{node_abi}-{platform}-{arch}",
       "host": "https://storage.googleapis.com/",
       "remote_path": "grpc-precompiled-binaries/node/{name}/v{version}",
       "package_name": "{node_abi}-{platform}-{arch}.tar.gz"


### PR DESCRIPTION
Allows to use more than one runtime. Should fix #8887 and #10558.