### PR TITLE
Upmerge 13057 from 1.7.x to 1.8.x

### DIFF
--- a/tools/run_tests/artifacts/build_artifact_ruby.sh
+++ b/tools/run_tests/artifacts/build_artifact_ruby.sh
@@ -42,6 +42,7 @@ tools/run_tests/helper_scripts/bundle_install_wrapper.sh
 
 set -ex
 
+export DOCKERHUB_ORGANIZATION=grpctesting
 rake gem:native
 
 if [ "$SYSTEM" == "Darwin" ] ; then


### PR DESCRIPTION
upmerges https://github.com/grpc/grpc/pull/13057 (this is in the middle of being upmerged to master right now in https://github.com/grpc/grpc/pull/13466, but it will need to be backported to 1.8.x anyways).

The underlying issue is the ruby artifact docker image is failing to build certain versions of ruby right now, but this allows using an already-successfully built image.