### PR TITLE
Add channel arg to enable/disable http proxy

### DIFF
--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -336,6 +336,8 @@ typedef struct {
 /** If non-zero, client authority filter is disabled for the channel */
 #define GRPC_ARG_DISABLE_CLIENT_AUTHORITY_FILTER \
   "grpc.disable_client_authority_filter"
+/** If set to zero, disables use of http proxies. Enabled by default. */
+#define GRPC_ARG_ENABLE_HTTP_PROXY "grpc.enable_http_proxy"
 /** \} */
 
 /** Result of a grpc call. If the caller satisfies the prerequisites of a

--- a/src/core/ext/filters/client_channel/http_proxy.cc
+++ b/src/core/ext/filters/client_channel/http_proxy.cc
@@ -83,11 +83,24 @@ done:
   return proxy_name;
 }
 
+/**
+ * Checks the value of GRPC_ARG_ENABLE_HTTP_PROXY to determine if http_proxy
+ * should be used.
+ */
+bool http_proxy_enabled(const grpc_channel_args* args) {
+  const grpc_arg* arg =
+      grpc_channel_args_find(args, GRPC_ARG_ENABLE_HTTP_PROXY);
+  return grpc_channel_arg_get_bool(arg, true);
+}
+
 static bool proxy_mapper_map_name(grpc_proxy_mapper* mapper,
                                   const char* server_uri,
                                   const grpc_channel_args* args,
                                   char** name_to_resolve,
                                   grpc_channel_args** new_args) {
+  if (!http_proxy_enabled(args)) {
+    return false;
+  }
   char* user_cred = nullptr;
   *name_to_resolve = get_http_proxy_server(&user_cred);
   if (*name_to_resolve == nullptr) return false;


### PR DESCRIPTION
Add channel arg to enable/disable http proxy.
Feature request from #11751

Currently, the recommended approach to disable proxy is to set the no_proxy environment variable. This environment variable is not suitable to be used with IP ranges.

After this change, we would still be supporting the 'no_proxy' environment variable to disable proxy usage for those names across gRPC. The additional capability that the new channel arg would provide is that we can now disable proxy use for a particular channel. This also means that usecases that need to disable proxy use for an entire range of IPs and hence cannot use the 'no_proxy' env variable to disable proxy usage, now have an option to use this channel arg to disable proxy use. 
Please note that this channel argument doesn't take the names/domains/addresses to be blacklisted. It simply disables proxy usage for this channel.

Given that we are adding an argument to disable http proxy, it might also make sense in the future to provide an argument that explicitly provides the http proxy to use. Currently, we just use the 'http_proxy' environment variable.