### PR TITLE
disable json_run_localhost on bazel RBE msan

### DIFF
--- a/tools/remote_build/rbe_common.bazelrc
+++ b/tools/remote_build/rbe_common.bazelrc
@@ -55,6 +55,8 @@ build:asan --test_tag_filters=-qps_json_driver,-json_run_localhost
 build:msan --copt=-gmlt
 # TODO(jtattermusch): use more reasonable test timeout
 build:msan --test_timeout=3600
+# TODO(jtattermusch): revisit the disabled tests
+build:msan --test_tag_filters=-json_run_localhost
 build:msan --cxxopt=--stdlib=libc++
 # setting LD_LIBRARY_PATH is necessary
 # to avoid "libc++.so.1: cannot open shared object file"


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/17038

disabling json_run_localhost because @ncteisen prefers that over introducing a memset in https://github.com/grpc/grpc/pull/17140