### PR TITLE
Makes @class forward decls unconditional in generated pbrpc.h files.

### DIFF
--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -206,7 +206,7 @@ void PrintMethodImplementations(Printer* printer,
     }
   }
   for (auto one_class : classes) {
-    output += "  @class " + one_class + ";\n";
+    output += "@class " + one_class + ";\n";
   }
 
   return output;

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -118,7 +118,7 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
       Write(context, file_name + ".pbrpc.h",
             PreprocIfNot(kForwardDeclare, imports) + "\n" +
                 PreprocIfNot(kProtocolOnly, system_imports) + "\n" +
-                class_declarations + "\n"
+                class_declarations + "\n" +
                 PreprocIfNot(kForwardDeclare, class_imports) +
                 "\n" + forward_declarations + "\n" + kNonNullBegin + "\n" +
                 protocols + "\n" + PreprocIfNot(kProtocolOnly, interfaces) +

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -118,8 +118,8 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
       Write(context, file_name + ".pbrpc.h",
             PreprocIfNot(kForwardDeclare, imports) + "\n" +
                 PreprocIfNot(kProtocolOnly, system_imports) + "\n" +
-                PreprocIfElse(kForwardDeclare, class_declarations,
-                              class_imports) +
+                class_declarations + "\n"
+                PreprocIfNot(kForwardDeclare, class_imports) +
                 "\n" + forward_declarations + "\n" + kNonNullBegin + "\n" +
                 protocols + "\n" + PreprocIfNot(kProtocolOnly, interfaces) +
                 "\n" + kNonNullEnd + "\n");

--- a/src/compiler/objective_c_plugin.cc
+++ b/src/compiler/objective_c_plugin.cc
@@ -119,10 +119,10 @@ class ObjectiveCGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
             PreprocIfNot(kForwardDeclare, imports) + "\n" +
                 PreprocIfNot(kProtocolOnly, system_imports) + "\n" +
                 class_declarations + "\n" +
-                PreprocIfNot(kForwardDeclare, class_imports) +
-                "\n" + forward_declarations + "\n" + kNonNullBegin + "\n" +
-                protocols + "\n" + PreprocIfNot(kProtocolOnly, interfaces) +
-                "\n" + kNonNullEnd + "\n");
+                PreprocIfNot(kForwardDeclare, class_imports) + "\n" +
+                forward_declarations + "\n" + kNonNullBegin + "\n" + protocols +
+                "\n" + PreprocIfNot(kProtocolOnly, interfaces) + "\n" +
+                kNonNullEnd + "\n");
     }
 
     {


### PR DESCRIPTION
Rationale:

When using GPB_GRPC_PROTOCOL_ONLY there is no guarantee that the user will actually whitelist all the interface-defined protobuf request/responses.

Unfortunately, since currently we have an Xor(forward decls, class imports) based on GPB_GRPC_FORWARD_DECLARE_MESSAGE_PROTO, any user #importing the .pbrpc.h will need to manually declare these forward decls from their own import site or get a compilation error.

However, there is no danger in allowing these forward decls to exist even when using a #import, and solves this problem, so I propose this fix as a solution.
