### PR TITLE
Add OAuth2 protocol in GRPCClient

### DIFF
--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -40,12 +40,9 @@ Pod::Spec.new do |s|
   s.header_dir = name
 
   src_dir = 'src/objective-c/GRPCClient'
-  s.source_files = "#{src_dir}/*.{h,m}", "#{src_dir}/**/*.{h,m}"
-  s.private_header_files = "#{src_dir}/private/*.h"
-  s.header_mappings_dir = "#{src_dir}"
 
-  s.dependency 'gRPC-Core', version
   s.dependency 'gRPC-RxLibrary', version
+  s.default_subspec = 'Main'
 
   # Certificates, to be able to establish TLS connections:
   s.resource_bundles = { 'gRPCCertificates' => ['etc/roots.pem'] }
@@ -54,4 +51,22 @@ Pod::Spec.new do |s|
     # This is needed by all pods that depend on gRPC-RxLibrary:
     'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
   }
+
+  s.subspec 'Main' do |ss|
+    ss.header_mappings_dir = "#{src_dir}"
+
+    ss.source_files = "#{src_dir}/*.{h,m}", "#{src_dir}/**/*.{h,m}"
+    ss.exclude_files = "#{src_dir}/GRPCCall+GID.{h,m}"
+    ss.private_header_files = "#{src_dir}/private/*.h"
+
+    ss.dependency 'gRPC-Core', version
+  end
+
+  s.subspec 'GID' do |ss|
+    ss.header_mappings_dir = "#{src_dir}"
+
+    ss.source_files = "#{src_dir}/GRPCCall+GID.{h,m}"
+
+    ss.dependency 'Google/SignIn'
+  end
 end

--- a/src/objective-c/GRPCClient/GRPCCall+GID.h
+++ b/src/objective-c/GRPCClient/GRPCCall+GID.h
@@ -1,0 +1,29 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#import "GRPCCall.h"
+#import "GRPCCall+OAuth2.h"
+
+#import <Google/SignIn.h>
+
+/**
+ * Extend GIDSignIn class to comply GRPCAuthorizationProtocol
+ */
+@interface GIDSignIn (GRPC) <GRPCAuthorizationProtocol>
+- (void)getTokenWithHandler:(void (^)(NSString *token))hander;
+@end

--- a/src/objective-c/GRPCClient/GRPCCall+GID.m
+++ b/src/objective-c/GRPCClient/GRPCCall+GID.m
@@ -1,0 +1,28 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#import "GRPCCall+GID.h"
+
+@implementation GIDSignIn (GRPC)
+
+- (void)getTokenWithHandler:(void (^)(NSString *token))handler {
+  NSString *token = self.currentUser.authentication.accessToken;
+  handler(token);
+}
+
+@end

--- a/src/objective-c/GRPCClient/GRPCCall+OAuth2.h
+++ b/src/objective-c/GRPCClient/GRPCCall+OAuth2.h
@@ -18,6 +18,13 @@
 
 #import "GRPCCall.h"
 
+/**
+ * The protocol of an OAuth2 token object from which GRPCCall can acquire a token.
+ */
+@protocol GRPCAuthorizationProtocol
+- (void)getTokenWithHandler:(void (^)(NSString *token))hander;
+@end
+
 /** Helpers for setting and reading headers compatible with OAuth2. */
 @interface GRPCCall (OAuth2)
 
@@ -32,5 +39,13 @@
 
 /** Returns the value (if any) of the "www-authenticate" response header (the challenge header). */
 @property(atomic, readonly) NSString *oauth2ChallengeHeader;
+
+/**
+ * The authorization token object to be used when starting the call. If the value is set to nil, no
+ * oauth authentication will be used.
+ *
+ * If tokenProvider exists, it takes precedence over the token set by oauth2AccessToken.
+ */
+@property(atomic, strong) id<GRPCAuthorizationProtocol> tokenProvider;
 
 @end

--- a/src/objective-c/GRPCClient/GRPCCall+OAuth2.m
+++ b/src/objective-c/GRPCClient/GRPCCall+OAuth2.m
@@ -16,6 +16,8 @@
  *
  */
 
+#import <objc/runtime.h>
+
 #import "GRPCCall+OAuth2.h"
 
 static NSString * const kAuthorizationHeader = @"authorization";
@@ -23,6 +25,7 @@ static NSString * const kBearerPrefix = @"Bearer ";
 static NSString * const kChallengeHeader = @"www-authenticate";
 
 @implementation GRPCCall (OAuth2)
+@dynamic tokenProvider;
 
 - (NSString *)oauth2AccessToken {
   NSString *headerValue = self.requestHeaders[kAuthorizationHeader];
@@ -43,6 +46,14 @@ static NSString * const kChallengeHeader = @"www-authenticate";
 
 - (NSString *)oauth2ChallengeHeader {
   return self.responseHeaders[kChallengeHeader];
+}
+
+- (void)setTokenProvider:(id<GRPCAuthorizationProtocol>)tokenProvider {
+  objc_setAssociatedObject(self, @selector(tokenProvider), tokenProvider, OBJC_ASSOCIATION_RETAIN);
+}
+
+- (id<GRPCAuthorizationProtocol>)tokenProvider {
+  return objc_getAssociatedObject(self, @selector(tokenProvider));
 }
 
 @end

--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -140,13 +140,6 @@ typedef NS_ENUM(NSUInteger, GRPCErrorCode) {
 };
 
 /**
- * The protocol of an OAuth2 token object from which GRPCCall can acquire a token.
- */
-@protocol GRPCAuthorizationProtocol
-- (void)getTokenWithHandler:(void (^)(NSString *token))hander;
-@end
-
-/**
  * Safety remark of a gRPC method as defined in RFC 2616 Section 9.1
  */
 typedef NS_ENUM(NSUInteger, GRPCCallSafety) {
@@ -221,14 +214,6 @@ extern id const kGRPCTrailersKey;
  * before -writesFinishedWithError: is sent to the writeable.
  */
 @property(atomic, readonly) NSDictionary *responseTrailers;
-
-/**
- * The authorization token object to be used when starting the call. If the value is set to nil, no 
- * oauth authentication will be used.
- *
- * Not compatible with property oauth2AccessToken in GRPCCall (OAuth2). Do not use both at the same time.
- */
-@property(atomic, strong) id<GRPCAuthorizationProtocol> tokenProvider;
 
 /**
  * The request writer has to write NSData objects into the provided Writeable. The server will

--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -140,6 +140,13 @@ typedef NS_ENUM(NSUInteger, GRPCErrorCode) {
 };
 
 /**
+ * The protocol of an OAuth2 token object from which GRPCCall can acquire a token.
+ */
+@protocol GRPCAuthorizationProtocol
+- (void)getTokenWithHandler:(void (^)(NSString *token))hander;
+@end
+
+/**
  * Safety remark of a gRPC method as defined in RFC 2616 Section 9.1
  */
 typedef NS_ENUM(NSUInteger, GRPCCallSafety) {
@@ -214,6 +221,14 @@ extern id const kGRPCTrailersKey;
  * before -writesFinishedWithError: is sent to the writeable.
  */
 @property(atomic, readonly) NSDictionary *responseTrailers;
+
+/**
+ * The authorization token object to be used when starting the call. If the value is set to nil, no 
+ * oauth authentication will be used.
+ *
+ * Not compatible with property oauth2AccessToken in GRPCCall (OAuth2). Do not use both at the same time.
+ */
+@property(atomic, strong) id<GRPCAuthorizationProtocol> oauthToken;
 
 /**
  * The request writer has to write NSData objects into the provided Writeable. The server will

--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -228,7 +228,7 @@ extern id const kGRPCTrailersKey;
  *
  * Not compatible with property oauth2AccessToken in GRPCCall (OAuth2). Do not use both at the same time.
  */
-@property(atomic, strong) id<GRPCAuthorizationProtocol> oauthToken;
+@property(atomic, strong) id<GRPCAuthorizationProtocol> tokenProvider;
 
 /**
  * The request writer has to write NSData objects into the provided Writeable. The server will

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -457,10 +457,10 @@ static NSString * const kBearerPrefix = @"Bearer ";
   // that the life of the instance is determined by this retain cycle.
   _retainSelf = self;
 
-  if (self.oauthToken != nil) {
+  if (self.tokenProvider != nil) {
     self.isWaitingForToken = YES;
     __weak typeof(self) weakSelf = self;
-    [self.oauthToken getTokenWithHandler:^(NSString *token){
+    [self.tokenProvider getTokenWithHandler:^(NSString *token){
       typeof(self) strongSelf = weakSelf;
       if (strongSelf && strongSelf.isWaitingForToken) {
         if (token) {

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -18,6 +18,8 @@
 
 #import "GRPCCall.h"
 
+#import "GRPCCall+OAuth2.h"
+
 #include <grpc/grpc.h>
 #include <grpc/support/time.h>
 #import <RxLibrary/GRXConcurrentWriteable.h>

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -185,9 +185,6 @@ static NSString * const kBearerPrefix = @"Bearer ";
 
 - (void)finishWithError:(NSError *)errorOrNil {
   @synchronized(self) {
-    if (_state == GRXWriterStateFinished) {
-      return;
-    }
     _state = GRXWriterStateFinished;
   }
 

--- a/src/objective-c/GRPCClient/private/GRPCRequestHeaders.m
+++ b/src/objective-c/GRPCClient/private/GRPCRequestHeaders.m
@@ -103,7 +103,6 @@ static void CheckKeyValuePairIsValid(NSString *key, id value) {
 }
 
 - (void)setObject:(id)obj forKey:(NSString *)key {
-  [self checkCallIsNotStarted];
   CheckIsNonNilASCII(@"Header name", key);
   key = key.lowercaseString;
   CheckKeyValuePairIsValid(key, obj);

--- a/templates/gRPC.podspec.template
+++ b/templates/gRPC.podspec.template
@@ -42,12 +42,9 @@
     s.header_dir = name
 
     src_dir = 'src/objective-c/GRPCClient'
-    s.source_files = "#{src_dir}/*.{h,m}", "#{src_dir}/**/*.{h,m}"
-    s.private_header_files = "#{src_dir}/private/*.h"
-    s.header_mappings_dir = "#{src_dir}"
 
-    s.dependency 'gRPC-Core', version
     s.dependency 'gRPC-RxLibrary', version
+    s.default_subspec = 'Main'
 
     # Certificates, to be able to establish TLS connections:
     s.resource_bundles = { 'gRPCCertificates' => ['etc/roots.pem'] }
@@ -56,4 +53,22 @@
       # This is needed by all pods that depend on gRPC-RxLibrary:
       'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
     }
+
+    s.subspec 'Main' do |ss|
+      ss.header_mappings_dir = "#{src_dir}"
+
+      ss.source_files = "#{src_dir}/*.{h,m}", "#{src_dir}/**/*.{h,m}"
+      ss.exclude_files = "#{src_dir}/GRPCCall+GID.{h,m}"
+      ss.private_header_files = "#{src_dir}/private/*.h"
+
+      ss.dependency 'gRPC-Core', version
+    end
+
+    s.subspec 'GID' do |ss|
+      ss.header_mappings_dir = "#{src_dir}"
+
+      ss.source_files = "#{src_dir}/GRPCCall+GID.{h,m}"
+
+      ss.dependency 'Google/SignIn'
+    end
   end


### PR DESCRIPTION
Allow users to set an object conforming to `GRPCAuthorizationProtocol` protocol to a `GRPCCall` object, which will be used for obtaining OAuth2 access token string when making a GRPC call.