### PR TITLE
Allow setsockopt and getsockopt to softly fail for TCP_USER_TIMEOUT

### DIFF
--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -296,10 +296,12 @@ grpc_error* grpc_set_socket_tcp_user_timeout(
     socklen_t len = sizeof(newval);
     if (0 != setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &timeout,
                         sizeof(timeout))) {
-      return GRPC_OS_ERROR(errno, "setsockopt(TCP_USER_TIMEOUT)");
+      gpr_log(GPR_ERROR, "setsockopt(TCP_USER_TIMEOUT) %s", strerror(errno));
+      return GRPC_ERROR_NONE;
     }
     if (0 != getsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &newval, &len)) {
-      return GRPC_OS_ERROR(errno, "getsockopt(TCP_USER_TIMEOUT)");
+      gpr_log(GPR_ERROR, "getsockopt(TCP_USER_TIMEOUT) %s", strerror(errno));
+      return GRPC_ERROR_NONE;
     }
     if (newval != timeout) {
       /* Do not fail on failing to set TCP_USER_TIMEOUT for now. */


### PR DESCRIPTION
Allow setsockopt and getsockopt to softly fail for TCP_USER_TIMEOUT
#17083 did not allow these to softly fail but this is required too