### PR TITLE
Various allocation optimizations

### DIFF
--- a/src/csharp/Grpc.Core/Internal/MarshalUtils.cs
+++ b/src/csharp/Grpc.Core/Internal/MarshalUtils.cs
@@ -35,6 +35,9 @@ namespace Grpc.Core.Internal
         /// </summary>
         public static string PtrToStringUTF8(IntPtr ptr, int len)
         {
+            if (len == 0)
+                return "";
+
             var bytes = new byte[len];
             Marshal.Copy(ptr, bytes, 0, len);
             return EncodingUTF8.GetString(bytes);

--- a/src/csharp/Grpc.Core/Metadata.cs
+++ b/src/csharp/Grpc.Core/Metadata.cs
@@ -225,8 +225,6 @@ namespace Grpc.Core
         /// </summary>
         public class Entry
         {
-            private static readonly Regex ValidKeyRegex = new Regex("^[.a-z0-9_-]+$");
-
             readonly string key;
             readonly string value;
             readonly byte[] valueBytes;
@@ -358,10 +356,39 @@ namespace Grpc.Core
 
             private static string NormalizeKey(string key)
             {
-                var normalized = GrpcPreconditions.CheckNotNull(key, "key").ToLowerInvariant();
-                GrpcPreconditions.CheckArgument(ValidKeyRegex.IsMatch(normalized), 
+                GrpcPreconditions.CheckNotNull(key, "key");
+
+                GrpcPreconditions.CheckArgument(IsValidKey(key, out bool isLowercase), 
                     "Metadata entry key not valid. Keys can only contain lowercase alphanumeric characters, underscores, hyphens and dots.");
-                return normalized;
+                if (isLowercase)
+                    return key;
+                
+                return key.ToLowerInvariant();
+            }
+
+            private static bool IsValidKey(string input, out bool isLowercase)
+            {
+                isLowercase = true;
+                for (int i = 0; i < input.Length; i++)
+                {
+                    char c = input[i];
+                    if ('a' <= c && c <= 'z' ||
+                        '0' <= c && c <= '9' ||
+                        c == '.' ||
+                        c == '_' || 
+                        c == '-' )
+                        continue;
+
+                    if ('A' <= c && c <= 'Z')
+                    {
+                        isLowercase = false;
+                        continue;
+                    }
+
+                    return false;
+                }
+
+                return true;
             }
 
             /// <summary>


### PR DESCRIPTION
These are 3 independent optimizations to avoid various (client-side) allocations I found during profiling.

The first two commits are purely to avoid allocations, the third one optimizes the Metadata.Entry check and normalization by using a simple loop and char comparison instead of the Regex. It also avoids a string allocation if the input is already lowercase (which should be the common case). The benchmark code for this change can be found here: https://gist.github.com/szehetner/c2044f703783bc7a19706cf7ead5805d

Results:
```
BenchmarkDotNet=v0.10.14, OS=Windows 10.0.16299.611 (1709/FallCreatorsUpdate/Redstone3)
Intel Xeon CPU E5-1620 v2 3.70GHz, 1 CPU, 8 logical and 4 physical cores
Frequency=3613277 Hz, Resolution=276.7571 ns, Timer=TSC
  [Host]     : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3132.0
  DefaultJob : .NET Framework 4.7.1 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.3132.0


         Method | InputValue |      Mean |     Error |     StdDev | Scaled |  Gen 0 | Allocated |
--------------- |----------- |----------:|----------:|-----------:|-------:|-------:|----------:|
        ToLower | HeaderName | 474.05 ns | 5.5187 ns |  4.8922 ns |   1.00 | 0.0086 |      48 B |
 ToLowerNoRegex | HeaderName |  94.15 ns | 1.7107 ns |  1.5165 ns |   0.20 | 0.0091 |      48 B |
                |            |           |           |            |        |        |           |
        ToLower | headername | 482.84 ns | 9.4752 ns | 11.6364 ns |   1.00 | 0.0086 |      48 B |
 ToLowerNoRegex | headername |  15.38 ns | 0.2342 ns |  0.2191 ns |   0.03 |      - |       0 B |
```