### PR TITLE
Tweak Ruby Documents

### DIFF
--- a/src/ruby/lib/grpc/core/time_consts.rb
+++ b/src/ruby/lib/grpc/core/time_consts.rb
@@ -32,7 +32,7 @@ module GRPC
       # * timish == 0 => TimeConsts.ZERO
       #
       # @param timeish [Number|TimeSpec]
-      # @return timeish [Number|TimeSpec]
+      # @return [Number|TimeSpec]
       def from_relative_time(timeish)
         if timeish.is_a? TimeSpec
           timeish

--- a/src/ruby/lib/grpc/generic/bidi_call.rb
+++ b/src/ruby/lib/grpc/generic/bidi_call.rb
@@ -64,7 +64,7 @@ module GRPC
     # @param requests the Enumerable of requests to send
     # @param set_input_stream_done [Proc] called back when we're done
     #   reading the input stream
-    # @param set_input_stream_done [Proc] called back when we're done
+    # @param set_output_stream_done [Proc] called back when we're done
     #   sending data on the output stream
     # @return an Enumerator of requests to yield
     def run_on_client(requests,

--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -58,8 +58,8 @@ module GRPC
     # Minimally, a stub is created with the just the host of the gRPC service
     # it wishes to access, e.g.,
     #
-    # my_stub = ClientStub.new(example.host.com:50505,
-    #                          :this_channel_is_insecure)
+    #   my_stub = ClientStub.new(example.host.com:50505,
+    #                            :this_channel_is_insecure)
     #
     # If a channel_override argument is passed, it will be used as the
     # underlying channel. Otherwise, the channel_args argument will be used
@@ -376,7 +376,7 @@ module GRPC
     # This is a blocking call.
     #
     # * the call completes when the next call to provided block returns
-    # * [False]
+    #   false
     #
     # * the execution block parameters are two objects for sending and
     #   receiving responses, each of which blocks waiting for flow control.
@@ -398,13 +398,9 @@ module GRPC
     # responses by throwing StopIteration, but can only happen either
     # if bidi_call#writes_done is called.
     #
-    # To terminate the RPC correctly the block:
-    #
-    # * must call bidi#writes_done and then
-    #
-    #    * either return false as soon as there is no need for other responses
-    #
-    #    * loop on responses#next until no further responses are available
+    # To properly terminate the RPC, the responses should be completely iterated
+    # through; one way to do this is to loop on responses#next until no further
+    # responses are available.
     #
     # == Errors ==
     # An RuntimeError is raised if

--- a/src/ruby/lib/grpc/generic/interceptors.rb
+++ b/src/ruby/lib/grpc/generic/interceptors.rb
@@ -153,7 +153,7 @@ module GRPC
   #
   class InterceptionContext
     ##
-    # @param [Array<GRPC::Interceptor>]
+    # @param interceptors [Array<GRPC::Interceptor>]
     #
     def initialize(interceptors = [])
       @interceptors = interceptors.dup

--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -204,7 +204,7 @@ module GRPC
     # * connect_md_proc:
     # when non-nil is a proc for determining metadata to to send back the client
     # on receiving an invocation req.  The proc signature is:
-    # {key: val, ..} func(method_name, {key: val, ...})
+    #   {key: val, ..} func(method_name, {key: val, ...})
     #
     # * server_args:
     # A server arguments hash to be passed down to the underlying core server
@@ -283,7 +283,7 @@ module GRPC
     # If run has not been called, this returns immediately.
     #
     # @param timeout [Numeric] number of seconds to wait
-    # @result [true, false] true if the server is running, false otherwise
+    # @return [true, false] true if the server is running, false otherwise
     def wait_till_running(timeout = nil)
       @run_mutex.synchronize do
         @run_cond.wait(@run_mutex, timeout) if @running_state == :not_started


### PR DESCRIPTION
Hi ☀️ 
I found layout of [ruby documents](http://www.rubydoc.info/gems/grpc/GRPC%2FClientStub:initialize) is off.

## This PR does
* Fix collapsed layout of ruby document
* Fix yardoc warnings

## Collapsed layout of document

### 1
before:

<img width="717" alt="2018-02-27 15 11 47" src="https://user-images.githubusercontent.com/1286807/36713373-9ebbb56a-1bd0-11e8-905b-7657e7772bc5.png">

after:

<img width="508" alt="2018-02-27 15 19 40" src="https://user-images.githubusercontent.com/1286807/36713574-b2d7b084-1bd1-11e8-94fe-7015c0efb135.png">

### 2 

before:

<img width="525" alt="2018-02-27 15 17 56" src="https://user-images.githubusercontent.com/1286807/36713525-75c2580c-1bd1-11e8-88c1-f81a04d06ca0.png">

after:

<img width="576" alt="2018-02-27 15 21 54" src="https://user-images.githubusercontent.com/1286807/36713631-f8ba3586-1bd1-11e8-972a-3cb3a0927f56.png">

### 3

before: 

<img width="544" alt="2018-02-27 15 11 58" src="https://user-images.githubusercontent.com/1286807/36713379-a2fb35c4-1bd0-11e8-8b8d-0735aced1e7d.png">

after:

<img width="659" alt="2018-02-27 15 22 34" src="https://user-images.githubusercontent.com/1286807/36713659-0ee3ae96-1bd2-11e8-85e0-fbe8f9d54fb5.png">


## Warnings
```
[warn]: Invalid tag format for @return in file `lib/grpc/core/time_consts.rb` near line 36
[warn]: @param tag has duplicate parameter name: set_input_stream_done
    in file `lib/grpc/generic/bidi_call.rb' near line 70
[warn]: Unknown tag @result in file `lib/grpc/generic/rpc_server.rb` near line 287
[warn]: @param tag has unknown parameter name:
    in file `lib/grpc/generic/interceptors.rb' near line 158
[warn]: In file `lib/grpc/generic/rpc_server.rb':217: Cannot resolve link to key: from text:
        ...{key: val, ..}
[warn]: In file `lib/grpc/generic/rpc_server.rb':217:
Cannot resolve link to key: from text:
        ...{key: val, ..}
```