### PR TITLE
Simple optimizations in TCP read

### DIFF
--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -468,7 +468,9 @@ static void tcp_do_read(grpc_tcp* tcp) {
     GRPC_STATS_INC_TCP_READ_SIZE(read_bytes);
     add_to_estimate(tcp, static_cast<size_t>(read_bytes));
     GPR_ASSERT((size_t)read_bytes <= tcp->incoming_buffer->length);
-    if (static_cast<size_t>(read_bytes) < tcp->incoming_buffer->length) {
+    if (static_cast<size_t>(read_bytes) == tcp->incoming_buffer->length) {
+      finish_estimate(tcp);
+    } else if (static_cast<size_t>(read_bytes) < tcp->incoming_buffer->length) {
       grpc_slice_buffer_trim_end(
           tcp->incoming_buffer,
           tcp->incoming_buffer->length - static_cast<size_t>(read_bytes),

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -500,7 +500,7 @@ static void tcp_read_allocation_done(void* tcpp, grpc_error* error) {
 
 static void tcp_continue_read(grpc_tcp* tcp) {
   size_t target_read_size = get_target_read_size(tcp);
-  if (tcp->incoming_buffer->length < target_read_size &&
+  if (tcp->incoming_buffer->length < target_read_size / 2 &&
       tcp->incoming_buffer->count < MAX_READ_IOVEC) {
     if (grpc_tcp_trace.enabled()) {
       gpr_log(GPR_INFO, "TCP:%p alloc_slices", tcp);


### PR DESCRIPTION
This PR has two commits. One fixes a bug IMO, and one is a performance enhancement.

These are both precursors to TCP_INQ.

## Patch 1
Update TCP read estimates as soon as we read the whole buffer.

If we have a continous stream of bytes on the socket, we will
never grow the buffer, because we will never get EAGAIN, and
call finish. This is a serious performance issue, which can
be misued.

As soon as we have a full buffer, update the estimate.

## Patch 2
Do not wait for allocation if buffer is less than half the target.

We overallocate by 2x for target. Unless buffer is more than half
full, we should not delay read for more allocation.