### PR TITLE
Updated CLA link to reflect migration to Linux Foundation.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ If you are new to github, please start by reading [Pull Request howto](https://h
 ## Legal requirements
 
 In order to protect both you and ourselves, you will need to sign the
-[Contributor License Agreement](https://cla.developers.google.com/clas).
+[Contributor License Agreement](https://identity.linuxfoundation.org/projects/cncf).
 
 ## Running tests
 


### PR DESCRIPTION
CONTRIBUTING.md was still pointing at the old Google CLA dashboard.