### PR TITLE
Add Electron 1.7 to Node artifact build targets

### DIFF
--- a/tools/run_tests/artifacts/build_artifact_node.bat
+++ b/tools/run_tests/artifacts/build_artifact_node.bat
@@ -14,7 +14,7 @@
 
 set node_versions=4.0.0 5.0.0 6.0.0 7.0.0 8.0.0
 
-set electron_versions=1.0.0 1.1.0 1.2.0 1.3.0 1.4.0 1.5.0 1.6.0
+set electron_versions=1.0.0 1.1.0 1.2.0 1.3.0 1.4.0 1.5.0 1.6.0 1.7.0
 
 set PATH=%PATH%;C:\Program Files\nodejs\;%APPDATA%\npm
 

--- a/tools/run_tests/artifacts/build_artifact_node.sh
+++ b/tools/run_tests/artifacts/build_artifact_node.sh
@@ -30,7 +30,7 @@ npm update
 
 node_versions=( 4.0.0 5.0.0 6.0.0 7.0.0 8.0.0 )
 
-electron_versions=( 1.0.0 1.1.0 1.2.0 1.3.0 1.4.0 1.5.0 1.6.0 )
+electron_versions=( 1.0.0 1.1.0 1.2.0 1.3.0 1.4.0 1.5.0 1.6.0 1.7.0 )
 
 for version in ${node_versions[@]}
 do


### PR DESCRIPTION
As requested in #12985.

My intention is to rebuild the artifacts for 1.6.6 and publish the additional artifacts for Electron 1.7