### PR TITLE
When using c-ares, resolve ip literals and Windows localhost on our own

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,7 +361,8 @@ endif()
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
 add_dependencies(buildtests_c resolve_address_posix_test)
 endif()
-add_dependencies(buildtests_c resolve_address_test)
+add_dependencies(buildtests_c resolve_address_using_ares_resolver_test)
+add_dependencies(buildtests_c resolve_address_using_native_resolver_test)
 add_dependencies(buildtests_c resource_quota_test)
 add_dependencies(buildtests_c secure_channel_create_test)
 add_dependencies(buildtests_c secure_endpoint_test)
@@ -8553,12 +8554,12 @@ endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
-add_executable(resolve_address_test
+add_executable(resolve_address_using_ares_resolver_test
   test/core/iomgr/resolve_address_test.cc
 )
 
 
-target_include_directories(resolve_address_test
+target_include_directories(resolve_address_using_ares_resolver_test
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
   PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
@@ -8571,7 +8572,36 @@ target_include_directories(resolve_address_test
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
 
-target_link_libraries(resolve_address_test
+target_link_libraries(resolve_address_using_ares_resolver_test
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc_test_util
+  grpc
+  gpr_test_util
+  gpr
+)
+
+endif (gRPC_BUILD_TESTS)
+if (gRPC_BUILD_TESTS)
+
+add_executable(resolve_address_using_native_resolver_test
+  test/core/iomgr/resolve_address_test.cc
+)
+
+
+target_include_directories(resolve_address_using_native_resolver_test
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
+  PRIVATE ${_gRPC_PROTOBUF_INCLUDE_DIR}
+  PRIVATE ${_gRPC_ZLIB_INCLUDE_DIR}
+  PRIVATE ${_gRPC_BENCHMARK_INCLUDE_DIR}
+  PRIVATE ${_gRPC_CARES_INCLUDE_DIR}
+  PRIVATE ${_gRPC_GFLAGS_INCLUDE_DIR}
+  PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+  PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
+)
+
+target_link_libraries(resolve_address_using_native_resolver_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
   grpc

--- a/Makefile
+++ b/Makefile
@@ -1081,7 +1081,8 @@ percent_encode_fuzzer: $(BINDIR)/$(CONFIG)/percent_encode_fuzzer
 percent_encoding_test: $(BINDIR)/$(CONFIG)/percent_encoding_test
 pollset_set_test: $(BINDIR)/$(CONFIG)/pollset_set_test
 resolve_address_posix_test: $(BINDIR)/$(CONFIG)/resolve_address_posix_test
-resolve_address_test: $(BINDIR)/$(CONFIG)/resolve_address_test
+resolve_address_using_ares_resolver_test: $(BINDIR)/$(CONFIG)/resolve_address_using_ares_resolver_test
+resolve_address_using_native_resolver_test: $(BINDIR)/$(CONFIG)/resolve_address_using_native_resolver_test
 resource_quota_test: $(BINDIR)/$(CONFIG)/resource_quota_test
 secure_channel_create_test: $(BINDIR)/$(CONFIG)/secure_channel_create_test
 secure_endpoint_test: $(BINDIR)/$(CONFIG)/secure_endpoint_test
@@ -1524,7 +1525,8 @@ buildtests_c: privatelibs_c \
   $(BINDIR)/$(CONFIG)/percent_encoding_test \
   $(BINDIR)/$(CONFIG)/pollset_set_test \
   $(BINDIR)/$(CONFIG)/resolve_address_posix_test \
-  $(BINDIR)/$(CONFIG)/resolve_address_test \
+  $(BINDIR)/$(CONFIG)/resolve_address_using_ares_resolver_test \
+  $(BINDIR)/$(CONFIG)/resolve_address_using_native_resolver_test \
   $(BINDIR)/$(CONFIG)/resource_quota_test \
   $(BINDIR)/$(CONFIG)/secure_channel_create_test \
   $(BINDIR)/$(CONFIG)/secure_endpoint_test \
@@ -2118,8 +2120,10 @@ test_c: buildtests_c
 	$(Q) $(BINDIR)/$(CONFIG)/pollset_set_test || ( echo test pollset_set_test failed ; exit 1 )
 	$(E) "[RUN]     Testing resolve_address_posix_test"
 	$(Q) $(BINDIR)/$(CONFIG)/resolve_address_posix_test || ( echo test resolve_address_posix_test failed ; exit 1 )
-	$(E) "[RUN]     Testing resolve_address_test"
-	$(Q) $(BINDIR)/$(CONFIG)/resolve_address_test || ( echo test resolve_address_test failed ; exit 1 )
+	$(E) "[RUN]     Testing resolve_address_using_ares_resolver_test"
+	$(Q) $(BINDIR)/$(CONFIG)/resolve_address_using_ares_resolver_test || ( echo test resolve_address_using_ares_resolver_test failed ; exit 1 )
+	$(E) "[RUN]     Testing resolve_address_using_native_resolver_test"
+	$(Q) $(BINDIR)/$(CONFIG)/resolve_address_using_native_resolver_test || ( echo test resolve_address_using_native_resolver_test failed ; exit 1 )
 	$(E) "[RUN]     Testing resource_quota_test"
 	$(Q) $(BINDIR)/$(CONFIG)/resource_quota_test || ( echo test resource_quota_test failed ; exit 1 )
 	$(E) "[RUN]     Testing secure_channel_create_test"
@@ -14031,34 +14035,66 @@ endif
 endif
 
 
-RESOLVE_ADDRESS_TEST_SRC = \
+RESOLVE_ADDRESS_USING_ARES_RESOLVER_TEST_SRC = \
     test/core/iomgr/resolve_address_test.cc \
 
-RESOLVE_ADDRESS_TEST_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(RESOLVE_ADDRESS_TEST_SRC))))
+RESOLVE_ADDRESS_USING_ARES_RESOLVER_TEST_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(RESOLVE_ADDRESS_USING_ARES_RESOLVER_TEST_SRC))))
 ifeq ($(NO_SECURE),true)
 
 # You can't build secure targets if you don't have OpenSSL.
 
-$(BINDIR)/$(CONFIG)/resolve_address_test: openssl_dep_error
+$(BINDIR)/$(CONFIG)/resolve_address_using_ares_resolver_test: openssl_dep_error
 
 else
 
 
 
-$(BINDIR)/$(CONFIG)/resolve_address_test: $(RESOLVE_ADDRESS_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
+$(BINDIR)/$(CONFIG)/resolve_address_using_ares_resolver_test: $(RESOLVE_ADDRESS_USING_ARES_RESOLVER_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
-	$(Q) $(LD) $(LDFLAGS) $(RESOLVE_ADDRESS_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LDLIBS) $(LDLIBS_SECURE) -o $(BINDIR)/$(CONFIG)/resolve_address_test
+	$(Q) $(LD) $(LDFLAGS) $(RESOLVE_ADDRESS_USING_ARES_RESOLVER_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LDLIBS) $(LDLIBS_SECURE) -o $(BINDIR)/$(CONFIG)/resolve_address_using_ares_resolver_test
 
 endif
 
 $(OBJDIR)/$(CONFIG)/test/core/iomgr/resolve_address_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
 
-deps_resolve_address_test: $(RESOLVE_ADDRESS_TEST_OBJS:.o=.dep)
+deps_resolve_address_using_ares_resolver_test: $(RESOLVE_ADDRESS_USING_ARES_RESOLVER_TEST_OBJS:.o=.dep)
 
 ifneq ($(NO_SECURE),true)
 ifneq ($(NO_DEPS),true)
--include $(RESOLVE_ADDRESS_TEST_OBJS:.o=.dep)
+-include $(RESOLVE_ADDRESS_USING_ARES_RESOLVER_TEST_OBJS:.o=.dep)
+endif
+endif
+
+
+RESOLVE_ADDRESS_USING_NATIVE_RESOLVER_TEST_SRC = \
+    test/core/iomgr/resolve_address_test.cc \
+
+RESOLVE_ADDRESS_USING_NATIVE_RESOLVER_TEST_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(RESOLVE_ADDRESS_USING_NATIVE_RESOLVER_TEST_SRC))))
+ifeq ($(NO_SECURE),true)
+
+# You can't build secure targets if you don't have OpenSSL.
+
+$(BINDIR)/$(CONFIG)/resolve_address_using_native_resolver_test: openssl_dep_error
+
+else
+
+
+
+$(BINDIR)/$(CONFIG)/resolve_address_using_native_resolver_test: $(RESOLVE_ADDRESS_USING_NATIVE_RESOLVER_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) $(LD) $(LDFLAGS) $(RESOLVE_ADDRESS_USING_NATIVE_RESOLVER_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LDLIBS) $(LDLIBS_SECURE) -o $(BINDIR)/$(CONFIG)/resolve_address_using_native_resolver_test
+
+endif
+
+$(OBJDIR)/$(CONFIG)/test/core/iomgr/resolve_address_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
+
+deps_resolve_address_using_native_resolver_test: $(RESOLVE_ADDRESS_USING_NATIVE_RESOLVER_TEST_OBJS:.o=.dep)
+
+ifneq ($(NO_SECURE),true)
+ifneq ($(NO_DEPS),true)
+-include $(RESOLVE_ADDRESS_USING_NATIVE_RESOLVER_TEST_OBJS:.o=.dep)
 endif
 endif
 

--- a/build.yaml
+++ b/build.yaml
@@ -3363,7 +3363,7 @@ targets:
   - mac
   - linux
   - posix
-- name: resolve_address_test
+- name: resolve_address_using_ares_resolver_test
   build: test
   language: c
   src:
@@ -3373,6 +3373,20 @@ targets:
   - grpc
   - gpr_test_util
   - gpr
+  args:
+  - --resolver=ares
+- name: resolve_address_using_native_resolver_test
+  build: test
+  language: c
+  src:
+  - test/core/iomgr/resolve_address_test.cc
+  deps:
+  - grpc_test_util
+  - grpc
+  - gpr_test_util
+  - gpr
+  args:
+  - --resolver=native
 - name: resource_quota_test
   cpu_cost: 30
   build: test

--- a/src/core/ext/filters/client_channel/parse_address.cc
+++ b/src/core/ext/filters/client_channel/parse_address.cc
@@ -197,3 +197,12 @@ bool grpc_parse_uri(const grpc_uri* uri, grpc_resolved_address* resolved_addr) {
   gpr_log(GPR_ERROR, "Can't parse scheme '%s'", uri->scheme);
   return false;
 }
+
+uint16_t grpc_strhtons(const char* port) {
+  if (strcmp(port, "http") == 0) {
+    return htons(80);
+  } else if (strcmp(port, "https") == 0) {
+    return htons(443);
+  }
+  return htons(static_cast<unsigned short>(atoi(port)));
+}

--- a/src/core/ext/filters/client_channel/parse_address.h
+++ b/src/core/ext/filters/client_channel/parse_address.h
@@ -47,4 +47,7 @@ bool grpc_parse_ipv4_hostport(const char* hostport, grpc_resolved_address* addr,
 bool grpc_parse_ipv6_hostport(const char* hostport, grpc_resolved_address* addr,
                               bool log_errors);
 
+/* Converts named or numeric port to a uint16 suitable for use in a sockaddr. */
+uint16_t grpc_strhtons(const char* port);
+
 #endif /* GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_PARSE_ADDRESS_H */

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
@@ -81,9 +81,15 @@ void grpc_ares_complete_request_locked(grpc_ares_request* request);
 /* E.g., return false if ipv6 is known to not be available. */
 bool grpc_ares_query_ipv6();
 
-/* Exposed only for testing */
-void grpc_cares_wrapper_test_only_address_sorting_sort(
-    grpc_lb_addresses* lb_addrs);
+/* Maybe (depending on the current platform) checks if "name" matches
+ * "localhost" and if so fills in addrs with the correct sockaddr structures.
+ * Returns a bool indicating whether or not such an action was performed.
+ * See https://github.com/grpc/grpc/issues/15158. */
+bool grpc_ares_maybe_resolve_localhost_manually_locked(
+    const char* name, const char* default_port, grpc_lb_addresses** addrs);
+
+/* Sorts destinations in lb_addrs according to RFC 6724. */
+void grpc_cares_wrapper_address_sorting_sort(grpc_lb_addresses* lb_addrs);
 
 #endif /* GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_RESOLVER_DNS_C_ARES_GRPC_ARES_WRAPPER_H \
         */

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_posix.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_posix.cc
@@ -26,4 +26,9 @@
 
 bool grpc_ares_query_ipv6() { return grpc_ipv6_loopback_available(); }
 
+bool grpc_ares_maybe_resolve_localhost_manually_locked(
+    const char* name, const char* default_port, grpc_lb_addresses** addrs) {
+  return false;
+}
+
 #endif /* GRPC_ARES == 1 && defined(GRPC_POSIX_SOCKET_ARES_EV_DRIVER) */

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_windows.cc
@@ -21,9 +21,79 @@
 #include "src/core/lib/iomgr/port.h"
 #if GRPC_ARES == 1 && defined(GPR_WINDOWS)
 
+#include <grpc/support/string_util.h>
+
+#include "src/core/ext/filters/client_channel/lb_policy_factory.h"
+#include "src/core/ext/filters/client_channel/parse_address.h"
 #include "src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h"
+#include "src/core/lib/gpr/host_port.h"
+#include "src/core/lib/gpr/string.h"
 #include "src/core/lib/iomgr/socket_windows.h"
 
 bool grpc_ares_query_ipv6() { return grpc_ipv6_loopback_available(); }
+
+static bool inner_maybe_resolve_localhost_manually_locked(
+    const char* name, const char* default_port, grpc_lb_addresses** addrs,
+    char** host, char** port) {
+  gpr_split_host_port(name, host, port);
+  if (*host == nullptr) {
+    gpr_log(GPR_ERROR,
+            "Failed to parse %s into host:port during Windows localhost "
+            "resolution check.",
+            name);
+    return false;
+  }
+  if (*port == nullptr) {
+    if (default_port == nullptr) {
+      gpr_log(GPR_ERROR,
+              "No port or default port for %s during Windows localhost "
+              "resolution check.",
+              name);
+      return false;
+    }
+    *port = gpr_strdup(default_port);
+  }
+  if (gpr_stricmp(*host, "localhost") == 0) {
+    GPR_ASSERT(*addrs == nullptr);
+    *addrs = grpc_lb_addresses_create(2, nullptr);
+    uint16_t numeric_port = grpc_strhtons(*port);
+    // Append the ipv6 loopback address.
+    struct sockaddr_in6 ipv6_loopback_addr;
+    memset(&ipv6_loopback_addr, 0, sizeof(ipv6_loopback_addr));
+    ((char*)&ipv6_loopback_addr.sin6_addr)[15] = 1;
+    ipv6_loopback_addr.sin6_family = AF_INET6;
+    ipv6_loopback_addr.sin6_port = numeric_port;
+    grpc_lb_addresses_set_address(
+        *addrs, 0, &ipv6_loopback_addr, sizeof(ipv6_loopback_addr),
+        false /* is_balancer */, nullptr /* balancer_name */,
+        nullptr /* user_data */);
+    // Append the ipv4 loopback address.
+    struct sockaddr_in ipv4_loopback_addr;
+    memset(&ipv4_loopback_addr, 0, sizeof(ipv4_loopback_addr));
+    ((char*)&ipv4_loopback_addr.sin_addr)[0] = 0x7f;
+    ((char*)&ipv4_loopback_addr.sin_addr)[3] = 0x01;
+    ipv4_loopback_addr.sin_family = AF_INET;
+    ipv4_loopback_addr.sin_port = numeric_port;
+    grpc_lb_addresses_set_address(
+        *addrs, 1, &ipv4_loopback_addr, sizeof(ipv4_loopback_addr),
+        false /* is_balancer */, nullptr /* balancer_name */,
+        nullptr /* user_data */);
+    // Let the address sorter figure out which one should be tried first.
+    grpc_cares_wrapper_address_sorting_sort(*addrs);
+    return true;
+  }
+  return false;
+}
+
+bool grpc_ares_maybe_resolve_localhost_manually_locked(
+    const char* name, const char* default_port, grpc_lb_addresses** addrs) {
+  char* host = nullptr;
+  char* port = nullptr;
+  bool out = inner_maybe_resolve_localhost_manually_locked(name, default_port,
+                                                           addrs, &host, &port);
+  gpr_free(host);
+  gpr_free(port);
+  return out;
+}
 
 #endif /* GRPC_ARES == 1 && defined(GPR_WINDOWS) */

--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -174,9 +174,27 @@ grpc_cc_test(
 )
 
 grpc_cc_test(
-    name = "resolve_address_test",
+    name = "resolve_address_using_ares_resolver_test",
     srcs = ["resolve_address_test.cc"],
     language = "C++",
+    args = [
+        "--resolver=ares",
+    ],
+    deps = [
+        "//:gpr",
+        "//:grpc",
+        "//test/core/util:gpr_test_util",
+        "//test/core/util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
+    name = "resolve_address_using_native_resolver_test",
+    srcs = ["resolve_address_test.cc"],
+    language = "C++",
+    args = [
+        "--resolver=native",
+    ],
     deps = [
         "//:gpr",
         "//:grpc",

--- a/test/cpp/naming/address_sorting_test.cc
+++ b/test/cpp/naming/address_sorting_test.cc
@@ -216,7 +216,7 @@ TEST_F(AddressSortingTest, TestDepriotizesUnreachableAddresses) {
       {"1.2.3.4:443", AF_INET},
       {"5.6.7.8:443", AF_INET},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "1.2.3.4:443",
                                     "5.6.7.8:443",
@@ -235,7 +235,7 @@ TEST_F(AddressSortingTest, TestDepriotizesUnsupportedDomainIpv6) {
       {"[2607:f8b0:400a:801::1002]:443", AF_INET6},
       {"1.2.3.4:443", AF_INET},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "1.2.3.4:443",
                                     "[2607:f8b0:400a:801::1002]:443",
@@ -255,7 +255,7 @@ TEST_F(AddressSortingTest, TestDepriotizesUnsupportedDomainIpv4) {
       {"[2607:f8b0:400a:801::1002]:443", AF_INET6},
       {"1.2.3.4:443", AF_INET},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[2607:f8b0:400a:801::1002]:443",
                                     "1.2.3.4:443",
@@ -279,7 +279,7 @@ TEST_F(AddressSortingTest, TestDepriotizesNonMatchingScope) {
       {"[2000:f8b0:400a:801::1002]:443", AF_INET6},
       {"[fec0::5000]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[fec0::5000]:443",
                                     "[2000:f8b0:400a:801::1002]:443",
@@ -302,7 +302,7 @@ TEST_F(AddressSortingTest, TestUsesLabelFromDefaultTable) {
       {"[2002::5001]:443", AF_INET6},
       {"[2001::5001]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[2001::5001]:443",
                                     "[2002::5001]:443",
@@ -325,7 +325,7 @@ TEST_F(AddressSortingTest, TestUsesLabelFromDefaultTableInputFlipped) {
       {"[2001::5001]:443", AF_INET6},
       {"[2002::5001]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[2001::5001]:443",
                                     "[2002::5001]:443",
@@ -348,7 +348,7 @@ TEST_F(AddressSortingTest,
       {"[3ffe::5001]:443", AF_INET6},
       {"1.2.3.4:443", AF_INET},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(
       lb_addrs, {
                     // The AF_INET address should be IPv4-mapped by the sort,
@@ -381,7 +381,7 @@ TEST_F(AddressSortingTest,
       {v4_compat_dest, AF_INET6},
       {"[::1]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[::1]:443",
                                     v4_compat_dest,
@@ -404,7 +404,7 @@ TEST_F(AddressSortingTest,
       {"[1234::2]:443", AF_INET6},
       {"[::1]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(
       lb_addrs,
       {
@@ -428,7 +428,7 @@ TEST_F(AddressSortingTest,
       {"[2001::1234]:443", AF_INET6},
       {"[2000::5001]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(
       lb_addrs, {
                     // The 2000::/16 address should match the ::/0 prefix rule
@@ -452,7 +452,7 @@ TEST_F(
       {"[2001::1231]:443", AF_INET6},
       {"[2000::5001]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[2000::5001]:443",
                                     "[2001::1231]:443",
@@ -473,7 +473,7 @@ TEST_F(AddressSortingTest,
       {"[fec0::1234]:443", AF_INET6},
       {"[fc00::5001]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[fc00::5001]:443",
                                     "[fec0::1234]:443",
@@ -498,7 +498,7 @@ TEST_F(
       {"[::ffff:1.1.1.2]:443", AF_INET6},
       {"[1234::2]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     // ::ffff:0:2 should match the v4-mapped
                                     // precedence entry and be deprioritized.
@@ -525,7 +525,7 @@ TEST_F(AddressSortingTest, TestPrefersSmallerScope) {
       {"[3ffe::5001]:443", AF_INET6},
       {"[fec0::1234]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[fec0::1234]:443",
                                     "[3ffe::5001]:443",
@@ -550,7 +550,7 @@ TEST_F(AddressSortingTest, TestPrefersLongestMatchingSrcDstPrefix) {
       {"[3ffe:5001::]:443", AF_INET6},
       {"[3ffe:1234::]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe:1234::]:443",
                                     "[3ffe:5001::]:443",
@@ -571,7 +571,7 @@ TEST_F(AddressSortingTest,
       {"[3ffe::5001]:443", AF_INET6},
       {"[3ffe::1234]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe::1234]:443",
                                     "[3ffe::5001]:443",
@@ -591,7 +591,7 @@ TEST_F(AddressSortingTest, TestPrefersLongestPrefixStressInnerBytePrefix) {
       {"[3ffe:8000::]:443", AF_INET6},
       {"[3ffe:2000::]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe:2000::]:443",
                                     "[3ffe:8000::]:443",
@@ -611,7 +611,7 @@ TEST_F(AddressSortingTest, TestPrefersLongestPrefixDiffersOnHighestBitOfByte) {
       {"[3ffe:6::]:443", AF_INET6},
       {"[3ffe:c::]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe:c::]:443",
                                     "[3ffe:6::]:443",
@@ -633,7 +633,7 @@ TEST_F(AddressSortingTest, TestPrefersLongestPrefixDiffersByLastBit) {
       {"[3ffe:1111:1111:1110::]:443", AF_INET6},
       {"[3ffe:1111:1111:1111::]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe:1111:1111:1111::]:443",
                                     "[3ffe:1111:1111:1110::]:443",
@@ -655,7 +655,7 @@ TEST_F(AddressSortingTest, TestStableSort) {
       {"[3ffe::1234]:443", AF_INET6},
       {"[3ffe::1235]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe::1234]:443",
                                     "[3ffe::1235]:443",
@@ -681,7 +681,7 @@ TEST_F(AddressSortingTest, TestStableSortFiveElements) {
       {"[3ffe::1234]:443", AF_INET6},
       {"[3ffe::1235]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe::1231]:443",
                                     "[3ffe::1232]:443",
@@ -702,7 +702,7 @@ TEST_F(AddressSortingTest, TestStableSortNoSrcAddrsExist) {
       {"[3ffe::1234]:443", AF_INET6},
       {"[3ffe::1235]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[3ffe::1231]:443",
                                     "[3ffe::1232]:443",
@@ -720,7 +720,7 @@ TEST_F(AddressSortingTest, TestStableSortNoSrcAddrsExistWithIpv4) {
       {"[::ffff:5.6.7.8]:443", AF_INET6},
       {"1.2.3.4:443", AF_INET},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[::ffff:5.6.7.8]:443",
                                     "1.2.3.4:443",
@@ -748,7 +748,7 @@ TEST_F(AddressSortingTest, TestStableSortV4CompatAndSiteLocalAddresses) {
       {"[fec0::2000]:443", AF_INET6},
       {v4_compat_dest, AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs,
                       {
                           // The sort should be stable since
@@ -769,7 +769,7 @@ TEST_F(AddressSortingTest, TestPrefersIpv6Loopback) {
       {"[::1]:443", AF_INET6},
       {"127.0.0.1:443", AF_INET},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[::1]:443",
                                     "127.0.0.1:443",
@@ -783,7 +783,7 @@ TEST_F(AddressSortingTest, TestPrefersIpv6LoopbackInputsFlipped) {
       {"127.0.0.1:443", AF_INET},
       {"[::1]:443", AF_INET6},
   });
-  grpc_cares_wrapper_test_only_address_sorting_sort(lb_addrs);
+  grpc_cares_wrapper_address_sorting_sort(lb_addrs);
   VerifyLbAddrOutputs(lb_addrs, {
                                     "[::1]:443",
                                     "127.0.0.1:443",

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -1897,7 +1897,24 @@
     "headers": [], 
     "is_filegroup": false, 
     "language": "c", 
-    "name": "resolve_address_test", 
+    "name": "resolve_address_using_ares_resolver_test", 
+    "src": [
+      "test/core/iomgr/resolve_address_test.cc"
+    ], 
+    "third_party": false, 
+    "type": "target"
+  }, 
+  {
+    "deps": [
+      "gpr", 
+      "gpr_test_util", 
+      "grpc", 
+      "grpc_test_util"
+    ], 
+    "headers": [], 
+    "is_filegroup": false, 
+    "language": "c", 
+    "name": "resolve_address_using_native_resolver_test", 
     "src": [
       "test/core/iomgr/resolve_address_test.cc"
     ], 

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -2146,7 +2146,9 @@
     "uses_polling": true
   }, 
   {
-    "args": [], 
+    "args": [
+      "--resolver=ares"
+    ], 
     "benchmark": false, 
     "ci_platforms": [
       "linux", 
@@ -2160,7 +2162,33 @@
     "flaky": false, 
     "gtest": false, 
     "language": "c", 
-    "name": "resolve_address_test", 
+    "name": "resolve_address_using_ares_resolver_test", 
+    "platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "uses_polling": true
+  }, 
+  {
+    "args": [
+      "--resolver=native"
+    ], 
+    "benchmark": false, 
+    "ci_platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "cpu_cost": 1.0, 
+    "exclude_configs": [], 
+    "exclude_iomgrs": [], 
+    "flaky": false, 
+    "gtest": false, 
+    "language": "c", 
+    "name": "resolve_address_using_native_resolver_test", 
     "platforms": [
       "linux", 
       "mac", 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/15158

Tested core end2end tests (which use "localhost" as a target) under `GRPC_DNS_RESOLVER=ares`, on a Windows machine having `C:\Windows\System32\drivers\etc\hosts` at it's default setting (with "localhost" commented out).

------

Note updates to this PR noted in:
  * https://github.com/grpc/grpc/pull/16420#issuecomment-415222352
    - Not only manually resolve "localhost" on windows manually, but also resolver ipv4 and ipv6 literals manually: if we don't resolve ip literals manually and attempt to resolve them via c-ares, then we end up making A record queries for raw ipv6 address, AAAA record queries for raw ipv4 addresses, and TXT/SRV record queries for both raw ipv6 and raw ipv4 addresses.
  * https://github.com/grpc/grpc/pull/16420#issuecomment-418932777
    - Skip a couple of unit tests with the c-ares resolver; the c-ares resolver is especially vulnerable to external DNS server query flakes because it doesn't take advantage of the same system caches that the system resolver uses.

PTAL

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/16420)
<!-- Reviewable:end -->
