### PR TITLE
run_tests.py: embed openssl during building c-core before running build_php.sh

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -533,6 +533,7 @@ class PhpLanguage(object):
     self.config = config
     self.args = args
     _check_compiler(self.args.compiler, ['default'])
+    self._make_options = ['EMBED_OPENSSL=true', 'EMBED_ZLIB=true']
 
   def test_specs(self):
     return [self.config.job_spec(['src/php/bin/run_tests.sh'],
@@ -545,7 +546,7 @@ class PhpLanguage(object):
     return ['static_c', 'shared_c']
 
   def make_options(self):
-    return []
+    return self._make_options;
 
   def build_steps(self):
     return [['tools/run_tests/helper_scripts/build_php.sh']]
@@ -569,6 +570,7 @@ class Php7Language(object):
     self.config = config
     self.args = args
     _check_compiler(self.args.compiler, ['default'])
+    self._make_options = ['EMBED_OPENSSL=true', 'EMBED_ZLIB=true']
 
   def test_specs(self):
     return [self.config.job_spec(['src/php/bin/run_tests.sh'],
@@ -581,7 +583,7 @@ class Php7Language(object):
     return ['static_c', 'shared_c']
 
   def make_options(self):
-    return []
+    return self._make_options;
 
   def build_steps(self):
     return [['tools/run_tests/helper_scripts/build_php.sh']]


### PR DESCRIPTION
When running tools/run_tests/run_performance_tests.py, libgrpc.so has link issues:
```
        linux-vdso.so.1 =>  (0x00007ffe3ffee000)
        libssl.so.1.0.0 => /lib/x86_64-linux-gnu/libssl.so.1.0.0 (0x00007f57c19dd000)
        libcrypto.so.1.0.0 => /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007f57c1599000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f57c1391000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f57c1088000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f57c0e6a000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f57c0aa1000)
        /lib64/ld-linux-x86-64.so.2 (0x0000562093469000)
        libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f57c089d000)
```
after this change,
```
        linux-vdso.so.1 =>  (0x00007ffe42558000)
        librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f4b92b44000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f4b9283b000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f4b9261d000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f4b92256000)
        /lib64/ld-linux-x86-64.so.2 (0x0000556e4c569000)
```