### PR TITLE
run_full_performance.sh: Enable php benchmarks

### DIFF
--- a/tools/jenkins/run_full_performance.sh
+++ b/tools/jenkins/run_full_performance.sh
@@ -21,7 +21,7 @@ cd $(dirname $0)/../..
 
 # run 8core client vs 8core server
 tools/run_tests/run_performance_tests.py \
-    -l c++ csharp node ruby java python go node_express \
+    -l c++ csharp node ruby java python go node_express php \
     --netperf \
     --category scalable \
     --bq_result_table performance_test.performance_experiment \


### PR DESCRIPTION
Followed by #12675. Two scenarios runs well under performance adhoc:
[php_to_cpp_protobuf_sync_streaming_ping_pong](https://grpc-testing.appspot.com/view/Performance/job/gRPC_performance_adhoc/462/consoleFull)
[php_to_cpp_protobuf_sync_unary_ping_pong](https://grpc-testing.appspot.com/view/Performance/job/gRPC_performance_adhoc/463/consoleFull)