### PR TITLE
Move GetSpanFromServerContext() to public header.

### DIFF
--- a/include/grpcpp/opencensus.h
+++ b/include/grpcpp/opencensus.h
@@ -19,6 +19,10 @@
 #ifndef GRPCPP_OPENCENSUS_H
 #define GRPCPP_OPENCENSUS_H
 
+#ifndef GRPC_BAZEL_BUILD
+#error OpenCensus for gRPC is only supported when building with bazel.
+#endif
+
 #include "opencensus/trace/span.h"
 
 namespace grpc {

--- a/include/grpcpp/opencensus.h
+++ b/include/grpcpp/opencensus.h
@@ -19,6 +19,8 @@
 #ifndef GRPCPP_OPENCENSUS_H
 #define GRPCPP_OPENCENSUS_H
 
+#include "opencensus/trace/span.h"
+
 namespace grpc {
 // These symbols in this file will not be included in the binary unless
 // grpc_opencensus_plugin build target was added as a dependency. At the moment
@@ -35,6 +37,11 @@ void RegisterOpenCensusPlugin();
 // registered stats exporter. For on-task stats, construct a View using the
 // ViewDescriptors below.
 void RegisterOpenCensusViewsForExport();
+
+class ServerContext;
+
+// Returns the tracing Span for the current RPC.
+::opencensus::trace::Span GetSpanFromServerContext(ServerContext* context);
 
 }  // namespace grpc
 

--- a/src/cpp/ext/filters/census/grpc_plugin.h
+++ b/src/cpp/ext/filters/census/grpc_plugin.h
@@ -24,14 +24,10 @@
 #include "absl/strings/string_view.h"
 #include "include/grpcpp/opencensus.h"
 #include "opencensus/stats/stats.h"
-#include "opencensus/trace/span.h"
 
 namespace grpc {
 
 class ServerContext;
-
-// Returns the tracing Span for the current RPC.
-::opencensus::trace::Span GetSpanFromServerContext(ServerContext* context);
 
 // The tag keys set when recording RPC stats.
 ::opencensus::stats::TagKey ClientMethodTagKey();


### PR DESCRIPTION
Move GetSpanFromServerContext() to public header.
