### PR TITLE
Fix channel args errors in google default credentials

### DIFF
--- a/src/core/lib/security/credentials/google_default/google_default_credentials.cc
+++ b/src/core/lib/security/credentials/google_default/google_default_credentials.cc
@@ -96,12 +96,14 @@ static grpc_security_status google_default_create_security_connector(
    * args. By doing that, it guarantees the connections to backends will not be
    * torn down and re-connected when switching in and out of fallback mode.
    */
-  static const char* args_to_remove[] = {
-      GRPC_ARG_ADDRESS_IS_GRPCLB_LOAD_BALANCER,
-      GRPC_ARG_ADDRESS_IS_BACKEND_FROM_GRPCLB_LOAD_BALANCER,
-  };
-  *new_args = grpc_channel_args_copy_and_add_and_remove(
-      args, args_to_remove, GPR_ARRAY_SIZE(args_to_remove), nullptr, 0);
+  if (use_alts) {
+    static const char* args_to_remove[] = {
+        GRPC_ARG_ADDRESS_IS_GRPCLB_LOAD_BALANCER,
+        GRPC_ARG_ADDRESS_IS_BACKEND_FROM_GRPCLB_LOAD_BALANCER,
+    };
+    *new_args = grpc_channel_args_copy_and_add_and_remove(
+        args, args_to_remove, GPR_ARRAY_SIZE(args_to_remove), nullptr, 0);
+  }
   return status;
 }
 


### PR DESCRIPTION
When removing grpclb-specific channel args, for SSL, we should remove them from `*new_args` instead of `args` as new channel args are added when creating a SSL security connector. Since grpclb-specific channel args are only added when ALTS is selected, we should also remove them when ALTS is used.

