### PR TITLE
[Channelz Page] Add an HTTP server to display debug information

### DIFF
--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -14,4 +14,3 @@ chardet==3.0.4
 certifi==2017.4.17
 idna==2.7
 googleapis-common-protos==1.5.5
-pyquery==1.2.4

--- a/requirements.bazel.txt
+++ b/requirements.bazel.txt
@@ -14,3 +14,4 @@ chardet==3.0.4
 certifi==2017.4.17
 idna==2.7
 googleapis-common-protos==1.5.5
+pyquery==1.2.4

--- a/src/python/grpcio/grpc/_cython/_cygrpc/channelz.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channelz.pyx.pxi
@@ -14,6 +14,8 @@
 
 
 def channelz_get_top_channels(start_channel_id):
+    if grpc_is_initialized() == 0:
+        raise RuntimeError('The gRPC library is not initialized.')
     cdef char *c_returned_str = grpc_channelz_get_top_channels(
         start_channel_id,
     )
@@ -23,6 +25,8 @@ def channelz_get_top_channels(start_channel_id):
     return c_returned_str
     
 def channelz_get_servers(start_server_id):
+    if grpc_is_initialized() == 0:
+        raise RuntimeError('The gRPC library is not initialized.')
     cdef char *c_returned_str = grpc_channelz_get_servers(start_server_id)
     if c_returned_str == NULL:
         raise ValueError('Failed to get servers, please ensure your' \
@@ -30,6 +34,8 @@ def channelz_get_servers(start_server_id):
     return c_returned_str
     
 def channelz_get_server(server_id):
+    if grpc_is_initialized() == 0:
+        raise RuntimeError('The gRPC library is not initialized.')
     cdef char *c_returned_str = grpc_channelz_get_server(server_id)
     if c_returned_str == NULL:
         raise ValueError('Failed to get the server, please ensure your' \
@@ -37,6 +43,8 @@ def channelz_get_server(server_id):
     return c_returned_str
     
 def channelz_get_server_sockets(server_id, start_socket_id, max_results):
+    if grpc_is_initialized() == 0:
+        raise RuntimeError('The gRPC library is not initialized.')
     cdef char *c_returned_str = grpc_channelz_get_server_sockets(
         server_id,
         start_socket_id,
@@ -50,6 +58,8 @@ def channelz_get_server_sockets(server_id, start_socket_id, max_results):
     return c_returned_str
     
 def channelz_get_channel(channel_id):
+    if grpc_is_initialized() == 0:
+        raise RuntimeError('The gRPC library is not initialized.')
     cdef char *c_returned_str = grpc_channelz_get_channel(channel_id)
     if c_returned_str == NULL:
         raise ValueError('Failed to get the channel, please ensure your' \
@@ -57,6 +67,8 @@ def channelz_get_channel(channel_id):
     return c_returned_str
     
 def channelz_get_subchannel(subchannel_id):
+    if grpc_is_initialized() == 0:
+        raise RuntimeError('The gRPC library is not initialized.')
     cdef char *c_returned_str = grpc_channelz_get_subchannel(subchannel_id)
     if c_returned_str == NULL:
         raise ValueError('Failed to get the subchannel, please ensure your' \
@@ -64,6 +76,8 @@ def channelz_get_subchannel(subchannel_id):
     return c_returned_str
     
 def channelz_get_socket(socket_id):
+    if grpc_is_initialized() == 0:
+        raise RuntimeError('The gRPC library is not initialized.')
     cdef char *c_returned_str = grpc_channelz_get_socket(socket_id)
     if c_returned_str == NULL:
         raise ValueError('Failed to get the socket, please ensure your' \

--- a/src/python/grpcio_channelz/MANIFEST.in
+++ b/src/python/grpcio_channelz/MANIFEST.in
@@ -2,3 +2,4 @@ include grpc_version.py
 recursive-include grpc_channelz *.py
 global-exclude *.pyc
 include LICENSE
+include grpc_channelz/v1/templates/*.html

--- a/src/python/grpcio_channelz/channelz_commands.py
+++ b/src/python/grpcio_channelz/channelz_commands.py
@@ -64,4 +64,5 @@ class BuildPackageProtos(setuptools.Command):
         # to `self.distribution.package_dir` (and get a key error if it's not
         # there).
         from grpc_tools import command
-        command.build_package_protos(self.distribution.package_dir[''])
+        command.build_package_protos(
+            self.distribution.package_dir['grpcio-channelz'])

--- a/src/python/grpcio_channelz/grpc_channelz/v1/BUILD.bazel
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/BUILD.bazel
@@ -27,12 +27,24 @@ py_proto_library(
     ],
 )
 
+filegroup(
+    name = "channelz_page_templates",
+    srcs = glob(["templates/*.html"]),
+)
+
 py_library(
     name = "grpc_channelz",
-    srcs = ["channelz.py",],
+    srcs = [
+        "channelz.py",
+        "_channelz_page.py",
+        "_renderer.py",
+    ],
     deps = [
         ":py_channelz_proto",
         "//src/python/grpcio/grpc:grpcio",
+    ],
+    data = [
+        "//src/python/grpcio_channelz/grpc_channelz/v1/templates",
     ],
     imports=["../../",],
 )

--- a/src/python/grpcio_channelz/grpc_channelz/v1/_channelz_page.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/_channelz_page.py
@@ -17,6 +17,7 @@ import pkgutil
 import collections
 import traceback
 from six.moves.BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from six.moves.urllib.parse import parse_qs, urlparse
 
 from grpc._cython import cygrpc
 import grpc_channelz.v1.channelz_pb2 as _channelz_pb2
@@ -43,13 +44,10 @@ _base_template = _fetch_template('base.html')
 
 
 def _parse_args(path):
-    if '?' not in path:
-        return {}
-    args = {}
-    args_list = path.split('?', 1)[1].split('&')
-    for arg_str in args_list:
-        key, value = arg_str.split('=')
-        args[key] = value
+    args = parse_qs(urlparse(path).query)
+    for key in args:
+        if isinstance(args[key], list) and len(args[key]) == 1:
+            args[key] = args[key][0]
     return args
 
 

--- a/src/python/grpcio_channelz/grpc_channelz/v1/_channelz_page.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/_channelz_page.py
@@ -1,0 +1,260 @@
+import os
+import pkgutil
+import collections
+import traceback
+from six.moves.BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+
+from grpc._cython import cygrpc
+import grpc_channelz.v1.channelz_pb2 as _channelz_pb2
+from google.protobuf import json_format
+
+from ._renderer import _Renderer
+
+_TEMPLATE_FOLDER = './templates'
+
+_PAGE = collections.namedtuple('_PAGE', ['title', 'template', 'handler'])
+_SERVER_N_SOCKETS = collections.namedtuple('_SERVER_N_SOCKETS',
+                                           ['server', 'listen_sockets'])
+
+_renderer = _Renderer()
+
+
+def _fetch_template(template_name):
+    return pkgutil.get_data(__name__,
+                            os.path.join(_TEMPLATE_FOLDER,
+                                         template_name)).decode('ASCII')
+
+
+_base_template = _fetch_template('base.html')
+
+
+def _parse_args(path):
+    if '?' not in path:
+        return {}
+    args = {}
+    args_list = path.split('?', 1)[1].split('&')
+    for arg_str in args_list:
+        key, value = arg_str.split('=')
+        args[key] = value
+    return args
+
+
+class _NotFound(Exception):
+    pass
+
+
+class _BadRequest(Exception):
+    pass
+
+
+def _homepage_handler(render, unused_args):
+    return render()
+
+
+def _topchannels_handler(render, args):
+    start_channel_id = int(args.get('start_channel_id', '0'))
+    topchannels = json_format.Parse(
+        cygrpc.channelz_get_top_channels(start_channel_id),
+        _channelz_pb2.GetTopChannelsResponse(),
+    ).channel
+    if not topchannels:
+        raise _NotFound(
+            'No channel found for "start_channel_id"==%d' % start_channel_id)
+    return render(
+        topchannels=topchannels,
+        num_channel=len(topchannels),
+        min_id=min(channel.ref.channel_id for channel in topchannels),
+        max_id=max(channel.ref.channel_id for channel in topchannels))
+
+
+def _channel_handler(render, args):
+    if 'channel_id' not in args:
+        raise _BadRequest('"channel_id" cannot be empty')
+    channel_id = int(args.get('channel_id'))
+    channel = json_format.Parse(
+        cygrpc.channelz_get_channel(channel_id),
+        _channelz_pb2.GetChannelResponse(),
+    ).channel
+
+    nested_channels = []
+    for ref in channel.channel_ref:
+        nested_channels.append(
+            json_format.Parse(
+                cygrpc.channelz_get_channel(ref.channel_id),
+                _channelz_pb2.GetChannelResponse(),
+            ).channel)
+
+    subchannels = []
+    for ref in channel.subchannel_ref:
+        subchannels.append(
+            json_format.Parse(
+                cygrpc.channelz_get_subchannel(ref.subchannel_id),
+                _channelz_pb2.GetSubchannelResponse(),
+            ).subchannel)
+
+    return render(
+        channel=channel,
+        nested_channels=nested_channels,
+        subchannels=subchannels)
+
+
+def _subchannel_handler(render, args):
+    if 'subchannel_id' not in args:
+        raise _BadRequest('"subchannel_id" cannot be empty')
+    subchannel_id = int(args.get('subchannel_id'))
+    subchannel = json_format.Parse(
+        cygrpc.channelz_get_subchannel(subchannel_id),
+        _channelz_pb2.GetSubchannelResponse(),
+    ).subchannel
+
+    sockets = []
+    for ref in subchannel.socket_ref:
+        sockets.append(
+            json_format.Parse(
+                cygrpc.channelz_get_socket(ref.socket_id),
+                _channelz_pb2.GetSocketResponse(),
+            ).socket)
+
+    return render(subchannel=subchannel, sockets=sockets)
+
+
+def _socket_handler(render, args):
+    if 'socket_id' not in args:
+        raise _BadRequest('"socket_id" cannot be empty')
+    socket_id = int(args.get('socket_id'))
+    socket = json_format.Parse(
+        cygrpc.channelz_get_socket(socket_id),
+        _channelz_pb2.GetSocketResponse(),
+    ).socket
+
+    return render(socket=socket)
+
+
+def _servers_handler(render, args):
+    start_server_id = int(args.get('start_server_id', '0'))
+    servers = json_format.Parse(
+        cygrpc.channelz_get_servers(start_server_id),
+        _channelz_pb2.GetServersResponse(),
+    ).server
+
+    if not servers:
+        raise _NotFound(
+            'No server found for "start_server_id"==%d' % start_server_id)
+
+    servers_n_sockets = []
+    for server in servers:
+        listen_sockets = []
+        for ref in server.listen_socket:
+            listen_sockets.append(
+                json_format.Parse(
+                    cygrpc.channelz_get_socket(ref.socket_id),
+                    _channelz_pb2.GetSocketResponse(),
+                ).socket)
+        servers_n_sockets.append(_SERVER_N_SOCKETS(server, listen_sockets))
+
+    return render(
+        num_servers=len(servers),
+        min_id=min(server.ref.server_id for server in servers),
+        max_id=max(server.ref.server_id for server in servers),
+        servers_n_sockets=servers_n_sockets)
+
+
+def _serversockets_handler(render, args):
+    if 'server_id' not in args:
+        raise _BadRequest('"server_id" cannot be empty')
+    server_id = int(args.get('server_id'))
+    start_socket_id = int(args.get('start_socket_id', '0'))
+    serversocket_refs = json_format.Parse(
+        cygrpc.channelz_get_server_sockets(server_id, start_socket_id, 0),
+        _channelz_pb2.GetServerSocketsResponse(),
+    ).socket_ref
+
+    if not serversocket_refs:
+        raise _NotFound(
+            'No server socket found for "server_id"==%d' % server_id)
+
+    serversockets = []
+    for ref in serversocket_refs:
+        serversockets.append(
+            json_format.Parse(
+                cygrpc.channelz_get_socket(ref.socket_id),
+                _channelz_pb2.GetSocketResponse(),
+            ).socket)
+
+    return render(
+        serversockets=serversockets,
+        num_serversockets=len(serversockets),
+        min_id=min(ref.socket_id for ref in serversocket_refs),
+        max_id=max(ref.socket_id for ref in serversocket_refs))
+
+
+_SERVING_PAGES = {
+    '':
+    _PAGE('<nil>', 'index.html', _homepage_handler),
+    'channel':
+    _PAGE('Channel', 'channel.html', _channel_handler),
+    'servers':
+    _PAGE('Servers', 'servers.html', _servers_handler),
+    'serversockets':
+    _PAGE('ServerSockets', 'serversockets.html', _serversockets_handler),
+    'socket':
+    _PAGE('Socket', 'socket.html', _socket_handler),
+    'subchannel':
+    _PAGE('Subchannel', 'subchannel.html', _subchannel_handler),
+    'topchannels':
+    _PAGE('TopChannels', 'topchannels.html', _topchannels_handler),
+}
+
+
+class _RequestHandler(BaseHTTPRequestHandler):
+
+    def _set_ok_headers(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+
+    def _handle(self):
+        if not self.path.startswith('/gdebug/channelz/'):
+            raise _NotFound()
+
+        request_page = self.path[17:].split('?', 1)[0]
+        if request_page not in _SERVING_PAGES:
+            raise _NotFound('Page not found')
+        serving_page = _SERVING_PAGES[request_page]
+
+        base_page = _renderer.format(
+            _base_template,
+            title=serving_page.title,
+            content=_fetch_template(serving_page.template))
+
+        # Encapsulate _renderer and base_page into an enclosure
+        def render(*args, **kwargs):
+            return _renderer.format(base_page, *args, **kwargs)
+
+        full_page = serving_page.handler(render, _parse_args(self.path))
+        self._set_ok_headers()
+        self.wfile.write(full_page.encode('ASCII'))
+
+    def do_GET(self):
+        try:
+            self._handle()
+        except _BadRequest as e:
+            self.send_error(400, str(e))
+        except _NotFound as e:
+            self.send_error(404, str(e))
+        except ValueError as e:
+            stack_str = traceback.format_exc()
+            if '_cython.cygrpc.channelz' in stack_str:
+                # Return 404 if the Channelz fetched nothing from C-Core
+                self.send_error(404, str(e))
+            else:
+                # Otherwise, return 400
+                traceback.print_exc()
+                self.send_error(400)
+        except Exception as e:  # pylint: disable=broad-except
+            traceback.print_exc()
+            self.send_error(500)
+
+
+def _create_http_server(addr):
+    return HTTPServer(addr, _RequestHandler)

--- a/src/python/grpcio_channelz/grpc_channelz/v1/_channelz_page.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/_channelz_page.py
@@ -176,6 +176,10 @@ def _serversockets_handler(render, args):
         raise _BadRequest('"server_id" cannot be empty')
     server_id = int(args.get('server_id'))
     start_socket_id = int(args.get('start_socket_id', '0'))
+    server = json_format.Parse(
+        cygrpc.channelz_get_server(server_id),
+        _channelz_pb2.GetServerResponse(),
+    ).server
     serversocket_refs = json_format.Parse(
         cygrpc.channelz_get_server_sockets(server_id, start_socket_id, 0),
         _channelz_pb2.GetServerSocketsResponse(),
@@ -194,6 +198,7 @@ def _serversockets_handler(render, args):
             ).socket)
 
     return render(
+        server=server,
         serversockets=serversockets,
         num_serversockets=len(serversockets),
         min_id=min(ref.socket_id for ref in serversocket_refs),

--- a/src/python/grpcio_channelz/grpc_channelz/v1/_channelz_page.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/_channelz_page.py
@@ -1,3 +1,17 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import pkgutil
 import collections

--- a/src/python/grpcio_channelz/grpc_channelz/v1/_renderer.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/_renderer.py
@@ -1,3 +1,17 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import string
 import grpc_channelz.v1.channelz_pb2 as _channelz_pb2
 

--- a/src/python/grpcio_channelz/grpc_channelz/v1/_renderer.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/_renderer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import string
+
 import grpc_channelz.v1.channelz_pb2 as _channelz_pb2
 
 _EMPTY_TIME_STR = '1970-01-01T00:00:00Z'
@@ -22,7 +23,7 @@ def _sanitize(text):
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
-class _Renderer(string.Formatter):
+class Renderer(string.Formatter):
 
     def format_field(self, value, format_spec):  # pylint: disable=too-many-return-statements
         if format_spec.startswith('loop'):
@@ -49,7 +50,7 @@ class _Renderer(string.Formatter):
             else:
                 return 'N/A'
         elif format_spec == 'sanitized':
-            return super(_Renderer, self).format_field(value, '')
+            return super(Renderer, self).format_field(value, '')
         else:
             return _sanitize(
-                super(_Renderer, self).format_field(value, format_spec))
+                super(Renderer, self).format_field(value, format_spec))

--- a/src/python/grpcio_channelz/grpc_channelz/v1/_renderer.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/_renderer.py
@@ -1,0 +1,39 @@
+import string
+import grpc_channelz.v1.channelz_pb2 as _channelz_pb2
+
+_EMPTY_TIME_STR = '1970-01-01T00:00:00Z'
+
+
+def _sanitize(text):
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+class _Renderer(string.Formatter):
+
+    def format_field(self, value, format_spec):  # pylint: disable=too-many-return-statements
+        if format_spec.startswith('loop'):
+            template = format_spec.partition(':')[-1]
+            return ''.join([self.format(template, item=item) for item in value])
+        elif format_spec == 'call':
+            return value()
+        elif format_spec == 'state':
+            return _channelz_pb2.ChannelConnectivityState.State.Name(
+                value.state)
+        elif format_spec == 'timestamp':
+            json_str = value.ToJsonString()
+            return 'N/A' if json_str == _EMPTY_TIME_STR else json_str
+        elif format_spec == 'address':
+            if value.HasField('tcpip_address'):
+                return '%s:%d' % (value.tcpip_address.ip_address,
+                                  value.tcpip_address.port)
+            elif value.HasField('uds_address'):
+                return value.uds_address.filename
+            elif value.HasField('other_address'):
+                return value.other_address.name
+            else:
+                return 'N/A'
+        elif format_spec == 'sanitized':
+            return super(_Renderer, self).format_field(value, '')
+        else:
+            return _sanitize(
+                super(_Renderer, self).format_field(value, format_spec))

--- a/src/python/grpcio_channelz/grpc_channelz/v1/_renderer.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/_renderer.py
@@ -33,6 +33,8 @@ class _Renderer(string.Formatter):
         elif format_spec == 'state':
             return _channelz_pb2.ChannelConnectivityState.State.Name(
                 value.state)
+        elif format_spec == 'severity':
+            return _channelz_pb2.ChannelTraceEvent.Severity.Name(value)
         elif format_spec == 'timestamp':
             json_str = value.ToJsonString()
             return 'N/A' if json_str == _EMPTY_TIME_STR else json_str

--- a/src/python/grpcio_channelz/grpc_channelz/v1/channelz.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/channelz.py
@@ -146,6 +146,27 @@ def add_channelz_servicer(server):
 
 
 def serve_channelz_page(host=None, port=None):
+    """Start an HTTP server serving Channelz Pages.
+
+    The pages will be served under: http://<URL>/gdebug/channelz/
+    The gRPC server/client have to be started prior to requesting the server.
+    Otherwise, the gRPC C-Core won't be started, and it will throw SIGABORT
+    terminating the process.
+
+    To close the HTTP server cleanly, you need to call 'shutdown()' and
+    'server_close()' on the returned HTTP server instance. For more details,
+    please check the definition of Python's BaseServer:
+    https://docs.python.org/3/library/socketserver.html#socketserver.BaseServer
+
+    This is an EXPERIMENTAL API.
+
+    Args:
+      host: a str indicates the address of the HTTP server.
+      port: a int indicates the tcp port of the HTTP server.
+    
+    Returns:
+      An http.Server.HTTPServer instance that is already started serving.
+    """
     if host is None or port is None:
         raise ValueError('"host" and "port" can\'t be None')
     http_server = _channelz_page._create_http_server((host, port))

--- a/src/python/grpcio_channelz/grpc_channelz/v1/channelz.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/channelz.py
@@ -13,16 +13,13 @@
 # limitations under the License.
 """Channelz debug service implementation in gRPC Python."""
 
-import threading
 import grpc
 from grpc._cython import cygrpc
-
-import grpc_channelz.v1.channelz_pb2 as _channelz_pb2
-import grpc_channelz.v1.channelz_pb2_grpc as _channelz_pb2_grpc
-
 from google.protobuf import json_format
 
-from . import _channelz_page
+from grpc_channelz.v1 import channelz_pb2 as _channelz_pb2
+from grpc_channelz.v1 import channelz_pb2_grpc as _channelz_pb2_grpc
+from grpc_channelz.v1 import _channelz_page
 
 
 class ChannelzServicer(_channelz_pb2_grpc.ChannelzServicer):
@@ -148,10 +145,7 @@ def add_channelz_servicer(server):
 def serve_channelz_page(host=None, port=None):
     """Start an HTTP server serving Channelz Pages.
 
-    The pages will be served under: http://<URL>/gdebug/channelz/
-    The gRPC server/client have to be started prior to requesting the server.
-    Otherwise, the gRPC C-Core won't be started, and it will throw SIGABORT
-    terminating the process.
+    The pages will be served under: http://<host>:<port>/gdebug/channelz/
 
     To close the HTTP server cleanly, you need to call 'shutdown()' and
     'server_close()' on the returned HTTP server instance. For more details,
@@ -161,17 +155,12 @@ def serve_channelz_page(host=None, port=None):
     This is an EXPERIMENTAL API.
 
     Args:
-      host: a str indicates the address of the HTTP server.
-      port: a int indicates the tcp port of the HTTP server.
+      host: a str specifying the host on which the HTTP server should listen.
+      port: a int indicating the tcp port of the HTTP server.
 
     Returns:
-      An http.Server.HTTPServer instance that is already started serving.
+      An http.Server.HTTPServer instance with Channelz Page handler.
     """
     if host is None or port is None:
         raise ValueError('"host" and "port" can\'t be None')
-    http_server = _channelz_page._create_http_server((host, port))
-
-    serving_thread = threading.Thread(target=http_server.serve_forever)
-    serving_thread.daemon = True
-    serving_thread.start()
-    return http_server
+    return _channelz_page._create_http_server((host, port))

--- a/src/python/grpcio_channelz/grpc_channelz/v1/channelz.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/channelz.py
@@ -163,20 +163,13 @@ def serve_channelz_page(host=None, port=None):
     Args:
       host: a str indicates the address of the HTTP server.
       port: a int indicates the tcp port of the HTTP server.
-    
+
     Returns:
       An http.Server.HTTPServer instance that is already started serving.
     """
     if host is None or port is None:
         raise ValueError('"host" and "port" can\'t be None')
     http_server = _channelz_page._create_http_server((host, port))
-
-    # SSL/TLS is required for gdebug HTTP server.
-    # But not for Channelz servicer.
-    # import ssl
-    # http_server.socket = ssl.wrap_socket(
-    #   http_server.socket, certfile='./server.pem', server_side=True)
-    # )
 
     serving_thread = threading.Thread(target=http_server.serve_forever)
     serving_thread.daemon = True

--- a/src/python/grpcio_channelz/grpc_channelz/v1/templates/BUILD.bazel
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/templates/BUILD.bazel
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name="templates",
+    srcs=glob([
+        "**",
+    ]),
+)

--- a/src/python/grpcio_channelz/grpc_channelz/v1/templates/base.html
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/templates/base.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+    <title>{title} - Channelz Page</title>
+</head>
+<body>
+    <h1>Channelz - {title}</h1>
+    <p>
+        <a href="servers">Servers</a>
+        <a href="topchannels">TopChannels</a>
+    </p>
+    {content:sanitized}
+</body>
+</html>

--- a/src/python/grpcio_channelz/grpc_channelz/v1/templates/channel.html
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/templates/channel.html
@@ -1,0 +1,67 @@
+<table border="1">
+    <tr>
+        <th>Channel ID</th>
+        <td>{channel.ref.channel_id} - [{channel.data.target}]</td>
+    </tr>
+    <tr>
+        <th>state</th>
+        <td>{channel.data.state:state}</td>
+    </tr>
+    <tr>
+        <th>target</th>
+        <td>{channel.data.target}</td>
+    </tr>
+    <tr>
+        <th>calls started</th>
+        <td>{channel.data.calls_started}</td>
+    </tr>
+    <tr>
+        <th>calls succeeded</th>
+        <td>{channel.data.calls_succeeded}</td>
+    </tr>
+    <tr>
+        <th>calls failed</th>
+        <td>{channel.data.calls_failed}</td>
+    </tr>
+    <tr>
+        <th>last call started</th>
+        <td>{channel.data.last_call_started_timestamp:timestamp}</td>
+    </tr>
+    <tr>
+        <th>nested channels</th>
+        <td>
+            {nested_channels:loop:
+            <a href='channel?channel_id={{item.ref.channel_id}}'>
+                {{item.ref.channel_id}} - [{{item.data.target}}]
+            </a>}
+        </td>
+    </tr>
+</table>
+
+<h2>SubChannels</h2>
+<table border="1">
+    <tr>
+        <th>ID</th>
+        <th>target</th>
+        <th>state</th>
+        <th>calls started</th>
+        <th>calls succeeded</th>
+        <th>calls failed</th>
+        <th>last call started</th>
+    </tr>
+    {subchannels:loop:
+    <tr>
+        <td>{{item.ref.subchannel_id}}</td>
+        <td>
+            <a href='subchannel?subchannel_id={{item.ref.subchannel_id}}'>
+                {{item.data.target}}
+            </a>
+        </td>
+        <td>{{item.data.state:state}}</td>
+        <td>{{item.data.calls_started}}</td>
+        <td>{{item.data.calls_succeeded}}</td>
+        <td>{{item.data.calls_failed}}</td>
+        <td>{{item.data.last_call_started_timestamp:timestamp}}</td>
+    </tr>
+    }
+</table>

--- a/src/python/grpcio_channelz/grpc_channelz/v1/templates/channel.html
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/templates/channel.html
@@ -65,3 +65,20 @@
     </tr>
     }
 </table>
+
+<h2>Trace</h2>
+<p>Tracer created at {channel.data.trace.creation_timestamp:timestamp}. Showing {channel.data.trace.num_events_logged} items.</p>
+<table border="1">
+    <tr>
+        <th>Timestamp</th>
+        <th>Severity</th>
+        <th>Trace</th>
+    </tr>
+    {channel.data.trace.events:loop:
+    <tr>
+        <td>{{item.timestamp:timestamp}}</td>
+        <td>{{item.severity:severity}}</td>
+        <td>{{item.description}}</td>
+    </tr>
+    }
+</table>

--- a/src/python/grpcio_channelz/grpc_channelz/v1/templates/servers.html
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/templates/servers.html
@@ -1,0 +1,27 @@
+<p>showing {num_servers} items (id: {min_id} - {max_id})</p>
+<table border="1">
+    <tr>
+        <th>Server</th>
+        <th>RefName</th>
+        <th>calls started</th>
+        <th>calls succeeded</th>
+        <th>calls failed</th>
+        <th>last call started</th>
+        <th>Listen Socket</th>
+    </tr>
+    {servers_n_sockets:loop:
+    <tr>
+        <td>
+            <a href="serversockets?server_id={{item.server.ref.server_id}}">{{item.server.ref.server_id}}</a>
+        </td>
+        <td>{{item.server.ref.name}}</td>
+        <td>{{item.server.data.calls_started}}</td>
+        <td>{{item.server.data.calls_succeeded}}</td>
+        <td>{{item.server.data.calls_failed}}</td>
+        <td>{{item.server.data.last_call_started_timestamp:timestamp}}</td>
+        <td>{{item.listen_sockets:loop:
+            <a href="socket?socket_id={{{{item.ref.socket_id}}}}">{{{{item.ref.socket_id}}}}[{{{{item.local:address}}}}]</a>
+        }}</td>
+    </tr>
+    }
+</table>

--- a/src/python/grpcio_channelz/grpc_channelz/v1/templates/serversockets.html
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/templates/serversockets.html
@@ -1,0 +1,31 @@
+<p>showing {num_serversockets} items (id: {min_id} - {max_id})</p>
+<table border="1">
+    <tr>
+        <th>ServerSocket</th>
+        <th>streams started</th>
+        <th>streams succeeded</th>
+        <th>streams failed</th>
+        <th>messages sent</th>
+        <th>messages received </th>
+        <th>keepalives sent</th>
+        <th>last message sent</th>
+        <th>last message received</th>
+    </tr>
+    {serversockets:loop:
+    <tr>
+        <td>
+            <a href='socket?socket_id={{item.ref.socket_id}}'>
+                {{item.ref.socket_id}}[{{item.local:address}} -> {{item.remote:address}}]
+            </a>    
+        </td>
+        <td>{{item.data.streams_started}}</td>
+        <td>{{item.data.streams_succeeded}}</td>
+        <td>{{item.data.streams_failed}}</td>
+        <td>{{item.data.messages_sent}}</td>
+        <td>{{item.data.messages_received}}</td>
+        <td>{{item.data.keep_alives_sent}}</td>
+        <td>{{item.data.last_message_sent_timestamp:timestamp}}</td>
+        <td>{{item.data.last_message_received_timestamp:timestamp}}</td>
+    </tr>
+    }
+</table>

--- a/src/python/grpcio_channelz/grpc_channelz/v1/templates/serversockets.html
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/templates/serversockets.html
@@ -1,3 +1,28 @@
+<h2>Server</h2>
+<table border="1">
+    <tr>
+        <th>Server ID</th>
+        <td>{server.ref.server_id}</td>
+    </tr>
+    <tr>
+        <th>calls started</th>
+        <td>{server.data.calls_started}</td>
+    </tr>
+    <tr>
+        <th>calls succeeded</th>
+        <td>{server.data.calls_succeeded}</td>
+    </tr>
+    <tr>
+        <th>calls failed</th>
+        <td>{server.data.calls_failed}</td>
+    </tr>
+    <tr>
+        <th>last call started</th>
+        <td>{server.data.last_call_started_timestamp:timestamp}</td>
+    </tr>
+</table>
+
+<h2>Server Sockets</h2>
 <p>showing {num_serversockets} items (id: {min_id} - {max_id})</p>
 <table border="1">
     <tr>
@@ -26,6 +51,23 @@
         <td>{{item.data.keep_alives_sent}}</td>
         <td>{{item.data.last_message_sent_timestamp:timestamp}}</td>
         <td>{{item.data.last_message_received_timestamp:timestamp}}</td>
+    </tr>
+    }
+</table>
+
+<h2>Trace</h2>
+<p>Tracer created at {server.data.trace.creation_timestamp:timestamp}. Showing {server.data.trace.num_events_logged} items.</p>
+<table border="1">
+    <tr>
+        <th>Timestamp</th>
+        <th>Severity</th>
+        <th>Trace</th>
+    </tr>
+    {server.data.trace.events:loop:
+    <tr>
+        <td>{{item.timestamp:timestamp}}</td>
+        <td>{{item.severity:severity}}</td>
+        <td>{{item.description}}</td>
     </tr>
     }
 </table>

--- a/src/python/grpcio_channelz/grpc_channelz/v1/templates/socket.html
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/templates/socket.html
@@ -1,0 +1,83 @@
+<table border="1">
+    <tr>
+        <th>Socket ID</th>
+        <td>{socket.ref.socket_id}</td>
+    </tr>
+    <tr>
+        <th>streams started</th>
+        <td>{socket.data.streams_started}</td>
+    </tr>
+    <tr>
+        <th>streams succeeded</th>
+        <td>{socket.data.streams_succeeded}</td>
+    </tr>
+    <tr>
+        <th>streams failed</th>
+        <td>{socket.data.streams_failed}</td>
+    </tr>
+    <tr>
+        <th>messages sent</th>
+        <td>{socket.data.messages_sent}</td>
+    </tr>
+    <tr>
+        <th>messages received</th>
+        <td>{socket.data.messages_received}</td>
+    </tr>
+    <tr>
+        <th>keepalives sent</th>
+        <td>{socket.data.keep_alives_sent}</td>
+    </tr>
+    <tr>
+        <th>last local stream created</th>
+        <td>{socket.data.last_local_stream_created_timestamp:timestamp}</td>
+    </tr>
+    <tr>
+        <th>last remote stream created</th>
+        <td>{socket.data.last_remote_stream_created_timestamp:timestamp}</td>
+    </tr>
+    <tr>
+        <th>last message sent</th>
+        <td>{socket.data.last_message_sent_timestamp:timestamp}</td>
+    </tr>
+    <tr>
+        <th>last message received</th>
+        <td>{socket.data.last_message_received_timestamp:timestamp}</td>
+    </tr>
+    <tr>
+        <th>local flowcontrol window</th>
+        <td>{socket.data.local_flow_control_window}</td>
+    </tr>
+    <tr>
+        <th>remote flowcontrol window</th>
+        <td>{socket.data.remote_flow_control_window}</td>
+    </tr>
+    <tr>
+        <th>local address</th>
+        <td>{socket.local.tcpip_address.ip_address}:{socket.local.tcpip_address.port}</td>
+    </tr>
+    <tr>
+        <th>remote address</th>
+        <td>{socket.remote.tcpip_address.ip_address}:{socket.remote.tcpip_address.port}</td>
+    </tr>
+    <tr>
+        <th>remote name</th>
+        <td>{socket.remote.other_address.name}</td>
+    </tr>
+    <tr>
+        <th>security</th>
+        <td>{socket.security}</td>
+    </tr>
+    <tr>
+        <th>socket options</th>
+        <td>
+            <table>
+            {socket.data.option:loop:
+                <tr>
+                    <th>{{item.name}}</th>
+                    <td>{{item.value}}</td>
+                </tr>
+            }
+            </table>
+        </td>
+    </tr>
+</table>

--- a/src/python/grpcio_channelz/grpc_channelz/v1/templates/subchannel.html
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/templates/subchannel.html
@@ -1,0 +1,39 @@
+<table border="1">
+    <tr>
+        <th>SubChannel ID</th>
+        <td>{subchannel.ref.subchannel_id} - [{subchannel.data.target}]</td>
+    </tr>
+    <tr>
+        <th>state</th>
+        <td>{subchannel.data.state:state}</td>
+    </tr>
+    <tr>
+        <th>target</th>
+        <td>{subchannel.data.target}</td>
+    </tr>
+    <tr>
+        <th>calls started</th>
+        <td>{subchannel.data.calls_started}</td>
+    </tr>
+    <tr>
+        <th>calls succeeded</th>
+        <td>{subchannel.data.calls_succeeded}</td>
+    </tr>
+    <tr>
+        <th>calls failed</th>
+        <td>{subchannel.data.calls_failed}</td>
+    </tr>
+    <tr>
+        <th>last call started</th>
+        <td>{subchannel.data.last_call_started_timestamp:timestamp}</td>
+    </tr>
+    <tr>
+        <th>sockets</th>
+        <td>
+            {sockets:loop:
+            <a href='socket?socket_id={{item.ref.socket_id}}'>
+                {{item.ref.socket_id}}[{{item.local:address}} -> {{item.remote:address}}]
+            </a>}
+        </td>
+    </tr>
+</table>

--- a/src/python/grpcio_channelz/grpc_channelz/v1/templates/topchannels.html
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/templates/topchannels.html
@@ -1,0 +1,27 @@
+<p>showing {num_channel} items (id: {min_id} - {max_id})</p>
+<table border="1">
+    <tr>
+        <th>ID</th>
+        <th>target</th>
+        <th>state</th>
+        <th>calls started</th>
+        <th>calls succeeded</th>
+        <th>calls failed</th>
+        <th>last call started</th>
+    </tr>
+    {topchannels:loop:
+    <tr>
+        <td>{{item.ref.channel_id}}</td>
+        <td>
+            <a href='channel?channel_id={{item.ref.channel_id}}'>
+                {{item.data.target}}
+            </a>
+        </td>
+        <td>{{item.data.state:state}}</td>
+        <td>{{item.data.calls_started}}</td>
+        <td>{{item.data.calls_succeeded}}</td>
+        <td>{{item.data.calls_failed}}</td>
+        <td>{{item.data.last_call_started_timestamp:timestamp}}</td>
+    </tr>
+    }
+</table>

--- a/src/python/grpcio_channelz/setup.py
+++ b/src/python/grpcio_channelz/setup.py
@@ -54,7 +54,12 @@ CLASSIFIERS = [
 ]
 
 PACKAGE_DIRECTORIES = {
-    '': '.',
+    'grpcio-channelz': '.',
+}
+
+_TEMPLATE_DIRECTORY = os.path.join('grpc_channelz', 'v1', 'templates')
+PACKAGE_DATA = {
+    'grpcio-channelz': [os.path.join(_TEMPLATE_DIRECTORY, '*.html')]
 }
 
 INSTALL_REQUIRES = (
@@ -90,7 +95,9 @@ setuptools.setup(
     classifiers=CLASSIFIERS,
     url='https://grpc.io',
     package_dir=PACKAGE_DIRECTORIES,
+    package_data=PACKAGE_DATA,
     packages=setuptools.find_packages('.'),
+    include_package_data=True,
     install_requires=INSTALL_REQUIRES,
     setup_requires=SETUP_REQUIRES,
     cmdclass=COMMAND_CLASS)

--- a/src/python/grpcio_tests/setup.py
+++ b/src/python/grpcio_tests/setup.py
@@ -50,7 +50,8 @@ INSTALL_REQUIRES = (
     'protobuf>=3.6.0',
     'six>=1.10',
     'google-auth>=1.0.0',
-    'requests>=2.14.2')
+    'requests>=2.14.2',
+    'pyquery==1.2.4')
 
 if not PY3:
     INSTALL_REQUIRES += ('futures>=2.2.0',)

--- a/src/python/grpcio_tests/setup.py
+++ b/src/python/grpcio_tests/setup.py
@@ -50,8 +50,7 @@ INSTALL_REQUIRES = (
     'protobuf>=3.6.0',
     'six>=1.10',
     'google-auth>=1.0.0',
-    'requests>=2.14.2',
-    'pyquery==1.2.4')
+    'requests>=2.14.2')
 
 if not PY3:
     INSTALL_REQUIRES += ('futures>=2.2.0',)

--- a/src/python/grpcio_tests/tests/channelz/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/channelz/BUILD.bazel
@@ -25,7 +25,6 @@ py_test(
         "//src/python/grpcio_channelz/grpc_channelz/v1:grpc_channelz",
         "//src/python/grpcio_tests/tests/unit:test_common",
         "//src/python/grpcio_tests/tests/unit/framework/common:common",
-        requirement("pyquery"),
         requirement("requests"),
         requirement("urllib3"),
         requirement("chardet"),

--- a/src/python/grpcio_tests/tests/channelz/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/channelz/BUILD.bazel
@@ -27,6 +27,10 @@ py_test(
         "//src/python/grpcio_tests/tests/unit/framework/common:common",
         requirement("pyquery"),
         requirement("requests"),
+        requirement("urllib3"),
+        requirement("chardet"),
+        requirement("certifi"),
+        requirement("idna"),
     ],
     imports = ["../../",],
 )

--- a/src/python/grpcio_tests/tests/channelz/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/channelz/BUILD.bazel
@@ -1,4 +1,5 @@
 package(default_visibility = ["//visibility:public"])
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
 
 py_test(
     name = "channelz_servicer_test",
@@ -10,6 +11,22 @@ py_test(
         "//src/python/grpcio_channelz/grpc_channelz/v1:grpc_channelz",
         "//src/python/grpcio_tests/tests/unit:test_common",
         "//src/python/grpcio_tests/tests/unit/framework/common:common",
+    ],
+    imports = ["../../",],
+)
+
+py_test(
+    name = "channelz_page_test",
+    srcs = ["_channelz_page_test.py"],
+    main = "_channelz_page_test.py",
+    size = "small",
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/python/grpcio_channelz/grpc_channelz/v1:grpc_channelz",
+        "//src/python/grpcio_tests/tests/unit:test_common",
+        "//src/python/grpcio_tests/tests/unit/framework/common:common",
+        requirement("pyquery"),
+        requirement("requests"),
     ],
     imports = ["../../",],
 )

--- a/src/python/grpcio_tests/tests/channelz/_channelz_page_test.py
+++ b/src/python/grpcio_tests/tests/channelz/_channelz_page_test.py
@@ -225,8 +225,8 @@ class ChannelzPagePreventAbortTest(unittest.TestCase):
         self._serving_thread.join()
 
     def test_request_page_without_grpc_init(self):
-        resp = requests.get(self._page_url_prefix + 'servers?start_server_id=0')
         # This shouldn't trigger SIGABORT
+        resp = requests.get(self._page_url_prefix + 'servers?start_server_id=0')
         self.assertEqual(resp.status_code, 503)
 
 

--- a/src/python/grpcio_tests/tests/channelz/_channelz_page_test.py
+++ b/src/python/grpcio_tests/tests/channelz/_channelz_page_test.py
@@ -160,7 +160,7 @@ class ChannelzPageTest(unittest.TestCase):
         resp = requests.get(self._page_url_prefix + surffix)
         self.assertEqual(resp.status_code, 200)
 
-        # Page of detail of the listen socket
+        # Page of detail of the server sockets
         surffix = pq(resp.text)('table a').attr('href')
         self.assertIn('socket?socket_id=', surffix)
         resp = requests.get(self._page_url_prefix + surffix)

--- a/src/python/grpcio_tests/tests/channelz/_channelz_page_test.py
+++ b/src/python/grpcio_tests/tests/channelz/_channelz_page_test.py
@@ -95,7 +95,8 @@ class ChannelzPageTest(unittest.TestCase):
         self._channel = grpc.insecure_channel('localhost:%d' % port)
 
         self._page_server = channelz.serve_channelz_page('', 0)
-        self._page_url_prefix = _CHANNELZ_URL_PREFIX_TEMPLATE % self._page_server.server_address[1]
+        self._page_url_prefix = _CHANNELZ_URL_PREFIX_TEMPLATE % self._page_server.server_address[
+            1]
 
         # Emit RPCs to make sure sockets are created
         self._send_successful_unary_unary()

--- a/src/python/grpcio_tests/tests/channelz/_channelz_page_test.py
+++ b/src/python/grpcio_tests/tests/channelz/_channelz_page_test.py
@@ -1,0 +1,206 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests of Serving HTTPS Channelz Page."""
+
+import unittest
+import time
+import logging
+
+import requests
+from pyquery import PyQuery as pq
+
+import grpc
+from grpc_channelz.v1 import channelz
+
+from tests.unit import test_common
+from tests.unit.framework.common import test_constants
+
+_CHANNELZ_PAGE_PORT = 8080
+_CHANNELZ_URL_PREFIX = 'http://localhost:%d/gdebug/channelz/' % (
+    _CHANNELZ_PAGE_PORT)
+
+_REQUEST = b'\x00\x00\x00'
+_RESPONSE = b'\x01\x01\x01'
+
+_SUCCESSFUL_UNARY_UNARY = '/test/SuccessfulUnaryUnary'
+_FAILED_UNARY_UNARY = '/test/FailedUnaryUnary'
+_SUCCESSFUL_STREAM_STREAM = '/test/SuccessfulStreamStream'
+
+
+def _successful_unary_unary(request, servicer_context):
+    return _RESPONSE
+
+
+def _failed_unary_unary(request, servicer_context):
+    servicer_context.abort(grpc.StatusCode.INTERNAL, 'Intended Failure')
+
+
+def _successful_stream_stream(request_iterator, servicer_context):
+    for _ in request_iterator:
+        yield _RESPONSE
+
+
+class _GenericHandler(grpc.GenericRpcHandler):
+
+    def service(self, handler_call_details):
+        if handler_call_details.method == _SUCCESSFUL_UNARY_UNARY:
+            return grpc.unary_unary_rpc_method_handler(_successful_unary_unary)
+        elif handler_call_details.method == _FAILED_UNARY_UNARY:
+            return grpc.unary_unary_rpc_method_handler(_failed_unary_unary)
+        elif handler_call_details.method == _SUCCESSFUL_STREAM_STREAM:
+            return grpc.stream_stream_rpc_method_handler(
+                _successful_stream_stream)
+        else:
+            return None
+
+
+class ChannelzPageTest(unittest.TestCase):
+
+    def _send_successful_unary_unary(self):
+        _, r = self._channel.unary_unary(_SUCCESSFUL_UNARY_UNARY).with_call(
+            _REQUEST)
+        self.assertEqual(r.code(), grpc.StatusCode.OK)
+
+    def _send_failed_unary_unary(self):
+        try:
+            self._channel.unary_unary(_FAILED_UNARY_UNARY)(_REQUEST)
+        except grpc.RpcError:
+            return
+
+    def _send_successful_stream_stream(self):
+        response_iterator = self._channel.stream_stream(
+            _SUCCESSFUL_STREAM_STREAM).__call__(
+                iter([_REQUEST] * test_constants.STREAM_LENGTH))
+        cnt = 0
+        for _ in response_iterator:
+            cnt += 1
+        self.assertEqual(cnt, test_constants.STREAM_LENGTH)
+
+    def setUp(self):
+        super(ChannelzPageTest, self).setUp()
+        self._server = test_common.test_server()
+        port = self._server.add_insecure_port('[::]:0')
+        self._server.add_generic_rpc_handlers((_GenericHandler(),))
+        self._server.start()
+
+        self._channel = grpc.insecure_channel('localhost:%d' % port)
+
+        self._page_server = channelz.serve_channelz_page(
+            '', _CHANNELZ_PAGE_PORT)
+
+        # Emit RPCs to make sure sockets are created
+        self._send_successful_unary_unary()
+        self._send_failed_unary_unary()
+        self._send_successful_stream_stream()
+
+    def tearDown(self):
+        self._page_server.shutdown()
+        self._page_server.server_close()
+        self._server.stop(None)
+        self._channel.close()
+        super(ChannelzPageTest, self).tearDown()
+
+    def test_homepage(self):
+        resp = requests.get(_CHANNELZ_URL_PREFIX)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_channel(self):
+        # Page of list of channels
+        resp = requests.get(_CHANNELZ_URL_PREFIX + 'topchannels')
+        self.assertEqual(resp.status_code, 200)
+
+        # Page of detail of a channel
+        surffix = pq(resp.text)('table a').attr('href')
+        self.assertIn('channel?channel_id=', surffix)
+        resp = requests.get(_CHANNELZ_URL_PREFIX + surffix)
+        self.assertEqual(resp.status_code, 200)
+
+        # Page of detail of a subchannel
+        surffix = pq(resp.text)('table').eq(1).find('a').attr('href')
+        self.assertIn('subchannel?subchannel_id=', surffix)
+        resp = requests.get(_CHANNELZ_URL_PREFIX + surffix)
+        self.assertEqual(resp.status_code, 200)
+
+        # Page of detail of a socket
+        surffix = pq(resp.text)('table a').attr('href')
+        self.assertIn('socket?socket_id=', surffix)
+        resp = requests.get(_CHANNELZ_URL_PREFIX + surffix)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_serversockets(self):
+        # Page of list of servers
+        resp = requests.get(_CHANNELZ_URL_PREFIX + 'servers')
+        self.assertEqual(resp.status_code, 200)
+
+        # TODO(lidiz) In Python 3, the server from last test unit will remain alive...
+        # Remove the selection logic when the deallocation is fixed.
+        trs = pq(resp.text)('table tr')
+        for i in range(len(trs)):
+            tds = trs.eq(i).find('td')
+            if not tds:
+                continue
+            if not tds.eq(0).find('a'):
+                continue
+            if not tds.eq(len(tds) - 1).find('a'):
+                continue
+            surffix = tds.eq(0).find('a').attr('href')
+
+        # Page of detail of a server
+        self.assertIn('serversockets?server_id=', surffix)
+        resp = requests.get(_CHANNELZ_URL_PREFIX + surffix)
+        self.assertEqual(resp.status_code, 200)
+
+        # Page of detail of the listen socket
+        surffix = pq(resp.text)('table a').attr('href')
+        self.assertIn('socket?socket_id=', surffix)
+        resp = requests.get(_CHANNELZ_URL_PREFIX + surffix)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_incomplete_arguments(self):
+        for surffix in ['channel', 'subchannel', 'socket', 'serversockets']:
+            resp = requests.get(_CHANNELZ_URL_PREFIX + surffix)
+            self.assertEqual(resp.status_code, 400)
+
+    def test_not_found_channel(self):
+        resp = requests.get(_CHANNELZ_URL_PREFIX + 'channel?channel_id=999')
+        self.assertEqual(resp.status_code, 404)
+
+    def test_not_found_subchannel(self):
+        resp = requests.get(
+            _CHANNELZ_URL_PREFIX + 'subchannel?subchannel_id=999')
+        self.assertEqual(resp.status_code, 404)
+
+    def test_not_found_socket(self):
+        resp = requests.get(_CHANNELZ_URL_PREFIX + 'socket?socket_id=999')
+        self.assertEqual(resp.status_code, 404)
+
+    def test_not_found_serversockets(self):
+        resp = requests.get(
+            _CHANNELZ_URL_PREFIX + 'serversockets?server_id=999')
+        self.assertEqual(resp.status_code, 404)
+
+    def test_not_found_topchannels(self):
+        resp = requests.get(
+            _CHANNELZ_URL_PREFIX + 'topchannels?start_channel_id=999')
+        self.assertEqual(resp.status_code, 404)
+
+    def test_not_found_servers(self):
+        resp = requests.get(
+            _CHANNELZ_URL_PREFIX + 'servers?start_server_id=999')
+        self.assertEqual(resp.status_code, 404)
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/tests.json
+++ b/src/python/grpcio_tests/tests/tests.json
@@ -1,5 +1,6 @@
 [
   "_sanity._sanity_test.SanityTest",
+  "channelz._channelz_page_test.ChannelzPageTest",
   "channelz._channelz_servicer_test.ChannelzServicerTest",
   "health_check._health_servicer_test.HealthServicerTest",
   "interop._insecure_intraop_test.InsecureIntraopTest",

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -215,7 +215,7 @@ pip_install_dir "$ROOT/src/python/grpcio_testing"
 # Build/install tests
 $VENV_PYTHON -m pip install coverage==4.4 oauth2client==4.1.0 \
                             google-auth==1.0.0 requests==2.14.2 \
-                            googleapis-common-protos==1.5.5
+                            googleapis-common-protos==1.5.5 pyquery==1.2.4
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" preprocess
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" build_package_protos
 pip_install_dir "$ROOT/src/python/grpcio_tests"

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -215,7 +215,7 @@ pip_install_dir "$ROOT/src/python/grpcio_testing"
 # Build/install tests
 $VENV_PYTHON -m pip install coverage==4.4 oauth2client==4.1.0 \
                             google-auth==1.0.0 requests==2.14.2 \
-                            googleapis-common-protos==1.5.5 pyquery==1.2.4
+                            googleapis-common-protos==1.5.5
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" preprocess
 $VENV_PYTHON "$ROOT/src/python/grpcio_tests/setup.py" build_package_protos
 pip_install_dir "$ROOT/src/python/grpcio_tests"


### PR DESCRIPTION
This PR adds an HTTP server to grpcio_channelz package. It serves Channelz channel tracing information as html pages with links to help developers inspect the running gRPC process. The design is following existing Java's & Golang's implementation.

```Python
# Same where in your gRPC process
from grpc_channelz.v1 import channelz

# The server starts serving in another thread
page_server = channelz.serve_channelz_page('', _CHANNELZ_PAGE_PORT)

# To shut it down, you need to call two function of the Python native HTTPServer.
page_server.shutdown()     # Stop serving
page_server.server_close() # Release file descriptor
```

Unlike Java & Golang, Python doesn't have a built-in template render package, but Python does have an incomplete string formatting semantics. Including template engine like `Jinja2` is easy, but might confuse our user, why installing a production debug tool will add dependency to a template engine. So, I attempt to not include third party packages to make the backend rendering HTTP server work, and extend the `string.Formatter` to a simplest template renderer. Code in `//src/python/grpcio_channelz/grpc_channelz/v1/_renderer.py`.

About the template engine:
* It will format twice, one for common html stuff (html, head, body tags), one for data filling.
* It supports loop over list-like object, invoke function, and plugin needed handle function for specific fields (like mapping channel state enum value to its name).
* It performs basic sanitization by replacing "&", "<", and ">".