### PR TITLE
Fixing make_grpcio_tools.py

### DIFF
--- a/templates/tools/dockerfile/bazel.include
+++ b/templates/tools/dockerfile/bazel.include
@@ -1,0 +1,5 @@
+#========================
+# Bazel installation
+RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/bazel.list
+RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
+RUN apt-get -y update && apt-get -y install bazel=0.13.1 && apt-get clean

--- a/templates/tools/dockerfile/test/bazel/Dockerfile.template
+++ b/templates/tools/dockerfile/test/bazel/Dockerfile.template
@@ -1,0 +1,36 @@
+%YAML 1.2
+--- |
+  # Copyright 2015 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  
+  FROM gcr.io/oss-fuzz-base/base-builder
+  
+  # Install basic packages and Bazel dependencies.
+  RUN apt-get update && apt-get install -y software-properties-common python-software-properties
+  RUN add-apt-repository ppa:webupd8team/java
+  RUN apt-get update && apt-get -y install ${'\\'}
+    autoconf ${'\\'}
+    build-essential ${'\\'}
+    curl ${'\\'}
+    libtool ${'\\'}
+    make ${'\\'}
+    openjdk-8-jdk ${'\\'}
+    vim
+  
+  <%include file="../../bazel.include"/>
+  
+  RUN mkdir -p /var/local/jenkins
+  
+  # Define the default command.
+  CMD ["bash"]

--- a/templates/tools/dockerfile/test/sanity/Dockerfile.template
+++ b/templates/tools/dockerfile/test/sanity/Dockerfile.template
@@ -38,21 +38,8 @@
   RUN echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/sources.list
   RUN apt-get update
   RUN apt-get install -y -t jessie-backports openjdk-8-jdk
-
-  #========================
-  # Bazel installation
-  RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/bazel.list
-  RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-  RUN apt-get -y update
-  RUN apt-get -y install bazel
-
-  # Pin Bazel to 0.9.0
-  # Installing Bazel via apt-get first is required before installing 0.9.0 to
-  # allow gRPC to build without errors. See https://github.com/grpc/grpc/issues/10553
-  RUN curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.9.0/bazel-0.9.0-installer-linux-x86_64.sh
-  RUN chmod +x ./bazel-0.9.0-installer-linux-x86_64.sh
-  RUN ./bazel-0.9.0-installer-linux-x86_64.sh
   
+  <%include file="../../bazel.include"/>
   <%include file="../../clang5.include"/>
   <%include file="../../run_tests_addons.include"/>
   

--- a/tools/distrib/python/make_grpcio_tools.py
+++ b/tools/distrib/python/make_grpcio_tools.py
@@ -98,6 +98,7 @@ def protobuf_submodule_commit_hash():
 
 
 def bazel_query(query):
+    print('Running "bazel query %s"' % query)
     output = subprocess.check_output([BAZEL_DEPS, query])
     return output.splitlines()
 
@@ -156,6 +157,7 @@ def main():
                 shutil.copyfile(source_file, target_file)
 
     try:
+        print('Invoking "bazel query" to gather the protobuf dependencies.')
         protoc_lib_deps_content = get_deps()
     except Exception as error:
         # We allow this script to succeed even if we couldn't get the dependencies,
@@ -167,6 +169,8 @@ def main():
     # If we successfully got the dependencies, truncate and rewrite the deps file.
     with open(GRPC_PYTHON_PROTOC_LIB_DEPS, 'w') as deps_file:
         deps_file.write(protoc_lib_deps_content)
+    print('File "%s" updated.' % GRPC_PYTHON_PROTOC_LIB_DEPS)
+    print('Done.')
 
 
 if __name__ == '__main__':

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -30,15 +30,8 @@ RUN apt-get update && apt-get -y install \
 # Bazel installation
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/bazel.list
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-RUN apt-get -y update
-RUN apt-get -y install bazel
+RUN apt-get -y update && apt-get -y install bazel=0.13.1 && apt-get clean
 
-# Pin Bazel to 0.9.0
-# Installing Bazel via apt-get first is required before installing 0.9.0 to
-# allow gRPC to build without errors. See https://github.com/grpc/grpc/issues/10553
-RUN curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.9.0/bazel-0.9.0-installer-linux-x86_64.sh
-RUN chmod +x ./bazel-0.9.0-installer-linux-x86_64.sh
-RUN ./bazel-0.9.0-installer-linux-x86_64.sh
 
 RUN mkdir -p /var/local/jenkins
 

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -95,15 +95,7 @@ RUN apt-get install -y -t jessie-backports openjdk-8-jdk
 # Bazel installation
 RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" > /etc/apt/sources.list.d/bazel.list
 RUN curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-RUN apt-get -y update
-RUN apt-get -y install bazel
-
-# Pin Bazel to 0.9.0
-# Installing Bazel via apt-get first is required before installing 0.9.0 to
-# allow gRPC to build without errors. See https://github.com/grpc/grpc/issues/10553
-RUN curl -fSsL -O https://github.com/bazelbuild/bazel/releases/download/0.9.0/bazel-0.9.0-installer-linux-x86_64.sh
-RUN chmod +x ./bazel-0.9.0-installer-linux-x86_64.sh
-RUN ./bazel-0.9.0-installer-linux-x86_64.sh
+RUN apt-get -y update && apt-get -y install bazel=0.13.1 && apt-get clean
 
 RUN apt-get update && apt-get -y install wget xz-utils
 RUN wget http://releases.llvm.org/5.0.0/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04.tar.xz


### PR DESCRIPTION
- make_grpcio_tools.py currently doesn't work if it falls back to using bazel from a dockerimage (= if bazel is not installed locally). See https://github.com/grpc/grpc/pull/15492#issuecomment-390758571.
