### PR TITLE
Don't Use Benchmark Counters

### DIFF
--- a/test/cpp/microbenchmarks/helpers.cc
+++ b/test/cpp/microbenchmarks/helpers.cc
@@ -48,16 +48,10 @@ void TrackCounters::AddToLabel(std::ostream& out, benchmark::State& state) {
             static_cast<double>(state.iterations()));
   }
   for (int i = 0; i < GRPC_STATS_HISTOGRAM_COUNT; i++) {
-    std::ostringstream median_ss;
-    median_ss << grpc_stats_histogram_name[i] << "-median";
-    state.counters[median_ss.str()] =
-        benchmark::Counter(grpc_stats_histo_percentile(
-            &stats, static_cast<grpc_stats_histograms>(i), 50.0));
-    std::ostringstream tail_ss;
-    tail_ss << grpc_stats_histogram_name[i] << "-99p";
-    state.counters[tail_ss.str()] =
-        benchmark::Counter(grpc_stats_histo_percentile(
-            &stats, static_cast<grpc_stats_histograms>(i), 99.0));
+    out << " " << grpc_stats_histogram_name[i] << "-median:"
+        << grpc_stats_histo_percentile(&stats, (grpc_stats_histograms)i, 50.0)
+        << " " << grpc_stats_histogram_name[i] << "-99p:"
+        << grpc_stats_histo_percentile(&stats, (grpc_stats_histograms)i, 99.0);
   }
 #ifdef GPR_LOW_LEVEL_COUNTERS
   grpc_memory_counters counters_at_end = grpc_memory_counters_snapshot();

--- a/tools/profiling/microbenchmarks/bm_diff/bm_constants.py
+++ b/tools/profiling/microbenchmarks/bm_diff/bm_constants.py
@@ -22,11 +22,10 @@ _AVAILABLE_BENCHMARK_TESTS = [
     'bm_metadata', 'bm_fullstack_trickle'
 ]
 
-_INTERESTING = ('cpu_time', 'real_time', 'call_initial_size-median',
-                'locks_per_iteration', 'allocs_per_iteration',
-                'writes_per_iteration', 'atm_cas_per_iteration',
-                'atm_add_per_iteration', 'nows_per_iteration',
-                'cli_transport_stalls_per_iteration',
+_INTERESTING = ('cpu_time', 'real_time', 'locks_per_iteration',
+                'allocs_per_iteration', 'writes_per_iteration',
+                'atm_cas_per_iteration', 'atm_add_per_iteration',
+                'nows_per_iteration', 'cli_transport_stalls_per_iteration',
                 'cli_stream_stalls_per_iteration',
                 'svr_transport_stalls_per_iteration',
                 'svr_stream_stalls_per_iteration',


### PR DESCRIPTION
Follows from #15188.

Using this feature prohibits us from linking our OSS benchmarks to internal code. 

Will this break #12870? call_initial_size-median and call_initial_size-99p still get printed