### PR TITLE
Fix the unused result error in client_channel_stress_test.cc.

### DIFF
--- a/test/cpp/client/client_channel_stress_test.cc
+++ b/test/cpp/client/client_channel_stress_test.cc
@@ -245,7 +245,7 @@ class ClientChannelStressTest {
       EchoResponse response;
       {
         std::lock_guard<std::mutex> lock(stub_mutex_);
-        stub_->Echo(&context, request, &response);
+        Status status = stub_->Echo(&context, request, &response);
       }
     }
     gpr_log(GPR_INFO, "Finish sending requests.");


### PR DESCRIPTION
This is to fix the unused result error in client_channel_stress_test.cc.