### PR TITLE
auto_set_flakes should respect platform

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -84,6 +84,7 @@ SELECT
     [grpc-testing:jenkins_test_results.aggregate_results]
   WHERE
     timestamp >= DATE_ADD(CURRENT_DATE(), -1, "WEEK")
+    AND platform = '"""+platform_string()+"""'
     AND NOT REGEXP_MATCH(job_name, '.*portability.*') )
 GROUP BY
   filtered_test_name


### PR DESCRIPTION
Currently a test is marked as flaky even if flakes only appear on different platform.
(in some cases - e.g. in C/C++ tests have same names from macOS and linux but a different name on Windows. on the other hand e.g. C# tests have the same names on all platforms).