### PR TITLE
Fix C# distribtest on kokoro macos

### DIFF
--- a/test/distrib/csharp/run_distrib_test.sh
+++ b/test/distrib/csharp/run_distrib_test.sh
@@ -21,6 +21,11 @@ unzip -o "$EXTERNAL_GIT_ROOT/input_artifacts/csharp_nugets_windows_dotnetcli.zip
 
 ./update_version.sh auto
 
+# With a recent-enough version of mono, the "nuget restore" command would
+# restore packages based on project.json files, but we want to restore packages
+# based on the net45 legacy "packages.config" file instead.
+rm DistribTest/*project.json
+
 nuget restore
 
 xbuild DistribTest.sln


### PR DESCRIPTION
Kokoro mac workers have a new version of mono, which picks up DistribTest.project.json file in the same directory. Deleting the project.json files fixes the problem (and we should migrate the distribtest to use the "new" .csproj format in the future - project.json files are deprecated).