### PR TITLE
Fix bazel build for fling, memory_usage test

### DIFF
--- a/test/core/fling/BUILD
+++ b/test/core/fling/BUILD
@@ -21,7 +21,7 @@ licenses(["notice"])  # Apache v2
 load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
 
 grpc_cc_binary(
-    name = "client",
+    name = "fling_client",
     testonly = 1,
     srcs = ["client.cc"],
     language = "C++",
@@ -34,7 +34,7 @@ grpc_cc_binary(
 )
 
 grpc_cc_binary(
-    name = "server",
+    name = "fling_server",
     testonly = 1,
     srcs = ["server.cc"],
     language = "C++",
@@ -50,8 +50,8 @@ grpc_cc_test(
     name = "fling",
     srcs = ["fling_test.cc"],
     data = [
-        ":client",
-        ":server",
+        ":fling_client",
+        ":fling_server",
     ],
     deps = [
         "//:gpr",
@@ -65,8 +65,8 @@ grpc_cc_test(
     name = "fling_stream",
     srcs = ["fling_stream_test.cc"],
     data = [
-        ":client",
-        ":server",
+        ":fling_client",
+        ":fling_server",
     ],
     deps = [
         "//:gpr",

--- a/test/core/memory_usage/BUILD
+++ b/test/core/memory_usage/BUILD
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/memory_usage")
 
 licenses(["notice"])  # Apache v2
 
-grpc_cc_library(
-    name = "client",
+grpc_cc_binary(
+    name = "memory_usage_client",
     testonly = 1,
     srcs = ["client.cc"],
     deps = [
@@ -29,8 +29,8 @@ grpc_cc_library(
     ],
 )
 
-grpc_cc_library(
-    name = "server",
+grpc_cc_binary(
+    name = "memory_usage_server",
     testonly = 1,
     srcs = ["server.cc"],
     deps = [
@@ -45,8 +45,8 @@ grpc_cc_test(
     name = "memory_usage_test",
     srcs = ["memory_usage_test.cc"],
     data = [
-        ":client",
-        ":server",
+        ":memory_usage_client",
+        ":memory_usage_server",
     ],
     language = "C++",
     deps = [


### PR DESCRIPTION
Automated tests for core are built using Makefile. Bazel build for a couple of tests was broken, fixed as part of this commit.