### PR TITLE
Add Check on Server for Channelz Accessor

### DIFF
--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -1500,5 +1500,8 @@ int grpc_server_has_open_connections(grpc_server* server) {
 
 grpc_core::channelz::ServerNode* grpc_server_get_channelz_node(
     grpc_server* server) {
+  if (server == nullptr) {
+    return nullptr;
+  }
   return server->channelz_server.get();
 }


### PR DESCRIPTION
args->server can be nullptr in the call constructor, so we must check for that before accessing call's server backpointer