### PR TITLE
pin protobuf dep to < 3.4 while latest protobuf package is being fixed

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -27,7 +27,9 @@ Gem::Specification.new do |s|
   s.require_paths = %w( src/ruby/lib src/ruby/bin src/ruby/pb )
   s.platform      = Gem::Platform::RUBY
 
-  s.add_dependency 'google-protobuf', '~> 3.1'
+  # TODO: workaround for https://github.com/google/protobuf/issues/3509
+  # remove '< 3.4' later
+  s.add_dependency 'google-protobuf', ['~> 3.1', '< 3.4']
   s.add_dependency 'googleauth',      '~> 0.5.1'
 
   s.add_development_dependency 'bundler',            '~> 1.9'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -29,7 +29,9 @@
     s.require_paths = %w( src/ruby/lib src/ruby/bin src/ruby/pb )
     s.platform      = Gem::Platform::RUBY
 
-    s.add_dependency 'google-protobuf', '~> 3.1'
+    # TODO: workaround for https://github.com/google/protobuf/issues/3509
+    # remove '< 3.4' later
+    s.add_dependency 'google-protobuf', ['~> 3.1', '< 3.4']
     s.add_dependency 'googleauth',      '~> 0.5.1'
 
     s.add_development_dependency 'bundler',            '~> 1.9'


### PR DESCRIPTION
Fixes this error in tests:

```
An error occurred while loading ./src/ruby/spec/pb/health/checker_spec.rb.
Failure/Error: require 'google/protobuf'
```

(issue https://github.com/google/protobuf/issues/3509)

3.4. was yanked, but it looks like this is needed to remove 3.4 from caches