### PR TITLE
PHP: Fix a few Windows/MacOS/ZTS issues for 1.4.3

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,8 +22,9 @@
  </stability>
  <license>BSD</license>
  <notes>
-- Fixed hang bug when fork() was used #11814
-- Channel are now by default persistent #11878
+- Fixed a Windows installation issue #12108
+- Fixed a MacOS mutex segfault #12109
+- Fixed a ZTS compilation issue #12109
  </notes>
  <contents>
   <dir baseinstalldir="/" name="/">

--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -165,7 +165,7 @@ PHP_METHOD(ChannelCredentials, createSsl) {
   }
 
   php_grpc_int hashkey_len = root_certs_length + cert_chain_length;
-  char hashkey[hashkey_len];
+  char *hashkey = emalloc(hashkey_len);
   if (root_certs_length > 0) {
     strcpy(hashkey, pem_root_certs);
   }
@@ -181,6 +181,7 @@ PHP_METHOD(ChannelCredentials, createSsl) {
       pem_key_cert_pair.private_key == NULL ? NULL : &pem_key_cert_pair, NULL);
   zval *creds_object = grpc_php_wrap_channel_credentials(creds, hashstr, false
                                                          TSRMLS_CC);
+  efree(hashkey);
   RETURN_DESTROY_ZVAL(creds_object);
 }
 

--- a/templates/package.xml.template
+++ b/templates/package.xml.template
@@ -24,8 +24,9 @@
    </stability>
    <license>BSD</license>
    <notes>
-  - Fixed hang bug when fork() was used #11814
-  - Channel are now by default persistent #11878
+  - Fixed a Windows installation issue #12108
+  - Fixed a MacOS mutex segfault #12109
+  - Fixed a ZTS compilation issue #12109
    </notes>
    <contents>
     <dir baseinstalldir="/" name="/">


### PR DESCRIPTION
Fixed a few issues found with 1.4.3

- Fixed an issue with Windows installation.
- Fixed a MacOS mutex segfault issue when running test
- Fixed a ZTS compilation issue

Fixes #12109 