### PR TITLE
Fix Server#addProtoService deprecation warning of basic Node.js example

### DIFF
--- a/examples/node/dynamic_codegen/greeter_server.js
+++ b/examples/node/dynamic_codegen/greeter_server.js
@@ -34,7 +34,7 @@ function sayHello(call, callback) {
  */
 function main() {
   var server = new grpc.Server();
-  server.addProtoService(hello_proto.Greeter.service, {sayHello: sayHello});
+  server.addService(hello_proto.Greeter.service, {sayHello: sayHello});
   server.bind('0.0.0.0:50051', grpc.ServerCredentials.createInsecure());
   server.start();
 }


### PR DESCRIPTION
This PR fixes the `addProtoService` deprecation warning in the greeter node example.

```
DeprecationWarning: Server#addProtoService: Use Server#addService instead
```