### PR TITLE
Fixed ordering in adding pending picks to RR

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
@@ -354,11 +354,11 @@ bool RoundRobin::PickLocked(PickState* pick) {
     if (DoPickLocked(pick)) return true;
   }
   /* no pick currently available. Save for later in list of pending picks */
+  pick->next = pending_picks_;
+  pending_picks_ = pick;
   if (!started_picking_) {
     StartPickingLocked();
   }
-  pick->next = pending_picks_;
-  pending_picks_ = pick;
   return false;
 }
 

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -546,16 +546,14 @@ TEST_F(ClientLbEnd2endTest, RoundRobinProcessPending) {
   SetNextResolution({servers_[0]->port_});
   WaitForServer(stub, 0, DEBUG_LOCATION);
   // Create a new channel and its corresponding RR LB policy, which will pick
-  // the subchannels in READY state from a the previous RPC against the same
+  // the subchannels in READY state from the previous RPC against the same
   // target (even if it happened over a different channel, because subchannels
   // are globally reused). Progress should happen without any transition from
   // this READY state.
-  {
-    auto second_channel = BuildChannel("round_robin");
-    auto second_stub = BuildStub(second_channel);
-    SetNextResolution({servers_[0]->port_});
-    CheckRpcSendOk(second_stub, DEBUG_LOCATION);
-  }
+  auto second_channel = BuildChannel("round_robin");
+  auto second_stub = BuildStub(second_channel);
+  SetNextResolution({servers_[0]->port_});
+  CheckRpcSendOk(second_stub, DEBUG_LOCATION);
 }
 
 TEST_F(ClientLbEnd2endTest, RoundRobinUpdates) {

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -539,6 +539,8 @@ TEST_F(ClientLbEnd2endTest, RoundRobin) {
   EXPECT_EQ("round_robin", channel->GetLoadBalancingPolicyName());
 }
 
+// TODO(juanlishen): Investigate getting rid of threads once
+// https://github.com/grpc/grpc/pull/15841 is in.
 TEST_F(ClientLbEnd2endTest, RoundRobinProcessPending) {
   StartServers(1);  // Single server
   auto channel = BuildChannel("round_robin");

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -551,10 +551,10 @@ TEST_F(ClientLbEnd2endTest, RoundRobinProcessPending) {
   constexpr int kNumThreads = 4;
   std::vector<std::thread> threads;
   // Create and destroy several channels concurrently, executing an RPC each
-  // time. This will force the recycling of the underlying (READY) subchannels.
-  // The RR LB policy of a newly created channel will pick these subchannels in
-  // READY state. Progress should happen without any transition from this READY
-  // state.
+  // time. The creation of new channels and their corresponding RR LB policies
+  // is the important part: new channels/RR policies will pick the subchannels
+  // in READY state (from a previous RPC against the same target). Progress
+  // should happen without any transition from this READY state.
   threads.push_back(std::thread([=]() {
     for (int i = 0; i < kNumThreads; ++i) {
       auto channel = BuildChannel("round_robin");


### PR DESCRIPTION
Otherwise we may try to drain the pending picks _before_ the pending pick has been added. 

If READY subchannels are being recycled (for instance, if channels against the same target/addresses are being created and destroyed in a loop), the RR LB policy of a new channel will pick these subchannels in READY state. However, prior to this fix, `DrainPendingPicksLocked` was called _before_ the pending pick is registered: only connectivity state _transitions_ would cause the pending picks to be reprocessed. Which is why things seemed to work, as in most cases, an LB policy (and its subchannels) would start in a state other than READY and then transition into it.

Consider (with extra logging and whitespace added for clarity):

```
I0706 13:52:28.572841742  206522 round_robin.cc:358]         [RR 0x7fdd5c004790] Trying to pick (shutdown: 0)

// The following block encompases DoPick
I0706 13:52:28.572850644  206522 round_robin.cc:362]         [RR 0x7fdd5c004790] XXX before DoPick
I0706 13:52:28.572868100  206522 round_robin.cc:555]         [RR 0x7fdd5c004790] getting next ready subchannel (out of 2), last_ready_index=18446744073709551615
I0706 13:52:28.572882302  206522 round_robin.cc:564]         [RR 0x7fdd5c004790] checking subchannel 0x7fdd5c005f90, subchannel_list 0x7fdd5c006d50, index 0: state=IDLE
I0706 13:52:28.572892832  206522 round_robin.cc:564]         [RR 0x7fdd5c004790] checking subchannel 0x7fdd5c006930, subchannel_list 0x7fdd5c006d50, index 1: state=IDLE
I0706 13:52:28.572898391  206522 round_robin.cc:582]         [RR 0x7fdd5c006d50] no subchannels in ready state
I0706 13:52:28.572923655  206522 round_robin.cc:364]         [RR 0x7fdd5c004790] XXX after DoPick


// The following encompases what happens after DoPick() has returned false,
// indiating an async pick.

I0706 13:52:28.572929421  206522 round_robin.cc:366]         [RR 0x7fdd5c004790] YYY before adding pick to pending_picks_=(nil)
I0706 13:52:28.572938257  206522 connectivity_state.cc:92]   CONWATCH: 0x7fdd5c0060b0 subchannel: get READY
I0706 13:52:28.573123261  206522 round_robin.cc:508]         [RR 0x7fdd5c004790] connectivity changed for subchannel 0x7fdd5c005f90, subchannel_list 0x7fdd5c006d50 (index 0 of 2): prev_state=IDLE new_state=READ
Y
I0706 13:52:28.573133577  206522 connectivity_state.cc:92]   CONWATCH: 0x7fdd5c006a50 subchannel: get READY
I0706 13:52:28.573141425  206522 round_robin.cc:508]         [RR 0x7fdd5c004790] connectivity changed for subchannel 0x7fdd5c006930, subchannel_list 0x7fdd5c006d50 (index 1 of 2): prev_state=IDLE new_state=READ
Y

// At this point, we try to process pending picks, but note no pending pick has
// been added yet.

I0706 13:52:28.573148090  206522 round_robin.cc:344]         [RR 0x7fdd5c004790] XXX DrainPendingPicksLocked pending_picks_=(nil) 
I0706 13:52:28.573182049  206522 connectivity_state.cc:164]  SET: 0x7fdd5c0047e8 round_robin: IDLE --> READY [rr_ready] error=(nil) "No Error"
I0706 13:52:28.573187842  206522 connectivity_state.cc:190]  NOTIFY: 0x7fdd5c0047e8 round_robin: 0x7fdd5c002ce8
I0706 13:52:28.573207063  206522 subchannel_list.h:292]      [round_robin 0x7fdd5c004790] subchannel list 0x7fdd5c006d50 index 0 of 2 (subchannel 0x7fdd5c005f90): starting watch: requesting connectivity change 
notification (from READY)
I0706 13:52:28.573250859  206522 subchannel_list.h:292]      [round_robin 0x7fdd5c004790] subchannel list 0x7fdd5c006d50 index 1 of 2 (subchannel 0x7fdd5c006930): starting watch: requesting connectivity change notification (from READY)

// It is at this point that the pending pick is registered, by the attempt to
// drain the pending picks has already happened and the policy is READY, which
// means the (pending) pick will stall until something else happens to the
// subchannels/policy (eg. disconnection).
I0706 13:52:28.573297056  206522 round_robin.cc:373]         [RR 0x7fdd5c004790] YYY after adding pick to pending_picks_=0x7fdd680266f8
```

Fixes #15892