### PR TITLE
Revert "Make Microbenchmarks Test Targets"

### DIFF
--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -47,15 +47,13 @@ grpc_cc_library(
     ],
 )
 
-grpc_cc_test(
+grpc_cc_binary(
     name = "bm_closure",
+    testonly = 1,
     srcs = ["bm_closure.cc"],
     deps = [":helpers"],
-    uses_polling = False,
 )
 
-# TODO(https://github.com/grpc/grpc/pull/16882): make this a test target
-# right now it OOMs
 grpc_cc_binary(
     name = "bm_arena",
     testonly = 1,
@@ -63,15 +61,13 @@ grpc_cc_binary(
     deps = [":helpers"],
 )
 
-grpc_cc_test(
+grpc_cc_binary(
     name = "bm_channel",
+    testonly = 1,
     srcs = ["bm_channel.cc"],
     deps = [":helpers"],
-    uses_polling = False,
 )
 
-# TODO(https://github.com/grpc/grpc/pull/16882): make this a test target
-# right now it fails UBSAN
 grpc_cc_binary(
     name = "bm_call_create",
     testonly = 1,
@@ -79,25 +75,25 @@ grpc_cc_binary(
     deps = [":helpers"],
 )
 
-grpc_cc_test(
+grpc_cc_binary(
     name = "bm_cq",
+    testonly = 1,
     srcs = ["bm_cq.cc"],
     deps = [":helpers"],
-    uses_polling = False,
 )
 
-grpc_cc_test(
+grpc_cc_binary(
     name = "bm_cq_multiple_threads",
+    testonly = 1,
     srcs = ["bm_cq_multiple_threads.cc"],
     deps = [":helpers"],
-    uses_polling = False,
 )
 
-grpc_cc_test(
+grpc_cc_binary(
     name = "bm_error",
+    testonly = 1,
     srcs = ["bm_error.cc"],
     deps = [":helpers"],
-    uses_polling = False,
 )
 
 grpc_cc_library(
@@ -109,8 +105,9 @@ grpc_cc_library(
     deps = [":helpers"],
 )
 
-grpc_cc_test(
+grpc_cc_binary(
     name = "bm_fullstack_streaming_ping_pong",
+    testonly = 1,
     srcs = [
         "bm_fullstack_streaming_ping_pong.cc",
     ],
@@ -126,8 +123,9 @@ grpc_cc_library(
     deps = [":helpers"],
 )
 
-grpc_cc_test(
+grpc_cc_binary(
     name = "bm_fullstack_streaming_pump",
+    testonly = 1,
     srcs = [
         "bm_fullstack_streaming_pump.cc",
     ],
@@ -150,37 +148,26 @@ grpc_cc_library(
     deps = [":helpers"],
 )
 
-grpc_cc_test(
+grpc_cc_binary(
     name = "bm_fullstack_unary_ping_pong",
+    testonly = 1,
     srcs = [
         "bm_fullstack_unary_ping_pong.cc",
     ],
     deps = [":fullstack_unary_ping_pong_h"],
 )
 
-grpc_cc_test(
+grpc_cc_binary(
     name = "bm_metadata",
+    testonly = 1,
     srcs = ["bm_metadata.cc"],
     deps = [":helpers"],
-    uses_polling = False,
 )
 
-grpc_cc_test(
+grpc_cc_binary(
     name = "bm_chttp2_hpack",
+    testonly = 1,
     srcs = ["bm_chttp2_hpack.cc"],
-    deps = [":helpers"],
-    uses_polling = False,
-)
-
-grpc_cc_test(
-    name = "bm_chttp2_transport",
-    srcs = ["bm_chttp2_transport.cc"],
-    deps = [":helpers"],
-)
-
-grpc_cc_test(
-    name = "bm_pollset",
-    srcs = ["bm_pollset.cc"],
     deps = [":helpers"],
 )
 

--- a/test/cpp/microbenchmarks/bm_call_create.cc
+++ b/test/cpp/microbenchmarks/bm_call_create.cc
@@ -526,7 +526,7 @@ static void BM_IsolatedFilter(benchmark::State& state) {
 
   grpc_core::ExecCtx exec_ctx;
   size_t channel_size = grpc_channel_stack_size(
-      filters.size() == 0 ? nullptr : filters.data(), filters.size());
+      filters.size() == 0 ? nullptr : &filters[0], filters.size());
   grpc_channel_stack* channel_stack =
       static_cast<grpc_channel_stack*>(gpr_zalloc(channel_size));
   GPR_ASSERT(GRPC_LOG_IF_ERROR(


### PR DESCRIPTION
Reverts grpc/grpc#16882

Breaks internal testing infra.