### PR TITLE
use Ninja to build grpc_csharp_ext windows artifact

### DIFF
--- a/doc/ssl-performance.md
+++ b/doc/ssl-performance.md
@@ -28,7 +28,7 @@ Language | From source | Platform | Uses assembly optimizations
 C#      | n/a | Linux, 64bit | :heavy_check_mark:
 C#      | n/a | Linux, 32bit | :x:
 C#      | n/a | MacOS | :heavy_check_mark:
-C#      | n/a | Windows | :x:
+C#      | n/a | Windows | :heavy_check_mark:
 Node.JS | n/a | Linux | :heavy_check_mark:
 Node.JS | n/a | MacOS | :heavy_check_mark:
 Node.JS | n/a | Windows | :x:

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -240,11 +240,10 @@ class CSharpExtArtifact:
                 ['tools/run_tests/artifacts/build_artifact_csharp_ios.sh'],
                 use_workspace=True)
         elif self.platform == 'windows':
-            cmake_arch_option = 'Win32' if self.arch == 'x86' else self.arch
             return create_jobspec(
                 self.name, [
                     'tools\\run_tests\\artifacts\\build_artifact_csharp.bat',
-                    cmake_arch_option
+                    self.arch
                 ],
                 use_workspace=True)
         else:

--- a/tools/run_tests/artifacts/build_artifact_csharp.bat
+++ b/tools/run_tests/artifacts/build_artifact_csharp.bat
@@ -15,16 +15,33 @@
 @rem Builds C# artifacts on Windows
 
 set ARCHITECTURE=%1
-set GRPC_SKIP_DOTNET_RESTORE=true
-@call tools\run_tests\helper_scripts\pre_build_csharp.bat %ARCHITECTURE% || goto :error
 
-cd cmake\build\%ARCHITECTURE%
-cmake --build . --target grpc_csharp_ext --config RelWithDebInfo
+@rem enter repo root
+cd /d %~dp0\..\..\..
+
+mkdir cmake
+cd cmake
+mkdir build
+cd build
+mkdir %ARCHITECTURE%
+cd %ARCHITECTURE%
+
+@rem TODO(jtattermusch): is there a better way to force using MSVC?
+@rem select the MSVC compiler explicitly to avoid using gcc from mingw or cygwin
+@rem (both are on path)
+set "MSVC_COMPILER=C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/cl.exe"
+if "%ARCHITECTURE%" == "x64" (
+  set "MSVC_COMPILER=C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/amd64/cl.exe"
+)
+
+call "%VS140COMNTOOLS%..\..\VC\vcvarsall.bat" %ARCHITECTURE%
+cmake -G Ninja -DCMAKE_C_COMPILER="%MSVC_COMPILER%" -DCMAKE_CXX_COMPILER="%MSVC_COMPILER%" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DgRPC_BUILD_TESTS=OFF -DgRPC_MSVC_STATIC_RUNTIME=ON ../../.. || goto :error
+cmake --build . --target grpc_csharp_ext
 cd ..\..\..
 
 mkdir -p %ARTIFACTS_OUT%
-copy /Y cmake\build\Win32\RelWithDebInfo\grpc_csharp_ext.dll %ARTIFACTS_OUT% || copy /Y cmake\build\x64\RelWithDebInfo\grpc_csharp_ext.dll %ARTIFACTS_OUT% || goto :error
-copy /Y cmake\build\Win32\RelWithDebInfo\grpc_csharp_ext.pdb %ARTIFACTS_OUT% || copy /Y cmake\build\x64\RelWithDebInfo\grpc_csharp_ext.pdb %ARTIFACTS_OUT% || goto :error
+copy /Y cmake\build\%ARCHITECTURE%\grpc_csharp_ext.dll %ARTIFACTS_OUT% || goto :error
+copy /Y cmake\build\%ARCHITECTURE%\grpc_csharp_ext.pdb %ARTIFACTS_OUT% || goto :error
 
 goto :EOF
 

--- a/tools/run_tests/helper_scripts/pre_build_csharp.bat
+++ b/tools/run_tests/helper_scripts/pre_build_csharp.bat
@@ -32,9 +32,7 @@ cmake -G "Visual Studio 14 2015" -A %ARCHITECTURE% -DgRPC_BUILD_TESTS=OFF -DgRPC
 
 cd ..\..\..\src\csharp
 
-if NOT DEFINED GRPC_SKIP_DOTNET_RESTORE (
-  dotnet restore Grpc.sln || goto :error
-)
+dotnet restore Grpc.sln || goto :error
 
 endlocal
 


### PR DESCRIPTION
When building with Ninja, we can actually produce assembly-optimized version of boringssl.

FTR this is why assembly optimizations are disabled with Visual Studio: https://github.com/grpc/grpc/blob/912b8ab4d49cd6cde76675d37c896e5edcf67487/cmake/ssl.cmake#L20