### PR TITLE
Adding num_streams to chttp2_transport

### DIFF
--- a/src/core/ext/transport/chttp2/transport/frame_data.c
+++ b/src/core/ext/transport/chttp2/transport/frame_data.c
@@ -310,7 +310,7 @@ grpc_error *grpc_chttp2_data_parser_parse(grpc_exec_ctx *exec_ctx, void *parser,
   }
 
   if (is_last && s->received_last_frame) {
-    grpc_chttp2_mark_stream_closed(exec_ctx, t, s, true, false,
+    grpc_chttp2_mark_stream_closed(exec_ctx, t, s, false, true, false,
                                    GRPC_ERROR_NONE);
   }
 

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.c
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.c
@@ -103,7 +103,7 @@ grpc_error *grpc_chttp2_rst_stream_parser_parse(grpc_exec_ctx *exec_ctx,
           GRPC_ERROR_INT_HTTP2_ERROR, (intptr_t)reason);
       gpr_free(message);
     }
-    grpc_chttp2_mark_stream_closed(exec_ctx, t, s, true, true, error);
+    grpc_chttp2_mark_stream_closed(exec_ctx, t, s, true, true, true, error);
   }
 
   return GRPC_ERROR_NONE;

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.c
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.c
@@ -1646,8 +1646,6 @@ static void force_client_rst_stream(grpc_exec_ctx *exec_ctx, void *sp,
   grpc_chttp2_stream *s = sp;
   grpc_chttp2_transport *t = s->t;
   if (!s->write_closed) {
-    grpc_chttp2_mark_stream_closed(exec_ctx, t, s, true, false, false,
-                                   GRPC_ERROR_NONE);
     grpc_slice_buffer_add(
         &t->qbuf, grpc_chttp2_rst_stream_create(s->id, GRPC_HTTP2_NO_ERROR,
                                                 &s->stats.outgoing));

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.c
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.c
@@ -1646,11 +1646,14 @@ static void force_client_rst_stream(grpc_exec_ctx *exec_ctx, void *sp,
   grpc_chttp2_stream *s = sp;
   grpc_chttp2_transport *t = s->t;
   if (!s->write_closed) {
+    grpc_chttp2_mark_stream_closed(exec_ctx, t, s, true, false, false,
+                                   GRPC_ERROR_NONE);
     grpc_slice_buffer_add(
         &t->qbuf, grpc_chttp2_rst_stream_create(s->id, GRPC_HTTP2_NO_ERROR,
                                                 &s->stats.outgoing));
     grpc_chttp2_initiate_write(exec_ctx, t, "force_rst_stream");
-    grpc_chttp2_mark_stream_closed(exec_ctx, t, s, true, true, GRPC_ERROR_NONE);
+    grpc_chttp2_mark_stream_closed(exec_ctx, t, s, true, true, true,
+                                   GRPC_ERROR_NONE);
   }
   GRPC_CHTTP2_STREAM_UNREF(exec_ctx, s, "final_rst");
 }
@@ -1726,7 +1729,7 @@ grpc_error *grpc_chttp2_header_parser_parse(grpc_exec_ctx *exec_ctx,
                                   grpc_combiner_finally_scheduler(t->combiner)),
               GRPC_ERROR_NONE);
         }
-        grpc_chttp2_mark_stream_closed(exec_ctx, t, s, true, false,
+        grpc_chttp2_mark_stream_closed(exec_ctx, t, s, false, true, false,
                                        GRPC_ERROR_NONE);
       }
     }

--- a/src/core/ext/transport/chttp2/transport/parsing.c
+++ b/src/core/ext/transport/chttp2/transport/parsing.c
@@ -386,7 +386,7 @@ error_handler:
   } else if (grpc_error_get_int(err, GRPC_ERROR_INT_STREAM_ID, NULL)) {
     /* handle stream errors by closing the stream */
     if (s != NULL) {
-      grpc_chttp2_mark_stream_closed(exec_ctx, t, s, true, false, err);
+      grpc_chttp2_mark_stream_closed(exec_ctx, t, s, false, true, false, err);
     }
     grpc_slice_buffer_add(
         &t->qbuf, grpc_chttp2_rst_stream_create(t->incoming_stream_id,
@@ -589,7 +589,7 @@ static grpc_error *init_header_frame_parser(grpc_exec_ctx *exec_ctx,
           "ignoring grpc_chttp2_stream with non-client generated index %d",
           t->incoming_stream_id));
       return init_skip_frame_parser(exec_ctx, t, 1);
-    } else if (grpc_chttp2_stream_map_size(&t->stream_map) >=
+    } else if (t->num_streams >=
                t->settings[GRPC_ACKED_SETTINGS]
                           [GRPC_CHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS]) {
       return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Max stream count exceeded");

--- a/src/core/ext/transport/chttp2/transport/writing.c
+++ b/src/core/ext/transport/chttp2/transport/writing.c
@@ -486,7 +486,7 @@ void grpc_chttp2_end_write(grpc_exec_ctx *exec_ctx, grpc_chttp2_transport *t,
       grpc_chttp2_complete_closure_step(
           exec_ctx, t, s, &s->send_trailing_metadata_finished,
           GRPC_ERROR_REF(error), "send_trailing_metadata_finished");
-      grpc_chttp2_mark_stream_closed(exec_ctx, t, s, !t->is_client, 1,
+      grpc_chttp2_mark_stream_closed(exec_ctx, t, s, false, !t->is_client, true,
                                      GRPC_ERROR_REF(error));
     }
     GRPC_CHTTP2_STREAM_UNREF(exec_ctx, s, "chttp2_writing:end");


### PR DESCRIPTION
Adding num_streams to chttp2_transport. This decouples checking of number of streams from the stream map. Also solves the race condition uncovered in issue #12201