### PR TITLE
cpu_linux: Don't spam sched_getcpu failures on qemu

### DIFF
--- a/src/core/lib/support/cpu_linux.cc
+++ b/src/core/lib/support/cpu_linux.cc
@@ -38,8 +38,9 @@ static int ncpus = 0;
 static void init_num_cpus() {
   /* This must be signed. sysconf returns -1 when the number cannot be
      determined */
+  int cpu = sched_getcpu();
   ncpus = (int)sysconf(_SC_NPROCESSORS_ONLN);
-  if (ncpus < 1) {
+  if (ncpus < 1 || cpu < 0) {
     gpr_log(GPR_ERROR, "Cannot determine number of CPUs: assuming 1");
     ncpus = 1;
   }
@@ -56,6 +57,9 @@ unsigned gpr_cpu_current_cpu(void) {
   // sched_getcpu() is undefined on musl
   return 0;
 #else
+  if (gpr_cpu_num_cores() == 1) {
+    return 0;
+  }
   int cpu = sched_getcpu();
   if (cpu < 0) {
     gpr_log(GPR_ERROR, "Error determining current CPU: %s\n", strerror(errno));


### PR DESCRIPTION
__NR_getcpu isn't implemented on qemu, and for some reason
sysconf(_SC_NPROCESSORS_ONLN) returns the number of processers
of the host system, giving a false indication that there is more
than one cpu for the qemu case.

Expand the init_num_cpus sequence to also run sched_getcpu once,
and if that call isn't supported, initialize 'ncpus' to 1.

Later, in gpr_cpu_current_cpu, use gpr_cpu_num_cores to avoid
the system call in cases where we know it isn't supported, or
if the ncpus is otherwise 1.