### PR TITLE
credentials: call grpc_init/grpc_shutdown when created/destroyed

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -61,6 +61,7 @@ cdef int _get_metadata(
 
 cdef void _destroy(void *state) with gil:
   cpython.Py_DECREF(<object>state)
+  grpc_shutdown()
 
 
 cdef class MetadataPluginCallCredentials(CallCredentials):
@@ -76,6 +77,7 @@ cdef class MetadataPluginCallCredentials(CallCredentials):
     c_metadata_plugin.state = <void *>self._metadata_plugin
     c_metadata_plugin.type = self._name
     cpython.Py_INCREF(self._metadata_plugin)
+    fork_handlers_and_grpc_init()
     return grpc_metadata_credentials_create_from_plugin(c_metadata_plugin, NULL)
 
 


### PR DESCRIPTION
This addresses https://github.com/grpc/grpc/issues/17001. Prior to PR https://github.com/grpc/grpc/pull/13603, our credentials cython objects used `grpc_initi()` and `grpc_shutdown()` on creation and destruction. Credentials objects are now initialized differently, but the missing calls to `grpc_init()` and `grpc_shutdown()` are still required.

Without this change, we can deadlock when a call to `grpc.Channel#close()` triggers `grpc_shutdown()` to block and wait for all timer threads to finish: one of these timer threads may end up unreffing the subchannel and triggering `grpc_call_credentials_unref`, which will jump back into Cython and hang when it tries to reacquire the GIL.

The contract with `grpc_init()`/`grpc_shutdown()` is that, when the last matching call to `grpc_shutdown()` is made, all application-owned gRPC objects must have been destroyed. See the [`MetadataCredentialsPluginWrapper`](https://github.com/grpc/grpc/blob/01792f00a33acab784233162c032a5fb0b5696ad/src/cpp/client/secure_credentials.h#L64) in C++,
which extends the GrpcLibraryCodegen class to ensure that `grpc_init()` and `grpc_shutdown()` are called appropriately.

This feels brittle and was far too hard to reason about to make sure this was the root cause of the bug in https://github.com/grpc/grpc/issues/17001. I would like to come up with a higher-level abstraction to make these calls to `grpc_init()`/`grpc_shutdown()` easier to reason about, and testable, but this fixes the immediate bug.