### PR TITLE
Try fixing PHP distribtest on mac kokoro.

### DIFF
--- a/test/distrib/php/run_distrib_test.sh
+++ b/test/distrib/php/run_distrib_test.sh
@@ -19,7 +19,7 @@ cd "$(dirname "$0")"
 
 cp -r "$EXTERNAL_GIT_ROOT"/input_artifacts/grpc-*.tgz .
 
-find . -regextype sed -regex ".*/grpc-[0-9].*.tgz" | cut -b3- | \
+find . -regex ".*/grpc-[0-9].*.tgz" | cut -b3- | \
     xargs pecl install
 
 php -d extension=grpc.so -d max_execution_time=300 distribtest.php


### PR DESCRIPTION
`-regextype` flag is not supported on mac

```
+ cp -r ../../../../input_artifacts/grpc-1.11.0dev.tgz .
+ find . -regextype sed -regex '.*/grpc-[0-9].*.tgz'
+ cut -b3-
+ xargs pecl install
find: -regextype: unknown primary or operator
+ php -d extension=grpc.so -d max_execution_time=300 distribtest.php
PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/lib/php/extensions/no-debug-non-zts-20131226/grpc.so' - dlopen(/usr/lib/php/extensions/no-debug-non-zts-20131226/grpc.so, 9): image not found in Unknown on line 0

Fatal error: Class 'Grpc\Channel' not found in /Volumes/BuildData/tmpfs/src/github/grpc/workspace_php_macos_x64_None/test/distrib/php/distribtest.php on line 20

2018-03-14 04:44:07,234 FAILED: distribtest.php_macos_x64_None [ret=255, pid=4270, time=12.3sec]
```