### PR TITLE
Improve Pypy compatibility

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -48,7 +48,7 @@ cdef int _get_metadata(
   cdef size_t metadata_count
   cdef grpc_metadata *c_metadata
   def callback(metadata, grpc_status_code status, bytes error_details):
-    if status is StatusCode.ok:
+    if status == StatusCode.ok:
       _store_c_metadata(metadata, &c_metadata, &metadata_count)
       cb(user_data, c_metadata, metadata_count, status, NULL)
       _release_c_metadata(c_metadata, metadata_count)


### PR DESCRIPTION
Hi,

I know that gRPC doesn't officially support Pypy yet, and saw #4221 .
I tried to run some GCP libraries with Pypy 6.0 anyway, and many things seemed to work out of the box :).

I stumbled upon a bug with the PubSub client, though, with this error:
```
AuthMetadataPluginCallback "<google.auth.transport.grpc.AuthMetadataPlugin object at 0x00007f7259ab7088>" raised exception!
Traceback (most recent call last):
  File "/home/me/.virtualenvs/pypy/site-packages/grpc/_plugin_wrapping.py", line 79, in __call__
    callback_state, callback))
  File "/home/me/pypy-grpc/google-auth-library-python/google/auth/transport/grpc.py", line 77, in __call__
    callback(self._get_authorization_headers(context), None)
  File "/home/me/.virtualenvs/pypy/site-packages/grpc/_plugin_wrapping.py", line 61, in __call__
    self._callback(metadata, cygrpc.StatusCode.ok, None)
  File "src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi", line 56, in grpc._cython.cygrpc._get_metadata.callback
TypeError: expected bytes, NoneType found
```

Upon inspection, it seems that this bug occurs because of a condition that always return `False` when comparing status codes (defined as integers) with the `is` keyword.
This is weird because I'm pretty sure Pypy does integer interning, but because there is a layer of Cython in the mix, I guess we can't count on every safety net Pypy tries to provide.

Anyway, `==` seems more adapted regardless of the interpreter, and it works fine for both CPython and Pypy.

I didn't encounter other major bugs with Pypy, but I didn't test it extensively yet.

Hope this PR will help making these two awesome projects work together :).

Regards.