### PR TITLE
Add new C# serialization API

### DIFF
--- a/src/csharp/Grpc.Core.Tests/ContextualMarshallerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ContextualMarshallerTest.cs
@@ -1,0 +1,119 @@
+#region Copyright notice and license
+
+// Copyright 2018 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Grpc.Core;
+using Grpc.Core.Internal;
+using Grpc.Core.Utils;
+using NUnit.Framework;
+
+namespace Grpc.Core.Tests
+{
+    public class ContextualMarshallerTest
+    {
+        const string Host = "127.0.0.1";
+
+        MockServiceHelper helper;
+        Server server;
+        Channel channel;
+
+        [SetUp]
+        public void Init()
+        {
+            var contextualMarshaller = new Marshaller<string>(
+                (str, serializationContext) =>
+                {
+                    if (str == "UNSERIALIZABLE_VALUE")
+                    {
+                        // Google.Protobuf throws exception inherited from IOException
+                        throw new IOException("Error serializing the message.");
+                    }
+                    if (str == "SERIALIZE_TO_NULL")
+                    {
+                        return;
+                    }
+                    var bytes = System.Text.Encoding.UTF8.GetBytes(str);
+                    serializationContext.Complete(bytes);
+                },
+                (deserializationContext) =>
+                {
+                    var buffer = deserializationContext.PayloadAsNewBuffer();
+                    Assert.AreEqual(buffer.Length, deserializationContext.PayloadLength);
+                    var s = System.Text.Encoding.UTF8.GetString(buffer);
+                    if (s == "UNPARSEABLE_VALUE")
+                    {
+                        // Google.Protobuf throws exception inherited from IOException
+                        throw new IOException("Error parsing the message.");
+                    }
+                    return s;
+                });
+            helper = new MockServiceHelper(Host, contextualMarshaller);
+            server = helper.GetServer();
+            server.Start();
+            channel = helper.GetChannel();
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            channel.ShutdownAsync().Wait();
+            server.ShutdownAsync().Wait();
+        }
+
+        [Test]
+        public void UnaryCall()
+        {
+            helper.UnaryHandler = new UnaryServerMethod<string, string>((request, context) =>
+            {
+                return Task.FromResult(request);
+            });
+            Assert.AreEqual("ABC", Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "ABC"));
+        }
+
+        [Test]
+        public void ResponseParsingError_UnaryResponse()
+        {
+            helper.UnaryHandler = new UnaryServerMethod<string, string>((request, context) =>
+            {
+                return Task.FromResult("UNPARSEABLE_VALUE");
+            });
+
+            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "REQUEST"));
+            Assert.AreEqual(StatusCode.Internal, ex.Status.StatusCode);
+        }
+
+        [Test]
+        public void RequestSerializationError_BlockingUnary()
+        {
+            Assert.Throws<IOException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "UNSERIALIZABLE_VALUE"));
+        }
+
+        [Test]
+        public void SerializationResultIsNull_BlockingUnary()
+        {
+            Assert.Throws<NullReferenceException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "SERIALIZE_TO_NULL"));
+        }
+    }
+}

--- a/src/csharp/Grpc.Core.Tests/MarshallerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/MarshallerTest.cs
@@ -1,0 +1,105 @@
+#region Copyright notice and license
+
+// Copyright 2018 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Grpc.Core;
+using Grpc.Core.Internal;
+using Grpc.Core.Utils;
+using NUnit.Framework;
+
+namespace Grpc.Core.Tests
+{
+    public class MarshallerTest
+    {
+        [Test]
+        public void ContextualSerializerEmulation()
+        {
+            Func<string, byte[]> simpleSerializer = System.Text.Encoding.UTF8.GetBytes;
+            Func<byte[], string> simpleDeserializer = System.Text.Encoding.UTF8.GetString;
+            var marshaller = new Marshaller<string>(simpleSerializer,
+                                                    simpleDeserializer);
+
+            Assert.AreSame(simpleSerializer, marshaller.Serializer);
+            Assert.AreSame(simpleDeserializer, marshaller.Deserializer);
+
+            // test that emulated contextual serializer and deserializer work
+            string origMsg = "abc";
+            var serializationContext = new FakeSerializationContext();
+            marshaller.ContextualSerializer(origMsg, serializationContext);
+
+            var deserializationContext = new FakeDeserializationContext(serializationContext.Payload);
+            Assert.AreEqual(origMsg, marshaller.ContextualDeserializer(deserializationContext));
+        }
+
+        [Test]
+        public void SimpleSerializerEmulation()
+        {
+            Action<string, SerializationContext> contextualSerializer = (str, context) =>
+            {
+                var bytes = System.Text.Encoding.UTF8.GetBytes(str);
+                context.Complete(bytes);
+            };
+            Func<DeserializationContext, string> contextualDeserializer = (context) =>
+            {
+                return System.Text.Encoding.UTF8.GetString(context.PayloadAsNewBuffer());
+            };
+            var marshaller = new Marshaller<string>(contextualSerializer, contextualDeserializer);
+
+            Assert.AreSame(contextualSerializer, marshaller.ContextualSerializer);
+            Assert.AreSame(contextualDeserializer, marshaller.ContextualDeserializer);
+
+            // test that emulated serializer and deserializer work
+            var origMsg = "abc";
+            var serialized = marshaller.Serializer(origMsg);
+            Assert.AreEqual(origMsg, marshaller.Deserializer(serialized));
+        }
+
+        class FakeSerializationContext : SerializationContext
+        {
+            public byte[] Payload;
+            public override void Complete(byte[] payload)
+            {
+                this.Payload = payload;
+            }
+        }
+
+        class FakeDeserializationContext : DeserializationContext
+        {
+            public byte[] payload;
+
+            public FakeDeserializationContext(byte[] payload)
+            {
+                this.payload = payload;
+            }
+
+            public override int PayloadLength => payload.Length;
+
+            public override byte[] PayloadAsNewBuffer()
+            {
+                return payload;
+            }
+        }
+    }
+}

--- a/src/csharp/Grpc.Core/DeserializationContext.cs
+++ b/src/csharp/Grpc.Core/DeserializationContext.cs
@@ -1,0 +1,49 @@
+#region Copyright notice and license
+
+// Copyright 2018 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+namespace Grpc.Core
+{
+    /// <summary>
+    /// Provides access to the payload being deserialized when deserializing messages.
+    /// </summary>
+    public abstract class DeserializationContext
+    {
+        /// <summary>
+        /// Returns <c>true</c> if there is a payload to deserialize (= payload is not null), <c>false</c> otherwise.
+        /// </summary>
+        public virtual bool HasPayload => PayloadLength.HasValue;
+
+        /// <summary>
+        /// Get the total length of the payload in bytes or <c>null</c> if the payload is null.
+        /// </summary>
+        public abstract int? PayloadLength { get; }
+
+        /// <summary>
+        /// Gets the entire payload as a newly allocated byte array.
+        /// Once the byte array is returned, the byte array becomes owned by the caller and won't be ever accessed or reused by gRPC again.
+        /// NOTE: Obtaining the buffer as a newly allocated byte array is the simplest way of accessing the payload,
+        /// but it can have important consequences in high-performance scenarios.
+        /// In particular, using this method usually requires copying of the entire buffer one extra time.
+        /// Also, allocating a new buffer each time can put excessive pressure on GC, especially if
+        /// the payload is more than 86700 bytes large (which means the newly allocated buffer will be placed in LOH,
+        /// and LOH object can only be garbage collected via a full ("stop the world") GC run).
+        /// </summary>
+        /// <returns>byte array containing the entire payload or null if there is no payload.</returns>
+        public abstract byte[] PayloadAsNewBuffer();
+    }
+}

--- a/src/csharp/Grpc.Core/DeserializationContext.cs
+++ b/src/csharp/Grpc.Core/DeserializationContext.cs
@@ -37,6 +37,8 @@ namespace Grpc.Core
         /// Also, allocating a new buffer each time can put excessive pressure on GC, especially if
         /// the payload is more than 86700 bytes large (which means the newly allocated buffer will be placed in LOH,
         /// and LOH object can only be garbage collected via a full ("stop the world") GC run).
+        /// NOTE: Deserializers are expected not to call this method more than once per received message
+        /// (as there is no practical reason for doing so) and <c>DeserializationContext</c> implementations are free to assume so.
         /// </summary>
         /// <returns>byte array containing the entire payload.</returns>
         public abstract byte[] PayloadAsNewBuffer();

--- a/src/csharp/Grpc.Core/DeserializationContext.cs
+++ b/src/csharp/Grpc.Core/DeserializationContext.cs
@@ -24,14 +24,9 @@ namespace Grpc.Core
     public abstract class DeserializationContext
     {
         /// <summary>
-        /// Returns <c>true</c> if there is a payload to deserialize (= payload is not null), <c>false</c> otherwise.
+        /// Get the total length of the payload in bytes.
         /// </summary>
-        public virtual bool HasPayload => PayloadLength.HasValue;
-
-        /// <summary>
-        /// Get the total length of the payload in bytes or <c>null</c> if the payload is null.
-        /// </summary>
-        public abstract int? PayloadLength { get; }
+        public abstract int PayloadLength { get; }
 
         /// <summary>
         /// Gets the entire payload as a newly allocated byte array.
@@ -43,7 +38,7 @@ namespace Grpc.Core
         /// the payload is more than 86700 bytes large (which means the newly allocated buffer will be placed in LOH,
         /// and LOH object can only be garbage collected via a full ("stop the world") GC run).
         /// </summary>
-        /// <returns>byte array containing the entire payload or null if there is no payload.</returns>
+        /// <returns>byte array containing the entire payload.</returns>
         public abstract byte[] PayloadAsNewBuffer();
     }
 }

--- a/src/csharp/Grpc.Core/Marshaller.cs
+++ b/src/csharp/Grpc.Core/Marshaller.cs
@@ -29,36 +29,122 @@ namespace Grpc.Core
         readonly Func<T, byte[]> serializer;
         readonly Func<byte[], T> deserializer;
 
+        readonly Action<T, SerializationContext> contextualSerializer;
+        readonly Func<DeserializationContext, T> contextualDeserializer;
+
         /// <summary>
-        /// Initializes a new marshaller.
+        /// Initializes a new marshaller from simple serialize/deserialize functions.
         /// </summary>
         /// <param name="serializer">Function that will be used to serialize messages.</param>
         /// <param name="deserializer">Function that will be used to deserialize messages.</param>
         public Marshaller(Func<T, byte[]> serializer, Func<byte[], T> deserializer)
         {
-            this.serializer = GrpcPreconditions.CheckNotNull(serializer, "serializer");
-            this.deserializer = GrpcPreconditions.CheckNotNull(deserializer, "deserializer");
+            this.serializer = GrpcPreconditions.CheckNotNull(serializer, nameof(serializer));
+            this.deserializer = GrpcPreconditions.CheckNotNull(deserializer, nameof(deserializer));
+            this.contextualSerializer = EmulateContextualSerializer;
+            this.contextualDeserializer = EmulateContextualDeserializer;
+        }
+
+        /// <summary>
+        /// Initializes a new marshaller from serialize/deserialize fuctions that can access serialization and deserialization
+        /// context. Compared to the simple serializer/deserializer functions, using the contextual version provides more
+        /// flexibility and can lead to increased efficiency (and better performance).
+        /// Note: This constructor is part of an experimental API that can change or be removed without any prior notice.
+        /// </summary>
+        /// <param name="serializer">Function that will be used to serialize messages.</param>
+        /// <param name="deserializer">Function that will be used to deserialize messages.</param>
+        public Marshaller(Action<T, SerializationContext> serializer, Func<DeserializationContext, T> deserializer)
+        {
+            this.contextualSerializer = GrpcPreconditions.CheckNotNull(serializer, nameof(serializer));
+            this.contextualDeserializer = GrpcPreconditions.CheckNotNull(deserializer, nameof(deserializer));
+            this.serializer = EmulateSimpleSerializer;
+            this.deserializer = EmulateSimpleDeserializer;
         }
 
         /// <summary>
         /// Gets the serializer function.
         /// </summary>
-        public Func<T, byte[]> Serializer
-        {
-            get
-            {
-                return this.serializer;
-            }
-        }
+        public Func<T, byte[]> Serializer => this.serializer;
 
         /// <summary>
         /// Gets the deserializer function.
         /// </summary>
-        public Func<byte[], T> Deserializer
+        public Func<byte[], T> Deserializer => this.deserializer;
+
+        /// <summary>
+        /// Gets the serializer function.
+        /// Note: experimental API that can change or be removed without any prior notice.
+        /// </summary>
+        public Action<T, SerializationContext> ContextualSerializer => this.contextualSerializer;
+
+        /// <summary>
+        /// Gets the serializer function.
+        /// Note: experimental API that can change or be removed without any prior notice.
+        /// </summary>
+        public Func<DeserializationContext, T> ContextualDeserializer => this.contextualDeserializer;
+
+        // for backward compatibility, emulate the simple serializer using the contextual one
+        private byte[] EmulateSimpleSerializer(T msg)
         {
-            get
+            // TODO(jtattermusch): avoid the allocation by passing a thread-local instance
+            var context = new EmulatedSerializationContext();
+            this.contextualSerializer(msg, context);
+            return context.GetPayload();
+        }
+
+        // for backward compatibility, emulate the simple deserializer using the contextual one
+        private T EmulateSimpleDeserializer(byte[] payload)
+        {
+            // TODO(jtattermusch): avoid the allocation by passing a thread-local instance
+            var context = new EmulatedDeserializationContext(payload);
+            return this.contextualDeserializer(context);
+        }
+
+        // for backward compatibility, emulate the contextual serializer using the simple one
+        private void EmulateContextualSerializer(T message, SerializationContext context)
+        {
+            var payload = this.serializer(message);
+            context.Complete(payload);
+        }
+
+        // for backward compatibility, emulate the contextual deserializer using the simple one
+        private T EmulateContextualDeserializer(DeserializationContext context)
+        {
+            return this.deserializer(context.PayloadAsNewBuffer());
+        }
+
+        internal class EmulatedSerializationContext : SerializationContext
+        {
+            bool isComplete;
+            byte[] payload;
+
+            public override void Complete(byte[] payload)
             {
-                return this.deserializer;
+                GrpcPreconditions.CheckState(!isComplete);
+                this.isComplete = true;
+                this.payload = payload;
+            }
+
+            internal byte[] GetPayload()
+            {
+                return this.payload;
+            }
+        }
+
+        internal class EmulatedDeserializationContext : DeserializationContext
+        {
+            readonly byte[] payload;
+
+            public EmulatedDeserializationContext(byte[] payload)
+            {
+                this.payload = payload;
+            }
+
+            public override int? PayloadLength => payload?.Length;
+
+            public override byte[] PayloadAsNewBuffer()
+            {
+                return payload;
             }
         }
     }

--- a/src/csharp/Grpc.Core/Marshaller.cs
+++ b/src/csharp/Grpc.Core/Marshaller.cs
@@ -163,6 +163,15 @@ namespace Grpc.Core
         }
 
         /// <summary>
+        /// Creates a marshaller from specified contextual serializer and deserializer.
+        /// Note: This method is part of an experimental API that can change or be removed without any prior notice.
+        /// </summary>
+        public static Marshaller<T> Create<T>(Action<T, SerializationContext> serializer, Func<DeserializationContext, T> deserializer)
+        {
+            return new Marshaller<T>(serializer, deserializer);
+        }
+
+        /// <summary>
         /// Returns a marshaller for <c>string</c> type. This is useful for testing.
         /// </summary>
         public static Marshaller<string> StringMarshaller

--- a/src/csharp/Grpc.Core/Marshaller.cs
+++ b/src/csharp/Grpc.Core/Marshaller.cs
@@ -137,10 +137,10 @@ namespace Grpc.Core
 
             public EmulatedDeserializationContext(byte[] payload)
             {
-                this.payload = payload;
+                this.payload = GrpcPreconditions.CheckNotNull(payload);
             }
 
-            public override int? PayloadLength => payload?.Length;
+            public override int PayloadLength => payload.Length;
 
             public override byte[] PayloadAsNewBuffer()
             {

--- a/src/csharp/Grpc.Core/SerializationContext.cs
+++ b/src/csharp/Grpc.Core/SerializationContext.cs
@@ -1,0 +1,34 @@
+#region Copyright notice and license
+
+// Copyright 2018 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+namespace Grpc.Core
+{
+    /// <summary>
+    /// Provides storage for payload when serializing a message.
+    /// </summary>
+    public abstract class SerializationContext
+    {
+        /// <summary>
+        /// Use the byte array as serialized form of current message and mark serialization process as complete.
+        /// Complete() can only be called once. By calling this method the caller gives up the ownership of the
+        /// payload which must not be accessed afterwards.
+        /// </summary>
+        /// <param name="payload">the serialized form of current message</param>
+        public abstract void Complete(byte[] payload);
+    }
+}

--- a/src/csharp/tests.json
+++ b/src/csharp/tests.json
@@ -23,6 +23,7 @@
     "Grpc.Core.Tests.ClientServerTest",
     "Grpc.Core.Tests.CompressionTest",
     "Grpc.Core.Tests.ContextPropagationTest",
+    "Grpc.Core.Tests.ContextualMarshallerTest",
     "Grpc.Core.Tests.GrpcEnvironmentTest",
     "Grpc.Core.Tests.HalfcloseTest",
     "Grpc.Core.Tests.MarshallingErrorsTest",

--- a/src/csharp/tests.json
+++ b/src/csharp/tests.json
@@ -26,6 +26,7 @@
     "Grpc.Core.Tests.ContextualMarshallerTest",
     "Grpc.Core.Tests.GrpcEnvironmentTest",
     "Grpc.Core.Tests.HalfcloseTest",
+    "Grpc.Core.Tests.MarshallerTest",
     "Grpc.Core.Tests.MarshallingErrorsTest",
     "Grpc.Core.Tests.MetadataTest",
     "Grpc.Core.Tests.PerformanceTest",


### PR DESCRIPTION
This PR is based on recent experiments with zero-copy parsing of received messages. It turns out a few degrees of optimization can be utilized when serializing/deserializing messages, but a new API is needed, as the existing API  just uses a function to converts msg of type T to a newly allocated byte array (and a newly created byte array to a msg of type T. The existing API basically necessitates copying of the buffer around and also prohibits us from pooling the buffers in any way.

This PR adds a new serialization API that is more general and extensible, basically it consists of two functions:
- `Action<T, SerializationContext> ContextualSerializer`  - when serializing, one gets access to an instance of a message  and a `SerializationContext` that provides methods by which we store the serialized data in the context (`Complete(payload)` in the simplest and least efficent case) before returning.
- `Func<DeserializationContext, T> ContextualDeserializer` - when deserializing, one gets access to a `DeserializationContext` which provides methods to access the payload at varying levels of efficiency

Right now the SerializationContext and DeserializationContext only provide the least efficient (but simplest to use) methods that basically mimic current idea of serialization (convert msg to a new byte array and back), but the idea is that more efficient methods of accessing the payload will be added over time (I have some prototypes what the new methods could look like).

The changes to the marshaller (and the way backward compatibility is ensured) are inspired by  https://github.com/grpc/grpc/pull/13440/files#diff-2058a085f39531e466d41c163feccbe5 (which got never merged because there were some concerns around it), but the advantage of the new approach is that using abstract classes SerializationContext and DeserializationContext makes the serialization/deserialization much more extensible (with the older PR there was a risk that the newly introduces API was pretty rigid and it was likely we would be needing yet another new API soon).

## Possible future additions to SerializationContext:
- Add `IBufferWriter`-like methods that will allow serializing data into a grpc-owned buffer that can be made available to C core without any extra copies and that can be reused (https://github.com/dotnet/corefx/blob/master/src/System.Memory/src/System/Buffers/IBufferWriter.cs)


## Possible future additions to DeserializationContext
for efficient deserialization I have some prototypes and this new deserializtion methods could look like this:
```csharp
        /// <summary>
        /// Gets the entire payload as a rented buffer.
        /// Caller is reponsible for disposing the rented buffer once the done processing it to signal that the buffer can be reclaimed by gRPC
        /// and used again for deserialization of another message.
        /// In most cases, using this method involves copying to the entire buffer (as the payload is internally
        /// delivered in multiple buffer segments and they need to be joined together to form a single monolithic buffer).
        /// On the other hand, this method is much more efficient in terms of GC pressure than <see cref="PayloadAsNewBuffer"/>
        /// as the buffer is reused rather than thrown away. This comes at the cost of the additional complexity where one needs
        /// to call <c>Dispose()</c> once done reading the data.
        /// </summary>
        /// <returns>a rented buffer the entire payload or null if payload is null.</returns>
        internal abstract IMemoryOwner<byte> PayloadAsRentedBuffer();
```

and  an advanced method that will allow reading data from C core's byte_buffer  slice by slice directly
(and that will utilize the new Span<> type to make that safely possible).
```csharp
        /// <summary>
        /// Tries to get next segment of the payload.
        /// This is the most efficient method of accessing the payload, no additional copying or allocation is made in most cases.
        /// Throws an exception if payload is null.
        /// </summary>
        /// <param name="bufferSegment">will be set to the next buffer segment if operation is successful.</param>
        /// <returns><c>true</c> the next segment was read, <c>false</c> if all segments have already been read.</returns>
        internal abstract bool TryGetNextBufferSegment(out Span<byte> bufferSegment);
```