### PR TITLE
Fix missing mutex destruction in C++

### DIFF
--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -129,6 +129,7 @@ static void destroy_server(void* arg, grpc_error* error) {
     gpr_free(sp);
   }
   grpc_channel_args_destroy(s->channel_args);
+  gpr_mu_destroy(&s->mu);
   gpr_free(s);
 }
 

--- a/src/core/lib/iomgr/timer_generic.cc
+++ b/src/core/lib/iomgr/timer_generic.cc
@@ -97,6 +97,12 @@ static void init_timer_ht() {
   }
 }
 
+static void destroy_timer_ht() {
+  for (int i = 0; i < NUM_HASH_BUCKETS; i++) {
+    gpr_mu_destroy(&g_hash_mu[i]);
+  }
+}
+
 static bool is_in_ht(grpc_timer* t) {
   size_t i = GPR_HASH_POINTER(t, NUM_HASH_BUCKETS);
 
@@ -188,6 +194,7 @@ static void validate_non_pending_timer(grpc_timer* t) {
 }
 
 #define INIT_TIMER_HASH_TABLE() init_timer_ht()
+#define DESTROY_TIMER_HASH_TABLE() destroy_timer_ht()
 #define ADD_TO_HASH_TABLE(t) add_to_ht((t))
 #define REMOVE_FROM_HASH_TABLE(t) remove_from_ht((t))
 #define VALIDATE_NON_PENDING_TIMER(t) validate_non_pending_timer((t))
@@ -195,6 +202,7 @@ static void validate_non_pending_timer(grpc_timer* t) {
 #else
 
 #define INIT_TIMER_HASH_TABLE()
+#define DESTROY_TIMER_HASH_TABLE()
 #define ADD_TO_HASH_TABLE(t)
 #define REMOVE_FROM_HASH_TABLE(t)
 #define VALIDATE_NON_PENDING_TIMER(t)
@@ -283,6 +291,8 @@ static void timer_list_shutdown() {
   gpr_free(g_shards);
   gpr_free(g_shard_queue);
   g_shared_mutables.initialized = false;
+
+  DESTROY_TIMER_HASH_TABLE();
 }
 
 /* returns true if the first element in the list */


### PR DESCRIPTION
The change fixes missing mutex destruction in the following places:
- The mutex constructed in [`tcp_server_create`](https://github.com/grpc/grpc/blob/master/src/core/lib/iomgr/tcp_server_windows.cc#L105) is not destroyed in [`destroy_server`](https://github.com/grpc/grpc/blob/master/src/core/lib/iomgr/tcp_server_windows.cc#L118).
- The mutexes constructed in [`init_timer_ht`](https://github.com/grpc/grpc/blob/master/src/core/lib/iomgr/timer_generic.cc#L96) are never destroyed.