### PR TITLE
Fix re-resolution in pick first

### DIFF
--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -402,8 +402,6 @@ static void continue_connect_locked(grpc_subchannel* c) {
   c->next_attempt_deadline = c->backoff->NextAttemptTime();
   args.deadline = std::max(c->next_attempt_deadline, min_deadline);
   args.channel_args = c->args;
-  grpc_connectivity_state_set(&c->state_tracker, GRPC_CHANNEL_CONNECTING,
-                              GRPC_ERROR_NONE, "state_change");
   grpc_connector_connect(c->connector, &args, &c->connecting_result,
                          &c->on_connected);
 }
@@ -459,27 +457,24 @@ static void maybe_start_connecting_locked(grpc_subchannel* c) {
     /* Don't try to connect if we're already disconnected */
     return;
   }
-
   if (c->connecting) {
     /* Already connecting: don't restart */
     return;
   }
-
   if (c->connected_subchannel != nullptr) {
     /* Already connected: don't restart */
     return;
   }
-
   if (!grpc_connectivity_state_has_watchers(&c->state_tracker)) {
     /* Nobody is interested in connecting: so don't just yet */
     return;
   }
-
   c->connecting = true;
   GRPC_SUBCHANNEL_WEAK_REF(c, "connecting");
-
   if (!c->backoff_begun) {
     c->backoff_begun = true;
+    grpc_connectivity_state_set(&c->state_tracker, GRPC_CHANNEL_CONNECTING,
+                                GRPC_ERROR_NONE, "connecting");
     continue_connect_locked(c);
   } else {
     GPR_ASSERT(!c->have_alarm);
@@ -494,6 +489,11 @@ static void maybe_start_connecting_locked(grpc_subchannel* c) {
     }
     GRPC_CLOSURE_INIT(&c->on_alarm, on_alarm, c, grpc_schedule_on_exec_ctx);
     grpc_timer_init(&c->alarm, c->next_attempt_deadline, &c->on_alarm);
+    // During backoff, we prefer the connectivity state of CONNECTING instead of
+    // TRANSIENT_FAILURE in order to prevent triggering re-resolution
+    // continuously in pick_first.
+    grpc_connectivity_state_set(&c->state_tracker, GRPC_CHANNEL_CONNECTING,
+                                GRPC_ERROR_NONE, "backoff");
   }
 }
 

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -279,9 +279,14 @@ class ClientLbEnd2endTest : public ::testing::Test {
 
   void WaitForServer(
       const std::unique_ptr<grpc::testing::EchoTestService::Stub>& stub,
-      size_t server_idx, const grpc_core::DebugLocation& location) {
+      size_t server_idx, const grpc_core::DebugLocation& location,
+      bool ignore_failure = false) {
     do {
-      CheckRpcSendOk(stub, location);
+      if (ignore_failure) {
+        SendRpc(stub);
+      } else {
+        CheckRpcSendOk(stub, location);
+      }
     } while (servers_[server_idx]->service_.request_count() == 0);
     ResetCounters();
   }
@@ -503,6 +508,37 @@ TEST_F(ClientLbEnd2endTest, PickFirstManyUpdates) {
       if (i % 10 == 0) CheckRpcSendOk(stub, DEBUG_LOCATION);
     }
   }
+  // Check LB policy name for the channel.
+  EXPECT_EQ("pick_first", channel->GetLoadBalancingPolicyName());
+}
+
+TEST_F(ClientLbEnd2endTest, PickFirstReresolutionNoSelected) {
+  // Prepare the ports for up servers and down servers.
+  const int kNumServers = 3;
+  const int kNumAliveServers = 1;
+  StartServers(kNumAliveServers);
+  std::vector<int> alive_ports, dead_ports;
+  for (size_t i = 0; i < kNumServers; ++i) {
+    if (i < kNumAliveServers) {
+      alive_ports.emplace_back(servers_[i]->port_);
+    } else {
+      dead_ports.emplace_back(grpc_pick_unused_port_or_die());
+    }
+  }
+  auto channel = BuildChannel("pick_first");
+  auto stub = BuildStub(channel);
+  // The initial resolution only contains dead ports. There won't be any
+  // selected subchannel. Re-resolution will return the same result.
+  SetNextResolution(dead_ports);
+  gpr_log(GPR_INFO, "****** INITIAL RESOLUTION SET *******");
+  for (size_t i = 0; i < 10; ++i) CheckRpcSendFailure(stub);
+  // Set a re-resolution result that contains reachable ports, so that the
+  // pick_first LB policy can recover soon.
+  SetNextResolutionUponError(alive_ports);
+  gpr_log(GPR_INFO, "****** RE-RESOLUTION SET *******");
+  WaitForServer(stub, 0, DEBUG_LOCATION, true /* ignore_failure */);
+  CheckRpcSendOk(stub, DEBUG_LOCATION);
+  EXPECT_EQ(servers_[0]->service_.request_count(), 1);
   // Check LB policy name for the channel.
   EXPECT_EQ("pick_first", channel->GetLoadBalancingPolicyName());
 }


### PR DESCRIPTION
Fix #16070.

I can't remember why we reset the state to `IDLE` and `started_picking` to false when we introduced re-resolution in #12829. It's meant to fix some issue, apparently. But I can't find the discussion in that PR..

For the new re-resolution code in this PR, I don't do that reset and so far so good. 

For the existing reset, it seems OK to keep the reset, because when the new resolution result comes, we don't have any selected subchannel or active subchannel_list, which is just like the very beginning. 

Pushing to see more test results..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/16076)
<!-- Reviewable:end -->
