### PR TITLE
To get the underlying byte buffer so flatbuffers could use it

### DIFF
--- a/include/grpcpp/impl/codegen/byte_buffer.h
+++ b/include/grpcpp/impl/codegen/byte_buffer.h
@@ -150,6 +150,9 @@ class ByteBuffer final {
   /// Is this ByteBuffer valid?
   bool Valid() const { return (buffer_ != nullptr); }
 
+  /// To get the underlying byte buffer
+  grpc_byte_buffer* get_buffer() const { return buffer_; }
+
  private:
   friend class SerializationTraits<ByteBuffer, void>;
   friend class ServerInterface;


### PR DESCRIPTION
Flatbuffers want to deserialize the bytes and put it into its data structure, but there is no interface to get it.

More generally, if we add the interface, it saves us to add a reader and set it as a friend class of ByteBuffer, like we have done with `ProtoBufferReader`. This make GRPC supports other underlying serialization/deserialization library better.

The motivation of this change is from [this](https://github.com/google/flatbuffers/issues/5096) and [this](https://github.com/google/flatbuffers/issues/5099).