### PR TITLE
Enhance nightly builds infrastructure

### DIFF
--- a/tools/internal_ci/linux/grpc_publish_packages.sh
+++ b/tools/internal_ci/linux/grpc_publish_packages.sh
@@ -101,6 +101,8 @@ function add_to_manifest() {
   local artifact_prefix=$3
   local artifact_name
   artifact_name=$(basename "$artifact_file")
+  local artifact_size
+  artifact_size=$(stat -c%s "$artifact_file")
   local artifact_sha256
   artifact_sha256=$(openssl sha256 -r "$artifact_file" | cut -d " " -f 1)
   local artifact_target=$LOCAL_BUILD_ROOT/$artifact_type/$artifact_prefix
@@ -110,6 +112,7 @@ function add_to_manifest() {
     <artifact name='$artifact_name'
               type='$artifact_type'
               path='$artifact_type/$artifact_prefix$artifact_name'
+              size='$artifact_size'
               sha256='$artifact_sha256' />
 EOF
 }
@@ -144,6 +147,7 @@ EOF
 EOF
 }> "$LOCAL_BUILD_INDEX"
 
+LOCAL_BUILD_INDEX_SIZE=$(stat -c%s "$LOCAL_BUILD_INDEX")
 LOCAL_BUILD_INDEX_SHA256=$(openssl sha256 -r "$LOCAL_BUILD_INDEX" | cut -d " " -f 1)
 
 OLD_INDEX=$(mktemp)
@@ -166,6 +170,7 @@ gsutil cp "$GCS_INDEX" "$OLD_INDEX"
            branch='$BUILD_BRANCH_NAME'
            commit='$BUILD_GIT_COMMIT'
            path='$GCS_ARCHIVE_PREFIX$BUILD_RELPATH$INDEX_FILENAME'
+           size='$LOCAL_BUILD_INDEX_SIZE'
            sha256='$LOCAL_BUILD_INDEX_SHA256' />
 EOF
   tail --lines=+5 "$OLD_INDEX"

--- a/tools/internal_ci/linux/grpc_publish_packages.sh
+++ b/tools/internal_ci/linux/grpc_publish_packages.sh
@@ -39,12 +39,31 @@ mkdir -p "$LOCAL_BUILD_ROOT"
 
 find "$INPUT_ARTIFACTS" -type f
 
+# protoc Plugins
+PROTOC_PLUGINS_ZIPPED_PACKAGES=$(mktemp -d)
+for zip_dir in protoc_windows_{x86,x64}
+do
+  zip -jr "$PROTOC_PLUGINS_ZIPPED_PACKAGES/$zip_dir.zip" "$INPUT_ARTIFACTS/$zip_dir/"*
+done
+for tar_dir in protoc_{linux,macos}_{x86,x64}
+do
+  chmod +x "$INPUT_ARTIFACTS/$tar_dir"/*
+  tar -cvzf "$PROTOC_PLUGINS_ZIPPED_PACKAGES/$tar_dir.tar.gz" -C "$INPUT_ARTIFACTS/$tar_dir" .
+done
+
+PROTOC_PACKAGES=(
+  "$PROTOC_PLUGINS_ZIPPED_PACKAGES"/protoc_windows_{x86,x64}.zip
+  "$PROTOC_PLUGINS_ZIPPED_PACKAGES"/protoc_{linux,macos}_{x86,x64}.tar.gz
+)
+
+# C#
 UNZIPPED_CSHARP_PACKAGES=$(mktemp -d)
 unzip "$INPUT_ARTIFACTS/csharp_nugets_windows_dotnetcli.zip" -d "$UNZIPPED_CSHARP_PACKAGES"
 CSHARP_PACKAGES=(
   "$UNZIPPED_CSHARP_PACKAGES"/*
 )
 
+# Python
 PYTHON_PACKAGES=(
   "$INPUT_ARTIFACTS"/grpcio-[0-9]*.tar.gz
   "$INPUT_ARTIFACTS"/grpcio-[0-9]*.whl
@@ -59,10 +78,12 @@ PYTHON_PACKAGES=(
   "$INPUT_ARTIFACTS"/grpcio-testing-[0-9]*.tar.gz
 )
 
+# PHP
 PHP_PACKAGES=(
   "$INPUT_ARTIFACTS"/grpc-[0-9]*.tgz
 )
 
+# Ruby
 RUBY_PACKAGES=(
   "$INPUT_ARTIFACTS"/grpc-[0-9]*.gem
   "$INPUT_ARTIFACTS"/grpc-tools-[0-9]*.gem
@@ -100,6 +121,7 @@ EOF
   <artifacts>
 EOF
 
+  for pkg in "${PROTOC_PACKAGES[@]}"; do add_to_manifest protoc "$pkg"; done
   for pkg in "${CSHARP_PACKAGES[@]}"; do add_to_manifest csharp "$pkg"; done
   for pkg in "${PHP_PACKAGES[@]}"; do add_to_manifest php "$pkg"; done
   for pkg in "${PYTHON_PACKAGES[@]}"; do add_to_manifest python "$pkg"; done

--- a/tools/internal_ci/linux/grpc_publish_packages.sh
+++ b/tools/internal_ci/linux/grpc_publish_packages.sh
@@ -111,7 +111,7 @@ EOF
   cat <<EOF
 <?xml version="1.0"?>
 <?xml-stylesheet href="/web-assets/build-201807.xsl" type="text/xsl"?>
-<build id='$BUILD_ID' timestamp='$BUILD_TIMESTAMP'>
+<build id='$BUILD_ID' timestamp='$BUILD_TIMESTAMP' version="201807">
   <metadata>
     <project>gRPC</project>
     <repository>https://github.com/grpc/grpc</repository>

--- a/tools/internal_ci/linux/grpc_publish_packages.sh
+++ b/tools/internal_ci/linux/grpc_publish_packages.sh
@@ -64,17 +64,23 @@ CSHARP_PACKAGES=(
 )
 
 # Python
-PYTHON_PACKAGES=(
+PYTHON_GRPCIO_PACKAGES=(
   "$INPUT_ARTIFACTS"/grpcio-[0-9]*.tar.gz
   "$INPUT_ARTIFACTS"/grpcio-[0-9]*.whl
   "$INPUT_ARTIFACTS"/python_linux_extra_arm*/grpcio-[0-9]*.whl
-
+)
+PYTHON_GRPCIO_TOOLS_PACKAGES=(
   "$INPUT_ARTIFACTS"/grpcio-tools-[0-9]*.tar.gz
   "$INPUT_ARTIFACTS"/grpcio_tools-[0-9]*.whl
   "$INPUT_ARTIFACTS"/python_linux_extra_arm*/grpcio_tools-[0-9]*.whl
-
+)
+PYTHON_GRPCIO_HEALTH_CHECKING_PACKAGES=(
   "$INPUT_ARTIFACTS"/grpcio-health-checking-[0-9]*.tar.gz
+)
+PYTHON_GRPCIO_REFLECTION_PACKAGES=(
   "$INPUT_ARTIFACTS"/grpcio-reflection-[0-9]*.tar.gz
+)
+PYTHON_GRPCIO_TESTING_PACKAGES=(
   "$INPUT_ARTIFACTS"/grpcio-testing-[0-9]*.tar.gz
 )
 
@@ -92,17 +98,18 @@ RUBY_PACKAGES=(
 function add_to_manifest() {
   local artifact_type=$1
   local artifact_file=$2
+  local artifact_prefix=$3
   local artifact_name
   artifact_name=$(basename "$artifact_file")
   local artifact_sha256
   artifact_sha256=$(openssl sha256 -r "$artifact_file" | cut -d " " -f 1)
-  local artifact_target=$LOCAL_BUILD_ROOT/$artifact_type
+  local artifact_target=$LOCAL_BUILD_ROOT/$artifact_type/$artifact_prefix
   mkdir -p "$artifact_target"
   cp "$artifact_file" "$artifact_target"
   cat <<EOF
     <artifact name='$artifact_name'
               type='$artifact_type'
-              path='$artifact_type/$artifact_name'
+              path='$artifact_type/$artifact_prefix$artifact_name'
               sha256='$artifact_sha256' />
 EOF
 }
@@ -124,7 +131,11 @@ EOF
   for pkg in "${PROTOC_PACKAGES[@]}"; do add_to_manifest protoc "$pkg"; done
   for pkg in "${CSHARP_PACKAGES[@]}"; do add_to_manifest csharp "$pkg"; done
   for pkg in "${PHP_PACKAGES[@]}"; do add_to_manifest php "$pkg"; done
-  for pkg in "${PYTHON_PACKAGES[@]}"; do add_to_manifest python "$pkg"; done
+  for pkg in "${PYTHON_GRPCIO_PACKAGES[@]}"; do add_to_manifest python "$pkg" grpcio/; done
+  for pkg in "${PYTHON_GRPCIO_TOOLS_PACKAGES[@]}"; do add_to_manifest python "$pkg" grpcio-tools/; done
+  for pkg in "${PYTHON_GRPCIO_HEALTH_CHECKING_PACKAGES[@]}"; do add_to_manifest python "$pkg" grpcio-health-checking/; done
+  for pkg in "${PYTHON_GRPCIO_REFLECTION_PACKAGES[@]}"; do add_to_manifest python "$pkg" grpcio-reflection/; done
+  for pkg in "${PYTHON_GRPCIO_TESTING_PACKAGES[@]}"; do add_to_manifest python "$pkg" grpcio-testing/; done
   for pkg in "${RUBY_PACKAGES[@]}"; do add_to_manifest ruby "$pkg"; done
 
   cat <<EOF


### PR DESCRIPTION
- Add `protoc` packages to nightlies.
- Put `python` packages in different directories to be able to fetch easily via `pip`.
- Generate HTML indicies for subdirectories for ease of access and discovery of tools like `pip`.
- Put file sizes in XML manifest files along with their SHA256 hashes. (Should add signatures soon).