### PR TITLE
Fix compilation error due to missing absl qualification.

### DIFF
--- a/src/cpp/ext/filters/census/server_filter.cc
+++ b/src/cpp/ext/filters/census/server_filter.cc
@@ -93,7 +93,7 @@ void CensusServerCallData::OnDoneRecvInitialMetadataCb(void* user_data,
     FilterInitialMetadata(initial_metadata, &sml);
     calld->path_ = grpc_slice_ref_internal(sml.path);
     calld->method_ = GetMethod(&calld->path_);
-    calld->qualified_method_ = StrCat("Recv.", calld->method_);
+    calld->qualified_method_ = absl::StrCat("Recv.", calld->method_);
     const char* tracing_str =
         GRPC_SLICE_IS_EMPTY(sml.tracing_slice)
             ? ""


### PR DESCRIPTION
When including the dependency @com_github_grpc_grpc//:grpc_opencensus_plugin in a cc_library it fails to compile with the following message:

external/com_github_grpc_grpc/src/cpp/ext/filters/census/server_filter.cc: In static member function 'static void grpc::CensusServerCallData::OnDoneRecvInitialMetadataCb(void*, grpc_error*)':
external/com_github_grpc_grpc/src/cpp/ext/filters/census/server_filter.cc:96:32: error: 'StrCat' was not declared in this scope
     calld->qualified_method_ = StrCat("Recv.", calld->method_);
                                ^~~~~~
external/com_github_grpc_grpc/src/cpp/ext/filters/census/server_filter.cc:96:32: note: suggested alternative:
In file included from external/com_github_grpc_grpc/src/cpp/ext/filters/census/server_filter.cc:23:0:
external/com_google_absl/absl/strings/str_cat.h:318:41: note:   'absl::StrCat'
 ABSL_MUST_USE_RESULT inline std::string StrCat(const AlphaNum& a, const AlphaNum& b,
                                         ^~~~~~
However, running bazel build grpc_opencensus_plugin completes just fine?  Not sure how, but this call should be qualified anyway as it's not using-declared in the file.