### PR TITLE
Utilize the GitHub Check Feature

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_linux_perf_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_linux_perf_rc
@@ -35,8 +35,6 @@ fi
 sudo pip install tabulate
 
 # Python dependencies for tools/run_tests/python_utils/check_on_pr.py
-sudo -H pip install pyjwt cryptography requests
-
-ls -al "${KOKORO_KEYSTORE_DIR}/73836_grpc_checks_private_key"
+time python2.7 -m pip install pyjwt cryptography requests --user
 
 git submodule update --init

--- a/tools/internal_ci/helper_scripts/prepare_build_linux_perf_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_linux_perf_rc
@@ -34,4 +34,9 @@ fi
 
 sudo pip install tabulate
 
+# Python dependencies for tools/run_tests/python_utils/check_on_pr.py
+sudo -H pip install pyjwt cryptography requests
+
+ls -al "${KOKORO_KEYSTORE_DIR}/73836_grpc_checks_private_key"
+
 git submodule update --init

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -31,6 +31,8 @@ date
 pip install google-api-python-client oauth2client --user python
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json
 
+ls -al "${KOKORO_KEYSTORE_DIR}/73836_grpc_checks_private_key"
+
 # If this is a PR using RUN_TESTS_FLAGS var, then add flags to filter tests
 if [ -n "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
   set +x
@@ -63,7 +65,7 @@ time pod repo update  # needed by python
 
 # python
 time pip install virtualenv --user python
-time pip install -U Mako six tox setuptools twisted pyyaml --user python
+time pip install -U Mako six tox setuptools twisted pyyaml pyjwt cryptography requests --user python
 export PYTHONPATH=/Library/Python/3.4/site-packages
 
 # Install Python 3.7

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -31,8 +31,6 @@ date
 pip install google-api-python-client oauth2client --user python
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json
 
-ls -al "${KOKORO_KEYSTORE_DIR}/73836_grpc_checks_private_key"
-
 # If this is a PR using RUN_TESTS_FLAGS var, then add flags to filter tests
 if [ -n "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
   set +x

--- a/tools/internal_ci/linux/pull_request/grpc_microbenchmark_diff.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_microbenchmark_diff.cfg
@@ -17,6 +17,14 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_microbenchmark_diff.sh"
 timeout_mins: 120
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73836
+      keyname: "grpc_checks_private_key"
+    }
+  }
+}
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/linux/pull_request/grpc_trickle_diff.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_trickle_diff.cfg
@@ -17,6 +17,14 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/linux/grpc_trickle_diff.sh"
 timeout_mins: 120
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73836
+      keyname: "grpc_checks_private_key"
+    }
+  }
+}
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/macos/pull_request/grpc_ios_binary_size.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_ios_binary_size.cfg
@@ -18,6 +18,14 @@
 build_file: "grpc/tools/internal_ci/macos/grpc_ios_binary_size.sh"
 timeout_mins: 60
 gfile_resources: "/bigstore/grpc-testing-secrets/github_credentials/oauth_token.txt"
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73836
+      keyname: "grpc_checks_private_key"
+    }
+  }
+}
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/profiling/bloat/bloat_diff.py
+++ b/tools/profiling/bloat/bloat_diff.py
@@ -25,7 +25,7 @@ import sys
 sys.path.append(
     os.path.join(
         os.path.dirname(sys.argv[0]), '..', '..', 'run_tests', 'python_utils'))
-import comment_on_pr
+import check_on_pr
 
 argp = argparse.ArgumentParser(description='Perform diff on microbenchmarks')
 
@@ -90,4 +90,4 @@ for lib in LIBS:
     text += '\n\n'
 
 print text
-comment_on_pr.comment_on_pr('```\n%s\n```' % text)
+check_on_pr.check_on_pr('Bloat Difference', '```\n%s\n```' % text)

--- a/tools/profiling/ios_bin/binary_size.py
+++ b/tools/profiling/ios_bin/binary_size.py
@@ -26,7 +26,7 @@ from parse_link_map import parse_link_map
 sys.path.append(
     os.path.join(
         os.path.dirname(sys.argv[0]), '..', '..', 'run_tests', 'python_utils'))
-import comment_on_pr
+import check_on_pr
 
 # Only show diff 1KB or greater
 diff_threshold = 1000
@@ -147,4 +147,4 @@ for frameworks in [False, True]:
 
 print text
 
-comment_on_pr.comment_on_pr('```\n%s\n```' % text)
+check_on_pr.check_on_pr('Binary Size', '```\n%s\n```' % text)

--- a/tools/profiling/microbenchmarks/bm_diff/bm_main.py
+++ b/tools/profiling/microbenchmarks/bm_diff/bm_main.py
@@ -30,7 +30,7 @@ import subprocess
 sys.path.append(
     os.path.join(
         os.path.dirname(sys.argv[0]), '..', '..', 'run_tests', 'python_utils'))
-import comment_on_pr
+import check_on_pr
 
 sys.path.append(
     os.path.join(
@@ -152,7 +152,7 @@ def main(args):
     if note:
         text = note + '\n\n' + text
     print('%s' % text)
-    comment_on_pr.comment_on_pr('```\n%s\n```' % text)
+    check_on_pr.check_on_pr('Benchmark', '```\n%s\n```' % text)
 
 
 if __name__ == '__main__':

--- a/tools/profiling/qps/qps_diff.py
+++ b/tools/profiling/qps/qps_diff.py
@@ -33,7 +33,7 @@ import bm_speedup
 sys.path.append(
     os.path.join(
         os.path.dirname(sys.argv[0]), '..', '..', 'run_tests', 'python_utils'))
-import comment_on_pr
+import check_on_pr
 
 
 def _args():
@@ -164,7 +164,7 @@ def main(args):
     else:
         text = '[qps] No significant performance differences'
     print('%s' % text)
-    comment_on_pr.comment_on_pr('```\n%s\n```' % text)
+    check_on_pr.check_on_pr('QPS', '```\n%s\n```' % text)
 
 
 if __name__ == '__main__':

--- a/tools/run_tests/python_utils/check_on_pr.py
+++ b/tools/run_tests/python_utils/check_on_pr.py
@@ -1,0 +1,98 @@
+# Copyright 2018 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import os
+import json
+import time
+import datetime
+
+import requests
+import jwt
+
+_GITHUB_API_PREFIX = 'https://api.github.com'
+_GITHUB_REPO = 'lidizheng/grpc'
+_GITHUB_APP_ID = 22288
+_INSTALLATION_ID = 516307
+_GITHUB_APP_KEY = open(os.environ['HOME'] + '/.ssh/google-grpc-checker.2018-12-13.private-key.pem', 'r').read()
+
+_ACCESS_TOKEN_CACHE = None
+
+def _jwt_token():
+    return jwt.encode({
+        'iat': int(time.time()),
+        'exp': int(time.time() + 60 * 10), # expire in 10 minutes
+        'iss': _GITHUB_APP_ID,
+    }, _GITHUB_APP_KEY, algorithm='RS256')
+
+def _access_token():
+    global _ACCESS_TOKEN_CACHE
+    if _ACCESS_TOKEN_CACHE == None or _ACCESS_TOKEN_CACHE['exp'] < time.time():
+        resp = requests.post(
+            url='https://api.github.com/app/installations/%s/access_tokens' % _INSTALLATION_ID,
+            headers={
+                'Authorization': 'Bearer %s' % _jwt_token().decode('ASCII'),
+                'Accept': 'application/vnd.github.machine-man-preview+json',
+            }
+        )
+        _ACCESS_TOKEN_CACHE = {'token': resp.json()['token'], 'exp': time.time()+60}
+    return _ACCESS_TOKEN_CACHE['token']
+
+def _call(url, method='GET', json=None):
+    if not url.startswith('https://'):
+        url = _GITHUB_API_PREFIX + url
+    headers={
+        'Authorization': 'Bearer %s' % _access_token(),
+        'Accept': 'application/vnd.github.antiope-preview+json',
+    }
+    return requests.request(
+        method=method,
+        url=url,
+        headers=headers,
+        json=json)
+
+def _latest_commit():
+    resp = _call('/repos/%s/pulls/%s/commits' % (_GITHUB_REPO, os.environ['ghprbPullId']))
+    return resp.json()[-1]
+
+def check_on_pr(name, summary, success=True):
+    """Create/Update a check on current pull request.
+
+    The check runs are aggregated by their name, so newer check will update the
+    older check with the same name.
+
+    Requires environment variable 'ghprbPullId' to indicate which pull request
+    should be updated.
+
+    Args:
+      name: The name of the check.
+      summary: A str in Markdown to be used as the detail information of the check.
+      success: A bool indicates whether the check is succeed or not.
+    """
+    if 'ghprbPullId' not in os.environ:
+        print('Missing ghprbPullId env var: not commenting')
+        return
+    commit = _latest_commit()
+    resp = _call('/repos/%s/check-runs' % _GITHUB_REPO, method='POST', json={
+        'name': name,
+        'head_sha': commit['sha'],
+        'status': 'completed',
+        'completed_at': '%sZ' % datetime.datetime.utcnow().replace(microsecond=0).isoformat(),
+        'conclusion': 'success' if success else 'failure',
+        'output': {
+            'title': name,
+            'summary': summary,
+        }
+    })
+    print('Result of Creating/Updating Check on PR:', json.dumps(resp.json(), indent=2))

--- a/tools/run_tests/python_utils/check_on_pr.py
+++ b/tools/run_tests/python_utils/check_on_pr.py
@@ -26,8 +26,8 @@ _GITHUB_REPO = 'grpc/grpc'
 _GITHUB_APP_ID = 22338
 _INSTALLATION_ID = 519109
 _GITHUB_APP_KEY = open(
-    os.environ['HOME'] + '/.ssh/google-grpc-checker.2018-12-13.private-key.pem',
-    'r').read()
+    os.path.join(os.environ['KOKORO_KEYSTORE_DIR'], '73836_grpc_checks_private_key'),
+    'rb').read()
 
 _ACCESS_TOKEN_CACHE = None
 

--- a/tools/run_tests/python_utils/check_on_pr.py
+++ b/tools/run_tests/python_utils/check_on_pr.py
@@ -22,9 +22,9 @@ import requests
 import jwt
 
 _GITHUB_API_PREFIX = 'https://api.github.com'
-_GITHUB_REPO = 'lidizheng/grpc'
-_GITHUB_APP_ID = 22288
-_INSTALLATION_ID = 516307
+_GITHUB_REPO = 'grpc/grpc'
+_GITHUB_APP_ID = 22338
+_INSTALLATION_ID = 519109
 _GITHUB_APP_KEY = open(
     os.environ['HOME'] + '/.ssh/google-grpc-checker.2018-12-13.private-key.pem',
     'r').read()

--- a/tools/run_tests/python_utils/check_on_pr.py
+++ b/tools/run_tests/python_utils/check_on_pr.py
@@ -71,8 +71,9 @@ def _call(url, method='GET', json=None):
 
 
 def _latest_commit():
-    resp = _call('/repos/%s/pulls/%s/commits' % (_GITHUB_REPO,
-                                                 os.environ['ghprbPullId']))
+    resp = _call('/repos/%s/pulls/%s/commits' %
+                 (_GITHUB_REPO,
+                  os.environ['KOKORO_GITHUB_PULL_REQUEST_NUMBER']))
     return resp.json()[-1]
 
 
@@ -82,7 +83,7 @@ def check_on_pr(name, summary, success=True):
     The check runs are aggregated by their name, so newer check will update the
     older check with the same name.
 
-    Requires environment variable 'ghprbPullId' to indicate which pull request
+    Requires environment variable 'KOKORO_GITHUB_PULL_REQUEST_NUMBER' to indicate which pull request
     should be updated.
 
     Args:
@@ -96,8 +97,8 @@ def check_on_pr(name, summary, success=True):
     if 'KOKORO_KEYSTORE_DIR' not in os.environ:
         print('Missing KOKORO_KEYSTORE_DIR env var: not checking')
         return
-    if 'ghprbPullId' not in os.environ:
-        print('Missing ghprbPullId env var: not checking')
+    if 'KOKORO_GITHUB_PULL_REQUEST_NUMBER' not in os.environ:
+        print('Missing KOKORO_GITHUB_PULL_REQUEST_NUMBER env var: not checking')
         return
     completion_time = str(
         datetime.datetime.utcnow().replace(microsecond=0).isoformat()) + 'Z'

--- a/tools/run_tests/python_utils/check_on_pr.py
+++ b/tools/run_tests/python_utils/check_on_pr.py
@@ -25,46 +25,56 @@ _GITHUB_API_PREFIX = 'https://api.github.com'
 _GITHUB_REPO = 'lidizheng/grpc'
 _GITHUB_APP_ID = 22288
 _INSTALLATION_ID = 516307
-_GITHUB_APP_KEY = open(os.environ['HOME'] + '/.ssh/google-grpc-checker.2018-12-13.private-key.pem', 'r').read()
+_GITHUB_APP_KEY = open(
+    os.environ['HOME'] + '/.ssh/google-grpc-checker.2018-12-13.private-key.pem',
+    'r').read()
 
 _ACCESS_TOKEN_CACHE = None
 
+
 def _jwt_token():
-    return jwt.encode({
-        'iat': int(time.time()),
-        'exp': int(time.time() + 60 * 10), # expire in 10 minutes
-        'iss': _GITHUB_APP_ID,
-    }, _GITHUB_APP_KEY, algorithm='RS256')
+    return jwt.encode(
+        {
+            'iat': int(time.time()),
+            'exp': int(time.time() + 60 * 10),  # expire in 10 minutes
+            'iss': _GITHUB_APP_ID,
+        },
+        _GITHUB_APP_KEY,
+        algorithm='RS256')
+
 
 def _access_token():
     global _ACCESS_TOKEN_CACHE
     if _ACCESS_TOKEN_CACHE == None or _ACCESS_TOKEN_CACHE['exp'] < time.time():
         resp = requests.post(
-            url='https://api.github.com/app/installations/%s/access_tokens' % _INSTALLATION_ID,
+            url='https://api.github.com/app/installations/%s/access_tokens' %
+            _INSTALLATION_ID,
             headers={
                 'Authorization': 'Bearer %s' % _jwt_token().decode('ASCII'),
                 'Accept': 'application/vnd.github.machine-man-preview+json',
-            }
-        )
-        _ACCESS_TOKEN_CACHE = {'token': resp.json()['token'], 'exp': time.time()+60}
+            })
+        _ACCESS_TOKEN_CACHE = {
+            'token': resp.json()['token'],
+            'exp': time.time() + 60
+        }
     return _ACCESS_TOKEN_CACHE['token']
+
 
 def _call(url, method='GET', json=None):
     if not url.startswith('https://'):
         url = _GITHUB_API_PREFIX + url
-    headers={
+    headers = {
         'Authorization': 'Bearer %s' % _access_token(),
         'Accept': 'application/vnd.github.antiope-preview+json',
     }
-    return requests.request(
-        method=method,
-        url=url,
-        headers=headers,
-        json=json)
+    return requests.request(method=method, url=url, headers=headers, json=json)
+
 
 def _latest_commit():
-    resp = _call('/repos/%s/pulls/%s/commits' % (_GITHUB_REPO, os.environ['ghprbPullId']))
+    resp = _call('/repos/%s/pulls/%s/commits' % (_GITHUB_REPO,
+                                                 os.environ['ghprbPullId']))
     return resp.json()[-1]
+
 
 def check_on_pr(name, summary, success=True):
     """Create/Update a check on current pull request.
@@ -84,15 +94,25 @@ def check_on_pr(name, summary, success=True):
         print('Missing ghprbPullId env var: not commenting')
         return
     commit = _latest_commit()
-    resp = _call('/repos/%s/check-runs' % _GITHUB_REPO, method='POST', json={
-        'name': name,
-        'head_sha': commit['sha'],
-        'status': 'completed',
-        'completed_at': '%sZ' % datetime.datetime.utcnow().replace(microsecond=0).isoformat(),
-        'conclusion': 'success' if success else 'failure',
-        'output': {
-            'title': name,
-            'summary': summary,
-        }
-    })
-    print('Result of Creating/Updating Check on PR:', json.dumps(resp.json(), indent=2))
+    resp = _call(
+        '/repos/%s/check-runs' % _GITHUB_REPO,
+        method='POST',
+        json={
+            'name':
+            name,
+            'head_sha':
+            commit['sha'],
+            'status':
+            'completed',
+            'completed_at':
+            '%sZ' %
+            datetime.datetime.utcnow().replace(microsecond=0).isoformat(),
+            'conclusion':
+            'success' if success else 'failure',
+            'output': {
+                'title': name,
+                'summary': summary,
+            }
+        })
+    print('Result of Creating/Updating Check on PR:',
+          json.dumps(resp.json(), indent=2))


### PR DESCRIPTION
Current infrastructure post some test results through comments on GitHub pull requests. It may post 4-5 comments on each commit, as a result, the technical discussion will be **immersed** by the ocean of test results.

Thanks for @nicolasnoble 's guidance,  there is a GitHub feature that is perfectly suitable to solve this problem, the [GitHub check](https://developer.github.com/v3/checks/). The check is similar to a test that associated with a specific commit, but in the check page only the latest check will show up. Each check allows to output a summary or detail in Markdown to briefly describe the test result. If there is something requires action, the check be labeled as `failure` or `timeout`. In this way, we can reduce the distraction in each PR and helps contributors of gRPC read the content of PR (the less noise is, the faster information spreads).

**NEED HELP**: Only GitHub app can manipulate the check state. To use it, we need to put the private key to our testing cluster. Also, we need to install a [GitHub app](https://developer.github.com/v3/apps/) for grpc/grpc.