### PR TITLE
Fix client-side callback API race, allow reuse of application reactor structure

### DIFF
--- a/include/grpcpp/impl/codegen/client_callback.h
+++ b/include/grpcpp/impl/codegen/client_callback.h
@@ -270,6 +270,7 @@ class ClientCallbackReaderWriterImpl
     // 2. Any read backlog
     // 3. Recv trailing metadata, on_completion callback
     // 4. Any write backlog
+    // 5. See if the call can finish (if other callbacks were triggered already)
     started_ = true;
 
     start_tag_.Set(call_.call(),
@@ -320,6 +321,7 @@ class ClientCallbackReaderWriterImpl
     if (writes_done_ops_at_start_) {
       call_.PerformOps(&writes_done_ops_);
     }
+    MaybeFinish();
   }
 
   void Read(Response* msg) override {
@@ -412,8 +414,8 @@ class ClientCallbackReaderWriterImpl
   CallbackWithSuccessTag read_tag_;
   bool read_ops_at_start_{false};
 
-  // Minimum of 2 outstanding callbacks to pre-register for start and finish
-  std::atomic_int callbacks_outstanding_{2};
+  // Minimum of 3 callbacks to pre-register for StartCall, start, and finish
+  std::atomic_int callbacks_outstanding_{3};
   bool started_{false};
 };
 
@@ -466,6 +468,7 @@ class ClientCallbackReaderImpl
     // 1. Send initial metadata (unless corked) + recv initial metadata
     // 2. Any backlog
     // 3. Recv trailing metadata, on_completion callback
+    // 4. See if the call can finish (if other callbacks were triggered already)
     started_ = true;
 
     start_tag_.Set(call_.call(),
@@ -497,6 +500,8 @@ class ClientCallbackReaderImpl
     finish_ops_.ClientRecvStatus(context_, &finish_status_);
     finish_ops_.set_core_cq_tag(&finish_tag_);
     call_.PerformOps(&finish_ops_);
+
+    MaybeFinish();
   }
 
   void Read(Response* msg) override {
@@ -540,8 +545,8 @@ class ClientCallbackReaderImpl
   CallbackWithSuccessTag read_tag_;
   bool read_ops_at_start_{false};
 
-  // Minimum of 2 outstanding callbacks to pre-register for start and finish
-  std::atomic_int callbacks_outstanding_{2};
+  // Minimum of 3 callbacks to pre-register for StartCall, start, and finish
+  std::atomic_int callbacks_outstanding_{3};
   bool started_{false};
 };
 
@@ -594,6 +599,7 @@ class ClientCallbackWriterImpl
     // 1. Send initial metadata (unless corked) + recv initial metadata
     // 2. Recv trailing metadata, on_completion callback
     // 3. Any backlog
+    // 4. See if the call can finish (if other callbacks were triggered already)
     started_ = true;
 
     start_tag_.Set(call_.call(),
@@ -633,6 +639,8 @@ class ClientCallbackWriterImpl
     if (writes_done_ops_at_start_) {
       call_.PerformOps(&writes_done_ops_);
     }
+
+    MaybeFinish();
   }
 
   void Write(const Request* msg, WriteOptions options) override {
@@ -714,8 +722,8 @@ class ClientCallbackWriterImpl
   CallbackWithSuccessTag writes_done_tag_;
   bool writes_done_ops_at_start_{false};
 
-  // Minimum of 2 outstanding callbacks to pre-register for start and finish
-  std::atomic_int callbacks_outstanding_{2};
+  // Minimum of 3 callbacks to pre-register for StartCall, start, and finish
+  std::atomic_int callbacks_outstanding_{3};
   bool started_{false};
 };
 

--- a/include/grpcpp/impl/codegen/client_callback.h
+++ b/include/grpcpp/impl/codegen/client_callback.h
@@ -255,10 +255,12 @@ class ClientCallbackReaderWriterImpl
 
   void MaybeFinish() {
     if (--callbacks_outstanding_ == 0) {
-      reactor_->OnDone(finish_status_);
+      Status s = std::move(finish_status_);
+      auto* reactor = reactor_;
       auto* call = call_.call();
       this->~ClientCallbackReaderWriterImpl();
       g_core_codegen_interface->grpc_call_unref(call);
+      reactor->OnDone(s);
     }
   }
 
@@ -450,10 +452,12 @@ class ClientCallbackReaderImpl
 
   void MaybeFinish() {
     if (--callbacks_outstanding_ == 0) {
-      reactor_->OnDone(finish_status_);
+      Status s = std::move(finish_status_);
+      auto* reactor = reactor_;
       auto* call = call_.call();
       this->~ClientCallbackReaderImpl();
       g_core_codegen_interface->grpc_call_unref(call);
+      reactor->OnDone(s);
     }
   }
 
@@ -576,10 +580,12 @@ class ClientCallbackWriterImpl
 
   void MaybeFinish() {
     if (--callbacks_outstanding_ == 0) {
-      reactor_->OnDone(finish_status_);
+      Status s = std::move(finish_status_);
+      auto* reactor = reactor_;
       auto* call = call_.call();
       this->~ClientCallbackWriterImpl();
       g_core_codegen_interface->grpc_call_unref(call);
+      reactor->OnDone(s);
     }
   }
 


### PR DESCRIPTION
1. OnDone is already the last callback, but let it be after the destruction of the streaming object so that the reactor can be reused to start a new call
1. Treat StartCall as an expected callback so that OnDone can't happen until StartCall completes

These are lumped as one PR since both of these can be considered races (the first was not explicitly allowed in the API, but it wasn't explicitly disallowed either)

Fixes #17375 
