### PR TITLE
Do not merge: move loading default ssl root certs to grpc_init

### DIFF
--- a/src/core/lib/security/security_connector/security_connector.h
+++ b/src/core/lib/security/security_connector/security_connector.h
@@ -274,12 +274,6 @@ class DefaultSslRootStore {
   // Construct me not!
   DefaultSslRootStore();
 
-  // Initialization of default SSL root store.
-  static void InitRootStore();
-
-  // One-time initialization of default SSL root store.
-  static void InitRootStoreOnce();
-
   // SSL root store in tsi_ssl_root_certs_store object.
   static tsi_ssl_root_certs_store* default_root_store_;
 

--- a/test/core/security/security_connector_test.cc
+++ b/test/core/security/security_connector_test.cc
@@ -398,9 +398,6 @@ static void test_default_ssl_roots(void) {
   grpc_set_ssl_roots_override_callback(override_roots_permanent_failure);
   roots = grpc_core::TestDefafaultSllRootStore::ComputePemRootCertsForTesting();
   GPR_ASSERT(GRPC_SLICE_IS_EMPTY(roots));
-  const tsi_ssl_root_certs_store* root_store =
-      grpc_core::TestDefafaultSllRootStore::GetRootStore();
-  GPR_ASSERT(root_store == nullptr);
 
   /* Cleanup. */
   remove(roots_env_var_file_path);


### PR DESCRIPTION
Currently loading default ssl root certs is only done once using gpr_once_init(). In the situation where grpc_init(), grpc_shutdown(), grpc_init(), the default SSL root store will be nullptr. We now move the initialization of default root certs to grpc_init. 