### PR TITLE
Fix a six.with_metaclass usage mistake

### DIFF
--- a/src/python/grpcio_testing/grpc_testing/__init__.py
+++ b/src/python/grpcio_testing/grpc_testing/__init__.py
@@ -213,7 +213,7 @@ class StreamStreamChannelRpc(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class Channel(six.with_metaclass(abc.ABCMeta), grpc.Channel):
+class Channel(six.with_metaclass(abc.ABCMeta, grpc.Channel)):
     """A grpc.Channel double with which to test a system that invokes RPCs."""
 
     @abc.abstractmethod


### PR DESCRIPTION
Whoopsie! Well I'm glad `six` is now that much stronger a collaborator helping me avoid such trouble again.