### PR TITLE
Auto_set_flakes also reruns tests that timeout

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -144,7 +144,7 @@ class Config(object):
                           cpu_cost=cpu_cost,
                           timeout_seconds=(self.timeout_multiplier * timeout_seconds if timeout_seconds else None),
                           flake_retries=5 if flaky or args.allow_flakes else 0,
-                          timeout_retries=3 if args.allow_flakes else 0)
+                          timeout_retries=3 if flaky or args.allow_flakes else 0)
 
 
 def get_c_tests(travis, test_lang) :


### PR DESCRIPTION
Until now, the tests marked as 'flaky' have only been re-run if they fail. Setting `timeout_retries` for flaky tests might potentially increase the total test runtime (and we need to keep an eye on it), but it should help to alleviate the problems with e.g. https://github.com/grpc/grpc/issues/11188.