### PR TITLE
php: fix call return peer leak

### DIFF
--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -538,7 +538,9 @@ cleanup:
  */
 PHP_METHOD(Call, getPeer) {
   wrapped_grpc_call *call = Z_WRAPPED_GRPC_CALL_P(getThis());
-  PHP_GRPC_RETURN_STRING(grpc_call_get_peer(call->wrapped), 1);
+  char *peer = grpc_call_get_peer(call->wrapped);
+  PHP_GRPC_RETVAL_STRING(peer, 1);
+  gpr_free(peer);
 }
 
 /**


### PR DESCRIPTION
It is split from this [PR](https://github.com/ZhouyihaiDing/grpc/pull/11).

peer should be freed after creating return value.