### PR TITLE
Unref uv timers/tcp handles

### DIFF
--- a/src/core/lib/iomgr/tcp_uv.cc
+++ b/src/core/lib/iomgr/tcp_uv.cc
@@ -204,6 +204,11 @@ static grpc_error* uv_socket_init_helper(uv_socket_t* uv_socket, int domain) {
   uv_socket->write_buffers = nullptr;
   uv_socket->read_len = 0;
   uv_tcp_nodelay(uv_socket->handle, 1);
+  // Node uses a garbage collector to call destructors, so we don't
+  // want to hold the uv loop open with active gRPC objects.
+#ifndef GRPC_UV_HOLD_LOOP
+  uv_unref((uv_handle_t*)uv_socket->handle);
+#endif
   uv_socket->pending_connection = false;
   uv_socket->accept_socket = nullptr;
   uv_socket->accept_error = GRPC_ERROR_NONE;

--- a/src/core/lib/iomgr/timer_uv.cc
+++ b/src/core/lib/iomgr/timer_uv.cc
@@ -52,6 +52,11 @@ static void timer_start(grpc_custom_timer* t) {
   uv_timer->data = t;
   t->timer = (void*)uv_timer;
   uv_timer_start(uv_timer, run_expired_timer, t->timeout_ms, 0);
+// Node uses a garbage collector to call destructors, so we don't
+// want to hold the uv loop open with active gRPC objects.
+#ifndef GRPC_UV_HOLD_LOOP
+  uv_unref((uv_handle_t*)uv_timer);
+#endif
 }
 
 static void timer_stop(grpc_custom_timer* t) {

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -290,7 +290,7 @@ class CLanguage(object):
             self._docker_distro, self._make_options = self._compiler_options(
                 self.args.use_docker, self.args.compiler)
         if args.iomgr_platform == "uv":
-            cflags = '-DGRPC_UV -DGRPC_CUSTOM_IOMGR_THREAD_CHECK -DGRPC_CUSTOM_SOCKET '
+            cflags = '-DGRPC_UV -DGRPC_CUSTOM_IOMGR_THREAD_CHECK -DGRPC_CUSTOM_SOCKET -DGRPC_UV_HOLD_LOOP '
             try:
                 cflags += subprocess.check_output(
                     ['pkg-config', '--cflags', 'libuv']).strip() + ' '


### PR DESCRIPTION
Fixes #14947.
 
@mehrdada This is a release blocker

During #14599 there was some offline discussion regarding the unrefing of uv_handles in gRPC.
At the time, we weren't sure exactly why we were doing it, and when I removed the unrefing it appeared that all the node tests and c-core libuv tests were passing, so I left it out.

It turns out this is very much necessary.  Node uses a garbage collector, so these timers/channels will block the uv loop from exiting until they are garbage collected.

The failures were not noticed immediately because they don't show up in the node unit tests, only the interop tests.  The Node interop tests that get run on PRs don't use the pending changes to c-core, so I did not notice the failures at the time.