### PR TITLE
Make address sorting depend on the same base libs as grpc, for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -700,6 +700,7 @@ target_include_directories(address_sorting
 )
 
 target_link_libraries(address_sorting
+  ${_gRPC_BASELIB_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
 )
 

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -35,7 +35,7 @@
 
   def get_deps(target_dict):
     deps = []
-    if target_dict.get('baselib', False):
+    if target_dict.get('baselib', False) or target_dict['name'] == 'address_sorting':
       deps.append("${_gRPC_BASELIB_LIBRARIES}")
     if target_dict.get('build', None) in ['protoc']:
       deps.append("${_gRPC_PROTOBUF_PROTOC_LIBRARIES}")


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/15333 (I was able to reproduce that issue, and this patch gets rid of the ` error LNK2019: unresolved external symbol __imp__htonl@4 referenced in function _in6_is_addr_loopback [C:\Users\coryan\source\grpc\.build\address_sorting.vcxproj]` error).

This is one way of doing this. It's a little specific to the cmake/windows build, so I'm not sure if this is the best, but it accomplishes the goal is to link address sorting against the same windows base libs as what grpc is linking against, on windows. As an alternative, I looked into setting `baselib: true` in `address_sorting` lib's `build.yaml` entry, but that causes the `libaddress_sorting.a` Makefile target to depend on `$(LIBGPR_OBJS)  $(ZLIB_MERGE_OBJS)  $(CARES_MERGE_OBJS)`, which seems over-reached.