### PR TITLE
PHP: add php-cs-fixer config and apply php-cs-fixer

### DIFF
--- a/src/php/.gitignore
+++ b/src/php/.gitignore
@@ -23,3 +23,5 @@ vendor/
 
 *.pb.php
 *_grpc_pb.php
+
+*.php_cs.cache

--- a/src/php/.php_cs.dist
+++ b/src/php/.php_cs.dist
@@ -1,0 +1,19 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->exclude('bin')
+    ->exclude('ext')
+    ->exclude('tests/data')
+    ->exclude('tests/qps/generated_code')
+    ->in(__DIR__)
+;
+
+return PhpCsFixer\Config::create()
+    ->setUsingCache(false)
+    ->setRules([
+        '@Symfony' => true,
+        'phpdoc_no_package' => false,
+        'yoda_style' => false,
+    ])
+    ->setFinder($finder)
+;

--- a/src/php/bin/run_php_cs_fixer.sh
+++ b/src/php/bin/run_php_cs_fixer.sh
@@ -19,7 +19,4 @@ command -v php-cs-fixer > /dev/null || {
   exit 1
 }
 cd $(dirname $0)/..
-php-cs-fixer fix lib/Grpc || true
-php-cs-fixer fix tests/generated_code || true
-php-cs-fixer fix tests/interop || true
-php-cs-fixer fix tests/unit_tests || true
+php-cs-fixer fix || true

--- a/src/php/lib/Grpc/AbstractCall.php
+++ b/src/php/lib/Grpc/AbstractCall.php
@@ -21,6 +21,7 @@ namespace Grpc;
 
 /**
  * Class AbstractCall.
+ *
  * @package Grpc
  */
 abstract class AbstractCall
@@ -39,7 +40,7 @@ abstract class AbstractCall
      * @param Channel  $channel     The channel to communicate on
      * @param string   $method      The method to call on the
      *                              remote server
-     * @param callback $deserialize A callback function to deserialize
+     * @param callable $deserialize A callback function to deserialize
      *                              the response
      * @param array    $options     Call options (optional)
      */

--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -33,12 +33,12 @@ class BaseStub
     private $update_metadata;
 
     /**
-     * @param string  $hostname
-     * @param array   $opts
-     *  - 'update_metadata': (optional) a callback function which takes in a
-     * metadata array, and returns an updated metadata array
-     *  - 'grpc.primary_user_agent': (optional) a user-agent string
-     * @param Channel|InterceptorChannel $channel An already created Channel or InterceptorChannel object (optional)
+     * @param string                     $hostname
+     * @param array                      $opts
+     *                                             - 'update_metadata': (optional) a callback function which takes in a
+     *                                             metadata array, and returns an updated metadata array
+     *                                             - 'grpc.primary_user_agent': (optional) a user-agent string
+     * @param Channel|InterceptorChannel $channel  An already created Channel or InterceptorChannel object (optional)
      */
     public function __construct($hostname, $opts, $channel = null)
     {
@@ -66,6 +66,7 @@ class BaseStub
                     'Interceptor::intercept($channel, Interceptor|Interceptor[] $interceptors)');
             }
             $this->channel = $channel;
+
             return;
         }
 
@@ -73,7 +74,7 @@ class BaseStub
     }
 
     /**
-     * Creates and returns the default Channel
+     * Creates and returns the default Channel.
      *
      * @param array $opts Channel constructor options
      *
@@ -97,6 +98,7 @@ class BaseStub
                 'required. Please see one of the '.
                 'ChannelCredentials::create methods');
         }
+
         return new Channel($hostname, $opts);
     }
 
@@ -225,10 +227,10 @@ class BaseStub
     }
 
     /**
-     * Create a function which can be used to create UnaryCall
+     * Create a function which can be used to create UnaryCall.
      *
-     * @param Channel|InterceptorChannel   $channel
-     * @param callable $deserialize A function that deserializes the response
+     * @param Channel|InterceptorChannel $channel
+     * @param callable                   $deserialize A function that deserializes the response
      *
      * @return \Closure
      */
@@ -256,15 +258,16 @@ class BaseStub
                 $metadata
             );
             $call->start($argument, $metadata, $options);
+
             return $call;
         };
     }
 
     /**
-     * Create a function which can be used to create ServerStreamingCall
+     * Create a function which can be used to create ServerStreamingCall.
      *
-     * @param Channel|InterceptorChannel   $channel
-     * @param callable $deserialize A function that deserializes the response
+     * @param Channel|InterceptorChannel $channel
+     * @param callable                   $deserialize A function that deserializes the response
      *
      * @return \Closure
      */
@@ -291,15 +294,16 @@ class BaseStub
                 $metadata
             );
             $call->start($metadata);
+
             return $call;
         };
     }
 
     /**
-     * Create a function which can be used to create ClientStreamingCall
+     * Create a function which can be used to create ClientStreamingCall.
      *
-     * @param Channel|InterceptorChannel   $channel
-     * @param callable $deserialize A function that deserializes the response
+     * @param Channel|InterceptorChannel $channel
+     * @param callable                   $deserialize A function that deserializes the response
      *
      * @return \Closure
      */
@@ -327,15 +331,16 @@ class BaseStub
                 $metadata
             );
             $call->start($argument, $metadata, $options);
+
             return $call;
         };
     }
 
     /**
-     * Create a function which can be used to create BidiStreamingCall
+     * Create a function which can be used to create BidiStreamingCall.
      *
-     * @param Channel|InterceptorChannel   $channel
-     * @param callable $deserialize A function that deserializes the response
+     * @param Channel|InterceptorChannel $channel
+     * @param callable                   $deserialize A function that deserializes the response
      *
      * @return \Closure
      */
@@ -368,10 +373,10 @@ class BaseStub
     }
 
     /**
-     * Create a function which can be used to create UnaryCall
+     * Create a function which can be used to create UnaryCall.
      *
-     * @param Channel|InterceptorChannel   $channel
-     * @param callable $deserialize A function that deserializes the response
+     * @param Channel|InterceptorChannel $channel
+     * @param callable                   $deserialize A function that deserializes the response
      *
      * @return \Closure
      */
@@ -391,14 +396,15 @@ class BaseStub
                 );
             };
         }
+
         return $this->_GrpcUnaryUnary($channel, $deserialize);
     }
 
     /**
-     * Create a function which can be used to create ServerStreamingCall
+     * Create a function which can be used to create ServerStreamingCall.
      *
-     * @param Channel|InterceptorChannel   $channel
-     * @param callable $deserialize A function that deserializes the response
+     * @param Channel|InterceptorChannel $channel
+     * @param callable                   $deserialize A function that deserializes the response
      *
      * @return \Closure
      */
@@ -418,14 +424,15 @@ class BaseStub
                 );
             };
         }
+
         return $this->_GrpcUnaryStream($channel, $deserialize);
     }
 
     /**
-     * Create a function which can be used to create ClientStreamingCall
+     * Create a function which can be used to create ClientStreamingCall.
      *
-     * @param Channel|InterceptorChannel   $channel
-     * @param callable $deserialize A function that deserializes the response
+     * @param Channel|InterceptorChannel $channel
+     * @param callable                   $deserialize A function that deserializes the response
      *
      * @return \Closure
      */
@@ -443,14 +450,15 @@ class BaseStub
                 );
             };
         }
+
         return $this->_GrpcStreamUnary($channel, $deserialize);
     }
 
     /**
-     * Create a function which can be used to create BidiStreamingCall
+     * Create a function which can be used to create BidiStreamingCall.
      *
-     * @param Channel|InterceptorChannel   $channel
-     * @param callable $deserialize A function that deserializes the response
+     * @param Channel|InterceptorChannel $channel
+     * @param callable                   $deserialize A function that deserializes the response
      *
      * @return \Closure
      */
@@ -468,11 +476,13 @@ class BaseStub
                 );
             };
         }
+
         return $this->_GrpcStreamStream($channel, $deserialize);
     }
 
     /* This class is intended to be subclassed by generated code, so
      * all functions begin with "_" to avoid name collisions. */
+
     /**
      * Call a remote method that takes a single argument and has a
      * single output.
@@ -495,6 +505,7 @@ class BaseStub
     ) {
         $call_factory = $this->_UnaryUnaryCallFactory($this->channel, $deserialize);
         $call = $call_factory($method, $argument, $metadata, $options);
+
         return $call;
     }
 
@@ -518,6 +529,7 @@ class BaseStub
     ) {
         $call_factory = $this->_StreamUnaryCallFactory($this->channel, $deserialize);
         $call = $call_factory($method, $metadata, $options);
+
         return $call;
     }
 
@@ -543,6 +555,7 @@ class BaseStub
     ) {
         $call_factory = $this->_UnaryStreamCallFactory($this->channel, $deserialize);
         $call = $call_factory($method, $argument, $metadata, $options);
+
         return $call;
     }
 
@@ -565,6 +578,7 @@ class BaseStub
     ) {
         $call_factory = $this->_StreamStreamCallFactory($this->channel, $deserialize);
         $call = $call_factory($method, $metadata, $options);
+
         return $call;
     }
 }

--- a/src/php/lib/Grpc/Interceptor.php
+++ b/src/php/lib/Grpc/Interceptor.php
@@ -64,23 +64,23 @@ class Interceptor
     }
 
     /**
-     * Intercept the methods with Channel
+     * Intercept the methods with Channel.
      *
-     * @param Channel|InterceptorChannel $channel An already created Channel or InterceptorChannel object (optional)
-     * @param Interceptor|Interceptor[] $interceptors interceptors to be added
+     * @param Channel|InterceptorChannel $channel      An already created Channel or InterceptorChannel object (optional)
+     * @param Interceptor|Interceptor[]  $interceptors interceptors to be added
      *
      * @return InterceptorChannel
      */
     public static function intercept($channel, $interceptors)
     {
         if (is_array($interceptors)) {
-            for ($i = count($interceptors) - 1; $i >= 0; $i--) {
+            for ($i = count($interceptors) - 1; $i >= 0; --$i) {
                 $channel = new Internal\InterceptorChannel($channel, $interceptors[$i]);
             }
         } else {
-            $channel =  new Internal\InterceptorChannel($channel, $interceptors);
+            $channel = new Internal\InterceptorChannel($channel, $interceptors);
         }
+
         return $channel;
     }
 }
-

--- a/src/php/lib/Grpc/Internal/InterceptorChannel.php
+++ b/src/php/lib/Grpc/Internal/InterceptorChannel.php
@@ -28,9 +28,9 @@ class InterceptorChannel extends \Grpc\Channel
     private $interceptor;
 
     /**
-     * @param Channel|InterceptorChannel $channel An already created Channel
-     * or InterceptorChannel object (optional)
-     * @param Interceptor  $interceptor
+     * @param Channel|InterceptorChannel $channel     An already created Channel
+     *                                                or InterceptorChannel object (optional)
+     * @param Interceptor                $interceptor
      */
     public function __construct($channel, $interceptor)
     {

--- a/src/php/lib/Grpc/ServerStreamingCall.php
+++ b/src/php/lib/Grpc/ServerStreamingCall.php
@@ -95,6 +95,7 @@ class ServerStreamingCall extends AbstractCall
             $event = $this->call->startBatch([OP_RECV_INITIAL_METADATA => true]);
             $this->metadata = $event->metadata;
         }
+
         return $this->metadata;
     }
 }

--- a/src/php/lib/Grpc/UnaryCall.php
+++ b/src/php/lib/Grpc/UnaryCall.php
@@ -80,6 +80,7 @@ class UnaryCall extends AbstractCall
             $event = $this->call->startBatch([OP_RECV_INITIAL_METADATA => true]);
             $this->metadata = $event->metadata;
         }
+
         return $this->metadata;
     }
 }

--- a/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
+++ b/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
@@ -53,7 +53,7 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testClose()
     {
@@ -63,7 +63,7 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidMetadata()
     {
@@ -124,7 +124,7 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidMethodName()
     {
@@ -136,7 +136,7 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testMissingCredentials()
     {
@@ -221,8 +221,8 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(is_string($call->getPeer()));
         $result_array = iterator_to_array($call->responses());
         $extract_num = function ($num) {
-                         return $num->getNum();
-                       };
+            return $num->getNum();
+        };
         $values = array_map($extract_num, $result_array);
         $this->assertSame([1, 1, 2, 3, 5, 8, 13], $values);
         $status = $call->getStatus();

--- a/src/php/tests/generated_code/GeneratedCodeWithCallbackTest.php
+++ b/src/php/tests/generated_code/GeneratedCodeWithCallbackTest.php
@@ -27,11 +27,11 @@ class GeneratedCodeWithCallbackTest extends AbstractGeneratedCodeTest
         ['credentials' => Grpc\ChannelCredentials::createInsecure(),
          'update_metadata' => function ($a_hash,
                                         $client = []) {
-                                $a_copy = $a_hash;
-                                $a_copy['foo'] = ['bar'];
+             $a_copy = $a_hash;
+             $a_copy['foo'] = ['bar'];
 
-                                return $a_copy;
-                              },
+             return $a_copy;
+         },
          ]);
     }
 

--- a/src/php/tests/generated_code/math_client.php
+++ b/src/php/tests/generated_code/math_client.php
@@ -17,9 +17,9 @@
  *
  */
 
-# Fix the following line to point to your installation
-# This assumes that you are using protoc 3.2.0+ and the generated stubs
-# were being autoloaded via composer.
+// Fix the following line to point to your installation
+// This assumes that you are using protoc 3.2.0+ and the generated stubs
+// were being autoloaded via composer.
 include 'vendor/autoload.php';
 
 function p($line)

--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -259,7 +259,7 @@ function clientStreaming($stub)
 /**
  * Run the server_streaming test.
  *
- * @param $stub Stub object that has service methods.
+ * @param $stub stub object that has service methods
  */
 function serverStreaming($stub)
 {
@@ -283,7 +283,7 @@ function serverStreaming($stub)
             'Payload '.$i.' had the wrong type');
         hardAssert(strlen($payload->getBody()) === $sizes[$i],
                    'Response '.$i.' had the wrong length');
-        $i += 1;
+        ++$i;
     }
     hardAssertIfStatusOk($call->getStatus());
 }
@@ -291,7 +291,7 @@ function serverStreaming($stub)
 /**
  * Run the ping_pong test.
  *
- * @param $stub Stub object that has service methods.
+ * @param $stub stub object that has service methods
  */
 function pingPong($stub)
 {
@@ -328,7 +328,7 @@ function pingPong($stub)
 /**
  * Run the empty_stream test.
  *
- * @param $stub Stub object that has service methods.
+ * @param $stub stub object that has service methods
  */
 function emptyStream($stub)
 {
@@ -341,7 +341,7 @@ function emptyStream($stub)
 /**
  * Run the cancel_after_begin test.
  *
- * @param $stub Stub object that has service methods.
+ * @param $stub stub object that has service methods
  */
 function cancelAfterBegin($stub)
 {
@@ -355,7 +355,7 @@ function cancelAfterBegin($stub)
 /**
  * Run the cancel_after_first_response test.
  *
- * @param $stub Stub object that has service methods.
+ * @param $stub stub object that has service methods
  */
 function cancelAfterFirstResponse($stub)
 {
@@ -500,7 +500,7 @@ function statusCodeAndMessage($stub)
                $status->details);
 }
 
-# NOTE: the stub input to this function is from UnimplementedService
+// NOTE: the stub input to this function is from UnimplementedService
 function unimplementedService($stub)
 {
     $call = $stub->UnimplementedCall(new Grpc\Testing\EmptyMessage());
@@ -509,7 +509,7 @@ function unimplementedService($stub)
                'Received unexpected status code');
 }
 
-# NOTE: the stub input to this function is from TestService
+// NOTE: the stub input to this function is from TestService
 function unimplementedMethod($stub)
 {
     $call = $stub->UnimplementedCall(new Grpc\Testing\EmptyMessage());

--- a/src/php/tests/qps/histogram.php
+++ b/src/php/tests/qps/histogram.php
@@ -18,76 +18,87 @@
  */
 
 // Histogram class for use in performance testing and measurement
-class Histogram {
-  private $resolution;
-  private $max_possible;
-  private $sum;
-  private $sum_of_squares;
-  private $multiplier;
-  private $count;
-  private $min_seen;
-  private $max_seen;
-  private $buckets;
+class Histogram
+{
+    private $resolution;
+    private $max_possible;
+    private $sum;
+    private $sum_of_squares;
+    private $multiplier;
+    private $count;
+    private $min_seen;
+    private $max_seen;
+    private $buckets;
 
-  private function bucket_for($value) {
-    return (int)(log($value) / log($this->multiplier));
-  }
-
-  public function __construct($resolution, $max_possible) {
-    $this->resolution = $resolution;
-    $this->max_possible = $max_possible;
-    $this->sum = 0;
-    $this->sum_of_squares = 0;
-    $this->multiplier = 1+$resolution;
-    $this->count = 0;
-    $this->min_seen = $max_possible;
-    $this->max_seen = 0;
-    $this->buckets = array_fill(0, $this->bucket_for($max_possible)+1, 0);
-  }
-
-  public function add($value) {
-    $this->sum += $value;
-    $this->sum_of_squares += $value * $value;
-    $this->count += 1;
-    if ($value < $this->min_seen) {
-      $this->min_seen = $value;
+    private function bucket_for($value)
+    {
+        return (int) (log($value) / log($this->multiplier));
     }
-    if ($value > $this->max_seen) {
-      $this->max_seen = $value;
+
+    public function __construct($resolution, $max_possible)
+    {
+        $this->resolution = $resolution;
+        $this->max_possible = $max_possible;
+        $this->sum = 0;
+        $this->sum_of_squares = 0;
+        $this->multiplier = 1 + $resolution;
+        $this->count = 0;
+        $this->min_seen = $max_possible;
+        $this->max_seen = 0;
+        $this->buckets = array_fill(0, $this->bucket_for($max_possible) + 1, 0);
     }
-    $this->buckets[$this->bucket_for($value)] += 1;
-  }
 
-  public function minimum() {
-    return $this->min_seen;
-  }
+    public function add($value)
+    {
+        $this->sum += $value;
+        $this->sum_of_squares += $value * $value;
+        ++$this->count;
+        if ($value < $this->min_seen) {
+            $this->min_seen = $value;
+        }
+        if ($value > $this->max_seen) {
+            $this->max_seen = $value;
+        }
+        ++$this->buckets[$this->bucket_for($value)];
+    }
 
-  public function maximum() {
-    return $this->max_seen;
-  }
+    public function minimum()
+    {
+        return $this->min_seen;
+    }
 
-  public function sum() {
-    return $this->sum;
-  }
+    public function maximum()
+    {
+        return $this->max_seen;
+    }
 
-  public function sum_of_squares() {
-    return $this->sum_of_squares;
-  }
+    public function sum()
+    {
+        return $this->sum;
+    }
 
-  public function count() {
-    return $this->count;
-  }
+    public function sum_of_squares()
+    {
+        return $this->sum_of_squares;
+    }
 
-  public function contents() {
-    return $this->buckets;
-  }
+    public function count()
+    {
+        return $this->count;
+    }
 
-  public function clean() {
-    $this->sum = 0;
-    $this->sum_of_squares = 0;
-    $this->count = 0;
-    $this->min_seen = $this->max_possible;
-    $this->max_seen = 0;
-    $this->buckets = array_fill(0, $this->bucket_for($this->max_possible)+1, 0);
-  }
+    public function contents()
+    {
+        return $this->buckets;
+    }
+
+    public function clean()
+    {
+        $this->sum = 0;
+        $this->sum_of_squares = 0;
+        $this->count = 0;
+        $this->min_seen = $this->max_possible;
+        $this->max_seen = 0;
+        $this->buckets = array_fill(0, $this->bucket_for($this->max_possible) + 1, 0);
+    }
 }

--- a/src/php/tests/unit_tests/CallCredentialsTest.php
+++ b/src/php/tests/unit_tests/CallCredentialsTest.php
@@ -138,7 +138,7 @@ class CallCredentialsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testCreateFromPluginInvalidParam()
     {
@@ -148,7 +148,7 @@ class CallCredentialsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testCreateCompositeInvalidParam()
     {

--- a/src/php/tests/unit_tests/CallTest.php
+++ b/src/php/tests/unit_tests/CallTest.php
@@ -95,7 +95,7 @@ class CallTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidStartBatchKey()
     {
@@ -106,7 +106,7 @@ class CallTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidMetadataStrKey()
     {
@@ -117,7 +117,7 @@ class CallTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidMetadataIntKey()
     {
@@ -128,7 +128,7 @@ class CallTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidMetadataInnerValue()
     {
@@ -139,7 +139,7 @@ class CallTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidConstuctor()
     {
@@ -148,7 +148,7 @@ class CallTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidConstuctor2()
     {
@@ -157,7 +157,7 @@ class CallTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidSetCredentials()
     {
@@ -165,7 +165,7 @@ class CallTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidSetCredentials2()
     {

--- a/src/php/tests/unit_tests/ChannelCredentialsTest.php
+++ b/src/php/tests/unit_tests/ChannelCredentialsTest.php
@@ -47,7 +47,7 @@ class ChanellCredentialsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidCreateSsl()
     {
@@ -55,7 +55,7 @@ class ChanellCredentialsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidCreateComposite()
     {

--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -82,7 +82,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->channel = new Grpc\Channel('localhost:50006',
              ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $now = Grpc\Timeval::now();
-        $deadline = $now->add(new Grpc\Timeval(100*1000));  // 100ms
+        $deadline = $now->add(new Grpc\Timeval(100 * 1000));  // 100ms
         // we act as if 'CONNECTING'(=1) was the last state
         // we saw, so the default state of 'IDLE' should be delivered instantly
         $state = $this->channel->watchConnectivityState(1, $deadline);
@@ -100,7 +100,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidConstructorWithNull()
     {
@@ -109,7 +109,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidConstructorWith()
     {
@@ -118,7 +118,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidCredentials()
     {
@@ -127,7 +127,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidOptionsArray()
     {
@@ -136,7 +136,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidGetConnectivityStateWithArray()
     {
@@ -146,7 +146,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidWatchConnectivityState()
     {
@@ -156,7 +156,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidWatchConnectivityState2()
     {
@@ -165,14 +165,15 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->channel->watchConnectivityState(1, 'hi');
     }
 
-
-    public function assertConnecting($state) {
-      $this->assertTrue($state == GRPC\CHANNEL_CONNECTING ||
+    public function assertConnecting($state)
+    {
+        $this->assertTrue($state == GRPC\CHANNEL_CONNECTING ||
                         $state == GRPC\CHANNEL_TRANSIENT_FAILURE);
     }
 
-    public function waitUntilNotIdle($channel) {
-        for ($i = 0; $i < 10; $i++) {
+    public function waitUntilNotIdle($channel)
+    {
+        for ($i = 0; $i < 10; ++$i) {
             $now = Grpc\Timeval::now();
             $deadline = $now->add(new Grpc\Timeval(1000));
             if ($channel->watchConnectivityState(GRPC\CHANNEL_IDLE,
@@ -186,7 +187,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     public function testPersistentChannelSameHost()
     {
         $this->channel1 = new Grpc\Channel('localhost:50014', [
-            "grpc_target_persist_bound" => 3,
+            'grpc_target_persist_bound' => 3,
         ]);
         // the underlying grpc channel is the same by default
         // when connecting to the same host
@@ -216,7 +217,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     {
         // two different underlying channels because different hostname
         $this->channel1 = new Grpc\Channel('localhost:50015', [
-            "grpc_target_persist_bound" => 3,
+            'grpc_target_persist_bound' => 3,
         ]);
         $this->channel2 = new Grpc\Channel('localhost:50016', []);
 
@@ -244,10 +245,10 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     public function testPersistentChannelSameArgs()
     {
         $this->channel1 = new Grpc\Channel('localhost:50017', [
-          "grpc_target_persist_bound" => 3,
-          "abc" => "def",
+          'grpc_target_persist_bound' => 3,
+          'abc' => 'def',
           ]);
-        $this->channel2 = new Grpc\Channel('localhost:50017', ["abc" => "def"]);
+        $this->channel2 = new Grpc\Channel('localhost:50017', ['abc' => 'def']);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -265,9 +266,9 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     public function testPersistentChannelDifferentArgs()
     {
         $this->channel1 = new Grpc\Channel('localhost:50018', [
-            "grpc_target_persist_bound" => 3,
+            'grpc_target_persist_bound' => 3,
           ]);
-        $this->channel2 = new Grpc\Channel('localhost:50018', ["abc" => "def"]);
+        $this->channel2 = new Grpc\Channel('localhost:50018', ['abc' => 'def']);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -288,11 +289,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $creds2 = Grpc\ChannelCredentials::createSsl();
 
         $this->channel1 = new Grpc\Channel('localhost:50019',
-                                           ["credentials" => $creds1,
-                                             "grpc_target_persist_bound" => 3,
+                                           ['credentials' => $creds1,
+                                             'grpc_target_persist_bound' => 3,
                                              ]);
         $this->channel2 = new Grpc\Channel('localhost:50019',
-                                           ["credentials" => $creds2]);
+                                           ['credentials' => $creds2]);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -314,11 +315,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
             file_get_contents(dirname(__FILE__).'/../data/ca.pem'));
 
         $this->channel1 = new Grpc\Channel('localhost:50020',
-                                           ["credentials" => $creds1,
-                                             "grpc_target_persist_bound" => 3,
+                                           ['credentials' => $creds1,
+                                             'grpc_target_persist_bound' => 3,
                                              ]);
         $this->channel2 = new Grpc\Channel('localhost:50020',
-                                           ["credentials" => $creds2]);
+                                           ['credentials' => $creds2]);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -341,11 +342,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
             file_get_contents(dirname(__FILE__).'/../data/ca.pem'));
 
         $this->channel1 = new Grpc\Channel('localhost:50021',
-                                           ["credentials" => $creds1,
-                                             "grpc_target_persist_bound" => 3,
+                                           ['credentials' => $creds1,
+                                             'grpc_target_persist_bound' => 3,
                                              ]);
         $this->channel2 = new Grpc\Channel('localhost:50021',
-                                           ["credentials" => $creds2]);
+                                           ['credentials' => $creds2]);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -366,11 +367,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $creds2 = Grpc\ChannelCredentials::createInsecure();
 
         $this->channel1 = new Grpc\Channel('localhost:50022',
-                                           ["credentials" => $creds1,
-                                             "grpc_target_persist_bound" => 3,
+                                           ['credentials' => $creds1,
+                                             'grpc_target_persist_bound' => 3,
                                              ]);
         $this->channel2 = new Grpc\Channel('localhost:50022',
-                                           ["credentials" => $creds2]);
+                                           ['credentials' => $creds2]);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -389,7 +390,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     {
         // same underlying channel
         $this->channel1 = new Grpc\Channel('localhost:50123', [
-            "grpc_target_persist_bound" => 3,
+            'grpc_target_persist_bound' => 3,
         ]);
         $this->channel2 = new Grpc\Channel('localhost:50123', []);
 
@@ -404,13 +405,13 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      */
     public function testPersistentChannelSharedChannelClose2()
     {
         // same underlying channel
         $this->channel1 = new Grpc\Channel('localhost:50223', [
-            "grpc_target_persist_bound" => 3,
+            'grpc_target_persist_bound' => 3,
         ]);
         $this->channel2 = new Grpc\Channel('localhost:50223', []);
 
@@ -428,7 +429,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     public function testPersistentChannelCreateAfterClose()
     {
         $this->channel1 = new Grpc\Channel('localhost:50024', [
-            "grpc_target_persist_bound" => 3,
+            'grpc_target_persist_bound' => 3,
         ]);
 
         $this->channel1->close();
@@ -443,7 +444,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     public function testPersistentChannelSharedMoreThanTwo()
     {
         $this->channel1 = new Grpc\Channel('localhost:50025', [
-            "grpc_target_persist_bound" => 3,
+            'grpc_target_persist_bound' => 3,
         ]);
         $this->channel2 = new Grpc\Channel('localhost:50025', []);
         $this->channel3 = new Grpc\Channel('localhost:50025', []);
@@ -470,7 +471,7 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function callbackFunc2($context)
     {
-        return ["k1" => "v1"];
+        return ['k1' => 'v1'];
     }
 
     public function testPersistentChannelWithCallCredentials()
@@ -485,13 +486,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         // CallCredentials object, the underlying grpc channel will
         // always be created new and NOT persisted.
         $this->channel1 = new Grpc\Channel('localhost:50026',
-                                           ["credentials" =>
-                                            $credsWithCallCreds,
-                                            "grpc_target_persist_bound" => 3,
+                                           ['credentials' => $credsWithCallCreds,
+                                            'grpc_target_persist_bound' => 3,
                                             ]);
         $this->channel2 = new Grpc\Channel('localhost:50026',
-                                           ["credentials" =>
-                                            $credsWithCallCreds]);
+                                           ['credentials' => $credsWithCallCreds]);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -524,13 +523,13 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         // underlying grpc channel will always be separate and not
         // persisted
         $this->channel1 = new Grpc\Channel('localhost:50027',
-                                           ["credentials" => $creds1,
-                                            "grpc_target_persist_bound" => 3,
+                                           ['credentials' => $creds1,
+                                            'grpc_target_persist_bound' => 3,
                                             ]);
         $this->channel2 = new Grpc\Channel('localhost:50027',
-                                           ["credentials" => $creds2]);
+                                           ['credentials' => $creds2]);
         $this->channel3 = new Grpc\Channel('localhost:50027',
-                                           ["credentials" => $creds3]);
+                                           ['credentials' => $creds3]);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -551,12 +550,12 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     public function testPersistentChannelForceNew()
     {
         $this->channel1 = new Grpc\Channel('localhost:50028', [
-            "grpc_target_persist_bound" => 2,
+            'grpc_target_persist_bound' => 2,
         ]);
         // even though all the channel params are the same, channel2
         // has a new and different underlying channel
         $this->channel2 = new Grpc\Channel('localhost:50028',
-                                           ["force_new" => true]);
+                                           ['force_new' => true]);
 
         // try to connect on channel1
         $state = $this->channel1->getConnectivityState(true);
@@ -573,12 +572,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testPersistentChannelForceNewOldChannelIdle1()
     {
-
         $this->channel1 = new Grpc\Channel('localhost:50029', [
-            "grpc_target_persist_bound" => 2,
+            'grpc_target_persist_bound' => 2,
         ]);
         $this->channel2 = new Grpc\Channel('localhost:50029',
-                                           ["force_new" => true]);
+                                           ['force_new' => true]);
         // channel3 shares with channel1
         $this->channel3 = new Grpc\Channel('localhost:50029', []);
 
@@ -598,9 +596,8 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testPersistentChannelForceNewOldChannelIdle2()
     {
-
         $this->channel1 = new Grpc\Channel('localhost:50029', [
-            "grpc_target_persist_bound" => 2,
+            'grpc_target_persist_bound' => 2,
         ]);
         $this->channel2 = new Grpc\Channel('localhost:50029', []);
 
@@ -618,12 +615,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testPersistentChannelForceNewOldChannelClose1()
     {
-
         $this->channel1 = new Grpc\Channel('localhost:50130', [
-            "grpc_target_persist_bound" => 2,
+            'grpc_target_persist_bound' => 2,
         ]);
         $this->channel2 = new Grpc\Channel('localhost:50130',
-                                           ["force_new" => true]);
+                                           ['force_new' => true]);
         // channel3 shares with channel1
         $this->channel3 = new Grpc\Channel('localhost:50130', []);
 
@@ -640,16 +636,15 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * @expectedException \RuntimeException
      */
     public function testPersistentChannelForceNewOldChannelClose2()
     {
-
         $this->channel1 = new Grpc\Channel('localhost:50230', [
-            "grpc_target_persist_bound" => 2,
+            'grpc_target_persist_bound' => 2,
         ]);
         $this->channel2 = new Grpc\Channel('localhost:50230',
-          ["force_new" => true]);
+          ['force_new' => true]);
         // channel3 shares with channel1
         $this->channel3 = new Grpc\Channel('localhost:50230', []);
 
@@ -668,12 +663,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testPersistentChannelForceNewNewChannelClose()
     {
-
         $this->channel1 = new Grpc\Channel('localhost:50031', [
-            "grpc_target_persist_bound" => 2,
+            'grpc_target_persist_bound' => 2,
         ]);
         $this->channel2 = new Grpc\Channel('localhost:50031',
-                                           ["force_new" => true]);
+                                           ['force_new' => true]);
         $this->channel3 = new Grpc\Channel('localhost:50031', []);
 
         $this->channel2->close();

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -186,7 +186,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidClientMessageArray()
     {
@@ -207,7 +207,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidClientMessageString()
     {
@@ -228,7 +228,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidClientMessageFlags()
     {
@@ -251,7 +251,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidServerStatusMetadata()
     {
@@ -292,7 +292,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidServerStatusCode()
     {
@@ -333,7 +333,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testMissingServerStatusCode()
     {
@@ -373,7 +373,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidServerStatusDetails()
     {
@@ -414,7 +414,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testMissingServerStatusDetails()
     {
@@ -454,7 +454,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidStartBatchKey()
     {
@@ -473,7 +473,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException LogicException
+     * @expectedException \LogicException
      */
     public function testInvalidStartBatch()
     {
@@ -555,7 +555,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testGetConnectivityStateInvalidParam()
     {
@@ -564,7 +564,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testWatchConnectivityStateInvalidParam()
     {
@@ -573,7 +573,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testChannelConstructorInvalidParam()
     {

--- a/src/php/tests/unit_tests/InterceptorTest.php
+++ b/src/php/tests/unit_tests/InterceptorTest.php
@@ -19,24 +19,27 @@
 /**
  * Interface exported by the server.
  */
-require_once(dirname(__FILE__).'/../../lib/Grpc/BaseStub.php');
-require_once(dirname(__FILE__).'/../../lib/Grpc/AbstractCall.php');
-require_once(dirname(__FILE__).'/../../lib/Grpc/UnaryCall.php');
-require_once(dirname(__FILE__).'/../../lib/Grpc/ClientStreamingCall.php');
-require_once(dirname(__FILE__).'/../../lib/Grpc/Interceptor.php');
-require_once(dirname(__FILE__).'/../../lib/Grpc/Internal/InterceptorChannel.php');
+require_once dirname(__FILE__).'/../../lib/Grpc/BaseStub.php';
+require_once dirname(__FILE__).'/../../lib/Grpc/AbstractCall.php';
+require_once dirname(__FILE__).'/../../lib/Grpc/UnaryCall.php';
+require_once dirname(__FILE__).'/../../lib/Grpc/ClientStreamingCall.php';
+require_once dirname(__FILE__).'/../../lib/Grpc/Interceptor.php';
+require_once dirname(__FILE__).'/../../lib/Grpc/Internal/InterceptorChannel.php';
 
 class SimpleRequest
 {
     private $data;
+
     public function __construct($data)
     {
         $this->data = $data;
     }
+
     public function setData($data)
     {
         $this->data = $data;
     }
+
     public function serializeToString()
     {
         return $this->data;
@@ -45,11 +48,10 @@ class SimpleRequest
 
 class InterceptorClient extends Grpc\BaseStub
 {
-
     /**
-     * @param string $hostname hostname
-     * @param array $opts channel options
-     * @param Channel|InterceptorChannel $channel (optional) re-use channel object
+     * @param string                     $hostname hostname
+     * @param array                      $opts     channel options
+     * @param Channel|InterceptorChannel $channel  (optional) re-use channel object
      */
     public function __construct($hostname, $opts, $channel = null)
     {
@@ -58,9 +60,10 @@ class InterceptorClient extends Grpc\BaseStub
 
     /**
      * A simple RPC.
+     *
      * @param SimpleRequest $argument input argument
-     * @param array $metadata metadata
-     * @param array $options call options
+     * @param array         $metadata metadata
+     * @param array         $options  call options
      */
     public function UnaryCall(
         SimpleRequest $argument,
@@ -78,8 +81,9 @@ class InterceptorClient extends Grpc\BaseStub
 
     /**
      * A client-to-server streaming RPC.
+     *
      * @param array $metadata metadata
-     * @param array $options call options
+     * @param array $options  call options
      */
     public function StreamCall(
         $metadata = [],
@@ -89,7 +93,6 @@ class InterceptorClient extends Grpc\BaseStub
     }
 }
 
-
 class ChangeMetadataInterceptor extends Grpc\Interceptor
 {
     public function interceptUnaryUnary($method,
@@ -98,12 +101,15 @@ class ChangeMetadataInterceptor extends Grpc\Interceptor
                                         array $options = [],
                                         $continuation)
     {
-        $metadata["foo"] = array('interceptor_from_unary_request');
+        $metadata['foo'] = array('interceptor_from_unary_request');
+
         return $continuation($method, $argument, $metadata, $options);
     }
+
     public function interceptStreamUnary($method, array $metadata = [], array $options = [], $continuation)
     {
-        $metadata["foo"] = array('interceptor_from_stream_request');
+        $metadata['foo'] = array('interceptor_from_stream_request');
+
         return $continuation($method, $metadata, $options);
     }
 }
@@ -119,10 +125,12 @@ class ChangeMetadataInterceptor2 extends Grpc\Interceptor
         if (array_key_exists('foo', $metadata)) {
             $metadata['bar'] = array('ChangeMetadataInterceptor should be executed first');
         } else {
-            $metadata["bar"] = array('interceptor_from_unary_request');
+            $metadata['bar'] = array('interceptor_from_unary_request');
         }
+
         return $continuation($method, $argument, $metadata, $options);
     }
+
     public function interceptStreamUnary($method,
                                          array $metadata = [],
                                          array $options = [],
@@ -131,8 +139,9 @@ class ChangeMetadataInterceptor2 extends Grpc\Interceptor
         if (array_key_exists('foo', $metadata)) {
             $metadata['bar'] = array('ChangeMetadataInterceptor should be executed first');
         } else {
-            $metadata["bar"] = array('interceptor_from_stream_request');
+            $metadata['bar'] = array('interceptor_from_stream_request');
         }
+
         return $continuation($method, $metadata, $options);
     }
 }
@@ -145,6 +154,7 @@ class ChangeRequestCall
     {
         $this->call = $call;
     }
+
     public function getCall()
     {
         return $this->call;
@@ -171,8 +181,10 @@ class ChangeRequestInterceptor extends Grpc\Interceptor
                                         $continuation)
     {
         $argument->setData('intercepted_unary_request');
+
         return $continuation($method, $argument, $metadata, $options);
     }
+
     public function interceptStreamUnary($method, array $metadata = [], array $options = [], $continuation)
     {
         return new ChangeRequestCall(
@@ -189,14 +201,15 @@ class StopCallInterceptor extends Grpc\Interceptor
                                         array $options = [],
                                         $continuation)
     {
-        $metadata["foo"] = array('interceptor_from_request_response');
+        $metadata['foo'] = array('interceptor_from_request_response');
     }
+
     public function interceptStreamUnary($method,
                                          array $metadata = [],
                                          array $options = [],
                                          $continuation)
     {
-        $metadata["foo"] = array('interceptor_from_request_response');
+        $metadata['foo'] = array('interceptor_from_request_response');
     }
 }
 
@@ -214,7 +227,6 @@ class InterceptorTest extends PHPUnit_Framework_TestCase
     {
         $this->channel->close();
     }
-
 
     public function testClientChangeMetadataOneInterceptor()
     {
@@ -361,7 +373,6 @@ class InterceptorTest extends PHPUnit_Framework_TestCase
         $unary_call = $client->UnaryCall($req);
         $this->assertNull($unary_call);
 
-
         $stream_call = $client->StreamCall();
         $this->assertNull($stream_call);
 
@@ -390,7 +401,7 @@ class InterceptorTest extends PHPUnit_Framework_TestCase
         );
         $interceptor_channel = Grpc\Interceptor::intercept($channel, new Grpc\Interceptor());
         $now = Grpc\Timeval::now();
-        $deadline = $now->add(new Grpc\Timeval(100*1000));
+        $deadline = $now->add(new Grpc\Timeval(100 * 1000));
         $state = $interceptor_channel->watchConnectivityState(1, $deadline);
         $this->assertTrue($state);
         unset($time);

--- a/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php
+++ b/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php
@@ -22,468 +22,469 @@
  */
 class PersistentListTest extends PHPUnit_Framework_TestCase
 {
-  public function setUp()
-  {
-  }
+    public function setUp()
+    {
+    }
 
-  public function tearDown()
-  {
-    $channel_clean_persistent =
+    public function tearDown()
+    {
+        $channel_clean_persistent =
         new Grpc\Channel('localhost:50010', []);
-    $plist = $channel_clean_persistent->getPersistentList();
-    $channel_clean_persistent->cleanPersistentList();
-  }
+        $plist = $channel_clean_persistent->getPersistentList();
+        $channel_clean_persistent->cleanPersistentList();
+    }
 
-  public function waitUntilNotIdle($channel) {
-      for ($i = 0; $i < 10; $i++) {
-          $now = Grpc\Timeval::now();
-          $deadline = $now->add(new Grpc\Timeval(1000));
-          if ($channel->watchConnectivityState(GRPC\CHANNEL_IDLE,
+    public function waitUntilNotIdle($channel)
+    {
+        for ($i = 0; $i < 10; ++$i) {
+            $now = Grpc\Timeval::now();
+            $deadline = $now->add(new Grpc\Timeval(1000));
+            if ($channel->watchConnectivityState(GRPC\CHANNEL_IDLE,
               $deadline)) {
-              return true;
-          }
-      }
-      $this->assertTrue(false);
-  }
+                return true;
+            }
+        }
+        $this->assertTrue(false);
+    }
 
-  public function assertConnecting($state) {
-      $this->assertTrue($state == GRPC\CHANNEL_CONNECTING ||
+    public function assertConnecting($state)
+    {
+        $this->assertTrue($state == GRPC\CHANNEL_CONNECTING ||
       $state == GRPC\CHANNEL_TRANSIENT_FAILURE);
-  }
+    }
 
-  public function testInitHelper()
-  {
-      // PersistentList is not empty at the beginning of the tests
+    public function testInitHelper()
+    {
+        // PersistentList is not empty at the beginning of the tests
       // because phpunit will cache the channels created by other test
       // files.
-  }
+    }
 
-
-  public function testChannelNotPersist()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:1', ['force_new' => true]);
-      $channel1_info = $this->channel1->getChannelInfo();
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals($channel1_info['target'], 'localhost:1');
-      $this->assertEquals($channel1_info['ref_count'], 1);
-      $this->assertEquals($channel1_info['connectivity_status'],
+    public function testChannelNotPersist()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:1', ['force_new' => true]);
+        $channel1_info = $this->channel1->getChannelInfo();
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals($channel1_info['target'], 'localhost:1');
+        $this->assertEquals($channel1_info['ref_count'], 1);
+        $this->assertEquals($channel1_info['connectivity_status'],
           GRPC\CHANNEL_IDLE);
-      $this->assertEquals(count($plist_info), 0);
-      $this->channel1->close();
-  }
+        $this->assertEquals(count($plist_info), 0);
+        $this->channel1->close();
+    }
 
-  public function testPersistentChannelCreateOneChannel()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:1', []);
-      $channel1_info = $this->channel1->getChannelInfo();
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals($channel1_info['target'], 'localhost:1');
-      $this->assertEquals($channel1_info['ref_count'], 2);
-      $this->assertEquals($channel1_info['connectivity_status'],
+    public function testPersistentChannelCreateOneChannel()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:1', []);
+        $channel1_info = $this->channel1->getChannelInfo();
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals($channel1_info['target'], 'localhost:1');
+        $this->assertEquals($channel1_info['ref_count'], 2);
+        $this->assertEquals($channel1_info['connectivity_status'],
                           GRPC\CHANNEL_IDLE);
-      $this->assertArrayHasKey($channel1_info['key'], $plist_info);
-      $this->assertEquals(count($plist_info), 1);
-      $this->channel1->close();
-  }
+        $this->assertArrayHasKey($channel1_info['key'], $plist_info);
+        $this->assertEquals(count($plist_info), 1);
+        $this->channel1->close();
+    }
 
-  public function testPersistentChannelCreateMultipleChannels()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:1', []);
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals(count($plist_info), 1);
+    public function testPersistentChannelCreateMultipleChannels()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:1', []);
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals(count($plist_info), 1);
 
-      $this->channel2 = new Grpc\Channel('localhost:2', []);
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals(count($plist_info), 2);
+        $this->channel2 = new Grpc\Channel('localhost:2', []);
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals(count($plist_info), 2);
 
-      $this->channel3 = new Grpc\Channel('localhost:3', []);
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals(count($plist_info), 3);
-  }
+        $this->channel3 = new Grpc\Channel('localhost:3', []);
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals(count($plist_info), 3);
+    }
 
-  public function testPersistentChannelStatusChange()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:4', []);
-      $channel1_info = $this->channel1->getChannelInfo();
-      $this->assertEquals($channel1_info['connectivity_status'],
+    public function testPersistentChannelStatusChange()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:4', []);
+        $channel1_info = $this->channel1->getChannelInfo();
+        $this->assertEquals($channel1_info['connectivity_status'],
                           GRPC\CHANNEL_IDLE);
 
-      $this->channel1->getConnectivityState(true);
-      $this->waitUntilNotIdle($this->channel1);
-      $channel1_info = $this->channel1->getChannelInfo();
-      $this->assertConnecting($channel1_info['connectivity_status']);
-      $this->channel1->close();
-  }
+        $this->channel1->getConnectivityState(true);
+        $this->waitUntilNotIdle($this->channel1);
+        $channel1_info = $this->channel1->getChannelInfo();
+        $this->assertConnecting($channel1_info['connectivity_status']);
+        $this->channel1->close();
+    }
 
-  public function testPersistentChannelCloseChannel()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:1', []);
-      $this->channel2 = new Grpc\Channel('localhost:1', []);
+    public function testPersistentChannelCloseChannel()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:1', []);
+        $this->channel2 = new Grpc\Channel('localhost:1', []);
 
-      $channel1_info = $this->channel1->getChannelInfo();
-      $this->assertEquals($channel1_info['ref_count'], 3);
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals($plist_info[$channel1_info['key']]['ref_count'], 3);
+        $channel1_info = $this->channel1->getChannelInfo();
+        $this->assertEquals($channel1_info['ref_count'], 3);
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals($plist_info[$channel1_info['key']]['ref_count'], 3);
 
-      $this->channel1->close();
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals($plist_info[$channel1_info['key']]['ref_count'], 2);
+        $this->channel1->close();
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals($plist_info[$channel1_info['key']]['ref_count'], 2);
 
-      $this->channel2->close();
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals($plist_info[$channel1_info['key']]['ref_count'], 1);
-  }
+        $this->channel2->close();
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals($plist_info[$channel1_info['key']]['ref_count'], 1);
+    }
 
-  public function testPersistentChannelSameTarget()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:1', []);
-      $this->channel2 = new Grpc\Channel('localhost:1', []);
-      $plist = $this->channel2->getPersistentList();
-      $channel1_info = $this->channel1->getChannelInfo();
-      $channel2_info = $this->channel2->getChannelInfo();
-      // $channel1 and $channel2 shares the same channel, thus only 1
-      // channel should be in the persistent list.
-      $this->assertEquals($channel1_info['key'], $channel2_info['key']);
-      $this->assertArrayHasKey($channel1_info['key'], $plist);
-      $this->assertEquals(count($plist), 1);
-      $this->channel1->close();
-      $this->channel2->close();
-  }
+    public function testPersistentChannelSameTarget()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:1', []);
+        $this->channel2 = new Grpc\Channel('localhost:1', []);
+        $plist = $this->channel2->getPersistentList();
+        $channel1_info = $this->channel1->getChannelInfo();
+        $channel2_info = $this->channel2->getChannelInfo();
+        // $channel1 and $channel2 shares the same channel, thus only 1
+        // channel should be in the persistent list.
+        $this->assertEquals($channel1_info['key'], $channel2_info['key']);
+        $this->assertArrayHasKey($channel1_info['key'], $plist);
+        $this->assertEquals(count($plist), 1);
+        $this->channel1->close();
+        $this->channel2->close();
+    }
 
-  public function testPersistentChannelDifferentTarget()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:1', []);
-      $channel1_info = $this->channel1->getChannelInfo();
-      $this->channel2 = new Grpc\Channel('localhost:2', []);
-      $channel2_info = $this->channel1->getChannelInfo();
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertArrayHasKey($channel1_info['key'], $plist_info);
-      $this->assertArrayHasKey($channel2_info['key'], $plist_info);
-      $this->assertEquals($plist_info[$channel1_info['key']]['ref_count'], 2);
-      $this->assertEquals($plist_info[$channel2_info['key']]['ref_count'], 2);
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals(count($plist_info), 2);
-      $this->channel1->close();
-      $this->channel2->close();
-  }
+    public function testPersistentChannelDifferentTarget()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:1', []);
+        $channel1_info = $this->channel1->getChannelInfo();
+        $this->channel2 = new Grpc\Channel('localhost:2', []);
+        $channel2_info = $this->channel1->getChannelInfo();
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertArrayHasKey($channel1_info['key'], $plist_info);
+        $this->assertArrayHasKey($channel2_info['key'], $plist_info);
+        $this->assertEquals($plist_info[$channel1_info['key']]['ref_count'], 2);
+        $this->assertEquals($plist_info[$channel2_info['key']]['ref_count'], 2);
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals(count($plist_info), 2);
+        $this->channel1->close();
+        $this->channel2->close();
+    }
 
-  /**
-   * @expectedException RuntimeException
-   * @expectedExceptionMessage startBatch Error. Channel is closed
-   */
-  public function testPersistentChannelSharedChannelClose()
-  {
-      // same underlying channel
-      $this->channel1 = new Grpc\Channel('localhost:10010', [
-          "grpc_target_persist_bound" => 2,
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage startBatch Error. Channel is closed
+     */
+    public function testPersistentChannelSharedChannelClose()
+    {
+        // same underlying channel
+        $this->channel1 = new Grpc\Channel('localhost:10010', [
+          'grpc_target_persist_bound' => 2,
       ]);
-      $this->channel2 = new Grpc\Channel('localhost:10010', []);
-      $this->server = new Grpc\Server([]);
-      $this->port = $this->server->addHttp2Port('localhost:10010');
+        $this->channel2 = new Grpc\Channel('localhost:10010', []);
+        $this->server = new Grpc\Server([]);
+        $this->port = $this->server->addHttp2Port('localhost:10010');
 
-      // channel2 can still be use
-      $state = $this->channel2->getConnectivityState();
-      $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
+        // channel2 can still be use
+        $state = $this->channel2->getConnectivityState();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $state);
 
-      $call1 = new Grpc\Call($this->channel1,
+        $call1 = new Grpc\Call($this->channel1,
           '/foo',
           Grpc\Timeval::infFuture());
-      $call2 = new Grpc\Call($this->channel2,
+        $call2 = new Grpc\Call($this->channel2,
           '/foo',
           Grpc\Timeval::infFuture());
-      $call3 = new Grpc\Call($this->channel1,
+        $call3 = new Grpc\Call($this->channel1,
           '/foo',
           Grpc\Timeval::infFuture());
-      $call4 = new Grpc\Call($this->channel2,
+        $call4 = new Grpc\Call($this->channel2,
           '/foo',
           Grpc\Timeval::infFuture());
-      $batch = [
+        $batch = [
           Grpc\OP_SEND_INITIAL_METADATA => [],
       ];
 
-      $result = $call1->startBatch($batch);
-      $this->assertTrue($result->send_metadata);
-      $result = $call2->startBatch($batch);
-      $this->assertTrue($result->send_metadata);
+        $result = $call1->startBatch($batch);
+        $this->assertTrue($result->send_metadata);
+        $result = $call2->startBatch($batch);
+        $this->assertTrue($result->send_metadata);
 
-      $this->channel1->close();
-      // After closing channel1, channel2 can still be use
-      $result = $call4->startBatch($batch);
-      $this->assertTrue($result->send_metadata);
-      // channel 1 is closed, it will throw an exception.
-      $result = $call3->startBatch($batch);
-  }
+        $this->channel1->close();
+        // After closing channel1, channel2 can still be use
+        $result = $call4->startBatch($batch);
+        $this->assertTrue($result->send_metadata);
+        // channel 1 is closed, it will throw an exception.
+        $result = $call3->startBatch($batch);
+    }
 
-  public function testPersistentChannelTargetDefaultUpperBound()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:10011', []);
-      $channel1_info = $this->channel1->getChannelInfo();
-      $this->assertEquals($channel1_info['target_upper_bound'], 1);
-      $this->assertEquals($channel1_info['target_current_size'], 1);
-  }
+    public function testPersistentChannelTargetDefaultUpperBound()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:10011', []);
+        $channel1_info = $this->channel1->getChannelInfo();
+        $this->assertEquals($channel1_info['target_upper_bound'], 1);
+        $this->assertEquals($channel1_info['target_current_size'], 1);
+    }
 
-  public function testPersistentChannelTargetUpperBoundZero()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:10011', [
-          "grpc_target_persist_bound" => 0,
+    public function testPersistentChannelTargetUpperBoundZero()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:10011', [
+          'grpc_target_persist_bound' => 0,
       ]);
-      // channel1 will not be persisted.
-      $channel1_info = $this->channel1->getChannelInfo();
-      $this->assertEquals($channel1_info['target_upper_bound'], 0);
-      $this->assertEquals($channel1_info['target_current_size'], 0);
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals(0, count($plist_info));
-  }
+        // channel1 will not be persisted.
+        $channel1_info = $this->channel1->getChannelInfo();
+        $this->assertEquals($channel1_info['target_upper_bound'], 0);
+        $this->assertEquals($channel1_info['target_current_size'], 0);
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals(0, count($plist_info));
+    }
 
-  public function testPersistentChannelTargetUpperBoundNotZero()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:10011', [
-          "grpc_target_persist_bound" => 3,
+    public function testPersistentChannelTargetUpperBoundNotZero()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:10011', [
+          'grpc_target_persist_bound' => 3,
       ]);
-      $channel1_info = $this->channel1->getChannelInfo();
-      $this->assertEquals($channel1_info['target_upper_bound'], 3);
-      $this->assertEquals($channel1_info['target_current_size'], 1);
+        $channel1_info = $this->channel1->getChannelInfo();
+        $this->assertEquals($channel1_info['target_upper_bound'], 3);
+        $this->assertEquals($channel1_info['target_current_size'], 1);
 
-      // The upper bound should not be changed
-      $this->channel2 = new Grpc\Channel('localhost:10011', []);
-      $channel2_info = $this->channel2->getChannelInfo();
-      $this->assertEquals($channel2_info['target_upper_bound'], 3);
-      $this->assertEquals($channel2_info['target_current_size'], 1);
+        // The upper bound should not be changed
+        $this->channel2 = new Grpc\Channel('localhost:10011', []);
+        $channel2_info = $this->channel2->getChannelInfo();
+        $this->assertEquals($channel2_info['target_upper_bound'], 3);
+        $this->assertEquals($channel2_info['target_current_size'], 1);
 
-      // The upper bound should not be changed
-      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+        // The upper bound should not be changed
+        $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
           null);
-      $this->channel3 = new Grpc\Channel('localhost:10011',
+        $this->channel3 = new Grpc\Channel('localhost:10011',
           ['credentials' => $channel_credentials]);
-      $channel3_info = $this->channel3->getChannelInfo();
-      $this->assertEquals($channel3_info['target_upper_bound'], 3);
-      $this->assertEquals($channel3_info['target_current_size'], 2);
+        $channel3_info = $this->channel3->getChannelInfo();
+        $this->assertEquals($channel3_info['target_upper_bound'], 3);
+        $this->assertEquals($channel3_info['target_current_size'], 2);
 
-      // The upper bound should not be changed
-      $this->channel4 = new Grpc\Channel('localhost:10011', [
-          "grpc_target_persist_bound" => 5,
+        // The upper bound should not be changed
+        $this->channel4 = new Grpc\Channel('localhost:10011', [
+          'grpc_target_persist_bound' => 5,
       ]);
-      $channel4_info = $this->channel4->getChannelInfo();
-      $this->assertEquals($channel4_info['target_upper_bound'], 5);
-      $this->assertEquals($channel4_info['target_current_size'], 2);
-  }
+        $channel4_info = $this->channel4->getChannelInfo();
+        $this->assertEquals($channel4_info['target_upper_bound'], 5);
+        $this->assertEquals($channel4_info['target_current_size'], 2);
+    }
 
-  public function testPersistentChannelDefaultOutBound1()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:10011', []);
-      // Make channel1 not IDLE.
-      $this->channel1->getConnectivityState(true);
-      $this->waitUntilNotIdle($this->channel1);
-      $channel1_info = $this->channel1->getChannelInfo();
-      $this->assertConnecting($channel1_info['connectivity_status']);
+    public function testPersistentChannelDefaultOutBound1()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:10011', []);
+        // Make channel1 not IDLE.
+        $this->channel1->getConnectivityState(true);
+        $this->waitUntilNotIdle($this->channel1);
+        $channel1_info = $this->channel1->getChannelInfo();
+        $this->assertConnecting($channel1_info['connectivity_status']);
 
-      // Since channel1 is CONNECTING, channel 2 will not be persisted
-      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+        // Since channel1 is CONNECTING, channel 2 will not be persisted
+        $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
         null);
-      $this->channel2 = new Grpc\Channel('localhost:10011',
+        $this->channel2 = new Grpc\Channel('localhost:10011',
           ['credentials' => $channel_credentials]);
-      $channel2_info = $this->channel2->getChannelInfo();
-      $this->assertEquals(GRPC\CHANNEL_IDLE, $channel2_info['connectivity_status']);
+        $channel2_info = $this->channel2->getChannelInfo();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $channel2_info['connectivity_status']);
 
-      // By default, target 'localhost:10011' only persist one channel.
-      // Since channel1 is not Idle channel2 will not be persisted.
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals(1, count($plist_info));
-      $this->assertArrayHasKey($channel1_info['key'], $plist_info);
-      $this->assertArrayNotHasKey($channel2_info['key'], $plist_info);
-  }
+        // By default, target 'localhost:10011' only persist one channel.
+        // Since channel1 is not Idle channel2 will not be persisted.
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals(1, count($plist_info));
+        $this->assertArrayHasKey($channel1_info['key'], $plist_info);
+        $this->assertArrayNotHasKey($channel2_info['key'], $plist_info);
+    }
 
-  public function testPersistentChannelDefaultOutBound2()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:10011', []);
-      $channel1_info = $this->channel1->getChannelInfo();
-      $this->assertEquals(GRPC\CHANNEL_IDLE, $channel1_info['connectivity_status']);
+    public function testPersistentChannelDefaultOutBound2()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:10011', []);
+        $channel1_info = $this->channel1->getChannelInfo();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $channel1_info['connectivity_status']);
 
-      // Although channel1 is IDLE, channel1 still has reference to the underline
-      // gRPC channel. channel2 will not be persisted
-      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+        // Although channel1 is IDLE, channel1 still has reference to the underline
+        // gRPC channel. channel2 will not be persisted
+        $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
         null);
-      $this->channel2 = new Grpc\Channel('localhost:10011',
+        $this->channel2 = new Grpc\Channel('localhost:10011',
           ['credentials' => $channel_credentials]);
-      $channel2_info = $this->channel2->getChannelInfo();
-      $this->assertEquals(GRPC\CHANNEL_IDLE, $channel2_info['connectivity_status']);
+        $channel2_info = $this->channel2->getChannelInfo();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $channel2_info['connectivity_status']);
 
-      // By default, target 'localhost:10011' only persist one channel.
-      // Since channel1 Idle, channel2 will be persisted.
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals(1, count($plist_info));
-      $this->assertArrayHasKey($channel1_info['key'], $plist_info);
-      $this->assertArrayNotHasKey($channel2_info['key'], $plist_info);
-  }
+        // By default, target 'localhost:10011' only persist one channel.
+        // Since channel1 Idle, channel2 will be persisted.
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals(1, count($plist_info));
+        $this->assertArrayHasKey($channel1_info['key'], $plist_info);
+        $this->assertArrayNotHasKey($channel2_info['key'], $plist_info);
+    }
 
-  public function testPersistentChannelDefaultOutBound3()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:10011', []);
-      $channel1_info = $this->channel1->getChannelInfo();
-      $this->assertEquals(GRPC\CHANNEL_IDLE, $channel1_info['connectivity_status']);
+    public function testPersistentChannelDefaultOutBound3()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:10011', []);
+        $channel1_info = $this->channel1->getChannelInfo();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $channel1_info['connectivity_status']);
 
-      $this->channel1->close();
-      // channel1 is closed, no reference holds to the underline channel.
-      // channel2 can be persisted.
-      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+        $this->channel1->close();
+        // channel1 is closed, no reference holds to the underline channel.
+        // channel2 can be persisted.
+        $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
         null);
-      $this->channel2 = new Grpc\Channel('localhost:10011',
+        $this->channel2 = new Grpc\Channel('localhost:10011',
         ['credentials' => $channel_credentials]);
-      $channel2_info = $this->channel2->getChannelInfo();
-      $this->assertEquals(GRPC\CHANNEL_IDLE, $channel2_info['connectivity_status']);
+        $channel2_info = $this->channel2->getChannelInfo();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $channel2_info['connectivity_status']);
 
-      // By default, target 'localhost:10011' only persist one channel.
-      // Since channel1 Idle, channel2 will be persisted.
-      $plist_info = $this->channel2->getPersistentList();
-      $this->assertEquals(1, count($plist_info));
-      $this->assertArrayHasKey($channel2_info['key'], $plist_info);
-      $this->assertArrayNotHasKey($channel1_info['key'], $plist_info);
-  }
+        // By default, target 'localhost:10011' only persist one channel.
+        // Since channel1 Idle, channel2 will be persisted.
+        $plist_info = $this->channel2->getPersistentList();
+        $this->assertEquals(1, count($plist_info));
+        $this->assertArrayHasKey($channel2_info['key'], $plist_info);
+        $this->assertArrayNotHasKey($channel1_info['key'], $plist_info);
+    }
 
-  public function testPersistentChannelTwoUpperBound()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:10011', [
-          "grpc_target_persist_bound" => 2,
+    public function testPersistentChannelTwoUpperBound()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:10011', [
+          'grpc_target_persist_bound' => 2,
       ]);
-      $channel1_info = $this->channel1->getChannelInfo();
-      $this->assertEquals(GRPC\CHANNEL_IDLE, $channel1_info['connectivity_status']);
+        $channel1_info = $this->channel1->getChannelInfo();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $channel1_info['connectivity_status']);
 
-      // Since channel1 is IDLE, channel 1 will be deleted
-      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+        // Since channel1 is IDLE, channel 1 will be deleted
+        $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
           null);
-      $this->channel2 = new Grpc\Channel('localhost:10011',
+        $this->channel2 = new Grpc\Channel('localhost:10011',
           ['credentials' => $channel_credentials]);
-      $channel2_info = $this->channel2->getChannelInfo();
-      $this->assertEquals(GRPC\CHANNEL_IDLE, $channel2_info['connectivity_status']);
+        $channel2_info = $this->channel2->getChannelInfo();
+        $this->assertEquals(GRPC\CHANNEL_IDLE, $channel2_info['connectivity_status']);
 
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals(2, count($plist_info));
-      $this->assertArrayHasKey($channel1_info['key'], $plist_info);
-      $this->assertArrayHasKey($channel2_info['key'], $plist_info);
-  }
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals(2, count($plist_info));
+        $this->assertArrayHasKey($channel1_info['key'], $plist_info);
+        $this->assertArrayHasKey($channel2_info['key'], $plist_info);
+    }
 
-  public function testPersistentChannelTwoUpperBoundOutBound1()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:10011', [
-          "grpc_target_persist_bound" => 2,
+    public function testPersistentChannelTwoUpperBoundOutBound1()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:10011', [
+          'grpc_target_persist_bound' => 2,
       ]);
-      $channel1_info = $this->channel1->getChannelInfo();
+        $channel1_info = $this->channel1->getChannelInfo();
 
-      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+        $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
         null);
-      $this->channel2 = new Grpc\Channel('localhost:10011',
+        $this->channel2 = new Grpc\Channel('localhost:10011',
           ['credentials' => $channel_credentials]);
-      $channel2_info = $this->channel2->getChannelInfo();
+        $channel2_info = $this->channel2->getChannelInfo();
 
-      // Close channel1, so that new channel can be persisted.
-      $this->channel1->close();
+        // Close channel1, so that new channel can be persisted.
+        $this->channel1->close();
 
-      $channel_credentials = Grpc\ChannelCredentials::createSsl("a", null,
+        $channel_credentials = Grpc\ChannelCredentials::createSsl('a', null,
         null);
-      $this->channel3 = new Grpc\Channel('localhost:10011',
+        $this->channel3 = new Grpc\Channel('localhost:10011',
           ['credentials' => $channel_credentials]);
-      $channel3_info = $this->channel3->getChannelInfo();
+        $channel3_info = $this->channel3->getChannelInfo();
 
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals(2, count($plist_info));
-      $this->assertArrayNotHasKey($channel1_info['key'], $plist_info);
-      $this->assertArrayHasKey($channel2_info['key'], $plist_info);
-      $this->assertArrayHasKey($channel3_info['key'], $plist_info);
-  }
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals(2, count($plist_info));
+        $this->assertArrayNotHasKey($channel1_info['key'], $plist_info);
+        $this->assertArrayHasKey($channel2_info['key'], $plist_info);
+        $this->assertArrayHasKey($channel3_info['key'], $plist_info);
+    }
 
-  public function testPersistentChannelTwoUpperBoundOutBound2()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:10011', [
-          "grpc_target_persist_bound" => 2,
+    public function testPersistentChannelTwoUpperBoundOutBound2()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:10011', [
+          'grpc_target_persist_bound' => 2,
       ]);
-      $channel1_info = $this->channel1->getChannelInfo();
+        $channel1_info = $this->channel1->getChannelInfo();
 
-      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+        $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
         null);
-      $this->channel2 = new Grpc\Channel('localhost:10011',
+        $this->channel2 = new Grpc\Channel('localhost:10011',
         ['credentials' => $channel_credentials]);
-      $channel2_info = $this->channel2->getChannelInfo();
+        $channel2_info = $this->channel2->getChannelInfo();
 
-      // Close channel2, so that new channel can be persisted.
-      $this->channel2->close();
+        // Close channel2, so that new channel can be persisted.
+        $this->channel2->close();
 
-      $channel_credentials = Grpc\ChannelCredentials::createSsl("a", null,
+        $channel_credentials = Grpc\ChannelCredentials::createSsl('a', null,
         null);
-      $this->channel3 = new Grpc\Channel('localhost:10011',
+        $this->channel3 = new Grpc\Channel('localhost:10011',
         ['credentials' => $channel_credentials]);
-      $channel3_info = $this->channel3->getChannelInfo();
+        $channel3_info = $this->channel3->getChannelInfo();
 
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals(2, count($plist_info));
-      $this->assertArrayHasKey($channel1_info['key'], $plist_info);
-      $this->assertArrayNotHasKey($channel2_info['key'], $plist_info);
-      $this->assertArrayHasKey($channel3_info['key'], $plist_info);
-  }
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals(2, count($plist_info));
+        $this->assertArrayHasKey($channel1_info['key'], $plist_info);
+        $this->assertArrayNotHasKey($channel2_info['key'], $plist_info);
+        $this->assertArrayHasKey($channel3_info['key'], $plist_info);
+    }
 
-  public function testPersistentChannelTwoUpperBoundOutBound3()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:10011', [
-          "grpc_target_persist_bound" => 2,
+    public function testPersistentChannelTwoUpperBoundOutBound3()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:10011', [
+          'grpc_target_persist_bound' => 2,
       ]);
-      $channel1_info = $this->channel1->getChannelInfo();
+        $channel1_info = $this->channel1->getChannelInfo();
 
-      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+        $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
           null);
-      $this->channel2 = new Grpc\Channel('localhost:10011',
+        $this->channel2 = new Grpc\Channel('localhost:10011',
           ['credentials' => $channel_credentials]);
-      $this->channel2->getConnectivityState(true);
-      $this->waitUntilNotIdle($this->channel2);
-      $channel2_info = $this->channel2->getChannelInfo();
-      $this->assertConnecting($channel2_info['connectivity_status']);
+        $this->channel2->getConnectivityState(true);
+        $this->waitUntilNotIdle($this->channel2);
+        $channel2_info = $this->channel2->getChannelInfo();
+        $this->assertConnecting($channel2_info['connectivity_status']);
 
-      // Only one channel will be deleted
-      $this->channel1->close();
-      $this->channel2->close();
+        // Only one channel will be deleted
+        $this->channel1->close();
+        $this->channel2->close();
 
-      $channel_credentials = Grpc\ChannelCredentials::createSsl("a", null,
+        $channel_credentials = Grpc\ChannelCredentials::createSsl('a', null,
         null);
-      $this->channel3 = new Grpc\Channel('localhost:10011',
+        $this->channel3 = new Grpc\Channel('localhost:10011',
           ['credentials' => $channel_credentials]);
-      $channel3_info = $this->channel3->getChannelInfo();
+        $channel3_info = $this->channel3->getChannelInfo();
 
-      // Only the Idle Channel will be deleted
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals(2, count($plist_info));
-      $this->assertArrayNotHasKey($channel1_info['key'], $plist_info);
-      $this->assertArrayHasKey($channel2_info['key'], $plist_info);
-      $this->assertArrayHasKey($channel3_info['key'], $plist_info);
-  }
+        // Only the Idle Channel will be deleted
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals(2, count($plist_info));
+        $this->assertArrayNotHasKey($channel1_info['key'], $plist_info);
+        $this->assertArrayHasKey($channel2_info['key'], $plist_info);
+        $this->assertArrayHasKey($channel3_info['key'], $plist_info);
+    }
 
-  public function testPersistentChannelTwoUpperBoundOutBound4()
-  {
-      $this->channel1 = new Grpc\Channel('localhost:10011', [
-          "grpc_target_persist_bound" => 2,
+    public function testPersistentChannelTwoUpperBoundOutBound4()
+    {
+        $this->channel1 = new Grpc\Channel('localhost:10011', [
+          'grpc_target_persist_bound' => 2,
       ]);
-      $this->channel1->getConnectivityState(true);
-      $this->waitUntilNotIdle($this->channel1);
-      $channel1_info = $this->channel1->getChannelInfo();
-      $this->assertConnecting($channel1_info['connectivity_status']);
+        $this->channel1->getConnectivityState(true);
+        $this->waitUntilNotIdle($this->channel1);
+        $channel1_info = $this->channel1->getChannelInfo();
+        $this->assertConnecting($channel1_info['connectivity_status']);
 
-      $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
+        $channel_credentials = Grpc\ChannelCredentials::createSsl(null, null,
           null);
-      $this->channel2 = new Grpc\Channel('localhost:10011',
+        $this->channel2 = new Grpc\Channel('localhost:10011',
           ['credentials' => $channel_credentials]);
-      $this->channel2->getConnectivityState(true);
-      $this->waitUntilNotIdle($this->channel2);
-      $channel2_info = $this->channel2->getChannelInfo();
-      $this->assertConnecting($channel2_info['connectivity_status']);
+        $this->channel2->getConnectivityState(true);
+        $this->waitUntilNotIdle($this->channel2);
+        $channel2_info = $this->channel2->getChannelInfo();
+        $this->assertConnecting($channel2_info['connectivity_status']);
 
-      $channel_credentials = Grpc\ChannelCredentials::createSsl("a", null,
+        $channel_credentials = Grpc\ChannelCredentials::createSsl('a', null,
           null);
-      $this->channel3 = new Grpc\Channel('localhost:10011',
+        $this->channel3 = new Grpc\Channel('localhost:10011',
           ['credentials' => $channel_credentials]);
-      $channel3_info = $this->channel3->getChannelInfo();
+        $channel3_info = $this->channel3->getChannelInfo();
 
-      // Channel3 will not be persisted
-      $plist_info = $this->channel1->getPersistentList();
-      $this->assertEquals(2, count($plist_info));
-      $this->assertArrayHasKey($channel1_info['key'], $plist_info);
-      $this->assertArrayHasKey($channel2_info['key'], $plist_info);
-      $this->assertArrayNotHasKey($channel3_info['key'], $plist_info);
-  }
+        // Channel3 will not be persisted
+        $plist_info = $this->channel1->getPersistentList();
+        $this->assertEquals(2, count($plist_info));
+        $this->assertArrayHasKey($channel1_info['key'], $plist_info);
+        $this->assertArrayHasKey($channel2_info['key'], $plist_info);
+        $this->assertArrayNotHasKey($channel3_info['key'], $plist_info);
+    }
 }

--- a/src/php/tests/unit_tests/ServerTest.php
+++ b/src/php/tests/unit_tests/ServerTest.php
@@ -44,7 +44,7 @@ class ServerTest extends PHPUnit_Framework_TestCase
     public function testConstructorWithArray()
     {
         // key of array must be string
-         $this->server = new Grpc\Server(['ip' => '127.0.0.1',
+        $this->server = new Grpc\Server(['ip' => '127.0.0.1',
                                           'port' => '8080', ]);
         $this->assertNotNull($this->server);
     }
@@ -88,7 +88,7 @@ class ServerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidConstructor()
     {
@@ -97,7 +97,7 @@ class ServerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidConstructorWithNumKeyOfArray()
     {
@@ -107,15 +107,16 @@ class ServerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidConstructorWithList()
     {
         $this->server = new Grpc\Server(['127.0.0.1', '8080']);
         $this->assertNull($this->server);
     }
+
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidAddHttp2Port()
     {
@@ -124,7 +125,7 @@ class ServerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidAddSecureHttp2Port()
     {
@@ -133,7 +134,7 @@ class ServerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidAddSecureHttp2Port2()
     {
@@ -142,7 +143,7 @@ class ServerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testInvalidAddSecureHttp2Port3()
     {

--- a/src/php/tests/unit_tests/TimevalTest.php
+++ b/src/php/tests/unit_tests/TimevalTest.php
@@ -152,7 +152,7 @@ class TimevalTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testConstructorInvalidParam()
     {
@@ -160,7 +160,7 @@ class TimevalTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testAddInvalidParam()
     {
@@ -169,7 +169,7 @@ class TimevalTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testSubtractInvalidParam()
     {
@@ -178,7 +178,7 @@ class TimevalTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testCompareInvalidParam()
     {
@@ -186,7 +186,7 @@ class TimevalTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testSimilarInvalidParam()
     {


### PR DESCRIPTION
Now we have had `run_php_cs_fixer.sh`, but some codes are not the result which run it.
For `tests/qps/generated_code` are not executed fixer, so add config file `.php_cs.dist`.
@ZhouyihaiDing please review the pull request, thanks!