### PR TITLE
Grpc.Core: add support for x86 android emulator

### DIFF
--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -54,6 +54,10 @@
       <PackagePath>runtimes/monoandroid/arm64-v8a/libgrpc_csharp_ext.so</PackagePath>
       <Pack>true</Pack>
     </Content>
+    <Content Include="..\nativelibs\csharp_ext_linux_android_x86\libgrpc_csharp_ext.so">
+      <PackagePath>runtimes/monoandroid/x86/libgrpc_csharp_ext.so</PackagePath>
+      <Pack>true</Pack>
+    </Content>
     <Content Include="..\nativelibs\csharp_ext_macos_ios\libgrpc_csharp_ext.a">
       <PackagePath>runtimes/ios/native/libgrpc_csharp_ext.a</PackagePath>
       <Pack>true</Pack>

--- a/src/csharp/Grpc.Core/build/MonoAndroid/Grpc.Core.targets
+++ b/src/csharp/Grpc.Core/build/MonoAndroid/Grpc.Core.targets
@@ -18,4 +18,11 @@
     </AndroidNativeLibrary>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == 'MonoAndroid'">
+    <AndroidNativeLibrary Include="$(_GrpcCoreNugetNativePath)runtimes\monoandroid\x86\libgrpc_csharp_ext.so">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <Abi>x86</Abi>
+    </AndroidNativeLibrary>
+  </ItemGroup>
+
 </Project>

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -361,6 +361,7 @@ def targets():
     ] + [
         CSharpExtArtifact('linux', 'android', arch_abi='arm64-v8a'),
         CSharpExtArtifact('linux', 'android', arch_abi='armeabi-v7a'),
+        CSharpExtArtifact('linux', 'android', arch_abi='x86'),
         CSharpExtArtifact('macos', 'ios'),
         PythonArtifact('linux', 'x86', 'cp27-cp27m'),
         PythonArtifact('linux', 'x86', 'cp27-cp27mu'),


### PR DESCRIPTION
- right now Grpc.Core nuget can be used when deploying the project to physical android device, but the accelerated emulator uses x86 architecture by default. Adding libgrpc_csharp_ext for x86 abi will simplify development.