### PR TITLE
Defer import of pkg_resources if / until it is needed.

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/security.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/security.pyx.pxi
@@ -14,12 +14,11 @@
 
 from libc.string cimport memcpy
 
-import pkg_resources
-
 
 cdef grpc_ssl_roots_override_result ssl_roots_override_callback(
     char **pem_root_certs) nogil:
   with gil:
+    import pkg_resources
     temporary_pem_root_certs = pkg_resources.resource_string(
         __name__.rstrip('.cygrpc'), '_credentials/roots.pem')
     pem_root_certs[0] = <char *>gpr_malloc(len(temporary_pem_root_certs) + 1)
@@ -86,4 +85,3 @@ def auth_context(Call call):
         py_auth_context[key] = [<bytes> property.value]
   grpc_auth_context_release(auth_context)
   return py_auth_context
-  

--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
@@ -14,7 +14,6 @@
 
 cimport cpython
 
-import pkg_resources
 import os.path
 import sys
 


### PR DESCRIPTION
`pkg_resources` can be a fairly heavy dependency and, in our setup at least, isn't generally available. It's only actually needed on one code path which is often not executed anyway.