### PR TITLE
Fix cmake install step with gRPC_BUILD_CODEGEN=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3753,8 +3753,6 @@ foreach(_hdr
     DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
   )
 endforeach()
-endif (gRPC_BUILD_CODEGEN)
-
 
 if (gRPC_INSTALL)
   install(TARGETS grpc++_error_details EXPORT gRPCTargets
@@ -3763,6 +3761,7 @@ if (gRPC_INSTALL)
     ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
   )
 endif()
+endif (gRPC_BUILD_CODEGEN)
 
 if (gRPC_BUILD_TESTS)
 
@@ -3883,8 +3882,6 @@ foreach(_hdr
     DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
   )
 endforeach()
-endif (gRPC_BUILD_CODEGEN)
-
 
 if (gRPC_INSTALL)
   install(TARGETS grpc++_reflection EXPORT gRPCTargets
@@ -3893,6 +3890,7 @@ if (gRPC_INSTALL)
     ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
   )
 endif()
+endif (gRPC_BUILD_CODEGEN)
 
 if (gRPC_BUILD_TESTS)
 
@@ -4841,8 +4839,6 @@ foreach(_hdr
     DESTINATION "${gRPC_INSTALL_INCLUDEDIR}/${_path}"
   )
 endforeach()
-endif (gRPC_BUILD_CODEGEN)
-
 
 if (gRPC_INSTALL)
   install(TARGETS grpcpp_channelz EXPORT gRPCTargets
@@ -4851,6 +4847,7 @@ if (gRPC_INSTALL)
     ARCHIVE DESTINATION ${gRPC_INSTALL_LIBDIR}
   )
 endif()
+endif (gRPC_BUILD_CODEGEN)
 
 if (gRPC_BUILD_TESTS)
 


### PR DESCRIPTION
# What this PR does?
* Fix cmake install step with `gRPC_BUILD_CODEGEN=OFF`

- **Issue**
   https://github.com/grpc/grpc/issues/16856
 
- **Explanation**
The targets `grpc++_error_details`, `grpc++_reflection` and `grpcpp_channelz` are defined inside `if(gRPC_BUILD_CODEGEN)` block, but their install steps are defined outside `if(gRPC_BUILD_CODEGEN)`.

- **Solution**
Move the install step into `if(gRPC_BUILD_CODEGEN)` block.

- **Expected behavior**
Install step should work properly with `gRPC_BUILD_CODEGEN=OFF` option.
