### PR TITLE
update tsi test library to support async tsi implementation

### DIFF
--- a/test/core/tsi/transport_security_test_lib.h
+++ b/test/core/tsi/transport_security_test_lib.h
@@ -21,6 +21,10 @@
 
 #include "src/core/tsi/transport_security_interface.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define TSI_TEST_TINY_HANDSHAKE_BUFFER_SIZE 32
 #define TSI_TEST_SMALL_HANDSHAKE_BUFFER_SIZE 128
 #define TSI_TEST_SMALL_READ_BUFFER_ALLOCATED_SIZE 41
@@ -56,10 +60,10 @@ typedef struct tsi_test_fixture_vtable {
   void (*setup_handshakers)(tsi_test_fixture *fixture);
   void (*check_handshaker_peers)(tsi_test_fixture *fixture);
   void (*destruct)(tsi_test_fixture *fixture);
-} tranport_security_test_vtable;
+} tsi_test_fixture_vtable;
 
 struct tsi_test_fixture {
-  const struct tsi_test_fixture_vtable *vtable;
+  const tsi_test_fixture_vtable *vtable;
   /* client/server TSI handshaker used to perform TSI handshakes, and will get
      instantiated during the call to setup_handshakers. */
   tsi_handshaker *client_handshaker;
@@ -95,6 +99,13 @@ struct tsi_test_fixture {
      (https://github.com/grpc/grpc/issues/12164).
   */
   bool test_unused_bytes;
+  /* These objects will be used coordinate client/server handshakers with TSI
+     thread to perform TSI handshakes in an asynchronous manner (for GTS TSI
+     implementations).
+  */
+  gpr_cv cv;
+  gpr_mu mu;
+  bool notified;
 };
 
 struct tsi_test_frame_protector_config {
@@ -161,5 +172,9 @@ void tsi_test_do_handshake(tsi_test_fixture *fixture);
    message, and unprotects it. The same operation is triggered again with
    the client and server switching its role. */
 void tsi_test_do_round_trip(tsi_test_fixture *fixture);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // GRPC_TEST_CORE_TSI_TRANSPORT_SECURITY_TEST_LIB_H_


### PR DESCRIPTION
The current TSI test library works for sync TSI implementations (SSL and fake), but not for async (GTS) due to the reason that in async implementation, the callback function (i.e., on_handshake_next_done()) is executed by a different thread (TSI thread) not the caller thread. So, we need an extra mechanism to orchestrate the caller and TSI threads to ensure the caller thread is allowed to proceed only if the TSI thread finishes the callback. For instance in tsi_test_do_handshake(), server's do_handshaker_next will not be executed if TSI thread has not finished the client's callback yet, and vice versa. The new mechanism will work for sync TSI implementations as well.