### PR TITLE
Compile gRPC Python extension as a C++ only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,9 +103,8 @@ ENABLE_DOCUMENTATION_BUILD = os.environ.get(
 EXTRA_ENV_COMPILE_ARGS = os.environ.get('GRPC_PYTHON_CFLAGS', None)
 EXTRA_ENV_LINK_ARGS = os.environ.get('GRPC_PYTHON_LDFLAGS', None)
 if EXTRA_ENV_COMPILE_ARGS is None:
-  EXTRA_ENV_COMPILE_ARGS = ''
+  EXTRA_ENV_COMPILE_ARGS = ' -std=c++11'
   if 'win32' in sys.platform and sys.version_info < (3, 5):
-    EXTRA_ENV_COMPILE_ARGS += ' -std=c++11'
     # We use define flags here and don't directly add to DEFINE_MACROS below to
     # ensure that the expert user/builder has a way of turning it off (via the
     # envvars) without adding yet more GRPC-specific envvars.
@@ -115,7 +114,7 @@ if EXTRA_ENV_COMPILE_ARGS is None:
     else:
       EXTRA_ENV_COMPILE_ARGS += ' -D_ftime=_ftime64 -D_timeb=__timeb64'
   elif "linux" in sys.platform:
-    EXTRA_ENV_COMPILE_ARGS += ' -std=c++11 -std=gnu99 -fvisibility=hidden -fno-wrapv -fno-exceptions'
+    EXTRA_ENV_COMPILE_ARGS += ' -fvisibility=hidden -fno-wrapv -fno-exceptions'
   elif "darwin" in sys.platform:
     EXTRA_ENV_COMPILE_ARGS += ' -fvisibility=hidden -fno-wrapv -fno-exceptions'
 
@@ -180,7 +179,7 @@ LDFLAGS = tuple(EXTRA_LINK_ARGS)
 CFLAGS = tuple(EXTRA_COMPILE_ARGS)
 if "linux" in sys.platform or "darwin" in sys.platform:
   pymodinit_type = 'PyObject*' if PY3 else 'void'
-  pymodinit = '__attribute__((visibility ("default"))) {}'.format(pymodinit_type)
+  pymodinit = 'extern "C" __attribute__((visibility ("default"))) {}'.format(pymodinit_type)
   DEFINE_MACROS += (('PyMODINIT_FUNC', pymodinit),)
   DEFINE_MACROS += (('GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK', 1),)
 

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -235,6 +235,7 @@ def try_cythonize(extensions, linetracing=False, mandatory=True):
         cython_compiler_directives['linetrace'] = True
     return Cython.Build.cythonize(
         extensions,
+        language="c++",
         include_path=[
             include_dir
             for extension in extensions
@@ -253,30 +254,6 @@ class BuildExt(build_ext.build_ext):
     LINK_OPTIONS = {}
 
     def build_extensions(self):
-        if "darwin" in sys.platform:
-            config = os.environ.get('CONFIG', 'opt')
-            target_path = os.path.abspath(
-                os.path.join(
-                    os.path.dirname(os.path.realpath(__file__)), '..', '..',
-                    '..', 'libs', config))
-            targets = [
-                os.path.join(target_path, 'libboringssl.a'),
-                os.path.join(target_path, 'libares.a'),
-                os.path.join(target_path, 'libgpr.a'),
-                os.path.join(target_path, 'libgrpc.a')
-            ]
-            make_process = subprocess.Popen(
-                ['make'] + targets,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
-            make_out, make_err = make_process.communicate()
-            if make_out and make_process.returncode != 0:
-                sys.stdout.write(str(make_out) + '\n')
-            if make_err:
-                sys.stderr.write(str(make_err) + '\n')
-            if make_process.returncode != 0:
-                raise Exception("make command failed!")
-
         compiler = self.compiler.compiler_type
         if compiler in BuildExt.C_OPTIONS:
             for extension in self.extensions:

--- a/src/python/grpcio/grpc/_cython/.gitignore
+++ b/src/python/grpcio/grpc/_cython/.gitignore
@@ -1,3 +1,4 @@
+cygrpc.cpp
 cygrpc.c
 *.a
 *.so

--- a/src/python/grpcio/grpc/_cython/cygrpc.pxd
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pxd
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# distutils: language=c++
+
 include "_cygrpc/grpc.pxi"
 
 include "_cygrpc/arguments.pxd.pxi"

--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# distutils: language=c++
+
 cimport cpython
 
 import pkg_resources


### PR DESCRIPTION
This fixes a temporary hack where we shelled out
to make on Mac (clang compiler) because it errored
passing gnu99 to a c++ compiler.