### PR TITLE
adding python version environmental markers in the new style

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -276,11 +276,11 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    'six>=1.5.2',
+    "six>=1.5.2",
+    "futures>=2.2.0 ; python_version<'3.2'",
+    "enum34>=1.0.4 ; python_version<'3.4'"
 )
 
-if not PY3:
-  INSTALL_REQUIRES += ('futures>=2.2.0', 'enum34>=1.0.4')
 
 SETUP_REQUIRES = INSTALL_REQUIRES + (
     'sphinx>=1.3',


### PR DESCRIPTION
A follow up on #16133 which I have tested locally to ensure that when doing `pip install` pulls `futures` on on Python versions less that `3.2` (when it was added to the stdlib) and enum34 when Python < 3.4.

@mehrdada - i'm hoping this one will pass the distrib tests as I was unable to work out how to run them locally but a pip install does do what I would expect.

Note: It does require a recent version of setuptools. So there may still be drama but I am hoping not.