### PR TITLE
Update gflags in Bazel build

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -90,8 +90,8 @@ def grpc_deps():
     if "com_github_gflags_gflags" not in native.existing_rules():
         native.http_archive(
             name = "com_github_gflags_gflags",
-            strip_prefix = "gflags-30dbc81fb5ffdc98ea9b14b1918bfe4e8779b26e",
-            url = "https://github.com/gflags/gflags/archive/30dbc81fb5ffdc98ea9b14b1918bfe4e8779b26e.tar.gz",
+            strip_prefix = "gflags-77592648e3f3be87d6c7123eb81cbad75f9aef5a",
+            url = "https://github.com/gflags/gflags/archive/77592648e3f3be87d6c7123eb81cbad75f9aef5a.tar.gz",
         )
 
     if "com_github_google_benchmark" not in native.existing_rules():

--- a/tools/run_tests/sanity/check_submodules.sh
+++ b/tools/run_tests/sanity/check_submodules.sh
@@ -29,7 +29,7 @@ cat << EOF | awk '{ print $1 }' | sort > "$want_submodules"
  5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8 third_party/benchmark (v1.2.0)
  4d7ba4e4e57195fcebdabe01489534b446ad02cb third_party/boringssl (heads/chromium-stable)
  886e7d75368e3f4fab3f4d0d3584e4abfc557755 third_party/boringssl-with-bazel (version_for_cocoapods_7.0-857-g886e7d7)
- 30dbc81fb5ffdc98ea9b14b1918bfe4e8779b26e third_party/gflags (v2.2.0)
+ 77592648e3f3be87d6c7123eb81cbad75f9aef5a third_party/gflags (v2.2.0)
  ec44c6c1675c25b9827aacd08c02433cccde7780 third_party/googletest (release-1.8.0)
  2761122b810fe8861004ae785cc3ab39f384d342 third_party/protobuf (v3.5.0)
  cacf7f1d4e3d44d871b605da3b647f07d718623f third_party/zlib (v1.2.11)


### PR DESCRIPTION
The updated gflags no longer leaks an internal config.h header, which
can avoid problems like https://github.com/google/glog/issues/297.