### PR TITLE
Convert the input timespec to GPR_CLOCK_MONOTONIC at surface

### DIFF
--- a/src/core/ext/filters/client_channel/channel_connectivity.cc
+++ b/src/core/ext/filters/client_channel/channel_connectivity.cc
@@ -234,7 +234,7 @@ void grpc_channel_watch_connectivity_state(
   watcher_timer_init_arg* wa =
       (watcher_timer_init_arg*)gpr_malloc(sizeof(watcher_timer_init_arg));
   wa->w = w;
-  wa->deadline = deadline;
+  wa->deadline = gpr_convert_clock_type(deadline, GPR_CLOCK_MONOTONIC);
   GRPC_CLOSURE_INIT(&w->watcher_timer_init, watcher_timer_init, wa,
                     grpc_schedule_on_exec_ctx);
 

--- a/src/core/lib/surface/alarm.cc
+++ b/src/core/lib/surface/alarm.cc
@@ -126,7 +126,9 @@ void grpc_alarm_set(grpc_alarm* alarm, grpc_completion_queue* cq,
 
   GPR_ASSERT(grpc_cq_begin_op(cq, tag));
   grpc_timer_init(&exec_ctx, &alarm->alarm,
-                  grpc_timespec_to_millis_round_up(deadline), &alarm->on_alarm);
+                  grpc_timespec_to_millis_round_up(
+                      gpr_convert_clock_type(deadline, GPR_CLOCK_MONOTONIC)),
+                  &alarm->on_alarm);
   grpc_exec_ctx_finish(&exec_ctx);
 }
 

--- a/src/core/lib/surface/channel.cc
+++ b/src/core/lib/surface/channel.cc
@@ -308,7 +308,8 @@ grpc_call* grpc_channel_create_call(grpc_channel* channel,
       host != nullptr ? grpc_mdelem_from_slices(&exec_ctx, GRPC_MDSTR_AUTHORITY,
                                                 grpc_slice_ref_internal(*host))
                       : GRPC_MDNULL,
-      grpc_timespec_to_millis_round_up(deadline));
+      grpc_timespec_to_millis_round_up(
+          gpr_convert_clock_type(deadline, GPR_CLOCK_MONOTONIC)));
   grpc_exec_ctx_finish(&exec_ctx);
   return call;
 }
@@ -374,7 +375,8 @@ grpc_call* grpc_channel_create_registered_call(
   grpc_call* call = grpc_channel_create_call_internal(
       &exec_ctx, channel, parent_call, propagation_mask, completion_queue,
       nullptr, GRPC_MDELEM_REF(rc->path), GRPC_MDELEM_REF(rc->authority),
-      grpc_timespec_to_millis_round_up(deadline));
+      grpc_timespec_to_millis_round_up(
+          gpr_convert_clock_type(deadline, GPR_CLOCK_MONOTONIC)));
   grpc_exec_ctx_finish(&exec_ctx);
   return call;
 }

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -1042,7 +1042,8 @@ static void cq_shutdown_next(grpc_exec_ctx* exec_ctx,
 
 grpc_event grpc_completion_queue_next(grpc_completion_queue* cq,
                                       gpr_timespec deadline, void* reserved) {
-  return cq->vtable->next(cq, deadline, reserved);
+  return cq->vtable->next(
+      cq, gpr_convert_clock_type(deadline, GPR_CLOCK_MONOTONIC), reserved);
 }
 
 static int add_plucker(grpc_completion_queue* cq, void* tag,
@@ -1225,7 +1226,8 @@ done:
 
 grpc_event grpc_completion_queue_pluck(grpc_completion_queue* cq, void* tag,
                                        gpr_timespec deadline, void* reserved) {
-  return cq->vtable->pluck(cq, tag, deadline, reserved);
+  return cq->vtable->pluck(
+      cq, tag, gpr_convert_clock_type(deadline, GPR_CLOCK_MONOTONIC), reserved);
 }
 
 static void cq_finish_shutdown_pluck(grpc_exec_ctx* exec_ctx,


### PR DESCRIPTION
Input timepec with the type of GPR_CLOCK_REALTIME may be vulnerable at `grpc_timespec_to_millis_round_up/down`, as the system time may jump forwards or backwards, but `g_start_time[GPR_CLOCK_REALTIME]` may not be updated in time.

This may cost one `gpr_now()` at each invocation of these APIs, but preserves their correctness.