### PR TITLE
PHP: fix pecl installation error for finding address_sorting.h

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -8,6 +8,7 @@ if test "$PHP_GRPC" != "no"; then
   PHP_ADD_INCLUDE(PHP_EXT_SRCDIR()/include)
   PHP_ADD_INCLUDE(PHP_EXT_SRCDIR()/src/php/ext/grpc)
   PHP_ADD_INCLUDE(PHP_EXT_SRCDIR()/third_party/boringssl/include)
+  PHP_ADD_INCLUDE(PHP_EXT_SRCDIR()/third_party/address_sorting/include)
 
   LIBS="-lpthread $LIBS"
 

--- a/templates/config.m4.template
+++ b/templates/config.m4.template
@@ -10,6 +10,7 @@
     PHP_ADD_INCLUDE(PHP_EXT_SRCDIR()/include)
     PHP_ADD_INCLUDE(PHP_EXT_SRCDIR()/src/php/ext/grpc)
     PHP_ADD_INCLUDE(PHP_EXT_SRCDIR()/third_party/boringssl/include)
+    PHP_ADD_INCLUDE(PHP_EXT_SRCDIR()/third_party/address_sorting/include)
 
     LIBS="-lpthread $LIBS"
 


### PR DESCRIPTION
Testing to see if it works for #14761
It works like adding `-I./third_party/address_sorting/include`
Tested on ubuntu and debian locally.