### PR TITLE
Add Ruby bindings for functions that consume raw file descriptors.

### DIFF
--- a/src/ruby/ext/grpc/rb_channel.c
+++ b/src/ruby/ext/grpc/rb_channel.c
@@ -28,6 +28,8 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
+#include <grpc/support/port_platform.h>
+#include <grpc/grpc_posix.h>
 #include "rb_call.h"
 #include "rb_channel_args.h"
 #include "rb_channel_credentials.h"
@@ -260,6 +262,65 @@ static VALUE grpc_rb_channel_init(int argc, VALUE *argv, VALUE self) {
   rb_ivar_set(self, id_target, target);
   return self;
 }
+
+/*
+  call-seq:
+    ch = Channel.insecure_create_from_fd("fd:42", 42, {'arg1': 'value1'})
+
+  Creates channel instances from an existing file descriptor. */
+static VALUE grpc_rb_channel_insecure_create_from_fd(
+    VALUE klass, VALUE rb_target, VALUE rb_fd, VALUE rb_args) {
+#ifdef GPR_SUPPORT_CHANNELS_FROM_FD
+  VALUE self;
+  grpc_rb_channel *wrapper = NULL;
+  grpc_channel *ch = NULL;
+  grpc_channel_args args;
+  channel_init_try_register_stack stack;
+  int stop_waiting_for_thread_start = 0;
+  MEMZERO(&args, grpc_channel_args, 1);
+
+  grpc_ruby_once_init();
+  rb_thread_call_without_gvl(
+      wait_until_channel_polling_thread_started_no_gil,
+      &stop_waiting_for_thread_start,
+      wait_until_channel_polling_thread_started_unblocking_func,
+      &stop_waiting_for_thread_start);
+
+  if (TYPE(rb_fd) != T_FIXNUM) {
+    rb_raise(rb_eTypeError, "bad fd, wanted an integer");
+    return Qnil;
+  }
+
+  grpc_rb_hash_convert_to_channel_args(rb_args, &args);
+
+  self = grpc_rb_channel_alloc(klass);
+  TypedData_Get_Struct(self, grpc_rb_channel, &grpc_channel_data_type, wrapper);
+  ch = grpc_insecure_channel_create_from_fd(StringValueCStr(rb_target),
+                                            NUM2INT(rb_fd), &args);
+  GPR_ASSERT(ch);
+  stack.channel = ch;
+  stack.wrapper = wrapper;
+  rb_thread_call_without_gvl(
+      channel_init_try_register_connection_polling_without_gil, &stack, NULL,
+      NULL);
+
+  if (args.args != NULL) {
+    xfree(args.args); /* Allocated by grpc_rb_hash_convert_to_channel_args */
+  }
+  if (ch == NULL) {
+    rb_raise(rb_eRuntimeError, "could not create an rpc channel to target:%s",
+             StringValueCStr(rb_target));
+    return Qnil;
+  }
+  rb_ivar_set(self, id_target, rb_target);
+  return self;
+#else /* GPR_SUPPORT_CHANNELS_FROM_FD */
+  rb_raise(
+      rb_eNotImpError,
+      "insecure_create_from_fd not implemented on this platform");
+#endif  /* GPR_SUPPORT_CHANNELS_FROM_FD */
+}
+
 
 typedef struct get_state_stack {
   bg_watched_channel *bg;
@@ -794,6 +855,10 @@ void Init_grpc_channel() {
   rb_define_method(grpc_rb_cChannel, "initialize", grpc_rb_channel_init, -1);
   rb_define_method(grpc_rb_cChannel, "initialize_copy",
                    grpc_rb_cannot_init_copy, 1);
+
+  /* Provides a Ruby constructor for wrapping an existing file descriptor */
+  rb_define_singleton_method(grpc_rb_cChannel, "insecure_create_from_fd",
+                             grpc_rb_channel_insecure_create_from_fd, 3);
 
   /* Add ruby analogues of the Channel methods. */
   rb_define_method(grpc_rb_cChannel, "connectivity_state",

--- a/src/ruby/ext/grpc/rb_server.c
+++ b/src/ruby/ext/grpc/rb_server.c
@@ -25,6 +25,8 @@
 #include <grpc/grpc_security.h>
 #include <grpc/support/atm.h>
 #include <grpc/support/log.h>
+#include <grpc/support/port_platform.h>
+#include <grpc/grpc_posix.h>
 #include "rb_byte_buffer.h"
 #include "rb_call.h"
 #include "rb_channel_args.h"
@@ -310,6 +312,29 @@ static VALUE grpc_rb_server_add_http2_port(VALUE self, VALUE port,
   return INT2NUM(recvd_port);
 }
 
+static VALUE grpc_rb_server_add_insecure_channel_from_fd(VALUE self, VALUE rb_fd) {
+#ifdef GPR_SUPPORT_CHANNELS_FROM_FD
+  grpc_rb_server *s = NULL;
+
+  TypedData_Get_Struct(self, grpc_rb_server, &grpc_rb_server_data_type, s);
+  if (s->wrapped == NULL) {
+    rb_raise(rb_eRuntimeError, "destroyed!");
+    return Qnil;
+  }
+  if (TYPE(rb_fd) != T_FIXNUM) {
+    rb_raise(rb_eTypeError, "bad fd, wanted an integer");
+    return Qnil;
+  }
+
+  grpc_server_add_insecure_channel_from_fd(s->wrapped, NULL, NUM2INT(rb_fd));
+  return Qnil;
+#else /* GPR_SUPPORT_CHANNELS_FROM_FD */
+  rb_raise(
+      rb_eNotImpError,
+      "add_insecure_channel_from_fd not implemented on this platform.");
+#endif  /* GPR_SUPPORT_CHANNELS_FROM_FD */
+}
+
 void Init_grpc_server() {
   grpc_rb_cServer =
       rb_define_class_under(grpc_rb_mGrpcCore, "Server", rb_cObject);
@@ -330,6 +355,8 @@ void Init_grpc_server() {
   rb_define_alias(grpc_rb_cServer, "close", "destroy");
   rb_define_method(grpc_rb_cServer, "add_http2_port",
                    grpc_rb_server_add_http2_port, 2);
+  rb_define_method(grpc_rb_cServer, "add_insecure_channel_from_fd",
+                   grpc_rb_server_add_insecure_channel_from_fd, 1);
   id_at = rb_intern("at");
   id_insecure_server = rb_intern("this_port_is_insecure");
 }

--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -150,7 +150,7 @@ module GRPC
     include Core::TimeConsts
     extend ::Forwardable
 
-    def_delegators :@server, :add_http2_port
+    def_delegators :@server, :add_http2_port, :add_insecure_channel_from_fd
 
     # Default thread pool size is 30
     DEFAULT_POOL_SIZE = 30


### PR DESCRIPTION
This is useful for clients/servers that run as process pool workers
accepting from a shared socket ("prefork model").

* `Channel.insecure_create_from_fd` binds
  `grpc_insecure_channel_create_from_fd`

* `RpcServer.add_insecure_channel_from_fd` binds
  `grpc_server_add_insecure_channel_from_fd`.

Also includes basic tests showing how to consume file descriptors from
the environment, because the C docs are unclear about expected FD state.