### PR TITLE
Use gevent greenlets for metadata callbacks

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -17,6 +17,17 @@ cimport cpython
 import grpc
 import threading
 
+def _spawn_callback_in_thread(cb_func, args):
+  threading.Thread(target=cb_func, args=args).start()
+
+async_callback_func = _spawn_callback_in_thread
+
+def set_async_callback_func(callback_func):
+  global async_callback_func
+  async_callback_func = callback_func
+
+def _spawn_callback_async(callback, args):
+  async_callback_func(callback, args)
 
 cdef class CallCredentials:
 
@@ -40,7 +51,7 @@ cdef int _get_metadata(
     else:
       cb(user_data, NULL, 0, status, error_details)
   args = context.service_url, context.method_name, callback,
-  threading.Thread(target=<object>state, args=args).start()
+  _spawn_callback_async(<object>state, args)
   return 0  # Asynchronous return
 
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx
@@ -418,6 +418,11 @@ def init_grpc_gevent():
 
   g_event = gevent.event.Event()
   g_pool = gevent.pool.Group()
+
+  def cb_func(cb, args):
+    _spawn_greenlet(cb, *args)
+  set_async_callback_func(cb_func)
+
   gevent_resolver_vtable.resolve = socket_resolve
   gevent_resolver_vtable.resolve_async = socket_resolve_async
 


### PR DESCRIPTION
Fixes #15071

If we don't explicitly track this callback in our gevent pool, it won't work well with gunicorn.