### PR TITLE
Fix failing ruby distrib tests

### DIFF
--- a/test/distrib/ruby/distribtest.gemspec
+++ b/test/distrib/ruby/distribtest.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.platform      = Gem::Platform::RUBY
 
   s.add_dependency 'grpc', '>=0'
+  s.add_dependency 'public_suffix', '< 3.0'
+  s.add_dependency 'jwt', '< 2.0'
 
   s.add_development_dependency 'bundler', '~> 1.7'
 end

--- a/test/distrib/ruby/run_distrib_test.sh
+++ b/test/distrib/ruby/run_distrib_test.sh
@@ -17,10 +17,16 @@ set -ex
 
 cd $(dirname $0)
 
+ARCH=$1
+PLATFORM=$2
 # Create an indexed local gem source with gRPC gems to test
 GEM_SOURCE=../../../gem_source
 mkdir -p ${GEM_SOURCE}/gems
-cp -r $EXTERNAL_GIT_ROOT/input_artifacts/*.gem ${GEM_SOURCE}/gems
+cp $EXTERNAL_GIT_ROOT/input_artifacts/grpc-*$ARCH-$PLATFORM.gem ${GEM_SOURCE}/gems
+if [[ "$(ls ${GEM_SOURCE}/gems | grep grpc | wc -l)" != 1 ]]; then
+  echo "Sanity check failed. Copied over more than one grpc gem into the gem source directory."
+  exit 1
+fi;
 gem install builder
 gem generate_index --directory ${GEM_SOURCE}
 

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -185,6 +185,10 @@ class RubyDistribTest(object):
         return []
 
     def build_jobspec(self):
+        arch_to_gem_arch = {
+            'x64': 'x86_64',
+            'x86': 'x86',
+        }
         if not self.platform == 'linux':
             raise Exception("Not supported yet.")
 
@@ -192,7 +196,8 @@ class RubyDistribTest(object):
             self.name,
             'tools/dockerfile/distribtest/ruby_%s_%s' % (self.docker_suffix,
                                                          self.arch),
-            'test/distrib/ruby/run_distrib_test.sh',
+            'test/distrib/ruby/run_distrib_test.sh %s %s' %
+            (arch_to_gem_arch[self.arch], self.platform),
             copy_rel_path='test/distrib')
 
     def __str__(self):


### PR DESCRIPTION
this should fix a couple of issues. (distrib tests now running in <s>https://grpc-testing.appspot.com/job/gRPC_build_artifacts/1476/</s>https://grpc-testing.appspot.com/job/gRPC_build_artifacts/1477/, distribtest in https://grpc-testing.appspot.com/job/gRPC_distribtest/1448/)

We need to add dependency constraints on `public_suffix` and `jwt` because a lot of the docker images turn out to be running ruby 2.0, which is incompatible with latest versions of those gems.

And lot of the [failing ruby distrib tests](https://grpc-testing.appspot.com/job/gRPC_distribtest/1419/#showFailuresLink) are currently failing with:

```
Use `bundle info [gemname]` to see where a bundled gem is installed.
The latest bundler is 1.16.0, but you are currently running 1.15.1.
To update, run `gem install bundler`
+ bundle exec ./distribtest.rb
bundler: failed to load command: ./distribtest.rb (./distribtest.rb)
Bundler::GemNotFound: Could not find grpc-1.8.0.pre2 in any of the sources
```

(link: https://grpc-testing.appspot.com/job/gRPC_distribtest/1419/platform=linux/testReport/junit/(root)/tasks/distribtest_ruby_linux_x64_centos7/)


I'm not sure what's the root of this is, but experimentation shows that on certain versions of ruby (`2.0.0` on the images where this failure happened), `bundler install/exec` is unable to cope with local gem indexes that have multiple versions of the same gem.

 