### PR TITLE
Empty implementation of grpc_use_signal since no longer needed

### DIFF
--- a/src/core/lib/iomgr/ev_posix.cc
+++ b/src/core/lib/iomgr/ev_posix.cc
@@ -395,4 +395,6 @@ void grpc_pollset_set_del_fd(grpc_pollset_set* pollset_set, grpc_fd* fd) {
   g_event_engine->pollset_set_del_fd(pollset_set, fd);
 }
 
+void grpc_use_signal(int signum) {}
+
 #endif  // GRPC_POSIX_SOCKET_EV


### PR DESCRIPTION
The implementation of this function was deleted in #16679 but is technically part of the API (even though I believe that there are currently no users of it). Reintroducing it here until we go through the gRFC process and land PR #16706.
