### PR TITLE
Make C# logging & tracing more intuitive

### DIFF
--- a/src/csharp/Grpc.Core.Tests/NUnitMain.cs
+++ b/src/csharp/Grpc.Core.Tests/NUnitMain.cs
@@ -33,7 +33,7 @@ namespace Grpc.Core.Tests
         public static int Main(string[] args)
         {
             // Make logger immune to NUnit capturing stdout and stderr to workaround https://github.com/nunit/nunit/issues/1406.
-            GrpcEnvironment.SetLogger(new TextWriterLogger(Console.Error));
+            GrpcEnvironment.SetLogger(new ConsoleLogger());
 #if NETCOREAPP1_0
             return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
 #else

--- a/src/csharp/Grpc.Core/GrpcEnvironment.cs
+++ b/src/csharp/Grpc.Core/GrpcEnvironment.cs
@@ -43,7 +43,7 @@ namespace Grpc.Core
         static readonly HashSet<Channel> registeredChannels = new HashSet<Channel>();
         static readonly HashSet<Server> registeredServers = new HashSet<Server>();
 
-        static ILogger logger = new NullLogger();
+        static ILogger logger = new LogLevelFilterLogger(new ConsoleLogger(), LogLevel.Off, true);
 
         readonly GrpcThreadPool threadPool;
         readonly DebugStats debugStats = new DebugStats();

--- a/src/csharp/Grpc.Core/Logging/LogLevel.cs
+++ b/src/csharp/Grpc.Core/Logging/LogLevel.cs
@@ -39,6 +39,10 @@ namespace Grpc.Core.Logging
         /// <summary>
         /// Error severity.
         /// </summary>
-        Error
+        Error,
+        /// <summary>
+        /// Logging is off.
+        /// </summary>
+        Off = int.MaxValue
     }
 }

--- a/src/csharp/Grpc.Core/Logging/LogLevelFilterLogger.cs
+++ b/src/csharp/Grpc.Core/Logging/LogLevelFilterLogger.cs
@@ -27,16 +27,31 @@ namespace Grpc.Core.Logging
     /// <summary>Logger that filters out messages below certain log level.</summary>
     public class LogLevelFilterLogger : ILogger
     {
+        // Verbosity environment variable used by C core.
+        private const string CoreVerbosityEnvVarName = "GRPC_VERBOSITY";
         readonly ILogger innerLogger;
         readonly LogLevel logLevel;
 
         /// <summary>
         /// Creates and instance of <c>LogLevelFilter.</c>
         /// </summary>
-        public LogLevelFilterLogger(ILogger logger, LogLevel logLevel)
+        public LogLevelFilterLogger(ILogger logger, LogLevel logLevel) : this(logger, logLevel, false)
+        {
+        }
+
+        /// <summary>
+        /// Creates and instance of <c>LogLevelFilter.</c>
+        /// The <c>fromEnvironmentVariable</c> parameter allows looking up "GRPC_VERBOSITY" setting provided by C-core
+        /// and uses the same log level for C# logs. Using this setting is recommended as it makes the otherwise separate
+        /// C# and C-core logging settings work in lockstep and more intutively.
+        /// </summary>
+        /// <param name="logger">the logger to forward filtered logs to.</param>
+        /// <param name="defaultLogLevel">the default log level, unless overriden by env variable.</param>
+        /// <param name="fromEnvironmentVariable">if <c>true</c>, override log level with setting from environment variable.</param>
+        public LogLevelFilterLogger(ILogger logger, LogLevel defaultLogLevel, bool fromEnvironmentVariable)
         {
             this.innerLogger = GrpcPreconditions.CheckNotNull(logger);
-            this.logLevel = logLevel;
+            this.logLevel = GetLogLevelFromEnvironment(defaultLogLevel, fromEnvironmentVariable);
         }
 
         /// <summary>
@@ -139,6 +154,34 @@ namespace Grpc.Core.Logging
             if (logLevel <= LogLevel.Error)
             {
                 innerLogger.Error(exception, message);
+            }
+        }
+
+        /// <summary>Get log level based on a default and lookup of <c>GRPC_VERBOSITY</c> environment variable.</summary>
+        private static LogLevel GetLogLevelFromEnvironment(LogLevel defaultLogLevel, bool fromEnvironmentVariable)
+        {
+            if (!fromEnvironmentVariable)
+            {
+                return defaultLogLevel;
+            }
+
+            var verbosityString = System.Environment.GetEnvironmentVariable(CoreVerbosityEnvVarName);
+            if (verbosityString == null)
+            {
+                return defaultLogLevel;
+            }
+
+            // NOTE: C core doesn't have "WARNING" log level
+            switch (verbosityString.ToUpperInvariant())
+            {
+                case "DEBUG":
+                    return LogLevel.Debug;
+                case "INFO":
+                    return LogLevel.Info;
+                case "ERROR":
+                    return LogLevel.Error;
+                default:
+                    return defaultLogLevel;
             }
         }
     }

--- a/src/csharp/Grpc.Core/Logging/LogLevelFilterLogger.cs
+++ b/src/csharp/Grpc.Core/Logging/LogLevelFilterLogger.cs
@@ -35,23 +35,23 @@ namespace Grpc.Core.Logging
         /// <summary>
         /// Creates and instance of <c>LogLevelFilter.</c>
         /// </summary>
-        public LogLevelFilterLogger(ILogger logger, LogLevel logLevel) : this(logger, logLevel, false)
+        public LogLevelFilterLogger(ILogger logger, LogLevel logLevel)
         {
+            this.innerLogger = GrpcPreconditions.CheckNotNull(logger);
+            this.logLevel = logLevel;
         }
 
         /// <summary>
         /// Creates and instance of <c>LogLevelFilter.</c>
         /// The <c>fromEnvironmentVariable</c> parameter allows looking up "GRPC_VERBOSITY" setting provided by C-core
-        /// and uses the same log level for C# logs. Using this setting is recommended as it makes the otherwise separate
-        /// C# and C-core logging settings work in lockstep and more intutively.
+        /// and uses the same log level for C# logs. Using this setting is recommended as it can prevent unintentionally hiding
+        /// C core logs requested by "GRPC_VERBOSITY" environment variable (which could happen if C# logger's log level was set to a more restrictive value).
         /// </summary>
         /// <param name="logger">the logger to forward filtered logs to.</param>
         /// <param name="defaultLogLevel">the default log level, unless overriden by env variable.</param>
         /// <param name="fromEnvironmentVariable">if <c>true</c>, override log level with setting from environment variable.</param>
-        public LogLevelFilterLogger(ILogger logger, LogLevel defaultLogLevel, bool fromEnvironmentVariable)
+        public LogLevelFilterLogger(ILogger logger, LogLevel defaultLogLevel, bool fromEnvironmentVariable) : this(logger, GetLogLevelFromEnvironment(defaultLogLevel, fromEnvironmentVariable))
         {
-            this.innerLogger = GrpcPreconditions.CheckNotNull(logger);
-            this.logLevel = GetLogLevelFromEnvironment(defaultLogLevel, fromEnvironmentVariable);
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Examples.Tests/NUnitMain.cs
+++ b/src/csharp/Grpc.Examples.Tests/NUnitMain.cs
@@ -33,7 +33,7 @@ namespace Grpc.Examples.Tests
         public static int Main(string[] args)
         {
             // Make logger immune to NUnit capturing stdout and stderr to workaround https://github.com/nunit/nunit/issues/1406.
-            GrpcEnvironment.SetLogger(new TextWriterLogger(Console.Error));
+            GrpcEnvironment.SetLogger(new ConsoleLogger());
 #if NETCOREAPP1_0
             return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
 #else

--- a/src/csharp/Grpc.HealthCheck.Tests/NUnitMain.cs
+++ b/src/csharp/Grpc.HealthCheck.Tests/NUnitMain.cs
@@ -33,7 +33,7 @@ namespace Grpc.HealthCheck.Tests
         public static int Main(string[] args)
         {
             // Make logger immune to NUnit capturing stdout and stderr to workaround https://github.com/nunit/nunit/issues/1406.
-            GrpcEnvironment.SetLogger(new TextWriterLogger(Console.Error));
+            GrpcEnvironment.SetLogger(new ConsoleLogger());
 #if NETCOREAPP1_0
             return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
 #else

--- a/src/csharp/Grpc.IntegrationTesting/NUnitMain.cs
+++ b/src/csharp/Grpc.IntegrationTesting/NUnitMain.cs
@@ -33,7 +33,7 @@ namespace Grpc.IntegrationTesting
         public static int Main(string[] args)
         {
             // Make logger immune to NUnit capturing stdout and stderr to workaround https://github.com/nunit/nunit/issues/1406.
-            GrpcEnvironment.SetLogger(new TextWriterLogger(Console.Error));
+            GrpcEnvironment.SetLogger(new ConsoleLogger());
 #if NETCOREAPP1_0
             return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
 #else

--- a/src/csharp/Grpc.Microbenchmarks/Program.cs
+++ b/src/csharp/Grpc.Microbenchmarks/Program.cs
@@ -27,7 +27,7 @@ namespace Grpc.Microbenchmarks
     {
         public static void Main(string[] args)
         {
-            GrpcEnvironment.SetLogger(new TextWriterLogger(Console.Error));
+            GrpcEnvironment.SetLogger(new ConsoleLogger());
             var benchmark = new SendMessageBenchmark();
             benchmark.Init();
             foreach (int threadCount in new int[] {1, 1, 2, 4, 8, 12})

--- a/src/csharp/Grpc.Reflection.Tests/NUnitMain.cs
+++ b/src/csharp/Grpc.Reflection.Tests/NUnitMain.cs
@@ -33,7 +33,7 @@ namespace Grpc.Reflection.Tests
         public static int Main(string[] args)
         {
             // Make logger immune to NUnit capturing stdout and stderr to workaround https://github.com/nunit/nunit/issues/1406.
-            GrpcEnvironment.SetLogger(new TextWriterLogger(Console.Error));
+            GrpcEnvironment.SetLogger(new ConsoleLogger());
 #if NETCOREAPP1_0
             return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
 #else


### PR DESCRIPTION
Tentative fix for https://github.com/grpc/grpc/issues/10574. Setting logging for C# is cumbersome now - it's hard to configure it to get the logs when you want them and by default, there are no logs (even the important ones, and users probably want to see them). This change aspires to make the default logging behavior more intuitive and sane in most use cases.

With this change, to get traces for C#, one only needs to set `GRPC_VERBOSITY=DEBUG GRPC_TRACE=the_trace_you_want`. At the same time, there shouldn't be any overly chatty messages coming from gRPC C# by default, as the default log level is set to 'Warning', but one would still see the important stuff by default.