### PR TITLE
Restore reverted Python Bazel work

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -8,3 +8,4 @@ wheel>=0.29
 futures>=2.2.0
 google-auth>=1.0.0
 oauth2client==4.1.0
+requests>=2.14.2

--- a/src/proto/grpc/reflection/v1alpha/BUILD
+++ b/src/proto/grpc/reflection/v1alpha/BUILD
@@ -22,3 +22,11 @@ grpc_proto_library(
     name = "reflection_proto",
     srcs = ["reflection.proto"],
 )
+
+filegroup(
+    name = "reflection_proto_file",
+    srcs = [
+        "reflection.proto",
+    ],
+)
+

--- a/src/proto/grpc/testing/BUILD
+++ b/src/proto/grpc/testing/BUILD
@@ -15,6 +15,8 @@
 licenses(["notice"])  # Apache v2
 
 load("//bazel:grpc_build_system.bzl", "grpc_proto_library", "grpc_package")
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_library")
 
 grpc_package(name = "testing", visibility = "public")
 
@@ -56,6 +58,15 @@ grpc_proto_library(
     name = "empty_proto",
     srcs = ["empty.proto"],
     has_services = False,
+)
+
+py_proto_library(
+    name = "py_empty_proto",
+    protos = ["empty.proto",],
+    with_grpc = True,
+    deps = [
+        requirement('protobuf'),
+    ],
 )
 
 grpc_proto_library(

--- a/src/proto/grpc/testing/BUILD
+++ b/src/proto/grpc/testing/BUILD
@@ -75,6 +75,15 @@ grpc_proto_library(
     has_services = False,
 )
 
+py_proto_library(
+    name = "py_messages_proto",
+    protos = ["messages.proto",],
+    with_grpc = True,
+    deps = [
+        requirement('protobuf'),
+    ],
+)
+
 grpc_proto_library(
     name = "metrics_proto",
     srcs = ["metrics.proto"],
@@ -127,3 +136,17 @@ grpc_proto_library(
         "messages_proto",
     ],
 )
+
+py_proto_library(
+    name = "py_test_proto",
+    protos = ["test.proto",],
+    with_grpc = True,
+    deps = [
+        requirement('protobuf'),
+    ],
+    proto_deps = [
+        ":py_empty_proto",
+        ":py_messages_proto",
+    ]
+)
+

--- a/src/proto/grpc/testing/proto2/BUILD.bazel
+++ b/src/proto/grpc/testing/proto2/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_proto_library(
+    name = "empty2_proto",
+    protos = [
+        "empty2.proto",
+    ],
+    with_grpc = True,
+    deps = [
+        requirement('protobuf'),
+    ],
+)
+
+py_proto_library(
+    name = "empty2_extensions_proto",
+    protos = [
+        "empty2_extensions.proto",
+    ],
+    proto_deps = [
+        ":empty2_proto",
+    ],
+    with_grpc = True,
+    deps = [
+        requirement('protobuf'),
+    ],
+)
+

--- a/src/python/grpcio_reflection/grpc_reflection/v1alpha/BUILD.bazel
+++ b/src/python/grpcio_reflection/grpc_reflection/v1alpha/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+genrule(
+    name = "mv_reflection_proto",
+    srcs = [
+        "//src/proto/grpc/reflection/v1alpha:reflection_proto_file",
+    ],
+    outs = ["reflection.proto",],
+    cmd = "cp $< $@",
+)
+
+py_proto_library(
+    name = "py_reflection_proto",
+    protos = [":mv_reflection_proto",],
+    with_grpc = True,
+    deps = [
+        requirement('protobuf'),
+    ],
+)
+
+py_library(
+    name = "grpc_reflection",
+    srcs = ["reflection.py",],
+    deps = [
+        ":py_reflection_proto",
+        "//src/python/grpcio/grpc:grpcio",
+        requirement('protobuf'),
+    ],
+    imports=["../../",],
+)
+

--- a/src/python/grpcio_tests/tests/interop/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/interop/BUILD.bazel
@@ -1,0 +1,97 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "_intraop_test_case",
+    srcs = ["_intraop_test_case.py"],
+    deps = [
+        ":methods",
+    ],
+    imports=["../../",],
+)
+
+py_library(
+    name = "client",
+    srcs = ["client.py"],
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        ":methods",
+        ":resources",
+        "//src/proto/grpc/testing:py_test_proto",
+        requirement('google-auth'),
+    ],
+    imports=["../../",],
+)
+
+py_library(
+    name = "methods",
+    srcs = ["methods.py"],
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/proto/grpc/testing:py_empty_proto",
+        "//src/proto/grpc/testing:py_messages_proto",
+        "//src/proto/grpc/testing:py_test_proto",
+        requirement('google-auth'),
+        requirement('requests'),
+        requirement('enum34'),
+    ],
+    imports=["../../",],
+)
+
+py_library(
+    name = "resources",
+    srcs = ["resources.py"],
+    data = [
+        "//src/python/grpcio_tests/tests/interop/credentials",
+    ],
+)
+
+py_library(
+    name = "server",
+    srcs = ["server.py"],
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        ":methods",
+        ":resources",
+        "//src/python/grpcio_tests/tests/unit:test_common",
+        "//src/proto/grpc/testing:py_test_proto",
+    ],
+    imports=["../../",],
+)
+
+py_test(
+    name="_insecure_intraop_test",
+    size="small",
+    srcs=["_insecure_intraop_test.py",],
+    main="_insecure_intraop_test.py",
+    deps=[
+        "//src/python/grpcio/grpc:grpcio",
+        ":_intraop_test_case",
+        ":methods",
+        ":server",
+        "//src/python/grpcio_tests/tests/unit:test_common",
+        "//src/proto/grpc/testing:py_test_proto",
+    ],
+    imports=["../../",],
+    data=[
+        "//src/python/grpcio_tests/tests/unit/credentials",
+    ],
+)
+
+py_test(
+    name="_secure_intraop_test",
+    size="small",
+    srcs=["_secure_intraop_test.py",],
+    main="_secure_intraop_test.py",
+    deps=[
+        "//src/python/grpcio/grpc:grpcio",
+        ":_intraop_test_case",
+        ":methods",
+        ":server",
+        "//src/python/grpcio_tests/tests/unit:test_common",
+        "//src/proto/grpc/testing:py_test_proto",
+    ],
+    imports=["../../",],
+)
+

--- a/src/python/grpcio_tests/tests/interop/credentials/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/interop/credentials/BUILD.bazel
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name="credentials",
+    srcs=glob([
+        "**",
+    ]),
+)
+

--- a/src/python/grpcio_tests/tests/reflection/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/reflection/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_test(
+    name="_reflection_servicer_test",
+    size="small",
+    timeout="moderate",
+    srcs=["_reflection_servicer_test.py",],
+    main="_reflection_servicer_test.py",
+    deps=[
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/python/grpcio_reflection/grpc_reflection/v1alpha:grpc_reflection",
+        "//src/python/grpcio_tests/tests/unit:test_common",
+        "//src/proto/grpc/testing:py_empty_proto",
+        "//src/proto/grpc/testing/proto2:empty2_extensions_proto",
+        requirement('protobuf'),
+    ],
+    imports=["../../",],
+)
+


### PR DESCRIPTION
This restores @ghostwriternr's work in pull requests [16813](https://github.com/grpc/grpc/pull/16813) and [16831](https://github.com/grpc/grpc/pull/16831) that was reverted in [pull request 16858](https://github.com/grpc/grpc/pull/16858). This does **not** restore the file renaming done in [pull request 16859](https://github.com/grpc/grpc/pull/16859) that was done in an attempt to work around the failing internal build problem that was the reason for needing to revert [16813](https://github.com/grpc/grpc/pull/16813) and [16831](https://github.com/grpc/grpc/pull/16831) - if we want to rename those `BUILD` files, that can be done separately (and will require _separate_ internal coordination).

I have tested this content against the internal build and believe that this content is now internal-build-safe to merge.