### PR TITLE
Disable uploading Kokoro Mac results

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -54,8 +54,7 @@ pod repo update  # needed by python
 brew install coreutils  # we need grealpath
 pip install virtualenv --user python
 pip install -U six tox setuptools --user python
-export PYTHONPATH=/Library/Python/2.7/site-packages
-source ~/.bashrc
+export PYTHONPATH=/Library/Python/3.4/site-packages
 
 # python 3.4
 wget -q https://www.python.org/ftp/python/3.4.4/python-3.4.4-macosx10.6.pkg

--- a/tools/internal_ci/macos/grpc_basictests_dbg.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_dbg.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos dbg --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
+  value: "-f basictests macos dbg --internal_ci -j 1 --inner_jobs 4"
 }

--- a/tools/internal_ci/macos/grpc_basictests_opt.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_opt.cfg
@@ -27,5 +27,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests macos opt --internal_ci -j 1 --inner_jobs 4 --bq_result_table aggregate_results"
+  value: "-f basictests macos opt --internal_ci -j 1 --inner_jobs 4"
 }


### PR DESCRIPTION
Fixes #12363
Partially reverts #12270

Temporarily disabling uploading results to BQ. The issue is that the GCP Python module requires a later version of Python's `six` module, and the new MacOS tries to use its pre-installed Python's modules, which has an outdated version of `six`. 