### PR TITLE
WIP PHP: call OP_RECV_STATUS_ON_CLIENT at the end of server  streaming

### DIFF
--- a/src/php/lib/Grpc/BidiStreamingCall.php
+++ b/src/php/lib/Grpc/BidiStreamingCall.php
@@ -25,6 +25,7 @@ namespace Grpc;
  */
 class BidiStreamingCall extends AbstractCall
 {
+    private $status;
     /**
      * Start the call.
      *
@@ -53,8 +54,15 @@ class BidiStreamingCall extends AbstractCall
         if ($this->metadata === null) {
             $this->metadata = $read_event->metadata;
         }
-
-        return $this->_deserializeResponse($read_event->message);
+        $response = $read_event->message;
+        if ($response == NULL && $this->status == NULL) {
+            $status_event = $this->call->startBatch([
+                OP_RECV_STATUS_ON_CLIENT => true,
+            ]);
+            $this->trailing_metadata = $status_event->status->metadata;
+            $this->status = $status_event->status;
+        }
+        return $this->_deserializeResponse($response);
     }
 
     /**
@@ -94,12 +102,15 @@ class BidiStreamingCall extends AbstractCall
      */
     public function getStatus()
     {
-        $status_event = $this->call->startBatch([
-            OP_RECV_STATUS_ON_CLIENT => true,
-        ]);
-
-        $this->trailing_metadata = $status_event->status->metadata;
-
-        return $status_event->status;
+        // For the backward compatibility, the user can still call it
+        // to call startBatch with OP_RECV_STATUS_ON_CLIENT tag.
+        if ($this->status == NULL) {
+            $status_event = $this->call->startBatch([
+                OP_RECV_STATUS_ON_CLIENT => true,
+            ]);
+            $this->trailing_metadata = $status_event->status->metadata;
+            $this->status = $status_event->status;
+        }
+        return $this->status;
     }
 }

--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -373,6 +373,8 @@ function cancelAfterFirstResponse($stub)
     $response = $call->read();
 
     $call->cancel();
+    $response = $call->read();
+
     hardAssert($call->getStatus()->code === Grpc\STATUS_CANCELLED,
                'Call status was not CANCELLED');
 }
@@ -447,6 +449,7 @@ function customMetadata($stub)
     $streaming_call->writesDone();
     $result = $streaming_call->read();
 
+    $streaming_call->read();
     hardAssertIfStatusOk($streaming_call->getStatus());
 
     $streaming_initial_metadata = $streaming_call->getMetadata();


### PR DESCRIPTION
In current implementation, the user should call [`getStatus`](https://github.com/grpc/grpc/blob/106d175c8c4e038960a9f3304fdfe36450fdf784/src/php/lib/Grpc/ServerStreamingCall.php#L78) for the server streaming call. However the user doesn't know when to call it because the user doesn't know when the call is finished. (Also, the user can more `getStatus` more than once, which will cause the problem).

Since the last response for the server streaming call is a nullptr, we can move the `OP_RECV_STATUS_ON_CLIENT` to when the nullptr is received from the server. The same idea from [ruby](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/generic/bidi_call.rb#L204:16).

@fengli79 . Save the status in order to make the original API still work. I think it should satisfy the backward compatibility. The only thing added is that the status can also be get when the last response is received without the need to call `getStatus`.