### PR TITLE
Support `IPv4 only` channel argument for server and client channels

### DIFF
--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -345,6 +345,8 @@ typedef struct {
 /** If set to non zero, surfaces the user agent string to the server. User
     agent is surfaced by default. */
 #define GRPC_ARG_SURFACE_USER_AGENT "grpc.surface_user_agent"
+/** If non-zero, resolve server port only on IPv4. */
+#define GRPC_ARG_IPV4_ONLY "grpc.ipv4_only"
 /** \} */
 
 /** Result of a grpc call. If the caller satisfies the prerequisites of a

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -454,13 +454,21 @@ static grpc_address_resolver_vtable* default_resolver;
 
 static grpc_error* blocking_resolve_address_ares(
     const char* name, const char* default_port,
-    grpc_resolved_addresses** addresses) {
+    grpc_resolved_addresses** addresses, grpc_channel_args* channel_args) {
   return default_resolver->blocking_resolve_address(name, default_port,
-                                                    addresses);
+                                                    addresses, channel_args);
+}
+
+static void resolve_address_ares(const char* name, const char* default_port,
+    grpc_pollset_set* interested_parties,
+    grpc_closure* on_done,
+    grpc_resolved_addresses** addresses,
+    grpc_channel_args*) {
+    grpc_resolve_address_ares(name, default_port, interested_parties, on_done, addresses);
 }
 
 static grpc_address_resolver_vtable ares_resolver = {
-    grpc_resolve_address_ares, blocking_resolve_address_ares};
+    resolve_address_ares, blocking_resolve_address_ares};
 
 void grpc_resolver_dns_ares_init() {
   char* resolver_env = gpr_getenv("GRPC_DNS_RESOLVER");

--- a/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
@@ -286,7 +286,7 @@ void NativeDnsResolver::StartResolvingLocked() {
   resolving_ = true;
   addresses_ = nullptr;
   grpc_resolve_address(name_to_resolve_, kDefaultPort, interested_parties_,
-                       &on_resolved_, &addresses_);
+                       &on_resolved_, &addresses_, channel_args_);
   last_resolution_timestamp_ = grpc_core::ExecCtx::Get()->Now();
 }
 

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -266,7 +266,7 @@ grpc_error* grpc_chttp2_server_add_port(grpc_server* server, const char* addr,
   *port_num = -1;
 
   /* resolve address */
-  err = grpc_blocking_resolve_address(addr, "https", &resolved);
+  err = grpc_blocking_resolve_address(addr, "https", &resolved, args);
   if (err != GRPC_ERROR_NONE) {
     goto error;
   }

--- a/src/core/lib/iomgr/resolve_address.cc
+++ b/src/core/lib/iomgr/resolve_address.cc
@@ -30,9 +30,10 @@ void grpc_set_resolver_impl(grpc_address_resolver_vtable* vtable) {
 void grpc_resolve_address(const char* addr, const char* default_port,
                           grpc_pollset_set* interested_parties,
                           grpc_closure* on_done,
-                          grpc_resolved_addresses** addresses) {
+                          grpc_resolved_addresses** addresses,
+                          grpc_channel_args* channel_args) {
   grpc_resolve_address_impl->resolve_address(
-      addr, default_port, interested_parties, on_done, addresses);
+      addr, default_port, interested_parties, on_done, addresses, channel_args);
 }
 
 void grpc_resolved_addresses_destroy(grpc_resolved_addresses* addrs) {
@@ -44,7 +45,8 @@ void grpc_resolved_addresses_destroy(grpc_resolved_addresses* addrs) {
 
 grpc_error* grpc_blocking_resolve_address(const char* name,
                                           const char* default_port,
-                                          grpc_resolved_addresses** addresses) {
+                                          grpc_resolved_addresses** addresses,
+                                          grpc_channel_args* channel_args) {
   return grpc_resolve_address_impl->blocking_resolve_address(name, default_port,
-                                                             addresses);
+                                                             addresses, channel_args);
 }

--- a/src/core/lib/iomgr/resolve_address.h
+++ b/src/core/lib/iomgr/resolve_address.h
@@ -20,6 +20,7 @@
 #define GRPC_CORE_LIB_IOMGR_RESOLVE_ADDRESS_H
 
 #include <grpc/support/port_platform.h>
+#include <grpc/impl/codegen/grpc_types.h>
 
 #include <stddef.h>
 
@@ -55,10 +56,12 @@ typedef struct grpc_address_resolver_vtable {
   void (*resolve_address)(const char* addr, const char* default_port,
                           grpc_pollset_set* interested_parties,
                           grpc_closure* on_done,
-                          grpc_resolved_addresses** addresses);
+                          grpc_resolved_addresses** addresses,
+                          grpc_channel_args* channel_args);
   grpc_error* (*blocking_resolve_address)(const char* name,
                                           const char* default_port,
-                                          grpc_resolved_addresses** addresses);
+                                          grpc_resolved_addresses** addresses,
+                                          grpc_channel_args* channel_args);
 } grpc_address_resolver_vtable;
 
 void grpc_set_resolver_impl(grpc_address_resolver_vtable* vtable);
@@ -69,7 +72,8 @@ void grpc_set_resolver_impl(grpc_address_resolver_vtable* vtable);
 void grpc_resolve_address(const char* addr, const char* default_port,
                           grpc_pollset_set* interested_parties,
                           grpc_closure* on_done,
-                          grpc_resolved_addresses** addresses);
+                          grpc_resolved_addresses** addresses,
+                          grpc_channel_args* channel_args = nullptr);
 
 /* Destroy resolved addresses */
 void grpc_resolved_addresses_destroy(grpc_resolved_addresses* addresses);
@@ -78,6 +82,7 @@ void grpc_resolved_addresses_destroy(grpc_resolved_addresses* addresses);
    result must be freed with grpc_resolved_addresses_destroy. */
 grpc_error* grpc_blocking_resolve_address(const char* name,
                                           const char* default_port,
-                                          grpc_resolved_addresses** addresses);
+                                          grpc_resolved_addresses** addresses,
+                                          grpc_channel_args* channel_args = nullptr);
 
 #endif /* GRPC_CORE_LIB_IOMGR_RESOLVE_ADDRESS_H */

--- a/src/core/lib/iomgr/resolve_address_custom.cc
+++ b/src/core/lib/iomgr/resolve_address_custom.cc
@@ -37,6 +37,7 @@
 typedef struct grpc_custom_resolver {
   grpc_closure* on_done;
   grpc_resolved_addresses** addresses;
+  grpc_channel_args* channel_args;
   char* host;
   char* port;
 } grpc_custom_resolver;
@@ -114,7 +115,7 @@ static grpc_error* try_split_host_port(const char* name,
 
 static grpc_error* blocking_resolve_address_impl(
     const char* name, const char* default_port,
-    grpc_resolved_addresses** addresses) {
+    grpc_resolved_addresses** addresses, grpc_channel_args* channel_args) {
   char* host;
   char* port;
   grpc_error* err;
@@ -132,6 +133,7 @@ static grpc_error* blocking_resolve_address_impl(
   grpc_custom_resolver resolver;
   resolver.host = host;
   resolver.port = port;
+  resolver.channel_args = channel_args;
 
   grpc_resolved_addresses* addrs;
   grpc_core::ExecCtx* curr = grpc_core::ExecCtx::Get();
@@ -155,7 +157,8 @@ static grpc_error* blocking_resolve_address_impl(
 static void resolve_address_impl(const char* name, const char* default_port,
                                  grpc_pollset_set* interested_parties,
                                  grpc_closure* on_done,
-                                 grpc_resolved_addresses** addrs) {
+                                 grpc_resolved_addresses** addrs,
+                                 grpc_channel_args* channel_args) {
   grpc_custom_resolver* r = nullptr;
   char* host = nullptr;
   char* port = nullptr;
@@ -171,6 +174,7 @@ static void resolve_address_impl(const char* name, const char* default_port,
   r = (grpc_custom_resolver*)gpr_malloc(sizeof(grpc_custom_resolver));
   r->on_done = on_done;
   r->addresses = addrs;
+  r->channel_args = channel_args;
   r->host = host;
   r->port = port;
 


### PR DESCRIPTION
### Problem:
Our service should always be reachable only by IPv4 network protocol.
When we run the service on a machine without reachable IPv4 network protocol - we want to see error on the service startup. But the service successfully starts only on IPv6 network protocol without any errors. As a result - we can't connect from a client to the successfully started service.

### Solution:
Added new channel argument for the server builder which resolving service only on IPv4 network protocol. As a result the server using only IPv4 for binding (server open the port only as IPv4). And the client using only IPv4 for connect to the server (IPv6 server interface ignored if exists).

### Implementation:
* Created a new channel argument `grpc.ipv4_only` with macro `GRPC_ARG_IPV4_ONLY` like other grpc channel arguments.
* Passed `grpc_channel_args` into address resolvers (linux, windows, etc...)
* Modified resolver using this channel argument and if this channel argument exists and non-zero - resolve only IPv4 addresses.

### Using this feature from code:
```
// For server
grpc::ServerBuilder builder;
builder.AddChannelArgument(GRPC_ARG_IPV4_ONLY, 1);
...
builder.BuildAndStart()

// For client
grpc::ChannelArguments channelArgs;
channelArgs.SetInt(GRPC_ARG_IPV4_ONLY, 1);
... = grpc::CreateCustomChannel(..., ..., channelArgs);
```

### Further development
Make same feature for the java.