### PR TITLE
Avoid warnings from LLVM -Wself-assign.

### DIFF
--- a/test/core/gprpp/ref_counted_ptr_test.cc
+++ b/test/core/gprpp/ref_counted_ptr_test.cc
@@ -88,7 +88,7 @@ TEST(RefCountedPtr, CopyAssignmentWhenEmpty) {
 
 TEST(RefCountedPtr, CopyAssignmentToSelf) {
   RefCountedPtr<Foo> foo(New<Foo>());
-  foo = foo;
+  foo = *&foo;  // The "*&" avoids warnings from LLVM -Wself-assign.
 }
 
 TEST(RefCountedPtr, EnclosedScope) {


### PR DESCRIPTION
Found during an internal clean-up.