### PR TITLE
Backport #16110 into v1.14.x

### DIFF
--- a/tools/internal_ci/linux/grpc_build_artifacts_extra_release.cfg
+++ b/tools/internal_ci/linux/grpc_build_artifacts_extra_release.cfg
@@ -1,0 +1,26 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_build_artifacts_extra.sh"
+timeout_mins: 240
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.xml"
+    regex: "github/grpc/reports/**"
+    regex: "github/grpc/artifacts/**"
+  }
+}


### PR DESCRIPTION
Backport #16110 into v1.14.x to enable `grpc_build_artifacts_linux_extra_release` on v1.14.x branch.

(To be merged after tagging v1.14.0-pre1)