### PR TITLE
Fix logging

### DIFF
--- a/src/python/.gitignore
+++ b/src/python/.gitignore
@@ -1,3 +1,4 @@
 gens/
 *_pb2.py
 *_pb2_grpc.py
+*.egg-info/

--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -25,6 +25,7 @@ from grpc._cython import cygrpc
 from grpc.framework.foundation import callable_util
 
 _LOGGER = logging.getLogger(__name__)
+_LOGGER.addHandler(logging.NullHandler)
 
 _USER_AGENT = 'grpc-python/{}'.format(_grpcio_metadata.__version__)
 

--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -24,7 +24,6 @@ from grpc import _grpcio_metadata
 from grpc._cython import cygrpc
 from grpc.framework.foundation import callable_util
 
-logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 _USER_AGENT = 'grpc-python/{}'.format(_grpcio_metadata.__version__)

--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -25,7 +25,7 @@ from grpc._cython import cygrpc
 from grpc.framework.foundation import callable_util
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.addHandler(logging.NullHandler)
+_LOGGER.addHandler(logging.NullHandler())
 
 _USER_AGENT = 'grpc-python/{}'.format(_grpcio_metadata.__version__)
 

--- a/src/python/grpcio/grpc/_common.py
+++ b/src/python/grpcio/grpc/_common.py
@@ -21,6 +21,7 @@ import grpc
 from grpc._cython import cygrpc
 
 _LOGGER = logging.getLogger(__name__)
+_LOGGER.addHandler(logging.NullHandler())
 
 CYGRPC_CONNECTIVITY_STATE_TO_CHANNEL_CONNECTIVITY = {
     cygrpc.ConnectivityState.idle:

--- a/src/python/grpcio/grpc/_common.py
+++ b/src/python/grpcio/grpc/_common.py
@@ -20,7 +20,6 @@ import six
 import grpc
 from grpc._cython import cygrpc
 
-logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 CYGRPC_CONNECTIVITY_STATE_TO_CHANNEL_CONNECTIVITY = {

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_string.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_string.pyx.pxi
@@ -14,7 +14,6 @@
 
 import logging
 
-logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 # This function will ascii encode unicode string inputs if neccesary.

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_string.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_string.pyx.pxi
@@ -15,6 +15,7 @@
 import logging
 
 _LOGGER = logging.getLogger(__name__)
+_LOGGER.addHandler(logging.NullHandler())
 
 # This function will ascii encode unicode string inputs if neccesary.
 # In Python3, unicode strings are the default str type.

--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
@@ -19,6 +19,7 @@ import time
 import grpc
 
 _LOGGER = logging.getLogger(__name__)
+_LOGGER.addHandler(logging.NullHandler())
 
 cdef class Server:
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
@@ -18,7 +18,6 @@ import logging
 import time
 import grpc
 
-logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 cdef class Server:

--- a/src/python/grpcio/grpc/_plugin_wrapping.py
+++ b/src/python/grpcio/grpc/_plugin_wrapping.py
@@ -21,6 +21,7 @@ from grpc import _common
 from grpc._cython import cygrpc
 
 _LOGGER = logging.getLogger(__name__)
+_LOGGER.addHandler(logging.NullHandler())
 
 
 class _AuthMetadataContext(

--- a/src/python/grpcio/grpc/_plugin_wrapping.py
+++ b/src/python/grpcio/grpc/_plugin_wrapping.py
@@ -20,7 +20,6 @@ import grpc
 from grpc import _common
 from grpc._cython import cygrpc
 
-logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -27,7 +27,6 @@ from grpc import _interceptor
 from grpc._cython import cygrpc
 from grpc.framework.foundation import callable_util
 
-logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 _SHUTDOWN_TAG = 'shutdown'

--- a/src/python/grpcio/grpc/framework/foundation/callable_util.py
+++ b/src/python/grpcio/grpc/framework/foundation/callable_util.py
@@ -21,7 +21,6 @@ import logging
 
 import six
 
-logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/src/python/grpcio/grpc/framework/foundation/callable_util.py
+++ b/src/python/grpcio/grpc/framework/foundation/callable_util.py
@@ -22,6 +22,7 @@ import logging
 import six
 
 _LOGGER = logging.getLogger(__name__)
+_LOGGER.addHandler(logging.NullHandler())
 
 
 class Outcome(six.with_metaclass(abc.ABCMeta)):

--- a/src/python/grpcio/grpc/framework/foundation/logging_pool.py
+++ b/src/python/grpcio/grpc/framework/foundation/logging_pool.py
@@ -17,7 +17,6 @@ import logging
 
 from concurrent import futures
 
-logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/src/python/grpcio/grpc/framework/foundation/logging_pool.py
+++ b/src/python/grpcio/grpc/framework/foundation/logging_pool.py
@@ -18,6 +18,7 @@ import logging
 from concurrent import futures
 
 _LOGGER = logging.getLogger(__name__)
+_LOGGER.addHandler(logging.NullHandler())
 
 
 def _wrap(behavior):

--- a/src/python/grpcio/grpc/framework/foundation/stream_util.py
+++ b/src/python/grpcio/grpc/framework/foundation/stream_util.py
@@ -20,6 +20,7 @@ from grpc.framework.foundation import stream
 
 _NO_VALUE = object()
 _LOGGER = logging.getLogger(__name__)
+_LOGGER.addHandler(NullHandler())
 
 
 class TransformingConsumer(stream.Consumer):

--- a/src/python/grpcio/grpc/framework/foundation/stream_util.py
+++ b/src/python/grpcio/grpc/framework/foundation/stream_util.py
@@ -20,7 +20,7 @@ from grpc.framework.foundation import stream
 
 _NO_VALUE = object()
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.addHandler(NullHandler())
+_LOGGER.addHandler(logging.NullHandler())
 
 
 class TransformingConsumer(stream.Consumer):

--- a/src/python/grpcio/grpc/framework/foundation/stream_util.py
+++ b/src/python/grpcio/grpc/framework/foundation/stream_util.py
@@ -19,7 +19,6 @@ import threading
 from grpc.framework.foundation import stream
 
 _NO_VALUE = object()
-logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/src/python/grpcio_testing/grpc_testing/_channel/_invocation.py
+++ b/src/python/grpcio_testing/grpc_testing/_channel/_invocation.py
@@ -18,6 +18,7 @@ import threading
 import grpc
 
 _NOT_YET_OBSERVED = object()
+logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/src/python/grpcio_testing/grpc_testing/_channel/_invocation.py
+++ b/src/python/grpcio_testing/grpc_testing/_channel/_invocation.py
@@ -18,7 +18,6 @@ import threading
 import grpc
 
 _NOT_YET_OBSERVED = object()
-logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/src/python/grpcio_testing/grpc_testing/_server/_rpc.py
+++ b/src/python/grpcio_testing/grpc_testing/_server/_rpc.py
@@ -21,6 +21,7 @@ from grpc_testing import _common
 logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
+
 class Rpc(object):
 
     def __init__(self, handler, invocation_metadata):

--- a/src/python/grpcio_testing/grpc_testing/_server/_rpc.py
+++ b/src/python/grpcio_testing/grpc_testing/_server/_rpc.py
@@ -18,8 +18,8 @@ import threading
 import grpc
 from grpc_testing import _common
 
+logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
-
 
 class Rpc(object):
 

--- a/src/python/grpcio_testing/grpc_testing/_server/_rpc.py
+++ b/src/python/grpcio_testing/grpc_testing/_server/_rpc.py
@@ -18,7 +18,6 @@ import threading
 import grpc
 from grpc_testing import _common
 
-logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/src/python/grpcio_testing/grpc_testing/_time.py
+++ b/src/python/grpcio_testing/grpc_testing/_time.py
@@ -21,6 +21,7 @@ import time as _time
 import grpc
 import grpc_testing
 
+logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/src/python/grpcio_testing/grpc_testing/_time.py
+++ b/src/python/grpcio_testing/grpc_testing/_time.py
@@ -21,7 +21,6 @@ import time as _time
 import grpc
 import grpc_testing
 
-logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/src/python/grpcio_tests/tests/interop/server.py
+++ b/src/python/grpcio_tests/tests/interop/server.py
@@ -26,6 +26,7 @@ from tests.interop import resources
 from tests.unit import test_common
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
+logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/src/python/grpcio_tests/tests/interop/server.py
+++ b/src/python/grpcio_tests/tests/interop/server.py
@@ -25,7 +25,6 @@ from tests.interop import methods
 from tests.interop import resources
 from tests.unit import test_common
 
-logging.basicConfig()
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 _LOGGER = logging.getLogger(__name__)
 

--- a/src/python/grpcio_tests/tests/tests.json
+++ b/src/python/grpcio_tests/tests/tests.json
@@ -46,6 +46,7 @@
   "unit._interceptor_test.InterceptorTest",
   "unit._invalid_metadata_test.InvalidMetadataTest",
   "unit._invocation_defects_test.InvocationDefectsTest",
+  "unit._logging_test.LoggingTest",
   "unit._metadata_code_details_test.MetadataCodeDetailsTest",
   "unit._metadata_test.MetadataTest",
   "unit._reconnect_test.ReconnectTest",

--- a/src/python/grpcio_tests/tests/unit/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/BUILD.bazel
@@ -17,6 +17,7 @@ GRPCIO_TESTS_UNIT = [
     "_interceptor_test.py",
     "_invalid_metadata_test.py",
     "_invocation_defects_test.py",
+    "_logging_test.py",
     "_metadata_code_details_test.py",
     "_metadata_test.py",
     # TODO: Issue 16336

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -102,4 +102,5 @@ class ChannelTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -14,6 +14,7 @@
 """Test of gRPC Python's application-layer API."""
 
 import unittest
+import logging
 
 import six
 

--- a/src/python/grpcio_tests/tests/unit/_auth_context_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_context_test.py
@@ -15,6 +15,7 @@
 
 import pickle
 import unittest
+import logging
 
 import grpc
 from grpc import _channel

--- a/src/python/grpcio_tests/tests/unit/_auth_context_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_context_test.py
@@ -187,4 +187,5 @@ class AuthContextTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_auth_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_test.py
@@ -16,6 +16,7 @@
 import collections
 import threading
 import unittest
+import logging
 
 from grpc import _auth
 

--- a/src/python/grpcio_tests/tests/unit/_auth_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_test.py
@@ -77,4 +77,5 @@ class AccessTokenAuthMetadataPluginTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_channel_args_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_args_test.py
@@ -15,6 +15,7 @@
 
 from concurrent import futures
 import unittest
+import logging
 
 import grpc
 
@@ -62,4 +63,5 @@ class ChannelArgsTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_channel_close_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_close_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests server and client side compression."""
 
+import logging
 import threading
 import time
 import unittest
@@ -182,4 +183,5 @@ class ChannelCloseTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_channel_connectivity_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_connectivity_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Tests of grpc._channel.Channel connectivity."""
 
+import logging
 import threading
 import time
 import unittest
@@ -142,4 +143,5 @@ class ChannelConnectivityTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_channel_ready_future_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_ready_future_test.py
@@ -15,6 +15,7 @@
 
 import threading
 import unittest
+import logging
 
 import grpc
 from tests.unit.framework.common import test_constants
@@ -85,4 +86,5 @@ class ChannelReadyFutureTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_compression_test.py
+++ b/src/python/grpcio_tests/tests/unit/_compression_test.py
@@ -15,6 +15,7 @@
 
 import unittest
 
+import logging
 import grpc
 from grpc import _grpcio_metadata
 
@@ -117,4 +118,5 @@ class CompressionTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_credentials_test.py
+++ b/src/python/grpcio_tests/tests/unit/_credentials_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Tests of credentials."""
 
-
 import unittest
 import logging
 

--- a/src/python/grpcio_tests/tests/unit/_credentials_test.py
+++ b/src/python/grpcio_tests/tests/unit/_credentials_test.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 """Tests of credentials."""
 
+
 import unittest
+import logging
 
 import grpc
 
@@ -54,4 +56,5 @@ class CredentialsTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_empty_message_test.py
+++ b/src/python/grpcio_tests/tests/unit/_empty_message_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+import logging
 
 import grpc
 
@@ -118,4 +119,5 @@ class EmptyMessageTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_exit_scenarios.py
+++ b/src/python/grpcio_tests/tests/unit/_exit_scenarios.py
@@ -16,6 +16,7 @@
 import argparse
 import threading
 import time
+import logging
 
 import grpc
 
@@ -161,6 +162,7 @@ def infinite_request_iterator():
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     parser = argparse.ArgumentParser()
     parser.add_argument('scenario', type=str)
     parser.add_argument(

--- a/src/python/grpcio_tests/tests/unit/_exit_test.py
+++ b/src/python/grpcio_tests/tests/unit/_exit_test.py
@@ -26,6 +26,7 @@ import sys
 import threading
 import time
 import unittest
+import logging
 
 from tests.unit import _exit_scenarios
 
@@ -187,4 +188,5 @@ class ExitTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_interceptor_test.py
+++ b/src/python/grpcio_tests/tests/unit/_interceptor_test.py
@@ -17,6 +17,7 @@ import collections
 import itertools
 import threading
 import unittest
+import logging
 from concurrent import futures
 
 import grpc
@@ -598,4 +599,5 @@ class InterceptorTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_invalid_metadata_test.py
+++ b/src/python/grpcio_tests/tests/unit/_invalid_metadata_test.py
@@ -14,6 +14,7 @@
 """Test of RPCs made against gRPC Python's application-layer API."""
 
 import unittest
+import logging
 
 import grpc
 
@@ -131,4 +132,5 @@ class InvalidMetadataTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_invocation_defects_test.py
+++ b/src/python/grpcio_tests/tests/unit/_invocation_defects_test.py
@@ -15,6 +15,7 @@
 import itertools
 import threading
 import unittest
+import logging
 
 import grpc
 
@@ -271,4 +272,5 @@ class InvocationDefectsTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_logging_test.py
+++ b/src/python/grpcio_tests/tests/unit/_logging_test.py
@@ -19,6 +19,7 @@ import grpc
 import logging
 
 class LoggingTest(unittest.TestCase):
+
   def test_logger_not_occupied(self):
     self.assertEqual(0, len(logging.getLogger().handlers))
 

--- a/src/python/grpcio_tests/tests/unit/_logging_test.py
+++ b/src/python/grpcio_tests/tests/unit/_logging_test.py
@@ -1,0 +1,26 @@
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test of gRPC Python's interaction with the python logging module"""
+
+import unittest
+import six
+import grpc
+import logging
+
+class LoggingTest(unittest.TestCase):
+  def test_logger_not_occupied(self):
+    self.assertEqual(0, len(logging.getLogger().handlers))
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_logging_test.py
+++ b/src/python/grpcio_tests/tests/unit/_logging_test.py
@@ -29,7 +29,7 @@ def patch_stderr(f):
         old_stderr = sys.stderr
         sys.stderr = six.StringIO()
         try:
-            f(args, kwargs)
+            f(*args, **kwargs)
         finally:
             sys.stderr = old_stderr
 

--- a/src/python/grpcio_tests/tests/unit/_logging_test.py
+++ b/src/python/grpcio_tests/tests/unit/_logging_test.py
@@ -21,7 +21,9 @@ import grpc
 import functools
 import sys
 
+
 def patch_stderr(f):
+
     @functools.wraps(f)
     def _impl(*args, **kwargs):
         old_stderr = sys.stderr
@@ -30,7 +32,9 @@ def patch_stderr(f):
             f(args, kwargs)
         finally:
             sys.stderr = old_stderr
+
     return _impl
+
 
 class LoggingTest(unittest.TestCase):
 
@@ -43,9 +47,11 @@ class LoggingTest(unittest.TestCase):
             reload_module(logging)
             logging.basicConfig()
             reload_module(grpc)
-            self.assertFalse("No handlers could be found" in sys.stderr.getvalue())
+            self.assertFalse(
+                "No handlers could be found" in sys.stderr.getvalue())
         finally:
             reload_module(logging)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_logging_test.py
+++ b/src/python/grpcio_tests/tests/unit/_logging_test.py
@@ -15,15 +15,28 @@
 
 import unittest
 import six
-import grpc
+from six.moves import reload_module
 import logging
-
+import grpc
+import functools
+import sys
 
 class LoggingTest(unittest.TestCase):
 
     def test_logger_not_occupied(self):
         self.assertEqual(0, len(logging.getLogger().handlers))
 
+    def test_handler_found(self):
+        old_stderr = sys.stderr
+        sys.stderr = six.StringIO()
+        try:
+            reload_module(logging)
+            logging.basicConfig()
+            reload_module(grpc)
+            self.assertFalse("No handlers could be found" in sys.stderr.getvalue())
+        finally:
+            sys.stderr = old_stderr
+            reload_module(logging)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_logging_test.py
+++ b/src/python/grpcio_tests/tests/unit/_logging_test.py
@@ -18,10 +18,12 @@ import six
 import grpc
 import logging
 
+
 class LoggingTest(unittest.TestCase):
 
-  def test_logger_not_occupied(self):
-    self.assertEqual(0, len(logging.getLogger().handlers))
+    def test_logger_not_occupied(self):
+        self.assertEqual(0, len(logging.getLogger().handlers))
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_logging_test.py
+++ b/src/python/grpcio_tests/tests/unit/_logging_test.py
@@ -66,8 +66,7 @@ class LoggingTest(unittest.TestCase):
         intended_stream = six.StringIO()
         logging.basicConfig(stream=intended_stream)
         self.assertEqual(1, len(logging.getLogger().handlers))
-        self.assertTrue(
-            logging.getLogger().handlers[0].stream is intended_stream)
+        self.assertIs(logging.getLogger().handlers[0].stream, intended_stream)
 
 
 if __name__ == '__main__':

--- a/src/python/grpcio_tests/tests/unit/_logging_test.py
+++ b/src/python/grpcio_tests/tests/unit/_logging_test.py
@@ -45,10 +45,20 @@ class LoggingTest(unittest.TestCase):
     def test_handler_found(self):
         try:
             reload_module(logging)
-            logging.basicConfig()
             reload_module(grpc)
             self.assertFalse(
                 "No handlers could be found" in sys.stderr.getvalue())
+        finally:
+            reload_module(logging)
+
+    def test_can_configure_logger(self):
+        reload_module(logging)
+        reload_module(grpc)
+        try:
+            intended_stream = six.StringIO()
+            logging.basicConfig(stream=intended_stream)
+            self.assertEqual(1, len(logging.getLogger().handlers))
+            self.assertTrue(logging.getLogger().handlers[0].stream is intended_stream)
         finally:
             reload_module(logging)
 

--- a/src/python/grpcio_tests/tests/unit/_logging_test.py
+++ b/src/python/grpcio_tests/tests/unit/_logging_test.py
@@ -58,7 +58,8 @@ class LoggingTest(unittest.TestCase):
             intended_stream = six.StringIO()
             logging.basicConfig(stream=intended_stream)
             self.assertEqual(1, len(logging.getLogger().handlers))
-            self.assertTrue(logging.getLogger().handlers[0].stream is intended_stream)
+            self.assertTrue(
+                logging.getLogger().handlers[0].stream is intended_stream)
         finally:
             reload_module(logging)
 

--- a/src/python/grpcio_tests/tests/unit/_metadata_code_details_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_code_details_test.py
@@ -15,6 +15,7 @@
 
 import threading
 import unittest
+import logging
 
 import grpc
 
@@ -656,4 +657,5 @@ class MetadataCodeDetailsTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_metadata_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_test.py
@@ -15,6 +15,7 @@
 
 import unittest
 import weakref
+import logging
 
 import grpc
 from grpc import _channel
@@ -237,4 +238,5 @@ class MetadataTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_reconnect_test.py
+++ b/src/python/grpcio_tests/tests/unit/_reconnect_test.py
@@ -15,6 +15,7 @@
 
 import socket
 import time
+import logging
 import unittest
 
 import grpc
@@ -100,4 +101,5 @@ class ReconnectTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_resource_exhausted_test.py
+++ b/src/python/grpcio_tests/tests/unit/_resource_exhausted_test.py
@@ -15,6 +15,7 @@
 
 import threading
 import unittest
+import logging
 
 import grpc
 from grpc import _channel
@@ -253,4 +254,5 @@ class ResourceExhaustedTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_rpc_test.py
+++ b/src/python/grpcio_tests/tests/unit/_rpc_test.py
@@ -16,6 +16,7 @@
 import itertools
 import threading
 import unittest
+import logging
 from concurrent import futures
 
 import grpc
@@ -846,4 +847,5 @@ class RPCTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
@@ -35,6 +35,7 @@ import os
 import six
 import threading
 import unittest
+import logging
 
 from concurrent import futures
 
@@ -518,4 +519,5 @@ class ServerSSLCertReloadTestCertConfigReuse(_ServerSSLCertReloadTest):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_server_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_test.py
@@ -14,6 +14,7 @@
 
 from concurrent import futures
 import unittest
+import logging
 
 import grpc
 
@@ -49,4 +50,5 @@ class ServerTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig() 
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_server_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_test.py
@@ -50,5 +50,5 @@ class ServerTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    logging.basicConfig() 
+    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_session_cache_test.py
+++ b/src/python/grpcio_tests/tests/unit/_session_cache_test.py
@@ -15,6 +15,7 @@
 
 import pickle
 import unittest
+import logging
 
 import grpc
 from grpc import _channel
@@ -142,4 +143,5 @@ class SSLSessionCacheTest(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    logging.basicConfig()
     unittest.main(verbosity=2)


### PR DESCRIPTION
This PR addresses both https://github.com/grpc/grpc/issues/17017 and https://github.com/grpc/grpc/issues/16572. In https://github.com/grpc/grpc/pull/16378, we add calls to `logging.basicConfig()` in various modules, which added a handler to the root logger.

One potential solution to the problem is to by default configure each module-level logger with a [`NullHandler`](https://docs.python.org/2/library/logging.handlers.html#nullhandler). This does two things:
 - avoids the pesky "No handlers could be found" message
 - doesn't mess with the user's own logging

Without explicit configuration of a handler for the root logger in application code, this change will result in no logging output from `grpcio`. To address this issue for tests, I have added a call to `logging.basicConfig()` in all unit tests and test utilities I could identify. It's entirely possible I've missed some places.