### PR TITLE
rename grpc_coverage XML log to get recognized by resultstore

### DIFF
--- a/tools/internal_ci/linux/grpc_coverage.sh
+++ b/tools/internal_ci/linux/grpc_coverage.sh
@@ -21,10 +21,9 @@ cd $(dirname $0)/../../..
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
 python tools/run_tests/run_tests.py \
-  --use_docker				        \
+  --use_docker                      \
   -t                                \
   -l all                            \
   -c gcov                           \
-  -x report.xml                     \
+  -x sponge_log.xml                 \
   -j 16
-  


### PR DESCRIPTION
Rename the report.xml so it gets picked up by resultstore and the structured test results get displayed in the UI.

Progress towards https://github.com/grpc/grpc/issues/14924.