### PR TITLE
Add cloudbuild.yaml to push images to GCR

### DIFF
--- a/tools/dockerfile/cloudbuild.yaml
+++ b/tools/dockerfile/cloudbuild.yaml
@@ -1,0 +1,165 @@
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/bazel', './tools/dockerfile/test/bazel']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/csharp_jessie_x64', './tools/dockerfile/test/csharp_jessie_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/cxx_alpine_x64', './tools/dockerfile/test/cxx_alpine_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/cxx_jessie_x64', './tools/dockerfile/test/cxx_jessie_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/cxx_jessie_x86', './tools/dockerfile/test/cxx_jessie_x86']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/cxx_ubuntu1404_x64', './tools/dockerfile/test/cxx_ubuntu1404_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/cxx_ubuntu1604_x64', './tools/dockerfile/test/cxx_ubuntu1604_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/fuzzer', './tools/dockerfile/test/fuzzer']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/multilang_jessie_x64', './tools/dockerfile/test/multilang_jessie_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/node_jessie_x64', './tools/dockerfile/test/node_jessie_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/php7_jessie_x64', './tools/dockerfile/test/php7_jessie_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/php_jessie_x64', './tools/dockerfile/test/php_jessie_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/python_alpine_x64', './tools/dockerfile/test/python_alpine_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/python_jessie_x64', './tools/dockerfile/test/python_jessie_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/python_pyenv_x64', './tools/dockerfile/test/python_pyenv_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/ruby_jessie_x64', './tools/dockerfile/test/ruby_jessie_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/test/sanity', './tools/dockerfile/test/sanity']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/grpc_artifact_linux_armv6', './tools/dockerfile/grpc_artifact_linux_armv6']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/grpc_artifact_linux_armv7', './tools/dockerfile/grpc_artifact_linux_armv7']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/grpc_artifact_linux_x64', './tools/dockerfile/grpc_artifact_linux_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/grpc_artifact_linux_x86', './tools/dockerfile/grpc_artifact_linux_x86']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/grpc_artifact_protoc', './tools/dockerfile/grpc_artifact_protoc']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/grpc_artifact_python_manylinux_x64', './tools/dockerfile/grpc_artifact_python_manylinux_x64']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/grpc_artifact_python_manylinux_x86', './tools/dockerfile/grpc_artifact_python_manylinux_x86']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_android_java', './tools/dockerfile/interoptest/grpc_interop_android_java']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_csharp', './tools/dockerfile/interoptest/grpc_interop_csharp']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr', './tools/dockerfile/interoptest/grpc_interop_csharpcoreclr']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_cxx', './tools/dockerfile/interoptest/grpc_interop_cxx']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_go', './tools/dockerfile/interoptest/grpc_interop_go']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_go1.7', './tools/dockerfile/interoptest/grpc_interop_go1.7']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_go1.8', './tools/dockerfile/interoptest/grpc_interop_go1.8']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_http2', './tools/dockerfile/interoptest/grpc_interop_http2']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_java', './tools/dockerfile/interoptest/grpc_interop_java']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_java_oracle8', './tools/dockerfile/interoptest/grpc_interop_java_oracle8']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_node', './tools/dockerfile/interoptest/grpc_interop_node']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_php', './tools/dockerfile/interoptest/grpc_interop_php']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_php7', './tools/dockerfile/interoptest/grpc_interop_php7']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_python', './tools/dockerfile/interoptest/grpc_interop_python']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_ruby', './tools/dockerfile/interoptest/grpc_interop_ruby']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/grpc-testing/third_party/rake-compiler-dock', './third_party/rake-compiler-dock']
+
+images:
+- 'gcr.io/grpc-testing/tools/dockerfile/test/bazel'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/csharp_jessie_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/cxx_alpine_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/cxx_jessie_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/cxx_jessie_x86'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/cxx_ubuntu1404_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/cxx_ubuntu1604_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/fuzzer'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/multilang_jessie_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/node_jessie_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/php7_jessie_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/php_jessie_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/python_alpine_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/python_jessie_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/python_pyenv_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/ruby_jessie_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/test/sanity'
+- 'gcr.io/grpc-testing/tools/dockerfile/grpc_artifact_linux_armv6'
+- 'gcr.io/grpc-testing/tools/dockerfile/grpc_artifact_linux_armv7'
+- 'gcr.io/grpc-testing/tools/dockerfile/grpc_artifact_linux_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/grpc_artifact_linux_x86'
+- 'gcr.io/grpc-testing/tools/dockerfile/grpc_artifact_protoc'
+- 'gcr.io/grpc-testing/tools/dockerfile/grpc_artifact_python_manylinux_x64'
+- 'gcr.io/grpc-testing/tools/dockerfile/grpc_artifact_python_manylinux_x86'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_android_java'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_csharp'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_cxx'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_go'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_go1.7'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_go1.8'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_http2'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_java'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_java_oracle8'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_node'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_php'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_php7'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_python'
+- 'gcr.io/grpc-testing/tools/dockerfile/interoptest/grpc_interop_ruby'
+- 'gcr.io/grpc-testing/third_party/rake-compiler-dock'
+
+# It can take a long time to upload images if many Dockerfiles are changed
+timeout: 2880m

--- a/tools/dockerfile/generate_cloudbuild_yaml.sh
+++ b/tools/dockerfile/generate_cloudbuild_yaml.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generates cloudbuild.yaml, which GCR uses to determine which Dockerfiles
+# to build when the gRPC repo is updated
+
+set +ex
+
+cd $(dirname $0)/../..
+
+CLOUDBUILD_YAML=tools/dockerfile/cloudbuild.yaml
+PROJECT_ID=grpc-testing
+
+echo "steps:" > $CLOUDBUILD_YAML
+
+for DOCKERFILE_DIR in tools/dockerfile/test/* tools/dockerfile/grpc_artifact_* tools/dockerfile/interoptest/* third_party/rake-compiler-dock
+do
+  echo "- name: 'gcr.io/cloud-builders/docker'" >> $CLOUDBUILD_YAML
+  echo -e "  args: ['build', '-t', 'gcr.io/$PROJECT_ID/$DOCKERFILE_DIR', './$DOCKERFILE_DIR']\n" >> $CLOUDBUILD_YAML
+done
+
+echo "images:" >> $CLOUDBUILD_YAML
+
+for DOCKERFILE_DIR in tools/dockerfile/test/* tools/dockerfile/grpc_artifact_* tools/dockerfile/interoptest/* third_party/rake-compiler-dock
+do
+  echo "- 'gcr.io/$PROJECT_ID/$DOCKERFILE_DIR'" >> $CLOUDBUILD_YAML
+done
+
+echo -e "\n# It can take a long time to upload images if many Dockerfiles are changed" >> $CLOUDBUILD_YAML
+echo "timeout: 2880m" >> $CLOUDBUILD_YAML


### PR DESCRIPTION
I set up a trigger so that every time anything is pushed to grpc/grpc master, our Docker images will be uploaded/updated on GCR (after this PR is merged). This way, we do not have to rely on `push_testing_images.sh` to have up-to-date images. 

I'll follow up this PR with one that switches pulling images from Dockerhub to GCR. 