### PR TITLE
C++: Allow no message on sync unary call, just like async

### DIFF
--- a/include/grpc++/impl/codegen/client_unary_call.h
+++ b/include/grpc++/impl/codegen/client_unary_call.h
@@ -65,6 +65,7 @@ class BlockingUnaryCallImpl {
                             context->initial_metadata_flags());
     ops.RecvInitialMetadata(context);
     ops.RecvMessage(result);
+    ops.AllowNoMessage();
     ops.ClientSendClose();
     ops.ClientRecvStatus(context, &status_);
     call.PerformOps(&ops);


### PR DESCRIPTION
It seems that this should be there for consistency and POLA
