### PR TITLE
Enable lcov 1.12 and 1.13 for gRPC PHP

### DIFF
--- a/src/php/ext/grpc/config.m4
+++ b/src/php/ext/grpc/config.m4
@@ -103,7 +103,7 @@ if test "$PHP_COVERAGE" = "yes"; then
     AC_MSG_ERROR([ccache must be disabled when --enable-coverage option is used. You can disable ccache by setting environment variable CCACHE_DISABLE=1.])
   fi
   
-  lcov_version_list="1.5 1.6 1.7 1.9 1.10 1.11"
+  lcov_version_list="1.5 1.6 1.7 1.9 1.10 1.11 1.12 1.13"
 
   AC_CHECK_PROG(LCOV, lcov, lcov)
   AC_CHECK_PROG(GENHTML, genhtml, genhtml)


### PR DESCRIPTION
Enable lcov 1.12 and 1.13 in favor of create a Docker image for issue #17198 