### PR TITLE
Fix tsan in bad_client tests

### DIFF
--- a/src/core/lib/iomgr/resource_quota.cc
+++ b/src/core/lib/iomgr/resource_quota.cc
@@ -507,6 +507,7 @@ static void ru_shutdown(void* ru, grpc_error* error) {
     gpr_log(GPR_DEBUG, "RU shutdown %p", ru);
   }
   grpc_resource_user* resource_user = (grpc_resource_user*)ru;
+  gpr_mu_lock(&resource_user->mu);
   GRPC_CLOSURE_SCHED(resource_user->reclaimers[0], GRPC_ERROR_CANCELLED);
   GRPC_CLOSURE_SCHED(resource_user->reclaimers[1], GRPC_ERROR_CANCELLED);
   resource_user->reclaimers[0] = nullptr;
@@ -516,6 +517,7 @@ static void ru_shutdown(void* ru, grpc_error* error) {
   if (resource_user->allocating) {
     rq_step_sched(resource_user->resource_quota);
   }
+  gpr_mu_unlock(&resource_user->mu);
 }
 
 static void ru_destroy(void* ru, grpc_error* error) {


### PR DESCRIPTION
Attempt to fix #13768 (and several other bad_client TSAN failures)

I could not repro this flake locally, so this is all based on the output from the [kokoro failure](https://sponge.corp.google.com/target?id=ae0b0925-20ec-4400-aeb3-929ce58ae990&target=github/grpc/c_linux_tsan_native&searchFor=&show=ALL&sortBy=STATUS)

Loos like even though `grpc_resource_user_shutdown` is protected by `resource_user->resource_quota->combiner`, that does not protect `allocating`, which is in `resource_user` and thus must be protected by `resource_user->mu`