### PR TITLE
Remove google-api-python-client pin

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -28,8 +28,7 @@ sudo systemsetup -setusingnetworktime on
 date
 
 # Add GCP credentials for BQ access
-# pin google-api-python-client to avoid https://github.com/grpc/grpc/issues/15600
-pip install google-api-python-client==1.6.7 --user python
+pip install google-api-python-client oauth2client --user python
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json
 
 # If this is a PR using RUN_TESTS_FLAGS var, then add flags to filter tests


### PR DESCRIPTION
Reintroduce what was reverted in https://github.com/grpc/grpc/pull/17274

Looks like oauth2client is not longer installed as part of google-api-python-client