### PR TITLE
Start port_server before running daily performance profile

### DIFF
--- a/tools/internal_ci/linux/grpc_performance_profile_daily.sh
+++ b/tools/internal_ci/linux/grpc_performance_profile_daily.sh
@@ -22,6 +22,8 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_perf_rc
 
 CPUS=`python -c 'import multiprocessing; print multiprocessing.cpu_count()'`
 
+./tools/run_tests/start_port_server.py || true
+
 make CONFIG=opt memory_profile_test memory_profile_client memory_profile_server -j $CPUS
 bins/opt/memory_profile_test
 bq load microbenchmarks.memory memory_usage.csv

--- a/tools/jenkins/run_performance_profile_daily.sh
+++ b/tools/jenkins/run_performance_profile_daily.sh
@@ -29,4 +29,6 @@ fi
 
 BENCHMARKS_TO_RUN="bm_fullstack_unary_ping_pong bm_fullstack_streaming_ping_pong bm_fullstack_streaming_pump bm_closure bm_cq bm_call_create bm_error bm_chttp2_hpack bm_chttp2_transport bm_pollset bm_metadata"
 
+./tools/run_tests/start_port_server.py || true
+
 $PYTHON tools/run_tests/run_microbenchmark.py --collect summary perf latency -b $BENCHMARKS_TO_RUN


### PR DESCRIPTION
The daily performance profile relies on `start_port_server.py`, and it only works when previous tests on the same VM have used `start_port_server.py`