### PR TITLE
No dump error for unknown value in accept-encoding

### DIFF
--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -878,8 +878,8 @@ static void set_encodings_accepted_by_peer(grpc_call* call, grpc_mdelem mdel,
     } else {
       char* accept_encoding_entry_str =
           grpc_slice_to_c_string(accept_encoding_entry_slice);
-      gpr_log(GPR_ERROR,
-              "Invalid entry in accept encoding metadata: '%s'. Ignoring.",
+      gpr_log(GPR_DEBUG,
+              "Unknown entry in accept encoding metadata: '%s'. Ignoring.",
               accept_encoding_entry_str);
       gpr_free(accept_encoding_entry_str);
     }


### PR DESCRIPTION
It is totally possible to receive an unknown value in this field. We should just ignore it without printing error.