### PR TITLE
Add missing test files to Cocoapods podspec

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -987,6 +987,7 @@ Pod::Spec.new do |s|
                       'test/core/end2end/end2end_tests.{c,h}',
                       'test/core/end2end/end2end_test_utils.c',
                       'test/core/end2end/tests/*.{c,h}',
+                      'test/core/end2end/fixtures/*.h',
                       'test/core/end2end/data/*.{c,h}',
                       'test/core/util/debugger_macros.{c,h}',
                       'test/core/util/test_config.{c,h}',

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -171,6 +171,7 @@
                         'test/core/end2end/end2end_tests.{c,h}',
                         'test/core/end2end/end2end_test_utils.c',
                         'test/core/end2end/tests/*.{c,h}',
+                        'test/core/end2end/fixtures/*.h',
                         'test/core/end2end/data/*.{c,h}',
                         'test/core/util/debugger_macros.{c,h}',
                         'test/core/util/test_config.{c,h}',


### PR DESCRIPTION
Fix the 'dependency not found' problem when submitting podspec to Cocoapods.

Fix for v1.6.0 release.