### PR TITLE
Necessary change after #17219

### DIFF
--- a/include/grpcpp/impl/codegen/client_unary_call.h
+++ b/include/grpcpp/impl/codegen/client_unary_call.h
@@ -69,18 +69,17 @@ class BlockingUnaryCallImpl {
     ops.ClientSendClose();
     ops.ClientRecvStatus(context, &status_);
     call.PerformOps(&ops);
-    if (cq.Pluck(&ops)) {
-      if (!ops.got_message && status_.ok()) {
-        status_ = Status(StatusCode::UNIMPLEMENTED,
-                         "No message returned for unary request");
-      }
-    } else {
-      // Some of the ops failed. For example, this can happen if deserialization
-      // of the message fails. gRPC Core guarantees that the op
-      // GRPC_OP_RECV_STATUS_ON_CLIENT always succeeds, so status would still be
-      // filled.
-      // TODO(yashykt): If deserialization fails, but the status received is OK,
-      // then it might be a good idea to change the status to reflect this.
+    cq.Pluck(&ops);
+    // Some of the ops might fail. If the ops fail in the core layer, status
+    // would reflect the error. But, if the ops fail in the C++ layer, the
+    // status would still be the same as the one returned by gRPC Core. This can
+    // happen if deserialization of the message fails.
+    // TODO(yashykt): If deserialization fails, but the status received is OK,
+    // then it might be a good idea to change the status to something better
+    // than StatusCode::UNIMPLEMENTED to reflect this.
+    if (!ops.got_message && status_.ok()) {
+      status_ = Status(StatusCode::UNIMPLEMENTED,
+                       "No message returned for unary request");
     }
   }
   Status status() { return status_; }

--- a/include/grpcpp/impl/codegen/client_unary_call.h
+++ b/include/grpcpp/impl/codegen/client_unary_call.h
@@ -75,7 +75,12 @@ class BlockingUnaryCallImpl {
                          "No message returned for unary request");
       }
     } else {
-      GPR_CODEGEN_ASSERT(!status_.ok());
+      // Some of the ops failed. For example, this can happen if deserialization
+      // of the message fails. gRPC Core guarantees that the op
+      // GRPC_OP_RECV_STATUS_ON_CLIENT always succeeds, so status would still be
+      // filled.
+      // TODO(yashykt): If deserialization fails, but the status received is OK,
+      // then it might be a good idea to change the status to reflect this.
     }
   }
   Status status() { return status_; }


### PR DESCRIPTION
Removing the assert. This needs to be done because of the changes made in #17219 which allow the FinalizeResult in Pluck to make changes to the success of the ops.

Also, since Pluck returning false is now possible after #17219 if deserialization fails, we should still be changing the status as earlier.