### PR TITLE
PHP: Surface a static method to fetch the default Channel

### DIFF
--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -69,6 +69,18 @@ class BaseStub
             return;
         }
 
+        $this->channel = static::getDefaultChannel($opts);
+    }
+
+    /**
+     * Creates and returns the default Channel
+     *
+     * @param array $opts Channel constructor options
+     *
+     * @return Channel The channel
+     */
+    public static function getDefaultChannel(array $opts)
+    {
         $package_config = json_decode(
             file_get_contents(dirname(__FILE__).'/../../composer.json'),
             true
@@ -85,7 +97,7 @@ class BaseStub
                 'required. Please see one of the '.
                 'ChannelCredentials::create methods');
         }
-        $this->channel = new Channel($hostname, $opts);
+        return new Channel($hostname, $opts);
     }
 
     /**

--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -69,7 +69,7 @@ class BaseStub
             return;
         }
 
-        $this->channel = static::getDefaultChannel($opts);
+        $this->channel = static::getDefaultChannel($hostname, $opts);
     }
 
     /**
@@ -79,7 +79,7 @@ class BaseStub
      *
      * @return Channel The channel
      */
-    public static function getDefaultChannel(array $opts)
+    public static function getDefaultChannel($hostname, array $opts)
     {
         $package_config = json_decode(
             file_get_contents(dirname(__FILE__).'/../../composer.json'),


### PR DESCRIPTION
Prior to having access to interceptors, a developer didn't care about the default Channel created.

If you are using interceptors and you want to use and interceptor with the default channel you would have to replicate the code in the BaseStub constructor.

This PR exposes a static method `BaseStub::getDefaultChannel(array $opts)` that can be used to fetch the default channel so that a developer can wrap the channel with an interceptor.

@ZhouyihaiDing 