### PR TITLE
Add Compaction to Channelz Registry

### DIFF
--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -78,11 +78,11 @@ void ChannelzRegistry::MaybePerformCompaction() {
 }
 
 int ChannelzRegistry::FindByUuid(intptr_t target_uuid) {
-  int left = 0;
-  int right = entities_.size() - 1;
+  size_t left = 0;
+  size_t right = entities_.size() - 1;
   while (left <= right) {
-    int true_middle = left + (right - left) / 2;
-    int first_non_null = true_middle;
+    size_t true_middle = left + (right - left) / 2;
+    size_t first_non_null = true_middle;
     while (first_non_null < right && entities_[first_non_null] == nullptr) {
       first_non_null++;
     }

--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -92,7 +92,7 @@ int ChannelzRegistry::FindByUuidLocked(intptr_t target_uuid) {
     }
     intptr_t uuid = entities_[first_non_null]->uuid();
     if (uuid == target_uuid) {
-      return first_non_null;
+      return int(first_non_null);
     }
     if (uuid < target_uuid) {
       left = first_non_null + 1;

--- a/src/core/lib/channel/channelz_registry.h
+++ b/src/core/lib/channel/channelz_registry.h
@@ -87,12 +87,12 @@ class ChannelzRegistry {
   char* InternalGetTopChannels(intptr_t start_channel_id);
   char* InternalGetServers(intptr_t start_server_id);
 
-  // If entities_ has a over a certain threshold of empty slots, it will
+  // If entities_ has over a certain threshold of empty slots, it will
   // compact the vector and move all used slots to the front.
-  void MaybePerformCompaction();
+  void MaybePerformCompactionLocked();
 
   // Performs binary search on entities_ to find the index with that uuid.
-  int FindByUuid(intptr_t uuid);
+  int FindByUuidLocked(intptr_t uuid);
 
   // protects members
   gpr_mu mu_;

--- a/src/core/lib/channel/channelz_registry.h
+++ b/src/core/lib/channel/channelz_registry.h
@@ -30,6 +30,10 @@
 namespace grpc_core {
 namespace channelz {
 
+namespace testing {
+class ChannelzRegistryPeer;
+}
+
 // singleton registry object to track all objects that are needed to support
 // channelz bookkeeping. All objects share globally distributed uuids.
 class ChannelzRegistry {
@@ -61,6 +65,7 @@ class ChannelzRegistry {
  private:
   GPRC_ALLOW_CLASS_TO_USE_NON_PUBLIC_NEW
   GPRC_ALLOW_CLASS_TO_USE_NON_PUBLIC_DELETE
+  friend class testing::ChannelzRegistryPeer;
 
   ChannelzRegistry();
   ~ChannelzRegistry();
@@ -82,9 +87,18 @@ class ChannelzRegistry {
   char* InternalGetTopChannels(intptr_t start_channel_id);
   char* InternalGetServers(intptr_t start_server_id);
 
-  // protects entities_ and uuid_
+  // If entities_ has a over a certain threshold of empty slots, it will
+  // compact the vector and move all used slots to the front.
+  void MaybePerformCompaction();
+
+  // Performs binary search on entities_ to find the index with that uuid.
+  int FindByUuid(intptr_t uuid);
+
+  // protects members
   gpr_mu mu_;
   InlinedVector<BaseNode*, 20> entities_;
+  intptr_t uuid_generator_ = 0;
+  int num_empty_slots_ = 0;
 };
 
 }  // namespace channelz

--- a/src/core/lib/gprpp/inlined_vector.h
+++ b/src/core/lib/gprpp/inlined_vector.h
@@ -123,6 +123,14 @@ class InlinedVector {
 
   void push_back(T&& value) { emplace_back(std::move(value)); }
 
+  void pop_back() {
+    assert(!empty());
+    size_t s = size();
+    T& value = data()[s - 1];
+    value.~T();
+    size_--;
+  }
+
   void copy_from(const InlinedVector& v) {
     // if v is allocated, copy over the buffer.
     if (v.dynamic_ != nullptr) {

--- a/test/core/channel/channelz_registry_test.cc
+++ b/test/core/channel/channelz_registry_test.cc
@@ -62,8 +62,8 @@ class ChannelzRegistryTest : public ::testing::Test {
 };
 
 TEST_F(ChannelzRegistryTest, UuidStartsAboveZeroTest) {
-  UniquePtr<BaseNode> channelz_channel(
-      new BaseNode(BaseNode::EntityType::kTopLevelChannel));
+  UniquePtr<BaseNode> channelz_channel =
+      MakeUnique<BaseNode>(BaseNode::EntityType::kTopLevelChannel);
   intptr_t uuid = channelz_channel->uuid();
   EXPECT_GT(uuid, 0) << "First uuid chose must be greater than zero. Zero if "
                         "reserved according to "
@@ -75,8 +75,8 @@ TEST_F(ChannelzRegistryTest, UuidsAreIncreasing) {
   std::vector<UniquePtr<BaseNode>> channelz_channels;
   channelz_channels.reserve(10);
   for (int i = 0; i < 10; ++i) {
-    channelz_channels.push_back(UniquePtr<BaseNode>(
-        New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
+    channelz_channels.push_back(
+        MakeUnique<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
   }
   for (size_t i = 1; i < channelz_channels.size(); ++i) {
     EXPECT_LT(channelz_channels[i - 1]->uuid(), channelz_channels[i]->uuid())
@@ -85,8 +85,8 @@ TEST_F(ChannelzRegistryTest, UuidsAreIncreasing) {
 }
 
 TEST_F(ChannelzRegistryTest, RegisterGetTest) {
-  UniquePtr<BaseNode> channelz_channel(
-      New<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
+  UniquePtr<BaseNode> channelz_channel =
+      MakeUnique<BaseNode>(BaseNode::EntityType::kTopLevelChannel);
   BaseNode* retrieved = ChannelzRegistry::Get(channelz_channel->uuid());
   EXPECT_EQ(channelz_channel.get(), retrieved);
 }
@@ -94,16 +94,16 @@ TEST_F(ChannelzRegistryTest, RegisterGetTest) {
 TEST_F(ChannelzRegistryTest, RegisterManyItems) {
   std::vector<UniquePtr<BaseNode>> channelz_channels;
   for (int i = 0; i < 100; i++) {
-    channelz_channels.push_back(UniquePtr<BaseNode>(
-        New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
+    channelz_channels.push_back(
+        MakeUnique<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
     BaseNode* retrieved = ChannelzRegistry::Get(channelz_channels[i]->uuid());
     EXPECT_EQ(channelz_channels[i].get(), retrieved);
   }
 }
 
 TEST_F(ChannelzRegistryTest, NullIfNotPresentTest) {
-  UniquePtr<BaseNode> channelz_channel(
-      New<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
+  UniquePtr<BaseNode> channelz_channel =
+      MakeUnique<BaseNode>(BaseNode::EntityType::kTopLevelChannel);
   // try to pull out a uuid that does not exist.
   BaseNode* nonexistant = ChannelzRegistry::Get(channelz_channel->uuid() + 1);
   EXPECT_EQ(nonexistant, nullptr);
@@ -121,10 +121,10 @@ TEST_F(ChannelzRegistryTest, TestCompaction) {
     std::vector<UniquePtr<BaseNode>> odd_channels;
     odd_channels.reserve(kLoopIterations);
     for (int i = 0; i < kLoopIterations; i++) {
-      even_channels.push_back(UniquePtr<BaseNode>(
-          New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
-      odd_channels.push_back(UniquePtr<BaseNode>(
-          New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
+      even_channels.push_back(
+          MakeUnique<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
+      odd_channels.push_back(
+          MakeUnique<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
     }
   }
   // without compaction, there would be exactly kLoopIterations empty slots at
@@ -146,10 +146,10 @@ TEST_F(ChannelzRegistryTest, TestGetAfterCompaction) {
     std::vector<UniquePtr<BaseNode>> odd_channels;
     odd_channels.reserve(kLoopIterations);
     for (int i = 0; i < kLoopIterations; i++) {
-      even_channels.push_back(UniquePtr<BaseNode>(
-          New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
-      odd_channels.push_back(UniquePtr<BaseNode>(
-          New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
+      even_channels.push_back(
+          MakeUnique<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
+      odd_channels.push_back(
+          MakeUnique<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
       odd_uuids.push_back(odd_channels[i]->uuid());
     }
   }
@@ -173,18 +173,18 @@ TEST_F(ChannelzRegistryTest, TestAddAfterCompaction) {
     std::vector<UniquePtr<BaseNode>> odd_channels;
     odd_channels.reserve(kLoopIterations);
     for (int i = 0; i < kLoopIterations; i++) {
-      even_channels.push_back(UniquePtr<BaseNode>(
-          New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
-      odd_channels.push_back(UniquePtr<BaseNode>(
-          New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
+      even_channels.push_back(
+          MakeUnique<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
+      odd_channels.push_back(
+          MakeUnique<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
       odd_uuids.push_back(odd_channels[i]->uuid());
     }
   }
   std::vector<UniquePtr<BaseNode>> more_channels;
   more_channels.reserve(kLoopIterations);
   for (int i = 0; i < kLoopIterations; i++) {
-    more_channels.push_back(UniquePtr<BaseNode>(
-        New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
+    more_channels.push_back(
+        MakeUnique<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
     BaseNode* retrieved = ChannelzRegistry::Get(more_channels[i]->uuid());
     EXPECT_EQ(more_channels[i].get(), retrieved);
   }

--- a/test/core/channel/channelz_registry_test.cc
+++ b/test/core/channel/channelz_registry_test.cc
@@ -76,7 +76,7 @@ TEST_F(ChannelzRegistryTest, UuidsAreIncreasing) {
   channelz_channels.reserve(10);
   for (int i = 0; i < 10; ++i) {
     channelz_channels.push_back(UniquePtr<BaseNode>(
-        new BaseNode(BaseNode::EntityType::kTopLevelChannel)));
+        New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
   }
   for (size_t i = 1; i < channelz_channels.size(); ++i) {
     EXPECT_LT(channelz_channels[i - 1]->uuid(), channelz_channels[i]->uuid())
@@ -86,7 +86,7 @@ TEST_F(ChannelzRegistryTest, UuidsAreIncreasing) {
 
 TEST_F(ChannelzRegistryTest, RegisterGetTest) {
   UniquePtr<BaseNode> channelz_channel(
-      new BaseNode(BaseNode::EntityType::kTopLevelChannel));
+      New<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
   BaseNode* retrieved = ChannelzRegistry::Get(channelz_channel->uuid());
   EXPECT_EQ(channelz_channel.get(), retrieved);
 }
@@ -95,7 +95,7 @@ TEST_F(ChannelzRegistryTest, RegisterManyItems) {
   std::vector<UniquePtr<BaseNode>> channelz_channels;
   for (int i = 0; i < 100; i++) {
     channelz_channels.push_back(UniquePtr<BaseNode>(
-        new BaseNode(BaseNode::EntityType::kTopLevelChannel)));
+        New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
     BaseNode* retrieved = ChannelzRegistry::Get(channelz_channels[i]->uuid());
     EXPECT_EQ(channelz_channels[i].get(), retrieved);
   }
@@ -103,7 +103,7 @@ TEST_F(ChannelzRegistryTest, RegisterManyItems) {
 
 TEST_F(ChannelzRegistryTest, NullIfNotPresentTest) {
   UniquePtr<BaseNode> channelz_channel(
-      new BaseNode(BaseNode::EntityType::kTopLevelChannel));
+      New<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
   // try to pull out a uuid that does not exist.
   BaseNode* nonexistant = ChannelzRegistry::Get(channelz_channel->uuid() + 1);
   EXPECT_EQ(nonexistant, nullptr);
@@ -122,9 +122,9 @@ TEST_F(ChannelzRegistryTest, TestCompaction) {
     odd_channels.reserve(kLoopIterations);
     for (int i = 0; i < kLoopIterations; i++) {
       even_channels.push_back(UniquePtr<BaseNode>(
-          new BaseNode(BaseNode::EntityType::kTopLevelChannel)));
+          New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
       odd_channels.push_back(UniquePtr<BaseNode>(
-          new BaseNode(BaseNode::EntityType::kTopLevelChannel)));
+          New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
     }
   }
   // without compaction, there would be exactly kLoopIterations empty slots at
@@ -147,9 +147,9 @@ TEST_F(ChannelzRegistryTest, TestGetAfterCompaction) {
     odd_channels.reserve(kLoopIterations);
     for (int i = 0; i < kLoopIterations; i++) {
       even_channels.push_back(UniquePtr<BaseNode>(
-          new BaseNode(BaseNode::EntityType::kTopLevelChannel)));
+          New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
       odd_channels.push_back(UniquePtr<BaseNode>(
-          new BaseNode(BaseNode::EntityType::kTopLevelChannel)));
+          New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
       odd_uuids.push_back(odd_channels[i]->uuid());
     }
   }
@@ -174,9 +174,9 @@ TEST_F(ChannelzRegistryTest, TestAddAfterCompaction) {
     odd_channels.reserve(kLoopIterations);
     for (int i = 0; i < kLoopIterations; i++) {
       even_channels.push_back(UniquePtr<BaseNode>(
-          new BaseNode(BaseNode::EntityType::kTopLevelChannel)));
+          New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
       odd_channels.push_back(UniquePtr<BaseNode>(
-          new BaseNode(BaseNode::EntityType::kTopLevelChannel)));
+          New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
       odd_uuids.push_back(odd_channels[i]->uuid());
     }
   }
@@ -184,7 +184,7 @@ TEST_F(ChannelzRegistryTest, TestAddAfterCompaction) {
   more_channels.reserve(kLoopIterations);
   for (int i = 0; i < kLoopIterations; i++) {
     more_channels.push_back(UniquePtr<BaseNode>(
-        new BaseNode(BaseNode::EntityType::kTopLevelChannel)));
+        New<BaseNode>(BaseNode::EntityType::kTopLevelChannel)));
     BaseNode* retrieved = ChannelzRegistry::Get(more_channels[i]->uuid());
     EXPECT_EQ(more_channels[i].get(), retrieved);
   }

--- a/test/core/gprpp/inlined_vector_test.cc
+++ b/test/core/gprpp/inlined_vector_test.cc
@@ -264,6 +264,32 @@ TEST(InlinedVectorTest, MoveAssignmentAllocatedAllocated) {
   EXPECT_EQ(move_assigned.data(), old_data);
 }
 
+TEST(InlinedVectorTest, PopBackInlined) {
+  InlinedVector<UniquePtr<int>, 2> v;
+  // Add two elements, pop one out
+  v.push_back(MakeUnique<int>(3));
+  EXPECT_EQ(1UL, v.size());
+  EXPECT_EQ(3, *v[0]);
+  v.push_back(MakeUnique<int>(5));
+  EXPECT_EQ(2UL, v.size());
+  EXPECT_EQ(5, *v[1]);
+  v.pop_back();
+  EXPECT_EQ(1UL, v.size());
+}
+
+TEST(InlinedVectorTest, PopBackAllocated) {
+  const int kInlinedSize = 2;
+  InlinedVector<UniquePtr<int>, kInlinedSize> v;
+  // Add elements to ensure allocated backing.
+  for (size_t i = 0; i < kInlinedSize + 1; ++i) {
+    v.push_back(MakeUnique<int>(3));
+    EXPECT_EQ(i + 1, v.size());
+  }
+  size_t sz = v.size();
+  v.pop_back();
+  EXPECT_EQ(sz - 1, v.size());
+}
+
 }  // namespace testing
 }  // namespace grpc_core
 


### PR DESCRIPTION
Adds a compaction operation if the registry is 1/3 empty.

This protects the registry from growing unbounded and not cleaning up after entities are deleted.

Tracking: #15340