### PR TITLE
Allow duplicates in ssl root certificate list.

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -619,10 +619,15 @@ static tsi_result x509_store_load_certs(X509_STORE* cert_store,
       sk_X509_NAME_push(*root_names, root_name);
       root_name = nullptr;
     }
+    ERR_clear_error();
     if (!X509_STORE_add_cert(cert_store, root)) {
-      gpr_log(GPR_ERROR, "Could not add root certificate to ssl context.");
-      result = TSI_INTERNAL_ERROR;
-      break;
+      size_t error = ERR_get_error();
+      if (ERR_GET_LIB(error) != ERR_LIB_X509 ||
+          ERR_GET_REASON(error) != X509_R_CERT_ALREADY_IN_HASH_TABLE) {
+        gpr_log(GPR_ERROR, "Could not add root certificate to ssl context.");
+        result = TSI_INTERNAL_ERROR;
+        break;
+      }
     }
     X509_free(root);
     num_roots++;

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -621,7 +621,7 @@ static tsi_result x509_store_load_certs(X509_STORE* cert_store,
     }
     ERR_clear_error();
     if (!X509_STORE_add_cert(cert_store, root)) {
-      size_t error = ERR_get_error();
+      unsigned long error = ERR_get_error();
       if (ERR_GET_LIB(error) != ERR_LIB_X509 ||
           ERR_GET_REASON(error) != X509_R_CERT_ALREADY_IN_HASH_TABLE) {
         gpr_log(GPR_ERROR, "Could not add root certificate to ssl context.");
@@ -632,7 +632,6 @@ static tsi_result x509_store_load_certs(X509_STORE* cert_store,
     X509_free(root);
     num_roots++;
   }
-
   if (num_roots == 0) {
     gpr_log(GPR_ERROR, "Could not load any root certificate.");
     result = TSI_INVALID_ARGUMENT;

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -777,7 +777,7 @@ void ssl_tsi_test_handshaker_factory_internals() {
 }
 
 void ssl_tsi_test_duplicate_root_certificates() {
-  const char* root_cert = load_file(SSL_TSI_TEST_CREDENTIALS_DIR, "ca.pem");
+  char* root_cert = load_file(SSL_TSI_TEST_CREDENTIALS_DIR, "ca.pem");
   char* dup_root_cert = static_cast<char*>(
       gpr_zalloc(sizeof(char) * (strlen(root_cert) * 2 + 1)));
   memcpy(dup_root_cert, root_cert, strlen(root_cert));
@@ -787,8 +787,8 @@ void ssl_tsi_test_duplicate_root_certificates() {
   GPR_ASSERT(root_store != nullptr);
   // Free memory.
   tsi_ssl_root_certs_store_destroy(root_store);
-  gpr_free((void*)root_cert);
-  gpr_free((void*)dup_root_cert);
+  gpr_free(root_cert);
+  gpr_free(dup_root_cert);
 }
 
 int main(int argc, char** argv) {

--- a/test/core/tsi/ssl_transport_security_test.cc
+++ b/test/core/tsi/ssl_transport_security_test.cc
@@ -776,10 +776,24 @@ void ssl_tsi_test_handshaker_factory_internals() {
   test_tsi_ssl_client_handshaker_factory_bad_params();
 }
 
+void ssl_tsi_test_duplicate_root_certificates() {
+  const char* root_cert = load_file(SSL_TSI_TEST_CREDENTIALS_DIR, "ca.pem");
+  char* dup_root_cert = static_cast<char*>(
+      gpr_zalloc(sizeof(char) * (strlen(root_cert) * 2 + 1)));
+  memcpy(dup_root_cert, root_cert, strlen(root_cert));
+  memcpy(dup_root_cert + strlen(root_cert), root_cert, strlen(root_cert));
+  tsi_ssl_root_certs_store* root_store =
+      tsi_ssl_root_certs_store_create(dup_root_cert);
+  GPR_ASSERT(root_store != nullptr);
+  // Free memory.
+  tsi_ssl_root_certs_store_destroy(root_store);
+  gpr_free((void*)root_cert);
+  gpr_free((void*)dup_root_cert);
+}
+
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   grpc_init();
-
   ssl_tsi_test_do_handshake_tiny_handshake_buffer();
   ssl_tsi_test_do_handshake_small_handshake_buffer();
   ssl_tsi_test_do_handshake();
@@ -801,6 +815,7 @@ int main(int argc, char** argv) {
   ssl_tsi_test_do_round_trip_for_all_configs();
   ssl_tsi_test_do_round_trip_odd_buffer_size();
   ssl_tsi_test_handshaker_factory_internals();
+  ssl_tsi_test_duplicate_root_certificates();
   grpc_shutdown();
   return 0;
 }


### PR DESCRIPTION
This PR allows duplicate root certs in a root cert list instead of returning a failure. It is confirmed that the change will fix #17646. 

Note that I could not reproduce the error the customer observed with the test that is newly added. The test still passes without the change in this PR. @davidben, @jiangtaoli2016, do you know what might be the issue here? 