### PR TITLE
Clang format and tidy shouldnt change file ownership when run locally.

### DIFF
--- a/templates/tools/dockerfile/grpc_clang_format/Dockerfile.template
+++ b/templates/tools/dockerfile/grpc_clang_format/Dockerfile.template
@@ -18,6 +18,11 @@
   
   <%include file="../clang5.include"/>
   ADD clang_format_all_the_things.sh /
+  
+  # When running locally, we'll be impersonating the current user, so we need
+  # to make the script runnable by everyone.
+  RUN chmod a+rx /clang_format_all_the_things.sh
+  
   CMD ["echo 'Run with tools/distrib/clang_format_code.sh'"]
   
   

--- a/templates/tools/dockerfile/grpc_clang_tidy/Dockerfile.template
+++ b/templates/tools/dockerfile/grpc_clang_tidy/Dockerfile.template
@@ -19,6 +19,11 @@
   <%include file="../clang5.include"/>
   <%include file="../python_deps.include"/>
   ADD clang_tidy_all_the_things.sh /
+  
+  # When running locally, we'll be impersonating the current user, so we need
+  # to make the script runnable by everyone.
+  RUN chmod a+rx /clang_tidy_all_the_things.sh
+  
   CMD ["echo 'Run with tools/distrib/clang_tidy_code.sh'"]
   
   

--- a/tools/distrib/clang_format_code.sh
+++ b/tools/distrib/clang_format_code.sh
@@ -25,7 +25,9 @@ then
   docker build -t grpc_clang_format tools/dockerfile/grpc_clang_format
 
   # run clang-format against the checked out codebase
-  docker run -e TEST=$TEST -e CHANGED_FILES="$CHANGED_FILES" -e CLANG_FORMAT_ROOT="/local-code" --rm=true -v "${REPO_ROOT}":/local-code -t grpc_clang_format /clang_format_all_the_things.sh
+  # when modifying the checked-out files, the current user will be impersonated
+  # so that the updated files don't end up being owned by "root".
+  docker run -e TEST=$TEST -e CHANGED_FILES="$CHANGED_FILES" -e CLANG_FORMAT_ROOT="/local-code" --rm=true -v "${REPO_ROOT}":/local-code --user "$(id -u):$(id -g)" -t grpc_clang_format /clang_format_all_the_things.sh
 else
   CLANG_FORMAT_ROOT="${REPO_ROOT}" tools/dockerfile/grpc_clang_format/clang_format_all_the_things.sh
 fi

--- a/tools/distrib/clang_format_code.sh
+++ b/tools/distrib/clang_format_code.sh
@@ -27,7 +27,7 @@ then
   # run clang-format against the checked out codebase
   # when modifying the checked-out files, the current user will be impersonated
   # so that the updated files don't end up being owned by "root".
-  docker run -e TEST=$TEST -e CHANGED_FILES="$CHANGED_FILES" -e CLANG_FORMAT_ROOT="/local-code" --rm=true -v "${REPO_ROOT}":/local-code --user "$(id -u):$(id -g)" -t grpc_clang_format /clang_format_all_the_things.sh
+  docker run -e TEST="$TEST" -e CHANGED_FILES="$CHANGED_FILES" -e CLANG_FORMAT_ROOT="/local-code" --rm=true -v "${REPO_ROOT}":/local-code --user "$(id -u):$(id -g)" -t grpc_clang_format /clang_format_all_the_things.sh
 else
   CLANG_FORMAT_ROOT="${REPO_ROOT}" tools/dockerfile/grpc_clang_format/clang_format_all_the_things.sh
 fi

--- a/tools/distrib/clang_tidy_code.sh
+++ b/tools/distrib/clang_tidy_code.sh
@@ -29,7 +29,7 @@ then
   # run clang-tidy against the checked out codebase
   # when modifying the checked-out files, the current user will be impersonated
   # so that the updated files don't end up being owned by "root".
-  docker run -e TEST=$TEST -e CHANGED_FILES="$CHANGED_FILES" -e CLANG_TIDY_ROOT="/local-code" --rm=true -v "${REPO_ROOT}":/local-code --user "$(id -u):$(id -g)" -t grpc_clang_tidy /clang_tidy_all_the_things.sh "$@"
+  docker run -e TEST="$TEST" -e CHANGED_FILES="$CHANGED_FILES" -e CLANG_TIDY_ROOT="/local-code" --rm=true -v "${REPO_ROOT}":/local-code --user "$(id -u):$(id -g)" -t grpc_clang_tidy /clang_tidy_all_the_things.sh "$@"
 else
   CLANG_TIDY_ROOT="${REPO_ROOT}" tools/dockerfile/grpc_clang_tidy/clang_tidy_all_the_things.sh "$@"
 fi

--- a/tools/distrib/clang_tidy_code.sh
+++ b/tools/distrib/clang_tidy_code.sh
@@ -27,7 +27,9 @@ then
   docker build -t grpc_clang_tidy tools/dockerfile/grpc_clang_tidy
 
   # run clang-tidy against the checked out codebase
-  docker run -e TEST=$TEST -e CHANGED_FILES="$CHANGED_FILES" -e CLANG_TIDY_ROOT="/local-code" --rm=true -v "${REPO_ROOT}":/local-code -t grpc_clang_tidy /clang_tidy_all_the_things.sh "$@"
+  # when modifying the checked-out files, the current user will be impersonated
+  # so that the updated files don't end up being owned by "root".
+  docker run -e TEST=$TEST -e CHANGED_FILES="$CHANGED_FILES" -e CLANG_TIDY_ROOT="/local-code" --rm=true -v "${REPO_ROOT}":/local-code --user "$(id -u):$(id -g)" -t grpc_clang_tidy /clang_tidy_all_the_things.sh "$@"
 else
   CLANG_TIDY_ROOT="${REPO_ROOT}" tools/dockerfile/grpc_clang_tidy/clang_tidy_all_the_things.sh "$@"
 fi

--- a/tools/dockerfile/grpc_clang_format/Dockerfile
+++ b/tools/dockerfile/grpc_clang_format/Dockerfile
@@ -23,4 +23,9 @@ RUN ln -s /clang+llvm-5.0.0-linux-x86_64-ubuntu14.04/bin/clang-tidy /usr/local/b
 ENV CLANG_TIDY=clang-tidy
 
 ADD clang_format_all_the_things.sh /
+
+# When running locally, we'll be impersonating the current user, so we need
+# to make the script runnable by everyone.
+RUN chmod a+rx /clang_format_all_the_things.sh
+
 CMD ["echo 'Run with tools/distrib/clang_format_code.sh'"]

--- a/tools/dockerfile/grpc_clang_tidy/Dockerfile
+++ b/tools/dockerfile/grpc_clang_tidy/Dockerfile
@@ -38,4 +38,9 @@ RUN pip install virtualenv
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.0.post1 six==1.10.0 twisted==17.5.0
 
 ADD clang_tidy_all_the_things.sh /
+
+# When running locally, we'll be impersonating the current user, so we need
+# to make the script runnable by everyone.
+RUN chmod a+rx /clang_tidy_all_the_things.sh
+
 CMD ["echo 'Run with tools/distrib/clang_tidy_code.sh'"]


### PR DESCRIPTION
Currently, the clang format and clang tidy scripts, when run locally on a checked-out copy of grpc, 
any updated files with be suddenly owned by root. This is because the docker container runs as root by default and it recreates the files being formatted - which makes them owned by root.
This can be mitigated by running docker as "current user" when invoking the local version of clang format script.

The changes shouldn't affect the clang-format in sanity suite.

@dgquintas, I assume folks on C-core have been seeing this problem too?