### PR TITLE
Ignore pyc files on yapf diff

### DIFF
--- a/tools/distrib/yapf_code.sh
+++ b/tools/distrib/yapf_code.sh
@@ -54,7 +54,7 @@ else
 	tempdir=$(mktemp -d)
 	cp -RT "${dir}" "${tempdir}"
 	yapf "${tempdir}"
-	diff -ru "${dir}" "${tempdir}" || ok=no
+	diff -x '*.pyc' -ru "${dir}" "${tempdir}" || ok=no
 	rm -rf "${tempdir}"
     done
     if [[ ${ok} == no ]]; then


### PR DESCRIPTION
Fixes #13757

Yapf was failing because a .pyc file was hanging around.  We should ignore these files.

Also, I looked into only diffing .py files, but it looks like ```diff``` only supports exclusionary arguments.