### PR TITLE
Fix ObjC GRXBufferedPipe to perform operations one by one

### DIFF
--- a/src/objective-c/RxLibrary/GRXForwardingWriter.m
+++ b/src/objective-c/RxLibrary/GRXForwardingWriter.m
@@ -68,6 +68,10 @@
   [_writeable writeValue:value];
 }
 
+- (void)writeValue:(id)value completionHandler:(void (^)(void))completionHandler {
+    [_writeable writeValue:value completionHandler:completionHandler];
+}
+
 - (void)writesFinishedWithError:(NSError *)errorOrNil {
   _writer = nil;
   [self finishOutputWithError:errorOrNil];

--- a/src/objective-c/RxLibrary/GRXWriteable.h
+++ b/src/objective-c/RxLibrary/GRXWriteable.h
@@ -27,6 +27,9 @@
 /** Push the next value of the sequence to the receiving object. */
 - (void)writeValue:(id)value;
 
+/** Push the next value of the sequence to the receiving object with completionHandler. */
+- (void)writeValue:(id)value completionHandler:(void (^)(void))completionHandler;
+
 /**
  * Signal that the sequence is completed, or that an error ocurred. After this
  * message is sent to the instance, neither it nor writeValue: may be

--- a/src/objective-c/RxLibrary/GRXWriteable.m
+++ b/src/objective-c/RxLibrary/GRXWriteable.m
@@ -98,6 +98,15 @@
   }
 }
 
+- (void)writeValue:(id)value completionHandler:(void (^)(void))completionHandler {
+  if (_valueHandler) {
+    _valueHandler(value);
+  }
+  if (completionHandler) {
+    completionHandler();
+  }
+}
+
 - (void)writesFinishedWithError:(NSError *)errorOrNil {
   if (_completionHandler) {
     _completionHandler(errorOrNil);

--- a/src/objective-c/RxLibrary/transformations/GRXMappingWriter.m
+++ b/src/objective-c/RxLibrary/transformations/GRXMappingWriter.m
@@ -43,4 +43,8 @@
 - (void)writeValue:(id)value {
   [super writeValue:_map(value)];
 }
+
+- (void)writeValue:(id)value completionHandler:(void (^)(void))completionHandler {
+  [super writeValue:_map(value) completionHandler:completionHandler];
+}
 @end


### PR DESCRIPTION
grpc_call allows only one operation by each op type. Otherwise, grpc_call will raise an error.
To avoid the error, use a queue and completion handler to perform operations one by one.