### PR TITLE
Update the CLI doc with a tip for resolving protobuf compilation errors

### DIFF
--- a/doc/command_line_tool.md
+++ b/doc/command_line_tool.md
@@ -52,6 +52,8 @@ Mac systems with Homebrew:
 brew install gflags
 ```
 
+Additionally, if your system already has protobuf installed, you may need to run `make` with the flag `HAS_SYSTEM_PROTOBUF=false`.
+
 Once the prerequisites are satisfied, you can build the command line tool with
 the command:
 


### PR DESCRIPTION
Very small documentation change.

Seems like the issue has been resolved/addressed in a couple of threads:  
-https://github.com/grpc/grpc/issues/12405
-https://github.com/grpc/grpc/issues/8556

This tip will hopefully reduce installation friction for OSX users as it did for me.

I don't think I can add labels to this PR since I am not a contributor.