### PR TITLE
Add checking for hotplugged CPUs in gpr_cpu_current_cpu for linux

### DIFF
--- a/src/core/lib/gpr/cpu_linux.cc
+++ b/src/core/lib/gpr/cpu_linux.cc
@@ -71,6 +71,10 @@ unsigned gpr_cpu_current_cpu(void) {
     gpr_log(GPR_ERROR, "Error determining current CPU: %s\n", strerror(errno));
     return 0;
   }
+  if (static_cast<unsigned>(cpu) >= gpr_cpu_num_cores()) {
+    gpr_log(GPR_ERROR, "Cannot handle hot-plugged CPUs");
+    return 0;
+  }
   return static_cast<unsigned>(cpu);
 #endif
 }


### PR DESCRIPTION
Fixes #14711 by defaulting to 0 if it's a hotplugged CPU