### PR TITLE
add ref count to alts shared resource.

### DIFF
--- a/src/core/lib/security/credentials/alts/alts_credentials.cc
+++ b/src/core/lib/security/credentials/alts/alts_credentials.cc
@@ -29,6 +29,7 @@
 
 #include "src/core/lib/security/credentials/alts/check_gcp_environment.h"
 #include "src/core/lib/security/security_connector/alts_security_connector.h"
+#include "src/core/tsi/alts_transport_security.h"
 
 #define GRPC_CREDENTIALS_TYPE_ALTS "Alts"
 #define GRPC_ALTS_HANDSHAKER_SERVICE_URL "metadata.google.internal:8080"
@@ -37,6 +38,7 @@ static void alts_credentials_destruct(grpc_channel_credentials* creds) {
   grpc_alts_credentials* alts_creds =
       reinterpret_cast<grpc_alts_credentials*>(creds);
   grpc_alts_credentials_options_destroy(alts_creds->options);
+  grpc_tsi_g_alts_resource_unref();
   gpr_free(alts_creds->handshaker_service_url);
 }
 
@@ -44,6 +46,7 @@ static void alts_server_credentials_destruct(grpc_server_credentials* creds) {
   grpc_alts_server_credentials* alts_creds =
       reinterpret_cast<grpc_alts_server_credentials*>(creds);
   grpc_alts_credentials_options_destroy(alts_creds->options);
+  grpc_tsi_g_alts_resource_unref();
   gpr_free(alts_creds->handshaker_service_url);
 }
 
@@ -84,6 +87,7 @@ grpc_channel_credentials* grpc_alts_credentials_create_customized(
   creds->base.type = GRPC_CREDENTIALS_TYPE_ALTS;
   creds->base.vtable = &alts_credentials_vtable;
   gpr_ref_init(&creds->base.refcount, 1);
+  grpc_tsi_g_alts_resource_ref();
   return &creds->base;
 }
 
@@ -103,6 +107,7 @@ grpc_server_credentials* grpc_alts_server_credentials_create_customized(
   creds->base.type = GRPC_CREDENTIALS_TYPE_ALTS;
   creds->base.vtable = &alts_server_credentials_vtable;
   gpr_ref_init(&creds->base.refcount, 1);
+  grpc_tsi_g_alts_resource_ref();
   return &creds->base;
 }
 

--- a/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
+++ b/src/core/tsi/alts/handshaker/alts_tsi_handshaker.cc
@@ -334,7 +334,6 @@ static void init_shared_resources(const char* handshaker_service_url) {
   GPR_ASSERT(handshaker_service_url != nullptr);
   gpr_mu_lock(&kSharedResource->mu);
   if (kSharedResource->channel == nullptr) {
-    gpr_cv_init(&kSharedResource->cv);
     kSharedResource->channel =
         grpc_insecure_channel_create(handshaker_service_url, nullptr, nullptr);
     kSharedResource->cq = grpc_completion_queue_create_for_next(nullptr);

--- a/src/core/tsi/alts_transport_security.cc
+++ b/src/core/tsi/alts_transport_security.cc
@@ -28,19 +28,27 @@ alts_shared_resource* alts_get_shared_resource(void) {
   return &g_alts_resource;
 }
 
-static void grpc_tsi_alts_wait_for_cq_drain() {
-  gpr_mu_lock(&g_alts_resource.mu);
-  while (!g_alts_resource.is_cq_drained) {
-    gpr_cv_wait(&g_alts_resource.cv, &g_alts_resource.mu,
+static void wait_for_cq_drain() {
+  while (!g_alts_resource.is_cq_drained)
+    gpr_cv_wait(&g_alts_resource.cq_cv, &g_alts_resource.mu,
                 gpr_inf_future(GPR_CLOCK_REALTIME));
-  }
-  gpr_mu_unlock(&g_alts_resource.mu);
+}
+
+static void wait_for_resource_destroy() {
+  while (!g_alts_resource.can_destroy_resource)
+    gpr_cv_wait(&g_alts_resource.res_cv, &g_alts_resource.mu,
+                gpr_inf_future(GPR_CLOCK_REALTIME));
+}
+
+static void signal_resource_destroy_locked() {
+  g_alts_resource.can_destroy_resource = true;
+  gpr_cv_signal(&g_alts_resource.res_cv);
 }
 
 void grpc_tsi_alts_signal_for_cq_destroy() {
   gpr_mu_lock(&g_alts_resource.mu);
   g_alts_resource.is_cq_drained = true;
-  gpr_cv_signal(&g_alts_resource.cv);
+  gpr_cv_signal(&g_alts_resource.cq_cv);
   gpr_mu_unlock(&g_alts_resource.mu);
 }
 
@@ -48,18 +56,38 @@ void grpc_tsi_alts_init() {
   g_alts_resource.channel = nullptr;
   g_alts_resource.cq = nullptr;
   g_alts_resource.is_cq_drained = false;
+  g_alts_resource.can_destroy_resource = true;
   gpr_mu_init(&g_alts_resource.mu);
-  gpr_cv_init(&g_alts_resource.cv);
+  gpr_cv_init(&g_alts_resource.cq_cv);
+  gpr_cv_init(&g_alts_resource.res_cv);
+  gpr_ref_init(&g_alts_resource.refcount, 0);
 }
 
 void grpc_tsi_alts_shutdown() {
+  wait_for_resource_destroy();
   if (g_alts_resource.cq != nullptr) {
     grpc_completion_queue_shutdown(g_alts_resource.cq);
-    grpc_tsi_alts_wait_for_cq_drain();
+    wait_for_cq_drain();
     grpc_completion_queue_destroy(g_alts_resource.cq);
     grpc_channel_destroy(g_alts_resource.channel);
     g_alts_resource.thread.Join();
   }
-  gpr_cv_destroy(&g_alts_resource.cv);
+  gpr_cv_destroy(&g_alts_resource.cq_cv);
+  gpr_cv_destroy(&g_alts_resource.res_cv);
   gpr_mu_destroy(&g_alts_resource.mu);
+}
+
+void grpc_tsi_g_alts_resource_ref() {
+  gpr_mu_lock(&g_alts_resource.mu);
+  g_alts_resource.can_destroy = false;
+  gpr_ref(&g_alts_resource.refcount);
+  gpr_mu_unlock(&g_alts_resource.mu);
+}
+
+void grpc_tsi_g_alts_resource_unref() {
+  gpr_mu_lock(&g_alts_resource.mu);
+  if (gpr_unref(&g_alts_resource.refcount)) {
+    signal_resource_destroy_locked();
+  }
+  gpr_mu_unlock(&g_alts_resource.mu);
 }

--- a/src/core/tsi/alts_transport_security.cc
+++ b/src/core/tsi/alts_transport_security.cc
@@ -29,15 +29,21 @@ alts_shared_resource* alts_get_shared_resource(void) {
 }
 
 static void wait_for_cq_drain() {
-  while (!g_alts_resource.is_cq_drained)
+  gpr_mu_lock(&g_alts_resource.mu);
+  while (!g_alts_resource.is_cq_drained) {
     gpr_cv_wait(&g_alts_resource.cq_cv, &g_alts_resource.mu,
                 gpr_inf_future(GPR_CLOCK_REALTIME));
+  }
+  gpr_mu_unlock(&g_alts_resource.mu);
 }
 
 static void wait_for_resource_destroy() {
-  while (!g_alts_resource.can_destroy_resource)
+  gpr_mu_lock(&g_alts_resource.mu);
+  while (!g_alts_resource.can_destroy_resource) {
     gpr_cv_wait(&g_alts_resource.res_cv, &g_alts_resource.mu,
                 gpr_inf_future(GPR_CLOCK_REALTIME));
+  }
+  gpr_mu_unlock(&g_alts_resource.mu);
 }
 
 static void signal_resource_destroy_locked() {

--- a/src/core/tsi/alts_transport_security.cc
+++ b/src/core/tsi/alts_transport_security.cc
@@ -79,7 +79,7 @@ void grpc_tsi_alts_shutdown() {
 
 void grpc_tsi_g_alts_resource_ref() {
   gpr_mu_lock(&g_alts_resource.mu);
-  g_alts_resource.can_destroy = false;
+  g_alts_resource.can_destroy_resource = false;
   gpr_ref(&g_alts_resource.refcount);
   gpr_mu_unlock(&g_alts_resource.mu);
 }

--- a/src/core/tsi/alts_transport_security.h
+++ b/src/core/tsi/alts_transport_security.h
@@ -31,8 +31,11 @@ typedef struct alts_shared_resource {
   grpc_channel* channel;
   grpc_completion_queue* cq;
   gpr_mu mu;
-  gpr_cv cv;
+  gpr_cv cq_cv;
+  gpr_cv res_cv;
+  bool can_destroy_resource;
   bool is_cq_drained;
+  gpr_refcount refcount;
 } alts_shared_resource;
 
 /* This method returns the address of alts_shared_resource object shared by all
@@ -41,7 +44,12 @@ alts_shared_resource* alts_get_shared_resource(void);
 
 /* This method signals the thread that invokes grpc_tsi_alts_shutdown() to
  * continue with destroying the cq as a part of shutdown process. */
-
 void grpc_tsi_alts_signal_for_cq_destroy(void);
+
+/** This method add a ref to the alts_shared_resource object. */
+void grpc_tsi_g_alts_resource_ref();
+
+/** This method removes a ref from the alts_shared_resource object. */
+void grpc_tsi_g_atls_resource_unref();
 
 #endif /* GRPC_CORE_TSI_ALTS_TRANSPORT_SECURITY_H */

--- a/src/core/tsi/alts_transport_security.h
+++ b/src/core/tsi/alts_transport_security.h
@@ -50,6 +50,6 @@ void grpc_tsi_alts_signal_for_cq_destroy(void);
 void grpc_tsi_g_alts_resource_ref();
 
 /** This method removes a ref from the alts_shared_resource object. */
-void grpc_tsi_g_atls_resource_unref();
+void grpc_tsi_g_alts_resource_unref();
 
 #endif /* GRPC_CORE_TSI_ALTS_TRANSPORT_SECURITY_H */

--- a/src/core/tsi/transport_security.cc
+++ b/src/core/tsi/transport_security.cc
@@ -213,10 +213,10 @@ tsi_result tsi_handshaker_next(
 
 void tsi_handshaker_shutdown(tsi_handshaker* self) {
   if (self == nullptr || self->vtable == nullptr) return;
-  self->handshake_shutdown = true;
   if (self->vtable->shutdown != nullptr) {
     self->vtable->shutdown(self);
   }
+  self->handshake_shutdown = true;
 }
 
 void tsi_handshaker_destroy(tsi_handshaker* self) {

--- a/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
+++ b/test/core/tsi/alts/handshaker/alts_tsi_handshaker_test.cc
@@ -752,6 +752,7 @@ void check_handshaker_success() {
 int main(int argc, char** argv) {
   /* Initialization. */
   grpc_init();
+  grpc_tsi_g_alts_resource_ref();
   /* Tests. */
   check_handshaker_success();
   check_handshaker_next_invalid_input();
@@ -763,6 +764,7 @@ int main(int argc, char** argv) {
   check_handle_response_failure();
   check_handle_response_after_shutdown();
   /* Cleanup. */
+  grpc_tsi_g_alts_resource_unref();
   grpc_shutdown();
   return 0;
 }


### PR DESCRIPTION
This PR adds a ref count to ALTS shared resources, and ref (unref) it whenever creating (destroying) alts server/channel credentials. It will resolve ALTS (and google default creds) test flakiness. 

I will prepare another PR later on that removes the TSI thread from gRPC use cases.