### PR TITLE
Dont assume sigint wasnt masked when invoking ruby tests

### DIFF
--- a/src/ruby/end2end/killed_client_thread_client.rb
+++ b/src/ruby/end2end/killed_client_thread_client.rb
@@ -35,7 +35,7 @@ def main
                                       :this_channel_is_insecure)
     stub.echo(Echo::EchoRequest.new(request: 'hello'))
     fail 'the clients rpc in this test shouldnt complete. ' \
-      'expecting SIGINT to happen in the middle of the call'
+      'expecting SIGTERM to happen in the middle of the call'
   end
   thd.join
 end

--- a/src/ruby/end2end/killed_client_thread_driver.rb
+++ b/src/ruby/end2end/killed_client_thread_driver.rb
@@ -69,9 +69,9 @@ def main
     call_started_cv.wait(call_started_mu) until call_started.val
   end
 
-  # SIGINT the child process now that it's
+  # SIGTERM the child process now that it's
   # in the middle of an RPC (happening on a non-main thread)
-  Process.kill('SIGINT', client_pid)
+  Process.kill('SIGTERM', client_pid)
   STDERR.puts 'sent shutdown'
 
   begin
@@ -88,8 +88,8 @@ def main
   end
 
   client_exit_code = $CHILD_STATUS
-  if client_exit_code.termsig != 2 # SIGINT
-    fail 'expected client exit from SIGINT ' \
+  if client_exit_code.termsig != 15 # SIGTERM
+    fail 'expected client exit from SIGTERM ' \
       "but got child status: #{client_exit_code}"
   end
 


### PR DESCRIPTION
fixes https://github.com/grpc/grpc/issues/12538

The `killed_client_thread_driver.rb` test spawns a child process, sends SIGINT to that process, and expects it to terminate (meant to exercise ruby signal handlers that wake up blocked threads). The test is failing because the signal doesn't appear to be received by the child process. Note though, explicitly setting up the default ruby-sigint handler at the beginning of the process does cause things to work.

The failure can be repro'd on mac or linux by running a bash script that looks like:
```
tools/run_tests/run_tests.py -l ruby &
wait 
```

[this explanation](https://lists.gnu.org/archive/html/bug-bash/2014-08/msg00061.html) for why that's expected to fail - I suspect that the kokoro mac test runner might be doing something along those lines. However, this seems reasonable for them to do and this test is probably too fragile.