### PR TITLE
Install enum34 on all Python < 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -236,14 +236,16 @@ INSTALL_REQUIRES = (
     'protobuf>=3.3.0',
 )
 
-if not PY3:
-  INSTALL_REQUIRES += ('futures>=2.2.0', 'enum34>=1.0.4')
-
 SETUP_REQUIRES = INSTALL_REQUIRES + (
     'sphinx>=1.3',
     'sphinx_rtd_theme>=0.1.8',
     'six>=1.10',
   ) if ENABLE_DOCUMENTATION_BUILD else ()
+
+EXTRAS_REQUIRE = {
+  ':python_version<"3.0"': ('futures>=2.2.0',),
+  ':python_version<"3.4"': ('enum34>=1.0.4',),
+}
 
 try:
   import Cython
@@ -301,6 +303,7 @@ setuptools.setup(
   package_dir=PACKAGE_DIRECTORIES,
   package_data=PACKAGE_DATA,
   install_requires=INSTALL_REQUIRES,
+  extras_require=EXTRAS_REQUIRE,
   setup_requires=SETUP_REQUIRES,
   cmdclass=COMMAND_CLASS,
 )


### PR DESCRIPTION
I am filing this PR on behalf of the author of GoogleCloudPlatform/google-cloud-python#4115.

In grpc's [`setup.py`, on line 229](https://github.com/grpc/grpc/blob/5253c8f9a899450397a5e46e4923d01ac9a66a27/setup.py#L229), you specify the inclusion of `enum34` as a dependency if the user is running in Python 2. However, the `enum` package was not added to the standard library until Python 3.4.

The correct syntax in `setup.py` to do the right thing all the time is:

```
    extras_require={
        ':python_version<"3.0"': ('futures >= 2.2.0',),
        ':python_version<"3.4"': ('enum34 >= 1.0.4',),
    },
```

I recognize that (like us) you likely do not officially support Python 3.3 anymore. However, this is an easy low-hanging fruit item, and it seems reasonably plausible that Python 3.3 will work. Since this is so low-hanging, it seems reasonable to change.

This is also more correct for other reasons (in principle, you can not rely on `setup.py` to be executed at install time).