### PR TITLE
EchoMsg is defined in spec/support/services.rb

### DIFF
--- a/src/ruby/spec/client_auth_spec.rb
+++ b/src/ruby/spec/client_auth_spec.rb
@@ -39,17 +39,6 @@ def create_server_creds
     true) # force client auth
 end
 
-# A test message
-class EchoMsg
-  def self.marshal(_o)
-    ''
-  end
-
-  def self.unmarshal(_o)
-    EchoMsg.new
-  end
-end
-
 # a test service that checks the cert of its peer
 class SslTestService
   include GRPC::GenericService

--- a/src/ruby/spec/google_rpc_status_utils_spec.rb
+++ b/src/ruby/spec/google_rpc_status_utils_spec.rb
@@ -114,17 +114,6 @@ describe 'conversion from a status struct to a google protobuf status' do
   end
 end
 
-# Test message
-class EchoMsg
-  def self.marshal(_o)
-    ''
-  end
-
-  def self.unmarshal(_o)
-    EchoMsg.new
-  end
-end
-
 # A test service that fills in the "reserved" grpc-status-details-bin trailer,
 # for client-side testing of GoogleRpcStatus protobuf extraction from trailers.
 class GoogleRpcStatusTestService


### PR DESCRIPTION
Remove duplicated Definition.
https://github.com/grpc/grpc/blob/01cbab60f3602d353a73d139204fd0f5058a5c4a/src/ruby/spec/support/services.rb#L19