### PR TITLE
Test grpc++_unsecure in Bazel build

### DIFF
--- a/test/core/util/BUILD
+++ b/test/core/util/BUILD
@@ -38,7 +38,7 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
-    name = "grpc_test_util",
+    name = "grpc_test_util_base",
     srcs = [
         "debugger_macros.c",
         "grpc_profiler.c",
@@ -68,7 +68,29 @@ grpc_cc_library(
     language = "C",
     deps = [
         ":gpr_test_util",
+        "//:grpc_common",
+    ],
+)
+
+grpc_cc_library(
+    name = "grpc_test_util",
+    srcs = [],
+    hdrs = [],
+    language = "C",
+    deps = [
+        ":grpc_test_util_base",
         "//:grpc",
+    ],
+)
+
+grpc_cc_library(
+    name = "grpc_test_util_unsecure",
+    srcs = [],
+    hdrs = [],
+    language = "C",
+    deps = [
+        ":grpc_test_util_base",
+        "//:grpc_unsecure",
     ],
 )
 

--- a/test/cpp/common/BUILD
+++ b/test/cpp/common/BUILD
@@ -27,7 +27,7 @@ grpc_cc_test(
     name = "alarm_cpp_test",
     srcs = ["alarm_cpp_test.cc"],
     deps = [
-        "//:grpc++",
+        "//:grpc++_unsecure",
         "//test/core/util:gpr_test_util",
     ],
     external_deps = [

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -40,9 +40,9 @@ grpc_cc_library(
         "helpers.h",
     ],
     deps = [
-        "//:grpc++",
+        "//:grpc++_unsecure",
         "//src/proto/grpc/testing:echo_proto",
-        "//test/core/util:grpc_test_util",
+        "//test/core/util:grpc_test_util_unsecure",
     ],
     external_deps = [
         "benchmark",

--- a/test/cpp/server/BUILD
+++ b/test/cpp/server/BUILD
@@ -20,9 +20,9 @@ grpc_cc_test(
     name = "server_builder_test",
     srcs = ["server_builder_test.cc"],
     deps = [
-        "//:grpc++",
+        "//:grpc++_unsecure",
         "//src/proto/grpc/testing:echo_proto",
-        "//test/core/util:grpc_test_util",
+        "//test/core/util:grpc_test_util_unsecure",
     ],
     external_deps = [
         "gtest",
@@ -33,9 +33,9 @@ grpc_cc_test(
     name = "server_request_call_test",
     srcs = ["server_request_call_test.cc"],
     deps = [
-        "//:grpc++",
+        "//:grpc++_unsecure",
         "//src/proto/grpc/testing:echo_proto",
-        "//test/core/util:grpc_test_util",
+        "//test/core/util:grpc_test_util_unsecure",
     ],
     external_deps = [
         "gtest",

--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -24,16 +24,6 @@ package(
     ],
 )
 
-# The following builds a shared-object to confirm that grpc++_unsecure
-# builds properly. Build-only is sufficient here
-grpc_cc_binary(
-    name = "testso.so",
-    srcs = [],
-    linkshared = 1,
-    linkopts = ['-Wl,--no-undefined'],
-    deps = ["//:grpc++_unsecure"],
-)
-
 grpc_cc_library(
     name = "test_config",
     srcs = [
@@ -64,26 +54,43 @@ grpc_cc_library(
     ],
 )
 
+GRPCXX_TESTUTIL_SRCS  = [
+    "byte_buffer_proto_helper.cc",
+    "string_ref_helper.cc",
+    "subprocess.cc",
+]
+
+GRPCXX_TESTUTIL_HDRS = [
+    "byte_buffer_proto_helper.h",
+    "string_ref_helper.h",
+    "subprocess.h",
+]
+
 grpc_cc_library(
     name = "test_util",
-    srcs = [
-        "byte_buffer_proto_helper.cc",
+    srcs = GRPCXX_TESTUTIL_SRCS + [
         "create_test_channel.cc",
-        "string_ref_helper.cc",
-        "subprocess.cc",
         "test_credentials_provider.cc",
     ],
-    hdrs = [
-        "byte_buffer_proto_helper.h",
+    hdrs = GRPCXX_TESTUTIL_HDRS + [
         "create_test_channel.h",
-        "string_ref_helper.h",
-        "subprocess.h",
         "test_credentials_provider.h",
     ],
     deps = [
         "//:grpc++",
         "//test/core/end2end:ssl_test_data",
-        "//test/core/util:gpr_test_util",
+    ],
+    external_deps = [
+        "protobuf",
+    ],
+)
+
+grpc_cc_library(
+    name = "test_util_unsecure",
+    srcs = GRPCXX_TESTUTIL_SRCS,
+    hdrs = GRPCXX_TESTUTIL_HDRS,
+    deps = [
+        "//:grpc++_unsecure",
     ],
     external_deps = [
         "protobuf",


### PR DESCRIPTION
Fixes #12019 .
This makes the Bazel BUILD match build.yaml in terms of which targets are built with secure vs unsecure.