### PR TITLE
Enable building opencensus for bazel build

### DIFF
--- a/include/grpcpp/opencensus.h
+++ b/include/grpcpp/opencensus.h
@@ -19,10 +19,6 @@
 #ifndef GRPCPP_OPENCENSUS_H
 #define GRPCPP_OPENCENSUS_H
 
-#ifndef GRPC_BAZEL_BUILD
-#error OpenCensus for gRPC is only supported when building with bazel.
-#endif
-
 #include "opencensus/trace/span.h"
 
 namespace grpc {


### PR DESCRIPTION
Cherry-pick https://github.com/grpc/grpc/pull/16871/files to fix bazel tests.