### PR TITLE
build.yaml cleanup: legacy visual studio fields

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1437,7 +1437,6 @@ libs:
   filegroups:
   - gpr_base
   secure: false
-  vs_project_guid: '{B23D3D1A-9438-4EDA-BEB6-9A0A03D17792}'
 - name: gpr_test_util
   build: private
   language: c
@@ -1448,7 +1447,6 @@ libs:
   deps:
   - gpr
   secure: false
-  vs_project_guid: '{EAB0A629-17A9-44DB-B5FF-E91A721FE037}'
 - name: grpc
   build: all
   language: c
@@ -1481,10 +1479,6 @@ libs:
   - grpc_server_backward_compatibility
   generate_plugin_registry: true
   secure: true
-  vs_packages:
-  - grpc.dependencies.openssl
-  - grpc.dependencies.zlib
-  vs_project_guid: '{29D16885-7228-4C31-81ED-5F9187C7F2A9}'
 - name: grpc_cronet
   build: all
   language: c
@@ -1511,17 +1505,6 @@ libs:
   build_system:
   - visual_studio
   deps_linkage: static
-  dll_def: grpc.def
-  vs_config_type: DynamicLibrary
-  vs_packages:
-  - grpc.dependencies.openssl
-  - grpc.dependencies.zlib
-  vs_project_guid: '{A2F6CBBA-A553-41B3-A7DE-F26DECCC27F0}'
-  vs_props:
-  - zlib
-  - openssl
-  - winsock
-  - global
 - name: grpc_test_util
   build: private
   language: c
@@ -1540,7 +1523,6 @@ libs:
   - grpc
   filegroups:
   - grpc_test_util_base
-  vs_project_guid: '{17BCAFC0-5FDC-4C94-AEB9-95F3E220614B}'
 - name: grpc_test_util_unsecure
   build: private
   language: c
@@ -1551,7 +1533,6 @@ libs:
   filegroups:
   - grpc_test_util_base
   secure: false
-  vs_project_guid: '{0A7E7F92-FDEA-40F1-A9EC-3BA484F98BBF}'
 - name: grpc_unsecure
   build: all
   language: c
@@ -1582,7 +1563,6 @@ libs:
   - grpc_server_backward_compatibility
   generate_plugin_registry: true
   secure: false
-  vs_project_guid: '{46CEDFFF-9692-456A-AA24-38B5D6BCF4C5}'
 - name: reconnect_server
   build: private
   language: c
@@ -1636,7 +1616,6 @@ libs:
   - grpc++_codegen_proto
   - grpc++_codegen_base_src
   secure: check
-  vs_project_guid: '{C187A093-A0FE-489D-A40A-6E33DE0F9FEB}'
 - name: grpc++_core_stats
   build: private
   language: c++
@@ -1682,7 +1661,6 @@ libs:
   deps:
   - grpc++
   baselib: true
-  vs_project_guid: '{9F58AD72-49E1-4D10-B826-9E190AB0AAC0}'
 - name: grpc++_proto_reflection_desc_db
   build: private
   language: c++
@@ -1795,7 +1773,6 @@ libs:
   - grpc++_codegen_base
   - grpc++_codegen_base_src
   secure: false
-  vs_project_guid: '{6EE56155-DF7C-4F6E-BFC4-F6F776BEB211}'
 - name: grpc_benchmark
   build: test
   language: c++
@@ -1870,9 +1847,6 @@ libs:
   filegroups:
   - grpc++_config_proto
   secure: false
-  vs_project_guid: '{B6E81D84-2ACB-41B8-8781-493A944C7817}'
-  vs_props:
-  - protoc
 - name: grpcpp_channelz
   build: all
   language: c++
@@ -2027,16 +2001,6 @@ libs:
   LDFLAGS: $(if $(subst Linux,,$(SYSTEM)),,-Wl$(comma)-wrap$(comma)memcpy)
   deps_linkage: static
   dll: only
-  vs_config_type: DynamicLibrary
-  vs_packages:
-  - grpc.dependencies.openssl
-  - grpc.dependencies.zlib
-  vs_project_guid: '{D64C6D63-4458-4A88-AB38-35678384A7E4}'
-  vs_props:
-  - zlib
-  - openssl
-  - winsock
-  - global
 targets:
 - name: algorithm_test
   build: test
@@ -4732,8 +4696,6 @@ targets:
   deps:
   - grpc_plugin_support
   secure: false
-  vs_config_type: Application
-  vs_project_guid: '{7E51A25F-AC59-488F-906C-C60FAAE706AA}'
 - name: grpc_csharp_plugin
   build: protoc
   language: c++
@@ -4742,8 +4704,6 @@ targets:
   deps:
   - grpc_plugin_support
   secure: false
-  vs_config_type: Application
-  vs_project_guid: '{3C813052-A49A-4662-B90A-1ADBEC7EE453}'
 - name: grpc_linux_system_roots_test
   gtest: true
   build: test
@@ -4763,7 +4723,6 @@ targets:
   deps:
   - grpc_plugin_support
   secure: false
-  vs_config_type: Application
 - name: grpc_objective_c_plugin
   build: protoc
   language: c++
@@ -4772,8 +4731,6 @@ targets:
   deps:
   - grpc_plugin_support
   secure: false
-  vs_config_type: Application
-  vs_project_guid: '{19564640-CEE6-4921-ABA5-676ED79A36F6}'
 - name: grpc_php_plugin
   build: protoc
   language: c++
@@ -4782,7 +4739,6 @@ targets:
   deps:
   - grpc_plugin_support
   secure: false
-  vs_config_type: Application
 - name: grpc_python_plugin
   build: protoc
   language: c++
@@ -4791,8 +4747,6 @@ targets:
   deps:
   - grpc_plugin_support
   secure: false
-  vs_config_type: Application
-  vs_project_guid: '{DF52D501-A6CF-4E6F-BA38-6EBE2E8DAFB2}'
 - name: grpc_ruby_plugin
   build: protoc
   language: c++
@@ -4801,8 +4755,6 @@ targets:
   deps:
   - grpc_plugin_support
   secure: false
-  vs_config_type: Application
-  vs_project_guid: '{069E9D05-B78B-4751-9252-D21EBAE7DE8E}'
 - name: grpc_tool_test
   gtest: true
   build: test

--- a/build.yaml
+++ b/build.yaml
@@ -1495,16 +1495,6 @@ libs:
   platforms:
   - linux
   secure: true
-- name: grpc_dll
-  build: private
-  language: c
-  src: []
-  deps:
-  - gpr
-  - grpc
-  build_system:
-  - visual_studio
-  deps_linkage: static
 - name: grpc_test_util
   build: private
   language: c

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -593,16 +593,6 @@
       ],
     },
     {
-      'target_name': 'grpc_dll',
-      'type': 'static_library',
-      'dependencies': [
-        'gpr',
-        'grpc',
-      ],
-      'sources': [
-      ],
-    },
-    {
       'target_name': 'grpc_test_util',
       'type': 'static_library',
       'dependencies': [

--- a/templates/README.md
+++ b/templates/README.md
@@ -87,7 +87,6 @@ src:                      # list of files to compile
 secure: boolean,          # see below
 baselib: boolean,         # this is a low level library that has system
                           # dependencies
-vs_project_guid: '{...}', # Visual Studio's unique guid for that project
 filegroups:               # list of filegroups to merge to that project
                           # note that this will be expanded automatically
 deps:                     # list of libraries this target depends on
@@ -95,12 +94,6 @@ deps_linkage: "..."       # "static"  or "dynamic". Used by the Makefile only to
                           # determine the way dependencies are linkned. Defaults
                           # to "dynamic".
 dll: "..."                # see below.
-dll_def: "..."            # Visual Studio's dll definition file.
-vs_props:                 # List of property sheets to attach to that project.
-vs_config_type: "..."     # DynamicLibrary/StaticLibrary. Used only when
-                          # creating a library. Specifies if we're building a
-                          # static library or a dll. Use in conjunction with `dll_def`.
-vs_packages:              # List of nuget packages this project depends on.
 ```
 
 ## The `"build"` tag
@@ -140,11 +133,6 @@ protobuf is for `"c++"` ones.
 Used only by Visual Studio's project files. "true" means the project will be
 built with both static and dynamic runtimes. "false" means it'll only be built
 with static runtime. "only" means it'll only be built with the dll runtime.
-
-## The `"dll_def"` tag
-
-Specifies the visual studio's dll definition file. When creating a DLL, you
-sometimes (not always) need a def file (see grpc.def).
 
 
 # The template system

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,9 +1,13 @@
 # Regenerating project files
 
-Prerequisites: `python`, `pip install mako`, `go`
+Prerequisites
+- `python`
+- `pip install mako` (the template processor)
+- `pip install pyyaml` (to read the yaml files)
+- `go` (required by boringssl dependency)
 
 ```
-# Regenerate the projects files using templates
+# Regenerate the projects files (and other generated files) using templates
 tools/buildgen/generate_projects.sh
 ```
 
@@ -19,24 +23,12 @@ So instead we decided to work the following way:
 targets and files needed to build grpc and its tests, as well as a basic system
 for dependency description.
 
-* Each project file (Makefile, Visual Studio project files, Bazel's BUILD) is
-a [YAML](http://yaml.org) file used by the `build.yaml` file to generate the
-final output file.
+* Most of the build systems supported by gRPC (e.g. Makefile, cmake, XCode) have a template defined in this directory. The templates use the information from the `build.yaml` file to generate the project files specific to a given build system.
 
 This way we can maintain as many project system as we see fit, without having
 to manually maintain them when we add or remove new code to the repository.
 Only the structure of the project file is relevant to the template. The actual
 list of source code and targets isn't.
-
-We currently have template files for GNU Make, Visual Studio 2013,
-[Bazel](http://bazel.io) and [gyp](https://gyp.gsrc.io/) (albeit only for
-Node.js). In the future, we
-would like to expand to also generate [cmake](https://cmake.org)
-project files, XCode project files, and an Android.mk file allowing to compile
-gRPC using Android's NDK.
-
-We'll gladly accept contribution that'd create additional project files
-using that system.
 
 # Structure of `build.yaml`
 
@@ -130,7 +122,7 @@ protobuf is for `"c++"` ones.
 
 ## The `"dll"` tag
 
-Used only by Visual Studio's project files. "true" means the project will be
+Currently only used by cmake. "true" means the project will be
 built with both static and dynamic runtimes. "false" means it'll only be built
 with static runtime. "only" means it'll only be built with the dll runtime.
 
@@ -140,8 +132,7 @@ with static runtime. "only" means it'll only be built with the dll runtime.
 We're currently using the [mako templates](http://www.makotemplates.org/)
 renderer. That choice enables us to simply render text files without dragging
 with us a lot of other features. Feel free to explore the current templates
-in that directory. The simplest one is probably [BUILD.template](BUILD.template)
-which is used to create the [Bazel](http://bazel.io/) project file.
+in that directory.
 
 ## The renderer engine
 

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -7092,19 +7092,6 @@
   {
     "deps": [
       "gpr", 
-      "grpc"
-    ], 
-    "headers": [], 
-    "is_filegroup": false, 
-    "language": "c", 
-    "name": "grpc_dll", 
-    "src": [], 
-    "third_party": false, 
-    "type": "lib"
-  }, 
-  {
-    "deps": [
-      "gpr", 
       "gpr_test_util", 
       "grpc", 
       "grpc_test_util_base"


### PR DESCRIPTION
After removal of visual studio projects (happened quite a while ago) some properties in build.yaml are no longer useful. This PR removes them and also fixes some inaccuracies in the README.md.