### PR TITLE
Put a safety limit on parallelization of tests

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -122,7 +122,7 @@ def max_parallel_tests_for_current_platform():
   # so far on windows.
   if jobset.platform_string() == 'windows':
     return 64
-  return 1e6
+  return 128
 
 # SimpleConfig: just compile with CONFIG=config, and run the binary to test
 class Config(object):

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -117,6 +117,13 @@ def run_shell_command(cmd, env=None, cwd=None):
                        e.cmd, e.returncode, e.output)
     raise
 
+def max_parallel_tests_for_current_platform():
+  # Too much test parallelization has only been seen to be a problem
+  # so far on windows.
+  if jobset.platform_string() == 'windows':
+    return 64
+  return 1e6
+
 # SimpleConfig: just compile with CONFIG=config, and run the binary to test
 class Config(object):
 
@@ -1553,7 +1560,7 @@ def _build_and_run(
       jobset.message('START', 'Running tests quietly, only failing tests will be reported', do_newline=True)
     num_test_failures, resultset = jobset.run(
         all_runs, check_cancelled, newline_on_success=newline_on_success,
-        travis=args.travis, maxjobs=args.jobs,
+        travis=args.travis, maxjobs=args.jobs, maxjobs_cpu_agnostic=max_parallel_tests_for_current_platform(),
         stop_on_failure=args.stop_on_failure,
         quiet_success=args.quiet_success, max_time=args.max_time)
     if resultset:


### PR DESCRIPTION
... this is really just one idea for a solution:

https://github.com/grpc/grpc/pull/12774 slightly improves the performance of the port server, but it looks like that wasn't enough, as can be seen by the one port server request failure in [one of those windows/kokoro tests](https://sponge.corp.google.com/target?id=e3d4d3e1-42f5-4ccd-93d7-243f0695981a&target=github/grpc/c_windows_dbg_native&searchFor=&show=FAILED&sortBy=STATUS).

It appears that the parallelization of tests in terms of CPU cost is causing too many tests to run in parallel, to the point that the port server is getting overloaded (don't have data for this right now besides error codes but I suspect that the focusing of port server failures on windows is related to differing behavior between windows and linux when listen socket queues overrun - as I understand, for [windows](https://tangentsoft.net/wskfaq/advanced.html) and [linux](http://veithen.github.io/2014/01/01/how-tcp-backlog-works-in-linux.html)). (also in some experiments on kokoro windows, sometimes the run_tests.py script will fail with "too many open files" too). It's looking like this large parallelization is the main cause of https://github.com/grpc/grpc/issues/12595.

With this change combined with https://github.com/grpc/grpc/pull/12774, I'm seeing windows core tests consistently pass (no port server related failures) on experimental kokoro windows "pull-request" jobs.