### PR TITLE
Allow choosing google default credentials in the C++ interop clients

### DIFF
--- a/test/cpp/util/test_credentials_provider.cc
+++ b/test/cpp/util/test_credentials_provider.cc
@@ -63,6 +63,8 @@ class DefaultCredentialsProvider : public CredentialsProvider {
       SslCredentialsOptions ssl_opts = {test_root_cert, "", ""};
       args->SetSslTargetNameOverride("foo.test.google.fr");
       return SslCredentials(ssl_opts);
+    } else if (type == grpc::testing::kGoogleDefaultCredentialsType) {
+      return grpc::GoogleDefaultCredentials();
     } else {
       std::unique_lock<std::mutex> lock(mu_);
       auto it(std::find(added_secure_type_names_.begin(),

--- a/test/cpp/util/test_credentials_provider.h
+++ b/test/cpp/util/test_credentials_provider.h
@@ -33,6 +33,7 @@ const char kInsecureCredentialsType[] = "INSECURE_CREDENTIALS";
 // property "transport_security_type".
 const char kTlsCredentialsType[] = "ssl";
 const char kAltsCredentialsType[] = "alts";
+const char kGoogleDefaultCredentialsType[] = "google_default_credentials";
 
 // Provide test credentials of a particular type.
 class CredentialTypeProvider {


### PR DESCRIPTION
Allows running the C++ standard interop clients with `bins/dbg/interop_client --custom_credentials_type=google_default_credentials ...`

Useful for testing google default creds specifically