### PR TITLE
Create a --call_creds flag for grpc_cli.

### DIFF
--- a/test/cpp/util/cli_credentials.cc
+++ b/test/cpp/util/cli_credentials.cc
@@ -28,7 +28,8 @@ DEFINE_bool(use_auth, false,
             "--channel_creds_type=gdc.");
 DEFINE_string(
     access_token, "",
-    "The access token that will be sent to the server to authenticate RPCs.");
+    "The access token that will be sent to the server to authenticate RPCs. "
+    "Deprecated. Use --call_creds=access_token=<token>.");
 DEFINE_string(
     ssl_target, "",
     "If not empty, treat the server host name as this for ssl/tls certificate "
@@ -37,9 +38,33 @@ DEFINE_string(
     channel_creds_type, "",
     "The channel creds type: insecure, ssl, gdc (Google Default Credentials) "
     "or alts.");
+DEFINE_string(
+    call_creds, "",
+    "Call credentials to use: none (default), or access_token=<token>. If "
+    "provided, the call creds are composited on top of channel creds.");
 
 namespace grpc {
 namespace testing {
+
+namespace {
+
+const char ACCESS_TOKEN_PREFIX[] = "access_token=";
+constexpr int ACCESS_TOKEN_PREFIX_LEN =
+    sizeof(ACCESS_TOKEN_PREFIX) / sizeof(*ACCESS_TOKEN_PREFIX) - 1;
+
+bool IsAccessToken(const grpc::string& auth) {
+  return auth.length() > ACCESS_TOKEN_PREFIX_LEN &&
+         auth.compare(0, ACCESS_TOKEN_PREFIX_LEN, ACCESS_TOKEN_PREFIX) == 0;
+}
+
+grpc::string AccessToken(const grpc::string& auth) {
+  if (!IsAccessToken(auth)) {
+    return "";
+  }
+  return grpc::string(auth, ACCESS_TOKEN_PREFIX_LEN);
+}
+
+}  // namespace
 
 grpc::string CliCredentials::GetDefaultChannelCredsType() const {
   // Compatibility logic for --enable_ssl.
@@ -57,6 +82,16 @@ grpc::string CliCredentials::GetDefaultChannelCredsType() const {
     return "gdc";
   }
   return "insecure";
+}
+
+grpc::string CliCredentials::GetDefaultCallCreds() const {
+  if (!FLAGS_access_token.empty()) {
+    fprintf(stderr,
+            "warning: --access_token is deprecated. Use "
+            "--call_creds=access_token=<token>.\n");
+    return grpc::string("access_token=") + FLAGS_access_token;
+  }
+  return "none";
 }
 
 std::shared_ptr<grpc::ChannelCredentials>
@@ -80,18 +115,30 @@ CliCredentials::GetChannelCredentials() const {
 
 std::shared_ptr<grpc::CallCredentials> CliCredentials::GetCallCredentials()
     const {
-  if (!FLAGS_access_token.empty()) {
-    if (FLAGS_use_auth) {
-      fprintf(stderr,
-              "warning: use_auth is ignored when access_token is provided.");
-    }
-    return grpc::AccessTokenCredentials(FLAGS_access_token);
+  if (IsAccessToken(FLAGS_call_creds)) {
+    return grpc::AccessTokenCredentials(AccessToken(FLAGS_call_creds));
   }
+  if (FLAGS_call_creds.compare("none") != 0) {
+    // Nothing to do; creds, if any, are baked into the channel.
+    return std::shared_ptr<grpc::CallCredentials>();
+  }
+  fprintf(stderr,
+          "--call_creds=%s invalid; must be none "
+          "or access_token=<token>.\n",
+          FLAGS_call_creds.c_str());
   return std::shared_ptr<grpc::CallCredentials>();
 }
 
 std::shared_ptr<grpc::ChannelCredentials> CliCredentials::GetCredentials()
     const {
+  if (FLAGS_call_creds.empty()) {
+    FLAGS_call_creds = GetDefaultCallCreds();
+  } else if (!FLAGS_access_token.empty() && !IsAccessToken(FLAGS_call_creds)) {
+    fprintf(stderr,
+            "warning: ignoring --access_token because --call_creds "
+            "already set to %s.\n",
+            FLAGS_call_creds.c_str());
+  }
   if (FLAGS_channel_creds_type.empty()) {
     FLAGS_channel_creds_type = GetDefaultChannelCredsType();
   } else if (FLAGS_enable_ssl && FLAGS_channel_creds_type.compare("ssl") != 0) {
@@ -106,7 +153,7 @@ std::shared_ptr<grpc::ChannelCredentials> CliCredentials::GetCredentials()
             FLAGS_channel_creds_type.c_str());
   }
   // Legacy transport upgrade logic for insecure requests.
-  if (!FLAGS_access_token.empty() &&
+  if (IsAccessToken(FLAGS_call_creds) &&
       FLAGS_channel_creds_type.compare("insecure") == 0) {
     fprintf(stderr,
             "warning: --channel_creds_type=insecure upgraded to ssl because "
@@ -126,10 +173,14 @@ const grpc::string CliCredentials::GetCredentialUsage() const {
   return "    --enable_ssl             ; Set whether to use ssl (deprecated)\n"
          "    --use_auth               ; Set whether to create default google"
          " credentials\n"
+         "                             ; (deprecated)\n"
          "    --access_token           ; Set the access token in metadata,"
          " overrides --use_auth\n"
+         "                             ; (deprecated)\n"
          "    --ssl_target             ; Set server host for ssl validation\n"
-         "    --channel_creds_type     ; Set to insecure, ssl, gdc, or alts\n";
+         "    --channel_creds_type     ; Set to insecure, ssl, gdc, or alts\n"
+         "    --call_creds             ; Set to none, or"
+         " access_token=<token>\n";
 }
 
 const grpc::string CliCredentials::GetSslTargetNameOverride() const {

--- a/test/cpp/util/cli_credentials.h
+++ b/test/cpp/util/cli_credentials.h
@@ -36,6 +36,9 @@ class CliCredentials {
   // Returns the appropriate channel_creds_type value for the set of legacy
   // flag arguments.
   virtual grpc::string GetDefaultChannelCredsType() const;
+  // Returns the appropriate call_creds value for the set of legacy flag
+  // arguments.
+  virtual grpc::string GetDefaultCallCreds() const;
   // Returns the base transport channel credentials. Child classes can override
   // to support additional channel_creds_types unknown to this base class.
   virtual std::shared_ptr<grpc::ChannelCredentials> GetChannelCredentials()


### PR DESCRIPTION
This replaces mutually-exclusive flags for a single selector flag which defines the call credentials to composite over any channel credentials. It is the call credentials version of PR #16204.

Fixes issue #16205.