### PR TITLE
Install Python3.7 on Windows and MacOS

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -67,6 +67,10 @@ pip install virtualenv --user python
 pip install -U Mako six tox setuptools twisted pyyaml --user python
 export PYTHONPATH=/Library/Python/3.4/site-packages
 
+# Install Python 3.7
+curl -O https://www.python.org/ftp/python/3.7.0/python-3.7.0-macosx10.9.pkg
+sudo installer -pkg ./python-3.7.0-macosx10.9.pkg -target /
+
 # set xcode version for Obj-C tests
 sudo xcode-select -switch /Applications/Xcode_9.2.app/Contents/Developer/
 

--- a/tools/internal_ci/helper_scripts/prepare_build_windows.bat
+++ b/tools/internal_ci/helper_scripts/prepare_build_windows.bat
@@ -14,7 +14,7 @@
 
 @rem make sure msys binaries are preferred over cygwin binaries
 @rem set path to python 2.7
-set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%
+set PATH=C:\tools\msys64\usr\bin;C:\Python27;C:\Python37;%PATH%
 
 @rem If this is a PR using RUN_TESTS_FLAGS var, then add flags to filter tests
 if defined KOKORO_GITHUB_PULL_REQUEST_NUMBER if defined RUN_TESTS_FLAGS (
@@ -33,6 +33,9 @@ netsh interface ip add dnsservers "Local Area Connection 8" 8.8.4.4 index=3
 
 @rem Needed for big_query_utils
 python -m pip install google-api-python-client
+
+@rem Install Python 3.7
+chocolatey install -y -r python3 --version 3.7
 
 @rem Disable some unwanted dotnet options
 set NUGET_XMLDOC_MODE=skip


### PR DESCRIPTION
We need Python 3.7 installed for building artifacts.