### PR TITLE
Add GPR_DEBUG_ASSERT

### DIFF
--- a/include/grpc/support/log.h
+++ b/include/grpc/support/log.h
@@ -99,6 +99,12 @@ GPRAPI void gpr_set_log_function(gpr_log_func func);
     }                                                 \
   } while (0)
 
+#ifndef NDEBUG
+#define GPR_DEBUG_ASSERT(x) GPR_ASSERT(x)
+#else
+#define GPR_DEBUG_ASSERT(x)
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
There are some places where a GPR_ASSERT kind of makes sense in opt builds. (They would be scenarios where we have not option but to abort.) But, in all other places we can use GPR_DEBUG_ASSERT and restrict assert to only our debug builds. 