### PR TITLE
Change virtualenv path for interop tests for Python 1.10.1

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -388,5 +388,5 @@ TESTCASES_VERSION_MATRIX = {
     'python_v1.7.2': 'python__v1.0.x',
     'python_v1.8.1': 'python__v1.0.x',
     'python_v1.9.1': 'python__v1.0.x',
-    'python_v1.10.0': 'python__v1.0.x',
+    'python_v1.10.1': 'python__v1.0.x',
 }


### PR DESCRIPTION
Fixes #15551