### PR TITLE
Fix a broken gcov test

### DIFF
--- a/src/ruby/spec/pb/package_with_underscore/checker_spec.rb
+++ b/src/ruby/spec/pb/package_with_underscore/checker_spec.rb
@@ -15,16 +15,13 @@
 require 'open3'
 require 'tmpdir'
 
-def debug_mode?
-  !ENV['CONFIG'].nil? && ENV['CONFIG'] == 'dbg'
-end
-
 describe 'Package with underscore protobuf code generation' do
   it 'should have the same content as created by code generation' do
     root_dir = File.join(File.dirname(__FILE__), '..', '..', '..', '..', '..')
     pb_dir = File.join(root_dir, 'src', 'ruby', 'spec', 'pb')
 
-    bins_sub_dir = debug_mode? ? 'dbg' : 'opt'
+    fail 'CONFIG env variable unexpectedly unset' unless ENV['CONFIG']
+    bins_sub_dir = ENV['CONFIG']
     bins_dir = File.join(root_dir, 'bins', bins_sub_dir)
 
     plugin = File.join(bins_dir, 'grpc_ruby_plugin')


### PR DESCRIPTION
Fixes the `Errno::ENOENT:` error in https://github.com/grpc/grpc/issues/14924#issuecomment-380393379 (cleanup from new test in https://github.com/grpc/grpc/pull/13634).

`run_tests.py -l ruby -c gcov` fails even after this locally with:

```
tools/run_tests/helper_scripts/post_tests_ruby.sh: line 25: lcov: command not found
```

but I'm not sure if that's actually an issue for the gcov tests noted in issue https://github.com/grpc/grpc/issues/14924