### PR TITLE
Revert "Switching from UNAUTHENTICATED to UNAVAILABLE for auth metadata failure"

### DIFF
--- a/src/core/lib/security/transport/client_auth_filter.cc
+++ b/src/core/lib/security/transport/client_auth_filter.cc
@@ -113,7 +113,7 @@ static void on_credentials_metadata(grpc_exec_ctx* exec_ctx, void* arg,
     grpc_call_next_op(exec_ctx, elem, batch);
   } else {
     error = grpc_error_set_int(error, GRPC_ERROR_INT_GRPC_STATUS,
-                               GRPC_STATUS_UNAVAILABLE);
+                               GRPC_STATUS_UNAUTHENTICATED);
     grpc_transport_stream_op_batch_finish_with_failure(exec_ctx, batch, error,
                                                        calld->call_combiner);
   }

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -1594,7 +1594,7 @@ TEST_P(SecureEnd2endTest, AuthMetadataPluginKeyFailure) {
 
   Status s = stub_->Echo(&context, request, &response);
   EXPECT_FALSE(s.ok());
-  EXPECT_EQ(s.error_code(), StatusCode::UNAVAILABLE);
+  EXPECT_EQ(s.error_code(), StatusCode::UNAUTHENTICATED);
 }
 
 TEST_P(SecureEnd2endTest, AuthMetadataPluginValueFailure) {
@@ -1611,7 +1611,7 @@ TEST_P(SecureEnd2endTest, AuthMetadataPluginValueFailure) {
 
   Status s = stub_->Echo(&context, request, &response);
   EXPECT_FALSE(s.ok());
-  EXPECT_EQ(s.error_code(), StatusCode::UNAVAILABLE);
+  EXPECT_EQ(s.error_code(), StatusCode::UNAUTHENTICATED);
 }
 
 TEST_P(SecureEnd2endTest, NonBlockingAuthMetadataPluginFailure) {
@@ -1629,7 +1629,7 @@ TEST_P(SecureEnd2endTest, NonBlockingAuthMetadataPluginFailure) {
 
   Status s = stub_->Echo(&context, request, &response);
   EXPECT_FALSE(s.ok());
-  EXPECT_EQ(s.error_code(), StatusCode::UNAVAILABLE);
+  EXPECT_EQ(s.error_code(), StatusCode::UNAUTHENTICATED);
   EXPECT_EQ(s.error_message(),
             grpc::string("Getting metadata from plugin failed with error: ") +
                 kTestCredsPluginErrorMsg);
@@ -1690,7 +1690,7 @@ TEST_P(SecureEnd2endTest, BlockingAuthMetadataPluginFailure) {
 
   Status s = stub_->Echo(&context, request, &response);
   EXPECT_FALSE(s.ok());
-  EXPECT_EQ(s.error_code(), StatusCode::UNAVAILABLE);
+  EXPECT_EQ(s.error_code(), StatusCode::UNAUTHENTICATED);
   EXPECT_EQ(s.error_message(),
             grpc::string("Getting metadata from plugin failed with error: ") +
                 kTestCredsPluginErrorMsg);


### PR DESCRIPTION
Reverts grpc/grpc#13322

The PR changes call statuses without updating tests for all languages. There are breakages at least in C#, Ruby and PHP (on all platforms).

E.g. in c#
```
1) Failed : Grpc.IntegrationTesting.MetadataCredentialsTest.MetadataCredentials_InterceptorThrows
  Expected: Unauthenticated
  But was:  Unavailable
at Grpc.IntegrationTesting.MetadataCredentialsTest.MetadataCredentials_InterceptorThrows()
```