### PR TITLE
Add a C++ wrapper for local credentials

### DIFF
--- a/include/grpc/grpc_security.h
+++ b/include/grpc/grpc_security.h
@@ -588,12 +588,6 @@ GRPCAPI grpc_server_credentials* grpc_alts_server_credentials_create(
 /** --- Local channel/server credentials --- **/
 
 /**
- * Type of local connection for which local channel/server credentials will be
- * applied. It only supports UDS for now.
- */
-typedef enum { UDS = 0 } grpc_local_connect_type;
-
-/**
  * This method creates a local channel credential object. It is used for
  * experimental purpose for now and subject to change.
  *

--- a/include/grpc/grpc_security_constants.h
+++ b/include/grpc/grpc_security_constants.h
@@ -100,6 +100,12 @@ typedef enum {
   GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY
 } grpc_ssl_client_certificate_request_type;
 
+/**
+ * Type of local connection for which local channel/server credentials will be
+ * applied. It only supports UDS for now.
+ */
+typedef enum { UDS = 0 } grpc_local_connect_type;
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/grpcpp/security/credentials.h
+++ b/include/grpcpp/security/credentials.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <vector>
 
+#include <grpc/grpc_security_constants.h>
 #include <grpcpp/impl/codegen/grpc_library.h>
 #include <grpcpp/security/auth_context.h>
 #include <grpcpp/support/status.h>
@@ -233,6 +234,10 @@ struct AltsCredentialsOptions {
 /// Builds ALTS Credentials given ALTS specific options
 std::shared_ptr<ChannelCredentials> AltsCredentials(
     const AltsCredentialsOptions& options);
+
+/// Builds Local Credentials.
+std::shared_ptr<ChannelCredentials> LocalCredentials(
+    grpc_local_connect_type type);
 
 }  // namespace experimental
 }  // namespace grpc

--- a/include/grpcpp/security/server_credentials.h
+++ b/include/grpcpp/security/server_credentials.h
@@ -97,6 +97,10 @@ struct AltsServerCredentialsOptions {
 std::shared_ptr<ServerCredentials> AltsServerCredentials(
     const AltsServerCredentialsOptions& options);
 
+/// Builds Local ServerCredentials.
+std::shared_ptr<ServerCredentials> LocalServerCredentials(
+    grpc_local_connect_type type);
+
 }  // namespace experimental
 }  // namespace grpc
 

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -107,6 +107,13 @@ std::shared_ptr<ChannelCredentials> AltsCredentials(
   return WrapChannelCredentials(c_creds);
 }
 
+// Builds Local Credentials
+std::shared_ptr<ChannelCredentials> LocalCredentials(
+    grpc_local_connect_type type) {
+  GrpcLibraryCodegen init;  // To call grpc_init().
+  return WrapChannelCredentials(grpc_local_credentials_create(type));
+}
+
 }  // namespace experimental
 
 // Builds credentials for use when running in GCE

--- a/src/cpp/server/secure_server_credentials.cc
+++ b/src/cpp/server/secure_server_credentials.cc
@@ -139,5 +139,11 @@ std::shared_ptr<ServerCredentials> AltsServerCredentials(
       new SecureServerCredentials(c_creds));
 }
 
+std::shared_ptr<ServerCredentials> LocalServerCredentials(
+    grpc_local_connect_type type) {
+  return std::shared_ptr<ServerCredentials>(
+      new SecureServerCredentials(grpc_local_server_credentials_create(type)));
+}
+
 }  // namespace experimental
 }  // namespace grpc


### PR DESCRIPTION
Similar to ALTS, the local credentials are placed in an "experimental" namespace.