### PR TITLE
Ensure gRPC is initialized for client/server context

### DIFF
--- a/include/grpcpp/impl/codegen/client_context.h
+++ b/include/grpcpp/impl/codegen/client_context.h
@@ -44,6 +44,7 @@
 #include <grpcpp/impl/codegen/config.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/codegen/create_auth_context.h>
+#include <grpcpp/impl/codegen/grpc_library.h>
 #include <grpcpp/impl/codegen/metadata_map.h>
 #include <grpcpp/impl/codegen/security/auth_context.h>
 #include <grpcpp/impl/codegen/slice.h>
@@ -159,7 +160,7 @@ class InteropClientContextInspector;
 /// (see \a grpc::CreateCustomChannel).
 ///
 /// \warning ClientContext instances should \em not be reused across rpcs.
-class ClientContext {
+class ClientContext : private GrpcLibraryCodegen {
  public:
   ClientContext();
   ~ClientContext();

--- a/include/grpcpp/impl/codegen/server_context.h
+++ b/include/grpcpp/impl/codegen/server_context.h
@@ -29,6 +29,7 @@
 #include <grpcpp/impl/codegen/completion_queue_tag.h>
 #include <grpcpp/impl/codegen/config.h>
 #include <grpcpp/impl/codegen/create_auth_context.h>
+#include <grpcpp/impl/codegen/grpc_library.h>
 #include <grpcpp/impl/codegen/metadata_map.h>
 #include <grpcpp/impl/codegen/security/auth_context.h>
 #include <grpcpp/impl/codegen/string_ref.h>
@@ -93,7 +94,7 @@ class ServerContextTestSpouse;
 /// to a \a grpc::ServerBuilder, via \a ServerBuilder::AddChannelArgument.
 ///
 /// \warning ServerContext instances should \em not be reused across rpcs.
-class ServerContext {
+class ServerContext : private GrpcLibraryCodegen {
  public:
   ServerContext();  // for async calls
   ~ServerContext();


### PR DESCRIPTION
```ClientContext```/```ServerContext``` make c-core calls when they are created/destroyed, so we need to make sure grpc is initialized before these objects are created/destroyed.