### PR TITLE
PHP: fix pecl build error

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -11,8 +11,8 @@ if test "$PHP_GRPC" != "no"; then
 
   LIBS="-lpthread $LIBS"
 
-  CFLAGS="-Wall -Werror -Wno-parentheses-equality -Wno-unused-value -std=c11 -g -O2"
-  CXXFLAGS="-std=c++11 -fno-exceptions -fno-rtti -g -O2"
+  CFLAGS="-Wall -Werror -Wno-parentheses-equality -Wno-unused-value -std=c11 -g -O2 -D PB_FIELD_16BIT=1"
+  CXXFLAGS="-std=c++11 -fno-exceptions -fno-rtti -g -O2 -D PB_FIELD_16BIT=1"
   GRPC_SHARED_LIBADD="-lpthread $GRPC_SHARED_LIBADD"
   PHP_REQUIRE_CXX()
   PHP_ADD_LIBRARY(pthread)

--- a/templates/config.m4.template
+++ b/templates/config.m4.template
@@ -13,8 +13,8 @@
 
     LIBS="-lpthread $LIBS"
 
-    CFLAGS="-Wall -Werror -Wno-parentheses-equality -Wno-unused-value -std=c11 -g -O2"
-    CXXFLAGS="-std=c++11 -fno-exceptions -fno-rtti -g -O2"
+    CFLAGS="-Wall -Werror -Wno-parentheses-equality -Wno-unused-value -std=c11 -g -O2 -D PB_FIELD_16BIT=1"
+    CXXFLAGS="-std=c++11 -fno-exceptions -fno-rtti -g -O2 -D PB_FIELD_16BIT=1"
     GRPC_SHARED_LIBADD="-lpthread $GRPC_SHARED_LIBADD"
     PHP_REQUIRE_CXX()
     PHP_ADD_LIBRARY(pthread)


### PR DESCRIPTION
Testing to see if this works for #14760 and #14761 
I don't find anywhere suitable to add "-D PB_FIELD_16BIT=1" in PHP's `config.m4`. Thus I append it into the `CFLAGS` and `CXXFLAGS`.