### PR TITLE
Revert "Revert "Provide protocol for initializer of generated messages""

### DIFF
--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -248,7 +248,7 @@ void PrintMethodImplementations(Printer* printer,
                 " */\n");
   printer.Print(vars,
                 "@interface $service_class$ :"
-                " GRPCProtoService<$service_class$>\n");
+                " GRPCProtoService<$service_class$, GRPCProtoServiceInit>\n");
   printer.Print(
       "- (instancetype)initWithHost:(NSString *)host"
       " NS_DESIGNATED_INITIALIZER;\n");

--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -222,7 +222,8 @@ void PrintMethodImplementations(Printer* printer,
   map< ::grpc::string, ::grpc::string> vars = {
       {"service_class", ServiceClassName(service)}};
 
-  printer.Print(vars, "@protocol $service_class$ <NSObject, GRPCProtoServiceInit>\n\n");
+  printer.Print(
+      vars, "@protocol $service_class$ <NSObject, GRPCProtoServiceInit>\n\n");
   for (int i = 0; i < service->method_count(); i++) {
     PrintMethodDeclarations(&printer, service->method(i));
   }

--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -222,7 +222,7 @@ void PrintMethodImplementations(Printer* printer,
   map< ::grpc::string, ::grpc::string> vars = {
       {"service_class", ServiceClassName(service)}};
 
-  printer.Print(vars, "@protocol $service_class$ <NSObject>\n\n");
+  printer.Print(vars, "@protocol $service_class$ <NSObject, GRPCProtoServiceInit>\n\n");
   for (int i = 0; i < service->method_count(); i++) {
     PrintMethodDeclarations(&printer, service->method(i));
   }
@@ -248,7 +248,7 @@ void PrintMethodImplementations(Printer* printer,
                 " */\n");
   printer.Print(vars,
                 "@interface $service_class$ :"
-                " GRPCProtoService<$service_class$, GRPCProtoServiceInit>\n");
+                " GRPCProtoService<$service_class$>\n");
   printer.Print(
       "- (instancetype)initWithHost:(NSString *)host"
       " NS_DESIGNATED_INITIALIZER;\n");

--- a/src/objective-c/ProtoRPC/ProtoService.h
+++ b/src/objective-c/ProtoRPC/ProtoService.h
@@ -22,6 +22,12 @@
 @protocol GRXWriteable;
 @class GRXWriter;
 
+@protocol GRPCProtoServiceInit
+
+- (instancetype)initWithHost:(NSString *)host;
+
+@end
+
 __attribute__((deprecated("Please use GRPCProtoService."))) @interface ProtoService
     : NSObject -
       (instancetype)initWithHost : (NSString *)host packageName


### PR DESCRIPTION
Reverts grpc/grpc#15258, which reverts #15193.

Since some users are using `id<ServiceName>` in their system, the protocol inheritance has to be in `@protocol`, not `@interface`.