### PR TITLE
Account the memory usage of channel and call by resource quota

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.h
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.h
@@ -32,7 +32,8 @@ extern grpc_core::DebugOnlyTraceFlag grpc_trace_chttp2_refcount;
 extern bool g_flow_control_enabled;
 
 grpc_transport* grpc_create_chttp2_transport(
-    const grpc_channel_args* channel_args, grpc_endpoint* ep, bool is_client);
+    const grpc_channel_args* channel_args, grpc_endpoint* ep, bool is_client,
+    grpc_resource_user* resource_user = nullptr);
 
 intptr_t grpc_chttp2_transport_get_socket_uuid(grpc_transport* transport);
 

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -32,7 +32,7 @@ grpc_slice grpc_chttp2_rst_stream_create(uint32_t id, uint32_t code,
                                          grpc_transport_one_way_stats* stats) {
   static const size_t frame_size = 13;
   grpc_slice slice = GRPC_SLICE_MALLOC(frame_size);
-  stats->framing_bytes += frame_size;
+  if (stats != nullptr) stats->framing_bytes += frame_size;
   uint8_t* p = GRPC_SLICE_START_PTR(slice);
 
   // Frame size.

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -285,6 +285,8 @@ struct grpc_chttp2_transport {
   grpc_endpoint* ep;
   char* peer_string;
 
+  grpc_resource_user* resource_user;
+
   grpc_combiner* combiner;
 
   grpc_closure* notify_on_receive_settings;

--- a/src/core/lib/channel/channel_stack_builder.cc
+++ b/src/core/lib/channel/channel_stack_builder.cc
@@ -40,6 +40,7 @@ struct grpc_channel_stack_builder {
   // various set/get-able parameters
   grpc_channel_args* args;
   grpc_transport* transport;
+  grpc_resource_user* resource_user;
   char* target;
   const char* name;
 };
@@ -157,6 +158,11 @@ void grpc_channel_stack_builder_set_channel_arguments(
   builder->args = grpc_channel_args_copy(args);
 }
 
+const grpc_channel_args* grpc_channel_stack_builder_get_channel_arguments(
+    grpc_channel_stack_builder* builder) {
+  return builder->args;
+}
+
 void grpc_channel_stack_builder_set_transport(
     grpc_channel_stack_builder* builder, grpc_transport* transport) {
   GPR_ASSERT(builder->transport == nullptr);
@@ -168,9 +174,15 @@ grpc_transport* grpc_channel_stack_builder_get_transport(
   return builder->transport;
 }
 
-const grpc_channel_args* grpc_channel_stack_builder_get_channel_arguments(
+void grpc_channel_stack_builder_set_resource_user(
+    grpc_channel_stack_builder* builder, grpc_resource_user* resource_user) {
+  GPR_ASSERT(builder->resource_user == nullptr);
+  builder->resource_user = resource_user;
+}
+
+grpc_resource_user* grpc_channel_stack_builder_get_resource_user(
     grpc_channel_stack_builder* builder) {
-  return builder->args;
+  return builder->resource_user;
 }
 
 bool grpc_channel_stack_builder_append_filter(

--- a/src/core/lib/channel/channel_stack_builder.h
+++ b/src/core/lib/channel/channel_stack_builder.h
@@ -54,6 +54,14 @@ void grpc_channel_stack_builder_set_transport(
 grpc_transport* grpc_channel_stack_builder_get_transport(
     grpc_channel_stack_builder* builder);
 
+/// Attach \a resource_user to the builder (does not take ownership)
+void grpc_channel_stack_builder_set_resource_user(
+    grpc_channel_stack_builder* builder, grpc_resource_user* resource_user);
+
+/// Fetch attached resource user
+grpc_resource_user* grpc_channel_stack_builder_get_resource_user(
+    grpc_channel_stack_builder* builder);
+
 /// Set channel arguments: copies args
 void grpc_channel_stack_builder_set_channel_arguments(
     grpc_channel_stack_builder* builder, const grpc_channel_args* args);

--- a/src/core/lib/surface/channel.cc
+++ b/src/core/lib/surface/channel.cc
@@ -39,6 +39,7 @@
 #include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/iomgr/iomgr.h"
+#include "src/core/lib/iomgr/resource_quota.h"
 #include "src/core/lib/slice/slice_internal.h"
 #include "src/core/lib/surface/api_trace.h"
 #include "src/core/lib/surface/call.h"
@@ -63,6 +64,7 @@ struct grpc_channel {
   grpc_compression_options compression_options;
 
   gpr_atm call_size_estimate;
+  grpc_resource_user* resource_user;
 
   gpr_mu registered_call_mu;
   registered_call* registered_calls;
@@ -82,6 +84,8 @@ grpc_channel* grpc_channel_create_with_builder(
   char* target = gpr_strdup(grpc_channel_stack_builder_get_target(builder));
   grpc_channel_args* args = grpc_channel_args_copy(
       grpc_channel_stack_builder_get_channel_arguments(builder));
+  grpc_resource_user* resource_user =
+      grpc_channel_stack_builder_get_resource_user(builder);
   grpc_channel* channel;
   if (channel_stack_type == GRPC_SERVER_CHANNEL) {
     GRPC_STATS_INC_SERVER_CHANNELS_CREATED();
@@ -101,6 +105,7 @@ grpc_channel* grpc_channel_create_with_builder(
   }
 
   channel->target = target;
+  channel->resource_user = resource_user;
   channel->is_client = grpc_channel_stack_type_is_client(channel_stack_type);
   bool channelz_enabled = GRPC_ENABLE_CHANNELZ_DEFAULT;
   size_t channel_tracer_max_memory = 0;  // default to off
@@ -217,7 +222,8 @@ grpc_core::channelz::ChannelNode* grpc_channel_get_channelz_node(
 grpc_channel* grpc_channel_create(const char* target,
                                   const grpc_channel_args* input_args,
                                   grpc_channel_stack_type channel_stack_type,
-                                  grpc_transport* optional_transport) {
+                                  grpc_transport* optional_transport,
+                                  grpc_resource_user* resource_user) {
   grpc_channel_stack_builder* builder = grpc_channel_stack_builder_create();
   const grpc_core::UniquePtr<char> default_authority =
       get_default_authority(input_args);
@@ -227,11 +233,17 @@ grpc_channel* grpc_channel_create(const char* target,
   grpc_channel_args_destroy(args);
   grpc_channel_stack_builder_set_target(builder, target);
   grpc_channel_stack_builder_set_transport(builder, optional_transport);
+  grpc_channel_stack_builder_set_resource_user(builder, resource_user);
   if (!grpc_channel_init_create_stack(builder, channel_stack_type)) {
     grpc_channel_stack_builder_destroy(builder);
+    if (resource_user != nullptr) {
+      grpc_resource_user_free(resource_user, GRPC_RESOURCE_QUOTA_CHANNEL_SIZE);
+    }
     return nullptr;
   }
-  return grpc_channel_create_with_builder(builder, channel_stack_type);
+  grpc_channel* channel =
+      grpc_channel_create_with_builder(builder, channel_stack_type);
+  return channel;
 }
 
 size_t grpc_channel_get_call_size_estimate(grpc_channel* channel) {
@@ -440,6 +452,10 @@ static void destroy_channel(void* arg, grpc_error* error) {
     GRPC_MDELEM_UNREF(rc->path);
     GRPC_MDELEM_UNREF(rc->authority);
     gpr_free(rc);
+  }
+  if (channel->resource_user != nullptr) {
+    grpc_resource_user_free(channel->resource_user,
+                            GRPC_RESOURCE_QUOTA_CHANNEL_SIZE);
   }
   gpr_mu_destroy(&channel->registered_call_mu);
   gpr_free(channel->target);

--- a/src/core/lib/surface/channel.h
+++ b/src/core/lib/surface/channel.h
@@ -29,7 +29,8 @@
 grpc_channel* grpc_channel_create(const char* target,
                                   const grpc_channel_args* args,
                                   grpc_channel_stack_type channel_stack_type,
-                                  grpc_transport* optional_transport);
+                                  grpc_transport* optional_transport,
+                                  grpc_resource_user* resource_user = nullptr);
 
 grpc_channel* grpc_channel_create_with_builder(
     grpc_channel_stack_builder* builder,

--- a/src/core/lib/surface/server.h
+++ b/src/core/lib/surface/server.h
@@ -47,7 +47,8 @@ void grpc_server_add_listener(grpc_server* server, void* listener,
 void grpc_server_setup_transport(grpc_server* server, grpc_transport* transport,
                                  grpc_pollset* accepting_pollset,
                                  const grpc_channel_args* args,
-                                 intptr_t socket_uuid);
+                                 intptr_t socket_uuid,
+                                 grpc_resource_user* resource_user = nullptr);
 
 /* fills in the uuids of all sockets used for connections on this server */
 void grpc_server_populate_server_sockets(
@@ -62,6 +63,8 @@ grpc_core::channelz::ServerNode* grpc_server_get_channelz_node(
     grpc_server* server);
 
 const grpc_channel_args* grpc_server_get_channel_args(grpc_server* server);
+
+grpc_resource_user* grpc_server_get_default_resource_user(grpc_server* server);
 
 int grpc_server_has_open_connections(grpc_server* server);
 

--- a/tools/run_tests/sanity/core_banned_functions.py
+++ b/tools/run_tests/sanity/core_banned_functions.py
@@ -24,7 +24,8 @@ os.chdir(os.path.join(os.path.dirname(sys.argv[0]), '../../..'))
 # map of banned function signature to whitelist
 BANNED_EXCEPT = {
     'grpc_resource_quota_ref(': ['src/core/lib/iomgr/resource_quota.cc'],
-    'grpc_resource_quota_unref(': ['src/core/lib/iomgr/resource_quota.cc'],
+    'grpc_resource_quota_unref(':
+    ['src/core/lib/iomgr/resource_quota.cc', 'src/core/lib/surface/server.cc'],
     'grpc_slice_buffer_destroy(': ['src/core/lib/slice/slice_buffer.cc'],
     'grpc_slice_buffer_reset_and_unref(':
     ['src/core/lib/slice/slice_buffer.cc'],


### PR DESCRIPTION
Ugly fixing an OOM issue. Previously, the resource quota is only accounting the data read from TCP endpoint. We should also account the data originated locally. 

Since this is kind of urgent, I am using hard coded sizes.