### PR TITLE
Explicitly delete copy constructor of ::grpc::Service class.

### DIFF
--- a/include/grpcpp/impl/codegen/service_type.h
+++ b/include/grpcpp/impl/codegen/service_type.h
@@ -58,6 +58,8 @@ class ServerAsyncStreamingInterface {
 class Service {
  public:
   Service() : server_(nullptr) {}
+  Service(const Service &) = delete;
+  Service & operator =(const Service &) = delete;
   virtual ~Service() {}
 
   bool has_async_methods() const {


### PR DESCRIPTION
Solve #15653