### PR TITLE
Unref LB if client channel is shutting down

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -548,6 +548,10 @@ static void on_resolver_result_changed_locked(grpc_exec_ctx* exec_ctx,
       GRPC_RESOLVER_UNREF(exec_ctx, chand->resolver, "channel");
       chand->resolver = nullptr;
     }
+    if (chand->lb_policy != nullptr) {
+      GRPC_LB_POLICY_UNREF(exec_ctx, chand->lb_policy, "channel");
+      chand->lb_policy = nullptr;
+    }
     set_channel_connectivity_state_locked(
         exec_ctx, chand, GRPC_CHANNEL_SHUTDOWN,
         GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(


### PR DESCRIPTION
We can already unref the LB policy at this point. 

If we don't unref the LB policy early here, it can happen that we have to do it in `cc_destroy_channel_elem()`, the destructor for channel data, even when we are shutting down normally. This deferring may cause some problem for clean shutdown.