### PR TITLE
Fix semantics of testWatchConnectivityState

### DIFF
--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -81,8 +81,12 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     {
         $this->channel = new Grpc\Channel('localhost:0',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
-        $time = new Grpc\Timeval(1000);
-        $state = $this->channel->watchConnectivityState(1, $time);
+        // 'true' will attempt connecting the channel.
+        $lastState = $this->channel->getConnectivityState(true);
+
+        $now = Grpc\Timeval::now();
+        $deadline = $now->add(new Grpc\Timeval(5000000));
+        $state = $this->channel->watchConnectivityState($lastState, $deadline);
         $this->assertTrue($state);
         unset($time);
     }


### PR DESCRIPTION
Tentative fix for: https://github.com/grpc/grpc/issues/12886

Copypasting the reasoning from #12886:
@ZhouyihaiDing actually, looking at what testWatchConnectivityState() is doing, it looks like it's not correct (I might be missing something):

it creates a channel (which will start with GRPC_CONNECTIVITY_IDLE
it wait a second for state change from GRPC_CONNECTIVITY_CONNECTING to something else - which should never happen as the channel is lazy and won't start connecting until you start a call on it. Also, why would last_state be "GRPC_CONNECTIVITY_CONNECTING" (we never observed that state before).
So overall, is the test testing something meaningful?