### PR TITLE
Backport PR #14017 and #12706 into 1.8.x

### DIFF
--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -242,6 +242,7 @@ PHP_METHOD(Channel, __construct) {
 
   // parse the rest of the channel args array
   if (php_grpc_read_args_array(args_array, &args TSRMLS_CC) == FAILURE) {
+    efree(args.args);
     return;
   }
 
@@ -301,6 +302,7 @@ PHP_METHOD(Channel, __construct) {
       create_and_add_channel_to_persistent_list(
           channel, target, args, creds, key, key_len TSRMLS_CC);
     } else {
+      efree(args.args);
       channel->wrapper = le->channel;
     }
   }

--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -35,6 +35,7 @@
 #include <zend_hash.h>
 
 #include <grpc/support/alloc.h>
+#include <grpc/support/string_util.h>
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
 
@@ -46,10 +47,11 @@ static char *default_pem_root_certs = NULL;
 
 static grpc_ssl_roots_override_result get_ssl_roots_override(
     char **pem_root_certs) {
-  *pem_root_certs = default_pem_root_certs;
-  if (default_pem_root_certs == NULL) {
+  if (!default_pem_root_certs) {
+    *pem_root_certs = NULL;
     return GRPC_SSL_ROOTS_OVERRIDE_FAIL;
   }
+  *pem_root_certs = gpr_strdup(default_pem_root_certs);
   return GRPC_SSL_ROOTS_OVERRIDE_OK;
 }
 
@@ -101,7 +103,7 @@ PHP_METHOD(ChannelCredentials, setDefaultRootsPem) {
                          "setDefaultRootsPem expects 1 string", 1 TSRMLS_CC);
     return;
   }
-  default_pem_root_certs = gpr_malloc((pem_roots_length + 1) * sizeof(char));
+  default_pem_root_certs = gpr_realloc(default_pem_root_certs, (pem_roots_length + 1) * sizeof(char));
   memcpy(default_pem_root_certs, pem_roots, pem_roots_length + 1);
 }
 


### PR DESCRIPTION
When using php-fpm, channel is reused, but allocation for arguments and credentials are not freed, which will cause the memory leak. It combines 2 commits in #14017, #12706.

Can't test on Sierra 10.13.2 because it will report error:
src/core/ext/transport/chttp2/server/chttp2_server.cc:194:43: error: use of undeclared identifier 'GRPC_ARG_SERVER_HANDSHAKE_TIMEOUT_MS'