### PR TITLE
C#: Use more precise term "consistency" rather than "sanity"

### DIFF
--- a/src/csharp/Grpc.Core.Tests/ConsistencyTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ConsistencyTest.cs
@@ -28,9 +28,9 @@ using NUnit.Framework;
 
 namespace Grpc.Core.Tests
 {
-    public class SanityTest
+    public class ConsistencyTest
     {
-        // TODO: make sanity test work for CoreCLR as well
+        // TODO: make consistency test work for CoreCLR as well
 #if !NETCOREAPP1_0
         /// <summary>
         /// Because we depend on a native library, sometimes when things go wrong, the

--- a/src/csharp/tests.json
+++ b/src/csharp/tests.json
@@ -30,7 +30,7 @@
     "Grpc.Core.Tests.PerformanceTest",
     "Grpc.Core.Tests.PInvokeTest",
     "Grpc.Core.Tests.ResponseHeadersTest",
-    "Grpc.Core.Tests.SanityTest",
+    "Grpc.Core.Tests.ConsistencyTest",
     "Grpc.Core.Tests.ServerTest",
     "Grpc.Core.Tests.ShutdownHookClientTest",
     "Grpc.Core.Tests.ShutdownHookPendingCallTest",


### PR DESCRIPTION
Relates to #16595 