### PR TITLE
Add dummy operator delete to make VS2015 not complain.

### DIFF
--- a/include/grpc++/impl/codegen/async_unary_call.h
+++ b/include/grpc++/impl/codegen/async_unary_call.h
@@ -103,6 +103,13 @@ class ClientAsyncResponseReader final
     assert(size == sizeof(ClientAsyncResponseReader));
   }
 
+  // This operator should never be called as the memory should be freed as part
+  // of the arena destruction. It only exists to provide a matching operator
+  // delete to the operator new so that some compilers will not complain (see
+  // Issue# 11301). Note at the time of adding this there is no tests catching
+  // the compiler warning.
+  static void operator delete(void*, void*) {}
+
   void StartCall() override {
     assert(!started_);
     started_ = true;

--- a/include/grpc++/impl/codegen/async_unary_call.h
+++ b/include/grpc++/impl/codegen/async_unary_call.h
@@ -106,9 +106,9 @@ class ClientAsyncResponseReader final
   // This operator should never be called as the memory should be freed as part
   // of the arena destruction. It only exists to provide a matching operator
   // delete to the operator new so that some compilers will not complain (see
-  // Issue# 11301). Note at the time of adding this there is no tests catching
-  // the compiler warning.
-  static void operator delete(void*, void*) {}
+  // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
+  // there are no tests catching the compiler warning.
+  static void operator delete(void*, void*) { assert(0); }
 
   void StartCall() override {
     assert(!started_);


### PR DESCRIPTION
As mentioned in the comment we do not have test infrastructure covering this, which means we may need to handle similar issues as they come out.

Fixes #11301.