### PR TITLE
fix github url in client_matrix.py

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -18,9 +18,9 @@
 
 def get_github_repo(lang):
     return {
-        'go': 'https://github.com:grpc/grpc-go.git',
-        'java': 'https://github.com:grpc/grpc-java.git',
-        'node': 'https://github.com:grpc/grpc-node.git',
+        'go': 'https://github.com/grpc/grpc-go.git',
+        'java': 'https://github.com/grpc/grpc-java.git',
+        'node': 'https://github.com/grpc/grpc-node.git',
         # all other languages use the grpc.git repo.
     }.get(lang, 'https://github.com/grpc/grpc.git')
 


### PR DESCRIPTION
Use slash instead of colon. The url format changed from `git@github.com:...` to `https://github.com:...` in https://github.com/grpc/grpc/commit/2de1195da6532ec52cd867da8d0613dc9c365a66#diff-6b34b224bd4d57f6dfdf3f46a282af44