### PR TITLE
Speedup interop builds (PHP and C++)

### DIFF
--- a/tools/dockerfile/interoptest/grpc_interop_cxx/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx/build_interop.sh
@@ -28,10 +28,10 @@ cp -r /var/local/jenkins/service_account $HOME || true
 
 cd /var/local/git/grpc
 
-make install-certs
+make install-certs -j4
 
 # build C++ interop client & server
-make interop_client interop_server -j2
+make interop_client interop_server -j4
 
 # build C++ http2 client
-make http2_client
+make http2_client -j4

--- a/tools/dockerfile/interoptest/grpc_interop_php/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_php/build_interop.sh
@@ -28,12 +28,13 @@ cp -r /var/local/jenkins/service_account $HOME || true
 
 cd /var/local/git/grpc
 
-# gRPC core and protobuf need to be installed
-make install
+# Install gRPC C core and build codegen plugins
+make -j4 install_c plugins
 
-(cd src/php/ext/grpc && phpize && ./configure && make)
+(cd src/php/ext/grpc && phpize && ./configure && make -j4)
 
-(cd third_party/protobuf && make install)
+# Install protobuf (need access to protoc)
+(cd third_party/protobuf && make -j4 install)
 
 (cd src/php && php -d extension=ext/grpc/modules/grpc.so /usr/local/bin/composer install)
 

--- a/tools/dockerfile/interoptest/grpc_interop_php7/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_php7/build_interop.sh
@@ -28,12 +28,13 @@ cp -r /var/local/jenkins/service_account $HOME || true
 
 cd /var/local/git/grpc
 
-# gRPC core and protobuf need to be installed
-make install
+# Install gRPC C core and build codegen plugins
+make -j4 install_c plugins
 
-(cd src/php/ext/grpc && phpize && ./configure && make)
+(cd src/php/ext/grpc && phpize && ./configure && make -j4)
 
-(cd third_party/protobuf && make install)
+# Install protobuf (need access to protoc)
+(cd third_party/protobuf && make -j4 install)
 
 (cd src/php && php -d extension=ext/grpc/modules/grpc.so /usr/local/bin/composer install)
 


### PR DESCRIPTION
Some interop builds are very slow as can be seen here:
https://sponge.corp.google.com/target?id=89f4a7bd-fbbd-49ff-a72e-7b6344ee6914&target=github/grpc/interop_docker_build&searchFor&show=ALL&sortBy=STATUS&sortMethodsBy=DURATION

- use parallel make to build some of the slowest ones (PHP, PHP7, C++)
- try to only build what's necessary for PHP.

Partially, the slowness is caused by the fact that we are running many docker image builds in parallel, I might experiment with reducing the number of parallel builds. This PR should still help though.