### PR TITLE
Fix sed error in podspecs on sed 4.4

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -1085,6 +1085,6 @@ Pod::Spec.new do |s|
 
   # TODO (mxyan): Instead of this hack, add include path "third_party" to C core's include path?
   s.prepare_command = <<-END_OF_COMMAND
-    find src/core/ -type f -exec sed -E -i '.back' 's;#include "third_party/nanopb/(.*)";#include <nanopb/\\1>;g' {} \\\;
+    find src/core/ -type f -exec sed -E -i'.back' 's;#include "third_party/nanopb/(.*)";#include <nanopb/\\1>;g' {} \\\;
   END_OF_COMMAND
 end

--- a/src/objective-c/BoringSSL.podspec
+++ b/src/objective-c/BoringSSL.podspec
@@ -136,12 +136,12 @@ Pod::Spec.new do |s|
     # Replace "const BIGNUM *I" in rsa.h with a lowercase i, as the former fails when including
     # OpenSSL in a Swift bridging header (complex.h defines "I", and it's as if the compiler
     # included it in every bridged header).
-    sed -E -i '.back' 's/\\*I,/*i,/g' include/openssl/rsa.h
+    sed -E -i'.back' 's/\\*I,/*i,/g' include/openssl/rsa.h
 
     # Replace `#include "../crypto/internal.h"` in e_tls.c with `#include "../internal.h"`. The
     # former assumes crypto/ is in the headers search path, which is hard to enforce when using
     # dynamic frameworks. The latters always works, being relative to the current file.
-    sed -E -i '.back' 's/crypto\\///g' crypto/cipher/e_tls.c
+    sed -E -i'.back' 's/crypto\\///g' crypto/cipher/e_tls.c
 
     # Add a module map and an umbrella header
     cat > include/openssl/umbrella.h <<EOF
@@ -197,11 +197,11 @@ Pod::Spec.new do |s|
     # https://github.com/libgit2/libgit2/commit/1ddada422caf8e72ba97dca2568d2bf879fed5f2 and libvpx
     # in https://chromium.googlesource.com/webm/libvpx/+/1bec0c5a7e885ec792f6bb658eb3f34ad8f37b15
     # work around it by removing the include. We need four of its macros, so we expand them here.
-    sed -E -i '.back' '/<inttypes.h>/d' include/openssl/bn.h
-    sed -E -i '.back' 's/PRIu32/"u"/g' include/openssl/bn.h
-    sed -E -i '.back' 's/PRIx32/"x"/g' include/openssl/bn.h
-    sed -E -i '.back' 's/PRIu64/"llu"/g' include/openssl/bn.h
-    sed -E -i '.back' 's/PRIx64/"llx"/g' include/openssl/bn.h
+    sed -E -i'.back' '/<inttypes.h>/d' include/openssl/bn.h
+    sed -E -i'.back' 's/PRIu32/"u"/g' include/openssl/bn.h
+    sed -E -i'.back' 's/PRIx32/"x"/g' include/openssl/bn.h
+    sed -E -i'.back' 's/PRIu64/"llu"/g' include/openssl/bn.h
+    sed -E -i'.back' 's/PRIx64/"llx"/g' include/openssl/bn.h
 
     # This is a bit ridiculous, but requiring people to install Go in order to build is slightly
     # more ridiculous IMO. To save you from scrolling, this is the last part of the podspec.

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -202,6 +202,6 @@
 
     # TODO (mxyan): Instead of this hack, add include path "third_party" to C core's include path?
     s.prepare_command = <<-END_OF_COMMAND
-      find src/core/ -type f -exec sed -E -i '.back' 's;#include "third_party/nanopb/(.*)";#include <nanopb/\\1>;g' {} \\\;
+      find src/core/ -type f -exec sed -E -i'.back' 's;#include "third_party/nanopb/(.*)";#include <nanopb/\\1>;g' {} \\\;
     END_OF_COMMAND
   end


### PR DESCRIPTION
`sed` prints error in version 4.4 when there is a space between -i and the extension string. Apparently it considers the extension string as script when there is a space.