### PR TITLE
Document fd_cache (and rename MAX_PROBE_EPOLL_FDS macro to MAX_FDS_IN_CACHE)

### DIFF
--- a/src/core/lib/iomgr/ev_epollex_linux.cc
+++ b/src/core/lib/iomgr/ev_epollex_linux.cc
@@ -142,7 +142,7 @@ struct pollable {
   // The following implements LRU-eviction cache of fds in this pollable
   cached_fd fd_cache[MAX_FDS_IN_CACHE];
   int fd_cache_size;
-  uint64_t fd_cache_counter; // Recency timer tick counter
+  uint64_t fd_cache_counter;  // Recency timer tick counter
 };
 
 static const char* pollable_type_string(pollable_type t) {


### PR DESCRIPTION
I am documenting the fd_cache feature that was added just to make sure we don't forget the reason why it was added in the first place :)

(I also renamed MAX_PROBE_EPOLL_FDS macro to MAX_FDS_IN_CACHE macro)

The following comment (also added in the code) is pretty much the crux of it.
``` c++
// We may be calling pollable_add_fd() on the same (pollable, fd) multiple
// times. To prevent pollable_add_fd() from making multiple sys calls to
// epoll_ctl() to add the fd, we maintain a cache of what fds are already
// present in the underlying epoll-set.
//
// Since this is not a correctness issue, we do not need to maintain all the
// fds in the cache. Hence we just use an LRU cache of size 'MAX_FDS_IN_CACHE'
//
// NOTE: An ideal implementation of this should do the following:
//  1) Add fds to the cache in pollable_add_fd() function (i.e whenever the fd
//     is added to the pollable's epoll set)
//  2) Remove the fd from the cache whenever the fd is removed from the
//     underlying epoll set (i.e whenever fd_orphan() is called).
//
// Implementing (2) above (i.e removing fds from cache on fd_orphan) adds a
// lot of complexity since an fd can be present in multiple pollalbles. So our
// implementation ONLY DOES (1) and NOT (2).
//
// The cache_fd.salt variable helps here to maintain correctness (it serves as
// an epoch that differentiates one grpc_fd from the other even though both of
// them may have the same fd number)
//
```