### PR TITLE
Prevent timeouts for linux artifact build on Kokoro

### DIFF
--- a/tools/internal_ci/linux/grpc_build_artifacts.sh
+++ b/tools/internal_ci/linux/grpc_build_artifacts.sh
@@ -26,4 +26,4 @@ set -e  # rvm commands are very verbose
 rvm --default use ruby-2.4.1
 set -ex
 
-tools/run_tests/task_runner.py -f artifact linux
+tools/run_tests/task_runner.py -f artifact linux -j 6


### PR DESCRIPTION
node artifact build times out pretty often, try decreasing parallelism to avoid this.