### PR TITLE
Allow interceptors to yield and update request arguments

### DIFF
--- a/src/ruby/lib/grpc/generic/client_stub.rb
+++ b/src/ruby/lib/grpc/generic/client_stub.rb
@@ -168,14 +168,16 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
-          interception_context.intercept!(:request_response, intercept_args) do
-            c.request_response(req, metadata: metadata)
+          interception_context.intercept!(:request_response, intercept_args) do |intercepted_args|
+            intercepted_args ||= intercept_args
+            c.request_response(intercepted_args[:request], metadata: intercepted_args[:metadata])
           end
         end
         op
       else
-        interception_context.intercept!(:request_response, intercept_args) do
-          c.request_response(req, metadata: metadata)
+        interception_context.intercept!(:request_response, intercept_args) do |intercepted_args|
+          intercepted_args ||= intercept_args
+          c.request_response(intercepted_args[:request], metadata: intercepted_args[:metadata])
         end
       end
     end
@@ -245,14 +247,16 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
-          interception_context.intercept!(:client_streamer, intercept_args) do
-            c.client_streamer(requests)
+          interception_context.intercept!(:client_streamer, intercept_args) do |intercepted_args|
+            intercepted_args ||= intercept_args
+            c.client_streamer(intercepted_args[:requests], metadata: intercepted_args[:metadata])
           end
         end
         op
       else
-        interception_context.intercept!(:client_streamer, intercept_args) do
-          c.client_streamer(requests, metadata: metadata)
+        interception_context.intercept!(:client_streamer, intercept_args) do |intercepted_args|
+          intercepted_args ||= intercept_args
+          c.client_streamer(intercepted_args[:requests], metadata: intercepted_args[:metadata])
         end
       end
     end
@@ -334,17 +338,18 @@ module GRPC
       if return_op
         # return the operation view of the active_call; define #execute
         # as a new method for this instance that invokes #server_streamer
-        c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
-          interception_context.intercept!(:server_streamer, intercept_args) do
-            c.server_streamer(req, &blk)
+          interception_context.intercept!(:server_streamer, intercept_args) do |intercepted_args|
+            intercepted_args ||= intercept_args
+            c.server_streamer(intercepted_args[:request], metadata: intercepted_args[:metadata], &blk)
           end
         end
         op
       else
-        interception_context.intercept!(:server_streamer, intercept_args) do
-          c.server_streamer(req, metadata: metadata, &blk)
+        interception_context.intercept!(:server_streamer, intercept_args) do |intercepted_args|
+          intercepted_args ||= intercept_args
+          c.server_streamer(intercepted_args[:request], metadata: intercepted_args[:metadata], &blk)
         end
       end
     end
@@ -459,14 +464,16 @@ module GRPC
         c.merge_metadata_to_send(metadata)
         op = c.operation
         op.define_singleton_method(:execute) do
-          interception_context.intercept!(:bidi_streamer, intercept_args) do
-            c.bidi_streamer(requests, &blk)
+          interception_context.intercept!(:bidi_streamer, intercept_args) do |intercepted_args|
+            intercepted_args ||= intercept_args
+            c.bidi_streamer(intercepted_args[:requests], metadata: intercepted_args[:metadata], &blk)
           end
         end
         op
       else
-        interception_context.intercept!(:bidi_streamer, intercept_args) do
-          c.bidi_streamer(requests, metadata: metadata, &blk)
+        interception_context.intercept!(:bidi_streamer, intercept_args) do |intercepted_args|
+          intercepted_args ||= intercept_args
+          c.bidi_streamer(intercepted_args[:requests], metadata: intercepted_args[:metadata], &blk)
         end
       end
     end

--- a/src/ruby/lib/grpc/generic/interceptors.rb
+++ b/src/ruby/lib/grpc/generic/interceptors.rb
@@ -167,18 +167,20 @@ module GRPC
     # @param [Hash] args The arguments for the call
     #
     def intercept!(type, args = {})
-      return yield if @interceptors.none?
+      return yield(args) if @interceptors.none?
 
       i = @interceptors.pop
-      return yield unless i
+      return yield(args) unless i
 
-      i.send(type, args) do
+      i.send(type, args) do |intercepted_args|
+        intercepted_args ||= args
         if @interceptors.any?
-          intercept!(type, args) do
-            yield
+          intercept!(type, intercepted_args) do |nested_intercepted_args|
+            nested_intercepted_args ||= intercepted_args
+            yield nested_intercepted_args
           end
         else
-          yield
+          yield intercepted_args
         end
       end
     end


### PR DESCRIPTION
This change allows Ruby interceptors to modify request values. (Response values are currently passed through the interceptor, and we have no issues modifying those values.) This was encountered while working on supporting OpenCensus in gRPC requests/responses. Specifically, streaming requests/responses are passed as Enumerable values. The approach we would like to take is to wrap the Enumerable with a [Lazy Eumerable](https://ruby-doc.org/core-2.5.0/Enumerator/Lazy.html) that will log when a request or response passes through the gRPC client. However, the current implementation does not allow the request Enumerable to be modified.

This change does not pass all the tests. There are some tests that specify that the request is opened _before_ the values are passed through the interceptors. I don't know how to keep this behavior while still allowing interceptors to wrap the request Enumerable. Therefore I am opening this PR to start a discussion on how to move forward.