### PR TITLE
Fix grpc_cli call segmentation fault if both input and output are binary

### DIFF
--- a/test/cpp/util/grpc_tool.cc
+++ b/test/cpp/util/grpc_tool.cc
@@ -506,7 +506,7 @@ bool GrpcTool::CallMethod(int argc, const char** argv,
     request_text = argv[2];
   }
 
-  if (parser->IsStreaming(method_name, true /* is_request */)) {
+  if (parser != nullptr && parser->IsStreaming(method_name, true /* is_request */)) {
     std::istream* input_stream;
     std::ifstream input_file;
 
@@ -597,7 +597,7 @@ bool GrpcTool::CallMethod(int argc, const char** argv,
 
   } else {  // parser->IsStreaming(method_name, true /* is_request */)
     if (FLAGS_batch) {
-      if (parser->IsStreaming(method_name, false /* is_request */)) {
+      if (parser != nullptr && parser->IsStreaming(method_name, false /* is_request */)) {
         fprintf(stderr, "Batch mode for streaming RPC is not supported.\n");
         return false;
       }


### PR DESCRIPTION
check whether ProtoFileParser is nullptr (if both input and output are binary) in CallMethod,
grpc_cli should support both binary input and output, this is really useful for AsyncGenericService without any proto

Really easy to reproduce this bug:

grpc_cli -binary_input -binary_output call localhost:8080 /Test.Service/Hello