### PR TITLE
Fix Python 3.7 Docker Environment

### DIFF
--- a/templates/tools/dockerfile/apt_get_pyenv.include
+++ b/templates/tools/dockerfile/apt_get_pyenv.include
@@ -20,4 +20,7 @@ RUN pyenv install 3.5-dev
 RUN pyenv install 3.6-dev
 RUN pyenv install 3.7-dev
 RUN pyenv install pypy-5.3.1
-RUN pyenv local 3.5-dev 3.6-dev 3.7-dev pypy-5.3.1
+RUN pyenv local system 3.5-dev 3.6-dev 3.7-dev pypy-5.3.1
+RUN echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> ~/.bashrc
+RUN echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+RUN echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc

--- a/tools/dockerfile/test/python_pyenv_x64/Dockerfile
+++ b/tools/dockerfile/test/python_pyenv_x64/Dockerfile
@@ -90,7 +90,10 @@ RUN pyenv install 3.5-dev
 RUN pyenv install 3.6-dev
 RUN pyenv install 3.7-dev
 RUN pyenv install pypy-5.3.1
-RUN pyenv local 3.5-dev 3.6-dev 3.7-dev pypy-5.3.1
+RUN pyenv local system 3.5-dev 3.6-dev 3.7-dev pypy-5.3.1
+RUN echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> ~/.bashrc
+RUN echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+RUN echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bashrc
 
 # Install pip and virtualenv for Python 3.5
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.5

--- a/tools/run_tests/dockerize/docker_run_tests.sh
+++ b/tools/run_tests/dockerize/docker_run_tests.sh
@@ -22,21 +22,13 @@ export CONFIG=$config
 export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
 export PATH=$PATH:/usr/bin/llvm-symbolizer
 
-mkdir -p /var/local/git
-git clone /var/local/jenkins/grpc /var/local/git/grpc
-# clone gRPC submodules, use data from locally cloned submodules where possible
-# TODO: figure out a way to eliminate this shellcheck suppression:
-# shellcheck disable=SC2016
-(cd /var/local/jenkins/grpc/ && git submodule foreach 'git clone /var/local/jenkins/grpc/${name} /var/local/git/grpc/${name}')
-(cd /var/local/git/grpc/ && git submodule init)
-
 mkdir -p reports
 
 $POST_GIT_STEP
 
 exit_code=0
 
-$RUN_TESTS_COMMAND || exit_code=$?
+cd /var/local/jenkins/grpc && $RUN_TESTS_COMMAND || exit_code=$?
 
 cd reports
 echo '<html><head></head><body>' > index.html

--- a/tools/run_tests/dockerize/docker_run_tests.sh
+++ b/tools/run_tests/dockerize/docker_run_tests.sh
@@ -22,7 +22,7 @@ export CONFIG=$config
 export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
 export PATH=$PATH:/usr/bin/llvm-symbolizer
 
-mkdir -p reports
+mkdir -p /var/local/git/grpc/reports
 
 $POST_GIT_STEP
 
@@ -30,7 +30,7 @@ exit_code=0
 
 cd /var/local/jenkins/grpc && $RUN_TESTS_COMMAND || exit_code=$?
 
-cd reports
+cd /var/local/git/grpc/reports
 echo '<html><head></head><body>' > index.html
 find . -maxdepth 1 -mindepth 1 -type d | sort | while read d ; do
   d=${d#*/}

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -759,7 +759,7 @@ class PythonLanguage(object):
             self.python_manager_name(), _docker_arch_suffix(self.args.arch))
 
     def python_manager_name(self):
-        if self.args.compiler in ['python3.5', 'python3.6']:
+        if self.args.compiler in ['python3.5', 'python3.6', 'python3.7']:
             return 'pyenv'
         elif self.args.compiler == 'python_alpine':
             return 'alpine'


### PR DESCRIPTION
Issue #16900
In short, an old version OpenSSL library dependency somehow sneaked into the build. I still attempt to locate the problem along the building procedure, but I found a not-elegant fix for the Python 3.7 Docker environment in `docker_run_tests.sh`.
* It doesn't copy files from the host into the container
* It use the volume directory to build the artifacts (key difference)
* So it may remain compiling files at the host's folder

More detail about the remaining files
* Most of it contained in `py37_native` folder
* It doesn't affect next build; you can repeat the `run_tests.py` without clean those files
* There is a dedicated `reports`
* To clean them with one command `git clean -xdf`

Also, without setting in `~/.bashrc`, `pyenv` won't switch Python version properly, and people who run this Docker image against `--compiler=python3.6` or `--compiler=python3.7` will encounter a command not found.

Key questions for @nicolasnoble 
1. Do you think this change is valid?
1. Is there other files need to be kept?
1. Is there any reason we can't clean the folder?