### PR TITLE
Make Combiner Tracer Debug Only

### DIFF
--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -44,7 +44,6 @@ some configuration as environment variables that can be set.
   - channel - traces operations on the C core channel stack
   - client_channel - traces client channel activity, including resolver
     and load balancing policy interaction
-  - combiner - traces combiner lock state
   - compression - traces compression operations
   - connectivity_state - traces connectivity state changes to channels
   - executor - traces grpc's internal thread pool ('the executor')
@@ -80,6 +79,7 @@ some configuration as environment variables that can be set.
   accomplished by invoking `CONFIG=dbg make <target>`
   - alarm_refcount - refcounting traces for grpc_alarm structure
   - metadata - tracks creation and mutation of metadata
+  - combiner - traces combiner lock state
   - closure - tracks closure creation, scheduling, and completion
   - pending_tags - traces still-in-progress tags on completion queues
   - polling - traces the selected polling engine

--- a/src/core/lib/iomgr/combiner.cc
+++ b/src/core/lib/iomgr/combiner.cc
@@ -31,7 +31,7 @@
 #include "src/core/lib/iomgr/executor.h"
 #include "src/core/lib/profiling/timers.h"
 
-grpc_core::TraceFlag grpc_combiner_trace(false, "combiner");
+grpc_core::DebugOnlyTraceFlag grpc_combiner_trace(false, "combiner");
 
 #define GRPC_COMBINER_TRACE(fn)          \
   do {                                   \

--- a/src/core/lib/iomgr/combiner.h
+++ b/src/core/lib/iomgr/combiner.h
@@ -61,6 +61,6 @@ grpc_closure_scheduler* grpc_combiner_finally_scheduler(grpc_combiner* lock);
 
 bool grpc_combiner_continue_exec_ctx();
 
-extern grpc_core::TraceFlag grpc_combiner_trace;
+extern grpc_core::DebugOnlyTraceFlag grpc_combiner_trace;
 
 #endif /* GRPC_CORE_LIB_IOMGR_COMBINER_H */


### PR DESCRIPTION
This is the spammiest tracer, and I have never used it to debug someone's issue.

cc @markdroth, @dgquintas, @yang-g, please push back if you have found this tracer to be helpful in debugging client issues