### PR TITLE
php: remove unrelated code from SharedChannelClose test

### DIFF
--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -380,11 +380,6 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         // close channel1
         $this->channel1->close();
 
-        // channel2 is now in SHUTDOWN state
-        $state = $this->channel2->getConnectivityState();
-        $this->assertEquals(GRPC\CHANNEL_FATAL_FAILURE, $state);
-
-        // calling it again will result in an exception because the
         // channel is already closed
         $state = $this->channel2->getConnectivityState();
     }


### PR DESCRIPTION
When the first Channel calls close, the real channel is destroyed. Thus when the second channel uses it, it will throw runtime exception "Channel already closed".

If the behavior of tests is supposed to be right, then we should change the implementation of the Channel.