### PR TITLE
Xamarin iOS: Add libgrpc_csharp_ext.a for iOS into Grpc.Core nuget.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1381,6 +1381,8 @@ static_c: pc_c pc_c_unsecure cache.mk  $(LIBDIR)/$(CONFIG)/libaddress_sorting.a 
 
 static_cxx: pc_cxx pc_cxx_unsecure cache.mk  $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc++_cronet.a $(LIBDIR)/$(CONFIG)/libgrpc++_error_details.a $(LIBDIR)/$(CONFIG)/libgrpc++_reflection.a $(LIBDIR)/$(CONFIG)/libgrpc++_unsecure.a $(LIBDIR)/$(CONFIG)/libgrpcpp_channelz.a
 
+static_csharp: static_c  $(LIBDIR)/$(CONFIG)/libgrpc_csharp_ext.a
+
 shared: shared_c shared_cxx
 
 shared_c: pc_c pc_c_unsecure cache.mk $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)address_sorting$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)gpr$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_cronet$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE) $(LIBDIR)/$(CONFIG)/$(SHARED_PREFIX)grpc_unsecure$(SHARED_VERSION_CORE).$(SHARED_EXT_CORE)

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -54,11 +54,11 @@
       <PackagePath>runtimes/monoandroid/arm64-v8a/libgrpc_csharp_ext.so</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="..\nativelibs\csharp_ext_macos_ios\arm64\libgrpc_csharp_ext.a">
+    <Content Include="..\nativelibs\csharp_ext_macos_ios\libgrpc_csharp_ext.a">
       <PackagePath>runtimes/ios/native/libgrpc_csharp_ext.a</PackagePath>
       <Pack>true</Pack>
     </Content>
-    <Content Include="..\nativelibs\csharp_ext_macos_ios\arm64\libgrpc.a">
+    <Content Include="..\nativelibs\csharp_ext_macos_ios\libgrpc.a">
       <PackagePath>runtimes/ios/native/libgrpc.a</PackagePath>
       <Pack>true</Pack>
     </Content>

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -54,12 +54,24 @@
       <PackagePath>runtimes/monoandroid/arm64-v8a/libgrpc_csharp_ext.so</PackagePath>
       <Pack>true</Pack>
     </Content>
+    <Content Include="..\nativelibs\csharp_ext_macos_ios\arm64\libgrpc_csharp_ext.a">
+      <PackagePath>runtimes/ios/native/libgrpc_csharp_ext.a</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="..\nativelibs\csharp_ext_macos_ios\arm64\libgrpc.a">
+      <PackagePath>runtimes/ios/native/libgrpc.a</PackagePath>
+      <Pack>true</Pack>
+    </Content>
     <Content Include="build\net45\Grpc.Core.targets">
       <PackagePath>build/net45/</PackagePath>
       <Pack>true</Pack>
     </Content>
     <Content Include="build\MonoAndroid\Grpc.Core.targets">
       <PackagePath>build/MonoAndroid/</PackagePath>
+      <Pack>true</Pack>
+    </Content>
+    <Content Include="build\Xamarin.iOS\Grpc.Core.targets">
+      <PackagePath>build/Xamarin.iOS/</PackagePath>
       <Pack>true</Pack>
     </Content>
   </ItemGroup>

--- a/src/csharp/Grpc.Core/build/Xamarin.iOS/Grpc.Core.targets
+++ b/src/csharp/Grpc.Core/build/Xamarin.iOS/Grpc.Core.targets
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup>
+    <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\ios\native\libgrpc_csharp_ext.a">
+      <Kind>Static</Kind>
+      <ForceLoad>True</ForceLoad>
+    </NativeReference>
+    <NativeReference Include="$(MSBuildThisFileDirectory)..\..\runtimes\ios\native\libgrpc.a">
+      <Kind>Static</Kind>
+      <ForceLoad>True</ForceLoad>
+    </NativeReference>
+  </ItemGroup>
+
+</Project>

--- a/src/csharp/experimental/build_native_ext_for_ios.sh
+++ b/src/csharp/experimental/build_native_ext_for_ios.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Copyright 2018 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Helper script to crosscompile grpc_csharp_ext native extension for Android.
+
+set -ex
+
+cd "$(dirname "$0")/../../.."
+
+# <iphoneos|iphonesimulator>
+SDK="iphoneos"
+# <arm64|x86_64|...>
+ARCH="arm64"
+
+PATH_AR="$(xcrun --sdk $SDK --find ar)"
+PATH_CC="$(xcrun --sdk $SDK --find clang)"
+PATH_CXX="$(xcrun --sdk $SDK --find clang++)"
+
+# TODO(jtattermusch): add  -mios-version-min=6.0 and -Wl,ios_version_min=6.0
+CPPFLAGS="-O2 -Wframe-larger-than=16384 -arch $ARCH -isysroot $(xcrun --sdk $SDK --show-sdk-path) -DPB_NO_PACKED_STRUCTS=1"
+LDFLAGS="-arch $ARCH -isysroot $(xcrun --sdk $SDK --show-sdk-path)"
+
+# TODO(jtattermusch): revisit the build arguments
+make -j4 static_csharp \
+    VALID_CONFIG_ios_$ARCH="1" \
+    CC_ios_$ARCH="$PATH_CC" \
+    CXX_ios_$ARCH="$PATH_CXX" \
+    LD_ios_$ARCH="$PATH_CC" \
+    LDXX_ios_$ARCH="$PATH_CXX" \
+    CPPFLAGS_ios_$ARCH="$CPPFLAGS" \
+    LDFLAGS_ios_$ARCH="$LDFLAGS" \
+    DEFINES_ios_$ARCH="NDEBUG" \
+    CONFIG="ios_$ARCH"

--- a/src/csharp/experimental/build_native_ext_for_ios.sh
+++ b/src/csharp/experimental/build_native_ext_for_ios.sh
@@ -19,27 +19,44 @@ set -ex
 
 cd "$(dirname "$0")/../../.."
 
-# <iphoneos|iphonesimulator>
-SDK="iphoneos"
-# <arm64|x86_64|...>
-ARCH="arm64"
+# Usage: build <iphoneos|iphonesimulator> <arm64|x86_64|...>
+function build {
+    SDK="$1"
+    ARCH="$2"
 
-PATH_AR="$(xcrun --sdk $SDK --find ar)"
-PATH_CC="$(xcrun --sdk $SDK --find clang)"
-PATH_CXX="$(xcrun --sdk $SDK --find clang++)"
+    PATH_AR="$(xcrun --sdk $SDK --find ar)"
+    PATH_CC="$(xcrun --sdk $SDK --find clang)"
+    PATH_CXX="$(xcrun --sdk $SDK --find clang++)"
 
-# TODO(jtattermusch): add  -mios-version-min=6.0 and -Wl,ios_version_min=6.0
-CPPFLAGS="-O2 -Wframe-larger-than=16384 -arch $ARCH -isysroot $(xcrun --sdk $SDK --show-sdk-path) -DPB_NO_PACKED_STRUCTS=1"
-LDFLAGS="-arch $ARCH -isysroot $(xcrun --sdk $SDK --show-sdk-path)"
+    # TODO(jtattermusch): add  -mios-version-min=6.0 and -Wl,ios_version_min=6.0
+    CPPFLAGS="-O2 -Wframe-larger-than=16384 -arch $ARCH -isysroot $(xcrun --sdk $SDK --show-sdk-path) -DPB_NO_PACKED_STRUCTS=1"
+    LDFLAGS="-arch $ARCH -isysroot $(xcrun --sdk $SDK --show-sdk-path)"
 
-# TODO(jtattermusch): revisit the build arguments
-make -j4 static_csharp \
-    VALID_CONFIG_ios_$ARCH="1" \
-    CC_ios_$ARCH="$PATH_CC" \
-    CXX_ios_$ARCH="$PATH_CXX" \
-    LD_ios_$ARCH="$PATH_CC" \
-    LDXX_ios_$ARCH="$PATH_CXX" \
-    CPPFLAGS_ios_$ARCH="$CPPFLAGS" \
-    LDFLAGS_ios_$ARCH="$LDFLAGS" \
-    DEFINES_ios_$ARCH="NDEBUG" \
-    CONFIG="ios_$ARCH"
+    # TODO(jtattermusch): revisit the build arguments
+    make -j4 static_csharp \
+        VALID_CONFIG_ios_$ARCH="1" \
+        CC_ios_$ARCH="$PATH_CC" \
+        CXX_ios_$ARCH="$PATH_CXX" \
+        LD_ios_$ARCH="$PATH_CC" \
+        LDXX_ios_$ARCH="$PATH_CXX" \
+        CPPFLAGS_ios_$ARCH="$CPPFLAGS" \
+        LDFLAGS_ios_$ARCH="$LDFLAGS" \
+        DEFINES_ios_$ARCH="NDEBUG" \
+        CONFIG="ios_$ARCH"
+}
+
+# Usage: fatten <grpc_csharp_ext|...>
+function fatten {
+    LIB_NAME="$1"
+
+    mkdir -p libs/ios
+    lipo -create -output libs/ios/lib$LIB_NAME.a \
+        libs/ios_arm64/lib$LIB_NAME.a \
+        libs/ios_x86_64/lib$LIB_NAME.a
+}
+
+build iphoneos arm64
+build iphonesimulator x86_64
+
+fatten grpc
+fatten grpc_csharp_ext

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -921,6 +921,16 @@
   % endfor
 
 
+  static_csharp: static_c \
+  % for lib in libs:
+  % if 'Makefile' in lib.get('build_system', ['Makefile']):
+  % if lib.build == 'all' and lib.language == 'csharp':
+   $(LIBDIR)/$(CONFIG)/lib${lib.name}.a\
+  % endif
+  % endif
+  % endfor
+
+
   shared: shared_c shared_cxx
 
   shared_c: pc_c pc_c_unsecure cache.mk\

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -234,6 +234,11 @@ class CSharpExtArtifact:
                 environ={
                     'ANDROID_ABI': self.arch_abi
                 })
+        elif self.arch == 'ios':
+            return create_jobspec(
+                self.name,
+                ['tools/run_tests/artifacts/build_artifact_csharp_ios.sh'],
+                use_workspace=True)
         elif self.platform == 'windows':
             cmake_arch_option = 'Win32' if self.arch == 'x86' else self.arch
             return create_jobspec(
@@ -356,6 +361,7 @@ def targets():
     ] + [
         CSharpExtArtifact('linux', 'android', arch_abi='arm64-v8a'),
         CSharpExtArtifact('linux', 'android', arch_abi='armeabi-v7a'),
+        CSharpExtArtifact('macos', 'ios'),
         PythonArtifact('linux', 'x86', 'cp27-cp27m'),
         PythonArtifact('linux', 'x86', 'cp27-cp27mu'),
         PythonArtifact('linux', 'x86', 'cp34-cp34m'),

--- a/tools/run_tests/artifacts/build_artifact_csharp_ios.sh
+++ b/tools/run_tests/artifacts/build_artifact_csharp_ios.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright 2016 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+cd "$(dirname "$0")/../../.."
+
+src/csharp/experimental/build_native_ext_for_ios.sh
+
+mkdir -p "${ARTIFACTS_OUT}"
+cp libs/ios_arm64/libgrpc_csharp_ext.a libs/ios_arm64/libgrpc.a "${ARTIFACTS_OUT}"

--- a/tools/run_tests/artifacts/build_artifact_csharp_ios.sh
+++ b/tools/run_tests/artifacts/build_artifact_csharp_ios.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2016 The gRPC Authors
+# Copyright 2018 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/run_tests/artifacts/build_artifact_csharp_ios.sh
+++ b/tools/run_tests/artifacts/build_artifact_csharp_ios.sh
@@ -20,4 +20,4 @@ cd "$(dirname "$0")/../../.."
 src/csharp/experimental/build_native_ext_for_ios.sh
 
 mkdir -p "${ARTIFACTS_OUT}"
-cp libs/ios_arm64/libgrpc_csharp_ext.a libs/ios_arm64/libgrpc.a "${ARTIFACTS_OUT}"
+cp libs/ios/libgrpc_csharp_ext.a libs/ios/libgrpc.a "${ARTIFACTS_OUT}"


### PR DESCRIPTION
- add static_csharp target to Makefile because iOS requires static build of grpc_csharp_ext.a
- build a fat library "grpc_csharp_ext.a"  that supports both arm64 and x86_64 (arm64 is supported by iPhone 6+ which is good enough to start with and x86_64 is needed for iOS simulator) and bundle it in the Grpc.Core nuget
- provide a Xamarin.iOS  .targets file so that project importing Grpc.Core nuget will pick up the native reference to grpc_csharp_ext.a

Inspired by ideas and comments from https://github.com/grpc/grpc/pull/16089