### PR TITLE
Make all ObjC tests intermediate files into /tmpfs

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -90,6 +90,9 @@ date
 
 git submodule update --init
 
-# Store intermediate build files of ios binary size test into /tmpfs
+# Store intermediate build files of ObjC tests into /tmpfs
 mkdir /tmpfs/Build-ios-binary-size
 ln -s /tmpfs/Build-ios-binary-size src/objective-c/examples/Sample/Build
+mkdir /tmpfs/DerivedData
+rm -rf ~/Library/Developer/Xcode/DerivedData
+ln -s /tmpfs/DerivedData ~/Library/Developer/Xcode/DerivedData


### PR DESCRIPTION
To resolve ObjC test failures complaining "no space left on device".

Fixes #16156 .