### PR TITLE
Init default root certs store once

### DIFF
--- a/src/core/lib/security/security_connector/security_connector.cc
+++ b/src/core/lib/security/security_connector/security_connector.cc
@@ -1151,16 +1151,6 @@ const char* DefaultSslRootStore::GetPemRootCerts() {
                    GRPC_SLICE_START_PTR(default_pem_root_certs_);
 }
 
-void DefaultSslRootStore::Initialize() {
-  default_root_store_ = nullptr;
-  default_pem_root_certs_ = grpc_empty_slice();
-}
-
-void DefaultSslRootStore::Destroy() {
-  tsi_ssl_root_certs_store_destroy(default_root_store_);
-  grpc_slice_unref_internal(default_pem_root_certs_);
-}
-
 grpc_slice DefaultSslRootStore::ComputePemRootCerts() {
   grpc_slice result = grpc_empty_slice();
   // First try to load the roots from the environment.

--- a/src/core/lib/security/security_connector/security_connector.h
+++ b/src/core/lib/security/security_connector/security_connector.h
@@ -256,15 +256,6 @@ class DefaultSslRootStore {
   // Gets the default PEM root certificate.
   static const char* GetPemRootCerts();
 
-  // Initializes the SSL root store's underlying data structure. It does not
-  // load default SSL root certificates. Should only be called by
-  // grpc_security_init().
-  static void Initialize();
-
-  // Destroys the default SSL root store. Should only be called by
-  // grpc_security_shutdown().
-  static void Destroy();
-
  protected:
   // Returns default PEM root certificates in nullptr terminated grpc_slice.
   // This function is protected instead of private, so that it can be tested.

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -172,7 +172,6 @@ void grpc_shutdown(void) {
           }
         }
       }
-      grpc_security_shutdown();
       grpc_iomgr_shutdown();
       gpr_timers_global_destroy();
       grpc_tracer_shutdown();

--- a/src/core/lib/surface/init.h
+++ b/src/core/lib/surface/init.h
@@ -22,7 +22,6 @@
 void grpc_register_security_filters(void);
 void grpc_security_pre_init(void);
 void grpc_security_init(void);
-void grpc_security_shutdown(void);
 int grpc_is_initialized(void);
 
 #endif /* GRPC_CORE_LIB_SURFACE_INIT_H */

--- a/src/core/lib/surface/init_secure.cc
+++ b/src/core/lib/surface/init_secure.cc
@@ -78,9 +78,4 @@ void grpc_register_security_filters(void) {
                                    maybe_prepend_server_auth_filter, nullptr);
 }
 
-void grpc_security_init() {
-  grpc_security_register_handshaker_factories();
-  grpc_core::DefaultSslRootStore::Initialize();
-}
-
-void grpc_security_shutdown() { grpc_core::DefaultSslRootStore::Destroy(); }
+void grpc_security_init() { grpc_security_register_handshaker_factories(); }

--- a/src/core/lib/surface/init_unsecure.cc
+++ b/src/core/lib/surface/init_unsecure.cc
@@ -25,5 +25,3 @@ void grpc_security_pre_init(void) {}
 void grpc_register_security_filters(void) {}
 
 void grpc_security_init(void) {}
-
-void grpc_security_shutdown(void) {}


### PR DESCRIPTION
Instead of load root cert store at grpc_init and destroy it at grpc_shutdown. This PR just initializes default SSL root certs and root store once and keep them as static value.