### PR TITLE
Reorder steps in ServerBuilder::BuildAndStart()

### DIFF
--- a/include/grpcpp/impl/server_builder_plugin.h
+++ b/include/grpcpp/impl/server_builder_plugin.h
@@ -37,8 +37,9 @@ class ServerBuilderPlugin {
   virtual ~ServerBuilderPlugin() {}
   virtual grpc::string name() = 0;
 
-  /// UpdateServerBuilder will be called at the beginning of
-  /// \a ServerBuilder::BuildAndStart().
+  /// UpdateServerBuilder will be called at an early stage in
+  /// ServerBuilder::BuildAndStart(), right after the ServerBuilderOptions have
+  /// done their updates.
   virtual void UpdateServerBuilder(ServerBuilder* builder) {}
 
   /// InitServer will be called in ServerBuilder::BuildAndStart(), after the

--- a/src/cpp/server/server_builder.cc
+++ b/src/cpp/server/server_builder.cc
@@ -174,10 +174,6 @@ ServerBuilder& ServerBuilder::AddListeningPort(
 }
 
 std::unique_ptr<Server> ServerBuilder::BuildAndStart() {
-  for (auto plugin = plugins_.begin(); plugin != plugins_.end(); plugin++) {
-    (*plugin)->UpdateServerBuilder(this);
-  }
-
   ChannelArguments args;
   for (auto option = options_.begin(); option != options_.end(); ++option) {
     (*option)->UpdateArguments(&args);
@@ -185,6 +181,7 @@ std::unique_ptr<Server> ServerBuilder::BuildAndStart() {
   }
 
   for (auto plugin = plugins_.begin(); plugin != plugins_.end(); plugin++) {
+    (*plugin)->UpdateServerBuilder(this);
     (*plugin)->UpdateChannelArguments(&args);
   }
 


### PR DESCRIPTION
This change is needed for cleanly enabling server load reporting. With this change, the plugins that are added by the options can also call `UpdateServerBuilder()`.

The only drawback is that the plugin can no longer add active options to the builder. But the plugin needn't add option to the builder in the first place, because its accessibility covers the options'.

My understanding is that option is a public API to allow users to add plugin. We may want to forbid the plugin from adding option to make the dependency clear.

The internal server load reporting plugin should be modified when we import this PR.