### PR TITLE
Fix the ownership comment on grpc_lb_addresses_set_address() function.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy_factory.h
+++ b/src/core/ext/filters/client_channel/lb_policy_factory.h
@@ -70,16 +70,14 @@ grpc_lb_addresses* grpc_lb_addresses_create(
 grpc_lb_addresses* grpc_lb_addresses_copy(const grpc_lb_addresses* addresses);
 
 /** Sets the value of the address at index \a index of \a addresses.
- * \a address is a socket address of length \a address_len.
- * Takes ownership of \a balancer_name. */
+ * \a address is a socket address of length \a address_len. */
 void grpc_lb_addresses_set_address(grpc_lb_addresses* addresses, size_t index,
                                    const void* address, size_t address_len,
                                    bool is_balancer, const char* balancer_name,
                                    void* user_data);
 
 /** Sets the value of the address at index \a index of \a addresses from \a uri.
- * Returns true upon success, false otherwise. Takes ownership of \a
- * balancer_name. */
+ * Returns true upon success, false otherwise. */
 bool grpc_lb_addresses_set_address_from_uri(grpc_lb_addresses* addresses,
                                             size_t index, const grpc_uri* uri,
                                             bool is_balancer,


### PR DESCRIPTION
It does not take ownership of balancer_name since commit
53af23cfbf3b1fd4579ec084dbcb7b89a7ae2e96