### PR TITLE
Resolve various races in QPS sync client

### DIFF
--- a/test/cpp/qps/client_sync.cc
+++ b/test/cpp/qps/client_sync.cc
@@ -196,9 +196,9 @@ class SynchronousStreamingClient : public SynchronousClient {
     for (size_t i = 0; i < num_threads_; i++) {
       cleanup_threads.emplace_back([this, i] {
         std::lock_guard<std::mutex> l(stream_mu_[i]);
-	shutdown_[i].val = true;
+        shutdown_[i].val = true;
         if (stream_[i]) {
-	  CleanStream(i);
+          CleanStream(i);
         }
       });
     }
@@ -206,6 +206,7 @@ class SynchronousStreamingClient : public SynchronousClient {
       th.join();
     }
   }
+
  private:
   void DestroyMultithreading() override final {
     CleanupAllStreams();
@@ -219,9 +220,8 @@ class SynchronousStreamingPingPongClient final
  public:
   SynchronousStreamingPingPongClient(const ClientConfig& config)
       : SynchronousStreamingClient(config) {}
-  ~SynchronousStreamingPingPongClient() {
-    CleanupAllStreams();
-  }
+  ~SynchronousStreamingPingPongClient() { CleanupAllStreams(); }
+
  private:
   bool InitThreadFuncImpl(size_t thread_idx) override {
     auto* stub = channels_[thread_idx % channels_.size()].get_stub();
@@ -280,9 +280,7 @@ class SynchronousStreamingFromClientClient final
  public:
   SynchronousStreamingFromClientClient(const ClientConfig& config)
       : SynchronousStreamingClient(config), last_issue_(num_threads_) {}
-  ~SynchronousStreamingFromClientClient() {
-    CleanupAllStreams();
-  }
+  ~SynchronousStreamingFromClientClient() { CleanupAllStreams(); }
 
  private:
   std::vector<double> last_issue_;
@@ -338,9 +336,7 @@ class SynchronousStreamingFromServerClient final
  public:
   SynchronousStreamingFromServerClient(const ClientConfig& config)
       : SynchronousStreamingClient(config), last_recv_(num_threads_) {}
-  ~SynchronousStreamingFromServerClient() {
-    CleanupAllStreams();
-  }
+  ~SynchronousStreamingFromServerClient() { CleanupAllStreams(); }
 
  private:
   std::vector<double> last_recv_;
@@ -391,9 +387,8 @@ class SynchronousStreamingBothWaysClient final
  public:
   SynchronousStreamingBothWaysClient(const ClientConfig& config)
       : SynchronousStreamingClient(config) {}
-  ~SynchronousStreamingBothWaysClient() {
-    CleanupAllStreams();
-  }
+  ~SynchronousStreamingBothWaysClient() { CleanupAllStreams(); }
+
  private:
   bool InitThreadFuncImpl(size_t thread_idx) override {
     auto* stub = channels_[thread_idx % channels_.size()].get_stub();


### PR DESCRIPTION
Fixes #13122 and various related issues

This resolves several different kinds of races in the QPS sync client:

1. Check if a specific RPC client thread needs to be shutdown before it is even started (analogous to #13409 for the async client)
1. Move end-of-test stream cancellation to `DestroyMultithreading` (which is called before the client has to shutdown) rather than at the client destructor. Test cases such as `streaming_from_server` could end up getting stuck forever otherwise if a client thread was still doing a Read op and could never escape it to do the thread join, creating a deadlock
1. Don't let an RPC completion trigger a new RPC if the thread has needed to be shutdown in between
1. Don't let an RPC finishing trigger a refresh of the ClientContext if the thread has needed to be shutdown meanwhile
1. Protect stream-changing operations with a lock so that a cancellation in a different thread doesn't conflict with a regular stream operation in the common thread for handling a stream

Additionally, this PR refactors a common code path by which a "cleanup" operation is applied to all streams at different points.


