### PR TITLE
Make local DNS server test runner more generic

### DIFF
--- a/templates/test/cpp/naming/resolver_component_tests_defs.include
+++ b/templates/test/cpp/naming/resolver_component_tests_defs.include
@@ -113,20 +113,18 @@ wait_until_dns_server_is_up(args,
 num_test_failures = 0
 
 % for test in tests:
-test_runner_log('Run test with target: %s' % '${test['target_name']}')\
+test_runner_log('Run test with target: %s' % '${test['test_title']}')\
 
 current_test_subprocess = subprocess.Popen([\
 
   args.test_bin_path,\
 
-  '--target_name', '${test['target_name']}',\
+  % for arg_name_and_value in test['arg_names_and_values']:
+\
+  '--${arg_name_and_value[0]}', '${arg_name_and_value[1]}',\
 
-  '--expected_addrs', '${test['expected_addrs']}',\
-
-  '--expected_chosen_service_config', '${test['expected_chosen_service_config']}',\
-
-  '--expected_lb_policy', '${test['expected_lb_policy']}',\
-
+\
+  % endfor
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])\
 
 current_test_subprocess.communicate()\

--- a/templates/test/cpp/naming/resolver_gce_integration_tests_defs.include
+++ b/templates/test/cpp/naming/resolver_gce_integration_tests_defs.include
@@ -48,15 +48,15 @@ echo "Sanity check PASSED. Run resolver tests:"
 ONE_FAILED=0
 bins/$CONFIG/resolver_component_test \\
 
-  --target_name='${test['target_name']}' \\
+  % for arg_name_and_value in test['arg_names_and_values'][0:-1]:
+\
+  --${arg_name_and_value[0]}='${arg_name_and_value[1]}' \\
 
-  --expected_addrs='${test['expected_addrs']}' \\
-
-  --expected_chosen_service_config='${test['expected_chosen_service_config']}' \\
-
-  --expected_lb_policy='${test['expected_lb_policy']}' || ONE_FAILED=1
+\
+  % endfor
+  --${test['arg_names_and_values'][-1][0]}='${test['arg_names_and_values'][-1][1]}' || ONE_FAILED=1
 if [[ "$ONE_FAILED" != 0 ]]; then
-  echo "Test based on target record: ${test['target_name']} FAILED"
+  echo "Test based on target record: ${test['test_title']} FAILED"
   EXIT_CODE=1
 fi
 

--- a/test/cpp/naming/gen_build_yaml.py
+++ b/test/cpp/naming/gen_build_yaml.py
@@ -119,12 +119,19 @@ def _resolver_test_cases(resolver_component_data, records_to_skip):
   for test_case in resolver_component_data['resolver_component_tests']:
     if test_case['record_to_resolve'] in records_to_skip:
       continue
+    target_name = _append_zone_name(
+        test_case['record_to_resolve'],
+        resolver_component_data['resolver_tests_common_zone_name'])
     out.append({
-      'target_name': _append_zone_name(test_case['record_to_resolve'],
-                                       resolver_component_data['resolver_tests_common_zone_name']),
-      'expected_addrs': _build_expected_addrs_cmd_arg(test_case['expected_addrs']),
-      'expected_chosen_service_config': (test_case['expected_chosen_service_config'] or ''),
-      'expected_lb_policy': (test_case['expected_lb_policy'] or ''),
+        'test_title': target_name,
+        'arg_names_and_values': [
+            ('target_name', target_name),
+            ('expected_addrs',
+             _build_expected_addrs_cmd_arg(test_case['expected_addrs'])),
+            ('expected_chosen_service_config',
+             (test_case['expected_chosen_service_config'] or '')),
+            ('expected_lb_policy', (test_case['expected_lb_policy'] or '')),
+        ],
     })
   return out
 


### PR DESCRIPTION
Moves towards possibility of reusing the local DNS server infra for other tests than just the `resolver_component_test.cc`. This could allow running a grpc client -> server end-to-end test with access to the local DNS server, which could be useful for e.g. a better end-to-end test on the c-ares address sorter.

Note the generated `resolver_component_tests_runner.py` and `resolver_gce_integration_tests_runner.sh` are unchanged with this PR.