### PR TITLE
Release self retain only after all clean-up done

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -196,9 +196,6 @@ static NSString * const kBearerPrefix = @"Bearer ";
     _state = GRXWriterStateFinished;
   }
 
-  // If the call isn't retained anywhere else, it can be deallocated now.
-  _retainSelf = nil;
-
   // If there were still request messages coming, stop them.
   @synchronized(_requestWriter) {
     _requestWriter.state = GRXWriterStateFinished;
@@ -211,6 +208,9 @@ static NSString * const kBearerPrefix = @"Bearer ";
   }
 
   [GRPCConnectivityMonitor unregisterObserver:self];
+
+  // If the call isn't retained anywhere else, it can be deallocated now.
+  _retainSelf = nil;
 }
 
 - (void)cancelCall {


### PR DESCRIPTION
It is possible that caller of this function does not hold strong reference to GRPCCall object (e.g. [NSNotificationCenter only holds weak reference](https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/KeyValueObserving/Articles/KVOBasics.html)). Hence `_retainSelf` should be nullified at the end of this function. Otherwise some methods after `_retainSelf = nil` are called on a deleted object.