### PR TITLE
fix generate project sanity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18719,7 +18719,7 @@ else
 
 ifeq ($(NO_PROTOBUF),true)
 
-# You can't build the protoc plugins or protobuf-enabled targets if you don't have protobuf 3.0.0+.
+# You can't build the protoc plugins or protobuf-enabled targets if you don't have protobuf 3.5.0+.
 
 $(BINDIR)/$(CONFIG)/retry_throttle_test: protobuf_dep_error
 


### PR DESCRIPTION
Apparently broken in https://github.com/grpc/grpc/pull/14821 , but seems due to race in merging (sanity tests passed on that PR)