### PR TITLE
Try adding recv_close_on_server as seaky op

### DIFF
--- a/include/grpc++/impl/codegen/call.h
+++ b/include/grpc++/impl/codegen/call.h
@@ -622,6 +622,7 @@ class CallOpSetInterface : public CompletionQueueTag {
   /// Fills in grpc_op, starting from ops[*nops] and moving
   /// upwards.
   virtual void FillOps(grpc_call* call, grpc_op* ops, size_t* nops) = 0;
+  virtual void SneakyExecute(grpc_call* call) {}
 };
 
 /// Primary implementaiton of CallOpSetInterface.

--- a/include/grpc++/impl/codegen/server_context.h
+++ b/include/grpc++/impl/codegen/server_context.h
@@ -95,6 +95,8 @@ class ServerContextTestSpouse;
 /// \warning ServerContext instances should \em not be reused across rpcs.
 class ServerContext {
  public:
+
+  class CompletionOp;
   ServerContext();  // for async calls
   ~ServerContext();
 
@@ -261,8 +263,6 @@ class ServerContext {
   /// Prevent copying.
   ServerContext(const ServerContext&);
   ServerContext& operator=(const ServerContext&);
-
-  class CompletionOp;
 
   void BeginCompletionOp(internal::Call* call);
   /// Return the tag queued by BeginCompletionOp()

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -2059,6 +2059,7 @@ grpc_call_error grpc_call_start_batch_and_execute(grpc_call* call,
                                                   const grpc_op* ops,
                                                   size_t nops,
                                                   grpc_closure* closure) {
+  grpc_core::ExecCtx exec_ctx;
   return call_start_batch(call, ops, nops, closure, 1);
 }
 

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -2055,11 +2055,18 @@ grpc_call_error grpc_call_start_batch(grpc_call* call, const grpc_op* ops,
   return err;
 }
 
-grpc_call_error grpc_call_start_batch_and_execute(grpc_call* call,
+grpc_call_error grpc_call_start_batch_and_execute_surface(grpc_call* call,
                                                   const grpc_op* ops,
                                                   size_t nops,
                                                   grpc_closure* closure) {
   grpc_core::ExecCtx exec_ctx;
+  return grpc_call_start_batch_and_execute(call, ops, nops, closure);
+}
+
+grpc_call_error grpc_call_start_batch_and_execute(grpc_call* call,
+                                                  const grpc_op* ops,
+                                                  size_t nops,
+                                                  grpc_closure* closure) {
   return call_start_batch(call, ops, nops, closure, 1);
 }
 

--- a/src/core/lib/surface/call.h
+++ b/src/core/lib/surface/call.h
@@ -71,6 +71,11 @@ void grpc_call_internal_unref(grpc_call* call);
 
 grpc_call_stack* grpc_call_get_call_stack(grpc_call* call);
 
+grpc_call_error grpc_call_start_batch_and_execute_surface(grpc_call* call,
+                                                  const grpc_op* ops,
+                                                  size_t nops,
+                                                  grpc_closure* closure);
+
 grpc_call_error grpc_call_start_batch_and_execute(grpc_call* call,
                                                   const grpc_op* ops,
                                                   size_t nops,

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -105,7 +105,7 @@ void ServerContext::CompletionOp::SneakyExecute(grpc_call* call) {
   ops.reserved = nullptr;
 
   grpc_closure* closure = GRPC_CLOSURE_CREATE(completion_op_callback, this, grpc_schedule_on_exec_ctx);
-  grpc_call_start_batch_and_execute(call, &ops, 1, closure);
+  grpc_call_start_batch_and_execute_surface(call, &ops, 1, closure);
 }
 
 void ServerContext::CompletionOp::FillOps(grpc_call* call, grpc_op* ops,


### PR DESCRIPTION
This is a proof of concept only.  The RECV_CLOSE_ON_SERVER op was causing an extra kick on the completion queues, despite in the common case the completion never being delivered to the user (because it only gets delivered if the user explicitly asks for this completion).

This causes the RECV_CLOSE_ON_SERVER to be done via grpc_call_start_batch_and_execute instead (in the common case).

In the Unary 1 channel/ 1 outstanding rpc, this showed up as 2-polls/request on the server, and after this change we have the 1-polls/request on the server we expect.

Don't have updated benchmark numbers yet, will update when available.
