### PR TITLE
add java options to empty.proto

### DIFF
--- a/src/proto/grpc/testing/empty.proto
+++ b/src/proto/grpc/testing/empty.proto
@@ -17,6 +17,9 @@ syntax = "proto3";
 
 package grpc.testing;
 
+option java_package = "io.grpc.testing.integration";
+option java_outer_classname = "EmptyProtos";
+
 // An empty message that you can re-use to avoid defining duplicated empty
 // messages in your project. A typical example is to use it as argument or the
 // return value of a service API. For instance:


### PR DESCRIPTION
Add java options to empty.proto for consistency.
In grpc-java, empty.proto has some java options. https://github.com/grpc/grpc-java/blob/master/interop-testing/src/main/proto/io/grpc/testing/integration/empty.proto

ref:
https://github.com/grpc/grpc-java/issues/4241
https://github.com/grpc/grpc-java/commit/156cc44c5f6ad64ff9b6706e4b03f24abadb4c99

cc: @ejona86 