### PR TITLE
Fix a memory leak in GRPCChannel

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.m
@@ -56,6 +56,7 @@ static void FreeChannelArgs(grpc_channel_args *channel_args) {
       gpr_free(arg->value.string);
     }
   }
+  gpr_free(channel_args->args);
   gpr_free(channel_args);
 }
 


### PR DESCRIPTION
The corresponding allocation of this memory chunk is [here](https://github.com/grpc/grpc/blob/master/src/objective-c/GRPCClient/private/GRPCChannel.m#L79).