### PR TITLE
Consolidate C# interop test docker images

### DIFF
--- a/templates/tools/dockerfile/csharp_build_interop.sh.include
+++ b/templates/tools/dockerfile/csharp_build_interop.sh.include
@@ -19,9 +19,9 @@ set -e
 mkdir -p /var/local/git
 git clone /var/local/jenkins/grpc /var/local/git/grpc
 # clone gRPC submodules, use data from locally cloned submodules where possible
-(cd /var/local/jenkins/grpc/ && git submodule foreach 'cd /var/local/git/grpc \
-&& git submodule update --init --reference /var/local/jenkins/grpc/${name} \
-${name}')
+(cd /var/local/jenkins/grpc/ && git submodule foreach 'cd /var/local/git/grpc ${'\\'}
+&& git submodule update --init --reference /var/local/jenkins/grpc/<%text>${name}</%text> ${'\\'}
+<%text>${name}</%text>')
 
 # copy service account keys if available
 cp -r /var/local/jenkins/service_account $HOME || true

--- a/templates/tools/dockerfile/interoptest/grpc_interop_csharp/build_interop.sh.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_csharp/build_interop.sh.template
@@ -1,0 +1,3 @@
+%YAML 1.2
+--- |
+  <%include file="../../csharp_build_interop.sh.include"/>

--- a/templates/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile.template
@@ -1,0 +1,26 @@
+%YAML 1.2
+--- |
+  # Copyright 2015 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  
+  FROM debian:jessie
+  
+  <%include file="../../apt_get_basic.include"/>
+  <%include file="../../python_deps.include"/>
+  <%include file="../../csharp_deps.include"/>
+  <%include file="../../csharp_dotnetcli_deps.include"/>
+  <%include file="../../run_tests_addons.include"/>
+  # Define the default command.
+  CMD ["bash"]
+  

--- a/templates/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/build_interop.sh.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/build_interop.sh.template
@@ -1,0 +1,3 @@
+%YAML 1.2
+--- |
+  <%include file="../../csharp_build_interop.sh.include"/>

--- a/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
   bzip2 \
   ccache \
   curl \
+  dnsutils \
   gcc \
   gcc-multilib \
   git \
@@ -61,7 +62,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==9.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.2.0 six==1.10.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.2.0 six==1.10.0 twisted==17.5.0
 
 #================
 # C# dependencies


### PR DESCRIPTION
Partially addresses https://github.com/grpc/grpc/issues/13280.

Getting rid of csharpcoreclr docker image would be a bit tricky, as currently in `run_interop_tests.py` there is a direct mapping between "language name" and docker suffix name.  This PR at least comes up with the right mako templates to keep _csharp and _csharpcoreclr setup always in sync (csharpcoreclr wasn't really in sync).