### PR TITLE
Add c++ google default creds to cloud to prod auth scenarios

### DIFF
--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -137,7 +137,8 @@ int main(int argc, char** argv) {
       &grpc::testing::InteropClient::DoTimeoutOnSleepingServer, &client);
   actions["empty_stream"] =
       std::bind(&grpc::testing::InteropClient::DoEmptyStream, &client);
-  if (FLAGS_use_tls) {
+  if (FLAGS_use_tls ||
+      FLAGS_custom_credentials_type == "google_default_credentials") {
     actions["compute_engine_creds"] =
         std::bind(&grpc::testing::InteropClient::DoComputeEngineCreds, &client,
                   FLAGS_default_service_account, FLAGS_oauth_scope);

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -1376,7 +1376,8 @@ try:
                                 transport_security='tls')
                             jobs.append(tls_test_job)
                             if str(language) in [
-                                    'go'
+                                    'c++',
+                                    'go',
                             ]:  # Add more languages to the list to turn on tests.
                                 google_default_creds_test_job = cloud_to_prod_jobspec(
                                     language,


### PR DESCRIPTION
C++ interop clients are running cloud to prod scenarios, but this adds the missing cloud to prod auth scenarios