### PR TITLE
Add CNAME test cases to c-ares resolver tests

### DIFF
--- a/templates/test/cpp/naming/resolver_gce_integration_tests_defs.include
+++ b/templates/test/cpp/naming/resolver_gce_integration_tests_defs.include
@@ -17,6 +17,7 @@
 
 set -ex
 
+export GRPC_VERBOSITY=DEBUG
 if [[ "$GRPC_DNS_RESOLVER" == "" ]]; then
   export GRPC_DNS_RESOLVER=ares
 elif [[ "$GRPC_DNS_RESOLVER" != ares ]]; then

--- a/test/cpp/naming/README.md
+++ b/test/cpp/naming/README.md
@@ -31,7 +31,7 @@ After making a change to `resolver_test_record_groups.yaml`:
 3. From the repo root, run:
 
 ```
-$ test/cpp/naming/create_dns_private_zone.sh
+$ test/cpp/naming/create_private_dns_zone.sh
 $ test/cpp/naming/private_dns_zone_init.sh
 ```
 

--- a/test/cpp/naming/create_private_dns_zone.sh
+++ b/test/cpp/naming/create_private_dns_zone.sh
@@ -20,8 +20,8 @@ set -ex
 cd $(dirname $0)/../../..
 
 gcloud alpha dns managed-zones create \
-  resolver-tests-version-1-grpctestingexp-zone-id \
-  --dns-name=resolver-tests-version-1.grpctestingexp. \
+  resolver-tests-version-3-grpctestingexp-zone-id \
+  --dns-name=resolver-tests-version-3.grpctestingexp. \
   --description="GCE-DNS-private-zone-for-GRPC-testing" \
   --visibility=private \
   --networks=default

--- a/test/cpp/naming/private_dns_zone_init.sh
+++ b/test/cpp/naming/private_dns_zone_init.sh
@@ -19,197 +19,267 @@ set -ex
 
 cd $(dirname $0)/../../..
 
-gcloud dns record-sets transaction start -z=resolver-tests-version-1-grpctestingexp-zone-id
+gcloud dns record-sets transaction start -z=resolver-tests-version-3-grpctestingexp-zone-id
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-3.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv4-single-target.resolver-tests-version-1.grpctestingexp."
+  "0 0 1234 ipv4-single-target.resolver-tests-version-3.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-single-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv4-single-target.resolver-tests-version-3.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-3.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv4-multi-target.resolver-tests-version-1.grpctestingexp."
+  "0 0 1234 ipv4-multi-target.resolver-tests-version-3.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-multi-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv4-multi-target.resolver-tests-version-3.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.5" "1.2.3.6" "1.2.3.7"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-3.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv6-single-target.resolver-tests-version-1.grpctestingexp."
+  "0 0 1234 ipv6-single-target.resolver-tests-version-3.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv6-single-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv6-single-target.resolver-tests-version-3.grpctestingexp. \
   --type=AAAA \
   --ttl=2100 \
   "2607:f8b0:400a:801::1001"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-3.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv6-multi-target.resolver-tests-version-1.grpctestingexp."
+  "0 0 1234 ipv6-multi-target.resolver-tests-version-3.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv6-multi-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv6-multi-target.resolver-tests-version-3.grpctestingexp. \
   --type=AAAA \
   --ttl=2100 \
   "2607:f8b0:400a:801::1002" "2607:f8b0:400a:801::1003" "2607:f8b0:400a:801::1004"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=srv-ipv4-simple-service-config.resolver-tests-version-3.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"SimpleService\",\"waitForReady\":true}]}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv4-simple-service-config.resolver-tests-version-3.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-3.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp."
+  "0 0 1234 ipv4-simple-service-config.resolver-tests-version-3.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv4-no-srv-simple-service-config.resolver-tests-version-3.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv4-no-srv-simple-service-config.resolver-tests-version-3.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"NoSrvSimpleService\",\"waitForReady\":true}]}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv4-no-config-for-cpp.resolver-tests-version-3.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv4-no-config-for-cpp.resolver-tests-version-3.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"clientLanguage\":[\"python\"],\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"PythonService\",\"waitForReady\":true}]}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv4-cpp-config-has-zero-percentage.resolver-tests-version-3.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv4-cpp-config-has-zero-percentage.resolver-tests-version-3.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"percentage\":0,\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"CppService\",\"waitForReady\":true}]}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv4-second-language-is-cpp.resolver-tests-version-3.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv4-second-language-is-cpp.resolver-tests-version-3.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"clientLanguage\":[\"go\"],\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"GoService\",\"waitForReady\":true}]}]}},{\"clientLanguage\":[\"c++\"],\"serviceConfig\":{" "\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"CppService\",\"waitForReady\":true}]}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv4-config-with-percentages.resolver-tests-version-3.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=ipv4-config-with-percentages.resolver-tests-version-3.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"percentage\":0,\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"NeverPickedService\",\"waitForReady\":true}]}]}},{\"percentage\":100,\"serviceConfig\":{\"loadBalanc" "ingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"AlwaysPickedService\",\"waitForReady\":true}]}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp."
+  "0 0 1234 balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp."
+  "0 0 1234 balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. \
   --type=AAAA \
   --ttl=2100 \
   "2607:f8b0:400a:801::1002"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. \
   --type=AAAA \
   --ttl=2100 \
   "2607:f8b0:400a:801::1002"
 
-gcloud dns record-sets transaction describe -z=resolver-tests-version-1-grpctestingexp-zone-id
-gcloud dns record-sets transaction execute -z=resolver-tests-version-1-grpctestingexp-zone-id
-gcloud dns record-sets list -z=resolver-tests-version-1-grpctestingexp-zone-id
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=simple-ipv4-from-cname.resolver-tests-version-3.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "11.22.33.44"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=simple-cname-to-ipv4.resolver-tests-version-3.grpctestingexp. \
+  --type=CNAME \
+  --ttl=2100 \
+  simple-ipv4-from-cname.resolver-tests-version-3.grpctestingexp.
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=simple-ipv6-from-cname.resolver-tests-version-3.grpctestingexp. \
+  --type=AAAA \
+  --ttl=2100 \
+  "3ffe::1234"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=simple-cname-to-ipv6.resolver-tests-version-3.grpctestingexp. \
+  --type=CNAME \
+  --ttl=2100 \
+  simple-ipv6-from-cname.resolver-tests-version-3.grpctestingexp.
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=target-of-cname-chain-to-ipv4.resolver-tests-version-3.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "10.20.30.40"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=middle-of-cname-chain-to-ipv4.resolver-tests-version-3.grpctestingexp. \
+  --type=CNAME \
+  --ttl=2100 \
+  target-of-cname-chain-to-ipv4.resolver-tests-version-3.grpctestingexp.
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=chained-cname-to-ipv4.resolver-tests-version-3.grpctestingexp. \
+  --type=CNAME \
+  --ttl=2100 \
+  middle-of-cname-chain-to-ipv4.resolver-tests-version-3.grpctestingexp.
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=target-of-cname-chain-to-ipv6.resolver-tests-version-3.grpctestingexp. \
+  --type=AAAA \
+  --ttl=2100 \
+  "fec0::5678"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=chained-cname-to-ipv6.resolver-tests-version-3.grpctestingexp. \
+  --type=CNAME \
+  --ttl=2100 \
+  middle-of-cname-chain-to-ipv6.resolver-tests-version-3.grpctestingexp.
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-3-grpctestingexp-zone-id \
+  --name=middle-of-cname-chain-to-ipv6.resolver-tests-version-3.grpctestingexp. \
+  --type=CNAME \
+  --ttl=2100 \
+  target-of-cname-chain-to-ipv6.resolver-tests-version-3.grpctestingexp.
+
+gcloud dns record-sets transaction describe -z=resolver-tests-version-3-grpctestingexp-zone-id
+gcloud dns record-sets transaction execute -z=resolver-tests-version-3-grpctestingexp-zone-id
+gcloud dns record-sets list -z=resolver-tests-version-3-grpctestingexp-zone-id

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -254,7 +254,7 @@ void CheckResolverResultLocked(grpc_exec_ctx* exec_ctx, void* argsp,
     grpc_lb_address addr = addresses->addresses[i];
     char* str;
     grpc_sockaddr_to_string(&str, &addr.address, 1 /* normalize */);
-    gpr_log(GPR_INFO, "%s", str);
+    gpr_log(GPR_INFO, "found:%s", str);
     found_lb_addrs.emplace_back(
         GrpcLBAddress(std::string(str), addr.is_balancer));
     gpr_free(str);

--- a/test/cpp/naming/resolver_component_tests_runner.sh
+++ b/test/cpp/naming/resolver_component_tests_runner.sh
@@ -73,7 +73,7 @@ EXIT_CODE=0
 # in the resolver.
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-single-target.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -81,7 +81,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-multi-target.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.5:1234,True;1.2.3.6:1234,True;1.2.3.7:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -89,7 +89,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv6-single-target.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1001]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -97,7 +97,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv6-multi-target.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1003]:1234,True;[2607:f8b0:400a:801::1004]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -105,7 +105,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -113,7 +113,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -121,7 +121,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -129,7 +129,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -137,7 +137,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -145,7 +145,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-config-with-percentages.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -153,7 +153,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True;1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -161,7 +161,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1002]:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -169,9 +169,25 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-config-causing-fallback-to-tcp.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-config-causing-fallback-to-tcp.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}' \
+  --expected_lb_policy='' \
+  --local_dns_server_address=127.0.0.1:$FLAGS_test_dns_server_port &
+wait $! || EXIT_CODE=1
+
+$FLAGS_test_bin_path \
+  --target_name='simple-cname-to-ipv4.resolver-tests-version-3.grpctestingexp.' \
+  --expected_addrs='11.22.33.44:443,False' \
+  --expected_chosen_service_config='' \
+  --expected_lb_policy='' \
+  --local_dns_server_address=127.0.0.1:$FLAGS_test_dns_server_port &
+wait $! || EXIT_CODE=1
+
+$FLAGS_test_bin_path \
+  --target_name='simple-cname-to-ipv6.resolver-tests-version-3.grpctestingexp.' \
+  --expected_addrs='[3ffe::1234]:443,False' \
+  --expected_chosen_service_config='' \
   --expected_lb_policy='' \
   --local_dns_server_address=127.0.0.1:$FLAGS_test_dns_server_port &
 wait $! || EXIT_CODE=1

--- a/test/cpp/naming/resolver_gce_integration_tests_runner.sh
+++ b/test/cpp/naming/resolver_gce_integration_tests_runner.sh
@@ -17,6 +17,7 @@
 
 set -ex
 
+export GRPC_VERBOSITY=DEBUG
 if [[ "$GRPC_DNS_RESOLVER" == "" ]]; then
   export GRPC_DNS_RESOLVER=ares
 elif [[ "$GRPC_DNS_RESOLVER" != ares ]]; then
@@ -34,191 +35,261 @@ echo "Sanity check DNS records are resolveable with dig:"
 EXIT_CODE=0
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-single-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-single-target.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-single-target.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-multi-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-multi-target.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-multi-target.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig AAAA ipv6-single-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig AAAA ipv6-single-target.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig AAAA ipv6-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig AAAA ipv6-single-target.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig AAAA ipv6-multi-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig AAAA ipv6-multi-target.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig AAAA ipv6-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig AAAA ipv6-multi-target.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT srv-ipv4-simple-service-config.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT srv-ipv4-simple-service-config.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-simple-service-config.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-simple-service-config.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-no-srv-simple-service-config.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-no-srv-simple-service-config.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT ipv4-no-srv-simple-service-config.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT ipv4-no-srv-simple-service-config.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-no-config-for-cpp.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-no-config-for-cpp.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT ipv4-no-config-for-cpp.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT ipv4-no-config-for-cpp.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-cpp-config-has-zero-percentage.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-cpp-config-has-zero-percentage.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT ipv4-cpp-config-has-zero-percentage.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT ipv4-cpp-config-has-zero-percentage.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-second-language-is-cpp.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-second-language-is-cpp.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT ipv4-second-language-is-cpp.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT ipv4-second-language-is-cpp.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-config-with-percentages.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-config-with-percentages.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT ipv4-config-with-percentages.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT ipv4-config-with-percentages.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig AAAA balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig AAAA balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig AAAA balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig AAAA balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig AAAA srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig AAAA srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig AAAA srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig AAAA srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig A simple-ipv4-from-cname.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig A simple-ipv4-from-cname.resolver-tests-version-3.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig CNAME simple-cname-to-ipv4.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig CNAME simple-cname-to-ipv4.resolver-tests-version-3.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig AAAA simple-ipv6-from-cname.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig AAAA simple-ipv6-from-cname.resolver-tests-version-3.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig CNAME simple-cname-to-ipv6.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig CNAME simple-cname-to-ipv6.resolver-tests-version-3.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig A target-of-cname-chain-to-ipv4.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig A target-of-cname-chain-to-ipv4.resolver-tests-version-3.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig CNAME middle-of-cname-chain-to-ipv4.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig CNAME middle-of-cname-chain-to-ipv4.resolver-tests-version-3.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig CNAME chained-cname-to-ipv4.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig CNAME chained-cname-to-ipv4.resolver-tests-version-3.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig AAAA target-of-cname-chain-to-ipv6.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig AAAA target-of-cname-chain-to-ipv6.resolver-tests-version-3.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig CNAME chained-cname-to-ipv6.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig CNAME chained-cname-to-ipv6.resolver-tests-version-3.grpctestingexp. FAILED"
+  exit 1
+fi
+
+ONE_FAILED=0
+dig CNAME middle-of-cname-chain-to-ipv6.resolver-tests-version-3.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Sanity check: dig CNAME middle-of-cname-chain-to-ipv6.resolver-tests-version-3.grpctestingexp. FAILED"
   exit 1
 fi
 
@@ -226,133 +297,177 @@ echo "Sanity check PASSED. Run resolver tests:"
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-single-target.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv4-single-target.resolver-tests-version-3.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-multi-target.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.5:1234,True;1.2.3.6:1234,True;1.2.3.7:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv4-multi-target.resolver-tests-version-3.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv6-single-target.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1001]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv6-single-target.resolver-tests-version-3.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv6-multi-target.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1003]:1234,True;[2607:f8b0:400a:801::1004]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv6-multi-target.resolver-tests-version-3.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv4-simple-service-config.resolver-tests-version-3.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-no-srv-simple-service-config.resolver-tests-version-3.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-no-config-for-cpp.resolver-tests-version-3.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-cpp-config-has-zero-percentage.resolver-tests-version-3.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-second-language-is-cpp.resolver-tests-version-3.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-config-with-percentages.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-config-with-percentages.resolver-tests-version-3.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True;1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1002]:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-3.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='simple-cname-to-ipv4.resolver-tests-version-3.grpctestingexp.' \
+  --expected_addrs='11.22.33.44:443,False' \
+  --expected_chosen_service_config='' \
+  --expected_lb_policy='' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: simple-cname-to-ipv4.resolver-tests-version-3.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='simple-cname-to-ipv6.resolver-tests-version-3.grpctestingexp.' \
+  --expected_addrs='[3ffe::1234]:443,False' \
+  --expected_chosen_service_config='' \
+  --expected_lb_policy='' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: simple-cname-to-ipv6.resolver-tests-version-3.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='chained-cname-to-ipv4.resolver-tests-version-3.grpctestingexp.' \
+  --expected_addrs='10.20.30.40:443,False' \
+  --expected_chosen_service_config='' \
+  --expected_lb_policy='' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: chained-cname-to-ipv4.resolver-tests-version-3.grpctestingexp. FAILED"
+  EXIT_CODE=1
+fi
+
+ONE_FAILED=0
+bins/$CONFIG/resolver_component_test \
+  --target_name='chained-cname-to-ipv6.resolver-tests-version-3.grpctestingexp.' \
+  --expected_addrs='[fec0::5678]:443,False' \
+  --expected_chosen_service_config='' \
+  --expected_lb_policy='' || ONE_FAILED=1
+if [[ "$ONE_FAILED" != 0 ]]; then
+  echo "Test based on target record: chained-cname-to-ipv6.resolver-tests-version-3.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 

--- a/test/cpp/naming/resolver_test_record_groups.yaml
+++ b/test/cpp/naming/resolver_test_record_groups.yaml
@@ -1,4 +1,4 @@
-resolver_tests_common_zone_name: resolver-tests-version-1.grpctestingexp.
+resolver_tests_common_zone_name: resolver-tests-version-3.grpctestingexp.
 resolver_component_tests:
 - expected_addrs:
   - {address: '1.2.3.4:1234', is_balancer: true}
@@ -147,3 +147,47 @@ resolver_component_tests:
     - {TTL: '2100', data: 1.2.3.4, type: A}
     - {TTL: '2100', data: 'grpc_config=[{"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}}]',
       type: TXT}
+- expected_addrs:
+  - {address: '11.22.33.44:443', is_balancer: false}
+  expected_chosen_service_config: null
+  expected_lb_policy: null
+  record_to_resolve: simple-cname-to-ipv4
+  records:
+    simple-cname-to-ipv4:
+    - {TTL: '2100', data: simple-ipv4-from-cname, type: CNAME}
+    simple-ipv4-from-cname:
+    - {TTL: '2100', data: 11.22.33.44, type: A}
+- expected_addrs:
+  - {address: '[3ffe::1234]:443', is_balancer: false}
+  expected_chosen_service_config: null
+  expected_lb_policy: null
+  record_to_resolve: simple-cname-to-ipv6
+  records:
+    simple-cname-to-ipv6:
+    - {TTL: '2100', data: simple-ipv6-from-cname, type: CNAME}
+    simple-ipv6-from-cname:
+    - {TTL: '2100', data: '3ffe::1234', type: AAAA}
+- expected_addrs:
+  - {address: '10.20.30.40:443', is_balancer: false}
+  expected_chosen_service_config: null
+  expected_lb_policy: null
+  record_to_resolve: chained-cname-to-ipv4
+  records:
+    chained-cname-to-ipv4:
+    - {TTL: '2100', data: middle-of-cname-chain-to-ipv4, type: CNAME}
+    middle-of-cname-chain-to-ipv4:
+    - {TTL: '2100', data: target-of-cname-chain-to-ipv4, type: CNAME}
+    target-of-cname-chain-to-ipv4:
+    - {TTL: '2100', data: '10.20.30.40', type: A}
+- expected_addrs:
+  - {address: '[fec0::5678]:443', is_balancer: false}
+  expected_chosen_service_config: null
+  expected_lb_policy: null
+  record_to_resolve: chained-cname-to-ipv6
+  records:
+    chained-cname-to-ipv6:
+    - {TTL: '2100', data: middle-of-cname-chain-to-ipv6, type: CNAME}
+    middle-of-cname-chain-to-ipv6:
+    - {TTL: '2100', data: target-of-cname-chain-to-ipv6, type: CNAME}
+    target-of-cname-chain-to-ipv6:
+    - {TTL: '2100', data: 'fec0::5678', type: AAAA}

--- a/test/cpp/naming/test_dns_server.py
+++ b/test/cpp/naming/test_dns_server.py
@@ -90,6 +90,11 @@ def start_local_dns_server(args):
           _push_record(record_full_name, dns.Record_SRV(p, w, port, target_full_name, ttl=r_ttl))
         if r_type == 'TXT':
           _maybe_split_up_txt_data(record_full_name, r_data, r_ttl)
+        if r_type == 'CNAME':
+          r_data = '%s.%s' % (r_data, common_zone_name)
+          assert r_data[-1] == '.'
+          r_data = r_data[:-1]
+          _push_record(record_full_name, dns.Record_CNAME(r_data, ttl=r_ttl))
   # Server health check record
   _push_record(_SERVER_HEALTH_CHECK_RECORD_NAME, dns.Record_A(_SERVER_HEALTH_CHECK_RECORD_DATA, ttl=0))
   soa_record = dns.Record_SOA(mname = common_zone_name)


### PR DESCRIPTION
The changes here involve a couple of tweaks to the buildgen and python server, new test cases in the yaml file, and `regenerate_projects.sh` run (and a couple of tweaks to test logging).

I uploaded the new DNS records that are in this PR, and ran the c-ares-to-GCE_DNS tests successfully with them in https://grpc-testing.appspot.com/job/gRPC_naming_Adhoc/203/console.

The CNAME chains tests need to be disabled on the local unit tests since the python DNS server in unit tests isn't able to handle them.

----

Noting to self, TODO: before merging, records version needs to update from 3 to 5, since 4 is latest

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/13320)
<!-- Reviewable:end -->
