### PR TITLE
use GPR_UNLIKELY in GPR_ASSERT

### DIFF
--- a/include/grpc/support/log.h
+++ b/include/grpc/support/log.h
@@ -93,7 +93,7 @@ GPRAPI void gpr_set_log_function(gpr_log_func func);
    an exception in a higher-level language, consider returning error code.  */
 #define GPR_ASSERT(x)                                 \
   do {                                                \
-    if (!(x)) {                                       \
+    if (GPR_UNLIKELY(!(x))) {                         \
       gpr_log(GPR_ERROR, "assertion failed: %s", #x); \
       abort();                                        \
     }                                                 \


### PR DESCRIPTION
By using GPR_UNLIKELY on GPR_ASSERT, we are simply saying that conditions that lead to an abort are rare.

This would mean that we accelerate the normal conditions where the asserts succeed, and we penalize the showstopper condition where it aborts.