### PR TITLE
Revert "Strip manylinux1 binary wheels"

### DIFF
--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -19,19 +19,9 @@ cd "$(dirname "$0")/../../.."
 
 mkdir -p artifacts/
 
+# All the python packages have been built in the artifact phase already
+# and we only collect them here to deliver them to the distribtest phase.
 cp -r "${EXTERNAL_GIT_ROOT}"/input_artifacts/python_*/* artifacts/ || true
-
-strip_binary_wheel() {
-  TEMP_WHEEL_DIR=$(mktemp -d)
-  unzip "$1" -d "$TEMP_WHEEL_DIR"
-  find "$TEMP_WHEEL_DIR" -name "_protoc_compiler*.so" -exec strip --strip-debug {} ";"
-  find "$TEMP_WHEEL_DIR" -name "cygrpc*.so" -exec strip --strip-debug {} ";"
-  (cd "$TEMP_WHEEL_DIR" && zip -r - .) > "$1"
-}
-
-for wheel in artifacts/*.whl; do
-    strip_binary_wheel "$wheel"
-done
 
 # TODO: all the artifact builder configurations generate a grpcio-VERSION.tar.gz
 # source distribution package, and only one of them will end up


### PR DESCRIPTION
This reverts commit be4b2db4ad68190288b5d1e8a9b54f094ebde157.

Appears to leave the incorrect hash in the wheel RECORD file, as in https://github.com/grpc/grpc/issues/17409