### PR TITLE
Adjust sanitizer timeouts

### DIFF
--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_asan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_asan.cfg
@@ -17,7 +17,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 1440
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_msan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_msan.cfg
@@ -17,7 +17,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 1440
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_tsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_tsan.cfg
@@ -17,7 +17,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 1440
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_ubsan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_c_ubsan.cfg
@@ -17,7 +17,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 1440
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"

--- a/tools/internal_ci/linux/sanitizer/pull_request/grpc_cpp_asan.cfg
+++ b/tools/internal_ci/linux/sanitizer/pull_request/grpc_cpp_asan.cfg
@@ -17,7 +17,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 1440
+timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -35,6 +35,9 @@ _DEFAULT_RUNTESTS_TIMEOUT = 1*60*60
 # clang docker.
 _CPP_RUNTESTS_TIMEOUT = 4*60*60
 
+# C++ TSAN takes longer than other sanitizers
+_CPP_TSAN_RUNTESTS_TIMEOUT = 8*60*60
+
 # Number of jobs assigned to each run_tests.py instance
 _DEFAULT_INNER_JOBS = 2
 
@@ -190,12 +193,19 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
                               inner_jobs=inner_jobs,
                               timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
   test_jobs += _generate_jobs(languages=['c++'],
-                              configs=['asan', 'tsan'],
+                              configs=['asan'],
                               platforms=['linux'],
                               labels=['sanitizers', 'corelang'],
                               extra_args=extra_args,
                               inner_jobs=inner_jobs,
                               timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
+  test_jobs += _generate_jobs(languages=['c++'],
+                              configs=['tsan'],
+                              platforms=['linux'],
+                              labels=['sanitizers', 'corelang'],
+                              extra_args=extra_args,
+                              inner_jobs=inner_jobs,
+                              timeout_seconds=_CPP_TSAN_RUNTESTS_TIMEOUT)
 
   return test_jobs
 


### PR DESCRIPTION
-- kokoro sanitizer timeouts are way too high (let's prevent clogging the queue in case the test runtime suddenly spikes)
-- C++ tsan is timing out on master in 100% cases (that prevents us from obtaining accurate stats in bigquery) - increase suite timeout to 8hours (won't affect PRs).