### PR TITLE
Add TLS verify callback for Python and Ruby

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7511,6 +7511,7 @@ target_include_directories(handshake_verify_peer_options
   PRIVATE ${_gRPC_CARES_INCLUDE_DIR}
   PRIVATE ${_gRPC_GFLAGS_INCLUDE_DIR}
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+  PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
 
 target_link_libraries(handshake_verify_peer_options

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -1378,7 +1378,8 @@ def method_handlers_generic_handler(service, method_handlers):
 
 def ssl_channel_credentials(root_certificates=None,
                             private_key=None,
-                            certificate_chain=None):
+                            certificate_chain=None,
+                            verify_options=None):
     """Creates a ChannelCredentials for use with an SSL-enabled Channel.
 
     Args:
@@ -1395,7 +1396,7 @@ def ssl_channel_credentials(root_certificates=None,
     """
     return ChannelCredentials(
         _cygrpc.SSLChannelCredentials(root_certificates, private_key,
-                                      certificate_chain))
+                                      certificate_chain, verify_options))
 
 
 def metadata_call_credentials(metadata_plugin, name=None):

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -1379,7 +1379,7 @@ def method_handlers_generic_handler(service, method_handlers):
 def ssl_channel_credentials(root_certificates=None,
                             private_key=None,
                             certificate_chain=None,
-                            verify_options=None):
+                            verify_callback=None):
     """Creates a ChannelCredentials for use with an SSL-enabled Channel.
 
     Args:
@@ -1390,13 +1390,19 @@ def ssl_channel_credentials(root_certificates=None,
         private key should be used.
       certificate_chain: The PEM-encoded certificate chain as a byte string
         to use or or None if no certificate chain should be used.
+      verify_callback: A function which will be called back during the TLS
+        handshake after hostname verification has been performed. This callback
+        can be used to perform additional custom verification of the server
+        certificate. The callback will receive two arguments: the expected
+        hostname of the server and the server's presented certificate as a
+        string in PEM format.
 
     Returns:
       A ChannelCredentials for use with an SSL-enabled Channel.
     """
     return ChannelCredentials(
         _cygrpc.SSLChannelCredentials(root_certificates, private_key,
-                                      certificate_chain, verify_options))
+                                      certificate_chain, verify_callback))
 
 
 def metadata_call_credentials(metadata_plugin, name=None):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
@@ -67,7 +67,7 @@ cdef class SSLChannelCredentials(ChannelCredentials):
   cdef readonly object _pem_root_certificates
   cdef readonly object _private_key
   cdef readonly object _certificate_chain
-  cdef readonly object _verify_options
+  cdef readonly object _verify_callback
 
   cdef grpc_channel_credentials *c(self)
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
@@ -67,6 +67,7 @@ cdef class SSLChannelCredentials(ChannelCredentials):
   cdef readonly object _pem_root_certificates
   cdef readonly object _private_key
   cdef readonly object _certificate_chain
+  cdef readonly object _verify_options
 
   cdef grpc_channel_credentials *c(self)
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -153,11 +153,11 @@ cdef void _verify_peer_callback_destruct(void *userdata) with gil:
 cdef class SSLChannelCredentials(ChannelCredentials):
 
   def __cinit__(
-      self, pem_root_certificates, private_key, certificate_chain, verify_options):
+      self, pem_root_certificates, private_key, certificate_chain, verify_callback):
     self._pem_root_certificates = pem_root_certificates
     self._private_key = private_key
     self._certificate_chain = certificate_chain
-    self._verify_options = verify_options
+    self._verify_callback = verify_callback
 
   cdef grpc_channel_credentials *c(self):
     cdef const char *c_pem_root_certificates
@@ -167,15 +167,13 @@ cdef class SSLChannelCredentials(ChannelCredentials):
     vp_options.verify_peer_callback = NULL
     vp_options.verify_peer_callback_userdata = NULL
     vp_options.verify_peer_destruct = NULL
-    if self._verify_options is not None:
-      if "checkServerIdentity" in self._verify_options:
-        fn = self._verify_options["checkServerIdentity"]
-        if not callable(fn):
-          raise TypeError("checkServerIdentity parameter must be callable.")
-        cpython.Py_INCREF(fn)
-        vp_options.verify_peer_callback = _verify_peer_callback_wrapper
-        vp_options.verify_peer_callback_userdata = <void*>fn
-        vp_options.verify_peer_destruct = _verify_peer_callback_destruct
+    if self._verify_callback is not None:
+      if not callable(self._verify_callback):
+        raise TypeError("verify_callback parameter must be callable.")
+      cpython.Py_INCREF(self._verify_callback)
+      vp_options.verify_peer_callback = _verify_peer_callback_wrapper
+      vp_options.verify_peer_callback_userdata = <void*>self._verify_callback
+      vp_options.verify_peer_destruct = _verify_peer_callback_destruct
 
     if self._pem_root_certificates is None:
       c_pem_root_certificates = NULL

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -458,8 +458,9 @@ cdef extern from "grpc/grpc_security.h":
     pass
 
   ctypedef struct verify_peer_options:
-    # We don't care about the internals (and in fact don't know them)
-    pass
+    int (*verify_peer_callback)(const char*, const char*, void*)
+    void *verify_peer_callback_userdata
+    void (*verify_peer_destruct)(void*)
 
   ctypedef void (*grpc_ssl_roots_override_callback)(char **pem_root_certs)
 

--- a/src/python/grpcio_tests/tests/unit/_auth_context_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_context_test.py
@@ -156,13 +156,13 @@ class AuthContextTest(unittest.TestCase):
         server.start()
 
         callbackResult = True
-        callbackHost = None
-        callbackCert = None
+        callbackReceiver = {
+            "host": None,
+            "cert": None
+        }
         def checkServerIdentity(host, cert):
-            nonlocal callbackHost
-            nonlocal callbackCert
-            callbackHost = host
-            callbackCert = cert
+            callbackReceiver["host"] = host
+            callbackReceiver["cert"] = cert
             return callbackResult
 
         channel_creds = grpc.ssl_channel_credentials(
@@ -183,21 +183,21 @@ class AuthContextTest(unittest.TestCase):
                 channel_creds,
                 options=_PROPERTY_OPTIONS)
             response = channel.unary_unary(_UNARY_UNARY)(_REQUEST)
-            self.assertEqual(_SERVER_HOST_OVERRIDE, callbackHost.decode('utf-8'))
-            self.assertEqual(_CERTIFICATE_CHAIN, callbackCert)
+            self.assertEqual(_SERVER_HOST_OVERRIDE, callbackReceiver["host"].decode('utf-8'))
+            self.assertEqual(_CERTIFICATE_CHAIN, callbackReceiver["cert"])
 
             # Run a failure connect and verify we got an exception and saw expected values
             callbackResult = False
-            callbackHost = None
-            callbackCert = None
+            callbackReceiver["host"] = None
+            callbackReceiver["cert"] = None
             channel = grpc.secure_channel(
                 'localhost:{}'.format(port),
                 channel_creds,
                 options=_PROPERTY_OPTIONS)
             with self.assertRaises(Exception):
                 response = channel.unary_unary(_UNARY_UNARY)(_REQUEST)
-            self.assertEqual(_SERVER_HOST_OVERRIDE, callbackHost.decode('utf-8'))
-            self.assertEqual(_CERTIFICATE_CHAIN, callbackCert)
+            self.assertEqual(_SERVER_HOST_OVERRIDE, callbackReceiver["host"].decode('utf-8'))
+            self.assertEqual(_CERTIFICATE_CHAIN, callbackReceiver["cert"])
         finally:
             server.stop(None)
 

--- a/src/python/grpcio_tests/tests/unit/_auth_context_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_context_test.py
@@ -169,9 +169,7 @@ class AuthContextTest(unittest.TestCase):
             root_certificates=_TEST_ROOT_CERTIFICATES,
             private_key=_PRIVATE_KEY,
             certificate_chain=_CERTIFICATE_CHAIN,
-            verify_options={
-                "checkServerIdentity": checkServerIdentity
-            }
+            verify_callback=checkServerIdentity
         )
         channel = grpc.secure_channel(
             'localhost:{}'.format(port),

--- a/src/python/grpcio_tests/tests/unit/_auth_context_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_context_test.py
@@ -156,10 +156,8 @@ class AuthContextTest(unittest.TestCase):
         server.start()
 
         callbackResult = True
-        callbackReceiver = {
-            "host": None,
-            "cert": None
-        }
+        callbackReceiver = {"host": None, "cert": None}
+
         def checkServerIdentity(host, cert):
             callbackReceiver["host"] = host
             callbackReceiver["cert"] = cert
@@ -169,8 +167,7 @@ class AuthContextTest(unittest.TestCase):
             root_certificates=_TEST_ROOT_CERTIFICATES,
             private_key=_PRIVATE_KEY,
             certificate_chain=_CERTIFICATE_CHAIN,
-            verify_callback=checkServerIdentity
-        )
+            verify_callback=checkServerIdentity)
         channel = grpc.secure_channel(
             'localhost:{}'.format(port),
             channel_creds,
@@ -183,7 +180,8 @@ class AuthContextTest(unittest.TestCase):
                 channel_creds,
                 options=_PROPERTY_OPTIONS)
             response = channel.unary_unary(_UNARY_UNARY)(_REQUEST)
-            self.assertEqual(_SERVER_HOST_OVERRIDE, callbackReceiver["host"].decode('utf-8'))
+            self.assertEqual(_SERVER_HOST_OVERRIDE,
+                             callbackReceiver["host"].decode('utf-8'))
             self.assertEqual(_CERTIFICATE_CHAIN, callbackReceiver["cert"])
 
             # Run a failure connect and verify we got an exception and saw expected values
@@ -196,11 +194,11 @@ class AuthContextTest(unittest.TestCase):
                 options=_PROPERTY_OPTIONS)
             with self.assertRaises(Exception):
                 response = channel.unary_unary(_UNARY_UNARY)(_REQUEST)
-            self.assertEqual(_SERVER_HOST_OVERRIDE, callbackReceiver["host"].decode('utf-8'))
+            self.assertEqual(_SERVER_HOST_OVERRIDE,
+                             callbackReceiver["host"].decode('utf-8'))
             self.assertEqual(_CERTIFICATE_CHAIN, callbackReceiver["cert"])
         finally:
             server.stop(None)
-
 
     def _do_one_shot_client_rpc(self, channel_creds, channel_options, port,
                                 expect_ssl_session_reused):

--- a/src/python/grpcio_tests/tests/unit/_cython/cygrpc_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/cygrpc_test.py
@@ -409,7 +409,7 @@ class SecureServerSecureClient(unittest.TestCase, ServerClientMixin):
                                          resources.certificate_chain())
             ], False)
         client_credentials = cygrpc.SSLChannelCredentials(
-            resources.test_root_certificates(), None, None)
+            resources.test_root_certificates(), None, None, None)
         self.setUpMixin(server_credentials, client_credentials,
                         _SSL_HOST_OVERRIDE)
 

--- a/src/ruby/ext/grpc/rb_channel_credentials.c
+++ b/src/ruby/ext/grpc/rb_channel_credentials.c
@@ -125,70 +125,82 @@ static ID id_pem_private_key;
 /* The attribute used on the mark object to hold the pem_private_key. */
 static ID id_pem_cert_chain;
 
-/* The attribute used on the mark object to hold the checkServerIdentity callback. */
+/* The attribute used on the mark object to hold the checkServerIdentity
+ * callback. */
 static ID id_check_server_identity_cb;
 
-
 struct verify_callback_params {
-    VALUE cb;
-    const char *servername;
-    const char *cert;
+  VALUE cb;
+  const char* servername;
+  const char* cert;
 };
 
 static VALUE verify_peer_callback_try_wrapper(VALUE arg) {
-    VALUE cb;
-    VALUE servername;
-    VALUE cert;
+  VALUE cb;
+  VALUE servername;
+  VALUE cert;
 
-    cb = rb_ary_entry(arg, 0);
-    servername = rb_ary_entry(arg, 1);
-    cert = rb_ary_entry(arg, 2);
+  cb = rb_ary_entry(arg, 0);
+  servername = rb_ary_entry(arg, 1);
+  cert = rb_ary_entry(arg, 2);
 
-    if (rb_class_of(cb) == rb_cProc) {
-        rb_funcall(cb, rb_intern("call"), 2, servername, cert);
-    } else if (rb_class_of(cb) == rb_cSymbol) {
-        rb_funcall(rb_class_of(cb), rb_to_id(cb), 2, servername, cert);
-    } else {
-        printf("Callback argument in verify_peer_callback_try_wrapper is an invalid type!\n");
-        return INT2NUM(1);
-    }
-    return INT2NUM(0);
-}
-
-static VALUE verify_peer_callback_catch_wrapper(VALUE arg, VALUE exception_object) {
-    // Catch just always returns a failure signal.
+  if (rb_class_of(cb) == rb_cProc) {
+    rb_funcall(cb, rb_intern("call"), 2, servername, cert);
+  } else if (rb_class_of(cb) == rb_cSymbol) {
+    rb_funcall(rb_class_of(cb), rb_to_id(cb), 2, servername, cert);
+  } else {
+    printf(
+        "Callback argument in verify_peer_callback_try_wrapper is an invalid "
+        "type!\n");
     return INT2NUM(1);
+  }
+  return INT2NUM(0);
 }
 
-/* Before we jump back from native code (which doesn't have the GVL), it's important
-   to re-acquire it otherwise badness can happen. So this method should be invoked
-   with the GVL (i.e. by using the rb_thread_call_with_gvl() method). */
-static void* invoke_rb_verify_callback_with_gvl(void *arg) {
-    VALUE result;
-    VALUE passthrough;
-    struct verify_callback_params* params = (struct verify_callback_params*)arg;
-
-    passthrough = rb_ary_new();
-    rb_ary_store(passthrough, 0, params->cb);
-    rb_ary_store(passthrough, 1, params->servername != NULL ? rb_str_new2(params->servername) : Qnil);
-    rb_ary_store(passthrough, 2, params->cert != NULL ? rb_str_new2(params->cert) : Qnil);
-
-    result = rb_rescue(verify_peer_callback_try_wrapper, passthrough, verify_peer_callback_catch_wrapper, Qnil);
-    return NUM2INT(result) == 0 ? NULL : arg;
+static VALUE verify_peer_callback_catch_wrapper(VALUE arg,
+                                                VALUE exception_object) {
+  // Catch just always returns a failure signal.
+  return INT2NUM(1);
 }
 
-static int verify_peer_callback_wrapper(const char* servername, const char* cert, void* userdata) {
-    struct verify_callback_params params;
-    if (userdata == NULL) {
-        printf("Error! Callback function wasn't set!\n");
-        return 1;
-    }
+/* Before we jump back from native code (which doesn't have the GVL), it's
+   important to re-acquire it otherwise badness can happen. So this method
+   should be invoked with the GVL (i.e. by using the rb_thread_call_with_gvl()
+   method). */
+static void* invoke_rb_verify_callback_with_gvl(void* arg) {
+  VALUE result;
+  VALUE passthrough;
+  struct verify_callback_params* params = (struct verify_callback_params*)arg;
 
-    params.cb = (VALUE)userdata;
-    params.servername = servername;
-    params.cert = cert;
+  passthrough = rb_ary_new();
+  rb_ary_store(passthrough, 0, params->cb);
+  rb_ary_store(
+      passthrough, 1,
+      params->servername != NULL ? rb_str_new2(params->servername) : Qnil);
+  rb_ary_store(passthrough, 2,
+               params->cert != NULL ? rb_str_new2(params->cert) : Qnil);
 
-    return rb_thread_call_with_gvl(invoke_rb_verify_callback_with_gvl, &params) == NULL ? 0 : 1;
+  result = rb_rescue(verify_peer_callback_try_wrapper, passthrough,
+                     verify_peer_callback_catch_wrapper, Qnil);
+  return NUM2INT(result) == 0 ? NULL : arg;
+}
+
+static int verify_peer_callback_wrapper(const char* servername,
+                                        const char* cert, void* userdata) {
+  struct verify_callback_params params;
+  if (userdata == NULL) {
+    printf("Error! Callback function wasn't set!\n");
+    return 1;
+  }
+
+  params.cb = (VALUE)userdata;
+  params.servername = servername;
+  params.cert = cert;
+
+  return rb_thread_call_with_gvl(invoke_rb_verify_callback_with_gvl, &params) ==
+                 NULL
+             ? 0
+             : 1;
 }
 
 /*
@@ -205,8 +217,8 @@ static int verify_peer_callback_wrapper(const char* servername, const char* cert
     pem_root_certs: (optional) PEM encoding of the server root certificate
     pem_private_key: (optional) PEM encoding of the client's private key
     pem_cert_chain: (optional) PEM encoding of the client's cert chain
-    verify_options: (optional) A Hash with key-value pairs defining additional peer verification options
-    Initializes Credential instances. */
+    verify_options: (optional) A Hash with key-value pairs defining additional
+  peer verification options Initializes Credential instances. */
 static VALUE grpc_rb_channel_credentials_init(int argc, VALUE* argv,
                                               VALUE self) {
   VALUE pem_root_certs = Qnil;
@@ -233,22 +245,26 @@ static VALUE grpc_rb_channel_credentials_init(int argc, VALUE* argv,
     pem_root_certs_cstr = RSTRING_PTR(pem_root_certs);
   }
   if (options_hash != Qnil) {
-    option_value = rb_hash_aref(options_hash, rb_str_new2("checkServerIdentity"));
+    option_value =
+        rb_hash_aref(options_hash, rb_str_new2("checkServerIdentity"));
     if (option_value != Qnil) {
-      if (rb_class_of(option_value) != rb_cProc && rb_class_of(option_value) != rb_cSymbol) {
-          rb_raise(rb_eTypeError, "Expected Proc or Symbol callback");
-          return Qnil;
+      if (rb_class_of(option_value) != rb_cProc &&
+          rb_class_of(option_value) != rb_cSymbol) {
+        rb_raise(rb_eTypeError, "Expected Proc or Symbol callback");
+        return Qnil;
       }
       vp_options.verify_peer_callback = verify_peer_callback_wrapper;
       vp_options.verify_peer_callback_userdata = (void*)option_value;
-      // The userdata object is marked on the credentials object as a hidden private member, so it will be automatically
-      // garbage collected by ruby (same as the PEM certs on the credentials object).
+      // The userdata object is marked on the credentials object as a hidden
+      // private member, so it will be automatically garbage collected by ruby
+      // (same as the PEM certs on the credentials object).
       vp_options.verify_peer_destruct = NULL;
       rb_ivar_set(self, id_check_server_identity_cb, option_value);
     }
   }
   if (pem_private_key == Qnil && pem_cert_chain == Qnil) {
-    creds = grpc_ssl_credentials_create(pem_root_certs_cstr, NULL, &vp_options, NULL);
+    creds = grpc_ssl_credentials_create(pem_root_certs_cstr, NULL, &vp_options,
+                                        NULL);
   } else {
     key_cert_pair.private_key = RSTRING_PTR(pem_private_key);
     key_cert_pair.cert_chain = RSTRING_PTR(pem_cert_chain);


### PR DESCRIPTION
Release 1.6.0 of grpc-java [added support](https://github.com/grpc/grpc-java/pull/3205) for using a custom TLS hostname verifier with clients. This feature parity doesn't exist for gRPC clients in other languages, which this PR tries to address (although an "override hostname" can be specified, support for an arbitrary callback is missing). In particular this adds support for a verification callback in JavaScript and Python. As an example, callbacks in JS look like:

    grpc.credentials.createSsl(
        fs.readFileSync("truststore.pem"),
        fs.readFileSync("client.pem.key"),
        fs.readFileSync("clent.pem.crt"),
        {
          "insecureSkipHostnameVerify": true,
          "checkServerIdentity": function(host, cert) {
            authContext = newAuthContextFromPem(cert);
            if (authContext.name != expectedName || (authContext.environment != myEnvironment) {
              throw "Invalid server certificate presented";
            }
          }
        });

The "checkServerIdentity" idiom was chosen to match the [same option](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) available to TLS clients with the built-in node library. (InsecurySkipHostnameVerify was inspired by [golang's InsecureSkipVerify option](https://golang.org/pkg/crypto/tls/#Config).)

In Python it looks like this:

    def checkServerIdentity(host, cert):
         authContext = newAuthContextFromPem(cert)
         if authContext.name != expectedName or authContext.environment != myEnvironment:
            return False
         return True

    grpc.ssl_channel_credentials(
        clientTrust.encode('utf-8'),
        open(clientKeystore[1]).read().encode('utf-8'),
        open(clientKeystore[0]).read().encode('utf-8'),
        {
          "insecureSkipHostnameVerify": True,
          "checkServerIdentity": checkServerIdentity
        })

For better context, the motivation for having callbacks like this stems from our internal PKI infrastructure where multidimensional identity information is added to various proprietary X.509 extensions. The policy on exactly which dimensions are relevant and should be checked varies from client to client so it's important that each client be able to supply verification logic.
In a less proprietary context, custom verifiers are often used as a supplemental check to do things like certificate or CA pinning.

We've been using an internal fork based on this PR for a few months now, so at least for JS and Python I have some practical confidence that this works as intended.