### PR TITLE
Remove dependency of grpc.framework.foundation.callable_util

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -22,7 +22,6 @@ import grpc
 from grpc import _common
 from grpc import _grpcio_metadata
 from grpc._cython import cygrpc
-from grpc.framework.foundation import callable_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -871,9 +870,11 @@ def _deliver(state, initial_connectivity, initial_callbacks):
     while True:
         for callback in callbacks:
             cygrpc.block_if_fork_in_progress(state)
-            callable_util.call_logging_exceptions(
-                callback, _CHANNEL_SUBSCRIPTION_CALLBACK_ERROR_LOG_MESSAGE,
-                connectivity)
+            try:
+                callback(connectivity)
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception(
+                    _CHANNEL_SUBSCRIPTION_CALLBACK_ERROR_LOG_MESSAGE)
         with state.lock:
             callbacks = _deliveries(state)
             if callbacks:

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -25,7 +25,6 @@ import grpc
 from grpc import _common
 from grpc import _interceptor
 from grpc._cython import cygrpc
-from grpc.framework.foundation import callable_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -748,8 +747,10 @@ def _process_event_and_continue(state, event):
     else:
         rpc_state, callbacks = event.tag(event)
         for callback in callbacks:
-            callable_util.call_logging_exceptions(callback,
-                                                  'Exception calling callback!')
+            try:
+                callback()
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception('Exception calling callback!')
         if rpc_state is not None:
             with state.lock:
                 state.rpc_states.remove(rpc_state)

--- a/src/python/grpcio/grpc/_utilities.py
+++ b/src/python/grpcio/grpc/_utilities.py
@@ -16,12 +16,14 @@
 import collections
 import threading
 import time
+import logging
 
 import six
 
 import grpc
 from grpc import _common
-from grpc.framework.foundation import callable_util
+
+_LOGGER = logging.getLogger(__name__)
 
 _DONE_CALLBACK_EXCEPTION_LOG_MESSAGE = (
     'Exception calling connectivity future "done" callback!')
@@ -98,8 +100,10 @@ class _ChannelReadyFuture(grpc.Future):
                 return
 
         for done_callback in done_callbacks:
-            callable_util.call_logging_exceptions(
-                done_callback, _DONE_CALLBACK_EXCEPTION_LOG_MESSAGE, self)
+            try:
+                done_callback(self)
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception(_DONE_CALLBACK_EXCEPTION_LOG_MESSAGE)
 
     def cancel(self):
         with self._condition:
@@ -113,8 +117,10 @@ class _ChannelReadyFuture(grpc.Future):
                 return False
 
         for done_callback in done_callbacks:
-            callable_util.call_logging_exceptions(
-                done_callback, _DONE_CALLBACK_EXCEPTION_LOG_MESSAGE, self)
+            try:
+                done_callback(self)
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception(_DONE_CALLBACK_EXCEPTION_LOG_MESSAGE)
 
         return True
 


### PR DESCRIPTION
* Used in _channel.py, _server.py, and _utilities.py
* This API can trace back to 4 years ago
* The code change ensures the logging info is exactly the same

---

Current usage of `callable_util` diverged far from its original design. Now, in our code base, we only utilizes `callable_util. call_logging_exceptions` which underlying is doing a try/except and log a static message if exception raised. Here is the implementation:

```Python
class Outcome(six.with_metaclass(abc.ABCMeta)):
    """A sum type describing the outcome of some call.

  Attributes:
    kind: One of Kind.RETURNED or Kind.RAISED respectively indicating that the
      call returned a value or raised an exception.
    return_value: The value returned by the call. Must be present if kind is
      Kind.RETURNED.
    exception: The exception raised by the call. Must be present if kind is
      Kind.RAISED.
  """

    @enum.unique
    class Kind(enum.Enum):
        """Identifies the general kind of the outcome of some call."""

        RETURNED = object()
        RAISED = object()


class _EasyOutcome(
        collections.namedtuple('_EasyOutcome',
                               ['kind', 'return_value', 'exception']), Outcome):
    """A trivial implementation of Outcome."""

def _call_logging_exceptions(behavior, message, *args, **kwargs):
    try:
        return _EasyOutcome(Outcome.Kind.RETURNED, behavior(*args, **kwargs),
                            None)
    except Exception as e:  # pylint: disable=broad-except
        _LOGGER.exception(message)
        return _EasyOutcome(Outcome.Kind.RAISED, None, e)

def call_logging_exceptions(behavior, message, *args, **kwargs):
    """Calls a behavior in a try-except that logs any exceptions it raises.

  Args:
    behavior: Any callable.
    message: A string to log if the behavior raises an exception.
    *args: Positional arguments to pass to the given behavior.
    **kwargs: Keyword arguments to pass to the given behavior.

  Returns:
    An Outcome describing whether the given behavior returned a value or raised
      an exception.
  """
    return _call_logging_exceptions(behavior, message, *args, **kwargs)
```

The most important part here I presume is the Outcome class, which indicates the result of an callable execution. However, there is no logic in our code base that is accepting the return value of this function. As a result, to do a simplest try/except, this API needs to import 1 deep module, call 2 functions, define 1 abstract base class, and instantiate 1 implementation of that class. That's fair amount of abstraction...

Another point I am not clear is about the logging message. In current design, the logging message explicitly hides the exception details. The purpose of this design can be protecting user's PII from leaking out of exception details. Since this behavior is 4 years old, it is possible some applications depends on parsing the static logging message. So, I keep the logging message the same as before.