### PR TITLE
Add interop test into bazel build

### DIFF
--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -142,3 +142,24 @@ grpc_cc_binary(
         "//test/cpp/util:test_config",
     ],
 )
+
+grpc_cc_test(
+    name = "interop_test",
+    srcs = ["interop_test.cc"],
+    data = [
+        ":interop_client",
+        ":interop_server",
+    ],
+    external_deps = [
+        "gflags",
+    ],
+    deps = [
+        "//:gpr",
+        "//:grpc",
+        "//:grpc++",
+        "//test/core/util:gpr_test_util",
+        "//test/core/util:grpc_test_util",
+        "//test/cpp/util:test_config",
+        "//test/cpp/util:test_util",
+    ],
+)


### PR DESCRIPTION
Fix https://github.com/grpc/grpc/issues/16853.

Let's see whether it breaks anything. Also, I am not sure how to add the `cpu_cost` config in bazel. @jtattermusch thoughts?