### PR TITLE
Remove wrong assert from grpclb

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1803,8 +1803,8 @@ static void glb_lb_channel_on_connectivity_changed_cb(grpc_exec_ctx *exec_ctx,
       break;
     }
     case GRPC_CHANNEL_IDLE:
-      // lb channel inactive (probably shutdown prior to update). Restart lb
-      // call to kick the lb channel into gear.
+    // lb channel inactive (probably shutdown prior to update). Restart lb
+    // call to kick the lb channel into gear.
     /* fallthrough */
     case GRPC_CHANNEL_READY:
       if (glb_policy->lb_call != NULL) {

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1805,7 +1805,6 @@ static void glb_lb_channel_on_connectivity_changed_cb(grpc_exec_ctx *exec_ctx,
     case GRPC_CHANNEL_IDLE:
       // lb channel inactive (probably shutdown prior to update). Restart lb
       // call to kick the lb channel into gear.
-      GPR_ASSERT(glb_policy->lb_call == NULL);
     /* fallthrough */
     case GRPC_CHANNEL_READY:
       if (glb_policy->lb_call != NULL) {


### PR DESCRIPTION
The LB channel may be in IDLE and the LB call be `!= NULL`, for example if the call hasn't been able to make immediate progress transitioning to `CONNECTING` right after being created.

For example, consider the following log before this change (mind the timestamps):
```
I0926 12:15:35.362566890   87608 grpclb.c:1583]              Restaring call to LB server (grpclb 0x1b95e80)
I0926 12:15:35.362591813   87608 grpclb.c:1370]              Query for backends (grpclb: 0x1b95e80, lb_channel: 0x1bb09
00, lb_call: 0x7fb68c004bd0)
E0926 12:15:35.362673295   87608 grpclb.c:1745]              assertion failed: glb_policy->lb_call == NULL
```
We can see how the previous events all happen within ~1ms, with no time for the newly created `lb_call` to make any progress, leaving the LB channel in its initial `IDLE` state, a valid state.