### PR TITLE
Cut down microbenchmark time

### DIFF
--- a/tools/profiling/microbenchmarks/bm_diff/bm_main.py
+++ b/tools/profiling/microbenchmarks/bm_diff/bm_main.py
@@ -78,7 +78,7 @@ def _args():
     '-l',
     '--loops',
     type=int,
-    default=20,
+    default=10,
     help='Number of times to loops the benchmarks. More loops cuts down on noise'
   )
   argp.add_argument(


### PR DESCRIPTION
This should cut runtime down to <60min. If there is a problem with how much noise this introduces, we can roll it back.

Fixes #13184