### PR TITLE
Disable 600+ channel json_run_localhost scenarios from RBE TSAN runs

### DIFF
--- a/test/cpp/qps/qps_benchmark_script.bzl
+++ b/test/cpp/qps/qps_benchmark_script.bzl
@@ -56,6 +56,15 @@ def qps_json_driver_batch():
 
 def json_run_localhost_batch():
     for scenario in JSON_RUN_LOCALHOST_SCENARIOS:
+        extra_tags = []
+        configs = JSON_RUN_LOCALHOST_SCENARIOS[scenario]
+        # sanity check
+        assert len(configs) == 1
+        client_config = configs[0]['client_config']
+        channels_per_client = client_config['client_channels']
+        num_clients = client_config['num_clients']
+        if num_clients * channels_per_client >= 600:
+            extra_tags += 'json_run_localhost_600_or_more_channels'
         grpc_cc_test(
             name = "json_run_localhost_%s" % scenario,
             srcs = ["json_run_localhost.cc"],
@@ -75,5 +84,5 @@ def json_run_localhost_batch():
             ],
             tags = [
                 "json_run_localhost",
-            ],
+            ] + extra_tags,
         )

--- a/tools/internal_ci/linux/grpc_tsan_on_foundry.sh
+++ b/tools/internal_ci/linux/grpc_tsan_on_foundry.sh
@@ -16,4 +16,5 @@
 set -ex
 
 export UPLOAD_TEST_RESULTS=true
-github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh --config=tsan --cache_test_results=no
+EXCLUDE_TESTS="--test_tag_filters=-json_run_localhost_600_or_more_channels"
+github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh --config=tsan --cache_test_results=no "${EXCLUDE_TESTS}"

--- a/tools/internal_ci/linux/pull_request/grpc_tsan_on_foundry.sh
+++ b/tools/internal_ci/linux/pull_request/grpc_tsan_on_foundry.sh
@@ -15,4 +15,5 @@
 
 set -ex
 
-github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh --config=tsan
+EXCLUDE_TESTS="--test_tag_filters=-json_run_localhost_600_or_more_channels"
+github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh --config=tsan "${EXCLUDE_TESTS}"


### PR DESCRIPTION
Per conversation in https://github.com/grpc/grpc/pull/17539 (which this PR is an alternative to)

One way to do this that might be better is to just have a blacklist of scenario names; I wasn't sure, if there are thoughts on that.

