### PR TITLE
Update security connector API w.r.t passing in pollset_set

### DIFF
--- a/src/core/lib/http/httpcli_security_connector.cc
+++ b/src/core/lib/http/httpcli_security_connector.cc
@@ -29,6 +29,7 @@
 #include "src/core/lib/channel/channel_args.h"
 #include "src/core/lib/channel/handshaker_registry.h"
 #include "src/core/lib/gpr/string.h"
+#include "src/core/lib/iomgr/pollset.h"
 #include "src/core/lib/security/transport/security_handshaker.h"
 #include "src/core/lib/slice/slice_internal.h"
 #include "src/core/tsi/ssl_transport_security.h"
@@ -51,6 +52,7 @@ static void httpcli_ssl_destroy(grpc_security_connector* sc) {
 }
 
 static void httpcli_ssl_add_handshakers(grpc_channel_security_connector* sc,
+                                        grpc_pollset_set* interested_parties,
                                         grpc_handshake_manager* handshake_mgr) {
   grpc_httpcli_ssl_channel_security_connector* c =
       reinterpret_cast<grpc_httpcli_ssl_channel_security_connector*>(sc);

--- a/src/core/lib/security/security_connector/alts_security_connector.cc
+++ b/src/core/lib/security/security_connector/alts_security_connector.cc
@@ -64,7 +64,7 @@ static void alts_server_destroy(grpc_security_connector* sc) {
 }
 
 static void alts_channel_add_handshakers(
-    grpc_channel_security_connector* sc,
+    grpc_channel_security_connector* sc, grpc_pollset_set* interested_parties,
     grpc_handshake_manager* handshake_manager) {
   tsi_handshaker* handshaker = nullptr;
   auto c = reinterpret_cast<grpc_alts_channel_security_connector*>(sc);
@@ -72,13 +72,13 @@ static void alts_channel_add_handshakers(
       reinterpret_cast<grpc_alts_credentials*>(c->base.channel_creds);
   GPR_ASSERT(alts_tsi_handshaker_create(
                  creds->options, c->target_name, creds->handshaker_service_url,
-                 true, sc->base.interested_parties, &handshaker) == TSI_OK);
+                 true, interested_parties, &handshaker) == TSI_OK);
   grpc_handshake_manager_add(handshake_manager, grpc_security_handshaker_create(
                                                     handshaker, &sc->base));
 }
 
 static void alts_server_add_handshakers(
-    grpc_server_security_connector* sc,
+    grpc_server_security_connector* sc, grpc_pollset_set* interested_parties,
     grpc_handshake_manager* handshake_manager) {
   tsi_handshaker* handshaker = nullptr;
   auto c = reinterpret_cast<grpc_alts_server_security_connector*>(sc);
@@ -86,7 +86,7 @@ static void alts_server_add_handshakers(
       reinterpret_cast<grpc_alts_server_credentials*>(c->base.server_creds);
   GPR_ASSERT(alts_tsi_handshaker_create(
                  creds->options, nullptr, creds->handshaker_service_url, false,
-                 sc->base.interested_parties, &handshaker) == TSI_OK);
+                 interested_parties, &handshaker) == TSI_OK);
   grpc_handshake_manager_add(handshake_manager, grpc_security_handshaker_create(
                                                     handshaker, &sc->base));
 }

--- a/src/core/lib/security/security_connector/local_security_connector.cc
+++ b/src/core/lib/security/security_connector/local_security_connector.cc
@@ -30,6 +30,7 @@
 
 #include "src/core/ext/filters/client_channel/client_channel.h"
 #include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/iomgr/pollset.h"
 #include "src/core/lib/security/credentials/local/local_credentials.h"
 #include "src/core/lib/security/transport/security_handshaker.h"
 #include "src/core/tsi/local_transport_security.h"
@@ -68,7 +69,7 @@ static void local_server_destroy(grpc_security_connector* sc) {
 }
 
 static void local_channel_add_handshakers(
-    grpc_channel_security_connector* sc,
+    grpc_channel_security_connector* sc, grpc_pollset_set* interested_parties,
     grpc_handshake_manager* handshake_manager) {
   tsi_handshaker* handshaker = nullptr;
   GPR_ASSERT(local_tsi_handshaker_create(true /* is_client */, &handshaker) ==
@@ -78,7 +79,7 @@ static void local_channel_add_handshakers(
 }
 
 static void local_server_add_handshakers(
-    grpc_server_security_connector* sc,
+    grpc_server_security_connector* sc, grpc_pollset_set* interested_parties,
     grpc_handshake_manager* handshake_manager) {
   tsi_handshaker* handshaker = nullptr;
   GPR_ASSERT(local_tsi_handshaker_create(false /* is_client */, &handshaker) ==

--- a/src/core/lib/security/security_connector/security_connector.cc
+++ b/src/core/lib/security/security_connector/security_connector.cc
@@ -123,8 +123,7 @@ void grpc_channel_security_connector_add_handshakers(
     grpc_pollset_set* interested_parties,
     grpc_handshake_manager* handshake_mgr) {
   if (connector != nullptr) {
-    connector->base.interested_parties = interested_parties;
-    connector->add_handshakers(connector, handshake_mgr);
+    connector->add_handshakers(connector, interested_parties, handshake_mgr);
   }
 }
 
@@ -133,8 +132,7 @@ void grpc_server_security_connector_add_handshakers(
     grpc_pollset_set* interested_parties,
     grpc_handshake_manager* handshake_mgr) {
   if (connector != nullptr) {
-    connector->base.interested_parties = interested_parties;
-    connector->add_handshakers(connector, handshake_mgr);
+    connector->add_handshakers(connector, interested_parties, handshake_mgr);
   }
 }
 
@@ -523,7 +521,7 @@ static void fake_channel_cancel_check_call_host(
 }
 
 static void fake_channel_add_handshakers(
-    grpc_channel_security_connector* sc,
+    grpc_channel_security_connector* sc, grpc_pollset_set* interested_parties,
     grpc_handshake_manager* handshake_mgr) {
   grpc_handshake_manager_add(
       handshake_mgr,
@@ -532,6 +530,7 @@ static void fake_channel_add_handshakers(
 }
 
 static void fake_server_add_handshakers(grpc_server_security_connector* sc,
+                                        grpc_pollset_set* interested_parties,
                                         grpc_handshake_manager* handshake_mgr) {
   grpc_handshake_manager_add(
       handshake_mgr,
@@ -673,6 +672,7 @@ static void ssl_server_destroy(grpc_security_connector* sc) {
 }
 
 static void ssl_channel_add_handshakers(grpc_channel_security_connector* sc,
+                                        grpc_pollset_set* interested_parties,
                                         grpc_handshake_manager* handshake_mgr) {
   grpc_ssl_channel_security_connector* c =
       reinterpret_cast<grpc_ssl_channel_security_connector*>(sc);
@@ -783,6 +783,7 @@ static bool try_fetch_ssl_server_credentials(
 }
 
 static void ssl_server_add_handshakers(grpc_server_security_connector* sc,
+                                       grpc_pollset_set* interested_parties,
                                        grpc_handshake_manager* handshake_mgr) {
   grpc_ssl_server_security_connector* c =
       reinterpret_cast<grpc_ssl_server_security_connector*>(sc);

--- a/src/core/lib/security/security_connector/security_connector.cc
+++ b/src/core/lib/security/security_connector/security_connector.cc
@@ -120,16 +120,20 @@ const tsi_peer_property* tsi_peer_get_property_by_name(const tsi_peer* peer,
 
 void grpc_channel_security_connector_add_handshakers(
     grpc_channel_security_connector* connector,
+    grpc_pollset_set* interested_parties,
     grpc_handshake_manager* handshake_mgr) {
   if (connector != nullptr) {
+    connector->base.interested_parties = interested_parties;
     connector->add_handshakers(connector, handshake_mgr);
   }
 }
 
 void grpc_server_security_connector_add_handshakers(
     grpc_server_security_connector* connector,
+    grpc_pollset_set* interested_parties,
     grpc_handshake_manager* handshake_mgr) {
   if (connector != nullptr) {
+    connector->base.interested_parties = interested_parties;
     connector->add_handshakers(connector, handshake_mgr);
   }
 }
@@ -154,13 +158,6 @@ int grpc_security_connector_cmp(grpc_security_connector* sc,
   int c = GPR_ICMP(sc->vtable, other->vtable);
   if (c != 0) return c;
   return sc->vtable->cmp(sc, other);
-}
-
-void grpc_security_connector_set_interested_parties(
-    grpc_security_connector* sc, grpc_pollset_set* interested_parties) {
-  if (sc != nullptr) {
-    sc->interested_parties = interested_parties;
-  }
 }
 
 int grpc_channel_security_connector_cmp(grpc_channel_security_connector* sc1,

--- a/src/core/lib/security/security_connector/security_connector.h
+++ b/src/core/lib/security/security_connector/security_connector.h
@@ -27,6 +27,7 @@
 
 #include "src/core/lib/channel/handshaker.h"
 #include "src/core/lib/iomgr/endpoint.h"
+#include "src/core/lib/iomgr/pollset.h"
 #include "src/core/lib/iomgr/tcp_server.h"
 #include "src/core/tsi/ssl_transport_security.h"
 #include "src/core/tsi/transport_security_interface.h"
@@ -63,7 +64,6 @@ struct grpc_security_connector {
   const grpc_security_connector_vtable* vtable;
   gpr_refcount refcount;
   const char* url_scheme;
-  grpc_pollset_set* interested_parties;
 };
 
 /* Refcounting. */
@@ -126,6 +126,7 @@ struct grpc_channel_security_connector {
                                  grpc_closure* on_call_host_checked,
                                  grpc_error* error);
   void (*add_handshakers)(grpc_channel_security_connector* sc,
+                          grpc_pollset_set* interested_parties,
                           grpc_handshake_manager* handshake_mgr);
 };
 
@@ -166,6 +167,7 @@ struct grpc_server_security_connector {
   grpc_security_connector base;
   grpc_server_credentials* server_creds;
   void (*add_handshakers)(grpc_server_security_connector* sc,
+                          grpc_pollset_set* interested_parties,
                           grpc_handshake_manager* handshake_mgr);
 };
 

--- a/src/core/lib/security/security_connector/security_connector.h
+++ b/src/core/lib/security/security_connector/security_connector.h
@@ -107,10 +107,6 @@ grpc_security_connector* grpc_security_connector_from_arg(const grpc_arg* arg);
 grpc_security_connector* grpc_security_connector_find_in_args(
     const grpc_channel_args* args);
 
-/* Util to set the interested_parties whose ownership is not transferred. */
-void grpc_security_connector_set_interested_parties(
-    grpc_security_connector* sc, grpc_pollset_set* interested_parties);
-
 /* --- channel_security_connector object. ---
 
     A channel security connector object represents a way to configure the
@@ -156,6 +152,7 @@ void grpc_channel_security_connector_cancel_check_call_host(
 /* Registers handshakers with \a handshake_mgr. */
 void grpc_channel_security_connector_add_handshakers(
     grpc_channel_security_connector* connector,
+    grpc_pollset_set* interested_parties,
     grpc_handshake_manager* handshake_mgr);
 
 /* --- server_security_connector object. ---
@@ -177,7 +174,8 @@ int grpc_server_security_connector_cmp(grpc_server_security_connector* sc1,
                                        grpc_server_security_connector* sc2);
 
 void grpc_server_security_connector_add_handshakers(
-    grpc_server_security_connector* sc, grpc_handshake_manager* handshake_mgr);
+    grpc_server_security_connector* sc, grpc_pollset_set* interested_parties,
+    grpc_handshake_manager* handshake_mgr);
 
 /* --- Creation security connectors. --- */
 

--- a/src/core/lib/security/transport/security_handshaker.cc
+++ b/src/core/lib/security/transport/security_handshaker.cc
@@ -480,12 +480,8 @@ static void client_handshaker_factory_add_handshakers(
   grpc_channel_security_connector* security_connector =
       reinterpret_cast<grpc_channel_security_connector*>(
           grpc_security_connector_find_in_args(args));
-  if (security_connector != nullptr) {
-    grpc_security_connector_set_interested_parties(&security_connector->base,
-                                                   interested_parties);
-  }
-  grpc_channel_security_connector_add_handshakers(security_connector,
-                                                  handshake_mgr);
+  grpc_channel_security_connector_add_handshakers(
+      security_connector, interested_parties, handshake_mgr);
 }
 
 static void server_handshaker_factory_add_handshakers(
@@ -495,12 +491,8 @@ static void server_handshaker_factory_add_handshakers(
   grpc_server_security_connector* security_connector =
       reinterpret_cast<grpc_server_security_connector*>(
           grpc_security_connector_find_in_args(args));
-  if (security_connector != nullptr) {
-    grpc_security_connector_set_interested_parties(&security_connector->base,
-                                                   interested_parties);
-  }
-  grpc_server_security_connector_add_handshakers(security_connector,
-                                                 handshake_mgr);
+  grpc_server_security_connector_add_handshakers(
+      security_connector, interested_parties, handshake_mgr);
 }
 
 static void handshaker_factory_destroy(

--- a/test/core/security/ssl_server_fuzzer.cc
+++ b/test/core/security/ssl_server_fuzzer.cc
@@ -91,7 +91,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     struct handshake_state state;
     state.done_callback_called = false;
     grpc_handshake_manager* handshake_mgr = grpc_handshake_manager_create();
-    grpc_server_security_connector_add_handshakers(sc, handshake_mgr);
+    grpc_server_security_connector_add_handshakers(sc, nullptr, handshake_mgr);
     grpc_handshake_manager_do_handshake(
         handshake_mgr, nullptr /* interested_parties */, mock_endpoint,
         nullptr /* channel_args */, deadline, nullptr /* acceptor */,


### PR DESCRIPTION
This PR changes the way pollset_set is set in security connector. That is, it is now set via `grpc_channel_security_connector_add_handshakers` and `grpc_server_security_connector_add_handshakers`. 