### PR TITLE
Clean up server and channel objects in tests

### DIFF
--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -133,6 +133,7 @@ class TestGevent(setuptools.Command):
         # This test will stuck while running higher version of gevent
         'unit._auth_context_test.AuthContextTest.testSessionResumption',
         # TODO(https://github.com/grpc/grpc/issues/15411) enable these tests
+        'unit._metadata_flags_test',
         'unit._exit_test.ExitTest.test_in_flight_unary_unary_call',
         'unit._exit_test.ExitTest.test_in_flight_unary_stream_call',
         'unit._exit_test.ExitTest.test_in_flight_stream_unary_call',

--- a/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
+++ b/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
@@ -39,8 +39,12 @@ class HealthServicerTest(unittest.TestCase):
         health_pb2_grpc.add_HealthServicer_to_server(servicer, self._server)
         self._server.start()
 
-        channel = grpc.insecure_channel('localhost:%d' % port)
-        self._stub = health_pb2_grpc.HealthStub(channel)
+        self._channel = grpc.insecure_channel('localhost:%d' % port)
+        self._stub = health_pb2_grpc.HealthStub(self._channel)
+
+    def tearDown(self):
+        self._server.stop(None)
+        self._channel.close()
 
     def test_empty_service(self):
         request = health_pb2.HealthCheckRequest()

--- a/src/python/grpcio_tests/tests/reflection/_reflection_servicer_test.py
+++ b/src/python/grpcio_tests/tests/reflection/_reflection_servicer_test.py
@@ -56,8 +56,12 @@ class ReflectionServicerTest(unittest.TestCase):
         port = self._server.add_insecure_port('[::]:0')
         self._server.start()
 
-        channel = grpc.insecure_channel('localhost:%d' % port)
-        self._stub = reflection_pb2_grpc.ServerReflectionStub(channel)
+        self._channel = grpc.insecure_channel('localhost:%d' % port)
+        self._stub = reflection_pb2_grpc.ServerReflectionStub(self._channel)
+
+    def tearDown(self):
+        self._server.stop(None)
+        self._channel.close()
 
     def testFileByName(self):
         requests = (

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -101,6 +101,7 @@ class ChannelTest(unittest.TestCase):
     def test_secure_channel(self):
         channel_credentials = grpc.ssl_channel_credentials()
         channel = grpc.secure_channel('google.com:443', channel_credentials)
+        channel.close()
 
 
 if __name__ == '__main__':

--- a/src/python/grpcio_tests/tests/unit/_auth_context_test.py
+++ b/src/python/grpcio_tests/tests/unit/_auth_context_test.py
@@ -71,8 +71,8 @@ class AuthContextTest(unittest.TestCase):
         port = server.add_insecure_port('[::]:0')
         server.start()
 
-        channel = grpc.insecure_channel('localhost:%d' % port)
-        response = channel.unary_unary(_UNARY_UNARY)(_REQUEST)
+        with grpc.insecure_channel('localhost:%d' % port) as channel:
+            response = channel.unary_unary(_UNARY_UNARY)(_REQUEST)
         server.stop(None)
 
         auth_data = pickle.loads(response)
@@ -98,6 +98,7 @@ class AuthContextTest(unittest.TestCase):
             channel_creds,
             options=_PROPERTY_OPTIONS)
         response = channel.unary_unary(_UNARY_UNARY)(_REQUEST)
+        channel.close()
         server.stop(None)
 
         auth_data = pickle.loads(response)
@@ -132,6 +133,7 @@ class AuthContextTest(unittest.TestCase):
             options=_PROPERTY_OPTIONS)
 
         response = channel.unary_unary(_UNARY_UNARY)(_REQUEST)
+        channel.close()
         server.stop(None)
 
         auth_data = pickle.loads(response)

--- a/src/python/grpcio_tests/tests/unit/_channel_connectivity_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_connectivity_test.py
@@ -75,6 +75,8 @@ class ChannelConnectivityTest(unittest.TestCase):
         channel.unsubscribe(callback.update)
         fifth_connectivities = callback.connectivities()
 
+        channel.close()
+
         self.assertSequenceEqual((grpc.ChannelConnectivity.IDLE,),
                                  first_connectivities)
         self.assertNotIn(grpc.ChannelConnectivity.READY, second_connectivities)
@@ -108,7 +110,8 @@ class ChannelConnectivityTest(unittest.TestCase):
             _ready_in_connectivities)
         second_callback.block_until_connectivities_satisfy(
             _ready_in_connectivities)
-        del channel
+        channel.close()
+        server.stop(None)
 
         self.assertSequenceEqual((grpc.ChannelConnectivity.IDLE,),
                                  first_connectivities)
@@ -139,6 +142,7 @@ class ChannelConnectivityTest(unittest.TestCase):
         callback.block_until_connectivities_satisfy(
             _last_connectivity_is_not_ready)
         channel.unsubscribe(callback.update)
+        channel.close()
         self.assertFalse(thread_pool.was_used())
 
 

--- a/src/python/grpcio_tests/tests/unit/_channel_ready_future_test.py
+++ b/src/python/grpcio_tests/tests/unit/_channel_ready_future_test.py
@@ -60,6 +60,8 @@ class ChannelReadyFutureTest(unittest.TestCase):
         self.assertTrue(ready_future.done())
         self.assertFalse(ready_future.running())
 
+        channel.close()
+
     def test_immediately_connectable_channel_connectivity(self):
         thread_pool = _thread_pool.RecordingThreadPool(max_workers=None)
         server = grpc.server(thread_pool, options=(('grpc.so_reuseport', 0),))
@@ -83,6 +85,9 @@ class ChannelReadyFutureTest(unittest.TestCase):
         self.assertTrue(ready_future.done())
         self.assertFalse(ready_future.running())
         self.assertFalse(thread_pool.was_used())
+
+        channel.close()
+        server.stop(None)
 
 
 if __name__ == '__main__':

--- a/src/python/grpcio_tests/tests/unit/_compression_test.py
+++ b/src/python/grpcio_tests/tests/unit/_compression_test.py
@@ -77,6 +77,9 @@ class CompressionTest(unittest.TestCase):
         self._port = self._server.add_insecure_port('[::]:0')
         self._server.start()
 
+    def tearDown(self):
+        self._server.stop(None)
+
     def testUnary(self):
         request = b'\x00' * 100
 
@@ -102,6 +105,7 @@ class CompressionTest(unittest.TestCase):
         response = multi_callable(
             request, metadata=[('grpc-internal-encoding-request', 'gzip')])
         self.assertEqual(request, response)
+        compressed_channel.close()
 
     def testStreaming(self):
         request = b'\x00' * 100
@@ -115,6 +119,7 @@ class CompressionTest(unittest.TestCase):
         call = multi_callable(iter([request] * test_constants.STREAM_LENGTH))
         for response in call:
             self.assertEqual(request, response)
+        compressed_channel.close()
 
 
 if __name__ == '__main__':

--- a/src/python/grpcio_tests/tests/unit/_empty_message_test.py
+++ b/src/python/grpcio_tests/tests/unit/_empty_message_test.py
@@ -96,6 +96,7 @@ class EmptyMessageTest(unittest.TestCase):
 
     def tearDown(self):
         self._server.stop(0)
+        self._channel.close()
 
     def testUnaryUnary(self):
         response = self._channel.unary_unary(_UNARY_UNARY)(_REQUEST)

--- a/src/python/grpcio_tests/tests/unit/_error_message_encoding_test.py
+++ b/src/python/grpcio_tests/tests/unit/_error_message_encoding_test.py
@@ -71,6 +71,7 @@ class ErrorMessageEncodingTest(unittest.TestCase):
 
     def tearDown(self):
         self._server.stop(0)
+        self._channel.close()
 
     def testMessageEncoding(self):
         for message in _UNICODE_ERROR_MESSAGES:

--- a/src/python/grpcio_tests/tests/unit/_interceptor_test.py
+++ b/src/python/grpcio_tests/tests/unit/_interceptor_test.py
@@ -337,6 +337,7 @@ class InterceptorTest(unittest.TestCase):
     def tearDown(self):
         self._server.stop(None)
         self._server_pool.shutdown(wait=True)
+        self._channel.close()
 
     def testTripleRequestMessagesClientInterceptor(self):
 

--- a/src/python/grpcio_tests/tests/unit/_invalid_metadata_test.py
+++ b/src/python/grpcio_tests/tests/unit/_invalid_metadata_test.py
@@ -62,6 +62,9 @@ class InvalidMetadataTest(unittest.TestCase):
         self._stream_unary = _stream_unary_multi_callable(self._channel)
         self._stream_stream = _stream_stream_multi_callable(self._channel)
 
+    def tearDown(self):
+        self._channel.close()
+
     def testUnaryRequestBlockingUnaryResponse(self):
         request = b'\x07\x08'
         metadata = (('InVaLiD', 'UnaryRequestBlockingUnaryResponse'),)

--- a/src/python/grpcio_tests/tests/unit/_invocation_defects_test.py
+++ b/src/python/grpcio_tests/tests/unit/_invocation_defects_test.py
@@ -215,6 +215,7 @@ class InvocationDefectsTest(unittest.TestCase):
 
     def tearDown(self):
         self._server.stop(0)
+        self._channel.close()
 
     def testIterableStreamRequestBlockingUnaryResponse(self):
         requests = [b'\x07\x08' for _ in range(test_constants.STREAM_LENGTH)]

--- a/src/python/grpcio_tests/tests/unit/_metadata_code_details_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_code_details_test.py
@@ -198,8 +198,8 @@ class MetadataCodeDetailsTest(unittest.TestCase):
         port = self._server.add_insecure_port('[::]:0')
         self._server.start()
 
-        channel = grpc.insecure_channel('localhost:{}'.format(port))
-        self._unary_unary = channel.unary_unary(
+        self._channel = grpc.insecure_channel('localhost:{}'.format(port))
+        self._unary_unary = self._channel.unary_unary(
             '/'.join((
                 '',
                 _SERVICE,
@@ -208,17 +208,17 @@ class MetadataCodeDetailsTest(unittest.TestCase):
             request_serializer=_REQUEST_SERIALIZER,
             response_deserializer=_RESPONSE_DESERIALIZER,
         )
-        self._unary_stream = channel.unary_stream('/'.join((
+        self._unary_stream = self._channel.unary_stream('/'.join((
             '',
             _SERVICE,
             _UNARY_STREAM,
         )),)
-        self._stream_unary = channel.stream_unary('/'.join((
+        self._stream_unary = self._channel.stream_unary('/'.join((
             '',
             _SERVICE,
             _STREAM_UNARY,
         )),)
-        self._stream_stream = channel.stream_stream(
+        self._stream_stream = self._channel.stream_stream(
             '/'.join((
                 '',
                 _SERVICE,
@@ -227,6 +227,10 @@ class MetadataCodeDetailsTest(unittest.TestCase):
             request_serializer=_REQUEST_SERIALIZER,
             response_deserializer=_RESPONSE_DESERIALIZER,
         )
+
+    def tearDown(self):
+        self._server.stop(None)
+        self._channel.close()
 
     def testSuccessfulUnaryUnary(self):
         self._servicer.set_details(_DETAILS)

--- a/src/python/grpcio_tests/tests/unit/_metadata_test.py
+++ b/src/python/grpcio_tests/tests/unit/_metadata_test.py
@@ -186,6 +186,7 @@ class MetadataTest(unittest.TestCase):
 
     def tearDown(self):
         self._server.stop(0)
+        self._channel.close()
 
     def testUnaryUnary(self):
         multi_callable = self._channel.unary_unary(_UNARY_UNARY)

--- a/src/python/grpcio_tests/tests/unit/_reconnect_test.py
+++ b/src/python/grpcio_tests/tests/unit/_reconnect_test.py
@@ -98,6 +98,8 @@ class ReconnectTest(unittest.TestCase):
         server.add_insecure_port('[::]:{}'.format(port))
         server.start()
         self.assertEqual(_RESPONSE, multi_callable(_REQUEST))
+        server.stop(None)
+        channel.close()
 
 
 if __name__ == '__main__':

--- a/src/python/grpcio_tests/tests/unit/_resource_exhausted_test.py
+++ b/src/python/grpcio_tests/tests/unit/_resource_exhausted_test.py
@@ -148,6 +148,7 @@ class ResourceExhaustedTest(unittest.TestCase):
 
     def tearDown(self):
         self._server.stop(0)
+        self._channel.close()
 
     def testUnaryUnary(self):
         multi_callable = self._channel.unary_unary(_UNARY_UNARY)

--- a/src/python/grpcio_tests/tests/unit/_rpc_test.py
+++ b/src/python/grpcio_tests/tests/unit/_rpc_test.py
@@ -193,6 +193,7 @@ class RPCTest(unittest.TestCase):
 
     def tearDown(self):
         self._server.stop(None)
+        self._channel.close()
 
     def testUnrecognizedMethod(self):
         request = b'abc'


### PR DESCRIPTION
Use `server.stop` and `channel.close`.

Part of resolving https://github.com/grpc/grpc/issues/15537