### PR TITLE
Update Python documentation

### DIFF
--- a/doc/python/sphinx/grpc.rst
+++ b/doc/python/sphinx/grpc.rst
@@ -1,10 +1,26 @@
-API Reference
+gRPC
 =============
 
 .. module:: grpc
 
+Tutorial
+--------
+
+If you want to see gRPC in action first, visit the `Python Quickstart <https://grpc.io/docs/quickstart/python.html>`_.
+Or, if you would like dive in with more extensive usage of gRPC Python, check `gRPC Basics - Python <https://grpc.io/docs/tutorials/basic/python.html>`_ out.
+
+
+Example
+-------
+
+Go to `gRPC Python Examples <https://github.com/grpc/grpc/tree/master/examples/python>`_
+
+
+Module Contents
+---------------
+
 Create Client
--------------
+^^^^^^^^^^^^^
 
 .. autofunction:: insecure_channel
 .. autofunction:: secure_channel
@@ -12,7 +28,7 @@ Create Client
 
 
 Create Client Credentials
--------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: ssl_channel_credentials
 .. autofunction:: metadata_call_credentials
@@ -22,13 +38,13 @@ Create Client Credentials
 
 
 Create Server
--------------
+^^^^^^^^^^^^^
 
 .. autofunction:: server
 
 
 Create Server Credentials
--------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: ssl_server_credentials
 .. autofunction:: ssl_server_certificate_configuration
@@ -36,7 +52,7 @@ Create Server Credentials
 
 
 RPC Method Handlers
---------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: unary_unary_rpc_method_handler
 .. autofunction:: unary_stream_rpc_method_handler
@@ -46,37 +62,37 @@ RPC Method Handlers
 
 
 Channel Ready Future
---------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: channel_ready_future
 
 
 Channel Connectivity
---------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: ChannelConnectivity
 
 
 gRPC Status Code
---------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: StatusCode
 
 
 Channel Object
---------------
+^^^^^^^^^^^^^^
 
 .. autoclass:: Channel
 
 
 Server Object
--------------
+^^^^^^^^^^^^^
 
 .. autoclass:: Server
 
 
 Authentication & Authorization Objects
---------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: ChannelCredentials
 .. autoclass:: CallCredentials
@@ -88,25 +104,25 @@ Authentication & Authorization Objects
 
 
 gRPC Exceptions
----------------
+^^^^^^^^^^^^^^^
 
 .. autoexception:: RpcError
 
 
 Shared Context
---------------
+^^^^^^^^^^^^^^
 
 .. autoclass:: RpcContext
 
 
 Client-Side Context
------------------------
+^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: Call
 
 
 Client-Side Interceptor
-------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: ClientCallDetails
 .. autoclass:: UnaryUnaryClientInterceptor
@@ -116,13 +132,13 @@ Client-Side Interceptor
 
 
 Service-Side Context
---------------------
+^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: ServicerContext
 
 
 Service-Side Handler
--------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: RpcMethodHandler
 .. autoclass:: HandlerCallDetails
@@ -131,13 +147,13 @@ Service-Side Handler
 
 
 Service-Side Interceptor
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: ServerInterceptor
 
 
-Multi-Callable
--------------------------
+Multi-Callable Interfaces
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: UnaryUnaryMultiCallable
 .. autoclass:: UnaryStreamMultiCallable
@@ -145,8 +161,8 @@ Multi-Callable
 .. autoclass:: StreamStreamMultiCallable
 
 
-Future
-----------------
+Future Interfaces
+^^^^^^^^^^^^^^^^^
 
 .. autoexception:: FutureTimeoutError
 .. autoexception:: FutureCancelledError

--- a/doc/python/sphinx/index.rst
+++ b/doc/python/sphinx/index.rst
@@ -9,7 +9,7 @@ API Reference
 .. toctree::
    :caption: Contents:
 
-   api
+   grpc
    grpc_health_checking
    grpc_reflection
    grpc_testing


### PR DESCRIPTION
Reorganized the section titles to make it more consistent, and added `Tutorial` and `Example` section to point to [grpc.io](https://grpc.io) and GitHub example folder.