### PR TITLE
php: adding trace for call_credentials plugin callback function

### DIFF
--- a/src/php/ext/grpc/call_credentials.c
+++ b/src/php/ext/grpc/call_credentials.c
@@ -35,6 +35,7 @@
 
 #include <grpc/grpc.h>
 #include <grpc/grpc_security.h>
+#include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 
 zend_class_entry *grpc_ce_call_credentials;
@@ -178,8 +179,10 @@ int plugin_get_metadata(
 
   PHP_GRPC_DELREF(arg);
 
+  gpr_log(GPR_INFO, "GRPC_PHP: call credentials plugin function - begin");
   /* call the user callback function */
   zend_call_function(state->fci, state->fci_cache TSRMLS_CC);
+  gpr_log(GPR_INFO, "GRPC_PHP: call credentials plugin function - end");
 
   *num_creds_md = 0;
   *status = GRPC_STATUS_OK;


### PR DESCRIPTION
Sometimes it's good to have such trace. For example, fetching auth token may take more than 50ms, which can be useful to debug what cause the latency for a RPC.