### PR TITLE
php: fix channel_credentials hashstr leak

### DIFF
--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -57,6 +57,10 @@ static grpc_ssl_roots_override_result get_ssl_roots_override(
 
 /* Frees and destroys an instance of wrapped_grpc_channel_credentials */
 PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_channel_credentials)
+  if (p->hashstr != NULL) {
+    free(p->hashstr);
+    p->hashstr = NULL;
+  }
   if (p->wrapped != NULL) {
     grpc_channel_credentials_release(p->wrapped);
     p->wrapped = NULL;


### PR DESCRIPTION
It is split from this [PR](https://github.com/ZhouyihaiDing/grpc/pull/11).

Since now channel_credentials has it's own allocation for hashstr, it can free it during the destruction.