### PR TITLE
Handle missing globals in Python Channel destructors

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -980,8 +980,9 @@ class Channel(grpc.Channel):
         # for as long as they are in use and to close them after using them,
         # then deletion of this grpc._channel.Channel instance can be made to
         # effect closure of the underlying cygrpc.Channel instance.
-        cygrpc.fork_unregister_channel(self)
+        if cygrpc is not None:  # Globals may have already been collected.
+            cygrpc.fork_unregister_channel(self)
         # This prevent the failed-at-initializing object removal from failing.
         # Though the __init__ failed, the removal will still trigger __del__.
-        if hasattr(self, "_connectivity_state"):
+        if _moot is not None and hasattr(self, "_connectivity_state"):
             _moot(self._connectivity_state)


### PR DESCRIPTION
If the last reference to a Python object is at module scope, when
its destructor is run before program termination it may find that
the globals it requires no longer exist. Destructors of objects
likely to be stored at module global scope need to check that
globals exist before attempting to use them, to avoid warnings
being printed by the Python interpreter.

See grpc#17004