### PR TITLE
Fix golden file test under bazel

### DIFF
--- a/test/cpp/codegen/BUILD
+++ b/test/cpp/codegen/BUILD
@@ -14,7 +14,7 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package", "grpc_cc_binary", "grpc_sh_test")
 
 grpc_package(name = "test/cpp/codegen")
 
@@ -55,14 +55,9 @@ grpc_cc_test(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_binary(
     name = "golden_file_test",
     srcs = ["golden_file_test.cc"],
-    args = ["--generated_file_path=$(GENDIR)/src/proto/grpc/testing/"],
-    data = [
-        ":compiler_test_golden",
-        "//src/proto/grpc/testing:_compiler_test_proto_grpc_codegen",
-    ],
     deps = [
         "//:grpc++",
         "//src/proto/grpc/testing:compiler_test_proto",
@@ -71,5 +66,16 @@ grpc_cc_test(
     external_deps = [
         "gtest",
         "gflags",
+    ],
+)
+
+grpc_sh_test(
+    name = "run_golden_file_test",
+    srcs = ["run_golden_file_test.sh"],
+    data = [
+        ":golden_file_test",
+        ":compiler_test_golden",
+        ":compiler_test_mock_golden",
+        "//src/proto/grpc/testing:_compiler_test_proto_grpc_codegen",
     ],
 )

--- a/test/cpp/codegen/run_golden_file_test.sh
+++ b/test/cpp/codegen/run_golden_file_test.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+GENERATED_FILES_PATH="$TEST_SRCDIR/../../../../../genfiles/src/proto/grpc/testing/"
+test/cpp/codegen/golden_file_test --generated_file_path="$GENERATED_FILES_PATH"


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/13615

I've tested this locally so far, in which `bazel test --spawn_strategy=standalone --genrule_strategy=standalone //test/cpp/codegen:run_golden_file_test` now passes when it didn't before.

It looks like this relative path should be stable, based off [this doc](https://docs.bazel.build/versions/master/output_directories.html)