### PR TITLE
 Revert to TRANSIENT_FAILURE during backoff

### DIFF
--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -404,6 +404,8 @@ static void continue_connect_locked(grpc_subchannel* c) {
   c->next_attempt_deadline = c->backoff->NextAttemptTime();
   args.deadline = std::max(c->next_attempt_deadline, min_deadline);
   args.channel_args = c->args;
+  grpc_connectivity_state_set(&c->state_tracker, GRPC_CHANNEL_CONNECTING,
+                              GRPC_ERROR_NONE, "connecting");
   grpc_connector_connect(c->connector, &args, &c->connecting_result,
                          &c->on_connected);
 }
@@ -478,8 +480,6 @@ static void maybe_start_connecting_locked(grpc_subchannel* c) {
   GRPC_SUBCHANNEL_WEAK_REF(c, "connecting");
   if (!c->backoff_begun) {
     c->backoff_begun = true;
-    grpc_connectivity_state_set(&c->state_tracker, GRPC_CHANNEL_CONNECTING,
-                                GRPC_ERROR_NONE, "connecting");
     continue_connect_locked(c);
   } else {
     GPR_ASSERT(!c->have_alarm);
@@ -494,11 +494,6 @@ static void maybe_start_connecting_locked(grpc_subchannel* c) {
     }
     GRPC_CLOSURE_INIT(&c->on_alarm, on_alarm, c, grpc_schedule_on_exec_ctx);
     grpc_timer_init(&c->alarm, c->next_attempt_deadline, &c->on_alarm);
-    // During backoff, we prefer the connectivity state of CONNECTING instead of
-    // TRANSIENT_FAILURE in order to prevent triggering re-resolution
-    // continuously in pick_first.
-    grpc_connectivity_state_set(&c->state_tracker, GRPC_CHANNEL_CONNECTING,
-                                GRPC_ERROR_NONE, "backoff");
   }
 }
 


### PR DESCRIPTION
Fix https://github.com/grpc/grpc/issues/16239. This reverts part of https://github.com/grpc/grpc/pull/16076.

https://github.com/grpc/grpc/pull/16076 fixed a test flake by setting the connectivity during backoff to `CONNECTING`. But that makes it hard to detect the situation that all the subchannels in RR have failed and we should set the RR to `TRANSIENT_FAILURE`. 

So this PR reverts that connectivity change. To fix the test flake above, this PR depends on https://github.com/grpc/grpc/pull/16306.