### PR TITLE
Fix return value doc in two PHP functions

### DIFF
--- a/src/php/ext/grpc/server.c
+++ b/src/php/ext/grpc/server.c
@@ -169,7 +169,7 @@ PHP_METHOD(Server, requestCall) {
 /**
  * Add a http2 over tcp listener.
  * @param string $addr The address to add
- * @return bool True on success, false on failure
+ * @return int Port on success, 0 on failure
  */
 PHP_METHOD(Server, addHttp2Port) {
   const char *addr;
@@ -190,7 +190,7 @@ PHP_METHOD(Server, addHttp2Port) {
  * Add a secure http2 over tcp listener.
  * @param string $addr The address to add
  * @param ServerCredentials The ServerCredentials object
- * @return bool True on success, false on failure
+ * @return int Port on success, 0 on failure
  */
 PHP_METHOD(Server, addSecureHttp2Port) {
   const char *addr;


### PR DESCRIPTION
Fixes the return value documentation on PHP addSecureHttp2Port and addHttp2Port

cc @stanley-cheung 