### PR TITLE
cmake: prevent C core from depending on libstdc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,17 @@ else()
   set(_gRPC_PROTOBUF_LIBRARY_NAME "libprotobuf")
 endif()
 
+if (_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC)
+  # C core has C++ source code, but should not depend on libstc++ (for better portability).
+  # We need to use a few tricks to convince cmake to do that.
+  # https://stackoverflow.com/questions/15058403/how-to-stop-cmake-from-linking-against-libstdc
+  set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "")
+  # Exceptions and RTTI must be off to avoid dependency on libstdc++
+  set(_gRPC_CORE_NOSTDCXX_FLAGS -fno-exceptions -fno-rtti)
+else()
+  set(_gRPC_CORE_NOSTDCXX_FLAGS "")
+endif()
+
 include(cmake/zlib.cmake)
 include(cmake/cares.cmake)
 include(cmake/protobuf.cmake)
@@ -710,7 +721,12 @@ target_include_directories(address_sorting
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(address_sorting PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(address_sorting PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(address_sorting
   ${_gRPC_BASELIB_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -757,7 +773,12 @@ target_include_directories(alts_test_util
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(alts_test_util PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(alts_test_util PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(alts_test_util
   ${_gRPC_SSL_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -833,7 +854,12 @@ target_include_directories(gpr
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(gpr PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(gpr
   ${_gRPC_ALLTARGETS_LIBRARIES}
 )
@@ -923,7 +949,12 @@ target_include_directories(gpr_test_util
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr_test_util PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(gpr_test_util PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(gpr_test_util
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gpr
@@ -1273,7 +1304,12 @@ target_include_directories(grpc
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(grpc PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(grpc
   ${_gRPC_BASELIB_LIBRARIES}
   ${_gRPC_SSL_LIBRARIES}
@@ -1650,7 +1686,12 @@ target_include_directories(grpc_cronet
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_cronet PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(grpc_cronet PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(grpc_cronet
   ${_gRPC_BASELIB_LIBRARIES}
   ${_gRPC_SSL_LIBRARIES}
@@ -1961,7 +2002,12 @@ target_include_directories(grpc_test_util
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_test_util PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(grpc_test_util PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(grpc_test_util
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gpr_test_util
@@ -2270,7 +2316,12 @@ target_include_directories(grpc_test_util_unsecure
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_test_util_unsecure PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(grpc_test_util_unsecure PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(grpc_test_util_unsecure
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gpr
@@ -2598,7 +2649,12 @@ target_include_directories(grpc_unsecure
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_unsecure PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(grpc_unsecure PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(grpc_unsecure
   ${_gRPC_BASELIB_LIBRARIES}
   ${_gRPC_ZLIB_LIBRARIES}
@@ -2691,7 +2747,12 @@ target_include_directories(reconnect_server
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(reconnect_server PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(reconnect_server PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(reconnect_server
   ${_gRPC_ALLTARGETS_LIBRARIES}
   test_tcp_server
@@ -2733,7 +2794,12 @@ target_include_directories(test_tcp_server
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(test_tcp_server PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(test_tcp_server PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(test_tcp_server
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
@@ -2815,7 +2881,6 @@ target_include_directories(grpc++
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(grpc++
   ${_gRPC_BASELIB_LIBRARIES}
   ${_gRPC_SSL_LIBRARIES}
@@ -3099,7 +3164,6 @@ target_include_directories(grpc++_core_stats
   PRIVATE third_party/googletest/googlemock
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(grpc++_core_stats
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -3385,7 +3449,6 @@ target_include_directories(grpc++_cronet
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(grpc++_cronet
   ${_gRPC_BASELIB_LIBRARIES}
   ${_gRPC_SSL_LIBRARIES}
@@ -3660,7 +3723,6 @@ target_include_directories(grpc++_error_details
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(grpc++_error_details
   ${_gRPC_BASELIB_LIBRARIES}
   ${_gRPC_PROTOBUF_LIBRARIES}
@@ -3732,7 +3794,6 @@ target_include_directories(grpc++_proto_reflection_desc_db
   PRIVATE third_party/googletest/googlemock
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(grpc++_proto_reflection_desc_db
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -3792,7 +3853,6 @@ target_include_directories(grpc++_reflection
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(grpc++_reflection
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -3856,7 +3916,6 @@ target_include_directories(grpc++_test_config
   PRIVATE third_party/googletest/googlemock
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(grpc++_test_config
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -3943,7 +4002,6 @@ target_include_directories(grpc++_test_util
   PRIVATE third_party/googletest/googlemock
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(grpc++_test_util
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -4123,7 +4181,6 @@ target_include_directories(grpc++_test_util_unsecure
   PRIVATE third_party/googletest/googlemock
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(grpc++_test_util_unsecure
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -4300,7 +4357,6 @@ target_include_directories(grpc++_unsecure
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(grpc++_unsecure
   ${_gRPC_BASELIB_LIBRARIES}
   ${_gRPC_PROTOBUF_LIBRARIES}
@@ -4569,7 +4625,6 @@ target_include_directories(grpc_benchmark
   PRIVATE third_party/googletest/googlemock
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(grpc_benchmark
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -4629,7 +4684,6 @@ target_include_directories(grpc_cli_libs
   PRIVATE third_party/googletest/googlemock
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(grpc_cli_libs
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -4687,7 +4741,6 @@ target_include_directories(grpc_plugin_support
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(grpc_plugin_support
   ${_gRPC_PROTOBUF_PROTOC_LIBRARIES}
   ${_gRPC_PROTOBUF_LIBRARIES}
@@ -4753,7 +4806,6 @@ target_include_directories(grpcpp_channelz
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(grpcpp_channelz
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -4838,7 +4890,6 @@ target_include_directories(http2_client_main
   PRIVATE third_party/googletest/googlemock
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(http2_client_main
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -4895,7 +4946,6 @@ target_include_directories(interop_client_helper
   PRIVATE third_party/googletest/googlemock
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(interop_client_helper
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -4967,7 +5017,6 @@ target_include_directories(interop_client_main
   PRIVATE third_party/googletest/googlemock
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(interop_client_main
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -5019,7 +5068,6 @@ target_include_directories(interop_server_helper
   PRIVATE third_party/googletest/googlemock
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(interop_server_helper
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -5089,7 +5137,6 @@ target_include_directories(interop_server_lib
   PRIVATE third_party/googletest/googlemock
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(interop_server_lib
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -5141,7 +5188,6 @@ target_include_directories(interop_server_main
   PRIVATE third_party/googletest/googlemock
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(interop_server_main
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -5245,7 +5291,6 @@ target_include_directories(qps
   PRIVATE third_party/googletest/googlemock
   PRIVATE ${_gRPC_PROTO_GENS_DIR}
 )
-
 target_link_libraries(qps
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -5289,7 +5334,12 @@ target_include_directories(grpc_csharp_ext
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_csharp_ext PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(grpc_csharp_ext PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(grpc_csharp_ext
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc
@@ -5337,7 +5387,12 @@ target_include_directories(bad_client_test
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(bad_client_test PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(bad_client_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(bad_client_test
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util_unsecure
@@ -5378,7 +5433,12 @@ target_include_directories(bad_ssl_test_server
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(bad_ssl_test_server PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(bad_ssl_test_server PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(bad_ssl_test_server
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util
@@ -5498,7 +5558,12 @@ target_include_directories(end2end_tests
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(end2end_tests PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(end2end_tests PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(end2end_tests
   ${_gRPC_SSL_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
@@ -5618,7 +5683,12 @@ target_include_directories(end2end_nosec_tests
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
 )
-
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(end2end_nosec_tests PROPERTIES LINKER_LANGUAGE C)
+    # only use the flags for C++ source files
+    target_compile_options(end2end_nosec_tests PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 target_link_libraries(end2end_nosec_tests
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_test_util_unsecure
@@ -5658,6 +5728,12 @@ target_link_libraries(algorithm_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(algorithm_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(algorithm_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -5684,6 +5760,12 @@ target_link_libraries(alloc_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(alloc_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(alloc_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -5714,6 +5796,12 @@ target_link_libraries(alpn_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(alpn_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(alpn_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -5740,6 +5828,12 @@ target_link_libraries(arena_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(arena_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(arena_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -5768,6 +5862,12 @@ target_link_libraries(avl_test
   gpr
   grpc
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(avl_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(avl_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -5799,6 +5899,12 @@ target_link_libraries(bad_server_response_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(bad_server_response_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(bad_server_response_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -5826,6 +5932,12 @@ target_link_libraries(bin_decoder_test
   grpc
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(bin_decoder_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(bin_decoder_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -5852,6 +5964,12 @@ target_link_libraries(bin_encoder_test
   grpc_test_util
   grpc
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(bin_encoder_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(bin_encoder_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -5883,6 +6001,12 @@ target_link_libraries(buffer_list_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(buffer_list_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(buffer_list_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -5913,6 +6037,12 @@ target_link_libraries(channel_create_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(channel_create_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(channel_create_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 
 add_executable(check_epollexclusive
@@ -5938,6 +6068,12 @@ target_link_libraries(check_epollexclusive
   grpc
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(check_epollexclusive PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(check_epollexclusive PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 if (gRPC_BUILD_TESTS)
 
@@ -5966,6 +6102,12 @@ target_link_libraries(chttp2_hpack_encoder_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(chttp2_hpack_encoder_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(chttp2_hpack_encoder_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -5996,6 +6138,12 @@ target_link_libraries(chttp2_stream_map_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(chttp2_stream_map_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(chttp2_stream_map_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -6025,6 +6173,12 @@ target_link_libraries(chttp2_varint_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(chttp2_varint_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(chttp2_varint_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -6052,6 +6206,12 @@ target_link_libraries(cmdline_test
   gpr_test_util
   grpc_test_util
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(cmdline_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(cmdline_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6082,6 +6242,12 @@ target_link_libraries(combiner_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(combiner_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(combiner_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -6110,6 +6276,12 @@ target_link_libraries(compression_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(compression_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(compression_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6140,6 +6312,12 @@ target_link_libraries(concurrent_connectivity_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(concurrent_connectivity_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(concurrent_connectivity_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -6168,6 +6346,12 @@ target_link_libraries(connection_refused_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(connection_refused_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(connection_refused_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6198,6 +6382,12 @@ target_link_libraries(dns_resolver_connectivity_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(dns_resolver_connectivity_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(dns_resolver_connectivity_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -6227,6 +6417,12 @@ target_link_libraries(dns_resolver_cooldown_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(dns_resolver_cooldown_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(dns_resolver_cooldown_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -6255,6 +6451,12 @@ target_link_libraries(dns_resolver_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(dns_resolver_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(dns_resolver_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6286,6 +6488,12 @@ target_link_libraries(dualstack_socket_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(dualstack_socket_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(dualstack_socket_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6316,6 +6524,12 @@ target_link_libraries(endpoint_pair_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(endpoint_pair_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(endpoint_pair_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -6344,6 +6558,12 @@ target_link_libraries(error_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(error_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(error_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6375,6 +6595,12 @@ target_link_libraries(ev_epollex_linux_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(ev_epollex_linux_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(ev_epollex_linux_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6405,6 +6631,12 @@ target_link_libraries(fake_resolver_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(fake_resolver_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(fake_resolver_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
@@ -6434,6 +6666,12 @@ target_link_libraries(fake_transport_security_test
   gpr
   grpc
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(fake_transport_security_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(fake_transport_security_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -6466,6 +6704,12 @@ target_link_libraries(fd_conservation_posix_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(fd_conservation_posix_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(fd_conservation_posix_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6497,6 +6741,12 @@ target_link_libraries(fd_posix_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(fd_posix_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(fd_posix_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6527,6 +6777,12 @@ target_link_libraries(fling_client
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(fling_client PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(fling_client PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -6555,6 +6811,12 @@ target_link_libraries(fling_server
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(fling_server PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(fling_server PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6585,6 +6847,12 @@ target_link_libraries(fling_stream_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(fling_stream_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(fling_stream_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -6617,6 +6885,12 @@ target_link_libraries(fling_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(fling_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(fling_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6645,6 +6919,12 @@ target_link_libraries(fork_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(fork_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(fork_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -6677,6 +6957,12 @@ target_link_libraries(goaway_server_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(goaway_server_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(goaway_server_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6705,6 +6991,12 @@ target_link_libraries(gpr_cpu_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr_cpu_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(gpr_cpu_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -6731,6 +7023,12 @@ target_link_libraries(gpr_env_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr_env_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(gpr_env_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6759,6 +7057,12 @@ target_link_libraries(gpr_host_port_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr_host_port_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(gpr_host_port_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -6785,6 +7089,12 @@ target_link_libraries(gpr_log_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr_log_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(gpr_log_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6813,6 +7123,12 @@ target_link_libraries(gpr_manual_constructor_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr_manual_constructor_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(gpr_manual_constructor_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -6839,6 +7155,12 @@ target_link_libraries(gpr_mpscq_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr_mpscq_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(gpr_mpscq_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6867,6 +7189,12 @@ target_link_libraries(gpr_spinlock_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr_spinlock_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(gpr_spinlock_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -6893,6 +7221,12 @@ target_link_libraries(gpr_string_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr_string_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(gpr_string_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6921,6 +7255,12 @@ target_link_libraries(gpr_sync_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr_sync_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(gpr_sync_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -6947,6 +7287,12 @@ target_link_libraries(gpr_thd_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr_thd_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(gpr_thd_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -6975,6 +7321,12 @@ target_link_libraries(gpr_time_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr_time_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(gpr_time_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -7002,6 +7354,12 @@ target_link_libraries(gpr_tls_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr_tls_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(gpr_tls_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -7028,6 +7386,12 @@ target_link_libraries(gpr_useful_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(gpr_useful_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(gpr_useful_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7058,6 +7422,12 @@ target_link_libraries(grpc_auth_context_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_auth_context_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_auth_context_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -7086,6 +7456,12 @@ target_link_libraries(grpc_b64_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_b64_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_b64_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7116,6 +7492,12 @@ target_link_libraries(grpc_byte_buffer_reader_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_byte_buffer_reader_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_byte_buffer_reader_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -7144,6 +7526,12 @@ target_link_libraries(grpc_channel_args_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_channel_args_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_channel_args_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7174,6 +7562,12 @@ target_link_libraries(grpc_channel_stack_builder_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_channel_stack_builder_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_channel_stack_builder_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -7202,6 +7596,12 @@ target_link_libraries(grpc_channel_stack_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_channel_stack_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_channel_stack_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7232,6 +7632,12 @@ target_link_libraries(grpc_completion_queue_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_completion_queue_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_completion_queue_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -7261,6 +7667,12 @@ target_link_libraries(grpc_completion_queue_threading_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_completion_queue_threading_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_completion_queue_threading_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 
 add_executable(grpc_create_jwt
@@ -7289,6 +7701,12 @@ target_link_libraries(grpc_create_jwt
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_create_jwt PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_create_jwt PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 if (gRPC_BUILD_TESTS)
 
 add_executable(grpc_credentials_test
@@ -7316,6 +7734,12 @@ target_link_libraries(grpc_credentials_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_credentials_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_credentials_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7346,6 +7770,12 @@ target_link_libraries(grpc_fetch_oauth2
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_fetch_oauth2 PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_fetch_oauth2 PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -7374,6 +7804,12 @@ target_link_libraries(grpc_ipv6_loopback_available_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_ipv6_loopback_available_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_ipv6_loopback_available_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7405,6 +7841,12 @@ target_link_libraries(grpc_json_token_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_json_token_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_json_token_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7435,6 +7877,12 @@ target_link_libraries(grpc_jwt_verifier_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_jwt_verifier_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_jwt_verifier_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 
 add_executable(grpc_print_google_default_creds_token
@@ -7461,6 +7909,12 @@ target_link_libraries(grpc_print_google_default_creds_token
   grpc
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_print_google_default_creds_token PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_print_google_default_creds_token PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 if (gRPC_BUILD_TESTS)
 
@@ -7489,6 +7943,12 @@ target_link_libraries(grpc_security_connector_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_security_connector_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_security_connector_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7519,6 +7979,12 @@ target_link_libraries(grpc_ssl_credentials_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_ssl_credentials_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_ssl_credentials_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 
 add_executable(grpc_verify_jwt
@@ -7545,6 +8011,12 @@ target_link_libraries(grpc_verify_jwt
   grpc
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(grpc_verify_jwt PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(grpc_verify_jwt PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 if (gRPC_BUILD_TESTS)
 if(_gRPC_PLATFORM_LINUX)
@@ -7575,6 +8047,12 @@ target_link_libraries(handshake_client
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(handshake_client PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(handshake_client PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -7609,6 +8087,12 @@ target_link_libraries(handshake_server
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(handshake_server PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(handshake_server PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7642,6 +8126,12 @@ target_link_libraries(handshake_server_with_readahead_handshaker
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(handshake_server_with_readahead_handshaker PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(handshake_server_with_readahead_handshaker PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7674,6 +8164,12 @@ target_link_libraries(handshake_verify_peer_options
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(handshake_verify_peer_options PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(handshake_verify_peer_options PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7701,6 +8197,12 @@ target_link_libraries(histogram_test
   grpc_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(histogram_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(histogram_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7731,6 +8233,12 @@ target_link_libraries(hpack_parser_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(hpack_parser_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(hpack_parser_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -7759,6 +8267,12 @@ target_link_libraries(hpack_table_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(hpack_table_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(hpack_table_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7789,6 +8303,12 @@ target_link_libraries(http_parser_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(http_parser_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(http_parser_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -7817,6 +8337,12 @@ target_link_libraries(httpcli_format_request_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(httpcli_format_request_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(httpcli_format_request_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7847,6 +8373,12 @@ target_link_libraries(httpcli_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(httpcli_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(httpcli_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -7879,6 +8411,12 @@ target_link_libraries(httpscli_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(httpscli_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(httpscli_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7909,6 +8447,12 @@ target_link_libraries(init_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(init_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(init_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -7937,6 +8481,12 @@ target_link_libraries(inproc_callback_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(inproc_callback_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(inproc_callback_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -7967,6 +8517,12 @@ target_link_libraries(invalid_call_argument_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(invalid_call_argument_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(invalid_call_argument_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -7995,6 +8551,12 @@ target_link_libraries(json_rewrite
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(json_rewrite PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(json_rewrite PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8025,6 +8587,12 @@ target_link_libraries(json_rewrite_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(json_rewrite_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(json_rewrite_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8053,6 +8621,12 @@ target_link_libraries(json_stream_error_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(json_stream_error_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(json_stream_error_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8083,6 +8657,12 @@ target_link_libraries(json_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(json_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(json_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8111,6 +8691,12 @@ target_link_libraries(lame_client_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(lame_client_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(lame_client_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8141,6 +8727,12 @@ target_link_libraries(load_file_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(load_file_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(load_file_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8170,6 +8762,12 @@ target_link_libraries(memory_profile_client
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(memory_profile_client PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(memory_profile_client PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8198,6 +8796,12 @@ target_link_libraries(memory_profile_server
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(memory_profile_server PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(memory_profile_server PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8229,6 +8833,12 @@ target_link_libraries(memory_profile_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(memory_profile_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(memory_profile_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8259,6 +8869,12 @@ target_link_libraries(message_compress_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(message_compress_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(message_compress_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8287,6 +8903,12 @@ target_link_libraries(minimal_stack_is_minimal_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(minimal_stack_is_minimal_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(minimal_stack_is_minimal_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8317,6 +8939,12 @@ target_link_libraries(multiple_server_queues_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(multiple_server_queues_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(multiple_server_queues_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8343,6 +8971,12 @@ target_link_libraries(murmur_hash_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(murmur_hash_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(murmur_hash_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8373,6 +9007,12 @@ target_link_libraries(no_server_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(no_server_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(no_server_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8401,6 +9041,12 @@ target_link_libraries(num_external_connectivity_watchers_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(num_external_connectivity_watchers_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(num_external_connectivity_watchers_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8431,6 +9077,12 @@ target_link_libraries(parse_address_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(parse_address_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(parse_address_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8459,6 +9111,12 @@ target_link_libraries(percent_encoding_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(percent_encoding_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(percent_encoding_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8490,6 +9148,12 @@ target_link_libraries(resolve_address_posix_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(resolve_address_posix_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(resolve_address_posix_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8520,6 +9184,12 @@ target_link_libraries(resolve_address_using_ares_resolver_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(resolve_address_using_ares_resolver_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(resolve_address_using_ares_resolver_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8548,6 +9218,12 @@ target_link_libraries(resolve_address_using_native_resolver_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(resolve_address_using_native_resolver_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(resolve_address_using_native_resolver_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8578,6 +9254,12 @@ target_link_libraries(resource_quota_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(resource_quota_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(resource_quota_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8606,6 +9288,12 @@ target_link_libraries(secure_channel_create_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(secure_channel_create_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(secure_channel_create_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8636,6 +9324,12 @@ target_link_libraries(secure_endpoint_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(secure_endpoint_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(secure_endpoint_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8664,6 +9358,12 @@ target_link_libraries(sequential_connectivity_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(sequential_connectivity_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(sequential_connectivity_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8694,6 +9394,12 @@ target_link_libraries(server_chttp2_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(server_chttp2_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(server_chttp2_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8722,6 +9428,12 @@ target_link_libraries(server_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(server_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(server_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8752,6 +9464,12 @@ target_link_libraries(slice_buffer_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(slice_buffer_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(slice_buffer_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8780,6 +9498,12 @@ target_link_libraries(slice_string_helpers_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(slice_string_helpers_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(slice_string_helpers_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8810,6 +9534,12 @@ target_link_libraries(slice_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(slice_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(slice_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8838,6 +9568,12 @@ target_link_libraries(sockaddr_resolver_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(sockaddr_resolver_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(sockaddr_resolver_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8868,6 +9604,12 @@ target_link_libraries(sockaddr_utils_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(sockaddr_utils_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(sockaddr_utils_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
@@ -8897,6 +9639,12 @@ target_link_libraries(socket_utils_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(socket_utils_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(socket_utils_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -8929,6 +9677,12 @@ target_link_libraries(ssl_transport_security_test
   grpc
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(ssl_transport_security_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(ssl_transport_security_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -8959,6 +9713,12 @@ target_link_libraries(status_conversion_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(status_conversion_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(status_conversion_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -8988,6 +9748,12 @@ target_link_libraries(stream_compression_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(stream_compression_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(stream_compression_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -9016,6 +9782,12 @@ target_link_libraries(stream_owned_slice_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(stream_owned_slice_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(stream_owned_slice_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -9047,6 +9819,12 @@ target_link_libraries(tcp_client_posix_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(tcp_client_posix_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(tcp_client_posix_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -9077,6 +9855,12 @@ target_link_libraries(tcp_client_uv_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(tcp_client_uv_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(tcp_client_uv_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
@@ -9106,6 +9890,12 @@ target_link_libraries(tcp_posix_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(tcp_posix_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(tcp_posix_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -9138,6 +9928,12 @@ target_link_libraries(tcp_server_posix_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(tcp_server_posix_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(tcp_server_posix_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -9168,6 +9964,12 @@ target_link_libraries(tcp_server_uv_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(tcp_server_uv_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(tcp_server_uv_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -9196,6 +9998,12 @@ target_link_libraries(time_averaged_stats_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(time_averaged_stats_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(time_averaged_stats_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -9226,6 +10034,12 @@ target_link_libraries(timeout_encoding_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(timeout_encoding_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(timeout_encoding_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -9254,6 +10068,12 @@ target_link_libraries(timer_heap_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(timer_heap_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(timer_heap_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -9284,6 +10104,12 @@ target_link_libraries(timer_list_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(timer_list_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(timer_list_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -9312,6 +10138,12 @@ target_link_libraries(transport_connectivity_state_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(transport_connectivity_state_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(transport_connectivity_state_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -9342,6 +10174,12 @@ target_link_libraries(transport_metadata_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(transport_metadata_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(transport_metadata_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
@@ -9371,6 +10209,12 @@ target_link_libraries(transport_security_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(transport_security_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(transport_security_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -9403,6 +10247,12 @@ target_link_libraries(udp_server_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(udp_server_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(udp_server_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -9433,6 +10283,12 @@ target_link_libraries(uri_parser_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(uri_parser_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(uri_parser_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
@@ -9462,6 +10318,12 @@ target_link_libraries(wakeup_fd_cv_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(wakeup_fd_cv_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(wakeup_fd_cv_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -9504,6 +10366,7 @@ target_link_libraries(alarm_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -9540,6 +10403,7 @@ target_link_libraries(alts_counter_test
   grpc
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -9579,6 +10443,7 @@ target_link_libraries(alts_crypt_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -9616,6 +10481,7 @@ target_link_libraries(alts_crypter_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -9652,6 +10518,7 @@ target_link_libraries(alts_frame_handler_test
   grpc
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -9691,6 +10558,7 @@ target_link_libraries(alts_frame_protector_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -9727,6 +10595,7 @@ target_link_libraries(alts_grpc_record_protocol_test
   grpc
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -9765,6 +10634,7 @@ target_link_libraries(alts_handshaker_client_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -9801,6 +10671,7 @@ target_link_libraries(alts_handshaker_service_api_test
   grpc
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -9839,6 +10710,7 @@ target_link_libraries(alts_iovec_record_protocol_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -9874,6 +10746,7 @@ target_link_libraries(alts_security_connector_test
   grpc
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -9912,6 +10785,7 @@ target_link_libraries(alts_tsi_handshaker_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -9949,6 +10823,7 @@ target_link_libraries(alts_tsi_utils_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -9985,6 +10860,7 @@ target_link_libraries(alts_zero_copy_grpc_protector_test
   grpc
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -10026,6 +10902,7 @@ target_link_libraries(async_end2end_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -10066,6 +10943,7 @@ target_link_libraries(auth_property_iterator_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -10103,6 +10981,7 @@ target_link_libraries(backoff_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -10143,6 +11022,7 @@ target_link_libraries(bdp_estimator_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -10187,6 +11067,7 @@ target_link_libraries(bm_arena
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -10233,6 +11114,7 @@ target_link_libraries(bm_call_create
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -10277,6 +11159,7 @@ target_link_libraries(bm_channel
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -10323,6 +11206,7 @@ target_link_libraries(bm_chttp2_hpack
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -10367,6 +11251,7 @@ target_link_libraries(bm_chttp2_transport
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -10413,6 +11298,7 @@ target_link_libraries(bm_closure
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -10457,6 +11343,7 @@ target_link_libraries(bm_cq
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -10503,6 +11390,7 @@ target_link_libraries(bm_cq_multiple_threads
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -10547,6 +11435,7 @@ target_link_libraries(bm_error
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -10593,6 +11482,7 @@ target_link_libraries(bm_fullstack_streaming_ping_pong
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -10637,6 +11527,7 @@ target_link_libraries(bm_fullstack_streaming_pump
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -10683,6 +11574,7 @@ target_link_libraries(bm_fullstack_trickle
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -10727,6 +11619,7 @@ target_link_libraries(bm_fullstack_unary_ping_pong
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -10773,6 +11666,7 @@ target_link_libraries(bm_metadata
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -10818,6 +11712,7 @@ target_link_libraries(bm_pollset
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -10857,6 +11752,7 @@ target_link_libraries(byte_stream_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -10894,6 +11790,7 @@ target_link_libraries(channel_arguments_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -10930,6 +11827,7 @@ target_link_libraries(channel_filter_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -10978,6 +11876,7 @@ target_link_libraries(channel_trace_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -11017,6 +11916,7 @@ target_link_libraries(channelz_registry_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -11066,6 +11966,7 @@ target_link_libraries(channelz_service_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -11113,6 +12014,7 @@ target_link_libraries(channelz_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -11149,6 +12051,7 @@ target_link_libraries(check_gcp_environment_linux_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -11184,6 +12087,7 @@ target_link_libraries(check_gcp_environment_windows_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -11222,6 +12126,7 @@ target_link_libraries(chttp2_settings_timeout_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -11264,6 +12169,7 @@ target_link_libraries(cli_call_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -11303,6 +12209,7 @@ target_link_libraries(client_callback_end2end_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -11351,6 +12258,7 @@ target_link_libraries(client_channel_stress_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
@@ -11391,6 +12299,7 @@ target_link_libraries(client_crash_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -11433,6 +12342,7 @@ target_link_libraries(client_crash_test_server
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -11472,6 +12382,7 @@ target_link_libraries(client_lb_end2end_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -11560,6 +12471,7 @@ target_link_libraries(codegen_test_full
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -11647,6 +12559,7 @@ target_link_libraries(codegen_test_minimal
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -11683,6 +12596,7 @@ target_link_libraries(credentials_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -11723,6 +12637,7 @@ target_link_libraries(cxx_byte_buffer_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -11762,6 +12677,7 @@ target_link_libraries(cxx_slice_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -11797,6 +12713,7 @@ target_link_libraries(cxx_string_ref_test
   grpc
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -11837,6 +12754,7 @@ target_link_libraries(cxx_time_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -11876,6 +12794,7 @@ target_link_libraries(end2end_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -11920,6 +12839,7 @@ target_link_libraries(error_details_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -11959,6 +12879,7 @@ target_link_libraries(exception_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -12000,6 +12921,7 @@ target_link_libraries(filter_end2end_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -12039,6 +12961,7 @@ target_link_libraries(generic_end2end_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -12084,6 +13007,7 @@ target_link_libraries(golden_file_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -12119,6 +13043,7 @@ target_link_libraries(grpc_alts_credentials_options_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -12160,6 +13085,7 @@ target_link_libraries(grpc_cli
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_CODEGEN)
 
@@ -12188,6 +13114,7 @@ target_link_libraries(grpc_cpp_plugin
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_plugin_support
 )
+
 
 
 if (gRPC_INSTALL)
@@ -12226,6 +13153,7 @@ target_link_libraries(grpc_csharp_plugin
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_plugin_support
 )
+
 
 
 if (gRPC_INSTALL)
@@ -12274,6 +13202,7 @@ target_link_libraries(grpc_linux_system_roots_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_CODEGEN)
 
@@ -12302,6 +13231,7 @@ target_link_libraries(grpc_node_plugin
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_plugin_support
 )
+
 
 
 if (gRPC_INSTALL)
@@ -12342,6 +13272,7 @@ target_link_libraries(grpc_objective_c_plugin
 )
 
 
+
 if (gRPC_INSTALL)
   install(TARGETS grpc_objective_c_plugin EXPORT gRPCTargets
     RUNTIME DESTINATION ${gRPC_INSTALL_BINDIR}
@@ -12378,6 +13309,7 @@ target_link_libraries(grpc_php_plugin
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_plugin_support
 )
+
 
 
 if (gRPC_INSTALL)
@@ -12418,6 +13350,7 @@ target_link_libraries(grpc_python_plugin
 )
 
 
+
 if (gRPC_INSTALL)
   install(TARGETS grpc_python_plugin EXPORT gRPCTargets
     RUNTIME DESTINATION ${gRPC_INSTALL_BINDIR}
@@ -12454,6 +13387,7 @@ target_link_libraries(grpc_ruby_plugin
   ${_gRPC_ALLTARGETS_LIBRARIES}
   grpc_plugin_support
 )
+
 
 
 if (gRPC_INSTALL)
@@ -12521,6 +13455,7 @@ target_link_libraries(grpc_tool_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -12565,6 +13500,7 @@ target_link_libraries(grpclb_api_test
   grpc
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -12613,6 +13549,7 @@ target_link_libraries(grpclb_end2end_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -12652,6 +13589,7 @@ target_link_libraries(h2_ssl_cert_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -12690,6 +13628,7 @@ target_link_libraries(h2_ssl_session_reuse_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -12731,6 +13670,7 @@ target_link_libraries(health_service_end2end_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
@@ -12770,6 +13710,7 @@ target_link_libraries(http2_client
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -12812,6 +13753,7 @@ target_link_libraries(hybrid_end2end_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -12850,6 +13792,7 @@ target_link_libraries(inlined_vector_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -12895,6 +13838,7 @@ target_link_libraries(inproc_sync_unary_ping_pong_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -12938,6 +13882,7 @@ target_link_libraries(interop_client
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -12984,6 +13929,7 @@ target_link_libraries(interop_server
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -13024,6 +13970,7 @@ target_link_libraries(interop_test
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -13068,6 +14015,7 @@ target_link_libraries(json_run_localhost
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -13107,6 +14055,7 @@ target_link_libraries(memory_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -13153,6 +14102,7 @@ target_link_libraries(metrics_client
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -13192,6 +14142,7 @@ target_link_libraries(mock_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -13233,6 +14184,7 @@ target_link_libraries(nonblocking_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -13267,6 +14219,7 @@ target_link_libraries(noop-benchmark
   ${_gRPC_BENCHMARK_LIBRARIES}
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -13306,6 +14259,7 @@ target_link_libraries(orphanable_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -13349,6 +14303,7 @@ target_link_libraries(proto_server_reflection_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -13384,6 +14339,7 @@ target_link_libraries(proto_utils_test
   grpc
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -13427,6 +14383,7 @@ target_link_libraries(qps_interarrival_test
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -13472,6 +14429,7 @@ target_link_libraries(qps_json_driver
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 if(_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_POSIX)
@@ -13515,6 +14473,7 @@ target_link_libraries(qps_openloop_test
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -13560,6 +14519,7 @@ target_link_libraries(qps_worker
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -13599,6 +14559,7 @@ target_link_libraries(raw_end2end_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -13661,6 +14622,7 @@ target_link_libraries(reconnect_interop_client
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -13726,6 +14688,7 @@ target_link_libraries(reconnect_interop_server
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -13764,6 +14727,7 @@ target_link_libraries(ref_counted_ptr_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -13804,6 +14768,7 @@ target_link_libraries(ref_counted_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -13841,6 +14806,7 @@ target_link_libraries(retry_throttle_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -13881,6 +14847,7 @@ target_link_libraries(secure_auth_context_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -13926,6 +14893,7 @@ target_link_libraries(secure_sync_unary_ping_pong_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -13966,6 +14934,7 @@ target_link_libraries(server_builder_plugin_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -14020,6 +14989,7 @@ target_link_libraries(server_builder_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -14076,6 +15046,7 @@ target_link_libraries(server_builder_with_socket_mutator_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -14115,6 +15086,7 @@ target_link_libraries(server_context_test_spouse_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -14157,6 +15129,7 @@ target_link_libraries(server_crash_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -14198,6 +15171,7 @@ target_link_libraries(server_crash_test_client
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -14237,6 +15211,7 @@ target_link_libraries(server_early_return_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -14292,6 +15267,7 @@ target_link_libraries(server_request_call_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -14332,6 +15308,7 @@ target_link_libraries(shutdown_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -14370,6 +15347,7 @@ target_link_libraries(slice_hash_table_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -14407,6 +15385,7 @@ target_link_libraries(slice_weak_hash_table_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -14447,6 +15426,7 @@ target_link_libraries(stats_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -14482,6 +15462,7 @@ target_link_libraries(status_metadata_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -14516,6 +15497,7 @@ target_link_libraries(status_util_test
   grpc
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -14557,6 +15539,7 @@ target_link_libraries(streaming_throughput_test
   gpr
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -14631,6 +15614,7 @@ target_link_libraries(stress_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -14668,6 +15652,7 @@ target_link_libraries(thread_manager_test
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -14709,6 +15694,7 @@ target_link_libraries(thread_stress_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -14749,6 +15735,7 @@ target_link_libraries(transport_pid_controller_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -14785,6 +15772,7 @@ target_link_libraries(transport_security_common_api_test
   grpc
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -14827,6 +15815,7 @@ target_link_libraries(writes_per_rpc_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -14855,6 +15844,7 @@ target_link_libraries(public_headers_must_be_c89
   gpr
 )
 
+
 endif (gRPC_BUILD_TESTS)
 
 add_executable(gen_hpack_tables
@@ -14882,6 +15872,7 @@ target_link_libraries(gen_hpack_tables
 )
 
 
+
 add_executable(gen_legal_metadata_characters
   tools/codegen/core/gen_legal_metadata_characters.cc
 )
@@ -14905,6 +15896,7 @@ target_link_libraries(gen_legal_metadata_characters
 )
 
 
+
 add_executable(gen_percent_encoding_tables
   tools/codegen/core/gen_percent_encoding_tables.cc
 )
@@ -14926,6 +15918,7 @@ target_include_directories(gen_percent_encoding_tables
 target_link_libraries(gen_percent_encoding_tables
   ${_gRPC_ALLTARGETS_LIBRARIES}
 )
+
 
 if (gRPC_BUILD_TESTS)
 
@@ -14956,6 +15949,12 @@ target_link_libraries(badreq_bad_client_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(badreq_bad_client_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(badreq_bad_client_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -14988,6 +15987,12 @@ target_link_libraries(connection_prefix_bad_client_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(connection_prefix_bad_client_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(connection_prefix_bad_client_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15018,6 +16023,12 @@ target_link_libraries(duplicate_header_bad_client_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(duplicate_header_bad_client_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(duplicate_header_bad_client_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15050,6 +16061,12 @@ target_link_libraries(head_of_line_blocking_bad_client_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(head_of_line_blocking_bad_client_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(head_of_line_blocking_bad_client_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15080,6 +16097,12 @@ target_link_libraries(headers_bad_client_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(headers_bad_client_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(headers_bad_client_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15112,6 +16135,12 @@ target_link_libraries(initial_settings_frame_bad_client_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(initial_settings_frame_bad_client_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(initial_settings_frame_bad_client_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15142,6 +16171,12 @@ target_link_libraries(large_metadata_bad_client_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(large_metadata_bad_client_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(large_metadata_bad_client_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15174,6 +16209,12 @@ target_link_libraries(server_registered_method_bad_client_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(server_registered_method_bad_client_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(server_registered_method_bad_client_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15204,6 +16245,12 @@ target_link_libraries(simple_request_bad_client_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(simple_request_bad_client_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(simple_request_bad_client_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15236,6 +16283,12 @@ target_link_libraries(unknown_frame_bad_client_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(unknown_frame_bad_client_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(unknown_frame_bad_client_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15266,6 +16319,12 @@ target_link_libraries(window_overflow_bad_client_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(window_overflow_bad_client_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(window_overflow_bad_client_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15298,6 +16357,12 @@ target_link_libraries(bad_ssl_cert_server
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(bad_ssl_cert_server PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(bad_ssl_cert_server PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15328,6 +16393,12 @@ target_link_libraries(bad_ssl_cert_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(bad_ssl_cert_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(bad_ssl_cert_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -15360,6 +16431,12 @@ target_link_libraries(h2_census_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_census_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_census_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15390,6 +16467,12 @@ target_link_libraries(h2_compress_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_compress_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_compress_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15419,6 +16502,12 @@ target_link_libraries(h2_fakesec_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_fakesec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_fakesec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15451,6 +16540,12 @@ target_link_libraries(h2_fd_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_fd_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_fd_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15481,6 +16576,12 @@ target_link_libraries(h2_full_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_full_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_full_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15513,6 +16614,12 @@ target_link_libraries(h2_full+pipe_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_full+pipe_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_full+pipe_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15544,6 +16651,12 @@ target_link_libraries(h2_full+trace_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_full+trace_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_full+trace_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15574,6 +16687,12 @@ target_link_libraries(h2_full+workarounds_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_full+workarounds_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_full+workarounds_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15603,6 +16722,12 @@ target_link_libraries(h2_http_proxy_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_http_proxy_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_http_proxy_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15635,6 +16760,12 @@ target_link_libraries(h2_local_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_local_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_local_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15666,6 +16797,12 @@ target_link_libraries(h2_oauth2_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_oauth2_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_oauth2_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15695,6 +16832,12 @@ target_link_libraries(h2_proxy_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_proxy_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_proxy_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15726,6 +16869,12 @@ target_link_libraries(h2_sockpair_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_sockpair_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_sockpair_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15755,6 +16904,12 @@ target_link_libraries(h2_sockpair+trace_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_sockpair+trace_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_sockpair+trace_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15786,6 +16941,12 @@ target_link_libraries(h2_sockpair_1byte_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_sockpair_1byte_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_sockpair_1byte_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15816,6 +16977,12 @@ target_link_libraries(h2_ssl_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_ssl_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_ssl_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15845,6 +17012,12 @@ target_link_libraries(h2_ssl_proxy_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_ssl_proxy_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_ssl_proxy_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15877,6 +17050,12 @@ target_link_libraries(h2_uds_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_uds_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_uds_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15908,6 +17087,12 @@ target_link_libraries(inproc_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(inproc_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(inproc_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15938,6 +17123,12 @@ target_link_libraries(h2_census_nosec_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_census_nosec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_census_nosec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -15967,6 +17158,12 @@ target_link_libraries(h2_compress_nosec_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_compress_nosec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_compress_nosec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -15999,6 +17196,12 @@ target_link_libraries(h2_fd_nosec_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_fd_nosec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_fd_nosec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16029,6 +17232,12 @@ target_link_libraries(h2_full_nosec_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_full_nosec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_full_nosec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16061,6 +17270,12 @@ target_link_libraries(h2_full+pipe_nosec_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_full+pipe_nosec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_full+pipe_nosec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16092,6 +17307,12 @@ target_link_libraries(h2_full+trace_nosec_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_full+trace_nosec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_full+trace_nosec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -16121,6 +17342,12 @@ target_link_libraries(h2_full+workarounds_nosec_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_full+workarounds_nosec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_full+workarounds_nosec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16152,6 +17379,12 @@ target_link_libraries(h2_http_proxy_nosec_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_http_proxy_nosec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_http_proxy_nosec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -16181,6 +17414,12 @@ target_link_libraries(h2_proxy_nosec_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_proxy_nosec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_proxy_nosec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16212,6 +17451,12 @@ target_link_libraries(h2_sockpair_nosec_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_sockpair_nosec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_sockpair_nosec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -16242,6 +17487,12 @@ target_link_libraries(h2_sockpair+trace_nosec_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_sockpair+trace_nosec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_sockpair+trace_nosec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -16271,6 +17522,12 @@ target_link_libraries(h2_sockpair_1byte_nosec_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_sockpair_1byte_nosec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_sockpair_1byte_nosec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16303,6 +17560,12 @@ target_link_libraries(h2_uds_nosec_test
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(h2_uds_nosec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(h2_uds_nosec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16333,6 +17596,12 @@ target_link_libraries(inproc_nosec_test
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(inproc_nosec_test PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(inproc_nosec_test PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16375,6 +17644,7 @@ target_link_libraries(resolver_component_test_unsecure
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -16415,6 +17685,7 @@ target_link_libraries(resolver_component_test
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16457,6 +17728,7 @@ target_link_libraries(resolver_component_tests_runner_invoker_unsecure
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif()
 endif (gRPC_BUILD_TESTS)
@@ -16501,6 +17773,7 @@ target_link_libraries(resolver_component_tests_runner_invoker
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16543,6 +17816,7 @@ target_link_libraries(address_sorting_test_unsecure
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -16583,6 +17857,7 @@ target_link_libraries(address_sorting_test
   grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
+
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16625,6 +17900,7 @@ target_link_libraries(cancel_ares_query_test
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -16654,6 +17930,12 @@ target_link_libraries(alts_credentials_fuzzer_one_entry
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(alts_credentials_fuzzer_one_entry PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(alts_credentials_fuzzer_one_entry PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16685,6 +17967,12 @@ target_link_libraries(api_fuzzer_one_entry
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(api_fuzzer_one_entry PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(api_fuzzer_one_entry PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -16714,6 +18002,12 @@ target_link_libraries(client_fuzzer_one_entry
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(client_fuzzer_one_entry PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(client_fuzzer_one_entry PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16745,6 +18039,12 @@ target_link_libraries(hpack_parser_fuzzer_test_one_entry
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(hpack_parser_fuzzer_test_one_entry PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(hpack_parser_fuzzer_test_one_entry PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -16774,6 +18074,12 @@ target_link_libraries(http_request_fuzzer_test_one_entry
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(http_request_fuzzer_test_one_entry PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(http_request_fuzzer_test_one_entry PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16805,6 +18111,12 @@ target_link_libraries(http_response_fuzzer_test_one_entry
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(http_response_fuzzer_test_one_entry PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(http_response_fuzzer_test_one_entry PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -16834,6 +18146,12 @@ target_link_libraries(json_fuzzer_test_one_entry
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(json_fuzzer_test_one_entry PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(json_fuzzer_test_one_entry PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16865,6 +18183,12 @@ target_link_libraries(nanopb_fuzzer_response_test_one_entry
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(nanopb_fuzzer_response_test_one_entry PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(nanopb_fuzzer_response_test_one_entry PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -16894,6 +18218,12 @@ target_link_libraries(nanopb_fuzzer_serverlist_test_one_entry
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(nanopb_fuzzer_serverlist_test_one_entry PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(nanopb_fuzzer_serverlist_test_one_entry PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16925,6 +18255,12 @@ target_link_libraries(percent_decode_fuzzer_one_entry
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(percent_decode_fuzzer_one_entry PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(percent_decode_fuzzer_one_entry PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -16954,6 +18290,12 @@ target_link_libraries(percent_encode_fuzzer_one_entry
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(percent_encode_fuzzer_one_entry PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(percent_encode_fuzzer_one_entry PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
@@ -16985,6 +18327,12 @@ target_link_libraries(server_fuzzer_one_entry
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(server_fuzzer_one_entry PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(server_fuzzer_one_entry PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -17015,6 +18363,12 @@ target_link_libraries(ssl_server_fuzzer_one_entry
   gpr
 )
 
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(ssl_server_fuzzer_one_entry PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(ssl_server_fuzzer_one_entry PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
+
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
@@ -17044,6 +18398,12 @@ target_link_libraries(uri_fuzzer_test_one_entry
   gpr_test_util
   gpr
 )
+
+  # avoid dependency on libstdc++
+  if (_gRPC_CORE_NOSTDCXX_FLAGS)
+    set_target_properties(uri_fuzzer_test_one_entry PROPERTIES LINKER_LANGUAGE C)
+    target_compile_options(uri_fuzzer_test_one_entry PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}>)
+  endif()
 
 endif (gRPC_BUILD_TESTS)
 

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -164,6 +164,17 @@
     set(_gRPC_PROTOBUF_LIBRARY_NAME "libprotobuf")
   endif()
 
+  if (_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC)
+    # C core has C++ source code, but should not depend on libstc++ (for better portability).
+    # We need to use a few tricks to convince cmake to do that.
+    # https://stackoverflow.com/questions/15058403/how-to-stop-cmake-from-linking-against-libstdc
+    set(CMAKE_CXX_IMPLICIT_LINK_LIBRARIES "")
+    # Exceptions and RTTI must be off to avoid dependency on libstdc++
+    set(_gRPC_CORE_NOSTDCXX_FLAGS -fno-exceptions -fno-rtti)
+  else()
+    set(_gRPC_CORE_NOSTDCXX_FLAGS "")
+  endif()
+
   include(cmake/zlib.cmake)
   include(cmake/cares.cmake)
   include(cmake/protobuf.cmake)
@@ -403,7 +414,14 @@
     PRIVATE <%text>${_gRPC_PROTO_GENS_DIR}</%text>
   % endif
   )
-
+  % if lib.language in ['c', 'csharp']:
+    # avoid dependency on libstdc++
+    if (_gRPC_CORE_NOSTDCXX_FLAGS)
+      set_target_properties(${lib.name} PROPERTIES LINKER_LANGUAGE C)
+      # only use the flags for C++ source files
+      target_compile_options(${lib.name} PRIVATE <%text>$<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}></%text>)
+    endif()
+  % endif
   % if len(get_deps(lib)) > 0:
   target_link_libraries(${lib.name}
   % for dep in get_deps(lib):
@@ -492,6 +510,14 @@
     ${dep}
   % endfor
   )
+
+  % if tgt.language in ['c', 'csharp']:
+    # avoid dependency on libstdc++
+    if (_gRPC_CORE_NOSTDCXX_FLAGS)
+      set_target_properties(${tgt.name} PROPERTIES LINKER_LANGUAGE C)
+      target_compile_options(${tgt.name} PRIVATE <%text>$<$<COMPILE_LANGUAGE:CXX>:${_gRPC_CORE_NOSTDCXX_FLAGS}></%text>)
+    endif()
+  % endif
   % endif
   </%def>
 


### PR DESCRIPTION
When building with make, C core libraries intentionally don't depend on libstdc++ (for better portability)

This PR makes that cmake-built core libraries (and C# extension) do not depend on libstdc++ on Linux and Mac.
On windows and Android this is not necessary because the backward-compatibility is ensured by other means.

Changes:
- where applicable, use C linker instead of C++ linker for C-core libraries and executables.
- set `-fno-exceptions` and  `-fno-rtti` for .cc files that are part of C-core as they would add a requirement to link against libstdc++ (Make does the same thing). 

Note: This PR is a prerequisite for building grpc_csharp_ext with assembly-optimized boringssl. 
