### PR TITLE
Ruby tooling: fix makefile strip dependency

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -110,7 +110,7 @@ if grpc_config == 'opt'
       o.puts i
     end
     o.puts
-    o.puts 'strip:'
+    o.puts 'strip: $(DLLIB)'
     o.puts "\t$(ECHO) Stripping $(DLLIB)"
     o.puts "\t$(Q) #{strip_tool} $(DLLIB)"
   end


### PR DESCRIPTION
This fixes a bug where the `strip` step could be scheduled before the `DLLIB` it's stripping has been built at high levels of parallelism. Sample build failure, when `MAKEFLAGS=-j8` has been exported:

```
compiling rb_event_thread.c
compiling rb_grpc.c
1 warning generated.
compiling rb_grpc_imports.generated.c
6 warnings generated.
1 warning generated.
compiling rb_loader.c
compiling rb_server.c
3 warnings generated.
compiling rb_server_credentials.c
Stripping grpc_c.bundle
rb_grpc.c:105:57: warning: must specify at least one argument for '...' parameter of variadic macro [-Wgnu-zero-variadic-macro-arguments]
        t.tv_sec = NUM2INT(rb_funcall(time, id_tv_sec, 0));
                                                        ^
/Users/spicycode/github/github/vendor/ruby/450160263aed8c446ce5b142d71f921ab4118f3a/include/ruby-2.5.0/ruby/ruby.h:2467:10: note: macro 'rb_funcall' defined here
# define rb_funcall(recv, mid, argc, ...) \
         ^
rb_grpc.c:106:59: warning: must specify at least one argument for '...' parameter of variadic macro [-Wgnu-zero-variadic-macro-arguments]
        t.tv_nsec = NUM2INT(rb_funcall(time, id_tv_nsec, 0));
                                                          ^
/Users/spicycode/github/github/vendor/ruby/450160263aed8c446ce5b142d71f921ab4118f3a/include/ruby-2.5.0/ruby/ruby.h:2467:10: note: macro 'rb_funcall' defined here
# define rb_funcall(recv, mid, argc, ...) \
         ^
rb_grpc.c:215:66: warning: must specify at least one argument for '...' parameter of variadic macro [-Wgnu-zero-variadic-macro-arguments]
  return rb_funcall(grpc_rb_time_val_to_time(self), id_inspect, 0);
                                                                 ^
/Users/spicycode/github/github/vendor/ruby/450160263aed8c446ce5b142d71f921ab4118f3a/include/ruby-2.5.0/ruby/ruby.h:2467:10: note: macro 'rb_funcall' defined here
# define rb_funcall(recv, mid, argc, ...) \
         ^
rb_grpc.c:220:63: warning: must specify at least one argument for '...' parameter of variadic macro [-Wgnu-zero-variadic-macro-arguments]
  return rb_funcall(grpc_rb_time_val_to_time(self), id_to_s, 0);
                                                              ^
/Users/spicycode/github/github/vendor/ruby/450160263aed8c446ce5b142d71f921ab4118f3a/include/ruby-2.5.0/ruby/ruby.h:2467:10: note: macro 'rb_funcall' defined here
# define rb_funcall(recv, mid, argc, ...) \
         ^
error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strip: can't open file: grpc_c.bundle (No such file or directory)
```

As you can see, several of the prerequisites for `grpc_c.bundle` are being built simultaneously with the `strip` step, ensuring that it will fail.

Can be closed if #16119 is merged.