### PR TITLE
Make python_wrapper.sh a copy instead of a symlink.

### DIFF
--- a/test/core/http/python_wrapper.sh
+++ b/test/core/http/python_wrapper.sh
@@ -1,1 +1,32 @@
-../../../tools/distrib/python_wrapper.sh
+#!/bin/sh
+
+# Copyright 2016 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+for p in python2.7 python2.6 python2 python not_found ; do 
+
+  python=$(which $p || echo not_found)
+
+  if [ -x "$python" ] ; then
+    break
+  fi
+
+done
+
+if [ -x "$python" ] ; then
+  exec "$python" "$@"
+else
+  echo "No acceptable version of python found on the system"
+  exit 1
+fi


### PR DESCRIPTION
Fixes Bazel error when a WORKSPACE imports
https://github.com/grpc/grpc/archive/master.zip:

"Zip entries cannot refer to files outside of their directory:
master.zip has a symlink to ../../../tools/distrib/python_wrapper.sh"