### PR TITLE
Revert "pin google-api-python-client to 1.6.7 to avoid breakage"

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -28,8 +28,7 @@ sudo systemsetup -setusingnetworktime on
 date
 
 # Add GCP credentials for BQ access
-# pin google-api-python-client to avoid https://github.com/grpc/grpc/issues/15600
-pip install google-api-python-client==1.6.7 --user python
+pip install google-api-python-client --user python
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json
 
 # If this is a PR using RUN_TESTS_FLAGS var, then add flags to filter tests


### PR DESCRIPTION
Reverts grpc/grpc#15602

Looks like https://github.com/google/google-api-python-client/issues/516#issuecomment-393947189 has already been fixed, so removing the hotfix for #15600.

A look at 
https://pypi.org/project/google-api-python-client/#history confirms that 1.7.1 has been published.

