### PR TITLE
Comment that IPv6 Any accepts both IPv4 and IPv6 connections.

### DIFF
--- a/include/grpc++/server_builder.h
+++ b/include/grpc++/server_builder.h
@@ -136,8 +136,10 @@ class ServerBuilder {
   /// It can be invoked multiple times.
   ///
   /// \param addr_uri The address to try to bind to the server in URI form. If
-  /// the scheme name is omitted, "dns:///" is assumed. Valid values include
-  /// dns:///localhost:1234, / 192.168.1.1:31416, dns:///[::1]:27182, etc.).
+  /// the scheme name is omitted, "dns:///" is assumed. To bind to any address,
+  /// please use IPv6 any, i.e., [::]:<port>, which also accepts IPv4
+  /// connections.  Valid values include dns:///localhost:1234, /
+  /// 192.168.1.1:31416, dns:///[::1]:27182, etc.).
   /// \params creds The credentials associated with the server.
   /// \param selected_port[out] If not `nullptr`, gets populated with the port
   /// number bound to the \a grpc::Server for the corresponding endpoint after


### PR DESCRIPTION
This helps to clarify the expectations of address URI for AddListeningPort.