### PR TITLE
Enforce shellcheck on tools/gce directory

### DIFF
--- a/tools/gce/create_interop_worker.sh
+++ b/tools/gce/create_interop_worker.sh
@@ -20,14 +20,14 @@
 
 set -ex
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 CLOUD_PROJECT=grpc-testing
 ZONE=us-east1-a  # canary gateway is reachable from this zone
 
 INSTANCE_NAME="${1:-grpc-canary-interop2}"
 
-gcloud compute instances create $INSTANCE_NAME \
+gcloud compute instances create "$INSTANCE_NAME" \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
     --machine-type n1-standard-16 \
@@ -42,9 +42,9 @@ sleep 60
 gcloud compute copy-files \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
-    jenkins_master.pub linux_worker_init.sh ${INSTANCE_NAME}:~
+    jenkins_master.pub linux_worker_init.sh "${INSTANCE_NAME}":~
 
 gcloud compute ssh \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
-    $INSTANCE_NAME --command "./linux_worker_init.sh"
+    "$INSTANCE_NAME" --command "./linux_worker_init.sh"

--- a/tools/gce/create_linux_kokoro_performance_worker.sh
+++ b/tools/gce/create_linux_kokoro_performance_worker.sh
@@ -17,7 +17,7 @@
 
 set -ex
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 CLOUD_PROJECT=grpc-testing
 ZONE=us-central1-b  # this zone allows 32core machines
@@ -25,7 +25,7 @@ ZONE=us-central1-b  # this zone allows 32core machines
 INSTANCE_NAME="${1:-grpc-kokoro-performance-server1}"
 MACHINE_TYPE=n1-standard-32
 
-gcloud compute instances create $INSTANCE_NAME \
+gcloud compute instances create "$INSTANCE_NAME" \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
     --machine-type $MACHINE_TYPE \
@@ -41,9 +41,9 @@ sleep 60
 gcloud compute copy-files \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
-    kokoro_performance.pub linux_kokoro_performance_worker_init.sh kbuilder@${INSTANCE_NAME}:~
+    kokoro_performance.pub linux_kokoro_performance_worker_init.sh "kbuilder@${INSTANCE_NAME}":~
 
 gcloud compute ssh \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
-    kbuilder@${INSTANCE_NAME} --command "./linux_kokoro_performance_worker_init.sh"
+    "kbuilder@${INSTANCE_NAME}" --command "./linux_kokoro_performance_worker_init.sh"

--- a/tools/gce/create_linux_performance_worker.sh
+++ b/tools/gce/create_linux_performance_worker.sh
@@ -21,7 +21,7 @@
 
 set -ex
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 CLOUD_PROJECT=grpc-testing
 ZONE=us-central1-b  # this zone allows 32core machines
@@ -29,7 +29,7 @@ ZONE=us-central1-b  # this zone allows 32core machines
 INSTANCE_NAME="${1:-grpc-performance-server1}"
 MACHINE_TYPE=n1-standard-32
 
-gcloud compute instances create $INSTANCE_NAME \
+gcloud compute instances create "$INSTANCE_NAME" \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
     --machine-type $MACHINE_TYPE \
@@ -45,9 +45,9 @@ sleep 60
 gcloud compute copy-files \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
-    jenkins_master.pub linux_performance_worker_init.sh jenkins@${INSTANCE_NAME}:~
+    jenkins_master.pub linux_performance_worker_init.sh "jenkins@${INSTANCE_NAME}":~
 
 gcloud compute ssh \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
-    jenkins@${INSTANCE_NAME} --command "./linux_performance_worker_init.sh"
+    "jenkins@${INSTANCE_NAME}" --command "./linux_performance_worker_init.sh"

--- a/tools/gce/create_linux_worker.sh
+++ b/tools/gce/create_linux_worker.sh
@@ -17,14 +17,14 @@
 
 set -ex
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 CLOUD_PROJECT=grpc-testing
 ZONE=us-central1-a
 
 INSTANCE_NAME="${1:-grpc-jenkins-worker1}"
 
-gcloud compute instances create $INSTANCE_NAME \
+gcloud compute instances create "$INSTANCE_NAME" \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
     --machine-type n1-standard-16 \
@@ -40,9 +40,9 @@ sleep 60
 gcloud compute copy-files \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
-    jenkins_master.pub linux_worker_init.sh ${INSTANCE_NAME}:~
+    jenkins_master.pub linux_worker_init.sh "${INSTANCE_NAME}":~
 
 gcloud compute ssh \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
-    $INSTANCE_NAME --command "./linux_worker_init.sh"
+    "$INSTANCE_NAME" --command "./linux_worker_init.sh"

--- a/tools/gce/create_windows_debug_worker.sh
+++ b/tools/gce/create_windows_debug_worker.sh
@@ -19,7 +19,7 @@
 
 set -ex
 
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 CLOUD_PROJECT=grpc-testing
 ZONE=us-central1-b
@@ -34,7 +34,7 @@ fi
 MACHINE_TYPE=n1-standard-8
 TMP_DISK_NAME="$INSTANCE_NAME-temp-disk"
 
-gcloud compute disks create $TMP_DISK_NAME \
+gcloud compute disks create "$TMP_DISK_NAME" \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
     --image-project google.com:kokoro \
@@ -44,13 +44,13 @@ gcloud compute disks create $TMP_DISK_NAME \
 echo 'Created scratch disk, waiting for it to become available.'
 sleep 15
 
-gcloud compute instances create $INSTANCE_NAME \
+gcloud compute instances create "$INSTANCE_NAME" \
     --project="$CLOUD_PROJECT" \
     --zone "$ZONE" \
-    --machine-type $MACHINE_TYPE \
+    --machine-type "$MACHINE_TYPE" \
     --image-project google.com:kokoro \
     --image kokoro-win7build-v9-prod-debug \
     --boot-disk-size 500 \
     --boot-disk-type pd-ssd \
     --tags=allow-ssh \
-    --disk auto-delete=yes,boot=no,name=$TMP_DISK_NAME
+    --disk "auto-delete=yes,boot=no,name=$TMP_DISK_NAME"

--- a/tools/gce/linux_kokoro_performance_worker_init.sh
+++ b/tools/gce/linux_kokoro_performance_worker_init.sh
@@ -81,10 +81,11 @@ sudo pip install virtualenv
 # is not available on Ubuntu 16.10, so install from source
 curl -O https://www.python.org/ftp/python/3.4.6/Python-3.4.6.tgz
 tar xzvf Python-3.4.6.tgz
-cd Python-3.4.6
+(
+cd Python-3.4.6 || exit
 ./configure --enable-shared --prefix=/usr/local LDFLAGS="-Wl,--rpath=/usr/local/lib"
 sudo make altinstall
-cd ..
+)
 rm Python-3.4.6.tgz
 
 curl -O https://bootstrap.pypa.io/get-pip.py
@@ -95,6 +96,8 @@ sudo pip install google-api-python-client
 # Node dependencies (nvm has to be installed under user kbuilder)
 touch .profile
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.25.4/install.sh | bash
+# silence shellcheck as it cannot follow the following `source` path statically:
+# shellcheck disable=SC1090
 source ~/.nvm/nvm.sh
 nvm install 0.12 && npm config set cache /tmp/npm-cache
 nvm install 4 && npm config set cache /tmp/npm-cache
@@ -130,6 +133,8 @@ sudo apt-get update && sudo apt-get install -y libicu55
 # Ruby dependencies
 gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 curl -sSL https://get.rvm.io | bash -s stable --ruby
+# silence shellcheck as it cannot follow the following `source` path statically:
+# shellcheck disable=SC1090
 source ~/.rvm/scripts/rvm
 
 git clone https://github.com/rbenv/rbenv.git ~/.rbenv
@@ -168,7 +173,7 @@ sudo ln -s /usr/local/go/bin/go /usr/bin/go
 rm go$GO_VERSION.$OS-$ARCH.tar.gz
 
 # Install perf, to profile benchmarks. (need to get the right linux-tools-<> for kernel version)
-sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-`uname -r`
+sudo apt-get install -y linux-tools-common linux-tools-generic "linux-tools-$(uname -r)"
 # see http://unix.stackexchange.com/questions/14227/do-i-need-root-admin-permissions-to-run-userspace-perf-tool-perf-events-ar
 echo 0 | sudo tee /proc/sys/kernel/perf_event_paranoid
 # see http://stackoverflow.com/questions/21284906/perf-couldnt-record-kernel-reference-relocation-symbol
@@ -186,7 +191,9 @@ git clone -v https://github.com/brendangregg/FlameGraph ~/FlameGraph
 sudo apt-get install -y python-scipy python-numpy
 
 # Add pubkey of Kokoro driver VM to allow SSH
-cat kokoro_performance.pub | sudo tee --append ~kbuilder/.ssh/authorized_keys
+# silence false-positive shellcheck warning ("< redirect does not affect sudo")
+# shellcheck disable=SC2024
+sudo tee --append ~kbuilder/.ssh/authorized_keys < kokoro_performance.pub
 
 # Restart for VM to pick up kernel update
 echo 'Successfully initialized the linux worker, going for reboot in 10 seconds'

--- a/tools/gce/linux_performance_worker_init.sh
+++ b/tools/gce/linux_performance_worker_init.sh
@@ -81,10 +81,11 @@ sudo pip install virtualenv
 # is not available on Ubuntu 16.10, so install from source
 curl -O https://www.python.org/ftp/python/3.4.6/Python-3.4.6.tgz
 tar xzvf Python-3.4.6.tgz
-cd Python-3.4.6
+(
+cd Python-3.4.6 || exit
 ./configure --enable-shared --prefix=/usr/local LDFLAGS="-Wl,--rpath=/usr/local/lib"
 sudo make altinstall
-cd ..
+)
 rm Python-3.4.6.tgz
 
 curl -O https://bootstrap.pypa.io/get-pip.py
@@ -95,6 +96,8 @@ sudo pip install google-api-python-client
 # Node dependencies (nvm has to be installed under user jenkins)
 touch .profile
 curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.25.4/install.sh | bash
+# silence shellcheck warning as it cannot follow the `source` path statically:
+# shellcheck disable=SC1090
 source ~/.nvm/nvm.sh
 nvm install 0.12 && npm config set cache /tmp/npm-cache
 nvm install 4 && npm config set cache /tmp/npm-cache
@@ -151,7 +154,7 @@ sudo ln -s /usr/local/go/bin/go /usr/bin/go
 rm go$GO_VERSION.$OS-$ARCH.tar.gz
 
 # Install perf, to profile benchmarks. (need to get the right linux-tools-<> for kernel version)
-sudo apt-get install -y linux-tools-common linux-tools-generic linux-tools-`uname -r`
+sudo apt-get install -y linux-tools-common linux-tools-generic "linux-tools-$(uname -r)"
 # see http://unix.stackexchange.com/questions/14227/do-i-need-root-admin-permissions-to-run-userspace-perf-tool-perf-events-ar
 echo 0 | sudo tee /proc/sys/kernel/perf_event_paranoid
 # see http://stackoverflow.com/questions/21284906/perf-couldnt-record-kernel-reference-relocation-symbol
@@ -171,7 +174,9 @@ sudo apt-get install -y python-scipy python-numpy
 # Add pubkey of jenkins@grpc-jenkins-master to authorized keys of jenkins@
 # This needs to happen as the last step to prevent Jenkins master from connecting
 # to a machine that hasn't been properly setup yet.
-cat jenkins_master.pub | sudo tee --append ~jenkins/.ssh/authorized_keys
+# silence false-positive shellcheck warning ("< redirect does not affect sudo")
+# shellcheck disable=SC2024
+sudo tee --append ~jenkins/.ssh/authorized_keys < jenkins_master.pub
 
 # Restart for VM to pick up kernel update
 echo 'Successfully initialized the linux worker, going for reboot in 10 seconds'

--- a/tools/gce/linux_worker_init.sh
+++ b/tools/gce/linux_worker_init.sh
@@ -66,7 +66,10 @@ rm linux-*
 # Add pubkey of jenkins@grpc-jenkins-master to authorized keys of jenkins@
 # This needs to happen as the last step to prevent Jenkins master from connecting
 # to a machine that hasn't been properly setup yet.
-cat jenkins_master.pub | sudo tee --append ~jenkins/.ssh/authorized_keys
+
+# disable superfluous warning by shellcheck:
+# shellcheck disable=SC2024
+sudo tee --append ~jenkins/.ssh/authorized_keys < jenkins_master.pub
 
 # Restart for docker to pick up the config changes.
 echo 'Successfully initialized the linux worker, going for reboot in 10 seconds'

--- a/tools/run_tests/sanity/check_shellcheck.sh
+++ b/tools/run_tests/sanity/check_shellcheck.sh
@@ -20,6 +20,7 @@ ROOT="$(dirname "$0")/../../.."
 
 DIRS=(
     'test'
+    'tools/gce'
     'tools/run_tests'
 )
 


### PR DESCRIPTION
Fix subtle flaws in scripts in `tools/gce` and make them pass `shellcheck`.

Expand shellcheck enforcement on `tools/gce` directory.

Progress on #11601.