### PR TITLE
Added resolver for grpclb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1199,6 +1199,7 @@ add_library(grpc
   src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
   src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
   src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_fallback.cc
+  src/core/ext/filters/client_channel/resolver/dns/grpclb/dns_resolver_grpclb.cc
   src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
   src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
   src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
@@ -2346,6 +2347,7 @@ add_library(grpc_unsecure
   src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
   src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
   src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_fallback.cc
+  src/core/ext/filters/client_channel/resolver/dns/grpclb/dns_resolver_grpclb.cc
   src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
   src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
   src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc

--- a/Makefile
+++ b/Makefile
@@ -3210,6 +3210,7 @@ LIBGRPC_SRC = \
     src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc \
     src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_fallback.cc \
     src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc \
+    src/core/ext/filters/client_channel/resolver/dns/grpclb/dns_resolver_grpclb.cc \
     src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc \
     src/core/ext/filters/load_reporting/server_load_reporting_filter.cc \
     src/core/ext/filters/load_reporting/server_load_reporting_plugin.cc \
@@ -4324,6 +4325,7 @@ LIBGRPC_UNSECURE_SRC = \
     src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc \
     src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc \
     src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_fallback.cc \
+    src/core/ext/filters/client_channel/resolver/dns/grpclb/dns_resolver_grpclb.cc \
     src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc \
     src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc \
     src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc \

--- a/src/core/ext/filters/client_channel/resolver/dns/grpclb/dns_resolver_grpclb.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/grpclb/dns_resolver_grpclb.cc
@@ -1,0 +1,312 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpc/support/port_platform.h>
+
+#include <inttypes.h>
+#include <string.h>
+
+#include <grpc/support/alloc.h>
+#include <grpc/support/host_port.h>
+#include <grpc/support/string_util.h>
+
+#include "src/core/ext/filters/client_channel/lb_policy_registry.h"
+#include "src/core/ext/filters/client_channel/resolver_registry.h"
+#include "src/core/lib/backoff/backoff.h"
+#include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/iomgr/combiner.h"
+#include "src/core/lib/iomgr/resolve_address.h"
+#include "src/core/lib/iomgr/timer.h"
+#include "src/core/lib/support/env.h"
+#include "src/core/lib/support/string.h"
+
+#define GRPC_DNS_MIN_CONNECT_TIMEOUT_SECONDS 1
+#define GRPC_DNS_INITIAL_CONNECT_BACKOFF_SECONDS 1
+#define GRPC_DNS_RECONNECT_BACKOFF_MULTIPLIER 1.6
+#define GRPC_DNS_RECONNECT_MAX_BACKOFF_SECONDS 120
+#define GRPC_DNS_RECONNECT_JITTER 0.2
+
+typedef struct {
+  /** base class: must be first */
+  grpc_resolver base;
+  /** gRPCLB host name before resolution */
+  char* balancer_name;
+  /** name to resolve, this is the gRPCLB server */
+  char* name_to_resolve;
+  /** default port to use */
+  char* default_port;
+  /** channel args. */
+  grpc_channel_args* channel_args;
+  /** pollset_set to drive the name resolution process */
+  grpc_pollset_set* interested_parties;
+
+  /** are we currently resolving? */
+  bool resolving;
+  /** which version of the result have we published? */
+  int published_version;
+  /** which version of the result is current? */
+  int resolved_version;
+  /** pending next completion, or NULL */
+  grpc_closure* next_completion;
+  /** target result address for next completion */
+  grpc_channel_args** target_result;
+  /** current (fully resolved) result */
+  grpc_channel_args* resolved_result;
+  /** retry timer */
+  bool have_retry_timer;
+  grpc_timer retry_timer;
+  grpc_closure on_retry;
+  /** retry backoff state */
+  grpc_backoff backoff_state;
+
+  /** currently resolving addresses */
+  grpc_resolved_addresses* addresses;
+} grpclb_dns_resolver;
+
+static void dns_grpclb_destroy(grpc_exec_ctx* exec_ctx, grpc_resolver* r);
+
+static void dns_grpclb_start_resolving_locked(grpc_exec_ctx* exec_ctx,
+                                       grpclb_dns_resolver* r);
+static void dns_grpclb_maybe_finish_next_locked(grpc_exec_ctx* exec_ctx,
+                                         grpclb_dns_resolver* r);
+
+static void dns_grpclb_shutdown_locked(grpc_exec_ctx* exec_ctx, grpc_resolver* r);
+static void dns_grpclb_channel_saw_error_locked(grpc_exec_ctx* exec_ctx,
+                                         grpc_resolver* r);
+static void dns_grpclb_next_locked(grpc_exec_ctx* exec_ctx, grpc_resolver* r,
+                            grpc_channel_args** target_result,
+                            grpc_closure* on_complete);
+
+static const grpc_resolver_vtable dns_grpclb_resolver_vtable = {
+    dns_grpclb_destroy, dns_grpclb_shutdown_locked, dns_grpclb_channel_saw_error_locked,
+    dns_grpclb_next_locked};
+
+static void dns_grpclb_shutdown_locked(grpc_exec_ctx* exec_ctx,
+                                grpc_resolver* resolver) {
+  grpclb_dns_resolver* r = (grpclb_dns_resolver*)resolver;
+  if (r->have_retry_timer) {
+    grpc_timer_cancel(exec_ctx, &r->retry_timer);
+  }
+  if (r->next_completion != nullptr) {
+    *r->target_result = nullptr;
+    GRPC_CLOSURE_SCHED(
+        exec_ctx, r->next_completion,
+        GRPC_ERROR_CREATE_FROM_STATIC_STRING("Resolver Shutdown"));
+    r->next_completion = nullptr;
+  }
+}
+
+static void dns_grpclb_channel_saw_error_locked(grpc_exec_ctx* exec_ctx,
+                                         grpc_resolver* resolver) {
+  grpclb_dns_resolver* r = (grpclb_dns_resolver*)resolver;
+  if (!r->resolving) {
+    grpc_backoff_reset(&r->backoff_state);
+    dns_grpclb_start_resolving_locked(exec_ctx, r);
+  }
+}
+
+static void dns_grpclb_next_locked(grpc_exec_ctx* exec_ctx, grpc_resolver* resolver,
+                            grpc_channel_args** target_result,
+                            grpc_closure* on_complete) {
+  grpclb_dns_resolver* r = (grpclb_dns_resolver*)resolver;
+  GPR_ASSERT(!r->next_completion);
+  r->next_completion = on_complete;
+  r->target_result = target_result;
+  if (r->resolved_version == 0 && !r->resolving) {
+    grpc_backoff_reset(&r->backoff_state);
+    dns_grpclb_start_resolving_locked(exec_ctx, r);
+  } else {
+    dns_grpclb_maybe_finish_next_locked(exec_ctx, r);
+  }
+}
+
+static void dns_grpclb_on_retry_timer_locked(grpc_exec_ctx* exec_ctx, void* arg,
+                                      grpc_error* error) {
+  grpclb_dns_resolver* r = (grpclb_dns_resolver*)arg;
+
+  r->have_retry_timer = false;
+  if (error == GRPC_ERROR_NONE) {
+    if (!r->resolving) {
+      dns_grpclb_start_resolving_locked(exec_ctx, r);
+    }
+  }
+
+  GRPC_RESOLVER_UNREF(exec_ctx, &r->base, "retry-timer");
+}
+
+static void dns_grpclb_on_resolved_locked(grpc_exec_ctx* exec_ctx, void* arg,
+                                   grpc_error* error) {
+  grpclb_dns_resolver* r = (grpclb_dns_resolver*)arg;
+  grpc_channel_args* result = nullptr;
+  GPR_ASSERT(r->resolving);
+  r->resolving = false;
+  GRPC_ERROR_REF(error);
+  error = grpc_error_set_str(error, GRPC_ERROR_STR_TARGET_ADDRESS,
+                             grpc_slice_from_copied_string(r->name_to_resolve));
+  if (r->addresses != nullptr) {
+    grpc_lb_addresses* addresses = grpc_lb_addresses_create(
+        r->addresses->naddrs, nullptr /* user_data_vtable */);
+    for (size_t i = 0; i < r->addresses->naddrs; ++i) {
+      grpc_lb_addresses_set_address(
+          addresses, i, &r->addresses->addrs[i].addr,
+          r->addresses->addrs[i].len, true /* is_balancer */,
+          r->balancer_name /* balancer_name */, nullptr /* user_data */);
+    }
+    grpc_arg new_arg = grpc_lb_addresses_create_channel_arg(addresses);
+    result = grpc_channel_args_copy_and_add(r->channel_args, &new_arg, 1);
+    grpc_resolved_addresses_destroy(r->addresses);
+    grpc_lb_addresses_destroy(exec_ctx, addresses);
+  } else {
+    grpc_millis next_try =
+        grpc_backoff_step(exec_ctx, &r->backoff_state).next_attempt_start_time;
+    grpc_millis timeout = next_try - grpc_exec_ctx_now(exec_ctx);
+    gpr_log(GPR_INFO, "dns resolution failed (will retry): %s",
+            grpc_error_string(error));
+    GPR_ASSERT(!r->have_retry_timer);
+    r->have_retry_timer = true;
+    GRPC_RESOLVER_REF(&r->base, "retry-timer");
+    if (timeout > 0) {
+      gpr_log(GPR_DEBUG, "retrying in %" PRIdPTR " milliseconds", timeout);
+    } else {
+      gpr_log(GPR_DEBUG, "retrying immediately");
+    }
+    GRPC_CLOSURE_INIT(&r->on_retry, dns_grpclb_on_retry_timer_locked, r,
+                      grpc_combiner_scheduler(r->base.combiner));
+    grpc_timer_init(exec_ctx, &r->retry_timer, next_try, &r->on_retry);
+  }
+  if (r->resolved_result != nullptr) {
+    grpc_channel_args_destroy(exec_ctx, r->resolved_result);
+  }
+  r->resolved_result = result;
+  r->resolved_version++;
+  dns_grpclb_maybe_finish_next_locked(exec_ctx, r);
+  GRPC_ERROR_UNREF(error);
+
+  GRPC_RESOLVER_UNREF(exec_ctx, &r->base, "dns-resolving");
+}
+
+static void dns_grpclb_start_resolving_locked(grpc_exec_ctx* exec_ctx,
+                                       grpclb_dns_resolver* r) {
+  GRPC_RESOLVER_REF(&r->base, "dns-resolving");
+  GPR_ASSERT(!r->resolving);
+  r->resolving = true;
+  r->addresses = nullptr;
+  grpc_resolve_address(
+      exec_ctx, r->name_to_resolve, r->default_port, r->interested_parties,
+      GRPC_CLOSURE_CREATE(dns_grpclb_on_resolved_locked, r,
+                          grpc_combiner_scheduler(r->base.combiner)),
+      &r->addresses);
+}
+
+static void dns_grpclb_maybe_finish_next_locked(grpc_exec_ctx* exec_ctx,
+                                         grpclb_dns_resolver* r) {
+  if (r->next_completion != nullptr &&
+      r->resolved_version != r->published_version) {
+    *r->target_result = r->resolved_result == nullptr
+                            ? nullptr
+                            : grpc_channel_args_copy(r->resolved_result);
+    GRPC_CLOSURE_SCHED(exec_ctx, r->next_completion, GRPC_ERROR_NONE);
+    r->next_completion = nullptr;
+    r->published_version = r->resolved_version;
+  }
+}
+
+static void dns_grpclb_destroy(grpc_exec_ctx* exec_ctx, grpc_resolver* gr) {
+  grpclb_dns_resolver* r = (grpclb_dns_resolver*)gr;
+  if (r->resolved_result != nullptr) {
+    grpc_channel_args_destroy(exec_ctx, r->resolved_result);
+  }
+  grpc_pollset_set_destroy(exec_ctx, r->interested_parties);
+  gpr_free(r->balancer_name);
+  gpr_free(r->name_to_resolve);
+  gpr_free(r->default_port);
+  grpc_channel_args_destroy(exec_ctx, r->channel_args);
+  gpr_free(r);
+}
+
+static grpc_resolver* dns_grpclb_create(grpc_exec_ctx* exec_ctx,
+                                 grpc_resolver_args* args,
+                                 const char* default_port) {
+  if (0 == strcmp(args->uri->authority, "")) {
+    gpr_log(GPR_ERROR, "grpclb has to be defined as authority");
+    return nullptr;
+  }
+  // Get balancer_name from authority.
+  char* balancer_name;
+  char* ignored_port;
+  if (!gpr_split_host_port(args->uri->authority, &balancer_name, &ignored_port)) {
+    gpr_log(GPR_ERROR, "grpclb authority was not parsable");
+    return nullptr;
+  }
+  gpr_free(ignored_port);
+  // Create resolver.
+  grpclb_dns_resolver* r = (grpclb_dns_resolver*)gpr_zalloc(sizeof(grpclb_dns_resolver));
+  grpc_resolver_init(&r->base, &dns_grpclb_resolver_vtable, args->combiner);
+  r->balancer_name = gpr_strdup(balancer_name);
+  r->name_to_resolve = gpr_strdup(args->uri->authority);
+  r->default_port = gpr_strdup(default_port);
+  r->channel_args = grpc_channel_args_copy(args->args);
+  r->interested_parties = grpc_pollset_set_create();
+  if (args->pollset_set != nullptr) {
+    grpc_pollset_set_add_pollset_set(exec_ctx, r->interested_parties,
+                                     args->pollset_set);
+  }
+  grpc_backoff_init(
+      &r->backoff_state, GRPC_DNS_INITIAL_CONNECT_BACKOFF_SECONDS * 1000,
+      GRPC_DNS_RECONNECT_BACKOFF_MULTIPLIER, GRPC_DNS_RECONNECT_JITTER,
+      GRPC_DNS_MIN_CONNECT_TIMEOUT_SECONDS * 1000,
+      GRPC_DNS_RECONNECT_MAX_BACKOFF_SECONDS * 1000);
+  gpr_free(balancer_name);
+  return &r->base;
+}
+
+/*
+ * FACTORY
+ */
+
+static void dns_grpclb_factory_ref(grpc_resolver_factory* factory) {}
+
+static void dns_grpclb_factory_unref(grpc_resolver_factory* factory) {}
+
+static grpc_resolver* dns_grpclb_factory_create_resolver(
+    grpc_exec_ctx* exec_ctx, grpc_resolver_factory* factory,
+    grpc_resolver_args* args) {
+  return dns_grpclb_create(exec_ctx, args, "https");
+}
+
+static char* dns_grpclb_factory_get_default_host_name(grpc_resolver_factory* factory,
+                                               grpc_uri* uri) {
+  const char* path = uri->path;
+  if (path[0] == '/') ++path;
+  return gpr_strdup(path);
+}
+
+static const grpc_resolver_factory_vtable dns_grpclb_factory_vtable = {
+    dns_grpclb_factory_ref, dns_grpclb_factory_unref, dns_grpclb_factory_create_resolver,
+    dns_grpclb_factory_get_default_host_name, "grpclb"};
+static grpc_resolver_factory grpclb_dns_resolver_factory = {&dns_grpclb_factory_vtable};
+
+static grpc_resolver_factory* grpclb_dns_resolver_factory_create() {
+  return &grpclb_dns_resolver_factory;
+}
+
+void grpc_resolver_dns_grpclb_init(void) {
+  grpc_register_resolver_type(grpclb_dns_resolver_factory_create());
+}
+
+void grpc_resolver_dns_grpclb_shutdown(void) {}

--- a/src/core/plugin_registry/grpc_plugin_registry.cc
+++ b/src/core/plugin_registry/grpc_plugin_registry.cc
@@ -42,6 +42,8 @@ void grpc_resolver_dns_ares_init(void);
 void grpc_resolver_dns_ares_shutdown(void);
 void grpc_resolver_dns_native_init(void);
 void grpc_resolver_dns_native_shutdown(void);
+void grpc_resolver_dns_grpclb_init(void);
+void grpc_resolver_dns_grpclb_shutdown(void);
 void grpc_resolver_sockaddr_init(void);
 void grpc_resolver_sockaddr_shutdown(void);
 void grpc_server_load_reporting_plugin_init(void);
@@ -78,6 +80,8 @@ void grpc_register_built_in_plugins(void) {
                        grpc_resolver_dns_ares_shutdown);
   grpc_register_plugin(grpc_resolver_dns_native_init,
                        grpc_resolver_dns_native_shutdown);
+  grpc_register_plugin(grpc_resolver_dns_grpclb_init,
+                       grpc_resolver_dns_grpclb_shutdown);
   grpc_register_plugin(grpc_resolver_sockaddr_init,
                        grpc_resolver_sockaddr_shutdown);
   grpc_register_plugin(grpc_server_load_reporting_plugin_init,

--- a/src/core/plugin_registry/grpc_unsecure_plugin_registry.cc
+++ b/src/core/plugin_registry/grpc_unsecure_plugin_registry.cc
@@ -32,6 +32,8 @@ void grpc_resolver_dns_ares_init(void);
 void grpc_resolver_dns_ares_shutdown(void);
 void grpc_resolver_dns_native_init(void);
 void grpc_resolver_dns_native_shutdown(void);
+void grpc_resolver_dns_grpclb_init(void);
+void grpc_resolver_dns_grpclb_shutdown(void);
 void grpc_resolver_sockaddr_init(void);
 void grpc_resolver_sockaddr_shutdown(void);
 void grpc_resolver_fake_init(void);
@@ -66,6 +68,8 @@ void grpc_register_built_in_plugins(void) {
                        grpc_resolver_dns_ares_shutdown);
   grpc_register_plugin(grpc_resolver_dns_native_init,
                        grpc_resolver_dns_native_shutdown);
+  grpc_register_plugin(grpc_resolver_dns_grpclb_init,
+                       grpc_resolver_dns_grpclb_shutdown);
   grpc_register_plugin(grpc_resolver_sockaddr_init,
                        grpc_resolver_sockaddr_shutdown);
   grpc_register_plugin(grpc_resolver_fake_init,


### PR DESCRIPTION
This is a fix for #11879 that allows directly contacting an GRPCLB using the common name resolver scheme that is also used for c-ares.  This also allows using GRPCLB without a DNS server in cases of a simple infrastructure or if running multiple GRPC services on premise. Since #12416 is not merged yet, that's also the only way to get GRPCLB usage on windows platforms with C#.