### PR TITLE
Improve the call size estimate

### DIFF
--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -67,6 +67,9 @@
 
 #define MAX_SEND_EXTRA_METADATA_COUNT 3
 
+// Used to create arena for the first call.
+#define ESTIMATED_MDELEM_COUNT 16
+
 /* Status data for a request can come from several sources; this
    enumerates them all, and acts as a priority sorting for which
    status to return to the application - earlier entries override
@@ -321,6 +324,11 @@ static parent_call* get_or_create_parent_call(grpc_call* call) {
 
 static parent_call* get_parent_call(grpc_call* call) {
   return (parent_call*)gpr_atm_acq_load(&call->parent_call_atm);
+}
+
+size_t grpc_call_get_initial_size_estimate() {
+  return sizeof(grpc_call) + sizeof(batch_control) * MAX_CONCURRENT_BATCHES +
+         sizeof(grpc_linked_mdelem) * ESTIMATED_MDELEM_COUNT;
 }
 
 grpc_error* grpc_call_create(const grpc_call_create_args* args,
@@ -1144,9 +1152,9 @@ static int batch_slot_for_op(grpc_op_type type) {
   GPR_UNREACHABLE_CODE(return 123456789);
 }
 
-static batch_control* allocate_batch_control(grpc_call* call,
-                                             const grpc_op* ops,
-                                             size_t num_ops) {
+static batch_control* reuse_or_allocate_batch_control(grpc_call* call,
+                                                      const grpc_op* ops,
+                                                      size_t num_ops) {
   int slot = batch_slot_for_op(ops[0].op);
   batch_control** pslot = &call->active_batches[slot];
   if (*pslot == nullptr) {
@@ -1565,7 +1573,7 @@ static grpc_call_error call_start_batch(grpc_call* call, const grpc_op* ops,
     goto done;
   }
 
-  bctl = allocate_batch_control(call, ops, nops);
+  bctl = reuse_or_allocate_batch_control(call, ops, nops);
   if (bctl == nullptr) {
     return GRPC_CALL_ERROR_TOO_MANY_OPERATIONS;
   }

--- a/src/core/lib/surface/call.h
+++ b/src/core/lib/surface/call.h
@@ -98,6 +98,11 @@ void* grpc_call_context_get(grpc_call* call, grpc_context_index elem);
 
 uint8_t grpc_call_is_client(grpc_call* call);
 
+/* Get the estimated memory size for a call BESIDES the call stack. Combined
+ * with the size of the call stack, it helps estimate the arena size for the
+ * initial call. */
+size_t grpc_call_get_initial_size_estimate();
+
 /* Return an appropriate compression algorithm for the requested compression \a
  * level in the context of \a call. */
 grpc_compression_algorithm grpc_call_compression_for_level(

--- a/src/core/lib/surface/channel.cc
+++ b/src/core/lib/surface/channel.cc
@@ -112,7 +112,8 @@ grpc_channel* grpc_channel_create_with_builder(
 
   gpr_atm_no_barrier_store(
       &channel->call_size_estimate,
-      (gpr_atm)CHANNEL_STACK_FROM_CHANNEL(channel)->call_stack_size);
+      (gpr_atm)CHANNEL_STACK_FROM_CHANNEL(channel)->call_stack_size +
+          grpc_call_get_initial_size_estimate());
 
   grpc_compression_options_init(&channel->compression_options);
   for (size_t i = 0; i < args->num_args; i++) {


### PR DESCRIPTION
When the first call creates its arena, it shouldn't just estimate the necessary size using the call stack. It should at least include the `grpc_call` and some other necessary stuff for a complete call. Otherwise, the arena will be too small for the first allocation for both the `grpc_call` and the call stack. And the initial zone of the arena will be wasted and the second zone will grow to twice the size of `grpc_call` and the call stack. 

This means a lot for the channels that only have one call per channel.

The test of the internal balancer shows that this PR can reduce the memory usage per channel (one bidi steaming call per channel) from ~100KB to ~75KB.