### PR TITLE
Fix gRPC connectivity issue using channel ping

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCChannel.h
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.h
@@ -65,4 +65,10 @@ struct grpc_channel_credentials;
                                    serverName:(nonnull NSString *)serverName
                                       timeout:(NSTimeInterval)timeout
                               completionQueue:(nonnull GRPCCompletionQueue *)queue;
+
+/**
+ * Makes a channel ping on the wrapped channel. On success, invoke handler.
+ */
+- (void)pingChannelWithSuccessHandler:(void (^ _Nullable)(void))handler;
+
 @end

--- a/src/objective-c/GRPCClient/private/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.m
@@ -211,4 +211,15 @@ static grpc_channel_args *BuildChannelArgs(NSDictionary *dictionary) {
   return call;
 }
 
+- (void)pingChannelWithSuccessHandler:(void (^ _Nullable)(void))handler {
+  grpc_channel_ping(_unmanagedChannel,
+                    [GRPCCompletionQueue completionQueue].unmanagedQueue,
+                    (__bridge_retained void *)(^(bool success) {
+                      if (success) {
+                        handler();
+                      }
+                    }),
+                    nil);
+}
+
 @end


### PR DESCRIPTION
**THIS IS STILL WIP**

When Wifi network switches in the background, gRPC does not get any notification in sockets, making calls hanging on the stale channel.

This PR resolves the problem by watching all network change events from Apple at Objective C layer. Any network change will trigger the watching callback (including change of cellular connection when connected to WiFi). However, gRPC should not disconnect channel upon all of the events. We need to distinguish between the following events:

* Network stays on the same WiFi connection - should not disconnect
* Network switched to another WiFi connection - should disconnect
* Network switched to another WiFi then switched back to the original WiFi connection - should disconnect
* Network stays on the same cellular connection - should not disconnect
* Network switched to another cellular connection - should disconnect

There is no tool to distinguish among all these events.

Instead, in this PR, when network change happens, we make a gRPC channel ping to the other channel to verify if the connectivity should be purged. A successful ping means the channel should be kept.

This approach still got some flaw. To know if ping succeeded, client must wait for a pong from server. It considers the ping to be failure if it does not receive pong after a timeout. However, it is possible that a call is attempted during the wait period using the old channel. That call is still hang for a long time currently.