### PR TITLE
Making tcp_custom's setsockopt a more generic thing.

### DIFF
--- a/src/core/lib/iomgr/tcp_custom.h
+++ b/src/core/lib/iomgr/tcp_custom.h
@@ -62,7 +62,6 @@ typedef struct grpc_socket_vtable {
                              const grpc_sockaddr* addr, int* len);
   grpc_error* (*getsockname)(grpc_custom_socket* socket,
                              const grpc_sockaddr* addr, int* len);
-  grpc_error* (*setsockopt)(grpc_custom_socket* socket);
   grpc_error* (*bind)(grpc_custom_socket* socket, const grpc_sockaddr* addr,
                       size_t len, int flags);
   grpc_error* (*listen)(grpc_custom_socket* socket);

--- a/src/core/lib/iomgr/tcp_custom.h
+++ b/src/core/lib/iomgr/tcp_custom.h
@@ -62,8 +62,7 @@ typedef struct grpc_socket_vtable {
                              const grpc_sockaddr* addr, int* len);
   grpc_error* (*getsockname)(grpc_custom_socket* socket,
                              const grpc_sockaddr* addr, int* len);
-  grpc_error* (*setsockopt)(grpc_custom_socket* socket, int level, int optname,
-                            const void* optval, uint32_t optlen);
+  grpc_error* (*setsockopt)(grpc_custom_socket* socket);
   grpc_error* (*bind)(grpc_custom_socket* socket, const grpc_sockaddr* addr,
                       size_t len, int flags);
   grpc_error* (*listen)(grpc_custom_socket* socket);

--- a/src/core/lib/iomgr/tcp_server_custom.cc
+++ b/src/core/lib/iomgr/tcp_server_custom.cc
@@ -393,10 +393,6 @@ static grpc_error* tcp_server_add_port(grpc_tcp_server* s,
   grpc_custom_socket_vtable->init(socket, family);
 
   if (error == GRPC_ERROR_NONE) {
-    error = grpc_custom_socket_vtable->setsockopt(socket);
-  }
-
-  if (error == GRPC_ERROR_NONE) {
     error = add_socket_to_server(s, socket, addr, port_index, &sp);
   }
   gpr_free(allocated_addr);

--- a/src/core/lib/iomgr/tcp_server_custom.cc
+++ b/src/core/lib/iomgr/tcp_server_custom.cc
@@ -393,13 +393,10 @@ static grpc_error* tcp_server_add_port(grpc_tcp_server* s,
   grpc_custom_socket_vtable->init(socket, family);
 
   if (error == GRPC_ERROR_NONE) {
-#if defined(GPR_LINUX) && defined(SO_REUSEPORT)
-    if (family == AF_INET || family == AF_INET6) {
-      int enable = 1;
-      grpc_custom_socket_vtable->setsockopt(socket, SOL_SOCKET, SO_REUSEPORT,
-                                            &enable, sizeof(enable));
-    }
-#endif /* GPR_LINUX && SO_REUSEPORT */
+    error = grpc_custom_socket_vtable->setsockopt(socket);
+  }
+
+  if (error == GRPC_ERROR_NONE) {
     error = add_socket_to_server(s, socket, addr, port_index, &sp);
   }
   gpr_free(allocated_addr);

--- a/src/core/lib/iomgr/tcp_uv.cc
+++ b/src/core/lib/iomgr/tcp_uv.cc
@@ -192,6 +192,16 @@ static grpc_error* uv_socket_init_helper(uv_socket_t* uv_socket, int domain) {
   if (status != 0) {
     return tcp_error_create("Failed to initialize UV tcp handle", status);
   }
+#if defined(GPR_LINUX) && defined(SO_REUSEPORT)
+  if (domain == AF_INET || domain == AF_INET6) {
+    int enable = 1;
+    int fd;
+    uv_socket_t* uv_socket = (uv_socket_t*)socket->impl;
+    uv_fileno((uv_handle_t*)uv_socket->handle, &fd);
+    // TODO Handle error here.
+    setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(enable));
+  }
+#endif
   uv_socket->write_buffers = nullptr;
   uv_socket->read_len = 0;
   uv_tcp_nodelay(uv_socket->handle, 1);
@@ -297,20 +307,6 @@ static grpc_error* uv_socket_listen(grpc_custom_socket* socket) {
   int status =
       uv_listen((uv_stream_t*)uv_socket->handle, SOMAXCONN, uv_on_connect);
   return tcp_error_create("Failed to listen to port", status);
-}
-
-static grpc_error* uv_socket_setsockopt(grpc_custom_socket* socket) {
-#if defined(GPR_LINUX) && defined(SO_REUSEPORT)
-  if (family == AF_INET || family == AF_INET6) {
-    int enable = 1;
-    int fd;
-    uv_socket_t* uv_socket = (uv_socket_t*)socket->impl;
-    uv_fileno((uv_handle_t*)uv_socket->handle, &fd);
-    // TODO Handle error here.
-    setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(enable));
-  }
-#endif
-  return GRPC_ERROR_NONE;
 }
 
 static void uv_tc_on_connect(uv_connect_t* req, int status) {
@@ -421,7 +417,6 @@ grpc_socket_vtable grpc_uv_socket_vtable = {
     uv_socket_init,       uv_socket_connect,     uv_socket_destroy,
     uv_socket_shutdown,   uv_socket_close,       uv_socket_write,
     uv_socket_read,       uv_socket_getpeername, uv_socket_getsockname,
-    uv_socket_setsockopt, uv_socket_bind,        uv_socket_listen,
-    uv_socket_accept};
+    uv_socket_bind,        uv_socket_listen,     uv_socket_accept};
 
 #endif

--- a/src/core/lib/iomgr/tcp_uv.cc
+++ b/src/core/lib/iomgr/tcp_uv.cc
@@ -414,9 +414,9 @@ static void uv_resolve_async(grpc_custom_resolver* r, char* host, char* port) {
 grpc_custom_resolver_vtable uv_resolver_vtable = {uv_resolve, uv_resolve_async};
 
 grpc_socket_vtable grpc_uv_socket_vtable = {
-    uv_socket_init,       uv_socket_connect,     uv_socket_destroy,
-    uv_socket_shutdown,   uv_socket_close,       uv_socket_write,
-    uv_socket_read,       uv_socket_getpeername, uv_socket_getsockname,
-    uv_socket_bind,        uv_socket_listen,     uv_socket_accept};
+    uv_socket_init,     uv_socket_connect,     uv_socket_destroy,
+    uv_socket_shutdown, uv_socket_close,       uv_socket_write,
+    uv_socket_read,     uv_socket_getpeername, uv_socket_getsockname,
+    uv_socket_bind,     uv_socket_listen,      uv_socket_accept};
 
 #endif

--- a/src/core/lib/iomgr/tcp_uv.cc
+++ b/src/core/lib/iomgr/tcp_uv.cc
@@ -196,8 +196,7 @@ static grpc_error* uv_socket_init_helper(uv_socket_t* uv_socket, int domain) {
   if (domain == AF_INET || domain == AF_INET6) {
     int enable = 1;
     int fd;
-    uv_socket_t* uv_socket = (uv_socket_t*)socket->impl;
-    uv_fileno((uv_handle_t*)uv_socket->handle, &fd);
+    uv_fileno((uv_handle_t*)tcp, &fd);
     // TODO Handle error here.
     setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(enable));
   }

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pxd
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pxd
@@ -83,8 +83,7 @@ cdef extern from "src/core/lib/iomgr/tcp_custom.h":
                                  const grpc_sockaddr* addr, int* len);
       grpc_error* (*getsockname)(grpc_custom_socket* socket,
                              const grpc_sockaddr* addr, int* len);
-      grpc_error* (*setsockopt)(grpc_custom_socket* socket, int level, int optname,
-                                const void* optval, uint32_t len);
+      grpc_error* (*setsockopt)(grpc_custom_socket* socket);
       grpc_error* (*bind)(grpc_custom_socket* socket, const grpc_sockaddr* addr,
                           size_t len, int flags);
       grpc_error* (*listen)(grpc_custom_socket* socket);

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pxd
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pxd
@@ -83,7 +83,6 @@ cdef extern from "src/core/lib/iomgr/tcp_custom.h":
                                  const grpc_sockaddr* addr, int* len);
       grpc_error* (*getsockname)(grpc_custom_socket* socket,
                              const grpc_sockaddr* addr, int* len);
-      grpc_error* (*setsockopt)(grpc_custom_socket* socket);
       grpc_error* (*bind)(grpc_custom_socket* socket, const grpc_sockaddr* addr,
                           size_t len, int flags);
       grpc_error* (*listen)(grpc_custom_socket* socket);

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx
@@ -239,8 +239,7 @@ cdef grpc_error* socket_getsockname(grpc_custom_socket* socket,
   length[0] = c_addr.len
   return grpc_error_none()
 
-cdef grpc_error* socket_setsockopt(grpc_custom_socket* socket, int level, int optname,
-                const void *optval, uint32_t optlen) with gil:
+cdef grpc_error* socket_setsockopt(grpc_custom_socket* socket) with gil:
   # No-op; we provide a default set of options
   return grpc_error_none()
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx
@@ -239,10 +239,6 @@ cdef grpc_error* socket_getsockname(grpc_custom_socket* socket,
   length[0] = c_addr.len
   return grpc_error_none()
 
-cdef grpc_error* socket_setsockopt(grpc_custom_socket* socket) with gil:
-  # No-op; we provide a default set of options
-  return grpc_error_none()
-
 def applysockopts(s):
   s.setsockopt(gevent_socket.SOL_SOCKET, gevent_socket.SO_REUSEADDR, 1)
   s.setsockopt(gevent_socket.IPPROTO_TCP, gevent_socket.TCP_NODELAY, True)
@@ -434,7 +430,6 @@ def init_grpc_gevent():
   gevent_socket_vtable.read = socket_read
   gevent_socket_vtable.getpeername = socket_getpeername
   gevent_socket_vtable.getsockname = socket_getsockname
-  gevent_socket_vtable.setsockopt = socket_setsockopt
   gevent_socket_vtable.bind = socket_bind
   gevent_socket_vtable.listen = socket_listen
   gevent_socket_vtable.accept = socket_accept


### PR DESCRIPTION
Kind of part of the discussion we had at some point - trying to make setsockopt a bit more of a "set default socket options we always want unconditionally". Also fixes a Windows breakage :P