### PR TITLE
C#: upgrade protobuf nugets to v3.6.1

### DIFF
--- a/src/csharp/Grpc.Core/Version.csproj.include
+++ b/src/csharp/Grpc.Core/Version.csproj.include
@@ -2,6 +2,6 @@
 <Project>
   <PropertyGroup>
     <GrpcCsharpVersion>1.15.0-dev</GrpcCsharpVersion>
-    <GoogleProtobufVersion>3.6.0</GoogleProtobufVersion>
+    <GoogleProtobufVersion>3.6.1</GoogleProtobufVersion>
   </PropertyGroup>
 </Project>

--- a/templates/src/csharp/Grpc.Core/Version.csproj.include.template
+++ b/templates/src/csharp/Grpc.Core/Version.csproj.include.template
@@ -4,6 +4,6 @@
   <Project>
     <PropertyGroup>
       <GrpcCsharpVersion>${settings.csharp_version}</GrpcCsharpVersion>
-      <GoogleProtobufVersion>3.6.0</GoogleProtobufVersion>
+      <GoogleProtobufVersion>3.6.1</GoogleProtobufVersion>
     </PropertyGroup>
   </Project>


### PR DESCRIPTION
Upgrade the nugets (followup for https://github.com/grpc/grpc/pull/15597).