### PR TITLE
* Fixed issue(17563) "Freeing heap block containing an active critical section."

### DIFF
--- a/src/core/lib/iomgr/resource_quota.cc
+++ b/src/core/lib/iomgr/resource_quota.cc
@@ -665,6 +665,7 @@ void grpc_resource_quota_unref_internal(grpc_resource_quota* resource_quota) {
     GPR_ASSERT(resource_quota->num_threads_allocated == 0);
     GRPC_COMBINER_UNREF(resource_quota->combiner, "resource_quota");
     gpr_free(resource_quota->name);
+    gpr_mu_destroy(&resource_quota->thread_count_mu);
     gpr_free(resource_quota);
   }
 }

--- a/src/core/lib/transport/metadata.cc
+++ b/src/core/lib/transport/metadata.cc
@@ -187,6 +187,7 @@ static void gc_mdtab(mdtab_shard* shard) {
           ((destroy_user_data_func)gpr_atm_no_barrier_load(
               &md->destroy_user_data))(user_data);
         }
+        gpr_mu_destroy(&md->mu_user_data);
         gpr_free(md);
         *prev_next = next;
         num_freed++;


### PR DESCRIPTION
* Fixed issue([17563](https://github.com/grpc/grpc/issues/17563)) "Freeing heap block containing an active critical section" reported by Application Verifier on Windows.
  - This issue always encounters exception(crash) when running on Windows with [Microsoft Application Verifier](https://www.microsoft.com/en-us/download/details.aspx?id=20028).