### PR TITLE
Fix implicit fallthrough warning on GCC 7.x

### DIFF
--- a/src/core/ext/transport/chttp2/transport/bin_decoder.c
+++ b/src/core/ext/transport/chttp2/transport/bin_decoder.c
@@ -118,6 +118,7 @@ bool grpc_base64_decode_partial(struct grpc_base64_decode_context *ctx) {
       switch (input_tail) {
         case 3:
           ctx->output_cur[1] = COMPOSE_OUTPUT_BYTE_1(ctx->input_cur);
+        /* fallthrough */
         case 2:
           ctx->output_cur[0] = COMPOSE_OUTPUT_BYTE_0(ctx->input_cur);
       }

--- a/src/core/ext/transport/chttp2/transport/varint.c
+++ b/src/core/ext/transport/chttp2/transport/varint.c
@@ -37,12 +37,16 @@ void grpc_chttp2_hpack_write_varint_tail(uint32_t tail_value, uint8_t* target,
   switch (tail_length) {
     case 5:
       target[4] = (uint8_t)((tail_value >> 28) | 0x80);
+    /* fallthrough */
     case 4:
       target[3] = (uint8_t)((tail_value >> 21) | 0x80);
+    /* fallthrough */
     case 3:
       target[2] = (uint8_t)((tail_value >> 14) | 0x80);
+    /* fallthrough */
     case 2:
       target[1] = (uint8_t)((tail_value >> 7) | 0x80);
+    /* fallthrough */
     case 1:
       target[0] = (uint8_t)((tail_value) | 0x80);
   }

--- a/src/core/lib/json/json_reader.c
+++ b/src/core/lib/json/json_reader.c
@@ -178,6 +178,7 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader *reader) {
             json_reader_string_clear(reader);
             reader->state = GRPC_JSON_STATE_VALUE_END;
           /* The missing break here is intentional. */
+          /* fallthrough */
 
           case GRPC_JSON_STATE_VALUE_END:
           case GRPC_JSON_STATE_OBJECT_KEY_BEGIN:

--- a/src/core/lib/support/murmur_hash.c
+++ b/src/core/lib/support/murmur_hash.c
@@ -62,8 +62,10 @@ uint32_t gpr_murmur_hash3(const void *key, size_t len, uint32_t seed) {
   switch (len & 3) {
     case 3:
       k1 ^= ((uint32_t)tail[2]) << 16;
+    /* fallthrough */
     case 2:
       k1 ^= ((uint32_t)tail[1]) << 8;
+    /* fallthrough */
     case 1:
       k1 ^= tail[0];
       k1 *= c1;


### PR DESCRIPTION
Add fallthrough comments to keep GCC >= 7.x happy.

Signed-off-by: Alexey Firago <alexey_firago@mentor.com>