### PR TITLE
Fix two ruby memory leaks when exceptions are raised

### DIFF
--- a/src/ruby/ext/grpc/rb_channel.c
+++ b/src/ruby/ext/grpc/rb_channel.c
@@ -427,16 +427,15 @@ static VALUE grpc_rb_channel_create_call(VALUE self, VALUE parent, VALUE mask,
     parent_call = grpc_rb_get_wrapped_call(parent);
   }
 
-  cq = grpc_completion_queue_create_for_pluck(NULL);
   TypedData_Get_Struct(self, grpc_rb_channel, &grpc_channel_data_type, wrapper);
   if (wrapper->bg_wrapped == NULL) {
     rb_raise(rb_eRuntimeError, "closed!");
     return Qnil;
   }
 
+  cq = grpc_completion_queue_create_for_pluck(NULL);
   method_slice =
       grpc_slice_from_copied_buffer(RSTRING_PTR(method), RSTRING_LEN(method));
-
   call = grpc_channel_create_call(wrapper->bg_wrapped->channel, parent_call,
                                   flags, cq, method_slice, host_slice_ptr,
                                   grpc_rb_time_timeval(deadline,


### PR DESCRIPTION
Towards being able to run tests asan tests from https://github.com/grpc/grpc/pull/11580 cleanly (those tests aren't automated yet because they aren't running completely cleanly right now).