### PR TITLE
prevent setting wrong time on macos high sierra kokoro workers

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -19,14 +19,6 @@
 launchctl limit maxfiles
 ulimit -a
 
-# synchronize the clock
-date
-sudo systemsetup -setusingnetworktime off
-sudo systemsetup -setnetworktimeserver "$( ipconfig getoption en0 server_identifier )"
-sudo systemsetup -settimezone America/Los_Angeles
-sudo systemsetup -setusingnetworktime on
-date
-
 # Add GCP credentials for BQ access
 pip install google-api-python-client oauth2client --user python
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json


### PR DESCRIPTION
Context: b/120214184

Setting "systemsetup -setusingnetworktime on" makes macos high sierra workers restore wrong time from snapshot. These commands were introduced long time ago and are no longer needed (and they are breaking tests on macos high sierra kokoro workers).