### PR TITLE
gRPC core: strip zone-id from IPv6 hosts before TLS verification

### DIFF
--- a/src/core/lib/security/security_connector/security_connector.h
+++ b/src/core/lib/security/security_connector/security_connector.h
@@ -243,6 +243,7 @@ grpc_auth_context* tsi_ssl_peer_to_auth_context(const tsi_peer* peer);
 tsi_peer tsi_shallow_peer_from_ssl_auth_context(
     const grpc_auth_context* auth_context);
 void tsi_shallow_peer_destruct(tsi_peer* peer);
+int grpc_ssl_host_matches_name(const tsi_peer* peer, const char* peer_name);
 
 /* --- Default SSL Root Store. --- */
 namespace grpc_core {


### PR DESCRIPTION
When initiating a connection to an IPv6 peer using an address that is
not globally scoped, there may be ambiguity regarding which zone the
destination address applies to when multiple links of the same scope
are present. The scoped address architecture and zone-id syntax are
described in rfc4007 and rfc 6874, respectively:

  * https://tools.ietf.org/html/rfc4007#section-6
  * https://tools.ietf.org/html/rfc6874

This patch allows host name verification performed during TLS session
establishment, and on a per-call basis, to work correctly when the peer
presents a certificate with a non-global IPv6 address listed as one of
its alternate names. Whether arbitrary certificate authorities choose
issue certificates of this nature, or not, is outside the scope of gRPC.

The zone-id is separated from the address using a percent (%) character.
It is considered a system implementation detail and guidance suggests it
be stripped from any paths or addresses egressing the host because it is
irrelevant and meaningless otherwise. Thus, it would not make sense for
a server to present a certificate containing non-global IPv6 addresses
with zone-ids present.

Resolves #14371

---

NOTE: I expect this will require a little cleanup and restructuring/testing
but I want to put it up to get discussion started. If needed, we could also
address #14369 at the same time.