### PR TITLE
Add back mpscq request matcher implementation

### DIFF
--- a/include/grpc++/server_builder.h
+++ b/include/grpc++/server_builder.h
@@ -202,7 +202,10 @@ class ServerBuilder {
 
   struct SyncServerSettings {
     SyncServerSettings()
-        : num_cqs(1), min_pollers(1), max_pollers(2), cq_timeout_msec(10000) {}
+        : num_cqs(GPR_MAX(1, gpr_cpu_num_cores())),
+          min_pollers(1),
+          max_pollers(2),
+          cq_timeout_msec(10000) {}
 
     /// Number of server completion queues to create to listen to incoming RPCs.
     int num_cqs;

--- a/src/core/lib/support/mpscq.h
+++ b/src/core/lib/support/mpscq.h
@@ -20,6 +20,7 @@
 #define GRPC_CORE_LIB_SUPPORT_MPSCQ_H
 
 #include <grpc/support/atm.h>
+#include <grpc/support/sync.h>
 #include <stdbool.h>
 #include <stddef.h>
 
@@ -49,13 +50,40 @@ typedef struct gpr_mpscq {
 void gpr_mpscq_init(gpr_mpscq* q);
 void gpr_mpscq_destroy(gpr_mpscq* q);
 // Push a node
-void gpr_mpscq_push(gpr_mpscq* q, gpr_mpscq_node* n);
+// Thread safe - can be called from multiple threads concurrently
+// Returns true if this was possibly the first node (may return true
+// sporadically, will not return false sporadically)
+bool gpr_mpscq_push(gpr_mpscq* q, gpr_mpscq_node* n);
 // Pop a node (returns NULL if no node is ready - which doesn't indicate that
 // the queue is empty!!)
+// Thread compatible - can only be called from one thread at a time
 gpr_mpscq_node* gpr_mpscq_pop(gpr_mpscq* q);
 // Pop a node; sets *empty to true if the queue is empty, or false if it is not
 gpr_mpscq_node* gpr_mpscq_pop_and_check_end(gpr_mpscq* q, bool* empty);
 
+// An mpscq with a lock: it's safe to pop from multiple threads, but doing
+// only one thread will succeed concurrently
+typedef struct gpr_locked_mpscq {
+  gpr_mpscq queue;
+  gpr_mu mu;
+} gpr_locked_mpscq;
+
+void gpr_locked_mpscq_init(gpr_locked_mpscq* q);
+void gpr_locked_mpscq_destroy(gpr_locked_mpscq* q);
+// Push a node
+// Thread safe - can be called from multiple threads concurrently
+// Returns true if this was possibly the first node (may return true
+// sporadically, will not return false sporadically)
+bool gpr_locked_mpscq_push(gpr_locked_mpscq* q, gpr_mpscq_node* n);
+
+// Pop a node (returns NULL if no node is ready - which doesn't indicate that
+// the queue is empty!!)
+// Thread safe - can be called from multiple threads concurrently
+gpr_mpscq_node* gpr_locked_mpscq_try_pop(gpr_locked_mpscq* q);
+
+// Pop a node.  Returns NULL only if the queue was empty at some point after
+// calling this function
+gpr_mpscq_node* gpr_locked_mpscq_pop(gpr_locked_mpscq* q);
 #ifdef __cplusplus
 }
 #endif

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -376,8 +376,8 @@ int grpc_completion_queue_thread_local_cache_flush(grpc_completion_queue* cq,
       (grpc_completion_queue*)gpr_tls_get(&g_cached_cq) == cq) {
     *tag = storage->tag;
     grpc_exec_ctx exec_ctx = GRPC_EXEC_CTX_INIT;
-    storage->done(&exec_ctx, storage->done_arg, storage);
     *ok = (storage->next & (uintptr_t)(1)) == 1;
+    storage->done(&exec_ctx, storage->done_arg, storage);
     ret = 1;
     cq_next_data* cqd = (cq_next_data*)DATA_FROM_CQ(cq);
     if (gpr_atm_full_fetch_add(&cqd->pending_events, -1) == 1) {


### PR DESCRIPTION
This fixes a bug where we attempt to pop() from a queue and get a failure, and assume that the queue is empty when it is not.

I confirmed that the Tensorflow OSS benchmark that was hanging is now passing.

I switched to use mutexes over spinlocks.  There doesn't seem to be a performance regression, probably because we only make the slow path significantly worse.