### PR TITLE
Remove Uneeded Header from Benchmark

### DIFF
--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -41,7 +41,6 @@ grpc_cc_library(
     ],
     deps = [
         "//:grpc++_unsecure",
-        "//:lb_server_load_reporting_filter",
         "//src/proto/grpc/testing:echo_proto",
         "//test/core/util:grpc_test_util_unsecure",
         "//test/cpp/util:test_config",

--- a/test/cpp/microbenchmarks/bm_call_create.cc
+++ b/test/cpp/microbenchmarks/bm_call_create.cc
@@ -34,7 +34,6 @@
 #include "src/core/ext/filters/http/client/http_client_filter.h"
 #include "src/core/ext/filters/http/message_compress/message_compress_filter.h"
 #include "src/core/ext/filters/http/server/http_server_filter.h"
-#include "src/core/ext/filters/load_reporting/server_load_reporting_filter.h"
 #include "src/core/ext/filters/message_size/message_size_filter.h"
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/core/lib/channel/connected_channel.h"


### PR DESCRIPTION
This import is not needed bc the benchmark is commented out for internal/external build issues. This is causing some problems with the gRPC import