### PR TITLE
Fix use-after-free in oauth2_credentials

### DIFF
--- a/src/core/lib/security/credentials/oauth2/oauth2_credentials.c
+++ b/src/core/lib/security/credentials/oauth2/oauth2_credentials.c
@@ -109,6 +109,8 @@ static void oauth2_token_fetcher_destruct(grpc_exec_ctx *exec_ctx,
       (grpc_oauth2_token_fetcher_credentials *)creds;
   GRPC_MDELEM_UNREF(exec_ctx, c->access_token_md);
   gpr_mu_destroy(&c->mu);
+  grpc_pollset_set_destroy(exec_ctx,
+                           grpc_polling_entity_pollset_set(&c->pollent));
   grpc_httpcli_context_destroy(exec_ctx, &c->httpcli_context);
 }
 
@@ -238,6 +240,9 @@ static void on_oauth2_token_fetcher_http_response(grpc_exec_ctx *exec_ctx,
           "Error occured when fetching oauth2 token.", &error, 1);
     }
     GRPC_CLOSURE_SCHED(exec_ctx, pending_request->on_request_metadata, error);
+    grpc_polling_entity_del_from_pollset_set(
+        exec_ctx, pending_request->pollent,
+        grpc_polling_entity_pollset_set(&c->pollent));
     grpc_oauth2_pending_get_request_metadata *prev = pending_request;
     pending_request = pending_request->next;
     gpr_free(prev);
@@ -278,6 +283,9 @@ static bool oauth2_token_fetcher_get_request_metadata(
           sizeof(*pending_request));
   pending_request->md_array = md_array;
   pending_request->on_request_metadata = on_request_metadata;
+  pending_request->pollent = pollent;
+  grpc_polling_entity_add_to_pollset_set(
+      exec_ctx, pollent, grpc_polling_entity_pollset_set(&c->pollent));
   pending_request->next = c->pending_requests;
   c->pending_requests = pending_request;
   bool start_fetch = false;
@@ -289,7 +297,7 @@ static bool oauth2_token_fetcher_get_request_metadata(
   if (start_fetch) {
     grpc_call_credentials_ref(creds);
     c->fetch_func(exec_ctx, grpc_credentials_metadata_request_create(creds),
-                  &c->httpcli_context, pollent,
+                  &c->httpcli_context, &c->pollent,
                   on_oauth2_token_fetcher_http_response,
                   gpr_time_add(gpr_now(GPR_CLOCK_REALTIME), refresh_threshold));
   }
@@ -334,6 +342,8 @@ static void init_oauth2_token_fetcher(grpc_oauth2_token_fetcher_credentials *c,
   gpr_mu_init(&c->mu);
   c->token_expiration = gpr_inf_past(GPR_CLOCK_REALTIME);
   c->fetch_func = fetch_func;
+  c->pollent =
+      grpc_polling_entity_create_from_pollset_set(grpc_pollset_set_create());
   grpc_httpcli_context_init(&c->httpcli_context);
 }
 

--- a/src/core/lib/security/credentials/oauth2/oauth2_credentials.h
+++ b/src/core/lib/security/credentials/oauth2/oauth2_credentials.h
@@ -62,6 +62,7 @@ typedef void (*grpc_fetch_oauth2_func)(grpc_exec_ctx *exec_ctx,
 typedef struct grpc_oauth2_pending_get_request_metadata {
   grpc_credentials_mdelem_array *md_array;
   grpc_closure *on_request_metadata;
+  grpc_polling_entity *pollent;
   struct grpc_oauth2_pending_get_request_metadata *next;
 } grpc_oauth2_pending_get_request_metadata;
 
@@ -74,6 +75,7 @@ typedef struct {
   grpc_oauth2_pending_get_request_metadata *pending_requests;
   grpc_httpcli_context httpcli_context;
   grpc_fetch_oauth2_func fetch_func;
+  grpc_polling_entity pollent;
 } grpc_oauth2_token_fetcher_credentials;
 
 // Google refresh token credentials.


### PR DESCRIPTION
The previous implementation may have the following issues:

- The http request used by `fetch_func` is driven by the polling entity from the surface call. The cancellation path cancels the pending get_request_metadata request, but it does not cancel the inflight http request. In the `finish` callback in [httpcli.c](https://github.com/grpc/grpc/blob/master/src/core/lib/http/httpcli.c#L92), we are trying to remove this polling entity, which may have already been destroyed with the surface call object, causing an use-after-free issue. 
- `fetch_func` only uses the polling entity from the first caller of `oauth2_token_fetcher_get_request_metadata()`. If the first request is canceled, no one will be driving the http requst.