### PR TITLE
Benchmark grpc_core::RefCountedPtr vs std::shared_ptr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,6 +510,9 @@ endif()
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 add_dependencies(buildtests_cxx bm_pollset)
 endif()
+if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
+add_dependencies(buildtests_cxx bm_refcount)
+endif()
 add_dependencies(buildtests_cxx channel_arguments_test)
 add_dependencies(buildtests_cxx channel_filter_test)
 add_dependencies(buildtests_cxx chttp2_settings_timeout_test)
@@ -9059,6 +9062,48 @@ target_include_directories(bm_pollset
 )
 
 target_link_libraries(bm_pollset
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc_benchmark
+  ${_gRPC_BENCHMARK_LIBRARIES}
+  grpc++_test_util_unsecure
+  grpc_test_util_unsecure
+  grpc++_unsecure
+  grpc_unsecure
+  gpr_test_util
+  gpr
+  ${_gRPC_GFLAGS_LIBRARIES}
+)
+
+endif()
+endif (gRPC_BUILD_TESTS)
+if (gRPC_BUILD_TESTS)
+if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
+
+add_executable(bm_refcount
+  test/cpp/microbenchmarks/bm_refcount.cc
+  third_party/googletest/googletest/src/gtest-all.cc
+  third_party/googletest/googlemock/src/gmock-all.cc
+)
+
+
+target_include_directories(bm_refcount
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
+  PRIVATE ${_gRPC_PROTOBUF_INCLUDE_DIR}
+  PRIVATE ${_gRPC_ZLIB_INCLUDE_DIR}
+  PRIVATE ${_gRPC_BENCHMARK_INCLUDE_DIR}
+  PRIVATE ${_gRPC_CARES_INCLUDE_DIR}
+  PRIVATE ${_gRPC_GFLAGS_INCLUDE_DIR}
+  PRIVATE third_party/googletest/googletest/include
+  PRIVATE third_party/googletest/googletest
+  PRIVATE third_party/googletest/googlemock/include
+  PRIVATE third_party/googletest/googlemock
+  PRIVATE ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(bm_refcount
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_benchmark

--- a/build.yaml
+++ b/build.yaml
@@ -3781,6 +3781,26 @@ targets:
   - mac
   - linux
   - posix
+- name: bm_refcount
+  build: test
+  language: c++
+  src:
+  - test/cpp/microbenchmarks/bm_refcount.cc
+  deps:
+  - grpc_benchmark
+  - benchmark
+  - grpc++_test_util_unsecure
+  - grpc_test_util_unsecure
+  - grpc++_unsecure
+  - grpc_unsecure
+  - gpr_test_util
+  - gpr
+  benchmark: true
+  defaults: benchmark
+  platforms:
+  - mac
+  - linux
+  - posix
 - name: channel_arguments_test
   gtest: true
   build: test

--- a/src/core/lib/gprpp/memory.h
+++ b/src/core/lib/gprpp/memory.h
@@ -59,6 +59,12 @@ inline UniquePtr<T> MakeUnique(Args&&... args) {
 template <class T>
 class Allocator {
  public:
+  Allocator() {}
+
+  // Create a copy of an allocator of a component type, used in allocate-shared
+  template <class Component>
+  Allocator(const Allocator<Component>&) {}
+
   typedef T value_type;
   typedef T* pointer;
   typedef const T* const_pointer;

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -143,3 +143,11 @@ grpc_cc_binary(
     srcs = ["bm_metadata.cc"],
     deps = [":helpers"],
 )
+
+grpc_cc_binary(
+    name = "bm_refcount",
+    testonly = 1,
+    srcs = ["bm_refcount.cc"],
+    deps = [":helpers"],
+)
+

--- a/test/cpp/microbenchmarks/bm_refcount.cc
+++ b/test/cpp/microbenchmarks/bm_refcount.cc
@@ -80,6 +80,16 @@ static void BM_RefCountedAllocateLarge(benchmark::State& state) {
 }
 BENCHMARK(BM_RefCountedAllocateLarge);
 
+static void BM_RefCountedCopy(benchmark::State& state) {
+  auto rcp = grpc_core::MakeRefCounted<SmallRef>();
+  TrackCounters track_counters;
+  while (state.KeepRunning()) {
+    auto rcp1 = rcp;
+  }
+  track_counters.Finish(state);
+}
+BENCHMARK(BM_RefCountedCopy);
+
 static void BM_SharedAllocateSmall(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::Allocator<Small> alloc;
@@ -109,6 +119,17 @@ static void BM_SharedAllocateLarge(benchmark::State& state) {
   track_counters.Finish(state);
 }
 BENCHMARK(BM_SharedAllocateLarge);
+
+static void BM_SharedCopy(benchmark::State& state) {
+  grpc_core::Allocator<Small> alloc;
+  auto sp = std::allocate_shared<Small>(alloc);
+  TrackCounters track_counters;
+  while (state.KeepRunning()) {
+    auto sp1 = sp;
+  }
+  track_counters.Finish(state);
+}
+BENCHMARK(BM_SharedCopy);
 
 }  // namespace testing
 }  // namespace grpc

--- a/test/cpp/microbenchmarks/bm_refcount.cc
+++ b/test/cpp/microbenchmarks/bm_refcount.cc
@@ -36,7 +36,7 @@ struct Small {
 struct SmallRef : public grpc_core::RefCounted {
   struct Small obj;
 };
-  
+
 struct Medium {
   int word[1000];
 };
@@ -44,7 +44,7 @@ struct Medium {
 struct MediumRef : public grpc_core::RefCounted {
   struct Medium obj;
 };
-  
+
 struct Large {
   int word[1000000];
 };
@@ -52,7 +52,7 @@ struct Large {
 struct LargeRef : public grpc_core::RefCounted {
   struct Large obj;
 };
-  
+
 static void BM_RefCountedAllocateSmall(benchmark::State& state) {
   TrackCounters track_counters;
   while (state.KeepRunning()) {

--- a/test/cpp/microbenchmarks/bm_refcount.cc
+++ b/test/cpp/microbenchmarks/bm_refcount.cc
@@ -28,6 +28,7 @@
 
 namespace grpc {
 namespace testing {
+namespace {
 
 struct Small {
   int word;
@@ -53,7 +54,7 @@ struct LargeRef : public grpc_core::RefCounted {
   struct Large obj;
 };
 
-static void BM_RefCountedAllocateSmall(benchmark::State& state) {
+void BM_RefCountedAllocateSmall(benchmark::State& state) {
   TrackCounters track_counters;
   while (state.KeepRunning()) {
     auto rcp = grpc_core::MakeRefCounted<SmallRef>();
@@ -62,7 +63,7 @@ static void BM_RefCountedAllocateSmall(benchmark::State& state) {
 }
 BENCHMARK(BM_RefCountedAllocateSmall);
 
-static void BM_RefCountedAllocateMedium(benchmark::State& state) {
+void BM_RefCountedAllocateMedium(benchmark::State& state) {
   TrackCounters track_counters;
   while (state.KeepRunning()) {
     auto rcp = grpc_core::MakeRefCounted<MediumRef>();
@@ -71,7 +72,7 @@ static void BM_RefCountedAllocateMedium(benchmark::State& state) {
 }
 BENCHMARK(BM_RefCountedAllocateMedium);
 
-static void BM_RefCountedAllocateLarge(benchmark::State& state) {
+void BM_RefCountedAllocateLarge(benchmark::State& state) {
   TrackCounters track_counters;
   while (state.KeepRunning()) {
     auto rcp = grpc_core::MakeRefCounted<LargeRef>();
@@ -80,7 +81,7 @@ static void BM_RefCountedAllocateLarge(benchmark::State& state) {
 }
 BENCHMARK(BM_RefCountedAllocateLarge);
 
-static void BM_RefCountedCopy(benchmark::State& state) {
+void BM_RefCountedCopy(benchmark::State& state) {
   auto rcp = grpc_core::MakeRefCounted<SmallRef>();
   TrackCounters track_counters;
   while (state.KeepRunning()) {
@@ -90,7 +91,7 @@ static void BM_RefCountedCopy(benchmark::State& state) {
 }
 BENCHMARK(BM_RefCountedCopy);
 
-static void BM_SharedAllocateSmall(benchmark::State& state) {
+void BM_SharedAllocateSmall(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::Allocator<Small> alloc;
   while (state.KeepRunning()) {
@@ -100,7 +101,7 @@ static void BM_SharedAllocateSmall(benchmark::State& state) {
 }
 BENCHMARK(BM_SharedAllocateSmall);
 
-static void BM_SharedAllocateMedium(benchmark::State& state) {
+void BM_SharedAllocateMedium(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::Allocator<Medium> alloc;
   while (state.KeepRunning()) {
@@ -110,7 +111,7 @@ static void BM_SharedAllocateMedium(benchmark::State& state) {
 }
 BENCHMARK(BM_SharedAllocateMedium);
 
-static void BM_SharedAllocateLarge(benchmark::State& state) {
+void BM_SharedAllocateLarge(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::Allocator<Large> alloc;
   while (state.KeepRunning()) {
@@ -120,7 +121,7 @@ static void BM_SharedAllocateLarge(benchmark::State& state) {
 }
 BENCHMARK(BM_SharedAllocateLarge);
 
-static void BM_SharedCopy(benchmark::State& state) {
+void BM_SharedCopy(benchmark::State& state) {
   grpc_core::Allocator<Small> alloc;
   auto sp = std::allocate_shared<Small>(alloc);
   TrackCounters track_counters;
@@ -131,6 +132,7 @@ static void BM_SharedCopy(benchmark::State& state) {
 }
 BENCHMARK(BM_SharedCopy);
 
+}  // namespace
 }  // namespace testing
 }  // namespace grpc
 

--- a/test/cpp/microbenchmarks/bm_refcount.cc
+++ b/test/cpp/microbenchmarks/bm_refcount.cc
@@ -1,0 +1,116 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <benchmark/benchmark.h>
+#include <grpc++/impl/grpc_library.h>
+#include <grpc/grpc.h>
+#include <grpc/support/log.h>
+#include "test/cpp/microbenchmarks/helpers.h"
+
+#include "src/core/lib/gprpp/memory.h"
+#include "src/core/lib/gprpp/ref_counted.h"
+#include "src/core/lib/gprpp/ref_counted_ptr.h"
+
+namespace grpc {
+namespace testing {
+
+struct Small {
+  int word;
+};
+
+struct SmallRef : public grpc_core::RefCounted {
+  struct Small obj;
+};
+  
+struct Medium {
+  int word[1000];
+};
+
+struct MediumRef : public grpc_core::RefCounted {
+  struct Medium obj;
+};
+  
+struct Large {
+  int word[1000000];
+};
+
+struct LargeRef : public grpc_core::RefCounted {
+  struct Large obj;
+};
+  
+static void BM_RefCountedAllocateSmall(benchmark::State& state) {
+  TrackCounters track_counters;
+  while (state.KeepRunning()) {
+    auto rcp = grpc_core::MakeRefCounted<SmallRef>();
+  }
+  track_counters.Finish(state);
+}
+BENCHMARK(BM_RefCountedAllocateSmall);
+
+static void BM_RefCountedAllocateMedium(benchmark::State& state) {
+  TrackCounters track_counters;
+  while (state.KeepRunning()) {
+    auto rcp = grpc_core::MakeRefCounted<MediumRef>();
+  }
+  track_counters.Finish(state);
+}
+BENCHMARK(BM_RefCountedAllocateMedium);
+
+static void BM_RefCountedAllocateLarge(benchmark::State& state) {
+  TrackCounters track_counters;
+  while (state.KeepRunning()) {
+    auto rcp = grpc_core::MakeRefCounted<LargeRef>();
+  }
+  track_counters.Finish(state);
+}
+BENCHMARK(BM_RefCountedAllocateLarge);
+
+static void BM_SharedAllocateSmall(benchmark::State& state) {
+  TrackCounters track_counters;
+  grpc_core::Allocator<Small> alloc;
+  while (state.KeepRunning()) {
+    auto sp = std::allocate_shared<Small>(alloc);
+  }
+  track_counters.Finish(state);
+}
+BENCHMARK(BM_SharedAllocateSmall);
+
+static void BM_SharedAllocateMedium(benchmark::State& state) {
+  TrackCounters track_counters;
+  grpc_core::Allocator<Medium> alloc;
+  while (state.KeepRunning()) {
+    auto sp = std::allocate_shared<Medium>(alloc);
+  }
+  track_counters.Finish(state);
+}
+BENCHMARK(BM_SharedAllocateMedium);
+
+static void BM_SharedAllocateLarge(benchmark::State& state) {
+  TrackCounters track_counters;
+  grpc_core::Allocator<Large> alloc;
+  while (state.KeepRunning()) {
+    auto sp = std::allocate_shared<Large>(alloc);
+  }
+  track_counters.Finish(state);
+}
+BENCHMARK(BM_SharedAllocateLarge);
+
+}  // namespace testing
+}  // namespace grpc
+
+BENCHMARK_MAIN();

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -2822,6 +2822,27 @@
   }, 
   {
     "deps": [
+      "benchmark", 
+      "gpr", 
+      "gpr_test_util", 
+      "grpc++_test_util_unsecure", 
+      "grpc++_unsecure", 
+      "grpc_benchmark", 
+      "grpc_test_util_unsecure", 
+      "grpc_unsecure"
+    ], 
+    "headers": [], 
+    "is_filegroup": false, 
+    "language": "c++", 
+    "name": "bm_refcount", 
+    "src": [
+      "test/cpp/microbenchmarks/bm_refcount.cc"
+    ], 
+    "third_party": false, 
+    "type": "target"
+  }, 
+  {
+    "deps": [
       "gpr", 
       "grpc", 
       "grpc++"

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3315,6 +3315,28 @@
   }, 
   {
     "args": [], 
+    "benchmark": true, 
+    "ci_platforms": [
+      "linux", 
+      "mac", 
+      "posix"
+    ], 
+    "cpu_cost": 1.0, 
+    "exclude_configs": [], 
+    "exclude_iomgrs": [], 
+    "flaky": false, 
+    "gtest": false, 
+    "language": "c++", 
+    "name": "bm_refcount", 
+    "platforms": [
+      "linux", 
+      "mac", 
+      "posix"
+    ], 
+    "uses_polling": true
+  }, 
+  {
+    "args": [], 
     "benchmark": false, 
     "ci_platforms": [
       "linux", 


### PR DESCRIPTION
On my Mac (edited 12/22, 9:48 PM):

```
$ bazel build -c opt //test/cpp/microbenchmarks:bm_refcount
$ ./bazel-bin/test/cpp/microbenchmarks/bm_refcount
Run on (8 X 2200 MHz CPU s)
2018-01-22 13:00:44

// grpc_core::MakeRefCounted
BM_RefCountedAllocateSmall          98 ns
BM_RefCountedAllocateMedium        132 ns
BM_RefCountedAllocateLarge      155570 ns
BM_RefCountedCopy                   15 ns

// std::allocate_shared
BM_SharedAllocateSmall              94 ns
BM_SharedAllocateMedium            130 ns
BM_SharedAllocateLarge          155026 ns
BM_SharedCopy                       17 ns
```

I'll add more results as I get them (or y'all can feel free to add them)

NOTE: There were differences in an earlier run but nothing substantial this time. I believe that the differences between the versions are only noise.


