### PR TITLE
Fix sanity check prompt when new QPS benchmark scenarios are added

### DIFF
--- a/tools/run_tests/sanity/check_qps_scenario_changes.py
+++ b/tools/run_tests/sanity/check_qps_scenario_changes.py
@@ -27,7 +27,10 @@ qps_json_driver_bzl = 'test/cpp/qps/qps_json_driver_scenarios.bzl'
 json_run_localhost_bzl = 'test/cpp/qps/json_run_localhost_scenarios.bzl'
 
 if qps_json_driver_bzl in output or json_run_localhost_bzl in output:
-    print('qps benchmark scenarios have been updated, please commit '
+    print('qps benchmark scenarios have been updated, please go '
+          'to //test/cpp/qps directory, run json_run_localhost_scenario_gen.py '
+          'and qps_json_driver_scenario_gen.py scripts, and commit '
+          'qps benchmark scenarios have been updated, please commit '
           'test/cpp/qps/qps_json_driver_scenarios.bzl and/or '
           'test/cpp/qps/json_run_localhost_scenarios.bzl')
     sys.exit(1)

--- a/tools/run_tests/sanity/check_qps_scenario_changes.py
+++ b/tools/run_tests/sanity/check_qps_scenario_changes.py
@@ -30,7 +30,6 @@ if qps_json_driver_bzl in output or json_run_localhost_bzl in output:
     print('qps benchmark scenarios have been updated, please go '
           'to //test/cpp/qps directory, run json_run_localhost_scenario_gen.py '
           'and qps_json_driver_scenario_gen.py scripts, and commit '
-          'qps benchmark scenarios have been updated, please commit '
           'test/cpp/qps/qps_json_driver_scenarios.bzl and/or '
           'test/cpp/qps/json_run_localhost_scenarios.bzl')
     sys.exit(1)


### PR DESCRIPTION
Added direction on the scripts that need to be run when QPS benchmark scenarios are updated