### PR TITLE
Fix gRPC performance regression

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.c
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.c
@@ -1901,7 +1901,8 @@ void grpc_chttp2_maybe_complete_recv_message(grpc_exec_ctx *exec_ctx,
                                  &s->frame_storage);
           s->unprocessed_incoming_frames_decompressed = false;
         }
-        if (!s->unprocessed_incoming_frames_decompressed) {
+        if (!s->unprocessed_incoming_frames_decompressed &&
+            s->stream_decompression_method != GRPC_STREAM_COMPRESSION_IDENTITY_DECOMPRESS) {
           GPR_ASSERT(s->decompressed_data_buffer.length == 0);
           bool end_of_context;
           if (!s->stream_decompression_ctx) {

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.c
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.c
@@ -1902,7 +1902,8 @@ void grpc_chttp2_maybe_complete_recv_message(grpc_exec_ctx *exec_ctx,
           s->unprocessed_incoming_frames_decompressed = false;
         }
         if (!s->unprocessed_incoming_frames_decompressed &&
-            s->stream_decompression_method != GRPC_STREAM_COMPRESSION_IDENTITY_DECOMPRESS) {
+            s->stream_decompression_method !=
+                GRPC_STREAM_COMPRESSION_IDENTITY_DECOMPRESS) {
           GPR_ASSERT(s->decompressed_data_buffer.length == 0);
           bool end_of_context;
           if (!s->stream_decompression_ctx) {


### PR DESCRIPTION
The stream compression refactor in #12399 routed non-compressed traffic through a truncation of first 5 bytes for deframing the gRPC header. This action is had some impact on performance when stream is not compressed but is actually not necessary in this case. This PR reroutes these data and consider them as decompressed.

Fixes #12768 