### PR TITLE
Fix Channelz Tsan Failures

### DIFF
--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -43,8 +43,10 @@
 namespace grpc_core {
 namespace channelz {
 
-BaseNode::BaseNode(EntityType type)
-    : type_(type), uuid_(ChannelzRegistry::Register(this)) {}
+BaseNode::BaseNode(EntityType type) : type_(type), uuid_(-1) {
+  // The registry will set uuid_ under its lock.
+  ChannelzRegistry::Register(this);
+}
 
 BaseNode::~BaseNode() { ChannelzRegistry::Unregister(uuid_); }
 

--- a/src/core/lib/channel/channelz.h
+++ b/src/core/lib/channel/channelz.h
@@ -92,8 +92,10 @@ class BaseNode : public RefCounted<BaseNode> {
   intptr_t uuid() const { return uuid_; }
 
  private:
+  // to allow the ChannelzRegistry to set uuid_ under its lock.
+  friend class ChannelzRegistry;
   const EntityType type_;
-  const intptr_t uuid_;
+  intptr_t uuid_;
 };
 
 // This class is a helper class for channelz entities that deal with Channels,

--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -53,10 +53,10 @@ ChannelzRegistry::ChannelzRegistry() { gpr_mu_init(&mu_); }
 
 ChannelzRegistry::~ChannelzRegistry() { gpr_mu_destroy(&mu_); }
 
-intptr_t ChannelzRegistry::InternalRegister(BaseNode* node) {
+void ChannelzRegistry::InternalRegister(BaseNode* node) {
   MutexLock lock(&mu_);
   entities_.push_back(node);
-  return ++uuid_generator_;
+  node->uuid_ = ++uuid_generator_;
 }
 
 void ChannelzRegistry::MaybePerformCompactionLocked() {

--- a/src/core/lib/channel/channelz_registry.h
+++ b/src/core/lib/channel/channelz_registry.h
@@ -44,7 +44,7 @@ class ChannelzRegistry {
   // To be called in grpc_shutdown();
   static void Shutdown();
 
-  static intptr_t Register(BaseNode* node) {
+  static void Register(BaseNode* node) {
     return Default()->InternalRegister(node);
   }
   static void Unregister(intptr_t uuid) { Default()->InternalUnregister(uuid); }
@@ -74,7 +74,7 @@ class ChannelzRegistry {
   static ChannelzRegistry* Default();
 
   // globally registers an Entry. Returns its unique uuid
-  intptr_t InternalRegister(BaseNode* node);
+  void InternalRegister(BaseNode* node);
 
   // globally unregisters the object that is associated to uuid. Also does
   // sanity check that an object doesn't try to unregister the wrong type.


### PR DESCRIPTION
Atomically set the uuid of the BaseNode so that ChannelzRegistry doesn't race with BaseNode constructor. 

Tracking: #15340 