### PR TITLE
Fix using gRPC from Swift via CocoaPods 

### DIFF
--- a/include/grpc/support/log.h
+++ b/include/grpc/support/log.h
@@ -21,7 +21,6 @@
 
 #include <grpc/impl/codegen/port_platform.h>
 
-#include <inttypes.h>
 #include <stdarg.h>
 #include <stdlib.h> /* for abort() */
 


### PR DESCRIPTION
By removing a reference to `<inttypes.h>`. See #14456 for details. As far as I can tell, that `#include` is not used anyway, so this should have no negative impact.