### PR TITLE
Move a CFLAG to be a CPPFLAG when building core for ruby

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -60,7 +60,7 @@ ENV['EMBED_ZLIB'] = 'true'
 ENV['EMBED_CARES'] = 'true'
 ENV['ARCH_FLAGS'] = RbConfig::CONFIG['ARCH_FLAG']
 ENV['ARCH_FLAGS'] = '-arch i386 -arch x86_64' if RUBY_PLATFORM =~ /darwin/
-ENV['CFLAGS'] = '-DGPR_BACKWARDS_COMPATIBILITY_MODE'
+ENV['CPPFLAGS'] = '-DGPR_BACKWARDS_COMPATIBILITY_MODE'
 
 output_dir = File.expand_path(RbConfig::CONFIG['topdir'])
 grpc_lib_dir = File.join(output_dir, 'libs', grpc_config)


### PR DESCRIPTION
ruby's glibc dependency jumped since it's missing the flag

should fix failing distrib tests, e.g. https://grpc-testing.appspot.com/job/gRPC_distribtest/1397/platform=linux/testReport/junit/(root)/tasks/distribtest_ruby_linux_x64_ubuntu1204/