### PR TITLE
Fix uploading Mac results to BQ 

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -28,8 +28,7 @@ ulimit -n 10000
 ulimit -a
 
 # Add GCP credentials for BQ access
-# pip does not install google-api-python-client properly, so use easy_install
-sudo easy_install --upgrade google-api-python-client
+pip install google-api-python-client --user python
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json
 
 # required to build protobuf
@@ -53,9 +52,10 @@ pod repo update  # needed by python
 
 # python
 brew install coreutils  # we need grealpath
-sudo pip install virtualenv
-sudo pip install -U six tox setuptools
-export PYTHONPATH=/Library/Python/3.4/site-packages
+pip install virtualenv --user python
+pip install -U six tox setuptools --user python
+export PYTHONPATH=/Library/Python/2.7/site-packages
+source ~/.bashrc
 
 # python 3.4
 wget -q https://www.python.org/ftp/python/3.4.4/python-3.4.4-macosx10.6.pkg


### PR DESCRIPTION
The changes from `sudo pip install x` to `pip install x --user python` is to get rid of this innocuous warning:
```
The directory '/Users/kbuilder/Library/Caches/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
```

I tested uploading results to BQ here: https://kokoro.corp.google.com/job/grpc/job/macos/job/pull_request/job/grpc_basictests_opt/1515/ - if you check the commit this is built on, the flags for this job were changed to upload its results to BQ