### PR TITLE
Handle timeouts when uploading ResultStore results

### DIFF
--- a/tools/run_tests/python_utils/upload_rbe_results.py
+++ b/tools/run_tests/python_utils/upload_rbe_results.py
@@ -146,7 +146,15 @@ if __name__ == "__main__":
             test_cases = [{
                 'testCase': {
                     'caseName': str(action['id']['actionId']),
-                    'result': str(action['statusAttributes']['status'])
+                }
+            }]
+        # Test timeouts have a different dictionary structure compared to pass and
+        # fail results.
+        elif action['statusAttributes']['status'] == 'TIMED_OUT':
+            test_cases = [{
+                'testCase': {
+                    'caseName': str(action['id']['actionId']),
+                    'timedOut': True
                 }
             }]
         else:
@@ -155,6 +163,8 @@ if __name__ == "__main__":
         for test_case in test_cases:
             if 'errors' in test_case['testCase']:
                 result = 'FAILED'
+            elif 'timedOut' in test_case['testCase']:
+                result = 'TIMEOUT'
             else:
                 result = 'PASSED'
             bq_rows.append({


### PR DESCRIPTION
Before, if there was a timeout in RBE, uploading the test results would fail because it couldn't handle the different dictionary structure of an `action` that timed out. (Un)fortunately, timeouts on RBE are uncommon enough that I didn't run into them when testing, but I find they happen <10% of the time on master, which runs each target twice. 