### PR TITLE
php: fix channel reuse doesn't free allocated wrapper

### DIFF
--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -318,6 +318,10 @@ PHP_METHOD(Channel, __construct) {
         channel->wrapper->creds_hashstr = NULL;
       }
       free(channel->wrapper->creds_hashstr);
+      free(channel->wrapper->key);
+      free(channel->wrapper->target);
+      free(channel->wrapper->args_hashstr);
+      free(channel->wrapper);
       channel->wrapper = le->channel;
     }
   }


### PR DESCRIPTION
It is split from [PR](https://github.com/ZhouyihaiDing/grpc/pull/9).

They are all allocated [here](https://github.com/grpc/grpc/pull/14129/files#diff-f942bdda09aac4a837cef783506850f0R275).