### PR TITLE
 Install Python 3.7 in pyenv Dockerfile

### DIFF
--- a/templates/tools/dockerfile/apt_get_pyenv.include
+++ b/templates/tools/dockerfile/apt_get_pyenv.include
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y ${'\\'}
   mercurial ${'\\'}
   zlib1g-dev && apt-get clean
 
-# Install Pyenv and dev Python versions 3.5 and 3.6
+# Install Pyenv and dev Python versions 3.{5,6,7}
 RUN curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
 ENV PATH /root/.pyenv/bin:$PATH
 RUN eval "$(pyenv init -)"
@@ -18,5 +18,6 @@ RUN eval "$(pyenv virtualenv-init -)"
 RUN pyenv update
 RUN pyenv install 3.5-dev
 RUN pyenv install 3.6-dev
+RUN pyenv install 3.7-dev
 RUN pyenv install pypy-5.3.1
-RUN pyenv local 3.5-dev 3.6-dev pypy-5.3.1
+RUN pyenv local 3.5-dev 3.6-dev 3.7-dev pypy-5.3.1

--- a/templates/tools/dockerfile/test/python_pyenv_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_pyenv_x64/Dockerfile.template
@@ -20,9 +20,9 @@
   <%include file="../../gcp_api_libraries.include"/>
   <%include file="../../python_deps.include"/>
   <%include file="../../apt_get_pyenv.include"/>
-  # Install pip and virtualenv for Python 3.4
-  RUN curl https://bootstrap.pypa.io/get-pip.py | python3.4
-  RUN python3.4 -m pip install virtualenv
+  # Install pip and virtualenv for Python 3.5
+  RUN curl https://bootstrap.pypa.io/get-pip.py | python3.5
+  RUN python3.5 -m pip install virtualenv
 
   <%include file="../../run_tests_addons.include"/>
   # Define the default command.

--- a/templates/tools/dockerfile/test/python_pyenv_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_pyenv_x64/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM debian:jessie
+  FROM debian:stretch
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../gcp_api_libraries.include"/>

--- a/tools/dockerfile/test/python_pyenv_x64/Dockerfile
+++ b/tools/dockerfile/test/python_pyenv_x64/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+FROM debian:stretch
 
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
@@ -80,7 +80,7 @@ RUN apt-get update && apt-get install -y \
   mercurial \
   zlib1g-dev && apt-get clean
 
-# Install Pyenv and dev Python versions 3.5 and 3.6
+# Install Pyenv and dev Python versions 3.{5,6,7}
 RUN curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
 ENV PATH /root/.pyenv/bin:$PATH
 RUN eval "$(pyenv init -)"
@@ -88,12 +88,13 @@ RUN eval "$(pyenv virtualenv-init -)"
 RUN pyenv update
 RUN pyenv install 3.5-dev
 RUN pyenv install 3.6-dev
+RUN pyenv install 3.7-dev
 RUN pyenv install pypy-5.3.1
-RUN pyenv local 3.5-dev 3.6-dev pypy-5.3.1
+RUN pyenv local 3.5-dev 3.6-dev 3.7-dev pypy-5.3.1
 
-# Install pip and virtualenv for Python 3.4
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3.4
-RUN python3.4 -m pip install virtualenv
+# Install pip and virtualenv for Python 3.5
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3.5
+RUN python3.5 -m pip install virtualenv
 
 
 RUN mkdir /var/local/jenkins


### PR DESCRIPTION
Bump pyenv Dockerfile to Debian stretch that provides
OpenSSL 1.0.2+ which is required to build Python 3.7
and get Python 3.7 installed in the test docker
image.

Progress toward https://github.com/grpc/grpc/issues/15191