### PR TITLE
Provide protocol for initializer of generated messages

### DIFF
--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -248,7 +248,7 @@ void PrintMethodImplementations(Printer* printer,
                 " */\n");
   printer.Print(vars,
                 "@interface $service_class$ :"
-                " GRPCProtoService<$service_class$>\n");
+                " GRPCProtoService<$service_class$, GRPCProtoServiceInit>\n");
   printer.Print(
       "- (instancetype)initWithHost:(NSString *)host"
       " NS_DESIGNATED_INITIALIZER;\n");

--- a/src/objective-c/ProtoRPC/ProtoService.h
+++ b/src/objective-c/ProtoRPC/ProtoService.h
@@ -22,6 +22,12 @@
 @protocol GRXWriteable;
 @class GRXWriter;
 
+@protocol GRPCProtoServiceInit
+
+- (instancetype)initWithHost:(NSString *)host;
+
+@end
+
 __attribute__((deprecated("Please use GRPCProtoService."))) @interface ProtoService
     : NSObject -
       (instancetype)initWithHost : (NSString *)host packageName


### PR DESCRIPTION
All generated service stubs have the same initializer. The new `@protocol` allows Swift users to use generic types for generated stubs.

Fix #14871. @dcow