### PR TITLE
Ruby tooling: respect user toolchain overrides

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -24,10 +24,18 @@ grpc_config = ENV['GRPC_CONFIG'] || 'opt'
 
 ENV['MACOSX_DEPLOYMENT_TARGET'] = '10.7'
 
-ENV['AR'] = RbConfig::CONFIG['AR'] + ' rcs'
-ENV['CC'] = RbConfig::CONFIG['CC']
-ENV['CXX'] = RbConfig::CONFIG['CXX']
-ENV['LD'] = ENV['CC']
+if ENV['AR'].nil? || ENV['AR'].size == 0
+    ENV['AR'] = RbConfig::CONFIG['AR'] + ' rcs'
+end
+if ENV['CC'].nil? || ENV['CC'].size == 0
+    ENV['CC'] = RbConfig::CONFIG['CC']
+end
+if ENV['CXX'].nil? || ENV['CXX'].size == 0
+    ENV['CXX'] = RbConfig::CONFIG['CXX']
+end
+if ENV['LD'].nil? || ENV['LD'].size == 0
+    ENV['LD'] = ENV['CC']
+end
 
 ENV['AR'] = 'libtool -o' if RUBY_PLATFORM =~ /darwin/
 


### PR DESCRIPTION
While compilation flag overrides for the Ruby native extension are
currently functional, specifying an alternate compiler is not, as the
Rbconfig values for key toolchain binaries are hardcoded at compile time
of the Ruby interpreter.  This patch allows them to be overrridden on
the command line via standard environment variables, defaulting to the
Rbconfig values only if unspecified by the user.