### PR TITLE
Ruby: Loosen development dependencies

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -41,8 +41,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake-compiler-dock', '~> 0.5.1'
   s.add_development_dependency 'rspec',              '~> 3.6'
   s.add_development_dependency 'rubocop',            '~> 0.49.1'
-  s.add_development_dependency 'signet',             '~> 0.7.0'
-  s.add_development_dependency 'googleauth',         '>= 0.5.1', '< 0.7'
+  s.add_development_dependency 'signet',             '~> 0.7'
+  s.add_development_dependency 'googleauth',         '>= 0.5.1', '< 0.10'
 
   s.extensions = %w(src/ruby/ext/grpc/extconf.rb)
 

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -43,8 +43,8 @@
     s.add_development_dependency 'rake-compiler-dock', '~> 0.5.1'
     s.add_development_dependency 'rspec',              '~> 3.6'
     s.add_development_dependency 'rubocop',            '~> 0.49.1'
-    s.add_development_dependency 'signet',             '~> 0.7.0'
-    s.add_development_dependency 'googleauth',         '>= 0.5.1', '< 0.7'
+    s.add_development_dependency 'signet',             '~> 0.7'
+    s.add_development_dependency 'googleauth',         '>= 0.5.1', '< 0.10'
 
     s.extensions = %w(src/ruby/ext/grpc/extconf.rb)
 


### PR DESCRIPTION
Loosen the googleauth and signet dependencies to for recent versions to be used during development. The googleauth dependency is changed to match the dependency to be used by the google-api-client and google-gax gems. The team supporting googleauth has committed to not change backwards compatibility before 0.10.0.