### PR TITLE
Remove a redundant ExecCtx in c-ares resolver

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -270,7 +270,6 @@ static void on_hostbyname_done_cb(void* arg, int status, int timeouts,
 static void on_srv_query_done_cb(void* arg, int status, int timeouts,
                                  unsigned char* abuf, int alen) {
   grpc_ares_request* r = static_cast<grpc_ares_request*>(arg);
-  grpc_core::ExecCtx exec_ctx;
   gpr_log(GPR_DEBUG, "on_query_srv_done_cb");
   if (status == ARES_SUCCESS) {
     gpr_log(GPR_DEBUG, "on_query_srv_done_cb ARES_SUCCESS");


### PR DESCRIPTION
Bringing this out from https://github.com/grpc/grpc/pull/15179.

Though this is callback is invoked from c-ares library, it's running on a grpc thread.