### PR TITLE
ability to set grpc proxy with no effect on http proxy

### DIFF
--- a/src/core/ext/filters/client_channel/http_proxy.cc
+++ b/src/core/ext/filters/client_channel/http_proxy.cc
@@ -126,9 +126,7 @@ static bool proxy_mapper_map_name(grpc_proxy_mapper* mapper,
   }
   /* Prefer using 'no_grpc_proxy'. Fallback on 'no_proxy' if it is not set. */
   no_proxy_str = gpr_getenv("no_grpc_proxy");
-  if (no_proxy_str == nullptr) {
-    no_proxy_str = gpr_getenv("no_proxy");
-  }
+  if (no_proxy_str == nullptr) no_proxy_str = gpr_getenv("no_proxy");
   if (no_proxy_str != nullptr) {
     static const char* NO_PROXY_SEPARATOR = ",";
     bool use_proxy = true;


### PR DESCRIPTION
In our infrastructure, we need to be able to route grpc and http requests both through different proxies. This update helps us to set proxy for grpc communication with use of 'grpc_proxy' environment variable and to ignore 'http_proxy' env. variable which is used to route http requests only. Old functionality is perserved with fallback. Thanks.