### PR TITLE
Fix CFStream default subspec

### DIFF
--- a/gRPC-ProtoRPC.podspec
+++ b/gRPC-ProtoRPC.podspec
@@ -42,6 +42,7 @@ Pod::Spec.new do |s|
 
   src_dir = 'src/objective-c/ProtoRPC'
 
+  s.default_subspec = 'Main'
 
   s.subspec 'Main' do |ss|
     ss.header_mappings_dir = "#{src_dir}"

--- a/templates/gRPC-ProtoRPC.podspec.template
+++ b/templates/gRPC-ProtoRPC.podspec.template
@@ -44,6 +44,7 @@
 
     src_dir = 'src/objective-c/ProtoRPC'
 
+    s.default_subspec = 'Main'
 
     s.subspec 'Main' do |ss|
       ss.header_mappings_dir = "#{src_dir}"


### PR DESCRIPTION
`CFStream` should not be a default subspec of `ProtoRPC` so that people get CFStream only when explicitly opt in.