### PR TITLE
Fix a Python spinlock bug

### DIFF
--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -71,6 +71,7 @@ struct grpc_fd {
   int shutdown;
   int closed;
   int released;
+  gpr_atm pollhup;
   grpc_error* shutdown_error;
 
   /* The watcher list.
@@ -339,6 +340,7 @@ static grpc_fd* fd_create(int fd, const char* name) {
   r->on_done_closure = nullptr;
   r->closed = 0;
   r->released = 0;
+  gpr_atm_no_barrier_store(&r->pollhup, 0);
   r->read_notifier_pollset = nullptr;
 
   char* name2;
@@ -964,7 +966,8 @@ static grpc_error* pollset_work(grpc_exec_ctx* exec_ctx, grpc_pollset* pollset,
       pfds[0].events = POLLIN;
       pfds[0].revents = 0;
       for (i = 0; i < pollset->fd_count; i++) {
-        if (fd_is_orphaned(pollset->fds[i])) {
+        if (fd_is_orphaned(pollset->fds[i]) ||
+            gpr_atm_no_barrier_load(&pollset->fds[i]->pollhup) == 1) {
           GRPC_FD_UNREF(pollset->fds[i], "multipoller");
         } else {
           pollset->fds[fd_count++] = pollset->fds[i];
@@ -1030,6 +1033,12 @@ static grpc_error* pollset_work(grpc_exec_ctx* exec_ctx, grpc_pollset* pollset,
               gpr_log(GPR_DEBUG, "%p got_event: %d r:%d w:%d [%d]", pollset,
                       pfds[i].fd, (pfds[i].revents & POLLIN_CHECK) != 0,
                       (pfds[i].revents & POLLOUT_CHECK) != 0, pfds[i].revents);
+            }
+            /* This is a mitigation to prevent poll() from spinning on a
+             ** POLLHUP https://github.com/grpc/grpc/pull/13665
+             */
+            if (pfds[i].revents & POLLHUP) {
+              gpr_atm_no_barrier_store(&watchers[i].fd->pollhup, 1);
             }
             fd_end_poll(exec_ctx, &watchers[i], pfds[i].revents & POLLIN_CHECK,
                         pfds[i].revents & POLLOUT_CHECK, pollset);


### PR DESCRIPTION
Hopefully finally fixes #9688

There has been an issue where ```poll()``` calls spinlock in the Python implementation.  The strace looks as follows.

```
poll([{fd=3, events=POLLIN}, {fd=8, events=POLLIN}, {fd=5, events=POLLIN|POLLOUT}, {fd=11, events=0}], 4, 188) = 1 ([{fd=11, revents=POLLHUP}])
clock_gettime(CLOCK_MONOTONIC, {905930, 24155064}) = 0
poll([{fd=3, events=POLLIN}, {fd=8, events=POLLIN}, {fd=5, events=POLLIN|POLLOUT}, {fd=11, events=0}], 4, 188) = 1 ([{fd=11, revents=POLLHUP}])
clock_gettime(CLOCK_MONOTONIC, {905930, 24206581}) = 0
poll([{fd=3, events=POLLIN}, {fd=8, events=POLLIN}, {fd=5, events=POLLIN|POLLOUT}, {fd=11, events=0}], 4, 188) = 1 ([{fd=11, revents=POLLHUP}])
....
```

I've addressed several Python fd refcounting issues that could have possibly been the cause, but users are still reporting the issue.  This code ~~should~~ be uneeded, but given that users see this in production code but we don't have a reproduction case, I would like to solve this issue once and for all.