### PR TITLE
Fix Android build

### DIFF
--- a/examples/android/helloworld/app/CMakeLists.txt
+++ b/examples/android/helloworld/app/CMakeLists.txt
@@ -26,6 +26,10 @@ add_library(libgpr STATIC IMPORTED)
 set_target_properties(libgpr PROPERTIES IMPORTED_LOCATION
   ${GRPC_BUILD_DIR}/libgpr.a)
 
+add_library(libaddress_sorting STATIC IMPORTED)
+set_target_properties(libaddress_sorting PROPERTIES IMPORTED_LOCATION
+  ${GRPC_BUILD_DIR}/libaddress_sorting.a)
+
 add_library(libcares STATIC IMPORTED)
 set_target_properties(libcares PROPERTIES IMPORTED_LOCATION
   ${GRPC_BUILD_DIR}/third_party/cares/cares/lib/libcares.a)
@@ -113,6 +117,7 @@ target_include_directories(grpc-helloworld
 target_link_libraries(grpc-helloworld
   libgrpc++
   libgrpc
+  libaddress_sorting
   libzlib
   libcares
   libssl


### PR DESCRIPTION
The fact that new dependencies have to go into the app's CMakeLists.txt instead of being automatically pulled in is itself suspicious, but this at least gets the build working (the app's CMakeLists.txt already explicitly pulls in libzlib, libcares, etc, so this follows the same pattern for third_party/ deps) Longer term solution may involve migrating the android build to bazel.