### PR TITLE
fix makefile's creating of a couple of tests, on msys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,19 @@ SYSTEM ?= $(HOST_SYSTEM)
 ifeq ($(SYSTEM),MSYS)
 SYSTEM = MINGW32
 endif
+ifeq ($(SYSTEM),CYGWIN)
+SYSTEM = MINGW32
+endif
 ifeq ($(SYSTEM),MINGW64)
 SYSTEM = MINGW32
 endif
 
+# add a function we can use to work around cygwin path fixing heuristics which makes hash out of this due to the ':' delimiter mostly: `--grpc_out=generate_mock_code=true:WINDOWSPATH`
+# see http://www.mingw.org/wiki/Posix_path_conversion
+GRPC_FIXPATH = $(1)
+ifeq ($(SYSTEM),MINGW32)
+GRPC_FIXPATH = $(shell cygpath -w $(1))
+endif
 
 MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 ifndef BUILDDIR
@@ -2621,7 +2630,7 @@ $(GENDIR)/src/proto/grpc/testing/compiler_test.pb.cc: src/proto/grpc/testing/com
 $(GENDIR)/src/proto/grpc/testing/compiler_test.grpc.pb.cc: src/proto/grpc/testing/compiler_test.proto $(GENDIR)/src/proto/grpc/testing/compiler_test.pb.cc $(PROTOBUF_DEP) $(PROTOC_PLUGINS) 
 	$(E) "[GRPC]    Generating gRPC's protobuf service CC file from $<"
 	$(Q) mkdir -p `dirname $@`
-	$(Q) $(PROTOC) -Ithird_party/protobuf/src -I. --grpc_out=generate_mock_code=true:$(GENDIR) --plugin=protoc-gen-grpc=$(PROTOC_PLUGINS_DIR)/grpc_cpp_plugin$(EXECUTABLE_SUFFIX) $<
+	$(Q) $(PROTOC) -Ithird_party/protobuf/src -I. --grpc_out=generate_mock_code=true:$(call GRPC_FIXPATH,$(GENDIR)) --plugin=protoc-gen-grpc=$(PROTOC_PLUGINS_DIR)/grpc_cpp_plugin$(EXECUTABLE_SUFFIX) $<
 endif
 
 ifeq ($(NO_PROTOC),true)
@@ -2670,7 +2679,7 @@ $(GENDIR)/src/proto/grpc/testing/echo.pb.cc: src/proto/grpc/testing/echo.proto $
 $(GENDIR)/src/proto/grpc/testing/echo.grpc.pb.cc: src/proto/grpc/testing/echo.proto $(GENDIR)/src/proto/grpc/testing/echo.pb.cc $(PROTOBUF_DEP) $(PROTOC_PLUGINS) $(GENDIR)/src/proto/grpc/testing/echo_messages.pb.cc $(GENDIR)/src/proto/grpc/testing/echo_messages.grpc.pb.cc
 	$(E) "[GRPC]    Generating gRPC's protobuf service CC file from $<"
 	$(Q) mkdir -p `dirname $@`
-	$(Q) $(PROTOC) -Ithird_party/protobuf/src -I. --grpc_out=generate_mock_code=true:$(GENDIR) --plugin=protoc-gen-grpc=$(PROTOC_PLUGINS_DIR)/grpc_cpp_plugin$(EXECUTABLE_SUFFIX) $<
+	$(Q) $(PROTOC) -Ithird_party/protobuf/src -I. --grpc_out=generate_mock_code=true:$(call GRPC_FIXPATH,$(GENDIR)) --plugin=protoc-gen-grpc=$(PROTOC_PLUGINS_DIR)/grpc_cpp_plugin$(EXECUTABLE_SUFFIX) $<
 endif
 
 ifeq ($(NO_PROTOC),true)


### PR DESCRIPTION
When using msys:

Due to protoc's peculiar use of `:` as a delimeter between parameters and (possibly) paths, `make` cannot build `compiler_test.grpc.pb.cc` or `echo.grpc.pb.cc:`. This is because `--grpc_out=generate_mock_code=true:$(GENDIR)` turns into something like `--grpc_out=generate_mock_code=true;c:/path/to/stuff` which then gets tokenized into `generate_mock_code=true;c` and `/path/to/stuff` 

I *do not* advise you to read more about why this happens at the following url, since you may be struck instantly insane: http://www.mingw.org/wiki/Posix_path_conversion

Here's a person who had the same problem, I'm pretty sure: https://groups.google.com/forum/#!msg/grpc-io/f9mQO5JikW0/oK47Dl8EBwAJ

I've solved the problem kind of arbitrarily by just doing something different so msys isn't agitated; so there may be other solutions. This is simply the first one I found.

I also added detection for cygwin, besides msys, but I didn't test that. I don't think it can hurt anything

I lost interest running the tests on my linux VM when it ran out of disk space. Since this is a fix to the makefile, I figure as long as it still _builds_, it's OK (and it does)