### PR TITLE
Corrected formatting of json files

### DIFF
--- a/examples/csharp/route_guide/RouteGuide/route_guide_db.json
+++ b/examples/csharp/route_guide/RouteGuide/route_guide_db.json
@@ -1,4 +1,4 @@
-﻿[{
+[{
     "location": {
         "latitude": 407838351,
         "longitude": -746143763

--- a/src/csharp/doc/docfx.json
+++ b/src/csharp/doc/docfx.json
@@ -24,7 +24,7 @@
         "dest": "api"
       },
       {
-        "files": [ "toc.yml"],
+        "files": [ "toc.yml"]
       }
     ],
     "globalMetadata": {


### PR DESCRIPTION
examples/csharp/route_guide/RouteGuide/route_guide_db.json: Removed BOM
encoding. Some json parsers cannot natively open these files. There are
more portable ways to define Unicode encodings than embedded in files.

src/csharp/doc/docfx.json: Incorrect json format.