### PR TITLE
Add 3rd-party bazel dependencies needed to run resolver tests in bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,5 @@
 workspace(name = "com_github_grpc_grpc")
 
-load("//bazel:grpc_deps.bzl", "grpc_deps")
+load("//bazel:grpc_deps.bzl", "grpc_deps", "grpc_test_only_deps")
 grpc_deps()
+grpc_test_only_deps()

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -165,8 +165,10 @@ def grpc_sh_binary(name, srcs, data = []):
 
 def grpc_py_binary(name, srcs, data = [], deps = []):
   if name == "test_dns_server":
-    # TODO: allow running test_dns_server in oss bazel test suite
-    deps = []
+    deps = _get_external_deps([
+      "twisted",
+      "yaml",
+    ])
   native.py_binary(
     name = name,
     srcs = srcs,

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -127,3 +127,57 @@ def grpc_deps():
             ],
             sha256 = "ed829b5eea8af1f405f4cc3d6ecfc3b1365bb7843171036030a31b5127002311",
         )
+
+# TODO: move some dependencies from "grpc_deps" here?
+def grpc_test_only_deps():
+    """Internal, not intended for use by packages that are consuming grpc.
+       Loads dependencies that are only needed to run grpc library's tests."""
+    native.bind(
+        name = "twisted",
+        actual = "@com_github_twisted_twisted//:twisted",
+    )
+
+    native.bind(
+        name = "yaml",
+        actual = "@com_github_yaml_pyyaml//:yaml",
+    )
+
+    if "com_github_twisted_twisted" not in native.existing_rules():
+        native.new_http_archive(
+            name = "com_github_twisted_twisted",
+            strip_prefix = "twisted-twisted-17.5.0",
+            url = "https://github.com/twisted/twisted/archive/twisted-17.5.0.zip",
+            build_file = "@com_github_grpc_grpc//third_party:twisted.BUILD",
+        )
+
+    if "com_github_yaml_pyyaml" not in native.existing_rules():
+        native.new_http_archive(
+            name = "com_github_yaml_pyyaml",
+            strip_prefix = "pyyaml-3.12",
+            url = "https://github.com/yaml/pyyaml/archive/3.12.zip",
+            build_file = "@com_github_grpc_grpc//third_party:yaml.BUILD",
+        )
+
+    if "com_github_twisted_incremental" not in native.existing_rules():
+        native.new_http_archive(
+            name = "com_github_twisted_incremental",
+            strip_prefix = "incremental-incremental-17.5.0",
+            url = "https://github.com/twisted/incremental/archive/incremental-17.5.0.zip",
+            build_file = "@com_github_grpc_grpc//third_party:incremental.BUILD",
+        )
+
+    if "com_github_zopefoundation_zope_interface" not in native.existing_rules():
+        native.new_http_archive(
+            name = "com_github_zopefoundation_zope_interface",
+            strip_prefix = "zope.interface-4.4.3",
+            url = "https://github.com/zopefoundation/zope.interface/archive/4.4.3.zip",
+            build_file = "@com_github_grpc_grpc//third_party:zope_interface.BUILD",
+        )
+
+    if "com_github_twisted_constantly" not in native.existing_rules():
+        native.new_http_archive(
+            name = "com_github_twisted_constantly",
+            strip_prefix = "constantly-15.1.0",
+            url = "https://github.com/twisted/constantly/archive/15.1.0.zip",
+            build_file = "@com_github_grpc_grpc//third_party:constantly.BUILD",
+        )

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -3,4 +3,9 @@ exports_files([
     "gtest.BUILD",
     "objective_c/Cronet/bidirectional_stream_c.h",
     "zlib.BUILD",
+    "twisted.BUILD",
+    "yaml.BUILD",
+    "incremental.BUILD",
+    "zope_interface.BUILD",
+    "constantly.BUILD",
 ])

--- a/third_party/constantly.BUILD
+++ b/third_party/constantly.BUILD
@@ -1,0 +1,7 @@
+py_library(
+    name = "constantly",
+    srcs = glob(["constantly/*.py"]),
+    visibility = [
+        "//visibility:public",
+    ],
+)

--- a/third_party/incremental.BUILD
+++ b/third_party/incremental.BUILD
@@ -1,0 +1,10 @@
+py_library(
+    name = "incremental",
+    srcs = glob(["src/incremental/*.py"]),
+    imports = [
+        "src",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+)

--- a/third_party/twisted.BUILD
+++ b/third_party/twisted.BUILD
@@ -1,0 +1,15 @@
+py_library(
+    name = "twisted",
+    srcs = glob(["src/twisted/**/*.py"]),
+    imports = [
+        "src",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "@com_github_twisted_incremental//:incremental",
+        "@com_github_twisted_constantly//:constantly",
+        "@com_github_zopefoundation_zope_interface//:zope_interface",
+    ],
+)

--- a/third_party/yaml.BUILD
+++ b/third_party/yaml.BUILD
@@ -1,0 +1,10 @@
+py_library(
+    name = "yaml",
+    srcs = glob(["lib/yaml/*.py"]),
+    imports = [
+        "lib",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+)

--- a/third_party/zope_interface.BUILD
+++ b/third_party/zope_interface.BUILD
@@ -1,0 +1,13 @@
+py_library(
+    name = "zope_interface",
+    srcs = glob([
+        "src/zope/interface/*.py",
+        "src/zope/interface/common/*.py",
+    ]),
+    imports = [
+        "src",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+)


### PR DESCRIPTION
To fix https://github.com/grpc/grpc/issues/13621

<s>WIP because we still need to make the `dig` command available to the `resolver_component_tests`.
One option for doing so might be to create a `cc_binary` bazel rule for it, if possible. Another option might be to request that `dig` command come pre-installed on all docker files and machines that bazel foundry tests run on.</s>

------

Separate PR: https://github.com/grpc/grpc/pull/14426 to make the `dig` command available through the environment.