### PR TITLE
Add 'multi_json' gem that route_guide_server can work

### DIFF
--- a/examples/ruby/grpc-demo.gemspec
+++ b/examples/ruby/grpc-demo.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.platform      = Gem::Platform::RUBY
 
   s.add_dependency 'grpc', '~> 1.0'
-
+  s.add_dependency 'multi_json', '~> 1.13.1'
   s.add_development_dependency 'bundler', '~> 1.7'
 end


### PR DESCRIPTION
Currently, the [gRPC Basics: Ruby](https://grpc.io/docs/tutorials/basic/ruby.html#try-it-out) tutorial does not work:

```
$ bundle exec route_guide/route_guide_server.rb ../python/route_guide/route_guide_db.json

bundler: failed to load command: route_guide/route_guide_server.rb (route_guide/route_guide_server.rb)
LoadError: cannot load such file -- multi_json
  route_guide/route_guide_server.rb:27:in `require'
  route_guide/route_guide_server.rb:27:in `<top (required)>'
```

The root cause is that the `multi_json` gem, which is required in `route_guide/route_guide_server.rb:27`, is not present in the gemspec.

Fix: Add `multi_json` gem to gemspec