### PR TITLE
Make run_tests.py python-version agnostic

### DIFF
--- a/tools/gcp/utils/big_query_utils.py
+++ b/tools/gcp/utils/big_query_utils.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 import argparse
 import json
 import uuid
@@ -50,11 +52,11 @@ def create_dataset(biq_query, project_id, dataset_id):
         dataset_req.execute(num_retries=NUM_RETRIES)
     except HttpError as http_error:
         if http_error.resp.status == 409:
-            print 'Warning: The dataset %s already exists' % dataset_id
+            print('Warning: The dataset %s already exists' % dataset_id)
         else:
             # Note: For more debugging info, print "http_error.content"
-            print 'Error in creating dataset: %s. Err: %s' % (dataset_id,
-                                                              http_error)
+            print('Error in creating dataset: %s. Err: %s' % (dataset_id,
+                                                              http_error))
             is_success = False
     return is_success
 
@@ -122,13 +124,13 @@ def create_table2(big_query,
         table_req = big_query.tables().insert(
             projectId=project_id, datasetId=dataset_id, body=body)
         res = table_req.execute(num_retries=NUM_RETRIES)
-        print 'Successfully created %s "%s"' % (res['kind'], res['id'])
+        print('Successfully created %s "%s"' % (res['kind'], res['id']))
     except HttpError as http_error:
         if http_error.resp.status == 409:
-            print 'Warning: Table %s already exists' % table_id
+            print('Warning: Table %s already exists' % table_id)
         else:
-            print 'Error in creating table: %s. Err: %s' % (table_id,
-                                                            http_error)
+            print('Error in creating table: %s. Err: %s' % (table_id,
+                                                            http_error))
             is_success = False
     return is_success
 
@@ -154,9 +156,9 @@ def patch_table(big_query, project_id, dataset_id, table_id, fields_schema):
             tableId=table_id,
             body=body)
         res = table_req.execute(num_retries=NUM_RETRIES)
-        print 'Successfully patched %s "%s"' % (res['kind'], res['id'])
+        print('Successfully patched %s "%s"' % (res['kind'], res['id']))
     except HttpError as http_error:
-        print 'Error in creating table: %s. Err: %s' % (table_id, http_error)
+        print('Error in creating table: %s. Err: %s' % (table_id, http_error))
         is_success = False
     return is_success
 
@@ -172,10 +174,10 @@ def insert_rows(big_query, project_id, dataset_id, table_id, rows_list):
             body=body)
         res = insert_req.execute(num_retries=NUM_RETRIES)
         if res.get('insertErrors', None):
-            print 'Error inserting rows! Response: %s' % res
+            print('Error inserting rows! Response: %s' % res)
             is_success = False
     except HttpError as http_error:
-        print 'Error inserting rows to the table %s' % table_id
+        print('Error inserting rows to the table %s' % table_id)
         is_success = False
 
     return is_success
@@ -189,8 +191,8 @@ def sync_query_job(big_query, project_id, query, timeout=5000):
             projectId=project_id,
             body=query_data).execute(num_retries=NUM_RETRIES)
     except HttpError as http_error:
-        print 'Query execute job failed with error: %s' % http_error
-        print http_error.content
+        print('Query execute job failed with error: %s' % http_error)
+        print(http_error.content)
     return query_job
 
 

--- a/tools/run_tests/python_utils/jobset.py
+++ b/tools/run_tests/python_utils/jobset.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """Run a group of subprocesses and then finish."""
 
-from __future__ import print_function
-
 import logging
 import multiprocessing
 import os
@@ -118,7 +116,7 @@ def eintr_be_gone(fn):
     while True:
         try:
             return fn()
-        except IOError, e:
+        except IOError as e:
             if e.errno != errno.EINTR:
                 raise
 
@@ -144,7 +142,7 @@ def message(tag, msg, explanatory_text=None, do_newline=False):
                      if do_newline or explanatory_text is not None else ''))
             sys.stdout.flush()
             return
-        except IOError, e:
+        except IOError as e:
             if e.errno != errno.EINTR:
                 raise
 

--- a/tools/run_tests/python_utils/port_server.py
+++ b/tools/run_tests/python_utils/port_server.py
@@ -14,15 +14,17 @@
 # limitations under the License.
 """Manage TCP ports for unit tests; started by run_tests.py"""
 
+from __future__ import print_function
+
 import argparse
-from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+from six.moves.BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+from six.moves.socketserver import ThreadingMixIn
 import hashlib
 import os
 import socket
 import sys
 import time
 import random
-from SocketServer import ThreadingMixIn
 import threading
 import platform
 
@@ -32,7 +34,7 @@ import platform
 _MY_VERSION = 20
 
 if len(sys.argv) == 2 and sys.argv[1] == 'dump_version':
-    print _MY_VERSION
+    print(_MY_VERSION)
     sys.exit(0)
 
 argp = argparse.ArgumentParser(description='Server for httpcli_test')
@@ -47,7 +49,7 @@ if args.logfile is not None:
     sys.stderr = open(args.logfile, 'w')
     sys.stdout = sys.stderr
 
-print 'port server running on port %d' % args.port
+print('port server running on port %d' % args.port)
 
 pool = []
 in_use = {}
@@ -74,7 +76,7 @@ def can_connect(port):
     try:
         s.connect(('localhost', port))
         return True
-    except socket.error, e:
+    except socket.error as e:
         return False
     finally:
         s.close()
@@ -86,7 +88,7 @@ def can_bind(port, proto):
     try:
         s.bind(('localhost', port))
         return True
-    except socket.error, e:
+    except socket.error as e:
         return False
     finally:
         s.close()
@@ -95,7 +97,7 @@ def can_bind(port, proto):
 def refill_pool(max_timeout, req):
     """Scan for ports not marked for being in use"""
     chk = [
-        port for port in list(range(1025, 32766))
+        port for port in range(1025, 32766)
         if port not in cronet_restricted_ports
     ]
     random.shuffle(chk)

--- a/tools/run_tests/python_utils/report_utils.py
+++ b/tools/run_tests/python_utils/report_utils.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """Generate XML and HTML test reports."""
 
-
-
 try:
     from mako.runtime import Context
     from mako.template import Template
@@ -33,7 +31,9 @@ def _filter_msg(msg, output_format):
     if output_format in ['XML', 'HTML']:
         # keep whitespaces but remove formfeed and vertical tab characters
         # that make XML report unparseable.
-        filtered_msg = [x for x in msg.decode('UTF-8', 'ignore') if x in string.printable and x != '\f' and x != '\v']
+        filtered_msg = filter(
+            lambda x: x in string.printable and x != '\f' and x != '\v',
+            msg.decode('UTF-8', 'ignore'))
         if output_format == 'HTML':
             filtered_msg = filtered_msg.replace('"', '&quot;')
         return filtered_msg

--- a/tools/run_tests/python_utils/report_utils.py
+++ b/tools/run_tests/python_utils/report_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Generate XML and HTML test reports."""
 
-from __future__ import print_function
+
 
 try:
     from mako.runtime import Context
@@ -33,9 +33,7 @@ def _filter_msg(msg, output_format):
     if output_format in ['XML', 'HTML']:
         # keep whitespaces but remove formfeed and vertical tab characters
         # that make XML report unparseable.
-        filtered_msg = filter(
-            lambda x: x in string.printable and x != '\f' and x != '\v',
-            msg.decode('UTF-8', 'ignore'))
+        filtered_msg = [x for x in msg.decode('UTF-8', 'ignore') if x in string.printable and x != '\f' and x != '\v']
         if output_format == 'HTML':
             filtered_msg = filtered_msg.replace('"', '&quot;')
         return filtered_msg

--- a/tools/run_tests/python_utils/start_port_server.py
+++ b/tools/run_tests/python_utils/start_port_server.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import urllib
-import jobset
+from __future__ import print_function
+
+from . import jobset
+
+import six.moves.urllib.request as request
 import logging
 import os
 import socket
@@ -33,7 +36,7 @@ def start_port_server():
     # otherwise, leave it up
     try:
         version = int(
-            urllib.urlopen('http://localhost:%d/version_number' %
+            request.urlopen('http://localhost:%d/version_number' %
                            _PORT_SERVER_PORT).read())
         logging.info('detected port server running version %d', version)
         running = True
@@ -51,7 +54,7 @@ def start_port_server():
         running = (version >= current_version)
         if not running:
             logging.info('port_server version mismatch: killing the old one')
-            urllib.urlopen(
+            request.urlopen(
                 'http://localhost:%d/quitquitquit' % _PORT_SERVER_PORT).read()
             time.sleep(1)
     if not running:
@@ -92,7 +95,7 @@ def start_port_server():
                 # try one final time: maybe another build managed to start one
                 time.sleep(1)
                 try:
-                    urllib.urlopen(
+                    request.urlopen(
                         'http://localhost:%d/get' % _PORT_SERVER_PORT).read()
                     logging.info(
                         'last ditch attempt to contact port server succeeded')
@@ -101,11 +104,11 @@ def start_port_server():
                     logging.exception(
                         'final attempt to contact port server failed')
                     port_log = open(logfile, 'r').read()
-                    print port_log
+                    print(port_log)
                     sys.exit(1)
             try:
                 port_server_url = 'http://localhost:%d/get' % _PORT_SERVER_PORT
-                urllib.urlopen(port_server_url).read()
+                request.urlopen(port_server_url).read()
                 logging.info('port server is up and ready')
                 break
             except socket.timeout:

--- a/tools/run_tests/python_utils/start_port_server.py
+++ b/tools/run_tests/python_utils/start_port_server.py
@@ -37,7 +37,7 @@ def start_port_server():
     try:
         version = int(
             request.urlopen('http://localhost:%d/version_number' %
-                           _PORT_SERVER_PORT).read())
+                            _PORT_SERVER_PORT).read())
         logging.info('detected port server running version %d', version)
         running = True
     except Exception as e:

--- a/tools/run_tests/python_utils/watch_dirs.py
+++ b/tools/run_tests/python_utils/watch_dirs.py
@@ -15,13 +15,14 @@
 
 import os
 import time
+from six import string_types
 
 
 class DirWatcher(object):
     """Helper to watch a (set) of directories for modifications."""
 
     def __init__(self, paths):
-        if isinstance(paths, basestring):
+        if isinstance(paths, string_types):
             paths = [paths]
         self._done = False
         self.paths = list(paths)

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Run tests in parallel."""
 
-from __future__ import print_function
+
 
 import argparse
 import ast
@@ -158,7 +158,7 @@ class Config(object):
                        would like to run
     """
         actual_environ = self.environ.copy()
-        for k, v in environ.items():
+        for k, v in list(environ.items()):
             actual_environ[k] = v
         if not flaky and shortname and shortname in flaky_tests:
             flaky = True
@@ -1512,7 +1512,7 @@ if args.travis:
     _FORCE_ENVIRON_FOR_WRAPPERS = {'GRPC_TRACE': 'api'}
 
 if 'all' in args.language:
-    lang_list = _LANGUAGES.keys()
+    lang_list = list(_LANGUAGES.keys())
 else:
     lang_list = args.language
 # We don't support code coverage on some languages
@@ -1653,7 +1653,7 @@ build_steps = list(
 if make_targets:
     make_commands = itertools.chain.from_iterable(
         make_jobspec(build_config, list(targets), makefile)
-        for (makefile, targets) in make_targets.items())
+        for (makefile, targets) in list(make_targets.items()))
     build_steps.extend(set(make_commands))
 build_steps.extend(
     set(
@@ -1719,9 +1719,9 @@ def _has_epollexclusive():
     try:
         subprocess.check_call(binary)
         return True
-    except subprocess.CalledProcessError, e:
+    except subprocess.CalledProcessError as e:
         return False
-    except OSError, e:
+    except OSError as e:
         # For languages other than C and Windows the binary won't exist
         return False
 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -158,7 +158,7 @@ class Config(object):
                        would like to run
     """
         actual_environ = self.environ.copy()
-        for k, v in list(environ.items()):
+        for k, v in environ.items():
             actual_environ[k] = v
         if not flaky and shortname and shortname in flaky_tests:
             flaky = True
@@ -1653,7 +1653,7 @@ build_steps = list(
 if make_targets:
     make_commands = itertools.chain.from_iterable(
         make_jobspec(build_config, list(targets), makefile)
-        for (makefile, targets) in list(make_targets.items()))
+        for (makefile, targets) in make_targets.items())
     build_steps.extend(set(make_commands))
 build_steps.extend(
     set(

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Run tests in parallel."""
 
+from __future__ import print_function
+
 import argparse
 import ast
 import collections

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Run tests in parallel."""
 
-
-
 import argparse
 import ast
 import collections


### PR DESCRIPTION
A few people have noticed that `run_tests.py` cannot be run under python 3. In fact, many files under the `tools/` directory use python2-only features/syntax. This PR makes all python dependencies of `run_tests.py` python2/3 compatible.

```bash
  python3 tools/run_tests/run_tests.py --language python
  File "tools/run_tests/run_tests.py", line 1722
    except subprocess.CalledProcessError, e:
                                        ^
  SyntaxError: invalid syntax
```