### PR TITLE
Minimal Bazel BUILD files for grpcio Python

### DIFF
--- a/src/python/grpcio/grpc/BUILD.bazel
+++ b/src/python/grpcio/grpc/BUILD.bazel
@@ -1,0 +1,82 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_binary(
+    name = "grpcio",
+    srcs = ["__init__.py"],
+    deps = [
+        ":utilities",
+        ":auth",
+        ":plugin_wrapping",
+        ":channel",
+        ":interceptor",
+        ":server",
+        "//src/python/grpcio/grpc/_cython:cygrpc",
+        "//src/python/grpcio/grpc/beta",
+        "//src/python/grpcio/grpc/experimental",
+        "//src/python/grpcio/grpc/framework",
+        requirement('enum34'),
+        requirement('six'),
+    ],
+    data = [
+        "//:grpc",
+    ],
+    main = "__init__.py",
+    imports = ["../",],
+)
+
+py_library(
+    name = "auth",
+    srcs = ["_auth.py"],
+)
+
+py_library(
+    name = "channel",
+    srcs = ["_channel.py"],
+    deps = [
+        ":common",
+        ":grpcio_metadata",
+    ],
+)
+
+py_library(
+    name = "common",
+    srcs = ["_common.py"],
+)
+
+py_library(
+    name = "grpcio_metadata",
+    srcs = ["_grpcio_metadata.py"],
+)
+
+py_library(
+    name = "interceptor",
+    srcs = ["_interceptor.py"],
+)
+
+py_library(
+    name = "plugin_wrapping",
+    srcs = ["_plugin_wrapping.py"],
+    deps = [
+        ":common",
+    ]
+)
+
+py_library(
+    name = "server",
+    srcs = ["_server.py"],
+    deps = [
+        ":common",
+        ":interceptor",
+    ],
+)
+
+py_library(
+    name = "utilities",
+    srcs = ["_utilities.py"],
+    deps = [
+        ":common",
+    ],
+)
+

--- a/src/python/grpcio/grpc/_cython/BUILD.bazel
+++ b/src/python/grpcio/grpc/_cython/BUILD.bazel
@@ -1,0 +1,46 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//bazel:cython_library.bzl", "pyx_library")
+
+pyx_library(
+    name = "cygrpc",
+    srcs = [
+        "__init__.py",
+        "cygrpc.pxd",
+        "cygrpc.pyx",
+        "_cygrpc/grpc_string.pyx.pxi",
+        "_cygrpc/arguments.pyx.pxi",
+        "_cygrpc/call.pyx.pxi",
+        "_cygrpc/channel.pyx.pxi",
+        "_cygrpc/credentials.pyx.pxi",
+        "_cygrpc/completion_queue.pyx.pxi",
+        "_cygrpc/event.pyx.pxi",
+        "_cygrpc/metadata.pyx.pxi",
+        "_cygrpc/operation.pyx.pxi",
+        "_cygrpc/records.pyx.pxi",
+        "_cygrpc/security.pyx.pxi",
+        "_cygrpc/server.pyx.pxi",
+        "_cygrpc/tag.pyx.pxi",
+        "_cygrpc/time.pyx.pxi",
+        "_cygrpc/grpc_gevent.pyx.pxi",
+        "_cygrpc/grpc.pxi",
+        "_cygrpc/arguments.pxd.pxi",
+        "_cygrpc/call.pxd.pxi",
+        "_cygrpc/channel.pxd.pxi",
+        "_cygrpc/credentials.pxd.pxi",
+        "_cygrpc/completion_queue.pxd.pxi",
+        "_cygrpc/event.pxd.pxi",
+        "_cygrpc/metadata.pxd.pxi",
+        "_cygrpc/operation.pxd.pxi",
+        "_cygrpc/records.pxd.pxi",
+        "_cygrpc/security.pxd.pxi",
+        "_cygrpc/server.pxd.pxi",
+        "_cygrpc/tag.pxd.pxi",
+        "_cygrpc/time.pxd.pxi",
+        "_cygrpc/grpc_gevent.pxd.pxi",
+    ],
+    deps = [
+       "//:grpc",
+    ],
+)
+

--- a/src/python/grpcio/grpc/beta/BUILD.bazel
+++ b/src/python/grpcio/grpc/beta/BUILD.bazel
@@ -1,0 +1,58 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "beta",
+    srcs = ["__init__.py",],
+    deps = [
+        ":client_adaptations",
+        ":metadata",
+        ":server_adaptations",
+        ":implementations",
+        ":interfaces",
+        ":utilities",
+    ],
+)
+
+py_library(
+    name = "client_adaptations",
+    srcs = ["_client_adaptations.py"],
+    imports=["../../",]
+)
+
+py_library(
+    name = "metadata",
+    srcs = ["_metadata.py"],
+)
+
+py_library(
+    name = "server_adaptations",
+    srcs = ["_server_adaptations.py"],
+    imports=["../../",],
+)
+
+py_library(
+    name = "implementations",
+    srcs = ["implementations.py"],
+    imports=["../../",],
+)
+
+py_library(
+    name = "interfaces",
+    srcs = ["interfaces.py"],
+    deps = [
+        requirement("six"),
+    ],
+    imports=["../../",],
+)
+
+py_library(
+    name = "utilities",
+    srcs = ["utilities.py"],
+    deps = [
+        ":implementations",
+        ":interfaces",
+        "//src/python/grpcio/grpc/framework/foundation",
+    ],
+)
+

--- a/src/python/grpcio/grpc/experimental/BUILD.bazel
+++ b/src/python/grpcio/grpc/experimental/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "experimental",
+    srcs = ["__init__.py",],
+    deps = [
+        ":gevent",
+        ":session_cache",
+    ],
+)
+
+py_library(
+    name = "gevent",
+    srcs = ["gevent.py"],
+    deps = [
+        "//src/python/grpcio/grpc/_cython:cygrpc",
+    ],
+)
+
+py_library(
+    name = "session_cache",
+    srcs = ["session_cache.py"],
+    deps = [
+        "//src/python/grpcio/grpc/_cython:cygrpc",
+    ],
+)

--- a/src/python/grpcio/grpc/framework/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/BUILD.bazel
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "framework",
+    srcs = ["__init__.py",],
+    deps = [
+        "//src/python/grpcio/grpc/framework/common",
+        "//src/python/grpcio/grpc/framework/foundation",
+        "//src/python/grpcio/grpc/framework/interfaces",
+    ],
+)

--- a/src/python/grpcio/grpc/framework/common/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/common/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "common",
+    srcs = ["__init__.py",],
+    deps = [
+        ":cardinality",
+        ":style",
+    ],
+)
+
+py_library(
+    name = "cardinality",
+    srcs = ["cardinality.py"],
+    deps = [
+        requirement("enum34"),
+    ],
+)
+
+py_library(
+    name = "style",
+    srcs = ["style.py"],
+    deps = [
+        requirement("enum34"),
+    ],
+)

--- a/src/python/grpcio/grpc/framework/foundation/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/foundation/BUILD.bazel
@@ -1,0 +1,61 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "foundation",
+    srcs = ["__init__.py",],
+    deps = [
+        ":abandonment",
+        ":callable_util",
+        ":future",
+        ":logging_pool",
+        ":stream_util",
+        ":stream",
+    ],
+)
+
+py_library(
+    name = "abandonment",
+    srcs = ["abandonment.py"],
+)
+
+py_library(
+    name = "callable_util",
+    srcs = ["callable_util.py"],
+    deps = [
+        requirement("enum34"),
+        requirement("six"),
+    ],
+)
+
+py_library(
+    name = "future",
+    srcs = ["future.py"],
+    deps = [
+        requirement("six"),
+    ],
+)
+
+py_library(
+    name = "logging_pool",
+    srcs = ["logging_pool.py"],
+    deps = [
+        requirement("futures"),
+    ],
+)
+
+py_library(
+    name = "stream_util",
+    srcs = ["stream_util.py"],
+    deps = [
+        ":stream",
+    ],
+)
+
+py_library(
+    name = "stream",
+    srcs = ["stream.py"],
+    deps = [
+        requirement("six"),
+    ],
+)

--- a/src/python/grpcio/grpc/framework/interfaces/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/interfaces/BUILD.bazel
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "interfaces",
+    srcs = ["__init__.py",],
+    deps = [
+        "//src/python/grpcio/grpc/framework/interfaces/base",
+        "//src/python/grpcio/grpc/framework/interfaces/face",
+    ],
+)

--- a/src/python/grpcio/grpc/framework/interfaces/base/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/interfaces/base/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "base_lib",
+    srcs = ["__init__.py",],
+    deps = [
+        ":base",
+        ":utilities",
+    ],
+)
+
+py_library(
+    name = "base",
+    srcs = ["base.py"],
+    deps = [
+        "//src/python/grpcio/grpc/framework/foundation:abandonment",
+        requirement("enum34"),
+        requirement("six"),
+    ],
+)
+
+py_library(
+    name = "utilities",
+    srcs = ["utilities.py"],
+    deps = [
+        requirement("enum34"),
+    ],
+)

--- a/src/python/grpcio/grpc/framework/interfaces/face/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/interfaces/face/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "face",
+    srcs = ["__init__.py",],
+    deps = [
+        ":face_lib",
+        ":utilities",
+    ],
+)
+
+py_library(
+    name = "face_lib",
+    srcs = ["face.py"],
+    deps = [
+        "//src/python/grpcio/grpc/framework/foundation",
+        "//src/python/grpcio/grpc/framework/common",
+        requirement("enum34"),
+        requirement("six"),
+    ],
+)
+
+py_library(
+    name = "utilities",
+    srcs = ["utilities.py"],
+    deps = [
+        "//src/python/grpcio/grpc/framework/common",
+        "//src/python/grpcio/grpc/framework/foundation:stream",
+        ":face_lib",
+    ],
+)

--- a/src/python/grpcio_tests/tests/unit/framework/foundation/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/framework/foundation/BUILD.bazel
@@ -1,0 +1,17 @@
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "stream_testing",
+    srcs = ["stream_testing.py"],
+)
+
+py_test(
+    name = "logging_pool_test",
+    srcs = ["_logging_pool_test.py"],
+    main = "_logging_pool_test.py",
+    size = "small",
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+    ],
+)
+


### PR DESCRIPTION
Follow-up on the additions in #15992. Pad the grpcio Python package with necessary BUILD files along with 2 simple tests.

cc: @nathanielmanistaatgoogle  @mehrdada 