### PR TITLE
Fix BDP Probe Bug

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.c
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.c
@@ -349,7 +349,7 @@ static void init_transport(grpc_exec_ctx *exec_ctx, grpc_chttp2_transport *t,
   t->force_send_settings = 1 << GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE;
   t->sent_local_settings = 0;
   t->write_buffer_size = DEFAULT_WINDOW;
-  t->flow_control.enable_bdp_probe = true;
+  t->enable_bdp_probe = true;
 
   if (is_client) {
     grpc_slice_buffer_add(&t->outbuf, grpc_slice_from_copied_string(
@@ -471,7 +471,7 @@ static void init_transport(grpc_exec_ctx *exec_ctx, grpc_chttp2_transport *t,
             (grpc_integer_options){0, 0, MAX_WRITE_BUFFER_SIZE});
       } else if (0 ==
                  strcmp(channel_args->args[i].key, GRPC_ARG_HTTP2_BDP_PROBE)) {
-        t->flow_control.enable_bdp_probe = grpc_channel_arg_get_integer(
+        t->enable_bdp_probe = grpc_channel_arg_get_integer(
             &channel_args->args[i], (grpc_integer_options){1, 0, 1});
       } else if (0 == strcmp(channel_args->args[i].key,
                              GRPC_ARG_KEEPALIVE_TIME_MS)) {
@@ -2467,14 +2467,6 @@ void grpc_chttp2_act_on_flowctl_action(grpc_exec_ctx *exec_ctx,
                                  GRPC_CHTTP2_INITIATE_WRITE_SEND_SETTINGS);
     }
   }
-  if (action.need_ping) {
-    GRPC_CHTTP2_REF_TRANSPORT(t, "bdp_ping");
-    grpc_bdp_estimator_schedule_ping(&t->flow_control.bdp_estimator);
-    send_ping_locked(exec_ctx, t,
-                     GRPC_CHTTP2_PING_BEFORE_TRANSPORT_WINDOW_UPDATE,
-                     &t->start_bdp_ping_locked, &t->finish_bdp_ping_locked,
-                     GRPC_CHTTP2_INITIATE_WRITE_BDP_ESTIMATOR_PING);
-  }
 }
 
 static grpc_error *try_http_parsing(grpc_exec_ctx *exec_ctx,
@@ -2512,6 +2504,7 @@ static void read_action_locked(grpc_exec_ctx *exec_ctx, void *tp,
   GPR_TIMER_BEGIN("reading_action_locked", 0);
 
   grpc_chttp2_transport *t = (grpc_chttp2_transport *)tp;
+  bool need_bdp_ping = false;
 
   GRPC_ERROR_REF(error);
 
@@ -2530,9 +2523,11 @@ static void read_action_locked(grpc_exec_ctx *exec_ctx, void *tp,
     grpc_error *errors[3] = {GRPC_ERROR_REF(error), GRPC_ERROR_NONE,
                              GRPC_ERROR_NONE};
     for (; i < t->read_buffer.count && errors[1] == GRPC_ERROR_NONE; i++) {
-      grpc_bdp_estimator_add_incoming_bytes(
-          &t->flow_control.bdp_estimator,
-          (int64_t)GRPC_SLICE_LENGTH(t->read_buffer.slices[i]));
+      if (grpc_bdp_estimator_add_incoming_bytes(
+              &t->flow_control.bdp_estimator,
+              (int64_t)GRPC_SLICE_LENGTH(t->read_buffer.slices[i]))) {
+        need_bdp_ping = true;
+      }
       errors[1] =
           grpc_chttp2_perform_read(exec_ctx, t, t->read_buffer.slices[i]);
     }
@@ -2580,9 +2575,19 @@ static void read_action_locked(grpc_exec_ctx *exec_ctx, void *tp,
   if (keep_reading) {
     grpc_endpoint_read(exec_ctx, t->ep, &t->read_buffer,
                        &t->read_action_locked);
-    grpc_chttp2_act_on_flowctl_action(
-        exec_ctx, grpc_chttp2_flowctl_get_bdp_action(&t->flow_control), t,
-        NULL);
+    if (t->enable_bdp_probe) {
+      if (need_bdp_ping) {
+        GRPC_CHTTP2_REF_TRANSPORT(t, "bdp_ping");
+        grpc_bdp_estimator_schedule_ping(&t->flow_control.bdp_estimator);
+        send_ping_locked(exec_ctx, t,
+                         GRPC_CHTTP2_PING_BEFORE_TRANSPORT_WINDOW_UPDATE,
+                         &t->start_bdp_ping_locked, &t->finish_bdp_ping_locked,
+                         GRPC_CHTTP2_INITIATE_WRITE_BDP_ESTIMATOR_PING);
+      }
+      grpc_chttp2_act_on_flowctl_action(
+          exec_ctx, grpc_chttp2_flowctl_get_bdp_action(&t->flow_control), t,
+          NULL);
+    }
     GRPC_CHTTP2_UNREF_TRANSPORT(exec_ctx, t, "keep_reading");
   } else {
     GRPC_CHTTP2_UNREF_TRANSPORT(exec_ctx, t, "reading_action");

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -265,9 +265,6 @@ typedef struct {
    * to send WINDOW_UPDATE frames. */
   int64_t announced_window;
 
-  /** should we probe bdp? */
-  bool enable_bdp_probe;
-
   /* bdp estimation */
   grpc_bdp_estimator bdp_estimator;
 
@@ -419,6 +416,9 @@ struct grpc_chttp2_transport {
   grpc_slice goaway_text;
 
   grpc_chttp2_write_cb *write_cb_pool;
+
+  /** should we probe bdp? */
+  bool enable_bdp_probe;
 
   /* bdp estimator */
   grpc_closure start_bdp_ping_locked;
@@ -748,7 +748,6 @@ typedef struct {
   grpc_chttp2_flowctl_urgency send_setting_update;
   uint32_t initial_window_size;
   uint32_t max_frame_size;
-  bool need_ping;
 } grpc_chttp2_flowctl_action;
 
 // Reads the flow control data and returns and actionable struct that will tell

--- a/src/core/lib/transport/bdp_estimator.c
+++ b/src/core/lib/transport/bdp_estimator.c
@@ -45,12 +45,9 @@ bool grpc_bdp_estimator_get_bw(const grpc_bdp_estimator *estimator,
   return true;
 }
 
-void grpc_bdp_estimator_add_incoming_bytes(grpc_bdp_estimator *estimator,
+bool grpc_bdp_estimator_add_incoming_bytes(grpc_bdp_estimator *estimator,
                                            int64_t num_bytes) {
   estimator->accumulator += num_bytes;
-}
-
-bool grpc_bdp_estimator_need_ping(const grpc_bdp_estimator *estimator) {
   switch (estimator->ping_state) {
     case GRPC_BDP_PING_UNSCHEDULED:
       return true;

--- a/src/core/lib/transport/bdp_estimator.h
+++ b/src/core/lib/transport/bdp_estimator.h
@@ -52,7 +52,7 @@ bool grpc_bdp_estimator_get_estimate(const grpc_bdp_estimator *estimator,
 // Tracks new bytes read.
 bool grpc_bdp_estimator_get_bw(const grpc_bdp_estimator *estimator, double *bw);
 // Returns true if the user should schedule a ping
-void grpc_bdp_estimator_add_incoming_bytes(grpc_bdp_estimator *estimator,
+bool grpc_bdp_estimator_add_incoming_bytes(grpc_bdp_estimator *estimator,
                                            int64_t num_bytes);
 // Returns true if the user should schedule a ping
 bool grpc_bdp_estimator_need_ping(const grpc_bdp_estimator *estimator);

--- a/test/core/transport/bdp_estimator_test.c
+++ b/test/core/transport/bdp_estimator_test.c
@@ -43,11 +43,12 @@ static void test_get_estimate_no_samples(void) {
 
 static void add_samples(grpc_bdp_estimator *estimator, int64_t *samples,
                         size_t n) {
-  GPR_ASSERT(grpc_bdp_estimator_add_incoming_bytes(estimator, 1234567));
+  GPR_ASSERT(grpc_bdp_estimator_add_incoming_bytes(estimator, 1234567) == true);
   grpc_bdp_estimator_schedule_ping(estimator);
   grpc_bdp_estimator_start_ping(estimator);
   for (size_t i = 0; i < n; i++) {
-    GPR_ASSERT(grpc_bdp_estimator_add_incoming_bytes(estimator, samples[i]));
+    GPR_ASSERT(grpc_bdp_estimator_add_incoming_bytes(estimator, samples[i]) ==
+               false);
   }
   gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
                                gpr_time_from_millis(1, GPR_TIMESPAN)));

--- a/test/core/transport/bdp_estimator_test.c
+++ b/test/core/transport/bdp_estimator_test.c
@@ -43,13 +43,11 @@ static void test_get_estimate_no_samples(void) {
 
 static void add_samples(grpc_bdp_estimator *estimator, int64_t *samples,
                         size_t n) {
-  grpc_bdp_estimator_add_incoming_bytes(estimator, 1234567);
-  GPR_ASSERT(grpc_bdp_estimator_need_ping(estimator) == true);
+  GPR_ASSERT(grpc_bdp_estimator_add_incoming_bytes(estimator, 1234567));
   grpc_bdp_estimator_schedule_ping(estimator);
   grpc_bdp_estimator_start_ping(estimator);
   for (size_t i = 0; i < n; i++) {
-    grpc_bdp_estimator_add_incoming_bytes(estimator, samples[i]);
-    GPR_ASSERT(grpc_bdp_estimator_need_ping(estimator) == false);
+    GPR_ASSERT(grpc_bdp_estimator_add_incoming_bytes(estimator, samples[i]));
   }
   gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
                                gpr_time_from_millis(1, GPR_TIMESPAN)));


### PR DESCRIPTION
This fixes #12461 (and several other QPS Driver flakes).

My refactor caused edged cases in which a bdp probe ping was initiated after the transport was closed, or when no bytes had come off the wire. This fixes that.

(might also explain the bloated ping count we just saw)