### PR TITLE
Only build with python27 in performance benchmarks

### DIFF
--- a/tools/run_tests/performance/build_performance.sh
+++ b/tools/run_tests/performance/build_performance.sh
@@ -62,7 +62,8 @@ do
     tools/run_tests/performance/build_performance_node.sh
     ;;
   *)
-    python tools/run_tests/run_tests.py -l "$language" -c "$CONFIG" --build_only -j 8
+    # python workers are only run with python2.7 and building with multiple python versions is costly
+    python tools/run_tests/run_tests.py -l "$language" -c "$CONFIG" --compiler python2.7 --build_only -j 8
     ;;
   esac
 done


### PR DESCRIPTION
In performance benchmarks, python workers only run with python2.7
https://github.com/grpc/grpc/blob/223995b3defe2b68a0f504c7001c2233f9acb309/tools/run_tests/performance/run_worker_python.sh#L20

no point of building both 2.7 and 3.4, especially when python build is super slow
https://github.com/grpc/grpc/blob/223995b3defe2b68a0f504c7001c2233f9acb309/tools/run_tests/run_tests.py#L837

Also, on our performance worker VMs the python3.4 installation is hacked-together and doesn't work well (and official python on ubuntu18.04 is python3.6 so dealing with 3.4 is not easy).