### PR TITLE
Fix objc build problem with C++ core

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -1008,7 +1008,7 @@ Pod::Spec.new do |s|
                       'test/core/end2end/tests/*.{c,h}',
                       'test/core/end2end/fixtures/*.h',
                       'test/core/end2end/data/*.{c,h}',
-                      'test/core/util/debugger_macros.{c,h}',
+                      'test/core/util/debugger_macros.{cc,h}',
                       'test/core/util/test_config.{c,h}',
                       'test/core/util/port.h',
                       'test/core/util/port.c',

--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -89,6 +89,7 @@ Pod::Spec.new do |s|
 
   s.default_subspecs = 'Interface', 'Implementation'
   s.compiler_flags = '-DGRPC_ARES=0'
+  s.libraries = 'c++'
 
   # Like many other C libraries, gRPC-Core has its public headers under `include/<libname>/` and its
   # sources and private headers in other directories outside `include/`. Cocoapods' linter doesn't

--- a/src/core/ext/transport/chttp2/transport/flow_control.cc
+++ b/src/core/ext/transport/chttp2/transport/flow_control.cc
@@ -165,7 +165,7 @@ TransportFlowControl::TransportFlowControl(grpc_exec_ctx* exec_ctx,
 
 uint32_t TransportFlowControl::MaybeSendUpdate(bool writing_anyway) {
   FlowControlTrace trace("t updt sent", this, nullptr);
-  const uint32_t target_announced_window = target_window();
+  const uint32_t target_announced_window = (const uint32_t)target_window();
   if ((writing_anyway || announced_window_ <= target_announced_window / 2) &&
       announced_window_ != target_announced_window) {
     const uint32_t announce = (uint32_t)GPR_CLAMP(

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -116,6 +116,7 @@
 
     s.default_subspecs = 'Interface', 'Implementation'
     s.compiler_flags = '-DGRPC_ARES=0'
+    s.libraries = 'c++'
 
     # Like many other C libraries, gRPC-Core has its public headers under `include/<libname>/` and its
     # sources and private headers in other directories outside `include/`. Cocoapods' linter doesn't

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -175,7 +175,7 @@
                         'test/core/end2end/tests/*.{c,h}',
                         'test/core/end2end/fixtures/*.h',
                         'test/core/end2end/data/*.{c,h}',
-                        'test/core/util/debugger_macros.{c,h}',
+                        'test/core/util/debugger_macros.{cc,h}',
                         'test/core/util/test_config.{c,h}',
                         'test/core/util/port.h',
                         'test/core/util/port.c',


### PR DESCRIPTION
Xcode build seems broken after switching to C++. This is the fix.

Fixes #13134 