### PR TITLE
Avoid allocating temporary strings in Channel::CreateCall().

### DIFF
--- a/include/grpcpp/impl/codegen/slice.h
+++ b/include/grpcpp/impl/codegen/slice.h
@@ -138,10 +138,6 @@ inline grpc_slice SliceFromCopiedString(const grpc::string& str) {
                                                                  str.length());
 }
 
-inline grpc_slice SliceFromArray(const char* arr, size_t len) {
-  return g_core_codegen_interface->grpc_slice_from_copied_buffer(arr, len);
-}
-
 }  // namespace grpc
 
 #endif  // GRPCPP_IMPL_CODEGEN_SLICE_H

--- a/include/grpcpp/impl/codegen/slice.h
+++ b/include/grpcpp/impl/codegen/slice.h
@@ -138,6 +138,10 @@ inline grpc_slice SliceFromCopiedString(const grpc::string& str) {
                                                                  str.length());
 }
 
+inline grpc_slice SliceFromArray(const char* arr, size_t len) {
+    return g_core_codegen_interface->grpc_slice_from_copied_buffer(arr, len);
+}
+
 }  // namespace grpc
 
 #endif  // GRPCPP_IMPL_CODEGEN_SLICE_H

--- a/include/grpcpp/impl/codegen/slice.h
+++ b/include/grpcpp/impl/codegen/slice.h
@@ -139,7 +139,7 @@ inline grpc_slice SliceFromCopiedString(const grpc::string& str) {
 }
 
 inline grpc_slice SliceFromArray(const char* arr, size_t len) {
-    return g_core_codegen_interface->grpc_slice_from_copied_buffer(arr, len);
+  return g_core_codegen_interface->grpc_slice_from_copied_buffer(arr, len);
 }
 
 }  // namespace grpc

--- a/src/cpp/client/channel_cc.cc
+++ b/src/cpp/client/channel_cc.cc
@@ -65,6 +65,10 @@ Channel::~Channel() {
 
 namespace {
 
+inline grpc_slice SliceFromArray(const char* arr, size_t len) {
+  return g_core_codegen_interface->grpc_slice_from_copied_buffer(arr, len);
+}
+
 grpc::string GetChannelInfoField(grpc_channel* channel,
                                  grpc_channel_info* channel_info,
                                  char*** channel_info_field) {
@@ -112,7 +116,7 @@ internal::Call Channel::CreateCall(const internal::RpcMethod& method,
         method.channel_tag(), context->raw_deadline(), nullptr);
   } else {
     const string* host_str = nullptr;
-    if (!context->authority().empty()) {
+    if (!context->authority_.empty()) {
       host_str = &context->authority_;
     } else if (!host_.empty()) {
       host_str = &host_;

--- a/src/cpp/client/channel_cc.cc
+++ b/src/cpp/client/channel_cc.cc
@@ -20,6 +20,7 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <cstring>
 #include <memory>
 #include <mutex>
 
@@ -116,10 +117,11 @@ internal::Call Channel::CreateCall(const internal::RpcMethod& method,
     } else if (!host_.empty()) {
       host_str = host_.c_str();
     }
-    grpc_slice method_slice = SliceFromCopiedString(method.name());
+    grpc_slice method_slice =
+        SliceFromArray(method.name(), strlen(method.name()));
     grpc_slice host_slice;
     if (host_str != nullptr) {
-      host_slice = SliceFromCopiedString(host_str);
+      host_slice = SliceFromArray(host_str, strlen(host_str));
     }
     c_call = grpc_channel_create_call(
         c_channel_, context->propagate_from_call_,

--- a/src/cpp/client/channel_cc.cc
+++ b/src/cpp/client/channel_cc.cc
@@ -111,17 +111,17 @@ internal::Call Channel::CreateCall(const internal::RpcMethod& method,
         context->propagation_options_.c_bitmask(), cq->cq(),
         method.channel_tag(), context->raw_deadline(), nullptr);
   } else {
-    const char* host_str = nullptr;
+    const string* host_str = nullptr;
     if (!context->authority().empty()) {
-      host_str = context->authority_.c_str();
+      host_str = &context->authority_;
     } else if (!host_.empty()) {
-      host_str = host_.c_str();
+      host_str = &host_;
     }
     grpc_slice method_slice =
         SliceFromArray(method.name(), strlen(method.name()));
     grpc_slice host_slice;
     if (host_str != nullptr) {
-      host_slice = SliceFromArray(host_str, strlen(host_str));
+      host_slice = SliceFromCopiedString(*host_str);
     }
     c_call = grpc_channel_create_call(
         c_channel_, context->propagate_from_call_,


### PR DESCRIPTION
Add `SliceFromArray()` which takes a `char*` instead of
`const string&`, to save string allocations for copying from a `char *`.

Use the new API to eliminate two string allocations and copies per call for
method and host names.

release note: no