### PR TITLE
fd tracing support

### DIFF
--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -49,7 +49,9 @@ some configuration as environment variables that can be set.
   - connectivity_state - traces connectivity state changes to channels
   - channel_stack_builder - traces information about channel stacks being built
   - executor - traces grpc's internal thread pool ('the executor')
-  - fd_trace - traces fd creation, shutdown and closure.
+  - fd_trace - traces fd create(), shutdown() and close() calls for channel fds.
+    Also traces epoll fd create()/close() calls in epollex polling engine
+    traces epoll-fd creation/close calls for epollex polling engine
   - glb - traces the grpclb load balancer
   - handshaker - traces handshaking state
   - http - traces state in the http2 transport engine

--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -49,6 +49,7 @@ some configuration as environment variables that can be set.
   - connectivity_state - traces connectivity state changes to channels
   - channel_stack_builder - traces information about channel stacks being built
   - executor - traces grpc's internal thread pool ('the executor')
+  - fd_trace - traces fd creation, shutdown and closure.
   - glb - traces the grpclb load balancer
   - handshaker - traces handshaking state
   - http - traces state in the http2 transport engine

--- a/src/core/lib/iomgr/ev_posix.cc
+++ b/src/core/lib/iomgr/ev_posix.cc
@@ -40,6 +40,9 @@
 
 grpc_core::TraceFlag grpc_polling_trace(false,
                                         "polling"); /* Disabled by default */
+
+/* Traces fd create/close operations */
+grpc_core::TraceFlag grpc_fd_trace(false, "fd_trace");
 grpc_core::DebugOnlyTraceFlag grpc_trace_fd_refcount(false, "fd_refcount");
 grpc_core::DebugOnlyTraceFlag grpc_polling_api_trace(false, "polling_api");
 
@@ -192,6 +195,7 @@ void grpc_event_engine_shutdown(void) {
 
 grpc_fd* grpc_fd_create(int fd, const char* name) {
   GRPC_POLLING_API_TRACE("fd_create(%d, %s)", fd, name);
+  GRPC_FD_TRACE("fd_create(%d, %s)", fd, name);
   return g_event_engine->fd_create(fd, name);
 }
 
@@ -204,11 +208,14 @@ void grpc_fd_orphan(grpc_fd* fd, grpc_closure* on_done, int* release_fd,
   GRPC_POLLING_API_TRACE("fd_orphan(%d, %p, %p, %d, %s)",
                          grpc_fd_wrapped_fd(fd), on_done, release_fd,
                          already_closed, reason);
+  GRPC_FD_TRACE("grpc_fd_orphan, fd:%d closed", grpc_fd_wrapped_fd(fd));
+
   g_event_engine->fd_orphan(fd, on_done, release_fd, already_closed, reason);
 }
 
 void grpc_fd_shutdown(grpc_fd* fd, grpc_error* why) {
   GRPC_POLLING_API_TRACE("fd_shutdown(%d)", grpc_fd_wrapped_fd(fd));
+  GRPC_FD_TRACE("fd_shutdown(%d)", grpc_fd_wrapped_fd(fd));
   g_event_engine->fd_shutdown(fd, why);
 }
 

--- a/src/core/lib/iomgr/ev_posix.h
+++ b/src/core/lib/iomgr/ev_posix.h
@@ -29,7 +29,13 @@
 #include "src/core/lib/iomgr/pollset_set.h"
 #include "src/core/lib/iomgr/wakeup_fd_posix.h"
 
+extern grpc_core::TraceFlag grpc_fd_trace;      /* Disabled by default */
 extern grpc_core::TraceFlag grpc_polling_trace; /* Disabled by default */
+
+#define GRPC_FD_TRACE(format, ...)                        \
+  if (grpc_fd_trace.enabled()) {                          \
+    gpr_log(GPR_INFO, "(fd-trace) " format, __VA_ARGS__); \
+  }
 
 typedef struct grpc_fd grpc_fd;
 


### PR DESCRIPTION
Trace fd create/shutdown/close calls. Helpful in debugging a recent issue where we are seeing a grpc server fail with "too many open files" error.
