### PR TITLE
Add missing transitive dependencies

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -9,3 +9,7 @@ futures>=2.2.0
 google-auth>=1.0.0
 oauth2client==4.1.0
 requests>=2.14.2
+urllib3==1.22
+chardet==3.0.4
+certifi==2017.4.17
+idna==2.7

--- a/src/python/grpcio_tests/tests/interop/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/interop/BUILD.bazel
@@ -35,6 +35,10 @@ py_library(
         requirement('google-auth'),
         requirement('requests'),
         requirement('enum34'),
+        requirement('urllib3'),
+        requirement('chardet'),
+        requirement('certifi'),
+        requirement('idna'),
     ],
     imports=["../../",],
 )


### PR DESCRIPTION
This commit resolves an interop test currently failing on master. Over
the past couple of weeks, bazel-based tests have been introduced. The
current setup does not appear to automatically handle transitive
dependencies. Instead, transitive dependencies such as `requests` have
been manually added to `requirements.bazel.txt`. It appears that the
build server happened to have the dependencies of the `requests` library
installed already, but later had a configuration wipe.

This was compounded by the google-auth library erroneously reporting
that the `requests` module itself was not installed. In fact, it was the
transitive dependencies of `requests` that were not being installed by
the build file. (third-order dependencies of our test)

I consider this a quick fix to get the build passing. In the long run,
we need to automatically resolve and install transitive dependencies in
our bazel builds.

Resolves: #17170 

@ghostwriternr Any suggestions on how to improve this setup?