### PR TITLE
Ignore zlib submodule if its dirty (due to CMake)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,10 @@
 [submodule "third_party/zlib"]
 	path = third_party/zlib
 	url = https://github.com/madler/zlib
+	# When using CMake to build, the zlib submodule ends up with a
+	# generated file that makes Git consider the submodule dirty. This
+	# state can be ignored for day-to-day development on gRPC.
+	ignore = dirty
 [submodule "third_party/protobuf"]
 	path = third_party/protobuf
 	url = https://github.com/google/protobuf.git


### PR DESCRIPTION
When using CMake to build, the zlib submodule ends up with a generated
file that makes Git consider the submodule dirty. This state can be
ignored for day-to-day development on gRPC.

We cannot use the weaker "ignore = untracked" as the build process
deletes a tracked file as well as generating a new file.