### PR TITLE
Revert "Class-ify lockfree event"

### DIFF
--- a/src/core/lib/iomgr/ev_epoll1_linux.cc
+++ b/src/core/lib/iomgr/ev_epoll1_linux.cc
@@ -46,7 +46,6 @@
 #include "src/core/lib/iomgr/lockfree_event.h"
 #include "src/core/lib/iomgr/wakeup_fd_posix.h"
 #include "src/core/lib/profiling/timers.h"
-#include "src/core/lib/support/manual_constructor.h"
 #include "src/core/lib/support/string.h"
 
 static grpc_wakeup_fd global_wakeup_fd;
@@ -112,8 +111,8 @@ static void epoll_set_shutdown() {
 struct grpc_fd {
   int fd;
 
-  grpc_core::ManualConstructor<grpc_core::LockfreeEvent> read_closure;
-  grpc_core::ManualConstructor<grpc_core::LockfreeEvent> write_closure;
+  gpr_atm read_closure;
+  gpr_atm write_closure;
 
   struct grpc_fd* freelist_next;
 
@@ -265,8 +264,8 @@ static grpc_fd* fd_create(int fd, const char* name) {
   }
 
   new_fd->fd = fd;
-  new_fd->read_closure.Init();
-  new_fd->write_closure.Init();
+  grpc_lfev_init(&new_fd->read_closure);
+  grpc_lfev_init(&new_fd->write_closure);
   gpr_atm_no_barrier_store(&new_fd->read_notifier_pollset, (gpr_atm)NULL);
 
   new_fd->freelist_next = NULL;
@@ -298,11 +297,12 @@ static int fd_wrapped_fd(grpc_fd* fd) { return fd->fd; }
  * shutdown() syscall on that fd) */
 static void fd_shutdown_internal(grpc_exec_ctx* exec_ctx, grpc_fd* fd,
                                  grpc_error* why, bool releasing_fd) {
-  if (fd->read_closure->SetShutdown(exec_ctx, GRPC_ERROR_REF(why))) {
+  if (grpc_lfev_set_shutdown(exec_ctx, &fd->read_closure,
+                             GRPC_ERROR_REF(why))) {
     if (!releasing_fd) {
       shutdown(fd->fd, SHUT_RDWR);
     }
-    fd->write_closure->SetShutdown(exec_ctx, GRPC_ERROR_REF(why));
+    grpc_lfev_set_shutdown(exec_ctx, &fd->write_closure, GRPC_ERROR_REF(why));
   }
   GRPC_ERROR_UNREF(why);
 }
@@ -318,7 +318,7 @@ static void fd_orphan(grpc_exec_ctx* exec_ctx, grpc_fd* fd,
   grpc_error* error = GRPC_ERROR_NONE;
   bool is_release_fd = (release_fd != NULL);
 
-  if (!fd->read_closure->IsShutdown()) {
+  if (!grpc_lfev_is_shutdown(&fd->read_closure)) {
     fd_shutdown_internal(exec_ctx, fd,
                          GRPC_ERROR_CREATE_FROM_COPIED_STRING(reason),
                          is_release_fd);
@@ -335,8 +335,8 @@ static void fd_orphan(grpc_exec_ctx* exec_ctx, grpc_fd* fd,
   GRPC_CLOSURE_SCHED(exec_ctx, on_done, GRPC_ERROR_REF(error));
 
   grpc_iomgr_unregister_object(&fd->iomgr_object);
-  fd->read_closure.Destroy();
-  fd->write_closure.Destroy();
+  grpc_lfev_destroy(&fd->read_closure);
+  grpc_lfev_destroy(&fd->write_closure);
 
   gpr_mu_lock(&fd_freelist_mu);
   fd->freelist_next = fd_freelist;
@@ -351,28 +351,28 @@ static grpc_pollset* fd_get_read_notifier_pollset(grpc_exec_ctx* exec_ctx,
 }
 
 static bool fd_is_shutdown(grpc_fd* fd) {
-  return fd->read_closure->IsShutdown();
+  return grpc_lfev_is_shutdown(&fd->read_closure);
 }
 
 static void fd_notify_on_read(grpc_exec_ctx* exec_ctx, grpc_fd* fd,
                               grpc_closure* closure) {
-  fd->read_closure->NotifyOn(exec_ctx, closure);
+  grpc_lfev_notify_on(exec_ctx, &fd->read_closure, closure, "read");
 }
 
 static void fd_notify_on_write(grpc_exec_ctx* exec_ctx, grpc_fd* fd,
                                grpc_closure* closure) {
-  fd->write_closure->NotifyOn(exec_ctx, closure);
+  grpc_lfev_notify_on(exec_ctx, &fd->write_closure, closure, "write");
 }
 
 static void fd_become_readable(grpc_exec_ctx* exec_ctx, grpc_fd* fd,
                                grpc_pollset* notifier) {
-  fd->read_closure->SetReady(exec_ctx);
+  grpc_lfev_set_ready(exec_ctx, &fd->read_closure, "read");
   /* Use release store to match with acquire load in fd_get_read_notifier */
   gpr_atm_rel_store(&fd->read_notifier_pollset, (gpr_atm)notifier);
 }
 
 static void fd_become_writable(grpc_exec_ctx* exec_ctx, grpc_fd* fd) {
-  fd->write_closure->SetReady(exec_ctx);
+  grpc_lfev_set_ready(exec_ctx, &fd->write_closure, "write");
 }
 
 /*******************************************************************************

--- a/src/core/lib/iomgr/ev_epollsig_linux.cc
+++ b/src/core/lib/iomgr/ev_epollsig_linux.cc
@@ -50,7 +50,6 @@
 #include "src/core/lib/iomgr/timer.h"
 #include "src/core/lib/iomgr/wakeup_fd_posix.h"
 #include "src/core/lib/profiling/timers.h"
-#include "src/core/lib/support/manual_constructor.h"
 
 #define GRPC_POLLSET_KICK_BROADCAST ((grpc_pollset_worker*)1)
 
@@ -128,8 +127,8 @@ struct grpc_fd {
      valid */
   bool orphaned;
 
-  grpc_core::ManualConstructor<grpc_core::LockfreeEvent> read_closure;
-  grpc_core::ManualConstructor<grpc_core::LockfreeEvent> write_closure;
+  gpr_atm read_closure;
+  gpr_atm write_closure;
 
   struct grpc_fd* freelist_next;
   grpc_closure* on_done_closure;
@@ -767,8 +766,8 @@ static void unref_by(grpc_fd* fd, int n) {
     fd_freelist = fd;
     grpc_iomgr_unregister_object(&fd->iomgr_object);
 
-    fd->read_closure.Destroy();
-    fd->write_closure.Destroy();
+    grpc_lfev_destroy(&fd->read_closure);
+    grpc_lfev_destroy(&fd->write_closure);
 
     gpr_mu_unlock(&fd_freelist_mu);
   } else {
@@ -833,8 +832,8 @@ static grpc_fd* fd_create(int fd, const char* name) {
   gpr_atm_rel_store(&new_fd->refst, (gpr_atm)1);
   new_fd->fd = fd;
   new_fd->orphaned = false;
-  new_fd->read_closure.Init();
-  new_fd->write_closure.Init();
+  grpc_lfev_init(&new_fd->read_closure);
+  grpc_lfev_init(&new_fd->write_closure);
   gpr_atm_no_barrier_store(&new_fd->read_notifier_pollset, (gpr_atm)NULL);
 
   new_fd->freelist_next = NULL;
@@ -925,26 +924,27 @@ static grpc_pollset* fd_get_read_notifier_pollset(grpc_exec_ctx* exec_ctx,
 }
 
 static bool fd_is_shutdown(grpc_fd* fd) {
-  return fd->read_closure->IsShutdown();
+  return grpc_lfev_is_shutdown(&fd->read_closure);
 }
 
 /* Might be called multiple times */
 static void fd_shutdown(grpc_exec_ctx* exec_ctx, grpc_fd* fd, grpc_error* why) {
-  if (fd->read_closure->SetShutdown(exec_ctx, GRPC_ERROR_REF(why))) {
+  if (grpc_lfev_set_shutdown(exec_ctx, &fd->read_closure,
+                             GRPC_ERROR_REF(why))) {
     shutdown(fd->fd, SHUT_RDWR);
-    fd->write_closure->SetShutdown(exec_ctx, GRPC_ERROR_REF(why));
+    grpc_lfev_set_shutdown(exec_ctx, &fd->write_closure, GRPC_ERROR_REF(why));
   }
   GRPC_ERROR_UNREF(why);
 }
 
 static void fd_notify_on_read(grpc_exec_ctx* exec_ctx, grpc_fd* fd,
                               grpc_closure* closure) {
-  fd->read_closure->NotifyOn(exec_ctx, closure);
+  grpc_lfev_notify_on(exec_ctx, &fd->read_closure, closure, "read");
 }
 
 static void fd_notify_on_write(grpc_exec_ctx* exec_ctx, grpc_fd* fd,
                                grpc_closure* closure) {
-  fd->write_closure->NotifyOn(exec_ctx, closure);
+  grpc_lfev_notify_on(exec_ctx, &fd->write_closure, closure, "write");
 }
 
 /*******************************************************************************
@@ -1108,7 +1108,7 @@ static int poll_deadline_to_millis_timeout(grpc_exec_ctx* exec_ctx,
 
 static void fd_become_readable(grpc_exec_ctx* exec_ctx, grpc_fd* fd,
                                grpc_pollset* notifier) {
-  fd->read_closure->SetReady(exec_ctx);
+  grpc_lfev_set_ready(exec_ctx, &fd->read_closure, "read");
 
   /* Note, it is possible that fd_become_readable might be called twice with
      different 'notifier's when an fd becomes readable and it is in two epoll
@@ -1120,7 +1120,7 @@ static void fd_become_readable(grpc_exec_ctx* exec_ctx, grpc_fd* fd,
 }
 
 static void fd_become_writable(grpc_exec_ctx* exec_ctx, grpc_fd* fd) {
-  fd->write_closure->SetReady(exec_ctx);
+  grpc_lfev_set_ready(exec_ctx, &fd->write_closure, "write");
 }
 
 static void pollset_release_polling_island(grpc_exec_ctx* exec_ctx,

--- a/src/core/lib/iomgr/lockfree_event.cc
+++ b/src/core/lib/iomgr/lockfree_event.cc
@@ -26,79 +26,92 @@ extern grpc_tracer_flag grpc_polling_trace;
 
 /* 'state' holds the to call when the fd is readable or writable respectively.
    It can contain one of the following values:
-     kClosureReady     : The fd has an I/O event of interest but there is no
+     CLOSURE_READY     : The fd has an I/O event of interest but there is no
                          closure yet to execute
 
-     kClosureNotReady : The fd has no I/O event of interest
+     CLOSURE_NOT_READY : The fd has no I/O event of interest
 
      closure ptr       : The closure to be executed when the fd has an I/O
                          event of interest
 
-     shutdown_error | kShutdownBit :
-                        'shutdown_error' field ORed with kShutdownBit.
+     shutdown_error | FD_SHUTDOWN_BIT :
+                        'shutdown_error' field ORed with FD_SHUTDOWN_BIT.
                          This indicates that the fd is shutdown. Since all
                          memory allocations are word-aligned, the lower two
                          bits of the shutdown_error pointer are always 0. So
-                         it is safe to OR these with kShutdownBit
+                         it is safe to OR these with FD_SHUTDOWN_BIT
 
    Valid state transitions:
 
-     <closure ptr> <-----3------ kClosureNotReady -----1------->  kClosureReady
+     <closure ptr> <-----3------ CLOSURE_NOT_READY ----1---->  CLOSURE_READY
        |  |                         ^   |    ^                         |  |
        |  |                         |   |    |                         |  |
        |  +--------------4----------+   6    +---------2---------------+  |
        |                                |                                 |
        |                                v                                 |
-       +-----5------->  [shutdown_error | kShutdownBit] <-------7---------+
+       +-----5------->  [shutdown_error | FD_SHUTDOWN_BIT] <----7---------+
 
-    For 1, 4 : See SetReady() function
-    For 2, 3 : See NotifyOn() function
-    For 5,6,7: See SetShutdown() function */
+    For 1, 4 : See grpc_lfev_set_ready() function
+    For 2, 3 : See grpc_lfev_notify_on() function
+    For 5,6,7: See grpc_lfev_set_shutdown() function */
 
-namespace grpc_core {
+#define CLOSURE_NOT_READY ((gpr_atm)0)
+#define CLOSURE_READY ((gpr_atm)2)
 
-LockfreeEvent::~LockfreeEvent() {
-  gpr_atm curr = gpr_atm_no_barrier_load(&state_);
-  if (curr & kShutdownBit) {
-    GRPC_ERROR_UNREF((grpc_error*)(curr & ~kShutdownBit));
+#define FD_SHUTDOWN_BIT ((gpr_atm)1)
+
+void grpc_lfev_init(gpr_atm* state) {
+  gpr_atm_no_barrier_store(state, CLOSURE_NOT_READY);
+}
+
+void grpc_lfev_destroy(gpr_atm* state) {
+  gpr_atm curr = gpr_atm_no_barrier_load(state);
+  if (curr & FD_SHUTDOWN_BIT) {
+    GRPC_ERROR_UNREF((grpc_error*)(curr & ~FD_SHUTDOWN_BIT));
   } else {
-    GPR_ASSERT(curr == kClosureNotReady || curr == kClosureReady);
+    GPR_ASSERT(curr == CLOSURE_NOT_READY || curr == CLOSURE_READY);
   }
 }
 
-void LockfreeEvent::NotifyOn(grpc_exec_ctx* exec_ctx, grpc_closure* closure) {
+bool grpc_lfev_is_shutdown(gpr_atm* state) {
+  gpr_atm curr = gpr_atm_no_barrier_load(state);
+  return (curr & FD_SHUTDOWN_BIT) != 0;
+}
+
+void grpc_lfev_notify_on(grpc_exec_ctx* exec_ctx, gpr_atm* state,
+                         grpc_closure* closure, const char* variable) {
   while (true) {
-    gpr_atm curr = gpr_atm_no_barrier_load(&state_);
+    gpr_atm curr = gpr_atm_no_barrier_load(state);
     if (GRPC_TRACER_ON(grpc_polling_trace)) {
-      gpr_log(GPR_ERROR, "LockfreeEvent::NotifyOn: %p curr=%p closure=%p", this,
-              (void*)curr, closure);
+      gpr_log(GPR_ERROR, "lfev_notify_on[%s]: %p curr=%p closure=%p", variable,
+              state, (void*)curr, closure);
     }
     switch (curr) {
-      case kClosureNotReady: {
-        /* kClosureNotReady -> <closure>.
+      case CLOSURE_NOT_READY: {
+        /* CLOSURE_NOT_READY -> <closure>.
 
            We're guaranteed by API that there's an acquire barrier before here,
            so there's no need to double-dip and this can be a release-only.
 
            The release itself pairs with the acquire half of a set_ready full
            barrier. */
-        if (gpr_atm_rel_cas(&state_, kClosureNotReady, (gpr_atm)closure)) {
+        if (gpr_atm_rel_cas(state, CLOSURE_NOT_READY, (gpr_atm)closure)) {
           return; /* Successful. Return */
         }
 
         break; /* retry */
       }
 
-      case kClosureReady: {
-        /* Change the state to kClosureNotReady. Schedule the closure if
+      case CLOSURE_READY: {
+        /* Change the state to CLOSURE_NOT_READY. Schedule the closure if
            successful. If not, the state most likely transitioned to shutdown.
            We should retry.
 
            This can be a no-barrier cas since the state is being transitioned to
-           kClosureNotReady; set_ready and set_shutdown do not schedule any
+           CLOSURE_NOT_READY; set_ready and set_shutdown do not schedule any
            closure when transitioning out of CLOSURE_NO_READY state (i.e there
            is no other code that needs to 'happen-after' this) */
-        if (gpr_atm_no_barrier_cas(&state_, kClosureReady, kClosureNotReady)) {
+        if (gpr_atm_no_barrier_cas(state, CLOSURE_READY, CLOSURE_NOT_READY)) {
           GRPC_CLOSURE_SCHED(exec_ctx, closure, GRPC_ERROR_NONE);
           return; /* Successful. Return */
         }
@@ -110,8 +123,8 @@ void LockfreeEvent::NotifyOn(grpc_exec_ctx* exec_ctx, grpc_closure* closure) {
         /* 'curr' is either a closure or the fd is shutdown(in which case 'curr'
            contains a pointer to the shutdown-error). If the fd is shutdown,
            schedule the closure with the shutdown error */
-        if ((curr & kShutdownBit) > 0) {
-          grpc_error* shutdown_err = (grpc_error*)(curr & ~kShutdownBit);
+        if ((curr & FD_SHUTDOWN_BIT) > 0) {
+          grpc_error* shutdown_err = (grpc_error*)(curr & ~FD_SHUTDOWN_BIT);
           GRPC_CLOSURE_SCHED(exec_ctx, closure,
                              GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
                                  "FD Shutdown", &shutdown_err, 1));
@@ -120,8 +133,7 @@ void LockfreeEvent::NotifyOn(grpc_exec_ctx* exec_ctx, grpc_closure* closure) {
 
         /* There is already a closure!. This indicates a bug in the code */
         gpr_log(GPR_ERROR,
-                "LockfreeEvent::NotifyOn: notify_on called with a previous "
-                "callback still pending");
+                "notify_on called with a previous callback still pending");
         abort();
       }
     }
@@ -130,22 +142,22 @@ void LockfreeEvent::NotifyOn(grpc_exec_ctx* exec_ctx, grpc_closure* closure) {
   GPR_UNREACHABLE_CODE(return );
 }
 
-bool LockfreeEvent::SetShutdown(grpc_exec_ctx* exec_ctx,
-                                grpc_error* shutdown_err) {
-  gpr_atm new_state = (gpr_atm)shutdown_err | kShutdownBit;
+bool grpc_lfev_set_shutdown(grpc_exec_ctx* exec_ctx, gpr_atm* state,
+                            grpc_error* shutdown_err) {
+  gpr_atm new_state = (gpr_atm)shutdown_err | FD_SHUTDOWN_BIT;
 
   while (true) {
-    gpr_atm curr = gpr_atm_no_barrier_load(&state_);
+    gpr_atm curr = gpr_atm_no_barrier_load(state);
     if (GRPC_TRACER_ON(grpc_polling_trace)) {
-      gpr_log(GPR_ERROR, "LockfreeEvent::SetShutdown: %p curr=%p err=%s",
-              &state_, (void*)curr, grpc_error_string(shutdown_err));
+      gpr_log(GPR_ERROR, "lfev_set_shutdown: %p curr=%p err=%s", state,
+              (void*)curr, grpc_error_string(shutdown_err));
     }
     switch (curr) {
-      case kClosureReady:
-      case kClosureNotReady:
+      case CLOSURE_READY:
+      case CLOSURE_NOT_READY:
         /* Need a full barrier here so that the initial load in notify_on
            doesn't need a barrier */
-        if (gpr_atm_full_cas(&state_, curr, new_state)) {
+        if (gpr_atm_full_cas(state, curr, new_state)) {
           return true; /* early out */
         }
         break; /* retry */
@@ -154,7 +166,7 @@ bool LockfreeEvent::SetShutdown(grpc_exec_ctx* exec_ctx,
         /* 'curr' is either a closure or the fd is already shutdown */
 
         /* If fd is already shutdown, we are done */
-        if ((curr & kShutdownBit) > 0) {
+        if ((curr & FD_SHUTDOWN_BIT) > 0) {
           GRPC_ERROR_UNREF(shutdown_err);
           return false;
         }
@@ -164,7 +176,7 @@ bool LockfreeEvent::SetShutdown(grpc_exec_ctx* exec_ctx,
            Needs an acquire to pair with setting the closure (and get a
            happens-after on that edge), and a release to pair with anything
            loading the shutdown state. */
-        if (gpr_atm_full_cas(&state_, curr, new_state)) {
+        if (gpr_atm_full_cas(state, curr, new_state)) {
           GRPC_CLOSURE_SCHED(exec_ctx, (grpc_closure*)curr,
                              GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
                                  "FD Shutdown", &shutdown_err, 1));
@@ -181,25 +193,26 @@ bool LockfreeEvent::SetShutdown(grpc_exec_ctx* exec_ctx,
   GPR_UNREACHABLE_CODE(return false);
 }
 
-void LockfreeEvent::SetReady(grpc_exec_ctx* exec_ctx) {
+void grpc_lfev_set_ready(grpc_exec_ctx* exec_ctx, gpr_atm* state,
+                         const char* variable) {
   while (true) {
-    gpr_atm curr = gpr_atm_no_barrier_load(&state_);
+    gpr_atm curr = gpr_atm_no_barrier_load(state);
 
     if (GRPC_TRACER_ON(grpc_polling_trace)) {
-      gpr_log(GPR_ERROR, "LockfreeEvent::SetReady: %p curr=%p", &state_,
+      gpr_log(GPR_ERROR, "lfev_set_ready[%s]: %p curr=%p", variable, state,
               (void*)curr);
     }
 
     switch (curr) {
-      case kClosureReady: {
+      case CLOSURE_READY: {
         /* Already ready. We are done here */
         return;
       }
 
-      case kClosureNotReady: {
+      case CLOSURE_NOT_READY: {
         /* No barrier required as we're transitioning to a state that does not
            involve a closure */
-        if (gpr_atm_no_barrier_cas(&state_, kClosureNotReady, kClosureReady)) {
+        if (gpr_atm_no_barrier_cas(state, CLOSURE_NOT_READY, CLOSURE_READY)) {
           return; /* early out */
         }
         break; /* retry */
@@ -207,14 +220,14 @@ void LockfreeEvent::SetReady(grpc_exec_ctx* exec_ctx) {
 
       default: {
         /* 'curr' is either a closure or the fd is shutdown */
-        if ((curr & kShutdownBit) > 0) {
+        if ((curr & FD_SHUTDOWN_BIT) > 0) {
           /* The fd is shutdown. Do nothing */
           return;
         }
         /* Full cas: acquire pairs with this cas' release in the event of a
            spurious set_ready; release pairs with this or the acquire in
            notify_on (or set_shutdown) */
-        else if (gpr_atm_full_cas(&state_, curr, kClosureNotReady)) {
+        else if (gpr_atm_full_cas(state, curr, CLOSURE_NOT_READY)) {
           GRPC_CLOSURE_SCHED(exec_ctx, (grpc_closure*)curr, GRPC_ERROR_NONE);
           return;
         }
@@ -226,5 +239,3 @@ void LockfreeEvent::SetReady(grpc_exec_ctx* exec_ctx) {
     }
   }
 }
-
-}  // namespace grpc_core

--- a/src/core/lib/iomgr/lockfree_event.h
+++ b/src/core/lib/iomgr/lockfree_event.h
@@ -25,30 +25,24 @@
 
 #include "src/core/lib/iomgr/exec_ctx.h"
 
-namespace grpc_core {
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-class LockfreeEvent {
- public:
-  LockfreeEvent() = default;
-  ~LockfreeEvent();
+void grpc_lfev_init(gpr_atm* state);
+void grpc_lfev_destroy(gpr_atm* state);
+bool grpc_lfev_is_shutdown(gpr_atm* state);
 
-  LockfreeEvent(const LockfreeEvent&) = delete;
-  LockfreeEvent& operator=(const LockfreeEvent&) = delete;
+void grpc_lfev_notify_on(grpc_exec_ctx* exec_ctx, gpr_atm* state,
+                         grpc_closure* closure, const char* variable);
+/* Returns true on first successful shutdown */
+bool grpc_lfev_set_shutdown(grpc_exec_ctx* exec_ctx, gpr_atm* state,
+                            grpc_error* shutdown_err);
+void grpc_lfev_set_ready(grpc_exec_ctx* exec_ctx, gpr_atm* state,
+                         const char* variable);
 
-  bool IsShutdown() const {
-    return (gpr_atm_no_barrier_load(&state_) & kShutdownBit) != 0;
-  }
-
-  void NotifyOn(grpc_exec_ctx* exec_ctx, grpc_closure* closure);
-  bool SetShutdown(grpc_exec_ctx* exec_ctx, grpc_error* error);
-  void SetReady(grpc_exec_ctx* exec_ctx);
-
- private:
-  enum State { kClosureNotReady = 0, kClosureReady = 2, kShutdownBit = 1 };
-
-  gpr_atm state_ = kClosureNotReady;
-};
-
-}  // namespace grpc_core
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* GRPC_CORE_LIB_IOMGR_LOCKFREE_EVENT_H */


### PR DESCRIPTION
Reverts grpc/grpc#13097

This PR introduces the following race:

```
FAILED: bins/tsan/h2_fakesec_test ping GRPC_POLL_STRATEGY=epoll1 [ret=66, pid=24032, time=1.1sec]

D1108 10:54:42.922041827   24023 test_config.cc:388]         test slowdown factor: sanitizer=5, fixture=1, poller=1, total=5
I1108 10:54:43.156348469   24023 ev_epoll1_linux.cc:94]      grpc epoll fd: 3
D1108 10:54:43.165179765   24023 ev_posix.cc:135]            Using polling engine: epoll1
D1108 10:54:43.173117844   24023 dns_resolver.cc:307]        Using native dns resolver
I1108 10:54:43.212031115   24023 no_op.cc:38]                Running test: no-op/chttp2/fullstack
==================
WARNING: ThreadSanitizer: data race (pid=24023)
  Write of size 8 at 0x7d100000bac8 by thread T1:
    #0 grpc_core::LockfreeEvent::LockfreeEvent() /usr/local/google/home/dgq/grpc/forks/grpc/./src/core/lib/iomgr/lockfree_event.h:49:11 (h2_http_proxy_nosec_test+0x0000005b9e02)
    #1 grpc_core::ManualConstructor<grpc_core::LockfreeEvent>::Init() /usr/local/google/home/dgq/grpc/forks/grpc/./src/core/lib/support/manual_constructor.h:48:31 (h2_http_proxy_nosec_test+0x0000005b9db8)
    #2 fd_create(int, char const*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/ev_epoll1_linux.cc:268:3 (h2_http_proxy_nosec_test+0x0000005b35a0)
    #3 grpc_fd_create /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/ev_posix.cc:189:10 (h2_http_proxy_nosec_test+0x00000053c0ed)
    #4 tcp_client_connect_impl(grpc_exec_ctx*, grpc_closure*, grpc_endpoint**, grpc_pollset_set*, grpc_channel_args const*, grpc_resolved_address const*, long) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/tcp_client_posix.cc:289:11 (h2_http_proxy_nosec_test+0x000000549dc8)
    #5 grpc_tcp_client_connect /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/tcp_client_posix.cc:351:3 (h2_http_proxy_nosec_test+0x00000054a389)
    #6 next_address(grpc_exec_ctx*, internal_request*, grpc_error*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/http/httpcli.cc:224:3 (h2_http_proxy_nosec_test+0x00000052f3ee)
    #7 on_connected(grpc_exec_ctx*, void*, grpc_error*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/http/httpcli.cc:196:5 (h2_http_proxy_nosec_test+0x00000052f716)
    #8 exec_ctx_run(grpc_exec_ctx*, grpc_closure*, grpc_error*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/exec_ctx.cc:70:3 (h2_http_proxy_nosec_test+0x00000053d6f3)
    #9 grpc_exec_ctx_flush /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/exec_ctx.cc:90:9 (h2_http_proxy_nosec_test+0x00000053d437)
    #10 run_closures(grpc_exec_ctx*, grpc_closure_list) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/executor.cc:81:5 (h2_http_proxy_nosec_test+0x00000053eef9)
    #11 executor_thread(void*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/executor.cc:182:22 (h2_http_proxy_nosec_test+0x00000053ec35)
    #12 thread_body(void*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/support/thd_posix.cc:42:3 (h2_http_proxy_nosec_test+0x00000063e50d)

  Previous atomic write of size 8 at 0x7d100000bac8 by main thread:
    #0 __tsan_atomic64_compare_exchange_val /home/development/llvm/3.8.0/final/llvm.src/projects/compiler-rt/lib/tsan/rtl/tsan_interface_atomic.cc:849:3 (h2_http_proxy_nosec_test+0x0000004717fe)
    #1 gpr_atm_no_barrier_cas(long*, long, long) /usr/local/google/home/dgq/grpc/forks/grpc/include/grpc/impl/codegen/atm_gcc_atomic.h:65:10 (h2_http_proxy_nosec_test+0x0000005d5cd9)
    #2 grpc_core::LockfreeEvent::SetReady(grpc_exec_ctx*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/lockfree_event.cc:202:13 (h2_http_proxy_nosec_test+0x0000005d6104)
    #3 fd_become_readable(grpc_exec_ctx*, grpc_fd*, grpc_pollset*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/ev_epoll1_linux.cc:369:3 (h2_http_proxy_nosec_test+0x0000005b9150)
    #4 process_epoll_events(grpc_exec_ctx*, grpc_pollset*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/ev_epoll1_linux.cc:611:9 (h2_http_proxy_nosec_test+0x0000005b832f)
    #5 pollset_work(grpc_exec_ctx*, grpc_pollset*, grpc_pollset_worker**, long) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/ev_epoll1_linux.cc:975:26 (h2_http_proxy_nosec_test+0x0000005b4824)
    #6 grpc_pollset_work /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/ev_posix.cc:238:10 (h2_http_proxy_nosec_test+0x00000053c6f2)
    #7 grpc_pick_port_using_server() /usr/local/google/home/dgq/grpc/forks/grpc/test/core/util/port_server_client.cc:235:10 (h2_http_proxy_nosec_test+0x000000520f68)
    #8 grpc_pick_unused_port_impl() /usr/local/google/home/dgq/grpc/forks/grpc/test/core/util/port.cc:84:14 (h2_http_proxy_nosec_test+0x000000520125)
    #9 grpc_pick_unused_port /usr/local/google/home/dgq/grpc/forks/grpc/test/core/util/port.cc:114:10 (h2_http_proxy_nosec_test+0x00000051ff22)
    #10 grpc_pick_unused_port_or_die_impl() /usr/local/google/home/dgq/grpc/forks/grpc/test/core/util/port.cc:93:14 (h2_http_proxy_nosec_test+0x000000520165)
    #11 grpc_pick_unused_port_or_die /usr/local/google/home/dgq/grpc/forks/grpc/test/core/util/port.cc:118:10 (h2_http_proxy_nosec_test+0x00000051ff66)
    #12 chttp2_create_fixture_fullstack(grpc_channel_args*, grpc_channel_args*) /usr/local/google/home/dgq/grpc/forks/grpc/test/core/end2end/fixtures/h2_http_proxy.cc:52:27 (h2_http_proxy_nosec_test+0x0000004a8636)
    #13 begin_test(grpc_end2end_test_config, char const*, grpc_channel_args*, grpc_channel_args*) /usr/local/google/home/dgq/grpc/forks/grpc/test/core/end2end/tests/no_op.cc:39:7 (h2_http_proxy_nosec_test+0x0000004edbd2)
    #14 test_no_op(grpc_end2end_test_config) /usr/local/google/home/dgq/grpc/forks/grpc/test/core/end2end/tests/no_op.cc:88:33 (h2_http_proxy_nosec_test+0x0000004edad6)
    #15 no_op(grpc_end2end_test_config) /usr/local/google/home/dgq/grpc/forks/grpc/test/core/end2end/tests/no_op.cc:93:47 (h2_http_proxy_nosec_test+0x0000004eda15)
    #16 grpc_end2end_tests /usr/local/google/home/dgq/grpc/forks/grpc/test/core/end2end/end2end_nosec_tests.cc:420:7 (h2_http_proxy_nosec_test+0x0000004abcbd)
    #17 main /usr/local/google/home/dgq/grpc/forks/grpc/test/core/end2end/fixtures/h2_http_proxy.cc:127:5 (h2_http_proxy_nosec_test+0x0000004a859d)

  Location is heap block of size 64 at 0x7d100000bac0 allocated by thread T1:
    #0 malloc /home/development/llvm/3.8.0/final/llvm.src/projects/compiler-rt/lib/tsan/rtl/tsan_interceptors.cc:595:5 (h2_http_proxy_nosec_test+0x00000041f70d)
    #1 gpr_malloc /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/support/alloc.cc:56:7 (h2_http_proxy_nosec_test+0x000000635dfd)
    #2 fd_create(int, char const*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/ev_epoll1_linux.cc:264:24 (h2_http_proxy_nosec_test+0x0000005b356a)
    #3 grpc_fd_create /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/ev_posix.cc:189:10 (h2_http_proxy_nosec_test+0x00000053c0ed)
    #4 tcp_client_connect_impl(grpc_exec_ctx*, grpc_closure*, grpc_endpoint**, grpc_pollset_set*, grpc_channel_args const*, grpc_resolved_address const*, long) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/tcp_client_posix.cc:289:11 (h2_http_proxy_nosec_test+0x000000549dc8)
    #5 grpc_tcp_client_connect /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/tcp_client_posix.cc:351:3 (h2_http_proxy_nosec_test+0x00000054a389)
    #6 next_address(grpc_exec_ctx*, internal_request*, grpc_error*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/http/httpcli.cc:224:3 (h2_http_proxy_nosec_test+0x00000052f3ee)
    #7 on_resolved(grpc_exec_ctx*, void*, grpc_error*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/http/httpcli.cc:236:3 (h2_http_proxy_nosec_test+0x00000052ebff)
    #8 closure_wrapper(grpc_exec_ctx*, void*, grpc_error*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/closure.cc:116:3 (h2_http_proxy_nosec_test+0x0000005347de)
    #9 exec_ctx_run(grpc_exec_ctx*, grpc_closure*, grpc_error*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/exec_ctx.cc:70:3 (h2_http_proxy_nosec_test+0x00000053d6f3)
    #10 grpc_exec_ctx_flush /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/exec_ctx.cc:90:9 (h2_http_proxy_nosec_test+0x00000053d437)
    #11 run_closures(grpc_exec_ctx*, grpc_closure_list) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/executor.cc:81:5 (h2_http_proxy_nosec_test+0x00000053eef9)
    #12 executor_thread(void*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/executor.cc:182:22 (h2_http_proxy_nosec_test+0x00000053ec35)
    #13 thread_body(void*) /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/support/thd_posix.cc:42:3 (h2_http_proxy_nosec_test+0x00000063e50d)

  Thread T1 (tid=24090, running) created by main thread at:
    #0 pthread_create /home/development/llvm/3.8.0/final/llvm.src/projects/compiler-rt/lib/tsan/rtl/tsan_interceptors.cc:954:3 (h2_http_proxy_nosec_test+0x0000004226e1)
    #1 gpr_thd_new /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/support/thd_posix.cc:66:21 (h2_http_proxy_nosec_test+0x00000063e3f3)
    #2 grpc_executor_set_threading /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/executor.cc:108:5 (h2_http_proxy_nosec_test+0x00000053e26a)
    #3 grpc_executor_init /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/executor.cc:139:3 (h2_http_proxy_nosec_test+0x00000053ef83)
    #4 grpc_iomgr_init /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/iomgr/iomgr.cc:53:3 (h2_http_proxy_nosec_test+0x00000053fb5e)
    #5 grpc_init /usr/local/google/home/dgq/grpc/forks/grpc/src/core/lib/surface/init.cc:154:5 (h2_http_proxy_nosec_test+0x00000063035a)
    #6 main /usr/local/google/home/dgq/grpc/forks/grpc/test/core/end2end/fixtures/h2_http_proxy.cc:124:3 (h2_http_proxy_nosec_test+0x0000004a8528)

SUMMARY: ThreadSanitizer: data race /usr/local/google/home/dgq/grpc/forks/grpc/./src/core/lib/iomgr/lockfree_event.h:49:11 in grpc_core::LockfreeEvent::LockfreeEvent()
```

causing many tests to fail.