### PR TITLE
Add ruby 2.6 build settings for mac and windows

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -124,10 +124,10 @@ task 'gem:native' do
         "invoked on macos with ruby #{RUBY_VERSION}. The ruby macos artifact " \
         "build should be running on ruby 2.5."
     end
-    system "rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0:2.3.0:2.2.2:2.1.6:2.0.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
+    system "rake cross native gem RUBY_CC_VERSION=2.6.0:2.5.0:2.4.0:2.3.0:2.2.2:2.1.6:2.0.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
   else
     Rake::Task['dlls'].execute
-    docker_for_windows "gem update --system --no-ri --no-doc && bundle && rake cross native gem RUBY_CC_VERSION=2.5.0:2.4.0:2.3.0:2.2.2:2.1.6:2.0.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
+    docker_for_windows "gem update --system --no-ri --no-doc && bundle && rake cross native gem RUBY_CC_VERSION=2.6.0:2.5.0:2.4.0:2.3.0:2.2.2:2.1.6:2.0.0 V=#{verbose} GRPC_CONFIG=#{grpc_config}"
   end
 end
 

--- a/tools/distrib/build_ruby_environment_macos.sh
+++ b/tools/distrib/build_ruby_environment_macos.sh
@@ -49,7 +49,7 @@ EOF
 
 MAKE="make -j8"
 
-for v in 2.5.0 2.4.0 2.3.0 2.2.2 2.1.6 2.0.0-p645 ; do
+for v in 2.6.0 2.5.0 2.4.0 2.3.0 2.2.2 2.1.6 2.0.0-p645 ; do
   ccache -c
   rake -f "$CROSS_RUBY" cross-ruby VERSION="$v" HOST=x86_64-darwin11 MAKE="$MAKE"
 done


### PR DESCRIPTION
ruby 2.6 is released.
https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/

So, add ruby 2.6 build settings for mac and windows.

`python tools/run_tests/run_tests.py -l ruby --build_only` is OK.
However `python tools/run_tests/run_tests.py -l ruby` is failed by RuboCop check...