### PR TITLE
Return UNIMPLEMENTED error when user does not implement server_streamer method

### DIFF
--- a/src/ruby/lib/grpc/generic/service.rb
+++ b/src/ruby/lib/grpc/generic/service.rb
@@ -95,7 +95,7 @@ module GRPC
         rpc_descs[name] = RpcDesc.new(name, input, output,
                                       marshal_class_method,
                                       unmarshal_class_method)
-        define_method(GenericService.underscore(name.to_s).to_sym) do |_, _|
+        define_method(GenericService.underscore(name.to_s).to_sym) do |*|
           fail GRPC::BadStatus.new_status_exception(
             GRPC::Core::StatusCodes::UNIMPLEMENTED)
         end

--- a/src/ruby/spec/support/services.rb
+++ b/src/ruby/spec/support/services.rb
@@ -33,6 +33,7 @@ class EchoService
   rpc :a_client_streaming_rpc, stream(EchoMsg), EchoMsg
   rpc :a_server_streaming_rpc, EchoMsg, stream(EchoMsg)
   rpc :a_bidi_rpc, stream(EchoMsg), stream(EchoMsg)
+  rpc :a_client_streaming_rpc_unimplemented, stream(EchoMsg), EchoMsg
   attr_reader :received_md
 
   def initialize(**kw)


### PR DESCRIPTION
When a user does not implement a server_streamer method in their server, grpc gem raises not an UNIMPLEMENTED error, but an Unknown error (like `2:ArgumentError: wrong number of arguments (given 1, expected 2) (GRPC::Unknown)`). It is caused by calling server_streamer method is called with a single argument in rpc_desc.rb.

https://github.com/grpc/grpc/blob/e0d9692fa30cf3a7a8410a722693d5d3d68fb0fd/src/ruby/lib/grpc/generic/rpc_desc.rb#L76

So I changed the signature of the default method which is used for raising an UNIMPLEMENTED error.

