### PR TITLE
PHP benchmark: support multi-rpc/channel; scenarios for 1M payload&32 cores; ruby proxy report CPU usage

### DIFF
--- a/src/ruby/qps/proxy-worker.rb
+++ b/src/ruby/qps/proxy-worker.rb
@@ -161,7 +161,7 @@ def proxymain
   Thread.abort_on_exception = true
 
   # Make sure proxy_server can handle the large number of calls in benchmarks
-  s = GRPC::RpcServer.new(pool_size: 1024)
+  s = GRPC::RpcServer.new(pool_size: 4096)
   port = s.add_http2_port("0.0.0.0:" + options['driver_port'].to_s,
                           :this_port_is_insecure)
   bmc = ProxyBenchmarkClientServiceImpl.new(port, options[:c_ext])

--- a/tools/jenkins/run_full_performance.sh
+++ b/tools/jenkins/run_full_performance.sh
@@ -34,7 +34,7 @@ git clean -fdxq --exclude='report*.xml'
 
 # scalability with 32cores (and upload to a different BQ table)
 tools/run_tests/run_performance_tests.py \
-    -l c++ java csharp go \
+    -l c++ java csharp go php7 php7_protobuf_c \
     --netperf \
     --category scalable \
     --bq_result_table performance_test.performance_experiment_32core \

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -835,38 +835,26 @@ class Php7Language:
     yield _ping_pong_scenario(
         '%s_to_cpp_protobuf_sync_unary_ping_pong_1MB' % php7_extension_mode,
         rpc_type='UNARY', client_type='SYNC_CLIENT', server_type='ASYNC_SERVER',
-        server_language='c++', outstanding=1, req_size=1024*1024, resp_size=1024*1024, 
-        async_server_threads=1, unconstrained_client='sync', categories=[SMOKETEST, SCALABLE])
+        server_language='c++', req_size=1024*1024, resp_size=1024*1024, 
+        categories=[SMOKETEST, SCALABLE])
 
     yield _ping_pong_scenario(
         '%s_to_cpp_protobuf_sync_streaming_ping_pong_1MB' % php7_extension_mode,
         rpc_type='STREAMING', client_type='SYNC_CLIENT', server_type='ASYNC_SERVER',
-        server_language='c++', outstanding=1, req_size=1024*1024, resp_size=1024*1024,
-        async_server_threads=1, unconstrained_client='sync', categories=[SMOKETEST, SCALABLE])
+        server_language='c++', req_size=1024*1024, resp_size=1024*1024,
+        categories=[SMOKETEST, SCALABLE])
 
     # TODO(ddyihai): Investigate why when outstanding=1, QPS decrease when increase async_server_threads;
     # async_server_threads=2 is a good value here. The same for other languages.
     yield _ping_pong_scenario(
         '%s_to_cpp_protobuf_sync_unary_qps_unconstrained' % php7_extension_mode,
         rpc_type='UNARY', client_type='SYNC_CLIENT', server_type='ASYNC_SERVER',
-        server_language='c++', outstanding=1, async_server_threads=1, unconstrained_client='sync')
+        server_language='c++', categories=[SMOKETEST,SCALABLE])
 
     yield _ping_pong_scenario(
         '%s_to_cpp_protobuf_sync_streaming_qps_unconstrained' % php7_extension_mode,
         rpc_type='STREAMING', client_type='SYNC_CLIENT', server_type='ASYNC_SERVER',
-        server_language='c++', outstanding=1, async_server_threads=1, unconstrained_client='sync')
-
-    # TODO(ddyihai): The bottleneck in the server side prevent php client use all cores in the
-    # 32-core-environment. Set "server_num=2" if possiable can get x2 higher QPS.
-    yield _ping_pong_scenario(
-        '%s_to_cpp_protobuf_sync_unary_qps_unconstrained_32cores' % php7_extension_mode,
-        rpc_type='UNARY', client_type='SYNC_CLIENT', server_type='ASYNC_SERVER', channels=256,
-        server_language='c++', outstanding=1, unconstrained_client='sync')
-
-    yield _ping_pong_scenario(
-        '%s_to_cpp_protobuf_sync_streaming_qps_unconstrained_32cores' % php7_extension_mode,
-        rpc_type='STREAMING', client_type='SYNC_CLIENT', server_type='ASYNC_SERVER', channels=256,
-        server_language='c++', outstanding=1, unconstrained_client='sync')
+        server_language='c++', categories=[SMOKETEST,SCALABLE])
 
   def __str__(self):
     if self.php7_protobuf_c:


### PR DESCRIPTION
Final work to make php benchmark result show in all the graphs from the dashboard.
1. support outstanding_rpc_channel;
2. report CPU usages
3. fill the missing scenarios
Get the payload size to determine the batch length from php-client to the ruby proxy. 2000 ping-pong batch length is too large for 1M payload because 30s is too short to send such amount of ping-pong.

Tested in the performance_adhoc.
