### PR TITLE
Properly clear metadata and other structs when reusing ServerContext in callback API

### DIFF
--- a/include/grpcpp/impl/codegen/metadata_map.h
+++ b/include/grpcpp/impl/codegen/metadata_map.h
@@ -32,11 +32,9 @@ const char kBinaryErrorDetailsKey[] = "grpc-status-details-bin";
 
 class MetadataMap {
  public:
-  MetadataMap() { memset(&arr_, 0, sizeof(arr_)); }
+  MetadataMap() { Setup(); }
 
-  ~MetadataMap() {
-    g_core_codegen_interface->grpc_metadata_array_destroy(&arr_);
-  }
+  ~MetadataMap() { Destroy(); }
 
   grpc::string GetBinaryErrorDetails() {
     // if filled_, extract from the multimap for O(log(n))
@@ -71,10 +69,23 @@ class MetadataMap {
   }
   grpc_metadata_array* arr() { return &arr_; }
 
+  void Reset() {
+    filled_ = false;
+    map_.clear();
+    Destroy();
+    Setup();
+  }
+
  private:
   bool filled_ = false;
   grpc_metadata_array arr_;
   std::multimap<grpc::string_ref, grpc::string_ref> map_;
+
+  void Destroy() {
+    g_core_codegen_interface->grpc_metadata_array_destroy(&arr_);
+  }
+
+  void Setup() { memset(&arr_, 0, sizeof(arr_)); }
 
   void FillMap() {
     if (filled_) return;

--- a/src/cpp/server/server_context.cc
+++ b/src/cpp/server/server_context.cc
@@ -247,6 +247,10 @@ void ServerContext::BindDeadlineAndMetadata(gpr_timespec deadline,
 ServerContext::~ServerContext() { Clear(); }
 
 void ServerContext::Clear() {
+  auth_context_.reset();
+  initial_metadata_.clear();
+  trailing_metadata_.clear();
+  client_metadata_.Reset();
   if (call_) {
     grpc_call_unref(call_);
   }


### PR DESCRIPTION
Credit for test and issue identification to @hcaseyal 