### PR TITLE
Make tsi handshaker result unused bytes const

### DIFF
--- a/src/core/lib/security/transport/security_handshaker.c
+++ b/src/core/lib/security/transport/security_handshaker.c
@@ -147,7 +147,7 @@ static void on_peer_checked(grpc_exec_ctx *exec_ctx, void *arg,
     goto done;
   }
   // Get unused bytes.
-  unsigned char *unused_bytes = NULL;
+  const unsigned char *unused_bytes = NULL;
   size_t unused_bytes_size = 0;
   result = tsi_handshaker_result_get_unused_bytes(
       h->handshaker_result, &unused_bytes, &unused_bytes_size);

--- a/src/core/tsi/fake_transport_security.c
+++ b/src/core/tsi/fake_transport_security.c
@@ -391,7 +391,7 @@ static tsi_result fake_handshaker_result_create_frame_protector(
 }
 
 static tsi_result fake_handshaker_result_get_unused_bytes(
-    const tsi_handshaker_result *self, unsigned char **bytes,
+    const tsi_handshaker_result *self, const unsigned char **bytes,
     size_t *bytes_size) {
   fake_handshaker_result *result = (fake_handshaker_result *)self;
   *bytes_size = result->unused_bytes_size;

--- a/src/core/tsi/transport_security.c
+++ b/src/core/tsi/transport_security.c
@@ -240,7 +240,7 @@ tsi_result tsi_handshaker_result_create_frame_protector(
 }
 
 tsi_result tsi_handshaker_result_get_unused_bytes(
-    const tsi_handshaker_result *self, unsigned char **bytes,
+    const tsi_handshaker_result *self, const unsigned char **bytes,
     size_t *bytes_size) {
   if (self == NULL || bytes == NULL || bytes_size == NULL) {
     return TSI_INVALID_ARGUMENT;

--- a/src/core/tsi/transport_security.h
+++ b/src/core/tsi/transport_security.h
@@ -90,7 +90,8 @@ typedef struct {
                                        size_t *max_output_protected_frame_size,
                                        tsi_frame_protector **protector);
   tsi_result (*get_unused_bytes)(const tsi_handshaker_result *self,
-                                 unsigned char **bytes, size_t *bytes_size);
+                                 const unsigned char **bytes,
+                                 size_t *bytes_size);
   void (*destroy)(tsi_handshaker_result *self);
 } tsi_handshaker_result_vtable;
 

--- a/src/core/tsi/transport_security_adapter.c
+++ b/src/core/tsi/transport_security_adapter.c
@@ -50,7 +50,7 @@ static tsi_result adapter_result_create_frame_protector(
 }
 
 static tsi_result adapter_result_get_unused_bytes(
-    const tsi_handshaker_result *self, unsigned char **bytes,
+    const tsi_handshaker_result *self, const unsigned char **bytes,
     size_t *byte_size) {
   tsi_adapter_handshaker_result *impl = (tsi_adapter_handshaker_result *)self;
   *bytes = impl->unused_bytes;

--- a/src/core/tsi/transport_security_interface.h
+++ b/src/core/tsi/transport_security_interface.h
@@ -221,7 +221,7 @@ tsi_result tsi_handshaker_result_create_frame_protector(
    Ownership of the bytes is retained by the handshaker result. As a
    consequence, the caller must not free the bytes.  */
 tsi_result tsi_handshaker_result_get_unused_bytes(
-    const tsi_handshaker_result *self, unsigned char **bytes,
+    const tsi_handshaker_result *self, const unsigned char **bytes,
     size_t *byte_size);
 
 /* This method releases the tsi_handshaker_handshaker object. After this method


### PR DESCRIPTION
Since unused bytes are owned by tsi_handshaker_result, caller is not supposed to modify it. We shall pass const unsigned ** in tsi_handshaker_result_get_unused_bytes().