### PR TITLE
Fix json_run_localhost failures under gcov

### DIFF
--- a/test/cpp/qps/gen_build_yaml.py
+++ b/test/cpp/qps/gen_build_yaml.py
@@ -63,6 +63,11 @@ def guess_cpu(scenario_json, is_tsan):
   return (scenario_json['num_clients'] * client +
           scenario_json['num_servers'] * server)
 
+def maybe_exclude_gcov(scenario_json):
+  if scenario_json['client_config']['client_channels'] > 100:
+    return ['gcov']
+  return []
+
 print yaml.dump({
   'tests': [
     {
@@ -76,7 +81,7 @@ print yaml.dump({
       'boringssl': True,
       'defaults': 'boringssl',
       'cpu_cost': guess_cpu(scenario_json, False),
-      'exclude_configs': ['tsan', 'asan'],
+      'exclude_configs': ['tsan', 'asan'] + maybe_exclude_gcov(scenario_json),
       'timeout_seconds': 2*60,
       'excluded_poll_engines': scenario_json.get('EXCLUDED_POLL_ENGINES', []),
       'auto_timeout_scaling': False

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -58026,7 +58026,8 @@
     "defaults": "boringssl", 
     "exclude_configs": [
       "tsan", 
-      "asan"
+      "asan", 
+      "gcov"
     ], 
     "excluded_poll_engines": [], 
     "flaky": false, 


### PR DESCRIPTION
It looks like that scenarios with many channels are just too slow to run under gcov (they can be made to pass if client connection timeout is increased)
For coverage puposes, it should be enough to just skip running scenarios that use a lot of channels (in our case that's cpp_protobuf_async_unary_75Kqps_600channel_60Krpcs_300Breq_50Bresp)

Progress towards https://github.com/grpc/grpc/issues/14924.