### PR TITLE
grpc-objc: Support IPv6 addresses with a zone-id

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -161,6 +161,11 @@ static NSString * const kBearerPrefix = @"Bearer ";
     [NSException raise:NSInvalidArgumentException
                 format:@"The requests writer can't be already started."];
   }
+  NSString *check_host = [NSURL URLWithString:[@"https://" stringByAppendingString:host]].host;
+  if (!check_host) {
+    [NSException raise:NSInvalidArgumentException format:@"host of %@ is nil", host];
+  }
+
   if ((self = [super init])) {
     _host = [host copy];
     _path = [path copy];
@@ -469,12 +474,6 @@ static NSString * const kBearerPrefix = @"Bearer ";
   [self sendHeaders:_requestHeaders];
   [self invokeCall];
 
-  // TODO(jcanizales): Extract this logic somewhere common.
-  NSString *host = [NSURL URLWithString:[@"https://" stringByAppendingString:_host]].host;
-  if (!host) {
-    // TODO(jcanizales): Check this on init.
-    [NSException raise:NSInvalidArgumentException format:@"host of %@ is nil", _host];
-  }
   [GRPCConnectivityMonitor registerObserver:self
                                    selector:@selector(connectivityChanged:)];
 }

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -163,7 +163,9 @@ static NSString * const kBearerPrefix = @"Bearer ";
   }
   NSString *check_host = [NSURL URLWithString:[@"https://" stringByAppendingString:host]].host;
   if (!check_host) {
-    [NSException raise:NSInvalidArgumentException format:@"host of %@ is nil", host];
+    if (host.length == 0) {
+      [NSException raise:NSInvalidArgumentException format:@"host of %@ is nil or empty", host];
+    }
   }
 
   if ((self = [super init])) {

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -65,6 +65,28 @@ static NSMutableDictionary *kHostCache;
   NSURL *hostURL = [NSURL URLWithString:[@"https://" stringByAppendingString:address]];
   if (hostURL.host && !hostURL.port) {
     address = [hostURL.host stringByAppendingString:@":443"];
+  } else if (!hostURL) {
+    // NSURL failed to parse the address. It probably has a `%` in it (denoting IPv6 zone-id).
+    // Connectivity monitor happens per host.
+    char *chost = NULL, *cport = NULL;
+    if (gpr_split_host_port(address.UTF8String, &chost, &cport)) {
+      return nil;
+    }
+    char *caddr = NULL;
+    if (!cport) {
+      if (gpr_join_host_port(caddr, chost, 443) == -1) {
+        gpr_free(chost);
+        return nil;
+      }
+    } else {
+      caddr = chost;
+    }
+    address = [[NSString alloc] initWithCString:caddr encoding:NSUTF8StringEncoding];
+    if (caddr != chost) {
+      gpr_free(caddr);
+    }
+    gpr_free(chost);
+    gpr_free(cport);
   }
 
   // Look up the GRPCHost in the cache.

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -78,11 +78,7 @@ static NSMutableDictionary *kHostCache;
         gpr_free(chost);
         return nil;
       }
-    } else {
-      caddr = chost;
-    }
-    address = [[NSString alloc] initWithCString:caddr encoding:NSUTF8StringEncoding];
-    if (caddr != chost) {
+      address = [[NSString alloc] initWithCString:caddr encoding:NSUTF8StringEncoding];
       gpr_free(caddr);
     }
     gpr_free(chost);

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -69,7 +69,7 @@ static NSMutableDictionary *kHostCache;
     // NSURL failed to parse the address. It probably has a `%` in it (denoting IPv6 zone-id).
     // Connectivity monitor happens per host.
     char *chost = NULL, *cport = NULL;
-    if (gpr_split_host_port(address.UTF8String, &chost, &cport)) {
+    if (!gpr_split_host_port(address.UTF8String, &chost, &cport)) {
       return nil;
     }
     char *caddr = NULL;


### PR DESCRIPTION
The objective-c layer crashes when you try to call to a host via its
IPv6 link-local address (which must contain a zone-id denoted by `%`).
NSURL does not handle % in hostnames correctly. Use gpr_split_host_port
if NSURL fails.

Resolves #14369