### PR TITLE
PHP: unref key and value in metadata 

### DIFF
--- a/src/php/ext/grpc/call.h
+++ b/src/php/ext/grpc/call.h
@@ -69,5 +69,6 @@ void grpc_init_call(TSRMLS_D);
 /* Populates a grpc_metadata_array with the data in a PHP array object.
    Returns true on success and false on failure */
 bool create_metadata_array(zval *array, grpc_metadata_array *metadata);
-
+void grpc_php_metadata_array_destroy_including_entries(
+    grpc_metadata_array* array);
 #endif /* NET_GRPC_PHP_GRPC_CHANNEL_H_ */


### PR DESCRIPTION
This is reported by Valgrind:
```
==17317== 1,632 bytes in 16 blocks are definitely lost in loss record 119 of 133
==17317==    at 0x4C2DB2F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==17317==    by 0x9926CEE: gpr_malloc (in /usr/local/lib/libgrpc.so.5.0.0-dev)
==17317==    by 0x98C8902: grpc_slice_malloc_large (in /usr/local/lib/libgrpc.so.5.0.0-dev)
==17317==    by 0x98C8989: grpc_slice_malloc (in /usr/local/lib/libgrpc.so.5.0.0-dev)
==17317==    by 0x98C89D2: grpc_slice_from_copied_buffer (in /usr/local/lib/libgrpc.so.5.0.0-dev)
==17317==    by 0x96660F2: create_metadata_array (call.c:169)
==17317==    by 0x966679C: zim_Call_startBatch (call.c:306)
==17317==    by 0x3F157D: ??? (in /usr/bin/php7.0)
==17317==    by 0x3ABDDA: execute_ex (in /usr/bin/php7.0)
==17317==    by 0x35BDB7: zend_call_function (in /usr/bin/php7.0)
==17317==    by 0x2A6B0E: zif_call_user_func_array (in /usr/bin/php7.0)
==17317==    by 0x3F0A9C: ??? (in /usr/bin/php7.0)
```
Unref like what ruby call does can fix it.
https://github.com/grpc/grpc/blob/e759d2ad7abdb0702970eeccc5f033ff4b2a4c7f/src/ruby/ext/grpc/rb_call.c#L652:6