### PR TITLE
PHP benchmark: add running php with protobuf C-extension

### DIFF
--- a/tools/jenkins/run_full_performance.sh
+++ b/tools/jenkins/run_full_performance.sh
@@ -21,7 +21,7 @@ cd $(dirname $0)/../..
 
 # run 8core client vs 8core server
 tools/run_tests/run_performance_tests.py \
-    -l c++ csharp node ruby java python go node_express php \
+    -l c++ csharp node ruby java python go node_express php php_ext \
     --netperf \
     --category scalable \
     --bq_result_table performance_test.performance_experiment \

--- a/tools/jenkins/run_full_performance.sh
+++ b/tools/jenkins/run_full_performance.sh
@@ -21,7 +21,7 @@ cd $(dirname $0)/../..
 
 # run 8core client vs 8core server
 tools/run_tests/run_performance_tests.py \
-    -l c++ csharp node ruby java python go node_express php php_ext \
+    -l c++ csharp node ruby java python go node_express php_protobuf_php php_protobuf_c \
     --netperf \
     --category scalable \
     --bq_result_table performance_test.performance_experiment \

--- a/tools/run_tests/performance/run_worker_php.sh
+++ b/tools/run_tests/performance/run_worker_php.sh
@@ -16,13 +16,18 @@
 source ~/.rvm/scripts/rvm
 set -ex
 
-repo=$(dirname $0)/../../..
-
+cd $(dirname $0)/../../..
+repo=$(pwd)
 # First set up all dependences needed for PHP QPS test
 cd $repo
 cd src/php/tests/qps
 composer install
+# Install protobuf C-extension for php
+cd vendor/google/protobuf/php/ext/google/protobuf
+phpize
+./configure
+make
 # The proxy worker for PHP is implemented in Ruby
-cd ../../../..
+cd $repo
 ruby src/ruby/qps/proxy-worker.rb $@
 

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -802,52 +802,32 @@ class RubyLanguage:
 
 class PhpLanguage:
 
-  def __init__(self):
+  def __init__(self, use_protobuf_c_extension=False):
     pass
+    self.use_protobuf_c_extension=use_protobuf_c_extension
     self.safename = str(self)
 
   def worker_cmdline(self):
+    if self.use_protobuf_c_extension:
+        return ['tools/run_tests/performance/run_worker_php.sh -c']
     return ['tools/run_tests/performance/run_worker_php.sh']
 
   def worker_port_offset(self):
     return 800
 
   def scenarios(self):
+    php_extension_mode='php_protobuf_php_extension'
+    if self.use_protobuf_c_extension:
+        php_extension_mode='php_protobuf_c_extension'
+    
     yield _ping_pong_scenario(
-        'php_to_cpp_protobuf_sync_unary_ping_pong', rpc_type='UNARY',
-        client_type='SYNC_CLIENT', server_type='SYNC_SERVER',
+        '%s_to_cpp_protobuf_sync_unary_ping_pong' % php_extension_mode, 
+        rpc_type='UNARY', client_type='SYNC_CLIENT', server_type='SYNC_SERVER',
         server_language='c++', async_server_threads=1)
 
     yield _ping_pong_scenario(
-        'php_to_cpp_protobuf_sync_streaming_ping_pong', rpc_type='STREAMING',
-        client_type='SYNC_CLIENT', server_type='SYNC_SERVER',
-        server_language='c++', async_server_threads=1)
-
-  def __str__(self):
-    return 'php'
-
-
-class PhpLanguage_ext:
-
-  def __init__(self):
-    pass
-    self.safename = str(self)
-
-  def worker_cmdline(self):
-    return ['tools/run_tests/performance/run_worker_php.sh -c']
-
-  def worker_port_offset(self):
-    return 800
-
-  def scenarios(self):
-    yield _ping_pong_scenario(
-        'php_to_cpp_protobuf_sync_unary_ping_pong', rpc_type='UNARY',
-        client_type='SYNC_CLIENT', server_type='SYNC_SERVER',
-        server_language='c++', async_server_threads=1)
-
-    yield _ping_pong_scenario(
-        'php_to_cpp_protobuf_sync_streaming_ping_pong', rpc_type='STREAMING',
-        client_type='SYNC_CLIENT', server_type='SYNC_SERVER',
+        '%s_to_cpp_protobuf_sync_streaming_ping_pong' % php_extension_mode, 
+        rpc_type='STREAMING', client_type='SYNC_CLIENT', server_type='SYNC_SERVER',
         server_language='c++', async_server_threads=1)
 
   def __str__(self):
@@ -1051,8 +1031,8 @@ LANGUAGES = {
     'node' : NodeLanguage(),
     'node_express': NodeExpressLanguage(),
     'ruby' : RubyLanguage(),
-    'php' : PhpLanguage(),
-    'php_ext' : PhpLanguage_ext(),
+    'php_protobuf_php' : PhpLanguage(),
+    'php_protobuf_c' : PhpLanguage(use_protobuf_c_extension=True),
     'java' : JavaLanguage(),
     'python' : PythonLanguage(),
     'go' : GoLanguage(),

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -827,6 +827,33 @@ class PhpLanguage:
     return 'php'
 
 
+class PhpLanguage_ext:
+
+  def __init__(self):
+    pass
+    self.safename = str(self)
+
+  def worker_cmdline(self):
+    return ['tools/run_tests/performance/run_worker_php.sh -c']
+
+  def worker_port_offset(self):
+    return 800
+
+  def scenarios(self):
+    yield _ping_pong_scenario(
+        'php_to_cpp_protobuf_sync_unary_ping_pong', rpc_type='UNARY',
+        client_type='SYNC_CLIENT', server_type='SYNC_SERVER',
+        server_language='c++', async_server_threads=1)
+
+    yield _ping_pong_scenario(
+        'php_to_cpp_protobuf_sync_streaming_ping_pong', rpc_type='STREAMING',
+        client_type='SYNC_CLIENT', server_type='SYNC_SERVER',
+        server_language='c++', async_server_threads=1)
+
+  def __str__(self):
+    return 'php'
+
+
 class JavaLanguage:
 
   def __init__(self):
@@ -1025,6 +1052,7 @@ LANGUAGES = {
     'node_express': NodeExpressLanguage(),
     'ruby' : RubyLanguage(),
     'php' : PhpLanguage(),
+    'php_ext' : PhpLanguage_ext(),
     'java' : JavaLanguage(),
     'python' : PythonLanguage(),
     'go' : GoLanguage(),


### PR DESCRIPTION
The current benchmark is using protobuf PHP extension, while using C extension is faster. We want to observe the benchmark results from using both extension.

I add a new language `php_ext` to run php with protobuf C-extension, it share the worker client with old php while passing a parameter `-c` indicating it will use C-extension.

It runs well in the performance_adhoc: [Unary](https://grpc-testing.appspot.com/view/Performance/job/gRPC_performance_adhoc/480/consoleFull), [Stream](https://grpc-testing.appspot.com/view/Performance/job/gRPC_performance_adhoc/479/consoleFull)

```
protobuf            PHP          C
unary QPS          2623.8      4357.5
stream QPS         3629.8      5379.9
```