### PR TITLE
Speed up final rsync for windows kokoro builds

### DIFF
--- a/tools/internal_ci/helper_scripts/delete_nonartifacts.sh
+++ b/tools/internal_ci/helper_scripts/delete_nonartifacts.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+# change to grpc repo root
+cd $(dirname $0)/../../..
+
+# After kokoro build finishes, the workspace gets rsync'ed to another machine,
+# from where the artifacts and reports are processed.
+# Especially on Windows, the rsync can take long time, so we cleanup the workspace
+# after finishing each build. We only leave files we want to keep:
+# - reports and artifacts
+# - directory containing the kokoro scripts to prevent deleting a script while being executed.
+time find . -type f -not -iname "*sponge_log.xml" -not -path "./reports/*" -not -path "./artifacts/*" -not -path "./tools/internal_ci/*" -exec rm -f {} +

--- a/tools/internal_ci/helper_scripts/delete_nonartifacts.sh
+++ b/tools/internal_ci/helper_scripts/delete_nonartifacts.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2017 gRPC authors.
+# Copyright 2018 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 set -ex
 
 # change to grpc repo root
-cd $(dirname $0)/../../..
+cd "$(dirname "$0")/../../.."
 
 # After kokoro build finishes, the workspace gets rsync'ed to another machine,
 # from where the artifacts and reports are processed.

--- a/tools/internal_ci/windows/grpc_build_artifacts.bat
+++ b/tools/internal_ci/windows/grpc_build_artifacts.bat
@@ -24,8 +24,9 @@ cd /d %~dp0\..\..\..
 
 call tools/internal_ci/helper_scripts/prepare_build_windows.bat
 
-python tools/run_tests/task_runner.py -f artifact windows -j 4 || goto :error
-goto :EOF
+python tools/run_tests/task_runner.py -f artifact windows -j 4
+set RUNTESTS_EXITCODE=%errorlevel%
 
-:error
-exit /b %errorlevel%
+bash tools/internal_ci/helper_scripts/delete_nonartifacts.sh
+
+exit /b %RUNTESTS_EXITCODE%

--- a/tools/internal_ci/windows/grpc_build_packages.bat
+++ b/tools/internal_ci/windows/grpc_build_packages.bat
@@ -28,8 +28,9 @@ call tools/internal_ci/helper_scripts/prepare_build_windows.bat
 powershell -Command "mv %KOKORO_GFILE_DIR%\github\grpc\artifacts input_artifacts"
 dir input_artifacts
 
-python tools/run_tests/task_runner.py -f package windows -j 4 || goto :error
-goto :EOF
+python tools/run_tests/task_runner.py -f package windows -j 4
+set RUNTESTS_EXITCODE=%errorlevel%
 
-:error
-exit /b %errorlevel%
+bash tools/internal_ci/helper_scripts/delete_nonartifacts.sh
+
+exit /b %RUNTESTS_EXITCODE%

--- a/tools/internal_ci/windows/grpc_distribtests.bat
+++ b/tools/internal_ci/windows/grpc_distribtests.bat
@@ -28,8 +28,9 @@ call tools/internal_ci/helper_scripts/prepare_build_windows.bat
 powershell -Command "mv %KOKORO_GFILE_DIR%\github\grpc\artifacts input_artifacts"
 dir input_artifacts
 
-python tools/run_tests/task_runner.py -f distribtest windows -j 4 || goto :error
-goto :EOF
+python tools/run_tests/task_runner.py -f distribtest windows -j 4
+set RUNTESTS_EXITCODE=%errorlevel%
 
-:error
-exit /b %errorlevel%
+bash tools/internal_ci/helper_scripts/delete_nonartifacts.sh
+
+exit /b %RUNTESTS_EXITCODE%

--- a/tools/internal_ci/windows/grpc_distribtests_standalone.bat
+++ b/tools/internal_ci/windows/grpc_distribtests_standalone.bat
@@ -24,8 +24,9 @@ cd /d %~dp0\..\..\..
 
 call tools/internal_ci/helper_scripts/prepare_build_windows.bat
 
-python tools/run_tests/task_runner.py -f distribtest windows cpp -j 4 || goto :error
-goto :EOF
+python tools/run_tests/task_runner.py -f distribtest windows cpp -j 4
+set RUNTESTS_EXITCODE=%errorlevel%
 
-:error
-exit /b %errorlevel%
+bash tools/internal_ci/helper_scripts/delete_nonartifacts.sh
+
+exit /b %RUNTESTS_EXITCODE%

--- a/tools/internal_ci/windows/grpc_run_tests_matrix.bat
+++ b/tools/internal_ci/windows/grpc_run_tests_matrix.bat
@@ -20,7 +20,6 @@ call tools/internal_ci/helper_scripts/prepare_build_windows.bat
 python tools/run_tests/run_tests_matrix.py %RUN_TESTS_FLAGS%
 set RUNTESTS_EXITCODE=%errorlevel%
 
-@rem Reveal leftover processes that might be left behind by the build
-tasklist /V
+bash tools/internal_ci/helper_scripts/delete_nonartifacts.sh
 
 exit /b %RUNTESTS_EXITCODE%


### PR DESCRIPTION
After kokoro build finishes, the workspace gets rsync'ed to another machine, from where the artifacts and reports are processed.
On Windows, the rsync can take long time (even ~20mins), so we cleanup the workspace after finishing each build and only keep the files we care about.