### PR TITLE
Watch the LB channel using the right initial conn. state

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.c
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.c
@@ -1772,7 +1772,8 @@ static void glb_update_locked(grpc_exec_ctx *exec_ctx, grpc_lb_policy *policy,
 
   if (!glb_policy->watching_lb_channel) {
     // Watch the LB channel connectivity for connection.
-    glb_policy->lb_channel_connectivity = GRPC_CHANNEL_INIT;
+    glb_policy->lb_channel_connectivity = grpc_channel_check_connectivity_state(
+        glb_policy->lb_channel, true /* try to connect */);
     grpc_channel_element *client_channel_elem = grpc_channel_stack_last_element(
         grpc_channel_get_channel_stack(glb_policy->lb_channel));
     GPR_ASSERT(client_channel_elem->filter == &grpc_client_channel_filter);


### PR DESCRIPTION
Assuming the connectivity state of an LB channel upon the arrival of an update is INIT is obviously a mistake, that became evident while trying under the new epoll1 poller, which changes connection timings a little bit.

When updating balancer addresses in grpclb we watch the LB channel, looking for the -> READY edge. An already existing PF policy must be watched for changes relative to its current connectivity state, not INIT.
 
For example: an already existing PF policy within grpclb is READY; grpclb propagates an update, subscribing as well to LB channel connectivity changes in order to react to the PF's -> READY edge; previously, this subscription would fire immediately (INIT -> READY), prompting grpclb to think the PF had already processed the update.
With epoll, things were _out of sheer luck_ working because it was very quick to connect to the updated subchannels, effectively going through INIT -(spurious)-> READY -(update)-> READY which from the outside were only visible as INIT -> (last)READY. With epoll1, subchannels take longer to connect in this scenario (the 3 backends, 2 balancers and client all share a single polling engine, as opposed to separate ones per thread as with epollsig), making the INIT -(spurious)-> READY edge visible.