### PR TITLE
Alter build criterion for health/reflection packages

### DIFF
--- a/src/python/grpcio_health_checking/setup.py
+++ b/src/python/grpcio_health_checking/setup.py
@@ -60,23 +60,21 @@ INSTALL_REQUIRES = ('protobuf>=3.3.0',
                     'grpcio>={version}'.format(version=grpc_version.VERSION),)
 
 try:
-    # ensure we can load the _pb2_grpc module:
-    from grpc_health.v1 import health_pb2_grpc as _pb2_grpc
-    # if we can find the _pb2_grpc module, the package has already been built.
-    SETUP_REQUIRES = ()
-    COMMAND_CLASS = {
-        # wire up commands to no-op not to break the external dependencies
-        'preprocess': _NoOpCommand,
-        'build_package_protos': _NoOpCommand,
-    }
-except ImportError:  # we are in the build environment
     import health_commands as _health_commands
+    # we are in the build environment, otherwise the above import fails
     SETUP_REQUIRES = (
         'grpcio-tools=={version}'.format(version=grpc_version.VERSION),)
     COMMAND_CLASS = {
         # Run preprocess from the repository *before* doing any packaging!
         'preprocess': _health_commands.CopyProtoModules,
         'build_package_protos': _health_commands.BuildPackageProtos,
+    }
+except ImportError:
+    SETUP_REQUIRES = ()
+    COMMAND_CLASS = {
+        # wire up commands to no-op not to break the external dependencies
+        'preprocess': _NoOpCommand,
+        'build_package_protos': _NoOpCommand,
     }
 
 setuptools.setup(

--- a/src/python/grpcio_reflection/setup.py
+++ b/src/python/grpcio_reflection/setup.py
@@ -61,23 +61,21 @@ INSTALL_REQUIRES = ('protobuf>=3.3.0',
                     'grpcio>={version}'.format(version=grpc_version.VERSION),)
 
 try:
-    # ensure we can load the _pb2_grpc module:
-    from grpc_reflection.v1alpha import reflection_pb2_grpc as _pb2_grpc
-    # if we can find the _pb2_grpc module, the package has already been built.
-    SETUP_REQUIRES = ()
-    COMMAND_CLASS = {
-        # wire up commands to no-op not to break the external dependencies
-        'preprocess': _NoOpCommand,
-        'build_package_protos': _NoOpCommand,
-    }
-except ImportError:  # we are in the build environment
     import reflection_commands as _reflection_commands
+    # we are in the build environment, otherwise the above import fails
     SETUP_REQUIRES = (
         'grpcio-tools=={version}'.format(version=grpc_version.VERSION),)
     COMMAND_CLASS = {
         # Run preprocess from the repository *before* doing any packaging!
         'preprocess': _reflection_commands.CopyProtoModules,
         'build_package_protos': _reflection_commands.BuildPackageProtos,
+    }
+except ImportError:
+    SETUP_REQUIRES = ()
+    COMMAND_CLASS = {
+        # wire up commands to no-op not to break the external dependencies
+        'preprocess': _NoOpCommand,
+        'build_package_protos': _NoOpCommand,
     }
 
 setuptools.setup(


### PR DESCRIPTION
Using the presence of the `_pb2_grpc` (in https://github.com/grpc/grpc/pull/13233) as opposed to the absence of the build script (`*_commands.py`) was a problematic choice, because even if *a* generated file is present, the test infrastructure may want to regenerate it under a different environment (e.g. different Python/proto package version).  This will ensure the `pb2`s always get regenerated if we have a commands module, meaning we are in a build/test environment, thereby making the process hermetic.