### PR TITLE
Add test under ruby GC stress mode and fix non-GC-rooted variable

### DIFF
--- a/src/ruby/end2end/load_grpc_with_gc_stress_driver.rb
+++ b/src/ruby/end2end/load_grpc_with_gc_stress_driver.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+#
+# Copyright 2016 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+this_dir = File.expand_path(File.dirname(__FILE__))
+protos_lib_dir = File.join(this_dir, 'lib')
+grpc_lib_dir = File.join(File.dirname(this_dir), 'lib')
+$LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
+$LOAD_PATH.unshift(protos_lib_dir) unless $LOAD_PATH.include?(protos_lib_dir)
+$LOAD_PATH.unshift(this_dir) unless $LOAD_PATH.include?(this_dir)
+
+GC.stress = 0x04
+
+require 'grpc'
+
+GRPC::Core::Channel.new('dummy_host', nil, :this_channel_is_insecure)
+GRPC::Core::Server.new({})
+GRPC::Core::ChannelCredentials.new
+GRPC::Core::CallCredentials.new(proc { |noop| noop })
+GRPC::Core::CompressionOptions.new

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -315,8 +315,8 @@ void Init_grpc_c() {
     return;
   }
 
-  bg_thread_init_rb_mu = rb_mutex_new();
   rb_global_variable(&bg_thread_init_rb_mu);
+  bg_thread_init_rb_mu = rb_mutex_new();
 
   grpc_rb_mGRPC = rb_define_module("GRPC");
   grpc_rb_mGrpcCore = rb_define_module_under(grpc_rb_mGRPC, "Core");

--- a/tools/run_tests/helper_scripts/run_ruby_end2end_tests.sh
+++ b/tools/run_tests/helper_scripts/run_ruby_end2end_tests.sh
@@ -27,4 +27,5 @@ ruby src/ruby/end2end/killed_client_thread_driver.rb || EXIT_CODE=1
 ruby src/ruby/end2end/forking_client_driver.rb || EXIT_CODE=1
 ruby src/ruby/end2end/grpc_class_init_driver.rb || EXIT_CODE=1
 ruby src/ruby/end2end/multiple_killed_watching_threads_driver.rb || EXIT_CODE=1
+ruby src/ruby/end2end/load_grpc_with_gc_stress_driver.rb || EXIT_CODE=1
 exit $EXIT_CODE


### PR DESCRIPTION
Running under `GC.stress = 0x04` is slow (this test takes 20-30 seconds), but it's able to catch the bug like the one fixed in this pr.

Fixes issue mentioned in [this comment](https://github.com/google/protobuf/issues/3352#issuecomment-334276510) in a protobuf issue.
