### PR TITLE
C#: allow dot in metadata keys

### DIFF
--- a/src/csharp/Grpc.Core.Tests/MetadataTest.cs
+++ b/src/csharp/Grpc.Core.Tests/MetadataTest.cs
@@ -66,6 +66,8 @@ namespace Grpc.Core.Tests
             new Metadata.Entry("0123456789abc", "XYZ");
             new Metadata.Entry("-abc", "XYZ");
             new Metadata.Entry("a_bc_", "XYZ");
+            new Metadata.Entry("abc.xyz", "XYZ");
+            new Metadata.Entry("abc.xyz-bin", new byte[] {1, 2, 3});
             Assert.Throws(typeof(ArgumentException), () => new Metadata.Entry("abc[", "xyz"));
             Assert.Throws(typeof(ArgumentException), () => new Metadata.Entry("abc/", "xyz"));
         }

--- a/src/csharp/Grpc.Core/Metadata.cs
+++ b/src/csharp/Grpc.Core/Metadata.cs
@@ -225,7 +225,7 @@ namespace Grpc.Core
         /// </summary>
         public class Entry
         {
-            private static readonly Regex ValidKeyRegex = new Regex("^[a-z0-9_-]+$");
+            private static readonly Regex ValidKeyRegex = new Regex("^[.a-z0-9_-]+$");
 
             readonly string key;
             readonly string value;
@@ -360,7 +360,7 @@ namespace Grpc.Core
             {
                 var normalized = GrpcPreconditions.CheckNotNull(key, "key").ToLowerInvariant();
                 GrpcPreconditions.CheckArgument(ValidKeyRegex.IsMatch(normalized), 
-                    "Metadata entry key not valid. Keys can only contain lowercase alphanumeric characters, underscores and hyphens.");
+                    "Metadata entry key not valid. Keys can only contain lowercase alphanumeric characters, underscores, hyphens and dots.");
                 return normalized;
             }
 


### PR DESCRIPTION
FTR, see https://github.com/grpc/grpc/pull/4465 and https://github.com/grpc/grpc/pull/4467.

Fixes internal bug b/113020728

