### PR TITLE
Create README for gRPC Python reflection package

### DIFF
--- a/src/python/grpcio_reflection/README.rst
+++ b/src/python/grpcio_reflection/README.rst
@@ -1,0 +1,10 @@
+gRPC Python Reflection package
+==============================
+
+Reference package for reflection in GRPC Python.
+
+Dependencies
+------------
+
+Depends on the `grpcio` package, available from PyPI via `pip install grpcio`.
+


### PR DESCRIPTION
Create a minimal README for gRPC Python reflection package.

Should also stop the `warning: sdist: standard file not found` warning when creating source distribution.