### PR TITLE
 GRPC::Cancelled should be occured when calling Enumrable#next on canceled call

### DIFF
--- a/src/ruby/spec/generic/client_stub_spec.rb
+++ b/src/ruby/spec/generic/client_stub_spec.rb
@@ -589,6 +589,18 @@ describe 'ClientStub' do  # rubocop:disable Metrics/BlockLength
           responses.each { |r| p r }
         end
       end
+
+      it 'raises GRPC::Cancelled after the call has been cancelled' do
+        server_port = create_test_server
+        host = "localhost:#{server_port}"
+        th = run_server_streamer(@sent_msg, @replys, @pass)
+        stub = GRPC::ClientStub.new(host, :this_channel_is_insecure)
+        resp = get_responses(stub, run_start_call_first: false)
+        expect(resp.next).to eq('reply_1')
+        @op.cancel
+        expect { resp.next }.to raise_error(GRPC::Cancelled)
+        th.join
+      end
     end
   end
 


### PR DESCRIPTION
When `Enumrable#next` is called on already canceled call, `GRPC::Cancelled` should occur instead of `GRPC::Core::CallError` like [bidi_streamer spec](https://github.com/grpc/grpc/blob/222655cab54028db55d8a24e08de26fbe84dcf8b/src/ruby/spec/generic/client_stub_spec.rb#L936) and [bidi_streamer](https://github.com/grpc/grpc/blob/master/src/ruby/lib/grpc/generic/bidi_call.rb#L134) does.
In order to achive it, `ActiveCall#each_remote_read_then_finish` surely call `receive_and_check_status` even if `GRPC::Core::CallError` occurs.

review please 🙏  @apolcyn 