### PR TITLE
Loosen restrictions on creds in C++ interop test client

### DIFF
--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -127,7 +127,7 @@ int main(int argc, char** argv) {
       &grpc::testing::InteropClient::DoTimeoutOnSleepingServer, &client);
   actions["empty_stream"] =
       std::bind(&grpc::testing::InteropClient::DoEmptyStream, &client);
-  if (FLAGS_use_tls) {
+  if (FLAGS_use_tls || FLAGS_use_alts) {
     actions["compute_engine_creds"] =
         std::bind(&grpc::testing::InteropClient::DoComputeEngineCreds, &client,
                   FLAGS_default_service_account, FLAGS_oauth_scope);

--- a/test/cpp/interop/client_helper.cc
+++ b/test/cpp/interop/client_helper.cc
@@ -88,11 +88,11 @@ std::shared_ptr<Channel> CreateChannelForTestCase(
 
   std::shared_ptr<CallCredentials> creds;
   if (test_case == "compute_engine_creds") {
-    GPR_ASSERT(FLAGS_use_tls);
+    GPR_ASSERT(FLAGS_use_tls || FLAGS_use_alts);
     creds = GoogleComputeEngineCredentials();
     GPR_ASSERT(creds);
   } else if (test_case == "jwt_token_creds") {
-    GPR_ASSERT(FLAGS_use_tls);
+    GPR_ASSERT(FLAGS_use_tls || FLAGS_use_alts);
     grpc::string json_key = GetServiceAccountJsonKey();
     std::chrono::seconds token_lifetime = std::chrono::hours(1);
     creds =


### PR DESCRIPTION
useful for new interop tests with different creds combinations