### PR TITLE
grpclb: Don't expect LB call to be NULL inside LB call retry timer.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1259,14 +1259,13 @@ static void lb_call_on_retry_timer_locked(grpc_exec_ctx* exec_ctx, void* arg,
                                           grpc_error* error) {
   glb_lb_policy* glb_policy = (glb_lb_policy*)arg;
   glb_policy->retry_timer_active = false;
-  if (!glb_policy->shutting_down && error == GRPC_ERROR_NONE) {
+  if (!glb_policy->shutting_down && glb_policy->lb_call == NULL &&
+      error == GRPC_ERROR_NONE) {
     if (GRPC_TRACER_ON(grpc_lb_glb_trace)) {
       gpr_log(GPR_INFO, "Restaring call to LB server (grpclb %p)",
               (void*)glb_policy);
     }
-    if (glb_policy->lb_call == NULL) {
-      query_for_backends_locked(exec_ctx, glb_policy);
-    }
+    query_for_backends_locked(exec_ctx, glb_policy);
   }
   GRPC_LB_POLICY_WEAK_UNREF(exec_ctx, &glb_policy->base, "grpclb_retry_timer");
 }

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1264,8 +1264,9 @@ static void lb_call_on_retry_timer_locked(grpc_exec_ctx* exec_ctx, void* arg,
       gpr_log(GPR_INFO, "Restaring call to LB server (grpclb %p)",
               (void*)glb_policy);
     }
-    GPR_ASSERT(glb_policy->lb_call == NULL);
-    query_for_backends_locked(exec_ctx, glb_policy);
+    if (glb_policy->lb_call == NULL) {
+      query_for_backends_locked(exec_ctx, glb_policy);
+    }
   }
   GRPC_LB_POLICY_WEAK_UNREF(exec_ctx, &glb_policy->base, "grpclb_retry_timer");
 }


### PR DESCRIPTION
The timer callback runs independently of query_for_backends_locked() (which initializes the LB call). It's possible for the timer callback to fire right after query_for_backends_locked() has initialized the LB
call. These changes makes the timer cb be a no-op in that scenario.

Example, as seen during internal stress testing:
```
I1109 09:40:39.169257  994714 grpclb.cc:1495] [grpclb 0x7f1dbb048300] Query for backends (lb_channel: 0x7f1dba165000, lb_call: 0x7f1db5480020)
...
I1109 09:40:39.171471  994714 grpclb.cc:1267] [grpclb 0x7f1dbb048300] Restaring call to LB server
E1109 09:40:39.172154  994714 grpclb.cc:1269] assertion failed: glb_policy->lb_call == NULL

```