### PR TITLE
Remove use of subowners from client_channel

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,5 @@
 /**/OWNERS @markdroth @nicolasnoble @a11r
 /bazel/** @nicolasnoble @dgquintas @a11r @vjpai
 /cmake/** @jtattermusch @nicolasnoble @mehrdada
-/src/core/ext/filters/client_channel/** @markdroth @dgquintas @AspirinSJL
 /tools/dockerfile/** @jtattermusch @mehrdada @nicolasnoble
 /tools/run_tests/performance/** @ncteisen @apolcyn @jtattermusch

--- a/src/core/ext/filters/client_channel/OWNERS
+++ b/src/core/ext/filters/client_channel/OWNERS
@@ -1,4 +1,0 @@
-set noparent
-@markdroth
-@dgquintas
-@AspirinSJL


### PR DESCRIPTION
Having subowners is blocking/delaying the use of safe and highly testable cleanup changes (like #16209). This code is mature and doesn't need subowners for trivial changes; of course, component owners should be assigned the reviews for any substantial changes, but there's no need to enforce this using the overly broad CODEOWNERS framework.
