### PR TITLE
Update unit testing documentation

### DIFF
--- a/tools/run_tests/README.md
+++ b/tools/run_tests/README.md
@@ -14,6 +14,10 @@ Builds gRPC in given language and runs unit tests. Use `tools/run_tests/run_test
 - `--use_docker` Builds a docker container containing all the prerequisites for given language and runs the tests under that container.
 - `--build_only` Only build, do not run the tests.
 
+Note: some tests may be flaky. Check the "Issues" tab for known flakes and other issues.
+
+The full suite of unit tests will take many minutes to run.
+
 # Interop tests (run_interop_tests.py)
 
 Runs tests for cross-platform/cross-language interoperability. For more details, see [Interop tests descriptions](/doc/interop-test-descriptions.md)


### PR DESCRIPTION
Adding this documentation because there are failures when running the unit tests and they are supposedly due to flakes, per our discussion.

The solution to check the Issues tab for flaky tests may be incorrect. Is there something else the user should do?