### PR TITLE
Core infrastructure for timer manager debug

### DIFF
--- a/src/core/lib/gpr/sync_posix.cc
+++ b/src/core/lib/gpr/sync_posix.cc
@@ -33,13 +33,11 @@
 void (*g_grpc_debug_timer_manager_stats)(int64_t timer_manager_init_count,
                                          int64_t timer_manager_shutdown_count,
                                          int64_t fork_count,
-                                         int64_t timer_wait_err,
-                                         int64_t timer_wait_cv) = nullptr;
+                                         int64_t timer_wait_err) = nullptr;
 int64_t g_timer_manager_init_count = 0;
 int64_t g_timer_manager_shutdown_count = 0;
 int64_t g_fork_count = 0;
 int64_t g_timer_wait_err = 0;
-int64_t g_timer_wait_cv = 0;
 #endif  // GRPC_DEBUG_TIMER_MANAGER
 
 #ifdef GPR_LOW_LEVEL_COUNTERS
@@ -110,10 +108,9 @@ int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu, gpr_timespec abs_deadline) {
   if (!(err == 0 || err == ETIMEDOUT || err == EAGAIN)) {
     if (g_grpc_debug_timer_manager_stats) {
       g_timer_wait_err = err;
-      g_timer_wait_cv = (int64_t)cv;
-      g_grpc_debug_timer_manager_stats(
-          g_timer_manager_init_count, g_timer_manager_shutdown_count,
-          g_fork_count, g_timer_wait_err, g_timer_wait_cv);
+      g_grpc_debug_timer_manager_stats(g_timer_manager_init_count,
+                                       g_timer_manager_shutdown_count,
+                                       g_fork_count, g_timer_wait_err);
     }
     GPR_ASSERT(err == 0 || err == ETIMEDOUT || err == EAGAIN);
   }

--- a/src/core/lib/gpr/sync_posix.cc
+++ b/src/core/lib/gpr/sync_posix.cc
@@ -30,14 +30,19 @@
 // For debug of the timer manager crash only.
 // TODO (mxyan): remove after bug is fixed.
 #ifdef GRPC_DEBUG_TIMER_MANAGER
-void (*g_grpc_debug_timer_manager_stats)(int64_t timer_manager_init_count,
-                                         int64_t timer_manager_shutdown_count,
-                                         int64_t fork_count,
-                                         int64_t timer_wait_err) = nullptr;
+void (*g_grpc_debug_timer_manager_stats)(
+    int64_t timer_manager_init_count, int64_t timer_manager_shutdown_count,
+    int64_t fork_count, int64_t timer_wait_err, int64_t timer_cv_value,
+    int64_t timer_mu_value, int64_t abstime_sec_value,
+    int64_t abstime_nsec_value) = nullptr;
 int64_t g_timer_manager_init_count = 0;
 int64_t g_timer_manager_shutdown_count = 0;
 int64_t g_fork_count = 0;
 int64_t g_timer_wait_err = 0;
+int64_t g_timer_cv_value = 0;
+int64_t g_timer_mu_value = 0;
+int64_t g_abstime_sec_value = -1;
+int64_t g_abstime_nsec_value = -1;
 #endif  // GRPC_DEBUG_TIMER_MANAGER
 
 #ifdef GPR_LOW_LEVEL_COUNTERS
@@ -100,17 +105,28 @@ int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu, gpr_timespec abs_deadline) {
     abs_deadline_ts.tv_sec = static_cast<time_t>(abs_deadline.tv_sec);
     abs_deadline_ts.tv_nsec = abs_deadline.tv_nsec;
     err = pthread_cond_timedwait(cv, mu, &abs_deadline_ts);
+#ifdef GRPC_DEBUG_TIMER_MANAGER
+    // For debug of the timer manager crash only.
+    // TODO (mxyan): remove after bug is fixed.
+    if (GPR_UNLIKELY(!(err == 0 || err == ETIMEDOUT || err == EAGAIN))) {
+      g_abstime_sec_value = abs_deadline_ts.tv_sec;
+      g_abstime_nsec_value = abs_deadline_ts.tv_nsec;
+    }
+#endif
   }
 
 #ifdef GRPC_DEBUG_TIMER_MANAGER
   // For debug of the timer manager crash only.
   // TODO (mxyan): remove after bug is fixed.
-  if (!(err == 0 || err == ETIMEDOUT || err == EAGAIN)) {
+  if (GPR_UNLIKELY(!(err == 0 || err == ETIMEDOUT || err == EAGAIN))) {
     if (g_grpc_debug_timer_manager_stats) {
       g_timer_wait_err = err;
-      g_grpc_debug_timer_manager_stats(g_timer_manager_init_count,
-                                       g_timer_manager_shutdown_count,
-                                       g_fork_count, g_timer_wait_err);
+      g_timer_cv_value = (int64_t)cv;
+      g_timer_mu_value = (int64_t)mu;
+      g_grpc_debug_timer_manager_stats(
+          g_timer_manager_init_count, g_timer_manager_shutdown_count,
+          g_fork_count, g_timer_wait_err, g_timer_cv_value, g_timer_mu_value,
+          g_abstime_sec_value, g_abstime_nsec_value);
     }
     GPR_ASSERT(err == 0 || err == ETIMEDOUT || err == EAGAIN);
   }

--- a/src/core/lib/gpr/sync_posix.cc
+++ b/src/core/lib/gpr/sync_posix.cc
@@ -28,6 +28,14 @@
 #include "src/core/lib/profiling/timers.h"
 
 // For debug of the timer manager crash only.
+#ifndef kGMS_BuildConfig_EnableGRPCTimerCrashDebug
+#define kGMS_BuildConfig_EnableGRPCTimerCrashDebug() GRPC_DEBUG_TIMER_MANAGER
+#endif
+#ifndef kBuildConfig_EnableGRPCTimerCrashDebug
+#define kBuildConfig_EnableGRPCTimerCrashDebug() GRPC_DEBUG_TIMER_MANAGER
+#endif
+
+// For debug of the timer manager crash only.
 // TODO (mxyan): remove after bug is fixed.
 #ifdef GRPC_DEBUG_TIMER_MANAGER
 void (*g_grpc_debug_timer_manager_stats)(

--- a/src/core/lib/gpr/sync_posix.cc
+++ b/src/core/lib/gpr/sync_posix.cc
@@ -28,13 +28,9 @@
 #include "src/core/lib/profiling/timers.h"
 
 // For debug of the timer manager crash only.
-#ifndef kGMS_BuildConfig_EnableGRPCTimerCrashDebug
-#define kGMS_BuildConfig_EnableGRPCTimerCrashDebug() GRPC_DEBUG_TIMER_MANAGER
+#ifndef kGMS_BuildConfig_EnableGRPC
+#define kGMS_BuildConfig_EnableGRPC() GRPC_DEBUG_TIMER_MANAGER
 #endif
-#ifndef kBuildConfig_EnableGRPCTimerCrashDebug
-#define kBuildConfig_EnableGRPCTimerCrashDebug() GRPC_DEBUG_TIMER_MANAGER
-#endif
-
 // For debug of the timer manager crash only.
 // TODO (mxyan): remove after bug is fixed.
 #ifdef GRPC_DEBUG_TIMER_MANAGER

--- a/src/core/lib/gpr/sync_posix.cc
+++ b/src/core/lib/gpr/sync_posix.cc
@@ -136,11 +136,9 @@ int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu, gpr_timespec abs_deadline) {
           g_fork_count, g_timer_wait_err, g_timer_cv_value, g_timer_mu_value,
           g_abstime_sec_value, g_abstime_nsec_value);
     }
-    GPR_ASSERT(err == 0 || err == ETIMEDOUT || err == EAGAIN);
   }
-#else
-  GPR_ASSERT(err == 0 || err == ETIMEDOUT || err == EAGAIN);
 #endif
+  GPR_ASSERT(err == 0 || err == ETIMEDOUT || err == EAGAIN);
   return err == ETIMEDOUT;
 }
 

--- a/src/core/lib/gpr/sync_posix.cc
+++ b/src/core/lib/gpr/sync_posix.cc
@@ -28,10 +28,6 @@
 #include "src/core/lib/profiling/timers.h"
 
 // For debug of the timer manager crash only.
-#ifndef kGMS_BuildConfig_EnableGRPC
-#define kGMS_BuildConfig_EnableGRPC() GRPC_DEBUG_TIMER_MANAGER
-#endif
-// For debug of the timer manager crash only.
 // TODO (mxyan): remove after bug is fixed.
 #ifdef GRPC_DEBUG_TIMER_MANAGER
 void (*g_grpc_debug_timer_manager_stats)(

--- a/src/core/lib/gpr/sync_posix.cc
+++ b/src/core/lib/gpr/sync_posix.cc
@@ -27,6 +27,15 @@
 #include <time.h>
 #include "src/core/lib/profiling/timers.h"
 
+// For debug only. Forward statistics to another module.
+void (*g_grpc_debug_timer_manager_stats)(int64_t timer_manager_init_count, int64_t timer_manager_shutdown_count, int64_t fork_count, int64_t timer_wait_err, int64_t timer_wait_cv) = nullptr;
+// For debug only. Variables storing the counters being logged.
+int64_t g_timer_manager_init_count = 0;
+int64_t g_timer_manager_shutdown_count = 0;
+int64_t g_fork_count = 0;
+int64_t g_timer_wait_err = 0;
+int64_t g_timer_wait_cv = 0;
+
 #ifdef GPR_LOW_LEVEL_COUNTERS
 gpr_atm gpr_mu_locks = 0;
 gpr_atm gpr_counter_atm_cas = 0;
@@ -88,7 +97,18 @@ int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu, gpr_timespec abs_deadline) {
     abs_deadline_ts.tv_nsec = abs_deadline.tv_nsec;
     err = pthread_cond_timedwait(cv, mu, &abs_deadline_ts);
   }
-  GPR_ASSERT(err == 0 || err == ETIMEDOUT || err == EAGAIN);
+  if (!(err == 0 || err == ETIMEDOUT || err == EAGAIN)) {
+    if (g_grpc_debug_timer_manager_stats) {
+      g_timer_wait_err = err;
+      g_timer_wait_cv = (int64_t)cv;
+      g_grpc_debug_timer_manager_stats(g_timer_manager_init_count,
+                                       g_timer_manager_shutdown_count,
+                                       g_fork_count,
+                                       g_timer_wait_err,
+                                       g_timer_wait_cv);
+    }
+    GPR_ASSERT(err == 0 || err == ETIMEDOUT || err == EAGAIN);
+  }
   return err == ETIMEDOUT;
 }
 

--- a/src/core/lib/iomgr/timer_manager.cc
+++ b/src/core/lib/iomgr/timer_manager.cc
@@ -291,13 +291,13 @@ static void start_threads(void) {
 }
 
 void grpc_timer_manager_init(void) {
+  gpr_mu_init(&g_mu);
+  gpr_cv_init(&g_cv_wait);
 #ifdef GRPC_DEBUG_TIMER_MANAGER
   // For debug of the timer manager crash only.
   // TODO (mxyan): remove after bug is fixed.
   g_timer_manager_init_count++;
 #endif
-  gpr_mu_init(&g_mu);
-  gpr_cv_init(&g_cv_wait);
   gpr_cv_init(&g_cv_shutdown);
   g_threaded = false;
   g_thread_count = 0;

--- a/src/core/lib/iomgr/timer_manager.cc
+++ b/src/core/lib/iomgr/timer_manager.cc
@@ -67,7 +67,6 @@ static void timer_thread(void* completed_thread_ptr);
 extern int64_t g_timer_manager_init_count;
 extern int64_t g_timer_manager_shutdown_count;
 extern int64_t g_fork_count;
-extern int64_t g_timer_wait_err;
 #endif  // GRPC_DEBUG_TIMER_MANAGER
 
 static void gc_completed_threads(void) {

--- a/src/core/lib/iomgr/timer_manager.cc
+++ b/src/core/lib/iomgr/timer_manager.cc
@@ -62,10 +62,6 @@ static uint64_t g_timed_waiter_generation;
 static void timer_thread(void* completed_thread_ptr);
 
 // For debug of the timer manager crash only.
-#ifndef kGMS_BuildConfig_EnableGRPC
-#define kGMS_BuildConfig_EnableGRPC() GRPC_DEBUG_TIMER_MANAGER
-#endif
-// For debug of the timer manager crash only.
 // TODO (mxyan): remove after bug is fixed.
 #ifdef GRPC_DEBUG_TIMER_MANAGER
 extern int64_t g_timer_manager_init_count;

--- a/src/core/lib/iomgr/timer_manager.cc
+++ b/src/core/lib/iomgr/timer_manager.cc
@@ -68,7 +68,6 @@ extern int64_t g_timer_manager_init_count;
 extern int64_t g_timer_manager_shutdown_count;
 extern int64_t g_fork_count;
 extern int64_t g_timer_wait_err;
-extern int64_t g_timer_wait_cv;
 #endif  // GRPC_DEBUG_TIMER_MANAGER
 
 static void gc_completed_threads(void) {
@@ -334,9 +333,9 @@ static void stop_threads(void) {
 }
 
 void grpc_timer_manager_shutdown(void) {
-// For debug of the timer manager crash only.
-// TODO (mxyan): remove after bug is fixed.
 #ifdef GRPC_DEBUG_TIMER_MANAGER
+  // For debug of the timer manager crash only.
+  // TODO (mxyan): remove after bug is fixed.
   g_timer_manager_shutdown_count++;
 #endif
   stop_threads();
@@ -347,9 +346,9 @@ void grpc_timer_manager_shutdown(void) {
 }
 
 void grpc_timer_manager_set_threading(bool threaded) {
-// For debug of the timer manager crash only.
-// TODO (mxyan): remove after bug is fixed.
 #ifdef GRPC_DEBUG_TIMER_MANAGER
+  // For debug of the timer manager crash only.
+  // TODO (mxyan): remove after bug is fixed.
   g_fork_count++;
 #endif
   if (threaded) {

--- a/src/core/lib/iomgr/timer_manager.cc
+++ b/src/core/lib/iomgr/timer_manager.cc
@@ -62,13 +62,9 @@ static uint64_t g_timed_waiter_generation;
 static void timer_thread(void* completed_thread_ptr);
 
 // For debug of the timer manager crash only.
-#ifndef kGMS_BuildConfig_EnableGRPCTimerCrashDebug
-#define kGMS_BuildConfig_EnableGRPCTimerCrashDebug() GRPC_DEBUG_TIMER_MANAGER
+#ifndef kGMS_BuildConfig_EnableGRPC
+#define kGMS_BuildConfig_EnableGRPC() GRPC_DEBUG_TIMER_MANAGER
 #endif
-#ifndef kBuildConfig_EnableGRPCTimerCrashDebug
-#define kBuildConfig_EnableGRPCTimerCrashDebug() GRPC_DEBUG_TIMER_MANAGER
-#endif
-
 // For debug of the timer manager crash only.
 // TODO (mxyan): remove after bug is fixed.
 #ifdef GRPC_DEBUG_TIMER_MANAGER

--- a/src/core/lib/iomgr/timer_manager.cc
+++ b/src/core/lib/iomgr/timer_manager.cc
@@ -62,6 +62,14 @@ static uint64_t g_timed_waiter_generation;
 static void timer_thread(void* completed_thread_ptr);
 
 // For debug of the timer manager crash only.
+#ifndef kGMS_BuildConfig_EnableGRPCTimerCrashDebug
+#define kGMS_BuildConfig_EnableGRPCTimerCrashDebug() GRPC_DEBUG_TIMER_MANAGER
+#endif
+#ifndef kBuildConfig_EnableGRPCTimerCrashDebug
+#define kBuildConfig_EnableGRPCTimerCrashDebug() GRPC_DEBUG_TIMER_MANAGER
+#endif
+
+// For debug of the timer manager crash only.
 // TODO (mxyan): remove after bug is fixed.
 #ifdef GRPC_DEBUG_TIMER_MANAGER
 extern int64_t g_timer_manager_init_count;

--- a/src/core/lib/iomgr/timer_manager.cc
+++ b/src/core/lib/iomgr/timer_manager.cc
@@ -61,14 +61,15 @@ static uint64_t g_timed_waiter_generation;
 
 static void timer_thread(void* completed_thread_ptr);
 
-// For debug only. Forward statistics to another module.
-extern void (*g_grpc_debug_timer_manager_stats)(int64_t timer_manager_init_count, int64_t timer_manager_shutdown_count, int64_t fork_count, int64_t timer_wait_err, int64_t timer_wait_cv);
-// For debug only. Variables storing the counters being logged.
+// For debug of the timer manager crash only.
+// TODO (mxyan): remove after bug is fixed.
+#ifdef GRPC_DEBUG_TIMER_MANAGER
 extern int64_t g_timer_manager_init_count;
 extern int64_t g_timer_manager_shutdown_count;
 extern int64_t g_fork_count;
 extern int64_t g_timer_wait_err;
 extern int64_t g_timer_wait_cv;
+#endif  // GRPC_DEBUG_TIMER_MANAGER
 
 static void gc_completed_threads(void) {
   if (g_completed_threads != nullptr) {
@@ -291,10 +292,14 @@ static void start_threads(void) {
 }
 
 void grpc_timer_manager_init(void) {
+#ifdef GRPC_DEBUG_TIMER_MANAGER
+  // For debug of the timer manager crash only.
+  // TODO (mxyan): remove after bug is fixed.
+  g_timer_manager_init_count++;
+#endif
   gpr_mu_init(&g_mu);
   gpr_cv_init(&g_cv_wait);
   gpr_cv_init(&g_cv_shutdown);
-  g_timer_manager_init_count++;
   g_threaded = false;
   g_thread_count = 0;
   g_waiter_count = 0;
@@ -329,7 +334,11 @@ static void stop_threads(void) {
 }
 
 void grpc_timer_manager_shutdown(void) {
+// For debug of the timer manager crash only.
+// TODO (mxyan): remove after bug is fixed.
+#ifdef GRPC_DEBUG_TIMER_MANAGER
   g_timer_manager_shutdown_count++;
+#endif
   stop_threads();
 
   gpr_mu_destroy(&g_mu);
@@ -338,7 +347,11 @@ void grpc_timer_manager_shutdown(void) {
 }
 
 void grpc_timer_manager_set_threading(bool threaded) {
+// For debug of the timer manager crash only.
+// TODO (mxyan): remove after bug is fixed.
+#ifdef GRPC_DEBUG_TIMER_MANAGER
   g_fork_count++;
+#endif
   if (threaded) {
     start_threads();
   } else {


### PR DESCRIPTION
Add debug infrastructure for timer manager. Part of the effort to investigate the crash in `gpr_cv_wait`.

Note: CV's are struct rather than pointer in iOS, so we are not logging them here.