### PR TITLE
Upmerge 1.10.x to 1.11.x

### DIFF
--- a/tools/internal_ci/linux/grpc_build_packages.sh
+++ b/tools/internal_ci/linux/grpc_build_packages.sh
@@ -30,6 +30,7 @@ set -ex
 # where they can be accessed from within a docker container that builds
 # the packages
 mv ${KOKORO_GFILE_DIR}/github/grpc/artifacts input_artifacts || true
+chmod +x input_artifacts/protoc*/* || true
 ls -R input_artifacts || true
 
 tools/run_tests/task_runner.py -f package linux -j 6

--- a/tools/run_tests/artifacts/build_package_ruby.sh
+++ b/tools/run_tests/artifacts/build_package_ruby.sh
@@ -53,8 +53,11 @@ for arch in {x86,x64}; do
     output_dir="$base/src/ruby/tools/bin/${ruby_arch}-${plat}"
     mkdir -p "$output_dir"/google/protobuf
     mkdir -p "$output_dir"/google/protobuf/compiler  # needed for plugin.proto
-    cp "$input_dir"/protoc* "$output_dir"/
-    cp "$input_dir"/grpc_ruby_plugin* "$output_dir"/
+    cp "$input_dir"/protoc* "$input_dir"/grpc_ruby_plugin* "$output_dir/"
+    if [[ "$plat" != "windows" ]]
+    then
+      chmod +x "$output_dir/protoc" "$output_dir/grpc_ruby_plugin"
+    fi
     for proto in "${well_known_protos[@]}"; do
       cp "$base/third_party/protobuf/src/google/protobuf/$proto.proto" "$output_dir/google/protobuf/$proto.proto"
     done


### PR DESCRIPTION
Upmerges the Ruby build fixes from 1.10.x to the 1.11.x branch.