### PR TITLE
Improve initial call size estimate on client side

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel_factory.cc
+++ b/src/core/ext/filters/client_channel/client_channel_factory.cc
@@ -21,6 +21,11 @@
 #include "src/core/ext/filters/client_channel/client_channel_factory.h"
 #include "src/core/lib/channel/channel_args.h"
 
+size_t grpc_client_channel_factory_get_stream_size(
+    grpc_client_channel_factory* factory) {
+  return factory->vtable->sizeof_stream;
+}
+
 void grpc_client_channel_factory_ref(grpc_client_channel_factory* factory) {
   factory->vtable->ref(factory);
 }

--- a/src/core/ext/filters/client_channel/client_channel_factory.h
+++ b/src/core/ext/filters/client_channel/client_channel_factory.h
@@ -46,6 +46,7 @@ struct grpc_client_channel_factory {
 };
 
 struct grpc_client_channel_factory_vtable {
+  size_t sizeof_stream;
   void (*ref)(grpc_client_channel_factory* factory);
   void (*unref)(grpc_client_channel_factory* factory);
   grpc_subchannel* (*create_subchannel)(grpc_client_channel_factory* factory,
@@ -56,14 +57,18 @@ struct grpc_client_channel_factory_vtable {
                                          const grpc_channel_args* args);
 };
 
+/** Gets the stream size. */
+size_t grpc_client_channel_factory_get_stream_size(
+    grpc_client_channel_factory* factory);
+
 void grpc_client_channel_factory_ref(grpc_client_channel_factory* factory);
 void grpc_client_channel_factory_unref(grpc_client_channel_factory* factory);
 
-/** Create a new grpc_subchannel */
+/** Creates a new grpc_subchannel. */
 grpc_subchannel* grpc_client_channel_factory_create_subchannel(
     grpc_client_channel_factory* factory, const grpc_subchannel_args* args);
 
-/** Create a new grpc_channel */
+/** Creates a new grpc_channel. */
 grpc_channel* grpc_client_channel_factory_create_channel(
     grpc_client_channel_factory* factory, const char* target,
     grpc_client_channel_type type, const grpc_channel_args* args);

--- a/src/core/ext/transport/chttp2/client/insecure/channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/insecure/channel_create.cc
@@ -29,6 +29,7 @@
 #include "src/core/ext/filters/client_channel/resolver_registry.h"
 #include "src/core/ext/transport/chttp2/client/authority.h"
 #include "src/core/ext/transport/chttp2/client/chttp2_connector.h"
+#include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/surface/api_trace.h"
 #include "src/core/lib/surface/channel.h"
@@ -73,8 +74,8 @@ static grpc_channel* client_channel_factory_create_channel(
 }
 
 static const grpc_client_channel_factory_vtable client_channel_factory_vtable =
-    {client_channel_factory_ref, client_channel_factory_unref,
-     client_channel_factory_create_subchannel,
+    {grpc_chttp2_get_stream_size(), client_channel_factory_ref,
+     client_channel_factory_unref, client_channel_factory_create_subchannel,
      client_channel_factory_create_channel};
 
 static grpc_client_channel_factory client_channel_factory = {

--- a/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
@@ -29,6 +29,7 @@
 #include "src/core/ext/filters/client_channel/resolver_registry.h"
 #include "src/core/ext/filters/client_channel/uri_parser.h"
 #include "src/core/ext/transport/chttp2/client/chttp2_connector.h"
+#include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/iomgr/sockaddr_utils.h"
@@ -186,8 +187,8 @@ static grpc_channel* client_channel_factory_create_channel(
 }
 
 static const grpc_client_channel_factory_vtable client_channel_factory_vtable =
-    {client_channel_factory_ref, client_channel_factory_unref,
-     client_channel_factory_create_subchannel,
+    {grpc_chttp2_get_stream_size(), client_channel_factory_ref,
+     client_channel_factory_unref, client_channel_factory_create_subchannel,
      client_channel_factory_create_channel};
 
 static grpc_client_channel_factory client_channel_factory = {

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -3125,3 +3125,5 @@ void grpc_chttp2_transport_start_reading(
   t->notify_on_receive_settings = notify_on_receive_settings;
   GRPC_CLOSURE_SCHED(&t->read_action_locked, GRPC_ERROR_NONE);
 }
+
+size_t grpc_chttp2_get_stream_size() { return sizeof(grpc_chttp2_stream); }

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.h
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.h
@@ -42,4 +42,6 @@ void grpc_chttp2_transport_start_reading(
     grpc_transport* transport, grpc_slice_buffer* read_buffer,
     grpc_closure* notify_on_receive_settings);
 
+size_t grpc_chttp2_get_stream_size();
+
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_CHTTP2_TRANSPORT_H */

--- a/src/core/lib/channel/channel_stack_builder.h
+++ b/src/core/lib/channel/channel_stack_builder.h
@@ -27,47 +27,48 @@
 #include "src/core/lib/channel/channel_stack.h"
 
 /// grpc_channel_stack_builder offers a programmatic interface to selected
-/// and order channel filters
+/// and order channel filters.
 typedef struct grpc_channel_stack_builder grpc_channel_stack_builder;
 typedef struct grpc_channel_stack_builder_iterator
     grpc_channel_stack_builder_iterator;
 
-/// Create a new channel stack builder
+/// Creates a new channel stack builder.
 grpc_channel_stack_builder* grpc_channel_stack_builder_create(void);
 
-/// Assign a name to the channel stack: \a name must be statically allocated
+/// Assigns a name to the channel stack: \a name must be statically allocated.
 void grpc_channel_stack_builder_set_name(grpc_channel_stack_builder* builder,
                                          const char* name);
 
-/// Set the target uri
+/// Sets the target uri.
 void grpc_channel_stack_builder_set_target(grpc_channel_stack_builder* b,
                                            const char* target);
 
 const char* grpc_channel_stack_builder_get_target(
     grpc_channel_stack_builder* b);
 
-/// Attach \a transport to the builder (does not take ownership)
+/// Attaches \a transport to the builder (does not take ownership).
 void grpc_channel_stack_builder_set_transport(
     grpc_channel_stack_builder* builder, grpc_transport* transport);
 
-/// Fetch attached transport
+/// Fetches attached transport.
 grpc_transport* grpc_channel_stack_builder_get_transport(
     grpc_channel_stack_builder* builder);
 
-/// Set channel arguments: copies args
+/// Sets channel arguments: copies args.
 void grpc_channel_stack_builder_set_channel_arguments(
     grpc_channel_stack_builder* builder, const grpc_channel_args* args);
 
-/// Return a borrowed pointer to the channel arguments
+/// Returns a borrowed pointer to the channel arguments.
 const grpc_channel_args* grpc_channel_stack_builder_get_channel_arguments(
     grpc_channel_stack_builder* builder);
 
-/// Begin iterating over already defined filters in the builder at the beginning
+/// Begins iterating over already defined filters in the builder at the
+/// beginning.
 grpc_channel_stack_builder_iterator*
 grpc_channel_stack_builder_create_iterator_at_first(
     grpc_channel_stack_builder* builder);
 
-/// Begin iterating over already defined filters in the builder at the end
+/// Begins iterating over already defined filters in the builder at the end.
 grpc_channel_stack_builder_iterator*
 grpc_channel_stack_builder_create_iterator_at_last(
     grpc_channel_stack_builder* builder);
@@ -84,15 +85,15 @@ bool grpc_channel_stack_builder_iterator_is_end(
 const char* grpc_channel_stack_builder_iterator_filter_name(
     grpc_channel_stack_builder_iterator* iterator);
 
-/// Move an iterator to the next item
+/// Moves an iterator to the next item.
 bool grpc_channel_stack_builder_move_next(
     grpc_channel_stack_builder_iterator* iterator);
 
-/// Move an iterator to the previous item
+/// Moves an iterator to the previous item.
 bool grpc_channel_stack_builder_move_prev(
     grpc_channel_stack_builder_iterator* iterator);
 
-/// Return an iterator at \a filter_name, or at the end of the list if not
+/// Returns an iterator at \a filter_name, or at the end of the list if not
 /// found.
 grpc_channel_stack_builder_iterator* grpc_channel_stack_builder_iterator_find(
     grpc_channel_stack_builder* builder, const char* filter_name);
@@ -100,8 +101,8 @@ grpc_channel_stack_builder_iterator* grpc_channel_stack_builder_iterator_find(
 typedef void (*grpc_post_filter_create_init_func)(
     grpc_channel_stack* channel_stack, grpc_channel_element* elem, void* arg);
 
-/// Add \a filter to the stack, after \a iterator.
-/// Call \a post_init_func(..., \a user_data) once the channel stack is
+/// Adds \a filter to the stack, after \a iterator.
+/// Calls \a post_init_func(..., \a user_data) once the channel stack is
 /// created.
 bool grpc_channel_stack_builder_add_filter_after(
     grpc_channel_stack_builder_iterator* iterator,
@@ -109,7 +110,7 @@ bool grpc_channel_stack_builder_add_filter_after(
     grpc_post_filter_create_init_func post_init_func,
     void* user_data) GRPC_MUST_USE_RESULT;
 
-/// Add \a filter to the stack, before \a iterator.
+/// Adds \a filter to the stack, before \a iterator.
 /// Call \a post_init_func(..., \a user_data) once the channel stack is
 /// created.
 bool grpc_channel_stack_builder_add_filter_before(
@@ -118,41 +119,44 @@ bool grpc_channel_stack_builder_add_filter_before(
     grpc_post_filter_create_init_func post_init_func,
     void* user_data) GRPC_MUST_USE_RESULT;
 
-/// Add \a filter to the beginning of the filter list.
-/// Call \a post_init_func(..., \a user_data) once the channel stack is
+/// Adds \a filter to the beginning of the filter list.
+/// Calls \a post_init_func(..., \a user_data) once the channel stack is
 /// created.
 bool grpc_channel_stack_builder_prepend_filter(
     grpc_channel_stack_builder* builder, const grpc_channel_filter* filter,
     grpc_post_filter_create_init_func post_init_func,
     void* user_data) GRPC_MUST_USE_RESULT;
 
-/// Add \a filter to the end of the filter list.
-/// Call \a post_init_func(..., \a user_data) once the channel stack is
+/// Adds \a filter to the end of the filter list.
+/// Calls \a post_init_func(..., \a user_data) once the channel stack is
 /// created.
 bool grpc_channel_stack_builder_append_filter(
     grpc_channel_stack_builder* builder, const grpc_channel_filter* filter,
     grpc_post_filter_create_init_func post_init_func,
     void* user_data) GRPC_MUST_USE_RESULT;
 
-/// Remove any filter whose name is \a filter_name from \a builder. Returns true
-/// if \a filter_name was not found.
+/// Removes any filter whose name is \a filter_name from \a builder. Returns
+/// true if \a filter_name was not found.
 bool grpc_channel_stack_builder_remove_filter(
     grpc_channel_stack_builder* builder, const char* filter_name);
 
-/// Terminate iteration and destroy \a iterator
+/// Terminates iteration and destroy \a iterator.
 void grpc_channel_stack_builder_iterator_destroy(
     grpc_channel_stack_builder_iterator* iterator);
 
-/// Destroy the builder, return the freshly minted channel stack in \a result.
-/// Allocates \a prefix_bytes bytes before the channel stack
-/// Returns the base pointer of the allocated block
-/// \a initial_refs, \a destroy, \a destroy_arg are as per
-/// grpc_channel_stack_init
+/// Destroies the builder, returns the freshly minted channel stack in \a
+/// result. Allocates \a prefix_bytes bytes before the channel stack. Returns
+/// the base pointer of the allocated block. \a initial_refs, \a destroy, \a
+/// destroy_arg are as per grpc_channel_stack_init.
 grpc_error* grpc_channel_stack_builder_finish(
     grpc_channel_stack_builder* builder, size_t prefix_bytes, int initial_refs,
     grpc_iomgr_cb_func destroy, void* destroy_arg, void** result);
 
-/// Destroy the builder without creating a channel stack
+/// Destroies the builder without creating a channel stack.
 void grpc_channel_stack_builder_destroy(grpc_channel_stack_builder* builder);
+
+/// Gets the estimated call stack size of a subchannel.
+size_t grpc_channel_stack_builder_get_subchannel_call_size(
+    grpc_channel_args* args);
 
 #endif /* GRPC_CORE_LIB_CHANNEL_CHANNEL_STACK_BUILDER_H */

--- a/test/cpp/microbenchmarks/bm_call_create.cc
+++ b/test/cpp/microbenchmarks/bm_call_create.cc
@@ -338,7 +338,7 @@ class FakeClientChannelFactory : public grpc_client_channel_factory {
 };
 
 const grpc_client_channel_factory_vtable FakeClientChannelFactory::vtable_ = {
-    NoRef, NoUnref, CreateSubchannel, CreateClientChannel};
+    0, NoRef, NoUnref, CreateSubchannel, CreateClientChannel};
 
 static grpc_arg StringArg(const char* key, const char* value) {
   grpc_arg a;


### PR DESCRIPTION
The client side has two special thing to consider when estimating the initial call size.

1. We should include the stream size. 
The stream size is always added to the total call stack size when the transport is bound. 
https://github.com/grpc/grpc/blob/7c3d13d440debe4b67e05e186a8e8e0d2b4f4918/src/core/lib/channel/connected_channel.cc#L227
In contrast with the server side, the client channel doesn't have the `connected` filter, but the subchannel does. When the subchannel binds the transport, it doesn't know which channel to update the call size estimate with the transport stream size.
The solution is to add the transport stream size when we create the channel. We know that size from the client channel factory. 

2. We should include the subchannel call size. 
The problem is that the subchannel stack is created after the subchannel is connected, as mentioned here https://github.com/grpc/grpc/pull/16232#discussion_r207687336. And again, the subchannel doesn't know which channel to update the subchannel call size. 
My solution is to create a fake subchannel and sum up the call stack sizes of its filters. This method is not good because which filter to enable depends on how I create the channel stack builder. 
There are some alternatives. For example, when we register the filter with subchannel type, we also add the call stack size to some variable, so that all the subchannel filters' call stack sizes are included. But I can't find a clean way to do so. Or, we can set some global variable when the first subchannel is created. But that will entail some synchronization delay.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/16248)
<!-- Reviewable:end -->
