### PR TITLE
Move policy's name from vtable to policy factory.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.c
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.c
@@ -1867,9 +1867,9 @@ static void glb_factory_ref(grpc_lb_policy_factory *factory) {}
 static void glb_factory_unref(grpc_lb_policy_factory *factory) {}
 
 static const grpc_lb_policy_factory_vtable glb_factory_vtable = {
-    glb_factory_ref, glb_factory_unref, glb_create, "grpclb"};
+    glb_factory_ref, glb_factory_unref, glb_create};
 
-static grpc_lb_policy_factory glb_lb_policy_factory = {&glb_factory_vtable};
+static grpc_lb_policy_factory glb_lb_policy_factory = {&glb_factory_vtable, "grpclb"};
 
 grpc_lb_policy_factory *grpc_glb_lb_factory_create() {
   return &glb_lb_policy_factory;

--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.c
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.c
@@ -694,11 +694,10 @@ static grpc_lb_policy *create_pick_first(grpc_exec_ctx *exec_ctx,
 }
 
 static const grpc_lb_policy_factory_vtable pick_first_factory_vtable = {
-    pick_first_factory_ref, pick_first_factory_unref, create_pick_first,
-    "pick_first"};
+    pick_first_factory_ref, pick_first_factory_unref, create_pick_first};
 
 static grpc_lb_policy_factory pick_first_lb_policy_factory = {
-    &pick_first_factory_vtable};
+    &pick_first_factory_vtable, "pick_first"};
 
 static grpc_lb_policy_factory *pick_first_lb_factory_create() {
   return &pick_first_lb_policy_factory;

--- a/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.c
+++ b/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.c
@@ -899,11 +899,10 @@ static grpc_lb_policy *round_robin_create(grpc_exec_ctx *exec_ctx,
 }
 
 static const grpc_lb_policy_factory_vtable round_robin_factory_vtable = {
-    round_robin_factory_ref, round_robin_factory_unref, round_robin_create,
-    "round_robin"};
+    round_robin_factory_ref, round_robin_factory_unref, round_robin_create};
 
 static grpc_lb_policy_factory round_robin_lb_policy_factory = {
-    &round_robin_factory_vtable};
+    &round_robin_factory_vtable, "round_robin"};
 
 static grpc_lb_policy_factory *round_robin_lb_factory_create() {
   return &round_robin_lb_policy_factory;

--- a/src/core/ext/filters/client_channel/lb_policy_factory.h
+++ b/src/core/ext/filters/client_channel/lb_policy_factory.h
@@ -34,6 +34,9 @@ typedef struct grpc_lb_policy_factory_vtable grpc_lb_policy_factory_vtable;
 
 struct grpc_lb_policy_factory {
   const grpc_lb_policy_factory_vtable *vtable;
+
+  /** Name for the LB policy this factory implements */
+  const char *name;
 };
 
 /** A resolved address alongside any LB related information associated with it.
@@ -117,9 +120,6 @@ struct grpc_lb_policy_factory_vtable {
   grpc_lb_policy *(*create_lb_policy)(grpc_exec_ctx *exec_ctx,
                                       grpc_lb_policy_factory *factory,
                                       grpc_lb_policy_args *args);
-
-  /** Name for the LB policy this factory implements */
-  const char *name;
 };
 
 void grpc_lb_policy_factory_ref(grpc_lb_policy_factory *factory);

--- a/src/core/ext/filters/client_channel/lb_policy_registry.c
+++ b/src/core/ext/filters/client_channel/lb_policy_registry.c
@@ -39,8 +39,8 @@ void grpc_lb_policy_registry_shutdown(void) {
 void grpc_register_lb_policy(grpc_lb_policy_factory *factory) {
   int i;
   for (i = 0; i < g_number_of_lb_policies; i++) {
-    GPR_ASSERT(0 != gpr_stricmp(factory->vtable->name,
-                                g_all_of_the_lb_policies[i]->vtable->name));
+    GPR_ASSERT(0 != gpr_stricmp(factory->name,
+                                g_all_of_the_lb_policies[i]->name));
   }
   GPR_ASSERT(g_number_of_lb_policies != MAX_POLICIES);
   grpc_lb_policy_factory_ref(factory);
@@ -53,7 +53,7 @@ static grpc_lb_policy_factory *lookup_factory(const char *name) {
   if (name == NULL) return NULL;
 
   for (i = 0; i < g_number_of_lb_policies; i++) {
-    if (0 == gpr_stricmp(name, g_all_of_the_lb_policies[i]->vtable->name)) {
+    if (0 == gpr_stricmp(name, g_all_of_the_lb_policies[i]->name)) {
       return g_all_of_the_lb_policies[i];
     }
   }


### PR DESCRIPTION
The member _name_ should be directly under the policy factory "class", because vtable is for method pointers only. 

This modification is also to conform with [`grpc_lb_policy`](https://github.com/grpc/grpc/blob/e252e5fd9dcd8b4bf90c4c1efe18145509e150b9/src/core/ext/filters/client_channel/lb_policy.h#L36) implementation.