### PR TITLE
Allow TSI handshaker to send an alert to peer on protocol failure

### DIFF
--- a/src/core/lib/security/transport/security_handshaker.cc
+++ b/src/core/lib/security/transport/security_handshaker.cc
@@ -47,6 +47,9 @@ typedef struct {
   gpr_refcount refs;
 
   bool shutdown;
+
+  // Indicates the error to fail with after writing to the endpoint. Used to
+  // send alert messages to the peer on handshake failure.
   grpc_error *fail_after_write;
 
   // Endpoint and read buffer to destroy after a shutdown.

--- a/src/core/lib/security/transport/security_handshaker.cc
+++ b/src/core/lib/security/transport/security_handshaker.cc
@@ -47,6 +47,7 @@ typedef struct {
   gpr_refcount refs;
 
   bool shutdown;
+  grpc_error *fail_after_write;
 
   // Endpoint and read buffer to destroy after a shutdown.
   grpc_endpoint *endpoint_to_destroy;
@@ -231,21 +232,9 @@ static grpc_error *on_handshake_next_done_locked(
 
   // Handle TSI errors.
   if (result == TSI_SEND_ALERT_AND_CLOSE && bytes_to_send_size > 0) {
-    gpr_log(GPR_DEBUG,
-            "Encountered TSI error. Sending alert message before closing");
     // Send an alert message before terminating the handshake.
-    grpc_slice to_send = grpc_slice_from_copied_buffer(
-      (const char *)bytes_to_send, bytes_to_send_size);
-    grpc_slice_buffer_reset_and_unref_internal(exec_ctx, &h->outgoing);
-    grpc_slice_buffer_add(&h->outgoing, to_send);
-    // To ensure that the alert is sent before the handshaker is destroyed,
-    // we must not return an error at this point. Instead, we set the shutdown
-    // flag so that the write callback can signal the handshaker to shutdown
-    // after the write has completed.
-    h->shutdown = true;
-    grpc_endpoint_write(exec_ctx, h->args->endpoint, &h->outgoing,
-                        &h->on_handshake_data_sent_to_peer);
-    return error;
+    h->fail_after_write = grpc_set_tsi_error_result(
+        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Handshake failed"), result);
   } else if (result != TSI_OK) {
     // The handshaker encountered an error and there is nothing to send to the
     // peer. We can return an error to signal that the handshaker should be
@@ -368,7 +357,7 @@ static void on_handshake_data_sent_to_peer(grpc_exec_ctx *exec_ctx, void *arg,
                                            grpc_error *error) {
   security_handshaker *h = (security_handshaker *)arg;
   gpr_mu_lock(&h->mu);
-  if (error != GRPC_ERROR_NONE) {
+  if (error != GRPC_ERROR_NONE || h->shutdown) {
     security_handshake_failed_locked(
         exec_ctx, h, GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
                          "Handshake write failed", &error, 1));
@@ -376,12 +365,12 @@ static void on_handshake_data_sent_to_peer(grpc_exec_ctx *exec_ctx, void *arg,
     security_handshaker_unref(exec_ctx, h);
     return;
   }
-  if (h->shutdown) {
-    // Allow final messages to be sent on shutdown. (TSI_SEND_ALERT_AND_CLOSE).
-    security_handshake_failed_locked(
-        exec_ctx, h, GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            "Handshake terminated after final write"));
+  if (h->fail_after_write != GRPC_ERROR_NONE) {
+    // The handshaker sent a final message before terminating. Return an error
+    // to signal the handshaker to shutdown.
+    security_handshake_failed_locked(exec_ctx, h, h->fail_after_write);
     gpr_mu_unlock(&h->mu);
+    security_handshaker_unref(exec_ctx, h);
     return;
   }
 

--- a/src/core/tsi/transport_security.cc
+++ b/src/core/tsi/transport_security.cc
@@ -60,6 +60,8 @@ const char *tsi_result_to_string(tsi_result result) {
       return "TSI_OUT_OF_RESOURCES";
     case TSI_ASYNC:
       return "TSI_ASYNC";
+    case TSI_SEND_ALERT_AND_CLOSE:
+      return "TSI_SEND_ALERT_AND_CLOSE";
     default:
       return "UNKNOWN";
   }

--- a/src/core/tsi/transport_security_interface.h
+++ b/src/core/tsi/transport_security_interface.h
@@ -44,7 +44,8 @@ typedef enum {
   TSI_PROTOCOL_FAILURE = 10,
   TSI_HANDSHAKE_IN_PROGRESS = 11,
   TSI_OUT_OF_RESOURCES = 12,
-  TSI_ASYNC = 13
+  TSI_ASYNC = 13,
+  TSI_SEND_ALERT_AND_CLOSE = 14,
 } tsi_result;
 
 typedef enum {


### PR DESCRIPTION
This change introduces a new tsi_result, TSI_SEND_ALERT_AND_CLOSE. This error code is used by a TSI handshaker to indicate that a protocol error occurred and that a final alert message is to be sent to the peer. This behavior is implemented in security_handshaker.cc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/12937)
<!-- Reviewable:end -->
