### PR TITLE
Fix leak in gprpp/thd_posix.cc

### DIFF
--- a/src/core/lib/gprpp/thd_posix.cc
+++ b/src/core/lib/gprpp/thd_posix.cc
@@ -110,7 +110,7 @@ class ThreadInternalsPosix
 
     GPR_ASSERT(pthread_attr_destroy(&attr) == 0);
 
-    if (!success) {
+    if (!(*success)) {
       /* don't use gpr_free, as this was allocated using malloc (see above) */
       free(info);
       dec_thd_count();


### PR DESCRIPTION
The success variable is a pointer.