### PR TITLE
Channelz Part 2: GetTopChannels

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel_channelz.cc
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.cc
@@ -41,8 +41,9 @@ static const grpc_arg_pointer_vtable client_channel_channelz_vtable = {
     client_channel_channelz_cmp};
 
 ClientChannelNode::ClientChannelNode(grpc_channel* channel,
-                                     size_t channel_tracer_max_nodes)
-    : ChannelNode(channel, channel_tracer_max_nodes) {
+                                     size_t channel_tracer_max_nodes,
+                                     bool is_top_level_channel)
+    : ChannelNode(channel, channel_tracer_max_nodes, is_top_level_channel) {
   client_channel_ =
       grpc_channel_stack_last_element(grpc_channel_get_channel_stack(channel));
   GPR_ASSERT(client_channel_->filter == &grpc_client_channel_filter);
@@ -71,9 +72,10 @@ grpc_arg ClientChannelNode::CreateChannelArg() {
 }
 
 RefCountedPtr<ChannelNode> ClientChannelNode::MakeClientChannelNode(
-    grpc_channel* channel, size_t channel_tracer_max_nodes) {
+    grpc_channel* channel, size_t channel_tracer_max_nodes,
+    bool is_top_level_channel) {
   return MakePolymorphicRefCounted<ChannelNode, ClientChannelNode>(
-      channel, channel_tracer_max_nodes);
+      channel, channel_tracer_max_nodes, is_top_level_channel);
 }
 
 }  // namespace channelz

--- a/src/core/ext/filters/client_channel/client_channel_channelz.h
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.h
@@ -32,7 +32,8 @@ namespace channelz {
 class ClientChannelNode : public ChannelNode {
  public:
   static RefCountedPtr<ChannelNode> MakeClientChannelNode(
-      grpc_channel* channel, size_t channel_tracer_max_nodes);
+      grpc_channel* channel, size_t channel_tracer_max_nodes,
+      bool is_top_level_channel);
 
   // Override this functionality since client_channels have a notion of
   // channel connectivity.
@@ -45,7 +46,8 @@ class ClientChannelNode : public ChannelNode {
  protected:
   GPRC_ALLOW_CLASS_TO_USE_NON_PUBLIC_DELETE
   GPRC_ALLOW_CLASS_TO_USE_NON_PUBLIC_NEW
-  ClientChannelNode(grpc_channel* channel, size_t channel_tracer_max_nodes);
+  ClientChannelNode(grpc_channel* channel, size_t channel_tracer_max_nodes,
+                    bool is_top_level_channel);
   virtual ~ClientChannelNode() {}
 
  private:

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1004,6 +1004,9 @@ grpc_channel_args* BuildBalancerChannelArgs(
       // A channel arg indicating the target is a grpclb load balancer.
       grpc_channel_arg_integer_create(
           const_cast<char*>(GRPC_ARG_ADDRESS_IS_GRPCLB_LOAD_BALANCER), 1),
+      // A channel arg indicating the target is a grpclb load balancer.
+      grpc_channel_arg_integer_create(
+          const_cast<char*>(GRPC_ARG_CHANNELZ_CHANNEL_IS_INTERNAL_CHANNEL), 1),
   };
   // Construct channel args.
   grpc_channel_args* new_args = grpc_channel_args_copy_and_add_and_remove(

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1004,7 +1004,8 @@ grpc_channel_args* BuildBalancerChannelArgs(
       // A channel arg indicating the target is a grpclb load balancer.
       grpc_channel_arg_integer_create(
           const_cast<char*>(GRPC_ARG_ADDRESS_IS_GRPCLB_LOAD_BALANCER), 1),
-      // A channel arg indicating the target is a grpclb load balancer.
+      // A channel arg indicating this is an internal channels, aka it is
+      // owned by components in Core, not by the user application.
       grpc_channel_arg_integer_create(
           const_cast<char*>(GRPC_ARG_CHANNELZ_CHANNEL_IS_INTERNAL_CHANNEL), 1),
   };

--- a/src/core/lib/channel/channel_trace.cc
+++ b/src/core/lib/channel/channel_trace.cc
@@ -206,7 +206,7 @@ void ChannelTrace::TraceEvent::RenderTraceEvent(grpc_json* json) const {
   }
 }
 
-grpc_json* ChannelTrace::RenderJSON() const {
+grpc_json* ChannelTrace::RenderJson() const {
   if (!max_list_size_)
     return nullptr;  // tracing is disabled if max_events == 0
   grpc_json* json = grpc_json_create(GRPC_JSON_OBJECT);

--- a/src/core/lib/channel/channel_trace.h
+++ b/src/core/lib/channel/channel_trace.h
@@ -71,7 +71,7 @@ class ChannelTrace {
 
   // Creates and returns the raw grpc_json object, so a parent channelz
   // object may incorporate the json before rendering.
-  grpc_json* RenderJSON() const;
+  grpc_json* RenderJson() const;
 
  private:
   // Types of objects that can be references by trace events.

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -88,8 +88,12 @@ grpc_json* add_num_str(grpc_json* parent, grpc_json* it, const char* name,
 
 }  // namespace
 
-ChannelNode::ChannelNode(grpc_channel* channel, size_t channel_tracer_max_nodes)
-    : channel_(channel), target_(nullptr), channel_uuid_(-1) {
+ChannelNode::ChannelNode(grpc_channel* channel, size_t channel_tracer_max_nodes,
+                         bool is_top_level_channel)
+    : channel_(channel),
+      target_(nullptr),
+      channel_uuid_(-1),
+      is_top_level_channel_(is_top_level_channel) {
   trace_.Init(channel_tracer_max_nodes);
   target_ = UniquePtr<char>(grpc_channel_get_target(channel_));
   channel_uuid_ = ChannelzRegistry::RegisterChannelNode(this);
@@ -136,7 +140,7 @@ grpc_json* ChannelNode::RenderJson() {
   // fill in the channel trace if applicable
   grpc_json* trace = trace_->RenderJson();
   if (trace != nullptr) {
-    // we manuall link up and fill the child since it was created for us in
+    // we manually link up and fill the child since it was created for us in
     // ChannelTrace::RenderJson
     json_iterator = grpc_json_link_child(json, trace, json_iterator);
     trace->parent = json;
@@ -175,9 +179,10 @@ char* ChannelNode::RenderJsonString() {
 }
 
 RefCountedPtr<ChannelNode> ChannelNode::MakeChannelNode(
-    grpc_channel* channel, size_t channel_tracer_max_nodes) {
+    grpc_channel* channel, size_t channel_tracer_max_nodes,
+    bool is_top_level_channel) {
   return MakeRefCounted<grpc_core::channelz::ChannelNode>(
-      channel, channel_tracer_max_nodes);
+      channel, channel_tracer_max_nodes, is_top_level_channel);
 }
 
 }  // namespace channelz

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -98,11 +98,8 @@ grpc_json* ChannelNode::RenderJson() {
   if (trace != nullptr) {
     // we manually link up and fill the child since it was created for us in
     // ChannelTrace::RenderJson
+    trace->key = "trace";  // this object is named trace in channelz.proto
     json_iterator = grpc_json_link_child(json, trace, json_iterator);
-    trace->parent = json;
-    trace->value = nullptr;
-    trace->key = "trace";
-    trace->owns_value = false;
   }
   // reset the parent to be the data object.
   json = data;

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -92,14 +92,14 @@ ChannelNode::ChannelNode(grpc_channel* channel, size_t channel_tracer_max_nodes)
     : channel_(channel), target_(nullptr), channel_uuid_(-1) {
   trace_.Init(channel_tracer_max_nodes);
   target_ = UniquePtr<char>(grpc_channel_get_target(channel_));
-  channel_uuid_ = ChannelzRegistry::Register(this);
+  channel_uuid_ = ChannelzRegistry::RegisterChannelNode(this);
   gpr_atm_no_barrier_store(&last_call_started_millis_,
                            (gpr_atm)ExecCtx::Get()->Now());
 }
 
 ChannelNode::~ChannelNode() {
   trace_.Destroy();
-  ChannelzRegistry::Unregister(channel_uuid_);
+  ChannelzRegistry::UnregisterChannelNode(channel_uuid_);
 }
 
 void ChannelNode::RecordCallStarted() {

--- a/src/core/lib/channel/channelz.h
+++ b/src/core/lib/channel/channelz.h
@@ -35,6 +35,10 @@
 #define GRPC_ARG_CHANNELZ_CHANNEL_NODE_CREATION_FUNC \
   "grpc.channelz_channel_node_creation_func"
 
+// Channel arg key to signal that the channel is an internal channel.
+#define GRPC_ARG_CHANNELZ_CHANNEL_IS_INTERNAL_CHANNEL \
+  "grpc.channelz_channel_is_internal_channel"
+
 namespace grpc_core {
 namespace channelz {
 
@@ -55,7 +59,8 @@ class ChannelNode : public RefCounted<ChannelNode> {
     gpr_atm_no_barrier_fetch_add(&calls_succeeded_, (gpr_atm(1)));
   }
 
-  char* RenderJSON();
+  grpc_json* RenderJson();
+  char* RenderJsonString();
 
   // helper for getting and populating connectivity state. It is virtual
   // because it allows the client_channel specific code to live in ext/
@@ -72,6 +77,10 @@ class ChannelNode : public RefCounted<ChannelNode> {
   bool ChannelIsDestroyed() { return channel_ == nullptr; }
 
   intptr_t channel_uuid() { return channel_uuid_; }
+  bool is_top_level_channel() { return is_top_level_channel_; }
+  void set_is_top_level_channel(bool is_top_level_channel) {
+    is_top_level_channel_ = is_top_level_channel;
+  }
 
  protected:
   GPRC_ALLOW_CLASS_TO_USE_NON_PUBLIC_DELETE
@@ -90,6 +99,7 @@ class ChannelNode : public RefCounted<ChannelNode> {
   gpr_atm calls_failed_ = 0;
   gpr_atm last_call_started_millis_ = 0;
   intptr_t channel_uuid_;
+  bool is_top_level_channel_ = true;
   ManualConstructor<ChannelTrace> trace_;
 };
 

--- a/src/core/lib/channel/channelz.h
+++ b/src/core/lib/channel/channelz.h
@@ -49,7 +49,8 @@ class ChannelNodePeer;
 class ChannelNode : public RefCounted<ChannelNode> {
  public:
   static RefCountedPtr<ChannelNode> MakeChannelNode(
-      grpc_channel* channel, size_t channel_tracer_max_nodes);
+      grpc_channel* channel, size_t channel_tracer_max_nodes,
+      bool is_top_level_channel);
 
   void RecordCallStarted();
   void RecordCallFailed() {
@@ -78,14 +79,12 @@ class ChannelNode : public RefCounted<ChannelNode> {
 
   intptr_t channel_uuid() { return channel_uuid_; }
   bool is_top_level_channel() { return is_top_level_channel_; }
-  void set_is_top_level_channel(bool is_top_level_channel) {
-    is_top_level_channel_ = is_top_level_channel;
-  }
 
  protected:
   GPRC_ALLOW_CLASS_TO_USE_NON_PUBLIC_DELETE
   GPRC_ALLOW_CLASS_TO_USE_NON_PUBLIC_NEW
-  ChannelNode(grpc_channel* channel, size_t channel_tracer_max_nodes);
+  ChannelNode(grpc_channel* channel, size_t channel_tracer_max_nodes,
+              bool is_top_level_channel);
   virtual ~ChannelNode();
 
  private:
@@ -106,7 +105,7 @@ class ChannelNode : public RefCounted<ChannelNode> {
 // Creation functions
 
 typedef RefCountedPtr<ChannelNode> (*ChannelNodeCreationFunc)(grpc_channel*,
-                                                              size_t);
+                                                              size_t, bool);
 
 }  // namespace channelz
 }  // namespace grpc_core

--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -86,7 +86,7 @@ char* ChannelzRegistry::InternalGetTopChannels(intptr_t start_channel_id) {
   grpc_json* json_iterator = nullptr;
   InlinedVector<ChannelNode*, 10> top_level_channels;
   // uuids index into entities one-off (idx 0 is really uuid 1, since 0 is
-  // reserved). However, we want to support requests coming in this
+  // reserved). However, we want to support requests coming in with
   // start_channel_id=0, which signifies "give me everything." Hence this
   // funky looking line below.
   size_t start_idx = start_channel_id == 0 ? 0 : start_channel_id - 1;

--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -107,7 +107,6 @@ char* ChannelzRegistry::InternalGetTopChannels(intptr_t start_channel_id) {
       grpc_json* channel_json = top_level_channels[i]->RenderJson();
       json_iterator =
           grpc_json_link_child(array_parent, channel_json, json_iterator);
-      channel_json->parent = array_parent;
     }
   }
   // For now we do not have any pagination rules. In the future we could

--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -86,7 +86,7 @@ char* ChannelzRegistry::InternalGetTopChannels(intptr_t start_channel_id) {
   grpc_json* json_iterator = nullptr;
   InlinedVector<ChannelNode*, 10> top_level_channels;
   // uuids index into entities one-off (idx 0 is really uuid 1, since 0 is
-  // reserver). However, we want to support requests coming in which
+  // reserved). However, we want to support requests coming in this
   // start_channel_id=0, which signifies "give me everything." Hence this
   // funky looking line below.
   size_t start_idx = start_channel_id == 0 ? 0 : start_channel_id - 1;
@@ -108,9 +108,6 @@ char* ChannelzRegistry::InternalGetTopChannels(intptr_t start_channel_id) {
       json_iterator =
           grpc_json_link_child(array_parent, channel_json, json_iterator);
       channel_json->parent = array_parent;
-      channel_json->value = nullptr;
-      channel_json->key = nullptr;
-      channel_json->owns_value = false;
     }
   }
   // For now we do not have any pagination rules. In the future we could

--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -19,6 +19,7 @@
 #include <grpc/impl/codegen/port_platform.h>
 
 #include "src/core/lib/channel/channel_trace.h"
+#include "src/core/lib/channel/channelz.h"
 #include "src/core/lib/channel/channelz_registry.h"
 #include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/gprpp/memory.h"
@@ -64,6 +65,7 @@ void ChannelzRegistry::InternalUnregisterEntry(intptr_t uuid, EntityType type) {
   GPR_ASSERT(static_cast<size_t>(uuid) <= entities_.size());
   GPR_ASSERT(entities_[uuid - 1].type == type);
   entities_[uuid - 1].object = nullptr;
+  entities_[uuid - 1].type = EntityType::kUnset;
 }
 
 void* ChannelzRegistry::InternalGetEntry(intptr_t uuid, EntityType type) {
@@ -76,6 +78,49 @@ void* ChannelzRegistry::InternalGetEntry(intptr_t uuid, EntityType type) {
   } else {
     return nullptr;
   }
+}
+
+char* ChannelzRegistry::InternalGetTopChannels(intptr_t start_channel_id) {
+  grpc_json* top_level_json = grpc_json_create(GRPC_JSON_OBJECT);
+  grpc_json* json = top_level_json;
+  grpc_json* json_iterator = nullptr;
+  InlinedVector<ChannelNode*, 10> top_level_channels;
+  // uuids index into entities one-off (idx 0 is really uuid 1, since 0 is
+  // reserver). However, we want to support requests coming in which
+  // start_channel_id=0, which signifies "give me everything." Hence this
+  // funky looking line below.
+  size_t start_idx = start_channel_id == 0 ? 0 : start_channel_id - 1;
+  for (size_t i = start_idx; i < entities_.size(); ++i) {
+    if (entities_[i].type == EntityType::kChannelNode) {
+      ChannelNode* channel_node =
+          static_cast<ChannelNode*>(entities_[i].object);
+      if (channel_node->is_top_level_channel()) {
+        top_level_channels.push_back(channel_node);
+      }
+    }
+  }
+  if (top_level_channels.size() > 0) {
+    // create list of channels
+    grpc_json* array_parent = grpc_json_create_child(
+        nullptr, json, "channel", nullptr, GRPC_JSON_ARRAY, false);
+    for (size_t i = 0; i < top_level_channels.size(); ++i) {
+      grpc_json* channel_json = top_level_channels[i]->RenderJson();
+      json_iterator =
+          grpc_json_link_child(array_parent, channel_json, json_iterator);
+      channel_json->parent = array_parent;
+      channel_json->value = nullptr;
+      channel_json->key = nullptr;
+      channel_json->owns_value = false;
+    }
+  }
+  // For now we do not have any pagination rules. In the future we could
+  // pick a constant for max_channels_sent for a GetTopChannels request.
+  // Tracking: https://github.com/grpc/grpc/issues/16019.
+  json_iterator = grpc_json_create_child(nullptr, json, "end", nullptr,
+                                         GRPC_JSON_TRUE, false);
+  char* json_str = grpc_json_dump_to_string(top_level_json, 0);
+  grpc_json_destroy(top_level_json);
+  return json_str;
 }
 
 }  // namespace channelz

--- a/src/core/lib/channel/channelz_registry.h
+++ b/src/core/lib/channel/channelz_registry.h
@@ -51,6 +51,11 @@ class ChannelzRegistry {
     return gotten == nullptr ? nullptr : static_cast<ChannelNode*>(gotten);
   }
 
+  // todo, protect me
+  static char* GetTopChannels(intptr_t start_channel_id) {
+    return Default()->InternalGetTopChannels(start_channel_id);
+  }
+
  private:
   enum class EntityType {
     kChannelNode,
@@ -83,6 +88,8 @@ class ChannelzRegistry {
   // if object with uuid has previously been registered as the correct type,
   // returns the void* associated with that uuid. Else returns nullptr.
   void* InternalGetEntry(intptr_t uuid, EntityType type);
+
+  char* InternalGetTopChannels(intptr_t start_channel_id);
 
   // protects entities_ and uuid_
   gpr_mu mu_;

--- a/src/core/lib/channel/channelz_registry.h
+++ b/src/core/lib/channel/channelz_registry.h
@@ -36,7 +36,7 @@ class ChannelzRegistry {
   // To be called in grpc_init()
   static void Init();
 
-  // To be callen in grpc_shutdown();
+  // To be called in grpc_shutdown();
   static void Shutdown();
 
   static intptr_t RegisterChannelNode(ChannelNode* channel_node) {
@@ -51,7 +51,8 @@ class ChannelzRegistry {
     return gotten == nullptr ? nullptr : static_cast<ChannelNode*>(gotten);
   }
 
-  // todo, protect me
+  // Returns the allocated JSON string that represents the proto
+  // GetTopChannelsResponse as per channelz.proto.
   static char* GetTopChannels(intptr_t start_channel_id) {
     return Default()->InternalGetTopChannels(start_channel_id);
   }

--- a/src/core/lib/json/json.cc
+++ b/src/core/lib/json/json.cc
@@ -58,6 +58,8 @@ void grpc_json_destroy(grpc_json* json) {
 
 grpc_json* grpc_json_link_child(grpc_json* parent, grpc_json* child,
                                 grpc_json* sibling) {
+  // link child up to parent
+  child->parent = parent;
   // first child case.
   if (parent->child == nullptr) {
     GPR_ASSERT(sibling == nullptr);
@@ -81,7 +83,6 @@ grpc_json* grpc_json_create_child(grpc_json* sibling, grpc_json* parent,
   grpc_json* child = grpc_json_create(type);
   grpc_json_link_child(parent, child, sibling);
   child->owns_value = owns_value;
-  child->parent = parent;
   child->value = value;
   child->key = key;
   return child;

--- a/src/core/lib/surface/channel.cc
+++ b/src/core/lib/surface/channel.cc
@@ -167,11 +167,9 @@ grpc_channel* grpc_channel_create_with_builder(
 
   grpc_channel_args_destroy(args);
   if (channelz_enabled) {
-    channel->channelz_channel =
-        channel_node_create_func(channel, channel_tracer_max_nodes);
-    if (internal_channel || !channel->is_client) {
-      channel->channelz_channel->set_is_top_level_channel(false);
-    }
+    bool is_top_level_channel = channel->is_client && !internal_channel;
+    channel->channelz_channel = channel_node_create_func(
+        channel, channel_tracer_max_nodes, is_top_level_channel);
     channel->channelz_channel->trace()->AddTraceEvent(
         grpc_core::channelz::ChannelTrace::Severity::Info,
         grpc_slice_from_static_string("Channel created"));

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -127,7 +127,7 @@ void grpc_init(void) {
     grpc_slice_intern_init();
     grpc_mdctx_global_init();
     grpc_channel_init_init();
-    grpc_core::ChannelzRegistry::Init();
+    grpc_core::channelz::ChannelzRegistry::Init();
     grpc_security_pre_init();
     grpc_core::ExecCtx::GlobalInit();
     grpc_iomgr_init();
@@ -176,7 +176,7 @@ void grpc_shutdown(void) {
       grpc_mdctx_global_shutdown();
       grpc_handshaker_factory_registry_shutdown();
       grpc_slice_intern_shutdown();
-      grpc_core::ChannelzRegistry::Shutdown();
+      grpc_core::channelz::ChannelzRegistry::Shutdown();
       grpc_stats_shutdown();
       grpc_core::Fork::GlobalShutdown();
     }

--- a/test/core/channel/channel_trace_test.cc
+++ b/test/core/channel/channel_trace_test.cc
@@ -88,7 +88,7 @@ void AddSimpleTrace(ChannelTrace* tracer) {
 void ValidateChannelTrace(ChannelTrace* tracer,
                           size_t expected_num_event_logged, size_t max_nodes) {
   if (!max_nodes) return;
-  grpc_json* json = tracer->RenderJSON();
+  grpc_json* json = tracer->RenderJson();
   EXPECT_NE(json, nullptr);
   char* json_str = grpc_json_dump_to_string(json, 0);
   grpc_json_destroy(json);

--- a/test/core/channel/channel_trace_test.cc
+++ b/test/core/channel/channel_trace_test.cc
@@ -34,8 +34,6 @@
 #include "test/core/util/test_config.h"
 #include "test/cpp/util/channel_trace_proto_helper.h"
 
-// remove me
-#include <grpc/support/string_util.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -157,7 +155,7 @@ TEST_P(ChannelTracerTest, ComplexTest) {
   AddSimpleTrace(&tracer);
   ChannelFixture channel1(GetParam());
   RefCountedPtr<ChannelNode> sc1 =
-      MakeRefCounted<ChannelNode>(channel1.channel(), GetParam());
+      MakeRefCounted<ChannelNode>(channel1.channel(), GetParam(), true);
   tracer.AddTraceEventReferencingSubchannel(
       ChannelTrace::Severity::Info,
       grpc_slice_from_static_string("subchannel one created"), sc1);
@@ -175,7 +173,7 @@ TEST_P(ChannelTracerTest, ComplexTest) {
   ValidateChannelTrace(&tracer, 5, GetParam());
   ChannelFixture channel2(GetParam());
   RefCountedPtr<ChannelNode> sc2 =
-      MakeRefCounted<ChannelNode>(channel2.channel(), GetParam());
+      MakeRefCounted<ChannelNode>(channel2.channel(), GetParam(), true);
   tracer.AddTraceEventReferencingChannel(
       ChannelTrace::Severity::Info,
       grpc_slice_from_static_string("LB channel two created"), sc2);
@@ -204,7 +202,7 @@ TEST_P(ChannelTracerTest, TestNesting) {
   ValidateChannelTrace(&tracer, 2, GetParam());
   ChannelFixture channel1(GetParam());
   RefCountedPtr<ChannelNode> sc1 =
-      MakeRefCounted<ChannelNode>(channel1.channel(), GetParam());
+      MakeRefCounted<ChannelNode>(channel1.channel(), GetParam(), true);
   tracer.AddTraceEventReferencingChannel(
       ChannelTrace::Severity::Info,
       grpc_slice_from_static_string("subchannel one created"), sc1);
@@ -212,7 +210,7 @@ TEST_P(ChannelTracerTest, TestNesting) {
   AddSimpleTrace(sc1->trace());
   ChannelFixture channel2(GetParam());
   RefCountedPtr<ChannelNode> conn1 =
-      MakeRefCounted<ChannelNode>(channel2.channel(), GetParam());
+      MakeRefCounted<ChannelNode>(channel2.channel(), GetParam(), true);
   // nesting one level deeper.
   sc1->trace()->AddTraceEventReferencingSubchannel(
       ChannelTrace::Severity::Info,
@@ -225,7 +223,7 @@ TEST_P(ChannelTracerTest, TestNesting) {
   ValidateChannelTrace(conn1->trace(), 1, GetParam());
   ChannelFixture channel3(GetParam());
   RefCountedPtr<ChannelNode> sc2 =
-      MakeRefCounted<ChannelNode>(channel3.channel(), GetParam());
+      MakeRefCounted<ChannelNode>(channel3.channel(), GetParam(), true);
   tracer.AddTraceEventReferencingSubchannel(
       ChannelTrace::Severity::Info,
       grpc_slice_from_static_string("subchannel two created"), sc2);

--- a/test/core/channel/channelz_registry_test.cc
+++ b/test/core/channel/channelz_registry_test.cc
@@ -42,36 +42,9 @@
 namespace grpc_core {
 namespace channelz {
 namespace testing {
-namespace {
 
-class ChannelFixture {
- public:
-  ChannelFixture() {
-    grpc_arg client_a[1];
-    client_a[0].type = GRPC_ARG_INTEGER;
-    client_a[0].key = const_cast<char*>(GRPC_ARG_ENABLE_CHANNELZ);
-    client_a[0].value.integer = true;
-    grpc_channel_args client_args = {GPR_ARRAY_SIZE(client_a), client_a};
-    channel_ =
-        grpc_insecure_channel_create("fake_target", &client_args, nullptr);
-  }
-
-  ~ChannelFixture() { grpc_channel_destroy(channel_); }
-
-  grpc_channel* channel() { return channel_; }
-
- private:
-  grpc_channel* channel_;
-};
-
-}  // namespace
-
-// Tests basic ChannelTrace functionality like construction, adding trace, and
-// lookups by uuid.
 TEST(ChannelzRegistryTest, UuidStartsAboveZeroTest) {
-  ChannelFixture channel;
-  ChannelNode* channelz_channel =
-      grpc_channel_get_channelz_node(channel.channel());
+  ChannelNode* channelz_channel = nullptr;
   intptr_t uuid = ChannelzRegistry::RegisterChannelNode(channelz_channel);
   EXPECT_GT(uuid, 0) << "First uuid chose must be greater than zero. Zero if "
                         "reserved according to "
@@ -81,9 +54,7 @@ TEST(ChannelzRegistryTest, UuidStartsAboveZeroTest) {
 }
 
 TEST(ChannelzRegistryTest, UuidsAreIncreasing) {
-  ChannelFixture channel;
-  ChannelNode* channelz_channel =
-      grpc_channel_get_channelz_node(channel.channel());
+  ChannelNode* channelz_channel = nullptr;
   std::vector<intptr_t> uuids;
   uuids.reserve(10);
   for (int i = 0; i < 10; ++i) {
@@ -96,18 +67,14 @@ TEST(ChannelzRegistryTest, UuidsAreIncreasing) {
 }
 
 TEST(ChannelzRegistryTest, RegisterGetTest) {
-  ChannelFixture channel;
-  ChannelNode* channelz_channel =
-      grpc_channel_get_channelz_node(channel.channel());
+  ChannelNode* channelz_channel = nullptr;
   intptr_t uuid = ChannelzRegistry::RegisterChannelNode(channelz_channel);
   ChannelNode* retrieved = ChannelzRegistry::GetChannelNode(uuid);
   EXPECT_EQ(channelz_channel, retrieved);
 }
 
 TEST(ChannelzRegistryTest, RegisterManyItems) {
-  ChannelFixture channel;
-  ChannelNode* channelz_channel =
-      grpc_channel_get_channelz_node(channel.channel());
+  ChannelNode* channelz_channel = nullptr;
   for (int i = 0; i < 100; i++) {
     intptr_t uuid = ChannelzRegistry::RegisterChannelNode(channelz_channel);
     ChannelNode* retrieved = ChannelzRegistry::GetChannelNode(uuid);
@@ -116,9 +83,7 @@ TEST(ChannelzRegistryTest, RegisterManyItems) {
 }
 
 TEST(ChannelzRegistryTest, NullIfNotPresentTest) {
-  ChannelFixture channel;
-  ChannelNode* channelz_channel =
-      grpc_channel_get_channelz_node(channel.channel());
+  ChannelNode* channelz_channel = nullptr;
   intptr_t uuid = ChannelzRegistry::RegisterChannelNode(channelz_channel);
   // try to pull out a uuid that does not exist.
   ChannelNode* nonexistant = ChannelzRegistry::GetChannelNode(uuid + 1);

--- a/test/core/channel/channelz_registry_test.cc
+++ b/test/core/channel/channelz_registry_test.cc
@@ -19,17 +19,20 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <grpc/grpc.h>
 #include <gtest/gtest.h>
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 
 #include "src/core/lib/channel/channel_trace.h"
+#include "src/core/lib/channel/channelz.h"
 #include "src/core/lib/channel/channelz_registry.h"
 #include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/json/json.h"
+#include "src/core/lib/surface/channel.h"
 
 #include "test/core/util/test_config.h"
 
@@ -37,27 +40,55 @@
 #include <string.h>
 
 namespace grpc_core {
+namespace channelz {
 namespace testing {
+namespace {
+
+class ChannelFixture {
+ public:
+  ChannelFixture() {
+    grpc_arg client_a[1];
+    client_a[0].type = GRPC_ARG_INTEGER;
+    client_a[0].key = const_cast<char*>(GRPC_ARG_ENABLE_CHANNELZ);
+    client_a[0].value.integer = true;
+    grpc_channel_args client_args = {GPR_ARRAY_SIZE(client_a), client_a};
+    channel_ =
+        grpc_insecure_channel_create("fake_target", &client_args, nullptr);
+  }
+
+  ~ChannelFixture() { grpc_channel_destroy(channel_); }
+
+  grpc_channel* channel() { return channel_; }
+
+ private:
+  grpc_channel* channel_;
+};
+
+}  // namespace
 
 // Tests basic ChannelTrace functionality like construction, adding trace, and
 // lookups by uuid.
 TEST(ChannelzRegistryTest, UuidStartsAboveZeroTest) {
-  int object_to_register;
-  intptr_t uuid = ChannelzRegistry::Register(&object_to_register);
+  ChannelFixture channel;
+  ChannelNode* channelz_channel =
+      grpc_channel_get_channelz_node(channel.channel());
+  intptr_t uuid = ChannelzRegistry::RegisterChannelNode(channelz_channel);
   EXPECT_GT(uuid, 0) << "First uuid chose must be greater than zero. Zero if "
                         "reserved according to "
                         "https://github.com/grpc/proposal/blob/master/"
                         "A14-channelz.md";
-  ChannelzRegistry::Unregister(uuid);
+  ChannelzRegistry::UnregisterChannelNode(uuid);
 }
 
 TEST(ChannelzRegistryTest, UuidsAreIncreasing) {
-  int object_to_register;
+  ChannelFixture channel;
+  ChannelNode* channelz_channel =
+      grpc_channel_get_channelz_node(channel.channel());
   std::vector<intptr_t> uuids;
   uuids.reserve(10);
   for (int i = 0; i < 10; ++i) {
     // reregister the same object. It's ok since we are just testing uuids
-    uuids.push_back(ChannelzRegistry::Register(&object_to_register));
+    uuids.push_back(ChannelzRegistry::RegisterChannelNode(channelz_channel));
   }
   for (size_t i = 1; i < uuids.size(); ++i) {
     EXPECT_LT(uuids[i - 1], uuids[i]) << "Uuids must always be increasing";
@@ -65,60 +96,39 @@ TEST(ChannelzRegistryTest, UuidsAreIncreasing) {
 }
 
 TEST(ChannelzRegistryTest, RegisterGetTest) {
-  int object_to_register = 42;
-  intptr_t uuid = ChannelzRegistry::Register(&object_to_register);
-  int* retrieved = ChannelzRegistry::Get<int>(uuid);
-  EXPECT_EQ(&object_to_register, retrieved);
-}
-
-TEST(ChannelzRegistryTest, MultipleTypeTest) {
-  int int_to_register = 42;
-  intptr_t int_uuid = ChannelzRegistry::Register(&int_to_register);
-  std::string str_to_register = "hello world";
-  intptr_t str_uuid = ChannelzRegistry::Register(&str_to_register);
-  int* retrieved_int = ChannelzRegistry::Get<int>(int_uuid);
-  std::string* retrieved_str = ChannelzRegistry::Get<std::string>(str_uuid);
-  EXPECT_EQ(&int_to_register, retrieved_int);
-  EXPECT_EQ(&str_to_register, retrieved_str);
+  ChannelFixture channel;
+  ChannelNode* channelz_channel =
+      grpc_channel_get_channelz_node(channel.channel());
+  intptr_t uuid = ChannelzRegistry::RegisterChannelNode(channelz_channel);
+  ChannelNode* retrieved = ChannelzRegistry::GetChannelNode(uuid);
+  EXPECT_EQ(channelz_channel, retrieved);
 }
 
 TEST(ChannelzRegistryTest, RegisterManyItems) {
-  int object_to_register = 42;
+  ChannelFixture channel;
+  ChannelNode* channelz_channel =
+      grpc_channel_get_channelz_node(channel.channel());
   for (int i = 0; i < 100; i++) {
-    intptr_t uuid = ChannelzRegistry::Register(&object_to_register);
-    int* retrieved = ChannelzRegistry::Get<int>(uuid);
-    EXPECT_EQ(&object_to_register, retrieved);
+    intptr_t uuid = ChannelzRegistry::RegisterChannelNode(channelz_channel);
+    ChannelNode* retrieved = ChannelzRegistry::GetChannelNode(uuid);
+    EXPECT_EQ(channelz_channel, retrieved);
   }
 }
 
-namespace {
-class Foo {
- public:
-  int bar;
-};
-}  // namespace
-
-TEST(ChannelzRegistryTest, CustomObjectTest) {
-  Foo* foo = New<Foo>();
-  foo->bar = 1024;
-  intptr_t uuid = ChannelzRegistry::Register(foo);
-  Foo* retrieved = ChannelzRegistry::Get<Foo>(uuid);
-  EXPECT_EQ(foo, retrieved);
-  Delete(foo);
-}
-
 TEST(ChannelzRegistryTest, NullIfNotPresentTest) {
-  int object_to_register = 42;
-  intptr_t uuid = ChannelzRegistry::Register(&object_to_register);
+  ChannelFixture channel;
+  ChannelNode* channelz_channel =
+      grpc_channel_get_channelz_node(channel.channel());
+  intptr_t uuid = ChannelzRegistry::RegisterChannelNode(channelz_channel);
   // try to pull out a uuid that does not exist.
-  int* nonexistant = ChannelzRegistry::Get<int>(uuid + 1);
+  ChannelNode* nonexistant = ChannelzRegistry::GetChannelNode(uuid + 1);
   EXPECT_EQ(nonexistant, nullptr);
-  int* retrieved = ChannelzRegistry::Get<int>(uuid);
-  EXPECT_EQ(object_to_register, *retrieved);
-  EXPECT_EQ(&object_to_register, retrieved);
+  ChannelNode* retrieved = ChannelzRegistry::GetChannelNode(uuid);
+  EXPECT_EQ(channelz_channel, retrieved);
 }
 
 }  // namespace testing
+}  // namespace channelz
 }  // namespace grpc_core
 
 int main(int argc, char** argv) {

--- a/test/core/channel/channelz_registry_test.cc
+++ b/test/core/channel/channelz_registry_test.cc
@@ -67,14 +67,16 @@ TEST(ChannelzRegistryTest, UuidsAreIncreasing) {
 }
 
 TEST(ChannelzRegistryTest, RegisterGetTest) {
-  ChannelNode* channelz_channel = nullptr;
+  // we hackily jam an intptr_t into this pointer to check for equality later
+  ChannelNode* channelz_channel = (ChannelNode*)42;
   intptr_t uuid = ChannelzRegistry::RegisterChannelNode(channelz_channel);
   ChannelNode* retrieved = ChannelzRegistry::GetChannelNode(uuid);
   EXPECT_EQ(channelz_channel, retrieved);
 }
 
 TEST(ChannelzRegistryTest, RegisterManyItems) {
-  ChannelNode* channelz_channel = nullptr;
+  // we hackily jam an intptr_t into this pointer to check for equality later
+  ChannelNode* channelz_channel = (ChannelNode*)42;
   for (int i = 0; i < 100; i++) {
     intptr_t uuid = ChannelzRegistry::RegisterChannelNode(channelz_channel);
     ChannelNode* retrieved = ChannelzRegistry::GetChannelNode(uuid);
@@ -83,7 +85,8 @@ TEST(ChannelzRegistryTest, RegisterManyItems) {
 }
 
 TEST(ChannelzRegistryTest, NullIfNotPresentTest) {
-  ChannelNode* channelz_channel = nullptr;
+  // we hackily jam an intptr_t into this pointer to check for equality later
+  ChannelNode* channelz_channel = (ChannelNode*)42;
   intptr_t uuid = ChannelzRegistry::RegisterChannelNode(channelz_channel);
   // try to pull out a uuid that does not exist.
   ChannelNode* nonexistant = ChannelzRegistry::GetChannelNode(uuid + 1);

--- a/test/core/channel/channelz_test.cc
+++ b/test/core/channel/channelz_test.cc
@@ -80,7 +80,7 @@ void ValidateJsonArraySize(grpc_json* json, const char* key,
   for (grpc_json* child = arr->child; child != nullptr; child = child->next) {
     ++count;
   }
-  ASSERT_EQ(count, expected_size);
+  EXPECT_EQ(count, expected_size);
 }
 
 void ValidateGetTopChannels(size_t expected_channels) {
@@ -91,7 +91,7 @@ void ValidateGetTopChannels(size_t expected_channels) {
   // tracked: https://github.com/grpc/grpc/issues/16019.
   ValidateJsonArraySize(parsed_json, "channel", expected_channels);
   grpc_json* end = GetJsonChild(parsed_json, "end");
-  EXPECT_NE(end, nullptr);
+  ASSERT_NE(end, nullptr);
   EXPECT_EQ(end->type, GRPC_JSON_TRUE);
   grpc_json_destroy(parsed_json);
   gpr_free(json_str);
@@ -101,13 +101,11 @@ class ChannelFixture {
  public:
   ChannelFixture(int max_trace_nodes = 0) {
     grpc_arg client_a[2];
-    client_a[0].type = GRPC_ARG_INTEGER;
-    client_a[0].key =
-        const_cast<char*>(GRPC_ARG_MAX_CHANNEL_TRACE_EVENTS_PER_NODE);
-    client_a[0].value.integer = max_trace_nodes;
-    client_a[1].type = GRPC_ARG_INTEGER;
-    client_a[1].key = const_cast<char*>(GRPC_ARG_ENABLE_CHANNELZ);
-    client_a[1].value.integer = true;
+    client_a[0] = grpc_channel_arg_integer_create(
+        const_cast<char*>(GRPC_ARG_MAX_CHANNEL_TRACE_EVENTS_PER_NODE),
+        max_trace_nodes);
+    client_a[1] = grpc_channel_arg_integer_create(
+        const_cast<char*>(GRPC_ARG_ENABLE_CHANNELZ), true);
     grpc_channel_args client_args = {GPR_ARRAY_SIZE(client_a), client_a};
     channel_ =
         grpc_insecure_channel_create("fake_target", &client_args, nullptr);
@@ -255,13 +253,10 @@ TEST(ChannelzGetTopChannelsTest, InternalChannelTest) {
   (void)channels;  // suppress unused variable error
   // create an internal channel
   grpc_arg client_a[2];
-  client_a[0].type = GRPC_ARG_INTEGER;
-  client_a[0].key =
-      const_cast<char*>(GRPC_ARG_CHANNELZ_CHANNEL_IS_INTERNAL_CHANNEL);
-  client_a[0].value.integer = 1;
-  client_a[1].type = GRPC_ARG_INTEGER;
-  client_a[1].key = const_cast<char*>(GRPC_ARG_ENABLE_CHANNELZ);
-  client_a[1].value.integer = true;
+  client_a[0] = grpc_channel_arg_integer_create(
+      const_cast<char*>(GRPC_ARG_CHANNELZ_CHANNEL_IS_INTERNAL_CHANNEL), true);
+  client_a[1] = grpc_channel_arg_integer_create(
+      const_cast<char*>(GRPC_ARG_ENABLE_CHANNELZ), true);
   grpc_channel_args client_args = {GPR_ARRAY_SIZE(client_a), client_a};
   grpc_channel* internal_channel =
       grpc_insecure_channel_create("fake_target", &client_args, nullptr);

--- a/test/core/channel/channelz_test.cc
+++ b/test/core/channel/channelz_test.cc
@@ -67,9 +67,39 @@ grpc_json* GetJsonChild(grpc_json* parent, const char* key) {
   return nullptr;
 }
 
+void ValidateJsonArraySize(grpc_json* json, const char* key,
+                           size_t expected_size) {
+  grpc_json* arr = GetJsonChild(json, key);
+  if (expected_size == 0) {
+    ASSERT_EQ(arr, nullptr);
+    return;
+  }
+  ASSERT_NE(arr, nullptr);
+  ASSERT_EQ(arr->type, GRPC_JSON_ARRAY);
+  size_t count = 0;
+  for (grpc_json* child = arr->child; child != nullptr; child = child->next) {
+    ++count;
+  }
+  ASSERT_EQ(count, expected_size);
+}
+
+void ValidateGetTopChannels(size_t expected_channels) {
+  char* json_str = ChannelzRegistry::GetTopChannels(0);
+  grpc::testing::ValidateGetTopChannelsResponseProtoJsonTranslation(json_str);
+  grpc_json* parsed_json = grpc_json_parse_string(json_str);
+  // This check will naturally have to change when we support pagination.
+  // tracked: https://github.com/grpc/grpc/issues/16019.
+  ValidateJsonArraySize(parsed_json, "channel", expected_channels);
+  grpc_json* end = GetJsonChild(parsed_json, "end");
+  EXPECT_NE(end, nullptr);
+  EXPECT_EQ(end->type, GRPC_JSON_TRUE);
+  grpc_json_destroy(parsed_json);
+  gpr_free(json_str);
+}
+
 class ChannelFixture {
  public:
-  ChannelFixture(int max_trace_nodes) {
+  ChannelFixture(int max_trace_nodes = 0) {
     grpc_arg client_a[2];
     client_a[0].type = GRPC_ARG_INTEGER;
     client_a[0].key =
@@ -99,6 +129,10 @@ struct validate_channel_data_args {
 
 void ValidateChildInteger(grpc_json* json, int64_t expect, const char* key) {
   grpc_json* gotten_json = GetJsonChild(json, key);
+  if (expect == 0) {
+    ASSERT_EQ(gotten_json, nullptr);
+    return;
+  }
   ASSERT_NE(gotten_json, nullptr);
   int64_t gotten_number = (int64_t)strtol(gotten_json->value, nullptr, 0);
   EXPECT_EQ(gotten_number, expect);
@@ -115,7 +149,7 @@ void ValidateCounters(char* json_str, validate_channel_data_args args) {
 }
 
 void ValidateChannel(ChannelNode* channel, validate_channel_data_args args) {
-  char* json_str = channel->RenderJSON();
+  char* json_str = channel->RenderJsonString();
   grpc::testing::ValidateChannelProtoJsonTranslation(json_str);
   ValidateCounters(json_str, args);
   gpr_free(json_str);
@@ -141,9 +175,7 @@ TEST_P(ChannelzChannelTest, BasicChannel) {
   ChannelFixture channel(GetParam());
   ChannelNode* channelz_channel =
       grpc_channel_get_channelz_node(channel.channel());
-  char* json_str = channelz_channel->RenderJSON();
-  ValidateCounters(json_str, {0, 0, 0});
-  gpr_free(json_str);
+  ValidateChannel(channelz_channel, {0, 0, 0});
 }
 
 TEST(ChannelzChannelTest, ChannelzDisabled) {
@@ -197,6 +229,45 @@ TEST_P(ChannelzChannelTest, LastCallStartedMillis) {
   channelz_channel->RecordCallStarted();
   grpc_millis millis4 = GetLastCallStartedMillis(channelz_channel);
   EXPECT_NE(millis1, millis4);
+}
+
+TEST(ChannelzGetTopChannelsTest, BasicTest) {
+  grpc_core::ExecCtx exec_ctx;
+  ChannelFixture channel;
+  ValidateGetTopChannels(1);
+}
+
+TEST(ChannelzGetTopChannelsTest, NoChannelsTest) {
+  grpc_core::ExecCtx exec_ctx;
+  ValidateGetTopChannels(0);
+}
+
+TEST(ChannelzGetTopChannelsTest, ManyChannelsTest) {
+  grpc_core::ExecCtx exec_ctx;
+  ChannelFixture channels[10];
+  (void)channels;  // suppress unused variable error
+  ValidateGetTopChannels(10);
+}
+
+TEST(ChannelzGetTopChannelsTest, InternalChannelTest) {
+  grpc_core::ExecCtx exec_ctx;
+  ChannelFixture channels[10];
+  (void)channels;  // suppress unused variable error
+  // create an internal channel
+  grpc_arg client_a[2];
+  client_a[0].type = GRPC_ARG_INTEGER;
+  client_a[0].key =
+      const_cast<char*>(GRPC_ARG_CHANNELZ_CHANNEL_IS_INTERNAL_CHANNEL);
+  client_a[0].value.integer = 1;
+  client_a[1].type = GRPC_ARG_INTEGER;
+  client_a[1].key = const_cast<char*>(GRPC_ARG_ENABLE_CHANNELZ);
+  client_a[1].value.integer = true;
+  grpc_channel_args client_args = {GPR_ARRAY_SIZE(client_a), client_a};
+  grpc_channel* internal_channel =
+      grpc_insecure_channel_create("fake_target", &client_args, nullptr);
+  // The internal channel should not be returned from the request
+  ValidateGetTopChannels(10);
+  grpc_channel_destroy(internal_channel);
 }
 
 INSTANTIATE_TEST_CASE_P(ChannelzChannelTestSweep, ChannelzChannelTest,

--- a/test/core/end2end/tests/channelz.cc
+++ b/test/core/end2end/tests/channelz.cc
@@ -209,27 +209,27 @@ static void test_channelz(grpc_end2end_test_config config) {
       grpc_channel_get_channelz_node(f.client);
 
   GPR_ASSERT(channelz_channel != nullptr);
-  char* json = channelz_channel->RenderJSON();
+  char* json = channelz_channel->RenderJsonString();
   GPR_ASSERT(json != nullptr);
-  GPR_ASSERT(nullptr != strstr(json, "\"callsStarted\":\"0\""));
-  GPR_ASSERT(nullptr != strstr(json, "\"callsFailed\":\"0\""));
-  GPR_ASSERT(nullptr != strstr(json, "\"callsSucceeded\":\"0\""));
+  // nothing is present yet
+  GPR_ASSERT(nullptr == strstr(json, "\"callsStarted\""));
+  GPR_ASSERT(nullptr == strstr(json, "\"callsFailed\""));
+  GPR_ASSERT(nullptr == strstr(json, "\"callsSucceeded\""));
   gpr_free(json);
 
   // one successful request
   run_one_request(config, f, true);
 
-  json = channelz_channel->RenderJSON();
+  json = channelz_channel->RenderJsonString();
   GPR_ASSERT(json != nullptr);
   GPR_ASSERT(nullptr != strstr(json, "\"callsStarted\":\"1\""));
-  GPR_ASSERT(nullptr != strstr(json, "\"callsFailed\":\"0\""));
   GPR_ASSERT(nullptr != strstr(json, "\"callsSucceeded\":\"1\""));
   gpr_free(json);
 
   // one failed request
   run_one_request(config, f, false);
 
-  json = channelz_channel->RenderJSON();
+  json = channelz_channel->RenderJsonString();
   GPR_ASSERT(json != nullptr);
   gpr_log(GPR_INFO, "%s", json);
   GPR_ASSERT(nullptr != strstr(json, "\"callsStarted\":\"2\""));
@@ -264,7 +264,7 @@ static void test_channelz_with_channel_trace(grpc_end2end_test_config config) {
       grpc_channel_get_channelz_node(f.client);
 
   GPR_ASSERT(channelz_channel != nullptr);
-  char* json = channelz_channel->RenderJSON();
+  char* json = channelz_channel->RenderJsonString();
   GPR_ASSERT(json != nullptr);
   gpr_log(GPR_INFO, "%s", json);
   GPR_ASSERT(nullptr != strstr(json, "\"trace\""));

--- a/test/cpp/util/channel_trace_proto_helper.cc
+++ b/test/cpp/util/channel_trace_proto_helper.cc
@@ -64,13 +64,17 @@ void VaidateProtoJsonTranslation(char* json_c_str) {
 
 }  // namespace
 
-void ValidateChannelTraceProtoJsonTranslation(char* tracer_json_c_str) {
-  VaidateProtoJsonTranslation<grpc::channelz::v1::ChannelTrace>(
-      tracer_json_c_str);
+void ValidateChannelTraceProtoJsonTranslation(char* json_c_str) {
+  VaidateProtoJsonTranslation<grpc::channelz::v1::ChannelTrace>(json_c_str);
 }
 
-void ValidateChannelProtoJsonTranslation(char* channel_json_c_str) {
-  VaidateProtoJsonTranslation<grpc::channelz::v1::Channel>(channel_json_c_str);
+void ValidateChannelProtoJsonTranslation(char* json_c_str) {
+  VaidateProtoJsonTranslation<grpc::channelz::v1::Channel>(json_c_str);
+}
+
+void ValidateGetTopChannelsResponseProtoJsonTranslation(char* json_c_str) {
+  VaidateProtoJsonTranslation<grpc::channelz::v1::GetTopChannelsResponse>(
+      json_c_str);
 }
 
 }  // namespace testing

--- a/test/cpp/util/channel_trace_proto_helper.h
+++ b/test/cpp/util/channel_trace_proto_helper.h
@@ -22,8 +22,9 @@
 namespace grpc {
 namespace testing {
 
-void ValidateChannelTraceProtoJsonTranslation(char* tracer_json_c_str);
-void ValidateChannelProtoJsonTranslation(char* channel_json_c_str);
+void ValidateChannelTraceProtoJsonTranslation(char* json_c_str);
+void ValidateChannelProtoJsonTranslation(char* json_c_str);
+void ValidateGetTopChannelsResponseProtoJsonTranslation(char* json_c_str);
 
 }  // namespace testing
 }  // namespace grpc


### PR DESCRIPTION
Supports the GetTopChannels request.

I had to reformat the registry to know which type it tracked, but I think this is better anyway. It stops people from shooting themselves in the foot by `Get`ing the wrong type.

Tracking bug: #15340

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/16020)
<!-- Reviewable:end -->
