### PR TITLE
Update xcode version for macOS Obj-C tests to 9.2

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -67,7 +67,7 @@ pip install -U Mako six tox setuptools twisted pyyaml --user python
 export PYTHONPATH=/Library/Python/3.4/site-packages
 
 # set xcode version for Obj-C tests
-sudo xcode-select -switch /Applications/Xcode_8.2.1.app/Contents/Developer
+sudo xcode-select -switch /Applications/Xcode_9.2.app/Contents/Developer/
 
 # TODO(jtattermusch): better debugging of clock skew, remove once not needed
 date


### PR DESCRIPTION
This is the latest xcode version available on Kokoro macOS Sierra workers. 

Fixes #15072 