### PR TITLE
Revert "Add c-ares resolver tests against GCE DNS, using the unit test."

### DIFF
--- a/templates/test/cpp/naming/create_private_dns_zone.sh.template
+++ b/templates/test/cpp/naming/create_private_dns_zone.sh.template
@@ -1,4 +1,0 @@
-%YAML 1.2
---- |
-  <%namespace file="create_private_dns_zone_defs.include" import="*"/>\
-  ${create_private_dns_zone(resolver_gce_integration_tests_zone_id, resolver_tests_common_zone_name)}

--- a/templates/test/cpp/naming/private_dns_zone_init.sh.template
+++ b/templates/test/cpp/naming/private_dns_zone_init.sh.template
@@ -1,4 +1,0 @@
-%YAML 1.2
---- |
-  <%namespace file="private_dns_zone_init_defs.include" import="*"/>\
-  ${private_dns_zone_init(all_integration_test_records, resolver_gce_integration_tests_zone_id, resolver_tests_common_zone_name)}

--- a/templates/test/cpp/naming/resolver_gce_integration_tests_runner.sh.template
+++ b/templates/test/cpp/naming/resolver_gce_integration_tests_runner.sh.template
@@ -1,4 +1,0 @@
-%YAML 1.2
---- |
-  <%namespace file="resolver_gce_integration_tests_defs.include" import="*"/>\
-  ${resolver_gce_integration_tests(resolver_gce_integration_test_cases, all_integration_test_records, resolver_tests_common_zone_name)}

--- a/test/cpp/naming/gen_build_yaml.py
+++ b/test/cpp/naming/gen_build_yaml.py
@@ -24,12 +24,6 @@ import json
 
 _LOCAL_DNS_SERVER_ADDRESS = '127.0.0.1:15353'
 
-_TARGET_RECORDS_TO_SKIP_AGAINST_GCE = [
-  # TODO: enable this once able to upload the very large TXT record
-  # in this group to GCE DNS.
-  'ipv4-config-causing-fallback-to-tcp',
-]
-
 def _append_zone_name(name, zone_name):
   return '%s.%s' % (name, zone_name)
 
@@ -39,107 +33,21 @@ def _build_expected_addrs_cmd_arg(expected_addrs):
     out.append('%s,%s' % (addr['address'], str(addr['is_balancer'])))
   return ';'.join(out)
 
-def _data_for_type(r_type, r_data, common_zone_name):
-  if r_type in ['A', 'AAAA']:
-    return ' '.join(map(lambda x: '\"%s\"' % x, r_data))
-  if r_type == 'SRV':
-    assert len(r_data) == 1
-    target = r_data[0].split(' ')[3]
-    uploadable_target = '%s.%s' % (target, common_zone_name)
-    uploadable = r_data[0].split(' ')
-    uploadable[3] = uploadable_target
-    return '\"%s\"' % ' '.join(uploadable)
-  if r_type == 'TXT':
-    assert len(r_data) == 1
-    chunks = []
-    all_data = r_data[0]
-    cur = 0
-    # Split TXT records that span more than 255 characters (the single
-    # string length-limit in DNS) into multiple strings. Each string
-    # needs to be wrapped with double-quotes, and all inner double-quotes
-    # are escaped. The wrapping double-quotes and inner backslashes can be
-    # counted towards the 255 character length limit (as observed with gcloud),
-    # so make sure all strings fit within that limit.
-    while len(all_data[cur:]) > 0:
-      next_chunk = '\"'
-      while len(next_chunk) < 254 and len(all_data[cur:]) > 0:
-        if all_data[cur] == '\"':
-          if len(next_chunk) < 253:
-            next_chunk += '\\\"'
-          else:
-            break
-        else:
-          next_chunk += all_data[cur]
-        cur += 1
-      next_chunk += '\"'
-      if len(next_chunk) > 255:
-        raise Exception('Bug: next chunk is too long.')
-      chunks.append(next_chunk)
-    # Wrap the whole record in single quotes to make sure all strings
-    # are associated with the same TXT record (to make it one bash token for
-    # gcloud)
-    return '\'%s\'' % ' '.join(chunks)
-
-# Convert DNS records from their "within a test group" format
-# of the yaml file to an easier form for the templates to use.
-def _gcloud_uploadable_form(test_cases, common_zone_name):
-  out = []
-  for group in test_cases:
-    if group['record_to_resolve'] in _TARGET_RECORDS_TO_SKIP_AGAINST_GCE:
-      continue
-    for record_name in group['records'].keys():
-      r_ttl = None
-      all_r_data = {}
-      for r_data in group['records'][record_name]:
-        # enforce records have the same TTL only for simplicity
-        if r_ttl is None:
-          r_ttl = r_data['TTL']
-        assert r_ttl == r_data['TTL'], '%s and %s differ' % (r_ttl, r_data['TTL'])
-        r_type = r_data['type']
-        if all_r_data.get(r_type) is None:
-          all_r_data[r_type] = []
-        all_r_data[r_type].append(r_data['data'])
-      for r_type in all_r_data.keys():
-        for r in out:
-          assert r['name'] != record_name or r['type'] != r_type, 'attempt to add a duplicate record'
-        out.append({
-            'name': record_name,
-            'ttl': r_ttl,
-            'type': r_type,
-            'data': _data_for_type(r_type, all_r_data[r_type], common_zone_name)
-        })
-  return out
-
-def _gce_dns_zone_id(resolver_component_data):
-  dns_name = resolver_component_data['resolver_tests_common_zone_name']
-  return dns_name.replace('.', '-') + 'zone-id'
-
-def _resolver_test_cases(resolver_component_data, records_to_skip):
-  out = []
-  for test_case in resolver_component_data['resolver_component_tests']:
-    if test_case['record_to_resolve'] in records_to_skip:
-      continue
-    out.append({
-      'target_name': _append_zone_name(test_case['record_to_resolve'],
-                                       resolver_component_data['resolver_tests_common_zone_name']),
-      'expected_addrs': _build_expected_addrs_cmd_arg(test_case['expected_addrs']),
-      'expected_chosen_service_config': (test_case['expected_chosen_service_config'] or ''),
-      'expected_lb_policy': (test_case['expected_lb_policy'] or ''),
-    })
-  return out
-
 def main():
   resolver_component_data = ''
   with open('test/cpp/naming/resolver_test_record_groups.yaml') as f:
     resolver_component_data = yaml.load(f)
 
   json = {
-      'resolver_tests_common_zone_name': resolver_component_data['resolver_tests_common_zone_name'],
-      'resolver_gce_integration_tests_zone_id': _gce_dns_zone_id(resolver_component_data),
-      'all_integration_test_records': _gcloud_uploadable_form(resolver_component_data['resolver_component_tests'],
-                                                              resolver_component_data['resolver_tests_common_zone_name']),
-      'resolver_gce_integration_test_cases': _resolver_test_cases(resolver_component_data, _TARGET_RECORDS_TO_SKIP_AGAINST_GCE),
-      'resolver_component_test_cases': _resolver_test_cases(resolver_component_data, []),
+      'resolver_component_test_cases': [
+          {
+              'target_name': _append_zone_name(test_case['record_to_resolve'],
+                                                 resolver_component_data['resolver_component_tests_common_zone_name']),
+              'expected_addrs': _build_expected_addrs_cmd_arg(test_case['expected_addrs']),
+              'expected_chosen_service_config': (test_case['expected_chosen_service_config'] or ''),
+              'expected_lb_policy': (test_case['expected_lb_policy'] or ''),
+          } for test_case in resolver_component_data['resolver_component_tests']
+      ],
       'targets': [
           {
               'name': 'resolver_component_test' + unsecure_build_config_suffix,

--- a/test/cpp/naming/resolver_component_tests_runner.sh
+++ b/test/cpp/naming/resolver_component_tests_runner.sh
@@ -73,7 +73,7 @@ EXIT_CODE=0
 # in the resolver.
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-single-target.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv4-single-target.resolver-tests.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -81,7 +81,7 @@ $FLAGS_test_bin_path \
 wait "$!" || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-multi-target.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv4-multi-target.resolver-tests.grpctestingexp.' \
   --expected_addrs='1.2.3.5:1234,True;1.2.3.6:1234,True;1.2.3.7:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -89,7 +89,7 @@ $FLAGS_test_bin_path \
 wait "$!" || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-single-target.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv6-single-target.resolver-tests.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1001]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -97,7 +97,7 @@ $FLAGS_test_bin_path \
 wait "$!" || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-multi-target.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv6-multi-target.resolver-tests.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1003]:1234,True;[2607:f8b0:400a:801::1004]:1234,True' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -105,7 +105,7 @@ $FLAGS_test_bin_path \
 wait "$!" || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-simple-service-config.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv4-simple-service-config.resolver-tests.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -113,7 +113,7 @@ $FLAGS_test_bin_path \
 wait "$!" || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-no-srv-simple-service-config.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-no-srv-simple-service-config.resolver-tests.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -121,7 +121,7 @@ $FLAGS_test_bin_path \
 wait "$!" || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-no-config-for-cpp.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-no-config-for-cpp.resolver-tests.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -129,7 +129,7 @@ $FLAGS_test_bin_path \
 wait "$!" || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-cpp-config-has-zero-percentage.resolver-tests.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -137,7 +137,7 @@ $FLAGS_test_bin_path \
 wait "$!" || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-second-language-is-cpp.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-second-language-is-cpp.resolver-tests.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -145,7 +145,7 @@ $FLAGS_test_bin_path \
 wait "$!" || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-config-with-percentages.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-config-with-percentages.resolver-tests.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}' \
   --expected_lb_policy='round_robin' \
@@ -153,7 +153,7 @@ $FLAGS_test_bin_path \
 wait "$!" || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv4-target-has-backend-and-balancer.resolver-tests.grpctestingexp.' \
   --expected_addrs='1.2.3.4:1234,True;1.2.3.4:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -161,7 +161,7 @@ $FLAGS_test_bin_path \
 wait "$!" || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='srv-ipv6-target-has-backend-and-balancer.resolver-tests.grpctestingexp.' \
   --expected_addrs='[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1002]:443,False' \
   --expected_chosen_service_config='' \
   --expected_lb_policy='' \
@@ -169,7 +169,7 @@ $FLAGS_test_bin_path \
 wait "$!" || EXIT_CODE=1
 
 $FLAGS_test_bin_path \
-  --target_name='ipv4-config-causing-fallback-to-tcp.resolver-tests-version-4.grpctestingexp.' \
+  --target_name='ipv4-config-causing-fallback-to-tcp.resolver-tests.grpctestingexp.' \
   --expected_addrs='1.2.3.4:443,False' \
   --expected_chosen_service_config='{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}' \
   --expected_lb_policy='' \

--- a/test/cpp/naming/resolver_test_record_groups.yaml
+++ b/test/cpp/naming/resolver_test_record_groups.yaml
@@ -1,4 +1,4 @@
-resolver_tests_common_zone_name: resolver-tests-version-4.grpctestingexp.
+resolver_component_tests_common_zone_name: resolver-tests.grpctestingexp.
 resolver_component_tests:
 - expected_addrs:
   - {address: '1.2.3.4:1234', is_balancer: true}

--- a/test/cpp/naming/test_dns_server.py
+++ b/test/cpp/naming/test_dns_server.py
@@ -66,7 +66,7 @@ def start_local_dns_server(args):
 
   with open(args.records_config_path) as config:
     test_records_config = yaml.load(config)
-  common_zone_name = test_records_config['resolver_tests_common_zone_name']
+  common_zone_name = test_records_config['resolver_component_tests_common_zone_name']
   for group in test_records_config['resolver_component_tests']:
     for name in group['records'].keys():
       for record in group['records'][name]:


### PR DESCRIPTION
This reverts commit 9e3a76ba717baf185918acb86871ae27b7810dbc.

This was generated by running `git revert 9e3a76ba717baf185918acb86871ae27b7810dbc` - the only manually solved conflict was in `test/cpp/naming/resolver_test_record_groups.yaml` (I got rid of the version number in the common DNS zone name, since without the GCE DNS tests it's no longer needed because they'll only be used in a hermetic environment).