### PR TITLE
Add copts to grpc_cc_(library|test|binary)

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -60,10 +60,9 @@ def _maybe_update_cc_library_hdrs(hdrs):
 def grpc_cc_library(name, srcs = [], public_hdrs = [], hdrs = [],
                     external_deps = [], deps = [], standalone = False,
                     language = "C++", testonly = False, visibility = None,
-                    alwayslink = 0, data = []):
-  copts = []
+                    alwayslink = 0, data = [], copts = []):
   if language.upper() == "C":
-    copts = if_not_windows(["-std=c99"])
+    copts += if_not_windows(["-std=c99"])
   native.cc_library(
     name = name,
     srcs = srcs,
@@ -109,10 +108,9 @@ def grpc_proto_library(name, srcs = [], deps = [], well_known_protos = False,
     generate_mocks = generate_mocks,
   )
 
-def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data = [], uses_polling = True, language = "C++", size = "medium", timeout = "moderate", tags = []):
-  copts = []
+def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data = [], uses_polling = True, language = "C++", size = "medium", timeout = "moderate", tags = [], copts = []):
   if language.upper() == "C":
-    copts = if_not_windows(["-std=c99"])
+    copts += if_not_windows(["-std=c99"])
   args = {
     'name': name,
     'srcs': srcs,
@@ -144,10 +142,9 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
   else:
     native.cc_test(**args)
 
-def grpc_cc_binary(name, srcs = [], deps = [], external_deps = [], args = [], data = [], language = "C++", testonly = False, linkshared = False, linkopts = []):
-  copts = []
+def grpc_cc_binary(name, srcs = [], deps = [], external_deps = [], args = [], data = [], language = "C++", testonly = False, linkshared = False, linkopts = [], copts = []):
   if language.upper() == "C":
-    copts = ["-std=c99"]
+    copts += ["-std=c99"]
   native.cc_binary(
     name = name,
     srcs = srcs,


### PR DESCRIPTION
# What
Allow specifying `copts` in the internal `grpc_cc_*` rules.

# Why (updated)
This repo does not work as an external dependency with a bazel `CROSSTOOL` which specifies `-Werror` and `-Weverything`.

The standard thing to do is to use the [`new_http_archive`](https://docs.bazel.build/versions/master/be/workspace.html#new_http_archive)'s `build_file` parameter to override the `BUILD` file of the imported repo. The overriding `BUILD` file would generally be a copy of the external repo's `BUILD` file which is altered in such a way that it suppresses all warnings.

If the grpc repo would expose the [`grpc`](https://github.com/grpc/grpc/blob/master/BUILD#L284) target as a `cc_library` this would consist of adding `copts = ["-w"]` to this target.

Since the grpc repo uses custom rule, `grpc_cc_library`, this non-trivial. Adding `copts` to this rule makes the above-described process _much_ easier.

# How
Moving the first line of each `grpc_cc_*` rule (i.e. `copts = []`) into the parameters list, so it can be overridden.