### PR TITLE
Include linux/version.h for manylinux

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -121,6 +121,7 @@
 #else /* _LP64 */
 #define GPR_ARCH_32 1
 #endif /* _LP64 */
+#include <linux/version.h>
 #elif defined(ANDROID) || defined(__ANDROID__)
 #define GPR_PLATFORM_STRING "android"
 #define GPR_ANDROID 1


### PR DESCRIPTION
Include linux/version.h for manylinux
This would enable all features that depend on the linux version being available.
One of them is TCP_USER_TIMEOUT