### PR TITLE
Do not interpolate variables in leading comments.

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -104,7 +104,7 @@ grpc::string GetHeaderPrologue(grpc_generator::File* file,
     grpc::string leading_comments = file->GetLeadingComments("//");
     if (!leading_comments.empty()) {
       printer->Print(vars, "// Original file comments:\n");
-      printer->Print(leading_comments.c_str());
+      printer->PrintRaw(leading_comments.c_str());
     }
     printer->Print(vars, "#ifndef GRPC_$filename_identifier$__INCLUDED\n");
     printer->Print(vars, "#define GRPC_$filename_identifier$__INCLUDED\n");

--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -666,7 +666,7 @@ grpc::string GetServices(const FileDescriptor* file, bool generate_client,
     grpc::string leading_comments = GetCsharpComments(file, true);
     if (!leading_comments.empty()) {
       out.Print("// Original file comments:\n");
-      out.Print(leading_comments.c_str());
+      out.PrintRaw(leading_comments.c_str());
     }
 
     out.Print("#pragma warning disable 1591\n");

--- a/src/compiler/node_generator.cc
+++ b/src/compiler/node_generator.cc
@@ -250,7 +250,7 @@ grpc::string GenerateFile(const FileDescriptor* file) {
     grpc::string leading_comments = GetNodeComments(file, true);
     if (!leading_comments.empty()) {
       out.Print("// Original file comments:\n");
-      out.Print(leading_comments.c_str());
+      out.PrintRaw(leading_comments.c_str());
     }
 
     out.Print("'use strict';\n");

--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -65,7 +65,7 @@ static void PrintAllComments(const DescriptorType* desc, Printer* printer) {
     printer->Print(" * ");
     size_t start_pos = it->find_first_not_of(' ');
     if (start_pos != grpc::string::npos) {
-      printer->Print(it->c_str() + start_pos);
+      printer->PrintRaw(it->c_str() + start_pos);
     }
     printer->Print("\n");
   }

--- a/src/compiler/php_generator.cc
+++ b/src/compiler/php_generator.cc
@@ -164,7 +164,7 @@ grpc::string GenerateFile(const FileDescriptor* file,
     grpc::string leading_comments = GetPHPComments(file, "//");
     if (!leading_comments.empty()) {
       out.Print("// Original file comments:\n");
-      out.Print(leading_comments.c_str());
+      out.PrintRaw(leading_comments.c_str());
     }
 
     map<grpc::string, grpc::string> vars;

--- a/src/compiler/protobuf_plugin.h
+++ b/src/compiler/protobuf_plugin.h
@@ -141,6 +141,7 @@ class ProtoBufPrinter : public grpc_generator::Printer {
   }
 
   void Print(const char* string) { printer_.Print(string); }
+  void PrintRaw(const char* string) { printer_.PrintRaw(string); }
   void Indent() { printer_.Indent(); }
   void Outdent() { printer_.Outdent(); }
 

--- a/src/compiler/python_generator.cc
+++ b/src/compiler/python_generator.cc
@@ -101,7 +101,7 @@ void PrivateGenerator::PrintAllComments(StringVector comments,
        ++it) {
     size_t start_pos = it->find_first_not_of(' ');
     if (start_pos != grpc::string::npos) {
-      out->Print(it->c_str() + start_pos);
+      out->PrintRaw(it->c_str() + start_pos);
     }
     out->Print("\n");
   }

--- a/src/compiler/ruby_generator.cc
+++ b/src/compiler/ruby_generator.cc
@@ -174,7 +174,7 @@ grpc::string GetServices(const FileDescriptor* file) {
     grpc::string leading_comments = GetRubyComments(file, true);
     if (!leading_comments.empty()) {
       out.Print("# Original file comments:\n");
-      out.Print(leading_comments.c_str());
+      out.PrintRaw(leading_comments.c_str());
     }
 
     out.Print("\n");

--- a/src/compiler/schema_interface.h
+++ b/src/compiler/schema_interface.h
@@ -86,6 +86,7 @@ struct Printer {
   virtual void Print(const std::map<grpc::string, grpc::string>& vars,
                      const char* template_string) = 0;
   virtual void Print(const char* string) = 0;
+  virtual void PrintRaw(const char* string) = 0;
   virtual void Indent() = 0;
   virtual void Outdent() = 0;
 };


### PR DESCRIPTION
There is at least one well-known proto file (plugin.proto) with comments
that include variable-like strings that are not actual variables. This
leads to DFATAL log statements that clutter the output and don't provide
any benefit.