### PR TITLE
Remove unnecessary callout_is_default checks

### DIFF
--- a/src/core/lib/transport/metadata_batch.cc
+++ b/src/core/lib/transport/metadata_batch.cc
@@ -105,7 +105,7 @@ static grpc_error* maybe_link_callout(grpc_metadata_batch* batch,
     return GRPC_ERROR_NONE;
   }
   if (batch->idx.array[idx] == nullptr) {
-    if (grpc_static_callout_is_default[idx]) ++batch->list.default_count;
+    ++batch->list.default_count;
     batch->idx.array[idx] = storage;
     return GRPC_ERROR_NONE;
   }
@@ -121,7 +121,7 @@ static void maybe_unlink_callout(grpc_metadata_batch* batch,
   if (idx == GRPC_BATCH_CALLOUTS_COUNT) {
     return;
   }
-  if (grpc_static_callout_is_default[idx]) --batch->list.default_count;
+  --batch->list.default_count;
   GPR_ASSERT(batch->idx.array[idx] != nullptr);
   batch->idx.array[idx] = nullptr;
 }

--- a/src/core/lib/transport/static_metadata.cc
+++ b/src/core/lib/transport/static_metadata.cc
@@ -24,8 +24,6 @@
  * an explanation of what's going on.
  */
 
-#include <grpc/support/port_platform.h>
-
 #include "src/core/lib/transport/static_metadata.h"
 
 #include "src/core/lib/slice/slice_internal.h"
@@ -568,33 +566,6 @@ grpc_mdelem_data grpc_static_mdelem_table[GRPC_STATIC_MDELEM_COUNT] = {
     {{&grpc_static_metadata_refcounts[16], {{g_bytes + 186, 15}}},
      {&grpc_static_metadata_refcounts[102], {{g_bytes + 1101, 13}}}},
 };
-bool grpc_static_callout_is_default[GRPC_BATCH_CALLOUTS_COUNT] = {
-    true,  // :path
-    true,  // :method
-    true,  // :status
-    true,  // :authority
-    true,  // :scheme
-    true,  // te
-    true,  // grpc-message
-    true,  // grpc-status
-    true,  // grpc-payload-bin
-    true,  // grpc-encoding
-    true,  // grpc-accept-encoding
-    true,  // grpc-server-stats-bin
-    true,  // grpc-tags-bin
-    true,  // grpc-trace-bin
-    true,  // content-type
-    true,  // content-encoding
-    true,  // accept-encoding
-    true,  // grpc-internal-encoding-request
-    true,  // grpc-internal-stream-encoding-request
-    true,  // user-agent
-    true,  // host
-    true,  // lb-token
-    true,  // grpc-previous-rpc-attempts
-    true,  // grpc-retry-pushback-ms
-};
-
 const uint8_t grpc_static_accept_encoding_metadata[8] = {0,  76, 77, 78,
                                                          79, 80, 81, 82};
 

--- a/src/core/lib/transport/static_metadata.cc
+++ b/src/core/lib/transport/static_metadata.cc
@@ -24,6 +24,8 @@
  * an explanation of what's going on.
  */
 
+#include <grpc/support/port_platform.h>
+
 #include "src/core/lib/transport/static_metadata.h"
 
 #include "src/core/lib/slice/slice_internal.h"

--- a/src/core/lib/transport/static_metadata.h
+++ b/src/core/lib/transport/static_metadata.h
@@ -27,8 +27,6 @@
 #ifndef GRPC_CORE_LIB_TRANSPORT_STATIC_METADATA_H
 #define GRPC_CORE_LIB_TRANSPORT_STATIC_METADATA_H
 
-#include <grpc/support/port_platform.h>
-
 #include "src/core/lib/transport/metadata.h"
 
 #define GRPC_STATIC_MDSTR_COUNT 105
@@ -586,8 +584,6 @@ typedef union {
              GRPC_STATIC_METADATA_INDEX((slice)), 0,    \
              GRPC_BATCH_CALLOUTS_COUNT)                 \
        : GRPC_BATCH_CALLOUTS_COUNT)
-
-extern bool grpc_static_callout_is_default[GRPC_BATCH_CALLOUTS_COUNT];
 
 extern const uint8_t grpc_static_accept_encoding_metadata[8];
 #define GRPC_MDELEM_ACCEPT_ENCODING_FOR_ALGORITHMS(algs)                       \

--- a/src/core/lib/transport/static_metadata.h
+++ b/src/core/lib/transport/static_metadata.h
@@ -27,6 +27,8 @@
 #ifndef GRPC_CORE_LIB_TRANSPORT_STATIC_METADATA_H
 #define GRPC_CORE_LIB_TRANSPORT_STATIC_METADATA_H
 
+#include <grpc/support/port_platform.h>
+
 #include "src/core/lib/transport/metadata.h"
 
 #define GRPC_STATIC_MDSTR_COUNT 105

--- a/tools/codegen/core/gen_static_metadata.py
+++ b/tools/codegen/core/gen_static_metadata.py
@@ -142,35 +142,34 @@ CONFIG = [
     ('www-authenticate', ''),
 ]
 
-# Entries marked with is_default=True are ignored when counting
-# non-default initial metadata that prevents the chttp2 server from
-# sending a Trailers-Only response.
+# All entries here are ignored when counting non-default initial metadata that
+# prevents the chttp2 server from sending a Trailers-Only response.
 METADATA_BATCH_CALLOUTS = [
-    # (name, is_default)
-    (':path', True),
-    (':method', True),
-    (':status', True),
-    (':authority', True),
-    (':scheme', True),
-    ('te', True),
-    ('grpc-message', True),
-    ('grpc-status', True),
-    ('grpc-payload-bin', True),
-    ('grpc-encoding', True),
-    ('grpc-accept-encoding', True),
-    ('grpc-server-stats-bin', True),
-    ('grpc-tags-bin', True),
-    ('grpc-trace-bin', True),
-    ('content-type', True),
-    ('content-encoding', True),
-    ('accept-encoding', True),
-    ('grpc-internal-encoding-request', True),
-    ('grpc-internal-stream-encoding-request', True),
-    ('user-agent', True),
-    ('host', True),
-    ('lb-token', True),
-    ('grpc-previous-rpc-attempts', True),
-    ('grpc-retry-pushback-ms', True),
+    # (name)
+    (':path'),
+    (':method'),
+    (':status'),
+    (':authority'),
+    (':scheme'),
+    ('te'),
+    ('grpc-message'),
+    ('grpc-status'),
+    ('grpc-payload-bin'),
+    ('grpc-encoding'),
+    ('grpc-accept-encoding'),
+    ('grpc-server-stats-bin'),
+    ('grpc-tags-bin'),
+    ('grpc-trace-bin'),
+    ('content-type'),
+    ('content-encoding'),
+    ('accept-encoding'),
+    ('grpc-internal-encoding-request'),
+    ('grpc-internal-stream-encoding-request'),
+    ('user-agent'),
+    ('host'),
+    ('lb-token'),
+    ('grpc-previous-rpc-attempts'),
+    ('grpc-retry-pushback-ms'),
 ]
 
 COMPRESSION_ALGORITHMS = [
@@ -252,7 +251,7 @@ all_elems = list()
 static_userdata = {}
 # put metadata batch callouts first, to make the check of if a static metadata
 # string is a callout trivial
-for elem, _ in METADATA_BATCH_CALLOUTS:
+for elem in METADATA_BATCH_CALLOUTS:
     if elem not in all_strs:
         all_strs.append(elem)
 for elem in CONFIG:
@@ -388,7 +387,7 @@ def slice_def(i):
 
 
 # validate configuration
-for elem, _ in METADATA_BATCH_CALLOUTS:
+for elem in METADATA_BATCH_CALLOUTS:
     assert elem in all_strs
 
 print >> H, '#define GRPC_STATIC_MDSTR_COUNT %d' % len(all_strs)
@@ -551,7 +550,7 @@ for a, b in all_elems:
 print >> C, '};'
 
 print >> H, 'typedef enum {'
-for elem, _ in METADATA_BATCH_CALLOUTS:
+for elem in METADATA_BATCH_CALLOUTS:
     print >> H, '  %s,' % mangle(elem, 'batch').upper()
 print >> H, '  GRPC_BATCH_CALLOUTS_COUNT'
 print >> H, '} grpc_metadata_batch_callouts_index;'
@@ -559,7 +558,7 @@ print >> H
 print >> H, 'typedef union {'
 print >> H, '  struct grpc_linked_mdelem *array[GRPC_BATCH_CALLOUTS_COUNT];'
 print >> H, '  struct {'
-for elem, _ in METADATA_BATCH_CALLOUTS:
+for elem in METADATA_BATCH_CALLOUTS:
     print >> H, '  struct grpc_linked_mdelem *%s;' % mangle(elem, '').lower()
 print >> H, '  } named;'
 print >> H, '} grpc_metadata_batch_callouts;'
@@ -567,14 +566,6 @@ print >> H
 print >> H, '#define GRPC_BATCH_INDEX_OF(slice) \\'
 print >> H, '  (GRPC_IS_STATIC_METADATA_STRING((slice)) ? (grpc_metadata_batch_callouts_index)GPR_CLAMP(GRPC_STATIC_METADATA_INDEX((slice)), 0, GRPC_BATCH_CALLOUTS_COUNT) : GRPC_BATCH_CALLOUTS_COUNT)'
 print >> H
-print >> H, ('extern bool grpc_static_callout_is_default['
-             'GRPC_BATCH_CALLOUTS_COUNT];')
-print >> H
-print >> C, 'bool grpc_static_callout_is_default[GRPC_BATCH_CALLOUTS_COUNT] = {'
-for elem, is_default in METADATA_BATCH_CALLOUTS:
-    print >> C, '  %s, // %s' % (str(is_default).lower(), elem)
-print >> C, '};'
-print >> C
 
 print >> H, 'extern const uint8_t grpc_static_accept_encoding_metadata[%d];' % (
     1 << len(COMPRESSION_ALGORITHMS))


### PR DESCRIPTION
Since all the callouts are considered default headers, then there is no point in doing the `grpc_static_callout_is_default` check. Removing this should save some per-RPC performance.