### PR TITLE
[Bazel] Do not use -pthread on Windows

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -53,6 +53,16 @@ config_setting(
     values = {"define": "GRPC_PORT_ISOLATED_RUNTIME=1"},
 )
 
+config_setting(
+    name = "windows",
+    values = { "cpu": "x64_windows" },
+)
+
+config_setting(
+    name = "windows_msvc",
+    values = {"cpu": "x64_windows_msvc"},
+)
+
 # This should be updated along with build.yaml
 g_stands_for = "glamorous"
 

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -26,6 +26,13 @@
 # The set of pollers to test against if a test exercises polling
 POLLERS = ['epollex', 'epollsig', 'epoll1', 'poll', 'poll-cv']
 
+def if_not_windows(a):
+  return select({
+      "//:windows": [],
+      "//:windows_msvc": [],
+      "//conditions:default": a,
+  })
+
 def _get_external_deps(external_deps):
   ret = []
   for dep in external_deps:
@@ -56,7 +63,7 @@ def grpc_cc_library(name, srcs = [], public_hdrs = [], hdrs = [],
                     alwayslink = 0):
   copts = []
   if language.upper() == "C":
-    copts = ["-std=c99"]
+    copts = if_not_windows(["-std=c99"])
   native.cc_library(
     name = name,
     srcs = srcs,
@@ -73,7 +80,7 @@ def grpc_cc_library(name, srcs = [], public_hdrs = [], hdrs = [],
     copts = copts,
     visibility = visibility,
     testonly = testonly,
-    linkopts = ["-pthread"],
+    linkopts = if_not_windows(["-pthread"]),
     includes = [
         "include"
     ],
@@ -104,7 +111,7 @@ def grpc_proto_library(name, srcs = [], deps = [], well_known_protos = False,
 def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data = [], uses_polling = True, language = "C++"):
   copts = []
   if language.upper() == "C":
-    copts = ["-std=c99"]
+    copts = if_not_windows(["-std=c99"])
   args = {
     'name': name,
     'srcs': srcs,
@@ -112,7 +119,7 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
     'data': data,
     'deps': deps + _get_external_deps(external_deps),
     'copts': copts,
-    'linkopts': ["-pthread"],
+    'linkopts': if_not_windows(["-pthread"]),
   }
   if uses_polling:
     native.cc_test(testonly=True, tags=['manual'], **args)
@@ -144,7 +151,7 @@ def grpc_cc_binary(name, srcs = [], deps = [], external_deps = [], args = [], da
     linkshared = linkshared,
     deps = deps + _get_external_deps(external_deps),
     copts = copts,
-    linkopts = ["-pthread"] + linkopts,
+    linkopts = if_not_windows(["-pthread"]) + linkopts,
   )
 
 def grpc_generate_one_off_targets():


### PR DESCRIPTION
Doing the same thing as Tensorflow, Protobuf and GoogleTest so that build console output is cleaner.

- https://github.com/tensorflow/tensorflow/blob/master/tensorflow/BUILD#L108
- https://github.com/google/protobuf/blob/master/BUILD#L32
- https://github.com/google/googletest/blob/master/BUILD.bazel#L39

`if_not_windows` is adapted from [Tensorflow](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tensorflow.bzl#L127).