### PR TITLE
Add two new metrics in QPS Driver.

### DIFF
--- a/src/proto/grpc/testing/control.proto
+++ b/src/proto/grpc/testing/control.proto
@@ -245,6 +245,10 @@ message ScenarioResultSummary
   // Queries per CPU-sec over all servers or clients
   double server_queries_per_cpu_sec = 17;
   double client_queries_per_cpu_sec = 18;
+
+  // Server and client cpu load
+  double server_cpu_load;
+  double client_cpu_load;
 }
 
 // Results of a single benchmark scenario.

--- a/src/proto/grpc/testing/control.proto
+++ b/src/proto/grpc/testing/control.proto
@@ -247,8 +247,8 @@ message ScenarioResultSummary
   double client_queries_per_cpu_sec = 18;
 
   // Server and client cpu load
-  double server_cpu_load;
-  double client_cpu_load;
+  double server_cpu_load = 19;
+  double client_cpu_load = 20;
 }
 
 // Results of a single benchmark scenario.

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -185,6 +185,11 @@ static void postprocess_scenario_result(ScenarioResult* result) {
       server_queries_per_cpu_sec);
   result->mutable_summary()->set_client_queries_per_cpu_sec(
       client_queries_per_cpu_sec);
+
+  result->mutable_summary()->set_server_cpu_load(server_system_time +
+                                                 server_user_time);
+  result->mutable_summary()->set_client_cpu_load(client_system_time +
+                                                 client_user_time);
 }
 
 std::unique_ptr<ScenarioResult> RunScenario(

--- a/test/cpp/qps/report.cc
+++ b/test/cpp/qps/report.cc
@@ -78,6 +78,12 @@ void CompositeReporter::ReportQueriesPerCpuSec(const ScenarioResult& result) {
   }
 }
 
+void CompositeReporter::ReportCpuLoad(const ScenarioResult& result) {
+  for (size_t i = 0; i < reporters_.size(); ++i) {
+    reporters_[i]->ReportCpuLoad(result);
+  }
+}
+
 void GprLogReporter::ReportQPS(const ScenarioResult& result) {
   gpr_log(GPR_INFO, "QPS: %.1f", result.summary().qps());
   if (result.summary().failed_requests_per_second() > 0) {
@@ -160,6 +166,13 @@ void GprLogReporter::ReportQueriesPerCpuSec(const ScenarioResult& result) {
           result.summary().client_queries_per_cpu_sec());
 }
 
+void GprLogReporter::ReportCpuLoad(const ScenarioResult& result) {
+  gpr_log(GPR_INFO, "Server CPU load: %.2f",
+          result.summary().server_cpu_load());
+  gpr_log(GPR_INFO, "Client CPU load: %.2f",
+          result.summary().client_cpu_load());
+}
+
 void JsonReporter::ReportQPS(const ScenarioResult& result) {
   grpc::string json_string =
       SerializeJson(result, "type.googleapis.com/grpc.testing.ScenarioResult");
@@ -189,6 +202,10 @@ void JsonReporter::ReportPollCount(const ScenarioResult& result) {
 }
 
 void JsonReporter::ReportQueriesPerCpuSec(const ScenarioResult& result) {
+  // NOP - all reporting is handled by ReportQPS.
+}
+
+void JsonReporter::ReportCpuLoad(const ScenarioResult& result) {
   // NOP - all reporting is handled by ReportQPS.
 }
 
@@ -229,6 +246,10 @@ void RpcReporter::ReportPollCount(const ScenarioResult& result) {
 }
 
 void RpcReporter::ReportQueriesPerCpuSec(const ScenarioResult& result) {
+  // NOP - all reporting is handled by ReportQPS.
+}
+
+void RpcReporter::ReportCpuLoad(const ScenarioResult& result) {
   // NOP - all reporting is handled by ReportQPS.
 }
 

--- a/test/cpp/qps/report.h
+++ b/test/cpp/qps/report.h
@@ -67,6 +67,9 @@ class Reporter {
   /** Reports queries per cpu-sec. */
   virtual void ReportQueriesPerCpuSec(const ScenarioResult& result) = 0;
 
+  /** Reports server and client cpu load. */
+  virtual void ReportCpuLoad(const ScenarioResult& result) = 0;
+
  private:
   const string name_;
 };
@@ -86,6 +89,7 @@ class CompositeReporter : public Reporter {
   void ReportCpuUsage(const ScenarioResult& result) override;
   void ReportPollCount(const ScenarioResult& result) override;
   void ReportQueriesPerCpuSec(const ScenarioResult& result) override;
+  void ReportCpuLoad(const ScenarioResult& result) override;
 
  private:
   std::vector<std::unique_ptr<Reporter> > reporters_;
@@ -104,6 +108,7 @@ class GprLogReporter : public Reporter {
   void ReportCpuUsage(const ScenarioResult& result) override;
   void ReportPollCount(const ScenarioResult& result) override;
   void ReportQueriesPerCpuSec(const ScenarioResult& result) override;
+  void ReportCpuLoad(const ScenarioResult& result) override;
 
   void ReportCoreStats(const char* name, int idx,
                        const grpc::core::Stats& stats);
@@ -123,6 +128,7 @@ class JsonReporter : public Reporter {
   void ReportCpuUsage(const ScenarioResult& result) override;
   void ReportPollCount(const ScenarioResult& result) override;
   void ReportQueriesPerCpuSec(const ScenarioResult& result) override;
+  void ReportCpuLoad(const ScenarioResult& result) override;
 
   const string report_file_;
 };
@@ -140,6 +146,7 @@ class RpcReporter : public Reporter {
   void ReportCpuUsage(const ScenarioResult& result) override;
   void ReportPollCount(const ScenarioResult& result) override;
   void ReportQueriesPerCpuSec(const ScenarioResult& result) override;
+  void ReportCpuLoad(const ScenarioResult& result) override;
 
   std::unique_ptr<ReportQpsScenarioService::Stub> stub_;
 };

--- a/tools/run_tests/performance/scenario_result_schema.json
+++ b/tools/run_tests/performance/scenario_result_schema.json
@@ -226,6 +226,16 @@
         "name": "clientQueriesPerCpuSec",
         "type": "FLOAT",
         "mode": "NULLABLE"
+      },
+      {
+        "name": "serverCpuLoad",
+        "type": "FLOAT",
+        "mode": "NULLABLE"
+      },
+      {
+        "name": "clientCpuLoad",
+        "type": "FLOAT",
+        "mode": "NULLABLE"
       }
     ]
   },


### PR DESCRIPTION
Add new metrics for server and client CPU loads in QPS Driver, and patch dashboard schema for the new metrics.

Fixes #12483 .