### PR TITLE
Add One Slice Deserialization Fastpath

### DIFF
--- a/include/grpcpp/impl/codegen/byte_buffer.h
+++ b/include/grpcpp/impl/codegen/byte_buffer.h
@@ -22,6 +22,9 @@
 #include <grpc/impl/codegen/byte_buffer.h>
 
 #include <grpcpp/impl/codegen/config.h>
+// Question for reviewers, does this bring in dependency on proto? or is this
+// safe?
+#include <grpcpp/impl/codegen/config_protobuf.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/codegen/serialization_traits.h>
 #include <grpcpp/impl/codegen/slice.h>
@@ -96,11 +99,6 @@ class ByteBuffer final {
   /// Dump (read) the buffer contents into \a slices.
   Status Dump(std::vector<Slice>* slices) const;
 
-  /// Returns true is buffer only holds one slice.
-  bool IsOneSliceByteBuffer() {
-    return buffer_->data.raw.slice_buffer.count == 1;
-  }
-
   /// Remove all data.
   void Clear() {
     if (buffer_) {
@@ -154,6 +152,9 @@ class ByteBuffer final {
   friend class ProtoBufferReader;
   friend class ProtoBufferWriter;
   friend class internal::GrpcByteBufferPeer;
+  template <class ProtoBufferReader, class T>
+  friend Status GenericDeserialize(ByteBuffer* buffer,
+                                   grpc::protobuf::Message* msg);
 
   grpc_byte_buffer* buffer_;
 

--- a/include/grpcpp/impl/codegen/byte_buffer.h
+++ b/include/grpcpp/impl/codegen/byte_buffer.h
@@ -96,6 +96,11 @@ class ByteBuffer final {
   /// Dump (read) the buffer contents into \a slices.
   Status Dump(std::vector<Slice>* slices) const;
 
+  /// Returns true is buffer only holds one slice.
+  bool IsOneSliceByteBuffer() {
+    return buffer_->data.raw.slice_buffer.count == 1;
+  }
+
   /// Remove all data.
   void Clear() {
     if (buffer_) {

--- a/include/grpcpp/impl/codegen/proto_utils.h
+++ b/include/grpcpp/impl/codegen/proto_utils.h
@@ -77,6 +77,14 @@ Status GenericDeserialize(ByteBuffer* buffer, grpc::protobuf::Message* msg) {
     return Status(StatusCode::INTERNAL, "No payload");
   }
   Status result = g_core_codegen_interface->ok();
+  if (buffer->IsOneSliceByteBuffer()) {
+    std::vector<Slice> slices;
+    buffer->Dump(&slices);
+    GPR_CODEGEN_ASSERT(slices.size() == 1);
+    return msg->ParseFromArray(slices[0].begin(), slices[0].size())
+               ? result
+               : Status(StatusCode::INTERNAL, "ParseFromArray has failed");
+  }
   {
     ProtoBufferReader reader(buffer);
     if (!reader.status().ok()) {


### PR DESCRIPTION
In the case that the buffer only holds one slice, we can use a faster API to deserialize directly from the bytes in the slice.

Will follow up with benchmarking data. But this should speed up deserialization of small payloads