### PR TITLE
Add _parallel_compile_patch.py to python manifest

### DIFF
--- a/PYTHON-MANIFEST.in
+++ b/PYTHON-MANIFEST.in
@@ -9,6 +9,7 @@ graft third_party/boringssl
 graft third_party/cares
 graft third_party/nanopb
 graft third_party/zlib
+include src/python/grpcio/_parallel_compile_patch.py
 include src/python/grpcio/_spawn_patch.py
 include src/python/grpcio/commands.py
 include src/python/grpcio/grpc_version.py

--- a/tools/distrib/python/grpcio_tools/MANIFEST.in
+++ b/tools/distrib/python/grpcio_tools/MANIFEST.in
@@ -1,3 +1,4 @@
+include _parallel_compile_patch.py
 include grpc_version.py
 include protoc_deps.py
 include protoc_lib_deps.py


### PR DESCRIPTION
Looks like https://github.com/grpc/grpc/pull/17057 have broken the python distribtests that try to build from source package:
https://source.cloud.google.com/results/invocations/1ab5947e-cf4c-4248-b121-f7369d509f17/targets/github%2Fgrpc/tests;passed=true;group=tasks;test=distribtest.python_dev_linux_x86_jessie;row=20

```
Processing /var/local/jenkins/grpc/input_artifacts/grpcio-1.17.0.dev0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-req-build-sSGKR7/setup.py", line 60, in <module>
        import _parallel_compile_patch
    ImportError: No module named _parallel_compile_patch
```

Adding _parallel_compile_patch.py to the manifest should fix the problem.
