### PR TITLE
Enable timer test on windows

### DIFF
--- a/test/core/iomgr/timer_list_test.cc
+++ b/test/core/iomgr/timer_list_test.cc
@@ -248,11 +248,7 @@ int main(int argc, char** argv) {
     grpc_determine_iomgr_platform();
     grpc_iomgr_platform_init();
     gpr_set_log_verbosity(GPR_LOG_SEVERITY_DEBUG);
-#ifndef GPR_WINDOWS
-    /* Skip this test on Windows until we figure out why it fails */
-    /* https://github.com/grpc/grpc/issues/16417 */
     long_running_service_cleanup_test();
-#endif  // GPR_WINDOWS
     add_test();
     destruction_test();
     grpc_iomgr_platform_shutdown();


### PR DESCRIPTION
Now that PR #15813 has been merged, issue #16417 should be fixed, so we should now re-enable this particular timer test on windows.