### PR TITLE
Allow gRPC ObjC user to set keepalive options

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall+ChannelArg.h
+++ b/src/objective-c/GRPCClient/GRPCCall+ChannelArg.h
@@ -46,4 +46,11 @@ typedef NS_ENUM(NSInteger, GRPCCompressAlgorithm) {
 + (void)setDefaultCompressMethod:(GRPCCompressAlgorithm)algorithm
                          forhost:(nonnull NSString *)host;
 
+/** Configure keepalive timeout parameters. A client ping after \a interval ms to check if the
+ * transport is still alive. After waiting for \a timeout ms, if the client does not receive the
+ * ping ack, it closes the transport. */
++ (void)setKeepaliveWithInterval:(int)interval
+                         timeout:(int)timeout
+                         forHost:(nonnull NSString *)host;
+
 @end

--- a/src/objective-c/GRPCClient/GRPCCall+ChannelArg.h
+++ b/src/objective-c/GRPCClient/GRPCCall+ChannelArg.h
@@ -46,9 +46,11 @@ typedef NS_ENUM(NSInteger, GRPCCompressAlgorithm) {
 + (void)setDefaultCompressMethod:(GRPCCompressAlgorithm)algorithm
                          forhost:(nonnull NSString *)host;
 
-/** Configure keepalive timeout parameters. A client ping after \a interval ms to check if the
- * transport is still alive. After waiting for \a timeout ms, if the client does not receive the
- * ping ack, it closes the transport. */
+/** Enable keepalive and configure keepalive parameters. A user should call this function once to
+ * enable keepalive for a particular host. gRPC client sends a ping after every \a interval ms to
+ * check if the transport is still alive. After waiting for \a timeout ms, if the client does not
+ * receive the ping ack, it closes the transport; all pending calls to this host will fail with
+ * error GRPC_STATUS_INTERNAL with error information "keepalive watchdog timeout". */
 + (void)setKeepaliveWithInterval:(int)interval
                          timeout:(int)timeout
                          forHost:(nonnull NSString *)host;

--- a/src/objective-c/GRPCClient/GRPCCall+ChannelArg.m
+++ b/src/objective-c/GRPCClient/GRPCCall+ChannelArg.m
@@ -57,4 +57,12 @@
   }
 }
 
++ (void)setKeepaliveWithInterval:(int)interval
+                         timeout:(int)timeout
+                         forHost:(nonnull NSString *)host {
+  GRPCHost *hostConfig = [GRPCHost hostWithAddress:host];
+  hostConfig.keepaliveInterval = interval;
+  hostConfig.keepaliveTimeout = timeout;
+}
+
 @end

--- a/src/objective-c/GRPCClient/private/GRPCHost.h
+++ b/src/objective-c/GRPCClient/private/GRPCHost.h
@@ -35,6 +35,8 @@ struct grpc_channel_credentials;
 @property(nonatomic, copy, nullable) NSString *userAgentPrefix;
 @property(nonatomic, nullable) struct grpc_channel_credentials *channelCreds;
 @property(nonatomic) grpc_compression_algorithm compressAlgorithm;
+@property(nonatomic) int keepaliveInterval;
+@property(nonatomic) int keepaliveTimeout;
 
 /** The following properties should only be modified for testing: */
 

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -216,6 +216,11 @@ static NSMutableDictionary *kHostCache;
         [NSNumber numberWithInt:_compressAlgorithm];
   }
 
+  if (_keepaliveInterval != 0) {
+    args[@GRPC_ARG_KEEPALIVE_TIME_MS] = [NSNumber numberWithInt:_keepaliveInterval];
+    args[@GRPC_ARG_KEEPALIVE_TIMEOUT_MS] = [NSNumber numberWithInt:_keepaliveTimeout];
+  }
+
   id logConfig = [GRPCCall logConfig];
   if (logConfig != nil) {
     args[@GRPC_ARG_MOBILE_LOG_CONFIG] = logConfig;

--- a/src/objective-c/tests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests.m
@@ -488,9 +488,9 @@ BOOL isRemoteInteropTest(NSString *host) {
 
 - (void)testKeepalive {
   XCTAssertNotNil(self.class.host);
-  __weak XCTestExpectation *expectation = [self expectationWithDescription:@"PingPong"];
+  __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Keepalive"];
 
-  [GRPCCall setKeepaliveWithInterval:1500 timeout:1 forHost:self.class.host];
+  [GRPCCall setKeepaliveWithInterval:1500 timeout:0 forHost:self.class.host];
 
   NSArray *requests = @[@27182, @8];
   NSArray *responses = @[@31415, @9];

--- a/src/objective-c/tests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests.m
@@ -486,6 +486,7 @@ BOOL isRemoteInteropTest(NSString *host) {
   [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
 }
 
+#ifndef GRPC_COMPILE_WITH_CRONET
 - (void)testKeepalive {
   XCTAssertNotNil(self.class.host);
   __weak XCTestExpectation *expectation = [self expectationWithDescription:@"Keepalive"];
@@ -525,5 +526,6 @@ BOOL isRemoteInteropTest(NSString *host) {
 
   [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
 }
+#endif
 
 @end

--- a/src/objective-c/tests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests.m
@@ -515,6 +515,9 @@ BOOL isRemoteInteropTest(NSString *host) {
     } else {
       // Keepalive should kick after 1s elapsed and fails the call.
       XCTAssertNotNil(error);
+      XCTAssertEqual(error.code, GRPC_STATUS_INTERNAL);
+      XCTAssertEqualObjects(error.localizedDescription, @"keepalive watchdog timeout",
+                            @"Unexpected failure that is not keepalive watchdog timeout.");
       XCTAssertTrue(done);
       [expectation fulfill];
     }

--- a/src/objective-c/tests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests.m
@@ -486,4 +486,41 @@ BOOL isRemoteInteropTest(NSString *host) {
   [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
 }
 
+- (void)testKeepalive {
+  XCTAssertNotNil(self.class.host);
+  __weak XCTestExpectation *expectation = [self expectationWithDescription:@"PingPong"];
+
+  [GRPCCall setKeepaliveWithInterval:1500 timeout:1 forHost:self.class.host];
+
+  NSArray *requests = @[@27182, @8];
+  NSArray *responses = @[@31415, @9];
+
+  GRXBufferedPipe *requestsBuffer = [[GRXBufferedPipe alloc] init];
+
+  __block int index = 0;
+
+  id request = [RMTStreamingOutputCallRequest messageWithPayloadSize:requests[index]
+                                               requestedResponseSize:responses[index]];
+  [requestsBuffer writeValue:request];
+
+  [_service fullDuplexCallWithRequestsWriter:requestsBuffer
+                                eventHandler:^(BOOL done,
+                                               RMTStreamingOutputCallResponse *response,
+                                               NSError *error) {
+    if (index == 0) {
+      XCTAssertNil(error, @"Finished with unexpected error: %@", error);
+      XCTAssertTrue(response, @"Event handler called without an event.");
+      XCTAssertFalse(done);
+      index++;
+    } else {
+      // Keepalive should kick after 1s elapsed and fails the call.
+      XCTAssertNotNil(error);
+      XCTAssertTrue(done);
+      [expectation fulfill];
+    }
+  }];
+
+  [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
+}
+
 @end


### PR DESCRIPTION
Fixes #8328. The new test will only pass after #14780 is merged.

cc: @srini100 