### PR TITLE
Address comments on #14610, fix c-ares tests on ipv6-only hosts

### DIFF
--- a/templates/test/cpp/naming/resolver_component_tests_defs.include
+++ b/templates/test/cpp/naming/resolver_component_tests_defs.include
@@ -58,7 +58,7 @@ def wait_until_dns_server_is_up(args,
     test_runner_log('Health check: attempt to connect to DNS server over TCP.')
     tcp_connect_subprocess = subprocess.Popen([
         args.tcp_connect_bin_path,
-        '--server_host', '127.0.0.1',
+        '--server_host', '::1',
         '--server_port', str(args.dns_server_port),
         '--timeout', str(1)])
     tcp_connect_subprocess.communicate()
@@ -68,7 +68,7 @@ def wait_until_dns_server_is_up(args,
       dns_resolver_subprocess = subprocess.Popen([
           args.dns_resolver_bin_path,
           '--qname', 'health-check-local-dns-server-is-alive.resolver-tests.grpctestingexp',
-          '--server_host', '127.0.0.1',
+          '--server_host', '::1',
           '--server_port', str(args.dns_server_port)],
           stdout=subprocess.PIPE)
       dns_resolver_stdout, _ = dns_resolver_subprocess.communicate()
@@ -125,7 +125,7 @@ current_test_subprocess = subprocess.Popen([\
 
 \
   % endfor
-  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])\
+  '--local_dns_server_address', '[::1]:%d' % args.dns_server_port])\
 
 current_test_subprocess.communicate()\
 

--- a/test/cpp/naming/gen_build_yaml.py
+++ b/test/cpp/naming/gen_build_yaml.py
@@ -22,7 +22,6 @@ import collections
 import hashlib
 import json
 
-_LOCAL_DNS_SERVER_ADDRESS = '127.0.0.1:15353'
 
 def _append_zone_name(name, zone_name):
   return '%s.%s' % (name, zone_name)

--- a/test/cpp/naming/resolver_component_tests_runner.py
+++ b/test/cpp/naming/resolver_component_tests_runner.py
@@ -58,7 +58,7 @@ def wait_until_dns_server_is_up(args,
     test_runner_log('Health check: attempt to connect to DNS server over TCP.')
     tcp_connect_subprocess = subprocess.Popen([
         args.tcp_connect_bin_path,
-        '--server_host', '127.0.0.1',
+        '--server_host', '::1',
         '--server_port', str(args.dns_server_port),
         '--timeout', str(1)])
     tcp_connect_subprocess.communicate()
@@ -68,7 +68,7 @@ def wait_until_dns_server_is_up(args,
       dns_resolver_subprocess = subprocess.Popen([
           args.dns_resolver_bin_path,
           '--qname', 'health-check-local-dns-server-is-alive.resolver-tests.grpctestingexp',
-          '--server_host', '127.0.0.1',
+          '--server_host', '::1',
           '--server_port', str(args.dns_server_port)],
           stdout=subprocess.PIPE)
       dns_resolver_stdout, _ = dns_resolver_subprocess.communicate()
@@ -119,7 +119,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:1234,True',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
-  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+  '--local_dns_server_address', '[::1]:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
   num_test_failures += 1
@@ -131,7 +131,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.5:1234,True;1.2.3.6:1234,True;1.2.3.7:1234,True',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
-  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+  '--local_dns_server_address', '[::1]:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
   num_test_failures += 1
@@ -143,7 +143,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '[2607:f8b0:400a:801::1001]:1234,True',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
-  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+  '--local_dns_server_address', '[::1]:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
   num_test_failures += 1
@@ -155,7 +155,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1003]:1234,True;[2607:f8b0:400a:801::1004]:1234,True',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
-  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+  '--local_dns_server_address', '[::1]:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
   num_test_failures += 1
@@ -167,7 +167,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:1234,True',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}',
   '--expected_lb_policy', 'round_robin',
-  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+  '--local_dns_server_address', '[::1]:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
   num_test_failures += 1
@@ -179,7 +179,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}',
   '--expected_lb_policy', 'round_robin',
-  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+  '--local_dns_server_address', '[::1]:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
   num_test_failures += 1
@@ -191,7 +191,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
-  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+  '--local_dns_server_address', '[::1]:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
   num_test_failures += 1
@@ -203,7 +203,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
-  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+  '--local_dns_server_address', '[::1]:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
   num_test_failures += 1
@@ -215,7 +215,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}',
   '--expected_lb_policy', 'round_robin',
-  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+  '--local_dns_server_address', '[::1]:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
   num_test_failures += 1
@@ -227,7 +227,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}',
   '--expected_lb_policy', 'round_robin',
-  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+  '--local_dns_server_address', '[::1]:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
   num_test_failures += 1
@@ -239,7 +239,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:1234,True;1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
-  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+  '--local_dns_server_address', '[::1]:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
   num_test_failures += 1
@@ -251,7 +251,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1002]:443,False',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
-  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+  '--local_dns_server_address', '[::1]:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
   num_test_failures += 1
@@ -263,7 +263,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}',
   '--expected_lb_policy', '',
-  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+  '--local_dns_server_address', '[::1]:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
   num_test_failures += 1

--- a/test/cpp/naming/utils/dns_resolver.py
+++ b/test/cpp/naming/utils/dns_resolver.py
@@ -25,7 +25,7 @@ import twisted.internet.reactor as reactor
 
 def main():
   argp = argparse.ArgumentParser(description='Make DNS queries for A records')
-  argp.add_argument('-s', '--server_host', default='127.0.0.1', type=str,
+  argp.add_argument('-s', '--server_host', default='::1', type=str,
                     help='Host for DNS server to listen on for TCP and UDP.')
   argp.add_argument('-p', '--server_port', default=53, type=int,
                     help='Port that the DNS server is listening on.')

--- a/test/cpp/naming/utils/dns_server.py
+++ b/test/cpp/naming/utils/dns_server.py
@@ -103,11 +103,11 @@ def start_local_dns_server(args):
   server = twisted.names.server.DNSServerFactory(
       authorities=[test_domain_com], verbose=2)
   server.noisy = 2
-  twisted.internet.reactor.listenTCP(args.port, server)
+  twisted.internet.reactor.listenTCP(args.port, server, interface='::1')
   dns_proto = twisted.names.dns.DNSDatagramProtocol(server)
   dns_proto.noisy = 2
-  twisted.internet.reactor.listenUDP(args.port, dns_proto)
-  print('starting local dns server on 127.0.0.1:%s' % args.port)
+  twisted.internet.reactor.listenUDP(args.port, dns_proto, interface='::1')
+  print('starting local dns server on [::1]:%s' % args.port)
   print('starting twisted.internet.reactor')
   twisted.internet.reactor.suggestThreadPoolSize(1)
   twisted.internet.reactor.run()


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/14644

Addresses comments in https://github.com/grpc/grpc/pull/14610

These tests are certainly not running on an ipv4-only hosts anyways, since the c-ares wrapper will only query for AAAA records (as the tests expects it to) if ipv6 is available.