### PR TITLE
Channelz++: Part 1 Bootstrap the C++ Service Layer

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2061,9 +2061,11 @@ grpc_cc_library(
     ],
     hdrs = [
         "src/cpp/server/channelz/channelz_service.h",
-        "src/cpp/server/channelz/channelz_service_plugin.h",
     ],
     language = "c++",
+    public_hdrs = [
+        "include/grpcpp/ext/channelz_service_plugin.h",
+    ],
     deps = [
         ":grpc++",
         "//src/proto/grpc/channelz:channelz_proto",

--- a/BUILD
+++ b/BUILD
@@ -2054,6 +2054,24 @@ grpc_cc_library(
 )
 
 grpc_cc_library(
+    name = "grpcpp_channelz",
+    srcs = [
+        "src/cpp/server/channelz/channelz_service.cc",
+        "src/cpp/server/channelz/channelz_service_plugin.cc",
+    ],
+    hdrs = [
+        "src/cpp/server/channelz/channelz_service.h",
+        "src/cpp/server/channelz/channelz_service_plugin.h",
+    ],
+    language = "c++",
+    deps = [
+        ":grpc++",
+        "//src/proto/grpc/channelz:channelz_proto",
+    ],
+    alwayslink = 1,
+)
+
+grpc_cc_library(
     name = "grpc++_test",
     public_hdrs = [
         "include/grpc++/test/mock_stream.h",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,6 +551,7 @@ add_dependencies(buildtests_cxx channel_arguments_test)
 add_dependencies(buildtests_cxx channel_filter_test)
 add_dependencies(buildtests_cxx channel_trace_test)
 add_dependencies(buildtests_cxx channelz_registry_test)
+add_dependencies(buildtests_cxx channelz_service_test)
 add_dependencies(buildtests_cxx channelz_test)
 add_dependencies(buildtests_cxx check_gcp_environment_linux_test)
 add_dependencies(buildtests_cxx check_gcp_environment_windows_test)
@@ -4684,6 +4685,64 @@ endforeach()
 
 if (gRPC_INSTALL)
   install(TARGETS grpc_plugin_support EXPORT gRPCTargets
+    RUNTIME DESTINATION ${gRPC_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${gRPC_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
+  )
+endif()
+
+
+if (gRPC_BUILD_CODEGEN)
+add_library(grpcpp_channelz
+  src/cpp/server/channelz/channelz_service.cc
+  src/cpp/server/channelz/channelz_service_plugin.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/channelz/channelz.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/channelz/channelz.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/channelz/channelz.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/channelz/channelz.grpc.pb.h
+)
+
+if(WIN32 AND MSVC)
+  set_target_properties(grpcpp_channelz PROPERTIES COMPILE_PDB_NAME "grpcpp_channelz"
+    COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+  )
+  if (gRPC_INSTALL)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/grpcpp_channelz.pdb
+      DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
+    )
+  endif()
+endif()
+
+protobuf_generate_grpc_cpp(
+  src/proto/grpc/channelz/channelz.proto
+)
+
+target_include_directories(grpcpp_channelz
+  PUBLIC $<INSTALL_INTERFACE:${gRPC_INSTALL_INCLUDEDIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
+  PRIVATE ${_gRPC_PROTOBUF_INCLUDE_DIR}
+  PRIVATE ${_gRPC_ZLIB_INCLUDE_DIR}
+  PRIVATE ${_gRPC_BENCHMARK_INCLUDE_DIR}
+  PRIVATE ${_gRPC_CARES_INCLUDE_DIR}
+  PRIVATE ${_gRPC_GFLAGS_INCLUDE_DIR}
+  PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+  PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
+  PRIVATE ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(grpcpp_channelz
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc++
+  grpc
+)
+
+endif (gRPC_BUILD_CODEGEN)
+
+
+if (gRPC_INSTALL)
+  install(TARGETS grpcpp_channelz EXPORT gRPCTargets
     RUNTIME DESTINATION ${gRPC_INSTALL_BINDIR}
     LIBRARY DESTINATION ${gRPC_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
@@ -10863,6 +10922,54 @@ target_link_libraries(channelz_registry_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc++_test_util
+  grpc++
+  grpc
+  gpr_test_util
+  gpr
+  ${_gRPC_GFLAGS_LIBRARIES}
+)
+
+endif (gRPC_BUILD_TESTS)
+if (gRPC_BUILD_TESTS)
+
+add_executable(channelz_service_test
+  test/cpp/end2end/channelz_service_test.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/channelz/channelz.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/channelz/channelz.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/channelz/channelz.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/channelz/channelz.grpc.pb.h
+  third_party/googletest/googletest/src/gtest-all.cc
+  third_party/googletest/googlemock/src/gmock-all.cc
+)
+
+protobuf_generate_grpc_cpp(
+  src/proto/grpc/channelz/channelz.proto
+)
+
+target_include_directories(channelz_service_test
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
+  PRIVATE ${_gRPC_PROTOBUF_INCLUDE_DIR}
+  PRIVATE ${_gRPC_ZLIB_INCLUDE_DIR}
+  PRIVATE ${_gRPC_BENCHMARK_INCLUDE_DIR}
+  PRIVATE ${_gRPC_CARES_INCLUDE_DIR}
+  PRIVATE ${_gRPC_GFLAGS_INCLUDE_DIR}
+  PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+  PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
+  PRIVATE third_party/googletest/googletest/include
+  PRIVATE third_party/googletest/googletest
+  PRIVATE third_party/googletest/googlemock/include
+  PRIVATE third_party/googletest/googlemock
+  PRIVATE ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(channelz_service_test
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpcpp_channelz
+  grpc++_test_util
+  grpc_test_util
   grpc++
   grpc
   gpr_test_util

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4738,6 +4738,15 @@ target_link_libraries(grpcpp_channelz
   grpc
 )
 
+foreach(_hdr
+  include/grpcpp/ext/channelz_service_plugin.h
+)
+  string(REPLACE "include/" "" _path ${_hdr})
+  get_filename_component(_path ${_path} PATH)
+  install(FILES ${_hdr}
+    DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
+  )
+endforeach()
 endif (gRPC_BUILD_CODEGEN)
 
 

--- a/Makefile
+++ b/Makefile
@@ -1142,6 +1142,7 @@ channel_arguments_test: $(BINDIR)/$(CONFIG)/channel_arguments_test
 channel_filter_test: $(BINDIR)/$(CONFIG)/channel_filter_test
 channel_trace_test: $(BINDIR)/$(CONFIG)/channel_trace_test
 channelz_registry_test: $(BINDIR)/$(CONFIG)/channelz_registry_test
+channelz_service_test: $(BINDIR)/$(CONFIG)/channelz_service_test
 channelz_test: $(BINDIR)/$(CONFIG)/channelz_test
 check_gcp_environment_linux_test: $(BINDIR)/$(CONFIG)/check_gcp_environment_linux_test
 check_gcp_environment_windows_test: $(BINDIR)/$(CONFIG)/check_gcp_environment_windows_test
@@ -1378,12 +1379,12 @@ static: static_c static_cxx
 
 static_c: pc_c pc_c_unsecure cache.mk  $(LIBDIR)/$(CONFIG)/libaddress_sorting.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgrpc_cronet.a $(LIBDIR)/$(CONFIG)/libgrpc_unsecure.a
 
-static_cxx: pc_cxx pc_cxx_unsecure cache.mk  $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc++_cronet.a $(LIBDIR)/$(CONFIG)/libgrpc++_error_details.a $(LIBDIR)/$(CONFIG)/libgrpc++_reflection.a $(LIBDIR)/$(CONFIG)/libgrpc++_unsecure.a
+static_cxx: pc_cxx pc_cxx_unsecure cache.mk  $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc++_cronet.a $(LIBDIR)/$(CONFIG)/libgrpc++_error_details.a $(LIBDIR)/$(CONFIG)/libgrpc++_reflection.a $(LIBDIR)/$(CONFIG)/libgrpc++_unsecure.a $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a
 
 shared: shared_c shared_cxx
 
 shared_c: pc_c pc_c_unsecure cache.mk $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_cronet$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)
-shared_cxx: pc_cxx pc_cxx_unsecure cache.mk $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_cronet$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)
+shared_cxx: pc_cxx pc_cxx_unsecure cache.mk $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_cronet$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_error_details$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)
 
 shared_csharp: shared_c  $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_csharp_ext$(SHARED_VERSION_CSHARP).$(SHARED_EXT_CSHARP)
 grpc_csharp_ext: shared_csharp
@@ -1640,6 +1641,7 @@ buildtests_cxx: privatelibs_cxx \
   $(BINDIR)/$(CONFIG)/channel_filter_test \
   $(BINDIR)/$(CONFIG)/channel_trace_test \
   $(BINDIR)/$(CONFIG)/channelz_registry_test \
+  $(BINDIR)/$(CONFIG)/channelz_service_test \
   $(BINDIR)/$(CONFIG)/channelz_test \
   $(BINDIR)/$(CONFIG)/check_gcp_environment_linux_test \
   $(BINDIR)/$(CONFIG)/check_gcp_environment_windows_test \
@@ -1818,6 +1820,7 @@ buildtests_cxx: privatelibs_cxx \
   $(BINDIR)/$(CONFIG)/channel_filter_test \
   $(BINDIR)/$(CONFIG)/channel_trace_test \
   $(BINDIR)/$(CONFIG)/channelz_registry_test \
+  $(BINDIR)/$(CONFIG)/channelz_service_test \
   $(BINDIR)/$(CONFIG)/channelz_test \
   $(BINDIR)/$(CONFIG)/check_gcp_environment_linux_test \
   $(BINDIR)/$(CONFIG)/check_gcp_environment_windows_test \
@@ -2261,6 +2264,8 @@ test_cxx: buildtests_cxx
 	$(Q) $(BINDIR)/$(CONFIG)/channel_trace_test || ( echo test channel_trace_test failed ; exit 1 )
 	$(E) "[RUN]     Testing channelz_registry_test"
 	$(Q) $(BINDIR)/$(CONFIG)/channelz_registry_test || ( echo test channelz_registry_test failed ; exit 1 )
+	$(E) "[RUN]     Testing channelz_service_test"
+	$(Q) $(BINDIR)/$(CONFIG)/channelz_service_test || ( echo test channelz_service_test failed ; exit 1 )
 	$(E) "[RUN]     Testing channelz_test"
 	$(Q) $(BINDIR)/$(CONFIG)/channelz_test || ( echo test channelz_test failed ; exit 1 )
 	$(E) "[RUN]     Testing check_gcp_environment_linux_test"
@@ -2459,6 +2464,8 @@ ifeq ($(CONFIG),opt)
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/libgrpc++_reflection.a
 	$(E) "[STRIP]   Stripping libgrpc++_unsecure.a"
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/libgrpc++_unsecure.a
+	$(E) "[STRIP]   Stripping libgrpcpp_channelz.a"
+	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a
 endif
 
 strip-shared_c: shared_c
@@ -2487,6 +2494,8 @@ ifeq ($(CONFIG),opt)
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_reflection$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)
 	$(E) "[STRIP]   Stripping $(SHARED_PREFIX)grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)"
 	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)
+	$(E) "[STRIP]   Stripping $(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)"
+	$(Q) $(STRIP) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)
 endif
 
 strip-shared_csharp: shared_csharp
@@ -2946,6 +2955,9 @@ install-static_cxx: static_cxx strip-static_cxx install-pkg-config_cxx
 	$(E) "[INSTALL] Installing libgrpc++_unsecure.a"
 	$(Q) $(INSTALL) -d $(prefix)/lib
 	$(Q) $(INSTALL) $(LIBDIR)/$(CONFIG)/libgrpc++_unsecure.a $(prefix)/lib/libgrpc++_unsecure.a
+	$(E) "[INSTALL] Installing libgrpcpp_channelz.a"
+	$(Q) $(INSTALL) -d $(prefix)/lib
+	$(Q) $(INSTALL) $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a $(prefix)/lib/libgrpcpp_channelz.a
 
 
 
@@ -3047,6 +3059,15 @@ ifeq ($(SYSTEM),MINGW32)
 else ifneq ($(SYSTEM),Darwin)
 	$(Q) ln -sf $(SHARED_PREFIX)grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(prefix)/lib/libgrpc++_unsecure.so.6
 	$(Q) ln -sf $(SHARED_PREFIX)grpc++_unsecure$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(prefix)/lib/libgrpc++_unsecure.so
+endif
+	$(E) "[INSTALL] Installing $(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)"
+	$(Q) $(INSTALL) -d $(prefix)/lib
+	$(Q) $(INSTALL) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(prefix)/lib/$(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP)
+ifeq ($(SYSTEM),MINGW32)
+	$(Q) $(INSTALL) $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP)-dll.a $(prefix)/lib/libgrpcpp_channelz.a
+else ifneq ($(SYSTEM),Darwin)
+	$(Q) ln -sf $(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(prefix)/lib/libgrpcpp_channelz.so.6
+	$(Q) ln -sf $(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(prefix)/lib/libgrpcpp_channelz.so
 endif
 ifneq ($(SYSTEM),MINGW32)
 ifneq ($(SYSTEM),Darwin)
@@ -7019,6 +7040,78 @@ endif
 ifneq ($(NO_DEPS),true)
 -include $(LIBGRPC_PLUGIN_SUPPORT_OBJS:.o=.dep)
 endif
+
+
+LIBGRPCPP_CHANNELZ_SRC = \
+    src/cpp/server/channelz/channelz_service.cc \
+    src/cpp/server/channelz/channelz_service_plugin.cc \
+    $(GENDIR)/src/proto/grpc/channelz/channelz.pb.cc $(GENDIR)/src/proto/grpc/channelz/channelz.grpc.pb.cc \
+
+PUBLIC_HEADERS_CXX += \
+
+LIBGRPCPP_CHANNELZ_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(LIBGRPCPP_CHANNELZ_SRC))))
+
+
+ifeq ($(NO_SECURE),true)
+
+# You can't build secure libraries if you don't have OpenSSL.
+
+$(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a: openssl_dep_error
+
+$(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): openssl_dep_error
+
+else
+
+ifeq ($(NO_PROTOBUF),true)
+
+# You can't build a C++ library if you don't have protobuf - a bit overreached, but still okay.
+
+$(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a: protobuf_dep_error
+
+$(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): protobuf_dep_error
+
+else
+
+$(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a: $(ZLIB_DEP) $(OPENSSL_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(PROTOBUF_DEP) $(LIBGRPCPP_CHANNELZ_OBJS) 
+	$(E) "[AR]      Creating $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) rm -f $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a
+	$(Q) $(AR) $(AROPTS) $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a $(LIBGRPCPP_CHANNELZ_OBJS) 
+ifeq ($(SYSTEM),Darwin)
+	$(Q) ranlib -no_warning_for_no_symbols $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a
+endif
+
+
+
+ifeq ($(SYSTEM),MINGW32)
+$(LIBDIR)/$(CONFIG)/grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPCPP_CHANNELZ_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/grpc++$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(OPENSSL_DEP)
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,--output-def=$(LIBDIR)/$(CONFIG)/grpcpp_channelz$(SHARED_VERSION_CPP).def -Wl,--out-implib=$(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP)-dll.a -o $(LIBDIR)/$(CONFIG)/grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPCPP_CHANNELZ_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++$(SHARED_VERSION_CPP)-dll -lgrpc$(SHARED_VERSION_CORE)-dll
+else
+$(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP): $(LIBGRPCPP_CHANNELZ_OBJS)  $(ZLIB_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(PROTOBUF_DEP) $(LIBDIR)/$(CONFIG)/libgrpc++.$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpc.$(SHARED_EXT_CORE) $(OPENSSL_DEP)
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+ifeq ($(SYSTEM),Darwin)
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -install_name $(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) -dynamiclib -o $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPCPP_CHANNELZ_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc
+else
+	$(Q) $(LDXX) $(LDFLAGS) -L$(LIBDIR)/$(CONFIG) -shared -Wl,-soname,libgrpcpp_channelz.so.1 -o $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBGRPCPP_CHANNELZ_OBJS) $(ZLIB_MERGE_LIBS) $(CARES_MERGE_LIBS) $(ADDRESS_SORTING_MERGE_LIBS) $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) -lgrpc++ -lgrpc
+	$(Q) ln -sf $(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP).so.1
+	$(Q) ln -sf $(SHARED_PREFIX)grpcpp_channelz$(SHARED_VERSION_CPP).$(SHARED_EXT_CPP) $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz$(SHARED_VERSION_CPP).so
+endif
+endif
+
+endif
+
+endif
+
+ifneq ($(NO_SECURE),true)
+ifneq ($(NO_DEPS),true)
+-include $(LIBGRPCPP_CHANNELZ_OBJS:.o=.dep)
+endif
+endif
+$(OBJDIR)/$(CONFIG)/src/cpp/server/channelz/channelz_service.o: $(GENDIR)/src/proto/grpc/channelz/channelz.pb.cc $(GENDIR)/src/proto/grpc/channelz/channelz.grpc.pb.cc
+$(OBJDIR)/$(CONFIG)/src/cpp/server/channelz/channelz_service_plugin.o: $(GENDIR)/src/proto/grpc/channelz/channelz.pb.cc $(GENDIR)/src/proto/grpc/channelz/channelz.grpc.pb.cc
 
 
 LIBHTTP2_CLIENT_MAIN_SRC = \
@@ -16562,6 +16655,53 @@ endif
 endif
 
 
+CHANNELZ_SERVICE_TEST_SRC = \
+    test/cpp/end2end/channelz_service_test.cc \
+    $(GENDIR)/src/proto/grpc/channelz/channelz.pb.cc $(GENDIR)/src/proto/grpc/channelz/channelz.grpc.pb.cc \
+
+CHANNELZ_SERVICE_TEST_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(CHANNELZ_SERVICE_TEST_SRC))))
+ifeq ($(NO_SECURE),true)
+
+# You can't build secure targets if you don't have OpenSSL.
+
+$(BINDIR)/$(CONFIG)/channelz_service_test: openssl_dep_error
+
+else
+
+
+
+
+ifeq ($(NO_PROTOBUF),true)
+
+# You can't build the protoc plugins or protobuf-enabled targets if you don't have protobuf 3.5.0+.
+
+$(BINDIR)/$(CONFIG)/channelz_service_test: protobuf_dep_error
+
+else
+
+$(BINDIR)/$(CONFIG)/channelz_service_test: $(PROTOBUF_DEP) $(CHANNELZ_SERVICE_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) $(LDXX) $(LDFLAGS) $(CHANNELZ_SERVICE_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) $(LDLIBS_SECURE) $(GTEST_LIB) -o $(BINDIR)/$(CONFIG)/channelz_service_test
+
+endif
+
+endif
+
+$(OBJDIR)/$(CONFIG)/test/cpp/end2end/channelz_service_test.o:  $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
+
+$(OBJDIR)/$(CONFIG)/src/proto/grpc/channelz/channelz.o:  $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
+
+deps_channelz_service_test: $(CHANNELZ_SERVICE_TEST_OBJS:.o=.dep)
+
+ifneq ($(NO_SECURE),true)
+ifneq ($(NO_DEPS),true)
+-include $(CHANNELZ_SERVICE_TEST_OBJS:.o=.dep)
+endif
+endif
+$(OBJDIR)/$(CONFIG)/test/cpp/end2end/channelz_service_test.o: $(GENDIR)/src/proto/grpc/channelz/channelz.pb.cc $(GENDIR)/src/proto/grpc/channelz/channelz.grpc.pb.cc
+
+
 CHANNELZ_TEST_SRC = \
     test/core/channel/channelz_test.cc \
     $(GENDIR)/src/proto/grpc/channelz/channelz.pb.cc $(GENDIR)/src/proto/grpc/channelz/channelz.grpc.pb.cc \
@@ -24517,6 +24657,8 @@ src/cpp/common/secure_channel_arguments.cc: $(OPENSSL_DEP)
 src/cpp/common/secure_create_auth_context.cc: $(OPENSSL_DEP)
 src/cpp/ext/proto_server_reflection.cc: $(OPENSSL_DEP)
 src/cpp/ext/proto_server_reflection_plugin.cc: $(OPENSSL_DEP)
+src/cpp/server/channelz/channelz_service.cc: $(OPENSSL_DEP)
+src/cpp/server/channelz/channelz_service_plugin.cc: $(OPENSSL_DEP)
 src/cpp/server/secure_server_credentials.cc: $(OPENSSL_DEP)
 src/cpp/util/core_stats.cc: $(OPENSSL_DEP)
 src/cpp/util/error_details.cc: $(OPENSSL_DEP)

--- a/Makefile
+++ b/Makefile
@@ -7048,6 +7048,7 @@ LIBGRPCPP_CHANNELZ_SRC = \
     $(GENDIR)/src/proto/grpc/channelz/channelz.pb.cc $(GENDIR)/src/proto/grpc/channelz/channelz.grpc.pb.cc \
 
 PUBLIC_HEADERS_CXX += \
+    include/grpcpp/ext/channelz_service_plugin.h \
 
 LIBGRPCPP_CHANNELZ_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(LIBGRPCPP_CHANNELZ_SRC))))
 

--- a/build.yaml
+++ b/build.yaml
@@ -1111,10 +1111,6 @@ filegroups:
   secure: true
   uses:
   - grpc_trace
-- name: grpc++_channelz_proto
-  language: c++
-  src:
-  - src/proto/grpc/channelz/channelz.proto
 - name: grpc++_codegen_base
   language: c++
   public_headers:
@@ -1359,6 +1355,10 @@ filegroups:
   deps:
   - grpc++
   - grpc
+- name: grpcpp_channelz_proto
+  language: c++
+  src:
+  - src/proto/grpc/channelz/channelz.proto
 libs:
 - name: address_sorting
   build: all
@@ -1851,6 +1851,20 @@ libs:
   vs_project_guid: '{B6E81D84-2ACB-41B8-8781-493A944C7817}'
   vs_props:
   - protoc
+- name: grpcpp_channelz
+  build: all
+  language: c++
+  headers:
+  - src/cpp/server/channelz/channelz_service.h
+  - src/cpp/server/channelz/channelz_service_plugin.h
+  src:
+  - src/cpp/server/channelz/channelz_service.cc
+  - src/cpp/server/channelz/channelz_service_plugin.cc
+  deps:
+  - grpc++
+  - grpc
+  filegroups:
+  - grpcpp_channelz_proto
 - name: http2_client_main
   build: private
   language: c++
@@ -4295,7 +4309,7 @@ targets:
   - gpr_test_util
   - gpr
   filegroups:
-  - grpc++_channelz_proto
+  - grpcpp_channelz_proto
   uses:
   - grpc++_test
 - name: channelz_registry_test
@@ -4314,6 +4328,22 @@ targets:
   uses:
   - grpc++_test
   uses_polling: false
+- name: channelz_service_test
+  gtest: true
+  build: test
+  language: c++
+  src:
+  - test/cpp/end2end/channelz_service_test.cc
+  deps:
+  - grpcpp_channelz
+  - grpc++_test_util
+  - grpc_test_util
+  - grpc++
+  - grpc
+  - gpr_test_util
+  - gpr
+  filegroups:
+  - grpcpp_channelz_proto
 - name: channelz_test
   gtest: true
   build: test
@@ -4328,7 +4358,7 @@ targets:
   - gpr_test_util
   - gpr
   filegroups:
-  - grpc++_channelz_proto
+  - grpcpp_channelz_proto
   uses:
   - grpc++_test
 - name: check_gcp_environment_linux_test

--- a/build.yaml
+++ b/build.yaml
@@ -1854,9 +1854,10 @@ libs:
 - name: grpcpp_channelz
   build: all
   language: c++
+  public_headers:
+  - include/grpcpp/ext/channelz_service_plugin.h
   headers:
   - src/cpp/server/channelz/channelz_service.h
-  - src/cpp/server/channelz/channelz_service_plugin.h
   src:
   - src/cpp/server/channelz/channelz_service.cc
   - src/cpp/server/channelz/channelz_service_plugin.cc

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -1586,6 +1586,19 @@
       ],
     },
     {
+      'target_name': 'grpcpp_channelz',
+      'type': 'static_library',
+      'dependencies': [
+        'grpc++',
+        'grpc',
+      ],
+      'sources': [
+        'src/cpp/server/channelz/channelz_service.cc',
+        'src/cpp/server/channelz/channelz_service_plugin.cc',
+        'src/proto/grpc/channelz/channelz.proto',
+      ],
+    },
+    {
       'target_name': 'http2_client_main',
       'type': 'static_library',
       'dependencies': [

--- a/include/grpcpp/ext/channelz_service_plugin.h
+++ b/include/grpcpp/ext/channelz_service_plugin.h
@@ -29,7 +29,10 @@
 
 namespace grpc {
 namespace channelz {
+namespace experimental {
 
+// This plugin is experimental for now. Track progress in
+// https://github.com/grpc/grpc/issues/15988.
 class ChannelzServicePlugin : public ::grpc::ServerBuilderPlugin {
  public:
   ChannelzServicePlugin();
@@ -48,6 +51,7 @@ class ChannelzServicePlugin : public ::grpc::ServerBuilderPlugin {
 /// be called at static initialization time.
 void InitChannelzServerBuilderPlugin();
 
+}  // namespace experimental
 }  // namespace channelz
 }  // namespace grpc
 

--- a/include/grpcpp/ext/channelz_service_plugin.h
+++ b/include/grpcpp/ext/channelz_service_plugin.h
@@ -30,8 +30,9 @@ namespace channelz {
 namespace experimental {
 
 /// Add channelz server plugin to \a ServerBuilder. This function should
-/// be called at static initialization time.
-void InitChannelzServiceBuilderPlugin();
+/// be called at static initialization time. This service is experimental
+/// for now. Track progress in https://github.com/grpc/grpc/issues/15988.
+void InitChannelzService();
 
 }  // namespace experimental
 }  // namespace channelz

--- a/include/grpcpp/ext/channelz_service_plugin.h
+++ b/include/grpcpp/ext/channelz_service_plugin.h
@@ -25,31 +25,13 @@
 #include <grpcpp/impl/server_initializer.h>
 #include <grpcpp/support/config.h>
 
-#include "src/cpp/server/channelz/channelz_service.h"
-
 namespace grpc {
 namespace channelz {
 namespace experimental {
 
-// This plugin is experimental for now. Track progress in
-// https://github.com/grpc/grpc/issues/15988.
-class ChannelzServicePlugin : public ::grpc::ServerBuilderPlugin {
- public:
-  ChannelzServicePlugin();
-  ::grpc::string name() override;
-  void InitServer(::grpc::ServerInitializer* si) override;
-  void Finish(::grpc::ServerInitializer* si) override;
-  void ChangeArguments(const ::grpc::string& name, void* value) override;
-  bool has_async_methods() const override;
-  bool has_sync_methods() const override;
-
- private:
-  std::shared_ptr<grpc::ChannelzService> channelz_service_;
-};
-
 /// Add channelz server plugin to \a ServerBuilder. This function should
 /// be called at static initialization time.
-void InitChannelzServerBuilderPlugin();
+void InitChannelzServiceBuilderPlugin();
 
 }  // namespace experimental
 }  // namespace channelz

--- a/src/cpp/server/channelz/channelz_service.cc
+++ b/src/cpp/server/channelz/channelz_service.cc
@@ -1,0 +1,57 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpc/support/port_platform.h>
+
+#include "src/cpp/server/channelz/channelz_service.h"
+
+#include <google/protobuf/text_format.h>
+#include <google/protobuf/util/json_util.h>
+
+#include <grpc/grpc.h>
+#include <grpc/support/alloc.h>
+
+namespace grpc {
+
+Status ChannelzService::GetTopChannels(
+    ServerContext* unused, const channelz::v1::GetTopChannelsRequest* request,
+    channelz::v1::GetTopChannelsResponse* response) {
+  char* json_str = grpc_channelz_get_top_channels(request->start_channel_id());
+  google::protobuf::util::Status s =
+      google::protobuf::util::JsonStringToMessage(json_str, response);
+  gpr_free(json_str);
+  if (s != google::protobuf::util::Status::OK) {
+    return Status(INTERNAL, s.ToString());
+  }
+  return Status::OK;
+}
+
+Status ChannelzService::GetChannel(
+    ServerContext* unused, const channelz::v1::GetChannelRequest* request,
+    channelz::v1::GetChannelResponse* response) {
+  char* json_str = grpc_channelz_get_channel(request->channel_id());
+  google::protobuf::util::Status s =
+      google::protobuf::util::JsonStringToMessage(json_str, response);
+  gpr_free(json_str);
+  if (s != google::protobuf::util::Status::OK) {
+    return Status(INTERNAL, s.ToString());
+  }
+  return Status::OK;
+}
+
+}  // namespace grpc

--- a/src/cpp/server/channelz/channelz_service.h
+++ b/src/cpp/server/channelz/channelz_service.h
@@ -1,0 +1,43 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GRPC_INTERNAL_CPP_SERVER_CHANNELZ_SERVICE_H
+#define GRPC_INTERNAL_CPP_SERVER_CHANNELZ_SERVICE_H
+
+#include <grpc/support/port_platform.h>
+
+#include <grpcpp/grpcpp.h>
+#include "src/proto/grpc/channelz/channelz.grpc.pb.h"
+
+namespace grpc {
+
+class ChannelzService final : public channelz::v1::Channelz::Service {
+ private:
+  // implementation of GetTopChannels rpc
+  Status GetTopChannels(
+      ServerContext* unused, const channelz::v1::GetTopChannelsRequest* request,
+      channelz::v1::GetTopChannelsResponse* response) override;
+  // implementation of GetChannel rpc
+  Status GetChannel(ServerContext* unused,
+                    const channelz::v1::GetChannelRequest* request,
+                    channelz::v1::GetChannelResponse* response) override;
+};
+
+}  // namespace grpc
+
+#endif  // GRPC_INTERNAL_CPP_SERVER_CHANNELZ_SERVICE_H

--- a/src/cpp/server/channelz/channelz_service_plugin.cc
+++ b/src/cpp/server/channelz/channelz_service_plugin.cc
@@ -1,0 +1,82 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpc/support/port_platform.h>
+
+#include "src/cpp/server/channelz/channelz_service_plugin.h"
+
+#include <grpcpp/impl/server_builder_plugin.h>
+#include <grpcpp/impl/server_initializer.h>
+#include <grpcpp/server.h>
+
+#include "src/cpp/server/channelz/channelz_service.h"
+
+namespace grpc {
+namespace channelz {
+
+ChannelzServicePlugin::ChannelzServicePlugin()
+    : channelz_service_(new grpc::ChannelzService()) {}
+
+grpc::string ChannelzServicePlugin::name() { return "channelz_service"; }
+
+void ChannelzServicePlugin::InitServer(grpc::ServerInitializer* si) {
+  si->RegisterService(channelz_service_);
+}
+
+void ChannelzServicePlugin::Finish(grpc::ServerInitializer* si) {}
+
+void ChannelzServicePlugin::ChangeArguments(const grpc::string& name,
+                                            void* value) {}
+
+bool ChannelzServicePlugin::has_sync_methods() const {
+  if (channelz_service_) {
+    return channelz_service_->has_synchronous_methods();
+  }
+  return false;
+}
+
+bool ChannelzServicePlugin::has_async_methods() const {
+  if (channelz_service_) {
+    return channelz_service_->has_async_methods();
+  }
+  return false;
+}
+
+static std::unique_ptr< ::grpc::ServerBuilderPlugin>
+CreateChannelzServicePlugin() {
+  return std::unique_ptr< ::grpc::ServerBuilderPlugin>(
+      new ChannelzServicePlugin());
+}
+
+void InitChannelzServiceBuilderPlugin() {
+  static bool already_here = false;
+  if (already_here) return;
+  already_here = true;
+  ::grpc::ServerBuilder::InternalAddPluginFactory(&CreateChannelzServicePlugin);
+}
+
+// Force InitChannelzServiceBuilderPlugin() to be called at static
+// initialization time.
+struct StaticChannelServicePluginInitializer {
+  StaticChannelServicePluginInitializer() {
+    InitChannelzServiceBuilderPlugin();
+  }
+} static_channelz_service_plugin_initializer;
+
+}  // namespace channelz
+}  // namespace grpc

--- a/src/cpp/server/channelz/channelz_service_plugin.cc
+++ b/src/cpp/server/channelz/channelz_service_plugin.cc
@@ -18,8 +18,7 @@
 
 #include <grpc/support/port_platform.h>
 
-#include "src/cpp/server/channelz/channelz_service_plugin.h"
-
+#include <grpcpp/ext/channelz_service_plugin.h>
 #include <grpcpp/impl/server_builder_plugin.h>
 #include <grpcpp/impl/server_initializer.h>
 #include <grpcpp/server.h>
@@ -28,6 +27,7 @@
 
 namespace grpc {
 namespace channelz {
+namespace experimental {
 
 ChannelzServicePlugin::ChannelzServicePlugin()
     : channelz_service_(new grpc::ChannelzService()) {}
@@ -78,5 +78,6 @@ struct StaticChannelServicePluginInitializer {
   }
 } static_channelz_service_plugin_initializer;
 
+}  // namespace experimental
 }  // namespace channelz
 }  // namespace grpc

--- a/src/cpp/server/channelz/channelz_service_plugin.cc
+++ b/src/cpp/server/channelz/channelz_service_plugin.cc
@@ -29,6 +29,22 @@ namespace grpc {
 namespace channelz {
 namespace experimental {
 
+// This plugin is experimental for now. Track progress in
+// https://github.com/grpc/grpc/issues/15988.
+class ChannelzServicePlugin : public ::grpc::ServerBuilderPlugin {
+ public:
+  ChannelzServicePlugin();
+  ::grpc::string name() override;
+  void InitServer(::grpc::ServerInitializer* si) override;
+  void Finish(::grpc::ServerInitializer* si) override;
+  void ChangeArguments(const ::grpc::string& name, void* value) override;
+  bool has_async_methods() const override;
+  bool has_sync_methods() const override;
+
+ private:
+  std::shared_ptr<grpc::ChannelzService> channelz_service_;
+};
+
 ChannelzServicePlugin::ChannelzServicePlugin()
     : channelz_service_(new grpc::ChannelzService()) {}
 
@@ -69,14 +85,6 @@ void InitChannelzServiceBuilderPlugin() {
   already_here = true;
   ::grpc::ServerBuilder::InternalAddPluginFactory(&CreateChannelzServicePlugin);
 }
-
-// Force InitChannelzServiceBuilderPlugin() to be called at static
-// initialization time.
-struct StaticChannelServicePluginInitializer {
-  StaticChannelServicePluginInitializer() {
-    InitChannelzServiceBuilderPlugin();
-  }
-} static_channelz_service_plugin_initializer;
 
 }  // namespace experimental
 }  // namespace channelz

--- a/src/cpp/server/channelz/channelz_service_plugin.h
+++ b/src/cpp/server/channelz/channelz_service_plugin.h
@@ -1,0 +1,54 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef GRPCPP_EXT_CHANNELZ_SERVICE_PLUGIN_H
+#define GRPCPP_EXT_CHANNELZ_SERVICE_PLUGIN_H
+
+#include <grpc/support/port_platform.h>
+
+#include <grpcpp/impl/server_builder_plugin.h>
+#include <grpcpp/impl/server_initializer.h>
+#include <grpcpp/support/config.h>
+
+#include "src/cpp/server/channelz/channelz_service.h"
+
+namespace grpc {
+namespace channelz {
+
+class ChannelzServicePlugin : public ::grpc::ServerBuilderPlugin {
+ public:
+  ChannelzServicePlugin();
+  ::grpc::string name() override;
+  void InitServer(::grpc::ServerInitializer* si) override;
+  void Finish(::grpc::ServerInitializer* si) override;
+  void ChangeArguments(const ::grpc::string& name, void* value) override;
+  bool has_async_methods() const override;
+  bool has_sync_methods() const override;
+
+ private:
+  std::shared_ptr<grpc::ChannelzService> channelz_service_;
+};
+
+/// Add channelz server plugin to \a ServerBuilder. This function should
+/// be called at static initialization time.
+void InitChannelzServerBuilderPlugin();
+
+}  // namespace channelz
+}  // namespace grpc
+
+#endif  // GRPCPP_EXT_CHANNELZ_SERVICE_PLUGIN_H

--- a/src/proto/grpc/testing/echo_messages.proto
+++ b/src/proto/grpc/testing/echo_messages.proto
@@ -46,6 +46,7 @@ message RequestParams {
   string binary_error_details = 13;
   ErrorStatus expected_error = 14;
   int32 server_sleep_us = 15; // Amount to sleep when invoking server
+  int32 backend_channel_idx = 16; // which backend to send request to
 }
 
 message EchoRequest {

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -120,6 +120,27 @@ grpc_cc_library(
 )
 
 grpc_cc_test(
+    name = "channelz_service_test",
+    srcs = ["channelz_service_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
+    deps = [
+        ":test_service_impl",
+        "//:gpr",
+        "//:grpc",
+        "//:grpc++",
+        "//:grpcpp_channelz",
+        "//src/proto/grpc/channelz:channelz_proto",
+        "//src/proto/grpc/testing:echo_messages_proto",
+        "//src/proto/grpc/testing:echo_proto",
+        "//test/core/util:gpr_test_util",
+        "//test/core/util:grpc_test_util",
+        "//test/cpp/util:test_util",
+    ],
+)
+
+grpc_cc_test(
     name = "server_early_return_test",
     srcs = ["server_early_return_test.cc"],
     external_deps = [

--- a/test/cpp/end2end/channelz_service_test.cc
+++ b/test/cpp/end2end/channelz_service_test.cc
@@ -28,7 +28,7 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
-#include "src/cpp/server/channelz/channelz_service_plugin.h"
+#include <grpcpp/ext/channelz_service_plugin.h>
 #include "src/proto/grpc/channelz/channelz.grpc.pb.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/port.h"
@@ -179,7 +179,7 @@ class ChannelzServerTest : public ::testing::Test {
   std::vector<BackendData> backends_;
 
   // ensure channel server is linked in.
-  channelz::ChannelzServicePlugin plugin_;
+  channelz::experimental::ChannelzServicePlugin plugin_;
 };
 
 TEST_F(ChannelzServerTest, BasicTest) {

--- a/test/cpp/end2end/channelz_service_test.cc
+++ b/test/cpp/end2end/channelz_service_test.cc
@@ -106,7 +106,6 @@ class ChannelzServerTest : public ::testing::Test {
       backend_builder.AddChannelArgument(GRPC_ARG_ENABLE_CHANNELZ, 0);
       backend_builder.RegisterService(backends_[i].service.get());
       backends_[i].server = backend_builder.BuildAndStart();
-
       // set up a channel to the backend. We ensure that this channel has
       // channelz enabled since these channels (proxy outbound to backends)
       // are the ones that our test will actually be validating.

--- a/test/cpp/end2end/channelz_service_test.cc
+++ b/test/cpp/end2end/channelz_service_test.cc
@@ -1,0 +1,353 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpc/support/port_platform.h>
+
+#include <grpc/grpc.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/create_channel.h>
+#include <grpcpp/security/credentials.h>
+#include <grpcpp/security/server_credentials.h>
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
+#include <grpcpp/server_context.h>
+
+#include "src/cpp/server/channelz/channelz_service_plugin.h"
+#include "src/proto/grpc/channelz/channelz.grpc.pb.h"
+#include "src/proto/grpc/testing/echo.grpc.pb.h"
+#include "test/core/util/port.h"
+#include "test/core/util/test_config.h"
+#include "test/cpp/end2end/test_service_impl.h"
+
+#include <gtest/gtest.h>
+
+using grpc::channelz::v1::GetChannelRequest;
+using grpc::channelz::v1::GetChannelResponse;
+using grpc::channelz::v1::GetTopChannelsRequest;
+using grpc::channelz::v1::GetTopChannelsResponse;
+
+namespace grpc {
+namespace testing {
+namespace {
+
+// Proxy service supports N backends. Sends RPC to backend dictated by
+// request->backend_channel_idx().
+class Proxy : public ::grpc::testing::EchoTestService::Service {
+ public:
+  Proxy() {}
+
+  void AddChannelToBackend(const std::shared_ptr<Channel>& channel) {
+    stubs_.push_back(grpc::testing::EchoTestService::NewStub(channel));
+  }
+
+  Status Echo(ServerContext* server_context, const EchoRequest* request,
+              EchoResponse* response) override {
+    std::unique_ptr<ClientContext> client_context =
+        ClientContext::FromServerContext(*server_context);
+    size_t idx = request->param().backend_channel_idx();
+    GPR_ASSERT(idx < stubs_.size());
+    return stubs_[idx]->Echo(client_context.get(), *request, response);
+  }
+
+ private:
+  std::vector<std::unique_ptr<::grpc::testing::EchoTestService::Stub>> stubs_;
+};
+
+}  // namespace
+
+class ChannelzServerTest : public ::testing::Test {
+ public:
+  ChannelzServerTest() {}
+
+  void SetUp() override {
+    // We set up a proxy server with channelz enabled.
+    proxy_port_ = grpc_pick_unused_port_or_die();
+    ServerBuilder proxy_builder;
+    grpc::string proxy_server_address = "localhost:" + to_string(proxy_port_);
+    proxy_builder.AddListeningPort(proxy_server_address,
+                                   InsecureServerCredentials());
+    // forces channelz and channel tracing to be enabled.
+    proxy_builder.AddChannelArgument(GRPC_ARG_ENABLE_CHANNELZ, 1);
+    proxy_builder.AddChannelArgument(GRPC_ARG_MAX_CHANNEL_TRACE_EVENTS_PER_NODE,
+                                     10);
+    proxy_builder.RegisterService(&proxy_service_);
+    proxy_server_ = proxy_builder.BuildAndStart();
+  }
+
+  // Sets the proxy up to have an arbitrary number of backends.
+  void ConfigureProxy(size_t num_backends) {
+    backends_.resize(num_backends);
+    for (size_t i = 0; i < num_backends; ++i) {
+      // create a new backend.
+      backends_[i].port = grpc_pick_unused_port_or_die();
+      ServerBuilder backend_builder;
+      grpc::string backend_server_address =
+          "localhost:" + to_string(backends_[i].port);
+      backend_builder.AddListeningPort(backend_server_address,
+                                       InsecureServerCredentials());
+      backends_[i].service.reset(new TestServiceImpl);
+      // ensure that the backend itself has channelz disabled.
+      backend_builder.AddChannelArgument(GRPC_ARG_ENABLE_CHANNELZ, 0);
+      backend_builder.RegisterService(backends_[i].service.get());
+      backends_[i].server = backend_builder.BuildAndStart();
+
+      // set up a channel to the backend. We ensure that this channel has
+      // channelz enabled since these channels (proxy outbound to backends)
+      // are the ones that our test will actually be validating.
+      ChannelArguments args;
+      args.SetInt(GRPC_ARG_ENABLE_CHANNELZ, 1);
+      args.SetInt(GRPC_ARG_MAX_CHANNEL_TRACE_EVENTS_PER_NODE, 10);
+      std::shared_ptr<Channel> channel_to_backend = CreateCustomChannel(
+          backend_server_address, InsecureChannelCredentials(), args);
+      proxy_service_.AddChannelToBackend(channel_to_backend);
+    }
+  }
+
+  void ResetStubs() {
+    string target = "dns:localhost:" + to_string(proxy_port_);
+    ChannelArguments args;
+    // disable channelz. We only want to focus on proxy to backend outbound.
+    args.SetInt(GRPC_ARG_ENABLE_CHANNELZ, 0);
+    std::shared_ptr<Channel> channel =
+        CreateCustomChannel(target, InsecureChannelCredentials(), args);
+    channelz_stub_ = grpc::channelz::v1::Channelz::NewStub(channel);
+    echo_stub_ = grpc::testing::EchoTestService::NewStub(channel);
+  }
+
+  void SendSuccessfulEcho(int channel_idx) {
+    EchoRequest request;
+    EchoResponse response;
+    request.set_message("Hello channelz");
+    request.mutable_param()->set_backend_channel_idx(channel_idx);
+    ClientContext context;
+    Status s = echo_stub_->Echo(&context, request, &response);
+    EXPECT_EQ(response.message(), request.message());
+    EXPECT_TRUE(s.ok());
+  }
+
+  void SendFailedEcho(int channel_idx) {
+    EchoRequest request;
+    EchoResponse response;
+    request.set_message("Hello channelz");
+    request.mutable_param()->set_backend_channel_idx(channel_idx);
+    auto* error = request.mutable_param()->mutable_expected_error();
+    error->set_code(13);  // INTERNAL
+    error->set_error_message("error");
+    ClientContext context;
+    Status s = echo_stub_->Echo(&context, request, &response);
+    EXPECT_FALSE(s.ok());
+  }
+
+  static string to_string(const int number) {
+    std::stringstream strs;
+    strs << number;
+    return strs.str();
+  }
+
+ protected:
+  // package of data needed for each backend server.
+  struct BackendData {
+    std::unique_ptr<Server> server;
+    int port;
+    std::unique_ptr<TestServiceImpl> service;
+  };
+
+  std::unique_ptr<grpc::channelz::v1::Channelz::Stub> channelz_stub_;
+  std::unique_ptr<grpc::testing::EchoTestService::Stub> echo_stub_;
+
+  // proxy server to ping with channelz requests.
+  std::unique_ptr<Server> proxy_server_;
+  int proxy_port_;
+  Proxy proxy_service_;
+
+  // backends. All implement the echo service.
+  std::vector<BackendData> backends_;
+
+  // ensure channel server is linked in.
+  channelz::ChannelzServicePlugin plugin_;
+};
+
+TEST_F(ChannelzServerTest, BasicTest) {
+  ResetStubs();
+  ConfigureProxy(1);
+  GetTopChannelsRequest request;
+  GetTopChannelsResponse response;
+  request.set_start_channel_id(0);
+  ClientContext context;
+  Status s = channelz_stub_->GetTopChannels(&context, request, &response);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(response.channel_size(), 1);
+}
+
+TEST_F(ChannelzServerTest, HighStartId) {
+  ResetStubs();
+  ConfigureProxy(1);
+  GetTopChannelsRequest request;
+  GetTopChannelsResponse response;
+  request.set_start_channel_id(10000);
+  ClientContext context;
+  Status s = channelz_stub_->GetTopChannels(&context, request, &response);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(response.channel_size(), 0);
+}
+
+TEST_F(ChannelzServerTest, SuccessfulRequestTest) {
+  ResetStubs();
+  ConfigureProxy(1);
+  SendSuccessfulEcho(0);
+  GetChannelRequest request;
+  GetChannelResponse response;
+  request.set_channel_id(1);
+  ClientContext context;
+  Status s = channelz_stub_->GetChannel(&context, request, &response);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(response.channel().data().calls_started(), 1);
+  EXPECT_EQ(response.channel().data().calls_succeeded(), 1);
+  EXPECT_EQ(response.channel().data().calls_failed(), 0);
+}
+
+TEST_F(ChannelzServerTest, FailedRequestTest) {
+  ResetStubs();
+  ConfigureProxy(1);
+  SendFailedEcho(0);
+  GetChannelRequest request;
+  GetChannelResponse response;
+  request.set_channel_id(1);
+  ClientContext context;
+  Status s = channelz_stub_->GetChannel(&context, request, &response);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(response.channel().data().calls_started(), 1);
+  EXPECT_EQ(response.channel().data().calls_succeeded(), 0);
+  EXPECT_EQ(response.channel().data().calls_failed(), 1);
+}
+
+TEST_F(ChannelzServerTest, ManyRequestsTest) {
+  ResetStubs();
+  ConfigureProxy(1);
+  // send some RPCs
+  const int kNumSuccess = 10;
+  const int kNumFailed = 11;
+  for (int i = 0; i < kNumSuccess; ++i) {
+    SendSuccessfulEcho(0);
+  }
+  for (int i = 0; i < kNumFailed; ++i) {
+    SendFailedEcho(0);
+  }
+  GetChannelRequest request;
+  GetChannelResponse response;
+  request.set_channel_id(1);
+  ClientContext context;
+  Status s = channelz_stub_->GetChannel(&context, request, &response);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(response.channel().data().calls_started(),
+            kNumSuccess + kNumFailed);
+  EXPECT_EQ(response.channel().data().calls_succeeded(), kNumSuccess);
+  EXPECT_EQ(response.channel().data().calls_failed(), kNumFailed);
+}
+
+TEST_F(ChannelzServerTest, ManyChannels) {
+  ResetStubs();
+  const int kNumChannels = 4;
+  ConfigureProxy(kNumChannels);
+  GetTopChannelsRequest request;
+  GetTopChannelsResponse response;
+  request.set_start_channel_id(0);
+  ClientContext context;
+  Status s = channelz_stub_->GetTopChannels(&context, request, &response);
+  EXPECT_TRUE(s.ok());
+  EXPECT_EQ(response.channel_size(), kNumChannels);
+}
+
+TEST_F(ChannelzServerTest, ManyRequestsManyChannels) {
+  ResetStubs();
+  const int kNumChannels = 4;
+  ConfigureProxy(kNumChannels);
+  const int kNumSuccess = 10;
+  const int kNumFailed = 11;
+  for (int i = 0; i < kNumSuccess; ++i) {
+    SendSuccessfulEcho(0);
+    SendSuccessfulEcho(2);
+  }
+  for (int i = 0; i < kNumFailed; ++i) {
+    SendFailedEcho(1);
+    SendFailedEcho(2);
+  }
+
+  // the first channel saw only successes
+  {
+    GetChannelRequest request;
+    GetChannelResponse response;
+    request.set_channel_id(1);
+    ClientContext context;
+    Status s = channelz_stub_->GetChannel(&context, request, &response);
+    EXPECT_TRUE(s.ok());
+    EXPECT_EQ(response.channel().data().calls_started(), kNumSuccess);
+    EXPECT_EQ(response.channel().data().calls_succeeded(), kNumSuccess);
+    EXPECT_EQ(response.channel().data().calls_failed(), 0);
+  }
+
+  // the second channel saw only failures
+  {
+    GetChannelRequest request;
+    GetChannelResponse response;
+    request.set_channel_id(2);
+    ClientContext context;
+    Status s = channelz_stub_->GetChannel(&context, request, &response);
+    EXPECT_TRUE(s.ok());
+    EXPECT_EQ(response.channel().data().calls_started(), kNumFailed);
+    EXPECT_EQ(response.channel().data().calls_succeeded(), 0);
+    EXPECT_EQ(response.channel().data().calls_failed(), kNumFailed);
+  }
+
+  // the third channel saw both
+  {
+    GetChannelRequest request;
+    GetChannelResponse response;
+    request.set_channel_id(3);
+    ClientContext context;
+    Status s = channelz_stub_->GetChannel(&context, request, &response);
+    EXPECT_TRUE(s.ok());
+    EXPECT_EQ(response.channel().data().calls_started(),
+              kNumSuccess + kNumFailed);
+    EXPECT_EQ(response.channel().data().calls_succeeded(), kNumSuccess);
+    EXPECT_EQ(response.channel().data().calls_failed(), kNumFailed);
+  }
+
+  // the fourth channel saw nothing
+  {
+    GetChannelRequest request;
+    GetChannelResponse response;
+    request.set_channel_id(4);
+    ClientContext context;
+    Status s = channelz_stub_->GetChannel(&context, request, &response);
+    EXPECT_TRUE(s.ok());
+    EXPECT_EQ(response.channel().data().calls_started(), 0);
+    EXPECT_EQ(response.channel().data().calls_succeeded(), 0);
+    EXPECT_EQ(response.channel().data().calls_failed(), 0);
+  }
+}
+
+}  // namespace testing
+}  // namespace grpc
+
+int main(int argc, char** argv) {
+  grpc_test_init(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/cpp/end2end/channelz_service_test.cc
+++ b/test/cpp/end2end/channelz_service_test.cc
@@ -77,7 +77,7 @@ class ChannelzServerTest : public ::testing::Test {
 
   void SetUp() override {
     // ensure channel server is brought up on all severs we build.
-    ::grpc::channelz::experimental::InitChannelzServiceBuilderPlugin();
+    ::grpc::channelz::experimental::InitChannelzService();
 
     // We set up a proxy server with channelz enabled.
     proxy_port_ = grpc_pick_unused_port_or_die();

--- a/test/cpp/end2end/channelz_service_test.cc
+++ b/test/cpp/end2end/channelz_service_test.cc
@@ -76,6 +76,9 @@ class ChannelzServerTest : public ::testing::Test {
   ChannelzServerTest() {}
 
   void SetUp() override {
+    // ensure channel server is brought up on all severs we build.
+    ::grpc::channelz::experimental::InitChannelzServiceBuilderPlugin();
+
     // We set up a proxy server with channelz enabled.
     proxy_port_ = grpc_pick_unused_port_or_die();
     ServerBuilder proxy_builder;
@@ -177,9 +180,6 @@ class ChannelzServerTest : public ::testing::Test {
 
   // backends. All implement the echo service.
   std::vector<BackendData> backends_;
-
-  // ensure channel server is linked in.
-  channelz::experimental::ChannelzServicePlugin plugin_;
 };
 
 TEST_F(ChannelzServerTest, BasicTest) {

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -7556,17 +7556,17 @@
       "grpcpp_channelz_proto"
     ], 
     "headers": [
-      "src/cpp/server/channelz/channelz_service.h", 
-      "src/cpp/server/channelz/channelz_service_plugin.h"
+      "include/grpcpp/ext/channelz_service_plugin.h", 
+      "src/cpp/server/channelz/channelz_service.h"
     ], 
     "is_filegroup": false, 
     "language": "c++", 
     "name": "grpcpp_channelz", 
     "src": [
+      "include/grpcpp/ext/channelz_service_plugin.h", 
       "src/cpp/server/channelz/channelz_service.cc", 
       "src/cpp/server/channelz/channelz_service.h", 
-      "src/cpp/server/channelz/channelz_service_plugin.cc", 
-      "src/cpp/server/channelz/channelz_service_plugin.h"
+      "src/cpp/server/channelz/channelz_service_plugin.cc"
     ], 
     "third_party": false, 
     "type": "lib"

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -3124,10 +3124,10 @@
       "gpr_test_util", 
       "grpc", 
       "grpc++", 
-      "grpc++_channelz_proto", 
       "grpc++_test", 
       "grpc++_test_util", 
-      "grpc_test_util"
+      "grpc_test_util", 
+      "grpcpp_channelz_proto"
     ], 
     "headers": [], 
     "is_filegroup": false, 
@@ -3165,10 +3165,31 @@
       "gpr_test_util", 
       "grpc", 
       "grpc++", 
-      "grpc++_channelz_proto", 
+      "grpc++_test_util", 
+      "grpc_test_util", 
+      "grpcpp_channelz", 
+      "grpcpp_channelz_proto"
+    ], 
+    "headers": [], 
+    "is_filegroup": false, 
+    "language": "c++", 
+    "name": "channelz_service_test", 
+    "src": [
+      "test/cpp/end2end/channelz_service_test.cc"
+    ], 
+    "third_party": false, 
+    "type": "target"
+  }, 
+  {
+    "deps": [
+      "gpr", 
+      "gpr_test_util", 
+      "grpc", 
+      "grpc++", 
       "grpc++_test", 
       "grpc++_test_util", 
-      "grpc_test_util"
+      "grpc_test_util", 
+      "grpcpp_channelz_proto"
     ], 
     "headers": [], 
     "is_filegroup": false, 
@@ -7532,6 +7553,28 @@
     "deps": [
       "grpc", 
       "grpc++", 
+      "grpcpp_channelz_proto"
+    ], 
+    "headers": [
+      "src/cpp/server/channelz/channelz_service.h", 
+      "src/cpp/server/channelz/channelz_service_plugin.h"
+    ], 
+    "is_filegroup": false, 
+    "language": "c++", 
+    "name": "grpcpp_channelz", 
+    "src": [
+      "src/cpp/server/channelz/channelz_service.cc", 
+      "src/cpp/server/channelz/channelz_service.h", 
+      "src/cpp/server/channelz/channelz_service_plugin.cc", 
+      "src/cpp/server/channelz/channelz_service_plugin.h"
+    ], 
+    "third_party": false, 
+    "type": "lib"
+  }, 
+  {
+    "deps": [
+      "grpc", 
+      "grpc++", 
       "grpc++_test_config", 
       "grpc++_test_util", 
       "grpc_test_util"
@@ -10889,20 +10932,6 @@
     "type": "filegroup"
   }, 
   {
-    "deps": [], 
-    "headers": [
-      "src/proto/grpc/channelz/channelz.grpc.pb.h", 
-      "src/proto/grpc/channelz/channelz.pb.h", 
-      "src/proto/grpc/channelz/channelz_mock.grpc.pb.h"
-    ], 
-    "is_filegroup": true, 
-    "language": "c++", 
-    "name": "grpc++_channelz_proto", 
-    "src": [], 
-    "third_party": false, 
-    "type": "filegroup"
-  }, 
-  {
     "deps": [
       "grpc_codegen"
     ], 
@@ -11375,6 +11404,20 @@
       "include/grpcpp/test/mock_stream.h", 
       "include/grpcpp/test/server_context_test_spouse.h"
     ], 
+    "third_party": false, 
+    "type": "filegroup"
+  }, 
+  {
+    "deps": [], 
+    "headers": [
+      "src/proto/grpc/channelz/channelz.grpc.pb.h", 
+      "src/proto/grpc/channelz/channelz.pb.h", 
+      "src/proto/grpc/channelz/channelz_mock.grpc.pb.h"
+    ], 
+    "is_filegroup": true, 
+    "language": "c++", 
+    "name": "grpcpp_channelz_proto", 
+    "src": [], 
     "third_party": false, 
     "type": "filegroup"
   }

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3770,6 +3770,30 @@
     "flaky": false, 
     "gtest": true, 
     "language": "c++", 
+    "name": "channelz_service_test", 
+    "platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "uses_polling": true
+  }, 
+  {
+    "args": [], 
+    "benchmark": false, 
+    "ci_platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "cpu_cost": 1.0, 
+    "exclude_configs": [], 
+    "exclude_iomgrs": [], 
+    "flaky": false, 
+    "gtest": true, 
+    "language": "c++", 
     "name": "channelz_test", 
     "platforms": [
       "linux", 


### PR DESCRIPTION
C++ service that serves the channelz data exposed by Core. 

So far this only supports GetChannel and GetTopChannels, because those are the only methods that the Core supports for now. Will add more to this service as that functionality is added to Core.

Built on #16020 and #16022 

Tracking issue: #15988

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/16023)
<!-- Reviewable:end -->
