### PR TITLE
Remove version column on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ This repository contains source code for gRPC libraries for multiple languages w
 
 Libraries in different languages may be in different states of development. We are seeking contributions for all of these libraries.
 
-| Language                | Source                              | Status  |
-|-------------------------|-------------------------------------|---------|
-| Shared C [core library] | [src/core](src/core)                | 1.8     |
-| C++                     | [src/cpp](src/cpp)                  | 1.8     |
-| Ruby                    | [src/ruby](src/ruby)                | 1.8     |
-| Python                  | [src/python](src/python)            | 1.8     |
-| PHP                     | [src/php](src/php)                  | 1.8     |
-| C#                      | [src/csharp](src/csharp)            | 1.8     |
-| Objective-C             | [src/objective-c](src/objective-c)  | 1.8     |
+| Language                | Source                              |
+|-------------------------|-------------------------------------|
+| Shared C [core library] | [src/core](src/core)                |
+| C++                     | [src/cpp](src/cpp)                  |
+| Ruby                    | [src/ruby](src/ruby)                |
+| Python                  | [src/python](src/python)            |
+| PHP                     | [src/php](src/php)                  |
+| C#                      | [src/csharp](src/csharp)            |
+| Objective-C             | [src/objective-c](src/objective-c)  |
 
 Java source code is in the [grpc-java](http://github.com/grpc/grpc-java)
 repository. Go source code is in the


### PR DESCRIPTION
It provides dubious benefits and often goes stale and becomes more misleading than useful. Let's kill off that column.