### PR TITLE
Fix GRPCHost callback for connectivity monitor

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -275,7 +275,7 @@ static NSMutableDictionary *kHostCache;
 // and Cellular data, so that a new call will use a new channel. Otherwise, a new call will still
 // use the cached channel which is no longer available and will cause gRPC to hang.
 - (void)connectivityChange:(NSNotification *)note {
-  [GRPCHost flushChannelCache];
+  [GRPCHost disconnect];
 }
 
 @end

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -50,6 +50,7 @@ static NSMutableDictionary *kHostCache;
   if (_channelCreds != nil) {
     grpc_channel_credentials_release(_channelCreds);
   }
+  [GRPCConnectivityMonitor unregisterObserver:self];
 }
 
 // Default initializer.

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -276,7 +276,7 @@ static NSMutableDictionary *kHostCache;
 // and Cellular data, so that a new call will use a new channel. Otherwise, a new call will still
 // use the cached channel which is no longer available and will cause gRPC to hang.
 - (void)connectivityChange:(NSNotification *)note {
-  [GRPCHost disconnect];
+  [self disconnect];
 }
 
 @end


### PR DESCRIPTION
Connectivity monitor callback is registered for *each* `GRPCHost` object. Therefore for each callback call, the `GRPCHost` object should only reset its own unmanaged channel.

The callback should be unregistered at `GRPCHost` object dealloc time.