### PR TITLE
Fix corruption of ares blocking_resolve_address when grpc is restarted

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -473,7 +473,9 @@ void grpc_resolver_dns_ares_init() {
       GRPC_LOG_IF_ERROR("ares_library_init() failed", error);
       return;
     }
-    default_resolver = grpc_resolve_address_impl;
+    if (default_resolver == nullptr) {
+      default_resolver = grpc_resolve_address_impl;
+    }
     grpc_set_resolver_impl(&ares_resolver);
     grpc_core::ResolverRegistry::Builder::RegisterResolverFactory(
         grpc_core::UniquePtr<grpc_core::ResolverFactory>(


### PR DESCRIPTION
Also extracted from https://github.com/grpc/grpc/pull/16862/files

Currently, if c-ares is in use and:

1) grpc is initialized
2) grpc is shutdown
3) grpc is initialized again

then [default resolver](https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc#L453) will be set to [grpc_resolve_address_impl](https://github.com/grpc/grpc/blob/master/src/core/lib/iomgr/resolve_address.cc#L27) which in turn actually points at [ares resolver vtable](https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc#L462). The net result is that the [default_resolver->blocking_resolve_address](https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc#L458) actually points at [blocking_resolve_address_ares](https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc#L455) <b>recursively</b>. Then, the next time that [grpc_blocking_resolve_address](https://github.com/grpc/grpc/blob/master/src/core/lib/iomgr/resolve_address.cc#L45) is called, we will crash by infinite recursion.

To fix this, we can make sure that we only set `default_resolver = grpc_resolve_address_impl` the first time the plugins are initialized. It's not safe to do this assignment on subsequent initializations because [the iomgr initialization](https://github.com/grpc/grpc/blob/master/src/core/lib/iomgr/iomgr_internal.cc#L35), which the c-ares plugin relies on having ran first, is only done the first time grpc initializes. This seems more complicated than it should be, but I can't see a better way right now.