### PR TITLE
Fix data race in call combiner

### DIFF
--- a/src/core/lib/iomgr/call_combiner.h
+++ b/src/core/lib/iomgr/call_combiner.h
@@ -28,6 +28,8 @@
 #include "src/core/lib/gpr/mpscq.h"
 #include "src/core/lib/iomgr/closure.h"
 
+struct grpc_call;
+
 // A simple, lock-free mechanism for serializing activity related to a
 // single call.  This is similar to a combiner but is more lightweight.
 //
@@ -46,6 +48,7 @@ typedef struct {
   // a grpc_closure* (if the lowest bit is 0),
   // or a grpc_error* (if the lowest bit is 1).
   gpr_atm cancel_state;
+  grpc_call* call;
 } grpc_call_combiner;
 
 // Assumes memory was initialized to zero.

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -339,6 +339,7 @@ grpc_error* grpc_call_create(const grpc_call_create_args* args,
   gpr_ref_init(&call->ext_ref, 1);
   call->arena = arena;
   grpc_call_combiner_init(&call->call_combiner);
+  call->call_combiner.call = call;
   *out_call = call;
   call->channel = args->channel;
   call->cq = args->cq;


### PR DESCRIPTION
Fix #15457.

1. If `call_combiner->size > 0`, which means there is a closure executing or the queue isn't empty, the call combiner should hold ref(s) to the call to avoid use-after-free issue or data race. The data race in #15457 happens because we are attempting to free the call and access the call combiner size simultaneously. 

2. The log shows that `grpc_call_combiner_start()` may be invoked when the call's internal ref is already 0. So I add a check at the the entry of the function.
