### PR TITLE
PHP: use persistent list not shared by other modules

### DIFF
--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -84,6 +84,7 @@ void php_grpc_delete_persistent_list_entry(char *key, php_grpc_int key_len
 
 typedef struct _channel_persistent_le {
   grpc_channel_wrapper *channel;
+  size_t ref_count;
 } channel_persistent_le_t;
 
 

--- a/src/php/ext/grpc/php7_wrapper.h
+++ b/src/php/ext/grpc/php7_wrapper.h
@@ -38,6 +38,12 @@
 #define PHP_GRPC_MAKE_STD_ZVAL(pzv) MAKE_STD_ZVAL(pzv)
 #define PHP_GRPC_FREE_STD_ZVAL(pzv)
 #define PHP_GRPC_DELREF(zv) Z_DELREF_P(zv)
+#define PHP_GRPC_ADD_STRING_TO_ARRAY(val, key, key_len, str, dup) \
+   add_assoc_string_ex(val, key, key_len , str, dup);
+#define PHP_GRPC_ADD_LONG_TO_ARRAY(val, key, key_len, str) \
+   add_assoc_long_ex(val, key, key_len, str);
+#define PHP_GRPC_ADD_BOOL_TO_ARRAY(val, key, key_len, str) \
+   add_assoc_bool_ex(val, key, key_len, str);
 
 #define RETURN_DESTROY_ZVAL(val) \
   RETURN_ZVAL(val, false /* Don't execute copy constructor */, \
@@ -88,6 +94,9 @@
                                          0, NULL); \
     data = *tmp##key;
 
+#define PHP_GRPC_HASH_VALPTR_TO_VAL(data) \
+  &data;
+
 #define PHP_GRPC_HASH_FOREACH_LONG_KEY_VAL_START(ht, key, key_type, index,\
                                                  data) \
   zval **tmp##key = NULL; \
@@ -128,6 +137,8 @@ static inline int php_grpc_zend_hash_find(HashTable *ht, char *key, int len,
 #define PHP_GRPC_PERSISTENT_LIST_UPDATE(plist, key, len, rsrc) \
   zend_hash_update(plist, key, len+1, rsrc, sizeof(php_grpc_zend_resource), \
                    NULL)
+#define PHP_GRPC_PERSISTENT_LIST_SIZE(plist) \
+  plist.nTableSize
 
 #define PHP_GRPC_GET_CLASS_ENTRY(object) zend_get_class_entry(object TSRMLS_CC)
 
@@ -152,6 +163,12 @@ static inline int php_grpc_zend_hash_find(HashTable *ht, char *key, int len,
   pzv = (zval *)emalloc(sizeof(zval));
 #define PHP_GRPC_FREE_STD_ZVAL(pzv) efree(pzv);
 #define PHP_GRPC_DELREF(zv)
+#define PHP_GRPC_ADD_STRING_TO_ARRAY(val, key, key_len, str, dup) \
+   add_assoc_string_ex(val, key, key_len - 1, str);
+#define PHP_GRPC_ADD_LONG_TO_ARRAY(val, key, key_len, str) \
+   add_assoc_long_ex(val, key, key_len - 1, str);
+#define PHP_GRPC_ADD_BOOL_TO_ARRAY(val, key, key_len, str) \
+   add_assoc_bool_ex(val, key, key_len - 1, str);
 
 #define RETURN_DESTROY_ZVAL(val) \
   RETVAL_ZVAL(val, false /* Don't execute copy constructor */, \
@@ -193,6 +210,9 @@ static inline int php_grpc_zend_hash_find(HashTable *ht, char *key, int len,
     if ((zs_##key) == NULL) {key = NULL; key_type = HASH_KEY_IS_LONG;} \
     else {key = (zs_##key)->val; key_type = HASH_KEY_IS_STRING;}
 
+#define PHP_GRPC_HASH_VALPTR_TO_VAL(data) \
+  Z_PTR_P(data);
+
 #define PHP_GRPC_HASH_FOREACH_LONG_KEY_VAL_START(ht, key, key_type, index, \
                                                  data) \
   zend_string *(zs_##key); \
@@ -230,6 +250,8 @@ static inline int php_grpc_zend_hash_del(HashTable *ht, char *key, int len) {
 #define PHP_GRPC_PERSISTENT_LIST_UPDATE(plist, key, len, rsrc) \
   zend_hash_str_update_mem(plist, key, len, rsrc, \
                            sizeof(php_grpc_zend_resource))
+#define PHP_GRPC_PERSISTENT_LIST_SIZE(plist) \
+  zend_array_count(plist)
 
 #define PHP_GRPC_GET_CLASS_ENTRY(object) Z_OBJ_P(object)->ce
 

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -36,7 +36,7 @@
 
 ZEND_DECLARE_MODULE_GLOBALS(grpc)
 static PHP_GINIT_FUNCTION(grpc);
-
+HashTable grpc_persistent_list;
 /* {{{ grpc_functions[]
  *
  * Every user visible function must have an entry in grpc_functions[].
@@ -240,6 +240,8 @@ PHP_MSHUTDOWN_FUNCTION(grpc) {
   // WARNING: This function IS being called by PHP when the extension
   // is unloaded but the logs were somehow suppressed.
   if (GRPC_G(initialized)) {
+    zend_hash_clean(&grpc_persistent_list);
+    zend_hash_destroy(&grpc_persistent_list);
     grpc_shutdown_timeval(TSRMLS_C);
     grpc_php_shutdown_completion_queue(TSRMLS_C);
     grpc_shutdown();
@@ -256,7 +258,6 @@ PHP_MINFO_FUNCTION(grpc) {
   php_info_print_table_row(2, "grpc support", "enabled");
   php_info_print_table_row(2, "grpc module version", PHP_GRPC_VERSION);
   php_info_print_table_end();
-
   /* Remove comments if you have entries in php.ini
      DISPLAY_INI_ENTRIES();
   */

--- a/src/php/tests/unit_tests/CallCredentials2Test.php
+++ b/src/php/tests/unit_tests/CallCredentials2Test.php
@@ -46,6 +46,9 @@ class CallCredentials2Test extends PHPUnit_Framework_TestCase
     {
         unset($this->channel);
         unset($this->server);
+        $channel_clean_persistent =
+            new Grpc\Channel('localhost:50010', []);
+        $channel_clean_persistent->cleanPersistentList();
     }
 
     public function callbackFunc($context)

--- a/src/php/tests/unit_tests/CallCredentialsTest.php
+++ b/src/php/tests/unit_tests/CallCredentialsTest.php
@@ -52,6 +52,9 @@ class CallCredentialsTest extends PHPUnit_Framework_TestCase
     {
         unset($this->channel);
         unset($this->server);
+        $channel_clean_persistent =
+            new Grpc\Channel('localhost:50010', []);
+        $channel_clean_persistent->cleanPersistentList();
     }
 
     public function callbackFunc($context)

--- a/src/php/tests/unit_tests/CallTest.php
+++ b/src/php/tests/unit_tests/CallTest.php
@@ -38,6 +38,9 @@ class CallTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $this->channel->close();
+        $channel_clean_persistent =
+            new Grpc\Channel('localhost:50010', []);
+        $channel_clean_persistent->cleanPersistentList();
     }
 
     public function testConstructor()

--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -28,6 +28,9 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         if (!empty($this->channel)) {
             $this->channel->close();
         }
+        $channel_clean_persistent =
+            new Grpc\Channel('localhost:50010', []);
+        $channel_clean_persistent->cleanPersistentList();
     }
 
     public function testInsecureCredentials()
@@ -380,6 +383,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         // close channel1
         $this->channel1->close();
 
+        // channel2 is now in SHUTDOWN state
+        $state = $this->channel2->getConnectivityState();
+        $this->assertEquals(GRPC\CHANNEL_FATAL_FAILURE, $state);
+
+        // calling it again will result in an exception because the
         // channel is already closed
         $state = $this->channel2->getConnectivityState();
     }

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -29,6 +29,9 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $this->channel->close();
+        $channel_clean_persistent =
+            new Grpc\Channel('localhost:50010', []);
+        $channel_clean_persistent->cleanPersistentList();
     }
 
     public function testSimpleRequestBody()

--- a/src/php/tests/unit_tests/PersistentChannelTest.php
+++ b/src/php/tests/unit_tests/PersistentChannelTest.php
@@ -1,0 +1,111 @@
+<?php
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+class PersistentListTest extends PHPUnit_Framework_TestCase
+{
+  public function setUp()
+  {
+  }
+
+  public function tearDown()
+  {
+      $channel_clean_persistent =
+          new Grpc\Channel('localhost:50010', []);
+      $channel_clean_persistent->cleanPersistentList();
+  }
+
+  public function waitUntilNotIdle($channel) {
+      for ($i = 0; $i < 10; $i++) {
+          $now = Grpc\Timeval::now();
+          $deadline = $now->add(new Grpc\Timeval(1000));
+          if ($channel->watchConnectivityState(GRPC\CHANNEL_IDLE,
+            $deadline)) {
+              return true;
+          }
+      }
+      $this->assertTrue(false);
+  }
+
+  public function testPersistentChennelCreateOneChannel()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:1', []);
+      $plist = $this->channel1->getPersistentList();
+      $this->assertEquals($plist['localhost:1']['target'], 'localhost:1');
+      $this->assertArrayHasKey('localhost:1', $plist);
+      $this->assertEquals($plist['localhost:1']['ref_count'], 1);
+      $this->assertEquals($plist['localhost:1']['connectivity_status'],
+                          GRPC\CHANNEL_IDLE);
+      $this->assertEquals($plist['localhost:1']['is_valid'], 1);
+      $this->channel1->close();
+  }
+
+  public function testPersistentChennelStatusChange()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:1', []);
+      $plist = $this->channel1->getPersistentList();
+      $this->assertEquals($plist['localhost:1']['connectivity_status'],
+                          GRPC\CHANNEL_IDLE);
+      $this->assertEquals($plist['localhost:1']['is_valid'], 1);
+      $state = $this->channel1->getConnectivityState(true);
+
+      $this->waitUntilNotIdle($this->channel1);
+      $plist = $this->channel1->getPersistentList();
+      $this->assertEquals($plist['localhost:1']['connectivity_status'],
+                          GRPC\CHANNEL_CONNECTING);
+      $this->assertEquals($plist['localhost:1']['is_valid'], 1);
+
+      $this->channel1->close();
+  }
+
+  public function testPersistentChennelCloseChannel()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:1', []);
+      $plist = $this->channel1->getPersistentList();
+      $this->assertEquals($plist['localhost:1']['ref_count'], 1);
+      $this->channel1->close();
+      $plist = $this->channel1->getPersistentList();
+      $this->assertArrayNotHasKey('localhost:1', $plist);
+  }
+
+  public function testPersistentChannelSameHost()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:1', []);
+      $this->channel2 = new Grpc\Channel('localhost:1', []);
+      //ref_count should be 2
+      $plist = $this->channel1->getPersistentList();
+      $this->assertArrayHasKey('localhost:1', $plist);
+      $this->assertEquals($plist['localhost:1']['ref_count'], 2);
+      $this->channel1->close();
+      $this->channel2->close();
+  }
+
+  public function testPersistentChannelDifferentHost()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:1', []);
+      $this->channel2 = new Grpc\Channel('localhost:2', []);
+      $plist = $this->channel1->getPersistentList();
+      $this->assertArrayHasKey('localhost:1', $plist);
+      $this->assertArrayHasKey('localhost:2', $plist);
+      $this->assertEquals($plist['localhost:1']['ref_count'], 1);
+      $this->assertEquals($plist['localhost:2']['ref_count'], 1);
+      $this->channel1->close();
+      $this->channel2->close();
+  }
+
+}

--- a/src/php/tests/unit_tests/SecureEndToEndTest.php
+++ b/src/php/tests/unit_tests/SecureEndToEndTest.php
@@ -44,6 +44,9 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $this->channel->close();
+        $channel_clean_persistent =
+          new Grpc\Channel('localhost:50010', []);
+        $channel_clean_persistent->cleanPersistentList();
     }
 
     public function testSimpleRequestBody()

--- a/src/php/tests/unit_tests/ServerTest.php
+++ b/src/php/tests/unit_tests/ServerTest.php
@@ -27,6 +27,9 @@ class ServerTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         unset($this->server);
+        $channel_clean_persistent =
+            new Grpc\Channel('localhost:50010', []);
+        $channel_clean_persistent->cleanPersistentList();
     }
 
     public function testConstructorWithNull()

--- a/src/php/tests/unit_tests/TimevalTest.php
+++ b/src/php/tests/unit_tests/TimevalTest.php
@@ -25,6 +25,9 @@ class TimevalTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         unset($this->time);
+        $channel_clean_persistent =
+            new Grpc\Channel('localhost:50010', []);
+        $channel_clean_persistent->cleanPersistentList();
     }
 
     public function testConstructorWithInt()


### PR DESCRIPTION
Testing it in Kokoro too see if it works for both PHP7 and PHP5 with this PR.

- Add a function `getPersistentList`, which return an array formatted as below. It can be used to debug, or check the channel status during tests/unit_tests when we want to know is the channel deleted or still there, if there, what is the connection status.
```
    [localhost:1] => Array
        (
            [target] => localhost:1
            [key] => localhost:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
            [ref_count] => 6
            [connectivity_status] => CONNECTING
            [is_valid] => 1
        )

    [localhost:2] => Array
        (
            [target] => localhost:2
            [key] => localhost:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
            [ref_count] => 1
            [connectivity_status] => IDLE
            [is_valid] => 1
        )

    [localhost:3] => Array
        (
            [target] => localhost:3
            [key] => localhost:xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
            [ref_count] => 1
            [connectivity_status] => CONNECTING
            [is_valid] => 1
        )
```
Reading what's inside the persistent list is important for test persistent channel under php-fpm mode. Currently what I am thinking is send a request to the php-fpm which creating a channel and then send another request to read this channel/connection_status from the list.
