### PR TITLE
Add interop_to_prod tests on macos

### DIFF
--- a/tools/internal_ci/macos/grpc_interop_toprod.cfg
+++ b/tools/internal_ci/macos/grpc_interop_toprod.cfg
@@ -1,0 +1,26 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/macos/grpc_interop_toprod.sh"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+timeout_mins: 240
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
+  }
+}

--- a/tools/internal_ci/macos/grpc_interop_toprod.sh
+++ b/tools/internal_ci/macos/grpc_interop_toprod.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# change to grpc repo root
+cd $(dirname $0)/../../..
+
+source tools/internal_ci/helper_scripts/prepare_build_macos_interop_rc
+source tools/internal_ci/helper_scripts/prepare_build_macos_rc
+
+# using run_interop_tests.py without --use_docker, so we need to build first
+tools/run_tests/run_tests.py -l c++ -c opt --build_only
+
+export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$(pwd)/etc/roots.pem"
+
+# NOTE: only tests a subset of languages for time & dependency constraints
+# building all languages in the same working copy can also lead to conflicts
+# due to different compilation flags
+# TODO(jtattermusch): add --cloud_to_prod_auth support
+tools/run_tests/run_interop_tests.py -l c++ --cloud_to_prod -t -j 4


### PR DESCRIPTION
- runs C++ only to_prod tests on mac, without using docker, so it should be reasonably quick to run
- kokoro macs actually live in macstadium hosting, which is outside GCP, which is a test path we want to be testing and we are having trouble doing that on kokoro linux machines (which are hosted in GCP).
- more languages and --cloud_to_prod_auth test to be added in the future.