### PR TITLE
Fix gpr_sync_test timing on Windows.

### DIFF
--- a/test/core/fling/client.cc
+++ b/test/core/fling/client.cc
@@ -186,8 +186,10 @@ int main(int argc, char** argv) {
   }
   if (!sc.name) {
     fprintf(stderr, "unsupported scenario '%s'. Valid are:", scenario_name);
+    fflush(stderr);
     for (i = 0; i < GPR_ARRAY_SIZE(scenarios); i++) {
       fprintf(stderr, " %s", scenarios[i].name);
+      fflush(stderr);
     }
     return 1;
   }

--- a/test/core/network_benchmarks/low_level_ping_pong.cc
+++ b/test/core/network_benchmarks/low_level_ping_pong.cc
@@ -535,6 +535,7 @@ void print_usage(char* argv0) {
   fprintf(stderr, "  tcp: fds are endpoints of a TCP connection\n");
   fprintf(stderr, "  socketpair: fds come from socketpair()\n");
   fprintf(stderr, "  pipe: fds come from pipe()\n");
+  fflush(stderr);
 }
 
 typedef struct test_strategy {
@@ -565,6 +566,7 @@ int create_socket(const char* socket_type, fd_pair* client_fds,
     create_sockets_pipe(client_fds, server_fds);
   } else {
     fprintf(stderr, "Invalid socket type %s\n", socket_type);
+    fflush(stderr);
     return -1;
   }
   return 0;
@@ -657,6 +659,7 @@ int main(int argc, char** argv) {
   }
   if (msg_size <= 0) {
     fprintf(stderr, "msg_size must be > 0\n");
+    fflush(stderr);
     print_usage(argv[0]);
     return -1;
   }
@@ -668,6 +671,7 @@ int main(int argc, char** argv) {
   }
   if (strategy == nullptr) {
     fprintf(stderr, "Invalid read strategy %s\n", read_strategy);
+    fflush(stderr);
     return -1;
   }
 

--- a/test/core/security/create_jwt.cc
+++ b/test/core/security/create_jwt.cc
@@ -39,6 +39,7 @@ void create_jwt(const char* json_key_file_path, const char* service_url,
   grpc_slice_unref(json_key_data);
   if (!grpc_auth_json_key_is_valid(&key)) {
     fprintf(stderr, "Could not parse json key.\n");
+    fflush(stderr);
     exit(1);
   }
   jwt = grpc_jwt_encode_and_sign(
@@ -47,6 +48,7 @@ void create_jwt(const char* json_key_file_path, const char* service_url,
   grpc_auth_json_key_destruct(&key);
   if (jwt == nullptr) {
     fprintf(stderr, "Could not create JWT.\n");
+    fflush(stderr);
     exit(1);
   }
   fprintf(stdout, "%s\n", jwt);
@@ -72,16 +74,19 @@ int main(int argc, char** argv) {
 
   if (json_key_file_path == nullptr) {
     fprintf(stderr, "Missing --json_key option.\n");
+    fflush(stderr);
     exit(1);
   }
   if (scope != nullptr) {
     if (service_url != nullptr) {
       fprintf(stderr,
               "Options --scope and --service_url are mutually exclusive.\n");
+      fflush(stderr);
       exit(1);
     }
   } else if (service_url == nullptr) {
     fprintf(stderr, "Need one of --service_url or --scope options.\n");
+    fflush(stderr);
     exit(1);
   }
 

--- a/test/core/security/print_google_default_creds_token.cc
+++ b/test/core/security/print_google_default_creds_token.cc
@@ -45,6 +45,7 @@ static void on_metadata_response(void* arg, grpc_error* error) {
   synchronizer* sync = static_cast<synchronizer*>(arg);
   if (error != GRPC_ERROR_NONE) {
     fprintf(stderr, "Fetching token failed: %s\n", grpc_error_string(error));
+    fflush(stderr);
   } else {
     char* token;
     GPR_ASSERT(sync->md_array.size == 1);
@@ -81,6 +82,7 @@ int main(int argc, char** argv) {
   creds = grpc_google_default_credentials_create();
   if (creds == nullptr) {
     fprintf(stderr, "\nCould not find default credentials.\n\n");
+    fflush(stderr);
     result = 1;
     goto end;
   }

--- a/test/core/security/verify_jwt.cc
+++ b/test/core/security/verify_jwt.cc
@@ -39,6 +39,7 @@ typedef struct {
 static void print_usage_and_exit(gpr_cmdline* cl, const char* argv0) {
   char* usage = gpr_cmdline_usage_string(cl, argv0);
   fprintf(stderr, "%s", usage);
+  fflush(stderr);
   gpr_free(usage);
   gpr_cmdline_destroy(cl);
   exit(1);
@@ -62,6 +63,7 @@ static void on_jwt_verification_done(void* user_data,
     GPR_ASSERT(claims == nullptr);
     fprintf(stderr, "Verification failed with error %s\n",
             grpc_jwt_verifier_status_to_string(status));
+    fflush(stderr);
   }
 
   gpr_mu_lock(sync->mu);

--- a/test/core/support/cpu_test.cc
+++ b/test/core/support/cpu_test.cc
@@ -119,13 +119,16 @@ static void cpu_test(void) {
   }
   gpr_mu_unlock(&ct.mu);
   fprintf(stderr, "Saw cores [");
+  fflush(stderr);
   for (i = 0; i < ct.ncores; i++) {
     if (ct.used[i]) {
       fprintf(stderr, "%d,", i);
+      fflush(stderr);
       cores_seen++;
     }
   }
   fprintf(stderr, "] (%d/%d)\n", cores_seen, ct.ncores);
+  fflush(stderr);
   gpr_free(ct.used);
 }
 

--- a/test/core/support/spinlock_test.cc
+++ b/test/core/support/spinlock_test.cc
@@ -95,15 +95,18 @@ static void test(const char* name, void (*body)(void* m), int timeout_s,
   gpr_timespec deadline = gpr_time_add(
       start, gpr_time_from_micros((int64_t)timeout_s * 1000000, GPR_TIMESPAN));
   fprintf(stderr, "%s:", name);
+  fflush(stderr);
   while (gpr_time_cmp(gpr_now(GPR_CLOCK_REALTIME), deadline) < 0) {
     if (iterations < INT64_MAX / 2) iterations <<= 1;
     fprintf(stderr, " %ld", (long)iterations);
+    fflush(stderr);
     m = test_new(10, iterations, incr_step);
     test_create_threads(m, body);
     test_wait(m);
     if (m->counter != m->thread_count * m->iterations * m->incr_step) {
       fprintf(stderr, "counter %ld  threads %d  iterations %ld\n",
               (long)m->counter, m->thread_count, (long)m->iterations);
+      fflush(stderr);
       GPR_ASSERT(0);
     }
     test_destroy(m);
@@ -111,6 +114,7 @@ static void test(const char* name, void (*body)(void* m), int timeout_s,
   time_taken = gpr_time_sub(gpr_now(GPR_CLOCK_REALTIME), start);
   fprintf(stderr, " done %lld.%09d s\n", (long long)time_taken.tv_sec,
           (int)time_taken.tv_nsec);
+  fflush(stderr);
 }
 
 /* Increment m->counter on each iteration; then mark thread as done.  */

--- a/test/core/support/sync_test.cc
+++ b/test/core/support/sync_test.cc
@@ -238,9 +238,11 @@ static void test(const char* name, void (*body)(void* m),
   gpr_timespec deadline = gpr_time_add(
       start, gpr_time_from_micros((int64_t)timeout_s * 1000000, GPR_TIMESPAN));
   fprintf(stderr, "%s:", name);
+  fflush(stderr);
   while (gpr_time_cmp(gpr_now(GPR_CLOCK_REALTIME), deadline) < 0) {
     iterations <<= 1;
     fprintf(stderr, " %ld", (long)iterations);
+    fflush(stderr);
     m = test_new(10, iterations, incr_step);
     if (extra != nullptr) {
       gpr_thd_id id;
@@ -252,6 +254,7 @@ static void test(const char* name, void (*body)(void* m),
     if (m->counter != m->threads * m->iterations * m->incr_step) {
       fprintf(stderr, "counter %ld  threads %d  iterations %ld\n",
               (long)m->counter, m->threads, (long)m->iterations);
+      fflush(stderr);
       GPR_ASSERT(0);
     }
     test_destroy(m);
@@ -259,6 +262,7 @@ static void test(const char* name, void (*body)(void* m),
   time_taken = gpr_time_sub(gpr_now(GPR_CLOCK_REALTIME), start);
   fprintf(stderr, " done %lld.%09d s\n", (long long)time_taken.tv_sec,
           (int)time_taken.tv_nsec);
+  fflush(stderr);
 }
 
 /* Increment m->counter on each iteration; then mark thread as done.  */

--- a/test/core/support/sync_test.cc
+++ b/test/core/support/sync_test.cc
@@ -231,7 +231,7 @@ static void mark_thread_done(struct test* m) {
    */
 static void test(const char* name, void (*body)(void* m),
                  void (*extra)(void* m), int timeout_s, int incr_step) {
-  int64_t iterations = 1024;
+  int64_t iterations = 256;
   struct test* m;
   gpr_timespec start = gpr_now(GPR_CLOCK_REALTIME);
   gpr_timespec time_taken;
@@ -240,7 +240,6 @@ static void test(const char* name, void (*body)(void* m),
   fprintf(stderr, "%s:", name);
   fflush(stderr);
   while (gpr_time_cmp(gpr_now(GPR_CLOCK_REALTIME), deadline) < 0) {
-    iterations <<= 1;
     fprintf(stderr, " %ld", (long)iterations);
     fflush(stderr);
     m = test_new(10, iterations, incr_step);
@@ -258,6 +257,7 @@ static void test(const char* name, void (*body)(void* m),
       GPR_ASSERT(0);
     }
     test_destroy(m);
+    iterations <<= 1;
   }
   time_taken = gpr_time_sub(gpr_now(GPR_CLOCK_REALTIME), start);
   fprintf(stderr, " done %lld.%09d s\n", (long long)time_taken.tv_sec,

--- a/test/core/support/time_test.cc
+++ b/test/core/support/time_test.cc
@@ -66,21 +66,28 @@ static void test_values(void) {
 
   x = gpr_inf_future(GPR_CLOCK_REALTIME);
   fprintf(stderr, "far future ");
+  fflush(stderr);
   i_to_s(x.tv_sec, 16, 16, &to_fp, stderr);
   fprintf(stderr, "\n");
   GPR_ASSERT(x.tv_sec == INT64_MAX);
   fprintf(stderr, "far future ");
+  fflush(stderr);
   ts_to_s(x, &to_fp, stderr);
   fprintf(stderr, "\n");
+  fflush(stderr);
 
   x = gpr_inf_past(GPR_CLOCK_REALTIME);
   fprintf(stderr, "far past   ");
+  fflush(stderr);
   i_to_s(x.tv_sec, 16, 16, &to_fp, stderr);
   fprintf(stderr, "\n");
+  fflush(stderr);
   GPR_ASSERT(x.tv_sec == INT64_MIN);
   fprintf(stderr, "far past   ");
+  fflush(stderr);
   ts_to_s(x, &to_fp, stderr);
   fprintf(stderr, "\n");
+  fflush(stderr);
 
   for (i = 1; i != 1000 * 1000 * 1000; i *= 10) {
     x = gpr_time_from_micros(i, GPR_TIMESPAN);
@@ -135,15 +142,19 @@ static void test_add_sub(void) {
         if (gpr_time_cmp(gpr_time_from_micros(sum * k, GPR_TIMESPAN), sumt) !=
             0) {
           fprintf(stderr, "i %d  j %d  sum %d    sumt ", i, j, sum);
+          fflush(stderr);
           ts_to_s(sumt, &to_fp, stderr);
           fprintf(stderr, "\n");
+          fflush(stderr);
           GPR_ASSERT(0);
         }
         if (gpr_time_cmp(gpr_time_from_micros(diff * k, GPR_TIMESPAN), difft) !=
             0) {
           fprintf(stderr, "i %d  j %d  diff %d    diff ", i, j, diff);
+          fflush(stderr);
           ts_to_s(sumt, &to_fp, stderr);
           fprintf(stderr, "\n");
+          fflush(stderr);
           GPR_ASSERT(0);
         }
       }

--- a/test/core/util/debugger_macros.cc
+++ b/test/core/util/debugger_macros.cc
@@ -39,6 +39,7 @@ grpc_stream* grpc_transport_stream_from_call(grpc_call* call) {
       grpc_subchannel_call* scc = grpc_client_channel_get_subchannel_call(el);
       if (scc == nullptr) {
         fprintf(stderr, "No subchannel-call");
+        fflush(stderr);
         return nullptr;
       }
       cs = grpc_subchannel_call_get_call_stack(scc);
@@ -46,6 +47,7 @@ grpc_stream* grpc_transport_stream_from_call(grpc_call* call) {
       return grpc_connected_channel_get_stream(el);
     } else {
       fprintf(stderr, "Unrecognized filter: %s", el->filter->name);
+      fflush(stderr);
       return nullptr;
     }
   }


### PR DESCRIPTION
Based on https://github.com/grpc/grpc/pull/14002.

- gpr_sync_test.exe sometimes times out (avg. runtime is ~150sec, timeout is 300)
- the `queue` test currently takes much longer time than on linux, because it combines  blocking and non-blocking producers and TryEnterCriticalSection seems to be less fair than on linux and it slows down the progress of the test case.
- the initial iteration count is set too high so instead of the preset 10-20s of runtime, the initial run takes much longer and if we are unlucky, it can time out.

```
 cmake/build/Debug/gpr_sync_test.exe
D0112 14:13:00.368000000  4744 test_config.cc:388] test slowdown factor: sanitizer=1, fixture=1, poller=1, total=1
mutex: 256 512 1024 2048 4096 8192 16384 32768 65536 131072 262144 524288 1048576 done 1.783000000 s
mutex try: 256 512 1024 2048 4096 8192 16384 32768 65536 131072 262144 done 1.424000000 s
cv: 256 512 1024 done 1.086000000 s
timedcv: 256 done 2.739000000 s
queue: 256 512 1024 2048 4096 8192 16384 32768 done 12.547000000 s
stats_counter: 256 512 1024 2048 4096 8192 16384 32768 65536 131072 262144 524288 1048576 done 1.626000000 s
refcount by 1: 256 512 1024 2048 4096 8192 16384 32768 65536 131072 262144 524288 done 1.011000000 s
refcount by 3: 256 512 1024 2048 4096 8192 16384 32768 65536 131072 262144 524288 done 1.359000000 s
timedevent: 256 512 done 1.336000000 s
```