### PR TITLE
Fix candid skipping of interop_to_prod tests.

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -776,9 +776,9 @@ def cloud_to_prod_jobspec(language,
         '--test_case=%s' % test_case
     ]
     if transport_security == 'tls':
-        transport_security_options += ['--use_tls=true']
+        transport_security_options = ['--use_tls=true']
     elif transport_security == 'google_default_credentials' and language == 'c++':
-        transport_security_options += [
+        transport_security_options = [
             '--custom_credentials_type=google_default_credentials'
         ]
     else:

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -1519,9 +1519,6 @@ try:
         sys.exit(1)
     else:
         sys.exit(0)
-except Exception as e:
-    print('exception occurred:')
-    traceback.print_exc(file=sys.stdout)
 finally:
     # Check if servers are still running.
     for server, job in server_jobs.items():


### PR DESCRIPTION
interop_to_prod tests are not actually running! see https://github.com/grpc/grpc/issues/16519 for explanation.

This PR is against, v1.15.x, we should sync to master as soon as this gets merged.

- fix the actual problem in run_interop_tests.py
- make sure the tests end up red if script crashes



