### PR TITLE
PHP: add deserialze as the argument for the interceptor

### DIFF
--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -232,12 +232,13 @@ class BaseStub
      *
      * @return \Closure
      */
-    private function _GrpcUnaryUnary($channel, $deserialize)
+    private function _GrpcUnaryUnary($channel)
     {
         return function ($method,
                          $argument,
+                         $deserialize,
                          array $metadata = [],
-                         array $options = []) use ($channel, $deserialize) {
+                         array $options = []) use ($channel) {
             $call = new UnaryCall(
                 $channel,
                 $method,
@@ -268,11 +269,12 @@ class BaseStub
      *
      * @return \Closure
      */
-    private function _GrpcStreamUnary($channel, $deserialize)
+    private function _GrpcStreamUnary($channel)
     {
         return function ($method,
+                         $deserialize,
                          array $metadata = [],
-                         array $options = []) use ($channel, $deserialize) {
+                         array $options = []) use ($channel) {
             $call = new ClientStreamingCall(
                 $channel,
                 $method,
@@ -303,12 +305,13 @@ class BaseStub
      *
      * @return \Closure
      */
-    private function _GrpcUnaryStream($channel, $deserialize)
+    private function _GrpcUnaryStream($channel)
     {
         return function ($method,
                          $argument,
+                         $deserialize,
                          array $metadata = [],
-                         array $options = []) use ($channel, $deserialize) {
+                         array $options = []) use ($channel) {
             $call = new ServerStreamingCall(
                 $channel,
                 $method,
@@ -339,11 +342,12 @@ class BaseStub
      *
      * @return \Closure
      */
-    private function _GrpcStreamStream($channel, $deserialize)
+    private function _GrpcStreamStream($channel)
     {
         return function ($method,
+                         $deserialize,
                          array $metadata = [],
-                         array $options = []) use ($channel ,$deserialize) {
+                         array $options = []) use ($channel) {
             $call = new BidiStreamingCall(
                 $channel,
                 $method,
@@ -375,23 +379,25 @@ class BaseStub
      *
      * @return \Closure
      */
-    private function _UnaryUnaryCallFactory($channel, $deserialize)
+    private function _UnaryUnaryCallFactory($channel)
     {
         if (is_a($channel, 'Grpc\Internal\InterceptorChannel')) {
             return function ($method,
                              $argument,
+                             $deserialize,
                              array $metadata = [],
-                             array $options = []) use ($channel, $deserialize) {
+                             array $options = []) use ($channel) {
                 return $channel->getInterceptor()->interceptUnaryUnary(
                     $method,
                     $argument,
+                    $deserialize,
                     $metadata,
                     $options,
-                    $this->_UnaryUnaryCallFactory($channel->getNext(), $deserialize)
+                    $this->_UnaryUnaryCallFactory($channel->getNext())
                 );
             };
         }
-        return $this->_GrpcUnaryUnary($channel, $deserialize);
+        return $this->_GrpcUnaryUnary($channel);
     }
 
     /**
@@ -402,23 +408,25 @@ class BaseStub
      *
      * @return \Closure
      */
-    private function _UnaryStreamCallFactory($channel, $deserialize)
+    private function _UnaryStreamCallFactory($channel)
     {
         if (is_a($channel, 'Grpc\Internal\InterceptorChannel')) {
             return function ($method,
                              $argument,
+                             $deserialize,
                              array $metadata = [],
-                             array $options = []) use ($channel, $deserialize) {
+                             array $options = []) use ($channel) {
                 return $channel->getInterceptor()->interceptUnaryStream(
                     $method,
                     $argument,
+                    $deserialize,
                     $metadata,
                     $options,
-                    $this->_UnaryStreamCallFactory($channel->getNext(), $deserialize)
+                    $this->_UnaryStreamCallFactory($channel->getNext())
                 );
             };
         }
-        return $this->_GrpcUnaryStream($channel, $deserialize);
+        return $this->_GrpcUnaryStream($channel);
     }
 
     /**
@@ -429,21 +437,23 @@ class BaseStub
      *
      * @return \Closure
      */
-    private function _StreamUnaryCallFactory($channel, $deserialize)
+    private function _StreamUnaryCallFactory($channel)
     {
         if (is_a($channel, 'Grpc\Internal\InterceptorChannel')) {
             return function ($method,
+                             $deserialize,
                              array $metadata = [],
-                             array $options = []) use ($channel, $deserialize) {
+                             array $options = []) use ($channel) {
                 return $channel->getInterceptor()->interceptStreamUnary(
                     $method,
+                    $deserialize,
                     $metadata,
                     $options,
-                    $this->_StreamUnaryCallFactory($channel->getNext(), $deserialize)
+                    $this->_StreamUnaryCallFactory($channel->getNext())
                 );
             };
         }
-        return $this->_GrpcStreamUnary($channel, $deserialize);
+        return $this->_GrpcStreamUnary($channel);
     }
 
     /**
@@ -454,21 +464,23 @@ class BaseStub
      *
      * @return \Closure
      */
-    private function _StreamStreamCallFactory($channel, $deserialize)
+    private function _StreamStreamCallFactory($channel)
     {
         if (is_a($channel, 'Grpc\Internal\InterceptorChannel')) {
             return function ($method,
+                             $deserialize,
                              array $metadata = [],
-                             array $options = []) use ($channel, $deserialize) {
+                             array $options = []) use ($channel) {
                 return $channel->getInterceptor()->interceptStreamStream(
                     $method,
+                    $deserialize,
                     $metadata,
                     $options,
-                    $this->_StreamStreamCallFactory($channel->getNext(), $deserialize)
+                    $this->_StreamStreamCallFactory($channel->getNext())
                 );
             };
         }
-        return $this->_GrpcStreamStream($channel, $deserialize);
+        return $this->_GrpcStreamStream($channel);
     }
 
     /* This class is intended to be subclassed by generated code, so
@@ -493,8 +505,8 @@ class BaseStub
         array $metadata = [],
         array $options = []
     ) {
-        $call_factory = $this->_UnaryUnaryCallFactory($this->channel, $deserialize);
-        $call = $call_factory($method, $argument, $metadata, $options);
+        $call_factory = $this->_UnaryUnaryCallFactory($this->channel);
+        $call = $call_factory($method, $argument, $deserialize, $metadata, $options);
         return $call;
     }
 
@@ -516,8 +528,8 @@ class BaseStub
         array $metadata = [],
         array $options = []
     ) {
-        $call_factory = $this->_StreamUnaryCallFactory($this->channel, $deserialize);
-        $call = $call_factory($method, $metadata, $options);
+        $call_factory = $this->_StreamUnaryCallFactory($this->channel);
+        $call = $call_factory($method, $deserialize, $metadata, $options);
         return $call;
     }
 
@@ -541,8 +553,8 @@ class BaseStub
         array $metadata = [],
         array $options = []
     ) {
-        $call_factory = $this->_UnaryStreamCallFactory($this->channel, $deserialize);
-        $call = $call_factory($method, $argument, $metadata, $options);
+        $call_factory = $this->_UnaryStreamCallFactory($this->channel);
+        $call = $call_factory($method, $argument, $deserialize, $metadata, $options);
         return $call;
     }
 
@@ -563,8 +575,8 @@ class BaseStub
         array $metadata = [],
         array $options = []
     ) {
-        $call_factory = $this->_StreamStreamCallFactory($this->channel, $deserialize);
-        $call = $call_factory($method, $metadata, $options);
+        $call_factory = $this->_StreamStreamCallFactory($this->channel);
+        $call = $call_factory($method, $deserialize, $metadata, $options);
         return $call;
     }
 }

--- a/src/php/lib/Grpc/Interceptor.php
+++ b/src/php/lib/Grpc/Interceptor.php
@@ -21,6 +21,8 @@ namespace Grpc;
 
 /**
  * Represents an interceptor that intercept RPC invocations before call starts.
+ * There is one proposal related to the argument $deserialize under the review.
+ * The proposal link is https://github.com/grpc/proposal/pull/86.
  * This is an EXPERIMENTAL API.
  */
 class Interceptor
@@ -28,39 +30,43 @@ class Interceptor
     public function interceptUnaryUnary(
         $method,
         $argument,
+        $deserialize,
         array $metadata = [],
         array $options = [],
         $continuation
     ) {
-        return $continuation($method, $argument, $metadata, $options);
+        return $continuation($method, $argument, $deserialize, $metadata, $options);
     }
 
     public function interceptStreamUnary(
         $method,
+        $deserialize,
         array $metadata = [],
         array $options = [],
         $continuation
     ) {
-        return $continuation($method, $metadata, $options);
+        return $continuation($method, $deserialize, $metadata, $options);
     }
 
     public function interceptUnaryStream(
         $method,
         $argument,
+        $deserialize,
         array $metadata = [],
         array $options = [],
         $continuation
     ) {
-        return $continuation($method, $argument, $metadata, $options);
+        return $continuation($method, $argument, $deserialize, $metadata, $options);
     }
 
     public function interceptStreamStream(
         $method,
+        $deserialize,
         array $metadata = [],
         array $options = [],
         $continuation
     ) {
-        return $continuation($method, $metadata, $options);
+        return $continuation($method, $deserialize, $metadata, $options);
     }
 
     /**

--- a/src/php/tests/unit_tests/InterceptorTest.php
+++ b/src/php/tests/unit_tests/InterceptorTest.php
@@ -94,17 +94,18 @@ class ChangeMetadataInterceptor extends Grpc\Interceptor
 {
     public function interceptUnaryUnary($method,
                                         $argument,
+                                        $deserialize,
                                         array $metadata = [],
                                         array $options = [],
                                         $continuation)
     {
         $metadata["foo"] = array('interceptor_from_unary_request');
-        return $continuation($method, $argument, $metadata, $options);
+        return $continuation($method, $argument, $deserialize, $metadata, $options);
     }
-    public function interceptStreamUnary($method, array $metadata = [], array $options = [], $continuation)
+    public function interceptStreamUnary($method, $deserialize, array $metadata = [], array $options = [], $continuation)
     {
         $metadata["foo"] = array('interceptor_from_stream_request');
-        return $continuation($method, $metadata, $options);
+        return $continuation($method, $deserialize, $metadata, $options);
     }
 }
 
@@ -112,6 +113,7 @@ class ChangeMetadataInterceptor2 extends Grpc\Interceptor
 {
     public function interceptUnaryUnary($method,
                                         $argument,
+                                        $deserialize,
                                         array $metadata = [],
                                         array $options = [],
                                         $continuation)
@@ -121,9 +123,10 @@ class ChangeMetadataInterceptor2 extends Grpc\Interceptor
         } else {
             $metadata["bar"] = array('interceptor_from_unary_request');
         }
-        return $continuation($method, $argument, $metadata, $options);
+        return $continuation($method, $argument, $deserialize, $metadata, $options);
     }
     public function interceptStreamUnary($method,
+                                         $deserialize,
                                          array $metadata = [],
                                          array $options = [],
                                          $continuation)
@@ -133,7 +136,7 @@ class ChangeMetadataInterceptor2 extends Grpc\Interceptor
         } else {
             $metadata["bar"] = array('interceptor_from_stream_request');
         }
-        return $continuation($method, $metadata, $options);
+        return $continuation($method, $deserialize, $metadata, $options);
     }
 }
 
@@ -166,17 +169,18 @@ class ChangeRequestInterceptor extends Grpc\Interceptor
 {
     public function interceptUnaryUnary($method,
                                         $argument,
+                                        $deserialize,
                                         array $metadata = [],
                                         array $options = [],
                                         $continuation)
     {
         $argument->setData('intercepted_unary_request');
-        return $continuation($method, $argument, $metadata, $options);
+        return $continuation($method, $argument, $deserialize, $metadata, $options);
     }
-    public function interceptStreamUnary($method, array $metadata = [], array $options = [], $continuation)
+    public function interceptStreamUnary($method, $deserialize, array $metadata = [], array $options = [], $continuation)
     {
         return new ChangeRequestCall(
-            $continuation($method, $metadata, $options)
+            $continuation($method, $deserialize, $metadata, $options)
         );
     }
 }


### PR DESCRIPTION
Hi @mehrdada 

For the interceptor API, I feel like adding `deserialize` as the argument makes more sense, because it should be couple with the `method`. For example, If the user changes the `method` through the interceptor, the response type will change and the deserialize method should change too. In another case, if the user uses something else other than protobuf, they can use the interceptor to pick whatever deserializer they want.

In addition, `use($channel)` in the code is enough to hide what the user doesn't needs.

Since we are releasing the PHP interceptor by 1.13.0 and now it's 1.13.0-pre, if this change make sense, I think we can backport it to 1.13.0?