### PR TITLE
Properly detect the availability of pthread_setname_np()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,12 @@ endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
 
+include(CheckSymbolExists)
+check_symbol_exists(pthread_setname_np pthread.h HAVE_PTHREAD_SETNAME_NP)
+if (HAVE_PTHREAD_SETNAME_NP)
+  add_definitions(-DHAVE_PTHREAD_SETNAME_NP)
+endif ()
+
 add_definitions(-DPB_FIELD_16BIT)
 
 if (MSVC)

--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -173,7 +173,9 @@
 #endif /* _LP64 */
 #ifdef __GLIBC__
 #define GPR_POSIX_CRASH_HANDLER 1
+#if defined(HAVE_PTHREAD_SETNAME_NP)
 #define GPR_LINUX_PTHREAD_NAME 1
+#endif /* HAVE_PTHREAD_SETNAME_NP */
 #include <linux/version.h>
 #else /* musl libc */
 #define GPR_MUSL_LIBC_COMPAT 1


### PR DESCRIPTION
This commit adds a CMake check for the availability of
pthread_setname_np(), and only uses it on Linux when available.

Indeed, some C libraries, such as uClibc, do not provide this
non-POSIX function in all cases.

Signed-off-by: Thomas Petazzoni <thomas.petazzoni@bootlin.com>