### PR TITLE
Remove asserts from tls_gcc.h

### DIFF
--- a/include/grpc/support/tls_gcc.h
+++ b/include/grpc/support/tls_gcc.h
@@ -26,44 +26,6 @@
 /** Thread local storage based on gcc compiler primitives.
    #include tls.h to use this - and see that file for documentation */
 
-#ifndef NDEBUG
-
-struct gpr_gcc_thread_local {
-  intptr_t value;
-  bool* inited;
-};
-
-#define GPR_TLS_DECL(name)           \
-  static bool name##_inited = false; \
-  static __thread struct gpr_gcc_thread_local name = {0, &(name##_inited)}
-
-#define gpr_tls_init(tls)                  \
-  do {                                     \
-    GPR_ASSERT(*((tls)->inited) == false); \
-    *((tls)->inited) = true;               \
-  } while (0)
-
-/** It is allowed to call gpr_tls_init after gpr_tls_destroy is called. */
-#define gpr_tls_destroy(tls)      \
-  do {                            \
-    GPR_ASSERT(*((tls)->inited)); \
-    *((tls)->inited) = false;     \
-  } while (0)
-
-#define gpr_tls_set(tls, new_value) \
-  do {                              \
-    GPR_ASSERT(*((tls)->inited));   \
-    (tls)->value = (new_value);     \
-  } while (0)
-
-#define gpr_tls_get(tls)          \
-  ({                              \
-    GPR_ASSERT(*((tls)->inited)); \
-    (tls)->value;                 \
-  })
-
-#else /* NDEBUG */
-
 struct gpr_gcc_thread_local {
   intptr_t value;
 };
@@ -79,7 +41,5 @@ struct gpr_gcc_thread_local {
   } while (0)
 #define gpr_tls_set(tls, new_value) (((tls)->value) = (new_value))
 #define gpr_tls_get(tls) ((tls)->value)
-
-#endif /* NDEBUG */
 
 #endif /* GRPC_SUPPORT_TLS_GCC_H */


### PR DESCRIPTION
These asserts are for checking whether the thread_local storage variable has been initialized or not. On platforms with gcc, thread_local variables do not need to be initialized and hence this assert is not needed here. tls_pthread which actually requires initialization already has an assert and would fail if used without being initialized.