### PR TITLE
Surface Error String to Wrapped Languages

### DIFF
--- a/include/grpc++/impl/codegen/call.h
+++ b/include/grpc++/impl/codegen/call.h
@@ -588,10 +588,12 @@ class CallOpClientRecvStatus {
       binary_error_details =
           grpc::string(iter->second.begin(), iter->second.length());
     }
-    *recv_status_ = Status(static_cast<StatusCode>(status_code_),
-                           grpc::string(GRPC_SLICE_START_PTR(error_message_),
-                                        GRPC_SLICE_END_PTR(error_message_)),
-                           binary_error_details, grpc::string(error_string_));
+    *recv_status_ =
+        Status(static_cast<StatusCode>(status_code_),
+               grpc::string(GRPC_SLICE_START_PTR(error_message_),
+                            GRPC_SLICE_END_PTR(error_message_)),
+               binary_error_details,
+               error_string_ != nullptr ? grpc::string(error_string_) : "");
     g_core_codegen_interface->grpc_slice_unref(error_message_);
     g_core_codegen_interface->gpr_free((void*)error_string_);
     recv_status_ = nullptr;

--- a/include/grpc++/impl/codegen/call.h
+++ b/include/grpc++/impl/codegen/call.h
@@ -574,7 +574,7 @@ class CallOpClientRecvStatus {
     op->data.recv_status_on_client.trailing_metadata = metadata_map_->arr();
     op->data.recv_status_on_client.status = &status_code_;
     op->data.recv_status_on_client.status_details = &error_message_;
-    op->data.recv_status_on_client.error_string = nullptr;
+    op->data.recv_status_on_client.error_string = &error_string_;
     op->flags = 0;
     op->reserved = NULL;
   }
@@ -591,14 +591,16 @@ class CallOpClientRecvStatus {
     *recv_status_ = Status(static_cast<StatusCode>(status_code_),
                            grpc::string(GRPC_SLICE_START_PTR(error_message_),
                                         GRPC_SLICE_END_PTR(error_message_)),
-                           binary_error_details);
+                           binary_error_details, grpc::string(error_string_));
     g_core_codegen_interface->grpc_slice_unref(error_message_);
+    g_core_codegen_interface->gpr_free((void*)error_string_);
     recv_status_ = nullptr;
   }
 
  private:
   MetadataMap* metadata_map_;
   Status* recv_status_;
+  const char* error_string_;
   grpc_status_code status_code_;
   grpc_slice error_message_;
 };

--- a/include/grpc++/impl/codegen/call.h
+++ b/include/grpc++/impl/codegen/call.h
@@ -558,7 +558,8 @@ class CallOpRecvInitialMetadata {
 
 class CallOpClientRecvStatus {
  public:
-  CallOpClientRecvStatus() : recv_status_(nullptr), error_string_(nullptr) {}
+  CallOpClientRecvStatus()
+      : recv_status_(nullptr), debug_error_string_(nullptr) {}
 
   void ClientRecvStatus(ClientContext* context, Status* status) {
     client_context_ = context;
@@ -575,7 +576,7 @@ class CallOpClientRecvStatus {
     op->data.recv_status_on_client.trailing_metadata = metadata_map_->arr();
     op->data.recv_status_on_client.status = &status_code_;
     op->data.recv_status_on_client.status_details = &error_message_;
-    op->data.recv_status_on_client.error_string = &error_string_;
+    op->data.recv_status_on_client.error_string = &debug_error_string_;
     op->flags = 0;
     op->reserved = NULL;
   }
@@ -594,10 +595,11 @@ class CallOpClientRecvStatus {
                                         GRPC_SLICE_END_PTR(error_message_)),
                            binary_error_details);
     client_context_->set_debug_error_string(
-        error_string_ != nullptr ? grpc::string(error_string_) : "");
+        debug_error_string_ != nullptr ? grpc::string(debug_error_string_)
+                                       : "");
     g_core_codegen_interface->grpc_slice_unref(error_message_);
-    if (error_string_ != nullptr) {
-      g_core_codegen_interface->gpr_free((void*)error_string_);
+    if (debug_error_string_ != nullptr) {
+      g_core_codegen_interface->gpr_free((void*)debug_error_string_);
     }
     recv_status_ = nullptr;
   }
@@ -606,7 +608,7 @@ class CallOpClientRecvStatus {
   ClientContext* client_context_;
   MetadataMap* metadata_map_;
   Status* recv_status_;
-  const char* error_string_;
+  const char* debug_error_string_;
   grpc_status_code status_code_;
   grpc_slice error_message_;
 };

--- a/include/grpc++/impl/codegen/call.h
+++ b/include/grpc++/impl/codegen/call.h
@@ -595,8 +595,7 @@ class CallOpClientRecvStatus {
                                         GRPC_SLICE_END_PTR(error_message_)),
                            binary_error_details);
     client_context_->set_debug_error_string(
-        debug_error_string_ != nullptr ? grpc::string(debug_error_string_)
-                                       : "");
+        debug_error_string_ != nullptr ? debug_error_string_ : "");
     g_core_codegen_interface->grpc_slice_unref(error_message_);
     if (debug_error_string_ != nullptr) {
       g_core_codegen_interface->gpr_free((void*)debug_error_string_);

--- a/include/grpc++/impl/codegen/client_context.h
+++ b/include/grpc++/impl/codegen/client_context.h
@@ -382,7 +382,7 @@ class ClientContext {
   friend class ::grpc::internal::BlockingUnaryCallImpl;
 
   // Used by friend class CallOpClientRecvStatus
-  void set_debug_error_string(grpc::string debug_error_string) {
+  void set_debug_error_string(const grpc::string& debug_error_string) {
     debug_error_string_ = debug_error_string;
   }
 

--- a/include/grpc++/impl/codegen/client_context.h
+++ b/include/grpc++/impl/codegen/client_context.h
@@ -348,6 +348,8 @@ class ClientContext {
   /// Applications never need to call this method.
   grpc_call* c_call() { return call_; }
 
+  grpc::string debug_error_string() const { return debug_error_string_; }
+
  private:
   // Disallow copy and assign.
   ClientContext(const ClientContext&);
@@ -373,6 +375,11 @@ class ClientContext {
   friend class ::grpc::ClientAsyncResponseReader;
   template <class InputMessage, class OutputMessage>
   friend class ::grpc::internal::BlockingUnaryCallImpl;
+
+  // Used by friend class CallOpClientRecvStatus
+  void set_debug_error_string(grpc::string debug_error_string) {
+    debug_error_string_ = debug_error_string;
+  }
 
   grpc_call* call() const { return call_; }
   void set_call(grpc_call* call, const std::shared_ptr<Channel>& channel);
@@ -412,6 +419,8 @@ class ClientContext {
 
   grpc_compression_algorithm compression_algorithm_;
   bool initial_metadata_corked_;
+
+  grpc::string debug_error_string_;
 };
 
 }  // namespace grpc

--- a/include/grpc++/impl/codegen/client_context.h
+++ b/include/grpc++/impl/codegen/client_context.h
@@ -348,6 +348,11 @@ class ClientContext {
   /// Applications never need to call this method.
   grpc_call* c_call() { return call_; }
 
+  /// EXPERIMENTAL debugging API
+  ///
+  /// if status is not ok() for an RPC, this will return a detailed string
+  /// of the gRPC Core error that led to the failure. It should not be relied
+  /// upon for anything other than gaining more debug data in failure cases.
   grpc::string debug_error_string() const { return debug_error_string_; }
 
  private:

--- a/include/grpc++/impl/codegen/status.h
+++ b/include/grpc++/impl/codegen/status.h
@@ -46,16 +46,6 @@ class Status {
         error_message_(error_message),
         binary_error_details_(error_details) {}
 
-  /// Construct an instance with \a code,  \a error_message and
-  /// \a error_details. It is an error to construct an OK status with non-empty
-  /// \a error_message and/or \a error_details.
-  Status(StatusCode code, const grpc::string& error_message,
-         const grpc::string& error_details, const grpc::string& error_string)
-      : code_(code),
-        error_message_(error_message),
-        binary_error_details_(error_details),
-        error_string_(error_string) {}
-
   // Pre-defined special status objects.
   /// An OK pre-defined instance.
   static const Status& OK;
@@ -69,8 +59,6 @@ class Status {
   /// Return the (binary) error details.
   // Usually it contains a serialized google.rpc.Status proto.
   grpc::string error_details() const { return binary_error_details_; }
-  /// Return the full fidelity error string, which includes all child errors.
-  grpc::string error_string() const { return error_string_; }
 
   /// Is the status OK?
   bool ok() const { return code_ == StatusCode::OK; }
@@ -84,7 +72,6 @@ class Status {
   StatusCode code_;
   grpc::string error_message_;
   grpc::string binary_error_details_;
-  grpc::string error_string_;
 };
 
 }  // namespace grpc

--- a/include/grpc++/impl/codegen/status.h
+++ b/include/grpc++/impl/codegen/status.h
@@ -46,6 +46,16 @@ class Status {
         error_message_(error_message),
         binary_error_details_(error_details) {}
 
+  /// Construct an instance with \a code,  \a error_message and
+  /// \a error_details. It is an error to construct an OK status with non-empty
+  /// \a error_message and/or \a error_details.
+  Status(StatusCode code, const grpc::string& error_message,
+         const grpc::string& error_details, const grpc::string& error_string)
+      : code_(code),
+        error_message_(error_message),
+        binary_error_details_(error_details),
+        error_string_(error_string) {}
+
   // Pre-defined special status objects.
   /// An OK pre-defined instance.
   static const Status& OK;
@@ -59,6 +69,8 @@ class Status {
   /// Return the (binary) error details.
   // Usually it contains a serialized google.rpc.Status proto.
   grpc::string error_details() const { return binary_error_details_; }
+  /// Return the full fidelity error string, which includes all child errors.
+  grpc::string error_string() const { return error_string_; }
 
   /// Is the status OK?
   bool ok() const { return code_ == StatusCode::OK; }
@@ -72,6 +84,7 @@ class Status {
   StatusCode code_;
   grpc::string error_message_;
   grpc::string binary_error_details_;
+  grpc::string error_string_;
 };
 
 }  // namespace grpc

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -741,6 +741,7 @@ TEST_P(End2endTest, RequestStreamOneRequest) {
   Status s = stream->Finish();
   EXPECT_EQ(response.message(), request.message());
   EXPECT_TRUE(s.ok());
+  EXPECT_TRUE(context.debug_error_string() == "");
 }
 
 TEST_P(End2endTest, RequestStreamOneRequestWithCoalescingApi) {
@@ -1258,6 +1259,13 @@ TEST_P(End2endTest, ExpectErrorTest) {
     EXPECT_EQ(iter->code(), s.error_code());
     EXPECT_EQ(iter->error_message(), s.error_message());
     EXPECT_EQ(iter->binary_error_details(), s.error_details());
+    EXPECT_TRUE(context.debug_error_string().find("created") !=
+                std::string::npos);
+    EXPECT_TRUE(context.debug_error_string().find("file") != std::string::npos);
+    EXPECT_TRUE(context.debug_error_string().find("line") != std::string::npos);
+    EXPECT_TRUE(context.debug_error_string().find("status") !=
+                std::string::npos);
+    EXPECT_TRUE(context.debug_error_string().find("13") != std::string::npos);
   }
 }
 

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -741,7 +741,7 @@ TEST_P(End2endTest, RequestStreamOneRequest) {
   Status s = stream->Finish();
   EXPECT_EQ(response.message(), request.message());
   EXPECT_TRUE(s.ok());
-  EXPECT_TRUE(context.debug_error_string() == "");
+  EXPECT_TRUE(context.debug_error_string().empty());
 }
 
 TEST_P(End2endTest, RequestStreamOneRequestWithCoalescingApi) {


### PR DESCRIPTION
Using #13364, this allows C++ users to get the full error string back from a status if an error occurred.

I will make separate PRs for each wrapped language

ongoing work for #13283 