### PR TITLE
Remove node benchmarks from run performance script.

### DIFF
--- a/tools/jenkins/run_full_performance.sh
+++ b/tools/jenkins/run_full_performance.sh
@@ -21,7 +21,7 @@ cd $(dirname $0)/../..
 
 # run 8core client vs 8core server
 tools/run_tests/run_performance_tests.py \
-    -l c++ csharp node ruby java python go node_express php7 php7_protobuf_c \
+    -l c++ csharp ruby java python go php7 php7_protobuf_c \
     --netperf \
     --category scalable \
     --bq_result_table performance_test.performance_experiment \


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/13347.

After doing the next release, we will also need to update 
https://github.com/grpc/grpc/blob/master/tools/jenkins/run_full_performance_released.sh
