### PR TITLE
Add a way for server and client context to directly return peer IP.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1793,6 +1793,7 @@ grpc_cc_library(
         "include/grpcpp/impl/codegen/grpc_library.h",
         "include/grpcpp/impl/codegen/metadata_map.h",
         "include/grpcpp/impl/codegen/method_handler_impl.h",
+        "include/grpcpp/impl/codegen/peer_info.h",
         "include/grpcpp/impl/codegen/rpc_method.h",
         "include/grpcpp/impl/codegen/rpc_service_method.h",
         "include/grpcpp/impl/codegen/security/auth_context.h",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2801,6 +2801,7 @@ foreach(_hdr
   include/grpcpp/impl/codegen/grpc_library.h
   include/grpcpp/impl/codegen/metadata_map.h
   include/grpcpp/impl/codegen/method_handler_impl.h
+  include/grpcpp/impl/codegen/peer_info.h
   include/grpcpp/impl/codegen/rpc_method.h
   include/grpcpp/impl/codegen/rpc_service_method.h
   include/grpcpp/impl/codegen/security/auth_context.h
@@ -3346,6 +3347,7 @@ foreach(_hdr
   include/grpcpp/impl/codegen/grpc_library.h
   include/grpcpp/impl/codegen/metadata_map.h
   include/grpcpp/impl/codegen/method_handler_impl.h
+  include/grpcpp/impl/codegen/peer_info.h
   include/grpcpp/impl/codegen/rpc_method.h
   include/grpcpp/impl/codegen/rpc_service_method.h
   include/grpcpp/impl/codegen/security/auth_context.h
@@ -3737,6 +3739,7 @@ foreach(_hdr
   include/grpcpp/impl/codegen/grpc_library.h
   include/grpcpp/impl/codegen/metadata_map.h
   include/grpcpp/impl/codegen/method_handler_impl.h
+  include/grpcpp/impl/codegen/peer_info.h
   include/grpcpp/impl/codegen/rpc_method.h
   include/grpcpp/impl/codegen/rpc_service_method.h
   include/grpcpp/impl/codegen/security/auth_context.h
@@ -3909,6 +3912,7 @@ foreach(_hdr
   include/grpcpp/impl/codegen/grpc_library.h
   include/grpcpp/impl/codegen/metadata_map.h
   include/grpcpp/impl/codegen/method_handler_impl.h
+  include/grpcpp/impl/codegen/peer_info.h
   include/grpcpp/impl/codegen/rpc_method.h
   include/grpcpp/impl/codegen/rpc_service_method.h
   include/grpcpp/impl/codegen/security/auth_context.h
@@ -4219,6 +4223,7 @@ foreach(_hdr
   include/grpcpp/impl/codegen/grpc_library.h
   include/grpcpp/impl/codegen/metadata_map.h
   include/grpcpp/impl/codegen/method_handler_impl.h
+  include/grpcpp/impl/codegen/peer_info.h
   include/grpcpp/impl/codegen/rpc_method.h
   include/grpcpp/impl/codegen/rpc_service_method.h
   include/grpcpp/impl/codegen/security/auth_context.h

--- a/Makefile
+++ b/Makefile
@@ -5038,6 +5038,7 @@ PUBLIC_HEADERS_CXX += \
     include/grpcpp/impl/codegen/grpc_library.h \
     include/grpcpp/impl/codegen/metadata_map.h \
     include/grpcpp/impl/codegen/method_handler_impl.h \
+    include/grpcpp/impl/codegen/peer_info.h \
     include/grpcpp/impl/codegen/rpc_method.h \
     include/grpcpp/impl/codegen/rpc_service_method.h \
     include/grpcpp/impl/codegen/security/auth_context.h \
@@ -5594,6 +5595,7 @@ PUBLIC_HEADERS_CXX += \
     include/grpcpp/impl/codegen/grpc_library.h \
     include/grpcpp/impl/codegen/metadata_map.h \
     include/grpcpp/impl/codegen/method_handler_impl.h \
+    include/grpcpp/impl/codegen/peer_info.h \
     include/grpcpp/impl/codegen/rpc_method.h \
     include/grpcpp/impl/codegen/rpc_service_method.h \
     include/grpcpp/impl/codegen/security/auth_context.h \
@@ -5981,6 +5983,7 @@ PUBLIC_HEADERS_CXX += \
     include/grpcpp/impl/codegen/grpc_library.h \
     include/grpcpp/impl/codegen/metadata_map.h \
     include/grpcpp/impl/codegen/method_handler_impl.h \
+    include/grpcpp/impl/codegen/peer_info.h \
     include/grpcpp/impl/codegen/rpc_method.h \
     include/grpcpp/impl/codegen/rpc_service_method.h \
     include/grpcpp/impl/codegen/security/auth_context.h \
@@ -6130,6 +6133,7 @@ PUBLIC_HEADERS_CXX += \
     include/grpcpp/impl/codegen/grpc_library.h \
     include/grpcpp/impl/codegen/metadata_map.h \
     include/grpcpp/impl/codegen/method_handler_impl.h \
+    include/grpcpp/impl/codegen/peer_info.h \
     include/grpcpp/impl/codegen/rpc_method.h \
     include/grpcpp/impl/codegen/rpc_service_method.h \
     include/grpcpp/impl/codegen/security/auth_context.h \
@@ -6446,6 +6450,7 @@ PUBLIC_HEADERS_CXX += \
     include/grpcpp/impl/codegen/grpc_library.h \
     include/grpcpp/impl/codegen/metadata_map.h \
     include/grpcpp/impl/codegen/method_handler_impl.h \
+    include/grpcpp/impl/codegen/peer_info.h \
     include/grpcpp/impl/codegen/rpc_method.h \
     include/grpcpp/impl/codegen/rpc_service_method.h \
     include/grpcpp/impl/codegen/security/auth_context.h \

--- a/include/grpcpp/impl/codegen/client_context.h
+++ b/include/grpcpp/impl/codegen/client_context.h
@@ -45,6 +45,7 @@
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/codegen/create_auth_context.h>
 #include <grpcpp/impl/codegen/metadata_map.h>
+#include <grpcpp/impl/codegen/peer_info.h>
 #include <grpcpp/impl/codegen/security/auth_context.h>
 #include <grpcpp/impl/codegen/slice.h>
 #include <grpcpp/impl/codegen/status.h>
@@ -315,14 +316,14 @@ class ClientContext {
     initial_metadata_corked_ = corked;
   }
 
-  /// Return the peer uri in a string.
+  /// Return the peer uri information.
   ///
   /// \warning This value is never authenticated or subject to any security
   /// related code. It must not be used for any authentication related
   /// functionality. Instead, use auth_context.
   ///
-  /// \return The call's peer URI.
-  grpc::string peer() const;
+  /// \return The call's peer URI information.
+  grpc::PeerInfo peer() const;
 
   /// Get and set census context.
   void set_census_context(struct census_context* ccp) { census_context_ = ccp; }

--- a/include/grpcpp/impl/codegen/peer_info.h
+++ b/include/grpcpp/impl/codegen/peer_info.h
@@ -1,0 +1,34 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GRPCPP_IMPL_CODEGEN_PEER_INFO_H
+#define GRPCPP_IMPL_CODEGEN_PEER_INFO_H
+
+namespace grpc {
+
+struct PeerInfo {
+  grpc::string protocol_;
+  grpc::string ip_;
+  grpc::string port_;
+
+  grpc::string to_string() const { return protocol_ + ':' + ip_ + ':' + port_; }
+};
+
+}  //  namespace grpc
+
+#endif  //  GRPCPP_IMPL_CODEGEN_PEER_INFO_H

--- a/include/grpcpp/impl/codegen/server_context.h
+++ b/include/grpcpp/impl/codegen/server_context.h
@@ -30,6 +30,7 @@
 #include <grpcpp/impl/codegen/config.h>
 #include <grpcpp/impl/codegen/create_auth_context.h>
 #include <grpcpp/impl/codegen/metadata_map.h>
+#include <grpcpp/impl/codegen/peer_info.h>
 #include <grpcpp/impl/codegen/security/auth_context.h>
 #include <grpcpp/impl/codegen/string_ref.h>
 #include <grpcpp/impl/codegen/time.h>
@@ -214,11 +215,15 @@ class ServerContext {
     return auth_context_;
   }
 
-  /// Return the peer uri in a string.
+  /// Return the peer uri information.
   /// WARNING: this value is never authenticated or subject to any security
   /// related code. It must not be used for any authentication related
   /// functionality. Instead, use auth_context.
-  grpc::string peer() const;
+  grpc::PeerInfo peer() const;
+
+  /// Return the peer uri data.
+  /// \see
+  // grpc::string peer_info() const;
 
   /// Get the census context associated with this server call.
   const struct census_context* census_context() const;

--- a/src/cpp/client/client_context.cc
+++ b/src/cpp/client/client_context.cc
@@ -116,14 +116,22 @@ void ClientContext::TryCancel() {
   }
 }
 
-grpc::string ClientContext::peer() const {
+grpc::PeerInfo ClientContext::peer() const {
   grpc::string peer;
   if (call_) {
     char* c_peer = grpc_call_get_peer(call_);
     peer = c_peer;
     gpr_free(c_peer);
   }
-  return peer;
+  grpc::PeerInfo info;
+  size_t first = peer.find_first_of(':');
+  size_t last = peer.find_last_of(':');
+  if (first != grpc::string::npos && last != grpc::string::npos) {
+    info.protocol_ = peer.substr(0, first);
+    info.ip_ = peer.substr(first + 1, last - first - 1);
+    info.port_ = peer.substr(last + 1);
+  }
+  return info;
 }
 
 void ClientContext::SetGlobalCallbacks(GlobalCallbacks* client_callbacks) {

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -201,14 +201,22 @@ void ServerContext::set_compression_algorithm(
   AddInitialMetadata(GRPC_COMPRESSION_REQUEST_ALGORITHM_MD_KEY, algorithm_name);
 }
 
-grpc::string ServerContext::peer() const {
+grpc::PeerInfo ServerContext::peer() const {
   grpc::string peer;
   if (call_) {
     char* c_peer = grpc_call_get_peer(call_);
     peer = c_peer;
     gpr_free(c_peer);
   }
-  return peer;
+  grpc::PeerInfo info;
+  size_t first = peer.find_first_of(':');
+  size_t last = peer.find_last_of(':');
+  if (first != grpc::string::npos && last != grpc::string::npos) {
+    info.protocol_ = peer.substr(0, first);
+    info.ip_ = peer.substr(first + 1, last - first - 1);
+    info.port_ = peer.substr(last + 1);
+  }
+  return info;
 }
 
 const struct census_context* ServerContext::census_context() const {

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -64,6 +64,12 @@ bool CheckIsLocalhost(const grpc::string& addr) {
          addr.substr(0, kIpv6.size()) == kIpv6;
 }
 
+bool CheckIsLocalhost(const grpc::PeerInfo& info) {
+  return (info.protocol_ == "ipv4" && info.ip_ == "127.0.0.1") ||
+         (info.protocol_ == "ipv6" &&
+          (info.ip_ == "[::1]" || info.ip_ == "[::ffff:127.0.0.1]"));
+}
+
 const char kTestCredsPluginErrorMsg[] = "Could not find plugin metadata.";
 
 class TestMetadataCredentialsPlugin : public MetadataCredentialsPlugin {

--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -160,7 +160,7 @@ Status TestServiceImpl::Echo(ServerContext* context, const EchoRequest* request,
         grpc::string(request->param().response_message_length(), '\0'));
   }
   if (request->has_param() && request->param().echo_peer()) {
-    response->mutable_param()->set_peer(context->peer());
+    response->mutable_param()->set_peer(context->peer().to_string());
   }
   return Status::OK;
 }


### PR DESCRIPTION
The proposed change for #5693 

A new struct `PeerInfo` is added to contain the peer information. Filling this struct exploit the fact that the peer's URI is always in the form PROTOCOL:IP:PORT

Since the issue is related to only the C++ API, I made the changes in it only.

Finally, I am not sure if this solves the problem of 'without string parsing' but though it is better to make the PR and discuss that. Also, the parsing of the URI may need to be in the struct CTOR.