### PR TITLE
Support tracking and closing fds post-fork in ev_poll_posix

### DIFF
--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -62,7 +62,7 @@ typedef struct grpc_fd_watcher {
 
 typedef struct grpc_cached_wakeup_fd grpc_cached_wakeup_fd;
 
-/* Only used by poll when GRPC_ENABLE_FORK_SUPPORT=1 */
+/* Only used when GRPC_ENABLE_FORK_SUPPORT=1 */
 struct grpc_fork_fd_list {
   /* Only one of fd or cached_wakeup_fd will be set. The unused field will be
   set to nullptr. */
@@ -122,15 +122,14 @@ struct grpc_fd {
 
   grpc_iomgr_object iomgr_object;
 
-  /* Only used by poll when GRPC_ENABLE_FORK_SUPPORT=1 */
+  /* Only used when GRPC_ENABLE_FORK_SUPPORT=1 */
   grpc_fork_fd_list* fork_fd_list;
 };
 
-/* True when GRPC_ENABLE_FORK_SUPPORT=1 and polling strategy is poll. We do not
- * support fork with poll-cv */
+/* True when GRPC_ENABLE_FORK_SUPPORT=1. We do not support fork with poll-cv */
 static bool track_fds_for_fork = false;
 
-/* Only used by poll when GRPC_ENABLE_FORK_SUPPORT=1 */
+/* Only used when GRPC_ENABLE_FORK_SUPPORT=1 */
 static grpc_fork_fd_list* fork_fd_list_head = nullptr;
 static gpr_mu fork_fd_list_mu;
 
@@ -181,7 +180,7 @@ typedef struct grpc_cached_wakeup_fd {
   grpc_wakeup_fd fd;
   struct grpc_cached_wakeup_fd* next;
 
-  /* Only used by poll when GRPC_ENABLE_FORK_SUPPORT=1 */
+  /* Only used when GRPC_ENABLE_FORK_SUPPORT=1 */
   grpc_fork_fd_list* fork_fd_list;
 } grpc_cached_wakeup_fd;
 

--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -358,9 +358,9 @@ static void fork_fd_list_add_wakeup_fd(grpc_cached_wakeup_fd* fd) {
   }
 }
 
-/*******************************************************************************
- * fd_posix.c
- */
+  /*******************************************************************************
+   * fd_posix.c
+   */
 
 #ifndef NDEBUG
 #define REF_BY(fd, n, reason) ref_by(fd, n, reason, __FILE__, __LINE__)

--- a/src/core/lib/iomgr/fork_posix.cc
+++ b/src/core/lib/iomgr/fork_posix.cc
@@ -58,6 +58,12 @@ void grpc_prefork() {
             "environment variable GRPC_ENABLE_FORK_SUPPORT=1");
     return;
   }
+  if (strcmp(grpc_get_poll_strategy_name(), "epoll1") != 0 &&
+      strcmp(grpc_get_poll_strategy_name(), "poll") != 0) {
+    gpr_log(GPR_ERROR,
+            "Fork support is only compatible with the epoll1 and poll polling "
+            "strategies");
+  }
   if (!grpc_core::Fork::BlockExecCtx()) {
     gpr_log(GPR_INFO,
             "Other threads are currently calling into gRPC, skipping fork() "


### PR DESCRIPTION
This extends gRPC Python's fork compatibility to Mac OS, which does not
support epoll

The changes are a no-op if fork supported is disabled