### PR TITLE
Set grpc CleanUpThread to daemon

### DIFF
--- a/src/python/grpcio/grpc/_common.py
+++ b/src/python/grpcio/grpc/_common.py
@@ -150,6 +150,7 @@ class CleanupThread(threading.Thread):
             kwargs: Keyword arguments passed to threading.Thread constructor.
         """
         super(CleanupThread, self).__init__(*args, **kwargs)
+        self.daemon = True
         self._behavior = behavior
 
     def join(self, timeout=None):


### PR DESCRIPTION
We are experiencing deadlock on shutdown in the cleanup code (see stack below). Setting thread to daemon should be fine, all it does is prevent blocking on the thread exiting but the interpreter is quitting anyway. @nathanielmanistaatgoogle 

```
  File "/usr/drte/v1/python-2.7.7/lib/python2.7/threading.py", line 1107, in _exitfunc
    t.join()
  File "/home/ubuntu/bazel_output/bazel-sandbox/8317233754796682900/execroot/__main__/bazel-out/local-fastbuild/bin/metaserver/controllers/api_v2/tests/seen_state/seen_state_tests.runfiles/__main__//metaserver/controllers/api_v2/tests/seen_state/seen_state_tests_bin-piplib/grpc/_common.py", line 177, in join
    super(CleanupThread, self).join(timeout)
  File "/usr/drte/v1/python-2.7.7/lib/python2.7/threading.py", line 949, in join
    self.__block.wait()
  File "/usr/drte/v1/python-2.7.7/lib/python2.7/threading.py", line 339, in wait
    waiter.acquire()
```