### PR TITLE
Only run interop_to_prod tests agains cloud gateways when in GCE

### DIFF
--- a/tools/internal_ci/linux/grpc_interop_toprod.cfg
+++ b/tools/internal_ci/linux/grpc_interop_toprod.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-l all --cloud_to_prod --cloud_to_prod_auth --prod_servers default gateway_v4 cloud_gateway cloud_gateway_v4 --use_docker --internal_ci -t -j 12 --bq_result_table interop_results"
+  value: "-l all --cloud_to_prod --cloud_to_prod_auth --prod_servers cloud_gateway cloud_gateway_v4 --use_docker --internal_ci -t -j 12 --bq_result_table interop_results"
 }

--- a/tools/internal_ci/linux/pull_request/grpc_interop_toprod.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_interop_toprod.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-l all --allow_flakes --cloud_to_prod --cloud_to_prod_auth --prod_servers default gateway_v4 --use_docker --internal_ci -t -j 12"
+  value: "-l all --cloud_to_prod --cloud_to_prod_auth --prod_servers cloud_gateway cloud_gateway_v4 --use_docker --internal_ci -t -j 12"
 }


### PR DESCRIPTION
Linux tests are running on GCE and the emulation of "non-cloud" access seems to introduce flakiness.
Thus we only want to test against "cloud_gateway" and "cloud_gateway_v4" in linux tests (that are all running on GCE).

We recently added subset of interop to_prod test on macos that are running on macstadium, and we can test accessing via "default" and "gateway_v4" from there.

This should be fixing https://github.com/grpc/grpc/issues/10763 which has been a real pain for the last few months. The immediate effect will be temporarily masked by https://github.com/grpc/grpc/issues/14969 until the node interop tests issue gets resolved.