### PR TITLE
[Cherry pick into v1.6.x] Fix build for ios app using grpc as cc_library

### DIFF
--- a/third_party/cares/cares.BUILD
+++ b/third_party/cares/cares.BUILD
@@ -3,6 +3,23 @@ config_setting(
     values = {"cpu": "darwin"},
 )
 
+config_setting(
+    name = "ios_x86_64",
+    values = {"cpu": "ios_x86_64"},
+)
+config_setting(
+    name = "ios_armv7",
+    values = {"cpu": "ios_armv7"},
+)
+config_setting(
+    name = "ios_armv7s",
+    values = {"cpu": "ios_armv7s"},
+)
+config_setting(
+    name = "ios_arm64",
+    values = {"cpu": "ios_arm64"},
+)
+
 cc_library(
     name = "ares",
     srcs = [
@@ -81,6 +98,10 @@ cc_library(
         "cares/nameser.h",
         "cares/setup_once.h",
     ] + select({
+        ":ios_x86_64": ["config_darwin/ares_config.h"],
+        ":ios_armv7": ["config_darwin/ares_config.h"],
+        ":ios_armv7s": ["config_darwin/ares_config.h"],
+        ":ios_arm64": ["config_darwin/ares_config.h"],
         ":darwin": ["config_darwin/ares_config.h"],
         "//conditions:default": ["config_linux/ares_config.h"],
     }),
@@ -88,6 +109,10 @@ cc_library(
         ".",
         "cares"
     ] + select({
+        ":ios_x86_64": ["config_darwin"],
+        ":ios_armv7": ["config_darwin"],
+        ":ios_armv7s": ["config_darwin"],
+        ":ios_arm64": ["config_darwin"],
         ":darwin": ["config_darwin"],
         "//conditions:default": ["config_linux"],
     }),


### PR DESCRIPTION
For ios build,  bazel build needs to be invoked with:
--ios_multi_cpu=armv7,arm64 build.  This in turn gets picked as
cpu based on the docs:
--[no]experimental_enable_objc_cc_deps default: "true"
Allows objc_* rules to depend on cc_library and causes any objc dependencies to be built with --cpu set to "ios_<--ios_cpu>" for any values in --ios_multi_cpu.

This diff explicitly adds darwin config for cpu being ios_x86_64, ios_armv7,
ios_armv7s and ios_arm64.  This is the pattern followed by protobuf build too
https://github.com/google/protobuf/blob/master/BUILD