### PR TITLE
php: Removed opts checks in BaseStub when the elements aren't being used.

### DIFF
--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -54,15 +54,24 @@ class BaseStub
             }
             unset($opts['update_metadata']);
         }
+        if (!empty($opts['grpc.ssl_target_name_override'])) {
+            $this->hostname_override = $opts['grpc.ssl_target_name_override'];
+        }
+        if ($channel) {
+            if (!is_a($channel, 'Grpc\Channel')) {
+                throw new \Exception('The channel argument is not a'.
+                                     'Channel object');
+            }
+            $this->channel = $channel;
+            return;
+        }
+
         $package_config = json_decode(
             file_get_contents(dirname(__FILE__).'/../../composer.json'), true);
         if (!empty($opts['grpc.primary_user_agent'])) {
             $opts['grpc.primary_user_agent'] .= ' ';
         } else {
             $opts['grpc.primary_user_agent'] = '';
-        }
-        if (!empty($opts['grpc.ssl_target_name_override'])) {
-            $this->hostname_override = $opts['grpc.ssl_target_name_override'];
         }
         $opts['grpc.primary_user_agent'] .=
             'grpc-php/'.$package_config['version'];
@@ -71,15 +80,7 @@ class BaseStub
                                  'required. Please see one of the '.
                                  'ChannelCredentials::create methods');
         }
-        if ($channel) {
-            if (!is_a($channel, 'Grpc\Channel')) {
-                throw new \Exception('The channel argument is not a'.
-                                     'Channel object');
-            }
-            $this->channel = $channel;
-        } else {
-            $this->channel = new Channel($hostname, $opts);
-        }
+        $this->channel = new Channel($hostname, $opts);
     }
 
     /**


### PR DESCRIPTION
Re-organized the $opts checks in BaseStub constructor, to make channel re-use easier and cleaner.  Channel-specific tests aren't useful when the channel is provided via parameter.