### PR TITLE
Disable epollex for grpclb_end2end_test while failures are investigated

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4250,6 +4250,7 @@ targets:
   excluded_poll_engines:
   - poll
   - poll-cv
+  - epollex
 - name: grpclb_test
   gtest: false
   build: test

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3914,7 +3914,8 @@
     "exclude_iomgrs": [], 
     "excluded_poll_engines": [
       "poll", 
-      "poll-cv"
+      "poll-cv", 
+      "epollex"
     ], 
     "flaky": false, 
     "gtest": true, 


### PR DESCRIPTION
Followup/missing parts of #13127.

See also https://github.com/grpc/grpc/issues/13128 for tracking the re-enabling. 