### PR TITLE
Fix header-with-priority for canceled stream bug

### DIFF
--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -590,7 +590,11 @@ static grpc_error* init_header_frame_parser(grpc_exec_ctx* exec_ctx,
         GRPC_CHTTP2_IF_TRACING(gpr_log(
             GPR_ERROR, "ignoring new grpc_chttp2_stream creation on client"));
       }
-      return init_skip_frame_parser(exec_ctx, t, 1);
+      grpc_error* err = init_skip_frame_parser(exec_ctx, t, 1);
+      if (t->incoming_frame_flags & GRPC_CHTTP2_FLAG_HAS_PRIORITY) {
+        grpc_chttp2_hpack_parser_set_has_priority(&t->hpack_parser);
+      }
+      return err;
     } else if (t->last_new_stream_id >= t->incoming_stream_id) {
       GRPC_CHTTP2_IF_TRACING(gpr_log(
           GPR_ERROR,


### PR DESCRIPTION
With a Java server, Python client code like this:

```Python
import grpc
import foo_pb2 as foo
import foo_pb2_grpc as foo_grpc

channel = grpc.insecure_channel('localhost:1234')
foo_stub = foo_grpc.FooServiceStub(channel)

for _ in range(100):
    stream = foo_stub.GetFoo(iter([foo.GetFooRequest(name="x")]))
    stream.next()
    stream.cancel()
```

Fails sporadically with this error:

```
grpc._channel._Rendezvous: <_Rendezvous of RPC that terminated with (StatusCode.UNAVAILABLE, Failed parsing HTTP/2)>
```
Looking at the trace output, the error comes from [here](https://github.com/grpc/grpc/blob/8afaf61fea1f3275972e143488e70fd6292cc6df/src/core/ext/transport/chttp2/transport/hpack_parser.cc#L1720).
    

Turns out the Java server (mine at least) sets `priority` on header frames. While the normal header parsing code path handles `priority`, the code path for handling headers for canceled streams does not. So the sequence of events below leaves a header frame unparsed and the hpack parser in a broken state.

1. Client opens bidirectional stream S1.
2. Client closes input to stream S1.
3. Client sends frame with `END_STREAM=1` (F1).
4. Java server receives F1, executes `onCompleted` and sends a header frame with `END_STREAM=1`  and the `PRIORITY` flag set (F2).
5. Client executes `S1.cancel()`
6. Client receives F2 and parses it with the "skip frame parser" code path which does not support `PRIORITY`.
7. Not configured for priority parsing, the hpack parser fails to parse F2 properly and is left in `state != parse_begin`.

When the next header frame arrives, `p->state != parse_begin` and we get the error. If you naively work around the `hpack_parser->state` problem you still periodically get `Invalid HPACK index received` because the header frame with priority set isn't successfully parsed and HPACK index entries are sometimes missed.

This PR fixes this bug by enabling support for the `priority` flag in the header-for-canceled-stream code path.

```
$ tools/run_tests/run_tests.py --disable_auto_set_flakes --use_docker -l python
...
SUCCESS: All tests passed
```

It'd be nice to add a test for this bug. I'd be interested to hear if there's a recommended approach there. I don't see an easy way to setup a test with`PRIORITY` set but I'm not overly familiar with how the tests work.