### PR TITLE
Don't run sanity tests as part of multilang testsuite.

### DIFF
--- a/tools/internal_ci/linux/grpc_sanity.cfg
+++ b/tools/internal_ci/linux/grpc_sanity.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux sanity opt --inner_jobs 16 -j 1 --internal_ci"
+  value: "-f basictests linux sanity --inner_jobs 16 -j 1 --internal_ci"
 }

--- a/tools/internal_ci/linux/pull_request/grpc_sanity.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_sanity.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
-timeout_mins: 20
+timeout_mins: 40
 action {
   define_artifacts {
     regex: "**/*sponge_log.xml"
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-f basictests linux sanity opt --inner_jobs 16 -j 1 --internal_ci"
+  value: "-f basictests linux sanity --inner_jobs 16 -j 1 --internal_ci"
 }

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -164,9 +164,18 @@ def _generate_jobs(languages,
 
 def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
     test_jobs = []
+    # sanity tests
+    test_jobs += _generate_jobs(
+        languages=['sanity'],
+        configs=['dbg', 'opt'],
+        platforms=['linux'],
+        labels=['basictests'],
+        extra_args=extra_args,
+        inner_jobs=inner_jobs)
+
     # supported on linux only
     test_jobs += _generate_jobs(
-        languages=['sanity', 'php7'],
+        languages=['php7'],
         configs=['dbg', 'opt'],
         platforms=['linux'],
         labels=['basictests', 'multilang'],


### PR DESCRIPTION
There are dedicated "sanity" jobs both on master and on PRs.

- remove "multilang" label from sanity job
- remove a no-longer-needed `grpc_sanity_webhook_test.cfg`
- for grpc_sanity.cfg into a master  and PR version, because once we disable the sanity tests in multilang testsuites, we need to start uploading results to bigquery from the sanity suite itself.