### PR TITLE
Add windows cmake distrib test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,6 +235,7 @@ if("${gRPC_SSL_PROVIDER}" STREQUAL "module")
 elseif("${gRPC_SSL_PROVIDER}" STREQUAL "package")
   find_package(OpenSSL REQUIRED)
   set(_gRPC_SSL_LIBRARIES ${OPENSSL_LIBRARIES})
+  include_directories(${OPENSSL_INCLUDE_DIR})
   set(_gRPC_FIND_SSL "if(NOT OPENSSL_FOUND)\n  find_package(OpenSSL)\nendif()")
 endif()
 

--- a/examples/cpp/helloworld/CMakeLists.txt
+++ b/examples/cpp/helloworld/CMakeLists.txt
@@ -6,12 +6,27 @@ project(HelloWorld C CXX)
 
 if(NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+else()
+  add_definitions(-D_WIN32_WINNT=0x600)
 endif()
 
 # Protobuf
-set(protobuf_MODULE_COMPATIBLE TRUE)
-find_package(protobuf CONFIG REQUIRED)
+# NOTE: we cannot use "CONFIG" mode here because protobuf-config.cmake
+# is broken when used with CMAKE_INSTALL_PREFIX
+find_package(protobuf REQUIRED)
 message(STATUS "Using protobuf ${protobuf_VERSION}")
+
+if(Protobuf_FOUND)
+  # Protobuf_FOUND is set for package type "CONFIG"
+  set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
+  set(_PROTOBUF_PROTOC protobuf::protoc)
+endif()
+if(PROTOBUF_FOUND)
+  # PROTOBUF_FOUND is set for package type "MODULE"
+  set(_PROTOBUF_LIBPROTOBUF ${PROTOBUF_LIBRARIES})
+  set(_PROTOBUF_PROTOC ${PROTOBUF_PROTOC_EXECUTABLE})
+  include_directories(${PROTOBUF_INCLUDE_DIRS})
+endif()
 
 # gRPC
 find_package(gRPC CONFIG REQUIRED)
@@ -31,7 +46,7 @@ set(hw_grpc_srcs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.cc")
 set(hw_grpc_hdrs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.h")
 add_custom_command(
       OUTPUT "${hw_grpc_srcs}" "${hw_grpc_hdrs}"
-      COMMAND protobuf::protoc
+      COMMAND ${_PROTOBUF_PROTOC}
       ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}" -I "${hw_proto_path}"
         --plugin=protoc-gen-grpc="${gRPC_CPP_PLUGIN_EXECUTABLE}"
         "${hw_proto}"
@@ -48,6 +63,6 @@ foreach(_target
     ${hw_proto_srcs}
     ${hw_grpc_srcs})
   target_link_libraries(${_target}
-    protobuf::libprotobuf
+    ${_PROTOBUF_LIBPROTOBUF}
     gRPC::grpc++_unsecure)
 endforeach()

--- a/examples/cpp/helloworld/CMakeLists.txt
+++ b/examples/cpp/helloworld/CMakeLists.txt
@@ -13,19 +13,20 @@ endif()
 # Protobuf
 # NOTE: we cannot use "CONFIG" mode here because protobuf-config.cmake
 # is broken when used with CMAKE_INSTALL_PREFIX
-find_package(protobuf REQUIRED)
+find_package(Protobuf REQUIRED)
 message(STATUS "Using protobuf ${protobuf_VERSION}")
 
 if(Protobuf_FOUND)
   # Protobuf_FOUND is set for package type "CONFIG"
   set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
   set(_PROTOBUF_PROTOC protobuf::protoc)
-endif()
-if(PROTOBUF_FOUND)
+elseif(PROTOBUF_FOUND)
   # PROTOBUF_FOUND is set for package type "MODULE"
   set(_PROTOBUF_LIBPROTOBUF ${PROTOBUF_LIBRARIES})
   set(_PROTOBUF_PROTOC ${PROTOBUF_PROTOC_EXECUTABLE})
   include_directories(${PROTOBUF_INCLUDE_DIRS})
+else()
+  message(WARNING "Failed to locate libprotobuf and protoc!")
 endif()
 
 # gRPC

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -280,6 +280,7 @@
   elseif("<%text>${gRPC_SSL_PROVIDER}</%text>" STREQUAL "package")
     find_package(OpenSSL REQUIRED)
     set(_gRPC_SSL_LIBRARIES <%text>${OPENSSL_LIBRARIES}</%text>)
+    include_directories(<%text>${OPENSSL_INCLUDE_DIR}</%text>)
     set(_gRPC_FIND_SSL "if(NOT OPENSSL_FOUND)\n  find_package(OpenSSL)\nendif()")
   endif()
 

--- a/test/distrib/cpp/run_distrib_test_cmake.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake.bat
@@ -1,0 +1,64 @@
+@rem Copyright 2016 gRPC authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+
+@rem enter this directory
+cd /d %~dp0\..\..\..
+
+@rem TODO(jtattermusch): use better install directory
+@rem set INSTALL_DIR=%cd%/testinstall
+set INSTALL_DIR=C:/testinstall
+
+cd third_party/zlib
+mkdir cmake
+cd cmake
+cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..
+cmake --build . --config Release --target install || goto :error
+cd ../../..
+
+cd third_party/protobuf/cmake
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -Dprotobuf_MSVC_STATIC_RUNTIME=OFF -Dprotobuf_BUILD_TESTS=OFF ..
+cmake --build . --config Release --target install || goto :error
+cd ../../../..
+
+cd third_party/cares/cares
+mkdir cmake
+cd cmake
+cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..
+cmake --build . --config Release --target install || goto :error
+cd ../../../..
+
+@rem TODO(jtattermusch): what do do with gflags
+@rem cd third_party/gflags/cmake
+@rem mkdir build
+@rem cd build
+@rem cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ../..
+@rem cmake --build . --config Release --target install || goto :error
+@rem cd ../../../..
+
+
+@rem OpenSSL-Win32 and OpenSSL-Win64 can be downloaded from https://slproweb.com/products/Win32OpenSSL.html
+cd cmake
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DOPENSSL_ROOT_DIR=C:/OpenSSL-Win32 -DOPENSSL_INCLUDE_DIR=C:/OpenSSL-Win32/include -DZLIB_LIBRARY=%INSTALL_DIR%/lib/zlibstatic.lib -DZLIB_INCLUDE_DIR=%INSTALL_DIR%/include -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DgRPC_PROTOBUF_PROVIDER=package -DgRPC_ZLIB_PROVIDER=package -DgRPC_CARES_PROVIDER=package -DgRPC_SSL_PROVIDER=package -DCMAKE_BUILD_TYPE=Release ../.. || goto :error
+cmake --build . --config Release --target install || goto :error
+cd ../..
+
+goto :EOF
+
+:error
+echo Failed!
+exit /b %errorlevel%

--- a/test/distrib/cpp/run_distrib_test_cmake.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake.bat
@@ -46,14 +46,6 @@ cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ..
 cmake --build . --config Release --target install || goto :error
 cd ../../../..
 
-@rem TODO(jtattermusch): what do do with gflags
-@rem cd third_party/gflags/cmake
-@rem mkdir build
-@rem cd build
-@rem cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ../..
-@rem cmake --build . --config Release --target install || goto :error
-@rem cd ../../../..
-
 @rem OpenSSL-Win32 and OpenSSL-Win64 can be downloaded from https://slproweb.com/products/Win32OpenSSL.html
 cd cmake
 mkdir build

--- a/test/distrib/cpp/run_distrib_test_cmake.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake.bat
@@ -57,6 +57,16 @@ cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DOPENSSL_ROOT_DIR=C:/OpenSSL-Win32 -
 cmake --build . --config Release --target install || goto :error
 cd ../..
 
+# Build helloworld example using cmake
+cd examples/cpp/helloworld
+mkdir cmake
+cd cmake
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% ../.. || goto :error
+cmake --build . --config Release || goto :error
+cd ../../../../..
+
 goto :EOF
 
 :error

--- a/test/distrib/cpp/run_distrib_test_cmake.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake.bat
@@ -15,6 +15,10 @@
 @rem enter this directory
 cd /d %~dp0\..\..\..
 
+@rem TODO(jtattermusch): Kokoro has pre-installed protoc.exe in C:\Program Files\ProtoC and that directory
+@rem is on PATH. To avoid picking up the older version protoc.exe, we change the path to something non-existent.
+set PATH=%PATH:ProtoC=DontPickupProtoC%
+
 @rem Install into ./testinstall, but use absolute path and foward slashes
 set INSTALL_DIR=%cd:\=/%/testinstall
 

--- a/test/distrib/cpp/run_distrib_test_cmake.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake.bat
@@ -15,9 +15,15 @@
 @rem enter this directory
 cd /d %~dp0\..\..\..
 
-@rem TODO(jtattermusch): use better install directory
-@rem set INSTALL_DIR=%cd%/testinstall
-set INSTALL_DIR=C:/testinstall
+@rem Install into ./testinstall, but use absolute path and foward slashes
+set INSTALL_DIR=%cd:\=/%/testinstall
+
+@rem Download OpenSSL-Win32 originally installed from https://slproweb.com/products/Win32OpenSSL.html
+powershell -Command "(New-Object Net.WebClient).DownloadFile('https://storage.googleapis.com/grpc-testing.appspot.com/OpenSSL-Win32-1_1_0g.zip', 'OpenSSL-Win32.zip')"
+powershell -Command "Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::ExtractToDirectory('OpenSSL-Win32.zip', '.');"
+
+@rem set absolute path to OpenSSL with forward slashes
+set OPENSSL_DIR=%cd:\=/%/OpenSSL-Win32
 
 cd third_party/zlib
 mkdir cmake
@@ -48,12 +54,11 @@ cd ../../../..
 @rem cmake --build . --config Release --target install || goto :error
 @rem cd ../../../..
 
-
 @rem OpenSSL-Win32 and OpenSSL-Win64 can be downloaded from https://slproweb.com/products/Win32OpenSSL.html
 cd cmake
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DOPENSSL_ROOT_DIR=C:/OpenSSL-Win32 -DOPENSSL_INCLUDE_DIR=C:/OpenSSL-Win32/include -DZLIB_LIBRARY=%INSTALL_DIR%/lib/zlibstatic.lib -DZLIB_INCLUDE_DIR=%INSTALL_DIR%/include -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DgRPC_PROTOBUF_PROVIDER=package -DgRPC_ZLIB_PROVIDER=package -DgRPC_CARES_PROVIDER=package -DgRPC_SSL_PROVIDER=package -DCMAKE_BUILD_TYPE=Release ../.. || goto :error
+cmake -DCMAKE_INSTALL_PREFIX=%INSTALL_DIR% -DOPENSSL_ROOT_DIR=%OPENSSL_DIR% -DOPENSSL_INCLUDE_DIR=%OPENSSL_DIR%/include -DZLIB_LIBRARY=%INSTALL_DIR%/lib/zlibstatic.lib -DZLIB_INCLUDE_DIR=%INSTALL_DIR%/include -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DgRPC_PROTOBUF_PROVIDER=package -DgRPC_ZLIB_PROVIDER=package -DgRPC_CARES_PROVIDER=package -DgRPC_SSL_PROVIDER=package -DCMAKE_BUILD_TYPE=Release ../.. || goto :error
 cmake --build . --config Release --target install || goto :error
 cd ../..
 

--- a/test/distrib/cpp/run_distrib_test_cmake.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake.sh
@@ -19,7 +19,6 @@ cd $(dirname $0)/../../..
 
 echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
 apt-get update
-#apt-get install -t jessie-backports -y libc-ares-dev  # we need specifically version 1.12
 apt-get install -t jessie-backports -y libssl-dev
 
 # Install c-ares


### PR DESCRIPTION
Adds a distrib test for:
- install gRPC prerequisites on windows using cmake
- install gRPC on windows using cmake
- build helloworld example on windows (using cmake).