### PR TITLE
Backport 13793 to 1.8.x

### DIFF
--- a/test/distrib/ruby/distribtest.gemspec
+++ b/test/distrib/ruby/distribtest.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.platform      = Gem::Platform::RUBY
 
   s.add_dependency 'grpc', '>=0'
+  s.add_dependency 'public_suffix', '< 3.0'
+  s.add_dependency 'jwt', '< 2.0'
 
   s.add_development_dependency 'bundler', '~> 1.7'
 end

--- a/test/distrib/ruby/run_distrib_test.sh
+++ b/test/distrib/ruby/run_distrib_test.sh
@@ -17,10 +17,16 @@ set -ex
 
 cd $(dirname $0)
 
+ARCH=$1
+PLATFORM=$2
 # Create an indexed local gem source with gRPC gems to test
 GEM_SOURCE=../../../gem_source
 mkdir -p ${GEM_SOURCE}/gems
-cp -r $EXTERNAL_GIT_ROOT/input_artifacts/*.gem ${GEM_SOURCE}/gems
+cp $EXTERNAL_GIT_ROOT/input_artifacts/grpc-*$ARCH-$PLATFORM.gem ${GEM_SOURCE}/gems
+if [[ "$(ls ${GEM_SOURCE}/gems | grep grpc | wc -l)" != 1 ]]; then
+  echo "Sanity check failed. Copied over more than one grpc gem into the gem source directory."
+  exit 1
+fi;
 gem install builder
 gem generate_index --directory ${GEM_SOURCE}
 

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -163,6 +163,10 @@ class RubyDistribTest(object):
     return []
 
   def build_jobspec(self):
+    arch_to_gem_arch = {
+        'x64': 'x86_64',
+        'x86': 'x86',
+    }
     if not self.platform == 'linux':
       raise Exception("Not supported yet.")
 
@@ -170,7 +174,8 @@ class RubyDistribTest(object):
           'tools/dockerfile/distribtest/ruby_%s_%s' % (
               self.docker_suffix,
               self.arch),
-          'test/distrib/ruby/run_distrib_test.sh',
+          'test/distrib/ruby/run_distrib_test.sh %s %s' %
+          (arch_to_gem_arch[self.arch], self.platform),
           copy_rel_path='test/distrib')
 
   def __str__(self):


### PR DESCRIPTION
I'd like +to backport this to 1.8.x so that I can verify #13910 with the distrib tests.