### PR TITLE
Add git submodule update to extconf

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -69,6 +69,10 @@ ENV['BUILDDIR'] = output_dir
 
 unless windows
   puts 'Building internal gRPC into ' + grpc_lib_dir
+
+  system('git submodule update --init')
+  exit 1 unless $? == 0
+
   nproc = 4
   nproc = Etc.nprocessors * 2 if Etc.respond_to? :nprocessors
   make = bsd ? 'gmake' : 'make'


### PR DESCRIPTION
Fow now, we can't use grpc-ruby gem with specifying commit hash like
below because executing extconf.rb failed while building gem.
The failure is caused by libraries which are needed while
building gem.

```
gem 'grpc', git: 'https://github.com/grpc/grpc', ref: 'ad4312aaa9af13addefdcda24432396b3b083c5e'
```

So I add `git submodule update --init` to extconf.rb to update and
fetch the libraries.

---

### An occured error while installing grpc gem with specifying commit hash

Gemfile

```rb
# frozen_string_literal: true

source "https://rubygems.org"

git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }

gem 'grpc', git: 'https://github.com/grpc/grpc', ref: 'ad4312aaa9af13addefdcda24432396b3b083c5e'
```

and invoke `bundle install`.

```$ bundle install                                                                                                                                                                [13:27:28]
Fetching https://github.com/grpc/grpc
Fetching gem metadata from https://rubygems.org/..........
Resolving dependencies...
Using public_suffix 3.0.2
Using bundler 1.16.1
Using google-protobuf 3.5.1.2 (universal-darwin)
Using multipart-post 2.0.0
Using jwt 2.1.0
Using little-plugger 1.1.4
Using multi_json 1.13.1
Using memoist 0.16.0
Using os 0.9.6
Using addressable 2.5.2
Using faraday 0.15.2
Using googleapis-common-protos-types 1.0.1
Using logging 2.2.2
Using signet 0.8.1
Using googleauth 0.6.2
Using grpc 1.13.0.dev from https://github.com/grpc/grpc (at ad4312a@ad4312a)
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/ganmacs/src/github.com/ganmacs/grpc-test/vendor/bundle/ruby/2.4.0/bundler/gems/grpc-ad4312aaa9af/src/ruby/ext/grpc
/Users/ganmacs/.rbenv/versions/2.4.4/bin/ruby -r ./siteconf20180606-59710-1hvrojy.rb extconf.rb
Building internal gRPC into /Users/ganmacs/src/github.com/ganmacs/grpc-test/vendor/bundle/ruby/2.4.0/bundler/gems/grpc-ad4312aaa9af/src/ruby/ext/grpc/libs/opt
make: Circular /Users/ganmacs/src/github.com/ganmacs/grpc-test/vendor/bundle/ruby/2.4.0/bundler/gems/grpc-ad4312aaa9af/src/ruby/ext/grpc/libs/opt/libares.a <-
/Users/ganmacs/src/github.com/ganmacs/grpc-test/vendor/bundle/ruby/2.4.0/bundler/gems/grpc-ad4312aaa9af/src/ruby/ext/grpc/libs/opt/libz.a dependency dropped.
make: Circular /Users/ganmacs/src/github.com/ganmacs/grpc-test/vendor/bundle/ruby/2.4.0/bundler/gems/grpc-ad4312aaa9af/src/ruby/ext/grpc/libs/opt/libaddress_sorting.a <-
/Users/ganmacs/src/github.com/ganmacs/grpc-test/vendor/bundle/ruby/2.4.0/bundler/gems/grpc-ad4312aaa9af/src/ruby/ext/grpc/libs/opt/libz.a dependency dropped.
make: Circular /Users/ganmacs/src/github.com/ganmacs/grpc-test/vendor/bundle/ruby/2.4.0/bundler/gems/grpc-ad4312aaa9af/src/ruby/ext/grpc/libs/opt/libaddress_sorting.a <-
/Users/ganmacs/src/github.com/ganmacs/grpc-test/vendor/bundle/ruby/2.4.0/bundler/gems/grpc-ad4312aaa9af/src/ruby/ext/grpc/libs/opt/libares.a dependency dropped.
make: *** No rule to make target
`/Users/ganmacs/src/github.com/ganmacs/grpc-test/vendor/bundle/ruby/2.4.0/bundler/gems/grpc-ad4312aaa9af/src/ruby/ext/grpc/objs/opt/third_party/cares/cares/ares__close_sockets.o',
needed by `/Users/ganmacs/src/github.com/ganmacs/grpc-test/vendor/bundle/ruby/2.4.0/bundler/gems/grpc-ad4312aaa9af/src/ruby/ext/grpc/libs/opt/libares.a'.  Stop.
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include
        --without-opt-include=${opt-dir}/include
        --with-opt-lib
        --without-opt-lib=${opt-dir}/lib
        --with-make-prog
        --without-make-prog
        --srcdir=.
        --curdir
        --ruby=/Users/ganmacs/.rbenv/versions/2.4.4/bin/$(RUBY_BASE_NAME)

extconf failed, exit code 1

Gem files will remain installed in /Users/ganmacs/src/github.com/ganmacs/grpc-test/vendor/bundle/ruby/2.4.0/bundler/gems/grpc-ad4312aaa9af for inspection.
Results logged to /Users/ganmacs/src/github.com/ganmacs/grpc-test/vendor/bundle/ruby/2.4.0/bundler/gems/extensions/x86_64-darwin-17/2.4.0/grpc-ad4312aaa9af/gem_make.out

An error occurred while installing grpc (1.13.0.dev), and Bundler cannot continue.

In Gemfile:
  grpc
bundle install  4.27s user 2.80s system 67% cpu 10.511 total
```



#### environment

 * Darwin P1012-17P13U.local 17.5.0 Darwin Kernel Version 17.5.0: Mon Mar  5 22:24:32 PST 2018; root:xnu-4570.51.1~1/RELEASE_X86_64 x86_64
* ruby 2.4.4p296 (2018-03-28 revision 63013) [x86_64-darwin17]




