### PR TITLE
[Ruby] Specify module init in README

### DIFF
--- a/src/ruby/README.md
+++ b/src/ruby/README.md
@@ -22,6 +22,12 @@ BUILD FROM SOURCE
 ---------------------
 - Clone this repository
 
+- Init submodules
+
+```sh
+git submodule update --init
+```
+
 - Install Ruby 2.x. Consider doing this with [RVM](http://rvm.io), it's a nice way of controlling
   the exact ruby version that's used.
 ```sh


### PR DESCRIPTION
README should include information on cloning submodule repositories as the instructions for building the Ruby GRPC gem from source won't work.

PR: Adds the following command into the steps to building the gem from source.
```sh
git submodule update --init
```