### PR TITLE
Stop including inttypes.h in gRPC core public header

### DIFF
--- a/include/grpc/support/log.h
+++ b/include/grpc/support/log.h
@@ -21,13 +21,6 @@
 
 #include <grpc/impl/codegen/port_platform.h>
 
-/* On Apple platforms, including inttypes.h in a public header prevents gRPC
- * core to be built as framework. We rule out this inclusion on Apple platforms.
- */
-#if !defined(__APPLE__)
-#include <inttypes.h>
-#endif
-
 #include <stdarg.h>
 #include <stdlib.h> /* for abort() */
 

--- a/include/grpc/support/log.h
+++ b/include/grpc/support/log.h
@@ -21,7 +21,13 @@
 
 #include <grpc/impl/codegen/port_platform.h>
 
+/* On Apple platforms, including inttypes.h in a public header prevents gRPC
+ * core to be built as framework. We rule out this inclusion on Apple platforms.
+ */
+#if !defined(__APPLE__)
 #include <inttypes.h>
+#endif
+
 #include <stdarg.h>
 #include <stdlib.h> /* for abort() */
 

--- a/src/core/lib/gpr/log_linux.cc
+++ b/src/core/lib/gpr/log_linux.cc
@@ -32,6 +32,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
+#include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>

--- a/test/core/end2end/cq_verifier.cc
+++ b/test/core/end2end/cq_verifier.cc
@@ -18,6 +18,7 @@
 
 #include "test/core/end2end/cq_verifier.h"
 
+#include <inttypes.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>

--- a/test/core/end2end/tests/cancel_after_invoke.cc
+++ b/test/core/end2end/tests/cancel_after_invoke.cc
@@ -18,6 +18,7 @@
 
 #include "test/core/end2end/end2end_tests.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/test/core/end2end/tests/cancel_before_invoke.cc
+++ b/test/core/end2end/tests/cancel_before_invoke.cc
@@ -18,6 +18,7 @@
 
 #include "test/core/end2end/end2end_tests.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/test/core/end2end/tests/cancel_with_status.cc
+++ b/test/core/end2end/tests/cancel_with_status.cc
@@ -18,6 +18,7 @@
 
 #include "test/core/end2end/end2end_tests.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/test/core/end2end/tests/negative_deadline.cc
+++ b/test/core/end2end/tests/negative_deadline.cc
@@ -18,6 +18,7 @@
 
 #include "test/core/end2end/end2end_tests.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/test/core/gpr/mpscq_test.cc
+++ b/test/core/gpr/mpscq_test.cc
@@ -18,6 +18,7 @@
 
 #include "src/core/lib/gpr/mpscq.h"
 
+#include <inttypes.h>
 #include <stdlib.h>
 
 #include <grpc/support/alloc.h>

--- a/test/core/gpr/time_test.cc
+++ b/test/core/gpr/time_test.cc
@@ -21,6 +21,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>
+#include <inttypes.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/core/util/test_config.cc
+++ b/test/core/util/test_config.cc
@@ -18,6 +18,7 @@
 
 #include "test/core/util/test_config.h"
 
+#include <inttypes.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/test/cpp/thread_manager/thread_manager_test.cc
+++ b/test/cpp/thread_manager/thread_manager_test.cc
@@ -16,6 +16,7 @@
  *is % allowed in string
  */
 
+#include <inttypes.h>
 #include <ctime>
 #include <memory>
 #include <string>


### PR DESCRIPTION
`inttypes.h` cannot be included in a public header `support/log.h` in Apple platforms (iOS, macos) when gRPC core is built as framework. The macros imported are not being used in this file either. This change fixes this problem and the resulted build issues on Apple platforms.

Fixes #14456 