### PR TITLE
Flow control fixes

### DIFF
--- a/src/core/ext/transport/chttp2/transport/flow_control.cc
+++ b/src/core/ext/transport/chttp2/transport/flow_control.cc
@@ -310,13 +310,11 @@ double TransportFlowControl::SmoothLogBdp(grpc_exec_ctx* exec_ctx,
                                           double value) {
   grpc_millis now = grpc_exec_ctx_now(exec_ctx);
   double bdp_error = value - pid_controller_.last_control_value();
-  double dt = (double)(now - last_pid_update_) * 1e-3;
-  // Limit dt to 100ms
-  if (dt > 0.1) {
-    dt = 0.1;
-  }
+  const double dt = (double)(now - last_pid_update_) * 1e-3;
   last_pid_update_ = now;
-  return pid_controller_.Update(bdp_error, dt);
+  // Limit dt to 100ms
+  const double kMaxDt = 0.1;
+  return pid_controller_.Update(bdp_error, dt > kMaxDt ? kMaxDt : dt);
 }
 
 FlowControlAction::Urgency TransportFlowControl::DeltaUrgency(

--- a/src/core/ext/transport/chttp2/transport/flow_control.cc
+++ b/src/core/ext/transport/chttp2/transport/flow_control.cc
@@ -310,7 +310,11 @@ double TransportFlowControl::SmoothLogBdp(grpc_exec_ctx* exec_ctx,
                                           double value) {
   grpc_millis now = grpc_exec_ctx_now(exec_ctx);
   double bdp_error = value - pid_controller_.last_control_value();
-  const double dt = (double)(now - last_pid_update_) * 1e-3;
+  double dt = (double)(now - last_pid_update_) * 1e-3;
+  // Limit dt to 100ms
+  if (dt > 0.1) {
+    dt = 0.1;
+  }
   last_pid_update_ = now;
   return pid_controller_.Update(bdp_error, dt);
 }

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -322,7 +322,7 @@ class DataSendContext {
         GPR_MIN(stream_remote_window(), t_->flow_control->remote_window()));
   }
 
-  bool AnyOutgoing() const { return max_outgoing() != 0; }
+  bool AnyOutgoing() const { return max_outgoing() > 0; }
 
   void FlushCompressedBytes() {
     uint32_t send_bytes =


### PR DESCRIPTION
- Handle negative remote_window in `AnyOutgoing`
- Limit the imput dt of PID to 100ms in `TransportFlowControl::SmoothLogBdp`