### PR TITLE
Revert "Sanity check that tests declared non-polling actually don't poll"

### DIFF
--- a/src/core/lib/iomgr/ev_posix.cc
+++ b/src/core/lib/iomgr/ev_posix.cc
@@ -61,30 +61,12 @@ typedef struct {
   event_engine_factory_fn factory;
 } event_engine_factory;
 
-namespace {
-extern "C" {
-int dummypoll(struct pollfd fds[], nfds_t nfds, int timeout) {
-  gpr_log(GPR_ERROR, "Attempted to poll despite declaring non-polling.");
-  GPR_ASSERT(false);
-  return -1;
-}
-}  // extern "C"
-
-const grpc_event_engine_vtable *init_non_polling(bool explicit_request) {
-  // return the simplest engine as a dummy but also override the poller
-  auto ret = grpc_init_poll_posix(explicit_request);
-  grpc_poll_function = dummypoll;
-  return ret;
-}
-}  // namespace
-
 static const event_engine_factory g_factories[] = {
     {"epoll1", grpc_init_epoll1_linux},
     {"epollsig", grpc_init_epollsig_linux},
     {"poll", grpc_init_poll_posix},
     {"poll-cv", grpc_init_poll_cv_posix},
     {"epollex", grpc_init_epollex_linux},
-    {"none", init_non_polling},
 };
 
 static void add(const char *beg, const char *end, char ***ss, size_t *ns) {

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3811,8 +3811,7 @@
       "mac", 
       "posix", 
       "windows"
-    ], 
-    "uses_polling": true
+    ]
   }, 
   {
     "args": [], 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -286,7 +286,7 @@ class CLanguage(object):
         continue
       polling_strategies = (_POLLING_STRATEGIES.get(self.platform, ['all'])
                             if target.get('uses_polling', True)
-                            else ['none'])
+                            else ['all'])
       if self.args.iomgr_platform == 'uv':
         polling_strategies = ['all']
       for polling_strategy in polling_strategies:


### PR DESCRIPTION
Reverts grpc/grpc#12953
because I pressed the merge button on the wrong PR
