### PR TITLE
Partially fix resolver_component_tests_runner test in gcc_musl portability suite

### DIFF
--- a/templates/tools/dockerfile/test/cxx_alpine_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_alpine_x64/Dockerfile.template
@@ -1,0 +1,57 @@
+%YAML 1.2
+--- |
+  # Copyright 2015 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  
+  FROM alpine:3.5
+  
+  # Install Git and basic packages.
+  RUN apk update && apk add ${'\\'}
+    autoconf ${'\\'}
+    automake ${'\\'}
+    bzip2 ${'\\'}
+    build-base ${'\\'}
+    cmake ${'\\'}
+    ccache ${'\\'}
+    curl ${'\\'}
+    gcc ${'\\'}
+    git ${'\\'}
+    libtool ${'\\'}
+    linux-headers ${'\\'}
+    make ${'\\'}
+    perl ${'\\'}
+    strace ${'\\'}
+    python-dev ${'\\'}
+    py-pip ${'\\'}
+    unzip ${'\\'}
+    wget ${'\\'}
+    zip
+  
+  # Install Python packages from PyPI
+  RUN pip install --upgrade pip==9.0.1
+  RUN pip install virtualenv
+  RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.0.post1 six==1.10.0 twisted==17.5.0
+  
+  # Google Cloud platform API libraries
+  RUN pip install --upgrade google-api-python-client
+  
+  # Install gflags
+  RUN git clone https://github.com/gflags/gflags.git && cd gflags && git checkout v2.2.0
+  RUN cd gflags && cmake . && make && make install
+  RUN ln -s /usr/local/include/gflags /usr/include/gflags
+  
+  <%include file="../../run_tests_addons.include"/>
+  
+  # Define the default command.
+  CMD ["bash"]

--- a/tools/dockerfile/test/cxx_alpine_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_alpine_x64/Dockerfile
@@ -39,23 +39,27 @@ RUN apk update && apk add \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==9.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.0.post1 six==1.10.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.0.post1 six==1.10.0 twisted==17.5.0
 
 # Google Cloud platform API libraries
 RUN pip install --upgrade google-api-python-client
-
-# Prepare ccache
-RUN ln -s /usr/bin/ccache /usr/local/bin/gcc
-RUN ln -s /usr/bin/ccache /usr/local/bin/g++
-RUN ln -s /usr/bin/ccache /usr/local/bin/cc 
-RUN ln -s /usr/bin/ccache /usr/local/bin/c++
 
 # Install gflags
 RUN git clone https://github.com/gflags/gflags.git && cd gflags && git checkout v2.2.0
 RUN cd gflags && cmake . && make && make install
 RUN ln -s /usr/local/include/gflags /usr/include/gflags
 
-RUN mkdir -p /var/local/jenkins
+# Prepare ccache
+RUN ln -s /usr/bin/ccache /usr/local/bin/gcc
+RUN ln -s /usr/bin/ccache /usr/local/bin/g++
+RUN ln -s /usr/bin/ccache /usr/local/bin/cc
+RUN ln -s /usr/bin/ccache /usr/local/bin/c++
+RUN ln -s /usr/bin/ccache /usr/local/bin/clang
+RUN ln -s /usr/bin/ccache /usr/local/bin/clang++
+
+
+RUN mkdir /var/local/jenkins
+
 
 # Define the default command.
 CMD ["bash"]


### PR DESCRIPTION
- Partially fixes an error in gcc_musl portability test
- Introduce a template from cxx_alpine_x64 docker image. 

Original error:
```
+ test/cpp/naming/utils/dns_resolver.py -s 127.0.0.1 -p 22960 -n health-check-local-dns-server-is-alive.resolver-tests.grpctestingexp. -t 1
+ grep 123.123.123.123
Traceback (most recent call last):
  File "test/cpp/naming/utils/dns_resolver.py", line 20, in <module>
    import twisted.internet.task as task
ImportError: No module named twisted.internet.task
+ RETRY=1
+ test/cpp/naming/utils/tcp_connect.py -s 127.0.0.1 -p 22960 -t 1
Traceback (most recent call last):
  File "test/cpp/naming/utils/tcp_connect.py", line 35, in <module>
    main()
  File "test/cpp/naming/utils/tcp_connect.py", line 32, in main
    socket.create_connection([args.server_host, args.server_port])
  File "/usr/lib/python2.7/socket.py", line 575, in create_connection
    raise err
socket.error: [Errno 111] Connection refused
```

https://sponge.corp.google.com/target?id=0c3336e8-0f8d-475c-94c6-d591d4aca246&target=github/grpc/cpp_linux_dbg_native_x64_gcc_musl&searchFor=&show=FAILED&sortBy=STATUS

The test still fails with:
```
+ echo 'FAILED TO START LOCAL DNS SERVER'
FAILED TO START LOCAL DNS SERVER
+ kill -SIGTERM 22544
```