### PR TITLE
Tentatively disable so_reuseport in ruby tests

### DIFF
--- a/src/ruby/end2end/channel_closing_client.rb
+++ b/src/ruby/end2end/channel_closing_client.rb
@@ -44,7 +44,7 @@ def main
   ch = GRPC::Core::Channel.new("localhost:#{server_port}", {},
                                :this_channel_is_insecure)
 
-  srv = GRPC::RpcServer.new
+  srv = new_rpc_server_for_testing
   thd = Thread.new do
     srv.add_http2_port("0.0.0.0:#{client_control_port}", :this_port_is_insecure)
     srv.handle(ChannelClosingClientController.new(ch))

--- a/src/ruby/end2end/end2end_common.rb
+++ b/src/ruby/end2end/end2end_common.rb
@@ -29,6 +29,9 @@ require 'optparse'
 require 'thread'
 require 'timeout'
 require 'English' # see https://github.com/bbatsov/rubocop/issues/1747
+require_relative '../spec/support/helpers'
+
+include GRPC::Spec::Helpers
 
 # GreeterServer is simple server that implements the Helloworld Greeter server.
 class EchoServerImpl < Echo::EchoServer::Service
@@ -46,7 +49,7 @@ class ServerRunner
   end
 
   def run
-    @srv = GRPC::RpcServer.new(@rpc_server_args)
+    @srv = new_rpc_server_for_testing(@rpc_server_args)
     port = @srv.add_http2_port('0.0.0.0:0', :this_port_is_insecure)
     @srv.handle(@service_impl)
 

--- a/src/ruby/end2end/sig_handling_client.rb
+++ b/src/ruby/end2end/sig_handling_client.rb
@@ -66,7 +66,7 @@ def main
 
   # The "shutdown" RPC should end very quickly.
   # Allow a few seconds to be safe.
-  srv = GRPC::RpcServer.new(poll_period: 3)
+  srv = new_rpc_server_for_testing(poll_period: 3)
   srv.add_http2_port("0.0.0.0:#{client_control_port}",
                      :this_port_is_insecure)
   stub = Echo::EchoServer::Stub.new("localhost:#{server_port}",

--- a/src/ruby/spec/channel_connection_spec.rb
+++ b/src/ruby/spec/channel_connection_spec.rb
@@ -16,9 +16,10 @@ require 'timeout'
 
 include Timeout
 include GRPC::Core
+include GRPC::Spec::Helpers
 
 def start_server(port = 0)
-  @srv = GRPC::RpcServer.new(pool_size: 1)
+  @srv = new_rpc_server_for_testing(pool_size: 1)
   server_port = @srv.add_http2_port("localhost:#{port}", :this_port_is_insecure)
   @srv.handle(EchoService)
   @server_thd = Thread.new { @srv.run }

--- a/src/ruby/spec/client_auth_spec.rb
+++ b/src/ruby/spec/client_auth_spec.rb
@@ -95,7 +95,7 @@ describe 'client-server auth' do
     server_opts = {
       poll_period: 1
     }
-    @srv = RpcServer.new(**server_opts)
+    @srv = new_rpc_server_for_testing(**server_opts)
     port = @srv.add_http2_port('0.0.0.0:0', create_server_creds)
     @srv.handle(SslTestService)
     @srv_thd = Thread.new { @srv.run }

--- a/src/ruby/spec/client_server_spec.rb
+++ b/src/ruby/spec/client_server_spec.rb
@@ -542,7 +542,7 @@ end
 describe 'the http client/server' do
   before(:example) do
     server_host = '0.0.0.0:0'
-    @server = GRPC::Core::Server.new(nil)
+    @server = new_core_server_for_testing(nil)
     server_port = @server.add_http2_port(server_host, :this_port_is_insecure)
     @server.start
     @ch = Channel.new("0.0.0.0:#{server_port}", nil, :this_channel_is_insecure)
@@ -574,7 +574,7 @@ describe 'the secure http client/server' do
     server_host = '0.0.0.0:0'
     server_creds = GRPC::Core::ServerCredentials.new(
       nil, [{ private_key: certs[1], cert_chain: certs[2] }], false)
-    @server = GRPC::Core::Server.new(nil)
+    @server = new_core_server_for_testing(nil)
     server_port = @server.add_http2_port(server_host, server_creds)
     @server.start
     args = { Channel::SSL_TARGET => 'foo.test.google.fr' }

--- a/src/ruby/spec/generic/active_call_spec.rb
+++ b/src/ruby/spec/generic/active_call_spec.rb
@@ -40,7 +40,7 @@ describe GRPC::ActiveCall do
   before(:each) do
     @pass_through = proc { |x| x }
     host = '0.0.0.0:0'
-    @server = GRPC::Core::Server.new(nil)
+    @server = new_core_server_for_testing(nil)
     server_port = @server.add_http2_port(host, :this_port_is_insecure)
     @server.start
     @ch = GRPC::Core::Channel.new("0.0.0.0:#{server_port}", nil,

--- a/src/ruby/spec/generic/client_stub_spec.rb
+++ b/src/ruby/spec/generic/client_stub_spec.rb
@@ -888,12 +888,12 @@ describe 'ClientStub' do
     secure_credentials = GRPC::Core::ServerCredentials.new(
       nil, [{ private_key: certs[1], cert_chain: certs[2] }], false)
 
-    @server = GRPC::Core::Server.new(nil)
+    @server = new_core_server_for_testing(nil)
     @server.add_http2_port('0.0.0.0:0', secure_credentials)
   end
 
   def create_test_server
-    @server = GRPC::Core::Server.new(nil)
+    @server = new_core_server_for_testing(nil)
     @server.add_http2_port('0.0.0.0:0', :this_port_is_insecure)
   end
 

--- a/src/ruby/spec/generic/interceptor_registry_spec.rb
+++ b/src/ruby/spec/generic/interceptor_registry_spec.rb
@@ -14,7 +14,7 @@
 require 'spec_helper'
 
 describe GRPC::InterceptorRegistry do
-  let(:server) { RpcServer.new }
+  let(:server) { new_rpc_server_for_testing }
   let(:interceptor) { TestServerInterceptor.new }
   let(:interceptors) { [interceptor] }
   let(:registry) { described_class.new(interceptors) }

--- a/src/ruby/spec/generic/rpc_server_spec.rb
+++ b/src/ruby/spec/generic/rpc_server_spec.rb
@@ -172,7 +172,7 @@ describe GRPC::RpcServer do
     it 'can be created with just some args' do
       opts = { server_args: { a_channel_arg: 'an_arg' } }
       blk = proc do
-        RpcServer.new(**opts)
+        new_rpc_server_for_testing(**opts)
       end
       expect(&blk).not_to raise_error
     end
@@ -183,7 +183,7 @@ describe GRPC::RpcServer do
           server_args: { a_channel_arg: 'an_arg' },
           creds: Object.new
         }
-        RpcServer.new(**opts)
+        new_rpc_server_for_testing(**opts)
       end
       expect(&blk).to raise_error
     end
@@ -192,7 +192,7 @@ describe GRPC::RpcServer do
   describe '#stopped?' do
     before(:each) do
       opts = { server_args: { a_channel_arg: 'an_arg' }, poll_period: 1.5 }
-      @srv = RpcServer.new(**opts)
+      @srv = new_rpc_server_for_testing(**opts)
       @srv.add_http2_port('0.0.0.0:0', :this_port_is_insecure)
     end
 
@@ -224,7 +224,7 @@ describe GRPC::RpcServer do
       opts = {
         server_args: { a_channel_arg: 'an_arg' }
       }
-      r = RpcServer.new(**opts)
+      r = new_rpc_server_for_testing(**opts)
       expect(r.running?).to be(false)
     end
 
@@ -233,7 +233,7 @@ describe GRPC::RpcServer do
         server_args: { a_channel_arg: 'an_arg' },
         poll_period: 2
       }
-      r = RpcServer.new(**opts)
+      r = new_rpc_server_for_testing(**opts)
       r.add_http2_port('0.0.0.0:0', :this_port_is_insecure)
       expect { r.run }.to raise_error(RuntimeError)
     end
@@ -243,7 +243,7 @@ describe GRPC::RpcServer do
         server_args: { a_channel_arg: 'an_arg' },
         poll_period: 2.5
       }
-      r = RpcServer.new(**opts)
+      r = new_rpc_server_for_testing(**opts)
       r.add_http2_port('0.0.0.0:0', :this_port_is_insecure)
       r.handle(EchoService)
       t = Thread.new { r.run }
@@ -257,7 +257,7 @@ describe GRPC::RpcServer do
   describe '#handle' do
     before(:each) do
       @opts = { server_args: { a_channel_arg: 'an_arg' }, poll_period: 1 }
-      @srv = RpcServer.new(**@opts)
+      @srv = new_rpc_server_for_testing(**@opts)
       @srv.add_http2_port('0.0.0.0:0', :this_port_is_insecure)
     end
 
@@ -303,7 +303,7 @@ describe GRPC::RpcServer do
         server_opts = {
           poll_period: 1
         }
-        @srv = RpcServer.new(**server_opts)
+        @srv = new_rpc_server_for_testing(**server_opts)
         server_port = @srv.add_http2_port('0.0.0.0:0', :this_port_is_insecure)
         @host = "localhost:#{server_port}"
         @ch = GRPC::Core::Channel.new(@host, nil, :this_channel_is_insecure)
@@ -474,7 +474,7 @@ describe GRPC::RpcServer do
           poll_period: 1,
           max_waiting_requests: 1
         }
-        alt_srv = RpcServer.new(**opts)
+        alt_srv = new_rpc_server_for_testing(**opts)
         alt_srv.handle(SlowService)
         alt_port = alt_srv.add_http2_port('0.0.0.0:0', :this_port_is_insecure)
         alt_host = "0.0.0.0:#{alt_port}"
@@ -538,7 +538,7 @@ describe GRPC::RpcServer do
           poll_period: 1,
           connect_md_proc: test_md_proc
         }
-        @srv = RpcServer.new(**server_opts)
+        @srv = new_rpc_server_for_testing(**server_opts)
         alt_port = @srv.add_http2_port('0.0.0.0:0', :this_port_is_insecure)
         @alt_host = "0.0.0.0:#{alt_port}"
       end
@@ -573,7 +573,7 @@ describe GRPC::RpcServer do
         server_opts = {
           poll_period: 1
         }
-        @srv = RpcServer.new(**server_opts)
+        @srv = new_rpc_server_for_testing(**server_opts)
         alt_port = @srv.add_http2_port('0.0.0.0:0', :this_port_is_insecure)
         @alt_host = "0.0.0.0:#{alt_port}"
       end
@@ -624,7 +624,7 @@ describe GRPC::RpcServer do
         server_opts = {
           poll_period: 1
         }
-        @srv = RpcServer.new(**server_opts)
+        @srv = new_rpc_server_for_testing(**server_opts)
         alt_port = @srv.add_http2_port('0.0.0.0:0', :this_port_is_insecure)
         @alt_host = "0.0.0.0:#{alt_port}"
 

--- a/src/ruby/spec/google_rpc_status_utils_spec.rb
+++ b/src/ruby/spec/google_rpc_status_utils_spec.rb
@@ -19,6 +19,7 @@ require_relative '../pb/src/proto/grpc/testing/messages_pb'
 require 'google/protobuf/well_known_types'
 
 include GRPC::Core
+include GRPC::Spec::Helpers
 
 describe 'conversion from a status struct to a google protobuf status' do
   it 'fails if the input is not a status struct' do
@@ -150,7 +151,7 @@ GoogleRpcStatusTestStub = GoogleRpcStatusTestService.rpc_stub_class
 
 describe 'receving a google rpc status from a remote endpoint' do
   def start_server(encoded_rpc_status)
-    @srv = GRPC::RpcServer.new(pool_size: 1)
+    @srv = new_rpc_server_for_testing(pool_size: 1)
     @server_port = @srv.add_http2_port('localhost:0',
                                        :this_port_is_insecure)
     @srv.handle(GoogleRpcStatusTestService.new(encoded_rpc_status))
@@ -238,7 +239,7 @@ NoStatusDetailsBinTestServiceStub = NoStatusDetailsBinTestService.rpc_stub_class
 
 describe 'when the endpoint doesnt send grpc-status-details-bin' do
   def start_server
-    @srv = GRPC::RpcServer.new(pool_size: 1)
+    @srv = new_rpc_server_for_testing(pool_size: 1)
     @server_port = @srv.add_http2_port('localhost:0',
                                        :this_port_is_insecure)
     @srv.handle(NoStatusDetailsBinTestService)

--- a/src/ruby/spec/pb/health/checker_spec.rb
+++ b/src/ruby/spec/pb/health/checker_spec.rb
@@ -192,7 +192,7 @@ describe Grpc::Health::Checker do
       server_opts = {
         poll_period: 1
       }
-      @srv = RpcServer.new(**server_opts)
+      @srv = new_rpc_server_for_testing(**server_opts)
       server_port = @srv.add_http2_port(server_host, :this_port_is_insecure)
       @host = "localhost:#{server_port}"
       @ch = GRPC::Core::Channel.new(@host, nil, :this_channel_is_insecure)

--- a/src/ruby/spec/server_spec.rb
+++ b/src/ruby/spec/server_spec.rb
@@ -30,12 +30,12 @@ describe Server do
 
   describe '#start' do
     it 'runs without failing' do
-      blk = proc { Server.new(nil).start }
+      blk = proc { new_core_server_for_testing(nil).start }
       expect(&blk).to_not raise_error
     end
 
     it 'fails if the server is closed' do
-      s = Server.new(nil)
+      s = new_core_server_for_testing(nil)
       s.close
       expect { s.start }.to raise_error(RuntimeError)
     end
@@ -85,7 +85,7 @@ describe Server do
     describe 'for insecure servers' do
       it 'runs without failing' do
         blk = proc do
-          s = Server.new(nil)
+          s = new_core_server_for_testing(nil)
           s.add_http2_port('localhost:0', :this_port_is_insecure)
           s.close
         end
@@ -93,7 +93,7 @@ describe Server do
       end
 
       it 'fails if the server is closed' do
-        s = Server.new(nil)
+        s = new_core_server_for_testing(nil)
         s.close
         blk = proc do
           s.add_http2_port('localhost:0', :this_port_is_insecure)
@@ -106,7 +106,7 @@ describe Server do
       let(:cert) { create_test_cert }
       it 'runs without failing' do
         blk = proc do
-          s = Server.new(nil)
+          s = new_core_server_for_testing(nil)
           s.add_http2_port('localhost:0', cert)
           s.close
         end
@@ -114,7 +114,7 @@ describe Server do
       end
 
       it 'fails if the server is closed' do
-        s = Server.new(nil)
+        s = new_core_server_for_testing(nil)
         s.close
         blk = proc { s.add_http2_port('localhost:0', cert) }
         expect(&blk).to raise_error(RuntimeError)
@@ -124,7 +124,7 @@ describe Server do
 
   shared_examples '#new' do
     it 'takes nil channel args' do
-      expect { Server.new(nil) }.to_not raise_error
+      expect { new_core_server_for_testing(nil) }.to_not raise_error
     end
 
     it 'does not take a hash with bad keys as channel args' do
@@ -175,14 +175,14 @@ describe Server do
 
   describe '#new with an insecure channel' do
     def construct_with_args(a)
-      proc { Server.new(a) }
+      proc { new_core_server_for_testing(a) }
     end
 
     it_behaves_like '#new'
   end
 
   def start_a_server
-    s = Server.new(nil)
+    s = new_core_server_for_testing(nil)
     s.add_http2_port('0.0.0.0:0', :this_port_is_insecure)
     s.start
     s

--- a/src/ruby/spec/support/helpers.rb
+++ b/src/ruby/spec/support/helpers.rb
@@ -31,7 +31,7 @@ module GRPC
       #
       def build_rpc_server(server_opts: {},
                            client_opts: {})
-        @server = RpcServer.new({ poll_period: 1 }.merge(server_opts))
+        @server = new_rpc_server_for_testing({ poll_period: 1 }.merge(server_opts))
         @port = @server.add_http2_port('0.0.0.0:0', :this_port_is_insecure)
         @host = "0.0.0.0:#{@port}"
         @client_opts = client_opts
@@ -67,6 +67,40 @@ module GRPC
         host ||= @host
         opts ||= @client_opts
         klass.new(host, :this_channel_is_insecure, **opts)
+      end
+
+      ##
+      # Build an RPCServer for use in tests. Adds args
+      # that are useful for all tests.
+      #
+      # @param [Hash] server_opts
+      #
+      def new_rpc_server_for_testing(server_opts = {})
+        server_opts[:server_args] ||= {}
+        update_server_args_hash(server_opts[:server_args])
+        RpcServer.new(**server_opts)
+      end
+
+      ##
+      # Build an GRPC::Core::Server for use in tests. Adds args
+      # that are useful for all tests.
+      #
+      # @param [Hash] server_args
+      #
+      def new_core_server_for_testing(server_args)
+        server_args.nil? && server_args = {}
+        update_server_args_hash(server_args)
+        GRPC::Core::Server.new(server_args)
+      end
+
+      def update_server_args_hash(server_args)
+        so_reuseport_arg = 'grpc.so_reuseport'
+        unless server_args[so_reuseport_arg].nil?
+          fail 'Unexpected. grpc.so_reuseport already set.'
+        end
+        # Run tests without so_reuseport to eliminate the chance of
+        # cross-talk.
+        server_args[so_reuseport_arg] = 0
       end
     end
   end


### PR DESCRIPTION
Follows after https://github.com/grpc/grpc/pull/10756, for ruby.

I haven't seen this to be the cause of any real test flakes yet, but I think it would be good to have.

This defines two helpers that start ruby servers without `grpc.so_reuseport` turned off, and then updates all occurrences of server construction within unit tests to use those helpers.