### PR TITLE
Fix Timing Test Bug

### DIFF
--- a/test/core/transport/status_conversion_test.c
+++ b/test/core/transport/status_conversion_test.c
@@ -16,6 +16,8 @@
  *
  */
 
+#include <unistd.h>
+
 #include "src/core/lib/transport/status_conversion.h"
 #include <grpc/support/log.h>
 #include "test/core/util/test_config.h"
@@ -38,6 +40,7 @@ int main(int argc, char **argv) {
   int i;
 
   grpc_test_init(argc, argv);
+  grpc_init();
 
   GRPC_STATUS_TO_HTTP2_ERROR(GRPC_STATUS_OK, GRPC_HTTP2_NO_ERROR);
   GRPC_STATUS_TO_HTTP2_ERROR(GRPC_STATUS_CANCELLED, GRPC_HTTP2_CANCEL);
@@ -129,6 +132,7 @@ int main(int argc, char **argv) {
                              GRPC_STATUS_INTERNAL);
   HTTP2_ERROR_TO_GRPC_STATUS(GRPC_HTTP2_REFUSED_STREAM, after_deadline,
                              GRPC_STATUS_UNAVAILABLE);
+  sleep(1);
   HTTP2_ERROR_TO_GRPC_STATUS(GRPC_HTTP2_CANCEL, after_deadline,
                              GRPC_STATUS_DEADLINE_EXCEEDED);
   HTTP2_ERROR_TO_GRPC_STATUS(GRPC_HTTP2_COMPRESSION_ERROR, after_deadline,
@@ -157,6 +161,8 @@ int main(int argc, char **argv) {
   for (i = 0; i <= 999; i++) {
     grpc_http2_status_to_grpc_status(i);
   }
+
+  grpc_shutdown();
 
   return 0;
 }

--- a/test/core/transport/status_conversion_test.c
+++ b/test/core/transport/status_conversion_test.c
@@ -16,10 +16,8 @@
  *
  */
 
-#include <unistd.h>
-
-#include <grpc/support/log.h>
 #include "src/core/lib/transport/status_conversion.h"
+#include <grpc/support/log.h>
 #include "test/core/util/test_config.h"
 
 #define GRPC_STATUS_TO_HTTP2_ERROR(a, b) \
@@ -132,10 +130,11 @@ int main(int argc, char **argv) {
                              GRPC_STATUS_INTERNAL);
   HTTP2_ERROR_TO_GRPC_STATUS(GRPC_HTTP2_REFUSED_STREAM, after_deadline,
                              GRPC_STATUS_UNAVAILABLE);
-  // We only have millisecond granularity in our timing code. This sleeps for 2
+  // We only have millisecond granularity in our timing code. This sleeps for 5
   // millis to ensure that the status conversion code will pick up the fact
   // that the deadline has expired.
-  usleep(2000);
+  gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
+                               gpr_time_from_millis(5, GPR_TIMESPAN)));
   HTTP2_ERROR_TO_GRPC_STATUS(GRPC_HTTP2_CANCEL, after_deadline,
                              GRPC_STATUS_DEADLINE_EXCEEDED);
   HTTP2_ERROR_TO_GRPC_STATUS(GRPC_HTTP2_COMPRESSION_ERROR, after_deadline,

--- a/test/core/transport/status_conversion_test.c
+++ b/test/core/transport/status_conversion_test.c
@@ -18,8 +18,8 @@
 
 #include <unistd.h>
 
-#include "src/core/lib/transport/status_conversion.h"
 #include <grpc/support/log.h>
+#include "src/core/lib/transport/status_conversion.h"
 #include "test/core/util/test_config.h"
 
 #define GRPC_STATUS_TO_HTTP2_ERROR(a, b) \
@@ -132,7 +132,10 @@ int main(int argc, char **argv) {
                              GRPC_STATUS_INTERNAL);
   HTTP2_ERROR_TO_GRPC_STATUS(GRPC_HTTP2_REFUSED_STREAM, after_deadline,
                              GRPC_STATUS_UNAVAILABLE);
-  sleep(1);
+  // We only have millisecond granularity in our timing code. This sleeps for 2
+  // millis to ensure that the status conversion code will pick up the fact
+  // that the deadline has expired.
+  usleep(2000);
   HTTP2_ERROR_TO_GRPC_STATUS(GRPC_HTTP2_CANCEL, after_deadline,
                              GRPC_STATUS_DEADLINE_EXCEEDED);
   HTTP2_ERROR_TO_GRPC_STATUS(GRPC_HTTP2_COMPRESSION_ERROR, after_deadline,


### PR DESCRIPTION
Fixes #13131

The recent timing change cached times, and rounded in certain scenarios. Adding a 1 second sleep ensures that the exec_ctx's now will return non-zero millis.

Also this test wasn't calling {init,shutdown}_grpc so the exec ctx timing system wasn't initialized.