### PR TITLE
Revert RR policy update in xDS

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
@@ -1321,10 +1321,12 @@ void XdsLb::ProcessChannelArgsLocked(const grpc_channel_args& args) {
 
 void XdsLb::UpdateLocked(const grpc_channel_args& args) {
   ProcessChannelArgsLocked(args);
-  // Note: We have disabled fallback mode in the code, so we don't need to
-  // handle fallback address changes.
+  // Update the existing RR policy.
+  // Note: We have disabled fallback mode in the code, so this RR policy must
+  // have been created from a serverlist.
   // TODO(vpowar): Handle the fallback_address changes when we add support for
   // fallback in xDS.
+  if (rr_policy_ != nullptr) CreateOrUpdateRoundRobinPolicyLocked();
   // Start watching the LB channel connectivity for connection, if not
   // already doing so.
   if (!watching_lb_channel_) {


### PR DESCRIPTION
The update was removed in https://github.com/grpc/grpc/pull/17125, because I thought it's just to update the fallback data. But it actually covered other channel args. So we should update the RR policy whenever it's non-null. I changed the grpclb code in https://github.com/grpc/grpc/pull/17131, but forgot to change the xds code. 

@vishalpowar Please update the RR policy name if this PR is merged into master branch earlier than https://github.com/grpc/grpc/pull/17163. Thanks! 