### PR TITLE
Fix C# connectivity watcher shutdown race

### DIFF
--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -163,9 +163,8 @@ namespace Grpc.Core
                 if (handle.IsClosed)
                 {
                     // If channel has been already shutdown and handle was disposed, we would end up with
-                    // an abandoned completion added to the completion registry. So we act as if the
-                    // wait has timed out instead.
-                    tcs.SetResult(false);
+                    // an abandoned completion added to the completion registry. Instead, we make sure we fail early.
+                    throw new ObjectDisposedException(nameof(handle), "Channel handle has already been disposed.");
                 }
                 else
                 {


### PR DESCRIPTION
Fixes `Shutdown check: Detected 1 pending batch completions` flake in `Grpc.IntegrationTesting.MetadataCredentialsTest.MetadataCredentials`.

```
1) Error : Grpc.IntegrationTesting.MetadataCredentialsTest.MetadataCredentials_InterceptorThrows
TearDown : System.AggregateException : One or more errors occurred.
  ----> System.Exception : Shutdown check: Detected 1 pending batch completions.
--TearDown
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at Grpc.IntegrationTesting.MetadataCredentialsTest.Cleanup()
--Exception
   at Grpc.Core.Internal.DebugStats.DebugWarning(String message)
   at Grpc.Core.Internal.DebugStats.CheckOK()
   at Grpc.Core.GrpcEnvironment.<ShutdownAsync>d__59.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at Grpc.Core.GrpcEnvironment.<ReleaseAsync>d__25.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at Grpc.Core.Server.<ShutdownInternalAsync>d__32.MoveNext()
```


Recent occurrences:
https://sponge.corp.google.com/invocation?id=54e2029b-4df5-491b-88d9-eafbfb045efe
https://sponge.corp.google.com/invocation?id=1028b12d-49bb-46ac-bffd-df53453c14b0
https://sponge.corp.google.com/invocation?id=ca45bab6-f6a8-4d6b-ad38-e9ec4168000c



