### PR TITLE
Fix unaligned access in murmur hash

### DIFF
--- a/src/core/lib/support/murmur_hash.cc
+++ b/src/core/lib/support/murmur_hash.cc
@@ -40,12 +40,12 @@ uint32_t gpr_murmur_hash3(const void* key, size_t len, uint32_t seed) {
   const uint32_t c1 = 0xcc9e2d51;
   const uint32_t c2 = 0x1b873593;
 
-  const uint32_t* blocks = ((const uint32_t*)key) + nblocks;
-  const uint8_t* tail = (const uint8_t*)(data + nblocks * 4);
+  const uint8_t* blocks = ((const uint8_t*)key) + nblocks * sizeof(uint32_t);
+  const uint8_t* tail = (const uint8_t*)(data + nblocks * sizeof(uint32_t));
 
   /* body */
   for (i = -(int)nblocks; i; i++) {
-    memcpy(&k1, blocks + i, sizeof(uint32_t));
+    memcpy(&k1, blocks + i * sizeof(uint32_t), sizeof(uint32_t));
 
     k1 *= c1;
     k1 = ROTL32(k1, 15);


### PR DESCRIPTION
The key argument to gpr_murmur_hash3() isn't guaranteed to be 32-bit
aligned, so it is undefined behavior to cast and dereference it as a
uint32_t*. This patch adds a cast back to uint8_t* before dereferencing
to avoid an unaligned load exception on ARM.

Fixes #13221.