### PR TITLE
fix nanopb bazel issues

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -37,7 +37,7 @@ def _get_external_deps(external_deps):
   ret = []
   for dep in external_deps:
     if dep == "nanopb":
-      ret += ["//third_party/nanopb"]
+      ret += ["grpc_nanopb"]
     elif dep == "cares":
       ret += select({"//:grpc_no_ares": [],
                      "//conditions:default": ["//external:cares"],})
@@ -57,12 +57,6 @@ def _maybe_update_cc_library_hdrs(hdrs):
       ret.append(h)
   return ret
 
-def _maybe_update_cc_library_defines(name):
-  ret = []
-  if name == "alts_proto":
-    ret += ["PB_FIELD_16BIT=1"]
-  return ret
-
 def grpc_cc_library(name, srcs = [], public_hdrs = [], hdrs = [],
                     external_deps = [], deps = [], standalone = False,
                     language = "C++", testonly = False, visibility = None,
@@ -70,11 +64,10 @@ def grpc_cc_library(name, srcs = [], public_hdrs = [], hdrs = [],
   copts = []
   if language.upper() == "C":
     copts = if_not_windows(["-std=c99"])
-  defines = _maybe_update_cc_library_defines(name)
   native.cc_library(
     name = name,
     srcs = srcs,
-    defines = defines + select({"//:grpc_no_ares": ["GRPC_ARES=0"],
+    defines = select({"//:grpc_no_ares": ["GRPC_ARES=0"],
                       "//conditions:default": [],}) +
               select({"//:remote_execution":  ["GRPC_PORT_ISOLATED_RUNTIME=1"],
                       "//conditions:default": [],}) +
@@ -162,7 +155,23 @@ def grpc_cc_binary(name, srcs = [], deps = [], external_deps = [], args = [], da
   )
 
 def grpc_generate_one_off_targets():
-  pass
+  native.cc_library(
+    name = "grpc_nanopb",
+    hdrs = [
+      "//third_party/nanopb:pb.h",
+      "//third_party/nanopb:pb_common.h",
+      "//third_party/nanopb:pb_decode.h",
+      "//third_party/nanopb:pb_encode.h",
+    ],
+    srcs = [
+      "//third_party/nanopb:pb_common.c",
+      "//third_party/nanopb:pb_decode.c",
+      "//third_party/nanopb:pb_encode.c",
+    ],
+    defines = [
+      "PB_FIELD_16BIT=1",
+    ],
+  )
 
 def grpc_sh_test(name, srcs, args = [], data = []):
   native.sh_test(


### PR DESCRIPTION
This PR correctly passes PB_FIELD_16BIT define macro to nanopb compilations. To achieve the goal, we have to recompile the nanopb source in grpc/BUILD instead of directly referencing the target from third_party/nanopb/BUILD.

This PR should fix the test failure in #14695, #14696, #14697