### PR TITLE
php qps: composer install stable protobuf instead of dev

### DIFF
--- a/src/php/tests/qps/composer.json
+++ b/src/php/tests/qps/composer.json
@@ -1,8 +1,7 @@
 {
-  "minimum-stability": "dev",
   "require": {
     "grpc/grpc": "dev-master",
-    "google/protobuf": "^v3.3.0"
+    "google/protobuf": "v3.4.1"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Before:
`- Installing google/protobuf (v3.4.1-dev): Loading from cache`
After:
`- Installing google/protobuf (v3.4.1): Loading from cache`
The reason for using fixed version is current v3.4.1-dev has reserved var which conflict with current proto files inside src/php/tests/qps/generated_code. If it is merge into v3.4.2, qps test will break.
