### PR TITLE
Fix gRPC build when using protobuf provider "package"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,7 +339,7 @@ function(protobuf_generate_grpc_cpp)
              "${_gRPC_PROTO_GENS_DIR}/${RELFIL_WE}_mock.grpc.pb.h"
              "${_gRPC_PROTO_GENS_DIR}/${RELFIL_WE}.pb.cc"
              "${_gRPC_PROTO_GENS_DIR}/${RELFIL_WE}.pb.h"
-      COMMAND $<TARGET_FILE:${_gRPC_PROTOBUF_PROTOC}>
+      COMMAND ${_gRPC_PROTOBUF_PROTOC}
       ARGS --grpc_out=generate_mock_code=true:${_gRPC_PROTO_GENS_DIR}
            --cpp_out=${_gRPC_PROTO_GENS_DIR}
            --plugin=protoc-gen-grpc=$<TARGET_FILE:grpc_cpp_plugin>

--- a/examples/cpp/helloworld/CMakeLists.txt
+++ b/examples/cpp/helloworld/CMakeLists.txt
@@ -29,7 +29,7 @@ add_custom_command(
       OUTPUT "${hw_grpc_srcs}" "${hw_grpc_hdrs}"
       COMMAND protobuf::protoc
       ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}" -I "${hw_proto_path}"
-        --plugin=protoc-gen-grpc="${gRPC_CPP_PLUGIN_EXECUTABLE}"
+        --plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>
         "${hw_proto}"
       DEPENDS "${hw_proto}")
 


### PR DESCRIPTION
When providing a custom installation of protobuf for gRPC
via `find_package` and -DgRPC_PROTOBUF_PROVIDER=package,
previously it wouldn't build as `${_gRPC_PROTOBUF_PROTOC}`
isn't a target, but expands to the location of `protoc`
found by `find_package`. Therefore, in the definition
of `protobuf_generate_grpc_cpp`, the generator expression
`$<TARGET_FILE:${_gRPC_PROTOBUF_PROTOC}>` is ill-formed.

By replacing that with just ${_gRPC_PROTOBUF_PROTOC}, gRPC
compiles fine both when building protobuf as part of gRPC's
build and when using an already existing installation of
protobuf.