### PR TITLE
PR as Question: Why Does this Cause ASAN Failures??

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
@@ -122,6 +122,8 @@ class PickFirst : public LoadBalancingPolicy {
   PickState* pending_picks_ = nullptr;
   // Our connectivity state tracker.
   grpc_connectivity_state_tracker state_tracker_;
+
+  InlinedVector<int, 10> why_does_this_cause_asan_failures;
 };
 
 PickFirst::PickFirst(const Args& args) : LoadBalancingPolicy(args) {


### PR DESCRIPTION
I cannot understand what is happening here... Seems very safe.

I ran into this in #15980, and created the smallest possible repro. Any idea what is going on? Here is the output when I run `bins/asan/h2_full_test simple_request`

```
[hi on] DESK ~/Desktop/grpc [inlined-vector-asan-crash] (0) $ bins/asan/h2_full_test simple_request
D0713 17:26:58.528112884  233231 test_config.cc:391]         test slowdown factor: sanitizer=3, fixture=1, poller=1, total=3
=================================================================
==233231==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x61300000ffd0 in thread T0
    #0 0x4d5558 in __interceptor_free.localalias.0 (/usr/local/google/home/ncteisen/Desktop/grpc/bins/asan/h2_full_test+0x4d5558)
    #1 0x86792e in gpr_free /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/gpr/alloc.cc:77:3
    #2 0x91b20a in void grpc_core::Delete<grpc_core::LoadBalancingPolicy>(grpc_core::LoadBalancingPolicy*) /usr/local/google/home/ncteisen/Desktop/grpc/./src/core/lib/gprpp/memory.h:63:5
    #3 0x91b10d in grpc_core::InternallyRefCountedWithTracing<grpc_core::LoadBalancingPolicy>::Unref() /usr/local/google/home/ncteisen/Desktop/grpc/./src/core/lib/gprpp/orphanable.h:172:7
    #4 0x9194b4 in grpc_core::InternallyRefCountedWithTracing<grpc_core::LoadBalancingPolicy>::Unref(grpc_core::DebugLocation const&, char const*) /usr/local/google/home/ncteisen/Desktop/grpc/./src/core/lib/gprpp/orphanable.h:183:5
    #5 0x92cf05 in grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelList::~PickFirstSubchannelList() /usr/local/google/home/ncteisen/Desktop/grpc/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc:102:10
    #6 0x93044e in void grpc_core::Delete<grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelList>(grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelList*) /usr/local/google/home/ncteisen/Desktop/grpc/./src/core/lib/gprpp/memory.h:59:7
    #7 0x93035d in grpc_core::InternallyRefCountedWithTracing<grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelList>::Unref() /usr/local/google/home/ncteisen/Desktop/grpc/./src/core/lib/gprpp/orphanable.h:172:7
    #8 0x9302a4 in grpc_core::InternallyRefCountedWithTracing<grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelList>::Unref(grpc_core::DebugLocation const&, char const*) /usr/local/google/home/ncteisen/Desktop/grpc/./src/core/lib/gprpp/orphanable.h:183:5
    #9 0x92fb41 in grpc_core::SubchannelData<grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelList, grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelData>::StopConnectivityWatchLocked() /usr/local/google/home/ncteisen/Desktop/grpc/./src/core/ext/filters/client_channel/lb_policy/subchannel_list.h:341:22
    #10 0x930c90 in grpc_core::SubchannelData<grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelList, grpc_core::(anonymous namespace)::PickFirst::PickFirstSubchannelData>::OnConnectivityChangedLocked(void*, grpc_error*) /usr/local/google/home/ncteisen/Desktop/grpc/./src/core/ext/filters/client_channel/lb_policy/subchannel_list.h:417:9
    #11 0x776df7 in grpc_combiner_continue_exec_ctx() /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/iomgr/combiner.cc:260:5
    #12 0x673c51 in grpc_core::ExecCtx::Flush() /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/iomgr/exec_ctx.cc:131:17
    #13 0x536b5a in grpc_core::ExecCtx::~ExecCtx() /usr/local/google/home/ncteisen/Desktop/grpc/./src/core/lib/iomgr/exec_ctx.h:108:5
    #14 0x6e09d6 in grpc_channel_destroy /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/surface/channel.cc:442:1
    #15 0x6160fd in shutdown_client(grpc_end2end_test_fixture*) /usr/local/google/home/ncteisen/Desktop/grpc/test/core/end2end/tests/simple_request.cc:75:3
    #16 0x6155de in end_test(grpc_end2end_test_fixture*) /usr/local/google/home/ncteisen/Desktop/grpc/test/core/end2end/tests/simple_request.cc:81:3
    #17 0x612d01 in test_invoke_simple_request(grpc_end2end_test_config) /usr/local/google/home/ncteisen/Desktop/grpc/test/core/end2end/tests/simple_request.cc:255:3
    #18 0x612991 in simple_request(grpc_end2end_test_config) /usr/local/google/home/ncteisen/Desktop/grpc/test/core/end2end/tests/simple_request.cc:274:5
    #19 0x51b24a in grpc_end2end_tests(int, char**, grpc_end2end_test_config) /usr/local/google/home/ncteisen/Desktop/grpc/test/core/end2end/end2end_tests.cc:640:7
    #20 0x513ffb in main /usr/local/google/home/ncteisen/Desktop/grpc/test/core/end2end/fixtures/h2_full.cc:105:5
    #21 0x7f60e98e12b0 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x202b0)
    #22 0x4200c9 in _start (/usr/local/google/home/ncteisen/Desktop/grpc/bins/asan/h2_full_test+0x4200c9)

0x61300000ffd0 is located 16 bytes inside of 343-byte region [0x61300000ffc0,0x613000010117)
allocated by thread T1 (global-executor) here:
    #0 0x4d5710 in __interceptor_malloc (/usr/local/google/home/ncteisen/Desktop/grpc/bins/asan/h2_full_test+0x4d5710)
    #1 0x8677c6 in gpr_malloc /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/gpr/alloc.cc:57:7
    #2 0x867b21 in gpr_malloc_aligned /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/gpr/alloc.cc:93:13
    #3 0x92712f in grpc_core::(anonymous namespace)::PickFirst* grpc_core::New<grpc_core::(anonymous namespace)::PickFirst, grpc_core::LoadBalancingPolicy::Args const&>(grpc_core::LoadBalancingPolicy::Args const&) /usr/local/google/home/ncteisen/Desktop/grpc/./src/core/lib/gprpp/memory.h:50:19
    #4 0x926ffc in grpc_core::(anonymous namespace)::PickFirstFactory::CreateLoadBalancingPolicy(grpc_core::LoadBalancingPolicy::Args const&) const /usr/local/google/home/ncteisen/Desktop/grpc/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc:547:47
    #5 0x7468fc in grpc_core::LoadBalancingPolicyRegistry::CreateLoadBalancingPolicy(char const*, grpc_core::LoadBalancingPolicy::Args const&) /usr/local/google/home/ncteisen/Desktop/grpc/src/core/ext/filters/client_channel/lb_policy_registry.cc:94:19
    #6 0x734d81 in create_new_lb_policy_locked(client_channel_channel_data*, char*, grpc_connectivity_state*, grpc_error**) /usr/local/google/home/ncteisen/Desktop/grpc/src/core/ext/filters/client_channel/client_channel.cc:392:7
    #7 0x733d5a in on_resolver_result_changed_locked(void*, grpc_error*) /usr/local/google/home/ncteisen/Desktop/grpc/src/core/ext/filters/client_channel/client_channel.cc:530:7
    #8 0x776df7 in grpc_combiner_continue_exec_ctx() /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/iomgr/combiner.cc:260:5
    #9 0x673c51 in grpc_core::ExecCtx::Flush() /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/iomgr/exec_ctx.cc:131:17
    #10 0x77cdad in GrpcExecutor::RunClosures(grpc_closure_list) /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/iomgr/executor.cc:73:32
    #11 0x77d8bd in GrpcExecutor::ThreadMain(void*) /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/iomgr/executor.cc:175:22
    #12 0x87db11 in grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*)::{lambda(void*)#1}::operator()(void*) const /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/gprpp/thd_posix.cc:100:27
    #13 0x87d545 in grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*)::{lambda(void*)#1}::__invoke(void*) /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/gprpp/thd_posix.cc:74:25
    #14 0x4e31c2 in __asan::AsanThread::ThreadStart(unsigned long, __sanitizer::atomic_uintptr_t*) (/usr/local/google/home/ncteisen/Desktop/grpc/bins/asan/h2_full_test+0x4e31c2)

Thread T1 (global-executor) created by T0 here:
    #0 0x438c00 in pthread_create (/usr/local/google/home/ncteisen/Desktop/grpc/bins/asan/h2_full_test+0x438c00)
    #1 0x87d0cf in grpc_core::(anonymous namespace)::ThreadInternalsPosix::ThreadInternalsPosix(char const*, void (*)(void*), void*, bool*) /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/gprpp/thd_posix.cc:73:10
    #2 0x87cbc9 in grpc_core::(anonymous namespace)::ThreadInternalsPosix* grpc_core::New<grpc_core::(anonymous namespace)::ThreadInternalsPosix, char const*&, void (*&)(void*), void*&, bool*>(char const*&, void (*&)(void*), void*&, bool*&&) /usr/local/google/home/ncteisen/Desktop/grpc/./src/core/lib/gprpp/memory.h:52:18
    #3 0x87c730 in grpc_core::Thread::Thread(char const*, void (*)(void*), void*, bool*) /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/gprpp/thd_posix.cc:142:7
    #4 0x77c160 in GrpcExecutor::SetThreading(bool) /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/iomgr/executor.cc:104:9
    #5 0x77ba1a in GrpcExecutor::Init() /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/iomgr/executor.cc:53:29
    #6 0x77f05e in grpc_executor_init() /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/iomgr/executor.cc:334:20
    #7 0x674b8b in grpc_iomgr_init() /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/iomgr/iomgr.cc:54:3
    #8 0x859fe3 in grpc_init /usr/local/google/home/ncteisen/Desktop/grpc/src/core/lib/surface/init.cc:133:5
    #9 0x513f79 in main /usr/local/google/home/ncteisen/Desktop/grpc/test/core/end2end/fixtures/h2_full.cc:102:3
    #10 0x7f60e98e12b0 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x202b0)

SUMMARY: AddressSanitizer: bad-free (/usr/local/google/home/ncteisen/Desktop/grpc/bins/asan/h2_full_test+0x4d5558) in __interceptor_free.localalias.0
==233231==ABORTING
```