### PR TITLE
Disable ConnectivityMonitor for CFStream builds

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -206,8 +206,9 @@ static NSString *const kBearerPrefix = @"Bearer ";
   } else {
     [_responseWriteable enqueueSuccessfulCompletion];
   }
-
+#ifndef GRPC_CFSTREAM
   [GRPCConnectivityMonitor unregisterObserver:self];
+#endif
 
   // If the call isn't retained anywhere else, it can be deallocated now.
   _retainSelf = nil;
@@ -462,7 +463,9 @@ static NSString *const kBearerPrefix = @"Bearer ";
   [self sendHeaders:_requestHeaders];
   [self invokeCall];
 
+#ifndef GRPC_CFSTREAM
   [GRPCConnectivityMonitor registerObserver:self selector:@selector(connectivityChanged:)];
+#endif
 }
 
 - (void)startWithWriteable:(id<GRXWriteable>)writeable {

--- a/src/objective-c/GRPCClient/private/GRPCHost.m
+++ b/src/objective-c/GRPCClient/private/GRPCHost.m
@@ -49,7 +49,9 @@ static NSMutableDictionary *kHostCache;
   if (_channelCreds != nil) {
     grpc_channel_credentials_release(_channelCreds);
   }
+#ifndef GRPC_CFSTREAM
   [GRPCConnectivityMonitor unregisterObserver:self];
+#endif
 }
 
 // Default initializer.
@@ -84,7 +86,9 @@ static NSMutableDictionary *kHostCache;
       kHostCache[address] = self;
       _compressAlgorithm = GRPC_COMPRESS_NONE;
     }
+#ifndef GRPC_CFSTREAM
     [GRPCConnectivityMonitor registerObserver:self selector:@selector(connectivityChange:)];
+#endif
   }
   return self;
 }

--- a/src/objective-c/tests/Connectivity/ConnectivityTestingApp.xcodeproj/project.pbxproj
+++ b/src/objective-c/tests/Connectivity/ConnectivityTestingApp.xcodeproj/project.pbxproj
@@ -99,7 +99,6 @@
 				5EC49F8D2043E46B00ED189A /* Sources */,
 				5EC49F8E2043E46B00ED189A /* Frameworks */,
 				5EC49F8F2043E46B00ED189A /* Resources */,
-				9F67C72B6B6BAF2781078886 /* [CP] Embed Pods Frameworks */,
 				735516C793AF7394FBB83B7F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
@@ -194,21 +193,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		9F67C72B6B6BAF2781078886 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ConnectivityTestingApp/Pods-ConnectivityTestingApp-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -284,6 +268,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
+					"GRPC_CFSTREAM=1",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;

--- a/src/objective-c/tests/Connectivity/ConnectivityTestingApp/ViewController.m
+++ b/src/objective-c/tests/Connectivity/ConnectivityTestingApp/ViewController.m
@@ -35,7 +35,9 @@ NSString *host = @"grpc-test.sandbox.googleapis.com";
 - (void)viewDidLoad {
   [super viewDidLoad];
 
+#ifndef GRPC_CFSTREAM
   [GRPCConnectivityMonitor registerObserver:self selector:@selector(reachabilityChanged:)];
+#endif
 }
 
 - (void)reachabilityChanged:(NSNotification *)note {

--- a/src/objective-c/tests/Connectivity/Podfile
+++ b/src/objective-c/tests/Connectivity/Podfile
@@ -5,9 +5,9 @@ platform :ios, '8.0'
 GRPC_LOCAL_SRC = '../../../..'
 
 target 'ConnectivityTestingApp' do
-  pod 'gRPC', :path => GRPC_LOCAL_SRC
-  pod 'gRPC-Core', :path => GRPC_LOCAL_SRC
-  pod 'gRPC-ProtoRPC', :path => GRPC_LOCAL_SRC
+  pod 'gRPC/CFStream', :path => GRPC_LOCAL_SRC
+  pod 'gRPC-Core/CFStream-Implementation', :path => GRPC_LOCAL_SRC
+  pod 'gRPC-ProtoRPC/CFStream', :path => GRPC_LOCAL_SRC
   pod 'gRPC-RxLibrary', :path => GRPC_LOCAL_SRC
   pod 'Protobuf', :path => "#{GRPC_LOCAL_SRC}/third_party/protobuf"
   pod 'BoringSSL', :podspec => "#{GRPC_LOCAL_SRC}/src/objective-c"


### PR DESCRIPTION
Disabled connectivity monitor for CFStream builds.

Updated `ConnectivityTest` accordingly and manually tested:
* Switch WiFi hotspot in background
* Switch between WiFi and cellular data
* Switch between WiFi and airplane mode
* Switch between cellular and airplane mode