### PR TITLE
Update bazel files to make grpc work as an external repository

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -15,17 +15,3 @@
 licenses(["notice"])  # Apache v2
 
 package(default_visibility = ["//:__subpackages__"])
-
-load(":cc_grpc_library.bzl", "cc_grpc_library")
-
-proto_library(
-    name = "well_known_protos_list",
-    srcs = ["@com_google_protobuf//:well_known_protos"],
-)
-
-cc_grpc_library(
-    name = "well_known_protos",
-    srcs = "well_known_protos_list",
-    proto_only = True,
-    deps = [],
-)

--- a/bazel/generate_cc.bzl
+++ b/bazel/generate_cc.bzl
@@ -4,13 +4,20 @@ This is an internal rule used by cc_grpc_library, and shouldn't be used
 directly.
 """
 
+def _maybe_terminate(value, suffix):
+  if value == "" or value.endswith(suffix):
+    return value
+  return value + suffix
+
+
 def generate_cc_impl(ctx):
   """Implementation of the generate_cc rule."""
   protos = [f for src in ctx.attr.srcs for f in src.proto.direct_sources]
   includes = [f for src in ctx.attr.srcs for f in src.proto.transitive_imports]
   outs = []
   # label_len is length of the path from WORKSPACE root to the location of this build file
-  label_len = len(ctx.label.package) + 1
+  prefix = _maybe_terminate(ctx.label.workspace_root, "/") + ctx.label.package
+  label_len = len(_maybe_terminate(prefix, "/"))
   if ctx.executable.plugin:
     outs += [proto.path[label_len:-len(".proto")] + ".grpc.pb.h" for proto in protos]
     outs += [proto.path[label_len:-len(".proto")] + ".grpc.pb.cc" for proto in protos]


### PR DESCRIPTION
The rules in bazel/BUILD were bitrotted, presumably no one was
depending on them.

generate_cc was updated to properly account for the external path that
bazel prepends when being used as an external repository.

A minimal demonstration of grpc integration that works after this patch can be found at: https://github.com/jpieper-tri/grpc_external_test