### PR TITLE
Fix a dangling pointer on ares_request object in case of cancellation

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -201,7 +201,7 @@ void AresDnsResolver::ShutdownLocked() {
     grpc_timer_cancel(&next_resolution_timer_);
   }
   if (pending_request_ != nullptr) {
-    grpc_cancel_ares_request(pending_request_);
+    grpc_cancel_ares_request_locked(pending_request_);
   }
   if (next_completion_ != nullptr) {
     *target_result_ = nullptr;
@@ -298,6 +298,7 @@ void AresDnsResolver::OnResolvedLocked(void* arg, grpc_error* error) {
   grpc_channel_args* result = nullptr;
   GPR_ASSERT(r->resolving_);
   r->resolving_ = false;
+  gpr_free(r->pending_request_);
   r->pending_request_ = nullptr;
   if (r->lb_addresses_ != nullptr) {
     static const char* args_to_remove[2];

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
@@ -54,7 +54,8 @@ extern void (*grpc_resolve_address_ares)(const char* name,
   port in \a name. grpc_ares_init() must be called at least once before this
   function. \a on_done may be called directly in this function without being
   scheduled with \a exec_ctx, so it must not try to acquire locks that are
-  being held by the caller. */
+  being held by the caller. The returned grpc_ares_request object is owned
+  by the caller and it is safe to free after on_done is called back. */
 extern grpc_ares_request* (*grpc_dns_lookup_ares_locked)(
     const char* dns_server, const char* name, const char* default_port,
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
@@ -62,7 +63,7 @@ extern grpc_ares_request* (*grpc_dns_lookup_ares_locked)(
     char** service_config_json, grpc_combiner* combiner);
 
 /* Cancel the pending grpc_ares_request \a request */
-void grpc_cancel_ares_request(grpc_ares_request* request);
+extern void (*grpc_cancel_ares_request_locked)(grpc_ares_request* request);
 
 /* Initialize gRPC ares wrapper. Must be called at least once before
    grpc_resolve_address_ares(). */

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_fallback.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_fallback.cc
@@ -40,7 +40,10 @@ grpc_ares_request* (*grpc_dns_lookup_ares_locked)(
     grpc_lb_addresses** addrs, bool check_grpclb, char** service_config_json,
     grpc_combiner* combiner) = grpc_dns_lookup_ares_locked_impl;
 
-void grpc_cancel_ares_request(grpc_ares_request* r) {}
+static void grpc_cancel_ares_request_locked_impl(grpc_ares_request* r) {}
+
+void (*grpc_cancel_ares_request_locked)(grpc_ares_request* r) =
+    grpc_cancel_ares_request_locked_impl;
 
 grpc_error* grpc_ares_init(void) { return GRPC_ERROR_NONE; }
 

--- a/test/core/client_channel/resolvers/dns_resolver_connectivity_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_connectivity_test.cc
@@ -82,6 +82,10 @@ static grpc_ares_request* my_dns_lookup_ares_locked(
   return nullptr;
 }
 
+static void my_cancel_ares_request_locked(grpc_ares_request* request) {
+  GPR_ASSERT(request == nullptr);
+}
+
 static grpc_core::OrphanablePtr<grpc_core::Resolver> create_resolver(
     const char* name) {
   grpc_core::ResolverFactory* factory =
@@ -148,6 +152,7 @@ int main(int argc, char** argv) {
   g_combiner = grpc_combiner_create();
   grpc_set_resolver_impl(&test_resolver);
   grpc_dns_lookup_ares_locked = my_dns_lookup_ares_locked;
+  grpc_cancel_ares_request_locked = my_cancel_ares_request_locked;
   grpc_channel_args* result = (grpc_channel_args*)1;
 
   {

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -390,6 +390,10 @@ grpc_ares_request* my_dns_lookup_ares_locked(
   return nullptr;
 }
 
+static void my_cancel_ares_request_locked(grpc_ares_request* request) {
+  GPR_ASSERT(request == nullptr);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // client connection
 
@@ -705,6 +709,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   }
   grpc_set_resolver_impl(&fuzzer_resolver);
   grpc_dns_lookup_ares_locked = my_dns_lookup_ares_locked;
+  grpc_cancel_ares_request_locked = my_cancel_ares_request_locked;
 
   GPR_ASSERT(g_channel == nullptr);
   GPR_ASSERT(g_server == nullptr);

--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -50,6 +50,8 @@ static grpc_ares_request* (*iomgr_dns_lookup_ares_locked)(
     grpc_lb_addresses** addresses, bool check_grpclb,
     char** service_config_json, grpc_combiner* combiner);
 
+static void (*iomgr_cancel_ares_request_locked)(grpc_ares_request* request);
+
 static void set_resolve_port(int port) {
   gpr_mu_lock(&g_mu);
   g_resolve_port = port;
@@ -130,6 +132,12 @@ static grpc_ares_request* my_dns_lookup_ares_locked(
   return nullptr;
 }
 
+static void my_cancel_ares_request_locked(grpc_ares_request* request) {
+  if (request != nullptr) {
+    iomgr_cancel_ares_request_locked(request);
+  }
+}
+
 int main(int argc, char** argv) {
   grpc_completion_queue* cq;
   cq_verifier* cqv;
@@ -143,7 +151,9 @@ int main(int argc, char** argv) {
   default_resolver = grpc_resolve_address_impl;
   grpc_set_resolver_impl(&test_resolver);
   iomgr_dns_lookup_ares_locked = grpc_dns_lookup_ares_locked;
+  iomgr_cancel_ares_request_locked = grpc_cancel_ares_request_locked;
   grpc_dns_lookup_ares_locked = my_dns_lookup_ares_locked;
+  grpc_cancel_ares_request_locked = my_cancel_ares_request_locked;
 
   int was_cancelled1;
   int was_cancelled2;


### PR DESCRIPTION
Extracted from https://github.com/grpc/grpc/pull/16862 - this bug was noticed by failing tests on that PR

Currently, if we `grpc_cancel_ares_request` <i>after</i> queries have been completed (`grpc_ares_complete_request_locked` has been invoked) but <i>before</i> the `on_done` closure is ran, then we will access previously free'd memory. This is because the party that's interested in ares resolution receives a pointer to a the `ares_request` object when the query is started, but it doesn't actually take any ownership of it, so when queries are completed, the pointer still points to free'd memory. This PR fixes the situation by making the `ares_request` owned by the party that's waiting for resolution to complete; when resolution does complete, it's safe to free the `ares_request` (safety guaranteed because the query won't complete until all internal DNS callbacks are done).

Slightly unrelated but this PR also changes the way that tests which mock the `grpc_ares_wrapper` work, to mock out the full `grpc_ares_wrapper` API.... this allows us to get rid of the `if (grpc_dns_lookup_ares_locked == grpc_dns_lookup_ares_locked_impl) {` check at the top of `grpc_ares_cancel_request`.