### PR TITLE
tcp_posix.cc: adhere to IOV_MAX in tcp_flush

### DIFF
--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -26,6 +26,7 @@
 #include "src/core/lib/iomgr/tcp_posix.h"
 
 #include <errno.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -513,7 +514,11 @@ static void tcp_read(grpc_endpoint* ep, grpc_slice_buffer* incoming_buffer,
 }
 
 /* returns true if done, false if pending; if returning true, *error is set */
+#if defined(IOV_MAX) && IOV_MAX < 1000
+#define MAX_WRITE_IOVEC IOV_MAX
+#else
 #define MAX_WRITE_IOVEC 1000
+#endif
 static bool tcp_flush(grpc_tcp* tcp, grpc_error** error) {
   struct msghdr msg;
   struct iovec iov[MAX_WRITE_IOVEC];


### PR DESCRIPTION
`tcp_posix.cc` defines a constant `MAX_WRITE_IOVEC` equal to 1000. This value works fine on Linux, but some other Unix platforms (in particular, Solaris) have a lower maximum.

This PR aims to fix this by using the standard `IOV_MAX` value defined in `limits.h` instead of an arbitrary constant. Per #7575, it's capped to a maximum of 1000 to ensure the stack frame doesn't get too large.