### PR TITLE
Fix warnings in doc comments

### DIFF
--- a/include/grpcpp/impl/codegen/completion_queue.h
+++ b/include/grpcpp/impl/codegen/completion_queue.h
@@ -199,7 +199,8 @@ class CompletionQueue : private GrpcLibraryCodegen {
   ///
   /// \param f [in] Function to execute before calling AsyncNext on this queue.
   /// \param tag [out] Upon sucess, updated to point to the event's tag.
-  /// \param ok [out] Upon sucess, true if read a regular event, false otherwise.
+  /// \param ok [out] Upon sucess, true if read a regular event, false
+  /// otherwise.
   /// \param deadline [in] How long to block in wait for an event.
   ///
   /// \return The type of event read.

--- a/include/grpcpp/impl/codegen/completion_queue.h
+++ b/include/grpcpp/impl/codegen/completion_queue.h
@@ -122,8 +122,8 @@ class CompletionQueue : private GrpcLibraryCodegen {
   /// Read from the queue, blocking until an event is available or the queue is
   /// shutting down.
   ///
-  /// \param tag[out] Updated to point to the read event's tag.
-  /// \param ok[out] true if read a successful event, false otherwise.
+  /// \param tag [out] Updated to point to the read event's tag.
+  /// \param ok [out] true if read a successful event, false otherwise.
   ///
   /// Note that each tag sent to the completion queue (through RPC operations
   /// or alarms) will be delivered out of the completion queue by a call to
@@ -178,10 +178,10 @@ class CompletionQueue : private GrpcLibraryCodegen {
   /// within the \a deadline).  A \a tag points to an arbitrary location usually
   /// employed to uniquely identify an event.
   ///
-  /// \param tag[out] Upon sucess, updated to point to the event's tag.
-  /// \param ok[out] Upon sucess, true if a successful event, false otherwise
+  /// \param tag [out] Upon sucess, updated to point to the event's tag.
+  /// \param ok [out] Upon sucess, true if a successful event, false otherwise
   ///        See documentation for CompletionQueue::Next for explanation of ok
-  /// \param deadline[in] How long to block in wait for an event.
+  /// \param deadline [in] How long to block in wait for an event.
   ///
   /// \return The type of event read.
   template <typename T>
@@ -197,10 +197,10 @@ class CompletionQueue : private GrpcLibraryCodegen {
   /// within the \a deadline).  A \a tag points to an arbitrary location usually
   /// employed to uniquely identify an event.
   ///
-  /// \param F[in] Function to execute before calling AsyncNext on this queue.
-  /// \param tag[out] Upon sucess, updated to point to the event's tag.
-  /// \param ok[out] Upon sucess, true if read a regular event, false otherwise.
-  /// \param deadline[in] How long to block in wait for an event.
+  /// \param f [in] Function to execute before calling AsyncNext on this queue.
+  /// \param tag [out] Upon sucess, updated to point to the event's tag.
+  /// \param ok [out] Upon sucess, true if read a regular event, false otherwise.
+  /// \param deadline [in] How long to block in wait for an event.
   ///
   /// \return The type of event read.
   template <typename T, typename F>
@@ -376,7 +376,7 @@ class ServerCompletionQueue : public CompletionQueue {
   ServerCompletionQueue() : polling_type_(GRPC_CQ_DEFAULT_POLLING) {}
 
  private:
-  /// \param is_frequently_polled Informs the GRPC library about whether the
+  /// \param polling_type Informs the GRPC library about whether the
   /// server completion queue would be actively polled (by calling Next() or
   /// AsyncNext()). By default all server completion queues are assumed to be
   /// frequently polled.

--- a/include/grpcpp/impl/codegen/server_context.h
+++ b/include/grpcpp/impl/codegen/server_context.h
@@ -107,7 +107,7 @@ class ServerContext {
   /// Return a \a gpr_timespec representation of the server call's deadline.
   gpr_timespec raw_deadline() const { return deadline_; }
 
-  /// Add the (\a meta_key, \a meta_value) pair to the initial metadata
+  /// Add the (\a key, \a value) pair to the initial metadata
   /// associated with a server call. These are made available at the client side
   /// by the \a grpc::ClientContext::GetServerInitialMetadata() method.
   ///
@@ -115,13 +115,13 @@ class ServerContext {
   /// to the client (which can happen explicitly, or implicitly when sending a
   /// a response message or status to the client).
   ///
-  /// \param meta_key The metadata key. If \a meta_value is binary data, it must
+  /// \param key The metadata key. If \a value is binary data, it must
   /// end in "-bin".
-  /// \param meta_value The metadata value. If its value is binary, the key name
+  /// \param value The metadata value. If its value is binary, the key name
   /// must end in "-bin".
   void AddInitialMetadata(const grpc::string& key, const grpc::string& value);
 
-  /// Add the (\a meta_key, \a meta_value) pair to the initial metadata
+  /// Add the (\a key, \a value) pair to the initial metadata
   /// associated with a server call. These are made available at the client
   /// side by the \a grpc::ClientContext::GetServerTrailingMetadata() method.
   ///
@@ -129,9 +129,9 @@ class ServerContext {
   /// metadata to the client (which happens when the call is finished and a
   /// status is sent to the client).
   ///
-  /// \param meta_key The metadata key. If \a meta_value is binary data,
+  /// \param key The metadata key. If \a value is binary data,
   /// it must end in "-bin".
-  /// \param meta_value The metadata value. If its value is binary, the key name
+  /// \param value The metadata value. If its value is binary, the key name
   /// must end in "-bin".
   void AddTrailingMetadata(const grpc::string& key, const grpc::string& value);
 
@@ -177,9 +177,9 @@ class ServerContext {
     return compression_level_;
   }
 
-  /// Set \a algorithm to be the compression algorithm used for the server call.
+  /// Set \a level to be the compression level used for the server call.
   ///
-  /// \param algorithm The compression algorithm used for the server call.
+  /// \param level The compression level used for the server call.
   void set_compression_level(grpc_compression_level level) {
     compression_level_set_ = true;
     compression_level_ = level;


### PR DESCRIPTION
Fixes clang warnings raised by `-Wdocumentation`. (See b/118395188)

Can I add this flag to the cflags somewhere?