### PR TITLE
Fix a use of nonexistent .received_cancelled

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_cython/_cancel_many_calls_test.py
+++ b/src/python/grpcio_tests/tests/unit/_cython/_cancel_many_calls_test.py
@@ -43,7 +43,7 @@ class _State(object):
 
 def _is_cancellation_event(event):
     return (event.tag is _RECEIVE_CLOSE_ON_SERVER_TAG and
-            event.batch_operations[0].received_cancelled)
+            event.batch_operations[0].cancelled())
 
 
 class _Handler(object):


### PR DESCRIPTION
This is a fix separated out of mainline work on [issue 12531](https://github.com/grpc/grpc/issues/12531).