### PR TITLE
php: fix channel wrapper leak

### DIFF
--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -40,6 +40,11 @@ typedef struct _grpc_channel_wrapper {
   char *args_hashstr;
   char *creds_hashstr;
   gpr_mu mu;
+  // is_valid is used to check the wrapped channel has been freed
+  // before to avoid double free.
+  bool is_valid;
+  // ref_count is used to let the last wrapper free related channel and key.
+  size_t ref_count;
 } grpc_channel_wrapper;
 
 /* Wrapper struct for grpc_channel that can be associated with a PHP object */


### PR DESCRIPTION
It is split from [PR](https://github.com/ZhouyihaiDing/grpc/pull/9).
There wasn't place to free channel wrapper allocated [here](https://github.com/grpc/grpc/pull/14130/files#diff-f942bdda09aac4a837cef783506850f0R308).
In php-fpm mode, each time a channel_wrapper is created, it remains there.

Another solution is use R_SHUTDOWN function to free them after each request.