### PR TITLE
mark XML log from grpc_coverage as artifact

### DIFF
--- a/tools/internal_ci/linux/grpc_coverage.cfg
+++ b/tools/internal_ci/linux/grpc_coverage.cfg
@@ -19,6 +19,7 @@ build_file: "grpc/tools/internal_ci/linux/grpc_coverage.sh"
 timeout_mins: 420
 action {
   define_artifacts {
+    regex: "**/*sponge_log.xml"
     regex: "github/grpc/reports/**"
   }
 }


### PR DESCRIPTION
To finally get the structured test results displayed.