### PR TITLE
move grpc_assert_never_ok out of extern C block

### DIFF
--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -186,11 +186,6 @@ grpc_error* grpc_error_add_child(grpc_error* src,
 grpc_error* grpc_os_error(const char* file, int line, int err,
                           const char* call_name) GRPC_MUST_USE_RESULT;
 
-inline grpc_error* grpc_assert_never_ok(grpc_error* error) {
-  GPR_ASSERT(error != GRPC_ERROR_NONE);
-  return error;
-}
-
 /// create an error associated with errno!=0 (an 'operating system' error)
 #define GRPC_OS_ERROR(err, call_name) \
   grpc_assert_never_ok(grpc_os_error(__FILE__, __LINE__, err, call_name))
@@ -208,5 +203,10 @@ bool grpc_log_if_error(const char* what, grpc_error* error, const char* file,
 #ifdef __cplusplus
 }
 #endif
+
+inline grpc_error* grpc_assert_never_ok(grpc_error* error) {
+  GPR_ASSERT(error != GRPC_ERROR_NONE);
+  return error;
+}
 
 #endif /* GRPC_CORE_LIB_IOMGR_ERROR_H */


### PR DESCRIPTION
move grpc_assert_never_ok out of extern C block