### PR TITLE
Fix gRPC ObjC return status

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -355,17 +355,8 @@ static NSString * const kBearerPrefix = @"Bearer ";
   }
 
   dispatch_async(_callQueue, ^{
-    __weak GRPCCall *weakSelf = self;
-    [self writeMessage:value withErrorHandler:^{
-      __strong GRPCCall *strongSelf = weakSelf;
-      if (strongSelf != nil) {
-        [strongSelf maybeFinishWithError:[NSError errorWithDomain:kGRPCErrorDomain
-                                                             code:GRPCErrorCodeInternal
-                                                         userInfo:nil]];
-        // Wrapped call must be canceled when error is reported to upper layers
-        [strongSelf cancelCall];
-      }
-    }];
+    // Write error is not processed here. It is handled by op batch of GRPC_OP_RECV_STATUS_ON_CLIENT
+    [self writeMessage:value withErrorHandler:nil];
   });
 }
 
@@ -387,15 +378,8 @@ static NSString * const kBearerPrefix = @"Bearer ";
     [self cancel];
   } else {
     dispatch_async(_callQueue, ^{
-      __weak GRPCCall *weakSelf = self;
-      [self finishRequestWithErrorHandler:^{
-        __strong GRPCCall *strongSelf = weakSelf;
-        [strongSelf maybeFinishWithError:[NSError errorWithDomain:kGRPCErrorDomain
-                                                             code:GRPCErrorCodeInternal
-                                                         userInfo:nil]];
-        // Wrapped call must be canceled when error is reported to upper layers
-        [strongSelf cancelCall];
-      }];
+      // EOS error is not processed here. It is handled by op batch of GRPC_OP_RECV_STATUS_ON_CLIENT
+      [self finishRequestWithErrorHandler:nil];
     });
   }
 }


### PR DESCRIPTION
Currently, when a write op failed the ObjC layer creates an INTERNAL error and surfaces it to user. We should not do this and, instead, should surface the return status from core (via `GRPC_OP_RECV_STATUS_ON_CLIENT`). This change removes creation and surface of INTERNAL error status so that the status in GRPC_OP_RECV_STATUS_ON_CLIENT can be surfaced.

Fixes #14612 