### PR TITLE
Take ownership of byte_buffer contents as soon as send_message op is started.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1473,6 +1473,7 @@ static void perform_stream_op_locked(void* stream_op,
       // streaming call might send another message before getting a
       // recv_message failure, breaking out of its loop, and then
       // starting recv_trailing_metadata.
+      grpc_byte_stream_destroy(op->payload->send_message.send_message);
       grpc_chttp2_complete_closure_step(
           t, s, &s->fetching_send_message_finished,
           t->is_client && s->received_trailing_metadata
@@ -2092,7 +2093,10 @@ void grpc_chttp2_fail_pending_writes(grpc_chttp2_transport* t,
                                     GRPC_ERROR_REF(error),
                                     "send_trailing_metadata_finished");
 
-  s->fetching_send_message = nullptr;
+  if (s->fetching_send_message != nullptr) {
+    grpc_byte_stream_destroy(s->fetching_send_message);
+    s->fetching_send_message = nullptr;
+  }
   grpc_chttp2_complete_closure_step(t, s, &s->fetching_send_message_finished,
                                     GRPC_ERROR_REF(error),
                                     "fetching_send_message_finished");

--- a/src/core/ext/transport/inproc/inproc_transport.cc
+++ b/src/core/ext/transport/inproc/inproc_transport.cc
@@ -480,6 +480,8 @@ static void fail_helper_locked(inproc_stream* s, grpc_error* error) {
     s->recv_message_op = nullptr;
   }
   if (s->send_message_op) {
+    grpc_byte_stream_destroy(
+        s->send_message_op->payload->send_message.send_message);
     complete_if_batch_end_locked(
         s, error, s->send_message_op,
         "fail_helper scheduling send-message-on-complete");
@@ -602,6 +604,8 @@ static void op_state_machine(void* arg, grpc_error* error) {
                (s->trailing_md_sent || other->recv_trailing_md_op)) {
       // A server send will never be matched if the client is waiting
       // for trailing metadata already
+      grpc_byte_stream_destroy(
+          s->send_message_op->payload->send_message.send_message);
       complete_if_batch_end_locked(
           s, GRPC_ERROR_NONE, s->send_message_op,
           "op_state_machine scheduling send-message-on-complete");
@@ -738,6 +742,8 @@ static void op_state_machine(void* arg, grpc_error* error) {
     if ((s->trailing_md_sent || s->t->is_client) && s->send_message_op) {
       // Nothing further will try to receive from this stream, so finish off
       // any outstanding send_message op
+      grpc_byte_stream_destroy(
+          s->send_message_op->payload->send_message.send_message);
       complete_if_batch_end_locked(
           s, new_err, s->send_message_op,
           "op_state_machine scheduling send-message-on-complete");
@@ -795,6 +801,8 @@ static void op_state_machine(void* arg, grpc_error* error) {
       s->send_message_op) {
     // Nothing further will try to receive from this stream, so finish off
     // any outstanding send_message op
+    grpc_byte_stream_destroy(
+        s->send_message_op->payload->send_message.send_message);
     complete_if_batch_end_locked(
         s, new_err, s->send_message_op,
         "op_state_machine scheduling send-message-on-complete");

--- a/src/core/ext/transport/inproc/inproc_transport.cc
+++ b/src/core/ext/transport/inproc/inproc_transport.cc
@@ -508,7 +508,7 @@ static void fail_helper_locked(inproc_stream* s, grpc_error* error) {
   GRPC_ERROR_UNREF(error);
 }
 
-// TODO(vpai): It should not be necessary to drain the incoming byte
+// TODO(vjpai): It should not be necessary to drain the incoming byte
 // stream and create a new one; instead, we should simply pass the byte
 // stream from the sender directly to the receiver as-is.
 //

--- a/src/core/lib/transport/byte_stream.h
+++ b/src/core/lib/transport/byte_stream.h
@@ -81,7 +81,7 @@ void grpc_byte_stream_destroy(grpc_byte_stream* byte_stream);
 
 typedef struct grpc_slice_buffer_stream {
   grpc_byte_stream base;
-  grpc_slice_buffer* backing_buffer;
+  grpc_slice_buffer backing_buffer;
   size_t cursor;
   grpc_error* shutdown_error;
 } grpc_slice_buffer_stream;


### PR DESCRIPTION
This builds on top of the earlier changes in #12306.

This avoids potential race conditions when we return recv_trailing_metadata before send_message completes and the application destroys the byte buffer before we can destroy the slices internally.