### PR TITLE
docs: provide a section aggregating per-language server reflection tu…

### DIFF
--- a/doc/server-reflection.md
+++ b/doc/server-reflection.md
@@ -15,19 +15,6 @@ This broadly involves two problems: determining what formats (which protobuf
 messages) a server’s method uses, and determining how to convert messages
 between human readable format and the (likely binary) wire format.
 
-## Enabling server reflection
-
-Enabling server reflection differs language-to-language. Here are links to docs relevant to
-each language:
-
-- [Java](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md#enable-server-reflection)
-- [Go](https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md#enable-server-reflection)
-- [C++](https://grpc.io/grpc/cpp/md_doc_server_reflection_tutorial.html)
-- Python: (tutorial not yet written)
-- C#: (tutorial not yet written)
-- Ruby: not yet implemented [#2567](https://github.com/grpc/grpc/issues/2567)
-- Node: not yet implemented [#2568](https://github.com/grpc/grpc/issues/2568)
-
 ## Method reflection
 
 We want to be able to answer the following queries:
@@ -194,3 +181,16 @@ will need to index those FileDescriptorProtos by file and symbol and imports.
 One issue is that some grpc implementations are very loosely coupled with
 protobufs; in such implementations it probably makes sense to split apart these
 reflection APIs so as not to take an additional proto dependency.
+
+## Known Implementations
+
+Enabling server reflection differs language-to-language. Here are links to docs relevant to
+each language:
+
+- [Java](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md#enable-server-reflection)
+- [Go](https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md#enable-server-reflection)
+- [C++](https://grpc.io/grpc/cpp/md_doc_server_reflection_tutorial.html)
+- Python: (tutorial not yet written)
+- C#: (tutorial not yet written)
+- Ruby: not yet implemented [#2567](https://github.com/grpc/grpc/issues/2567)
+- Node: not yet implemented [#2568](https://github.com/grpc/grpc/issues/2568)

--- a/doc/server-reflection.md
+++ b/doc/server-reflection.md
@@ -190,7 +190,7 @@ each language:
 - [Java](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md#enable-server-reflection)
 - [Go](https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md#enable-server-reflection)
 - [C++](https://grpc.io/grpc/cpp/md_doc_server_reflection_tutorial.html)
+- [C#](https://github.com/grpc/grpc/blob/master/doc/csharp/server_reflection.md)
 - Python: (tutorial not yet written)
-- C#: (tutorial not yet written)
 - Ruby: not yet implemented [#2567](https://github.com/grpc/grpc/issues/2567)
 - Node: not yet implemented [#2568](https://github.com/grpc/grpc/issues/2568)

--- a/doc/server-reflection.md
+++ b/doc/server-reflection.md
@@ -15,6 +15,19 @@ This broadly involves two problems: determining what formats (which protobuf
 messages) a server’s method uses, and determining how to convert messages
 between human readable format and the (likely binary) wire format.
 
+## Enabling server reflection
+
+Enabling server reflection differs language-to-language. Here are links to docs relevant to
+each language:
+
+- [Java](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md#enable-server-reflection)
+- [Go](https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md#enable-server-reflection)
+- [C++](https://grpc.io/grpc/cpp/md_doc_server_reflection_tutorial.html)
+- Python: (tutorial not yet written)
+- C#: (tutorial not yet written)
+- Ruby: not yet implemented [#2567](https://github.com/grpc/grpc/issues/2567)
+- Node: not yet implemented [#2568](https://github.com/grpc/grpc/issues/2568)
+
 ## Method reflection
 
 We want to be able to answer the following queries:


### PR DESCRIPTION
…torials

This allows users of any language to find documentation about server reflection. I chose this document as the place to put it because it has quite good SEO for the term "server reflection grpc".

This is WIP pending:

- https://github.com/grpc/grpc/issues/16017
- https://github.com/grpc/grpc/issues/16101

If we can get python and c# examples, I will update this PR with those links. Just wanted to get the PR out for initial review.