### PR TITLE
cmake "superbuild" example using ExternalProjects_Add

### DIFF
--- a/examples/cpp/helloworld/CMakeLists.txt
+++ b/examples/cpp/helloworld/CMakeLists.txt
@@ -1,7 +1,24 @@
-# Minimum CMake required
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# cmake build file for C++ helloworld example.
+# Assumes protobuf and gRPC have been installed using cmake.
+# See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
+# that automatically builds all the dependencies before building helloworld.
+
 cmake_minimum_required(VERSION 2.8)
 
-# Project
 project(HelloWorld C CXX)
 
 if(NOT MSVC)
@@ -10,57 +27,43 @@ else()
   add_definitions(-D_WIN32_WINNT=0x600)
 endif()
 
-# Protobuf
-# NOTE: we cannot use "CONFIG" mode here because protobuf-config.cmake
-# is broken when used with CMAKE_INSTALL_PREFIX
-find_package(Protobuf REQUIRED)
+# Find Protobuf installation
+# Looks for protobuf-config.cmake file installed by Protobuf's cmake installation.
+set(protobuf_MODULE_COMPATIBLE TRUE)
+find_package(Protobuf CONFIG REQUIRED)
 message(STATUS "Using protobuf ${protobuf_VERSION}")
 
-# {Protobuf,PROTOBUF}_FOUND is defined based on find_package type ("MODULE" vs "CONFIG").
-# For "MODULE", the case has also changed between cmake 3.5 and 3.6.
-# We use the legacy uppercase version for *_LIBRARIES AND *_INCLUDE_DIRS variables
-# as newer cmake versions provide them too for backward compatibility.
-if(Protobuf_FOUND OR PROTOBUF_FOUND)
-  if(TARGET protobuf::libprotobuf)
-    set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
-  else()
-    set(_PROTOBUF_LIBPROTOBUF ${PROTOBUF_LIBRARIES})
-    include_directories(${PROTOBUF_INCLUDE_DIRS})
-  endif()
-  if(TARGET protobuf::protoc)
-    set(_PROTOBUF_PROTOC $<TARGET_FILE:protobuf::protoc>)
-  else()
-    set(_PROTOBUF_PROTOC ${PROTOBUF_PROTOC_EXECUTABLE})
-  endif()
-else()
-  message(WARNING "Failed to locate libprotobuf and protoc!")
-endif()
+set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
+set(_PROTOBUF_PROTOC $<TARGET_FILE:protobuf::protoc>)
 
-# gRPC
+# Find gRPC installation
+# Looks for gRPCConfig.cmake file installed by gRPC's cmake installation.
 find_package(gRPC CONFIG REQUIRED)
 message(STATUS "Using gRPC ${gRPC_VERSION}")
 
 # gRPC C++ plugin
-get_target_property(gRPC_CPP_PLUGIN_EXECUTABLE gRPC::grpc_cpp_plugin
-    IMPORTED_LOCATION_RELEASE)
+set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
 
 # Proto file
 get_filename_component(hw_proto "../../protos/helloworld.proto" ABSOLUTE)
 get_filename_component(hw_proto_path "${hw_proto}" PATH)
 
 # Generated sources
-protobuf_generate_cpp(hw_proto_srcs hw_proto_hdrs "${hw_proto}")
+set(hw_proto_srcs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.pb.cc")
+set(hw_proto_hdrs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.pb.h")
 set(hw_grpc_srcs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.cc")
 set(hw_grpc_hdrs "${CMAKE_CURRENT_BINARY_DIR}/helloworld.grpc.pb.h")
 add_custom_command(
-      OUTPUT "${hw_grpc_srcs}" "${hw_grpc_hdrs}"
+      OUTPUT "${hw_proto_srcs}" "${hw_proto_hdrs}" "${hw_grpc_srcs}" "${hw_grpc_hdrs}"
       COMMAND ${_PROTOBUF_PROTOC}
-      ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}" -I "${hw_proto_path}"
-        --plugin=protoc-gen-grpc="${gRPC_CPP_PLUGIN_EXECUTABLE}"
+      ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
+        --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
+        -I "${hw_proto_path}"
+        --plugin=protoc-gen-grpc="${_GRPC_CPP_PLUGIN_EXECUTABLE}"
         "${hw_proto}"
       DEPENDS "${hw_proto}")
 
-# Generated include directory
+# Include generated *.pb.h files
 include_directories("${CMAKE_CURRENT_BINARY_DIR}")
 
 # Targets greeter_[async_](client|server)

--- a/examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt
+++ b/examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt
@@ -1,0 +1,116 @@
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# cmake "superbuild" file for C++ helloworld example.
+# This build file demonstrates how to build the helloworld project
+# and all its dependencies in a single cmake build (hence "superbuild")
+# that is easy to build and maintain.
+# cmake's ExternalProject_Add() is used to import all the sub-projects,
+# including the "helloworld" project itself.
+# See https://blog.kitware.com/cmake-superbuilds-git-submodules/
+
+cmake_minimum_required(VERSION 2.8)
+
+# Project
+project(HelloWorld-SuperBuild C CXX)
+
+include(ExternalProject)
+
+# Builds c-ares project from the git submodule.
+# Note: For all external projects, instead of using checked-out code, one could
+# specify GIT_REPOSITORY and GIT_TAG to have cmake download the dependency directly,
+# without needing to add a submodule to your project.
+ExternalProject_Add(c-ares
+  PREFIX c-ares
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../third_party/cares/cares"
+  CMAKE_CACHE_ARGS
+        -DCARES_SHARED:BOOL=OFF
+        -DCARES_STATIC:BOOL=ON
+        -DCARES_STATIC_PIC:BOOL=ON
+        -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/c-ares
+)
+
+# Builds protobuf project from the git submodule.
+ExternalProject_Add(protobuf
+  PREFIX protobuf
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../third_party/protobuf/cmake"
+  CMAKE_CACHE_ARGS
+        -Dprotobuf_BUILD_TESTS:BOOL=OFF
+        -Dprotobuf_WITH_ZLIB:BOOL=OFF
+        -Dprotobuf_MSVC_STATIC_RUNTIME:BOOL=OFF
+        -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/protobuf
+)
+
+# Builds zlib project from the git submodule.
+ExternalProject_Add(zlib
+  PREFIX zlib
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../../third_party/zlib"
+  CMAKE_CACHE_ARGS
+        -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/zlib
+)
+
+# the location where protobuf-config.cmake will be installed varies by platform
+if (WIN32)
+  set(_FINDPACKAGE_PROTOBUF_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}/protobuf/cmake")
+else()
+  set(_FINDPACKAGE_PROTOBUF_CONFIG_DIR "${CMAKE_CURRENT_BINARY_DIR}/protobuf/lib/cmake/protobuf")
+endif()
+
+# if OPENSSL_ROOT_DIR is set, propagate that hint path to the external projects with OpenSSL dependency.
+set(_CMAKE_ARGS_OPENSSL_ROOT_DIR "")
+if (OPENSSL_ROOT_DIR)
+  set(_CMAKE_ARGS_OPENSSL_ROOT_DIR "-DOPENSSL_ROOT_DIR:PATH=${OPENSSL_ROOT_DIR}")
+endif()
+
+# Builds gRPC based on locally checked-out sources and set arguments so that all the dependencies
+# are correctly located.
+ExternalProject_Add(grpc
+  PREFIX grpc
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../../.."
+  CMAKE_CACHE_ARGS
+        -DgRPC_INSTALL:BOOL=ON
+        -DgRPC_BUILD_TESTS:BOOL=OFF
+        -DgRPC_PROTOBUF_PROVIDER:STRING=package
+        -DgRPC_PROTOBUF_PACKAGE_TYPE:STRING=CONFIG
+        -DProtobuf_DIR:PATH=${_FINDPACKAGE_PROTOBUF_CONFIG_DIR}
+        -DgRPC_ZLIB_PROVIDER:STRING=package
+        -DZLIB_ROOT:STRING=${CMAKE_CURRENT_BINARY_DIR}/zlib
+        -DgRPC_CARES_PROVIDER:STRING=package
+        -Dc-ares_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/c-ares/lib/cmake/c-ares
+        -DgRPC_SSL_PROVIDER:STRING=package
+        ${_CMAKE_ARGS_OPENSSL_ROOT_DIR}
+        -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/grpc
+  DEPENDS c-ares protobuf zlib
+)
+
+# Build the helloworld projects itself using a CMakeLists.txt that assumes all the dependencies
+# have already been installed.
+# Even though helloworld is not really an "external project" from perspective of this build,
+# we are still importing it using ExternalProject_Add because that allows us to use find_package()
+# to locate all the dependencies (if we were building helloworld directly in this build we,
+# we would have needed to manually import the libraries as opposed to reusing targets exported by
+# gRPC and protobuf).
+ExternalProject_Add(helloworld
+  PREFIX helloworld
+  SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/.."
+  BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/helloworld"
+  INSTALL_COMMAND ""
+  CMAKE_CACHE_ARGS
+        -DProtobuf_DIR:PATH=${_FINDPACKAGE_PROTOBUF_CONFIG_DIR}
+        -Dc-ares_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/c-ares/lib/cmake/c-ares
+        -DZLIB_ROOT:STRING=${CMAKE_CURRENT_BINARY_DIR}/zlib
+        ${_CMAKE_ARGS_OPENSSL_ROOT_DIR}
+        -DgRPC_DIR:PATH=${CMAKE_CURRENT_BINARY_DIR}/grpc/lib/cmake/grpc
+  DEPENDS protobuf grpc
+)

--- a/test/distrib/cpp/run_distrib_test_cmake_as_externalproject.bat
+++ b/test/distrib/cpp/run_distrib_test_cmake_as_externalproject.bat
@@ -1,0 +1,41 @@
+@rem Copyright 2016 gRPC authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+
+@rem enter this directory
+cd /d %~dp0\..\..\..
+
+@rem TODO(jtattermusch): Kokoro has pre-installed protoc.exe in C:\Program Files\ProtoC and that directory
+@rem is on PATH. To avoid picking up the older version protoc.exe, we change the path to something non-existent.
+set PATH=%PATH:ProtoC=DontPickupProtoC%
+
+@rem Download OpenSSL-Win32 originally installed from https://slproweb.com/products/Win32OpenSSL.html
+powershell -Command "(New-Object Net.WebClient).DownloadFile('https://storage.googleapis.com/grpc-testing.appspot.com/OpenSSL-Win32-1_1_0g.zip', 'OpenSSL-Win32.zip')"
+powershell -Command "Add-Type -Assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::ExtractToDirectory('OpenSSL-Win32.zip', '.');"
+
+@rem set absolute path to OpenSSL with forward slashes
+set OPENSSL_DIR=%cd:\=/%/OpenSSL-Win32
+
+@rem Build helloworld example using cmake
+@rem Use non-standard build directory to avoid too long filenames
+mkdir example_build
+cd example_build
+cmake -DOPENSSL_ROOT_DIR=%OPENSSL_DIR% ../examples/cpp/helloworld/cmake_externalproject || goto :error
+cmake --build . --config Release || goto :error
+cd ..
+
+goto :EOF
+
+:error
+echo Failed!
+exit /b %errorlevel%

--- a/test/distrib/cpp/run_distrib_test_cmake_as_externalproject.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_as_externalproject.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+cd "$(dirname "$0")/../../.."
+
+echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
+apt-get update
+apt-get install -t jessie-backports -y libssl-dev
+
+# To increase the confidence that gRPC installation works without depending on
+# too many submodules unnecessarily, just wipe out contents of most submodules
+# before starting the test.
+rm -r third_party/abseil-cpp/* || true
+rm -r third_party/benchmark/* || true
+rm -r third_party/bloaty/* || true
+rm -r third_party/boringssl/* || true
+rm -r third_party/boringssl-with-bazel/* || true
+rm -r third_party/gflags/* || true
+rm -r third_party/googletest/* || true
+
+# Build helloworld example using cmake superbuild
+cd examples/cpp/helloworld/cmake_externalproject
+mkdir -p cmake/build
+cd cmake/build
+cmake ../..
+make
+

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -287,7 +287,9 @@ def targets():
     return [
         CppDistribTest('linux', 'x64', 'jessie', 'routeguide'),
         CppDistribTest('linux', 'x64', 'jessie', 'cmake'),
+        CppDistribTest('linux', 'x64', 'jessie', 'cmake_as_externalproject'),
         CppDistribTest('windows', 'x86', testcase='cmake'),
+        CppDistribTest('windows', 'x86', testcase='cmake_as_externalproject'),
         CSharpDistribTest('linux', 'x64', 'wheezy'),
         CSharpDistribTest('linux', 'x64', 'jessie'),
         CSharpDistribTest('linux', 'x86', 'jessie'),


### PR DESCRIPTION
- demonstrate how to use cmake's "superbuild" technique to easily build a project that uses grpc along with all its dependencies
- add linux & windows distribtests for the project
- polish helloworld's CMakeLists.txt (simplify & add some explanatory comments)
- all the C++ distribtests run on PRs and should be green.