### PR TITLE
Expose version

### DIFF
--- a/doc/python/sphinx/grpc.rst
+++ b/doc/python/sphinx/grpc.rst
@@ -19,6 +19,11 @@ Go to `gRPC Python Examples <https://github.com/grpc/grpc/tree/master/examples/p
 Module Contents
 ---------------
 
+Version
+^^^^^^^
+
+The version string is available as :code:`grpc.__version__`.
+
 Create Client
 ^^^^^^^^^^^^^
 

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -23,6 +23,11 @@ from grpc._cython import cygrpc as _cygrpc
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
+try:
+    from ._grpcio_metadata import __version__
+except ImportError:
+    __version__ = "dev0"
+
 ############################## Future Interface  ###############################
 
 

--- a/src/python/grpcio_tests/tests/tests.json
+++ b/src/python/grpcio_tests/tests/tests.json
@@ -64,6 +64,7 @@
   "unit._server_ssl_cert_config_test.ServerSSLCertReloadTestWithoutClientAuth",
   "unit._server_test.ServerTest",
   "unit._session_cache_test.SSLSessionCacheTest",
+  "unit._version_test.VersionTest",
   "unit.beta._beta_features_test.BetaFeaturesTest",
   "unit.beta._beta_features_test.ContextManagementAndLifecycleTest",
   "unit.beta._connectivity_channel_test.ConnectivityStatesTest",

--- a/src/python/grpcio_tests/tests/unit/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/BUILD.bazel
@@ -7,6 +7,7 @@ GRPCIO_TESTS_UNIT = [
     "_api_test.py",
     "_auth_context_test.py",
     "_auth_test.py",
+    "_version_test.py",
     "_channel_args_test.py",
     "_channel_close_test.py",
     "_channel_connectivity_test.py",

--- a/src/python/grpcio_tests/tests/unit/_version_test.py
+++ b/src/python/grpcio_tests/tests/unit/_version_test.py
@@ -1,0 +1,30 @@
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Test for grpc.__version__"""
+
+import unittest
+import grpc
+import logging
+from grpc import _grpcio_metadata
+
+
+class VersionTest(unittest.TestCase):
+
+    def test_get_version(self):
+        self.assertEqual(grpc.__version__, _grpcio_metadata.__version__)
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Addresses #17572

This PR adds a programmatic API to retrieve the version of gRPC. This method is already in use [within numpy](https://github.com/numpy/numpy/blob/master/numpy/__init__.py#L134) and is described in detail in [PEP 396](https://www.python.org/dev/peps/pep-0396/).