### PR TITLE
Add CONFIG environment variable to README

### DIFF
--- a/src/ruby/README.md
+++ b/src/ruby/README.md
@@ -48,7 +48,7 @@ $ gem install bundler
 ```sh
 $ # from this directory
 $ bundle install  # creates the ruby bundle, including building the grpc extension
-$ rake  # runs the unit tests, see rake -T for other options
+$ CONFIG='build config subdirectory' rake  # runs the unit tests, see rake -T for other options
 ```
 
 DOCUMENTATION


### PR DESCRIPTION
Since https://github.com/grpc/grpc/pull/15021 PR, `rake` command always fails without `CONFIG` environment variable.  So I added the comment about it to README.