### PR TITLE
Added the checks to detect for Xamarin iOS and Android

### DIFF
--- a/src/csharp/Grpc.Core/Internal/NativeExtension.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeExtension.cs
@@ -106,7 +106,19 @@ namespace Grpc.Core.Internal
         /// </summary>
         private static NativeMethods LoadNativeMethods()
         {
-            return PlatformApis.IsUnity ? LoadNativeMethodsUnity() : new NativeMethods(LoadUnmanagedLibrary());
+            if (PlatformApis.IsUnity)
+            {
+                return LoadNativeMethodsUnity();
+            }
+            if (PlatformApis.IsXamariniOS)
+            {
+                return LoadNativeMethodsXamariniOS();
+            }
+            if (PlatformApis.IsXamarinAndroid)
+            {
+                return LoadNativeMethodsXamarinAndroid();
+            }
+            return new NativeMethods(LoadUnmanagedLibrary());
         }
 
         /// <summary>
@@ -126,6 +138,26 @@ namespace Grpc.Core.Internal
                     // most other platforms load unity plugins as a shared library
                     return new NativeMethods(new NativeMethods.DllImportsFromSharedLib());
             }
+        }
+
+        /// <summary>
+        /// Return native method delegates when running on the Xamarin.iOS platform.
+        /// WARNING: Xamarin.iOS support is experimental and work-in-progress. Don't expect it to work.
+        /// </summary>
+        private static NativeMethods LoadNativeMethodsXamariniOS()
+        {
+            // iOS is always a static archive
+            return new NativeMethods(new NativeMethods.DllImportsFromStaticLib());
+        }
+
+        /// <summary>
+        /// Return native method delegates when running on the Xamarin.Android platform.
+        /// WARNING: Xamarin.Android support is experimental and work-in-progress. Don't expect it to work.
+        /// </summary>
+        private static NativeMethods LoadNativeMethodsXamarinAndroid()
+        {
+            // Android is always a shared object
+            return new NativeMethods(new NativeMethods.DllImportsFromSharedLib());
         }
 
         private static string GetAssemblyPath()

--- a/src/csharp/Grpc.Core/Internal/NativeLogRedirector.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeLogRedirector.cs
@@ -51,6 +51,7 @@ namespace Grpc.Core.Internal
             }
         }
 
+        [MonoPInvokeCallback(typeof(GprLogDelegate))]
         private static void HandleWrite(IntPtr fileStringPtr, int line, ulong threadId, IntPtr severityStringPtr, IntPtr msgPtr)
         {
             try
@@ -85,5 +86,16 @@ namespace Grpc.Core.Internal
                 Console.WriteLine("Caught exception in native callback " + e);
             }
         }
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    internal sealed class MonoPInvokeCallbackAttribute : Attribute
+    {
+        public MonoPInvokeCallbackAttribute(Type type)
+        {
+            Type = type;
+        }
+
+        public Type Type { get; private set; }
     }
 }

--- a/src/csharp/Grpc.Core/Internal/PlatformApis.cs
+++ b/src/csharp/Grpc.Core/Internal/PlatformApis.cs
@@ -33,12 +33,17 @@ namespace Grpc.Core.Internal
     internal static class PlatformApis
     {
         const string UnityEngineApplicationClassName = "UnityEngine.Application, UnityEngine";
+        const string XamarinAndroidApplicationClassName = "Android.App.Application, Mono.Android";
+        const string XamariniOSApplicationClassName = "UIKit.UIApplication, Xamarin.iOS";
+
         static readonly bool isLinux;
         static readonly bool isMacOSX;
         static readonly bool isWindows;
         static readonly bool isMono;
         static readonly bool isNetCore;
         static readonly bool isUnity;
+        static readonly bool isXamariniOS;
+        static readonly bool isXamarinAndroid;
 
         static PlatformApis()
         {
@@ -58,6 +63,8 @@ namespace Grpc.Core.Internal
 #endif
             isMono = Type.GetType("Mono.Runtime") != null;
             isUnity = Type.GetType(UnityEngineApplicationClassName) != null;
+            isXamariniOS = Type.GetType(XamariniOSApplicationClassName) != null;
+            isXamarinAndroid = Type.GetType(XamarinAndroidApplicationClassName) != null;
         }
 
         public static bool IsLinux
@@ -86,6 +93,22 @@ namespace Grpc.Core.Internal
         public static bool IsUnity
         {
             get { return isUnity; }
+        }
+
+        /// <summary>
+        /// true if running on Xamarin.iOS, false otherwise.
+        /// </summary>
+        public static bool IsXamariniOS
+        {
+            get { return isXamariniOS; }
+        }
+
+        /// <summary>
+        /// true if running on Xamarin.Android, false otherwise.
+        /// </summary>
+        public static bool IsXamarinAndroid
+        {
+            get { return isXamarinAndroid; }
         }
 
         /// <summary>


### PR DESCRIPTION
This PR makes a few tweaks to the managed code to load the correct native files.

_To build the native libraries for iOS, I am using this: https://gist.github.com/mattleibow/f480c8bb4720b0fdb7d99bd087954263_

If the native files are build and added to the NuGet package, then they can be added to iOS apps with something like this: 

```xml
<?xml version="1.0" encoding="UTF-8"?>
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
    <ItemGroup>
        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\ios\native\libgrpc_csharp_ext.a">
            <Kind>Static</Kind>
            <ForceLoad>True</ForceLoad>
        </NativeReference>
        <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\ios\native\libgrpc.a">
            <Kind>Static</Kind>
            <ForceLoad>True</ForceLoad>
        </NativeReference>
    </ItemGroup>
</Project>
```

I did notice that I had to add a reference to both `libgrpc_csharp_ext.a` and `libgrpc.a`.