### PR TITLE
WIP: Deflaking gRPC Python's unit test `_server_ssl_cert_config_test`

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
@@ -519,5 +519,4 @@ class ServerSSLCertReloadTestCertConfigReuse(_ServerSSLCertReloadTest):
 
 
 if __name__ == '__main__':
-    logging.basicConfig()
     unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
@@ -298,6 +298,7 @@ class _ServerSSLCertReloadTest(
             private_key=CLIENT_KEY_2_PEM,
             certificate_chain=CLIENT_CERT_CHAIN_2_PEM)
         actual_calls = self.cert_config_fetcher.getCalls()
+        print '301 actual_calls', actual_calls
         self.assertGreaterEqual(len(actual_calls), 1)
         self.assertFalse(actual_calls[0].did_raise)
         for i, call in enumerate(actual_calls):
@@ -314,6 +315,7 @@ class _ServerSSLCertReloadTest(
             private_key=CLIENT_KEY_1_PEM,
             certificate_chain=CLIENT_CERT_CHAIN_1_PEM)
         actual_calls = self.cert_config_fetcher.getCalls()
+        print '318 actual_calls', actual_calls
         self.assertEqual(len(actual_calls), 1)
         self.assertFalse(actual_calls[0].did_raise)
         self.assertIsNone(actual_calls[0].returned_cert_config)
@@ -351,6 +353,7 @@ class _ServerSSLCertReloadTest(
         self.cert_config_fetcher.configure(False, None)
         self._perform_rpc(persistent_client_stub_A, True)
         actual_calls = self.cert_config_fetcher.getCalls()
+        print '356 actual_calls', actual_calls
         self.assertEqual(len(actual_calls), 0)
 
         self.cert_config_fetcher.reset()

--- a/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
+++ b/src/python/grpcio_tests/tests/unit/_server_ssl_cert_config_test.py
@@ -29,6 +29,8 @@ Core by extension, support for server certificate rotation.
   to deal with user's reuse of ServerCertificateConfiguration instances.
 """
 
+from __future__ import print_function
+
 import abc
 import collections
 import os
@@ -298,7 +300,7 @@ class _ServerSSLCertReloadTest(
             private_key=CLIENT_KEY_2_PEM,
             certificate_chain=CLIENT_CERT_CHAIN_2_PEM)
         actual_calls = self.cert_config_fetcher.getCalls()
-        print '301 actual_calls', actual_calls
+        print('301 actual_calls', actual_calls)
         self.assertGreaterEqual(len(actual_calls), 1)
         self.assertFalse(actual_calls[0].did_raise)
         for i, call in enumerate(actual_calls):
@@ -315,7 +317,7 @@ class _ServerSSLCertReloadTest(
             private_key=CLIENT_KEY_1_PEM,
             certificate_chain=CLIENT_CERT_CHAIN_1_PEM)
         actual_calls = self.cert_config_fetcher.getCalls()
-        print '318 actual_calls', actual_calls
+        print('318 actual_calls', actual_calls)
         self.assertEqual(len(actual_calls), 1)
         self.assertFalse(actual_calls[0].did_raise)
         self.assertIsNone(actual_calls[0].returned_cert_config)
@@ -353,7 +355,7 @@ class _ServerSSLCertReloadTest(
         self.cert_config_fetcher.configure(False, None)
         self._perform_rpc(persistent_client_stub_A, True)
         actual_calls = self.cert_config_fetcher.getCalls()
-        print '356 actual_calls', actual_calls
+        print('356 actual_calls', actual_calls)
         self.assertEqual(len(actual_calls), 0)
 
         self.cert_config_fetcher.reset()


### PR DESCRIPTION
Issue #17138

Two failed unit tests:
* ServerSSLCertReloadTest**With**ClientAuth
* ServerSSLCertReloadTest**Without**ClientAuth