### PR TITLE
Add go release versions to client_matrix.py

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -103,6 +103,9 @@ LANG_RELEASE_MATRIX = {
         {
             'v1.8.1': None
         },
+        {
+            'v1.9.1': None
+        },
     ],
     'java': [
         {


### PR DESCRIPTION
Image was built.

$ gcloud beta container images list-tags gcr.io/grpc-testing/grpc_interop_go1.8
```
DIGEST        TAGS    TIMESTAMP
a3a67d963a7c  v1.9.1  2018-01-08T14:26:31
bab9522bb241  v1.9.0  2018-01-04T14:48:09
ae47eb7fee72  v1.8.2  2017-12-12T17:01:54
1f30029aefbe  v1.8.1  2017-12-05T11:29:58
de5de35d8c0f  v1.7.4  2017-12-05T11:29:14
01cdc4b28bf8  v1.8.0  2017-11-21T17:22:51
2bdc2990d55a  v1.7.3  2017-11-21T17:22:31
c8cca2206b87  v1.7.2  2017-11-21T17:21:53
415038162393  v1.7.1  2017-11-21T17:21:20
43e487f6259e          2017-11-21T17:16:08
```
  