### PR TITLE
Add python example - channel options

### DIFF
--- a/examples/python/helloworld/greeter_client_with_options.py
+++ b/examples/python/helloworld/greeter_client_with_options.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""The Python implementation of the GRPC helloworld.Greeter client."""
+"""The Python implementation of the GRPC helloworld.Greeter client with channel options and call timeout parameters."""
 
 from __future__ import print_function
 

--- a/examples/python/helloworld/greeter_client_with_options.py
+++ b/examples/python/helloworld/greeter_client_with_options.py
@@ -33,8 +33,8 @@ def run():
                      ('grpc.enable_retries', 0),
                      ('grpc.keepalive_timeout_ms', 10000)]) as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
-        # timeout in second
-        response = stub.SayHello(helloworld_pb2.HelloRequest(name='you'), timeout=1)
+        # Timeout in seconds.
+        response = stub.SayHello(helloworld_pb2.HelloRequest(name='you'), timeout=10)
     print("Greeter client received: " + response.message)
 
 

--- a/examples/python/helloworld/greeter_client_with_options.py
+++ b/examples/python/helloworld/greeter_client_with_options.py
@@ -22,28 +22,20 @@ import helloworld_pb2_grpc
 
 
 def run():
+    # NOTE(gRPC Python Team): .close() is possible on a channel and should be
+    # used in circumstances in which the with statement does not fit the needs
+    # of the code.
+    #
     # For more channel options, please see https://grpc.io/grpc/core/group__grpc__arg__keys.html
-    channel = grpc.insecure_channel(
-        target='localhost:50051',
-        options=[('grpc.lb_policy_name', 'pick_first'),
-                 ('grpc.enable_retries', 0),
-                 ('grpc.keepalive_timeout_ms', 10),
-                 ('grpc.max_receive_message_length', 12)])
-    stub = helloworld_pb2_grpc.GreeterStub(channel)
-
-    try:
-        # synchronous rpc call
-        stub.SayHello(helloworld_pb2.HelloRequest(name='you'))
-    except Exception as err:
-        print('Raised by max_receive_message_length option\n' + str(err))
-
-    try:
-        # asynchronous rpc call. timeout in second
-        future = stub.SayHello.future(helloworld_pb2.HelloRequest(name='me'), timeout=1)
-        response = future.result()
-        print("Greeter client received: " + response.message)
-    finally:
-        channel.close()
+    with grpc.insecure_channel(
+            target='localhost:50051',
+            options=[('grpc.lb_policy_name', 'pick_first'),
+                     ('grpc.enable_retries', 0),
+                     ('grpc.keepalive_timeout_ms', 10)]) as channel:
+        stub = helloworld_pb2_grpc.GreeterStub(channel)
+        # timeout in second
+        response = stub.SayHello(helloworld_pb2.HelloRequest(name='you'), timeout=1)
+    print("Greeter client received: " + response.message)
 
 
 if __name__ == '__main__':

--- a/examples/python/helloworld/greeter_client_with_options.py
+++ b/examples/python/helloworld/greeter_client_with_options.py
@@ -30,12 +30,13 @@ def run():
     with grpc.insecure_channel(
             target='localhost:50051',
             options=[('grpc.lb_policy_name', 'pick_first'),
-                     ('grpc.enable_retries', 0),
-                     ('grpc.keepalive_timeout_ms', 10000)]) as channel:
+                     ('grpc.enable_retries', 0), ('grpc.keepalive_timeout_ms',
+                                                  10000)]) as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
         # Timeout in seconds.
         # Please refer gRPC Python documents for more detail. https://grpc.io/grpc/python/grpc.html
-        response = stub.SayHello(helloworld_pb2.HelloRequest(name='you'), timeout=10)
+        response = stub.SayHello(
+            helloworld_pb2.HelloRequest(name='you'), timeout=10)
     print("Greeter client received: " + response.message)
 
 

--- a/examples/python/helloworld/greeter_client_with_options.py
+++ b/examples/python/helloworld/greeter_client_with_options.py
@@ -34,6 +34,7 @@ def run():
                      ('grpc.keepalive_timeout_ms', 10000)]) as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
         # Timeout in seconds.
+        # Please refer gRPC Python documents for more detail. https://grpc.io/grpc/python/grpc.html
         response = stub.SayHello(helloworld_pb2.HelloRequest(name='you'), timeout=10)
     print("Greeter client received: " + response.message)
 

--- a/examples/python/helloworld/greeter_client_with_options.py
+++ b/examples/python/helloworld/greeter_client_with_options.py
@@ -1,0 +1,50 @@
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The Python implementation of the GRPC helloworld.Greeter client."""
+
+from __future__ import print_function
+
+import grpc
+
+import helloworld_pb2
+import helloworld_pb2_grpc
+
+
+def run():
+    # For more channel options, please see https://grpc.io/grpc/core/group__grpc__arg__keys.html
+    channel = grpc.insecure_channel(
+        target='localhost:50051',
+        options=[('grpc.lb_policy_name', 'pick_first'),
+                 ('grpc.enable_retries', 0),
+                 ('grpc.keepalive_timeout_ms', 10),
+                 ('grpc.max_receive_message_length', 12)])
+    stub = helloworld_pb2_grpc.GreeterStub(channel)
+
+    try:
+        # synchronous rpc call
+        stub.SayHello(helloworld_pb2.HelloRequest(name='you'))
+    except Exception as err:
+        print('Raised by max_receive_message_length option\n' + str(err))
+
+    try:
+        # asynchronous rpc call. timeout in second
+        future = stub.SayHello.future(helloworld_pb2.HelloRequest(name='me'), timeout=1)
+        response = future.result()
+        print("Greeter client received: " + response.message)
+    finally:
+        channel.close()
+
+
+if __name__ == '__main__':
+    run()

--- a/examples/python/helloworld/greeter_client_with_options.py
+++ b/examples/python/helloworld/greeter_client_with_options.py
@@ -31,7 +31,7 @@ def run():
             target='localhost:50051',
             options=[('grpc.lb_policy_name', 'pick_first'),
                      ('grpc.enable_retries', 0),
-                     ('grpc.keepalive_timeout_ms', 10)]) as channel:
+                     ('grpc.keepalive_timeout_ms', 10000)]) as channel:
         stub = helloworld_pb2_grpc.GreeterStub(channel)
         # timeout in second
         response = stub.SayHello(helloworld_pb2.HelloRequest(name='you'), timeout=1)


### PR DESCRIPTION
@srini100

I struggled while I find channel options to build gRPC python client.
So I brought it up at [google forum](https://groups.google.com/forum/#!topic/grpc-io/6t_CmT4p9Kk) and got some PR feedback. Please check it out.

This example might be very helpful for python users.

Please review this example, and feel free to feedback.