### PR TITLE
Add Kokoro tests to build gRPC with an updated submodule

### DIFF
--- a/tools/internal_ci/linux/grpc_build_boringssl_at_head.cfg
+++ b/tools/internal_ci/linux/grpc_build_boringssl_at_head.cfg
@@ -1,0 +1,31 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_build_submodule_at_head.sh"
+timeout_mins: 180
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
+  }
+}
+
+# Tiny hack: misusing an already whitelisted env var to pass submodule name
+env_vars {
+  key: "RUN_TESTS_FLAGS"
+  value: "boringssl"
+}

--- a/tools/internal_ci/linux/grpc_build_protobuf_at_head.cfg
+++ b/tools/internal_ci/linux/grpc_build_protobuf_at_head.cfg
@@ -1,0 +1,31 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_build_submodule_at_head.sh"
+timeout_mins: 180
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
+  }
+}
+
+# Tiny hack: misusing an already whitelisted env var to pass submodule name
+env_vars {
+  key: "RUN_TESTS_FLAGS"
+  value: "protobuf"
+}

--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build portability tests with an updated submodule
+
+set -ex
+
+# change to grpc repo root
+cd $(dirname $0)/../../..
+
+source tools/internal_ci/helper_scripts/prepare_build_linux_rc
+
+# Update submodule and commit it so changes are passed to Docker
+(cd third_party/$RUN_TESTS_FLAGS && git pull origin master)
+git -c user.name='foo' -c user.email='foo@google.com' commit -a -m 'Update submodule'
+
+tools/run_tests/run_tests_matrix.py -f linux --internal_ci --build_only
+


### PR DESCRIPTION
This offers early detection of when changes from either us or Protobuf/Boringssl cause issues for updating our submodules. 

CC @nicolasnoble 