### PR TITLE
Add exception info to Status.Detail if metadata credentials throws.

### DIFF
--- a/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
@@ -68,9 +68,8 @@ namespace Grpc.Core.Internal
             }
             catch (Exception e)
             {
-                var detail = GetMetadataExceptionStatusMsg + " " + e.ToString();
-                Native.grpcsharp_metadata_credentials_notify_from_plugin(callbackPtr, userDataPtr, MetadataArraySafeHandle.Create(Metadata.Empty), StatusCode.Unknown, detail);
-                Logger.Error(e, GetMetadataExceptionLogMsg);
+                // eat the exception, we must not throw when inside callback from native code.
+                Logger.Error(e, "Exception occurred while invoking native metadata interceptor handler.");
             }
         }
 

--- a/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
@@ -68,7 +68,8 @@ namespace Grpc.Core.Internal
             }
             catch (Exception e)
             {
-                Native.grpcsharp_metadata_credentials_notify_from_plugin(callbackPtr, userDataPtr, MetadataArraySafeHandle.Create(Metadata.Empty), StatusCode.Unknown, GetMetadataExceptionStatusMsg);
+                var detail = GetMetadataExceptionStatusMsg + " " + e.ToString();
+                Native.grpcsharp_metadata_credentials_notify_from_plugin(callbackPtr, userDataPtr, MetadataArraySafeHandle.Create(Metadata.Empty), StatusCode.Unknown, detail);
                 Logger.Error(e, GetMetadataExceptionLogMsg);
             }
         }
@@ -87,7 +88,8 @@ namespace Grpc.Core.Internal
             }
             catch (Exception e)
             {
-                Native.grpcsharp_metadata_credentials_notify_from_plugin(callbackPtr, userDataPtr, MetadataArraySafeHandle.Create(Metadata.Empty), StatusCode.Unknown, GetMetadataExceptionStatusMsg);
+                string detail = GetMetadataExceptionStatusMsg + " " + e.ToString();
+                Native.grpcsharp_metadata_credentials_notify_from_plugin(callbackPtr, userDataPtr, MetadataArraySafeHandle.Create(Metadata.Empty), StatusCode.Unknown, detail);
                 Logger.Error(e, GetMetadataExceptionLogMsg);
             }
         }

--- a/src/csharp/Grpc.IntegrationTesting/MetadataCredentialsTest.cs
+++ b/src/csharp/Grpc.IntegrationTesting/MetadataCredentialsTest.cs
@@ -153,9 +153,10 @@ namespace Grpc.IntegrationTesting
         [Test]
         public void MetadataCredentials_InterceptorThrows()
         {
+            var authInterceptorExceptionMessage = "Auth interceptor throws";
             var callCredentials = CallCredentials.FromInterceptor(new AsyncAuthInterceptor((context, metadata) =>
             {
-                throw new Exception("Auth interceptor throws");
+                throw new Exception(authInterceptorExceptionMessage);
             }));
             var channelCredentials = ChannelCredentials.Create(TestCredentials.CreateSslCredentials(), callCredentials);
             channel = new Channel(Host, server.Ports.Single().BoundPort, channelCredentials, options);
@@ -163,6 +164,7 @@ namespace Grpc.IntegrationTesting
 
             var ex = Assert.Throws<RpcException>(() => client.UnaryCall(new SimpleRequest { }));
             Assert.AreEqual(StatusCode.Unavailable, ex.Status.StatusCode);
+            StringAssert.Contains(authInterceptorExceptionMessage, ex.Status.Detail);
         }
 
         private class FakeTestService : TestService.TestServiceBase


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/14461.

Because the execution flow passes through the native layer when metadata credentials are used, we can't easily keep the exception instance around to be able to populate InnerException in RpcException thrown by the call if an exception is throws when getting the auth token. (as requested in #14461)
Instead, this PR adds the exception info (message + stacktrace) to the  Status.Details of the failed RPC. This should make details of the underlying problem obvious to the users without needing to consult (and enable) extra logging.

Adding this info to the Status.Details because if metadata credentials throw an exception, the call fails immediately without leaving the client.



