### PR TITLE
Wait for queued continuations when shutting down GrpcThreadPool

### DIFF
--- a/src/csharp/Grpc.Core/Internal/AtomicCounter.cs
+++ b/src/csharp/Grpc.Core/Internal/AtomicCounter.cs
@@ -64,7 +64,7 @@ namespace Grpc.Core.Internal
         {
             get
             {
-                return counter;
+                return Interlocked.Read(ref counter);
             }
         }
     }


### PR DESCRIPTION
This should fix C# flakes that recently started appearing mostly on MacOS.
Details in comments.