### PR TITLE
"ninja install" command in instructions is misleading

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -142,7 +142,6 @@ installed to be able to compile the C/C++ sources.
 > call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" x64
 > cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release
 > cmake --build .
-> ninja install
 ```
 
 ### msys2 (with mingw)


### PR DESCRIPTION
Context: https://github.com/grpc/grpc/issues/15228  (ninja install  or cmake install should only be run when dependencies have already been installed independently)