### PR TITLE
Make bytes_to_send in tsi_handshaker_next const

### DIFF
--- a/src/core/lib/security/transport/security_handshaker.c
+++ b/src/core/lib/security/transport/security_handshaker.c
@@ -261,7 +261,7 @@ static grpc_error *do_handshaker_next_locked(
     grpc_exec_ctx *exec_ctx, security_handshaker *h,
     const unsigned char *bytes_received, size_t bytes_received_size) {
   // Invoke TSI handshaker.
-  unsigned char *bytes_to_send = NULL;
+  const unsigned char *bytes_to_send = NULL;
   size_t bytes_to_send_size = 0;
   tsi_handshaker_result *handshaker_result = NULL;
   tsi_result result = tsi_handshaker_next(

--- a/src/core/tsi/fake_transport_security.c
+++ b/src/core/tsi/fake_transport_security.c
@@ -530,7 +530,7 @@ static void fake_handshaker_destroy(tsi_handshaker *self) {
 
 static tsi_result fake_handshaker_next(
     tsi_handshaker *self, const unsigned char *received_bytes,
-    size_t received_bytes_size, unsigned char **bytes_to_send,
+    size_t received_bytes_size, const unsigned char **bytes_to_send,
     size_t *bytes_to_send_size, tsi_handshaker_result **handshaker_result,
     tsi_handshaker_on_next_done_cb cb, void *user_data) {
   /* Sanity check the arguments. */

--- a/src/core/tsi/transport_security.c
+++ b/src/core/tsi/transport_security.c
@@ -198,7 +198,7 @@ tsi_result tsi_handshaker_create_frame_protector(
 
 tsi_result tsi_handshaker_next(
     tsi_handshaker *self, const unsigned char *received_bytes,
-    size_t received_bytes_size, unsigned char **bytes_to_send,
+    size_t received_bytes_size, const unsigned char **bytes_to_send,
     size_t *bytes_to_send_size, tsi_handshaker_result **handshaker_result,
     tsi_handshaker_on_next_done_cb cb, void *user_data) {
   if (self == NULL) return TSI_INVALID_ARGUMENT;

--- a/src/core/tsi/transport_security.h
+++ b/src/core/tsi/transport_security.h
@@ -70,7 +70,8 @@ typedef struct {
                                        tsi_frame_protector **protector);
   void (*destroy)(tsi_handshaker *self);
   tsi_result (*next)(tsi_handshaker *self, const unsigned char *received_bytes,
-                     size_t received_bytes_size, unsigned char **bytes_to_send,
+                     size_t received_bytes_size,
+                     const unsigned char **bytes_to_send,
                      size_t *bytes_to_send_size,
                      tsi_handshaker_result **handshaker_result,
                      tsi_handshaker_on_next_done_cb cb, void *user_data);

--- a/src/core/tsi/transport_security_adapter.c
+++ b/src/core/tsi/transport_security_adapter.c
@@ -140,7 +140,7 @@ static void adapter_destroy(tsi_handshaker *self) {
 
 static tsi_result adapter_next(
     tsi_handshaker *self, const unsigned char *received_bytes,
-    size_t received_bytes_size, unsigned char **bytes_to_send,
+    size_t received_bytes_size, const unsigned char **bytes_to_send,
     size_t *bytes_to_send_size, tsi_handshaker_result **handshaker_result,
     tsi_handshaker_on_next_done_cb cb, void *user_data) {
   /* Input sanity check.  */

--- a/src/core/tsi/transport_security_interface.h
+++ b/src/core/tsi/transport_security_interface.h
@@ -429,7 +429,7 @@ typedef void (*tsi_handshaker_on_next_done_cb)(
    tsi_handshaker object.  */
 tsi_result tsi_handshaker_next(
     tsi_handshaker *self, const unsigned char *received_bytes,
-    size_t received_bytes_size, unsigned char **bytes_to_send,
+    size_t received_bytes_size, const unsigned char **bytes_to_send,
     size_t *bytes_to_send_size, tsi_handshaker_result **handshaker_result,
     tsi_handshaker_on_next_done_cb cb, void *user_data);
 


### PR DESCRIPTION
The bytes_to_send in tsi_handshaker_next is owned by TSI handshaker, not the caller. Thus, it is better to make it const.