### PR TITLE
Channel Arg Utility: grpc_channel_arg_get_string

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -402,7 +402,6 @@ static void on_resolver_result_changed_locked(void* arg, grpc_error* error) {
   if (chand->resolver_result != nullptr) {
     if (chand->resolver != nullptr) {
       // Find LB policy name.
-      const char* lb_policy_name = nullptr;
       const grpc_arg* channel_arg = grpc_channel_args_find(
           chand->resolver_result, GRPC_ARG_LB_POLICY_NAME);
       const char* lb_policy_name = grpc_channel_arg_get_string(channel_arg);

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -405,10 +405,7 @@ static void on_resolver_result_changed_locked(void* arg, grpc_error* error) {
       const char* lb_policy_name = nullptr;
       const grpc_arg* channel_arg = grpc_channel_args_find(
           chand->resolver_result, GRPC_ARG_LB_POLICY_NAME);
-      if (channel_arg != nullptr) {
-        GPR_ASSERT(channel_arg->type == GRPC_ARG_STRING);
-        lb_policy_name = channel_arg->value.string;
-      }
+      const char* lb_policy_name = grpc_channel_arg_get_string(channel_arg);
       // Special case: If at least one balancer address is present, we use
       // the grpclb policy, regardless of what the resolver actually specified.
       channel_arg =
@@ -475,16 +472,17 @@ static void on_resolver_result_changed_locked(void* arg, grpc_error* error) {
       // Find service config.
       channel_arg = grpc_channel_args_find(chand->resolver_result,
                                            GRPC_ARG_SERVICE_CONFIG);
-      if (channel_arg != nullptr && channel_arg->type == GRPC_ARG_STRING) {
-        service_config_json = gpr_strdup(channel_arg->value.string);
+      service_config_json =
+          gpr_strdup(grpc_channel_arg_get_string(channel_arg));
+      if (service_config_json != nullptr) {
         grpc_service_config* service_config =
             grpc_service_config_create(service_config_json);
         if (service_config != nullptr) {
           channel_arg = grpc_channel_args_find(chand->resolver_result,
                                                GRPC_ARG_SERVER_URI);
-          GPR_ASSERT(channel_arg != nullptr);
-          GPR_ASSERT(channel_arg->type == GRPC_ARG_STRING);
-          grpc_uri* uri = grpc_uri_parse(channel_arg->value.string, true);
+          const char* server_uri = grpc_channel_arg_get_string(channel_arg);
+          GPR_ASSERT(server_uri != nullptr);
+          grpc_uri* uri = grpc_uri_parse(server_uri, true);
           GPR_ASSERT(uri->path[0] != '\0');
           service_config_parsing_state parsing_state;
           memset(&parsing_state, 0, sizeof(parsing_state));

--- a/src/core/ext/filters/client_channel/http_connect_handshaker.cc
+++ b/src/core/ext/filters/client_channel/http_connect_handshaker.cc
@@ -254,7 +254,8 @@ static void http_connect_handshaker_do_handshake(
   // If not found, invoke on_handshake_done without doing anything.
   const grpc_arg* arg =
       grpc_channel_args_find(args->args, GRPC_ARG_HTTP_CONNECT_SERVER);
-  if (arg == nullptr || arg->type != GRPC_ARG_STRING) {
+  char* server_name = grpc_channel_arg_get_string(arg);
+  if (server_name == nullptr) {
     // Set shutdown to true so that subsequent calls to
     // http_connect_handshaker_shutdown() do nothing.
     gpr_mu_lock(&handshaker->mu);
@@ -263,16 +264,15 @@ static void http_connect_handshaker_do_handshake(
     GRPC_CLOSURE_SCHED(on_handshake_done, GRPC_ERROR_NONE);
     return;
   }
-  char* server_name = arg->value.string;
   // Get headers from channel args.
   arg = grpc_channel_args_find(args->args, GRPC_ARG_HTTP_CONNECT_HEADERS);
+  char* arg_header_string = grpc_channel_arg_get_string(arg);
   grpc_http_header* headers = nullptr;
   size_t num_headers = 0;
   char** header_strings = nullptr;
   size_t num_header_strings = 0;
-  if (arg != nullptr) {
-    GPR_ASSERT(arg->type == GRPC_ARG_STRING);
-    gpr_string_split(arg->value.string, "\n", &header_strings,
+  if (arg_header_string != nullptr) {
+    gpr_string_split(arg_header_string, "\n", &header_strings,
                      &num_header_strings);
     headers = static_cast<grpc_http_header*>(
         gpr_malloc(sizeof(grpc_http_header) * num_header_strings));

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1829,9 +1829,9 @@ static grpc_lb_policy* glb_create(grpc_lb_policy_factory* factory,
 
   /* Get server name. */
   arg = grpc_channel_args_find(args->args, GRPC_ARG_SERVER_URI);
-  GPR_ASSERT(arg != nullptr);
-  GPR_ASSERT(arg->type == GRPC_ARG_STRING);
-  grpc_uri* uri = grpc_uri_parse(arg->value.string, true);
+  const char* server_uri = grpc_channel_arg_get_string(arg);
+  GPR_ASSERT(server_uri != nullptr);
+  grpc_uri* uri = grpc_uri_parse(server_uri, true);
   GPR_ASSERT(uri->path[0] != '\0');
   glb_policy->server_name =
       gpr_strdup(uri->path[0] == '/' ? uri->path + 1 : uri->path);

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -728,9 +728,9 @@ void grpc_get_subchannel_address_arg(const grpc_channel_args* args,
 const char* grpc_get_subchannel_address_uri_arg(const grpc_channel_args* args) {
   const grpc_arg* addr_arg =
       grpc_channel_args_find(args, GRPC_ARG_SUBCHANNEL_ADDRESS);
-  GPR_ASSERT(addr_arg != nullptr);  // Should have been set by LB policy.
-  GPR_ASSERT(addr_arg->type == GRPC_ARG_STRING);
-  return addr_arg->value.string;
+  const char* addr_str = grpc_channel_arg_get_string(addr_arg);
+  GPR_ASSERT(addr_str != nullptr);  // Should have been set by LB policy.
+  return addr_str;
 }
 
 grpc_arg grpc_create_subchannel_address_arg(const grpc_resolved_address* addr) {

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -249,10 +249,10 @@ static grpc_error* init_channel_elem(grpc_channel_element* elem,
   // Get method config table from channel args.
   const grpc_arg* channel_arg =
       grpc_channel_args_find(args->channel_args, GRPC_ARG_SERVICE_CONFIG);
-  if (channel_arg != nullptr) {
-    GPR_ASSERT(channel_arg->type == GRPC_ARG_STRING);
+  const char* service_config_str = grpc_channel_arg_get_string(channel_arg);
+  if (service_config_str != nullptr) {
     grpc_service_config* service_config =
-        grpc_service_config_create(channel_arg->value.string);
+        grpc_service_config_create(service_config_str);
     if (service_config != nullptr) {
       chand->method_limit_table =
           grpc_service_config_create_method_config_table(

--- a/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
@@ -63,9 +63,7 @@ static grpc_subchannel_args* get_secure_naming_subchannel_args(
   // To which address are we connecting? By default, use the server URI.
   const grpc_arg* server_uri_arg =
       grpc_channel_args_find(args->args, GRPC_ARG_SERVER_URI);
-  GPR_ASSERT(server_uri_arg != nullptr);
-  GPR_ASSERT(server_uri_arg->type == GRPC_ARG_STRING);
-  const char* server_uri_str = server_uri_arg->value.string;
+  const char* server_uri_str = grpc_channel_arg_get_string(server_uri_arg);
   GPR_ASSERT(server_uri_str != nullptr);
   grpc_uri* server_uri =
       grpc_uri_parse(server_uri_str, true /* supress errors */);

--- a/src/core/lib/channel/channel_args.cc
+++ b/src/core/lib/channel/channel_args.cc
@@ -354,6 +354,15 @@ int grpc_channel_arg_get_integer(const grpc_arg* arg,
   return arg->value.integer;
 }
 
+char* grpc_channel_arg_get_string(const grpc_arg* arg) {
+  if (arg == nullptr) return nullptr;
+  if (arg->type != GRPC_ARG_STRING) {
+    gpr_log(GPR_ERROR, "%s ignored: it must be an string", arg->key);
+    return nullptr;
+  }
+  return arg->value.string;
+}
+
 bool grpc_channel_arg_get_bool(const grpc_arg* arg, bool default_value) {
   if (arg == nullptr) return default_value;
   if (arg->type != GRPC_ARG_INTEGER) {

--- a/src/core/lib/channel/channel_args.h
+++ b/src/core/lib/channel/channel_args.h
@@ -109,6 +109,10 @@ typedef struct grpc_integer_options {
 int grpc_channel_arg_get_integer(const grpc_arg* arg,
                                  const grpc_integer_options options);
 
+/** Returns the value of \a arg if \a arg is of type GRPC_ARG_STRING.
+    Otherwise, emits a warning log, and returns nullptr */
+char* grpc_channel_arg_get_string(const grpc_arg* arg);
+
 bool grpc_channel_arg_get_bool(const grpc_arg* arg, bool default_value);
 
 // Helpers for creating channel args.

--- a/src/core/lib/channel/channel_args.h
+++ b/src/core/lib/channel/channel_args.h
@@ -110,7 +110,8 @@ int grpc_channel_arg_get_integer(const grpc_arg* arg,
                                  const grpc_integer_options options);
 
 /** Returns the value of \a arg if \a arg is of type GRPC_ARG_STRING.
-    Otherwise, emits a warning log, and returns nullptr */
+    Otherwise, emits a warning log, and returns nullptr.
+    If arg is nullptr, returns nullptr, and does not emit a warning. */
 char* grpc_channel_arg_get_string(const grpc_arg* arg);
 
 bool grpc_channel_arg_get_bool(const grpc_arg* arg, bool default_value);

--- a/src/core/lib/security/credentials/fake/fake_credentials.cc
+++ b/src/core/lib/security/credentials/fake/fake_credentials.cc
@@ -87,11 +87,7 @@ const char* grpc_fake_transport_get_expected_targets(
     const grpc_channel_args* args) {
   const grpc_arg* expected_target_arg =
       grpc_channel_args_find(args, GRPC_ARG_FAKE_SECURITY_EXPECTED_TARGETS);
-  if (expected_target_arg != nullptr &&
-      expected_target_arg->type == GRPC_ARG_STRING) {
-    return expected_target_arg->value.string;
-  }
-  return nullptr;
+  return grpc_channel_arg_get_string(expected_target_arg);
 }
 
 /* -- Metadata-only test credentials. -- */

--- a/test/core/end2end/fixtures/h2_http_proxy.cc
+++ b/test/core/end2end/fixtures/h2_http_proxy.cc
@@ -72,11 +72,12 @@ void chttp2_init_client_fullstack(grpc_end2end_test_fixture* f,
   /* If testing for proxy auth, add credentials to proxy uri */
   const grpc_arg* proxy_auth_arg =
       grpc_channel_args_find(client_args, GRPC_ARG_HTTP_PROXY_AUTH_CREDS);
-  if (proxy_auth_arg == nullptr || proxy_auth_arg->type != GRPC_ARG_STRING) {
+  const char* proxy_auth_str = grpc_channel_arg_get_string(proxy_auth_arg);
+  if (proxy_auth_str == nullptr) {
     gpr_asprintf(&proxy_uri, "http://%s",
                  grpc_end2end_http_proxy_get_proxy_name(ffd->proxy));
   } else {
-    gpr_asprintf(&proxy_uri, "http://%s@%s", proxy_auth_arg->value.string,
+    gpr_asprintf(&proxy_uri, "http://%s@%s", proxy_auth_str,
                  grpc_end2end_http_proxy_get_proxy_name(ffd->proxy));
   }
   gpr_setenv("http_proxy", proxy_uri);

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -413,12 +413,13 @@ static void on_read_request_done(void* arg, grpc_error* error) {
   // If proxy auth is being used, check if the header is present and as expected
   const grpc_arg* proxy_auth_arg = grpc_channel_args_find(
       conn->proxy->channel_args, GRPC_ARG_HTTP_PROXY_AUTH_CREDS);
-  if (proxy_auth_arg != nullptr && proxy_auth_arg->type == GRPC_ARG_STRING) {
+  const char* proxy_auth_str = grpc_channel_arg_get_string(proxy_auth_arg);
+  if (proxy_auth_str != nullptr) {
     bool client_authenticated = false;
     for (size_t i = 0; i < conn->http_request.hdr_count; i++) {
       if (strcmp(conn->http_request.hdrs[i].key, "Proxy-Authorization") == 0) {
         client_authenticated = proxy_auth_header_matches(
-            conn->http_request.hdrs[i].value, proxy_auth_arg->value.string);
+            conn->http_request.hdrs[i].value, proxy_auth_str);
         break;
       }
     }

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -413,7 +413,7 @@ static void on_read_request_done(void* arg, grpc_error* error) {
   // If proxy auth is being used, check if the header is present and as expected
   const grpc_arg* proxy_auth_arg = grpc_channel_args_find(
       conn->proxy->channel_args, GRPC_ARG_HTTP_PROXY_AUTH_CREDS);
-  const char* proxy_auth_str = grpc_channel_arg_get_string(proxy_auth_arg);
+  char* proxy_auth_str = grpc_channel_arg_get_string(proxy_auth_arg);
   if (proxy_auth_str != nullptr) {
     bool client_authenticated = false;
     for (size_t i = 0; i < conn->http_request.hdr_count; i++) {


### PR DESCRIPTION
Adds helper, grpc_channel_arg_get_string, which will output GRPC_ERROR log if someone passes a channel_arg that MUST be a string as any other type.

The motivation comes from #14423 and #14428. Failing 'silently' on those strange mismatch types seems like an easy way to allow some user to shoot themselves in the foot. I can envision someone wondering what is happening when the arg is present, but ignored, because they fat fingered it as GRPC_ARG_INT instead of GRPC_ARG_STRING.

I have used this function in one place, but if you think this change is a good idea, I will do a quick search for more instances of the pattern and use the new helper