### PR TITLE
Fix Dart interop tests by upgrading to Dart 2

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_dart/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_dart/Dockerfile.template
@@ -16,5 +16,8 @@
 
   FROM google/dart:latest
 
+  # Upgrade Dart to version 2.
+  RUN apt-get update && apt-get upgrade -y dart
+
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_dart/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_dart/Dockerfile
@@ -14,5 +14,8 @@
 
 FROM google/dart:latest
 
+# Upgrade Dart to version 2.
+RUN apt-get update && apt-get upgrade -y dart
+
 # Define the default command.
 CMD ["bash"]


### PR DESCRIPTION
Fixes #15916

grpc-dart was failing to build because Dart version 1.x was installed in the Docker container. 