### PR TITLE
add nanopb support for fields larger than 255 bits

### DIFF
--- a/third_party/nanopb/pb.h
+++ b/third_party/nanopb/pb.h
@@ -22,7 +22,7 @@
 /* #define PB_MAX_REQUIRED_FIELDS 256 */
 
 /* Add support for tag numbers > 255 and fields larger than 255 bytes. */
-/* #define PB_FIELD_16BIT 1 */
+#define PB_FIELD_16BIT 1 
 
 /* Add support for tag numbers > 65536 and fields larger than 65536 bytes. */
 /* #define PB_FIELD_32BIT 1 */


### PR DESCRIPTION
The PR adds nanopb support for fields larger than 255 bytes. The reason for adding this support is ALTS handshaker proto which is about to be open sourced (together with grpc Core), contains fields that can not be fit in 8 bit field descriptors. Notice that the modification in this PR does not alter nanopb output of load balancer proto. All it does is to use uint_least16_t, instead of uint_leas8_t to represent pb_size_t type field. With this change, there is also no need to import the new version of nanopb into grpc. 