### PR TITLE
Wrap duplicated-name definitions in anonymous namespace (except for iomgr)

### DIFF
--- a/src/core/ext/filters/client_channel/backup_poller.cc
+++ b/src/core/ext/filters/client_channel/backup_poller.cc
@@ -33,7 +33,8 @@
 
 #define DEFAULT_POLL_INTERVAL_MS 5000
 
-typedef struct backup_poller {
+namespace {
+struct backup_poller {
   grpc_timer polling_timer;
   grpc_closure run_poller_closure;
   grpc_closure shutdown_closure;
@@ -42,7 +43,8 @@ typedef struct backup_poller {
   bool shutting_down;     // guarded by pollset_mu
   gpr_refcount refs;
   gpr_refcount shutdown_refs;
-} backup_poller;
+};
+}  // namespace
 
 static gpr_once g_once = GPR_ONCE_INIT;
 static gpr_mu g_poller_mu;

--- a/src/core/ext/filters/client_channel/channel_connectivity.cc
+++ b/src/core/ext/filters/client_channel/channel_connectivity.cc
@@ -58,7 +58,8 @@ typedef enum {
   CALLING_BACK_AND_FINISHED,
 } callback_phase;
 
-typedef struct {
+namespace {
+struct state_watcher {
   gpr_mu mu;
   callback_phase phase;
   grpc_closure on_complete;
@@ -71,7 +72,8 @@ typedef struct {
   grpc_channel* channel;
   grpc_error* error;
   void* tag;
-} state_watcher;
+};
+}  // namespace
 
 static void delete_state_watcher(state_watcher* w) {
   grpc_channel_element* client_channel_elem = grpc_channel_stack_last_element(

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/client_load_reporting_filter.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/client_load_reporting_filter.cc
@@ -32,7 +32,8 @@ static grpc_error* init_channel_elem(grpc_channel_element* elem,
 
 static void destroy_channel_elem(grpc_channel_element* elem) {}
 
-typedef struct {
+namespace {
+struct call_data {
   // Stats object to update.
   grpc_grpclb_client_stats* client_stats;
   // State for intercepting send_initial_metadata.
@@ -43,7 +44,8 @@ typedef struct {
   grpc_closure recv_initial_metadata_ready;
   grpc_closure* original_recv_initial_metadata_ready;
   bool recv_initial_metadata_succeeded;
-} call_data;
+};
+}  // namespace
 
 static void on_complete_for_send(void* arg, grpc_error* error) {
   call_data* calld = (call_data*)arg;

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -226,6 +226,7 @@ static void wrapped_rr_closure(void* arg, grpc_error* error) {
   gpr_free(wc_arg->free_when_done);
 }
 
+namespace {
 /* Linked list of pending pick requests. It stores all information needed to
  * eventually call (Round Robin's) pick() on them. They mainly stay pending
  * waiting for the RR policy to be created/updated.
@@ -234,7 +235,7 @@ static void wrapped_rr_closure(void* arg, grpc_error* error) {
  * (in \a wrapped_on_complete and \a wrapped_on_complete_arg). This is needed in
  * order to correctly unref the RR policy instance upon completion of the pick.
  * See \a wrapped_rr_closure for details. */
-typedef struct pending_pick {
+struct pending_pick {
   struct pending_pick* next;
 
   /* original pick()'s arguments */
@@ -246,7 +247,8 @@ typedef struct pending_pick {
 
   /* args for wrapped_on_complete */
   wrapped_rr_closure_arg wrapped_on_complete_arg;
-} pending_pick;
+};
+}  // namespace
 
 static void add_pending_pick(pending_pick** root,
                              const grpc_lb_policy_pick_args* pick_args,

--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
@@ -31,12 +31,14 @@
 
 grpc_core::TraceFlag grpc_lb_pick_first_trace(false, "pick_first");
 
-typedef struct pending_pick {
+namespace {
+struct pending_pick {
   struct pending_pick* next;
   uint32_t initial_metadata_flags;
   grpc_connected_subchannel** target;
   grpc_closure* on_complete;
-} pending_pick;
+};
+}  // namespace
 
 typedef struct {
   /** base policy: must be first */

--- a/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
@@ -41,11 +41,12 @@
 
 grpc_core::TraceFlag grpc_lb_round_robin_trace(false, "round_robin");
 
+namespace {
 /** List of entities waiting for a pick.
  *
  * Once a pick is available, \a target is updated and \a on_complete called. */
-typedef struct pending_pick {
-  struct pending_pick* next;
+struct pending_pick {
+  pending_pick* next;
 
   /* output argument where to store the pick()ed user_data. It'll be NULL if no
    * such data is present or there's an error (the definite test for errors is
@@ -62,7 +63,8 @@ typedef struct pending_pick {
 
   /* to be invoked once the pick() has completed (regardless of success) */
   grpc_closure* on_complete;
-} pending_pick;
+};
+}  // namespace
 
 typedef struct round_robin_lb_policy {
   /** base policy: must be first */

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -59,11 +59,13 @@
   ((grpc_connected_subchannel*)(gpr_atm_##barrier##_load( \
       &(subchannel)->connected_subchannel)))
 
-typedef struct {
+namespace {
+struct state_watcher {
   grpc_closure closure;
   grpc_subchannel* subchannel;
   grpc_connectivity_state connectivity_state;
-} state_watcher;
+};
+}  // namespace
 
 typedef struct external_state_watcher {
   grpc_subchannel* subchannel;

--- a/src/core/ext/filters/http/client/http_client_filter.cc
+++ b/src/core/ext/filters/http/client/http_client_filter.cc
@@ -35,7 +35,8 @@
 /* default maximum size of payload eligable for GET request */
 static const size_t kMaxPayloadSizeForGet = 2048;
 
-typedef struct call_data {
+namespace {
+struct call_data {
   grpc_call_combiner* call_combiner;
   // State for handling send_initial_metadata ops.
   grpc_linked_mdelem method;
@@ -60,13 +61,14 @@ typedef struct call_data {
   grpc_closure on_send_message_next_done;
   grpc_closure* original_send_message_on_complete;
   grpc_closure send_message_on_complete;
-} call_data;
+};
 
-typedef struct channel_data {
+struct channel_data {
   grpc_mdelem static_scheme;
   grpc_mdelem user_agent;
   size_t max_payload_size_for_get;
-} channel_data;
+};
+}  // namespace
 
 static grpc_error* client_filter_incoming_metadata(grpc_call_element* elem,
                                                    grpc_metadata_batch* b) {

--- a/src/core/ext/filters/http/message_compress/message_compress_filter.cc
+++ b/src/core/ext/filters/http/message_compress/message_compress_filter.cc
@@ -35,16 +35,17 @@
 #include "src/core/lib/surface/call.h"
 #include "src/core/lib/transport/static_metadata.h"
 
-typedef enum {
+namespace {
+enum initial_metadata_state {
   // Initial metadata not yet seen.
   INITIAL_METADATA_UNSEEN = 0,
   // Initial metadata seen; compression algorithm set.
   HAS_COMPRESSION_ALGORITHM,
   // Initial metadata seen; no compression algorithm set.
   NO_COMPRESSION_ALGORITHM,
-} initial_metadata_state;
+};
 
-typedef struct call_data {
+struct call_data {
   grpc_call_combiner* call_combiner;
   grpc_linked_mdelem compression_algorithm_storage;
   grpc_linked_mdelem stream_compression_algorithm_storage;
@@ -62,9 +63,9 @@ typedef struct call_data {
   grpc_closure* original_send_message_on_complete;
   grpc_closure send_message_on_complete;
   grpc_closure on_send_message_next_done;
-} call_data;
+};
 
-typedef struct channel_data {
+struct channel_data {
   /** The default, channel-level, compression algorithm */
   grpc_compression_algorithm default_compression_algorithm;
   /** Bitset of enabled algorithms */
@@ -78,7 +79,8 @@ typedef struct channel_data {
   uint32_t enabled_stream_compression_algorithms_bitset;
   /** Supported stream compression algorithms */
   uint32_t supported_stream_compression_algorithms;
-} channel_data;
+};
+}  // namespace
 
 static bool skip_compression(grpc_call_element* elem, uint32_t flags,
                              bool has_compression_algorithm) {

--- a/src/core/ext/filters/http/server/http_server_filter.cc
+++ b/src/core/ext/filters/http/server/http_server_filter.cc
@@ -31,7 +31,8 @@
 #define EXPECTED_CONTENT_TYPE "application/grpc"
 #define EXPECTED_CONTENT_TYPE_LENGTH sizeof(EXPECTED_CONTENT_TYPE) - 1
 
-typedef struct call_data {
+namespace {
+struct call_data {
   grpc_call_combiner* call_combiner;
 
   grpc_linked_mdelem status;
@@ -60,11 +61,12 @@ typedef struct call_data {
   grpc_closure hs_on_recv;
   grpc_closure hs_on_complete;
   grpc_closure hs_recv_message_ready;
-} call_data;
+};
 
-typedef struct channel_data {
+struct channel_data {
   uint8_t unused;
-} channel_data;
+};
+}  // namespace
 
 static grpc_error* server_filter_outgoing_metadata(grpc_call_element* elem,
                                                    grpc_metadata_batch* b) {

--- a/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
+++ b/src/core/ext/filters/load_reporting/server_load_reporting_filter.cc
@@ -31,7 +31,8 @@
 #include "src/core/lib/slice/slice_internal.h"
 #include "src/core/lib/transport/static_metadata.h"
 
-typedef struct call_data {
+namespace {
+struct call_data {
   intptr_t id; /**< an id unique to the call */
   bool have_trailing_md_string;
   grpc_slice trailing_md_string;
@@ -48,11 +49,12 @@ typedef struct call_data {
   /* to get notified of the availability of the incoming initial metadata. */
   grpc_closure on_initial_md_ready;
   grpc_metadata_batch* recv_initial_metadata;
-} call_data;
+};
 
-typedef struct channel_data {
+struct channel_data {
   intptr_t id; /**< an id unique to the channel */
-} channel_data;
+};
+}  // namespace
 
 static void on_initial_md_ready(void* user_data, grpc_error* err) {
   grpc_call_element* elem = (grpc_call_element*)user_data;

--- a/src/core/ext/filters/max_age/max_age_filter.cc
+++ b/src/core/ext/filters/max_age/max_age_filter.cc
@@ -37,7 +37,8 @@
 #define MAX_CONNECTION_IDLE_INTEGER_OPTIONS \
   { DEFAULT_MAX_CONNECTION_IDLE_MS, 1, INT_MAX }
 
-typedef struct channel_data {
+namespace {
+struct channel_data {
   /* We take a reference to the channel stack for the timer callback */
   grpc_channel_stack* channel_stack;
   /* Guards access to max_age_timer, max_age_timer_pending, max_age_grace_timer
@@ -84,7 +85,8 @@ typedef struct channel_data {
   grpc_connectivity_state connectivity_state;
   /* Number of active calls */
   gpr_atm call_count;
-} channel_data;
+};
+}  // namespace
 
 /* Increase the nubmer of active calls. Before the increasement, if there are no
    calls, the max_idle_timer should be cancelled. */

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -86,7 +86,8 @@ static void* refcounted_message_size_limits_create_from_json(
   return value;
 }
 
-typedef struct call_data {
+namespace {
+struct call_data {
   grpc_call_combiner* call_combiner;
   message_size_limits limits;
   // Receive closures are chained: we inject this closure as the
@@ -97,13 +98,14 @@ typedef struct call_data {
   grpc_byte_stream** recv_message;
   // Original recv_message_ready callback, invoked after our own.
   grpc_closure* next_recv_message_ready;
-} call_data;
+};
 
-typedef struct channel_data {
+struct channel_data {
   message_size_limits limits;
   // Maps path names to refcounted_message_size_limits structs.
   grpc_slice_hash_table* method_limit_table;
-} channel_data;
+};
+}  // namespace
 
 // Callback invoked when we receive a message.  Here we check the max
 // receive message size.

--- a/src/core/ext/filters/workarounds/workaround_cronet_compression_filter.cc
+++ b/src/core/ext/filters/workarounds/workaround_cronet_compression_filter.cc
@@ -25,7 +25,8 @@
 #include "src/core/lib/surface/channel_init.h"
 #include "src/core/lib/transport/metadata.h"
 
-typedef struct call_data {
+namespace {
+struct call_data {
   // Receive closures are chained: we inject this closure as the
   // recv_initial_metadata_ready up-call on transport_stream_op, and remember to
   // call our next_recv_initial_metadata_ready member after handling it.
@@ -37,7 +38,8 @@ typedef struct call_data {
 
   // Marks whether the workaround is active
   bool workaround_active;
-} call_data;
+};
+}  // namespace
 
 // Find the user agent metadata element in the batch
 static bool get_user_agent_mdelem(const grpc_metadata_batch* batch,

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -63,7 +63,8 @@ typedef size_t msg_iovlen_type;
 
 grpc_core::TraceFlag grpc_tcp_trace(false, "tcp");
 
-typedef struct {
+namespace {
+struct grpc_tcp {
   grpc_endpoint base;
   grpc_fd* em_fd;
   int fd;
@@ -96,12 +97,13 @@ typedef struct {
 
   grpc_resource_user* resource_user;
   grpc_resource_user_slice_allocator slice_allocator;
-} grpc_tcp;
+};
 
-typedef struct backup_poller {
+struct backup_poller {
   gpr_mu* pollset_mu;
   grpc_closure run_poller;
-} backup_poller;
+};
+}  // namespace
 
 #define BACKUP_POLLER_POLLSET(b) ((grpc_pollset*)((b) + 1))
 

--- a/src/core/lib/security/transport/client_auth_filter.cc
+++ b/src/core/lib/security/transport/client_auth_filter.cc
@@ -37,8 +37,9 @@
 
 #define MAX_CREDENTIALS_METADATA_COUNT 4
 
+namespace {
 /* We can have a per-call credentials. */
-typedef struct {
+struct call_data {
   grpc_call_stack* owning_call;
   grpc_call_combiner* call_combiner;
   grpc_call_credentials* creds;
@@ -57,13 +58,14 @@ typedef struct {
   grpc_closure async_result_closure;
   grpc_closure check_call_host_cancel_closure;
   grpc_closure get_request_metadata_cancel_closure;
-} call_data;
+};
 
 /* We can have a per-channel credentials. */
-typedef struct {
+struct channel_data {
   grpc_channel_security_connector* security_connector;
   grpc_auth_context* auth_context;
-} channel_data;
+};
+}  // namespace
 
 void grpc_auth_metadata_context_reset(
     grpc_auth_metadata_context* auth_md_context) {

--- a/src/core/lib/security/transport/server_auth_filter.cc
+++ b/src/core/lib/security/transport/server_auth_filter.cc
@@ -26,13 +26,14 @@
 #include "src/core/lib/security/transport/auth_filters.h"
 #include "src/core/lib/slice/slice_internal.h"
 
-typedef enum {
+namespace {
+enum async_state {
   STATE_INIT = 0,
   STATE_DONE,
   STATE_CANCELLED,
-} async_state;
+};
 
-typedef struct call_data {
+struct call_data {
   grpc_call_combiner* call_combiner;
   grpc_call_stack* owning_call;
   grpc_transport_stream_op_batch* recv_initial_metadata_batch;
@@ -44,12 +45,13 @@ typedef struct call_data {
   grpc_auth_context* auth_context;
   grpc_closure cancel_closure;
   gpr_atm state;  // async_state
-} call_data;
+};
 
-typedef struct channel_data {
+struct channel_data {
   grpc_auth_context* auth_context;
   grpc_server_credentials* creds;
-} channel_data;
+};
+}  // namespace
 
 static grpc_metadata_array metadata_batch_to_md_array(
     const grpc_metadata_batch* batch) {

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -780,11 +780,10 @@ typedef struct {
   bool first_loop;
 } cq_is_finished_arg;
 
-class ExecCtxNext final : public grpc_core::ExecCtx {
+class ExecCtxNext : public grpc_core::ExecCtx {
  public:
   ExecCtxNext(void* arg) : ExecCtx(0), check_ready_to_finish_arg_(arg) {}
 
- private:
   bool CheckReadyToFinish() override {
     cq_is_finished_arg* a = (cq_is_finished_arg*)check_ready_to_finish_arg_;
     grpc_completion_queue* cq = a->cq;
@@ -812,6 +811,7 @@ class ExecCtxNext final : public grpc_core::ExecCtx {
     return !a->first_loop && a->deadline < grpc_core::ExecCtx::Get()->Now();
   }
 
+ private:
   void* check_ready_to_finish_arg_;
 };
 
@@ -1035,11 +1035,10 @@ static void del_plucker(grpc_completion_queue* cq, void* tag,
   GPR_UNREACHABLE_CODE(return );
 }
 
-class ExecCtxPluck final : public grpc_core::ExecCtx {
+class ExecCtxPluck : public grpc_core::ExecCtx {
  public:
   ExecCtxPluck(void* arg) : ExecCtx(0), check_ready_to_finish_arg_(arg) {}
 
- private:
   bool CheckReadyToFinish() override {
     cq_is_finished_arg* a = (cq_is_finished_arg*)check_ready_to_finish_arg_;
     grpc_completion_queue* cq = a->cq;
@@ -1073,6 +1072,7 @@ class ExecCtxPluck final : public grpc_core::ExecCtx {
     return !a->first_loop && a->deadline < grpc_core::ExecCtx::Get()->Now();
   }
 
+ private:
   void* check_ready_to_finish_arg_;
 };
 

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -780,10 +780,11 @@ typedef struct {
   bool first_loop;
 } cq_is_finished_arg;
 
-class ExecCtxNext : public grpc_core::ExecCtx {
+class ExecCtxNext final : public grpc_core::ExecCtx {
  public:
   ExecCtxNext(void* arg) : ExecCtx(0), check_ready_to_finish_arg_(arg) {}
 
+ private:
   bool CheckReadyToFinish() override {
     cq_is_finished_arg* a = (cq_is_finished_arg*)check_ready_to_finish_arg_;
     grpc_completion_queue* cq = a->cq;
@@ -811,7 +812,6 @@ class ExecCtxNext : public grpc_core::ExecCtx {
     return !a->first_loop && a->deadline < grpc_core::ExecCtx::Get()->Now();
   }
 
- private:
   void* check_ready_to_finish_arg_;
 };
 
@@ -1035,10 +1035,11 @@ static void del_plucker(grpc_completion_queue* cq, void* tag,
   GPR_UNREACHABLE_CODE(return );
 }
 
-class ExecCtxPluck : public grpc_core::ExecCtx {
+class ExecCtxPluck final : public grpc_core::ExecCtx {
  public:
   ExecCtxPluck(void* arg) : ExecCtx(0), check_ready_to_finish_arg_(arg) {}
 
+ private:
   bool CheckReadyToFinish() override {
     cq_is_finished_arg* a = (cq_is_finished_arg*)check_ready_to_finish_arg_;
     grpc_completion_queue* cq = a->cq;
@@ -1072,7 +1073,6 @@ class ExecCtxPluck : public grpc_core::ExecCtx {
     return !a->first_loop && a->deadline < grpc_core::ExecCtx::Get()->Now();
   }
 
- private:
   void* check_ready_to_finish_arg_;
 };
 

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -44,24 +44,23 @@
 #include "src/core/lib/transport/metadata.h"
 #include "src/core/lib/transport/static_metadata.h"
 
-typedef struct listener {
+grpc_core::TraceFlag grpc_server_channel_trace(false, "server_channel");
+
+namespace {
+struct listener {
   void* arg;
   void (*start)(grpc_server* server, void* arg, grpc_pollset** pollsets,
                 size_t pollset_count);
   void (*destroy)(grpc_server* server, void* arg, grpc_closure* closure);
   struct listener* next;
   grpc_closure destroy_done;
-} listener;
+};
 
-typedef struct call_data call_data;
-typedef struct channel_data channel_data;
-typedef struct registered_method registered_method;
+enum requested_call_type { BATCH_CALL, REGISTERED_CALL };
 
-typedef enum { BATCH_CALL, REGISTERED_CALL } requested_call_type;
+struct registered_method;
 
-grpc_core::TraceFlag grpc_server_channel_trace(false, "server_channel");
-
-typedef struct requested_call {
+struct requested_call {
   gpr_mpscq_node request_link; /* must be first */
   requested_call_type type;
   size_t cq_idx;
@@ -81,15 +80,15 @@ typedef struct requested_call {
       grpc_byte_buffer** optional_payload;
     } registered;
   } data;
-} requested_call;
+};
 
-typedef struct channel_registered_method {
+struct channel_registered_method {
   registered_method* server_registered_method;
   uint32_t flags;
   bool has_host;
   grpc_slice method;
   grpc_slice host;
-} channel_registered_method;
+};
 
 struct channel_data {
   grpc_server* server;
@@ -176,6 +175,7 @@ typedef struct {
   grpc_channel** channels;
   size_t num_channels;
 } channel_broadcaster;
+}  // namespace
 
 struct grpc_server {
   grpc_channel_args* channel_args;


### PR DESCRIPTION
This addresses some of the problems seen in #13832 . In particular, this wraps duplicated name definitions in anonymous namespaces except for those in `src/core/lib/iomgr` which is going through a separate overhaul anyway. Although these structs don't have external linkage using standard compile options, adding `-flto` to the gcc build flags to enable link-time optimization causes them to become subject to ODR rules.

Over time, more stuff from the files in `src/core` should be moved into anonymous namespaces anyway (in particular, to deprecate the use of `static` linkage which is non-preferred) so this is maybe the first step of a longer-term cleanup.
