### PR TITLE
Fix Clang Tidy (again...)

### DIFF
--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -500,7 +500,7 @@ GRPCAPI const grpc_arg_pointer_vtable* grpc_resource_quota_arg_vtable(void);
 GRPCAPI char* grpc_channelz_get_top_channels(intptr_t start_channel_id);
 
 /* Gets all servers that exist in the process. */
-GRPCAPI char* grpc_channelz_get_servers(intptr_t start_channel_id);
+GRPCAPI char* grpc_channelz_get_servers(intptr_t start_server_id);
 
 /* Returns a single Channel, or else a NOT_FOUND code. The returned string
    is allocated and must be freed by the application. */

--- a/src/core/lib/channel/channel_trace.h
+++ b/src/core/lib/channel/channel_trace.h
@@ -63,7 +63,7 @@ class ChannelTrace {
   // stack, determine if it makes more sense to accept a char* instead of a
   // slice.
   void AddTraceEventWithReference(Severity severity, grpc_slice data,
-                                  RefCountedPtr<BaseNode> referenced_channel);
+                                  RefCountedPtr<BaseNode> referenced_entity);
 
   // Creates and returns the raw grpc_json object, so a parent channelz
   // object may incorporate the json before rendering.

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.h
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.h
@@ -266,7 +266,7 @@ extern grpc_resource_quota_arg_vtable_type grpc_resource_quota_arg_vtable_import
 typedef char*(*grpc_channelz_get_top_channels_type)(intptr_t start_channel_id);
 extern grpc_channelz_get_top_channels_type grpc_channelz_get_top_channels_import;
 #define grpc_channelz_get_top_channels grpc_channelz_get_top_channels_import
-typedef char*(*grpc_channelz_get_servers_type)(intptr_t start_channel_id);
+typedef char*(*grpc_channelz_get_servers_type)(intptr_t start_server_id);
 extern grpc_channelz_get_servers_type grpc_channelz_get_servers_import;
 #define grpc_channelz_get_servers grpc_channelz_get_servers_import
 typedef char*(*grpc_channelz_get_channel_type)(intptr_t channel_id);


### PR DESCRIPTION
We really need to get our clang tidy to enforce the same degree of strictness as google3 clang tidy (saying this to myself, I will pick up #15684 again)