### PR TITLE
Do not reach into BoringSSL internals.

### DIFF
--- a/test/core/tsi/ssl_session_cache_test.cc
+++ b/test/core/tsi/ssl_session_cache_test.cc
@@ -88,7 +88,6 @@ TEST(SslSessionCacheTest, InitialState) {
   // Verify session initial state.
   {
     tsi::SslSessionPtr tmp_sess = tracker.NewSession(1);
-    EXPECT_EQ(tmp_sess->references, 1);
     EXPECT_TRUE(tracker.IsAlive(1));
     EXPECT_EQ(tracker.AliveCount(), 1);
   }


### PR DESCRIPTION
SSL_SESSION is a private struct and should not be accessed by calling
code. There is no need to assert on the reference count in that test;
the test already asserts on whether the SSL_SESSION was destroyed.