### PR TITLE
Build python3.7 32-bit packages on Windows

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_windows.bat
+++ b/tools/internal_ci/helper_scripts/prepare_build_windows.bat
@@ -14,7 +14,7 @@
 
 @rem make sure msys binaries are preferred over cygwin binaries
 @rem set path to python 2.7
-set PATH=C:\tools\msys64\usr\bin;C:\Python27;C:\Python37;%PATH%
+set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%
 
 @rem If this is a PR using RUN_TESTS_FLAGS var, then add flags to filter tests
 if defined KOKORO_GITHUB_PULL_REQUEST_NUMBER if defined RUN_TESTS_FLAGS (
@@ -33,9 +33,6 @@ netsh interface ip add dnsservers "Local Area Connection 8" 8.8.4.4 index=3
 
 @rem Needed for big_query_utils
 python -m pip install google-api-python-client
-
-@rem Install Python 3.7
-chocolatey install -y -r python3 --version 3.7
 
 @rem Disable some unwanted dotnet options
 set NUGET_XMLDOC_MODE=skip

--- a/tools/internal_ci/windows/grpc_build_artifacts.bat
+++ b/tools/internal_ci/windows/grpc_build_artifacts.bat
@@ -18,6 +18,7 @@ rename C:\Python27_32bit Python27_32bits
 rename C:\Python34_32bit Python34_32bits
 rename C:\Python35_32bit Python35_32bits
 rename C:\Python36_32bit Python36_32bits
+rename C:\Python37_32bit Python37_32bits
 
 @rem enter repo root
 cd /d %~dp0\..\..\..

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -378,6 +378,7 @@ def targets():
         PythonArtifact('windows', 'x86', 'Python34_32bits'),
         PythonArtifact('windows', 'x86', 'Python35_32bits'),
         PythonArtifact('windows', 'x86', 'Python36_32bits'),
+        PythonArtifact('windows', 'x86', 'Python37_32bits'),
         PythonArtifact('windows', 'x64', 'Python27'),
         PythonArtifact('windows', 'x64', 'Python34'),
         PythonArtifact('windows', 'x64', 'Python35'),


### PR DESCRIPTION
Backport #16111 into v1.14.x to build 32-bit Python 3.7 wheels for Windows. Addresses https://github.com/grpc/grpc/issues/15968 (after pushed to PyPI)