### PR TITLE
Add support for GPR_LIKELY and GPR_UNLIKELY

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -508,6 +508,7 @@ typedef unsigned __int64 uint64_t;
 #define GPR_UNLIKELY(x) __builtin_expect((x), 0)
 #else /* __GNUC__ */
 #define GPR_LIKELY(x) (x)
+#define GPR_UNLIKELY(x) (x)
 #endif /* __GNUC__ */
 
 #ifndef __STDC_FORMAT_MACROS

--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -500,6 +500,16 @@ typedef unsigned __int64 uint64_t;
 #endif /* __GPR_WINDOWS */
 #endif /* GRPC_ALLOW_EXCEPTIONS */
 
+/* Use GPR_LIKELY only in cases where you are sure that a certain outcome is the
+ * most likely. Ideally, also collect performance numbers to justify the claim.
+ */
+#ifdef __GNUC__
+#define GPR_LIKELY(x) __builtin_expect((x), 1)
+#define GPR_UNLIKELY(x) __builtin_expect((x), 0)
+#else /* __GNUC__ */
+#define GPR_LIKELY(x) (x)
+#endif /* __GNUC__ */
+
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif

--- a/include/grpc/support/log.h
+++ b/include/grpc/support/log.h
@@ -91,7 +91,7 @@ GPRAPI void gpr_set_log_function(gpr_log_func func);
    an exception in a higher-level language, consider returning error code.  */
 #define GPR_ASSERT(x)                                 \
   do {                                                \
-    if (!(x)) {                                       \
+    if (GPR_UNLIKELY(!(x))) {                         \
       gpr_log(GPR_ERROR, "assertion failed: %s", #x); \
       abort();                                        \
     }                                                 \

--- a/include/grpc/support/log.h
+++ b/include/grpc/support/log.h
@@ -91,7 +91,7 @@ GPRAPI void gpr_set_log_function(gpr_log_func func);
    an exception in a higher-level language, consider returning error code.  */
 #define GPR_ASSERT(x)                                 \
   do {                                                \
-    if (GPR_UNLIKELY(!(x))) {                         \
+    if (!(x)) {                                       \
       gpr_log(GPR_ERROR, "assertion failed: %s", #x); \
       abort();                                        \
     }                                                 \


### PR DESCRIPTION
GPR_LIKELY and GPR_UNLIKELY are intended to be used only in cases where a certain outcome is the most likely. Please pay close attention to benchmarks and performance numbers when using this.