### PR TITLE
Resolve Swift warnings by specifying void arguments

### DIFF
--- a/include/grpc/impl/codegen/fork.h
+++ b/include/grpc/impl/codegen/fork.h
@@ -37,12 +37,12 @@
  * }
  */
 
-void grpc_prefork();
+void grpc_prefork(void);
 
-void grpc_postfork_parent();
+void grpc_postfork_parent(void);
 
-void grpc_postfork_child();
+void grpc_postfork_child(void);
 
-void grpc_fork_handlers_auto_register();
+void grpc_fork_handlers_auto_register(void);
 
 #endif /* GRPC_IMPL_CODEGEN_FORK_H */


### PR DESCRIPTION
The following functions in the `fork.h` file cause a `This function declaration is not a prototype` warning in Swift:
```
void grpc_prefork();

void grpc_postfork_parent();

void grpc_postfork_child();

void grpc_fork_handlers_auto_register();
```

Explicitly specifying `void` as the argument resolves the warnings.

Reproducible using Xcode 9.2 with `SwiftGRPC`/`gRPC-Core` via CocoaPods.