### PR TITLE
Write stalling fix

### DIFF
--- a/src/core/ext/transport/chttp2/transport/stream_lists.cc
+++ b/src/core/ext/transport/chttp2/transport/stream_lists.cc
@@ -35,6 +35,8 @@ static const char* stream_list_id_string(grpc_chttp2_stream_list_id id) {
       return "stalled_by_stream";
     case GRPC_CHTTP2_LIST_WAITING_FOR_CONCURRENCY:
       return "waiting_for_concurrency";
+    case GRPC_CHTTP2_LIST_WAITING_FOR_WRITE:
+      return "waiting_for_write";
     case STREAM_LIST_COUNT:
       GPR_UNREACHABLE_CODE(return "unknown");
   }
@@ -213,4 +215,19 @@ bool grpc_chttp2_list_pop_stalled_by_stream(grpc_chttp2_transport* t,
 bool grpc_chttp2_list_remove_stalled_by_stream(grpc_chttp2_transport* t,
                                                grpc_chttp2_stream* s) {
   return stream_list_maybe_remove(t, s, GRPC_CHTTP2_LIST_STALLED_BY_STREAM);
+}
+
+bool grpc_chttp2_list_add_waiting_for_write_stream(grpc_chttp2_transport* t,
+                                                   grpc_chttp2_stream* s) {
+  return stream_list_add(t, s, GRPC_CHTTP2_LIST_WAITING_FOR_WRITE);
+}
+
+bool grpc_chttp2_list_pop_waiting_for_write_stream(grpc_chttp2_transport* t,
+                                                   grpc_chttp2_stream** s) {
+  return stream_list_pop(t, s, GRPC_CHTTP2_LIST_WAITING_FOR_WRITE);
+}
+
+bool grpc_chttp2_list_remove_waiting_for_write_stream(grpc_chttp2_transport* t,
+                                                      grpc_chttp2_stream* s) {
+  return stream_list_maybe_remove(t, s, GRPC_CHTTP2_LIST_WAITING_FOR_WRITE);
 }

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -641,6 +641,10 @@ void grpc_chttp2_end_write(grpc_chttp2_transport* t, grpc_error* error) {
     }
     GRPC_CHTTP2_STREAM_UNREF(s, "chttp2_writing:end");
   }
+  while (grpc_chttp2_list_pop_waiting_for_write_stream(t, &s)) {
+    GRPC_CLOSURE_LIST_SCHED(&s->run_after_write);
+    GRPC_CHTTP2_STREAM_UNREF(s, "chttp2:write_closure_sched");
+  }
   grpc_slice_buffer_reset_and_unref_internal(&t->outbuf);
   GRPC_ERROR_UNREF(error);
 }

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -641,10 +641,6 @@ void grpc_chttp2_end_write(grpc_chttp2_transport* t, grpc_error* error) {
     }
     GRPC_CHTTP2_STREAM_UNREF(s, "chttp2_writing:end");
   }
-  while (grpc_chttp2_list_pop_waiting_for_write_stream(t, &s)) {
-    GRPC_CLOSURE_LIST_SCHED(&s->run_after_write);
-    GRPC_CHTTP2_STREAM_UNREF(s, "chttp2:write_closure_sched");
-  }
   grpc_slice_buffer_reset_and_unref_internal(&t->outbuf);
   GRPC_ERROR_UNREF(error);
 }


### PR DESCRIPTION
The chttp2 transport would not execute write closures until a write occurred, even if the stream was cancelled.

This PR separates the write callback closure lists based on streams, so they can be run when a cancellation comes in.

Fixes #15889