### PR TITLE
C++: Catch exceptions from sync method handlers rather than crashing server

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -39,6 +39,16 @@ config_setting(
 )
 
 config_setting(
+    name = "grpc_allow_exceptions",
+    values = {"define": "GRPC_ALLOW_EXCEPTIONS=1"},
+)
+
+config_setting(
+    name = "grpc_disallow_exceptions",
+    values = {"define": "GRPC_ALLOW_EXCEPTIONS=0"},
+)
+
+config_setting(
     name = "remote_execution",
     values = {"define": "GRPC_PORT_ISOLATED_RUNTIME=1"},
 )
@@ -544,24 +554,24 @@ grpc_cc_library(
 
 grpc_cc_library(
     name = "debug_location",
-    public_hdrs = ["src/core/lib/support/debug_location.h"],
     language = "c++",
+    public_hdrs = ["src/core/lib/support/debug_location.h"],
 )
 
 grpc_cc_library(
     name = "ref_counted",
-    public_hdrs = ["src/core/lib/support/ref_counted.h"],
     language = "c++",
+    public_hdrs = ["src/core/lib/support/ref_counted.h"],
     deps = [
-        "grpc_trace",
         "debug_location",
+        "grpc_trace",
     ],
 )
 
 grpc_cc_library(
     name = "ref_counted_ptr",
-    public_hdrs = ["src/core/lib/support/ref_counted_ptr.h"],
     language = "c++",
+    public_hdrs = ["src/core/lib/support/ref_counted_ptr.h"],
 )
 
 grpc_cc_library(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,6 +525,7 @@ add_dependencies(buildtests_cxx cxx_string_ref_test)
 add_dependencies(buildtests_cxx cxx_time_test)
 add_dependencies(buildtests_cxx end2end_test)
 add_dependencies(buildtests_cxx error_details_test)
+add_dependencies(buildtests_cxx exception_test)
 add_dependencies(buildtests_cxx filter_end2end_test)
 add_dependencies(buildtests_cxx generic_end2end_test)
 add_dependencies(buildtests_cxx golden_file_test)
@@ -10182,6 +10183,46 @@ target_link_libraries(error_details_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_error_details
   grpc++
+  ${_gRPC_GFLAGS_LIBRARIES}
+)
+
+endif (gRPC_BUILD_TESTS)
+if (gRPC_BUILD_TESTS)
+
+add_executable(exception_test
+  test/cpp/end2end/exception_test.cc
+  third_party/googletest/googletest/src/gtest-all.cc
+  third_party/googletest/googlemock/src/gmock-all.cc
+)
+
+
+target_include_directories(exception_test
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
+  PRIVATE ${PROTOBUF_ROOT_DIR}/src
+  PRIVATE ${BENCHMARK_ROOT_DIR}/include
+  PRIVATE ${ZLIB_ROOT_DIR}
+  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/third_party/zlib
+  PRIVATE ${CARES_INCLUDE_DIR}
+  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/third_party/cares/cares
+  PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/third_party/gflags/include
+  PRIVATE third_party/googletest/googletest/include
+  PRIVATE third_party/googletest/googletest
+  PRIVATE third_party/googletest/googlemock/include
+  PRIVATE third_party/googletest/googlemock
+  PRIVATE ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(exception_test
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc++_test_util
+  grpc_test_util
+  grpc++
+  grpc
+  gpr_test_util
+  gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 

--- a/Makefile
+++ b/Makefile
@@ -142,14 +142,14 @@ LDXX_asan-noleaks = clang++
 CPPFLAGS_asan-noleaks = -O0 -fsanitize-coverage=edge -fsanitize=address -fno-omit-frame-pointer -Wno-unused-command-line-argument -DGPR_NO_DIRECT_SYSCALLS
 LDFLAGS_asan-noleaks = -fsanitize=address
 
-VALID_CONFIG_c++-compat = 1
-CC_c++-compat = $(DEFAULT_CC)
-CXX_c++-compat = $(DEFAULT_CXX)
-LD_c++-compat = $(DEFAULT_CC)
-LDXX_c++-compat = $(DEFAULT_CXX)
-CFLAGS_c++-compat = -Wc++-compat
-CPPFLAGS_c++-compat = -O0
-DEFINES_c++-compat = _DEBUG DEBUG
+VALID_CONFIG_noexcept = 1
+CC_noexcept = $(DEFAULT_CC)
+CXX_noexcept = $(DEFAULT_CXX)
+LD_noexcept = $(DEFAULT_CC)
+LDXX_noexcept = $(DEFAULT_CXX)
+CXXFLAGS_noexcept = -fno-exceptions
+CPPFLAGS_noexcept = -O2
+DEFINES_noexcept = NDEBUG
 
 VALID_CONFIG_ubsan = 1
 REQUIRE_CUSTOM_LIBRARIES_ubsan = 1
@@ -204,6 +204,15 @@ LD_lto = $(DEFAULT_CC)
 LDXX_lto = $(DEFAULT_CXX)
 CPPFLAGS_lto = -O2
 DEFINES_lto = NDEBUG
+
+VALID_CONFIG_c++-compat = 1
+CC_c++-compat = $(DEFAULT_CC)
+CXX_c++-compat = $(DEFAULT_CXX)
+LD_c++-compat = $(DEFAULT_CC)
+LDXX_c++-compat = $(DEFAULT_CXX)
+CFLAGS_c++-compat = -Wc++-compat
+CPPFLAGS_c++-compat = -O0
+DEFINES_c++-compat = _DEBUG DEBUG
 
 VALID_CONFIG_mutrace = 1
 CC_mutrace = $(DEFAULT_CC)

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,6 @@ CC_opt = $(DEFAULT_CC)
 CXX_opt = $(DEFAULT_CXX)
 LD_opt = $(DEFAULT_CC)
 LDXX_opt = $(DEFAULT_CXX)
-CXXFLAGS_opt = -fno-exceptions
 CPPFLAGS_opt = -O2
 DEFINES_opt = NDEBUG
 
@@ -95,7 +94,6 @@ CC_dbg = $(DEFAULT_CC)
 CXX_dbg = $(DEFAULT_CXX)
 LD_dbg = $(DEFAULT_CC)
 LDXX_dbg = $(DEFAULT_CXX)
-CXXFLAGS_dbg = -fno-exceptions
 CPPFLAGS_dbg = -O0
 DEFINES_dbg = _DEBUG DEBUG
 
@@ -1126,6 +1124,7 @@ cxx_string_ref_test: $(BINDIR)/$(CONFIG)/cxx_string_ref_test
 cxx_time_test: $(BINDIR)/$(CONFIG)/cxx_time_test
 end2end_test: $(BINDIR)/$(CONFIG)/end2end_test
 error_details_test: $(BINDIR)/$(CONFIG)/error_details_test
+exception_test: $(BINDIR)/$(CONFIG)/exception_test
 filter_end2end_test: $(BINDIR)/$(CONFIG)/filter_end2end_test
 generic_end2end_test: $(BINDIR)/$(CONFIG)/generic_end2end_test
 golden_file_test: $(BINDIR)/$(CONFIG)/golden_file_test
@@ -1573,6 +1572,7 @@ buildtests_cxx: privatelibs_cxx \
   $(BINDIR)/$(CONFIG)/cxx_time_test \
   $(BINDIR)/$(CONFIG)/end2end_test \
   $(BINDIR)/$(CONFIG)/error_details_test \
+  $(BINDIR)/$(CONFIG)/exception_test \
   $(BINDIR)/$(CONFIG)/filter_end2end_test \
   $(BINDIR)/$(CONFIG)/generic_end2end_test \
   $(BINDIR)/$(CONFIG)/golden_file_test \
@@ -1702,6 +1702,7 @@ buildtests_cxx: privatelibs_cxx \
   $(BINDIR)/$(CONFIG)/cxx_time_test \
   $(BINDIR)/$(CONFIG)/end2end_test \
   $(BINDIR)/$(CONFIG)/error_details_test \
+  $(BINDIR)/$(CONFIG)/exception_test \
   $(BINDIR)/$(CONFIG)/filter_end2end_test \
   $(BINDIR)/$(CONFIG)/generic_end2end_test \
   $(BINDIR)/$(CONFIG)/golden_file_test \
@@ -2101,6 +2102,8 @@ test_cxx: buildtests_cxx
 	$(Q) $(BINDIR)/$(CONFIG)/end2end_test || ( echo test end2end_test failed ; exit 1 )
 	$(E) "[RUN]     Testing error_details_test"
 	$(Q) $(BINDIR)/$(CONFIG)/error_details_test || ( echo test error_details_test failed ; exit 1 )
+	$(E) "[RUN]     Testing exception_test"
+	$(Q) $(BINDIR)/$(CONFIG)/exception_test || ( echo test exception_test failed ; exit 1 )
 	$(E) "[RUN]     Testing filter_end2end_test"
 	$(Q) $(BINDIR)/$(CONFIG)/filter_end2end_test || ( echo test filter_end2end_test failed ; exit 1 )
 	$(E) "[RUN]     Testing generic_end2end_test"
@@ -14979,6 +14982,49 @@ ifneq ($(NO_DEPS),true)
 endif
 endif
 $(OBJDIR)/$(CONFIG)/test/cpp/util/error_details_test.o: $(GENDIR)/src/proto/grpc/testing/echo_messages.pb.cc $(GENDIR)/src/proto/grpc/testing/echo_messages.grpc.pb.cc
+
+
+EXCEPTION_TEST_SRC = \
+    test/cpp/end2end/exception_test.cc \
+
+EXCEPTION_TEST_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(EXCEPTION_TEST_SRC))))
+ifeq ($(NO_SECURE),true)
+
+# You can't build secure targets if you don't have OpenSSL.
+
+$(BINDIR)/$(CONFIG)/exception_test: openssl_dep_error
+
+else
+
+
+
+
+ifeq ($(NO_PROTOBUF),true)
+
+# You can't build the protoc plugins or protobuf-enabled targets if you don't have protobuf 3.0.0+.
+
+$(BINDIR)/$(CONFIG)/exception_test: protobuf_dep_error
+
+else
+
+$(BINDIR)/$(CONFIG)/exception_test: $(PROTOBUF_DEP) $(EXCEPTION_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) $(LDXX) $(LDFLAGS) $(EXCEPTION_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) $(LDLIBS_SECURE) $(GTEST_LIB) -o $(BINDIR)/$(CONFIG)/exception_test
+
+endif
+
+endif
+
+$(OBJDIR)/$(CONFIG)/test/cpp/end2end/exception_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
+
+deps_exception_test: $(EXCEPTION_TEST_OBJS:.o=.dep)
+
+ifneq ($(NO_SECURE),true)
+ifneq ($(NO_DEPS),true)
+-include $(EXCEPTION_TEST_OBJS:.o=.dep)
+endif
+endif
 
 
 FILTER_END2END_TEST_SRC = \

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -60,6 +60,10 @@ def grpc_cc_library(name, srcs = [], public_hdrs = [], hdrs = [],
     defines = select({"//:grpc_no_ares": ["GRPC_ARES=0"],
                       "//conditions:default": [],}) +
               select({"//:remote_execution":  ["GRPC_PORT_ISOLATED_RUNTIME=1"],
+                      "//conditions:default": [],} +
+              select({"//:grpc_allow_exceptions":  ["GRPC_ALLOW_EXCEPTIONS=1"],
+                      "//:grpc_disallow_exceptions":
+                      ["GRPC_ALLOW_EXCEPTIONS=0"],
                       "//conditions:default": [],}),
     hdrs = _maybe_update_cc_library_hdrs(hdrs + public_hdrs),
     deps = deps + _get_external_deps(external_deps),

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -60,7 +60,7 @@ def grpc_cc_library(name, srcs = [], public_hdrs = [], hdrs = [],
     defines = select({"//:grpc_no_ares": ["GRPC_ARES=0"],
                       "//conditions:default": [],}) +
               select({"//:remote_execution":  ["GRPC_PORT_ISOLATED_RUNTIME=1"],
-                      "//conditions:default": [],} +
+                      "//conditions:default": [],}) +
               select({"//:grpc_allow_exceptions":  ["GRPC_ALLOW_EXCEPTIONS=1"],
                       "//:grpc_disallow_exceptions":
                       ["GRPC_ALLOW_EXCEPTIONS=0"],

--- a/build.yaml
+++ b/build.yaml
@@ -4007,6 +4007,20 @@ targets:
   deps:
   - grpc++_error_details
   - grpc++
+- name: exception_test
+  gtest: true
+  build: test
+  language: c++
+  src:
+  - test/cpp/end2end/exception_test.cc
+  deps:
+  - grpc++_test_util
+  - grpc_test_util
+  - grpc++
+  - grpc
+  - gpr_test_util
+  - gpr
+  uses_polling: false
 - name: filter_end2end_test
   gtest: true
   build: test
@@ -4913,7 +4927,6 @@ configs:
     DEFINES: NDEBUG
   dbg:
     CPPFLAGS: -O0
-    CXXFLAGS: -fno-exceptions
     DEFINES: _DEBUG DEBUG
   gcov:
     CC: gcc
@@ -4956,7 +4969,6 @@ configs:
     LDFLAGS: -rdynamic
   opt:
     CPPFLAGS: -O2
-    CXXFLAGS: -fno-exceptions
     DEFINES: NDEBUG
   stapprof:
     CPPFLAGS: -O2 -DGRPC_STAP_PROFILER

--- a/build.yaml
+++ b/build.yaml
@@ -4020,7 +4020,6 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
-  uses_polling: false
 - name: filter_end2end_test
   gtest: true
   build: test

--- a/build.yaml
+++ b/build.yaml
@@ -4966,6 +4966,10 @@ configs:
     CPPFLAGS: -O3 -fno-omit-frame-pointer
     DEFINES: NDEBUG
     LDFLAGS: -rdynamic
+  noexcept:
+    CPPFLAGS: -O2
+    CXXFLAGS: -fno-exceptions
+    DEFINES: NDEBUG
   opt:
     CPPFLAGS: -O2
     DEFINES: NDEBUG

--- a/include/grpc++/impl/codegen/method_handler_impl.h
+++ b/include/grpc++/impl/codegen/method_handler_impl.h
@@ -45,9 +45,9 @@ Status CatchingFunctionHandler(Callable&& handler) {
   } catch (...) {
     return Status(StatusCode::UNKNOWN, "Exception in method handler");
   }
-#else
+#else   // GRPC_ALLOW_EXCEPTIONS
   return handler();
-#endif
+#endif  // GRPC_ALLOW_EXCEPTIONS
 }
 
 /// A wrapper class of an application provided rpc method handler.

--- a/include/grpc++/impl/codegen/method_handler_impl.h
+++ b/include/grpc++/impl/codegen/method_handler_impl.h
@@ -35,15 +35,19 @@ namespace internal {
 // so this process doesn't require additional overhead in the common case.
 // Additionally, we don't need to return if we caught an exception or not;
 // the handling is the same in either case.
-template <class F>
-Status CatchingFunctionHandler(F&& callable) {
+template <class Callable>
+Status CatchingFunctionHandler(Callable&& handler) {
+#if GRPC_ALLOW_EXCEPTIONS
   try {
-    return callable();
+    return handler();
   } catch (const std::exception& e) {
     return Status(StatusCode::UNKNOWN, e.what());
   } catch (...) {
     return Status(StatusCode::UNKNOWN, "Exception in method handler");
   }
+#else
+  return handler();
+#endif
 }
 
 /// A wrapper class of an application provided rpc method handler.

--- a/include/grpc++/impl/codegen/method_handler_impl.h
+++ b/include/grpc++/impl/codegen/method_handler_impl.h
@@ -40,10 +40,8 @@ Status CatchingFunctionHandler(Callable&& handler) {
 #if GRPC_ALLOW_EXCEPTIONS
   try {
     return handler();
-  } catch (const std::exception& e) {
-    return Status(StatusCode::UNKNOWN, e.what());
   } catch (...) {
-    return Status(StatusCode::UNKNOWN, "Exception in method handler");
+    return Status(StatusCode::UNKNOWN, "Unexpected error in RPC handling");
   }
 #else   // GRPC_ALLOW_EXCEPTIONS
   return handler();

--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -483,14 +483,14 @@ typedef unsigned __int64 uint64_t;
  * 0 on non-Windows platforms unless the compiler defines __EXCEPTIONS */
 #ifdef GPR_WINDOWS
 #define GRPC_ALLOW_EXCEPTIONS 1
-#else
+#else /* GPR_WINDOWS */
 #ifdef __EXCEPTIONS
 #define GRPC_ALLOW_EXCEPTIONS 1
-#else
+#else /* __EXCEPTIONS */
 #define GRPC_ALLOW_EXCEPTIONS 0
-#endif
-#endif
-#endif
+#endif /* __EXCEPTIONS */
+#endif /* __GPR_WINDOWS */
+#endif /* GRPC_ALLOW_EXCEPTIONS */
 
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS

--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -477,6 +477,21 @@ typedef unsigned __int64 uint64_t;
 #endif /* GPR_ATTRIBUTE_NO_TSAN (2) */
 #endif /* GPR_ATTRIBUTE_NO_TSAN (1) */
 
+/* GRPC_ALLOW_EXCEPTIONS should be 0 or 1 if exceptions are allowed or not */
+#ifndef GRPC_ALLOW_EXCEPTIONS
+/* If not already set, set to 1 on Windows (style guide standard) but to
+ * 0 on non-Windows platforms unless the compiler defines __EXCEPTIONS */
+#ifdef GPR_WINDOWS
+#define GRPC_ALLOW_EXCEPTIONS 1
+#else
+#ifdef __EXCEPTIONS
+#define GRPC_ALLOW_EXCEPTIONS 1
+#else
+#define GRPC_ALLOW_EXCEPTIONS 0
+#endif
+#endif
+#endif
+
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -16,25 +16,31 @@ licenses(["notice"])  # Apache v2
 
 load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package", "grpc_cc_binary")
 
-grpc_package(name = "test/cpp/end2end", visibility = "public") # Allows external users to implement end2end tests.
+grpc_package(
+    name = "test/cpp/end2end",
+    visibility = "public",
+)  # Allows external users to implement end2end tests.
 
 grpc_cc_library(
     name = "test_service_impl",
     testonly = True,
     srcs = ["test_service_impl.cc"],
     hdrs = ["test_service_impl.h"],
+    external_deps = [
+        "gtest",
+    ],
     deps = [
         "//src/proto/grpc/testing:echo_proto",
         "//test/cpp/util:test_util",
-    ],
-    external_deps = [
-        "gtest",
     ],
 )
 
 grpc_cc_test(
     name = "async_end2end_test",
     srcs = ["async_end2end_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
     deps = [
         "//:gpr",
         "//:grpc",
@@ -47,14 +53,17 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    external_deps = [
-        "gtest",
-    ],
 )
 
 grpc_cc_test(
     name = "client_crash_test",
     srcs = ["client_crash_test.cc"],
+    data = [
+        ":client_crash_test_server",
+    ],
+    external_deps = [
+        "gtest",
+    ],
     deps = [
         "//:gpr",
         "//:grpc",
@@ -65,12 +74,6 @@ grpc_cc_test(
         "//test/core/util:gpr_test_util",
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
-    ],
-    data = [
-        ":client_crash_test_server",
-    ],
-    external_deps = [
-        "gtest",
     ],
 )
 
@@ -78,6 +81,10 @@ grpc_cc_binary(
     name = "client_crash_test_server",
     testonly = True,
     srcs = ["client_crash_test_server.cc"],
+    external_deps = [
+        "gflags",
+        "gtest",
+    ],
     deps = [
         "//:gpr",
         "//:grpc",
@@ -89,16 +96,15 @@ grpc_cc_binary(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    external_deps = [
-        "gflags",
-        "gtest",
-    ],
 )
 
 grpc_cc_library(
     name = "end2end_test_lib",
-    srcs = ["end2end_test.cc"],
     testonly = True,
+    srcs = ["end2end_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
     deps = [
         ":test_service_impl",
         "//:gpr",
@@ -110,22 +116,40 @@ grpc_cc_library(
         "//test/core/util:gpr_test_util",
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
-    ],
-    external_deps = [
-        "gtest",
     ],
 )
 
 grpc_cc_test(
     name = "end2end_test",
     deps = [
-        ":end2end_test_lib"
+        ":end2end_test_lib",
+    ],
+)
+
+grpc_cc_test(
+    name = "exception_test",
+    srcs = ["exception_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
+    deps = [
+        "//:gpr",
+        "//:grpc",
+        "//:grpc++",
+        "//src/proto/grpc/testing:echo_messages_proto",
+        "//src/proto/grpc/testing:echo_proto",
+        "//test/core/util:gpr_test_util",
+        "//test/core/util:grpc_test_util",
+        "//test/cpp/util:test_util",
     ],
 )
 
 grpc_cc_test(
     name = "filter_end2end_test",
     srcs = ["filter_end2end_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
     deps = [
         "//:gpr",
         "//:grpc",
@@ -136,15 +160,15 @@ grpc_cc_test(
         "//test/core/util:gpr_test_util",
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
-    ],
-    external_deps = [
-        "gtest",
     ],
 )
 
 grpc_cc_test(
     name = "generic_end2end_test",
     srcs = ["generic_end2end_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
     deps = [
         "//:gpr",
         "//:grpc",
@@ -156,14 +180,14 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    external_deps = [
-        "gtest",
-    ],
 )
 
 grpc_cc_test(
     name = "hybrid_end2end_test",
     srcs = ["hybrid_end2end_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
     deps = [
         ":test_service_impl",
         "//:gpr",
@@ -176,14 +200,15 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    external_deps = [
-        "gtest",
-    ],
 )
 
 grpc_cc_test(
     name = "mock_test",
     srcs = ["mock_test.cc"],
+    external_deps = [
+        "gmock",
+        "gtest",
+    ],
     deps = [
         "//:gpr",
         "//:grpc",
@@ -196,15 +221,14 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    external_deps = [
-        "gmock",
-        "gtest",
-    ],
 )
 
 grpc_cc_test(
     name = "client_lb_end2end_test",
     srcs = ["client_lb_end2end_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
     deps = [
         ":test_service_impl",
         "//:gpr",
@@ -216,38 +240,39 @@ grpc_cc_test(
         "//test/core/util:gpr_test_util",
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
-    ],
-    external_deps = [
-        "gtest",
     ],
 )
 
 grpc_cc_test(
     name = "grpclb_end2end_test",
     srcs = ["grpclb_end2end_test.cc"],
+    external_deps = [
+        "gmock",
+        "gtest",
+    ],
     deps = [
         ":test_service_impl",
         "//:gpr",
         "//:grpc",
         "//:grpc++",
+        "//:grpc_resolver_fake",
         "//src/proto/grpc/lb/v1:load_balancer_proto",
         "//src/proto/grpc/testing:echo_messages_proto",
         "//src/proto/grpc/testing:echo_proto",
         "//src/proto/grpc/testing/duplicate:echo_duplicate_proto",
-        "//:grpc_resolver_fake",
         "//test/core/util:gpr_test_util",
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
-    ],
-    external_deps = [
-        "gmock",
-        "gtest",
     ],
 )
 
 grpc_cc_test(
     name = "proto_server_reflection_test",
     srcs = ["proto_server_reflection_test.cc"],
+    external_deps = [
+        "gtest",
+        "gflags",
+    ],
     deps = [
         ":test_service_impl",
         "//:gpr",
@@ -262,15 +287,14 @@ grpc_cc_test(
         "//test/cpp/util:grpc++_proto_reflection_desc_db",
         "//test/cpp/util:test_util",
     ],
-    external_deps = [
-        "gtest",
-        "gflags",
-    ],
 )
 
 grpc_cc_test(
     name = "server_builder_plugin_test",
     srcs = ["server_builder_plugin_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
     deps = [
         ":test_service_impl",
         "//:gpr",
@@ -283,14 +307,17 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    external_deps = [
-        "gtest",
-    ],
 )
 
 grpc_cc_test(
     name = "server_crash_test",
     srcs = ["server_crash_test.cc"],
+    data = [
+        ":server_crash_test_client",
+    ],
+    external_deps = [
+        "gtest",
+    ],
     deps = [
         "//:gpr",
         "//:grpc",
@@ -301,12 +328,6 @@ grpc_cc_test(
         "//test/core/util:gpr_test_util",
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
-    ],
-    external_deps = [
-        "gtest",
-    ],
-    data = [
-        ":server_crash_test_client",
     ],
 )
 
@@ -314,6 +335,10 @@ grpc_cc_binary(
     name = "server_crash_test_client",
     testonly = True,
     srcs = ["server_crash_test_client.cc"],
+    external_deps = [
+        "gflags",
+        "gtest",
+    ],
     deps = [
         "//:gpr",
         "//:grpc",
@@ -324,16 +349,15 @@ grpc_cc_binary(
         "//test/core/util:gpr_test_util",
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
-    ],
-    external_deps = [
-        "gflags",
-        "gtest",
     ],
 )
 
 grpc_cc_test(
     name = "shutdown_test",
     srcs = ["shutdown_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
     deps = [
         "//:gpr",
         "//:grpc",
@@ -344,15 +368,15 @@ grpc_cc_test(
         "//test/core/util:gpr_test_util",
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
-    ],
-    external_deps = [
-        "gtest",
     ],
 )
 
 grpc_cc_test(
     name = "streaming_throughput_test",
     srcs = ["streaming_throughput_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
     deps = [
         "//:gpr",
         "//:grpc",
@@ -363,15 +387,15 @@ grpc_cc_test(
         "//test/core/util:gpr_test_util",
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
-    ],
-    external_deps = [
-        "gtest",
     ],
 )
 
 grpc_cc_test(
     name = "thread_stress_test",
     srcs = ["thread_stress_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
     deps = [
         "//:gpr",
         "//:grpc",
@@ -382,8 +406,5 @@ grpc_cc_test(
         "//test/core/util:gpr_test_util",
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
-    ],
-    external_deps = [
-        "gtest",
     ],
 )

--- a/test/cpp/end2end/exception_test.cc
+++ b/test/cpp/end2end/exception_test.cc
@@ -105,7 +105,6 @@ TEST_F(ExceptionTest, RequestStream) {
 
   EXPECT_FALSE(s.ok());
   EXPECT_EQ(s.error_code(), StatusCode::UNKNOWN);
-  EXPECT_EQ(s.error_message(), kErrorMessage);
 }
 
 #endif  // GRPC_ALLOW_EXCEPTIONS

--- a/test/cpp/end2end/exception_test.cc
+++ b/test/cpp/end2end/exception_test.cc
@@ -1,0 +1,116 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <exception>
+#include <memory>
+
+#include <grpc++/channel.h>
+#include <grpc++/client_context.h>
+#include <grpc++/server.h>
+#include <grpc++/server_builder.h>
+#include <grpc++/server_context.h>
+
+#include "src/proto/grpc/testing/echo.grpc.pb.h"
+#include "test/core/util/test_config.h"
+
+#include <gtest/gtest.h>
+
+namespace grpc {
+namespace testing {
+
+const char* kErrorMessage = "This service caused an exception";
+
+class ExceptingServiceImpl : public ::grpc::testing::EchoTestService::Service {
+ public:
+  Status Echo(ServerContext* server_context, const EchoRequest* request,
+              EchoResponse* response) override {
+    throw - 1;
+  }
+  Status RequestStream(ServerContext* context,
+                       ServerReader<EchoRequest>* reader,
+                       EchoResponse* response) override {
+    throw ServiceException();
+  }
+
+ private:
+  class ServiceException final : public std::exception {
+   public:
+    ServiceException() {}
+
+   private:
+    const char* what() const noexcept override { return kErrorMessage; }
+  };
+};
+
+class ExceptionTest : public ::testing::Test {
+ protected:
+  ExceptionTest() {}
+
+  void SetUp() override {
+    ServerBuilder builder;
+    builder.RegisterService(&service_);
+    server_ = builder.BuildAndStart();
+  }
+
+  void TearDown() override { server_->Shutdown(); }
+
+  void ResetStub() {
+    channel_ = server_->InProcessChannel(ChannelArguments());
+    stub_ = grpc::testing::EchoTestService::NewStub(channel_);
+  }
+
+  std::shared_ptr<Channel> channel_;
+  std::unique_ptr<grpc::testing::EchoTestService::Stub> stub_;
+  std::unique_ptr<Server> server_;
+  ExceptingServiceImpl service_;
+};
+
+TEST_F(ExceptionTest, Unary) {
+  ResetStub();
+  EchoRequest request;
+  EchoResponse response;
+  request.set_message("test");
+  ClientContext context;
+
+  Status s = stub_->Echo(&context, request, &response);
+  EXPECT_FALSE(s.ok());
+  EXPECT_EQ(s.error_code(), StatusCode::UNKNOWN);
+}
+
+TEST_F(ExceptionTest, RequestStream) {
+  ResetStub();
+  EchoResponse response;
+  ClientContext context;
+
+  auto stream = stub_->RequestStream(&context, &response);
+  stream->WritesDone();
+  Status s = stream->Finish();
+
+  EXPECT_FALSE(s.ok());
+  EXPECT_EQ(s.error_code(), StatusCode::UNKNOWN);
+  EXPECT_EQ(s.error_message(), kErrorMessage);
+}
+
+}  // namespace testing
+}  // namespace grpc
+
+int main(int argc, char** argv) {
+  grpc_test_init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/cpp/end2end/exception_test.cc
+++ b/test/cpp/end2end/exception_test.cc
@@ -108,7 +108,7 @@ TEST_F(ExceptionTest, RequestStream) {
   EXPECT_EQ(s.error_message(), kErrorMessage);
 }
 
-#endif
+#endif  // GRPC_ALLOW_EXCEPTIONS
 
 }  // namespace testing
 }  // namespace grpc

--- a/test/cpp/end2end/exception_test.cc
+++ b/test/cpp/end2end/exception_test.cc
@@ -24,6 +24,7 @@
 #include <grpc++/server.h>
 #include <grpc++/server_builder.h>
 #include <grpc++/server_context.h>
+#include <grpc/impl/codegen/port_platform.h>
 
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/test_config.h"
@@ -35,6 +36,7 @@ namespace testing {
 
 const char* kErrorMessage = "This service caused an exception";
 
+#if GRPC_ALLOW_EXCEPTIONS
 class ExceptingServiceImpl : public ::grpc::testing::EchoTestService::Service {
  public:
   Status Echo(ServerContext* server_context, const EchoRequest* request,
@@ -105,6 +107,8 @@ TEST_F(ExceptionTest, RequestStream) {
   EXPECT_EQ(s.error_code(), StatusCode::UNKNOWN);
   EXPECT_EQ(s.error_message(), kErrorMessage);
 }
+
+#endif
 
 }  // namespace testing
 }  // namespace grpc

--- a/tools/run_tests/generated/configs.json
+++ b/tools/run_tests/generated/configs.json
@@ -42,7 +42,7 @@
     }
   }, 
   {
-    "config": "c++-compat"
+    "config": "noexcept"
   }, 
   {
     "config": "ubsan", 
@@ -72,6 +72,9 @@
   }, 
   {
     "config": "lto"
+  }, 
+  {
+    "config": "c++-compat"
   }, 
   {
     "config": "mutrace"

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -3172,6 +3172,25 @@
     "headers": [], 
     "is_filegroup": false, 
     "language": "c++", 
+    "name": "exception_test", 
+    "src": [
+      "test/cpp/end2end/exception_test.cc"
+    ], 
+    "third_party": false, 
+    "type": "target"
+  }, 
+  {
+    "deps": [
+      "gpr", 
+      "gpr_test_util", 
+      "grpc", 
+      "grpc++", 
+      "grpc++_test_util", 
+      "grpc_test_util"
+    ], 
+    "headers": [], 
+    "is_filegroup": false, 
+    "language": "c++", 
     "name": "filter_end2end_test", 
     "src": [
       "test/cpp/end2end/filter_end2end_test.cc"

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3717,7 +3717,7 @@
       "posix", 
       "windows"
     ], 
-    "uses_polling": false
+    "uses_polling": true
   }, 
   {
     "args": [], 

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3710,6 +3710,30 @@
     "flaky": false, 
     "gtest": true, 
     "language": "c++", 
+    "name": "exception_test", 
+    "platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "uses_polling": false
+  }, 
+  {
+    "args": [], 
+    "benchmark": false, 
+    "ci_platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "cpu_cost": 1.0, 
+    "exclude_configs": [], 
+    "exclude_iomgrs": [], 
+    "flaky": false, 
+    "gtest": true, 
+    "language": "c++", 
     "name": "filter_end2end_test", 
     "platforms": [
       "linux", 

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -313,6 +313,15 @@ def _create_portability_test_jobs(extra_args=[],
         extra_envs={'GRPC_DNS_RESOLVER': 'ares'},
         timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
 
+    # C and C++ with no-exceptions on Linux
+    test_jobs += _generate_jobs(
+        languages=['c', 'c++'],
+        configs=['noexcept'],
+        platforms=['linux'],
+        labels=['portability', 'corelang'],
+        extra_args=extra_args,
+        timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
+
     # TODO(zyc): Turn on this test after adding c-ares support on windows.
     # C with the c-ares DNS resolver on Windows
     # test_jobs += _generate_jobs(languages=['c'],


### PR DESCRIPTION
This is part of the work required to solve #13706 

Cc: @tudor

