### PR TITLE
Only increase strike once

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1711,7 +1711,6 @@ static void send_goaway(grpc_chttp2_transport* t, grpc_error* error) {
 }
 
 void grpc_chttp2_add_ping_strike(grpc_chttp2_transport* t) {
-  t->ping_recv_state.ping_strikes++;
   if (++t->ping_recv_state.ping_strikes > t->ping_policy.max_ping_strikes &&
       t->ping_policy.max_ping_strikes != 0) {
     send_goaway(t,

--- a/test/core/end2end/tests/bad_ping.cc
+++ b/test/core/end2end/tests/bad_ping.cc
@@ -155,14 +155,15 @@ static void test_bad_ping(grpc_end2end_test_config config) {
   cq_verify(cqv);
 
   // Send too many pings to the server to trigger the punishment:
-  // Each ping will trigger a ping strike, and we need at least MAX_PING_STRIKES
-  // strikes to trigger the punishment. So (MAX_PING_STRIKES + 1) pings are
+  // The first ping will let server mark its last_recv time. Afterwards, each
+  // ping will trigger a ping strike, and we need at least MAX_PING_STRIKES
+  // strikes to trigger the punishment. So (MAX_PING_STRIKES + 2) pings are
   // needed here.
   int i;
-  for (i = 1; i <= MAX_PING_STRIKES + 1; i++) {
+  for (i = 1; i <= MAX_PING_STRIKES + 2; i++) {
     grpc_channel_ping(f.client, f.cq, tag(200 + i), nullptr);
     CQ_EXPECT_COMPLETION(cqv, tag(200 + i), 1);
-    if (i == MAX_PING_STRIKES + 1) {
+    if (i == MAX_PING_STRIKES + 2) {
       CQ_EXPECT_COMPLETION(cqv, tag(1), 1);
     }
     cq_verify(cqv);


### PR DESCRIPTION
The bad_ping test previously depended on the broken behavior. We need MAX_STRIKE + 2 to trigger the server goaway because the first one will only mark the recv_ping timestamp and would not be counted as a strike.