### PR TITLE
Update ruby macos package build on 1.8.x to work with updated mac workers

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -113,7 +113,7 @@ task 'gem:native' do
   if RUBY_PLATFORM =~ /darwin/
     FileUtils.touch 'grpc_c.32.ruby'
     FileUtils.touch 'grpc_c.64.ruby'
-    system "rake cross native gem RUBY_CC_VERSION=2.4.0:2.3.0:2.2.2:2.1.5:2.0.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
+    system "rake cross native gem RUBY_CC_VERSION=2.4.0:2.3.0:2.2.2:2.1.6:2.0.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
   else
     Rake::Task['dlls'].execute
     docker_for_windows "gem update --system && bundle && rake cross native gem RUBY_CC_VERSION=2.4.0:2.3.0:2.2.2:2.1.5:2.0.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/14277

https://github.com/grpc/grpc/pull/13930/files#diff-52c976fc38ed2b4e3b1192f8a8e24cffL116 updated the ruby mac package build, and the mac workers themselves were also updated. However, the updates to the mac workers breaks the 2.1.x builds on all earlier branches.

My plan is to update all earlier branches so that they build on the new mac workers, rather than changing things around on master/1.9.x and the mac workers themselves. 
