### PR TITLE
intern default authority

### DIFF
--- a/src/core/ext/filters/http/client_authority_filter.cc
+++ b/src/core/ext/filters/http/client_authority_filter.cc
@@ -103,7 +103,7 @@ grpc_error* init_channel_elem(grpc_channel_element* elem,
         "GRPC_ARG_DEFAULT_AUTHORITY channel arg. must be a string");
   }
   chand->default_authority =
-      grpc_slice_from_copied_string(default_authority_str);
+      grpc_slice_intern(grpc_slice_from_static_string(default_authority_str));
   GPR_ASSERT(!args->is_last);
   return GRPC_ERROR_NONE;
 }


### PR DESCRIPTION
The hpack encoder uses whether the slice is interned as a hint of whether it should be put into the hpack table. Currently only the :authority key but not the value is interned, and as a result we are not using the metadata element but only the key from the table. Considering this is a per-channel thing, I think it is better to intern it to make better use of the hpack compression.

This seems to be a regression introduced when the authority filter was introduced. I believe previously the interned slice is from the registered call.