### PR TITLE
Enforce CRTP: weaken reinterpret_cast to static_cast

### DIFF
--- a/src/core/lib/gprpp/orphanable.h
+++ b/src/core/lib/gprpp/orphanable.h
@@ -92,7 +92,7 @@ class InternallyRefCounted : public Orphanable {
 
   RefCountedPtr<Child> Ref() GRPC_MUST_USE_RESULT {
     IncrementRefCount();
-    return RefCountedPtr<Child>(reinterpret_cast<Child*>(this));
+    return RefCountedPtr<Child>(static_cast<Child*>(this));
   }
 
   void Unref() {
@@ -149,7 +149,7 @@ class InternallyRefCountedWithTracing : public Orphanable {
 
   RefCountedPtr<Child> Ref() GRPC_MUST_USE_RESULT {
     IncrementRefCount();
-    return RefCountedPtr<Child>(reinterpret_cast<Child*>(this));
+    return RefCountedPtr<Child>(static_cast<Child*>(this));
   }
 
   RefCountedPtr<Child> Ref(const DebugLocation& location,

--- a/src/core/lib/gprpp/ref_counted.h
+++ b/src/core/lib/gprpp/ref_counted.h
@@ -41,7 +41,7 @@ class RefCounted {
  public:
   RefCountedPtr<Child> Ref() GRPC_MUST_USE_RESULT {
     IncrementRefCount();
-    return RefCountedPtr<Child>(reinterpret_cast<Child*>(this));
+    return RefCountedPtr<Child>(static_cast<Child*>(this));
   }
 
   // TODO(roth): Once all of our code is converted to C++ and can use
@@ -89,7 +89,7 @@ class RefCountedWithTracing {
  public:
   RefCountedPtr<Child> Ref() GRPC_MUST_USE_RESULT {
     IncrementRefCount();
-    return RefCountedPtr<Child>(reinterpret_cast<Child*>(this));
+    return RefCountedPtr<Child>(static_cast<Child*>(this));
   }
 
   RefCountedPtr<Child> Ref(const DebugLocation& location,


### PR DESCRIPTION
Since RefCounted is designed for use with CRTP, let these casts be static_cast (which can only do void, up, down, and nullptr casts) rather than reinterpret_cast (which can do anything). This helps to make sure that an appropriate CRTP parameter is used (the static_casts will break if misdeclared).
