### PR TITLE
Fix clang-tidy issues

### DIFF
--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -149,7 +149,7 @@ class ClientLbEnd2endTest : public ::testing::Test {
 
   void StartServers(size_t num_servers,
                     std::vector<int> ports = std::vector<int>()) {
-    CreateServers(num_servers, ports);
+    CreateServers(num_servers, std::move(ports));
     for (size_t i = 0; i < num_servers; ++i) {
       StartServer(i);
     }

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -272,6 +272,7 @@ class End2endTest : public ::testing::TestWithParam<TestScenario> {
           std::unique_ptr<experimental::ServerInterceptorFactoryInterface>>
           creators;
       // Add 20 dummy server interceptors
+      creators.reserve(20);
       for (auto i = 0; i < 20; i++) {
         creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
             new DummyInterceptorFactory()));

--- a/test/cpp/end2end/server_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/server_interceptors_end2end_test.cc
@@ -391,6 +391,7 @@ TEST_F(ServerInterceptorsAsyncEnd2endTest, GenericRPCTest) {
   builder.RegisterAsyncGenericService(&service);
   std::vector<std::unique_ptr<experimental::ServerInterceptorFactoryInterface>>
       creators;
+  creators.reserve(20);
   for (auto i = 0; i < 20; i++) {
     creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
         new DummyInterceptorFactory()));
@@ -486,6 +487,7 @@ TEST_F(ServerInterceptorsAsyncEnd2endTest, UnimplementedRpcTest) {
   builder.AddListeningPort(server_address, InsecureServerCredentials());
   std::vector<std::unique_ptr<experimental::ServerInterceptorFactoryInterface>>
       creators;
+  creators.reserve(20);
   for (auto i = 0; i < 20; i++) {
     creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
         new DummyInterceptorFactory()));
@@ -539,6 +541,7 @@ TEST_F(ServerInterceptorsSyncUnimplementedEnd2endTest, UnimplementedRpcTest) {
   builder.AddListeningPort(server_address, InsecureServerCredentials());
   std::vector<std::unique_ptr<experimental::ServerInterceptorFactoryInterface>>
       creators;
+  creators.reserve(20);
   for (auto i = 0; i < 20; i++) {
     creators.push_back(std::unique_ptr<DummyInterceptorFactory>(
         new DummyInterceptorFactory()));

--- a/test/cpp/interop/interop_client.cc
+++ b/test/cpp/interop/interop_client.cc
@@ -76,7 +76,7 @@ void UnaryCompressionChecks(const InteropClientContextInspector& inspector,
 
 InteropClient::ServiceStub::ServiceStub(
     ChannelCreationFunc channel_creation_func, bool new_stub_every_call)
-    : channel_creation_func_(channel_creation_func),
+    : channel_creation_func_(std::move(channel_creation_func)),
       channel_(channel_creation_func_()),
       new_stub_every_call_(new_stub_every_call) {
   // If new_stub_every_call is false, then this is our chance to initialize
@@ -112,7 +112,7 @@ void InteropClient::ServiceStub::ResetChannel() {
 InteropClient::InteropClient(ChannelCreationFunc channel_creation_func,
                              bool new_stub_every_test_case,
                              bool do_not_abort_on_transient_failures)
-    : serviceStub_(channel_creation_func, new_stub_every_test_case),
+    : serviceStub_(std::move(channel_creation_func), new_stub_every_test_case),
       do_not_abort_on_transient_failures_(do_not_abort_on_transient_failures) {}
 
 bool InteropClient::AssertStatusOk(const Status& s,

--- a/test/cpp/interop/stress_interop_client.cc
+++ b/test/cpp/interop/stress_interop_client.cc
@@ -73,7 +73,7 @@ StressTestInteropClient::StressTestInteropClient(
     long sleep_duration_ms, bool do_not_abort_on_transient_failures)
     : test_id_(test_id),
       server_address_(server_address),
-      channel_creation_func_(channel_creation_func),
+      channel_creation_func_(std::move(channel_creation_func)),
       interop_client_(new InteropClient(channel_creation_func_, false,
                                         do_not_abort_on_transient_failures)),
       test_selector_(test_selector),


### PR DESCRIPTION
Fix a bunch of clang-tidy issues around std::move and vector reserve for fixed-size vectors