### PR TITLE
Revert "Orphan underlying byte stream as soon as it's been drained."

### DIFF
--- a/src/core/lib/transport/byte_stream.h
+++ b/src/core/lib/transport/byte_stream.h
@@ -139,7 +139,6 @@ class ByteStreamCache {
    private:
     ByteStreamCache* cache_;
     size_t cursor_ = 0;
-    size_t offset_ = 0;
     grpc_error* shutdown_error_ = GRPC_ERROR_NONE;
   };
 
@@ -154,8 +153,6 @@ class ByteStreamCache {
 
  private:
   OrphanablePtr<ByteStream> underlying_stream_;
-  uint32_t length_;
-  uint32_t flags_;
   grpc_slice_buffer cache_buffer_;
 };
 


### PR DESCRIPTION
Reverts grpc/grpc#14686

Try to fix a timeout issue. 