### PR TITLE
Make ruby google RPC status conversion return nil if the status-details trailer was missing

### DIFF
--- a/src/ruby/lib/grpc/google_rpc_status_utils.rb
+++ b/src/ruby/lib/grpc/google_rpc_status_utils.rb
@@ -19,10 +19,17 @@ require 'google/rpc/status_pb'
 module GRPC
   # GoogleRpcStatusUtils provides utilities to convert between a
   # GRPC::Core::Status and a deserialized Google::Rpc::Status proto
+  # Returns nil if the grpc-status-details-bin trailer could not be
+  # converted to a GoogleRpcStatus due to the server not providing
+  # the necessary trailers.
+  # Raises an error if the server did provide the necessary trailers
+  # but they fail to deseriliaze into a GoogleRpcStatus protobuf.
   class GoogleRpcStatusUtils
     def self.extract_google_rpc_status(status)
       fail ArgumentError, 'bad type' unless status.is_a? Struct::Status
-      Google::Rpc::Status.decode(status.metadata['grpc-status-details-bin'])
+      grpc_status_details_bin_trailer = 'grpc-status-details-bin'
+      return nil if status.metadata[grpc_status_details_bin_trailer].nil?
+      Google::Rpc::Status.decode(status.metadata[grpc_status_details_bin_trailer])
     end
   end
 end


### PR DESCRIPTION
This is per feedback on this new utility in the 1.6.2 release (cc @geigerj).  Raising a protobuf parser error when the trailer containing the `Google::Rpc::Status` serialized protobuf is missing (which is expected to happen right now when talking to any server that hasn't implemented the new `Google::Rpc::Status` trailer yet),  doesn't provide enough useful info to the caller. This separates the "error return values" from the conversion utility into

1. Converting `GRPC::Core::Status` to `Google::Rpc::Status` returns `nil` if the trailer to create the `Google::Rpc::Status` is missing.

2. Converting `GRPC::Core::Status` to `Google::Rpc::Status` raises a protobuf parser error if the trailer to create the `Google::Rpc::Status` is present but doesn't contain a serialized `Google::Rpc::Status` (raising an error here because this case is unexpected and is likely due to an error within grpc).