### PR TITLE
Fix unused parameter warning in cpp codegen

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -1383,6 +1383,7 @@ void PrintSourceService(grpc_generator::Printer* printer,
                  "std::unique_ptr< $ns$$Service$::Stub> $ns$$Service$::NewStub("
                  "const std::shared_ptr< ::grpc::ChannelInterface>& channel, "
                  "const ::grpc::StubOptions& options) {\n"
+                 "  (void)options;\n"
                  "  std::unique_ptr< $ns$$Service$::Stub> stub(new "
                  "$ns$$Service$::Stub(channel));\n"
                  "  return stub;\n"


### PR DESCRIPTION
Credit to @dholm for this fix #13104, It just never got merged due to a CLA issue.

Fixes #6518 