### PR TITLE
Data race fix for lockfree_event

### DIFF
--- a/src/core/lib/iomgr/lockfree_event.cc
+++ b/src/core/lib/iomgr/lockfree_event.cc
@@ -91,7 +91,7 @@ void LockfreeEvent::NotifyOn(grpc_closure* closure) {
   while (true) {
     /* This load needs to be an acquire load because this can be a shutdown
      * error that we might need to reference. Adding acquire semantics makes
-     * sure that the shutdown error has been inited properly before us
+     * sure that the shutdown error has been initialized properly before us
      * referencing it. */
     gpr_atm curr = gpr_atm_acq_load(&state_);
     if (grpc_polling_trace.enabled()) {

--- a/src/core/lib/iomgr/lockfree_event.cc
+++ b/src/core/lib/iomgr/lockfree_event.cc
@@ -89,7 +89,11 @@ void LockfreeEvent::DestroyEvent() {
 
 void LockfreeEvent::NotifyOn(grpc_closure* closure) {
   while (true) {
-    gpr_atm curr = gpr_atm_no_barrier_load(&state_);
+    /* This load needs to be an acquire load because this can be a shutdown
+     * error that we might need to reference. Adding acquire semantics makes
+     * sure that the shutdown error has been inited properly before us
+     * referencing it. */
+    gpr_atm curr = gpr_atm_acq_load(&state_);
     if (grpc_polling_trace.enabled()) {
       gpr_log(GPR_ERROR, "LockfreeEvent::NotifyOn: %p curr=%p closure=%p", this,
               (void*)curr, closure);


### PR DESCRIPTION
Fixes #16009, #14470 

To explain the fix in more detail, the sequence of events for the data race is as such -
1) Thread 1 creates an error. It uses this error as the shutdown error and destroys a transport. This translates to a SetShutdown in lockfree_event. While setting this shutdown error, we use a full barrier CAS, so there is no issue here.
2) Thread 2 does a tcp_read or a similar call which translates into a NotifyOn call in lockfree_event. NotifyOn uses a no barrier load to read the value instead of using acquire semantics. This means that there is no guarantee that the error will have been properly inited at this point. 
This means that when we perform a gpr_ref on this error inside thread 2, we are potentially incrementing a garbage value. The actual initialization may happen later leading to the data race and possible segmentation faults.