### PR TITLE
Use GRPC_CLOSURE_RUN in client channel if it's safe

### DIFF
--- a/src/core/ext/filters/client_channel/http_connect_handshaker.cc
+++ b/src/core/ext/filters/client_channel/http_connect_handshaker.cc
@@ -116,7 +116,7 @@ static void handshake_failed_locked(http_connect_handshaker* handshaker,
     handshaker->shutdown = true;
   }
   // Invoke callback.
-  GRPC_CLOSURE_SCHED(handshaker->on_handshake_done, error);
+  GRPC_CLOSURE_RUN(handshaker->on_handshake_done, error);
 }
 
 // Callback invoked when finished writing HTTP CONNECT request.
@@ -214,7 +214,7 @@ static void on_read_done(void* arg, grpc_error* error) {
     goto done;
   }
   // Success.  Invoke handshake-done callback.
-  GRPC_CLOSURE_SCHED(handshaker->on_handshake_done, error);
+  GRPC_CLOSURE_RUN(handshaker->on_handshake_done, error);
 done:
   // Set shutdown to true so that subsequent calls to
   // http_connect_handshaker_shutdown() do nothing.

--- a/src/core/ext/filters/client_channel/lb_policy.cc
+++ b/src/core/ext/filters/client_channel/lb_policy.cc
@@ -41,7 +41,7 @@ LoadBalancingPolicy::~LoadBalancingPolicy() {
 void LoadBalancingPolicy::TryReresolutionLocked(
     grpc_core::TraceFlag* grpc_lb_trace, grpc_error* error) {
   if (request_reresolution_ != nullptr) {
-    GRPC_CLOSURE_SCHED(request_reresolution_, error);
+    GRPC_CLOSURE_RUN(request_reresolution_, error);
     request_reresolution_ = nullptr;
     if (grpc_lb_trace->enabled()) {
       gpr_log(GPR_INFO,

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1549,7 +1549,7 @@ void GrpcLb::PendingPickSetMetadataAndContext(PendingPick* pp) {
 void GrpcLb::OnPendingPickComplete(void* arg, grpc_error* error) {
   PendingPick* pp = static_cast<PendingPick*>(arg);
   PendingPickSetMetadataAndContext(pp);
-  GRPC_CLOSURE_SCHED(pp->original_on_complete, GRPC_ERROR_REF(error));
+  GRPC_CLOSURE_RUN(pp->original_on_complete, GRPC_ERROR_REF(error));
   Delete(pp);
 }
 

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1549,8 +1549,9 @@ void GrpcLb::PendingPickSetMetadataAndContext(PendingPick* pp) {
 void GrpcLb::OnPendingPickComplete(void* arg, grpc_error* error) {
   PendingPick* pp = static_cast<PendingPick*>(arg);
   PendingPickSetMetadataAndContext(pp);
-  // We can run the original closure safely here because it is run in the same
-  // combiner as the wrapper closure.
+  // We can use GRPC_CLOSURE_RUN() instead of GRPC_CLOSURE_SCHED() safely here
+  // because the original closure and the wrapper closure are run in the same
+  // combiner.
   GRPC_CLOSURE_RUN(pp->original_on_complete, GRPC_ERROR_REF(error));
   Delete(pp);
 }

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1111,7 +1111,7 @@ void GrpcLb::ShutdownLocked() {
     pending_picks_ = pp->next;
     pp->pick->connected_subchannel.reset();
     // Note: pp is deleted in this callback.
-    GRPC_CLOSURE_SCHED(&pp->on_complete, GRPC_ERROR_REF(error));
+    GRPC_CLOSURE_RUN(&pp->on_complete, GRPC_ERROR_REF(error));
   }
   // Clear pending pings.
   PendingPing* pping;
@@ -1136,7 +1136,7 @@ void GrpcLb::HandOffPendingPicksLocked(LoadBalancingPolicy* new_policy) {
     pp->pick->user_data = nullptr;
     if (new_policy->PickLocked(pp->pick)) {
       // Synchronous return; schedule closure.
-      GRPC_CLOSURE_SCHED(pp->pick->on_complete, GRPC_ERROR_NONE);
+      GRPC_CLOSURE_RUN(pp->pick->on_complete, GRPC_ERROR_NONE);
     }
     Delete(pp);
   }
@@ -1161,9 +1161,9 @@ void GrpcLb::CancelPickLocked(PickState* pick, grpc_error* error) {
     if (pp->pick == pick) {
       pick->connected_subchannel.reset();
       // Note: pp is deleted in this callback.
-      GRPC_CLOSURE_SCHED(&pp->on_complete,
-                         GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                             "Pick Cancelled", &error, 1));
+      GRPC_CLOSURE_RUN(&pp->on_complete,
+                       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
+                           "Pick Cancelled", &error, 1));
     } else {
       pp->next = pending_picks_;
       pending_picks_ = pp;
@@ -1197,9 +1197,9 @@ void GrpcLb::CancelMatchingPicksLocked(uint32_t initial_metadata_flags_mask,
     if ((pp->pick->initial_metadata_flags & initial_metadata_flags_mask) ==
         initial_metadata_flags_eq) {
       // Note: pp is deleted in this callback.
-      GRPC_CLOSURE_SCHED(&pp->on_complete,
-                         GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                             "Pick Cancelled", &error, 1));
+      GRPC_CLOSURE_RUN(&pp->on_complete,
+                       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
+                           "Pick Cancelled", &error, 1));
     } else {
       pp->next = pending_picks_;
       pending_picks_ = pp;
@@ -1612,7 +1612,7 @@ bool GrpcLb::PickFromRoundRobinPolicyLocked(bool force_async, PendingPick* pp) {
             server->load_balance_token);
       }
       if (force_async) {
-        GRPC_CLOSURE_SCHED(pp->original_on_complete, GRPC_ERROR_NONE);
+        GRPC_CLOSURE_RUN(pp->original_on_complete, GRPC_ERROR_NONE);
         Delete(pp);
         return false;
       }
@@ -1631,7 +1631,7 @@ bool GrpcLb::PickFromRoundRobinPolicyLocked(bool force_async, PendingPick* pp) {
   if (pick_done) {
     PendingPickSetMetadataAndContext(pp);
     if (force_async) {
-      GRPC_CLOSURE_SCHED(pp->original_on_complete, GRPC_ERROR_NONE);
+      GRPC_CLOSURE_RUN(pp->original_on_complete, GRPC_ERROR_NONE);
       pick_done = false;
     }
     Delete(pp);

--- a/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
@@ -232,8 +232,7 @@ void RoundRobin::HandOffPendingPicksLocked(LoadBalancingPolicy* new_policy) {
   while ((pick = pending_picks_) != nullptr) {
     pending_picks_ = pick->next;
     if (new_policy->PickLocked(pick)) {
-      // Synchronous return, schedule closure.
-      GRPC_CLOSURE_SCHED(pick->on_complete, GRPC_ERROR_NONE);
+      GRPC_CLOSURE_RUN(pick->on_complete, GRPC_ERROR_NONE);
     }
   }
 }
@@ -248,7 +247,7 @@ void RoundRobin::ShutdownLocked() {
   while ((pick = pending_picks_) != nullptr) {
     pending_picks_ = pick->next;
     pick->connected_subchannel.reset();
-    GRPC_CLOSURE_SCHED(pick->on_complete, GRPC_ERROR_REF(error));
+    GRPC_CLOSURE_RUN(pick->on_complete, GRPC_ERROR_REF(error));
   }
   grpc_connectivity_state_set(&state_tracker_, GRPC_CHANNEL_SHUTDOWN,
                               GRPC_ERROR_REF(error), "rr_shutdown");
@@ -265,9 +264,9 @@ void RoundRobin::CancelPickLocked(PickState* pick, grpc_error* error) {
     PickState* next = pp->next;
     if (pp == pick) {
       pick->connected_subchannel.reset();
-      GRPC_CLOSURE_SCHED(pick->on_complete,
-                         GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                             "Pick Cancelled", &error, 1));
+      GRPC_CLOSURE_RUN(pick->on_complete,
+                       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
+                           "Pick Cancelled", &error, 1));
     } else {
       pp->next = pending_picks_;
       pending_picks_ = pp;
@@ -287,9 +286,9 @@ void RoundRobin::CancelMatchingPicksLocked(uint32_t initial_metadata_flags_mask,
     if ((pick->initial_metadata_flags & initial_metadata_flags_mask) ==
         initial_metadata_flags_eq) {
       pick->connected_subchannel.reset();
-      GRPC_CLOSURE_SCHED(pick->on_complete,
-                         GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                             "Pick Cancelled", &error, 1));
+      GRPC_CLOSURE_RUN(pick->on_complete,
+                       GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
+                           "Pick Cancelled", &error, 1));
     } else {
       pick->next = pending_picks_;
       pending_picks_ = pick;
@@ -341,7 +340,7 @@ void RoundRobin::DrainPendingPicksLocked() {
   while ((pick = pending_picks_)) {
     pending_picks_ = pick->next;
     GPR_ASSERT(DoPickLocked(pick));
-    GRPC_CLOSURE_SCHED(pick->on_complete, GRPC_ERROR_NONE);
+    GRPC_CLOSURE_RUN(pick->on_complete, GRPC_ERROR_NONE);
   }
 }
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -197,8 +197,8 @@ void AresDnsResolver::ShutdownLocked() {
   }
   if (next_completion_ != nullptr) {
     *target_result_ = nullptr;
-    GRPC_CLOSURE_SCHED(next_completion_, GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                             "Resolver Shutdown"));
+    GRPC_CLOSURE_RUN(next_completion_,
+                     GRPC_ERROR_CREATE_FROM_STATIC_STRING("Resolver Shutdown"));
     next_completion_ = nullptr;
   }
 }
@@ -427,7 +427,7 @@ void AresDnsResolver::MaybeFinishNextLocked() {
                           ? nullptr
                           : grpc_channel_args_copy(resolved_result_);
     gpr_log(GPR_DEBUG, "AresDnsResolver::MaybeFinishNextLocked()");
-    GRPC_CLOSURE_SCHED(next_completion_, GRPC_ERROR_NONE);
+    GRPC_CLOSURE_RUN(next_completion_, GRPC_ERROR_NONE);
     next_completion_ = nullptr;
     published_version_ = resolved_version_;
   }

--- a/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
@@ -164,8 +164,8 @@ void NativeDnsResolver::ShutdownLocked() {
   }
   if (next_completion_ != nullptr) {
     *target_result_ = nullptr;
-    GRPC_CLOSURE_SCHED(next_completion_, GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                             "Resolver Shutdown"));
+    GRPC_CLOSURE_RUN(next_completion_,
+                     GRPC_ERROR_CREATE_FROM_STATIC_STRING("Resolver Shutdown"));
     next_completion_ = nullptr;
   }
 }
@@ -296,7 +296,7 @@ void NativeDnsResolver::MaybeFinishNextLocked() {
     *target_result_ = resolved_result_ == nullptr
                           ? nullptr
                           : grpc_channel_args_copy(resolved_result_);
-    GRPC_CLOSURE_SCHED(next_completion_, GRPC_ERROR_NONE);
+    GRPC_CLOSURE_RUN(next_completion_, GRPC_ERROR_NONE);
     next_completion_ = nullptr;
     published_version_ = resolved_version_;
   }

--- a/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
@@ -130,7 +130,7 @@ void FakeResolver::MaybeFinishNextLocked() {
                         : grpc_channel_args_union(next_results_, channel_args_);
     grpc_channel_args_destroy(next_results_);
     next_results_ = nullptr;
-    GRPC_CLOSURE_SCHED(next_completion_, GRPC_ERROR_NONE);
+    GRPC_CLOSURE_RUN(next_completion_, GRPC_ERROR_NONE);
     next_completion_ = nullptr;
     return_failure_ = false;
   }
@@ -139,8 +139,8 @@ void FakeResolver::MaybeFinishNextLocked() {
 void FakeResolver::ShutdownLocked() {
   if (next_completion_ != nullptr) {
     *target_result_ = nullptr;
-    GRPC_CLOSURE_SCHED(next_completion_, GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                             "Resolver Shutdown"));
+    GRPC_CLOSURE_RUN(next_completion_,
+                     GRPC_ERROR_CREATE_FROM_STATIC_STRING("Resolver Shutdown"));
     next_completion_ = nullptr;
   }
 }

--- a/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/sockaddr/sockaddr_resolver.cc
@@ -98,8 +98,8 @@ void SockaddrResolver::RequestReresolutionLocked() {
 void SockaddrResolver::ShutdownLocked() {
   if (next_completion_ != nullptr) {
     *target_result_ = nullptr;
-    GRPC_CLOSURE_SCHED(next_completion_, GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-                                             "Resolver Shutdown"));
+    GRPC_CLOSURE_RUN(next_completion_,
+                     GRPC_ERROR_CREATE_FROM_STATIC_STRING("Resolver Shutdown"));
     next_completion_ = nullptr;
   }
 }
@@ -109,7 +109,7 @@ void SockaddrResolver::MaybeFinishNextLocked() {
     published_ = true;
     grpc_arg arg = grpc_lb_addresses_create_channel_arg(addresses_);
     *target_result_ = grpc_channel_args_copy_and_add(channel_args_, &arg, 1);
-    GRPC_CLOSURE_SCHED(next_completion_, GRPC_ERROR_NONE);
+    GRPC_CLOSURE_RUN(next_completion_, GRPC_ERROR_NONE);
     next_completion_ = nullptr;
   }
 }


### PR DESCRIPTION
From my understanding, all the wrapper closures can directly run the original closures instead of scheduling them.