### PR TITLE
Do not make TCP_USER_TIMEOUT failure an error

### DIFF
--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -302,8 +302,9 @@ grpc_error* grpc_set_socket_tcp_user_timeout(
       return GRPC_OS_ERROR(errno, "getsockopt(TCP_USER_TIMEOUT)");
     }
     if (newval != timeout) {
-      return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
-          "Failed to set TCP_USER_TIMEOUT");
+      /* Do not fail on failing to set TCP_USER_TIMEOUT for now. */
+      gpr_log(GPR_ERROR, "Failed to set TCP_USER_TIMEOUT");
+      return GRPC_ERROR_NONE;
     }
   }
 #else


### PR DESCRIPTION
Do not make TCP_USER_TIMEOUT failure an error. This was breaking some internal tests. Given that we already cannot guarantee that it will be set because of an outdated system, it should be fine to never fail on this.