### PR TITLE
Fix test failure detection when doing RBE uploads

### DIFF
--- a/tools/run_tests/python_utils/upload_rbe_results.py
+++ b/tools/run_tests/python_utils/upload_rbe_results.py
@@ -161,7 +161,7 @@ if __name__ == "__main__":
             test_cases = action['testAction']['testSuite']['tests'][0][
                 'testSuite']['tests']
         for test_case in test_cases:
-            if 'errors' in test_case['testCase']:
+            if any(s in test_case['testCase'] for s in ['errors', 'failures']):
                 result = 'FAILED'
             elif 'timedOut' in test_case['testCase']:
                 result = 'TIMEOUT'


### PR DESCRIPTION
I tested this locally on https://source.cloud.google.com/results/invocations/f8865380-e791-4421-b428-a7add1419e40/targets and it uploaded 12 rows, 2 flakes and 5 tests failing 2/2 times. 