### PR TITLE
Adding --base to generate_projects.py

### DIFF
--- a/tools/buildgen/generate_projects.py
+++ b/tools/buildgen/generate_projects.py
@@ -34,6 +34,7 @@ argp.add_argument('build_files', nargs='+', default=[])
 argp.add_argument('--templates', nargs='+', default=[])
 argp.add_argument('--output_merged', default=None, type=str)
 argp.add_argument('--jobs', '-j', default=multiprocessing.cpu_count(), type=int)
+argp.add_argument('--base', default='.', type=str)
 args = argp.parse_args()
 
 json = args.build_files
@@ -69,7 +70,7 @@ jobs = []
 for template in reversed(sorted(templates)):
   root, f = os.path.split(template)
   if os.path.splitext(f)[1] == '.template':
-    out_dir = '.' + root[len('templates'):]
+    out_dir = args.base + root[len('templates'):]
     out = out_dir + '/' + os.path.splitext(f)[0]
     if not os.path.exists(out_dir):
       os.makedirs(out_dir)


### PR DESCRIPTION
The generate_projects system used to work with files outside the repository. This tries to restore this functionality.