### PR TITLE
Remove hostname extraction for ConnectivityMonitor

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -469,12 +469,6 @@ static NSString * const kBearerPrefix = @"Bearer ";
   [self sendHeaders:_requestHeaders];
   [self invokeCall];
 
-  // TODO(jcanizales): Extract this logic somewhere common.
-  NSString *host = [NSURL URLWithString:[@"https://" stringByAppendingString:_host]].host;
-  if (!host) {
-    // TODO(jcanizales): Check this on init.
-    [NSException raise:NSInvalidArgumentException format:@"host of %@ is nil", _host];
-  }
   [GRPCConnectivityMonitor registerObserver:self
                                    selector:@selector(connectivityChanged:)];
 }


### PR DESCRIPTION
`ConnectivityMonitor` has been refactored in #14529 and no longer requires host string to be extracted. 