### PR TITLE
Extend foundry dockerfile with dnsutils

### DIFF
--- a/tools/dockerfile/grpc_foundry_tests/Dockerfile
+++ b/tools/dockerfile/grpc_foundry_tests/Dockerfile
@@ -1,0 +1,2 @@
+FROM gcr.io/asci-toolchain/nosla-debian8-clang-fl@sha256:496193842f61c9494be68bd624e47c74d706cabf19a693c4653ffe96a97e43e3
+RUN apt-get update && apt-get install -y dnsutils

--- a/tools/dockerfile/push_testing_images.sh
+++ b/tools/dockerfile/push_testing_images.sh
@@ -29,6 +29,7 @@ cd -
 
 DOCKERHUB_ORGANIZATION=grpctesting
 
+echo "Uploading images to dockerhub..."
 for DOCKERFILE_DIR in tools/dockerfile/test/* tools/dockerfile/grpc_artifact_* tools/dockerfile/interoptest/* tools/dockerfile/distribtest/cpp_jessie_x64 third_party/rake-compiler-dock
 do
   # Generate image name based on Dockerfile checksum. That works well as long
@@ -47,3 +48,10 @@ do
   # "docker login" needs to be run in advance
   docker push ${DOCKERHUB_ORGANIZATION}/${DOCKER_IMAGE_NAME}
 done
+
+echo "Uploading foundry tests image to GCR..."
+DOCKERFILE_DIR=tools/dockerfile/grpc_foundry_tests
+GCR_PROJECT_ID=grpc-testing
+DOCKER_IMAGE_NAME="gcr.io/$GCR_PROJECT_ID/$(basename $DOCKERFILE_DIR)_$(sha1sum $DOCKERFILE_DIR/Dockerfile | cut -f1 -d\ )"
+docker build -t ${DOCKER_IMAGE_NAME} ${DOCKERFILE_DIR}
+gcloud docker -- push ${DOCKER_IMAGE_NAME}

--- a/tools/internal_ci/helper_scripts/prepare_build_linux_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_linux_rc
@@ -29,5 +29,11 @@ sudo service docker restart
 
 # Download Docker images from DockerHub
 export DOCKERHUB_ORGANIZATION=grpctesting
+# Set name of GCR docker image used for foundry tests
+FOUNDRY_DOCKERFILE_SHA1="$(sha1sum tools/dockerfile/grpc_foundry_tests/Dockerfile | cut -f1 -d\ )"
+GCR_PROJECT_ID=grpc-testing
+export GRPC_FOUNDRY_TESTS_DOCKER_IMAGE="gcr.io/$GCR_PROJECT_ID/grpc_foundry_tests_$FOUNDRY_DOCKERFILE_SHA1"
+unset FOUNDRY_DOCKERFILE_SHA1
+unset GCR_PROJECT_ID
 
 git submodule update --init

--- a/tools/internal_ci/linux/grpc_bazel_on_foundry_dbg.sh
+++ b/tools/internal_ci/linux/grpc_bazel_on_foundry_dbg.sh
@@ -50,7 +50,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
   --strategy=Closure=remote  \
   --genrule_strategy=remote  \
   --experimental_strict_action_env=true \
-  --experimental_remote_platform_override='properties:{name:"container-image" value:"docker://gcr.io/asci-toolchain/nosla-debian8-clang-fl@sha256:496193842f61c9494be68bd624e47c74d706cabf19a693c4653ffe96a97e43e3" }' \
+  --experimental_remote_platform_override="properties:{name:\"container-image\" value:\"docker://$GRPC_FOUNDRY_TESTS_DOCKER_IMAGE\" }" \
   --crosstool_top=@com_github_bazelbuild_bazeltoolchains//configs/debian8_clang/0.2.0/bazel_0.7.0:toolchain \
   --define GRPC_PORT_ISOLATED_RUNTIME=1 \
   -c dbg \

--- a/tools/internal_ci/linux/grpc_bazel_on_foundry_opt.sh
+++ b/tools/internal_ci/linux/grpc_bazel_on_foundry_opt.sh
@@ -50,7 +50,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
   --strategy=Closure=remote  \
   --genrule_strategy=remote  \
   --experimental_strict_action_env=true \
-  --experimental_remote_platform_override='properties:{name:"container-image" value:"docker://gcr.io/asci-toolchain/nosla-debian8-clang-fl@sha256:496193842f61c9494be68bd624e47c74d706cabf19a693c4653ffe96a97e43e3" }' \
+  --experimental_remote_platform_override="properties:{name:\"container-image\" value:\"docker://$GRPC_FOUNDRY_TESTS_DOCKER_IMAGE\" }" \
   --crosstool_top=@com_github_bazelbuild_bazeltoolchains//configs/debian8_clang/0.2.0/bazel_0.7.0:toolchain \
   --define GRPC_PORT_ISOLATED_RUNTIME=1 \
   -c opt \

--- a/tools/internal_ci/linux/grpc_tsan_on_foundry.sh
+++ b/tools/internal_ci/linux/grpc_tsan_on_foundry.sh
@@ -50,7 +50,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
   --strategy=Closure=remote  \
   --genrule_strategy=remote  \
   --experimental_strict_action_env=true \
-  --experimental_remote_platform_override='properties:{name:"container-image" value:"docker://gcr.io/asci-toolchain/nosla-debian8-clang-fl@sha256:496193842f61c9494be68bd624e47c74d706cabf19a693c4653ffe96a97e43e3" }' \
+  --experimental_remote_platform_override="properties:{name:\"container-image\" value:\"docker://$GRPC_FOUNDRY_TESTS_DOCKER_IMAGE\" }" \
   --crosstool_top=@com_github_bazelbuild_bazeltoolchains//configs/debian8_clang/0.2.0/bazel_0.7.0:toolchain \
   --define GRPC_PORT_ISOLATED_RUNTIME=1 \
   --copt=-gmlt \


### PR DESCRIPTION
Towards fixing https://github.com/grpc/grpc/issues/13621. (this PR fixes the `dig: command not found` error. https://github.com/grpc/grpc/pull/14411 will be needed on top of this PR in order to fix that test completely).

I've uploaded this image to our GCR repo and given RBE read access for our GCR repo, so this <i>should</i> be ready to go. I haven't actually ran the foundry tests with this change yet though and not sure how to at the moment.