### PR TITLE
Limit concurrent jobs for build_only on linux

### DIFF
--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -27,5 +27,5 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 tools/buildgen/generate_projects.sh
 git -c user.name='foo' -c user.email='foo@google.com' commit -a -m 'Update submodule'
 
-tools/run_tests/run_tests_matrix.py -f linux --internal_ci --build_only
+tools/run_tests/run_tests_matrix.py -f linux --inner_jobs 4 -j 4 --internal_ci --build_only
 

--- a/tools/internal_ci/linux/grpc_portability_build_only.cfg
+++ b/tools/internal_ci/linux/grpc_portability_build_only.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f portability linux --internal_ci --build_only"
+  value: "-f portability linux --inner_jobs 4 -j 4 --internal_ci --build_only"
 }


### PR DESCRIPTION
grpc_build_protobuf_at_head and grpc_portability_build_only seem to be suffering from b/68023586, so trying if making fewer builds in parallel would help (currently, -j defaults to 8 for 16core workers)