### PR TITLE
Test message size of 100MB

### DIFF
--- a/test/core/util/test_config.cc
+++ b/test/core/util/test_config.cc
@@ -342,6 +342,10 @@ bool BuiltUnderUbsan() {
 #endif
 }
 
+bool grpc_test_built_under_tsan_or_msan() {
+  return BuiltUnderTsan() || BuiltUnderMsan();
+};
+
 int64_t grpc_test_sanitizer_slowdown_factor() {
   int64_t sanitizer_multiplier = 1;
   if (BuiltUnderValgrind()) {

--- a/test/core/util/test_config.h
+++ b/test/core/util/test_config.h
@@ -24,6 +24,9 @@
 extern int64_t g_fixture_slowdown_factor;
 extern int64_t g_poller_slowdown_factor;
 
+/* Returns if the test is built under TSAN or MSAN. */
+bool grpc_test_built_under_tsan_or_msan();
+
 /* Returns an appropriate scaling factor for timeouts. */
 int64_t grpc_test_slowdown_factor();
 

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -34,6 +34,7 @@
 
 #include "src/core/ext/filters/client_channel/backup_poller.h"
 #include "src/core/lib/gpr/tls.h"
+#include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/iomgr/port.h"
 #include "src/proto/grpc/health/v1/health.grpc.pb.h"
 #include "src/proto/grpc/testing/duplicate/echo_duplicate.grpc.pb.h"
@@ -58,6 +59,18 @@ namespace grpc {
 namespace testing {
 
 namespace {
+
+const size_t MAX_TEST_MESSAGE_SIZE =
+#if defined(GPR_APPLE)
+    // The test will time out with macos build.
+    GRPC_DEFAULT_MAX_RECV_MESSAGE_LENGTH;
+#else
+    // Don't test extreme size under tsan or msan, because it uses too much
+    // memory.
+    grpc_test_built_under_tsan_or_msan()
+        ? GRPC_DEFAULT_MAX_RECV_MESSAGE_LENGTH
+        : GPR_MAX(100 * 1024 * 1024, GRPC_DEFAULT_MAX_RECV_MESSAGE_LENGTH);
+#endif
 
 void* tag(int i) { return (void*)static_cast<intptr_t>(i); }
 int detag(void* p) { return static_cast<int>(reinterpret_cast<intptr_t>(p)); }
@@ -218,6 +231,17 @@ class ServerBuilderSyncPluginDisabler : public ::grpc::ServerBuilderOption {
   }
 };
 
+class ServerBuilderMaxRecvMessageSizeOption
+    : public ::grpc::ServerBuilderOption {
+ public:
+  void UpdateArguments(ChannelArguments* arg) override {
+    arg->SetInt(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, -1);
+  }
+
+  void UpdatePlugins(
+      std::vector<std::unique_ptr<ServerBuilderPlugin>>* plugins) override {}
+};
+
 class TestScenario {
  public:
   TestScenario(bool inproc_stub, const grpc::string& creds_type, bool hcs,
@@ -290,6 +314,9 @@ class AsyncEnd2endTest : public ::testing::TestWithParam<TestScenario> {
     std::unique_ptr<ServerBuilderOption> sync_plugin_disabler(
         new ServerBuilderSyncPluginDisabler());
     builder.SetOption(move(sync_plugin_disabler));
+    std::unique_ptr<ServerBuilderOption> max_recv_option(
+        new ServerBuilderMaxRecvMessageSizeOption());
+    builder.SetOption(move(max_recv_option));
     server_ = builder.BuildAndStart();
   }
 
@@ -297,6 +324,7 @@ class AsyncEnd2endTest : public ::testing::TestWithParam<TestScenario> {
     ChannelArguments args;
     auto channel_creds = GetCredentialsProvider()->GetChannelCredentials(
         GetParam().credentials_type, &args);
+    args.SetInt(GRPC_ARG_MAX_RECEIVE_MESSAGE_LENGTH, -1);
     std::shared_ptr<Channel> channel =
         !(GetParam().inproc) ? ::grpc::CreateCustomChannel(
                                    server_address_.str(), channel_creds, args)
@@ -1822,7 +1850,7 @@ TEST_P(AsyncEnd2endServerTryCancelTest, ServerBidiStreamingTryCancelAfter) {
 }
 
 std::vector<TestScenario> CreateTestScenarios(bool test_secure,
-                                              bool test_message_size_limit) {
+                                              bool test_big_message) {
   std::vector<TestScenario> scenarios;
   std::vector<grpc::string> credentials_types;
   std::vector<grpc::string> messages;
@@ -1844,9 +1872,8 @@ std::vector<TestScenario> CreateTestScenarios(bool test_secure,
   GPR_ASSERT(!credentials_types.empty());
 
   messages.push_back("Hello");
-  if (test_message_size_limit) {
-    for (size_t k = 1; k < GRPC_DEFAULT_MAX_RECV_MESSAGE_LENGTH / 1024;
-         k *= 32) {
+  if (test_big_message) {
+    for (size_t k = 1; k < MAX_TEST_MESSAGE_SIZE / 1024; k *= 32) {
       grpc::string big_msg;
       for (size_t i = 0; i < k * 1024; ++i) {
         char c = 'a' + (i % 26);
@@ -1854,8 +1881,7 @@ std::vector<TestScenario> CreateTestScenarios(bool test_secure,
       }
       messages.push_back(big_msg);
     }
-    messages.push_back(
-        grpc::string(GRPC_DEFAULT_MAX_RECV_MESSAGE_LENGTH - 10, 'a'));
+    messages.push_back(grpc::string(MAX_TEST_MESSAGE_SIZE - 10, 'a'));
   }
 
   // TODO (sreek) Renable tests with health check service after the issue


### PR DESCRIPTION
A followup of https://github.com/grpc/grpc/pull/16259.

We want to be able to say "we can handle 100MB request". But we don't have any promise about message that's beyond that size.