### PR TITLE
Unflake build_ruby_environment_macos.sh on kokoro

### DIFF
--- a/tools/distrib/build_ruby_environment_macos.sh
+++ b/tools/distrib/build_ruby_environment_macos.sh
@@ -21,9 +21,10 @@ CROSS_RUBY=`mktemp tmpfile.XXXXXXXX`
 
 curl https://raw.githubusercontent.com/rake-compiler/rake-compiler/v1.0.3/tasks/bin/cross-ruby.rake > $CROSS_RUBY
 
+# See https://github.com/grpc/grpc/issues/12161 for verconf.h patch details
 patch $CROSS_RUBY << EOF
---- cross-ruby.rake	2016-02-05 16:26:53.000000000 -0800
-+++ cross-ruby.rake.patched	2016-02-05 16:27:33.000000000 -0800
+--- cross-ruby.rake 2017-09-27 16:46:00.311020325 +0200
++++ patched 2017-09-27 16:49:46.127016895 +0200
 @@ -133,7 +133,8 @@
      "--host=#{MINGW_HOST}",
      "--target=#{MINGW_TARGET}",
@@ -32,8 +33,16 @@ patch $CROSS_RUBY << EOF
 +    '--enable-static',
 +    '--disable-shared',
      '--disable-install-doc',
-     '--without-tk',
-     '--without-tcl'
+     '--with-ext='
+   ]
+@@ -151,6 +152,7 @@
+ # make
+ file "#{USER_HOME}/builds/#{MINGW_HOST}/#{RUBY_CC_VERSION}/ruby.exe" => ["#{USER_HOME}/builds/#{MINGW_HOST}/#{RUBY_CC_VERSION}/Makefile"] do |t|
+   chdir File.dirname(t.prerequisites.first) do
++    sh "test -s verconf.h || rm -f verconf.h"  # if verconf.h has size 0, make sure it gets re-built by make
+     sh MAKE
+   end
+ end
 EOF
 
 MAKE="make -j8"

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -51,7 +51,6 @@ export LANG=en_US.UTF-8
 pod repo update  # needed by python
 
 # python
-brew install coreutils  # we need grealpath
 pip install virtualenv --user python
 pip install -U six tox setuptools twisted pyyaml --user python
 export PYTHONPATH=/Library/Python/3.4/site-packages

--- a/tools/internal_ci/macos/grpc_build_artifacts.sh
+++ b/tools/internal_ci/macos/grpc_build_artifacts.sh
@@ -27,8 +27,7 @@ python3.5 -m pip install cython setuptools wheel
 python3.6 -m pip install cython setuptools wheel
 
 # needed to build ruby artifacts
-wget https://raw.githubusercontent.com/grpc/grpc/master/tools/distrib/build_ruby_environment_macos.sh
-bash build_ruby_environment_macos.sh
+time bash tools/distrib/build_ruby_environment_macos.sh
 
 gem install rubygems-update
 update_rubygems


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/12161.

The problem is that a dummy verconf.h is of size 0 is generated by the configure script (in ruby 2.2.0 and 2.15) and if the timing is right, it won't get regenerated by the makefile. See https://patchwork.ozlabs.org/patch/418321/