### PR TITLE
Bazel rules for Python grpcio_health_checking

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,10 +34,11 @@ pip_import(
 load("@grpc_python_dependencies//:requirements.bzl", "pip_install")
 pip_install()
 
+# NOTE(https://github.com/pubref/rules_protobuf/pull/196): Switch to upstream repo after this gets merged.
 git_repository(
     name="org_pubref_rules_protobuf",
-    remote="https://github.com/pubref/rules_protobuf",
-    tag="v0.8.2",
+    remote="https://github.com/ghostwriternr/rules_protobuf",
+    tag="v0.8.2.1-alpha",
 )
 
 load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_repositories")

--- a/src/proto/grpc/health/v1/BUILD
+++ b/src/proto/grpc/health/v1/BUILD
@@ -22,3 +22,11 @@ grpc_proto_library(
     name = "health_proto",
     srcs = ["health.proto"],
 )
+
+filegroup(
+    name = "health_proto_file",
+    srcs = [
+        "health.proto",
+    ],
+)
+

--- a/src/python/grpcio_health_checking/grpc_health/v1/BUILD.bazel
+++ b/src/python/grpcio_health_checking/grpc_health/v1/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+genrule(
+    name = "mv_health_proto",
+    srcs = [
+        "//src/proto/grpc/health/v1:health_proto_file",
+    ],
+    outs = ["health.proto",],
+    cmd = "cp $< $@",
+)
+
+py_proto_library(
+    name = "py_health_proto",
+    protos = [":mv_health_proto",],
+    with_grpc = True,
+    deps = [
+        requirement('protobuf'),
+    ],
+)
+
+py_library(
+    name = "grpc_health",
+    srcs = ["health.py",],
+    deps = [
+        ":py_health_proto",
+        "//src/python/grpcio/grpc:grpcio",
+    ],
+    imports=["../../",],
+)
+

--- a/src/python/grpcio_tests/tests/health_check/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/health_check/BUILD.bazel
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+py_test(
+    name = "health_servicer_test",
+    srcs = ["_health_servicer_test.py"],
+    main = "_health_servicer_test.py",
+    size = "small",
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/python/grpcio_health_checking/grpc_health/v1:grpc_health",
+        "//src/python/grpcio_tests/tests/unit:test_common",
+    ],
+    imports = ["../../",],
+)
+


### PR DESCRIPTION
Add Bazel rules for building and testing grpcio_health_checking.

An unofficial fork for rules_protobuf is used for now as it incorporates a change ([#196](https://github.com/pubref/rules_protobuf/pull/196) by [duduko](https://github.com/dududko) on the upstream repo [pubref/rules_protobuf](https://github.com/pubref/rules_protobuf)) which allows the protoc compiler to compile generated protos too. This was not merged because the change was failing for golang, but works as expected for Python.

This is needed because grpcio_health_checking fetches it's proto file from a different directory (previously achieved via a [setup.py](https://github.com/grpc/grpc/blob/912b8ab4d49cd6cde76675d37c896e5edcf67487/src/python/grpcio_health_checking/health_commands.py#L37-L41) command) and thus needs to be moved to the required location within bazel-genfiles using a genrule.