### PR TITLE
Decrease parallelism in interop tests

### DIFF
--- a/tools/internal_ci/linux/grpc_interop_tocloud.cfg
+++ b/tools/internal_ci/linux/grpc_interop_tocloud.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-l all -s all --use_docker --http2_interop --internal_ci -t -j 12 --bq_result_table interop_results"
+  value: "-l all -s all --use_docker --http2_interop --internal_ci -t -j 8 --bq_result_table interop_results"
 }

--- a/tools/internal_ci/linux/grpc_interop_toprod.cfg
+++ b/tools/internal_ci/linux/grpc_interop_toprod.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "-l all --cloud_to_prod --cloud_to_prod_auth --prod_servers default gateway_v4 --use_docker --internal_ci -t -j 12 --bq_result_table interop_results"
+  value: "-l all --cloud_to_prod --cloud_to_prod_auth --prod_servers default gateway_v4 --use_docker --internal_ci -t -j 8 --bq_result_table interop_results"
 }


### PR DESCRIPTION
To see if this helps with https://github.com/grpc/grpc/issues/15540.

Basically we are running 12 parallel builds of all the languages currently.