### PR TITLE
PHP: add tests for php-fpm mode

### DIFF
--- a/src/php/bin/run_tests.sh
+++ b/src/php/bin/run_tests.sh
@@ -28,3 +28,22 @@ php $extension_dir -d max_execution_time=300 $(which phpunit) -v --debug \
 php $extension_dir -d max_execution_time=300 $(which phpunit) -v --debug \
   ../tests/unit_tests/PersistentChannelTests
 
+if [ "$1" = "with-php-fpm-tests" ]; then
+  if [ -e "/usr/local/etc/php.ini" ]; then
+    # start nginx
+    service nginx start
+    # restart php-fpm
+    pkill -o php-fpm
+    php-fpm -c /usr/local/etc
+    cp ../tests/php-fpm-tests/channel1.php /var/www/html/channel1.php
+    cp ../tests/php-fpm-tests/channel2.php /var/www/html/channel2.php
+    curl -o - "localhost/channel1.php"
+    curl -o - "localhost/channel2.php" | tee output
+    res=`head -n 1 output`
+    if [ $res == "0" ]; then
+      exit 0
+    fi
+    exit 1
+  fi
+fi
+

--- a/src/php/tests/php-fpm-tests/channel1.php
+++ b/src/php/tests/php-fpm-tests/channel1.php
@@ -1,0 +1,4 @@
+<?php
+
+$channel = new Grpc\Channel('localhost:50001',
+   ['credentials' => Grpc\ChannelCredentials::createInsecure()]);

--- a/src/php/tests/php-fpm-tests/channel2.php
+++ b/src/php/tests/php-fpm-tests/channel2.php
@@ -1,0 +1,17 @@
+<?php
+
+$channel = new Grpc\Channel('localhost:50002',
+    ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
+
+$plist = $channel->getPersistentList();
+
+// The persistent list should have 'localhost:50001' created by
+// the previews request.
+$return_status = 1;
+foreach ($plist as &$value) {
+    if ($value["target"] == "localhost:50001") {
+        $return_status = 0;
+        break;
+    }
+}
+echo $return_status. PHP_EOL;

--- a/templates/tools/dockerfile/php7_deps.include
+++ b/templates/tools/dockerfile/php7_deps.include
@@ -41,5 +41,9 @@ RUN cd /var/local/git/php-src ${'\\'}
   --with-gmp ${'\\'}
   --with-openssl ${'\\'}
   --with-zlib ${'\\'}
+  --with-fpm ${'\\'}
+  --with-fpm-user=www-data ${'\\'}
+  --with-fpm-group=www-data ${'\\'}
+  --enable-fpm ${'\\'}
   && make ${'\\'}
   && make install

--- a/templates/tools/dockerfile/php_fpm_nginx.include
+++ b/templates/tools/dockerfile/php_fpm_nginx.include
@@ -1,0 +1,16 @@
+# Install nginx
+RUN apt-get install -y nginx-extras --no-install-recommends
+
+# Set the worker process for php-fpm to 1
+RUN sed -i "s|worker_processes 4|worker_processes 1|g" /etc/nginx/nginx.conf
+# Enable php-fpm with nginx and use tcp port
+RUN sed -i "s|#location ~ \\\.php\$ {| location ~ \\\.php\$ {include snippets\/fastcgi-php\.conf;fastcgi_pass 127\.0\.0\.1:9000;}|g" /etc/nginx/sites-available/default
+
+# Create config files for php-fpm and set the path information
+RUN cp /usr/local/etc/php-fpm.conf.default /usr/local/etc/php-fpm.conf
+RUN cp /usr/local/etc/php-fpm.d/www.conf.default /usr/local/etc/php-fpm.d/www.conf
+RUN sed -i "s|include=NONE\/etc|include=etc|g" /usr/local/etc/php-fpm.conf
+
+# Enable gRPC-PHP extension with php-fpm
+RUN echo "extension=grpc.so" >> /usr/local/etc/php.ini
+

--- a/templates/tools/dockerfile/test/php7_jessie_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/php7_jessie_x64/Dockerfile.template
@@ -17,6 +17,7 @@
   FROM debian:jessie
   
   <%include file="../../php7_deps.include"/>
+  <%include file="../../php_fpm_nginx.include"/>
   <%include file="../../gcp_api_libraries.include"/>
   <%include file="../../python_deps.include"/>
   <%include file="../../run_tests_addons.include"/>

--- a/templates/tools/dockerfile/test/php_jessie_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/php_jessie_x64/Dockerfile.template
@@ -20,6 +20,7 @@
   <%include file="../../gcp_api_libraries.include"/>
   <%include file="../../python_deps.include"/>
   <%include file="../../php_deps.include"/>
+  <%include file="../../php_fpm_nginx.include"/>
   <%include file="../../run_tests_addons.include"/>
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_php7/Dockerfile
@@ -57,6 +57,10 @@ RUN cd /var/local/git/php-src \
   --with-gmp \
   --with-openssl \
   --with-zlib \
+  --with-fpm \
+  --with-fpm-user=www-data \
+  --with-fpm-group=www-data \
+  --enable-fpm \
   && make \
   && make install
 

--- a/tools/dockerfile/test/php7_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/php7_jessie_x64/Dockerfile
@@ -57,8 +57,29 @@ RUN cd /var/local/git/php-src \
   --with-gmp \
   --with-openssl \
   --with-zlib \
+  --with-fpm \
+  --with-fpm-user=www-data \
+  --with-fpm-group=www-data \
+  --enable-fpm \
   && make \
   && make install
+
+# Install nginx
+RUN apt-get install -y nginx-extras --no-install-recommends
+
+# Set the worker process for php-fpm to 1
+RUN sed -i "s|worker_processes 4|worker_processes 1|g" /etc/nginx/nginx.conf
+# Enable php-fpm with nginx and use tcp port
+RUN sed -i "s|#location ~ \\\.php\$ {| location ~ \\\.php\$ {include snippets\/fastcgi-php\.conf;fastcgi_pass 127\.0\.0\.1:9000;}|g" /etc/nginx/sites-available/default
+
+# Create config files for php-fpm and set the path information
+RUN cp /usr/local/etc/php-fpm.conf.default /usr/local/etc/php-fpm.conf
+RUN cp /usr/local/etc/php-fpm.d/www.conf.default /usr/local/etc/php-fpm.d/www.conf
+RUN sed -i "s|include=NONE\/etc|include=etc|g" /usr/local/etc/php-fpm.conf
+
+# Enable gRPC-PHP extension with php-fpm
+RUN echo "extension=grpc.so" >> /usr/local/etc/php.ini
+
 
 # Google Cloud platform API libraries
 RUN apt-get update && apt-get install -y python-pip && apt-get clean

--- a/tools/dockerfile/test/php_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/php_jessie_x64/Dockerfile
@@ -76,6 +76,23 @@ RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 t
 RUN apt-get update && apt-get install -y \
     git php5 php5-dev phpunit unzip
 
+# Install nginx
+RUN apt-get install -y nginx-extras --no-install-recommends
+
+# Set the worker process for php-fpm to 1
+RUN sed -i "s|worker_processes 4|worker_processes 1|g" /etc/nginx/nginx.conf
+# Enable php-fpm with nginx and use tcp port
+RUN sed -i "s|#location ~ \\\.php\$ {| location ~ \\\.php\$ {include snippets\/fastcgi-php\.conf;fastcgi_pass 127\.0\.0\.1:9000;}|g" /etc/nginx/sites-available/default
+
+# Create config files for php-fpm and set the path information
+RUN cp /usr/local/etc/php-fpm.conf.default /usr/local/etc/php-fpm.conf
+RUN cp /usr/local/etc/php-fpm.d/www.conf.default /usr/local/etc/php-fpm.d/www.conf
+RUN sed -i "s|include=NONE\/etc|include=etc|g" /usr/local/etc/php-fpm.conf
+
+# Enable gRPC-PHP extension with php-fpm
+RUN echo "extension=grpc.so" >> /usr/local/etc/php.ini
+
+
 # Prepare ccache
 RUN ln -s /usr/bin/ccache /usr/local/bin/gcc
 RUN ln -s /usr/bin/ccache /usr/local/bin/g++

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -621,7 +621,7 @@ class PhpLanguage(object):
     def test_specs(self):
         return [
             self.config.job_spec(
-                ['src/php/bin/run_tests.sh'],
+                ['src/php/bin/run_tests.sh with-php-fpm-tests'],
                 environ=_FORCE_ENVIRON_FOR_WRAPPERS)
         ]
 


### PR DESCRIPTION
Since php-fpm is a popular mode for running php and there were issues happen with this mode. We should have an environment for testing php-fpm with nginx.

This PR is just my idea for testing the persistent channel behavior under php-fpm mode, which `channel2.php` can access the channel created by `channel1.php`.

@jtattermusch , is it okay I add an `php_fpm_nginx.include` ? It doesn't need to be in interop tests.