### PR TITLE
Add an option to collect latency medians every epoch

### DIFF
--- a/src/proto/grpc/testing/control.proto
+++ b/src/proto/grpc/testing/control.proto
@@ -111,6 +111,10 @@ message ClientConfig {
 
   // Use coalescing API when possible.
   bool use_coalesce_api = 19;
+
+  // If 0, disabled. Else, specifies the period between gathering latency
+  // medians in milliseconds.
+  int32 median_latency_collection_interval_millis = 20;
 }
 
 message ClientStatus { ClientStats stats = 1; }

--- a/test/cpp/qps/client.h
+++ b/test/cpp/qps/client.h
@@ -323,7 +323,6 @@ class Client {
       return medians_each_interval_list_;
     }
 
-
     void UpdateHistogram(HistogramEntry* entry) {
       std::lock_guard<std::mutex> g(mu_);
       if (entry->value_used()) {

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -198,7 +198,8 @@ std::unique_ptr<ScenarioResult> RunScenario(
     const ServerConfig& initial_server_config, size_t num_servers,
     int warmup_seconds, int benchmark_seconds, int spawn_local_worker_count,
     const grpc::string& qps_server_target_override,
-    const grpc::string& credential_type, bool run_inproc) {
+    const grpc::string& credential_type, bool run_inproc,
+    int32_t median_latency_collection_interval_millis) {
   if (run_inproc) {
     g_inproc_servers = new std::vector<grpc::testing::Server*>;
   }
@@ -316,6 +317,9 @@ std::unique_ptr<ScenarioResult> RunScenario(
       gpr_free(cli_target);
     }
   }
+
+  client_config.set_median_latency_collection_interval_millis(
+      median_latency_collection_interval_millis);
 
   // Targets are all set by now
   result_client_config = client_config;

--- a/test/cpp/qps/driver.h
+++ b/test/cpp/qps/driver.h
@@ -32,7 +32,8 @@ std::unique_ptr<ScenarioResult> RunScenario(
     const grpc::testing::ServerConfig& server_config, size_t num_servers,
     int warmup_seconds, int benchmark_seconds, int spawn_local_worker_count,
     const grpc::string& qps_server_target_override,
-    const grpc::string& credential_type, bool run_inproc);
+    const grpc::string& credential_type, bool run_inproc,
+    int32_t median_latency_collection_interval_millis);
 
 bool RunQuit(const grpc::string& credential_type);
 }  // namespace testing

--- a/test/cpp/qps/histogram.h
+++ b/test/cpp/qps/histogram.h
@@ -34,6 +34,11 @@ class Histogram {
   ~Histogram() {
     if (impl_) grpc_histogram_destroy(impl_);
   }
+  void Reset() {
+    if (impl_) grpc_histogram_destroy(impl_);
+    impl_ = grpc_histogram_create(default_resolution(), default_max_possible());
+  }
+
   Histogram(Histogram&& other) : impl_(other.impl_) { other.impl_ = nullptr; }
 
   void Merge(const Histogram& h) { grpc_histogram_merge(impl_, h.impl_); }

--- a/test/cpp/qps/inproc_sync_unary_ping_pong_test.cc
+++ b/test/cpp/qps/inproc_sync_unary_ping_pong_test.cc
@@ -48,7 +48,7 @@ static void RunSynchronousUnaryPingPong() {
 
   const auto result =
       RunScenario(client_config, 1, server_config, 1, WARMUP, BENCHMARK, -2, "",
-                  kInsecureCredentialsType, true);
+                  kInsecureCredentialsType, true, 0);
 
   GetReporter()->ReportQPS(*result);
   GetReporter()->ReportLatency(*result);

--- a/test/cpp/qps/qps_json_driver.cc
+++ b/test/cpp/qps/qps_json_driver.cc
@@ -79,12 +79,12 @@ static std::unique_ptr<ScenarioResult> RunAndReport(const Scenario& scenario,
                                                     bool* success) {
   std::cerr << "RUNNING SCENARIO: " << scenario.name() << "\n";
   auto result = RunScenario(
-    scenario.client_config(), scenario.num_clients(),
-    scenario.server_config(), scenario.num_servers(),
-    scenario.warmup_seconds(), scenario.benchmark_seconds(),
-    !FLAGS_run_inproc ? scenario.spawn_local_worker_count() : -2,
-    FLAGS_qps_server_target_override, FLAGS_credential_type, FLAGS_run_inproc,
-    FLAGS_median_latency_collection_interval_millis);
+      scenario.client_config(), scenario.num_clients(),
+      scenario.server_config(), scenario.num_servers(),
+      scenario.warmup_seconds(), scenario.benchmark_seconds(),
+      !FLAGS_run_inproc ? scenario.spawn_local_worker_count() : -2,
+      FLAGS_qps_server_target_override, FLAGS_credential_type, FLAGS_run_inproc,
+      FLAGS_median_latency_collection_interval_millis);
 
   // Amend the result with scenario config. Eventually we should adjust
   // RunScenario contract so we don't need to touch the result here.
@@ -150,8 +150,7 @@ static double SearchOfferedLoad(double initial_offered_load,
                                 bool* success) {
   std::cerr << "RUNNING SCENARIO: " << scenario->name() << "\n";
   double current_offered_load = initial_offered_load;
-  double current_cpu_load =
-      GetCpuLoad(scenario, current_offered_load, success);
+  double current_cpu_load = GetCpuLoad(scenario, current_offered_load, success);
   if (current_cpu_load > targeted_cpu_load) {
     gpr_log(GPR_ERROR, "Initial offered load too high");
     return -1;

--- a/test/cpp/qps/qps_openloop_test.cc
+++ b/test/cpp/qps/qps_openloop_test.cc
@@ -52,7 +52,7 @@ static void RunQPS() {
 
   const auto result =
       RunScenario(client_config, 1, server_config, 1, WARMUP, BENCHMARK, -2, "",
-                  kInsecureCredentialsType, false);
+                  kInsecureCredentialsType, false, 0);
 
   GetReporter()->ReportQPSPerCore(*result);
   GetReporter()->ReportLatency(*result);

--- a/test/cpp/qps/secure_sync_unary_ping_pong_test.cc
+++ b/test/cpp/qps/secure_sync_unary_ping_pong_test.cc
@@ -55,7 +55,7 @@ static void RunSynchronousUnaryPingPong() {
 
   const auto result =
       RunScenario(client_config, 1, server_config, 1, WARMUP, BENCHMARK, -2, "",
-                  kInsecureCredentialsType, false);
+                  kInsecureCredentialsType, false, 0);
 
   GetReporter()->ReportQPS(*result);
   GetReporter()->ReportLatency(*result);


### PR DESCRIPTION
This allows us to gather per second median latencies and has been useful in some recent performance experiments.