### PR TITLE
Throttle Kokoro Linux output, so workers don't run OoM

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_linux_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_linux_rc
@@ -29,6 +29,9 @@ sudo mkdir -p /tmp/xdg-cache-home
 PYTHONWARNINGS=ignore XDG_CACHE_HOME=/tmp/xdg-cache-home sudo -E pip install setuptools wheel
 PYTHONWARNINGS=ignore XDG_CACHE_HOME=/tmp/xdg-cache-home sudo -E pip install coverage==4.4 pylint==1.6.5
 
+# Need pv to throttle stdout, so machines don't run out of memory
+sudo apt-get install -y pv
+
 # Download Docker images from DockerHub
 export DOCKERHUB_ORGANIZATION=grpctesting
 

--- a/tools/internal_ci/linux/grpc_run_tests_matrix.sh
+++ b/tools/internal_ci/linux/grpc_run_tests_matrix.sh
@@ -27,7 +27,8 @@ if [ -n "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ] && [ -n "$RUN_TESTS_FLAGS" ]; the
   export RUN_TESTS_FLAGS="$RUN_TESTS_FLAGS --filter_pr_tests --base_branch origin/$ghprbTargetBranch"
 fi
 
-tools/run_tests/run_tests_matrix.py $RUN_TESTS_FLAGS || FAILED="true"
+# Throttle stdout, so workers don't run out of memory
+tools/run_tests/run_tests_matrix.py $RUN_TESTS_FLAGS | pv -q -L 128000 || FAILED="true"
 
 # Reveal leftover processes that might be left behind by the build
 ps aux | grep -i kbuilder


### PR DESCRIPTION
This should roughly halve stdout's speed. It might need to be throttled more, but the OoM issue isn't easily reproducible, so let's start with this. 
```
$ time cat Makefile

real    0m3.377s
user    0m0.000s
sys     0m0.024s

$ time cat Makefile | pv -q -L 128000

real    0m7.036s
user    0m0.000s
sys     0m0.036s
```