### PR TITLE
[WIP] Enable Python 3 for Bazel

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -63,6 +63,11 @@ config_setting(
     values = {"cpu": "x64_windows_msvc"},
 )
 
+config_setting(
+    name = "python3",
+    values = {"python_path": "python3"},
+)
+
 # This should be updated along with build.yaml
 g_stands_for = "goose"
 

--- a/src/python/grpcio/grpc/BUILD.bazel
+++ b/src/python/grpcio/grpc/BUILD.bazel
@@ -15,9 +15,11 @@ py_library(
         "//src/python/grpcio/grpc/_cython:cygrpc",
         "//src/python/grpcio/grpc/experimental",
         "//src/python/grpcio/grpc/framework",
-        requirement('enum34'),
         requirement('six'),
-    ],
+    ] + select({
+        "//conditions:default": [requirement('enum34'),],
+        "//:python3": [],
+    }),
     data = [
         "//:grpc",
     ],

--- a/src/python/grpcio/grpc/framework/common/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/common/BUILD.bazel
@@ -13,15 +13,17 @@ py_library(
 py_library(
     name = "cardinality",
     srcs = ["cardinality.py"],
-    deps = [
-        requirement("enum34"),
-    ],
+    deps = select({
+        "//conditions:default": [requirement('enum34'),],
+        "//:python3": [],
+    }),
 )
 
 py_library(
     name = "style",
     srcs = ["style.py"],
-    deps = [
-        requirement("enum34"),
-    ],
+    deps = select({
+        "//conditions:default": [requirement('enum34'),],
+        "//:python3": [],
+    }),
 )

--- a/src/python/grpcio/grpc/framework/foundation/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/foundation/BUILD.bazel
@@ -23,9 +23,11 @@ py_library(
     name = "callable_util",
     srcs = ["callable_util.py"],
     deps = [
-        requirement("enum34"),
         requirement("six"),
-    ],
+    ] + select({
+        "//conditions:default": [requirement('enum34'),],
+        "//:python3": [],
+    }),
 )
 
 py_library(

--- a/src/python/grpcio/grpc/framework/interfaces/base/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/interfaces/base/BUILD.bazel
@@ -15,15 +15,18 @@ py_library(
     srcs = ["base.py"],
     deps = [
         "//src/python/grpcio/grpc/framework/foundation:abandonment",
-        requirement("enum34"),
         requirement("six"),
-    ],
+    ] + select({
+        "//conditions:default": [requirement('enum34'),],
+        "//:python3": [],
+    }),
 )
 
 py_library(
     name = "utilities",
     srcs = ["utilities.py"],
-    deps = [
-        requirement("enum34"),
-    ],
+    deps = select({
+        "//conditions:default": [requirement('enum34'),],
+        "//:python3": [],
+    }),
 )

--- a/src/python/grpcio/grpc/framework/interfaces/face/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/interfaces/face/BUILD.bazel
@@ -16,9 +16,11 @@ py_library(
     deps = [
         "//src/python/grpcio/grpc/framework/foundation",
         "//src/python/grpcio/grpc/framework/common",
-        requirement("enum34"),
         requirement("six"),
-    ],
+    ] + select({
+        "//conditions:default": [requirement('enum34'),],
+        "//:python3": [],
+    }),
 )
 
 py_library(

--- a/src/python/grpcio_tests/tests/interop/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/interop/BUILD.bazel
@@ -34,12 +34,14 @@ py_library(
         "//src/proto/grpc/testing:py_test_proto",
         requirement('google-auth'),
         requirement('requests'),
-        requirement('enum34'),
         requirement('urllib3'),
         requirement('chardet'),
         requirement('certifi'),
         requirement('idna'),
-    ],
+    ] + select({
+        "//conditions:default": [requirement('enum34'),],
+        "//:python3": [],
+    }),
     imports=["../../",],
 )
 

--- a/src/python/grpcio_tests/tests/unit/_api_test.py
+++ b/src/python/grpcio_tests/tests/unit/_api_test.py
@@ -103,6 +103,7 @@ class ChannelTest(unittest.TestCase):
         channel = grpc.secure_channel('google.com:443', channel_credentials)
         channel.close()
 
+print("HELLO", "WORLD", end='!\n')
 
 if __name__ == '__main__':
     logging.basicConfig()

--- a/third_party/py/python_configure.bzl
+++ b/third_party/py/python_configure.bzl
@@ -139,9 +139,9 @@ def _symlink_genrule_for_dir(repository_ctx,
 def _get_python_bin(repository_ctx):
     """Gets the python bin path."""
     python_bin = repository_ctx.os.environ.get(_PYTHON_BIN_PATH)
-    if python_bin != None:
-        return python_bin
-    python_bin_path = repository_ctx.which("python")
+    if python_bin == None:
+        python_bin = 'python'
+    python_bin_path = repository_ctx.which(python_bin)
     if python_bin_path != None:
         return str(python_bin_path)
     _fail("Cannot find python in PATH, please make sure " +

--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -57,3 +57,6 @@ build:basicprof --copt=-DNDEBUG
 build:basicprof --copt=-O2
 build:basicprof --copt=-DGRPC_BASIC_PROFILER
 build:basicprof --copt=-DGRPC_TIMERS_RDTSC
+
+build:python3 --python_path=python3
+build:python3 --action_env=PYTHON_BIN_PATH=python3


### PR DESCRIPTION
Related: https://github.com/grpc/grpc/issues/17622

With this PR, gRPC developers should be able to use `--config=python3` to switch the Bazel Python interpreter to Python 3.
```
bazel test --config=python3 --test_output=errors //src/python/grpcio_tests/tests/...
```