### PR TITLE
PHP: fix flaky tests

### DIFF
--- a/src/php/tests/unit_tests/CallCredentials2Test.php
+++ b/src/php/tests/unit_tests/CallCredentials2Test.php
@@ -35,6 +35,7 @@ class CallCredentials2Test extends PHPUnit_Framework_TestCase
         $this->channel = new Grpc\Channel(
             'localhost:'.$this->port,
             [
+            'force_new' => true,
             'grpc.ssl_target_name_override' => $this->host_override,
             'grpc.default_authority' => $this->host_override,
             'credentials' => $credentials,

--- a/src/php/tests/unit_tests/CallCredentialsTest.php
+++ b/src/php/tests/unit_tests/CallCredentialsTest.php
@@ -41,6 +41,7 @@ class CallCredentialsTest extends PHPUnit_Framework_TestCase
         $this->channel = new Grpc\Channel(
             'localhost:'.$this->port,
             [
+            'force_new' => true,
             'grpc.ssl_target_name_override' => $this->host_override,
             'grpc.default_authority' => $this->host_override,
             'credentials' => $this->credentials,

--- a/src/php/tests/unit_tests/CallTest.php
+++ b/src/php/tests/unit_tests/CallTest.php
@@ -24,12 +24,14 @@ class CallTest extends PHPUnit_Framework_TestCase
     public static function setUpBeforeClass()
     {
         self::$server = new Grpc\Server([]);
-        self::$port = self::$server->addHttp2Port('0.0.0.0:0');
+        self::$port = self::$server->addHttp2Port('0.0.0.0:53000');
     }
 
     public function setUp()
     {
-        $this->channel = new Grpc\Channel('localhost:'.self::$port, []);
+        $this->channel = new Grpc\Channel('localhost:'.self::$port, [
+            'force_new' => true,
+        ]);
         $this->call = new Grpc\Call($this->channel,
                                     '/foo',
                                     Grpc\Timeval::infFuture());

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -22,13 +22,16 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     {
         $this->server = new Grpc\Server([]);
         $this->port = $this->server->addHttp2Port('0.0.0.0:0');
-        $this->channel = new Grpc\Channel('localhost:'.$this->port, []);
+        $this->channel = new Grpc\Channel('localhost:'.$this->port, [
+            "force_new" => true,
+        ]);
         $this->server->start();
     }
 
     public function tearDown()
     {
         $this->channel->close();
+        unset($this->server);
     }
 
     public function testSimpleRequestBody()

--- a/src/php/tests/unit_tests/InterceptorTest.php
+++ b/src/php/tests/unit_tests/InterceptorTest.php
@@ -206,13 +206,16 @@ class InterceptorTest extends PHPUnit_Framework_TestCase
     {
         $this->server = new Grpc\Server([]);
         $this->port = $this->server->addHttp2Port('0.0.0.0:0');
-        $this->channel = new Grpc\Channel('localhost:'.$this->port, ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
+        $this->channel = new Grpc\Channel('localhost:'.$this->port, [
+            'force_new' => true,
+            'credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->server->start();
     }
 
     public function tearDown()
     {
         $this->channel->close();
+        unset($this->server);
     }
 
 
@@ -222,6 +225,7 @@ class InterceptorTest extends PHPUnit_Framework_TestCase
         $channel_matadata_interceptor = new ChangeMetadataInterceptor();
         $intercept_channel = Grpc\Interceptor::intercept($this->channel, $channel_matadata_interceptor);
         $client = new InterceptorClient('localhost:'.$this->port, [
+            'force_new' => true,
             'credentials' => Grpc\ChannelCredentials::createInsecure(),
         ], $intercept_channel);
         $req = new SimpleRequest($req_text);
@@ -250,6 +254,7 @@ class InterceptorTest extends PHPUnit_Framework_TestCase
         $intercept_channel1 = Grpc\Interceptor::intercept($this->channel, $channel_matadata_interceptor);
         $intercept_channel2 = Grpc\Interceptor::intercept($intercept_channel1, $channel_matadata_intercepto2);
         $client = new InterceptorClient('localhost:'.$this->port, [
+            'force_new' => true,
             'credentials' => Grpc\ChannelCredentials::createInsecure(),
         ], $intercept_channel2);
 
@@ -275,6 +280,7 @@ class InterceptorTest extends PHPUnit_Framework_TestCase
         $intercept_channel3 = Grpc\Interceptor::intercept($this->channel,
             [$channel_matadata_intercepto2, $channel_matadata_interceptor]);
         $client = new InterceptorClient('localhost:'.$this->port, [
+            'force_new' => true,
             'credentials' => Grpc\ChannelCredentials::createInsecure(),
         ], $intercept_channel3);
 
@@ -304,6 +310,7 @@ class InterceptorTest extends PHPUnit_Framework_TestCase
         $intercept_channel = Grpc\Interceptor::intercept($this->channel,
             $change_request_interceptor);
         $client = new InterceptorClient('localhost:'.$this->port, [
+            'force_new' => true,
             'credentials' => Grpc\ChannelCredentials::createInsecure(),
         ], $intercept_channel);
 
@@ -354,6 +361,7 @@ class InterceptorTest extends PHPUnit_Framework_TestCase
         $intercept_channel = Grpc\Interceptor::intercept($this->channel,
             $channel_request_interceptor);
         $client = new InterceptorClient('localhost:'.$this->port, [
+            'force_new' => true,
             'credentials' => Grpc\ChannelCredentials::createInsecure(),
         ], $intercept_channel);
 
@@ -374,7 +382,10 @@ class InterceptorTest extends PHPUnit_Framework_TestCase
     {
         $channel = new Grpc\Channel(
             'localhost:0',
-            ['credentials' => Grpc\ChannelCredentials::createInsecure()]
+            [
+                'force_new' => true,
+                'credentials' => Grpc\ChannelCredentials::createInsecure()
+            ]
         );
         $interceptor_channel = Grpc\Interceptor::intercept($channel, new Grpc\Interceptor());
         $state = $interceptor_channel->getConnectivityState();
@@ -386,7 +397,10 @@ class InterceptorTest extends PHPUnit_Framework_TestCase
     {
         $channel = new Grpc\Channel(
             'localhost:0',
-            ['credentials' => Grpc\ChannelCredentials::createInsecure()]
+            [
+                'force_new' => true,
+                'credentials' => Grpc\ChannelCredentials::createInsecure()
+            ]
         );
         $interceptor_channel = Grpc\Interceptor::intercept($channel, new Grpc\Interceptor());
         $now = Grpc\Timeval::now();
@@ -402,7 +416,10 @@ class InterceptorTest extends PHPUnit_Framework_TestCase
     {
         $channel = new Grpc\Channel(
             'localhost:0',
-            ['credentials' => Grpc\ChannelCredentials::createInsecure()]
+            [
+                'force_new' => true,
+                'credentials' => Grpc\ChannelCredentials::createInsecure()
+            ]
         );
         $interceptor_channel = Grpc\Interceptor::intercept($channel, new Grpc\Interceptor());
         $this->assertNotNull($interceptor_channel);
@@ -413,7 +430,10 @@ class InterceptorTest extends PHPUnit_Framework_TestCase
     {
         $channel = new Grpc\Channel(
             'localhost:8888',
-            ['credentials' => Grpc\ChannelCredentials::createInsecure()]
+            [
+                'force_new' => true,
+                'credentials' => Grpc\ChannelCredentials::createInsecure()
+            ]
         );
         $interceptor_channel = Grpc\Interceptor::intercept($channel, new Grpc\Interceptor());
         $target = $interceptor_channel->getTarget();

--- a/src/php/tests/unit_tests/SecureEndToEndTest.php
+++ b/src/php/tests/unit_tests/SecureEndToEndTest.php
@@ -34,6 +34,7 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase
         $this->channel = new Grpc\Channel(
             'localhost:'.$this->port,
             [
+            'force_new' => true,
             'grpc.ssl_target_name_override' => $this->host_override,
             'grpc.default_authority' => $this->host_override,
             'credentials' => $credentials,
@@ -44,6 +45,7 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $this->channel->close();
+        unset($this->server);
     }
 
     public function testSimpleRequestBody()

--- a/src/php/tests/unit_tests/ServerTest.php
+++ b/src/php/tests/unit_tests/ServerTest.php
@@ -55,7 +55,10 @@ class ServerTest extends PHPUnit_Framework_TestCase
         $port = $this->server->addHttp2Port('0.0.0.0:0');
         $this->server->start();
         $channel = new Grpc\Channel('localhost:'.$port,
-             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
+             [
+                 'force_new' => true,
+                 'credentials' => Grpc\ChannelCredentials::createInsecure()
+             ]);
 
         $deadline = Grpc\Timeval::infFuture();
         $call = new Grpc\Call($channel, 'dummy_method', $deadline);


### PR DESCRIPTION
Solve issue #15582.

Before: hang for running ~<500 times on gLinux.
After: pass for 5000 times. No flaky.

Root cause: some tests use the port `localhost:0`, which will use a random port. However, in php tests, all objects allocated in C level can live cross scripts, it will make some unexpected behavior. Seems this issue exist long time ago.

For some system can't reproduce it, I guess it is either it checks the port `localhost:0` usage, or deal with `CLOSE_WAIT/FIN_WAIT2` differently, like small timeout.

**For timeout issue:**

Solution:
1. Add `unset($this->server)`, otherwise [`grpc_server_destroy`](https://github.com/grpc/grpc/blob/master/src/php/ext/grpc/server.c#L38) won't be executed, which leads to the port still connected after the test:
```
TCP localhost:49406->localhost:50123 (ESTABLISHED)
TCP localhost:50123->localhost:49406 (ESTABLISHED)
```

2. Add `force_new => true`. Adding `unset($this->server)` is not enough because it will leads to
```
TCP localhost:49406->localhost:50123 (CLOSE_WAIT)
TCP localhost:50123->localhost:49406 (FIN_WAIT2)
```
This is because `$channel->close()` won't call `grpc_channel_destroy()` when it is persisted. This is the same cause as #13474. Although the client is fixed by this issue, the php server will still hang on [grpc_completion_queue_pluck](https://github.com/grpc/grpc/blob/master/src/php/ext/grpc/server.c#L113). I guess the `CLOSE_WAIT` takes the request sent by the client, which leads to `grpc_completion_queue_pluck` waiting for something never come.

**For flaky issue**

Solution:
Add `force_new => true`.
(`grpc_persistent_per_target => 0` should work as well.)

If the random port already exists in the persistent list, it will re-use a channel created by other tests. If that channel has already been closed or has the status `CONNECTING`, it is conflict with the assert that a new created Channel should be `Idle`.
