### PR TITLE
Resolve a deadlock caused by invocation of grpc_call_cancel inside of gRPC core

### DIFF
--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -694,6 +694,10 @@ static void cancel_with_error(grpc_call* c, grpc_error* error) {
   execute_batch(c, op, &state->start_batch);
 }
 
+void grpc_call_cancel_internal(grpc_call* call) {
+  cancel_with_error(call, GRPC_ERROR_CANCELLED);
+}
+
 static grpc_error* error_from_status(grpc_status_code status,
                                      const char* description) {
   // copying 'description' is needed to ensure the grpc_call_cancel_with_status

--- a/src/core/lib/surface/call.h
+++ b/src/core/lib/surface/call.h
@@ -81,6 +81,10 @@ grpc_call_error grpc_call_start_batch_and_execute(grpc_call* call,
                                                   size_t nops,
                                                   grpc_closure* closure);
 
+/* gRPC core internal version of grpc_call_cancel that does not create
+ * exec_ctx. */
+void grpc_call_cancel_internal(grpc_call* call);
+
 /* Given the top call_element, get the call object. */
 grpc_call* grpc_call_from_top_element(grpc_call_element* surface_element);
 

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
@@ -376,7 +376,7 @@ static void handshaker_client_shutdown(alts_handshaker_client* c) {
   alts_grpc_handshaker_client* client =
       reinterpret_cast<alts_grpc_handshaker_client*>(c);
   if (client->call != nullptr) {
-    GPR_ASSERT(grpc_call_cancel(client->call, nullptr) == GRPC_CALL_OK);
+    grpc_call_cancel_internal(client->call);
   }
 }
 

--- a/src/core/tsi/transport_security.cc
+++ b/src/core/tsi/transport_security.cc
@@ -213,10 +213,10 @@ tsi_result tsi_handshaker_next(
 
 void tsi_handshaker_shutdown(tsi_handshaker* self) {
   if (self == nullptr || self->vtable == nullptr) return;
-  self->handshake_shutdown = true;
   if (self->vtable->shutdown != nullptr) {
     self->vtable->shutdown(self);
   }
+  self->handshake_shutdown = true;
 }
 
 void tsi_handshaker_destroy(tsi_handshaker* self) {

--- a/tools/run_tests/sanity/core_banned_functions.py
+++ b/tools/run_tests/sanity/core_banned_functions.py
@@ -39,6 +39,7 @@ BANNED_EXCEPT = {
     'grpc_wsa_error(': ['src/core/lib/iomgr/error.cc'],
     'grpc_log_if_error(': ['src/core/lib/iomgr/error.cc'],
     'grpc_slice_malloc(': ['src/core/lib/slice/slice.cc'],
+    'grpc_call_cancel_internal(': ['src/core/lib/surface/call.cc'],
     'grpc_closure_create(': ['src/core/lib/iomgr/closure.cc'],
     'grpc_closure_init(': ['src/core/lib/iomgr/closure.cc'],
     'grpc_closure_sched(': ['src/core/lib/iomgr/closure.cc'],


### PR DESCRIPTION
This PR introduces a gRPC core-version of `grpc_call_cancel` that gets invoked by ALTS TSI implementation which is now a part of gRPC core.

Before the change, a deadlock is introduced between `security_handshaker_shutdown` and `on_handshake_next_done_grpc_wrapper` API invocations. That is, `security_handshaker_shutdown` will trigger `tsi_handshaker_shutdown` that will eventually invoke `grpc_call_cancel` in ALTS handshaker client. `grpc_call_cancel` will flush its exec ctx before its return which triggers `on_handshake_next_done_grpc_wrapper` that attempts to acquire the lock that has not yet been released by `security_handshaker_shutdown`. 