### PR TITLE
Disable SO_REUSEPORT disabled test for uv tests

### DIFF
--- a/test/core/surface/server_chttp2_test.cc
+++ b/test/core/surface/server_chttp2_test.cc
@@ -37,6 +37,8 @@ void test_unparsable_target(void) {
   grpc_server_destroy(server);
 }
 
+// GRPC_ARG_ALLOW_REUSEPORT isn't supported for custom servers
+#ifndef GRPC_UV
 void test_add_same_port_twice() {
   grpc_arg a;
   a.type = GRPC_ARG_INTEGER;
@@ -62,12 +64,15 @@ void test_add_same_port_twice() {
   grpc_server_destroy(server);
   grpc_completion_queue_destroy(cq);
 }
+#endif
 
 int main(int argc, char** argv) {
   grpc_test_init(argc, argv);
   grpc_init();
   test_unparsable_target();
+#ifndef GRPC_UV
   test_add_same_port_twice();
+#endif
   grpc_shutdown();
   return 0;
 }

--- a/test/core/surface/server_test.cc
+++ b/test/core/surface/server_test.cc
@@ -69,6 +69,8 @@ void test_request_call_on_no_server_cq(void) {
   grpc_server_destroy(server);
 }
 
+// GRPC_ARG_ALLOW_REUSEPORT isn't supported for custom servers
+#ifndef GRPC_UV
 void test_bind_server_twice(void) {
   grpc_arg a;
   a.type = GRPC_ARG_INTEGER;
@@ -100,6 +102,7 @@ void test_bind_server_twice(void) {
   grpc_completion_queue_destroy(cq);
   gpr_free(addr);
 }
+#endif
 
 void test_bind_server_to_addr(const char* host, bool secure) {
   int port = grpc_pick_unused_port_or_die();
@@ -149,7 +152,9 @@ int main(int argc, char** argv) {
   grpc_init();
   test_register_method_fail();
   test_request_call_on_no_server_cq();
+#ifndef GRPC_UV
   test_bind_server_twice();
+#endif
 
   static const char* addrs[] = {
       "::1", "127.0.0.1", "::ffff:127.0.0.1", "localhost", "0.0.0.0", "::",


### PR DESCRIPTION
After the libuv/ custom server refactor, there isn't an easy way to disable the use of SO_REUSEPORT.
This disables the test for GRPC_ARG_ALLOW_REUSEPORT for libuv and fixes.
#14926

cc @jtattermusch 