### PR TITLE
Make `pylint` include Python files in examples

### DIFF
--- a/examples/python/helloworld/greeter_client_with_options.py
+++ b/examples/python/helloworld/greeter_client_with_options.py
@@ -22,22 +22,19 @@ import helloworld_pb2_grpc
 
 
 def run():
-    # NOTE(gRPC Python Team): .close() is possible on a channel and should be
-    # used in circumstances in which the with statement does not fit the needs
-    # of the code.
-    #
     # For more channel options, please see https://grpc.io/grpc/core/group__grpc__arg__keys.html
-    with grpc.insecure_channel(
-            target='localhost:50051',
-            options=[('grpc.lb_policy_name', 'pick_first'),
-                     ('grpc.enable_retries', 0), ('grpc.keepalive_timeout_ms',
-                                                  10000)]) as channel:
-        stub = helloworld_pb2_grpc.GreeterStub(channel)
-        # Timeout in seconds.
-        # Please refer gRPC Python documents for more detail. https://grpc.io/grpc/python/grpc.html
-        response = stub.SayHello(
-            helloworld_pb2.HelloRequest(name='you'), timeout=10)
+    channel = grpc.insecure_channel(
+        target='localhost:50051',
+        options=[('grpc.lb_policy_name', 'pick_first'),
+                 ('grpc.enable_retries', 0), ('grpc.keepalive_timeout_ms',
+                                              10000)])
+    stub = helloworld_pb2_grpc.GreeterStub(channel)
+    # Timeout in seconds.
+    # Please refer gRPC Python documents for more detail. https://grpc.io/grpc/python/grpc.html
+    response = stub.SayHello(
+        helloworld_pb2.HelloRequest(name='you'), timeout=10)
     print("Greeter client received: " + response.message)
+    channel.close()
 
 
 if __name__ == '__main__':

--- a/tools/distrib/pylint_code.sh
+++ b/tools/distrib/pylint_code.sh
@@ -34,8 +34,8 @@ python -m virtualenv $VIRTUALENV
 
 PYTHON=$VIRTUALENV/bin/python
 
-$PYTHON -m pip install --upgrade pip==10.0.1
-$PYTHON -m pip install pylint==1.9.2
+$PYTHON -m pip install --upgrade pip==18.1
+$PYTHON -m pip install pylint==1.9.3
 
 EXIT=0
 for dir in "${DIRS[@]}"; do
@@ -45,5 +45,8 @@ done
 for dir in "${TEST_DIRS[@]}"; do
   $PYTHON -m pylint --rcfile=.pylintrc-tests -rn "$dir" || EXIT=1
 done
+
+EXAMPLE_PY_FILES=`find examples/python -iname "*.py" -not -name "*_pb2.py" -not -name "*_pb2_grpc.py"`
+pylint --rcfile=.pylintrc-tests -rn $EXAMPLE_PY_FILES
 
 exit $EXIT

--- a/tools/distrib/pylint_code.sh
+++ b/tools/distrib/pylint_code.sh
@@ -46,7 +46,10 @@ for dir in "${TEST_DIRS[@]}"; do
   $PYTHON -m pylint --rcfile=.pylintrc-tests -rn "$dir" || EXIT=1
 done
 
-EXAMPLE_PY_FILES=`find examples/python -iname "*.py" -not -name "*_pb2.py" -not -name "*_pb2_grpc.py"`
-pylint --rcfile=.pylintrc-tests -rn $EXAMPLE_PY_FILES
+find examples/python \
+  -iname "*.py" \
+  -not -name "*_pb2.py" \
+  -not -name "*_pb2_grpc.py" \
+  | xargs pylint --rcfile=.pylintrc-tests -rn
 
 exit $EXIT


### PR DESCRIPTION
#15768 
Due to issue of `pylint` and `yapf`, I removed the complex with clause to make it LGTM for both linter.