### PR TITLE
Make package name of ALTS tests explicitly under test

### DIFF
--- a/test/core/tsi/alts/crypt/BUILD
+++ b/test/core/tsi/alts/crypt/BUILD
@@ -16,7 +16,7 @@ load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_p
 
 licenses(["notice"])  # Apache v2
 
-grpc_package(name = "crypt", visibility = "public")
+grpc_package(name = "test/core/tsi/alts/crypt", visibility = "public")
 
 grpc_cc_test(
     name = "alts_crypt_test",

--- a/test/core/tsi/alts/frame_protector/BUILD
+++ b/test/core/tsi/alts/frame_protector/BUILD
@@ -16,7 +16,7 @@ load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_p
 
 licenses(["notice"])  # Apache v2
 
-grpc_package(name = "frame_protector")
+grpc_package(name = "test/core/tsi/alts/frame_protector")
 
 grpc_cc_test(
     name = "alts_counter_test",

--- a/test/core/tsi/alts/handshaker/BUILD
+++ b/test/core/tsi/alts/handshaker/BUILD
@@ -16,7 +16,7 @@ load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_p
 
 licenses(["notice"])  # Apache v2 
          
-grpc_package(name = "handshaker")
+grpc_package(name = "test/core/tsi/alts/handshaker")
          
 grpc_cc_library(
     name = "alts_handshaker_service_api_test_lib",

--- a/test/core/tsi/alts/zero_copy_frame_protector/BUILD
+++ b/test/core/tsi/alts/zero_copy_frame_protector/BUILD
@@ -16,7 +16,7 @@ load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])  # Apache v2
 
-grpc_package(name = "zero_copy_frame_protector")
+grpc_package(name = "test/core/tsi/alts/zero_copy_frame_protector")
 
 grpc_cc_test(
     name = "alts_grpc_record_protocol_test",


### PR DESCRIPTION
Otherwise, some internal check disabled for tests can't be disabled for these packages.