### PR TITLE
Revert recent changes to node interop build script

### DIFF
--- a/tools/dockerfile/interoptest/grpc_interop_node/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_node/build_interop.sh
@@ -17,22 +17,11 @@
 set -e
 
 mkdir -p /var/local/git
-
 git clone /var/local/jenkins/grpc-node /var/local/git/grpc-node
 # clone gRPC submodules, use data from locally cloned submodules where possible
 (cd /var/local/jenkins/grpc-node/ && git submodule foreach 'cd /var/local/git/grpc-node \
 && git submodule update --init --recursive --reference /var/local/jenkins/grpc-node/${name} \
 ${name}')
-
-# Use the pending c-core changes if possible
-if [ -d "/var/local/jenkins/grpc" ]; then
-  cd /var/local/jenkins/grpc
-  CURRENT_COMMIT="$(git rev-parse --verify HEAD)"
-  cd /var/local/git/grpc-node/packages/grpc-native-core/deps/grpc/
-  git fetch --tags --progress https://github.com/grpc/grpc.git +refs/pull/*:refs/remotes/origin/pr/*
-  git checkout $CURRENT_COMMIT
-  git submodule update --init --recursive --reference /var/local/jenkins/grpc
-fi
 
 # copy service account keys if available
 cp -r /var/local/jenkins/service_account $HOME || true


### PR DESCRIPTION
Fix issues with build file changes not propagating to the Node repo in interop tests.

Fixes #15289