### PR TITLE
Fix performance profile jobs

### DIFF
--- a/tools/profiling/microbenchmarks/bm2bq.py
+++ b/tools/profiling/microbenchmarks/bm2bq.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python2.7
 #
-# Convert google-benchmark json output to something that can be uploaded to
-# BigQuery
-#
-#
 # Copyright 2017 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Convert google-benchmark json output to something that can be uploaded to
+# BigQuery
 
 import sys
 import json
@@ -54,6 +53,7 @@ if len(sys.argv) > 2:
 else:
     js2 = None
 
+# TODO(jtattermusch): write directly to a file instead of stdout
 writer = csv.DictWriter(sys.stdout, [c for c, t in columns])
 
 for row in bm_json.expand_json(js, js2):

--- a/tools/profiling/microbenchmarks/bm_json.py
+++ b/tools/profiling/microbenchmarks/bm_json.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Utilities for manipulating JSON data that represents microbenchmark results.
+
 import os
 
+# template arguments and dynamic arguments of individual benchmark types
+# Example benchmark name: "BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/0"
 _BM_SPECS = {
     'BM_UnaryPingPong': {
         'tpl': ['fixture', 'client_mutator', 'server_mutator'],
@@ -115,6 +119,7 @@ _BM_SPECS = {
 
 
 def numericalize(s):
+    """Convert abbreviations like '100M' or '10k' to a number."""
     if not s: return ''
     if s[-1] == 'k':
         return float(s[:-1]) * 1024
@@ -159,9 +164,6 @@ def parse_name(name):
         rest = s[0]
         dyn_args = s[1:]
     name = rest
-    print(name)
-    print(dyn_args, _BM_SPECS[name]['dyn'])
-    print(tpl_args, _BM_SPECS[name]['tpl'])
     assert name in _BM_SPECS, '_BM_SPECS needs to be expanded for %s' % name
     assert len(dyn_args) == len(_BM_SPECS[name]['dyn'])
     assert len(tpl_args) == len(_BM_SPECS[name]['tpl'])


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/13628 and  https://github.com/grpc/grpc/issues/14860.

The breakage was introduces by inadvertently adding  debugging print statements to to bm_json.py https://github.com/grpc/grpc/commit/4c9fa854f691726e73efeca20e7141c0f8dc10c6

Because bm2bq.py prints its output to stdout, output from the debug print statements gets mixed with the output data and resulting CSV output ends up being malformed.

Overall, the bm2bq.py and other scripts are quite messy code so this problem took a while to diagnose. We'd benefit from some refactoring as well as improving comments (some comments being added in this PR).