### PR TITLE
Fix dockerized Linux artifact builds on master (upmerge from 1.10.x)

### DIFF
--- a/tools/run_tests/dockerize/docker_run.sh
+++ b/tools/run_tests/dockerize/docker_run.sh
@@ -26,6 +26,7 @@ then
   # TODO: figure out a way to eliminate this following shellcheck suppressions
   # shellcheck disable=SC2016,SC1004
   (cd "${EXTERNAL_GIT_ROOT}" && git submodule foreach 'git clone ${EXTERNAL_GIT_ROOT}/${name} /var/local/git/grpc/${name}')
+  (cd /var/local/git/grpc && git submodule init)
 else
   mkdir -p "/var/local/git/grpc/$RELATIVE_COPY_PATH"
   cp -r "$EXTERNAL_GIT_ROOT/$RELATIVE_COPY_PATH"/* "/var/local/git/grpc/$RELATIVE_COPY_PATH"

--- a/tools/run_tests/dockerize/docker_run_tests.sh
+++ b/tools/run_tests/dockerize/docker_run_tests.sh
@@ -26,8 +26,9 @@ mkdir -p /var/local/git
 git clone /var/local/jenkins/grpc /var/local/git/grpc
 # clone gRPC submodules, use data from locally cloned submodules where possible
 # TODO: figure out a way to eliminate this shellcheck suppression:
-# shellcheck disable=SC2016,SC1004
-(cd /var/local/jenkins/grpc/ && git submodule foreach 'git clone /var/local/jenkins/grpc/{$name} /var/local/jenkins/grpc/${name}')
+# shellcheck disable=SC2016
+(cd /var/local/jenkins/grpc/ && git submodule foreach 'git clone /var/local/jenkins/grpc/${name} /var/local/git/grpc/${name}')
+(cd /var/local/git/grpc/ && git submodule init)
 
 mkdir -p reports
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/14496.

Bonus point: makes local test runs under `--use_docker` snappier by eliminating network access on `git submodule update`.