### PR TITLE
Enable timer test on windows

### DIFF
--- a/src/core/ext/filters/http/server/http_server_filter.cc
+++ b/src/core/ext/filters/http/server/http_server_filter.cc
@@ -322,9 +322,9 @@ static grpc_error* hs_mutate_op(grpc_call_element* elem,
     grpc_error* error = GRPC_ERROR_NONE;
     static const char* error_name = "Failed sending initial metadata";
     hs_add_error(error_name, &error,
-                 grpc_metadata_batch_add_head(
+                 grpc_metadata_batch_add_head_index(
                      op->payload->send_initial_metadata.send_initial_metadata,
-                     &calld->status, GRPC_MDELEM_STATUS_200));
+                     &calld->status, GRPC_MDELEM_STATUS_200_INDEX));
     hs_add_error(error_name, &error,
                  grpc_metadata_batch_add_tail(
                      op->payload->send_initial_metadata.send_initial_metadata,

--- a/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
@@ -692,7 +692,11 @@ void grpc_chttp2_encode_header(grpc_chttp2_hpack_compressor* c,
   }
   grpc_metadata_batch_assert_ok(metadata);
   for (grpc_linked_mdelem* l = metadata->list.head; l; l = l->next) {
-    hpack_enc(c, l->md, &st);
+    if (is_valid_mdelem_index(l->md_index)) {
+      emit_indexed(c, l->md_index, &st);
+    } else {
+      hpack_enc(c, l->md, &st);
+    }
   }
   grpc_millis deadline = metadata->deadline;
   if (deadline != GRPC_MILLIS_INF_FUTURE) {

--- a/src/core/lib/transport/metadata.h
+++ b/src/core/lib/transport/metadata.h
@@ -162,4 +162,194 @@ void grpc_mdelem_unref(grpc_mdelem md);
 void grpc_mdctx_global_init(void);
 void grpc_mdctx_global_shutdown();
 
+#define MIN_STATIC_HPACK_TABLE_IDX 1
+#define MAX_STATIC_HPACK_TABLE_IDX 61
+
+/* Static hpack table metadata indices */
+
+/* {:authority, ""} */
+#define GRPC_MDELEM_AUTHORITY_EMPTY_INDEX 1
+
+/* {":method", "GET"} */
+#define GRPC_MDELEM_METHOD_GET_INDEX 2
+
+/* {":method", "POST"} */
+#define GRPC_MDELEM_METHOD_POST_INDEX 3
+
+/* {":path", "/"} */
+#define GRPC_MDELEM_PATH_SLASH_INDEX 4
+
+/* {":path", "/index.html"} */
+#define GRPC_MDELEM_PATH_SLASH_INDEX_DOT_HTML_INDEX 5
+
+/* {":scheme", "http"} */
+#define GRPC_MDELEM_SCHEME_HTTP_INDEX 6
+
+/* {":scheme", "https"} */
+#define GRPC_MDELEM_SCHEME_HTTPS_INDEX 7
+
+/* {":status", "200"} */
+#define GRPC_MDELEM_STATUS_200_INDEX 8
+
+/* {":status", "204"} */
+#define GRPC_MDELEM_STATUS_204_INDEX 9
+
+/* {":status", "206"} */
+#define GRPC_MDELEM_STATUS_206_INDEX 10
+
+/* {":status", "304"} */
+#define GRPC_MDELEM_STATUS_304_INDEX 11
+
+/* {":status", "400"} */
+#define GRPC_MDELEM_STATUS_400_INDEX 12
+
+/* {":status", "404"} */
+#define GRPC_MDELEM_STATUS_404_INDEX 13
+
+/* {":status", "500"} */
+#define GRPC_MDELEM_STATUS_500_INDEX 14
+
+/* {"accept-charset", ""} */
+#define GRPC_MDELEM_ACCEPT_CHARSET_EMPTY_INDEX 15
+
+/* {"accept-encoding", "gzip, deflate"} */
+#define GRPC_MDELEM_ACCEPT_ENCODING_GZIP_DEFLATE_INDEX 16
+
+/* {"accept-language", ""} */
+#define GRPC_MDELEM_MDELEM_ACCEPT_LANGUAGE_EMPTY_INDEX 17
+
+/* {"accept-ranges", ""} */
+#define GRPC_MDELEM_MDELEM_ACCEPT_RANGES_EMPTY_INDEX 18
+
+/* {"accept", ""} */
+#define GRPC_MDELEM_ACCEPT_EMPTY_INDEX 19
+
+/* {"access-control-allow-origin", ""} */
+#define GRPC_MDELEM_ACCESS_CONTROL_ALLOW_ORIGIN_EMPTY_INDEX 20
+
+/* {"age", ""} */
+#define GRPC_MDELEM_AGE_EMPTY_INDEX 21
+
+/* {"allow", ""} */
+#define GRPC_MDELEM_ALLOW_EMPTY_INDEX 22
+
+/* {"authorization", ""} */
+#define GRPC_MDELEM_AUTHORIZATION_EMPTY_INDEX 23
+
+/* {"cache-control", ""} */
+#define GRPC_MDELEM_CACHE_CONTROL_EMPTY_INDEX 24
+
+/* {"content-disposition", ""} */
+#define GRPC_MDELEM_CONTENT_DISPOSITION_EMPTY_INDEX 25
+
+/* {"content-encoding", ""} */
+#define GRPC_MDELEM_CONTENT_ENCODING_EMPTY_INDEX 26
+
+/* {"content-language", ""} */
+#define GRPC_MDELEM_CONTENT_LANGUAGE_EMPTY_INDEX 27
+
+/* {"content-length", ""} */
+#define GRPC_MDELEM_CONTENT_LENGTH_EMPTY_INDEX 28
+
+/* {"content-location", ""} */
+#define GRPC_MDELEM_CONTENT_LOCATION_EMPTY_INDEX 29
+
+/* {"content-range", ""} */
+#define GRPC_MDELEM_CONTENT_RANGE_EMPTY_INDEX 30
+
+/* {"content-type", ""} */
+#define GRPC_MDELEM_CONTENT_TYPE_EMPTY_INDEX 31
+
+/* {"cookie", ""} */
+#define GRPC_MDELEM_COOKIE_EMPTY_INDEX 32
+
+/* {"date", ""} */
+#define GRPC_MDELEM_DATE_EMPTY_INDEX 33
+
+/* {"etag", ""} */
+#define GRPC_MDELEM_ETAG_EMPTY_INDEX 34
+
+/* {"expect", ""} */
+#define GRPC_MDELEM_EXPECT_EMPTY_INDEX 35
+
+/* {"expires", ""} */
+#define GRPC_MDELEM_EXPIRES_EMPTY_INDEX 36
+
+/* {"from", ""} */
+#define GRPC_MDELEM_FROM_EMPTY_INDEX 37
+
+/* {"host", ""} */
+#define GRPC_MDELEM_HOST_EMPTY_INDEX 38
+
+/* {"if-match", ""} */
+#define GRPC_MDELEM_IF_MATCH_EMPTY_INDEX 39
+
+/* {"if-modified-since", ""} */
+#define GRPC_MDELEM_IF_MODIFIED_SINCE_EMPTY_INDEX 40
+
+/* {"if-none-match", ""} */
+#define GRPC_MDELEM_IF_NONE_MATCH_EMPTY_INDEX 41
+
+/* {"if-range", ""} */
+#define GRPC_MDELEM_IF_RANGE_EMPTY_INDEX 42
+
+/* {"if-unmodified-since", ""} */
+#define GRPC_MDELEM_IF_UNMODIFIED_SINCE_EMPTY_INDEX 43
+
+/* {"last-modified", ""} */
+#define GRPC_MDELEM_LAST_MODIFIED_EMPTY_INDEX 44
+
+/* {"link", ""} */
+#define GRPC_MDELEM_LINK_EMPTY_INDEX 45
+
+/* {"location", ""} */
+#define GRPC_MDELEM_LOCATION_EMPTY_INDEX 46
+
+/* {"max-forwards", ""} */
+#define GRPC_MDELEM_MAX_FORWARDS_EMPTY_INDEX 47
+
+/* {"proxy-authenticate", ""} */
+#define GRPC_MDELEM_PROXY_AUTHENTICATE_EMPTY_INDEX 48
+
+/* {"proxy-authorization", ""} */
+#define GRPC_MDELEM_PROXY_AUTHORIZATION_EMPTY_INDEX 49
+
+/* {"range", ""} */
+#define GRPC_MDELEM_RANGE_EMPTY_INDEX 50
+
+/* {"referer", ""} */
+#define GRPC_MDELEM_REFERER_EMPTY_INDEX 51
+
+/* {"refresh", ""} */
+#define GRPC_MDELEM_REFRESH_EMPTY_INDEX 52
+
+/* {"retry-after", ""} */
+#define GRPC_MDELEM_RETRY_AFTER_EMPTY_INDEX 53
+
+/* {"server", ""} */
+#define GRPC_MDELEM_SERVER_EMPTY_INDEX 54
+
+/* {"set-cookie", ""} */
+#define GRPC_MDELEM_SET_COOKIE_EMPTY_INDEX 55 * /
+
+/* {"strict-transport-security", ""} */
+#define GRPC_MDELEM_STRICT_TRANSPORT_SECURITY_EMPTY_INDEX 56
+
+/* {"transfer-encoding", ""} */
+#define GRPC_MDELEM_TRANSFER_ENCODING_EMPTY_INDEX 57
+
+/* {"user-agent", ""} */
+#define GRPC_MDELEM_USER_AGENT_EMPTY_INDEX 58
+
+/* {"vary", ""} */
+#define GRPC_MDELEM_VARY_EMPTY_INDEX 59
+
+/* {"via", ""} */
+#define GRPC_MDELEM_VIA_EMPTY_INDEX 60
+
+/* {"www-authenticate", ""} */
+#define GRPC_MDELEM_WWW_AUTHENTICATE_EMPTY_INDEX 61
+
+/* Forward declarations */
+typedef struct grpc_mdelem grpc_mdelem;
 #endif /* GRPC_CORE_LIB_TRANSPORT_METADATA_H */

--- a/test/core/iomgr/timer_list_test.cc
+++ b/test/core/iomgr/timer_list_test.cc
@@ -248,11 +248,7 @@ int main(int argc, char** argv) {
     grpc_determine_iomgr_platform();
     grpc_iomgr_platform_init();
     gpr_set_log_verbosity(GPR_LOG_SEVERITY_DEBUG);
-#ifndef GPR_WINDOWS
-    /* Skip this test on Windows until we figure out why it fails */
-    /* https://github.com/grpc/grpc/issues/16417 */
     long_running_service_cleanup_test();
-#endif  // GPR_WINDOWS
     add_test();
     destruction_test();
     grpc_iomgr_platform_shutdown();


### PR DESCRIPTION
Now that PR #15813 has been merged, issue #16417 should be fixed, so we should now re-enable this particular timer test on windows.