### PR TITLE
Rename the BoringSSL framework to openssl_grpc to avoid conflict with OpenSSL

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -181,7 +181,7 @@ Pod::Spec.new do |s|
     ss.header_mappings_dir = '.'
     ss.libraries = 'z'
     ss.dependency "#{s.name}/Interface", version
-    ss.dependency 'BoringSSL-GRPC', '0.0.1'
+    ss.dependency 'BoringSSL-GRPC', '0.0.2'
     ss.dependency 'nanopb', '~> 0.3'
     ss.compiler_flags = '-DGRPC_SHADOW_BORINGSSL_SYMBOLS'
 
@@ -1307,5 +1307,6 @@ Pod::Spec.new do |s|
   s.prepare_command = <<-END_OF_COMMAND
     find src/core/ -type f ! -path '*.grpc_back' -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include "(pb(_.*)?\\.h)";#include <nanopb/\\1>;g'
     find src/core/ -type f -path '*.grpc_back' -print0 | xargs -0 rm
+    find src/core/ -type f -path '*.h' -or -path '*.cc' -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
   END_OF_COMMAND
 end

--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -1307,6 +1307,6 @@ Pod::Spec.new do |s|
   s.prepare_command = <<-END_OF_COMMAND
     find src/core/ -type f ! -path '*.grpc_back' -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include "(pb(_.*)?\\.h)";#include <nanopb/\\1>;g'
     find src/core/ -type f -path '*.grpc_back' -print0 | xargs -0 rm
-    find src/core/ -type f -path '*.h' -or -path '*.cc' -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
+    find src/core/ -type f \\( -path '*.h' -or -path '*.cc' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
   END_OF_COMMAND
 end

--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -1546,6 +1546,7 @@ Pod::Spec.new do |s|
     sed -i'.back' '/^#define \\([A-Za-z0-9_]*\\) \\1/d' include/openssl/ssl.h
     sed -i'.back' 'N;/^#define \\([A-Za-z0-9_]*\\) *\\\\\\n *\\1/d' include/openssl/ssl.h
     sed -i'.back' 's/#ifndef md5_block_data_order/#ifndef GRPC_SHADOW_md5_block_data_order/g' crypto/fipsmodule/md5/md5.c
+    find . -type f -path '*.h' -or -path '*.cc' -or -path '*.c' -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
   END_OF_COMMAND
 
   # Redefine symbols to avoid conflict when the same app also depends on OpenSSL. The list of

--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -38,7 +38,7 @@
 
 Pod::Spec.new do |s|
   s.name     = 'BoringSSL-GRPC'
-  version = '0.0.1'
+  version = '0.0.2'
   s.version  = version
   s.summary  = 'BoringSSL is a fork of OpenSSL that is designed to meet Google\'s needs.'
   # Adapted from the homepage:
@@ -81,7 +81,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
 
-  name = 'openssl'
+  name = 'openssl_grpc'
 
   # When creating a dynamic framework, name it openssl.framework instead of BoringSSL.framework.
   # This lets users write their includes like `#include <openssl/ssl.h>` as opposed to `#include

--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -1546,7 +1546,7 @@ Pod::Spec.new do |s|
     sed -i'.back' '/^#define \\([A-Za-z0-9_]*\\) \\1/d' include/openssl/ssl.h
     sed -i'.back' 'N;/^#define \\([A-Za-z0-9_]*\\) *\\\\\\n *\\1/d' include/openssl/ssl.h
     sed -i'.back' 's/#ifndef md5_block_data_order/#ifndef GRPC_SHADOW_md5_block_data_order/g' crypto/fipsmodule/md5/md5.c
-    find . -type f -path '*.h' -or -path '*.cc' -or -path '*.c' -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
+    find . -type f \\( -path '*.h' -or -path '*.cc' -or -path '*.c' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
   END_OF_COMMAND
 
   # Redefine symbols to avoid conflict when the same app also depends on OpenSSL. The list of

--- a/src/objective-c/tests/CronetUnitTests/CronetUnitTests.m
+++ b/src/objective-c/tests/CronetUnitTests/CronetUnitTests.m
@@ -39,7 +39,7 @@
 
 #import "src/core/tsi/grpc_shadow_boringssl.h"
 
-#import <openssl/ssl.h>
+#import <openssl_grpc/ssl.h>
 
 static void drain_cq(grpc_completion_queue *cq) {
   grpc_event ev;

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -223,6 +223,6 @@
     s.prepare_command = <<-END_OF_COMMAND
       find src/core/ -type f ! -path '*.grpc_back' -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include "(pb(_.*)?\\.h)";#include <nanopb/\\1>;g'
       find src/core/ -type f -path '*.grpc_back' -print0 | xargs -0 rm
-      find src/core/ -type f -path '*.h' -or -path '*.cc' -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
+      find src/core/ -type f \\( -path '*.h' -or -path '*.cc' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
     END_OF_COMMAND
   end

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -174,7 +174,7 @@
       ss.header_mappings_dir = '.'
       ss.libraries = 'z'
       ss.dependency "#{s.name}/Interface", version
-      ss.dependency 'BoringSSL-GRPC', '0.0.1'
+      ss.dependency 'BoringSSL-GRPC', '0.0.2'
       ss.dependency 'nanopb', '~> 0.3'
       ss.compiler_flags = '-DGRPC_SHADOW_BORINGSSL_SYMBOLS'
 
@@ -223,5 +223,6 @@
     s.prepare_command = <<-END_OF_COMMAND
       find src/core/ -type f ! -path '*.grpc_back' -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include "(pb(_.*)?\\.h)";#include <nanopb/\\1>;g'
       find src/core/ -type f -path '*.grpc_back' -print0 | xargs -0 rm
+      find src/core/ -type f -path '*.h' -or -path '*.cc' -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
     END_OF_COMMAND
   end

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -1551,7 +1551,7 @@
       sed -i'.back' '/^#define \\([A-Za-z0-9_]*\\) \\1/d' include/openssl/ssl.h
       sed -i'.back' 'N;/^#define \\([A-Za-z0-9_]*\\) *\\\\\\n *\\1/d' include/openssl/ssl.h
       sed -i'.back' 's/#ifndef md5_block_data_order/#ifndef GRPC_SHADOW_md5_block_data_order/g' crypto/fipsmodule/md5/md5.c
-      find . -type f -path '*.h' -or -path '*.cc' -or -path '*.c' -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
+      find . -type f \\( -path '*.h' -or -path '*.cc' -or -path '*.c' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
     END_OF_COMMAND
 
     # Redefine symbols to avoid conflict when the same app also depends on OpenSSL. The list of

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -43,7 +43,7 @@
 
   Pod::Spec.new do |s|
     s.name     = 'BoringSSL-GRPC'
-    version = '0.0.1'
+    version = '0.0.2'
     s.version  = version
     s.summary  = 'BoringSSL is a fork of OpenSSL that is designed to meet Google\'s needs.'
     # Adapted from the homepage:
@@ -86,7 +86,7 @@
     s.ios.deployment_target = '5.0'
     s.osx.deployment_target = '10.7'
 
-    name = 'openssl'
+    name = 'openssl_grpc'
 
     # When creating a dynamic framework, name it openssl.framework instead of BoringSSL.framework.
     # This lets users write their includes like `#include <openssl/ssl.h>` as opposed to `#include

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -1551,6 +1551,7 @@
       sed -i'.back' '/^#define \\([A-Za-z0-9_]*\\) \\1/d' include/openssl/ssl.h
       sed -i'.back' 'N;/^#define \\([A-Za-z0-9_]*\\) *\\\\\\n *\\1/d' include/openssl/ssl.h
       sed -i'.back' 's/#ifndef md5_block_data_order/#ifndef GRPC_SHADOW_md5_block_data_order/g' crypto/fipsmodule/md5/md5.c
+      find . -type f -path '*.h' -or -path '*.cc' -or -path '*.c' -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
     END_OF_COMMAND
 
     # Redefine symbols to avoid conflict when the same app also depends on OpenSSL. The list of


### PR DESCRIPTION
We renamed all the BoringSSL symbols but did not rename the framework or library's name. If a user write `#include <openssl/ssl.h>` they are still referring to the header of the internal version of BoringSSL.

cc: @srini100 