### PR TITLE
Remove gcloud auth activate-service-account from Kokoro Mac build

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -31,7 +31,6 @@ ulimit -a
 # pip does not install google-api-python-client properly, so use easy_install
 sudo easy_install --upgrade google-api-python-client
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json
-gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 
 # required to build protobuf
 brew install gflags


### PR DESCRIPTION
Fixes #12056