### PR TITLE
Make unmeasured CPU costs be 1, not 0

### DIFF
--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -224,7 +224,7 @@ class JobResult(object):
     self.retries = 0
     self.message = ''
     self.cpu_estimated = 1
-    self.cpu_measured = 0
+    self.cpu_measured = 1
 
 
 def read_from_start(f):


### PR DESCRIPTION
Allows capturing 0 as a CPU cost, which we'll be able to leverage to
increase concurrency (once data has caught up in a few days)