### PR TITLE
Fix subchannel key comparison if forcing creation

### DIFF
--- a/src/core/ext/filters/client_channel/subchannel_index.cc
+++ b/src/core/ext/filters/client_channel/subchannel_index.cc
@@ -42,7 +42,7 @@ struct grpc_subchannel_key {
   grpc_subchannel_args args;
 };
 
-static bool g_force_creation = false;
+static gpr_atm g_force_creation = false;
 
 static grpc_subchannel_key* create_key(
     const grpc_subchannel_args* args,
@@ -74,7 +74,7 @@ static grpc_subchannel_key* subchannel_key_copy(grpc_subchannel_key* k) {
 int grpc_subchannel_key_compare(const grpc_subchannel_key* a,
                                 const grpc_subchannel_key* b) {
   // To pretend the keys are different, return a non-zero value.
-  if (g_force_creation) return 1;
+  if (GPR_UNLIKELY(gpr_atm_no_barrier_load(&g_force_creation))) return 1;
   int c = GPR_ICMP(a->args.filter_count, b->args.filter_count);
   if (c != 0) return c;
   if (a->args.filter_count > 0) {
@@ -251,5 +251,5 @@ void grpc_subchannel_index_unregister(grpc_subchannel_key* key,
 }
 
 void grpc_subchannel_index_test_only_set_force_creation(bool force_creation) {
-  g_force_creation = force_creation;
+  gpr_atm_no_barrier_store(&g_force_creation, force_creation);
 }

--- a/src/core/ext/filters/client_channel/subchannel_index.cc
+++ b/src/core/ext/filters/client_channel/subchannel_index.cc
@@ -73,7 +73,8 @@ static grpc_subchannel_key* subchannel_key_copy(grpc_subchannel_key* k) {
 
 int grpc_subchannel_key_compare(const grpc_subchannel_key* a,
                                 const grpc_subchannel_key* b) {
-  if (g_force_creation) return false;
+  // To pretend the keys are different, return a non-zero value.
+  if (g_force_creation) return 1;
   int c = GPR_ICMP(a->args.filter_count, b->args.filter_count);
   if (c != 0) return c;
   if (a->args.filter_count > 0) {

--- a/src/core/ext/filters/client_channel/subchannel_index.h
+++ b/src/core/ext/filters/client_channel/subchannel_index.h
@@ -65,12 +65,9 @@ void grpc_subchannel_index_ref(void);
 void grpc_subchannel_index_unref(void);
 
 /** \em TEST ONLY.
- * If \a force_creation is true, all key comparisons will be false, resulting in
+ * If \a force_creation is true, all keys are regarded different, resulting in
  * new subchannels always being created. Otherwise, the keys will be compared as
  * usual.
- *
- * This function is *not* threadsafe on purpose: it should *only* be used in
- * test code.
  *
  * Tests using this function \em MUST run tests with and without \a
  * force_creation set. */


### PR DESCRIPTION
Prior to this PR, if `g_force_creation` is true, we will unconditionally reusing the subchannel, even when the subchannel keys are different.

For example, search for 0x4ee610 in the following log.

```
[ RUN      ] ClientLbEnd2endTest.PickFirstManyUpdates
I0906 14:56:20.221150601  120357 client_lb_end2end_test.cc:261] starting server on port 63238
I0906 14:56:20.221265739  120375 server_builder.cc:270]      Synchronous server. Num CQs: 1, Min pollers: 1, Max Pollers: 2, CQ timeout (msec): 10000
I0906 14:56:20.221733957  120357 client_lb_end2end_test.cc:269] server startup complete
I0906 14:56:20.221743894  120357 client_lb_end2end_test.cc:261] starting server on port 63239
I0906 14:56:20.221832871  120377 server_builder.cc:270]      Synchronous server. Num CQs: 1, Min pollers: 1, Max Pollers: 2, CQ timeout (msec): 10000
I0906 14:56:20.222094190  120357 client_lb_end2end_test.cc:269] server startup complete
I0906 14:56:20.222127611  120357 client_lb_end2end_test.cc:261] starting server on port 63240
I0906 14:56:20.222315697  120379 server_builder.cc:270]      Synchronous server. Num CQs: 1, Min pollers: 1, Max Pollers: 2, CQ timeout (msec): 10000
I0906 14:56:20.222631231  120357 client_lb_end2end_test.cc:269] server startup complete
I0906 14:56:20.222796673  120357 client_lb_end2end_test.cc:577] Force subchannel creation: 1
I0906 14:56:20.222995630  120357 pick_first.cc:159]          Pick First 0x4ed9f0 created.
I0906 14:56:20.223022004  120357 pick_first.cc:356]          Pick First 0x4ed9f0 received update with 3 addresses
I0906 14:56:20.223036144  120357 subchannel_list.h:488]      [pick_first 0x4ed9f0] Creating subchannel list 0x4ede30 for 3 subchannels
I0906 14:56:20.223108541  120357 subchannel_list.h:528]      [pick_first 0x4ed9f0] subchannel list 0x4ede30 index 0: Created subchannel 0x4ee610 for address uri ipv4:127.0.0.1:63238
I0906 14:56:20.223148687  120357 subchannel_list.h:528]      [pick_first 0x4ed9f0] subchannel list 0x4ede30 index 1: Created subchannel 0x4ee610 for address uri ipv4:127.0.0.1:63239
I0906 14:56:20.223181373  120357 subchannel_list.h:528]      [pick_first 0x4ed9f0] subchannel list 0x4ede30 index 2: Created subchannel 0x4ee610 for address uri ipv4:127.0.0.1:63240
```

But I believe what we actually want is the opposite. 

```
[ RUN      ] ClientLbEnd2endTest.PickFirstManyUpdates
I0906 14:58:09.311265150  121884 client_lb_end2end_test.cc:261] starting server on port 18443
I0906 14:58:09.311453755  121909 server_builder.cc:270]      Synchronous server. Num CQs: 1, Min pollers: 1, Max Pollers: 2, CQ timeout (msec): 10000
I0906 14:58:09.311961372  121884 client_lb_end2end_test.cc:269] server startup complete
I0906 14:58:09.311978407  121884 client_lb_end2end_test.cc:261] starting server on port 22478
I0906 14:58:09.312073074  121911 server_builder.cc:270]      Synchronous server. Num CQs: 1, Min pollers: 1, Max Pollers: 2, CQ timeout (msec): 10000
I0906 14:58:09.312382352  121884 client_lb_end2end_test.cc:269] server startup complete
I0906 14:58:09.312399269  121884 client_lb_end2end_test.cc:261] starting server on port 18820
I0906 14:58:09.312524988  121913 server_builder.cc:270]      Synchronous server. Num CQs: 1, Min pollers: 1, Max Pollers: 2, CQ timeout (msec): 10000
I0906 14:58:09.312872334  121884 client_lb_end2end_test.cc:269] server startup complete
I0906 14:58:09.312995696  121884 client_lb_end2end_test.cc:577] Force subchannel creation: 1
I0906 14:58:09.313117937  121884 pick_first.cc:159]          Pick First 0x4efc60 created.
I0906 14:58:09.313129363  121884 pick_first.cc:356]          Pick First 0x4efc60 received update with 3 addresses
I0906 14:58:09.313137230  121884 subchannel_list.h:488]      [pick_first 0x4efc60] Creating subchannel list 0x4ebd80 for 3 subchannels
I0906 14:58:09.313177742  121884 subchannel_list.h:528]      [pick_first 0x4efc60] subchannel list 0x4ebd80 index 0: Created subchannel 0x4ec2f0 for address uri ipv4:127.0.0.1:18443
I0906 14:58:09.313212535  121884 subchannel_list.h:528]      [pick_first 0x4efc60] subchannel list 0x4ebd80 index 1: Created subchannel 0x4ed060 for address uri ipv4:127.0.0.1:22478
I0906 14:58:09.313249035  121884 subchannel_list.h:528]      [pick_first 0x4efc60] subchannel list 0x4ebd80 index 2: Created subchannel 0x4f0c10 for address uri ipv4:127.0.0.1:18820

```