### PR TITLE
Install bash in alpine distribtest image

### DIFF
--- a/tools/dockerfile/distribtest/python_dev_alpine3.7_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/python_dev_alpine3.7_x64/Dockerfile
@@ -19,3 +19,9 @@ RUN apk add --update build-base python python-dev py-pip
 RUN pip install --upgrade pip
 
 RUN pip install virtualenv
+
+# bash is required for our test script invocation
+# ideally, we want to fix the invocation mechanism
+# so we can remove this, but it has to be here for
+# now:
+RUN apk add --update bash


### PR DESCRIPTION
Fixes distribtest failure for Python on the new docker image for Alpine.

`bash` is required for our test script invocation (see failure in https://sponge.corp.google.com/invocation?tab=Build+Log&id=b0753197-5061-4d0d-b07a-58dca7845898)
ideally, we want to fix the invocation mechanism
so we can remove this, but it has to be there for now.