### PR TITLE
Fix incompatible_bzl_disallow_load_after_statement, deprecated attribute usage

### DIFF
--- a/bazel/cc_grpc_library.bzl
+++ b/bazel/cc_grpc_library.bzl
@@ -1,6 +1,6 @@
 """Generates and compiles C++ grpc stubs from proto_library rules."""
 
-load("//:bazel/generate_cc.bzl", "generate_cc")
+load("//bazel:generate_cc.bzl", "generate_cc")
 
 def cc_grpc_library(name, srcs, deps, proto_only, well_known_protos, generate_mocks = False, use_external = False, **kwargs):
   """Generates C++ grpc classes from a .proto file.

--- a/bazel/generate_cc.bzl
+++ b/bazel/generate_cc.bzl
@@ -83,7 +83,7 @@ _generate_cc = rule(
     attrs = {
         "srcs": attr.label_list(
             mandatory = True,
-            non_empty = True,
+            allow_empty = False,
             providers = ["proto"],
         ),
         "plugin": attr.label(

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -23,6 +23,8 @@
 # each change must be ported from one to the other.
 #
 
+load("//bazel:cc_grpc_library.bzl", "cc_grpc_library")
+
 # The set of pollers to test against if a test exercises polling
 POLLERS = ["epollex", "epoll1", "poll", "poll-cv"]
 
@@ -111,7 +113,6 @@ def grpc_proto_plugin(name, srcs = [], deps = []):
         deps = deps,
     )
 
-load("//:bazel/cc_grpc_library.bzl", "cc_grpc_library")
 
 def grpc_proto_library(
         name,


### PR DESCRIPTION
Fixes `bazel` upcoming incompatible changes (found by `--all_incompatible_changes`)