### PR TITLE
Enable BQ access for Kokoro Macs

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -27,6 +27,11 @@ ulimit -n 10000
 # show current limits
 ulimit -a
 
+# Add GCP credentials for BQ access
+# pip does not install google-api-python-client properly, so use easy_install
+sudo easy_install --upgrade google-api-python-client
+export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json
+gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 
 # required to build protobuf
 brew install gflags

--- a/tools/internal_ci/macos/grpc_basictests.cfg
+++ b/tools/internal_ci/macos/grpc_basictests.cfg
@@ -16,6 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_tests_matrix.sh"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 timeout_mins: 240
 action {
   define_artifacts {
@@ -26,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos --internal_ci -j 2 --inner_jobs 4"
+  value: "-f basictests macos --internal_ci -j 2 --inner_jobs 4 --bq_result_table aggregate_results"
 }


### PR DESCRIPTION
This will: 
- add downloading a service account key for BQ access as a Mac prebuild step.
- allow auto test flakiness detection
- enable uploading test results to BQ

CC @adelez 