### PR TITLE
Fix init_max_accept_queue_size

### DIFF
--- a/src/core/lib/iomgr/tcp_server_utils_posix_common.c
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_common.c
@@ -55,7 +55,7 @@ static void init_max_accept_queue_size(void) {
   if (fgets(buf, sizeof buf, fp)) {
     char *end;
     long i = strtol(buf, &end, 10);
-    if (i > 0 && i <= INT_MAX && end && *end == 0) {
+    if (i > 0 && i <= INT_MAX && end && *end == '\n') {
       n = (int)i;
     }
   }


### PR DESCRIPTION
File `/proc/sys/net/core/somaxconn` ends with a `\n`, but not `\0`. So, after calling to `strtol`, `*end` would be `\n`. This results in `s_max_accept_queue_size` always being `SOMAXCONN`.