### PR TITLE
Fix cares resolution with default authority (for v1.11.x)

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -135,6 +135,7 @@ AresDnsResolver::AresDnsResolver(const ResolverArgs& args)
   if (path[0] == '/') ++path;
   name_to_resolve_ = gpr_strdup(path);
   // Get DNS server from URI authority.
+  dns_server_ = nullptr;
   if (0 != strcmp(args.uri->authority, "")) {
     dns_server_ = gpr_strdup(args.uri->authority);
   }


### PR DESCRIPTION
- always initialize dns_server_ in ares resolver.
- if `uri.authority` is empty,  the dns_server_ ends up containing garbage and that fails the DNS resolution.
- it looks like we don't have tests for "dns:///foo.bar.com" (when DNS server is not specified explicitly in the URI), so it would be good to add a test for this. For now, I tested this locally.

Example of failed DNS resolution (can be tested with interop_client when GRPC_DNS_RESOLVER=ares can is set):
```
I0416 09:59:49.922035 140086169052928 src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc:366: Using DNS server 
E0416 09:59:49.922058 140086169052928 src/core/ext/filters/client_channel/parse_address.cc:144: invalid ipv6 address: ''
```