### PR TITLE
Fix out of disk space flake in run_interop_matrix_tests.py

### DIFF
--- a/tools/internal_ci/linux/grpc_interop_matrix.sh
+++ b/tools/internal_ci/linux/grpc_interop_matrix.sh
@@ -22,4 +22,15 @@ cd $(dirname $0)/../../..
 
 source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
-tools/interop_matrix/run_interop_matrix_tests.py $RUN_TESTS_FLAGS
+# TODO(jtattermusch): Diagnose out of disk space problems. Remove once not needed.
+df -h
+
+tools/interop_matrix/run_interop_matrix_tests.py $RUN_TESTS_FLAGS || FAILED="true"
+
+# TODO(jtattermusch): Diagnose out of disk space problems. Remove once not needed.
+df -h
+
+if [ "$FAILED" != "" ]
+then
+  exit 1
+fi


### PR DESCRIPTION
Internal bug: b/122114875

I was able to rootcause the reason for random "out of disk space" flakes in run_interop_matrix_tests.py. Here's what happens.

In case download of some docker image fails (for whatever reason) randomly, run_interop_tests_matrix_tests.py doesn't cleanup the other downloaded images for given language. When images for the next languages are downloaded, there's not enough space of them, so we suddenly get "out of disk space" error.

This PR fixes the behavior of interop matrix script to always cleanup the downloaded docker images.
Also, it marks the skipped interop tests as "skipped" in the report (as can be seen e.g. here:
https://source.cloud.google.com/results/invocations/9ed4c564-aee8-4c54-81e1-c39a39d30cd5/targets;collapsed=/github%2Fgrpc/tests;passed=false;notrun=true)