### PR TITLE
run_performance_tests.py: cleaner way to start port_server.py

### DIFF
--- a/tools/run_tests/performance/remote_host_prepare.sh
+++ b/tools/run_tests/performance/remote_host_prepare.sh
@@ -38,3 +38,6 @@ ssh "${USER_AT_HOST}" "tar -xf ~/performance_workspace/grpc.tar -C ~/performance
 # For consistency with local run, invoke the kill_workers script remotely.
 # shellcheck disable=SC2088
 ssh "${USER_AT_HOST}" "~/performance_workspace/grpc/tools/run_tests/performance/kill_workers.sh"
+
+# make sure the port server is running (required by C++ qps_worker)
+ssh "${USER_AT_HOST}" "cd ~/performance_workspace/grpc/ && python tools/run_tests/start_port_server.py"

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -92,8 +92,7 @@ def create_qpsworker_job(language,
         cmdline = ['timeout', '%s' % (worker_timeout + 30)] + cmdline
         ssh_cmd.extend([
             str(user_at_host),
-            'cd ~/performance_workspace/grpc/ && python tools/run_tests/start_port_server.py && %s'
-            % ' '.join(cmdline)
+            'cd ~/performance_workspace/grpc/ && %s' % ' '.join(cmdline)
         ])
         cmdline = ssh_cmd
 
@@ -270,6 +269,12 @@ def build_on_remote_hosts(hosts,
                          'CONFIG': 'opt'},
                 timeout_seconds=build_timeout))
     if build_local:
+        # start port server locally
+        build_jobs.append(
+            jobset.JobSpec(
+                cmdline=['python', 'tools/run_tests/start_port_server.py'],
+                shortname='local_start_port_server',
+                timeout_seconds=2 * 60))
         # Build locally as well
         build_jobs.append(
             jobset.JobSpec(


### PR DESCRIPTION
- fix: when running run_performance_tests.py locally, port server is not started at all
- refactoring: on remote workers, start port server in prepare script rather than via a hack right before starting a qps_worker (qps_workers get started multiple times actually) FTR: https://github.com/grpc/grpc/commit/6921820fab0c9a2df8d4f258de76086cf7596b28#diff-bebe0cf9197257d9fbb6d940119b2944