### PR TITLE
size_t shouldn't have the value -1; switch to int

### DIFF
--- a/src/core/lib/transport/service_config.cc
+++ b/src/core/lib/transport/service_config.cc
@@ -65,8 +65,8 @@ const char* ServiceConfig::GetLoadBalancingPolicyName() const {
   return lb_policy_name;
 }
 
-size_t ServiceConfig::CountNamesInMethodConfig(grpc_json* json) {
-  size_t num_names = 0;
+int ServiceConfig::CountNamesInMethodConfig(grpc_json* json) {
+  int num_names = 0;
   for (grpc_json* field = json->child; field != nullptr; field = field->next) {
     if (field->key != nullptr && strcmp(field->key, "name") == 0) {
       if (field->type != GRPC_JSON_ARRAY) return -1;

--- a/src/core/lib/transport/service_config.h
+++ b/src/core/lib/transport/service_config.h
@@ -103,7 +103,7 @@ class ServiceConfig {
   ServiceConfig(UniquePtr<char> json_string, grpc_json* json_tree);
 
   // Returns the number of names specified in the method config \a json.
-  static size_t CountNamesInMethodConfig(grpc_json* json);
+  static int CountNamesInMethodConfig(grpc_json* json);
 
   // Returns a path string for the JSON name object specified by \a json.
   // Returns null on error.
@@ -188,9 +188,9 @@ ServiceConfig::CreateMethodConfigTable(CreateValue<T> create_value) {
       // Find number of entries.
       for (grpc_json* method = field->child; method != nullptr;
            method = method->next) {
-        size_t count = CountNamesInMethodConfig(method);
+        int count = CountNamesInMethodConfig(method);
         if (count <= 0) return nullptr;
-        num_entries += count;
+        num_entries += static_cast<size_t>(count);
       }
       // Populate method config table entries.
       entries = static_cast<typename SliceHashTable<RefCountedPtr<T>>::Entry*>(


### PR DESCRIPTION
Currently there is no difference in behavior between -1 and 0 as a return value of this function, but the indication is that -1 is supposed to be an error return value; if this error is ever enforced, it's worth continuing to check for the distinction. As a result, I changed this function to return an int
