### PR TITLE
Backport #12615

### DIFF
--- a/src/python/grpcio_testing/grpc_testing/__init__.py
+++ b/src/python/grpcio_testing/grpc_testing/__init__.py
@@ -213,7 +213,7 @@ class StreamStreamChannelRpc(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
 
-class Channel(six.with_metaclass(abc.ABCMeta), grpc.Channel):
+class Channel(six.with_metaclass(abc.ABCMeta, grpc.Channel)):
     """A grpc.Channel double with which to test a system that invokes RPCs."""
 
     @abc.abstractmethod


### PR DESCRIPTION
#12615
This is causing Python tests to fail on the 1.6 line.