### PR TITLE
ipv6 addresses must be bracketed if using a port

### DIFF
--- a/doc/naming.md
+++ b/doc/naming.md
@@ -51,7 +51,9 @@ but may not be supported in other languages:
 
 - `ipv6:address[:port][,address[:port],...]` -- IPv6 addresses
   - Can specify multiple comma-delimited addresses of the form `address[:port]`:
-    - `address` is the IPv6 address to use.
+    - `address` is the IPv6 address to use. To use with a `port` the `address`
+      must enclosed in literal square brakets (`[` and `]`).  Example: 
+      `ipv6:[2607:f8b0:400e:c00::ef]:443` or `ipv6:[::]:1234`
     - `port` is the port to use.  If not specified, 443 is used.
 
 In the future, additional schemes such as `etcd` could be added.


### PR DESCRIPTION
The host/port splitting code will not pull out a port if there are >=2 colons[1].
Unit test code demos this [2].  Note other documentation gets this right[3].  Example IP came from this issue[4] and the unit tests[2].
See also: relevant RFCs [5] [6]

[1]https://github.com/grpc/grpc/blob/618a3f561d4a93f263cca23abad086ed8f4d5e86/src/core/lib/gpr/host_port.cc#L81
[2]https://github.com/grpc/grpc/blob/618a3f561d4a93f263cca23abad086ed8f4d5e86/test/core/client_channel/resolvers/sockaddr_resolver_test.cc#L107
[3]https://chromium.googlesource.com/external/github.com/grpc/grpc/+/chromium-deps/2016-07-19/src/core/ext/client_config/README.md
[4]https://github.com/grpc/grpc/issues/6623
[5]http://www.iana.org/go/rfc5952#section-6
[6]http://www.iana.org/go/rfc3986#section-3.2.3