### PR TITLE
Pre-populate xdg-cache-home to deflake python kokoro build

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_linux_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_linux_rc
@@ -24,6 +24,10 @@ ulimit -n 32768
 echo 'DOCKER_OPTS="${DOCKER_OPTS} --graph=/tmpfs/docker"' | sudo tee --append /etc/default/docker
 sudo service docker restart
 
+# Populate xdg-cache-home to workaround https://github.com/grpc/grpc/issues/11968
+sudo mkdir -p /tmp/xdg-cache-home
+PYTHONWARNINGS=ignore XDG_CACHE_HOME=/tmp/xdg-cache-home sudo -E pip install coverage==4.4
+
 # Download Docker images from DockerHub
 export DOCKERHUB_ORGANIZATION=grpctesting
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/11968.

Looks like it was caused by two concurrent runs of python tests trying to download the python wheel to /tmp/xdg-cache-home on the host machine (it's mounted from inside through docker -v to host machine's directory - the purpose is to cache pip downloaded packages on Jenkins - on Kokoro it doesn't have effect unless we'd populate the xdg-cache-home in the Kokoro image).