### PR TITLE
Remove Stats Printing from simple_request

### DIFF
--- a/test/core/end2end/tests/simple_request.cc
+++ b/test/core/end2end/tests/simple_request.cc
@@ -227,10 +227,6 @@ static void simple_request_body(grpc_end2end_test_config config,
 
   grpc_stats_collect(after);
 
-  char* stats = grpc_stats_data_as_json(after);
-  gpr_log(GPR_DEBUG, "%s", stats);
-  gpr_free(stats);
-
   int expected_calls = 1;
   if (config.feature_mask & FEATURE_MASK_SUPPORTS_REQUEST_PROXYING) {
     expected_calls *= 2;


### PR DESCRIPTION
These probably never should have been printed. I find myself commenting it out whenever I use simple_request to iterate on a project.