### PR TITLE
fix macos PR jobs on high-sierra workers

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -35,7 +35,7 @@ export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db3
 if [ -n "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
   set +x
   brew update
-  brew install jq
+  brew install jq || brew upgrade jq
   ghprbTargetBranch=$(curl -s https://api.github.com/repos/grpc/grpc/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER | jq -r .base.ref)
   export RUN_TESTS_FLAGS="$RUN_TESTS_FLAGS --filter_pr_tests --base_branch origin/$ghprbTargetBranch"
 


### PR DESCRIPTION
Looks like macos high sierra workers already have `jq` installed, so PR jobs are failing with:
```
Error: jq 1.5_3 is already installed
To upgrade to 1.6, run `brew upgrade jq`
```