### PR TITLE
Avoid unneeded dotnet restore in artifact builds

### DIFF
--- a/tools/run_tests/artifacts/build_artifact_csharp.bat
+++ b/tools/run_tests/artifacts/build_artifact_csharp.bat
@@ -15,7 +15,7 @@
 @rem Builds C# artifacts on Windows
 
 set ARCHITECTURE=%1
-
+set GRPC_SKIP_DOTNET_RESTORE=true
 @call tools\run_tests\helper_scripts\pre_build_csharp.bat %ARCHITECTURE% || goto :error
 
 cd cmake\build\%ARCHITECTURE%

--- a/tools/run_tests/artifacts/build_artifact_protoc.bat
+++ b/tools/run_tests/artifacts/build_artifact_protoc.bat
@@ -22,11 +22,7 @@ cd cmake
 mkdir build
 cd build
 
-@rem TODO(jtattermusch): Stop hardcoding path to yasm once Jenkins workers can locate yasm correctly
-@rem If yasm is not on the path, use hardcoded path instead.
-yasm --version || set USE_HARDCODED_YASM_PATH_MAYBE=-DCMAKE_ASM_NASM_COMPILER="C:/Program Files (x86)/yasm/yasm.exe"
-
-cmake -G "%generator%" -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON %USE_HARDCODED_YASM_PATH_MAYBE% ../.. || goto :error
+cmake -G "%generator%" -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON ../.. || goto :error
 cmake --build . --target protoc --config Release || goto :error
 cmake --build . --target plugins --config Release || goto :error
 cd ..\..

--- a/tools/run_tests/helper_scripts/pre_build_cmake.bat
+++ b/tools/run_tests/helper_scripts/pre_build_cmake.bat
@@ -24,11 +24,7 @@ cd cmake
 mkdir build
 cd build
 
-@rem TODO(jtattermusch): Stop hardcoding path to yasm once Jenkins workers can locate yasm correctly
-@rem If yasm is not on the path, use hardcoded path instead.
-yasm --version || set USE_HARDCODED_YASM_PATH_MAYBE=-DCMAKE_ASM_NASM_COMPILER="C:/Program Files (x86)/yasm/yasm.exe"
-
-cmake -G %GENERATOR% -A %ARCHITECTURE% -DgRPC_BUILD_TESTS=ON %USE_HARDCODED_YASM_PATH_MAYBE% ../.. || goto :error
+cmake -G %GENERATOR% -A %ARCHITECTURE% -DgRPC_BUILD_TESTS=ON ../.. || goto :error
 
 endlocal
 

--- a/tools/run_tests/helper_scripts/pre_build_csharp.bat
+++ b/tools/run_tests/helper_scripts/pre_build_csharp.bat
@@ -28,11 +28,7 @@ cd build
 mkdir %ARCHITECTURE%
 cd %ARCHITECTURE%
 
-@rem TODO(jtattermusch): Stop hardcoding path to yasm once Jenkins workers can locate yasm correctly
-@rem If yasm is not on the path, use hardcoded path instead.
-yasm --version || set USE_HARDCODED_YASM_PATH_MAYBE=-DCMAKE_ASM_NASM_COMPILER="C:/Program Files (x86)/yasm/yasm.exe"
-
-cmake -G "Visual Studio 14 2015" -A %ARCHITECTURE% -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON %USE_HARDCODED_YASM_PATH_MAYBE% ../../.. || goto :error
+cmake -G "Visual Studio 14 2015" -A %ARCHITECTURE% -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON ../../.. || goto :error
 
 cd ..\..\..\src\csharp
 

--- a/tools/run_tests/helper_scripts/pre_build_csharp.bat
+++ b/tools/run_tests/helper_scripts/pre_build_csharp.bat
@@ -32,7 +32,9 @@ cmake -G "Visual Studio 14 2015" -A %ARCHITECTURE% -DgRPC_BUILD_TESTS=OFF -DgRPC
 
 cd ..\..\..\src\csharp
 
-dotnet restore Grpc.sln || goto :error
+if NOT DEFINED GRPC_SKIP_DOTNET_RESTORE (
+  dotnet restore Grpc.sln || goto :error
+)
 
 endlocal
 


### PR DESCRIPTION
- This should fix https://github.com/grpc/grpc/issues/15305, which fails because `dotnet restore Grpc.sln` sometimes happens concurrently for x86 and x64 builds, but for artifact build. We could avoid that, but at the same time, we actually don't need to perform `dotnet restore` - we only care about building the `grpc_csharp_ext` library as part of the artifact build, not the C# code.

- Also removing an old cmake yasm hack we used for Jenkins that is no longer needed.