### PR TITLE
Allow bazel builds to disable c-ares at command line or bazelrc

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -33,6 +33,11 @@ load(
     "grpc_generate_one_off_targets",
 )
 
+config_setting(
+    name = "grpc_no_ares",
+    values = {"define": "grpc_no_ares=true"},
+)
+
 # This should be updated along with build.yaml
 g_stands_for = "generous"
 

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -33,6 +33,10 @@ def grpc_cc_library(name, srcs = [], public_hdrs = [], hdrs = [],
   native.cc_library(
     name = name,
     srcs = srcs,
+    defines = select({
+        "//:grpc_no_ares": ["GRPC_ARES=0"],
+	"//conditions:default": [],
+    }),
     hdrs = hdrs + public_hdrs,
     deps = deps + ["//external:" + dep for dep in external_deps],
     copts = copts,


### PR DESCRIPTION
This works much better than attempting to do this as a bazel.rc file change as was attempted in tensorflow/tensorflow#13958
