### PR TITLE
Make comparison of LB policy name case-insensitive.

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -432,7 +432,7 @@ static void on_resolver_result_changed_locked(grpc_exec_ctx* exec_ctx,
     // once at any given time.
     lb_policy_name_changed =
         chand->info_lb_policy_name == nullptr ||
-        strcmp(chand->info_lb_policy_name, lb_policy_name) != 0;
+        gpr_stricmp(chand->info_lb_policy_name, lb_policy_name) != 0;
     if (chand->lb_policy != nullptr && !lb_policy_name_changed) {
       // Continue using the same LB policy.  Update with new addresses.
       lb_policy_updated = true;


### PR DESCRIPTION
It looks like we are already using case-insensitive match for creation of the LB policy (see https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/lb_policy_registry.cc#L56), but we were not doing so when deciding whether the LB policy name has changed.  This PR fixes that.