### PR TITLE
Add health statuses for multiple services at once

### DIFF
--- a/src/ruby/pb/grpc/health/checker.rb
+++ b/src/ruby/pb/grpc/health/checker.rb
@@ -48,6 +48,20 @@ module Grpc
         @status_mutex.synchronize { @statuses["#{service}"] = status }
       end
 
+      # Adds given health status for all given services
+      def set_status_for_services(status, *services)
+        @status_mutex.synchronize do
+          services.each { |service| @statuses["#{service}"] = status }
+        end
+      end
+
+      # Adds health status for each service given within hash
+      def add_statuses(service_statuses = {})
+        @status_mutex.synchronize do
+          service_statuses.each_pair { |service, status| @statuses["#{service}"] = status }
+        end
+      end
+
       # Clears the status for the given service.
       def clear_status(service)
         @status_mutex.synchronize { @statuses.delete("#{service}") }

--- a/src/ruby/spec/pb/health/checker_spec.rb
+++ b/src/ruby/spec/pb/health/checker_spec.rb
@@ -99,6 +99,35 @@ describe Grpc::Health::Checker do
     end
   end
 
+  context 'method `add_statuses`' do
+    it 'should add status to each service' do
+      checker = Grpc::Health::Checker.new
+      checker.add_statuses(
+        'service1' => ServingStatus::SERVING,
+        'service2' => ServingStatus::NOT_SERVING
+      )
+      service1_health = checker.check(HCReq.new(service: 'service1'), nil)
+      service2_health = checker.check(HCReq.new(service: 'service2'), nil)
+      expect(service1_health).to eq(HCResp.new(status: ServingStatus::SERVING))
+      expect(service2_health).to eq(HCResp.new(status: ServingStatus::NOT_SERVING))
+    end
+  end
+
+  context 'method `set_status_for_services`' do
+    it 'should add given status to all given services' do
+      checker = Grpc::Health::Checker.new
+      checker.set_status_for_services(
+        ServingStatus::SERVING,
+        'service1',
+        'service2'
+      )
+      service1_health = checker.check(HCReq.new(service: 'service1'), nil)
+      service2_health = checker.check(HCReq.new(service: 'service2'), nil)
+      expect(service1_health).to eq(HCResp.new(status: ServingStatus::SERVING))
+      expect(service2_health).to eq(HCResp.new(status: ServingStatus::SERVING))
+    end
+  end
+
   context 'method `check`' do
     success_tests.each do |t|
       it "should fail with NOT_FOUND when #{t[:desc]}" do


### PR DESCRIPTION
I find it a bit more Ruby stylish to pass all statuses for handled services at once.

So I prefer doing:

```
health_checker.add_statuses(
  "service1" => ServingStatus::SERVING,
  "service2" => ServingStatus::SERVING,
  "service2" => ServingStatus::SERVING
)
```

Instead of:

```
health_checker.add_statuse(
  "service1",
  ServingStatus::SERVING
)

health_checker.add_statuse(
  "service2",
  ServingStatus::SERVING
)

health_checker.add_statuse(
  "service3",
  ServingStatus::SERVING
)
```

Also if I want to set array of services with SERVING status, I would like to be able to do:
```
health_checker.set_status_for_services(
  ServingStatus::SERVING,
  "service1",
  "service2",
  "service3"
)
```
These are the helpers that means a lot to Ruby people. If you agree with these changes please provide me with feedback to continue work on this PR.

Thanks