### PR TITLE
WIP PHP: add ChannelInterface for GCP extension to maintain channel pool

### DIFF
--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -60,10 +60,12 @@ class BaseStub
         }
         if ($channel) {
             if (!is_a($channel, 'Grpc\Channel') &&
-                !is_a($channel, 'Grpc\Internal\InterceptorChannel')) {
+                !is_a($channel, 'Grpc\Internal\InterceptorChannel') &&
+                !($channel instanceof \Grpc\ChannelInterface)) {
                 throw new \Exception('The channel argument is not a Channel object '.
                     'or an InterceptorChannel object created by '.
-                    'Interceptor::intercept($channel, Interceptor|Interceptor[] $interceptors)');
+                    'Interceptor::intercept($channel, Interceptor|Interceptor[] $interceptors)'.
+                    'or an Instance of ChannelInterface');
             }
             $this->channel = $channel;
             return;

--- a/src/php/lib/Grpc/ChannelInterface.php
+++ b/src/php/lib/Grpc/ChannelInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Grpc;
+
+interface ChannelInterface
+{
+    /**
+   * * Construct an instance of the Channel class. If the $args array contains a
+   * "credentials" key mapping to a ChannelCredentials object, a secure channel
+   * will be created with those credentials.
+   *
+   * @param string $target The hostname to associate with this channel
+   * @param array  $args   The arguments to pass to the Channel (optional)
+   *
+   * @throws \InvalidArgumentException
+   */
+  public function __construct($target, $args = array());
+  /**
+   * Get the endpoint this call/stream is connected to
+   *
+   * @return string The URI of the endpoint
+   */
+  public function getTarget();
+  /**
+   * Get the connectivity state of the channel
+   *
+   * @param bool $try_to_connect try to connect on the channel
+   *
+   * @return int The grpc connectivity state
+   * @throws \InvalidArgumentException
+   */
+  public function getConnectivityState($try_to_connect = false);
+  /**
+   * Watch the connectivity state of the channel until it changed
+   *
+   * @param int     $last_state   The previous connectivity state of the channel
+   * @param Timeval $deadline_obj The deadline this function should wait until
+   *
+   * @return bool If the connectivity state changes from last_state
+   *              before deadline
+   * @throws \InvalidArgumentException
+   */
+  public function watchConnectivityState($last_state, Timeval $deadline_obj);
+  /**
+   * Close the channel
+   */
+  public function close();
+}


### PR DESCRIPTION
It should work together with #15749.
I will add tests if this PR and #15749 are approved.

The GCP extension will use ChannelInterface and CallInvoker to maintain a channel pool. The implementation and tests drafts can be seen at [PR: add GCP extension support via call invoker](https://github.com/ZhouyihaiDing/grpc/pull/21)