### PR TITLE
C++ microbenchmarks: update from KeepRunning to range-based for 

### DIFF
--- a/test/cpp/microbenchmarks/bm_alarm.cc
+++ b/test/cpp/microbenchmarks/bm_alarm.cc
@@ -37,7 +37,7 @@ static void BM_Alarm_Tag_Immediate(benchmark::State& state) {
   void* output_tag;
   bool ok;
   auto deadline = grpc_timeout_seconds_to_deadline(0);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     alarm.Set(&cq, deadline, nullptr);
     cq.Next(&output_tag, &ok);
   }

--- a/test/cpp/microbenchmarks/bm_arena.cc
+++ b/test/cpp/microbenchmarks/bm_arena.cc
@@ -26,7 +26,7 @@
 using grpc_core::Arena;
 
 static void BM_Arena_NoOp(benchmark::State& state) {
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     Arena::Create(state.range(0))->Destroy();
   }
 }
@@ -49,7 +49,7 @@ static void BM_Arena_ManyAlloc(benchmark::State& state) {
 BENCHMARK(BM_Arena_ManyAlloc)->Ranges({{1, 1024 * 1024}, {1, 32 * 1024}});
 
 static void BM_Arena_Batch(benchmark::State& state) {
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     Arena* a = Arena::Create(state.range(0));
     for (int i = 0; i < state.range(1); i++) {
       a->Alloc(state.range(2));

--- a/test/cpp/microbenchmarks/bm_byte_buffer.cc
+++ b/test/cpp/microbenchmarks/bm_byte_buffer.cc
@@ -40,7 +40,7 @@ static void BM_ByteBuffer_Copy(benchmark::State& state) {
     slices.emplace_back(buf.get(), slice_size);
   }
   grpc::ByteBuffer bb(slices.data(), num_slices);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc::ByteBuffer cc(bb);
   }
 }
@@ -60,7 +60,7 @@ static void BM_ByteBufferReader_Next(benchmark::State& state) {
   grpc_byte_buffer_reader reader;
   GPR_ASSERT(
       g_core_codegen_interface->grpc_byte_buffer_reader_init(&reader, bb));
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_slice* slice;
     if (GPR_UNLIKELY(!g_core_codegen_interface->grpc_byte_buffer_reader_peek(
             &reader, &slice))) {
@@ -93,7 +93,7 @@ static void BM_ByteBufferReader_Peek(benchmark::State& state) {
   grpc_byte_buffer_reader reader;
   GPR_ASSERT(
       g_core_codegen_interface->grpc_byte_buffer_reader_init(&reader, bb));
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_slice* slice;
     if (GPR_UNLIKELY(!g_core_codegen_interface->grpc_byte_buffer_reader_peek(
             &reader, &slice))) {

--- a/test/cpp/microbenchmarks/bm_call_create.cc
+++ b/test/cpp/microbenchmarks/bm_call_create.cc
@@ -52,7 +52,7 @@ void BM_Zalloc(benchmark::State& state) {
   // sizes
   TrackCounters track_counters;
   size_t sz = state.range(0);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     gpr_free(gpr_zalloc(sz));
   }
   track_counters.Finish(state);
@@ -107,7 +107,7 @@ static void BM_CallCreateDestroy(benchmark::State& state) {
   gpr_timespec deadline = gpr_inf_future(GPR_CLOCK_MONOTONIC);
   void* method_hdl = grpc_channel_register_call(fixture.channel(), "/foo/bar",
                                                 nullptr, nullptr);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_call_unref(grpc_channel_create_registered_call(
         fixture.channel(), nullptr, GRPC_PROPAGATE_DEFAULTS, cq, method_hdl,
         deadline, nullptr));
@@ -139,7 +139,7 @@ static void BM_LameChannelCallCreateCpp(benchmark::State& state) {
   grpc::testing::EchoRequest send_request;
   grpc::testing::EchoResponse recv_response;
   grpc::Status recv_status;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GPR_TIMER_SCOPE("BenchmarkCycle", 0);
     grpc::ClientContext cli_ctx;
     auto reader = stub->AsyncEcho(&cli_ctx, send_request, &cq);
@@ -174,7 +174,7 @@ static void BM_LameChannelCallCreateCore(benchmark::State& state) {
   cq = grpc_completion_queue_create_for_next(nullptr);
   void* rc = grpc_channel_register_call(
       channel, "/grpc.testing.EchoTestService/Echo", nullptr, nullptr);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GPR_TIMER_SCOPE("BenchmarkCycle", 0);
     grpc_call* call = grpc_channel_create_registered_call(
         channel, nullptr, GRPC_PROPAGATE_DEFAULTS, cq, rc,
@@ -248,7 +248,7 @@ static void BM_LameChannelCallCreateCoreSeparateBatch(benchmark::State& state) {
   cq = grpc_completion_queue_create_for_next(nullptr);
   void* rc = grpc_channel_register_call(
       channel, "/grpc.testing.EchoTestService/Echo", nullptr, nullptr);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GPR_TIMER_SCOPE("BenchmarkCycle", 0);
     grpc_call* call = grpc_channel_create_registered_call(
         channel, nullptr, GRPC_PROPAGATE_DEFAULTS, cq, rc,
@@ -720,7 +720,7 @@ static void BM_IsolatedCall_NoOp(benchmark::State& state) {
   gpr_timespec deadline = gpr_inf_future(GPR_CLOCK_MONOTONIC);
   void* method_hdl = grpc_channel_register_call(fixture.channel(), "/foo/bar",
                                                 nullptr, nullptr);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GPR_TIMER_SCOPE("BenchmarkCycle", 0);
     grpc_call_unref(grpc_channel_create_registered_call(
         fixture.channel(), nullptr, GRPC_PROPAGATE_DEFAULTS, fixture.cq(),
@@ -759,7 +759,7 @@ static void BM_IsolatedCall_Unary(benchmark::State& state) {
   ops[5].data.recv_status_on_client.status = &status_code;
   ops[5].data.recv_status_on_client.status_details = &status_details;
   ops[5].data.recv_status_on_client.trailing_metadata = &recv_trailing_metadata;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GPR_TIMER_SCOPE("BenchmarkCycle", 0);
     grpc_call* call = grpc_channel_create_registered_call(
         fixture.channel(), nullptr, GRPC_PROPAGATE_DEFAULTS, fixture.cq(),
@@ -802,7 +802,7 @@ static void BM_IsolatedCall_StreamingSend(benchmark::State& state) {
   memset(ops, 0, sizeof(ops));
   ops[0].op = GRPC_OP_SEND_MESSAGE;
   ops[0].data.send_message.send_message = send_message;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GPR_TIMER_SCOPE("BenchmarkCycle", 0);
     grpc_call_start_batch(call, ops, 1, tag(2), nullptr);
     grpc_completion_queue_next(fixture.cq(),

--- a/test/cpp/microbenchmarks/bm_channel.cc
+++ b/test/cpp/microbenchmarks/bm_channel.cc
@@ -62,7 +62,7 @@ static void BM_InsecureChannelCreateDestroy(benchmark::State& state) {
   for (int i = 0; i < state.range(0); i++) {
     initial_channels[i].Init();
   }
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     Fixture channel;
     channel.Init();
   }

--- a/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
@@ -54,7 +54,7 @@ static void BM_HpackEncoderInitDestroy(benchmark::State& state) {
   grpc_core::ExecCtx exec_ctx;
   std::unique_ptr<grpc_chttp2_hpack_compressor> c(
       new grpc_chttp2_hpack_compressor);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_chttp2_hpack_compressor_init(c.get());
     grpc_chttp2_hpack_compressor_destroy(c.get());
     grpc_core::ExecCtx::Get()->Flush();
@@ -435,7 +435,7 @@ static void BM_HpackParserInitDestroy(benchmark::State& state) {
   grpc_chttp2_hpack_parser p;
   // Initial destruction so we don't leak memory in the loop.
   grpc_chttp2_hptbl_destroy(&p.table);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_chttp2_hpack_parser_init(&p);
     // Note that grpc_chttp2_hpack_parser_destroy frees the table dynamic
     // elements so we need to recreate it here. In actual operation,

--- a/test/cpp/microbenchmarks/bm_closure.cc
+++ b/test/cpp/microbenchmarks/bm_closure.cc
@@ -32,7 +32,7 @@
 
 static void BM_NoOpExecCtx(benchmark::State& state) {
   TrackCounters track_counters;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_core::ExecCtx exec_ctx;
   }
   track_counters.Finish(state);
@@ -42,7 +42,7 @@ BENCHMARK(BM_NoOpExecCtx);
 static void BM_WellFlushed(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_core::ExecCtx::Get()->Flush();
   }
 
@@ -55,7 +55,7 @@ static void DoNothing(void* arg, grpc_error* error) {}
 static void BM_ClosureInitAgainstExecCtx(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_closure c;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     benchmark::DoNotOptimize(
         GRPC_CLOSURE_INIT(&c, DoNothing, nullptr, grpc_schedule_on_exec_ctx));
   }
@@ -68,7 +68,7 @@ static void BM_ClosureInitAgainstCombiner(benchmark::State& state) {
   grpc_combiner* combiner = grpc_combiner_create();
   grpc_closure c;
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     benchmark::DoNotOptimize(GRPC_CLOSURE_INIT(
         &c, DoNothing, nullptr, grpc_combiner_scheduler(combiner)));
   }
@@ -83,7 +83,7 @@ static void BM_ClosureRunOnExecCtx(benchmark::State& state) {
   grpc_closure c;
   GRPC_CLOSURE_INIT(&c, DoNothing, nullptr, grpc_schedule_on_exec_ctx);
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_CLOSURE_RUN(&c, GRPC_ERROR_NONE);
     grpc_core::ExecCtx::Get()->Flush();
   }
@@ -95,7 +95,7 @@ BENCHMARK(BM_ClosureRunOnExecCtx);
 static void BM_ClosureCreateAndRun(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_CLOSURE_RUN(
         GRPC_CLOSURE_CREATE(DoNothing, nullptr, grpc_schedule_on_exec_ctx),
         GRPC_ERROR_NONE);
@@ -109,7 +109,7 @@ static void BM_ClosureInitAndRun(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::ExecCtx exec_ctx;
   grpc_closure c;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_CLOSURE_RUN(
         GRPC_CLOSURE_INIT(&c, DoNothing, nullptr, grpc_schedule_on_exec_ctx),
         GRPC_ERROR_NONE);
@@ -124,7 +124,7 @@ static void BM_ClosureSchedOnExecCtx(benchmark::State& state) {
   grpc_closure c;
   GRPC_CLOSURE_INIT(&c, DoNothing, nullptr, grpc_schedule_on_exec_ctx);
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_CLOSURE_SCHED(&c, GRPC_ERROR_NONE);
     grpc_core::ExecCtx::Get()->Flush();
   }
@@ -140,7 +140,7 @@ static void BM_ClosureSched2OnExecCtx(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c1, DoNothing, nullptr, grpc_schedule_on_exec_ctx);
   GRPC_CLOSURE_INIT(&c2, DoNothing, nullptr, grpc_schedule_on_exec_ctx);
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_CLOSURE_SCHED(&c1, GRPC_ERROR_NONE);
     GRPC_CLOSURE_SCHED(&c2, GRPC_ERROR_NONE);
     grpc_core::ExecCtx::Get()->Flush();
@@ -159,7 +159,7 @@ static void BM_ClosureSched3OnExecCtx(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c2, DoNothing, nullptr, grpc_schedule_on_exec_ctx);
   GRPC_CLOSURE_INIT(&c3, DoNothing, nullptr, grpc_schedule_on_exec_ctx);
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_CLOSURE_SCHED(&c1, GRPC_ERROR_NONE);
     GRPC_CLOSURE_SCHED(&c2, GRPC_ERROR_NONE);
     GRPC_CLOSURE_SCHED(&c3, GRPC_ERROR_NONE);
@@ -176,7 +176,7 @@ static void BM_AcquireMutex(benchmark::State& state) {
   gpr_mu mu;
   gpr_mu_init(&mu);
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     gpr_mu_lock(&mu);
     DoNothing(nullptr, GRPC_ERROR_NONE);
     gpr_mu_unlock(&mu);
@@ -193,7 +193,7 @@ static void BM_TryAcquireMutex(benchmark::State& state) {
   gpr_mu mu;
   gpr_mu_init(&mu);
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     if (gpr_mu_trylock(&mu)) {
       DoNothing(nullptr, GRPC_ERROR_NONE);
       gpr_mu_unlock(&mu);
@@ -212,7 +212,7 @@ static void BM_AcquireSpinlock(benchmark::State& state) {
   // for comparison with the combiner stuff below
   gpr_spinlock mu = GPR_SPINLOCK_INITIALIZER;
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     gpr_spinlock_lock(&mu);
     DoNothing(nullptr, GRPC_ERROR_NONE);
     gpr_spinlock_unlock(&mu);
@@ -227,7 +227,7 @@ static void BM_TryAcquireSpinlock(benchmark::State& state) {
   // for comparison with the combiner stuff below
   gpr_spinlock mu = GPR_SPINLOCK_INITIALIZER;
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     if (gpr_spinlock_trylock(&mu)) {
       DoNothing(nullptr, GRPC_ERROR_NONE);
       gpr_spinlock_unlock(&mu);
@@ -246,7 +246,7 @@ static void BM_ClosureSchedOnCombiner(benchmark::State& state) {
   grpc_closure c;
   GRPC_CLOSURE_INIT(&c, DoNothing, nullptr, grpc_combiner_scheduler(combiner));
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_CLOSURE_SCHED(&c, GRPC_ERROR_NONE);
     grpc_core::ExecCtx::Get()->Flush();
   }
@@ -264,7 +264,7 @@ static void BM_ClosureSched2OnCombiner(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c1, DoNothing, nullptr, grpc_combiner_scheduler(combiner));
   GRPC_CLOSURE_INIT(&c2, DoNothing, nullptr, grpc_combiner_scheduler(combiner));
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_CLOSURE_SCHED(&c1, GRPC_ERROR_NONE);
     GRPC_CLOSURE_SCHED(&c2, GRPC_ERROR_NONE);
     grpc_core::ExecCtx::Get()->Flush();
@@ -285,7 +285,7 @@ static void BM_ClosureSched3OnCombiner(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c2, DoNothing, nullptr, grpc_combiner_scheduler(combiner));
   GRPC_CLOSURE_INIT(&c3, DoNothing, nullptr, grpc_combiner_scheduler(combiner));
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_CLOSURE_SCHED(&c1, GRPC_ERROR_NONE);
     GRPC_CLOSURE_SCHED(&c2, GRPC_ERROR_NONE);
     GRPC_CLOSURE_SCHED(&c3, GRPC_ERROR_NONE);
@@ -308,7 +308,7 @@ static void BM_ClosureSched2OnTwoCombiners(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c2, DoNothing, nullptr,
                     grpc_combiner_scheduler(combiner2));
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_CLOSURE_SCHED(&c1, GRPC_ERROR_NONE);
     GRPC_CLOSURE_SCHED(&c2, GRPC_ERROR_NONE);
     grpc_core::ExecCtx::Get()->Flush();
@@ -337,7 +337,7 @@ static void BM_ClosureSched4OnTwoCombiners(benchmark::State& state) {
   GRPC_CLOSURE_INIT(&c4, DoNothing, nullptr,
                     grpc_combiner_scheduler(combiner2));
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_CLOSURE_SCHED(&c1, GRPC_ERROR_NONE);
     GRPC_CLOSURE_SCHED(&c2, GRPC_ERROR_NONE);
     GRPC_CLOSURE_SCHED(&c3, GRPC_ERROR_NONE);

--- a/test/cpp/microbenchmarks/bm_cq.cc
+++ b/test/cpp/microbenchmarks/bm_cq.cc
@@ -34,7 +34,7 @@ namespace testing {
 
 static void BM_CreateDestroyCpp(benchmark::State& state) {
   TrackCounters track_counters;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     CompletionQueue cq;
   }
   track_counters.Finish(state);
@@ -44,7 +44,7 @@ BENCHMARK(BM_CreateDestroyCpp);
 /* Create cq using a different constructor */
 static void BM_CreateDestroyCpp2(benchmark::State& state) {
   TrackCounters track_counters;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_completion_queue* core_cq =
         grpc_completion_queue_create_for_next(nullptr);
     CompletionQueue cq(core_cq);
@@ -55,7 +55,7 @@ BENCHMARK(BM_CreateDestroyCpp2);
 
 static void BM_CreateDestroyCore(benchmark::State& state) {
   TrackCounters track_counters;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     // TODO: sreek Templatize this benchmark and pass completion type and
     // polling type as parameters
     grpc_completion_queue_destroy(
@@ -77,7 +77,7 @@ static void BM_Pass1Cpp(benchmark::State& state) {
   TrackCounters track_counters;
   CompletionQueue cq;
   grpc_completion_queue* c_cq = cq.cq();
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_cq_completion completion;
     DummyTag dummy_tag;
     grpc_core::ExecCtx exec_ctx;
@@ -98,7 +98,7 @@ static void BM_Pass1Core(benchmark::State& state) {
   // TODO: sreek Templatize this benchmark and pass polling_type as a param
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
   gpr_timespec deadline = gpr_inf_future(GPR_CLOCK_MONOTONIC);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_cq_completion completion;
     grpc_core::ExecCtx exec_ctx;
     GPR_ASSERT(grpc_cq_begin_op(cq, nullptr));
@@ -117,7 +117,7 @@ static void BM_Pluck1Core(benchmark::State& state) {
   // TODO: sreek Templatize this benchmark and pass polling_type as a param
   grpc_completion_queue* cq = grpc_completion_queue_create_for_pluck(nullptr);
   gpr_timespec deadline = gpr_inf_future(GPR_CLOCK_MONOTONIC);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_cq_completion completion;
     grpc_core::ExecCtx exec_ctx;
     GPR_ASSERT(grpc_cq_begin_op(cq, nullptr));
@@ -136,7 +136,7 @@ static void BM_EmptyCore(benchmark::State& state) {
   // TODO: sreek Templatize this benchmark and pass polling_type as a param
   grpc_completion_queue* cq = grpc_completion_queue_create_for_next(nullptr);
   gpr_timespec deadline = gpr_inf_past(GPR_CLOCK_MONOTONIC);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_completion_queue_next(cq, deadline, nullptr);
   }
   grpc_completion_queue_destroy(cq);
@@ -202,7 +202,7 @@ static void BM_Callback_CQ_Pass1Core(benchmark::State& state) {
   ShutdownCallback shutdown_cb(&got_shutdown);
   grpc_completion_queue* cc =
       grpc_completion_queue_create_for_callback(&shutdown_cb, nullptr);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
     grpc_core::ExecCtx exec_ctx;
     grpc_cq_completion completion;

--- a/test/cpp/microbenchmarks/bm_cq_multiple_threads.cc
+++ b/test/cpp/microbenchmarks/bm_cq_multiple_threads.cc
@@ -174,7 +174,7 @@ static void BM_Cq_Throughput(benchmark::State& state) {
   // (optionally including low-level counters) before and after the test
   TrackCounters track_counters;
 
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GPR_ASSERT(grpc_completion_queue_next(g_cq, deadline, nullptr).type ==
                GRPC_OP_COMPLETE);
   }

--- a/test/cpp/microbenchmarks/bm_error.cc
+++ b/test/cpp/microbenchmarks/bm_error.cc
@@ -35,7 +35,7 @@ typedef std::unique_ptr<grpc_error, ErrorDeleter> ErrorPtr;
 
 static void BM_ErrorCreateFromStatic(benchmark::State& state) {
   TrackCounters track_counters;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_ERROR_UNREF(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Error"));
   }
   track_counters.Finish(state);
@@ -44,7 +44,7 @@ BENCHMARK(BM_ErrorCreateFromStatic);
 
 static void BM_ErrorCreateFromCopied(benchmark::State& state) {
   TrackCounters track_counters;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_ERROR_UNREF(GRPC_ERROR_CREATE_FROM_COPIED_STRING("Error not inline"));
   }
   track_counters.Finish(state);
@@ -53,7 +53,7 @@ BENCHMARK(BM_ErrorCreateFromCopied);
 
 static void BM_ErrorCreateAndSetStatus(benchmark::State& state) {
   TrackCounters track_counters;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_ERROR_UNREF(
         grpc_error_set_int(GRPC_ERROR_CREATE_FROM_STATIC_STRING("Error"),
                            GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_ABORTED));
@@ -64,7 +64,7 @@ BENCHMARK(BM_ErrorCreateAndSetStatus);
 
 static void BM_ErrorCreateAndSetIntAndStr(benchmark::State& state) {
   TrackCounters track_counters;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_ERROR_UNREF(grpc_error_set_str(
         grpc_error_set_int(
             GRPC_ERROR_CREATE_FROM_STATIC_STRING("GOAWAY received"),
@@ -79,7 +79,7 @@ static void BM_ErrorCreateAndSetIntLoop(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_error* error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Error");
   int n = 0;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     error = grpc_error_set_int(error, GRPC_ERROR_INT_GRPC_STATUS, n++);
   }
   GRPC_ERROR_UNREF(error);
@@ -91,7 +91,7 @@ static void BM_ErrorCreateAndSetStrLoop(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_error* error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Error");
   const char* str = "hello";
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     error = grpc_error_set_str(error, GRPC_ERROR_STR_GRPC_MESSAGE,
                                grpc_slice_from_static_string(str));
   }
@@ -103,7 +103,7 @@ BENCHMARK(BM_ErrorCreateAndSetStrLoop);
 static void BM_ErrorRefUnref(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_error* error = GRPC_ERROR_CREATE_FROM_STATIC_STRING("Error");
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_ERROR_UNREF(GRPC_ERROR_REF(error));
   }
   GRPC_ERROR_UNREF(error);
@@ -113,7 +113,7 @@ BENCHMARK(BM_ErrorRefUnref);
 
 static void BM_ErrorUnrefNone(benchmark::State& state) {
   TrackCounters track_counters;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_ERROR_UNREF(GRPC_ERROR_NONE);
   }
 }
@@ -121,7 +121,7 @@ BENCHMARK(BM_ErrorUnrefNone);
 
 static void BM_ErrorGetIntFromNoError(benchmark::State& state) {
   TrackCounters track_counters;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     intptr_t value;
     grpc_error_get_int(GRPC_ERROR_NONE, GRPC_ERROR_INT_GRPC_STATUS, &value);
   }
@@ -133,7 +133,7 @@ static void BM_ErrorGetMissingInt(benchmark::State& state) {
   TrackCounters track_counters;
   ErrorPtr error(grpc_error_set_int(
       GRPC_ERROR_CREATE_FROM_STATIC_STRING("Error"), GRPC_ERROR_INT_INDEX, 1));
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     intptr_t value;
     grpc_error_get_int(error.get(), GRPC_ERROR_INT_OFFSET, &value);
   }
@@ -145,7 +145,7 @@ static void BM_ErrorGetPresentInt(benchmark::State& state) {
   TrackCounters track_counters;
   ErrorPtr error(grpc_error_set_int(
       GRPC_ERROR_CREATE_FROM_STATIC_STRING("Error"), GRPC_ERROR_INT_OFFSET, 1));
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     intptr_t value;
     grpc_error_get_int(error.get(), GRPC_ERROR_INT_OFFSET, &value);
   }
@@ -224,7 +224,7 @@ class ErrorWithNestedGrpcStatus {
 template <class Fixture>
 static void BM_ErrorStringOnNewError(benchmark::State& state) {
   TrackCounters track_counters;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     Fixture fixture;
     grpc_error_string(fixture.error());
   }
@@ -235,7 +235,7 @@ template <class Fixture>
 static void BM_ErrorStringRepeatedly(benchmark::State& state) {
   TrackCounters track_counters;
   Fixture fixture;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_error_string(fixture.error());
   }
   track_counters.Finish(state);
@@ -246,7 +246,7 @@ static void BM_ErrorGetStatus(benchmark::State& state) {
   TrackCounters track_counters;
   Fixture fixture;
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_status_code status;
     grpc_slice slice;
     grpc_error_get_status(fixture.error(), fixture.deadline(), &status, &slice,
@@ -261,7 +261,7 @@ static void BM_ErrorGetStatusCode(benchmark::State& state) {
   TrackCounters track_counters;
   Fixture fixture;
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_status_code status;
     grpc_error_get_status(fixture.error(), fixture.deadline(), &status, nullptr,
                           nullptr, nullptr);
@@ -275,7 +275,7 @@ static void BM_ErrorHttpError(benchmark::State& state) {
   TrackCounters track_counters;
   Fixture fixture;
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_http2_error_code error;
     grpc_error_get_status(fixture.error(), fixture.deadline(), nullptr, nullptr,
                           &error, nullptr);
@@ -288,7 +288,7 @@ template <class Fixture>
 static void BM_HasClearGrpcStatus(benchmark::State& state) {
   TrackCounters track_counters;
   Fixture fixture;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_error_has_clear_grpc_status(fixture.error());
   }
   track_counters.Finish(state);

--- a/test/cpp/microbenchmarks/bm_metadata.cc
+++ b/test/cpp/microbenchmarks/bm_metadata.cc
@@ -30,7 +30,7 @@
 
 static void BM_SliceFromStatic(benchmark::State& state) {
   TrackCounters track_counters;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     benchmark::DoNotOptimize(grpc_core::ExternallyManagedSlice("abc"));
   }
   track_counters.Finish(state);
@@ -39,7 +39,7 @@ BENCHMARK(BM_SliceFromStatic);
 
 static void BM_SliceFromCopied(benchmark::State& state) {
   TrackCounters track_counters;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_slice_unref(grpc_core::UnmanagedMemorySlice("abc"));
   }
   track_counters.Finish(state);
@@ -49,7 +49,7 @@ BENCHMARK(BM_SliceFromCopied);
 static void BM_SliceIntern(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::ExternallyManagedSlice slice("abc");
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_slice_unref(grpc_core::ManagedMemorySlice(&slice));
   }
   track_counters.Finish(state);
@@ -60,7 +60,7 @@ static void BM_SliceReIntern(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::ExternallyManagedSlice static_slice("abc");
   grpc_core::ManagedMemorySlice slice(&static_slice);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_slice_unref(grpc_core::ManagedMemorySlice(&slice));
   }
   track_counters.Finish(state);
@@ -69,7 +69,7 @@ BENCHMARK(BM_SliceReIntern);
 
 static void BM_SliceInternStaticMetadata(benchmark::State& state) {
   TrackCounters track_counters;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     benchmark::DoNotOptimize(grpc_core::ManagedMemorySlice(&GRPC_MDSTR_GZIP));
   }
   track_counters.Finish(state);
@@ -79,7 +79,7 @@ BENCHMARK(BM_SliceInternStaticMetadata);
 static void BM_SliceInternEqualToStaticMetadata(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::ExternallyManagedSlice slice("gzip");
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     benchmark::DoNotOptimize(grpc_core::ManagedMemorySlice(&slice));
   }
   track_counters.Finish(state);
@@ -91,7 +91,7 @@ static void BM_MetadataFromNonInternedSlices(benchmark::State& state) {
   grpc_core::ExternallyManagedSlice k("key");
   grpc_core::ExternallyManagedSlice v("value");
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_MDELEM_UNREF(grpc_mdelem_create(k, v, nullptr));
   }
 
@@ -104,7 +104,7 @@ static void BM_MetadataFromInternedSlices(benchmark::State& state) {
   grpc_core::ManagedMemorySlice k("key");
   grpc_core::ManagedMemorySlice v("value");
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_MDELEM_UNREF(grpc_mdelem_create(k, v, nullptr));
   }
 
@@ -121,7 +121,7 @@ static void BM_MetadataFromInternedSlicesAlreadyInIndex(
   grpc_core::ManagedMemorySlice v("value");
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem seed = grpc_mdelem_create(k, v, nullptr);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_MDELEM_UNREF(grpc_mdelem_create(k, v, nullptr));
   }
   GRPC_MDELEM_UNREF(seed);
@@ -137,7 +137,7 @@ static void BM_MetadataFromInternedKey(benchmark::State& state) {
   grpc_core::ManagedMemorySlice k("key");
   grpc_core::ExternallyManagedSlice v("value");
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_MDELEM_UNREF(grpc_mdelem_create(k, v, nullptr));
   }
 
@@ -153,7 +153,7 @@ static void BM_MetadataFromNonInternedSlicesWithBackingStore(
   grpc_core::ExternallyManagedSlice v("value");
   char backing_store[sizeof(grpc_mdelem_data)];
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_MDELEM_UNREF(grpc_mdelem_create(
         k, v, reinterpret_cast<grpc_mdelem_data*>(backing_store)));
   }
@@ -169,7 +169,7 @@ static void BM_MetadataFromInternedSlicesWithBackingStore(
   grpc_core::ManagedMemorySlice v("value");
   char backing_store[sizeof(grpc_mdelem_data)];
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_MDELEM_UNREF(grpc_mdelem_create(
         k, v, reinterpret_cast<grpc_mdelem_data*>(backing_store)));
   }
@@ -187,7 +187,7 @@ static void BM_MetadataFromInternedKeyWithBackingStore(
   grpc_core::ExternallyManagedSlice v("value");
   char backing_store[sizeof(grpc_mdelem_data)];
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_MDELEM_UNREF(grpc_mdelem_create(
         k, v, reinterpret_cast<grpc_mdelem_data*>(backing_store)));
   }
@@ -200,7 +200,7 @@ BENCHMARK(BM_MetadataFromInternedKeyWithBackingStore);
 static void BM_MetadataFromStaticMetadataStrings(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_MDELEM_UNREF(
         grpc_mdelem_create(GRPC_MDSTR_STATUS, GRPC_MDSTR_200, nullptr));
   }
@@ -213,7 +213,7 @@ static void BM_MetadataFromStaticMetadataStringsNotIndexed(
     benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::ExecCtx exec_ctx;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_MDELEM_UNREF(
         grpc_mdelem_create(GRPC_MDSTR_STATUS, GRPC_MDSTR_GZIP, nullptr));
   }
@@ -230,7 +230,7 @@ static void BM_MetadataRefUnrefExternal(benchmark::State& state) {
       grpc_mdelem_create(grpc_core::ExternallyManagedSlice("a"),
                          grpc_core::ExternallyManagedSlice("b"),
                          reinterpret_cast<grpc_mdelem_data*>(backing_store));
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_MDELEM_UNREF(GRPC_MDELEM_REF(el));
   }
   GRPC_MDELEM_UNREF(el);
@@ -249,7 +249,7 @@ static void BM_MetadataRefUnrefInterned(benchmark::State& state) {
       k, v, reinterpret_cast<grpc_mdelem_data*>(backing_store));
   grpc_slice_unref(k);
   grpc_slice_unref(v);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_MDELEM_UNREF(GRPC_MDELEM_REF(el));
   }
   GRPC_MDELEM_UNREF(el);
@@ -264,7 +264,7 @@ static void BM_MetadataRefUnrefAllocated(benchmark::State& state) {
   grpc_mdelem el =
       grpc_mdelem_create(grpc_core::ExternallyManagedSlice("a"),
                          grpc_core::ExternallyManagedSlice("b"), nullptr);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_MDELEM_UNREF(GRPC_MDELEM_REF(el));
   }
   GRPC_MDELEM_UNREF(el);
@@ -278,7 +278,7 @@ static void BM_MetadataRefUnrefStatic(benchmark::State& state) {
   grpc_core::ExecCtx exec_ctx;
   grpc_mdelem el =
       grpc_mdelem_create(GRPC_MDSTR_STATUS, GRPC_MDSTR_200, nullptr);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_MDELEM_UNREF(GRPC_MDELEM_REF(el));
   }
   GRPC_MDELEM_UNREF(el);

--- a/test/cpp/microbenchmarks/bm_pollset.cc
+++ b/test/cpp/microbenchmarks/bm_pollset.cc
@@ -53,7 +53,7 @@ static void BM_CreateDestroyPollset(benchmark::State& state) {
   grpc_closure shutdown_ps_closure;
   GRPC_CLOSURE_INIT(&shutdown_ps_closure, shutdown_ps, ps,
                     grpc_schedule_on_exec_ctx);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     memset(ps, 0, ps_sz);
     grpc_pollset_init(ps, &mu);
     gpr_mu_lock(mu);
@@ -84,7 +84,7 @@ static void BM_PollEmptyPollset_SpeedOfLight(benchmark::State& state) {
     ev.events = EPOLLIN;
     epoll_ctl(epfd, EPOLL_CTL_ADD, fds.back(), &ev);
   }
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     epoll_wait(epfd, ev, nev, 0);
   }
   for (auto fd : fds) {
@@ -115,7 +115,7 @@ static void BM_PollEmptyPollset(benchmark::State& state) {
   grpc_pollset_init(ps, &mu);
   grpc_core::ExecCtx exec_ctx;
   gpr_mu_lock(mu);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GRPC_ERROR_UNREF(grpc_pollset_work(ps, nullptr, 0));
   }
   grpc_closure shutdown_ps_closure;
@@ -140,7 +140,7 @@ static void BM_PollAddFd(benchmark::State& state) {
   GPR_ASSERT(
       GRPC_LOG_IF_ERROR("wakeup_fd_init", grpc_wakeup_fd_init(&wakeup_fd)));
   grpc_fd* fd = grpc_fd_create(wakeup_fd.read_fd, "xxx", false);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     grpc_pollset_add_fd(ps, fd);
     grpc_core::ExecCtx::Get()->Flush();
   }
@@ -188,7 +188,7 @@ static void BM_SingleThreadPollOneFd_SpeedOfLight(benchmark::State& state) {
   int fd = eventfd(0, EFD_NONBLOCK);
   ev[0].events = EPOLLIN;
   epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &ev[0]);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     int err;
     do {
       err = eventfd_write(fd, 1);

--- a/test/cpp/microbenchmarks/bm_timer.cc
+++ b/test/cpp/microbenchmarks/bm_timer.cc
@@ -43,7 +43,7 @@ static void BM_InitCancelTimer(benchmark::State& state) {
   grpc_core::ExecCtx exec_ctx;
   std::vector<TimerClosure> timer_closures(kTimerCount);
   int i = 0;
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     TimerClosure* timer_closure = &timer_closures[i++ % kTimerCount];
     GRPC_CLOSURE_INIT(&timer_closure->closure,
                       [](void* /*args*/, grpc_error* /*err*/) {}, nullptr,
@@ -71,7 +71,7 @@ static void BM_TimerBatch(benchmark::State& state) {
   TrackCounters track_counters;
   grpc_core::ExecCtx exec_ctx;
   std::vector<TimerClosure> timer_closures(kTimerCount);
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     for (grpc_millis deadline = start; deadline != end; deadline += increment) {
       TimerClosure* timer_closure = &timer_closures[deadline % kTimerCount];
       GRPC_CLOSURE_INIT(&timer_closure->closure,

--- a/test/cpp/microbenchmarks/fullstack_streaming_ping_pong.h
+++ b/test/cpp/microbenchmarks/fullstack_streaming_ping_pong.h
@@ -65,7 +65,7 @@ static void BM_StreamingPingPong(benchmark::State& state) {
     std::unique_ptr<EchoTestService::Stub> stub(
         EchoTestService::NewStub(fixture->channel()));
 
-    while (state.KeepRunning()) {
+    for (auto _ : state) {
       ServerContext svr_ctx;
       ServerContextMutator svr_ctx_mut(&svr_ctx);
       ServerAsyncReaderWriter<EchoResponse, EchoRequest> response_rw(&svr_ctx);
@@ -180,7 +180,7 @@ static void BM_StreamingPingPongMsgs(benchmark::State& state) {
       need_tags &= ~(1 << i);
     }
 
-    while (state.KeepRunning()) {
+    for (auto _ : state) {
       GPR_TIMER_SCOPE("BenchmarkCycle", 0);
       request_rw->Write(send_request, tag(0));   // Start client send
       response_rw.Read(&recv_request, tag(1));   // Start server recv
@@ -262,7 +262,7 @@ static void BM_StreamingPingPongWithCoalescingApi(benchmark::State& state) {
     std::unique_ptr<EchoTestService::Stub> stub(
         EchoTestService::NewStub(fixture->channel()));
 
-    while (state.KeepRunning()) {
+    for (auto _ : state) {
       ServerContext svr_ctx;
       ServerContextMutator svr_ctx_mut(&svr_ctx);
       ServerAsyncReaderWriter<EchoResponse, EchoRequest> response_rw(&svr_ctx);

--- a/test/cpp/microbenchmarks/fullstack_streaming_pump.h
+++ b/test/cpp/microbenchmarks/fullstack_streaming_pump.h
@@ -67,7 +67,7 @@ static void BM_PumpStreamClientToServer(benchmark::State& state) {
       need_tags &= ~(1 << i);
     }
     response_rw.Read(&recv_request, tag(0));
-    while (state.KeepRunning()) {
+    for (auto _ : state) {
       GPR_TIMER_SCOPE("BenchmarkCycle", 0);
       request_rw->Write(send_request, tag(1));
       while (true) {
@@ -136,7 +136,7 @@ static void BM_PumpStreamServerToClient(benchmark::State& state) {
       need_tags &= ~(1 << i);
     }
     request_rw->Read(&recv_response, tag(0));
-    while (state.KeepRunning()) {
+    for (auto _ : state) {
       GPR_TIMER_SCOPE("BenchmarkCycle", 0);
       response_rw.Write(send_response, tag(1));
       while (true) {

--- a/test/cpp/microbenchmarks/fullstack_unary_ping_pong.h
+++ b/test/cpp/microbenchmarks/fullstack_unary_ping_pong.h
@@ -71,7 +71,7 @@ static void BM_UnaryPingPong(benchmark::State& state) {
                       fixture->cq(), tag(1));
   std::unique_ptr<EchoTestService::Stub> stub(
       EchoTestService::NewStub(fixture->channel()));
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
     GPR_TIMER_SCOPE("BenchmarkCycle", 0);
     recv_response.Clear();
     ClientContext cli_ctx;

--- a/test/cpp/microbenchmarks/noop-benchmark.cc
+++ b/test/cpp/microbenchmarks/noop-benchmark.cc
@@ -22,7 +22,7 @@
 #include <benchmark/benchmark.h>
 
 static void BM_NoOp(benchmark::State& state) {
-  while (state.KeepRunning()) {
+  for (auto _ : state) {
   }
 }
 BENCHMARK(BM_NoOp);


### PR DESCRIPTION
Fixes #16326 . Supposedly reduces benchmarking overhead. In practice, nearly all benchmarks report unchanged results, about 5 get some reduction in overhead, and 1 has an increase.

