### PR TITLE
Remove Channel Stack Construction Tracer

### DIFF
--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -47,7 +47,6 @@ some configuration as environment variables that can be set.
   - combiner - traces combiner lock state
   - compression - traces compression operations
   - connectivity_state - traces connectivity state changes to channels
-  - channel_stack_builder - traces information about channel stacks being built
   - executor - traces grpc's internal thread pool ('the executor')
   - fd_trace - traces fd create(), shutdown() and close() calls for channel fds.
     Also traces epoll fd create()/close() calls in epollex polling engine

--- a/src/core/lib/channel/channel_stack_builder.cc
+++ b/src/core/lib/channel/channel_stack_builder.cc
@@ -25,9 +25,6 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
 
-grpc_core::TraceFlag grpc_trace_channel_stack_builder(false,
-                                                      "channel_stack_builder");
-
 typedef struct filter_node {
   struct filter_node* next;
   struct filter_node* prev;

--- a/src/core/lib/channel/channel_stack_builder.h
+++ b/src/core/lib/channel/channel_stack_builder.h
@@ -155,6 +155,4 @@ grpc_error* grpc_channel_stack_builder_finish(
 /// Destroy the builder without creating a channel stack
 void grpc_channel_stack_builder_destroy(grpc_channel_stack_builder* builder);
 
-extern grpc_core::TraceFlag grpc_trace_channel_stack_builder;
-
 #endif /* GRPC_CORE_LIB_CHANNEL_CHANNEL_STACK_BUILDER_H */


### PR DESCRIPTION
The trace flag channel_stack_builder was never being used.

I think the channel tracer provides enough info.