### PR TITLE
Disable Beta API ChannelConnectivityTest

### DIFF
--- a/src/python/grpcio_tests/tests/unit/beta/_utilities_test.py
+++ b/src/python/grpcio_tests/tests/unit/beta/_utilities_test.py
@@ -41,6 +41,7 @@ class _Callback(object):
             return self._value
 
 
+@unittest.skip('https://github.com/grpc/grpc/issues/16134')
 class ChannelConnectivityTest(unittest.TestCase):
 
     def test_lonely_channel_connectivity(self):


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/16134 by disabling the flaky test identified.

(As a reminder, the Beta API has been unsupported for a while and the plan for flaky tests in the Beta API has been to disable the tests if they occur.)