### PR TITLE
Only Add NullHandler to Module-Root Logger

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -15,11 +15,13 @@
 
 import abc
 import enum
+import logging
 import sys
-
 import six
 
 from grpc._cython import cygrpc as _cygrpc
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 ############################## Future Interface  ###############################
 

--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -25,7 +25,6 @@ from grpc._cython import cygrpc
 from grpc.framework.foundation import callable_util
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.addHandler(logging.NullHandler())
 
 _USER_AGENT = 'grpc-python/{}'.format(_grpcio_metadata.__version__)
 

--- a/src/python/grpcio/grpc/_common.py
+++ b/src/python/grpcio/grpc/_common.py
@@ -21,7 +21,6 @@ import grpc
 from grpc._cython import cygrpc
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.addHandler(logging.NullHandler())
 
 CYGRPC_CONNECTIVITY_STATE_TO_CHANNEL_CONNECTIVITY = {
     cygrpc.ConnectivityState.idle:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_string.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_string.pyx.pxi
@@ -15,7 +15,6 @@
 import logging
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.addHandler(logging.NullHandler())
 
 # This function will ascii encode unicode string inputs if neccesary.
 # In Python3, unicode strings are the default str type.

--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
@@ -19,7 +19,6 @@ import time
 import grpc
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.addHandler(logging.NullHandler())
 
 cdef class Server:
 

--- a/src/python/grpcio/grpc/_plugin_wrapping.py
+++ b/src/python/grpcio/grpc/_plugin_wrapping.py
@@ -21,7 +21,6 @@ from grpc import _common
 from grpc._cython import cygrpc
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.addHandler(logging.NullHandler())
 
 
 class _AuthMetadataContext(

--- a/src/python/grpcio/grpc/framework/foundation/callable_util.py
+++ b/src/python/grpcio/grpc/framework/foundation/callable_util.py
@@ -22,7 +22,6 @@ import logging
 import six
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.addHandler(logging.NullHandler())
 
 
 class Outcome(six.with_metaclass(abc.ABCMeta)):

--- a/src/python/grpcio/grpc/framework/foundation/logging_pool.py
+++ b/src/python/grpcio/grpc/framework/foundation/logging_pool.py
@@ -18,7 +18,6 @@ import logging
 from concurrent import futures
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.addHandler(logging.NullHandler())
 
 
 def _wrap(behavior):

--- a/src/python/grpcio/grpc/framework/foundation/stream_util.py
+++ b/src/python/grpcio/grpc/framework/foundation/stream_util.py
@@ -20,7 +20,6 @@ from grpc.framework.foundation import stream
 
 _NO_VALUE = object()
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.addHandler(logging.NullHandler())
 
 
 class TransformingConsumer(stream.Consumer):

--- a/src/python/grpcio_tests/tests/unit/_logging_test.py
+++ b/src/python/grpcio_tests/tests/unit/_logging_test.py
@@ -68,6 +68,13 @@ class LoggingTest(unittest.TestCase):
         self.assertEqual(1, len(logging.getLogger().handlers))
         self.assertIs(logging.getLogger().handlers[0].stream, intended_stream)
 
+    @isolated_logging
+    def test_grpc_logger(self):
+        self.assertIn("grpc", logging.Logger.manager.loggerDict)
+        root_logger = logging.getLogger("grpc")
+        self.assertEqual(1, len(root_logger.handlers))
+        self.assertIsInstance(root_logger.handlers[0], logging.NullHandler)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
I was trying to get a feel for what the rest of the python ecosystem does with its logging, so I looked into the top few libraries on pypi:

### `urllib3`

`urllib3` maintains a logger for not quite every module, but for each one that does heavy lifting. The logger name is `__name__`, and no handlers are registered for any module-level loggers, including `NullHandler`. Their documentation [spells out how to configure logging for the library](https://github.com/urllib3/urllib3/blob/0f85e05af9ef2ded671a7b47506dfd24b32decf0/docs/user-guide.rst#logging).

They explicitly configure a library root-level logger called `urllib3` to which they attach a `NullHandler`. This addresses the "no handlers could be found" problem.

Their tests explicitly configure handlers, just like ours do.

### `scrapy`

`scrapy` is more hands-on. It provides a [configuration module for its logging](https://github.com/scrapy/scrapy/blob/master/scrapy/utils/log.py) and [a whole document](https://github.com/scrapy/scrapy/blob/master/docs/topics/logging.rst) on how to handle logging with `scrapy`. It looks like `log.py`'s whole reason for existence is making sure that a handler is attached to to the `scrapy` handler at startup.

I think the extra complexity here is because `scrapy` also offers a CLI, so there has to be some way to configure logging without resorting to writing python.

---
Based on all of the libraries I've looked at, I think our current approach is reasonable. The one change I would make is to explicitly configure a `grpc` logger and to only attach a `NullHandler` to it instead of putting the burden on the author of each new module to configure it there.

### tl;dr
I think we should
 - Configure a logger in each module that cares about logging
 - Do *not* attach any handler to the module level loggers (including `NullHandler`s)
 - Explicity configure a `grpc` logger with a `NullHandler` attached
