### PR TITLE
Suppress noisy output during rspec

### DIFF
--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -25,7 +25,7 @@ module GRPC
     DEFAULT_KEEP_ALIVE = 1
 
     def initialize(size, keep_alive: DEFAULT_KEEP_ALIVE)
-      fail 'pool size must be positive' unless size > 0
+      fail 'pool size must be positive' unless Integer(size) > 0
       @jobs = Queue.new
       @size = size
       @stopped = false

--- a/src/ruby/spec/call_credentials_spec.rb
+++ b/src/ruby/spec/call_credentials_spec.rb
@@ -15,27 +15,25 @@
 require 'grpc'
 
 describe GRPC::Core::CallCredentials do
-  CallCredentials = GRPC::Core::CallCredentials
-
   let(:auth_proc) { proc { { 'plugin_key' => 'plugin_value' } } }
 
   describe '#new' do
     it 'can successfully create a CallCredentials from a proc' do
-      expect { CallCredentials.new(auth_proc) }.not_to raise_error
+      expect { described_class.new(auth_proc) }.not_to raise_error
     end
   end
 
   describe '#compose' do
-    it 'can compose with another CallCredentials' do
-      creds1 = CallCredentials.new(auth_proc)
-      creds2 = CallCredentials.new(auth_proc)
+    it 'can compose with another described_class' do
+      creds1 = described_class.new(auth_proc)
+      creds2 = described_class.new(auth_proc)
       expect { creds1.compose creds2 }.not_to raise_error
     end
 
-    it 'can compose with multiple CallCredentials' do
-      creds1 = CallCredentials.new(auth_proc)
-      creds2 = CallCredentials.new(auth_proc)
-      creds3 = CallCredentials.new(auth_proc)
+    it 'can compose with multiple described_class' do
+      creds1 = described_class.new(auth_proc)
+      creds2 = described_class.new(auth_proc)
+      creds3 = described_class.new(auth_proc)
       expect { creds1.compose(creds2, creds3) }.not_to raise_error
     end
   end

--- a/src/ruby/spec/channel_connection_spec.rb
+++ b/src/ruby/spec/channel_connection_spec.rb
@@ -14,7 +14,6 @@
 require 'spec_helper'
 require 'timeout'
 
-include Timeout
 include GRPC::Core
 include GRPC::Spec::Helpers
 
@@ -97,7 +96,7 @@ describe 'channel connection behavior' do
   end
 
   it 'concurrent watches on the same channel' do
-    timeout(180) do
+    Timeout.timeout(180) do
       port = start_server
       ch = GRPC::Core::Channel.new("localhost:#{port}", {},
                                    :this_channel_is_insecure)

--- a/src/ruby/spec/channel_credentials_spec.rb
+++ b/src/ruby/spec/channel_credentials_spec.rb
@@ -15,9 +15,6 @@
 require 'grpc'
 
 describe GRPC::Core::ChannelCredentials do
-  ChannelCredentials = GRPC::Core::ChannelCredentials
-  CallCredentials = GRPC::Core::CallCredentials
-
   def load_test_certs
     test_root = File.join(File.dirname(__FILE__), 'testdata')
     files = ['ca.pem', 'server1.key', 'server1.pem']
@@ -26,28 +23,28 @@ describe GRPC::Core::ChannelCredentials do
 
   describe '#new' do
     it 'can be constructed with fake inputs' do
-      blk = proc  { ChannelCredentials.new('root_certs', 'key', 'cert') }
+      blk = proc  { described_class.new('root_certs', 'key', 'cert') }
       expect(&blk).not_to raise_error
     end
 
     it 'it can be constructed using specific test certificates' do
       certs = load_test_certs
-      expect { ChannelCredentials.new(*certs) }.not_to raise_error
+      expect { described_class.new(*certs) }.not_to raise_error
     end
 
     it 'can be constructed with server roots certs only' do
       root_cert, _, _ = load_test_certs
-      expect { ChannelCredentials.new(root_cert) }.not_to raise_error
+      expect { described_class.new(root_cert) }.not_to raise_error
     end
 
     it 'can be constructed with a nil server roots' do
       _, client_key, client_chain = load_test_certs
-      blk = proc { ChannelCredentials.new(nil, client_key, client_chain) }
+      blk = proc { described_class.new(nil, client_key, client_chain) }
       expect(&blk).not_to raise_error
     end
 
     it 'can be constructed with no params' do
-      blk = proc { ChannelCredentials.new(nil) }
+      blk = proc { described_class.new(nil) }
       expect(&blk).not_to raise_error
     end
   end
@@ -55,27 +52,27 @@ describe GRPC::Core::ChannelCredentials do
   describe '#compose' do
     it 'can compose with a CallCredentials' do
       certs = load_test_certs
-      channel_creds = ChannelCredentials.new(*certs)
+      channel_creds = described_class.new(*certs)
       auth_proc = proc { { 'plugin_key' => 'plugin_value' } }
-      call_creds = CallCredentials.new auth_proc
+      call_creds = GRPC::Core::CallCredentials.new(auth_proc)
       expect { channel_creds.compose call_creds }.not_to raise_error
     end
 
     it 'can compose with multiple CallCredentials' do
       certs = load_test_certs
-      channel_creds = ChannelCredentials.new(*certs)
+      channel_creds = described_class.new(*certs)
       auth_proc = proc { { 'plugin_key' => 'plugin_value' } }
-      call_creds1 = CallCredentials.new auth_proc
-      call_creds2 = CallCredentials.new auth_proc
+      call_creds1 = GRPC::Core::CallCredentials.new(auth_proc)
+      call_creds2 = GRPC::Core::CallCredentials.new(auth_proc)
       expect do
         channel_creds.compose(call_creds1, call_creds2)
       end.not_to raise_error
     end
 
-    it 'cannot compose with ChannelCredentials' do
+    it 'cannot compose with described_class' do
       certs = load_test_certs
-      channel_creds1 = ChannelCredentials.new(*certs)
-      channel_creds2 = ChannelCredentials.new(*certs)
+      channel_creds1 = described_class.new(*certs)
+      channel_creds2 = described_class.new(*certs)
       expect { channel_creds1.compose channel_creds2 }.to raise_error(TypeError)
     end
   end

--- a/src/ruby/spec/client_auth_spec.rb
+++ b/src/ruby/spec/client_auth_spec.rb
@@ -89,8 +89,6 @@ end
 SslTestServiceStub = SslTestService.rpc_stub_class
 
 describe 'client-server auth' do
-  RpcServer = GRPC::RpcServer
-
   before(:all) do
     server_opts = {
       poll_period: 1

--- a/src/ruby/spec/client_auth_spec.rb
+++ b/src/ruby/spec/client_auth_spec.rb
@@ -30,7 +30,7 @@ end
 
 def create_server_creds
   test_root = File.join(File.dirname(__FILE__), 'testdata')
-  p "test root: #{test_root}"
+  GRPC.logger.info("test root: #{test_root}")
   files = ['ca.pem', 'server1.key', 'server1.pem']
   creds = files.map { |f| File.open(File.join(test_root, f)).read }
   GRPC::Core::ServerCredentials.new(
@@ -70,7 +70,7 @@ class SslTestService
 
   def a_client_streaming_rpc(call)
     check_peer_cert(call)
-    call.each_remote_read.each { |r| p r }
+    call.each_remote_read.each { |r| GRPC.logger.info(r) }
     EchoMsg.new
   end
 
@@ -81,7 +81,7 @@ class SslTestService
 
   def a_bidi_rpc(requests, call)
     check_peer_cert(call)
-    requests.each { |r| p r }
+    requests.each { |r| GRPC.logger.info(r) }
     [EchoMsg.new, EchoMsg.new]
   end
 end
@@ -125,11 +125,11 @@ describe 'client-server auth' do
 
   it 'client-server auth with server streaming RPCs' do
     responses = @stub.a_server_streaming_rpc(EchoMsg.new)
-    responses.each { |r| p r }
+    responses.each { |r| GRPC.logger.info(r) }
   end
 
   it 'client-server auth with bidi RPCs' do
     responses = @stub.a_bidi_rpc([EchoMsg.new, EchoMsg.new])
-    responses.each { |r| p r }
+    responses.each { |r| GRPC.logger.info(r) }
   end
 end

--- a/src/ruby/spec/compression_options_spec.rb
+++ b/src/ruby/spec/compression_options_spec.rb
@@ -103,12 +103,12 @@ describe GRPC::Core::CompressionOptions do
   describe '#new with bad parameters' do
     it 'should fail with more than one parameter' do
       blk = proc { GRPC::Core::CompressionOptions.new(:gzip, :none) }
-      expect { blk.call }.to raise_error
+      expect { blk.call }.to raise_error(ArgumentError)
     end
 
     it 'should fail with a non-hash parameter' do
       blk = proc { GRPC::Core::CompressionOptions.new(:gzip) }
-      expect { blk.call }.to raise_error
+      expect { blk.call }.to raise_error(ArgumentError)
     end
   end
 
@@ -134,7 +134,7 @@ describe GRPC::Core::CompressionOptions do
   end
 
   describe '#algorithm_enabled?' do
-    [:none, :any, 'gzip', Object.new, 1].each do |name|
+    [:none, :any].each do |name|
       it "should fail for parameter ${name} of class #{name.class}" do
         options = GRPC::Core::CompressionOptions.new(
           disabled_algorithms: [:gzip])
@@ -142,7 +142,19 @@ describe GRPC::Core::CompressionOptions do
         blk = proc do
           options.algorithm_enabled?(name)
         end
-        expect { blk.call }.to raise_error
+        expect { blk.call }.to raise_error(NameError)
+      end
+    end
+
+    ['gzip', Object.new, 1].each do |name|
+      it "should fail for parameter ${name} of class #{name.class}" do
+        options = GRPC::Core::CompressionOptions.new(
+          disabled_algorithms: [:gzip])
+
+        blk = proc do
+          options.algorithm_enabled?(name)
+        end
+        expect { blk.call }.to raise_error(TypeError)
       end
     end
   end

--- a/src/ruby/spec/generic/client_stub_spec.rb
+++ b/src/ruby/spec/generic/client_stub_spec.rb
@@ -293,7 +293,7 @@ describe 'ClientStub' do  # rubocop:disable Metrics/BlockLength
 
     describe 'without a call operation' do
       def get_response(stub, credentials: nil)
-        puts credentials.inspect
+        GRPC.logger.info(credentials.inspect)
         stub.request_response(@method, @sent_msg, noop, noop,
                               metadata: @metadata,
                               credentials: credentials)
@@ -342,13 +342,15 @@ describe 'ClientStub' do  # rubocop:disable Metrics/BlockLength
       it 'sends metadata to the server ok when running start_call first' do
         run_op_view_metadata_test(true)
         check_op_view_of_finished_client_call(
-          @op, @server_initial_md, @server_trailing_md) { |r| p r }
+          @op, @server_initial_md, @server_trailing_md
+        ) { |r| GRPC.logger.info(r) }
       end
 
       it 'does not crash when used after the call has been finished' do
         run_op_view_metadata_test(false)
         check_op_view_of_finished_client_call(
-          @op, @server_initial_md, @server_trailing_md) { |r| p r }
+          @op, @server_initial_md, @server_trailing_md
+        ) { |r| GRPC.logger.info(r) }
       end
     end
   end
@@ -435,13 +437,15 @@ describe 'ClientStub' do  # rubocop:disable Metrics/BlockLength
       it 'sends metadata to the server ok when running start_call first' do
         run_op_view_metadata_test(true)
         check_op_view_of_finished_client_call(
-          @op, @server_initial_md, @server_trailing_md) { |r| p r }
+          @op, @server_initial_md, @server_trailing_md
+        ) { |r| GRPC.logger.info(r) }
       end
 
       it 'does not crash when used after the call has been finished' do
         run_op_view_metadata_test(false)
         check_op_view_of_finished_client_call(
-          @op, @server_initial_md, @server_trailing_md) { |r| p r }
+          @op, @server_initial_md, @server_trailing_md
+        ) { |r| GRPC.logger.info(r) }
       end
     end
   end
@@ -578,7 +582,7 @@ describe 'ClientStub' do  # rubocop:disable Metrics/BlockLength
         run_op_view_metadata_test(true)
         check_op_view_of_finished_client_call(
           @op, @server_initial_md, @server_trailing_md) do |responses|
-          responses.each { |r| p r }
+          responses.each { |r| GRPC.logger.info(r) }
         end
       end
 
@@ -586,7 +590,7 @@ describe 'ClientStub' do  # rubocop:disable Metrics/BlockLength
         run_op_view_metadata_test(false)
         check_op_view_of_finished_client_call(
           @op, @server_initial_md, @server_trailing_md) do |responses|
-          responses.each { |r| p r }
+          responses.each { |r| GRPC.logger.info(r) }
         end
       end
     end
@@ -883,7 +887,7 @@ describe 'ClientStub' do  # rubocop:disable Metrics/BlockLength
         run_op_view_metadata_test(true)
         check_op_view_of_finished_client_call(
           @op, @server_initial_md, @server_trailing_md) do |responses|
-          responses.each { |r| p r }
+          responses.each { |r| GRPC.logger.info(r) }
         end
       end
 
@@ -891,7 +895,7 @@ describe 'ClientStub' do  # rubocop:disable Metrics/BlockLength
         run_op_view_metadata_test(false)
         check_op_view_of_finished_client_call(
           @op, @server_initial_md, @server_trailing_md) do |responses|
-          responses.each { |r| p r }
+          responses.each { |r| GRPC.logger.info(r) }
         end
       end
 

--- a/src/ruby/spec/generic/rpc_desc_spec.rb
+++ b/src/ruby/spec/generic/rpc_desc_spec.rb
@@ -215,7 +215,7 @@ describe GRPC::RpcDesc do
         blk = proc do
           @request_response.assert_arity_matches(method(mth))
         end
-        expect(&blk).to raise_error
+        expect(&blk).to raise_error(RuntimeError, /bad arg count/)
       end
     end
 
@@ -231,7 +231,7 @@ describe GRPC::RpcDesc do
         blk = proc do
           @server_streamer.assert_arity_matches(method(mth))
         end
-        expect(&blk).to raise_error
+        expect(&blk).to raise_error(RuntimeError, /bad arg count/)
       end
     end
 
@@ -247,7 +247,7 @@ describe GRPC::RpcDesc do
         blk = proc do
           @client_streamer.assert_arity_matches(method(mth))
         end
-        expect(&blk).to raise_error
+        expect(&blk).to raise_error(RuntimeError, /bad arg count/)
       end
     end
 
@@ -263,7 +263,7 @@ describe GRPC::RpcDesc do
         blk = proc do
           @bidi_streamer.assert_arity_matches(method(mth))
         end
-        expect(&blk).to raise_error
+        expect(&blk).to raise_error(RuntimeError, /bad arg count/)
       end
     end
 

--- a/src/ruby/spec/generic/rpc_server_pool_spec.rb
+++ b/src/ruby/spec/generic/rpc_server_pool_spec.rb
@@ -21,9 +21,9 @@ describe GRPC::Pool do
 
   describe '#new' do
     it 'raises if a non-positive size is used' do
-      expect { Pool.new(Object.new) }.to raise_error
       expect { Pool.new(0) }.to raise_error(StandardError, /pool size must be positive/)
       expect { Pool.new(-1) }.to raise_error(StandardError, /pool size must be positive/)
+      expect { Pool.new(Object.new) }.to raise_error(TypeError)
     end
 
     it 'is constructed OK with a positive size' do

--- a/src/ruby/spec/generic/rpc_server_pool_spec.rb
+++ b/src/ruby/spec/generic/rpc_server_pool_spec.rb
@@ -21,9 +21,9 @@ describe GRPC::Pool do
 
   describe '#new' do
     it 'raises if a non-positive size is used' do
-      expect { Pool.new(0) }.to raise_error
-      expect { Pool.new(-1) }.to raise_error
       expect { Pool.new(Object.new) }.to raise_error
+      expect { Pool.new(0) }.to raise_error(StandardError, /pool size must be positive/)
+      expect { Pool.new(-1) }.to raise_error(StandardError, /pool size must be positive/)
     end
 
     it 'is constructed OK with a positive size' do

--- a/src/ruby/spec/generic/rpc_server_spec.rb
+++ b/src/ruby/spec/generic/rpc_server_spec.rb
@@ -125,7 +125,7 @@ class CheckCallAfterFinishedService
     fail 'shouldnt reuse service' unless @server_side_call.nil?
     @server_side_call = call
     # iterate through requests so call can complete
-    call.each_remote_read.each { |r| p r }
+    call.each_remote_read.each { |r| GRPC.logger.info(r) }
     EchoMsg.new
   end
 
@@ -138,7 +138,7 @@ class CheckCallAfterFinishedService
   def a_bidi_rpc(requests, call)
     fail 'shouldnt reuse service' unless @server_side_call.nil?
     @server_side_call = call
-    requests.each { |r| p r }
+    requests.each { |r| GRPC.logger.info(r) }
     [EchoMsg.new, EchoMsg.new]
   end
 end
@@ -557,7 +557,7 @@ describe GRPC::RpcServer do
           'connect_k1' => 'connect_v1'
         }
         wanted_md.each do |key, value|
-          puts "key: #{key}"
+          GRPC.logger.info("key: #{key}")
           expect(op.metadata[key]).to eq(value)
         end
         @srv.stop

--- a/src/ruby/spec/generic/rpc_server_spec.rb
+++ b/src/ruby/spec/generic/rpc_server_spec.rb
@@ -158,9 +158,6 @@ end
 BidiStub = BidiService.rpc_stub_class
 
 describe GRPC::RpcServer do
-  RpcServer = GRPC::RpcServer
-  StatusCodes = GRPC::Core::StatusCodes
-
   before(:each) do
     @method = 'an_rpc_method'
     @pass = 0

--- a/src/ruby/spec/server_credentials_spec.rb
+++ b/src/ruby/spec/server_credentials_spec.rb
@@ -40,7 +40,7 @@ describe GRPC::Core::ServerCredentials do
       blk = proc do
         Creds.new(root_cert, nil, false)
       end
-      expect(&blk).to raise_error
+      expect(&blk).to raise_error(TypeError)
     end
 
     it 'cannot be constructed without any key_cert pairs' do
@@ -48,7 +48,7 @@ describe GRPC::Core::ServerCredentials do
       blk = proc do
         Creds.new(root_cert, [], false)
       end
-      expect(&blk).to raise_error
+      expect(&blk).to raise_error(TypeError)
     end
 
     it 'cannot be constructed without a server cert chain' do
@@ -58,7 +58,7 @@ describe GRPC::Core::ServerCredentials do
                   [{ server_key: server_key, cert_chain: nil }],
                   false)
       end
-      expect(&blk).to raise_error
+      expect(&blk).to raise_error(TypeError)
     end
 
     it 'cannot be constructed without a server key' do
@@ -67,7 +67,7 @@ describe GRPC::Core::ServerCredentials do
         Creds.new(root_cert,
                   [{ server_key: nil, cert_chain: cert_chain }])
       end
-      expect(&blk).to raise_error
+      expect(&blk).to raise_error(NameError)
     end
 
     it 'can be constructed without a root_cret' do

--- a/src/ruby/spec/time_consts_spec.rb
+++ b/src/ruby/spec/time_consts_spec.rb
@@ -34,7 +34,9 @@ describe GRPC::Core::TimeConsts do
 
   describe '#from_relative_time' do
     it 'cannot handle arbitrary objects' do
-      expect { described_class.from_relative_time(Object.new) }.to raise_error
+      expect do
+        described_class.from_relative_time(Object.new)
+      end.to raise_error(TypeError)
     end
 
     it 'preserves TimeConsts' do

--- a/src/ruby/spec/time_consts_spec.rb
+++ b/src/ruby/spec/time_consts_spec.rb
@@ -14,61 +14,59 @@
 
 require 'grpc'
 
-TimeConsts = GRPC::Core::TimeConsts
-
-describe TimeConsts do
+describe GRPC::Core::TimeConsts do
   before(:each) do
     @known_consts = [:ZERO, :INFINITE_FUTURE, :INFINITE_PAST].sort
   end
 
   it 'should have all the known types' do
-    expect(TimeConsts.constants.collect.sort).to eq(@known_consts)
+    expect(described_class.constants.collect.sort).to eq(@known_consts)
   end
 
   describe '#to_time' do
     it 'converts each constant to a Time' do
-      m = TimeConsts
+      m = described_class
       m.constants.each do |c|
         expect(m.const_get(c).to_time).to be_a(Time)
       end
     end
   end
-end
 
-describe '#from_relative_time' do
-  it 'cannot handle arbitrary objects' do
-    expect { TimeConsts.from_relative_time(Object.new) }.to raise_error
-  end
-
-  it 'preserves TimeConsts' do
-    m = TimeConsts
-    m.constants.each do |c|
-      const = m.const_get(c)
-      expect(TimeConsts.from_relative_time(const)).to be(const)
+  describe '#from_relative_time' do
+    it 'cannot handle arbitrary objects' do
+      expect { described_class.from_relative_time(Object.new) }.to raise_error
     end
-  end
 
-  it 'converts 0 to TimeConsts::ZERO' do
-    expect(TimeConsts.from_relative_time(0)).to eq(TimeConsts::ZERO)
-  end
-
-  it 'converts nil to TimeConsts::ZERO' do
-    expect(TimeConsts.from_relative_time(nil)).to eq(TimeConsts::ZERO)
-  end
-
-  it 'converts negative values to TimeConsts::INFINITE_FUTURE' do
-    [-1, -3.2, -1e6].each do |t|
-      y = TimeConsts.from_relative_time(t)
-      expect(y).to eq(TimeConsts::INFINITE_FUTURE)
+    it 'preserves TimeConsts' do
+      m = described_class
+      m.constants.each do |c|
+        const = m.const_get(c)
+        expect(described_class.from_relative_time(const)).to be(const)
+      end
     end
-  end
 
-  it 'converts a positive value to an absolute time' do
-    epsilon = 1
-    [1, 3.2, 1e6].each do |t|
-      want = Time.now + t
-      abs = TimeConsts.from_relative_time(t)
-      expect(abs.to_f).to be_within(epsilon).of(want.to_f)
+    it 'converts 0 to described_class::ZERO' do
+      expect(described_class.from_relative_time(0)).to eq(described_class::ZERO)
+    end
+
+    it 'converts nil to TimeConsts::ZERO' do
+      expect(described_class.from_relative_time(nil)).to eq(described_class::ZERO)
+    end
+
+    it 'converts negative values to TimeConsts::INFINITE_FUTURE' do
+      [-1, -3.2, -1e6].each do |t|
+        y = described_class.from_relative_time(t)
+        expect(y).to eq(described_class::INFINITE_FUTURE)
+      end
+    end
+
+    it 'converts a positive value to an absolute time' do
+      epsilon = 1
+      [1, 3.2, 1e6].each do |t|
+        want = Time.now + t
+        abs = described_class.from_relative_time(t)
+        expect(abs.to_f).to be_within(epsilon).of(want.to_f)
+      end
     end
   end
 end


### PR DESCRIPTION
Suppress noisy output when running specs. 
And I changed only one production [code](https://github.com/ganmacs/grpc/blob/441f8729170973f1f11fb88f1392c2365dcf3018/src/ruby/lib/grpc/generic/rpc_server.rb#L28).
I think a better error raised at this code is TypeError because in [spec](https://github.com/grpc/grpc/blob/9fcfbb07bd5a7303cc23893268c40f65d249c340/src/ruby/spec/generic/rpc_server_pool_spec.rb#L26), `Pool.new` received `Object.new` then raised NoMethodError (undefined method `>' for #<Object:0x007fd8fa073d68> (NoMethodError)). 