### PR TITLE
use SourceLink.Create.CommandLine instead of Embed

### DIFF
--- a/src/csharp/Grpc.Core/SourceLink.csproj.include
+++ b/src/csharp/Grpc.Core/SourceLink.csproj.include
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.7.3" PrivateAssets="all" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.6" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
You should use source linking instead of embedding the source files. This saves 275 KB for the nupkg. It goes from 12317 KB to 12042 KB.