### PR TITLE
Add Python prefork handler to clean up internal threads

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/call.pyx.pxi
@@ -19,7 +19,7 @@ cdef class Call:
 
   def __cinit__(self):
     # Create an *empty* call
-    grpc_init()
+    fork_handlers_and_grpc_init()
     self.c_call = NULL
     self.references = []
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
@@ -391,7 +391,7 @@ cdef class Channel:
       self, bytes target, object arguments,
       ChannelCredentials channel_credentials):
     arguments = () if arguments is None else tuple(arguments)
-    grpc_init()
+    fork_handlers_and_grpc_init()
     self._state = _ChannelState()
     self._vtable.copy = &_copy_pointer
     self._vtable.destroy = &_destroy_pointer

--- a/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pyx.pxi
@@ -71,7 +71,7 @@ cdef class CompletionQueue:
 
   def __cinit__(self, shutdown_cq=False):
     cdef grpc_completion_queue_attributes c_attrs
-    grpc_init()
+    fork_handlers_and_grpc_init()
     if shutdown_cq:
       c_attrs.version = 1
       c_attrs.cq_completion_type = GRPC_CQ_NEXT

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -21,7 +21,7 @@ from libc.stdint cimport uintptr_t
 
 
 def _spawn_callback_in_thread(cb_func, args):
-  threading.Thread(target=cb_func, args=args).start()
+  fork_managed_thread(target=cb_func, args=args).start()
 
 async_callback_func = _spawn_callback_in_thread
 
@@ -114,7 +114,7 @@ cdef class ChannelCredentials:
 cdef class SSLSessionCacheLRU:
 
   def __cinit__(self, capacity):
-    grpc_init()
+    fork_handlers_and_grpc_init()
     self._cache = grpc_ssl_session_cache_create_lru(capacity)
 
   def __int__(self):
@@ -172,7 +172,7 @@ cdef class CompositeChannelCredentials(ChannelCredentials):
 cdef class ServerCertificateConfig:
 
   def __cinit__(self):
-    grpc_init()
+    fork_handlers_and_grpc_init()
     self.c_cert_config = NULL
     self.c_pem_root_certs = NULL
     self.c_ssl_pem_key_cert_pairs = NULL
@@ -187,7 +187,7 @@ cdef class ServerCertificateConfig:
 cdef class ServerCredentials:
 
   def __cinit__(self):
-    grpc_init()
+    fork_handlers_and_grpc_init()
     self.c_credentials = NULL
     self.references = []
     self.initial_cert_config = None

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pxd.pxi
@@ -1,0 +1,27 @@
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# TODO(ericgribkoff) Build on Windows
+cdef extern from "pthread.h" nogil:
+    int pthread_atfork(
+        void (*prepare)() nogil,
+        void (*parent)() nogil,
+        void (*child)() nogil)
+
+
+cdef void __prefork() nogil
+
+
+cdef void __postfork() nogil

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
@@ -1,0 +1,128 @@
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+import os
+import threading
+
+_LOGGER = logging.getLogger(__name__)
+
+_AWAIT_THREADS_TIMEOUT_SECONDS = 5
+
+_TRUE_VALUES = ['y', 'yes', 't', 'true', 'on', '1']
+
+# This flag enables experimental support within gRPC Python for applications
+# that will fork() without exec(). When enabled, gRPC Python will attempt to
+# halt all of its internally created threads before the fork syscall proceeds.
+#
+# For this to be successful, the application must not have any ongoing RPCs, and
+# any callbacks from gRPC Python into user code must not block and must execute 
+# quickly (they will be from a gRPC-created thread that must terminate before 
+# the fork syscall proceeds).
+#
+# Similarly, the application should not have multiple threads of its own running
+# when fork is invoked. This means that fork must not be invoked in response to
+# a gRPC Python initiated callback for an asynchronous RPC, as this means that
+# at least two threads are active: the application'ss main thread and the thread
+# executing the callback.
+#
+# Channel connectivity subscriptions will be unsubscribed when forking, as gRPC
+# Python must shut down the thread it uses to poll for channel updates.
+#
+# The gRPC C++ core library requires additional changes to support fork that are
+# in progress. Until this work is complete, combining gRPC Python and fork may
+# still result in failed RPCs due to shared connections between the child and
+# parent process, even with the GRPC_PYTHON_EXPERIMENTAL_FORK_SUPPORT flag
+# enabled.
+#
+# This flag is not supported on Windows.
+_EXPERIMENTAL_FORK_SUPPORT_ENABLED = (
+    os.environ.get('GRPC_PYTHON_EXPERIMENTAL_FORK_SUPPORT', '0')
+        .lower() in _TRUE_VALUES)
+
+cdef void __prefork() nogil:
+    with gil:
+        with _fork_state.fork_in_progress_lock:
+            _fork_state.fork_in_progress = True
+        if not _fork_state.thread_count.await_zero_threads(
+                _AWAIT_THREADS_TIMEOUT_SECONDS):
+            _LOGGER.exception(
+                'Failed to shutdown gRPC Python threads prior to fork. '
+                'Behavior after fork will be undefined.')
+
+
+cdef void __postfork() nogil:
+    with gil:
+        with _fork_state.fork_in_progress_lock:
+            _fork_state.fork_in_progress = False
+
+
+def fork_handlers_and_grpc_init():
+    grpc_init()
+    if _EXPERIMENTAL_FORK_SUPPORT_ENABLED:
+        with _fork_state.fork_handler_registered_lock:
+            if not _fork_state.fork_handler_registered:
+                pthread_atfork(&__prefork, &__postfork, &__postfork)
+                _fork_state.fork_handler_registered = True
+
+
+def fork_managed_thread(target, args=()):
+    if _EXPERIMENTAL_FORK_SUPPORT_ENABLED:
+        def managed_target(*args):
+            _fork_state.thread_count.increment()
+            target(*args)
+            _fork_state.thread_count.decrement()
+        return threading.Thread(target=managed_target, args=args)
+    else:
+        return threading.Thread(target=target, args=args)
+
+
+def is_fork_in_progress():
+    with _fork_state.fork_in_progress_lock:
+        return _fork_state.fork_in_progress
+
+
+class _ThreadCount(object):
+    def __init__(self):
+        self._num_threads = 0
+        self._condition = threading.Condition()
+
+    def increment(self):
+        with self._condition:
+            self._num_threads += 1
+
+    def decrement(self):
+        with self._condition:
+            self._num_threads -= 1
+            if self._num_threads == 0:
+                self._condition.notify_all()
+
+    def await_zero_threads(self, timeout_secs):
+        with self._condition:
+            if self._num_threads > 0:
+                self._condition.wait(timeout_secs)
+            return self._num_threads == 0
+
+
+class _ForkState(object):
+    def __init__(self):
+        self.fork_in_progress_lock = threading.Lock()
+        self.fork_in_progress = False
+        self.fork_handler_registered_lock = threading.Lock()
+        self.fork_handler_registered = False
+        self.thread_count = _ThreadCount()
+
+
+_fork_state = _ForkState()

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_windows.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_windows.pyx.pxi
@@ -1,0 +1,29 @@
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import threading
+
+# No-op implementations for Windows.
+
+def fork_handlers_and_grpc_init():
+    grpc_init()
+
+
+def fork_managed_thread(target, args=()):
+    return threading.Thread(target=target, args=args)
+
+
+def is_fork_in_progress():
+    return False

--- a/src/python/grpcio/grpc/_cython/_cygrpc/records.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/records.pyx.pxi
@@ -127,7 +127,7 @@ class CompressionLevel:
 cdef class CallDetails:
 
   def __cinit__(self):
-    grpc_init()
+    fork_handlers_and_grpc_init()
     with nogil:
       grpc_call_details_init(&self.c_details)
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
@@ -60,7 +60,7 @@ cdef grpc_ssl_certificate_config_reload_status _server_cert_config_fetcher_wrapp
 cdef class Server:
 
   def __cinit__(self, object arguments):
-    grpc_init()
+    fork_handlers_and_grpc_init()
     self.references = []
     self.registered_completion_queues = []
     self._vtable.copy = &_copy_pointer

--- a/src/python/grpcio/grpc/_cython/cygrpc.pxd
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pxd
@@ -30,3 +30,6 @@ include "_cygrpc/tag.pxd.pxi"
 include "_cygrpc/time.pxd.pxi"
 
 include "_cygrpc/grpc_gevent.pxd.pxi"
+
+IF UNAME_SYSNAME != "Windows":
+    include "_cygrpc/fork_posix.pxd.pxi"

--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
@@ -38,6 +38,11 @@ include "_cygrpc/time.pyx.pxi"
 
 include "_cygrpc/grpc_gevent.pyx.pxi"
 
+IF UNAME_SYSNAME == "Windows":
+    include "_cygrpc/fork_windows.pyx.pxi"
+ELSE:
+    include "_cygrpc/fork_posix.pyx.pxi"
+
 #
 # initialize gRPC
 #


### PR DESCRIPTION
This PR is part 1 of supporting client-side fork with potentially open connections but no active RPCs.

On the client side, gRPC Python spawns its own threads for:

1. Client-streaming request generation (calling into user-provided code to generate requests)
2. Channel connectivity subscriptions (polling core)
3. Asynchronous calls (channel spin thread)
4. Auth credentials refresh

These threads need to be finished before fork can be done safely. This PR adds mechanisms to:

- Monitor the number of threads spawned by the gRPC client library, and
- Installs a pre-fork handler that waits for this thread count to go to zero (or a timeout occurs) before fork proceeds

Some of these threads may be calling into user-provided code, in which case the best we can do is wait for them to complete. In the channel connectivity subscription case, we are typically not in a user-callback and instead are polling core for updates. The fork handler in this PR will cause this polling loop to short circuit to terminate the thread early and allow fork to proceed. The other threads that are potentially in user-code are simply awaited.

The feature is hidden behind a environment flag (GRPC_PYTHON_EXPERIMENTAL_FORK_SUPPORT) that can be unified with the similar flag in core at a future date. Dropping the flag altogether would be desirable from a usability standpoint, but we don't want to introduce unnecessary latency (waiting for threads to complete) in the recommended fork+exec case.

Supporting fork without active RPCs also requires changes to core's fork handler, to prevent open connections being shared across parent and child processes. This will be a separate PR. But the changes here should be sufficient, from the Python layer's point-of-view, for supporting fork with no active RPCs.