### PR TITLE
Checking alignment.

### DIFF
--- a/src/core/lib/gpr/alloc.cc
+++ b/src/core/lib/gpr/alloc.cc
@@ -58,6 +58,7 @@ void* gpr_malloc(size_t size) {
   if (!p) {
     abort();
   }
+  GPR_ASSERT((((uintptr_t)p) & ((sizeof(void*) << 1) - 1)) == 0);
   return p;
 }
 
@@ -69,6 +70,7 @@ void* gpr_zalloc(size_t size) {
   if (!p) {
     abort();
   }
+  GPR_ASSERT((((uintptr_t)p) & ((sizeof(void*) << 1) - 1)) == 0);
   return p;
 }
 
@@ -84,6 +86,7 @@ void* gpr_realloc(void* p, size_t size) {
   if (!p) {
     abort();
   }
+  GPR_ASSERT((((uintptr_t)p) & ((sizeof(void*) << 1) - 1)) == 0);
   return p;
 }
 


### PR DESCRIPTION
This isn't necessarily to be merged, but I want to run all of our tests to see what breaks with these checks. I suspect only the fuzzer tests will.

From [glibc's memory alignment page](https://www.gnu.org/software/libc/manual/html_node/Aligned-Memory-Blocks.html): allocations on a 32 bits platform should be 8-bytes aligned, and allocations on a 64 bits platform should be 16-bytes aligned.