### PR TITLE
Temporarily take ownership of cpp generator to prevent changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,5 @@
 # repository as the source of truth for module ownership.
 /**/OWNERS @markdroth @nicolasnoble @ctiller
 /bazel/** @nicolasnoble @dgquintas @ctiller
+/src/compiler/cpp_generator.cc @vjpai
 /src/core/ext/filters/client_channel/** @markdroth @dgquintas @ctiller

--- a/src/compiler/OWNERS
+++ b/src/compiler/OWNERS
@@ -1,0 +1,1 @@
+@vjpai cpp_generator.cc


### PR DESCRIPTION
Although we don't allow sole ownership, this is a temporary workaround to prevent changes while #12269 is in progress.
