### PR TITLE
Add owners to C++ end2end tests to reduce chance of accidental API breakage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,6 @@
 /bazel/** @nicolasnoble @dgquintas @a11r @vjpai
 /cmake/** @jtattermusch @nicolasnoble @matt-kwong
 /src/core/ext/filters/client_channel/** @markdroth @dgquintas @a11r
+/test/cpp/end2end/** @vjpai @yang-g @y-zeng
 /tools/dockerfile/** @jtattermusch @matt-kwong @nicolasnoble
 /tools/run_tests/performance/** @ncteisen @matt-kwong @jtattermusch

--- a/test/cpp/end2end/OWNERS
+++ b/test/cpp/end2end/OWNERS
@@ -1,0 +1,5 @@
+set noparent
+@vjpai
+@yang-g
+@y-zeng
+


### PR DESCRIPTION
Most API breakages or API extensions will end up requiring some change to an existing C++ end2end test (or a new test). Putting owners on this directory will help to make sure that tests are not being changed to resolve API breakages or to test new API that hasn't been gRFCed.
