### PR TITLE
More parallelism for multilang linux tests

### DIFF
--- a/tools/internal_ci/linux/grpc_basictests_multilang.cfg
+++ b/tools/internal_ci/linux/grpc_basictests_multilang.cfg
@@ -25,5 +25,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux multilang --inner_jobs 16 -j 1 --internal_ci --bq_result_table aggregate_results"
+  value: "-f basictests linux multilang --inner_jobs 16 -j 2 --internal_ci --bq_result_table aggregate_results"
 }


### PR DESCRIPTION
Wrapped languages should be more flake-proof and this should decrease their runtime.