### PR TITLE
Don't send error on call_creds=none

### DIFF
--- a/test/cpp/util/cli_credentials.cc
+++ b/test/cpp/util/cli_credentials.cc
@@ -151,7 +151,7 @@ std::shared_ptr<grpc::CallCredentials> CliCredentials::GetCallCredentials()
   if (IsAccessToken(FLAGS_call_creds)) {
     return grpc::AccessTokenCredentials(AccessToken(FLAGS_call_creds));
   }
-  if (FLAGS_call_creds.compare("none") != 0) {
+  if (FLAGS_call_creds.compare("none") == 0) {
     // Nothing to do; creds, if any, are baked into the channel.
     return std::shared_ptr<grpc::CallCredentials>();
   }


### PR DESCRIPTION
The "call_creds=%s invalid" error message is intended for call_creds other than an access token or "none". However due to the inverted compare check, we printed the error message when call_creds=none, rather than on invalid option. This commit changes to print error message in correct situation.

Note actual behavior is not changed, as invalid call_creds is treated the same as "none".