### PR TITLE
EXPERIMENTAL: Catch exceptions in user callbacks

### DIFF
--- a/include/grpcpp/impl/codegen/callback_common.h
+++ b/include/grpcpp/impl/codegen/callback_common.h
@@ -35,6 +35,10 @@ class CQCallbackInterface;
 namespace grpc {
 namespace internal {
 
+// The contract on these tags is that they are single-shot. They must be
+// constructed and then fired at exactly one point. There is no expectation
+// that they can be reused without reconstruction.
+
 class CallbackWithStatusTag {
  public:
   // always allocated against a call arena, no memory free required


### PR DESCRIPTION
Fixes #16607 

Don't let a user callback cause the library to crash

