### PR TITLE
Rich status transport implementation 

### DIFF
--- a/doc/python/sphinx/glossary.rst
+++ b/doc/python/sphinx/glossary.rst
@@ -14,3 +14,12 @@ Glossary
 
   metadata
     A sequence of metadatum.
+
+  status code
+    The gRPC status code defined in https://github.com/grpc/grpc/blob/master/doc/statuscodes.md.
+
+  status message
+    A text (unicode allowed) field that indicates the status of the RPC call and it is intended to be read by the developers.
+
+  status details
+    A encoded *google.rpc.status.Status* proto message that serves as rich status error details about the RPC Call.

--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -13,3 +13,4 @@ urllib3==1.22
 chardet==3.0.4
 certifi==2017.4.17
 idna==2.7
+googleapis-common-protos==1.5.5

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -354,7 +354,7 @@ class Call(six.with_metaclass(abc.ABCMeta, RpcContext)):
 
     @abc.abstractmethod
     def code(self):
-        """Accesses the status code sent by the server.
+        """Accesses the :term:`status code` sent by the server.
 
         This method blocks until the value is available.
 
@@ -365,12 +365,26 @@ class Call(six.with_metaclass(abc.ABCMeta, RpcContext)):
 
     @abc.abstractmethod
     def details(self):
-        """Accesses the details sent by the server.
+        """Accesses the :term:`status message` sent by the server.
 
         This method blocks until the value is available.
 
         Returns:
-          The details string of the RPC.
+          The status message string of the RPC.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def status(self):
+        """Accesses the status of the RPC. The status includes :term:`status code`,
+        :term:`status message`, and :term:`status details`.
+
+        This method blocks until the value is available.
+
+        This is an EXPERIMENTAL API.
+
+        Returns:
+          An instance of *namedtuple('Status', ['code', 'message', 'details'])*
         """
         raise NotImplementedError()
 
@@ -666,7 +680,7 @@ class UnaryUnaryMultiCallable(six.with_metaclass(abc.ABCMeta)):
         Raises:
           RpcError: Indicating that the RPC terminated with non-OK status. The
             raised RpcError will also be a Call for the RPC affording the RPC's
-            metadata, status code, and details.
+            metadata, status code, message and details.
         """
         raise NotImplementedError()
 
@@ -695,7 +709,7 @@ class UnaryUnaryMultiCallable(six.with_metaclass(abc.ABCMeta)):
         Raises:
           RpcError: Indicating that the RPC terminated with non-OK status. The
             raised RpcError will also be a Call for the RPC affording the RPC's
-            metadata, status code, and details.
+            metadata, status code, message and details.
         """
         raise NotImplementedError()
 
@@ -818,7 +832,7 @@ class StreamUnaryMultiCallable(six.with_metaclass(abc.ABCMeta)):
         Raises:
           RpcError: Indicating that the RPC terminated with non-OK status. The
             raised RpcError will also be a Call for the RPC affording the RPC's
-            metadata, status code, and details.
+            metadata, status code, message and details.
         """
         raise NotImplementedError()
 
@@ -1109,8 +1123,8 @@ class ServicerContext(six.with_metaclass(abc.ABCMeta, RpcContext)):
         Args:
           code: A StatusCode object to be sent to the client.
             It must not be StatusCode.OK.
-          details: An ASCII-encodable string to be sent to the client upon
-            termination of the RPC.
+          details: A :term:`status message` string to be sent to the client
+            upon termination of the RPC.
 
         Raises:
           Exception: An exception is always raised to signal the abortion the
@@ -1120,7 +1134,7 @@ class ServicerContext(six.with_metaclass(abc.ABCMeta, RpcContext)):
 
     @abc.abstractmethod
     def set_code(self, code):
-        """Sets the value to be used as status code upon RPC completion.
+        """Sets the value to be used as :term:`status code` upon RPC completion.
 
         This method need not be called by method implementations if they wish
         the gRPC runtime to determine the status code of the RPC.
@@ -1132,14 +1146,34 @@ class ServicerContext(six.with_metaclass(abc.ABCMeta, RpcContext)):
 
     @abc.abstractmethod
     def set_details(self, details):
-        """Sets the value to be used as detail string upon RPC completion.
+        """Sets the value to be used as :term:`status message` upon RPC
+        completion.
 
         This method need not be called by method implementations if they have
         no details to transmit.
 
         Args:
-          details: An ASCII-encodable string to be sent to the client upon
-            termination of the RPC.
+          details: A :term:`status message` string to be sent to the client
+            upon termination of the RPC.
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
+    def set_status(self, code, message, details=None):
+        """Sets all status-related values to be used upon RPC completionself.
+
+        This method need not be called by method implementations if they wish
+        the gRPC runtime to determine the status code of the RPC or have no
+        message to transmit.
+
+        This is an EXPERIMENTAL API.
+
+        Args:
+          code: A StatusCode object to be sent to the client.
+          message: A :term:`status message` string to be sent to the client
+            upon termination of the RPC.
+          details: A binary :term:`status details` string to be sent to the
+            client upon termination of the RPC.
         """
         raise NotImplementedError()
 

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -99,6 +99,10 @@ class _FailureOutcome(grpc.RpcError, grpc.Future, grpc.Call):
     def details(self):
         return 'Exception raised while intercepting the RPC'
 
+    def status(self):
+        return (grpc.StatusCode.INTERNAL,
+                'Exception raised while intercepting the RPC', None)
+
     def cancel(self):
         return False
 
@@ -156,6 +160,9 @@ class _UnaryOutcome(grpc.Call, grpc.Future):
 
     def details(self):
         return self._call.details()
+
+    def status(self):
+        return self._call.status()
 
     def is_active(self):
         return self._call.is_active()

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -50,6 +50,8 @@ _EMPTY_FLAGS = 0
 
 _UNEXPECTED_EXIT_SERVER_GRACE = 1.0
 
+_GRPC_DETAILS_METADATA_KEY = 'grpc-status-details-bin'
+
 
 def _serialized_request(request_event):
     return request_event.batch_operations[0].message()
@@ -298,6 +300,16 @@ class _Context(grpc.ServicerContext):
     def set_details(self, details):
         with self._state.condition:
             self._state.details = _common.encode(details)
+
+    def set_status(self, code, message, details=None):
+        with self._state.condition:
+            self._state.code = code
+            self._state.details = _common.encode(message)
+            if details is not None:
+                trailing_metadata = ((_GRPC_DETAILS_METADATA_KEY, details),)
+                if self._state.trailing_metadata is not None:
+                    trailing_metadata += self._state.trailing_metadata
+                self._state.trailing_metadata = trailing_metadata
 
 
 class _RequestIterator(object):

--- a/src/python/grpcio_status/.gitignore
+++ b/src/python/grpcio_status/.gitignore
@@ -1,0 +1,3 @@
+build/
+grpcio_status.egg-info/
+dist/

--- a/src/python/grpcio_status/MANIFEST.in
+++ b/src/python/grpcio_status/MANIFEST.in
@@ -1,0 +1,3 @@
+include grpc_version.py
+recursive-include grpc_status *.py
+global-exclude *.pyc

--- a/src/python/grpcio_status/README.rst
+++ b/src/python/grpcio_status/README.rst
@@ -1,0 +1,9 @@
+gRPC Python Status Proto
+===========================
+
+Reference package for GRPC Python status proto mapping.
+
+Dependencies
+------------
+
+Depends on the `grpcio` package, available from PyPI via `pip install grpcio`.

--- a/src/python/grpcio_status/grpc_status/BUILD.bazel
+++ b/src/python/grpcio_status/grpc_status/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "grpc_status",
+    srcs = ["rpc_status.py",],
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        requirement('protobuf'),
+        requirement('googleapis-common-protos'),
+    ],
+    imports=["../",],
+)

--- a/src/python/grpcio_status/grpc_status/__init__.py
+++ b/src/python/grpcio_status/grpc_status/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2018 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/python/grpcio_status/grpc_status/rpc_status.py
+++ b/src/python/grpcio_status/grpc_status/rpc_status.py
@@ -1,0 +1,78 @@
+# Copyright 2018 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reference implementation for status mapping in gRPC Python."""
+
+import grpc
+
+# NOTE(https://github.com/bazelbuild/bazel/issues/6844)
+# Due to Bazel issue, the namespace packages won't resolve correctly.
+# Adding this unused-import as a workaround to avoid module-not-found error
+# under Bazel builds.
+import google.protobuf  # pylint: disable=unused-import
+from google.rpc import status_pb2
+
+_CODE_TO_GRPC_CODE_MAPPING = dict([(x.value[0], x) for x in grpc.StatusCode])
+
+_GRPC_DETAILS_METADATA_KEY = 'grpc-status-details-bin'
+
+
+def _code_to_grpc_status_code(code):
+    try:
+        return _CODE_TO_GRPC_CODE_MAPPING[code]
+    except KeyError:
+        raise ValueError('Invalid status code %s' % code)
+
+
+def from_rpc_error(rpc_error):
+    """Returns a google.rpc.status.Status message corresponding to a given grpc.RpcError.
+
+    Args:
+      call: A grpc.RpcError instance raised by an RPC.
+
+    Returns:
+      A google.rpc.status.Status message representing the status of the RPC.
+
+    Raises:
+      ValueError: If the status code, status message is inconsistent with the rich status
+        inside of status details.
+    """
+    code, message, details = rpc_error.status()
+    if details is None:
+        return None
+    rich_status = status_pb2.Status.FromString(details)
+    if code.value[0] != rich_status.code:
+        raise ValueError(
+            'Code in status details (%s) doesn\'t match status code (%s)' %
+            (_code_to_grpc_status_code(rich_status.code), code))
+    if message != rich_status.message:
+        raise ValueError(
+            'Message in status details (%s) doesn\'t match status message (%s)'
+            % (rich_status.message, message))
+    return rich_status
+
+
+def convert(status):
+    """Convert a google.rpc.status.Status message to a tuple of status code, status message,
+    and status details.
+
+    Args:
+      status: a google.rpc.status.Status message representing the non-OK status
+        to terminate the RPC with and communicate it to the client.
+
+    Returns:
+      A 3-tuple where the first entry is the status code, the second entry is the
+        status message, and the third entry is the status details.
+    """
+    return _code_to_grpc_status_code(
+        status.code), status.message, status.SerializeToString()

--- a/src/python/grpcio_status/grpc_version.py
+++ b/src/python/grpcio_status/grpc_version.py
@@ -1,0 +1,17 @@
+# Copyright 2018 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_status/grpc_version.py.template`!!!
+
+VERSION = '1.18.0.dev0'

--- a/src/python/grpcio_status/setup.py
+++ b/src/python/grpcio_status/setup.py
@@ -1,0 +1,86 @@
+# Copyright 2018 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Setup module for the GRPC Python package's status mapping."""
+
+import os
+
+import setuptools
+
+# Ensure we're in the proper directory whether or not we're being used by pip.
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+# Break import-style to ensure we can actually find our local modules.
+import grpc_version
+
+
+class _NoOpCommand(setuptools.Command):
+    """No-op command."""
+
+    description = ''
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        pass
+
+
+CLASSIFIERS = [
+    'Development Status :: 5 - Production/Stable',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 2',
+    'Programming Language :: Python :: 2.7',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'License :: OSI Approved :: Apache Software License',
+]
+
+PACKAGE_DIRECTORIES = {
+    '': '.',
+}
+
+INSTALL_REQUIRES = (
+    'protobuf>=3.6.0',
+    'grpcio>={version}'.format(version=grpc_version.VERSION),
+    'googleapis-common-protos>=1.5.5',
+)
+
+SETUP_REQUIRES = ()
+COMMAND_CLASS = {
+    # wire up commands to no-op not to break the external dependencies
+    'preprocess': _NoOpCommand,
+    'build_package_protos': _NoOpCommand,
+}
+
+setuptools.setup(
+    name='grpcio-status',
+    version=grpc_version.VERSION,
+    description='Status proto mapping for gRPC',
+    author='The gRPC Authors',
+    author_email='grpc-io@googlegroups.com',
+    url='https://grpc.io',
+    license='Apache License 2.0',
+    classifiers=CLASSIFIERS,
+    package_dir=PACKAGE_DIRECTORIES,
+    packages=setuptools.find_packages('.'),
+    install_requires=INSTALL_REQUIRES,
+    setup_requires=SETUP_REQUIRES,
+    cmdclass=COMMAND_CLASS)

--- a/src/python/grpcio_testing/grpc_testing/_server/_rpc.py
+++ b/src/python/grpcio_testing/grpc_testing/_server/_rpc.py
@@ -21,6 +21,8 @@ from grpc_testing import _common
 logging.basicConfig()
 _LOGGER = logging.getLogger(__name__)
 
+_GRPC_DETAILS_METADATA_KEY = 'grpc-status-details-bin'
+
 
 class Rpc(object):
 
@@ -153,3 +155,12 @@ class Rpc(object):
     def set_details(self, details):
         with self._condition:
             self._pending_details = details
+
+    def set_status(self, code, message, details=None):
+        with self._condition:
+            self._pending_code = code
+            self._pending_details = message
+            trailing_metadata = ((_GRPC_DETAILS_METADATA_KEY, details),)
+            if self._pending_trailing_metadata is not None:
+                trailing_metadata += self._pending_trailing_metadata
+            self._pending_trailing_metadata = trailing_metadata

--- a/src/python/grpcio_testing/grpc_testing/_server/_servicer_context.py
+++ b/src/python/grpcio_testing/grpc_testing/_server/_servicer_context.py
@@ -75,3 +75,6 @@ class ServicerContext(grpc.ServicerContext):
 
     def set_details(self, details):
         self._rpc.set_details(details)
+
+    def set_status(self, code, message, details=None):
+        self._rpc.set_status(code, message, details)

--- a/src/python/grpcio_tests/setup.py
+++ b/src/python/grpcio_tests/setup.py
@@ -40,6 +40,7 @@ INSTALL_REQUIRES = (
     'coverage>=4.0', 'enum34>=1.0.4',
     'grpcio>={version}'.format(version=grpc_version.VERSION),
     'grpcio-channelz>={version}'.format(version=grpc_version.VERSION),
+    'grpcio-status>={version}'.format(version=grpc_version.VERSION),
     'grpcio-tools>={version}'.format(version=grpc_version.VERSION),
     'grpcio-health-checking>={version}'.format(version=grpc_version.VERSION),
     'oauth2client>=1.4.7', 'protobuf>=3.6.0', 'six>=1.10', 'google-auth>=1.0.0',

--- a/src/python/grpcio_tests/tests/status/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/status/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_test(
+    name = "grpc_status_test",
+    srcs = ["_grpc_status_test.py"],
+    main = "_grpc_status_test.py",
+    size = "small",
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/python/grpcio_status/grpc_status:grpc_status",
+        "//src/python/grpcio_tests/tests/unit:test_common",
+        "//src/python/grpcio_tests/tests/unit/framework/common:common",
+        requirement('protobuf'),
+        requirement('googleapis-common-protos'),
+    ],
+    imports = ["../../",],
+)

--- a/src/python/grpcio_tests/tests/status/__init__.py
+++ b/src/python/grpcio_tests/tests/status/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2018 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/python/grpcio_tests/tests/status/_grpc_status_test.py
+++ b/src/python/grpcio_tests/tests/status/_grpc_status_test.py
@@ -1,0 +1,192 @@
+# Copyright 2018 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests of grpc_status."""
+
+import unittest
+
+import logging
+import traceback
+
+import grpc
+from grpc_status import rpc_status
+
+from tests.unit import test_common
+
+from google.protobuf import any_pb2
+from google.rpc import code_pb2, status_pb2, error_details_pb2
+
+_STATUS_OK = '/test/StatusOK'
+_STATUS_NOT_OK = '/test/StatusNotOk'
+_ERROR_DETAILS = '/test/ErrorDetails'
+_STATUS_REWRITE = '/test/StatusRewrite'
+_STATUS_REWRITE_REVERSE = '/test/StatusRewriteReverse'
+_INVALID_CODE = '/test/InvalidCode'
+
+_REQUEST = b'\x00\x00\x00'
+_RESPONSE = b'\x01\x01\x01'
+
+
+def _ok_unary_unary(request, servicer_context):
+    return _RESPONSE
+
+
+def _not_ok_unary_unary(request, servicer_context):
+    servicer_context.set_status(
+        code=grpc.StatusCode.PERMISSION_DENIED, message='Intended failure')
+
+
+def _error_details_unary_unary(request, servicer_context):
+    details = any_pb2.Any()
+    details.Pack(
+        error_details_pb2.DebugInfo(
+            stack_entries=traceback.format_stack(),
+            detail='Intensionally invoked'))
+    rich_status = status_pb2.Status(
+        code=code_pb2.Code.Value('INTERNAL'),
+        message='It shall be aborted',
+        details=[details],
+    )
+    servicer_context.set_status(*rpc_status.convert(rich_status))
+
+
+def _status_rewrite_unary_unary(request, servicer_context):
+    servicer_context.set_code(grpc.StatusCode.NOT_FOUND)
+
+    rich_status = status_pb2.Status(
+        code=code_pb2.Code.Value('INTERNAL'),
+        message='It shall be aborted',
+    )
+    servicer_context.set_status(*rpc_status.convert(rich_status))
+
+
+def _status_rewrite_reverse_unary_unary(request, servicer_context):
+    rich_status = status_pb2.Status(
+        code=code_pb2.Code.Value('INTERNAL'),
+        message='It shall be aborted',
+    )
+    servicer_context.set_status(*rpc_status.convert(rich_status))
+
+    servicer_context.set_code(grpc.StatusCode.NOT_FOUND)
+    servicer_context.set_details('Another message')
+
+
+def _invalid_code_unary_unary(request, servicer_context):
+    rich_status = status_pb2.Status(
+        code=42,
+        message='Invalid code',
+    )
+    servicer_context.set_status(*rpc_status.convert(rich_status))
+
+
+class _GenericHandler(grpc.GenericRpcHandler):
+
+    def service(self, handler_call_details):
+        if handler_call_details.method == _STATUS_OK:
+            return grpc.unary_unary_rpc_method_handler(_ok_unary_unary)
+        elif handler_call_details.method == _STATUS_NOT_OK:
+            return grpc.unary_unary_rpc_method_handler(_not_ok_unary_unary)
+        elif handler_call_details.method == _ERROR_DETAILS:
+            return grpc.unary_unary_rpc_method_handler(
+                _error_details_unary_unary)
+        elif handler_call_details.method == _STATUS_REWRITE:
+            return grpc.unary_unary_rpc_method_handler(
+                _status_rewrite_unary_unary)
+        elif handler_call_details.method == _STATUS_REWRITE_REVERSE:
+            return grpc.unary_unary_rpc_method_handler(
+                _status_rewrite_reverse_unary_unary)
+        elif handler_call_details.method == _INVALID_CODE:
+            return grpc.unary_unary_rpc_method_handler(
+                _invalid_code_unary_unary)
+        else:
+            return None
+
+
+class StatusTest(unittest.TestCase):
+
+    def setUp(self):
+        self._server = test_common.test_server()
+        self._server.add_generic_rpc_handlers((_GenericHandler(),))
+        port = self._server.add_insecure_port('[::]:0')
+        self._server.start()
+
+        self._channel = grpc.insecure_channel('localhost:%d' % port)
+
+    def tearDown(self):
+        self._server.stop(None)
+        self._channel.close()
+
+    def test_status_ok(self):
+        try:
+            self._channel.unary_unary(_STATUS_OK)(_REQUEST)
+        except grpc.RpcError as rpc_error:
+            self.fail(rpc_error)
+
+    def test_status_not_ok(self):
+        with self.assertRaises(grpc.RpcError) as exception_context:
+            self._channel.unary_unary(_STATUS_NOT_OK).with_call(_REQUEST)
+        rpc_error = exception_context.exception
+
+        self.assertEqual(rpc_error.status().code,
+                         grpc.StatusCode.PERMISSION_DENIED)
+        status = rpc_status.from_rpc_error(rpc_error)
+        self.assertIs(status, None)
+
+    def test_error_details(self):
+        with self.assertRaises(grpc.RpcError) as exception_context:
+            self._channel.unary_unary(_ERROR_DETAILS).with_call(_REQUEST)
+        rpc_error = exception_context.exception
+
+        status = rpc_status.from_rpc_error(rpc_error)
+        self.assertEqual(rpc_error.status().code, grpc.StatusCode.INTERNAL)
+        self.assertEqual(status.code, code_pb2.Code.Value('INTERNAL'))
+
+        self.assertEqual(status.details[0].Is(
+            error_details_pb2.DebugInfo.DESCRIPTOR), True)
+        info = error_details_pb2.DebugInfo()
+        status.details[0].Unpack(info)
+        self.assertIn('_error_details_unary_unary', info.stack_entries[-1])
+
+    def test_status_rewrite(self):
+        """This tests a behavior (flaw) of current API design that code and
+        message can be set multiple times. Since it is a longlived behavior,
+        this unit test will serve as a regression test for it."""
+        with self.assertRaises(grpc.RpcError) as exception_context:
+            self._channel.unary_unary(_STATUS_REWRITE).with_call(_REQUEST)
+        rpc_error = exception_context.exception
+
+        self.assertEqual(rpc_error.status().code, grpc.StatusCode.INTERNAL)
+        status = rpc_status.from_rpc_error(rpc_error)
+        self.assertEqual(status.code, rpc_error.status().code.value[0])
+        self.assertEqual(status.message, rpc_error.status().message)
+
+    def test_code_message_validation(self):
+        with self.assertRaises(grpc.RpcError) as exception_context:
+            self._channel.unary_unary(_STATUS_REWRITE_REVERSE).with_call(
+                _REQUEST)
+        rpc_error = exception_context.exception
+        self.assertEqual(rpc_error.status().code, grpc.StatusCode.NOT_FOUND)
+
+        self.assertRaises(ValueError, rpc_status.from_rpc_error, rpc_error)
+
+    def test_invalid_code(self):
+        with self.assertRaises(grpc.RpcError) as exception_context:
+            self._channel.unary_unary(_INVALID_CODE).with_call(_REQUEST)
+        rpc_error = exception_context.exception
+        self.assertEqual(rpc_error.status().code, grpc.StatusCode.UNKNOWN)
+        self.assertIn('Invalid status code', rpc_error.status().message)
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/tests.json
+++ b/src/python/grpcio_tests/tests/tests.json
@@ -15,6 +15,7 @@
   "protoc_plugin._split_definitions_test.SplitProtoSingleProtocExecutionProtocStyleTest",
   "protoc_plugin.beta_python_plugin_test.PythonPluginTest",
   "reflection._reflection_servicer_test.ReflectionServicerTest",
+  "status._grpc_status_test.StatusTest",
   "testing._client_test.ClientTest",
   "testing._server_test.FirstServiceServicerTest",
   "testing._time_test.StrictFakeTimeTest",

--- a/templates/src/python/grpcio_status/grpc_version.py.template
+++ b/templates/src/python/grpcio_status/grpc_version.py.template
@@ -1,0 +1,19 @@
+%YAML 1.2
+--- |
+  # Copyright 2018 The gRPC Authors
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  # AUTO-GENERATED FROM `$REPO_ROOT/templates/src/python/grpcio_status/grpc_version.py.template`!!!
+
+  VERSION = '${settings.python_version.pep440()}'

--- a/tools/distrib/pylint_code.sh
+++ b/tools/distrib/pylint_code.sh
@@ -24,6 +24,7 @@ DIRS=(
     'src/python/grpcio_health_checking/grpc_health'
     'src/python/grpcio_reflection/grpc_reflection'
     'src/python/grpcio_testing/grpc_testing'
+    'src/python/grpcio_status/grpc_status'
 )
 
 TEST_DIRS=(

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -122,6 +122,11 @@ then
   ${SETARCH_CMD} "${PYTHON}" src/python/grpcio_reflection/setup.py \
       preprocess build_package_protos sdist
   cp -r src/python/grpcio_reflection/dist/* "$ARTIFACT_DIR"
+
+  # Build grpcio_status source distribution
+  ${SETARCH_CMD} "${PYTHON}" src/python/grpcio_status/setup.py \
+      preprocess build_package_protos sdist
+  cp -r src/python/grpcio_status/dist/* "$ARTIFACT_DIR"
 fi
 
 cp -r dist/* "$ARTIFACT_DIR"

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -204,12 +204,18 @@ $VENV_PYTHON "$ROOT/src/python/grpcio_reflection/setup.py" preprocess
 $VENV_PYTHON "$ROOT/src/python/grpcio_reflection/setup.py" build_package_protos
 pip_install_dir "$ROOT/src/python/grpcio_reflection"
 
+# Build/install status proto mapping
+$VENV_PYTHON "$ROOT/src/python/grpcio_status/setup.py" preprocess
+$VENV_PYTHON "$ROOT/src/python/grpcio_status/setup.py" build_package_protos
+pip_install_dir "$ROOT/src/python/grpcio_status"
+
 # Install testing
 pip_install_dir "$ROOT/src/python/grpcio_testing"
 
 # Build/install tests
 $VENV_PYTHON -m pip install coverage==4.4 oauth2client==4.1.0 \
-                            google-auth==1.0.0 requests==2.14.2
+                            google-auth==1.0.0 requests==2.14.2 \
+                            googleapis-common-protos==1.5.5
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" preprocess
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" build_package_protos
 pip_install_dir "$ROOT/src/python/grpcio_tests"


### PR DESCRIPTION
### Background
gRPC spec defined two trailing data to indicate the status of a RPC call `Status` and `Status-Message` ([Spec](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses)). But status code and a text message themselves are insufficient to express more complicate situation like the RPC call failed because of quota check of certain policy, or the stack trace from the crashed server, or obtain retry delay from the server (see [error details](https://github.com/googleapis/api-common-protos/blob/master/google/rpc/error_details.proto)).

### Objective
So, gRPC needs a mechanism to transport those complex status. It is implemented in C++, Java, Golang, and now Python.

### Design
It is quite straight forward, we provide two API:
* A server API to pack the rich status proto.
* A client API to unpack the rich status proto.

The transportation is done by setting/getting a trailing metadata entry named `grpc-status-details-bin`. Rich status message is encoded by ProtoBuf and transmit as binary.

### Implementation
This PR

### Related Issue
Addresses: https://github.com/grpc/grpc/issues/16366