### PR TITLE
Add well_known_protos = False to cc_grpc_library call

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -28,4 +28,5 @@ cc_grpc_library(
     srcs = "well_known_protos_list",
     proto_only = True,
     deps = [],
+    well_known_protos = False,
 )


### PR DESCRIPTION
`well_known_protos` is a mandatory argument. Omitting it here means that GRPC will fail to build when used as an external Bazel dependency in another project.