### PR TITLE
Don't raise call errors for failed reads or writes of ruby bidi streams

### DIFF
--- a/src/ruby/lib/grpc/generic/bidi_call.rb
+++ b/src/ruby/lib/grpc/generic/bidi_call.rb
@@ -124,12 +124,18 @@ module GRPC
     def read_using_run_batch
       ops = { RECV_MESSAGE => nil }
       ops[RECV_INITIAL_METADATA] = nil unless @metadata_received
-      batch_result = @call.run_batch(ops)
-      unless @metadata_received
-        @call.metadata = batch_result.metadata
-        @metadata_received = true
+      begin
+        batch_result = @call.run_batch(ops)
+        unless @metadata_received
+          @call.metadata = batch_result.metadata
+          @metadata_received = true
+        end
+        batch_result
+      rescue GRPC::Core::CallError => e
+        GRPC.logger.warn('bidi call: read_using_run_batch failed')
+        GRPC.logger.warn(e)
+        nil
       end
-      batch_result
     end
 
     # set_output_stream_done is relevant on client-side
@@ -155,7 +161,12 @@ module GRPC
       GRPC.logger.debug("bidi-write-loop: #{count} writes done")
       if is_client
         GRPC.logger.debug("bidi-write-loop: client sent #{count}, waiting")
-        @call.run_batch(SEND_CLOSE_FROM_CLIENT => nil)
+        begin
+          @call.run_batch(SEND_CLOSE_FROM_CLIENT => nil)
+        rescue GRPC::Core::CallError => e
+          GRPC.logger.warn('bidi-write-loop: send close failed')
+          GRPC.logger.warn(e)
+        end
         GRPC.logger.debug('bidi-write-loop: done')
       end
       GRPC.logger.debug('bidi-write-loop: finished')
@@ -187,7 +198,7 @@ module GRPC
           batch_result = read_using_run_batch
 
           # handle the next message
-          if batch_result.message.nil?
+          if batch_result.nil? || batch_result.message.nil?
             GRPC.logger.debug("bidi-read-loop: null batch #{batch_result}")
 
             if is_client


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/14853

This doesn't fix the underlying reason why certain message read/write attempts are failing, but it does convert those errors from `GRPC::Core::CallErrors` to `GRPC::BadStatus` errors. Doing so fixes the "silent failure" issue described in that issue, and also fixes the situation related to that issue in which the raising of `GRPC::Core::CallErrors` by the gRPC-Ruby library breaks application's ability to turn on `Thread.abort_on_exception = true` (currently, if someone sets `Thread.abort_on_exception = true`, and a write-message-attempt of a bidi call fails, then the process will crash).