### PR TITLE
PHP: change the behavior of clients sharing one channel

### DIFF
--- a/src/php/ext/grpc/call.h
+++ b/src/php/ext/grpc/call.h
@@ -27,6 +27,7 @@
 #include <php_ini.h>
 #include <ext/standard/info.h>
 #include "php_grpc.h"
+#include "channel.h"
 
 #include <grpc/grpc.h>
 
@@ -37,6 +38,7 @@ extern zend_class_entry *grpc_ce_call;
 PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_call)
   bool owned;
   grpc_call *wrapped;
+  wrapped_grpc_channel* channel;
 PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_call)
 
 #if PHP_MAJOR_VERSION < 7

--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -1,7 +1,7 @@
 <?php
 /*
  *
- * Copyright 2015 gRPC authors.
+ * Copyright 2018 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,14 +32,14 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testInsecureCredentials()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50000',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->assertSame('Grpc\Channel', get_class($this->channel));
     }
 
     public function testGetConnectivityState()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50001',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $state = $this->channel->getConnectivityState();
         $this->assertEquals(0, $state);
@@ -47,7 +47,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testGetConnectivityStateWithInt()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50002',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $state = $this->channel->getConnectivityState(123);
         $this->assertEquals(0, $state);
@@ -55,7 +55,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testGetConnectivityStateWithString()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50003',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $state = $this->channel->getConnectivityState('hello');
         $this->assertEquals(0, $state);
@@ -63,7 +63,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testGetConnectivityStateWithBool()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50004',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $state = $this->channel->getConnectivityState(true);
         $this->assertEquals(0, $state);
@@ -71,7 +71,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testGetTarget()
     {
-        $this->channel = new Grpc\Channel('localhost:8888',
+        $this->channel = new Grpc\Channel('localhost:50005',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $target = $this->channel->getTarget();
         $this->assertTrue(is_string($target));
@@ -79,7 +79,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testWatchConnectivityState()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50006',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $now = Grpc\Timeval::now();
         $deadline = $now->add(new Grpc\Timeval(100*1000));  // 100ms
@@ -93,7 +93,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testClose()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50007',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->assertNotNull($this->channel);
         $this->channel->close();
@@ -113,7 +113,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidConstructorWith()
     {
-        $this->channel = new Grpc\Channel('localhost:0', 'invalid');
+        $this->channel = new Grpc\Channel('localhost:50008', 'invalid');
         $this->assertNull($this->channel);
     }
 
@@ -122,7 +122,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidCredentials()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50009',
             ['credentials' => new Grpc\Timeval(100)]);
     }
 
@@ -131,7 +131,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidOptionsArray()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50010',
             ['abc' => []]);
     }
 
@@ -140,7 +140,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidGetConnectivityStateWithArray()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50011',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->getConnectivityState([]);
     }
@@ -150,7 +150,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidWatchConnectivityState()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50012',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->watchConnectivityState([]);
     }
@@ -160,7 +160,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidWatchConnectivityState2()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50013',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->watchConnectivityState(1, 'hi');
     }
@@ -185,10 +185,10 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testPersistentChannelSameHost()
     {
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
+        $this->channel1 = new Grpc\Channel('localhost:50014', []);
         // the underlying grpc channel is the same by default
         // when connecting to the same host
-        $this->channel2 = new Grpc\Channel('localhost:1', []);
+        $this->channel2 = new Grpc\Channel('localhost:50014', []);
 
         // both channels should be IDLE
         $state = $this->channel1->getConnectivityState();
@@ -213,8 +213,8 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     public function testPersistentChannelDifferentHost()
     {
         // two different underlying channels because different hostname
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:2', []);
+        $this->channel1 = new Grpc\Channel('localhost:50015', []);
+        $this->channel2 = new Grpc\Channel('localhost:50016', []);
 
         // both channels should be IDLE
         $state = $this->channel1->getConnectivityState();
@@ -239,8 +239,8 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testPersistentChannelSameArgs()
     {
-        $this->channel1 = new Grpc\Channel('localhost:1', ["abc" => "def"]);
-        $this->channel2 = new Grpc\Channel('localhost:1', ["abc" => "def"]);
+        $this->channel1 = new Grpc\Channel('localhost:50017', ["abc" => "def"]);
+        $this->channel2 = new Grpc\Channel('localhost:50017', ["abc" => "def"]);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -257,8 +257,8 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testPersistentChannelDifferentArgs()
     {
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1', ["abc" => "def"]);
+        $this->channel1 = new Grpc\Channel('localhost:50018', []);
+        $this->channel2 = new Grpc\Channel('localhost:50018', ["abc" => "def"]);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -278,9 +278,9 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $creds1 = Grpc\ChannelCredentials::createSsl();
         $creds2 = Grpc\ChannelCredentials::createSsl();
 
-        $this->channel1 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50019',
                                            ["credentials" => $creds1]);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel2 = new Grpc\Channel('localhost:50019',
                                            ["credentials" => $creds2]);
 
         // try to connect on channel1
@@ -302,9 +302,9 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $creds2 = Grpc\ChannelCredentials::createSsl(
             file_get_contents(dirname(__FILE__).'/../data/ca.pem'));
 
-        $this->channel1 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50020',
                                            ["credentials" => $creds1]);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel2 = new Grpc\Channel('localhost:50020',
                                            ["credentials" => $creds2]);
 
         // try to connect on channel1
@@ -327,9 +327,9 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $creds2 = Grpc\ChannelCredentials::createSsl(
             file_get_contents(dirname(__FILE__).'/../data/ca.pem'));
 
-        $this->channel1 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50021',
                                            ["credentials" => $creds1]);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel2 = new Grpc\Channel('localhost:50021',
                                            ["credentials" => $creds2]);
 
         // try to connect on channel1
@@ -350,9 +350,9 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $creds1 = Grpc\ChannelCredentials::createSsl();
         $creds2 = Grpc\ChannelCredentials::createInsecure();
 
-        $this->channel1 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50022',
                                            ["credentials" => $creds1]);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel2 = new Grpc\Channel('localhost:50022',
                                            ["credentials" => $creds2]);
 
         // try to connect on channel1
@@ -368,29 +368,49 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->channel2->close();
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
-    public function testPersistentChannelSharedChannelClose()
+    public function testPersistentChannelSharedChannelClose1()
     {
         // same underlying channel
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1', []);
+        $this->channel1 = new Grpc\Channel('localhost:50123', []);
+        $this->channel2 = new Grpc\Channel('localhost:50123', []);
 
         // close channel1
         $this->channel1->close();
 
-        // channel is already closed
+        // channel2 can still be use. We need to exclude the possible that
+        // in testPersistentChannelSharedChannelClose2, the exception is thrown
+        // by channel1.
         $state = $this->channel2->getConnectivityState();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testPersistentChannelSharedChannelClose2()
+    {
+        // same underlying channel
+        $this->channel1 = new Grpc\Channel('localhost:50223', []);
+        $this->channel2 = new Grpc\Channel('localhost:50223', []);
+
+        // close channel1
+        $this->channel1->close();
+
+        // channel2 can still be use
+        $state = $this->channel2->getConnectivityState();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+
+        // channel 1 is closed
+        $state = $this->channel1->getConnectivityState();
     }
 
     public function testPersistentChannelCreateAfterClose()
     {
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
+        $this->channel1 = new Grpc\Channel('localhost:50024', []);
 
         $this->channel1->close();
 
-        $this->channel2 = new Grpc\Channel('localhost:1', []);
+        $this->channel2 = new Grpc\Channel('localhost:50024', []);
         $state = $this->channel2->getConnectivityState();
         $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
 
@@ -399,9 +419,9 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testPersistentChannelSharedMoreThanTwo()
     {
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1', []);
-        $this->channel3 = new Grpc\Channel('localhost:1', []);
+        $this->channel1 = new Grpc\Channel('localhost:50025', []);
+        $this->channel2 = new Grpc\Channel('localhost:50025', []);
+        $this->channel3 = new Grpc\Channel('localhost:50025', []);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -439,10 +459,10 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         // If a ChannelCredentials object is composed with a
         // CallCredentials object, the underlying grpc channel will
         // always be created new and NOT persisted.
-        $this->channel1 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50026',
                                            ["credentials" =>
                                             $credsWithCallCreds]);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel2 = new Grpc\Channel('localhost:50026',
                                            ["credentials" =>
                                             $credsWithCallCreds]);
 
@@ -476,11 +496,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         // object is composed with a CallCredentials object, the
         // underlying grpc channel will always be separate and not
         // persisted
-        $this->channel1 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50027',
                                            ["credentials" => $creds1]);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel2 = new Grpc\Channel('localhost:50027',
                                            ["credentials" => $creds2]);
-        $this->channel3 = new Grpc\Channel('localhost:1',
+        $this->channel3 = new Grpc\Channel('localhost:50027',
                                            ["credentials" => $creds3]);
 
         // try to connect on channel1
@@ -501,10 +521,10 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testPersistentChannelForceNew()
     {
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
+        $this->channel1 = new Grpc\Channel('localhost:50028', []);
         // even though all the channel params are the same, channel2
         // has a new and different underlying channel
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel2 = new Grpc\Channel('localhost:50028',
                                            ["force_new" => true]);
 
         // try to connect on channel1
@@ -523,16 +543,15 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     public function testPersistentChannelForceNewOldChannelIdle()
     {
 
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50029', []);
+        $this->channel2 = new Grpc\Channel('localhost:50029',
                                            ["force_new" => true]);
         // channel3 shares with channel1
-        $this->channel3 = new Grpc\Channel('localhost:1', []);
+        $this->channel3 = new Grpc\Channel('localhost:50029', []);
 
         // try to connect on channel2
         $state = $this->channel2->getConnectivityState(true);
         $this->waitUntilNotIdle($this->channel2);
-
         $state = $this->channel1->getConnectivityState();
         $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
         $state = $this->channel2->getConnectivityState();
@@ -544,34 +563,59 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->channel2->close();
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
-    public function testPersistentChannelForceNewOldChannelClose()
+    public function testPersistentChannelForceNewOldChannelClose1()
     {
 
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50130', []);
+        $this->channel2 = new Grpc\Channel('localhost:50130',
                                            ["force_new" => true]);
         // channel3 shares with channel1
-        $this->channel3 = new Grpc\Channel('localhost:1', []);
+        $this->channel3 = new Grpc\Channel('localhost:50130', []);
 
         $this->channel1->close();
 
         $state = $this->channel2->getConnectivityState();
         $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
 
-        // channel3 already closed
+        // channel3 is still usable. We need to exclude the possibility that in
+        // testPersistentChannelForceNewOldChannelClose2, the exception is thrown
+        // by channel1 and channel2.
         $state = $this->channel3->getConnectivityState();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testPersistentChannelForceNewOldChannelClose2()
+    {
+
+        $this->channel1 = new Grpc\Channel('localhost:50230', []);
+        $this->channel2 = new Grpc\Channel('localhost:50230',
+          ["force_new" => true]);
+        // channel3 shares with channel1
+        $this->channel3 = new Grpc\Channel('localhost:50230', []);
+
+        $this->channel1->close();
+
+        $state = $this->channel2->getConnectivityState();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+
+        // channel3 is still usable
+        $state = $this->channel3->getConnectivityState();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+
+        // channel 1 is closed
+        $this->channel1->getConnectivityState();
     }
 
     public function testPersistentChannelForceNewNewChannelClose()
     {
 
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50031', []);
+        $this->channel2 = new Grpc\Channel('localhost:50031',
                                            ["force_new" => true]);
-        $this->channel3 = new Grpc\Channel('localhost:1', []);
+        $this->channel3 = new Grpc\Channel('localhost:50031', []);
 
         $this->channel2->close();
 


### PR DESCRIPTION
This PR depends on #14991, which add our own map and iterate method . 

Hi, @fengli79 can you please help me verify this new change make sense or not:
In the old way, if $client1 and $client2 share the same channel, when $client1 is closed, $client2 cannot be used anymore.
In the new change, only $client1 is invalid. $client2 is still usable.

Every channel has a new attribute `is_valid` and mark it to false when `close()` is called.
With this PR, the `close()` method will have 2 path:
- If the channel is not persisted: Free everything.
- If the channel is persisted: Only minus ref_count in the map with 1.
Then mark the channel is invalid. Every other methods need to check this bool before processing.
```
struct wrapped_grpc_channel { // Each wrapped_grpc_channel stands for one stub.
  grpc_channel_wrapper* real_channel; // Multiple wrapped_grpc_channel can point to it.
  bool is_valid;
  bool is_persistent;
}
struct channel_persistent_le { // Nodes in the map. Each key points to one channel.
  grpc_channel_wrapper* real_channel;
}
```
**Cons:** For every rpc call, we need to check the `$client` calling it is valid or not, which may
 affect performance.
