### PR TITLE
Rescue `GRPC::Core::CallError`  so that worker threads are not killed

### DIFF
--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -136,7 +136,7 @@ module GRPC
         begin
           blk, args = worker_queue.pop
           blk.call(*args)
-        rescue StandardError => e
+        rescue StandardError, GRPC::Core::CallError => e
           GRPC.logger.warn('Error in worker thread')
           GRPC.logger.warn(e)
         end


### PR DESCRIPTION
I'd like to add the code which rescues `GRPC::Core::CallError` at GRPC::Pool#loop_execute_jobs  so that worker threads are not killed.
When a client sends a request with a deadline and server exceed it during returning response, the client could terminate a connection.
So In Server, [GRPC::RpcDesc#send_status ](https://github.com/grpc/grpc/blob/35501ad1df5799be17cc41894a0dc1d3ed43a8f0/src/ruby/lib/grpc/generic/rpc_desc.rb#L153) could raise `GRPC::Core::CallError`.

This is a reproduction code and its result. https://gist.github.com/ganmacs/c7620111d25bef8081ce7b16d1d4e2b8
https://gist.github.com/ganmacs/c7620111d25bef8081ce7b16d1d4e2b8#file-server-log-L80 shows worker thread is killed by `GRPC::Core::CallError`
To show this error, I added a bit code to grpc gem https://github.com/grpc/grpc/compare/master...ganmacs:monitoring-worker-count?expand=1