### PR TITLE
Update instructions to include how to satisfy gFlags prerequisite on a Mac

### DIFF
--- a/doc/command_line_tool.md
+++ b/doc/command_line_tool.md
@@ -41,11 +41,15 @@ repository, you need to run the following command to update submodules:
 git submodule update --init
 ```
 
-You also need to have the gflags library installed on your system. On Linux
-systems, gflags can be installed with the following command:
-
+You also need to have the gflags library installed on your system. gflags can be
+installed with the following command:
+Linux:
 ```
 sudo apt-get install libgflags-dev
+```
+Mac systems with Homebrew:
+```
+brew install gflags
 ```
 
 Once the prerequisites are satisfied, you can build the command line tool with


### PR DESCRIPTION
I was trying to build the `grpc_cli` on my mac today and ran into the prerequisite error:
```
test/cpp/util/cli_credentials.cc:21:10: fatal error: 'gflags/gflags.h' file not found
#include <gflags/gflags.h>
         ^~~~~~~~~~~~~~~~~
```

I thought it would be helpful to add Mac instructions since there were only instructions for Linux there.