### PR TITLE
Re-enable GoogleDefaultCreds C++ cloud to prod auth tests

### DIFF
--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -137,7 +137,8 @@ int main(int argc, char** argv) {
       &grpc::testing::InteropClient::DoTimeoutOnSleepingServer, &client);
   actions["empty_stream"] =
       std::bind(&grpc::testing::InteropClient::DoEmptyStream, &client);
-  if (FLAGS_use_tls) {
+  if (FLAGS_use_tls ||
+      FLAGS_custom_credentials_type == "google_default_credentials") {
     actions["compute_engine_creds"] =
         std::bind(&grpc::testing::InteropClient::DoComputeEngineCreds, &client,
                   FLAGS_default_service_account, FLAGS_oauth_scope);

--- a/tools/internal_ci/macos/grpc_interop_toprod.sh
+++ b/tools/internal_ci/macos/grpc_interop_toprod.sh
@@ -32,6 +32,7 @@ export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$(pwd)/etc/roots.pem"
 tools/run_tests/run_interop_tests.py -l c++ \
     --cloud_to_prod --cloud_to_prod_auth --prod_servers default gateway_v4 \
     --service_account_key_file="${KOKORO_GFILE_DIR}/GrpcTesting-726eb1347f15.json" \
+    --key_file_for_non_auth_google_default_creds_tests="${KOKORO_GFILE_DIR}/GrpcTesting-726eb1347f15.json" \
     --skip_compute_engine_creds --internal_ci -t -j 4 || FAILED="true"
 
 tools/internal_ci/helper_scripts/delete_nonartifacts.sh || true

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -710,7 +710,10 @@ def compute_engine_creds_required(language, test_case):
     return False
 
 
-def auth_options(language, test_case, service_account_key_file=None):
+def auth_options(language,
+                 test_case,
+                 transport_security,
+                 service_account_key_file=None):
     """Returns (cmdline, env) tuple with cloud_to_prod_auth test options."""
 
     language = str(language)
@@ -724,15 +727,15 @@ def auth_options(language, test_case, service_account_key_file=None):
     key_file_arg = '--service_account_key_file=%s' % service_account_key_file
     default_account_arg = '--default_service_account=830293263384-compute@developer.gserviceaccount.com'
 
-    # TODO: When using google_default_credentials outside of cloud-to-prod, the environment variable
-    # 'GOOGLE_APPLICATION_CREDENTIALS' needs to be set for the test case
-    # 'jwt_token_creds' to work.
     if test_case in ['jwt_token_creds', 'per_rpc_creds', 'oauth2_auth_token']:
         if language in [
                 'csharp', 'csharpcoreclr', 'node', 'php', 'php7', 'python',
                 'ruby', 'nodepurejs'
         ]:
             env['GOOGLE_APPLICATION_CREDENTIALS'] = service_account_key_file
+        elif language == 'c++' and transport_security == 'google_default_credentials':
+            env['GOOGLE_APPLICATION_CREDENTIALS'] = service_account_key_file
+            cmdargs += [key_file_arg]
         else:
             cmdargs += [key_file_arg]
 
@@ -767,6 +770,7 @@ def cloud_to_prod_jobspec(language,
                           auth=False,
                           manual_cmd_log=None,
                           service_account_key_file=None,
+                          key_file_for_non_auth_google_default_creds_tests=None,
                           transport_security='tls'):
     """Creates jobspec for cloud-to-prod interop test"""
     container_name = None
@@ -789,10 +793,19 @@ def cloud_to_prod_jobspec(language,
     cmdargs = cmdargs + transport_security_options
     environ = dict(language.cloud_to_prod_env(), **language.global_env())
     if auth:
-        auth_cmdargs, auth_env = auth_options(language, test_case,
-                                              service_account_key_file)
+        auth_cmdargs, auth_env = auth_options(
+            language, test_case, transport_security, service_account_key_file)
         cmdargs += auth_cmdargs
         environ.update(auth_env)
+    elif transport_security == 'google_default_credentials':
+        # Channels with GoogleDefaultCredentials need to be able to find an OAuth
+        # token in order to function at all (this env variable allows doing that
+        # even when running outside of compute engine).
+        if key_file_for_non_auth_google_default_creds_tests:
+            environ.update({
+                'GOOGLE_APPLICATION_CREDENTIALS':
+                key_file_for_non_auth_google_default_creds_tests,
+            })
     cmdline = bash_cmdline(language.client_cmd(cmdargs))
     cwd = language.client_cwd
 
@@ -1153,6 +1166,12 @@ argp.add_argument(
     const=True,
     help='Skip auth tests requiring access to compute engine credentials.')
 argp.add_argument(
+    '--key_file_for_non_auth_google_default_creds_tests',
+    type=str,
+    help='GOOGLE_APPLICATION_CREDENTIALS service account key file to use for '
+    'non-auth tests that are running with GoogleDefaultCredentials.',
+    default=None)
+argp.add_argument(
     '--internal_ci',
     default=False,
     action='store_const',
@@ -1336,6 +1355,9 @@ try:
                                     manual_cmd_log=client_manual_cmd_log,
                                     service_account_key_file=args.
                                     service_account_key_file,
+                                    key_file_for_non_auth_google_default_creds_tests
+                                    =args.
+                                    key_file_for_non_auth_google_default_creds_tests,
                                     transport_security=
                                     'google_default_credentials')
                                 jobs.append(google_default_creds_test_job)
@@ -1378,7 +1400,7 @@ try:
                                 transport_security='tls')
                             jobs.append(tls_test_job)
                             if str(language) in [
-                                    'go'
+                                    'c++', 'go'
                             ]:  # Add more languages to the list to turn on tests.
                                 google_default_creds_test_job = cloud_to_prod_jobspec(
                                     language,


### PR DESCRIPTION
Reverts https://github.com/grpc/grpc/pull/16880 after fixing the underlying issue of https://github.com/grpc/grpc/issues/16879

This change brings back #16841 but does two things differently:
1) When the test is an auth test that needs a service account key file (e.g. `jwt_token_creds`) and we're using GoogleDefaultCredentials, then regardless of where we're running, set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to a valid service account key file, allowing these tests to run outside of GCP.
2) When running outside of GCP, and the test is <i>not</i> an auth test (e.g. `empty_stream`) but we are using GoogleDefaultCredentials, set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to a valid service account key file, so that the channel can still operate.
3) Skip `per_rpc_creds` and `oauth2_auth_token` tests when GoogleDefaultCredentials is in use, because these test cases are designed to test features that are irrelevant to GoogleDefaultCredentials

PTAL