### PR TITLE
Make sure to always pass bazel "args" to tests

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -98,7 +98,7 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
         args = [
           poller,
           '$(location %s)' % name
-        ],
+        ] + args['args'],
       )
   else:
     native.cc_test(**args)


### PR DESCRIPTION
Towards fixing some of the broken bazel tests, e.g. https://github.com/grpc/grpc/issues/13615

Looks like the `args` aren't not getting passed to test binaries invoked through poller script right now because they're getting called directly rather than via `bazel test` or `bazel run`



