### PR TITLE
Get rid of C# connectivity watcher task

### DIFF
--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -44,8 +44,6 @@ namespace Grpc.Core
         readonly ChannelSafeHandle handle;
         readonly Dictionary<string, ChannelOption> options;
 
-        readonly Task connectivityWatcherTask;
-
         bool shutdownRequested;
 
         /// <summary>
@@ -86,9 +84,6 @@ namespace Grpc.Core
                     this.handle = ChannelSafeHandle.CreateInsecure(target, nativeChannelArgs);
                 }
             }
-            // TODO(jtattermusch): Workaround for https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/822.
-            // Remove once retries are supported in C core
-            this.connectivityWatcherTask = RunConnectivityWatcherAsync();
             GrpcEnvironment.RegisterChannel(this);
         }
 
@@ -250,7 +245,7 @@ namespace Grpc.Core
                 handle.Dispose();
             }
 
-            await Task.WhenAll(GrpcEnvironment.ReleaseAsync(), connectivityWatcherTask).ConfigureAwait(false);
+            await GrpcEnvironment.ReleaseAsync().ConfigureAwait(false);
         }
 
         internal ChannelSafeHandle Handle
@@ -305,34 +300,6 @@ namespace Grpc.Core
             catch (ObjectDisposedException)
             {
                 return ChannelState.Shutdown;
-            }
-        }
-
-        /// <summary>
-        /// Constantly Watches channel connectivity status to work around https://github.com/GoogleCloudPlatform/google-cloud-dotnet/issues/822
-        /// </summary>
-        private async Task RunConnectivityWatcherAsync()
-        {
-            try
-            {
-                var lastState = State;
-                while (lastState != ChannelState.Shutdown)
-                {
-                    lock (myLock)
-                    {
-                        if (shutdownRequested)
-                        {
-                            break;
-                        }
-                    }
-
-                    // ignore the result
-                    await WaitForStateChangedInternalAsync(lastState, DateTime.UtcNow.AddSeconds(1)).ConfigureAwait(false);
-                    lastState = State;
-                }
-            }
-            catch (ObjectDisposedException) {
-                // during shutdown, channel is going to be disposed.
             }
         }
 


### PR DESCRIPTION
Get rid of the workaround introduced in https://github.com/grpc/grpc/pull/11021.

The workaround is no longer necessary (after https://github.com/grpc/grpc/pull/12732)

Related: https://github.com/grpc/grpc/pull/14448