### PR TITLE
Fixed undefined `_WIN32_WINNT` for generated files on Windows.

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -39,6 +39,8 @@
 #define NOMINMAX
 #endif /* NOMINMAX */
 
+#include <windows.h>
+
 #ifndef _WIN32_WINNT
 #error \
     "Please compile grpc with _WIN32_WINNT of at least 0x600 (aka Windows Vista)"
@@ -48,8 +50,6 @@
     "Please compile grpc with _WIN32_WINNT of at least 0x600 (aka Windows Vista)"
 #endif /* _WIN32_WINNT < 0x0600 */
 #endif /* defined(_WIN32_WINNT) */
-
-#include <windows.h>
 
 #ifdef GRPC_WIN32_LEAN_AND_MEAN_WAS_NOT_DEFINED
 #undef GRPC_WIN32_LEAN_AND_MEAN_WAS_NOT_DEFINED


### PR DESCRIPTION
When compiling a `.grpc.cc` file generated by `protoc.exe` with `grpc_cpp_plugin.exe`, the following error would show up:
```
Please compile grpc with _WIN32_WINNT of at least 0x600 (aka Windows Vista)
```
It seems that the generated file somehow includes `port_platform.h`, which checks `_WIN32_WINNT` before including `windows.h`, which includes `sdkddkver.h`, which in turn defines `_WIN32_WINNT`. This PR moves the inclusion of `windows.h` before checking `_WIN32_WINNT` in this header file.

This patch is the same as https://github.com/grpc/grpc/pull/14574, and might be the same error described in https://github.com/grpc/grpc/issues/14575.