### PR TITLE
Use static slice constructor in common case where method name is static

### DIFF
--- a/include/grpcpp/channel.h
+++ b/include/grpcpp/channel.h
@@ -67,7 +67,14 @@ class Channel final : public ChannelInterface,
 
   internal::Call CreateCall(const internal::RpcMethod& method,
                             ClientContext* context,
-                            CompletionQueue* cq) override;
+                            CompletionQueue* cq) override {
+    return CreateCall(method, context, cq, nullptr, 0);
+  }
+  internal::Call CreateCall(const internal::RpcMethod& method,
+                            ClientContext* context, CompletionQueue* cq,
+                            const char* static_name,
+                            size_t static_name_len) override;
+
   void PerformOpsOnCall(internal::CallOpSetInterface* ops,
                         internal::Call* call) override;
   void* RegisterMethod(const char* method) override;

--- a/include/grpcpp/impl/codegen/async_stream.h
+++ b/include/grpcpp/impl/codegen/async_stream.h
@@ -184,8 +184,11 @@ class ClientAsyncReaderFactory {
                                       CompletionQueue* cq,
                                       const ::grpc::internal::RpcMethod& method,
                                       ClientContext* context, const W& request,
-                                      bool start, void* tag) {
-    ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
+                                      bool start, void* tag,
+                                      const char* static_name,
+                                      size_t static_name_len) {
+    ::grpc::internal::Call call =
+        channel->CreateCall(method, context, cq, static_name, static_name_len);
     return new (g_core_codegen_interface->grpc_call_arena_alloc(
         call.call(), sizeof(ClientAsyncReader<R>)))
         ClientAsyncReader<R>(call, context, request, start, tag);
@@ -332,8 +335,11 @@ class ClientAsyncWriterFactory {
                                       CompletionQueue* cq,
                                       const ::grpc::internal::RpcMethod& method,
                                       ClientContext* context, R* response,
-                                      bool start, void* tag) {
-    ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
+                                      bool start, void* tag,
+                                      const char* static_name,
+                                      size_t static_name_len) {
+    ::grpc::internal::Call call =
+        channel->CreateCall(method, context, cq, static_name, static_name_len);
     return new (g_core_codegen_interface->grpc_call_arena_alloc(
         call.call(), sizeof(ClientAsyncWriter<W>)))
         ClientAsyncWriter<W>(call, context, response, start, tag);
@@ -496,8 +502,9 @@ class ClientAsyncReaderWriterFactory {
   static ClientAsyncReaderWriter<W, R>* Create(
       ChannelInterface* channel, CompletionQueue* cq,
       const ::grpc::internal::RpcMethod& method, ClientContext* context,
-      bool start, void* tag) {
-    ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
+      bool start, void* tag, const char* static_name, size_t static_name_len) {
+    ::grpc::internal::Call call =
+        channel->CreateCall(method, context, cq, static_name, static_name_len);
 
     return new (g_core_codegen_interface->grpc_call_arena_alloc(
         call.call(), sizeof(ClientAsyncReaderWriter<W, R>)))

--- a/include/grpcpp/impl/codegen/async_unary_call.h
+++ b/include/grpcpp/impl/codegen/async_unary_call.h
@@ -83,8 +83,10 @@ class ClientAsyncResponseReaderFactory {
   static ClientAsyncResponseReader<R>* Create(
       ChannelInterface* channel, CompletionQueue* cq,
       const ::grpc::internal::RpcMethod& method, ClientContext* context,
-      const W& request, bool start) {
-    ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
+      const W& request, bool start, const char* static_name,
+      size_t static_name_len) {
+    ::grpc::internal::Call call =
+        channel->CreateCall(method, context, cq, static_name, static_name_len);
     return new (g_core_codegen_interface->grpc_call_arena_alloc(
         call.call(), sizeof(ClientAsyncResponseReader<R>)))
         ClientAsyncResponseReader<R>(call, context, request, start);

--- a/include/grpcpp/impl/codegen/channel_interface.h
+++ b/include/grpcpp/impl/codegen/channel_interface.h
@@ -20,6 +20,7 @@
 #define GRPCPP_IMPL_CODEGEN_CHANNEL_INTERFACE_H
 
 #include <grpc/impl/codegen/connectivity_state.h>
+#include <grpcpp/impl/codegen/call.h>
 #include <grpcpp/impl/codegen/status.h>
 #include <grpcpp/impl/codegen/time.h>
 
@@ -111,6 +112,12 @@ class ChannelInterface {
   virtual internal::Call CreateCall(const internal::RpcMethod& method,
                                     ClientContext* context,
                                     CompletionQueue* cq) = 0;
+  virtual internal::Call CreateCall(const internal::RpcMethod& method,
+                                    ClientContext* context, CompletionQueue* cq,
+                                    const char* static_name,
+                                    size_t static_name_len) {
+    return CreateCall(method, context, cq);
+  };
   virtual void PerformOpsOnCall(internal::CallOpSetInterface* ops,
                                 internal::Call* call) = 0;
   virtual void* RegisterMethod(const char* method) = 0;

--- a/include/grpcpp/impl/codegen/client_callback.h
+++ b/include/grpcpp/impl/codegen/client_callback.h
@@ -43,9 +43,11 @@ template <class InputMessage, class OutputMessage>
 void CallbackUnaryCall(ChannelInterface* channel, const RpcMethod& method,
                        ClientContext* context, const InputMessage* request,
                        OutputMessage* result,
-                       std::function<void(Status)> on_completion) {
+                       std::function<void(Status)> on_completion,
+                       const char* static_name, size_t static_name_len) {
   CallbackUnaryCallImpl<InputMessage, OutputMessage> x(
-      channel, method, context, request, result, on_completion);
+      channel, method, context, request, result, on_completion, static_name,
+      static_name_len);
 }
 
 template <class InputMessage, class OutputMessage>
@@ -54,10 +56,12 @@ class CallbackUnaryCallImpl {
   CallbackUnaryCallImpl(ChannelInterface* channel, const RpcMethod& method,
                         ClientContext* context, const InputMessage* request,
                         OutputMessage* result,
-                        std::function<void(Status)> on_completion) {
+                        std::function<void(Status)> on_completion,
+                        const char* static_name, size_t static_name_len) {
     CompletionQueue* cq = channel->CallbackCQ();
     GPR_CODEGEN_ASSERT(cq != nullptr);
-    Call call(channel->CreateCall(method, context, cq));
+    Call call(
+        channel->CreateCall(method, context, cq, static_name, static_name_len));
 
     using FullCallOpSet =
         CallOpSet<CallOpSendInitialMetadata, CallOpSendMessage,

--- a/include/grpcpp/impl/codegen/client_unary_call.h
+++ b/include/grpcpp/impl/codegen/client_unary_call.h
@@ -37,9 +37,11 @@ class RpcMethod;
 template <class InputMessage, class OutputMessage>
 Status BlockingUnaryCall(ChannelInterface* channel, const RpcMethod& method,
                          ClientContext* context, const InputMessage& request,
-                         OutputMessage* result) {
+                         OutputMessage* result, const char* static_name,
+                         size_t static_name_len) {
   return BlockingUnaryCallImpl<InputMessage, OutputMessage>(
-             channel, method, context, request, result)
+             channel, method, context, request, result, static_name,
+             static_name_len)
       .status();
 }
 
@@ -48,11 +50,13 @@ class BlockingUnaryCallImpl {
  public:
   BlockingUnaryCallImpl(ChannelInterface* channel, const RpcMethod& method,
                         ClientContext* context, const InputMessage& request,
-                        OutputMessage* result) {
+                        OutputMessage* result, const char* static_name,
+                        size_t static_name_len) {
     CompletionQueue cq(grpc_completion_queue_attributes{
         GRPC_CQ_CURRENT_VERSION, GRPC_CQ_PLUCK, GRPC_CQ_DEFAULT_POLLING,
         nullptr});  // Pluckable completion queue
-    Call call(channel->CreateCall(method, context, &cq));
+    Call call(channel->CreateCall(method, context, &cq, static_name,
+                                  static_name_len));
     CallOpSet<CallOpSendInitialMetadata, CallOpSendMessage,
               CallOpRecvInitialMetadata, CallOpRecvMessage<OutputMessage>,
               CallOpClientSendClose, CallOpClientRecvStatus>

--- a/src/cpp/client/generic_stub.cc
+++ b/src/cpp/client/generic_stub.cc
@@ -33,7 +33,7 @@ std::unique_ptr<GenericClientAsyncReaderWriter> CallInternal(
           channel, cq,
           internal::RpcMethod(method.c_str(),
                               internal::RpcMethod::BIDI_STREAMING),
-          context, start, tag));
+          context, start, tag, nullptr, 0));
 }
 
 }  // namespace
@@ -59,7 +59,7 @@ std::unique_ptr<GenericClientAsyncResponseReader> GenericStub::PrepareUnaryCall(
       internal::ClientAsyncResponseReaderFactory<ByteBuffer>::Create(
           channel_.get(), cq,
           internal::RpcMethod(method.c_str(), internal::RpcMethod::NORMAL_RPC),
-          context, request, false));
+          context, request, false, nullptr, 0));
 }
 
 void GenericStub::experimental_type::UnaryCall(
@@ -69,7 +69,7 @@ void GenericStub::experimental_type::UnaryCall(
   internal::CallbackUnaryCall(
       stub_->channel_.get(),
       internal::RpcMethod(method.c_str(), internal::RpcMethod::NORMAL_RPC),
-      context, request, response, std::move(on_completion));
+      context, request, response, std::move(on_completion), nullptr, 0);
 }
 
 }  // namespace grpc


### PR DESCRIPTION
Cc @soheilhy 

I think this addresses Yang's comment in #16699 . I know it conflicts with that PR, so feel free to use it or not as you want. This should provide the codegen support to allow the use of a static string for method name in the common case of codegen.

