### PR TITLE
Move ares_channel from the request object to the resolver

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -27,6 +27,8 @@
 #include <grpc/support/alloc.h>
 #include <grpc/support/string_util.h>
 
+#include <ares.h>
+
 #include <address_sorting/address_sorting.h>
 
 #include "src/core/ext/filters/client_channel/http_connect_handshaker.h"
@@ -125,6 +127,8 @@ class AresDnsResolver : public Resolver {
   bool shutdown_initiated_ = false;
   // timeout in milliseconds for active DNS queries
   int query_timeout_ms_;
+  // c-ares channel to perform queries on
+  ares_channel c_ares_channel_;
 };
 
 AresDnsResolver::AresDnsResolver(const ResolverArgs& args)
@@ -167,6 +171,7 @@ AresDnsResolver::AresDnsResolver(const ResolverArgs& args)
   query_timeout_ms_ = grpc_channel_arg_get_integer(
       query_timeout_ms_arg,
       {GRPC_DNS_ARES_DEFAULT_QUERY_TIMEOUT_MS, 0, INT_MAX});
+  grpc_init_c_ares_channel(&c_ares_channel_);
 }
 
 AresDnsResolver::~AresDnsResolver() {
@@ -178,6 +183,7 @@ AresDnsResolver::~AresDnsResolver() {
   gpr_free(dns_server_);
   gpr_free(name_to_resolve_);
   grpc_channel_args_destroy(channel_args_);
+  ares_destroy(c_ares_channel_);
 }
 
 void AresDnsResolver::NextLocked(grpc_channel_args** target_result,
@@ -418,8 +424,8 @@ void AresDnsResolver::StartResolvingLocked() {
   resolving_ = true;
   service_config_json_ = nullptr;
   pending_request_ = grpc_dns_lookup_ares_locked(
-      dns_server_, name_to_resolve_, kDefaultPort, interested_parties_,
-      &on_resolved_, &addresses_, true /* check_grpclb */,
+      c_ares_channel_, dns_server_, name_to_resolve_, kDefaultPort,
+      interested_parties_, &on_resolved_, &addresses_, true /* check_grpclb */,
       request_service_config_ ? &service_config_json_ : nullptr,
       query_timeout_ms_, combiner());
   last_resolution_timestamp_ = grpc_core::ExecCtx::Get()->Now();

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h
@@ -26,18 +26,10 @@
 #include "src/core/lib/gprpp/abstract.h"
 #include "src/core/lib/iomgr/pollset_set.h"
 
-typedef struct grpc_ares_ev_driver grpc_ares_ev_driver;
-
 /* Start \a ev_driver. It will keep working until all IO on its ares_channel is
    done, or grpc_ares_ev_driver_destroy() is called. It may notify the callbacks
    bound to its ares_channel when necessary. */
 void grpc_ares_ev_driver_start_locked(grpc_ares_ev_driver* ev_driver);
-
-/* Returns the ares_channel owned by \a ev_driver. To bind a c-ares query to
-   \a ev_driver, use the ares_channel owned by \a ev_driver as the arg of the
-   query. */
-ares_channel* grpc_ares_ev_driver_get_channel_locked(
-    grpc_ares_ev_driver* ev_driver);
 
 /* Creates a new grpc_ares_ev_driver. Returns GRPC_ERROR_NONE if \a ev_driver is
    created successfully. */

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_fallback.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_fallback.cc
@@ -20,6 +20,8 @@
 
 #if GRPC_ARES != 1 || defined(GRPC_UV)
 
+#include <ares.h>
+
 #include "src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h"
 
 struct grpc_ares_request {
@@ -27,8 +29,9 @@ struct grpc_ares_request {
 };
 
 static grpc_ares_request* grpc_dns_lookup_ares_locked_impl(
-    const char* dns_server, const char* name, const char* default_port,
-    grpc_pollset_set* interested_parties, grpc_closure* on_done,
+    ares_channel c_ares_channel, const char* dns_server, const char* name,
+    const char* default_port, grpc_pollset_set* interested_parties,
+    grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addrs,
     bool check_grpclb, char** service_config_json, int query_timeout_ms,
     grpc_combiner* combiner) {
@@ -36,8 +39,9 @@ static grpc_ares_request* grpc_dns_lookup_ares_locked_impl(
 }
 
 grpc_ares_request* (*grpc_dns_lookup_ares_locked)(
-    const char* dns_server, const char* name, const char* default_port,
-    grpc_pollset_set* interested_parties, grpc_closure* on_done,
+    ares_channel c_ares_channel, const char* dns_server, const char* name,
+    const char* default_port, grpc_pollset_set* interested_parties,
+    grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addrs,
     bool check_grpclb, char** service_config_json, int query_timeout_ms,
     grpc_combiner* combiner) = grpc_dns_lookup_ares_locked_impl;

--- a/test/core/client_channel/resolvers/dns_resolver_connectivity_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_connectivity_test.cc
@@ -21,6 +21,8 @@
 #include <grpc/grpc.h>
 #include <grpc/support/alloc.h>
 
+#include <ares.h>
+
 #include "src/core/ext/filters/client_channel/resolver.h"
 #include "src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h"
 #include "src/core/ext/filters/client_channel/resolver_registry.h"
@@ -61,8 +63,9 @@ static grpc_address_resolver_vtable test_resolver = {my_resolve_address,
                                                      nullptr};
 
 static grpc_ares_request* my_dns_lookup_ares_locked(
-    const char* dns_server, const char* addr, const char* default_port,
-    grpc_pollset_set* interested_parties, grpc_closure* on_done,
+    ares_channel c_ares_channel, const char* dns_server, const char* addr,
+    const char* default_port, grpc_pollset_set* interested_parties,
+    grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
     bool check_grpclb, char** service_config_json, int query_timeout_ms,
     grpc_combiner* combiner) {

--- a/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_cooldown_test.cc
@@ -39,8 +39,9 @@ static grpc_address_resolver_vtable* default_resolve_address;
 static grpc_combiner* g_combiner;
 
 static grpc_ares_request* (*g_default_dns_lookup_ares_locked)(
-    const char* dns_server, const char* name, const char* default_port,
-    grpc_pollset_set* interested_parties, grpc_closure* on_done,
+    ares_channel c_ares_channel, const char* dns_server, const char* name,
+    const char* default_port, grpc_pollset_set* interested_parties,
+    grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
     bool check_grpclb, char** service_config_json, int query_timeout_ms,
     grpc_combiner* combiner);
@@ -90,14 +91,16 @@ static grpc_address_resolver_vtable test_resolver = {
     test_resolve_address_impl, test_blocking_resolve_address_impl};
 
 static grpc_ares_request* test_dns_lookup_ares_locked(
-    const char* dns_server, const char* name, const char* default_port,
-    grpc_pollset_set* interested_parties, grpc_closure* on_done,
+    ares_channel c_ares_channel, const char* dns_server, const char* name,
+    const char* default_port, grpc_pollset_set* interested_parties,
+    grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
     bool check_grpclb, char** service_config_json, int query_timeout_ms,
     grpc_combiner* combiner) {
   grpc_ares_request* result = g_default_dns_lookup_ares_locked(
-      dns_server, name, default_port, g_iomgr_args.pollset_set, on_done,
-      addresses, check_grpclb, service_config_json, query_timeout_ms, combiner);
+      c_ares_channel, dns_server, name, default_port, g_iomgr_args.pollset_set,
+      on_done, addresses, check_grpclb, service_config_json, query_timeout_ms,
+      combiner);
   ++g_resolution_count;
   static grpc_millis last_resolution_time = 0;
   if (last_resolution_time == 0) {

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -375,8 +375,9 @@ static grpc_address_resolver_vtable fuzzer_resolver = {my_resolve_address,
                                                        nullptr};
 
 grpc_ares_request* my_dns_lookup_ares_locked(
-    const char* dns_server, const char* addr, const char* default_port,
-    grpc_pollset_set* interested_parties, grpc_closure* on_done,
+    ares_channel c_ares_channel, const char* dns_server, const char* addr,
+    const char* default_port, grpc_pollset_set* interested_parties,
+    grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
     bool check_grpclb, char** service_config_json, int query_timeout,
     grpc_combiner* combiner) {

--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -45,8 +45,9 @@ static gpr_mu g_mu;
 static int g_resolve_port = -1;
 
 static grpc_ares_request* (*iomgr_dns_lookup_ares_locked)(
-    const char* dns_server, const char* addr, const char* default_port,
-    grpc_pollset_set* interested_parties, grpc_closure* on_done,
+    ares_channel c_ares_channel, const char* dns_server, const char* addr,
+    const char* default_port, grpc_pollset_set* interested_parties,
+    grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
     bool check_grpclb, char** service_config_json, int query_timeout_ms,
     grpc_combiner* combiner);
@@ -102,15 +103,17 @@ static grpc_address_resolver_vtable test_resolver = {
     my_resolve_address, my_blocking_resolve_address};
 
 static grpc_ares_request* my_dns_lookup_ares_locked(
-    const char* dns_server, const char* addr, const char* default_port,
-    grpc_pollset_set* interested_parties, grpc_closure* on_done,
+    ares_channel c_ares_channel, const char* dns_server, const char* addr,
+    const char* default_port, grpc_pollset_set* interested_parties,
+    grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
     bool check_grpclb, char** service_config_json, int query_timeout_ms,
     grpc_combiner* combiner) {
   if (0 != strcmp(addr, "test")) {
     return iomgr_dns_lookup_ares_locked(
-        dns_server, addr, default_port, interested_parties, on_done, addresses,
-        check_grpclb, service_config_json, query_timeout_ms, combiner);
+        c_ares_channel, dns_server, addr, default_port, interested_parties,
+        on_done, addresses, check_grpclb, service_config_json, query_timeout_ms,
+        combiner);
   }
 
   grpc_error* error = GRPC_ERROR_NONE;


### PR DESCRIPTION
... to the reduce number of expensive calls to `ares_init_options`

From investigations, it looks like `concurrent_connectivity_test` is flaking in https://github.com/grpc/grpc/pull/16862 when c-ares is used because sometimes `watch connectivity state` calls aren't able to complete within their deadline because their completion closures get held up on a slow executor. It looks like c-ares queries are what's slowing things down, mostly due to `ares_init_options` (and `ares__init_list_head`)