### PR TITLE
PHP: add per target upper bound checks for the persistent list

### DIFF
--- a/src/php/bin/run_tests.sh
+++ b/src/php/bin/run_tests.sh
@@ -23,4 +23,8 @@ source ./determine_extension_dir.sh
 # in some jenkins macos machine, somehow the PHP build script can't find libgrpc.dylib
 export DYLD_LIBRARY_PATH=$root/libs/$CONFIG
 php $extension_dir -d max_execution_time=300 $(which phpunit) -v --debug \
-  ../tests/unit_tests
+  --exclude-group persistent_list_bound_tests ../tests/unit_tests
+
+php $extension_dir -d max_execution_time=300 $(which phpunit) -v --debug \
+  ../tests/unit_tests/PersistentChannelTests
+

--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -230,7 +230,7 @@ PHP_METHOD(Call, __construct) {
   }
   wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(channel_obj);
   gpr_mu_lock(&channel->wrapper->mu);
-  if (channel->wrapper->wrapped == NULL) {
+  if (channel->wrapper == NULL || channel->wrapper->wrapped == NULL) {
     zend_throw_exception(spl_ce_InvalidArgumentException,
                          "Call cannot be constructed from a closed Channel",
                          1 TSRMLS_CC);
@@ -251,6 +251,7 @@ PHP_METHOD(Call, __construct) {
   grpc_slice_unref(method_slice);
   grpc_slice_unref(host_slice);
   call->owned = true;
+  call->channel = channel;
   gpr_mu_unlock(&channel->wrapper->mu);
 }
 
@@ -270,6 +271,15 @@ PHP_METHOD(Call, startBatch) {
   zval *message_value;
   zval *message_flags;
   wrapped_grpc_call *call = Z_WRAPPED_GRPC_CALL_P(getThis());
+  if (call->channel) {
+    // startBatch in gRPC PHP server doesn't have channel in it.
+    if (call->channel->wrapper == NULL ||
+        call->channel->wrapper->wrapped == NULL) {
+      zend_throw_exception(spl_ce_RuntimeException,
+                           "startBatch Error. Channel is closed",
+                           1 TSRMLS_CC);
+    }
+  }
   
   grpc_op ops[8];
   size_t op_num = 0;

--- a/src/php/ext/grpc/call.h
+++ b/src/php/ext/grpc/call.h
@@ -27,6 +27,7 @@
 #include <php_ini.h>
 #include <ext/standard/info.h>
 #include "php_grpc.h"
+#include "channel.h"
 
 #include <grpc/grpc.h>
 
@@ -37,6 +38,7 @@ extern zend_class_entry *grpc_ce_call;
 PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_call)
   bool owned;
   grpc_call *wrapped;
+  wrapped_grpc_channel* channel;
 PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_call)
 
 #if PHP_MAJOR_VERSION < 7

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -39,12 +39,8 @@ typedef struct _grpc_channel_wrapper {
   char *target;
   char *args_hashstr;
   char *creds_hashstr;
-  gpr_mu mu;
-  // is_valid is used to check the wrapped channel has been freed
-  // before to avoid double free.
-  bool is_valid;
-  // ref_count is used to let the last wrapper free related channel and key.
   size_t ref_count;
+  gpr_mu mu;
 } grpc_channel_wrapper;
 
 /* Wrapper struct for grpc_channel that can be associated with a PHP object */
@@ -86,5 +82,9 @@ typedef struct _channel_persistent_le {
   grpc_channel_wrapper *channel;
 } channel_persistent_le_t;
 
+typedef struct _target_bound_le {
+  int upper_bound;
+  int current_count;
+} target_bound_le_t;
 
 #endif /* NET_GRPC_PHP_GRPC_CHANNEL_H_ */

--- a/src/php/ext/grpc/config.m4
+++ b/src/php/ext/grpc/config.m4
@@ -4,6 +4,14 @@ PHP_ARG_ENABLE(grpc, whether to enable grpc support,
 PHP_ARG_ENABLE(coverage, whether to include code coverage symbols,
 [  --enable-coverage       Enable coverage support], no, no)
 
+PHP_ARG_ENABLE(tests, whether to compile helper methods for tests,
+[  --enable-tests          Enable tests methods], no, no)
+
+dnl Check whether to enable tests
+if test "$PHP_TESTS" != "no"; then
+  CPPFLAGS="$CPPFLAGS -DGRPC_PHP_DEBUG"
+fi
+
 if test "$PHP_GRPC" != "no"; then
   dnl Write more examples of tests here...
 

--- a/src/php/ext/grpc/php7_wrapper.h
+++ b/src/php/ext/grpc/php7_wrapper.h
@@ -46,6 +46,8 @@
    add_assoc_long_ex(val, key, key_len, str);
 #define PHP_GRPC_ADD_BOOL_TO_ARRAY(val, key, key_len, str) \
    add_assoc_bool_ex(val, key, key_len, str);
+#define PHP_GRPC_ADD_LONG_TO_RETVAL(val, key, key_len, str) \
+   add_assoc_long_ex(val, key, key_len+1, str);
 
 #define RETURN_DESTROY_ZVAL(val) \
   RETURN_ZVAL(val, false /* Don't execute copy constructor */, \
@@ -140,7 +142,7 @@ static inline int php_grpc_zend_hash_find(HashTable *ht, char *key, int len,
   zend_hash_update(plist, key, len+1, rsrc, sizeof(php_grpc_zend_resource), \
                    NULL)
 #define PHP_GRPC_PERSISTENT_LIST_SIZE(plist) \
-  plist.nTableSize
+  *plist.nNumOfElements
 
 #define PHP_GRPC_GET_CLASS_ENTRY(object) zend_get_class_entry(object TSRMLS_CC)
 
@@ -176,6 +178,8 @@ static inline int php_grpc_zend_hash_find(HashTable *ht, char *key, int len,
    add_assoc_long_ex(val, key, key_len - 1, str);
 #define PHP_GRPC_ADD_BOOL_TO_ARRAY(val, key, key_len, str) \
    add_assoc_bool_ex(val, key, key_len - 1, str);
+#define PHP_GRPC_ADD_LONG_TO_RETVAL(val, key, key_len, str) \
+   add_assoc_long_ex(val, key, key_len, str);
 
 #define RETURN_DESTROY_ZVAL(val) \
   RETVAL_ZVAL(val, false /* Don't execute copy constructor */, \

--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -37,6 +37,7 @@
 ZEND_DECLARE_MODULE_GLOBALS(grpc)
 static PHP_GINIT_FUNCTION(grpc);
 HashTable grpc_persistent_list;
+HashTable grpc_target_upper_bound_map;
 /* {{{ grpc_functions[]
  *
  * Every user visible function must have an entry in grpc_functions[].
@@ -242,6 +243,8 @@ PHP_MSHUTDOWN_FUNCTION(grpc) {
   if (GRPC_G(initialized)) {
     zend_hash_clean(&grpc_persistent_list);
     zend_hash_destroy(&grpc_persistent_list);
+    zend_hash_clean(&grpc_target_upper_bound_map);
+    zend_hash_destroy(&grpc_target_upper_bound_map);
     grpc_shutdown_timeval(TSRMLS_C);
     grpc_php_shutdown_completion_queue(TSRMLS_C);
     grpc_shutdown();

--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -1,7 +1,7 @@
 <?php
 /*
  *
- * Copyright 2015 gRPC authors.
+ * Copyright 2018 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,14 +32,14 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testInsecureCredentials()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50000',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->assertSame('Grpc\Channel', get_class($this->channel));
     }
 
     public function testGetConnectivityState()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50001',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $state = $this->channel->getConnectivityState();
         $this->assertEquals(0, $state);
@@ -47,7 +47,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testGetConnectivityStateWithInt()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50002',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $state = $this->channel->getConnectivityState(123);
         $this->assertEquals(0, $state);
@@ -55,7 +55,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testGetConnectivityStateWithString()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50003',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $state = $this->channel->getConnectivityState('hello');
         $this->assertEquals(0, $state);
@@ -63,7 +63,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testGetConnectivityStateWithBool()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50004',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $state = $this->channel->getConnectivityState(true);
         $this->assertEquals(0, $state);
@@ -71,7 +71,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testGetTarget()
     {
-        $this->channel = new Grpc\Channel('localhost:8888',
+        $this->channel = new Grpc\Channel('localhost:50005',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $target = $this->channel->getTarget();
         $this->assertTrue(is_string($target));
@@ -79,7 +79,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testWatchConnectivityState()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50006',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $now = Grpc\Timeval::now();
         $deadline = $now->add(new Grpc\Timeval(100*1000));  // 100ms
@@ -93,7 +93,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testClose()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50007',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->assertNotNull($this->channel);
         $this->channel->close();
@@ -113,7 +113,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidConstructorWith()
     {
-        $this->channel = new Grpc\Channel('localhost:0', 'invalid');
+        $this->channel = new Grpc\Channel('localhost:50008', 'invalid');
         $this->assertNull($this->channel);
     }
 
@@ -122,7 +122,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidCredentials()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50009',
             ['credentials' => new Grpc\Timeval(100)]);
     }
 
@@ -131,7 +131,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidOptionsArray()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50010',
             ['abc' => []]);
     }
 
@@ -140,7 +140,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidGetConnectivityStateWithArray()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50011',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->getConnectivityState([]);
     }
@@ -150,7 +150,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidWatchConnectivityState()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50012',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->watchConnectivityState([]);
     }
@@ -160,7 +160,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
      */
     public function testInvalidWatchConnectivityState2()
     {
-        $this->channel = new Grpc\Channel('localhost:0',
+        $this->channel = new Grpc\Channel('localhost:50013',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->watchConnectivityState(1, 'hi');
     }
@@ -185,10 +185,12 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testPersistentChannelSameHost()
     {
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
+        $this->channel1 = new Grpc\Channel('localhost:50014', [
+            "grpc_target_persist_bound" => 3,
+        ]);
         // the underlying grpc channel is the same by default
         // when connecting to the same host
-        $this->channel2 = new Grpc\Channel('localhost:1', []);
+        $this->channel2 = new Grpc\Channel('localhost:50014', []);
 
         // both channels should be IDLE
         $state = $this->channel1->getConnectivityState();
@@ -213,8 +215,10 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     public function testPersistentChannelDifferentHost()
     {
         // two different underlying channels because different hostname
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:2', []);
+        $this->channel1 = new Grpc\Channel('localhost:50015', [
+            "grpc_target_persist_bound" => 3,
+        ]);
+        $this->channel2 = new Grpc\Channel('localhost:50016', []);
 
         // both channels should be IDLE
         $state = $this->channel1->getConnectivityState();
@@ -239,8 +243,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testPersistentChannelSameArgs()
     {
-        $this->channel1 = new Grpc\Channel('localhost:1', ["abc" => "def"]);
-        $this->channel2 = new Grpc\Channel('localhost:1', ["abc" => "def"]);
+        $this->channel1 = new Grpc\Channel('localhost:50017', [
+          "grpc_target_persist_bound" => 3,
+          "abc" => "def",
+          ]);
+        $this->channel2 = new Grpc\Channel('localhost:50017', ["abc" => "def"]);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -257,8 +264,10 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testPersistentChannelDifferentArgs()
     {
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1', ["abc" => "def"]);
+        $this->channel1 = new Grpc\Channel('localhost:50018', [
+            "grpc_target_persist_bound" => 3,
+          ]);
+        $this->channel2 = new Grpc\Channel('localhost:50018', ["abc" => "def"]);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -278,9 +287,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $creds1 = Grpc\ChannelCredentials::createSsl();
         $creds2 = Grpc\ChannelCredentials::createSsl();
 
-        $this->channel1 = new Grpc\Channel('localhost:1',
-                                           ["credentials" => $creds1]);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50019',
+                                           ["credentials" => $creds1,
+                                             "grpc_target_persist_bound" => 3,
+                                             ]);
+        $this->channel2 = new Grpc\Channel('localhost:50019',
                                            ["credentials" => $creds2]);
 
         // try to connect on channel1
@@ -302,9 +313,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $creds2 = Grpc\ChannelCredentials::createSsl(
             file_get_contents(dirname(__FILE__).'/../data/ca.pem'));
 
-        $this->channel1 = new Grpc\Channel('localhost:1',
-                                           ["credentials" => $creds1]);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50020',
+                                           ["credentials" => $creds1,
+                                             "grpc_target_persist_bound" => 3,
+                                             ]);
+        $this->channel2 = new Grpc\Channel('localhost:50020',
                                            ["credentials" => $creds2]);
 
         // try to connect on channel1
@@ -327,9 +340,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $creds2 = Grpc\ChannelCredentials::createSsl(
             file_get_contents(dirname(__FILE__).'/../data/ca.pem'));
 
-        $this->channel1 = new Grpc\Channel('localhost:1',
-                                           ["credentials" => $creds1]);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50021',
+                                           ["credentials" => $creds1,
+                                             "grpc_target_persist_bound" => 3,
+                                             ]);
+        $this->channel2 = new Grpc\Channel('localhost:50021',
                                            ["credentials" => $creds2]);
 
         // try to connect on channel1
@@ -350,9 +365,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $creds1 = Grpc\ChannelCredentials::createSsl();
         $creds2 = Grpc\ChannelCredentials::createInsecure();
 
-        $this->channel1 = new Grpc\Channel('localhost:1',
-                                           ["credentials" => $creds1]);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50022',
+                                           ["credentials" => $creds1,
+                                             "grpc_target_persist_bound" => 3,
+                                             ]);
+        $this->channel2 = new Grpc\Channel('localhost:50022',
                                            ["credentials" => $creds2]);
 
         // try to connect on channel1
@@ -368,29 +385,55 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->channel2->close();
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
-    public function testPersistentChannelSharedChannelClose()
+    public function testPersistentChannelSharedChannelClose1()
     {
         // same underlying channel
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1', []);
+        $this->channel1 = new Grpc\Channel('localhost:50123', [
+            "grpc_target_persist_bound" => 3,
+        ]);
+        $this->channel2 = new Grpc\Channel('localhost:50123', []);
 
         // close channel1
         $this->channel1->close();
 
-        // channel is already closed
+        // channel2 can still be use. We need to exclude the possible that
+        // in testPersistentChannelSharedChannelClose2, the exception is thrown
+        // by channel1.
         $state = $this->channel2->getConnectivityState();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testPersistentChannelSharedChannelClose2()
+    {
+        // same underlying channel
+        $this->channel1 = new Grpc\Channel('localhost:50223', [
+            "grpc_target_persist_bound" => 3,
+        ]);
+        $this->channel2 = new Grpc\Channel('localhost:50223', []);
+
+        // close channel1
+        $this->channel1->close();
+
+        // channel2 can still be use
+        $state = $this->channel2->getConnectivityState();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+
+        // channel 1 is closed
+        $state = $this->channel1->getConnectivityState();
     }
 
     public function testPersistentChannelCreateAfterClose()
     {
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
+        $this->channel1 = new Grpc\Channel('localhost:50024', [
+            "grpc_target_persist_bound" => 3,
+        ]);
 
         $this->channel1->close();
 
-        $this->channel2 = new Grpc\Channel('localhost:1', []);
+        $this->channel2 = new Grpc\Channel('localhost:50024', []);
         $state = $this->channel2->getConnectivityState();
         $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
 
@@ -399,9 +442,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testPersistentChannelSharedMoreThanTwo()
     {
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1', []);
-        $this->channel3 = new Grpc\Channel('localhost:1', []);
+        $this->channel1 = new Grpc\Channel('localhost:50025', [
+            "grpc_target_persist_bound" => 3,
+        ]);
+        $this->channel2 = new Grpc\Channel('localhost:50025', []);
+        $this->channel3 = new Grpc\Channel('localhost:50025', []);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -439,10 +484,12 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         // If a ChannelCredentials object is composed with a
         // CallCredentials object, the underlying grpc channel will
         // always be created new and NOT persisted.
-        $this->channel1 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50026',
                                            ["credentials" =>
-                                            $credsWithCallCreds]);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+                                            $credsWithCallCreds,
+                                            "grpc_target_persist_bound" => 3,
+                                            ]);
+        $this->channel2 = new Grpc\Channel('localhost:50026',
                                            ["credentials" =>
                                             $credsWithCallCreds]);
 
@@ -476,11 +523,13 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         // object is composed with a CallCredentials object, the
         // underlying grpc channel will always be separate and not
         // persisted
-        $this->channel1 = new Grpc\Channel('localhost:1',
-                                           ["credentials" => $creds1]);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50027',
+                                           ["credentials" => $creds1,
+                                            "grpc_target_persist_bound" => 3,
+                                            ]);
+        $this->channel2 = new Grpc\Channel('localhost:50027',
                                            ["credentials" => $creds2]);
-        $this->channel3 = new Grpc\Channel('localhost:1',
+        $this->channel3 = new Grpc\Channel('localhost:50027',
                                            ["credentials" => $creds3]);
 
         // try to connect on channel1
@@ -501,10 +550,12 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testPersistentChannelForceNew()
     {
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
+        $this->channel1 = new Grpc\Channel('localhost:50028', [
+            "grpc_target_persist_bound" => 2,
+        ]);
         // even though all the channel params are the same, channel2
         // has a new and different underlying channel
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel2 = new Grpc\Channel('localhost:50028',
                                            ["force_new" => true]);
 
         // try to connect on channel1
@@ -520,19 +571,20 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->channel2->close();
     }
 
-    public function testPersistentChannelForceNewOldChannelIdle()
+    public function testPersistentChannelForceNewOldChannelIdle1()
     {
 
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50029', [
+            "grpc_target_persist_bound" => 2,
+        ]);
+        $this->channel2 = new Grpc\Channel('localhost:50029',
                                            ["force_new" => true]);
         // channel3 shares with channel1
-        $this->channel3 = new Grpc\Channel('localhost:1', []);
+        $this->channel3 = new Grpc\Channel('localhost:50029', []);
 
         // try to connect on channel2
         $state = $this->channel2->getConnectivityState(true);
         $this->waitUntilNotIdle($this->channel2);
-
         $state = $this->channel1->getConnectivityState();
         $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
         $state = $this->channel2->getConnectivityState();
@@ -544,34 +596,85 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->channel2->close();
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
-    public function testPersistentChannelForceNewOldChannelClose()
+    public function testPersistentChannelForceNewOldChannelIdle2()
     {
 
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50029', [
+            "grpc_target_persist_bound" => 2,
+        ]);
+        $this->channel2 = new Grpc\Channel('localhost:50029', []);
+
+        // try to connect on channel2
+        $state = $this->channel1->getConnectivityState(true);
+        $this->waitUntilNotIdle($this->channel2);
+        $state = $this->channel1->getConnectivityState();
+        $this->assertConnecting($state);
+        $state = $this->channel2->getConnectivityState();
+        $this->assertConnecting($state);
+
+        $this->channel1->close();
+        $this->channel2->close();
+    }
+
+    public function testPersistentChannelForceNewOldChannelClose1()
+    {
+
+        $this->channel1 = new Grpc\Channel('localhost:50130', [
+            "grpc_target_persist_bound" => 2,
+        ]);
+        $this->channel2 = new Grpc\Channel('localhost:50130',
                                            ["force_new" => true]);
         // channel3 shares with channel1
-        $this->channel3 = new Grpc\Channel('localhost:1', []);
+        $this->channel3 = new Grpc\Channel('localhost:50130', []);
 
         $this->channel1->close();
 
         $state = $this->channel2->getConnectivityState();
         $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
 
-        // channel3 already closed
+        // channel3 is still usable. We need to exclude the possibility that in
+        // testPersistentChannelForceNewOldChannelClose2, the exception is thrown
+        // by channel1 and channel2.
         $state = $this->channel3->getConnectivityState();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testPersistentChannelForceNewOldChannelClose2()
+    {
+
+        $this->channel1 = new Grpc\Channel('localhost:50230', [
+            "grpc_target_persist_bound" => 2,
+        ]);
+        $this->channel2 = new Grpc\Channel('localhost:50230',
+          ["force_new" => true]);
+        // channel3 shares with channel1
+        $this->channel3 = new Grpc\Channel('localhost:50230', []);
+
+        $this->channel1->close();
+
+        $state = $this->channel2->getConnectivityState();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+
+        // channel3 is still usable
+        $state = $this->channel3->getConnectivityState();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+
+        // channel 1 is closed
+        $this->channel1->getConnectivityState();
     }
 
     public function testPersistentChannelForceNewNewChannelClose()
     {
 
-        $this->channel1 = new Grpc\Channel('localhost:1', []);
-        $this->channel2 = new Grpc\Channel('localhost:1',
+        $this->channel1 = new Grpc\Channel('localhost:50031', [
+            "grpc_target_persist_bound" => 2,
+        ]);
+        $this->channel2 = new Grpc\Channel('localhost:50031',
                                            ["force_new" => true]);
-        $this->channel3 = new Grpc\Channel('localhost:1', []);
+        $this->channel3 = new Grpc\Channel('localhost:50031', []);
 
         $this->channel2->close();
 

--- a/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php
+++ b/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php
@@ -1,0 +1,489 @@
+<?php
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * @group persistent_list_bound_tests
+ */
+class PersistentListTest extends PHPUnit_Framework_TestCase
+{
+  public function setUp()
+  {
+  }
+
+  public function tearDown()
+  {
+    $channel_clean_persistent =
+        new Grpc\Channel('localhost:50010', []);
+    $plist = $channel_clean_persistent->getPersistentList();
+    $channel_clean_persistent->cleanPersistentList();
+  }
+
+  public function waitUntilNotIdle($channel) {
+      for ($i = 0; $i < 10; $i++) {
+          $now = Grpc\Timeval::now();
+          $deadline = $now->add(new Grpc\Timeval(1000));
+          if ($channel->watchConnectivityState(GRPC\CHANNEL_IDLE,
+              $deadline)) {
+              return true;
+          }
+      }
+      $this->assertTrue(false);
+  }
+
+  public function assertConnecting($state) {
+      $this->assertTrue($state == GRPC\CHANNEL_CONNECTING ||
+      $state == GRPC\CHANNEL_TRANSIENT_FAILURE);
+  }
+
+  public function testInitHelper()
+  {
+      // PersistentList is not empty at the beginning of the tests
+      // because phpunit will cache the channels created by other test
+      // files.
+  }
+
+
+  public function testChannelNotPersist()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:1', ['force_new' => true]);
+      $channel1_info = $this->channel1->getChannelInfo();
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals($channel1_info['target'], 'localhost:1');
+      $this->assertEquals($channel1_info['ref_count'], 1);
+      $this->assertEquals($channel1_info['connectivity_status'],
+          GRPC\CHANNEL_IDLE);
+      $this->assertEquals(count($plist_info), 0);
+      $this->channel1->close();
+  }
+
+  public function testPersistentChannelCreateOneChannel()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:1', []);
+      $channel1_info = $this->channel1->getChannelInfo();
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals($channel1_info['target'], 'localhost:1');
+      $this->assertEquals($channel1_info['ref_count'], 2);
+      $this->assertEquals($channel1_info['connectivity_status'],
+                          GRPC\CHANNEL_IDLE);
+      $this->assertArrayHasKey($channel1_info['key'], $plist_info);
+      $this->assertEquals(count($plist_info), 1);
+      $this->channel1->close();
+  }
+
+  public function testPersistentChannelCreateMultipleChannels()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:1', []);
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals(count($plist_info), 1);
+
+      $this->channel2 = new Grpc\Channel('localhost:2', []);
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals(count($plist_info), 2);
+
+      $this->channel3 = new Grpc\Channel('localhost:3', []);
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals(count($plist_info), 3);
+  }
+
+  public function testPersistentChannelStatusChange()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:4', []);
+      $channel1_info = $this->channel1->getChannelInfo();
+      $this->assertEquals($channel1_info['connectivity_status'],
+                          GRPC\CHANNEL_IDLE);
+
+      $this->channel1->getConnectivityState(true);
+      $this->waitUntilNotIdle($this->channel1);
+      $channel1_info = $this->channel1->getChannelInfo();
+      $this->assertConnecting($channel1_info['connectivity_status']);
+      $this->channel1->close();
+  }
+
+  public function testPersistentChannelCloseChannel()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:1', []);
+      $this->channel2 = new Grpc\Channel('localhost:1', []);
+
+      $channel1_info = $this->channel1->getChannelInfo();
+      $this->assertEquals($channel1_info['ref_count'], 3);
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals($plist_info[$channel1_info['key']]['ref_count'], 3);
+
+      $this->channel1->close();
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals($plist_info[$channel1_info['key']]['ref_count'], 2);
+
+      $this->channel2->close();
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals($plist_info[$channel1_info['key']]['ref_count'], 1);
+  }
+
+  public function testPersistentChannelSameTarget()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:1', []);
+      $this->channel2 = new Grpc\Channel('localhost:1', []);
+      $plist = $this->channel2->getPersistentList();
+      $channel1_info = $this->channel1->getChannelInfo();
+      $channel2_info = $this->channel2->getChannelInfo();
+      // $channel1 and $channel2 shares the same channel, thus only 1
+      // channel should be in the persistent list.
+      $this->assertEquals($channel1_info['key'], $channel2_info['key']);
+      $this->assertArrayHasKey($channel1_info['key'], $plist);
+      $this->assertEquals(count($plist), 1);
+      $this->channel1->close();
+      $this->channel2->close();
+  }
+
+  public function testPersistentChannelDifferentTarget()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:1', []);
+      $channel1_info = $this->channel1->getChannelInfo();
+      $this->channel2 = new Grpc\Channel('localhost:2', []);
+      $channel2_info = $this->channel1->getChannelInfo();
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertArrayHasKey($channel1_info['key'], $plist_info);
+      $this->assertArrayHasKey($channel2_info['key'], $plist_info);
+      $this->assertEquals($plist_info[$channel1_info['key']]['ref_count'], 2);
+      $this->assertEquals($plist_info[$channel2_info['key']]['ref_count'], 2);
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals(count($plist_info), 2);
+      $this->channel1->close();
+      $this->channel2->close();
+  }
+
+  /**
+   * @expectedException RuntimeException
+   * @expectedExceptionMessage startBatch Error. Channel is closed
+   */
+  public function testPersistentChannelSharedChannelClose()
+  {
+      // same underlying channel
+      $this->channel1 = new Grpc\Channel('localhost:10010', [
+          "grpc_target_persist_bound" => 2,
+      ]);
+      $this->channel2 = new Grpc\Channel('localhost:10010', []);
+      $this->server = new Grpc\Server([]);
+      $this->port = $this->server->addHttp2Port('localhost:10010');
+
+      // channel2 can still be use
+      $state = $this->channel2->getConnectivityState();
+      $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+
+      $call1 = new Grpc\Call($this->channel1,
+          '/foo',
+          Grpc\Timeval::infFuture());
+      $call2 = new Grpc\Call($this->channel2,
+          '/foo',
+          Grpc\Timeval::infFuture());
+      $call3 = new Grpc\Call($this->channel1,
+          '/foo',
+          Grpc\Timeval::infFuture());
+      $call4 = new Grpc\Call($this->channel2,
+          '/foo',
+          Grpc\Timeval::infFuture());
+      $batch = [
+          Grpc\OP_SEND_INITIAL_METADATA => [],
+      ];
+
+      $result = $call1->startBatch($batch);
+      $this->assertTrue($result->send_metadata);
+      $result = $call2->startBatch($batch);
+      $this->assertTrue($result->send_metadata);
+
+      $this->channel1->close();
+      // After closing channel1, channel2 can still be use
+      $result = $call4->startBatch($batch);
+      $this->assertTrue($result->send_metadata);
+      // channel 1 is closed, it will throw an exception.
+      $result = $call3->startBatch($batch);
+  }
+
+  public function testPersistentChannelTargetDefaultUpperBound()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:10011', []);
+      $channel1_info = $this->channel1->getChannelInfo();
+      $this->assertEquals($channel1_info['target_upper_bound'], 1);
+      $this->assertEquals($channel1_info['target_current_size'], 1);
+  }
+
+  public function testPersistentChannelTargetUpperBoundZero()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:10011', [
+          "grpc_target_persist_bound" => 0,
+      ]);
+      // channel1 will not be persisted.
+      $channel1_info = $this->channel1->getChannelInfo();
+      $this->assertEquals($channel1_info['target_upper_bound'], 0);
+      $this->assertEquals($channel1_info['target_current_size'], 0);
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals(0, count($plist_info));
+  }
+
+  public function testPersistentChannelTargetUpperBoundNotZero()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:10011', [
+          "grpc_target_persist_bound" => 3,
+      ]);
+      $channel1_info = $this->channel1->getChannelInfo();
+      $this->assertEquals($channel1_info['target_upper_bound'], 3);
+      $this->assertEquals($channel1_info['target_current_size'], 1);
+
+      // The upper bound should not be changed
+      $this->channel2 = new Grpc\Channel('localhost:10011', []);
+      $channel2_info = $this->channel2->getChannelInfo();
+      $this->assertEquals($channel2_info['target_upper_bound'], 3);
+      $this->assertEquals($channel2_info['target_current_size'], 1);
+
+      // The upper bound should not be changed
+      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+          null);
+      $this->channel3 = new Grpc\Channel('localhost:10011',
+          ['credentials' => $channel_credentials]);
+      $channel3_info = $this->channel3->getChannelInfo();
+      $this->assertEquals($channel3_info['target_upper_bound'], 3);
+      $this->assertEquals($channel3_info['target_current_size'], 2);
+
+      // The upper bound should not be changed
+      $this->channel4 = new Grpc\Channel('localhost:10011', [
+          "grpc_target_persist_bound" => 5,
+      ]);
+      $channel4_info = $this->channel4->getChannelInfo();
+      $this->assertEquals($channel4_info['target_upper_bound'], 5);
+      $this->assertEquals($channel4_info['target_current_size'], 2);
+  }
+
+  public function testPersistentChannelDefaultOutBound1()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:10011', []);
+      // Make channel1 not IDLE.
+      $this->channel1->getConnectivityState(true);
+      $this->waitUntilNotIdle($this->channel1);
+      $channel1_info = $this->channel1->getChannelInfo();
+      $this->assertConnecting($channel1_info['connectivity_status']);
+
+      // Since channel1 is CONNECTING, channel 2 will not be persisted
+      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+        null);
+      $this->channel2 = new Grpc\Channel('localhost:10011',
+          ['credentials' => $channel_credentials]);
+      $channel2_info = $this->channel2->getChannelInfo();
+      $this->assertEquals(GRPC\CHANNEL_IDLE, $channel2_info['connectivity_status']);
+
+      // By default, target 'localhost:10011' only persist one channel.
+      // Since channel1 is not Idle channel2 will not be persisted.
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals(1, count($plist_info));
+      $this->assertArrayHasKey($channel1_info['key'], $plist_info);
+      $this->assertArrayNotHasKey($channel2_info['key'], $plist_info);
+  }
+
+  public function testPersistentChannelDefaultOutBound2()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:10011', []);
+      $channel1_info = $this->channel1->getChannelInfo();
+      $this->assertEquals(GRPC\CHANNEL_IDLE, $channel1_info['connectivity_status']);
+
+      // Although channel1 is IDLE, channel1 still has reference to the underline
+      // gRPC channel. channel2 will not be persisted
+      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+        null);
+      $this->channel2 = new Grpc\Channel('localhost:10011',
+          ['credentials' => $channel_credentials]);
+      $channel2_info = $this->channel2->getChannelInfo();
+      $this->assertEquals(GRPC\CHANNEL_IDLE, $channel2_info['connectivity_status']);
+
+      // By default, target 'localhost:10011' only persist one channel.
+      // Since channel1 Idle, channel2 will be persisted.
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals(1, count($plist_info));
+      $this->assertArrayHasKey($channel1_info['key'], $plist_info);
+      $this->assertArrayNotHasKey($channel2_info['key'], $plist_info);
+  }
+
+  public function testPersistentChannelDefaultOutBound3()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:10011', []);
+      $channel1_info = $this->channel1->getChannelInfo();
+      $this->assertEquals(GRPC\CHANNEL_IDLE, $channel1_info['connectivity_status']);
+
+      $this->channel1->close();
+      // channel1 is closed, no reference holds to the underline channel.
+      // channel2 can be persisted.
+      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+        null);
+      $this->channel2 = new Grpc\Channel('localhost:10011',
+        ['credentials' => $channel_credentials]);
+      $channel2_info = $this->channel2->getChannelInfo();
+      $this->assertEquals(GRPC\CHANNEL_IDLE, $channel2_info['connectivity_status']);
+
+      // By default, target 'localhost:10011' only persist one channel.
+      // Since channel1 Idle, channel2 will be persisted.
+      $plist_info = $this->channel2->getPersistentList();
+      $this->assertEquals(1, count($plist_info));
+      $this->assertArrayHasKey($channel2_info['key'], $plist_info);
+      $this->assertArrayNotHasKey($channel1_info['key'], $plist_info);
+  }
+
+  public function testPersistentChannelTwoUpperBound()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:10011', [
+          "grpc_target_persist_bound" => 2,
+      ]);
+      $channel1_info = $this->channel1->getChannelInfo();
+      $this->assertEquals(GRPC\CHANNEL_IDLE, $channel1_info['connectivity_status']);
+
+      // Since channel1 is IDLE, channel 1 will be deleted
+      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+          null);
+      $this->channel2 = new Grpc\Channel('localhost:10011',
+          ['credentials' => $channel_credentials]);
+      $channel2_info = $this->channel2->getChannelInfo();
+      $this->assertEquals(GRPC\CHANNEL_IDLE, $channel2_info['connectivity_status']);
+
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals(2, count($plist_info));
+      $this->assertArrayHasKey($channel1_info['key'], $plist_info);
+      $this->assertArrayHasKey($channel2_info['key'], $plist_info);
+  }
+
+  public function testPersistentChannelTwoUpperBoundOutBound1()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:10011', [
+          "grpc_target_persist_bound" => 2,
+      ]);
+      $channel1_info = $this->channel1->getChannelInfo();
+
+      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+        null);
+      $this->channel2 = new Grpc\Channel('localhost:10011',
+          ['credentials' => $channel_credentials]);
+      $channel2_info = $this->channel2->getChannelInfo();
+
+      // Close channel1, so that new channel can be persisted.
+      $this->channel1->close();
+
+      $channel_credentials = Grpc\ChannelCredentials::createSsl("a", null,
+        null);
+      $this->channel3 = new Grpc\Channel('localhost:10011',
+          ['credentials' => $channel_credentials]);
+      $channel3_info = $this->channel3->getChannelInfo();
+
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals(2, count($plist_info));
+      $this->assertArrayNotHasKey($channel1_info['key'], $plist_info);
+      $this->assertArrayHasKey($channel2_info['key'], $plist_info);
+      $this->assertArrayHasKey($channel3_info['key'], $plist_info);
+  }
+
+  public function testPersistentChannelTwoUpperBoundOutBound2()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:10011', [
+          "grpc_target_persist_bound" => 2,
+      ]);
+      $channel1_info = $this->channel1->getChannelInfo();
+
+      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+        null);
+      $this->channel2 = new Grpc\Channel('localhost:10011',
+        ['credentials' => $channel_credentials]);
+      $channel2_info = $this->channel2->getChannelInfo();
+
+      // Close channel2, so that new channel can be persisted.
+      $this->channel2->close();
+
+      $channel_credentials = Grpc\ChannelCredentials::createSsl("a", null,
+        null);
+      $this->channel3 = new Grpc\Channel('localhost:10011',
+        ['credentials' => $channel_credentials]);
+      $channel3_info = $this->channel3->getChannelInfo();
+
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals(2, count($plist_info));
+      $this->assertArrayHasKey($channel1_info['key'], $plist_info);
+      $this->assertArrayNotHasKey($channel2_info['key'], $plist_info);
+      $this->assertArrayHasKey($channel3_info['key'], $plist_info);
+  }
+
+  public function testPersistentChannelTwoUpperBoundOutBound3()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:10011', [
+          "grpc_target_persist_bound" => 2,
+      ]);
+      $channel1_info = $this->channel1->getChannelInfo();
+
+      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+          null);
+      $this->channel2 = new Grpc\Channel('localhost:10011',
+          ['credentials' => $channel_credentials]);
+      $this->channel2->getConnectivityState(true);
+      $this->waitUntilNotIdle($this->channel2);
+      $channel2_info = $this->channel2->getChannelInfo();
+      $this->assertConnecting($channel2_info['connectivity_status']);
+
+      // Only one channel will be deleted
+      $this->channel1->close();
+      $this->channel2->close();
+
+      $channel_credentials = Grpc\ChannelCredentials::createSsl("a", null,
+        null);
+      $this->channel3 = new Grpc\Channel('localhost:10011',
+          ['credentials' => $channel_credentials]);
+      $channel3_info = $this->channel3->getChannelInfo();
+
+      // Only the Idle Channel will be deleted
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals(2, count($plist_info));
+      $this->assertArrayNotHasKey($channel1_info['key'], $plist_info);
+      $this->assertArrayHasKey($channel2_info['key'], $plist_info);
+      $this->assertArrayHasKey($channel3_info['key'], $plist_info);
+  }
+
+  public function testPersistentChannelTwoUpperBoundOutBound4()
+  {
+      $this->channel1 = new Grpc\Channel('localhost:10011', [
+          "grpc_target_persist_bound" => 2,
+      ]);
+      $this->channel1->getConnectivityState(true);
+      $this->waitUntilNotIdle($this->channel1);
+      $channel1_info = $this->channel1->getChannelInfo();
+      $this->assertConnecting($channel1_info['connectivity_status']);
+
+      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+          null);
+      $this->channel2 = new Grpc\Channel('localhost:10011',
+          ['credentials' => $channel_credentials]);
+      $this->channel2->getConnectivityState(true);
+      $this->waitUntilNotIdle($this->channel2);
+      $channel2_info = $this->channel2->getChannelInfo();
+      $this->assertConnecting($channel2_info['connectivity_status']);
+
+      $channel_credentials = Grpc\ChannelCredentials::createSsl("a", null,
+          null);
+      $this->channel3 = new Grpc\Channel('localhost:10011',
+          ['credentials' => $channel_credentials]);
+      $channel3_info = $this->channel3->getChannelInfo();
+
+      // Channel3 will not be persisted
+      $plist_info = $this->channel1->getPersistentList();
+      $this->assertEquals(2, count($plist_info));
+      $this->assertArrayHasKey($channel1_info['key'], $plist_info);
+      $this->assertArrayHasKey($channel2_info['key'], $plist_info);
+      $this->assertArrayNotHasKey($channel3_info['key'], $plist_info);
+  }
+}

--- a/tools/run_tests/helper_scripts/build_php.sh
+++ b/tools/run_tests/helper_scripts/build_php.sh
@@ -30,8 +30,8 @@ cd src/php
 cd ext/grpc
 phpize
 if [ "$CONFIG" != "gcov" ] ; then
-  ./configure --enable-grpc="$root"
+  ./configure --enable-grpc="$root" --enable-tests
 else
-  ./configure --enable-grpc="$root" --enable-coverage
+  ./configure --enable-grpc="$root" --enable-coverage --enable-tests
 fi
 make


### PR DESCRIPTION
Channel persisted is managed per target. By default, if a channel can be persisted, the upper bound is set to 1 unless it is set to the other number.

Use `ref` and `unref` to manage the channel destroy, which can delete most codes from current `destroy` and `close()` function.

There are 3 helper methods only used for testing: `clearPersistentList`, `getPersistentList` and `getChannelInfo`, which can help to test the connection is already there or not under php-fpm mode.

The way to compile helper method: `./configure --enable-tests`.