### PR TITLE
Catch NotImplementedError exceptions and forward them to the client.

### DIFF
--- a/src/ruby/lib/grpc/generic/rpc_desc.rb
+++ b/src/ruby/lib/grpc/generic/rpc_desc.rb
@@ -99,9 +99,13 @@ module GRPC
       # event.  Send a status of deadline exceeded
       GRPC.logger.warn("late call: #{active_call}")
       send_status(active_call, DEADLINE_EXCEEDED, 'late')
-    rescue StandardError => e
+    rescue StandardError, NotImplementedError => e
       # This will usuaally be an unhandled error in the handling code.
       # Send back a UNKNOWN status to the client
+      #
+      # Note: this intentionally does not map NotImplementedError to
+      # UNIMPLEMENTED because NotImplementedError is intended for low-level
+      # OS interaction (e.g. syscalls) not supported by the current OS.
       GRPC.logger.warn("failed handler: #{active_call}; sending status:UNKNOWN")
       GRPC.logger.warn(e)
       send_status(active_call, UNKNOWN, "#{e.class}: #{e.message}")


### PR DESCRIPTION
The old code only caught `StandardError`, which doesn't include some
common error types such as `LoadError`[1] or `NotImplementedError`[2].
Any errors not caught by this section will cause the server to
terminate, which is generally undesirable because it might be happily
handling other requests.

[1] Raised if the handler performs lazy loading of other modules and
    fails to load something.
[2] Raised if some OS-specific function is called on the wrong OS.