### PR TITLE
Add long_description for grpcio-tools

### DIFF
--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -193,6 +193,7 @@ setuptools.setup(
     url='https://grpc.io',
     license='Apache License 2.0',
     classifiers=CLASSIFIERS,
+    long_description=open('README.rst').read(),
     ext_modules=extension_modules(),
     packages=setuptools.find_packages('.'),
     install_requires=[


### PR DESCRIPTION
This works with `os.chdir(os.path.dirname(os.path.abspath(__file__)))` at the beginning of the `setup.py`.