### PR TITLE
Update Dockerfiles for python artifacts to use latest git version

### DIFF
--- a/tools/dockerfile/grpc_artifact_python_manylinux_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux_x64/Dockerfile
@@ -18,6 +18,7 @@ FROM quay.io/pypa/manylinux1_x86_64
 
 # Update the package manager
 RUN yum update -y
+RUN yum install -y curl-devel expat-devel gettext-devel linux-headers openssl-devel zlib-devel gcc
 
 ###################################
 # Install Python build requirements

--- a/tools/dockerfile/grpc_artifact_python_manylinux_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux_x64/Dockerfile
@@ -19,19 +19,6 @@ FROM quay.io/pypa/manylinux1_x86_64
 # Update the package manager
 RUN yum update -y
 
-#############################################################
-# Update Git to allow cloning submodules with --reference arg
-RUN yum remove -y git
-RUN yum install -y curl-devel expat-devel gettext-devel linux-headers openssl-devel zlib-devel gcc
-RUN cd /usr/src && \
-  curl -O -L https://kernel.org/pub/software/scm/git/git-2.0.5.tar.gz && \
-  tar xzf git-2.0.5.tar.gz
-RUN cd /usr/src/git-2.0.5 && \
-  make prefix=/usr/local/git all && \
-  make prefix=/usr/local/git install
-ENV PATH /usr/local/git/bin:$PATH
-RUN source /etc/bashrc
-
 ###################################
 # Install Python build requirements
 RUN /opt/python/cp27-cp27m/bin/pip install cython

--- a/tools/dockerfile/grpc_artifact_python_manylinux_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux_x86/Dockerfile
@@ -19,19 +19,6 @@ FROM quay.io/pypa/manylinux1_i686
 # Update the package manager
 RUN yum update -y
 
-#############################################################
-# Update Git to allow cloning submodules with --reference arg
-RUN yum remove -y git
-RUN yum install -y curl-devel expat-devel gettext-devel linux-headers openssl-devel zlib-devel gcc
-RUN cd /usr/src && \
-  curl -O -L https://kernel.org/pub/software/scm/git/git-2.0.5.tar.gz && \
-  tar xzf git-2.0.5.tar.gz
-RUN cd /usr/src/git-2.0.5 && \
-  make prefix=/usr/local/git all && \
-  make prefix=/usr/local/git install
-ENV PATH /usr/local/git/bin:$PATH
-RUN source /etc/bashrc
-
 ###################################
 # Install Python build requirements
 RUN /opt/python/cp27-cp27m/bin/pip install cython

--- a/tools/dockerfile/grpc_artifact_python_manylinux_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux_x86/Dockerfile
@@ -18,6 +18,7 @@ FROM quay.io/pypa/manylinux1_i686
 
 # Update the package manager
 RUN yum update -y
+RUN yum install -y curl-devel expat-devel gettext-devel linux-headers openssl-devel zlib-devel gcc
 
 ###################################
 # Install Python build requirements


### PR DESCRIPTION
Due to a recent change (Feb 2018) in Github's policy to discontinue support for weak cryptographic standards, older git versions stopped working with Github repositories. The Dockerfiles for building python artifacts currently uses git 2.0.5, that fails with an error `tlsv1 alert protocol version`.

The CentOS image by the latest source Dockerfile, `manylinux` comes with the latest version of git as well, removing the need to manually build git from source.