### PR TITLE
Reset the SendMessage pointer before post-interception hooks

### DIFF
--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -325,7 +325,11 @@ class CallOpSendMessage {
   }
 
   void SetFinishInterceptionHookPoint(
-      InterceptorBatchMethodsImpl* interceptor_methods) {}
+      InterceptorBatchMethodsImpl* interceptor_methods) {
+    // The contents of the SendMessage value that was previously set
+    // has had its references stolen by core's operations
+    interceptor_methods->SetSendMessage(nullptr);
+  }
 
   void SetHijackingState(InterceptorBatchMethodsImpl* interceptor_methods) {
     hijacked_ = true;


### PR DESCRIPTION
Sending a message steals the references from the send byte-buffer, so clear this pointer before reaching the post-interceptor calls. If the post-interceptors need this value, they should do a byte buffer copy during the pre-interception hooks (and byte buffer copy is inexpensive cf #17510)

Cc: @tsalomie

