### PR TITLE
Build for ARMv6 as well as ARMv7

### DIFF
--- a/tools/internal_ci/linux/grpc_build_artifacts_extra.sh
+++ b/tools/internal_ci/linux/grpc_build_artifacts_extra.sh
@@ -16,7 +16,7 @@
 set -ex
 
 # change to grpc repo root
-cd $(dirname $0)/../../..
+cd "$(dirname "$0")/../../.."
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
@@ -27,3 +27,4 @@ rvm --default use ruby-2.4.1
 set -ex
 
 tools/run_tests/task_runner.py -f artifact linux_extra armv7 -j 6
+tools/run_tests/task_runner.py -f artifact linux_extra armv6 -j 6


### PR DESCRIPTION
Seems like people want an ARMv6 build as well as ARMv7 build. https://github.com/googlesamples/assistant-sdk-python/issues/235