### PR TITLE
Channelz Part 10: More Channel Tracing

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.h
+++ b/src/core/ext/filters/client_channel/client_channel.h
@@ -40,6 +40,9 @@ extern grpc_core::TraceFlag grpc_client_channel_trace;
 
 extern const grpc_channel_filter grpc_client_channel_filter;
 
+void grpc_client_channel_set_channelz_node(
+    grpc_channel_element* elem, grpc_core::channelz::ClientChannelNode* node);
+
 void grpc_client_channel_populate_child_refs(
     grpc_channel_element* elem,
     grpc_core::channelz::ChildRefsList* child_subchannels,

--- a/src/core/ext/filters/client_channel/client_channel_channelz.cc
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.cc
@@ -49,6 +49,7 @@ ClientChannelNode::ClientChannelNode(grpc_channel* channel,
     : ChannelNode(channel, channel_tracer_max_nodes, is_top_level_channel) {
   client_channel_ =
       grpc_channel_stack_last_element(grpc_channel_get_channel_stack(channel));
+  grpc_client_channel_set_channelz_node(client_channel_, this);
   GPR_ASSERT(client_channel_->filter == &grpc_client_channel_filter);
 }
 


### PR DESCRIPTION
Adds tracing for connectivity state change.

Tracking: #15340 

Example output from a simple RPC scenario:

```
{  
   "ref":{  
      "channelId":"3"
   },
   "data":{  
      "state":{  
         "state":"READY"
      },
      "target":"localhost:29788",
      "trace":{  
         "numEventsLogged":"4",
         "creationTimestamp":"2018-10-15T13:45:51.809444890Z",
         "events":[  
            {  
               "description":"Channel created",
               "severity":"CT_INFO",
               "timestamp":"2018-10-15T13:45:51.809445533Z"
            },
            {  
               "description":"Channel state change to IDLE",
               "severity":"CT_INFO",
               "timestamp":"2018-10-15T13:45:51.809445011Z"
            },
            {  
               "description":"Channel state change to CONNECTING",
               "severity":"CT_INFO",
               "timestamp":"2018-10-15T13:45:51.809444963Z"
            },
            {  
               "description":"Channel state change to READY",
               "severity":"CT_INFO",
               "timestamp":"2018-10-15T13:45:51.810445024Z"
            }
         ]
      },
      "callsStarted":"1",
      "callsSucceeded":"1",
      "lastCallStartedTimestamp":"2018-10-15T13:45:51.809444632Z"
   },
   "subchannelRef":[  
      {  
         "subchannelId":"4"
      },
      {  
         "subchannelId":"5"
      }
   ]
}
```