### PR TITLE
Increase json run localhost timeout under tsan, preparation for enabling c-ares

### DIFF
--- a/test/core/util/test_config.h
+++ b/test/core/util/test_config.h
@@ -54,4 +54,11 @@ class TestEnvironment {
 }  // namespace testing
 }  // namespace grpc
 
+// Utilities to determine what the build config is
+bool BuiltUnderValgrind();
+bool BuiltUnderTsan();
+bool BuiltUnderAsan();
+bool BuiltUnderMsan();
+bool BuiltUnderUbsan();
+
 #endif /* GRPC_TEST_CORE_UTIL_TEST_CONFIG_H */


### PR DESCRIPTION
The 600 channel scenario under TSAN fails almost every time under c-ares (when ran under the bazel RBE TSAN suite). This is because QPS workers hit an [assertion failure](https://github.com/grpc/grpc/blob/master/test/cpp/qps/client.h#L506) because they fail to connect all channels to servers within the 10 second deadline in this configuration about every time.

As observable with logging, in this scenario/config, channels can sometimes spend huge amounts of time in [subchannel_index_register](https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/subchannel_index.cc#L160). I've seen the slowest-connecting channels spend just over a minute within a single call to `subchannel_index_register`, whie taking ~200 [passes](https://github.com/grpc/grpc/blob/master/src/core/ext/filters/client_channel/subchannel_index.cc#L192) through the while loop before finishing. However, I think this slowness makes sense here, and so increasing the test timeout is the right fix:
  a) all 600 channels artificially have [different args](https://github.com/grpc/grpc/blob/master/test/cpp/qps/client.h#L458), so there's no subchannel sharing
  b) Bazel RBE tests don't run on a lot of cores
  c) slow TSAN
  d) There's more room for concurrency with subchannel creation when c-ares is used than with the native resolver. When the native resolver is used, the number of concurrent DNS resolutions (and subsequent subchannel creations), is constrained by the number of resolver executor threads, but c-ares can run on all threads. Thus there are more chances for races during `subchannel_register_index` - e.g., [this PR](https://github.com/grpc/grpc/pull/17529) is an alternative "fix" for this issue.