### PR TITLE
Reenable cronet unit tests

### DIFF
--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -88,16 +88,14 @@ xcodebuild \
     -destination name="iPhone 6" \
     test | xcpretty
 
-# Temporarily disabled for (possible) flakiness on Jenkins.
-# Fix or reenable after confirmation/disconfirmation that it is the source of
-# Jenkins problem.
-
-# echo "TIME:  $(date)"
-# xcodebuild \
-#     -workspace Tests.xcworkspace \
-#     -scheme CronetUnitTests \
-#     -destination name="iPhone 6" \
-#     test | xcpretty
+echo "TIME:  $(date)"
+xcodebuild \
+    -workspace Tests.xcworkspace \
+    -scheme CronetUnitTests \
+    -destination name="iPhone 6" \
+    test \
+    | egrep "$XCODEBUILD_FILTER" \
+    | egrep -v "(GPBDictionary|GPBArray)" -
 
 echo "TIME:  $(date)"
 xcodebuild \


### PR DESCRIPTION
The reason for temporarily disabling them seems to no longer be available. Reenabling these tests.