### PR TITLE
Fix macos interop_to_prod tests ("out of disk space")

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_interop_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_interop_rc
@@ -17,17 +17,6 @@
 # builds. This rc script must be used in the root directory of gRPC
 # and is expected to be used before prepare_build_macos_rc
 
-export CONFIG=opt
-
-# Move gRPC repo to directory that Docker for Mac has drive access to
-mkdir /Users/kbuilder/workspace
-cp -R ./ /Users/kbuilder/workspace/grpc
-cd /Users/kbuilder/workspace/grpc
-
-# Needed for identifying Docker image sha1
-brew update
-brew install md5sha1sum
-
 # Set up gRPC-Go and gRPC-Java to test
 git clone --recursive https://github.com/grpc/grpc-go ./../grpc-go
 git clone --recursive https://github.com/grpc/grpc-java ./../grpc-java

--- a/tools/internal_ci/macos/grpc_interop_toprod.sh
+++ b/tools/internal_ci/macos/grpc_interop_toprod.sh
@@ -18,8 +18,8 @@ set -ex
 # change to grpc repo root
 cd $(dirname $0)/../../..
 
-source tools/internal_ci/helper_scripts/prepare_build_macos_interop_rc
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
+source tools/internal_ci/helper_scripts/prepare_build_macos_interop_rc
 
 # using run_interop_tests.py without --use_docker, so we need to build first
 tools/run_tests/run_tests.py -l c++ -c opt --build_only


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/16268

It turns out `prepare_build_macos_interop_rc` still had some leftover cruft from the time we were trying to use docker to run interop tests on mac. That stuff is not necessary anymore so removing and also doing a bit of cleanup. 