### PR TITLE
Add go release versions to client_matrix.py

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -109,6 +109,9 @@ LANG_RELEASE_MATRIX = {
         {
             'v1.9.2': None
         },
+        {
+            'v1.10.0': None
+        },
     ],
     'java': [
         {


### PR DESCRIPTION
$ gcloud beta container images list-tags gcr.io/grpc-testing/grpc_interop_go1.8
```
DIGEST        TAGS     TIMESTAMP
1cd66951fb6e  v1.10.0  2018-02-15T15:21:20
fe1cdb9d89c6  v1.9.2   2018-01-19T11:37:05
a3a67d963a7c  v1.9.1   2018-01-08T14:26:31
bab9522bb241  v1.9.0   2018-01-04T14:48:09
ae47eb7fee72  v1.8.2   2017-12-12T17:01:54
1f30029aefbe  v1.8.1   2017-12-05T11:29:58
de5de35d8c0f  v1.7.4   2017-12-05T11:29:14
01cdc4b28bf8  v1.8.0   2017-11-21T17:22:51
2bdc2990d55a  v1.7.3   2017-11-21T17:22:31
c8cca2206b87  v1.7.2   2017-11-21T17:21:53
```