### PR TITLE
server-reflection.md: fix markdown

### DIFF
--- a/doc/server-reflection.md
+++ b/doc/server-reflection.md
@@ -161,6 +161,7 @@ which FileDescriptorProtos have been sent on a given stream, for a given value
 of valid_host, and avoid sending them repeatedly for overlapping requests.
 
 | message_request message     | Result                                          |
+| --------------------------- | ----------------------------------------------- |
 | files_for_file_name         | transitive closure of file name                 |
 | files_for_symbol_name       | transitive closure file containing symbol       |
 | file_containing_extension   | transitive closure of file containing a given extension number of a given symbol |


### PR DESCRIPTION
The table isn't rendered correctly.

Supersedes https://github.com/grpc/grpc/pull/16093 (which doesn't have CLA signed, so I recreated the fix).