### PR TITLE
Fix two memory leak points in ObjC

### DIFF
--- a/src/core/ext/transport/cronet/transport/cronet_transport.c
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.c
@@ -968,6 +968,9 @@ static enum e_op_result execute_stream_op(grpc_exec_ctx *exec_ctx,
     s->header_array.capacity = s->header_array.count;
     CRONET_LOG(GPR_DEBUG, "bidirectional_stream_start(%p, %s)", s->cbs, url);
     bidirectional_stream_start(s->cbs, url, 0, method, &s->header_array, false);
+    if (url) {
+      gpr_free(url);
+    }
     unsigned int header_index;
     for (header_index = 0; header_index < s->header_array.count;
          header_index++) {

--- a/src/objective-c/GRPCClient/private/NSData+GRPC.m
+++ b/src/objective-c/GRPCClient/private/NSData+GRPC.m
@@ -47,6 +47,8 @@ static void MallocAndCopyByteBufferToCharArray(grpc_byte_buffer *buffer,
   grpc_slice_unref(slice);
   *array = result;
   *length = uncompressed_length;
+
+  grpc_byte_buffer_reader_destroy(&reader);
 }
 
 static grpc_byte_buffer *CopyCharArrayToNewByteBuffer(const char *array,


### PR DESCRIPTION
Some old bugs where things are not destroyed properly.