### PR TITLE
C#: fix subchannel sharing for secure channels

### DIFF
--- a/src/csharp/Grpc.Core.Tests/FakeCredentials.cs
+++ b/src/csharp/Grpc.Core.Tests/FakeCredentials.cs
@@ -16,15 +16,7 @@
 
 #endregion
 
-using System;
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
-using Grpc.Core;
 using Grpc.Core.Internal;
-using Grpc.Core.Utils;
-using NUnit.Framework;
 
 namespace Grpc.Core.Tests
 {
@@ -42,7 +34,7 @@ namespace Grpc.Core.Tests
             get { return composable; }
         }
 
-        internal override ChannelCredentialsSafeHandle ToNativeCredentials()
+        internal override ChannelCredentialsSafeHandle CreateNativeCredentials()
         {
             return null;
         }

--- a/src/csharp/Grpc.Core/Channel.cs
+++ b/src/csharp/Grpc.Core/Channel.cs
@@ -72,9 +72,9 @@ namespace Grpc.Core
             this.environment = GrpcEnvironment.AddRef();
 
             this.completionQueue = this.environment.PickCompletionQueue();
-            using (var nativeCredentials = credentials.ToNativeCredentials())
             using (var nativeChannelArgs = ChannelOptions.CreateChannelArgs(this.options.Values))
             {
+                var nativeCredentials = credentials.GetNativeCredentials();
                 if (nativeCredentials != null)
                 {
                     this.handle = ChannelSafeHandle.CreateSecure(nativeCredentials, target, nativeChannelArgs);


### PR DESCRIPTION
Tentative fix for https://github.com/grpc/grpc/issues/15207

The idea is that for the same ChannelCredentials instance, we need to cache the native credentials object once created, because passing a different `grpc_channel_credentials* creds` when creating a channel in C core will result in C core acting as if the channel args were different (and thus subchannels are not shared).

Keeping the ChannelCredentialsSafeHandle around can lead to using extra memory, but the native object will get cleaned up by finalizer once (and if) ChannelCredentialsSafeHandle gets garbage collected.