### PR TITLE
Fix GID podspec issue

### DIFF
--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -63,10 +63,13 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'GID' do |ss|
+    ss.ios.deployment_target = '7.0'
+
     ss.header_mappings_dir = "#{src_dir}"
 
     ss.source_files = "#{src_dir}/GRPCCall+GID.{h,m}"
 
+    ss.dependency "#{s.name}/Main", version
     ss.dependency 'Google/SignIn'
   end
 end

--- a/templates/gRPC.podspec.template
+++ b/templates/gRPC.podspec.template
@@ -65,10 +65,13 @@
     end
 
     s.subspec 'GID' do |ss|
+      ss.ios.deployment_target = '7.0'
+
       ss.header_mappings_dir = "#{src_dir}"
 
       ss.source_files = "#{src_dir}/GRPCCall+GID.{h,m}"
 
+      ss.dependency "#{s.name}/Main", version
       ss.dependency 'Google/SignIn'
     end
   end


### PR DESCRIPTION
The podspec dependency "Google/SignIn" only supports iOS deployment (not OS X), and it should have depended on the Main subspec.