### PR TITLE
Don't overwrite HOST_* make variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -455,11 +455,11 @@ LDFLAGS += $(EXTRA_LDFLAGS)
 DEFINES += $(EXTRA_DEFINES)
 LDLIBS += $(EXTRA_LDLIBS)
 
-HOST_CPPFLAGS = $(CPPFLAGS)
-HOST_CFLAGS = $(CFLAGS)
-HOST_CXXFLAGS = $(CXXFLAGS)
-HOST_LDFLAGS = $(LDFLAGS)
-HOST_LDLIBS = $(LDLIBS)
+HOST_CPPFLAGS += $(CPPFLAGS)
+HOST_CFLAGS += $(CFLAGS)
+HOST_CXXFLAGS += $(CXXFLAGS)
+HOST_LDFLAGS += $(LDFLAGS)
+HOST_LDLIBS += $(LDLIBS)
 
 # These are automatically computed variables.
 # There shouldn't be any need to change anything from now on.

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -323,11 +323,11 @@
   ${arg} += $(EXTRA_${arg})
   % endfor
 
-  HOST_CPPFLAGS = $(CPPFLAGS)
-  HOST_CFLAGS = $(CFLAGS)
-  HOST_CXXFLAGS = $(CXXFLAGS)
-  HOST_LDFLAGS = $(LDFLAGS)
-  HOST_LDLIBS = $(LDLIBS)
+  HOST_CPPFLAGS += $(CPPFLAGS)
+  HOST_CFLAGS += $(CFLAGS)
+  HOST_CXXFLAGS += $(CXXFLAGS)
+  HOST_LDFLAGS += $(LDFLAGS)
+  HOST_LDLIBS += $(LDLIBS)
 
   # These are automatically computed variables.
   # There shouldn't be any need to change anything from now on.


### PR DESCRIPTION
In order to allow building within a cross compilation environment like buildroot, we need to be able to configure the HOST_{CFLAGS,CXXFLAGS,LDFLAGS,...} variables so that the compilation environment can find all the libraries that the host tools need (like c-ares and protoc).