### PR TITLE
Minor changes to control files from Tools package rework

### DIFF
--- a/src/csharp/.editorconfig
+++ b/src/csharp/.editorconfig
@@ -1,5 +1,6 @@
 root = true
 [**]
+charset = utf-8  ; Implies no BOM.
 end_of_line = LF
 indent_style = space
 indent_size = 4

--- a/src/csharp/.gitignore
+++ b/src/csharp/.gitignore
@@ -1,15 +1,17 @@
-*.xproj.user
 *.userprefs
-*.csproj.user
+*.user
 *.lock.json
+/*.suo
+/*.sdf
+/.vs/
+bin/
+obj/
+*.nupkg
 StyleCop.Cache
-test-results
-packages
-Grpc.v12.suo
-Grpc.sdf
+/packages/
+/protoc_plugins/
 
+test-results/
 TestResult.xml
 coverage_results.xml
 /TestResults
-.vs/
-*.nupkg


### PR DESCRIPTION
Minor changes to .gitignore and .editorconfig to clean up after Grpc.Tools split. Can be committed separately, better before #13207, so that git workspace does not show untracked files.

Ref #13207
