### PR TITLE
Change Ref() methods to return a RefCountedPtr<>.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -599,6 +599,7 @@ grpc_cc_library(
     public_hdrs = ["src/core/lib/gprpp/orphanable.h"],
     deps = [
         "debug_location",
+        "ref_counted_ptr",
         "gpr++_base",
         "grpc_trace",
     ],
@@ -610,6 +611,7 @@ grpc_cc_library(
     public_hdrs = ["src/core/lib/gprpp/ref_counted.h"],
     deps = [
         "debug_location",
+        "ref_counted_ptr",
         "gpr++_base",
         "grpc_trace",
     ],

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -738,8 +738,9 @@ grpc_arg grpc_create_subchannel_address_arg(const grpc_resolved_address* addr) {
 }
 
 namespace grpc_core {
+
 ConnectedSubchannel::ConnectedSubchannel(grpc_channel_stack* channel_stack)
-    : grpc_core::RefCountedWithTracing(&grpc_trace_stream_refcount),
+    : RefCountedWithTracing<ConnectedSubchannel>(&grpc_trace_stream_refcount),
       channel_stack_(channel_stack) {}
 
 ConnectedSubchannel::~ConnectedSubchannel() {
@@ -774,7 +775,9 @@ grpc_error* ConnectedSubchannel::CreateCall(const CallArgs& args,
       args.arena,
       sizeof(grpc_subchannel_call) + channel_stack_->call_stack_size);
   grpc_call_stack* callstk = SUBCHANNEL_CALL_TO_CALL_STACK(*call);
-  Ref(DEBUG_LOCATION, "subchannel_call");
+  RefCountedPtr<ConnectedSubchannel> connection =
+      Ref(DEBUG_LOCATION, "subchannel_call");
+  connection.release();  // Ref is passed to the grpc_subchannel_call object.
   (*call)->connection = this;
   const grpc_call_element_args call_args = {
       callstk,           /* call_stack */
@@ -796,4 +799,5 @@ grpc_error* ConnectedSubchannel::CreateCall(const CallArgs& args,
   grpc_call_stack_set_pollset_or_pollset_set(callstk, args.pollent);
   return GRPC_ERROR_NONE;
 }
+
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/subchannel.h
+++ b/src/core/ext/filters/client_channel/subchannel.h
@@ -68,7 +68,8 @@ typedef struct grpc_subchannel_key grpc_subchannel_key;
 #endif
 
 namespace grpc_core {
-class ConnectedSubchannel : public grpc_core::RefCountedWithTracing {
+
+class ConnectedSubchannel : public RefCountedWithTracing<ConnectedSubchannel> {
  public:
   struct CallArgs {
     grpc_polling_entity* pollent;
@@ -93,6 +94,7 @@ class ConnectedSubchannel : public grpc_core::RefCountedWithTracing {
  private:
   grpc_channel_stack* channel_stack_;
 };
+
 }  // namespace grpc_core
 
 grpc_subchannel* grpc_subchannel_ref(

--- a/src/core/lib/gprpp/ref_counted.h
+++ b/src/core/lib/gprpp/ref_counted.h
@@ -26,16 +26,28 @@
 #include "src/core/lib/gprpp/abstract.h"
 #include "src/core/lib/gprpp/debug_location.h"
 #include "src/core/lib/gprpp/memory.h"
+#include "src/core/lib/gprpp/ref_counted_ptr.h"
 
 namespace grpc_core {
 
 // A base class for reference-counted objects.
 // New objects should be created via New() and start with a refcount of 1.
 // When the refcount reaches 0, the object will be deleted via Delete().
+//
+// This will commonly be used by CRTP (curiously-recurring template pattern)
+// e.g., class MyClass : public RefCounted<MyClass>
+template <typename Child>
 class RefCounted {
  public:
-  void Ref() { gpr_ref(&refs_); }
+  RefCountedPtr<Child> Ref() GRPC_MUST_USE_RESULT {
+    IncrementRefCount();
+    return RefCountedPtr<Child>(reinterpret_cast<Child*>(this));
+  }
 
+  // TODO(roth): Once all of our code is converted to C++ and can use
+  // RefCountedPtr<> instead of manual ref-counting, make this method
+  // private, since it will only be used by RefCountedPtr<>, which is a
+  // friend of this class.
   void Unref() {
     if (gpr_unref(&refs_)) {
       Delete(this);
@@ -58,6 +70,11 @@ class RefCounted {
   virtual ~RefCounted() {}
 
  private:
+  // Allow RefCountedPtr<> to access IncrementRefCount().
+  friend class RefCountedPtr<Child>;
+
+  void IncrementRefCount() { gpr_ref(&refs_); }
+
   gpr_refcount refs_;
 };
 
@@ -67,19 +84,29 @@ class RefCounted {
 // pointers and legacy code that is manually calling Ref() and Unref().
 // Once all of our code is converted to idiomatic C++, we may be able to
 // eliminate this class.
+template <typename Child>
 class RefCountedWithTracing {
  public:
-  void Ref() { gpr_ref(&refs_); }
+  RefCountedPtr<Child> Ref() GRPC_MUST_USE_RESULT {
+    IncrementRefCount();
+    return RefCountedPtr<Child>(reinterpret_cast<Child*>(this));
+  }
 
-  void Ref(const DebugLocation& location, const char* reason) {
+  RefCountedPtr<Child> Ref(const DebugLocation& location,
+                           const char* reason) GRPC_MUST_USE_RESULT {
     if (location.Log() && trace_flag_ != nullptr && trace_flag_->enabled()) {
       gpr_atm old_refs = gpr_atm_no_barrier_load(&refs_.count);
       gpr_log(GPR_DEBUG, "%s:%p %s:%d ref %" PRIdPTR " -> %" PRIdPTR " %s",
               trace_flag_->name(), this, location.file(), location.line(),
               old_refs, old_refs + 1, reason);
     }
-    Ref();
+    return Ref();
   }
+
+  // TODO(roth): Once all of our code is converted to C++ and can use
+  // RefCountedPtr<> instead of manual ref-counting, make the Unref() methods
+  // private, since they will only be used by RefCountedPtr<>, which is a
+  // friend of this class.
 
   void Unref() {
     if (gpr_unref(&refs_)) {
@@ -124,6 +151,11 @@ class RefCountedWithTracing {
   virtual ~RefCountedWithTracing() {}
 
  private:
+  // Allow RefCountedPtr<> to access IncrementRefCount().
+  friend class RefCountedPtr<Child>;
+
+  void IncrementRefCount() { gpr_ref(&refs_); }
+
   TraceFlag* trace_flag_ = nullptr;
   gpr_refcount refs_;
 };

--- a/test/core/gprpp/ref_counted_ptr_test.cc
+++ b/test/core/gprpp/ref_counted_ptr_test.cc
@@ -30,7 +30,7 @@ namespace grpc_core {
 namespace testing {
 namespace {
 
-class Foo : public RefCounted {
+class Foo : public RefCounted<Foo> {
  public:
   Foo() : value_(0) {}
 
@@ -163,14 +163,15 @@ TEST(MakeRefCounted, Args) {
 
 TraceFlag foo_tracer(true, "foo");
 
-class FooWithTracing : public RefCountedWithTracing {
+class FooWithTracing : public RefCountedWithTracing<FooWithTracing> {
  public:
   FooWithTracing() : RefCountedWithTracing(&foo_tracer) {}
 };
 
 TEST(RefCountedPtr, RefCountedWithTracing) {
   RefCountedPtr<FooWithTracing> foo(New<FooWithTracing>());
-  foo->Ref(DEBUG_LOCATION, "foo");
+  RefCountedPtr<FooWithTracing> foo2 = foo->Ref(DEBUG_LOCATION, "foo");
+  foo2.release();
   foo->Unref(DEBUG_LOCATION, "foo");
 }
 

--- a/test/core/gprpp/ref_counted_test.cc
+++ b/test/core/gprpp/ref_counted_test.cc
@@ -27,7 +27,7 @@ namespace grpc_core {
 namespace testing {
 namespace {
 
-class Foo : public RefCounted {
+class Foo : public RefCounted<Foo> {
  public:
   Foo() {}
 };
@@ -39,7 +39,8 @@ TEST(RefCounted, Basic) {
 
 TEST(RefCounted, ExtraRef) {
   Foo* foo = New<Foo>();
-  foo->Ref();
+  RefCountedPtr<Foo> foop = foo->Ref();
+  foop.release();
   foo->Unref();
   foo->Unref();
 }
@@ -48,17 +49,19 @@ TEST(RefCounted, ExtraRef) {
 // things build properly in both debug and non-debug cases.
 DebugOnlyTraceFlag foo_tracer(true, "foo");
 
-class FooWithTracing : public RefCountedWithTracing {
+class FooWithTracing : public RefCountedWithTracing<FooWithTracing> {
  public:
   FooWithTracing() : RefCountedWithTracing(&foo_tracer) {}
 };
 
 TEST(RefCountedWithTracing, Basic) {
   FooWithTracing* foo = New<FooWithTracing>();
-  foo->Ref(DEBUG_LOCATION, "extra_ref");
+  RefCountedPtr<FooWithTracing> foop = foo->Ref(DEBUG_LOCATION, "extra_ref");
+  foop.release();
   foo->Unref(DEBUG_LOCATION, "extra_ref");
   // Can use the no-argument methods, too.
-  foo->Ref();
+  foop = foo->Ref();
+  foop.release();
   foo->Unref();
   foo->Unref(DEBUG_LOCATION, "original_ref");
 }


### PR DESCRIPTION
This is an alternative to #14179.  The idea here is that instead of creating a new base class for objects for which we want to generate a new `RefCountedPtr<>` internally, we give that capability to any ref-counted object.  This is done by changing the `Ref()` method to return a `RefCountedPtr<>` directly.  This has the nice property that creating a ref automatically yields a `RefCountedPtr<>`, so it's not possible to create a ref that the type system won't automatically clean up for us.

Some things to note:

- We now use the [Curiously Recurring Template Pattern](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern) for the ref-counting classes.

- This does require tighter coupling between the ref-counting classes and `RefCountedPtr<>`.  In particular, there is a need to increment the refcount without creating a new `RefCountedPtr<>` (e.g., when copying a `RefCountedPtr<>` to another one).  To support this, there is now a private `IncrementRefCount()` method, and `RefCountedPtr<>` is now a friend of the ref-counting classes.

- Making `RefCountedPtr<>` a friend of `InternallyRefCounted` also fixes a pre-existing problem whereby `RefCountedPtr<>` could not call the `InternallyRefCounted` object's `Unref()` method, which was protected.

- For cases where we need to pass a ref-counted pointer to legacy C code that handles the references manually instead of using `RefCountedPtr<>`, the caller will need to first get `RefCountedPtr<>` and then call its `release()` method.  This is a bit cumbersome, but I think that's a feature, not a bug: it provides a code smell that tells the reader that something funny is going on and that it needs to be fixed as part of converting the C code to C++.

- For the subchannel code, we continue to use manual ref-counting instead of `RefCountedPtr<>`.  We can look at changing this if we find a good solution for #14219.

Please let me know what you think.  Thanks!