### PR TITLE
Adjust server_auth_filter location.

### DIFF
--- a/src/core/lib/surface/init_secure.cc
+++ b/src/core/lib/surface/init_secure.cc
@@ -74,7 +74,7 @@ void grpc_register_security_filters(void) {
                                    maybe_prepend_client_auth_filter, nullptr);
   grpc_channel_init_register_stage(GRPC_CLIENT_DIRECT_CHANNEL, INT_MAX - 1,
                                    maybe_prepend_client_auth_filter, nullptr);
-  grpc_channel_init_register_stage(GRPC_SERVER_CHANNEL, INT_MAX,
+  grpc_channel_init_register_stage(GRPC_SERVER_CHANNEL, INT_MAX - 1,
                                    maybe_prepend_server_auth_filter, nullptr);
 }
 


### PR DESCRIPTION
This is part of a larger change which can disable adding server_auth_filter when needed.