### PR TITLE
Update GRPCCall doc to clarify serial queue requirement

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -253,7 +253,7 @@ extern id const kGRPCTrailersKey;
 + (void)setCallSafety:(GRPCCallSafety)callSafety host:(NSString *)host path:(NSString *)path;
 
 /**
- * Set the dispatch queue to be used for callbacks.
+ * Set the dispatch queue to be used for callbacks. Current implementation requires \a queue to be a serial queue.
  *
  * This configuration is only effective before the call starts.
  */

--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -253,7 +253,8 @@ extern id const kGRPCTrailersKey;
 + (void)setCallSafety:(GRPCCallSafety)callSafety host:(NSString *)host path:(NSString *)path;
 
 /**
- * Set the dispatch queue to be used for callbacks. Current implementation requires \a queue to be a serial queue.
+ * Set the dispatch queue to be used for callbacks. Current implementation requires \a queue to be a
+ * serial queue.
  *
  * This configuration is only effective before the call starts.
  */


### PR DESCRIPTION
`GRPCCall` requires serial queue to work correctly. This requirement was not documented and causing people to use the interface incorrectly. This PR adds this requirement.