### PR TITLE
pin google-api-python-client to 1.6.7 to avoid breakage

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -34,7 +34,8 @@ sudo systemsetup -setusingnetworktime on
 date
 
 # Add GCP credentials for BQ access
-pip install google-api-python-client --user python
+# pin google-api-python-client to avoid https://github.com/grpc/grpc/issues/15600
+pip install google-api-python-client==1.6.7 --user python
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json
 
 # If this is a PR using RUN_TESTS_FLAGS var, then add flags to filter tests


### PR DESCRIPTION
Tentative fix for https://github.com/grpc/grpc/issues/15600.

(looks like google-api-python-client 1.7.0 was released 11 hours ago, which seems to coincide with the breakage
https://pypi.org/project/google-api-python-client/#history)