### PR TITLE
Add support to RunServer for notifying clients via condition variable that the interop server has started.

### DIFF
--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -322,7 +322,7 @@ void grpc::testing::interop::RunServer(
 
 void grpc::testing::interop::RunServer(
     std::shared_ptr<ServerCredentials> creds, const int port,
-    ServerStartedCondition *server_started_condition) {
+    ServerStartedCondition* server_started_condition) {
   GPR_ASSERT(port != 0);
   std::ostringstream server_address;
   server_address << "0.0.0.0:" << port;

--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -317,9 +317,16 @@ class TestServiceImpl : public TestService::Service {
 
 void grpc::testing::interop::RunServer(
     std::shared_ptr<ServerCredentials> creds) {
-  GPR_ASSERT(FLAGS_port != 0);
+  RunServer(creds, FLAGS_port, nullptr);
+}
+
+void grpc::testing::interop::RunServer(
+    std::shared_ptr<ServerCredentials> creds,
+    const int port,
+    std::condition_variable *server_started_condition) {
+  GPR_ASSERT(port != 0);
   std::ostringstream server_address;
-  server_address << "0.0.0.0:" << FLAGS_port;
+  server_address << "0.0.0.0:" << port;
   TestServiceImpl service;
 
   SimpleRequest request;
@@ -333,6 +340,10 @@ void grpc::testing::interop::RunServer(
   }
   std::unique_ptr<Server> server(builder.BuildAndStart());
   gpr_log(GPR_INFO, "Server listening on %s", server_address.str().c_str());
+
+  // Signal that the server has started.
+  if (server_started_condition) server_started_condition->notify_all();
+
   while (!gpr_atm_no_barrier_load(&g_got_sigint)) {
     gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_REALTIME),
                                  gpr_time_from_seconds(5, GPR_TIMESPAN)));

--- a/test/cpp/interop/interop_server.cc
+++ b/test/cpp/interop/interop_server.cc
@@ -321,8 +321,7 @@ void grpc::testing::interop::RunServer(
 }
 
 void grpc::testing::interop::RunServer(
-    std::shared_ptr<ServerCredentials> creds,
-    const int port,
+    std::shared_ptr<ServerCredentials> creds, const int port,
     ServerStartedCondition *server_started_condition) {
   GPR_ASSERT(port != 0);
   std::ostringstream server_address;

--- a/test/cpp/interop/server_helper.h
+++ b/test/cpp/interop/server_helper.h
@@ -52,6 +52,12 @@ namespace interop {
 
 extern gpr_atm g_got_sigint;
 
+struct ServerStartedCondition {
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool server_started = false;
+};
+
 /// Run gRPC interop server using port FLAGS_port.
 ///
 /// \param creds The credentials associated with the server.
@@ -61,11 +67,11 @@ void RunServer(std::shared_ptr<ServerCredentials> creds);
 ///
 /// \param creds The credentials associated with the server.
 /// \param port Port to use for the server.
-/// \param server_started_condition (optional) Condition variable used to notify
-///     when the server has started.
+/// \param server_started_condition (optional) Struct holding mutex, condition
+///     variable, and condition used to notify when the server has started.
 void RunServer(std::shared_ptr<ServerCredentials> creds,
                int port,
-               std::condition_variable *server_started_condition);
+               ServerStartedCondition *server_started_condition);
 
 }  // namespace interop
 }  // namespace testing

--- a/test/cpp/interop/server_helper.h
+++ b/test/cpp/interop/server_helper.h
@@ -69,8 +69,7 @@ void RunServer(std::shared_ptr<ServerCredentials> creds);
 /// \param port Port to use for the server.
 /// \param server_started_condition (optional) Struct holding mutex, condition
 ///     variable, and condition used to notify when the server has started.
-void RunServer(std::shared_ptr<ServerCredentials> creds,
-               int port,
+void RunServer(std::shared_ptr<ServerCredentials> creds, int port,
                ServerStartedCondition *server_started_condition);
 
 }  // namespace interop

--- a/test/cpp/interop/server_helper.h
+++ b/test/cpp/interop/server_helper.h
@@ -19,6 +19,7 @@
 #ifndef GRPC_TEST_CPP_INTEROP_SERVER_HELPER_H
 #define GRPC_TEST_CPP_INTEROP_SERVER_HELPER_H
 
+#include <condition_variable>
 #include <memory>
 
 #include <grpc/compression.h>
@@ -50,7 +51,21 @@ class InteropServerContextInspector {
 namespace interop {
 
 extern gpr_atm g_got_sigint;
+
+/// Run gRPC interop server using port FLAGS_port.
+///
+/// \param creds The credentials associated with the server.
 void RunServer(std::shared_ptr<ServerCredentials> creds);
+
+/// Run gRPC interop server.
+///
+/// \param creds The credentials associated with the server.
+/// \param port Port to use for the server.
+/// \param server_started_condition (optional) Condition variable to used to
+///     notify when the server has started.
+void RunServer(std::shared_ptr<ServerCredentials> creds,
+               int port,
+               std::condition_variable *server_started_condition);
 
 }  // namespace interop
 }  // namespace testing

--- a/test/cpp/interop/server_helper.h
+++ b/test/cpp/interop/server_helper.h
@@ -70,7 +70,7 @@ void RunServer(std::shared_ptr<ServerCredentials> creds);
 /// \param server_started_condition (optional) Struct holding mutex, condition
 ///     variable, and condition used to notify when the server has started.
 void RunServer(std::shared_ptr<ServerCredentials> creds, int port,
-               ServerStartedCondition *server_started_condition);
+               ServerStartedCondition* server_started_condition);
 
 }  // namespace interop
 }  // namespace testing

--- a/test/cpp/interop/server_helper.h
+++ b/test/cpp/interop/server_helper.h
@@ -61,8 +61,8 @@ void RunServer(std::shared_ptr<ServerCredentials> creds);
 ///
 /// \param creds The credentials associated with the server.
 /// \param port Port to use for the server.
-/// \param server_started_condition (optional) Condition variable to used to
-///     notify when the server has started.
+/// \param server_started_condition (optional) Condition variable used to notify
+///     when the server has started.
 void RunServer(std::shared_ptr<ServerCredentials> creds,
                int port,
                std::condition_variable *server_started_condition);


### PR DESCRIPTION
Change adds a version of grpc::testing::interop::RunServer that allows clients to pass in optional condition_variable which will be notified when the server has started and port to use, avoiding the need for callers to work with command line options.

Above is used to support clients running the server in a separate thread in the same process as the tests are run to support local only tests.

Existing grpc::testing::interop::RunServer calls into new version passing in FLAGS_port and null condition_variable.