### PR TITLE
Work around nuget restore flake in C# distrib tests

### DIFF
--- a/test/distrib/csharp/run_distrib_test.sh
+++ b/test/distrib/csharp/run_distrib_test.sh
@@ -21,7 +21,8 @@ unzip -o "$EXTERNAL_GIT_ROOT/input_artifacts/csharp_nugets_windows_dotnetcli.zip
 
 ./update_version.sh auto
 
-nuget restore
+# Retry "nuget restore" to work around https://github.com/grpc/grpc/issues/16312
+nuget restore || nuget restore || nuget restore
 
 xbuild DistribTest.sln
 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/16312.