### PR TITLE
Zero out address before calling accept

### DIFF
--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -213,6 +213,7 @@ static void on_read(void* arg, grpc_error* err) {
     grpc_resolved_address addr;
     char* addr_str;
     char* name;
+    memset(&addr, 0, sizeof(addr));
     addr.len = sizeof(struct sockaddr_storage);
     /* Note: If we ever decide to return this address to the user, remember to
        strip off the ::ffff:0.0.0.0/96 prefix first. */


### PR DESCRIPTION
If the client is a Unix Domain Socket that has not bound to an address, then the sun_path in the sockaddr_un struct is not filled on an accept at the server. (Refer man page for unix - man 7 unix for more details)

Without zeroing it out, we are setting the peer uri to a garbage string.