### PR TITLE
Fix 'Release of a suspended object' issue in GRXBufferedPipe

### DIFF
--- a/src/objective-c/RxLibrary/GRXBufferedPipe.m
+++ b/src/objective-c/RxLibrary/GRXBufferedPipe.m
@@ -110,4 +110,12 @@
   self.state = GRXWriterStateFinished;
 }
 
+- (void)dealloc {
+  GRXWriterState state = self.state;
+  if (state == GRXWriterStateNotStarted ||
+      state == GRXWriterStatePaused) {
+    dispatch_resume(_writeQueue);
+  }
+}
+
 @end


### PR DESCRIPTION
The Objective C utility `dispatch_queue_t` asserts itself to be on a `resumed` state when it gets dealloc'ed ([ref](https://opensource.apple.com/source/libdispatch/libdispatch-228.18/src/object.c)).  

This PR fixes a bug where the member `_writeQueue` of `GRXBufferedPipe` is still suspended when it gets dealloc'ed.