### PR TITLE
Missing s/NULL/nullptr

### DIFF
--- a/src/core/lib/iomgr/exec_ctx.h
+++ b/src/core/lib/iomgr/exec_ctx.h
@@ -111,7 +111,7 @@ class ExecCtx {
 
   /** Checks if there is work to be done */
   bool HasWork() {
-    return combiner_data_.active_combiner != NULL ||
+    return combiner_data_.active_combiner != nullptr ||
            !grpc_closure_list_empty(closure_list_);
   }
 

--- a/src/core/lib/iomgr/gethostname_sysconf.cc
+++ b/src/core/lib/iomgr/gethostname_sysconf.cc
@@ -30,7 +30,7 @@ char* grpc_gethostname() {
   char* hostname = (char*)gpr_malloc(host_name_max);
   if (gethostname(hostname, host_name_max) != 0) {
     gpr_free(hostname);
-    return NULL;
+    return nullptr;
   }
   return hostname;
 }

--- a/src/core/lib/iomgr/wakeup_fd_nospecial.cc
+++ b/src/core/lib/iomgr/wakeup_fd_nospecial.cc
@@ -31,6 +31,6 @@
 static int check_availability_invalid(void) { return 0; }
 
 const grpc_wakeup_fd_vtable grpc_specialized_wakeup_fd_vtable = {
-    NULL, NULL, NULL, NULL, check_availability_invalid};
+    nullptr, nullptr, nullptr, nullptr, check_availability_invalid};
 
 #endif /* GRPC_POSIX_NO_SPECIAL_WAKEUP_FD */

--- a/src/core/lib/support/env_posix.cc
+++ b/src/core/lib/support/env_posix.cc
@@ -31,12 +31,12 @@
 
 const char* gpr_getenv_silent(const char* name, char** dst) {
   *dst = gpr_getenv(name);
-  return NULL;
+  return nullptr;
 }
 
 char* gpr_getenv(const char* name) {
   char* result = getenv(name);
-  return result == NULL ? result : gpr_strdup(result);
+  return result == nullptr ? result : gpr_strdup(result);
 }
 
 void gpr_setenv(const char* name, const char* value) {

--- a/src/core/lib/support/fork.cc
+++ b/src/core/lib/support/fork.cc
@@ -39,7 +39,7 @@ void grpc_fork_support_init() {
 #else
   fork_support_enabled = 0;
   char* env = gpr_getenv("GRPC_ENABLE_FORK_SUPPORT");
-  if (env != NULL) {
+  if (env != nullptr) {
     static const char* truthy[] = {"yes",  "Yes",  "YES", "true",
                                    "True", "TRUE", "1"};
     for (size_t i = 0; i < GPR_ARRAY_SIZE(truthy); i++) {

--- a/src/core/lib/support/log_posix.cc
+++ b/src/core/lib/support/log_posix.cc
@@ -35,15 +35,15 @@ static intptr_t gettid(void) { return (intptr_t)pthread_self(); }
 void gpr_log(const char* file, int line, gpr_log_severity severity,
              const char* format, ...) {
   char buf[64];
-  char* allocated = NULL;
-  char* message = NULL;
+  char* allocated = nullptr;
+  char* message = nullptr;
   int ret;
   va_list args;
   va_start(args, format);
   ret = vsnprintf(buf, sizeof(buf), format, args);
   va_end(args);
   if (ret < 0) {
-    message = NULL;
+    message = nullptr;
   } else if ((size_t)ret <= sizeof(buf) - 1) {
     message = buf;
   } else {
@@ -66,7 +66,7 @@ void gpr_default_log(gpr_log_func_args* args) {
 
   timer = (time_t)now.tv_sec;
   final_slash = strrchr(args->file, '/');
-  if (final_slash == NULL)
+  if (final_slash == nullptr)
     display_file = args->file;
   else
     display_file = final_slash + 1;

--- a/src/core/lib/support/time_posix.cc
+++ b/src/core/lib/support/time_posix.cc
@@ -107,7 +107,7 @@ static gpr_timespec now_impl(gpr_clock_type clock) {
   now.clock_type = clock;
   switch (clock) {
     case GPR_CLOCK_REALTIME:
-      gettimeofday(&now_tv, NULL);
+      gettimeofday(&now_tv, nullptr);
       now.tv_sec = now_tv.tv_sec;
       now.tv_nsec = now_tv.tv_usec * 1000;
       break;

--- a/src/core/lib/transport/error_utils.cc
+++ b/src/core/lib/transport/error_utils.cc
@@ -70,7 +70,7 @@ void grpc_error_get_status(grpc_error* error, grpc_millis deadline,
   }
   if (code != nullptr) *code = status;
 
-  if (error_string != NULL && status != GRPC_STATUS_OK) {
+  if (error_string != nullptr && status != GRPC_STATUS_OK) {
     *error_string = gpr_strdup(grpc_error_string(error));
   }
 

--- a/test/core/iomgr/fd_conservation_posix_test.cc
+++ b/test/core/iomgr/fd_conservation_posix_test.cc
@@ -43,7 +43,7 @@ int main(int argc, char** argv) {
         grpc_resource_quota_create("fd_conservation_posix_test");
 
     for (i = 0; i < 100; i++) {
-      p = grpc_iomgr_create_endpoint_pair("test", NULL);
+      p = grpc_iomgr_create_endpoint_pair("test", nullptr);
       grpc_endpoint_destroy(p.client);
       grpc_endpoint_destroy(p.server);
       grpc_core::ExecCtx::Get()->Flush();

--- a/test/core/iomgr/resource_quota_test.cc
+++ b/test/core/iomgr/resource_quota_test.cc
@@ -118,7 +118,7 @@ static void test_instant_alloc_then_free(void) {
   grpc_resource_user* usr = grpc_resource_user_create(q, "usr");
   {
     grpc_core::ExecCtx exec_ctx;
-    grpc_resource_user_alloc(usr, 1024, NULL);
+    grpc_resource_user_alloc(usr, 1024, nullptr);
   }
   {
     grpc_core::ExecCtx exec_ctx;
@@ -136,7 +136,7 @@ static void test_instant_alloc_free_pair(void) {
   grpc_resource_user* usr = grpc_resource_user_create(q, "usr");
   {
     grpc_core::ExecCtx exec_ctx;
-    grpc_resource_user_alloc(usr, 1024, NULL);
+    grpc_resource_user_alloc(usr, 1024, nullptr);
     grpc_resource_user_free(usr, 1024);
   }
   grpc_resource_quota_unref(q);
@@ -565,7 +565,7 @@ static void test_resource_user_stays_allocated_until_memory_released(void) {
   grpc_resource_user* usr = grpc_resource_user_create(q, "usr");
   {
     grpc_core::ExecCtx exec_ctx;
-    grpc_resource_user_alloc(usr, 1024, NULL);
+    grpc_resource_user_alloc(usr, 1024, nullptr);
   }
   {
     grpc_core::ExecCtx exec_ctx;
@@ -608,8 +608,8 @@ test_resource_user_stays_allocated_and_reclaimers_unrun_until_memory_released(
       grpc_core::ExecCtx exec_ctx;
       grpc_resource_user_alloc(usr, 1024, set_event(&allocated));
       grpc_core::ExecCtx::Get()->Flush();
-      GPR_ASSERT(gpr_event_wait(&allocated,
-                                grpc_timeout_seconds_to_deadline(5)) != NULL);
+      GPR_ASSERT(gpr_event_wait(&allocated, grpc_timeout_seconds_to_deadline(
+                                                5)) != nullptr);
       GPR_ASSERT(gpr_event_wait(&reclaimer_cancelled,
                                 grpc_timeout_milliseconds_to_deadline(100)) ==
                  nullptr);
@@ -667,8 +667,8 @@ static void test_reclaimers_can_be_posted_repeatedly(void) {
       grpc_core::ExecCtx exec_ctx;
       grpc_resource_user_alloc(usr, 1024, set_event(&allocated));
       grpc_core::ExecCtx::Get()->Flush();
-      GPR_ASSERT(gpr_event_wait(&allocated,
-                                grpc_timeout_seconds_to_deadline(5)) != NULL);
+      GPR_ASSERT(gpr_event_wait(&allocated, grpc_timeout_seconds_to_deadline(
+                                                5)) != nullptr);
       GPR_ASSERT(gpr_event_wait(&reclaimer_done,
                                 grpc_timeout_seconds_to_deadline(5)) !=
                  nullptr);


### PR DESCRIPTION
This would seem to indicate that the check_clang_tidy sanity test is not doing its job correctly... Will investigate further