### PR TITLE
Fix a nit in run_tests.sh in ObjC tests

### DIFF
--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -57,7 +57,7 @@ while [ $retries -lt 3 ]; do
         HOST_PORT_LOCALSSL=localhost:5051 \
         HOST_PORT_LOCAL=localhost:5050 \
         HOST_PORT_REMOTE=grpc-test.sandbox.googleapis.com \
-        test \
+        test 2>&1 \
         | egrep -v "$XCODEBUILD_FILTER" \
         | egrep -v '^$' \
         | egrep -v "(GPBDictionary|GPBArray)" - ) || return_code=$?

--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -66,6 +66,7 @@ while [ $retries -lt 3 ]; do
     echo "Failed with code 65 (DTXProxyChannel error 1); retry."
     retries=$(($retries+1))
   elif [ $return_code == 0 ]; then
+    echo "$out"
     break
   else
     echo "$out"


### PR DESCRIPTION
* Certain error messages are printed to stderr by Xcode, which cannot be captured by bash operator `$()`. This change redirects stderr to stdout so that they can be filtered by the retry logic in #13849.
* Build log is missing when the test succeeded. Print it out.