### PR TITLE
No need to build artifact for PHP MacOS

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -290,11 +290,10 @@ class PHPArtifact:
         return []
 
     def build_jobspec(self):
-        if self.platform == 'linux':
-            return create_docker_jobspec(
-                self.name, 'tools/dockerfile/grpc_artifact_linux_{}'.format(
-                    self.arch),
-                'tools/run_tests/artifacts/build_artifact_php.sh')
+        return create_docker_jobspec(
+            self.name, 'tools/dockerfile/grpc_artifact_linux_{}'.format(
+                self.arch),
+            'tools/run_tests/artifacts/build_artifact_php.sh')
 
 
 class ProtocArtifact:

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -295,10 +295,6 @@ class PHPArtifact:
                 self.name, 'tools/dockerfile/grpc_artifact_linux_{}'.format(
                     self.arch),
                 'tools/run_tests/artifacts/build_artifact_php.sh')
-        else:
-            return create_jobspec(
-                self.name, ['tools/run_tests/artifacts/build_artifact_php.sh'],
-                use_workspace=True)
 
 
 class ProtocArtifact:
@@ -400,6 +396,5 @@ def targets():
         PythonArtifact('windows', 'x64', 'Python37'),
         RubyArtifact('linux', 'x64'),
         RubyArtifact('macos', 'x64'),
-        PHPArtifact('linux', 'x64'),
-        PHPArtifact('macos', 'x64')
+        PHPArtifact('linux', 'x64')
     ])

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -292,8 +292,7 @@ class PHPArtifact:
     def build_jobspec(self):
         return create_docker_jobspec(
             self.name, 'tools/dockerfile/grpc_artifact_linux_{}'.format(
-                self.arch),
-            'tools/run_tests/artifacts/build_artifact_php.sh')
+                self.arch), 'tools/run_tests/artifacts/build_artifact_php.sh')
 
 
 class ProtocArtifact:


### PR DESCRIPTION
There is no need to build artifacts for PHP on MacOS. For PHP, we only need to build the `.tgz` package in Linux. It's a source distribution so there will be no material difference if we build from another platform.