### PR TITLE
GPR_ATTRIBUTE_NO_TSAN doesn't reach through function calls, so use a friend

### DIFF
--- a/src/core/ext/transport/chttp2/transport/flow_control.h
+++ b/src/core/ext/transport/chttp2/transport/flow_control.h
@@ -32,6 +32,12 @@ struct grpc_chttp2_stream;
 
 extern "C" grpc_tracer_flag grpc_flowctl_trace;
 
+namespace grpc {
+namespace testing {
+  class TrickledCHTTP2; // to make this a friend
+}  // namespace testing
+}  // namespace grpc
+
 namespace grpc_core {
 namespace chttp2 {
 
@@ -203,6 +209,7 @@ class TransportFlowControl {
   }
 
  private:
+  friend class ::grpc::testing::TrickledCHTTP2;
   double TargetLogBdp();
   double SmoothLogBdp(grpc_exec_ctx* exec_ctx, double value);
   FlowControlAction::Urgency DeltaUrgency(int32_t value,
@@ -297,6 +304,7 @@ class StreamFlowControl {
   }
 
  private:
+  friend class ::grpc::testing::TrickledCHTTP2;
   TransportFlowControl* const tfc_;
   const grpc_chttp2_stream* const s_;
 

--- a/src/core/ext/transport/chttp2/transport/flow_control.h
+++ b/src/core/ext/transport/chttp2/transport/flow_control.h
@@ -34,7 +34,7 @@ extern "C" grpc_tracer_flag grpc_flowctl_trace;
 
 namespace grpc {
 namespace testing {
-  class TrickledCHTTP2; // to make this a friend
+class TrickledCHTTP2;  // to make this a friend
 }  // namespace testing
 }  // namespace grpc
 

--- a/test/cpp/microbenchmarks/bm_fullstack_trickle.cc
+++ b/test/cpp/microbenchmarks/bm_fullstack_trickle.cc
@@ -21,6 +21,7 @@
 #include <benchmark/benchmark.h>
 #include <gflags/gflags.h>
 #include <fstream>
+
 #include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
 #include "src/core/ext/transport/chttp2/transport/internal.h"
 #include "src/core/lib/iomgr/timer_manager.h"
@@ -142,17 +143,17 @@ class TrickledCHTTP2 : public EndpointPairFixture {
         client->lists[GRPC_CHTTP2_LIST_STALLED_BY_STREAM].head != nullptr,
         server->lists[GRPC_CHTTP2_LIST_STALLED_BY_TRANSPORT].head != nullptr,
         server->lists[GRPC_CHTTP2_LIST_STALLED_BY_STREAM].head != nullptr,
-        client->flow_control->remote_window(),
-        server->flow_control->remote_window(),
-        client->flow_control->announced_window(),
-        server->flow_control->announced_window(),
-        client_stream ? client_stream->flow_control->remote_window_delta() : -1,
-        server_stream ? server_stream->flow_control->remote_window_delta() : -1,
-        client_stream ? client_stream->flow_control->local_window_delta() : -1,
-        server_stream ? server_stream->flow_control->local_window_delta() : -1,
-        client_stream ? client_stream->flow_control->announced_window_delta()
+        client->flow_control->remote_window_,
+        server->flow_control->remote_window_,
+        client->flow_control->announced_window_,
+        server->flow_control->announced_window_,
+        client_stream ? client_stream->flow_control->remote_window_delta_ : -1,
+        server_stream ? server_stream->flow_control->remote_window_delta_ : -1,
+        client_stream ? client_stream->flow_control->local_window_delta_ : -1,
+        server_stream ? server_stream->flow_control->local_window_delta_ : -1,
+        client_stream ? client_stream->flow_control->announced_window_delta_
                       : -1,
-        server_stream ? server_stream->flow_control->announced_window_delta()
+        server_stream ? server_stream->flow_control->announced_window_delta_
                       : -1,
         client->settings[GRPC_PEER_SETTINGS]
                         [GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE],


### PR DESCRIPTION
Unorthodox and highly breakable way of doing this, but a response to a TSAN race seen at:

 https://sponge.corp.google.com/target?id=ee26cf80-81c7-408b-a0bc-2cd73867c72e&target=github/grpc/c%2B%2B_linux_tsan_native&searchFor=&show=ALL&sortBy=STATUS

The alternative is to add synchronization...


Fixes #13191 