### PR TITLE
Fix case on internal type names

### DIFF
--- a/tools/profiling/microbenchmarks/bm2bq.py
+++ b/tools/profiling/microbenchmarks/bm2bq.py
@@ -30,7 +30,7 @@ columns = []
 for row in json.loads(
     subprocess.check_output([
       'bq','--format=json','show','microbenchmarks.microbenchmarks']))['schema']['fields']:
-  columns.append((row['name'], row['type']))
+  columns.append((row['name'], row['type'].lower()))
 
 SANITIZE = {
   'integer': int,


### PR DESCRIPTION
Should allow microbenchmarks to get running again