### PR TITLE
Make ChannelInterface virtual methods protected instead of private

### DIFF
--- a/include/grpc++/impl/codegen/channel_interface.h
+++ b/include/grpc++/impl/codegen/channel_interface.h
@@ -80,7 +80,7 @@ class ChannelInterface {
     return true;
   }
 
- private:
+ protected:
   template <class R>
   friend class ::grpc::ClientReader;
   template <class W>


### PR DESCRIPTION
I'd like to be able to implement a `ChannelInterface` subclass that delegates to another `ChannelInterface` instance.  This isn't currently possible, because most of the virtual `ChannelInterface` methods that I would need to delegate to are marked private, and so can't be called by the subclass.  Changing these methods from private to protected allows for delegation.