### PR TITLE
Rename set to depset

### DIFF
--- a/bazel/generate_cc.bzl
+++ b/bazel/generate_cc.bzl
@@ -55,7 +55,7 @@ def generate_cc_impl(ctx):
       arguments = arguments,
   )
 
-  return struct(files=set(out_files))
+  return struct(files=depset(out_files))
 
 _generate_cc = rule(
     attrs = {


### PR DESCRIPTION
`set` is a deprecated alias of `depset` and it will no longer be supported starting with the upcoming Bazel 0.6.

It's also recommended that a new version of grps is released with this patch included.