### PR TITLE
Elide local field by directly returning values.

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -274,10 +274,10 @@ def call_credentials_metadata_plugin(CredentialsMetadataPlugin plugin):
   return credentials
 
 cdef const char* _get_c_pem_root_certs(pem_root_certs):
-  cdef char *c_pem_root_certs = NULL
-  if pem_root_certs is not None:
-    c_pem_root_certs = pem_root_certs
-  return c_pem_root_certs
+  if pem_root_certs is None:
+    return NULL
+  else:
+    return pem_root_certs
 
 cdef grpc_ssl_pem_key_cert_pair* _create_c_ssl_pem_key_cert_pairs(pem_key_cert_pairs):
   # return a malloc'ed grpc_ssl_pem_key_cert_pair from a _list_ of SslPemKeyCertPair

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -303,7 +303,7 @@ def server_credentials_ssl(pem_root_certs, pem_key_cert_pairs,
   cdef ServerCredentials credentials = ServerCredentials()
   credentials.references.append(pem_root_certs)
   credentials.references.append(pem_key_cert_pairs)
-  cdef char * c_pem_root_certs = _get_c_pem_root_certs(pem_root_certs)
+  cdef const char * c_pem_root_certs = _get_c_pem_root_certs(pem_root_certs)
   credentials.c_ssl_pem_key_cert_pairs_count = len(pem_key_cert_pairs)
   credentials.c_ssl_pem_key_cert_pairs = _create_c_ssl_pem_key_cert_pairs(pem_key_cert_pairs)
   cdef grpc_ssl_server_certificate_config *c_cert_config = NULL


### PR DESCRIPTION
This depends upon and should be integrated after [pull request 13485](https://github.com/grpc/grpc/pull/13485).