### PR TITLE
Add a matching _unwrap_grpc_arg

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/arguments.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/arguments.pxd.pxi
@@ -25,6 +25,9 @@ cdef int _compare_pointer(void* first_pointer, void* second_pointer)
 cdef tuple _wrap_grpc_arg(grpc_arg arg)
 
 
+cdef grpc_arg _unwrap_grpc_arg(tuple wrapped_arg)
+
+
 cdef class _ArgumentProcessor:
 
   cdef grpc_arg c_argument

--- a/src/python/grpcio/grpc/_cython/_cygrpc/arguments.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/arguments.pyx.pxi
@@ -40,10 +40,14 @@ cdef class _GrpcArgWrapper:
 
 
 cdef tuple _wrap_grpc_arg(grpc_arg arg):
-
   wrapped = _GrpcArgWrapper()
   wrapped.arg = arg
   return ("grpc.python._cygrpc._GrpcArgWrapper", wrapped)
+
+
+cdef grpc_arg _unwrap_grpc_arg(tuple wrapped_arg):
+  cdef _GrpcArgWrapper wrapped = wrapped_arg[1]
+  return wrapped.arg
 
 
 cdef class _ArgumentProcessor:


### PR DESCRIPTION
Encapsulate the implementation detail of `_GrpcArgWrapper` in `arguments.pyx.pxi` Cython module so the users just call `_wrap_grpc_arg` and `_unwrap_grpc_arg` and not access the internals directly.

Builds on https://github.com/grpc/grpc/pull/16192