### PR TITLE
Fix bug in address sorting shutdown

### DIFF
--- a/test/cpp/naming/address_sorting_test.cc
+++ b/test/cpp/naming/address_sorting_test.cc
@@ -722,16 +722,24 @@ TEST(AddressSortingTest, TestStableSortV4CompatAndSiteLocalAddresses) {
 }
 
 int main(int argc, char** argv) {
-  const char* resolver = gpr_getenv("GRPC_DNS_RESOLVER");
+  char* resolver = gpr_getenv("GRPC_DNS_RESOLVER");
   if (resolver == nullptr || strlen(resolver) == 0) {
     gpr_setenv("GRPC_DNS_RESOLVER", "ares");
   } else if (strcmp("ares", resolver)) {
     gpr_log(GPR_INFO, "GRPC_DNS_RESOLVER != ares: %s.", resolver);
   }
+  gpr_free(resolver);
   grpc_test_init(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   grpc_init();
   auto result = RUN_ALL_TESTS();
+  grpc_shutdown();
+  // Test sequential and nested inits and shutdowns.
+  grpc_init();
+  grpc_init();
+  grpc_shutdown();
+  grpc_shutdown();
+  grpc_init();
   grpc_shutdown();
   return result;
 }

--- a/third_party/address_sorting/address_sorting.c
+++ b/third_party/address_sorting/address_sorting.c
@@ -366,4 +366,5 @@ void address_sorting_shutdown() {
     abort();
   }
   g_current_source_addr_factory->vtable->destroy(g_current_source_addr_factory);
+  g_current_source_addr_factory = NULL;
 }


### PR DESCRIPTION
Noticed while working on https://github.com/grpc/grpc/pull/12416

currently, if we do an init that follows a shutdown, then [an assertion failure in address_sorting.c will be triggered](https://github.com/grpc/grpc/blob/master/third_party/address_sorting/address_sorting.c#L358)