### PR TITLE
Don't reset channel state on resolver failure when LB policy exists.

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -597,6 +597,8 @@ static void on_resolver_result_changed_locked(void* arg, grpc_error* error) {
     if (grpc_client_channel_trace.enabled()) {
       gpr_log(GPR_INFO, "chand=%p: resolver transient failure", chand);
     }
+    // Don't override connectivity state if we already have an LB policy.
+    if (chand->lb_policy != nullptr) set_connectivity_state = false;
   } else {
     grpc_core::UniquePtr<char> lb_policy_name =
         get_lb_policy_name_from_resolver_result_locked(chand);

--- a/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h
+++ b/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h
@@ -61,6 +61,10 @@ class FakeResolverResponseGenerator
   // returning a null result with no error).
   void SetFailure();
 
+  // Same as SetFailure(), but instead of returning the error
+  // immediately, waits for the next call to RequestReresolutionLocked().
+  void SetFailureOnReresolution();
+
   // Returns a channel arg containing \a generator.
   static grpc_arg MakeChannelArg(FakeResolverResponseGenerator* generator);
 


### PR DESCRIPTION
cc @muxi @srini100 