### PR TITLE
Change [GRPCCall load] to [GRPCCall initialize]

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -113,6 +113,8 @@ static NSString * const kBearerPrefix = @"Bearer ";
 @synthesize state = _state;
 
 + (void)initialize {
+  // Guarantees the code in {} block is invoked only once. See ref at:
+  // https://developer.apple.com/documentation/objectivec/nsobject/1418639-initialize?language=objc
   if (self == [GRPCCall self]) {
     grpc_init();
     callFlags = [NSMutableDictionary dictionary];

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -112,10 +112,11 @@ static NSString * const kBearerPrefix = @"Bearer ";
 
 @synthesize state = _state;
 
-// TODO(jcanizales): If grpc_init is idempotent, this should be changed from load to initialize.
-+ (void)load {
-  grpc_init();
-  callFlags = [NSMutableDictionary dictionary];
++ (void)initialize {
+  if (self == [GRPCCall self]) {
+    grpc_init();
+    callFlags = [NSMutableDictionary dictionary];
+  }
 }
 
 + (void)setCallSafety:(GRPCCallSafety)callSafety host:(NSString *)host path:(NSString *)path {


### PR DESCRIPTION
The change allows grpc to initialize only after some call is made, saving some resource.