### PR TITLE
Más limpieza Clang

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,6 @@
 ---
-Checks: 'modernize-use-nullptr,google-build-namespaces,google-build-explicit-make-pair,readability-function-size,performance-*'
-WarningsAsErrors: 'modernize-use-nullptr,google-build-namespaces,google-build-explicit-make-pair,readability-function-size,performance-*'
+Checks: modernize-use-nullptr,google-build-namespaces,google-build-explicit-make-pair,readability-function-size,performance-*,google-*,-google-readability-casting,-google-runtime-references,-google-runtime-int,-google-build-using-namespace,-google-explicit-constructor
+WarningsAsErrors: modernize-use-nullptr,google-build-namespaces,google-build-explicit-make-pair,readability-function-size,performance-*,google-*,-google-readability-casting,-google-runtime-references,-google-runtime-int,-google-build-using-namespace,-google-explicit-constructor
 CheckOptions:
   - key:    readability-function-size.StatementThreshold
     value:  '450'

--- a/src/core/ext/filters/client_channel/lb_policy_factory.cc
+++ b/src/core/ext/filters/client_channel/lb_policy_factory.cc
@@ -149,7 +149,9 @@ grpc_lb_addresses* grpc_lb_addresses_find_channel_arg(
     const grpc_channel_args* channel_args) {
   const grpc_arg* lb_addresses_arg =
       grpc_channel_args_find(channel_args, GRPC_ARG_LB_ADDRESSES);
-  if (lb_addresses_arg == nullptr || lb_addresses_arg->type != GRPC_ARG_POINTER)
+  if (lb_addresses_arg == nullptr ||
+      lb_addresses_arg->type != GRPC_ARG_POINTER) {
     return nullptr;
+  }
   return static_cast<grpc_lb_addresses*>(lb_addresses_arg->value.pointer.p);
 }

--- a/src/core/ext/filters/http/server/http_server_filter.cc
+++ b/src/core/ext/filters/http/server/http_server_filter.cc
@@ -206,8 +206,8 @@ static grpc_error* hs_filter_incoming_metadata(grpc_call_element* elem,
     /* offset of the character '?' */
     size_t offset = 0;
     for (offset = 0; offset < path_length && *path_ptr != k_query_separator;
-         path_ptr++, offset++)
-      ;
+         path_ptr++, offset++) {
+    }
     if (offset < path_length) {
       grpc_slice query_slice =
           grpc_slice_sub(path_slice, offset + 1, path_length);

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.cc
@@ -130,9 +130,10 @@ grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
       ++cur;
     /* fallthrough */
     case GRPC_CHTTP2_GOAWAY_DEBUG:
-      if (end != cur)
+      if (end != cur) {
         memcpy(p->debug_data + p->debug_pos, cur,
                static_cast<size_t>(end - cur));
+      }
       GPR_ASSERT((size_t)(end - cur) < UINT32_MAX - p->debug_pos);
       p->debug_pos += static_cast<uint32_t>(end - cur);
       p->state = GRPC_CHTTP2_GOAWAY_DEBUG;

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -1271,12 +1271,13 @@ static grpc_error* append_string(grpc_chttp2_hpack_parser* p,
       }
       bits = inverse_base64[*cur];
       ++cur;
-      if (bits == 255)
+      if (bits == 255) {
         return parse_error(
             p, cur, end,
             GRPC_ERROR_CREATE_FROM_STATIC_STRING("Illegal base64 character"));
-      else if (bits == 64)
+      } else if (bits == 64) {
         goto b64_byte0;
+      }
       p->base64_buffer = bits << 18;
     /* fallthrough */
     b64_byte1:
@@ -1287,12 +1288,13 @@ static grpc_error* append_string(grpc_chttp2_hpack_parser* p,
       }
       bits = inverse_base64[*cur];
       ++cur;
-      if (bits == 255)
+      if (bits == 255) {
         return parse_error(
             p, cur, end,
             GRPC_ERROR_CREATE_FROM_STATIC_STRING("Illegal base64 character"));
-      else if (bits == 64)
+      } else if (bits == 64) {
         goto b64_byte1;
+      }
       p->base64_buffer |= bits << 12;
     /* fallthrough */
     b64_byte2:
@@ -1303,12 +1305,13 @@ static grpc_error* append_string(grpc_chttp2_hpack_parser* p,
       }
       bits = inverse_base64[*cur];
       ++cur;
-      if (bits == 255)
+      if (bits == 255) {
         return parse_error(
             p, cur, end,
             GRPC_ERROR_CREATE_FROM_STATIC_STRING("Illegal base64 character"));
-      else if (bits == 64)
+      } else if (bits == 64) {
         goto b64_byte2;
+      }
       p->base64_buffer |= bits << 6;
     /* fallthrough */
     b64_byte3:
@@ -1319,12 +1322,13 @@ static grpc_error* append_string(grpc_chttp2_hpack_parser* p,
       }
       bits = inverse_base64[*cur];
       ++cur;
-      if (bits == 255)
+      if (bits == 255) {
         return parse_error(
             p, cur, end,
             GRPC_ERROR_CREATE_FROM_STATIC_STRING("Illegal base64 character"));
-      else if (bits == 64)
+      } else if (bits == 64) {
         goto b64_byte3;
+      }
       p->base64_buffer |= bits;
       bits = p->base64_buffer;
       decoded[0] = static_cast<uint8_t>(bits >> 16);

--- a/src/core/ext/transport/cronet/transport/cronet_transport.cc
+++ b/src/core/ext/transport/cronet/transport/cronet_transport.cc
@@ -863,57 +863,73 @@ static bool op_can_be_run(grpc_transport_stream_op_batch* curr_op,
     if (stream_state->state_op_done[OP_SEND_INITIAL_METADATA]) result = false;
   } else if (op_id == OP_RECV_INITIAL_METADATA) {
     /* already executed */
-    if (stream_state->state_op_done[OP_RECV_INITIAL_METADATA]) result = false;
-    /* we haven't sent headers yet. */
-    else if (!stream_state->state_callback_received[OP_SEND_INITIAL_METADATA])
+    if (stream_state->state_op_done[OP_RECV_INITIAL_METADATA]) {
       result = false;
-    /* we haven't received headers yet. */
-    else if (!stream_state->state_callback_received[OP_RECV_INITIAL_METADATA] &&
-             !stream_state->state_op_done[OP_RECV_TRAILING_METADATA])
+      /* we haven't sent headers yet. */
+    } else if (!stream_state
+                    ->state_callback_received[OP_SEND_INITIAL_METADATA]) {
       result = false;
+      /* we haven't received headers yet. */
+    } else if (!stream_state
+                    ->state_callback_received[OP_RECV_INITIAL_METADATA] &&
+               !stream_state->state_op_done[OP_RECV_TRAILING_METADATA]) {
+      result = false;
+    }
   } else if (op_id == OP_SEND_MESSAGE) {
     /* already executed (note we're checking op specific state, not stream
      state) */
-    if (op_state->state_op_done[OP_SEND_MESSAGE]) result = false;
-    /* we haven't sent headers yet. */
-    else if (!stream_state->state_callback_received[OP_SEND_INITIAL_METADATA])
+    if (op_state->state_op_done[OP_SEND_MESSAGE]) {
       result = false;
+      /* we haven't sent headers yet. */
+    } else if (!stream_state
+                    ->state_callback_received[OP_SEND_INITIAL_METADATA]) {
+      result = false;
+    }
   } else if (op_id == OP_RECV_MESSAGE) {
     /* already executed */
-    if (op_state->state_op_done[OP_RECV_MESSAGE]) result = false;
-    /* we haven't received headers yet. */
-    else if (!stream_state->state_callback_received[OP_RECV_INITIAL_METADATA] &&
-             !stream_state->state_op_done[OP_RECV_TRAILING_METADATA])
+    if (op_state->state_op_done[OP_RECV_MESSAGE]) {
       result = false;
+      /* we haven't received headers yet. */
+    } else if (!stream_state
+                    ->state_callback_received[OP_RECV_INITIAL_METADATA] &&
+               !stream_state->state_op_done[OP_RECV_TRAILING_METADATA]) {
+      result = false;
+    }
   } else if (op_id == OP_RECV_TRAILING_METADATA) {
     /* already executed */
-    if (stream_state->state_op_done[OP_RECV_TRAILING_METADATA]) result = false;
-    /* we have asked for but haven't received message yet. */
-    else if (stream_state->state_op_done[OP_READ_REQ_MADE] &&
-             !stream_state->state_op_done[OP_RECV_MESSAGE])
+    if (stream_state->state_op_done[OP_RECV_TRAILING_METADATA]) {
       result = false;
-    /* we haven't received trailers  yet. */
-    else if (!stream_state->state_callback_received[OP_RECV_TRAILING_METADATA])
+      /* we have asked for but haven't received message yet. */
+    } else if (stream_state->state_op_done[OP_READ_REQ_MADE] &&
+               !stream_state->state_op_done[OP_RECV_MESSAGE]) {
       result = false;
-    /* we haven't received on_succeeded  yet. */
-    else if (!stream_state->state_callback_received[OP_SUCCEEDED])
+      /* we haven't received trailers  yet. */
+    } else if (!stream_state
+                    ->state_callback_received[OP_RECV_TRAILING_METADATA]) {
       result = false;
+      /* we haven't received on_succeeded  yet. */
+    } else if (!stream_state->state_callback_received[OP_SUCCEEDED]) {
+      result = false;
+    }
   } else if (op_id == OP_SEND_TRAILING_METADATA) {
     /* already executed */
-    if (stream_state->state_op_done[OP_SEND_TRAILING_METADATA]) result = false;
-    /* we haven't sent initial metadata yet */
-    else if (!stream_state->state_callback_received[OP_SEND_INITIAL_METADATA])
+    if (stream_state->state_op_done[OP_SEND_TRAILING_METADATA]) {
       result = false;
-    /* we haven't sent message yet */
-    else if (stream_state->pending_send_message &&
-             !stream_state->state_op_done[OP_SEND_MESSAGE])
+      /* we haven't sent initial metadata yet */
+    } else if (!stream_state
+                    ->state_callback_received[OP_SEND_INITIAL_METADATA]) {
       result = false;
-    /* we haven't got on_write_completed for the send yet */
-    else if (stream_state->state_op_done[OP_SEND_MESSAGE] &&
-             !stream_state->state_callback_received[OP_SEND_MESSAGE] &&
-             !(t->use_packet_coalescing &&
-               stream_state->pending_write_for_trailer))
+      /* we haven't sent message yet */
+    } else if (stream_state->pending_send_message &&
+               !stream_state->state_op_done[OP_SEND_MESSAGE]) {
       result = false;
+      /* we haven't got on_write_completed for the send yet */
+    } else if (stream_state->state_op_done[OP_SEND_MESSAGE] &&
+               !stream_state->state_callback_received[OP_SEND_MESSAGE] &&
+               !(t->use_packet_coalescing &&
+                 stream_state->pending_write_for_trailer)) {
+      result = false;
+    }
   } else if (op_id == OP_CANCEL_ERROR) {
     /* already executed */
     if (stream_state->state_op_done[OP_CANCEL_ERROR]) result = false;
@@ -978,8 +994,9 @@ static bool op_can_be_run(grpc_transport_stream_op_batch* curr_op,
     /* We should see at least one on_write_completed for the trailers that we
       sent */
     else if (curr_op->send_trailing_metadata &&
-             !stream_state->state_callback_received[OP_SEND_MESSAGE])
+             !stream_state->state_callback_received[OP_SEND_MESSAGE]) {
       result = false;
+    }
   }
   CRONET_LOG(GPR_DEBUG, "op_can_be_run %s : %s", op_id_string(op_id),
              result ? "YES" : "NO");
@@ -1342,8 +1359,9 @@ static enum e_op_result execute_stream_op(struct op_and_state* oas) {
     result = ACTION_TAKEN_NO_CALLBACK;
     /* If this is the on_complete callback being called for a received message -
       make a note */
-    if (stream_op->recv_message)
+    if (stream_op->recv_message) {
       stream_state->state_op_done[OP_RECV_MESSAGE_AND_ON_COMPLETE] = true;
+    }
   } else {
     result = NO_ACTION_POSSIBLE;
   }

--- a/src/core/lib/channel/channel_args.cc
+++ b/src/core/lib/channel/channel_args.cc
@@ -176,8 +176,9 @@ grpc_channel_args* grpc_channel_args_normalize(const grpc_channel_args* a) {
   for (size_t i = 0; i < a->num_args; i++) {
     args[i] = &a->args[i];
   }
-  if (a->num_args > 1)
+  if (a->num_args > 1) {
     qsort(args, a->num_args, sizeof(grpc_arg*), cmp_key_stable);
+  }
 
   grpc_channel_args* b =
       static_cast<grpc_channel_args*>(gpr_malloc(sizeof(grpc_channel_args)));

--- a/src/core/lib/channel/channel_trace.cc
+++ b/src/core/lib/channel/channel_trace.cc
@@ -207,8 +207,9 @@ void ChannelTrace::TraceEvent::RenderTraceEvent(grpc_json* json) const {
 }
 
 grpc_json* ChannelTrace::RenderJSON() const {
-  if (!max_list_size_)
+  if (!max_list_size_) {
     return nullptr;  // tracing is disabled if max_events == 0
+  }
   grpc_json* json = grpc_json_create(GRPC_JSON_OBJECT);
   char* num_events_logged_str;
   gpr_asprintf(&num_events_logged_str, "%" PRId64, num_events_logged_);

--- a/src/core/lib/compression/compression.cc
+++ b/src/core/lib/compression/compression.cc
@@ -151,8 +151,9 @@ grpc_compression_algorithm grpc_compression_algorithm_from_slice(
   if (grpc_slice_eq(str, GRPC_MDSTR_IDENTITY)) return GRPC_COMPRESS_NONE;
   if (grpc_slice_eq(str, GRPC_MDSTR_DEFLATE)) return GRPC_COMPRESS_DEFLATE;
   if (grpc_slice_eq(str, GRPC_MDSTR_GZIP)) return GRPC_COMPRESS_GZIP;
-  if (grpc_slice_eq(str, GRPC_MDSTR_STREAM_SLASH_GZIP))
+  if (grpc_slice_eq(str, GRPC_MDSTR_STREAM_SLASH_GZIP)) {
     return GRPC_COMPRESS_STREAM_GZIP;
+  }
   return GRPC_COMPRESS_ALGORITHMS_COUNT;
 }
 

--- a/src/core/lib/compression/compression_internal.cc
+++ b/src/core/lib/compression/compression_internal.cc
@@ -33,10 +33,12 @@
 
 grpc_message_compression_algorithm
 grpc_message_compression_algorithm_from_slice(grpc_slice str) {
-  if (grpc_slice_eq(str, GRPC_MDSTR_IDENTITY))
+  if (grpc_slice_eq(str, GRPC_MDSTR_IDENTITY)) {
     return GRPC_MESSAGE_COMPRESS_NONE;
-  if (grpc_slice_eq(str, GRPC_MDSTR_DEFLATE))
+  }
+  if (grpc_slice_eq(str, GRPC_MDSTR_DEFLATE)) {
     return GRPC_MESSAGE_COMPRESS_DEFLATE;
+  }
   if (grpc_slice_eq(str, GRPC_MDSTR_GZIP)) return GRPC_MESSAGE_COMPRESS_GZIP;
   return GRPC_MESSAGE_COMPRESS_ALGORITHMS_COUNT;
 }

--- a/src/core/lib/gpr/log_linux.cc
+++ b/src/core/lib/gpr/log_linux.cc
@@ -74,10 +74,11 @@ void gpr_default_log(gpr_log_func_args* args) {
 
   timer = static_cast<time_t>(now.tv_sec);
   final_slash = strrchr(args->file, '/');
-  if (final_slash == nullptr)
+  if (final_slash == nullptr) {
     display_file = args->file;
-  else
+  } else {
     display_file = final_slash + 1;
+  }
 
   if (!localtime_r(&timer, &tm)) {
     strcpy(time_buffer, "error:localtime");

--- a/src/core/lib/gprpp/fork.cc
+++ b/src/core/lib/gprpp/fork.cc
@@ -154,7 +154,7 @@ class ThreadState {
   int count_;
 };
 
-}  // namespace
+}  // namespace internal
 
 void Fork::GlobalInit() {
   if (!overrideEnabled_) {

--- a/src/core/lib/http/format_request.cc
+++ b/src/core/lib/http/format_request.cc
@@ -38,8 +38,9 @@ static void fill_common_header(const grpc_httpcli_request* request,
   gpr_strvec_add(buf, gpr_strdup("Host: "));
   gpr_strvec_add(buf, gpr_strdup(request->host));
   gpr_strvec_add(buf, gpr_strdup("\r\n"));
-  if (connection_close)
+  if (connection_close) {
     gpr_strvec_add(buf, gpr_strdup("Connection: close\r\n"));
+  }
   gpr_strvec_add(buf,
                  gpr_strdup("User-Agent: " GRPC_HTTPCLI_USER_AGENT "\r\n"));
   /* user supplied headers */

--- a/src/core/lib/http/parser.cc
+++ b/src/core/lib/http/parser.cc
@@ -42,36 +42,48 @@ static grpc_error* handle_response_line(grpc_http_parser* parser) {
   uint8_t* cur = beg;
   uint8_t* end = beg + parser->cur_line_length;
 
-  if (cur == end || *cur++ != 'H')
+  if (cur == end || *cur++ != 'H') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'H'");
-  if (cur == end || *cur++ != 'T')
+  }
+  if (cur == end || *cur++ != 'T') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'T'");
-  if (cur == end || *cur++ != 'T')
+  }
+  if (cur == end || *cur++ != 'T') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'T'");
-  if (cur == end || *cur++ != 'P')
+  }
+  if (cur == end || *cur++ != 'P') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'P'");
-  if (cur == end || *cur++ != '/')
+  }
+  if (cur == end || *cur++ != '/') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected '/'");
-  if (cur == end || *cur++ != '1')
+  }
+  if (cur == end || *cur++ != '1') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected '1'");
-  if (cur == end || *cur++ != '.')
+  }
+  if (cur == end || *cur++ != '.') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected '.'");
+  }
   if (cur == end || *cur < '0' || *cur++ > '1') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "Expected HTTP/1.0 or HTTP/1.1");
   }
-  if (cur == end || *cur++ != ' ')
+  if (cur == end || *cur++ != ' ') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected ' '");
-  if (cur == end || *cur < '1' || *cur++ > '9')
+  }
+  if (cur == end || *cur < '1' || *cur++ > '9') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected status code");
-  if (cur == end || *cur < '0' || *cur++ > '9')
+  }
+  if (cur == end || *cur < '0' || *cur++ > '9') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected status code");
-  if (cur == end || *cur < '0' || *cur++ > '9')
+  }
+  if (cur == end || *cur < '0' || *cur++ > '9') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected status code");
+  }
   parser->http.response->status =
       (cur[-3] - '0') * 100 + (cur[-2] - '0') * 10 + (cur[-1] - '0');
-  if (cur == end || *cur++ != ' ')
+  if (cur == end || *cur++ != ' ') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected ' '");
+  }
 
   /* we don't really care about the status code message */
 
@@ -85,36 +97,44 @@ static grpc_error* handle_request_line(grpc_http_parser* parser) {
   uint8_t vers_major = 0;
   uint8_t vers_minor = 0;
 
-  while (cur != end && *cur++ != ' ')
-    ;
-  if (cur == end)
+  while (cur != end && *cur++ != ' ') {
+  }
+  if (cur == end) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "No method on HTTP request line");
+  }
   parser->http.request->method =
       buf2str(beg, static_cast<size_t>(cur - beg - 1));
 
   beg = cur;
-  while (cur != end && *cur++ != ' ')
-    ;
-  if (cur == end)
+  while (cur != end && *cur++ != ' ') {
+  }
+  if (cur == end) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("No path on HTTP request line");
+  }
   parser->http.request->path = buf2str(beg, static_cast<size_t>(cur - beg - 1));
 
-  if (cur == end || *cur++ != 'H')
+  if (cur == end || *cur++ != 'H') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'H'");
-  if (cur == end || *cur++ != 'T')
+  }
+  if (cur == end || *cur++ != 'T') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'T'");
-  if (cur == end || *cur++ != 'T')
+  }
+  if (cur == end || *cur++ != 'T') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'T'");
-  if (cur == end || *cur++ != 'P')
+  }
+  if (cur == end || *cur++ != 'P') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected 'P'");
-  if (cur == end || *cur++ != '/')
+  }
+  if (cur == end || *cur++ != '/') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING("Expected '/'");
+  }
   vers_major = static_cast<uint8_t>(*cur++ - '1' + 1);
   ++cur;
-  if (cur == end)
+  if (cur == end) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "End of line in HTTP version string");
+  }
   vers_minor = static_cast<uint8_t>(*cur++ - '1' + 1);
 
   if (vers_major == 1) {
@@ -300,9 +320,10 @@ static grpc_error* addbyte(grpc_http_parser* parser, uint8_t byte,
     case GRPC_HTTP_FIRST_LINE:
     case GRPC_HTTP_HEADERS:
       if (parser->cur_line_length >= GRPC_HTTP_PARSER_MAX_HEADER_LENGTH) {
-        if (grpc_http1_trace.enabled())
+        if (grpc_http1_trace.enabled()) {
           gpr_log(GPR_ERROR, "HTTP header max line length (%d) exceeded",
                   GRPC_HTTP_PARSER_MAX_HEADER_LENGTH);
+        }
         return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
             "HTTP header max line length exceeded");
       }

--- a/src/core/lib/iomgr/error_internal.h
+++ b/src/core/lib/iomgr/error_internal.h
@@ -22,7 +22,6 @@
 #include <grpc/support/port_platform.h>
 
 #include <inttypes.h>
-#include <stdbool.h>  // TODO, do we need this?
 
 #include <grpc/support/sync.h>
 #include "src/core/lib/iomgr/error.h"

--- a/src/core/lib/iomgr/ev_epoll1_linux.cc
+++ b/src/core/lib/iomgr/ev_epoll1_linux.cc
@@ -565,8 +565,8 @@ static grpc_error* pollset_kick_all(grpc_pollset* pollset) {
       worker = worker->next;
     } while (worker != pollset->root_worker);
   }
-  // TODO: sreek.  Check if we need to set 'kicked_without_poller' to true here
-  // in the else case
+  // TODO(sreek): Check if we need to set 'kicked_without_poller' to
+  // true here in the else case
   return error;
 }
 

--- a/src/core/lib/iomgr/ev_epollex_linux.cc
+++ b/src/core/lib/iomgr/ev_epollex_linux.cc
@@ -822,12 +822,13 @@ static void pollset_init(grpc_pollset* pollset, gpr_mu** mu) {
 static int poll_deadline_to_millis_timeout(grpc_millis millis) {
   if (millis == GRPC_MILLIS_INF_FUTURE) return -1;
   grpc_millis delta = millis - grpc_core::ExecCtx::Get()->Now();
-  if (delta > INT_MAX)
+  if (delta > INT_MAX) {
     return INT_MAX;
-  else if (delta < 0)
+  } else if (delta < 0) {
     return 0;
-  else
+  } else {
     return static_cast<int>(delta);
+  }
 }
 
 static void fd_become_readable(grpc_fd* fd, grpc_pollset* notifier) {

--- a/src/core/lib/iomgr/ev_epollsig_linux.cc
+++ b/src/core/lib/iomgr/ev_epollsig_linux.cc
@@ -1107,12 +1107,13 @@ static void pollset_init(grpc_pollset* pollset, gpr_mu** mu) {
 static int poll_deadline_to_millis_timeout(grpc_millis millis) {
   if (millis == GRPC_MILLIS_INF_FUTURE) return -1;
   grpc_millis delta = millis - grpc_core::ExecCtx::Get()->Now();
-  if (delta > INT_MAX)
+  if (delta > INT_MAX) {
     return INT_MAX;
-  else if (delta < 0)
+  } else if (delta < 0) {
     return 0;
-  else
+  } else {
     return static_cast<int>(delta);
+  }
 }
 
 static void fd_become_readable(grpc_fd* fd, grpc_pollset* notifier) {

--- a/src/core/lib/iomgr/timer_generic.cc
+++ b/src/core/lib/iomgr/timer_generic.cc
@@ -429,10 +429,11 @@ static void timer_init(grpc_timer* timer, grpc_millis deadline,
       note_deadline_change(shard);
       if (shard->shard_queue_index == 0 && deadline < old_min_deadline) {
 #if GPR_ARCH_64
-        // TODO: sreek - Using c-style cast here. static_cast<> gives an error
-        // (on mac platforms complaining that gpr_atm* is (long *) while
-        // (&g_shared_mutables.min_timer) is a (long long *). The cast should be
-        // safe since we know that both are pointer types and 64-bit wide.
+        // TODO(sreek): Using c-style cast here. static_cast<> gives
+        // an error (on mac platforms complaining that gpr_atm* is (long *)
+        // while (&g_shared_mutables.min_timer) is a (long long *). The cast
+        // should be safe since we know that both are pointer types and
+        // 64-bit wide.
         gpr_atm_no_barrier_store((gpr_atm*)(&g_shared_mutables.min_timer),
                                  deadline);
 #else
@@ -582,8 +583,8 @@ static grpc_timer_check_result run_some_expired_timers(grpc_millis now,
   grpc_timer_check_result result = GRPC_TIMERS_NOT_CHECKED;
 
 #if GPR_ARCH_64
-  // TODO: sreek - Using c-style cast here. static_cast<> gives an error (on
-  // mac platforms complaining that gpr_atm* is (long *) while
+  // TODO(sreek): Using c-style cast here. static_cast<> gives an
+  // error (on mac platforms complaining that gpr_atm* is (long *) while
   // (&g_shared_mutables.min_timer) is a (long long *). The cast should be
   // safe since we know that both are pointer types and 64-bit wide
   grpc_millis min_timer = static_cast<grpc_millis>(
@@ -647,8 +648,8 @@ static grpc_timer_check_result run_some_expired_timers(grpc_millis now,
     }
 
 #if GPR_ARCH_64
-    // TODO: sreek - Using c-style cast here. static_cast<> gives an error (on
-    // mac platforms complaining that gpr_atm* is (long *) while
+    // TODO(sreek): Using c-style cast here. static_cast<> gives an
+    // error (on mac platforms complaining that gpr_atm* is (long *) while
     // (&g_shared_mutables.min_timer) is a (long long *). The cast should be
     // safe since we know that both are pointer types and 64-bit wide
     gpr_atm_no_barrier_store((gpr_atm*)(&g_shared_mutables.min_timer),

--- a/src/core/lib/iomgr/wakeup_fd_pipe.cc
+++ b/src/core/lib/iomgr/wakeup_fd_pipe.cc
@@ -71,8 +71,8 @@ static grpc_error* pipe_consume(grpc_wakeup_fd* fd_info) {
 
 static grpc_error* pipe_wakeup(grpc_wakeup_fd* fd_info) {
   char c = 0;
-  while (write(fd_info->write_fd, &c, 1) != 1 && errno == EINTR)
-    ;
+  while (write(fd_info->write_fd, &c, 1) != 1 && errno == EINTR) {
+  }
   return GRPC_ERROR_NONE;
 }
 

--- a/src/core/lib/json/json_reader.cc
+++ b/src/core/lib/json/json_reader.cc
@@ -129,8 +129,9 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader* reader) {
           case GRPC_JSON_STATE_OBJECT_KEY_STRING:
           case GRPC_JSON_STATE_VALUE_STRING:
             if (c != ' ') return GRPC_JSON_PARSE_ERROR;
-            if (reader->unicode_high_surrogate != 0)
+            if (reader->unicode_high_surrogate != 0) {
               return GRPC_JSON_PARSE_ERROR;
+            }
             json_reader_string_add_char(reader, c);
             break;
 
@@ -252,8 +253,9 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader* reader) {
 
           /* This is the \\ case. */
           case GRPC_JSON_STATE_STRING_ESCAPE:
-            if (reader->unicode_high_surrogate != 0)
+            if (reader->unicode_high_surrogate != 0) {
               return GRPC_JSON_PARSE_ERROR;
+            }
             json_reader_string_add_char(reader, '\\');
             if (reader->escaped_string_was_key) {
               reader->state = GRPC_JSON_STATE_OBJECT_KEY_STRING;
@@ -438,14 +440,16 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader* reader) {
                  */
                 if ((reader->unicode_char & 0xfc00) == 0xd800) {
                   /* high surrogate utf-16 */
-                  if (reader->unicode_high_surrogate != 0)
+                  if (reader->unicode_high_surrogate != 0) {
                     return GRPC_JSON_PARSE_ERROR;
+                  }
                   reader->unicode_high_surrogate = reader->unicode_char;
                 } else if ((reader->unicode_char & 0xfc00) == 0xdc00) {
                   /* low surrogate utf-16 */
                   uint32_t utf32;
-                  if (reader->unicode_high_surrogate == 0)
+                  if (reader->unicode_high_surrogate == 0) {
                     return GRPC_JSON_PARSE_ERROR;
+                  }
                   utf32 = 0x10000;
                   utf32 += static_cast<uint32_t>(
                       (reader->unicode_high_surrogate - 0xd800) * 0x400);
@@ -454,8 +458,9 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader* reader) {
                   reader->unicode_high_surrogate = 0;
                 } else {
                   /* anything else */
-                  if (reader->unicode_high_surrogate != 0)
+                  if (reader->unicode_high_surrogate != 0) {
                     return GRPC_JSON_PARSE_ERROR;
+                  }
                   json_reader_string_add_utf32(reader, reader->unicode_char);
                 }
                 if (reader->escaped_string_was_key) {

--- a/src/core/lib/json/json_string.cc
+++ b/src/core/lib/json/json_string.cc
@@ -320,9 +320,10 @@ static void json_dump_recursive(grpc_json_writer* writer, grpc_json* json,
       case GRPC_JSON_OBJECT:
       case GRPC_JSON_ARRAY:
         grpc_json_writer_container_begins(writer, json->type);
-        if (json->child)
+        if (json->child) {
           json_dump_recursive(writer, json->child,
                               json->type == GRPC_JSON_OBJECT);
+        }
         grpc_json_writer_container_ends(writer, json->type);
         break;
       case GRPC_JSON_STRING:

--- a/src/core/lib/json/json_writer.cc
+++ b/src/core/lib/json/json_writer.cc
@@ -159,8 +159,9 @@ static void json_writer_escape_string(grpc_json_writer* writer,
        * Any other range is technically reserved for future usage, so if we
        * don't want the software to break in the future, we have to allow
        * anything else. The first non-unicode character is 0x110000. */
-      if (((utf32 >= 0xd800) && (utf32 <= 0xdfff)) || (utf32 >= 0x110000))
+      if (((utf32 >= 0xd800) && (utf32 <= 0xdfff)) || (utf32 >= 0x110000)) {
         break;
+      }
       if (utf32 >= 0x10000) {
         /* If utf32 contains a character that is above 0xffff, it needs to be
          * broken down into a utf-16 surrogate pair. A surrogate pair is first
@@ -204,8 +205,9 @@ void grpc_json_writer_container_begins(grpc_json_writer* writer,
 
 void grpc_json_writer_container_ends(grpc_json_writer* writer,
                                      grpc_json_type type) {
-  if (writer->indent && !writer->container_empty)
+  if (writer->indent && !writer->container_empty) {
     json_writer_output_char(writer, '\n');
+  }
   writer->depth--;
   if (!writer->container_empty) json_writer_output_indent(writer);
   json_writer_output_char(writer, type == GRPC_JSON_OBJECT ? '}' : ']');

--- a/src/core/lib/security/credentials/jwt/jwt_verifier.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.cc
@@ -258,16 +258,19 @@ grpc_jwt_claims* grpc_jwt_claims_from_json(grpc_json* json, grpc_slice buffer) {
       if (claims->jti == nullptr) goto error;
     } else if (strcmp(cur->key, "iat") == 0) {
       claims->iat = validate_time_field(cur, "iat");
-      if (gpr_time_cmp(claims->iat, gpr_time_0(GPR_CLOCK_REALTIME)) == 0)
+      if (gpr_time_cmp(claims->iat, gpr_time_0(GPR_CLOCK_REALTIME)) == 0) {
         goto error;
+      }
     } else if (strcmp(cur->key, "exp") == 0) {
       claims->exp = validate_time_field(cur, "exp");
-      if (gpr_time_cmp(claims->exp, gpr_time_0(GPR_CLOCK_REALTIME)) == 0)
+      if (gpr_time_cmp(claims->exp, gpr_time_0(GPR_CLOCK_REALTIME)) == 0) {
         goto error;
+      }
     } else if (strcmp(cur->key, "nbf") == 0) {
       claims->nbf = validate_time_field(cur, "nbf");
-      if (gpr_time_cmp(claims->nbf, gpr_time_0(GPR_CLOCK_REALTIME)) == 0)
+      if (gpr_time_cmp(claims->nbf, gpr_time_0(GPR_CLOCK_REALTIME)) == 0) {
         goto error;
+      }
     }
   }
   return claims;

--- a/src/core/lib/security/transport/server_auth_filter.cc
+++ b/src/core/lib/security/transport/server_auth_filter.cc
@@ -85,8 +85,9 @@ static grpc_filtered_mdelem remove_consumed_md(void* user_data,
   for (i = 0; i < calld->num_consumed_md; i++) {
     const grpc_metadata* consumed_md = &calld->consumed_md[i];
     if (grpc_slice_eq(GRPC_MDKEY(md), consumed_md->key) &&
-        grpc_slice_eq(GRPC_MDVALUE(md), consumed_md->value))
+        grpc_slice_eq(GRPC_MDVALUE(md), consumed_md->value)) {
       return GRPC_FILTERED_REMOVE();
+    }
   }
   return GRPC_FILTERED_MDELEM(md);
 }

--- a/src/core/lib/slice/slice.cc
+++ b/src/core/lib/slice/slice.cc
@@ -452,8 +452,9 @@ int grpc_slice_buf_start_eq(grpc_slice a, const void* b, size_t len) {
 int grpc_slice_rchr(grpc_slice s, char c) {
   const char* b = reinterpret_cast<const char*> GRPC_SLICE_START_PTR(s);
   int i;
-  for (i = static_cast<int> GRPC_SLICE_LENGTH(s) - 1; i != -1 && b[i] != c; i--)
-    ;
+  for (i = static_cast<int> GRPC_SLICE_LENGTH(s) - 1; i != -1 && b[i] != c;
+       i--) {
+  }
   return i;
 }
 
@@ -471,10 +472,12 @@ int grpc_slice_slice(grpc_slice haystack, grpc_slice needle) {
 
   if (haystack_len == 0 || needle_len == 0) return -1;
   if (haystack_len < needle_len) return -1;
-  if (haystack_len == needle_len)
+  if (haystack_len == needle_len) {
     return grpc_slice_eq(haystack, needle) ? 0 : -1;
-  if (needle_len == 1)
+  }
+  if (needle_len == 1) {
     return grpc_slice_chr(haystack, static_cast<char>(*needle_bytes));
+  }
 
   const uint8_t* last = haystack_bytes + haystack_len - needle_len;
   for (const uint8_t* cur = haystack_bytes; cur != last; ++cur) {

--- a/src/core/lib/slice/slice_buffer.cc
+++ b/src/core/lib/slice/slice_buffer.cc
@@ -92,8 +92,9 @@ uint8_t* grpc_slice_buffer_tiny_add(grpc_slice_buffer* sb, size_t n) {
   if (sb->count == 0) goto add_new;
   back = &sb->slices[sb->count - 1];
   if (back->refcount) goto add_new;
-  if ((back->data.inlined.length + n) > sizeof(back->data.inlined.bytes))
+  if ((back->data.inlined.length + n) > sizeof(back->data.inlined.bytes)) {
     goto add_new;
+  }
   out = back->data.inlined.bytes + back->data.inlined.length;
   back->data.inlined.length =
       static_cast<uint8_t>(back->data.inlined.length + n);

--- a/src/core/lib/slice/slice_intern.cc
+++ b/src/core/lib/slice/slice_intern.cc
@@ -84,8 +84,8 @@ static void interned_slice_destroy(interned_slice_refcount* s) {
   interned_slice_refcount* cur;
   for (prev_next = &shard->strs[TABLE_IDX(s->hash, shard->capacity)],
       cur = *prev_next;
-       cur != s; prev_next = &cur->bucket_next, cur = cur->bucket_next)
-    ;
+       cur != s; prev_next = &cur->bucket_next, cur = cur->bucket_next) {
+  }
   *prev_next = cur->bucket_next;
   shard->count--;
   gpr_free(s);

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -309,8 +309,9 @@ static void add_batch_error(batch_control* bctl, grpc_error* error,
 
 static void add_init_error(grpc_error** composite, grpc_error* new_err) {
   if (new_err == GRPC_ERROR_NONE) return;
-  if (*composite == GRPC_ERROR_NONE)
+  if (*composite == GRPC_ERROR_NONE) {
     *composite = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Call creation failed");
+  }
   *composite = grpc_error_add_child(*composite, new_err);
 }
 

--- a/src/core/lib/surface/completion_queue.cc
+++ b/src/core/lib/surface/completion_queue.cc
@@ -117,8 +117,8 @@ static grpc_error* non_polling_poller_work(grpc_pollset* pollset,
   gpr_timespec deadline_ts =
       grpc_millis_to_timespec(deadline, GPR_CLOCK_MONOTONIC);
   while (!npp->shutdown && !w.kicked &&
-         !gpr_cv_wait(&w.cv, &npp->mu, deadline_ts))
-    ;
+         !gpr_cv_wait(&w.cv, &npp->mu, deadline_ts)) {
+  }
   grpc_core::ExecCtx::Get()->InvalidateNow();
   if (&w == npp->root) {
     npp->root = w.next;
@@ -139,8 +139,9 @@ static grpc_error* non_polling_poller_work(grpc_pollset* pollset,
 static grpc_error* non_polling_poller_kick(
     grpc_pollset* pollset, grpc_pollset_worker* specific_worker) {
   non_polling_poller* p = reinterpret_cast<non_polling_poller*>(pollset);
-  if (specific_worker == nullptr)
+  if (specific_worker == nullptr) {
     specific_worker = reinterpret_cast<grpc_pollset_worker*>(p->root);
+  }
   if (specific_worker != nullptr) {
     non_polling_worker* w =
         reinterpret_cast<non_polling_worker*>(specific_worker);

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -1111,8 +1111,8 @@ void grpc_server_setup_transport(grpc_server* s, grpc_transport* transport,
                                 grpc_slice_hash(method));
       for (probes = 0; chand->registered_methods[(hash + probes) % slots]
                            .server_registered_method != nullptr;
-           probes++)
-        ;
+           probes++) {
+      }
       if (probes > max_probes) max_probes = probes;
       crm = &chand->registered_methods[(hash + probes) % slots];
       crm->server_registered_method = rm;

--- a/src/core/lib/transport/timeout_encoding.cc
+++ b/src/core/lib/transport/timeout_encoding.cc
@@ -95,8 +95,8 @@ int grpc_http2_decode_timeout(grpc_slice text, grpc_millis* timeout) {
   const uint8_t* end = GRPC_SLICE_END_PTR(text);
   int have_digit = 0;
   /* skip whitespace */
-  for (; p != end && *p == ' '; p++)
-    ;
+  for (; p != end && *p == ' '; p++) {
+  }
   /* decode numeric part */
   for (; p != end && *p >= '0' && *p <= '9'; p++) {
     int32_t digit = static_cast<int32_t>(*p - static_cast<uint8_t>('0'));
@@ -112,8 +112,8 @@ int grpc_http2_decode_timeout(grpc_slice text, grpc_millis* timeout) {
   }
   if (!have_digit) return 0;
   /* skip whitespace */
-  for (; p != end && *p == ' '; p++)
-    ;
+  for (; p != end && *p == ' '; p++) {
+  }
   if (p == end) return 0;
   /* decode unit specifier */
   switch (*p) {

--- a/src/core/tsi/alts/handshaker/alts_handshaker_service_api_util.cc
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_service_api_util.cc
@@ -86,8 +86,9 @@ bool encode_repeated_identity_cb(pb_ostream_t* stream, const pb_field_t* field,
   while (var != nullptr) {
     if (!pb_encode_tag_for_field(stream, field)) return false;
     if (!pb_encode_submessage(stream, grpc_gcp_Identity_fields,
-                              (grpc_gcp_identity*)var->data))
+                              (grpc_gcp_identity*)var->data)) {
       return false;
+    }
     var = var->next;
   }
   return true;
@@ -100,8 +101,9 @@ bool encode_repeated_string_cb(pb_ostream_t* stream, const pb_field_t* field,
     if (!pb_encode_tag_for_field(stream, field)) return false;
     const grpc_slice* slice = static_cast<const grpc_slice*>(var->data);
     if (!pb_encode_string(stream, GRPC_SLICE_START_PTR(*slice),
-                          GRPC_SLICE_LENGTH(*slice)))
+                          GRPC_SLICE_LENGTH(*slice))) {
       return false;
+    }
     var = var->next;
   }
   return true;
@@ -113,8 +115,9 @@ bool decode_string_or_bytes_cb(pb_istream_t* stream, const pb_field_t* field,
   grpc_slice* cb_slice =
       static_cast<grpc_slice*>(gpr_zalloc(sizeof(*cb_slice)));
   memcpy(cb_slice, &slice, sizeof(*cb_slice));
-  if (!pb_read(stream, GRPC_SLICE_START_PTR(*cb_slice), stream->bytes_left))
+  if (!pb_read(stream, GRPC_SLICE_START_PTR(*cb_slice), stream->bytes_left)) {
     return false;
+  }
   *arg = cb_slice;
   return true;
 }
@@ -136,8 +139,9 @@ bool decode_repeated_string_cb(pb_istream_t* stream, const pb_field_t* field,
   grpc_slice* cb_slice =
       static_cast<grpc_slice*>(gpr_zalloc(sizeof(*cb_slice)));
   memcpy(cb_slice, &slice, sizeof(grpc_slice));
-  if (!pb_read(stream, GRPC_SLICE_START_PTR(*cb_slice), stream->bytes_left))
+  if (!pb_read(stream, GRPC_SLICE_START_PTR(*cb_slice), stream->bytes_left)) {
     return false;
+  }
   add_repeated_field(reinterpret_cast<repeated_field**>(arg), cb_slice);
   return true;
 }

--- a/src/core/tsi/transport_security.cc
+++ b/src/core/tsi/transport_security.cc
@@ -137,8 +137,9 @@ tsi_result tsi_handshaker_get_bytes_to_send_to_peer(tsi_handshaker* self,
   }
   if (self->frame_protector_created) return TSI_FAILED_PRECONDITION;
   if (self->handshake_shutdown) return TSI_HANDSHAKE_SHUTDOWN;
-  if (self->vtable->get_bytes_to_send_to_peer == nullptr)
+  if (self->vtable->get_bytes_to_send_to_peer == nullptr) {
     return TSI_UNIMPLEMENTED;
+  }
   return self->vtable->get_bytes_to_send_to_peer(self, bytes, bytes_size);
 }
 
@@ -151,8 +152,9 @@ tsi_result tsi_handshaker_process_bytes_from_peer(tsi_handshaker* self,
   }
   if (self->frame_protector_created) return TSI_FAILED_PRECONDITION;
   if (self->handshake_shutdown) return TSI_HANDSHAKE_SHUTDOWN;
-  if (self->vtable->process_bytes_from_peer == nullptr)
+  if (self->vtable->process_bytes_from_peer == nullptr) {
     return TSI_UNIMPLEMENTED;
+  }
   return self->vtable->process_bytes_from_peer(self, bytes, bytes_size);
 }
 

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -474,7 +474,7 @@ bool Server::RegisterService(const grpc::string* host, Service* service) {
   const char* method_name = nullptr;
   for (auto it = service->methods_.begin(); it != service->methods_.end();
        ++it) {
-    if (it->get() == nullptr) {  // Handled by generic service if any.
+    if (*it == nullptr) {  // Handled by generic service if any.
       continue;
     }
 

--- a/src/cpp/thread_manager/thread_manager.h
+++ b/src/cpp/thread_manager/thread_manager.h
@@ -112,7 +112,7 @@ class ThreadManager {
   void CleanupCompletedThreads();
 
   // Protects shutdown_, num_pollers_ and num_threads_
-  // TODO: sreek - Change num_pollers and num_threads_ to atomics
+  // TODO(sreek): Change num_pollers and num_threads_ to atomics
   std::mutex mu_;
 
   bool shutdown_;

--- a/test/core/channel/channelz_registry_test.cc
+++ b/test/core/channel/channelz_registry_test.cc
@@ -53,9 +53,8 @@ TEST(ChannelzRegistryTest, UuidStartsAboveZeroTest) {
 
 TEST(ChannelzRegistryTest, UuidsAreIncreasing) {
   int object_to_register;
-  std::vector<intptr_t> uuids;
-  uuids.reserve(10);
-  for (int i = 0; i < 10; ++i) {
+  std::vector<intptr_t> uuids(10);
+  for (size_t i = 0; i < uuids.size(); ++i) {
     // reregister the same object. It's ok since we are just testing uuids
     uuids.push_back(ChannelzRegistry::Register(&object_to_register));
   }

--- a/test/core/client_channel/resolvers/fake_resolver_test.cc
+++ b/test/core/client_channel/resolvers/fake_resolver_test.cc
@@ -122,7 +122,7 @@ static void test_fake_resolver() {
           grpc_core::MakeRefCounted<grpc_core::FakeResolverResponseGenerator>();
   grpc_core::OrphanablePtr<grpc_core::Resolver> resolver =
       build_fake_resolver(combiner, response_generator.get());
-  GPR_ASSERT(resolver.get() != nullptr);
+  GPR_ASSERT(resolver != nullptr);
   // Test 1: normal resolution.
   // next_results != NULL, reresolution_results == NULL, last_used_results ==
   // NULL. Expected response is next_results.

--- a/test/core/end2end/connection_refused_test.cc
+++ b/test/core/end2end/connection_refused_test.cc
@@ -123,8 +123,8 @@ static void run_test(bool wait_for_ready, bool use_service_config) {
   grpc_completion_queue_shutdown(cq);
   while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
                                     nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
   grpc_completion_queue_destroy(cq);
   grpc_call_unref(call);
   grpc_channel_destroy(chan);

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -195,9 +195,10 @@ static const char* read_cred_artifact(cred_artifact_ctx* ctx, input_stream* inp,
                                       size_t num_builtins) {
   uint8_t b = grpc_fuzzer_get_next_byte(inp);
   if (b == 0) return nullptr;
-  if (b == 1)
+  if (b == 1) {
     return ctx->release[ctx->num_release++] =
                grpc_fuzzer_get_next_string(inp, nullptr);
+  }
   if (b >= num_builtins + 1) {
     end(inp);
     return nullptr;

--- a/test/core/end2end/invalid_call_argument_test.cc
+++ b/test/core/end2end/invalid_call_argument_test.cc
@@ -137,8 +137,8 @@ static void cleanup_test() {
   grpc_completion_queue_shutdown(g_state.cq);
   while (grpc_completion_queue_next(g_state.cq,
                                     gpr_inf_future(GPR_CLOCK_REALTIME), nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
   grpc_completion_queue_destroy(g_state.cq);
 }
 

--- a/test/core/end2end/no_server_test.cc
+++ b/test/core/end2end/no_server_test.cc
@@ -96,8 +96,8 @@ void run_test(bool wait_for_ready) {
   grpc_completion_queue_shutdown(cq);
   while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
                                     nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
   grpc_completion_queue_destroy(cq);
   grpc_call_unref(call);
   grpc_channel_destroy(chan);

--- a/test/core/handshake/client_ssl.cc
+++ b/test/core/handshake/client_ssl.cc
@@ -197,8 +197,8 @@ static void server_thread(void* arg) {
 
   // Wait until the client drops its connection.
   char buf;
-  while (SSL_read(ssl, &buf, sizeof(buf)) > 0)
-    ;
+  while (SSL_read(ssl, &buf, sizeof(buf)) > 0) {
+  }
 
   SSL_free(ssl);
   close(client);

--- a/test/core/security/print_google_default_creds_token.cc
+++ b/test/core/security/print_google_default_creds_token.cc
@@ -112,8 +112,9 @@ int main(int argc, char** argv) {
     if (!GRPC_LOG_IF_ERROR(
             "pollset_work",
             grpc_pollset_work(grpc_polling_entity_pollset(&sync.pops), &worker,
-                              GRPC_MILLIS_INF_FUTURE)))
+                              GRPC_MILLIS_INF_FUTURE))) {
       sync.is_done = true;
+    }
     gpr_mu_unlock(sync.mu);
     grpc_core::ExecCtx::Get()->Flush();
     gpr_mu_lock(sync.mu);

--- a/test/core/security/security_connector_test.cc
+++ b/test/core/security/security_connector_test.cc
@@ -373,8 +373,8 @@ class TestDefafaultSllRootStore : public DefaultSslRootStore {
 }  // namespace
 }  // namespace grpc_core
 
-// TODO: Convert this test to C++ test when security_connector implementation
-// is converted to C++.
+// TODO(roth, juanlishen): Convert this test to C++ test when security_connector
+// implementation is converted to C++.
 static void test_default_ssl_roots(void) {
   const char* roots_for_env_var = "roots for env var";
 

--- a/test/core/security/verify_jwt.cc
+++ b/test/core/security/verify_jwt.cc
@@ -105,8 +105,9 @@ int main(int argc, char** argv) {
     grpc_pollset_worker* worker = nullptr;
     if (!GRPC_LOG_IF_ERROR(
             "pollset_work",
-            grpc_pollset_work(sync.pollset, &worker, GRPC_MILLIS_INF_FUTURE)))
+            grpc_pollset_work(sync.pollset, &worker, GRPC_MILLIS_INF_FUTURE))) {
       sync.is_done = true;
+    }
     gpr_mu_unlock(sync.mu);
     grpc_core::ExecCtx::Get()->Flush();
     gpr_mu_lock(sync.mu);

--- a/test/core/surface/sequential_connectivity_test.cc
+++ b/test/core/surface/sequential_connectivity_test.cc
@@ -100,12 +100,12 @@ static void run_test(const test_fixture* fixture) {
 
   while (grpc_completion_queue_next(server_cq,
                                     gpr_inf_future(GPR_CLOCK_REALTIME), nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
   while (grpc_completion_queue_next(cq, gpr_inf_future(GPR_CLOCK_REALTIME),
                                     nullptr)
-             .type != GRPC_QUEUE_SHUTDOWN)
-    ;
+             .type != GRPC_QUEUE_SHUTDOWN) {
+  }
 
   for (size_t i = 0; i < NUM_CONNECTIONS; i++) {
     grpc_channel_destroy(channels[i]);

--- a/test/core/tsi/alts/handshaker/alts_handshaker_service_api_test_lib.cc
+++ b/test/core/tsi/alts/handshaker/alts_handshaker_service_api_test_lib.cc
@@ -546,8 +546,9 @@ bool grpc_gcp_handshaker_server_start_req_equals(
                          static_cast<grpc_slice*>(r_req->in_bytes.arg));
   if ((l_req->has_local_endpoint ^ r_req->has_local_endpoint) |
       (l_req->has_remote_endpoint ^ r_req->has_remote_endpoint) |
-      (l_req->has_rpc_versions ^ r_req->has_rpc_versions))
+      (l_req->has_rpc_versions ^ r_req->has_rpc_versions)) {
     return false;
+  }
   if (l_req->has_local_endpoint) {
     result &= handshaker_endpoint_equals(&l_req->local_endpoint,
                                          &r_req->local_endpoint);

--- a/test/cpp/codegen/golden_file_test.cc
+++ b/test/cpp/codegen/golden_file_test.cc
@@ -71,7 +71,8 @@ int main(int argc, char** argv) {
   if (FLAGS_generated_file_path.empty()) {
     FLAGS_generated_file_path = "gens/src/proto/grpc/testing/";
   }
-  if (FLAGS_generated_file_path.back() != '/')
+  if (FLAGS_generated_file_path.back() != '/') {
     FLAGS_generated_file_path.append("/");
+  }
   return RUN_ALL_TESTS();
 }

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -263,8 +263,8 @@ class AsyncEnd2endTest : public ::testing::TestWithParam<TestScenario> {
     void* ignored_tag;
     bool ignored_ok;
     cq_->Shutdown();
-    while (cq_->Next(&ignored_tag, &ignored_ok))
-      ;
+    while (cq_->Next(&ignored_tag, &ignored_ok)) {
+    }
     stub_.reset();
     grpc_recycle_unused_port(port_);
   }
@@ -371,8 +371,8 @@ TEST_P(AsyncEnd2endTest, ReconnectChannel) {
   void* ignored_tag;
   bool ignored_ok;
   cq_->Shutdown();
-  while (cq_->Next(&ignored_tag, &ignored_ok))
-    ;
+  while (cq_->Next(&ignored_tag, &ignored_ok)) {
+  }
   BuildAndStartServer();
   // It needs more than GRPC_CLIENT_CHANNEL_BACKUP_POLL_INTERVAL_MS time to
   // reconnect the channel.

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -684,13 +684,11 @@ TEST_F(ClientLbEnd2endTest, RoundRobinConcurrentUpdates) {
 TEST_F(ClientLbEnd2endTest, RoundRobinReresolve) {
   // Start servers and send one RPC per server.
   const int kNumServers = 3;
-  std::vector<int> first_ports;
-  std::vector<int> second_ports;
-  first_ports.reserve(kNumServers);
+  std::vector<int> first_ports(kNumServers);
+  std::vector<int> second_ports(kNumServers);
   for (int i = 0; i < kNumServers; ++i) {
     first_ports.push_back(grpc_pick_unused_port_or_die());
   }
-  second_ports.reserve(kNumServers);
   for (int i = 0; i < kNumServers; ++i) {
     second_ports.push_back(grpc_pick_unused_port_or_die());
   }
@@ -741,8 +739,9 @@ TEST_F(ClientLbEnd2endTest, RoundRobinSingleReconnect) {
   auto channel = BuildChannel("round_robin");
   auto stub = BuildStub(channel);
   SetNextResolution(ports);
-  for (size_t i = 0; i < kNumServers; ++i)
+  for (size_t i = 0; i < kNumServers; ++i) {
     WaitForServer(stub, i, DEBUG_LOCATION);
+  }
   for (size_t i = 0; i < servers_.size(); ++i) {
     CheckRpcSendOk(stub, DEBUG_LOCATION);
     EXPECT_EQ(1, servers_[i]->service_.request_count()) << "for backend #" << i;

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -682,24 +682,22 @@ TEST_P(End2endTest, SimpleRpcWithCustomUserAgentPrefix) {
 
 TEST_P(End2endTest, MultipleRpcsWithVariedBinaryMetadataValue) {
   ResetStub();
-  std::vector<std::thread> threads;
-  threads.reserve(10);
-  for (int i = 0; i < 10; ++i) {
+  std::vector<std::thread> threads(10);
+  for (size_t i = 0; i < threads.size(); ++i) {
     threads.emplace_back(SendRpc, stub_.get(), 10, true);
   }
-  for (int i = 0; i < 10; ++i) {
+  for (size_t i = 0; i < threads.size(); ++i) {
     threads[i].join();
   }
 }
 
 TEST_P(End2endTest, MultipleRpcs) {
   ResetStub();
-  std::vector<std::thread> threads;
-  threads.reserve(10);
-  for (int i = 0; i < 10; ++i) {
+  std::vector<std::thread> threads(10);
+  for (size_t i = 0; i < threads.size(); ++i) {
     threads.emplace_back(SendRpc, stub_.get(), 10, false);
   }
-  for (int i = 0; i < 10; ++i) {
+  for (size_t i = 0; i < threads.size(); ++i) {
     threads[i].join();
   }
 }
@@ -1273,12 +1271,11 @@ TEST_P(ProxyEnd2endTest, SimpleRpcWithEmptyMessages) {
 
 TEST_P(ProxyEnd2endTest, MultipleRpcs) {
   ResetStub();
-  std::vector<std::thread> threads;
-  threads.reserve(10);
-  for (int i = 0; i < 10; ++i) {
+  std::vector<std::thread> threads(10);
+  for (size_t i = 0; i < threads.size(); ++i) {
     threads.emplace_back(SendRpc, stub_.get(), 10, false);
   }
-  for (int i = 0; i < 10; ++i) {
+  for (size_t i = 0; i < threads.size(); ++i) {
     threads[i].join();
   }
 }

--- a/test/cpp/end2end/filter_end2end_test.cc
+++ b/test/cpp/end2end/filter_end2end_test.cc
@@ -139,10 +139,10 @@ class FilterEnd2endTest : public ::testing::Test {
     bool ignored_ok;
     cli_cq_.Shutdown();
     srv_cq_->Shutdown();
-    while (cli_cq_.Next(&ignored_tag, &ignored_ok))
-      ;
-    while (srv_cq_->Next(&ignored_tag, &ignored_ok))
-      ;
+    while (cli_cq_.Next(&ignored_tag, &ignored_ok)) {
+    }
+    while (srv_cq_->Next(&ignored_tag, &ignored_ok)) {
+    }
   }
 
   void ResetStub() {

--- a/test/cpp/end2end/generic_end2end_test.cc
+++ b/test/cpp/end2end/generic_end2end_test.cc
@@ -82,10 +82,10 @@ class GenericEnd2endTest : public ::testing::Test {
     bool ignored_ok;
     cli_cq_.Shutdown();
     srv_cq_->Shutdown();
-    while (cli_cq_.Next(&ignored_tag, &ignored_ok))
-      ;
-    while (srv_cq_->Next(&ignored_tag, &ignored_ok))
-      ;
+    while (cli_cq_.Next(&ignored_tag, &ignored_ok)) {
+    }
+    while (srv_cq_->Next(&ignored_tag, &ignored_ok)) {
+    }
   }
 
   void ResetStub() {
@@ -218,8 +218,8 @@ TEST_F(GenericEnd2endTest, SequentialUnaryRpcs) {
         SerializeToByteBuffer(&send_request);
     // Use the same cq as server so that events can be polled in time.
     std::unique_ptr<GenericClientAsyncResponseReader> call =
-        generic_stub_->PrepareUnaryCall(&cli_ctx, kMethodName,
-                                        *cli_send_buffer.get(), srv_cq_.get());
+        generic_stub_->PrepareUnaryCall(&cli_ctx, kMethodName, *cli_send_buffer,
+                                        srv_cq_.get());
     call->StartCall();
     ByteBuffer cli_recv_buffer;
     call->Finish(&cli_recv_buffer, &recv_status, tag(1));

--- a/test/cpp/end2end/hybrid_end2end_test.cc
+++ b/test/cpp/end2end/hybrid_end2end_test.cc
@@ -224,8 +224,8 @@ class HybridEnd2endTest : public ::testing::Test {
     bool ignored_ok;
     for (auto it = cqs_.begin(); it != cqs_.end(); ++it) {
       (*it)->Shutdown();
-      while ((*it)->Next(&ignored_tag, &ignored_ok))
-        ;
+      while ((*it)->Next(&ignored_tag, &ignored_ok)) {
+      }
     }
   }
 

--- a/test/cpp/end2end/nonblocking_test.cc
+++ b/test/cpp/end2end/nonblocking_test.cc
@@ -89,8 +89,8 @@ class NonblockingTest : public ::testing::Test {
     void* ignored_tag;
     bool ignored_ok;
     cq_->Shutdown();
-    while (LoopForTag(&ignored_tag, &ignored_ok))
-      ;
+    while (LoopForTag(&ignored_tag, &ignored_ok)) {
+    }
     stub_.reset();
     grpc_recycle_unused_port(port_);
   }

--- a/test/cpp/end2end/server_builder_plugin_test.cc
+++ b/test/cpp/end2end/server_builder_plugin_test.cc
@@ -232,8 +232,8 @@ class ServerBuilderPluginTest : public ::testing::TestWithParam<bool> {
   void RunCQ() {
     void* tag;
     bool ok;
-    while (cq_->Next(&tag, &ok))
-      ;
+    while (cq_->Next(&tag, &ok)) {
+    }
   }
 };
 

--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -225,8 +225,8 @@ class CommonStressTestAsyncServer : public BaseClass {
 
     void* ignored_tag;
     bool ignored_ok;
-    while (cq_->Next(&ignored_tag, &ignored_ok))
-      ;
+    while (cq_->Next(&ignored_tag, &ignored_ok)) {
+    }
     this->TearDownEnd();
   }
 
@@ -321,8 +321,7 @@ typedef ::testing::Types<
 TYPED_TEST_CASE(End2endTest, CommonTypes);
 TYPED_TEST(End2endTest, ThreadStress) {
   this->common_.ResetStub();
-  std::vector<std::thread> threads;
-  threads.reserve(kNumThreads);
+  std::vector<std::thread> threads(kNumThreads);
   for (int i = 0; i < kNumThreads; ++i) {
     threads.emplace_back(SendRpc, this->common_.GetStub(), kNumRpcs);
   }
@@ -340,8 +339,8 @@ class AsyncClientEnd2endTest : public ::testing::Test {
   void TearDown() override {
     void* ignored_tag;
     bool ignored_ok;
-    while (cq_.Next(&ignored_tag, &ignored_ok))
-      ;
+    while (cq_.Next(&ignored_tag, &ignored_ok)) {
+    }
     common_.TearDown();
   }
 

--- a/test/cpp/interop/stress_interop_client.h
+++ b/test/cpp/interop/stress_interop_client.h
@@ -104,7 +104,7 @@ class StressTestInteropClient {
   bool RunTest(TestCaseType test_case);
 
   int test_id_;
-  const grpc::string& server_address_;
+  grpc::string server_address_;
   std::shared_ptr<Channel> channel_;
   std::unique_ptr<InteropClient> interop_client_;
   const WeightedRandomTestSelector& test_selector_;

--- a/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
@@ -207,8 +207,7 @@ class SingleInternedBinaryElem {
 
  private:
   static grpc_slice MakeBytes() {
-    std::vector<char> v;
-    v.reserve(kLength);
+    std::vector<char> v(kLength);
     for (int i = 0; i < kLength; i++) {
       v.push_back(static_cast<char>(rand()));
     }
@@ -246,8 +245,7 @@ class SingleNonInternedBinaryElem {
 
  private:
   static grpc_slice MakeBytes() {
-    std::vector<char> v;
-    v.reserve(kLength);
+    std::vector<char> v(kLength);
     for (int i = 0; i < kLength; i++) {
       v.push_back(static_cast<char>(rand()));
     }

--- a/test/cpp/microbenchmarks/bm_cq.cc
+++ b/test/cpp/microbenchmarks/bm_cq.cc
@@ -58,8 +58,8 @@ BENCHMARK(BM_CreateDestroyCpp2);
 static void BM_CreateDestroyCore(benchmark::State& state) {
   TrackCounters track_counters;
   while (state.KeepRunning()) {
-    // TODO: sreek Templatize this benchmark and pass completion type and
-    // polling type as parameters
+    // TODO(sreek): Templatize this benchmark and pass completion type
+    // and polling type as parameters
     grpc_completion_queue_destroy(
         grpc_completion_queue_create_for_next(nullptr));
   }
@@ -97,7 +97,8 @@ BENCHMARK(BM_Pass1Cpp);
 
 static void BM_Pass1Core(benchmark::State& state) {
   TrackCounters track_counters;
-  // TODO: sreek Templatize this benchmark and pass polling_type as a param
+  // TODO(sreek): Templatize this benchmark and pass polling_type as a
+  // param
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
   gpr_timespec deadline = gpr_inf_future(GPR_CLOCK_MONOTONIC);
   while (state.KeepRunning()) {
@@ -116,7 +117,8 @@ BENCHMARK(BM_Pass1Core);
 
 static void BM_Pluck1Core(benchmark::State& state) {
   TrackCounters track_counters;
-  // TODO: sreek Templatize this benchmark and pass polling_type as a param
+  // TODO(sreek): Templatize this benchmark and pass polling_type as a
+  // param
   grpc_completion_queue* cq = grpc_completion_queue_create_for_pluck(nullptr);
   gpr_timespec deadline = gpr_inf_future(GPR_CLOCK_MONOTONIC);
   while (state.KeepRunning()) {
@@ -135,7 +137,8 @@ BENCHMARK(BM_Pluck1Core);
 
 static void BM_EmptyCore(benchmark::State& state) {
   TrackCounters track_counters;
-  // TODO: sreek Templatize this benchmark and pass polling_type as a param
+  // TODO(sreek): Templatize this benchmark and pass polling_type as a
+  // param
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
   gpr_timespec deadline = gpr_inf_past(GPR_CLOCK_MONOTONIC);
   while (state.KeepRunning()) {

--- a/test/cpp/microbenchmarks/fullstack_context_mutators.h
+++ b/test/cpp/microbenchmarks/fullstack_context_mutators.h
@@ -41,8 +41,7 @@ static const int kPregenerateKeyCount = 100000;
 
 template <class F>
 auto MakeVector(size_t length, F f) -> std::vector<decltype(f())> {
-  std::vector<decltype(f())> out;
-  out.reserve(length);
+  std::vector<decltype(f())> out(length);
   for (size_t i = 0; i < length; i++) {
     out.push_back(f());
   }

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -45,7 +45,7 @@
 #include "test/core/util/port.h"
 #include "test/core/util/test_config.h"
 
-// TODO: pull in different headers when enabling this
+// TODO(apolcyn): pull in different headers when enabling this
 // test on windows. Also set BAD_SOCKET_RETURN_VAL
 // to INVALID_SOCKET on windows.
 #include "src/core/lib/iomgr/sockaddr_posix.h"

--- a/test/cpp/qps/.clang-tidy
+++ b/test/cpp/qps/.clang-tidy
@@ -1,0 +1,6 @@
+---
+Checks: modernize-use-nullptr,google-build-namespaces,google-build-explicit-make-pair,readability-function-size,performance-*,google-*,-google-readability-casting,-google-runtime-references,-google-runtime-int,-google-build-using-namespace,-google-explicit-constructor,-google-readability-namespace-comments
+WarningsAsErrors: modernize-use-nullptr,google-build-namespaces,google-build-explicit-make-pair,readability-function-size,performance-*,google-*,-google-readability-casting,-google-runtime-references,-google-runtime-int,-google-build-using-namespace,-google-explicit-constructor,-google-readability-namespace-comments
+CheckOptions:
+  - key:    readability-function-size.StatementThreshold
+    value:  '450'

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -51,6 +51,7 @@ using std::vector;
 
 namespace grpc {
 namespace testing {
+
 static std::string get_host(const std::string& worker) {
   char* host;
   char* port;

--- a/test/cpp/qps/histogram.h
+++ b/test/cpp/qps/histogram.h
@@ -27,7 +27,7 @@ namespace testing {
 
 class Histogram {
  public:
-  // TODO: look into making histogram params not hardcoded for C++
+  // TODO(vpai): look into making histogram params not hardcoded for C++
   Histogram()
       : impl_(grpc_histogram_create(default_resolution(),
                                     default_max_possible())) {}

--- a/test/cpp/qps/interarrival.h
+++ b/test/cpp/qps/interarrival.h
@@ -92,8 +92,9 @@ class InterarrivalTimer {
 
   int64_t next(int thread_num) {
     auto ret = *(thread_posns_[thread_num]++);
-    if (thread_posns_[thread_num] == random_table_.end())
+    if (thread_posns_[thread_num] == random_table_.end()) {
       thread_posns_[thread_num] = random_table_.begin();
+    }
     return ret;
   }
 

--- a/test/cpp/qps/server_async.cc
+++ b/test/cpp/qps/server_async.cc
@@ -172,8 +172,8 @@ class AsyncQpsServerTest final : public grpc::testing::Server {
     for (auto cq = srv_cqs_.begin(); cq != srv_cqs_.end(); ++cq) {
       bool ok;
       void* got_tag;
-      while ((*cq)->Next(&got_tag, &ok))
-        ;
+      while ((*cq)->Next(&got_tag, &ok)) {
+      }
     }
     shutdown_thread.join();
   }

--- a/test/cpp/util/create_test_channel.cc
+++ b/test/cpp/util/create_test_channel.cc
@@ -92,7 +92,7 @@ std::shared_ptr<Channel> CreateTestChannel(
 
     const grpc::string& connect_to =
         server.empty() ? override_hostname : server;
-    if (creds.get()) {
+    if (creds) {
       channel_creds = CompositeChannelCredentials(channel_creds, creds);
     }
     return CreateCustomChannel(connect_to, channel_creds, channel_args);
@@ -148,7 +148,7 @@ std::shared_ptr<Channel> CreateTestChannel(
       testing::GetCredentialsProvider()->GetChannelCredentials(credential_type,
                                                                &channel_args);
   GPR_ASSERT(channel_creds != nullptr);
-  if (creds.get()) {
+  if (creds) {
     channel_creds = CompositeChannelCredentials(channel_creds, creds);
   }
   return CreateCustomChannel(server, channel_creds, channel_args);

--- a/test/cpp/util/proto_file_parser.cc
+++ b/test/cpp/util/proto_file_parser.cc
@@ -282,7 +282,7 @@ grpc::string ProtoFileParser::GetTextFormatFromMessageType(
     return "";
   }
   grpc::string text_format;
-  if (!protobuf::TextFormat::PrintToString(*msg.get(), &text_format)) {
+  if (!protobuf::TextFormat::PrintToString(*msg, &text_format)) {
     LogError("Failed to print proto message to text format");
     return "";
   }


### PR DESCRIPTION
~Build off #15680 and #15681.~

Working towards #14085.

This enables all google style clang tidy rules except:
- readability-casting
- runtime-references
- runtime-int
- build-using-namespace
- explicit-constructor

These should be enabled and fixed one by one. All of them will need some degree of manual changes.