### PR TITLE
Revert "Revert "pin google-api-python-client to 1.6.7 to avoid breakage""

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -28,7 +28,8 @@ sudo systemsetup -setusingnetworktime on
 date
 
 # Add GCP credentials for BQ access
-pip install google-api-python-client --user python
+# pin google-api-python-client to avoid https://github.com/grpc/grpc/issues/15600
+pip install google-api-python-client==1.6.7 --user python
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json
 
 # If this is a PR using RUN_TESTS_FLAGS var, then add flags to filter tests


### PR DESCRIPTION
Reverts grpc/grpc#15626

Without the pin, this still breaks uploading of test results on master (the regression is clear, it happens for several macos jobs on master).
```
Traceback (most recent call last):
  File "workspace_objc_macos_dbg_native/tools/run_tests/run_tests.py", line 1878, in <module>
    build_only=args.build_only)
  File "workspace_objc_macos_dbg_native/tools/run_tests/run_tests.py", line 1832, in _build_and_run
    upload_results_to_bq(resultset, args.bq_result_table,
NameError: global name 'upload_results_to_bq' is not defined
```

