### PR TITLE
Fix interop_matrix/create_matrix_images.py error

### DIFF
--- a/tools/interop_matrix/create_matrix_images.py
+++ b/tools/interop_matrix/create_matrix_images.py
@@ -254,8 +254,9 @@ def maybe_apply_patches_on_git_tag(stack_base, lang, release):
     files_to_patch = []
     for release_info in client_matrix.LANG_RELEASE_MATRIX[lang]:
         if client_matrix.get_release_tag_name(release_info) == release:
-            files_to_patch = release_info[release].get('patch')
-            break
+            if release_info[release] is not None:
+                files_to_patch = release_info[release].get('patch')
+                break
     if not files_to_patch:
         return
     patch_file_relative_path = 'patches/%s_%s/git_repo.patch' % (lang, release)


### PR DESCRIPTION
Without this change, `tools/interop_matrix/create_matrix_images.py --git_checkout --release=v1.7.4 --language=go` fails with
```
Traceback (most recent call last):
  File "tools/interop_matrix/create_matrix_images.py", line 334, in <module>
    docker_images = build_all_images_for_lang(lang)
  File "tools/interop_matrix/create_matrix_images.py", line 187, in build_all_images_for_lang
    images += build_all_images_for_release(lang, release)
  File "tools/interop_matrix/create_matrix_images.py", line 204, in build_all_images_for_release
    stack_base = checkout_grpc_stack(lang, release)
  File "tools/interop_matrix/create_matrix_images.py", line 318, in checkout_grpc_stack
    maybe_apply_patches_on_git_tag(stack_base, lang, release)
  File "tools/interop_matrix/create_matrix_images.py", line 257, in maybe_apply_patches_on_git_tag
    files_to_patch = release_info[release].get('patch')
AttributeError: 'NoneType' object has no attribute 'get'
```