### PR TITLE
Sanity check that tests declared non-polling actually don't poll

### DIFF
--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3811,7 +3811,8 @@
       "mac", 
       "posix", 
       "windows"
-    ]
+    ], 
+    "uses_polling": true
   }, 
   {
     "args": [], 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -286,7 +286,7 @@ class CLanguage(object):
         continue
       polling_strategies = (_POLLING_STRATEGIES.get(self.platform, ['all'])
                             if target.get('uses_polling', True)
-                            else ['all'])
+                            else ['none'])
       if self.args.iomgr_platform == 'uv':
         polling_strategies = ['all']
       for polling_strategy in polling_strategies:


### PR DESCRIPTION
Step needed to enable broader and safe use of 
``` yaml
uses_polling: false
```
in build.yaml

