### PR TITLE
Fix grpcio_{reflection,health_checking} packaging

### DIFF
--- a/src/python/grpcio_health_checking/MANIFEST.in
+++ b/src/python/grpcio_health_checking/MANIFEST.in
@@ -1,4 +1,3 @@
 include grpc_version.py
-include health_commands.py
-graft grpc_health
+recursive-include grpc_health *.py
 global-exclude *.pyc

--- a/src/python/grpcio_reflection/MANIFEST.in
+++ b/src/python/grpcio_reflection/MANIFEST.in
@@ -1,4 +1,3 @@
 include grpc_version.py
-include reflection_commands.py
-graft grpc_reflection
+recursive-include grpc_reflection *.py
 global-exclude *.pyc

--- a/src/python/grpcio_reflection/setup.py
+++ b/src/python/grpcio_reflection/setup.py
@@ -21,9 +21,25 @@ import setuptools
 # Ensure we're in the proper directory whether or not we're being used by pip.
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
-# Break import-style to ensure we can actually find our commands module.
-import reflection_commands
+# Break import-style to ensure we can actually find our local modules.
 import grpc_version
+
+
+class _NoOpCommand(setuptools.Command):
+    """No-op command."""
+
+    description = ''
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        pass
+
 
 CLASSIFIERS = [
     'Development Status :: 5 - Production/Stable',
@@ -41,17 +57,28 @@ PACKAGE_DIRECTORIES = {
     '': '.',
 }
 
-SETUP_REQUIRES = (
-    'grpcio-tools>={version}'.format(version=grpc_version.VERSION),)
-
 INSTALL_REQUIRES = ('protobuf>=3.3.0',
                     'grpcio>={version}'.format(version=grpc_version.VERSION),)
 
-COMMAND_CLASS = {
-    # Run preprocess from the repository *before* doing any packaging!
-    'preprocess': reflection_commands.CopyProtoModules,
-    'build_package_protos': reflection_commands.BuildPackageProtos,
-}
+try:
+    # ensure we can load the _pb2_grpc module:
+    from grpc_reflection.v1alpha import reflection_pb2_grpc as _pb2_grpc
+    # if we can find the _pb2_grpc module, the package has already been built.
+    SETUP_REQUIRES = ()
+    COMMAND_CLASS = {
+        # wire up commands to no-op not to break the external dependencies
+        'preprocess': _NoOpCommand,
+        'build_package_protos': _NoOpCommand,
+    }
+except ImportError:  # we are in the build environment
+    import reflection_commands as _reflection_commands
+    SETUP_REQUIRES = (
+        'grpcio-tools=={version}'.format(version=grpc_version.VERSION),)
+    COMMAND_CLASS = {
+        # Run preprocess from the repository *before* doing any packaging!
+        'preprocess': _reflection_commands.CopyProtoModules,
+        'build_package_protos': _reflection_commands.BuildPackageProtos,
+    }
 
 setuptools.setup(
     name='grpcio-reflection',


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/12992.

I have tried it out and it seems to work (including looking into the final generated artifacts on our CI infrastructure), but we should make sure to manually test the PyPI packages when we upload the 1.8-rc to ensure nothing break in the process of installation from PyPI to make sure no accidents happen.