### PR TITLE
Add Type Checking On Channel Args

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -327,15 +327,13 @@ static void on_resolver_result_changed_locked(void* arg, grpc_error* error) {
   if (chand->resolver_result != nullptr) {
     if (chand->resolver != nullptr) {
       // Find LB policy name.
-      const grpc_arg* channel_arg = grpc_channel_args_find(
+      const char* lb_policy_name = grpc_channel_args_get_string(
           chand->resolver_result, GRPC_ARG_LB_POLICY_NAME);
-      const char* lb_policy_name = grpc_channel_arg_get_string(channel_arg);
       // Special case: If at least one balancer address is present, we use
       // the grpclb policy, regardless of what the resolver actually specified.
-      channel_arg =
-          grpc_channel_args_find(chand->resolver_result, GRPC_ARG_LB_ADDRESSES);
       grpc_lb_addresses* addresses =
-          grpc_channel_arg_get_pointer<grpc_lb_addresses>(channel_arg);
+          grpc_channel_args_get_pointer<grpc_lb_addresses>(
+              chand->resolver_result, GRPC_ARG_LB_ADDRESSES);
       if (addresses != nullptr) {
         bool found_balancer_address = false;
         for (size_t i = 0; i < addresses->num_addresses; ++i) {
@@ -400,18 +398,15 @@ static void on_resolver_result_changed_locked(void* arg, grpc_error* error) {
       // The copy will be saved in chand->lb_policy_name below.
       lb_policy_name_dup = gpr_strdup(lb_policy_name);
       // Find service config.
-      channel_arg = grpc_channel_args_find(chand->resolver_result,
-                                           GRPC_ARG_SERVICE_CONFIG);
-      service_config_json =
-          gpr_strdup(grpc_channel_arg_get_string(channel_arg));
+      service_config_json = gpr_strdup(grpc_channel_args_get_string(
+          chand->resolver_result, GRPC_ARG_SERVICE_CONFIG));
       if (service_config_json != nullptr) {
         grpc_core::UniquePtr<grpc_core::ServiceConfig> service_config =
             grpc_core::ServiceConfig::Create(service_config_json);
         if (service_config != nullptr) {
           if (chand->enable_retries) {
-            channel_arg = grpc_channel_args_find(chand->resolver_result,
-                                                 GRPC_ARG_SERVER_URI);
-            const char* server_uri = grpc_channel_arg_get_string(channel_arg);
+            const char* server_uri = grpc_channel_args_get_string(
+                chand->resolver_result, GRPC_ARG_SERVER_URI);
             GPR_ASSERT(server_uri != nullptr);
             grpc_uri* uri = grpc_uri_parse(server_uri, true);
             GPR_ASSERT(uri->path[0] != '\0');
@@ -648,18 +643,16 @@ static grpc_error* cc_init_channel_elem(grpc_channel_element* elem,
                                "client_channel");
   grpc_client_channel_start_backup_polling(chand->interested_parties);
   // Record max per-RPC retry buffer size.
-  const grpc_arg* arg = grpc_channel_args_find(
-      args->channel_args, GRPC_ARG_PER_RPC_RETRY_BUFFER_SIZE);
-  chand->per_rpc_retry_buffer_size = (size_t)grpc_channel_arg_get_integer(
-      arg, {DEFAULT_PER_RPC_RETRY_BUFFER_SIZE, 0, INT_MAX});
+  chand->per_rpc_retry_buffer_size = (size_t)grpc_channel_args_get_integer(
+      args->channel_args, GRPC_ARG_PER_RPC_RETRY_BUFFER_SIZE,
+      {DEFAULT_PER_RPC_RETRY_BUFFER_SIZE, 0, INT_MAX});
   // Record enable_retries.
-  arg = grpc_channel_args_find(args->channel_args, GRPC_ARG_ENABLE_RETRIES);
-  chand->enable_retries = grpc_channel_arg_get_bool(arg, true);
+  chand->enable_retries = grpc_channel_args_get_bool(
+      args->channel_args, GRPC_ARG_ENABLE_RETRIES, true);
   // Record client channel factory.
-  arg = grpc_channel_args_find(args->channel_args,
-                               GRPC_ARG_CLIENT_CHANNEL_FACTORY);
   grpc_client_channel_factory* client_channel_factory =
-      grpc_channel_arg_get_pointer<grpc_client_channel_factory>(arg);
+      grpc_channel_args_get_pointer<grpc_client_channel_factory>(
+          args->channel_args, GRPC_ARG_CLIENT_CHANNEL_FACTORY);
   if (client_channel_factory == nullptr) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "Missing or malformed client channel factory in args for client "
@@ -668,8 +661,8 @@ static grpc_error* cc_init_channel_elem(grpc_channel_element* elem,
   grpc_client_channel_factory_ref(client_channel_factory);
   chand->client_channel_factory = client_channel_factory;
   // Get server name to resolve, using proxy mapper if needed.
-  arg = grpc_channel_args_find(args->channel_args, GRPC_ARG_SERVER_URI);
-  char* server_uri = grpc_channel_arg_get_string(arg);
+  char* server_uri =
+      grpc_channel_args_get_string(args->channel_args, GRPC_ARG_SERVER_URI);
   if (server_uri == nullptr) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "Missing or malformed server uri in args for client channel filter");

--- a/src/core/ext/filters/client_channel/http_connect_handshaker.cc
+++ b/src/core/ext/filters/client_channel/http_connect_handshaker.cc
@@ -254,9 +254,8 @@ static void http_connect_handshaker_do_handshake(
       reinterpret_cast<http_connect_handshaker*>(handshaker_in);
   // Check for HTTP CONNECT channel arg.
   // If not found, invoke on_handshake_done without doing anything.
-  const grpc_arg* arg =
-      grpc_channel_args_find(args->args, GRPC_ARG_HTTP_CONNECT_SERVER);
-  char* server_name = grpc_channel_arg_get_string(arg);
+  char* server_name =
+      grpc_channel_args_get_string(args->args, GRPC_ARG_HTTP_CONNECT_SERVER);
   if (server_name == nullptr) {
     // Set shutdown to true so that subsequent calls to
     // http_connect_handshaker_shutdown() do nothing.
@@ -267,8 +266,8 @@ static void http_connect_handshaker_do_handshake(
     return;
   }
   // Get headers from channel args.
-  arg = grpc_channel_args_find(args->args, GRPC_ARG_HTTP_CONNECT_HEADERS);
-  char* arg_header_string = grpc_channel_arg_get_string(arg);
+  char* arg_header_string =
+      grpc_channel_args_get_string(args->args, GRPC_ARG_HTTP_CONNECT_HEADERS);
   grpc_http_header* headers = nullptr;
   size_t num_headers = 0;
   char** header_strings = nullptr;

--- a/src/core/ext/filters/client_channel/http_proxy.cc
+++ b/src/core/ext/filters/client_channel/http_proxy.cc
@@ -88,9 +88,7 @@ done:
  * should be used.
  */
 bool http_proxy_enabled(const grpc_channel_args* args) {
-  const grpc_arg* arg =
-      grpc_channel_args_find(args, GRPC_ARG_ENABLE_HTTP_PROXY);
-  return grpc_channel_arg_get_bool(arg, true);
+  return grpc_channel_args_get_bool(args, GRPC_ARG_ENABLE_HTTP_PROXY, true);
 }
 
 static bool proxy_mapper_map_name(grpc_proxy_mapper* mapper,

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1045,8 +1045,8 @@ GrpcLb::GrpcLb(const grpc_lb_addresses* addresses,
                     grpc_combiner_scheduler(args.combiner));
   grpc_connectivity_state_init(&state_tracker_, GRPC_CHANNEL_IDLE, "grpclb");
   // Record server name.
-  const grpc_arg* arg = grpc_channel_args_find(args.args, GRPC_ARG_SERVER_URI);
-  const char* server_uri = grpc_channel_arg_get_string(arg);
+  const char* server_uri =
+      grpc_channel_args_get_string(args.args, GRPC_ARG_SERVER_URI);
   GPR_ASSERT(server_uri != nullptr);
   grpc_uri* uri = grpc_uri_parse(server_uri, true);
   GPR_ASSERT(uri->path[0] != '\0');
@@ -1058,12 +1058,12 @@ GrpcLb::GrpcLb(const grpc_lb_addresses* addresses,
   }
   grpc_uri_destroy(uri);
   // Record LB call timeout.
-  arg = grpc_channel_args_find(args.args, GRPC_ARG_GRPCLB_CALL_TIMEOUT_MS);
-  lb_call_timeout_ms_ = grpc_channel_arg_get_integer(arg, {0, 0, INT_MAX});
+  lb_call_timeout_ms_ = grpc_channel_args_get_integer(
+      args.args, GRPC_ARG_GRPCLB_CALL_TIMEOUT_MS, {0, 0, INT_MAX});
   // Record fallback timeout.
-  arg = grpc_channel_args_find(args.args, GRPC_ARG_GRPCLB_FALLBACK_TIMEOUT_MS);
-  lb_fallback_timeout_ms_ = grpc_channel_arg_get_integer(
-      arg, {GRPC_GRPCLB_DEFAULT_FALLBACK_TIMEOUT_MS, 0, INT_MAX});
+  lb_fallback_timeout_ms_ = grpc_channel_args_get_integer(
+      args.args, GRPC_ARG_GRPCLB_FALLBACK_TIMEOUT_MS,
+      {GRPC_GRPCLB_DEFAULT_FALLBACK_TIMEOUT_MS, 0, INT_MAX});
   // Process channel args.
   ProcessChannelArgsLocked(*args.args);
 }
@@ -1284,9 +1284,9 @@ void GrpcLb::NotifyOnStateChangeLocked(grpc_connectivity_state* current,
 }
 
 void GrpcLb::ProcessChannelArgsLocked(const grpc_channel_args& args) {
-  const grpc_arg* arg = grpc_channel_args_find(&args, GRPC_ARG_LB_ADDRESSES);
   const grpc_lb_addresses* addresses =
-      grpc_channel_arg_get_pointer<grpc_lb_addresses>(arg);
+      grpc_channel_args_get_pointer<grpc_lb_addresses>(&args,
+                                                       GRPC_ARG_LB_ADDRESSES);
   if (GPR_UNLIKELY(addresses == nullptr)) {
     // Ignore this update.
     gpr_log(
@@ -1860,11 +1860,10 @@ class GrpcLbFactory : public LoadBalancingPolicyFactory {
   OrphanablePtr<LoadBalancingPolicy> CreateLoadBalancingPolicy(
       const LoadBalancingPolicy::Args& args) const override {
     /* Count the number of gRPC-LB addresses. There must be at least one. */
-    const grpc_arg* arg =
-        grpc_channel_args_find(args.args, GRPC_ARG_LB_ADDRESSES);
     grpc_lb_addresses* addresses =
-        grpc_channel_arg_get_pointer<grpc_lb_addresses>(arg);
-    if (addresses) {
+        grpc_channel_args_get_pointer<grpc_lb_addresses>(args.args,
+                                                         GRPC_ARG_LB_ADDRESSES);
+    if (addresses == nullptr) {
       return nullptr;
     }
     size_t num_grpclb_addrs = 0;
@@ -1893,9 +1892,8 @@ bool maybe_add_client_load_reporting_filter(grpc_channel_stack_builder* builder,
                                             void* arg) {
   const grpc_channel_args* args =
       grpc_channel_stack_builder_get_channel_arguments(builder);
-  const grpc_arg* channel_arg =
-      grpc_channel_args_find(args, GRPC_ARG_LB_POLICY_NAME);
-  const char* lb_policy = grpc_channel_arg_get_string(channel_arg);
+  const char* lb_policy =
+      grpc_channel_args_get_string(args, GRPC_ARG_LB_POLICY_NAME);
   if (lb_policy != nullptr && strcmp(lb_policy, "grpclb") == 0) {
     return grpc_channel_stack_builder_append_filter(
         builder, (const grpc_channel_filter*)arg, nullptr, nullptr);

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
@@ -73,10 +73,9 @@ grpc_channel_args* grpc_lb_policy_grpclb_modify_lb_channel_args(
   size_t num_args_to_add = 0;
   // Add arg for targets info table.
   const grpc_arg* arg = grpc_channel_args_find(args, GRPC_ARG_LB_ADDRESSES);
-  GPR_ASSERT(arg != nullptr);
-  GPR_ASSERT(arg->type == GRPC_ARG_POINTER);
   grpc_lb_addresses* addresses =
-      static_cast<grpc_lb_addresses*>(arg->value.pointer.p);
+      grpc_channel_arg_get_pointer<grpc_lb_addresses>(arg);
+  GPR_ASSERT(addresses != nullptr);
   grpc_core::RefCountedPtr<grpc_core::TargetAuthorityTable>
       target_authority_table = grpc_core::CreateTargetAuthorityTable(addresses);
   args_to_add[num_args_to_add++] =

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
@@ -72,9 +72,9 @@ grpc_channel_args* grpc_lb_policy_grpclb_modify_lb_channel_args(
   grpc_arg args_to_add[2];
   size_t num_args_to_add = 0;
   // Add arg for targets info table.
-  const grpc_arg* arg = grpc_channel_args_find(args, GRPC_ARG_LB_ADDRESSES);
   grpc_lb_addresses* addresses =
-      grpc_channel_arg_get_pointer<grpc_lb_addresses>(arg);
+      grpc_channel_args_get_pointer<grpc_lb_addresses>(args,
+                                                       GRPC_ARG_LB_ADDRESSES);
   GPR_ASSERT(addresses != nullptr);
   grpc_core::RefCountedPtr<grpc_core::TargetAuthorityTable>
       target_authority_table = grpc_core::CreateTargetAuthorityTable(addresses);

--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
@@ -282,7 +282,9 @@ void PickFirst::PingOneLocked(grpc_closure* on_initiate, grpc_closure* on_ack) {
 
 void PickFirst::UpdateLocked(const grpc_channel_args& args) {
   const grpc_arg* arg = grpc_channel_args_find(&args, GRPC_ARG_LB_ADDRESSES);
-  if (arg == nullptr || arg->type != GRPC_ARG_POINTER) {
+  const grpc_lb_addresses* addresses =
+      grpc_channel_arg_get_pointer<const grpc_lb_addresses>(arg);
+  if (addresses == nullptr) {
     if (subchannel_list_ == nullptr) {
       // If we don't have a current subchannel list, go into TRANSIENT FAILURE.
       grpc_connectivity_state_set(
@@ -298,8 +300,6 @@ void PickFirst::UpdateLocked(const grpc_channel_args& args) {
     }
     return;
   }
-  const grpc_lb_addresses* addresses =
-      static_cast<const grpc_lb_addresses*>(arg->value.pointer.p);
   if (grpc_lb_pick_first_trace.enabled()) {
     gpr_log(GPR_INFO,
             "Pick First %p received update with %" PRIuPTR " addresses", this,

--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
@@ -281,9 +281,9 @@ void PickFirst::PingOneLocked(grpc_closure* on_initiate, grpc_closure* on_ack) {
 }
 
 void PickFirst::UpdateLocked(const grpc_channel_args& args) {
-  const grpc_arg* arg = grpc_channel_args_find(&args, GRPC_ARG_LB_ADDRESSES);
   const grpc_lb_addresses* addresses =
-      grpc_channel_arg_get_pointer<const grpc_lb_addresses>(arg);
+      grpc_channel_args_get_pointer<const grpc_lb_addresses>(
+          &args, GRPC_ARG_LB_ADDRESSES);
   if (addresses == nullptr) {
     if (subchannel_list_ == nullptr) {
       // If we don't have a current subchannel list, go into TRANSIENT FAILURE.

--- a/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
@@ -607,9 +607,9 @@ void RoundRobin::PingOneLocked(grpc_closure* on_initiate,
 }
 
 void RoundRobin::UpdateLocked(const grpc_channel_args& args) {
-  const grpc_arg* arg = grpc_channel_args_find(&args, GRPC_ARG_LB_ADDRESSES);
   grpc_lb_addresses* addresses =
-      grpc_channel_arg_get_pointer<grpc_lb_addresses>(arg);
+      grpc_channel_args_get_pointer<grpc_lb_addresses>(&args,
+                                                       GRPC_ARG_LB_ADDRESSES);
   if (GPR_UNLIKELY(addresses == nullptr)) {
     gpr_log(GPR_ERROR, "[RR %p] update provided no addresses; ignoring", this);
     // If we don't have a current subchannel list, go into TRANSIENT_FAILURE.

--- a/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
@@ -608,7 +608,9 @@ void RoundRobin::PingOneLocked(grpc_closure* on_initiate,
 
 void RoundRobin::UpdateLocked(const grpc_channel_args& args) {
   const grpc_arg* arg = grpc_channel_args_find(&args, GRPC_ARG_LB_ADDRESSES);
-  if (GPR_UNLIKELY(arg == nullptr || arg->type != GRPC_ARG_POINTER)) {
+  grpc_lb_addresses* addresses =
+      grpc_channel_arg_get_pointer<grpc_lb_addresses>(arg);
+  if (GPR_UNLIKELY(addresses == nullptr)) {
     gpr_log(GPR_ERROR, "[RR %p] update provided no addresses; ignoring", this);
     // If we don't have a current subchannel list, go into TRANSIENT_FAILURE.
     // Otherwise, keep using the current subchannel list (ignore this update).
@@ -620,8 +622,6 @@ void RoundRobin::UpdateLocked(const grpc_channel_args& args) {
     }
     return;
   }
-  grpc_lb_addresses* addresses =
-      static_cast<grpc_lb_addresses*>(arg->value.pointer.p);
   if (grpc_lb_round_robin_trace.enabled()) {
     gpr_log(GPR_INFO, "[RR %p] received update with %" PRIuPTR " addresses",
             this, addresses->num_addresses);

--- a/src/core/ext/filters/client_channel/lb_policy_factory.cc
+++ b/src/core/ext/filters/client_channel/lb_policy_factory.cc
@@ -149,7 +149,5 @@ grpc_lb_addresses* grpc_lb_addresses_find_channel_arg(
     const grpc_channel_args* channel_args) {
   const grpc_arg* lb_addresses_arg =
       grpc_channel_args_find(channel_args, GRPC_ARG_LB_ADDRESSES);
-  if (lb_addresses_arg == nullptr || lb_addresses_arg->type != GRPC_ARG_POINTER)
-    return nullptr;
-  return static_cast<grpc_lb_addresses*>(lb_addresses_arg->value.pointer.p);
+  return grpc_channel_arg_get_pointer<grpc_lb_addresses>(lb_addresses_arg);
 }

--- a/src/core/ext/filters/client_channel/lb_policy_factory.cc
+++ b/src/core/ext/filters/client_channel/lb_policy_factory.cc
@@ -147,7 +147,6 @@ grpc_arg grpc_lb_addresses_create_channel_arg(
 
 grpc_lb_addresses* grpc_lb_addresses_find_channel_arg(
     const grpc_channel_args* channel_args) {
-  const grpc_arg* lb_addresses_arg =
-      grpc_channel_args_find(channel_args, GRPC_ARG_LB_ADDRESSES);
-  return grpc_channel_arg_get_pointer<grpc_lb_addresses>(lb_addresses_arg);
+  return grpc_channel_args_get_pointer<grpc_lb_addresses>(
+      channel_args, GRPC_ARG_LB_ADDRESSES);
 }

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -140,14 +140,11 @@ AresDnsResolver::AresDnsResolver(const ResolverArgs& args)
     dns_server_ = gpr_strdup(args.uri->authority);
   }
   channel_args_ = grpc_channel_args_copy(args.args);
-  const grpc_arg* arg = grpc_channel_args_find(
-      channel_args_, GRPC_ARG_SERVICE_CONFIG_DISABLE_RESOLUTION);
-  request_service_config_ = !grpc_channel_arg_get_integer(
-      arg, (grpc_integer_options){false, false, true});
-  arg = grpc_channel_args_find(channel_args_,
-                               GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS);
-  min_time_between_resolutions_ =
-      grpc_channel_arg_get_integer(arg, {1000, 0, INT_MAX});
+  request_service_config_ = !grpc_channel_args_get_bool(
+      channel_args_, GRPC_ARG_SERVICE_CONFIG_DISABLE_RESOLUTION, false);
+  min_time_between_resolutions_ = grpc_channel_args_get_integer(
+      channel_args_, GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS,
+      {1000, 0, INT_MAX});
   interested_parties_ = grpc_pollset_set_create();
   if (args.pollset_set != nullptr) {
     grpc_pollset_set_add_pollset_set(interested_parties_, args.pollset_set);

--- a/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
@@ -116,10 +116,9 @@ NativeDnsResolver::NativeDnsResolver(const ResolverArgs& args)
   if (path[0] == '/') ++path;
   name_to_resolve_ = gpr_strdup(path);
   channel_args_ = grpc_channel_args_copy(args.args);
-  const grpc_arg* arg = grpc_channel_args_find(
-      args.args, GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS);
-  min_time_between_resolutions_ =
-      grpc_channel_arg_get_integer(arg, {1000, 0, INT_MAX});
+  min_time_between_resolutions_ = grpc_channel_args_get_integer(
+      args.args, GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS,
+      {1000, 0, INT_MAX});
   interested_parties_ = grpc_pollset_set_create();
   if (args.pollset_set != nullptr) {
     grpc_pollset_set_add_pollset_set(interested_parties_, args.pollset_set);

--- a/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
@@ -252,20 +252,16 @@ static const grpc_arg_pointer_vtable response_generator_arg_vtable = {
 
 grpc_arg FakeResolverResponseGenerator::MakeChannelArg(
     FakeResolverResponseGenerator* generator) {
-  grpc_arg arg;
-  arg.type = GRPC_ARG_POINTER;
-  arg.key = (char*)GRPC_ARG_FAKE_RESOLVER_RESPONSE_GENERATOR;
-  arg.value.pointer.p = generator;
-  arg.value.pointer.vtable = &response_generator_arg_vtable;
-  return arg;
+  return grpc_channel_arg_pointer_create(
+      const_cast<char*>(GRPC_ARG_FAKE_RESOLVER_RESPONSE_GENERATOR), generator,
+      &response_generator_arg_vtable);
 }
 
 FakeResolverResponseGenerator* FakeResolverResponseGenerator::GetFromArgs(
     const grpc_channel_args* args) {
   const grpc_arg* arg =
       grpc_channel_args_find(args, GRPC_ARG_FAKE_RESOLVER_RESPONSE_GENERATOR);
-  if (arg == nullptr || arg->type != GRPC_ARG_POINTER) return nullptr;
-  return static_cast<FakeResolverResponseGenerator*>(arg->value.pointer.p);
+  return grpc_channel_arg_get_pointer<FakeResolverResponseGenerator>(arg);
 }
 
 //

--- a/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
@@ -259,9 +259,8 @@ grpc_arg FakeResolverResponseGenerator::MakeChannelArg(
 
 FakeResolverResponseGenerator* FakeResolverResponseGenerator::GetFromArgs(
     const grpc_channel_args* args) {
-  const grpc_arg* arg =
-      grpc_channel_args_find(args, GRPC_ARG_FAKE_RESOLVER_RESPONSE_GENERATOR);
-  return grpc_channel_arg_get_pointer<FakeResolverResponseGenerator>(arg);
+  return grpc_channel_args_get_pointer<FakeResolverResponseGenerator>(
+      args, GRPC_ARG_FAKE_RESOLVER_RESPONSE_GENERATOR);
 }
 
 //

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -736,9 +736,8 @@ void grpc_get_subchannel_address_arg(const grpc_channel_args* args,
 }
 
 const char* grpc_get_subchannel_address_uri_arg(const grpc_channel_args* args) {
-  const grpc_arg* addr_arg =
-      grpc_channel_args_find(args, GRPC_ARG_SUBCHANNEL_ADDRESS);
-  const char* addr_str = grpc_channel_arg_get_string(addr_arg);
+  const char* addr_str =
+      grpc_channel_args_get_string(args, GRPC_ARG_SUBCHANNEL_ADDRESS);
   GPR_ASSERT(addr_str != nullptr);  // Should have been set by LB policy.
   return addr_str;
 }

--- a/src/core/ext/filters/deadline/deadline_filter.cc
+++ b/src/core/ext/filters/deadline/deadline_filter.cc
@@ -358,8 +358,8 @@ const grpc_channel_filter grpc_server_deadline_filter = {
 };
 
 bool grpc_deadline_checking_enabled(const grpc_channel_args* channel_args) {
-  return grpc_channel_arg_get_bool(
-      grpc_channel_args_find(channel_args, GRPC_ARG_ENABLE_DEADLINE_CHECKS),
+  return grpc_channel_args_get_bool(
+      channel_args, GRPC_ARG_ENABLE_DEADLINE_CHECKS,
       !grpc_channel_args_want_minimal_stack(channel_args));
 }
 

--- a/src/core/ext/filters/http/client/http_client_filter.cc
+++ b/src/core/ext/filters/http/client/http_client_filter.cc
@@ -455,18 +455,14 @@ static grpc_mdelem scheme_from_args(const grpc_channel_args* channel_args) {
   return GRPC_MDELEM_SCHEME_HTTP;
 }
 
-static size_t max_payload_size_from_args(const grpc_channel_args* args) {
-  if (args != nullptr) {
-    for (size_t i = 0; i < args->num_args; ++i) {
-      if (0 == strcmp(args->args[i].key, GRPC_ARG_MAX_PAYLOAD_SIZE_FOR_GET)) {
-        if (args->args[i].type != GRPC_ARG_INTEGER) {
-          gpr_log(GPR_ERROR, "%s: must be an integer",
-                  GRPC_ARG_MAX_PAYLOAD_SIZE_FOR_GET);
-        } else {
-          return static_cast<size_t>(args->args[i].value.integer);
-        }
-      }
-    }
+static size_t max_payload_size_from_args(
+    const grpc_channel_args* channel_args) {
+  if (channel_args != nullptr) {
+    const grpc_arg* arg =
+        grpc_channel_args_find(channel_args, GRPC_ARG_MAX_PAYLOAD_SIZE_FOR_GET);
+    // TODO(mark): is 0 a correct minimum for this value?
+    return grpc_channel_arg_get_integer(
+        arg, {kMaxPayloadSizeForGet, 0, kMaxPayloadSizeForGet});
   }
   return kMaxPayloadSizeForGet;
 }

--- a/src/core/ext/filters/http/client/http_client_filter.cc
+++ b/src/core/ext/filters/http/client/http_client_filter.cc
@@ -437,18 +437,14 @@ static void destroy_call_elem(grpc_call_element* elem,
                               grpc_closure* ignored) {}
 
 static grpc_mdelem scheme_from_args(const grpc_channel_args* channel_args) {
-  size_t i;
   grpc_mdelem valid_schemes[] = {GRPC_MDELEM_SCHEME_HTTP,
                                  GRPC_MDELEM_SCHEME_HTTPS};
-  if (channel_args != nullptr) {
-    const grpc_arg* arg =
-        grpc_channel_args_find(channel_args, GRPC_ARG_HTTP2_SCHEME);
-    char* scheme = grpc_channel_arg_get_string(arg);
-    if (scheme != nullptr) {
-      for (i = 0; i < GPR_ARRAY_SIZE(valid_schemes); i++) {
-        if (0 == grpc_slice_str_cmp(GRPC_MDVALUE(valid_schemes[i]), scheme)) {
-          return valid_schemes[i];
-        }
+  char* scheme =
+      grpc_channel_args_get_string(channel_args, GRPC_ARG_HTTP2_SCHEME);
+  if (scheme != nullptr) {
+    for (size_t i = 0; i < GPR_ARRAY_SIZE(valid_schemes); i++) {
+      if (0 == grpc_slice_str_cmp(GRPC_MDVALUE(valid_schemes[i]), scheme)) {
+        return valid_schemes[i];
       }
     }
   }
@@ -457,14 +453,9 @@ static grpc_mdelem scheme_from_args(const grpc_channel_args* channel_args) {
 
 static size_t max_payload_size_from_args(
     const grpc_channel_args* channel_args) {
-  if (channel_args != nullptr) {
-    const grpc_arg* arg =
-        grpc_channel_args_find(channel_args, GRPC_ARG_MAX_PAYLOAD_SIZE_FOR_GET);
-    // TODO(mark): is 0 a correct minimum for this value?
-    return grpc_channel_arg_get_integer(
-        arg, {kMaxPayloadSizeForGet, 0, kMaxPayloadSizeForGet});
-  }
-  return kMaxPayloadSizeForGet;
+  return grpc_channel_args_get_integer(
+      channel_args, GRPC_ARG_MAX_PAYLOAD_SIZE_FOR_GET,
+      {kMaxPayloadSizeForGet, 0, kMaxPayloadSizeForGet});
 }
 
 static grpc_slice user_agent_from_args(const grpc_channel_args* args,
@@ -476,9 +467,8 @@ static grpc_slice user_agent_from_args(const grpc_channel_args* args,
 
   gpr_strvec_init(&v);
 
-  const grpc_arg* arg =
-      grpc_channel_args_find(args, GRPC_ARG_PRIMARY_USER_AGENT_STRING);
-  char* user_agent_str = grpc_channel_arg_get_string(arg);
+  char* user_agent_str =
+      grpc_channel_args_get_string(args, GRPC_ARG_PRIMARY_USER_AGENT_STRING);
   if (user_agent_str != nullptr) {
     if (!is_first) gpr_strvec_add(&v, gpr_strdup(" "));
     is_first = 0;
@@ -491,8 +481,8 @@ static grpc_slice user_agent_from_args(const grpc_channel_args* args,
   is_first = 0;
   gpr_strvec_add(&v, tmp);
 
-  arg = grpc_channel_args_find(args, GRPC_ARG_SECONDARY_USER_AGENT_STRING);
-  user_agent_str = grpc_channel_arg_get_string(arg);
+  user_agent_str =
+      grpc_channel_args_get_string(args, GRPC_ARG_SECONDARY_USER_AGENT_STRING);
   if (user_agent_str != nullptr) {
     gpr_strvec_add(&v, gpr_strdup(" "));
     gpr_strvec_add(&v, gpr_strdup(user_agent_str));

--- a/src/core/ext/filters/http/client/http_client_filter.cc
+++ b/src/core/ext/filters/http/client/http_client_filter.cc
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <string.h>
 #include "src/core/ext/filters/http/client/http_client_filter.h"
+#include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/gprpp/manual_constructor.h"
 #include "src/core/lib/profiling/timers.h"
@@ -435,20 +436,18 @@ static void destroy_call_elem(grpc_call_element* elem,
                               const grpc_call_final_info* final_info,
                               grpc_closure* ignored) {}
 
-static grpc_mdelem scheme_from_args(const grpc_channel_args* args) {
-  unsigned i;
-  size_t j;
+static grpc_mdelem scheme_from_args(const grpc_channel_args* channel_args) {
+  size_t i;
   grpc_mdelem valid_schemes[] = {GRPC_MDELEM_SCHEME_HTTP,
                                  GRPC_MDELEM_SCHEME_HTTPS};
-  if (args != nullptr) {
-    for (i = 0; i < args->num_args; ++i) {
-      if (args->args[i].type == GRPC_ARG_STRING &&
-          strcmp(args->args[i].key, GRPC_ARG_HTTP2_SCHEME) == 0) {
-        for (j = 0; j < GPR_ARRAY_SIZE(valid_schemes); j++) {
-          if (0 == grpc_slice_str_cmp(GRPC_MDVALUE(valid_schemes[j]),
-                                      args->args[i].value.string)) {
-            return valid_schemes[j];
-          }
+  if (channel_args != nullptr) {
+    const grpc_arg* arg =
+        grpc_channel_args_find(channel_args, GRPC_ARG_HTTP2_SCHEME);
+    char* scheme = grpc_channel_arg_get_string(arg);
+    if (scheme != nullptr) {
+      for (i = 0; i < GPR_ARRAY_SIZE(valid_schemes); i++) {
+        if (0 == grpc_slice_str_cmp(GRPC_MDVALUE(valid_schemes[i]), scheme)) {
+          return valid_schemes[i];
         }
       }
     }
@@ -475,24 +474,19 @@ static size_t max_payload_size_from_args(const grpc_channel_args* args) {
 static grpc_slice user_agent_from_args(const grpc_channel_args* args,
                                        const char* transport_name) {
   gpr_strvec v;
-  size_t i;
   int is_first = 1;
   char* tmp;
   grpc_slice result;
 
   gpr_strvec_init(&v);
 
-  for (i = 0; args && i < args->num_args; i++) {
-    if (0 == strcmp(args->args[i].key, GRPC_ARG_PRIMARY_USER_AGENT_STRING)) {
-      if (args->args[i].type != GRPC_ARG_STRING) {
-        gpr_log(GPR_ERROR, "Channel argument '%s' should be a string",
-                GRPC_ARG_PRIMARY_USER_AGENT_STRING);
-      } else {
-        if (!is_first) gpr_strvec_add(&v, gpr_strdup(" "));
-        is_first = 0;
-        gpr_strvec_add(&v, gpr_strdup(args->args[i].value.string));
-      }
-    }
+  const grpc_arg* arg =
+      grpc_channel_args_find(args, GRPC_ARG_PRIMARY_USER_AGENT_STRING);
+  char* user_agent_str = grpc_channel_arg_get_string(arg);
+  if (user_agent_str != nullptr) {
+    if (!is_first) gpr_strvec_add(&v, gpr_strdup(" "));
+    is_first = 0;
+    gpr_strvec_add(&v, gpr_strdup(user_agent_str));
   }
 
   gpr_asprintf(&tmp, "%sgrpc-c/%s (%s; %s; %s)", is_first ? "" : " ",
@@ -501,17 +495,11 @@ static grpc_slice user_agent_from_args(const grpc_channel_args* args,
   is_first = 0;
   gpr_strvec_add(&v, tmp);
 
-  for (i = 0; args && i < args->num_args; i++) {
-    if (0 == strcmp(args->args[i].key, GRPC_ARG_SECONDARY_USER_AGENT_STRING)) {
-      if (args->args[i].type != GRPC_ARG_STRING) {
-        gpr_log(GPR_ERROR, "Channel argument '%s' should be a string",
-                GRPC_ARG_SECONDARY_USER_AGENT_STRING);
-      } else {
-        if (!is_first) gpr_strvec_add(&v, gpr_strdup(" "));
-        is_first = 0;
-        gpr_strvec_add(&v, gpr_strdup(args->args[i].value.string));
-      }
-    }
+  arg = grpc_channel_args_find(args, GRPC_ARG_SECONDARY_USER_AGENT_STRING);
+  user_agent_str = grpc_channel_arg_get_string(arg);
+  if (user_agent_str != nullptr) {
+    gpr_strvec_add(&v, gpr_strdup(" "));
+    gpr_strvec_add(&v, gpr_strdup(user_agent_str));
   }
 
   tmp = gpr_strvec_flatten(&v, nullptr);

--- a/src/core/ext/filters/http/http_filters_plugin.cc
+++ b/src/core/ext/filters/http/http_filters_plugin.cc
@@ -48,8 +48,8 @@ static bool maybe_add_optional_filter(grpc_channel_stack_builder* builder,
   optional_filter* filtarg = static_cast<optional_filter*>(arg);
   const grpc_channel_args* channel_args =
       grpc_channel_stack_builder_get_channel_arguments(builder);
-  bool enable = grpc_channel_arg_get_bool(
-      grpc_channel_args_find(channel_args, filtarg->control_channel_arg),
+  bool enable = grpc_channel_args_get_bool(
+      channel_args, filtarg->control_channel_arg,
       !grpc_channel_args_want_minimal_stack(channel_args));
   return enable ? grpc_channel_stack_builder_prepend_filter(
                       builder, filtarg->filter, nullptr, nullptr)

--- a/src/core/ext/filters/load_reporting/server_load_reporting_plugin.cc
+++ b/src/core/ext/filters/load_reporting/server_load_reporting_plugin.cc
@@ -33,8 +33,7 @@
 #include "src/core/lib/surface/channel_init.h"
 
 static bool is_load_reporting_enabled(const grpc_channel_args* a) {
-  return grpc_channel_arg_get_bool(
-      grpc_channel_args_find(a, GRPC_ARG_ENABLE_LOAD_REPORTING), false);
+  return grpc_channel_args_get_bool(a, GRPC_ARG_ENABLE_LOAD_REPORTING, false);
 }
 
 static bool maybe_add_server_load_reporting_filter(

--- a/src/core/ext/filters/max_age/max_age_filter.cc
+++ b/src/core/ext/filters/max_age/max_age_filter.cc
@@ -519,13 +519,12 @@ static bool maybe_add_max_age_filter(grpc_channel_stack_builder* builder,
                                      void* arg) {
   const grpc_channel_args* channel_args =
       grpc_channel_stack_builder_get_channel_arguments(builder);
-  bool enable =
-      grpc_channel_arg_get_integer(
-          grpc_channel_args_find(channel_args, GRPC_ARG_MAX_CONNECTION_AGE_MS),
-          MAX_CONNECTION_AGE_INTEGER_OPTIONS) != INT_MAX ||
-      grpc_channel_arg_get_integer(
-          grpc_channel_args_find(channel_args, GRPC_ARG_MAX_CONNECTION_IDLE_MS),
-          MAX_CONNECTION_IDLE_INTEGER_OPTIONS) != INT_MAX;
+  bool enable = grpc_channel_args_get_integer(
+                    channel_args, GRPC_ARG_MAX_CONNECTION_AGE_MS,
+                    MAX_CONNECTION_AGE_INTEGER_OPTIONS) != INT_MAX ||
+                grpc_channel_args_get_integer(
+                    channel_args, GRPC_ARG_MAX_CONNECTION_IDLE_MS,
+                    MAX_CONNECTION_IDLE_INTEGER_OPTIONS) != INT_MAX;
   if (enable) {
     return grpc_channel_stack_builder_prepend_filter(
         builder, &grpc_max_age_filter, nullptr, nullptr);

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -254,9 +254,8 @@ static grpc_error* init_channel_elem(grpc_channel_element* elem,
   channel_data* chand = static_cast<channel_data*>(elem->channel_data);
   chand->limits = get_message_size_limits(args->channel_args);
   // Get method config table from channel args.
-  const grpc_arg* channel_arg =
-      grpc_channel_args_find(args->channel_args, GRPC_ARG_SERVICE_CONFIG);
-  const char* service_config_str = grpc_channel_arg_get_string(channel_arg);
+  const char* service_config_str =
+      grpc_channel_args_get_string(args->channel_args, GRPC_ARG_SERVICE_CONFIG);
   if (service_config_str != nullptr) {
     grpc_core::UniquePtr<grpc_core::ServiceConfig> service_config =
         grpc_core::ServiceConfig::Create(service_config_str);

--- a/src/core/ext/transport/chttp2/client/authority.cc
+++ b/src/core/ext/transport/chttp2/client/authority.cc
@@ -28,9 +28,8 @@ grpc_channel_args* grpc_default_authority_add_if_not_present(
   size_t num_new_args = 0;
   grpc_core::UniquePtr<char> default_authority;
   if (!has_default_authority) {
-    const grpc_arg* server_uri_arg =
-        grpc_channel_args_find(args, GRPC_ARG_SERVER_URI);
-    const char* server_uri_str = grpc_channel_arg_get_string(server_uri_arg);
+    const char* server_uri_str =
+        grpc_channel_args_get_string(args, GRPC_ARG_SERVER_URI);
     GPR_ASSERT(server_uri_str != nullptr);
     default_authority =
         grpc_core::ResolverRegistry::GetDefaultAuthority(server_uri_str);

--- a/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
@@ -64,9 +64,8 @@ static grpc_subchannel_args* get_secure_naming_subchannel_args(
     return nullptr;
   }
   // To which address are we connecting? By default, use the server URI.
-  const grpc_arg* server_uri_arg =
-      grpc_channel_args_find(args->args, GRPC_ARG_SERVER_URI);
-  const char* server_uri_str = grpc_channel_arg_get_string(server_uri_arg);
+  const char* server_uri_str =
+      grpc_channel_args_get_string(args->args, GRPC_ARG_SERVER_URI);
   GPR_ASSERT(server_uri_str != nullptr);
   grpc_uri* server_uri =
       grpc_uri_parse(server_uri_str, true /* supress errors */);

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -447,20 +447,19 @@ static void init_transport(grpc_chttp2_transport* t,
             grpc_channel_arg_get_integer(&channel_args->args[i], {0, 0, 1}));
       } else if (0 == strcmp(channel_args->args[i].key,
                              GRPC_ARG_OPTIMIZATION_TARGET)) {
-        if (channel_args->args[i].type != GRPC_ARG_STRING) {
-          gpr_log(GPR_ERROR, "%s should be a string",
-                  GRPC_ARG_OPTIMIZATION_TARGET);
-        } else if (0 == strcmp(channel_args->args[i].value.string, "blend")) {
+        char* opt_target_str =
+            grpc_channel_arg_get_string(&channel_args->args[i]);
+        if (opt_target_str == nullptr) {
+          gpr_log(GPR_ERROR, "null/missing value opt target, assuming 'blend'");
+        } else if (0 == strcmp(opt_target_str, "blend")) {
           t->opt_target = GRPC_CHTTP2_OPTIMIZE_FOR_LATENCY;
-        } else if (0 == strcmp(channel_args->args[i].value.string, "latency")) {
+        } else if (0 == strcmp(opt_target_str, "latency")) {
           t->opt_target = GRPC_CHTTP2_OPTIMIZE_FOR_LATENCY;
-        } else if (0 ==
-                   strcmp(channel_args->args[i].value.string, "throughput")) {
+        } else if (0 == strcmp(opt_target_str, "throughput")) {
           t->opt_target = GRPC_CHTTP2_OPTIMIZE_FOR_THROUGHPUT;
         } else {
           gpr_log(GPR_ERROR, "%s value '%s' unknown, assuming 'blend'",
-                  GRPC_ARG_OPTIMIZATION_TARGET,
-                  channel_args->args[i].value.string);
+                  GRPC_ARG_OPTIMIZATION_TARGET, opt_target_str);
         }
       } else {
         static const struct {

--- a/src/core/ext/transport/cronet/transport/cronet_transport.cc
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.cc
@@ -1450,12 +1450,8 @@ grpc_transport* grpc_create_cronet_transport(void* engine, const char* target,
   }
   strcpy(ct->host, target);
 
-  ct->use_packet_coalescing = true;
-  if (args) {
-    const grpc_arg* arg =
-        grpc_channel_args_find(args, GRPC_ARG_USE_CRONET_PACKET_COALESCING);
-    ct->use_packet_coalescing = grpc_channel_arg_get_bool(arg, false);
-  }
+  ct->use_packet_coalescing = grpc_channel_args_get_bool(
+      args, GRPC_ARG_USE_CRONET_PACKET_COALESCING, true);
 
   return &ct->base;
 

--- a/src/core/ext/transport/cronet/transport/cronet_transport.cc
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.cc
@@ -1452,17 +1452,9 @@ grpc_transport* grpc_create_cronet_transport(void* engine, const char* target,
 
   ct->use_packet_coalescing = true;
   if (args) {
-    for (size_t i = 0; i < args->num_args; i++) {
-      if (0 ==
-          strcmp(args->args[i].key, GRPC_ARG_USE_CRONET_PACKET_COALESCING)) {
-        if (GPR_UNLIKELY(args->args[i].type != GRPC_ARG_INTEGER)) {
-          gpr_log(GPR_ERROR, "%s ignored: it must be an integer",
-                  GRPC_ARG_USE_CRONET_PACKET_COALESCING);
-        } else {
-          ct->use_packet_coalescing = (args->args[i].value.integer != 0);
-        }
-      }
-    }
+    const grpc_arg* arg =
+        grpc_channel_args_find(args, GRPC_ARG_USE_CRONET_PACKET_COALESCING);
+    ct->use_packet_coalescing = grpc_channel_arg_get_bool(arg, false);
   }
 
   return &ct->base;

--- a/src/core/ext/transport/inproc/inproc_transport.cc
+++ b/src/core/ext/transport/inproc/inproc_transport.cc
@@ -1204,10 +1204,9 @@ grpc_channel* grpc_inproc_channel_create(grpc_server* server,
 
   // Add a default authority channel argument for the client
 
-  grpc_arg default_authority_arg;
-  default_authority_arg.type = GRPC_ARG_STRING;
-  default_authority_arg.key = (char*)GRPC_ARG_DEFAULT_AUTHORITY;
-  default_authority_arg.value.string = (char*)"inproc.authority";
+  grpc_arg default_authority_arg = grpc_channel_arg_string_create(
+      const_cast<char*>(GRPC_ARG_DEFAULT_AUTHORITY),
+      const_cast<char*>("inproc.authority"));
   grpc_channel_args* client_args =
       grpc_channel_args_copy_and_add(args, &default_authority_arg, 1);
 

--- a/src/core/lib/channel/channel_args.h
+++ b/src/core/lib/channel/channel_args.h
@@ -23,6 +23,7 @@
 
 #include <grpc/compression.h>
 #include <grpc/grpc.h>
+#include <grpc/support/log.h>
 #include "src/core/lib/iomgr/socket_mutator.h"
 
 // Channel args are intentionally immutable, to avoid the need for locking.
@@ -115,6 +116,19 @@ int grpc_channel_arg_get_integer(const grpc_arg* arg,
     Otherwise, emits a warning log, and returns nullptr.
     If arg is nullptr, returns nullptr, and does not emit a warning. */
 char* grpc_channel_arg_get_string(const grpc_arg* arg);
+
+/** Returns the value of \a arg if \a arg is of type GRPC_ARG_POINTER
+    Otherwise, emits a warning log, and returns nullptr.
+    If arg is nullptr, returns nullptr, and does not emit a warning. */
+template <typename Type>
+Type* grpc_channel_arg_get_pointer(const grpc_arg* arg) {
+  if (arg == nullptr) return nullptr;
+  if (arg->type != GRPC_ARG_POINTER) {
+    gpr_log(GPR_ERROR, "%s ignored: it must be an pointer", arg->key);
+    return nullptr;
+  }
+  return static_cast<Type*>(arg->value.pointer.p);
+}
 
 bool grpc_channel_arg_get_bool(const grpc_arg* arg, bool default_value);
 

--- a/src/core/lib/channel/channel_args.h
+++ b/src/core/lib/channel/channel_args.h
@@ -111,17 +111,29 @@ typedef struct grpc_integer_options {
 /** Returns the value of \a arg, subject to the contraints in \a options. */
 int grpc_channel_arg_get_integer(const grpc_arg* arg,
                                  const grpc_integer_options options);
+/** convinience helper for the above that finds the arg first. */
+inline int grpc_channel_args_get_integer(const grpc_channel_args* args,
+                                         const char* name,
+                                         const grpc_integer_options options) {
+  return grpc_channel_arg_get_integer(grpc_channel_args_find(args, name),
+                                      options);
+}
 
 /** Returns the value of \a arg if \a arg is of type GRPC_ARG_STRING.
     Otherwise, emits a warning log, and returns nullptr.
     If arg is nullptr, returns nullptr, and does not emit a warning. */
 char* grpc_channel_arg_get_string(const grpc_arg* arg);
+/** convinience helper for the above that finds the arg first. */
+inline char* grpc_channel_args_get_string(const grpc_channel_args* args,
+                                          const char* name) {
+  return grpc_channel_arg_get_string(grpc_channel_args_find(args, name));
+}
 
 /** Returns the value of \a arg if \a arg is of type GRPC_ARG_POINTER
     Otherwise, emits a warning log, and returns nullptr.
     If arg is nullptr, returns nullptr, and does not emit a warning. */
 template <typename Type>
-Type* grpc_channel_arg_get_pointer(const grpc_arg* arg) {
+inline Type* grpc_channel_arg_get_pointer(const grpc_arg* arg) {
   if (arg == nullptr) return nullptr;
   if (arg->type != GRPC_ARG_POINTER) {
     gpr_log(GPR_ERROR, "%s ignored: it must be an pointer", arg->key);
@@ -129,8 +141,19 @@ Type* grpc_channel_arg_get_pointer(const grpc_arg* arg) {
   }
   return static_cast<Type*>(arg->value.pointer.p);
 }
+/** convinience helper for the above that finds the arg first. */
+template <typename Type>
+inline Type* grpc_channel_args_get_pointer(const grpc_channel_args* args,
+                                           const char* name) {
+  return grpc_channel_arg_get_pointer<Type>(grpc_channel_args_find(args, name));
+}
 
 bool grpc_channel_arg_get_bool(const grpc_arg* arg, bool default_value);
+inline bool grpc_channel_args_get_bool(const grpc_channel_args* args,
+                                       const char* name, bool default_value) {
+  return grpc_channel_arg_get_bool(grpc_channel_args_find(args, name),
+                                   default_value);
+}
 
 // Helpers for creating channel args.
 grpc_arg grpc_channel_arg_string_create(char* name, char* value);

--- a/src/core/lib/iomgr/resource_quota.cc
+++ b/src/core/lib/iomgr/resource_quota.cc
@@ -671,10 +671,8 @@ size_t grpc_resource_quota_peek_size(grpc_resource_quota* resource_quota) {
 
 grpc_resource_quota* grpc_resource_quota_from_channel_args(
     const grpc_channel_args* channel_args) {
-  const grpc_arg* arg =
-      grpc_channel_args_find(channel_args, GRPC_ARG_RESOURCE_QUOTA);
-  grpc_resource_quota* rq =
-      grpc_channel_arg_get_pointer<grpc_resource_quota>(arg);
+  grpc_resource_quota* rq = grpc_channel_args_get_pointer<grpc_resource_quota>(
+      channel_args, GRPC_ARG_RESOURCE_QUOTA);
   return rq == nullptr ? grpc_resource_quota_create(nullptr) : rq;
 }
 

--- a/src/core/lib/iomgr/tcp_client_posix.cc
+++ b/src/core/lib/iomgr/tcp_client_posix.cc
@@ -80,14 +80,13 @@ static grpc_error* prepare_socket(const grpc_resolved_address* addr, int fd,
   err = grpc_set_socket_no_sigpipe_if_possible(fd);
   if (err != GRPC_ERROR_NONE) goto error;
   if (channel_args) {
-    for (size_t i = 0; i < channel_args->num_args; i++) {
-      if (0 == strcmp(channel_args->args[i].key, GRPC_ARG_SOCKET_MUTATOR)) {
-        GPR_ASSERT(channel_args->args[i].type == GRPC_ARG_POINTER);
-        grpc_socket_mutator* mutator = static_cast<grpc_socket_mutator*>(
-            channel_args->args[i].value.pointer.p);
-        err = grpc_set_socket_with_mutator(fd, mutator);
-        if (err != GRPC_ERROR_NONE) goto error;
-      }
+    const grpc_arg* arg =
+        grpc_channel_args_find(channel_args, GRPC_ARG_SOCKET_MUTATOR);
+    grpc_socket_mutator* mutator =
+        grpc_channel_arg_get_pointer<grpc_socket_mutator>(arg);
+    if (mutator) {
+      err = grpc_set_socket_with_mutator(fd, mutator);
+      if (err != GRPC_ERROR_NONE) goto error;
     }
   }
   goto done;

--- a/src/core/lib/iomgr/tcp_server_custom.cc
+++ b/src/core/lib/iomgr/tcp_server_custom.cc
@@ -81,9 +81,8 @@ static grpc_error* tcp_server_create(grpc_closure* shutdown_complete,
                                      const grpc_channel_args* args,
                                      grpc_tcp_server** server) {
   grpc_tcp_server* s = (grpc_tcp_server*)gpr_malloc(sizeof(grpc_tcp_server));
-  const grpc_arg* arg = grpc_channel_args_find(args, GRPC_ARG_RESOURCE_QUOTA);
-  grpc_resource_quota* rq =
-      grpc_channel_arg_get_pointer<grpc_resource_quota>(arg);
+  grpc_resource_quota* rq = grpc_channel_args_get_pointer<grpc_resource_quota>(
+      args, GRPC_ARG_RESOURCE_QUOTA);
   s->resource_quota = rq == nullptr ? grpc_resource_quota_create(nullptr) : rq;
   gpr_ref_init(&s->refs, 1);
   s->on_accept_cb = nullptr;

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -63,23 +63,14 @@ static grpc_error* tcp_server_create(grpc_closure* shutdown_complete,
   s->so_reuseport = grpc_is_socket_reuse_port_supported();
   s->expand_wildcard_addrs = false;
   for (size_t i = 0; i < (args == nullptr ? 0 : args->num_args); i++) {
+    // TODO(roth): I chose that these both default to true. Is this reasonable?
+    // Before they would create errors, so this is actually making the
+    // restrictions more lenient.
     if (0 == strcmp(GRPC_ARG_ALLOW_REUSEPORT, args->args[i].key)) {
-      if (args->args[i].type == GRPC_ARG_INTEGER) {
-        s->so_reuseport = grpc_is_socket_reuse_port_supported() &&
-                          (args->args[i].value.integer != 0);
-      } else {
-        gpr_free(s);
-        return GRPC_ERROR_CREATE_FROM_STATIC_STRING(GRPC_ARG_ALLOW_REUSEPORT
-                                                    " must be an integer");
-      }
+      s->so_reuseport = grpc_channel_arg_get_bool(&args->args[i], true);
     } else if (0 == strcmp(GRPC_ARG_EXPAND_WILDCARD_ADDRS, args->args[i].key)) {
-      if (args->args[i].type == GRPC_ARG_INTEGER) {
-        s->expand_wildcard_addrs = (args->args[i].value.integer != 0);
-      } else {
-        gpr_free(s);
-        return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-            GRPC_ARG_EXPAND_WILDCARD_ADDRS " must be an integer");
-      }
+      s->expand_wildcard_addrs =
+          grpc_channel_arg_get_bool(&args->args[i], true);
     }
   }
   gpr_ref_init(&s->refs, 1);

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -63,14 +63,12 @@ static grpc_error* tcp_server_create(grpc_closure* shutdown_complete,
   s->so_reuseport = grpc_is_socket_reuse_port_supported();
   s->expand_wildcard_addrs = false;
   for (size_t i = 0; i < (args == nullptr ? 0 : args->num_args); i++) {
-    // TODO(roth): I chose that these both default to true. Is this reasonable?
-    // Before they would create errors, so this is actually making the
-    // restrictions more lenient.
     if (0 == strcmp(GRPC_ARG_ALLOW_REUSEPORT, args->args[i].key)) {
-      s->so_reuseport = grpc_channel_arg_get_bool(&args->args[i], true);
+      s->so_reuseport = grpc_channel_arg_get_bool(
+          &args->args[i], grpc_is_socket_reuse_port_supported());
     } else if (0 == strcmp(GRPC_ARG_EXPAND_WILDCARD_ADDRS, args->args[i].key)) {
       s->expand_wildcard_addrs =
-          grpc_channel_arg_get_bool(&args->args[i], true);
+          grpc_channel_arg_get_bool(&args->args[i], false);
     }
   }
   gpr_ref_init(&s->refs, 1);

--- a/src/core/lib/iomgr/udp_server.cc
+++ b/src/core/lib/iomgr/udp_server.cc
@@ -199,10 +199,7 @@ struct grpc_udp_server {
 static grpc_socket_factory* get_socket_factory(const grpc_channel_args* args) {
   if (args) {
     const grpc_arg* arg = grpc_channel_args_find(args, GRPC_ARG_SOCKET_FACTORY);
-    if (arg) {
-      GPR_ASSERT(arg->type == GRPC_ARG_POINTER);
-      return static_cast<grpc_socket_factory*>(arg->value.pointer.p);
-    }
+    return grpc_channel_arg_get_pointer<grpc_socket_factory>(arg);
   }
   return nullptr;
 }

--- a/src/core/lib/iomgr/udp_server.cc
+++ b/src/core/lib/iomgr/udp_server.cc
@@ -197,11 +197,8 @@ struct grpc_udp_server {
 };
 
 static grpc_socket_factory* get_socket_factory(const grpc_channel_args* args) {
-  if (args) {
-    const grpc_arg* arg = grpc_channel_args_find(args, GRPC_ARG_SOCKET_FACTORY);
-    return grpc_channel_arg_get_pointer<grpc_socket_factory>(arg);
-  }
-  return nullptr;
+  return grpc_channel_args_get_pointer<grpc_socket_factory>(
+      args, GRPC_ARG_SOCKET_FACTORY);
 }
 
 grpc_udp_server* grpc_udp_server_create(const grpc_channel_args* args) {

--- a/src/core/lib/security/context/security_context.cc
+++ b/src/core/lib/security/context/security_context.cc
@@ -326,23 +326,9 @@ grpc_arg grpc_auth_context_to_arg(grpc_auth_context* p) {
                                          &auth_context_pointer_vtable);
 }
 
-grpc_auth_context* grpc_auth_context_from_arg(const grpc_arg* arg) {
-  if (strcmp(arg->key, GRPC_AUTH_CONTEXT_ARG) != 0) return nullptr;
-  if (arg->type != GRPC_ARG_POINTER) {
-    gpr_log(GPR_ERROR, "Invalid type %d for arg %s", arg->type,
-            GRPC_AUTH_CONTEXT_ARG);
-    return nullptr;
-  }
-  return static_cast<grpc_auth_context*>(arg->value.pointer.p);
-}
-
 grpc_auth_context* grpc_find_auth_context_in_args(
-    const grpc_channel_args* args) {
-  size_t i;
-  if (args == nullptr) return nullptr;
-  for (i = 0; i < args->num_args; i++) {
-    grpc_auth_context* p = grpc_auth_context_from_arg(&args->args[i]);
-    if (p != nullptr) return p;
-  }
-  return nullptr;
+    const grpc_channel_args* channel_args) {
+  const grpc_arg* arg =
+      grpc_channel_args_find(channel_args, GRPC_AUTH_CONTEXT_ARG);
+  return grpc_channel_arg_get_pointer<grpc_auth_context>(arg);
 }

--- a/src/core/lib/security/context/security_context.cc
+++ b/src/core/lib/security/context/security_context.cc
@@ -328,7 +328,6 @@ grpc_arg grpc_auth_context_to_arg(grpc_auth_context* p) {
 
 grpc_auth_context* grpc_find_auth_context_in_args(
     const grpc_channel_args* channel_args) {
-  const grpc_arg* arg =
-      grpc_channel_args_find(channel_args, GRPC_AUTH_CONTEXT_ARG);
-  return grpc_channel_arg_get_pointer<grpc_auth_context>(arg);
+  return grpc_channel_args_get_pointer<grpc_auth_context>(
+      channel_args, GRPC_AUTH_CONTEXT_ARG);
 }

--- a/src/core/lib/security/context/security_context.h
+++ b/src/core/lib/security/context/security_context.h
@@ -108,7 +108,6 @@ void grpc_server_security_context_destroy(void* ctx);
 #define GRPC_AUTH_CONTEXT_ARG "grpc.auth_context"
 
 grpc_arg grpc_auth_context_to_arg(grpc_auth_context* c);
-grpc_auth_context* grpc_auth_context_from_arg(const grpc_arg* arg);
 grpc_auth_context* grpc_find_auth_context_in_args(
     const grpc_channel_args* args);
 

--- a/src/core/lib/security/credentials/credentials.cc
+++ b/src/core/lib/security/credentials/credentials.cc
@@ -168,27 +168,11 @@ grpc_arg grpc_channel_credentials_to_arg(
                                          &credentials_pointer_vtable);
 }
 
-grpc_channel_credentials* grpc_channel_credentials_from_arg(
-    const grpc_arg* arg) {
-  if (strcmp(arg->key, GRPC_ARG_CHANNEL_CREDENTIALS)) return nullptr;
-  if (arg->type != GRPC_ARG_POINTER) {
-    gpr_log(GPR_ERROR, "Invalid type %d for arg %s", arg->type,
-            GRPC_ARG_CHANNEL_CREDENTIALS);
-    return nullptr;
-  }
-  return static_cast<grpc_channel_credentials*>(arg->value.pointer.p);
-}
-
 grpc_channel_credentials* grpc_channel_credentials_find_in_args(
-    const grpc_channel_args* args) {
-  size_t i;
-  if (args == nullptr) return nullptr;
-  for (i = 0; i < args->num_args; i++) {
-    grpc_channel_credentials* credentials =
-        grpc_channel_credentials_from_arg(&args->args[i]);
-    if (credentials != nullptr) return credentials;
-  }
-  return nullptr;
+    const grpc_channel_args* channel_args) {
+  const grpc_arg* arg =
+      grpc_channel_args_find(channel_args, GRPC_ARG_CHANNEL_CREDENTIALS);
+  return grpc_channel_arg_get_pointer<grpc_channel_credentials>(arg);
 }
 
 grpc_server_credentials* grpc_server_credentials_ref(
@@ -263,24 +247,9 @@ grpc_arg grpc_server_credentials_to_arg(grpc_server_credentials* p) {
                                          &cred_ptr_vtable);
 }
 
-grpc_server_credentials* grpc_server_credentials_from_arg(const grpc_arg* arg) {
-  if (strcmp(arg->key, GRPC_SERVER_CREDENTIALS_ARG) != 0) return nullptr;
-  if (arg->type != GRPC_ARG_POINTER) {
-    gpr_log(GPR_ERROR, "Invalid type %d for arg %s", arg->type,
-            GRPC_SERVER_CREDENTIALS_ARG);
-    return nullptr;
-  }
-  return static_cast<grpc_server_credentials*>(arg->value.pointer.p);
-}
-
 grpc_server_credentials* grpc_find_server_credentials_in_args(
-    const grpc_channel_args* args) {
-  size_t i;
-  if (args == nullptr) return nullptr;
-  for (i = 0; i < args->num_args; i++) {
-    grpc_server_credentials* p =
-        grpc_server_credentials_from_arg(&args->args[i]);
-    if (p != nullptr) return p;
-  }
-  return nullptr;
+    const grpc_channel_args* channel_args) {
+  const grpc_arg* arg =
+      grpc_channel_args_find(channel_args, GRPC_SERVER_CREDENTIALS_ARG);
+  return grpc_channel_arg_get_pointer<grpc_server_credentials>(arg);
 }

--- a/src/core/lib/security/credentials/credentials.cc
+++ b/src/core/lib/security/credentials/credentials.cc
@@ -170,9 +170,8 @@ grpc_arg grpc_channel_credentials_to_arg(
 
 grpc_channel_credentials* grpc_channel_credentials_find_in_args(
     const grpc_channel_args* channel_args) {
-  const grpc_arg* arg =
-      grpc_channel_args_find(channel_args, GRPC_ARG_CHANNEL_CREDENTIALS);
-  return grpc_channel_arg_get_pointer<grpc_channel_credentials>(arg);
+  return grpc_channel_args_get_pointer<grpc_channel_credentials>(
+      channel_args, GRPC_ARG_CHANNEL_CREDENTIALS);
 }
 
 grpc_server_credentials* grpc_server_credentials_ref(
@@ -249,7 +248,6 @@ grpc_arg grpc_server_credentials_to_arg(grpc_server_credentials* p) {
 
 grpc_server_credentials* grpc_find_server_credentials_in_args(
     const grpc_channel_args* channel_args) {
-  const grpc_arg* arg =
-      grpc_channel_args_find(channel_args, GRPC_SERVER_CREDENTIALS_ARG);
-  return grpc_channel_arg_get_pointer<grpc_server_credentials>(arg);
+  return grpc_channel_args_get_pointer<grpc_server_credentials>(
+      channel_args, GRPC_SERVER_CREDENTIALS_ARG);
 }

--- a/src/core/lib/security/credentials/credentials.h
+++ b/src/core/lib/security/credentials/credentials.h
@@ -131,10 +131,6 @@ grpc_channel_credentials_duplicate_without_call_credentials(
 /* Util to encapsulate the channel credentials in a channel arg. */
 grpc_arg grpc_channel_credentials_to_arg(grpc_channel_credentials* credentials);
 
-/* Util to get the channel credentials from a channel arg. */
-grpc_channel_credentials* grpc_channel_credentials_from_arg(
-    const grpc_arg* arg);
-
 /* Util to find the channel credentials from channel args. */
 grpc_channel_credentials* grpc_channel_credentials_find_in_args(
     const grpc_channel_args* args);
@@ -227,7 +223,6 @@ void grpc_server_credentials_unref(grpc_server_credentials* creds);
 #define GRPC_SERVER_CREDENTIALS_ARG "grpc.server_credentials"
 
 grpc_arg grpc_server_credentials_to_arg(grpc_server_credentials* c);
-grpc_server_credentials* grpc_server_credentials_from_arg(const grpc_arg* arg);
 grpc_server_credentials* grpc_find_server_credentials_in_args(
     const grpc_channel_args* args);
 

--- a/src/core/lib/security/credentials/fake/fake_credentials.cc
+++ b/src/core/lib/security/credentials/fake/fake_credentials.cc
@@ -84,9 +84,8 @@ grpc_arg grpc_fake_transport_expected_targets_arg(char* expected_targets) {
 
 const char* grpc_fake_transport_get_expected_targets(
     const grpc_channel_args* args) {
-  const grpc_arg* expected_target_arg =
-      grpc_channel_args_find(args, GRPC_ARG_FAKE_SECURITY_EXPECTED_TARGETS);
-  return grpc_channel_arg_get_string(expected_target_arg);
+  return grpc_channel_args_get_string(args,
+                                      GRPC_ARG_FAKE_SECURITY_EXPECTED_TARGETS);
 }
 
 /* -- Metadata-only test credentials. -- */

--- a/src/core/lib/security/credentials/google_default/google_default_credentials.cc
+++ b/src/core/lib/security/credentials/google_default/google_default_credentials.cc
@@ -79,13 +79,10 @@ static grpc_security_status google_default_create_security_connector(
     grpc_channel_security_connector** sc, grpc_channel_args** new_args) {
   grpc_google_default_channel_credentials* c =
       reinterpret_cast<grpc_google_default_channel_credentials*>(creds);
-  bool is_grpclb_load_balancer = grpc_channel_arg_get_bool(
-      grpc_channel_args_find(args, GRPC_ARG_ADDRESS_IS_GRPCLB_LOAD_BALANCER),
-      false);
-  bool is_backend_from_grpclb_load_balancer = grpc_channel_arg_get_bool(
-      grpc_channel_args_find(
-          args, GRPC_ARG_ADDRESS_IS_BACKEND_FROM_GRPCLB_LOAD_BALANCER),
-      false);
+  bool is_grpclb_load_balancer = grpc_channel_args_get_bool(
+      args, GRPC_ARG_ADDRESS_IS_GRPCLB_LOAD_BALANCER, false);
+  bool is_backend_from_grpclb_load_balancer = grpc_channel_args_get_bool(
+      args, GRPC_ARG_ADDRESS_IS_BACKEND_FROM_GRPCLB_LOAD_BALANCER, false);
   bool use_alts =
       is_grpclb_load_balancer || is_backend_from_grpclb_load_balancer;
   grpc_security_status status = GRPC_SECURITY_ERROR;

--- a/src/core/lib/security/credentials/ssl/ssl_credentials.cc
+++ b/src/core/lib/security/credentials/ssl/ssl_credentials.cc
@@ -60,14 +60,12 @@ static grpc_security_status ssl_create_security_connector(
   tsi_ssl_session_cache* ssl_session_cache = nullptr;
   for (size_t i = 0; args && i < args->num_args; i++) {
     grpc_arg* arg = &args->args[i];
-    if (strcmp(arg->key, GRPC_SSL_TARGET_NAME_OVERRIDE_ARG) == 0 &&
-        arg->type == GRPC_ARG_STRING) {
-      overridden_target_name = arg->value.string;
+    if (strcmp(arg->key, GRPC_SSL_TARGET_NAME_OVERRIDE_ARG) == 0) {
+      overridden_target_name = grpc_channel_arg_get_string(arg);
     }
-    if (strcmp(arg->key, GRPC_SSL_SESSION_CACHE_ARG) == 0 &&
-        arg->type == GRPC_ARG_POINTER) {
+    if (strcmp(arg->key, GRPC_SSL_SESSION_CACHE_ARG) == 0) {
       ssl_session_cache =
-          static_cast<tsi_ssl_session_cache*>(arg->value.pointer.p);
+          grpc_channel_arg_get_pointer<tsi_ssl_session_cache>(arg);
     }
   }
   status = grpc_ssl_channel_security_connector_create(

--- a/src/core/lib/security/security_connector/security_connector.cc
+++ b/src/core/lib/security/security_connector/security_connector.cc
@@ -255,26 +255,11 @@ grpc_arg grpc_security_connector_to_arg(grpc_security_connector* sc) {
                                          &connector_arg_vtable);
 }
 
-grpc_security_connector* grpc_security_connector_from_arg(const grpc_arg* arg) {
-  if (strcmp(arg->key, GRPC_ARG_SECURITY_CONNECTOR)) return nullptr;
-  if (arg->type != GRPC_ARG_POINTER) {
-    gpr_log(GPR_ERROR, "Invalid type %d for arg %s", arg->type,
-            GRPC_ARG_SECURITY_CONNECTOR);
-    return nullptr;
-  }
-  return static_cast<grpc_security_connector*>(arg->value.pointer.p);
-}
-
 grpc_security_connector* grpc_security_connector_find_in_args(
-    const grpc_channel_args* args) {
-  size_t i;
-  if (args == nullptr) return nullptr;
-  for (i = 0; i < args->num_args; i++) {
-    grpc_security_connector* sc =
-        grpc_security_connector_from_arg(&args->args[i]);
-    if (sc != nullptr) return sc;
-  }
-  return nullptr;
+    const grpc_channel_args* channel_args) {
+  const grpc_arg* arg =
+      grpc_channel_args_find(channel_args, GRPC_ARG_SECURITY_CONNECTOR);
+  return grpc_channel_arg_get_pointer<grpc_security_connector>(arg);
 }
 
 static tsi_client_certificate_request_type

--- a/src/core/lib/security/security_connector/security_connector.cc
+++ b/src/core/lib/security/security_connector/security_connector.cc
@@ -257,9 +257,8 @@ grpc_arg grpc_security_connector_to_arg(grpc_security_connector* sc) {
 
 grpc_security_connector* grpc_security_connector_find_in_args(
     const grpc_channel_args* channel_args) {
-  const grpc_arg* arg =
-      grpc_channel_args_find(channel_args, GRPC_ARG_SECURITY_CONNECTOR);
-  return grpc_channel_arg_get_pointer<grpc_security_connector>(arg);
+  return grpc_channel_args_get_pointer<grpc_security_connector>(
+      channel_args, GRPC_ARG_SECURITY_CONNECTOR);
 }
 
 static tsi_client_certificate_request_type

--- a/src/core/lib/security/security_connector/security_connector.h
+++ b/src/core/lib/security/security_connector/security_connector.h
@@ -99,9 +99,6 @@ int grpc_security_connector_cmp(grpc_security_connector* sc,
 /* Util to encapsulate the connector in a channel arg. */
 grpc_arg grpc_security_connector_to_arg(grpc_security_connector* sc);
 
-/* Util to get the connector from a channel arg. */
-grpc_security_connector* grpc_security_connector_from_arg(const grpc_arg* arg);
-
 /* Util to find the connector from channel args. */
 grpc_security_connector* grpc_security_connector_find_in_args(
     const grpc_channel_args* args);

--- a/src/core/lib/security/transport/target_authority_table.cc
+++ b/src/core/lib/security/transport/target_authority_table.cc
@@ -61,15 +61,7 @@ TargetAuthorityTable* FindTargetAuthorityTableInArgs(
     const grpc_channel_args* args) {
   const grpc_arg* arg =
       grpc_channel_args_find(args, GRPC_ARG_TARGET_AUTHORITY_TABLE);
-  if (arg != nullptr) {
-    if (arg->type == GRPC_ARG_POINTER) {
-      return static_cast<TargetAuthorityTable*>(arg->value.pointer.p);
-    } else {
-      gpr_log(GPR_ERROR, "value of " GRPC_ARG_TARGET_AUTHORITY_TABLE
-                         " channel arg was not pointer type; ignoring");
-    }
-  }
-  return nullptr;
+  return grpc_channel_arg_get_pointer<TargetAuthorityTable>(arg);
 }
 
 }  // namespace grpc_core

--- a/src/core/lib/security/transport/target_authority_table.cc
+++ b/src/core/lib/security/transport/target_authority_table.cc
@@ -59,9 +59,8 @@ grpc_arg CreateTargetAuthorityTableChannelArg(TargetAuthorityTable* table) {
 
 TargetAuthorityTable* FindTargetAuthorityTableInArgs(
     const grpc_channel_args* args) {
-  const grpc_arg* arg =
-      grpc_channel_args_find(args, GRPC_ARG_TARGET_AUTHORITY_TABLE);
-  return grpc_channel_arg_get_pointer<TargetAuthorityTable>(arg);
+  return grpc_channel_args_get_pointer<TargetAuthorityTable>(
+      args, GRPC_ARG_TARGET_AUTHORITY_TABLE);
 }
 
 }  // namespace grpc_core

--- a/test/core/end2end/fixtures/h2_http_proxy.cc
+++ b/test/core/end2end/fixtures/h2_http_proxy.cc
@@ -69,9 +69,8 @@ void chttp2_init_client_fullstack(grpc_end2end_test_fixture* f,
   char* proxy_uri;
 
   /* If testing for proxy auth, add credentials to proxy uri */
-  const grpc_arg* proxy_auth_arg =
-      grpc_channel_args_find(client_args, GRPC_ARG_HTTP_PROXY_AUTH_CREDS);
-  const char* proxy_auth_str = grpc_channel_arg_get_string(proxy_auth_arg);
+  const char* proxy_auth_str =
+      grpc_channel_args_get_string(client_args, GRPC_ARG_HTTP_PROXY_AUTH_CREDS);
   if (proxy_auth_str == nullptr) {
     gpr_asprintf(&proxy_uri, "http://%s",
                  grpc_end2end_http_proxy_get_proxy_name(ffd->proxy));

--- a/test/core/end2end/fixtures/http_proxy_fixture.cc
+++ b/test/core/end2end/fixtures/http_proxy_fixture.cc
@@ -411,9 +411,8 @@ static void on_read_request_done(void* arg, grpc_error* error) {
     return;
   }
   // If proxy auth is being used, check if the header is present and as expected
-  const grpc_arg* proxy_auth_arg = grpc_channel_args_find(
+  char* proxy_auth_str = grpc_channel_args_get_string(
       conn->proxy->channel_args, GRPC_ARG_HTTP_PROXY_AUTH_CREDS);
-  char* proxy_auth_str = grpc_channel_arg_get_string(proxy_auth_arg);
   if (proxy_auth_str != nullptr) {
     bool client_authenticated = false;
     for (size_t i = 0; i < conn->http_request.hdr_count; i++) {

--- a/tools/run_tests/sanity/check_channel_arg_usage.py
+++ b/tools/run_tests/sanity/check_channel_arg_usage.py
@@ -30,6 +30,7 @@ _EXCEPTIONS = set([
 _BANNED = set([
     "GRPC_ARG_POINTER",
     "GRPC_ARG_STRING",
+    "GRPC_ARG_INTEGER",
 ])
 
 errors = 0

--- a/tools/run_tests/sanity/check_channel_arg_usage.py
+++ b/tools/run_tests/sanity/check_channel_arg_usage.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+import sys
+
+os.chdir(os.path.join(os.path.dirname(sys.argv[0]), '../../..'))
+
+# set of files that are allowed to use the raw GRPC_ARG_* types
+_EXCEPTIONS = set([
+    'src/core/lib/channel/channel_args.cc',
+    'src/core/lib/channel/channel_args.h',
+])
+
+_BANNED = set([
+    "GRPC_ARG_POINTER",
+])
+
+errors = 0
+num_files = 0
+for root, dirs, files in os.walk('src/core'):
+    for filename in files:
+        num_files += 1
+        path = os.path.join(root, filename)
+        if path in _EXCEPTIONS: continue
+        with open(path) as f:
+            text = f.read()
+        for banned in _BANNED:
+            if banned in text:
+                print('Illegal use of "%s" in %s' % (banned, path))
+                errors += 1
+
+assert errors == 0
+# This check comes about from this issue:
+# https://github.com/grpc/grpc/issues/15381
+# Basically, a change rendered this script useless and we did not realize it.
+# This dumb check ensures that this type of issue doesn't occur again.
+assert num_files > 300  # we definitely have more than 300 files

--- a/tools/run_tests/sanity/check_channel_arg_usage.py
+++ b/tools/run_tests/sanity/check_channel_arg_usage.py
@@ -29,6 +29,7 @@ _EXCEPTIONS = set([
 
 _BANNED = set([
     "GRPC_ARG_POINTER",
+    "GRPC_ARG_STRING",
 ])
 
 errors = 0


### PR DESCRIPTION
Addressed #8694

Will also add a linter. Eventually the promise should be that no code is using GRPC_ARG_* explicitly, but is always interacting with the args via the channel arg API

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/15678)
<!-- Reviewable:end -->
