### PR TITLE
Remove memset(0) from arena allocate memory.

### DIFF
--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -140,3 +140,13 @@ some configuration as environment variables that can be set.
 * grpc_cfstream
   set to 1 to turn on CFStream experiment. With this experiment gRPC uses CFStream API to make TCP
   connections. The option is only available on iOS platform and when macro GRPC_CFSTREAM is defined.
+
+* GRPC_ARENA_INIT_STRATEGY
+  Selects the initialization strategy for blocks allocated in the arena. Valid
+  values are:
+  - no_init (default): Do not inialize the arena block.
+  - zero_init: Initialize the arena blocks with 0.
+  - non_zero_init: Initialize the arena blocks with a non-zero value.
+
+  NOTE: This environment variable is experimental and will be removed. Thus, it
+        should not be relied upon.

--- a/src/core/ext/filters/client_channel/health/health_check_client.cc
+++ b/src/core/ext/filters/client_channel/health/health_check_client.cc
@@ -286,10 +286,9 @@ HealthCheckClient::CallState::CallState(
       health_check_client_(std::move(health_check_client)),
       pollent_(grpc_polling_entity_create_from_pollset_set(interested_parties)),
       arena_(gpr_arena_create(health_check_client_->connected_subchannel_
-                                  ->GetInitialCallSizeEstimate(0))) {
-  memset(&call_combiner_, 0, sizeof(call_combiner_));
+                                  ->GetInitialCallSizeEstimate(0))),
+      payload_(context_) {
   grpc_call_combiner_init(&call_combiner_);
-  memset(context_, 0, sizeof(context_));
   gpr_atm_rel_store(&seen_response_, static_cast<gpr_atm>(0));
 }
 

--- a/src/core/ext/filters/client_channel/health/health_check_client.h
+++ b/src/core/ext/filters/client_channel/health/health_check_client.h
@@ -97,7 +97,7 @@ class HealthCheckClient
 
     gpr_arena* arena_;
     grpc_call_combiner call_combiner_;
-    grpc_call_context_element context_[GRPC_CONTEXT_COUNT];
+    grpc_call_context_element context_[GRPC_CONTEXT_COUNT] = {};
 
     // The streaming call to the backend. Always non-NULL.
     grpc_subchannel_call* call_;

--- a/src/core/ext/filters/client_channel/lb_policy.h
+++ b/src/core/ext/filters/client_channel/lb_policy.h
@@ -63,29 +63,29 @@ class LoadBalancingPolicy
   /// State used for an LB pick.
   struct PickState {
     /// Initial metadata associated with the picking call.
-    grpc_metadata_batch* initial_metadata;
+    grpc_metadata_batch* initial_metadata = nullptr;
     /// Bitmask used for selective cancelling. See
     /// \a CancelMatchingPicksLocked() and \a GRPC_INITIAL_METADATA_* in
     /// grpc_types.h.
-    uint32_t initial_metadata_flags;
+    uint32_t initial_metadata_flags = 0;
     /// Storage for LB token in \a initial_metadata, or nullptr if not used.
     grpc_linked_mdelem lb_token_mdelem_storage;
     /// Closure to run when pick is complete, if not completed synchronously.
     /// If null, pick will fail if a result is not available synchronously.
-    grpc_closure* on_complete;
+    grpc_closure* on_complete = nullptr;
     /// Will be set to the selected subchannel, or nullptr on failure or when
     /// the LB policy decides to drop the call.
     RefCountedPtr<ConnectedSubchannel> connected_subchannel;
     /// Will be populated with context to pass to the subchannel call, if
     /// needed.
-    grpc_call_context_element subchannel_call_context[GRPC_CONTEXT_COUNT];
+    grpc_call_context_element subchannel_call_context[GRPC_CONTEXT_COUNT] = {};
     /// Upon success, \a *user_data will be set to whatever opaque information
     /// may need to be propagated from the LB policy, or nullptr if not needed.
     // TODO(roth): As part of revamping our metadata APIs, try to find a
     // way to clean this up and C++-ify it.
-    void** user_data;
+    void** user_data = nullptr;
     /// Next pointer.  For internal use by LB policy.
-    PickState* next;
+    PickState* next = nullptr;
   };
 
   // Not copyable nor movable.

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -162,12 +162,16 @@ struct grpc_subchannel {
 };
 
 struct grpc_subchannel_call {
+  grpc_subchannel_call(grpc_core::ConnectedSubchannel* connection,
+                       const grpc_core::ConnectedSubchannel::CallArgs& args)
+      : connection(connection), deadline(args.deadline) {}
+
   grpc_core::ConnectedSubchannel* connection;
-  grpc_closure* schedule_closure_after_destroy;
+  grpc_closure* schedule_closure_after_destroy = nullptr;
   // state needed to support channelz interception of recv trailing metadata.
   grpc_closure recv_trailing_metadata_ready;
   grpc_closure* original_recv_trailing_metadata;
-  grpc_metadata_batch* recv_trailing_metadata;
+  grpc_metadata_batch* recv_trailing_metadata = nullptr;
   grpc_millis deadline;
 };
 
@@ -905,6 +909,7 @@ static void subchannel_call_destroy(void* call, grpc_error* error) {
   grpc_call_stack_destroy(SUBCHANNEL_CALL_TO_CALL_STACK(c), nullptr,
                           c->schedule_closure_after_destroy);
   connection->Unref(DEBUG_LOCATION, "subchannel_call");
+  c->~grpc_subchannel_call();
 }
 
 void grpc_subchannel_call_set_cleanup_closure(grpc_subchannel_call* call,
@@ -1102,14 +1107,12 @@ grpc_error* ConnectedSubchannel::CreateCall(const CallArgs& args,
                                             grpc_subchannel_call** call) {
   const size_t allocation_size =
       GetInitialCallSizeEstimate(args.parent_data_size);
-  *call = static_cast<grpc_subchannel_call*>(
-      gpr_arena_alloc(args.arena, allocation_size));
+  *call = new (gpr_arena_alloc(args.arena, allocation_size))
+      grpc_subchannel_call(this, args);
   grpc_call_stack* callstk = SUBCHANNEL_CALL_TO_CALL_STACK(*call);
   RefCountedPtr<ConnectedSubchannel> connection =
       Ref(DEBUG_LOCATION, "subchannel_call");
   connection.release();  // Ref is passed to the grpc_subchannel_call object.
-  (*call)->connection = this;
-  (*call)->deadline = args.deadline;
   const grpc_call_element_args call_args = {
       callstk,           /* call_stack */
       nullptr,           /* server_transport_data */

--- a/src/core/ext/filters/deadline/deadline_filter.h
+++ b/src/core/ext/filters/deadline/deadline_filter.h
@@ -22,19 +22,23 @@
 #include "src/core/lib/channel/channel_stack.h"
 #include "src/core/lib/iomgr/timer.h"
 
-typedef enum grpc_deadline_timer_state {
+enum grpc_deadline_timer_state {
   GRPC_DEADLINE_STATE_INITIAL,
   GRPC_DEADLINE_STATE_PENDING,
   GRPC_DEADLINE_STATE_FINISHED
-} grpc_deadline_timer_state;
+};
 
 // State used for filters that enforce call deadlines.
 // Must be the first field in the filter's call_data.
-typedef struct grpc_deadline_state {
+struct grpc_deadline_state {
+  grpc_deadline_state(grpc_call_element* elem, grpc_call_stack* call_stack,
+                      grpc_call_combiner* call_combiner, grpc_millis deadline);
+  ~grpc_deadline_state();
+
   // We take a reference to the call stack for the timer callback.
   grpc_call_stack* call_stack;
   grpc_call_combiner* call_combiner;
-  grpc_deadline_timer_state timer_state;
+  grpc_deadline_timer_state timer_state = GRPC_DEADLINE_STATE_INITIAL;
   grpc_timer timer;
   grpc_closure timer_callback;
   // Closure to invoke when we receive trailing metadata.
@@ -43,20 +47,12 @@ typedef struct grpc_deadline_state {
   // The original recv_trailing_metadata_ready closure, which we chain to
   // after our own closure is invoked.
   grpc_closure* original_recv_trailing_metadata_ready;
-} grpc_deadline_state;
+};
 
 //
 // NOTE: All of these functions require that the first field in
 // elem->call_data is a grpc_deadline_state.
 //
-
-// assumes elem->call_data is zero'd
-void grpc_deadline_state_init(grpc_call_element* elem,
-                              grpc_call_stack* call_stack,
-                              grpc_call_combiner* call_combiner,
-                              grpc_millis deadline);
-
-void grpc_deadline_state_destroy(grpc_call_element* elem);
 
 // Cancels the existing timer and starts a new one with new_deadline.
 //

--- a/src/core/ext/filters/http/client/http_client_filter.cc
+++ b/src/core/ext/filters/http/client/http_client_filter.cc
@@ -37,10 +37,31 @@
 #define EXPECTED_CONTENT_TYPE_LENGTH sizeof(EXPECTED_CONTENT_TYPE) - 1
 
 /* default maximum size of payload eligable for GET request */
-static const size_t kMaxPayloadSizeForGet = 2048;
+static constexpr size_t kMaxPayloadSizeForGet = 2048;
+
+static void recv_initial_metadata_ready(void* user_data, grpc_error* error);
+static void recv_trailing_metadata_ready(void* user_data, grpc_error* error);
+static void on_send_message_next_done(void* arg, grpc_error* error);
+static void send_message_on_complete(void* arg, grpc_error* error);
 
 namespace {
 struct call_data {
+  call_data(grpc_call_element* elem, const grpc_call_element_args& args)
+      : call_combiner(args.call_combiner) {
+    GRPC_CLOSURE_INIT(&recv_initial_metadata_ready,
+                      ::recv_initial_metadata_ready, elem,
+                      grpc_schedule_on_exec_ctx);
+    GRPC_CLOSURE_INIT(&recv_trailing_metadata_ready,
+                      ::recv_trailing_metadata_ready, elem,
+                      grpc_schedule_on_exec_ctx);
+    GRPC_CLOSURE_INIT(&on_send_message_next_done, ::on_send_message_next_done,
+                      elem, grpc_schedule_on_exec_ctx);
+    GRPC_CLOSURE_INIT(&send_message_on_complete, ::send_message_on_complete,
+                      elem, grpc_schedule_on_exec_ctx);
+  }
+
+  ~call_data() { GRPC_ERROR_UNREF(recv_initial_metadata_error); }
+
   grpc_call_combiner* call_combiner;
   // State for handling send_initial_metadata ops.
   grpc_linked_mdelem method;
@@ -51,18 +72,18 @@ struct call_data {
   grpc_linked_mdelem user_agent;
   // State for handling recv_initial_metadata ops.
   grpc_metadata_batch* recv_initial_metadata;
-  grpc_error* recv_initial_metadata_error;
-  grpc_closure* original_recv_initial_metadata_ready;
+  grpc_error* recv_initial_metadata_error = GRPC_ERROR_NONE;
+  grpc_closure* original_recv_initial_metadata_ready = nullptr;
   grpc_closure recv_initial_metadata_ready;
   // State for handling recv_trailing_metadata ops.
   grpc_metadata_batch* recv_trailing_metadata;
   grpc_closure* original_recv_trailing_metadata_ready;
   grpc_closure recv_trailing_metadata_ready;
-  grpc_error* recv_trailing_metadata_error;
-  bool seen_recv_trailing_metadata_ready;
+  grpc_error* recv_trailing_metadata_error = GRPC_ERROR_NONE;
+  bool seen_recv_trailing_metadata_ready = false;
   // State for handling send_message ops.
   grpc_transport_stream_op_batch* send_message_batch;
-  size_t send_message_bytes_read;
+  size_t send_message_bytes_read = 0;
   grpc_core::ManualConstructor<grpc_core::ByteStreamCache> send_message_cache;
   grpc_core::ManualConstructor<grpc_core::ByteStreamCache::CachingByteStream>
       send_message_caching_stream;
@@ -442,18 +463,7 @@ done:
 /* Constructor for call_data */
 static grpc_error* init_call_elem(grpc_call_element* elem,
                                   const grpc_call_element_args* args) {
-  call_data* calld = static_cast<call_data*>(elem->call_data);
-  calld->call_combiner = args->call_combiner;
-  GRPC_CLOSURE_INIT(&calld->recv_initial_metadata_ready,
-                    recv_initial_metadata_ready, elem,
-                    grpc_schedule_on_exec_ctx);
-  GRPC_CLOSURE_INIT(&calld->recv_trailing_metadata_ready,
-                    recv_trailing_metadata_ready, elem,
-                    grpc_schedule_on_exec_ctx);
-  GRPC_CLOSURE_INIT(&calld->send_message_on_complete, send_message_on_complete,
-                    elem, grpc_schedule_on_exec_ctx);
-  GRPC_CLOSURE_INIT(&calld->on_send_message_next_done,
-                    on_send_message_next_done, elem, grpc_schedule_on_exec_ctx);
+  new (elem->call_data) call_data(elem, *args);
   return GRPC_ERROR_NONE;
 }
 
@@ -462,7 +472,7 @@ static void destroy_call_elem(grpc_call_element* elem,
                               const grpc_call_final_info* final_info,
                               grpc_closure* ignored) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
-  GRPC_ERROR_UNREF(calld->recv_initial_metadata_error);
+  calld->~call_data();
 }
 
 static grpc_mdelem scheme_from_args(const grpc_channel_args* args) {

--- a/src/core/ext/filters/http/server/http_server_filter.cc
+++ b/src/core/ext/filters/http/server/http_server_filter.cc
@@ -35,9 +35,32 @@
 #define EXPECTED_CONTENT_TYPE "application/grpc"
 #define EXPECTED_CONTENT_TYPE_LENGTH sizeof(EXPECTED_CONTENT_TYPE) - 1
 
+static void hs_recv_initial_metadata_ready(void* user_data, grpc_error* err);
+static void hs_recv_trailing_metadata_ready(void* user_data, grpc_error* err);
+static void hs_recv_message_ready(void* user_data, grpc_error* err);
+
 namespace {
 
 struct call_data {
+  call_data(grpc_call_element* elem, const grpc_call_element_args& args)
+      : call_combiner(args.call_combiner) {
+    GRPC_CLOSURE_INIT(&recv_initial_metadata_ready,
+                      hs_recv_initial_metadata_ready, elem,
+                      grpc_schedule_on_exec_ctx);
+    GRPC_CLOSURE_INIT(&recv_message_ready, hs_recv_message_ready, elem,
+                      grpc_schedule_on_exec_ctx);
+    GRPC_CLOSURE_INIT(&recv_trailing_metadata_ready,
+                      hs_recv_trailing_metadata_ready, elem,
+                      grpc_schedule_on_exec_ctx);
+  }
+
+  ~call_data() {
+    GRPC_ERROR_UNREF(recv_initial_metadata_ready_error);
+    if (have_read_stream) {
+      read_stream->Orphan();
+    }
+  }
+
   grpc_call_combiner* call_combiner;
 
   // Outgoing headers to add to send_initial_metadata.
@@ -47,27 +70,27 @@ struct call_data {
   // If we see the recv_message contents in the GET query string, we
   // store it here.
   grpc_core::ManualConstructor<grpc_core::SliceBufferByteStream> read_stream;
-  bool have_read_stream;
+  bool have_read_stream = false;
 
   // State for intercepting recv_initial_metadata.
   grpc_closure recv_initial_metadata_ready;
-  grpc_error* recv_initial_metadata_ready_error;
+  grpc_error* recv_initial_metadata_ready_error = GRPC_ERROR_NONE;
   grpc_closure* original_recv_initial_metadata_ready;
-  grpc_metadata_batch* recv_initial_metadata;
+  grpc_metadata_batch* recv_initial_metadata = nullptr;
   uint32_t* recv_initial_metadata_flags;
-  bool seen_recv_initial_metadata_ready;
+  bool seen_recv_initial_metadata_ready = false;
 
   // State for intercepting recv_message.
   grpc_closure* original_recv_message_ready;
   grpc_closure recv_message_ready;
   grpc_core::OrphanablePtr<grpc_core::ByteStream>* recv_message;
-  bool seen_recv_message_ready;
+  bool seen_recv_message_ready = false;
 
   // State for intercepting recv_trailing_metadata
   grpc_closure recv_trailing_metadata_ready;
   grpc_closure* original_recv_trailing_metadata_ready;
   grpc_error* recv_trailing_metadata_ready_error;
-  bool seen_recv_trailing_metadata_ready;
+  bool seen_recv_trailing_metadata_ready = false;
 };
 
 struct channel_data {
@@ -431,16 +454,7 @@ static void hs_start_transport_stream_op_batch(
 /* Constructor for call_data */
 static grpc_error* hs_init_call_elem(grpc_call_element* elem,
                                      const grpc_call_element_args* args) {
-  call_data* calld = static_cast<call_data*>(elem->call_data);
-  calld->call_combiner = args->call_combiner;
-  GRPC_CLOSURE_INIT(&calld->recv_initial_metadata_ready,
-                    hs_recv_initial_metadata_ready, elem,
-                    grpc_schedule_on_exec_ctx);
-  GRPC_CLOSURE_INIT(&calld->recv_message_ready, hs_recv_message_ready, elem,
-                    grpc_schedule_on_exec_ctx);
-  GRPC_CLOSURE_INIT(&calld->recv_trailing_metadata_ready,
-                    hs_recv_trailing_metadata_ready, elem,
-                    grpc_schedule_on_exec_ctx);
+  new (elem->call_data) call_data(elem, *args);
   return GRPC_ERROR_NONE;
 }
 
@@ -449,10 +463,7 @@ static void hs_destroy_call_elem(grpc_call_element* elem,
                                  const grpc_call_final_info* final_info,
                                  grpc_closure* ignored) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
-  GRPC_ERROR_UNREF(calld->recv_initial_metadata_ready_error);
-  if (calld->have_read_stream) {
-    calld->read_stream->Orphan();
-  }
+  calld->~call_data();
 }
 
 /* Constructor for channel_data */

--- a/src/core/ext/filters/message_size/message_size_filter.cc
+++ b/src/core/ext/filters/message_size/message_size_filter.cc
@@ -90,9 +90,53 @@ RefCountedPtr<MessageSizeLimits> MessageSizeLimits::CreateFromJson(
 }  // namespace
 }  // namespace grpc_core
 
+static void recv_message_ready(void* user_data, grpc_error* error);
+static void recv_trailing_metadata_ready(void* user_data, grpc_error* error);
+
 namespace {
 
+struct channel_data {
+  message_size_limits limits;
+  // Maps path names to refcounted_message_size_limits structs.
+  grpc_core::RefCountedPtr<grpc_core::SliceHashTable<
+      grpc_core::RefCountedPtr<grpc_core::MessageSizeLimits>>>
+      method_limit_table;
+};
+
 struct call_data {
+  call_data(grpc_call_element* elem, const channel_data& chand,
+            const grpc_call_element_args& args)
+      : call_combiner(args.call_combiner), limits(chand.limits) {
+    GRPC_CLOSURE_INIT(&recv_message_ready, ::recv_message_ready, elem,
+                      grpc_schedule_on_exec_ctx);
+    GRPC_CLOSURE_INIT(&recv_trailing_metadata_ready,
+                      ::recv_trailing_metadata_ready, elem,
+                      grpc_schedule_on_exec_ctx);
+    // Get max sizes from channel data, then merge in per-method config values.
+    // Note: Per-method config is only available on the client, so we
+    // apply the max request size to the send limit and the max response
+    // size to the receive limit.
+    if (chand.method_limit_table != nullptr) {
+      grpc_core::RefCountedPtr<grpc_core::MessageSizeLimits> limits =
+          grpc_core::ServiceConfig::MethodConfigTableLookup(
+              *chand.method_limit_table, args.path);
+      if (limits != nullptr) {
+        if (limits->limits().max_send_size >= 0 &&
+            (limits->limits().max_send_size < this->limits.max_send_size ||
+             this->limits.max_send_size < 0)) {
+          this->limits.max_send_size = limits->limits().max_send_size;
+        }
+        if (limits->limits().max_recv_size >= 0 &&
+            (limits->limits().max_recv_size < this->limits.max_recv_size ||
+             this->limits.max_recv_size < 0)) {
+          this->limits.max_recv_size = limits->limits().max_recv_size;
+        }
+      }
+    }
+  }
+
+  ~call_data() { GRPC_ERROR_UNREF(error); }
+
   grpc_call_combiner* call_combiner;
   message_size_limits limits;
   // Receive closures are chained: we inject this closure as the
@@ -101,23 +145,15 @@ struct call_data {
   grpc_closure recv_message_ready;
   grpc_closure recv_trailing_metadata_ready;
   // The error caused by a message that is too large, or GRPC_ERROR_NONE
-  grpc_error* error;
+  grpc_error* error = GRPC_ERROR_NONE;
   // Used by recv_message_ready.
-  grpc_core::OrphanablePtr<grpc_core::ByteStream>* recv_message;
+  grpc_core::OrphanablePtr<grpc_core::ByteStream>* recv_message = nullptr;
   // Original recv_message_ready callback, invoked after our own.
-  grpc_closure* next_recv_message_ready;
+  grpc_closure* next_recv_message_ready = nullptr;
   // Original recv_trailing_metadata callback, invoked after our own.
   grpc_closure* original_recv_trailing_metadata_ready;
-  bool seen_recv_trailing_metadata;
+  bool seen_recv_trailing_metadata = false;
   grpc_error* recv_trailing_metadata_error;
-};
-
-struct channel_data {
-  message_size_limits limits;
-  // Maps path names to refcounted_message_size_limits structs.
-  grpc_core::RefCountedPtr<grpc_core::SliceHashTable<
-      grpc_core::RefCountedPtr<grpc_core::MessageSizeLimits>>>
-      method_limit_table;
 };
 
 }  // namespace
@@ -228,38 +264,7 @@ static void start_transport_stream_op_batch(
 static grpc_error* init_call_elem(grpc_call_element* elem,
                                   const grpc_call_element_args* args) {
   channel_data* chand = static_cast<channel_data*>(elem->channel_data);
-  call_data* calld = static_cast<call_data*>(elem->call_data);
-  calld->call_combiner = args->call_combiner;
-  calld->next_recv_message_ready = nullptr;
-  calld->original_recv_trailing_metadata_ready = nullptr;
-  calld->error = GRPC_ERROR_NONE;
-  GRPC_CLOSURE_INIT(&calld->recv_message_ready, recv_message_ready, elem,
-                    grpc_schedule_on_exec_ctx);
-  GRPC_CLOSURE_INIT(&calld->recv_trailing_metadata_ready,
-                    recv_trailing_metadata_ready, elem,
-                    grpc_schedule_on_exec_ctx);
-  // Get max sizes from channel data, then merge in per-method config values.
-  // Note: Per-method config is only available on the client, so we
-  // apply the max request size to the send limit and the max response
-  // size to the receive limit.
-  calld->limits = chand->limits;
-  if (chand->method_limit_table != nullptr) {
-    grpc_core::RefCountedPtr<grpc_core::MessageSizeLimits> limits =
-        grpc_core::ServiceConfig::MethodConfigTableLookup(
-            *chand->method_limit_table, args->path);
-    if (limits != nullptr) {
-      if (limits->limits().max_send_size >= 0 &&
-          (limits->limits().max_send_size < calld->limits.max_send_size ||
-           calld->limits.max_send_size < 0)) {
-        calld->limits.max_send_size = limits->limits().max_send_size;
-      }
-      if (limits->limits().max_recv_size >= 0 &&
-          (limits->limits().max_recv_size < calld->limits.max_recv_size ||
-           calld->limits.max_recv_size < 0)) {
-        calld->limits.max_recv_size = limits->limits().max_recv_size;
-      }
-    }
-  }
+  new (elem->call_data) call_data(elem, *chand, *args);
   return GRPC_ERROR_NONE;
 }
 
@@ -268,7 +273,7 @@ static void destroy_call_elem(grpc_call_element* elem,
                               const grpc_call_final_info* final_info,
                               grpc_closure* ignored) {
   call_data* calld = (call_data*)elem->call_data;
-  GRPC_ERROR_UNREF(calld->error);
+  calld->~call_data();
 }
 
 static int default_size(const grpc_channel_args* args,

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -154,53 +154,52 @@ bool g_flow_control_enabled = true;
 /*******************************************************************************
  * CONSTRUCTION/DESTRUCTION/REFCOUNTING
  */
-
-static void destruct_transport(grpc_chttp2_transport* t) {
+grpc_chttp2_transport::~grpc_chttp2_transport() {
   size_t i;
 
-  if (t->channelz_socket != nullptr) {
-    t->channelz_socket.reset();
+  if (channelz_socket != nullptr) {
+    channelz_socket.reset();
   }
 
-  grpc_endpoint_destroy(t->ep);
+  grpc_endpoint_destroy(ep);
 
-  grpc_slice_buffer_destroy_internal(&t->qbuf);
+  grpc_slice_buffer_destroy_internal(&qbuf);
 
-  grpc_slice_buffer_destroy_internal(&t->outbuf);
-  grpc_chttp2_hpack_compressor_destroy(&t->hpack_compressor);
+  grpc_slice_buffer_destroy_internal(&outbuf);
+  grpc_chttp2_hpack_compressor_destroy(&hpack_compressor);
 
-  grpc_slice_buffer_destroy_internal(&t->read_buffer);
-  grpc_chttp2_hpack_parser_destroy(&t->hpack_parser);
-  grpc_chttp2_goaway_parser_destroy(&t->goaway_parser);
+  grpc_slice_buffer_destroy_internal(&read_buffer);
+  grpc_chttp2_hpack_parser_destroy(&hpack_parser);
+  grpc_chttp2_goaway_parser_destroy(&goaway_parser);
 
   for (i = 0; i < STREAM_LIST_COUNT; i++) {
-    GPR_ASSERT(t->lists[i].head == nullptr);
-    GPR_ASSERT(t->lists[i].tail == nullptr);
+    GPR_ASSERT(lists[i].head == nullptr);
+    GPR_ASSERT(lists[i].tail == nullptr);
   }
 
-  GRPC_ERROR_UNREF(t->goaway_error);
+  GRPC_ERROR_UNREF(goaway_error);
 
-  GPR_ASSERT(grpc_chttp2_stream_map_size(&t->stream_map) == 0);
+  GPR_ASSERT(grpc_chttp2_stream_map_size(&stream_map) == 0);
 
-  grpc_chttp2_stream_map_destroy(&t->stream_map);
-  grpc_connectivity_state_destroy(&t->channel_callback.state_tracker);
+  grpc_chttp2_stream_map_destroy(&stream_map);
+  grpc_connectivity_state_destroy(&channel_callback.state_tracker);
 
-  GRPC_COMBINER_UNREF(t->combiner, "chttp2_transport");
+  GRPC_COMBINER_UNREF(combiner, "chttp2_transport");
 
-  cancel_pings(t, GRPC_ERROR_CREATE_FROM_STATIC_STRING("Transport destroyed"));
+  cancel_pings(this,
+               GRPC_ERROR_CREATE_FROM_STATIC_STRING("Transport destroyed"));
 
-  while (t->write_cb_pool) {
-    grpc_chttp2_write_cb* next = t->write_cb_pool->next;
-    gpr_free(t->write_cb_pool);
-    t->write_cb_pool = next;
+  while (write_cb_pool) {
+    grpc_chttp2_write_cb* next = write_cb_pool->next;
+    gpr_free(write_cb_pool);
+    write_cb_pool = next;
   }
 
-  t->flow_control.Destroy();
+  flow_control.Destroy();
 
-  GRPC_ERROR_UNREF(t->closed_with_error);
-  gpr_free(t->ping_acks);
-  gpr_free(t->peer_string);
-  gpr_free(t);
+  GRPC_ERROR_UNREF(closed_with_error);
+  gpr_free(ping_acks);
+  gpr_free(peer_string);
 }
 
 #ifndef NDEBUG
@@ -212,7 +211,8 @@ void grpc_chttp2_unref_transport(grpc_chttp2_transport* t, const char* reason,
             t, val, val - 1, reason, file, line);
   }
   if (!gpr_unref(&t->refs)) return;
-  destruct_transport(t);
+  t->~grpc_chttp2_transport();
+  gpr_free(t);
 }
 
 void grpc_chttp2_ref_transport(grpc_chttp2_transport* t, const char* reason,
@@ -227,7 +227,8 @@ void grpc_chttp2_ref_transport(grpc_chttp2_transport* t, const char* reason,
 #else
 void grpc_chttp2_unref_transport(grpc_chttp2_transport* t) {
   if (!gpr_unref(&t->refs)) return;
-  destruct_transport(t);
+  t->~grpc_chttp2_transport();
+  gpr_free(t);
 }
 
 void grpc_chttp2_ref_transport(grpc_chttp2_transport* t) { gpr_ref(&t->refs); }
@@ -481,115 +482,97 @@ static void init_keepalive_pings_if_enabled(grpc_chttp2_transport* t) {
   }
 }
 
-static void init_transport(grpc_chttp2_transport* t,
-                           const grpc_channel_args* channel_args,
-                           grpc_endpoint* ep, bool is_client,
-                           grpc_resource_user* resource_user) {
+grpc_chttp2_transport::grpc_chttp2_transport(
+    const grpc_channel_args* channel_args, grpc_endpoint* ep, bool is_client,
+    grpc_resource_user* resource_user)
+    : ep(ep),
+      peer_string(grpc_endpoint_get_peer(ep)),
+      resource_user(resource_user),
+      combiner(grpc_combiner_create()),
+      is_client(is_client),
+      next_stream_id(is_client ? 1 : 2),
+      deframe_state(is_client ? GRPC_DTS_FH_0 : GRPC_DTS_CLIENT_PREFIX_0) {
   GPR_ASSERT(strlen(GRPC_CHTTP2_CLIENT_CONNECT_STRING) ==
              GRPC_CHTTP2_CLIENT_CONNECT_STRLEN);
-
-  t->base.vtable = get_vtable();
-  t->ep = ep;
+  base.vtable = get_vtable();
   /* one ref is for destroy */
-  gpr_ref_init(&t->refs, 1);
-  t->combiner = grpc_combiner_create();
-  t->peer_string = grpc_endpoint_get_peer(ep);
-  t->endpoint_reading = 1;
-  t->next_stream_id = is_client ? 1 : 2;
-  t->is_client = is_client;
-  t->resource_user = resource_user;
-  t->deframe_state = is_client ? GRPC_DTS_FH_0 : GRPC_DTS_CLIENT_PREFIX_0;
-  t->is_first_frame = true;
-  grpc_connectivity_state_init(
-      &t->channel_callback.state_tracker, GRPC_CHANNEL_READY,
-      is_client ? "client_transport" : "server_transport");
-
-  grpc_slice_buffer_init(&t->qbuf);
-  grpc_slice_buffer_init(&t->outbuf);
-  grpc_chttp2_hpack_compressor_init(&t->hpack_compressor);
-
-  init_transport_closures(t);
-
-  t->goaway_error = GRPC_ERROR_NONE;
-  grpc_chttp2_goaway_parser_init(&t->goaway_parser);
-  grpc_chttp2_hpack_parser_init(&t->hpack_parser);
-
-  grpc_slice_buffer_init(&t->read_buffer);
-
+  gpr_ref_init(&refs, 1);
   /* 8 is a random stab in the dark as to a good initial size: it's small enough
      that it shouldn't waste memory for infrequently used connections, yet
      large enough that the exponential growth should happen nicely when it's
      needed.
      TODO(ctiller): tune this */
-  grpc_chttp2_stream_map_init(&t->stream_map, 8);
+  grpc_chttp2_stream_map_init(&stream_map, 8);
 
+  grpc_slice_buffer_init(&read_buffer);
+  grpc_connectivity_state_init(
+      &channel_callback.state_tracker, GRPC_CHANNEL_READY,
+      is_client ? "client_transport" : "server_transport");
+  grpc_slice_buffer_init(&outbuf);
+  if (is_client) {
+    grpc_slice_buffer_add(&outbuf, grpc_slice_from_copied_string(
+                                       GRPC_CHTTP2_CLIENT_CONNECT_STRING));
+  }
+  grpc_chttp2_hpack_compressor_init(&hpack_compressor);
+  grpc_slice_buffer_init(&qbuf);
   /* copy in initial settings to all setting sets */
   size_t i;
   int j;
   for (i = 0; i < GRPC_CHTTP2_NUM_SETTINGS; i++) {
     for (j = 0; j < GRPC_NUM_SETTING_SETS; j++) {
-      t->settings[j][i] = grpc_chttp2_settings_parameters[i].default_value;
+      settings[j][i] = grpc_chttp2_settings_parameters[i].default_value;
     }
   }
-  t->dirtied_local_settings = 1;
-  /* Hack: it's common for implementations to assume 65536 bytes initial send
-     window -- this should by rights be 0 */
-  t->force_send_settings = 1 << GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE;
-  t->sent_local_settings = 0;
-  t->write_buffer_size = grpc_core::chttp2::kDefaultWindow;
+  grpc_chttp2_hpack_parser_init(&hpack_parser);
+  grpc_chttp2_goaway_parser_init(&goaway_parser);
 
-  if (is_client) {
-    grpc_slice_buffer_add(&t->outbuf, grpc_slice_from_copied_string(
-                                          GRPC_CHTTP2_CLIENT_CONNECT_STRING));
-  }
+  init_transport_closures(this);
 
   /* configure http2 the way we like it */
   if (is_client) {
-    queue_setting_update(t, GRPC_CHTTP2_SETTINGS_ENABLE_PUSH, 0);
-    queue_setting_update(t, GRPC_CHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 0);
+    queue_setting_update(this, GRPC_CHTTP2_SETTINGS_ENABLE_PUSH, 0);
+    queue_setting_update(this, GRPC_CHTTP2_SETTINGS_MAX_CONCURRENT_STREAMS, 0);
   }
-  queue_setting_update(t, GRPC_CHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE,
+  queue_setting_update(this, GRPC_CHTTP2_SETTINGS_MAX_HEADER_LIST_SIZE,
                        DEFAULT_MAX_HEADER_LIST_SIZE);
-  queue_setting_update(t, GRPC_CHTTP2_SETTINGS_GRPC_ALLOW_TRUE_BINARY_METADATA,
-                       1);
+  queue_setting_update(this,
+                       GRPC_CHTTP2_SETTINGS_GRPC_ALLOW_TRUE_BINARY_METADATA, 1);
 
-  configure_transport_ping_policy(t);
-  init_transport_keepalive_settings(t);
-
-  t->opt_target = GRPC_CHTTP2_OPTIMIZE_FOR_LATENCY;
+  configure_transport_ping_policy(this);
+  init_transport_keepalive_settings(this);
 
   bool enable_bdp = true;
   if (channel_args) {
-    enable_bdp = read_channel_args(t, channel_args, is_client);
+    enable_bdp = read_channel_args(this, channel_args, is_client);
   }
 
   if (g_flow_control_enabled) {
-    t->flow_control.Init<grpc_core::chttp2::TransportFlowControl>(t,
-                                                                  enable_bdp);
+    flow_control.Init<grpc_core::chttp2::TransportFlowControl>(this,
+                                                               enable_bdp);
   } else {
-    t->flow_control.Init<grpc_core::chttp2::TransportFlowControlDisabled>(t);
+    flow_control.Init<grpc_core::chttp2::TransportFlowControlDisabled>(this);
     enable_bdp = false;
   }
 
   /* No pings allowed before receiving a header or data frame. */
-  t->ping_state.pings_before_data_required = 0;
-  t->ping_state.is_delayed_ping_timer_set = false;
-  t->ping_state.last_ping_sent_time = GRPC_MILLIS_INF_PAST;
+  ping_state.pings_before_data_required = 0;
+  ping_state.is_delayed_ping_timer_set = false;
+  ping_state.last_ping_sent_time = GRPC_MILLIS_INF_PAST;
 
-  t->ping_recv_state.last_ping_recv_time = GRPC_MILLIS_INF_PAST;
-  t->ping_recv_state.ping_strikes = 0;
+  ping_recv_state.last_ping_recv_time = GRPC_MILLIS_INF_PAST;
+  ping_recv_state.ping_strikes = 0;
 
-  init_keepalive_pings_if_enabled(t);
+  init_keepalive_pings_if_enabled(this);
 
   if (enable_bdp) {
-    GRPC_CHTTP2_REF_TRANSPORT(t, "bdp_ping");
-    schedule_bdp_ping_locked(t);
-    grpc_chttp2_act_on_flowctl_action(t->flow_control->PeriodicUpdate(), t,
+    GRPC_CHTTP2_REF_TRANSPORT(this, "bdp_ping");
+    schedule_bdp_ping_locked(this);
+    grpc_chttp2_act_on_flowctl_action(flow_control->PeriodicUpdate(), this,
                                       nullptr);
   }
 
-  grpc_chttp2_initiate_write(t, GRPC_CHTTP2_INITIATE_WRITE_INITIAL_WRITE);
-  post_benign_reclaimer(t);
+  grpc_chttp2_initiate_write(this, GRPC_CHTTP2_INITIATE_WRITE_INITIAL_WRITE);
+  post_benign_reclaimer(this);
 }
 
 static void destroy_transport_locked(void* tp, grpc_error* error) {
@@ -599,6 +582,7 @@ static void destroy_transport_locked(void* tp, grpc_error* error) {
       t, grpc_error_set_int(
              GRPC_ERROR_CREATE_FROM_STATIC_STRING("Transport destroyed"),
              GRPC_ERROR_INT_OCCURRED_DURING_WRITE, t->write_state));
+  // Must be the last line.
   GRPC_CHTTP2_UNREF_TRANSPORT(t, "destroy");
 }
 
@@ -683,115 +667,108 @@ void grpc_chttp2_stream_unref(grpc_chttp2_stream* s) {
 }
 #endif
 
-static int init_stream(grpc_transport* gt, grpc_stream* gs,
-                       grpc_stream_refcount* refcount, const void* server_data,
-                       gpr_arena* arena) {
-  GPR_TIMER_SCOPE("init_stream", 0);
-  grpc_chttp2_transport* t = reinterpret_cast<grpc_chttp2_transport*>(gt);
-  grpc_chttp2_stream* s = reinterpret_cast<grpc_chttp2_stream*>(gs);
-
-  s->t = t;
-  s->refcount = refcount;
+grpc_chttp2_stream::grpc_chttp2_stream(grpc_chttp2_transport* t,
+                                       grpc_stream_refcount* refcount,
+                                       const void* server_data,
+                                       gpr_arena* arena)
+    : t(t), refcount(refcount), metadata_buffer{{arena}, {arena}} {
   /* We reserve one 'active stream' that's dropped when the stream is
      read-closed. The others are for Chttp2IncomingByteStreams that are
      actively reading */
-  GRPC_CHTTP2_STREAM_REF(s, "chttp2");
-
-  grpc_chttp2_incoming_metadata_buffer_init(&s->metadata_buffer[0], arena);
-  grpc_chttp2_incoming_metadata_buffer_init(&s->metadata_buffer[1], arena);
-  grpc_chttp2_data_parser_init(&s->data_parser);
-  grpc_slice_buffer_init(&s->flow_controlled_buffer);
-  s->deadline = GRPC_MILLIS_INF_FUTURE;
-  GRPC_CLOSURE_INIT(&s->complete_fetch_locked, complete_fetch_locked, s,
-                    grpc_schedule_on_exec_ctx);
-  grpc_slice_buffer_init(&s->unprocessed_incoming_frames_buffer);
-  s->unprocessed_incoming_frames_buffer_cached_length = 0;
-  grpc_slice_buffer_init(&s->frame_storage);
-  grpc_slice_buffer_init(&s->compressed_data_buffer);
-  grpc_slice_buffer_init(&s->decompressed_data_buffer);
-  s->pending_byte_stream = false;
-  s->decompressed_header_bytes = 0;
-  GRPC_CLOSURE_INIT(&s->reset_byte_stream, reset_byte_stream, s,
-                    grpc_combiner_scheduler(t->combiner));
-
+  GRPC_CHTTP2_STREAM_REF(this, "chttp2");
   GRPC_CHTTP2_REF_TRANSPORT(t, "stream");
 
   if (server_data) {
-    s->id = static_cast<uint32_t>((uintptr_t)server_data);
-    *t->accepting_stream = s;
-    grpc_chttp2_stream_map_add(&t->stream_map, s->id, s);
+    id = static_cast<uint32_t>((uintptr_t)server_data);
+    *t->accepting_stream = this;
+    grpc_chttp2_stream_map_add(&t->stream_map, id, this);
     post_destructive_reclaimer(t);
   }
-
   if (t->flow_control->flow_control_enabled()) {
-    s->flow_control.Init<grpc_core::chttp2::StreamFlowControl>(
+    flow_control.Init<grpc_core::chttp2::StreamFlowControl>(
         static_cast<grpc_core::chttp2::TransportFlowControl*>(
             t->flow_control.get()),
-        s);
+        this);
   } else {
-    s->flow_control.Init<grpc_core::chttp2::StreamFlowControlDisabled>();
+    flow_control.Init<grpc_core::chttp2::StreamFlowControlDisabled>();
   }
 
-  return 0;
+  grpc_slice_buffer_init(&frame_storage);
+  grpc_slice_buffer_init(&unprocessed_incoming_frames_buffer);
+  grpc_slice_buffer_init(&flow_controlled_buffer);
+  grpc_slice_buffer_init(&compressed_data_buffer);
+  grpc_slice_buffer_init(&decompressed_data_buffer);
+
+  GRPC_CLOSURE_INIT(&complete_fetch_locked, ::complete_fetch_locked, this,
+                    grpc_schedule_on_exec_ctx);
+  GRPC_CLOSURE_INIT(&reset_byte_stream, ::reset_byte_stream, this,
+                    grpc_combiner_scheduler(t->combiner));
 }
 
-static void destroy_stream_locked(void* sp, grpc_error* error) {
-  GPR_TIMER_SCOPE("destroy_stream", 0);
-  grpc_chttp2_stream* s = static_cast<grpc_chttp2_stream*>(sp);
-  grpc_chttp2_transport* t = s->t;
-
+grpc_chttp2_stream::~grpc_chttp2_stream() {
   if (t->channelz_socket != nullptr) {
-    if ((t->is_client && s->eos_received) || (!t->is_client && s->eos_sent)) {
+    if ((t->is_client && eos_received) || (!t->is_client && eos_sent)) {
       t->channelz_socket->RecordStreamSucceeded();
     } else {
       t->channelz_socket->RecordStreamFailed();
     }
   }
 
-  GPR_ASSERT((s->write_closed && s->read_closed) || s->id == 0);
-  if (s->id != 0) {
-    GPR_ASSERT(grpc_chttp2_stream_map_find(&t->stream_map, s->id) == nullptr);
+  GPR_ASSERT((write_closed && read_closed) || id == 0);
+  if (id != 0) {
+    GPR_ASSERT(grpc_chttp2_stream_map_find(&t->stream_map, id) == nullptr);
   }
 
-  grpc_slice_buffer_destroy_internal(&s->unprocessed_incoming_frames_buffer);
-  grpc_slice_buffer_destroy_internal(&s->frame_storage);
-  grpc_slice_buffer_destroy_internal(&s->compressed_data_buffer);
-  grpc_slice_buffer_destroy_internal(&s->decompressed_data_buffer);
+  grpc_slice_buffer_destroy_internal(&unprocessed_incoming_frames_buffer);
+  grpc_slice_buffer_destroy_internal(&frame_storage);
+  grpc_slice_buffer_destroy_internal(&compressed_data_buffer);
+  grpc_slice_buffer_destroy_internal(&decompressed_data_buffer);
 
-  grpc_chttp2_list_remove_stalled_by_transport(t, s);
-  grpc_chttp2_list_remove_stalled_by_stream(t, s);
+  grpc_chttp2_list_remove_stalled_by_transport(t, this);
+  grpc_chttp2_list_remove_stalled_by_stream(t, this);
 
   for (int i = 0; i < STREAM_LIST_COUNT; i++) {
-    if (GPR_UNLIKELY(s->included[i])) {
+    if (GPR_UNLIKELY(included[i])) {
       gpr_log(GPR_ERROR, "%s stream %d still included in list %d",
-              t->is_client ? "client" : "server", s->id, i);
+              t->is_client ? "client" : "server", id, i);
       abort();
     }
   }
 
-  GPR_ASSERT(s->send_initial_metadata_finished == nullptr);
-  GPR_ASSERT(s->fetching_send_message == nullptr);
-  GPR_ASSERT(s->send_trailing_metadata_finished == nullptr);
-  GPR_ASSERT(s->recv_initial_metadata_ready == nullptr);
-  GPR_ASSERT(s->recv_message_ready == nullptr);
-  GPR_ASSERT(s->recv_trailing_metadata_finished == nullptr);
-  grpc_chttp2_data_parser_destroy(&s->data_parser);
-  grpc_chttp2_incoming_metadata_buffer_destroy(&s->metadata_buffer[0]);
-  grpc_chttp2_incoming_metadata_buffer_destroy(&s->metadata_buffer[1]);
-  grpc_slice_buffer_destroy_internal(&s->flow_controlled_buffer);
-  GRPC_ERROR_UNREF(s->read_closed_error);
-  GRPC_ERROR_UNREF(s->write_closed_error);
-  GRPC_ERROR_UNREF(s->byte_stream_error);
+  GPR_ASSERT(send_initial_metadata_finished == nullptr);
+  GPR_ASSERT(fetching_send_message == nullptr);
+  GPR_ASSERT(send_trailing_metadata_finished == nullptr);
+  GPR_ASSERT(recv_initial_metadata_ready == nullptr);
+  GPR_ASSERT(recv_message_ready == nullptr);
+  GPR_ASSERT(recv_trailing_metadata_finished == nullptr);
+  grpc_slice_buffer_destroy_internal(&flow_controlled_buffer);
+  GRPC_ERROR_UNREF(read_closed_error);
+  GRPC_ERROR_UNREF(write_closed_error);
+  GRPC_ERROR_UNREF(byte_stream_error);
 
-  s->flow_control.Destroy();
+  flow_control.Destroy();
 
   if (t->resource_user != nullptr) {
     grpc_resource_user_free(t->resource_user, GRPC_RESOURCE_QUOTA_CALL_SIZE);
   }
 
   GRPC_CHTTP2_UNREF_TRANSPORT(t, "stream");
+  GRPC_CLOSURE_SCHED(destroy_stream_arg, GRPC_ERROR_NONE);
+}
 
-  GRPC_CLOSURE_SCHED(s->destroy_stream_arg, GRPC_ERROR_NONE);
+static int init_stream(grpc_transport* gt, grpc_stream* gs,
+                       grpc_stream_refcount* refcount, const void* server_data,
+                       gpr_arena* arena) {
+  GPR_TIMER_SCOPE("init_stream", 0);
+  grpc_chttp2_transport* t = reinterpret_cast<grpc_chttp2_transport*>(gt);
+  new (gs) grpc_chttp2_stream(t, refcount, server_data, arena);
+  return 0;
+}
+
+static void destroy_stream_locked(void* sp, grpc_error* error) {
+  GPR_TIMER_SCOPE("destroy_stream", 0);
+  grpc_chttp2_stream* s = static_cast<grpc_chttp2_stream*>(sp);
+  s->~grpc_chttp2_stream();
 }
 
 static void destroy_stream(grpc_transport* gt, grpc_stream* gs,
@@ -1726,8 +1703,8 @@ static void perform_stream_op(grpc_transport* gt, grpc_stream* gs,
     gpr_free(str);
   }
 
-  op->handler_private.extra_arg = gs;
   GRPC_CHTTP2_STREAM_REF(s, "perform_stream_op");
+  op->handler_private.extra_arg = gs;
   GRPC_CLOSURE_SCHED(
       GRPC_CLOSURE_INIT(&op->handler_private.closure, perform_stream_op_locked,
                         op, grpc_combiner_scheduler(t->combiner)),
@@ -2733,6 +2710,7 @@ static void init_keepalive_ping_locked(void* arg, grpc_error* error) {
         grpc_chttp2_stream_map_size(&t->stream_map) > 0) {
       t->keepalive_state = GRPC_CHTTP2_KEEPALIVE_STATE_PINGING;
       GRPC_CHTTP2_REF_TRANSPORT(t, "keepalive ping end");
+      grpc_timer_init_unset(&t->keepalive_watchdog_timer);
       send_keepalive_ping_locked(t);
       grpc_chttp2_initiate_write(t, GRPC_CHTTP2_INITIATE_WRITE_KEEPALIVE_PING);
     } else {
@@ -3212,9 +3190,8 @@ intptr_t grpc_chttp2_transport_get_socket_uuid(grpc_transport* transport) {
 grpc_transport* grpc_create_chttp2_transport(
     const grpc_channel_args* channel_args, grpc_endpoint* ep, bool is_client,
     grpc_resource_user* resource_user) {
-  grpc_chttp2_transport* t = static_cast<grpc_chttp2_transport*>(
-      gpr_zalloc(sizeof(grpc_chttp2_transport)));
-  init_transport(t, channel_args, ep, is_client, resource_user);
+  auto t = new (gpr_malloc(sizeof(grpc_chttp2_transport)))
+      grpc_chttp2_transport(channel_args, ep, is_client, resource_user);
   return &t->base;
 }
 

--- a/src/core/ext/transport/chttp2/transport/frame_data.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_data.cc
@@ -32,18 +32,12 @@
 #include "src/core/lib/slice/slice_string_helpers.h"
 #include "src/core/lib/transport/transport.h"
 
-grpc_error* grpc_chttp2_data_parser_init(grpc_chttp2_data_parser* parser) {
-  parser->state = GRPC_CHTTP2_DATA_FH_0;
-  parser->parsing_frame = nullptr;
-  return GRPC_ERROR_NONE;
-}
-
-void grpc_chttp2_data_parser_destroy(grpc_chttp2_data_parser* parser) {
-  if (parser->parsing_frame != nullptr) {
-    GRPC_ERROR_UNREF(parser->parsing_frame->Finished(
+grpc_chttp2_data_parser::~grpc_chttp2_data_parser() {
+  if (parsing_frame != nullptr) {
+    GRPC_ERROR_UNREF(parsing_frame->Finished(
         GRPC_ERROR_CREATE_FROM_STATIC_STRING("Parser destroyed"), false));
   }
-  GRPC_ERROR_UNREF(parser->error);
+  GRPC_ERROR_UNREF(error);
 }
 
 grpc_error* grpc_chttp2_data_parser_begin_frame(grpc_chttp2_data_parser* parser,

--- a/src/core/ext/transport/chttp2/transport/frame_data.h
+++ b/src/core/ext/transport/chttp2/transport/frame_data.h
@@ -43,20 +43,18 @@ namespace grpc_core {
 class Chttp2IncomingByteStream;
 }  // namespace grpc_core
 
-typedef struct {
-  grpc_chttp2_stream_state state;
-  uint8_t frame_type;
-  uint32_t frame_size;
-  grpc_error* error;
+struct grpc_chttp2_data_parser {
+  grpc_chttp2_data_parser() = default;
+  ~grpc_chttp2_data_parser();
 
-  bool is_frame_compressed;
-  grpc_core::Chttp2IncomingByteStream* parsing_frame;
-} grpc_chttp2_data_parser;
+  grpc_chttp2_stream_state state = GRPC_CHTTP2_DATA_FH_0;
+  uint8_t frame_type = 0;
+  uint32_t frame_size = 0;
+  grpc_error* error = GRPC_ERROR_NONE;
 
-/* initialize per-stream state for data frame parsing */
-grpc_error* grpc_chttp2_data_parser_init(grpc_chttp2_data_parser* parser);
-
-void grpc_chttp2_data_parser_destroy(grpc_chttp2_data_parser* parser);
+  bool is_frame_compressed = false;
+  grpc_core::Chttp2IncomingByteStream* parsing_frame = nullptr;
+};
 
 /* start processing a new data frame */
 grpc_error* grpc_chttp2_data_parser_begin_frame(grpc_chttp2_data_parser* parser,

--- a/src/core/ext/transport/chttp2/transport/incoming_metadata.cc
+++ b/src/core/ext/transport/chttp2/transport/incoming_metadata.cc
@@ -27,18 +27,6 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 
-void grpc_chttp2_incoming_metadata_buffer_init(
-    grpc_chttp2_incoming_metadata_buffer* buffer, gpr_arena* arena) {
-  buffer->arena = arena;
-  grpc_metadata_batch_init(&buffer->batch);
-  buffer->batch.deadline = GRPC_MILLIS_INF_FUTURE;
-}
-
-void grpc_chttp2_incoming_metadata_buffer_destroy(
-    grpc_chttp2_incoming_metadata_buffer* buffer) {
-  grpc_metadata_batch_destroy(&buffer->batch);
-}
-
 grpc_error* grpc_chttp2_incoming_metadata_buffer_add(
     grpc_chttp2_incoming_metadata_buffer* buffer, grpc_mdelem elem) {
   buffer->size += GRPC_MDELEM_LENGTH(elem);

--- a/src/core/ext/transport/chttp2/transport/incoming_metadata.h
+++ b/src/core/ext/transport/chttp2/transport/incoming_metadata.h
@@ -23,17 +23,20 @@
 
 #include "src/core/lib/transport/transport.h"
 
-typedef struct {
+struct grpc_chttp2_incoming_metadata_buffer {
+  grpc_chttp2_incoming_metadata_buffer(gpr_arena* arena) : arena(arena) {
+    grpc_metadata_batch_init(&batch);
+    batch.deadline = GRPC_MILLIS_INF_FUTURE;
+  }
+  ~grpc_chttp2_incoming_metadata_buffer() {
+    grpc_metadata_batch_destroy(&batch);
+  }
+
   gpr_arena* arena;
   grpc_metadata_batch batch;
-  size_t size;  // total size of metadata
-} grpc_chttp2_incoming_metadata_buffer;
+  size_t size = 0;  // total size of metadata
+};
 
-/** assumes everything initially zeroed */
-void grpc_chttp2_incoming_metadata_buffer_init(
-    grpc_chttp2_incoming_metadata_buffer* buffer, gpr_arena* arena);
-void grpc_chttp2_incoming_metadata_buffer_destroy(
-    grpc_chttp2_incoming_metadata_buffer* buffer);
 void grpc_chttp2_incoming_metadata_buffer_publish(
     grpc_chttp2_incoming_metadata_buffer* buffer, grpc_metadata_batch* batch);
 

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -103,8 +103,8 @@ const char* grpc_chttp2_initiate_write_reason_string(
     grpc_chttp2_initiate_write_reason reason);
 
 typedef struct {
-  grpc_closure_list lists[GRPC_CHTTP2_PCL_COUNT];
-  uint64_t inflight_id;
+  grpc_closure_list lists[GRPC_CHTTP2_PCL_COUNT] = {};
+  uint64_t inflight_id = 0;
 } grpc_chttp2_ping_queue;
 
 typedef struct {
@@ -280,6 +280,11 @@ typedef enum {
 } grpc_chttp2_keepalive_state;
 
 struct grpc_chttp2_transport {
+  grpc_chttp2_transport(const grpc_channel_args* channel_args,
+                        grpc_endpoint* ep, bool is_client,
+                        grpc_resource_user* resource_user);
+  ~grpc_chttp2_transport();
+
   grpc_transport base; /* must be first */
   gpr_refcount refs;
   grpc_endpoint* ep;
@@ -289,27 +294,27 @@ struct grpc_chttp2_transport {
 
   grpc_combiner* combiner;
 
-  grpc_closure* notify_on_receive_settings;
+  grpc_closure* notify_on_receive_settings = nullptr;
 
   /** write execution state of the transport */
-  grpc_chttp2_write_state write_state;
+  grpc_chttp2_write_state write_state = GRPC_CHTTP2_WRITE_STATE_IDLE;
   /** is this the first write in a series of writes?
       set when we initiate writing from idle, cleared when we
       initiate writing from writing+more */
-  bool is_first_write_in_batch;
+  bool is_first_write_in_batch = false;
 
   /** is the transport destroying itself? */
-  uint8_t destroying;
+  uint8_t destroying = false;
   /** has the upper layer closed the transport? */
-  grpc_error* closed_with_error;
+  grpc_error* closed_with_error = GRPC_ERROR_NONE;
 
   /** is there a read request to the endpoint outstanding? */
-  uint8_t endpoint_reading;
+  uint8_t endpoint_reading = 1;
 
-  grpc_chttp2_optimization_target opt_target;
+  grpc_chttp2_optimization_target opt_target = GRPC_CHTTP2_OPTIMIZE_FOR_LATENCY;
 
   /** various lists of streams */
-  grpc_chttp2_stream_list lists[STREAM_LIST_COUNT];
+  grpc_chttp2_stream_list lists[STREAM_LIST_COUNT] = {};
 
   /** maps stream id to grpc_chttp2_stream objects */
   grpc_chttp2_stream_map stream_map;
@@ -326,7 +331,7 @@ struct grpc_chttp2_transport {
   /** address to place a newly accepted stream - set and unset by
       grpc_chttp2_parsing_accept_stream; used by init_stream to
       publish the accepted server stream */
-  grpc_chttp2_stream** accepting_stream;
+  grpc_chttp2_stream** accepting_stream = nullptr;
 
   struct {
     /* accept stream callback */
@@ -350,41 +355,43 @@ struct grpc_chttp2_transport {
 
   /** how much data are we willing to buffer when the WRITE_BUFFER_HINT is set?
    */
-  uint32_t write_buffer_size;
+  uint32_t write_buffer_size = grpc_core::chttp2::kDefaultWindow;
 
   /** Set to a grpc_error object if a goaway frame is received. By default, set
    * to GRPC_ERROR_NONE */
-  grpc_error* goaway_error;
+  grpc_error* goaway_error = GRPC_ERROR_NONE;
 
-  grpc_chttp2_sent_goaway_state sent_goaway_state;
+  grpc_chttp2_sent_goaway_state sent_goaway_state = GRPC_CHTTP2_NO_GOAWAY_SEND;
 
   /** are the local settings dirty and need to be sent? */
-  bool dirtied_local_settings;
+  bool dirtied_local_settings = true;
   /** have local settings been sent? */
-  bool sent_local_settings;
-  /** bitmask of setting indexes to send out */
-  uint32_t force_send_settings;
+  bool sent_local_settings = false;
+  /** bitmask of setting indexes to send out
+      Hack: it's common for implementations to assume 65536 bytes initial send
+      window -- this should by rights be 0 */
+  uint32_t force_send_settings = 1 << GRPC_CHTTP2_SETTINGS_INITIAL_WINDOW_SIZE;
   /** settings values */
   uint32_t settings[GRPC_NUM_SETTING_SETS][GRPC_CHTTP2_NUM_SETTINGS];
 
   /** what is the next stream id to be allocated by this peer?
       copied to next_stream_id in parsing when parsing commences */
-  uint32_t next_stream_id;
+  uint32_t next_stream_id = 0;
 
   /** last new stream id */
-  uint32_t last_new_stream_id;
+  uint32_t last_new_stream_id = 0;
 
   /** ping queues for various ping insertion points */
-  grpc_chttp2_ping_queue ping_queue;
+  grpc_chttp2_ping_queue ping_queue = grpc_chttp2_ping_queue();
   grpc_chttp2_repeated_ping_policy ping_policy;
   grpc_chttp2_repeated_ping_state ping_state;
-  uint64_t ping_ctr; /* unique id for pings */
+  uint64_t ping_ctr = 0; /* unique id for pings */
   grpc_closure retry_initiate_ping_locked;
 
   /** ping acks */
-  size_t ping_ack_count;
-  size_t ping_ack_capacity;
-  uint64_t* ping_acks;
+  size_t ping_ack_count = 0;
+  size_t ping_ack_capacity = 0;
+  uint64_t* ping_acks = nullptr;
   grpc_chttp2_server_ping_recv_state ping_recv_state;
 
   /** parser for headers */
@@ -410,22 +417,22 @@ struct grpc_chttp2_transport {
   int64_t initial_window_update = 0;
 
   /* deframing */
-  grpc_chttp2_deframe_transport_state deframe_state;
-  uint8_t incoming_frame_type;
-  uint8_t incoming_frame_flags;
-  uint8_t header_eof;
-  bool is_first_frame;
-  uint32_t expect_continuation_stream_id;
-  uint32_t incoming_frame_size;
-  uint32_t incoming_stream_id;
+  grpc_chttp2_deframe_transport_state deframe_state = GRPC_DTS_CLIENT_PREFIX_0;
+  uint8_t incoming_frame_type = 0;
+  uint8_t incoming_frame_flags = 0;
+  uint8_t header_eof = 0;
+  bool is_first_frame = true;
+  uint32_t expect_continuation_stream_id = 0;
+  uint32_t incoming_frame_size = 0;
+  uint32_t incoming_stream_id = 0;
 
   /* active parser */
-  void* parser_data;
-  grpc_chttp2_stream* incoming_stream;
+  void* parser_data = nullptr;
+  grpc_chttp2_stream* incoming_stream = nullptr;
   grpc_error* (*parser)(void* parser_user_data, grpc_chttp2_transport* t,
                         grpc_chttp2_stream* s, grpc_slice slice, int is_last);
 
-  grpc_chttp2_write_cb* write_cb_pool;
+  grpc_chttp2_write_cb* write_cb_pool = nullptr;
 
   /* bdp estimator */
   grpc_closure next_bdp_ping_timer_expired_locked;
@@ -434,23 +441,23 @@ struct grpc_chttp2_transport {
 
   /* if non-NULL, close the transport with this error when writes are finished
    */
-  grpc_error* close_transport_on_writes_finished;
+  grpc_error* close_transport_on_writes_finished = GRPC_ERROR_NONE;
 
   /* a list of closures to run after writes are finished */
-  grpc_closure_list run_after_write;
+  grpc_closure_list run_after_write = GRPC_CLOSURE_LIST_INIT;
 
   /* buffer pool state */
   /** have we scheduled a benign cleanup? */
-  bool benign_reclaimer_registered;
+  bool benign_reclaimer_registered = false;
   /** have we scheduled a destructive cleanup? */
-  bool destructive_reclaimer_registered;
+  bool destructive_reclaimer_registered = false;
   /** benign cleanup closure */
   grpc_closure benign_reclaimer_locked;
   /** destructive cleanup closure */
   grpc_closure destructive_reclaimer_locked;
 
   /* next bdp ping timer */
-  bool have_next_bdp_ping_timer;
+  bool have_next_bdp_ping_timer = false;
   grpc_timer next_bdp_ping_timer;
 
   /* keep-alive ping support */
@@ -471,12 +478,12 @@ struct grpc_chttp2_transport {
   /** grace period for a ping to complete before watchdog kicks in */
   grpc_millis keepalive_timeout;
   /** if keepalive pings are allowed when there's no outstanding streams */
-  bool keepalive_permit_without_calls;
+  bool keepalive_permit_without_calls = false;
   /** keep-alive state machine state */
   grpc_chttp2_keepalive_state keepalive_state;
 
   grpc_core::RefCountedPtr<grpc_core::channelz::SocketNode> channelz_socket;
-  uint32_t num_messages_in_next_write;
+  uint32_t num_messages_in_next_write = 0;
 };
 
 typedef enum {
@@ -487,6 +494,10 @@ typedef enum {
 } grpc_published_metadata_method;
 
 struct grpc_chttp2_stream {
+  grpc_chttp2_stream(grpc_chttp2_transport* t, grpc_stream_refcount* refcount,
+                     const void* server_data, gpr_arena* arena);
+  ~grpc_chttp2_stream();
+
   grpc_chttp2_transport* t;
   grpc_stream_refcount* refcount;
 
@@ -494,63 +505,63 @@ struct grpc_chttp2_stream {
   grpc_closure* destroy_stream_arg;
 
   grpc_chttp2_stream_link links[STREAM_LIST_COUNT];
-  uint8_t included[STREAM_LIST_COUNT];
+  uint8_t included[STREAM_LIST_COUNT] = {};
 
   /** HTTP2 stream id for this stream, or zero if one has not been assigned */
-  uint32_t id;
+  uint32_t id = 0;
 
   /** things the upper layers would like to send */
-  grpc_metadata_batch* send_initial_metadata;
-  grpc_closure* send_initial_metadata_finished;
-  grpc_metadata_batch* send_trailing_metadata;
-  grpc_closure* send_trailing_metadata_finished;
+  grpc_metadata_batch* send_initial_metadata = nullptr;
+  grpc_closure* send_initial_metadata_finished = nullptr;
+  grpc_metadata_batch* send_trailing_metadata = nullptr;
+  grpc_closure* send_trailing_metadata_finished = nullptr;
 
   grpc_core::OrphanablePtr<grpc_core::ByteStream> fetching_send_message;
-  uint32_t fetched_send_message_length;
-  grpc_slice fetching_slice;
+  uint32_t fetched_send_message_length = 0;
+  grpc_slice fetching_slice = grpc_empty_slice();
   int64_t next_message_end_offset;
-  int64_t flow_controlled_bytes_written;
-  int64_t flow_controlled_bytes_flowed;
+  int64_t flow_controlled_bytes_written = 0;
+  int64_t flow_controlled_bytes_flowed = 0;
   grpc_closure complete_fetch_locked;
-  grpc_closure* fetching_send_message_finished;
+  grpc_closure* fetching_send_message_finished = nullptr;
 
   grpc_metadata_batch* recv_initial_metadata;
-  grpc_closure* recv_initial_metadata_ready;
-  bool* trailing_metadata_available;
+  grpc_closure* recv_initial_metadata_ready = nullptr;
+  bool* trailing_metadata_available = nullptr;
   grpc_core::OrphanablePtr<grpc_core::ByteStream>* recv_message;
-  grpc_closure* recv_message_ready;
+  grpc_closure* recv_message_ready = nullptr;
   grpc_metadata_batch* recv_trailing_metadata;
-  grpc_closure* recv_trailing_metadata_finished;
+  grpc_closure* recv_trailing_metadata_finished = nullptr;
 
-  grpc_transport_stream_stats* collecting_stats;
-  grpc_transport_stream_stats stats;
+  grpc_transport_stream_stats* collecting_stats = nullptr;
+  grpc_transport_stream_stats stats = grpc_transport_stream_stats();
 
   /** Is this stream closed for writing. */
-  bool write_closed;
+  bool write_closed = false;
   /** Is this stream reading half-closed. */
-  bool read_closed;
+  bool read_closed = false;
   /** Are all published incoming byte streams closed. */
-  bool all_incoming_byte_streams_finished;
+  bool all_incoming_byte_streams_finished = false;
   /** Has this stream seen an error.
       If true, then pending incoming frames can be thrown away. */
-  bool seen_error;
+  bool seen_error = false;
   /** Are we buffering writes on this stream? If yes, we won't become writable
       until there's enough queued up in the flow_controlled_buffer */
-  bool write_buffering;
+  bool write_buffering = false;
   /** Has trailing metadata been received. */
-  bool received_trailing_metadata;
+  bool received_trailing_metadata = false;
 
   /* have we sent or received the EOS bit? */
-  bool eos_received;
-  bool eos_sent;
+  bool eos_received = false;
+  bool eos_sent = false;
 
   /** the error that resulted in this stream being read-closed */
-  grpc_error* read_closed_error;
+  grpc_error* read_closed_error = GRPC_ERROR_NONE;
   /** the error that resulted in this stream being write-closed */
-  grpc_error* write_closed_error;
+  grpc_error* write_closed_error = GRPC_ERROR_NONE;
 
-  grpc_published_metadata_method published_metadata[2];
-  bool final_metadata_requested;
+  grpc_published_metadata_method published_metadata[2] = {};
+  bool final_metadata_requested = false;
 
   grpc_chttp2_incoming_metadata_buffer metadata_buffer[2];
 
@@ -560,33 +571,33 @@ struct grpc_chttp2_stream {
    * Accessed only by application thread when stream->pending_byte_stream ==
    * true */
   grpc_slice_buffer unprocessed_incoming_frames_buffer;
-  grpc_closure* on_next;    /* protected by t combiner */
-  bool pending_byte_stream; /* protected by t combiner */
+  grpc_closure* on_next = nullptr;  /* protected by t combiner */
+  bool pending_byte_stream = false; /* protected by t combiner */
   // cached length of buffer to be used by the transport thread in cases where
   // stream->pending_byte_stream == true. The value is saved before
   // application threads are allowed to modify
   // unprocessed_incoming_frames_buffer
-  size_t unprocessed_incoming_frames_buffer_cached_length;
+  size_t unprocessed_incoming_frames_buffer_cached_length = 0;
   grpc_closure reset_byte_stream;
-  grpc_error* byte_stream_error; /* protected by t combiner */
-  bool received_last_frame;      /* protected by t combiner */
+  grpc_error* byte_stream_error = GRPC_ERROR_NONE; /* protected by t combiner */
+  bool received_last_frame = false;                /* protected by t combiner */
 
-  grpc_millis deadline;
+  grpc_millis deadline = GRPC_MILLIS_INF_FUTURE;
 
   /** saw some stream level error */
-  grpc_error* forced_close_error;
+  grpc_error* forced_close_error = GRPC_ERROR_NONE;
   /** how many header frames have we received? */
-  uint8_t header_frames_received;
+  uint8_t header_frames_received = 0;
   /** parsing state for data frames */
   /* Accessed only by transport thread when stream->pending_byte_stream == false
    * Accessed only by application thread when stream->pending_byte_stream ==
    * true */
   grpc_chttp2_data_parser data_parser;
   /** number of bytes received - reset at end of parse thread execution */
-  int64_t received_bytes;
+  int64_t received_bytes = 0;
 
-  bool sent_initial_metadata;
-  bool sent_trailing_metadata;
+  bool sent_initial_metadata = false;
+  bool sent_trailing_metadata = false;
 
   grpc_core::PolymorphicManualConstructor<
       grpc_core::chttp2::StreamFlowControlBase,
@@ -596,32 +607,34 @@ struct grpc_chttp2_stream {
 
   grpc_slice_buffer flow_controlled_buffer;
 
-  grpc_chttp2_write_cb* on_flow_controlled_cbs;
-  grpc_chttp2_write_cb* on_write_finished_cbs;
-  grpc_chttp2_write_cb* finish_after_write;
-  size_t sending_bytes;
+  grpc_chttp2_write_cb* on_flow_controlled_cbs = nullptr;
+  grpc_chttp2_write_cb* on_write_finished_cbs = nullptr;
+  grpc_chttp2_write_cb* finish_after_write = nullptr;
+  size_t sending_bytes = 0;
 
   /* Stream compression method to be used. */
-  grpc_stream_compression_method stream_compression_method;
+  grpc_stream_compression_method stream_compression_method =
+      GRPC_STREAM_COMPRESSION_IDENTITY_COMPRESS;
   /* Stream decompression method to be used. */
-  grpc_stream_compression_method stream_decompression_method;
+  grpc_stream_compression_method stream_decompression_method =
+      GRPC_STREAM_COMPRESSION_IDENTITY_COMPRESS;
   /** Stream compression decompress context */
-  grpc_stream_compression_context* stream_decompression_ctx;
+  grpc_stream_compression_context* stream_decompression_ctx = nullptr;
   /** Stream compression compress context */
-  grpc_stream_compression_context* stream_compression_ctx;
+  grpc_stream_compression_context* stream_compression_ctx = nullptr;
 
   /** Buffer storing data that is compressed but not sent */
   grpc_slice_buffer compressed_data_buffer;
   /** Amount of uncompressed bytes sent out when compressed_data_buffer is
    * emptied */
-  size_t uncompressed_data_size;
+  size_t uncompressed_data_size = 0;
   /** Temporary buffer storing decompressed data */
   grpc_slice_buffer decompressed_data_buffer;
   /** Whether bytes stored in unprocessed_incoming_byte_stream is decompressed
    */
-  bool unprocessed_incoming_frames_decompressed;
+  bool unprocessed_incoming_frames_decompressed = false;
   /** gRPC header bytes that are already decompressed */
-  size_t decompressed_header_bytes;
+  size_t decompressed_header_bytes = 0;
 };
 
 /** Transport writing call flow:

--- a/src/core/ext/transport/inproc/inproc_transport.cc
+++ b/src/core/ext/transport/inproc/inproc_transport.cc
@@ -40,18 +40,68 @@
     if (grpc_inproc_trace.enabled()) gpr_log(__VA_ARGS__); \
   } while (0)
 
-static grpc_slice g_empty_slice;
-static grpc_slice g_fake_path_key;
-static grpc_slice g_fake_path_value;
-static grpc_slice g_fake_auth_key;
-static grpc_slice g_fake_auth_value;
+namespace {
+grpc_slice g_empty_slice;
+grpc_slice g_fake_path_key;
+grpc_slice g_fake_path_value;
+grpc_slice g_fake_auth_key;
+grpc_slice g_fake_auth_value;
 
-typedef struct {
+struct inproc_stream;
+bool cancel_stream_locked(inproc_stream* s, grpc_error* error);
+void op_state_machine(void* arg, grpc_error* error);
+void log_metadata(const grpc_metadata_batch* md_batch, bool is_client,
+                  bool is_initial);
+grpc_error* fill_in_metadata(inproc_stream* s,
+                             const grpc_metadata_batch* metadata,
+                             uint32_t flags, grpc_metadata_batch* out_md,
+                             uint32_t* outflags, bool* markfilled);
+
+struct shared_mu {
+  shared_mu() {
+    // Share one lock between both sides since both sides get affected
+    gpr_mu_init(&mu);
+    gpr_ref_init(&refs, 2);
+  }
+
   gpr_mu mu;
   gpr_refcount refs;
-} shared_mu;
+};
 
-typedef struct inproc_transport {
+struct inproc_transport {
+  inproc_transport(const grpc_transport_vtable* vtable, shared_mu* mu,
+                   bool is_client)
+      : mu(mu), is_client(is_client) {
+    base.vtable = vtable;
+    // Start each side of transport with 2 refs since they each have a ref
+    // to the other
+    gpr_ref_init(&refs, 2);
+    grpc_connectivity_state_init(&connectivity, GRPC_CHANNEL_READY,
+                                 is_client ? "inproc_client" : "inproc_server");
+  }
+
+  ~inproc_transport() {
+    grpc_connectivity_state_destroy(&connectivity);
+    if (gpr_unref(&mu->refs)) {
+      gpr_free(mu);
+    }
+  }
+
+  void ref() {
+    INPROC_LOG(GPR_INFO, "ref_transport %p", this);
+    gpr_ref(&refs);
+  }
+
+  void unref() {
+    INPROC_LOG(GPR_INFO, "unref_transport %p", this);
+    if (!gpr_unref(&refs)) {
+      return;
+    }
+    INPROC_LOG(GPR_INFO, "really_destroy_transport %p", this);
+    this->~inproc_transport();
+    gpr_free(this);
+  }
+
   grpc_transport base;
   shared_mu* mu;
   gpr_refcount refs;
@@ -60,89 +110,98 @@ typedef struct inproc_transport {
   void (*accept_stream_cb)(void* user_data, grpc_transport* transport,
                            const void* server_data);
   void* accept_stream_data;
-  bool is_closed;
+  bool is_closed = false;
   struct inproc_transport* other_side;
-  struct inproc_stream* stream_list;
-} inproc_transport;
+  struct inproc_stream* stream_list = nullptr;
+};
 
-typedef struct inproc_stream {
-  inproc_transport* t;
-  grpc_metadata_batch to_read_initial_md;
-  uint32_t to_read_initial_md_flags;
-  bool to_read_initial_md_filled;
-  grpc_metadata_batch to_read_trailing_md;
-  bool to_read_trailing_md_filled;
-  bool ops_needed;
-  bool op_closure_scheduled;
-  grpc_closure op_closure;
-  // Write buffer used only during gap at init time when client-side
-  // stream is set up but server side stream is not yet set up
-  grpc_metadata_batch write_buffer_initial_md;
-  bool write_buffer_initial_md_filled;
-  uint32_t write_buffer_initial_md_flags;
-  grpc_millis write_buffer_deadline;
-  grpc_metadata_batch write_buffer_trailing_md;
-  bool write_buffer_trailing_md_filled;
-  grpc_error* write_buffer_cancel_error;
+struct inproc_stream {
+  inproc_stream(inproc_transport* t, grpc_stream_refcount* refcount,
+                const void* server_data, gpr_arena* arena)
+      : t(t), refs(refcount), arena(arena) {
+    // Ref this stream right now for ctor and list.
+    ref("inproc_init_stream:init");
+    ref("inproc_init_stream:list");
 
-  struct inproc_stream* other_side;
-  bool other_side_closed;               // won't talk anymore
-  bool write_buffer_other_side_closed;  // on hold
-  grpc_stream_refcount* refs;
-  grpc_closure* closure_at_destroy;
+    grpc_metadata_batch_init(&to_read_initial_md);
+    grpc_metadata_batch_init(&to_read_trailing_md);
+    GRPC_CLOSURE_INIT(&op_closure, op_state_machine, this,
+                      grpc_schedule_on_exec_ctx);
+    grpc_metadata_batch_init(&write_buffer_initial_md);
+    grpc_metadata_batch_init(&write_buffer_trailing_md);
 
-  gpr_arena* arena;
+    stream_list_prev = nullptr;
+    gpr_mu_lock(&t->mu->mu);
+    stream_list_next = t->stream_list;
+    if (t->stream_list) {
+      t->stream_list->stream_list_prev = this;
+    }
+    t->stream_list = this;
+    gpr_mu_unlock(&t->mu->mu);
 
-  grpc_transport_stream_op_batch* send_message_op;
-  grpc_transport_stream_op_batch* send_trailing_md_op;
-  grpc_transport_stream_op_batch* recv_initial_md_op;
-  grpc_transport_stream_op_batch* recv_message_op;
-  grpc_transport_stream_op_batch* recv_trailing_md_op;
+    if (!server_data) {
+      t->ref();
+      inproc_transport* st = t->other_side;
+      st->ref();
+      other_side = nullptr;  // will get filled in soon
+      // Pass the client-side stream address to the server-side for a ref
+      ref("inproc_init_stream:clt");  // ref it now on behalf of server
+                                      // side to avoid destruction
+      INPROC_LOG(GPR_INFO, "calling accept stream cb %p %p",
+                 st->accept_stream_cb, st->accept_stream_data);
+      (*st->accept_stream_cb)(st->accept_stream_data, &st->base, (void*)this);
+    } else {
+      // This is the server-side and is being called through accept_stream_cb
+      inproc_stream* cs = (inproc_stream*)server_data;
+      other_side = cs;
+      // Ref the server-side stream on behalf of the client now
+      ref("inproc_init_stream:srv");
 
-  grpc_slice_buffer recv_message;
-  grpc_core::ManualConstructor<grpc_core::SliceBufferByteStream> recv_stream;
-  bool recv_inited;
+      // Now we are about to affect the other side, so lock the transport
+      // to make sure that it doesn't get destroyed
+      gpr_mu_lock(&t->mu->mu);
+      cs->other_side = this;
+      // Now transfer from the other side's write_buffer if any to the to_read
+      // buffer
+      if (cs->write_buffer_initial_md_filled) {
+        fill_in_metadata(this, &cs->write_buffer_initial_md,
+                         cs->write_buffer_initial_md_flags, &to_read_initial_md,
+                         &to_read_initial_md_flags, &to_read_initial_md_filled);
+        deadline = GPR_MIN(deadline, cs->write_buffer_deadline);
+        grpc_metadata_batch_clear(&cs->write_buffer_initial_md);
+        cs->write_buffer_initial_md_filled = false;
+      }
+      if (cs->write_buffer_trailing_md_filled) {
+        fill_in_metadata(this, &cs->write_buffer_trailing_md, 0,
+                         &to_read_trailing_md, nullptr,
+                         &to_read_trailing_md_filled);
+        grpc_metadata_batch_clear(&cs->write_buffer_trailing_md);
+        cs->write_buffer_trailing_md_filled = false;
+      }
+      if (cs->write_buffer_cancel_error != GRPC_ERROR_NONE) {
+        cancel_other_error = cs->write_buffer_cancel_error;
+        cs->write_buffer_cancel_error = GRPC_ERROR_NONE;
+      }
 
-  bool initial_md_sent;
-  bool trailing_md_sent;
-  bool initial_md_recvd;
-  bool trailing_md_recvd;
-
-  bool closed;
-
-  grpc_error* cancel_self_error;
-  grpc_error* cancel_other_error;
-
-  grpc_millis deadline;
-
-  bool listed;
-  struct inproc_stream* stream_list_prev;
-  struct inproc_stream* stream_list_next;
-} inproc_stream;
-
-static bool cancel_stream_locked(inproc_stream* s, grpc_error* error);
-static void op_state_machine(void* arg, grpc_error* error);
-
-static void ref_transport(inproc_transport* t) {
-  INPROC_LOG(GPR_INFO, "ref_transport %p", t);
-  gpr_ref(&t->refs);
-}
-
-static void really_destroy_transport(inproc_transport* t) {
-  INPROC_LOG(GPR_INFO, "really_destroy_transport %p", t);
-  grpc_connectivity_state_destroy(&t->connectivity);
-  if (gpr_unref(&t->mu->refs)) {
-    gpr_free(t->mu);
+      gpr_mu_unlock(&t->mu->mu);
+    }
   }
-  gpr_free(t);
-}
 
-static void unref_transport(inproc_transport* t) {
-  INPROC_LOG(GPR_INFO, "unref_transport %p", t);
-  if (gpr_unref(&t->refs)) {
-    really_destroy_transport(t);
+  ~inproc_stream() {
+    GRPC_ERROR_UNREF(write_buffer_cancel_error);
+    GRPC_ERROR_UNREF(cancel_self_error);
+    GRPC_ERROR_UNREF(cancel_other_error);
+
+    if (recv_inited) {
+      grpc_slice_buffer_destroy_internal(&recv_message);
+    }
+
+    t->unref();
+
+    if (closure_at_destroy) {
+      GRPC_CLOSURE_SCHED(closure_at_destroy, GRPC_ERROR_NONE);
+    }
   }
-}
 
 #ifndef NDEBUG
 #define STREAM_REF(refs, reason) grpc_stream_ref(refs, reason)
@@ -151,37 +210,74 @@ static void unref_transport(inproc_transport* t) {
 #define STREAM_REF(refs, reason) grpc_stream_ref(refs)
 #define STREAM_UNREF(refs, reason) grpc_stream_unref(refs)
 #endif
-
-static void ref_stream(inproc_stream* s, const char* reason) {
-  INPROC_LOG(GPR_INFO, "ref_stream %p %s", s, reason);
-  STREAM_REF(s->refs, reason);
-}
-
-static void unref_stream(inproc_stream* s, const char* reason) {
-  INPROC_LOG(GPR_INFO, "unref_stream %p %s", s, reason);
-  STREAM_UNREF(s->refs, reason);
-}
-
-static void really_destroy_stream(inproc_stream* s) {
-  INPROC_LOG(GPR_INFO, "really_destroy_stream %p", s);
-
-  GRPC_ERROR_UNREF(s->write_buffer_cancel_error);
-  GRPC_ERROR_UNREF(s->cancel_self_error);
-  GRPC_ERROR_UNREF(s->cancel_other_error);
-
-  if (s->recv_inited) {
-    grpc_slice_buffer_destroy_internal(&s->recv_message);
+  void ref(const char* reason) {
+    INPROC_LOG(GPR_INFO, "ref_stream %p %s", this, reason);
+    STREAM_REF(refs, reason);
   }
 
-  unref_transport(s->t);
-
-  if (s->closure_at_destroy) {
-    GRPC_CLOSURE_SCHED(s->closure_at_destroy, GRPC_ERROR_NONE);
+  void unref(const char* reason) {
+    INPROC_LOG(GPR_INFO, "unref_stream %p %s", this, reason);
+    STREAM_UNREF(refs, reason);
   }
-}
+#undef STREAM_REF
+#undef STREAM_UNREF
 
-static void log_metadata(const grpc_metadata_batch* md_batch, bool is_client,
-                         bool is_initial) {
+  inproc_transport* t;
+  grpc_metadata_batch to_read_initial_md;
+  uint32_t to_read_initial_md_flags = 0;
+  bool to_read_initial_md_filled = false;
+  grpc_metadata_batch to_read_trailing_md;
+  bool to_read_trailing_md_filled = false;
+  bool ops_needed = false;
+  bool op_closure_scheduled = false;
+  grpc_closure op_closure;
+  // Write buffer used only during gap at init time when client-side
+  // stream is set up but server side stream is not yet set up
+  grpc_metadata_batch write_buffer_initial_md;
+  bool write_buffer_initial_md_filled = false;
+  uint32_t write_buffer_initial_md_flags = 0;
+  grpc_millis write_buffer_deadline = GRPC_MILLIS_INF_FUTURE;
+  grpc_metadata_batch write_buffer_trailing_md;
+  bool write_buffer_trailing_md_filled = false;
+  grpc_error* write_buffer_cancel_error = GRPC_ERROR_NONE;
+
+  struct inproc_stream* other_side;
+  bool other_side_closed = false;               // won't talk anymore
+  bool write_buffer_other_side_closed = false;  // on hold
+  grpc_stream_refcount* refs;
+  grpc_closure* closure_at_destroy = nullptr;
+
+  gpr_arena* arena;
+
+  grpc_transport_stream_op_batch* send_message_op = nullptr;
+  grpc_transport_stream_op_batch* send_trailing_md_op = nullptr;
+  grpc_transport_stream_op_batch* recv_initial_md_op = nullptr;
+  grpc_transport_stream_op_batch* recv_message_op = nullptr;
+  grpc_transport_stream_op_batch* recv_trailing_md_op = nullptr;
+
+  grpc_slice_buffer recv_message;
+  grpc_core::ManualConstructor<grpc_core::SliceBufferByteStream> recv_stream;
+  bool recv_inited = false;
+
+  bool initial_md_sent = false;
+  bool trailing_md_sent = false;
+  bool initial_md_recvd = false;
+  bool trailing_md_recvd = false;
+
+  bool closed = false;
+
+  grpc_error* cancel_self_error = GRPC_ERROR_NONE;
+  grpc_error* cancel_other_error = GRPC_ERROR_NONE;
+
+  grpc_millis deadline = GRPC_MILLIS_INF_FUTURE;
+
+  bool listed = true;
+  struct inproc_stream* stream_list_prev;
+  struct inproc_stream* stream_list_next;
+};
+
+void log_metadata(const grpc_metadata_batch* md_batch, bool is_client,
+                  bool is_initial) {
   for (grpc_linked_mdelem* md = md_batch->list.head; md != nullptr;
        md = md->next) {
     char* key = grpc_slice_to_c_string(GRPC_MDKEY(md->md));
@@ -193,10 +289,10 @@ static void log_metadata(const grpc_metadata_batch* md_batch, bool is_client,
   }
 }
 
-static grpc_error* fill_in_metadata(inproc_stream* s,
-                                    const grpc_metadata_batch* metadata,
-                                    uint32_t flags, grpc_metadata_batch* out_md,
-                                    uint32_t* outflags, bool* markfilled) {
+grpc_error* fill_in_metadata(inproc_stream* s,
+                             const grpc_metadata_batch* metadata,
+                             uint32_t flags, grpc_metadata_batch* out_md,
+                             uint32_t* outflags, bool* markfilled) {
   if (grpc_inproc_trace.enabled()) {
     log_metadata(metadata, s->t->is_client, outflags != nullptr);
   }
@@ -221,109 +317,16 @@ static grpc_error* fill_in_metadata(inproc_stream* s,
   return error;
 }
 
-static int init_stream(grpc_transport* gt, grpc_stream* gs,
-                       grpc_stream_refcount* refcount, const void* server_data,
-                       gpr_arena* arena) {
+int init_stream(grpc_transport* gt, grpc_stream* gs,
+                grpc_stream_refcount* refcount, const void* server_data,
+                gpr_arena* arena) {
   INPROC_LOG(GPR_INFO, "init_stream %p %p %p", gt, gs, server_data);
   inproc_transport* t = reinterpret_cast<inproc_transport*>(gt);
-  inproc_stream* s = reinterpret_cast<inproc_stream*>(gs);
-  s->arena = arena;
-
-  s->refs = refcount;
-  // Ref this stream right now
-  ref_stream(s, "inproc_init_stream:init");
-
-  grpc_metadata_batch_init(&s->to_read_initial_md);
-  s->to_read_initial_md_flags = 0;
-  s->to_read_initial_md_filled = false;
-  grpc_metadata_batch_init(&s->to_read_trailing_md);
-  s->to_read_trailing_md_filled = false;
-  grpc_metadata_batch_init(&s->write_buffer_initial_md);
-  s->write_buffer_initial_md_flags = 0;
-  s->write_buffer_initial_md_filled = false;
-  grpc_metadata_batch_init(&s->write_buffer_trailing_md);
-  s->write_buffer_trailing_md_filled = false;
-  s->ops_needed = false;
-  s->op_closure_scheduled = false;
-  GRPC_CLOSURE_INIT(&s->op_closure, op_state_machine, s,
-                    grpc_schedule_on_exec_ctx);
-  s->t = t;
-  s->closure_at_destroy = nullptr;
-  s->other_side_closed = false;
-
-  s->initial_md_sent = s->trailing_md_sent = s->initial_md_recvd =
-      s->trailing_md_recvd = false;
-
-  s->closed = false;
-
-  s->cancel_self_error = GRPC_ERROR_NONE;
-  s->cancel_other_error = GRPC_ERROR_NONE;
-  s->write_buffer_cancel_error = GRPC_ERROR_NONE;
-  s->deadline = GRPC_MILLIS_INF_FUTURE;
-  s->write_buffer_deadline = GRPC_MILLIS_INF_FUTURE;
-
-  s->stream_list_prev = nullptr;
-  gpr_mu_lock(&t->mu->mu);
-  s->listed = true;
-  ref_stream(s, "inproc_init_stream:list");
-  s->stream_list_next = t->stream_list;
-  if (t->stream_list) {
-    t->stream_list->stream_list_prev = s;
-  }
-  t->stream_list = s;
-  gpr_mu_unlock(&t->mu->mu);
-
-  if (!server_data) {
-    ref_transport(t);
-    inproc_transport* st = t->other_side;
-    ref_transport(st);
-    s->other_side = nullptr;  // will get filled in soon
-    // Pass the client-side stream address to the server-side for a ref
-    ref_stream(s, "inproc_init_stream:clt");  // ref it now on behalf of server
-                                              // side to avoid destruction
-    INPROC_LOG(GPR_INFO, "calling accept stream cb %p %p", st->accept_stream_cb,
-               st->accept_stream_data);
-    (*st->accept_stream_cb)(st->accept_stream_data, &st->base, (void*)s);
-  } else {
-    // This is the server-side and is being called through accept_stream_cb
-    inproc_stream* cs = (inproc_stream*)server_data;
-    s->other_side = cs;
-    // Ref the server-side stream on behalf of the client now
-    ref_stream(s, "inproc_init_stream:srv");
-
-    // Now we are about to affect the other side, so lock the transport
-    // to make sure that it doesn't get destroyed
-    gpr_mu_lock(&s->t->mu->mu);
-    cs->other_side = s;
-    // Now transfer from the other side's write_buffer if any to the to_read
-    // buffer
-    if (cs->write_buffer_initial_md_filled) {
-      fill_in_metadata(s, &cs->write_buffer_initial_md,
-                       cs->write_buffer_initial_md_flags,
-                       &s->to_read_initial_md, &s->to_read_initial_md_flags,
-                       &s->to_read_initial_md_filled);
-      s->deadline = GPR_MIN(s->deadline, cs->write_buffer_deadline);
-      grpc_metadata_batch_clear(&cs->write_buffer_initial_md);
-      cs->write_buffer_initial_md_filled = false;
-    }
-    if (cs->write_buffer_trailing_md_filled) {
-      fill_in_metadata(s, &cs->write_buffer_trailing_md, 0,
-                       &s->to_read_trailing_md, nullptr,
-                       &s->to_read_trailing_md_filled);
-      grpc_metadata_batch_clear(&cs->write_buffer_trailing_md);
-      cs->write_buffer_trailing_md_filled = false;
-    }
-    if (cs->write_buffer_cancel_error != GRPC_ERROR_NONE) {
-      s->cancel_other_error = cs->write_buffer_cancel_error;
-      cs->write_buffer_cancel_error = GRPC_ERROR_NONE;
-    }
-
-    gpr_mu_unlock(&s->t->mu->mu);
-  }
+  new (gs) inproc_stream(t, refcount, server_data, arena);
   return 0;  // return value is not important
 }
 
-static void close_stream_locked(inproc_stream* s) {
+void close_stream_locked(inproc_stream* s) {
   if (!s->closed) {
     // Release the metadata that we would have written out
     grpc_metadata_batch_destroy(&s->write_buffer_initial_md);
@@ -341,21 +344,21 @@ static void close_stream_locked(inproc_stream* s) {
         n->stream_list_prev = p;
       }
       s->listed = false;
-      unref_stream(s, "close_stream:list");
+      s->unref("close_stream:list");
     }
     s->closed = true;
-    unref_stream(s, "close_stream:closing");
+    s->unref("close_stream:closing");
   }
 }
 
 // This function means that we are done talking/listening to the other side
-static void close_other_side_locked(inproc_stream* s, const char* reason) {
+void close_other_side_locked(inproc_stream* s, const char* reason) {
   if (s->other_side != nullptr) {
     // First release the metadata that came from the other side's arena
     grpc_metadata_batch_destroy(&s->to_read_initial_md);
     grpc_metadata_batch_destroy(&s->to_read_trailing_md);
 
-    unref_stream(s->other_side, reason);
+    s->other_side->unref(reason);
     s->other_side_closed = true;
     s->other_side = nullptr;
   } else if (!s->other_side_closed) {
@@ -367,9 +370,9 @@ static void close_other_side_locked(inproc_stream* s, const char* reason) {
 // this stream_op_batch is only one of the pending operations for this
 // stream. This is called when one of the pending operations for the stream
 // is done and about to be NULLed out
-static void complete_if_batch_end_locked(inproc_stream* s, grpc_error* error,
-                                         grpc_transport_stream_op_batch* op,
-                                         const char* msg) {
+void complete_if_batch_end_locked(inproc_stream* s, grpc_error* error,
+                                  grpc_transport_stream_op_batch* op,
+                                  const char* msg) {
   int is_sm = static_cast<int>(op == s->send_message_op);
   int is_stm = static_cast<int>(op == s->send_trailing_md_op);
   // TODO(vjpai): We should not consider the recv ops here, since they
@@ -386,8 +389,7 @@ static void complete_if_batch_end_locked(inproc_stream* s, grpc_error* error,
   }
 }
 
-static void maybe_schedule_op_closure_locked(inproc_stream* s,
-                                             grpc_error* error) {
+void maybe_schedule_op_closure_locked(inproc_stream* s, grpc_error* error) {
   if (s && s->ops_needed && !s->op_closure_scheduled) {
     GRPC_CLOSURE_SCHED(&s->op_closure, GRPC_ERROR_REF(error));
     s->op_closure_scheduled = true;
@@ -395,7 +397,7 @@ static void maybe_schedule_op_closure_locked(inproc_stream* s,
   }
 }
 
-static void fail_helper_locked(inproc_stream* s, grpc_error* error) {
+void fail_helper_locked(inproc_stream* s, grpc_error* error) {
   INPROC_LOG(GPR_INFO, "op_state_machine %p fail_helper", s);
   // If we're failing this side, we need to make sure that
   // we also send or have already sent trailing metadata
@@ -525,8 +527,7 @@ static void fail_helper_locked(inproc_stream* s, grpc_error* error) {
 // that the incoming byte stream's next() call will always return
 // synchronously.  That assumption is true today but may not always be
 // true in the future.
-static void message_transfer_locked(inproc_stream* sender,
-                                    inproc_stream* receiver) {
+void message_transfer_locked(inproc_stream* sender, inproc_stream* receiver) {
   size_t remaining =
       sender->send_message_op->payload->send_message.send_message->length();
   if (receiver->recv_inited) {
@@ -572,7 +573,7 @@ static void message_transfer_locked(inproc_stream* sender,
   sender->send_message_op = nullptr;
 }
 
-static void op_state_machine(void* arg, grpc_error* error) {
+void op_state_machine(void* arg, grpc_error* error) {
   // This function gets called when we have contents in the unprocessed reads
   // Get what we want based on our ops wanted
   // Schedule our appropriate closures
@@ -847,7 +848,7 @@ done:
   GRPC_ERROR_UNREF(new_err);
 }
 
-static bool cancel_stream_locked(inproc_stream* s, grpc_error* error) {
+bool cancel_stream_locked(inproc_stream* s, grpc_error* error) {
   bool ret = false;  // was the cancel accepted
   INPROC_LOG(GPR_INFO, "cancel_stream %p with %s", s, grpc_error_string(error));
   if (s->cancel_self_error == GRPC_ERROR_NONE) {
@@ -900,10 +901,10 @@ static bool cancel_stream_locked(inproc_stream* s, grpc_error* error) {
   return ret;
 }
 
-static void do_nothing(void* arg, grpc_error* error) {}
+void do_nothing(void* arg, grpc_error* error) {}
 
-static void perform_stream_op(grpc_transport* gt, grpc_stream* gs,
-                              grpc_transport_stream_op_batch* op) {
+void perform_stream_op(grpc_transport* gt, grpc_stream* gs,
+                       grpc_transport_stream_op_batch* op) {
   INPROC_LOG(GPR_INFO, "perform_stream_op %p %p %p", gt, gs, op);
   inproc_stream* s = reinterpret_cast<inproc_stream*>(gs);
   gpr_mu* mu = &s->t->mu->mu;  // save aside in case s gets closed
@@ -1083,7 +1084,7 @@ static void perform_stream_op(grpc_transport* gt, grpc_stream* gs,
   GRPC_ERROR_UNREF(error);
 }
 
-static void close_transport_locked(inproc_transport* t) {
+void close_transport_locked(inproc_transport* t) {
   INPROC_LOG(GPR_INFO, "close_transport %p %d", t, t->is_closed);
   grpc_connectivity_state_set(
       &t->connectivity, GRPC_CHANNEL_SHUTDOWN,
@@ -1103,7 +1104,7 @@ static void close_transport_locked(inproc_transport* t) {
   }
 }
 
-static void perform_transport_op(grpc_transport* gt, grpc_transport_op* op) {
+void perform_transport_op(grpc_transport* gt, grpc_transport_op* op) {
   inproc_transport* t = reinterpret_cast<inproc_transport*>(gt);
   INPROC_LOG(GPR_INFO, "perform_transport_op %p %p", t, op);
   gpr_mu_lock(&t->mu->mu);
@@ -1136,39 +1137,64 @@ static void perform_transport_op(grpc_transport* gt, grpc_transport_op* op) {
   gpr_mu_unlock(&t->mu->mu);
 }
 
-static void destroy_stream(grpc_transport* gt, grpc_stream* gs,
-                           grpc_closure* then_schedule_closure) {
+void destroy_stream(grpc_transport* gt, grpc_stream* gs,
+                    grpc_closure* then_schedule_closure) {
   INPROC_LOG(GPR_INFO, "destroy_stream %p %p", gs, then_schedule_closure);
   inproc_stream* s = reinterpret_cast<inproc_stream*>(gs);
   s->closure_at_destroy = then_schedule_closure;
-  really_destroy_stream(s);
+  s->~inproc_stream();
 }
 
-static void destroy_transport(grpc_transport* gt) {
+void destroy_transport(grpc_transport* gt) {
   inproc_transport* t = reinterpret_cast<inproc_transport*>(gt);
   INPROC_LOG(GPR_INFO, "destroy_transport %p", t);
   gpr_mu_lock(&t->mu->mu);
   close_transport_locked(t);
   gpr_mu_unlock(&t->mu->mu);
-  unref_transport(t->other_side);
-  unref_transport(t);
+  t->other_side->unref();
+  t->unref();
 }
 
 /*******************************************************************************
  * INTEGRATION GLUE
  */
 
-static void set_pollset(grpc_transport* gt, grpc_stream* gs,
-                        grpc_pollset* pollset) {
+void set_pollset(grpc_transport* gt, grpc_stream* gs, grpc_pollset* pollset) {
   // Nothing to do here
 }
 
-static void set_pollset_set(grpc_transport* gt, grpc_stream* gs,
-                            grpc_pollset_set* pollset_set) {
+void set_pollset_set(grpc_transport* gt, grpc_stream* gs,
+                     grpc_pollset_set* pollset_set) {
   // Nothing to do here
 }
 
-static grpc_endpoint* get_endpoint(grpc_transport* t) { return nullptr; }
+grpc_endpoint* get_endpoint(grpc_transport* t) { return nullptr; }
+
+const grpc_transport_vtable inproc_vtable = {
+    sizeof(inproc_stream), "inproc",        init_stream,
+    set_pollset,           set_pollset_set, perform_stream_op,
+    perform_transport_op,  destroy_stream,  destroy_transport,
+    get_endpoint};
+
+/*******************************************************************************
+ * Main inproc transport functions
+ */
+void inproc_transports_create(grpc_transport** server_transport,
+                              const grpc_channel_args* server_args,
+                              grpc_transport** client_transport,
+                              const grpc_channel_args* client_args) {
+  INPROC_LOG(GPR_INFO, "inproc_transports_create");
+  shared_mu* mu = new (gpr_malloc(sizeof(*mu))) shared_mu();
+  inproc_transport* st = new (gpr_malloc(sizeof(*st)))
+      inproc_transport(&inproc_vtable, mu, /*is_client=*/false);
+  inproc_transport* ct = new (gpr_malloc(sizeof(*ct)))
+      inproc_transport(&inproc_vtable, mu, /*is_client=*/true);
+  st->other_side = ct;
+  ct->other_side = st;
+  *server_transport = reinterpret_cast<grpc_transport*>(st);
+  *client_transport = reinterpret_cast<grpc_transport*>(ct);
+}
+}  // namespace
 
 /*******************************************************************************
  * GLOBAL INIT AND DESTROY
@@ -1188,48 +1214,6 @@ void grpc_inproc_transport_init(void) {
   grpc_slice_unref_internal(auth_tmp);
 
   g_fake_auth_value = grpc_slice_from_static_string("inproc-fail");
-}
-
-static const grpc_transport_vtable inproc_vtable = {
-    sizeof(inproc_stream), "inproc",        init_stream,
-    set_pollset,           set_pollset_set, perform_stream_op,
-    perform_transport_op,  destroy_stream,  destroy_transport,
-    get_endpoint};
-
-/*******************************************************************************
- * Main inproc transport functions
- */
-static void inproc_transports_create(grpc_transport** server_transport,
-                                     const grpc_channel_args* server_args,
-                                     grpc_transport** client_transport,
-                                     const grpc_channel_args* client_args) {
-  INPROC_LOG(GPR_INFO, "inproc_transports_create");
-  inproc_transport* st =
-      static_cast<inproc_transport*>(gpr_zalloc(sizeof(*st)));
-  inproc_transport* ct =
-      static_cast<inproc_transport*>(gpr_zalloc(sizeof(*ct)));
-  // Share one lock between both sides since both sides get affected
-  st->mu = ct->mu = static_cast<shared_mu*>(gpr_malloc(sizeof(*st->mu)));
-  gpr_mu_init(&st->mu->mu);
-  gpr_ref_init(&st->mu->refs, 2);
-  st->base.vtable = &inproc_vtable;
-  ct->base.vtable = &inproc_vtable;
-  // Start each side of transport with 2 refs since they each have a ref
-  // to the other
-  gpr_ref_init(&st->refs, 2);
-  gpr_ref_init(&ct->refs, 2);
-  st->is_client = false;
-  ct->is_client = true;
-  grpc_connectivity_state_init(&st->connectivity, GRPC_CHANNEL_READY,
-                               "inproc_server");
-  grpc_connectivity_state_init(&ct->connectivity, GRPC_CHANNEL_READY,
-                               "inproc_client");
-  st->other_side = ct;
-  ct->other_side = st;
-  st->stream_list = nullptr;
-  ct->stream_list = nullptr;
-  *server_transport = reinterpret_cast<grpc_transport*>(st);
-  *client_transport = reinterpret_cast<grpc_transport*>(ct);
 }
 
 grpc_channel* grpc_inproc_channel_create(grpc_server* server,

--- a/src/core/lib/channel/channel_stack.h
+++ b/src/core/lib/channel/channel_stack.h
@@ -79,11 +79,11 @@ typedef struct {
 } grpc_call_stats;
 
 /** Information about the call upon completion. */
-typedef struct {
+struct grpc_call_final_info {
   grpc_call_stats stats;
-  grpc_status_code final_status;
-  const char* error_string;
-} grpc_call_final_info;
+  grpc_status_code final_status = GRPC_STATUS_OK;
+  const char* error_string = nullptr;
+};
 
 /* Channel filters specify:
    1. the amount of memory needed in the channel & call (via the sizeof_XXX

--- a/src/core/lib/channel/context.h
+++ b/src/core/lib/channel/context.h
@@ -41,9 +41,9 @@ typedef enum {
   GRPC_CONTEXT_COUNT
 } grpc_context_index;
 
-typedef struct {
-  void* value;
-  void (*destroy)(void*);
-} grpc_call_context_element;
+struct grpc_call_context_element {
+  void* value = nullptr;
+  void (*destroy)(void*) = nullptr;
+};
 
 #endif /* GRPC_CORE_LIB_CHANNEL_CONTEXT_H */

--- a/src/core/lib/gpr/arena.h
+++ b/src/core/lib/gpr/arena.h
@@ -37,5 +37,7 @@ gpr_arena* gpr_arena_create(size_t initial_size);
 void* gpr_arena_alloc(gpr_arena* arena, size_t size);
 // Destroy an arena, returning the total number of bytes allocated
 size_t gpr_arena_destroy(gpr_arena* arena);
+// Initializes the Arena component.
+void gpr_arena_init();
 
 #endif /* GRPC_CORE_LIB_GPR_ARENA_H */

--- a/src/core/lib/iomgr/call_combiner.cc
+++ b/src/core/lib/iomgr/call_combiner.cc
@@ -40,6 +40,8 @@ static gpr_atm encode_cancel_state_error(grpc_error* error) {
 }
 
 void grpc_call_combiner_init(grpc_call_combiner* call_combiner) {
+  gpr_atm_no_barrier_store(&call_combiner->cancel_state, 0);
+  gpr_atm_no_barrier_store(&call_combiner->size, 0);
   gpr_mpscq_init(&call_combiner->queue);
 }
 

--- a/src/core/lib/iomgr/call_combiner.h
+++ b/src/core/lib/iomgr/call_combiner.h
@@ -41,12 +41,12 @@
 extern grpc_core::TraceFlag grpc_call_combiner_trace;
 
 typedef struct {
-  gpr_atm size;  // size_t, num closures in queue or currently executing
+  gpr_atm size = 0;  // size_t, num closures in queue or currently executing
   gpr_mpscq queue;
   // Either 0 (if not cancelled and no cancellation closure set),
   // a grpc_closure* (if the lowest bit is 0),
   // or a grpc_error* (if the lowest bit is 1).
-  gpr_atm cancel_state;
+  gpr_atm cancel_state = 0;
 } grpc_call_combiner;
 
 // Assumes memory was initialized to zero.

--- a/src/core/lib/iomgr/closure.h
+++ b/src/core/lib/iomgr/closure.h
@@ -114,6 +114,7 @@ inline grpc_closure* grpc_closure_init(grpc_closure* closure,
   closure->cb = cb;
   closure->cb_arg = cb_arg;
   closure->scheduler = scheduler;
+  closure->error_data.error = GRPC_ERROR_NONE;
 #ifndef NDEBUG
   closure->scheduled = false;
   closure->file_initiated = nullptr;

--- a/src/core/lib/iomgr/polling_entity.h
+++ b/src/core/lib/iomgr/polling_entity.h
@@ -34,13 +34,13 @@ typedef enum grpc_pollset_tag {
  * functions that accept a pollset XOR a pollset_set to do so through an
  * abstract interface. No ownership is taken. */
 
-typedef struct grpc_polling_entity {
+struct grpc_polling_entity {
   union {
-    grpc_pollset* pollset;
+    grpc_pollset* pollset = nullptr;
     grpc_pollset_set* pollset_set;
   } pollent;
-  grpc_pollset_tag tag;
-} grpc_polling_entity;
+  grpc_pollset_tag tag = GRPC_POLLS_NONE;
+};
 
 grpc_polling_entity grpc_polling_entity_create_from_pollset_set(
     grpc_pollset_set* pollset_set);

--- a/src/core/lib/security/context/security_context.cc
+++ b/src/core/lib/security/context/security_context.cc
@@ -81,38 +81,45 @@ void grpc_auth_context_release(grpc_auth_context* context) {
 }
 
 /* --- grpc_client_security_context --- */
+grpc_client_security_context::~grpc_client_security_context() {
+  grpc_call_credentials_unref(creds);
+  GRPC_AUTH_CONTEXT_UNREF(auth_context, "client_security_context");
+  if (extension.instance != nullptr && extension.destroy != nullptr) {
+    extension.destroy(extension.instance);
+  }
+}
 
 grpc_client_security_context* grpc_client_security_context_create(
     gpr_arena* arena) {
-  return static_cast<grpc_client_security_context*>(
-      gpr_arena_alloc(arena, sizeof(grpc_client_security_context)));
+  return new (gpr_arena_alloc(arena, sizeof(grpc_client_security_context)))
+      grpc_client_security_context();
 }
 
 void grpc_client_security_context_destroy(void* ctx) {
   grpc_core::ExecCtx exec_ctx;
   grpc_client_security_context* c =
       static_cast<grpc_client_security_context*>(ctx);
-  grpc_call_credentials_unref(c->creds);
-  GRPC_AUTH_CONTEXT_UNREF(c->auth_context, "client_security_context");
-  if (c->extension.instance != nullptr && c->extension.destroy != nullptr) {
-    c->extension.destroy(c->extension.instance);
-  }
+  c->~grpc_client_security_context();
 }
 
 /* --- grpc_server_security_context --- */
+grpc_server_security_context::~grpc_server_security_context() {
+  GRPC_AUTH_CONTEXT_UNREF(auth_context, "server_security_context");
+  if (extension.instance != nullptr && extension.destroy != nullptr) {
+    extension.destroy(extension.instance);
+  }
+}
+
 grpc_server_security_context* grpc_server_security_context_create(
     gpr_arena* arena) {
-  return static_cast<grpc_server_security_context*>(
-      gpr_arena_alloc(arena, sizeof(grpc_server_security_context)));
+  return new (gpr_arena_alloc(arena, sizeof(grpc_server_security_context)))
+      grpc_server_security_context();
 }
 
 void grpc_server_security_context_destroy(void* ctx) {
   grpc_server_security_context* c =
       static_cast<grpc_server_security_context*>(ctx);
-  GRPC_AUTH_CONTEXT_UNREF(c->auth_context, "server_security_context");
-  if (c->extension.instance != nullptr && c->extension.destroy != nullptr) {
-    c->extension.destroy(c->extension.instance);
-  }
+  c->~grpc_server_security_context();
 }
 
 /* --- grpc_auth_context --- */

--- a/src/core/lib/security/context/security_context.h
+++ b/src/core/lib/security/context/security_context.h
@@ -34,18 +34,20 @@ struct gpr_arena;
 
 /* Property names are always NULL terminated. */
 
-typedef struct {
-  grpc_auth_property* array;
-  size_t count;
-  size_t capacity;
-} grpc_auth_property_array;
+struct grpc_auth_property_array {
+  grpc_auth_property* array = nullptr;
+  size_t count = 0;
+  size_t capacity = 0;
+};
 
 struct grpc_auth_context {
-  struct grpc_auth_context* chained;
+  grpc_auth_context() { gpr_ref_init(&refcount, 0); }
+
+  struct grpc_auth_context* chained = nullptr;
   grpc_auth_property_array properties;
   gpr_refcount refcount;
-  const char* peer_identity_property_name;
-  grpc_pollset* pollset;
+  const char* peer_identity_property_name = nullptr;
+  grpc_pollset* pollset = nullptr;
 };
 
 /* Creation. */
@@ -76,20 +78,23 @@ void grpc_auth_property_reset(grpc_auth_property* property);
    Extension to the security context that may be set in a filter and accessed
    later by a higher level method on a grpc_call object. */
 
-typedef struct {
-  void* instance;
-  void (*destroy)(void*);
-} grpc_security_context_extension;
+struct grpc_security_context_extension {
+  void* instance = nullptr;
+  void (*destroy)(void*) = nullptr;
+};
 
 /* --- grpc_client_security_context ---
 
    Internal client-side security context. */
 
-typedef struct {
-  grpc_call_credentials* creds;
-  grpc_auth_context* auth_context;
+struct grpc_client_security_context {
+  grpc_client_security_context() = default;
+  ~grpc_client_security_context();
+
+  grpc_call_credentials* creds = nullptr;
+  grpc_auth_context* auth_context = nullptr;
   grpc_security_context_extension extension;
-} grpc_client_security_context;
+};
 
 grpc_client_security_context* grpc_client_security_context_create(
     gpr_arena* arena);
@@ -99,10 +104,13 @@ void grpc_client_security_context_destroy(void* ctx);
 
    Internal server-side security context. */
 
-typedef struct {
-  grpc_auth_context* auth_context;
+struct grpc_server_security_context {
+  grpc_server_security_context() = default;
+  ~grpc_server_security_context();
+
+  grpc_auth_context* auth_context = nullptr;
   grpc_security_context_extension extension;
-} grpc_server_security_context;
+};
 
 grpc_server_security_context* grpc_server_security_context_create(
     gpr_arena* arena);

--- a/src/core/lib/security/credentials/credentials.h
+++ b/src/core/lib/security/credentials/credentials.h
@@ -142,8 +142,8 @@ grpc_channel_credentials* grpc_channel_credentials_find_in_args(
 /* --- grpc_credentials_mdelem_array. --- */
 
 typedef struct {
-  grpc_mdelem* md;
-  size_t size;
+  grpc_mdelem* md = nullptr;
+  size_t size = 0;
 } grpc_credentials_mdelem_array;
 
 /// Takes a new ref to \a md.

--- a/src/core/lib/security/transport/client_auth_filter.cc
+++ b/src/core/lib/security/transport/client_auth_filter.cc
@@ -43,20 +43,39 @@
 namespace {
 /* We can have a per-call credentials. */
 struct call_data {
+  call_data(grpc_call_element* elem, const grpc_call_element_args& args)
+      : arena(args.arena),
+        owning_call(args.call_stack),
+        call_combiner(args.call_combiner) {}
+
+  // This method is technically the dtor of this class. However, since
+  // `get_request_metadata_cancel_closure` can run in parallel to
+  // `destroy_call_elem`, we cannot call the dtor in them. Otherwise,
+  // fields will be accessed after calling dtor, and msan correctly complains
+  // that the memory is not initialized.
+  void destroy() {
+    grpc_credentials_mdelem_array_destroy(&md_array);
+    grpc_call_credentials_unref(creds);
+    grpc_slice_unref_internal(host);
+    grpc_slice_unref_internal(method);
+    grpc_auth_metadata_context_reset(&auth_md_context);
+  }
+
   gpr_arena* arena;
   grpc_call_stack* owning_call;
   grpc_call_combiner* call_combiner;
-  grpc_call_credentials* creds;
-  grpc_slice host;
-  grpc_slice method;
+  grpc_call_credentials* creds = nullptr;
+  grpc_slice host = grpc_empty_slice();
+  grpc_slice method = grpc_empty_slice();
   /* pollset{_set} bound to this call; if we need to make external
      network requests, they should be done under a pollset added to this
      pollset_set so that work can progress when this call wants work to progress
   */
-  grpc_polling_entity* pollent;
+  grpc_polling_entity* pollent = nullptr;
   grpc_credentials_mdelem_array md_array;
-  grpc_linked_mdelem md_links[MAX_CREDENTIALS_METADATA_COUNT];
-  grpc_auth_metadata_context auth_md_context;
+  grpc_linked_mdelem md_links[MAX_CREDENTIALS_METADATA_COUNT] = {};
+  grpc_auth_metadata_context auth_md_context =
+      grpc_auth_metadata_context();  // Zero-initialize the C struct.
   grpc_closure async_result_closure;
   grpc_closure check_call_host_cancel_closure;
   grpc_closure get_request_metadata_cancel_closure;
@@ -334,12 +353,7 @@ static void auth_start_transport_stream_op_batch(
 /* Constructor for call_data */
 static grpc_error* init_call_elem(grpc_call_element* elem,
                                   const grpc_call_element_args* args) {
-  call_data* calld = static_cast<call_data*>(elem->call_data);
-  calld->arena = args->arena;
-  calld->owning_call = args->call_stack;
-  calld->call_combiner = args->call_combiner;
-  calld->host = grpc_empty_slice();
-  calld->method = grpc_empty_slice();
+  new (elem->call_data) call_data(elem, *args);
   return GRPC_ERROR_NONE;
 }
 
@@ -354,11 +368,7 @@ static void destroy_call_elem(grpc_call_element* elem,
                               const grpc_call_final_info* final_info,
                               grpc_closure* ignored) {
   call_data* calld = static_cast<call_data*>(elem->call_data);
-  grpc_credentials_mdelem_array_destroy(&calld->md_array);
-  grpc_call_credentials_unref(calld->creds);
-  grpc_slice_unref_internal(calld->host);
-  grpc_slice_unref_internal(calld->method);
-  grpc_auth_metadata_context_reset(&calld->auth_md_context);
+  calld->destroy();
 }
 
 /* Constructor for channel_data */

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -72,8 +72,11 @@
 // Used to create arena for the first call.
 #define ESTIMATED_MDELEM_COUNT 16
 
-typedef struct batch_control {
-  grpc_call* call;
+struct batch_control {
+  batch_control() { gpr_ref_init(&steps_to_complete, 0); }
+
+  grpc_call* call = nullptr;
+  grpc_transport_stream_op_batch op;
   /* Share memory for cq_completion and notify_tag as they are never needed
      simultaneously. Each byte used in this data structure count as six bytes
      per call, so any savings we can make are worthwhile,
@@ -96,84 +99,110 @@ typedef struct batch_control {
   grpc_closure start_batch;
   grpc_closure finish_batch;
   gpr_refcount steps_to_complete;
-  gpr_atm batch_error;
-  grpc_transport_stream_op_batch op;
-} batch_control;
+  gpr_atm batch_error = reinterpret_cast<gpr_atm>(GRPC_ERROR_NONE);
+};
 
-typedef struct {
+struct parent_call {
+  parent_call() { gpr_mu_init(&child_list_mu); }
+  ~parent_call() { gpr_mu_destroy(&child_list_mu); }
+
   gpr_mu child_list_mu;
-  grpc_call* first_child;
-} parent_call;
+  grpc_call* first_child = nullptr;
+};
 
-typedef struct {
+struct child_call {
+  child_call(grpc_call* parent) : parent(parent) {}
   grpc_call* parent;
   /** siblings: children of the same parent form a list, and this list is
      protected under
       parent->mu */
-  grpc_call* sibling_next;
-  grpc_call* sibling_prev;
-} child_call;
+  grpc_call* sibling_next = nullptr;
+  grpc_call* sibling_prev = nullptr;
+};
 
 #define RECV_NONE ((gpr_atm)0)
 #define RECV_INITIAL_METADATA_FIRST ((gpr_atm)1)
 
 struct grpc_call {
+  grpc_call(gpr_arena* arena, const grpc_call_create_args& args)
+      : arena(arena),
+        cq(args.cq),
+        channel(args.channel),
+        is_client(args.server_transport_data == nullptr),
+        stream_op_payload(context) {
+    gpr_ref_init(&ext_ref, 1);
+    grpc_call_combiner_init(&call_combiner);
+    for (int i = 0; i < 2; i++) {
+      for (int j = 0; j < 2; j++) {
+        metadata_batch[i][j].deadline = GRPC_MILLIS_INF_FUTURE;
+      }
+    }
+  }
+
+  ~grpc_call() {
+    gpr_free(static_cast<void*>(const_cast<char*>(final_info.error_string)));
+    grpc_call_combiner_destroy(&call_combiner);
+  }
+
   gpr_refcount ext_ref;
   gpr_arena* arena;
   grpc_call_combiner call_combiner;
   grpc_completion_queue* cq;
   grpc_polling_entity pollent;
   grpc_channel* channel;
-  gpr_timespec start_time;
-  /* parent_call* */ gpr_atm parent_call_atm;
-  child_call* child;
+  gpr_timespec start_time = gpr_now(GPR_CLOCK_MONOTONIC);
+  /* parent_call* */ gpr_atm parent_call_atm = 0;
+  child_call* child = nullptr;
 
   /* client or server call */
   bool is_client;
   /** has grpc_call_unref been called */
-  bool destroy_called;
+  bool destroy_called = false;
   /** flag indicating that cancellation is inherited */
-  bool cancellation_is_inherited;
+  bool cancellation_is_inherited = false;
   /** which ops are in-flight */
-  bool sent_initial_metadata;
-  bool sending_message;
-  bool sent_final_op;
-  bool received_initial_metadata;
-  bool receiving_message;
-  bool requested_final_op;
-  gpr_atm any_ops_sent_atm;
-  gpr_atm received_final_op_atm;
+  bool sent_initial_metadata = false;
+  bool sending_message = false;
+  bool sent_final_op = false;
+  bool received_initial_metadata = false;
+  bool receiving_message = false;
+  bool requested_final_op = false;
+  gpr_atm any_ops_sent_atm = 0;
+  gpr_atm received_final_op_atm = 0;
 
-  batch_control* active_batches[MAX_CONCURRENT_BATCHES];
+  batch_control* active_batches[MAX_CONCURRENT_BATCHES] = {};
   grpc_transport_stream_op_batch_payload stream_op_payload;
 
   /* first idx: is_receiving, second idx: is_trailing */
-  grpc_metadata_batch metadata_batch[2][2];
+  grpc_metadata_batch metadata_batch[2][2] = {};
 
   /* Buffered read metadata waiting to be returned to the application.
      Element 0 is initial metadata, element 1 is trailing metadata. */
-  grpc_metadata_array* buffered_metadata[2];
+  grpc_metadata_array* buffered_metadata[2] = {};
 
   grpc_metadata compression_md;
 
   // A char* indicating the peer name.
-  gpr_atm peer_string;
+  gpr_atm peer_string = 0;
 
   /* Call data useful used for reporting. Only valid after the call has
    * completed */
   grpc_call_final_info final_info;
 
   /* Compression algorithm for *incoming* data */
-  grpc_message_compression_algorithm incoming_message_compression_algorithm;
+  grpc_message_compression_algorithm incoming_message_compression_algorithm =
+      GRPC_MESSAGE_COMPRESS_NONE;
   /* Stream compression algorithm for *incoming* data */
-  grpc_stream_compression_algorithm incoming_stream_compression_algorithm;
-  /* Supported encodings (compression algorithms), a bitset */
-  uint32_t encodings_accepted_by_peer;
+  grpc_stream_compression_algorithm incoming_stream_compression_algorithm =
+      GRPC_STREAM_COMPRESS_NONE;
+  /* Supported encodings (compression algorithms), a bitset.
+   * Always support no compression. */
+  uint32_t encodings_accepted_by_peer = 1 << GRPC_MESSAGE_COMPRESS_NONE;
   /* Supported stream encodings (stream compression algorithms), a bitset */
-  uint32_t stream_encodings_accepted_by_peer;
+  uint32_t stream_encodings_accepted_by_peer = 0;
 
   /* Contexts for various subsystems (security, tracing, ...). */
-  grpc_call_context_element context[GRPC_CONTEXT_COUNT];
+  grpc_call_context_element context[GRPC_CONTEXT_COUNT] = {};
 
   /* for the client, extra metadata is initial metadata; for the
      server, it's trailing metadata */
@@ -184,14 +213,14 @@ struct grpc_call {
   grpc_core::ManualConstructor<grpc_core::SliceBufferByteStream> sending_stream;
 
   grpc_core::OrphanablePtr<grpc_core::ByteStream> receiving_stream;
-  grpc_byte_buffer** receiving_buffer;
-  grpc_slice receiving_slice;
+  grpc_byte_buffer** receiving_buffer = nullptr;
+  grpc_slice receiving_slice = grpc_empty_slice();
   grpc_closure receiving_slice_ready;
   grpc_closure receiving_stream_ready;
   grpc_closure receiving_initial_metadata_ready;
   grpc_closure receiving_trailing_metadata_ready;
-  uint32_t test_only_last_message_flags;
-  gpr_atm cancelled;
+  uint32_t test_only_last_message_flags = 0;
+  gpr_atm cancelled = 0;
 
   grpc_closure release_call;
 
@@ -207,7 +236,7 @@ struct grpc_call {
       grpc_server* server;
     } server;
   } final_op;
-  gpr_atm status_error;
+  gpr_atm status_error = 0;
 
   /* recv_state can contain one of the following values:
      RECV_NONE :                 :  no initial metadata and messages received
@@ -225,7 +254,7 @@ struct grpc_call {
 
     For 1, 4: See receiving_initial_metadata_ready() function
     For 2, 3: See receiving_stream_ready() function */
-  gpr_atm recv_state;
+  gpr_atm recv_state = 0;
 };
 
 grpc_core::TraceFlag grpc_call_error_trace(false, "call_error");
@@ -269,11 +298,10 @@ void* grpc_call_arena_alloc(grpc_call* call, size_t size) {
 static parent_call* get_or_create_parent_call(grpc_call* call) {
   parent_call* p = (parent_call*)gpr_atm_acq_load(&call->parent_call_atm);
   if (p == nullptr) {
-    p = static_cast<parent_call*>(gpr_arena_alloc(call->arena, sizeof(*p)));
-    gpr_mu_init(&p->child_list_mu);
+    p = new (gpr_arena_alloc(call->arena, sizeof(*p))) parent_call();
     if (!gpr_atm_rel_cas(&call->parent_call_atm, (gpr_atm) nullptr,
                          (gpr_atm)p)) {
-      gpr_mu_destroy(&p->child_list_mu);
+      p->~parent_call();
       p = (parent_call*)gpr_atm_acq_load(&call->parent_call_atm);
     }
   }
@@ -292,7 +320,9 @@ size_t grpc_call_get_initial_size_estimate() {
 grpc_error* grpc_call_create(const grpc_call_create_args* args,
                              grpc_call** out_call) {
   GPR_TIMER_SCOPE("grpc_call_create", 0);
-  size_t i, j;
+
+  GRPC_CHANNEL_INTERNAL_REF(args->channel, "call");
+
   grpc_error* error = GRPC_ERROR_NONE;
   grpc_channel_stack* channel_stack =
       grpc_channel_get_channel_stack(args->channel);
@@ -300,27 +330,19 @@ grpc_error* grpc_call_create(const grpc_call_create_args* args,
   size_t initial_size = grpc_channel_get_call_size_estimate(args->channel);
   GRPC_STATS_INC_CALL_INITIAL_SIZE(initial_size);
   gpr_arena* arena = gpr_arena_create(initial_size);
-  call = static_cast<grpc_call*>(
-      gpr_arena_alloc(arena, GPR_ROUND_UP_TO_ALIGNMENT_SIZE(sizeof(grpc_call)) +
-                                 channel_stack->call_stack_size));
-  gpr_ref_init(&call->ext_ref, 1);
-  gpr_atm_no_barrier_store(&call->cancelled, 0);
-  call->arena = arena;
-  grpc_call_combiner_init(&call->call_combiner);
+  call = new (gpr_arena_alloc(
+      arena, GPR_ROUND_UP_TO_ALIGNMENT_SIZE(sizeof(grpc_call)) +
+                 channel_stack->call_stack_size)) grpc_call(arena, *args);
   *out_call = call;
-  call->channel = args->channel;
-  call->cq = args->cq;
-  call->start_time = gpr_now(GPR_CLOCK_MONOTONIC);
-  /* Always support no compression */
-  GPR_BITSET(&call->encodings_accepted_by_peer, GRPC_MESSAGE_COMPRESS_NONE);
-  call->is_client = args->server_transport_data == nullptr;
-  call->stream_op_payload.context = call->context;
   grpc_slice path = grpc_empty_slice();
   if (call->is_client) {
+    call->final_op.client.status_details = nullptr;
+    call->final_op.client.status = nullptr;
+    call->final_op.client.error_string = nullptr;
     GRPC_STATS_INC_CLIENT_CALLS_CREATED();
     GPR_ASSERT(args->add_initial_metadata_count <
                MAX_SEND_EXTRA_METADATA_COUNT);
-    for (i = 0; i < args->add_initial_metadata_count; i++) {
+    for (size_t i = 0; i < args->add_initial_metadata_count; i++) {
       call->send_extra_metadata[i].md = args->add_initial_metadata[i];
       if (grpc_slice_eq(GRPC_MDKEY(args->add_initial_metadata[i]),
                         GRPC_MDSTR_PATH)) {
@@ -332,23 +354,18 @@ grpc_error* grpc_call_create(const grpc_call_create_args* args,
         static_cast<int>(args->add_initial_metadata_count);
   } else {
     GRPC_STATS_INC_SERVER_CALLS_CREATED();
+    call->final_op.server.cancelled = nullptr;
     call->final_op.server.server = args->server;
     GPR_ASSERT(args->add_initial_metadata_count == 0);
     call->send_extra_metadata_count = 0;
   }
-  for (i = 0; i < 2; i++) {
-    for (j = 0; j < 2; j++) {
-      call->metadata_batch[i][j].deadline = GRPC_MILLIS_INF_FUTURE;
-    }
-  }
-  grpc_millis send_deadline = args->send_deadline;
 
+  grpc_millis send_deadline = args->send_deadline;
   bool immediately_cancel = false;
 
   if (args->parent != nullptr) {
-    call->child =
-        static_cast<child_call*>(gpr_arena_alloc(arena, sizeof(child_call)));
-    call->child->parent = args->parent;
+    call->child = new (gpr_arena_alloc(arena, sizeof(child_call)))
+        child_call(args->parent);
 
     GRPC_CALL_INTERNAL_REF(args->parent, "child");
     GPR_ASSERT(call->is_client);
@@ -382,10 +399,7 @@ grpc_error* grpc_call_create(const grpc_call_create_args* args,
       }
     }
   }
-
   call->send_deadline = send_deadline;
-
-  GRPC_CHANNEL_INTERNAL_REF(args->channel, "call");
   /* initial refcount dropped by grpc_call_unref */
   grpc_call_element_args call_args = {CALL_STACK_FROM_CALL(call),
                                       args->server_transport_data,
@@ -413,6 +427,7 @@ grpc_error* grpc_call_create(const grpc_call_create_args* args,
     }
     gpr_mu_unlock(&pc->child_list_mu);
   }
+
   if (error != GRPC_ERROR_NONE) {
     cancel_with_error(call, GRPC_ERROR_REF(error));
   }
@@ -487,9 +502,9 @@ void grpc_call_internal_unref(grpc_call* c REF_ARG) {
 static void release_call(void* call, grpc_error* error) {
   grpc_call* c = static_cast<grpc_call*>(call);
   grpc_channel* channel = c->channel;
-  gpr_free(static_cast<void*>(const_cast<char*>(c->final_info.error_string)));
-  grpc_call_combiner_destroy(&c->call_combiner);
-  grpc_channel_update_call_size_estimate(channel, gpr_arena_destroy(c->arena));
+  gpr_arena* arena = c->arena;
+  c->~grpc_call();
+  grpc_channel_update_call_size_estimate(channel, gpr_arena_destroy(arena));
   GRPC_CHANNEL_INTERNAL_UNREF(channel, "call");
 }
 
@@ -505,7 +520,7 @@ static void destroy_call(void* call, grpc_error* error) {
   c->receiving_stream.reset();
   parent_call* pc = get_parent_call(c);
   if (pc != nullptr) {
-    gpr_mu_destroy(&pc->child_list_mu);
+    pc->~parent_call();
   }
   for (ii = 0; ii < c->send_extra_metadata_count; ii++) {
     GRPC_MDELEM_UNREF(c->send_extra_metadata[ii].md);
@@ -1100,10 +1115,11 @@ static batch_control* reuse_or_allocate_batch_control(grpc_call* call,
     if (bctl->call != nullptr) {
       return nullptr;
     }
-    memset(bctl, 0, sizeof(*bctl));
+    bctl->~batch_control();
+    bctl->op = {};
   } else {
-    bctl = static_cast<batch_control*>(
-        gpr_arena_alloc(call->arena, sizeof(batch_control)));
+    bctl = new (gpr_arena_alloc(call->arena, sizeof(batch_control)))
+        batch_control();
     *pslot = bctl;
   }
   bctl->call = call;

--- a/src/core/lib/surface/channel.cc
+++ b/src/core/lib/surface/channel.cc
@@ -322,8 +322,8 @@ static grpc_call* grpc_channel_create_call_internal(
   }
 
   grpc_call_create_args args;
-  memset(&args, 0, sizeof(args));
   args.channel = channel;
+  args.server = nullptr;
   args.parent = parent_call;
   args.propagation_mask = propagation_mask;
   args.cq = cq;

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -123,6 +123,7 @@ void grpc_init(void) {
     grpc_core::Fork::GlobalInit();
     grpc_fork_handlers_auto_register();
     gpr_time_init();
+    gpr_arena_init();
     grpc_stats_init();
     grpc_slice_intern_init();
     grpc_mdctx_global_init();

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -824,11 +824,16 @@ static void accept_stream(void* cd, grpc_transport* transport,
   channel_data* chand = static_cast<channel_data*>(cd);
   /* create a call */
   grpc_call_create_args args;
-  memset(&args, 0, sizeof(args));
   args.channel = chand->channel;
-  args.server_transport_data = transport_server_data;
-  args.send_deadline = GRPC_MILLIS_INF_FUTURE;
   args.server = chand->server;
+  args.parent = nullptr;
+  args.propagation_mask = 0;
+  args.cq = nullptr;
+  args.pollset_set_alternative = nullptr;
+  args.server_transport_data = transport_server_data;
+  args.add_initial_metadata = nullptr;
+  args.add_initial_metadata_count = 0;
+  args.send_deadline = GRPC_MILLIS_INF_FUTURE;
   grpc_call* call;
   grpc_error* error = grpc_call_create(&args, &call);
   grpc_call_element* elem =
@@ -840,8 +845,9 @@ static void accept_stream(void* cd, grpc_transport* transport,
   }
   call_data* calld = static_cast<call_data*>(elem->call_data);
   grpc_op op;
-  memset(&op, 0, sizeof(op));
   op.op = GRPC_OP_RECV_INITIAL_METADATA;
+  op.flags = 0;
+  op.reserved = nullptr;
   op.data.recv_initial_metadata.recv_initial_metadata =
       &calld->initial_metadata;
   GRPC_CLOSURE_INIT(&calld->got_initial_metadata, got_initial_metadata, elem,

--- a/src/core/lib/transport/metadata_batch.h
+++ b/src/core/lib/transport/metadata_batch.h
@@ -31,9 +31,11 @@
 #include "src/core/lib/transport/static_metadata.h"
 
 typedef struct grpc_linked_mdelem {
+  grpc_linked_mdelem() {}
+
   grpc_mdelem md;
-  struct grpc_linked_mdelem* next;
-  struct grpc_linked_mdelem* prev;
+  struct grpc_linked_mdelem* next = nullptr;
+  struct grpc_linked_mdelem* prev = nullptr;
   void* reserved;
 } grpc_linked_mdelem;
 

--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -81,16 +81,16 @@ void grpc_stream_unref(grpc_stream_refcount* refcount);
 grpc_slice grpc_slice_from_stream_owned_buffer(grpc_stream_refcount* refcount,
                                                void* buffer, size_t length);
 
-typedef struct {
-  uint64_t framing_bytes;
-  uint64_t data_bytes;
-  uint64_t header_bytes;
-} grpc_transport_one_way_stats;
+struct grpc_transport_one_way_stats {
+  uint64_t framing_bytes = 0;
+  uint64_t data_bytes = 0;
+  uint64_t header_bytes = 0;
+};
 
-typedef struct grpc_transport_stream_stats {
+struct grpc_transport_stream_stats {
   grpc_transport_one_way_stats incoming;
   grpc_transport_one_way_stats outgoing;
-} grpc_transport_stream_stats;
+};
 
 void grpc_transport_move_one_way_stats(grpc_transport_one_way_stats* from,
                                        grpc_transport_one_way_stats* to);
@@ -121,7 +121,16 @@ typedef struct grpc_transport_stream_op_batch_payload
 
 /* Transport stream op: a set of operations to perform on a transport
    against a single stream */
-typedef struct grpc_transport_stream_op_batch {
+struct grpc_transport_stream_op_batch {
+  grpc_transport_stream_op_batch()
+      : send_initial_metadata(false),
+        send_trailing_metadata(false),
+        send_message(false),
+        recv_initial_metadata(false),
+        recv_message(false),
+        recv_trailing_metadata(false),
+        cancel_stream(false) {}
+
   /** Should be scheduled when all of the non-recv operations in the batch
       are complete.
 
@@ -131,10 +140,10 @@ typedef struct grpc_transport_stream_op_batch {
       scheduled as soon as the non-recv ops are complete, regardless of
       whether or not the recv ops are complete.  If a batch contains
       only recv ops, on_complete can be null. */
-  grpc_closure* on_complete;
+  grpc_closure* on_complete = nullptr;
 
   /** Values for the stream op (fields set are determined by flags above) */
-  grpc_transport_stream_op_batch_payload* payload;
+  grpc_transport_stream_op_batch_payload* payload = nullptr;
 
   /** Send initial metadata to the peer, from the provided metadata batch. */
   bool send_initial_metadata : 1;
@@ -163,24 +172,33 @@ typedef struct grpc_transport_stream_op_batch {
    * current handler of the op */
 
   grpc_handler_private_op_data handler_private;
-} grpc_transport_stream_op_batch;
+};
 
 struct grpc_transport_stream_op_batch_payload {
+  explicit grpc_transport_stream_op_batch_payload(
+      grpc_call_context_element* context)
+      : context(context) {}
+  ~grpc_transport_stream_op_batch_payload() {
+    // We don't really own `send_message`, so release ownership and let the
+    // owner clean the data.
+    send_message.send_message.release();
+  }
+
   struct {
-    grpc_metadata_batch* send_initial_metadata;
+    grpc_metadata_batch* send_initial_metadata = nullptr;
     /** Iff send_initial_metadata != NULL, flags associated with
         send_initial_metadata: a bitfield of GRPC_INITIAL_METADATA_xxx */
-    uint32_t send_initial_metadata_flags;
+    uint32_t send_initial_metadata_flags = 0;
     // If non-NULL, will be set by the transport to the peer string (a char*).
     // The transport retains ownership of the string.
     // Note: This pointer may be used by the transport after the
     // send_initial_metadata op is completed.  It must remain valid
     // until the call is destroyed.
-    gpr_atm* peer_string;
+    gpr_atm* peer_string = nullptr;
   } send_initial_metadata;
 
   struct {
-    grpc_metadata_batch* send_trailing_metadata;
+    grpc_metadata_batch* send_trailing_metadata = nullptr;
   } send_trailing_metadata;
 
   struct {
@@ -192,39 +210,39 @@ struct grpc_transport_stream_op_batch_payload {
   } send_message;
 
   struct {
-    grpc_metadata_batch* recv_initial_metadata;
+    grpc_metadata_batch* recv_initial_metadata = nullptr;
     // Flags are used only on the server side.  If non-null, will be set to
     // a bitfield of the GRPC_INITIAL_METADATA_xxx macros (e.g., to
     // indicate if the call is idempotent).
-    uint32_t* recv_flags;
+    uint32_t* recv_flags = nullptr;
     /** Should be enqueued when initial metadata is ready to be processed. */
-    grpc_closure* recv_initial_metadata_ready;
+    grpc_closure* recv_initial_metadata_ready = nullptr;
     // If not NULL, will be set to true if trailing metadata is
     // immediately available.  This may be a signal that we received a
     // Trailers-Only response.
-    bool* trailing_metadata_available;
+    bool* trailing_metadata_available = nullptr;
     // If non-NULL, will be set by the transport to the peer string (a char*).
     // The transport retains ownership of the string.
     // Note: This pointer may be used by the transport after the
     // recv_initial_metadata op is completed.  It must remain valid
     // until the call is destroyed.
-    gpr_atm* peer_string;
+    gpr_atm* peer_string = nullptr;
   } recv_initial_metadata;
 
   struct {
     // Will be set by the transport to point to the byte stream
     // containing a received message.
     // Will be NULL if trailing metadata is received instead of a message.
-    grpc_core::OrphanablePtr<grpc_core::ByteStream>* recv_message;
+    grpc_core::OrphanablePtr<grpc_core::ByteStream>* recv_message = nullptr;
     /** Should be enqueued when one message is ready to be processed. */
-    grpc_closure* recv_message_ready;
+    grpc_closure* recv_message_ready = nullptr;
   } recv_message;
 
   struct {
-    grpc_metadata_batch* recv_trailing_metadata;
-    grpc_transport_stream_stats* collect_stats;
+    grpc_metadata_batch* recv_trailing_metadata = nullptr;
+    grpc_transport_stream_stats* collect_stats = nullptr;
     /** Should be enqueued when initial metadata is ready to be processed. */
-    grpc_closure* recv_trailing_metadata_ready;
+    grpc_closure* recv_trailing_metadata_ready = nullptr;
   } recv_trailing_metadata;
 
   /** Forcefully close this stream.
@@ -240,7 +258,7 @@ struct grpc_transport_stream_op_batch_payload {
   struct {
     // Error contract: the transport that gets this op must cause cancel_error
     //                 to be unref'ed after processing it
-    grpc_error* cancel_error;
+    grpc_error* cancel_error = GRPC_ERROR_NONE;
   } cancel_stream;
 
   /* Indexes correspond to grpc_context_index enum values */

--- a/test/cpp/microbenchmarks/bm_call_create.cc
+++ b/test/cpp/microbenchmarks/bm_call_create.cc
@@ -468,7 +468,7 @@ class NoOp {
 
 class SendEmptyMetadata {
  public:
-  SendEmptyMetadata() {
+  SendEmptyMetadata() : op_payload_(nullptr) {
     memset(&op_, 0, sizeof(op_));
     op_.on_complete = GRPC_CLOSURE_INIT(&closure_, DoNothing, nullptr,
                                         grpc_schedule_on_exec_ctx);

--- a/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
@@ -778,8 +778,7 @@ static void free_timeout(void* p) { gpr_free(p); }
 // Benchmark the current on_initial_header implementation
 static void OnInitialHeader(void* user_data, grpc_mdelem md) {
   // Setup for benchmark. This will bloat the absolute values of this benchmark
-  grpc_chttp2_incoming_metadata_buffer buffer;
-  grpc_chttp2_incoming_metadata_buffer_init(&buffer, (gpr_arena*)user_data);
+  grpc_chttp2_incoming_metadata_buffer buffer((gpr_arena*)user_data);
   bool seen_error = false;
 
   // Below here is the code we actually care about benchmarking
@@ -822,7 +821,6 @@ static void OnInitialHeader(void* user_data, grpc_mdelem md) {
       GPR_ASSERT(0);
     }
   }
-  grpc_chttp2_incoming_metadata_buffer_destroy(&buffer);
 }
 
 // Benchmark timeout handling

--- a/test/cpp/microbenchmarks/bm_chttp2_transport.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_transport.cc
@@ -262,7 +262,7 @@ static void BM_StreamCreateDestroy(benchmark::State& state) {
   Fixture f(grpc::ChannelArguments(), true);
   Stream s(&f);
   grpc_transport_stream_op_batch op;
-  grpc_transport_stream_op_batch_payload op_payload;
+  grpc_transport_stream_op_batch_payload op_payload(nullptr);
   memset(&op, 0, sizeof(op));
   op.cancel_stream = true;
   op.payload = &op_payload;
@@ -308,8 +308,7 @@ static void BM_StreamCreateSendInitialMetadataDestroy(benchmark::State& state) {
   Fixture f(grpc::ChannelArguments(), true);
   Stream s(&f);
   grpc_transport_stream_op_batch op;
-  grpc_transport_stream_op_batch_payload op_payload;
-  memset(&op_payload, 0, sizeof(op_payload));
+  grpc_transport_stream_op_batch_payload op_payload(nullptr);
   std::unique_ptr<Closure> start;
   std::unique_ptr<Closure> done;
 
@@ -360,8 +359,7 @@ static void BM_TransportEmptyOp(benchmark::State& state) {
   Stream s(&f);
   s.Init(state);
   grpc_transport_stream_op_batch op;
-  grpc_transport_stream_op_batch_payload op_payload;
-  memset(&op_payload, 0, sizeof(op_payload));
+  grpc_transport_stream_op_batch_payload op_payload(nullptr);
   auto reset_op = [&]() {
     memset(&op, 0, sizeof(op));
     op.payload = &op_payload;
@@ -393,8 +391,7 @@ static void BM_TransportStreamSend(benchmark::State& state) {
   auto s = std::unique_ptr<Stream>(new Stream(&f));
   s->Init(state);
   grpc_transport_stream_op_batch op;
-  grpc_transport_stream_op_batch_payload op_payload;
-  memset(&op_payload, 0, sizeof(op_payload));
+  grpc_transport_stream_op_batch_payload op_payload(nullptr);
   auto reset_op = [&]() {
     memset(&op, 0, sizeof(op));
     op.payload = &op_payload;
@@ -526,8 +523,7 @@ static void BM_TransportStreamRecv(benchmark::State& state) {
   Fixture f(grpc::ChannelArguments(), true);
   Stream s(&f);
   s.Init(state);
-  grpc_transport_stream_op_batch_payload op_payload;
-  memset(&op_payload, 0, sizeof(op_payload));
+  grpc_transport_stream_op_batch_payload op_payload(nullptr);
   grpc_transport_stream_op_batch op;
   grpc_core::OrphanablePtr<grpc_core::ByteStream> recv_stream;
   grpc_slice incoming_data = CreateIncomingDataSlice(state.range(0), 16384);


### PR DESCRIPTION
Callers should properly initialize the memory.

Note that to avoid performance regressions we need some
reordering in the initialization of `grpc_call`.

This behavior can be overridden using `GRPC_ARENA_INIT_STRATEGY`
environment variable. 

I had two more changes in the following files which I will skip in the
PR because they are purely performance changes for cache
coherency. I will upload that as a separate patch once this PR
is merged:
src/core/lib/channel/channel_stack.cc
src/core/lib/surface/call.cc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/16944)
<!-- Reviewable:end -->
