### PR TITLE
Treat received trailing metadata the same as Trailers-Only.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1863,6 +1863,15 @@ void grpc_chttp2_maybe_complete_recv_initial_metadata(grpc_exec_ctx* exec_ctx,
     }
     grpc_chttp2_incoming_metadata_buffer_publish(
         exec_ctx, &s->metadata_buffer[0], s->recv_initial_metadata);
+    if (s->trailing_metadata_available != nullptr) {
+      // We set trailing_metadata_available to true if we've either
+      // already received trailing metadata or encountered an error,
+      // because in either case, we will immediately return a
+      // recv_trailing_metadata op.
+      *s->trailing_metadata_available =
+          s->received_trailing_metadata || s->seen_error;
+      s->trailing_metadata_available = nullptr;
+    }
     null_then_run_closure(exec_ctx, &s->recv_initial_metadata_ready,
                           GRPC_ERROR_NONE);
   }

--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -639,9 +639,6 @@ static grpc_error* init_header_frame_parser(grpc_exec_ctx* exec_ctx,
     case 0:
       if (t->is_client && t->header_eof) {
         GRPC_CHTTP2_IF_TRACING(gpr_log(GPR_INFO, "parsing Trailers-Only"));
-        if (s->trailing_metadata_available != nullptr) {
-          *s->trailing_metadata_available = true;
-        }
         t->hpack_parser.on_header = on_trailing_header;
         s->received_trailing_metadata = true;
       } else {


### PR DESCRIPTION
I still need to test this with the retry code, but I think this does what you suggested.  I've also changed it to (I think) handle the case where the stream fails (or is cancelled) before receiving trailing metadata.