### PR TITLE
Add traced information to stream op

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1390,6 +1390,7 @@ static void perform_stream_op_locked(void* stream_op,
   GRPC_STATS_INC_HTTP2_OP_BATCHES();
 
   s->context = op->payload->context;
+  s->traced = op->is_traced;
   if (grpc_http_trace.enabled()) {
     char* str = grpc_transport_stream_op_batch_string(op);
     gpr_log(GPR_INFO, "perform_stream_op_locked: %s; on_complete = %p", str,

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -642,10 +642,10 @@ struct grpc_chttp2_stream {
   /** Whether bytes stored in unprocessed_incoming_byte_stream is decompressed
    */
   bool unprocessed_incoming_frames_decompressed = false;
-  /** gRPC header bytes that are already decompressed */
-  size_t decompressed_header_bytes = 0;
   /** Whether the bytes needs to be traced using Fathom */
   bool traced = false;
+  /** gRPC header bytes that are already decompressed */
+  size_t decompressed_header_bytes = 0;
 };
 
 /** Transport writing call flow:

--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -129,7 +129,8 @@ struct grpc_transport_stream_op_batch {
         recv_initial_metadata(false),
         recv_message(false),
         recv_trailing_metadata(false),
-        cancel_stream(false) {}
+        cancel_stream(false),
+        is_traced(false) {}
 
   /** Should be scheduled when all of the non-recv operations in the batch
       are complete.
@@ -166,6 +167,9 @@ struct grpc_transport_stream_op_batch {
 
   /** Cancel this stream with the provided error */
   bool cancel_stream : 1;
+
+  /** Is this stream traced */
+  bool is_traced : 1;
 
   /***************************************************************************
    * remaining fields are initialized and used at the discretion of the


### PR DESCRIPTION
Add traced information to stream op.

The census filter will be able to set this flag for RPCs that should be traced with Fathom