### PR TITLE
Fix service config structures in c-ares tests

### DIFF
--- a/test/cpp/naming/create_private_dns_zone.sh
+++ b/test/cpp/naming/create_private_dns_zone.sh
@@ -20,8 +20,8 @@ set -ex
 cd $(dirname $0)/../../..
 
 gcloud alpha dns managed-zones create \
-  resolver-tests-version-4-grpctestingexp-zone-id \
-  --dns-name=resolver-tests-version-4.grpctestingexp. \
+  resolver-tests-version-10-grpctestingexp-zone-id \
+  --dns-name=resolver-tests-version-10.grpctestingexp. \
   --description="GCE-DNS-private-zone-for-GRPC-testing" \
   --visibility=private \
   --networks=default

--- a/test/cpp/naming/private_dns_zone_init.sh
+++ b/test/cpp/naming/private_dns_zone_init.sh
@@ -82,7 +82,7 @@ gcloud dns record-sets transaction add \
   --name=_grpc_config.srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
-  '"grpc_config=[{\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"SimpleService\",\"waitForReady\":true}]}]}}]"'
+  '"grpc_config=[{\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"SimpleService\"}],\"waitForReady\":true}]}}]"'
 
 gcloud dns record-sets transaction add \
   -z=resolver-tests-version-4-grpctestingexp-zone-id \
@@ -110,14 +110,14 @@ gcloud dns record-sets transaction add \
   --name=_grpc_config.ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
-  '"grpc_config=[{\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"NoSrvSimpleService\",\"waitForReady\":true}]}]}}]"'
+  '"grpc_config=[{\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"NoSrvSimpleService\"}],\"waitForReady\":true}]}}]"'
 
 gcloud dns record-sets transaction add \
   -z=resolver-tests-version-4-grpctestingexp-zone-id \
   --name=_grpc_config.ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
-  '"grpc_config=[{\"clientLanguage\":[\"python\"],\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"PythonService\",\"waitForReady\":true}]}]}}]"'
+  '"grpc_config=[{\"clientLanguage\":[\"python\"],\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"PythonService\"}],\"waitForReady\":true}]}}]"'
 
 gcloud dns record-sets transaction add \
   -z=resolver-tests-version-4-grpctestingexp-zone-id \
@@ -138,7 +138,7 @@ gcloud dns record-sets transaction add \
   --name=_grpc_config.ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
-  '"grpc_config=[{\"percentage\":0,\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"CppService\",\"waitForReady\":true}]}]}}]"'
+  '"grpc_config=[{\"percentage\":0,\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"CppService\"}],\"waitForReady\":true}]}}]"'
 
 gcloud dns record-sets transaction add \
   -z=resolver-tests-version-4-grpctestingexp-zone-id \
@@ -166,7 +166,7 @@ gcloud dns record-sets transaction add \
   --name=_grpc_config.ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
-  '"grpc_config=[{\"percentage\":0,\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"NeverPickedService\",\"waitForReady\":true}]}]}},{\"percentage\":100,\"serviceConfig\":{\"loadBalanc" "ingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"AlwaysPickedService\",\"waitForReady\":true}]}]}}]"'
+  '"grpc_config=[{\"percentage\":0,\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"NeverPickedService\"}],\"waitForReady\":true}]}},{\"percentage\":100,\"serviceConfig\":{\"loadBalanc" "ingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"AlwaysPickedService\"}],\"waitForReady\":true}]}}]"'
 
 gcloud dns record-sets transaction add \
   -z=resolver-tests-version-4-grpctestingexp-zone-id \

--- a/test/cpp/naming/private_dns_zone_init.sh
+++ b/test/cpp/naming/private_dns_zone_init.sh
@@ -19,197 +19,197 @@ set -ex
 
 cd $(dirname $0)/../../..
 
-gcloud dns record-sets transaction start -z=resolver-tests-version-4-grpctestingexp-zone-id
+gcloud dns record-sets transaction start -z=resolver-tests-version-10-grpctestingexp-zone-id
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-10.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv4-single-target.resolver-tests-version-4.grpctestingexp."
+  "0 0 1234 ipv4-single-target.resolver-tests-version-10.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=ipv4-single-target.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=ipv4-single-target.resolver-tests-version-10.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-10.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv4-multi-target.resolver-tests-version-4.grpctestingexp."
+  "0 0 1234 ipv4-multi-target.resolver-tests-version-10.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=ipv4-multi-target.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=ipv4-multi-target.resolver-tests-version-10.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.5" "1.2.3.6" "1.2.3.7"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-10.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv6-single-target.resolver-tests-version-4.grpctestingexp."
+  "0 0 1234 ipv6-single-target.resolver-tests-version-10.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=ipv6-single-target.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=ipv6-single-target.resolver-tests-version-10.grpctestingexp. \
   --type=AAAA \
   --ttl=2100 \
   "2607:f8b0:400a:801::1001"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-10.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv6-multi-target.resolver-tests-version-4.grpctestingexp."
+  "0 0 1234 ipv6-multi-target.resolver-tests-version-10.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=ipv6-multi-target.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=ipv6-multi-target.resolver-tests-version-10.grpctestingexp. \
   --type=AAAA \
   --ttl=2100 \
   "2607:f8b0:400a:801::1002" "2607:f8b0:400a:801::1003" "2607:f8b0:400a:801::1004"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=_grpc_config.srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=_grpc_config.srv-ipv4-simple-service-config.resolver-tests-version-10.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"SimpleService\"}],\"waitForReady\":true}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-10.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp."
+  "0 0 1234 ipv4-simple-service-config.resolver-tests-version-10.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=ipv4-simple-service-config.resolver-tests-version-10.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=ipv4-no-srv-simple-service-config.resolver-tests-version-10.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=_grpc_config.ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=_grpc_config.ipv4-no-srv-simple-service-config.resolver-tests-version-10.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"NoSrvSimpleService\"}],\"waitForReady\":true}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=_grpc_config.ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=_grpc_config.ipv4-no-config-for-cpp.resolver-tests-version-10.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"clientLanguage\":[\"python\"],\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"PythonService\"}],\"waitForReady\":true}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=ipv4-no-config-for-cpp.resolver-tests-version-10.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=ipv4-cpp-config-has-zero-percentage.resolver-tests-version-10.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=_grpc_config.ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=_grpc_config.ipv4-cpp-config-has-zero-percentage.resolver-tests-version-10.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"percentage\":0,\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"CppService\"}],\"waitForReady\":true}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=_grpc_config.ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=_grpc_config.ipv4-second-language-is-cpp.resolver-tests-version-10.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"clientLanguage\":[\"go\"],\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"GoService\",\"waitForReady\":true}]}]}},{\"clientLanguage\":[\"c++\"],\"serviceConfig\":{" "\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"CppService\",\"waitForReady\":true}]}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=ipv4-second-language-is-cpp.resolver-tests-version-10.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=ipv4-config-with-percentages.resolver-tests-version-10.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=_grpc_config.ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=_grpc_config.ipv4-config-with-percentages.resolver-tests-version-10.grpctestingexp. \
   --type=TXT \
   --ttl=2100 \
   '"grpc_config=[{\"percentage\":0,\"serviceConfig\":{\"loadBalancingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"NeverPickedService\"}],\"waitForReady\":true}]}},{\"percentage\":100,\"serviceConfig\":{\"loadBalanc" "ingPolicy\":\"round_robin\",\"methodConfig\":[{\"name\":[{\"method\":\"Foo\",\"service\":\"AlwaysPickedService\"}],\"waitForReady\":true}]}}]"'
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp."
+  "0 0 1234 balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. \
   --type=A \
   --ttl=2100 \
   "1.2.3.4"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=_grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=_grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. \
   --type=SRV \
   --ttl=2100 \
-  "0 0 1234 balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp."
+  "0 0 1234 balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp."
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. \
   --type=AAAA \
   --ttl=2100 \
   "2607:f8b0:400a:801::1002"
 
 gcloud dns record-sets transaction add \
-  -z=resolver-tests-version-4-grpctestingexp-zone-id \
-  --name=srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. \
+  -z=resolver-tests-version-10-grpctestingexp-zone-id \
+  --name=srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. \
   --type=AAAA \
   --ttl=2100 \
   "2607:f8b0:400a:801::1002"
 
-gcloud dns record-sets transaction describe -z=resolver-tests-version-4-grpctestingexp-zone-id
-gcloud dns record-sets transaction execute -z=resolver-tests-version-4-grpctestingexp-zone-id
-gcloud dns record-sets list -z=resolver-tests-version-4-grpctestingexp-zone-id
+gcloud dns record-sets transaction describe -z=resolver-tests-version-10-grpctestingexp-zone-id
+gcloud dns record-sets transaction execute -z=resolver-tests-version-10-grpctestingexp-zone-id
+gcloud dns record-sets list -z=resolver-tests-version-10-grpctestingexp-zone-id

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -212,12 +212,12 @@ void CheckServiceConfigResultLocked(grpc_channel_args* channel_args,
   const grpc_arg* service_config_arg =
       grpc_channel_args_find(channel_args, GRPC_ARG_SERVICE_CONFIG);
   if (args->expected_service_config_string != "") {
-    GPR_ASSERT(service_config_arg != nullptr);
-    GPR_ASSERT(service_config_arg->type == GRPC_ARG_STRING);
+    ASSERT_NE(service_config_arg, nullptr);
+    ASSERT_EQ(service_config_arg->type, GRPC_ARG_STRING);
     EXPECT_EQ(service_config_arg->value.string,
               args->expected_service_config_string);
   } else {
-    GPR_ASSERT(service_config_arg == nullptr);
+    ASSERT_EQ(service_config_arg, nullptr);
   }
 }
 

--- a/test/cpp/naming/resolver_component_tests_runner.sh
+++ b/test/cpp/naming/resolver_component_tests_runner.sh
@@ -107,7 +107,7 @@ wait $! || EXIT_CODE=1
 $FLAGS_test_bin_path \
   --target_name='srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
-  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}' \
+  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService"}],"waitForReady":true}]}' \
   --expected_lb_policy='round_robin' \
   --local_dns_server_address=127.0.0.1:$FLAGS_test_dns_server_port &
 wait $! || EXIT_CODE=1
@@ -115,7 +115,7 @@ wait $! || EXIT_CODE=1
 $FLAGS_test_bin_path \
   --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
-  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}' \
+  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService"}],"waitForReady":true}]}' \
   --expected_lb_policy='round_robin' \
   --local_dns_server_address=127.0.0.1:$FLAGS_test_dns_server_port &
 wait $! || EXIT_CODE=1
@@ -147,7 +147,7 @@ wait $! || EXIT_CODE=1
 $FLAGS_test_bin_path \
   --target_name='ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
-  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}' \
+  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService"}],"waitForReady":true}]}' \
   --expected_lb_policy='round_robin' \
   --local_dns_server_address=127.0.0.1:$FLAGS_test_dns_server_port &
 wait $! || EXIT_CODE=1
@@ -171,7 +171,7 @@ wait $! || EXIT_CODE=1
 $FLAGS_test_bin_path \
   --target_name='ipv4-config-causing-fallback-to-tcp.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
-  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}' \
+  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwo","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooThree","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooFour","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooFive","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooSix","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooSeven","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooEight","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooNine","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTen","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooEleven","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwelve","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwelve","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwelve","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwelve","service":"SimpleService"}],"waitForReady":true}]}' \
   --expected_lb_policy='' \
   --local_dns_server_address=127.0.0.1:$FLAGS_test_dns_server_port &
 wait $! || EXIT_CODE=1

--- a/test/cpp/naming/resolver_component_tests_runner.sh
+++ b/test/cpp/naming/resolver_component_tests_runner.sh
@@ -73,7 +73,7 @@ EXIT_CODE=0
 # in the resolver.
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv4-single-target.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -81,7 +81,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-multi-target.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv4-multi-target.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.5:1234,True;1.2.3.6:1234,True;1.2.3.7:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -89,7 +89,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-single-target.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv6-single-target.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1001]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -97,7 +97,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-multi-target.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv6-multi-target.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1003]:1234,True;[2607:f8b0:400a:801::1004]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -105,7 +105,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService"}],"waitForReady":true}]}' \
   --expected_lb_policy='round_robin' \
@@ -113,7 +113,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService"}],"waitForReady":true}]}' \
   --expected_lb_policy='round_robin' \
@@ -121,7 +121,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -129,7 +129,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -137,7 +137,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -145,7 +145,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-config-with-percentages.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService"}],"waitForReady":true}]}' \
   --expected_lb_policy='round_robin' \
@@ -153,7 +153,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True;1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -161,7 +161,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1002]:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -169,7 +169,7 @@ $FLAGS_test_bin_path \
 wait $! || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-config-causing-fallback-to-tcp.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-config-causing-fallback-to-tcp.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwo","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooThree","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooFour","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooFive","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooSix","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooSeven","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooEight","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooNine","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTen","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooEleven","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwelve","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwelve","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwelve","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwelve","service":"SimpleService"}],"waitForReady":true}]}' \
   --expected_lb_policy='' \

--- a/test/cpp/naming/resolver_gce_integration_tests_runner.sh
+++ b/test/cpp/naming/resolver_gce_integration_tests_runner.sh
@@ -272,7 +272,7 @@ ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
   --target_name='srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
-  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}' \
+  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService"}],"waitForReady":true}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
   echo "Test based on target record: srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
@@ -283,7 +283,7 @@ ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
   --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
-  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}' \
+  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService"}],"waitForReady":true}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
   echo "Test based on target record: ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
@@ -327,7 +327,7 @@ ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
   --target_name='ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
-  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}' \
+  --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService"}],"waitForReady":true}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
   echo "Test based on target record: ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. FAILED"

--- a/test/cpp/naming/resolver_gce_integration_tests_runner.sh
+++ b/test/cpp/naming/resolver_gce_integration_tests_runner.sh
@@ -34,191 +34,191 @@ echo "Sanity check DNS records are resolveable with dig:"
 EXIT_CODE=0
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-single-target.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-single-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-single-target.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-single-target.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-single-target.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-multi-target.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-multi-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-multi-target.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-multi-target.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-multi-target.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-single-target.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig AAAA ipv6-single-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig AAAA ipv6-single-target.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig AAAA ipv6-single-target.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig AAAA ipv6-single-target.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-multi-target.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig AAAA ipv6-multi-target.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig AAAA ipv6-multi-target.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig AAAA ipv6-multi-target.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig AAAA ipv6-multi-target.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT _grpc_config.srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT _grpc_config.srv-ipv4-simple-service-config.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT _grpc_config.srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT _grpc_config.srv-ipv4-simple-service-config.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-simple-service-config.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-simple-service-config.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-simple-service-config.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-no-srv-simple-service-config.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-no-srv-simple-service-config.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT _grpc_config.ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT _grpc_config.ipv4-no-srv-simple-service-config.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT _grpc_config.ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT _grpc_config.ipv4-no-srv-simple-service-config.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT _grpc_config.ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT _grpc_config.ipv4-no-config-for-cpp.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT _grpc_config.ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT _grpc_config.ipv4-no-config-for-cpp.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-no-config-for-cpp.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-no-config-for-cpp.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-cpp-config-has-zero-percentage.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-cpp-config-has-zero-percentage.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT _grpc_config.ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT _grpc_config.ipv4-cpp-config-has-zero-percentage.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT _grpc_config.ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT _grpc_config.ipv4-cpp-config-has-zero-percentage.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT _grpc_config.ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT _grpc_config.ipv4-second-language-is-cpp.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT _grpc_config.ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT _grpc_config.ipv4-second-language-is-cpp.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-second-language-is-cpp.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-second-language-is-cpp.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A ipv4-config-with-percentages.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig A ipv4-config-with-percentages.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig TXT _grpc_config.ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig TXT _grpc_config.ipv4-config-with-percentages.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig TXT _grpc_config.ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig TXT _grpc_config.ipv4-config-with-percentages.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig A balancer-for-ipv4-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig A srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig A srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig A srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig A srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig SRV _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig SRV _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig SRV _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig AAAA balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig AAAA balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig AAAA balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig AAAA balancer-for-ipv6-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
 ONE_FAILED=0
-dig AAAA srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
+dig AAAA srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. | grep 'ANSWER SECTION' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Sanity check: dig AAAA srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Sanity check: dig AAAA srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. FAILED"
   exit 1
 fi
 
@@ -226,133 +226,133 @@ echo "Sanity check PASSED. Run resolver tests:"
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv4-single-target.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv4-single-target.resolver-tests-version-10.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv4-multi-target.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv4-multi-target.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.5:1234,True;1.2.3.6:1234,True;1.2.3.7:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv4-multi-target.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv4-multi-target.resolver-tests-version-10.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv6-single-target.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv6-single-target.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1001]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv6-single-target.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv6-single-target.resolver-tests-version-10.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv6-multi-target.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv6-multi-target.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1003]:1234,True;[2607:f8b0:400a:801::1004]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv6-multi-target.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv6-multi-target.resolver-tests-version-10.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService"}],"waitForReady":true}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv4-simple-service-config.resolver-tests-version-10.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService"}],"waitForReady":true}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-no-srv-simple-service-config.resolver-tests-version-10.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-no-config-for-cpp.resolver-tests-version-10.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-cpp-config-has-zero-percentage.resolver-tests-version-10.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-second-language-is-cpp.resolver-tests-version-10.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-config-with-percentages.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService"}],"waitForReady":true}]}' \
   --expected_lb_policy='round_robin' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Test based on target record: ipv4-config-with-percentages.resolver-tests-version-10.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True;1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \
-  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1002]:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp. FAILED"
+  echo "Test based on target record: srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-10.grpctestingexp. FAILED"
   EXIT_CODE=1
 fi
 

--- a/test/cpp/naming/resolver_test_record_groups.yaml
+++ b/test/cpp/naming/resolver_test_record_groups.yaml
@@ -1,4 +1,4 @@
-resolver_tests_common_zone_name: resolver-tests-version-4.grpctestingexp.
+resolver_tests_common_zone_name: resolver-tests-version-10.grpctestingexp.
 resolver_component_tests:
 - expected_addrs:
   - {address: '1.2.3.4:1234', is_balancer: true}

--- a/test/cpp/naming/resolver_test_record_groups.yaml
+++ b/test/cpp/naming/resolver_test_record_groups.yaml
@@ -50,7 +50,7 @@ resolver_component_tests:
     - {TTL: '2100', data: '2607:f8b0:400a:801::1004', type: AAAA}
 - expected_addrs:
   - {address: '1.2.3.4:1234', is_balancer: true}
-  expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}'
+  expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService"}],"waitForReady":true}]}'
   expected_lb_policy: round_robin
   record_to_resolve: srv-ipv4-simple-service-config
   records:
@@ -59,19 +59,17 @@ resolver_component_tests:
     ipv4-simple-service-config:
     - {TTL: '2100', data: 1.2.3.4, type: A}
     _grpc_config.srv-ipv4-simple-service-config:
-    - {TTL: '2100', data: 'grpc_config=[{"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}}]',
-      type: TXT}
+    - {TTL: '2100', type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
-  expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}'
+  expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService"}],"waitForReady":true}]}'
   expected_lb_policy: round_robin
   record_to_resolve: ipv4-no-srv-simple-service-config
   records:
     ipv4-no-srv-simple-service-config:
     - {TTL: '2100', data: 1.2.3.4, type: A}
     _grpc_config.ipv4-no-srv-simple-service-config:
-    - {TTL: '2100', data: 'grpc_config=[{"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}}]',
-      type: TXT}
+    - {TTL: '2100', type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
   expected_chosen_service_config: null
@@ -81,8 +79,7 @@ resolver_component_tests:
     ipv4-no-config-for-cpp:
     - {TTL: '2100', data: 1.2.3.4, type: A}
     _grpc_config.ipv4-no-config-for-cpp:
-    - {TTL: '2100', data: 'grpc_config=[{"clientLanguage":["python"],"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"PythonService","waitForReady":true}]}]}}]',
-      type: TXT}
+    - {TTL: '2100', type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
   expected_chosen_service_config: null
@@ -92,8 +89,7 @@ resolver_component_tests:
     ipv4-cpp-config-has-zero-percentage:
     - {TTL: '2100', data: 1.2.3.4, type: A}
     _grpc_config.ipv4-cpp-config-has-zero-percentage:
-    - {TTL: '2100', data: 'grpc_config=[{"percentage":0,"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}}]',
-      type: TXT}
+    - {TTL: '2100', type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}'
@@ -103,19 +99,17 @@ resolver_component_tests:
     ipv4-second-language-is-cpp:
     - {TTL: '2100', data: 1.2.3.4, type: A}
     _grpc_config.ipv4-second-language-is-cpp:
-    - {TTL: '2100', data: 'grpc_config=[{"clientLanguage":["go"],"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"GoService","waitForReady":true}]}]}},{"clientLanguage":["c++"],"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}}]',
-      type: TXT}
+    - {TTL: '2100', type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
-  expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}'
+  expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService"}],"waitForReady":true}]}'
   expected_lb_policy: round_robin
   record_to_resolve: ipv4-config-with-percentages
   records:
     ipv4-config-with-percentages:
     - {TTL: '2100', data: 1.2.3.4, type: A}
     _grpc_config.ipv4-config-with-percentages:
-    - {TTL: '2100', data: 'grpc_config=[{"percentage":0,"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NeverPickedService","waitForReady":true}]}]}},{"percentage":100,"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}}]',
-      type: TXT}
+    - {TTL: '2100', type: TXT}
 - expected_addrs:
   - {address: '1.2.3.4:1234', is_balancer: true}
   - {address: '1.2.3.4:443', is_balancer: false}
@@ -144,12 +138,11 @@ resolver_component_tests:
     - {TTL: '2100', data: '2607:f8b0:400a:801::1002', type: AAAA}
 - expected_addrs:
   - {address: '1.2.3.4:443', is_balancer: false}
-  expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}'
+  expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwo","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooThree","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooFour","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooFive","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooSix","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooSeven","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooEight","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooNine","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTen","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooEleven","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwelve","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwelve","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwelve","service":"SimpleService"}],"waitForReady":true},{"name":[{"method":"FooTwelve","service":"SimpleService"}],"waitForReady":true}]}'
   expected_lb_policy: null
   record_to_resolve: ipv4-config-causing-fallback-to-tcp
   records:
     ipv4-config-causing-fallback-to-tcp:
     - {TTL: '2100', data: 1.2.3.4, type: A}
     _grpc_config.ipv4-config-causing-fallback-to-tcp:
-    - {TTL: '2100', data: 'grpc_config=[{"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}}]',
-      type: TXT}
+    - {TTL: '2100', type: TXT}

--- a/test/cpp/naming/service_config_utils.py
+++ b/test/cpp/naming/service_config_utils.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python2.7
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility for packing grpc service config JSON into TXT DNS records"""
+
+import json
+
+def txt_data_list_from_service_config_json(record_name, gcloud_form):
+  service_config_json_path = 'test/cpp/naming/service_configs/%s.json' % record_name
+  with open(service_config_json_path) as service_config_json_in:
+    all_data = json.dumps(json.load(service_config_json_in))
+    all_data = all_data.replace(' ', '').replace('\n', '')
+    all_data = 'grpc_config=%s' % all_data
+    chunks = []
+    cur = 0
+    # Split TXT records that span more than 255 characters (the single
+    # string length-limit in DNS) into multiple strings.
+    # The quoting and escaping rules depend on what the TXT record is
+    # intented for, "gcloud upload" or "twisted DNS server".
+    # If "gcloud upload" is the target, then each string
+    # needs to be wrapped with double-quotes, and all inner double-quotes
+    # need to be escaped. The wrapping double-quotes and inner backslashes can be
+    # counted towards the 255 character length limit
+    # though (as observed with gcloud), so make sure all strings
+    # fit within that limit.
+    while len(all_data[cur:]) > 0:
+      next_chunk = ""
+      if gcloud_form:
+        next_chunk += '\"'
+      while len(next_chunk) < 254 and len(all_data[cur:]) > 0:
+        if all_data[cur] == '\"':
+          if len(next_chunk) < 253:
+            if gcloud_form:
+              next_chunk += '\\'
+            next_chunk += all_data[cur]
+          else:
+            break
+        else:
+          next_chunk += all_data[cur]
+        cur += 1
+      if gcloud_form:
+        next_chunk += '\"'
+      if len(next_chunk) > 255:
+        raise Exception('Bug: next chunk is too long.')
+      chunks.append(next_chunk)
+    return chunks

--- a/test/cpp/naming/service_configs/_grpc_config.ipv4-config-causing-fallback-to-tcp.json
+++ b/test/cpp/naming/service_configs/_grpc_config.ipv4-config-causing-fallback-to-tcp.json
@@ -1,0 +1,144 @@
+[
+    {
+        "serviceConfig": {
+            "loadBalancingPolicy": "round_robin", 
+            "methodConfig": [
+                {
+                    "name": [
+                        {
+                            "method": "Foo", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }, 
+                {
+                    "name": [
+                        {
+                            "method": "FooTwo", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }, 
+                {
+                    "name": [
+                        {
+                            "method": "FooThree", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }, 
+                {
+                    "name": [
+                        {
+                            "method": "FooFour", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }, 
+                {
+                    "name": [
+                        {
+                            "method": "FooFive", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }, 
+                {
+                    "name": [
+                        {
+                            "method": "FooSix", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }, 
+                {
+                    "name": [
+                        {
+                            "method": "FooSeven", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }, 
+                {
+                    "name": [
+                        {
+                            "method": "FooEight", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }, 
+                {
+                    "name": [
+                        {
+                            "method": "FooNine", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }, 
+                {
+                    "name": [
+                        {
+                            "method": "FooTen", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }, 
+                {
+                    "name": [
+                        {
+                            "method": "FooEleven", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }, 
+                {
+                    "name": [
+                        {
+                            "method": "FooTwelve", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }, 
+                {
+                    "name": [
+                        {
+                            "method": "FooTwelve", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }, 
+                {
+                    "name": [
+                        {
+                            "method": "FooTwelve", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }, 
+                {
+                    "name": [
+                        {
+                            "method": "FooTwelve", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }
+            ]
+        }
+    }
+]

--- a/test/cpp/naming/service_configs/_grpc_config.ipv4-config-with-percentages.json
+++ b/test/cpp/naming/service_configs/_grpc_config.ipv4-config-with-percentages.json
@@ -1,0 +1,36 @@
+[
+    {
+        "percentage": 0, 
+        "serviceConfig": {
+            "loadBalancingPolicy": "round_robin", 
+            "methodConfig": [
+                {
+                    "name": [
+                        {
+                            "method": "Foo", 
+                            "service": "NeverPickedService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }
+            ]
+        }
+    }, 
+    {
+        "percentage": 100, 
+        "serviceConfig": {
+            "loadBalancingPolicy": "round_robin", 
+            "methodConfig": [
+                {
+                    "name": [
+                        {
+                            "method": "Foo", 
+                            "service": "AlwaysPickedService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }
+            ]
+        }
+    }
+]

--- a/test/cpp/naming/service_configs/_grpc_config.ipv4-cpp-config-has-zero-percentage.json
+++ b/test/cpp/naming/service_configs/_grpc_config.ipv4-cpp-config-has-zero-percentage.json
@@ -1,0 +1,19 @@
+[
+    {
+        "percentage": 0, 
+        "serviceConfig": {
+            "loadBalancingPolicy": "round_robin", 
+            "methodConfig": [
+                {
+                    "name": [
+                        {
+                            "method": "Foo", 
+                            "service": "CppService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }
+            ]
+        }
+    }
+]

--- a/test/cpp/naming/service_configs/_grpc_config.ipv4-no-config-for-cpp.json
+++ b/test/cpp/naming/service_configs/_grpc_config.ipv4-no-config-for-cpp.json
@@ -1,0 +1,21 @@
+[
+    {
+        "clientLanguage": [
+            "python"
+        ], 
+        "serviceConfig": {
+            "loadBalancingPolicy": "round_robin", 
+            "methodConfig": [
+                {
+                    "name": [
+                        {
+                            "method": "Foo", 
+                            "service": "PythonService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }
+            ]
+        }
+    }
+]

--- a/test/cpp/naming/service_configs/_grpc_config.ipv4-no-srv-simple-service-config.json
+++ b/test/cpp/naming/service_configs/_grpc_config.ipv4-no-srv-simple-service-config.json
@@ -1,0 +1,18 @@
+[
+    {
+        "serviceConfig": {
+            "loadBalancingPolicy": "round_robin", 
+            "methodConfig": [
+                {
+                    "name": [
+                        {
+                            "method": "Foo", 
+                            "service": "NoSrvSimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }
+            ]
+        }
+    }
+]

--- a/test/cpp/naming/service_configs/_grpc_config.ipv4-second-language-is-cpp.json
+++ b/test/cpp/naming/service_configs/_grpc_config.ipv4-second-language-is-cpp.json
@@ -1,0 +1,40 @@
+[
+    {
+        "clientLanguage": [
+            "go"
+        ], 
+        "serviceConfig": {
+            "loadBalancingPolicy": "round_robin", 
+            "methodConfig": [
+                {
+                    "name": [
+                        {
+                            "method": "Foo", 
+                            "service": "GoService", 
+                            "waitForReady": true
+                        }
+                    ]
+                }
+            ]
+        }
+    }, 
+    {
+        "clientLanguage": [
+            "c++"
+        ], 
+        "serviceConfig": {
+            "loadBalancingPolicy": "round_robin", 
+            "methodConfig": [
+                {
+                    "name": [
+                        {
+                            "method": "Foo", 
+                            "service": "CppService", 
+                            "waitForReady": true
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+]

--- a/test/cpp/naming/service_configs/_grpc_config.srv-ipv4-simple-service-config.json
+++ b/test/cpp/naming/service_configs/_grpc_config.srv-ipv4-simple-service-config.json
@@ -1,0 +1,18 @@
+[
+    {
+        "serviceConfig": {
+            "loadBalancingPolicy": "round_robin", 
+            "methodConfig": [
+                {
+                    "name": [
+                        {
+                            "method": "Foo", 
+                            "service": "SimpleService"
+                        }
+                    ], 
+                    "waitForReady": true
+                }
+            ]
+        }
+    }
+]


### PR DESCRIPTION
This brings out the fixes for service config JSONs from https://github.com/grpc/grpc/pull/12942, and also does a small refactoring

Manual changs were made to:
* `test/cpp/naming/resolver_component_test_record_groups.yaml`
* `test/cpp/naming/service_config_utils.py`
* `test/cpp/naming/test_dns_server.py`
* `test/cpp/naming/gen_build_yaml.py`
* `test/cpp/naming/resolver_component_test.cc`
* all `.json` files under `test/cpp/naming/service_configs/`

The rest of the changes are from regenerating projects.