### PR TITLE
PHP: remove invalid include-file and adjust include-file sort

### DIFF
--- a/src/php/ext/grpc/byte_buffer.c
+++ b/src/php/ext/grpc/byte_buffer.c
@@ -16,23 +16,11 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
-#include <ext/spl/spl_exceptions.h>
-#include "php_grpc.h"
-
-#include <string.h>
 
 #include "byte_buffer.h"
 
-#include <grpc/grpc.h>
 #include <grpc/byte_buffer_reader.h>
-#include <grpc/slice.h>
 
 grpc_byte_buffer *string_to_byte_buffer(char *string, size_t length) {
   grpc_slice slice = grpc_slice_from_copied_buffer(string, length);

--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -18,25 +18,12 @@
 
 #include "call.h"
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
 #include <ext/spl/spl_exceptions.h>
-#include "php_grpc.h"
-#include "call_credentials.h"
-
 #include <zend_exceptions.h>
-#include <zend_hash.h>
-
-#include <stdbool.h>
 
 #include <grpc/support/alloc.h>
-#include <grpc/grpc.h>
 
+#include "call_credentials.h"
 #include "completion_queue.h"
 #include "timeval.h"
 #include "channel.h"
@@ -230,7 +217,7 @@ PHP_METHOD(Call, __construct) {
   }
   wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(channel_obj);
   gpr_mu_lock(&channel->wrapper->mu);
-  if (channel->wrapper == NULL || channel->wrapper->wrapped == NULL) {
+  if (channel->wrapper->wrapped == NULL) {
     zend_throw_exception(spl_ce_InvalidArgumentException,
                          "Call cannot be constructed from a closed Channel",
                          1 TSRMLS_CC);
@@ -251,7 +238,6 @@ PHP_METHOD(Call, __construct) {
   grpc_slice_unref(method_slice);
   grpc_slice_unref(host_slice);
   call->owned = true;
-  call->channel = channel;
   gpr_mu_unlock(&channel->wrapper->mu);
 }
 
@@ -271,15 +257,6 @@ PHP_METHOD(Call, startBatch) {
   zval *message_value;
   zval *message_flags;
   wrapped_grpc_call *call = Z_WRAPPED_GRPC_CALL_P(getThis());
-  if (call->channel) {
-    // startBatch in gRPC PHP server doesn't have channel in it.
-    if (call->channel->wrapper == NULL ||
-        call->channel->wrapper->wrapped == NULL) {
-      zend_throw_exception(spl_ce_RuntimeException,
-                           "startBatch Error. Channel is closed",
-                           1 TSRMLS_CC);
-    }
-  }
   
   grpc_op ops[8];
   size_t op_num = 0;

--- a/src/php/ext/grpc/call.h
+++ b/src/php/ext/grpc/call.h
@@ -19,17 +19,7 @@
 #ifndef NET_GRPC_PHP_GRPC_CALL_H_
 #define NET_GRPC_PHP_GRPC_CALL_H_
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
 #include "php_grpc.h"
-#include "channel.h"
-
-#include <grpc/grpc.h>
 
 /* Class entry for the Call PHP class */
 extern zend_class_entry *grpc_ce_call;
@@ -38,7 +28,6 @@ extern zend_class_entry *grpc_ce_call;
 PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_call)
   bool owned;
   grpc_call *wrapped;
-  wrapped_grpc_channel* channel;
 PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_call)
 
 #if PHP_MAJOR_VERSION < 7

--- a/src/php/ext/grpc/call_credentials.c
+++ b/src/php/ext/grpc/call_credentials.c
@@ -16,27 +16,15 @@
  *
  */
 
-#include "channel_credentials.h"
 #include "call_credentials.h"
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
 #include <ext/spl/spl_exceptions.h>
-#include "php_grpc.h"
-#include "call.h"
-
 #include <zend_exceptions.h>
-#include <zend_hash.h>
 
-#include <grpc/grpc.h>
-#include <grpc/grpc_security.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
+
+#include "call.h"
 
 zend_class_entry *grpc_ce_call_credentials;
 #if PHP_MAJOR_VERSION >= 7

--- a/src/php/ext/grpc/call_credentials.h
+++ b/src/php/ext/grpc/call_credentials.h
@@ -19,17 +19,9 @@
 #ifndef NET_GRPC_PHP_GRPC_CALL_CREDENTIALS_H_
 #define NET_GRPC_PHP_GRPC_CALL_CREDENTIALS_H_
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
 #include "php_grpc.h"
 
-#include "grpc/grpc.h"
-#include "grpc/grpc_security.h"
+#include <grpc/grpc_security.h>
 
 /* Class entry for the CallCredentials PHP class */
 extern zend_class_entry *grpc_ce_call_credentials;

--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -18,13 +18,6 @@
 
 #include "channel.h"
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
 #include <ext/standard/php_var.h>
 #include <ext/standard/sha1.h>
 #if PHP_MAJOR_VERSION < 7
@@ -33,19 +26,13 @@
 #include <zend_smart_str.h>
 #endif
 #include <ext/spl/spl_exceptions.h>
-#include "php_grpc.h"
-
 #include <zend_exceptions.h>
 
-#include <stdbool.h>
-
-#include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/support/alloc.h>
 
 #include "completion_queue.h"
 #include "channel_credentials.h"
-#include "server.h"
 #include "timeval.h"
 
 zend_class_entry *grpc_ce_channel;
@@ -54,51 +41,47 @@ static zend_object_handlers channel_ce_handlers;
 #endif
 static gpr_mu global_persistent_list_mu;
 int le_plink;
-int le_bound;
 extern HashTable grpc_persistent_list;
-extern HashTable grpc_target_upper_bound_map;
-
-void free_grpc_channel_wrapper(grpc_channel_wrapper* channel, bool free_channel) {
-  if (free_channel) {
-    grpc_channel_destroy(channel->wrapped);
-    channel->wrapped = NULL;
-  }
-  free(channel->target);
-  free(channel->args_hashstr);
-  free(channel->creds_hashstr);
-  free(channel->key);
-  channel->target = NULL;
-  channel->args_hashstr = NULL;
-  channel->creds_hashstr = NULL;
-  channel->key = NULL;
-}
-
-void php_grpc_channel_ref(grpc_channel_wrapper* wrapper) {
-  gpr_mu_lock(&wrapper->mu);
-  wrapper->ref_count += 1;
-  gpr_mu_unlock(&wrapper->mu);
-}
-
-void php_grpc_channel_unref(grpc_channel_wrapper* wrapper) {
-  gpr_mu_lock(&wrapper->mu);
-  wrapper->ref_count -= 1;
-  if (wrapper->ref_count == 0) {
-    free_grpc_channel_wrapper(wrapper, true);
-    gpr_mu_unlock(&wrapper->mu);
-    free(wrapper);
-    wrapper = NULL;
-    return;
-  }
-  gpr_mu_unlock(&wrapper->mu);
-}
 
 /* Frees and destroys an instance of wrapped_grpc_channel */
 PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_channel)
   // In_persistent_list is used when the user don't close the channel,
   // In this case, channels not in the list should be freed.
+  bool in_persistent_list = true;
   if (p->wrapper != NULL) {
-    php_grpc_channel_unref(p->wrapper);
-    p->wrapper = NULL;
+    gpr_mu_lock(&p->wrapper->mu);
+    if (p->wrapper->wrapped != NULL) {
+      if (p->wrapper->is_valid) {
+        php_grpc_zend_resource *rsrc;
+        php_grpc_int key_len = strlen(p->wrapper->key);
+        // only destroy the channel here if not found in the persistent list
+        gpr_mu_lock(&global_persistent_list_mu);
+        if (!(PHP_GRPC_PERSISTENT_LIST_FIND(&grpc_persistent_list, p->wrapper->key,
+                                            key_len, rsrc))) {
+          in_persistent_list = false;
+          grpc_channel_destroy(p->wrapper->wrapped);
+          free(p->wrapper->target);
+          free(p->wrapper->args_hashstr);
+          if (p->wrapper->creds_hashstr != NULL) {
+            free(p->wrapper->creds_hashstr);
+            p->wrapper->creds_hashstr = NULL;
+          }
+          free(p->wrapper->key);
+          p->wrapper->wrapped = NULL;
+          p->wrapper->target = NULL;
+          p->wrapper->args_hashstr = NULL;
+          p->wrapper->key = NULL;
+        }
+        gpr_mu_unlock(&global_persistent_list_mu);
+      }
+    }
+    p->wrapper->ref_count -= 1;
+    gpr_mu_unlock(&p->wrapper->mu);
+    if (!in_persistent_list) {
+      gpr_mu_destroy(&p->wrapper->mu);
+      free(p->wrapper);
+      p->wrapper = NULL;
+    }
   }
 PHP_GRPC_FREE_WRAPPED_FUNC_END()
 
@@ -166,67 +149,6 @@ void generate_sha1_str(char *sha1str, char *str, php_grpc_int len) {
   make_sha1_digest(sha1str, digest);
 }
 
-bool php_grpc_persistent_list_delete_unused_channel(
-    char* target,
-    target_bound_le_t* target_bound_status TSRMLS_DC) {
-  zval *data;
-  PHP_GRPC_HASH_FOREACH_VAL_START(&grpc_persistent_list, data)
-    php_grpc_zend_resource *rsrc  = (php_grpc_zend_resource*) PHP_GRPC_HASH_VALPTR_TO_VAL(data)
-    if (rsrc == NULL) {
-      break;
-    }
-    channel_persistent_le_t* le = rsrc->ptr;
-    // Find the channel sharing the same target.
-    if (strcmp(le->channel->target, target) == 0) {
-      // ref_count=1 means that only the map holds the reference to the channel.
-      if (le->channel->ref_count == 1) {
-        php_grpc_delete_persistent_list_entry(le->channel->key,
-                                              strlen(le->channel->key)
-                                              TSRMLS_CC);
-        target_bound_status->current_count -= 1;
-        if (target_bound_status->current_count < target_bound_status->upper_bound) {
-          return true;
-        }
-      }
-    }
-  PHP_GRPC_HASH_FOREACH_END()
-  return false;
-}
-
-target_bound_le_t* update_and_get_target_upper_bound(char* target, int bound) {
-  php_grpc_zend_resource *rsrc;
-  target_bound_le_t* target_bound_status;
-  php_grpc_int key_len = strlen(target);
-  if (!(PHP_GRPC_PERSISTENT_LIST_FIND(&grpc_target_upper_bound_map, target,
-      key_len, rsrc))) {
-    // Target is not not persisted.
-    php_grpc_zend_resource new_rsrc;
-    target_bound_status = malloc(sizeof(target_bound_le_t));
-    if (bound == -1) {
-      // If the bound is not set, use 1 as default.s
-      bound = 1;
-    }
-    target_bound_status->upper_bound = bound;
-    // Init current_count with 1. It should be add 1 when the channel is successfully
-    // created and minus 1 when it is removed from the persistent list.
-    target_bound_status->current_count = 0;
-    new_rsrc.type = le_bound;
-    new_rsrc.ptr = target_bound_status;
-    gpr_mu_lock(&global_persistent_list_mu);
-    PHP_GRPC_PERSISTENT_LIST_UPDATE(&grpc_target_upper_bound_map,
-                                    target, key_len, (void *)&new_rsrc);
-    gpr_mu_unlock(&global_persistent_list_mu);
-  } else {
-    // The target already in the map recording the upper bound.
-    // If no newer bound set, use the original now.
-    target_bound_status = (target_bound_le_t *)rsrc->ptr;
-    if (bound != -1) {
-      target_bound_status->upper_bound = bound;
-    }
-  }
-  return target_bound_status;
-}
-
 void create_channel(
     wrapped_grpc_channel *channel,
     char *target,
@@ -239,8 +161,6 @@ void create_channel(
     channel->wrapper->wrapped =
         grpc_secure_channel_create(creds->wrapped, target, &args, NULL);
   }
-  // There is an Grpc\Channel object refer to it.
-  php_grpc_channel_ref(channel->wrapper);
   efree(args.args);
 }
 
@@ -250,28 +170,7 @@ void create_and_add_channel_to_persistent_list(
     grpc_channel_args args,
     wrapped_grpc_channel_credentials *creds,
     char *key,
-    php_grpc_int key_len,
-    int target_upper_bound TSRMLS_DC) {
-  target_bound_le_t* target_bound_status =
-    update_and_get_target_upper_bound(target, target_upper_bound);
-  // Check the upper bound status before inserting to the persistent map.
-  if (target_bound_status->current_count >=
-      target_bound_status->upper_bound) {
-    if (!php_grpc_persistent_list_delete_unused_channel(
-          target, target_bound_status TSRMLS_CC)) {
-      // If no channel can be deleted from the persistent map,
-      // do not persist this one.
-      create_channel(channel, target, args, creds);
-      php_printf("[Warning] The number of channel for the"
-                 " target %s is maxed out bounded.\n", target);
-      php_printf("[Warning] Target upper bound: %d. Current size: %d.\n",
-                 target_bound_status->upper_bound,
-                 target_bound_status->current_count);
-      php_printf("[Warning] Target %s will not be persisted.\n", target);
-      return;
-    }
-  }
-  // There is space in the persistent map.
+    php_grpc_int key_len TSRMLS_DC) {
   php_grpc_zend_resource new_rsrc;
   channel_persistent_le_t *le;
   // this links each persistent list entry to a destructor
@@ -279,15 +178,12 @@ void create_and_add_channel_to_persistent_list(
   le = malloc(sizeof(channel_persistent_le_t));
 
   create_channel(channel, target, args, creds);
-  target_bound_status->current_count += 1;
 
   le->channel = channel->wrapper;
   new_rsrc.ptr = le;
   gpr_mu_lock(&global_persistent_list_mu);
   PHP_GRPC_PERSISTENT_LIST_UPDATE(&grpc_persistent_list, key, key_len,
                                   (void *)&new_rsrc);
-  // Persistent map refer to it.
-  php_grpc_channel_ref(channel->wrapper);
   gpr_mu_unlock(&global_persistent_list_mu);
 }
 
@@ -321,7 +217,6 @@ PHP_METHOD(Channel, __construct) {
   php_grpc_zend_resource *rsrc;
   bool force_new = false;
   zval *force_new_obj = NULL;
-  int target_upper_bound = -1;
 
   /* "sa" == 1 string, 1 array */
   if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sa", &target,
@@ -353,19 +248,6 @@ PHP_METHOD(Channel, __construct) {
       force_new = true;
     }
     php_grpc_zend_hash_del(array_hash, "force_new", sizeof("force_new"));
-  }
-
-  if (php_grpc_zend_hash_find(array_hash, "grpc_target_persist_bound",
-                              sizeof("grpc_target_persist_bound"),
-                              (void **)&force_new_obj) == SUCCESS) {
-    if (Z_TYPE_P(force_new_obj) != IS_LONG) {
-      zend_throw_exception(spl_ce_InvalidArgumentException,
-                           "plist_bound must be a number",
-                           1 TSRMLS_CC);
-    }
-    target_upper_bound = (int)Z_LVAL_P(force_new_obj);
-    php_grpc_zend_hash_del(array_hash, "grpc_target_persist_bound",
-                           sizeof("grpc_target_persist_bound"));
   }
 
   // parse the rest of the channel args array
@@ -401,11 +283,12 @@ PHP_METHOD(Channel, __construct) {
     strcat(key, creds->hashstr);
   }
   channel->wrapper = malloc(sizeof(grpc_channel_wrapper));
-  channel->wrapper->ref_count = 0;
   channel->wrapper->key = key;
   channel->wrapper->target = strdup(target);
   channel->wrapper->args_hashstr = strdup(sha1str);
   channel->wrapper->creds_hashstr = NULL;
+  channel->wrapper->ref_count = 1;
+  channel->wrapper->is_valid = true;
   if (creds != NULL && creds->hashstr != NULL) {
     php_grpc_int creds_hashstr_len = strlen(creds->hashstr);
     char *channel_creds_hashstr = malloc(creds_hashstr_len + 1);
@@ -423,7 +306,7 @@ PHP_METHOD(Channel, __construct) {
   } else if (!(PHP_GRPC_PERSISTENT_LIST_FIND(&grpc_persistent_list, key,
                                              key_len, rsrc))) {
     create_and_add_channel_to_persistent_list(
-        channel, target, args, creds, key, key_len, target_upper_bound TSRMLS_CC);
+        channel, target, args, creds, key, key_len TSRMLS_CC);
   } else {
     // Found a previously stored channel in the persistent list
     channel_persistent_le_t *le = (channel_persistent_le_t *)rsrc->ptr;
@@ -433,17 +316,20 @@ PHP_METHOD(Channel, __construct) {
          strcmp(creds->hashstr, le->channel->creds_hashstr) != 0)) {
       // somehow hash collision
       create_and_add_channel_to_persistent_list(
-          channel, target, args, creds, key, key_len, target_upper_bound TSRMLS_CC);
+          channel, target, args, creds, key, key_len TSRMLS_CC);
     } else {
       efree(args.args);
-      free_grpc_channel_wrapper(channel->wrapper, false);
-      gpr_mu_destroy(&channel->wrapper->mu);
+      if (channel->wrapper->creds_hashstr != NULL) {
+        free(channel->wrapper->creds_hashstr);
+        channel->wrapper->creds_hashstr = NULL;
+      }
+      free(channel->wrapper->creds_hashstr);
+      free(channel->wrapper->key);
+      free(channel->wrapper->target);
+      free(channel->wrapper->args_hashstr);
       free(channel->wrapper);
-      channel->wrapper = NULL;
       channel->wrapper = le->channel;
-      // One more Grpc\Channel object refer to it.
-      php_grpc_channel_ref(channel->wrapper);
-      update_and_get_target_upper_bound(target, target_upper_bound);
+      channel->wrapper->ref_count += 1;
     }
   }
 }
@@ -454,13 +340,13 @@ PHP_METHOD(Channel, __construct) {
  */
 PHP_METHOD(Channel, getTarget) {
   wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(getThis());
-  if (channel->wrapper == NULL) {
+  gpr_mu_lock(&channel->wrapper->mu);
+  if (channel->wrapper->wrapped == NULL) {
     zend_throw_exception(spl_ce_RuntimeException,
-                         "getTarget error."
-                         "Channel is already closed.", 1 TSRMLS_CC);
+                         "Channel already closed", 1 TSRMLS_CC);
+    gpr_mu_unlock(&channel->wrapper->mu);
     return;
   }
-  gpr_mu_lock(&channel->wrapper->mu);
   char *target = grpc_channel_get_target(channel->wrapper->wrapped);
   gpr_mu_unlock(&channel->wrapper->mu);
   PHP_GRPC_RETVAL_STRING(target, 1);
@@ -474,14 +360,16 @@ PHP_METHOD(Channel, getTarget) {
  */
 PHP_METHOD(Channel, getConnectivityState) {
   wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(getThis());
-  if (channel->wrapper == NULL) {
+  gpr_mu_lock(&channel->wrapper->mu);
+  if (channel->wrapper->wrapped == NULL) {
     zend_throw_exception(spl_ce_RuntimeException,
-                         "getConnectivityState error."
-                         "Channel is already closed.", 1 TSRMLS_CC);
+                         "Channel already closed", 1 TSRMLS_CC);
+    gpr_mu_unlock(&channel->wrapper->mu);
     return;
   }
-  gpr_mu_lock(&channel->wrapper->mu);
+
   bool try_to_connect = false;
+
   /* "|b" == 1 optional bool */
   if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|b", &try_to_connect)
       == FAILURE) {
@@ -492,6 +380,11 @@ PHP_METHOD(Channel, getConnectivityState) {
   }
   int state = grpc_channel_check_connectivity_state(channel->wrapper->wrapped,
                                                     (int)try_to_connect);
+  // this can happen if another shared Channel object close the underlying
+  // channel
+  if (state == GRPC_CHANNEL_SHUTDOWN) {
+    channel->wrapper->wrapped = NULL;
+  }
   gpr_mu_unlock(&channel->wrapper->mu);
   RETURN_LONG(state);
 }
@@ -505,13 +398,14 @@ PHP_METHOD(Channel, getConnectivityState) {
  */
 PHP_METHOD(Channel, watchConnectivityState) {
   wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(getThis());
-  if (channel->wrapper == NULL) {
+  gpr_mu_lock(&channel->wrapper->mu);
+  if (channel->wrapper->wrapped == NULL) {
     zend_throw_exception(spl_ce_RuntimeException,
-                         "watchConnectivityState error"
-                         "Channel is already closed.", 1 TSRMLS_CC);
+                         "Channel already closed", 1 TSRMLS_CC);
+    gpr_mu_unlock(&channel->wrapper->mu);
     return;
   }
-  gpr_mu_lock(&channel->wrapper->mu);
+
   php_grpc_long last_state;
   zval *deadline_obj;
 
@@ -544,10 +438,46 @@ PHP_METHOD(Channel, watchConnectivityState) {
  */
 PHP_METHOD(Channel, close) {
   wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(getThis());
+  bool is_last_wrapper = false;
   if (channel->wrapper != NULL) {
-    php_grpc_channel_unref(channel->wrapper);
-    channel->wrapper = NULL;
+    // Channel_wrapper hasn't call close before.
+    gpr_mu_lock(&channel->wrapper->mu);
+    if (channel->wrapper->wrapped != NULL) {
+      if (channel->wrapper->is_valid) {
+        // Wrapped channel hasn't been destoryed by other wrapper.
+        grpc_channel_destroy(channel->wrapper->wrapped);
+        free(channel->wrapper->target);
+        free(channel->wrapper->args_hashstr);
+        free(channel->wrapper->creds_hashstr);
+        channel->wrapper->creds_hashstr = NULL;
+        channel->wrapper->target = NULL;
+        channel->wrapper->args_hashstr = NULL;
+        channel->wrapper->wrapped = NULL;
+        channel->wrapper->is_valid = false;
+
+        php_grpc_delete_persistent_list_entry(channel->wrapper->key,
+                                              strlen(channel->wrapper->key)
+                                              TSRMLS_CC);
+      }
+    }
+    channel->wrapper->ref_count -= 1;
+    if (channel->wrapper->ref_count == 0) {
+      // Mark that the wrapper can be freed because mu should be
+      // destroyed outside the lock.
+      is_last_wrapper = true;
+    }
+    gpr_mu_unlock(&channel->wrapper->mu);
   }
+  gpr_mu_lock(&global_persistent_list_mu);
+  if (is_last_wrapper) {
+    gpr_mu_destroy(&channel->wrapper->mu);
+    free(channel->wrapper->key);
+    free(channel->wrapper);
+  }
+  // Set channel->wrapper to NULL to avoid call close twice for the same
+  // channel.
+  channel->wrapper = NULL;
+  gpr_mu_unlock(&global_persistent_list_mu);
 }
 
 // Delete an entry from the persistent list
@@ -558,7 +488,11 @@ void php_grpc_delete_persistent_list_entry(char *key, php_grpc_int key_len
   gpr_mu_lock(&global_persistent_list_mu);
   if (PHP_GRPC_PERSISTENT_LIST_FIND(&grpc_persistent_list, key,
                                     key_len, rsrc)) {
+    channel_persistent_le_t *le;
+    le = (channel_persistent_le_t *)rsrc->ptr;
+    le->channel = NULL;
     php_grpc_zend_hash_del(&grpc_persistent_list, key, key_len+1);
+    free(le);
   }
   gpr_mu_unlock(&global_persistent_list_mu);
 }
@@ -571,136 +505,19 @@ static void php_grpc_channel_plink_dtor(php_grpc_zend_resource *rsrc
     return;
   }
   if (le->channel != NULL) {
-    php_grpc_channel_unref(le->channel);
-    le->channel = NULL;
-  }
-  free(le);
-  le = NULL;
-}
-
-// A destructor associated with each list entry from the target_bound map
-static void php_grpc_target_bound_dtor(php_grpc_zend_resource *rsrc
-                                        TSRMLS_DC) {
-  target_bound_le_t *le = (target_bound_le_t *) rsrc->ptr;
-  if (le == NULL) {
-    return;
-  }
-  free(le);
-  le = NULL;
-}
-
-#ifdef GRPC_PHP_DEBUG
-
-/**
-* Clean all channels in the persistent. Test only.
-* @return void
-*/
-PHP_METHOD(Channel, cleanPersistentList) {
-  zend_hash_clean(&grpc_persistent_list);
-  zend_hash_clean(&grpc_target_upper_bound_map);
-}
-
-char *grpc_connectivity_state_name(grpc_connectivity_state state) {
- switch (state) {
-   case GRPC_CHANNEL_IDLE:
-     return "IDLE";
-   case GRPC_CHANNEL_CONNECTING:
-     return "CONNECTING";
-   case GRPC_CHANNEL_READY:
-     return "READY";
-   case GRPC_CHANNEL_TRANSIENT_FAILURE:
-     return "TRANSIENT_FAILURE";
-   case GRPC_CHANNEL_SHUTDOWN:
-     return "SHUTDOWN";
- }
- return "UNKNOWN";
-}
-
-/**
-* Return the info about the current channel. Test only.
-* @return array
-*/
-PHP_METHOD(Channel, getChannelInfo) {
-  wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(getThis());
-  array_init(return_value);
-   // Info about the target
-  PHP_GRPC_ADD_STRING_TO_ARRAY(return_value, "target",
-              sizeof("target"), channel->wrapper->target, true);
-  // Info about the upper bound for the target
-  target_bound_le_t* target_bound_status =
-    update_and_get_target_upper_bound(channel->wrapper->target, -1);
-  PHP_GRPC_ADD_LONG_TO_ARRAY(return_value, "target_upper_bound",
-    sizeof("target_upper_bound"), target_bound_status->upper_bound);
-  PHP_GRPC_ADD_LONG_TO_ARRAY(return_value, "target_current_size",
-    sizeof("target_current_size"), target_bound_status->current_count);
-  // Info about key
-  PHP_GRPC_ADD_STRING_TO_ARRAY(return_value, "key",
-              sizeof("key"), channel->wrapper->key, true);
-  // Info about persistent channel ref_count
-  PHP_GRPC_ADD_LONG_TO_ARRAY(return_value, "ref_count",
-              sizeof("ref_count"), channel->wrapper->ref_count);
-  // Info about connectivity status
-  int state =
-      grpc_channel_check_connectivity_state(channel->wrapper->wrapped, (int)0);
-  // It should be set to 'true' in PHP 5.6.33
-  PHP_GRPC_ADD_LONG_TO_ARRAY(return_value, "connectivity_status",
-              sizeof("connectivity_status"), state);
-  PHP_GRPC_ADD_STRING_TO_ARRAY(return_value, "ob",
-              sizeof("ob"),
-              grpc_connectivity_state_name(state), true);
-  // Info about the channel is closed or not
-  PHP_GRPC_ADD_BOOL_TO_ARRAY(return_value, "is_valid",
-              sizeof("is_valid"), (channel->wrapper == NULL));
-}
-
-/**
-* Return an array of all channels in the persistent list. Test only.
-* @return array
-*/
-PHP_METHOD(Channel, getPersistentList) {
-  array_init(return_value);
-  zval *data;
-  PHP_GRPC_HASH_FOREACH_VAL_START(&grpc_persistent_list, data)
-    php_grpc_zend_resource *rsrc  =
-                (php_grpc_zend_resource*) PHP_GRPC_HASH_VALPTR_TO_VAL(data)
-    if (rsrc == NULL) {
-      break;
+    gpr_mu_lock(&le->channel->mu);
+    if (le->channel->wrapped != NULL) {
+      grpc_channel_destroy(le->channel->wrapped);
+      free(le->channel->args_hashstr);
+      le->channel->wrapped = NULL;
+      le->channel->target = NULL;
+      le->channel->args_hashstr = NULL;
+      free(le->channel->key);
+      le->channel->key = NULL;
     }
-    channel_persistent_le_t* le = rsrc->ptr;
-    zval* ret_arr;
-    PHP_GRPC_MAKE_STD_ZVAL(ret_arr);
-    array_init(ret_arr);
-    // Info about the target
-    PHP_GRPC_ADD_STRING_TO_ARRAY(ret_arr, "target",
-                sizeof("target"), le->channel->target, true);
-    // Info about the upper bound for the target
-    target_bound_le_t* target_bound_status =
-      update_and_get_target_upper_bound(le->channel->target, -1);
-    PHP_GRPC_ADD_LONG_TO_ARRAY(ret_arr, "target_upper_bound",
-      sizeof("target_upper_bound"), target_bound_status->upper_bound);
-    PHP_GRPC_ADD_LONG_TO_ARRAY(ret_arr, "target_current_size",
-      sizeof("target_current_size"), target_bound_status->current_count);
-    // Info about key
-    PHP_GRPC_ADD_STRING_TO_ARRAY(ret_arr, "key",
-                sizeof("key"), le->channel->key, true);
-    // Info about persistent channel ref_count
-    PHP_GRPC_ADD_LONG_TO_ARRAY(ret_arr, "ref_count",
-                sizeof("ref_count"), le->channel->ref_count);
-    // Info about connectivity status
-    int state =
-        grpc_channel_check_connectivity_state(le->channel->wrapped, (int)0);
-    // It should be set to 'true' in PHP 5.6.33
-    PHP_GRPC_ADD_LONG_TO_ARRAY(ret_arr, "connectivity_status",
-                sizeof("connectivity_status"), state);
-    PHP_GRPC_ADD_STRING_TO_ARRAY(ret_arr, "ob",
-                sizeof("ob"),
-                grpc_connectivity_state_name(state), true);
-    add_assoc_zval(return_value, le->channel->key, ret_arr);
-    PHP_GRPC_FREE_STD_ZVAL(ret_arr);
-  PHP_GRPC_HASH_FOREACH_END()
+    gpr_mu_unlock(&le->channel->mu);
+  }
 }
-#endif
-
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_construct, 0, 0, 2)
   ZEND_ARG_INFO(0, target)
@@ -722,18 +539,6 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_close, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
-#ifdef GRPC_PHP_DEBUG
-ZEND_BEGIN_ARG_INFO_EX(arginfo_getChannelInfo, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_cleanPersistentList, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
-ZEND_BEGIN_ARG_INFO_EX(arginfo_getPersistentList, 0, 0, 0)
-ZEND_END_ARG_INFO()
-#endif
-
-
 static zend_function_entry channel_methods[] = {
   PHP_ME(Channel, __construct, arginfo_construct,
          ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
@@ -745,14 +550,6 @@ static zend_function_entry channel_methods[] = {
          ZEND_ACC_PUBLIC)
   PHP_ME(Channel, close, arginfo_close,
          ZEND_ACC_PUBLIC)
-  #ifdef GRPC_PHP_DEBUG
-  PHP_ME(Channel, getChannelInfo, arginfo_getChannelInfo,
-         ZEND_ACC_PUBLIC)
-  PHP_ME(Channel, cleanPersistentList, arginfo_cleanPersistentList,
-         ZEND_ACC_PUBLIC)
-  PHP_ME(Channel, getPersistentList, arginfo_getPersistentList,
-         ZEND_ACC_PUBLIC)
-  #endif
   PHP_FE_END
 };
 
@@ -766,12 +563,6 @@ GRPC_STARTUP_FUNCTION(channel) {
       NULL, php_grpc_channel_plink_dtor, "Persistent Channel", module_number);
   zend_hash_init_ex(&grpc_persistent_list, 20, NULL,
                     EG(persistent_list).pDestructor, 1, 0);
-  // Register the target->upper_bound map.
-  le_bound = zend_register_list_destructors_ex(
-      NULL, php_grpc_target_bound_dtor, "Target Bound", module_number);
-  zend_hash_init_ex(&grpc_target_upper_bound_map, 20, NULL,
-                    EG(persistent_list).pDestructor, 1, 0);
-
   PHP_GRPC_INIT_HANDLER(wrapped_grpc_channel, channel_ce_handlers);
   return SUCCESS;
 }

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -19,16 +19,7 @@
 #ifndef NET_GRPC_PHP_GRPC_CHANNEL_H_
 #define NET_GRPC_PHP_GRPC_CHANNEL_H_
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
 #include "php_grpc.h"
-
-#include <grpc/grpc.h>
 
 /* Class entry for the PHP Channel class */
 extern zend_class_entry *grpc_ce_channel;
@@ -39,8 +30,12 @@ typedef struct _grpc_channel_wrapper {
   char *target;
   char *args_hashstr;
   char *creds_hashstr;
-  size_t ref_count;
   gpr_mu mu;
+  // is_valid is used to check the wrapped channel has been freed
+  // before to avoid double free.
+  bool is_valid;
+  // ref_count is used to let the last wrapper free related channel and key.
+  size_t ref_count;
 } grpc_channel_wrapper;
 
 /* Wrapper struct for grpc_channel that can be associated with a PHP object */
@@ -82,9 +77,5 @@ typedef struct _channel_persistent_le {
   grpc_channel_wrapper *channel;
 } channel_persistent_le_t;
 
-typedef struct _target_bound_le {
-  int upper_bound;
-  int current_count;
-} target_bound_le_t;
 
 #endif /* NET_GRPC_PHP_GRPC_CHANNEL_H_ */

--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -17,27 +17,16 @@
  */
 
 #include "channel_credentials.h"
-#include "call_credentials.h"
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
 #include <ext/standard/sha1.h>
 #include <ext/spl/spl_exceptions.h>
-#include "channel.h"
-#include "php_grpc.h"
-
 #include <zend_exceptions.h>
-#include <zend_hash.h>
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
-#include <grpc/grpc.h>
-#include <grpc/grpc_security.h>
+
+#include "call_credentials.h"
+#include "channel.h"
 
 zend_class_entry *grpc_ce_channel_credentials;
 #if PHP_MAJOR_VERSION >= 7

--- a/src/php/ext/grpc/channel_credentials.h
+++ b/src/php/ext/grpc/channel_credentials.h
@@ -19,17 +19,9 @@
 #ifndef NET_GRPC_PHP_GRPC_CHANNEL_CREDENTIALS_H_
 #define NET_GRPC_PHP_GRPC_CHANNEL_CREDENTIALS_H_
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include "php.h"
-#include "php_ini.h"
-#include "ext/standard/info.h"
 #include "php_grpc.h"
 
-#include "grpc/grpc.h"
-#include "grpc/grpc_security.h"
+#include <grpc/grpc_security.h>
 
 /* Class entry for the ChannelCredentials PHP class */
 extern zend_class_entry *grpc_ce_channel_credentials;

--- a/src/php/ext/grpc/completion_queue.c
+++ b/src/php/ext/grpc/completion_queue.c
@@ -18,8 +18,6 @@
 
 #include "completion_queue.h"
 
-#include <php.h>
-
 grpc_completion_queue *completion_queue;
 
 void grpc_php_init_completion_queue(TSRMLS_D) {

--- a/src/php/ext/grpc/config.m4
+++ b/src/php/ext/grpc/config.m4
@@ -4,14 +4,6 @@ PHP_ARG_ENABLE(grpc, whether to enable grpc support,
 PHP_ARG_ENABLE(coverage, whether to include code coverage symbols,
 [  --enable-coverage       Enable coverage support], no, no)
 
-PHP_ARG_ENABLE(tests, whether to compile helper methods for tests,
-[  --enable-tests          Enable tests methods], no, no)
-
-dnl Check whether to enable tests
-if test "$PHP_TESTS" != "no"; then
-  CPPFLAGS="$CPPFLAGS -DGRPC_PHP_DEBUG"
-fi
-
 if test "$PHP_GRPC" != "no"; then
   dnl Write more examples of tests here...
 

--- a/src/php/ext/grpc/php7_wrapper.h
+++ b/src/php/ext/grpc/php7_wrapper.h
@@ -46,8 +46,6 @@
    add_assoc_long_ex(val, key, key_len, str);
 #define PHP_GRPC_ADD_BOOL_TO_ARRAY(val, key, key_len, str) \
    add_assoc_bool_ex(val, key, key_len, str);
-#define PHP_GRPC_ADD_LONG_TO_RETVAL(val, key, key_len, str) \
-   add_assoc_long_ex(val, key, key_len+1, str);
 
 #define RETURN_DESTROY_ZVAL(val) \
   RETURN_ZVAL(val, false /* Don't execute copy constructor */, \
@@ -142,7 +140,7 @@ static inline int php_grpc_zend_hash_find(HashTable *ht, char *key, int len,
   zend_hash_update(plist, key, len+1, rsrc, sizeof(php_grpc_zend_resource), \
                    NULL)
 #define PHP_GRPC_PERSISTENT_LIST_SIZE(plist) \
-  *plist.nNumOfElements
+  plist.nTableSize
 
 #define PHP_GRPC_GET_CLASS_ENTRY(object) zend_get_class_entry(object TSRMLS_CC)
 
@@ -178,8 +176,6 @@ static inline int php_grpc_zend_hash_find(HashTable *ht, char *key, int len,
    add_assoc_long_ex(val, key, key_len - 1, str);
 #define PHP_GRPC_ADD_BOOL_TO_ARRAY(val, key, key_len, str) \
    add_assoc_bool_ex(val, key, key_len - 1, str);
-#define PHP_GRPC_ADD_LONG_TO_RETVAL(val, key, key_len, str) \
-   add_assoc_long_ex(val, key, key_len, str);
 
 #define RETURN_DESTROY_ZVAL(val) \
   RETVAL_ZVAL(val, false /* Don't execute copy constructor */, \

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -16,6 +16,8 @@
  *
  */
 
+#include "php_grpc.h"
+
 #include "call.h"
 #include "channel.h"
 #include "server.h"
@@ -25,19 +27,9 @@
 #include "server_credentials.h"
 #include "completion_queue.h"
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
-#include "php_grpc.h"
-
 ZEND_DECLARE_MODULE_GLOBALS(grpc)
 static PHP_GINIT_FUNCTION(grpc);
 HashTable grpc_persistent_list;
-HashTable grpc_target_upper_bound_map;
 /* {{{ grpc_functions[]
  *
  * Every user visible function must have an entry in grpc_functions[].
@@ -243,8 +235,6 @@ PHP_MSHUTDOWN_FUNCTION(grpc) {
   if (GRPC_G(initialized)) {
     zend_hash_clean(&grpc_persistent_list);
     zend_hash_destroy(&grpc_persistent_list);
-    zend_hash_clean(&grpc_target_upper_bound_map);
-    zend_hash_destroy(&grpc_target_upper_bound_map);
     grpc_shutdown_timeval(TSRMLS_C);
     grpc_php_shutdown_completion_queue(TSRMLS_C);
     grpc_shutdown();

--- a/src/php/ext/grpc/php_grpc.h
+++ b/src/php/ext/grpc/php_grpc.h
@@ -20,7 +20,20 @@
 #ifndef PHP_GRPC_H
 #define PHP_GRPC_H
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <stdbool.h>
+
+#include <php.h>
+#include <php_ini.h>
+#include <ext/standard/info.h>
+
+#include <grpc/grpc.h>
+
+#include "php7_wrapper.h"
+#include "version.h"
 
 extern zend_module_entry grpc_module_entry;
 #define phpext_grpc_ptr &grpc_module_entry
@@ -36,11 +49,6 @@ extern zend_module_entry grpc_module_entry;
 #ifdef ZTS
 #include "TSRM.h"
 #endif
-
-#include "php.h"
-#include "php7_wrapper.h"
-#include "grpc/grpc.h"
-#include "version.h"
 
 /* These are all function declarations */
 /* Code that runs at module initialization */

--- a/src/php/ext/grpc/server.c
+++ b/src/php/ext/grpc/server.c
@@ -16,29 +16,17 @@
  *
  */
 
-#include "call.h"
+#include "server.h"
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
 #include <ext/spl/spl_exceptions.h>
-#include "php_grpc.h"
-
 #include <zend_exceptions.h>
 
-#include <stdbool.h>
-
-#include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 #include <grpc/slice.h>
 #include <grpc/support/alloc.h>
 
+#include "call.h"
 #include "completion_queue.h"
-#include "server.h"
 #include "channel.h"
 #include "server_credentials.h"
 #include "timeval.h"

--- a/src/php/ext/grpc/server.h
+++ b/src/php/ext/grpc/server.h
@@ -19,16 +19,7 @@
 #ifndef NET_GRPC_PHP_GRPC_SERVER_H_
 #define NET_GRPC_PHP_GRPC_SERVER_H_
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
 #include "php_grpc.h"
-
-#include <grpc/grpc.h>
 
 /* Class entry for the Server PHP class */
 extern zend_class_entry *grpc_ce_server;

--- a/src/php/ext/grpc/server_credentials.c
+++ b/src/php/ext/grpc/server_credentials.c
@@ -18,21 +18,8 @@
 
 #include "server_credentials.h"
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
 #include <ext/spl/spl_exceptions.h>
-#include "php_grpc.h"
-
 #include <zend_exceptions.h>
-#include <zend_hash.h>
-
-#include <grpc/grpc.h>
-#include <grpc/grpc_security.h>
 
 zend_class_entry *grpc_ce_server_credentials;
 #if PHP_MAJOR_VERSION >= 7

--- a/src/php/ext/grpc/server_credentials.h
+++ b/src/php/ext/grpc/server_credentials.h
@@ -26,9 +26,9 @@
 #include <php.h>
 #include <php_ini.h>
 #include <ext/standard/info.h>
+
 #include "php_grpc.h"
 
-#include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 
 /* Class entry for the Server_Credentials PHP class */

--- a/src/php/ext/grpc/timeval.c
+++ b/src/php/ext/grpc/timeval.c
@@ -18,22 +18,8 @@
 
 #include "timeval.h"
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
 #include <ext/spl/spl_exceptions.h>
-#include "php_grpc.h"
-
 #include <zend_exceptions.h>
-
-#include <stdbool.h>
-
-#include <grpc/grpc.h>
-#include <grpc/support/time.h>
 
 zend_class_entry *grpc_ce_timeval;
 #if PHP_MAJOR_VERSION >= 7

--- a/src/php/ext/grpc/timeval.h
+++ b/src/php/ext/grpc/timeval.h
@@ -19,17 +19,7 @@
 #ifndef NET_GRPC_PHP_GRPC_TIMEVAL_H_
 #define NET_GRPC_PHP_GRPC_TIMEVAL_H_
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
 #include "php_grpc.h"
-
-#include <grpc/grpc.h>
-#include <grpc/support/time.h>
 
 /* Class entry for the Timeval PHP Class */
 extern zend_class_entry *grpc_ce_timeval;


### PR DESCRIPTION
The pr remove some invalid or duplicate include files and adjust these files sort:
- first part is the correspond include file of source file,
- second part is php standard include file,
- third part is grpc include file,
- last part is some include files on php-grpc ext directory.

Please @stanley-cheung review the pr, thanks!