### PR TITLE
Server interceptor test should understand the health checking service

### DIFF
--- a/test/cpp/end2end/server_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/server_interceptors_end2end_test.cc
@@ -52,11 +52,13 @@ class LoggingInterceptor : public experimental::Interceptor {
     experimental::ServerRpcInfo::Type type = info->type();
 
     // Check that we use one of our standard methods with expected type.
+    // Also allow the health checking service.
     // We accept BIDI_STREAMING for Echo in case it's an AsyncGenericService
     // being tested (the GenericRpc test).
     // The empty method is for the Unimplemented requests that arise
     // when draining the CQ.
     EXPECT_TRUE(
+        strstr(method, "/grpc.health") == method ||
         (strcmp(method, "/grpc.testing.EchoTestService/Echo") == 0 &&
          (type == experimental::ServerRpcInfo::Type::UNARY ||
           type == experimental::ServerRpcInfo::Type::BIDI_STREAMING)) ||


### PR DESCRIPTION
Fixes a breakage when this test is used with health checking enabled

