### PR TITLE
Disable epoll1 unless explicitly requested

### DIFF
--- a/src/core/lib/iomgr/ev_epoll1_linux.c
+++ b/src/core/lib/iomgr/ev_epoll1_linux.c
@@ -1030,6 +1030,12 @@ static const grpc_event_engine_vtable vtable = {
 /* It is possible that GLIBC has epoll but the underlying kernel doesn't.
  * Create a dummy epoll_fd to make sure epoll support is available */
 const grpc_event_engine_vtable *grpc_init_epoll1_linux(bool explicit_request) {
+  /* TODO(sreek): Temporarily disable this poller unless explicitly requested
+   * via GRPC_POLL_STRATEGY */
+  if (!explicit_request) {
+    return NULL;
+  }
+
   if (!grpc_has_wakeup_fd()) {
     return NULL;
   }

--- a/src/core/lib/iomgr/ev_epollsig_linux.c
+++ b/src/core/lib/iomgr/ev_epollsig_linux.c
@@ -1730,7 +1730,7 @@ const grpc_event_engine_vtable *grpc_init_epollsig_linux(
   if (!is_grpc_wakeup_signal_initialized) {
     /* TODO(ctiller): when other epoll engines are ready, remove the true || to
      * force this to be explitly chosen if needed */
-    if (explicit_request) {
+    if (true || explicit_request) {
       grpc_use_signal(SIGRTMIN + 6);
     } else {
       return NULL;


### PR DESCRIPTION
When I recently merged epoll1, I forgot to add this line.   Until epoll1 is fully stabilized, we cannot risk it being accidentally getting enabled (unless explicitly chosen via GRPC_POLL_STRATEGY env var).

