### PR TITLE
Scale Back Concurrency of arena_test

### DIFF
--- a/test/core/gpr/arena_test.cc
+++ b/test/core/gpr/arena_test.cc
@@ -71,7 +71,7 @@ static void test(const char* name, size_t init_size, const size_t* allocs,
   static const size_t allocs_##name[] = {__VA_ARGS__}; \
   test(#name, init_size, allocs_##name, GPR_ARRAY_SIZE(allocs_##name))
 
-#define CONCURRENT_TEST_THREADS 100
+#define CONCURRENT_TEST_THREADS 10
 
 size_t concurrent_test_iterations() {
   if (sizeof(void*) < 8) return 1000;


### PR DESCRIPTION
Fixes #14513 

Looks like this test was too resource heavy for extra overhead needed by TSAN.

I was able to reproduce the timeout locally, and this change fixes it