### PR TITLE
Cancel max idle timer when shutting down the server channel

### DIFF
--- a/src/core/ext/filters/max_age/max_age_filter.cc
+++ b/src/core/ext/filters/max_age/max_age_filter.cc
@@ -368,6 +368,9 @@ static void channel_connectivity_changed(void* arg, grpc_error* error) {
        max_idle_timer, and prevent max_idle_timer from being started in the
        future. */
     increase_call_count(chand);
+    if (gpr_atm_acq_load(&chand->idle_state) == MAX_IDLE_STATE_SEEN_EXIT_IDLE) {
+      grpc_timer_cancel(&chand->max_idle_timer);
+    }
   }
 }
 


### PR DESCRIPTION
The max idle timer was not shutdown properly when the server channel is being shutdown. This caused a reference of each channel stack to be held until the max idle timer times out.  