### PR TITLE
Fix timer freed early in uv pollset

### DIFF
--- a/src/core/lib/iomgr/pollset_uv.cc
+++ b/src/core/lib/iomgr/pollset_uv.cc
@@ -40,7 +40,7 @@ grpc_tracer_flag grpc_trace_fd_refcount =
 #endif
 
 struct grpc_pollset {
-  uv_timer_t *timer;
+  uv_timer_t* timer;
   int shutting_down;
 };
 

--- a/src/core/lib/iomgr/pollset_uv.cc
+++ b/src/core/lib/iomgr/pollset_uv.cc
@@ -40,7 +40,7 @@ grpc_tracer_flag grpc_trace_fd_refcount =
 #endif
 
 struct grpc_pollset {
-  uv_timer_t timer;
+  uv_timer_t *timer;
   int shutting_down;
 };
 
@@ -78,12 +78,16 @@ void grpc_pollset_global_shutdown(void) {
 
 static void timer_run_cb(uv_timer_t* timer) {}
 
-static void timer_close_cb(uv_handle_t* handle) { handle->data = (void*)1; }
+static void timer_close_cb(uv_handle_t* handle) {
+  handle->data = (void*)1;
+  gpr_free(handle);
+}
 
 void grpc_pollset_init(grpc_pollset* pollset, gpr_mu** mu) {
   GRPC_UV_ASSERT_SAME_THREAD();
   *mu = &grpc_polling_mu;
-  uv_timer_init(uv_default_loop(), &pollset->timer);
+  pollset->timer = (uv_timer_t*)gpr_malloc(sizeof(uv_timer_t));
+  uv_timer_init(uv_default_loop(), pollset->timer);
   pollset->shutting_down = 0;
 }
 
@@ -104,11 +108,11 @@ void grpc_pollset_shutdown(grpc_exec_ctx* exec_ctx, grpc_pollset* pollset,
 
 void grpc_pollset_destroy(grpc_exec_ctx* exec_ctx, grpc_pollset* pollset) {
   GRPC_UV_ASSERT_SAME_THREAD();
-  uv_close((uv_handle_t*)&pollset->timer, timer_close_cb);
+  uv_close((uv_handle_t*)pollset->timer, timer_close_cb);
   // timer.data is a boolean indicating that the timer has finished closing
-  pollset->timer.data = (void*)0;
+  pollset->timer->data = (void*)0;
   if (grpc_pollset_work_run_loop) {
-    while (!pollset->timer.data) {
+    while (!pollset->timer->data) {
       uv_run(uv_default_loop(), UV_RUN_NOWAIT);
     }
   }
@@ -130,11 +134,11 @@ grpc_error* grpc_pollset_work(grpc_exec_ctx* exec_ctx, grpc_pollset* pollset,
     /* We special-case timeout=0 so that we don't bother with the timer when
        the loop won't block anyway */
     if (timeout > 0) {
-      uv_timer_start(&pollset->timer, timer_run_cb, timeout, 0);
+      uv_timer_start(pollset->timer, timer_run_cb, timeout, 0);
       /* Run until there is some I/O activity or the timer triggers. It doesn't
          matter which happens */
       uv_run(uv_default_loop(), UV_RUN_ONCE);
-      uv_timer_stop(&pollset->timer);
+      uv_timer_stop(pollset->timer);
     } else {
       uv_run(uv_default_loop(), UV_RUN_NOWAIT);
     }


### PR DESCRIPTION
Previously, the uv loop could still hold a reference to the pollset timer after the pollset was destroyed, so if the pollset was freed at that time it would cause use-after-free errors. This fixes that by dynamically allocating the timer separately from the pollset.

This appears to fix #13242.