### PR TITLE
Interceptors should see a Cancellation notification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12888,6 +12888,7 @@ if (gRPC_BUILD_TESTS)
 
 add_executable(end2end_test
   test/cpp/end2end/end2end_test.cc
+  test/cpp/end2end/interceptor_util.cc
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12888,7 +12888,7 @@ if (gRPC_BUILD_TESTS)
 
 add_executable(end2end_test
   test/cpp/end2end/end2end_test.cc
-  test/cpp/end2end/interceptor_util.cc
+  test/cpp/end2end/interceptors_util.cc
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12434,6 +12434,7 @@ if (gRPC_BUILD_TESTS)
 
 add_executable(client_interceptors_end2end_test
   test/cpp/end2end/client_interceptors_end2end_test.cc
+  test/cpp/end2end/interceptors_util.cc
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc
 )
@@ -15344,6 +15345,7 @@ endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 
 add_executable(server_interceptors_end2end_test
+  test/cpp/end2end/interceptors_util.cc
   test/cpp/end2end/server_interceptors_end2end_test.cc
   third_party/googletest/googletest/src/gtest-all.cc
   third_party/googletest/googlemock/src/gmock-all.cc

--- a/Makefile
+++ b/Makefile
@@ -17754,7 +17754,7 @@ endif
 
 END2END_TEST_SRC = \
     test/cpp/end2end/end2end_test.cc \
-    test/cpp/end2end/interceptor_util.cc \
+    test/cpp/end2end/interceptors_util.cc \
 
 END2END_TEST_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(END2END_TEST_SRC))))
 ifeq ($(NO_SECURE),true)
@@ -17787,7 +17787,7 @@ endif
 
 $(OBJDIR)/$(CONFIG)/test/cpp/end2end/end2end_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
 
-$(OBJDIR)/$(CONFIG)/test/cpp/end2end/interceptor_util.o:  $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
+$(OBJDIR)/$(CONFIG)/test/cpp/end2end/interceptors_util.o:  $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
 
 deps_end2end_test: $(END2END_TEST_OBJS:.o=.dep)
 

--- a/Makefile
+++ b/Makefile
@@ -17754,6 +17754,7 @@ endif
 
 END2END_TEST_SRC = \
     test/cpp/end2end/end2end_test.cc \
+    test/cpp/end2end/interceptor_util.cc \
 
 END2END_TEST_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(END2END_TEST_SRC))))
 ifeq ($(NO_SECURE),true)
@@ -17785,6 +17786,8 @@ endif
 endif
 
 $(OBJDIR)/$(CONFIG)/test/cpp/end2end/end2end_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
+
+$(OBJDIR)/$(CONFIG)/test/cpp/end2end/interceptor_util.o:  $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
 
 deps_end2end_test: $(END2END_TEST_OBJS:.o=.dep)
 

--- a/Makefile
+++ b/Makefile
@@ -17316,6 +17316,7 @@ endif
 
 CLIENT_INTERCEPTORS_END2END_TEST_SRC = \
     test/cpp/end2end/client_interceptors_end2end_test.cc \
+    test/cpp/end2end/interceptors_util.cc \
 
 CLIENT_INTERCEPTORS_END2END_TEST_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(CLIENT_INTERCEPTORS_END2END_TEST_SRC))))
 ifeq ($(NO_SECURE),true)
@@ -17347,6 +17348,8 @@ endif
 endif
 
 $(OBJDIR)/$(CONFIG)/test/cpp/end2end/client_interceptors_end2end_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
+
+$(OBJDIR)/$(CONFIG)/test/cpp/end2end/interceptors_util.o:  $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
 
 deps_client_interceptors_end2end_test: $(CLIENT_INTERCEPTORS_END2END_TEST_OBJS:.o=.dep)
 
@@ -20143,6 +20146,7 @@ endif
 
 
 SERVER_INTERCEPTORS_END2END_TEST_SRC = \
+    test/cpp/end2end/interceptors_util.cc \
     test/cpp/end2end/server_interceptors_end2end_test.cc \
 
 SERVER_INTERCEPTORS_END2END_TEST_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(SERVER_INTERCEPTORS_END2END_TEST_SRC))))
@@ -20173,6 +20177,8 @@ $(BINDIR)/$(CONFIG)/server_interceptors_end2end_test: $(PROTOBUF_DEP) $(SERVER_I
 endif
 
 endif
+
+$(OBJDIR)/$(CONFIG)/test/cpp/end2end/interceptors_util.o:  $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
 
 $(OBJDIR)/$(CONFIG)/test/cpp/end2end/server_interceptors_end2end_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc++_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr_test_util.a $(LIBDIR)/$(CONFIG)/libgpr.a
 

--- a/build.yaml
+++ b/build.yaml
@@ -4668,7 +4668,7 @@ targets:
   - test/cpp/end2end/interceptors_util.h
   src:
   - test/cpp/end2end/end2end_test.cc
-  - test/cpp/end2end/interceptor_util.cc
+  - test/cpp/end2end/interceptors_util.cc
   deps:
   - grpc++_test_util
   - grpc_test_util

--- a/build.yaml
+++ b/build.yaml
@@ -4537,6 +4537,7 @@ targets:
   - test/cpp/end2end/interceptors_util.h
   src:
   - test/cpp/end2end/client_interceptors_end2end_test.cc
+  - test/cpp/end2end/interceptors_util.cc
   deps:
   - grpc++_test_util
   - grpc_test_util
@@ -5464,6 +5465,7 @@ targets:
   headers:
   - test/cpp/end2end/interceptors_util.h
   src:
+  - test/cpp/end2end/interceptors_util.cc
   - test/cpp/end2end/server_interceptors_end2end_test.cc
   deps:
   - grpc++_test_util

--- a/build.yaml
+++ b/build.yaml
@@ -4664,8 +4664,11 @@ targets:
   cpu_cost: 0.5
   build: test
   language: c++
+  headers:
+  - test/cpp/end2end/interceptors_util.h
   src:
   - test/cpp/end2end/end2end_test.cc
+  - test/cpp/end2end/interceptor_util.cc
   deps:
   - grpc++_test_util
   - grpc_test_util

--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -214,11 +214,10 @@ class CallNoOp {
   void AddOp(grpc_op* ops, size_t* nops) {}
   void FinishOp(bool* status) {}
   void SetInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {}
+      InterceptorBatchMethodsImpl* interceptor_methods) {}
   void SetFinishInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {}
-  void SetHijackingState(InternalInterceptorBatchMethods* interceptor_methods) {
-  }
+      InterceptorBatchMethodsImpl* interceptor_methods) {}
+  void SetHijackingState(InterceptorBatchMethodsImpl* interceptor_methods) {}
 };
 
 class CallOpSendInitialMetadata {
@@ -265,7 +264,7 @@ class CallOpSendInitialMetadata {
   }
 
   void SetInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {
+      InterceptorBatchMethodsImpl* interceptor_methods) {
     if (!send_) return;
     interceptor_methods->AddInterceptionHookPoint(
         experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA);
@@ -273,9 +272,9 @@ class CallOpSendInitialMetadata {
   }
 
   void SetFinishInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {}
+      InterceptorBatchMethodsImpl* interceptor_methods) {}
 
-  void SetHijackingState(InternalInterceptorBatchMethods* interceptor_methods) {
+  void SetHijackingState(InterceptorBatchMethodsImpl* interceptor_methods) {
     hijacked_ = true;
   }
 
@@ -318,7 +317,7 @@ class CallOpSendMessage {
   void FinishOp(bool* status) { send_buf_.Clear(); }
 
   void SetInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {
+      InterceptorBatchMethodsImpl* interceptor_methods) {
     if (!send_buf_.Valid()) return;
     interceptor_methods->AddInterceptionHookPoint(
         experimental::InterceptionHookPoints::PRE_SEND_MESSAGE);
@@ -326,9 +325,9 @@ class CallOpSendMessage {
   }
 
   void SetFinishInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {}
+      InterceptorBatchMethodsImpl* interceptor_methods) {}
 
-  void SetHijackingState(InternalInterceptorBatchMethods* interceptor_methods) {
+  void SetHijackingState(InterceptorBatchMethodsImpl* interceptor_methods) {
     hijacked_ = true;
   }
 
@@ -406,17 +405,17 @@ class CallOpRecvMessage {
   }
 
   void SetInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {
+      InterceptorBatchMethodsImpl* interceptor_methods) {
     interceptor_methods->SetRecvMessage(message_);
   }
 
   void SetFinishInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {
+      InterceptorBatchMethodsImpl* interceptor_methods) {
     if (!got_message) return;
     interceptor_methods->AddInterceptionHookPoint(
         experimental::InterceptionHookPoints::POST_RECV_MESSAGE);
   }
-  void SetHijackingState(InternalInterceptorBatchMethods* interceptor_methods) {
+  void SetHijackingState(InterceptorBatchMethodsImpl* interceptor_methods) {
     hijacked_ = true;
     if (message_ == nullptr) return;
     interceptor_methods->AddInterceptionHookPoint(
@@ -501,17 +500,17 @@ class CallOpGenericRecvMessage {
   }
 
   void SetInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {
+      InterceptorBatchMethodsImpl* interceptor_methods) {
     interceptor_methods->SetRecvMessage(message_);
   }
 
   void SetFinishInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {
+      InterceptorBatchMethodsImpl* interceptor_methods) {
     if (!got_message) return;
     interceptor_methods->AddInterceptionHookPoint(
         experimental::InterceptionHookPoints::POST_RECV_MESSAGE);
   }
-  void SetHijackingState(InternalInterceptorBatchMethods* interceptor_methods) {
+  void SetHijackingState(InterceptorBatchMethodsImpl* interceptor_methods) {
     hijacked_ = true;
     if (!deserialize_) return;
     interceptor_methods->AddInterceptionHookPoint(
@@ -543,16 +542,16 @@ class CallOpClientSendClose {
   void FinishOp(bool* status) { send_ = false; }
 
   void SetInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {
+      InterceptorBatchMethodsImpl* interceptor_methods) {
     if (!send_) return;
     interceptor_methods->AddInterceptionHookPoint(
         experimental::InterceptionHookPoints::PRE_SEND_CLOSE);
   }
 
   void SetFinishInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {}
+      InterceptorBatchMethodsImpl* interceptor_methods) {}
 
-  void SetHijackingState(InternalInterceptorBatchMethods* interceptor_methods) {
+  void SetHijackingState(InterceptorBatchMethodsImpl* interceptor_methods) {
     hijacked_ = true;
   }
 
@@ -600,7 +599,7 @@ class CallOpServerSendStatus {
   }
 
   void SetInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {
+      InterceptorBatchMethodsImpl* interceptor_methods) {
     if (!send_status_available_) return;
     interceptor_methods->AddInterceptionHookPoint(
         experimental::InterceptionHookPoints::PRE_SEND_STATUS);
@@ -610,9 +609,9 @@ class CallOpServerSendStatus {
   }
 
   void SetFinishInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {}
+      InterceptorBatchMethodsImpl* interceptor_methods) {}
 
-  void SetHijackingState(InternalInterceptorBatchMethods* interceptor_methods) {
+  void SetHijackingState(InterceptorBatchMethodsImpl* interceptor_methods) {
     hijacked_ = true;
   }
 
@@ -652,19 +651,19 @@ class CallOpRecvInitialMetadata {
   }
 
   void SetInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {
+      InterceptorBatchMethodsImpl* interceptor_methods) {
     interceptor_methods->SetRecvInitialMetadata(metadata_map_);
   }
 
   void SetFinishInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {
+      InterceptorBatchMethodsImpl* interceptor_methods) {
     if (metadata_map_ == nullptr) return;
     interceptor_methods->AddInterceptionHookPoint(
         experimental::InterceptionHookPoints::POST_RECV_INITIAL_METADATA);
     metadata_map_ = nullptr;
   }
 
-  void SetHijackingState(InternalInterceptorBatchMethods* interceptor_methods) {
+  void SetHijackingState(InterceptorBatchMethodsImpl* interceptor_methods) {
     hijacked_ = true;
     if (metadata_map_ == nullptr) return;
     interceptor_methods->AddInterceptionHookPoint(
@@ -720,20 +719,20 @@ class CallOpClientRecvStatus {
   }
 
   void SetInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {
+      InterceptorBatchMethodsImpl* interceptor_methods) {
     interceptor_methods->SetRecvStatus(recv_status_);
     interceptor_methods->SetRecvTrailingMetadata(metadata_map_);
   }
 
   void SetFinishInterceptionHookPoint(
-      InternalInterceptorBatchMethods* interceptor_methods) {
+      InterceptorBatchMethodsImpl* interceptor_methods) {
     if (recv_status_ == nullptr) return;
     interceptor_methods->AddInterceptionHookPoint(
         experimental::InterceptionHookPoints::POST_RECV_STATUS);
     recv_status_ = nullptr;
   }
 
-  void SetHijackingState(InternalInterceptorBatchMethods* interceptor_methods) {
+  void SetHijackingState(InterceptorBatchMethodsImpl* interceptor_methods) {
     hijacked_ = true;
     if (recv_status_ == nullptr) return;
     interceptor_methods->AddInterceptionHookPoint(

--- a/include/grpcpp/impl/codegen/client_context.h
+++ b/include/grpcpp/impl/codegen/client_context.h
@@ -426,6 +426,8 @@ class ClientContext {
 
   grpc::string authority() { return authority_; }
 
+  void SendCancelToInterceptors();
+
   bool initial_metadata_received_;
   bool wait_for_ready_;
   bool wait_for_ready_explicitly_set_;

--- a/include/grpcpp/impl/codegen/interceptor.h
+++ b/include/grpcpp/impl/codegen/interceptor.h
@@ -56,6 +56,9 @@ enum class InterceptionHookPoints {
   POST_RECV_MESSAGE,
   POST_RECV_STATUS /* client only */,
   POST_RECV_CLOSE /* server only */,
+  /* This is a special hook point available to both clients and servers. It is
+     illegal for an interceptor to block/delay this operation */
+  PRE_SEND_CANCEL,
   NUM_INTERCEPTION_HOOKS
 };
 
@@ -66,7 +69,9 @@ class InterceptorBatchMethods {
   // of type \a type
   virtual bool QueryInterceptionHookPoint(InterceptionHookPoints type) = 0;
   // Calling this will signal that the interceptor is done intercepting the
-  // current batch of the RPC
+  // current batch of the RPC.
+  // Proceed is a no-op if the batch contains PRE_SEND_CANCEL. Simply returning
+  // from the Intercept method does the job of continuing the RPC.
   virtual void Proceed() = 0;
   // Calling this indicates that the interceptor has hijacked the RPC (only
   // valid if the batch contains send_initial_metadata on the client side)

--- a/include/grpcpp/impl/codegen/interceptor.h
+++ b/include/grpcpp/impl/codegen/interceptor.h
@@ -56,8 +56,10 @@ enum class InterceptionHookPoints {
   POST_RECV_MESSAGE,
   POST_RECV_STATUS /* client only */,
   POST_RECV_CLOSE /* server only */,
-  /* This is a special hook point available to both clients and servers. It is
-     illegal for an interceptor to block/delay this operation */
+  /* This is a special hook point available to both clients and servers when
+     TryCancel() is performed. It is illegal for an interceptor to block/delay
+     this operation. ALL interceptors see this hook point irrespective of
+     whether the RPC was hijacked or not. */
   PRE_SEND_CANCEL,
   NUM_INTERCEPTION_HOOKS
 };
@@ -71,7 +73,7 @@ class InterceptorBatchMethods {
   // Calling this will signal that the interceptor is done intercepting the
   // current batch of the RPC.
   // Proceed is a no-op if the batch contains PRE_SEND_CANCEL. Simply returning
-  // from the Intercept method does the job of continuing the RPC.
+  // from the Intercept method does the job of continuing the RPC in this case.
   virtual void Proceed() = 0;
   // Calling this indicates that the interceptor has hijacked the RPC (only
   // valid if the batch contains send_initial_metadata on the client side)

--- a/include/grpcpp/impl/codegen/interceptor_common.h
+++ b/include/grpcpp/impl/codegen/interceptor_common.h
@@ -352,6 +352,105 @@ class InterceptorBatchMethodsImpl
   MetadataMap* recv_trailing_metadata_ = nullptr;
 };
 
+// A special implementation of InterceptorBatchMethods to send a Cancel
+// notification down the interceptor stack
+class CancelInterceptorBatchMethods
+    : public experimental::InterceptorBatchMethods {
+ public:
+  bool QueryInterceptionHookPoint(
+      experimental::InterceptionHookPoints type) override {
+    if (type == experimental::InterceptionHookPoints::PRE_SEND_CANCEL) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  void Proceed() override {
+    // This is a no-op. For actual continuation of the RPC simply needs to
+    // return from the Intercept method
+  }
+
+  void Hijack() override {
+    // Only the client can hijack when sending down initial metadata
+    GPR_CODEGEN_ASSERT(false &&
+                       "It is illegal to call Hijack on a method which has a "
+                       "Cancel notification");
+  }
+
+  ByteBuffer* GetSendMessage() override {
+    GPR_CODEGEN_ASSERT(false &&
+                       "It is illegal to call GetSendMessage on a method which "
+                       "has a Cancel notification");
+    return nullptr;
+  }
+
+  std::multimap<grpc::string, grpc::string>* GetSendInitialMetadata() override {
+    GPR_CODEGEN_ASSERT(false &&
+                       "It is illegal to call GetSendInitialMetadata on a "
+                       "method which has a Cancel notification");
+    return nullptr;
+  }
+
+  Status GetSendStatus() override {
+    GPR_CODEGEN_ASSERT(false &&
+                       "It is illegal to call GetSendStatus on a method which "
+                       "has a Cancel notification");
+    return Status();
+  }
+
+  void ModifySendStatus(const Status& status) override {
+    GPR_CODEGEN_ASSERT(false &&
+                       "It is illegal to call ModifySendStatus on a method "
+                       "which has a Cancel notification");
+    return;
+  }
+
+  std::multimap<grpc::string, grpc::string>* GetSendTrailingMetadata()
+      override {
+    GPR_CODEGEN_ASSERT(false &&
+                       "It is illegal to call GetSendTrailingMetadata on a "
+                       "method which has a Cancel notification");
+    return nullptr;
+  }
+
+  void* GetRecvMessage() override {
+    GPR_CODEGEN_ASSERT(false &&
+                       "It is illegal to call GetRecvMessage on a method which "
+                       "has a Cancel notification");
+    return nullptr;
+  }
+
+  std::multimap<grpc::string_ref, grpc::string_ref>* GetRecvInitialMetadata()
+      override {
+    GPR_CODEGEN_ASSERT(false &&
+                       "It is illegal to call GetRecvInitialMetadata on a "
+                       "method which has a Cancel notification");
+    return nullptr;
+  }
+
+  Status* GetRecvStatus() override {
+    GPR_CODEGEN_ASSERT(false &&
+                       "It is illegal to call GetRecvStatus on a method which "
+                       "has a Cancel notification");
+    return nullptr;
+  }
+
+  std::multimap<grpc::string_ref, grpc::string_ref>* GetRecvTrailingMetadata()
+      override {
+    GPR_CODEGEN_ASSERT(false &&
+                       "It is illegal to call GetRecvTrailingMetadata on a "
+                       "method which has a Cancel notification");
+    return nullptr;
+  }
+
+  std::unique_ptr<ChannelInterface> GetInterceptedChannel() {
+    GPR_CODEGEN_ASSERT(false &&
+                       "It is illegal to call GetInterceptedChannel on a "
+                       "method which has a Cancel notification");
+    return std::unique_ptr<ChannelInterface>(nullptr);
+  }
+};
 }  // namespace internal
 }  // namespace grpc
 

--- a/include/grpcpp/impl/codegen/interceptor_common.h
+++ b/include/grpcpp/impl/codegen/interceptor_common.h
@@ -19,6 +19,7 @@
 #ifndef GRPCPP_IMPL_CODEGEN_INTERCEPTOR_COMMON_H
 #define GRPCPP_IMPL_CODEGEN_INTERCEPTOR_COMMON_H
 
+#include <array>
 #include <functional>
 
 #include <grpcpp/impl/codegen/call.h>

--- a/include/grpcpp/impl/codegen/interceptor_common.h
+++ b/include/grpcpp/impl/codegen/interceptor_common.h
@@ -145,7 +145,7 @@ class InterceptorBatchMethodsImpl
     recv_trailing_metadata_ = map;
   }
 
-  std::unique_ptr<ChannelInterface> GetInterceptedChannel() {
+  std::unique_ptr<ChannelInterface> GetInterceptedChannel() override {
     auto* info = call_->client_rpc_info();
     if (info == nullptr) {
       return std::unique_ptr<ChannelInterface>(nullptr);
@@ -444,7 +444,7 @@ class CancelInterceptorBatchMethods
     return nullptr;
   }
 
-  std::unique_ptr<ChannelInterface> GetInterceptedChannel() {
+  std::unique_ptr<ChannelInterface> GetInterceptedChannel() override {
     GPR_CODEGEN_ASSERT(false &&
                        "It is illegal to call GetInterceptedChannel on a "
                        "method which has a Cancel notification");

--- a/src/cpp/client/channel_cc.cc
+++ b/src/cpp/client/channel_cc.cc
@@ -147,10 +147,14 @@ internal::Call Channel::CreateCallInternal(const internal::RpcMethod& method,
     }
   }
   grpc_census_call_set_context(c_call, context->census_context());
-  context->set_call(c_call, shared_from_this());
 
+  // ClientRpcInfo should be set before call because set_call also checks
+  // whether the call has been cancelled, and if the call was cancelled, we
+  // should notify the interceptors too/
   auto* info = context->set_client_rpc_info(
       method.name(), this, interceptor_creators_, interceptor_pos);
+  context->set_call(c_call, shared_from_this());
+
   return internal::Call(c_call, this, cq, info);
 }
 

--- a/src/cpp/client/client_context.cc
+++ b/src/cpp/client/client_context.cc
@@ -87,10 +87,13 @@ void ClientContext::set_call(grpc_call* call,
   call_ = call;
   channel_ = channel;
   if (creds_ && !creds_->ApplyToCall(call_)) {
+    // TODO(yashykt): should interceptors also see this status?
+    SendCancelToInterceptors();
     grpc_call_cancel_with_status(call, GRPC_STATUS_CANCELLED,
                                  "Failed to set credentials to rpc.", nullptr);
   }
   if (call_canceled_) {
+    SendCancelToInterceptors();
     grpc_call_cancel(call_, nullptr);
   }
 }
@@ -111,13 +114,17 @@ void ClientContext::set_compression_algorithm(
 void ClientContext::TryCancel() {
   std::unique_lock<std::mutex> lock(mu_);
   if (call_) {
-    internal::CancelInterceptorBatchMethods cancel_methods;
-    for (size_t i = 0; i < rpc_info_.interceptors_.size(); i++) {
-      rpc_info_.RunInterceptor(&cancel_methods, i);
-    }
+    SendCancelToInterceptors();
     grpc_call_cancel(call_, nullptr);
   } else {
     call_canceled_ = true;
+  }
+}
+
+void ClientContext::SendCancelToInterceptors() {
+  internal::CancelInterceptorBatchMethods cancel_methods;
+  for (size_t i = 0; i < rpc_info_.interceptors_.size(); i++) {
+    rpc_info_.RunInterceptor(&cancel_methods, i);
   }
 }
 

--- a/src/cpp/client/client_context.cc
+++ b/src/cpp/client/client_context.cc
@@ -111,9 +111,10 @@ void ClientContext::set_compression_algorithm(
 void ClientContext::TryCancel() {
   std::unique_lock<std::mutex> lock(mu_);
   if (call_) {
-    // for(size_t i = 0; i < rpc_info_.interceptors_.size(); i++) {
-    // rpc_info_.RunInterceptor(, 0);
-    //}
+    internal::CancelInterceptorBatchMethods cancel_methods;
+    for (size_t i = 0; i < rpc_info_.interceptors_.size(); i++) {
+      rpc_info_.RunInterceptor(&cancel_methods, i);
+    }
     grpc_call_cancel(call_, nullptr);
   } else {
     call_canceled_ = true;

--- a/src/cpp/client/client_context.cc
+++ b/src/cpp/client/client_context.cc
@@ -24,6 +24,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 
+#include <grpcpp/impl/codegen/interceptor_common.h>
 #include <grpcpp/impl/grpc_library.h>
 #include <grpcpp/security/credentials.h>
 #include <grpcpp/server_context.h>
@@ -110,6 +111,9 @@ void ClientContext::set_compression_algorithm(
 void ClientContext::TryCancel() {
   std::unique_lock<std::mutex> lock(mu_);
   if (call_) {
+    // for(size_t i = 0; i < rpc_info_.interceptors_.size(); i++) {
+    // rpc_info_.RunInterceptor(, 0);
+    //}
     grpc_call_cancel(call_, nullptr);
   } else {
     call_canceled_ = true;

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -275,6 +275,12 @@ void ServerContext::AddTrailingMetadata(const grpc::string& key,
 }
 
 void ServerContext::TryCancel() const {
+  internal::CancelInterceptorBatchMethods cancel_methods;
+  if (rpc_info_) {
+    for (size_t i = 0; i < rpc_info_->interceptors_.size(); i++) {
+      rpc_info_->RunInterceptor(&cancel_methods, i);
+    }
+  }
   grpc_call_error err = grpc_call_cancel_with_status(
       call_, GRPC_STATUS_CANCELLED, "Cancelled on the server side", nullptr);
   if (err != GRPC_CALL_OK) {

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -159,6 +159,7 @@ grpc_cc_library(
         "gtest",
     ],
     deps = [
+        ":interceptors_util",
         ":test_service_impl",
         "//:gpr",
         "//:grpc",

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -38,6 +38,7 @@ grpc_cc_library(
 grpc_cc_library(
     name = "interceptors_util",
     testonly = True,
+    srcs = ["interceptors_util.cc"],
     hdrs = ["interceptors_util.h"],
     external_deps = [
         "gtest",

--- a/test/cpp/end2end/client_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/client_interceptors_end2end_test.cc
@@ -43,44 +43,6 @@ namespace grpc {
 namespace testing {
 namespace {
 
-class ClientInterceptorsStreamingEnd2endTest : public ::testing::Test {
- protected:
-  ClientInterceptorsStreamingEnd2endTest() {
-    int port = grpc_pick_unused_port_or_die();
-
-    ServerBuilder builder;
-    server_address_ = "localhost:" + std::to_string(port);
-    builder.AddListeningPort(server_address_, InsecureServerCredentials());
-    builder.RegisterService(&service_);
-    server_ = builder.BuildAndStart();
-  }
-
-  ~ClientInterceptorsStreamingEnd2endTest() { server_->Shutdown(); }
-
-  std::string server_address_;
-  EchoTestServiceStreamingImpl service_;
-  std::unique_ptr<Server> server_;
-};
-
-class ClientInterceptorsEnd2endTest : public ::testing::Test {
- protected:
-  ClientInterceptorsEnd2endTest() {
-    int port = grpc_pick_unused_port_or_die();
-
-    ServerBuilder builder;
-    server_address_ = "localhost:" + std::to_string(port);
-    builder.AddListeningPort(server_address_, InsecureServerCredentials());
-    builder.RegisterService(&service_);
-    server_ = builder.BuildAndStart();
-  }
-
-  ~ClientInterceptorsEnd2endTest() { server_->Shutdown(); }
-
-  std::string server_address_;
-  TestServiceImpl service_;
-  std::unique_ptr<Server> server_;
-};
-
 /* Hijacks Echo RPC and fills in the expected values */
 class HijackingInterceptor : public experimental::Interceptor {
  public:
@@ -377,6 +339,25 @@ class LoggingInterceptorFactory
   }
 };
 
+class ClientInterceptorsEnd2endTest : public ::testing::Test {
+ protected:
+  ClientInterceptorsEnd2endTest() {
+    int port = grpc_pick_unused_port_or_die();
+
+    ServerBuilder builder;
+    server_address_ = "localhost:" + std::to_string(port);
+    builder.AddListeningPort(server_address_, InsecureServerCredentials());
+    builder.RegisterService(&service_);
+    server_ = builder.BuildAndStart();
+  }
+
+  ~ClientInterceptorsEnd2endTest() { server_->Shutdown(); }
+
+  std::string server_address_;
+  TestServiceImpl service_;
+  std::unique_ptr<Server> server_;
+};
+
 TEST_F(ClientInterceptorsEnd2endTest, ClientInterceptorLoggingTest) {
   ChannelArguments args;
   DummyInterceptor::Reset();
@@ -492,6 +473,25 @@ TEST_F(ClientInterceptorsEnd2endTest,
   // Make sure all 20 dummy interceptors were run
   EXPECT_EQ(DummyInterceptor::GetNumTimesRun(), 20);
 }
+
+class ClientInterceptorsStreamingEnd2endTest : public ::testing::Test {
+ protected:
+  ClientInterceptorsStreamingEnd2endTest() {
+    int port = grpc_pick_unused_port_or_die();
+
+    ServerBuilder builder;
+    server_address_ = "localhost:" + std::to_string(port);
+    builder.AddListeningPort(server_address_, InsecureServerCredentials());
+    builder.RegisterService(&service_);
+    server_ = builder.BuildAndStart();
+  }
+
+  ~ClientInterceptorsStreamingEnd2endTest() { server_->Shutdown(); }
+
+  std::string server_address_;
+  EchoTestServiceStreamingImpl service_;
+  std::unique_ptr<Server> server_;
+};
 
 TEST_F(ClientInterceptorsStreamingEnd2endTest, ClientStreamingTest) {
   ChannelArguments args;

--- a/test/cpp/end2end/client_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/client_interceptors_end2end_test.cc
@@ -81,51 +81,6 @@ class ClientInterceptorsEnd2endTest : public ::testing::Test {
   std::unique_ptr<Server> server_;
 };
 
-/* This interceptor does nothing. Just keeps a global count on the number of
- * times it was invoked. */
-class DummyInterceptor : public experimental::Interceptor {
- public:
-  DummyInterceptor(experimental::ClientRpcInfo* info) {}
-
-  virtual void Intercept(experimental::InterceptorBatchMethods* methods) {
-    if (methods->QueryInterceptionHookPoint(
-            experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
-      num_times_run_++;
-    } else if (methods->QueryInterceptionHookPoint(
-                   experimental::InterceptionHookPoints::
-                       POST_RECV_INITIAL_METADATA)) {
-      num_times_run_reverse_++;
-    }
-    methods->Proceed();
-  }
-
-  static void Reset() {
-    num_times_run_.store(0);
-    num_times_run_reverse_.store(0);
-  }
-
-  static int GetNumTimesRun() {
-    EXPECT_EQ(num_times_run_.load(), num_times_run_reverse_.load());
-    return num_times_run_.load();
-  }
-
- private:
-  static std::atomic<int> num_times_run_;
-  static std::atomic<int> num_times_run_reverse_;
-};
-
-std::atomic<int> DummyInterceptor::num_times_run_;
-std::atomic<int> DummyInterceptor::num_times_run_reverse_;
-
-class DummyInterceptorFactory
-    : public experimental::ClientInterceptorFactoryInterface {
- public:
-  virtual experimental::Interceptor* CreateClientInterceptor(
-      experimental::ClientRpcInfo* info) override {
-    return new DummyInterceptor(info);
-  }
-};
-
 /* Hijacks Echo RPC and fills in the expected values */
 class HijackingInterceptor : public experimental::Interceptor {
  public:

--- a/test/cpp/end2end/interceptors_util.cc
+++ b/test/cpp/end2end/interceptors_util.cc
@@ -1,0 +1,134 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "test/cpp/end2end/interceptors_util.h"
+
+namespace grpc {
+namespace testing {
+
+std::atomic<int> DummyInterceptor::num_times_run_;
+std::atomic<int> DummyInterceptor::num_times_run_reverse_;
+
+void MakeCall(const std::shared_ptr<Channel>& channel) {
+  auto stub = grpc::testing::EchoTestService::NewStub(channel);
+  ClientContext ctx;
+  EchoRequest req;
+  req.mutable_param()->set_echo_metadata(true);
+  ctx.AddMetadata("testkey", "testvalue");
+  req.set_message("Hello");
+  EchoResponse resp;
+  Status s = stub->Echo(&ctx, req, &resp);
+  EXPECT_EQ(s.ok(), true);
+  EXPECT_EQ(resp.message(), "Hello");
+}
+
+void MakeClientStreamingCall(const std::shared_ptr<Channel>& channel) {
+  auto stub = grpc::testing::EchoTestService::NewStub(channel);
+  ClientContext ctx;
+  EchoRequest req;
+  req.mutable_param()->set_echo_metadata(true);
+  ctx.AddMetadata("testkey", "testvalue");
+  req.set_message("Hello");
+  EchoResponse resp;
+  string expected_resp = "";
+  auto writer = stub->RequestStream(&ctx, &resp);
+  for (int i = 0; i < 10; i++) {
+    writer->Write(req);
+    expected_resp += "Hello";
+  }
+  writer->WritesDone();
+  Status s = writer->Finish();
+  EXPECT_EQ(s.ok(), true);
+  EXPECT_EQ(resp.message(), expected_resp);
+}
+
+void MakeServerStreamingCall(const std::shared_ptr<Channel>& channel) {
+  auto stub = grpc::testing::EchoTestService::NewStub(channel);
+  ClientContext ctx;
+  EchoRequest req;
+  req.mutable_param()->set_echo_metadata(true);
+  ctx.AddMetadata("testkey", "testvalue");
+  req.set_message("Hello");
+  EchoResponse resp;
+  string expected_resp = "";
+  auto reader = stub->ResponseStream(&ctx, req);
+  int count = 0;
+  while (reader->Read(&resp)) {
+    EXPECT_EQ(resp.message(), "Hello");
+    count++;
+  }
+  ASSERT_EQ(count, 10);
+  Status s = reader->Finish();
+  EXPECT_EQ(s.ok(), true);
+}
+
+void MakeBidiStreamingCall(const std::shared_ptr<Channel>& channel) {
+  auto stub = grpc::testing::EchoTestService::NewStub(channel);
+  ClientContext ctx;
+  EchoRequest req;
+  EchoResponse resp;
+  ctx.AddMetadata("testkey", "testvalue");
+  auto stream = stub->BidiStream(&ctx);
+  for (auto i = 0; i < 10; i++) {
+    req.set_message("Hello" + std::to_string(i));
+    stream->Write(req);
+    stream->Read(&resp);
+    EXPECT_EQ(req.message(), resp.message());
+  }
+  ASSERT_TRUE(stream->WritesDone());
+  Status s = stream->Finish();
+  EXPECT_EQ(s.ok(), true);
+}
+
+void MakeCallbackCall(const std::shared_ptr<Channel>& channel) {
+  auto stub = grpc::testing::EchoTestService::NewStub(channel);
+  ClientContext ctx;
+  EchoRequest req;
+  std::mutex mu;
+  std::condition_variable cv;
+  bool done = false;
+  req.mutable_param()->set_echo_metadata(true);
+  ctx.AddMetadata("testkey", "testvalue");
+  req.set_message("Hello");
+  EchoResponse resp;
+  stub->experimental_async()->Echo(&ctx, &req, &resp,
+                                   [&resp, &mu, &done, &cv](Status s) {
+                                     // gpr_log(GPR_ERROR, "got the callback");
+                                     EXPECT_EQ(s.ok(), true);
+                                     EXPECT_EQ(resp.message(), "Hello");
+                                     std::lock_guard<std::mutex> l(mu);
+                                     done = true;
+                                     cv.notify_one();
+                                   });
+  std::unique_lock<std::mutex> l(mu);
+  while (!done) {
+    cv.wait(l);
+  }
+}
+
+bool CheckMetadata(const std::multimap<grpc::string_ref, grpc::string_ref>& map,
+                   const string& key, const string& value) {
+  for (const auto& pair : map) {
+    if (pair.first.starts_with(key) && pair.second.starts_with(value)) {
+      return true;
+    }
+  }
+  return false;
+}
+}  // namespace testing
+}  // namespace grpc

--- a/test/cpp/end2end/interceptors_util.cc
+++ b/test/cpp/end2end/interceptors_util.cc
@@ -131,5 +131,21 @@ bool CheckMetadata(const std::multimap<grpc::string_ref, grpc::string_ref>& map,
   }
   return false;
 }
+
+std::unique_ptr<std::vector<
+    std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>>
+CreateDummyClientInterceptors() {
+  auto creators = std::unique_ptr<std::vector<
+      std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>>(
+      new std::vector<
+          std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>());
+  // Add 20 dummy interceptors before hijacking interceptor
+  for (auto i = 0; i < 20; i++) {
+    creators->push_back(std::unique_ptr<DummyInterceptorFactory>(
+        new DummyInterceptorFactory()));
+  }
+  return creators;
+}
+
 }  // namespace testing
 }  // namespace grpc

--- a/test/cpp/end2end/interceptors_util.cc
+++ b/test/cpp/end2end/interceptors_util.cc
@@ -23,6 +23,7 @@ namespace testing {
 
 std::atomic<int> DummyInterceptor::num_times_run_;
 std::atomic<int> DummyInterceptor::num_times_run_reverse_;
+std::atomic<int> DummyInterceptor::num_times_cancel_;
 
 void MakeCall(const std::shared_ptr<Channel>& channel) {
   auto stub = grpc::testing::EchoTestService::NewStub(channel);

--- a/test/cpp/end2end/interceptors_util.h
+++ b/test/cpp/end2end/interceptors_util.h
@@ -41,6 +41,9 @@ class DummyInterceptor : public experimental::Interceptor {
                    experimental::InterceptionHookPoints::
                        POST_RECV_INITIAL_METADATA)) {
       num_times_run_reverse_++;
+    } else if (methods->QueryInterceptionHookPoint(
+                   experimental::InterceptionHookPoints::PRE_SEND_CANCEL)) {
+      num_times_cancel_++;
     }
     methods->Proceed();
   }
@@ -48,6 +51,7 @@ class DummyInterceptor : public experimental::Interceptor {
   static void Reset() {
     num_times_run_.store(0);
     num_times_run_reverse_.store(0);
+    num_times_cancel_.store(0);
   }
 
   static int GetNumTimesRun() {
@@ -55,9 +59,12 @@ class DummyInterceptor : public experimental::Interceptor {
     return num_times_run_.load();
   }
 
+  static int GetNumTimesCancel() { return num_times_cancel_.load(); }
+
  private:
   static std::atomic<int> num_times_run_;
   static std::atomic<int> num_times_run_reverse_;
+  static std::atomic<int> num_times_cancel_;
 };
 
 class DummyInterceptorFactory

--- a/test/cpp/end2end/interceptors_util.h
+++ b/test/cpp/end2end/interceptors_util.h
@@ -149,6 +149,10 @@ void MakeCallbackCall(const std::shared_ptr<Channel>& channel);
 bool CheckMetadata(const std::multimap<grpc::string_ref, grpc::string_ref>& map,
                    const string& key, const string& value);
 
+std::unique_ptr<std::vector<
+    std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>>
+CreateDummyClientInterceptors();
+
 inline void* tag(int i) { return (void*)static_cast<intptr_t>(i); }
 inline int detag(void* p) {
   return static_cast<int>(reinterpret_cast<intptr_t>(p));

--- a/test/cpp/end2end/interceptors_util.h
+++ b/test/cpp/end2end/interceptors_util.h
@@ -16,6 +16,10 @@
  *
  */
 
+#include <condition_variable>
+
+#include <grpcpp/channel.h>
+
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/cpp/util/string_ref_helper.h"
 
@@ -23,6 +27,54 @@
 
 namespace grpc {
 namespace testing {
+/* This interceptor does nothing. Just keeps a global count on the number of
+ * times it was invoked. */
+class DummyInterceptor : public experimental::Interceptor {
+ public:
+  DummyInterceptor() {}
+
+  virtual void Intercept(experimental::InterceptorBatchMethods* methods) {
+    if (methods->QueryInterceptionHookPoint(
+            experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
+      num_times_run_++;
+    } else if (methods->QueryInterceptionHookPoint(
+                   experimental::InterceptionHookPoints::
+                       POST_RECV_INITIAL_METADATA)) {
+      num_times_run_reverse_++;
+    }
+    methods->Proceed();
+  }
+
+  static void Reset() {
+    num_times_run_.store(0);
+    num_times_run_reverse_.store(0);
+  }
+
+  static int GetNumTimesRun() {
+    EXPECT_EQ(num_times_run_.load(), num_times_run_reverse_.load());
+    return num_times_run_.load();
+  }
+
+ private:
+  static std::atomic<int> num_times_run_;
+  static std::atomic<int> num_times_run_reverse_;
+};
+
+class DummyInterceptorFactory
+    : public experimental::ClientInterceptorFactoryInterface,
+      public experimental::ServerInterceptorFactoryInterface {
+ public:
+  virtual experimental::Interceptor* CreateClientInterceptor(
+      experimental::ClientRpcInfo* info) override {
+    return new DummyInterceptor();
+  }
+
+  virtual experimental::Interceptor* CreateServerInterceptor(
+      experimental::ServerRpcInfo* info) override {
+    return new DummyInterceptor();
+  }
+};
+
 class EchoTestServiceStreamingImpl : public EchoTestService::Service {
  public:
   ~EchoTestServiceStreamingImpl() override {}
@@ -77,115 +129,23 @@ class EchoTestServiceStreamingImpl : public EchoTestService::Service {
   }
 };
 
-void MakeCall(const std::shared_ptr<Channel>& channel) {
-  auto stub = grpc::testing::EchoTestService::NewStub(channel);
-  ClientContext ctx;
-  EchoRequest req;
-  req.mutable_param()->set_echo_metadata(true);
-  ctx.AddMetadata("testkey", "testvalue");
-  req.set_message("Hello");
-  EchoResponse resp;
-  Status s = stub->Echo(&ctx, req, &resp);
-  EXPECT_EQ(s.ok(), true);
-  EXPECT_EQ(resp.message(), "Hello");
-}
+void MakeCall(const std::shared_ptr<Channel>& channel);
 
-void MakeClientStreamingCall(const std::shared_ptr<Channel>& channel) {
-  auto stub = grpc::testing::EchoTestService::NewStub(channel);
-  ClientContext ctx;
-  EchoRequest req;
-  req.mutable_param()->set_echo_metadata(true);
-  ctx.AddMetadata("testkey", "testvalue");
-  req.set_message("Hello");
-  EchoResponse resp;
-  string expected_resp = "";
-  auto writer = stub->RequestStream(&ctx, &resp);
-  for (int i = 0; i < 10; i++) {
-    writer->Write(req);
-    expected_resp += "Hello";
-  }
-  writer->WritesDone();
-  Status s = writer->Finish();
-  EXPECT_EQ(s.ok(), true);
-  EXPECT_EQ(resp.message(), expected_resp);
-}
+void MakeClientStreamingCall(const std::shared_ptr<Channel>& channel);
 
-void MakeServerStreamingCall(const std::shared_ptr<Channel>& channel) {
-  auto stub = grpc::testing::EchoTestService::NewStub(channel);
-  ClientContext ctx;
-  EchoRequest req;
-  req.mutable_param()->set_echo_metadata(true);
-  ctx.AddMetadata("testkey", "testvalue");
-  req.set_message("Hello");
-  EchoResponse resp;
-  string expected_resp = "";
-  auto reader = stub->ResponseStream(&ctx, req);
-  int count = 0;
-  while (reader->Read(&resp)) {
-    EXPECT_EQ(resp.message(), "Hello");
-    count++;
-  }
-  ASSERT_EQ(count, 10);
-  Status s = reader->Finish();
-  EXPECT_EQ(s.ok(), true);
-}
+void MakeServerStreamingCall(const std::shared_ptr<Channel>& channel);
 
-void MakeBidiStreamingCall(const std::shared_ptr<Channel>& channel) {
-  auto stub = grpc::testing::EchoTestService::NewStub(channel);
-  ClientContext ctx;
-  EchoRequest req;
-  EchoResponse resp;
-  ctx.AddMetadata("testkey", "testvalue");
-  auto stream = stub->BidiStream(&ctx);
-  for (auto i = 0; i < 10; i++) {
-    req.set_message("Hello" + std::to_string(i));
-    stream->Write(req);
-    stream->Read(&resp);
-    EXPECT_EQ(req.message(), resp.message());
-  }
-  ASSERT_TRUE(stream->WritesDone());
-  Status s = stream->Finish();
-  EXPECT_EQ(s.ok(), true);
-}
+void MakeBidiStreamingCall(const std::shared_ptr<Channel>& channel);
 
-void MakeCallbackCall(const std::shared_ptr<Channel>& channel) {
-  auto stub = grpc::testing::EchoTestService::NewStub(channel);
-  ClientContext ctx;
-  EchoRequest req;
-  std::mutex mu;
-  std::condition_variable cv;
-  bool done = false;
-  req.mutable_param()->set_echo_metadata(true);
-  ctx.AddMetadata("testkey", "testvalue");
-  req.set_message("Hello");
-  EchoResponse resp;
-  stub->experimental_async()->Echo(&ctx, &req, &resp,
-                                   [&resp, &mu, &done, &cv](Status s) {
-                                     // gpr_log(GPR_ERROR, "got the callback");
-                                     EXPECT_EQ(s.ok(), true);
-                                     EXPECT_EQ(resp.message(), "Hello");
-                                     std::lock_guard<std::mutex> l(mu);
-                                     done = true;
-                                     cv.notify_one();
-                                   });
-  std::unique_lock<std::mutex> l(mu);
-  while (!done) {
-    cv.wait(l);
-  }
-}
+void MakeCallbackCall(const std::shared_ptr<Channel>& channel);
 
 bool CheckMetadata(const std::multimap<grpc::string_ref, grpc::string_ref>& map,
-                   const string& key, const string& value) {
-  for (const auto& pair : map) {
-    if (pair.first.starts_with(key) && pair.second.starts_with(value)) {
-      return true;
-    }
-  }
-  return false;
-}
+                   const string& key, const string& value);
 
-void* tag(int i) { return (void*)static_cast<intptr_t>(i); }
-int detag(void* p) { return static_cast<int>(reinterpret_cast<intptr_t>(p)); }
+inline void* tag(int i) { return (void*)static_cast<intptr_t>(i); }
+inline int detag(void* p) {
+  return static_cast<int>(reinterpret_cast<intptr_t>(p));
+}
 
 class Verifier {
  public:

--- a/test/cpp/end2end/server_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/server_interceptors_end2end_test.cc
@@ -42,51 +42,6 @@ namespace grpc {
 namespace testing {
 namespace {
 
-/* This interceptor does nothing. Just keeps a global count on the number of
- * times it was invoked. */
-class DummyInterceptor : public experimental::Interceptor {
- public:
-  DummyInterceptor(experimental::ServerRpcInfo* info) {}
-
-  virtual void Intercept(experimental::InterceptorBatchMethods* methods) {
-    if (methods->QueryInterceptionHookPoint(
-            experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
-      num_times_run_++;
-    } else if (methods->QueryInterceptionHookPoint(
-                   experimental::InterceptionHookPoints::
-                       POST_RECV_INITIAL_METADATA)) {
-      num_times_run_reverse_++;
-    }
-    methods->Proceed();
-  }
-
-  static void Reset() {
-    num_times_run_.store(0);
-    num_times_run_reverse_.store(0);
-  }
-
-  static int GetNumTimesRun() {
-    EXPECT_EQ(num_times_run_.load(), num_times_run_reverse_.load());
-    return num_times_run_.load();
-  }
-
- private:
-  static std::atomic<int> num_times_run_;
-  static std::atomic<int> num_times_run_reverse_;
-};
-
-std::atomic<int> DummyInterceptor::num_times_run_;
-std::atomic<int> DummyInterceptor::num_times_run_reverse_;
-
-class DummyInterceptorFactory
-    : public experimental::ServerInterceptorFactoryInterface {
- public:
-  virtual experimental::Interceptor* CreateServerInterceptor(
-      experimental::ServerRpcInfo* info) override {
-    return new DummyInterceptor(info);
-  }
-};
-
 class LoggingInterceptor : public experimental::Interceptor {
  public:
   LoggingInterceptor(experimental::ServerRpcInfo* info) { info_ = info; }

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -3609,7 +3609,7 @@
     "name": "end2end_test", 
     "src": [
       "test/cpp/end2end/end2end_test.cc", 
-      "test/cpp/end2end/interceptor_util.cc", 
+      "test/cpp/end2end/interceptors_util.cc", 
       "test/cpp/end2end/interceptors_util.h"
     ], 
     "third_party": false, 

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -3402,6 +3402,7 @@
     "name": "client_interceptors_end2end_test", 
     "src": [
       "test/cpp/end2end/client_interceptors_end2end_test.cc", 
+      "test/cpp/end2end/interceptors_util.cc", 
       "test/cpp/end2end/interceptors_util.h"
     ], 
     "third_party": false, 
@@ -4736,6 +4737,7 @@
     "language": "c++", 
     "name": "server_interceptors_end2end_test", 
     "src": [
+      "test/cpp/end2end/interceptors_util.cc", 
       "test/cpp/end2end/interceptors_util.h", 
       "test/cpp/end2end/server_interceptors_end2end_test.cc"
     ], 

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -3601,12 +3601,16 @@
       "grpc++_test_util", 
       "grpc_test_util"
     ], 
-    "headers": [], 
+    "headers": [
+      "test/cpp/end2end/interceptors_util.h"
+    ], 
     "is_filegroup": false, 
     "language": "c++", 
     "name": "end2end_test", 
     "src": [
-      "test/cpp/end2end/end2end_test.cc"
+      "test/cpp/end2end/end2end_test.cc", 
+      "test/cpp/end2end/interceptor_util.cc", 
+      "test/cpp/end2end/interceptors_util.h"
     ], 
     "third_party": false, 
     "type": "target"


### PR DESCRIPTION
This Pull Request adds the feature that C++ interceptors are notified when a client/server issues a TryCancel.

This Interception Hook Point ,i.e., PRE_SEND_CANCEL (I am willing to change the name if there is a suggestion),  is different from the other hook points. It is illegal for the interceptor to hold on to or delay the batch. Also, it doesn't matter whether this RPC was hijacked or not. All interceptors will see this notification.

For testing this, the existing testbed of end2end_test was used, since it already has a lot of infrastructure in place. 

Some minor refactoring of code in the tests is also included.