### PR TITLE
Add a ref count to alts shared resource. 

### DIFF
--- a/src/core/tsi/alts/handshaker/alts_shared_resource.cc
+++ b/src/core/tsi/alts/handshaker/alts_shared_resource.cc
@@ -25,7 +25,6 @@
 #include "src/core/tsi/alts/handshaker/alts_handshaker_client.h"
 
 static alts_shared_resource_dedicated g_alts_resource_dedicated;
-static alts_shared_resource* g_shared_resources = alts_get_shared_resource();
 
 alts_shared_resource_dedicated* grpc_alts_get_shared_resource_dedicated(void) {
   return &g_alts_resource_dedicated;

--- a/src/core/tsi/alts_transport_security.h
+++ b/src/core/tsi/alts_transport_security.h
@@ -29,10 +29,21 @@
 typedef struct alts_shared_resource {
   grpc_channel* channel;
   gpr_mu mu;
+  gpr_refcount refcount;
 } alts_shared_resource;
 
 /* This method returns the address of alts_shared_resource object shared by all
  *    TSI handshakes. */
-alts_shared_resource* alts_get_shared_resource(void);
+alts_shared_resource* grpc_alts_get_shared_resource(void);
 
+/**
+ * This method ref's an alts_shared_resource object.
+ */
+alts_shared_resource* grpc_alts_shared_resource_ref(
+    alts_shared_resource* resource);
+
+/**
+ * This method unref's an alts_shared_resource object.
+ */
+void grpc_alts_shared_resource_unref(alts_shared_resource* resource);
 #endif /* GRPC_CORE_TSI_ALTS_TRANSPORT_SECURITY_H */


### PR DESCRIPTION
This PR adds a ref count to ALTS shared resources, and ref (unref) it whenever creating (destroying) alts server/channel TSI handshakers. The reason for adding the ref count is to ensure the ALTS shared channel will get destroyed before `grpc_shutdown` is invoked.  In the original implementation, the destroy of shared channel requires the objects that have already been destroyed in `grpc_shtudown`.