### PR TITLE
 Remove C# shutdown hook on .NET Core

### DIFF
--- a/src/csharp/Grpc.Core/GrpcEnvironment.cs
+++ b/src/csharp/Grpc.Core/GrpcEnvironment.cs
@@ -423,7 +423,7 @@ namespace Grpc.Core
                     if (!hooksRegistered)
                     {
 #if NETSTANDARD1_5
-                        System.Runtime.Loader.AssemblyLoadContext.Default.Unloading += (assemblyLoadContext) => { HandleShutdown(); };
+                        // No action required at shutdown on .NET Core
 #else
                         AppDomain.CurrentDomain.ProcessExit += (sender, eventArgs) => { HandleShutdown(); };
                         AppDomain.CurrentDomain.DomainUnload += (sender, eventArgs) => { HandleShutdown(); };

--- a/src/csharp/Grpc.Core/GrpcEnvironment.cs
+++ b/src/csharp/Grpc.Core/GrpcEnvironment.cs
@@ -434,6 +434,8 @@ namespace Grpc.Core
                         // - .NET core doesn't run finalizers on shutdown, so there's no risk of getting
                         //   a crash because grpc_*_destroy methods for native objects being invoked
                         //   in wrong order.
+                        // TODO(jtattermusch): Verify that the shutdown hooks are still not needed
+                        // once we add support for new platforms using netstandard (e.g. Xamarin).
 #else
                         // On desktop .NET framework and Mono, we need to register for a shutdown
                         // event to explicitly shutdown the GrpcEnvironment.


### PR DESCRIPTION
Supersedes #15952 (added detailed comments).

See #14856.