### PR TITLE
Update the run tests instructions to clarify a python module error

### DIFF
--- a/tools/run_tests/README.md
+++ b/tools/run_tests/README.md
@@ -14,6 +14,8 @@ Builds gRPC in given language and runs unit tests. Use `tools/run_tests/run_test
 - `--use_docker` Builds a docker container containing all the prerequisites for given language and runs the tests under that container.
 - `--build_only` Only build, do not run the tests.
 
+Note: If you get an error such as `ImportError: No module named httplib2`, then you may be missing some Python modules. Install the module listed in the error and try again. 
+
 Note: some tests may be flaky. Check the "Issues" tab for known flakes and other issues.
 
 The full suite of unit tests will take many minutes to run.


### PR DESCRIPTION
I got this error while trying to run the unit tests on both my computers. It may not be immediately clear to some users how to resolve this error, so these instructions might help.