### PR TITLE
In gRPC-C++ podspec, copy the certificate to bundle resources

### DIFF
--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -69,7 +69,7 @@ Pod::Spec.new do |s|
 
   s.default_subspecs = 'Interface', 'Implementation'
 
-  # Certificates, to be able to establish TLS connections:
+  # Certificates, to be able to establish TLS connections
   s.resource_bundles = { 'gRPCCertificates' => ['etc/roots.pem'] }
 
   s.header_mappings_dir = 'include/grpcpp'

--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -69,6 +69,9 @@ Pod::Spec.new do |s|
 
   s.default_subspecs = 'Interface', 'Implementation'
 
+  # Certificates, to be able to establish TLS connections:
+  s.resource_bundles = { 'gRPCCertificates' => ['etc/roots.pem'] }
+
   s.header_mappings_dir = 'include/grpcpp'
 
   s.subspec 'Interface' do |ss|
@@ -269,7 +272,6 @@ Pod::Spec.new do |s|
                       'src/core/ext/filters/http/message_compress/message_compress_filter.h',
                       'src/core/ext/filters/http/server/http_server_filter.h',
                       'src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.h',
-                      'src/core/ext/filters/client_channel/lb_policy/xds/xds.h',
                       'src/core/lib/security/context/security_context.h',
                       'src/core/lib/security/credentials/alts/alts_credentials.h',
                       'src/core/lib/security/credentials/composite/composite_credentials.h',
@@ -496,13 +498,10 @@ Pod::Spec.new do |s|
                       'src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.h',
                       'src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_client_stats.h',
                       'src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.h',
-                      'src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h',
                       'src/core/ext/filters/client_channel/lb_policy/grpclb/proto/grpc/lb/v1/google/protobuf/duration.pb.h',
                       'src/core/ext/filters/client_channel/lb_policy/grpclb/proto/grpc/lb/v1/google/protobuf/timestamp.pb.h',
                       'src/core/ext/filters/client_channel/lb_policy/grpclb/proto/grpc/lb/v1/load_balancer.pb.h',
-                      'src/core/ext/filters/client_channel/lb_policy/xds/xds_channel.h',
-                      'src/core/ext/filters/client_channel/lb_policy/xds/xds_client_stats.h',
-                      'src/core/ext/filters/client_channel/lb_policy/xds/xds_load_balancer_api.h',
+                      'src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h',
                       'src/core/ext/filters/client_channel/lb_policy/subchannel_list.h',
                       'src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h',
                       'src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h',

--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -69,7 +69,7 @@ Pod::Spec.new do |s|
 
   s.default_subspecs = 'Interface', 'Implementation'
 
-  # Certificates, to be able to establish TLS connections
+  # Certificates, to be able to establish TLS connections:
   s.resource_bundles = { 'gRPCCertificates' => ['etc/roots.pem'] }
 
   s.header_mappings_dir = 'include/grpcpp'
@@ -272,6 +272,7 @@ Pod::Spec.new do |s|
                       'src/core/ext/filters/http/message_compress/message_compress_filter.h',
                       'src/core/ext/filters/http/server/http_server_filter.h',
                       'src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.h',
+                      'src/core/ext/filters/client_channel/lb_policy/xds/xds.h',
                       'src/core/lib/security/context/security_context.h',
                       'src/core/lib/security/credentials/alts/alts_credentials.h',
                       'src/core/lib/security/credentials/composite/composite_credentials.h',
@@ -498,10 +499,13 @@ Pod::Spec.new do |s|
                       'src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.h',
                       'src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_client_stats.h',
                       'src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.h',
+                      'src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h',
                       'src/core/ext/filters/client_channel/lb_policy/grpclb/proto/grpc/lb/v1/google/protobuf/duration.pb.h',
                       'src/core/ext/filters/client_channel/lb_policy/grpclb/proto/grpc/lb/v1/google/protobuf/timestamp.pb.h',
                       'src/core/ext/filters/client_channel/lb_policy/grpclb/proto/grpc/lb/v1/load_balancer.pb.h',
-                      'src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h',
+                      'src/core/ext/filters/client_channel/lb_policy/xds/xds_channel.h',
+                      'src/core/ext/filters/client_channel/lb_policy/xds/xds_client_stats.h',
+                      'src/core/ext/filters/client_channel/lb_policy/xds/xds_load_balancer_api.h',
                       'src/core/ext/filters/client_channel/lb_policy/subchannel_list.h',
                       'src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h',
                       'src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h',

--- a/templates/gRPC-C++.podspec.template
+++ b/templates/gRPC-C++.podspec.template
@@ -177,6 +177,9 @@
 
     s.default_subspecs = 'Interface', 'Implementation'
 
+    # Certificates, to be able to establish TLS connections:
+    s.resource_bundles = { 'gRPCCertificates' => ['etc/roots.pem'] }
+
     s.header_mappings_dir = 'include/grpcpp'
 
     s.subspec 'Interface' do |ss|


### PR DESCRIPTION
In [`GRPC.podspec`](https://github.com/grpc/grpc/blob/master/gRPC.podspec#L47-L48), the root certificates file from `etc/roots.pem` is copied to the bundle resources, so that it can be loaded at runtime for SSL to function properly. However, `roots.pem` is not preserved in `gRPC-C++.podspec`, so a project depending on that pod won't be able to establish SSL connections. Having the project maintain its own copy of the certificates file and keep it in sync with gRPC repo is undesirable.