### PR TITLE
Remove build status indicator from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://grpc-testing.appspot.com/job/gRPC_master/badge/icon)](https://grpc-testing.appspot.com/job/gRPC_master)
-
 [gRPC - An RPC library and framework](http://github.com/grpc/grpc)
 ===================================
 


### PR DESCRIPTION
The image link is broken and reaches out to
Jenkins which is getting deprecated anyway.
Removing the indicator.