### PR TITLE
Add a connectivity state test for a channel with no server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,7 @@ add_dependencies(buildtests_c secure_endpoint_test)
 add_dependencies(buildtests_c sequential_connectivity_test)
 add_dependencies(buildtests_c server_chttp2_test)
 add_dependencies(buildtests_c server_test)
+add_dependencies(buildtests_c serverless_connectivity_test)
 add_dependencies(buildtests_c slice_buffer_test)
 add_dependencies(buildtests_c slice_hash_table_test)
 add_dependencies(buildtests_c slice_string_helpers_test)
@@ -8312,6 +8313,36 @@ target_include_directories(server_test
 )
 
 target_link_libraries(server_test
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc_test_util
+  grpc
+  gpr_test_util
+  gpr
+)
+
+endif (gRPC_BUILD_TESTS)
+if (gRPC_BUILD_TESTS)
+
+add_executable(serverless_connectivity_test
+  test/core/surface/serverless_connectivity_test.cc
+)
+
+
+target_include_directories(serverless_connectivity_test
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+  PRIVATE ${BORINGSSL_ROOT_DIR}/include
+  PRIVATE ${PROTOBUF_ROOT_DIR}/src
+  PRIVATE ${BENCHMARK_ROOT_DIR}/include
+  PRIVATE ${ZLIB_ROOT_DIR}
+  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/third_party/zlib
+  PRIVATE ${CARES_INCLUDE_DIR}
+  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/third_party/cares/cares
+  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/third_party/gflags/include
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/third_party/abseil-cpp
+)
+
+target_link_libraries(serverless_connectivity_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc

--- a/Makefile
+++ b/Makefile
@@ -1064,6 +1064,7 @@ sequential_connectivity_test: $(BINDIR)/$(CONFIG)/sequential_connectivity_test
 server_chttp2_test: $(BINDIR)/$(CONFIG)/server_chttp2_test
 server_fuzzer: $(BINDIR)/$(CONFIG)/server_fuzzer
 server_test: $(BINDIR)/$(CONFIG)/server_test
+serverless_connectivity_test: $(BINDIR)/$(CONFIG)/serverless_connectivity_test
 slice_buffer_test: $(BINDIR)/$(CONFIG)/slice_buffer_test
 slice_hash_table_test: $(BINDIR)/$(CONFIG)/slice_hash_table_test
 slice_string_helpers_test: $(BINDIR)/$(CONFIG)/slice_string_helpers_test
@@ -1443,6 +1444,7 @@ buildtests_c: privatelibs_c \
   $(BINDIR)/$(CONFIG)/sequential_connectivity_test \
   $(BINDIR)/$(CONFIG)/server_chttp2_test \
   $(BINDIR)/$(CONFIG)/server_test \
+  $(BINDIR)/$(CONFIG)/serverless_connectivity_test \
   $(BINDIR)/$(CONFIG)/slice_buffer_test \
   $(BINDIR)/$(CONFIG)/slice_hash_table_test \
   $(BINDIR)/$(CONFIG)/slice_string_helpers_test \
@@ -1938,6 +1940,8 @@ test_c: buildtests_c
 	$(Q) $(BINDIR)/$(CONFIG)/server_chttp2_test || ( echo test server_chttp2_test failed ; exit 1 )
 	$(E) "[RUN]     Testing server_test"
 	$(Q) $(BINDIR)/$(CONFIG)/server_test || ( echo test server_test failed ; exit 1 )
+	$(E) "[RUN]     Testing serverless_connectivity_test"
+	$(Q) $(BINDIR)/$(CONFIG)/serverless_connectivity_test || ( echo test serverless_connectivity_test failed ; exit 1 )
 	$(E) "[RUN]     Testing slice_buffer_test"
 	$(Q) $(BINDIR)/$(CONFIG)/slice_buffer_test || ( echo test slice_buffer_test failed ; exit 1 )
 	$(E) "[RUN]     Testing slice_hash_table_test"
@@ -12506,6 +12510,38 @@ deps_server_test: $(SERVER_TEST_OBJS:.o=.dep)
 ifneq ($(NO_SECURE),true)
 ifneq ($(NO_DEPS),true)
 -include $(SERVER_TEST_OBJS:.o=.dep)
+endif
+endif
+
+
+SERVERLESS_CONNECTIVITY_TEST_SRC = \
+    test/core/surface/serverless_connectivity_test.cc \
+
+SERVERLESS_CONNECTIVITY_TEST_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(SERVERLESS_CONNECTIVITY_TEST_SRC))))
+ifeq ($(NO_SECURE),true)
+
+# You can't build secure targets if you don't have OpenSSL.
+
+$(BINDIR)/$(CONFIG)/serverless_connectivity_test: openssl_dep_error
+
+else
+
+
+
+$(BINDIR)/$(CONFIG)/serverless_connectivity_test: $(SERVERLESS_CONNECTIVITY_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) $(LD) $(LDFLAGS) $(SERVERLESS_CONNECTIVITY_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LDLIBS) $(LDLIBS_SECURE) -o $(BINDIR)/$(CONFIG)/serverless_connectivity_test
+
+endif
+
+$(OBJDIR)/$(CONFIG)/test/core/surface/serverless_connectivity_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
+
+deps_serverless_connectivity_test: $(SERVERLESS_CONNECTIVITY_TEST_OBJS:.o=.dep)
+
+ifneq ($(NO_SECURE),true)
+ifneq ($(NO_DEPS),true)
+-include $(SERVERLESS_CONNECTIVITY_TEST_OBJS:.o=.dep)
 endif
 endif
 

--- a/build.yaml
+++ b/build.yaml
@@ -3055,6 +3055,16 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+- name: serverless_connectivity_test
+  build: test
+  language: c
+  src:
+  - test/core/surface/serverless_connectivity_test.cc
+  deps:
+  - grpc_test_util
+  - grpc
+  - gpr_test_util
+  - gpr
 - name: slice_buffer_test
   build: test
   language: c

--- a/test/core/surface/serverless_connectivity_test.cc
+++ b/test/core/surface/serverless_connectivity_test.cc
@@ -1,0 +1,113 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpc/grpc.h>
+#include <grpc/grpc_security.h>
+#include <grpc/support/alloc.h>
+#include <grpc/support/host_port.h>
+#include <grpc/support/log.h>
+
+#include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/iomgr/exec_ctx.h"
+#include "test/core/end2end/data/ssl_test_data.h"
+#include "test/core/util/port.h"
+#include "test/core/util/test_config.h"
+
+typedef struct test_fixture {
+  const char* name;
+  grpc_channel* (*create_channel)(const char* addr);
+} test_fixture;
+
+#define NUM_CONNECTIONS 1000
+
+static void run_test(const test_fixture* fixture) {
+  gpr_log(GPR_INFO, "TEST: %s", fixture->name);
+
+  grpc_init();
+
+  char* addr;
+  gpr_join_host_port(&addr, "localhost", grpc_pick_unused_port_or_die());
+
+  grpc_completion_queue* cq = grpc_completion_queue_create_for_next(NULL);
+  grpc_channel* channel = fixture->create_channel(addr);
+  gpr_timespec connect_deadline = grpc_timeout_seconds_to_deadline(30);
+  grpc_connectivity_state state =
+      grpc_channel_check_connectivity_state(channel, 0);
+  grpc_channel_watch_connectivity_state(channel, state, connect_deadline, cq,
+                                        NULL);
+  // Start connecting after calling watch_connectivity_state
+  grpc_channel_check_connectivity_state(channel, 1);
+  grpc_event ev =
+      grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME), NULL);
+  GPR_ASSERT(grpc_channel_num_external_connectivity_watchers(channel) == 0);
+  GPR_ASSERT(ev.type == GRPC_OP_COMPLETE);
+  GPR_ASSERT(ev.tag == NULL);
+  GPR_ASSERT(ev.success == true);
+  grpc_channel_destroy(channel);
+
+  grpc_completion_queue_shutdown(cq);
+  while (
+      grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME), NULL)
+          .type != GRPC_QUEUE_SHUTDOWN)
+    ;
+  grpc_completion_queue_destroy(cq);
+
+  grpc_shutdown();
+  gpr_free(addr);
+}
+
+static grpc_channel* insecure_test_create_channel(const char* addr) {
+  return grpc_insecure_channel_create(addr, NULL, NULL);
+}
+
+static const test_fixture insecure_test = {
+    "insecure",
+    insecure_test_create_channel,
+};
+
+static grpc_channel* secure_test_create_channel(const char* addr) {
+  grpc_channel_credentials* ssl_creds =
+      grpc_ssl_credentials_create(test_root_cert, NULL, NULL);
+  grpc_arg ssl_name_override = {
+      GRPC_ARG_STRING,
+      const_cast<char*>(GRPC_SSL_TARGET_NAME_OVERRIDE_ARG),
+      {const_cast<char*>("foo.test.google.fr")}};
+  grpc_channel_args* new_client_args =
+      grpc_channel_args_copy_and_add(NULL, &ssl_name_override, 1);
+  grpc_channel* channel =
+      grpc_secure_channel_create(ssl_creds, addr, new_client_args, NULL);
+  {
+    grpc_exec_ctx exec_ctx = GRPC_EXEC_CTX_INIT;
+    grpc_channel_args_destroy(&exec_ctx, new_client_args);
+    grpc_exec_ctx_finish(&exec_ctx);
+  }
+  grpc_channel_credentials_release(ssl_creds);
+  return channel;
+}
+
+static const test_fixture secure_test = {
+    "secure",
+    secure_test_create_channel,
+};
+
+int main(int argc, char** argv) {
+  grpc_test_init(argc, argv);
+
+  run_test(&insecure_test);
+  run_test(&secure_test);
+}

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -1988,6 +1988,23 @@
     "headers": [], 
     "is_filegroup": false, 
     "language": "c", 
+    "name": "serverless_connectivity_test", 
+    "src": [
+      "test/core/surface/serverless_connectivity_test.cc"
+    ], 
+    "third_party": false, 
+    "type": "target"
+  }, 
+  {
+    "deps": [
+      "gpr", 
+      "gpr_test_util", 
+      "grpc", 
+      "grpc_test_util"
+    ], 
+    "headers": [], 
+    "is_filegroup": false, 
+    "language": "c", 
     "name": "slice_buffer_test", 
     "src": [
       "test/core/slice/slice_buffer_test.cc"

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -2254,6 +2254,30 @@
     "flaky": false, 
     "gtest": false, 
     "language": "c", 
+    "name": "serverless_connectivity_test", 
+    "platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "uses_polling": true
+  }, 
+  {
+    "args": [], 
+    "benchmark": false, 
+    "ci_platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "cpu_cost": 1.0, 
+    "exclude_configs": [], 
+    "exclude_iomgrs": [], 
+    "flaky": false, 
+    "gtest": false, 
+    "language": "c", 
     "name": "slice_buffer_test", 
     "platforms": [
       "linux", 


### PR DESCRIPTION
The primary goal here is to attempt to reproduce the failure in #12932 without Node. The test here is based on the `sequential_connectivity_test.cc` file in the same directory.