### PR TITLE
Avoid daemon threads when polling a completion queue

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
@@ -455,14 +455,10 @@ cdef class Channel:
         self._state, flags, method, host, deadline, metadata, credentials,
         operationses_and_tags, context)
 
-  def next_call_event(self):
+  def next_call_event(self, queue_deadline=None):
     def on_success(tag):
       if tag is not None:
         _process_integrated_call_tag(self._state, tag)
-    if is_fork_support_enabled():
-      queue_deadline = time.time() + 1.0
-    else:
-      queue_deadline = None
     return _next_call_event(self._state, self._state.c_call_completion_queue,
                             on_success, queue_deadline)
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pxd.pxi
@@ -22,7 +22,6 @@ cdef _interpret_event(grpc_event c_event)
 cdef class CompletionQueue:
 
   cdef grpc_completion_queue *c_completion_queue
-  cdef bint is_shutting_down
   cdef bint is_shutdown
 
   cdef _interpret_event(self, grpc_event c_event)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
@@ -101,7 +101,7 @@ cdef class Server:
           <cpython.PyObject *>server_shutdown_tag)
 
   def shutdown(self, CompletionQueue queue not None, tag):
-    if queue.is_shutting_down:
+    if queue.is_shutdown:
       raise ValueError("queue must be live")
     elif not self.is_started:
       raise ValueError("the server hasn't started yet")
@@ -147,6 +147,7 @@ cdef class Server:
         while not self.is_shutdown:
           time.sleep(0)
       grpc_server_destroy(self.c_server)
+      self.backup_shutdown_queue.shutdown()
       self.c_server = NULL
 
   def __dealloc(self):

--- a/src/python/grpcio/grpc/_thread.py
+++ b/src/python/grpcio/grpc/_thread.py
@@ -1,0 +1,44 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Interpreter-exit aware daemon thread support"""
+
+
+import atexit
+import threading
+import weakref
+
+
+INTERPRETER_EXIT_CHECK_PERIOD_S = 1.0
+
+_daemon_threads = weakref.WeakSet()
+_exiting = False
+_shutdown_lock = threading.Lock()
+
+
+def _await_daemon_threads():
+    global _exiting
+    _exiting = True
+    daemon_threads = list(_daemon_threads)
+    for t in daemon_threads:
+        t.join()
+
+def add_daemon_thread(daemon_thread):
+    with _shutdown_lock:
+        _daemon_threads.add(daemon_thread)
+
+def is_exiting():
+    return _exiting
+
+
+atexit.register(_await_daemon_threads)

--- a/src/python/grpcio_tests/tests/_runner.py
+++ b/src/python/grpcio_tests/tests/_runner.py
@@ -197,12 +197,12 @@ class Runner(object):
                 case_thread = threading.Thread(
                     target=augmented_case.case.run, args=(result,))
                 try:
-                    with stdout_pipe, stderr_pipe:
-                        case_thread.start()
-                        while case_thread.is_alive():
-                            check_kill_self()
-                            time.sleep(0)
-                        case_thread.join()
+                    # with stdout_pipe, stderr_pipe:
+                    case_thread.start()
+                    while case_thread.is_alive():
+                        check_kill_self()
+                        time.sleep(0)
+                    case_thread.join()
                 except:  # pylint: disable=try-except-raise
                     # re-raise the exception after forcing the with-block to end
                     raise

--- a/src/python/grpcio_tests/tests/protoc_plugin/beta_python_plugin_test.py
+++ b/src/python/grpcio_tests/tests/protoc_plugin/beta_python_plugin_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import contextlib
+import faulthandler
 import importlib
 import os
 from os import path
@@ -21,6 +22,7 @@ import shutil
 import sys
 import tempfile
 import threading
+import time
 import unittest
 
 from six import moves
@@ -105,6 +107,15 @@ def _packagify(directory):
         init_file_name = path.join(subdirectory, '__init__.py')
         with open(init_file_name, 'wb') as init_file:
             init_file.write(b'')
+
+
+def dump_threads():
+    start_time = time.time()
+    while True:
+        if time.time() > start_time+30:
+            faulthandler.dump_traceback()
+            return
+        time.sleep(1)
 
 
 class _ServicerMethods(object):
@@ -313,6 +324,11 @@ class PythonPluginTest(unittest.TestCase):
             with open(proto_file_name, 'wb') as proto_file:
                 proto_file.write(massaged_proto_content)
             self._proto_file_names.add(proto_file_name)
+
+
+        t = threading.Thread(target=dump_threads)
+        t.daemon = True
+        t.start()
 
     def tearDown(self):
         shutil.rmtree(self._directory)

--- a/src/python/grpcio_tests/tests/tests.json
+++ b/src/python/grpcio_tests/tests/tests.json
@@ -48,6 +48,7 @@
   "unit._error_message_encoding_test.ErrorMessageEncodingTest",
   "unit._exit_test.ExitTest",
   "unit._interceptor_test.InterceptorTest",
+  "unit._interpreter_exit_test.InterpreterExitTest",
   "unit._invalid_metadata_test.InvalidMetadataTest",
   "unit._invocation_defects_test.InvocationDefectsTest",
   "unit._logging_test.LoggingTest",

--- a/src/python/grpcio_tests/tests/unit/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/BUILD.bazel
@@ -18,6 +18,7 @@ GRPCIO_TESTS_UNIT = [
     "_exit_test.py",
     "_interceptor_test.py",
     "_invalid_metadata_test.py",
+    "_interpreter_exit_test.py",
     "_invocation_defects_test.py",
     "_logging_test.py",
     "_metadata_code_details_test.py",

--- a/src/python/grpcio_tests/tests/unit/_interpreter_exit_test.py
+++ b/src/python/grpcio_tests/tests/unit/_interpreter_exit_test.py
@@ -1,0 +1,60 @@
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests to ensure that gRPC does not segfault or hang on interpreter exit"""
+
+import logging
+import subprocess
+import sys
+import unittest
+
+import grpc
+
+INTERPRETER = sys.executable
+
+
+class InterpreterExitTest(unittest.TestCase):
+
+    # NOTE: We  avoid Python daemon threads due to potential for segfaults after
+    # the main thread exits. See https://bugs.python.org/issue1856, although
+    # issues were also observed with Python3 (see also
+    # https://github.com/grpc/grpc/issues/11804).
+    def test_server_cleanup_exits_cleanly(self):
+        script = """if True:
+            import sys
+
+            import grpc
+            from tests.unit import test_common
+
+            servers = []
+            while len(servers) < 1000:
+                server = test_common.test_server()
+                server.add_insecure_port('[::]:0')
+                server.start()
+                servers.append(server)
+            sys.exit(0)
+
+        """
+        process = subprocess.Popen(
+            [INTERPRETER, '-c', script],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE)
+        out, err = process.communicate()
+        self.assertEqual(0, process.returncode,
+                         "process failed with exit code %d" %
+                         (process.returncode))
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_interpreter_exit_test.py
+++ b/src/python/grpcio_tests/tests/unit/_interpreter_exit_test.py
@@ -25,10 +25,9 @@ INTERPRETER = sys.executable
 
 class InterpreterExitTest(unittest.TestCase):
 
-    # NOTE: We  avoid Python daemon threads due to potential for segfaults after
-    # the main thread exits. See https://bugs.python.org/issue1856, although
-    # issues were also observed with Python3 (see also
-    # https://github.com/grpc/grpc/issues/11804).
+    # NOTE: Daemon threads may cause crashes upon interpreter exit. See
+    # https://bugs.python.org/issue1856, although this wasalso observed with
+    # Python 3 (see also https://github.com/grpc/grpc/issues/11804).
     def test_server_cleanup_exits_cleanly(self):
         script = """if True:
             import sys
@@ -50,9 +49,10 @@ class InterpreterExitTest(unittest.TestCase):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
         out, err = process.communicate()
-        self.assertEqual(0, process.returncode,
-                         "process failed with exit code %d" %
-                         (process.returncode))
+        self.assertEqual(
+            0, process.returncode,
+            'process failed with exit code %d (stdout: %s, stderr: %s)' %
+            (process.returncode, out, err))
 
 
 if __name__ == '__main__':

--- a/src/python/grpcio_tests/tests/unit/_interpreter_exit_test.py
+++ b/src/python/grpcio_tests/tests/unit/_interpreter_exit_test.py
@@ -1,4 +1,4 @@
-# Copyright 2015 gRPC authors.
+# Copyright 2019 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/python/grpcio_tests/tests/unit/_invocation_defects_test.py
+++ b/src/python/grpcio_tests/tests/unit/_invocation_defects_test.py
@@ -214,7 +214,7 @@ class InvocationDefectsTest(unittest.TestCase):
         self._channel = grpc.insecure_channel('localhost:%d' % port)
 
     def tearDown(self):
-        self._server.stop(0)
+        self._server.stop(None)
         self._channel.close()
 
     def testIterableStreamRequestBlockingUnaryResponse(self):

--- a/tools/run_tests/helper_scripts/build_python.sh
+++ b/tools/run_tests/helper_scripts/build_python.sh
@@ -182,6 +182,7 @@ $VENV_PYTHON -m pip install six enum34 protobuf
 if [ "$("$VENV_PYTHON" -c "import sys; print(sys.version_info[0])")" == "2" ]
 then
   $VENV_PYTHON -m pip install futures
+  $VENV_PYTHON -m pip install faulthandler
 fi
 
 pip_install_dir "$ROOT"


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/11804 and associated build flakes (https://github.com/grpc/grpc/issues/15308, https://github.com/grpc/grpc/issues/17553, https://github.com/grpc/grpc/issues/17568)

Daemon threads calling into cq next then re-acquiring the GIL can lead to segfaults. This is a known bug in Python 2 (https://bugs.python.org/issue1856) but the provided test case in `_interpreter_exit_test` also segfaults on Python 3 if daemon threads are used by gRPC. The segfault occurs in CPython code with the following (truncated) backtrace:

```
#0  new_threadstate (interp=0x0, init=init@entry=1) at ../Python/pystate.c:231
#1  0x00005606a354bdde in PyThreadState_New () at ../Python/pystate.c:244
#2  PyGILState_Ensure () at ../Python/pystate.c:812
#3  0x00007fb0a09febe5 in __pyx_f_4grpc_7_cython_6cygrpc__next (__pyx_v_c_completion_queue=
    0x5606a51ed320, __pyx_v_deadline=<optimized out>)
    at src/python/grpcio/grpc/_cython/cygrpc.cpp:23330
#4  0x00007fb0a0a25f2c in __pyx_pf_4grpc_7_cython_6cygrpc_15CompletionQueue_2poll (
    __pyx_v_deadline=<optimized out>, __pyx_v_self=0x7fb09c41f648)
    at src/python/grpcio/grpc/_cython/cygrpc.cpp:24115
#5  __pyx_pw_4grpc_7_cython_6cygrpc_15CompletionQueue_3poll (
    __pyx_v_self=<grpc._cython.cygrpc.CompletionQueue at remote 0x7fb09c41f648>, 
    __pyx_args=<optimized out>, __pyx_kwds=<optimized out>)
    at src/python/grpcio/grpc/_cython/cygrpc.cpp:24094
#6  0x00005606a3614327 in PyCFunction_Call (
    func=<built-in method poll of grpc._cython.cygrpc.CompletionQueue object at remote 0x7fb09c41f648>, args=<optimized out>, kwds=<optimized out>) at ../Objects/methodobject.c:98
#7  0x00005606a35d4ede in call_function (oparg=<optimized out>, pp_stack=0x7fae07e3e7e0)
    at ../Python/ceval.c:4758
#8  PyEval_EvalFrameEx (f=<optimized out>, throwflag=<optimized out>) at ../Python/ceval.c:3289
...
```

Further, changing the server's `_serve` thread to be non-daemonic required changing how the completion queue's `__dealloc__` function (`completion_queue.pyx.pxi` is only used on the server-side; channel's managed their own core CQ directly). Since the `_serve` thread is no longer daemonic, Python now runs clean-up code upon exit, which includes garbage collection. Since the server itself has not stopped, the request call tag is still pending in the core completion queue. This caused the existing completion queue `__dealloc__` to hang indefinitely, as the request call tag must come out of the CQ before the shutdown tag will be processed.