### PR TITLE
Fix broken ByteBuffer copy ctor

### DIFF
--- a/src/cpp/util/byte_buffer_cc.cc
+++ b/src/cpp/util/byte_buffer_cc.cc
@@ -43,8 +43,9 @@ Status ByteBuffer::Dump(std::vector<Slice>* slices) const {
   return Status::OK;
 }
 
-ByteBuffer::ByteBuffer(const ByteBuffer& buf)
-    : buffer_(grpc_byte_buffer_copy(buf.buffer_)) {}
+ByteBuffer::ByteBuffer(const ByteBuffer& buf) : buffer_(nullptr) {
+  operator=(buf);
+}
 
 ByteBuffer& ByteBuffer::operator=(const ByteBuffer& buf) {
   if (this != &buf) {

--- a/test/cpp/util/byte_buffer_test.cc
+++ b/test/cpp/util/byte_buffer_test.cc
@@ -38,6 +38,13 @@ const char* kContent2 = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy world";
 
 class ByteBufferTest : public ::testing::Test {};
 
+TEST_F(ByteBufferTest, CopyCtor) {
+  ByteBuffer buffer1;
+  EXPECT_FALSE(buffer1.Valid());
+  ByteBuffer buffer2 = buffer1;
+  EXPECT_FALSE(buffer2.Valid());
+}
+
 TEST_F(ByteBufferTest, CreateFromSingleSlice) {
   Slice s(kContent1);
   ByteBuffer buffer(&s, 1);


### PR DESCRIPTION
Fixes the broken copy constructor in `grpc::ByteBuffer` which will crash in below case:
```cpp
grpc::ByteBuffer b;
auto b2 = b;
```