### PR TITLE
Switch last_ready_index_ initial value to be non-negative

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
@@ -180,7 +180,7 @@ class RoundRobin : public LoadBalancingPolicy {
     size_t num_connecting_ = 0;
     size_t num_transient_failure_ = 0;
     grpc_error* last_transient_failure_error_ = GRPC_ERROR_NONE;
-    size_t last_ready_index_ = -1;  // Index into list of last pick.
+    size_t last_ready_index_ = 0;  // Index into list of last pick.
   };
 
   // Helper class to ensure that any function that modifies the child refs


### PR DESCRIPTION
size_t should not be negative as that is undefined behavior. I understand the intention, and this PR will change behavior ever so slightly by possibly having a different initial start point for the RR if the first use already sees multiple subchannels (which will change all RR behavior ever after).