### PR TITLE
Fix c-ares tests under gcc musl

### DIFF
--- a/templates/test/cpp/naming/resolver_component_tests_defs.include
+++ b/templates/test/cpp/naming/resolver_component_tests_defs.include
@@ -36,7 +36,8 @@ if [[ "$GRPC_DNS_RESOLVER" != "" && "$GRPC_DNS_RESOLVER" != ares ]]; then
 fi
 export GRPC_DNS_RESOLVER=ares
 
-"$FLAGS_dns_server_bin_path" --records_config_path="$FLAGS_records_config_path" --port="$FLAGS_dns_server_port" > /dev/null 2>&1 &
+DNS_SERVER_LOG="$(mktemp)"
+"$FLAGS_dns_server_bin_path" --records_config_path="$FLAGS_records_config_path" --port="$FLAGS_dns_server_port" > "$DNS_SERVER_LOG" 2>&1 &
 DNS_SERVER_PID=$!
 echo "Local DNS server started. PID: $DNS_SERVER_PID"
 
@@ -55,8 +56,11 @@ done
 
 if [[ $RETRY == 1 ]]; then
   echo "FAILED TO START LOCAL DNS SERVER"
-  kill -SIGTERM "$DNS_SERVER_PID"
+  kill -SIGTERM "$DNS_SERVER_PID" || true
   wait
+  echo "========== DNS server log (merged stdout and stderr) ========="
+  cat "$DNS_SERVER_LOG"
+  echo "========== end DNS server log ================================"
   exit 1
 fi
 

--- a/templates/tools/dockerfile/test/cxx_alpine_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_alpine_x64/Dockerfile.template
@@ -34,6 +34,7 @@
     strace ${'\\'}
     python-dev ${'\\'}
     py-pip ${'\\'}
+    py-yaml ${'\\'}
     unzip ${'\\'}
     wget ${'\\'}
     zip

--- a/test/cpp/naming/resolver_component_tests_runner.sh
+++ b/test/cpp/naming/resolver_component_tests_runner.sh
@@ -36,7 +36,8 @@ if [[ "$GRPC_DNS_RESOLVER" != "" && "$GRPC_DNS_RESOLVER" != ares ]]; then
 fi
 export GRPC_DNS_RESOLVER=ares
 
-"$FLAGS_dns_server_bin_path" --records_config_path="$FLAGS_records_config_path" --port="$FLAGS_dns_server_port" > /dev/null 2>&1 &
+DNS_SERVER_LOG="$(mktemp)"
+"$FLAGS_dns_server_bin_path" --records_config_path="$FLAGS_records_config_path" --port="$FLAGS_dns_server_port" > "$DNS_SERVER_LOG" 2>&1 &
 DNS_SERVER_PID=$!
 echo "Local DNS server started. PID: $DNS_SERVER_PID"
 
@@ -55,8 +56,11 @@ done
 
 if [[ $RETRY == 1 ]]; then
   echo "FAILED TO START LOCAL DNS SERVER"
-  kill -SIGTERM "$DNS_SERVER_PID"
+  kill -SIGTERM "$DNS_SERVER_PID" || true
   wait
+  echo "========== DNS server log (merged stdout and stderr) ========="
+  cat "$DNS_SERVER_LOG"
+  echo "========== end DNS server log ================================"
   exit 1
 fi
 

--- a/tools/dockerfile/test/cxx_alpine_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_alpine_x64/Dockerfile
@@ -32,6 +32,7 @@ RUN apk update && apk add \
   strace \
   python-dev \
   py-pip \
+  py-yaml \
   unzip \
   wget \
   zip


### PR DESCRIPTION
fixes https://github.com/grpc/grpc/issues/14928 - the DNS server was [failing to import the yaml package](https://github.com/grpc/grpc/blob/master/test/cpp/naming/utils/dns_server.py#L20)

also starts `cat`'ing the DNS server's log if it failed to start