### PR TITLE
Verbose log of start of each test suite

### DIFF
--- a/src/objective-c/tests/GRPCClientTests.m
+++ b/src/objective-c/tests/GRPCClientTests.m
@@ -95,6 +95,10 @@ static GRPCProtoMethod *kFullDuplexCallMethod;
 
 @implementation GRPCClientTests
 
++ (void)setUp {
+  NSLog(@"GRPCClientTests Started");
+}
+
 - (void)setUp {
   // Add a custom user agent prefix that will be used in test
   [GRPCCall setUserAgentPrefix:@"Foo" forHost:kHostAddress];

--- a/src/objective-c/tests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests.m
@@ -86,6 +86,7 @@
 }
 
 + (void)setUp {
+  NSLog(@"InteropTest Started, class: %@", [[self class] description]);
 #ifdef GRPC_COMPILE_WITH_CRONET
   // Cronet setup
   [Cronet setHttp2Enabled:YES];

--- a/src/objective-c/tests/RxLibraryUnitTests.m
+++ b/src/objective-c/tests/RxLibraryUnitTests.m
@@ -58,6 +58,10 @@
 
 @implementation RxLibraryUnitTests
 
++ (void)setUp {
+  NSLog(@"GRPCClientTests Started");
+}
+
 #pragma mark Writeable
 
 - (void)testWriteableSingleHandlerIsCalledForValue {

--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -38,7 +38,7 @@ trap 'kill -9 `jobs -p` ; echo "EXIT TIME:  $(date)"' EXIT
 # element of the pipe fails.
 # TODO(jcanizales): Use xctool instead? Issue #2540.
 set -o pipefail
-XCODEBUILD_FILTER='(^CompileC |^Ld |^.*clang |^ *cd |^ *export |^Libtool |^.*libtool |^CpHeader |^ *builtin-copy )'
+XCODEBUILD_FILTER='(^CompileC |^Ld |^ *[^ ]*clang |^ *cd |^ *export |^Libtool |^ *[^ ]*libtool |^CpHeader |^ *builtin-copy )'
 echo "TIME:  $(date)"
 xcodebuild \
     -workspace Tests.xcworkspace \


### PR DESCRIPTION
Some ObjC tests are still flaky. This PR prints out message when each test suite started in order to verify whether it was a test case failed or the test framework failed.

This PR also better tunes the test output filter in run_tests.sh