### PR TITLE
Use the kokoro's default maxfiles on macosx

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -15,14 +15,8 @@
 
 # Source this rc script to prepare the environment for macos builds
 
-sudo launchctl limit maxfiles unlimited unlimited
-
-# show current maxfiles
+# show original open file limit values
 launchctl limit maxfiles
-
-ulimit -n 10000
-
-# show current limits
 ulimit -a
 
 # synchronize the clock


### PR DESCRIPTION
Long time ago, kokoro was setting max open files to something low, so we needed to override that value. Right now, it seems that the default maxfiles is 500000, so we should just go with that.

Tentative fix for #16985.