### PR TITLE
Correctly set performance job metadata on kokoro

### DIFF
--- a/tools/run_tests/performance/bq_upload_result.py
+++ b/tools/run_tests/performance/bq_upload_result.py
@@ -128,14 +128,16 @@ def _flatten_result_inplace(scenario_result):
 
 def _populate_metadata_inplace(scenario_result):
     """Populates metadata based on environment variables set by Jenkins."""
-    # NOTE: Grabbing the Jenkins environment variables will only work if the
-    # driver is running locally on the same machine where Jenkins has started
+    # NOTE: Grabbing the Kokoro environment variables will only work if the
+    # driver is running locally on the same machine where Kokoro has started
     # the job. For our setup, this is currently the case, so just assume that.
-    build_number = os.getenv('BUILD_NUMBER')
-    build_url = os.getenv('BUILD_URL')
-    job_name = os.getenv('JOB_NAME')
-    git_commit = os.getenv('GIT_COMMIT')
+    build_number = os.getenv('KOKORO_BUILD_NUMBER')
+    build_url = 'https://source.cloud.google.com/results/invocations/%s' % os.getenv(
+        'KOKORO_BUILD_ID')
+    job_name = os.getenv('KOKORO_JOB_NAME')
+    git_commit = os.getenv('KOKORO_GIT_COMMIT')
     # actual commit is the actual head of PR that is getting tested
+    # TODO(jtattermusch): unclear how to obtain on Kokoro
     git_actual_commit = os.getenv('ghprbActualCommit')
 
     utc_timestamp = str(calendar.timegm(time.gmtime()))

--- a/tools/run_tests/python_utils/upload_test_results.py
+++ b/tools/run_tests/python_utils/upload_test_results.py
@@ -68,15 +68,13 @@ _INTEROP_RESULTS_SCHEMA = [
 
 
 def _get_build_metadata(test_results):
-    """Add Jenkins/Kokoro build metadata to test_results based on environment
-  variables set by Jenkins/Kokoro.
+    """Add Kokoro build metadata to test_results based on environment
+  variables set by Kokoro.
   """
-    build_id = os.getenv('BUILD_ID') or os.getenv('KOKORO_BUILD_NUMBER')
-    build_url = os.getenv('BUILD_URL')
-    if os.getenv('KOKORO_BUILD_ID'):
-        build_url = 'https://source.cloud.google.com/results/invocations/%s' % os.getenv(
-            'KOKORO_BUILD_ID')
-    job_name = os.getenv('JOB_BASE_NAME') or os.getenv('KOKORO_JOB_NAME')
+    build_id = os.getenv('KOKORO_BUILD_NUMBER')
+    build_url = 'https://source.cloud.google.com/results/invocations/%s' % os.getenv(
+        'KOKORO_BUILD_ID')
+    job_name = os.getenv('KOKORO_JOB_NAME')
 
     if build_id:
         test_results['build_id'] = build_id


### PR DESCRIPTION
In the grpc-testing:performance_test.performance_experiment biquery dataset, 
the metadata fields (e.g. metadata.jobName) are currently not being set because the upload script hasn't been updated since we migrated off of Jenkins.

Updating the upload scripts to use env variables set by Kokoro.