### PR TITLE
Ruby: remove duplicated `Unimplemented` error definition

### DIFF
--- a/src/ruby/lib/grpc/errors.rb
+++ b/src/ruby/lib/grpc/errors.rb
@@ -68,7 +68,6 @@ module GRPC
       codes[OUT_OF_RANGE] = OutOfRange
       codes[UNIMPLEMENTED] = Unimplemented
       codes[INTERNAL] = Internal
-      codes[UNIMPLEMENTED] = Unimplemented
       codes[UNAVAILABLE] = Unavailable
       codes[DATA_LOSS] = DataLoss
 


### PR DESCRIPTION
Fix these duplicated error definitions. What do you think?
- https://github.com/grpc/grpc/blob/c02e39d14cf20a39a0c2054d968f5833aff2f7fd/src/ruby/lib/grpc/errors.rb#L69
- https://github.com/grpc/grpc/blob/c02e39d14cf20a39a0c2054d968f5833aff2f7fd/src/ruby/lib/grpc/errors.rb#L71