### PR TITLE
Remove unnecessary secure dependences

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -418,7 +418,6 @@ grpc_cc_library(
     ],
     external_deps = [
         "nanopb",
-        "libssl",
     ],
     language = "c++",
     public_hdrs = [

--- a/bazel/cc_grpc_library.bzl
+++ b/bazel/cc_grpc_library.bzl
@@ -60,10 +60,10 @@ def cc_grpc_library(name, srcs, deps, proto_only, well_known_protos, generate_mo
 
     if use_external:
       # when this file is used by non-grpc projects
-      grpc_deps = ["//external:grpc++", "//external:grpc++_codegen_proto",
+      grpc_deps = ["//external:grpc++_codegen_proto",
                    "//external:protobuf"]
     else:
-      grpc_deps = ["//:grpc++", "//:grpc++_codegen_proto", "//external:protobuf"]
+      grpc_deps = ["//:grpc++_codegen_proto", "//external:protobuf"]
 
     native.cc_library(
         name = name,

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -42,12 +42,12 @@ cc_binary(
     name = "greeter_client",
     srcs = ["cpp/helloworld/greeter_client.cc"],
     defines = ["BAZEL_BUILD"],
-    deps = [":helloworld"],
+    deps = [":helloworld", "//:grpc++"],
 )
 
 cc_binary(
     name = "greeter_server",
     srcs = ["cpp/helloworld/greeter_server.cc"],
     defines = ["BAZEL_BUILD"],
-    deps = [":helloworld"],
+    deps = [":helloworld", "//:grpc++"],
 )

--- a/tools/run_tests/sanity/check_unsecure.sh
+++ b/tools/run_tests/sanity/check_unsecure.sh
@@ -19,6 +19,6 @@ set -e
 # Make sure that there is no path from a known unsecure target
 # to an SSL library
 
-[[ $(bazel query "somepath(//test/cpp/microbenchmarks:helpers, //external:libssl)" 2>/dev/null | wc -l) -eq 0 ]]
+test `bazel query "somepath(//test/cpp/microbenchmarks:helpers, //external:libssl)" 2>/dev/null | wc -l` -eq 0
 
 # Fall through with the exit code of that command

--- a/tools/run_tests/sanity/check_unsecure.sh
+++ b/tools/run_tests/sanity/check_unsecure.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -e
+
+# Make sure that there is no path from a known unsecure target
+# to an SSL library
+
+[[ $(bazel query "somepath(//test/cpp/microbenchmarks:helpers, //external:libssl)" 2>/dev/null | wc -l) -eq 0 ]]
+
+# Fall through with the exit code of that command

--- a/tools/run_tests/sanity/sanity_tests.yaml
+++ b/tools/run_tests/sanity/sanity_tests.yaml
@@ -6,6 +6,7 @@
 - script: tools/run_tests/sanity/check_submodules.sh
 - script: tools/run_tests/sanity/check_test_filtering.py
 - script: tools/run_tests/sanity/check_tracer_sanity.py
+- script: tools/run_tests/sanity/check_unsecure.sh
 - script: tools/run_tests/sanity/core_banned_functions.py
 - script: tools/run_tests/sanity/core_untyped_structs.sh
 - script: tools/buildgen/generate_projects.sh -j 3


### PR DESCRIPTION
These were forcing linkage of ssl into supposedly unsecure targets.
Fixes #13518 