### PR TITLE
Objective-C: UTF8 encoding for error messages and metadata values

### DIFF
--- a/src/objective-c/GRPCClient/private/NSDictionary+GRPC.m
+++ b/src/objective-c/GRPCClient/private/NSDictionary+GRPC.m
@@ -54,7 +54,7 @@
 + (instancetype)grpc_stringFromMetadataValue:(grpc_metadata *)metadata {
   return [[self alloc] initWithBytes:GRPC_SLICE_START_PTR(metadata->value)
                               length:GRPC_SLICE_LENGTH(metadata->value)
-                            encoding:NSASCIIStringEncoding];
+                            encoding:NSUTF8StringEncoding];
 }
 
 // Precondition: This object contains only ASCII characters.

--- a/src/objective-c/GRPCClient/private/NSError+GRPC.m
+++ b/src/objective-c/GRPCClient/private/NSError+GRPC.m
@@ -27,7 +27,7 @@ NSString * const kGRPCErrorDomain = @"io.grpc";
   if (statusCode == GRPC_STATUS_OK) {
     return nil;
   }
-  NSString *message = [NSString stringWithCString:details encoding:NSASCIIStringEncoding];
+  NSString *message = [NSString stringWithCString:details encoding:NSUTF8StringEncoding];
   return [NSError errorWithDomain:kGRPCErrorDomain
                              code:statusCode
                          userInfo:@{NSLocalizedDescriptionKey: message}];


### PR DESCRIPTION
We have run into the same issue as mentioned in https://github.com/grpc/grpc/issues/11617. We need to send a localized string from our backend but the Objective-C client coerces the received string to ASCII which breaks some of the extended characters.

Other clients we tested (such as https://github.com/njpatel/grpcc) seemed to handle this correctly.

Is this change a good idea or is there some sort of limitation I'm not aware of?