### PR TITLE
Ensure thread_pool is not None for grpc.Server

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_channel_args_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_args_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests of Channel Args on client/server side."""
 
+from concurrent import futures
 import unittest
 
 import grpc
@@ -39,7 +40,9 @@ class ChannelArgsTest(unittest.TestCase):
         grpc.insecure_channel('localhost:8080', options=TEST_CHANNEL_ARGS)
 
     def test_server(self):
-        grpc.server(None, options=TEST_CHANNEL_ARGS)
+        grpc.server(
+            futures.ThreadPoolExecutor(max_workers=1),
+            options=TEST_CHANNEL_ARGS)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I am considering checking `thread_pool` on server construction time, rather than failing at runtime when a job is submitted to the `thread_pool`, in a similar vein to validating `generic_handlers` passed at initialization time. However, this test was passing a `None` thread pool for implementation simplicity of the test, which makes it fail when that validation lands.