### PR TITLE
Don't segfault when product name from BIOS is empty

### DIFF
--- a/src/core/lib/security/credentials/alts/check_gcp_environment_linux.cc
+++ b/src/core/lib/security/credentials/alts/check_gcp_environment_linux.cc
@@ -41,8 +41,9 @@ namespace internal {
 
 bool check_bios_data(const char* bios_data_file) {
   char* bios_data = read_bios_file(bios_data_file);
-  bool result = (!strcmp(bios_data, GRPC_ALTS_EXPECT_NAME_GOOGLE)) ||
-                (!strcmp(bios_data, GRPC_ALTS_EXPECT_NAME_GCE));
+  bool result = bios_data &&
+                ((!strcmp(bios_data, GRPC_ALTS_EXPECT_NAME_GOOGLE)) ||
+                 (!strcmp(bios_data, GRPC_ALTS_EXPECT_NAME_GCE)));
   gpr_free(bios_data);
   return result;
 }


### PR DESCRIPTION
Somehow some Dell servers we're trying to run a gRPC client on have an empty product name in the BIOS. When gRPC tries to create default credentials, it checks whether it's running on GCE by strcmp()ing the contents of /sys/class/dmi/id/product_name to some magic strings. When it reads that file, it gets only a newline; in trim() it skips over the newline in both directions, and since end < start it returns nullptr. This causes a segfault in the strcmp() call. Since a machine without a product name clearly isn't GCE, change it to return false instead.