### PR TITLE
Fix up g_alts_resource usage.

### DIFF
--- a/src/core/tsi/alts_transport_security.cc
+++ b/src/core/tsi/alts_transport_security.cc
@@ -20,7 +20,7 @@
 
 #include "src/core/tsi/alts_transport_security.h"
 
-#include <string.h>
+#include <new>
 
 static alts_shared_resource *g_alts_resource;
 

--- a/src/core/tsi/alts_transport_security.cc
+++ b/src/core/tsi/alts_transport_security.cc
@@ -22,42 +22,44 @@
 
 #include <string.h>
 
-static alts_shared_resource g_alts_resource;
+static alts_shared_resource *g_alts_resource;
 
 alts_shared_resource* alts_get_shared_resource(void) {
-  return &g_alts_resource;
+  return g_alts_resource;
 }
 
 static void grpc_tsi_alts_wait_for_cq_drain() {
-  gpr_mu_lock(&g_alts_resource.mu);
-  while (!g_alts_resource.is_cq_drained) {
-    gpr_cv_wait(&g_alts_resource.cv, &g_alts_resource.mu,
+  gpr_mu_lock(&g_alts_resource->mu);
+  while (!g_alts_resource->is_cq_drained) {
+    gpr_cv_wait(&g_alts_resource->cv, &g_alts_resource->mu,
                 gpr_inf_future(GPR_CLOCK_REALTIME));
   }
-  gpr_mu_unlock(&g_alts_resource.mu);
+  gpr_mu_unlock(&g_alts_resource->mu);
 }
 
 void grpc_tsi_alts_signal_for_cq_destroy() {
-  gpr_mu_lock(&g_alts_resource.mu);
-  g_alts_resource.is_cq_drained = true;
-  gpr_cv_signal(&g_alts_resource.cv);
-  gpr_mu_unlock(&g_alts_resource.mu);
+  gpr_mu_lock(&g_alts_resource->mu);
+  g_alts_resource->is_cq_drained = true;
+  gpr_cv_signal(&g_alts_resource->cv);
+  gpr_mu_unlock(&g_alts_resource->mu);
 }
 
 void grpc_tsi_alts_init() {
-  memset(&g_alts_resource, 0, sizeof(alts_shared_resource));
-  gpr_mu_init(&g_alts_resource.mu);
-  gpr_cv_init(&g_alts_resource.cv);
+  g_alts_resource = new alts_shared_resource;
+  gpr_mu_init(&g_alts_resource->mu);
+  gpr_cv_init(&g_alts_resource->cv);
 }
 
 void grpc_tsi_alts_shutdown() {
-  if (g_alts_resource.cq != nullptr) {
-    grpc_completion_queue_shutdown(g_alts_resource.cq);
+  if (g_alts_resource->cq != nullptr) {
+    grpc_completion_queue_shutdown(g_alts_resource->cq);
     grpc_tsi_alts_wait_for_cq_drain();
-    grpc_completion_queue_destroy(g_alts_resource.cq);
-    grpc_channel_destroy(g_alts_resource.channel);
-    g_alts_resource.thread.Join();
+    grpc_completion_queue_destroy(g_alts_resource->cq);
+    grpc_channel_destroy(g_alts_resource->channel);
+    g_alts_resource->thread.Join();
   }
-  gpr_cv_destroy(&g_alts_resource.cv);
-  gpr_mu_destroy(&g_alts_resource.mu);
+  gpr_cv_destroy(&g_alts_resource->cv);
+  gpr_mu_destroy(&g_alts_resource->mu);
+  delete g_alts_resource;
+  g_alts_resource = nullptr;
 }


### PR DESCRIPTION
Avoids useless initialization of g_alts_resource before main which affects startup time.

Also fixes up issue where it appears that the default constructor values for any fields inside of g_alts_resource were being set to zero indiscriminately.