### PR TITLE
Modifying semantics for GetSendMessage and GetSerializedSendMessage. Also adding ModifySendMessage

### DIFF
--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -324,8 +324,8 @@ class CallOpSendMessage {
     }
     if (msg_ != nullptr) {
       GPR_CODEGEN_ASSERT(serializer_(msg_).ok());
-      serializer_ = nullptr;
     }
+    serializer_ = nullptr;
     grpc_op* op = &ops[(*nops)++];
     op->op = GRPC_OP_SEND_MESSAGE;
     op->flags = write_options_.flags();

--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -361,7 +361,6 @@ class CallOpSendMessage {
 template <class M>
 Status CallOpSendMessage::SendMessage(const M& message, WriteOptions options) {
   write_options_ = options;
-  bool own_buf;
   // TODO(vjpai): Remove the void below when possible
   // The void in the template parameter below should not be needed
   // (since it should be implicit) but is needed due to an observed

--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -379,7 +379,7 @@ Status CallOpSendMessage::SendMessage(const M& message, WriteOptions options) {
   if (msg_ == nullptr) {
     return serializer_(&message);
   }
-  return Status::OK;
+  return Status();
 }
 
 template <class M>

--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -321,6 +321,7 @@ class CallOpSendMessage {
     if (msg_ != nullptr) {
       GPR_CODEGEN_ASSERT(serializer_(msg_).ok());
     }
+    serializer_ = nullptr;
     grpc_op* op = &ops[(*nops)++];
     op->op = GRPC_OP_SEND_MESSAGE;
     op->flags = write_options_.flags();
@@ -361,13 +362,13 @@ class CallOpSendMessage {
 template <class M>
 Status CallOpSendMessage::SendMessage(const M& message, WriteOptions options) {
   write_options_ = options;
-  // TODO(vjpai): Remove the void below when possible
-  // The void in the template parameter below should not be needed
-  // (since it should be implicit) but is needed due to an observed
-  // difference in behavior between clang and gcc for certain internal users
   serializer_ = [this](const void* message) {
     bool own_buf;
     send_buf_.Clear();
+    // TODO(vjpai): Remove the void below when possible
+    // The void in the template parameter below should not be needed
+    // (since it should be implicit) but is needed due to an observed
+    // difference in behavior between clang and gcc for certain internal users
     Status result = SerializationTraits<M, void>::Serialize(
         *static_cast<const M*>(message), send_buf_.bbuf_ptr(), &own_buf);
     if (!own_buf) {

--- a/include/grpcpp/impl/codegen/interceptor.h
+++ b/include/grpcpp/impl/codegen/interceptor.h
@@ -117,6 +117,8 @@ class InterceptorBatchMethods {
   /// only supported for sync and callback APIs at the present moment.
   virtual const void* GetSendMessage() = 0;
 
+  virtual void ModifySendMessage(const void* message) = 0;
+
   /// Returns a modifiable multimap of the initial metadata to be sent. Valid
   /// for PRE_SEND_INITIAL_METADATA interceptions. A value of nullptr indicates
   /// that this field is not valid.

--- a/include/grpcpp/impl/codegen/interceptor_common.h
+++ b/include/grpcpp/impl/codegen/interceptor_common.h
@@ -98,9 +98,7 @@ class InterceptorBatchMethodsImpl
     *orig_send_message_ = message;
   }
 
-  bool GetSendMessageStatus() override {
-    return !*fail_send_message_;
-  }
+  bool GetSendMessageStatus() override { return !*fail_send_message_; }
 
   std::multimap<grpc::string, grpc::string>* GetSendInitialMetadata() override {
     return send_initial_metadata_;

--- a/test/cpp/end2end/client_interceptors_end2end_test.cc
+++ b/test/cpp/end2end/client_interceptors_end2end_test.cc
@@ -287,16 +287,16 @@ class LoggingInterceptor : public experimental::Interceptor {
     if (methods->QueryInterceptionHookPoint(
             experimental::InterceptionHookPoints::PRE_SEND_MESSAGE)) {
       EchoRequest req;
+      EXPECT_EQ(static_cast<const EchoRequest*>(methods->GetSendMessage())
+                    ->message()
+                    .find("Hello"),
+                0u);
       auto* buffer = methods->GetSerializedSendMessage();
       auto copied_buffer = *buffer;
       EXPECT_TRUE(
           SerializationTraits<EchoRequest>::Deserialize(&copied_buffer, &req)
               .ok());
       EXPECT_TRUE(req.message().find("Hello") == 0u);
-      EXPECT_EQ(static_cast<const EchoRequest*>(methods->GetSendMessage())
-                    ->message()
-                    .find("Hello"),
-                0u);
     }
     if (methods->QueryInterceptionHookPoint(
             experimental::InterceptionHookPoints::PRE_SEND_CLOSE)) {


### PR DESCRIPTION
This PR makes the following interception API changes -
1) Serialization of message is now delayed for sync and callback APIs. Serialization is now only done after all interceptors are done running or when an interceptor calls GetSerializedSendMessage, whichever happens earlier.
2) Invoking GetSerializedSendMessage now has a side-effect that all future calls to GetSendMessage will return nullptr. 
3) New API method - ModifySendMessage allows interceptors to replace the message to be sent with a new message. Note that the interceptor is responsible for maintaining the life of the message for the duration of the Send message op, i.e., till POST_SEND_MESSAGE is received.

In most cases, interceptors will be prefering GetSendMessage() over GetSerializedSendMessage() if available.
