### PR TITLE
Add C# distribtest for alpine linux

### DIFF
--- a/test/distrib/csharp/run_distrib_test_dotnetcli.sh
+++ b/test/distrib/csharp/run_distrib_test_dotnetcli.sh
@@ -33,11 +33,14 @@ dotnet publish -f net45 DistribTestDotNet.csproj
 
 ls -R bin
 
-# .NET 4.5 target after dotnet build
-mono bin/Debug/net45/publish/DistribTestDotNet.exe
+if [ "${SKIP_MONO_DISTRIBTEST}" != "1" ]
+then
+  # .NET 4.5 target after dotnet build
+  mono bin/Debug/net45/publish/DistribTestDotNet.exe
 
-# .NET 4.5 target after dotnet publish
-mono bin/Debug/net45/publish/DistribTestDotNet.exe
+  # .NET 4.5 target after dotnet publish
+  mono bin/Debug/net45/publish/DistribTestDotNet.exe
+fi
 
 # .NET Core target after dotnet build
 dotnet exec bin/Debug/netcoreapp2.1/DistribTestDotNet.dll

--- a/tools/dockerfile/distribtest/csharp_alpine_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_alpine_x64/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1-alpine3.9
+
+RUN apk update && apk add bash
+RUN apk update && apk add unzip
+
+# Workaround for https://github.com/grpc/grpc/issues/18428
+# Also see https://github.com/sgerrand/alpine-pkg-glibc
+RUN apk update && apk --no-cache add ca-certificates wget
+RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
+RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.30-r0/glibc-2.30-r0.apk
+RUN apk add glibc-2.30-r0.apk
+
+# installing mono on alpine is hard and we don't really need it
+ENV SKIP_MONO_DISTRIBTEST=1

--- a/tools/run_tests/artifacts/distribtest_targets.py
+++ b/tools/run_tests/artifacts/distribtest_targets.py
@@ -310,6 +310,7 @@ def targets():
         CSharpDistribTest('linux', 'x64', 'centos7'),
         CSharpDistribTest('linux', 'x64', 'ubuntu1604'),
         CSharpDistribTest('linux', 'x64', 'ubuntu1604', use_dotnet_cli=True),
+        CSharpDistribTest('linux', 'x64', 'alpine', use_dotnet_cli=True),
         CSharpDistribTest('macos', 'x86'),
         CSharpDistribTest('windows', 'x86'),
         CSharpDistribTest('windows', 'x64'),


### PR DESCRIPTION
Add alpine 3.9 C# distribtest - a workaround mentioned here https://github.com/grpc/grpc/issues/18428#issuecomment-535041155 is necessary, but at least it things work with it.