### PR TITLE
pkg-config needs an argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -442,7 +442,7 @@ HOST_LDLIBS = $(LDLIBS)
 
 CACHE_MK =
 
-HAS_PKG_CONFIG ?= $(shell command -v $(PKG_CONFIG) >/dev/null 2>&1 && echo true || echo false)
+HAS_PKG_CONFIG ?= $(shell command -v $(PKG_CONFIG) --help >/dev/null 2>&1 && echo true || echo false)
 
 ifeq ($(HAS_PKG_CONFIG), true)
 CACHE_MK += HAS_PKG_CONFIG = true,

--- a/Makefile
+++ b/Makefile
@@ -791,6 +791,7 @@ ifneq ($(LDFLAGS_PROTOBUF_PKG_CONFIG),)
 LDFLAGS_PROTOBUF_PKG_CONFIG += $(shell $(PKG_CONFIG) --libs-only-L protobuf | sed s/L/Wl,-rpath,/)
 endif
 endif
+LDFLAGS := $(LDFLAGS_PROTOBUF_PKG_CONFIG) $(LDFLAGS)
 else
 PC_LIBS_GRPCXX = -lprotobuf
 endif


### PR DESCRIPTION
running pkg-config without an argument fails:

$ pkg-config
Must specify package names on the command line
$ echo $?
1

thus --help is added to the check.

Tested on CentOS 6/7 and Fedora 26