### PR TITLE
C-Ares: Remove Internal Header

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.c
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.c
@@ -33,7 +33,6 @@
 #include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
 #include <grpc/support/useful.h>
-#include <nameser.h>
 
 #include "src/core/ext/filters/client_channel/parse_address.h"
 #include "src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h"
@@ -358,6 +357,9 @@ static grpc_ares_request *grpc_dns_lookup_ares_impl(
     grpc_ares_request_ref(r);
     char *service_name;
     gpr_asprintf(&service_name, "_grpclb._tcp.%s", host);
+    // see: RFC 1035, section 3.2.4. CLASS values
+    const int ns_c_in = 1; // internet
+    const int ns_t_srv = 33; // SRV record (RFC 2782)
     ares_query(*channel, service_name, ns_c_in, ns_t_srv, on_srv_query_done_cb,
                r);
     gpr_free(service_name);


### PR DESCRIPTION
The `nameser.h` header is a [C-Ares internal header](https://github.com/c-ares/c-ares/issues/131) which is not installed with C-Ares.

This fixes build errors with externally installed C-Ares (1.13) with
```bash
  cmake -DgRPC_CARES_PROVIDER=package ..
```

Removes a the header defining two [IANA controlled numbers](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml) to do a SRV lookup.