### PR TITLE
Use http_archive only with urls attribute.

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -110,7 +110,9 @@ def grpc_deps():
         http_archive(
             name = "boringssl",
             # on the chromium-stable-with-bazel branch
-            url = "https://boringssl.googlesource.com/boringssl/+archive/afc30d43eef92979b05776ec0963c9cede5fb80f.tar.gz",
+            urls = [
+                 "https://boringssl.googlesource.com/boringssl/+archive/afc30d43eef92979b05776ec0963c9cede5fb80f.tar.gz",
+            ],
         )
 
     if "com_github_madler_zlib" not in native.existing_rules():
@@ -118,14 +120,18 @@ def grpc_deps():
             name = "com_github_madler_zlib",
             build_file = "@com_github_grpc_grpc//third_party:zlib.BUILD",
             strip_prefix = "zlib-cacf7f1d4e3d44d871b605da3b647f07d718623f",
-            url = "https://github.com/madler/zlib/archive/cacf7f1d4e3d44d871b605da3b647f07d718623f.tar.gz",
+            urls = [
+                 "https://github.com/madler/zlib/archive/cacf7f1d4e3d44d871b605da3b647f07d718623f.tar.gz",
+            ],
         )
 
     if "com_google_protobuf" not in native.existing_rules():
         http_archive(
             name = "com_google_protobuf",
             strip_prefix = "protobuf-48cb18e5c419ddd23d9badcfe4e9df7bde1979b2",
-            url = "https://github.com/google/protobuf/archive/48cb18e5c419ddd23d9badcfe4e9df7bde1979b2.tar.gz",
+            urls = [
+                 "https://github.com/google/protobuf/archive/48cb18e5c419ddd23d9badcfe4e9df7bde1979b2.tar.gz",
+            ],
         )
 
     if "com_github_nanopb_nanopb" not in native.existing_rules():
@@ -133,7 +139,9 @@ def grpc_deps():
             name = "com_github_nanopb_nanopb",
             build_file = "@com_github_grpc_grpc//third_party:nanopb.BUILD",
             strip_prefix = "nanopb-f8ac463766281625ad710900479130c7fcb4d63b",
-            url = "https://github.com/nanopb/nanopb/archive/f8ac463766281625ad710900479130c7fcb4d63b.tar.gz",
+            urls = [
+                 "https://github.com/nanopb/nanopb/archive/f8ac463766281625ad710900479130c7fcb4d63b.tar.gz",
+            ],
         )
 
     if "com_github_google_googletest" not in native.existing_rules():
@@ -141,14 +149,18 @@ def grpc_deps():
             name = "com_github_google_googletest",
             build_file = "@com_github_grpc_grpc//third_party:gtest.BUILD",
             strip_prefix = "googletest-ec44c6c1675c25b9827aacd08c02433cccde7780",
-            url = "https://github.com/google/googletest/archive/ec44c6c1675c25b9827aacd08c02433cccde7780.tar.gz",
+            urls = [
+                 "https://github.com/google/googletest/archive/ec44c6c1675c25b9827aacd08c02433cccde7780.tar.gz",
+            ],
         )
 
     if "com_github_gflags_gflags" not in native.existing_rules():
         http_archive(
             name = "com_github_gflags_gflags",
             strip_prefix = "gflags-30dbc81fb5ffdc98ea9b14b1918bfe4e8779b26e",
-            url = "https://github.com/gflags/gflags/archive/30dbc81fb5ffdc98ea9b14b1918bfe4e8779b26e.tar.gz",
+            urls = [
+                 "https://github.com/gflags/gflags/archive/30dbc81fb5ffdc98ea9b14b1918bfe4e8779b26e.tar.gz",
+            ],
         )
 
     if "com_github_google_benchmark" not in native.existing_rules():
@@ -156,7 +168,9 @@ def grpc_deps():
             name = "com_github_google_benchmark",
             build_file = "@com_github_grpc_grpc//third_party:benchmark.BUILD",
             strip_prefix = "benchmark-9913418d323e64a0111ca0da81388260c2bbe1e9",
-            url = "https://github.com/google/benchmark/archive/9913418d323e64a0111ca0da81388260c2bbe1e9.tar.gz",
+            urls = [
+                 "https://github.com/google/benchmark/archive/9913418d323e64a0111ca0da81388260c2bbe1e9.tar.gz",
+            ],
         )
 
     if "com_github_cares_cares" not in native.existing_rules():
@@ -164,14 +178,18 @@ def grpc_deps():
             name = "com_github_cares_cares",
             build_file = "@com_github_grpc_grpc//third_party:cares/cares.BUILD",
             strip_prefix = "c-ares-3be1924221e1326df520f8498d704a5c4c8d0cce",
-            url = "https://github.com/c-ares/c-ares/archive/3be1924221e1326df520f8498d704a5c4c8d0cce.tar.gz",
+            urls = [
+                 "https://github.com/c-ares/c-ares/archive/3be1924221e1326df520f8498d704a5c4c8d0cce.tar.gz",
+            ],
         )
 
     if "com_google_absl" not in native.existing_rules():
         http_archive(
             name = "com_google_absl",
             strip_prefix = "abseil-cpp-cd95e71df6eaf8f2a282b1da556c2cf1c9b09207",
-            url = "https://github.com/abseil/abseil-cpp/archive/cd95e71df6eaf8f2a282b1da556c2cf1c9b09207.tar.gz",
+            urls = [
+                 "https://github.com/abseil/abseil-cpp/archive/cd95e71df6eaf8f2a282b1da556c2cf1c9b09207.tar.gz",
+            ],
         )
 
     if "com_github_bazelbuild_bazeltoolchains" not in native.existing_rules():
@@ -189,14 +207,18 @@ def grpc_deps():
       http_archive(
             name = "io_opencensus_cpp",
             strip_prefix = "opencensus-cpp-fdf0f308b1631bb4a942e32ba5d22536a6170274",
-            url = "https://github.com/census-instrumentation/opencensus-cpp/archive/fdf0f308b1631bb4a942e32ba5d22536a6170274.tar.gz",
+            urls = [
+                 "https://github.com/census-instrumentation/opencensus-cpp/archive/fdf0f308b1631bb4a942e32ba5d22536a6170274.tar.gz",
+            ],
         )
 
     if "upb" not in native.existing_rules():
         http_archive(
             name = "upb",
             strip_prefix = "upb-9ce4a77f61c134bbed28bfd5be5cd7dc0e80f5e3",
-            url = "https://github.com/google/upb/archive/9ce4a77f61c134bbed28bfd5be5cd7dc0e80f5e3.tar.gz",
+            urls = [
+                 "https://github.com/google/upb/archive/9ce4a77f61c134bbed28bfd5be5cd7dc0e80f5e3.tar.gz",
+            ],
         )
 
 
@@ -218,7 +240,9 @@ def grpc_test_only_deps():
         http_archive(
             name = "com_github_twisted_twisted",
             strip_prefix = "twisted-twisted-17.5.0",
-            url = "https://github.com/twisted/twisted/archive/twisted-17.5.0.zip",
+            urls = [
+                 "https://github.com/twisted/twisted/archive/twisted-17.5.0.zip",
+            ],
             build_file = "@com_github_grpc_grpc//third_party:twisted.BUILD",
         )
 
@@ -226,7 +250,9 @@ def grpc_test_only_deps():
         http_archive(
             name = "com_github_yaml_pyyaml",
             strip_prefix = "pyyaml-3.12",
-            url = "https://github.com/yaml/pyyaml/archive/3.12.zip",
+            urls = [
+                 "https://github.com/yaml/pyyaml/archive/3.12.zip",
+            ],
             build_file = "@com_github_grpc_grpc//third_party:yaml.BUILD",
         )
 
@@ -234,7 +260,9 @@ def grpc_test_only_deps():
         http_archive(
             name = "com_github_twisted_incremental",
             strip_prefix = "incremental-incremental-17.5.0",
-            url = "https://github.com/twisted/incremental/archive/incremental-17.5.0.zip",
+            urls = [
+                "https://github.com/twisted/incremental/archive/incremental-17.5.0.zip",
+            ],
             build_file = "@com_github_grpc_grpc//third_party:incremental.BUILD",
         )
 
@@ -242,7 +270,9 @@ def grpc_test_only_deps():
         http_archive(
             name = "com_github_zopefoundation_zope_interface",
             strip_prefix = "zope.interface-4.4.3",
-            url = "https://github.com/zopefoundation/zope.interface/archive/4.4.3.zip",
+            urls = [
+                 "https://github.com/zopefoundation/zope.interface/archive/4.4.3.zip",
+            ],
             build_file = "@com_github_grpc_grpc//third_party:zope_interface.BUILD",
         )
 
@@ -250,6 +280,8 @@ def grpc_test_only_deps():
         http_archive(
             name = "com_github_twisted_constantly",
             strip_prefix = "constantly-15.1.0",
-            url = "https://github.com/twisted/constantly/archive/15.1.0.zip",
+            urls = [
+                 "https://github.com/twisted/constantly/archive/15.1.0.zip",
+            ],
             build_file = "@com_github_grpc_grpc//third_party:constantly.BUILD",
         )

--- a/tools/run_tests/sanity/check_bazel_workspace.py
+++ b/tools/run_tests/sanity/check_bazel_workspace.py
@@ -96,7 +96,7 @@ class BazelEvalState(object):
         if args['name'] in _GRPC_BAZEL_ONLY_DEPS:
             self.names_and_urls[args['name']] = 'dont care'
             return
-        self.names_and_urls[args['name']] = args['url']
+        self.names_and_urls[args['name']] = args['urls']
 
 
 # Parse git hashes from bazel/grpc_deps.bzl {new_}http_archive rules


### PR DESCRIPTION
Older versions of Bazel (which are still found in the wild) do not
provide the url attribute for the http_archive() Starlark (formerly
Skylark) rule.