### PR TITLE
Increase reference count on state used in tcp connect.

### DIFF
--- a/src/core/lib/iomgr/tcp_client_uv.c
+++ b/src/core/lib/iomgr/tcp_client_uv.c
@@ -145,7 +145,7 @@ static void tcp_client_connect_impl(grpc_exec_ctx *exec_ctx,
   connect->resource_quota = resource_quota;
   uv_tcp_init(uv_default_loop(), connect->tcp_handle);
   connect->connect_req.data = connect;
-  connect->refs = 1;
+  connect->refs = 2; // One for the connect operation, one for the timer.
 
   if (GRPC_TRACER_ON(grpc_tcp_trace)) {
     gpr_log(GPR_DEBUG, "CLIENT_CONNECT: %s: asynchronously connecting",

--- a/src/core/lib/iomgr/tcp_client_uv.c
+++ b/src/core/lib/iomgr/tcp_client_uv.c
@@ -145,7 +145,7 @@ static void tcp_client_connect_impl(grpc_exec_ctx *exec_ctx,
   connect->resource_quota = resource_quota;
   uv_tcp_init(uv_default_loop(), connect->tcp_handle);
   connect->connect_req.data = connect;
-  connect->refs = 2; // One for the connect operation, one for the timer.
+  connect->refs = 2;  // One for the connect operation, one for the timer.
 
   if (GRPC_TRACER_ON(grpc_tcp_trace)) {
     gpr_log(GPR_DEBUG, "CLIENT_CONNECT: %s: asynchronously connecting",


### PR DESCRIPTION
The state is used both in the callback for the actual connect as well as
in the additional timeout that is setup for the operation. Both code
paths decrease the reference count and if they happen to be queued at
the same time, memory is corrupted. Subsequent behavior is undefined and
segfaults can be observed as a result.

Fixes #12608