### PR TITLE
upload coverage reports as a zip file

### DIFF
--- a/tools/internal_ci/linux/grpc_coverage.sh
+++ b/tools/internal_ci/linux/grpc_coverage.sh
@@ -26,4 +26,16 @@ python tools/run_tests/run_tests.py \
   -l all                            \
   -c gcov                           \
   -x sponge_log.xml                 \
-  -j 16
+  -j 16 || FAILED="true"
+  
+# HTML reports can't be easily displayed in GCS, so create a zip archive
+# and put it under reports directory to get it uploaded as an artifact.
+zip -q -r coverage_report.zip reports || true
+rm -rf reports || true
+mkdir reports  || true
+mv coverage_report.zip reports || true
+
+if [ "$FAILED" != "" ]
+then
+  exit 1
+fi


### PR DESCRIPTION
currently coverage reports cannot be easily displayed
https://pantheon.corp.google.com/storage/browser/grpc-testing-kokoro-prod/test_result_public/prod/grpc/core/master/linux/grpc_coverage/46/20180521-112403/github/grpc/reports/