### PR TITLE
Use lock when popping requests on server shutdown

### DIFF
--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -350,14 +350,8 @@ static void request_matcher_kill_requests(grpc_exec_ctx* exec_ctx,
                                           grpc_error* error) {
   requested_call* rc;
   for (size_t i = 0; i < server->cq_count; i++) {
-    /* Here we know:
-       1. no requests are being added (since the server is shut down)
-       2. no other threads are pulling (since the shut down process is single
-          threaded)
-       So, we can ignore the queue lock and just pop, with the guarantee that a
-       NULL returned here truly means that the queue is empty */
-    while ((rc = (requested_call*)gpr_mpscq_pop(
-                &rm->requests_per_cq[i].queue)) != nullptr) {
+    while ((rc = (requested_call*)gpr_locked_mpscq_pop(
+                &rm->requests_per_cq[i])) != nullptr) {
       fail_call(exec_ctx, server, i, rc, GRPC_ERROR_REF(error));
     }
   }


### PR DESCRIPTION
Doing this without a lock causes TSAN failures for quic.

There isn't much need to be clever here because this only impacts
shutdown performance, which doesn't really matter.