### PR TITLE
Use ResultStore URL instead of Sponge for bigquery test results

### DIFF
--- a/tools/run_tests/python_utils/upload_test_results.py
+++ b/tools/run_tests/python_utils/upload_test_results.py
@@ -74,7 +74,7 @@ def _get_build_metadata(test_results):
     build_id = os.getenv('BUILD_ID') or os.getenv('KOKORO_BUILD_NUMBER')
     build_url = os.getenv('BUILD_URL')
     if os.getenv('KOKORO_BUILD_ID'):
-        build_url = 'https://sponge.corp.google.com/invocation?id=%s' % os.getenv(
+        build_url = 'https://source.cloud.google.com/results/invocations/%s' % os.getenv(
             'KOKORO_BUILD_ID')
     job_name = os.getenv('JOB_BASE_NAME') or os.getenv('KOKORO_JOB_NAME')
 


### PR DESCRIPTION
Sponge URLs are commonly copy-pasted into github issues for current flakes but they are not accessible externally.
Resultstore URLs have the same info but can be accessed by everyone.