### PR TITLE
Fix bazel for //test/cpp/microbenchmarks/...

### DIFF
--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -24,7 +24,7 @@ grpc_cc_test(
     external_deps = [
         "benchmark",
     ],
-    deps = ["//test/core/util:gpr_test_util",]
+    deps = ["//test/core/util:gpr_test_util"],
 )
 
 grpc_cc_library(
@@ -41,6 +41,7 @@ grpc_cc_library(
     ],
     deps = [
         "//:grpc++_unsecure",
+        "//:lb_server_load_reporting_filter",
         "//src/proto/grpc/testing:echo_proto",
         "//test/core/util:grpc_test_util_unsecure",
         "//test/cpp/util:test_config",
@@ -65,6 +66,13 @@ grpc_cc_binary(
     name = "bm_channel",
     testonly = 1,
     srcs = ["bm_channel.cc"],
+    deps = [":helpers"],
+)
+
+grpc_cc_binary(
+    name = "bm_call_create",
+    testonly = 1,
+    srcs = ["bm_call_create.cc"],
     deps = [":helpers"],
 )
 


### PR DESCRIPTION
Fix a build failure due to missed dependency and add the bm_create_call
benchmark as a build target.