### PR TITLE
Add API comments indicating that byte buffer copy is size-independent

### DIFF
--- a/include/grpcpp/impl/codegen/byte_buffer.h
+++ b/include/grpcpp/impl/codegen/byte_buffer.h
@@ -93,7 +93,9 @@ class ByteBuffer final {
   }
 
   /// Constuct a byte buffer by referencing elements of existing buffer
-  /// \a buf. Wrapper of core function grpc_byte_buffer_copy
+  /// \a buf. Wrapper of core function grpc_byte_buffer_copy . This is not
+  /// a deep copy; it is just a referencing. As a result, its performance is
+  /// size-independent.
   ByteBuffer(const ByteBuffer& buf);
 
   ~ByteBuffer() {
@@ -102,6 +104,9 @@ class ByteBuffer final {
     }
   }
 
+  /// Wrapper of core function grpc_byte_buffer_copy . This is not
+  /// a deep copy; it is just a referencing. As a result, its performance is
+  /// size-independent.
   ByteBuffer& operator=(const ByteBuffer&);
 
   /// Dump (read) the buffer contents into \a slices.
@@ -117,7 +122,9 @@ class ByteBuffer final {
 
   /// Make a duplicate copy of the internals of this byte
   /// buffer so that we have our own owned version of it.
-  /// bbuf.Duplicate(); is equivalent to bbuf=bbuf; but is actually readable
+  /// bbuf.Duplicate(); is equivalent to bbuf=bbuf; but is actually readable.
+  /// This is not a deep copy; it is a referencing and its performance
+  /// is size-independent.
   void Duplicate() {
     buffer_ = g_core_codegen_interface->grpc_byte_buffer_copy(buffer_);
   }


### PR DESCRIPTION
At suggestion of @ncteisen 