### PR TITLE
Backport #15953 into v1.13.x (Pin cython to 0.28.3)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # GRPC Python setup requirements
 coverage>=4.0
-cython>=0.27
+cython==0.28.3
 enum34>=1.0.4
 protobuf>=3.5.0.post1
 six>=1.10


### PR DESCRIPTION
Pin cython to 0.28.3 temporarily
To fix Windows artifact failures.