### PR TITLE
Add a grpc_exec_ctx_invalidate_now in grpc_pollset_work for windows

### DIFF
--- a/src/core/lib/iomgr/pollset_windows.cc
+++ b/src/core/lib/iomgr/pollset_windows.cc
@@ -161,8 +161,10 @@ grpc_error *grpc_pollset_work(grpc_exec_ctx *exec_ctx, grpc_pollset *pollset,
     while (!worker.kicked) {
       if (gpr_cv_wait(&worker.cv, &grpc_polling_mu,
                       grpc_millis_to_timespec(deadline, GPR_CLOCK_REALTIME))) {
+        grpc_exec_ctx_invalidate_now(exec_ctx);
         break;
       }
+      grpc_exec_ctx_invalidate_now(exec_ctx);
     }
   } else {
     pollset->kicked_without_pollers = 0;

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -972,7 +972,6 @@ static grpc_event cq_next(grpc_completion_queue *cq, gpr_timespec deadline,
       break;
     }
     is_finished_arg.first_loop = false;
-    grpc_exec_ctx_invalidate_now(&exec_ctx);
   }
 
   if (cq_event_queue_num_items(&cqd->queue) > 0 &&

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -972,6 +972,7 @@ static grpc_event cq_next(grpc_completion_queue *cq, gpr_timespec deadline,
       break;
     }
     is_finished_arg.first_loop = false;
+    grpc_exec_ctx_invalidate_now(&exec_ctx);
   }
 
   if (cq_event_queue_num_items(&cqd->queue) > 0 &&


### PR DESCRIPTION
Add a grpc_exec_ctx_invalidate_now at the end of cq_next loop to solve Windows timeout issues. Fixes #13079