### PR TITLE
Add Another Repro for RefCountedPtr Issue

### DIFF
--- a/test/core/gprpp/ref_counted_ptr_test.cc
+++ b/test/core/gprpp/ref_counted_ptr_test.cc
@@ -175,6 +175,27 @@ TEST(RefCountedPtr, RefCountedWithTracing) {
   foo->Unref(DEBUG_LOCATION, "foo");
 }
 
+class Parent : public RefCounted<Parent> {
+ public:
+  Parent() {}
+  ~Parent() {}
+};
+
+class Child : public Parent {
+ public:
+  Child() {}
+  ~Child() {}
+};
+
+void FunctionThatTakesChild(RefCountedPtr<Child> child) {
+  (void)child;
+}
+
+TEST(RefCountedPtr, TestInheritance) {
+  RefCountedPtr<Child> child = MakeRefCounted<Child>();
+  FunctionThatTakesChild(child);
+}
+
 }  // namespace
 }  // namespace testing
 }  // namespace grpc_core


### PR DESCRIPTION
Error message:

```
LAPTOP ~/Desktop/grpc [ref-counted-ptr-part-2] (0) $ make ref_counted_ptr_test
[CXX]     Compiling test/core/gprpp/ref_counted_ptr_test.cc
In file included from test/core/gprpp/ref_counted_ptr_test.cc:19:
./src/core/lib/gprpp/ref_counted_ptr.h:55:48: error: 'IncrementRefCount' is a private member of 'grpc_core::RefCounted<grpc_core::testing::(anonymous namespace)::Parent>'
    if (other.value_ != nullptr) other.value_->IncrementRefCount();
                                               ^
test/core/gprpp/ref_counted_ptr_test.cc:196:26: note: in instantiation of member function 'grpc_core::RefCountedPtr<grpc_core::testing::(anonymous namespace)::Child>::RefCountedPtr' requested here
  FunctionThatTakesChild(child);
                         ^
./src/core/lib/gprpp/ref_counted.h:78:8: note: declared private here
  void IncrementRefCount() { gpr_ref(&refs_); }
       ^
1 error generated.
make: *** [/Users/ncteisen/Desktop/grpc/objs/opt/test/core/gprpp/ref_counted_ptr_test.o] Error 1
```