### PR TITLE
Fix warning & typo in grpc++/impl/codegen/call.h

### DIFF
--- a/include/grpc++/impl/codegen/call.h
+++ b/include/grpc++/impl/codegen/call.h
@@ -607,7 +607,7 @@ class CallOpSetInterface : public CompletionQueueTag {
   virtual void FillOps(grpc_call* call, grpc_op* ops, size_t* nops) = 0;
 };
 
-/// Primary implementaiton of CallOpSetInterface.
+/// Primary implementation of CallOpSetInterface.
 /// Since we cannot use variadic templates, we declare slots up to
 /// the maximum count of ops we'll need in a set. We leverage the
 /// empty base class optimization to slim this class (especially
@@ -624,7 +624,7 @@ class CallOpSet : public CallOpSetInterface,
                   public Op5,
                   public Op6 {
  public:
-  CallOpSet() : return_tag_(this) {}
+  CallOpSet() : return_tag_(this), call_(nullptr) {}
   void FillOps(grpc_call* call, grpc_op* ops, size_t* nops) override {
     this->Op1::AddOp(ops, nops);
     this->Op2::AddOp(ops, nops);


### PR DESCRIPTION
With gcc7.2, getting this warning:
```
include/grpc++/impl/codegen/call.h:619:7: error: ‘*((void*)(&<anonymous>)+56).grpc::internal::CallOpSet<grpc::internal::CallOpSendInitialMetadata>::call_’ may be used uninitialized in this function [-Werror=maybe-uninitialized] class CallOpSet : public CallOpSetInterface,       ^~~~~~~~~include/grpc++/impl/codegen/call.h: In member function ‘void grpc::testing::AsyncQpsServerTest<RequestType, ResponseType, ServiceType, ServerContextType>::ServerRpcContextStreamingFromClientImpl::Reset() 
```