### PR TITLE
Add c-ares resolver tests against GCE DNS, redo of #12010

### DIFF
--- a/templates/test/cpp/naming/create_private_dns_zone.sh.template
+++ b/templates/test/cpp/naming/create_private_dns_zone.sh.template
@@ -1,0 +1,4 @@
+%YAML 1.2
+--- |
+  <%namespace file="create_private_dns_zone_defs.include" import="*"/>\
+  ${create_private_dns_zone(resolver_gce_integration_tests_zone_id, resolver_tests_common_zone_name)}

--- a/templates/test/cpp/naming/create_private_dns_zone_defs.include
+++ b/templates/test/cpp/naming/create_private_dns_zone_defs.include
@@ -1,0 +1,32 @@
+<%def name="create_private_dns_zone(resolver_gce_integration_tests_zone_id, resolver_tests_common_zone_name)">#!/bin/bash
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is auto-generated
+
+set -ex
+
+cd $(dirname $0)/../../..
+
+gcloud alpha dns managed-zones create \\
+
+  ${resolver_gce_integration_tests_zone_id} \\
+
+  --dns-name=${resolver_tests_common_zone_name} \\
+
+  --description="GCE-DNS-private-zone-for-GRPC-testing" \\
+
+  --visibility=private \\
+
+  --networks=default</%def>

--- a/templates/test/cpp/naming/private_dns_zone_init.sh.template
+++ b/templates/test/cpp/naming/private_dns_zone_init.sh.template
@@ -1,0 +1,4 @@
+%YAML 1.2
+--- |
+  <%namespace file="private_dns_zone_init_defs.include" import="*"/>\
+  ${private_dns_zone_init(all_integration_test_records, resolver_gce_integration_tests_zone_id, resolver_tests_common_zone_name)}

--- a/templates/test/cpp/naming/private_dns_zone_init_defs.include
+++ b/templates/test/cpp/naming/private_dns_zone_init_defs.include
@@ -1,0 +1,40 @@
+<%def name="private_dns_zone_init(records,resolver_gce_integration_tests_zone_id,resolver_tests_common_zone_name)">#!/bin/bash
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is auto-generated
+
+set -ex
+
+cd $(dirname $0)/../../..
+
+gcloud dns record-sets transaction start -z=${resolver_gce_integration_tests_zone_id}
+
+% for r in records:
+gcloud dns record-sets transaction add \\
+
+  -z=${resolver_gce_integration_tests_zone_id} \\
+
+  --name=${r['name']}.${resolver_tests_common_zone_name} \\
+
+  --type=${r['type']} \\
+
+  --ttl=${r['ttl']} \\
+
+  ${r['data']}
+
+% endfor
+gcloud dns record-sets transaction describe -z=${resolver_gce_integration_tests_zone_id}
+gcloud dns record-sets transaction execute -z=${resolver_gce_integration_tests_zone_id}
+gcloud dns record-sets list -z=${resolver_gce_integration_tests_zone_id}</%def>

--- a/templates/test/cpp/naming/resolver_gce_integration_tests_defs.include
+++ b/templates/test/cpp/naming/resolver_gce_integration_tests_defs.include
@@ -1,0 +1,64 @@
+<%def name="resolver_gce_integration_tests(tests, records, resolver_tests_common_zone_name)">#!/bin/bash
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is auto-generated
+
+set -ex
+
+if [[ "$GRPC_DNS_RESOLVER" == "" ]]; then
+  export GRPC_DNS_RESOLVER=ares
+elif [[ "$GRPC_DNS_RESOLVER" != ares ]]; then
+  echo "Unexpected: GRPC_DNS_RESOLVER=$GRPC_DNS_RESOLVER. This test only works with c-ares resolver"
+  exit 1
+fi
+
+cd $(dirname $0)/../../..
+
+if [[ "$CONFIG" == "" ]]; then
+  export CONFIG=opt
+fi
+make resolver_component_test
+echo "Sanity check DNS records are resolveable with dig:"
+EXIT_CODE=0
+
+% for r in records:
+ONE_FAILED=0
+dig ${r['type']} ${r['name']}.${resolver_tests_common_zone_name} | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig ${r['type']} ${r['name']}.${resolver_tests_common_zone_name} FAILED"
+  exit 1
+fi
+
+% endfor
+echo "Sanity check PASSED. Run resolver tests:"
+
+% for test in tests:
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \\
+
+  --target_name='${test['target_name']}' \\
+
+  --expected_addrs='${test['expected_addrs']}' \\
+
+  --expected_chosen_service_config='${test['expected_chosen_service_config']}' \\
+
+  --expected_lb_policy='${test['expected_lb_policy']}' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: ${test['target_name']} FAILED"
+  EXIT_CODE=1
+fi
+
+% endfor
+exit $EXIT_CODE</%def>

--- a/templates/test/cpp/naming/resolver_gce_integration_tests_runner.sh.template
+++ b/templates/test/cpp/naming/resolver_gce_integration_tests_runner.sh.template
@@ -1,0 +1,4 @@
+%YAML 1.2
+--- |
+  <%namespace file="resolver_gce_integration_tests_defs.include" import="*"/>\
+  ${resolver_gce_integration_tests(resolver_gce_integration_test_cases, all_integration_test_records, resolver_tests_common_zone_name)}

--- a/test/cpp/naming/README.md
+++ b/test/cpp/naming/README.md
@@ -1,0 +1,43 @@
+# Resolver Tests
+
+This directory has tests and infrastructure for unit tests and GCE
+integration tests of gRPC resolver functionality.
+
+There are two different tests here:
+
+## Resolver unit tests (resolver "component" tests)
+
+These tests run per-change, along with the rest of the grpc unit tests.
+They query a local testing DNS server.
+
+## GCE integration tests
+
+These tests use the same test binary and the same test records
+as the unit tests, but they run against GCE DNS (this is done by
+running the test on a GCE instance and not specifying an authority
+in uris). These tests run in a background job, which needs to be
+actively monitored.
+
+## Making changes to test records
+
+After making a change to `resolver_test_record_groups.yaml`:
+
+1. Increment the "version number" in the `resolver_tests_common_zone_name`
+   DNS zone (this is a yaml field at the top
+   of `resolver_test_record_groups.yaml`).
+
+2. Regenerate projects.
+
+3. From the repo root, run:
+
+```
+$ test/cpp/naming/create_dns_private_zone.sh
+$ test/cpp/naming/private_dns_zone_init.sh
+```
+
+Note that these commands must be ran in environment that
+has access to the grpc-testing GCE project.
+
+If everything runs smoothly, then once the change is merged,
+the GCE DNS integration testing job will transition to the
+new records and continue passing.

--- a/test/cpp/naming/create_private_dns_zone.sh
+++ b/test/cpp/naming/create_private_dns_zone.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is auto-generated
+
+set -ex
+
+cd $(dirname $0)/../../..
+
+gcloud alpha dns managed-zones create \
+  resolver-tests-version-1-grpctestingexp-zone-id \
+  --dns-name=resolver-tests-version-1.grpctestingexp. \
+  --description="GCE-DNS-private-zone-for-GRPC-testing" \
+  --visibility=private \
+  --networks=default

--- a/test/cpp/naming/gen_build_yaml.py
+++ b/test/cpp/naming/gen_build_yaml.py
@@ -24,6 +24,12 @@ import json
 
 _LOCAL_DNS_SERVER_ADDRESS = '127.0.0.1:15353'
 
+_TARGET_RECORDS_TO_SKIP_AGAINST_GCE = [
+  # TODO: enable this once able to upload the very large TXT record
+  # in this group to GCE DNS.
+  'ipv4-config-causing-fallback-to-tcp',
+]
+
 def _append_zone_name(name, zone_name):
   return '%s.%s' % (name, zone_name)
 
@@ -33,21 +39,107 @@ def _build_expected_addrs_cmd_arg(expected_addrs):
     out.append('%s,%s' % (addr['address'], str(addr['is_balancer'])))
   return ';'.join(out)
 
+def _data_for_type(r_type, r_data, common_zone_name):
+  if r_type in ['A', 'AAAA']:
+    return ' '.join(map(lambda x: '\"%s\"' % x, r_data))
+  if r_type == 'SRV':
+    assert len(r_data) == 1
+    target = r_data[0].split(' ')[3]
+    uploadable_target = '%s.%s' % (target, common_zone_name)
+    uploadable = r_data[0].split(' ')
+    uploadable[3] = uploadable_target
+    return '\"%s\"' % ' '.join(uploadable)
+  if r_type == 'TXT':
+    assert len(r_data) == 1
+    chunks = []
+    all_data = r_data[0]
+    cur = 0
+    # Split TXT records that span more than 255 characters (the single
+    # string length-limit in DNS) into multiple strings. Each string
+    # needs to be wrapped with double-quotes, and all inner double-quotes
+    # are escaped. The wrapping double-quotes and inner backslashes can be
+    # counted towards the 255 character length limit (as observed with gcloud),
+    # so make sure all strings fit within that limit.
+    while len(all_data[cur:]) > 0:
+      next_chunk = '\"'
+      while len(next_chunk) < 254 and len(all_data[cur:]) > 0:
+        if all_data[cur] == '\"':
+          if len(next_chunk) < 253:
+            next_chunk += '\\\"'
+          else:
+            break
+        else:
+          next_chunk += all_data[cur]
+        cur += 1
+      next_chunk += '\"'
+      if len(next_chunk) > 255:
+        raise Exception('Bug: next chunk is too long.')
+      chunks.append(next_chunk)
+    # Wrap the whole record in single quotes to make sure all strings
+    # are associated with the same TXT record (to make it one bash token for
+    # gcloud)
+    return '\'%s\'' % ' '.join(chunks)
+
+# Convert DNS records from their "within a test group" format
+# of the yaml file to an easier form for the templates to use.
+def _gcloud_uploadable_form(test_cases, common_zone_name):
+  out = []
+  for group in test_cases:
+    if group['record_to_resolve'] in _TARGET_RECORDS_TO_SKIP_AGAINST_GCE:
+      continue
+    for record_name in group['records'].keys():
+      r_ttl = None
+      all_r_data = {}
+      for r_data in group['records'][record_name]:
+        # enforce records have the same TTL only for simplicity
+        if r_ttl is None:
+          r_ttl = r_data['TTL']
+        assert r_ttl == r_data['TTL'], '%s and %s differ' % (r_ttl, r_data['TTL'])
+        r_type = r_data['type']
+        if all_r_data.get(r_type) is None:
+          all_r_data[r_type] = []
+        all_r_data[r_type].append(r_data['data'])
+      for r_type in all_r_data.keys():
+        for r in out:
+          assert r['name'] != record_name or r['type'] != r_type, 'attempt to add a duplicate record'
+        out.append({
+            'name': record_name,
+            'ttl': r_ttl,
+            'type': r_type,
+            'data': _data_for_type(r_type, all_r_data[r_type], common_zone_name)
+        })
+  return out
+
+def _gce_dns_zone_id(resolver_component_data):
+  dns_name = resolver_component_data['resolver_tests_common_zone_name']
+  return dns_name.replace('.', '-') + 'zone-id'
+
+def _resolver_test_cases(resolver_component_data, records_to_skip):
+  out = []
+  for test_case in resolver_component_data['resolver_component_tests']:
+    if test_case['record_to_resolve'] in records_to_skip:
+      continue
+    out.append({
+      'target_name': _append_zone_name(test_case['record_to_resolve'],
+                                       resolver_component_data['resolver_tests_common_zone_name']),
+      'expected_addrs': _build_expected_addrs_cmd_arg(test_case['expected_addrs']),
+      'expected_chosen_service_config': (test_case['expected_chosen_service_config'] or ''),
+      'expected_lb_policy': (test_case['expected_lb_policy'] or ''),
+    })
+  return out
+
 def main():
   resolver_component_data = ''
   with open('test/cpp/naming/resolver_test_record_groups.yaml') as f:
     resolver_component_data = yaml.load(f)
 
   json = {
-      'resolver_component_test_cases': [
-          {
-              'target_name': _append_zone_name(test_case['record_to_resolve'],
-                                                 resolver_component_data['resolver_component_tests_common_zone_name']),
-              'expected_addrs': _build_expected_addrs_cmd_arg(test_case['expected_addrs']),
-              'expected_chosen_service_config': (test_case['expected_chosen_service_config'] or ''),
-              'expected_lb_policy': (test_case['expected_lb_policy'] or ''),
-          } for test_case in resolver_component_data['resolver_component_tests']
-      ],
+      'resolver_tests_common_zone_name': resolver_component_data['resolver_tests_common_zone_name'],
+      'resolver_gce_integration_tests_zone_id': _gce_dns_zone_id(resolver_component_data),
+      'all_integration_test_records': _gcloud_uploadable_form(resolver_component_data['resolver_component_tests'],
+                                                              resolver_component_data['resolver_tests_common_zone_name']),
+      'resolver_gce_integration_test_cases': _resolver_test_cases(resolver_component_data, _TARGET_RECORDS_TO_SKIP_AGAINST_GCE),
+      'resolver_component_test_cases': _resolver_test_cases(resolver_component_data, []),
       'targets': [
           {
               'name': 'resolver_component_test' + unsecure_build_config_suffix,

--- a/test/cpp/naming/private_dns_zone_init.sh
+++ b/test/cpp/naming/private_dns_zone_init.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is auto-generated
+
+set -ex
+
+cd $(dirname $0)/../../..
+
+gcloud dns record-sets transaction start -z=resolver-tests-version-1-grpctestingexp-zone-id
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp. \
+  --type=SRV \
+  --ttl=2100 \
+  "0 0 1234 ipv4-single-target.resolver-tests-version-1.grpctestingexp."
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv4-single-target.resolver-tests-version-1.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "1.2.3.4"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp. \
+  --type=SRV \
+  --ttl=2100 \
+  "0 0 1234 ipv4-multi-target.resolver-tests-version-1.grpctestingexp."
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv4-multi-target.resolver-tests-version-1.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "1.2.3.5" "1.2.3.6" "1.2.3.7"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp. \
+  --type=SRV \
+  --ttl=2100 \
+  "0 0 1234 ipv6-single-target.resolver-tests-version-1.grpctestingexp."
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv6-single-target.resolver-tests-version-1.grpctestingexp. \
+  --type=AAAA \
+  --ttl=2100 \
+  "2607:f8b0:400a:801::1001"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp. \
+  --type=SRV \
+  --ttl=2100 \
+  "0 0 1234 ipv6-multi-target.resolver-tests-version-1.grpctestingexp."
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv6-multi-target.resolver-tests-version-1.grpctestingexp. \
+  --type=AAAA \
+  --ttl=2100 \
+  "2607:f8b0:400a:801::1002" "2607:f8b0:400a:801::1003" "2607:f8b0:400a:801::1004"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. \
+  --type=TXT \
+  --ttl=2100 \
+  '"grpc_config=[{\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"SimpleService\",\"waitForReady\":true}]}]}}]"'
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "1.2.3.4"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. \
+  --type=SRV \
+  --ttl=2100 \
+  "0 0 1234 ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp."
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "1.2.3.4"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. \
+  --type=TXT \
+  --ttl=2100 \
+  '"grpc_config=[{\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"NoSrvSimpleService\",\"waitForReady\":true}]}]}}]"'
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "1.2.3.4"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. \
+  --type=TXT \
+  --ttl=2100 \
+  '"grpc_config=[{\"clientLanguage\":[\"python\"],\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"PythonService\",\"waitForReady\":true}]}]}}]"'
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "1.2.3.4"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. \
+  --type=TXT \
+  --ttl=2100 \
+  '"grpc_config=[{\"percentage\":0,\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"CppService\",\"waitForReady\":true}]}]}}]"'
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "1.2.3.4"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. \
+  --type=TXT \
+  --ttl=2100 \
+  '"grpc_config=[{\"clientLanguage\":[\"go\"],\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"GoService\",\"waitForReady\":true}]}]}},{\"clientLanguage\":[\"c++\"],\"serviceConfig\":{" "\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"CppService\",\"waitForReady\":true}]}]}}]"'
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "1.2.3.4"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. \
+  --type=TXT \
+  --ttl=2100 \
+  '"grpc_config=[{\"percentage\":0,\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"NeverPickedService\",\"waitForReady\":true}]}]}},{\"percentage\":100,\"serviceConfig\":{\"loadBalanc" "ingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"AlwaysPickedService\",\"waitForReady\":true}]}]}}]"'
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  --type=SRV \
+  --ttl=2100 \
+  "0 0 1234 balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp."
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "1.2.3.4"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "1.2.3.4"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  --type=SRV \
+  --ttl=2100 \
+  "0 0 1234 balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp."
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  --type=AAAA \
+  --ttl=2100 \
+  "2607:f8b0:400a:801::1002"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-1-grpctestingexp-zone-id \
+  --name=srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  --type=AAAA \
+  --ttl=2100 \
+  "2607:f8b0:400a:801::1002"
+
+gcloud dns record-sets transaction describe -z=resolver-tests-version-1-grpctestingexp-zone-id
+gcloud dns record-sets transaction execute -z=resolver-tests-version-1-grpctestingexp-zone-id
+gcloud dns record-sets list -z=resolver-tests-version-1-grpctestingexp-zone-id

--- a/test/cpp/naming/resolver_component_tests_runner.sh
+++ b/test/cpp/naming/resolver_component_tests_runner.sh
@@ -73,7 +73,7 @@ EXIT_CODE=0
 # in the resolver.
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-single-target.resolver-tests.grpctestingexp.' \
+  --target_name='srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -81,7 +81,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-multi-target.resolver-tests.grpctestingexp.' \
+  --target_name='srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp.' \
   --expected_addrs='1.2.3.5:1234,True;1.2.3.6:1234,True;1.2.3.7:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -89,7 +89,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-single-target.resolver-tests.grpctestingexp.' \
+  --target_name='srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1001]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -97,7 +97,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-multi-target.resolver-tests.grpctestingexp.' \
+  --target_name='srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1003]:1234,True;[2607:f8b0:400a:801::1004]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -105,7 +105,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-simple-service-config.resolver-tests.grpctestingexp.' \
+  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -113,7 +113,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-no-srv-simple-service-config.resolver-tests.grpctestingexp.' \
+  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -121,7 +121,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-no-config-for-cpp.resolver-tests.grpctestingexp.' \
+  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -129,7 +129,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests.grpctestingexp.' \
+  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -137,7 +137,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-second-language-is-cpp.resolver-tests.grpctestingexp.' \
+  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -145,7 +145,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-config-with-percentages.resolver-tests.grpctestingexp.' \
+  --target_name='ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -153,7 +153,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests.grpctestingexp.' \
+  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True;1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -161,7 +161,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests.grpctestingexp.' \
+  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1002]:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -169,7 +169,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-config-causing-fallback-to-tcp.resolver-tests.grpctestingexp.' \
+  --target_name='ipv4-config-causing-fallback-to-tcp.resolver-tests-version-1.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='' \

--- a/test/cpp/naming/resolver_gce_integration_tests_runner.sh
+++ b/test/cpp/naming/resolver_gce_integration_tests_runner.sh
@@ -1,0 +1,359 @@
+#!/bin/bash
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is auto-generated
+
+set -ex
+
+if [[ "$GRPC_DNS_RESOLVER" == "" ]]; then
+  export GRPC_DNS_RESOLVER=ares
+elif [[ "$GRPC_DNS_RESOLVER" != ares ]]; then
+  echo "Unexpected: GRPC_DNS_RESOLVER=$GRPC_DNS_RESOLVER. This test only works with c-ares resolver"
+  exit 1
+fi
+
+cd $(dirname $0)/../../..
+
+if [[ "$CONFIG" == "" ]]; then
+  export CONFIG=opt
+fi
+make resolver_component_test
+echo "Sanity check DNS records are resolveable with dig:"
+EXIT_CODE=0
+
+ONE_FAILED=0
+dig SRV _grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig A ipv4-single-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig A ipv4-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig SRV _grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig A ipv4-multi-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig A ipv4-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig SRV _grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig AAAA ipv6-single-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig AAAA ipv6-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig SRV _grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig AAAA ipv6-multi-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig AAAA ipv6-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig TXT srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig TXT srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig A ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig A ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig SRV _grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig A ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig A ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig TXT ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig TXT ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig A ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig A ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig TXT ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig TXT ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig A ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig A ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig TXT ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig TXT ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig A ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig A ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig TXT ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig TXT ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig A ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig A ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig TXT ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig TXT ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig SRV _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig A balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig A balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig A srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig A srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig SRV _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig AAAA balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig AAAA balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig AAAA srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig AAAA srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  exit 1
+fi
+
+echo "Sanity check PASSED. Run resolver tests:"
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp.' \
+  --expected_addrs='1.2.3.4:1234,True' \
+  --expected_chosen_service_config='' \
+  --expected_lb_policy='' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp.' \
+  --expected_addrs='1.2.3.5:1234,True;1.2.3.6:1234,True;1.2.3.7:1234,True' \
+  --expected_chosen_service_config='' \
+  --expected_lb_policy='' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp.' \
+  --expected_addrs='[2607:f8b0:400a:801::1001]:1234,True' \
+  --expected_chosen_service_config='' \
+  --expected_lb_policy='' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp.' \
+  --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1003]:1234,True;[2607:f8b0:400a:801::1004]:1234,True' \
+  --expected_chosen_service_config='' \
+  --expected_lb_policy='' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp.' \
+  --expected_addrs='1.2.3.4:1234,True' \
+  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}' \
+  --expected_lb_policy='round_robin' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp.' \
+  --expected_addrs='1.2.3.4:443,False' \
+  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}' \
+  --expected_lb_policy='round_robin' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp.' \
+  --expected_addrs='1.2.3.4:443,False' \
+  --expected_chosen_service_config='' \
+  --expected_lb_policy='' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp.' \
+  --expected_addrs='1.2.3.4:443,False' \
+  --expected_chosen_service_config='' \
+  --expected_lb_policy='' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp.' \
+  --expected_addrs='1.2.3.4:443,False' \
+  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}' \
+  --expected_lb_policy='round_robin' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp.' \
+  --expected_addrs='1.2.3.4:443,False' \
+  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}' \
+  --expected_lb_policy='round_robin' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp.' \
+  --expected_addrs='1.2.3.4:1234,True;1.2.3.4:443,False' \
+  --expected_chosen_service_config='' \
+  --expected_lb_policy='' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp.' \
+  --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1002]:443,False' \
+  --expected_chosen_service_config='' \
+  --expected_lb_policy='' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+exit $EXIT_CODE

--- a/test/cpp/naming/resolver_test_record_groups.yaml
+++ b/test/cpp/naming/resolver_test_record_groups.yaml
@@ -1,4 +1,4 @@
-resolver_component_tests_common_zone_name: resolver-tests.grpctestingexp.
+resolver_tests_common_zone_name: resolver-tests-version-1.grpctestingexp.
 resolver_component_tests:
 - expected_addrs:
   - {address: '1.2.3.4:1234', is_balancer: true}

--- a/test/cpp/naming/test_dns_server.py
+++ b/test/cpp/naming/test_dns_server.py
@@ -66,7 +66,7 @@ def start_local_dns_server(args):
 
   with open(args.records_config_path) as config:
     test_records_config = yaml.load(config)
-  common_zone_name = test_records_config['resolver_component_tests_common_zone_name']
+  common_zone_name = test_records_config['resolver_tests_common_zone_name']
   for group in test_records_config['resolver_component_tests']:
     for name in group['records'].keys():
       for record in group['records'][name]:


### PR DESCRIPTION
This is a redo of https://github.com/grpc/grpc/pull/12010, now using the infrastructure added in #12210.

This adds a "background job" that tests c-ares resolver against GCE DNS. It allows testing that c-ares interops with GCE DNS. IMO another benefit is it adds a sanity check that the local testing DNS server from #12210 is realistic.

This is running in an adhoc jenkins right now, in https://grpc-testing.appspot.com/job/gRPC_naming_adhoc/ (that job previously used by #12010).