### PR TITLE
Bump google/benchmark submodule to v1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8298,6 +8298,7 @@ LIBBENCHMARK_SRC = \
     third_party/benchmark/src/commandlineflags.cc \
     third_party/benchmark/src/complexity.cc \
     third_party/benchmark/src/console_reporter.cc \
+    third_party/benchmark/src/counter.cc \
     third_party/benchmark/src/csv_reporter.cc \
     third_party/benchmark/src/json_reporter.cc \
     third_party/benchmark/src/reporter.cc \

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -2316,6 +2316,7 @@
         'third_party/benchmark/src/commandlineflags.cc',
         'third_party/benchmark/src/complexity.cc',
         'third_party/benchmark/src/console_reporter.cc',
+        'third_party/benchmark/src/counter.cc',
         'third_party/benchmark/src/csv_reporter.cc',
         'third_party/benchmark/src/json_reporter.cc',
         'third_party/benchmark/src/reporter.cc',

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -7453,7 +7453,6 @@
     "headers": [
       "third_party/benchmark/include/benchmark/benchmark.h", 
       "third_party/benchmark/include/benchmark/benchmark_api.h", 
-      "third_party/benchmark/include/benchmark/macros.h", 
       "third_party/benchmark/include/benchmark/reporter.h", 
       "third_party/benchmark/src/arraysize.h", 
       "third_party/benchmark/src/benchmark_api_internal.h", 
@@ -7461,6 +7460,7 @@
       "third_party/benchmark/src/colorprint.h", 
       "third_party/benchmark/src/commandlineflags.h", 
       "third_party/benchmark/src/complexity.h", 
+      "third_party/benchmark/src/counter.h", 
       "third_party/benchmark/src/cycleclock.h", 
       "third_party/benchmark/src/internal_macros.h", 
       "third_party/benchmark/src/log.h", 

--- a/tools/run_tests/sanity/check_submodules.sh
+++ b/tools/run_tests/sanity/check_submodules.sh
@@ -26,7 +26,7 @@ want_submodules=`mktemp /tmp/submXXXXXX`
 
 git submodule | awk '{ print $1 }' | sort > $submodules
 cat << EOF | awk '{ print $1 }' | sort > $want_submodules
- 44c25c892a6229b20db7cd9dc05584ea865896de third_party/benchmark (v0.1.0-343-g44c25c8)
+ 5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8 third_party/benchmark (v1.2.0)
  be2ee342d3781ddb954f91f8a7e660c6f59e87e5 third_party/boringssl (heads/chromium-stable)
  886e7d75368e3f4fab3f4d0d3584e4abfc557755 third_party/boringssl-with-bazel (version_for_cocoapods_7.0-857-g886e7d7)
  30dbc81fb5ffdc98ea9b14b1918bfe4e8779b26e third_party/gflags (v2.2.0)


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/12694; build issues the older versions have on ppc64le architecture.