### PR TITLE
change google.protobuf.Empty to google.protobuf.GPBEmpty

### DIFF
--- a/src/compiler/php_generator.cc
+++ b/src/compiler/php_generator.cc
@@ -34,7 +34,8 @@ namespace grpc_php_generator {
 namespace {
 
 grpc::string MessageIdentifierName(const grpc::string &name) {
-  std::vector<grpc::string> tokens = grpc_generator::tokenize(name, ".");
+  grpc::string tmpName = grpc_generator::StringReplace(name, "google.protobuf.Empty", "google.protobuf.GPBEmpty");
+  std::vector<grpc::string> tokens = grpc_generator::tokenize(tmpName, ".");
   std::ostringstream oss;
   for (unsigned int i = 0; i < tokens.size(); i++) {
     oss << (i == 0 ? "" : "\\")


### PR DESCRIPTION
the genrated code of google/protobuf/empty.proto is GPBEmpty.php, but the generated class of customized proto which used the google.protobuf.Empy is \Google\Protobuf\Empty.