### PR TITLE
Simplify in-Python call of grpc_tools.protoc.main(...)

### DIFF
--- a/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
+++ b/tools/distrib/python/grpcio_tools/grpc_tools/protoc.py
@@ -14,23 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import pkg_resources
 import sys
 
 from grpc_tools import _protoc_compiler
 
 
-def main(command_arguments):
+def main(command_arguments, include_module_proto=True):
     """Run the protocol buffer compiler with the given command-line arguments.
 
   Args:
-    command_arguments: a list of strings representing command line arguments to
+    command_arguments: A list of strings representing command line arguments to
         `protoc`.
+    include_module_proto: Wether `*.proto` files comming with the current py-module
+        will be included too.
   """
+    if include_module_proto:
+        proto_include = pkg_resources.resource_filename('grpc_tools', '_proto')
+        command_arguments.append('-I{}'.format(proto_include))
+
+    command_arguments = [os.path.abspath(__file__)] + command_arguments
     command_arguments = [argument.encode() for argument in command_arguments]
     return _protoc_compiler.run_main(command_arguments)
 
 
 if __name__ == '__main__':
-    proto_include = pkg_resources.resource_filename('grpc_tools', '_proto')
-    sys.exit(main(sys.argv + ['-I{}'.format(proto_include)]))
+    retcode = main(sys.argv[1:], include_module_proto=True)
+    sys.exit(retcode)


### PR DESCRIPTION
In-Python call of `grpc_tools.protoc.main(...)` has two issues:
* One need to specify path to the `protoc.py` as the first argument;
* `proto`-files from the `<py-packages>/grpc_tools/_proto` are not included by default.