### PR TITLE
Increase Python mac target build time 30m -> 60m

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -157,6 +157,7 @@ class PythonArtifact:
       return create_jobspec(self.name,
                             ['tools/run_tests/artifacts/build_artifact_python.sh'],
                             environ=environ,
+                            timeout_seconds=60*60,
                             use_workspace=True)
 
   def __str__(self):


### PR DESCRIPTION
https://grpc-testing.appspot.com/view/Artifacts/job/gRPC_build_artifacts/706/