### PR TITLE
run_tests_matrix.py should log run_tests commands

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -574,11 +574,8 @@ if __name__ == "__main__":
 
     print('Will run these tests:')
     for job in jobs:
-        if args.dry_run:
-            print('  %s: "%s"' % (job.shortname, ' '.join(job.cmdline)))
-        else:
-            print('  %s' % job.shortname)
-    print
+        print('  %s: "%s"' % (job.shortname, ' '.join(job.cmdline)))
+    print('')
 
     if args.dry_run:
         print('--dry_run was used, exiting')


### PR DESCRIPTION
Revealing the run_tests.py arguments makes it easier to reproduce test failures locally.
This is only a small improvement, but better than nothing. 