### PR TITLE
use bazel --config= for all foundry builds

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -6,7 +6,10 @@
 build --client_env=CC=clang
 build --copt=-DGRPC_BAZEL_BUILD
 
+build:opt --compilation_mode=opt
 build:opt --copt=-Wframe-larger-than=16384
+
+build:dbg --compilation_mode=dbg
 
 build:asan --strip=never
 build:asan --copt=-fsanitize=address

--- a/tools/internal_ci/linux/grpc_bazel_on_foundry_dbg.sh
+++ b/tools/internal_ci/linux/grpc_bazel_on_foundry_dbg.sh
@@ -16,5 +16,5 @@
 set -ex
 
 export UPLOAD_TEST_RESULTS=true
-EXTRA_FLAGS="-c dbg --test_timeout=300,450,1200,3600 --cache_test_results=no"
+EXTRA_FLAGS="--config=dbg --test_timeout=300,450,1200,3600 --cache_test_results=no"
 github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh "${EXTRA_FLAGS}"

--- a/tools/internal_ci/linux/grpc_bazel_on_foundry_opt.sh
+++ b/tools/internal_ci/linux/grpc_bazel_on_foundry_opt.sh
@@ -16,5 +16,5 @@
 set -ex
 
 export UPLOAD_TEST_RESULTS=true
-EXTRA_FLAGS="-c opt --test_timeout=300,450,1200,3600 --cache_test_results=no"
+EXTRA_FLAGS="--config=opt --test_timeout=300,450,1200,3600 --cache_test_results=no"
 github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh "${EXTRA_FLAGS}"

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_dbg.sh
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_dbg.sh
@@ -15,5 +15,5 @@
 
 set -ex
 
-EXTRA_FLAGS="-c dbg --test_timeout=300,450,1200,3600"
+EXTRA_FLAGS="--config=dbg --test_timeout=300,450,1200,3600"
 github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh "${EXTRA_FLAGS}"

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_opt.sh
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_opt.sh
@@ -15,5 +15,5 @@
 
 set -ex
 
-EXTRA_FLAGS="-c opt --test_timeout=300,450,1200,3600"
+EXTRA_FLAGS="--config=opt --test_timeout=300,450,1200,3600"
 github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh "${EXTRA_FLAGS}"

--- a/tools/remote_build/README.md
+++ b/tools/remote_build/README.md
@@ -17,10 +17,10 @@ and tests run by Kokoro CI.
 
 ## Running remote build manually from dev workstation
 
-Run from repository root:
+Run from repository root (opt, dbg):
 ```
 # manual run of bazel tests remotely on Foundry
-bazel --bazelrc=tools/remote_build/manual.bazelrc test -c opt //test/...
+bazel --bazelrc=tools/remote_build/manual.bazelrc test --config=opt //test/...
 ```
 
 Sanitizer runs (asan, msan, tsan, ubsan):


### PR DESCRIPTION
Bazel has two options that can easily be confused: `-c` (= `--compilation_mode`) and `--config`.
This PR codifies the use of `--config` for `opt` and `dbg` configurations to avoid confusion between `-c` and `--config`.