### PR TITLE
Split up macos basictests into dbg and opt and set num of jobs to 1.

### DIFF
--- a/tools/internal_ci/macos/grpc_basictests_dbg.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_dbg.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
+  value: "-f basictests macos dbg --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/macos/grpc_basictests_opt.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_opt.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
+  value: "-f basictests macos opt --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_dbg.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_dbg.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
+  value: "-f basictests macos dbg --internal_ci -j 1 --inner_jobs 4"
 }

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_opt.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_opt.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos --internal_ci -j 2 --inner_jobs 4"
+  value: "-f basictests macos opt --internal_ci -j 1 --inner_jobs 4"
 }


### PR DESCRIPTION
-- Kokoro macos workers are 1 core only
-- objc tests are designed in a wrong way and running opt and dbg configuration in parallel is not safe (talking to a wrong interop server and builds influencing each other in subtle ways)
-- tests taking too long anyway (1.5 hrs single run).

grpc_basictests.cfg will be deleted once kokoro job configuration is updated.
