### PR TITLE
Workaround for h2_http_proxy_nosec_test.exe shutdown_finishes_calls flake

### DIFF
--- a/test/core/end2end/tests/shutdown_finishes_calls.cc
+++ b/test/core/end2end/tests/shutdown_finishes_calls.cc
@@ -150,6 +150,13 @@ static void test_early_server_shutdown_finishes_inflight_calls(
                                 nullptr);
   GPR_ASSERT(GRPC_CALL_OK == error);
 
+  /* Make sure we don't shutdown the server while HTTP/2 PING frames are still
+   * being exchanged on the newly established connection. It can lead to
+   * failures when testing with HTTP proxy. See
+   * https://github.com/grpc/grpc/issues/14471
+   */
+  gpr_sleep_until(n_seconds_from_now(1));
+
   /* shutdown and destroy the server */
   grpc_server_shutdown_and_notify(f.server, f.cq, tag(1000));
   grpc_server_cancel_all_calls(f.server);


### PR DESCRIPTION
Tentative fix for https://github.com/grpc/grpc/issues/14471.

- I've verified that is fixes the flake locally (I didn't get a single flake over thousands of runs and I was able to reproduce quite easily before).
- Is there a better way to fix? I believe I've diagnosed the problem correctly (see #14471 for analysis), but I'm not sure how a perfect fix would look like.
- Ideally we would only use the workaround for tests using http_proxy (not sure how to achieve that easily).