### PR TITLE
Silence openssl 1.1.0 warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,7 +327,7 @@ CXXFLAGS += -std=c++11
 ifeq ($(SYSTEM),Darwin)
 CXXFLAGS += -stdlib=libc++
 endif
-CPPFLAGS += -g -Wall -Wextra -Werror -Wno-long-long -Wno-unused-parameter -DOSATOMIC_USE_INLINED=1
+CPPFLAGS += -g -Wall -Wextra -Werror -Wno-long-long -Wno-unused-parameter -DOSATOMIC_USE_INLINED=1 -Wno-deprecated-declarations
 COREFLAGS += -fno-rtti -fno-exceptions
 LDFLAGS += -g
 

--- a/build.yaml
+++ b/build.yaml
@@ -5004,6 +5004,7 @@ defaults:
   global:
     COREFLAGS: -fno-rtti -fno-exceptions
     CPPFLAGS: -g -Wall -Wextra -Werror -Wno-long-long -Wno-unused-parameter -DOSATOMIC_USE_INLINED=1
+      -Wno-deprecated-declarations
     LDFLAGS: -g
   zlib:
     CFLAGS: -Wno-sign-conversion -Wno-conversion -Wno-unused-value -Wno-implicit-function-declaration

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -57,6 +57,7 @@
       '-Wno-long-long',
       '-Wno-unused-parameter',
       '-DOSATOMIC_USE_INLINED=1',
+      '-Wno-deprecated-declarations',
     ],
     'ldflags': [
       '-g',
@@ -134,6 +135,7 @@
             '-Wno-long-long',
             '-Wno-unused-parameter',
             '-DOSATOMIC_USE_INLINED=1',
+            '-Wno-deprecated-declarations',
           ],
           'OTHER_CPLUSPLUSFLAGS': [
             '-g',
@@ -143,6 +145,7 @@
             '-Wno-long-long',
             '-Wno-unused-parameter',
             '-DOSATOMIC_USE_INLINED=1',
+            '-Wno-deprecated-declarations',
             '-stdlib=libc++',
             '-std=c++11',
             '-Wno-error=deprecated-declarations'

--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -421,6 +421,14 @@ typedef unsigned __int64 uint64_t;
 #endif
 #endif
 
+#ifndef GRPC_UNUSED
+#if defined(__GNUC__) && !defined(__MINGW32__)
+#define GRPC_UNUSED __attribute__((unused))
+#else
+#define GRPC_UNUSED
+#endif
+#endif
+
 #ifndef GPR_PRINT_FORMAT_CHECK
 #ifdef __GNUC__
 #define GPR_PRINT_FORMAT_CHECK(FORMAT_STR, ARGS) \

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -116,6 +116,9 @@ typedef struct {
 
 static gpr_once init_openssl_once = GPR_ONCE_INIT;
 static gpr_mu* openssl_mutexes = nullptr;
+static void openssl_locking_cb(int mode, int type, const char* file,
+                               int line) GRPC_UNUSED;
+static unsigned long openssl_thread_id_cb(void) GRPC_UNUSED;
 
 static void openssl_locking_cb(int mode, int type, const char* file, int line) {
   if (mode & CRYPTO_LOCK) {


### PR DESCRIPTION
Silence the unused-function and deprecated-declarations warnings when using openssl 1.1.0