### PR TITLE
C++ benchmark: build C++ with assembly optimizations

### DIFF
--- a/tools/run_tests/performance/build_performance.sh
+++ b/tools/run_tests/performance/build_performance.sh
@@ -25,10 +25,16 @@ CONFIG=${CONFIG:-opt}
 # TODO(jtattermusch): C++ worker and driver are not buildable on Windows yet
 if [ "$OSTYPE" != "msys" ]
 then
-  # TODO(jtattermusch): not embedding OpenSSL breaks the C# build because
-  # grpc_csharp_ext needs OpenSSL embedded and some intermediate files from
-  # this build will be reused.
-  make CONFIG="${CONFIG}" EMBED_OPENSSL=true EMBED_ZLIB=true qps_worker qps_json_driver -j8
+  # build C++ with cmake as building with "make" disables boringssl assembly
+  # optimizations that can have huge impact on secure channel throughput.
+  mkdir -p cmake/build
+  cd cmake/build
+  cmake -DgRPC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release ../..
+  make qps_worker qps_json_driver -j8
+  cd ../..
+  # unbreak subsequent make builds by restoring zconf.h (previously renamed by cmake build)
+  # See https://github.com/grpc/grpc/issues/11581
+  (cd third_party/zlib; git checkout zconf.h)
 fi
 
 PHP_ALREADY_BUILT=""

--- a/tools/run_tests/performance/run_qps_driver.sh
+++ b/tools/run_tests/performance/run_qps_driver.sh
@@ -17,7 +17,7 @@ set -ex
 
 cd "$(dirname "$0")/../../.."
 
-bins/opt/qps_json_driver "$@"
+cmake/build/qps_json_driver "$@"
 
 if [ "$BQ_RESULT_TABLE" != "" ]
 then

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -250,7 +250,7 @@ class CXXLanguage:
             channels=1,
             num_clients=1,
             secure=False,
-            categories=[SMOKETEST] + [INPROC] + [SCALABLE])
+            categories=[INPROC] + [SCALABLE])
 
         yield _ping_pong_scenario(
             'cpp_protobuf_async_streaming_from_client_1channel_1MB',
@@ -280,12 +280,12 @@ class CXXLanguage:
             secure=False,
             async_server_threads=16,
             server_threads_per_cq=1,
-            categories=[SMOKETEST] + [SCALABLE])
+            categories=[SCALABLE])
 
         for secure in [True, False]:
             secstr = 'secure' if secure else 'insecure'
-            smoketest_categories = ([SMOKETEST]
-                                    if secure else [INPROC]) + [SCALABLE]
+            smoketest_categories = ([SMOKETEST] if secure else [])
+            inproc_categories = ([INPROC] if not secure else [])
 
             yield _ping_pong_scenario(
                 'cpp_generic_async_streaming_ping_pong_%s' % secstr,
@@ -295,7 +295,8 @@ class CXXLanguage:
                 use_generic_payload=True,
                 async_server_threads=1,
                 secure=secure,
-                categories=smoketest_categories)
+                categories=smoketest_categories + inproc_categories +
+                [SCALABLE])
 
             yield _ping_pong_scenario(
                 'cpp_generic_async_streaming_qps_unconstrained_%s' % secstr,
@@ -306,7 +307,8 @@ class CXXLanguage:
                 use_generic_payload=True,
                 secure=secure,
                 minimal_stack=not secure,
-                categories=smoketest_categories + [SCALABLE])
+                categories=smoketest_categories + inproc_categories +
+                [SCALABLE])
 
             for mps in geometric_progression(1, 20, 10):
                 yield _ping_pong_scenario(
@@ -320,7 +322,8 @@ class CXXLanguage:
                     secure=secure,
                     messages_per_stream=mps,
                     minimal_stack=not secure,
-                    categories=smoketest_categories + [SCALABLE])
+                    categories=smoketest_categories + inproc_categories +
+                    [SCALABLE])
 
             for mps in geometric_progression(1, 200, math.sqrt(10)):
                 yield _ping_pong_scenario(
@@ -347,7 +350,7 @@ class CXXLanguage:
                 use_generic_payload=True,
                 secure=secure,
                 minimal_stack=not secure,
-                categories=smoketest_categories + [SCALABLE],
+                categories=inproc_categories + [SCALABLE],
                 channels=1,
                 outstanding=100)
 
@@ -363,7 +366,7 @@ class CXXLanguage:
                 use_generic_payload=True,
                 secure=secure,
                 minimal_stack=not secure,
-                categories=smoketest_categories + [SCALABLE])
+                categories=inproc_categories + [SCALABLE])
 
             yield _ping_pong_scenario(
                 'cpp_generic_async_streaming_qps_unconstrained_1cq_%s' % secstr,
@@ -375,7 +378,8 @@ class CXXLanguage:
                 secure=secure,
                 client_threads_per_cq=1000000,
                 server_threads_per_cq=1000000,
-                categories=smoketest_categories + [SCALABLE])
+                categories=smoketest_categories + inproc_categories +
+                [SCALABLE])
 
             yield _ping_pong_scenario(
                 'cpp_generic_async_streaming_qps_unconstrained_2waysharedcq_%s'
@@ -388,7 +392,7 @@ class CXXLanguage:
                 secure=secure,
                 client_threads_per_cq=2,
                 server_threads_per_cq=2,
-                categories=smoketest_categories + [SCALABLE])
+                categories=inproc_categories + [SCALABLE])
 
             yield _ping_pong_scenario(
                 'cpp_protobuf_async_streaming_qps_unconstrained_1cq_%s' %
@@ -400,7 +404,7 @@ class CXXLanguage:
                 secure=secure,
                 client_threads_per_cq=1000000,
                 server_threads_per_cq=1000000,
-                categories=smoketest_categories + [SCALABLE])
+                categories=inproc_categories + [SCALABLE])
 
             yield _ping_pong_scenario(
                 'cpp_protobuf_async_streaming_qps_unconstrained_2waysharedcq_%s'
@@ -412,7 +416,7 @@ class CXXLanguage:
                 secure=secure,
                 client_threads_per_cq=2,
                 server_threads_per_cq=2,
-                categories=smoketest_categories + [SCALABLE])
+                categories=inproc_categories + [SCALABLE])
 
             yield _ping_pong_scenario(
                 'cpp_protobuf_async_unary_qps_unconstrained_1cq_%s' % secstr,
@@ -423,7 +427,8 @@ class CXXLanguage:
                 secure=secure,
                 client_threads_per_cq=1000000,
                 server_threads_per_cq=1000000,
-                categories=smoketest_categories + [SCALABLE])
+                categories=smoketest_categories + inproc_categories +
+                [SCALABLE])
 
             yield _ping_pong_scenario(
                 'cpp_protobuf_async_unary_qps_unconstrained_2waysharedcq_%s' %
@@ -435,7 +440,7 @@ class CXXLanguage:
                 secure=secure,
                 client_threads_per_cq=2,
                 server_threads_per_cq=2,
-                categories=smoketest_categories + [SCALABLE])
+                categories=inproc_categories + [SCALABLE])
 
             yield _ping_pong_scenario(
                 'cpp_generic_async_streaming_qps_one_server_core_%s' % secstr,
@@ -457,7 +462,8 @@ class CXXLanguage:
                 unconstrained_client='async',
                 secure=secure,
                 minimal_stack=not secure,
-                categories=smoketest_categories + [SCALABLE],
+                categories=smoketest_categories + inproc_categories +
+                [SCALABLE],
                 excluded_poll_engines=['poll-cv'])
 
             yield _ping_pong_scenario(
@@ -472,7 +478,7 @@ class CXXLanguage:
                 resp_size=8 * 1024 * 1024,
                 secure=secure,
                 minimal_stack=not secure,
-                categories=smoketest_categories + [SCALABLE])
+                categories=inproc_categories + [SCALABLE])
 
             yield _ping_pong_scenario(
                 'cpp_protobuf_async_client_sync_server_streaming_qps_unconstrained_%s'
@@ -483,7 +489,8 @@ class CXXLanguage:
                 unconstrained_client='async',
                 secure=secure,
                 minimal_stack=not secure,
-                categories=smoketest_categories + [SCALABLE],
+                categories=smoketest_categories + inproc_categories +
+                [SCALABLE],
                 excluded_poll_engines=['poll-cv'])
 
             yield _ping_pong_scenario(
@@ -495,7 +502,8 @@ class CXXLanguage:
                 resp_size=1024 * 1024,
                 secure=secure,
                 minimal_stack=not secure,
-                categories=smoketest_categories + [SCALABLE])
+                categories=smoketest_categories + inproc_categories +
+                [SCALABLE])
 
             for rpc_type in [
                     'unary', 'streaming', 'streaming_from_client',
@@ -538,7 +546,7 @@ class CXXLanguage:
                         minimal_stack=not secure,
                         server_threads_per_cq=3,
                         client_threads_per_cq=3,
-                        categories=smoketest_categories + [SCALABLE])
+                        categories=inproc_categories + [SCALABLE])
 
                     # TODO(vjpai): Re-enable this test. It has a lot of timeouts
                     # and hasn't yet been conclusively identified as a test failure
@@ -565,7 +573,7 @@ class CXXLanguage:
                                 secure=secure,
                                 messages_per_stream=mps,
                                 minimal_stack=not secure,
-                                categories=smoketest_categories + [SCALABLE])
+                                categories=inproc_categories + [SCALABLE])
 
                         for mps in geometric_progression(1, 200, math.sqrt(10)):
                             yield _ping_pong_scenario(

--- a/tools/run_tests/performance/scenario_config.py
+++ b/tools/run_tests/performance/scenario_config.py
@@ -231,7 +231,7 @@ class CXXLanguage:
         self.safename = 'cxx'
 
     def worker_cmdline(self):
-        return ['bins/opt/qps_worker']
+        return ['cmake/build/qps_worker']
 
     def worker_port_offset(self):
         return 0

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -41,6 +41,11 @@ os.chdir(_ROOT)
 
 _REMOTE_HOST_USERNAME = 'jenkins'
 
+_SCENARIO_TIMEOUT = 3 * 60
+_WORKER_TIMEOUT = 3 * 60
+_NETPERF_TIMEOUT = 60
+_QUIT_WORKER_TIMEOUT = 2 * 60
+
 
 class QpsWorkerJob:
     """Encapsulates a qps worker server job."""
@@ -85,7 +90,7 @@ def create_qpsworker_job(language,
         cmdline = perf_cmd + ['-o', '%s-perf.data' % perf_file_base_name
                              ] + cmdline
 
-    worker_timeout = 3 * 60
+    worker_timeout = _WORKER_TIMEOUT
     if remote_host:
         user_at_host = '%s@%s' % (_REMOTE_HOST_USERNAME, remote_host)
         ssh_cmd = ['ssh']
@@ -131,7 +136,7 @@ def create_scenario_jobspec(scenario_json,
     return jobset.JobSpec(
         cmdline=[cmd],
         shortname='qps_json_driver.%s' % scenario_json['name'],
-        timeout_seconds=12 * 60,
+        timeout_seconds=_SCENARIO_TIMEOUT,
         shell=True,
         verbose_success=True)
 
@@ -149,7 +154,7 @@ def create_quit_jobspec(workers, remote_host=None):
     return jobset.JobSpec(
         cmdline=[cmd],
         shortname='qps_json_driver.quit',
-        timeout_seconds=3 * 60,
+        timeout_seconds=_QUIT_WORKER_TIMEOUT,
         shell=True,
         verbose_success=True)
 
@@ -181,7 +186,7 @@ def create_netperf_jobspec(server_host='localhost',
     return jobset.JobSpec(
         cmdline=[cmd],
         shortname='netperf',
-        timeout_seconds=60,
+        timeout_seconds=_NETPERF_TIMEOUT,
         shell=True,
         verbose_success=True)
 

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -144,7 +144,7 @@ def create_scenario_jobspec(scenario_json,
 def create_quit_jobspec(workers, remote_host=None):
     """Runs quit using QPS driver."""
     # setting QPS_WORKERS env variable here makes sure it works with SSH too.
-    cmd = 'QPS_WORKERS="%s" bins/opt/qps_json_driver --quit' % ','.join(
+    cmd = 'QPS_WORKERS="%s" cmake/build/qps_json_driver --quit' % ','.join(
         w.host_and_port for w in workers)
     if remote_host:
         user_at_host = '%s@%s' % (_REMOTE_HOST_USERNAME, remote_host)


### PR DESCRIPTION
Based on #16957.

Right now we are building C++ qps_worker in e2e benchmarks with make, which disables boringssl assembly optimizations. We should see much better numbers for secure channel when building with cmake.

https://github.com/grpc/grpc/blob/master/doc/ssl-performance.md