### PR TITLE
Refactor connectivity monitor on iOS

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -343,6 +343,8 @@ static NSString * const kBearerPrefix = @"Bearer ";
         [strongSelf finishWithError:[NSError errorWithDomain:kGRPCErrorDomain
                                                         code:GRPCErrorCodeInternal
                                                     userInfo:nil]];
+        // Wrapped call must be canceled when error is reported to upper layers
+        [strongSelf cancelCall];
       }
     }];
   });
@@ -372,6 +374,8 @@ static NSString * const kBearerPrefix = @"Bearer ";
         [strongSelf finishWithError:[NSError errorWithDomain:kGRPCErrorDomain
                                                         code:GRPCErrorCodeInternal
                                                     userInfo:nil]];
+        // Wrapped call must be canceled when error is reported to upper layers
+        [strongSelf cancelCall];
       }];
     });
   }

--- a/src/objective-c/GRPCClient/private/GRPCConnectivityMonitor.h
+++ b/src/objective-c/GRPCClient/private/GRPCConnectivityMonitor.h
@@ -19,44 +19,30 @@
 #import <Foundation/Foundation.h>
 #import <SystemConfiguration/SystemConfiguration.h>
 
-@interface GRPCReachabilityFlags : NSObject
+typedef NS_ENUM(NSInteger, GRPCConnectivityStatus) {
+  GRPCConnectivityUnknown = 0,
+  GRPCConnectivityNoNetwork = 1,
+  GRPCConnectivityCellular = 2,
+  GRPCConnectivityWiFi = 3,
+};
 
-+ (nonnull instancetype)flagsWithFlags:(SCNetworkReachabilityFlags)flags;
+extern NSString * _Nonnull kGRPCConnectivityNotification;
 
-/**
- * One accessor method to query each of the different flags. Example:
-
-@property(nonatomic, readonly) BOOL isCell;
-
- */
-#define GRPC_XMACRO_ITEM(methodName, FlagName) \
-@property(nonatomic, readonly) BOOL methodName;
-
-#include "GRPCReachabilityFlagNames.xmacro.h"
-#undef GRPC_XMACRO_ITEM
-
-@property(nonatomic, readonly) BOOL isHostReachable;
-@end
-
+// This interface monitors OS reachability interface for any network status
+// change. Parties interested in these events should register themselves as
+// observer.
 @interface GRPCConnectivityMonitor : NSObject
-
-+ (nullable instancetype)monitorWithHost:(nonnull NSString *)hostName;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
-/**
- * Queue on which callbacks will be dispatched. Default is the main queue. Set it before calling
- * handleLossWithHandler:.
- */
-// TODO(jcanizales): Default to a serial background queue instead.
-@property(nonatomic, strong, null_resettable) dispatch_queue_t queue;
+// Register an object as observer of network status change. \a observer
+// must have a notification method with one parameter of type
+// (NSNotification *) and should pass it to parameter \a selector. The
+// parameter of this notification method is not used for now.
++ (void)registerObserver:(_Nonnull id)observer
+                selector:(_Nonnull SEL)selector;
 
-/**
- * Calls handler every time the connectivity to this instance's host is lost. If this instance is
- * released before that happens, the handler won't be called.
- * Only one handler is active at a time, so if this method is called again before the previous
- * handler has been called, it might never be called at all (or yes, if it has already been queued).
- */
-- (void)handleLossWithHandler:(nullable void (^)(void))lossHandler
-      wifiStatusChangeHandler:(nullable void (^)(void))wifiStatusChangeHandler;
+// Ungegister an object from observers of network status change.
++ (void)unregisterObserver:(_Nonnull id)observer;
+
 @end

--- a/src/objective-c/GRPCClient/private/GRPCConnectivityMonitor.m
+++ b/src/objective-c/GRPCClient/private/GRPCConnectivityMonitor.m
@@ -18,175 +18,74 @@
 
 #import "GRPCConnectivityMonitor.h"
 
-#pragma mark Flags
+#include <netinet/in.h>
 
-@implementation GRPCReachabilityFlags {
-  SCNetworkReachabilityFlags _flags;
-}
+NSString *kGRPCConnectivityNotification = @"kGRPCConnectivityNotification";
 
-+ (instancetype)flagsWithFlags:(SCNetworkReachabilityFlags)flags {
-  return [[self alloc] initWithFlags:flags];
-}
+static SCNetworkReachabilityRef reachability;
+static GRPCConnectivityStatus currentStatus;
 
-- (instancetype)initWithFlags:(SCNetworkReachabilityFlags)flags {
-  if ((self = [super init])) {
-    _flags = flags;
+// Aggregate information in flags into network status.
+GRPCConnectivityStatus CalculateConnectivityStatus(SCNetworkReachabilityFlags flags) {
+  GRPCConnectivityStatus result = GRPCConnectivityUnknown;
+  if (((flags & kSCNetworkReachabilityFlagsReachable) == 0) ||
+      ((flags & kSCNetworkReachabilityFlagsConnectionRequired) != 0)) {
+    return GRPCConnectivityNoNetwork;
   }
-  return self;
-}
-
-/*
- * One accessor method implementation per flag. Example:
-
-- (BOOL)isCell { \
-  return !!(_flags & kSCNetworkReachabilityFlagsIsWWAN); \
-}
-
- */
-#define GRPC_XMACRO_ITEM(methodName, FlagName) \
-- (BOOL)methodName { \
-  return !!(_flags & kSCNetworkReachabilityFlags ## FlagName); \
-}
-#include "GRPCReachabilityFlagNames.xmacro.h"
-#undef GRPC_XMACRO_ITEM
-
-- (BOOL)isHostReachable {
-  // Note: connectionOnDemand means it'll be reachable only if using the CFSocketStream API or APIs
-  // on top of it.
-  // connectionRequired means we can't tell until a connection is attempted (e.g. for VPN on
-  // demand).
-  return self.reachable && !self.interventionRequired && !self.connectionOnDemand;
-}
-
-- (NSString *)description {
-  NSMutableArray *activeOptions = [NSMutableArray arrayWithCapacity:9];
-
-  /*
-   * For each flag, add its name to the array if it's ON. Example:
-
-  if (self.isCell) {
-    [activeOptions addObject:@"isCell"];
-  }
-
-   */
-  #define GRPC_XMACRO_ITEM(methodName, FlagName) \
-    if (self.methodName) {                       \
-      [activeOptions addObject:@ #methodName];   \
-    }
-  #include "GRPCReachabilityFlagNames.xmacro.h"
-  #undef GRPC_XMACRO_ITEM
-
-  return activeOptions.count == 0 ? @"(none)" : [activeOptions componentsJoinedByString:@", "];
-}
-
-- (BOOL)isEqual:(id)object {
-  return [object isKindOfClass:[GRPCReachabilityFlags class]] &&
-      _flags == ((GRPCReachabilityFlags *)object)->_flags;
-}
-
-- (NSUInteger)hash {
-  return _flags;
-}
-@end
-
-#pragma mark Connectivity Monitor
-
-// Assumes the third argument is a block that accepts a GRPCReachabilityFlags object, and passes the
-// received ones to it.
-static void PassFlagsToContextInfoBlock(SCNetworkReachabilityRef target,
-                                        SCNetworkReachabilityFlags flags,
-                                        void *info) {
-  #pragma unused (target)
-  // This can be called many times with the same info. The info is retained by SCNetworkReachability
-  // while this function is being executed.
-  void (^handler)(GRPCReachabilityFlags *) = (__bridge void (^)(GRPCReachabilityFlags *))info;
-  handler([[GRPCReachabilityFlags alloc] initWithFlags:flags]);
-}
-
-@implementation GRPCConnectivityMonitor {
-  SCNetworkReachabilityRef _reachabilityRef;
-  GRPCReachabilityFlags *_previousReachabilityFlags;
-}
-
-- (nullable instancetype)initWithReachability:(nullable SCNetworkReachabilityRef)reachability {
-  if (!reachability) {
-    return nil;
-  }
-  if ((self = [super init])) {
-    _reachabilityRef = CFRetain(reachability);
-    _queue = dispatch_get_main_queue();
-    _previousReachabilityFlags = nil;
-  }
-  return self;
-}
-
-+ (nullable instancetype)monitorWithHost:(nonnull NSString *)host {
-  const char *hostName = host.UTF8String;
-  if (!hostName) {
-    [NSException raise:NSInvalidArgumentException
-                format:@"host.UTF8String returns NULL for %@", host];
-  }
-  SCNetworkReachabilityRef reachability =
-      SCNetworkReachabilityCreateWithName(NULL, hostName);
-
-  GRPCConnectivityMonitor *returnValue = [[self alloc] initWithReachability:reachability];
-  if (reachability) {
-    CFRelease(reachability);
-  }
-  return returnValue;
-}
-
-- (void)handleLossWithHandler:(nullable void (^)(void))lossHandler
-      wifiStatusChangeHandler:(nullable void (^)(void))wifiStatusChangeHandler {
-  __weak typeof(self) weakSelf = self;
-  [self startListeningWithHandler:^(GRPCReachabilityFlags *flags) {
-    typeof(self) strongSelf = weakSelf;
-    if (strongSelf) {
-      if (lossHandler && !flags.reachable) {
-        lossHandler();
+  result = GRPCConnectivityWiFi;
 #if TARGET_OS_IPHONE
-      } else if (wifiStatusChangeHandler &&
-                 strongSelf->_previousReachabilityFlags &&
-                 (flags.isWWAN ^
-                  strongSelf->_previousReachabilityFlags.isWWAN)) {
-        wifiStatusChangeHandler();
-#endif
-      }
-      strongSelf->_previousReachabilityFlags = flags;
-    }
-  }];
-}
-
-- (void)startListeningWithHandler:(void (^)(GRPCReachabilityFlags *))handler {
-  // Copy to ensure the handler block is in the heap (and so can't be deallocated when this method
-  // returns).
-  void (^copiedHandler)(GRPCReachabilityFlags *) = [handler copy];
-  SCNetworkReachabilityContext context = {
-    .version = 0,
-    .info = (__bridge void *)copiedHandler,
-    .retain = CFRetain,
-    .release = CFRelease,
-  };
-  // The following will retain context.info, and release it when the callback is set to NULL.
-  SCNetworkReachabilitySetCallback(_reachabilityRef, PassFlagsToContextInfoBlock, &context);
-  SCNetworkReachabilitySetDispatchQueue(_reachabilityRef, _queue);
-}
-
-- (void)stopListening {
-  // This releases the block on context.info.
-  SCNetworkReachabilitySetCallback(_reachabilityRef, NULL, NULL);
-  SCNetworkReachabilitySetDispatchQueue(_reachabilityRef, NULL);
-}
-
-- (void)setQueue:(dispatch_queue_t)queue {
-  _queue = queue ?: dispatch_get_main_queue();
-}
-
-- (void)dealloc {
-  if (_reachabilityRef) {
-    [self stopListening];
-    CFRelease(_reachabilityRef);
+  if (flags & kSCNetworkReachabilityFlagsIsWWAN) {
+    return result = GRPCConnectivityCellular;
   }
+#endif
+  return result;
+}
+
+static void ReachabilityCallback(
+    SCNetworkReachabilityRef target, SCNetworkReachabilityFlags flags, void* info) {
+  GRPCConnectivityStatus newStatus = CalculateConnectivityStatus(flags);
+
+  if (newStatus != currentStatus) {
+    [[NSNotificationCenter defaultCenter] postNotificationName:kGRPCConnectivityNotification
+                                                        object:nil];
+    currentStatus = newStatus;
+  }
+}
+
+@implementation GRPCConnectivityMonitor
+
++ (void)initialize {
+  if (self == [GRPCConnectivityMonitor self]) {
+    struct sockaddr_in addr = {0};
+    addr.sin_len = sizeof(addr);
+    addr.sin_family = AF_INET;
+    reachability = SCNetworkReachabilityCreateWithAddress(NULL, (struct sockaddr *)&addr);
+    currentStatus = GRPCConnectivityUnknown;
+
+    SCNetworkConnectionFlags flags;
+    if (SCNetworkReachabilityGetFlags(reachability, &flags)) {
+      currentStatus = CalculateConnectivityStatus(flags);
+    }
+
+    SCNetworkReachabilityContext context = {0, (__bridge void *)(self), NULL, NULL, NULL};
+    if (!SCNetworkReachabilitySetCallback(reachability, ReachabilityCallback, &context) ||
+        !SCNetworkReachabilityScheduleWithRunLoop(
+            reachability, CFRunLoopGetMain(), kCFRunLoopCommonModes)) {
+      NSLog(@"gRPC connectivity monitor fail to set");
+    }
+  }
+}
+
++ (void)registerObserver:(_Nonnull id)observer
+                selector:(SEL)selector {
+  [[NSNotificationCenter defaultCenter] addObserver:observer
+                                           selector:selector
+                                               name:kGRPCConnectivityNotification
+                                             object:nil];
+}
+
++ (void)unregisterObserver:(_Nonnull id)observer {
+  [[NSNotificationCenter defaultCenter] removeObserver:observer];
 }
 
 @end


### PR DESCRIPTION
Refactor connectivity monitor:
- Use a single global `SCNetworkReachability` callback to monitor network change
- Use `NSNotificationCenter` for broadcasting network change event

Change usage of connectivity monitor in `GRPCCall`
- Use the new connectivity monitor API
- Send UNAVAILABLE error to upper layer upon network change (this fixes #14220)
- Guarantees that `GRPCCall:finishWithError` is only called once

Besides that, also fixes a few places where weak `self` was directly used inside blocks instead of acquiring a strong ref. This may cause runtime error.

cc: @srini100 