### PR TITLE
Allow InterceptableView to return the status value

### DIFF
--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -664,7 +664,8 @@ module GRPC
                            :write_flag=, :trailing_metadata)
 
     # InterceptableView further limits access to an ActiveCall's methods
-    # for use in interceptors on the client, exposing only the deadline
-    InterceptableView = view_class(:deadline)
+    # for use in interceptors on the client, exposing only the deadline and the
+    # status.
+    InterceptableView = view_class(:deadline, :status)
   end
 end

--- a/src/ruby/spec/generic/active_call_spec.rb
+++ b/src/ruby/spec/generic/active_call_spec.rb
@@ -86,7 +86,7 @@ describe GRPC::ActiveCall do
 
     describe '#interceptable' do
       it 'exposes a fixed subset of the ActiveCall.methods' do
-        want = %w(deadline)
+        want = %w(deadline status)
         v = @client_call.interceptable
         want.each do |w|
           expect(v.methods.include?(w))


### PR DESCRIPTION
This change allows Ruby interceptors access to the response status code.