### PR TITLE
Fix compile error on ArchLinux

### DIFF
--- a/src/core/ext/transport/cronet/transport/cronet_transport.c
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.c
@@ -690,7 +690,7 @@ static void create_grpc_frame(grpc_exec_ctx *exec_ctx,
   uint8_t *p = (uint8_t *)write_buffer;
   /* Append 5 byte header */
   /* Compressed flag */
-  *p++ = (flags & GRPC_WRITE_INTERNAL_COMPRESS) ? 1 : 0;
+  *p++ = (uint8_t)((flags & GRPC_WRITE_INTERNAL_COMPRESS) ? 1 : 0);
   /* Message length */
   *p++ = (uint8_t)(length >> 24);
   *p++ = (uint8_t)(length >> 16);


### PR DESCRIPTION
Fix build error on ArchLinux:  

```
src/core/ext/transport/cronet/transport/cronet_transport.c: In function ‘create_grpc_frame’:
src/core/ext/transport/cronet/transport/cronet_transport.c:693:10: error: conversion to ‘uint8_t {aka unsigned char}’ from ‘int’ may alter its value [-Werror=conversion]
   *p++ = (flags & GRPC_WRITE_INTERNAL_COMPRESS) ? 1 : 0;
          ^
cc1: all warnings being treated as errors
```
