### PR TITLE
Run interop tests using python3.4 (and build interop with 3.4 only)

### DIFF
--- a/src/python/grpcio_tests/tests/interop/methods.py
+++ b/src/python/grpcio_tests/tests/interop/methods.py
@@ -391,7 +391,7 @@ def _custom_metadata(stub):
         if trailing_metadata[_TRAILING_METADATA_KEY] != trailing_metadata_value:
             raise ValueError('expected trailing metadata %s, got %s' %
                              (trailing_metadata_value,
-                              initial_metadata[_TRAILING_METADATA_KEY]))
+                              trailing_metadata[_TRAILING_METADATA_KEY]))
 
     # Testing with UnaryCall
     request = messages_pb2.SimpleRequest(

--- a/src/python/grpcio_tests/tests/interop/methods.py
+++ b/src/python/grpcio_tests/tests/interop/methods.py
@@ -377,7 +377,7 @@ def _unimplemented_service(unimplemented_service_stub):
 
 def _custom_metadata(stub):
     initial_metadata_value = "test_initial_metadata_value"
-    trailing_metadata_value = "\x0a\x0b\x0a\x0b\x0a\x0b"
+    trailing_metadata_value = b"\x0a\x0b\x0a\x0b\x0a\x0b"
     metadata = ((_INITIAL_METADATA_KEY, initial_metadata_value),
                 (_TRAILING_METADATA_KEY, trailing_metadata_value))
 

--- a/src/python/grpcio_tests/tests/interop/methods.py
+++ b/src/python/grpcio_tests/tests/interop/methods.py
@@ -422,7 +422,7 @@ def _compute_engine_creds(stub, args):
 
 def _oauth2_auth_token(stub, args):
     json_key_filename = os.environ[google_auth_environment_vars.CREDENTIALS]
-    wanted_email = json.load(open(json_key_filename, 'rb'))['client_email']
+    wanted_email = json.load(open(json_key_filename, 'r'))['client_email']
     response = _large_unary_common_behavior(stub, True, True, None)
     if wanted_email != response.username:
         raise ValueError('expected username %s, got %s' % (wanted_email,
@@ -435,7 +435,7 @@ def _oauth2_auth_token(stub, args):
 
 def _jwt_token_creds(stub, args):
     json_key_filename = os.environ[google_auth_environment_vars.CREDENTIALS]
-    wanted_email = json.load(open(json_key_filename, 'rb'))['client_email']
+    wanted_email = json.load(open(json_key_filename, 'r'))['client_email']
     response = _large_unary_common_behavior(stub, True, False, None)
     if wanted_email != response.username:
         raise ValueError('expected username %s, got %s' % (wanted_email,
@@ -444,7 +444,7 @@ def _jwt_token_creds(stub, args):
 
 def _per_rpc_creds(stub, args):
     json_key_filename = os.environ[google_auth_environment_vars.CREDENTIALS]
-    wanted_email = json.load(open(json_key_filename, 'rb'))['client_email']
+    wanted_email = json.load(open(json_key_filename, 'r'))['client_email']
     google_credentials, unused_project_id = google_auth.default(
         scopes=[args.oauth_scope])
     call_credentials = grpc.metadata_call_credentials(

--- a/tools/dockerfile/interoptest/grpc_interop_python/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_python/build_interop.sh
@@ -28,5 +28,5 @@ cp -r /var/local/jenkins/service_account $HOME || true
 
 cd /var/local/git/grpc
 
-# interop tests only run using python2.7 currently (and python build is slow)
-tools/run_tests/run_tests.py -l python --compiler python2.7 -c opt --build_only
+# interop tests only run using python3.4 currently (and python build is slow)
+tools/run_tests/run_tests.py -l python --compiler python3.4 -c opt --build_only

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -545,13 +545,13 @@ class PythonLanguage:
 
     def client_cmd(self, args):
         return [
-            'py27_native/bin/python', 'src/python/grpcio_tests/setup.py',
+            'py34_native/bin/python', 'src/python/grpcio_tests/setup.py',
             'run_interop', '--client', '--args="{}"'.format(' '.join(args))
         ]
 
     def client_cmd_http2interop(self, args):
         return [
-            'py27_native/bin/python',
+            'py34_native/bin/python',
             'src/python/grpcio_tests/tests/http2/negative_http2_client.py',
         ] + args
 
@@ -560,7 +560,7 @@ class PythonLanguage:
 
     def server_cmd(self, args):
         return [
-            'py27_native/bin/python', 'src/python/grpcio_tests/setup.py',
+            'py34_native/bin/python', 'src/python/grpcio_tests/setup.py',
             'run_interop', '--server', '--args="{}"'.format(' '.join(args))
         ]
 


### PR DESCRIPTION
- fixes to make sure interop tests can be run using python3.x (without this the tests fail, mostly on bytes vs string problems in python3).
- switch python interop tests to python3.4 (currently running using python2.7)