### PR TITLE
Reintroduce check_sources_and_headers optimization

### DIFF
--- a/tools/run_tests/sanity/check_sources_and_headers.py
+++ b/tools/run_tests/sanity/check_sources_and_headers.py
@@ -69,13 +69,10 @@ target_headers_transitive = get_headers_transitive()
 
 
 def target_has_header(target, name):
-    if name.startswith('absl/'): return True
-    # print target['name'], name
-    if name in target['headers']:
+    if name in target_headers_transitive[target['name']]:
         return True
-    for dep in target['deps']:
-        if target_has_header(get_target(dep), name):
-            return True
+    if name.startswith('absl/'):
+        return True
     if name in [
             'src/core/lib/profiling/stap_probes.h',
             'src/proto/grpc/reflection/v1alpha/reflection.grpc.pb.h'


### PR DESCRIPTION
Changes from https://github.com/grpc/grpc/pull/13700 were partially reverted by a bad manual merge in https://github.com/grpc/grpc/pull/13719 (and in historical data the check_sources_and_headers runtime jumped back from seconds to >10minutes, which is how I discovered it).

With large PRs that are generated automatically (formatting, changes to project templates) I'd suggest rebasing on top of freshest master and regenerating instead of pulling upstream/master and merging manually, as it is very easy to miss inadvertent changes in the merge.