### PR TITLE
To dump grpc byte buffer into one Slice

### DIFF
--- a/include/grpcpp/impl/codegen/byte_buffer.h
+++ b/include/grpcpp/impl/codegen/byte_buffer.h
@@ -112,6 +112,9 @@ class ByteBuffer final {
   /// Dump (read) the buffer contents into \a slices.
   Status Dump(std::vector<Slice>* slices) const;
 
+  /// Dump (read) the buffer contents into a Slice
+  Status Dump(Slice* slice) const;
+
   /// Remove all data.
   void Clear() {
     if (buffer_) {


### PR DESCRIPTION
An alternative solution to https://github.com/grpc/grpc/pull/17603. Although this one is heavier, it looks better to add another dump API for ByteBuffer.