### PR TITLE
Don't rerun flakes when uploading results to BQ

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1274,12 +1274,12 @@ argp.add_argument('--bq_result_table',
                   type=str,
                   nargs='?',
                   help='Upload test results to a specified BQ table.')
-argp.add_argument('--auto_set_flakes', default=True, type=bool,
-                  help='Set flakiness data from historic data')
+argp.add_argument('--disable_auto_set_flakes', default=False, const=True, action='store_const',
+                  help='Disable rerunning historically flaky tests')
 args = argp.parse_args()
 
 flaky_tests = set()
-if args.auto_set_flakes:
+if not args.disable_auto_set_flakes:
   try:
     flaky_tests = set(get_flaky_tests())
   except:

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -411,6 +411,7 @@ if __name__ == "__main__":
     extra_args.append('--bq_result_table')
     extra_args.append('%s' % args.bq_result_table)
     extra_args.append('--measure_cpu_costs')
+    extra_args.append('--disable_auto_set_flakes')
 
   all_jobs = _create_test_jobs(extra_args=extra_args, inner_jobs=args.inner_jobs) + \
              _create_portability_test_jobs(extra_args=extra_args, inner_jobs=args.inner_jobs)


### PR DESCRIPTION
Our master builds are the only ones that upload results and these are the ones that should let flaky tests fail to get a reliable estimate of how flaky tests are. 