### PR TITLE
Increase timeout for init_test

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2659,6 +2659,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  timeout_seconds: 1200
 - name: invalid_call_argument_test
   cpu_cost: 0.1
   build: test

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -1609,7 +1609,8 @@
       "mac", 
       "posix", 
       "windows"
-    ]
+    ], 
+    "timeout_seconds": 1200
   }, 
   {
     "args": [], 


### PR DESCRIPTION
- `init_test.exe` has been failing on windows (in Debug mode)
- When I tried to reproduce manually, it passed.

I am following @ctiller's suggestion to increase the timeout and see if this passes.

Setting DO-NOT-MERGE label for now.
