### PR TITLE
Add Node v1.11.2 to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -237,6 +237,9 @@ LANG_RELEASE_MATRIX = {
         {
             'v1.10.0': None
         },
+        {
+            'v1.11.2': None
+        }
     ],
     'ruby': [
         {


### PR DESCRIPTION
I don't think we've changed anything with the interop tests in the Node repo, so this should just work.