### PR TITLE
Don't hardcode python2.7 in generate_projects.py script

### DIFF
--- a/tools/buildgen/generate_projects.py
+++ b/tools/buildgen/generate_projects.py
@@ -52,7 +52,7 @@ if not templates:
             templates.append(os.path.join(root, f))
 
 pre_jobs = []
-base_cmd = ['python2.7', 'tools/buildgen/mako_renderer.py']
+base_cmd = [sys.executable, 'tools/buildgen/mako_renderer.py']
 cmd = base_cmd[:]
 for plugin in plugins:
     cmd.append('-p')


### PR DESCRIPTION
Instead, use the same python interpreter for calling the mako renderer
that is currently use (which is sys.executable).

This is useful when trying to run generate_projects.py in a python3
only environment (which is still broken but this is a first step).