### PR TITLE
C#: avoid unnecessary ifdefine in NUnitMain.cs

### DIFF
--- a/src/csharp/Grpc.Core.Tests/NUnitMain.cs
+++ b/src/csharp/Grpc.Core.Tests/NUnitMain.cs
@@ -34,11 +34,7 @@ namespace Grpc.Core.Tests
         {
             // Make logger immune to NUnit capturing stdout and stderr to workaround https://github.com/nunit/nunit/issues/1406.
             GrpcEnvironment.SetLogger(new ConsoleLogger());
-#if NETCOREAPP1_1 || NETCOREAPP2_1
-            return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
-#else
-            return new AutoRun().Execute(args);
-#endif
+            return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args);
         }
     }
 }

--- a/src/csharp/Grpc.Examples.Tests/NUnitMain.cs
+++ b/src/csharp/Grpc.Examples.Tests/NUnitMain.cs
@@ -34,11 +34,7 @@ namespace Grpc.Examples.Tests
         {
             // Make logger immune to NUnit capturing stdout and stderr to workaround https://github.com/nunit/nunit/issues/1406.
             GrpcEnvironment.SetLogger(new ConsoleLogger());
-#if NETCOREAPP1_1 || NETCOREAPP2_1
-            return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
-#else
-            return new AutoRun().Execute(args);
-#endif
+            return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args);
         }
     }
 }

--- a/src/csharp/Grpc.HealthCheck.Tests/NUnitMain.cs
+++ b/src/csharp/Grpc.HealthCheck.Tests/NUnitMain.cs
@@ -34,11 +34,7 @@ namespace Grpc.HealthCheck.Tests
         {
             // Make logger immune to NUnit capturing stdout and stderr to workaround https://github.com/nunit/nunit/issues/1406.
             GrpcEnvironment.SetLogger(new ConsoleLogger());
-#if NETCOREAPP1_1 || NETCOREAPP2_1
-            return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
-#else
-            return new AutoRun().Execute(args);
-#endif
+            return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args);
         }
     }
 }

--- a/src/csharp/Grpc.IntegrationTesting/NUnitMain.cs
+++ b/src/csharp/Grpc.IntegrationTesting/NUnitMain.cs
@@ -34,11 +34,7 @@ namespace Grpc.IntegrationTesting
         {
             // Make logger immune to NUnit capturing stdout and stderr to workaround https://github.com/nunit/nunit/issues/1406.
             GrpcEnvironment.SetLogger(new ConsoleLogger());
-#if NETCOREAPP1_1 || NETCOREAPP2_1
-            return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
-#else
-            return new AutoRun().Execute(args);
-#endif
+            return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args);
         }
     }
 }

--- a/src/csharp/Grpc.Reflection.Tests/NUnitMain.cs
+++ b/src/csharp/Grpc.Reflection.Tests/NUnitMain.cs
@@ -34,11 +34,7 @@ namespace Grpc.Reflection.Tests
         {
             // Make logger immune to NUnit capturing stdout and stderr to workaround https://github.com/nunit/nunit/issues/1406.
             GrpcEnvironment.SetLogger(new ConsoleLogger());
-#if NETCOREAPP1_1 || NETCOREAPP2_1
-            return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args, new ExtendedTextWrapper(Console.Out), Console.In);
-#else
-            return new AutoRun().Execute(args);
-#endif
+            return new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args);
         }
     }
 }

--- a/src/csharp/Grpc.Tools.Tests/NUnitMain.cs
+++ b/src/csharp/Grpc.Tools.Tests/NUnitMain.cs
@@ -24,10 +24,6 @@ namespace Grpc.Tools.Tests
     static class NUnitMain
     {
         public static int Main(string[] args) =>
-#if NETCOREAPP1_1 || NETCOREAPP2_1
             new AutoRun(typeof(NUnitMain).GetTypeInfo().Assembly).Execute(args);
-#else
-            new AutoRun().Execute(args);
-#endif
     };
 }


### PR DESCRIPTION
Avoid boilerplate for easier maintenance.