### PR TITLE
Shutdown timer manager first and then executor

### DIFF
--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -162,9 +162,9 @@ void grpc_shutdown(void) {
     {
       grpc_core::ExecCtx exec_ctx(0);
       {
-        grpc_executor_shutdown();
         grpc_timer_manager_set_threading(
             false);  // shutdown timer_manager thread
+        grpc_executor_shutdown();
         for (i = g_number_of_plugins; i >= 0; i--) {
           if (g_all_of_the_plugins[i].destroy != nullptr) {
             g_all_of_the_plugins[i].destroy();


### PR DESCRIPTION
Because timer can push callbacks to the executor, yet the executor has been shutdown.

I think this caused #14249.