### PR TITLE
Try fixing Grpc.Core.targets to avoid include dependencies in dependent packages

### DIFF
--- a/src/csharp/Grpc.Core/Grpc.Core.targets
+++ b/src/csharp/Grpc.Core/Grpc.Core.targets
@@ -1,35 +1,35 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win\native\grpc_csharp_ext.x86.dll">
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win\native\grpc_csharp_ext.x86.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>grpc_csharp_ext.x86.dll</Link>
       <Visible>false</Visible>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win\native\grpc_csharp_ext.x64.dll">
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win\native\grpc_csharp_ext.x64.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>grpc_csharp_ext.x64.dll</Link>
       <Visible>false</Visible>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux\native\libgrpc_csharp_ext.x86.so">
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux\native\libgrpc_csharp_ext.x86.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>libgrpc_csharp_ext.x86.so</Link>
       <Visible>false</Visible>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux\native\libgrpc_csharp_ext.x64.so">
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux\native\libgrpc_csharp_ext.x64.so">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>libgrpc_csharp_ext.x64.so</Link>
       <Visible>false</Visible>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx\native\libgrpc_csharp_ext.x86.dylib">
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx\native\libgrpc_csharp_ext.x86.dylib">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>libgrpc_csharp_ext.x86.dylib</Link>
       <Visible>false</Visible>
-    </Content>
-    <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx\native\libgrpc_csharp_ext.x64.dylib">
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx\native\libgrpc_csharp_ext.x64.dylib">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>libgrpc_csharp_ext.x64.dylib</Link>
       <Visible>false</Visible>
-    </Content>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/12926.

This change is potentially dangerous because I think there was a reason why we used `Content` initially:
- let's have a solution with project A that has a dependency on Grpc.Core nuget.  We also have a project B (e.g. an executable) that depends on project A, but doesn't explicitly add Grpc.Core dependency. The Grpc.Core.targets are supposed to make sure that the native libraries are copied to output all projects that transitively depend on Grpc.Core (in our case that's project B). Otherwise, when running B.exe, the native libraries won't be available in the output directory as expected and the application will crash at startup.
- this is all for .NET4.5 and the "old style" .csproj projects. In dotnet CLI, things work without relying on Grpc.Core.targets.

Because of the reasons above, we need to check carefully if changing Content -> None won't break our users.

