### PR TITLE
Remove old environment variable from Python artifact build

### DIFF
--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -17,7 +17,6 @@ set -ex
 
 cd "$(dirname "$0")/../../.."
 
-export GRPC_PYTHON_USE_CUSTOM_BDIST=0
 export GRPC_PYTHON_BUILD_WITH_CYTHON=1
 export PYTHON=${PYTHON:-python}
 export PIP=${PIP:-pip}


### PR DESCRIPTION
It appears `GRPC_PYTHON_USE_CUSTOM_BDIST` is no longer used anywhere: it was added in https://github.com/grpc/grpc/commit/5c04760d46f2628a83106d048e732c997fed8801 but reading it was removed in https://github.com/grpc/grpc/commit/f747409f6f528c95f39297ebf3aea02085119285#diff-2661f7832fd616ffcef52579b626c053