### PR TITLE
Generalize CatchingCallback function

### DIFF
--- a/include/grpcpp/impl/codegen/callback_common.h
+++ b/include/grpcpp/impl/codegen/callback_common.h
@@ -32,16 +32,16 @@ namespace grpc {
 namespace internal {
 
 /// An exception-safe way of invoking a user-specified callback function
-template <class Func, class Arg>
-void CatchingCallback(Func&& func, Arg&& arg) {
+template <class Func, class... Args>
+void CatchingCallback(Func&& func, Args&&... args) {
 #if GRPC_ALLOW_EXCEPTIONS
   try {
-    func(arg);
+    func(std::forward<Args>(args)...);
   } catch (...) {
     // nothing to return or change here, just don't crash the library
   }
 #else   // GRPC_ALLOW_EXCEPTIONS
-  func(arg);
+  func(std::forward<Args>(args)...);
 #endif  // GRPC_ALLOW_EXCEPTIONS
 }
 


### PR DESCRIPTION
Use variadic template and perfect forwarding so that this is a more general exception catcher (in particular, for use in server-side handlers that are all of different flavors)

