### PR TITLE
Disable Channelz connectivity_state Query for Now

### DIFF
--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -113,7 +113,10 @@ grpc_connectivity_state ChannelNode::GetConnectivityState() {
   if (channel_ == nullptr) {
     return GRPC_CHANNEL_SHUTDOWN;
   } else {
-    return grpc_channel_check_connectivity_state(channel_, false);
+    // TODO(ncteisen): re-enable this once we have cleaned up all of the
+    // internal dependency issues.
+    // return grpc_channel_check_connectivity_state(channel_, false);
+    return GRPC_CHANNEL_IDLE;
   }
 }
 


### PR DESCRIPTION
This is causing a low priority internal build failure. The right fix is a cleanup of how teams depend on gRPC internally. That will take some time, so we should disable this for now.

This is ok since this is a default-off feature that no one is using yet