### PR TITLE
Rename ProtoBuffer Helpers

### DIFF
--- a/include/grpcpp/impl/codegen/byte_buffer.h
+++ b/include/grpcpp/impl/codegen/byte_buffer.h
@@ -146,8 +146,8 @@ class ByteBuffer final {
   friend class internal::ServerStreamingHandler;
   template <class R>
   friend class internal::DeserializeFuncType;
-  friend class GrpcProtoBufferReader;
-  friend class GrpcProtoBufferWriter;
+  friend class ProtoBufferReader;
+  friend class ProtoBufferWriter;
   friend class internal::GrpcByteBufferPeer;
 
   grpc_byte_buffer* buffer_;

--- a/include/grpcpp/impl/codegen/proto_buffer_reader.h
+++ b/include/grpcpp/impl/codegen/proto_buffer_reader.h
@@ -43,11 +43,11 @@ extern CoreCodegenInterface* g_core_codegen_interface;
 ///
 /// Read more about ZeroCopyInputStream interface here:
 /// https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.zero_copy_stream#ZeroCopyInputStream
-class GrpcProtoBufferReader : public ::grpc::protobuf::io::ZeroCopyInputStream {
+class ProtoBufferReader : public ::grpc::protobuf::io::ZeroCopyInputStream {
  public:
   /// Constructs buffer reader from \a buffer. Will set \a status() to non ok
   /// if \a buffer is invalid (the internal buffer has not been initialized).
-  explicit GrpcProtoBufferReader(ByteBuffer* buffer)
+  explicit ProtoBufferReader(ByteBuffer* buffer)
       : byte_count_(0), backup_count_(0), status_() {
     /// Implemented through a grpc_byte_buffer_reader which iterates
     /// over the slices that make up a byte buffer
@@ -59,7 +59,7 @@ class GrpcProtoBufferReader : public ::grpc::protobuf::io::ZeroCopyInputStream {
     }
   }
 
-  ~GrpcProtoBufferReader() {
+  ~ProtoBufferReader() {
     if (status_.ok()) {
       g_core_codegen_interface->grpc_byte_buffer_reader_destroy(&reader_);
     }

--- a/include/grpcpp/impl/codegen/proto_buffer_writer.h
+++ b/include/grpcpp/impl/codegen/proto_buffer_writer.h
@@ -38,10 +38,10 @@ extern CoreCodegenInterface* g_core_codegen_interface;
 
 // Forward declaration for testing use only
 namespace internal {
-class GrpcProtoBufferWriterPeer;
+class ProtoBufferWriterPeer;
 }  // namespace internal
 
-const int kGrpcProtoBufferWriterMaxBufferLength = 1024 * 1024;
+const int kProtoBufferWriterMaxBufferLength = 1024 * 1024;
 
 /// This is a specialization of the protobuf class ZeroCopyOutputStream.
 /// The principle is to give the proto layer one buffer of bytes at a time
@@ -50,15 +50,14 @@ const int kGrpcProtoBufferWriterMaxBufferLength = 1024 * 1024;
 ///
 /// Read more about ZeroCopyOutputStream interface here:
 /// https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.io.zero_copy_stream#ZeroCopyOutputStream
-class GrpcProtoBufferWriter
-    : public ::grpc::protobuf::io::ZeroCopyOutputStream {
+class ProtoBufferWriter : public ::grpc::protobuf::io::ZeroCopyOutputStream {
  public:
   /// Constructor for this derived class
   ///
   /// \param[out] byte_buffer A pointer to the grpc::ByteBuffer created
   /// \param block_size How big are the chunks to allocate at a time
   /// \param total_size How many total bytes are required for this proto
-  GrpcProtoBufferWriter(ByteBuffer* byte_buffer, int block_size, int total_size)
+  ProtoBufferWriter(ByteBuffer* byte_buffer, int block_size, int total_size)
       : block_size_(block_size),
         total_size_(total_size),
         byte_count_(0),
@@ -71,7 +70,7 @@ class GrpcProtoBufferWriter
     slice_buffer_ = &bp->data.raw.slice_buffer;
   }
 
-  ~GrpcProtoBufferWriter() {
+  ~ProtoBufferWriter() {
     if (have_backup_) {
       g_core_codegen_interface->grpc_slice_unref(backup_slice_);
     }
@@ -151,7 +150,7 @@ class GrpcProtoBufferWriter
 
  private:
   // friend for testing purposes only
-  friend class internal::GrpcProtoBufferWriterPeer;
+  friend class internal::ProtoBufferWriterPeer;
   const int block_size_;  ///< size to alloc for each new \a grpc_slice needed
   const int total_size_;  ///< byte size of proto being serialized
   int64_t byte_count_;    ///< bytes written since this object was created

--- a/include/grpcpp/impl/codegen/proto_utils.h
+++ b/include/grpcpp/impl/codegen/proto_utils.h
@@ -60,8 +60,7 @@ Status GenericSerialize(const grpc::protobuf::Message& msg, ByteBuffer* bb,
 
     return g_core_codegen_interface->ok();
   }
-  ProtoBufferWriter writer(bb, kGrpcProtoBufferWriterMaxBufferLength,
-                           byte_size);
+  ProtoBufferWriter writer(bb, kProtoBufferWriterMaxBufferLength, byte_size);
   return msg.SerializeToZeroCopyStream(&writer)
              ? g_core_codegen_interface->ok()
              : Status(StatusCode::INTERNAL, "Failed to serialize message");
@@ -108,11 +107,11 @@ class SerializationTraits<T, typename std::enable_if<std::is_base_of<
  public:
   static Status Serialize(const grpc::protobuf::Message& msg, ByteBuffer* bb,
                           bool* own_buffer) {
-    return GenericSerialize<GrpcProtoBufferWriter, T>(msg, bb, own_buffer);
+    return GenericSerialize<ProtoBufferWriter, T>(msg, bb, own_buffer);
   }
 
   static Status Deserialize(ByteBuffer* buffer, grpc::protobuf::Message* msg) {
-    return GenericDeserialize<GrpcProtoBufferReader, T>(buffer, msg);
+    return GenericDeserialize<ProtoBufferReader, T>(buffer, msg);
   }
 };
 #endif

--- a/test/cpp/codegen/proto_utils_test.cc
+++ b/test/cpp/codegen/proto_utils_test.cc
@@ -27,17 +27,16 @@ namespace grpc {
 
 namespace internal {
 
-// Provide access to GrpcProtoBufferWriter internals.
-class GrpcProtoBufferWriterPeer {
+// Provide access to ProtoBufferWriter internals.
+class ProtoBufferWriterPeer {
  public:
-  explicit GrpcProtoBufferWriterPeer(GrpcProtoBufferWriter* writer)
-      : writer_(writer) {}
+  explicit ProtoBufferWriterPeer(ProtoBufferWriter* writer) : writer_(writer) {}
   bool have_backup() const { return writer_->have_backup_; }
   const grpc_slice& backup_slice() const { return writer_->backup_slice_; }
   const grpc_slice& slice() const { return writer_->slice_; }
 
  private:
-  GrpcProtoBufferWriter* writer_;
+  ProtoBufferWriter* writer_;
 };
 
 // Provide access to ByteBuffer internals.
@@ -53,14 +52,14 @@ class GrpcByteBufferPeer {
 class ProtoUtilsTest : public ::testing::Test {};
 
 // Regression test for a memory corruption bug where a series of
-// GrpcProtoBufferWriter Next()/Backup() invocations could result in a dangling
+// ProtoBufferWriter Next()/Backup() invocations could result in a dangling
 // pointer returned by Next() due to the interaction between grpc_slice inlining
 // and GRPC_SLICE_START_PTR.
 TEST_F(ProtoUtilsTest, TinyBackupThenNext) {
   ByteBuffer bp;
   const int block_size = 1024;
-  GrpcProtoBufferWriter writer(&bp, block_size, 8192);
-  GrpcProtoBufferWriterPeer peer(&writer);
+  ProtoBufferWriter writer(&bp, block_size, 8192);
+  ProtoBufferWriterPeer peer(&writer);
 
   void* data;
   int size;
@@ -81,7 +80,7 @@ namespace {
 // Set backup_size to 0 to indicate no backup is needed.
 void BufferWriterTest(int block_size, int total_size, int backup_size) {
   ByteBuffer bb;
-  GrpcProtoBufferWriter writer(&bb, block_size, total_size);
+  ProtoBufferWriter writer(&bb, block_size, total_size);
 
   int written_size = 0;
   void* data;
@@ -162,7 +161,7 @@ TEST(WriterTest, LargeBlockLargeBackup) { BufferWriterTest(4096, 8192, 4095); }
 }  // namespace grpc
 
 int main(int argc, char** argv) {
-  // Ensure the GrpcProtoBufferWriter internals are initialized.
+  // Ensure the ProtoBufferWriter internals are initialized.
   grpc::internal::GrpcLibraryInitializer init;
   init.summon();
   grpc::GrpcLibraryCodegen lib;


### PR DESCRIPTION
Thout shall not prepend classes in the grpc namespace with Grpc