### PR TITLE
Correct a usage of select in grpc_build_system

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -30,12 +30,12 @@ def _get_external_deps(external_deps):
   ret = []
   for dep in external_deps:
     if dep == "nanopb":
-      ret.append("//third_party/nanopb")
+      ret += ["//third_party/nanopb"]
     elif dep == "cares":
       ret += select({"//:grpc_no_ares": [],
                      "//conditions:default": ["//external:cares"],})
     else:
-      ret.append("//external:" + dep)
+      ret += ["//external:" + dep]
   return ret
 
 def _maybe_update_cc_library_hdrs(hdrs):


### PR DESCRIPTION
Follow up to https://github.com/grpc/grpc/pull/13991

Apparently the bazel `select` function creates something that is able to be added with other arrays using the `+` operator, but it can't be treated like an array necessarily, you can't call `append` on it.

When merging #13991 into https://github.com/grpc/grpc/pull/13290, I found that a BUILD rule having `address_sorting` dep come after `cares` failed because we can't `append` to the thing returned by `select` 