### PR TITLE
support/cpu: avoid out of bound access

### DIFF
--- a/src/core/lib/support/cpu_linux.cc
+++ b/src/core/lib/support/cpu_linux.cc
@@ -61,7 +61,7 @@ unsigned gpr_cpu_current_cpu(void) {
     gpr_log(GPR_ERROR, "Error determining current CPU: %s\n", strerror(errno));
     return 0;
   }
-  return (unsigned)cpu;
+  return cpu < ncpus ? (unsigned)cpu : 0;
 #endif
 }
 


### PR DESCRIPTION
When using `rr` to reproduce some bugs, `gpr_cpu_num_cores` always returns 1. However `gpr_cpu_current_cpu` will return the actual CPU index. So add a check to avoid out of bound access.

/cc mozilla/rr#2141