### PR TITLE
Make stats_test.IncHistogram skip values far from boundaries

### DIFF
--- a/test/core/debug/stats_test.cc
+++ b/test/core/debug/stats_test.cc
@@ -109,11 +109,12 @@ TEST_P(HistogramTest, IncHistogram) {
     }
   };
   std::vector<int> test_values;
-  for (int j = -1000;
-       j < grpc_stats_histo_bucket_boundaries
-                   [kHistogram][grpc_stats_histo_buckets[kHistogram] - 1] +
-               1000;
-       j++) {
+  // largest bucket boundary for current histogram type.
+  int max_bucket_boundary =
+      grpc_stats_histo_bucket_boundaries[kHistogram]
+                                        [grpc_stats_histo_buckets[kHistogram] -
+                                         1];
+  for (int j = -1000; j < max_bucket_boundary + 1000;) {
     int expected_bucket = FindExpectedBucket(kHistogram, j);
     if (cur_bucket != expected_bucket) {
       threads.emplace_back(
@@ -122,6 +123,14 @@ TEST_P(HistogramTest, IncHistogram) {
       test_values.clear();
     }
     test_values.push_back(j);
+    if (j < max_bucket_boundary &&
+        FindExpectedBucket(kHistogram, j + 1000) == expected_bucket &&
+        FindExpectedBucket(kHistogram, j - 1000) == expected_bucket) {
+      // if we are far from bucket boundary, skip values to speed-up the tests
+      j += 500;
+    } else {
+      j++;
+    }
   }
   run(test_values, cur_bucket);
   for (auto& t : threads) {


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/13155.

(basically for large buckets, it skips some middle values and only checks one by one when close to bucket boundary - see analysis in #13155).