### PR TITLE
Do not take ownership for grpc server global callbacks.

### DIFF
--- a/include/grpcpp/server_impl.h
+++ b/include/grpcpp/server_impl.h
@@ -322,8 +322,6 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   grpc::internal::CondVar callback_reqs_done_cv_;
   std::atomic_int callback_reqs_outstanding_{0};
 
-  std::shared_ptr<GlobalCallbacks> global_callbacks_;
-
   std::vector<grpc::string> services_;
   bool has_async_generic_service_{false};
   bool has_callback_generic_service_{false};

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -949,9 +949,9 @@ Server::Server(
     }
 
     for (const auto& it : *sync_server_cqs_) {
-      sync_req_mgrs_.emplace_back(new SyncRequestThreadManager(
-          this, it.get(), server_rq, min_pollers, max_pollers,
-          sync_cq_timeout_msec));
+      sync_req_mgrs_.emplace_back(
+          new SyncRequestThreadManager(this, it.get(), server_rq, min_pollers,
+                                       max_pollers, sync_cq_timeout_msec));
     }
 
     if (default_rq_created) {

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -77,8 +77,8 @@ class DefaultGlobalCallbacks final : public Server::GlobalCallbacks {
   void PostSynchronousRequest(ServerContext* context) override {}
 };
 
-DefaultGlobalCallbacks g_default_callbacks;
-Server::GlobalCallbacks* g_callbacks = &g_default_callbacks;
+DefaultGlobalCallbacks* g_default_callbacks = new DefaultGlobalCallbacks();
+Server::GlobalCallbacks* g_callbacks = g_default_callbacks;
 
 class ShutdownTag : public internal::CompletionQueueTag {
  public:
@@ -1007,9 +1007,9 @@ Server::~Server() {
 }
 
 void Server::SetGlobalCallbacks(GlobalCallbacks* callbacks) {
-  GPR_ASSERT(grpc::g_callbacks == &g_default_callbacks);
+  GPR_ASSERT(grpc::g_callbacks == g_default_callbacks);
   GPR_ASSERT(callbacks);
-  GPR_ASSERT(callbacks != &g_default_callbacks);
+  GPR_ASSERT(callbacks != g_default_callbacks);
   grpc::g_callbacks = callbacks;
 }
 

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -1007,9 +1007,9 @@ Server::~Server() {
 }
 
 void Server::SetGlobalCallbacks(GlobalCallbacks* callbacks) {
-  GPR_ASSERT(grpc::g_callbacks == g_default_callbacks);
+  GPR_ASSERT(grpc::g_callbacks == grpc::g_default_callbacks);
   GPR_ASSERT(callbacks);
-  GPR_ASSERT(callbacks != g_default_callbacks);
+  GPR_ASSERT(callbacks != grpc::g_default_callbacks);
   grpc::g_callbacks = callbacks;
 }
 


### PR DESCRIPTION
The function comment of grpc::Server::SetGlobalCallbacks() states that "Can only be called once per application. Does not take ownership of callbacks". However, the implementation uses shared_ptr which takes ownership. Make it the same as ClientContext's GlobalCallbacks.