### PR TITLE
avoid c-ares dependency on libnsl (for v1.17.x)

### DIFF
--- a/cmake/cares.cmake
+++ b/cmake/cares.cmake
@@ -18,6 +18,10 @@ if("${gRPC_CARES_PROVIDER}" STREQUAL "module")
   endif()
   set(CARES_SHARED OFF CACHE BOOL "disable shared library")
   set(CARES_STATIC ON CACHE BOOL "link cares statically")
+  if(gRPC_BACKWARDS_COMPATIBILITY_MODE)
+    # See https://github.com/grpc/grpc/issues/17255
+    set(HAVE_LIBNSL OFF CACHE BOOL "avoid cares dependency on libnsl")
+  endif()
   add_subdirectory(third_party/cares/cares)
 
   if(TARGET c-ares)


### PR DESCRIPTION
Fix for #17255.

Also see https://github.com/grpc/grpc/pull/17270

Still needs to be upmerged to master.