### PR TITLE
remove FALLTHROUGH warning in latest clang.

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -518,4 +518,18 @@ typedef unsigned __int64 uint64_t;
 #define __STDC_FORMAT_MACROS
 #endif
 
+#if defined(__clang__) && defined(__has_cpp_attribute) \
+    && !defined(GOOGLE_PROTOBUF_OS_APPLE)
+# if defined(GOOGLE_PROTOBUF_OS_NACL) || defined(EMSCRIPTEN) || \
+     __has_cpp_attribute(clang::fallthrough)
+#  define GOOGLE_FALLTHROUGH_INTENDED [[clang::fallthrough]]
+# endif
+#elif defined(__GNUC__) && __GNUC__ > 6
+# define GOOGLE_FALLTHROUGH_INTENDED [[gnu::fallthrough]]
+#endif
+
+#ifndef GOOGLE_FALLTHROUGH_INTENDED
+# define GOOGLE_FALLTHROUGH_INTENDED
+#endif
+
 #endif /* GRPC_IMPL_CODEGEN_PORT_PLATFORM_H */

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1487,7 +1487,7 @@ void GrpcLb::OnBalancerChannelConnectivityChangedLocked(void* arg,
         grpclb_policy->lb_call_backoff_.Reset();
         grpclb_policy->StartBalancerCallLocked();
       }
-      // Fall through.
+      GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_CHANNEL_SHUTDOWN:
     done:
       grpclb_policy->watching_lb_channel_ = false;

--- a/src/core/ext/transport/chttp2/transport/bin_decoder.cc
+++ b/src/core/ext/transport/chttp2/transport/bin_decoder.cc
@@ -147,6 +147,7 @@ bool grpc_base64_decode_partial(struct grpc_base64_decode_context* ctx) {
         case 3:
           ctx->output_cur[1] = COMPOSE_OUTPUT_BYTE_1(ctx->input_cur);
         /* fallthrough */
+        GOOGLE_FALLTHROUGH_INTENDED;
         case 2:
           ctx->output_cur[0] = COMPOSE_OUTPUT_BYTE_0(ctx->input_cur);
       }

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2374,6 +2374,7 @@ static void WithUrgency(grpc_chttp2_transport* t,
     case grpc_core::chttp2::FlowControlAction::Urgency::UPDATE_IMMEDIATELY:
       grpc_chttp2_initiate_write(t, reason);
     // fallthrough
+    GOOGLE_FALLTHROUGH_INTENDED;
     case grpc_core::chttp2::FlowControlAction::Urgency::QUEUE_UPDATE:
       action();
       break;

--- a/src/core/ext/transport/chttp2/transport/frame_data.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_data.cc
@@ -159,6 +159,7 @@ grpc_error* grpc_deframe_unprocessed_incoming_frames(
           continue;
         }
       /* fallthrough */
+      GOOGLE_FALLTHROUGH_INTENDED;
       case GRPC_CHTTP2_DATA_FH_1:
         s->stats.incoming.framing_bytes++;
         p->frame_size = (static_cast<uint32_t>(*cur)) << 24;
@@ -168,6 +169,7 @@ grpc_error* grpc_deframe_unprocessed_incoming_frames(
           continue;
         }
       /* fallthrough */
+      GOOGLE_FALLTHROUGH_INTENDED;
       case GRPC_CHTTP2_DATA_FH_2:
         s->stats.incoming.framing_bytes++;
         p->frame_size |= (static_cast<uint32_t>(*cur)) << 16;
@@ -177,6 +179,7 @@ grpc_error* grpc_deframe_unprocessed_incoming_frames(
           continue;
         }
       /* fallthrough */
+      GOOGLE_FALLTHROUGH_INTENDED;
       case GRPC_CHTTP2_DATA_FH_3:
         s->stats.incoming.framing_bytes++;
         p->frame_size |= (static_cast<uint32_t>(*cur)) << 8;
@@ -186,6 +189,7 @@ grpc_error* grpc_deframe_unprocessed_incoming_frames(
           continue;
         }
       /* fallthrough */
+      GOOGLE_FALLTHROUGH_INTENDED;
       case GRPC_CHTTP2_DATA_FH_4:
         s->stats.incoming.framing_bytes++;
         GPR_ASSERT(stream_out != nullptr);

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.cc
@@ -73,6 +73,7 @@ grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
       p->last_stream_id = (static_cast<uint32_t>(*cur)) << 24;
       ++cur;
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_CHTTP2_GOAWAY_LSI1:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_LSI1;
@@ -81,6 +82,7 @@ grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
       p->last_stream_id |= (static_cast<uint32_t>(*cur)) << 16;
       ++cur;
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_CHTTP2_GOAWAY_LSI2:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_LSI2;
@@ -89,6 +91,7 @@ grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
       p->last_stream_id |= (static_cast<uint32_t>(*cur)) << 8;
       ++cur;
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_CHTTP2_GOAWAY_LSI3:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_LSI3;
@@ -97,6 +100,7 @@ grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
       p->last_stream_id |= (static_cast<uint32_t>(*cur));
       ++cur;
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_CHTTP2_GOAWAY_ERR0:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_ERR0;
@@ -105,6 +109,7 @@ grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
       p->error_code = (static_cast<uint32_t>(*cur)) << 24;
       ++cur;
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_CHTTP2_GOAWAY_ERR1:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_ERR1;
@@ -113,6 +118,7 @@ grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
       p->error_code |= (static_cast<uint32_t>(*cur)) << 16;
       ++cur;
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_CHTTP2_GOAWAY_ERR2:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_ERR2;
@@ -121,6 +127,7 @@ grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
       p->error_code |= (static_cast<uint32_t>(*cur)) << 8;
       ++cur;
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_CHTTP2_GOAWAY_ERR3:
       if (cur == end) {
         p->state = GRPC_CHTTP2_GOAWAY_ERR3;
@@ -129,6 +136,7 @@ grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
       p->error_code |= (static_cast<uint32_t>(*cur));
       ++cur;
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_CHTTP2_GOAWAY_DEBUG:
       if (end != cur)
         memcpy(p->debug_data + p->debug_pos, cur,

--- a/src/core/ext/transport/chttp2/transport/frame_settings.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.cc
@@ -143,6 +143,7 @@ grpc_error* grpc_chttp2_settings_parser_parse(void* p, grpc_chttp2_transport* t,
         parser->id = static_cast<uint16_t>((static_cast<uint16_t>(*cur)) << 8);
         cur++;
       /* fallthrough */
+      GOOGLE_FALLTHROUGH_INTENDED;
       case GRPC_CHTTP2_SPS_ID1:
         if (cur == end) {
           parser->state = GRPC_CHTTP2_SPS_ID1;
@@ -151,6 +152,7 @@ grpc_error* grpc_chttp2_settings_parser_parse(void* p, grpc_chttp2_transport* t,
         parser->id = static_cast<uint16_t>(parser->id | (*cur));
         cur++;
       /* fallthrough */
+      GOOGLE_FALLTHROUGH_INTENDED;
       case GRPC_CHTTP2_SPS_VAL0:
         if (cur == end) {
           parser->state = GRPC_CHTTP2_SPS_VAL0;
@@ -159,6 +161,7 @@ grpc_error* grpc_chttp2_settings_parser_parse(void* p, grpc_chttp2_transport* t,
         parser->value = (static_cast<uint32_t>(*cur)) << 24;
         cur++;
       /* fallthrough */
+      GOOGLE_FALLTHROUGH_INTENDED;
       case GRPC_CHTTP2_SPS_VAL1:
         if (cur == end) {
           parser->state = GRPC_CHTTP2_SPS_VAL1;
@@ -167,6 +170,7 @@ grpc_error* grpc_chttp2_settings_parser_parse(void* p, grpc_chttp2_transport* t,
         parser->value |= (static_cast<uint32_t>(*cur)) << 16;
         cur++;
       /* fallthrough */
+      GOOGLE_FALLTHROUGH_INTENDED;
       case GRPC_CHTTP2_SPS_VAL2:
         if (cur == end) {
           parser->state = GRPC_CHTTP2_SPS_VAL2;
@@ -175,6 +179,7 @@ grpc_error* grpc_chttp2_settings_parser_parse(void* p, grpc_chttp2_transport* t,
         parser->value |= (static_cast<uint32_t>(*cur)) << 8;
         cur++;
       /* fallthrough */
+      GOOGLE_FALLTHROUGH_INTENDED;
       case GRPC_CHTTP2_SPS_VAL3:
         if (cur == end) {
           parser->state = GRPC_CHTTP2_SPS_VAL3;

--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -114,6 +114,7 @@ grpc_error* grpc_chttp2_perform_read(grpc_chttp2_transport* t,
         return GRPC_ERROR_NONE;
       }
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_1:
       GPR_ASSERT(cur < end);
       t->incoming_frame_size |= (static_cast<uint32_t>(*cur)) << 8;
@@ -122,6 +123,7 @@ grpc_error* grpc_chttp2_perform_read(grpc_chttp2_transport* t,
         return GRPC_ERROR_NONE;
       }
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_2:
       GPR_ASSERT(cur < end);
       t->incoming_frame_size |= *cur;
@@ -130,6 +132,7 @@ grpc_error* grpc_chttp2_perform_read(grpc_chttp2_transport* t,
         return GRPC_ERROR_NONE;
       }
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_3:
       GPR_ASSERT(cur < end);
       t->incoming_frame_type = *cur;
@@ -138,6 +141,7 @@ grpc_error* grpc_chttp2_perform_read(grpc_chttp2_transport* t,
         return GRPC_ERROR_NONE;
       }
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_4:
       GPR_ASSERT(cur < end);
       t->incoming_frame_flags = *cur;
@@ -146,6 +150,7 @@ grpc_error* grpc_chttp2_perform_read(grpc_chttp2_transport* t,
         return GRPC_ERROR_NONE;
       }
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_5:
       GPR_ASSERT(cur < end);
       t->incoming_stream_id = ((static_cast<uint32_t>(*cur)) & 0x7f) << 24;
@@ -154,6 +159,7 @@ grpc_error* grpc_chttp2_perform_read(grpc_chttp2_transport* t,
         return GRPC_ERROR_NONE;
       }
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_6:
       GPR_ASSERT(cur < end);
       t->incoming_stream_id |= (static_cast<uint32_t>(*cur)) << 16;
@@ -162,6 +168,7 @@ grpc_error* grpc_chttp2_perform_read(grpc_chttp2_transport* t,
         return GRPC_ERROR_NONE;
       }
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_7:
       GPR_ASSERT(cur < end);
       t->incoming_stream_id |= (static_cast<uint32_t>(*cur)) << 8;
@@ -170,6 +177,7 @@ grpc_error* grpc_chttp2_perform_read(grpc_chttp2_transport* t,
         return GRPC_ERROR_NONE;
       }
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FH_8:
       GPR_ASSERT(cur < end);
       t->incoming_stream_id |= (static_cast<uint32_t>(*cur));
@@ -206,6 +214,7 @@ grpc_error* grpc_chttp2_perform_read(grpc_chttp2_transport* t,
         return GRPC_ERROR_NONE;
       }
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case GRPC_DTS_FRAME:
       GPR_ASSERT(cur < end);
       if (static_cast<uint32_t>(end - cur) == t->incoming_frame_size) {

--- a/src/core/ext/transport/chttp2/transport/varint.cc
+++ b/src/core/ext/transport/chttp2/transport/varint.cc
@@ -40,15 +40,19 @@ void grpc_chttp2_hpack_write_varint_tail(uint32_t tail_value, uint8_t* target,
     case 5:
       target[4] = static_cast<uint8_t>((tail_value >> 28) | 0x80);
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case 4:
       target[3] = static_cast<uint8_t>((tail_value >> 21) | 0x80);
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case 3:
       target[2] = static_cast<uint8_t>((tail_value >> 14) | 0x80);
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case 2:
       target[1] = static_cast<uint8_t>((tail_value >> 7) | 0x80);
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case 1:
       target[0] = static_cast<uint8_t>((tail_value) | 0x80);
   }

--- a/src/core/lib/gpr/murmur_hash.cc
+++ b/src/core/lib/gpr/murmur_hash.cc
@@ -62,9 +62,11 @@ uint32_t gpr_murmur_hash3(const void* key, size_t len, uint32_t seed) {
     case 3:
       k1 ^= (static_cast<uint32_t>(keyptr[2])) << 16;
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case 2:
       k1 ^= (static_cast<uint32_t>(keyptr[1])) << 8;
     /* fallthrough */
+    GOOGLE_FALLTHROUGH_INTENDED;
     case 1:
       k1 ^= keyptr[0];
       k1 *= c1;

--- a/src/core/lib/iomgr/timer_manager.cc
+++ b/src/core/lib/iomgr/timer_manager.cc
@@ -236,6 +236,7 @@ static void timer_main_loop() {
         }
         next = GRPC_MILLIS_INF_FUTURE;
       /* fall through */
+      GOOGLE_FALLTHROUGH_INTENDED;
       case GRPC_TIMERS_CHECKED_AND_EMPTY:
         if (!wait_until(next)) {
           return;

--- a/src/core/lib/json/json_reader.cc
+++ b/src/core/lib/json/json_reader.cc
@@ -179,7 +179,7 @@ grpc_json_reader_status grpc_json_reader_run(grpc_json_reader* reader) {
             reader->state = GRPC_JSON_STATE_VALUE_END;
             /* The missing break here is intentional. */
             /* fallthrough */
-
+          GOOGLE_FALLTHROUGH_INTENDED;
           case GRPC_JSON_STATE_VALUE_END:
           case GRPC_JSON_STATE_OBJECT_KEY_BEGIN:
           case GRPC_JSON_STATE_VALUE_BEGIN:


### PR DESCRIPTION
Macro defined method to get rid of different versions of fallthrough pragmas in various compilers.