### PR TITLE
Correctly reference the internal string for socket mutator arg

### DIFF
--- a/src/cpp/common/channel_arguments.cc
+++ b/src/cpp/common/channel_arguments.cc
@@ -106,7 +106,9 @@ void ChannelArguments::SetSocketMutator(grpc_socket_mutator* mutator) {
   }
 
   if (!replaced) {
+    strings_.push_back(grpc::string(mutator_arg.key));
     args_.push_back(mutator_arg);
+    args_.back().key = const_cast<char*>(strings_.back().c_str());
   }
 }
 

--- a/test/cpp/common/channel_arguments_test.cc
+++ b/test/cpp/common/channel_arguments_test.cc
@@ -209,6 +209,9 @@ TEST_F(ChannelArgumentsTest, SetSocketMutator) {
   channel_args_.SetSocketMutator(mutator0);
   EXPECT_TRUE(HasArg(arg0));
 
+  // Exercise the copy constructor because we ran some sanity checks in it.
+  grpc::ChannelArguments new_args{channel_args_};
+
   channel_args_.SetSocketMutator(mutator1);
   EXPECT_TRUE(HasArg(arg1));
   // arg0 is replaced by arg1


### PR DESCRIPTION
Caught by an internal test.

Otherwise it will fail the check in copy ctor because the `char* key` is not pointing to the internal `strings_` buffer element.

