### PR TITLE
Make Error Non-Fatal

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.c
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.c
@@ -753,7 +753,6 @@ static void destroy_stream_locked(grpc_exec_ctx *exec_ctx, void *sp,
     if (s->included[i]) {
       gpr_log(GPR_ERROR, "%s stream %d still included in list %d",
               t->is_client ? "client" : "server", s->id, i);
-      abort();
     }
   }
 


### PR DESCRIPTION
Not a good fix unless we can describe with full understanding why the abort() was wrong.

But I am curious