### PR TITLE
Fix a per-call memory leak in ruby

### DIFF
--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -101,6 +101,7 @@ static void grpc_rb_call_destroy(void *p) {
     return;
   }
   destroy_call((grpc_rb_call *)p);
+  xfree(p);
 }
 
 static size_t md_ary_datasize(const void *p) {


### PR DESCRIPTION
fixes https://github.com/grpc/grpc/issues/12443

it looks like the current GC function for `GRPC::Core::Call` objects doesn't free the ruby struct (allocated in https://github.com/grpc/grpc/blob/master/src/ruby/ext/grpc/rb_call.c#L1048).


The leak can be made apparent by running:

```
this_dir = File.expand_path(File.dirname(__FILE__))
lib_dir = File.join(File.join(File.join(File.join(this_dir, 'src'), 'ruby'), 'lib'))
$LOAD_PATH.unshift(lib_dir) unless $LOAD_PATH.include?(lib_dir)

require 'grpc'

def main
  ch = GRPC::Core::Channel.new('localhost:12345', nil, :this_channel_is_insecure)
  i = 0
  loop do
    deadline = Time.now + 5
    ch.create_call(nil, nil, 'dummy_method', nil, deadline)
    i += 1
    p "#{i}" if i % 1000 == 0
  end
end
```

for a few million counts, under `valgrind --tool=massif`, and then dumping the profile with `ms_print`.

Before the fix for the leak, the heap snapshots begin with almost all total memory allocated by `zalloc_with_calloc` when `grpc_channel_create_call` is creating a new call arena, and with less than one percent of the active heap alloc'd by `ruby_xmalloc` (called by [ALLOC macro](https://github.com/ruby/ruby/blob/trunk/include/ruby/ruby.h#L1588)). As time goes on, allocs due to `zalloc_with_calloc` make up less and less of heap snapshot and the percentage due to `ruby_xmalloc` steadily grows. After the fix, allocs due to `ruby_xmalloc` never account for more than 1%.