### PR TITLE
Resolve Kokoro's Mac Build Error

### DIFF
--- a/src/objective-c/tests/build_tests.sh
+++ b/src/objective-c/tests/build_tests.sh
@@ -35,6 +35,8 @@ rm -rf Tests.xcworkspace
 rm -f Podfile.lock
 rm -f RemoteTestClient/*.{h,m}
 
+# Update repo due to Kokoro issue #11987 (https://github.com/grpc/grpc/issues/11987)
+pod repo update
 echo "TIME:  $(date)"
 pod install
 


### PR DESCRIPTION
The reason why Kokoro did not respect `pod repo update` in `tools/internal_ci/helper_scripts/prepare_build_macos_rc` still remains unknown, but adding `pod repo update` in `build_test.sh` of ObjC test seems to be a valid work around (as verified [here](https://kokoro.corp.google.com/job/grpc/job/macos/job/experimental/job/muxi_experiment/15)).

#11987 