### PR TITLE
Disable bm_trickle from running under TSAN

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3784,11 +3784,11 @@ targets:
   - --benchmark_min_time=0
   benchmark: true
   defaults: benchmark
+  exclude_configs:
+  - tsan
   excluded_poll_engines:
   - poll
   - poll-cv
-  exclude_configs:
-  - tsan
   platforms:
   - mac
   - linux

--- a/build.yaml
+++ b/build.yaml
@@ -3787,6 +3787,8 @@ targets:
   excluded_poll_engines:
   - poll
   - poll-cv
+  exclude_configs:
+  - tsan
   platforms:
   - mac
   - linux

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3320,7 +3320,9 @@
       "posix"
     ], 
     "cpu_cost": 1.0, 
-    "exclude_configs": [], 
+    "exclude_configs": [
+      "tsan"
+    ], 
     "exclude_iomgrs": [], 
     "excluded_poll_engines": [
       "poll", 


### PR DESCRIPTION
Resolves #13035

Feel free to nix this, but I think it would be safe to disable under TSAN. Some scenarios take 30 min to run. My intuition is that running under all the sans sans tsan plus running bm_trickle will give a good enough testing signal.