### PR TITLE
Fix call object memory leak in ruby, when call object is closed

### DIFF
--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -221,6 +221,7 @@ static VALUE grpc_rb_call_close(VALUE self) {
   TypedData_Get_Struct(self, grpc_rb_call, &grpc_call_data_type, call);
   if (call != NULL) {
     destroy_call(call);
+    xfree(RTYPEDDATA_DATA(self));
     RTYPEDDATA_DATA(self) = NULL;
   }
   return Qnil;


### PR DESCRIPTION
Second fix for https://github.com/grpc/grpc/issues/12443.

https://github.com/grpc/grpc/pull/12493 fixes the memory leak in the call object's GC handler. But when the the call gets closed (the most common case), the [data](https://github.com/ruby/ruby/blob/c08f7b80889b531865e74bc5f573df8fa27f2088/include/ruby/ruby.h#L1090) of the call object, pointing to a still-alloc'd memory, gets 
[cleared](https://github.com/grpc/grpc/blob/master/src/ruby/ext/grpc/rb_call.c#L224) and forgotten about.