### PR TITLE
Only build interop tests with python2.7

### DIFF
--- a/tools/dockerfile/interoptest/grpc_interop_python/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_python/build_interop.sh
@@ -28,4 +28,5 @@ cp -r /var/local/jenkins/service_account $HOME || true
 
 cd /var/local/git/grpc
 
-tools/run_tests/run_tests.py -l python -c opt --build_only
+# interop tests only run using python2.7 currently (and python build is slow)
+tools/run_tests/run_tests.py -l python --compiler python2.7 -c opt --build_only


### PR DESCRIPTION
Fixes #15640.

Supersedes #15640 - there are some issues with running interop tests with python3.4 so it make sense to first speed up the build to fix #15640  and the make python2->python3 switch as a separate PR.