### PR TITLE
Fix permissions on protoc and protoc plugins packaged as grpc-tools

### DIFF
--- a/src/csharp/build_packages_dotnetcli.sh
+++ b/src/csharp/build_packages_dotnetcli.sh
@@ -32,6 +32,8 @@ mkdir -p protoc_plugins
 cp -r $EXTERNAL_GIT_ROOT/platform={windows,linux,macos}/artifacts/protoc_* protoc_plugins || true
 # Kokoro flow
 cp -r $EXTERNAL_GIT_ROOT/input_artifacts/protoc_* protoc_plugins || true
+find protoc_plugins/ -type f -name protoc -exec chmod +x {} ";"
+find protoc_plugins/ -type f -name grpc_csharp_plugin -exec chmod +x {} ";"
 
 dotnet restore Grpc.sln
 

--- a/templates/src/csharp/build_packages_dotnetcli.sh.template
+++ b/templates/src/csharp/build_packages_dotnetcli.sh.template
@@ -34,7 +34,9 @@
   cp -r $EXTERNAL_GIT_ROOT/platform={windows,linux,macos}/artifacts/protoc_* protoc_plugins || true
   # Kokoro flow
   cp -r $EXTERNAL_GIT_ROOT/input_artifacts/protoc_* protoc_plugins || true
-  
+  find protoc_plugins/ -type f -name protoc -exec chmod +x {} ";"
+  find protoc_plugins/ -type f -name grpc_csharp_plugin -exec chmod +x {} ";"
+
   dotnet restore Grpc.sln
   
   # To be able to build, we also need to put grpc_csharp_ext to its normal location

--- a/tools/run_tests/artifacts/build_package_ruby.sh
+++ b/tools/run_tests/artifacts/build_package_ruby.sh
@@ -55,6 +55,10 @@ for arch in {x86,x64}; do
     mkdir -p "$output_dir"/google/protobuf/compiler  # needed for plugin.proto
     cp "$input_dir"/protoc* "$output_dir"/
     cp "$input_dir"/grpc_ruby_plugin* "$output_dir"/
+    if [[ "$plat" != "windows" ]]
+    then
+      chmod +x "$output_dir/protoc" "$output_dir/grpc_ruby_plugin"
+    fi
     for proto in "${well_known_protos[@]}"; do
       cp "$base/third_party/protobuf/src/google/protobuf/$proto.proto" "$output_dir/google/protobuf/$proto.proto"
     done


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/14975 for Ruby and C#.

Python and PHP do not need it as it gets built from source.

Node might or might not need to apply something like this in their repo as well, but this obviously can't address it.