### PR TITLE
Upgrade cmake in C++ dockerfiles

### DIFF
--- a/templates/tools/dockerfile/clang_update.include
+++ b/templates/tools/dockerfile/clang_update.include
@@ -1,8 +1,6 @@
 #=================
 # Update clang to a version with improved tsan and fuzzing capabilities
 
-RUN apt-get update && apt-get -y install python cmake && apt-get clean
-
 RUN git clone -n -b release_38 http://llvm.org/git/llvm.git && ${'\\'}
   cd llvm && git checkout ad57503 && cd ..
 RUN git clone -n -b release_38 http://llvm.org/git/clang.git && ${'\\'}

--- a/templates/tools/dockerfile/cmake_jessie_backports.include
+++ b/templates/tools/dockerfile/cmake_jessie_backports.include
@@ -1,0 +1,6 @@
+#=================
+# Use cmake 3.6 from jessie-backports
+# should only be used for images based on debian jessie.
+
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
+RUN apt-get update && apt-get install -t jessie-backports -y cmake && apt-get clean

--- a/templates/tools/dockerfile/test/cxx_jessie_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_jessie_x64/Dockerfile.template
@@ -20,6 +20,7 @@
   <%include file="../../gcp_api_libraries.include"/>
   <%include file="../../python_deps.include"/>
   <%include file="../../cxx_deps.include"/>
+  <%include file="../../cmake_jessie_backports.include"/>
   <%include file="../../clang_update.include"/>
   <%include file="../../run_tests_addons.include"/>
   <%include file="../../libuv_install.include"/>

--- a/templates/tools/dockerfile/test/fuzzer/Dockerfile.template
+++ b/templates/tools/dockerfile/test/fuzzer/Dockerfile.template
@@ -20,6 +20,7 @@
   <%include file="../../gcp_api_libraries.include"/>
   <%include file="../../python_deps.include"/>
   <%include file="../../cxx_deps.include"/>
+  <%include file="../../cmake_jessie_backports.include"/>
   <%include file="../../clang_update.include"/>
   <%include file="../../run_tests_addons.include"/>
   RUN clang++ -c -g -O2 -std=c++11 llvm/lib/Fuzzer/*.cpp -IFuzzer

--- a/tools/dockerfile/distribtest/cpp_jessie_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/cpp_jessie_x64/Dockerfile
@@ -27,6 +27,9 @@ RUN apt-get update && apt-get install -y \
       pkg-config \
       unzip && apt-get clean
 
-RUN apt-get update && apt-get install -y cmake golang && apt-get clean
+RUN apt-get update && apt-get install -y golang && apt-get clean
+
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
+RUN apt-get update && apt-get install -t jessie-backports -y cmake && apt-get clean
 
 CMD ["bash"]

--- a/tools/dockerfile/test/cxx_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_jessie_x64/Dockerfile
@@ -73,9 +73,14 @@ RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 t
 RUN apt-get update && apt-get -y install libgflags-dev libgtest-dev libc++-dev clang && apt-get clean
 
 #=================
-# Update clang to a version with improved tsan and fuzzing capabilities
+# Use cmake 3.6 from jessie-backports
+# should only be used for images based on debian jessie.
 
-RUN apt-get update && apt-get -y install python cmake && apt-get clean
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
+RUN apt-get update && apt-get install -t jessie-backports -y cmake && apt-get clean
+
+#=================
+# Update clang to a version with improved tsan and fuzzing capabilities
 
 RUN git clone -n -b release_38 http://llvm.org/git/llvm.git && \
   cd llvm && git checkout ad57503 && cd ..

--- a/tools/dockerfile/test/fuzzer/Dockerfile
+++ b/tools/dockerfile/test/fuzzer/Dockerfile
@@ -73,9 +73,14 @@ RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 t
 RUN apt-get update && apt-get -y install libgflags-dev libgtest-dev libc++-dev clang && apt-get clean
 
 #=================
-# Update clang to a version with improved tsan and fuzzing capabilities
+# Use cmake 3.6 from jessie-backports
+# should only be used for images based on debian jessie.
 
-RUN apt-get update && apt-get -y install python cmake && apt-get clean
+RUN echo "deb http://ftp.debian.org/debian jessie-backports main" | tee /etc/apt/sources.list.d/jessie-backports.list
+RUN apt-get update && apt-get install -t jessie-backports -y cmake && apt-get clean
+
+#=================
+# Update clang to a version with improved tsan and fuzzing capabilities
 
 RUN git clone -n -b release_38 http://llvm.org/git/llvm.git && \
   cd llvm && git checkout ad57503 && cd ..


### PR DESCRIPTION
Protobuf now requires newer cmake than what debian jessie provides: https://www.google.com/url?q=https://github.com/google/protobuf/pull/4550&sa=D&usg=AFQjCNGecb-5GoPujaCTdTwDZwh5aBVc3g

This PR is progress towards unbreaking protobuf_at_head test suite.
(and can also be used as base for https://github.com/grpc/grpc/pull/15301)