### PR TITLE
Upload test results to BQ in batches

### DIFF
--- a/tools/run_tests/python_utils/upload_rbe_results.py
+++ b/tools/run_tests/python_utils/upload_rbe_results.py
@@ -125,7 +125,7 @@ def _get_resultstore_data(api_key, invocation_id):
 
 
 if __name__ == "__main__":
-    # Arguments are necessary if running in a non-Kokoro envrionment.
+    # Arguments are necessary if running in a non-Kokoro environment.
     argp = argparse.ArgumentParser(description='Upload RBE results.')
     argp.add_argument('--api_key', default='', type=str)
     argp.add_argument('--invocation_id', default='', type=str)


### PR DESCRIPTION
- Uploading generates huge amount of logs:  the `URL being requested: ...` line is logged for each row uploaded.
- Uploading row by row is not very efficient (upload itself can take ~3mins).