### PR TITLE
Revert "Enable C++ in ALTS interop tests"

### DIFF
--- a/src/core/lib/security/transport/security_handshaker.cc
+++ b/src/core/lib/security/transport/security_handshaker.cc
@@ -232,10 +232,6 @@ static grpc_error* on_handshake_next_done_locked(
     const unsigned char* bytes_to_send, size_t bytes_to_send_size,
     tsi_handshaker_result* handshaker_result) {
   grpc_error* error = GRPC_ERROR_NONE;
-  // Handshaker was shutdown.
-  if (h->shutdown) {
-    return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Handshaker shutdown");
-  }
   // Read more if we need to.
   if (result == TSI_INCOMPLETE_DATA) {
     GPR_ASSERT(bytes_to_send_size == 0);

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -638,10 +638,10 @@ _LANGUAGES_WITH_HTTP2_CLIENTS_FOR_HTTP2_SERVER_TEST_CASES = [
 ]
 
 #TODO: Add c++ when c++ ALTS interop client is ready.
-_LANGUAGES_FOR_ALTS_TEST_CASES = ['java', 'go', 'c++']
+_LANGUAGES_FOR_ALTS_TEST_CASES = ['java', 'go']
 
 #TODO: Add c++ when c++ ALTS interop server is ready.
-_SERVERS_FOR_ALTS_TEST_CASES = ['java', 'go', 'c++']
+_SERVERS_FOR_ALTS_TEST_CASES = ['java', 'go']
 
 _TRANSPORT_SECURITY_OPTIONS = ['tls', 'alts', 'insecure']
 


### PR DESCRIPTION
Reverts grpc/grpc#15190
It breaks the bazel build: https://fusion.corp.google.com/projectanalysis/current/KOKORO/prod:grpc%2Fcore%2Fmaster%2Flinux%2Fremote_bazel_tests_dbg