### PR TITLE
Increase the maximum number of timer shards to 32.

### DIFF
--- a/src/core/lib/iomgr/timer_generic.cc
+++ b/src/core/lib/iomgr/timer_generic.cc
@@ -256,7 +256,7 @@ static grpc_millis compute_min_deadline(timer_shard* shard) {
 static void timer_list_init() {
   uint32_t i;
 
-  g_num_shards = GPR_MIN(1, 2 * gpr_cpu_num_cores());
+  g_num_shards = GPR_MIN(32, 2 * gpr_cpu_num_cores());
   g_shards =
       static_cast<timer_shard*>(gpr_zalloc(g_num_shards * sizeof(*g_shards)));
   g_shard_queue = static_cast<timer_shard**>(

--- a/src/core/lib/iomgr/timer_generic.cc
+++ b/src/core/lib/iomgr/timer_generic.cc
@@ -256,7 +256,7 @@ static grpc_millis compute_min_deadline(timer_shard* shard) {
 static void timer_list_init() {
   uint32_t i;
 
-  g_num_shards = GPR_MIN(32, 2 * gpr_cpu_num_cores());
+  g_num_shards = GPR_CLAMP(2 * gpr_cpu_num_cores(), 1, 32);
   g_shards =
       static_cast<timer_shard*>(gpr_zalloc(g_num_shards * sizeof(*g_shards)));
   g_shard_queue = static_cast<timer_shard**>(


### PR DESCRIPTION
Commit 82f9886e accidentally sets the maximum number of timer shards 1, from
previously 32.

We probably want to increase the max shards further.

release-note: no