### PR TITLE
Remove extraneous Finish in ExecCtx

### DIFF
--- a/src/core/lib/iomgr/exec_ctx.h
+++ b/src/core/lib/iomgr/exec_ctx.h
@@ -158,10 +158,6 @@ on outside context */
     now_is_valid_ = true;
   }
 
-  /** Finish any pending work for a grpc_exec_ctx. Must be called before
-   *  the instance is destroyed, or work may be lost. */
-  void Finish();
-
   /** Global initialization for ExecCtx. Called by iomgr */
   static void GlobalInit(void);
 


### PR DESCRIPTION
This Finish() was removed because it was not needed, but the declaration remains.