### PR TITLE
Use higher timeout for objc tests

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -37,6 +37,9 @@ _CPP_RUNTESTS_TIMEOUT = 4 * 60 * 60
 # C++ TSAN takes longer than other sanitizers
 _CPP_TSAN_RUNTESTS_TIMEOUT = 8 * 60 * 60
 
+# Set timeout high for ObjC for Cocoapods to install pods
+_OBJC_RUNTESTS_TIMEOUT = 90 * 60
+
 # Number of jobs assigned to each run_tests.py instance
 _DEFAULT_INNER_JOBS = 2
 
@@ -213,7 +216,8 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
         platforms=['macos'],
         labels=['basictests', 'multilang'],
         extra_args=extra_args,
-        inner_jobs=inner_jobs)
+        inner_jobs=inner_jobs,
+        timeout_seconds=_OBJC_RUNTESTS_TIMEOUT)
 
     # sanitizers
     test_jobs += _generate_jobs(


### PR DESCRIPTION
Cocoapods occasionally takes more time to install pods. Increase total timeout of ObjC tests for that.