### PR TITLE
Restart LB call after client load report completion, if needed.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1342,6 +1342,9 @@ static void client_load_report_done_locked(grpc_exec_ctx* exec_ctx, void* arg,
     glb_policy->client_load_report_timer_pending = false;
     GRPC_LB_POLICY_WEAK_UNREF(exec_ctx, &glb_policy->base,
                               "client_load_report");
+    if (glb_policy->lb_call == nullptr) {
+      maybe_restart_lb_call(exec_ctx, glb_policy);
+    }
     return;
   }
   schedule_next_client_load_report(exec_ctx, glb_policy);


### PR DESCRIPTION
Fixes #13350.

The problem here was that if the client load report completion callback was in flight when we received status, then we were not cleaning up.  We were already handling this properly if we received status when the client load report timer had not yet fired (see  `send_client_load_report_locked()`), but we were not handling the case where sending the load report itself was actually in flight.  This PR makes the logic in `client_load_report_done_locked()` match that of `send_client_load_report_locked()`.

Note that this is more than a simple memory leak; it could actually cause a client to fail to restart the LB call, thus continuing to use an increasingly stale serverlist.