### PR TITLE
Further increase deadline in dualstack_socket_test

### DIFF
--- a/test/core/end2end/dualstack_socket_test.cc
+++ b/test/core/end2end/dualstack_socket_test.cc
@@ -166,7 +166,7 @@ void test_connect(const char* server_host, const char* client_host, int port,
   } else {
     /* Give up faster when failure is expected.
        BUG: Setting this to 1000 reveals a memory leak (b/18608927). */
-    deadline = grpc_timeout_milliseconds_to_deadline(3000);
+    deadline = grpc_timeout_milliseconds_to_deadline(8000);
   }
 
   /* Send a trivial request. */


### PR DESCRIPTION
Tentative fix for https://github.com/grpc/grpc/issues/13727.

Deadline was increased in https://github.com/grpc/grpc/pull/14046  after which the flakiness rate went down, but we still occasionally see the flake -> increasing further.