### PR TITLE
C# benchmark improvements

### DIFF
--- a/src/csharp/Grpc.Core/Internal/GrpcThreadPool.cs
+++ b/src/csharp/Grpc.Core/Internal/GrpcThreadPool.cs
@@ -176,10 +176,10 @@ namespace Grpc.Core.Internal
                     try
                     {
                         var callback = cq.CompletionRegistry.Extract(tag);
-                        // Use cached delegates to avoid unnecessary allocations
+                        queuedContinuationCounter.Increment();
                         if (!inlineHandlers)
                         {
-                            queuedContinuationCounter.Increment();
+                            // Use cached delegates to avoid unnecessary allocations
                             ThreadPool.QueueUserWorkItem(success ? runCompletionQueueEventCallbackSuccess : runCompletionQueueEventCallbackFailure, callback);
                         }
                         else

--- a/src/csharp/Grpc.IntegrationTesting/ControlExtensions.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ControlExtensions.cs
@@ -1,0 +1,43 @@
+#region Copyright notice and license
+
+// Copyright 2016 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using Grpc.Core;
+using Grpc.Testing;
+
+namespace Grpc.IntegrationTesting
+{
+    /// <summary>
+    /// Helpers for Control.cs
+    /// </summary>
+    public static class ControlExtensions
+    {
+        public static ChannelOption ToChannelOption(this ChannelArg channelArgument)
+        {
+            switch (channelArgument.ValueCase)
+            {
+                case ChannelArg.ValueOneofCase.StrValue:
+                  return new ChannelOption(channelArgument.Name, channelArgument.StrValue);
+                case ChannelArg.ValueOneofCase.IntValue:
+                  return new ChannelOption(channelArgument.Name, channelArgument.IntValue);
+                default:
+                  throw new ArgumentException("Unsupported channel argument value.");
+            }
+        }
+    }
+}

--- a/src/csharp/Grpc.IntegrationTesting/ServerRunners.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ServerRunners.cs
@@ -78,7 +78,8 @@ namespace Grpc.IntegrationTesting
                 throw new ArgumentException("Unsupported ServerType");
             }
 
-            var server = new Server
+            var channelOptions = new List<ChannelOption>(config.ChannelArgs.Select((arg) => arg.ToChannelOption()));
+            var server = new Server(channelOptions)
             {
                 Services = { service },
                 Ports = { new ServerPort("[::]", config.Port, credentials) }


### PR DESCRIPTION
-- honor the "grpc.optimization_target" channel argument when set by scenario_config.py
-- balance out `queuedContinuationCounter` when inlineHandlers==true (values were only getting decremented, not incremented).