### PR TITLE
Add allow-ssh tags to newly created GCE VMs

### DIFF
--- a/tools/gce/create_interop_worker.sh
+++ b/tools/gce/create_interop_worker.sh
@@ -33,7 +33,8 @@ gcloud compute instances create $INSTANCE_NAME \
     --machine-type n1-standard-16 \
     --image ubuntu-15-10 \
     --boot-disk-size 1000 \
-    --scopes https://www.googleapis.com/auth/xapi.zoo
+    --scopes https://www.googleapis.com/auth/xapi.zoo \
+    --tags=allow-ssh
 
 echo 'Created GCE instance, waiting 60 seconds for it to come online.'
 sleep 60

--- a/tools/gce/create_linux_performance_worker.sh
+++ b/tools/gce/create_linux_performance_worker.sh
@@ -36,7 +36,8 @@ gcloud compute instances create $INSTANCE_NAME \
     --image-project ubuntu-os-cloud \
     --image-family ubuntu-1704 \
     --boot-disk-size 300 \
-    --scopes https://www.googleapis.com/auth/bigquery
+    --scopes https://www.googleapis.com/auth/bigquery \
+    --tags=allow-ssh
 
 echo 'Created GCE instance, waiting 60 seconds for it to come online.'
 sleep 60

--- a/tools/gce/create_linux_worker.sh
+++ b/tools/gce/create_linux_worker.sh
@@ -31,7 +31,8 @@ gcloud compute instances create $INSTANCE_NAME \
     --image=ubuntu-1510 \
     --image-project=grpc-testing \
     --boot-disk-size 1000 \
-    --scopes https://www.googleapis.com/auth/bigquery
+    --scopes https://www.googleapis.com/auth/bigquery \
+    --tags=allow-ssh
 
 echo 'Created GCE instance, waiting 60 seconds for it to come online.'
 sleep 60


### PR DESCRIPTION
These tags have already been added to existing VMs. This change accompanies a change to make disallowing SSH the default for untagged VMs.