### PR TITLE
Ensure Lib is Initialize for ByteBuffer Use

### DIFF
--- a/src/cpp/util/byte_buffer_cc.cc
+++ b/src/cpp/util/byte_buffer_cc.cc
@@ -23,6 +23,8 @@
 
 namespace grpc {
 
+static internal::GrpcLibraryInitializer g_gli_initializer;
+
 Status ByteBuffer::Dump(std::vector<Slice>* slices) const {
   slices->clear();
   if (!buffer_) {


### PR DESCRIPTION
I did not mean to take this out in #14541 