### PR TITLE
Fix new memory corruption in QPS test

### DIFF
--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -685,8 +685,8 @@ void Server::PerformOpsOnCall(internal::CallOpSetInterface* ops,
   size_t nops = 0;
   grpc_op cops[MAX_OPS];
   ops->FillOps(call->call(), cops, &nops);
-  // TODO(vjpai): Use ops->cq_tag once this case supports callbacks
-  auto result = grpc_call_start_batch(call->call(), cops, nops, ops, nullptr);
+  auto result =
+      grpc_call_start_batch(call->call(), cops, nops, ops->cq_tag(), nullptr);
   if (result != GRPC_CALL_OK) {
     gpr_log(GPR_ERROR, "Fatal: grpc_call_start_batch returned %d", result);
     grpc_call_log_batch(__FILE__, __LINE__, GPR_LOG_SEVERITY_ERROR,


### PR DESCRIPTION
Maybe it was never really legit to use the assignment operator on a ServerResponseWriter (etc) class but the issue got exposed because of the cq_tag change.

Supercedes #16889 
Fixes #16899 