### PR TITLE
Remove superfluous dependency on the protobuf package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -239,9 +239,6 @@ PACKAGE_DIRECTORIES = {
 
 INSTALL_REQUIRES = (
     'six>=1.5.2',
-    # TODO(atash): eventually split the grpcio package into a metapackage
-    # depending on protobuf and the runtime component (independent of protobuf)
-    'protobuf>=3.5.0.post1',
 )
 
 if not PY3:


### PR DESCRIPTION
Looks like we have a longstanding dependency on the `protobuf` package in the `grpcio` runtime library and we are not directly using it. It makes sense to remove the dependency from the core package so as to leave room for users to use older protobuf versions than what we mandate should they choose to, or not use `protobuf` at all (bring your own serialization or just use byte buffers directly). 

Note that `grpcio-health-checking` and `grpcio-reflection` packages do still need the dependency on `protobuf` as they expose proto services.