### PR TITLE
Upload results for Kokoro master portability tests

### DIFF
--- a/tools/internal_ci/linux/grpc_portability.cfg
+++ b/tools/internal_ci/linux/grpc_portability.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux --inner_jobs 16 -j 1 --internal_ci"
+  value: "-f portability linux --inner_jobs 16 -j 1 --internal_ci --bq_result_table aggregate_results"
 }

--- a/tools/internal_ci/windows/grpc_portability.cfg
+++ b/tools/internal_ci/windows/grpc_portability.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability windows -j 1 --inner_jobs 8 --internal_ci"
+  value: "-f portability windows -j 1 --inner_jobs 8 --internal_ci --bq_result_table aggregate_results"
 }


### PR DESCRIPTION
The results won't be used for flake detection, but it's nice to be able to easily detect when our master build breaks with different configs. 