### PR TITLE
PHP: add _getChannel to the Call object so that the interceptor can access it

### DIFF
--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -60,7 +60,8 @@ class BaseStub
         }
         if ($channel) {
             if (!is_a($channel, 'Grpc\Channel') &&
-                !is_a($channel, 'Grpc\Internal\InterceptorChannel')) {
+                !is_a($channel, 'Grpc\Internal\InterceptorChannel') &&
+                !is_a($channel, 'Grpc\GrpcExtensionChannel')) {
                 throw new \Exception('The channel argument is not a Channel object '.
                     'or an InterceptorChannel object created by '.
                     'Interceptor::intercept($channel, Interceptor|Interceptor[] $interceptors)');

--- a/src/php/lib/Grpc/Internal/EmptyCall.php
+++ b/src/php/lib/Grpc/Internal/EmptyCall.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Grpc\Internal;
+
+/**
+ * Class EmptyCall.
+ * When ExtensionChannel is used to create the Grpc\Call object, EmptyCall will
+ * let the program continue without throwing exception.
+ * In addition, EmptyCall contains all information needed for creating a Grpc\Call,
+ * including ExtensionChannel object.
+ * @package Grpc
+ */
+class EmptyCall
+{
+  private $channel;
+  private $method;
+  private $deserialize;
+  private $options;
+  private $metadata;
+  public function __construct($channel,
+                              $method,
+                              $deserialize,
+                              $options) {
+    $this->channel = $channel;
+    $this->method = $method;
+    $this->deserialize = $deserialize;
+    $this->options = $options;
+  }
+  public function startBatch(array $batch) {
+    $this->metadata = $batch[\Grpc\OP_SEND_INITIAL_METADATA];
+  }
+  public function setCredentials(\Grpc\CallCredentials $creds_obj) {}
+  public function getPeer() {}
+  public function cancel() {}
+  public function _getChannel() {
+    return $this->channel;
+  }
+  public function _getMethod() {
+    return $this->method;
+  }
+  public function _getDeserialize() {
+    return $this->deserialize;
+  }
+  public function _getOptions() {
+    return $this->options;
+  }
+  public function _getMetadata() {
+    return $this->metadata;
+  }
+}

--- a/src/php/lib/Grpc/Internal/InterceptorChannel.php
+++ b/src/php/lib/Grpc/Internal/InterceptorChannel.php
@@ -35,7 +35,8 @@ class InterceptorChannel extends \Grpc\Channel
     public function __construct($channel, $interceptor)
     {
         if (!is_a($channel, 'Grpc\Channel') &&
-            !is_a($channel, 'Grpc\Internal\InterceptorChannel')) {
+            !is_a($channel, 'Grpc\Internal\InterceptorChannel') &&
+            !is_a($channel, 'Grpc\GrpcExtensionChannel')) {
             throw new \Exception('The channel argument is not a Channel object '.
                 'or an InterceptorChannel object created by '.
                 'Interceptor::intercept($channel, Interceptor|Interceptor[] $interceptors)');


### PR DESCRIPTION
The purpose of this PR is making the Interceptor access the $channel object(It can't before this PR). By doing so we can delay where Grpc\Call object is created via Interceptor.

For example,  if we pass an `ExtensionChannel` for creating the call, it will create an `EmptyCall`, which saves all information needed for creating a `Grpc\Call`. Then inside interceptor, 
`$continuation` returns this `EmptyCall` with channel information get by `_getChannel`, we can do any preprocess and postprocess here.

This change has none influence on the current user because checking type Grpc\Channel is still there. Only when it is not Grpc\Channel, it will check the type one more time. But since the program will throw the exception for the current user, it doesn’t deliver latency to the user.


An example of using it(manage channel pool) is in the PR
https://github.com/ZhouyihaiDing/grpc/pull/20