### PR TITLE
Make gRPC C++ library depend on protobuf_headers,  not protobuf

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1545,7 +1545,7 @@ grpc_cc_library(
 grpc_cc_library(
     name = "grpc++_config_proto",
     external_deps = [
-        "protobuf",
+        "protobuf_headers",
     ],
     language = "c++",
     public_hdrs = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,6 +24,11 @@ bind(
 )
 
 bind(
+    name = "protobuf_headers",
+    actual = "@com_google_protobuf//:protobuf_headers",
+)
+
+bind(
     name = "protocol_compiler",
     actual = "@com_google_protobuf//:protoc",
 )

--- a/test/cpp/codegen/BUILD
+++ b/test/cpp/codegen/BUILD
@@ -51,6 +51,7 @@ grpc_cc_test(
     ],
     external_deps = [
         "gtest",
+        "protobuf",
     ],
 )
 


### PR DESCRIPTION
We're keeping the protobuf external dependence listed in the WORKSPACE, though, so that tests can work without further changes.
