### PR TITLE
Bring down channel setup latency when using c-ares

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -478,7 +478,7 @@ static grpc_ares_request* grpc_dns_lookup_ares_impl(
     grpc_ares_request_ref(r);
     char* config_name;
     gpr_asprintf(&config_name, "_grpc_config.%s", host);
-    ares_search(*channel, config_name, ns_c_in, ns_t_txt, on_txt_done_cb, r);
+    ares_query(*channel, config_name, ns_c_in, ns_t_txt, on_txt_done_cb, r);
     gpr_free(config_name);
   }
   /* TODO(zyc): Handle CNAME records here. */


### PR DESCRIPTION
Using the `ares_search` API for TXT records causes c-ares internally to do a TXT record lookup for `_grpc_config.<target>` suffixed with <i>each</i> of the domains listed on the "search" field of the host's `/etc/resolv.conf` file, sequentially, until an answer is found. 

E.g., if there are are 6 domains listed in the "search" field of the host's `/etc/resolv.conf`, and each failed TXT DNS request/response to the nearby recursive resolver takes ~70ms (what I'm seeing on my local machine), then using `GRPC_DNS_RESOLVER=ares` and connecting to a server at `localhost:<port>` takes 400ms, where as using the native resolver is just a host file lookup. This change causes c-ares to query for only `_grpc_config.<target>`, and so it brings down that time to just one of the RTT's

cc @ejona86 @dfawley, I'm not sure what Go and Java do here.