### PR TITLE
Fill in 2nd template argument of SerializationTraits

### DIFF
--- a/include/grpc++/impl/codegen/call.h
+++ b/include/grpc++/impl/codegen/call.h
@@ -295,7 +295,8 @@ class CallOpSendMessage {
 template <class M>
 Status CallOpSendMessage::SendMessage(const M& message, WriteOptions options) {
   write_options_ = options;
-  return SerializationTraits<M>::Serialize(message, &send_buf_, &own_buf_);
+  return SerializationTraits<M, void>::Serialize(message, &send_buf_,
+                                                 &own_buf_);
 }
 
 template <class M>


### PR DESCRIPTION
Strangely, this inexplicable change makes some code build that was broken post-internalization. This is bizarre since void is the default 2nd argument anyway.

