### PR TITLE
Don't run bm_fullstack_trickle in basic tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3690,6 +3690,9 @@ targets:
   args:
   - --benchmark_min_time=0
   defaults: benchmark
+  exclude_configs:
+  - dbg
+  - opt
   excluded_poll_engines:
   - poll
   - poll-cv

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3065,7 +3065,10 @@
       "posix"
     ], 
     "cpu_cost": 1.0, 
-    "exclude_configs": [], 
+    "exclude_configs": [
+      "dbg", 
+      "opt"
+    ], 
     "exclude_iomgrs": [], 
     "excluded_poll_engines": [
       "poll", 


### PR DESCRIPTION
`bm_fullstack_trickle` takes ~20 minutes to run under both epollsig and epoll1. It's already being tested in our performance job, so testing it in basic tests is redundant. It'll still be tested under asan/tsan. Not running it should allow time for more C++ tests to run for pull requests. 