### PR TITLE
Support for dllexport_decl option in grpc plugin for C++ (like protoc)

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -167,7 +167,7 @@ grpc::string GetHeaderIncludes(grpc_generator::File* file,
 
 void PrintHeaderClientMethodInterfaces(
     grpc_generator::Printer* printer, const grpc_generator::Method* method,
-    std::map<grpc::string, grpc::string>* vars, bool is_public) {
+    std::map<grpc::string, grpc::string>* vars, bool is_public, const Parameters& params) {
   (*vars)["Method"] = method->name();
   (*vars)["Request"] = method->input_type_name();
   (*vars)["Response"] = method->output_type_name();
@@ -181,12 +181,20 @@ void PrintHeaderClientMethodInterfaces(
 
   if (is_public) {
     if (method->NoStreaming()) {
+      if (!params.dllexport_decl.empty()) {
+        printer->Print(params.dllexport_decl.c_str());
+        printer->Print(" ");
+      }
       printer->Print(
           *vars,
           "virtual ::grpc::Status $Method$(::grpc::ClientContext* context, "
           "const $Request$& request, $Response$* response) = 0;\n");
       for (auto async_prefix : async_prefixes) {
         (*vars)["AsyncPrefix"] = async_prefix.prefix;
+        if (!params.dllexport_decl.empty()) {
+            printer->Print(params.dllexport_decl.c_str());
+            printer->Print(" ");
+        }
         printer->Print(
             *vars,
             "std::unique_ptr< "
@@ -204,6 +212,10 @@ void PrintHeaderClientMethodInterfaces(
         printer->Print("}\n");
       }
     } else if (ClientOnlyStreaming(method)) {
+      if (!params.dllexport_decl.empty()) {
+          printer->Print(params.dllexport_decl.c_str());
+          printer->Print(" ");
+      }
       printer->Print(
           *vars,
           "std::unique_ptr< ::grpc::ClientWriterInterface< $Request$>>"
@@ -220,6 +232,10 @@ void PrintHeaderClientMethodInterfaces(
         (*vars)["AsyncPrefix"] = async_prefix.prefix;
         (*vars)["AsyncMethodParams"] = async_prefix.method_params;
         (*vars)["AsyncRawArgs"] = async_prefix.raw_args;
+        if (!params.dllexport_decl.empty()) {
+            printer->Print(params.dllexport_decl.c_str());
+            printer->Print(" ");
+        }
         printer->Print(
             *vars,
             "std::unique_ptr< ::grpc::ClientAsyncWriterInterface< $Request$>>"
@@ -237,6 +253,10 @@ void PrintHeaderClientMethodInterfaces(
         printer->Print("}\n");
       }
     } else if (ServerOnlyStreaming(method)) {
+      if (!params.dllexport_decl.empty()) {
+          printer->Print(params.dllexport_decl.c_str());
+          printer->Print(" ");
+      }
       printer->Print(
           *vars,
           "std::unique_ptr< ::grpc::ClientReaderInterface< $Response$>>"
@@ -253,6 +273,10 @@ void PrintHeaderClientMethodInterfaces(
         (*vars)["AsyncPrefix"] = async_prefix.prefix;
         (*vars)["AsyncMethodParams"] = async_prefix.method_params;
         (*vars)["AsyncRawArgs"] = async_prefix.raw_args;
+        if (!params.dllexport_decl.empty()) {
+            printer->Print(params.dllexport_decl.c_str());
+            printer->Print(" ");
+        }
         printer->Print(
             *vars,
             "std::unique_ptr< ::grpc::ClientAsyncReaderInterface< $Response$>> "
@@ -269,6 +293,10 @@ void PrintHeaderClientMethodInterfaces(
         printer->Print("}\n");
       }
     } else if (method->BidiStreaming()) {
+      if (!params.dllexport_decl.empty()) {
+          printer->Print(params.dllexport_decl.c_str());
+          printer->Print(" ");
+      }
       printer->Print(*vars,
                      "std::unique_ptr< ::grpc::ClientReaderWriterInterface< "
                      "$Request$, $Response$>> "
@@ -285,6 +313,10 @@ void PrintHeaderClientMethodInterfaces(
         (*vars)["AsyncPrefix"] = async_prefix.prefix;
         (*vars)["AsyncMethodParams"] = async_prefix.method_params;
         (*vars)["AsyncRawArgs"] = async_prefix.raw_args;
+        if (!params.dllexport_decl.empty()) {
+            printer->Print(params.dllexport_decl.c_str());
+            printer->Print(" ");
+        }
         printer->Print(
             *vars,
             "std::unique_ptr< "
@@ -366,7 +398,7 @@ void PrintHeaderClientMethodInterfaces(
 void PrintHeaderClientMethod(grpc_generator::Printer* printer,
                              const grpc_generator::Method* method,
                              std::map<grpc::string, grpc::string>* vars,
-                             bool is_public) {
+                             bool is_public, const Parameters& params) {
   (*vars)["Method"] = method->name();
   (*vars)["Request"] = method->input_type_name();
   (*vars)["Response"] = method->output_type_name();
@@ -379,12 +411,20 @@ void PrintHeaderClientMethod(grpc_generator::Printer* printer,
 
   if (is_public) {
     if (method->NoStreaming()) {
+      if (!params.dllexport_decl.empty()) {
+          printer->Print(params.dllexport_decl.c_str());
+          printer->Print(" ");
+      }
       printer->Print(
           *vars,
           "::grpc::Status $Method$(::grpc::ClientContext* context, "
           "const $Request$& request, $Response$* response) override;\n");
       for (auto async_prefix : async_prefixes) {
         (*vars)["AsyncPrefix"] = async_prefix.prefix;
+        if (!params.dllexport_decl.empty()) {
+            printer->Print(params.dllexport_decl.c_str());
+            printer->Print(" ");
+        }
         printer->Print(
             *vars,
             "std::unique_ptr< ::grpc::ClientAsyncResponseReader< $Response$>> "
@@ -400,6 +440,10 @@ void PrintHeaderClientMethod(grpc_generator::Printer* printer,
         printer->Print("}\n");
       }
     } else if (ClientOnlyStreaming(method)) {
+      if (!params.dllexport_decl.empty()) {
+          printer->Print(params.dllexport_decl.c_str());
+          printer->Print(" ");
+      }
       printer->Print(
           *vars,
           "std::unique_ptr< ::grpc::ClientWriter< $Request$>>"
@@ -415,6 +459,10 @@ void PrintHeaderClientMethod(grpc_generator::Printer* printer,
         (*vars)["AsyncPrefix"] = async_prefix.prefix;
         (*vars)["AsyncMethodParams"] = async_prefix.method_params;
         (*vars)["AsyncRawArgs"] = async_prefix.raw_args;
+        if (!params.dllexport_decl.empty()) {
+            printer->Print(params.dllexport_decl.c_str());
+            printer->Print(" ");
+        }
         printer->Print(*vars,
                        "std::unique_ptr< ::grpc::ClientAsyncWriter< $Request$>>"
                        " $AsyncPrefix$$Method$(::grpc::ClientContext* context, "
@@ -430,6 +478,10 @@ void PrintHeaderClientMethod(grpc_generator::Printer* printer,
         printer->Print("}\n");
       }
     } else if (ServerOnlyStreaming(method)) {
+      if (!params.dllexport_decl.empty()) {
+          printer->Print(params.dllexport_decl.c_str());
+          printer->Print(" ");
+      }
       printer->Print(
           *vars,
           "std::unique_ptr< ::grpc::ClientReader< $Response$>>"
@@ -446,6 +498,10 @@ void PrintHeaderClientMethod(grpc_generator::Printer* printer,
         (*vars)["AsyncPrefix"] = async_prefix.prefix;
         (*vars)["AsyncMethodParams"] = async_prefix.method_params;
         (*vars)["AsyncRawArgs"] = async_prefix.raw_args;
+        if (!params.dllexport_decl.empty()) {
+            printer->Print(params.dllexport_decl.c_str());
+            printer->Print(" ");
+        }
         printer->Print(
             *vars,
             "std::unique_ptr< ::grpc::ClientAsyncReader< $Response$>> "
@@ -461,6 +517,10 @@ void PrintHeaderClientMethod(grpc_generator::Printer* printer,
         printer->Print("}\n");
       }
     } else if (method->BidiStreaming()) {
+      if (!params.dllexport_decl.empty()) {
+          printer->Print(params.dllexport_decl.c_str());
+          printer->Print(" ");
+      }
       printer->Print(
           *vars,
           "std::unique_ptr< ::grpc::ClientReaderWriter< $Request$, $Response$>>"
@@ -476,6 +536,10 @@ void PrintHeaderClientMethod(grpc_generator::Printer* printer,
         (*vars)["AsyncPrefix"] = async_prefix.prefix;
         (*vars)["AsyncMethodParams"] = async_prefix.method_params;
         (*vars)["AsyncRawArgs"] = async_prefix.raw_args;
+        if (!params.dllexport_decl.empty()) {
+            printer->Print(params.dllexport_decl.c_str());
+            printer->Print(" ");
+        }
         printer->Print(*vars,
                        "std::unique_ptr<  ::grpc::ClientAsyncReaderWriter< "
                        "$Request$, $Response$>> "
@@ -693,11 +757,16 @@ void PrintHeaderClientMethodData(grpc_generator::Printer* printer,
 
 void PrintHeaderServerMethodSync(grpc_generator::Printer* printer,
                                  const grpc_generator::Method* method,
-                                 std::map<grpc::string, grpc::string>* vars) {
+                                 std::map<grpc::string, grpc::string>* vars, 
+                                 const Parameters& params) {
   (*vars)["Method"] = method->name();
   (*vars)["Request"] = method->input_type_name();
   (*vars)["Response"] = method->output_type_name();
   printer->Print(method->GetLeadingComments("//").c_str());
+  if (!params.dllexport_decl.empty()) {
+      printer->Print(params.dllexport_decl.c_str());
+      printer->Print(" ");
+  }
   if (method->NoStreaming()) {
     printer->Print(*vars,
                    "virtual ::grpc::Status $Method$("
@@ -1267,7 +1336,8 @@ void PrintHeaderServerMethodRaw(grpc_generator::Printer* printer,
 
 void PrintHeaderService(grpc_generator::Printer* printer,
                         const grpc_generator::Service* service,
-                        std::map<grpc::string, grpc::string>* vars) {
+                        std::map<grpc::string, grpc::string>* vars,
+                        const Parameters& params) {
   (*vars)["Service"] = service->name();
 
   printer->Print(service->GetLeadingComments("//").c_str());
@@ -1287,11 +1357,15 @@ void PrintHeaderService(grpc_generator::Printer* printer,
       "class StubInterface {\n"
       " public:\n");
   printer->Indent();
+  if (!params.dllexport_decl.empty()) {
+      printer->Print(params.dllexport_decl.c_str());
+      printer->Print(" ");
+  }
   printer->Print("virtual ~StubInterface() {}\n");
   for (int i = 0; i < service->method_count(); ++i) {
     printer->Print(service->method(i)->GetLeadingComments("//").c_str());
     PrintHeaderClientMethodInterfaces(printer, service->method(i).get(), vars,
-                                      true);
+                                      true, params);
     printer->Print(service->method(i)->GetTrailingComments("//").c_str());
   }
   PrintHeaderClientMethodCallbackInterfacesStart(printer, vars);
@@ -1307,7 +1381,7 @@ void PrintHeaderService(grpc_generator::Printer* printer,
   printer->Indent();
   for (int i = 0; i < service->method_count(); ++i) {
     PrintHeaderClientMethodInterfaces(printer, service->method(i).get(), vars,
-                                      false);
+                                      false, params);
   }
   printer->Outdent();
   printer->Print("};\n");
@@ -1315,11 +1389,15 @@ void PrintHeaderService(grpc_generator::Printer* printer,
       "class Stub final : public StubInterface"
       " {\n public:\n");
   printer->Indent();
+  if (!params.dllexport_decl.empty()) {
+      printer->Print(params.dllexport_decl.c_str());
+      printer->Print(" ");
+  }
   printer->Print(
       "Stub(const std::shared_ptr< ::grpc::ChannelInterface>& "
       "channel);\n");
   for (int i = 0; i < service->method_count(); ++i) {
-    PrintHeaderClientMethod(printer, service->method(i).get(), vars, true);
+    PrintHeaderClientMethod(printer, service->method(i).get(), vars, true, params);
   }
   PrintHeaderClientMethodCallbackStart(printer, vars);
   for (int i = 0; i < service->method_count(); ++i) {
@@ -1333,13 +1411,17 @@ void PrintHeaderService(grpc_generator::Printer* printer,
   printer->Print("std::shared_ptr< ::grpc::ChannelInterface> channel_;\n");
   printer->Print("class experimental_async async_stub_{this};\n");
   for (int i = 0; i < service->method_count(); ++i) {
-    PrintHeaderClientMethod(printer, service->method(i).get(), vars, false);
+    PrintHeaderClientMethod(printer, service->method(i).get(), vars, false, params);
   }
   for (int i = 0; i < service->method_count(); ++i) {
     PrintHeaderClientMethodData(printer, service->method(i).get(), vars);
   }
   printer->Outdent();
   printer->Print("};\n");
+  if (!params.dllexport_decl.empty()) {
+      printer->Print(params.dllexport_decl.c_str());
+      printer->Print(" ");
+  }
   printer->Print(
       "static std::unique_ptr<Stub> NewStub(const std::shared_ptr< "
       "::grpc::ChannelInterface>& channel, "
@@ -1352,10 +1434,18 @@ void PrintHeaderService(grpc_generator::Printer* printer,
       "class Service : public ::grpc::Service {\n"
       " public:\n");
   printer->Indent();
+  if (!params.dllexport_decl.empty()) {
+      printer->Print(params.dllexport_decl.c_str());
+      printer->Print(" ");
+  }
   printer->Print("Service();\n");
+  if (!params.dllexport_decl.empty()) {
+      printer->Print(params.dllexport_decl.c_str());
+      printer->Print(" ");
+  }
   printer->Print("virtual ~Service();\n");
   for (int i = 0; i < service->method_count(); ++i) {
-    PrintHeaderServerMethodSync(printer, service->method(i).get(), vars);
+    PrintHeaderServerMethodSync(printer, service->method(i).get(), vars, params);
   }
   printer->Outdent();
   printer->Print("};\n");
@@ -1507,7 +1597,7 @@ grpc::string GetHeaderServices(grpc_generator::File* file,
     }
 
     for (int i = 0; i < file->service_count(); ++i) {
-      PrintHeaderService(printer.get(), file->service(i).get(), &vars);
+      PrintHeaderService(printer.get(), file->service(i).get(), &vars, params);
       printer->Print("\n");
     }
 

--- a/src/compiler/cpp_generator.h
+++ b/src/compiler/cpp_generator.h
@@ -56,6 +56,8 @@ struct Parameters {
   grpc::string gmock_search_path;
   // *EXPERIMENTAL* Additional include files in grpc.pb.h
   std::vector<grpc::string> additional_header_includes;
+  // Generate preprocessor definitions near services declaration for export symbols from dll's
+  grpc::string dllexport_decl;
 };
 
 // Return the prologue of the generated header file.

--- a/src/compiler/cpp_plugin.cc
+++ b/src/compiler/cpp_plugin.cc
@@ -83,7 +83,11 @@ class CppGrpcGenerator : public grpc::protobuf::compiler::CodeGenerator {
         } else if (param[0] == "additional_header_includes") {
           generator_parameters.additional_header_includes =
               grpc_generator::tokenize(param[1], ":");
-        } else {
+        }
+        else if (param[0] == "dllexport_decl") {
+            generator_parameters.dllexport_decl = param[1];
+        }
+        else {
           *error = grpc::string("Unknown parameter: ") + *parameter_string;
           return false;
         }


### PR DESCRIPTION
### Problem
Default _protoc_ can append _dllexport_ macro to auto generated files of protobuf messages (*.pb.h), but grpc plugin for protobuf can't do it.

### About changes
Added support of _dllexport_decl_ command line argument to C++ grpc plugin to generate grpc services (*.grpc.pb.h) with _dllexport_ macro like protoc style.

### How to use
```
protoc.exe Example.proto --cpp_out=dllexport_decl=EXAMPLE_DLL_EXPORT:%cpp_gen_path% --proto_path=%proto_path%
protoc.exe Example.proto --grpc_out=dllexport_decl=EXAMPLE_DLL_EXPORT:%cpp_gen_path% --plugin=protoc-gen-grpc=grpc_cpp_plugin.exe --proto_path=%proto_path%
```

### Notes

- It does not change existing logic of grpc plugin when call it without _dllexport_decl_ option.
- Also this option implemented exactly the same as in protoc and can be helpful for all, who use grpc on windows.