### PR TITLE
Fix timer manager debug code

### DIFF
--- a/src/core/lib/gpr/sync_posix.cc
+++ b/src/core/lib/gpr/sync_posix.cc
@@ -30,11 +30,13 @@
 // For debug of the timer manager crash only.
 // TODO (mxyan): remove after bug is fixed.
 #ifdef GRPC_DEBUG_TIMER_MANAGER
-void GRPCDebugTimerManagerLogStats(
-    int64_t timer_manager_init_count, int64_t timer_manager_shutdown_count,
-    int64_t fork_count, int64_t timer_wait_err, int64_t timer_cv_value,
-    int64_t timer_mu_value, int64_t abstime_sec_value,
-    int64_t abstime_nsec_value);
+void GRPCDebugTimerManagerLogStats(int64_t timer_manager_init_count,
+                                   int64_t timer_manager_shutdown_count,
+                                   int64_t fork_count, int64_t timer_wait_err,
+                                   int64_t timer_cv_value,
+                                   int64_t timer_mu_value,
+                                   int64_t abstime_sec_value,
+                                   int64_t abstime_nsec_value);
 int64_t g_timer_manager_init_count = 0;
 int64_t g_timer_manager_shutdown_count = 0;
 int64_t g_fork_count = 0;

--- a/src/core/lib/gpr/sync_posix.cc
+++ b/src/core/lib/gpr/sync_posix.cc
@@ -30,11 +30,11 @@
 // For debug of the timer manager crash only.
 // TODO (mxyan): remove after bug is fixed.
 #ifdef GRPC_DEBUG_TIMER_MANAGER
-void (*g_grpc_debug_timer_manager_stats)(
+void GRPCDebugTimerManagerLogStats(
     int64_t timer_manager_init_count, int64_t timer_manager_shutdown_count,
     int64_t fork_count, int64_t timer_wait_err, int64_t timer_cv_value,
     int64_t timer_mu_value, int64_t abstime_sec_value,
-    int64_t abstime_nsec_value) = nullptr;
+    int64_t abstime_nsec_value);
 int64_t g_timer_manager_init_count = 0;
 int64_t g_timer_manager_shutdown_count = 0;
 int64_t g_fork_count = 0;
@@ -119,15 +119,13 @@ int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu, gpr_timespec abs_deadline) {
   // For debug of the timer manager crash only.
   // TODO (mxyan): remove after bug is fixed.
   if (GPR_UNLIKELY(!(err == 0 || err == ETIMEDOUT || err == EAGAIN))) {
-    if (g_grpc_debug_timer_manager_stats) {
-      g_timer_wait_err = err;
-      g_timer_cv_value = (int64_t)cv;
-      g_timer_mu_value = (int64_t)mu;
-      g_grpc_debug_timer_manager_stats(
-          g_timer_manager_init_count, g_timer_manager_shutdown_count,
-          g_fork_count, g_timer_wait_err, g_timer_cv_value, g_timer_mu_value,
-          g_abstime_sec_value, g_abstime_nsec_value);
-    }
+    g_timer_wait_err = err;
+    g_timer_cv_value = (int64_t)cv;
+    g_timer_mu_value = (int64_t)mu;
+    GRPCDebugTimerManagerLogStats(
+        g_timer_manager_init_count, g_timer_manager_shutdown_count,
+        g_fork_count, g_timer_wait_err, g_timer_cv_value, g_timer_mu_value,
+        g_abstime_sec_value, g_abstime_nsec_value);
   }
 #endif
   GPR_ASSERT(err == 0 || err == ETIMEDOUT || err == EAGAIN);

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -114,21 +114,8 @@ void grpc_register_plugin(void (*init)(void), void (*destroy)(void)) {
   g_number_of_plugins++;
 }
 
-// For debug of the timer manager crash only.
-// TODO (mxyan): remove after bug is fixed.
-#ifdef GRPC_DEBUG_TIMER_MANAGER
-void init_debug_timer_manager();
-#endif
-
 void grpc_init(void) {
   int i;
-
-// For debug of the timer manager crash only.
-// TODO (mxyan): remove after bug is fixed.
-  #ifdef GRPC_DEBUG_TIMER_MANAGER
-  init_debug_timer_manager();
-  #endif
-
   gpr_once_init(&g_basic_init, do_basic_init);
 
   gpr_mu_lock(&g_init_mu);

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -114,8 +114,21 @@ void grpc_register_plugin(void (*init)(void), void (*destroy)(void)) {
   g_number_of_plugins++;
 }
 
+// For debug of the timer manager crash only.
+// TODO (mxyan): remove after bug is fixed.
+#ifdef GRPC_DEBUG_TIMER_MANAGER
+void init_debug_timer_manager();
+#endif
+
 void grpc_init(void) {
   int i;
+
+// For debug of the timer manager crash only.
+// TODO (mxyan): remove after bug is fixed.
+  #ifdef GRPC_DEBUG_TIMER_MANAGER
+  init_debug_timer_manager();
+  #endif
+
   gpr_once_init(&g_basic_init, do_basic_init);
 
   gpr_mu_lock(&g_init_mu);


### PR DESCRIPTION
This PR prevents dead-stripping of timer manager debug code by directly calling the log function, rather than using a pre-initialized pointer. The suspected reason for previous debug code (#16714) not working was because of dead-stripping of the pointer initialization (see internal CL).