### PR TITLE
Fix php testWatchConnectivityState

### DIFF
--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -81,10 +81,14 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     {
         $this->channel = new Grpc\Channel('localhost:0',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
-        $time = new Grpc\Timeval(1000);
-        $state = $this->channel->watchConnectivityState(1, $time);
+        $now = Grpc\Timeval::now();
+        $deadline = $now->add(new Grpc\Timeval(100*1000));  // 100ms
+        // we act as if 'CONNECTING'(=1) was the last state
+        // we saw, so the default state of 'IDLE' should be delivered instantly
+        $state = $this->channel->watchConnectivityState(1, $deadline);
         $this->assertTrue($state);
-        unset($time);
+        unset($now);
+        unset($deadline);
     }
 
     public function testClose()


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/12886. 

The previous version of code was passing 'GPR_TIMESPAN' value as a deadline to C-core (which is treated as a timeout). Currently, that's probably broken, so changing to passing  now() + timeout.

I tested locally and it seems to be fixing the issue even with timeout of 1000micro, but I wanted to be safe so I changed the timeout to 100ms.

We should probably file an issue for "passing GPR_TIMESPAN as a deadline" to C core not working correctly.