### PR TITLE
Fix build with LibreSSL 2.7

### DIFF
--- a/src/core/lib/security/credentials/jwt/jwt_verifier.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.cc
@@ -466,7 +466,7 @@ static BIGNUM* bignum_from_base64(const char* b64) {
   return result;
 }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x20700000L)
 
 // Provide compatibility across OpenSSL 1.02 and 1.1.
 static int RSA_set0_key(RSA* r, BIGNUM* n, BIGNUM* e, BIGNUM* d) {


### PR DESCRIPTION
LibreSSL 2.7 adds OpenSSL 1.1 API leading to conflicts in method names

See also: https://bugs.freebsd.org/227187
Signed-off-by: Bernard Spil <brnrd@FreeBSD.org>