### PR TITLE
Use 'preX' version number when pre-releasing gRPC-C++.podspec

### DIFF
--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.name     = 'gRPC-C++'
   # TODO (mxyan): use version that match gRPC version when pod is stabilized
   # version = '1.17.0-pre2'
-  version = '0.0.4'
+  version = '0.0.6-pre2'
   s.version  = version
   s.summary  = 'gRPC C++ library'
   s.homepage = 'https://grpc.io'

--- a/templates/gRPC-C++.podspec.template
+++ b/templates/gRPC-C++.podspec.template
@@ -127,12 +127,20 @@
 
   def ruby_multiline_list(files, indent):
     return (',\n' + indent*' ').join('\'%s\'' % f for f in files)
+
+  def modify_podspec_version_string(pod_version, grpc_version):
+    # Append -preX when it is a pre-release
+    if len(str(grpc_version).split('-')) > 1:
+      return pod_version + '-' + str(grpc_version).split('-')[-1]
+    else:
+      return pod_version
+
   %>
   Pod::Spec.new do |s|
     s.name     = 'gRPC-C++'
     # TODO (mxyan): use version that match gRPC version when pod is stabilized
     # version = '${settings.version}'
-    version = '0.0.4'
+    version = '${modify_podspec_version_string('0.0.6', settings.version)}'
     s.version  = version
     s.summary  = 'gRPC C++ library'
     s.homepage = 'https://grpc.io'


### PR DESCRIPTION
ref: https://github.com/firebase/firebase-ios-sdk/issues/2102

If we directly release another version, during pre-release some users that are flexible on the version of `gRPC-C++` pod will depend on the pre-release version of other gRPC pods. This will stop such behavior.