### PR TITLE
Add C# tests that demonstrate how to unit test grpc code with test doubles.

### DIFF
--- a/src/csharp/Grpc.Core.Testing/TestCalls.cs
+++ b/src/csharp/Grpc.Core.Testing/TestCalls.cs
@@ -65,7 +65,7 @@ namespace Grpc.Core.Testing
         /// Creates a test double for <c>AsyncDuplexStreamingCall</c>. Only for testing.
         /// Note: experimental API that can change or be removed without any prior notice.
         /// </summary>
-        public static AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TResponse, TRequest>(
+        public static AsyncDuplexStreamingCall<TRequest, TResponse> AsyncDuplexStreamingCall<TRequest, TResponse>(
             IClientStreamWriter<TRequest> requestStream, IAsyncStreamReader<TResponse> responseStream,
             Task<Metadata> responseHeadersAsync, Func<Status> getStatusFunc,
             Func<Metadata> getTrailersFunc, Action disposeAction)

--- a/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.csproj
+++ b/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.csproj
@@ -13,11 +13,13 @@
 
   <ItemGroup>
     <ProjectReference Include="../Grpc.Examples/Grpc.Examples.csproj" />
+    <ProjectReference Include="../Grpc.Core.Testing/Grpc.Core.Testing.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.6.0" />
     <PackageReference Include="NUnitLite" Version="3.6.0" />
+    <PackageReference Include="Moq" Version="4.8.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/csharp/Grpc.Examples.Tests/MathClientMockableTest.cs
+++ b/src/csharp/Grpc.Examples.Tests/MathClientMockableTest.cs
@@ -1,0 +1,101 @@
+#region Copyright notice and license
+
+// Copyright 2018 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Testing;
+using NUnit.Framework;
+
+namespace Math.Tests
+{
+    /// <summary>
+    /// Demonstrates how to mock method stubs for all method types in a generated client.
+    /// </summary>
+    public class MathClientMockableTest
+    {
+        [Test]
+        public void ClientBaseBlockingUnaryCallCanBeMocked()
+        {
+            var mockClient = new Moq.Mock<Math.MathClient>();
+            
+            var expected = new DivReply();
+            mockClient.Setup(m => m.Div(Moq.It.IsAny<DivArgs>(), null, null, CancellationToken.None)).Returns(expected);
+            Assert.AreSame(expected, mockClient.Object.Div(new DivArgs()));
+        }
+
+        [Test]
+        public void ClientBaseBlockingUnaryCallWithCallOptionsCallCanBeMocked()
+        {
+            var mockClient = new Moq.Mock<Math.MathClient>();
+
+            var expected = new DivReply();
+            mockClient.Setup(m => m.Div(Moq.It.IsAny<DivArgs>(), Moq.It.IsAny<CallOptions>())).Returns(expected);
+            Assert.AreSame(expected, mockClient.Object.Div(new DivArgs(), new CallOptions()));
+        }
+
+        [Test]
+        public void ClientBaseAsyncUnaryCallCanBeMocked()
+        {
+            var mockClient = new Moq.Mock<Math.MathClient>();
+
+            // Use a factory method provided by Grpc.Core.Testing.TestCalls to create an instance of a call.
+            var fakeCall = TestCalls.AsyncUnaryCall<DivReply>(Task.FromResult(new DivReply()), Task.FromResult(new Metadata()), () => Status.DefaultSuccess, () => new Metadata(), () => { });
+            mockClient.Setup(m => m.DivAsync(Moq.It.IsAny<DivArgs>(), null, null, CancellationToken.None)).Returns(fakeCall);
+            Assert.AreSame(fakeCall, mockClient.Object.DivAsync(new DivArgs()));
+        }
+
+        [Test]
+        public void ClientBaseClientStreamingCallCanBeMocked()
+        {
+            var mockClient = new Moq.Mock<Math.MathClient>();
+            var mockRequestStream = new Moq.Mock<IClientStreamWriter<Num>>();
+
+            // Use a factory method provided by Grpc.Core.Testing.TestCalls to create an instance of a call.
+            var fakeCall = TestCalls.AsyncClientStreamingCall<Num, Num>(mockRequestStream.Object, Task.FromResult(new Num()), Task.FromResult(new Metadata()), () => Status.DefaultSuccess, () => new Metadata(), () => { });
+            mockClient.Setup(m => m.Sum(null, null, CancellationToken.None)).Returns(fakeCall);
+            Assert.AreSame(fakeCall, mockClient.Object.Sum());
+        }
+
+        [Test]
+        public void ClientBaseServerStreamingCallCanBeMocked()
+        {
+            var mockClient = new Moq.Mock<Math.MathClient>();
+            var mockResponseStream = new Moq.Mock<IAsyncStreamReader<Num>>();
+
+            // Use a factory method provided by Grpc.Core.Testing.TestCalls to create an instance of a call.
+            var fakeCall = TestCalls.AsyncServerStreamingCall<Num>(mockResponseStream.Object, Task.FromResult(new Metadata()), () => Status.DefaultSuccess, () => new Metadata(), () => { });
+            mockClient.Setup(m => m.Fib(Moq.It.IsAny<FibArgs>(), null, null, CancellationToken.None)).Returns(fakeCall);
+            Assert.AreSame(fakeCall, mockClient.Object.Fib(new FibArgs()));
+        }
+
+        [Test]
+        public void ClientBaseDuplexStreamingCallCanBeMocked()
+        {
+            var mockClient = new Moq.Mock<Math.MathClient>();
+            var mockRequestStream = new Moq.Mock<IClientStreamWriter<DivArgs>>();
+            var mockResponseStream = new Moq.Mock<IAsyncStreamReader<DivReply>>();
+
+            // Use a factory method provided by Grpc.Core.Testing.TestCalls to create an instance of a call.
+            var fakeCall = TestCalls.AsyncDuplexStreamingCall<DivArgs, DivReply>(mockRequestStream.Object, mockResponseStream.Object, Task.FromResult(new Metadata()), () => Status.DefaultSuccess, () => new Metadata(), () => { });
+            mockClient.Setup(m => m.DivMany(null, null, CancellationToken.None)).Returns(fakeCall);
+            Assert.AreSame(fakeCall, mockClient.Object.DivMany());
+        }
+    }
+}

--- a/src/csharp/Grpc.Examples.Tests/MathServiceImplTestabilityTest.cs
+++ b/src/csharp/Grpc.Examples.Tests/MathServiceImplTestabilityTest.cs
@@ -1,0 +1,47 @@
+#region Copyright notice and license
+
+// Copyright 2018 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Testing;
+using Grpc.Core.Utils;
+using NUnit.Framework;
+
+namespace Math.Tests
+{
+    /// <summary>
+    /// Demonstrates how to unit test implementations of generated server stubs.
+    /// </summary>
+    public class MathServiceImplTestabilityTest
+    {
+        [Test]
+        public async Task ServerCallImplIsTestable()
+        {
+            var mathImpl = new MathServiceImpl();
+
+            // Use a factory method provided by Grpc.Core.Testing.TestServerCallContext to create an instance of server call context.
+            // This allows testing even those server-side implementations that rely on the contents of ServerCallContext.
+            var fakeServerCallContext = TestServerCallContext.Create("fooMethod", null, DateTime.UtcNow.AddHours(1), new Metadata(), CancellationToken.None, "127.0.0.1", null, null, (metadata) => TaskUtils.CompletedTask, () => new WriteOptions(), (writeOptions) => { });
+            var response = await mathImpl.Div(new DivArgs { Dividend = 10, Divisor = 2 }, fakeServerCallContext);
+            Assert.AreEqual(5, response.Quotient);
+            Assert.AreEqual(0, response.Remainder);
+        }
+    }
+}

--- a/src/csharp/Grpc.IntegrationTesting/GeneratedClientTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/GeneratedClientTest.cs
@@ -34,29 +34,6 @@ namespace Grpc.IntegrationTesting
         TestService.TestServiceClient unimplementedClient = new UnimplementedTestServiceClient();
 
         [Test]
-        public void ExpandedParamOverloadCanBeMocked()
-        {
-            var expected = new SimpleResponse();
-
-            var mockClient = new Moq.Mock<TestService.TestServiceClient>();
-            // mocking is relatively clumsy because one needs to specify value for all the optional params.
-            mockClient.Setup(m => m.UnaryCall(Moq.It.IsAny<SimpleRequest>(), null, null, CancellationToken.None)).Returns(expected);
-
-            Assert.AreSame(expected, mockClient.Object.UnaryCall(new SimpleRequest()));
-        }
-
-        [Test]
-        public void CallOptionsOverloadCanBeMocked()
-        {
-            var expected = new SimpleResponse();
-
-            var mockClient = new Moq.Mock<TestService.TestServiceClient>();
-            mockClient.Setup(m => m.UnaryCall(Moq.It.IsAny<SimpleRequest>(), Moq.It.IsAny<CallOptions>())).Returns(expected);
-
-            Assert.AreSame(expected, mockClient.Object.UnaryCall(new SimpleRequest(), new CallOptions()));
-        }
-
-        [Test]
         public void DefaultMethodStubThrows_UnaryCall()
         {
             Assert.Throws(typeof(NotImplementedException), () => unimplementedClient.UnaryCall(new SimpleRequest()));

--- a/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
+++ b/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
@@ -19,7 +19,6 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="$(GoogleProtobufVersion)" />
     <PackageReference Include="CommandLineParser" Version="2.1.1-beta" />
-    <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="NUnit" Version="3.6.0" />
     <PackageReference Include="NUnitLite" Version="3.6.0" />
   </ItemGroup>

--- a/src/csharp/tests.json
+++ b/src/csharp/tests.json
@@ -41,6 +41,7 @@
     "Grpc.Core.Tests.UserAgentStringTest"
   ],
   "Grpc.Examples.Tests": [
+    "Math.Tests.MathClientMockableTest",
     "Math.Tests.MathClientServerTest"
   ],
   "Grpc.HealthCheck.Tests": [

--- a/src/csharp/tests.json
+++ b/src/csharp/tests.json
@@ -42,7 +42,8 @@
   ],
   "Grpc.Examples.Tests": [
     "Math.Tests.MathClientMockableTest",
-    "Math.Tests.MathClientServerTest"
+    "Math.Tests.MathClientServerTest",
+    "Math.Tests.MathServiceImplTestabilityTest"
   ],
   "Grpc.HealthCheck.Tests": [
     "Grpc.HealthCheck.Tests.HealthClientServerTest",


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/14522 (this demonstrates that mocking is possible and shows how).

- fix a bug in Test.CallAsyncDuplexStreamingCall (reverse order of generic args).
- show how to create a fake client stub
- show how to test server-side impl classes that implement the generated server methods.