### PR TITLE
change use of directory as input to data field for to use of native.glob in grpc_fuzzer.bzl

### DIFF
--- a/test/core/util/grpc_fuzzer.bzl
+++ b/test/core/util/grpc_fuzzer.bzl
@@ -19,8 +19,7 @@ def grpc_fuzzer(name, corpus, srcs = [], deps = [], **kwargs):
     name = name,
     srcs = srcs,
     deps = deps + ["//test/core/util:fuzzer_corpus_test"],
-    data = [corpus],
-    args = ['--directory', '$(location %s)' % corpus],
+    data = native.glob([corpus + "/**"]),
     external_deps = [
       'gtest',
     ],


### PR DESCRIPTION
use of directory as input to data is not supported with experimental
remote execution build service.