### PR TITLE
PHP: backport master features into v1.6.x branch

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
   <email>grpc-packages@google.com</email>
   <active>yes</active>
  </lead>
- <date>2017-05-22</date>
+ <date>2017-08-24</date>
  <time>16:06:07</time>
  <version>
   <release>1.6.0RC1</release>
@@ -22,13 +22,9 @@
  </stability>
  <license>Apache 2.0</license>
  <notes>
-- Fixed some memory leaks #9559, #10996
-- Disabled cares dependency from gRPC C Core #10940
-- De-coupled protobuf dependency #11112
-- Fixed extension reported version #10842
-- Added config.w32 for Windows support #8161
-- Fixed PHP distrib test after cc files were added #11193
-- Fixed protoc plugin comment escape bug #11025
+- License changed to Apache 2.0
+- Added support for php_namespace option in codegen plugin #11886
+- Updated gRPC C Core library version 1.6
  </notes>
  <contents>
   <dir baseinstalldir="/" name="/">

--- a/src/php/ext/grpc/call_credentials.c
+++ b/src/php/ext/grpc/call_credentials.c
@@ -179,7 +179,7 @@ void plugin_get_metadata(void *ptr, grpc_auth_metadata_context context,
   grpc_metadata_array metadata;
   bool cleanup = true;
 
-  if (Z_TYPE_P(retval) != IS_ARRAY) {
+  if (retval == NULL || Z_TYPE_P(retval) != IS_ARRAY) {
     cleanup = false;
     code = GRPC_STATUS_INVALID_ARGUMENT;
   } else if (!create_metadata_array(retval, &metadata)) {

--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -135,6 +135,8 @@ PHP_METHOD(ChannelCredentials, createSsl) {
 
   pem_key_cert_pair.private_key = pem_key_cert_pair.cert_chain = NULL;
 
+  grpc_set_ssl_roots_override_callback(get_ssl_roots_override);
+
   /* "|s!s!s!" == 3 optional nullable strings */
   if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|s!s!s!",
                             &pem_root_certs, &root_certs_length,
@@ -148,7 +150,7 @@ PHP_METHOD(ChannelCredentials, createSsl) {
   }
 
   php_grpc_int hashkey_len = root_certs_length + cert_chain_length;
-  char hashkey[hashkey_len];
+  char *hashkey = emalloc(hashkey_len);
   if (root_certs_length > 0) {
     strcpy(hashkey, pem_root_certs);
   }
@@ -164,6 +166,7 @@ PHP_METHOD(ChannelCredentials, createSsl) {
       pem_key_cert_pair.private_key == NULL ? NULL : &pem_key_cert_pair, NULL);
   zval *creds_object = grpc_php_wrap_channel_credentials(creds, hashstr, false
                                                          TSRMLS_CC);
+  efree(hashkey);
   RETURN_DESTROY_ZVAL(creds_object);
 }
 
@@ -176,6 +179,8 @@ PHP_METHOD(ChannelCredentials, createSsl) {
 PHP_METHOD(ChannelCredentials, createComposite) {
   zval *cred1_obj;
   zval *cred2_obj;
+
+  grpc_set_ssl_roots_override_callback(get_ssl_roots_override);
 
   /* "OO" == 2 Objects */
   if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "OO", &cred1_obj,
@@ -245,7 +250,6 @@ void grpc_init_channel_credentials(TSRMLS_D) {
   zend_class_entry ce;
   INIT_CLASS_ENTRY(ce, "Grpc\\ChannelCredentials",
                    channel_credentials_methods);
-  grpc_set_ssl_roots_override_callback(get_ssl_roots_override);
   ce.create_object = create_wrapped_grpc_channel_credentials;
   grpc_ce_channel_credentials = zend_register_internal_class(&ce TSRMLS_CC);
   PHP_GRPC_INIT_HANDLER(wrapped_grpc_channel_credentials,

--- a/src/php/ext/grpc/php_grpc.h
+++ b/src/php/ext/grpc/php_grpc.h
@@ -49,14 +49,16 @@ PHP_MINIT_FUNCTION(grpc);
 PHP_MSHUTDOWN_FUNCTION(grpc);
 /* Displays information about the module */
 PHP_MINFO_FUNCTION(grpc);
+/* Code that runs at request start */
+PHP_RINIT_FUNCTION(grpc);
 
 /*
   Declare any global variables you may need between the BEGIN
   and END macros here:
-
-ZEND_BEGIN_MODULE_GLOBALS(grpc)
-ZEND_END_MODULE_GLOBALS(grpc)
 */
+ZEND_BEGIN_MODULE_GLOBALS(grpc)
+  zend_bool initialized;
+ZEND_END_MODULE_GLOBALS(grpc)
 
 /* In every utility function you add that needs to use variables
    in php_grpc_globals, call TSRMLS_FETCH(); after declaring other

--- a/src/php/lib/Grpc/UnaryCall.php
+++ b/src/php/lib/Grpc/UnaryCall.php
@@ -40,13 +40,11 @@ class UnaryCall extends AbstractCall
         if (isset($options['flags'])) {
             $message_array['flags'] = $options['flags'];
         }
-        $event = $this->call->startBatch([
+        $this->call->startBatch([
             OP_SEND_INITIAL_METADATA => $metadata,
-            OP_RECV_INITIAL_METADATA => true,
             OP_SEND_MESSAGE => $message_array,
             OP_SEND_CLOSE_FROM_CLIENT => true,
         ]);
-        $this->metadata = $event->metadata;
     }
 
     /**
@@ -56,14 +54,32 @@ class UnaryCall extends AbstractCall
      */
     public function wait()
     {
-        $event = $this->call->startBatch([
+        $batch = [
             OP_RECV_MESSAGE => true,
             OP_RECV_STATUS_ON_CLIENT => true,
-        ]);
-
+        ];
+        if ($this->metadata === null) {
+            $batch[OP_RECV_INITIAL_METADATA] = true;
+        }
+        $event = $this->call->startBatch($batch);
+        if ($this->metadata === null) {
+            $this->metadata = $event->metadata;
+        }
         $status = $event->status;
         $this->trailing_metadata = $status->metadata;
 
         return [$this->_deserializeResponse($event->message), $status];
+    }
+
+    /**
+     * @return mixed The metadata sent by the server
+     */
+    public function getMetadata()
+    {
+        if ($this->metadata === null) {
+            $event = $this->call->startBatch([OP_RECV_INITIAL_METADATA => true]);
+            $this->metadata = $event->metadata;
+        }
+        return $this->metadata;
     }
 }

--- a/templates/package.xml.template
+++ b/templates/package.xml.template
@@ -12,7 +12,7 @@
     <email>grpc-packages@google.com</email>
     <active>yes</active>
    </lead>
-   <date>2017-05-22</date>
+   <date>2017-08-24</date>
    <time>16:06:07</time>
    <version>
     <release>${settings.php_version.php()}</release>
@@ -24,13 +24,9 @@
    </stability>
    <license>Apache 2.0</license>
    <notes>
-  - Fixed some memory leaks #9559, #10996
-  - Disabled cares dependency from gRPC C Core #10940
-  - De-coupled protobuf dependency #11112
-  - Fixed extension reported version #10842
-  - Added config.w32 for Windows support #8161
-  - Fixed PHP distrib test after cc files were added #11193
-  - Fixed protoc plugin comment escape bug #11025
+  - License changed to Apache 2.0
+  - Added support for php_namespace option in codegen plugin #11886
+  - Updated gRPC C Core library version 1.6
    </notes>
    <contents>
     <dir baseinstalldir="/" name="/">


### PR DESCRIPTION
Just cherry-pick and squash all relevant PHP PRs into the `v1.6.x` branch. All previously reviewed.
