### PR TITLE
Try avoid deadline_exceeded failure in dualstack_socket_test

### DIFF
--- a/test/core/end2end/dualstack_socket_test.cc
+++ b/test/core/end2end/dualstack_socket_test.cc
@@ -43,14 +43,11 @@
 
 static void* tag(intptr_t i) { return (void*)i; }
 
-static gpr_timespec ms_from_now(int ms) {
-  return grpc_timeout_milliseconds_to_deadline(ms);
-}
-
 static void drain_cq(grpc_completion_queue* cq) {
   grpc_event ev;
   do {
-    ev = grpc_completion_queue_next(cq, ms_from_now(5000), nullptr);
+    ev = grpc_completion_queue_next(
+        cq, grpc_timeout_milliseconds_to_deadline(5000), nullptr);
   } while (ev.type != GRPC_QUEUE_SHUTDOWN);
 }
 
@@ -165,11 +162,11 @@ void test_connect(const char* server_host, const char* client_host, int port,
 
   if (expect_ok) {
     /* Normal deadline, shouldn't be reached. */
-    deadline = ms_from_now(60000);
+    deadline = grpc_timeout_milliseconds_to_deadline(60000);
   } else {
     /* Give up faster when failure is expected.
        BUG: Setting this to 1000 reveals a memory leak (b/18608927). */
-    deadline = ms_from_now(3000);
+    deadline = grpc_timeout_milliseconds_to_deadline(3000);
   }
 
   /* Send a trivial request. */

--- a/test/core/end2end/dualstack_socket_test.cc
+++ b/test/core/end2end/dualstack_socket_test.cc
@@ -169,7 +169,7 @@ void test_connect(const char* server_host, const char* client_host, int port,
   } else {
     /* Give up faster when failure is expected.
        BUG: Setting this to 1000 reveals a memory leak (b/18608927). */
-    deadline = ms_from_now(1500);
+    deadline = ms_from_now(3000);
   }
 
   /* Send a trivial request. */


### PR DESCRIPTION
All failures in https://github.com/grpc/grpc/issues/13727 show `status: 4 (expected: 14) assertion failed: status == GRPC_STATUS_UNAVAILABLE`.
status 4 is DEADLINE_EXCEEDED. So there's a good chance that the testing machines under load just time out (there's also a chance there's an actual bug, but if there is, changing the timeout from 1500ms to 3000ms probably won't hide it anyway).

I was able to get a reproduction locally when I set this deadline very low.

Fixes  https://github.com/grpc/grpc/issues/13727

