### PR TITLE
Remove C# from coverage suite (to make the suite green again)

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1515,7 +1515,7 @@ else:
     lang_list = args.language
 # We don't support code coverage on some languages
 if 'gcov' in args.config:
-    for bad in ['grpc-node', 'objc', 'sanity']:
+    for bad in ['csharp', 'grpc-node', 'objc', 'sanity']:
         if bad in lang_list:
             lang_list.remove(bad)
 


### PR DESCRIPTION
The coverage suite is currently broken because C# has transitioned to a cmake-based build.
We haven't really been looking at the coverage reports in the past and they way they are setup for C# is outdated anyway, so removing C# from the code coverage suite seems fine.

The log of broken code coverage suite (caused by the c# cmake build):
https://source.cloud.google.com/results/invocations/e5697e67-12d8-41ef-b168-db9381babf19/log