### PR TITLE
AuthMetadataProcessor: don't start a ThreadPool for non-blocking

### DIFF
--- a/src/cpp/server/secure_server_credentials.cc
+++ b/src/cpp/server/secure_server_credentials.cc
@@ -23,6 +23,7 @@
 #include <grpcpp/impl/codegen/slice.h>
 #include <grpcpp/security/auth_metadata_processor.h>
 
+#include "include/grpc/impl/codegen/log.h"  // for GPR_ASSERT
 #include "src/cpp/common/secure_auth_context.h"
 #include "src/cpp/server/secure_server_credentials.h"
 
@@ -43,6 +44,7 @@ void AuthMetadataProcessorAyncWrapper::Process(
     return;
   }
   if (w->processor_->IsBlocking()) {
+    GPR_ASSERT(w->thread_pool_);
     w->thread_pool_->Add([w, context, md, num_md, cb, user_data] {
       w->AuthMetadataProcessorAyncWrapper::InvokeProcessor(context, md, num_md,
                                                            cb, user_data);

--- a/src/cpp/server/secure_server_credentials.cc
+++ b/src/cpp/server/secure_server_credentials.cc
@@ -23,7 +23,6 @@
 #include <grpcpp/impl/codegen/slice.h>
 #include <grpcpp/security/auth_metadata_processor.h>
 
-#include "include/grpc/impl/codegen/log.h"  // for GPR_ASSERT
 #include "src/cpp/common/secure_auth_context.h"
 #include "src/cpp/server/secure_server_credentials.h"
 
@@ -44,7 +43,6 @@ void AuthMetadataProcessorAyncWrapper::Process(
     return;
   }
   if (w->processor_->IsBlocking()) {
-    GPR_ASSERT(w->thread_pool_);
     w->thread_pool_->Add([w, context, md, num_md, cb, user_data] {
       w->AuthMetadataProcessorAyncWrapper::InvokeProcessor(context, md, num_md,
                                                            cb, user_data);

--- a/src/cpp/server/secure_server_credentials.h
+++ b/src/cpp/server/secure_server_credentials.h
@@ -39,7 +39,13 @@ class AuthMetadataProcessorAyncWrapper final {
 
   AuthMetadataProcessorAyncWrapper(
       const std::shared_ptr<AuthMetadataProcessor>& processor)
-      : thread_pool_(CreateDefaultThreadPool()), processor_(processor) {}
+      : processor_(processor) {
+    // No need to create a ThreadPool which would not be used for a non-blocking
+    // AuthMetadataProcessor
+    if (processor && processor_->IsBlocking()) {
+      thread_pool_.reset(CreateDefaultThreadPool());
+    }
+  }
 
  private:
   void InvokeProcessor(grpc_auth_context* context, const grpc_metadata* md,


### PR DESCRIPTION
Fixes #16855

Without this, N threads(one per core) end up waiting
on a cond var that is never updated
at DynamicThreadPool::ThreadFunc()