### PR TITLE
Fix leak caused by C# context pooling (when GrpcEnvironment is shutdown).

### DIFF
--- a/src/csharp/Grpc.Core/GrpcEnvironment.cs
+++ b/src/csharp/Grpc.Core/GrpcEnvironment.cs
@@ -299,8 +299,8 @@ namespace Grpc.Core
         private GrpcEnvironment()
         {
             GrpcNativeInit();
-            batchContextPool = new DefaultObjectPool<BatchContextSafeHandle>(() => BatchContextSafeHandle.Create(this.batchContextPool), batchContextPoolSharedCapacity, batchContextPoolThreadLocalCapacity);
-            requestCallContextPool = new DefaultObjectPool<RequestCallContextSafeHandle>(() => RequestCallContextSafeHandle.Create(this.requestCallContextPool), requestCallContextPoolSharedCapacity, requestCallContextPoolThreadLocalCapacity);
+            batchContextPool = new DefaultObjectPool<BatchContextSafeHandle>(() => BatchContextSafeHandle.Create(), batchContextPoolSharedCapacity, batchContextPoolThreadLocalCapacity);
+            requestCallContextPool = new DefaultObjectPool<RequestCallContextSafeHandle>(() => RequestCallContextSafeHandle.Create(), requestCallContextPoolSharedCapacity, requestCallContextPoolThreadLocalCapacity);
             threadPool = new GrpcThreadPool(this, GetThreadPoolSizeOrDefault(), GetCompletionQueueCountOrDefault(), inlineHandlers);
             threadPool.Start();
         }

--- a/src/csharp/Grpc.Core/Internal/IPooledObject.cs
+++ b/src/csharp/Grpc.Core/Internal/IPooledObject.cs
@@ -1,0 +1,34 @@
+#region Copyright notice and license
+
+// Copyright 2018 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+
+namespace Grpc.Core.Internal
+{
+    /// <summary>
+    /// An object that can be pooled in <c>IObjectPool</c>.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal interface IPooledObject<T> : IDisposable
+    {
+        /// <summary>
+        /// Set the action that will be invoked to return a leased object to the pool.
+        /// </summary>
+        void SetReturnToPoolAction(Action<T> returnAction);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/14021 in v1.9.x.

When pooling BatchContextSafeHandle and RequestCallSafeHandle objects, we make sure that the pooled object don't contain a reference to the object pool (which in turn has references to other objects created by GrpcEnvironment), because they can keep references from an already-shutdown GrpcEnviroment alive even though they should have been dead.

I verified that the fix is effective with a variation of the example from https://github.com/grpc/grpc/issues/14021 and https://github.com/grpc/grpc/issues/13941.

