### PR TITLE
Include port_platform in gcp_environment tests.

### DIFF
--- a/test/core/security/check_gcp_environment_linux_test.cc
+++ b/test/core/security/check_gcp_environment_linux_test.cc
@@ -16,6 +16,8 @@
  *
  */
 
+#include <grpc/support/port_platform.h>
+
 #include "src/core/lib/security/credentials/alts/check_gcp_environment.h"
 
 #if GPR_LINUX

--- a/test/core/security/check_gcp_environment_windows_test.cc
+++ b/test/core/security/check_gcp_environment_windows_test.cc
@@ -16,6 +16,8 @@
  *
  */
 
+#include <grpc/support/port_platform.h>
+
 #include "src/core/lib/security/credentials/alts/check_gcp_environment.h"
 
 #ifdef GPR_WINDOWS


### PR DESCRIPTION
Both the Windows and Linux tests use platform-specific macros to
determine whether they should execute, but they weren't including the
file where those macros were defined, so they were always running the
else case of that check, which meant they weren't testing anything.

(This is why I was having trouble making a repro for #15888.)