### PR TITLE
Update ruby googleauth dependency

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.platform      = Gem::Platform::RUBY
 
   s.add_dependency 'google-protobuf', '~> 3.1'
-  s.add_dependency 'googleauth',      '~> 0.5.1'
+  s.add_dependency 'googleauth',      '>= 0.5.1', '< 0.7'
   s.add_dependency 'googleapis-common-protos-types', '~> 1.0.0'
 
   s.add_development_dependency 'bundler',            '~> 1.9'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -30,7 +30,7 @@
     s.platform      = Gem::Platform::RUBY
 
     s.add_dependency 'google-protobuf', '~> 3.1'
-    s.add_dependency 'googleauth',      '~> 0.5.1'
+    s.add_dependency 'googleauth',      '>= 0.5.1', '< 0.7'
     s.add_dependency 'googleapis-common-protos-types', '~> 1.0.0'
 
     s.add_development_dependency 'bundler',            '~> 1.9'


### PR DESCRIPTION
To enable cloud ruby APIs to release new features that rely on the latest `googleauth`. cc @geigerj 