### PR TITLE
Set DYLD_LIBRARY_PATH to be based off of

### DIFF
--- a/src/php/bin/run_tests.sh
+++ b/src/php/bin/run_tests.sh
@@ -21,6 +21,6 @@ root=$(pwd)
 cd src/php/bin
 source ./determine_extension_dir.sh
 # in some jenkins macos machine, somehow the PHP build script can't find libgrpc.dylib
-export DYLD_LIBRARY_PATH=$root/libs/$config
+export DYLD_LIBRARY_PATH=$root/libs/$CONFIG
 php $extension_dir -d max_execution_time=300 $(which phpunit) -v --debug \
   ../tests/unit_tests


### PR DESCRIPTION
Fixes this error:
```
2018-04-13 15:27:39,847 START: src/php/bin/run_tests.sh
2018-04-13 15:27:40,123 ++ dirname src/php/bin/run_tests.sh
+ cd src/php/bin/../../..
++ pwd
+ root=/Users/kbuilder/grpc/workspace_php_macos_opt_native
+ cd src/php/bin
+ source ./determine_extension_dir.sh
++ set -e
+++ php-config --extension-dir
++ default_extension_dir=/usr/lib/php/extensions/no-debug-non-zts-20131226
++ '[' '!' -e /usr/lib/php/extensions/no-debug-non-zts-20131226/grpc.so ']'
+++ pwd
++ module_dir=/Users/kbuilder/grpc/workspace_php_macos_opt_native/src/php/bin/../ext/grpc/modules
++ '[' '!' -e /Users/kbuilder/grpc/workspace_php_macos_opt_native/src/php/bin/../ext/grpc/modules/grpc.so ']'
++ for f in '$default_extension_dir/*.so'
+++ basename /usr/lib/php/extensions/no-debug-non-zts-20131226/opcache.so
++ ln -s /usr/lib/php/extensions/no-debug-non-zts-20131226/opcache.so /Users/kbuilder/grpc/workspace_php_macos_opt_native/src/php/bin/../ext/grpc/modules/opcache.so
++ for f in '$default_extension_dir/*.so'
+++ basename /usr/lib/php/extensions/no-debug-non-zts-20131226/xdebug.so
++ ln -s /usr/lib/php/extensions/no-debug-non-zts-20131226/xdebug.so /Users/kbuilder/grpc/workspace_php_macos_opt_native/src/php/bin/../ext/grpc/modules/xdebug.so
++ extension_dir='-d extension_dir=/Users/kbuilder/grpc/workspace_php_macos_opt_native/src/php/bin/../ext/grpc/modules -d extension=grpc.so'
+ export DYLD_LIBRARY_PATH=/Users/kbuilder/grpc/workspace_php_macos_opt_native/libs/
+ DYLD_LIBRARY_PATH=/Users/kbuilder/grpc/workspace_php_macos_opt_native/libs/
++ which phpunit
+ php -d extension_dir=/Users/kbuilder/grpc/workspace_php_macos_opt_native/src/php/bin/../ext/grpc/modules -d extension=grpc.so -d max_execution_time=300 /usr/local/bin/phpunit -v --debug ../tests/unit_tests
PHP Warning:  PHP Startup: Unable to load dynamic library '/Users/kbuilder/grpc/workspace_php_macos_opt_native/src/php/bin/../ext/grpc/modules/grpc.so' - dlopen(/Users/kbuilder/grpc/workspace_php_macos_opt_native/src/php/bin/../ext/grpc/modules/grpc.so, 9): Library not loaded: libgrpc.dylib
  Referenced from: /Users/kbuilder/grpc/workspace_php_macos_opt_native/src/php/ext/grpc/modules/grpc.so
  Reason: image not found in Unknown on line 0
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.

Runtime:	PHP 5.6.30


Starting test 'CallCredentials2Test::testCreateFromPlugin'.

Fatal error: Class 'Grpc\ChannelCredentials' not found in /Users/kbuilder/grpc/workspace_php_macos_opt_native/src/php/tests/unit_tests/CallCredentials2Test.php on line 24

2018-04-13 15:27:40,124 FAILED: src/php/bin/run_tests.sh [ret=255, pid=57327, time=0.3sec]
```