### PR TITLE
Reduce timeout for json_run_localhost to 120sec.

### DIFF
--- a/test/cpp/qps/gen_build_yaml.py
+++ b/test/cpp/qps/gen_build_yaml.py
@@ -77,7 +77,7 @@ print yaml.dump({
       'defaults': 'boringssl',
       'cpu_cost': guess_cpu(scenario_json, False),
       'exclude_configs': ['tsan', 'asan'],
-      'timeout_seconds': 6*60,
+      'timeout_seconds': 2*60,
       'excluded_poll_engines': scenario_json.get('EXCLUDED_POLL_ENGINES', [])
     }
     for scenario_json in scenario_config.CXXLanguage().scenarios()
@@ -95,7 +95,7 @@ print yaml.dump({
       'defaults': 'boringssl',
       'cpu_cost': guess_cpu(scenario_json, True),
       'exclude_configs': sorted(c for c in configs_from_yaml if c not in ('tsan', 'asan')),
-      'timeout_seconds': 6*60,
+      'timeout_seconds': 2*60,
       'excluded_poll_engines': scenario_json.get('EXCLUDED_POLL_ENGINES', [])
    }
     for scenario_json in scenario_config.CXXLanguage().scenarios()

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -49542,7 +49542,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_1channel_100rpcs_1MB", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49567,7 +49567,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_client_1channel_1MB", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49592,7 +49592,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_ping_pong_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49617,7 +49617,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49642,7 +49642,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_1mps_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49667,7 +49667,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_10mps_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49692,7 +49692,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_1channel_1MBmsg_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49717,7 +49717,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_64KBmsg_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49742,7 +49742,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_2waysharedcq_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49767,7 +49767,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_2waysharedcq_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49792,7 +49792,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_qps_unconstrained_2waysharedcq_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49817,7 +49817,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_one_server_core_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49844,7 +49844,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_client_sync_server_unary_qps_unconstrained_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49869,7 +49869,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_client_unary_1channel_64wide_128Breq_8MBresp_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49896,7 +49896,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_client_sync_server_streaming_qps_unconstrained_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49921,7 +49921,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_ping_pong_secure_1MB", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49946,7 +49946,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_unary_ping_pong_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49971,7 +49971,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_unary_qps_unconstrained_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -49996,7 +49996,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_ping_pong_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50021,7 +50021,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_qps_unconstrained_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50046,7 +50046,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_ping_pong_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50071,7 +50071,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_qps_unconstrained_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50096,7 +50096,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_qps_unconstrained_1mps_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50121,7 +50121,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_qps_unconstrained_10mps_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50146,7 +50146,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_ping_pong_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50171,7 +50171,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50196,7 +50196,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_1mps_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50221,7 +50221,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_10mps_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50246,7 +50246,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_client_ping_pong_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50271,7 +50271,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_client_qps_unconstrained_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50296,7 +50296,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_client_ping_pong_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50321,7 +50321,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_client_qps_unconstrained_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50346,7 +50346,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_server_ping_pong_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50371,7 +50371,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_server_qps_unconstrained_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50396,7 +50396,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_server_ping_pong_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50421,7 +50421,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_server_qps_unconstrained_secure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50446,7 +50446,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_ping_pong_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50471,7 +50471,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50496,7 +50496,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_1mps_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50521,7 +50521,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_10mps_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50546,7 +50546,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_1channel_1MBmsg_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50571,7 +50571,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_64KBmsg_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50596,7 +50596,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_2waysharedcq_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50621,7 +50621,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_2waysharedcq_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50646,7 +50646,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_qps_unconstrained_2waysharedcq_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50671,7 +50671,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_one_server_core_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50698,7 +50698,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_client_sync_server_unary_qps_unconstrained_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50723,7 +50723,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_client_unary_1channel_64wide_128Breq_8MBresp_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50750,7 +50750,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_client_sync_server_streaming_qps_unconstrained_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50775,7 +50775,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_ping_pong_insecure_1MB", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50800,7 +50800,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_unary_ping_pong_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50825,7 +50825,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_unary_qps_unconstrained_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50850,7 +50850,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_ping_pong_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50875,7 +50875,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_qps_unconstrained_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50900,7 +50900,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_ping_pong_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50925,7 +50925,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_qps_unconstrained_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50950,7 +50950,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_qps_unconstrained_1mps_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -50975,7 +50975,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_qps_unconstrained_10mps_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51000,7 +51000,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_ping_pong_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51025,7 +51025,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51050,7 +51050,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_1mps_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51075,7 +51075,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_10mps_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51100,7 +51100,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_client_ping_pong_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51125,7 +51125,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_client_qps_unconstrained_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51150,7 +51150,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_client_ping_pong_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51175,7 +51175,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_client_qps_unconstrained_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51200,7 +51200,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_server_ping_pong_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51225,7 +51225,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_server_qps_unconstrained_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51250,7 +51250,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_server_ping_pong_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51275,7 +51275,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_server_qps_unconstrained_insecure", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51313,7 +51313,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_1channel_100rpcs_1MB_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51351,7 +51351,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_client_1channel_1MB_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51389,7 +51389,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_ping_pong_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51427,7 +51427,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51465,7 +51465,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_1mps_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51503,7 +51503,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_10mps_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51541,7 +51541,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_1channel_1MBmsg_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51579,7 +51579,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_64KBmsg_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51617,7 +51617,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_2waysharedcq_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51655,7 +51655,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_2waysharedcq_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51693,7 +51693,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_qps_unconstrained_2waysharedcq_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51731,7 +51731,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_one_server_core_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51771,7 +51771,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_client_sync_server_unary_qps_unconstrained_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51809,7 +51809,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_client_unary_1channel_64wide_128Breq_8MBresp_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51849,7 +51849,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_client_sync_server_streaming_qps_unconstrained_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51887,7 +51887,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_ping_pong_secure_1MB_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51925,7 +51925,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_unary_ping_pong_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -51963,7 +51963,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_unary_qps_unconstrained_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52001,7 +52001,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_ping_pong_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52039,7 +52039,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_qps_unconstrained_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52077,7 +52077,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_ping_pong_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52115,7 +52115,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_qps_unconstrained_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52153,7 +52153,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_qps_unconstrained_1mps_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52191,7 +52191,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_qps_unconstrained_10mps_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52229,7 +52229,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_ping_pong_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52267,7 +52267,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52305,7 +52305,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_1mps_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52343,7 +52343,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_10mps_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52381,7 +52381,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_client_ping_pong_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52419,7 +52419,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_client_qps_unconstrained_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52457,7 +52457,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_client_ping_pong_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52495,7 +52495,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_client_qps_unconstrained_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52533,7 +52533,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_server_ping_pong_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52571,7 +52571,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_server_qps_unconstrained_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52609,7 +52609,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_server_ping_pong_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52647,7 +52647,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_server_qps_unconstrained_secure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52685,7 +52685,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_ping_pong_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52723,7 +52723,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52761,7 +52761,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_1mps_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52799,7 +52799,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_10mps_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52837,7 +52837,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_1channel_1MBmsg_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52875,7 +52875,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_64KBmsg_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52913,7 +52913,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_unconstrained_2waysharedcq_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52951,7 +52951,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_2waysharedcq_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -52989,7 +52989,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_qps_unconstrained_2waysharedcq_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53027,7 +53027,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_generic_async_streaming_qps_one_server_core_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53067,7 +53067,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_client_sync_server_unary_qps_unconstrained_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53105,7 +53105,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_client_unary_1channel_64wide_128Breq_8MBresp_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53145,7 +53145,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_client_sync_server_streaming_qps_unconstrained_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53183,7 +53183,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_ping_pong_insecure_1MB_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53221,7 +53221,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_unary_ping_pong_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53259,7 +53259,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_unary_qps_unconstrained_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53297,7 +53297,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_ping_pong_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53335,7 +53335,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_unary_qps_unconstrained_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53373,7 +53373,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_ping_pong_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53411,7 +53411,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_qps_unconstrained_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53449,7 +53449,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_qps_unconstrained_1mps_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53487,7 +53487,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_qps_unconstrained_10mps_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53525,7 +53525,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_ping_pong_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53563,7 +53563,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53601,7 +53601,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_1mps_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53639,7 +53639,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_qps_unconstrained_10mps_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53677,7 +53677,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_client_ping_pong_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53715,7 +53715,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_client_qps_unconstrained_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53753,7 +53753,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_client_ping_pong_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53791,7 +53791,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_client_qps_unconstrained_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53829,7 +53829,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_server_ping_pong_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53867,7 +53867,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_sync_streaming_from_server_qps_unconstrained_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53905,7 +53905,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_server_ping_pong_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [
@@ -53943,7 +53943,7 @@
       "linux"
     ], 
     "shortname": "json_run_localhost:cpp_protobuf_async_streaming_from_server_qps_unconstrained_insecure_low_thread_count", 
-    "timeout_seconds": 360
+    "timeout_seconds": 120
   }, 
   {
     "args": [


### PR DESCRIPTION
As per https://github.com/grpc/grpc/issues/12669,
2mins should be more than enough after fixing the streaming_from_server scenarios

With the multipliers, sanitizers will have 2*20 min to run (more than enough for them, they should be fine with ~5mins based on my data).