### PR TITLE
When building with bazel on a Mac, workaround bazelbuild/bazel#4341

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -195,12 +195,25 @@
 #define GPR_PTHREAD_TLS 1
 #else /* __MAC_OS_X_VERSION_MIN_REQUIRED < __MAC_10_7 */
 #define GPR_CPU_POSIX 1
+/* TODO(vjpai): there is a reported issue in bazel build for Mac where __thread
+   in a header is currently not working (bazelbuild/bazel#4341). Remove
+   the following conditional and use GPR_GCC_TLS when that is fixed */
+#ifndef GRPC_BAZEL_BUILD
 #define GPR_GCC_TLS 1
+#else /* GRPC_BAZEL_BUILD */
+#define GPR_PTHREAD_TLS 1
+#endif /* GRPC_BAZEL_BUILD */
 #define GPR_APPLE_PTHREAD_NAME 1
 #endif
 #else /* __MAC_OS_X_VERSION_MIN_REQUIRED */
 #define GPR_CPU_POSIX 1
+/* TODO(vjpai): Remove the following conditional and use only GPR_GCC_TLS
+   when bazelbuild/bazel#4341 is fixed */
+#ifndef GRPC_BAZEL_BUILD
 #define GPR_GCC_TLS 1
+#else /* GRPC_BAZEL_BUILD */
+#define GPR_PTHREAD_TLS 1
+#endif /* GRPC_BAZEL_BUILD */
 #endif
 #define GPR_POSIX_CRASH_HANDLER 1
 #endif

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,4 +1,5 @@
 build --client_env=CC=clang
+build --copt -DGRPC_BAZEL_BUILD
 
 build:asan --strip=never
 build:asan --copt -fsanitize-coverage=edge


### PR DESCRIPTION
Fixes #13856.
This is an alternative and more-targeted workaround than the one in #13916 . This way is probably preferred since that way prevented inlining functions and hurt the performance of some microbenchmarks. This will have no effect on any versions except for Mac bazel builds.


  