### PR TITLE
Add hooks so that code generator can inject headers to grpc.pb.h file

### DIFF
--- a/src/compiler/cpp_generator.h
+++ b/src/compiler/cpp_generator.h
@@ -54,6 +54,8 @@ struct Parameters {
   bool generate_mock_code;
   // Google Mock search path, when non-empty, local includes will be used.
   grpc::string gmock_search_path;
+  // *EXPERIMENTAL* Additional include files in grpc.pb.h
+  std::vector<grpc::string> additional_header_includes;
 };
 
 // Return the prologue of the generated header file.

--- a/src/compiler/cpp_plugin.cc
+++ b/src/compiler/cpp_plugin.cc
@@ -80,6 +80,9 @@ class CppGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
           }
         } else if (param[0] == "gmock_search_path") {
           generator_parameters.gmock_search_path = param[1];
+        } else if (param[0] == "additional_header_includes") {
+          generator_parameters.additional_header_includes =
+              grpc_generator::tokenize(param[1], ":");
         } else {
           *error = grpc::string("Unknown parameter: ") + *parameter_string;
           return false;


### PR DESCRIPTION
This is experimental and the cc_grpc_library is *not* supporting it.