### PR TITLE
Add benchmarks for on_initial_header

### DIFF
--- a/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
@@ -458,9 +458,8 @@ static void BM_HpackParserParseHeader(benchmark::State& state) {
   grpc_chttp2_hpack_parser p;
   grpc_chttp2_hpack_parser_init(&p);
   const int kArenaSize = 4096 * 4096;
-  gpr_arena* arena = gpr_arena_create(kArenaSize);
+  p.on_header_user_data = gpr_arena_create(kArenaSize);
   p.on_header = OnHeader;
-  p.on_header_user_data = arena;
   for (auto slice : init_slices) {
     GPR_ASSERT(GRPC_ERROR_NONE == grpc_chttp2_hpack_parser_parse(&p, slice));
   }
@@ -471,12 +470,12 @@ static void BM_HpackParserParseHeader(benchmark::State& state) {
     grpc_core::ExecCtx::Get()->Flush();
     // Recreate arena every 4k iterations to avoid oom
     if (0 == (state.iterations() & 0xfff)) {
-      gpr_arena_destroy(arena);
-      arena = gpr_arena_create(kArenaSize);
+      gpr_arena_destroy((gpr_arena*)p.on_header_user_data);
+      p.on_header_user_data = gpr_arena_create(kArenaSize);
     }
   }
   // Clean up
-  gpr_arena_destroy(arena);
+  gpr_arena_destroy((gpr_arena*)p.on_header_user_data);
   for (auto slice : init_slices) grpc_slice_unref(slice);
   for (auto slice : benchmark_slices) grpc_slice_unref(slice);
   grpc_chttp2_hpack_parser_destroy(&p);

--- a/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
@@ -822,6 +822,7 @@ static void OnInitialHeader(void* user_data, grpc_mdelem md) {
       GPR_ASSERT(0);
     }
   }
+  grpc_chttp2_incoming_metadata_buffer_destroy(&buffer);
 }
 
 // Benchmark timeout handling

--- a/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
@@ -475,6 +475,8 @@ static void BM_HpackParserParseHeader(benchmark::State& state) {
       arena = gpr_arena_create(kArenaSize);
     }
   }
+  // Clean up
+  gpr_arena_destroy(arena);
   for (auto slice : init_slices) grpc_slice_unref(slice);
   for (auto slice : benchmark_slices) grpc_slice_unref(slice);
   grpc_chttp2_hpack_parser_destroy(&p);

--- a/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
@@ -457,7 +457,7 @@ static void BM_HpackParserParseHeader(benchmark::State& state) {
   std::vector<grpc_slice> benchmark_slices = Fixture::GetBenchmarkSlices();
   grpc_chttp2_hpack_parser p;
   grpc_chttp2_hpack_parser_init(&p);
-  const int kArenaSize = 4096;
+  const int kArenaSize = 4096 * 4096;
   gpr_arena* arena = gpr_arena_create(kArenaSize);
   p.on_header = OnHeader;
   p.on_header_user_data = arena;
@@ -469,8 +469,8 @@ static void BM_HpackParserParseHeader(benchmark::State& state) {
       GPR_ASSERT(GRPC_ERROR_NONE == grpc_chttp2_hpack_parser_parse(&p, slice));
     }
     grpc_core::ExecCtx::Get()->Flush();
-    // recreate arena every 64k iterations to avoid oom
-    if (0 == (state.iterations() & 0xffff)) {
+    // Recreate arena every 4k iterations to avoid oom
+    if (0 == (state.iterations() & 0xfff)) {
       gpr_arena_destroy(arena);
       arena = gpr_arena_create(kArenaSize);
     }


### PR DESCRIPTION
Currently, the on_initial_header function is not microbenchmarked in the hpack benchmarks. This is problematic because other tools have shown on_initial_header has significant overhead on the hpack parse path and we need these numbers.

In the long run, it would be better to properly mock out the transport so we can directly call the on_initial_header function instead of doing the copy and paste thing that I did. I will take this as an action item for next quarter. For now, this change is better than not having this code path microbenchmarked at all (and note that the existing microbenchmark called OnHeaderNew was a copy paste thing, so this is certainly not worse than the existing microbenchmark).

This PR adds new hpack benchmarks to benchmark on_initial_header and renames an existing benchmark, OnHeaderNew, to a more representative name, OnHeaderTimeout. The overhead of re-creating the arena every 4000 iterations adds a constant ~200ns to each HpackParserParseHeader benchmark.