### PR TITLE
Ensure `libboringssl.a` is always built for Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,19 +87,19 @@ BUILD_WITH_CYTHON = os.environ.get('GRPC_PYTHON_BUILD_WITH_CYTHON', False)
 
 # Export this variable to use the system installation of openssl. You need to
 # have the header files installed (in /usr/include/openssl) and during
-# runtime, the shared libary must be installed
+# runtime, the shared library must be installed
 BUILD_WITH_SYSTEM_OPENSSL = os.environ.get('GRPC_PYTHON_BUILD_SYSTEM_OPENSSL',
                                            False)
 
 # Export this variable to use the system installation of zlib. You need to
 # have the header files installed (in /usr/include/) and during
-# runtime, the shared libary must be installed
+# runtime, the shared library must be installed
 BUILD_WITH_SYSTEM_ZLIB = os.environ.get('GRPC_PYTHON_BUILD_SYSTEM_ZLIB',
                                         False)
 
 # Export this variable to use the system installation of cares. You need to
 # have the header files installed (in /usr/include/) and during
-# runtime, the shared libary must be installed
+# runtime, the shared library must be installed
 BUILD_WITH_SYSTEM_CARES = os.environ.get('GRPC_PYTHON_BUILD_SYSTEM_CARES',
                                          False)
 
@@ -202,7 +202,7 @@ DEFINE_MACROS = (
     ('OPENSSL_NO_ASM', 1), ('_WIN32_WINNT', 0x600),
     ('GPR_BACKWARDS_COMPATIBILITY_MODE', 1))
 if "win32" in sys.platform:
-  # TODO(zyc): Re-enble c-ares on x64 and x86 windows after fixing the
+  # TODO(zyc): Re-enable c-ares on x64 and x86 windows after fixing the
   # ares_library_init compilation issue
   DEFINE_MACROS += (('WIN32_LEAN_AND_MEAN', 1), ('CARES_STATICLIB', 1),
                     ('GRPC_ARES', 0), ('NTDDI_VERSION', 0x06000000),

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -276,7 +276,7 @@ class BuildExt(build_ext.build_ext):
             ]
             # Ensure the BoringSSL are built instead of using system provided
             #   libraries. It prevents dependency issues while distributing to
-            #   Mac users who use MacPorts to manage their libraries.
+            #   Mac users who use MacPorts to manage their libraries. #17002
             env = os.environ.copy()
             env['HAS_SYSTEM_OPENSSL_ALPN'] = '0'
             make_process = subprocess.Popen(

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -278,7 +278,7 @@ class BuildExt(build_ext.build_ext):
             #   libraries. It prevents dependency issues while distributing to
             #   Mac users who use MacPorts to manage their libraries. #17002
             mod_env = dict(os.environ)
-            mod_env['HAS_SYSTEM_OPENSSL_ALPN'] = '0'
+            mod_env['REQUIRE_CUSTOM_LIBRARIES_opt'] = '1'
             make_process = subprocess.Popen(
                 ['make'] + extra_defines + targets,
                 env=mod_env,

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -277,11 +277,11 @@ class BuildExt(build_ext.build_ext):
             # Ensure the BoringSSL are built instead of using system provided
             #   libraries. It prevents dependency issues while distributing to
             #   Mac users who use MacPorts to manage their libraries. #17002
-            env = os.environ.copy()
-            env['HAS_SYSTEM_OPENSSL_ALPN'] = '0'
+            mod_env = dict(os.environ)
+            mod_env['HAS_SYSTEM_OPENSSL_ALPN'] = '0'
             make_process = subprocess.Popen(
                 ['make'] + extra_defines + targets,
-                # env=env,
+                env=mod_env,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
             make_out, make_err = make_process.communicate()

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -281,7 +281,7 @@ class BuildExt(build_ext.build_ext):
             env['HAS_SYSTEM_OPENSSL_ALPN'] = '0'
             make_process = subprocess.Popen(
                 ['make'] + extra_defines + targets,
-                env=env,
+                # env=env,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
             make_out, make_err = make_process.communicate()

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -274,8 +274,14 @@ class BuildExt(build_ext.build_ext):
             extra_defines = [
                 'EXTRA_DEFINES="GRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK=1"'
             ]
+            # Ensure the BoringSSL are built instead of using system provided
+            #   libraries. It prevents dependency issues while distributing to
+            #   Mac users who use MacPorts to manage their libraries.
+            env = os.environ.copy()
+            env['HAS_SYSTEM_OPENSSL_ALPN'] = '0'
             make_process = subprocess.Popen(
                 ['make'] + extra_defines + targets,
+                env=env,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
             make_out, make_err = make_process.communicate()


### PR DESCRIPTION
Issue https://github.com/grpc/grpc/issues/17002

After discussing with @nicolasnoble , it is important to keep the BoringSSL inside the gRPC Python distribution. It is much easier to link inside the Python distribution than linking to the system's library, and may potentially create problems in Windows. So, instead of risking to build upon arbitrary dependencies, it seems more sensible to ensure `libboringssl.a` is always built for gRPC Python.