### PR TITLE
Reveal processes left by our test suite.

### DIFF
--- a/tools/internal_ci/linux/grpc_run_tests_matrix.sh
+++ b/tools/internal_ci/linux/grpc_run_tests_matrix.sh
@@ -20,4 +20,14 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-tools/run_tests/run_tests_matrix.py $RUN_TESTS_FLAGS
+tools/run_tests/run_tests_matrix.py $RUN_TESTS_FLAGS || FAILED="true"
+
+# Reveal leftover processes that might be left behind by the build
+ps aux | grep -i kbuilder
+
+echo 'Exiting gRPC main test script.'
+
+if [ "$FAILED" != "" ]
+then
+  exit 1
+fi

--- a/tools/internal_ci/macos/grpc_run_tests_matrix.sh
+++ b/tools/internal_ci/macos/grpc_run_tests_matrix.sh
@@ -25,6 +25,11 @@ tools/run_tests/run_tests_matrix.py $RUN_TESTS_FLAGS || FAILED="true"
 # kill port_server.py to prevent the build from hanging
 ps aux | grep port_server\\.py | awk '{print $2}' | xargs kill -9
 
+# Reveal leftover processes that might be left behind by the build
+ps aux | grep -i kbuilder
+
+echo 'Exiting gRPC main test script.'
+
 if [ "$FAILED" != "" ]
 then
   exit 1

--- a/tools/internal_ci/windows/grpc_run_tests_matrix.bat
+++ b/tools/internal_ci/windows/grpc_run_tests_matrix.bat
@@ -17,8 +17,10 @@ cd /d %~dp0\..\..\..
 
 call tools/internal_ci/helper_scripts/prepare_build_windows.bat
 
-python tools/run_tests/run_tests_matrix.py %RUN_TESTS_FLAGS% || goto :error
-goto :EOF
+python tools/run_tests/run_tests_matrix.py %RUN_TESTS_FLAGS%
+set RUNTESTS_EXITCODE=%errorlevel%
 
-:error
-exit /b %errorlevel%
+@rem Reveal leftover processes that might be left behind by the build
+tasklist /V
+
+exit /b %RUNTESTS_EXITCODE%


### PR DESCRIPTION
It looks like that some processes left by our tests cause kokoro builds to sometimes timeout. https://github.com/grpc/grpc/issues/12476

Note that processes under docker run as root, but this should at least show the top level processes?