### PR TITLE
Add Missing Ref in Channelz Closure

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -2617,7 +2617,8 @@ static void recv_trailing_metadata_ready_channelz(void* arg,
     channelz_subchannel->RecordCallFailed();
   }
   calld->recv_trailing_metadata = nullptr;
-  GRPC_CLOSURE_RUN(calld->original_recv_trailing_metadata, error);
+  GRPC_CLOSURE_RUN(calld->original_recv_trailing_metadata,
+                   GRPC_ERROR_REF(error));
 }
 
 // If channelz is enabled, intercept recv_trailing so that we may check the


### PR DESCRIPTION
This was causing failures in the PR to enable channelz be default.

The closure does not own the error, so it must ref it before passing off to GRPC_CLOSURE_RUN