### PR TITLE
Init connect timer before calling connect

### DIFF
--- a/src/core/lib/iomgr/tcp_client_custom.cc
+++ b/src/core/lib/iomgr/tcp_client_custom.cc
@@ -140,12 +140,12 @@ static void tcp_connect(grpc_closure* closure, grpc_endpoint** ep,
             socket, connect->addr_name);
   }
 
-  grpc_custom_socket_vtable->connect(
-      socket, (const grpc_sockaddr*)resolved_addr->addr, resolved_addr->len,
-      custom_connect_callback);
   GRPC_CLOSURE_INIT(&connect->on_alarm, on_alarm, socket,
                     grpc_schedule_on_exec_ctx);
   grpc_timer_init(&connect->alarm, deadline, &connect->on_alarm);
+  grpc_custom_socket_vtable->connect(
+      socket, (const grpc_sockaddr*)resolved_addr->addr, resolved_addr->len,
+      custom_connect_callback);
 }
 
 grpc_tcp_client_vtable custom_tcp_client_vtable = {tcp_connect};


### PR DESCRIPTION
#15545

I wasn't able to reproduce locally, but from the stack trace, I think I can tell what is happening.
From the user's stack trace, it looks like connect is invoking the custom_connect_callback immediately.

This tries to cancel the timer, but the timer hasn't yet been initialized, so this moves timer initialization before the connect call.
