### PR TITLE
Removing ctiller as owner of tools/run_tests/performance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 /cmake/** @jtattermusch @nicolasnoble @matt-kwong
 /src/core/ext/filters/client_channel/** @markdroth @dgquintas @a11r
 /tools/dockerfile/** @jtattermusch @matt-kwong @nicolasnoble
-/tools/run_tests/performance/** @ncteisen @matt-kwong @ctiller
+/tools/run_tests/performance/** @ncteisen @matt-kwong @jtattermusch

--- a/tools/run_tests/performance/OWNERS
+++ b/tools/run_tests/performance/OWNERS
@@ -6,4 +6,4 @@ set noparent
 
 @ncteisen
 @matt-kwong
-@ctiller
+@jtattermusch


### PR DESCRIPTION
Switched it to @jtattermusch since it's connected with testing

