### PR TITLE
Unpin pip version installed in build_python.sh

### DIFF
--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -132,7 +132,7 @@ fi
 # Perform build operations #
 ############################
 
-# Instnatiate the virtualenv, preferring to do so from the relevant python
+# Instantiate the virtualenv, preferring to do so from the relevant python
 # version. Even if these commands fail (e.g. on Windows due to name conflicts)
 # it's possible that the virtualenv is still usable and we trust the tester to
 # be able to 'figure it out' instead of us e.g. doing potentially expensive and
@@ -158,7 +158,7 @@ case "$VENV" in
   ;;
 esac
 
-$VENV_PYTHON -m pip install --upgrade pip==9.0.1
+$VENV_PYTHON -m pip install --upgrade pip
 $VENV_PYTHON -m pip install setuptools
 $VENV_PYTHON -m pip install cython
 $VENV_PYTHON -m pip install six enum34 protobuf futures


### PR DESCRIPTION
Fix for issue #14815. 

Pinning to 9.0.3 doesn't work because pip fails to recognize that as a valid version. Newer versions of pip have a fallback on macOS to use SecureTransport instead of their outdated OpenSSL that doesn't support TLSv1.2.

See this for why pinning to 9.0.3 fails:
```
+ /Volumes/BuildData/tmpfs/src/github/grpc/workspace_python_macos_opt_native/py34_native/bin/python3.4 -m pip install --upgrade pip==9.0.3
Collecting pip==9.0.3
  Could not find a version that satisfies the requirement pip==9.0.3 (from versions: )
No matching distribution found for pip==9.0.3
You are using pip version 9.0.1, however version 9.0.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```