### PR TITLE
Deflake macos artifact build

### DIFF
--- a/tools/distrib/build_ruby_environment_macos.sh
+++ b/tools/distrib/build_ruby_environment_macos.sh
@@ -40,7 +40,14 @@ MAKE="make -j8"
 
 for v in 2.4.0 2.3.0 2.2.2 2.1.5 2.0.0-p645 ; do
   ccache -c
-  rake -f $CROSS_RUBY cross-ruby VERSION=$v HOST=x86_64-darwin11
+
+  # retry a few times as building older versions of ruby is flaky
+  # https://github.com/grpc/grpc/issues/12161
+  for attempt in $(seq 1 3)
+  do
+    echo "Building cross-ruby ${v}, attempt ${attempt}"
+    rake -f $CROSS_RUBY cross-ruby VERSION=$v HOST=x86_64-darwin11 && break
+  done
 done
 
 sed 's/x86_64-darwin-11/universal-darwin/' ~/.rake-compiler/config.yml > $CROSS_RUBY

--- a/tools/internal_ci/macos/grpc_build_artifacts.sh
+++ b/tools/internal_ci/macos/grpc_build_artifacts.sh
@@ -27,8 +27,7 @@ python3.5 -m pip install cython setuptools wheel
 python3.6 -m pip install cython setuptools wheel
 
 # needed to build ruby artifacts
-wget https://raw.githubusercontent.com/grpc/grpc/master/tools/distrib/build_ruby_environment_macos.sh
-bash build_ruby_environment_macos.sh
+time bash tools/distrib/build_ruby_environment_macos.sh
 
 gem install rubygems-update
 update_rubygems


### PR DESCRIPTION
Workaround for https://github.com/grpc/grpc/issues/12161
- retry building cross-ruby when preparing environment for macos artifact build
- also print timing info
