### PR TITLE
Restructure plugin builds to avoid building more than needed

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -311,36 +311,12 @@ grpc_cc_library(
 
 grpc_cc_library(
     name = "grpc_plugin_support",
-    srcs = [
-        "src/compiler/cpp_generator.cc",
-        "src/compiler/csharp_generator.cc",
-        "src/compiler/node_generator.cc",
-        "src/compiler/objective_c_generator.cc",
-        "src/compiler/php_generator.cc",
-        "src/compiler/python_generator.cc",
-        "src/compiler/ruby_generator.cc",
-    ],
     hdrs = [
         "src/compiler/config.h",
-        "src/compiler/cpp_generator.h",
         "src/compiler/cpp_generator_helpers.h",
-        "src/compiler/csharp_generator.h",
-        "src/compiler/csharp_generator_helpers.h",
         "src/compiler/generator_helpers.h",
-        "src/compiler/node_generator.h",
-        "src/compiler/node_generator_helpers.h",
-        "src/compiler/objective_c_generator.h",
-        "src/compiler/objective_c_generator_helpers.h",
-        "src/compiler/php_generator.h",
-        "src/compiler/php_generator_helpers.h",
         "src/compiler/protobuf_plugin.h",
-        "src/compiler/python_generator.h",
         "src/compiler/python_generator_helpers.h",
-        "src/compiler/python_private_generator.h",
-        "src/compiler/ruby_generator.h",
-        "src/compiler/ruby_generator_helpers-inl.h",
-        "src/compiler/ruby_generator_map-inl.h",
-        "src/compiler/ruby_generator_string-inl.h",
         "src/compiler/schema_interface.h",
     ],
     external_deps = [
@@ -354,43 +330,93 @@ grpc_cc_library(
 
 grpc_proto_plugin(
     name = "grpc_cpp_plugin",
-    srcs = ["src/compiler/cpp_plugin.cc"],
+    srcs = [
+        "src/compiler/cpp_generator.cc",
+        "src/compiler/cpp_plugin.cc",
+    ],
+    hdrs = [
+        "src/compiler/cpp_generator.h",
+    ],
     deps = [":grpc_plugin_support"],
 )
 
 grpc_proto_plugin(
     name = "grpc_csharp_plugin",
-    srcs = ["src/compiler/csharp_plugin.cc"],
+    srcs = [
+        "src/compiler/csharp_generator.cc",
+        "src/compiler/csharp_plugin.cc",
+    ],
+    hdrs = [
+        "src/compiler/csharp_generator.h",
+        "src/compiler/csharp_generator_helpers.h",
+    ],
     deps = [":grpc_plugin_support"],
 )
 
 grpc_proto_plugin(
     name = "grpc_node_plugin",
-    srcs = ["src/compiler/node_plugin.cc"],
+    srcs = [
+        "src/compiler/node_generator.cc",
+        "src/compiler/node_plugin.cc",
+    ],
+    hdrs = [
+        "src/compiler/node_generator.h",
+        "src/compiler/node_generator_helpers.h",
+    ],
     deps = [":grpc_plugin_support"],
 )
 
 grpc_proto_plugin(
     name = "grpc_objective_c_plugin",
-    srcs = ["src/compiler/objective_c_plugin.cc"],
+    srcs = [
+        "src/compiler/objective_c_generator.cc",
+        "src/compiler/objective_c_plugin.cc",
+    ],
+    hdrs = [
+        "src/compiler/objective_c_generator.h",
+        "src/compiler/objective_c_generator_helpers.h",
+    ],
     deps = [":grpc_plugin_support"],
 )
 
 grpc_proto_plugin(
     name = "grpc_php_plugin",
-    srcs = ["src/compiler/php_plugin.cc"],
+    srcs = [
+        "src/compiler/php_generator.cc",
+        "src/compiler/php_plugin.cc",
+    ],
+    hdrs = [
+        "src/compiler/php_generator.h",
+        "src/compiler/php_generator_helpers.h",
+    ],
     deps = [":grpc_plugin_support"],
 )
 
 grpc_proto_plugin(
     name = "grpc_python_plugin",
-    srcs = ["src/compiler/python_plugin.cc"],
+    srcs = [
+        "src/compiler/python_generator.cc",
+        "src/compiler/python_plugin.cc",
+    ],
+    hdrs = [
+        "src/compiler/python_generator.h",
+        "src/compiler/python_private_generator.h",
+    ],
     deps = [":grpc_plugin_support"],
 )
 
 grpc_proto_plugin(
     name = "grpc_ruby_plugin",
-    srcs = ["src/compiler/ruby_plugin.cc"],
+    srcs = [
+        "src/compiler/ruby_generator.cc",
+        "src/compiler/ruby_plugin.cc",
+    ],
+    hdrs = [
+        "src/compiler/ruby_generator.h",
+        "src/compiler/ruby_generator_helpers-inl.h",
+        "src/compiler/ruby_generator_map-inl.h",
+        "src/compiler/ruby_generator_string-inl.h",
+    ],
     deps = [":grpc_plugin_support"],
 )
 

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -45,10 +45,10 @@ def grpc_cc_library(name, srcs = [], public_hdrs = [], hdrs = [],
     alwayslink = alwayslink,
   )
 
-def grpc_proto_plugin(name, srcs = [], deps = []):
+def grpc_proto_plugin(name, srcs = [], hdrs = [], deps = []):
   native.cc_binary(
     name = name,
-    srcs = srcs,
+    srcs = srcs + hdrs,
     deps = deps,
   )
 

--- a/src/compiler/protobuf_plugin.h
+++ b/src/compiler/protobuf_plugin.h
@@ -22,7 +22,6 @@
 #include "src/compiler/config.h"
 #include "src/compiler/cpp_generator_helpers.h"
 #include "src/compiler/python_generator_helpers.h"
-#include "src/compiler/python_private_generator.h"
 #include "src/compiler/schema_interface.h"
 
 #include <vector>

--- a/src/compiler/python_generator_helpers.h
+++ b/src/compiler/python_generator_helpers.h
@@ -26,8 +26,6 @@
 
 #include "src/compiler/config.h"
 #include "src/compiler/generator_helpers.h"
-#include "src/compiler/python_generator.h"
-#include "src/compiler/python_private_generator.h"
 
 using grpc::protobuf::Descriptor;
 using grpc::protobuf::FileDescriptor;


### PR DESCRIPTION
It violates POLA to build the ruby generator when explicitly requesting grpc_cpp_plugin . Changing that behavior.
