### PR TITLE
Surfacing Debug Error String Python

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -291,6 +291,7 @@ cdef extern from "grpc/grpc.h":
     grpc_metadata_array *trailing_metadata
     grpc_status_code *status
     grpc_slice *status_details
+    char** error_string
 
   ctypedef struct grpc_op_data_recv_close_on_server:
     int *cancelled

--- a/src/python/grpcio/grpc/_cython/_cygrpc/operation.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/operation.pxd.pxi
@@ -91,9 +91,11 @@ cdef class ReceiveStatusOnClientOperation(Operation):
   cdef grpc_metadata_array _c_trailing_metadata
   cdef grpc_status_code _c_code
   cdef grpc_slice _c_details
+  cdef const char* _c_error_string
   cdef tuple _trailing_metadata
   cdef object _code
   cdef str _details
+  cdef str _error_string
 
   cdef void c(self)
   cdef void un_c(self)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/operation.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/operation.pyx.pxi
@@ -199,6 +199,8 @@ cdef class ReceiveStatusOnClientOperation(Operation):
         &self._c_code)
     self.c_op.data.receive_status_on_client.status_details = (
         &self._c_details)
+    self.c_op.data.receive_status_on_client.error_string = (
+        &self._c_error_string)
 
   cdef void un_c(self):
     self._trailing_metadata = _metadata(&self._c_trailing_metadata)
@@ -206,6 +208,11 @@ cdef class ReceiveStatusOnClientOperation(Operation):
     self._code = self._c_code
     self._details = _decode(_slice_bytes(self._c_details))
     grpc_slice_unref(self._c_details)
+    if self._c_error_string != NULL:
+      self._error_string = _decode(self._c_error_string)
+      gpr_free(<void*>self._c_error_string)
+    else:
+      self._error_string = ""
 
   def trailing_metadata(self):
     return self._trailing_metadata
@@ -215,6 +222,9 @@ cdef class ReceiveStatusOnClientOperation(Operation):
 
   def details(self):
     return self._details
+
+  def error_string(self):
+    return self._error_string
 
 
 cdef class ReceiveCloseOnServerOperation(Operation):

--- a/src/python/grpcio_tests/tests/unit/_rpc_test.py
+++ b/src/python/grpcio_tests/tests/unit/_rpc_test.py
@@ -225,6 +225,7 @@ class RPCTest(unittest.TestCase):
 
         self.assertEqual(expected_response, response)
         self.assertIs(grpc.StatusCode.OK, call.code())
+        self.assertEqual("", call.debug_error_string())
 
     def testSuccessfulUnaryRequestFutureUnaryResponse(self):
         request = b'\x07\x08'
@@ -706,6 +707,13 @@ class RPCTest(unittest.TestCase):
 
         self.assertIs(grpc.StatusCode.UNKNOWN,
                       exception_context.exception.code())
+        # sanity checks on to make sure returned string contains default members
+        # of the error
+        debug_error_string = exception_context.exception.debug_error_string()
+        self.assertIn("created", debug_error_string)
+        self.assertIn("description", debug_error_string)
+        self.assertIn("file", debug_error_string)
+        self.assertIn("file_line", debug_error_string)
 
     def testFailedUnaryRequestFutureUnaryResponse(self):
         request = b'\x37\x17'


### PR DESCRIPTION
Similar to #13413, but for Python.

Surfaces debug_error_string to the application. Updates representative unit tests to test this behavior

Fixes #13790 