### PR TITLE
Move fallthrough comment so it is recognized internally

### DIFF
--- a/test/core/memory_usage/BUILD
+++ b/test/core/memory_usage/BUILD
@@ -12,13 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
 
 grpc_package(name = "test/core/memory_usage")
 
 licenses(["notice"])  # Apache v2
-
-load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
 
 grpc_cc_binary(
     name = "client",

--- a/test/core/memory_usage/server.cc
+++ b/test/core/memory_usage/server.cc
@@ -292,9 +292,9 @@ int main(int argc, char** argv) {
                 send_status(&calls[k]);
               }
             }
+          /* fallthrough */
           // no break here since we want to continue to case
           // FLING_SERVER_SEND_STATUS_SNAPSHOT to destroy the snapshot call
-          /* fallthrough */
           case FLING_SERVER_SEND_STATUS_SNAPSHOT:
             grpc_byte_buffer_destroy(payload_buffer);
             grpc_byte_buffer_destroy(terminal_buffer);


### PR DESCRIPTION
Otherwise, this file breaks the import because the fall-through appears unannotated.