### PR TITLE
Fix ruby memory leaks when composing credentials, noticed with asan

### DIFF
--- a/src/ruby/ext/grpc/rb_call_credentials.c
+++ b/src/ruby/ext/grpc/rb_call_credentials.c
@@ -239,6 +239,7 @@ static VALUE grpc_rb_call_credentials_compose(int argc, VALUE *argv,
                                               VALUE self) {
   grpc_call_credentials *creds;
   grpc_call_credentials *other;
+  grpc_call_credentials *prev = NULL;
   VALUE mark;
   if (argc == 0) {
     return self;
@@ -249,6 +250,10 @@ static VALUE grpc_rb_call_credentials_compose(int argc, VALUE *argv,
     rb_ary_push(mark, argv[i]);
     other = grpc_rb_get_wrapped_call_credentials(argv[i]);
     creds = grpc_composite_call_credentials_create(creds, other, NULL);
+    if (prev != NULL) {
+      grpc_call_credentials_release(prev);
+    }
+    prev = creds;
   }
   return grpc_rb_wrap_call_credentials(creds, mark);
 }

--- a/src/ruby/ext/grpc/rb_channel_credentials.c
+++ b/src/ruby/ext/grpc/rb_channel_credentials.c
@@ -184,6 +184,7 @@ static VALUE grpc_rb_channel_credentials_compose(int argc, VALUE *argv,
                                                  VALUE self) {
   grpc_channel_credentials *creds;
   grpc_call_credentials *other;
+  grpc_channel_credentials *prev = NULL;
   VALUE mark;
   if (argc == 0) {
     return self;
@@ -195,6 +196,11 @@ static VALUE grpc_rb_channel_credentials_compose(int argc, VALUE *argv,
     rb_ary_push(mark, argv[i]);
     other = grpc_rb_get_wrapped_call_credentials(argv[i]);
     creds = grpc_composite_channel_credentials_create(creds, other, NULL);
+    if (prev != NULL) {
+      grpc_channel_credentials_release(prev);
+    }
+    prev = creds;
+
     if (creds == NULL) {
       rb_raise(rb_eRuntimeError,
                "Failed to compose channel and call credentials");


### PR DESCRIPTION
Fixes a couple of memory leaks pointed out by https://github.com/grpc/grpc/pull/11580

On #11580:

running `run_tests.py -l ruby -c asan-dynamic --use_docker -r call_credentials_spec` results in:
* https://gist.github.com/apolcyn/b94b11772eb81c9a793ea9fd5b60a748

running `run_tests.py -l ruby -c asan-dynamic --use_docker -r channel_credentials_spec` results in:
* https://gist.github.com/apolcyn/dfe3fa716cfc4cda1abb11ecf97c8bb4

Both pass without errors with this change