### PR TITLE
Fix Linux Artifact builds

### DIFF
--- a/tools/run_tests/dockerize/docker_run.sh
+++ b/tools/run_tests/dockerize/docker_run.sh
@@ -25,9 +25,7 @@ then
   # clone gRPC submodules, use data from locally cloned submodules where possible
   # TODO: figure out a way to eliminate this following shellcheck suppressions
   # shellcheck disable=SC2016,SC1004
-  (cd "${EXTERNAL_GIT_ROOT}" && git submodule foreach 'cd /var/local/git/grpc \
-  && git submodule update --init --reference ${EXTERNAL_GIT_ROOT}/${name} \
-  ${name}')
+  (cd "${EXTERNAL_GIT_ROOT}" && git submodule foreach 'git clone ${EXTERNAL_GIT_ROOT}/${name} /var/local/git/grpc/${name}')
 else
   mkdir -p "/var/local/git/grpc/$RELATIVE_COPY_PATH"
   cp -r "$EXTERNAL_GIT_ROOT/$RELATIVE_COPY_PATH"/* "/var/local/git/grpc/$RELATIVE_COPY_PATH"

--- a/tools/run_tests/dockerize/docker_run_tests.sh
+++ b/tools/run_tests/dockerize/docker_run_tests.sh
@@ -23,13 +23,11 @@ export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
 export PATH=$PATH:/usr/bin/llvm-symbolizer
 
 mkdir -p /var/local/git
-git clone  /var/local/jenkins/grpc /var/local/git/grpc
+git clone /var/local/jenkins/grpc /var/local/git/grpc
 # clone gRPC submodules, use data from locally cloned submodules where possible
 # TODO: figure out a way to eliminate this shellcheck suppression:
 # shellcheck disable=SC2016,SC1004
-(cd /var/local/jenkins/grpc/ && git submodule foreach 'cd /var/local/git/grpc \
-&& git submodule update --init --reference /var/local/jenkins/grpc/${name} \
-${name}')
+(cd /var/local/jenkins/grpc/ && git submodule foreach 'git clone /var/local/jenkins/grpc/{$name} /var/local/jenkins/grpc/${name}')
 
 mkdir -p reports
 


### PR DESCRIPTION
Change `git submodule` copying mechanism from the host
to the docker container to use `git clone` instead of
`git submodule update --init --reference`, which reaches
out to the network and fails on older docker containers
with deprecated openssl versions that do not support
modern TLS versions required by GitHub, e.g. manylinux1.

This fixes artifact builds for protoc and Python on Linux.