### PR TITLE
Remove exec_ctx from slice and slice buffer

### DIFF
--- a/src/core/lib/slice/slice.cc
+++ b/src/core/lib/slice/slice.cc
@@ -68,10 +68,7 @@ grpc_slice grpc_slice_ref(grpc_slice slice) {
 }
 
 /* Public API */
-void grpc_slice_unref(grpc_slice slice) {
-  grpc_core::ExecCtx exec_ctx;
-  grpc_slice_unref_internal(slice);
-}
+void grpc_slice_unref(grpc_slice slice) { grpc_slice_unref_internal(slice); }
 
 /* grpc_slice_from_static_string support structure - a refcount that does
    nothing */

--- a/src/core/lib/slice/slice.cc
+++ b/src/core/lib/slice/slice.cc
@@ -68,7 +68,14 @@ grpc_slice grpc_slice_ref(grpc_slice slice) {
 }
 
 /* Public API */
-void grpc_slice_unref(grpc_slice slice) { grpc_slice_unref_internal(slice); }
+void grpc_slice_unref(grpc_slice slice) {
+  if (grpc_core::ExecCtx::Get() == nullptr) {
+    grpc_core::ExecCtx exec_ctx;
+    grpc_slice_unref_internal(slice);
+  } else {
+    grpc_slice_unref_internal(slice);
+  }
+}
 
 /* grpc_slice_from_static_string support structure - a refcount that does
    nothing */

--- a/src/core/lib/slice/slice_buffer.cc
+++ b/src/core/lib/slice/slice_buffer.cc
@@ -75,7 +75,12 @@ void grpc_slice_buffer_destroy_internal(grpc_slice_buffer* sb) {
 }
 
 void grpc_slice_buffer_destroy(grpc_slice_buffer* sb) {
-  grpc_slice_buffer_destroy_internal(sb);
+  if (grpc_core::ExecCtx::Get() == nullptr) {
+    grpc_core::ExecCtx exec_ctx;
+    grpc_slice_buffer_destroy_internal(sb);
+  } else {
+    grpc_slice_buffer_destroy_internal(sb);
+  }
 }
 
 uint8_t* grpc_slice_buffer_tiny_add(grpc_slice_buffer* sb, size_t n) {
@@ -175,7 +180,12 @@ void grpc_slice_buffer_reset_and_unref_internal(grpc_slice_buffer* sb) {
 }
 
 void grpc_slice_buffer_reset_and_unref(grpc_slice_buffer* sb) {
-  grpc_slice_buffer_reset_and_unref_internal(sb);
+  if (grpc_core::ExecCtx::Get() == nullptr) {
+    grpc_core::ExecCtx exec_ctx;
+    grpc_slice_buffer_reset_and_unref_internal(sb);
+  } else {
+    grpc_slice_buffer_reset_and_unref_internal(sb);
+  }
 }
 
 void grpc_slice_buffer_swap(grpc_slice_buffer* a, grpc_slice_buffer* b) {

--- a/src/core/lib/slice/slice_buffer.cc
+++ b/src/core/lib/slice/slice_buffer.cc
@@ -75,7 +75,6 @@ void grpc_slice_buffer_destroy_internal(grpc_slice_buffer* sb) {
 }
 
 void grpc_slice_buffer_destroy(grpc_slice_buffer* sb) {
-  grpc_core::ExecCtx exec_ctx;
   grpc_slice_buffer_destroy_internal(sb);
 }
 
@@ -176,7 +175,6 @@ void grpc_slice_buffer_reset_and_unref_internal(grpc_slice_buffer* sb) {
 }
 
 void grpc_slice_buffer_reset_and_unref(grpc_slice_buffer* sb) {
-  grpc_core::ExecCtx exec_ctx;
   grpc_slice_buffer_reset_and_unref_internal(sb);
 }
 

--- a/test/core/end2end/tests/resource_quota_server.cc
+++ b/test/core/end2end/tests/resource_quota_server.cc
@@ -26,6 +26,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 
+#include "src/core/lib/iomgr/exec_ctx.h"
 #include "test/core/end2end/cq_verifier.h"
 
 static void* tag(intptr_t t) { return (void*)t; }
@@ -106,6 +107,7 @@ void resource_quota_server(grpc_end2end_test_config config) {
       FEATURE_MASK_DOES_NOT_SUPPORT_RESOURCE_QUOTA_SERVER) {
     return;
   }
+  grpc_core::ExecCtx exec_ctx;
   grpc_resource_quota* resource_quota =
       grpc_resource_quota_create("test_server");
   grpc_resource_quota_resize(resource_quota, 5 * 1024 * 1024);

--- a/test/core/end2end/tests/resource_quota_server.cc
+++ b/test/core/end2end/tests/resource_quota_server.cc
@@ -26,7 +26,6 @@
 #include <grpc/support/log.h>
 #include <grpc/support/time.h>
 
-#include "src/core/lib/iomgr/exec_ctx.h"
 #include "test/core/end2end/cq_verifier.h"
 
 static void* tag(intptr_t t) { return (void*)t; }
@@ -107,7 +106,6 @@ void resource_quota_server(grpc_end2end_test_config config) {
       FEATURE_MASK_DOES_NOT_SUPPORT_RESOURCE_QUOTA_SERVER) {
     return;
   }
-  grpc_core::ExecCtx exec_ctx;
   grpc_resource_quota* resource_quota =
       grpc_resource_quota_create("test_server");
   grpc_resource_quota_resize(resource_quota, 5 * 1024 * 1024);


### PR DESCRIPTION
Since slice and slice buffer are not part of surface API here, we should not need to create exec_ctx on the stack here.