### PR TITLE
Do not pass interested_parties during handshake

### DIFF
--- a/src/core/ext/transport/chttp2/client/chttp2_connector.cc
+++ b/src/core/ext/transport/chttp2/client/chttp2_connector.cc
@@ -163,9 +163,8 @@ static void start_handshake_locked(chttp2_connector* c) {
                        c->args.interested_parties, c->handshake_mgr);
   grpc_endpoint_add_to_pollset_set(c->endpoint, c->args.interested_parties);
   grpc_handshake_manager_do_handshake(
-      c->handshake_mgr, c->args.interested_parties, c->endpoint,
-      c->args.channel_args, c->args.deadline, nullptr /* acceptor */,
-      on_handshake_done, c);
+      c->handshake_mgr, c->endpoint, c->args.channel_args, c->args.deadline,
+      nullptr /* acceptor */, on_handshake_done, c);
   c->endpoint = nullptr;  // Endpoint handed off to handshake manager.
 }
 

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -208,10 +208,10 @@ static void on_accept(void* arg, grpc_endpoint* tcp,
       grpc_core::ExecCtx::Get()->Now() +
       grpc_channel_arg_get_integer(timeout_arg,
                                    {120 * GPR_MS_PER_SEC, 1, INT_MAX});
-  grpc_handshake_manager_do_handshake(
-      connection_state->handshake_mgr, nullptr /* interested_parties */, tcp,
-      state->args, connection_state->deadline, acceptor, on_handshake_done,
-      connection_state);
+  grpc_handshake_manager_do_handshake(connection_state->handshake_mgr, tcp,
+                                      state->args, connection_state->deadline,
+                                      acceptor, on_handshake_done,
+                                      connection_state);
 }
 
 /* Server callback: start listening on our ports */

--- a/src/core/lib/channel/handshaker.cc
+++ b/src/core/lib/channel/handshaker.cc
@@ -292,17 +292,18 @@ static void on_timeout(void* arg, grpc_error* error) {
   grpc_handshake_manager_unref(mgr);
 }
 
-void grpc_handshake_manager_do_handshake(
-    grpc_handshake_manager* mgr, grpc_pollset_set* interested_parties,
-    grpc_endpoint* endpoint, const grpc_channel_args* channel_args,
-    grpc_millis deadline, grpc_tcp_server_acceptor* acceptor,
-    grpc_iomgr_cb_func on_handshake_done, void* user_data) {
+void grpc_handshake_manager_do_handshake(grpc_handshake_manager* mgr,
+                                         grpc_endpoint* endpoint,
+                                         const grpc_channel_args* channel_args,
+                                         grpc_millis deadline,
+                                         grpc_tcp_server_acceptor* acceptor,
+                                         grpc_iomgr_cb_func on_handshake_done,
+                                         void* user_data) {
   gpr_mu_lock(&mgr->mu);
   GPR_ASSERT(mgr->index == 0);
   GPR_ASSERT(!mgr->shutdown);
   // Construct handshaker args.  These will be passed through all
   // handshakers and eventually be freed by the on_handshake_done callback.
-  mgr->args.interested_parties = interested_parties;
   mgr->args.endpoint = endpoint;
   mgr->args.args = grpc_channel_args_copy(channel_args);
   mgr->args.user_data = user_data;

--- a/src/core/lib/channel/handshaker.h
+++ b/src/core/lib/channel/handshaker.h
@@ -56,7 +56,6 @@ typedef struct grpc_handshaker grpc_handshaker;
 /// For the on_handshake_done callback, all members are input arguments,
 /// which the callback takes ownership of.
 typedef struct {
-  grpc_pollset_set* interested_parties;
   grpc_endpoint* endpoint;
   grpc_channel_args* args;
   grpc_slice_buffer* read_buffer;
@@ -132,8 +131,6 @@ void grpc_handshake_manager_shutdown(grpc_handshake_manager* mgr,
                                      grpc_error* why);
 
 /// Invokes handshakers in the order they were added.
-/// \a interested_parties may be non-nullptr to provide a pollset_set that
-/// may be used during handshaking. Ownership is not taken.
 /// Takes ownership of \a endpoint, and then passes that ownership to
 /// the \a on_handshake_done callback.
 /// Does NOT take ownership of \a channel_args.  Instead, makes a copy before
@@ -145,11 +142,13 @@ void grpc_handshake_manager_shutdown(grpc_handshake_manager* mgr,
 /// GRPC_ERROR_NONE, then handshaking failed and the handshaker has done
 /// the necessary clean-up.  Otherwise, the callback takes ownership of
 /// the arguments.
-void grpc_handshake_manager_do_handshake(
-    grpc_handshake_manager* mgr, grpc_pollset_set* interested_parties,
-    grpc_endpoint* endpoint, const grpc_channel_args* channel_args,
-    grpc_millis deadline, grpc_tcp_server_acceptor* acceptor,
-    grpc_iomgr_cb_func on_handshake_done, void* user_data);
+void grpc_handshake_manager_do_handshake(grpc_handshake_manager* mgr,
+                                         grpc_endpoint* endpoint,
+                                         const grpc_channel_args* channel_args,
+                                         grpc_millis deadline,
+                                         grpc_tcp_server_acceptor* acceptor,
+                                         grpc_iomgr_cb_func on_handshake_done,
+                                         void* user_data);
 
 /// Add \a mgr to the server side list of all pending handshake managers, the
 /// list starts with \a *head.

--- a/src/core/lib/http/httpcli_security_connector.cc
+++ b/src/core/lib/http/httpcli_security_connector.cc
@@ -194,9 +194,8 @@ static void ssl_handshake(void* arg, grpc_endpoint* tcp, const char* host,
   grpc_handshakers_add(HANDSHAKER_CLIENT, &args,
                        nullptr /* interested_parties */, c->handshake_mgr);
   grpc_handshake_manager_do_handshake(
-      c->handshake_mgr, nullptr /* interested_parties */, tcp,
-      nullptr /* channel_args */, deadline, nullptr /* acceptor */,
-      on_handshake_done, c /* user_data */);
+      c->handshake_mgr, tcp, nullptr /* channel_args */, deadline,
+      nullptr /* acceptor */, on_handshake_done, c /* user_data */);
   GRPC_SECURITY_CONNECTOR_UNREF(&sc->base, "httpcli");
 }
 

--- a/test/core/security/ssl_server_fuzzer.cc
+++ b/test/core/security/ssl_server_fuzzer.cc
@@ -93,9 +93,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
     grpc_handshake_manager* handshake_mgr = grpc_handshake_manager_create();
     grpc_server_security_connector_add_handshakers(sc, nullptr, handshake_mgr);
     grpc_handshake_manager_do_handshake(
-        handshake_mgr, nullptr /* interested_parties */, mock_endpoint,
-        nullptr /* channel_args */, deadline, nullptr /* acceptor */,
-        on_handshake_done, &state);
+        handshake_mgr, mock_endpoint, nullptr /* channel_args */, deadline,
+        nullptr /* acceptor */, on_handshake_done, &state);
     grpc_core::ExecCtx::Get()->Flush();
 
     // If the given string happens to be part of the correct client hello, the


### PR DESCRIPTION
Due to recent change in #16792, there is no need to pass in `interested_parties` during handshake any more, since the same information is passed in during handshaker construction time at both client and server sides. 

The PR basically reverts the changes made in #13420. I will also prepare a CL to apply the changes to internal PSP implementation.