### PR TITLE
Use spinlock in CompletionRegistry (and improve the benchmark).

### DIFF
--- a/src/csharp/Grpc.Microbenchmarks/Program.cs
+++ b/src/csharp/Grpc.Microbenchmarks/Program.cs
@@ -77,7 +77,10 @@ namespace Grpc.Microbenchmarks
             benchmark.Init();
             foreach (int threadCount in new int[] {1, 1, 2, 4, 8, 12})
             {
-                benchmark.Run(threadCount, 4 * 1000 * 1000);
+                foreach (bool useSharedRegistry in new bool[] {false, true})
+                {
+                    benchmark.Run(threadCount, 4 * 1000 * 1000, useSharedRegistry);
+                }
             }
             benchmark.Cleanup();
         }


### PR DESCRIPTION
- use spinlock in completion registry (it performs slightly better than a regular "lock")
- improve completion registry benchmark to also test scenario where multiple threads are hitting the same completion registry instance concurrently.
