### PR TITLE
Fixup #16837 (build_performance.sh)

### DIFF
--- a/tools/run_tests/performance/build_performance.sh
+++ b/tools/run_tests/performance/build_performance.sh
@@ -61,9 +61,12 @@ do
   "node"|"node_purejs")
     tools/run_tests/performance/build_performance_node.sh
     ;;
-  *)
+  "python")
     # python workers are only run with python2.7 and building with multiple python versions is costly
     python tools/run_tests/run_tests.py -l "$language" -c "$CONFIG" --compiler python2.7 --build_only -j 8
+    ;;
+  *)
+    python tools/run_tests/run_tests.py -l "$language" -c "$CONFIG" --build_only -j 8
     ;;
   esac
 done


### PR DESCRIPTION
Fixup problem caused by #16837

Fixing broken ruby build:
```
+ for language in "$@"
+ case "$language" in
+ python tools/run_tests/run_tests.py -l ruby -c opt --compiler python2.7 --build_only -j 8
Traceback (most recent call last):
  File "tools/run_tests/run_tests.py", line 1515, in <module>
    l.configure(run_config, args)
  File "tools/run_tests/run_tests.py", line 874, in configure
    _check_compiler(self.args.compiler, ['default'])
  File "tools/run_tests/run_tests.py", line 193, in _check_compiler
    'Compiler %s not supported (on this platform).' % compiler)
Exception: Compiler python2.7 not supported (on this platform).
```