### PR TITLE
Set higher cpu_cost for arena test

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2032,6 +2032,7 @@ targets:
   dict: test/core/end2end/fuzzers/api_fuzzer.dictionary
   maxlen: 2048
 - name: arena_test
+  cpu_cost: 10
   build: test
   language: c
   src:

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -82,7 +82,7 @@
       "posix", 
       "windows"
     ], 
-    "cpu_cost": 1.0, 
+    "cpu_cost": 10, 
     "exclude_configs": [], 
     "exclude_iomgrs": [], 
     "flaky": false, 


### PR DESCRIPTION
Arena test is pretty cpu intensive, but cpu_cost was set to 1.0 (perhaps increases flakiness of other tests).