### PR TITLE
Add GetHost() to ChannelInterface

### DIFF
--- a/include/grpcpp/channel.h
+++ b/include/grpcpp/channel.h
@@ -49,6 +49,14 @@ class Channel final : public ChannelInterface,
   /// not available.
   grpc::string GetServiceConfigJSON() const;
 
+  /// Return the host name for this channel.
+  ///
+  /// \return Based on the channel type this function will return:
+  /// - the actual host name if the channel represents a physical network
+  ///   connection.
+  /// - "inproc" if the channel is an in-process channel.
+  grpc::string GetHost() const override;
+
  private:
   template <class InputMessage, class OutputMessage>
   friend class internal::BlockingUnaryCallImpl;

--- a/include/grpcpp/impl/codegen/channel_interface.h
+++ b/include/grpcpp/impl/codegen/channel_interface.h
@@ -59,6 +59,14 @@ class ChannelInterface {
   /// \a try_to_connect is set to true, try to connect.
   virtual grpc_connectivity_state GetState(bool try_to_connect) = 0;
 
+  /// Return the host name for this channel.
+  ///
+  /// \return Based on the channel type this function will return:
+  /// - the actual host name if the channel represents a physical network
+  ///   connection.
+  /// - "inproc" if the channel is an in-process channel.
+  virtual grpc::string GetHost() const = 0;
+
   /// Return the \a tag on \a cq when the channel state is changed or \a
   /// deadline expires. \a GetState needs to called to get the current state.
   template <typename T>

--- a/src/cpp/client/channel_cc.cc
+++ b/src/cpp/client/channel_cc.cc
@@ -140,6 +140,10 @@ grpc_connectivity_state Channel::GetState(bool try_to_connect) {
   return grpc_channel_check_connectivity_state(c_channel_, try_to_connect);
 }
 
+grpc::string Channel::GetHost() const {
+  return host_;
+}
+
 namespace {
 
 class TagSaver final : public internal::CompletionQueueTag {


### PR DESCRIPTION
This pull request adds a function `GetHost` to `ChannelInterface`. It allows to retrieve the hostname a channel was created with, after creation.

The requirement for this change was mentioned in
https://groups.google.com/forum/#!topic/grpc-io/8T2N5_jcyJA