### PR TITLE
Attempt to fix large_metadata_bad_client test flakiness.

### DIFF
--- a/test/core/bad_client/tests/large_metadata.c
+++ b/test/core/bad_client/tests/large_metadata.c
@@ -228,7 +228,7 @@ int main(int argc, char **argv) {
       client_payload + sizeof(PFX_TOO_MUCH_METADATA_FROM_CLIENT_PREFIX_STR) - 1,
       client_headers, headers_len);
   GRPC_RUN_BAD_CLIENT_TEST(server_verifier, client_validator, client_payload,
-                           0);
+                           GRPC_BAD_CLIENT_LARGE_REQUEST);
   gpr_free((void *)client_headers);
 
   // Test sending more metadata than the client will accept.


### PR DESCRIPTION
Fixes #11745 (I hope).

This uses the new flag added in #12729.