### PR TITLE
Removing port 443 for the service name (used as jwt audience) for https

### DIFF
--- a/src/core/lib/security/transport/auth_filters.h
+++ b/src/core/lib/security/transport/auth_filters.h
@@ -19,6 +19,7 @@
 #ifndef GRPC_CORE_LIB_SECURITY_TRANSPORT_AUTH_FILTERS_H
 #define GRPC_CORE_LIB_SECURITY_TRANSPORT_AUTH_FILTERS_H
 
+#include <grpc/grpc_security.h>
 #include "src/core/lib/channel/channel_stack.h"
 
 #ifdef __cplusplus
@@ -27,6 +28,13 @@ extern "C" {
 
 extern const grpc_channel_filter grpc_client_auth_filter;
 extern const grpc_channel_filter grpc_server_auth_filter;
+
+void grpc_auth_metadata_context_build(
+    const char *url_scheme, grpc_slice call_host, grpc_slice call_method,
+    grpc_auth_context *auth_context,
+    grpc_auth_metadata_context *auth_md_context);
+
+void grpc_auth_metadata_context_reset(grpc_auth_metadata_context *context);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This should take care of issues that we've had with google apis acceptance of JWT access tokens.