### PR TITLE
Use uses_polling build flag to reduce # of tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1736,6 +1736,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: alloc_test
   build: test
   language: c
@@ -1744,6 +1745,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: alpn_test
   build: test
   language: c
@@ -1776,6 +1778,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: backoff_test
   build: test
   language: c
@@ -1786,6 +1789,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: bad_server_response_test
   build: test
   language: c
@@ -1807,6 +1811,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  uses_polling: false
 - name: bin_encoder_test
   build: test
   language: c
@@ -1815,6 +1820,7 @@ targets:
   deps:
   - grpc_test_util
   - grpc
+  uses_polling: false
 - name: byte_stream_test
   build: test
   language: c
@@ -1825,6 +1831,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: census_context_test
   build: test
   language: c
@@ -1835,6 +1842,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: census_intrusive_hash_map_test
   build: test
   language: c
@@ -1845,6 +1853,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: census_resource_test
   build: test
   language: c
@@ -1855,6 +1864,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: census_trace_context_test
   build: test
   language: c
@@ -1865,6 +1875,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: channel_create_test
   build: test
   language: c
@@ -1893,6 +1904,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: chttp2_stream_map_test
   build: test
   language: c
@@ -1903,6 +1915,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: chttp2_varint_test
   build: test
   language: c
@@ -1913,6 +1926,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: client_fuzzer
   build: fuzzer
   language: c
@@ -1948,6 +1962,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: concurrent_connectivity_test
   cpu_cost: 2.0
   build: test
@@ -2035,6 +2050,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: ev_epollsig_linux_test
   cpu_cost: 3
   build: test
@@ -2167,6 +2183,7 @@ targets:
   deps:
   - gpr
   - grpc
+  uses_polling: false
 - name: gen_legal_metadata_characters
   build: tool
   language: c
@@ -2179,6 +2196,7 @@ targets:
   src:
   - tools/codegen/core/gen_percent_encoding_tables.c
   deps: []
+  uses_polling: false
 - name: goaway_server_test
   cpu_cost: 0.1
   build: test
@@ -2204,6 +2222,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: gpr_cmdline_test
   build: test
   language: c
@@ -2212,6 +2231,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: gpr_cpu_test
   cpu_cost: 30
   build: test
@@ -2221,6 +2241,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: gpr_env_test
   build: test
   language: c
@@ -2229,6 +2250,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: gpr_histogram_test
   build: test
   language: c
@@ -2237,6 +2259,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: gpr_host_port_test
   build: test
   language: c
@@ -2245,6 +2268,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: gpr_log_test
   build: test
   language: c
@@ -2253,6 +2277,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: gpr_mpscq_test
   cpu_cost: 30
   build: test
@@ -2272,6 +2297,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: gpr_stack_lockfree_test
   cpu_cost: 7
   build: test
@@ -2281,6 +2307,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: gpr_string_test
   build: test
   language: c
@@ -2289,6 +2316,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: gpr_sync_test
   cpu_cost: 10
   build: test
@@ -2298,6 +2326,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: gpr_thd_test
   cpu_cost: 10
   build: test
@@ -2307,6 +2336,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: gpr_time_test
   build: test
   language: c
@@ -2315,6 +2345,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: gpr_tls_test
   build: test
   language: c
@@ -2323,6 +2354,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: gpr_useful_test
   build: test
   language: c
@@ -2331,6 +2363,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: grpc_auth_context_test
   build: test
   language: c
@@ -2341,6 +2374,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: grpc_b64_test
   build: test
   language: c
@@ -2351,6 +2385,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: grpc_byte_buffer_reader_test
   build: test
   language: c
@@ -2361,6 +2396,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: grpc_channel_args_test
   build: test
   language: c
@@ -2371,6 +2407,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: grpc_channel_stack_builder_test
   build: test
   language: c
@@ -2391,6 +2428,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: grpc_completion_queue_test
   build: test
   language: c
@@ -2422,6 +2460,7 @@ targets:
   - grpc
   - gpr
   secure: true
+  uses_polling: false
 - name: grpc_credentials_test
   build: test
   language: c
@@ -2453,6 +2492,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: grpc_json_token_test
   build: test
   language: c
@@ -2467,6 +2507,7 @@ targets:
   - linux
   - posix
   - mac
+  uses_polling: false
 - name: grpc_jwt_verifier_test
   build: test
   language: c
@@ -2477,6 +2518,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: grpc_print_google_default_creds_token
   build: tool
   language: c
@@ -2485,6 +2527,7 @@ targets:
   deps:
   - grpc
   - gpr
+  uses_polling: false
 - name: grpc_security_connector_test
   build: test
   language: c
@@ -2503,6 +2546,7 @@ targets:
   deps:
   - grpc
   - gpr
+  uses_polling: false
 - name: handshake_client
   build: test
   language: c
@@ -2557,6 +2601,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: hpack_table_test
   build: test
   language: c
@@ -2567,6 +2612,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: http_parser_test
   build: test
   language: c
@@ -2577,6 +2623,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: http_request_fuzzer_test
   build: fuzzer
   language: c
@@ -2651,6 +2698,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: invalid_call_argument_test
   cpu_cost: 0.1
   build: test
@@ -2684,6 +2732,7 @@ targets:
   deps:
   - grpc
   - gpr
+  uses_polling: false
 - name: json_rewrite_test
   build: test
   language: c
@@ -2694,6 +2743,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: json_stream_error_test
   build: test
   language: c
@@ -2704,6 +2754,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: json_test
   build: test
   language: c
@@ -2714,6 +2765,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: lame_client_test
   build: test
   language: c
@@ -2736,6 +2788,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: load_file_test
   build: test
   language: c
@@ -2746,6 +2799,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: low_level_ping_pong_benchmark
   build: benchmark
   language: c
@@ -2771,6 +2825,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: memory_profile_server
   build: test
   run: false
@@ -2807,6 +2862,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: minimal_stack_is_minimal_test
   build: test
   language: c
@@ -2817,6 +2873,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: mlog_test
   flaky: true
   build: test
@@ -2828,6 +2885,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: multiple_server_queues_test
   build: test
   language: c
@@ -2846,6 +2904,7 @@ targets:
   deps:
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: nanopb_fuzzer_response_test
   build: fuzzer
   language: c
@@ -2905,6 +2964,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: percent_decode_fuzzer
   build: fuzzer
   language: c
@@ -2941,6 +3001,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: pollset_set_test
   build: test
   language: c
@@ -3070,6 +3131,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: slice_hash_table_test
   build: test
   language: c
@@ -3080,6 +3142,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: slice_string_helpers_test
   build: test
   language: c
@@ -3090,6 +3153,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: slice_test
   build: test
   language: c
@@ -3100,6 +3164,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: sockaddr_resolver_test
   build: test
   language: c
@@ -3174,6 +3239,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: stream_compression_test
   build: test
   language: c
@@ -3184,6 +3250,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: stream_owned_slice_test
   build: test
   language: c
@@ -3194,6 +3261,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: tcp_client_posix_test
   cpu_cost: 0.5
   build: test
@@ -3279,6 +3347,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: timeout_encoding_test
   build: test
   language: c
@@ -3289,6 +3358,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: timer_heap_test
   build: test
   language: c
@@ -3301,6 +3371,7 @@ targets:
   - gpr
   exclude_iomgrs:
   - uv
+  uses_polling: false
 - name: timer_list_test
   build: test
   language: c
@@ -3313,6 +3384,7 @@ targets:
   - gpr
   exclude_iomgrs:
   - uv
+  uses_polling: false
 - name: transport_connectivity_state_test
   build: test
   language: c
@@ -3333,6 +3405,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: transport_pid_controller_test
   build: test
   language: c
@@ -3343,6 +3416,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: transport_security_test
   build: test
   language: c
@@ -3451,6 +3525,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: bdp_estimator_test
   build: test
   language: c++
@@ -3463,6 +3538,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: bm_arena
   build: test
   language: c++
@@ -3484,6 +3560,7 @@ targets:
   - mac
   - linux
   - posix
+  uses_polling: false
 - name: bm_call_create
   build: test
   language: c++
@@ -3505,6 +3582,7 @@ targets:
   - mac
   - linux
   - posix
+  uses_polling: false
 - name: bm_chttp2_hpack
   build: test
   language: c++
@@ -3526,6 +3604,7 @@ targets:
   - mac
   - linux
   - posix
+  uses_polling: false
 - name: bm_chttp2_transport
   build: test
   language: c++
@@ -3631,6 +3710,7 @@ targets:
   - mac
   - linux
   - posix
+  uses_polling: false
 - name: bm_fullstack_streaming_ping_pong
   build: test
   language: c++
@@ -3759,6 +3839,7 @@ targets:
   - mac
   - linux
   - posix
+  uses_polling: false
 - name: bm_pollset
   build: test
   language: c++
@@ -3790,6 +3871,7 @@ targets:
   - grpc++
   - grpc
   - gpr
+  uses_polling: false
 - name: channel_filter_test
   gtest: true
   build: test
@@ -3800,6 +3882,7 @@ targets:
   - grpc++
   - grpc
   - gpr
+  uses_polling: false
 - name: cli_call_test
   gtest: true
   build: test
@@ -3879,6 +3962,7 @@ targets:
   - gpr
   filegroups:
   - grpc++_codegen_base
+  uses_polling: false
 - name: codegen_test_minimal
   gtest: true
   build: test
@@ -3897,6 +3981,7 @@ targets:
   filegroups:
   - grpc++_codegen_base
   - grpc++_codegen_base_src
+  uses_polling: false
 - name: credentials_test
   gtest: true
   build: test
@@ -3919,6 +4004,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: cxx_slice_test
   gtest: true
   build: test
@@ -3931,6 +4017,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: cxx_string_ref_test
   gtest: true
   build: test
@@ -3940,6 +4027,7 @@ targets:
   deps:
   - grpc++
   - grpc
+  uses_polling: false
 - name: cxx_time_test
   gtest: true
   build: test
@@ -3952,6 +4040,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: end2end_test
   gtest: true
   cpu_cost: 0.5
@@ -4015,6 +4104,7 @@ targets:
   - gpr
   args:
   - --generated_file_path=gens/src/proto/grpc/testing/
+  uses_polling: false
 - name: grpc_cli
   build: test
   run: false
@@ -4307,6 +4397,7 @@ targets:
   - gpr
   uses:
   - grpc++_test
+  uses_polling: false
 - name: metrics_client
   build: test
   run: false
@@ -4371,6 +4462,7 @@ targets:
   filegroups:
   - grpc++_codegen_base
   - grpc++_codegen_proto
+  uses_polling: false
 - name: qps_interarrival_test
   build: test
   run: false
@@ -4390,6 +4482,7 @@ targets:
   - mac
   - linux
   - posix
+  uses_polling: false
 - name: qps_json_driver
   build: test
   run: false
@@ -4626,6 +4719,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: status_test
   build: test
   language: c++
@@ -4637,6 +4731,7 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  uses_polling: false
 - name: streaming_throughput_test
   gtest: true
   build: test

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -45,7 +45,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -68,7 +68,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -114,7 +114,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -137,7 +137,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -185,7 +185,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -208,7 +208,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -231,7 +231,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -254,7 +254,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -277,7 +277,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -300,7 +300,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -323,7 +323,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -369,7 +369,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -392,7 +392,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -415,7 +415,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -461,7 +461,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -628,7 +628,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -825,7 +825,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -848,7 +848,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -871,7 +871,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -894,7 +894,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -917,7 +917,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -940,7 +940,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -963,7 +963,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1009,7 +1009,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1032,7 +1032,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1055,7 +1055,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1078,7 +1078,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1101,7 +1101,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1124,7 +1124,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1147,7 +1147,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1170,7 +1170,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1193,7 +1193,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1216,7 +1216,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1239,7 +1239,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1262,7 +1262,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1308,7 +1308,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1402,7 +1402,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1423,7 +1423,7 @@
       "mac", 
       "posix"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1446,7 +1446,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1530,7 +1530,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1553,7 +1553,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1576,7 +1576,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1660,7 +1660,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1706,7 +1706,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1729,7 +1729,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1752,7 +1752,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1798,7 +1798,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1842,7 +1842,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1865,7 +1865,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1888,7 +1888,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -1934,7 +1934,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2005,7 +2005,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2028,7 +2028,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2258,7 +2258,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2281,7 +2281,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2304,7 +2304,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2327,7 +2327,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2440,7 +2440,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2463,7 +2463,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2486,7 +2486,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2628,7 +2628,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2651,7 +2651,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2676,7 +2676,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2701,7 +2701,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2747,7 +2747,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2770,7 +2770,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2929,7 +2929,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -2952,7 +2952,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [
@@ -2975,7 +2975,7 @@
       "mac", 
       "posix"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [
@@ -2998,7 +2998,7 @@
       "mac", 
       "posix"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [
@@ -3021,7 +3021,7 @@
       "mac", 
       "posix"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [
@@ -3136,7 +3136,7 @@
       "mac", 
       "posix"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [
@@ -3271,7 +3271,7 @@
       "mac", 
       "posix"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [
@@ -3317,7 +3317,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -3340,7 +3340,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -3434,7 +3434,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -3457,7 +3457,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -3503,7 +3503,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -3526,7 +3526,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -3549,7 +3549,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -3572,7 +3572,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -3689,7 +3689,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -3902,7 +3902,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -3994,7 +3994,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -4218,7 +4218,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 
@@ -4241,7 +4241,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": true
+    "uses_polling": false
   }, 
   {
     "args": [], 


### PR DESCRIPTION
Declaring tests with "uses_polling: false" allows them to be tested with just one (dummy) poller rather than the full suite of polling strategies for a given platform. This build.yaml flag should only be used for tests that never execute a blocking polling operation. This would apply for unit tests of most structs (e.g., slice buffer), algorithm tests (e.g., message compression), and many other significant categories. If the test ever actually executes a polling operation with non-zero timeout, the code in #12965 makes sure that the test fails with an error log.
