### PR TITLE
Longer timeout for protoc artifacts on macos

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -317,6 +317,7 @@ class ProtocArtifact:
                     self.name,
                     ['tools/run_tests/artifacts/build_artifact_protoc.sh'],
                     environ=environ,
+                    timeout_seconds=60 * 60,
                     use_workspace=True)
         else:
             generator = 'Visual Studio 14 2015 Win64' if self.arch == 'x64' else 'Visual Studio 14 2015'


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/13806.
Both failures are timeout of the protoc build on mac (at 1800seconds).

