### PR TITLE
Remove required keyword args to fix forward breakage of ruby 2.0

### DIFF
--- a/src/ruby/lib/grpc/generic/interceptors.rb
+++ b/src/ruby/lib/grpc/generic/interceptors.rb
@@ -41,7 +41,7 @@ module GRPC
     # @param [Method] method
     # @param [Hash] metadata
     #
-    def request_response(request:, call:, method:, metadata:)
+    def request_response(request: nil, call: nil, method: nil, metadata: nil)
       GRPC.logger.debug "Intercepting request response method #{method}" \
         " for request #{request} with call #{call} and metadata: #{metadata}"
       yield
@@ -55,7 +55,7 @@ module GRPC
     # @param [Method] method
     # @param [Hash] metadata
     #
-    def client_streamer(requests:, call:, method:, metadata:)
+    def client_streamer(requests: nil, call: nil, method: nil, metadata: nil)
       GRPC.logger.debug "Intercepting client streamer method #{method}" \
        " for requests #{requests} with call #{call} and metadata: #{metadata}"
       yield
@@ -69,7 +69,7 @@ module GRPC
     # @param [Method] method
     # @param [Hash] metadata
     #
-    def server_streamer(request:, call:, method:, metadata:)
+    def server_streamer(request: nil, call: nil, method: nil, metadata: nil)
       GRPC.logger.debug "Intercepting server streamer method #{method}" \
         " for request #{request} with call #{call} and metadata: #{metadata}"
       yield
@@ -83,7 +83,7 @@ module GRPC
     # @param [Method] method
     # @param [Hash] metadata
     #
-    def bidi_streamer(requests:, call:, method:, metadata:)
+    def bidi_streamer(requests: nil, call: nil, method: nil, metadata: nil)
       GRPC.logger.debug "Intercepting bidi streamer method #{method}" \
         " for requests #{requests} with call #{call} and metadata: #{metadata}"
       yield
@@ -102,7 +102,7 @@ module GRPC
     # @param [GRPC::ActiveCall::SingleReqView] call
     # @param [Method] method
     #
-    def request_response(request:, call:, method:)
+    def request_response(request: nil, call: nil, method: nil)
       GRPC.logger.debug "Intercepting request response method #{method}" \
         " for request #{request} with call #{call}"
       yield
@@ -114,7 +114,7 @@ module GRPC
     # @param [GRPC::ActiveCall::MultiReqView] call
     # @param [Method] method
     #
-    def client_streamer(call:, method:)
+    def client_streamer(call: nil, method: nil)
       GRPC.logger.debug "Intercepting client streamer method #{method}" \
         " with call #{call}"
       yield
@@ -127,7 +127,7 @@ module GRPC
     # @param [GRPC::ActiveCall::SingleReqView] call
     # @param [Method] method
     #
-    def server_streamer(request:, call:, method:)
+    def server_streamer(request: nil, call: nil, method: nil)
       GRPC.logger.debug "Intercepting server streamer method #{method}" \
         " for request #{request} with call #{call}"
       yield
@@ -140,7 +140,7 @@ module GRPC
     # @param [GRPC::ActiveCall::MultiReqView] call
     # @param [Method] method
     #
-    def bidi_streamer(requests:, call:, method:)
+    def bidi_streamer(requests: nil, call: nil, method: nil)
       GRPC.logger.debug "Intercepting bidi streamer method #{method}" \
         " for requests #{requests} with call #{call}"
       yield


### PR DESCRIPTION
As noticed in this travis test: https://travis-ci.org/googleapis/gax-ruby/jobs/295485654

cc @geigerj