### PR TITLE
Fix internal build breakage

### DIFF
--- a/src/core/ext/filters/client_channel/health/health_check_client.cc
+++ b/src/core/ext/filters/client_channel/health/health_check_client.cc
@@ -19,6 +19,7 @@
 #include <grpc/support/port_platform.h>
 
 #include <stdint.h>
+#include <stdio.h>
 
 #include "src/core/ext/filters/client_channel/health/health_check_client.h"
 


### PR DESCRIPTION
Not including stdio causes an internal build breakage.