### PR TITLE
Revert "Restructure plugin builds to avoid building more than needed"

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -316,12 +316,36 @@ grpc_cc_library(
 
 grpc_cc_library(
     name = "grpc_plugin_support",
+    srcs = [
+        "src/compiler/cpp_generator.cc",
+        "src/compiler/csharp_generator.cc",
+        "src/compiler/node_generator.cc",
+        "src/compiler/objective_c_generator.cc",
+        "src/compiler/php_generator.cc",
+        "src/compiler/python_generator.cc",
+        "src/compiler/ruby_generator.cc",
+    ],
     hdrs = [
         "src/compiler/config.h",
+        "src/compiler/cpp_generator.h",
         "src/compiler/cpp_generator_helpers.h",
+        "src/compiler/csharp_generator.h",
+        "src/compiler/csharp_generator_helpers.h",
         "src/compiler/generator_helpers.h",
+        "src/compiler/node_generator.h",
+        "src/compiler/node_generator_helpers.h",
+        "src/compiler/objective_c_generator.h",
+        "src/compiler/objective_c_generator_helpers.h",
+        "src/compiler/php_generator.h",
+        "src/compiler/php_generator_helpers.h",
         "src/compiler/protobuf_plugin.h",
+        "src/compiler/python_generator.h",
         "src/compiler/python_generator_helpers.h",
+        "src/compiler/python_private_generator.h",
+        "src/compiler/ruby_generator.h",
+        "src/compiler/ruby_generator_helpers-inl.h",
+        "src/compiler/ruby_generator_map-inl.h",
+        "src/compiler/ruby_generator_string-inl.h",
         "src/compiler/schema_interface.h",
     ],
     external_deps = [
@@ -335,93 +359,43 @@ grpc_cc_library(
 
 grpc_proto_plugin(
     name = "grpc_cpp_plugin",
-    srcs = [
-        "src/compiler/cpp_generator.cc",
-        "src/compiler/cpp_plugin.cc",
-    ],
-    hdrs = [
-        "src/compiler/cpp_generator.h",
-    ],
+    srcs = ["src/compiler/cpp_plugin.cc"],
     deps = [":grpc_plugin_support"],
 )
 
 grpc_proto_plugin(
     name = "grpc_csharp_plugin",
-    srcs = [
-        "src/compiler/csharp_generator.cc",
-        "src/compiler/csharp_plugin.cc",
-    ],
-    hdrs = [
-        "src/compiler/csharp_generator.h",
-        "src/compiler/csharp_generator_helpers.h",
-    ],
+    srcs = ["src/compiler/csharp_plugin.cc"],
     deps = [":grpc_plugin_support"],
 )
 
 grpc_proto_plugin(
     name = "grpc_node_plugin",
-    srcs = [
-        "src/compiler/node_generator.cc",
-        "src/compiler/node_plugin.cc",
-    ],
-    hdrs = [
-        "src/compiler/node_generator.h",
-        "src/compiler/node_generator_helpers.h",
-    ],
+    srcs = ["src/compiler/node_plugin.cc"],
     deps = [":grpc_plugin_support"],
 )
 
 grpc_proto_plugin(
     name = "grpc_objective_c_plugin",
-    srcs = [
-        "src/compiler/objective_c_generator.cc",
-        "src/compiler/objective_c_plugin.cc",
-    ],
-    hdrs = [
-        "src/compiler/objective_c_generator.h",
-        "src/compiler/objective_c_generator_helpers.h",
-    ],
+    srcs = ["src/compiler/objective_c_plugin.cc"],
     deps = [":grpc_plugin_support"],
 )
 
 grpc_proto_plugin(
     name = "grpc_php_plugin",
-    srcs = [
-        "src/compiler/php_generator.cc",
-        "src/compiler/php_plugin.cc",
-    ],
-    hdrs = [
-        "src/compiler/php_generator.h",
-        "src/compiler/php_generator_helpers.h",
-    ],
+    srcs = ["src/compiler/php_plugin.cc"],
     deps = [":grpc_plugin_support"],
 )
 
 grpc_proto_plugin(
     name = "grpc_python_plugin",
-    srcs = [
-        "src/compiler/python_generator.cc",
-        "src/compiler/python_plugin.cc",
-    ],
-    hdrs = [
-        "src/compiler/python_generator.h",
-        "src/compiler/python_private_generator.h",
-    ],
+    srcs = ["src/compiler/python_plugin.cc"],
     deps = [":grpc_plugin_support"],
 )
 
 grpc_proto_plugin(
     name = "grpc_ruby_plugin",
-    srcs = [
-        "src/compiler/ruby_generator.cc",
-        "src/compiler/ruby_plugin.cc",
-    ],
-    hdrs = [
-        "src/compiler/ruby_generator.h",
-        "src/compiler/ruby_generator_helpers-inl.h",
-        "src/compiler/ruby_generator_map-inl.h",
-        "src/compiler/ruby_generator_string-inl.h",
-    ],
+    srcs = ["src/compiler/ruby_plugin.cc"],
     deps = [":grpc_plugin_support"],
 )
 

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -49,10 +49,10 @@ def grpc_cc_library(name, srcs = [], public_hdrs = [], hdrs = [],
     alwayslink = alwayslink,
   )
 
-def grpc_proto_plugin(name, srcs = [], hdrs = [], deps = []):
+def grpc_proto_plugin(name, srcs = [], deps = []):
   native.cc_binary(
     name = name,
-    srcs = srcs + hdrs,
+    srcs = srcs,
     deps = deps,
   )
 

--- a/src/compiler/protobuf_plugin.h
+++ b/src/compiler/protobuf_plugin.h
@@ -22,6 +22,7 @@
 #include "src/compiler/config.h"
 #include "src/compiler/cpp_generator_helpers.h"
 #include "src/compiler/python_generator_helpers.h"
+#include "src/compiler/python_private_generator.h"
 #include "src/compiler/schema_interface.h"
 
 #include <vector>

--- a/src/compiler/python_generator_helpers.h
+++ b/src/compiler/python_generator_helpers.h
@@ -26,6 +26,8 @@
 
 #include "src/compiler/config.h"
 #include "src/compiler/generator_helpers.h"
+#include "src/compiler/python_generator.h"
+#include "src/compiler/python_private_generator.h"
 
 using grpc::protobuf::Descriptor;
 using grpc::protobuf::FileDescriptor;


### PR DESCRIPTION
Reverts grpc/grpc#13359

This broke assumptions in an internal build file. It can be reverted painlessly since this was just a build optimization, not really fundamental.
