### PR TITLE
run_interop_matrix.py speedup

### DIFF
--- a/tools/internal_ci/linux/grpc_interop_matrix.sh
+++ b/tools/internal_ci/linux/grpc_interop_matrix.sh
@@ -22,4 +22,4 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-tools/interop_matrix/run_interop_matrix_tests.py --language=all --release=all --allow_flakes --report_file=sponge_log.xml --bq_result_table interop_results $@
+tools/interop_matrix/run_interop_matrix_tests.py $RUN_TESTS_FLAGS

--- a/tools/internal_ci/linux/pull_request/grpc_interop_matrix_adhoc.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_interop_matrix_adhoc.cfg
@@ -26,5 +26,5 @@ action {
 
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "--language=all --release=all --allow_flakes --report_file=sponge_log.xml --bq_result_table interop_results"
+  value: "--language=all --release=all --allow_flakes --report_file=sponge_log.xml"
 }

--- a/tools/interop_matrix/run_interop_matrix_tests.py
+++ b/tools/interop_matrix/run_interop_matrix_tests.py
@@ -244,8 +244,7 @@ def run_tests_for_lang(lang, runtime, images):
     pull_images_for_lang(lang, images)
 
     total_num_failures = 0
-    for image_tuple in images:
-        release, image = image_tuple
+    for release, image in images:
         jobset.message('START', 'Testing %s' % image, do_newline=True)
 
         suite_name = '%s__%s_%s' % (lang, runtime, release)


### PR DESCRIPTION
interop matrix now takes several hours to run, while there's only a few minutes worth of tests to run. Most time is spent downloading images, and those are downloaded one by one.
- download all images for given language in parallel (that will also allow downloading of shared portions of the images only once - right now we need to re-download because every lang/release deletes the image eagerly).