### PR TITLE
Minor refactor of CallbackWithSuccessTag

### DIFF
--- a/include/grpcpp/impl/codegen/server_callback.h
+++ b/include/grpcpp/impl/codegen/server_callback.h
@@ -22,6 +22,7 @@
 #include <functional>
 
 #include <grpcpp/impl/codegen/call.h>
+#include <grpcpp/impl/codegen/call_op_set.h>
 #include <grpcpp/impl/codegen/callback_common.h>
 #include <grpcpp/impl/codegen/config.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
@@ -116,7 +117,7 @@ class CallbackUnaryHandler : public MethodHandler {
       : public experimental::ServerCallbackRpcController {
    public:
     void Finish(Status s) override {
-      finish_tag_ = CallbackWithSuccessTag(
+      finish_tag_.Set(
           call_.call(),
           [this](bool) {
             grpc_call* call = call_.call();
@@ -149,8 +150,7 @@ class CallbackUnaryHandler : public MethodHandler {
     void SendInitialMetadata(std::function<void(bool)> f) override {
       GPR_CODEGEN_ASSERT(!ctx_->sent_initial_metadata_);
 
-      meta_tag_ =
-          CallbackWithSuccessTag(call_.call(), std::move(f), &meta_buf_);
+      meta_tag_.Set(call_.call(), std::move(f), &meta_buf_);
       meta_buf_.SendInitialMetadata(&ctx_->initial_metadata_,
                                     ctx_->initial_metadata_flags());
       if (ctx_->compression_level_set()) {

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -252,6 +252,7 @@ void ServerContext::Clear() {
   }
   if (completion_op_) {
     completion_op_->Unref();
+    completion_tag_.Clear();
   }
   if (rpc_info_) {
     rpc_info_->Unref();

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -270,8 +270,7 @@ void ServerContext::BeginCompletionOp(internal::Call* call, bool callback) {
       new (grpc_call_arena_alloc(call->call(), sizeof(CompletionOp)))
           CompletionOp(call);
   if (callback) {
-    completion_tag_ =
-        internal::CallbackWithSuccessTag(call->call(), nullptr, completion_op_);
+    completion_tag_.Set(call->call(), nullptr, completion_op_);
     completion_op_->set_core_cq_tag(&completion_tag_);
   } else if (has_notify_when_done_tag_) {
     completion_op_->set_tag(async_notify_when_done_tag_);


### PR DESCRIPTION
Used in both client-side and server-side streaming APIs. This refactor allows reuse of the same tag, which is important for streaming performance


