### PR TITLE
PHP: fix php pecl installation error on windos

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -637,11 +637,13 @@ if (PHP_GRPC != "no") {
   EXTENSION("grpc", grpc_source, null,
     "/DOPENSSL_NO_ASM /D_GNU_SOURCE /DWIN32_LEAN_AND_MEAN "+
     "/D_HAS_EXCEPTIONS=0 /DNOMINMAX /DGRPC_ARES=0 /D_WIN32_WINNT=0x600 "+
+    "/DPB_FIELD_16BIT "+
     "/I"+configure_module_dirname+" "+
     "/I"+configure_module_dirname+"\\include "+
     "/I"+configure_module_dirname+"\\src\\php\\ext\\grpc "+
     "/I"+configure_module_dirname+"\\third_party\\boringssl\\include "+
-    "/I"+configure_module_dirname+"\\third_party\\zlib");
+    "/I"+configure_module_dirname+"\\third_party\\zlib "+
+    "/I"+configure_module_dirname+"\\third_party\\address_sorting\\include");
 
   base_dir = get_define('BUILD_DIR');
   FSO.CreateFolder(base_dir+"\\ext");

--- a/templates/config.w32.template
+++ b/templates/config.w32.template
@@ -23,11 +23,13 @@
     EXTENSION("grpc", grpc_source, null,
       "/DOPENSSL_NO_ASM /D_GNU_SOURCE /DWIN32_LEAN_AND_MEAN "+
       "/D_HAS_EXCEPTIONS=0 /DNOMINMAX /DGRPC_ARES=0 /D_WIN32_WINNT=0x600 "+
+      "/DPB_FIELD_16BIT "+
       "/I"+configure_module_dirname+" "+
       "/I"+configure_module_dirname+"\\include "+
       "/I"+configure_module_dirname+"\\src\\php\\ext\\grpc "+
       "/I"+configure_module_dirname+"\\third_party\\boringssl\\include "+
-      "/I"+configure_module_dirname+"\\third_party\\zlib");
+      "/I"+configure_module_dirname+"\\third_party\\zlib "+
+      "/I"+configure_module_dirname+"\\third_party\\address_sorting\\include");
   <%
     dirs = {}
     for lib in libs:


### PR DESCRIPTION
WIP
Use this PR to checkout the changes on Windows and make test.

Update:
Seems it works:
```
$c = new Grpc\Server();
var_dump($c);
print("INVALID_ARGUMENT code = ".Grpc\STATUS_INVALID_ARGUMENT);
```
It has output
```
object(Grpc\Server)#1 (0) {
}
INVALID_ARGUMENT code = 3
```
It is better if you can help me to double check. I was using the `php.exe` under `.\Release\php.exe`.