### PR TITLE
Replace addProtoService with addService

### DIFF
--- a/examples/node/dynamic_codegen/route_guide/route_guide_server.js
+++ b/examples/node/dynamic_codegen/route_guide/route_guide_server.js
@@ -218,7 +218,7 @@ function routeChat(call) {
  */
 function getServer() {
   var server = new grpc.Server();
-  server.addProtoService(routeguide.RouteGuide.service, {
+  server.addService(routeguide.RouteGuide.service, {
     getFeature: getFeature,
     listFeatures: listFeatures,
     recordRoute: recordRoute,


### PR DESCRIPTION
`addProtoService` is now deprecated. Compilation step informs us to use `addService` instead

`(node:14032) DeprecationWarning: Server#addProtoService: Use Server#addService instead`