### PR TITLE
Instead of seen for error, check for stream being cancelled

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1208,7 +1208,8 @@ void grpc_chttp2_complete_closure_step(grpc_chttp2_transport* t,
         grpc_error_add_child(closure->error_data.error, error);
   }
   if (closure->next_data.scratch < CLOSURE_BARRIER_FIRST_REF_BIT) {
-    if (s->seen_error || (t->write_state == GRPC_CHTTP2_WRITE_STATE_IDLE) ||
+    if ((s->cancelled) ||
+        (t->write_state == GRPC_CHTTP2_WRITE_STATE_IDLE) ||
         !(closure->next_data.scratch & CLOSURE_BARRIER_MAY_COVER_WRITE)) {
       GRPC_CLOSURE_RUN(closure, closure->error_data.error);
     } else {
@@ -2017,6 +2018,7 @@ static void remove_stream(grpc_chttp2_transport* t, uint32_t id,
 void grpc_chttp2_cancel_stream(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
                                grpc_error* due_to_error) {
   GRPC_CLOSURE_LIST_SCHED(&s->run_after_write);
+  s->cancelled = true;
   if (grpc_chttp2_list_remove_waiting_for_write_stream(t, s)) {
     GRPC_CHTTP2_STREAM_UNREF(s, "chttp2:pending_write_closure");
   }

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -525,6 +525,7 @@ struct grpc_chttp2_stream {
   /** Has this stream seen an error.
       If true, then pending incoming frames can be thrown away. */
   bool seen_error;
+  bool cancelled;
   /** Are we buffering writes on this stream? If yes, we won't become writable
       until there's enough queued up in the flow_controlled_buffer */
   bool write_buffering;

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -520,12 +520,13 @@ struct grpc_chttp2_stream {
   bool write_closed;
   /** Is this stream reading half-closed. */
   bool read_closed;
+  /** Has this stream been cancelled */
+  bool cancelled;
   /** Are all published incoming byte streams closed. */
   bool all_incoming_byte_streams_finished;
   /** Has this stream seen an error.
       If true, then pending incoming frames can be thrown away. */
   bool seen_error;
-  bool cancelled;
   /** Are we buffering writes on this stream? If yes, we won't become writable
       until there's enough queued up in the flow_controlled_buffer */
   bool write_buffering;


### PR DESCRIPTION
Running a closure just on seeing an error is too early. Instead, as intended, let's run it when the stream is closed.

