### PR TITLE
timer manager: don't turn off threading in start_threads()

### DIFF
--- a/src/core/lib/iomgr/timer_manager.cc
+++ b/src/core/lib/iomgr/timer_manager.cc
@@ -277,7 +277,6 @@ static void start_threads(void) {
     g_threaded = true;
     start_timer_thread_and_unlock();
   } else {
-    g_threaded = false;
     gpr_mu_unlock(&g_mu);
   }
 }


### PR DESCRIPTION
This code doesn't appear to be executed currently, as no code path will invoke `start_threads()` with threading already enabled (`g_threaded=true`), but there seems to be no reason to ever turn off threading within the `start_threads()` method. As-is, two consecutive calls to `grpc_timer_manager_set_threading(threaded=true)` will actually turn off threading, which is counter-intuitive and (perhaps?) unintentional.