### PR TITLE
poll-cv Fix for zero timeout

### DIFF
--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -1530,6 +1530,12 @@ static void run_poll(void* args) {
 
 // This function overrides poll() to handle condition variable wakeup fds
 static int cvfd_poll(struct pollfd* fds, nfds_t nfds, int timeout) {
+  if (timeout == 0) {
+    // Don't bother using background threads for polling if timeout is 0,
+    // poll-cv might not wait for a poll to return otherwise.
+    // https://github.com/grpc/grpc/issues/13298
+    return poll(fds, nfds, 0);
+  }
   unsigned int i;
   int res, idx;
   grpc_cv_node* pollcv;


### PR DESCRIPTION
Fixes #14910, #13298 and other poll-cv bugs caused when timeout is zero.

Explanation -
The issue arises when a timeout of zero is provided. The polling engine poll-cv uses a background thread and waits on a condition variable for timeout duration. With a zero timeout, the condition variable might wake up immediately without a poll ever having occurred.

This causes issues especially for the backup poller which provides a timeout of zero ms. The bug in #14910 surfaced this issue. It was expected that the backup poller on the client side would poll on a socket which had been closed by the server, and result in a logic which would try establishing another subchannel to the server. In the failing case, the backup poller never really polled the fd and hence never got the socket error. 