### PR TITLE
Remove stripping

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -98,21 +98,3 @@ $CFLAGS << ' -pedantic '
 output = File.join('grpc', 'grpc_c')
 puts 'Generating Makefile for ' + output
 create_makefile(output)
-
-strip_tool = RbConfig::CONFIG['STRIP']
-strip_tool = 'strip -x' if RUBY_PLATFORM =~ /darwin/
-
-if grpc_config == 'opt'
-  File.open('Makefile.new', 'w') do |o|
-    o.puts 'hijack: all strip'
-    o.puts
-    File.foreach('Makefile') do |i|
-      o.puts i
-    end
-    o.puts
-    o.puts 'strip:'
-    o.puts "\t$(ECHO) Stripping $(DLLIB)"
-    o.puts "\t$(Q) #{strip_tool} $(DLLIB)"
-  end
-  File.rename('Makefile.new', 'Makefile')
-end


### PR DESCRIPTION
Don't strip binaries.  End users can have the option to strip the binary
themselves.

Hi, I'm not sure why this strips binaries by default.  I saw it was introduced in e7a91a2f57e, but I don't understand the reason.  I'd like to compile the gem without stripping.  I think if people want to strip the binary, they should do it themselves.  Or if we're building a pre-compiled gem, make stripping part of the packaging process.

Thanks!