### PR TITLE
Fixed `grpc_unsecure` CMake build failures due to non-standard ssl path.

### DIFF
--- a/src/core/ext/census/tracing.c
+++ b/src/core/ext/census/tracing.c
@@ -21,7 +21,6 @@
 #include <grpc/census.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
-#include <openssl/rand.h>
 #include "src/core/ext/census/mlog.h"
 
 void trace_start_span(const trace_span_context *span_ctxt,


### PR DESCRIPTION
`grpc_unsecure` doesn't use openssl, but one of its source file accidently
includes `openssl/rand.h`. Since `CMakeLists.txt` doesn't specify that
`grpc_unsecure` requires openssl, the build would fail. This can be fixed
by simply removing this header inclusion.

Fixed #11600.