### PR TITLE
Fix reference of self in a block

### DIFF
--- a/src/objective-c/RxLibrary/GRXConcurrentWriteable.m
+++ b/src/objective-c/RxLibrary/GRXConcurrentWriteable.m
@@ -64,21 +64,25 @@
 }
 
 - (void)enqueueSuccessfulCompletion {
+  __weak typeof(self) weakSelf = self;
   dispatch_async(_writeableQueue, ^{
-    BOOL finished = NO;
-    @synchronized (self) {
-      if (!_alreadyFinished) {
-        _alreadyFinished = YES;
-      } else {
-        finished = YES;
+    typeof(self) strongSelf = self;
+    if (strongSelf) {
+      BOOL finished = NO;
+      @synchronized (self) {
+        if (!strongSelf->_alreadyFinished) {
+          strongSelf->_alreadyFinished = YES;
+        } else {
+          finished = YES;
+        }
       }
-    }
-    if (!finished) {
-      // Cancellation is now impossible. None of the other three blocks can run concurrently with
-      // this one.
-      [self.writeable writesFinishedWithError:nil];
-      // Skip any possible message to the wrapped writeable enqueued after this one.
-      self.writeable = nil;
+      if (!finished) {
+        // Cancellation is now impossible. None of the other three blocks can run concurrently with
+        // this one.
+        [self.writeable writesFinishedWithError:nil];
+        // Skip any possible message to the wrapped writeable enqueued after this one.
+        self.writeable = nil;
+      }
     }
   });
 }


### PR DESCRIPTION
Retain weak self when dispatching block in `enqueueSuccessfulCompletion`.