### PR TITLE
Ref tcp server under lock

### DIFF
--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -179,8 +179,8 @@ static void on_accept(void* arg, grpc_endpoint* tcp,
   grpc_handshake_manager* handshake_mgr = grpc_handshake_manager_create();
   grpc_handshake_manager_pending_list_add(&state->pending_handshake_mgrs,
                                           handshake_mgr);
-  gpr_mu_unlock(&state->mu);
   grpc_tcp_server_ref(state->tcp_server);
+  gpr_mu_unlock(&state->mu);
   server_connection_state* connection_state =
       static_cast<server_connection_state*>(
           gpr_zalloc(sizeof(*connection_state)));


### PR DESCRIPTION
Fixes #14614

It looks like we should have short circuited the ```on_accept``` callback a few lines above when we detected the server was shutdown, but because we did it outside of the mutex, there was a race condition.

With this change I got > 2000 clean runs:

```
/tools/run_tests/run_tests.py -l c++ -c tsan -r PickFirstBackOffInitialReconnect --force_use_pollers=epollex -n inf -a 10 -S 
PASSED: make [time=97.9sec, retries=0:0]2018-05-31 14:26:33,973 detected port server running version 20
2018-05-31 14:26:34,054 my port server is version 20
WAITING: 12 jobs running, 2052 complete, 0 failed (load 12.00) next: bins/tsan/client_lb_end2end_test --gtest_filter=ClientLbEnd2endTest.PickFirstBackOffInitialReconnect  GRPC_POLL_STRATEGY=epollex
```