### PR TITLE
Generate kokoro_index.html before starting kokoro build

### DIFF
--- a/tools/internal_ci/helper_scripts/gen_report_index.sh
+++ b/tools/internal_ci/helper_scripts/gen_report_index.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generates index.html that will contain links to various test results on kokoro.
+set -e
+
+# change to grpc repo root
+cd $(dirname $0)/../../..
+
+# Jenkins URLs are in form "grpc/job/macos/job/experimental/job/jtattermusch_experiment"
+KOKORO_JOB_PATH=$(echo "${KOKORO_JOB_NAME}" | sed "s|/|/job/|g")
+
+mkdir -p reports
+
+echo '<html><head></head><body>' > reports/kokoro_index.html
+echo '<h1>'${KOKORO_JOB_NAME}', build '#${KOKORO_BUILD_NUMBER}'</h1>' >> reports/kokoro_index.html
+echo '<h2><a href="https://kokoro.corp.google.com/job/'${KOKORO_JOB_PATH}'/'${KOKORO_BUILD_NUMBER}'/">Kokoro build dashboard (internal only)</a></h2>' >> reports/kokoro_index.html
+echo '<h2><a href="https://sponge.corp.google.com/invocation?id='${KOKORO_BUILD_ID}'&searchFor=">Test result dashboard (internal only)</a></h2>' >> reports/kokoro_index.html
+echo '<h2><a href="test_report.html">HTML test report (Not available yet)</a></h2>' >> reports/kokoro_index.html
+echo '<h2><a href="test_log.txt">Test log (Not available yet)</a></h2>' >> reports/kokoro_index.html
+echo '</body></html>' >> reports/kokoro_index.html
+
+echo 'Created reports/kokoro_index.html report index'

--- a/tools/internal_ci/helper_scripts/gen_report_index.sh
+++ b/tools/internal_ci/helper_scripts/gen_report_index.sh
@@ -19,7 +19,7 @@ set -e
 # change to grpc repo root
 cd $(dirname $0)/../../..
 
-# Jenkins URLs are in form "grpc/job/macos/job/experimental/job/jtattermusch_experiment"
+# Kororo URLs are in the form "grpc/job/macos/job/master/job/grpc_build_artifacts"
 KOKORO_JOB_PATH=$(echo "${KOKORO_JOB_NAME}" | sed "s|/|/job/|g")
 
 mkdir -p reports

--- a/tools/internal_ci/helper_scripts/prepare_build_linux_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_linux_rc
@@ -15,6 +15,8 @@
 
 # Source this rc script to prepare the environment for linux builds
 
+tools/internal_ci/helper_scripts/gen_report_index.sh
+
 # Need to increase open files limit for c tests
 ulimit -n 32768
 

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -15,6 +15,8 @@
 
 # Source this rc script to prepare the environment for macos builds
 
+tools/internal_ci/helper_scripts/gen_report_index.sh
+
 sudo launchctl limit maxfiles unlimited unlimited
 
 # show current maxfiles

--- a/tools/internal_ci/helper_scripts/prepare_build_windows.bat
+++ b/tools/internal_ci/helper_scripts/prepare_build_windows.bat
@@ -12,22 +12,10 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 
-@rem Move python installation from _32bit to _32bits where they are expected by python artifact builder
-@rem TODO(jtattermusch): get rid of this hack
-rename C:\Python27_32bit Python27_32bits
-rename C:\Python34_32bit Python34_32bits
-rename C:\Python35_32bit Python35_32bits
-rename C:\Python36_32bit Python36_32bits
+@rem make sure msys binaries are preferred over cygwin binaries
+@rem set path to python 2.7
+set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%
 
-pacman -S --noconfirm mingw64/mingw-w64-x86_64-gcc mingw32/mingw-w64-i686-gcc
+bash tools/internal_ci/helper_scripts/gen_report_index.sh
 
-@rem enter repo root
-cd /d %~dp0\..\..\..
-
-call tools/internal_ci/helper_scripts/prepare_build_windows.bat
-
-python tools/run_tests/task_runner.py -f artifact windows || goto :error
-goto :EOF
-
-:error
-exit /b %errorlevel%
+git submodule update --init

--- a/tools/internal_ci/linux/grpc_basictests_c_cpp_dbg.cfg
+++ b/tools/internal_ci/linux/grpc_basictests_c_cpp_dbg.cfg
@@ -20,6 +20,7 @@ timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/grpc_basictests_c_cpp_opt.cfg
+++ b/tools/internal_ci/linux/grpc_basictests_c_cpp_opt.cfg
@@ -20,6 +20,7 @@ timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/grpc_basictests_multilang.cfg
+++ b/tools/internal_ci/linux/grpc_basictests_multilang.cfg
@@ -20,6 +20,7 @@ timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/grpc_build_artifacts.cfg
+++ b/tools/internal_ci/linux/grpc_build_artifacts.cfg
@@ -20,6 +20,7 @@ timeout_mins: 120
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
     regex: "github/grpc/artifacts/**"
   }
 }

--- a/tools/internal_ci/linux/grpc_interop_badserver_java.cfg
+++ b/tools/internal_ci/linux/grpc_interop_badserver_java.cfg
@@ -20,7 +20,7 @@ build_file: "grpc/tools/internal_ci/linux/grpc_interop_badserver_java.sh"
 timeout_mins: 480
 action {
   define_artifacts {
-    regex: "**/report.xml",
+    regex: "**/report.xml"
     regex: "github/grpc/reports/**"
   }
 }

--- a/tools/internal_ci/linux/grpc_interop_badserver_python.cfg
+++ b/tools/internal_ci/linux/grpc_interop_badserver_python.cfg
@@ -20,7 +20,7 @@ build_file: "grpc/tools/internal_ci/linux/grpc_interop_badserver_python.sh"
 timeout_mins: 480
 action {
   define_artifacts {
-    regex: "**/report.xml",
+    regex: "**/report.xml"
     regex: "github/grpc/reports/**"
   }
 }

--- a/tools/internal_ci/linux/grpc_interop_matrix.cfg
+++ b/tools/internal_ci/linux/grpc_interop_matrix.cfg
@@ -21,5 +21,6 @@ timeout_mins: 60
 action {
   define_artifacts {
     regex: "**/sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }

--- a/tools/internal_ci/linux/grpc_interop_tocloud.cfg
+++ b/tools/internal_ci/linux/grpc_interop_tocloud.cfg
@@ -21,5 +21,6 @@ timeout_mins: 480
 action {
   define_artifacts {
     regex: "**/sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }

--- a/tools/internal_ci/linux/grpc_interop_toprod.cfg
+++ b/tools/internal_ci/linux/grpc_interop_toprod.cfg
@@ -21,6 +21,7 @@ timeout_mins: 60
 action {
   define_artifacts {
     regex: "**/sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/grpc_master.cfg
+++ b/tools/internal_ci/linux/grpc_master.cfg
@@ -20,6 +20,7 @@ timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/grpc_portability.cfg
+++ b/tools/internal_ci/linux/grpc_portability.cfg
@@ -20,6 +20,7 @@ timeout_mins: 1440
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/linux/grpc_portability_build_only.cfg
@@ -20,6 +20,7 @@ timeout_mins: 180
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/grpc_pull_request_sanity.cfg
+++ b/tools/internal_ci/linux/grpc_pull_request_sanity.cfg
@@ -20,6 +20,7 @@ timeout_mins: 30
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/grpc_sanity.cfg
+++ b/tools/internal_ci/linux/grpc_sanity.cfg
@@ -20,6 +20,7 @@ timeout_mins: 20
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/sanitizer/grpc_c_asan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_c_asan.cfg
@@ -20,6 +20,7 @@ timeout_mins: 1440
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/sanitizer/grpc_c_msan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_c_msan.cfg
@@ -20,6 +20,7 @@ timeout_mins: 1440
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/sanitizer/grpc_c_tsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_c_tsan.cfg
@@ -20,6 +20,7 @@ timeout_mins: 1440
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/sanitizer/grpc_c_ubsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_c_ubsan.cfg
@@ -20,6 +20,7 @@ timeout_mins: 1440
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/sanitizer/grpc_cpp_asan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_cpp_asan.cfg
@@ -20,6 +20,7 @@ timeout_mins: 1440
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/sanitizer/grpc_cpp_tsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/grpc_cpp_tsan.cfg
@@ -20,6 +20,7 @@ timeout_mins: 1440
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_asan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_asan.cfg
@@ -21,6 +21,7 @@ timeout_mins: 1440
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_msan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_msan.cfg
@@ -21,6 +21,7 @@ timeout_mins: 1440
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_tsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_tsan.cfg
@@ -21,6 +21,7 @@ timeout_mins: 1440
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_ubsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_ubsan.cfg
@@ -21,6 +21,7 @@ timeout_mins: 1440
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_cpp_asan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_cpp_asan.cfg
@@ -21,6 +21,7 @@ timeout_mins: 1440
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_cpp_tsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_cpp_tsan.cfg
@@ -21,6 +21,7 @@ timeout_mins: 1440
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }
 

--- a/tools/internal_ci/macos/grpc_build_artifacts.cfg
+++ b/tools/internal_ci/macos/grpc_build_artifacts.cfg
@@ -20,6 +20,7 @@ timeout_mins: 120
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
     regex: "github/grpc/artifacts/**"
   }
 }

--- a/tools/internal_ci/macos/grpc_interop.cfg
+++ b/tools/internal_ci/macos/grpc_interop.cfg
@@ -19,7 +19,7 @@ build_file: "grpc/tools/internal_ci/macos/grpc_interop.sh"
 timeout_mins: 240
 action {
   define_artifacts {
-    regex: "**/*sponge_log.xml",
+    regex: "**/*sponge_log.xml"
     regex: "github/grpc/reports/**"
   }
 }

--- a/tools/internal_ci/macos/grpc_master.cfg
+++ b/tools/internal_ci/macos/grpc_master.cfg
@@ -20,5 +20,6 @@ timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }

--- a/tools/internal_ci/windows/grpc_build_artifacts.cfg
+++ b/tools/internal_ci/windows/grpc_build_artifacts.cfg
@@ -20,6 +20,7 @@ timeout_mins: 120
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
     regex: "github/grpc/artifacts/**"
   }
 }

--- a/tools/internal_ci/windows/grpc_master.bat
+++ b/tools/internal_ci/windows/grpc_master.bat
@@ -12,14 +12,10 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 
-@rem make sure msys binaries are preferred over cygwin binaries
-@rem set path to python 2.7
-set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%
-
 @rem enter repo root
 cd /d %~dp0\..\..\..
 
-git submodule update --init
+call tools/internal_ci/helper_scripts/prepare_build_windows.bat
 
 python tools/run_tests/run_tests_matrix.py -f basictests windows -j 1 --inner_jobs 8 --internal_ci || goto :error
 goto :EOF

--- a/tools/internal_ci/windows/grpc_master.cfg
+++ b/tools/internal_ci/windows/grpc_master.cfg
@@ -20,5 +20,6 @@ timeout_mins: 360
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }

--- a/tools/internal_ci/windows/grpc_portability_master.bat
+++ b/tools/internal_ci/windows/grpc_portability_master.bat
@@ -12,14 +12,10 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 
-@rem make sure msys binaries are preferred over cygwin binaries
-@rem set path to python 2.7
-set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%
-
 @rem enter repo root
 cd /d %~dp0\..\..\..
 
-git submodule update --init
+call tools/internal_ci/helper_scripts/prepare_build_windows.bat
 
 python tools/run_tests/run_tests_matrix.py -f portability windows -j 1 --inner_jobs 8 --internal_ci || goto :error
 goto :EOF

--- a/tools/internal_ci/windows/grpc_portability_master.cfg
+++ b/tools/internal_ci/windows/grpc_portability_master.cfg
@@ -20,5 +20,6 @@ timeout_mins: 360
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
   }
 }


### PR DESCRIPTION
Preparation for making test results publicly accessible:
Before starting a build, generate generate a kokoro_index.html with links to  Kokoro build, test dashboard and other TBD items. Eventually (once the feature is available), the "Details" link on github PRs will point to this HTML file.