### PR TITLE
Default to 1 cq per sync server

### DIFF
--- a/include/grpc++/server_builder.h
+++ b/include/grpc++/server_builder.h
@@ -202,10 +202,7 @@ class ServerBuilder {
 
   struct SyncServerSettings {
     SyncServerSettings()
-        : num_cqs(GPR_MAX(1, gpr_cpu_num_cores())),
-          min_pollers(1),
-          max_pollers(2),
-          cq_timeout_msec(10000) {}
+        : num_cqs(1), min_pollers(1), max_pollers(2), cq_timeout_msec(10000) {}
 
     /// Number of server completion queues to create to listen to incoming RPCs.
     int num_cqs;


### PR DESCRIPTION
This fixes a flake for loon introduced with

https://github.com/grpc/grpc/pull/12648

I verified that this change induces the flake with both this PR rolled back and at head, which suggests that there is a flake with multiple cqs per sync server unrelated to this PR.