### PR TITLE
Update Go interop image to go1.11

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_go/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_go/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM golang:latest
+  FROM golang:1.11
   
   <%include file="../../go_path.include"/>
   <%include file="../../python_deps.include"/>

--- a/tools/dockerfile/interoptest/grpc_interop_go/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_go/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:latest
+FROM golang:1.11
 
 # Using login shell removes Go from path, so we add it.
 RUN ln -s /usr/local/go/bin/go /usr/local/bin


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/16604,  

updated the image, regenerated and pushed with `tools/dockerfile/push_testing_images.sh`.