### PR TITLE
Const-ify Client/ServerRpcInfo structures

### DIFF
--- a/include/grpcpp/impl/codegen/client_interceptor.h
+++ b/include/grpcpp/impl/codegen/client_interceptor.h
@@ -41,7 +41,7 @@ class ClientRpcInfo;
 class ClientInterceptorFactoryInterface {
  public:
   virtual ~ClientInterceptorFactoryInterface() {}
-  virtual Interceptor* CreateClientInterceptor(ClientRpcInfo* info) = 0;
+  virtual Interceptor* CreateClientInterceptor(const ClientRpcInfo* info) = 0;
 };
 }  // namespace experimental
 
@@ -70,8 +70,8 @@ class ClientRpcInfo {
 
   // Getter methods
   const char* method() const { return method_; }
-  ChannelInterface* channel() { return channel_; }
-  grpc::ClientContext* client_context() { return ctx_; }
+  ChannelInterface* channel() const { return channel_; }
+  grpc::ClientContext* client_context() const { return ctx_; }
   Type type() const { return type_; }
 
  private:

--- a/include/grpcpp/impl/codegen/server_interceptor.h
+++ b/include/grpcpp/impl/codegen/server_interceptor.h
@@ -40,7 +40,7 @@ class ServerRpcInfo;
 class ServerInterceptorFactoryInterface {
  public:
   virtual ~ServerInterceptorFactoryInterface() {}
-  virtual Interceptor* CreateServerInterceptor(ServerRpcInfo* info) = 0;
+  virtual Interceptor* CreateServerInterceptor(const ServerRpcInfo* info) = 0;
 };
 
 class ServerRpcInfo {
@@ -56,7 +56,7 @@ class ServerRpcInfo {
   // Getter methods
   const char* method() const { return method_; }
   Type type() const { return type_; }
-  grpc::ServerContext* server_context() { return ctx_; }
+  grpc::ServerContext* server_context() const { return ctx_; }
 
  private:
   static_assert(Type::UNARY ==

--- a/test/cpp/end2end/client_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/client_interceptors_end2end_test.cc
@@ -46,8 +46,7 @@ namespace {
 /* Hijacks Echo RPC and fills in the expected values */
 class HijackingInterceptor : public experimental::Interceptor {
  public:
-  HijackingInterceptor(experimental::ClientRpcInfo* info) {
-    info_ = info;
+  HijackingInterceptor(const experimental::ClientRpcInfo* info) : info_(info) {
     // Make sure it is the right method
     EXPECT_EQ(strcmp("/grpc.testing.EchoTestService/Echo", info->method()), 0);
     EXPECT_EQ(info->type(), experimental::ClientRpcInfo::Type::UNARY);
@@ -138,22 +137,22 @@ class HijackingInterceptor : public experimental::Interceptor {
   }
 
  private:
-  experimental::ClientRpcInfo* info_;
+  const experimental::ClientRpcInfo* info_;
 };
 
 class HijackingInterceptorFactory
     : public experimental::ClientInterceptorFactoryInterface {
  public:
   virtual experimental::Interceptor* CreateClientInterceptor(
-      experimental::ClientRpcInfo* info) override {
+      const experimental::ClientRpcInfo* info) override {
     return new HijackingInterceptor(info);
   }
 };
 
 class HijackingInterceptorMakesAnotherCall : public experimental::Interceptor {
  public:
-  HijackingInterceptorMakesAnotherCall(experimental::ClientRpcInfo* info) {
-    info_ = info;
+  HijackingInterceptorMakesAnotherCall(const experimental::ClientRpcInfo* info)
+      : info_(info) {
     // Make sure it is the right method
     EXPECT_EQ(strcmp("/grpc.testing.EchoTestService/Echo", info->method()), 0);
   }
@@ -253,7 +252,7 @@ class HijackingInterceptorMakesAnotherCall : public experimental::Interceptor {
   }
 
  private:
-  experimental::ClientRpcInfo* info_;
+  const experimental::ClientRpcInfo* info_;
   std::multimap<grpc::string, grpc::string> metadata_map_;
   ClientContext ctx_;
   EchoRequest req_;
@@ -265,14 +264,14 @@ class HijackingInterceptorMakesAnotherCallFactory
     : public experimental::ClientInterceptorFactoryInterface {
  public:
   virtual experimental::Interceptor* CreateClientInterceptor(
-      experimental::ClientRpcInfo* info) override {
+      const experimental::ClientRpcInfo* info) override {
     return new HijackingInterceptorMakesAnotherCall(info);
   }
 };
 
 class LoggingInterceptor : public experimental::Interceptor {
  public:
-  LoggingInterceptor(experimental::ClientRpcInfo* info) { info_ = info; }
+  LoggingInterceptor(const experimental::ClientRpcInfo* info) : info_(info) {}
 
   virtual void Intercept(experimental::InterceptorBatchMethods* methods) {
     if (methods->QueryInterceptionHookPoint(
@@ -328,14 +327,14 @@ class LoggingInterceptor : public experimental::Interceptor {
   }
 
  private:
-  experimental::ClientRpcInfo* info_;
+  const experimental::ClientRpcInfo* info_;
 };
 
 class LoggingInterceptorFactory
     : public experimental::ClientInterceptorFactoryInterface {
  public:
   virtual experimental::Interceptor* CreateClientInterceptor(
-      experimental::ClientRpcInfo* info) override {
+      const experimental::ClientRpcInfo* info) override {
     return new LoggingInterceptor(info);
   }
 };

--- a/test/cpp/end2end/interceptors_util.h
+++ b/test/cpp/end2end/interceptors_util.h
@@ -72,12 +72,12 @@ class DummyInterceptorFactory
       public experimental::ServerInterceptorFactoryInterface {
  public:
   virtual experimental::Interceptor* CreateClientInterceptor(
-      experimental::ClientRpcInfo* info) override {
+      const experimental::ClientRpcInfo* info) override {
     return new DummyInterceptor();
   }
 
   virtual experimental::Interceptor* CreateServerInterceptor(
-      experimental::ServerRpcInfo* info) override {
+      const experimental::ServerRpcInfo* info) override {
     return new DummyInterceptor();
   }
 };

--- a/test/cpp/end2end/server_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/server_interceptors_end2end_test.cc
@@ -44,9 +44,7 @@ namespace {
 
 class LoggingInterceptor : public experimental::Interceptor {
  public:
-  LoggingInterceptor(experimental::ServerRpcInfo* info) {
-    info_ = info;
-
+  LoggingInterceptor(const experimental::ServerRpcInfo* info) {
     // Check the method name and compare to the type
     const char* method = info->method();
     experimental::ServerRpcInfo::Type type = info->type();
@@ -128,16 +126,13 @@ class LoggingInterceptor : public experimental::Interceptor {
     }
     methods->Proceed();
   }
-
- private:
-  experimental::ServerRpcInfo* info_;
 };
 
 class LoggingInterceptorFactory
     : public experimental::ServerInterceptorFactoryInterface {
  public:
   virtual experimental::Interceptor* CreateServerInterceptor(
-      experimental::ServerRpcInfo* info) override {
+      const experimental::ServerRpcInfo* info) override {
     return new LoggingInterceptor(info);
   }
 };


### PR DESCRIPTION
Not sure if this is a good idea: they have no setters, so that's a pro. But these are not really "morally" const since you can use them to peer into the Context and set deadlines, metadata, etc. Just for consideration.

Cc: @tsalomie , wdyt?
