### PR TITLE
Support features in grpc_package

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -106,7 +106,7 @@ def grpc_sh_test(name, srcs, args = [], data = []):
     args = args,
     data = data)
 
-def grpc_package(name, visibility = "private"):
+def grpc_package(name, visibility = "private", features = []):
   if visibility == "tests":
     visibility = ["//test:__subpackages__"]
   elif visibility == "public":
@@ -118,5 +118,6 @@ def grpc_package(name, visibility = "private"):
 
   if len(visibility) != 0:
     native.package(
-      default_visibility = visibility
+      default_visibility = visibility,
+      features = features
     )

--- a/test/core/network_benchmarks/BUILD
+++ b/test/core/network_benchmarks/BUILD
@@ -14,16 +14,11 @@
 
 load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
 
-grpc_package(name = "test/core/network_benchmarks")
+grpc_package(name = "test/core/network_benchmarks",
+             features = ["-layering_check", "-parse_headers" ]
+)
 
 licenses(["notice"])  # Apache v2
-
-package(
-    features = [
-        "-layering_check",
-        "-parse_headers",
-    ],
-)
 
 grpc_cc_binary(
     name = "low_level_ping_pong",


### PR DESCRIPTION
bazel complains when there are two package in a BUILD file