### PR TITLE
Fix mkdir race in build_packages task

### DIFF
--- a/tools/run_tests/dockerize/build_and_run_docker.sh
+++ b/tools/run_tests/dockerize/build_and_run_docker.sh
@@ -73,6 +73,10 @@ docker run \
 # Copy output artifacts
 if [ "$OUTPUT_DIR" != "" ]
 then
+  # Create the artifact directory in advance to avoid a race in "docker cp" if tasks
+  # that were running in parallel finish at the same time.
+  # see https://github.com/grpc/grpc/issues/16155
+  mkdir -p "$git_root/$OUTPUT_DIR"
   docker cp "$CONTAINER_NAME:/var/local/git/grpc/$OUTPUT_DIR" "$git_root" || FAILED="true"
 fi
 


### PR DESCRIPTION
Fixes #16155.

As supportive evidence, looking at https://source.cloud.google.com/results/invocations/6efc0b89-6c48-4e5b-a727-30d9fd89053d/targets/github%2Fgrpc/tests;passed=true shows that all 3 tasks have almost exactly the same runtime (~1:30).