### PR TITLE
Revert "Define the tests as grpc_cc_test to automatically test against all po…"

### DIFF
--- a/test/core/bad_client/generate_tests.bzl
+++ b/test/core/bad_client/generate_tests.bzl
@@ -16,7 +16,6 @@
 
 """Generates the appropriate build.json data for all the bad_client tests."""
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_cc_library")
 
 def test_options():
   return struct()
@@ -37,14 +36,14 @@ BAD_CLIENT_TESTS = {
 }
 
 def grpc_bad_client_tests():
-  grpc_cc_library(
+  native.cc_library(
       name = 'bad_client_test',
       srcs = ['bad_client.cc'],
       hdrs = ['bad_client.h'],
       deps = ['//test/core/util:grpc_test_util', '//:grpc', '//:gpr', '//test/core/end2end:cq_verifier']
   )
   for t, topt in BAD_CLIENT_TESTS.items():
-    grpc_cc_test(
+    native.cc_test(
         name = '%s_bad_client_test' % t,
         srcs = ['tests/%s.cc' % t],
         deps = [':bad_client_test'],


### PR DESCRIPTION
Reverts grpc/grpc#14326 because it breaks import.