### PR TITLE
Fix compilation on Mac

### DIFF
--- a/src/core/lib/support/log_posix.cc
+++ b/src/core/lib/support/log_posix.cc
@@ -58,7 +58,7 @@ void gpr_log(const char *file, int line, gpr_log_severity severity,
 }
 
 extern "C" void gpr_default_log(gpr_log_func_args *args) {
-  char *final_slash;
+  const char *final_slash;
   const char *display_file;
   char time_buffer[64];
   time_t timer;


### PR DESCRIPTION
Small compilation fix.

See: http://www.cplusplus.com/reference/cstring/strrchr/

c defines `char * strrchr ( const char *, int );`
c++ defines two copies, one with const and one without