### PR TITLE
Cleanup: remove Jenkins references from build_packages scripts

### DIFF
--- a/src/csharp/build_packages_dotnetcli.bat
+++ b/src/csharp/build_packages_dotnetcli.bat
@@ -21,18 +21,12 @@ set DOTNET=dotnet
 
 mkdir ..\..\artifacts
 
-@rem Collect the artifacts built by the previous build step if running on Jenkins
+@rem Collect the artifacts built by the previous build step
 mkdir nativelibs
-@rem Jenkins flow (deprecated)
-powershell -Command "cp -r ..\..\platform=*\artifacts\csharp_ext_* nativelibs"
-@rem Kokoro flow
 powershell -Command "cp -r ..\..\input_artifacts\csharp_ext_* nativelibs"
 
 @rem Collect protoc artifacts built by the previous build step
 mkdir protoc_plugins
-@rem Jenkins flow (deprecated)
-powershell -Command "cp -r ..\..\platform=*\artifacts\protoc_* protoc_plugins"
-@rem Kokoro flow
 powershell -Command "cp -r ..\..\input_artifacts\protoc_* protoc_plugins"
 
 %DOTNET% restore Grpc.sln || goto :error

--- a/src/csharp/build_packages_dotnetcli.sh
+++ b/src/csharp/build_packages_dotnetcli.sh
@@ -21,16 +21,10 @@ mkdir -p ../../artifacts/
 
 # Collect the artifacts built by the previous build step
 mkdir -p nativelibs
-# Jenkins flow (deprecated)
-cp -r $EXTERNAL_GIT_ROOT/platform={windows,linux,macos}/artifacts/csharp_ext_* nativelibs || true
-# Kokoro flow
 cp -r $EXTERNAL_GIT_ROOT/input_artifacts/csharp_ext_* nativelibs || true
 
 # Collect protoc artifacts built by the previous build step
 mkdir -p protoc_plugins
-# Jenkins flow (deprecated)
-cp -r $EXTERNAL_GIT_ROOT/platform={windows,linux,macos}/artifacts/protoc_* protoc_plugins || true
-# Kokoro flow
 cp -r $EXTERNAL_GIT_ROOT/input_artifacts/protoc_* protoc_plugins || true
 
 dotnet restore Grpc.sln

--- a/templates/src/csharp/build_packages_dotnetcli.bat.template
+++ b/templates/src/csharp/build_packages_dotnetcli.bat.template
@@ -23,18 +23,12 @@
   
   mkdir ..\..\artifacts
   
-  @rem Collect the artifacts built by the previous build step if running on Jenkins
+  @rem Collect the artifacts built by the previous build step
   mkdir nativelibs
-  @rem Jenkins flow (deprecated)
-  powershell -Command "cp -r ..\..\platform=*\artifacts\csharp_ext_* nativelibs"
-  @rem Kokoro flow
   powershell -Command "cp -r ..\..\input_artifacts\csharp_ext_* nativelibs"
   
   @rem Collect protoc artifacts built by the previous build step
   mkdir protoc_plugins
-  @rem Jenkins flow (deprecated)
-  powershell -Command "cp -r ..\..\platform=*\artifacts\protoc_* protoc_plugins"
-  @rem Kokoro flow
   powershell -Command "cp -r ..\..\input_artifacts\protoc_* protoc_plugins"
   
   %%DOTNET% restore Grpc.sln || goto :error

--- a/templates/src/csharp/build_packages_dotnetcli.sh.template
+++ b/templates/src/csharp/build_packages_dotnetcli.sh.template
@@ -23,16 +23,10 @@
   
   # Collect the artifacts built by the previous build step
   mkdir -p nativelibs
-  # Jenkins flow (deprecated)
-  cp -r $EXTERNAL_GIT_ROOT/platform={windows,linux,macos}/artifacts/csharp_ext_* nativelibs || true
-  # Kokoro flow
   cp -r $EXTERNAL_GIT_ROOT/input_artifacts/csharp_ext_* nativelibs || true
   
   # Collect protoc artifacts built by the previous build step
   mkdir -p protoc_plugins
-  # Jenkins flow (deprecated)
-  cp -r $EXTERNAL_GIT_ROOT/platform={windows,linux,macos}/artifacts/protoc_* protoc_plugins || true
-  # Kokoro flow
   cp -r $EXTERNAL_GIT_ROOT/input_artifacts/protoc_* protoc_plugins || true
   
   dotnet restore Grpc.sln

--- a/tools/run_tests/artifacts/build_package_php.sh
+++ b/tools/run_tests/artifacts/build_package_php.sh
@@ -20,7 +20,4 @@ cd "$(dirname "$0")/../../.."
 # All the PHP packages have been built in the artifact phase already
 # and we only collect them here to deliver them to the distribtest phase.
 mkdir -p artifacts/
-# Jenkins flow (deprecated)
-cp -r "${EXTERNAL_GIT_ROOT}"/platform={windows,linux,macos}/artifacts/php_*/* artifacts/ || true
-# Kokoro flow
 cp -r "${EXTERNAL_GIT_ROOT}"/input_artifacts/php_*/* artifacts/ || true

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -21,9 +21,6 @@ mkdir -p artifacts/
 
 # All the python packages have been built in the artifact phase already
 # and we only collect them here to deliver them to the distribtest phase.
-# Jenkins flow (deprecated)
-cp -r "${EXTERNAL_GIT_ROOT}"/platform={windows,linux,macos}/artifacts/python_*/* artifacts/ || true
-# Kokoro flow
 cp -r "${EXTERNAL_GIT_ROOT}"/input_artifacts/python_*/* artifacts/ || true
 
 # TODO: all the artifact builder configurations generate a grpcio-VERSION.tar.gz

--- a/tools/run_tests/artifacts/build_package_ruby.sh
+++ b/tools/run_tests/artifacts/build_package_ruby.sh
@@ -23,9 +23,6 @@ mkdir -p artifacts/
 
 # All the ruby packages have been built in the artifact phase already
 # and we only collect them here to deliver them to the distribtest phase.
-# Jenkins flow (deprecated)
-cp -r "${EXTERNAL_GIT_ROOT}"/platform={windows,linux,macos}/artifacts/ruby_native_gem_*/* artifacts/ || true
-# Kokoro flow
 cp -r "${EXTERNAL_GIT_ROOT}"/input_artifacts/ruby_native_gem_*/* artifacts/ || true
 
 well_known_protos=( any api compiler/plugin descriptor duration empty field_mask source_context struct timestamp type wrappers )
@@ -44,12 +41,7 @@ for arch in {x86,x64}; do
       ;;
   esac
   for plat in {windows,linux,macos}; do
-    if [ "${KOKORO_JOB_NAME}" != "" ]
-    then
-      input_dir="${EXTERNAL_GIT_ROOT}/input_artifacts/protoc_${plat}_${arch}"
-    else
-      input_dir="${EXTERNAL_GIT_ROOT}/platform=${plat}/artifacts/protoc_${plat}_${arch}"
-    fi
+    input_dir="${EXTERNAL_GIT_ROOT}/input_artifacts/protoc_${plat}_${arch}"
     output_dir="$base/src/ruby/tools/bin/${ruby_arch}-${plat}"
     mkdir -p "$output_dir"/google/protobuf
     mkdir -p "$output_dir"/google/protobuf/compiler  # needed for plugin.proto


### PR DESCRIPTION
- Jenkins has been shutdown several month ago, we no longer need the code for handling jenkins paths in build_packages