### PR TITLE
Fix Bazel build for zlib dependency

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -25,7 +25,7 @@ def grpc_deps():
 
     native.bind(
         name = "zlib",
-        actual = "@com_github_madler_zlib//:z",
+        actual = "@com_github_madler_zlib//:zlib",
     )
 
     native.bind(


### PR DESCRIPTION
Without this change, I get an error trying to build GRPC inside another Bazel repository:

```
$ bazel build @com_github_grpc_grpc//:grpc                
ERROR: /home/lyft/.cache/bazel/_bazel_lyft/6de58db54f5ebc38127e731d0c917ae1/external/com_github_grpc_grpc/bazel/grpc_deps.bzl:26:5: no such target '@com_github_madler_zlib//:z': target 'z' not declared in package '' defined by /home/lyft/.cache/bazel/_bazel_lyft/6de58db54f5ebc38127e731d0c917ae1/external/com_github_madler_zlib/BUILD.bazel and referenced by '//external:zlib'
ERROR: Analysis of target '@com_github_grpc_grpc//:grpc' failed; build aborted: Loading failed
INFO: Elapsed time: 3.474s
FAILED: Build did NOT complete successfully (5 packages loaded)
```