### PR TITLE
Fix race condition when shutting down LB policies for re-resolution.

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -1040,6 +1040,8 @@ static void pick_done_locked(grpc_exec_ctx* exec_ctx, grpc_call_element* elem,
                              "Call dropped by load balancing policy")
                        : GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
                              "Failed to create subchannel", &error, 1);
+    calld->error = grpc_error_set_int(calld->error, GRPC_ERROR_INT_GRPC_STATUS,
+                                      GRPC_STATUS_UNAVAILABLE);
     if (grpc_client_channel_trace.enabled()) {
       gpr_log(GPR_DEBUG,
               "chand=%p calld=%p: failed to create subchannel: error=%s", chand,


### PR DESCRIPTION
Fixes #13581.

Note that although the crash was only being reported in PF, the RR code has the same problem, so I've added a work-around in both places.  The grpclb LB policy is not affected, because it never shuts itself down.

The work-around that I've added to PF and RR should be removed as part of #12829.  Note that the behavior with this work-around is to fail these picks, but the behavior under #12829 should be better: the picks should be queued up until we get an update and can process them successfully.

The change in client_channel.cc to set the gRPC status for failed LB picks is necessary to get the resource_quota_server test to pass.  And it seems like UNAVAILABLE is the right status to return for a failed LB pick anyway.