### PR TITLE
Always fill "empty" on return from gpr_mpscq_pop_and_check_end

### DIFF
--- a/src/core/lib/gpr/mpscq.cc
+++ b/src/core/lib/gpr/mpscq.cc
@@ -71,6 +71,7 @@ gpr_mpscq_node* gpr_mpscq_pop_and_check_end(gpr_mpscq* q, bool* empty) {
   gpr_mpscq_push(q, &q->stub);
   next = (gpr_mpscq_node*)gpr_atm_acq_load(&tail->next);
   if (next != nullptr) {
+    *empty = false;
     q->tail = next;
     return tail;
   }


### PR DESCRIPTION
gpr_mpscq_pop_and_check_end may leave "empty" flag uninitialized in certain exit scenarios. 

Luckily, this flag does not seem to be used anywhere except for
https://github.com/grpc/grpc/blob/f4a94b61266dc468af2de213ea50b997a39b7508/src/core/lib/surface/completion_queue.cc#L401
where it only affects performance counters.