### PR TITLE
Address a few "deprecated" warnings on foundry

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh
+++ b/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh
@@ -15,8 +15,8 @@
 
 set -ex
 
-# A temporary solution to give Kokoro credentials. 
-# The file name 4321_grpc-testing-service needs to match auth_credential in 
+# A temporary solution to give Kokoro credentials.
+# The file name 4321_grpc-testing-service needs to match auth_credential in
 # the build config.
 mkdir -p ${KOKORO_KEYSTORE_DIR}
 cp ${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json ${KOKORO_KEYSTORE_DIR}/4321_grpc-testing-service
@@ -35,14 +35,15 @@ cd $(dirname $0)/../../..
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
 # to get "bazel" link for kokoro build, we need to generate
-# invocation UUID, set an env var for bazel to pick it up
-#  and upload "bazel_invocation_ids" file as artifact.
-export BAZEL_INTERNAL_INVOCATION_ID="$(uuidgen)"
-echo "${BAZEL_INTERNAL_INVOCATION_ID}" >"${KOKORO_ARTIFACTS_DIR}/bazel_invocation_ids"
+# invocation UUID, set a flag for bazel to use it
+# and upload "bazel_invocation_ids" file as artifact.
+BAZEL_INVOCATION_ID="$(uuidgen)"
+echo "${BAZEL_INVOCATION_ID}" >"${KOKORO_ARTIFACTS_DIR}/bazel_invocation_ids"
 
 bazel \
   --bazelrc=tools/remote_build/kokoro.bazelrc \
   test \
+  --invocation_id="${BAZEL_INVOCATION_ID}" \
   $@ \
   -- //test/... || FAILED="true"
 

--- a/tools/remote_build/kokoro.bazelrc
+++ b/tools/remote_build/kokoro.bazelrc
@@ -26,7 +26,6 @@ build --auth_credentials=/tmpfs/src/keystore/4321_grpc-testing-service
 build --auth_scope=https://www.googleapis.com/auth/cloud-source-tools
 
 build --bes_backend=buildeventservice.googleapis.com
-build --bes_best_effort=false
 build --bes_timeout=600s
 build --project_id=grpc-testing
 


### PR DESCRIPTION

```
WARNING: Option 'bes_best_effort' is deprecated: BES best effort upload has been removed. The flag has no more functionality attached to it and will be removed in a future release.
INFO: Streaming Build Event Protocol to buildeventservice.googleapis.com build_request_id: 43283a41-1f5c-4dba-ad66-088b0fa72cdc invocation_id: b5ce52b0-e5b3-4bfb-b49b-700f2a4d25ea
WARNING: BAZEL_INTERNAL_INVOCATION_ID is set. This will soon be deprecated in favor of --invocation_id. Please switch to using the flag.
```