### PR TITLE
Default Off for Tracers, Delete an Unused One

### DIFF
--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -67,7 +67,6 @@ some configuration as environment variables that can be set.
   - resource_quota - trace resource quota objects internals
   - round_robin - traces the round_robin load balancing policy
   - queue_pluck
-  - queue_timeout
   - server_channel - lightweight trace of significant server channel events
   - secure_endpoint - traces bytes flowing through encrypted channels
   - timer - timers (alarms) in the grpc internals

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -321,8 +321,7 @@ static const cq_vtable g_cq_vtable[] = {
 #define POLLSET_FROM_CQ(cq) \
   ((grpc_pollset*)(cq->vtable->data_size + (char*)DATA_FROM_CQ(cq)))
 
-grpc_core::TraceFlag grpc_cq_pluck_trace(true, "queue_pluck");
-grpc_core::TraceFlag grpc_cq_event_timeout_trace(true, "queue_timeout");
+grpc_core::TraceFlag grpc_cq_pluck_trace(false, "queue_pluck");
 
 #define GRPC_SURFACE_TRACE_RETURNED_EVENT(cq, event)                       \
   if (grpc_api_trace.enabled() && (grpc_cq_pluck_trace.enabled() ||        \

--- a/src/core/lib/surface/completion_queue.h
+++ b/src/core/lib/surface/completion_queue.h
@@ -30,7 +30,6 @@
 /* These trace flags default to 1. The corresponding lines are only traced
    if grpc_api_trace is also truthy */
 extern grpc_core::TraceFlag grpc_cq_pluck_trace;
-extern grpc_core::TraceFlag grpc_cq_event_timeout_trace;
 extern grpc_core::TraceFlag grpc_trace_operation_failures;
 extern grpc_core::DebugOnlyTraceFlag grpc_trace_pending_tags;
 extern grpc_core::DebugOnlyTraceFlag grpc_trace_cq_refcount;


### PR DESCRIPTION
`grpc_cq_pluck_trace` should not have been default on...

Also `grpc_cq_event_timeout_trace` was never being used