### PR TITLE
Properly version grpcpp_channelz so library in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4873,6 +4873,11 @@ add_library(grpcpp_channelz
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/channelz/channelz.grpc.pb.h
 )
 
+if(_gRPC_PLATFORM_LINUX)
+  set_property(TARGET grpcpp_channelz PROPERTY VERSION ${CPP_VERSION})
+  set_property(TARGET grpcpp_channelz PROPERTY SOVERSION ${CPP_VERSION_MAJOR})
+endif()
+
 if(WIN32 AND MSVC)
   set_target_properties(grpcpp_channelz PROPERTIES COMPILE_PDB_NAME "grpcpp_channelz"
     COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"


### PR DESCRIPTION
In CMake currently only a libgrpcpp_channelz.so is created not a versioned
file. This change adds the proper symlinks like for all the other libraries.

Signed-off-by: Pascal Bach <pascal.bach@siemens.com>