### PR TITLE
Add kokoro job for single VM benchmark

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_singlevm.cfg
+++ b/tools/internal_ci/linux/grpc_e2e_performance_singlevm.cfg
@@ -1,0 +1,25 @@
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_e2e_performance_singlevm.sh"
+timeout_mins: 360
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "**/perf_reports/**"
+  }
+}

--- a/tools/internal_ci/linux/grpc_e2e_performance_singlevm.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_singlevm.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copyright 2017 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -ex
+
+# Enter the gRPC repo root
+cd $(dirname $0)/../../..
+
+source tools/internal_ci/helper_scripts/prepare_build_linux_perf_multilang_rc
+
+# "smoketest" scenarios on a single VM (=no remote VM for running qps_workers)
+tools/run_tests/run_performance_tests.py \
+    -l c++ csharp ruby java python go php7 php7_protobuf_c node node_purejs \
+    --netperf \
+    --category smoketest \
+    -u kbuilder \
+    --xml_report reports/singlemachine/sponge_log.xml


### PR DESCRIPTION
Add a job that will run a single-VM  end to end benchmark suite (= qps_driver and qps_worker all on the same machine).

Why this job is needed:
- the multimachine job is hard to maintain as kokoro doesn't support multi-VM setup so there are often breakages that are hard to debug
- the singlevm job is easier to maintain, offers better isolation and can be used for quicker iteration on fixing the multi-vm benchmark.
- such job is great for running adhoc experiments when setting up new benchmarks

The single machine job doesn't upload to bigquery and the data are not presented anywhere, it's basically only about making sure that the benchmarks are not broken (but it helps a great deal there).