### PR TITLE
Temporarily disable node_purejs benchmarks

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_singlevm.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_singlevm.sh
@@ -21,7 +21,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_perf_multilang_rc
 
 # "smoketest" scenarios on a single VM (=no remote VM for running qps_workers)
 tools/run_tests/run_performance_tests.py \
-    -l c++ csharp ruby java python go php7 php7_protobuf_c node node_purejs \
+    -l c++ csharp ruby java python go php7 php7_protobuf_c node \
     --netperf \
     --category smoketest \
     -u kbuilder \

--- a/tools/internal_ci/linux/grpc_full_performance_master.sh
+++ b/tools/internal_ci/linux/grpc_full_performance_master.sh
@@ -21,7 +21,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_perf_multilang_rc
 
 # run 8core client vs 8core server
 tools/run_tests/run_performance_tests.py \
-    -l c++ csharp ruby java python go php7 php7_protobuf_c node node_purejs \
+    -l c++ csharp ruby java python go php7 php7_protobuf_c node \
     --netperf \
     --category scalable \
     --remote_worker_host grpc-kokoro-performance-server-8core grpc-kokoro-performance-client-8core grpc-kokoro-performance-client2-8core \


### PR DESCRIPTION
They have been failing for quite a while (reported in https://github.com/grpc/grpc/issues/16897).

At least in the singlevm benchmarks, they are the only language it's failing, so it's preventing the test suite from being green (and thus providing signal about new breakages).
https://source.cloud.google.com/results/invocations/2f75115b-5a07-473b-8238-f91dc3f758c4/targets

node_purejs can be added back once they are fixed https://github.com/grpc/grpc/issues/16897.