### PR TITLE
Make the BG poller poll very frequently in LB tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3877,10 +3877,6 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
-  excluded_poll_engines:
-  - poll
-  - poll-cv
-  - epollex
 - name: codegen_test_full
   gtest: true
   build: test
@@ -4169,9 +4165,6 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
-  excluded_poll_engines:
-  - poll
-  - poll-cv
 - name: grpclb_test
   gtest: false
   build: test
@@ -4186,10 +4179,6 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
-  excluded_poll_engines:
-  - poll
-  - poll-cv
-  - epollex
 - name: h2_ssl_cert_test
   gtest: true
   build: test

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -36,6 +36,7 @@
 extern "C" {
 #include "src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h"
 #include "src/core/ext/filters/client_channel/subchannel_index.h"
+#include "src/core/lib/support/env.h"
 }
 
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
@@ -86,7 +87,11 @@ class MyTestServiceImpl : public TestServiceImpl {
 class ClientLbEnd2endTest : public ::testing::Test {
  protected:
   ClientLbEnd2endTest()
-      : server_host_("localhost"), kRequestMessage_("Live long and prosper.") {}
+      : server_host_("localhost"), kRequestMessage_("Live long and prosper.") {
+    // Make the backup poller poll very frequently in order to pick up
+    // updates from all the subchannels's FDs.
+    gpr_setenv("GRPC_CLIENT_CHANNEL_BACKUP_POLL_INTERVAL_MS", "1");
+  }
 
   void SetUp() override {
     response_generator_ = grpc_fake_resolver_response_generator_create();

--- a/test/cpp/end2end/grpclb_end2end_test.cc
+++ b/test/cpp/end2end/grpclb_end2end_test.cc
@@ -36,6 +36,7 @@
 extern "C" {
 #include "src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h"
 #include "src/core/lib/iomgr/sockaddr.h"
+#include "src/core/lib/support/env.h"
 }
 
 #include "test/core/util/port.h"
@@ -74,9 +75,9 @@ extern "C" {
 
 using std::chrono::system_clock;
 
+using grpc::lb::v1::LoadBalancer;
 using grpc::lb::v1::LoadBalanceRequest;
 using grpc::lb::v1::LoadBalanceResponse;
-using grpc::lb::v1::LoadBalancer;
 
 namespace grpc {
 namespace testing {
@@ -332,7 +333,11 @@ class GrpclbEnd2endTest : public ::testing::Test {
         num_backends_(num_backends),
         num_balancers_(num_balancers),
         client_load_reporting_interval_seconds_(
-            client_load_reporting_interval_seconds) {}
+            client_load_reporting_interval_seconds) {
+    // Make the backup poller poll very frequently in order to pick up
+    // updates from all the subchannels's FDs.
+    gpr_setenv("GRPC_CLIENT_CHANNEL_BACKUP_POLL_INTERVAL_MS", "1");
+  }
 
   void SetUp() override {
     response_generator_ = grpc_fake_resolver_response_generator_create();

--- a/test/cpp/grpclb/grpclb_test.cc
+++ b/test/cpp/grpclb/grpclb_test.cc
@@ -42,6 +42,7 @@ extern "C" {
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/core/lib/iomgr/sockaddr.h"
 #include "src/core/lib/security/credentials/fake/fake_credentials.h"
+#include "src/core/lib/support/env.h"
 #include "src/core/lib/support/string.h"
 #include "src/core/lib/support/tmpfile.h"
 #include "src/core/lib/surface/channel.h"
@@ -790,6 +791,9 @@ TEST(GrpclbTest, InvalidAddressInServerlist) {}
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   grpc_test_init(argc, argv);
+  // Make the backup poller poll very frequently in order to pick up
+  // updates from all the subchannels's FDs.
+  gpr_setenv("GRPC_CLIENT_CHANNEL_BACKUP_POLL_INTERVAL_MS", "1");
   grpc_init();
   const auto result = RUN_ALL_TESTS();
   grpc_shutdown();

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3425,11 +3425,6 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "exclude_iomgrs": [], 
-    "excluded_poll_engines": [
-      "poll", 
-      "poll-cv", 
-      "epollex"
-    ], 
     "flaky": false, 
     "gtest": true, 
     "language": "c++", 
@@ -3792,10 +3787,6 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "exclude_iomgrs": [], 
-    "excluded_poll_engines": [
-      "poll", 
-      "poll-cv"
-    ], 
     "flaky": false, 
     "gtest": true, 
     "language": "c++", 
@@ -3820,11 +3811,6 @@
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
     "exclude_iomgrs": [], 
-    "excluded_poll_engines": [
-      "poll", 
-      "poll-cv", 
-      "epollex"
-    ], 
     "flaky": false, 
     "gtest": false, 
     "language": "c++", 


### PR DESCRIPTION
LB policies hold an arbitrary number of subchannels, with their corresponding FDs. For performance reasons, not all of these FDs can be linked to the call's pollset_set. However, they still need to be polled for the LB policies to be notified of changes in the subchannels's connectivity state. 

This PR leverages the background poller introduced in #12732 to poll the client_channel's interested parties very frequently in order to minimize delays in detecting subchannel activity.  

Fixes #13081 #13080 #13128 #13159
Reverts #13127 (re-enables tests)