### PR TITLE
Work-around for ref-counted subclass deletion address problem.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy.h
+++ b/src/core/ext/filters/client_channel/lb_policy.h
@@ -162,6 +162,10 @@ class LoadBalancingPolicy
   GRPC_ABSTRACT_BASE_CLASS
 
  protected:
+  // So Delete() can access our protected dtor.
+  template <typename T>
+  friend void Delete(T*);
+
   explicit LoadBalancingPolicy(const Args& args);
   virtual ~LoadBalancingPolicy();
 

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -189,6 +189,10 @@ class GrpcLb : public LoadBalancingPolicy {
     bool seen_initial_response() const { return seen_initial_response_; }
 
    private:
+    // So Delete() can access our private dtor.
+    template <typename T>
+    friend void grpc_core::Delete(T*);
+
     ~BalancerCallState();
 
     GrpcLb* grpclb_policy() const {

--- a/src/core/ext/filters/client_channel/method_params.h
+++ b/src/core/ext/filters/client_channel/method_params.h
@@ -60,6 +60,10 @@ class ClientChannelMethodParams : public RefCounted<ClientChannelMethodParams> {
   template <typename T, typename... Args>
   friend T* grpc_core::New(Args&&... args);
 
+  // So Delete() can call our private dtor.
+  template <typename T>
+  friend void grpc_core::Delete(T*);
+
   ClientChannelMethodParams() {}
   virtual ~ClientChannelMethodParams() {}
 

--- a/src/core/ext/filters/client_channel/resolver.h
+++ b/src/core/ext/filters/client_channel/resolver.h
@@ -105,6 +105,10 @@ class Resolver : public InternallyRefCountedWithTracing<Resolver> {
   GRPC_ABSTRACT_BASE_CLASS
 
  protected:
+  // So Delete() can access our protected dtor.
+  template <typename T>
+  friend void Delete(T*);
+
   /// Does NOT take ownership of the reference to \a combiner.
   // TODO(roth): Once we have a C++-like interface for combiners, this
   // API should change to take a RefCountedPtr<>, so that we always take

--- a/src/core/ext/filters/client_channel/retry_throttle.h
+++ b/src/core/ext/filters/client_channel/retry_throttle.h
@@ -42,6 +42,10 @@ class ServerRetryThrottleData : public RefCounted<ServerRetryThrottleData> {
   intptr_t milli_token_ratio() const { return milli_token_ratio_; }
 
  private:
+  // So Delete() can call our private dtor.
+  template <typename T>
+  friend void grpc_core::Delete(T*);
+
   ~ServerRetryThrottleData();
 
   void GetReplacementThrottleDataIfNeeded(

--- a/src/core/lib/gprpp/orphanable.h
+++ b/src/core/lib/gprpp/orphanable.h
@@ -100,7 +100,7 @@ class InternallyRefCounted : public Orphanable {
 
   void Unref() {
     if (gpr_unref(&refs_)) {
-      Delete(this);
+      Delete(static_cast<Child*>(this));
     }
   }
 
@@ -173,7 +173,7 @@ class InternallyRefCountedWithTracing : public Orphanable {
 
   void Unref() {
     if (gpr_unref(&refs_)) {
-      Delete(this);
+      Delete(static_cast<Child*>(this));
     }
   }
 

--- a/src/core/lib/gprpp/ref_counted.h
+++ b/src/core/lib/gprpp/ref_counted.h
@@ -54,7 +54,7 @@ class RefCounted {
   // friend of this class.
   void Unref() {
     if (gpr_unref(&refs_)) {
-      Delete(this);
+      Delete(static_cast<Child*>(this));
     }
   }
 
@@ -114,7 +114,7 @@ class RefCountedWithTracing {
 
   void Unref() {
     if (gpr_unref(&refs_)) {
-      Delete(this);
+      Delete(static_cast<Child*>(this));
     }
   }
 

--- a/src/core/lib/slice/slice_hash_table.h
+++ b/src/core/lib/slice/slice_hash_table.h
@@ -81,6 +81,10 @@ class SliceHashTable : public RefCounted<SliceHashTable<T>> {
   template <typename T2, typename... Args>
   friend T2* New(Args&&... args);
 
+  // So Delete() can call our private dtor.
+  template <typename T2>
+  friend void Delete(T2*);
+
   SliceHashTable(size_t num_entries, Entry* entries, ValueCmp value_cmp);
   virtual ~SliceHashTable();
 

--- a/src/core/lib/slice/slice_weak_hash_table.h
+++ b/src/core/lib/slice/slice_weak_hash_table.h
@@ -65,6 +65,10 @@ class SliceWeakHashTable : public RefCounted<SliceWeakHashTable<T, Size>> {
   template <typename T2, typename... Args>
   friend T2* New(Args&&... args);
 
+  // So Delete() can call our private dtor.
+  template <typename T2>
+  friend void Delete(T2*);
+
   SliceWeakHashTable() = default;
   ~SliceWeakHashTable() = default;
 

--- a/src/core/tsi/ssl/session_cache/ssl_session_cache.h
+++ b/src/core/tsi/ssl/session_cache/ssl_session_cache.h
@@ -69,6 +69,10 @@ class SslSessionLRUCache : public grpc_core::RefCounted<SslSessionLRUCache> {
   template <typename T, typename... Args>
   friend T* grpc_core::New(Args&&... args);
 
+  // So Delete() can call our private dtor.
+  template <typename T>
+  friend void grpc_core::Delete(T*);
+
   class Node;
 
   explicit SslSessionLRUCache(size_t capacity);


### PR DESCRIPTION
I've once again run into the problem where the ref-counted base class is passing a different address to `Delete()` than the one that was returned from `New()`.  In this case, I was not using multiple inheritance, so I'm not sure what triggered the problem, but I suspect it has something to do with the way I'm templating the class that inherits from the ref-counting base class.  See #14886 for the code that caused the problem.

In any case, it looks like this problem can be worked around for now by explicitly casting the pointer to the subclass type when passing it to `Delete()`, so I've changed the ref-counting classes to do that in this PR.

I'm not really happy with this approach, because it makes our use of CRTP somewhat viral.  Any time we run into this problem, we need to parameterize all classes in the inheritance hierarchy with the type of the leaf class.  But I don't have a better solution until we're able to use C++ `new` and `delete`.

For some reason, this requires making `Delete()` a friend of all subclasses with private or protected dtors.  I'm not sure exactly why, but the compiler wasn't happy without it.

If you have any better suggestions for how to deal with this, I'd love to hear them.