### PR TITLE
Fix issue from google/protobuf#1745 - javascript allow dot in filename

### DIFF
--- a/src/compiler/node_generator.cc
+++ b/src/compiler/node_generator.cc
@@ -47,7 +47,7 @@ grpc::string ModuleAlias(const grpc::string filename) {
   grpc::string basename = grpc_generator::StripProto(filename);
   basename = grpc_generator::StringReplace(basename, "-", "$");
   basename = grpc_generator::StringReplace(basename, "/", "_");
-  basename = grpc_generator::StringReplace(basename, “.”, "_");
+  basename = grpc_generator::StringReplace(basename, ".", "_");
   return basename + "_pb";
 }
 

--- a/src/compiler/node_generator.cc
+++ b/src/compiler/node_generator.cc
@@ -47,6 +47,7 @@ grpc::string ModuleAlias(const grpc::string filename) {
   grpc::string basename = grpc_generator::StripProto(filename);
   basename = grpc_generator::StringReplace(basename, "-", "$");
   basename = grpc_generator::StringReplace(basename, "/", "_");
+  basename = grpc_generator::StringReplace(basename, “.”, "_");
   return basename + "_pb";
 }
 


### PR DESCRIPTION
This is a simple PR to allow dot characters to be used in .proto file filenames with JavaScript.

google/protobuf#1745 - javascript allow dot in filename

google/protobuf/pull/3410 - relevant PR.