### PR TITLE
Experiment: Build C# libraries to support netstandard2.0 as well.

### DIFF
--- a/src/csharp/Grpc.Auth/Grpc.Auth.csproj
+++ b/src/csharp/Grpc.Auth/Grpc.Auth.csproj
@@ -8,7 +8,7 @@
     <AssemblyTitle>gRPC C# Auth</AssemblyTitle>
     <VersionPrefix>$(GrpcCsharpVersion)</VersionPrefix>
     <Authors>Google Inc.</Authors>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.5;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);SIGNED</DefineConstants>
     <AssemblyName>Grpc.Auth</AssemblyName>
     <PackageId>Grpc.Auth</PackageId>

--- a/src/csharp/Grpc.Core.Testing/Grpc.Core.Testing.csproj
+++ b/src/csharp/Grpc.Core.Testing/Grpc.Core.Testing.csproj
@@ -8,7 +8,7 @@
     <AssemblyTitle>gRPC C# Core Testing</AssemblyTitle>
     <VersionPrefix>$(GrpcCsharpVersion)</VersionPrefix>
     <Authors>Google Inc.</Authors>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.5;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Grpc.Core.Testing</AssemblyName>
     <PackageId>Grpc.Core.Testing</PackageId>

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -8,7 +8,7 @@
     <AssemblyTitle>gRPC C# Core</AssemblyTitle>
     <VersionPrefix>$(GrpcCsharpVersion)</VersionPrefix>
     <Authors>Google Inc.</Authors>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.5;netstandard2.0</TargetFrameworks>
     <AssemblyName>Grpc.Core</AssemblyName>
     <PackageId>Grpc.Core</PackageId>
     <PackageTags>gRPC RPC Protocol HTTP/2</PackageTags>
@@ -62,6 +62,12 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
+    <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
+    <PackageReference Include="System.Threading.ThreadPool" Version="4.0.10" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.0.10" />

--- a/src/csharp/Grpc.Core/GrpcEnvironment.cs
+++ b/src/csharp/Grpc.Core/GrpcEnvironment.cs
@@ -364,7 +364,7 @@ namespace Grpc.Core
                 {
                     if (!hooksRegistered)
                     {
-#if NETSTANDARD1_5
+#if (NETSTANDARD1_5 || NETSTANDARD2_0)
                         System.Runtime.Loader.AssemblyLoadContext.Default.Unloading += (assemblyLoadContext) => { HandleShutdown(); };
 #else
                         AppDomain.CurrentDomain.ProcessExit += (sender, eventArgs) => { HandleShutdown(); };

--- a/src/csharp/Grpc.Core/Internal/NativeExtension.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeExtension.cs
@@ -104,7 +104,7 @@ namespace Grpc.Core.Internal
         private static string GetAssemblyPath()
         {
             var assembly = typeof(NativeExtension).GetTypeInfo().Assembly;
-#if NETSTANDARD1_5
+#if (NETSTANDARD1_5 || NETSTANDARD2_0)
             // Assembly.EscapedCodeBase does not exist under CoreCLR, but assemblies imported from a nuget package
             // don't seem to be shadowed by DNX-based projects at all.
             return assembly.Location;
@@ -123,7 +123,7 @@ namespace Grpc.Core.Internal
 #endif
         }
 
-#if !NETSTANDARD1_5
+#if (!NETSTANDARD1_5 && !NETSTANDARD2_0)
         private static bool IsFileUri(string uri)
         {
             return uri.ToLowerInvariant().StartsWith(Uri.UriSchemeFile);

--- a/src/csharp/Grpc.Core/Internal/PlatformApis.cs
+++ b/src/csharp/Grpc.Core/Internal/PlatformApis.cs
@@ -39,7 +39,7 @@ namespace Grpc.Core.Internal
 
         static PlatformApis()
         {
-#if NETSTANDARD1_5
+#if (NETSTANDARD1_5 || NETSTANDARD2_0)
             isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
             isMacOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
             isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);

--- a/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
+++ b/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
@@ -119,7 +119,7 @@ namespace Grpc.Core.Internal
             {
                 throw new MissingMethodException(string.Format("The native method \"{0}\" does not exist", methodName));
             }
-#if NETSTANDARD1_5
+#if (NETSTANDARD1_5 || NETSTANDARD2_0)
             return Marshal.GetDelegateForFunctionPointer<T>(ptr);  // non-generic version is obsolete
 #else
             return Marshal.GetDelegateForFunctionPointer(ptr, typeof(T)) as T;  // generic version not available in .NET45

--- a/src/csharp/Grpc.Core/Utils/TaskUtils.cs
+++ b/src/csharp/Grpc.Core/Utils/TaskUtils.cs
@@ -33,7 +33,7 @@ namespace Grpc.Core.Utils
         {
             get
             {
-#if NETSTANDARD1_5
+#if (NETSTANDARD1_5 || NETSTANDARD2_0)
                 return Task.CompletedTask;
 #else
                 return Task.FromResult<object>(null);  // for .NET45, emulate the functionality

--- a/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.csproj
+++ b/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.csproj
@@ -8,7 +8,7 @@
     <AssemblyTitle>gRPC C# Healthchecking</AssemblyTitle>
     <VersionPrefix>$(GrpcCsharpVersion)</VersionPrefix>
     <Authors>Google Inc.</Authors>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.5;netstandard2.0</TargetFrameworks>
     <AssemblyName>Grpc.HealthCheck</AssemblyName>
     <PackageId>Grpc.HealthCheck</PackageId>
     <PackageTags>gRPC health check</PackageTags>

--- a/src/csharp/Grpc.Reflection/Grpc.Reflection.csproj
+++ b/src/csharp/Grpc.Reflection/Grpc.Reflection.csproj
@@ -8,7 +8,7 @@
     <AssemblyTitle>gRPC C# Reflection</AssemblyTitle>
     <VersionPrefix>$(GrpcCsharpVersion)</VersionPrefix>
     <Authors>Google Inc.</Authors>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.5;netstandard2.0</TargetFrameworks>
     <AssemblyName>Grpc.Reflection</AssemblyName>
     <PackageId>Grpc.Reflection</PackageId>
     <PackageTags>gRPC reflection</PackageTags>


### PR DESCRIPTION
See https://github.com/grpc/grpc/issues/9441.

Currently I'm unable to build the tests under netcoreapp2.0, but the libraries shipped as nugets are building fine.

