### PR TITLE
Add grpc-java 1.9.1 to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -139,7 +139,7 @@ LANG_RELEASE_MATRIX = {
             'v1.8.0': None
         },
         {
-            'v1.9.0': None
+            'v1.9.1': None
         },
     ],
     'python': [


### PR DESCRIPTION
```
$ gcloud beta container images list-tags gcr.io/grpc-testing/grpc_interop_java_oracle8
DIGEST        TAGS    TIMESTAMP
dff161e22023  v1.9.1  2018-02-09T16:24:35
363aa9376e98  v1.9.0  2018-01-11T12:08:36
e10b79b1cb85  v1.8.0  2017-11-21T09:55:59
ab391fa5671d  v1.7.0  2017-10-18T21:59:02
272f6f251aba  v1.6.1  2017-10-18T21:54:14
e7a6b5e2ddac  v1.5.0  2017-07-18T17:57:30
f04cb0c66d4e  v1.4.0  2017-07-18T17:56:46
d8d3948bd15f  v1.3.1  2017-07-18T17:56:01
99546a622b0b  v1.2.0  2017-07-18T17:55:11
0684c6378210  v1.1.2  2017-07-18T17:54:26
```