### PR TITLE
Fix Xcode warning of mis-aligned structs

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -84,6 +84,7 @@ Pod::Spec.new do |s|
     # build.
     'USE_HEADERMAP' => 'NO',
     'ALWAYS_SEARCH_USER_PATHS' => 'NO',
+    'GCC_PREPROCESSOR_DEFINITIONS' => '"$(inherited)" "COCOAPODS=1" "PB_NO_PACKED_STRUCTS=1"',
   }
 
   s.default_subspecs = 'Interface', 'Implementation'

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -111,6 +111,7 @@
       # build.
       'USE_HEADERMAP' => 'NO',
       'ALWAYS_SEARCH_USER_PATHS' => 'NO',
+      'GCC_PREPROCESSOR_DEFINITIONS' => '"$(inherited)" "COCOAPODS=1" "PB_NO_PACKED_STRUCTS=1"',
     }
 
     s.default_subspecs = 'Interface', 'Implementation'


### PR DESCRIPTION
The Xcode warning of struct misalignment is due to nanopb packing structs across byte alignment boundaries. It appears there is no Apple LLVM compiler option provided to supress this problem. On the other hand, nanopb supports disabling struct packing for compatibility on some platforms.

In this PR, we disable struct packing to eliminates the corresponding warning. The cost of the change, according to [nanopb manual](https://jpa.kapsi.fi/nanopb/docs/reference.html), should be minor RAM increase.

#12194 