### PR TITLE
Fix error when a language skips a certain version in interop test

### DIFF
--- a/tools/interop_matrix/run_interop_matrix_tests.py
+++ b/tools/interop_matrix/run_interop_matrix_tests.py
@@ -100,7 +100,7 @@ def find_all_images_for_lang(lang):
       jobset.message('SKIPPED',
                      '%s for %s is not defined' % (args.release, lang),
                      do_newline=True)
-      return []
+      return {}
     releases = [args.release]
 
   # Images tuples keyed by runtime.


### PR DESCRIPTION
On master, running 
`tools/interop_matrix/run_interop_matrix_tests.py --release=v1.0.1 --language all` appears to result in `AttributeError: 'list' object has no attribute 'keys'`.

I was able to run that without script errors after this change.