### PR TITLE
Fix mac jobs attempting to use gfile service account key

### DIFF
--- a/tools/internal_ci/macos/grpc_build_artifacts.cfg
+++ b/tools/internal_ci/macos/grpc_build_artifacts.cfg
@@ -16,6 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_build_artifacts.sh"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 timeout_mins: 120
 action {
   define_artifacts {

--- a/tools/internal_ci/macos/grpc_interop.cfg
+++ b/tools/internal_ci/macos/grpc_interop.cfg
@@ -16,6 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_interop.sh"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 timeout_mins: 240
 action {
   define_artifacts {

--- a/tools/internal_ci/macos/pull_request/grpc_interop.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_interop.cfg
@@ -16,6 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_interop.sh"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
 timeout_mins: 240
 action {
   define_artifacts {


### PR DESCRIPTION
Fix: activation of the key was added to  https://github.com/grpc/grpc/blob/9a19606af0091a4d38ca923a6a26191aa67feb6a/tools/internal_ci/helper_scripts/prepare_build_macos_rc#L34, but not all the jobs actually download the file which results in a failure.

```
++ export GOOGLE_APPLICATION_CREDENTIALS=/tmpfs/src/gfile/GrpcTesting-d0eeee2db331.json
++ GOOGLE_APPLICATION_CREDENTIALS=/tmpfs/src/gfile/GrpcTesting-d0eeee2db331.json
++ gcloud auth activate-service-account --key-file=/tmpfs/src/gfile/GrpcTesting-d0eeee2db331.json
ERROR: (gcloud.auth.activate-service-account) Unable to read file [/tmpfs/src/gfile/GrpcTesting-d0eeee2db331.json]: [Errno 2] No such file or directory: '/tmpfs/src/gfile/GrpcTesting-d0eeee2db331.json'
```