### PR TITLE
Add owners file for tools/run_tests/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,6 @@
 /cmake/** @jtattermusch @nicolasnoble @matt-kwong
 /src/core/ext/filters/client_channel/** @markdroth @dgquintas @a11r
 /tools/dockerfile/** @jtattermusch @matt-kwong @nicolasnoble
+/tools/run_tests/** @jtattermusch @matt-kwong @dgquintas
+/tools/run_tests/generated/** @grpc/grpc-team
 /tools/run_tests/performance/** @ncteisen @matt-kwong @jtattermusch

--- a/tools/run_tests/OWNERS
+++ b/tools/run_tests/OWNERS
@@ -1,0 +1,8 @@
+set noparent
+
+# These owners are in place to because our test runners are non-trivial
+# and bad changes can cause lot of stuff fail silently.
+
+@jtattermusch
+@matt-kwong
+@dgquintas

--- a/tools/run_tests/generated/OWNERS
+++ b/tools/run_tests/generated/OWNERS
@@ -1,0 +1,4 @@
+set noparent
+
+# Files in this directory are generated. Anyone from grpc-team can approve.
+@grpc/grpc-team


### PR DESCRIPTION
The run_tests scripts are fragile, so it makes to require owners approval.