### PR TITLE
Move ios-binary-size build intermediate files to /tmpfs

### DIFF
--- a/src/objective-c/tests/build_one_example.sh
+++ b/src/objective-c/tests/build_one_example.sh
@@ -43,7 +43,7 @@ xcodebuild \
     -workspace *.xcworkspace \
     -scheme $SCHEME \
     -destination generic/platform=iOS \
-    -derivedDataPath Build \
+    -derivedDataPath Build/Build \
     CODE_SIGN_IDENTITY="" \
     CODE_SIGNING_REQUIRED=NO \
     | egrep -v "$XCODEBUILD_FILTER" \

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -89,3 +89,7 @@ export DOTNET_CLI_TELEMETRY_OPTOUT=true
 date
 
 git submodule update --init
+
+# Store intermediate build files of ios binary size test into /tmpfs
+mkdir /tmpfs/Build-ios-binary-size
+ln -s /tmpfs/Build-ios-binary-size src/objective-c/examples/Sample/Build

--- a/tools/profiling/ios_bin/binary_size.py
+++ b/tools/profiling/ios_bin/binary_size.py
@@ -55,7 +55,7 @@ def dir_size(dir):
 
 
 def get_size(where, frameworks):
-    build_dir = 'src/objective-c/examples/Sample/Build-%s/' % where
+    build_dir = 'src/objective-c/examples/Sample/Build/Build-%s/' % where
     if not frameworks:
         link_map_filename = 'Build/Intermediates.noindex/Sample.build/Release-iphoneos/Sample.build/Sample-LinkMap-normal-arm64.txt'
         return parse_link_map(build_dir + link_map_filename)
@@ -76,14 +76,15 @@ def get_size(where, frameworks):
 
 def build(where, frameworks):
     shutil.rmtree(
-        'src/objective-c/examples/Sample/Build-%s' % where, ignore_errors=True)
+        'src/objective-c/examples/Sample/Build/Build-%s' % where,
+        ignore_errors=True)
     subprocess.check_call(
         'CONFIG=opt EXAMPLE_PATH=src/objective-c/examples/Sample SCHEME=Sample FRAMEWORKS=%s ./build_one_example.sh'
         % ('YES' if frameworks else 'NO'),
         shell=True,
         cwd='src/objective-c/tests')
-    os.rename('src/objective-c/examples/Sample/Build',
-              'src/objective-c/examples/Sample/Build-%s' % where)
+    os.rename('src/objective-c/examples/Sample/Build/Build',
+              'src/objective-c/examples/Sample/Build/Build-%s' % where)
 
 
 text = 'Objective-C binary sizes\n'


### PR DESCRIPTION
Kokoro have limited space in `/`. Moving build intermediates to `/tmpfs` would solve the problem of not enough space on macos.