### PR TITLE
Optimize error handling for special cases.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -368,6 +368,7 @@ static grpc_error* init_data_frame_parser(grpc_chttp2_transport* t) {
         &s->data_parser, t->incoming_frame_flags, s->id, s);
   }
 error_handler:
+  intptr_t unused;
   if (err == GRPC_ERROR_NONE) {
     t->incoming_stream = s;
     /* t->parser = grpc_chttp2_data_parser_parse;*/
@@ -375,7 +376,7 @@ error_handler:
     t->parser_data = &s->data_parser;
     t->ping_state.last_ping_sent_time = GRPC_MILLIS_INF_PAST;
     return GRPC_ERROR_NONE;
-  } else if (grpc_error_get_int(err, GRPC_ERROR_INT_STREAM_ID, nullptr)) {
+  } else if (grpc_error_get_int(err, GRPC_ERROR_INT_STREAM_ID, &unused)) {
     /* handle stream errors by closing the stream */
     if (s != nullptr) {
       grpc_chttp2_mark_stream_closed(t, s, true, false, err);
@@ -756,9 +757,10 @@ static grpc_error* parse_frame_slice(grpc_chttp2_transport* t, grpc_slice slice,
                                      int is_last) {
   grpc_chttp2_stream* s = t->incoming_stream;
   grpc_error* err = t->parser(t->parser_data, t, s, slice, is_last);
+  intptr_t unused;
   if (GPR_LIKELY(err == GRPC_ERROR_NONE)) {
     return err;
-  } else if (grpc_error_get_int(err, GRPC_ERROR_INT_STREAM_ID, nullptr)) {
+  } else if (grpc_error_get_int(err, GRPC_ERROR_INT_STREAM_ID, &unused)) {
     if (grpc_http_trace.enabled()) {
       const char* msg = grpc_error_string(err);
       gpr_log(GPR_ERROR, "%s", msg);

--- a/src/core/lib/iomgr/error_internal.h
+++ b/src/core/lib/iomgr/error_internal.h
@@ -58,6 +58,4 @@ struct grpc_error {
   intptr_t arena[0];
 };
 
-bool grpc_error_is_special(struct grpc_error* err);
-
 #endif /* GRPC_CORE_LIB_IOMGR_ERROR_INTERNAL_H */

--- a/src/core/lib/transport/error_utils.cc
+++ b/src/core/lib/transport/error_utils.cc
@@ -26,8 +26,9 @@
 
 static grpc_error* recursively_find_error_with_field(grpc_error* error,
                                                      grpc_error_ints which) {
+  intptr_t unused;
   // If the error itself has a status code, return it.
-  if (grpc_error_get_int(error, which, nullptr)) {
+  if (grpc_error_get_int(error, which, &unused)) {
     return error;
   }
   if (grpc_error_is_special(error)) return nullptr;
@@ -102,7 +103,8 @@ void grpc_error_get_status(grpc_error* error, grpc_millis deadline,
 }
 
 bool grpc_error_has_clear_grpc_status(grpc_error* error) {
-  if (grpc_error_get_int(error, GRPC_ERROR_INT_GRPC_STATUS, nullptr)) {
+  intptr_t unused;
+  if (grpc_error_get_int(error, GRPC_ERROR_INT_GRPC_STATUS, &unused)) {
     return true;
   }
   uint8_t slot = error->first_err;


### PR DESCRIPTION
This commit contains a few improvements:
1. Using a consequetive range of [0..4], will allow us to merge all
   branches of error_is_special into one comparison.
2. With (1), we can remove the for loops to find entries in
   error_status_map with a single O(1) lookup.
3. grpc_error_is_special() code paths should be inlined for ref
   and unref to avoid callq for the majority of cases where speical
   error is used.
4. grpc_error_get_int() should never accept a nullptr argument to
   avoid an expensive branch in the hot path. Callers should all
   allocate a dummy int on the stack when calling.