### PR TITLE
Optimize blocking intercepted response-unary calls

### DIFF
--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -134,6 +134,58 @@ class _LocalFailure(grpc.RpcError, grpc.Future, grpc.Call):
         raise self._exception
 
 
+class _UnaryOutcome(grpc.Call, grpc.Future):
+
+    def __init__(self, response, call):
+        self._response = response
+        self._call = call
+
+    def initial_metadata(self):
+        return self._call.initial_metadata()
+
+    def trailing_metadata(self):
+        return self._call.trailing_metadata()
+
+    def code(self):
+        return self._call.code()
+
+    def details(self):
+        return self._call.details()
+
+    def is_active(self):
+        return self._call.is_active()
+
+    def time_remaining(self):
+        return self._call.time_remaining()
+
+    def cancel(self):
+        return self._call.cancel()
+
+    def add_callback(self, callback):
+        return self._call.add_callback(callback)
+
+    def cancelled(self):
+        return False
+
+    def running(self):
+        return False
+
+    def done(self):
+        return True
+
+    def result(self, ignored_timeout=None):
+        return self._response
+
+    def exception(self, ignored_timeout=None):
+        return None
+
+    def traceback(self, ignored_timeout=None):
+        return None
+
+    def add_done_callback(self, fn):
+        fn(self)
+
+
 class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
 
     def __init__(self, thunk, method, interceptor):
@@ -142,23 +194,35 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
         self._interceptor = interceptor
 
     def __call__(self, request, timeout=None, metadata=None, credentials=None):
-        call_future = self.future(
+        response, ignored_call = self.with_call(
             request,
             timeout=timeout,
             metadata=metadata,
             credentials=credentials)
-        return call_future.result()
+        return response
 
     def with_call(self, request, timeout=None, metadata=None, credentials=None):
-        call_future = self.future(
-            request,
-            timeout=timeout,
-            metadata=metadata,
-            credentials=credentials)
+        client_call_details = _ClientCallDetails(self._method, timeout,
+                                                 metadata, credentials)
+
+        def continuation(new_details, request):
+            new_method, new_timeout, new_metadata, new_credentials = (
+                _unwrap_client_call_details(new_details, client_call_details))
+            try:
+                response, call = self._thunk(new_method).with_call(
+                    request,
+                    timeout=new_timeout,
+                    metadata=new_metadata,
+                    credentials=new_credentials)
+                return _UnaryOutcome(response, call)
+            except Exception as exception:  # pylint:disable=broad-except
+                return _LocalFailure(exception, sys.exc_info()[2])
+
+        call_future = self._interceptor.intercept_unary_unary(
+            continuation, client_call_details, request)
         return call_future.result(), call_future
 
     def future(self, request, timeout=None, metadata=None, credentials=None):
-
         client_call_details = _ClientCallDetails(self._method, timeout,
                                                  metadata, credentials)
 

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -194,7 +194,7 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
         self._interceptor = interceptor
 
     def __call__(self, request, timeout=None, metadata=None, credentials=None):
-        response, ignored_call = self.with_call(
+        response, ignored_call = self._with_call(
             request,
             timeout=timeout,
             metadata=metadata,
@@ -202,6 +202,14 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
         return response
 
     def with_call(self, request, timeout=None, metadata=None, credentials=None):
+        return self._with_call(
+            request,
+            timeout=timeout,
+            metadata=metadata,
+            credentials=credentials)
+
+    def _with_call(self, request, timeout=None, metadata=None,
+                   credentials=None):
         client_call_details = _ClientCallDetails(self._method, timeout,
                                                  metadata, credentials)
 
@@ -283,7 +291,7 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
                  timeout=None,
                  metadata=None,
                  credentials=None):
-        response, ignored_call = self.with_call(
+        response, ignored_call = self._with_call(
             request_iterator,
             timeout=timeout,
             metadata=metadata,
@@ -295,6 +303,17 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
                   timeout=None,
                   metadata=None,
                   credentials=None):
+        return self._with_call(
+            request_iterator,
+            timeout=timeout,
+            metadata=metadata,
+            credentials=credentials)
+
+    def _with_call(self,
+                   request_iterator,
+                   timeout=None,
+                   metadata=None,
+                   credentials=None):
         client_call_details = _ClientCallDetails(self._method, timeout,
                                                  metadata, credentials)
 

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -201,13 +201,6 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
             credentials=credentials)
         return response
 
-    def with_call(self, request, timeout=None, metadata=None, credentials=None):
-        return self._with_call(
-            request,
-            timeout=timeout,
-            metadata=metadata,
-            credentials=credentials)
-
     def _with_call(self, request, timeout=None, metadata=None,
                    credentials=None):
         client_call_details = _ClientCallDetails(self._method, timeout,
@@ -231,6 +224,13 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
         call = self._interceptor.intercept_unary_unary(
             continuation, client_call_details, request)
         return call.result(), call
+
+    def with_call(self, request, timeout=None, metadata=None, credentials=None):
+        return self._with_call(
+            request,
+            timeout=timeout,
+            metadata=metadata,
+            credentials=credentials)
 
     def future(self, request, timeout=None, metadata=None, credentials=None):
         client_call_details = _ClientCallDetails(self._method, timeout,
@@ -298,17 +298,6 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
             credentials=credentials)
         return response
 
-    def with_call(self,
-                  request_iterator,
-                  timeout=None,
-                  metadata=None,
-                  credentials=None):
-        return self._with_call(
-            request_iterator,
-            timeout=timeout,
-            metadata=metadata,
-            credentials=credentials)
-
     def _with_call(self,
                    request_iterator,
                    timeout=None,
@@ -335,6 +324,17 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
         call = self._interceptor.intercept_stream_unary(
             continuation, client_call_details, request_iterator)
         return call.result(), call
+
+    def with_call(self,
+                  request_iterator,
+                  timeout=None,
+                  metadata=None,
+                  credentials=None):
+        return self._with_call(
+            request_iterator,
+            timeout=timeout,
+            metadata=metadata,
+            credentials=credentials)
 
     def future(self,
                request_iterator,

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -75,10 +75,10 @@ def _unwrap_client_call_details(call_details, default_details):
     return method, timeout, metadata, credentials
 
 
-class _LocalFailure(grpc.RpcError, grpc.Future, grpc.Call):
+class _FailureOutcome(grpc.RpcError, grpc.Future, grpc.Call):
 
     def __init__(self, exception, traceback):
-        super(_LocalFailure, self).__init__()
+        super(_FailureOutcome, self).__init__()
         self._exception = exception
         self._traceback = traceback
 
@@ -216,7 +216,7 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
                     credentials=new_credentials)
                 return _UnaryOutcome(response, call)
             except Exception as exception:  # pylint:disable=broad-except
-                return _LocalFailure(exception, sys.exc_info()[2])
+                return _FailureOutcome(exception, sys.exc_info()[2])
 
         call = self._interceptor.intercept_unary_unary(
             continuation, client_call_details, request)
@@ -239,7 +239,7 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
             return self._interceptor.intercept_unary_unary(
                 continuation, client_call_details, request)
         except Exception as exception:  # pylint:disable=broad-except
-            return _LocalFailure(exception, sys.exc_info()[2])
+            return _FailureOutcome(exception, sys.exc_info()[2])
 
 
 class _UnaryStreamMultiCallable(grpc.UnaryStreamMultiCallable):
@@ -266,7 +266,7 @@ class _UnaryStreamMultiCallable(grpc.UnaryStreamMultiCallable):
             return self._interceptor.intercept_unary_stream(
                 continuation, client_call_details, request)
         except Exception as exception:  # pylint:disable=broad-except
-            return _LocalFailure(exception, sys.exc_info()[2])
+            return _FailureOutcome(exception, sys.exc_info()[2])
 
 
 class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
@@ -307,7 +307,7 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
                     credentials=new_credentials)
                 return _UnaryOutcome(response, call)
             except Exception as exception:  # pylint:disable=broad-except
-                return _LocalFailure(exception, sys.exc_info()[2])
+                return _FailureOutcome(exception, sys.exc_info()[2])
 
         call = self._interceptor.intercept_stream_unary(
             continuation, client_call_details, request_iterator)
@@ -334,7 +334,7 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
             return self._interceptor.intercept_stream_unary(
                 continuation, client_call_details, request_iterator)
         except Exception as exception:  # pylint:disable=broad-except
-            return _LocalFailure(exception, sys.exc_info()[2])
+            return _FailureOutcome(exception, sys.exc_info()[2])
 
 
 class _StreamStreamMultiCallable(grpc.StreamStreamMultiCallable):
@@ -365,7 +365,7 @@ class _StreamStreamMultiCallable(grpc.StreamStreamMultiCallable):
             return self._interceptor.intercept_stream_stream(
                 continuation, client_call_details, request_iterator)
         except Exception as exception:  # pylint:disable=broad-except
-            return _LocalFailure(exception, sys.exc_info()[2])
+            return _FailureOutcome(exception, sys.exc_info()[2])
 
 
 class _Channel(grpc.Channel):

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -215,6 +215,8 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
                     metadata=new_metadata,
                     credentials=new_credentials)
                 return _UnaryOutcome(response, call)
+            except grpc.RpcError:
+                raise
             except Exception as exception:  # pylint:disable=broad-except
                 return _FailureOutcome(exception, sys.exc_info()[2])
 
@@ -306,6 +308,8 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
                     metadata=new_metadata,
                     credentials=new_credentials)
                 return _UnaryOutcome(response, call)
+            except grpc.RpcError:
+                raise
             except Exception as exception:  # pylint:disable=broad-except
                 return _FailureOutcome(exception, sys.exc_info()[2])
 


### PR DESCRIPTION
Change the blocking response-unary call code path to rely on the underlying synchronous API, as opposed to calling the Future-based underlying async API and invoking `.result()` on the returned Future object immediately, which can be resource-intensive.

Fixes https://github.com/grpc/grpc/issues/14621