### PR TITLE
Update grpcio_tools in build_protobuf_at_head build

### DIFF
--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -28,9 +28,14 @@ tools/buildgen/generate_projects.sh
 
 if [ "$RUN_TESTS_FLAGS" == "protobuf" ]
 then
-  # this either requires bazel (tested with 0.13.1) to be available on kokoro worker
-  # or we need to fallback to bazel dockerimage, but we want prevent building it from
-  # scratch.
+  # Upgrade bazel.
+  # make_grpcio_tools.py requires bazel >=0.13.1 to run (Kokoro workers only have bazel 0.9)
+  curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.13.1/bazel-0.13.1-installer-linux-x86_64.sh
+  chmod +x ./bazel-0.13.1-installer-linux-x86_64.sh
+  ./bazel-0.13.1-installer-linux-x86_64.sh --user
+  rm -f ./bazel-0.13.1-installer-linux-x86_64.sh
+  export PATH="$PATH:$HOME/bin"
+
   tools/distrib/python/make_grpcio_tools.py
 fi
 

--- a/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
+++ b/tools/internal_ci/linux/grpc_build_submodule_at_head.sh
@@ -22,9 +22,19 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-# Update submodule and commit it so changes are passed to Docker
+# Update submodule to be tested at HEAD
 (cd third_party/$RUN_TESTS_FLAGS && git fetch --all && git checkout origin/master)
 tools/buildgen/generate_projects.sh
+
+if [ "$RUN_TESTS_FLAGS" == "protobuf" ]
+then
+  # this either requires bazel (tested with 0.13.1) to be available on kokoro worker
+  # or we need to fallback to bazel dockerimage, but we want prevent building it from
+  # scratch.
+  tools/distrib/python/make_grpcio_tools.py
+fi
+
+# commit so that changes are passed to Docker
 git -c user.name='foo' -c user.email='foo@google.com' commit -a -m 'Update submodule'
 
 tools/run_tests/run_tests_matrix.py -f linux --inner_jobs 4 -j 4 --internal_ci --build_only


### PR DESCRIPTION
Without this the protobuf_at_head  python builds will always fails if protobuf adds/removes source files.
e.g.:
https://source.cloud.google.com/results/invocations/6d108280-8d8a-4e66-aeef-ef165cb795e9/targets/github%2Fgrpc%2Faggregate_tests/tests;query=python