### PR TITLE
pre-boot xcode sim in objc-tests

### DIFF
--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -34,6 +34,18 @@ $BINDIR/interop_server --port=5051 --max_send_message_size=8388608 --use_tls &
 # Kill them when this script exits.
 trap 'kill -9 `jobs -p` ; echo "EXIT TIME:  $(date)"' EXIT
 
+# Boot Xcode first with several retries since Xcode might fail due to a bug:
+# http://www.openradar.me/29785686
+xcrun simctl list | egrep 'iPhone 6 \('
+udid=`xcrun simctl list | egrep 'iPhone 6 \(.*\) \(.*\)' | sed -E 's/ *iPhone 6 \(([^\)]*)\).*/\1/g' | head -n 1`
+retries=0
+while [ $retries -lt 3 ] && ! open -a Simulator --args -CurrentDeviceUDID $udid ; do
+retries=$(($retries+1))
+done
+if [ $retries == 3 ]; then
+  exit 1
+fi
+
 # xcodebuild is very verbose. We filter its output and tell Bash to fail if any
 # element of the pipe fails.
 # TODO(jcanizales): Use xctool instead? Issue #2540.

--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -43,6 +43,7 @@ while [ $retries -lt 3 ] && ! open -a Simulator --args -CurrentDeviceUDID $udid 
 retries=$(($retries+1))
 done
 if [ $retries == 3 ]; then
+  echo "Xcode simulator failed to start after 3 retries."
   exit 1
 fi
 


### PR DESCRIPTION
Xcode fails occasionally on starting up Xcode simulator, due to [a bug](http://www.openradar.me/29785686). This PR tentatively fixes test flakes caused by this problem by pre-booting xcode simulator with 3 times of retries. Needs to put in CI environment to check if it works.