### PR TITLE
write slice buffers

### DIFF
--- a/grpc.def
+++ b/grpc.def
@@ -148,6 +148,8 @@ EXPORTS
     grpc_slice_new_with_len
     grpc_slice_malloc
     grpc_slice_malloc_large
+    grpc_write_slice_malloc
+    grpc_slice_write
     grpc_slice_intern
     grpc_slice_from_copied_string
     grpc_slice_from_copied_buffer

--- a/include/grpc++/impl/codegen/core_codegen.h
+++ b/include/grpc++/impl/codegen/core_codegen.h
@@ -84,6 +84,7 @@ class CoreCodegen final : public CoreCodegenInterface {
                                            void* user_data) override;
   grpc_slice grpc_empty_slice() override;
   grpc_slice grpc_slice_malloc(size_t length) override;
+  grpc_slice grpc_write_slice_malloc(size_t length) override;
   void grpc_slice_unref(grpc_slice slice) override;
   grpc_slice grpc_slice_ref(grpc_slice slice) override;
   grpc_slice grpc_slice_split_tail(grpc_slice* s, size_t split) override;

--- a/include/grpc++/impl/codegen/core_codegen_interface.h
+++ b/include/grpc++/impl/codegen/core_codegen_interface.h
@@ -98,6 +98,7 @@ class CoreCodegenInterface {
   virtual void* grpc_call_arena_alloc(grpc_call* call, size_t length) = 0;
   virtual grpc_slice grpc_empty_slice() = 0;
   virtual grpc_slice grpc_slice_malloc(size_t length) = 0;
+  virtual grpc_slice grpc_write_slice_malloc(size_t length) = 0;
   virtual void grpc_slice_unref(grpc_slice slice) = 0;
   virtual grpc_slice grpc_slice_ref(grpc_slice slice) = 0;
   virtual grpc_slice grpc_slice_split_tail(grpc_slice* s, size_t split) = 0;

--- a/include/grpc++/impl/codegen/proto_utils.h
+++ b/include/grpc++/impl/codegen/proto_utils.h
@@ -59,7 +59,7 @@ class GrpcBufferWriter final
       slice_ = backup_slice_;
       have_backup_ = false;
     } else {
-      slice_ = g_core_codegen_interface->grpc_slice_malloc(block_size_);
+      slice_ = g_core_codegen_interface->grpc_write_slice_malloc(block_size_);
     }
     *data = GRPC_SLICE_START_PTR(slice_);
     // On win x64, int is only 32bit
@@ -179,7 +179,8 @@ class SerializationTraits<T, typename std::enable_if<std::is_base_of<
     *own_buffer = true;
     int byte_size = msg.ByteSize();
     if (byte_size <= internal::kGrpcBufferWriterMaxBufferLength) {
-      grpc_slice slice = g_core_codegen_interface->grpc_slice_malloc(byte_size);
+      grpc_slice slice =
+          g_core_codegen_interface->grpc_slice_malloc(byte_size);
       GPR_CODEGEN_ASSERT(
           GRPC_SLICE_END_PTR(slice) ==
           msg.SerializeWithCachedSizesToArray(GRPC_SLICE_START_PTR(slice)));

--- a/include/grpc/impl/codegen/slice.h
+++ b/include/grpc/impl/codegen/slice.h
@@ -46,6 +46,7 @@ typedef struct grpc_slice_refcount_vtable {
   void (*unref)(grpc_exec_ctx *exec_ctx, void *);
   int (*eq)(grpc_slice a, grpc_slice b);
   uint32_t (*hash)(grpc_slice slice);
+  void (*write)(grpc_exec_ctx *exec_ctx, grpc_slice slice);
 } grpc_slice_refcount_vtable;
 
 /** Reference count container for grpc_slice. Contains function pointers to

--- a/include/grpc/slice.h
+++ b/include/grpc/slice.h
@@ -65,6 +65,10 @@ GPRAPI grpc_slice grpc_slice_new_with_len(void *p, size_t len,
 GPRAPI grpc_slice grpc_slice_malloc(size_t length);
 GPRAPI grpc_slice grpc_slice_malloc_large(size_t length);
 
+/** Malloc a write slice */
+GPRAPI grpc_slice grpc_write_slice_malloc(size_t len);
+GPRAPI void grpc_slice_write(grpc_exec_ctx *exec_ctx, grpc_slice s);
+
 #define GRPC_SLICE_MALLOC(len)                                    \
   ((len) <= GRPC_SLICE_INLINED_SIZE                               \
        ? (grpc_slice){.refcount = NULL,                           \

--- a/src/core/lib/iomgr/resource_quota.c
+++ b/src/core/lib/iomgr/resource_quota.c
@@ -394,7 +394,7 @@ static void ru_slice_unref(grpc_exec_ctx *exec_ctx, void *p) {
 
 static const grpc_slice_refcount_vtable ru_slice_vtable = {
     ru_slice_ref, ru_slice_unref, grpc_slice_default_eq_impl,
-    grpc_slice_default_hash_impl};
+    grpc_slice_default_hash_impl, NULL};
 
 static grpc_slice ru_slice_create(grpc_resource_user *resource_user,
                                   size_t size) {

--- a/src/core/lib/slice/slice_intern.c
+++ b/src/core/lib/slice/slice_intern.c
@@ -116,10 +116,10 @@ static int interned_slice_eq(grpc_slice a, grpc_slice b) {
 
 static const grpc_slice_refcount_vtable interned_slice_vtable = {
     interned_slice_ref, interned_slice_unref, interned_slice_eq,
-    interned_slice_hash};
+    interned_slice_hash, NULL};
 static const grpc_slice_refcount_vtable interned_slice_sub_vtable = {
     interned_slice_sub_ref, interned_slice_sub_unref,
-    grpc_slice_default_eq_impl, grpc_slice_default_hash_impl};
+    grpc_slice_default_eq_impl, grpc_slice_default_hash_impl, NULL};
 
 static void grow_shard(slice_shard *shard) {
   size_t capacity = shard->capacity * 2;

--- a/src/core/lib/transport/static_metadata.c
+++ b/src/core/lib/transport/static_metadata.c
@@ -104,9 +104,10 @@ static void static_ref(void *unused) {}
 static void static_unref(grpc_exec_ctx *exec_ctx, void *unused) {}
 static const grpc_slice_refcount_vtable static_sub_vtable = {
     static_ref, static_unref, grpc_slice_default_eq_impl,
-    grpc_slice_default_hash_impl};
+    grpc_slice_default_hash_impl, NULL};
 const grpc_slice_refcount_vtable grpc_static_metadata_vtable = {
-    static_ref, static_unref, grpc_static_slice_eq, grpc_static_slice_hash};
+    static_ref, static_unref, grpc_static_slice_eq, grpc_static_slice_hash,
+    NULL};
 static grpc_slice_refcount static_sub_refcnt = {&static_sub_vtable,
                                                 &static_sub_refcnt};
 grpc_slice_refcount grpc_static_metadata_refcounts[GRPC_STATIC_MDSTR_COUNT] = {

--- a/src/core/lib/transport/transport.c
+++ b/src/core/lib/transport/transport.c
@@ -109,7 +109,8 @@ static const grpc_slice_refcount_vtable stream_ref_slice_vtable = {
     .ref = slice_stream_ref,
     .unref = slice_stream_unref,
     .eq = grpc_slice_default_eq_impl,
-    .hash = grpc_slice_default_hash_impl};
+    .hash = grpc_slice_default_hash_impl,
+    .write = NULL};
 
 #ifndef NDEBUG
 void grpc_stream_ref_init(grpc_stream_refcount *refcount, int initial_refs,

--- a/src/cpp/common/core_codegen.cc
+++ b/src/cpp/common/core_codegen.cc
@@ -136,6 +136,10 @@ grpc_slice CoreCodegen::grpc_slice_malloc(size_t length) {
   return ::grpc_slice_malloc(length);
 }
 
+grpc_slice CoreCodegen::grpc_write_slice_malloc(size_t length) {
+  return ::grpc_write_slice_malloc(length);
+}
+
 void CoreCodegen::grpc_slice_unref(grpc_slice slice) {
   ::grpc_slice_unref(slice);
 }

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.c
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.c
@@ -171,6 +171,8 @@ grpc_slice_new_with_user_data_type grpc_slice_new_with_user_data_import;
 grpc_slice_new_with_len_type grpc_slice_new_with_len_import;
 grpc_slice_malloc_type grpc_slice_malloc_import;
 grpc_slice_malloc_large_type grpc_slice_malloc_large_import;
+grpc_write_slice_malloc_type grpc_write_slice_malloc_import;
+grpc_slice_write_type grpc_slice_write_import;
 grpc_slice_intern_type grpc_slice_intern_import;
 grpc_slice_from_copied_string_type grpc_slice_from_copied_string_import;
 grpc_slice_from_copied_buffer_type grpc_slice_from_copied_buffer_import;
@@ -474,6 +476,8 @@ void grpc_rb_load_imports(HMODULE library) {
   grpc_slice_new_with_len_import = (grpc_slice_new_with_len_type) GetProcAddress(library, "grpc_slice_new_with_len");
   grpc_slice_malloc_import = (grpc_slice_malloc_type) GetProcAddress(library, "grpc_slice_malloc");
   grpc_slice_malloc_large_import = (grpc_slice_malloc_large_type) GetProcAddress(library, "grpc_slice_malloc_large");
+  grpc_write_slice_malloc_import = (grpc_write_slice_malloc_type) GetProcAddress(library, "grpc_write_slice_malloc");
+  grpc_slice_write_import = (grpc_slice_write_type) GetProcAddress(library, "grpc_slice_write");
   grpc_slice_intern_import = (grpc_slice_intern_type) GetProcAddress(library, "grpc_slice_intern");
   grpc_slice_from_copied_string_import = (grpc_slice_from_copied_string_type) GetProcAddress(library, "grpc_slice_from_copied_string");
   grpc_slice_from_copied_buffer_import = (grpc_slice_from_copied_buffer_type) GetProcAddress(library, "grpc_slice_from_copied_buffer");

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.h
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.h
@@ -494,6 +494,12 @@ extern grpc_slice_malloc_type grpc_slice_malloc_import;
 typedef grpc_slice(*grpc_slice_malloc_large_type)(size_t length);
 extern grpc_slice_malloc_large_type grpc_slice_malloc_large_import;
 #define grpc_slice_malloc_large grpc_slice_malloc_large_import
+typedef grpc_slice(*grpc_write_slice_malloc_type)(size_t len);
+extern grpc_write_slice_malloc_type grpc_write_slice_malloc_import;
+#define grpc_write_slice_malloc grpc_write_slice_malloc_import
+typedef void(*grpc_slice_write_type)(grpc_exec_ctx *exec_ctx, grpc_slice s);
+extern grpc_slice_write_type grpc_slice_write_import;
+#define grpc_slice_write grpc_slice_write_import
 typedef grpc_slice(*grpc_slice_intern_type)(grpc_slice slice);
 extern grpc_slice_intern_type grpc_slice_intern_import;
 #define grpc_slice_intern grpc_slice_intern_import


### PR DESCRIPTION
Write slices will do an additional unreference when writing to a tcp
socket.  This allows for more agressive memory freeing, which can avoid
OOMs and increase performance when a large number of large message
requests are outstanding.

Currently, this optimization is only enabled for protobus > 1MB.