### PR TITLE
Ruby macos kokoro environment and package build updates

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -99,7 +99,7 @@ task 'dlls' do
     env_comp = "CC=#{opt[:cross]}-gcc "
     env_comp += "CXX=#{opt[:cross]}-g++ "
     env_comp += "LD=#{opt[:cross]}-gcc "
-    docker_for_windows "gem update --system && #{env} #{env_comp} make -j #{out} && #{opt[:cross]}-strip -x -S #{out} && cp #{out} #{opt[:out]}"
+    docker_for_windows "gem update --system --no-ri --no-doc && #{env} #{env_comp} make -j #{out} && #{opt[:cross]}-strip -x -S #{out} && cp #{out} #{opt[:out]}"
   end
 
 end
@@ -113,10 +113,15 @@ task 'gem:native' do
   if RUBY_PLATFORM =~ /darwin/
     FileUtils.touch 'grpc_c.32.ruby'
     FileUtils.touch 'grpc_c.64.ruby'
+    unless '2.5' == /(\d+\.\d+)/.match(RUBY_VERSION).to_s
+      fail "rake gem:native (the rake task to build the binary packages) is being " \
+        "invoked on macos with ruby #{RUBY_VERSION}. The ruby macos artifact " \
+        "build should be running on ruby 2.5."
+    end
     system "rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0:2.3.0:2.2.2:2.1.6:2.0.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
   else
     Rake::Task['dlls'].execute
-    docker_for_windows "gem update --system && bundle && rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0:2.3.0:2.2.2:2.1.6:2.0.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
+    docker_for_windows "gem update --system --no-ri --no-doc && bundle && rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0:2.3.0:2.2.2:2.1.6:2.0.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
   end
 end
 

--- a/src/objective-c/GRPCClient/private/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.m
@@ -189,6 +189,7 @@ static grpc_channel_args *BuildChannelArgs(NSDictionary *dictionary) {
     timeout = 0;
   }
   grpc_slice host_slice;
+  memset(&host_slice, 0, sizeof(host_slice));
   if (serverName) {
     host_slice = grpc_slice_from_copied_string(serverName.UTF8String);
   }

--- a/test/core/end2end/tests/streaming_error_response.cc
+++ b/test/core/end2end/tests/streaming_error_response.cc
@@ -111,7 +111,7 @@ static void test(grpc_end2end_test_config config, bool request_status_early) {
   grpc_byte_buffer* response_payload1_recv = nullptr;
   grpc_byte_buffer* response_payload2_recv = nullptr;
   grpc_call_details call_details;
-  grpc_status_code status;
+  grpc_status_code status = GRPC_STATUS_OK;
   grpc_call_error error;
   grpc_slice details;
   int was_cancelled = 2;

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -50,7 +50,8 @@ fi
 set +ex  # rvm script is very verbose and exits with errorcode
 source $HOME/.rvm/scripts/rvm
 set -e  # rvm commands are very verbose
-rvm use ruby-2.4
+rvm install 2.5.0
+rvm use 2.5.0 --default
 rvm osx-ssl-certs status all
 rvm osx-ssl-certs update all
 set -ex

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -50,8 +50,11 @@ fi
 set +ex  # rvm script is very verbose and exits with errorcode
 source $HOME/.rvm/scripts/rvm
 set -e  # rvm commands are very verbose
-rvm install 2.5.0
+time rvm install 2.5.0
 rvm use 2.5.0 --default
+gem install bundler --no-ri --no-doc
+gem install cocoapods --version 1.3.1 --no-ri --no-doc
+gem install rake-compiler --no-ri --no-doc
 rvm osx-ssl-certs status all
 rvm osx-ssl-certs update all
 set -ex


### PR DESCRIPTION
This updates kokoro tests to use ruby  2.5 and adds a sanity check that jenkins mac are configured as expected. (All jenkins mac workers are now running ruby 2.5; observably, this was needed for grpc-ruby mac binaries in mac packages to load on ruby 2.5).

Also, skipping the doc installation during `gem  update --system` cuts ~1 minute from the package build