### PR TITLE
PHP: add two macro for reduce duplicate code

### DIFF
--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -43,9 +43,7 @@
 #include "byte_buffer.h"
 
 zend_class_entry *grpc_ce_call;
-#if PHP_MAJOR_VERSION >= 7
-static zend_object_handlers call_ce_handlers;
-#endif
+PHP_GRPC_DECLARE_OBJECT_HANDLER(call_ce_handlers)
 
 /* Frees and destroys an instance of wrapped_grpc_call */
 PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_call)
@@ -195,7 +193,8 @@ zval *grpc_php_wrap_call(grpc_call *wrapped, bool owned TSRMLS_DC) {
   zval *call_object;
   PHP_GRPC_MAKE_STD_ZVAL(call_object);
   object_init_ex(call_object, grpc_ce_call);
-  wrapped_grpc_call *call = Z_WRAPPED_GRPC_CALL_P(call_object);
+  wrapped_grpc_call *call = PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_call,
+                                                        call_object);
   call->wrapped = wrapped;
   call->owned = owned;
   return call_object;
@@ -216,7 +215,8 @@ PHP_METHOD(Call, __construct) {
   zval *deadline_obj;
   char *host_override = NULL;
   php_grpc_int host_override_len = 0;
-  wrapped_grpc_call *call = Z_WRAPPED_GRPC_CALL_P(getThis());
+  wrapped_grpc_call *call = PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_call,
+                                                        getThis());
 
   /* "OsO|s" == 1 Object, 1 string, 1 Object, 1 optional string */
   if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "OsO|s", &channel_obj,
@@ -228,7 +228,8 @@ PHP_METHOD(Call, __construct) {
                          "an optional String", 1 TSRMLS_CC);
     return;
   }
-  wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(channel_obj);
+  wrapped_grpc_channel *channel =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_channel, channel_obj);
   gpr_mu_lock(&channel->wrapper->mu);
   if (channel->wrapper == NULL || channel->wrapper->wrapped == NULL) {
     zend_throw_exception(spl_ce_InvalidArgumentException,
@@ -238,7 +239,8 @@ PHP_METHOD(Call, __construct) {
     return;
   }
   add_property_zval(getThis(), "channel", channel_obj);
-  wrapped_grpc_timeval *deadline = Z_WRAPPED_GRPC_TIMEVAL_P(deadline_obj);
+  wrapped_grpc_timeval *deadline =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, deadline_obj);
   grpc_slice method_slice = grpc_slice_from_copied_string(method);
   grpc_slice host_slice = host_override != NULL ?
       grpc_slice_from_copied_string(host_override) : grpc_empty_slice();
@@ -270,7 +272,8 @@ PHP_METHOD(Call, startBatch) {
   zval *inner_value;
   zval *message_value;
   zval *message_flags;
-  wrapped_grpc_call *call = Z_WRAPPED_GRPC_CALL_P(getThis());
+  wrapped_grpc_call *call = PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_call,
+                                                        getThis());
   if (call->channel) {
     // startBatch in gRPC PHP server doesn't have channel in it.
     if (call->channel->wrapper == NULL ||
@@ -552,7 +555,8 @@ cleanup:
  * @return string The URI of the endpoint
  */
 PHP_METHOD(Call, getPeer) {
-  wrapped_grpc_call *call = Z_WRAPPED_GRPC_CALL_P(getThis());
+  wrapped_grpc_call *call = PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_call,
+                                                        getThis());
   char *peer = grpc_call_get_peer(call->wrapped);
   PHP_GRPC_RETVAL_STRING(peer, 1);
   gpr_free(peer);
@@ -564,7 +568,8 @@ PHP_METHOD(Call, getPeer) {
  * @return void
  */
 PHP_METHOD(Call, cancel) {
-  wrapped_grpc_call *call = Z_WRAPPED_GRPC_CALL_P(getThis());
+  wrapped_grpc_call *call = PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_call,
+                                                        getThis());
   grpc_call_cancel(call->wrapped, NULL);
 }
 
@@ -586,8 +591,9 @@ PHP_METHOD(Call, setCredentials) {
   }
 
   wrapped_grpc_call_credentials *creds =
-    Z_WRAPPED_GRPC_CALL_CREDS_P(creds_obj);
-  wrapped_grpc_call *call = Z_WRAPPED_GRPC_CALL_P(getThis());
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_call_credentials, creds_obj);
+  wrapped_grpc_call *call = PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_call,
+                                                        getThis());
 
   grpc_call_error error = GRPC_CALL_ERROR;
   error = grpc_call_set_credentials(call->wrapped, creds->wrapped);

--- a/src/php/ext/grpc/call.h
+++ b/src/php/ext/grpc/call.h
@@ -19,17 +19,9 @@
 #ifndef NET_GRPC_PHP_GRPC_CALL_H_
 #define NET_GRPC_PHP_GRPC_CALL_H_
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#include <php.h>
-#include <php_ini.h>
-#include <ext/standard/info.h>
 #include "php_grpc.h"
-#include "channel.h"
 
-#include <grpc/grpc.h>
+#include "channel.h"
 
 /* Class entry for the Call PHP class */
 extern zend_class_entry *grpc_ce_call;
@@ -41,22 +33,11 @@ PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_call)
   wrapped_grpc_channel* channel;
 PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_call)
 
-#if PHP_MAJOR_VERSION < 7
-
-#define Z_WRAPPED_GRPC_CALL_P(zv) \
-  (wrapped_grpc_call *)zend_object_store_get_object(zv TSRMLS_CC)
-
-#else
-
 static inline wrapped_grpc_call
 *wrapped_grpc_call_from_obj(zend_object *obj) {
   return (wrapped_grpc_call*)((char*)(obj) -
                               XtOffsetOf(wrapped_grpc_call, std));
 }
-
-#define Z_WRAPPED_GRPC_CALL_P(zv) wrapped_grpc_call_from_obj(Z_OBJ_P((zv)))
-
-#endif /* PHP_MAJOR_VERSION */
 
 /* Creates and returns a PHP associative array of metadata from a C array of
  * call metadata */

--- a/src/php/ext/grpc/call_credentials.c
+++ b/src/php/ext/grpc/call_credentials.c
@@ -39,9 +39,7 @@
 #include <grpc/support/string_util.h>
 
 zend_class_entry *grpc_ce_call_credentials;
-#if PHP_MAJOR_VERSION >= 7
-static zend_object_handlers call_credentials_ce_handlers;
-#endif
+PHP_GRPC_DECLARE_OBJECT_HANDLER(call_credentials_ce_handlers)
 
 /* Frees and destroys an instance of wrapped_grpc_call_credentials */
 PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_call_credentials)
@@ -67,7 +65,8 @@ zval *grpc_php_wrap_call_credentials(grpc_call_credentials
   PHP_GRPC_MAKE_STD_ZVAL(credentials_object);
   object_init_ex(credentials_object, grpc_ce_call_credentials);
   wrapped_grpc_call_credentials *credentials =
-    Z_WRAPPED_GRPC_CALL_CREDS_P(credentials_object);
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_call_credentials,
+                                credentials_object);
   credentials->wrapped = wrapped;
   return credentials_object;
 }
@@ -92,12 +91,12 @@ PHP_METHOD(CallCredentials, createComposite) {
     return;
   }
   wrapped_grpc_call_credentials *cred1 =
-    Z_WRAPPED_GRPC_CALL_CREDS_P(cred1_obj);
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_call_credentials, cred1_obj);
   wrapped_grpc_call_credentials *cred2 =
-    Z_WRAPPED_GRPC_CALL_CREDS_P(cred2_obj);
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_call_credentials, cred2_obj);
   grpc_call_credentials *creds =
-      grpc_composite_call_credentials_create(cred1->wrapped, cred2->wrapped,
-                                             NULL);
+    grpc_composite_call_credentials_create(cred1->wrapped, cred2->wrapped,
+                                           NULL);
   zval *creds_object = grpc_php_wrap_call_credentials(creds TSRMLS_CC);
   RETURN_DESTROY_ZVAL(creds_object);
 }

--- a/src/php/ext/grpc/call_credentials.h
+++ b/src/php/ext/grpc/call_credentials.h
@@ -40,23 +40,11 @@ PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_call_credentials)
   grpc_call_credentials *wrapped;
 PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_call_credentials)
 
-#if PHP_MAJOR_VERSION < 7
-
-#define Z_WRAPPED_GRPC_CALL_CREDS_P(zv) \
-  (wrapped_grpc_call_credentials *)zend_object_store_get_object(zv TSRMLS_CC)
-
-#else
-
 static inline wrapped_grpc_call_credentials
 *wrapped_grpc_call_credentials_from_obj(zend_object *obj) {
   return (wrapped_grpc_call_credentials*)(
       (char*)(obj) - XtOffsetOf(wrapped_grpc_call_credentials, std));
 }
-
-#define Z_WRAPPED_GRPC_CALL_CREDS_P(zv) \
-  wrapped_grpc_call_credentials_from_obj(Z_OBJ_P((zv)))
-
-#endif /* PHP_MAJOR_VERSION */
 
 /* Struct to hold callback function for plugin creds API */
 typedef struct plugin_state {

--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -49,9 +49,7 @@
 #include "timeval.h"
 
 zend_class_entry *grpc_ce_channel;
-#if PHP_MAJOR_VERSION >= 7
-static zend_object_handlers channel_ce_handlers;
-#endif
+PHP_GRPC_DECLARE_OBJECT_HANDLER(channel_ce_handlers)
 static gpr_mu global_persistent_list_mu;
 int le_plink;
 int le_bound;
@@ -310,7 +308,8 @@ void create_and_add_channel_to_persistent_list(
  * @param array $args_array The arguments to pass to the Channel
  */
 PHP_METHOD(Channel, __construct) {
-  wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(getThis());
+  wrapped_grpc_channel *channel =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_channel, getThis());
   zval *creds_obj = NULL;
   char *target;
   php_grpc_int target_length;
@@ -343,7 +342,8 @@ PHP_METHOD(Channel, __construct) {
                            1 TSRMLS_CC);
       return;
     } else {
-      creds = Z_WRAPPED_GRPC_CHANNEL_CREDS_P(creds_obj);
+      creds = PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_channel_credentials,
+                                          creds_obj);
       php_grpc_zend_hash_del(array_hash, "credentials", sizeof("credentials"));
     }
   }
@@ -453,7 +453,8 @@ PHP_METHOD(Channel, __construct) {
  * @return string The URI of the endpoint
  */
 PHP_METHOD(Channel, getTarget) {
-  wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(getThis());
+  wrapped_grpc_channel *channel =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_channel, getThis());
   if (channel->wrapper == NULL) {
     zend_throw_exception(spl_ce_RuntimeException,
                          "getTarget error."
@@ -473,7 +474,8 @@ PHP_METHOD(Channel, getTarget) {
  * @return long The grpc connectivity state
  */
 PHP_METHOD(Channel, getConnectivityState) {
-  wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(getThis());
+  wrapped_grpc_channel *channel =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_channel, getThis());
   if (channel->wrapper == NULL) {
     zend_throw_exception(spl_ce_RuntimeException,
                          "getConnectivityState error."
@@ -504,7 +506,8 @@ PHP_METHOD(Channel, getConnectivityState) {
  *              before deadline
  */
 PHP_METHOD(Channel, watchConnectivityState) {
-  wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(getThis());
+  wrapped_grpc_channel *channel =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_channel, getThis());
   if (channel->wrapper == NULL) {
     zend_throw_exception(spl_ce_RuntimeException,
                          "watchConnectivityState error"
@@ -526,7 +529,8 @@ PHP_METHOD(Channel, watchConnectivityState) {
     return;
   }
 
-  wrapped_grpc_timeval *deadline = Z_WRAPPED_GRPC_TIMEVAL_P(deadline_obj);
+  wrapped_grpc_timeval *deadline =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, deadline_obj);
   grpc_channel_watch_connectivity_state(channel->wrapper->wrapped,
                                         (grpc_connectivity_state)last_state,
                                         deadline->wrapped, completion_queue,
@@ -543,7 +547,8 @@ PHP_METHOD(Channel, watchConnectivityState) {
  * @return void
  */
 PHP_METHOD(Channel, close) {
-  wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(getThis());
+  wrapped_grpc_channel *channel =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_channel, getThis());
   if (channel->wrapper != NULL) {
     php_grpc_channel_unref(channel->wrapper);
     channel->wrapper = NULL;
@@ -621,7 +626,8 @@ char *grpc_connectivity_state_name(grpc_connectivity_state state) {
 * @return array
 */
 PHP_METHOD(Channel, getChannelInfo) {
-  wrapped_grpc_channel *channel = Z_WRAPPED_GRPC_CHANNEL_P(getThis());
+  wrapped_grpc_channel *channel =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_channel, getThis());
   array_init(return_value);
    // Info about the target
   PHP_GRPC_ADD_STRING_TO_ARRAY(return_value, "target",

--- a/src/php/ext/grpc/channel.h
+++ b/src/php/ext/grpc/channel.h
@@ -48,23 +48,11 @@ PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_channel)
   grpc_channel_wrapper *wrapper;
 PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_channel)
 
-#if PHP_MAJOR_VERSION < 7
-
-#define Z_WRAPPED_GRPC_CHANNEL_P(zv) \
-  (wrapped_grpc_channel *)zend_object_store_get_object(zv TSRMLS_CC)
-
-#else
-
 static inline wrapped_grpc_channel
 *wrapped_grpc_channel_from_obj(zend_object *obj) {
   return (wrapped_grpc_channel*)((char*)(obj) -
                                  XtOffsetOf(wrapped_grpc_channel, std));
 }
-
-#define Z_WRAPPED_GRPC_CHANNEL_P(zv) \
-  wrapped_grpc_channel_from_obj(Z_OBJ_P((zv)))
-
-#endif /* PHP_MAJOR_VERSION */
 
 /* Initializes the Channel class */
 GRPC_STARTUP_FUNCTION(channel);

--- a/src/php/ext/grpc/channel_credentials.c
+++ b/src/php/ext/grpc/channel_credentials.c
@@ -40,9 +40,7 @@
 #include <grpc/grpc_security.h>
 
 zend_class_entry *grpc_ce_channel_credentials;
-#if PHP_MAJOR_VERSION >= 7
-static zend_object_handlers channel_credentials_ce_handlers;
-#endif
+PHP_GRPC_DECLARE_OBJECT_HANDLER(channel_credentials_ce_handlers)
 static char *default_pem_root_certs = NULL;
 
 static grpc_ssl_roots_override_result get_ssl_roots_override(
@@ -85,7 +83,8 @@ zval *grpc_php_wrap_channel_credentials(grpc_channel_credentials *wrapped,
   PHP_GRPC_MAKE_STD_ZVAL(credentials_object);
   object_init_ex(credentials_object, grpc_ce_channel_credentials);
   wrapped_grpc_channel_credentials *credentials =
-    Z_WRAPPED_GRPC_CHANNEL_CREDS_P(credentials_object);
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_channel_credentials,
+                                credentials_object);
   credentials->wrapped = wrapped;
   credentials->hashstr = hashstr;
   credentials->has_call_creds = has_call_creds;
@@ -198,20 +197,19 @@ PHP_METHOD(ChannelCredentials, createComposite) {
     return;
   }
   wrapped_grpc_channel_credentials *cred1 =
-    Z_WRAPPED_GRPC_CHANNEL_CREDS_P(cred1_obj);
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_channel_credentials, cred1_obj);
   wrapped_grpc_call_credentials *cred2 =
-    Z_WRAPPED_GRPC_CALL_CREDS_P(cred2_obj);
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_call_credentials, cred2_obj);
   grpc_channel_credentials *creds =
-      grpc_composite_channel_credentials_create(cred1->wrapped, cred2->wrapped,
-                                                NULL);
+    grpc_composite_channel_credentials_create(cred1->wrapped, cred2->wrapped,
+                                              NULL);
   // wrapped_grpc_channel_credentials object should keeps it's own
   // allocation. Otherwise it conflicts free hashstr with call.c.
   php_grpc_int cred1_len = strlen(cred1->hashstr);
   char *cred1_hashstr = malloc(cred1_len+1);
   strcpy(cred1_hashstr, cred1->hashstr);
   zval *creds_object =
-      grpc_php_wrap_channel_credentials(creds, cred1_hashstr, true
-                                        TSRMLS_CC);
+    grpc_php_wrap_channel_credentials(creds, cred1_hashstr, true TSRMLS_CC);
   RETURN_DESTROY_ZVAL(creds_object);
 }
 

--- a/src/php/ext/grpc/channel_credentials.h
+++ b/src/php/ext/grpc/channel_credentials.h
@@ -42,23 +42,11 @@ PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_channel_credentials)
   zend_bool has_call_creds;
 PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_channel_credentials)
 
-#if PHP_MAJOR_VERSION < 7
-
-#define Z_WRAPPED_GRPC_CHANNEL_CREDS_P(zv) \
-  (wrapped_grpc_channel_credentials *)zend_object_store_get_object(zv TSRMLS_CC)
-
-#else
-
 static inline wrapped_grpc_channel_credentials
 *wrapped_grpc_channel_credentials_from_obj(zend_object *obj) {
   return (wrapped_grpc_channel_credentials *)(
       (char*)(obj) - XtOffsetOf(wrapped_grpc_channel_credentials, std));
 }
-
-#define Z_WRAPPED_GRPC_CHANNEL_CREDS_P(zv) \
-  wrapped_grpc_channel_credentials_from_obj(Z_OBJ_P((zv)))
-
-#endif /* PHP_MAJOR_VERSION */
 
 /* Initializes the ChannelCredentials PHP class */
 void grpc_init_channel_credentials(TSRMLS_D);

--- a/src/php/ext/grpc/php7_wrapper.h
+++ b/src/php/ext/grpc/php7_wrapper.h
@@ -148,6 +148,11 @@ static inline int php_grpc_zend_hash_find(HashTable *ht, char *key, int len,
 
 #define PHP_GRPC_INIT_HANDLER(class_object, handler_name)
 
+#define PHP_GRPC_DECLARE_OBJECT_HANDLER(handler_name)
+
+#define PHP_GRPC_GET_WRAPPED_OBJECT(class_object, zv) \
+  (class_object *)zend_object_store_get_object(zv TSRMLS_CC)
+
 #else
 
 #define php_grpc_int size_t
@@ -271,6 +276,12 @@ static inline int php_grpc_zend_hash_del(HashTable *ht, char *key, int len) {
          sizeof(zend_object_handlers)); \
   handler_name.offset = XtOffsetOf(class_object, std); \
   handler_name.free_obj = free_##class_object
+
+#define PHP_GRPC_DECLARE_OBJECT_HANDLER(handler_name) \
+  static zend_object_handlers handler_name;
+
+#define PHP_GRPC_GET_WRAPPED_OBJECT(class_object, zv) \
+  class_object##_from_obj(Z_OBJ_P((zv)))
 
 #endif /* PHP_MAJOR_VERSION */
 

--- a/src/php/ext/grpc/server.c
+++ b/src/php/ext/grpc/server.c
@@ -44,9 +44,7 @@
 #include "timeval.h"
 
 zend_class_entry *grpc_ce_server;
-#if PHP_MAJOR_VERSION >= 7
-static zend_object_handlers server_ce_handlers;
-#endif
+PHP_GRPC_DECLARE_OBJECT_HANDLER(server_ce_handlers)
 
 /* Frees and destroys an instance of wrapped_grpc_server */
 PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_server)
@@ -74,7 +72,8 @@ php_grpc_zend_object create_wrapped_grpc_server(zend_class_entry *class_type
  * @param array $args_array The arguments to pass to the server (optional)
  */
 PHP_METHOD(Server, __construct) {
-  wrapped_grpc_server *server = Z_WRAPPED_GRPC_SERVER_P(getThis());
+  wrapped_grpc_server *server =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_server, getThis());
   zval *args_array = NULL;
   grpc_channel_args args;
 
@@ -82,8 +81,7 @@ PHP_METHOD(Server, __construct) {
   if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|a", &args_array) ==
       FAILURE) {
     zend_throw_exception(spl_ce_InvalidArgumentException,
-                         "Server expects an array",
-                         1 TSRMLS_CC);
+                         "Server expects an array", 1 TSRMLS_CC);
     return;
   }
   if (args_array == NULL) {
@@ -108,7 +106,8 @@ PHP_METHOD(Server, requestCall) {
   grpc_metadata_array metadata;
   grpc_event event;
 
-  wrapped_grpc_server *server = Z_WRAPPED_GRPC_SERVER_P(getThis());
+  wrapped_grpc_server *server =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_server, getThis());
   zval *result;
   PHP_GRPC_MAKE_STD_ZVAL(result);
   object_init(result);
@@ -159,7 +158,8 @@ PHP_METHOD(Server, requestCall) {
 PHP_METHOD(Server, addHttp2Port) {
   const char *addr;
   php_grpc_int addr_len;
-  wrapped_grpc_server *server = Z_WRAPPED_GRPC_SERVER_P(getThis());
+  wrapped_grpc_server *server =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_server, getThis());
 
   /* "s" == 1 string */
   if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &addr, &addr_len)
@@ -181,7 +181,8 @@ PHP_METHOD(Server, addSecureHttp2Port) {
   const char *addr;
   php_grpc_int addr_len;
   zval *creds_obj;
-  wrapped_grpc_server *server = Z_WRAPPED_GRPC_SERVER_P(getThis());
+  wrapped_grpc_server *server =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_server, getThis());
 
   /* "sO" == 1 string, 1 object */
   if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sO", &addr, &addr_len,
@@ -193,7 +194,7 @@ PHP_METHOD(Server, addSecureHttp2Port) {
     return;
   }
   wrapped_grpc_server_credentials *creds =
-    Z_WRAPPED_GRPC_SERVER_CREDS_P(creds_obj);
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_server_credentials, creds_obj);
   RETURN_LONG(grpc_server_add_secure_http2_port(server->wrapped, addr,
                                                 creds->wrapped));
 }
@@ -203,7 +204,8 @@ PHP_METHOD(Server, addSecureHttp2Port) {
  * @return void
  */
 PHP_METHOD(Server, start) {
-  wrapped_grpc_server *server = Z_WRAPPED_GRPC_SERVER_P(getThis());
+  wrapped_grpc_server *server =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_server, getThis());
   grpc_server_start(server->wrapped);
 }
 

--- a/src/php/ext/grpc/server.h
+++ b/src/php/ext/grpc/server.h
@@ -38,22 +38,11 @@ PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_server)
   grpc_server *wrapped;
 PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_server)
 
-#if PHP_MAJOR_VERSION < 7
-
-#define Z_WRAPPED_GRPC_SERVER_P(zv) \
-  (wrapped_grpc_server *)zend_object_store_get_object(zv TSRMLS_CC)
-
-#else
-
 static inline wrapped_grpc_server
 *wrapped_grpc_server_from_obj(zend_object *obj) {
   return (wrapped_grpc_server*)((char*)(obj) -
                                 XtOffsetOf(wrapped_grpc_server, std));
 }
-
-#define Z_WRAPPED_GRPC_SERVER_P(zv) wrapped_grpc_server_from_obj(Z_OBJ_P((zv)))
-
-#endif /* PHP_MAJOR_VERSION */
 
 /* Initializes the Server class */
 void grpc_init_server(TSRMLS_D);

--- a/src/php/ext/grpc/server_credentials.c
+++ b/src/php/ext/grpc/server_credentials.c
@@ -35,9 +35,7 @@
 #include <grpc/grpc_security.h>
 
 zend_class_entry *grpc_ce_server_credentials;
-#if PHP_MAJOR_VERSION >= 7
-static zend_object_handlers server_credentials_ce_handlers;
-#endif
+PHP_GRPC_DECLARE_OBJECT_HANDLER(server_credentials_ce_handlers)
 
 /* Frees and destroys an instace of wrapped_grpc_server_credentials */
 PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_server_credentials)
@@ -63,7 +61,8 @@ zval *grpc_php_wrap_server_credentials(grpc_server_credentials
   PHP_GRPC_MAKE_STD_ZVAL(server_credentials_object);
   object_init_ex(server_credentials_object, grpc_ce_server_credentials);
   wrapped_grpc_server_credentials *server_credentials =
-    Z_WRAPPED_GRPC_SERVER_CREDS_P(server_credentials_object);
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_server_credentials,
+                                server_credentials_object);
   server_credentials->wrapped = wrapped;
   return server_credentials_object;
 }

--- a/src/php/ext/grpc/server_credentials.h
+++ b/src/php/ext/grpc/server_credentials.h
@@ -40,23 +40,11 @@ PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_server_credentials)
   grpc_server_credentials *wrapped;
 PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_server_credentials)
 
-#if PHP_MAJOR_VERSION < 7
-
-#define Z_WRAPPED_GRPC_SERVER_CREDS_P(zv) \
-  (wrapped_grpc_server_credentials *)zend_object_store_get_object(zv TSRMLS_CC)
-
-#else
-
 static inline wrapped_grpc_server_credentials
 *wrapped_grpc_server_credentials_from_obj(zend_object *obj) {
   return (wrapped_grpc_server_credentials*)(
       (char*)(obj) - XtOffsetOf(wrapped_grpc_server_credentials, std));
 }
-
-#define Z_WRAPPED_GRPC_SERVER_CREDS_P(zv) \
-  wrapped_grpc_server_credentials_from_obj(Z_OBJ_P((zv)))
-
-#endif /* PHP_MAJOR_VERSION */
 
 /* Initializes the Server_Credentials PHP class */
 void grpc_init_server_credentials(TSRMLS_D);

--- a/src/php/ext/grpc/timeval.c
+++ b/src/php/ext/grpc/timeval.c
@@ -36,9 +36,7 @@
 #include <grpc/support/time.h>
 
 zend_class_entry *grpc_ce_timeval;
-#if PHP_MAJOR_VERSION >= 7
-static zend_object_handlers timeval_ce_handlers;
-#endif
+PHP_GRPC_DECLARE_OBJECT_HANDLER(timeval_ce_handlers)
 
 /* Frees and destroys an instance of wrapped_grpc_call */
 PHP_GRPC_FREE_WRAPPED_FUNC_START(wrapped_grpc_timeval)
@@ -58,7 +56,8 @@ zval *grpc_php_wrap_timeval(gpr_timespec wrapped TSRMLS_DC) {
   zval *timeval_object;
   PHP_GRPC_MAKE_STD_ZVAL(timeval_object);
   object_init_ex(timeval_object, grpc_ce_timeval);
-  wrapped_grpc_timeval *timeval = Z_WRAPPED_GRPC_TIMEVAL_P(timeval_object);
+  wrapped_grpc_timeval *timeval =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, timeval_object);
   memcpy(&timeval->wrapped, &wrapped, sizeof(gpr_timespec));
   return timeval_object;
 }
@@ -68,7 +67,8 @@ zval *grpc_php_wrap_timeval(gpr_timespec wrapped TSRMLS_DC) {
  * @param long $microseconds The number of microseconds in the interval
  */
 PHP_METHOD(Timeval, __construct) {
-  wrapped_grpc_timeval *timeval = Z_WRAPPED_GRPC_TIMEVAL_P(getThis());
+  wrapped_grpc_timeval *timeval =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, getThis());
   php_grpc_long microseconds;
 
   /* "l" == 1 long */
@@ -98,8 +98,10 @@ PHP_METHOD(Timeval, add) {
                          "add expects a Timeval", 1 TSRMLS_CC);
     return;
   }
-  wrapped_grpc_timeval *self = Z_WRAPPED_GRPC_TIMEVAL_P(getThis());
-  wrapped_grpc_timeval *other = Z_WRAPPED_GRPC_TIMEVAL_P(other_obj);
+  wrapped_grpc_timeval *self =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, getThis());
+  wrapped_grpc_timeval *other =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, other_obj);
   zval *sum =
     grpc_php_wrap_timeval(gpr_time_add(self->wrapped, other->wrapped)
                           TSRMLS_CC);
@@ -122,8 +124,10 @@ PHP_METHOD(Timeval, subtract) {
                          "subtract expects a Timeval", 1 TSRMLS_CC);
     return;
   }
-  wrapped_grpc_timeval *self = Z_WRAPPED_GRPC_TIMEVAL_P(getThis());
-  wrapped_grpc_timeval *other = Z_WRAPPED_GRPC_TIMEVAL_P(other_obj);
+  wrapped_grpc_timeval *self =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, getThis());
+  wrapped_grpc_timeval *other =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, other_obj);
   zval *diff =
     grpc_php_wrap_timeval(gpr_time_sub(self->wrapped, other->wrapped)
                           TSRMLS_CC);
@@ -149,8 +153,10 @@ PHP_METHOD(Timeval, compare) {
                          "compare expects two Timevals", 1 TSRMLS_CC);
     return;
   }
-  wrapped_grpc_timeval *a = Z_WRAPPED_GRPC_TIMEVAL_P(a_obj);
-  wrapped_grpc_timeval *b = Z_WRAPPED_GRPC_TIMEVAL_P(b_obj);
+  wrapped_grpc_timeval *a =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, a_obj);
+  wrapped_grpc_timeval *b =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, b_obj);
   long result = gpr_time_cmp(a->wrapped, b->wrapped);
   RETURN_LONG(result);
 }
@@ -175,9 +181,12 @@ PHP_METHOD(Timeval, similar) {
                          "compare expects three Timevals", 1 TSRMLS_CC);
     return;
   }
-  wrapped_grpc_timeval *a = Z_WRAPPED_GRPC_TIMEVAL_P(a_obj);
-  wrapped_grpc_timeval *b = Z_WRAPPED_GRPC_TIMEVAL_P(b_obj);
-  wrapped_grpc_timeval *thresh = Z_WRAPPED_GRPC_TIMEVAL_P(thresh_obj);
+  wrapped_grpc_timeval *a =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, a_obj);
+  wrapped_grpc_timeval *b =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, b_obj);
+  wrapped_grpc_timeval *thresh =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, thresh_obj);
   int result = gpr_time_similar(a->wrapped, b->wrapped, thresh->wrapped);
   RETURN_BOOL(result);
 }
@@ -226,7 +235,8 @@ PHP_METHOD(Timeval, infPast) {
  * @return void
  */
 PHP_METHOD(Timeval, sleepUntil) {
-  wrapped_grpc_timeval *this = Z_WRAPPED_GRPC_TIMEVAL_P(getThis());
+  wrapped_grpc_timeval *this =
+    PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_timeval, getThis());
   gpr_sleep_until(this->wrapped);
 }
 

--- a/src/php/ext/grpc/timeval.h
+++ b/src/php/ext/grpc/timeval.h
@@ -39,23 +39,11 @@ PHP_GRPC_WRAP_OBJECT_START(wrapped_grpc_timeval)
   gpr_timespec wrapped;
 PHP_GRPC_WRAP_OBJECT_END(wrapped_grpc_timeval)
 
-#if PHP_MAJOR_VERSION < 7
-
-#define Z_WRAPPED_GRPC_TIMEVAL_P(zv) \
-  (wrapped_grpc_timeval *)zend_object_store_get_object(zv TSRMLS_CC)
-
-#else
-
 static inline wrapped_grpc_timeval
 *wrapped_grpc_timeval_from_obj(zend_object *obj) {
   return (wrapped_grpc_timeval*)((char*)(obj) -
                                  XtOffsetOf(wrapped_grpc_timeval, std));
 }
-
-#define Z_WRAPPED_GRPC_TIMEVAL_P(zv) \
-  wrapped_grpc_timeval_from_obj(Z_OBJ_P((zv)))
-
-#endif /* PHP_MAJOR_VERSION */
 
 /* Initialize the Timeval PHP class */
 void grpc_init_timeval(TSRMLS_D);


### PR DESCRIPTION
@ZhouyihaiDing  the two macro can reduce some dup-codes and make code better clear.
Please review the PR, thanks!
The PR includes:
- Add macro `PHP_GRPC_DECLARE_OBJECT_HANDLER` to reduce code duplication
- Add macro `PHP_GRPC_GET_WRAPPED_OBJECT` to replace `Z_WRAPPED_GRPC_XXX_P` to unify all macro start with `PHP_GRPC_`, and delete `Z_WRAPPED_GRPC_XXX_P` in each header file

So far, I think that `all macro` have complete and are wrapped in `php7_wrapper.h` file.