### PR TITLE
Run remote bazel tests with GRPC_VERBOSITY=debug

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh
+++ b/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh
@@ -57,6 +57,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
   --host_platform=//third_party/toolchains:rbe_ubuntu1604 \
   --platforms=//third_party/toolchains:rbe_ubuntu1604 \
   --remote_instance_name=grpc-testing/instances/default_instance \
+  --test_env=GRPC_VERBOSITY=debug \
   $1 \
   -- //test/... || FAILED="true"
 

--- a/tools/internal_ci/linux/grpc_msan_on_foundry.sh
+++ b/tools/internal_ci/linux/grpc_msan_on_foundry.sh
@@ -66,6 +66,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
   --host_platform=//third_party/toolchains:rbe_ubuntu1604 \
   --platforms=//third_party/toolchains:rbe_ubuntu1604 \
   --remote_instance_name=grpc-testing/instances/default_instance \
+  --test_env=GRPC_VERBOSITY=debug \
   -- //test/... || FAILED="true"
 
 # Sleep to let ResultStore finish writing results before querying

--- a/tools/internal_ci/linux/grpc_ubsan_on_foundry.sh
+++ b/tools/internal_ci/linux/grpc_ubsan_on_foundry.sh
@@ -63,6 +63,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
   --platforms=//third_party/toolchains:rbe_ubuntu1604 \
   --cache_test_results=no \
   --remote_instance_name=grpc-testing/instances/default_instance \
+  --test_env=GRPC_VERBOSITY=debug \
   -- //test/... || FAILED="true"
 
 # Sleep to let ResultStore finish writing results before querying

--- a/tools/internal_ci/linux/pull_request/grpc_ubsan_on_foundry.sh
+++ b/tools/internal_ci/linux/pull_request/grpc_ubsan_on_foundry.sh
@@ -62,6 +62,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
   --host_platform=//third_party/toolchains:rbe_ubuntu1604 \
   --platforms=//third_party/toolchains:rbe_ubuntu1604 \
   --remote_instance_name=grpc-testing/instances/default_instance \
+  --test_env=GRPC_VERBOSITY=debug \
   -- //test/... || FAILED="true"
 
 if [ "$FAILED" != "" ]


### PR DESCRIPTION
I was trying to look into https://github.com/grpc/grpc/issues/16123, but the logs are not very useful as they are using `GRPC_VERBOSITY=error`.  With run_tests.py runs, we are always setting GRPC_VERBOSITY=debug
https://github.com/grpc/grpc/blob/35501ad1df5799be17cc41894a0dc1d3ed43a8f0/tools/run_tests/run_tests.py#L328

We should do the same for all foundry tests.





