### PR TITLE
Bazel support: run end2end tests with different pollers

### DIFF
--- a/test/core/end2end/BUILD
+++ b/test/core/end2end/BUILD
@@ -71,4 +71,95 @@ grpc_cc_library(
     ],
 )
 
+grpc_cc_test(
+    name = "bad_server_response_test",
+    srcs = ["bad_server_response_test.cc"],
+    language = "C++",
+    deps = [
+        ":cq_verifier",
+        "//:gpr",
+        "//:grpc",
+        "//test/core/util:gpr_test_util",
+        "//test/core/util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
+    name = "connection_refused_test",
+    srcs = ["connection_refused_test.cc"],
+    language = "C++",
+    deps = [
+        ":cq_verifier",
+        "//:gpr",
+        "//:grpc",
+        "//test/core/util:gpr_test_util",
+        "//test/core/util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
+    name = "dualstack_socket_test",
+    srcs = ["dualstack_socket_test.cc"],
+    language = "C++",
+    deps = [
+        ":cq_verifier",
+        "//:gpr",
+        "//:grpc",
+        "//test/core/util:gpr_test_util",
+        "//test/core/util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
+    name = "goaway_server_test",
+    srcs = ["goaway_server_test.cc"],
+    language = "C++",
+    deps = [
+        ":cq_verifier",
+        "//:gpr",
+        "//:grpc",
+        "//test/core/util:gpr_test_util",
+        "//test/core/util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
+    name = "invalid_call_argument_test",
+    srcs = ["invalid_call_argument_test.cc"],
+    language = "C++",
+    deps = [
+        ":cq_verifier",
+        "//:gpr",
+        "//:grpc",
+        "//test/core/util:gpr_test_util",
+        "//test/core/util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
+    name = "multiple_server_queues_test",
+    srcs = ["multiple_server_queues_test.cc"],
+    language = "C++",
+    deps = [
+        ":cq_verifier",
+        "//:gpr",
+        "//:grpc",
+        "//test/core/util:gpr_test_util",
+        "//test/core/util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
+    name = "no_server_test",
+    srcs = ["no_server_test.cc"],
+    language = "C++",
+    deps = [
+        ":cq_verifier",
+        "//:gpr",
+        "//:grpc",
+        "//test/core/util:gpr_test_util",
+        "//test/core/util:grpc_test_util",
+    ],
+)
+
 grpc_end2end_tests()

--- a/test/core/end2end/end2end_test.sh
+++ b/test/core/end2end/end2end_test.sh
@@ -15,4 +15,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+if [ -z "$3" ]
+  then
+    export GRPC_POLL_STRATEGY=$3
+fi
 "$1" "$2"

--- a/test/core/end2end/generate_tests.bzl
+++ b/test/core/end2end/generate_tests.bzl
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+POLLERS = ['epollex', 'epollsig', 'epoll1', 'poll', 'poll-cv']
+
 load("//bazel:grpc_build_system.bzl", "grpc_sh_test", "grpc_cc_binary", "grpc_cc_library")
 
 """Generates the appropriate build.json data for all the end2end tests."""
@@ -219,9 +221,14 @@ def grpc_end2end_tests():
     for t, topt in END2END_TESTS.items():
       #print(compatible(fopt, topt), f, t, fopt, topt)
       if not compatible(fopt, topt): continue
-      grpc_sh_test(
-        name = '%s_test@%s' % (f, t),
-        srcs = ['end2end_test.sh'],
-        args = ['$(location %s_test)' % f, t],
-        data = [':%s_test' % f],
-      )
+      for poller in POLLERS:
+        native.sh_test(
+          name = '%s_test@%s@poller=%s' % (f, t, poller),
+          data = [':%s_test' % f],
+          srcs = ['end2end_test.sh'],
+          args = [
+            '$(location %s_test)' % f, 
+            t,
+            poller,
+          ],
+        )

--- a/test/core/security/BUILD
+++ b/test/core/security/BUILD
@@ -24,7 +24,7 @@ grpc_fuzzer(
     name = "ssl_server_fuzzer",
     srcs = ["ssl_server_fuzzer.cc"],
     language = "C++",
-    corpus = "corpus",
+    corpus = "corpus/ssl_server_corpus",
     deps = [
         "//:gpr",
         "//:grpc",


### PR DESCRIPTION
Also fixed a corpus path for a fuzzer test and add missing end2end tests with bazel.