### PR TITLE
Missing HOST_LDLIBSXX in Makefile.template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -442,6 +442,7 @@ HOST_CFLAGS = $(CFLAGS)
 HOST_CXXFLAGS = $(CXXFLAGS)
 HOST_LDFLAGS = $(LDFLAGS)
 HOST_LDLIBS = $(LDLIBS)
+HOST_LDLIBSXX = $(LDLIBSXX)
 
 # These are automatically computed variables.
 # There shouldn't be any need to change anything from now on.

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -322,6 +322,7 @@
   HOST_CXXFLAGS = $(CXXFLAGS)
   HOST_LDFLAGS = $(LDFLAGS)
   HOST_LDLIBS = $(LDLIBS)
+  HOST_LDLIBSXX = $(LDLIBSXX)
 
   # These are automatically computed variables.
   # There shouldn't be any need to change anything from now on.


### PR DESCRIPTION
HOST_LDLIBSXX is used for the grpc plugins.