### PR TITLE
Make grpc_end2end_tests() make visible libraries

### DIFF
--- a/test/core/end2end/generate_tests.bzl
+++ b/test/core/end2end/generate_tests.bzl
@@ -370,6 +370,7 @@ def grpc_end2end_tests():
             "tests/cancel_test_helpers.h",
             "end2end_tests.h",
         ],
+        visibility = ["//visibility:public"],
         language = "C++",
         deps = [
             ":cq_verifier",


### PR DESCRIPTION
The Asylo project (https://github.com/google/asylo) uses this test
generator for testing its enclave channel in gRPC. We think it's a
useful tool for others to have at their disposal when creating their own
custom channels. Plus, it's preferable that this is in the main
distribution and supported rather than patched in when we pull in the
gRPC dependency.