### PR TITLE
Make logging after success in jobset more apparent

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -31,7 +31,8 @@ def create_docker_jobspec(name,
                           timeout_retries=0,
                           timeout_seconds=30 * 60,
                           docker_base_image=None,
-                          extra_docker_args=None):
+                          extra_docker_args=None,
+                          verbose_success=False):
     """Creates jobspec for a task running under docker."""
     environ = environ.copy()
     environ['RUN_COMMAND'] = shell_command
@@ -57,7 +58,8 @@ def create_docker_jobspec(name,
         shortname='build_artifact.%s' % (name),
         timeout_seconds=timeout_seconds,
         flake_retries=flake_retries,
-        timeout_retries=timeout_retries)
+        timeout_retries=timeout_retries,
+        verbose_success=verbose_success)
     return jobspec
 
 
@@ -69,7 +71,8 @@ def create_jobspec(name,
                    timeout_retries=0,
                    timeout_seconds=30 * 60,
                    use_workspace=False,
-                   cpu_cost=1.0):
+                   cpu_cost=1.0,
+                   verbose_success=False):
     """Creates jobspec."""
     environ = environ.copy()
     if use_workspace:
@@ -88,7 +91,8 @@ def create_jobspec(name,
         flake_retries=flake_retries,
         timeout_retries=timeout_retries,
         shell=shell,
-        cpu_cost=cpu_cost)
+        cpu_cost=cpu_cost,
+        verbose_success=verbose_success)
     return jobspec
 
 


### PR DESCRIPTION
[tools/run_tests/artifacts/artifact_targets.py](https://github.com/grpc/grpc/blob/master/tools/run_tests/artifacts/artifact_targets.py) is used in the artifact build process to create the relevant jobset.JobSpec, but currently prints the console output only if the build fails.

jobset.JobSpec has a verbose_success flag that is [used to print the process output even if it ends in PASSED](https://github.com/grpc/grpc/blob/59ea0ae3ebcca0aef5a15c5aa5b4d27b7f3fc9c4/tools/run_tests/python_utils/jobset.py#L358), but is currently not easily perceivable and is hard to find, making it very difficult to debug PASSED/SUCCESS cases. Make the flag more apparent by adding it as parameters to jobspec creation methods in artifact_targets.