### PR TITLE
Fix build error for snprintf

### DIFF
--- a/src/core/lib/channel/channel_trace.cc
+++ b/src/core/lib/channel/channel_trace.cc
@@ -25,6 +25,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "src/core/lib/channel/channel_trace_registry.h"

--- a/src/core/lib/channel/channel_trace.cc
+++ b/src/core/lib/channel/channel_trace.cc
@@ -24,8 +24,8 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "src/core/lib/channel/channel_trace_registry.h"


### PR DESCRIPTION
`snprintf` is part of `stdio.h`. Needs to include the header to build.