### PR TITLE
cmake: disable assembly optimizations only when necessary

### DIFF
--- a/cmake/ssl.cmake
+++ b/cmake/ssl.cmake
@@ -17,7 +17,14 @@ if("${gRPC_SSL_PROVIDER}" STREQUAL "module")
     set(BORINGSSL_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/boringssl)
   endif()
   if(EXISTS "${BORINGSSL_ROOT_DIR}/CMakeLists.txt")
-    set(OPENSSL_NO_ASM ON)  # make boringssl buildable with Visual Studio
+    if (MSVC AND NOT CMAKE_GENERATOR STREQUAL "Ninja")
+      # Visual Studio build with assembly optimizations is broken,
+      # but it works with Ninja generator.
+      # This will get eventually fixed in cmake, but until then
+      # we need to disable assembly optimizations.
+      # See https://github.com/grpc/grpc/issues/16376
+      set(OPENSSL_NO_ASM ON)
+    endif()
     add_subdirectory(${BORINGSSL_ROOT_DIR} third_party/boringssl)
     if(TARGET ssl)
       set(_gRPC_SSL_LIBRARIES ssl)

--- a/doc/ssl-performance.md
+++ b/doc/ssl-performance.md
@@ -14,7 +14,9 @@ Makefile | all other cases | all | :x:
 Bazel | | Linux | :heavy_check_mark:
 Bazel | | MacOS | :heavy_check_mark:
 Bazel | | Windows | :x:
-CMake | boringssl from submodule (default) | all | :x:
+CMake | boringssl from submodule (default) | Linux or MacOS | :heavy_check_mark:
+CMake | boringssl from submodule (default), generator=Ninja | Windows | :heavy_check_mark:
+CMake | boringssl from submodule (default), generator=Visual Studio | Windows | :x:
 CMake | pre-installed OpenSSL 1.0.2+ (`gRPC_SSL_PROVIDER=package`) | all | :heavy_check_mark:
 
 ## Other Languages: Binary/Source Packages


### PR DESCRIPTION
Based on discussion here https://github.com/grpc/grpc/issues/16376#issuecomment-414726024,
this is the first step to enable assembly optimizations where possible.

This change by itself doesn't really influence much as cmake is not used to build any artifacts on linux or macos, but it gives the opportunity to build with cmake with embedded boringssl while using the assembly optimizations (we can later make use of it when building e.g. C# artifacts).
