### PR TITLE
Node: fix segfault with incorrect status argument types

### DIFF
--- a/src/node/ext/call.cc
+++ b/src/node/ext/call.cc
@@ -260,7 +260,10 @@ class SendClientCloseOp : public Op {
 
 class SendServerStatusOp : public Op {
  public:
-  SendServerStatusOp() { grpc_metadata_array_init(&status_metadata); }
+  SendServerStatusOp() {
+    details = grpc_empty_slice();
+    grpc_metadata_array_init(&status_metadata);
+  }
   ~SendServerStatusOp() {
     grpc_slice_unref(details);
     DestroyMetadataArray(&status_metadata);
@@ -381,7 +384,10 @@ class ReadMessageOp : public Op {
 
 class ClientStatusOp : public Op {
  public:
-  ClientStatusOp() { grpc_metadata_array_init(&metadata_array); }
+  ClientStatusOp() {
+    grpc_metadata_array_init(&metadata_array);
+    status_details = grpc_empty_slice();
+  }
 
   ~ClientStatusOp() {
     grpc_metadata_array_destroy(&metadata_array);

--- a/src/node/test/call_test.js
+++ b/src/node/test/call_test.js
@@ -189,18 +189,24 @@ describe('call', function() {
     });
   });
   describe('startBatch with message', function() {
-    it('should fail with non-buffer arguments', function() {
+    it('should fail with null argument', function() {
       var call = new grpc.Call(channel, 'method', getDeadline(1));
       assert.throws(function() {
         var batch = {};
         batch[grpc.opType.SEND_MESSAGE] = null;
         call.startBatch(batch, function(){});
       }, TypeError);
+    });
+    it('should fail with numeric argument', function() {
+      var call = new grpc.Call(channel, 'method', getDeadline(1));
       assert.throws(function() {
         var batch = {};
         batch[grpc.opType.SEND_MESSAGE] = 5;
         call.startBatch(batch, function(){});
       }, TypeError);
+    });
+    it('should fail with string argument', function() {
+      var call = new grpc.Call(channel, 'method', getDeadline(1));
       assert.throws(function() {
         var batch = {};
         batch[grpc.opType.SEND_MESSAGE] = 'value';
@@ -242,7 +248,7 @@ describe('call', function() {
         call.startBatch(batch, function(){});
       }, TypeError);
     });
-    it('should fail with incorrectly typed arguments', function() {
+    it('should fail with incorrectly typed code argument', function() {
       var call = new grpc.Call(channel, 'method', getDeadline(1));
       assert.throws(function() {
         var batch = {};
@@ -253,6 +259,9 @@ describe('call', function() {
         };
         call.startBatch(batch, function(){});
       }, TypeError);
+    });
+    it('should fail with incorrectly typed details argument', function() {
+      var call = new grpc.Call(channel, 'method', getDeadline(1));
       assert.throws(function() {
         var batch = {};
         batch[grpc.opType.SEND_STATUS_FROM_SERVER] = {
@@ -262,6 +271,9 @@ describe('call', function() {
         };
         call.startBatch(batch, function(){});
       }, TypeError);
+    });
+    it('should fail with incorrectly typed metadata argument', function() {
+      var call = new grpc.Call(channel, 'method', getDeadline(1));
       assert.throws(function() {
         var batch = {};
         batch[grpc.opType.SEND_STATUS_FROM_SERVER] = {

--- a/src/node/test/call_test.js
+++ b/src/node/test/call_test.js
@@ -188,6 +188,91 @@ describe('call', function() {
       }, TypeError);
     });
   });
+  describe('startBatch with message', function() {
+    it('should fail with non-buffer arguments', function() {
+      var call = new grpc.Call(channel, 'method', getDeadline(1));
+      assert.throws(function() {
+        var batch = {};
+        batch[grpc.opType.SEND_MESSAGE] = null;
+        call.startBatch(batch, function(){});
+      }, TypeError);
+      assert.throws(function() {
+        var batch = {};
+        batch[grpc.opType.SEND_MESSAGE] = 5;
+        call.startBatch(batch, function(){});
+      }, TypeError);
+      assert.throws(function() {
+        var batch = {};
+        batch[grpc.opType.SEND_MESSAGE] = 'value';
+        call.startBatch(batch, function(){});
+      }, TypeError);
+    });
+  });
+  describe('startBatch with status', function() {
+    it('should fail without a code', function() {
+      var call = new grpc.Call(channel, 'method', getDeadline(1));
+      assert.throws(function() {
+        var batch = {};
+        batch[grpc.opType.SEND_STATUS_FROM_SERVER] = {
+          details: 'details string',
+          metadata: {}
+        };
+        call.startBatch(batch, function(){});
+      }, TypeError);
+    });
+    it('should fail without details', function() {
+      var call = new grpc.Call(channel, 'method', getDeadline(1));
+      assert.throws(function() {
+        var batch = {};
+        batch[grpc.opType.SEND_STATUS_FROM_SERVER] = {
+          code: 0,
+          metadata: {}
+        };
+        call.startBatch(batch, function(){});
+      }, TypeError);
+    });
+    it('should fail without metadata', function() {
+      var call = new grpc.Call(channel, 'method', getDeadline(1));
+      assert.throws(function() {
+        var batch = {};
+        batch[grpc.opType.SEND_STATUS_FROM_SERVER] = {
+          code: 0,
+          details: 'details string'
+        };
+        call.startBatch(batch, function(){});
+      }, TypeError);
+    });
+    it('should fail with incorrectly typed arguments', function() {
+      var call = new grpc.Call(channel, 'method', getDeadline(1));
+      assert.throws(function() {
+        var batch = {};
+        batch[grpc.opType.SEND_STATUS_FROM_SERVER] = {
+          code: 'code string',
+          details: 'details string',
+          metadata: {}
+        };
+        call.startBatch(batch, function(){});
+      }, TypeError);
+      assert.throws(function() {
+        var batch = {};
+        batch[grpc.opType.SEND_STATUS_FROM_SERVER] = {
+          code: 0,
+          details: 5,
+          metadata: {}
+        };
+        call.startBatch(batch, function(){});
+      }, TypeError);
+      assert.throws(function() {
+        var batch = {};
+        batch[grpc.opType.SEND_STATUS_FROM_SERVER] = {
+          code: 0,
+          details: 'details string',
+          metadata: 'abc'
+        };
+        call.startBatch(batch, function(){});
+      }, TypeError);
+    });
+  });
   describe('cancel', function() {
     it('should succeed', function() {
       var call = new grpc.Call(channel, 'method', getDeadline(1));


### PR DESCRIPTION
This ensures that values that get destroyed in the destructors of status-related Op wrapper objects also get dummy values created in the constructors of those objects.

This fixes #11984.