### PR TITLE
Compile tests on windows with /maxcpucount switch

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1590,9 +1590,15 @@ def make_jobspec(cfg, targets, makefile='Makefile'):
         return [
             jobset.JobSpec(
                 [
-                    'cmake', '--build', '.', '--target',
-                    '%s' % target, '--config', _MSBUILD_CONFIG[cfg],
-                    '--', '/maxcpucount:%d' % args.jobs,
+                    'cmake',
+                    '--build',
+                    '.',
+                    '--target',
+                    '%s' % target,
+                    '--config',
+                    _MSBUILD_CONFIG[cfg],
+                    '--',
+                    '/maxcpucount:%d' % args.jobs,
                 ],
                 cwd=os.path.dirname(makefile),
                 timeout_seconds=None) for target in targets

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1591,7 +1591,8 @@ def make_jobspec(cfg, targets, makefile='Makefile'):
             jobset.JobSpec(
                 [
                     'cmake', '--build', '.', '--target',
-                    '%s' % target, '--config', _MSBUILD_CONFIG[cfg]
+                    '%s' % target, '--config', _MSBUILD_CONFIG[cfg],
+                    '--', '/maxcpucount:%d' % args.jobs,
                 ],
                 cwd=os.path.dirname(makefile),
                 timeout_seconds=None) for target in targets

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1597,8 +1597,8 @@ def make_jobspec(cfg, targets, makefile='Makefile'):
                     '%s' % target,
                     '--config',
                     _MSBUILD_CONFIG[cfg],
-                    '--',
-                    '/maxcpucount:%d' % args.jobs,
+                    '--parallel',
+                    args.jobs,
                 ],
                 cwd=os.path.dirname(makefile),
                 timeout_seconds=None) for target in targets

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1598,7 +1598,7 @@ def make_jobspec(cfg, targets, makefile='Makefile'):
                     '--config',
                     _MSBUILD_CONFIG[cfg],
                     '--parallel',
-                    args.jobs,
+                    str(args.jobs),
                 ],
                 cwd=os.path.dirname(makefile),
                 timeout_seconds=None) for target in targets


### PR DESCRIPTION
This is just an idea. I've used this to speed up compilation when running tests on windows locally/manually, but I'm not sure if there concerns about increasing CPU.