### PR TITLE
compiler: cpp: Fix unused parameter warning

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -1376,6 +1376,7 @@ void PrintSourceService(grpc_generator::Printer *printer,
                  "std::unique_ptr< $ns$$Service$::Stub> $ns$$Service$::NewStub("
                  "const std::shared_ptr< ::grpc::ChannelInterface>& channel, "
                  "const ::grpc::StubOptions& options) {\n"
+                 "  (void)options;\n"
                  "  std::unique_ptr< $ns$$Service$::Stub> stub(new "
                  "$ns$$Service$::Stub(channel));\n"
                  "  return stub;\n"


### PR DESCRIPTION
Fix "unused parameter 'options'" in the generated code for
$ns$$Service$::NewStub by casting options to void.

Fixes #6518.