### PR TITLE
Avoid allocating the peer string returned from the transport.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1451,10 +1451,8 @@ static void perform_stream_op_locked(void* stream_op,
       }
     }
     if (op_payload->send_initial_metadata.peer_string != nullptr) {
-      char* old_peer_string = (char*)gpr_atm_full_xchg(
-          op_payload->send_initial_metadata.peer_string,
-          (gpr_atm)gpr_strdup(t->peer_string));
-      gpr_free(old_peer_string);
+      gpr_atm_rel_store(op_payload->send_initial_metadata.peer_string,
+                        (gpr_atm)t->peer_string);
     }
   }
 
@@ -1569,10 +1567,8 @@ static void perform_stream_op_locked(void* stream_op,
     s->trailing_metadata_available =
         op_payload->recv_initial_metadata.trailing_metadata_available;
     if (op_payload->recv_initial_metadata.peer_string != nullptr) {
-      char* old_peer_string = (char*)gpr_atm_full_xchg(
-          op_payload->recv_initial_metadata.peer_string,
-          (gpr_atm)gpr_strdup(t->peer_string));
-      gpr_free(old_peer_string);
+      gpr_atm_rel_store(op_payload->recv_initial_metadata.peer_string,
+                        (gpr_atm)t->peer_string);
     }
     grpc_chttp2_maybe_complete_recv_initial_metadata(t, s);
   }

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -516,7 +516,6 @@ static void release_call(void* call, grpc_error* error) {
   grpc_call* c = static_cast<grpc_call*>(call);
   grpc_channel* channel = c->channel;
   grpc_call_combiner_destroy(&c->call_combiner);
-  gpr_free((char*)c->peer_string);
   grpc_channel_update_call_size_estimate(channel, gpr_arena_destroy(c->arena));
   GRPC_CHANNEL_INTERNAL_UNREF(channel, "call");
 }

--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -168,13 +168,11 @@ struct grpc_transport_stream_op_batch_payload {
     /** Iff send_initial_metadata != NULL, flags associated with
         send_initial_metadata: a bitfield of GRPC_INITIAL_METADATA_xxx */
     uint32_t send_initial_metadata_flags;
-    // If non-NULL, will be set by the transport to the peer string
-    // (a char*, which the caller takes ownership of).
+    // If non-NULL, will be set by the transport to the peer string (a char*).
+    // The transport retains ownership of the string.
     // Note: This pointer may be used by the transport after the
     // send_initial_metadata op is completed.  It must remain valid
     // until the call is destroyed.
-    // Note: When a transport sets this, it must free the previous
-    // value, if any.
     gpr_atm* peer_string;
   } send_initial_metadata;
 
@@ -202,13 +200,11 @@ struct grpc_transport_stream_op_batch_payload {
     // immediately available.  This may be a signal that we received a
     // Trailers-Only response.
     bool* trailing_metadata_available;
-    // If non-NULL, will be set by the transport to the peer string
-    // (a char*, which the caller takes ownership of).
+    // If non-NULL, will be set by the transport to the peer string (a char*).
+    // The transport retains ownership of the string.
     // Note: This pointer may be used by the transport after the
     // recv_initial_metadata op is completed.  It must remain valid
     // until the call is destroyed.
-    // Note: When a transport sets this, it must free the previous
-    // value, if any.
     gpr_atm* peer_string;
   } recv_initial_metadata;
 


### PR DESCRIPTION
I think this should be safe, because the transport should continue to exist until after the call is destroyed.  But let's see if any tests break.