### PR TITLE
fix inverted logic check for call_creds

### DIFF
--- a/test/cpp/util/cli_credentials.cc
+++ b/test/cpp/util/cli_credentials.cc
@@ -118,7 +118,7 @@ std::shared_ptr<grpc::CallCredentials> CliCredentials::GetCallCredentials()
   if (IsAccessToken(FLAGS_call_creds)) {
     return grpc::AccessTokenCredentials(AccessToken(FLAGS_call_creds));
   }
-  if (FLAGS_call_creds.compare("none") != 0) {
+  if (FLAGS_call_creds.compare("none") == 0) {
     // Nothing to do; creds, if any, are baked into the channel.
     return std::shared_ptr<grpc::CallCredentials>();
   }


### PR DESCRIPTION
The intention is surely to compare if the user specified the default value "none".
Without this fix, the default of "none" is considered an erroneous value:

```
$ grpc_cli ls host:80
--call_creds=none invalid; must be none or access_token=<token>.
$ grpc_cli ls --call_creds=none host:80
--call_creds=none invalid; must be none or access_token=<token>.
Received an error when querying services endpoint.
```