### PR TITLE
Make link_head consistent with link_tail.

### DIFF
--- a/src/core/lib/transport/metadata_batch.cc
+++ b/src/core/lib/transport/metadata_batch.cc
@@ -139,6 +139,7 @@ static void link_head(grpc_mdelem_list* list, grpc_linked_mdelem* storage) {
   GPR_ASSERT(!GRPC_MDISNULL(storage->md));
   storage->prev = nullptr;
   storage->next = list->head;
+  storage->reserved = nullptr;
   if (list->head != nullptr) {
     list->head->prev = storage;
   } else {


### PR DESCRIPTION
This is a tiny change I note while removing memset() calls.
link_head doesn't set the reserved pointer while link_tail (correctly)
does.