### PR TITLE
Python fork handler checks if gRPC core successfully shutdown

### DIFF
--- a/grpc.def
+++ b/grpc.def
@@ -15,6 +15,7 @@ EXPORTS
     grpc_register_plugin
     grpc_init
     grpc_shutdown
+    grpc_is_initialized
     grpc_version_string
     grpc_g_stands_for
     grpc_completion_queue_factory_lookup

--- a/include/grpc/grpc.h
+++ b/include/grpc/grpc.h
@@ -79,6 +79,12 @@ GRPCAPI void grpc_init(void);
     destroyed. */
 GRPCAPI void grpc_shutdown(void);
 
+/** EXPERIMENTAL. Returns 1 if the grpc library has been initialized.
+    TODO(ericgribkoff) Decide if this should be promoted to non-experimental as
+    part of stabilizing the fork support API, as tracked in
+    https://github.com/grpc/grpc/issues/15334 */
+GRPCAPI int grpc_is_initialized(void);
+
 /** Return a string representing the current version of grpc */
 GRPCAPI const char* grpc_version_string(void);
 

--- a/src/core/lib/iomgr/fork_posix.cc
+++ b/src/core/lib/iomgr/fork_posix.cc
@@ -25,6 +25,7 @@
 #include <string.h>
 
 #include <grpc/fork.h>
+#include <grpc/grpc.h>
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gpr/env.h"
@@ -34,7 +35,6 @@
 #include "src/core/lib/iomgr/executor.h"
 #include "src/core/lib/iomgr/timer_manager.h"
 #include "src/core/lib/iomgr/wakeup_fd_posix.h"
-#include "src/core/lib/surface/init.h"
 
 /*
  * NOTE: FORKING IS NOT GENERALLY SUPPORTED, THIS IS ONLY INTENDED TO WORK

--- a/src/core/lib/surface/init.h
+++ b/src/core/lib/surface/init.h
@@ -22,6 +22,5 @@
 void grpc_register_security_filters(void);
 void grpc_security_pre_init(void);
 void grpc_security_init(void);
-int grpc_is_initialized(void);
 
 #endif /* GRPC_CORE_LIB_SURFACE_INIT_H */

--- a/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/fork_posix.pyx.pxi
@@ -73,6 +73,10 @@ cdef void __postfork_child() nogil:
         # TODO(ericgribkoff) Check and abort if core is not shutdown
         with _fork_state.fork_in_progress_condition:
             _fork_state.fork_in_progress = False
+    if grpc_is_initialized() > 0:
+        with gil:
+            _LOGGER.error('Failed to shutdown gRPC Core after fork()')
+            os._exit(os.EX_USAGE)
 
 
 def fork_handlers_and_grpc_init():

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -322,6 +322,7 @@ cdef extern from "grpc/grpc.h":
 
   void grpc_init() nogil
   void grpc_shutdown() nogil
+  int grpc_is_initialized() nogil
 
   ctypedef struct grpc_completion_queue_factory:
     pass

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.c
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.c
@@ -38,6 +38,7 @@ grpc_call_details_destroy_type grpc_call_details_destroy_import;
 grpc_register_plugin_type grpc_register_plugin_import;
 grpc_init_type grpc_init_import;
 grpc_shutdown_type grpc_shutdown_import;
+grpc_is_initialized_type grpc_is_initialized_import;
 grpc_version_string_type grpc_version_string_import;
 grpc_g_stands_for_type grpc_g_stands_for_import;
 grpc_completion_queue_factory_lookup_type grpc_completion_queue_factory_lookup_import;
@@ -291,6 +292,7 @@ void grpc_rb_load_imports(HMODULE library) {
   grpc_register_plugin_import = (grpc_register_plugin_type) GetProcAddress(library, "grpc_register_plugin");
   grpc_init_import = (grpc_init_type) GetProcAddress(library, "grpc_init");
   grpc_shutdown_import = (grpc_shutdown_type) GetProcAddress(library, "grpc_shutdown");
+  grpc_is_initialized_import = (grpc_is_initialized_type) GetProcAddress(library, "grpc_is_initialized");
   grpc_version_string_import = (grpc_version_string_type) GetProcAddress(library, "grpc_version_string");
   grpc_g_stands_for_import = (grpc_g_stands_for_type) GetProcAddress(library, "grpc_g_stands_for");
   grpc_completion_queue_factory_lookup_import = (grpc_completion_queue_factory_lookup_type) GetProcAddress(library, "grpc_completion_queue_factory_lookup");

--- a/src/ruby/ext/grpc/rb_grpc_imports.generated.h
+++ b/src/ruby/ext/grpc/rb_grpc_imports.generated.h
@@ -89,6 +89,9 @@ extern grpc_init_type grpc_init_import;
 typedef void(*grpc_shutdown_type)(void);
 extern grpc_shutdown_type grpc_shutdown_import;
 #define grpc_shutdown grpc_shutdown_import
+typedef int(*grpc_is_initialized_type)(void);
+extern grpc_is_initialized_type grpc_is_initialized_import;
+#define grpc_is_initialized grpc_is_initialized_import
 typedef const char*(*grpc_version_string_type)(void);
 extern grpc_version_string_type grpc_version_string_import;
 #define grpc_version_string grpc_version_string_import

--- a/test/core/surface/public_headers_must_be_c89.c
+++ b/test/core/surface/public_headers_must_be_c89.c
@@ -77,6 +77,7 @@ int main(int argc, char **argv) {
   printf("%lx", (unsigned long) grpc_register_plugin);
   printf("%lx", (unsigned long) grpc_init);
   printf("%lx", (unsigned long) grpc_shutdown);
+  printf("%lx", (unsigned long) grpc_is_initialized);
   printf("%lx", (unsigned long) grpc_version_string);
   printf("%lx", (unsigned long) grpc_g_stands_for);
   printf("%lx", (unsigned long) grpc_completion_queue_factory_lookup);


### PR DESCRIPTION
This is a follow-up to https://github.com/grpc/grpc/pull/16264. The first commit here contains the contents of that PR and can be ignored. The second commit adds `grpc_is_initialized()` (previously only declared in `src/core/lib/surface/init.h)  to `grpc/grpc.h`, allowing gRPC Python to check in its child post-fork handler if core was successfully shutdown. This guards against an application that enables fork support but also has gRPC core resources outside of gRPC Python's control, which cannot be shutdown cleanly in the post-fork handler and should therefore cause the forked process to fail with an error.