### PR TITLE
Don't run gcov coverage for Node

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1490,7 +1490,7 @@ else:
     lang_list = args.language
 # We don't support code coverage on some languages
 if 'gcov' in args.config:
-    for bad in ['objc', 'sanity']:
+    for bad in ['grpc-node', 'objc', 'sanity']:
         if bad in lang_list:
             lang_list.remove(bad)
 


### PR DESCRIPTION
the gcov build is broken for Node and given Node now lives in a separate repo, it probably doesn't make sense to support it for gcov anyway.