### PR TITLE
Update urllib3 to avoid security vulnerability

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -9,7 +9,7 @@ futures>=2.2.0
 google-auth>=1.0.0
 oauth2client==4.1.0
 requests>=2.14.2
-urllib3==1.22
+urllib3>=1.23
 chardet==3.0.4
 certifi==2017.4.17
 idna==2.7


### PR DESCRIPTION
This PR updates `urllib3` to avoid [CVE-2018-20060](https://nvd.nist.gov/vuln/detail/CVE-2018-20060). This update process will be automatic after https://github.com/grpc/grpc/issues/17177 is resolved.

(cherry-pick of https://github.com/grpc/grpc/pull/17476)