### PR TITLE
Fix build on MacOS sierra.

### DIFF
--- a/src/core/lib/iomgr/sockaddr_utils.cc
+++ b/src/core/lib/iomgr/sockaddr_utils.cc
@@ -148,7 +148,7 @@ int grpc_sockaddr_to_string(char** out,
   grpc_resolved_address addr_normalized;
   char ntop_buf[INET6_ADDRSTRLEN];
   const void* ip = nullptr;
-  int port;
+  int port = 0;
   uint32_t sin6_scope_id = 0;
   int ret;
 


### PR DESCRIPTION
Using the suggested fix to silence, but there might be a cleaner way to fix.
```
/Volumes/BuildData/tmpfs/src/github/grpc/workspace_objc_macos_dbg_native/src/core/lib/iomgr/sockaddr_utils.cc:176:54: error: variable 'port' may be uninitialized when used here [-Werror,-Wconditional-uninitialized]
      ret = gpr_join_host_port(out, host_with_scope, port);
                                                     ^~~~
/Volumes/BuildData/tmpfs/src/github/grpc/workspace_objc_macos_dbg_native/src/core/lib/iomgr/sockaddr_utils.cc:151:11: note: initialize the variable 'port' to silence this warning
  int port;
          ^
           = 0
```