### PR TITLE
Fix Python blocking interceptors facing RpcError

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
+Dropbox, Inc.
 Google Inc.
 WeWork Companies Inc.

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -232,8 +232,8 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
                     credentials=new_credentials,
                     wait_for_ready=new_wait_for_ready)
                 return _UnaryOutcome(response, call)
-            except grpc.RpcError:
-                raise
+            except grpc.RpcError as rpc_error:
+                return rpc_error
             except Exception as exception:  # pylint:disable=broad-except
                 return _FailureOutcome(exception, sys.exc_info()[2])
 
@@ -354,8 +354,8 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
                     credentials=new_credentials,
                     wait_for_ready=new_wait_for_ready)
                 return _UnaryOutcome(response, call)
-            except grpc.RpcError:
-                raise
+            except grpc.RpcError as rpc_error:
+                return rpc_error
             except Exception as exception:  # pylint:disable=broad-except
                 return _FailureOutcome(exception, sys.exc_info()[2])
 


### PR DESCRIPTION
`RpcError` should be returned from the continuation intact, not raised. (bug introduced in https://github.com/grpc/grpc/pull/14639)