### PR TITLE
Avoid the ares bazel dependency with grpc_no_ares=true

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -31,6 +31,9 @@ def _get_external_deps(external_deps):
   for dep in external_deps:
     if dep == "nanopb":
       ret.append("//third_party/nanopb")
+    elif dep == "cares":
+      ret += select({"//:grpc_no_ares": [],
+                     "//conditions:default": ["//external:cares"],})
     else:
       ret.append("//external:" + dep)
   return ret


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/13979 (allows building on windows with `--define grpc_no_ares=true`).