### PR TITLE
Fix _channel ref count issue

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -108,6 +108,9 @@ static NSMutableDictionary *kHostCache;
                                    serverName:(NSString *)serverName
                                       timeout:(NSTimeInterval)timeout
                               completionQueue:(GRPCCompletionQueue *)queue {
+  // The __block attribute is to allow channel take refcount inside @synchronized block. Without
+  // this attribute, retain of channel object happens after objc_sync_exit in release builds, which
+  // may result in channel released before used. See grpc/#15033.
   __block GRPCChannel *channel;
   // This is racing -[GRPCHost disconnect].
   @synchronized(self) {

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -108,7 +108,7 @@ static NSMutableDictionary *kHostCache;
                                    serverName:(NSString *)serverName
                                       timeout:(NSTimeInterval)timeout
                               completionQueue:(GRPCCompletionQueue *)queue {
-  GRPCChannel *channel;
+  __block GRPCChannel *channel;
   // This is racing -[GRPCHost disconnect].
   @synchronized(self) {
     if (!_channel) {


### PR DESCRIPTION
`_channel` ref obtain happened after the sync block exited, which might be a compiler bug. This PR mitigates this problem by making `_channel` a `__block` variable.

Fixes #15033. 