### PR TITLE
Switch to Buffer.from to avoid using deprecated constructor

### DIFF
--- a/src/compiler/node_generator.cc
+++ b/src/compiler/node_generator.cc
@@ -134,7 +134,7 @@ void PrintMessageTransformer(const Descriptor* descriptor, Printer* out) {
              "throw new Error('Expected argument of type $name$');\n");
   out->Outdent();
   out->Print("}\n");
-  out->Print("return new Buffer(arg.serializeBinary());\n");
+  out->Print("return Buffer.from(arg.serializeBinary());\n");
   out->Outdent();
   out->Print("}\n\n");
 


### PR DESCRIPTION
To address NodeJS deprecation of the Buffer constructor.
```
(node:37470) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```

NOTE: `Buffer.from(...)` was introduced in node v5.10.0.  This would mean that earlier versions would break.  Seeing at node 4.x is [EOL from Monday](https://medium.com/the-node-js-collection/april-2018-release-updates-from-the-node-js-project-71687e1f7742) (Apr 30 2018), it's probably time to consider only supporting newer node versions.