### PR TITLE
Exit 1 if some tests fail

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -1230,6 +1230,11 @@ try:
       _HTTP2_TEST_CASES, http2_server_test_cases, resultset, num_failures,
       args.cloud_to_prod_auth or args.cloud_to_prod, args.prod_servers,
       args.http2_interop)
+  
+  if num_failures:
+    sys.exit(1)
+  else:
+    sys.exit(0)
 except Exception as e:
   print('exception occurred:')
   traceback.print_exc(file=sys.stdout)


### PR DESCRIPTION
Otherwise, internal CI will show the build as a success even though some tests fail.