### PR TITLE
PHP: upgrade interop test google/auth version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "php": ">=5.5.0"
   },
   "require-dev": {
-    "google/auth": "v0.9"
+    "google/auth": "^v1.3.0"
   },
   "suggest": {
     "ext-protobuf": "For better performance, install the protobuf C extension.",

--- a/src/php/composer.json
+++ b/src/php/composer.json
@@ -8,7 +8,7 @@
     "google/protobuf": "^v3.3.0"
   },
   "require-dev": {
-    "google/auth": "v0.9"
+    "google/auth": "^v1.3.0"
   },
   "autoload": {
     "psr-4": {

--- a/templates/composer.json.template
+++ b/templates/composer.json.template
@@ -11,7 +11,7 @@
       "php": ">=5.5.0"
     },
     "require-dev": {
-      "google/auth": "v0.9"
+      "google/auth": "^v1.3.0"
     },
     "suggest": {
       "ext-protobuf": "For better performance, install the protobuf C extension.",

--- a/templates/src/php/composer.json.template
+++ b/templates/src/php/composer.json.template
@@ -10,7 +10,7 @@
       "google/protobuf": "^v3.3.0"
     },
     "require-dev": {
-      "google/auth": "v0.9"
+      "google/auth": "^v1.3.0"
     },
     "autoload": {
       "psr-4": {


### PR DESCRIPTION
For issue #12490
`^v1.3.0` means using the latest version greater than `v1.3.0`.