### PR TITLE
Fix linux_extra python artifacts

### DIFF
--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -124,6 +124,8 @@ class PythonArtifact:
             # https://github.com/resin-io-projects/armv7hf-debian-qemu/issues/9
             # A QEMU bug causes submodule update to hang, so we copy directly
             environ['RELATIVE_COPY_PATH'] = '.'
+            # Parallel builds are counterproductive in emulated environment
+            environ['GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS'] = '1'
             extra_args = ' --entrypoint=/usr/bin/qemu-arm-static '
             return create_docker_jobspec(
                 self.name,

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -24,7 +24,8 @@ export AUDITWHEEL=${AUDITWHEEL:-auditwheel}
 
 # Allow build_ext to build C/C++ files in parallel
 # by enabling a monkeypatch. It speeds up the build a lot.
-export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=2
+# Use externally provided GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS value if set.
+export GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS=${GRPC_PYTHON_BUILD_EXT_COMPILER_JOBS:-2}
 
 mkdir -p "${ARTIFACTS_OUT}"
 ARTIFACT_DIR="$PWD/${ARTIFACTS_OUT}"


### PR DESCRIPTION
the arm artifacts for python ("linux_extra") currently seems broken, probably because of https://github.com/grpc/grpc/pull/17133.

It turns out that the parallel build is extremely slow when running on arm emulator so the jobs are timing out. Adding a flag to disable parallel compilation when building the arm artifacts.

Example successful build:
https://source.cloud.google.com/results/invocations/b8eb061e-c7ae-4ed1-a30e-2d9eececdb91/targets