### PR TITLE
Mark error code details as global

### DIFF
--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -905,6 +905,9 @@ static void Init_grpc_error_codes() {
   rb_define_const(grpc_rb_mRpcErrors, "INVALID_FLAGS",
                   UINT2NUM(GRPC_CALL_ERROR_INVALID_FLAGS));
 
+  /* Hint the GC that this is a global and shouldn't be sweeped. */
+  rb_global_variable(&rb_error_code_details);
+
   /* Add the detail strings to a Hash */
   rb_error_code_details = rb_hash_new();
   rb_hash_aset(rb_error_code_details, UINT2NUM(GRPC_CALL_OK),


### PR DESCRIPTION
In the Ruby implementation, the code [initializes a hash and then initializes a bunch of strings before assigning the hash to a constant](https://github.com/grpc/grpc/blob/master/src/ruby/ext/grpc/rb_call.c#L908-L934).

In some cases, the string allocations trigger a GC event, which will clear the hash because nothing references it.

Further down the line, the hash is frozen, but it makes Ruby processes segfault when it's been collected by GC.

This PR marks it as global to hint the GC to leave it alone.

Thank you @fbogsany for pointing me in the right direction.