### PR TITLE
Avoid extra branches in grpc_error_get_(str|int).

### DIFF
--- a/src/core/lib/iomgr/error.cc
+++ b/src/core/lib/iomgr/error.cc
@@ -454,7 +454,7 @@ typedef struct {
   grpc_status_code code;
   const char* msg;
 } special_error_status_map;
-static special_error_status_map error_status_map[] = {
+static const special_error_status_map error_status_map[] = {
     {GRPC_ERROR_NONE, GRPC_STATUS_OK, ""},
     {GRPC_ERROR_CANCELLED, GRPC_STATUS_CANCELLED, "Cancelled"},
     {GRPC_ERROR_OOM, GRPC_STATUS_RESOURCE_EXHAUSTED, "Out of memory"},
@@ -463,15 +463,13 @@ static special_error_status_map error_status_map[] = {
 bool grpc_error_get_int(grpc_error* err, grpc_error_ints which, intptr_t* p) {
   GPR_TIMER_SCOPE("grpc_error_get_int", 0);
   if (grpc_error_is_special(err)) {
-    if (which == GRPC_ERROR_INT_GRPC_STATUS) {
-      for (size_t i = 0; i < GPR_ARRAY_SIZE(error_status_map); i++) {
-        if (error_status_map[i].error == err) {
-          if (p != nullptr) *p = error_status_map[i].code;
-          return true;
-        }
+    for (size_t i = 0; i < GPR_ARRAY_SIZE(error_status_map); i++) {
+      if (error_status_map[i].error == err) {
+        if (which != GRPC_ERROR_INT_GRPC_STATUS) return false;
+        if (p != nullptr) *p = error_status_map[i].code;
+        return true;
       }
     }
-    return false;
   }
   uint8_t slot = err->ints[which];
   if (slot != UINT8_MAX) {
@@ -492,15 +490,13 @@ grpc_error* grpc_error_set_str(grpc_error* src, grpc_error_strs which,
 bool grpc_error_get_str(grpc_error* err, grpc_error_strs which,
                         grpc_slice* str) {
   if (grpc_error_is_special(err)) {
-    if (which == GRPC_ERROR_STR_GRPC_MESSAGE) {
-      for (size_t i = 0; i < GPR_ARRAY_SIZE(error_status_map); i++) {
-        if (error_status_map[i].error == err) {
-          *str = grpc_slice_from_static_string(error_status_map[i].msg);
-          return true;
-        }
+    for (size_t i = 0; i < GPR_ARRAY_SIZE(error_status_map); i++) {
+      if (error_status_map[i].error == err) {
+        if (which != GRPC_ERROR_STR_GRPC_MESSAGE) return false;
+        *str = grpc_slice_from_static_string(error_status_map[i].msg);
+        return true;
       }
     }
-    return false;
   }
   uint8_t slot = err->strs[which];
   if (slot != UINT8_MAX) {


### PR DESCRIPTION
Moving the check for "which" inside the for loop, will let the compiler
unroll the loop and merge it with the branches grpc_error_is_especial.

This is visible in the following godbolts:
Before: https://godbolt.org/z/Nqujh1
After:  https://godbolt.org/z/fA2PX-