### PR TITLE
grpc_1_0 flag for gRPC Python Protoc Plug-In

### DIFF
--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -769,7 +769,7 @@ bool PythonGrpcGenerator::Generate(const FileDescriptor* file,
   PrivateGenerator generator(config_, &pbfile);
   if (parameter == "grpc_2_0") {
     return GenerateGrpc(context, generator, pb2_grpc_file_name, true);
-  } else if (parameter == "") {
+  } else if (parameter == "grpc_1_0" || parameter == "") {
     return GenerateGrpc(context, generator, pb2_grpc_file_name, true) &&
            GenerateGrpc(context, generator, pb2_file_name, false);
   } else {


### PR DESCRIPTION
Because there are out-of-this-repository customers depending on the old behavior being the default the act-the-old-way flag has to be introduced before the default behavior can be changed to be the new behavior.