### PR TITLE
PHP: make generate_projects.sh smarter for package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
   <email>grpc-packages@google.com</email>
   <active>yes</active>
  </lead>
- <date>2017-08-24</date>
+ <date>2018-01-19</date>
  <time>16:06:07</time>
  <version>
   <release>1.10.0dev</release>
@@ -22,12 +22,7 @@
  </stability>
  <license>Apache 2.0</license>
  <notes>
-- Channel are now by default persistent #11878
-- Some bug fixes from 1.4 branch #12109, #12123
-- Fixed hang bug when fork() was used #11814
-- License changed to Apache 2.0
-- Added support for php_namespace option in codegen plugin #11886
-- Updated gRPC C Core library version 1.6
+- TBD
  </notes>
  <contents>
   <dir baseinstalldir="/" name="/">

--- a/templates/package.xml.template
+++ b/templates/package.xml.template
@@ -12,24 +12,19 @@
     <email>grpc-packages@google.com</email>
     <active>yes</active>
    </lead>
-   <date>2017-08-24</date>
+   <date>2018-01-19</date>
    <time>16:06:07</time>
    <version>
     <release>${settings.php_version.php()}</release>
     <api>${settings.php_version.php()}</api>
    </version>
    <stability>
-    <release>beta</release>
-    <api>beta</api>
+    <release>${settings.php_version.php_stability()}</release>
+    <api>${settings.php_version.php_stability()}</api>
    </stability>
    <license>Apache 2.0</license>
    <notes>
-  - Channel are now by default persistent #11878
-  - Some bug fixes from 1.4 branch #12109, #12123
-  - Fixed hang bug when fork() was used #11814
-  - License changed to Apache 2.0
-  - Added support for php_namespace option in codegen plugin #11886
-  - Updated gRPC C Core library version 1.6
+  - TBD
    </notes>
    <contents>
     <dir baseinstalldir="/" name="/">

--- a/tools/buildgen/plugins/expand_version.py
+++ b/tools/buildgen/plugins/expand_version.py
@@ -84,6 +84,13 @@ class Version:
                     % self.tag)
         return s
 
+    def php_stability(self):
+        """stability string for PHP PECL package.xml file"""
+        if self.tag:
+            return 'beta'
+        else:
+            return 'stable'
+
     def php_composer(self):
         """Version string for PHP Composer package"""
         return '%d.%d.%d' % (self.major, self.minor, self.patch)


### PR DESCRIPTION
When we are at `RC` or `dev`, the PHP `package.xml` should have the stability `beta`. Otherwise, the string should be `stable`.

This is to further minimize the amount of manual work we have to do per release on PECL.