### PR TITLE
Add missing subcommand to windows install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -142,7 +142,7 @@ installed to be able to compile the C/C++ sources.
 > call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" x64
 > cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release
 > cmake --build .
-> ninja
+> ninja install
 ```
 
 ### msys2 (with mingw)


### PR DESCRIPTION
As written, windows ninja-based build and install instructions successfully build gRPC, but do not install anything. Additionally, the last line of the instructions does nothing, because it duplicates the effect of the next-to-last-line. Adding "install" to the last line fixes both issues.