### PR TITLE
Remove unnecessary working state on c-ares event driver

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h
@@ -28,10 +28,12 @@
 
 typedef struct grpc_ares_ev_driver grpc_ares_ev_driver;
 
-/* Start \a ev_driver. It will keep working until all IO on its ares_channel is
-   done, or grpc_ares_ev_driver_destroy() is called. It may notify the callbacks
-   bound to its ares_channel when necessary. */
-void grpc_ares_ev_driver_start_locked(grpc_ares_ev_driver* ev_driver);
+/* Examine the file descriptors of interest to the \a ev_driver and check if we
+ * should watch, shutdown, or destroy any of them. IO work started here
+ * will continue until all IO on this ares_channel is done due to completion
+ * or cancellation. The \a ev_driver may notify the callbacks bound to its
+ * ares_channel when necessary. */
+void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver);
 
 /* Returns the ares_channel owned by \a ev_driver. To bind a c-ares query to
    \a ev_driver, use the ares_channel owned by \a ev_driver as the arg of the

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -292,7 +292,7 @@ static void on_srv_query_done_locked(void* arg, int status, int timeouts,
             r, srv_it->host, htons(srv_it->port), true /* is_balancer */);
         ares_gethostbyname(*channel, hr->host, AF_INET,
                            on_hostbyname_done_locked, hr);
-        grpc_ares_ev_driver_start_locked(r->ev_driver);
+        grpc_ares_notify_on_event_locked(r->ev_driver);
       }
     }
     if (reply != nullptr) {
@@ -480,7 +480,7 @@ static grpc_ares_request* grpc_dns_lookup_ares_locked_impl(
                 r);
     gpr_free(config_name);
   }
-  grpc_ares_ev_driver_start_locked(r->ev_driver);
+  grpc_ares_notify_on_event_locked(r->ev_driver);
   grpc_ares_request_unref_locked(r);
   gpr_free(host);
   gpr_free(port);


### PR DESCRIPTION
The `working` variable on the c-ares event driver object is used to decide whether or not a particular call to `grpc_ares_ev_driver_start_locked` should make a pass through the c-ares channel file descriptors in `grpc_ares_notify_on_event_locked`. This seems unnecessary, because it's safe to make multiple calls through `grpc_ares_notify_on_event_locked`.

Overall this looks like it can be removed/simplified.