### PR TITLE
Deflake ruby artifact build on Kokoro

### DIFF
--- a/tools/distrib/docker_for_windows.rb
+++ b/tools/distrib/docker_for_windows.rb
@@ -23,11 +23,21 @@ def docker_for_windows_image()
   dockerfile = File.join(grpc_root, 'third_party', 'rake-compiler-dock', 'Dockerfile') 
   dockerpath = File.dirname(dockerfile)
   version = Digest::SHA1.file(dockerfile).hexdigest
-  image_name = 'grpc/rake-compiler-dock:' + version
-  cmd = "docker build -t #{image_name} --file #{dockerfile} #{dockerpath}"
-  puts cmd
-  system cmd
-  raise "Failed to build the docker image." unless $? == 0
+  image_name = 'rake-compiler-dock_' + version
+  # if "DOCKERHUB_ORGANIZATION" env is set, we try to pull the pre-built
+  # rake-compiler-dock image from dockerhub rather then building from scratch.
+  if ENV.has_key?('DOCKERHUB_ORGANIZATION')
+    image_name = ENV['DOCKERHUB_ORGANIZATION'] + '/' + image_name
+    cmd = "docker pull #{image_name}"
+    puts cmd
+    system cmd
+    raise "Failed to pull the docker image." unless $? == 0
+  else
+    cmd = "docker build -t #{image_name} --file #{dockerfile} #{dockerpath}"
+    puts cmd
+    system cmd
+    raise "Failed to build the docker image." unless $? == 0
+  end
   image_name
 end
 

--- a/tools/dockerfile/push_testing_images.sh
+++ b/tools/dockerfile/push_testing_images.sh
@@ -29,7 +29,7 @@ cd -
 
 DOCKERHUB_ORGANIZATION=grpctesting
 
-for DOCKERFILE_DIR in tools/dockerfile/test/* tools/dockerfile/grpc_artifact_* tools/dockerfile/interoptest/*
+for DOCKERFILE_DIR in tools/dockerfile/test/* tools/dockerfile/grpc_artifact_* tools/dockerfile/interoptest/* third_party/rake-compiler-dock
 do
   # Generate image name based on Dockerfile checksum. That works well as long
   # as can count on dockerfiles being written in a way that changing the logical 


### PR DESCRIPTION
Currently linux artifact build on Kokoro is flaky (and slow) because  rake rebuilds a large Dockerfile each time the build runs.
This PR introduces the same docker image caching logic we use for run_tests.py.