### PR TITLE
better testing of SNI for C-based languages

### DIFF
--- a/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
@@ -45,7 +45,7 @@ namespace Grpc.IntegrationTesting
             [Option("server_host", Default = "localhost")]
             public string ServerHost { get; set; }
 
-            [Option("server_host_override", Default = TestCredentials.DefaultHostOverride)]
+            [Option("server_host_override")]
             public string ServerHostOverride { get; set; }
 
             [Option("server_port", Required = true)]

--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -530,7 +530,7 @@ function _makeStub($args)
         throw new Exception('Missing argument: --test_case is required');
     }
 
-    if ($args['server_port'] === 443) {
+    if ($args['server_port'] === '443') {
         $server_address = $args['server_host'];
     } else {
         $server_address = $args['server_host'].':'.$args['server_port'];

--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -538,7 +538,7 @@ function _makeStub($args)
 
     $test_case = $args['test_case'];
 
-    $host_override = 'foo.test.google.fr';
+    $host_override = '';
     if (array_key_exists('server_host_override', $args)) {
         $host_override = $args['server_host_override'];
     }
@@ -565,7 +565,9 @@ function _makeStub($args)
             $ssl_credentials = Grpc\ChannelCredentials::createSsl();
         }
         $opts['credentials'] = $ssl_credentials;
-        $opts['grpc.ssl_target_name_override'] = $host_override;
+        if (!empty($host_override)) {
+            $opts['grpc.ssl_target_name_override'] = $host_override;
+        }
     } else {
         $opts['credentials'] = Grpc\ChannelCredentials::createInsecure();
     }

--- a/src/python/grpcio_tests/tests/interop/client.py
+++ b/src/python/grpcio_tests/tests/interop/client.py
@@ -54,7 +54,6 @@ def _args():
         help='replace platform root CAs with ca.pem')
     parser.add_argument(
         '--server_host_override',
-        default="foo.test.google.fr",
         type=str,
         help='the server host to which to claim to connect')
     parser.add_argument(
@@ -100,10 +99,13 @@ def _stub(args):
             channel_credentials = grpc.composite_channel_credentials(
                 channel_credentials, call_credentials)
 
-        channel = grpc.secure_channel(target, channel_credentials, ((
-            'grpc.ssl_target_name_override',
-            args.server_host_override,
-        ),))
+        channel_opts = None
+        if args.server_host_override:
+            channel_opts = ((
+                'grpc.ssl_target_name_override',
+                args.server_host_override,
+            ),)
+        channel = grpc.secure_channel(target, channel_credentials, channel_opts)
     else:
         channel = grpc.insecure_channel(target)
     if args.test_case == "unimplemented_service":

--- a/src/python/grpcio_tests/tests/stress/client.py
+++ b/src/python/grpcio_tests/tests/stress/client.py
@@ -71,7 +71,6 @@ def _args():
         '--use_tls', help='Whether to use TLS', default=False, type=bool)
     parser.add_argument(
         '--server_host_override',
-        default="foo.test.google.fr",
         help='the server host to which to claim to connect',
         type=str)
     return parser.parse_args()

--- a/src/ruby/pb/test/client.rb
+++ b/src/ruby/pb/test/client.rb
@@ -111,10 +111,13 @@ def create_stub(opts)
   if opts.secure
     creds = ssl_creds(opts.use_test_ca)
     stub_opts = {
-      channel_args: {
-        GRPC::Core::Channel::SSL_TARGET => opts.server_host_override
-      }
+      channel_args: {}
     }
+    unless opts.server_host_override.empty?
+      stub_opts[:channel_args].merge!({
+          GRPC::Core::Channel::SSL_TARGET => opts.server_host_override
+      })
+    end
 
     # Add service account creds if specified
     wants_creds = %w(all compute_engine_creds service_account_creds)
@@ -603,7 +606,7 @@ class NamedTests
     if not op.metadata.has_key?(initial_metadata_key)
       fail AssertionError, "Expected initial metadata. None received"
     elsif op.metadata[initial_metadata_key] != metadata[initial_metadata_key]
-      fail AssertionError, 
+      fail AssertionError,
              "Expected initial metadata: #{metadata[initial_metadata_key]}. "\
              "Received: #{op.metadata[initial_metadata_key]}"
     end
@@ -611,7 +614,7 @@ class NamedTests
       fail AssertionError, "Expected trailing metadata. None received"
     elsif op.trailing_metadata[trailing_metadata_key] !=
           metadata[trailing_metadata_key]
-      fail AssertionError, 
+      fail AssertionError,
             "Expected trailing metadata: #{metadata[trailing_metadata_key]}. "\
             "Received: #{op.trailing_metadata[trailing_metadata_key]}"
     end
@@ -639,7 +642,7 @@ class NamedTests
       fail AssertionError, "Expected trailing metadata. None received"
     elsif duplex_op.trailing_metadata[trailing_metadata_key] !=
           metadata[trailing_metadata_key]
-      fail AssertionError, 
+      fail AssertionError,
           "Expected trailing metadata: #{metadata[trailing_metadata_key]}. "\
           "Received: #{duplex_op.trailing_metadata[trailing_metadata_key]}"
     end
@@ -710,7 +713,7 @@ Args = Struct.new(:default_service_account, :server_host, :server_host_override,
 # validates the command line options, returning them as a Hash.
 def parse_args
   args = Args.new
-  args.server_host_override = 'foo.test.google.fr'
+  args.server_host_override = ''
   OptionParser.new do |opts|
     opts.on('--oauth_scope scope',
             'Scope for OAuth tokens') { |v| args['oauth_scope'] = v }

--- a/test/cpp/interop/client.cc
+++ b/test/cpp/interop/client.cc
@@ -38,7 +38,7 @@ DEFINE_string(custom_credentials_type, "", "User provided credentials type.");
 DEFINE_bool(use_test_ca, false, "False to use SSL roots for google");
 DEFINE_int32(server_port, 0, "Server port.");
 DEFINE_string(server_host, "localhost", "Server host to connect to");
-DEFINE_string(server_host_override, "foo.test.google.fr",
+DEFINE_string(server_host_override, "",
               "Override the server host which is sent in HTTP header");
 DEFINE_string(
     test_case, "large_unary",

--- a/test/cpp/interop/stress_test.cc
+++ b/test/cpp/interop/stress_test.cc
@@ -103,7 +103,7 @@ DEFINE_bool(use_alts, false,
             "Whether to use alts. Enable alts will disable tls.");
 DEFINE_bool(use_tls, false, "Whether to use tls.");
 DEFINE_bool(use_test_ca, false, "False to use SSL roots for google");
-DEFINE_string(server_host_override, "foo.test.google.fr",
+DEFINE_string(server_host_override, "",
               "Override the server host which is sent in HTTP header");
 
 using grpc::testing::ALTS;

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -775,8 +775,7 @@ def cloud_to_prod_jobspec(language,
     """Creates jobspec for cloud-to-prod interop test"""
     container_name = None
     cmdargs = [
-        '--server_host=%s' % server_host,
-        '--server_port=443',
+        '--server_host=%s' % server_host, '--server_port=443',
         '--test_case=%s' % test_case
     ]
     if transport_security == 'tls':

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -776,7 +776,7 @@ def cloud_to_prod_jobspec(language,
     container_name = None
     cmdargs = [
         '--server_host=%s' % server_host,
-        '--server_host_override=%s' % server_host, '--server_port=443',
+        '--server_port=443',
         '--test_case=%s' % test_case
     ]
     if transport_security == 'tls':


### PR DESCRIPTION
Tentative fix for https://github.com/grpc/grpc/issues/16759

- for cloud_to_prod tests, removes the --server_host_override for case where `server_host` is the same as `server_host_override`
- fixes the interop client for all impacted languages