### PR TITLE
Print trailing metadata in the "grpc_cli call" command.

### DIFF
--- a/test/cpp/util/grpc_tool.cc
+++ b/test/cpp/util/grpc_tool.cc
@@ -747,6 +747,8 @@ bool GrpcTool::CallMethod(int argc, const char** argv,
       }
     }
     Status status = call.Finish(&server_trailing_metadata);
+    PrintMetadata(server_trailing_metadata,
+                  "Received trailing metadata from server:");
     if (status.ok()) {
       fprintf(stderr, "Rpc succeeded with OK status\n");
       return true;


### PR DESCRIPTION
This often includes important debugging information when the RPC returns
a non-OK status.