### PR TITLE
Remove initial backoff override in ObjC

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -225,8 +225,6 @@ static GRPCConnectivityMonitor *connectivityMonitor = nil;
   if (_responseSizeLimitOverride) {
     args[@GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH] = _responseSizeLimitOverride;
   }
-  // Use 10000ms initial backoff time for correct behavior on bad/slow networks  
-  args[@GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS] = @10000;
 
   if (_compressAlgorithm != GRPC_COMPRESS_NONE) {
     args[@GRPC_COMPRESSION_CHANNEL_DEFAULT_ALGORITHM] =


### PR DESCRIPTION
The override was introduced in #8235 to resolve the problem of failing too soon. However, since our subchannel has parameter [MIN_CONNECT_TIMEOUT](https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md), I don't think this is needed anymore.