### PR TITLE
PHP: persistent channel helper method should not be exposed

### DIFF
--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -534,6 +534,7 @@ static void php_grpc_channel_plink_dtor(php_grpc_zend_resource *rsrc
   }
 }
 
+#ifdef GRPC_PHP_DEBUG
 /**
  * Clean all channels in the persistent.
  * @return void
@@ -580,6 +581,7 @@ PHP_METHOD(Channel, getPersistentList) {
     add_assoc_zval(return_value, le->channel->target, ret_arr);
   PHP_GRPC_HASH_FOREACH_END()
 }
+#endif
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_construct, 0, 0, 2)
   ZEND_ARG_INFO(0, target)
@@ -601,11 +603,13 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_close, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
+#ifdef GRPC_PHP_DEBUG
 ZEND_BEGIN_ARG_INFO_EX(arginfo_cleanPersistentList, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_getPersistentList, 0, 0, 0)
 ZEND_END_ARG_INFO()
+#endif
 
 static zend_function_entry channel_methods[] = {
   PHP_ME(Channel, __construct, arginfo_construct,
@@ -618,10 +622,12 @@ static zend_function_entry channel_methods[] = {
          ZEND_ACC_PUBLIC)
   PHP_ME(Channel, close, arginfo_close,
          ZEND_ACC_PUBLIC)
+  #ifdef GRPC_PHP_DEBUG
   PHP_ME(Channel, cleanPersistentList, arginfo_cleanPersistentList,
          ZEND_ACC_PUBLIC)
   PHP_ME(Channel, getPersistentList, arginfo_getPersistentList,
          ZEND_ACC_PUBLIC)
+  #endif
   PHP_FE_END
 };
 

--- a/src/php/ext/grpc/config.m4
+++ b/src/php/ext/grpc/config.m4
@@ -4,6 +4,14 @@ PHP_ARG_ENABLE(grpc, whether to enable grpc support,
 PHP_ARG_ENABLE(coverage, whether to include code coverage symbols,
 [  --enable-coverage       Enable coverage support], no, no)
 
+PHP_ARG_ENABLE(tests, whether to compile helper methods for tests,
+[  --enable-tests          Enable tests methods], no, no)
+
+dnl Check whether to enable tests
+if test "$PHP_TESTS" != "no"; then
+  CPPFLAGS="$CPPFLAGS -DGRPC_PHP_DEBUG"
+fi
+
 if test "$PHP_GRPC" != "no"; then
   dnl Write more examples of tests here...
 

--- a/tools/run_tests/helper_scripts/build_php.sh
+++ b/tools/run_tests/helper_scripts/build_php.sh
@@ -23,15 +23,14 @@ cd "$(dirname "$0")/../../.."
 root=$(pwd)
 export GRPC_LIB_SUBDIR=libs/$CONFIG
 export CFLAGS="-Wno-parentheses-equality"
-
 # build php
 cd src/php
 
 cd ext/grpc
 phpize
 if [ "$CONFIG" != "gcov" ] ; then
-  ./configure --enable-grpc="$root"
+  ./configure --enable-grpc="$root" --enable-tests
 else
-  ./configure --enable-grpc="$root" --enable-coverage
+  ./configure --enable-grpc="$root" --enable-coverage --enable-tests
 fi
 make


### PR DESCRIPTION
Two methods:
`cleanPersistentChannel` and `getPersistentChannel` should only be used during the tests.
Use macro to not compile them.
To enable then:
`./configure --enable-tests`