### PR TITLE
Refactor ruby server shutdown to fix a race in tests

### DIFF
--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -246,7 +246,7 @@ module GRPC
         transition_running_state(:stopping)
       end
       deadline = from_relative_time(@poll_period)
-      @server.close(deadline)
+      @server.shutdown_and_notify(deadline)
       @pool.stop
     end
 
@@ -418,6 +418,7 @@ module GRPC
       # @running_state should be :stopping here
       @run_mutex.synchronize { transition_running_state(:stopped) }
       GRPC.logger.info("stopped: #{self}")
+      @server.close
     end
 
     def new_active_server_call(an_rpc)

--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -244,9 +244,9 @@ module GRPC
         fail 'Cannot stop before starting' if @running_state == :not_started
         return if @running_state != :running
         transition_running_state(:stopping)
+        deadline = from_relative_time(@poll_period)
+        @server.shutdown_and_notify(deadline)
       end
-      deadline = from_relative_time(@poll_period)
-      @server.shutdown_and_notify(deadline)
       @pool.stop
     end
 
@@ -416,9 +416,11 @@ module GRPC
         end
       end
       # @running_state should be :stopping here
-      @run_mutex.synchronize { transition_running_state(:stopped) }
-      GRPC.logger.info("stopped: #{self}")
-      @server.close
+      @run_mutex.synchronize do
+        transition_running_state(:stopped)
+        GRPC.logger.info("stopped: #{self}")
+        @server.close
+      end
     end
 
     def new_active_server_call(an_rpc)

--- a/src/ruby/spec/client_server_spec.rb
+++ b/src/ruby/spec/client_server_spec.rb
@@ -550,7 +550,8 @@ describe 'the http client/server' do
 
   after(:example) do
     @ch.close
-    @server.close(deadline)
+    @server.shutdown_and_notify(deadline)
+    @server.close
   end
 
   it_behaves_like 'basic GRPC message delivery is OK' do
@@ -583,7 +584,8 @@ describe 'the secure http client/server' do
   end
 
   after(:example) do
-    @server.close(deadline)
+    @server.shutdown_and_notify(deadline)
+    @server.close
   end
 
   it_behaves_like 'basic GRPC message delivery is OK' do

--- a/src/ruby/spec/generic/active_call_spec.rb
+++ b/src/ruby/spec/generic/active_call_spec.rb
@@ -48,7 +48,8 @@ describe GRPC::ActiveCall do
   end
 
   after(:each) do
-    @server.close(deadline)
+    @server.shutdown_and_notify(deadline)
+    @server.close
   end
 
   describe 'restricted view methods' do

--- a/src/ruby/spec/generic/client_stub_spec.rb
+++ b/src/ruby/spec/generic/client_stub_spec.rb
@@ -83,7 +83,12 @@ def sanity_check_values_of_accessors(op_view,
          op_view.deadline.is_a?(Time)).to be(true)
 end
 
-describe 'ClientStub' do
+def close_active_server_call(active_server_call)
+  active_server_call.send(:set_input_stream_done)
+  active_server_call.send(:set_output_stream_done)
+end
+
+describe 'ClientStub' do  # rubocop:disable Metrics/BlockLength
   let(:noop) { proc { |x| x } }
 
   before(:each) do
@@ -96,7 +101,10 @@ describe 'ClientStub' do
   end
 
   after(:each) do
-    @server.close(from_relative_time(2)) unless @server.nil?
+    unless @server.nil?
+      @server.shutdown_and_notify(from_relative_time(2))
+      @server.close
+    end
   end
 
   describe '#new' do
@@ -230,7 +238,15 @@ describe 'ClientStub' do
 
       it 'should receive UNAVAILABLE if call credentials plugin fails' do
         server_port = create_secure_test_server
-        th = run_request_response(@sent_msg, @resp, @pass)
+        server_started_notifier = GRPC::Notifier.new
+        th = Thread.new do
+          @server.start
+          server_started_notifier.notify(nil)
+          # Poll on the server so that the client connection can proceed.
+          # We don't expect the server to actually accept a call though.
+          expect { @server.request_call }.to raise_error(GRPC::Core::CallError)
+        end
+        server_started_notifier.wait
 
         certs = load_test_certs
         secure_channel_creds = GRPC::Core::ChannelCredentials.new(
@@ -249,17 +265,18 @@ describe 'ClientStub' do
         end
         creds = GRPC::Core::CallCredentials.new(failing_auth)
 
-        unauth_error_occured = false
+        unavailable_error_occured = false
         begin
           get_response(stub, credentials: creds)
         rescue GRPC::Unavailable => e
-          unauth_error_occured = true
+          unavailable_error_occured = true
           expect(e.details.include?(error_message)).to be true
         end
-        expect(unauth_error_occured).to eq(true)
+        expect(unavailable_error_occured).to eq(true)
 
-        # Kill the server thread so tests can complete
-        th.kill
+        @server.shutdown_and_notify(Time.now + 3)
+        th.join
+        @server.close
       end
 
       it 'should raise ArgumentError if metadata contains invalid values' do
@@ -493,6 +510,7 @@ describe 'ClientStub' do
             p 'remote_send failed (allowed because call expected to cancel)'
           ensure
             c.send_status(OK, 'OK', true)
+            close_active_server_call(c)
           end
         end
       end
@@ -659,6 +677,7 @@ describe 'ClientStub' do
           end
           # can't fail since initial metadata already sent
           server_call.send_status(@pass, 'OK', true)
+          close_active_server_call(server_call)
         end
 
         def verify_error_from_write_thread(stub, requests_to_push,
@@ -809,6 +828,7 @@ describe 'ClientStub' do
       replys.each { |r| c.remote_send(r) }
       c.send_status(status, status == @pass ? 'OK' : 'NOK', true,
                     metadata: server_trailing_md)
+      close_active_server_call(c)
     end
   end
 
@@ -819,6 +839,7 @@ describe 'ClientStub' do
       expected_inputs.each { |i| expect(c.remote_read).to eq(i) }
       replys.each { |r| c.remote_send(r) }
       c.send_status(status, status == @pass ? 'OK' : 'NOK', true)
+      close_active_server_call(c)
     end
   end
 
@@ -844,6 +865,7 @@ describe 'ClientStub' do
       end
       c.send_status(status, status == @pass ? 'OK' : 'NOK', true,
                     metadata: server_trailing_md)
+      close_active_server_call(c)
     end
   end
 
@@ -862,6 +884,7 @@ describe 'ClientStub' do
       c.remote_send(resp)
       c.send_status(status, status == @pass ? 'OK' : 'NOK', true,
                     metadata: server_trailing_md)
+      close_active_server_call(c)
     end
   end
 
@@ -880,6 +903,7 @@ describe 'ClientStub' do
       c.remote_send(resp)
       c.send_status(status, status == @pass ? 'OK' : 'NOK', true,
                     metadata: server_trailing_md)
+      close_active_server_call(c)
     end
   end
 

--- a/src/ruby/spec/server_spec.rb
+++ b/src/ruby/spec/server_spec.rb
@@ -36,45 +36,60 @@ describe Server do
 
     it 'fails if the server is closed' do
       s = new_core_server_for_testing(nil)
+      s.shutdown_and_notify(nil)
       s.close
       expect { s.start }.to raise_error(RuntimeError)
     end
   end
 
-  describe '#destroy' do
+  describe '#shutdown_and_notify and #destroy' do
     it 'destroys a server ok' do
       s = start_a_server
-      blk = proc { s.destroy }
+      blk = proc do
+        s.shutdown_and_notify(nil)
+        s.destroy
+      end
       expect(&blk).to_not raise_error
     end
 
     it 'can be called more than once without error' do
       s = start_a_server
       begin
-        blk = proc { s.destroy }
+        blk = proc do
+          s.shutdown_and_notify(nil)
+          s.destroy
+        end
         expect(&blk).to_not raise_error
         blk.call
         expect(&blk).to_not raise_error
       ensure
+        s.shutdown_and_notify(nil)
         s.close
       end
     end
   end
 
-  describe '#close' do
+  describe '#shutdown_and_notify and #close' do
     it 'closes a server ok' do
       s = start_a_server
       begin
-        blk = proc { s.close }
+        blk = proc do
+          s.shutdown_and_notify(nil)
+          s.close
+        end
         expect(&blk).to_not raise_error
       ensure
-        s.close(@cq)
+        s.shutdown_and_notify(nil)
+        s.close
       end
     end
 
     it 'can be called more than once without error' do
       s = start_a_server
-      blk = proc { s.close }
+      blk = proc do
+        s.shutdown_and_notify(nil)
+        s.close
+      end
       expect(&blk).to_not raise_error
       blk.call
       expect(&blk).to_not raise_error
@@ -87,6 +102,7 @@ describe Server do
         blk = proc do
           s = new_core_server_for_testing(nil)
           s.add_http2_port('localhost:0', :this_port_is_insecure)
+          s.shutdown_and_notify(nil)
           s.close
         end
         expect(&blk).to_not raise_error
@@ -94,6 +110,7 @@ describe Server do
 
       it 'fails if the server is closed' do
         s = new_core_server_for_testing(nil)
+        s.shutdown_and_notify(nil)
         s.close
         blk = proc do
           s.add_http2_port('localhost:0', :this_port_is_insecure)
@@ -108,6 +125,7 @@ describe Server do
         blk = proc do
           s = new_core_server_for_testing(nil)
           s.add_http2_port('localhost:0', cert)
+          s.shutdown_and_notify(nil)
           s.close
         end
         expect(&blk).to_not raise_error
@@ -115,6 +133,7 @@ describe Server do
 
       it 'fails if the server is closed' do
         s = new_core_server_for_testing(nil)
+        s.shutdown_and_notify(nil)
         s.close
         blk = proc { s.add_http2_port('localhost:0', cert) }
         expect(&blk).to raise_error(RuntimeError)


### PR DESCRIPTION
Fixes a race that shows up when ruby tests are ran on a busy machine, towards fixing https://github.com/grpc/grpc/issues/14043. Also does some test clean up to make sure server calls get closed/finished in tests to move towards enabling https://github.com/grpc/grpc/pull/11580.

Before this change, running `tools/run_tests.py -l ruby -c dbg -n inf -r run_ruby.sh` would result in a frequent failure (I observed almost 1/4 flakiness locally):

```
assertion failed: cqd->completed_head.next == (uintptr_t)&cqd->completed_head
```

... which doesn't seem to occur after this change.

The problem appears to be that `Server.close` can sometimes destroy a server's completion queue <i>after</i> the server has requested a new call on it, but <i>before</i> the server has finished it's pluck for that requested call.

------------------------------------------

fixes fixes https://github.com/grpc/grpc/issues/14334