### PR TITLE
Fix initialization bug in channel creation

### DIFF
--- a/src/cpp/client/create_channel.cc
+++ b/src/cpp/client/create_channel.cc
@@ -38,7 +38,7 @@ std::shared_ptr<Channel> CreateCustomChannel(
     const grpc::string& target,
     const std::shared_ptr<ChannelCredentials>& creds,
     const ChannelArguments& args) {
-  internal::GrpcLibrary
+  GrpcLibraryCodegen
       init_lib;  // We need to call init in case of a bad creds.
   return creds
              ? creds->CreateChannel(target, args)

--- a/src/cpp/client/create_channel.cc
+++ b/src/cpp/client/create_channel.cc
@@ -38,8 +38,7 @@ std::shared_ptr<Channel> CreateCustomChannel(
     const grpc::string& target,
     const std::shared_ptr<ChannelCredentials>& creds,
     const ChannelArguments& args) {
-  GrpcLibraryCodegen
-      init_lib;  // We need to call init in case of a bad creds.
+  GrpcLibraryCodegen init_lib;  // We need to call init in case of a bad creds.
   return creds
              ? creds->CreateChannel(target, args)
              : CreateChannelInternal("", grpc_lame_client_channel_create(


### PR DESCRIPTION
The `init_lib` variable has the wrong type. As it is now, it has no effect and doesn't satisfy the comment.