### PR TITLE
Fix memory_usage_test (and performance_profile_daily kokoro job)

### DIFF
--- a/test/core/memory_usage/memory_usage_test.cc
+++ b/test/core/memory_usage/memory_usage_test.cc
@@ -43,7 +43,7 @@ int main(int argc, char** argv) {
     strcpy(root, ".");
   }
   /* start the server */
-  gpr_asprintf(&args[0], "%s/memory_profile_server%s", root,
+  gpr_asprintf(&args[0], "%s/memory_usage_server%s", root,
                gpr_subprocess_binary_extension());
   args[1] = const_cast<char*>("--bind");
   gpr_join_host_port(&args[2], "::", port);
@@ -53,7 +53,7 @@ int main(int argc, char** argv) {
   gpr_free(args[2]);
 
   /* start the client */
-  gpr_asprintf(&args[0], "%s/memory_profile_client%s", root,
+  gpr_asprintf(&args[0], "%s/memory_usage_client%s", root,
                gpr_subprocess_binary_extension());
   args[1] = const_cast<char*>("--target");
   gpr_join_host_port(&args[2], "127.0.0.1", port);


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc/pull/16907.

The performance_profile_daily job is still broken:

```
+ bins/opt/memory_usage_test
E1018 10:13:00.218943401   13443 subprocess_posix.cc:61]     execv 'bins/opt/memory_profile_server' failed: No such file or directory
E1018 10:13:00.219081904   13444 subprocess_posix.cc:61]     execv 'bins/opt/memory_profile_client' failed: No such file or directory
waiting for client
```
https://source.cloud.google.com/results/invocations/a91f4c6a-d76d-4229-b640-c595a17bb811/log