### PR TITLE
Make code consistent with backoff spec names

### DIFF
--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -232,8 +232,8 @@ typedef struct {
 /** Secondary user agent: goes at the end of the user-agent metadata
     sent on each request. A string. */
 #define GRPC_ARG_SECONDARY_USER_AGENT_STRING "grpc.secondary_user_agent"
-/** The minimum time between subsequent connection attempts, in ms */
-#define GRPC_ARG_MIN_RECONNECT_BACKOFF_MS "grpc.min_reconnect_backoff_ms"
+/** The minimum time we are giving a connection to complete, in ms */
+#define GRPC_ARG_MIN_CONNECT_TIMEOUT "grpc.min_connect_timeout_ms"
 /** The maximum time between subsequent connection attempts, in ms */
 #define GRPC_ARG_MAX_RECONNECT_BACKOFF_MS "grpc.max_reconnect_backoff_ms"
 /** The time between the first and second connection attempts, in ms */

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -280,8 +280,7 @@ static void parse_args_for_backoff_values(
             grpc_channel_arg_get_integer(
                 &args->args[i],
                 {static_cast<int>(initial_backoff_ms), 100, INT_MAX});
-      } else if (0 ==
-                 strcmp(args->args[i].key, GRPC_ARG_MIN_RECONNECT_BACKOFF_MS)) {
+      } else if (0 == strcmp(args->args[i].key, GRPC_ARG_MIN_CONNECT_TIMEOUT)) {
         fixed_reconnect_backoff = false;
         *min_connect_timeout_ms = grpc_channel_arg_get_integer(
             &args->args[i],

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -346,24 +346,24 @@ TEST_F(ClientLbEnd2endTest, PickFirstBackOffInitialReconnect) {
 
 TEST_F(ClientLbEnd2endTest, PickFirstBackOffMinReconnect) {
   ChannelArguments args;
-  constexpr int kMinReconnectBackOffMs = 1000;
-  args.SetInt(GRPC_ARG_MIN_RECONNECT_BACKOFF_MS, kMinReconnectBackOffMs);
+  constexpr int kMinConnectTimeout = 1000;
+  args.SetInt(GRPC_ARG_MIN_CONNECT_TIMEOUT, kMinConnectTimeout);
   const std::vector<int> ports = {grpc_pick_unused_port_or_die()};
   ResetStub(ports, "pick_first", args);
   SetNextResolution(ports);
   // Make connection delay a 10% longer than it's willing to in order to make
   // sure we are hitting the codepath that waits for the min reconnect backoff.
-  gpr_atm_rel_store(&g_connection_delay_ms, kMinReconnectBackOffMs * 1.10);
+  gpr_atm_rel_store(&g_connection_delay_ms, kMinConnectTimeout * 1.10);
   grpc_tcp_client_connect_impl = tcp_client_connect_with_delay;
   const gpr_timespec t0 = gpr_now(GPR_CLOCK_MONOTONIC);
   channel_->WaitForConnected(
-      grpc_timeout_milliseconds_to_deadline(kMinReconnectBackOffMs * 2));
+      grpc_timeout_milliseconds_to_deadline(kMinConnectTimeout * 2));
   const gpr_timespec t1 = gpr_now(GPR_CLOCK_MONOTONIC);
   const grpc_millis waited_ms = gpr_time_to_millis(gpr_time_sub(t1, t0));
   gpr_log(GPR_DEBUG, "Waited %ld ms", waited_ms);
-  // We should have waited at least kMinReconnectBackOffMs. We substract one to
+  // We should have waited at least kMinConnectTimeout. We substract one to
   // account for test and precision accuracy drift.
-  EXPECT_GE(waited_ms, kMinReconnectBackOffMs - 1);
+  EXPECT_GE(waited_ms, kMinConnectTimeout - 1);
   gpr_atm_rel_store(&g_connection_delay_ms, 0);
 }
 


### PR DESCRIPTION
In particular for `GRPC_ARG_MIN_RECONNECT_BACKOFF_MS` vs [the spec's](https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md) MIN_CONNECT_TIMEOUT

This change is motivated by John Hume's input from
https://groups.google.com/d/topic/grpc-io/X5LqZM6yUW0/discussion . Thanks!