### PR TITLE
Use x64 tools on 64-bit Windows in Grpc.Tools

### DIFF
--- a/src/csharp/Grpc.Tools/build/_grpc/_Grpc.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_grpc/_Grpc.Tools.targets
@@ -22,9 +22,8 @@
   <Target Name="gRPC_ResolvePluginFullPath" AfterTargets="Protobuf_ResolvePlatform">
     <PropertyGroup>
       <!-- TODO(kkm): Do not use Protobuf_PackagedToolsPath, roll gRPC's own. -->
-      <!-- TODO(kkm): Do not package windows x64 builds (#13098). -->
       <gRPC_PluginFullPath Condition=" '$(gRPC_PluginFullPath)' == '' and '$(Protobuf_ToolsOs)' == 'windows' "
-           >$(Protobuf_PackagedToolsPath)\$(Protobuf_ToolsOs)_x86\$(gRPC_PluginFileName).exe</gRPC_PluginFullPath>
+           >$(Protobuf_PackagedToolsPath)\$(Protobuf_ToolsOs)_$(Protobuf_ToolsCpu)\$(gRPC_PluginFileName).exe</gRPC_PluginFullPath>
       <gRPC_PluginFullPath Condition=" '$(gRPC_PluginFullPath)' == '' "
            >$(Protobuf_PackagedToolsPath)/$(Protobuf_ToolsOs)_$(Protobuf_ToolsCpu)/$(gRPC_PluginFileName)</gRPC_PluginFullPath>
     </PropertyGroup>

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -74,9 +74,8 @@
       <!-- Next try OS and CPU resolved by ProtoToolsPlatform. -->
       <Protobuf_ToolsOs Condition=" '$(Protobuf_ToolsOs)' == '' ">$(_Protobuf_ToolsOs)</Protobuf_ToolsOs>
       <Protobuf_ToolsCpu Condition=" '$(Protobuf_ToolsCpu)' == '' ">$(_Protobuf_ToolsCpu)</Protobuf_ToolsCpu>
-      <!-- TODO(kkm): Do not package windows x64 builds (#13098). -->
       <Protobuf_ProtocFullPath Condition=" '$(Protobuf_ProtocFullPath)' == '' and '$(Protobuf_ToolsOs)' == 'windows' "
-           >$(Protobuf_PackagedToolsPath)\$(Protobuf_ToolsOs)_x86\protoc.exe</Protobuf_ProtocFullPath>
+           >$(Protobuf_PackagedToolsPath)\$(Protobuf_ToolsOs)_$(Protobuf_ToolsCpu)\protoc.exe</Protobuf_ProtocFullPath>
       <Protobuf_ProtocFullPath Condition=" '$(Protobuf_ProtocFullPath)' == '' "
            >$(Protobuf_PackagedToolsPath)/$(Protobuf_ToolsOs)_$(Protobuf_ToolsCpu)/protoc</Protobuf_ProtocFullPath>
     </PropertyGroup>


### PR DESCRIPTION
The Windows Nano Server Docker image does not support 32-bit executables. See https://github.com/grpc/grpc/pull/13207#issuecomment-444846082 and next 2 comments. Thanks to @hagen93 for bringing up the issue!

Docs: https://docs.microsoft.com/windows-server/get-started/getting-started-with-nano-server#important-differences-in-nano-server

I confirmed generation working on my Windows 10 x64 machine:
```
_Protobuf_CoreCompile:
  C:\Users\kkm\.nuget\packages\grpc.tools\1.17.1-dev2\tools\windows_x64\protoc.exe --csharp_out=obj\Debug\netstandard1.5 --plugin=protoc-gen-grpc=C:\Users\kkm\.nuget\packages\grpc.tools\1.17.1-dev2\tools\windows_x64\grpc_csharp_plugin.exe --grpc_out=obj\Debug\netstandard1.5 --proto_path=C:\Users\kkm\.nuget\packages\grpc.tools\1.17.1-dev2\build\native\include --proto_path=..\..\..\protos --dependency_out=obj\Debug\netstandard1.5\50c9e7acc97344d0_helloworld.protodep ../../../protos/helloworld.proto
```
Both protoc and the plugin are run from the `windows_x64` package directory now.

(If only I could come up with unit tests for the scripts!)

I was so wrong in #13098 about Windows always being able to run 32-bit processes! You never know...

@jtattermusch, I am targeting the v1.17.x branch, as this is essentially a hotfix, correct? Are there release notes that need to be updated?

Close: #13098 (wontfix)
