### PR TITLE
Add Repro for RefCountedPtr Issue

### DIFF
--- a/test/core/gprpp/ref_counted_ptr_test.cc
+++ b/test/core/gprpp/ref_counted_ptr_test.cc
@@ -175,6 +175,27 @@ TEST(RefCountedPtr, RefCountedWithTracing) {
   foo->Unref(DEBUG_LOCATION, "foo");
 }
 
+class Parent : public RefCounted<Parent> {
+ public:
+  Parent() {}
+  ~Parent() {}
+};
+
+class Child : public Parent {
+ public:
+  Child() {}
+  ~Child() {}
+};
+
+void FunctionThatTakesParent(RefCountedPtr<Parent> parent) {
+  (void)parent;
+}
+
+TEST(RefCountedPtr, TestInheritance) {
+  RefCountedPtr<Child> child = MakeRefCounted<Child>();
+  FunctionThatTakesParent(child);
+}
+
 }  // namespace
 }  // namespace testing
 }  // namespace grpc_core


### PR DESCRIPTION
Error:

```
LAPTOP ~/Desktop/grpc [ref-counted-ptr] (0) $ make ref_counted_ptr_test
[CXX]     Compiling test/core/gprpp/ref_counted_ptr_test.cc
test/core/gprpp/ref_counted_ptr_test.cc:196:3: error: no matching function for call to 'FunctionThatTakesParent'
  FunctionThatTakesParent(child);
  ^~~~~~~~~~~~~~~~~~~~~~~
test/core/gprpp/ref_counted_ptr_test.cc:190:6: note: candidate function not viable: no known conversion from 'RefCountedPtr<grpc_core::testing::(anonymous namespace)::Child>' to
      'RefCountedPtr<grpc_core::testing::(anonymous namespace)::Parent>' for 1st argument
void FunctionThatTakesParent(RefCountedPtr<Parent> parent) {
     ^
1 error generated.
make: *** [/Users/ncteisen/Desktop/grpc/objs/opt/test/core/gprpp/ref_counted_ptr_test.o] Error 1
```