### PR TITLE
Unblock the server destruction process

### DIFF
--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -828,7 +828,7 @@ class _Server(grpc.Server):
         return _stop(self._state, grace)
 
     def __del__(self):
-        _stop(self._state, None)
+        _stop(self._state, 0)
 
 
 def create_server(thread_pool, generic_rpc_handlers, interceptors, options,


### PR DESCRIPTION
This is an ugly fix for #17214.
In Python 2, it should be an noop. In Python 3, it frees the main thread from blocked during server destruction.

It is challenging to trace down behavior of CPython. So far I know that, the actual serving thread exits immediately after the exception is raised, but Python 3 failed to notice that, then hung on a lock that was trashed by gc.

Let's see whether our test is happy with this one-line change or not.

There is a unit test suits this scenario but disabled long ago by issue https://github.com/grpc/grpc/issues/7311. It runs script in another process, which is perfect for this bug reproduction, but it requires to know which executable it is using by `sys.executable`. In cases that gRPC got compiled into binary, there is no way to retrieve `sys.executable`. If there are better idea to test it, I would love to implement it.