### PR TITLE
Add Bazel targets for Python unit tests

### DIFF
--- a/src/python/grpcio_tests/tests/testing/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/testing/BUILD.bazel
@@ -1,0 +1,30 @@
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "testing",
+    srcs = ["__init__.py",],
+    deps = [
+        # ":_application_common",
+        ":_server_application",
+    ],
+)
+
+# TODO(ghostwriternr): To be added later.
+# py_library(
+#     name = "_application_common",
+#     srcs = ["_application_common.py",],
+#     deps = [
+#         "//src/python/grpcio_tests/tests/testing/proto:requests",
+#         "//src/python/grpcio_tests/tests/testing/proto:services",
+#     ],
+#     imports = ["../../",],
+# )
+
+py_library(
+    name = "_server_application",
+    srcs = ["_server_application.py",],
+    imports = ["../../",],
+)
+
+
+

--- a/src/python/grpcio_tests/tests/unit/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/BUILD.bazel
@@ -1,0 +1,83 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+GRPCIO_TESTS_UNIT = [
+    "_api_test.py",
+    "_auth_context_test.py",
+    "_auth_test.py",
+    "_channel_args_test.py",
+    "_channel_close_test.py",
+    "_channel_connectivity_test.py",
+    "_channel_ready_future_test.py",
+    "_compression_test.py",
+    "_credentials_test.py",
+    "_empty_message_test.py",
+    "_exit_test.py",
+    "_interceptor_test.py",
+    "_invalid_metadata_test.py",
+    "_invocation_defects_test.py",
+    "_metadata_code_details_test.py",
+    "_metadata_test.py",
+    # TODO: Issue 16336
+    # "_reconnect_test.py",
+    "_resource_exhausted_test.py",
+    "_rpc_test.py",
+    # TODO(ghostwriternr): To be added later.
+    # "_server_ssl_cert_config_test.py",
+    "_server_test.py",
+    "_session_cache_test.py",
+]
+
+py_library(
+    name = "resources",
+    srcs = ["resources.py"],
+    data=[
+        "//src/python/grpcio_tests/tests/unit/credentials",
+    ],
+)
+
+py_library(
+    name = "test_common",
+    srcs = ["test_common.py"],
+)
+
+py_library(
+    name = "_exit_scenarios",
+    srcs = ["_exit_scenarios.py"],
+)
+
+py_library(
+    name = "_thread_pool",
+    srcs = ["_thread_pool.py"],
+)
+
+py_library(
+    name = "_from_grpc_import_star",
+    srcs = ["_from_grpc_import_star.py"],
+)
+
+[
+    py_test(
+        name=test_file_name[:-3],
+        size="small",
+        srcs=[test_file_name],
+        main=test_file_name,
+        deps=[
+            "//src/python/grpcio/grpc:grpcio",
+            ":resources",
+            ":test_common",
+            ":_exit_scenarios",
+            ":_thread_pool",
+            ":_from_grpc_import_star",
+            "//src/python/grpcio_tests/tests/unit/framework/common",
+            "//src/python/grpcio_tests/tests/testing",
+            requirement('six'),
+        ],
+        imports=["../../",],
+        data=[
+            "//src/python/grpcio_tests/tests/unit/credentials",
+        ],
+    ) for test_file_name in GRPCIO_TESTS_UNIT
+]
+

--- a/src/python/grpcio_tests/tests/unit/_cython/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/_cython/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+GRPCIO_TESTS_UNIT_CYTHON = [
+    "_cancel_many_calls_test.py",
+    "_channel_test.py",
+    "_no_messages_server_completion_queue_per_call_test.py",
+    "_no_messages_single_server_completion_queue_test.py",
+    "_read_some_but_not_all_responses_test.py",
+    "_server_test.py",
+    "cygrpc_test.py",
+]
+
+py_library(
+    name = "common",
+    srcs = ["_common.py"],
+)
+
+py_library(
+    name = "test_utilities",
+    srcs = ["test_utilities.py"],
+)
+
+[
+    py_test(
+        name=test_file_name[:-3],
+        size="small",
+        srcs=[test_file_name],
+        main=test_file_name,
+        deps=[
+            "//src/python/grpcio/grpc:grpcio",
+            ":common",
+            ":test_utilities",
+            "//src/python/grpcio_tests/tests/unit/framework/common",
+            "//src/python/grpcio_tests/tests/unit:test_common",
+            "//src/python/grpcio_tests/tests/unit:resources",
+        ],
+        imports=["../../../",],
+        data=[
+            "//src/python/grpcio_tests/tests/unit/credentials",
+        ],
+    ) for test_file_name in GRPCIO_TESTS_UNIT_CYTHON
+]
+
+

--- a/src/python/grpcio_tests/tests/unit/beta/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/beta/BUILD.bazel
@@ -1,0 +1,75 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "test_utilities",
+    srcs = ["test_utilities.py"],
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+    ],
+)
+
+py_test(
+    name = "_beta_features_test",
+    srcs = ["_beta_features_test.py"],
+    main = "_beta_features_test.py",
+    size = "small",
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/python/grpcio_tests/tests/unit:resources",
+        "//src/python/grpcio_tests/tests/unit/framework/common",
+        ":test_utilities",
+    ],
+    imports=["../../../",],
+)
+
+py_test(
+    name = "_connectivity_channel_test",
+    srcs = ["_connectivity_channel_test.py"],
+    main = "_connectivity_channel_test.py",
+    size = "small",
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+    ],
+)
+
+# TODO(ghostwriternr): To be added later.
+#py_test(
+#    name = "_implementations_test",
+#    srcs = ["_implementations_test.py"],
+#    main = "_implementations_test.py",
+#    size = "small",
+#    deps = [
+#        "//src/python/grpcio/grpc:grpcio",
+#        "//src/python/grpcio_tests/tests/unit:resources",
+#        requirement('oauth2client'),
+#    ],
+#    imports=["../../../",],
+#)
+
+py_test(
+    name = "_not_found_test",
+    srcs = ["_not_found_test.py"],
+    main = "_not_found_test.py",
+    size = "small",
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/python/grpcio_tests/tests/unit/framework/common",
+    ],
+    imports=["../../../",],
+)
+
+py_test(
+    name = "_utilities_test",
+    srcs = ["_utilities_test.py"],
+    main = "_utilities_test.py",
+    size = "small",
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/python/grpcio_tests/tests/unit/framework/common",
+    ],
+    imports=["../../../",],
+)
+
+

--- a/src/python/grpcio_tests/tests/unit/credentials/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/credentials/BUILD.bazel
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name="credentials",
+    srcs=glob([
+        "**",
+    ]),
+)
+
+

--- a/src/python/grpcio_tests/tests/unit/framework/common/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/framework/common/BUILD.bazel
@@ -1,0 +1,11 @@
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "common",
+    srcs = [
+        "test_constants.py",
+        "test_control.py",
+        "test_coverage.py",
+    ],
+)
+


### PR DESCRIPTION
There are exactly 50 tests under grpcio_tests/tests/testing and grpcio_tests/tests/unit for gRPC Python. Add Bazel targets for 44 of them. unit._reconnect_test has been left out for now due to an unexpected RuntimeError (#16336) and unit._server_ssl_cert_config_test because of changes needed to the import path within src/python/grpcio_tests/tests/testing/proto/services.proto (will possibly be included as a fix to #15370).