### PR TITLE
Essential code changes needed to load native arm lib on windows based systems

### DIFF
--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -8,7 +8,7 @@
     <AssemblyTitle>gRPC C# Core</AssemblyTitle>
     <VersionPrefix>$(GrpcCsharpVersion)</VersionPrefix>
     <Authors>Google Inc.</Authors>
-    <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <AssemblyName>Grpc.Core</AssemblyName>
     <PackageId>Grpc.Core</PackageId>
     <PackageTags>gRPC RPC Protocol HTTP/2</PackageTags>
@@ -89,7 +89,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Runtime.Loader" Version="4.0.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.0.10" />

--- a/src/csharp/Grpc.Core/Internal/PlatformApis.cs
+++ b/src/csharp/Grpc.Core/Internal/PlatformApis.cs
@@ -163,6 +163,20 @@ namespace Grpc.Core.Internal
         }
 
         /// <summary>
+        /// Gets a value indicating whether the current architecture is arm based.
+        /// </summary>
+        public static bool IsArm
+        {
+            get
+            {
+                PortableExecutableKinds peKind;
+                ImageFileMachine machine;
+                typeof(object).Module.GetPEKind(out peKind, out machine);
+                return machine == ImageFileMachine.ARM;
+            }
+        }
+
+        /// <summary>
         /// Returns <c>UnityEngine.Application.platform</c> as a string.
         /// See https://docs.unity3d.com/ScriptReference/Application-platform.html for possible values.
         /// Value is obtained via reflection to avoid compile-time dependency on Unity.

--- a/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
+++ b/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
@@ -70,7 +70,7 @@ namespace Grpc.Core.Internal
             if (PlatformApis.IsWindows)
             {
                 // See http://stackoverflow.com/questions/10473310 for background on this.
-                if (PlatformApis.Is64Bit)
+                if (PlatformApis.Is64Bit || (PlatformApis.IsWindows && PlatformApis.IsArm))
                 {
                     return Windows.GetProcAddress(this.handle, symbolName);
                 }

--- a/src/csharp/Grpc.Core/SourceLink.csproj.include
+++ b/src/csharp/Grpc.Core/SourceLink.csproj.include
@@ -2,9 +2,9 @@
 <Project>
 
   <ItemGroup Label="dotnet pack instructions">
-    <Content Include="$(OutputPath)netstandard1.5\$(PackageId).pdb">
+    <Content Include="$(OutputPath)netstandard2.0\$(PackageId).pdb">
       <Pack>true</Pack>
-      <PackagePath>lib/netstandard1.5</PackagePath>
+      <PackagePath>lib/netstandard2.0</PackagePath>
     </Content>
     <Content Include="$(OutputPath)net45\$(PackageId).pdb">
       <Pack>true</Pack>


### PR DESCRIPTION
Basic features needed to support native arm lib on windows based system. 
See also https://github.com/grpc/grpc/issues/16929 

Had to switch to netstandard 2.0, because found no other way to check for arm architecture.