### PR TITLE
Clang fix-errors

### DIFF
--- a/tools/distrib/run_clang_tidy.py
+++ b/tools/distrib/run_clang_tidy.py
@@ -59,7 +59,7 @@ cmdline = [
 ]
 
 if args.fix:
-  cmdline.append('--fix')
+  cmdline.append('--fix-errors')
 
 jobs = []
 for filename in args.files:


### PR DESCRIPTION
I think we want fix errors here. just `--fix` wasn't working for me

I think this is because:
```
Without -fix-errors
clang-tidy will bail out if any compilation
errors were found.
```

And we are using `warnings-as-errors`, so even things like NULL cause compilation errors