### PR TITLE
Re-enable some tests for the Node Pure JS interop client

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -406,11 +406,7 @@ class NodePureJSLanguage:
         return {}
 
     def unimplemented_test_cases(self):
-        return (
-            _SKIP_COMPRESSION + _SKIP_DATA_FRAME_PADDING + _AUTH_TEST_CASES + [
-                'cancel_after_begin', 'cancel_after_first_response',
-                'timeout_on_sleeping_server'
-            ])
+        return _SKIP_COMPRESSION + _SKIP_DATA_FRAME_PADDING
 
     def unimplemented_test_cases_server(self):
         return []


### PR DESCRIPTION
The tests that are re-enabled here should now work because of grpc/grpc-node#219, grpc/grpc-node#221, and grpc/grpc-node#231.