### PR TITLE
Remove use_external

### DIFF
--- a/bazel/cc_grpc_library.bzl
+++ b/bazel/cc_grpc_library.bzl
@@ -2,7 +2,7 @@
 
 load("//:bazel/generate_cc.bzl", "generate_cc")
 
-def cc_grpc_library(name, srcs, deps, proto_only, well_known_protos, generate_mock, use_external = False, **kwargs):
+def cc_grpc_library(name, srcs, deps, proto_only, well_known_protos, generate_mock, **kwargs):
   """Generates C++ grpc classes from a .proto file.
 
   Assumes the generated classes will be used in cc_api_version = 2.
@@ -14,8 +14,6 @@ def cc_grpc_library(name, srcs, deps, proto_only, well_known_protos, generate_mo
         the compiled code of any message that the services depend on.
       well_known_protos: Should this library additionally depend on well known
         protos
-      use_external: When True the grpc deps are prefixed with //external. This
-        allows grpc to be used as a dependency in other bazel projects.
       generate_mock: When true GMOCk code for client stub is generated.
       **kwargs: rest of arguments, e.g., compatible_with and visibility.
   """
@@ -43,33 +41,23 @@ def cc_grpc_library(name, srcs, deps, proto_only, well_known_protos, generate_mo
   )
 
   if not proto_only:
-    if use_external:
-      # when this file is used by non-grpc projects
-      plugin = "//external:grpc_cpp_plugin"
-    else:
-      plugin = "//:grpc_cpp_plugin"
-
     generate_cc(
         name = codegen_grpc_target,
         srcs = [proto_target],
-        plugin = plugin,
+        plugin = "@com_github_grpc_grpc//:grpc_cpp_plugin",
         well_known_protos = well_known_protos,
         generate_mock = generate_mock,
         **kwargs
     )
 
-    if use_external:
-      # when this file is used by non-grpc projects
-      grpc_deps = ["//external:grpc++_codegen_proto",
-                   "//external:protobuf"]
-    else:
-      grpc_deps = ["//:grpc++_codegen_proto", "//external:protobuf"]
-
     native.cc_library(
         name = name,
         srcs = [":" + codegen_grpc_target, ":" + codegen_target],
         hdrs = [":" + codegen_grpc_target, ":" + codegen_target],
-        deps = deps + grpc_deps,
+        deps = deps + [
+            "@com_github_grpc_grpc//:grpc++_codegen_proto",
+            "@com_google_protobuf//:protobuf",
+        ],
         **kwargs
     )
   else:

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -90,14 +90,13 @@ def grpc_proto_plugin(name, srcs = [], deps = []):
 load("//:bazel/cc_grpc_library.bzl", "cc_grpc_library")
 
 def grpc_proto_library(name, srcs = [], deps = [], well_known_protos = False,
-                       has_services = True, use_external = False, generate_mock = False):
+                       has_services = True, generate_mock = False):
   cc_grpc_library(
     name = name,
     srcs = srcs,
     deps = deps,
     well_known_protos = well_known_protos,
     proto_only = not has_services,
-    use_external = use_external,
     generate_mock = generate_mock,
   )
 


### PR DESCRIPTION
use_external is unnecessary, and complicates the cc_grpc_library
interface. It can be replaced by using fully-qualified labels to refer
to targets in the gRPC workspace.

"//external" also relies on bind(), which is not recommended:
https://docs.bazel.build/versions/master/be/workspace.html#bind

I have tested by running `CC=gcc bazel build //test/...`.