### PR TITLE
Add grpc_posix bindings.

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -1222,6 +1222,17 @@ class Server(six.with_metaclass(abc.ABCMeta)):
         raise NotImplementedError()
 
     @abc.abstractmethod
+    def add_fd(self, fd):
+        """Opens an insecure channel for accepting RPCs over a file descriptor.
+
+        This method may only be called before starting the server.
+
+        Args:
+          fd: The socket file descriptor to use to talk to clients.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def start(self):
         """Starts this Server.
 
@@ -1582,6 +1593,22 @@ def secure_channel(target, credentials, options=None):
     from grpc import _channel  # pylint: disable=cyclic-import
     return _channel.Channel(target, () if options is None else options,
                             credentials._credentials)
+
+
+def insecure_fd_channel(target, fd, options=None):
+    """Creates an insecure Channel over a file descriptor.
+
+    Args:
+      target: The server address
+      fd: The socket file descriptor to use to talk to the server.
+      options: An optional list of key-value pairs (channel args
+        in gRPC Core runtime) to configure the channel.
+
+    Returns:
+      An FDChannel object.
+    """
+    from grpc import _channel  # pylint: disable=cyclic-import
+    return _channel.FDChannel(target, fd, () if options is None else options)
 
 
 def intercept_channel(channel, *interceptors):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/channel.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channel.pxd.pxi
@@ -13,9 +13,17 @@
 # limitations under the License.
 
 
-cdef class Channel:
+cdef class ChannelBase:
 
   cdef grpc_arg_pointer_vtable _vtable
   cdef grpc_channel *c_channel
   cdef list references
   cdef readonly _ArgumentsProcessor _arguments_processor
+
+
+cdef class Channel(ChannelBase):
+  pass
+
+
+cdef class FDChannel(ChannelBase):
+  pass

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -588,3 +588,10 @@ cdef extern from "grpc/compression.h":
   int grpc_compression_options_is_algorithm_enabled(
       const grpc_compression_options *opts,
       grpc_compression_algorithm algorithm) nogil
+
+cdef extern from "grpc/grpc_posix.h":
+
+  grpc_channel *grpc_insecure_channel_create_from_fd(
+      const char *target, int fd, const grpc_channel_args *args) nogil
+  void grpc_server_add_insecure_channel_from_fd(
+      grpc_server *server, void *reserved, int fd) nogil

--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
@@ -128,6 +128,10 @@ cdef class Server:
                                                      address_c_string)
     return result
 
+  def add_fd(self, int fd):
+    with nogil:
+      grpc_server_add_insecure_channel_from_fd(self.c_server, NULL, fd)
+
   cdef _c_shutdown(self, CompletionQueue queue, tag):
     self.is_shutting_down = True
     cdef _ServerShutdownTag server_shutdown_tag = _ServerShutdownTag(tag, self)

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -677,6 +677,11 @@ def _add_secure_port(state, address, server_credentials):
                                            server_credentials._credentials)
 
 
+def _add_fd(state, fd):
+    with state.lock:
+        state.server.add_fd(fd)
+
+
 def _request_call(state):
     state.server.request_call(state.completion_queue, state.completion_queue,
                               _REQUEST_CALL_TAG)
@@ -812,6 +817,9 @@ class Server(grpc.Server):
     def add_secure_port(self, address, server_credentials):
         return _add_secure_port(self._state, _common.encode(address),
                                 server_credentials)
+
+    def add_fd(self, fd):
+        _add_fd(self._state, fd)
 
     def start(self):
         _start(self._state)

--- a/src/python/grpcio_tests/tests/tests.json
+++ b/src/python/grpcio_tests/tests/tests.json
@@ -26,6 +26,7 @@
   "unit._auth_test.GoogleCallCredentialsTest",
   "unit._channel_args_test.ChannelArgsTest",
   "unit._channel_connectivity_test.ChannelConnectivityTest",
+  "unit._channel_fd_test.ChannelFDTest",
   "unit._channel_ready_future_test.ChannelReadyFutureTest",
   "unit._compression_test.CompressionTest",
   "unit._credentials_test.CredentialsTest",

--- a/src/python/grpcio_tests/tests/unit/_channel_fd_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_fd_test.py
@@ -1,0 +1,129 @@
+# Copyright 2016 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import socket
+import unittest
+
+import grpc
+
+from tests.unit import test_common
+from tests.unit.framework.common import test_constants
+
+_REQUEST = b''
+_RESPONSE = b''
+
+_UNARY_UNARY = '/test/UnaryUnary'
+_UNARY_STREAM = '/test/UnaryStream'
+_STREAM_UNARY = '/test/StreamUnary'
+_STREAM_STREAM = '/test/StreamStream'
+
+
+def handle_unary_unary(request, servicer_context):
+    return _RESPONSE
+
+
+def handle_unary_stream(request, servicer_context):
+    for _ in range(test_constants.STREAM_LENGTH):
+        yield _RESPONSE
+
+
+def handle_stream_unary(request_iterator, servicer_context):
+    for request in request_iterator:
+        pass
+    return _RESPONSE
+
+
+def handle_stream_stream(request_iterator, servicer_context):
+    for request in request_iterator:
+        yield _RESPONSE
+
+
+class _MethodHandler(grpc.RpcMethodHandler):
+
+    def __init__(self, request_streaming, response_streaming):
+        self.request_streaming = request_streaming
+        self.response_streaming = response_streaming
+        self.request_deserializer = None
+        self.response_serializer = None
+        self.unary_unary = None
+        self.unary_stream = None
+        self.stream_unary = None
+        self.stream_stream = None
+        if self.request_streaming and self.response_streaming:
+            self.stream_stream = handle_stream_stream
+        elif self.request_streaming:
+            self.stream_unary = handle_stream_unary
+        elif self.response_streaming:
+            self.unary_stream = handle_unary_stream
+        else:
+            self.unary_unary = handle_unary_unary
+
+
+class _GenericHandler(grpc.GenericRpcHandler):
+
+    def service(self, handler_call_details):
+        if handler_call_details.method == _UNARY_UNARY:
+            return _MethodHandler(False, False)
+        elif handler_call_details.method == _UNARY_STREAM:
+            return _MethodHandler(False, True)
+        elif handler_call_details.method == _STREAM_UNARY:
+            return _MethodHandler(True, False)
+        elif handler_call_details.method == _STREAM_STREAM:
+            return _MethodHandler(True, True)
+        else:
+            return None
+
+
+class ChannelFDTest(unittest.TestCase):
+
+    def setUp(self):
+        self._socks = socket.socketpair()
+        self._socks[0].setblocking(False)
+        self._socks[1].setblocking(False)
+        self._channel = grpc.insecure_fd_channel(
+            'channel_fd_test', self._socks[0].fileno())
+        self._server = test_common.test_server()
+        self._server.add_generic_rpc_handlers((_GenericHandler(),))
+        self._server.start()
+        self._server.add_fd(self._socks[1].fileno())
+
+    def tearDown(self):
+        self._server.stop(0)
+        self._socks[1].close()
+        self._socks[0].close()
+
+    def testUnaryUnary(self):
+        response = self._channel.unary_unary(_UNARY_UNARY)(_REQUEST)
+        self.assertEqual(_RESPONSE, response)
+
+    def testUnaryStream(self):
+        response_iterator = self._channel.unary_stream(_UNARY_STREAM)(_REQUEST)
+        self.assertSequenceEqual([_RESPONSE] * test_constants.STREAM_LENGTH,
+                                 list(response_iterator))
+
+    def testStreamUnary(self):
+        response = self._channel.stream_unary(_STREAM_UNARY)(iter(
+            [_REQUEST] * test_constants.STREAM_LENGTH))
+        self.assertEqual(_RESPONSE, response)
+
+    def testStreamStream(self):
+        response_iterator = self._channel.stream_stream(_STREAM_STREAM)(iter(
+            [_REQUEST] * test_constants.STREAM_LENGTH))
+        self.assertSequenceEqual([_RESPONSE] * test_constants.STREAM_LENGTH,
+                                 list(response_iterator))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_channel_fd_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_fd_test.py
@@ -1,4 +1,4 @@
-# Copyright 2016 gRPC authors.
+# Copyright 2018 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This will allow Python users to use POSIX file descriptors to create
gRPC channels. Both client and server bindings are included.

The test, unfortunately, hangs. I haven't yet figured out why.

I'm also concerned about platforms where the `grpc_posix` bindings
aren't available (*cough*Windows*cough*). The test shouldn't run
there.