### PR TITLE
chttp2_transport: remove unused string

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1800,8 +1800,11 @@ static void perform_transport_op_locked(void* stream_op,
 
 static void perform_transport_op(grpc_transport* gt, grpc_transport_op* op) {
   grpc_chttp2_transport* t = reinterpret_cast<grpc_chttp2_transport*>(gt);
-  char* msg = grpc_transport_op_string(op);
-  gpr_free(msg);
+  if (grpc_http_trace.enabled()) {
+    char* msg = grpc_transport_op_string(op);
+    gpr_log(GPR_INFO, "perform_transport_op[t=%p]: %s", t, msg);
+    gpr_free(msg);
+  }
   op->handler_private.extra_arg = gt;
   GRPC_CHTTP2_REF_TRANSPORT(t, "transport_op");
   GRPC_CLOSURE_SCHED(GRPC_CLOSURE_INIT(&op->handler_private.closure,


### PR DESCRIPTION
Unless there's some sneaky side-effect I'm missing here, this call to `grpc_transport_op_string` is unnecessary. Git blame points to [this commit](https://github.com/grpc/grpc/commit/e194ff010691458bc300b59f957e38740bd188c3#diff-ce37d99bf1a5e7e131e56cee8f3f30c6), where the string was actually being logged, but in the actual [PR](https://github.com/grpc/grpc/pull/8008/files#diff-ce37d99bf1a5e7e131e56cee8f3f30c6R1244) it was just make the string + free the string. 