### PR TITLE
Function shouldn't have semicolon afterward

### DIFF
--- a/include/grpc++/impl/codegen/client_unary_call.h
+++ b/include/grpc++/impl/codegen/client_unary_call.h
@@ -41,7 +41,7 @@ Status BlockingUnaryCall(ChannelInterface* channel, const RpcMethod& method,
   return BlockingUnaryCallImpl<InputMessage, OutputMessage>(
              channel, method, context, request, result)
       .status();
-};
+}
 
 template <class InputMessage, class OutputMessage>
 class BlockingUnaryCallImpl {


### PR DESCRIPTION
This short and low-impact pull is being requested solely for the purpose of avoiding a linter warning in internal tooling.