### PR TITLE
Return response object to server interceptors in request/response calls

### DIFF
--- a/src/ruby/lib/grpc/generic/rpc_desc.rb
+++ b/src/ruby/lib/grpc/generic/rpc_desc.rb
@@ -62,6 +62,7 @@ module GRPC
           resp,
           trailing_metadata: active_call.output_metadata
         )
+        resp
       end
     end
 


### PR DESCRIPTION
Attempt to fix https://github.com/grpc/grpc/issues/15966

I didn't have enough time to invest into understand the test suite as of right now, but there didn't seem to be an automated test covering this part of the code specifically.

I would probably suggest writing a simple functional test covering this scenario (from the interceptors proposal), but I would appreciate any guidance on what would be the best way to automate it on this project.