### PR TITLE
Make benchmark tests use correct timeout

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -385,7 +385,9 @@ class CLanguage(object):
                                     shortname='%s %s' % (' '.join(cmdline),
                                                          shortname_ext),
                                     cpu_cost=cpu_cost,
-                                    timeout_seconds=_DEFAULT_TIMEOUT_SECONDS *
+                                    timeout_seconds=target.get(
+                                        'timeout_seconds',
+                                        _DEFAULT_TIMEOUT_SECONDS) *
                                     timeout_scaling,
                                     environ=env))
                     elif 'gtest' in target and target['gtest']:


### PR DESCRIPTION
Fixes #13403

Kokoro logs show that that the passing instances of `BM_PumpUnbalancedUnary_Trickle/1/16777216/67108864` take close to 300s. Anything over times out. Doubling timeout for those cases should fix this