### PR TITLE
Add go release versions to client_matrix.py

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -101,7 +101,7 @@ LANG_RELEASE_MATRIX = {
             'v1.7.4': None
         },
         {
-            'v1.8.1': None
+            'v1.8.2': None
         },
     ],
     'java': [


### PR DESCRIPTION
$ gcloud beta container images list-tags gcr.io/grpc-testing/grpc_interop_go1.8
```
DIGEST        TAGS    TIMESTAMP
ae47eb7fee72  v1.8.2  2017-12-12T17:01:54
1f30029aefbe  v1.8.1  2017-12-05T11:29:58
de5de35d8c0f  v1.7.4  2017-12-05T11:29:14
01cdc4b28bf8  v1.8.0  2017-11-21T17:22:51
2bdc2990d55a  v1.7.3  2017-11-21T17:22:31
c8cca2206b87  v1.7.2  2017-11-21T17:21:53
415038162393  v1.7.1  2017-11-21T17:21:20
43e487f6259e          2017-11-21T17:16:08
1098f018bbcf  v1.7.0  2017-10-18T21:48:41
4dc5a1f3f7c2  v1.6.0  2017-10-18T21:31:41
```