### PR TITLE
Bazel rules for gRPC Python interop tests

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -8,3 +8,4 @@ wheel>=0.29
 futures>=2.2.0
 google-auth>=1.0.0
 oauth2client==4.1.0
+requests>=2.14.2

--- a/src/proto/grpc/testing/BUILD
+++ b/src/proto/grpc/testing/BUILD
@@ -15,6 +15,8 @@
 licenses(["notice"])  # Apache v2
 
 load("//bazel:grpc_build_system.bzl", "grpc_proto_library", "grpc_package")
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_library")
 
 grpc_package(name = "testing", visibility = "public")
 
@@ -58,10 +60,28 @@ grpc_proto_library(
     has_services = False,
 )
 
+py_proto_library(
+    name = "py_empty_proto",
+    protos = ["empty.proto",],
+    with_grpc = True,
+    deps = [
+        requirement('protobuf'),
+    ],
+)
+
 grpc_proto_library(
     name = "messages_proto",
     srcs = ["messages.proto"],
     has_services = False,
+)
+
+py_proto_library(
+    name = "py_messages_proto",
+    protos = ["messages.proto",],
+    with_grpc = True,
+    deps = [
+        requirement('protobuf'),
+    ],
 )
 
 grpc_proto_library(
@@ -116,3 +136,17 @@ grpc_proto_library(
         "messages_proto",
     ],
 )
+
+py_proto_library(
+    name = "py_test_proto",
+    protos = ["test.proto",],
+    with_grpc = True,
+    deps = [
+        requirement('protobuf'),
+    ],
+    proto_deps = [
+        ":py_empty_proto",
+        ":py_messages_proto",
+    ]
+)
+

--- a/src/python/grpcio_tests/tests/interop/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/interop/BUILD.bazel
@@ -1,0 +1,97 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "_intraop_test_case",
+    srcs = ["_intraop_test_case.py"],
+    deps = [
+        ":methods",
+    ],
+    imports=["../../",],
+)
+
+py_library(
+    name = "client",
+    srcs = ["client.py"],
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        ":methods",
+        ":resources",
+        "//src/proto/grpc/testing:py_test_proto",
+        requirement('google-auth'),
+    ],
+    imports=["../../",],
+)
+
+py_library(
+    name = "methods",
+    srcs = ["methods.py"],
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/proto/grpc/testing:py_empty_proto",
+        "//src/proto/grpc/testing:py_messages_proto",
+        "//src/proto/grpc/testing:py_test_proto",
+        requirement('google-auth'),
+        requirement('requests'),
+        requirement('enum34'),
+    ],
+    imports=["../../",],
+)
+
+py_library(
+    name = "resources",
+    srcs = ["resources.py"],
+    data = [
+        "//src/python/grpcio_tests/tests/interop/credentials",
+    ],
+)
+
+py_library(
+    name = "server",
+    srcs = ["server.py"],
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        ":methods",
+        ":resources",
+        "//src/python/grpcio_tests/tests/unit:test_common",
+        "//src/proto/grpc/testing:py_test_proto",
+    ],
+    imports=["../../",],
+)
+
+py_test(
+    name="_insecure_intraop_test",
+    size="small",
+    srcs=["_insecure_intraop_test.py",],
+    main="_insecure_intraop_test.py",
+    deps=[
+        "//src/python/grpcio/grpc:grpcio",
+        ":_intraop_test_case",
+        ":methods",
+        ":server",
+        "//src/python/grpcio_tests/tests/unit:test_common",
+        "//src/proto/grpc/testing:py_test_proto",
+    ],
+    imports=["../../",],
+    data=[
+        "//src/python/grpcio_tests/tests/unit/credentials",
+    ],
+)
+
+py_test(
+    name="_secure_intraop_test",
+    size="small",
+    srcs=["_secure_intraop_test.py",],
+    main="_secure_intraop_test.py",
+    deps=[
+        "//src/python/grpcio/grpc:grpcio",
+        ":_intraop_test_case",
+        ":methods",
+        ":server",
+        "//src/python/grpcio_tests/tests/unit:test_common",
+        "//src/proto/grpc/testing:py_test_proto",
+    ],
+    imports=["../../",],
+)
+

--- a/src/python/grpcio_tests/tests/interop/credentials/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/interop/credentials/BUILD.bazel
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name="credentials",
+    srcs=glob([
+        "**",
+    ]),
+)
+


### PR DESCRIPTION
Add interop tests for gRPC Python. py_proto_library rules are added to [src/proto/grpc/testing/BUILD](https://github.com/ghostwriternr/grpc/blob/912b8ab4d49cd6cde76675d37c896e5edcf67487/src/proto/grpc/testing/BUILD) since grpc_proto_library is not compatible with py_* rules.

'requests' python module is added to requirements.bazel.txt as it is a dependency for google-auth. Previously, this was installed through [tools/run_tests/helper_scripts/build_python.sh](https://github.com/ghostwriternr/grpc/blob/912b8ab4d49cd6cde76675d37c896e5edcf67487/tools/run_tests/helper_scripts/build_python.sh) before running tests.