### PR TITLE
PHP: fix qps benchmark failure by updating composer protobuf

### DIFF
--- a/src/php/tests/qps/composer.json
+++ b/src/php/tests/qps/composer.json
@@ -1,7 +1,7 @@
 {
   "require": {
     "grpc/grpc": "dev-master",
-    "google/protobuf": "v3.4.1"
+    "google/protobuf": "v3.5.1.1"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Running `grpc_full_performance_master` test.

Currently all pb files are updated with protoc 3.5.1.1 by #15107, the error happens when it wants to use protobuf PHP 3.4.1.