### PR TITLE
Sleep a second to deflake ReconnectTest

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_reconnect_test.py
+++ b/src/python/grpcio_tests/tests/unit/_reconnect_test.py
@@ -14,6 +14,7 @@
 """Tests that a channel will reconnect if a connection is dropped"""
 
 import socket
+import time
 import unittest
 
 import grpc
@@ -88,6 +89,7 @@ class ReconnectTest(unittest.TestCase):
         multi_callable = channel.unary_unary(_UNARY_UNARY)
         self.assertEqual(_RESPONSE, multi_callable(_REQUEST))
         server.stop(None)
+        time.sleep(1)
         server = grpc.server(server_pool, (handler,))
         server.add_insecure_port('[::]:{}'.format(port))
         server.start()


### PR DESCRIPTION
The thread that watches connectivity on the channel might not
pick up that the server has gone away before the request is
dispatched, and return UNAVAILABLE instead of reconnecting
prior to sending the request.  The fundamental solution would
basically be enabling retries in C-core.  For now, we opt to
sleep a second to deflake this particular test case.

Fixes #11676