### PR TITLE
Build with stack frame size limits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ CC_opt = $(DEFAULT_CC)
 CXX_opt = $(DEFAULT_CXX)
 LD_opt = $(DEFAULT_CC)
 LDXX_opt = $(DEFAULT_CXX)
-CPPFLAGS_opt = -O2
+CPPFLAGS_opt = -O2 -Wframe-larger-than=16384
 DEFINES_opt = NDEBUG
 
 VALID_CONFIG_asan-trace-cmp = 1
@@ -148,7 +148,7 @@ CXX_noexcept = $(DEFAULT_CXX)
 LD_noexcept = $(DEFAULT_CC)
 LDXX_noexcept = $(DEFAULT_CXX)
 CXXFLAGS_noexcept = -fno-exceptions
-CPPFLAGS_noexcept = -O2
+CPPFLAGS_noexcept = -O2 -Wframe-larger-than=16384
 DEFINES_noexcept = NDEBUG
 
 VALID_CONFIG_ubsan = 1

--- a/build.yaml
+++ b/build.yaml
@@ -5128,11 +5128,11 @@ configs:
     DEFINES: NDEBUG
     LDFLAGS: -rdynamic
   noexcept:
-    CPPFLAGS: -O2
+    CPPFLAGS: -O2 -Wframe-larger-than=16384
     CXXFLAGS: -fno-exceptions
     DEFINES: NDEBUG
   opt:
-    CPPFLAGS: -O2
+    CPPFLAGS: -O2 -Wframe-larger-than=16384
     DEFINES: NDEBUG
   stapprof:
     CPPFLAGS: -O2 -DGRPC_STAP_PROFILER

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -34,6 +34,7 @@
       'Release': {
         'cflags': [
           '-O2',
+          '-Wframe-larger-than=16384',
         ],
         'defines': [
           'NDEBUG',

--- a/test/core/debug/stats_test.cc
+++ b/test/core/debug/stats_test.cc
@@ -47,22 +47,22 @@ class Snapshot {
 
 TEST(StatsTest, IncCounters) {
   for (int i = 0; i < GRPC_STATS_COUNTER_COUNT; i++) {
-    Snapshot snapshot;
+    std::unique_ptr<Snapshot> snapshot(new Snapshot);
 
     grpc_core::ExecCtx exec_ctx;
     GRPC_STATS_INC_COUNTER((grpc_stats_counters)i);
 
-    EXPECT_EQ(snapshot.delta().counters[i], 1);
+    EXPECT_EQ(snapshot->delta().counters[i], 1);
   }
 }
 
 TEST(StatsTest, IncSpecificCounter) {
-  Snapshot snapshot;
+  std::unique_ptr<Snapshot> snapshot(new Snapshot);
 
   grpc_core::ExecCtx exec_ctx;
   GRPC_STATS_INC_SYSCALL_POLL();
 
-  EXPECT_EQ(snapshot.delta().counters[GRPC_STATS_COUNTER_SYSCALL_POLL], 1);
+  EXPECT_EQ(snapshot->delta().counters[GRPC_STATS_COUNTER_SYSCALL_POLL], 1);
 }
 
 static int FindExpectedBucket(int i, int j) {
@@ -90,12 +90,12 @@ TEST_P(HistogramTest, IncHistogram) {
     gpr_log(GPR_DEBUG, "expected_bucket:%d nvalues=%" PRIdPTR, expected_bucket,
             test_values.size());
     for (auto j : test_values) {
-      Snapshot snapshot;
+      std::unique_ptr<Snapshot> snapshot(new Snapshot);
 
       grpc_core::ExecCtx exec_ctx;
       grpc_stats_inc_histogram[kHistogram](j);
 
-      auto delta = snapshot.delta();
+      auto delta = snapshot->delta();
 
       EXPECT_EQ(
           delta

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -143,3 +143,10 @@ grpc_cc_binary(
     srcs = ["bm_metadata.cc"],
     deps = [":helpers"],
 )
+
+grpc_cc_binary(
+    name = "bm_chttp2_hpack",
+    testonly = 1,
+    srcs = ["bm_chttp2_hpack.cc"],
+    deps = [":helpers"],
+)

--- a/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
@@ -18,9 +18,11 @@
 
 /* Microbenchmarks around CHTTP2 HPACK operations */
 
+#include <benchmark/benchmark.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <string.h>
+#include <memory>
 #include <sstream>
 
 #include "src/core/ext/transport/chttp2/transport/hpack_encoder.h"
@@ -31,7 +33,6 @@
 #include "src/core/lib/transport/timeout_encoding.h"
 
 #include "test/cpp/microbenchmarks/helpers.h"
-#include "third_party/benchmark/include/benchmark/benchmark.h"
 
 auto& force_library_initialization = Library::get();
 
@@ -51,10 +52,11 @@ static grpc_slice MakeSlice(std::vector<uint8_t> bytes) {
 static void BM_HpackEncoderInitDestroy(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::ExecCtx exec_ctx;
-  grpc_chttp2_hpack_compressor c;
+  std::unique_ptr<grpc_chttp2_hpack_compressor> c(
+      new grpc_chttp2_hpack_compressor);
   while (state.KeepRunning()) {
-    grpc_chttp2_hpack_compressor_init(&c);
-    grpc_chttp2_hpack_compressor_destroy(&c);
+    grpc_chttp2_hpack_compressor_init(c.get());
+    grpc_chttp2_hpack_compressor_destroy(c.get());
     grpc_core::ExecCtx::Get()->Flush();
   }
 
@@ -71,8 +73,9 @@ static void BM_HpackEncoderEncodeDeadline(benchmark::State& state) {
   grpc_metadata_batch_init(&b);
   b.deadline = saved_now + 30 * 1000;
 
-  grpc_chttp2_hpack_compressor c;
-  grpc_chttp2_hpack_compressor_init(&c);
+  std::unique_ptr<grpc_chttp2_hpack_compressor> c(
+      new grpc_chttp2_hpack_compressor);
+  grpc_chttp2_hpack_compressor_init(c.get());
   grpc_transport_one_way_stats stats;
   memset(&stats, 0, sizeof(stats));
   grpc_slice_buffer outbuf;
@@ -85,12 +88,12 @@ static void BM_HpackEncoderEncodeDeadline(benchmark::State& state) {
         static_cast<size_t>(1024),
         &stats,
     };
-    grpc_chttp2_encode_header(&c, nullptr, 0, &b, &hopt, &outbuf);
+    grpc_chttp2_encode_header(c.get(), nullptr, 0, &b, &hopt, &outbuf);
     grpc_slice_buffer_reset_and_unref_internal(&outbuf);
     grpc_core::ExecCtx::Get()->Flush();
   }
   grpc_metadata_batch_destroy(&b);
-  grpc_chttp2_hpack_compressor_destroy(&c);
+  grpc_chttp2_hpack_compressor_destroy(c.get());
   grpc_slice_buffer_destroy_internal(&outbuf);
 
   std::ostringstream label;
@@ -120,8 +123,9 @@ static void BM_HpackEncoderEncodeHeader(benchmark::State& state) {
         "addmd", grpc_metadata_batch_add_tail(&b, &storage[i], elems[i])));
   }
 
-  grpc_chttp2_hpack_compressor c;
-  grpc_chttp2_hpack_compressor_init(&c);
+  std::unique_ptr<grpc_chttp2_hpack_compressor> c(
+      new grpc_chttp2_hpack_compressor);
+  grpc_chttp2_hpack_compressor_init(c.get());
   grpc_transport_one_way_stats stats;
   memset(&stats, 0, sizeof(stats));
   grpc_slice_buffer outbuf;
@@ -134,7 +138,7 @@ static void BM_HpackEncoderEncodeHeader(benchmark::State& state) {
         static_cast<size_t>(state.range(1)),
         &stats,
     };
-    grpc_chttp2_encode_header(&c, nullptr, 0, &b, &hopt, &outbuf);
+    grpc_chttp2_encode_header(c.get(), nullptr, 0, &b, &hopt, &outbuf);
     if (!logged_representative_output && state.iterations() > 3) {
       logged_representative_output = true;
       for (size_t i = 0; i < outbuf.count; i++) {
@@ -147,7 +151,7 @@ static void BM_HpackEncoderEncodeHeader(benchmark::State& state) {
     grpc_core::ExecCtx::Get()->Flush();
   }
   grpc_metadata_batch_destroy(&b);
-  grpc_chttp2_hpack_compressor_destroy(&c);
+  grpc_chttp2_hpack_compressor_destroy(c.get());
   grpc_slice_buffer_destroy_internal(&outbuf);
 
   std::ostringstream label;

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -1,5 +1,6 @@
 build --client_env=CC=clang
 build --copt -DGRPC_BAZEL_BUILD
+build --copt -Wframe-larger-than=16384
 
 build:asan --strip=never
 build:asan --copt -fsanitize-coverage=edge


### PR DESCRIPTION
We've had to make last-minute changes over this issue several times in the past, so let's go ahead and put in the limit here itself. This is only used on opt builds (not dbg) since dbg builds use excess stack space and opt builds are actually representative of production use where this issue actually arises.