### PR TITLE
Rename a flag in c-ares driver, add a test for cancelled queries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,6 +659,9 @@ endif()
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 add_dependencies(buildtests_cxx address_sorting_test)
 endif()
+if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
+add_dependencies(buildtests_cxx cancel_ares_query_test)
+endif()
 
 add_custom_target(buildtests
   DEPENDS buildtests_c buildtests_cxx)
@@ -15756,6 +15759,48 @@ target_include_directories(address_sorting_test
 )
 
 target_link_libraries(address_sorting_test
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc++_test_util
+  grpc_test_util
+  gpr_test_util
+  grpc++
+  grpc
+  gpr
+  grpc++_test_config
+  ${_gRPC_GFLAGS_LIBRARIES}
+)
+
+endif()
+endif (gRPC_BUILD_TESTS)
+if (gRPC_BUILD_TESTS)
+if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
+
+add_executable(cancel_ares_query_test
+  test/cpp/naming/cancel_ares_query_test.cc
+  third_party/googletest/googletest/src/gtest-all.cc
+  third_party/googletest/googlemock/src/gmock-all.cc
+)
+
+
+target_include_directories(cancel_ares_query_test
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
+  PRIVATE ${_gRPC_PROTOBUF_INCLUDE_DIR}
+  PRIVATE ${_gRPC_ZLIB_INCLUDE_DIR}
+  PRIVATE ${_gRPC_BENCHMARK_INCLUDE_DIR}
+  PRIVATE ${_gRPC_CARES_INCLUDE_DIR}
+  PRIVATE ${_gRPC_GFLAGS_INCLUDE_DIR}
+  PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+  PRIVATE third_party/googletest/googletest/include
+  PRIVATE third_party/googletest/googletest
+  PRIVATE third_party/googletest/googlemock/include
+  PRIVATE third_party/googletest/googlemock
+  PRIVATE ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(cancel_ares_query_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc++_test_util

--- a/Makefile
+++ b/Makefile
@@ -1327,6 +1327,7 @@ resolver_component_tests_runner_invoker_unsecure: $(BINDIR)/$(CONFIG)/resolver_c
 resolver_component_tests_runner_invoker: $(BINDIR)/$(CONFIG)/resolver_component_tests_runner_invoker
 address_sorting_test_unsecure: $(BINDIR)/$(CONFIG)/address_sorting_test_unsecure
 address_sorting_test: $(BINDIR)/$(CONFIG)/address_sorting_test
+cancel_ares_query_test: $(BINDIR)/$(CONFIG)/cancel_ares_query_test
 alts_credentials_fuzzer_one_entry: $(BINDIR)/$(CONFIG)/alts_credentials_fuzzer_one_entry
 api_fuzzer_one_entry: $(BINDIR)/$(CONFIG)/api_fuzzer_one_entry
 client_fuzzer_one_entry: $(BINDIR)/$(CONFIG)/client_fuzzer_one_entry
@@ -1762,6 +1763,7 @@ buildtests_cxx: privatelibs_cxx \
   $(BINDIR)/$(CONFIG)/resolver_component_tests_runner_invoker \
   $(BINDIR)/$(CONFIG)/address_sorting_test_unsecure \
   $(BINDIR)/$(CONFIG)/address_sorting_test \
+  $(BINDIR)/$(CONFIG)/cancel_ares_query_test \
 
 else
 buildtests_cxx: privatelibs_cxx \
@@ -1885,6 +1887,7 @@ buildtests_cxx: privatelibs_cxx \
   $(BINDIR)/$(CONFIG)/resolver_component_tests_runner_invoker \
   $(BINDIR)/$(CONFIG)/address_sorting_test_unsecure \
   $(BINDIR)/$(CONFIG)/address_sorting_test \
+  $(BINDIR)/$(CONFIG)/cancel_ares_query_test \
 
 endif
 
@@ -2366,6 +2369,8 @@ test_cxx: buildtests_cxx
 	$(Q) $(BINDIR)/$(CONFIG)/address_sorting_test_unsecure || ( echo test address_sorting_test_unsecure failed ; exit 1 )
 	$(E) "[RUN]     Testing address_sorting_test"
 	$(Q) $(BINDIR)/$(CONFIG)/address_sorting_test || ( echo test address_sorting_test failed ; exit 1 )
+	$(E) "[RUN]     Testing cancel_ares_query_test"
+	$(Q) $(BINDIR)/$(CONFIG)/cancel_ares_query_test || ( echo test cancel_ares_query_test failed ; exit 1 )
 
 
 flaky_test_cxx: buildtests_cxx
@@ -23531,6 +23536,49 @@ deps_address_sorting_test: $(ADDRESS_SORTING_TEST_OBJS:.o=.dep)
 ifneq ($(NO_SECURE),true)
 ifneq ($(NO_DEPS),true)
 -include $(ADDRESS_SORTING_TEST_OBJS:.o=.dep)
+endif
+endif
+
+
+CANCEL_ARES_QUERY_TEST_SRC = \
+    test/cpp/naming/cancel_ares_query_test.cc \
+
+CANCEL_ARES_QUERY_TEST_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(CANCEL_ARES_QUERY_TEST_SRC))))
+ifeq ($(NO_SECURE),true)
+
+# You can't build secure targets if you don't have OpenSSL.
+
+$(BINDIR)/$(CONFIG)/cancel_ares_query_test: openssl_dep_error
+
+else
+
+
+
+
+ifeq ($(NO_PROTOBUF),true)
+
+# You can't build the protoc plugins or protobuf-enabled targets if you don't have protobuf 3.5.0+.
+
+$(BINDIR)/$(CONFIG)/cancel_ares_query_test: protobuf_dep_error
+
+else
+
+$(BINDIR)/$(CONFIG)/cancel_ares_query_test: $(PROTOBUF_DEP) $(CANCEL_ARES_QUERY_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libgrpc++_test_config.a
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) $(LDXX) $(LDFLAGS) $(CANCEL_ARES_QUERY_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libgrpc++_test_config.a $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) $(LDLIBS_SECURE) $(GTEST_LIB) -o $(BINDIR)/$(CONFIG)/cancel_ares_query_test
+
+endif
+
+endif
+
+$(OBJDIR)/$(CONFIG)/test/cpp/naming/cancel_ares_query_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libgrpc++_test_config.a
+
+deps_cancel_ares_query_test: $(CANCEL_ARES_QUERY_TEST_OBJS:.o=.dep)
+
+ifneq ($(NO_SECURE),true)
+ifneq ($(NO_DEPS),true)
+-include $(CANCEL_ARES_QUERY_TEST_OBJS:.o=.dep)
 endif
 endif
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
@@ -21,6 +21,7 @@
 #if GRPC_ARES == 1 && defined(GRPC_POSIX_SOCKET)
 
 #include <ares.h>
+#include <string.h>
 #include <sys/ioctl.h>
 
 #include "src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h"
@@ -55,8 +56,10 @@ typedef struct fd_node {
   bool readable_registered;
   /** if the writable closure has been registered */
   bool writable_registered;
-  /** if the fd is being shut down */
-  bool shutting_down;
+  /** has this fd node been shutdown yet */
+  bool already_shutdown;
+  /** refcount of the fd node*/
+  gpr_refcount refs;
 } fd_node;
 
 struct grpc_ares_ev_driver {
@@ -79,6 +82,27 @@ struct grpc_ares_ev_driver {
 
 static void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver);
 
+static void grpc_ares_fd_node_ref(fd_node* fdn) {
+  gpr_log(GPR_DEBUG, "Ref fd_node: %d", grpc_fd_wrapped_fd(fdn->fd));
+  gpr_ref(&fdn->refs);
+}
+
+static void grpc_ares_fd_node_unref(fd_node* fdn) {
+  gpr_log(GPR_DEBUG, "Unref fd_node: %d", grpc_fd_wrapped_fd(fdn->fd));
+  if (gpr_unref(&fdn->refs)) {
+    gpr_log(GPR_DEBUG, "delete fd: %d", grpc_fd_wrapped_fd(fdn->fd));
+    GPR_ASSERT(!fdn->readable_registered);
+    GPR_ASSERT(!fdn->writable_registered);
+    gpr_mu_destroy(&fdn->mu);
+    /* c-ares library has closed the fd inside grpc_fd. This fd may be picked up
+       immediately by another thread, and should not be closed by the following
+       grpc_fd_orphan. */
+    grpc_fd_orphan(fdn->fd, nullptr, nullptr, true /* already_closed */,
+                   "c-ares query finished");
+    gpr_free(fdn);
+  }
+}
+
 static grpc_ares_ev_driver* grpc_ares_ev_driver_ref(
     grpc_ares_ev_driver* ev_driver) {
   gpr_log(GPR_DEBUG, "Ref ev_driver %" PRIuPTR, (uintptr_t)ev_driver);
@@ -97,37 +121,26 @@ static void grpc_ares_ev_driver_unref(grpc_ares_ev_driver* ev_driver) {
   }
 }
 
-static void fd_node_destroy(fd_node* fdn) {
-  gpr_log(GPR_DEBUG, "delete fd: %d", grpc_fd_wrapped_fd(fdn->fd));
-  GPR_ASSERT(!fdn->readable_registered);
-  GPR_ASSERT(!fdn->writable_registered);
-  gpr_mu_destroy(&fdn->mu);
-  /* c-ares library has closed the fd inside grpc_fd. This fd may be picked up
-     immediately by another thread, and should not be closed by the following
-     grpc_fd_orphan. */
-  grpc_fd_orphan(fdn->fd, nullptr, nullptr, true /* already_closed */,
-                 "c-ares query finished");
-  gpr_free(fdn);
-}
-
-static void fd_node_shutdown(fd_node* fdn) {
+static void fd_node_shutdown(fd_node* fdn, const char* reason) {
   gpr_mu_lock(&fdn->mu);
-  fdn->shutting_down = true;
-  if (!fdn->readable_registered && !fdn->writable_registered) {
-    gpr_mu_unlock(&fdn->mu);
-    fd_node_destroy(fdn);
-  } else {
-    grpc_fd_shutdown(
-        fdn->fd, GRPC_ERROR_CREATE_FROM_STATIC_STRING("c-ares fd shutdown"));
-    gpr_mu_unlock(&fdn->mu);
+  if (!fdn->already_shutdown) {
+    fdn->already_shutdown = true;
+    grpc_fd_shutdown(fdn->fd, GRPC_ERROR_CREATE_FROM_STATIC_STRING(reason));
   }
+  gpr_mu_unlock(&fdn->mu);
 }
 
 grpc_error* grpc_ares_ev_driver_create(grpc_ares_ev_driver** ev_driver,
                                        grpc_pollset_set* pollset_set) {
   *ev_driver = static_cast<grpc_ares_ev_driver*>(
       gpr_malloc(sizeof(grpc_ares_ev_driver)));
-  int status = ares_init(&(*ev_driver)->channel);
+  ares_options opts;
+  memset(&opts, 0, sizeof(opts));
+  // Pass ARES_FLAGS_STAYOPEN: defer closing of fd's that were
+  // opened by c-ares until "ares_destroy" is called, to avoid operating
+  // on closed fd's.
+  opts.flags |= ARES_FLAG_STAYOPEN;
+  int status = ares_init_options(&(*ev_driver)->channel, &opts, ARES_OPT_FLAGS);
   gpr_log(GPR_DEBUG, "grpc_ares_ev_driver_create");
   if (status != ARES_SUCCESS) {
     char* err_msg;
@@ -164,8 +177,7 @@ void grpc_ares_ev_driver_shutdown(grpc_ares_ev_driver* ev_driver) {
   ev_driver->shutting_down = true;
   fd_node* fn = ev_driver->fds;
   while (fn != nullptr) {
-    grpc_fd_shutdown(fn->fd, GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                 "grpc_ares_ev_driver_shutdown"));
+    fd_node_shutdown(fn, "grpc_ares_ev_driver_shutdown");
     fn = fn->next;
   }
   gpr_mu_unlock(&ev_driver->mu);
@@ -202,14 +214,7 @@ static void on_readable_cb(void* arg, grpc_error* error) {
   gpr_mu_lock(&fdn->mu);
   const int fd = grpc_fd_wrapped_fd(fdn->fd);
   fdn->readable_registered = false;
-  if (fdn->shutting_down && !fdn->writable_registered) {
-    gpr_mu_unlock(&fdn->mu);
-    fd_node_destroy(fdn);
-    grpc_ares_ev_driver_unref(ev_driver);
-    return;
-  }
   gpr_mu_unlock(&fdn->mu);
-
   gpr_log(GPR_DEBUG, "readable on %d", fd);
   if (error == GRPC_ERROR_NONE) {
     do {
@@ -228,6 +233,7 @@ static void on_readable_cb(void* arg, grpc_error* error) {
   grpc_ares_notify_on_event_locked(ev_driver);
   gpr_mu_unlock(&ev_driver->mu);
   grpc_ares_ev_driver_unref(ev_driver);
+  grpc_ares_fd_node_unref(fdn);
 }
 
 static void on_writable_cb(void* arg, grpc_error* error) {
@@ -236,12 +242,6 @@ static void on_writable_cb(void* arg, grpc_error* error) {
   gpr_mu_lock(&fdn->mu);
   const int fd = grpc_fd_wrapped_fd(fdn->fd);
   fdn->writable_registered = false;
-  if (fdn->shutting_down && !fdn->readable_registered) {
-    gpr_mu_unlock(&fdn->mu);
-    fd_node_destroy(fdn);
-    grpc_ares_ev_driver_unref(ev_driver);
-    return;
-  }
   gpr_mu_unlock(&fdn->mu);
 
   gpr_log(GPR_DEBUG, "writable on %d", fd);
@@ -260,6 +260,7 @@ static void on_writable_cb(void* arg, grpc_error* error) {
   grpc_ares_notify_on_event_locked(ev_driver);
   gpr_mu_unlock(&ev_driver->mu);
   grpc_ares_ev_driver_unref(ev_driver);
+  grpc_ares_fd_node_unref(fdn);
 }
 
 ares_channel* grpc_ares_ev_driver_get_channel(grpc_ares_ev_driver* ev_driver) {
@@ -288,7 +289,8 @@ static void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver) {
           fdn->ev_driver = ev_driver;
           fdn->readable_registered = false;
           fdn->writable_registered = false;
-          fdn->shutting_down = false;
+          fdn->already_shutdown = false;
+          gpr_ref_init(&fdn->refs, 1);
           gpr_mu_init(&fdn->mu);
           GRPC_CLOSURE_INIT(&fdn->read_closure, on_readable_cb, fdn,
                             grpc_schedule_on_exec_ctx);
@@ -306,6 +308,7 @@ static void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver) {
             !fdn->readable_registered) {
           grpc_ares_ev_driver_ref(ev_driver);
           gpr_log(GPR_DEBUG, "notify read on: %d", grpc_fd_wrapped_fd(fdn->fd));
+          grpc_ares_fd_node_ref(fdn);
           grpc_fd_notify_on_read(fdn->fd, &fdn->read_closure);
           fdn->readable_registered = true;
         }
@@ -316,6 +319,7 @@ static void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver) {
           gpr_log(GPR_DEBUG, "notify write on: %d",
                   grpc_fd_wrapped_fd(fdn->fd));
           grpc_ares_ev_driver_ref(ev_driver);
+          grpc_ares_fd_node_ref(fdn);
           grpc_fd_notify_on_write(fdn->fd, &fdn->write_closure);
           fdn->writable_registered = true;
         }
@@ -329,7 +333,8 @@ static void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver) {
   while (ev_driver->fds != nullptr) {
     fd_node* cur = ev_driver->fds;
     ev_driver->fds = ev_driver->fds->next;
-    fd_node_shutdown(cur);
+    fd_node_shutdown(cur, "shutdown c-ares fd node");
+    grpc_ares_fd_node_unref(cur);
   }
   ev_driver->fds = new_list;
   // If the ev driver has no working fd, all the tasks are done.

--- a/test/cpp/naming/BUILD
+++ b/test/cpp/naming/BUILD
@@ -22,7 +22,7 @@ package(
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_py_binary")
+load("//bazel:grpc_build_system.bzl", "grpc_py_binary", "grpc_cc_test")
 
 load(":generate_resolver_component_tests.bzl", "generate_resolver_component_tests")
 
@@ -33,6 +33,22 @@ grpc_py_binary(
         "resolver_component_tests_runner.py",
     ],
     testonly = True,
+)
+
+grpc_cc_test(
+    name = "cancel_ares_query_test",
+    srcs = ["cancel_ares_query_test.cc"],
+    external_deps = ["gmock"],
+    deps = [
+        "//test/cpp/util:test_util",
+        "//test/core/util:grpc_test_util",
+        "//test/core/util:gpr_test_util",
+        "//:grpc++",
+        "//:grpc",
+        "//:gpr",
+        "//test/cpp/util:test_config",
+        "//test/core/end2end:cq_verifier",
+    ],
 )
 
 generate_resolver_component_tests()

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -16,8 +16,6 @@
  *
  */
 
-#include "test/core/end2end/end2end_tests.h"
-
 #include <stdio.h>
 #include <string.h>
 

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -1,0 +1,199 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "test/core/end2end/end2end_tests.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include <gflags/gflags.h>
+#include <gmock/gmock.h>
+
+#include <grpc/byte_buffer.h>
+#include <grpc/grpc.h>
+#include <grpc/support/alloc.h>
+#include <grpc/support/log.h>
+#include <grpc/support/time.h>
+#include "include/grpc/support/string_util.h"
+#include "src/core/lib/debug/stats.h"
+#include "src/core/lib/gpr/env.h"
+#include "src/core/lib/gpr/host_port.h"
+#include "src/core/lib/gpr/string.h"
+#include "src/core/lib/gprpp/thd.h"
+#include "test/core/end2end/cq_verifier.h"
+#include "test/core/util/cmdline.h"
+#include "test/core/util/port.h"
+#include "test/core/util/test_config.h"
+
+// TODO: pull in different headers when enabling this
+// test on windows. Also set BAD_SOCKET_RETURN_VAL
+// to INVALID_SOCKET on windows.
+#include "src/core/lib/iomgr/sockaddr_posix.h"
+#define BAD_SOCKET_RETURN_VAL -1
+
+namespace {
+
+gpr_timespec FiveSecondsFromNow(void) {
+  return grpc_timeout_seconds_to_deadline(5);
+}
+
+void DrainCq(grpc_completion_queue* cq) {
+  grpc_event ev;
+  do {
+    ev = grpc_completion_queue_next(cq, FiveSecondsFromNow(), nullptr);
+  } while (ev.type != GRPC_QUEUE_SHUTDOWN);
+}
+
+void EndTest(grpc_channel* client, grpc_completion_queue* cq) {
+  grpc_channel_destroy(client);
+  grpc_completion_queue_shutdown(cq);
+  DrainCq(cq);
+  grpc_completion_queue_destroy(cq);
+}
+
+class FakeNonResponsiveDNSServer {
+ public:
+  FakeNonResponsiveDNSServer(int port) {
+    socket_ = socket(AF_INET6, SOCK_DGRAM, 0);
+    if (socket_ == BAD_SOCKET_RETURN_VAL) {
+      gpr_log(GPR_DEBUG, "Failed to create UDP ipv6 socket");
+      abort();
+    }
+    sockaddr_in6 addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin6_family = AF_INET6;
+    addr.sin6_port = htons(port);
+    ((char*)&addr.sin6_addr)[15] = 1;
+    if (bind(socket_, (const sockaddr*)&addr, sizeof(addr)) != 0) {
+      gpr_log(GPR_DEBUG, "Failed to bind UDP ipv6 socket to [::1]:%d", port);
+      abort();
+    }
+  }
+  ~FakeNonResponsiveDNSServer() { close(socket_); }
+  int socket_;
+};
+
+class CallWithNonResponsiveDNSServer {
+ public:
+  CallWithNonResponsiveDNSServer(int fake_dns_port, gpr_timespec deadline) {
+    char* client_target = nullptr;
+    GPR_ASSERT(gpr_asprintf(
+        &client_target,
+        "dns://[::1]:%d/dont-care-since-wont-be-resolved.test.com:1234",
+        fake_dns_port));
+    client_ = grpc_insecure_channel_create(client_target,
+                                           /* client_args */ nullptr, nullptr);
+    gpr_free(client_target);
+    cq_ = grpc_completion_queue_create_for_next(nullptr);
+    cqv_ = cq_verifier_create(cq_);
+    call_ = grpc_channel_create_call(client_, nullptr, GRPC_PROPAGATE_DEFAULTS,
+                                     cq_, grpc_slice_from_static_string("/foo"),
+                                     nullptr, deadline, nullptr);
+    GPR_ASSERT(call_);
+    grpc_metadata_array_init(&initial_metadata_recv_);
+    grpc_metadata_array_init(&trailing_metadata_recv_);
+    grpc_metadata_array_init(&request_metadata_recv_);
+    grpc_call_details_init(&call_details_);
+    // Set ops for client request
+    memset(ops_base_, 0, sizeof(ops_base_));
+    grpc_op* op = ops_base_;
+    op->op = GRPC_OP_SEND_INITIAL_METADATA;
+    op->data.send_initial_metadata.count = 0;
+    op->flags = 0;
+    op->reserved = nullptr;
+    op++;
+    op->op = GRPC_OP_SEND_CLOSE_FROM_CLIENT;
+    op->flags = 0;
+    op->reserved = nullptr;
+    op++;
+    op->op = GRPC_OP_RECV_INITIAL_METADATA;
+    op->data.recv_initial_metadata.recv_initial_metadata =
+        &initial_metadata_recv_;
+    op->flags = 0;
+    op->reserved = nullptr;
+    op++;
+    op->op = GRPC_OP_RECV_STATUS_ON_CLIENT;
+    op->data.recv_status_on_client.trailing_metadata = &trailing_metadata_recv_;
+    op->data.recv_status_on_client.status = &status_;
+    op->data.recv_status_on_client.status_details = &details_;
+    op->data.recv_status_on_client.error_string = &error_string_;
+    op->flags = 0;
+    op->reserved = nullptr;
+    op++;
+    // Start a call
+    grpc_call_error error = grpc_call_start_batch(
+        call_, ops_base_, static_cast<size_t>(op - ops_base_), this, nullptr);
+    EXPECT_EQ(GRPC_CALL_OK, error);
+  }
+
+  ~CallWithNonResponsiveDNSServer() {
+    grpc_slice_unref(details_);
+    gpr_free((void*)error_string_);
+    grpc_metadata_array_destroy(&initial_metadata_recv_);
+    grpc_metadata_array_destroy(&trailing_metadata_recv_);
+    grpc_metadata_array_destroy(&request_metadata_recv_);
+    grpc_call_details_destroy(&call_details_);
+    grpc_call_unref(call_);
+    cq_verifier_destroy(cqv_);
+    EndTest(client_, cq_);
+  }
+
+  void CqVerify() {
+    CQ_EXPECT_COMPLETION(cqv_, this, 1);
+    cq_verify(cqv_);
+  }
+
+  grpc_status_code GetStatus() { return status_; }
+
+  grpc_call* GetCall() { return call_; }
+
+  grpc_channel* client_;
+  grpc_call* call_;
+  grpc_completion_queue* cq_;
+  cq_verifier* cqv_;
+  grpc_op ops_base_[6];
+  grpc_metadata_array initial_metadata_recv_;
+  grpc_metadata_array trailing_metadata_recv_;
+  grpc_metadata_array request_metadata_recv_;
+  grpc_call_details call_details_;
+  grpc_status_code status_;
+  const char* error_string_;
+  grpc_slice details_;
+};
+
+TEST(CancelDuringAresQuery,
+     TestHitDeadlineAndDestroyChannelDuringAresResolutionIsGraceful) {
+  int fake_dns_port = grpc_pick_unused_port_or_die();
+  FakeNonResponsiveDNSServer fake_dns_server(fake_dns_port);
+  CallWithNonResponsiveDNSServer test_call(
+      fake_dns_port, grpc_timeout_milliseconds_to_deadline(10));
+  test_call.CqVerify();
+  EXPECT_EQ(test_call.GetStatus(), GRPC_STATUS_DEADLINE_EXCEEDED);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  grpc_test_init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  gpr_setenv("GRPC_DNS_RESOLVER", "ares");
+  grpc_init();
+  auto result = RUN_ALL_TESTS();
+  grpc_shutdown();
+  return result;
+}

--- a/test/cpp/naming/gen_build_yaml.py
+++ b/test/cpp/naming/gen_build_yaml.py
@@ -201,6 +201,25 @@ def main():
                   'grpc++_test_config',
               ],
           } for unsecure_build_config_suffix in ['_unsecure', '']
+      ] + [
+          {
+          'name': 'cancel_ares_query_test',
+          'build': 'test',
+          'language': 'c++',
+          'gtest': True,
+          'run': True,
+          'src': ['test/cpp/naming/cancel_ares_query_test.cc'],
+          'platforms': ['linux', 'posix', 'mac'],
+          'deps': [
+              'grpc++_test_util',
+              'grpc_test_util',
+              'gpr_test_util',
+              'grpc++',
+              'grpc',
+              'gpr',
+              'grpc++_test_config',
+          ],
+          },
       ]
   }
 

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -6497,6 +6497,26 @@
       "gpr", 
       "gpr_test_util", 
       "grpc", 
+      "grpc++", 
+      "grpc++_test_config", 
+      "grpc++_test_util", 
+      "grpc_test_util"
+    ], 
+    "headers": [], 
+    "is_filegroup": false, 
+    "language": "c++", 
+    "name": "cancel_ares_query_test", 
+    "src": [
+      "test/cpp/naming/cancel_ares_query_test.cc"
+    ], 
+    "third_party": false, 
+    "type": "target"
+  }, 
+  {
+    "deps": [
+      "gpr", 
+      "gpr_test_util", 
+      "grpc", 
       "grpc_test_util"
     ], 
     "headers": [], 

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -5596,6 +5596,28 @@
   }, 
   {
     "args": [], 
+    "benchmark": false, 
+    "ci_platforms": [
+      "linux", 
+      "mac", 
+      "posix"
+    ], 
+    "cpu_cost": 1.0, 
+    "exclude_configs": [], 
+    "exclude_iomgrs": [], 
+    "flaky": false, 
+    "gtest": true, 
+    "language": "c++", 
+    "name": "cancel_ares_query_test", 
+    "platforms": [
+      "linux", 
+      "mac", 
+      "posix"
+    ], 
+    "uses_polling": true
+  }, 
+  {
+    "args": [], 
     "boringssl": true, 
     "ci_platforms": [
       "linux", 


### PR DESCRIPTION
Bringing this out of https://github.com/grpc/grpc/pull/15179

This changes the c-ares fd shutdown/destroy logic to use ref counts rather than `shutdown` and `readable/writeable_registered` flags, which makes it simpler to convert to C++ (which in turn simplifies porting to windows). Also adds a test for DNS queries that are cancelled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/15420)
<!-- Reviewable:end -->
