### PR TITLE
Close only the endpoint that has error

### DIFF
--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -137,11 +137,14 @@ static void proxy_connection_failed(grpc_exec_ctx* exec_ctx,
   const char* msg = grpc_error_string(error);
   gpr_log(GPR_INFO, "%s: %s", prefix, msg);
 
-  grpc_endpoint_shutdown(exec_ctx, conn->client_endpoint,
-                         GRPC_ERROR_REF(error));
-  if (conn->server_endpoint != nullptr) {
-    grpc_endpoint_shutdown(exec_ctx, conn->server_endpoint,
+  if (is_client) {
+    grpc_endpoint_shutdown(exec_ctx, conn->client_endpoint,
                            GRPC_ERROR_REF(error));
+  } else {
+    if (conn->server_endpoint != nullptr) {
+      grpc_endpoint_shutdown(exec_ctx, conn->server_endpoint,
+                             GRPC_ERROR_REF(error));
+    }
   }
   proxy_connection_unref(exec_ctx, conn, "conn_failed");
 }


### PR DESCRIPTION
This is a quick fix to address: https://github.com/grpc/grpc/issues/13124

This is not the ideal fix but i want to get something in to reduce the test flakes we are seeing.