### PR TITLE
Make Pluck use the changes made in FinalizeResult

### DIFF
--- a/include/grpcpp/impl/codegen/completion_queue.h
+++ b/include/grpcpp/impl/codegen/completion_queue.h
@@ -307,8 +307,7 @@ class CompletionQueue : private GrpcLibraryCodegen {
       void* ignored = tag;
       if (tag->FinalizeResult(&ignored, &ok)) {
         GPR_CODEGEN_ASSERT(ignored == tag);
-        // Ignore mutations by FinalizeResult: Pluck returns the C API status
-        return ev.success != 0;
+        return ok;
       }
     }
   }

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -84,10 +84,7 @@ class ShutdownTag : public internal::CompletionQueueTag {
 
 class DummyTag : public internal::CompletionQueueTag {
  public:
-  bool FinalizeResult(void** tag, bool* status) {
-    *status = true;
-    return true;
-  }
+  bool FinalizeResult(void** tag, bool* status) { return true; }
 };
 
 class UnimplementedAsyncRequestContext {


### PR DESCRIPTION
Make Pluck use the changes made in FinalizeResult. 

I have no idea why it was done this way.