### PR TITLE
Attempt to demonstrate ruby_package option failing to generate services properly when importing request/response messages

### DIFF
--- a/src/proto/grpc/testing/importing_package_options_service.proto
+++ b/src/proto/grpc/testing/importing_package_options_service.proto
@@ -1,0 +1,26 @@
+// Copyright 2018 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package grpc.testing;
+
+import "grpc/testing/package_options.proto";
+
+// For sanity checking package definitions
+option ruby_package = "Grpc.Testing.Importing";
+
+service ImportingTestService {
+  rpc GetTest(grpc.testing.TestRequest) returns (grpc.testing.TestResponse) { }
+}

--- a/src/ruby/spec/pb/codegen/package_option_spec.rb
+++ b/src/ruby/spec/pb/codegen/package_option_spec.rb
@@ -85,9 +85,9 @@ describe 'Code Generation Options' do
       expect(gen_file).to be_truthy
       begin
         $LOAD_PATH.push(tmp_dir)
-        expect { Grpc::Testing::Package::Options::TestService::Service }.to raise_error(NameError)
-        expect(require('grpc/testing/package_options_services_pb')).to be_truthy
-        expect { Grpc::Testing::Package::Options::TestService::Service }.to_not raise_error
+        expect { Grpc::Testing::Importing::ImportingTestService }.to_not raise_error(NameError)
+        expect(require('grpc/testing/importing_package_options_service_services_pb')).to be_truthy
+        expect { Grpc::Testing::Importing::ImportingTestService }.to_not raise_error
       ensure
         $LOAD_PATH.delete(tmp_dir)
       end


### PR DESCRIPTION
As mentioned in [this mailing list thread](https://groups.google.com/forum/#!topic/grpc-io/24gojtb8MH8), this PR attempts to demonstrate what appears to be mishandling of the `ruby_package` option for imported message types used as request/response message types when generating the service files.

Given a protobuf file defining request and response messages, specifying the `ruby_package` option, and a separate protobuf file defining the RPC service, specifying the same `ruby_package`, importing the messages and using those as the RPC endpoint request and response times.

### Example

I've prepared a gist with what should demonstrate this unexpected behavior:
https://gist.github.com/mtodd/cb6c189b2d3dec494c7f81f5f5e288f6

Notice that [the generated gRPC service file](https://gist.github.com/mtodd/cb6c189b2d3dec494c7f81f5f5e288f6#file-service_services_pb-rb) appears to ignore the configured `ruby_package` option, resulting in invalid Ruby code.
