### PR TITLE
Surface exceptions from Cython to Python as much as possible

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
@@ -15,7 +15,7 @@
 
 cdef class CallCredentials:
 
-  cdef grpc_call_credentials *c(self)
+  cdef grpc_call_credentials *c(self) except *
 
   # TODO(https://github.com/grpc/grpc/issues/12531): remove.
   cdef grpc_call_credentials *c_credentials
@@ -36,7 +36,7 @@ cdef class MetadataPluginCallCredentials(CallCredentials):
   cdef readonly object _metadata_plugin
   cdef readonly bytes _name
 
-  cdef grpc_call_credentials *c(self)
+  cdef grpc_call_credentials *c(self) except *
 
 
 cdef grpc_call_credentials *_composition(call_credentialses)
@@ -46,12 +46,12 @@ cdef class CompositeCallCredentials(CallCredentials):
 
   cdef readonly tuple _call_credentialses
 
-  cdef grpc_call_credentials *c(self)
+  cdef grpc_call_credentials *c(self) except *
 
 
 cdef class ChannelCredentials:
 
-  cdef grpc_channel_credentials *c(self)
+  cdef grpc_channel_credentials *c(self) except *
 
   # TODO(https://github.com/grpc/grpc/issues/12531): remove.
   cdef grpc_channel_credentials *c_credentials
@@ -68,7 +68,7 @@ cdef class SSLChannelCredentials(ChannelCredentials):
   cdef readonly object _private_key
   cdef readonly object _certificate_chain
 
-  cdef grpc_channel_credentials *c(self)
+  cdef grpc_channel_credentials *c(self) except *
 
 
 cdef class CompositeChannelCredentials(ChannelCredentials):
@@ -76,7 +76,7 @@ cdef class CompositeChannelCredentials(ChannelCredentials):
   cdef readonly tuple _call_credentialses
   cdef readonly ChannelCredentials _channel_credentials
 
-  cdef grpc_channel_credentials *c(self)
+  cdef grpc_channel_credentials *c(self) except *
 
 
 cdef class ServerCertificateConfig:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -35,7 +35,7 @@ def _spawn_callback_async(callback, args):
 
 cdef class CallCredentials:
 
-  cdef grpc_call_credentials *c(self):
+  cdef grpc_call_credentials *c(self) except *:
     raise NotImplementedError()
 
 
@@ -69,7 +69,7 @@ cdef class MetadataPluginCallCredentials(CallCredentials):
     self._metadata_plugin = metadata_plugin
     self._name = name
 
-  cdef grpc_call_credentials *c(self):
+  cdef grpc_call_credentials *c(self) except *:
     cdef grpc_metadata_credentials_plugin c_metadata_plugin
     c_metadata_plugin.get_metadata = _get_metadata
     c_metadata_plugin.destroy = _destroy
@@ -101,13 +101,13 @@ cdef class CompositeCallCredentials(CallCredentials):
   def __cinit__(self, call_credentialses):
     self._call_credentialses = call_credentialses
 
-  cdef grpc_call_credentials *c(self):
+  cdef grpc_call_credentials *c(self) except *:
     return _composition(self._call_credentialses)
 
 
 cdef class ChannelCredentials:
 
-  cdef grpc_channel_credentials *c(self):
+  cdef grpc_channel_credentials *c(self) except *:
     raise NotImplementedError()
 
 
@@ -135,7 +135,7 @@ cdef class SSLChannelCredentials(ChannelCredentials):
     self._private_key = private_key
     self._certificate_chain = certificate_chain
 
-  cdef grpc_channel_credentials *c(self):
+  cdef grpc_channel_credentials *c(self) except *:
     cdef const char *c_pem_root_certificates
     cdef grpc_ssl_pem_key_cert_pair c_pem_key_certificate_pair
     if self._pem_root_certificates is None:
@@ -164,7 +164,7 @@ cdef class CompositeChannelCredentials(ChannelCredentials):
     self._call_credentialses = call_credentialses
     self._channel_credentials = channel_credentials
 
-  cdef grpc_channel_credentials *c(self):
+  cdef grpc_channel_credentials *c(self) except *:
     cdef grpc_channel_credentials *c_channel_credentials
     c_channel_credentials = self._channel_credentials.c()
     cdef grpc_call_credentials *c_call_credentials_composition = _composition(

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx.pxi
@@ -266,7 +266,7 @@ cdef grpc_error* socket_listen(grpc_custom_socket* socket) with gil:
   (<SocketWrapper>socket.impl).socket.listen(50)
   return grpc_error_none()
 
-cdef void accept_callback_cython(SocketWrapper s):
+cdef void accept_callback_cython(SocketWrapper s) except *:
    try:
      conn, address = s.socket.accept()
      sw = SocketWrapper()

--- a/src/python/grpcio/grpc/_cython/_cygrpc/metadata.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/metadata.pxd.pxi
@@ -14,10 +14,10 @@
 
 
 cdef void _store_c_metadata(
-    metadata, grpc_metadata **c_metadata, size_t *c_count)
+    metadata, grpc_metadata **c_metadata, size_t *c_count) except *
 
 
-cdef void _release_c_metadata(grpc_metadata *c_metadata, int count)
+cdef void _release_c_metadata(grpc_metadata *c_metadata, int count) except *
 
 
 cdef tuple _metadatum(grpc_slice key_slice, grpc_slice value_slice)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/metadata.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/metadata.pyx.pxi
@@ -25,7 +25,7 @@ _Metadatum = collections.namedtuple('_Metadatum', ('key', 'value',))
 
 
 cdef void _store_c_metadata(
-    metadata, grpc_metadata **c_metadata, size_t *c_count):
+    metadata, grpc_metadata **c_metadata, size_t *c_count) except *:
   if metadata is None:
     c_count[0] = 0
     c_metadata[0] = NULL
@@ -45,7 +45,7 @@ cdef void _store_c_metadata(
         c_metadata[0][index].value = _slice_from_bytes(encoded_value)
 
 
-cdef void _release_c_metadata(grpc_metadata *c_metadata, int count):
+cdef void _release_c_metadata(grpc_metadata *c_metadata, int count) except *:
   if 0 < count:
     for index in range(count):
       grpc_slice_unref(c_metadata[index].key)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/operation.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/operation.pxd.pxi
@@ -15,8 +15,8 @@
 
 cdef class Operation:
 
-  cdef void c(self)
-  cdef void un_c(self)
+  cdef void c(self) except *
+  cdef void un_c(self) except *
 
   # TODO(https://github.com/grpc/grpc/issues/7950): Eliminate this!
   cdef grpc_op c_op
@@ -29,8 +29,8 @@ cdef class SendInitialMetadataOperation(Operation):
   cdef grpc_metadata *_c_initial_metadata
   cdef size_t _c_initial_metadata_count
 
-  cdef void c(self)
-  cdef void un_c(self)
+  cdef void c(self) except *
+  cdef void un_c(self) except *
 
 
 cdef class SendMessageOperation(Operation):
@@ -39,16 +39,16 @@ cdef class SendMessageOperation(Operation):
   cdef readonly int _flags
   cdef grpc_byte_buffer *_c_message_byte_buffer
 
-  cdef void c(self)
-  cdef void un_c(self)
+  cdef void c(self) except *
+  cdef void un_c(self) except *
 
 
 cdef class SendCloseFromClientOperation(Operation):
 
   cdef readonly int _flags
 
-  cdef void c(self)
-  cdef void un_c(self)
+  cdef void c(self) except *
+  cdef void un_c(self) except *
 
 
 cdef class SendStatusFromServerOperation(Operation):
@@ -61,8 +61,8 @@ cdef class SendStatusFromServerOperation(Operation):
   cdef size_t _c_trailing_metadata_count
   cdef grpc_slice _c_details
 
-  cdef void c(self)
-  cdef void un_c(self)
+  cdef void c(self) except *
+  cdef void un_c(self) except *
 
 
 cdef class ReceiveInitialMetadataOperation(Operation):
@@ -71,8 +71,8 @@ cdef class ReceiveInitialMetadataOperation(Operation):
   cdef tuple _initial_metadata
   cdef grpc_metadata_array _c_initial_metadata
 
-  cdef void c(self)
-  cdef void un_c(self)
+  cdef void c(self) except *
+  cdef void un_c(self) except *
 
 
 cdef class ReceiveMessageOperation(Operation):
@@ -81,8 +81,8 @@ cdef class ReceiveMessageOperation(Operation):
   cdef grpc_byte_buffer *_c_message_byte_buffer
   cdef bytes _message
 
-  cdef void c(self)
-  cdef void un_c(self)
+  cdef void c(self) except *
+  cdef void un_c(self) except *
 
 
 cdef class ReceiveStatusOnClientOperation(Operation):
@@ -97,8 +97,8 @@ cdef class ReceiveStatusOnClientOperation(Operation):
   cdef str _details
   cdef str _error_string
 
-  cdef void c(self)
-  cdef void un_c(self)
+  cdef void c(self) except *
+  cdef void un_c(self) except *
 
 
 cdef class ReceiveCloseOnServerOperation(Operation):
@@ -107,5 +107,5 @@ cdef class ReceiveCloseOnServerOperation(Operation):
   cdef object _cancelled
   cdef int _c_cancelled
 
-  cdef void c(self)
-  cdef void un_c(self)
+  cdef void c(self) except *
+  cdef void un_c(self) except *

--- a/src/python/grpcio/grpc/_cython/_cygrpc/operation.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/operation.pyx.pxi
@@ -15,10 +15,10 @@
 
 cdef class Operation:
 
-  cdef void c(self):
+  cdef void c(self) except *:
     raise NotImplementedError()
 
-  cdef void un_c(self):
+  cdef void un_c(self) except *:
     raise NotImplementedError()
 
 
@@ -31,7 +31,7 @@ cdef class SendInitialMetadataOperation(Operation):
   def type(self):
     return GRPC_OP_SEND_INITIAL_METADATA
 
-  cdef void c(self):
+  cdef void c(self) except *:
     self.c_op.type = GRPC_OP_SEND_INITIAL_METADATA
     self.c_op.flags = self._flags
     _store_c_metadata(
@@ -41,7 +41,7 @@ cdef class SendInitialMetadataOperation(Operation):
     self.c_op.data.send_initial_metadata.count = self._c_initial_metadata_count
     self.c_op.data.send_initial_metadata.maybe_compression_level.is_set = 0
 
-  cdef void un_c(self):
+  cdef void un_c(self) except *:
     _release_c_metadata(
         self._c_initial_metadata, self._c_initial_metadata_count)
 
@@ -55,7 +55,7 @@ cdef class SendMessageOperation(Operation):
   def type(self):
     return GRPC_OP_SEND_MESSAGE
 
-  cdef void c(self):
+  cdef void c(self) except *:
     self.c_op.type = GRPC_OP_SEND_MESSAGE
     self.c_op.flags = self._flags
     cdef grpc_slice message_slice = grpc_slice_from_copied_buffer(
@@ -65,7 +65,7 @@ cdef class SendMessageOperation(Operation):
     grpc_slice_unref(message_slice)
     self.c_op.data.send_message.send_message = self._c_message_byte_buffer
 
-  cdef void un_c(self):
+  cdef void un_c(self) except *:
     grpc_byte_buffer_destroy(self._c_message_byte_buffer)
 
 
@@ -77,11 +77,11 @@ cdef class SendCloseFromClientOperation(Operation):
   def type(self):
     return GRPC_OP_SEND_CLOSE_FROM_CLIENT
 
-  cdef void c(self):
+  cdef void c(self) except *:
     self.c_op.type = GRPC_OP_SEND_CLOSE_FROM_CLIENT
     self.c_op.flags = self._flags
 
-  cdef void un_c(self):
+  cdef void un_c(self) except *:
     pass
 
 
@@ -96,7 +96,7 @@ cdef class SendStatusFromServerOperation(Operation):
   def type(self):
     return GRPC_OP_SEND_STATUS_FROM_SERVER
 
-  cdef void c(self):
+  cdef void c(self) except *:
     self.c_op.type = GRPC_OP_SEND_STATUS_FROM_SERVER
     self.c_op.flags = self._flags
     _store_c_metadata(
@@ -110,7 +110,7 @@ cdef class SendStatusFromServerOperation(Operation):
     self._c_details = _slice_from_bytes(_encode(self._details))
     self.c_op.data.send_status_from_server.status_details = &self._c_details
 
-  cdef void un_c(self):
+  cdef void un_c(self) except *:
     grpc_slice_unref(self._c_details)
     _release_c_metadata(
         self._c_trailing_metadata, self._c_trailing_metadata_count)
@@ -124,14 +124,14 @@ cdef class ReceiveInitialMetadataOperation(Operation):
   def type(self):
     return GRPC_OP_RECV_INITIAL_METADATA
 
-  cdef void c(self):
+  cdef void c(self) except *:
     self.c_op.type = GRPC_OP_RECV_INITIAL_METADATA
     self.c_op.flags = self._flags
     grpc_metadata_array_init(&self._c_initial_metadata)
     self.c_op.data.receive_initial_metadata.receive_initial_metadata = (
         &self._c_initial_metadata)
 
-  cdef void un_c(self):
+  cdef void un_c(self) except *:
     self._initial_metadata = _metadata(&self._c_initial_metadata)
     grpc_metadata_array_destroy(&self._c_initial_metadata)
 
@@ -147,13 +147,13 @@ cdef class ReceiveMessageOperation(Operation):
   def type(self):
     return GRPC_OP_RECV_MESSAGE
 
-  cdef void c(self):
+  cdef void c(self) except *:
     self.c_op.type = GRPC_OP_RECV_MESSAGE
     self.c_op.flags = self._flags
     self.c_op.data.receive_message.receive_message = (
         &self._c_message_byte_buffer)
 
-  cdef void un_c(self):
+  cdef void un_c(self) except *:
     cdef grpc_byte_buffer_reader message_reader
     cdef bint message_reader_status
     cdef grpc_slice message_slice
@@ -189,7 +189,7 @@ cdef class ReceiveStatusOnClientOperation(Operation):
   def type(self):
     return GRPC_OP_RECV_STATUS_ON_CLIENT
 
-  cdef void c(self):
+  cdef void c(self) except *:
     self.c_op.type = GRPC_OP_RECV_STATUS_ON_CLIENT
     self.c_op.flags = self._flags
     grpc_metadata_array_init(&self._c_trailing_metadata)
@@ -202,7 +202,7 @@ cdef class ReceiveStatusOnClientOperation(Operation):
     self.c_op.data.receive_status_on_client.error_string = (
         &self._c_error_string)
 
-  cdef void un_c(self):
+  cdef void un_c(self) except *:
     self._trailing_metadata = _metadata(&self._c_trailing_metadata)
     grpc_metadata_array_destroy(&self._c_trailing_metadata)
     self._code = self._c_code
@@ -235,12 +235,12 @@ cdef class ReceiveCloseOnServerOperation(Operation):
   def type(self):
     return GRPC_OP_RECV_CLOSE_ON_SERVER
 
-  cdef void c(self):
+  cdef void c(self) except *:
     self.c_op.type = GRPC_OP_RECV_CLOSE_ON_SERVER
     self.c_op.flags = self._flags
     self.c_op.data.receive_close_on_server.cancelled = &self._c_cancelled
 
-  cdef void un_c(self):
+  cdef void un_c(self) except *:
     self._cancelled = bool(self._c_cancelled)
 
   def cancelled(self):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/tag.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/tag.pxd.pxi
@@ -32,7 +32,7 @@ cdef class _RequestCallTag(_Tag):
   cdef CallDetails call_details
   cdef grpc_metadata_array c_invocation_metadata
 
-  cdef void prepare(self)
+  cdef void prepare(self) except *
   cdef RequestCallEvent event(self, grpc_event c_event)
 
 
@@ -44,7 +44,7 @@ cdef class _BatchOperationTag(_Tag):
   cdef grpc_op *c_ops
   cdef size_t c_nops
 
-  cdef void prepare(self)
+  cdef void prepare(self) except *
   cdef BatchOperationEvent event(self, grpc_event c_event)
 
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/tag.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/tag.pyx.pxi
@@ -35,7 +35,7 @@ cdef class _RequestCallTag(_Tag):
     self.call = None
     self.call_details = None
 
-  cdef void prepare(self):
+  cdef void prepare(self) except *:
     self.call = Call()
     self.call_details = CallDetails()
     grpc_metadata_array_init(&self.c_invocation_metadata)
@@ -55,7 +55,7 @@ cdef class _BatchOperationTag:
     self._operations = operations
     self._retained_call = call
 
-  cdef void prepare(self):
+  cdef void prepare(self) except *:
     self.c_nops = 0 if self._operations is None else len(self._operations)
     if 0 < self.c_nops:
       self.c_ops = <grpc_op *>gpr_malloc(sizeof(grpc_op) * self.c_nops)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/time.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/time.pxd.pxi
@@ -16,4 +16,4 @@
 cdef gpr_timespec _timespec_from_time(object time)
 
 
-cdef double _time_from_timespec(gpr_timespec timespec)
+cdef double _time_from_timespec(gpr_timespec timespec) except *

--- a/src/python/grpcio/grpc/_cython/_cygrpc/time.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/time.pyx.pxi
@@ -24,7 +24,7 @@ cdef gpr_timespec _timespec_from_time(object time):
     return timespec
 
 
-cdef double _time_from_timespec(gpr_timespec timespec):
+cdef double _time_from_timespec(gpr_timespec timespec) except *:
   cdef gpr_timespec real_timespec = gpr_convert_clock_type(
       timespec, GPR_CLOCK_REALTIME)
   return <double>real_timespec.seconds + <double>real_timespec.nanoseconds / 1e9

--- a/src/python/grpcio_tests/tests/unit/_invalid_metadata_test.py
+++ b/src/python/grpcio_tests/tests/unit/_invalid_metadata_test.py
@@ -130,6 +130,9 @@ class InvalidMetadataTest(unittest.TestCase):
             self._stream_stream(request_iterator, metadata=metadata)
         self.assertIn(expected_error_details, str(exception_context.exception))
 
+    def testInvalidMetadata(self):
+        self.assertRaises(TypeError, self._unary_unary, b'', metadata=42)
+
 
 if __name__ == '__main__':
     logging.basicConfig()


### PR DESCRIPTION
* If the function is returning an Python object, `except *` is not needed
* The integration between `nogil` and `except *` is under investigation

Issues #16643