### PR TITLE
Update service_config doc

### DIFF
--- a/doc/service_config.md
+++ b/doc/service_config.md
@@ -24,10 +24,7 @@ The service config is a JSON string of the following form:
   // opposed to backend addresses), gRPC will use grpclb (see
   // https://github.com/grpc/grpc/blob/master/doc/load-balancing.md),
   // regardless of what LB policy is requested either here or via the
-  // client API.  However, if the resolver returns at least one backend
-  // address in addition to the balancer address(es), the client may fall
-  // back to the requested policy if it is unable to reach any of the
-  // grpclb load balancers.
+  // client API.
   'loadBalancingPolicy': string,
 
   // Per-method configuration.  Optional.


### PR DESCRIPTION
The current grpclb fallback implementation is to continue using the internal round_robin policy but feed it with the backends from the resolver. We didn't fall back to the policy indicated in service config (or client API) because that's too complex and has more different behavior from the normal situation where we do connect to the balancer.