### PR TITLE
Log the grpc_subchannel instead of SubchannelData

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
@@ -490,7 +490,7 @@ void PickFirst::PickFirstSubchannelData::ProcessConnectivityChangeLocked(
         if (grpc_lb_pick_first_trace.enabled()) {
           gpr_log(GPR_INFO,
                   "Servicing pending pick with selected subchannel %p",
-                  p->selected_);
+                  p->selected_->subchannel());
         }
         GRPC_CLOSURE_SCHED(pick->on_complete, GRPC_ERROR_NONE);
       }


### PR DESCRIPTION
This makes the logging consistent with https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc#L479