### PR TITLE
Ruby: Fix default pool keep alive

### DIFF
--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -217,7 +217,7 @@ module GRPC
     def initialize(pool_size: DEFAULT_POOL_SIZE,
                    max_waiting_requests: DEFAULT_MAX_WAITING_REQUESTS,
                    poll_period: DEFAULT_POLL_PERIOD,
-                   pool_keep_alive: GRPC::RpcServer::DEFAULT_POOL_SIZE,
+                   pool_keep_alive: Pool::DEFAULT_KEEP_ALIVE,
                    connect_md_proc: nil,
                    server_args: {},
                    interceptors: [])


### PR DESCRIPTION
* The default value for the pool_keep_alive param for the Ruby RpcServer class references an incorrect constant.
* This means that the default value for the pool keep alive will be 30, which is higher than the default value for the server poll_period, which is 1.