### PR TITLE
Check that all structs/unions in public core headers have named types

### DIFF
--- a/tools/run_tests/sanity/core_untyped_structs.sh
+++ b/tools/run_tests/sanity/core_untyped_structs.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+cd `dirname $0`/../../..
+
+#
+# Make sure that all core struct/unions have a name or are typedef'ed
+#
+
+egrep -Irn '(struct|union) *{' include/grpc |
+    egrep -v typedef |
+    diff - /dev/null
+

--- a/tools/run_tests/sanity/sanity_tests.yaml
+++ b/tools/run_tests/sanity/sanity_tests.yaml
@@ -6,6 +6,7 @@
 - script: tools/run_tests/sanity/check_test_filtering.py
 - script: tools/run_tests/sanity/check_tracer_sanity.py
 - script: tools/run_tests/sanity/core_banned_functions.py
+- script: tools/run_tests/sanity/core_untyped_structs.sh
 - script: tools/buildgen/generate_projects.sh -j 3
   cpu_cost: 3
 - script: tools/distrib/check_copyright.py


### PR DESCRIPTION
If we decide to accept #12075 and #12059, this is a sanity check that makes sure that any new aggregates added to public gRPC core headers have a named type.

This PR's sanity tests will not pass until #12059 goes in, so it is dependent on #12059 before it can go in. Alternatively, I can send it as a sub-PR to the author of #12059 so that they go in as an atomic unit (kinda like a struct).


