### PR TITLE
Fix Windows's memory leak in v1.7.x

### DIFF
--- a/src/core/lib/support/env_windows.c
+++ b/src/core/lib/support/env_windows.c
@@ -43,7 +43,10 @@ char *gpr_getenv(const char *name) {
   DWORD ret;
 
   ret = GetEnvironmentVariable(tname, NULL, 0);
-  if (ret == 0) return NULL;
+  if (ret == 0) {
+    gpr_free(tname);
+    return NULL;
+  }
   size = ret * (DWORD)sizeof(TCHAR);
   tresult = gpr_malloc(size);
   ret = GetEnvironmentVariable(tname, tresult, size);


### PR DESCRIPTION
Backport MR #12930 to 1.7.

(cherry picked from commit 3290e49a1d5b896b7ce65d658ffef00bf65d35dd)
(cherry picked from commit c02dbe57c666e26f40e517b6f940f6cbd4bb43fc)

Close #10453  
Close #10546