### PR TITLE
Update tcp_server_utils_posix_common with GPR_ONCE_INIT

### DIFF
--- a/src/core/lib/iomgr/tcp_server_utils_posix_common.c
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_common.c
@@ -39,7 +39,7 @@
 
 #define MIN_SAFE_ACCEPT_QUEUE_SIZE 100
 
-static gpr_once s_init_max_accept_queue_size;
+static gpr_once s_init_max_accept_queue_size = GPR_ONCE_INIT;
 static int s_max_accept_queue_size;
 
 /* get max listen queue size on linux */


### PR DESCRIPTION
Never initializing s_init_max_accept_queue_size could lead to undefined behavior.