### PR TITLE
Query for TXT service configs with _gprc_config prefix

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -431,7 +431,10 @@ static grpc_ares_request* grpc_dns_lookup_ares_impl(
   }
   if (service_config_json != nullptr) {
     grpc_ares_request_ref(r);
-    ares_search(*channel, hr->host, ns_c_in, ns_t_txt, on_txt_done_cb, r);
+    char* config_name;
+    gpr_asprintf(&config_name, "_grpc_config.%s", host);
+    ares_search(*channel, config_name, ns_c_in, ns_t_txt, on_txt_done_cb, r);
+    gpr_free(config_name);
   }
   /* TODO(zyc): Handle CNAME records here. */
   grpc_ares_ev_driver_start(exec_ctx, r->ev_driver);

--- a/test/cpp/naming/README.md
+++ b/test/cpp/naming/README.md
@@ -31,7 +31,7 @@ After making a change to `resolver_test_record_groups.yaml`:
 3. From the repo root, run:
 
 ```
-$ test/cpp/naming/create_dns_private_zone.sh
+$ test/cpp/naming/create_private_dns_zone.sh
 $ test/cpp/naming/private_dns_zone_init.sh
 ```
 

--- a/test/cpp/naming/create_private_dns_zone.sh
+++ b/test/cpp/naming/create_private_dns_zone.sh
@@ -20,8 +20,8 @@ set -ex
 cd $(dirname $0)/../../..
 
 gcloud alpha dns managed-zones create \
-  resolver-tests-version-1-grpctestingexp-zone-id \
-  --dns-name=resolver-tests-version-1.grpctestingexp. \
+  resolver-tests-version-4-grpctestingexp-zone-id \
+  --dns-name=resolver-tests-version-4.grpctestingexp. \
   --description="GCE-DNS-private-zone-for-GRPC-testing" \
   --visibility=private \
   --networks=default

--- a/test/cpp/naming/private_dns_zone_init.sh
+++ b/test/cpp/naming/private_dns_zone_init.sh
@@ -19,197 +19,197 @@ set -ex
 
 cd $(dirname $0)/../../..
 
-gcloud dns record-sets transaction start -z=resolver-tests-version-1-grpctestingexp-zone-id
+gcloud dns record-sets transaction start -z=resolver-tests-version-4-grpctestingexp-zone-id
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv4-single-target.resolver-tests-version-1.grpctestingexp."
+  "0 0 1234 ipv4-single-target.resolver-tests-version-4.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-single-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=ipv4-single-target.resolver-tests-version-4.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-4.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv4-multi-target.resolver-tests-version-1.grpctestingexp."
+  "0 0 1234 ipv4-multi-target.resolver-tests-version-4.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-multi-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=ipv4-multi-target.resolver-tests-version-4.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.5" "1.2.3.6" "1.2.3.7"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-4.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv6-single-target.resolver-tests-version-1.grpctestingexp."
+  "0 0 1234 ipv6-single-target.resolver-tests-version-4.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv6-single-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=ipv6-single-target.resolver-tests-version-4.grpctestingexp. \
   --type=AAAA \
   --ttl=2100 \
   "2607:f8b0:400a:801::1001"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-4.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv6-multi-target.resolver-tests-version-1.grpctestingexp."
+  "0 0 1234 ipv6-multi-target.resolver-tests-version-4.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv6-multi-target.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=ipv6-multi-target.resolver-tests-version-4.grpctestingexp. \
   --type=AAAA \
   --ttl=2100 \
   "2607:f8b0:400a:801::1002" "2607:f8b0:400a:801::1003" "2607:f8b0:400a:801::1004"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=_grpc_config.srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"SimpleService\",\"waitForReady\":true}]}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. \
-  --type=A \
-  --ttl=2100 \
-  "1.2.3.4"
-
-gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp."
+  "0 0 1234 ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "1.2.3.4"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=_grpc_config.ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"NoSrvSimpleService\",\"waitForReady\":true}]}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. \
-  --type=A \
-  --ttl=2100 \
-  "1.2.3.4"
-
-gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=_grpc_config.ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"clientLanguage\":[\"python\"],\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"PythonService\",\"waitForReady\":true}]}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "1.2.3.4"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=_grpc_config.ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"percentage\":0,\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"CppService\",\"waitForReady\":true}]}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. \
-  --type=A \
-  --ttl=2100 \
-  "1.2.3.4"
-
-gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=_grpc_config.ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"clientLanguage\":[\"go\"],\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"GoService\",\"waitForReady\":true}]}]}},{\"clientLanguage\":[\"c++\"],\"serviceConfig\":{" "\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"CppService\",\"waitForReady\":true}]}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. \
+  --type=A \
+  --ttl=2100 \
+  "1.2.3.4"
+
+gcloud dns record-sets transaction add \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=_grpc_config.ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"percentage\":0,\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"NeverPickedService\",\"waitForReady\":true}]}]}},{\"percentage\":100,\"serviceConfig\":{\"loadBalanc" "ingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"AlwaysPickedService\",\"waitForReady\":true}]}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp."
+  "0 0 1234 balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp."
+  "0 0 1234 balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. \
   --type=AAAA \
   --ttl=2100 \
   "2607:f8b0:400a:801::1002"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-1-grpctestingexp-zone-id \
-  --name=srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. \
+  -z=resolver-tests-version-4-grpctestingexp-zone-id \
+  --name=srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. \
   --type=AAAA \
   --ttl=2100 \
   "2607:f8b0:400a:801::1002"
 
-gcloud dns record-sets transaction describe -z=resolver-tests-version-1-grpctestingexp-zone-id
-gcloud dns record-sets transaction execute -z=resolver-tests-version-1-grpctestingexp-zone-id
-gcloud dns record-sets list -z=resolver-tests-version-1-grpctestingexp-zone-id
+gcloud dns record-sets transaction describe -z=resolver-tests-version-4-grpctestingexp-zone-id
+gcloud dns record-sets transaction execute -z=resolver-tests-version-4-grpctestingexp-zone-id
+gcloud dns record-sets list -z=resolver-tests-version-4-grpctestingexp-zone-id

--- a/test/cpp/naming/resolver_component_tests_runner.sh
+++ b/test/cpp/naming/resolver_component_tests_runner.sh
@@ -73,7 +73,7 @@ EXIT_CODE=0
 # in the resolver.
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -81,7 +81,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-multi-target.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.5:1234,True;1.2.3.6:1234,True;1.2.3.7:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -89,7 +89,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv6-single-target.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1001]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -97,7 +97,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv6-multi-target.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1003]:1234,True;[2607:f8b0:400a:801::1004]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -105,7 +105,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -113,7 +113,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -121,7 +121,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -129,7 +129,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -137,7 +137,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -145,7 +145,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -153,7 +153,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True;1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -161,7 +161,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1002]:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -169,7 +169,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-config-causing-fallback-to-tcp.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-config-causing-fallback-to-tcp.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='' \

--- a/test/cpp/naming/resolver_gce_integration_tests_runner.sh
+++ b/test/cpp/naming/resolver_gce_integration_tests_runner.sh
@@ -34,191 +34,191 @@ echo "Sanity check DNS records are resolveable with dig:"
 EXIT_CODE=0
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-single-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-single-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-single-target.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-multi-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-multi-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-multi-target.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig AAAA ipv6-single-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig AAAA ipv6-single-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig AAAA ipv6-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig AAAA ipv6-single-target.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig AAAA ipv6-multi-target.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig AAAA ipv6-multi-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig AAAA ipv6-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig AAAA ipv6-multi-target.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT _grpc_config.srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT _grpc_config.srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT _grpc_config.ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT _grpc_config.ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT _grpc_config.ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT _grpc_config.ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT _grpc_config.ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT _grpc_config.ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT _grpc_config.ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT _grpc_config.ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT _grpc_config.ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT _grpc_config.ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig A srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig AAAA balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig AAAA balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig AAAA balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig AAAA balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig AAAA srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig AAAA srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig AAAA srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Sanity check: dig AAAA srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
   exit 1
 fi
 
@@ -226,133 +226,133 @@ echo "Sanity check PASSED. Run resolver tests:"
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv4-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-multi-target.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.5:1234,True;1.2.3.6:1234,True;1.2.3.7:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv4-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv4-multi-target.resolver-tests-version-4.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv6-single-target.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1001]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv6-single-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv6-single-target.resolver-tests-version-4.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv6-multi-target.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1003]:1234,True;[2607:f8b0:400a:801::1004]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv6-multi-target.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv6-multi-target.resolver-tests-version-4.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv4-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-no-srv-simple-service-config.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-no-config-for-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-cpp-config-has-zero-percentage.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-second-language-is-cpp.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-config-with-percentages.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True;1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp.' \
+  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1002]:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-1.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 

--- a/test/cpp/naming/resolver_test_record_groups.yaml
+++ b/test/cpp/naming/resolver_test_record_groups.yaml
@@ -1,4 +1,4 @@
-resolver_tests_common_zone_name: resolver-tests-version-1.grpctestingexp.
+resolver_tests_common_zone_name: resolver-tests-version-4.grpctestingexp.
 resolver_component_tests:
 - expected_addrs:
   - {address: '1.2.3.4:1234', is_balancer: true}
@@ -58,7 +58,7 @@ resolver_component_tests:
     - {TTL: '2100', data: 0 0 1234 ipv4-simple-service-config, type: SRV}
     ipv4-simple-service-config:
     - {TTL: '2100', data: 1.2.3.4, type: A}
-    srv-ipv4-simple-service-config:
+    _grpc_config.srv-ipv4-simple-service-config:
     - {TTL: '2100', data: 'grpc_config=[{"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}}]',
       type: TXT}
 - expected_addrs:
@@ -69,6 +69,7 @@ resolver_component_tests:
   records:
     ipv4-no-srv-simple-service-config:
     - {TTL: '2100', data: 1.2.3.4, type: A}
+    _grpc_config.ipv4-no-srv-simple-service-config:
     - {TTL: '2100', data: 'grpc_config=[{"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}}]',
       type: TXT}
 - expected_addrs:
@@ -79,6 +80,7 @@ resolver_component_tests:
   records:
     ipv4-no-config-for-cpp:
     - {TTL: '2100', data: 1.2.3.4, type: A}
+    _grpc_config.ipv4-no-config-for-cpp:
     - {TTL: '2100', data: 'grpc_config=[{"clientLanguage":["python"],"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"PythonService","waitForReady":true}]}]}}]',
       type: TXT}
 - expected_addrs:
@@ -89,6 +91,7 @@ resolver_component_tests:
   records:
     ipv4-cpp-config-has-zero-percentage:
     - {TTL: '2100', data: 1.2.3.4, type: A}
+    _grpc_config.ipv4-cpp-config-has-zero-percentage:
     - {TTL: '2100', data: 'grpc_config=[{"percentage":0,"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}}]',
       type: TXT}
 - expected_addrs:
@@ -99,6 +102,7 @@ resolver_component_tests:
   records:
     ipv4-second-language-is-cpp:
     - {TTL: '2100', data: 1.2.3.4, type: A}
+    _grpc_config.ipv4-second-language-is-cpp:
     - {TTL: '2100', data: 'grpc_config=[{"clientLanguage":["go"],"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"GoService","waitForReady":true}]}]}},{"clientLanguage":["c++"],"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}}]',
       type: TXT}
 - expected_addrs:
@@ -109,6 +113,7 @@ resolver_component_tests:
   records:
     ipv4-config-with-percentages:
     - {TTL: '2100', data: 1.2.3.4, type: A}
+    _grpc_config.ipv4-config-with-percentages:
     - {TTL: '2100', data: 'grpc_config=[{"percentage":0,"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NeverPickedService","waitForReady":true}]}]}},{"percentage":100,"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}}]',
       type: TXT}
 - expected_addrs:
@@ -145,5 +150,6 @@ resolver_component_tests:
   records:
     ipv4-config-causing-fallback-to-tcp:
     - {TTL: '2100', data: 1.2.3.4, type: A}
+    _grpc_config.ipv4-config-causing-fallback-to-tcp:
     - {TTL: '2100', data: 'grpc_config=[{"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}}]',
       type: TXT}


### PR DESCRIPTION
Follow up for https://github.com/grpc/proposal/pull/44

Updated test records and added `_grpc_config` as prefix of TXT query. 

Waiting for tests against GCE in https://grpc-testing.appspot.com/job/gRPC_naming_Adhoc/210/

------

looks like tests against GCE DNS are successful