### PR TITLE
fix issue 16684 - wrong number of arguments to request_response

### DIFF
--- a/src/ruby/lib/grpc/generic/service.rb
+++ b/src/ruby/lib/grpc/generic/service.rb
@@ -167,7 +167,8 @@ module GRPC
             if desc.request_response?
               define_method(mth_name) do |req, metadata = {}|
                 GRPC.logger.debug("calling #{@host}:#{route}")
-                request_response(route, req, marshal, unmarshal, metadata)
+                request_response(
+                  route, req, marshal, unmarshal, metadata: metadata)
               end
             elsif desc.client_streamer?
               define_method(mth_name) do |reqs, metadata = {}|


### PR DESCRIPTION
This appears to fix the specific issue I was seeing.

It seems likely that this is only one of a category of bugs, which this patch does not completely address.