### PR TITLE
php: fix grpc_parse_metadata_array leak

### DIFF
--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -99,6 +99,7 @@ zval *grpc_parse_metadata_array(grpc_metadata_array
                              1 TSRMLS_CC);
         efree(str_key);
         efree(str_val);
+        PHP_GRPC_FREE_STD_ZVAL(array);
         return NULL;
       }
       php_grpc_add_next_index_stringl(data, str_val,


### PR DESCRIPTION
It is split from this [PR](https://github.com/ZhouyihaiDing/grpc/pull/11).

array should be freed before return.