### PR TITLE
Adding names to all Python threads created.

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -231,7 +231,7 @@ def _consume_request_iterator(request_iterator, state, call,
     consumption_thread = _common.CleanupThread(
         stop_consumption_thread,
         target=consume_request_iterator,
-        name='Thread-gRPC-ConsumeRequestIterator',
+        name='Thread-gRPC-consume_request_iterator',
     )
     consumption_thread.start()
 
@@ -713,7 +713,7 @@ def _run_channel_spin_thread(state):
     channel_spin_thread = _common.CleanupThread(
         stop_channel_spin,
         target=channel_spin,
-        name='Thread-gRPC-StopChannelSpin',
+        name='Thread-gRPC-channel_spin',
     )
     channel_spin_thread.start()
 
@@ -797,7 +797,7 @@ def _spawn_delivery(state, callbacks):
     delivering_thread = threading.Thread(
         target=_deliver,
         args=(state, state.connectivity, callbacks,),
-        name='Thread-gRPC-SpawnDelivery',
+        name='Thread-gRPC-_deliver',
     )
     delivering_thread.start()
     state.delivering = True
@@ -858,7 +858,7 @@ def _subscribe(state, callback, try_to_connect):
                 lambda timeout: _moot(state),
                 target=_poll_connectivity,
                 args=(state, state.channel, bool(try_to_connect)),
-                name='Thread-gRPC-SubscribeMoot',
+                name='Thread-gRPC-_poll_connectivity',
             )
             polling_thread.start()
             state.polling = True

--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -229,7 +229,10 @@ def _consume_request_iterator(request_iterator, state, call,
                 state.condition.notify_all()
 
     consumption_thread = _common.CleanupThread(
-        stop_consumption_thread, target=consume_request_iterator)
+        stop_consumption_thread,
+        target=consume_request_iterator,
+        name='Thread-gRPC-ConsumeRequestIterator',
+    )
     consumption_thread.start()
 
 
@@ -708,7 +711,10 @@ def _run_channel_spin_thread(state):
                     call.cancel()
 
     channel_spin_thread = _common.CleanupThread(
-        stop_channel_spin, target=channel_spin)
+        stop_channel_spin,
+        target=channel_spin,
+        name='Thread-gRPC-StopChannelSpin',
+    )
     channel_spin_thread.start()
 
 
@@ -789,7 +795,10 @@ def _deliver(state, initial_connectivity, initial_callbacks):
 
 def _spawn_delivery(state, callbacks):
     delivering_thread = threading.Thread(
-        target=_deliver, args=(state, state.connectivity, callbacks,))
+        target=_deliver,
+        args=(state, state.connectivity, callbacks,),
+        name='Thread-gRPC-SpawnDelivery',
+    )
     delivering_thread.start()
     state.delivering = True
 
@@ -848,7 +857,9 @@ def _subscribe(state, callback, try_to_connect):
             polling_thread = _common.CleanupThread(
                 lambda timeout: _moot(state),
                 target=_poll_connectivity,
-                args=(state, state.channel, bool(try_to_connect)))
+                args=(state, state.channel, bool(try_to_connect)),
+                name='Thread-gRPC-SubscribeMoot',
+            )
             polling_thread.start()
             state.polling = True
             state.callbacks_and_connectivities.append([callback, None])

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -40,7 +40,11 @@ cdef int _get_metadata(
     else:
       cb(user_data, NULL, 0, status, error_details)
   args = context.service_url, context.method_name, callback,
-  threading.Thread(target=<object>state, args=args).start()
+  threading.Thread(
+      target=<object>state,
+      args=args,
+      name='Thread-gRPC-PluginGetMetadata',
+  ).start()
   return 0  # Asynchronous return
 
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -43,7 +43,7 @@ cdef int _get_metadata(
   threading.Thread(
       target=<object>state,
       args=args,
-      name='Thread-gRPC-PluginGetMetadata',
+      name='Thread-gRPC-_get_metadata',
   ).start()
   return 0  # Asynchronous return
 

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -754,7 +754,10 @@ def _stop(state, grace):
                     with state.lock:
                         state.server.cancel_all_calls()
 
-                thread = threading.Thread(target=cancel_all_calls_after_grace)
+                thread = threading.Thread(
+                    target=cancel_all_calls_after_grace,
+                    name='Thread-gRPC-CancelAfterGrace',
+                )
                 thread.start()
                 return shutdown_event
     shutdown_event.wait()
@@ -776,7 +779,11 @@ def _start(state):
                 _stop(state, timeout).wait()
 
         thread = _common.CleanupThread(
-            cleanup_server, target=_serve, args=(state,))
+            cleanup_server,
+            target=_serve,
+            args=(state,),
+            name='Thread-gRPC-CleanupServer',
+        )
         thread.start()
 
 

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -756,7 +756,7 @@ def _stop(state, grace):
 
                 thread = threading.Thread(
                     target=cancel_all_calls_after_grace,
-                    name='Thread-gRPC-CancelAfterGrace',
+                    name='Thread-gRPC-cancel_all_calls_after_grace',
                 )
                 thread.start()
                 return shutdown_event
@@ -782,7 +782,7 @@ def _start(state):
             cleanup_server,
             target=_serve,
             args=(state,),
-            name='Thread-gRPC-CleanupServer',
+            name='Thread-gRPC-_serve',
         )
         thread.start()
 

--- a/src/python/grpcio/grpc/beta/_server_adaptations.py
+++ b/src/python/grpcio/grpc/beta/_server_adaptations.py
@@ -172,7 +172,10 @@ def _run_request_pipe_thread(request_iterator, request_consumer,
         thread_joined.set()
 
     request_pipe_thread = _common.CleanupThread(
-        stop_request_pipe, target=pipe_requests)
+        stop_request_pipe,
+        target=pipe_requests,
+        name='Thread-gRPC-StopRequestPipe',
+    )
     request_pipe_thread.start()
 
 

--- a/src/python/grpcio/grpc/beta/_server_adaptations.py
+++ b/src/python/grpcio/grpc/beta/_server_adaptations.py
@@ -174,7 +174,7 @@ def _run_request_pipe_thread(request_iterator, request_consumer,
     request_pipe_thread = _common.CleanupThread(
         stop_request_pipe,
         target=pipe_requests,
-        name='Thread-gRPC-StopRequestPipe',
+        name='Thread-gRPC-pipe_requests',
     )
     request_pipe_thread.start()
 


### PR DESCRIPTION
Forgive me for not following protocol and filing an issue first.

Also, since "naming things" is one of the hard problems in computer science, I fully acknowledge that I may have chosen bad names and am open to suggestions.

To give some context, I'm currently debugging the `google-cloud-python` implementation of Pub / Sub, which heavily uses threads (bidirectional streaming is quite complex to implement). To track zombie threads, it's quite helpful to give each thread a name.

/cc @jonparrott @lukesneeringer