### PR TITLE
Make user able to instantiate RpcServer with pool_size as string

### DIFF
--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -224,7 +224,7 @@ module GRPC
       @connect_md_proc = RpcServer.setup_connect_md_proc(connect_md_proc)
       @max_waiting_requests = max_waiting_requests
       @poll_period = poll_period
-      @pool_size = pool_size
+      @pool_size = pool_size.to_i
       @pool = Pool.new(@pool_size, keep_alive: pool_keep_alive)
       @run_cond = ConditionVariable.new
       @run_mutex = Mutex.new


### PR DESCRIPTION
This is more convenient for a user since most of the time pool_size is passed from the environment variable which is a string. There is no need to put the burden on a user to do the conversion.