### PR TITLE
Fix use of Cronet refcount

### DIFF
--- a/src/core/ext/transport/cronet/transport/cronet_transport.c
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.c
@@ -195,22 +195,21 @@ typedef struct stream_obj stream_obj;
 
 #ifndef NDEBUG
 #define GRPC_CRONET_STREAM_REF(stream, reason) \
-grpc_cronet_stream_ref((stream), (reason))
+  grpc_cronet_stream_ref((stream), (reason))
 #define GRPC_CRONET_STREAM_UNREF(exec_ctx, stream, reason) \
-grpc_cronet_stream_unref((exec_ctx), (stream), (reason))
+  grpc_cronet_stream_unref((exec_ctx), (stream), (reason))
 void grpc_cronet_stream_ref(stream_obj *s, const char *reason) {
   grpc_stream_ref(s->refcount, reason);
 }
-void grpc_cronet_stream_unref(grpc_exec_ctx *exec_ctx, stream_obj *s, const char *reason) {
+void grpc_cronet_stream_unref(grpc_exec_ctx *exec_ctx, stream_obj *s,
+                              const char *reason) {
   grpc_stream_unref(exec_ctx, s->refcount, reason);
 }
 #else
 #define GRPC_CRONET_STREAM_REF(stream, reason) grpc_cronet_stream_ref((stream))
 #define GRPC_CRONET_STREAM_UNREF(exec_ctx, stream, reason) \
-grpc_cronet_stream_unref((exec_ctx), (stream))
-void grpc_cronet_stream_ref(stream_obj *s) {
-  grpc_stream_ref(s->refcount);
-}
+  grpc_cronet_stream_unref((exec_ctx), (stream))
+void grpc_cronet_stream_ref(stream_obj *s) { grpc_stream_ref(s->refcount); }
 void grpc_cronet_stream_unref(grpc_exec_ctx *exec_ctx, stream_obj *s) {
   grpc_stream_unref(exec_ctx, s->refcount);
 }


### PR DESCRIPTION
It turns out that Cronet transport never used the stream refcount object (passed in by `init_stream`). When a call is unref'ed, the stream may be destroyed before the corresponding Cronet stream is done with callbacks, thus introducing crash.

This PR refs the refcount object when a stream is initiated at Cronet transport layer. Unref happens when Cronet issues a finishing callback (either on_succeeded, on_failed, or on_canceled). This guarantees that even the call is unref'ed, the stream context is still valid when the finishing callback happens

The second commit polishes the exec_ctx usage in Cronet transport. In particular, when Cronet issues a callback, the execution context is created immediately. The context is flushed when the callback returns. This is the recommended way of using exec_ctx. It also guarantees that there is no recursive exec_ctx init/flush in a single callback's call stack.