### PR TITLE
Add a little sleep in end2end_test service to make short deadlines actually expire

### DIFF
--- a/src/proto/grpc/testing/echo_messages.proto
+++ b/src/proto/grpc/testing/echo_messages.proto
@@ -45,6 +45,7 @@ message RequestParams {
   bool server_die = 12; // Server should not see a request with this set.
   string binary_error_details = 13;
   ErrorStatus expected_error = 14;
+  int32 server_sleep_us = 15; // Amount to sleep when invoking server
 }
 
 message EchoRequest {

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -1280,6 +1280,8 @@ TEST_P(ProxyEnd2endTest, RpcDeadlineExpires) {
   EchoResponse response;
   request.set_message("Hello");
   request.mutable_param()->set_skip_cancelled_check(true);
+  // Let server sleep for 2 ms first to guarantee expiry
+  request.mutable_param()->set_server_sleep_us(2 * 1000);
 
   ClientContext context;
   std::chrono::system_clock::time_point deadline =

--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -73,6 +73,10 @@ void CheckServerAuthContext(
 
 Status TestServiceImpl::Echo(ServerContext* context, const EchoRequest* request,
                              EchoResponse* response) {
+  // A bit of sleep to make sure that short deadline tests fail
+  gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
+                               gpr_time_from_millis(2, GPR_TIMESPAN)));
+
   if (request->has_param() && request->param().server_die()) {
     gpr_log(GPR_ERROR, "The request should not reach application handler.");
     GPR_ASSERT(0);

--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -74,8 +74,12 @@ void CheckServerAuthContext(
 Status TestServiceImpl::Echo(ServerContext* context, const EchoRequest* request,
                              EchoResponse* response) {
   // A bit of sleep to make sure that short deadline tests fail
-  gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
-                               gpr_time_from_millis(2, GPR_TIMESPAN)));
+  if (request->has_param() && request->param().server_sleep_us() > 0) {
+    gpr_sleep_until(
+        gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
+                     gpr_time_from_micros(request->param().server_sleep_us(),
+                                          GPR_TIMESPAN)));
+  }
 
   if (request->has_param() && request->param().server_die()) {
     gpr_log(GPR_ERROR, "The request should not reach application handler.");


### PR DESCRIPTION
Fixes #12917 
