### PR TITLE
Add rpath to plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -821,6 +821,9 @@ endif
 LIBS_PROTOBUF = protobuf
 LIBS_PROTOC = protoc protobuf
 
+ifneq ($(LDFLAGS_PROTOBUF_PKG_CONFIG),)
+HOST_LDLIBS_PROTOC += $(shell $(PKG_CONFIG) --libs-only-L protobuf | sed s/L/Wl,-rpath,/)
+endif
 HOST_LDLIBS_PROTOC += $(addprefix -l, $(LIBS_PROTOC))
 
 ifeq ($(PROTOBUF_PKG_CONFIG),true)

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -740,6 +740,9 @@
   LIBS_PROTOBUF = protobuf
   LIBS_PROTOC = protoc protobuf
 
+  ifneq ($(LDFLAGS_PROTOBUF_PKG_CONFIG),)
+  HOST_LDLIBS_PROTOC += $(shell $(PKG_CONFIG) --libs-only-L protobuf | sed s/L/Wl,-rpath,/)
+  endif
   HOST_LDLIBS_PROTOC += $(addprefix -l, $(LIBS_PROTOC))
 
   ifeq ($(PROTOBUF_PKG_CONFIG),true)


### PR DESCRIPTION
If grpc is installed in a directory that is not in the dynamic library paths (/etc/ld.so.conf.d or exporting LD_LIBRARY_PATH) the plugin will complain about `libprotoc` and `libprotobuf` libraries not found.

```
/path/to/bin/grpc_cpp_plugin: error while loading shared libraries: libprotoc.so.15: cannot open shared object file: No such file or directory
```
This patch fixes this by adding the rpath.