### PR TITLE
Use grpc/grpc-node in Bazel builds; fix #16956

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -393,7 +393,7 @@ grpc_cc_library(
     srcs = [
         "src/compiler/cpp_generator.cc",
         "src/compiler/csharp_generator.cc",
-        "src/compiler/node_generator.cc",
+        "//third_party/grpc-node:node_generator_cc",
         "src/compiler/objective_c_generator.cc",
         "src/compiler/php_generator.cc",
         "src/compiler/python_generator.cc",
@@ -406,8 +406,8 @@ grpc_cc_library(
         "src/compiler/csharp_generator.h",
         "src/compiler/csharp_generator_helpers.h",
         "src/compiler/generator_helpers.h",
-        "src/compiler/node_generator.h",
-        "src/compiler/node_generator_helpers.h",
+        "//third_party/grpc-node:node_generator_h",
+        "//third_party/grpc-node:node_generator_helpers_h",
         "src/compiler/objective_c_generator.h",
         "src/compiler/objective_c_generator_helpers.h",
         "src/compiler/php_generator.h",
@@ -445,7 +445,7 @@ grpc_proto_plugin(
 
 grpc_proto_plugin(
     name = "grpc_node_plugin",
-    srcs = ["src/compiler/node_plugin.cc"],
+    srcs = ["//third_party/grpc-node:node_plugin_cc"],
     deps = [":grpc_plugin_support"],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -43,3 +43,12 @@ git_repository(
 
 load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_repositories")
 py_proto_repositories()
+
+
+http_archive(
+    name="grpc_grpc_node",
+    urls=[
+        "https://github.com/graknlabs/grpc-node/archive/bazel-migration.tar.gz",
+    ],
+    strip_prefix="grpc-node-bazel-migration",
+)

--- a/third_party/grpc-node/BUILD
+++ b/third_party/grpc-node/BUILD
@@ -1,0 +1,42 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+
+sh_binary(
+	name = "update_includes",
+	srcs = ["update_includes.sh"]
+)
+
+genrule(
+	name = "node_generator_cc",
+	srcs = ["@grpc_grpc_node//:node_generator_cc"],
+	cmd = "$(location :update_includes) $< $@",
+	tools = [":update_includes"],
+	outs = ["src/compiler/node_generator.cc"]
+)
+
+genrule(
+	name = "node_plugin_cc",
+	srcs = ["@grpc_grpc_node//:node_plugin_cc"],
+	cmd = "$(location :update_includes) $< $@",
+	tools = [":update_includes"],
+	outs = ["src/compiler/node_plugin.cc"]
+)
+
+
+genrule(
+	name = "node_generator_h",
+	srcs = ["@grpc_grpc_node//:node_generator_h"],
+	cmd = "$(location :update_includes) $< $@",
+	tools = [":update_includes"],
+	outs = ["node_generator.h"]
+)
+
+genrule(
+	name = "node_generator_helpers_h",
+	srcs = ["@grpc_grpc_node//:node_generator_helpers_h"],
+	cmd = "$(location :update_includes) $< $@",
+	tools = [":update_includes"],
+	outs = ["node_generator_helpers.h"]
+)

--- a/third_party/grpc-node/update_includes.sh
+++ b/third_party/grpc-node/update_includes.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Rewrites C++ #include statements so external files could be used
+
+COMPILER_PACKAGE="src/compiler"
+THIRD_PARTY_PACKAGE="third_party/grpc-node"
+
+sed -i -e 's|#include "config.h"|#include "'$COMPILER_PACKAGE'/config.h"|g' $1
+sed -i -e 's|#include "generator_helpers.h"|#include "'$COMPILER_PACKAGE'/generator_helpers.h"|g' $1
+sed -i -e 's|#include "node_generator.h"|#include "'$THIRD_PARTY_PACKAGE'/node_generator.h"|g' $1
+sed -i -e 's|#include "node_generator_helpers.h"|#include "'$THIRD_PARTY_PACKAGE'/node_generator_helpers.h"|g' $1
+cp $1 $2

--- a/third_party/grpc_node.BUILD
+++ b/third_party/grpc_node.BUILD
@@ -1,0 +1,21 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+	name = "node_generator_cc",
+	srcs = ["packages/grpc-tools/src/node_generator.cc"]
+)
+
+filegroup(
+	name = "node_plugin_cc",
+	srcs = ["packages/grpc-tools/src/node_plugin.cc"]
+)
+
+filegroup(
+	name = "node_generator_h",
+	srcs = ["packages/grpc-tools/src/node_generator.h"]	
+)
+
+filegroup(
+	name = "node_generator_helpers_h",
+	srcs = ["packages/grpc-tools/src/node_generator_helpers.h"]	
+)


### PR DESCRIPTION
https://github.com/graknlabs/grpc/blob/use-grpc-node/WORKSPACE#L51
to be replaced with `grpc/grpc-node` link when grpc/grpc-node#581 is merged