### PR TITLE
Add License to Python tarball

### DIFF
--- a/PYTHON-MANIFEST.in
+++ b/PYTHON-MANIFEST.in
@@ -20,3 +20,4 @@ include src/python/grpcio/README.rst
 include requirements.txt
 include etc/roots.pem
 include Makefile
+include LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,6 @@ exclude=.*protoc_plugin/protoc_plugin_test\.proto$
 # Style settings
 [yapf]
 based_on_style = google
+
+[metadata]
+license_files = LICENSE

--- a/src/python/grpcio_channelz/MANIFEST.in
+++ b/src/python/grpcio_channelz/MANIFEST.in
@@ -1,3 +1,4 @@
 include grpc_version.py
 recursive-include grpc_channelz *.py
 global-exclude *.pyc
+include LICENSE

--- a/src/python/grpcio_channelz/channelz_commands.py
+++ b/src/python/grpcio_channelz/channelz_commands.py
@@ -21,10 +21,12 @@ import setuptools
 ROOT_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
 CHANNELZ_PROTO = os.path.join(ROOT_DIR,
                               '../../proto/grpc/channelz/channelz.proto')
+LICENSE = os.path.join(ROOT_DIR, '../../../LICENSE')
 
 
-class CopyProtoModules(setuptools.Command):
-    """Command to copy proto modules from grpc/src/proto."""
+class Preprocess(setuptools.Command):
+    """Command to copy proto modules from grpc/src/proto and LICENSE from
+    the root directory"""
 
     description = ''
     user_options = []
@@ -40,6 +42,8 @@ class CopyProtoModules(setuptools.Command):
             shutil.copyfile(CHANNELZ_PROTO,
                             os.path.join(ROOT_DIR,
                                          'grpc_channelz/v1/channelz.proto'))
+        if os.path.isfile(LICENSE):
+            shutil.copyfile(LICENSE, os.path.join(ROOT_DIR, 'LICENSE'))
 
 
 class BuildPackageProtos(setuptools.Command):

--- a/src/python/grpcio_channelz/setup.py
+++ b/src/python/grpcio_channelz/setup.py
@@ -69,7 +69,7 @@ try:
         'grpcio-tools=={version}'.format(version=grpc_version.VERSION),)
     COMMAND_CLASS = {
         # Run preprocess from the repository *before* doing any packaging!
-        'preprocess': _channelz_commands.CopyProtoModules,
+        'preprocess': _channelz_commands.Preprocess,
         'build_package_protos': _channelz_commands.BuildPackageProtos,
     }
 except ImportError:

--- a/src/python/grpcio_health_checking/MANIFEST.in
+++ b/src/python/grpcio_health_checking/MANIFEST.in
@@ -1,3 +1,4 @@
 include grpc_version.py
 recursive-include grpc_health *.py
 global-exclude *.pyc
+include LICENSE

--- a/src/python/grpcio_health_checking/setup.py
+++ b/src/python/grpcio_health_checking/setup.py
@@ -68,7 +68,7 @@ try:
         'grpcio-tools=={version}'.format(version=grpc_version.VERSION),)
     COMMAND_CLASS = {
         # Run preprocess from the repository *before* doing any packaging!
-        'preprocess': _health_commands.CopyProtoModules,
+        'preprocess': _health_commands.Preprocess,
         'build_package_protos': _health_commands.BuildPackageProtos,
     }
 except ImportError:

--- a/src/python/grpcio_reflection/MANIFEST.in
+++ b/src/python/grpcio_reflection/MANIFEST.in
@@ -1,3 +1,4 @@
 include grpc_version.py
 recursive-include grpc_reflection *.py
 global-exclude *.pyc
+include LICENSE

--- a/src/python/grpcio_reflection/reflection_commands.py
+++ b/src/python/grpcio_reflection/reflection_commands.py
@@ -21,10 +21,12 @@ import setuptools
 ROOT_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
 REFLECTION_PROTO = os.path.join(
     ROOT_DIR, '../../proto/grpc/reflection/v1alpha/reflection.proto')
+LICENSE = os.path.join(ROOT_DIR, '../../../LICENSE')
 
 
-class CopyProtoModules(setuptools.Command):
-    """Command to copy proto modules from grpc/src/proto."""
+class Preprocess(setuptools.Command):
+    """Command to copy proto modules from grpc/src/proto and LICENSE from
+    the root directory"""
 
     description = ''
     user_options = []
@@ -41,6 +43,8 @@ class CopyProtoModules(setuptools.Command):
                 REFLECTION_PROTO,
                 os.path.join(ROOT_DIR,
                              'grpc_reflection/v1alpha/reflection.proto'))
+        if os.path.isfile(LICENSE):
+            shutil.copyfile(LICENSE, os.path.join(ROOT_DIR, 'LICENSE'))
 
 
 class BuildPackageProtos(setuptools.Command):

--- a/src/python/grpcio_reflection/setup.py
+++ b/src/python/grpcio_reflection/setup.py
@@ -69,7 +69,7 @@ try:
         'grpcio-tools=={version}'.format(version=grpc_version.VERSION),)
     COMMAND_CLASS = {
         # Run preprocess from the repository *before* doing any packaging!
-        'preprocess': _reflection_commands.CopyProtoModules,
+        'preprocess': _reflection_commands.Preprocess,
         'build_package_protos': _reflection_commands.BuildPackageProtos,
     }
 except ImportError:

--- a/src/python/grpcio_testing/MANIFEST.in
+++ b/src/python/grpcio_testing/MANIFEST.in
@@ -1,3 +1,4 @@
 include grpc_version.py
 recursive-include grpc_testing *.py
 global-exclude *.pyc
+include LICENSE

--- a/src/python/grpcio_testing/setup.py
+++ b/src/python/grpcio_testing/setup.py
@@ -24,6 +24,23 @@ os.chdir(os.path.dirname(os.path.abspath(__file__)))
 # Break import style to ensure that we can find same-directory modules.
 import grpc_version
 
+
+class _NoOpCommand(setuptools.Command):
+    """No-op command."""
+
+    description = ''
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        pass
+
+
 PACKAGE_DIRECTORIES = {
     '': '.',
 }
@@ -32,6 +49,19 @@ INSTALL_REQUIRES = (
     'protobuf>=3.6.0',
     'grpcio>={version}'.format(version=grpc_version.VERSION),
 )
+
+try:
+    import testing_commands as _testing_commands
+    # we are in the build environment, otherwise the above import fails
+    COMMAND_CLASS = {
+        # Run preprocess from the repository *before* doing any packaging!
+        'preprocess': _testing_commands.Preprocess,
+    }
+except ImportError:
+    COMMAND_CLASS = {
+        # wire up commands to no-op not to break the external dependencies
+        'preprocess': _NoOpCommand,
+    }
 
 setuptools.setup(
     name='grpcio-testing',
@@ -43,4 +73,5 @@ setuptools.setup(
     url='https://grpc.io',
     package_dir=PACKAGE_DIRECTORIES,
     packages=setuptools.find_packages('.'),
-    install_requires=INSTALL_REQUIRES)
+    install_requires=INSTALL_REQUIRES,
+    cmdclass=COMMAND_CLASS)

--- a/src/python/grpcio_testing/testing_commands.py
+++ b/src/python/grpcio_testing/testing_commands.py
@@ -1,4 +1,4 @@
-# Copyright 2015 gRPC authors.
+# Copyright 2018 gRPC Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,13 +19,11 @@ import shutil
 import setuptools
 
 ROOT_DIR = os.path.abspath(os.path.dirname(os.path.abspath(__file__)))
-HEALTH_PROTO = os.path.join(ROOT_DIR, '../../proto/grpc/health/v1/health.proto')
 LICENSE = os.path.join(ROOT_DIR, '../../../LICENSE')
 
 
 class Preprocess(setuptools.Command):
-    """Command to copy proto modules from grpc/src/proto and LICENSE from
-    the root directory"""
+    """Command to copy LICENSE from root directory."""
 
     description = ''
     user_options = []
@@ -37,30 +35,5 @@ class Preprocess(setuptools.Command):
         pass
 
     def run(self):
-        if os.path.isfile(HEALTH_PROTO):
-            shutil.copyfile(HEALTH_PROTO,
-                            os.path.join(ROOT_DIR,
-                                         'grpc_health/v1/health.proto'))
         if os.path.isfile(LICENSE):
             shutil.copyfile(LICENSE, os.path.join(ROOT_DIR, 'LICENSE'))
-
-
-class BuildPackageProtos(setuptools.Command):
-    """Command to generate project *_pb2.py modules from proto files."""
-
-    description = 'build grpc protobuf modules'
-    user_options = []
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        # due to limitations of the proto generator, we require that only *one*
-        # directory is provided as an 'include' directory. We assume it's the '' key
-        # to `self.distribution.package_dir` (and get a key error if it's not
-        # there).
-        from grpc_tools import command
-        command.build_package_protos(self.distribution.package_dir[''])

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -105,7 +105,8 @@ then
   "${PIP}" install grpcio-tools --no-index --find-links "file://$ARTIFACT_DIR/"
 
   # Build grpcio_testing source distribution
-  ${SETARCH_CMD} "${PYTHON}" src/python/grpcio_testing/setup.py sdist
+  ${SETARCH_CMD} "${PYTHON}" src/python/grpcio_testing/setup.py preprocess \
+      sdist
   cp -r src/python/grpcio_testing/dist/* "$ARTIFACT_DIR"
 
   # Build grpcio_channelz source distribution


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/16732

With those 2 lines added, the gRPC Python source distribution or binary distribution wheel will contain a copy of our LICENSE file.