### PR TITLE
Add low-level Cython debug/expansion hooks

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/_hooks.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/_hooks.pxd.pxi
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-cdef object _custom_op_on_c_call(grpc_call *call)
+cdef object _custom_op_on_c_call(int op, grpc_call *call)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/_hooks.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/_hooks.pxd.pxi
@@ -1,0 +1,16 @@
+# Copyright 2018 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+cdef object _custom_op_on_c_call(grpc_call *call)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/_hooks.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/_hooks.pyx.pxi
@@ -1,0 +1,17 @@
+# Copyright 2018 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+cdef object _custom_op_on_c_call(grpc_call *call):
+  return None

--- a/src/python/grpcio/grpc/_cython/_cygrpc/_hooks.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/_hooks.pyx.pxi
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 
-cdef object _custom_op_on_c_call(grpc_call *call):
-  return None
+cdef object _custom_op_on_c_call(int op, grpc_call *call):
+  raise NotImplementedError("No custom hooks are implemented")

--- a/src/python/grpcio/grpc/_cython/_cygrpc/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/call.pyx.pxi
@@ -94,3 +94,5 @@ cdef class Call:
   def is_valid(self):
     return self.c_call != NULL
 
+  def _custom_op_on_c_call(self):
+    return _custom_op_on_c_call(self.c_call)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/call.pyx.pxi
@@ -94,5 +94,5 @@ cdef class Call:
   def is_valid(self):
     return self.c_call != NULL
 
-  def _custom_op_on_c_call(self):
-    return _custom_op_on_c_call(self.c_call)
+  def _custom_op_on_c_call(self, int op):
+    return _custom_op_on_c_call(op, self.c_call)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
@@ -300,7 +300,7 @@ cdef class SegregatedCall:
   def next_event(self):
     def on_success(tag):
       _process_segregated_call_tag(
-          self._channel_state, self._call_state, self._c_completion_queue, tag)
+        self._channel_state, self._call_state, self._c_completion_queue, tag)
     return _next_call_event(
         self._channel_state, self._c_completion_queue, on_success)
 

--- a/src/python/grpcio/grpc/_cython/cygrpc.pxd
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pxd
@@ -28,5 +28,6 @@ include "_cygrpc/security.pxd.pxi"
 include "_cygrpc/server.pxd.pxi"
 include "_cygrpc/tag.pxd.pxi"
 include "_cygrpc/time.pxd.pxi"
+include "_cygrpc/_hooks.pxd.pxi"
 
 include "_cygrpc/grpc_gevent.pxd.pxi"

--- a/src/python/grpcio/grpc/_cython/cygrpc.pyx
+++ b/src/python/grpcio/grpc/_cython/cygrpc.pyx
@@ -35,6 +35,7 @@ include "_cygrpc/security.pyx.pxi"
 include "_cygrpc/server.pyx.pxi"
 include "_cygrpc/tag.pyx.pxi"
 include "_cygrpc/time.pyx.pxi"
+include "_cygrpc/_hooks.pyx.pxi"
 
 include "_cygrpc/grpc_gevent.pyx.pxi"
 


### PR DESCRIPTION
Provide an easy way to decompose low-level Cython code into various files so they can be easily replaced and linked with other functions when compiled from source.