### PR TITLE
Provide access to verify_peer_callback from C#

### DIFF
--- a/src/csharp/Grpc.Core/ChannelCredentials.cs
+++ b/src/csharp/Grpc.Core/ChannelCredentials.cs
@@ -18,9 +18,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Grpc.Core.Internal;
+using Grpc.Core.Logging;
 using Grpc.Core.Utils;
 
 namespace Grpc.Core
@@ -105,19 +108,35 @@ namespace Grpc.Core
     }
 
     /// <summary>
+    /// Callback invoked with the expected targetHost and the peer's certificate.
+    /// If false is returned by this callback then it is treated as a
+    /// verification failure. Invocation of the callback is blocking, so any
+    /// implementation should be light-weight.
+    /// </summary>
+    /// <param name="context">The <see cref="T:Grpc.Core.VerifyPeerContext"/> associated with the callback</param>
+    /// <returns>true if verification succeeded, false otherwise.</returns>
+    /// Note: experimental API that can change or be removed without any prior notice.
+    public delegate bool VerifyPeerCallback(VerifyPeerContext context);
+
+    /// <summary>
     /// Client-side SSL credentials.
     /// </summary>
     public sealed class SslCredentials : ChannelCredentials
     {
+        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<SslCredentials>();
+
         readonly string rootCertificates;
         readonly KeyCertificatePair keyCertificatePair;
+        readonly VerifyPeerCallback verifyPeerCallback;
+        readonly VerifyPeerCallbackInternal verifyPeerCallbackInternal;
+        readonly NativeCallbackRegistration callbackRegistration;
 
         /// <summary>
         /// Creates client-side SSL credentials loaded from
         /// disk file pointed to by the GRPC_DEFAULT_SSL_ROOTS_FILE_PATH environment variable.
         /// If that fails, gets the roots certificates from a well known place on disk.
         /// </summary>
-        public SslCredentials() : this(null, null)
+        public SslCredentials() : this(null, null, null)
         {
         }
 
@@ -125,19 +144,37 @@ namespace Grpc.Core
         /// Creates client-side SSL credentials from
         /// a string containing PEM encoded root certificates.
         /// </summary>
-        public SslCredentials(string rootCertificates) : this(rootCertificates, null)
+        public SslCredentials(string rootCertificates) : this(rootCertificates, null, null)
         {
         }
-            
+
         /// <summary>
         /// Creates client-side SSL credentials.
         /// </summary>
         /// <param name="rootCertificates">string containing PEM encoded server root certificates.</param>
         /// <param name="keyCertificatePair">a key certificate pair.</param>
-        public SslCredentials(string rootCertificates, KeyCertificatePair keyCertificatePair)
+        public SslCredentials(string rootCertificates, KeyCertificatePair keyCertificatePair) :
+            this(rootCertificates, keyCertificatePair, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates client-side SSL credentials.
+        /// </summary>
+        /// <param name="rootCertificates">string containing PEM encoded server root certificates.</param>
+        /// <param name="keyCertificatePair">a key certificate pair.</param>
+        /// <param name="verifyPeerCallback">a callback to verify peer's target name and certificate.</param>
+        /// Note: experimental API that can change or be removed without any prior notice.
+        public SslCredentials(string rootCertificates, KeyCertificatePair keyCertificatePair, VerifyPeerCallback verifyPeerCallback)
         {
             this.rootCertificates = rootCertificates;
             this.keyCertificatePair = keyCertificatePair;
+            if (verifyPeerCallback != null)
+            {
+                this.verifyPeerCallback = verifyPeerCallback;
+                this.verifyPeerCallbackInternal = this.VerifyPeerCallbackHandler;
+                this.callbackRegistration = NativeCallbackDispatcher.RegisterCallback(HandleUniversalCallback);
+            }
         }
 
         /// <summary>
@@ -171,7 +208,36 @@ namespace Grpc.Core
 
         internal override ChannelCredentialsSafeHandle CreateNativeCredentials()
         {
-            return ChannelCredentialsSafeHandle.CreateSslCredentials(rootCertificates, keyCertificatePair);
+            var tag = this.callbackRegistration?.Tag ?? IntPtr.Zero;
+            return ChannelCredentialsSafeHandle.CreateSslCredentials(rootCertificates, keyCertificatePair, tag);
+        }
+
+        private int HandleUniversalCallback( IntPtr arg0, IntPtr arg1, IntPtr arg2, IntPtr arg3, IntPtr arg4, IntPtr arg5)
+        {
+            return verifyPeerCallbackInternal(arg0, arg1, arg2, arg4 != IntPtr.Zero);
+        }
+
+        private int VerifyPeerCallbackHandler(IntPtr host, IntPtr pem, IntPtr userData, bool isDestroy)
+        {
+            if (isDestroy)
+            {
+                this.callbackRegistration.Dispose();
+                return 0;
+            }
+
+            try
+            {
+                var context = new VerifyPeerContext(Marshal.PtrToStringAnsi(host), Marshal.PtrToStringAnsi(pem));
+
+                return this.verifyPeerCallback(context) ? 0 : 1;
+            }
+            catch (Exception e)
+            {
+                // eat the exception, we must not throw when inside callback from native code.
+                Logger.Error(e, "Exception occurred while invoking verify peer callback handler.");
+                // Return validation failure in case of exception.
+                return 1;
+            }
         }
     }
 

--- a/src/csharp/Grpc.Core/Internal/ChannelCredentialsSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/ChannelCredentialsSafeHandle.cs
@@ -20,6 +20,12 @@ using System.Threading.Tasks;
 
 namespace Grpc.Core.Internal
 {
+    internal delegate int VerifyPeerCallbackInternal(
+        IntPtr targetHost,
+        IntPtr targetPem,
+        IntPtr userData,
+        bool isDestroy);
+
     /// <summary>
     /// grpc_channel_credentials from <c>grpc/grpc_security.h</c>
     /// </summary>
@@ -38,15 +44,15 @@ namespace Grpc.Core.Internal
             return creds;
         }
 
-        public static ChannelCredentialsSafeHandle CreateSslCredentials(string pemRootCerts, KeyCertificatePair keyCertPair)
+        public static ChannelCredentialsSafeHandle CreateSslCredentials(string pemRootCerts, KeyCertificatePair keyCertPair, IntPtr nativeCallbackTag)
         {
             if (keyCertPair != null)
             {
-                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, keyCertPair.CertificateChain, keyCertPair.PrivateKey);
+                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, keyCertPair.CertificateChain, keyCertPair.PrivateKey, nativeCallbackTag);
             }
             else
             {
-                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, null, null);
+                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, null, null, nativeCallbackTag);
             }
         }
 

--- a/src/csharp/Grpc.Core/Internal/NativeMethods.Generated.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMethods.Generated.cs
@@ -482,7 +482,7 @@ namespace Grpc.Core.Internal
             public delegate void grpcsharp_channel_args_set_integer_delegate(ChannelArgsSafeHandle args, UIntPtr index, string key, int value);
             public delegate void grpcsharp_channel_args_destroy_delegate(IntPtr args);
             public delegate void grpcsharp_override_default_ssl_roots_delegate(string pemRootCerts);
-            public delegate ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create_delegate(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey);
+            public delegate ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create_delegate(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr nativeCallbackTag);
             public delegate ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create_delegate(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds);
             public delegate void grpcsharp_channel_credentials_release_delegate(IntPtr credentials);
             public delegate ChannelSafeHandle grpcsharp_insecure_channel_create_delegate(string target, ChannelArgsSafeHandle channelArgs);
@@ -676,7 +676,7 @@ namespace Grpc.Core.Internal
             public static extern void grpcsharp_override_default_ssl_roots(string pemRootCerts);
             
             [DllImport(ImportName)]
-            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey);
+            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr nativeCallbackTag);
             
             [DllImport(ImportName)]
             public static extern ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds);
@@ -972,7 +972,7 @@ namespace Grpc.Core.Internal
             public static extern void grpcsharp_override_default_ssl_roots(string pemRootCerts);
             
             [DllImport(ImportName)]
-            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey);
+            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr nativeCallbackTag);
             
             [DllImport(ImportName)]
             public static extern ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds);

--- a/src/csharp/Grpc.Core/VerifyPeerContext.cs
+++ b/src/csharp/Grpc.Core/VerifyPeerContext.cs
@@ -1,0 +1,30 @@
+namespace Grpc.Core
+{
+    /// <summary>
+    /// Verification context for VerifyPeerCallback.
+    /// Note: experimental API that can change or be removed without any prior notice.
+    /// </summary>
+    public class VerifyPeerContext
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:Grpc.Core.VerifyPeerContext"/> class.
+        /// </summary>
+        /// <param name="targetHost">string containing the host name of the peer.</param>
+        /// <param name="targetPem">string containing PEM encoded certificate of the peer.</param>
+        internal VerifyPeerContext(string targetHost, string targetPem)
+        {
+            this.TargetHost = targetHost;
+            this.TargetPem = targetPem;
+        }
+
+        /// <summary>
+        /// String containing the host name of the peer.
+        /// </summary>
+        public string TargetHost { get; }
+
+        /// <summary>
+        /// string containing PEM encoded certificate of the peer.
+        /// </summary>
+        public string TargetPem { get; }
+    }
+}

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -927,20 +927,63 @@ grpcsharp_override_default_ssl_roots(const char* pem_root_certs) {
   grpc_set_ssl_roots_override_callback(override_ssl_roots_handler);
 }
 
+/* Native callback dispatcher */
+
+typedef int(GPR_CALLTYPE* grpcsharp_native_callback_dispatcher_func)(
+    void* tag, void* arg0, void* arg1, void* arg2, void* arg3, void* arg4,
+    void* arg5);
+
+static grpcsharp_native_callback_dispatcher_func native_callback_dispatcher =
+    NULL;
+
+GPR_EXPORT void GPR_CALLTYPE grpcsharp_native_callback_dispatcher_init(
+    grpcsharp_native_callback_dispatcher_func func) {
+  GPR_ASSERT(func);
+  native_callback_dispatcher = func;
+}
+
+typedef int(GPR_CALLTYPE* grpcsharp_verify_peer_func)(const char* target_host,
+                                                      const char* target_pem,
+                                                      void* userdata,
+                                                      int32_t isDestroy);
+
+static void grpcsharp_verify_peer_destroy_handler(void* userdata) {
+  native_callback_dispatcher(userdata, NULL, NULL, NULL, 1, NULL, NULL);
+}
+
+static int grpcsharp_verify_peer_handler(const char* target_host,
+                                         const char* target_pem,
+                                         void* userdata) {
+  return native_callback_dispatcher(userdata, target_host, target_pem, NULL, 0, NULL, NULL);
+}
+
+
 GPR_EXPORT grpc_channel_credentials* GPR_CALLTYPE
 grpcsharp_ssl_credentials_create(const char* pem_root_certs,
                                  const char* key_cert_pair_cert_chain,
-                                 const char* key_cert_pair_private_key) {
+                                 const char* key_cert_pair_private_key,
+                                 void* callback_tag) {
   grpc_ssl_pem_key_cert_pair key_cert_pair;
+  verify_peer_options verify_options;
+  verify_peer_options* p_verify_options = NULL;
+  if (callback_tag != NULL) {
+    verify_options.verify_peer_callback_userdata = callback_tag;
+    verify_options.verify_peer_destruct =
+            grpcsharp_verify_peer_destroy_handler;
+    verify_options.verify_peer_callback = grpcsharp_verify_peer_handler;
+    p_verify_options = &verify_options;
+  }
+
   if (key_cert_pair_cert_chain || key_cert_pair_private_key) {
     key_cert_pair.cert_chain = key_cert_pair_cert_chain;
     key_cert_pair.private_key = key_cert_pair_private_key;
-    return grpc_ssl_credentials_create(pem_root_certs, &key_cert_pair, NULL,
-                                       NULL);
+    return grpc_ssl_credentials_create(pem_root_certs, &key_cert_pair,
+                                       p_verify_options, NULL);
   } else {
     GPR_ASSERT(!key_cert_pair_cert_chain);
     GPR_ASSERT(!key_cert_pair_private_key);
-    return grpc_ssl_credentials_create(pem_root_certs, NULL, NULL, NULL);
+    return grpc_ssl_credentials_create(pem_root_certs, NULL, p_verify_options,
+                                       NULL);
   }
 }
 
@@ -1008,21 +1051,6 @@ GPR_EXPORT grpc_call_credentials* GPR_CALLTYPE
 grpcsharp_composite_call_credentials_create(grpc_call_credentials* creds1,
                                             grpc_call_credentials* creds2) {
   return grpc_composite_call_credentials_create(creds1, creds2, NULL);
-}
-
-/* Native callback dispatcher */
-
-typedef int(GPR_CALLTYPE* grpcsharp_native_callback_dispatcher_func)(
-    void* tag, void* arg0, void* arg1, void* arg2, void* arg3, void* arg4,
-    void* arg5);
-
-static grpcsharp_native_callback_dispatcher_func native_callback_dispatcher =
-    NULL;
-
-GPR_EXPORT void GPR_CALLTYPE grpcsharp_native_callback_dispatcher_init(
-    grpcsharp_native_callback_dispatcher_func func) {
-  GPR_ASSERT(func);
-  native_callback_dispatcher = func;
 }
 
 /* Metadata credentials plugin */

--- a/templates/src/csharp/Grpc.Core/Internal/native_methods.include
+++ b/templates/src/csharp/Grpc.Core/Internal/native_methods.include
@@ -44,7 +44,7 @@ native_method_signatures = [
     'void grpcsharp_channel_args_set_integer(ChannelArgsSafeHandle args, UIntPtr index, string key, int value)',
     'void grpcsharp_channel_args_destroy(IntPtr args)',
     'void grpcsharp_override_default_ssl_roots(string pemRootCerts)',
-    'ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey)',
+    'ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr nativeCallbackTag)',
     'ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds)',
     'void grpcsharp_channel_credentials_release(IntPtr credentials)',
     'ChannelSafeHandle grpcsharp_insecure_channel_create(string target, ChannelArgsSafeHandle channelArgs)',


### PR DESCRIPTION
At the moment there is no possibilities from C# to access the server certificate from the client side when using TLS. In P2P settings it is practical to be able to identify a node in the network using its TLS certificate.
This PR exposes `verify_peer_callback` available in the C++ layer to the C# library to be able to obtain the server certificate.

Notes:
* I defined two types of delegates `VerifyPeerCallback` and `VerifyCallbackInternal`. The first is the one exposed to be used externally of the library, the second is the one passed to the native code. The reason for defining both was to hide the `userData` parameter of the callback (it is not clear to me if/how keeping this parameter could work).
* I added an optional parameter to the `SslCredentials` constructors to pass a `VerifyPeerCallback` delegate.
* I added some tests in "src/csharp/Grpc.IntegrationTesting/SslCredentialsTest.cs" to test the proper working of the functionality.
* "src/csharp/ext/grpc_csharp_ext.c" was modified so that `grpcsharp_ssl_credentials_create` takes the extra delegate parameter.
