### PR TITLE
Temporarily disable a test that is consistently failing

### DIFF
--- a/test/cpp/end2end/client_callback_end2end_test.cc
+++ b/test/cpp/end2end/client_callback_end2end_test.cc
@@ -183,6 +183,10 @@ class ClientCallbackEnd2endTest
   }
 
   void SendGenericEchoAsBidi(int num_rpcs) {
+    // TODO(vjpai): re-enable this test once our RBE-MSAN issues are sorted
+    if (GetParam().callback_server) {
+      return;
+    }
     const grpc::string kMethodName("/grpc.testing.EchoTestService/Echo");
     grpc::string test_string("");
     for (int i = 0; i < num_rpcs; i++) {


### PR DESCRIPTION
Seen repeatedly in #17375 . The better solution would be to fix the bug, but our development access to the RBE MSAN toolchain is currently broken, so I want to temporarily disable this test until that underlying issue is sorted out. I will file a bug to re-enable this test.

