### PR TITLE
doc: add missing condition to statuscodes.md

### DIFF
--- a/doc/statuscodes.md
+++ b/doc/statuscodes.md
@@ -18,9 +18,10 @@ situations in which they are generated.
 
 | Case        | Code           | Generated at Client or Server  |
 | ------------- |:-------------| :-----:|
-| Client Application cancelled the request	| CANCELLED | Both |
+| Client application cancelled the request	| CANCELLED | Both |
 | Deadline expires before server returns status	| DEADLINE_EXCEEDED | Both |
 | Method not found at server	| UNIMPLEMENTED | Server|
+| Client channel enters TRANSIENT_FAILURE state for pending RPC and RPC is not [Wait For Ready](wait-for-ready.md)	|	UNAVAILABLE	|	Client	|
 | Server shutting down	| UNAVAILABLE | Server|
 | Server side application throws an exception (or does something other than returning a Status code to terminate an RPC) |	UNKNOWN | Server|
 | No response received before Deadline expires. This may occur either when the client is unable to send the request to the server or when the server fails to respond in time. |	DEADLINE_EXCEEDED | Both|

--- a/doc/wait-for-ready.md
+++ b/doc/wait-for-ready.md
@@ -3,10 +3,9 @@ gRPC Wait for Ready Semantics
 
 If an RPC is issued but the channel is in `TRANSIENT_FAILURE` or `SHUTDOWN`
 states, the RPC is unable to be transmited promptly. By default, gRPC
-implementations SHOULD fail such RPCs immediately with a status code of
-UNAVAILABLE. This is known as "fail fast," but usage of the term is
-historical. RPCs SHOULD NOT fail as a result of the channel being in other
-states (`CONNECTING`, `READY`, or `IDLE`).
+implementations SHOULD fail such RPCs immediately. This is known as "fail fast,"
+but usage of the term is historical. RPCs SHOULD NOT fail as a result of the
+channel being in other states (`CONNECTING`, `READY`, or `IDLE`).
 
 gRPC implementations MAY provide a per-RPC option to not fail RPCs as a result
 of the channel being in `TRANSIENT_FAILURE` state. Instead, the implementation

--- a/doc/wait-for-ready.md
+++ b/doc/wait-for-ready.md
@@ -3,9 +3,10 @@ gRPC Wait for Ready Semantics
 
 If an RPC is issued but the channel is in `TRANSIENT_FAILURE` or `SHUTDOWN`
 states, the RPC is unable to be transmited promptly. By default, gRPC
-implementations SHOULD fail such RPCs immediately. This is known as "fail fast,"
-but usage of the term is historical. RPCs SHOULD NOT fail as a result of the
-channel being in other states (`CONNECTING`, `READY`, or `IDLE`).
+implementations SHOULD fail such RPCs immediately with a status code of
+UNAVAILABLE. This is known as "fail fast," but usage of the term is
+historical. RPCs SHOULD NOT fail as a result of the channel being in other
+states (`CONNECTING`, `READY`, or `IDLE`).
 
 gRPC implementations MAY provide a per-RPC option to not fail RPCs as a result
 of the channel being in `TRANSIENT_FAILURE` state. Instead, the implementation


### PR DESCRIPTION
Also, mention status code returned in wait-for-ready.md.