### PR TITLE
Trying to make the code more readable

### DIFF
--- a/tools/codegen/core/gen_hpack_tables.c
+++ b/tools/codegen/core/gen_hpack_tables.c
@@ -189,7 +189,10 @@ static unsigned state_index(unsigned bitofs, symset syms, unsigned *isnew) {
     return i;
   }
   GPR_ASSERT(nhuffstates != MAXHUFFSTATES);
-  i = nhuffstates++;
+ 
+  i = nhuffstates;
+  nhuffstates++;
+  
   huffstates[i].bitofs = bitofs;
   huffstates[i].syms = syms;
   huffstates[i].next = nibblelut_empty();


### PR DESCRIPTION
Hi all,

I'm running some C code analysis tool that pointed me to this small code fragment. I'm suggesting this patch to try to make the source code more understandable by removing mixing of ternary if statements with attributions.

Would you guys agree with this type of changes? The tools pointed me to almost 20 cases like this one in the source code of grpc.