### PR TITLE
Create a --channel_creds_type flag for grpc_cli.

### DIFF
--- a/test/cpp/util/cli_credentials.h
+++ b/test/cpp/util/cli_credentials.h
@@ -28,9 +28,21 @@ namespace testing {
 class CliCredentials {
  public:
   virtual ~CliCredentials() {}
-  virtual std::shared_ptr<grpc::ChannelCredentials> GetCredentials() const;
+  std::shared_ptr<grpc::ChannelCredentials> GetCredentials() const;
   virtual const grpc::string GetCredentialUsage() const;
   virtual const grpc::string GetSslTargetNameOverride() const;
+ protected:
+  // Returns the appropriate channel_creds_type value for the set of legacy
+  // flag arguments.
+  virtual grpc::string GetDefaultChannelCredsType() const;
+  // Returns the base transport channel credentials. Child classes can override
+  // to support additional channel_creds_types unknown to this base class.
+  virtual std::shared_ptr<grpc::ChannelCredentials> GetChannelCredentials()
+      const;
+  // Returns call credentials to composite onto the base transport channel
+  // credentials. Child classes can override to support additional
+  // authentication flags unknown to this base class.
+  virtual std::shared_ptr<grpc::CallCredentials> GetCallCredentials() const;
 };
 
 }  // namespace testing

--- a/test/cpp/util/grpc_tool_test.cc
+++ b/test/cpp/util/grpc_tool_test.cc
@@ -81,7 +81,7 @@ using grpc::testing::EchoResponse;
   "  peer: \"peer\"\n"        \
   "}\n\n"
 
-DECLARE_bool(enable_ssl);
+DECLARE_string(channel_creds_type);
 DECLARE_string(ssl_target);
 
 namespace grpc {
@@ -102,7 +102,8 @@ const int kServerDefaultResponseStreamsToSend = 3;
 class TestCliCredentials final : public grpc::testing::CliCredentials {
  public:
   TestCliCredentials(bool secure = false) : secure_(secure) {}
-  std::shared_ptr<grpc::ChannelCredentials> GetCredentials() const override {
+  std::shared_ptr<grpc::ChannelCredentials> GetChannelCredentials() const
+      override {
     if (!secure_) {
       return InsecureChannelCredentials();
     }
@@ -769,12 +770,12 @@ TEST_F(GrpcToolTest, CallCommandWithBadMetadata) {
 TEST_F(GrpcToolTest, ListCommand_OverrideSslHostName) {
   const grpc::string server_address = SetUpServer(true);
 
-  // Test input "grpc_cli ls localhost:<port> --enable_ssl
+  // Test input "grpc_cli ls localhost:<port> --channel_creds_type=ssl
   // --ssl_target=z.test.google.fr"
   std::stringstream output_stream;
   const char* argv[] = {"grpc_cli", "ls", server_address.c_str()};
   FLAGS_l = false;
-  FLAGS_enable_ssl = true;
+  FLAGS_channel_creds_type = "ssl";
   FLAGS_ssl_target = "z.test.google.fr";
   EXPECT_TRUE(
       0 == GrpcToolMainLib(
@@ -784,7 +785,7 @@ TEST_F(GrpcToolTest, ListCommand_OverrideSslHostName) {
                           "grpc.testing.EchoTestService\n"
                           "grpc.reflection.v1alpha.ServerReflection\n"));
 
-  FLAGS_enable_ssl = false;
+  FLAGS_channel_creds_type = "";
   FLAGS_ssl_target = "";
   ShutdownServer();
 }


### PR DESCRIPTION
This replaces several mutually-exclusive flags for a single selector flag which defines the base channel type. It also allows child classes to selectively override the defaults and provide additional channel types (e.g., LOAS in the mono repo), or call creds types which, if exist, will be composited over the channel creds.

Fixes issue #16060.