### PR TITLE
Prevent gcc 4.7 from thinking a static func shadows an arg

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.c
+++ b/src/core/ext/filters/client_channel/client_channel.c
@@ -1553,11 +1553,11 @@ typedef struct external_connectivity_watcher {
 } external_connectivity_watcher;
 
 static external_connectivity_watcher *lookup_external_connectivity_watcher(
-    channel_data *chand, grpc_closure *on_complete) {
+    channel_data *chand, grpc_closure *on_complete_closure) {
   gpr_mu_lock(&chand->external_connectivity_watcher_list_mu);
   external_connectivity_watcher *w =
       chand->external_connectivity_watcher_list_head;
-  while (w != NULL && w->on_complete != on_complete) {
+  while (w != NULL && w->on_complete != on_complete_closure) {
     w = w->next;
   }
   gpr_mu_unlock(&chand->external_connectivity_watcher_list_mu);


### PR DESCRIPTION
Fixes #11867