### PR TITLE
Node: document that root_certs in createSsl is optional

### DIFF
--- a/src/node/src/credentials.js
+++ b/src/node/src/credentials.js
@@ -82,7 +82,7 @@ var _ = require('lodash');
  * @memberof grpc.credentials
  * @alias grpc.credentials.createSsl
  * @kind function
- * @param {Buffer} root_certs The root certificate data
+ * @param {Buffer=} root_certs The root certificate data
  * @param {Buffer=} private_key The client certificate private key, if
  *     applicable
  * @param {Buffer=} cert_chain The client certificate cert chain, if applicable


### PR DESCRIPTION
It appears that omitting it causes grpc to use the hosts' default cert data.
This was brought up (as I had implemented this method incorrectly) in:
https://github.com/mixer/etcd3/issues/28#issuecomment-319510441