### PR TITLE
Use reasonable multiplier values for C/C++ tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4838,7 +4838,6 @@ targets:
   - grpc_unsecure
   - gpr_test_util
   - gpr
-  timeout_seconds: 1200
 - name: transport_pid_controller_test
   build: test
   language: c++

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -4522,7 +4522,6 @@
       "posix", 
       "windows"
     ], 
-    "timeout_seconds": 1200, 
     "uses_polling": true
   }, 
   {


### PR DESCRIPTION
Progress towards https://github.com/grpc/grpc/issues/12925 and #11690.

With this PR, the default timeout for sanitizer tests is 15min (3*5min the default). Based on historical data, that is enough for all currently existing tests  (and there is also some extra padding for safety).
Also, because of the default test timeout of 5min, the poll-cv scaling is currently not useful, it only bloats the timeouts.

More data from the analysis:
- The longest running testcases with default timeout is `bins/tsan/h2_sockpair_1byte`, taking 750s with very low variance, so 900s should be enough here. Other tests take much shorter (>450s).
- From tests that override the default timeout, there are a few outliers that still take too long
(e.g. stats_test in #13155) but the limits set in this PR are still sufficient for them to finish.
In followup work, these long running tests need to be looked at to make sure they are not taking longer than necessary. Eventually all tests should have a resonable timeout so we can guarantee the PR test job max time is predictable.


