### PR TITLE
Channelz Part 3.67: gRPC LB Subchannel Refs Support

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel_channelz.cc
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.cc
@@ -85,12 +85,12 @@ void ClientChannelNode::PopulateChildRefs(grpc_json* json) {
     grpc_json* array_parent = grpc_json_create_child(
         nullptr, json, "channelRef", nullptr, GRPC_JSON_ARRAY, false);
     json_iterator = nullptr;
-    for (size_t i = 0; i < child_subchannels.size(); ++i) {
+    for (size_t i = 0; i < child_channels.size(); ++i) {
       json_iterator =
           grpc_json_create_child(json_iterator, array_parent, nullptr, nullptr,
                                  GRPC_JSON_OBJECT, false);
       grpc_json_add_number_string_child(json_iterator, nullptr, "channelId",
-                                        child_subchannels[i]);
+                                        child_channels[i]);
     }
   }
 }


### PR DESCRIPTION
Supports subchannels refs population for grpclb policy

Built on #16050 

Tracking in #15340

TESTED = output from `bins/opt/grpclb_end2end_test --gtest_filter=*SingleBalancerTest.Vanilla*`

```
{
  "channel":[
    {
      "ref":{
        "channelId":"1"
      },
      "data":{
        "state":{
          "state":"READY"
        },
        "target":"fake:///application_target_name",
        "callsStarted":"404",
        "callsSucceeded":"404",
        "lastCallStartedTimestamp":"2018-07-18T11:45:37.288129053Z"
      },
      "subchannelRef":[
        {
          "subchannelId":"4"
        },
        {
          "subchannelId":"5"
        },
        {
          "subchannelId":"6"
        },
        {
          "subchannelId":"7"
        }
      ],
      "channelRef":[
        {
          "channelId":"2"
        }
      ]
    }
  ],
  "end":true
}
```