### PR TITLE
PHP: Move OP_RECV_INITIAL_METADATA out of start() methods

### DIFF
--- a/src/php/lib/Grpc/UnaryCall.php
+++ b/src/php/lib/Grpc/UnaryCall.php
@@ -40,7 +40,7 @@ class UnaryCall extends AbstractCall
         if (isset($options['flags'])) {
             $message_array['flags'] = $options['flags'];
         }
-        $event = $this->call->startBatch([
+        $this->call->startBatch([
             OP_SEND_INITIAL_METADATA => $metadata,
             OP_SEND_MESSAGE => $message_array,
             OP_SEND_CLOSE_FROM_CLIENT => true,

--- a/src/php/lib/Grpc/UnaryCall.php
+++ b/src/php/lib/Grpc/UnaryCall.php
@@ -45,7 +45,6 @@ class UnaryCall extends AbstractCall
             OP_SEND_MESSAGE => $message_array,
             OP_SEND_CLOSE_FROM_CLIENT => true,
         ]);
-        $this->metadata = $event->metadata;
     }
 
     /**


### PR DESCRIPTION
Moves the OP_RECV_INITIAL_METADATA out of the start() methods for
UnaryCall and ServerStreamingCall, and adds a check so that the
getMetadata methods for those objects will always contain the
metadata.

cc @stanley-cheung @murgatroid99 