### PR TITLE
Fix choosing of service config when percentage is zero

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.c
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.c
@@ -204,7 +204,7 @@ static char *choose_service_config(char *service_config_choice_json) {
         int random_pct = rand() % 100;
         int percentage;
         if (sscanf(field->value, "%d", &percentage) != 1 ||
-            random_pct > percentage) {
+            random_pct > percentage || percentage == 0) {
           service_config_json = NULL;
           break;
         }


### PR DESCRIPTION
Cherry-picked from https://github.com/grpc/grpc/pull/12210. This was causing some flakes in the test in that PR.