### PR TITLE
Increase port server's listen socket backlog

### DIFF
--- a/tools/run_tests/python_utils/port_server.py
+++ b/tools/run_tests/python_utils/port_server.py
@@ -31,7 +31,9 @@ import platform
 # increment this number whenever making a change to ensure that
 # the changes are picked up by running CI servers
 # note that all changes must be backwards compatible
-_MY_VERSION = 20
+
+# TODO: increase to 21 before merging
+_MY_VERSION = 19
 
 
 if len(sys.argv) == 2 and sys.argv[1] == 'dump_version':
@@ -181,5 +183,9 @@ class Handler(BaseHTTPRequestHandler):
 
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
   """Handle requests in a separate thread"""
+  def server_activate(self):
+    # The default server_activate for HTTPServer sets the listen backlog
+    # to 5. Make sure that this is large enough for tests.
+    self.socket.listen(100)
 
 ThreadedHTTPServer(('', args.port), Handler).serve_forever()


### PR DESCRIPTION
Logs from tests that failed in https://github.com/grpc/grpc/issues/12595, like https://grpc-testing.appspot.com/job/gRPC_pr_win/8126/#showFailuresLink, show a lot of `10061`/`WSAECONNREFUSED` error codes, [which appear to be due to request arriving while queue backlog is full](https://msdn.microsoft.com/en-us/library/windows/desktop/ms739168(v=vs.85).aspx).

It looks like the [default listen socket backlog](https://github.com/python/cpython/blob/2.7/Lib/SocketServer.py#L440) for the port server is small, at 5. 100 is somewhat arbitrary but seems large enough. This appears to fix my repro (of the port server requests failing) in https://github.com/grpc/grpc/issues/12595.

---

....there is actually a port server request failure [in this PR](https://sponge.corp.google.com/target?id=e3d4d3e1-42f5-4ccd-93d7-243f0695981a&target=github/grpc/c_windows_dbg_native&searchFor=&show=FAILED&sortBy=STATUS). However, an eyeball of [CPU costs for tests in that run](https://sponge.corp.google.com/invocation?tab=Kokoro&id=546f6436-e1cf-42db-895e-a97f54d2540d&searchFor&page=1) shows ~1200 tests with 0.01 CPU cost, so it looks like we might be having up to ~800 parallel requests to the port server at once. I <i>think </i> https://github.com/grpc/grpc/pull/12777 can alleviate that  issue though.