### PR TITLE
Response status as Trailers-Only if initial metadata has not been sent

### DIFF
--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -205,6 +205,8 @@ module GRPC
     # list, mulitple metadata for its key are sent
     def send_status(code = OK, details = '', assert_finished = false,
                     metadata: {})
+      return if response_status_as_trailers_only(code, details, metadata: metadata)
+
       send_initial_metadata
       ops = {
         SEND_STATUS_FROM_SERVER => Struct::Status.new(code, details, metadata)
@@ -581,6 +583,23 @@ module GRPC
     end
 
     private
+
+    # response_status_as_trailers_only sends a status as Trailers-only
+    # https://github.com/grpc/grpc/blob/ceecf80283e6ca184df587f76ed053f1f5295b7f/doc/PROTOCOL-HTTP2.md
+    def response_status_as_trailers_only(code, details, metadata: {})
+      @send_initial_md_mutex.synchronize do
+        # Can't send Trailers-Only since Response-Headers have already been sent
+        return false if @metadata_sent
+        @metadata_sent = true
+      end
+
+      @call.run_batch(
+        SEND_INITIAL_METADATA => @metadata_to_send,
+        SEND_STATUS_FROM_SERVER => Struct::Status.new(code, details, metadata)
+      )
+      set_output_stream_done
+      true
+    end
 
     # To be called once the "input stream" has been completelly
     # read through (i.e, done reading from client or received status)

--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -217,6 +217,8 @@ module GRPC
       }
       ops[RECV_CLOSE_ON_SERVER] = nil if assert_finished
 
+      # To send initial metadata as trailing metadata(Trailers-Only) in order to support retries.
+      # https://github.com/grpc/grpc/blob/92b45c8eefcdde5e0c0ec36373fdecb7cd7007d7/doc/PROTOCOL-HTTP2.md#responses
       ops[SEND_INITIAL_METADATA] = @metadata_to_send unless metadata_already_sent
 
       @call.run_batch(ops)


### PR DESCRIPTION
To enable retry by middlewares such as [envoyproxy/envoy](https://github.com/envoyproxy/envoy) when grpc gem returns an error status, I added the code which returns the status as [Trailers-Only](https://github.com/grpc/grpc/blob/ceecf80283e6ca184df587f76ed053f1f5295b7f/doc/PROTOCOL-HTTP2.md#responses) if grpc gem doesn't send Response-Headers to a client.

* envoy's retry policies for gRPC https://github.com/envoyproxy/envoy/issues/721
* Example use case  https://github.com/ganmacs/envoy-grpc
  * Result log  https://gist.github.com/ganmacs/722fff16f9a9fe7bc3df4b9554d61fe9
