### PR TITLE
make client_channel_stress_test run exclusively

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4489,6 +4489,7 @@ targets:
   - gpr
 - name: client_channel_stress_test
   gtest: false
+  cpu_cost: 10.0
   build: test
   language: c++
   src:

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -3990,7 +3990,7 @@
       "posix", 
       "windows"
     ], 
-    "cpu_cost": 1.0, 
+    "cpu_cost": 10.0, 
     "exclude_configs": [], 
     "exclude_iomgrs": [], 
     "flaky": false, 


### PR DESCRIPTION
Tentative fix for https://github.com/grpc/grpc/issues/16985.

If I run locally with the same `ulimit -n` as on kokoro, the test is passing, but it seems that the tests is running in parallel with other tests with might make it go over the limit. Setting high cpu_count to make sure the tests runs on macos as "exclusive".