### PR TITLE
Add windows portability build_only job

### DIFF
--- a/tools/internal_ci/windows/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/windows/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability windows -j 1 --inner_jobs 8 --internal_ci"
+  value: "-f portability windows --internal_ci  --build_only"
 }


### PR DESCRIPTION
-- remove unused grpc_portability_master.cfg  file (recently renamed to grpc_portability.cfg)
-- add portability build-only job for windows