### PR TITLE
Revert "Add Testonly to Targets"

### DIFF
--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -29,7 +29,6 @@ grpc_cc_test(
 
 grpc_cc_library(
     name = "helpers",
-    testonly = 1,
     srcs = ["helpers.cc"],
     hdrs = [
         "fullstack_context_mutators.h",
@@ -58,7 +57,6 @@ grpc_cc_test(
 # right now it OOMs
 grpc_cc_binary(
     name = "bm_arena",
-    testonly = 1,
     srcs = ["bm_arena.cc"],
     deps = [":helpers"],
 )
@@ -74,7 +72,6 @@ grpc_cc_test(
 # right now it fails UBSAN
 grpc_cc_binary(
     name = "bm_call_create",
-    testonly = 1,
     srcs = ["bm_call_create.cc"],
     deps = [":helpers"],
 )
@@ -102,7 +99,6 @@ grpc_cc_test(
 
 grpc_cc_library(
     name = "fullstack_streaming_ping_pong_h",
-    testonly = 1,
     hdrs = [
         "fullstack_streaming_ping_pong.h",
     ],
@@ -119,7 +115,6 @@ grpc_cc_test(
 
 grpc_cc_library(
     name = "fullstack_streaming_pump_h",
-    testonly = 1,
     hdrs = [
         "fullstack_streaming_pump.h",
     ],
@@ -136,14 +131,12 @@ grpc_cc_test(
 
 grpc_cc_binary(
     name = "bm_fullstack_trickle",
-    testonly = 1,
     srcs = ["bm_fullstack_trickle.cc"],
     deps = [":helpers"],
 )
 
 grpc_cc_library(
     name = "fullstack_unary_ping_pong_h",
-    testonly = 1,
     hdrs = [
         "fullstack_unary_ping_pong.h",
     ],


### PR DESCRIPTION
Reverts grpc/grpc#17394

Causes build errors with TAP internally.