### PR TITLE
Fix inverted logic for --call_creds=none.

### DIFF
--- a/test/cpp/util/cli_credentials.cc
+++ b/test/cpp/util/cli_credentials.cc
@@ -151,7 +151,7 @@ std::shared_ptr<grpc::CallCredentials> CliCredentials::GetCallCredentials()
   if (IsAccessToken(FLAGS_call_creds)) {
     return grpc::AccessTokenCredentials(AccessToken(FLAGS_call_creds));
   }
-  if (FLAGS_call_creds.compare("none") != 0) {
+  if (FLAGS_call_creds.compare("none") == 0) {
     // Nothing to do; creds, if any, are baked into the channel.
     return std::shared_ptr<grpc::CallCredentials>();
   }


### PR DESCRIPTION
Fixes #16622. Follow up to change 6e3938c. Thanks to @bluecmd for pointing it out.