### PR TITLE
Fix a PHP memory leak with SSL root certificates

### DIFF
--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -35,6 +35,7 @@
 #include <zend_hash.h>
 
 #include <grpc/support/alloc.h>
+#include <grpc/support/string_util.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 
@@ -46,10 +47,11 @@ static char *default_pem_root_certs = NULL;
 
 static grpc_ssl_roots_override_result get_ssl_roots_override(
     char **pem_root_certs) {
-  *pem_root_certs = default_pem_root_certs;
-  if (default_pem_root_certs == NULL) {
+  if (!default_pem_root_certs) {
+    *pem_root_certs = NULL;
     return GRPC_SSL_ROOTS_OVERRIDE_FAIL;
   }
+  *pem_root_certs = gpr_strdup(default_pem_root_certs);
   return GRPC_SSL_ROOTS_OVERRIDE_OK;
 }
 
@@ -101,7 +103,7 @@ PHP_METHOD(ChannelCredentials, setDefaultRootsPem) {
                          "setDefaultRootsPem expects 1 string", 1 TSRMLS_CC);
     return;
   }
-  default_pem_root_certs = gpr_malloc((pem_roots_length + 1) * sizeof(char));
+  default_pem_root_certs = gpr_realloc(default_pem_root_certs, (pem_roots_length + 1) * sizeof(char));
   memcpy(default_pem_root_certs, pem_roots, pem_roots_length + 1);
 }
 


### PR DESCRIPTION
I've been running into an issue with requests to PHP-FPM increasing memory by ~100MB which doesn't get freed.

I ran strace on PHP-FPM and noticed many calls to map `vendor/grpc/grpc/etc/roots.pem` into memory, narrowed this down to `grpc_ssl_roots_override_result` and `PHP_METHOD(ChannelCredentials, setDefaultRootsPem)` mallocing `default_pem_root_certs` without freeing, so replaced this with `grp_realloc` and made sure to make a copy of the value in `grpc_ssl_roots_override_result`.

I based this on the C# extension https://github.com/grpc/grpc/blob/8399f92fd644c263df041d3809380944276f4274/src/csharp/ext/grpc_csharp_ext.c#L901

This appears to be related to #11632 