### PR TITLE
Install pip for Python3.4 for gcov tests

### DIFF
--- a/templates/tools/dockerfile/test/multilang_jessie_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/multilang_jessie_x64/Dockerfile.template
@@ -25,6 +25,10 @@
   <%include file="../../php_deps.include"/>
   <%include file="../../ruby_deps.include"/>
   <%include file="../../python_deps.include"/>
+  # Install pip and virtualenv for Python 3.4
+  RUN curl https://bootstrap.pypa.io/get-pip.py | python3.4
+  RUN python3.4 -m pip install virtualenv
+  
   # Install coverage for Python test coverage reporting
   RUN pip install coverage
   ENV PATH ~/.local/bin:$PATH

--- a/tools/dockerfile/test/multilang_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/multilang_jessie_x64/Dockerfile
@@ -144,6 +144,10 @@ RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
 RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
 
+# Install pip and virtualenv for Python 3.4
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3.4
+RUN python3.4 -m pip install virtualenv
+
 # Install coverage for Python test coverage reporting
 RUN pip install coverage
 ENV PATH ~/.local/bin:$PATH


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc/pull/15312.

Gcov tests are now broken with
``` 
+ python3.4 -m pip install virtualenv
/usr/bin/python3.4: No module named pip
2018-05-09 09:14:18,696 FAILED: /var/local/git/grpc/tools/run_tests/helper_scripts/build_python.sh [ret=1, pid=2028, time=0.0sec]
```

https://source.cloud.google.com/results/invocations/51a10c7b-2652-4d33-8d16-dec1e844241e/targets/grpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_coverage/log

I think we will need a round at cleaning up python docker images (I'm getting lost with which are used for what - e.g. are we currently using python_jessie_x64?). 

