### PR TITLE
Add missing exec_ctx parameter to pollset_uv.c

### DIFF
--- a/src/core/lib/iomgr/pollset_uv.c
+++ b/src/core/lib/iomgr/pollset_uv.c
@@ -145,7 +145,7 @@ grpc_error *grpc_pollset_work(grpc_exec_ctx *exec_ctx, grpc_pollset *pollset,
   return GRPC_ERROR_NONE;
 }
 
-grpc_error *grpc_pollset_kick(grpc_pollset *pollset,
+grpc_error *grpc_pollset_kick(grpc_exec_ctx *exec_ctx, grpc_pollset *pollset,
                               grpc_pollset_worker *specific_worker) {
   GRPC_UV_ASSERT_SAME_THREAD();
   uv_timer_start(dummy_uv_handle, dummy_timer_cb, 0, 0);

--- a/test/core/iomgr/tcp_client_uv_test.c
+++ b/test/core/iomgr/tcp_client_uv_test.c
@@ -46,11 +46,11 @@ static gpr_timespec test_deadline(void) {
   return grpc_timeout_seconds_to_deadline(10);
 }
 
-static void finish_connection() {
+static void finish_connection(grpc_exec_ctx *exec_ctx) {
   gpr_mu_lock(g_mu);
   g_connections_complete++;
-  GPR_ASSERT(
-      GRPC_LOG_IF_ERROR("pollset_kick", grpc_pollset_kick(g_pollset, NULL)));
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("pollset_kick",
+                               grpc_pollset_kick(exec_ctx, g_pollset, NULL)));
   gpr_mu_unlock(g_mu);
 }
 
@@ -63,7 +63,7 @@ static void must_succeed(grpc_exec_ctx *exec_ctx, void *arg,
       GRPC_ERROR_CREATE_FROM_STATIC_STRING("must_succeed called"));
   grpc_endpoint_destroy(exec_ctx, g_connecting);
   g_connecting = NULL;
-  finish_connection();
+  finish_connection(exec_ctx);
 }
 
 static void must_fail(grpc_exec_ctx *exec_ctx, void *arg, grpc_error *error) {

--- a/test/core/iomgr/tcp_server_uv_test.c
+++ b/test/core/iomgr/tcp_server_uv_test.c
@@ -111,8 +111,8 @@ static void on_connect(grpc_exec_ctx *exec_ctx, void *arg, grpc_endpoint *tcp,
   gpr_mu_lock(g_mu);
   g_result = temp_result;
   g_nconnects++;
-  GPR_ASSERT(
-      GRPC_LOG_IF_ERROR("pollset_kick", grpc_pollset_kick(g_pollset, NULL)));
+  GPR_ASSERT(GRPC_LOG_IF_ERROR("pollset_kick",
+                               grpc_pollset_kick(exec_ctx, g_pollset, NULL)));
   gpr_mu_unlock(g_mu);
 }
 


### PR DESCRIPTION
Fix a missing parameter bug leading to build failures
../src/core/lib/iomgr/pollset_uv.c:148:13: error: conflicting types for 'grpc_pollset_kick'
 grpc_error *grpc_pollset_kick(grpc_pollset *pollset,
             ^
In file included from ../src/core/lib/iomgr/pollset_uv.c:32:0:
.././src/core/lib/iomgr/pollset.h:79:13: note: previous declaration of 'grpc_pollset_kick' was here
 grpc_error *grpc_pollset_kick(grpc_exec_ctx *exec_ctx, grpc_pollset *pollset,