### PR TITLE
Add template-friendly function in generated C++ WithAsyncMethod classes

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -607,6 +607,17 @@ void PrintHeaderServerAsyncMethodsHelper(
         "}\n");
     printer->Print(
         *vars,
+        "void Request("
+        "::grpc::ServerContext* context, $RealRequest$* request, "
+        "::grpc::ServerAsyncResponseWriter< $RealResponse$>* response, "
+        "::grpc::CompletionQueue* new_call_cq, "
+        "::grpc::ServerCompletionQueue* notification_cq, void *tag) {\n");
+    printer->Print(*vars,
+                   "  ::grpc::Service::RequestAsyncUnary($Idx$, context, "
+                   "request, response, new_call_cq, notification_cq, tag);\n");
+    printer->Print("}\n");
+    printer->Print(
+        *vars,
         "void Request$Method$("
         "::grpc::ServerContext* context, $RealRequest$* request, "
         "::grpc::ServerAsyncResponseWriter< $RealResponse$>* response, "


### PR DESCRIPTION
This PR generates one template-friendly function in `WithAsyncMethod_*` class in C++ code generator. The objective is to call the family of `WithAsyncMethod_Foo::RequestFoo` functions without knowing the exact names of the functions. 

For instance, I would like to allow application frameworks to write code like below to invoke all the nested `WithAsyncMethod_*::Request*` functions belonging to `AsyncService`.

```cpp
int nested_async_methods() {
  MyGame::Example::MonsterStorage::AsyncService async;
  // Somehow call WithAsyncMethod_Retrieve::RequestRetrieve 
  // and WithAsyncMethod_Store::RequestStore.
  call_nested(async);
  return 0;
}
```
Such generic code is possible if there is a duplicate of `WithAsyncMethod_*::Request*` function with  a generic name---`Request`. See the diffs for `tests/monster_test.grpc.fb.h` [here](https://github.com/google/flatbuffers/pull/4901/files#diff-62b42c0d54d6d3f7044e45159eebcf8b). Here's how generic code might work. There's some additional discussion in [this](https://github.com/google/flatbuffers/pull/4901) PR.

```cpp
template <class AsyncService>
struct CallNested {
  static void call(AsyncService &s) {}
};

template <class Nested, template <class> class WithAsyncMethod>
struct CallNested<WithAsyncMethod<Nested>> {
  static void call(WithAsyncMethod<Nested> &async) {
    // The next line is the objective. Of course, in real code, it's not all zeros.
    async.Request(0, 0, 0, 0, 0, 0);
    CallNested<Nested>::call(async);
  };
};

template <class AsyncService>
void call_nested(AsyncService &async) {
  CallNested<AsyncService>::call(async);
}
```

The current proposal is to call it `Request` to avoid any possibility of collision with a user-defined rpc operation. An alternative is `operator()`.

The changes required in C++ code generator are next to trivial.