### PR TITLE
Fix up tracers so they can be enabled/disabled completely.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -54,6 +54,16 @@ config_setting(
 )
 
 config_setting(
+    name = "grpc_use_tracers",
+    values = {"define": "GRPC_USE_TRACERS=1"},
+)
+
+config_setting(
+    name = "grpc_no_tracers",
+    values = {"define": "GRPC_USE_TRACERS=0"},
+)
+
+config_setting(
     name = "windows",
     values = {"cpu": "x64_windows"},
 )

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -71,6 +71,9 @@ def grpc_cc_library(name, srcs = [], public_hdrs = [], hdrs = [],
                       "//conditions:default": [],}) +
               select({"//:remote_execution":  ["GRPC_PORT_ISOLATED_RUNTIME=1"],
                       "//conditions:default": [],}) +
+              select({":grpc_use_tracers": ["GRPC_USE_TRACERS=1"],
+                      ":grpc_no_tracers": ["GRPC_USE_TRACERS=0"],
+                      "//conditions:default": ["GRPC_USE_TRACERS=1"],}) +
               select({"//:grpc_allow_exceptions":  ["GRPC_ALLOW_EXCEPTIONS=1"],
                       "//:grpc_disallow_exceptions":
                       ["GRPC_ALLOW_EXCEPTIONS=0"],

--- a/src/core/lib/debug/trace.cc
+++ b/src/core/lib/debug/trace.cc
@@ -27,9 +27,18 @@
 #include <grpc/support/log.h>
 #include "src/core/lib/gpr/env.h"
 
-int grpc_tracer_set_enabled(const char* name, int enabled);
-
+#if GRPC_USE_TRACERS
 namespace grpc_core {
+
+class TraceFlagList {
+ public:
+  static bool Set(const char* name, bool enabled);
+  static void Add(TraceFlag* flag);
+
+ private:
+  static void LogAllTracers();
+  static TraceFlag* root_tracer_;
+};
 
 TraceFlag* TraceFlagList::root_tracer_ = nullptr;
 
@@ -143,3 +152,15 @@ void grpc_tracer_shutdown(void) {}
 int grpc_tracer_set_enabled(const char* name, int enabled) {
   return grpc_core::TraceFlagList::Set(name, enabled != 0);
 }
+
+#else  // GRPC_USE_TRACERS
+
+void grpc_tracer_init(const char* env_var) {}
+
+void grpc_tracer_shutdown(void) {}
+
+int grpc_tracer_set_enabled(const char* name, int enabled) {
+  return 0;
+}
+
+#endif  // GRPC_USE_TRACERS


### PR DESCRIPTION
Tracers can add unnecessary code that was running pre-main. The comments in the source file
implied that you could disable them, but that was not possible. Now by defining GRPC_USE_TRACERS
to 0, you can disable tracers.

They are enabled by default in opensource builds.