### PR TITLE
Reenable tcp server posix test after applying workaround

### DIFF
--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -237,7 +237,6 @@ grpc_cc_test(
     name = "tcp_server_posix_test",
     srcs = ["tcp_server_posix_test.cc"],
     language = "C++",
-    tags = ["manual"],  # TODO(adelez): Remove once this works on Foundry.
     deps = [
         "//:gpr",
         "//:grpc",

--- a/test/core/iomgr/tcp_server_posix_test.cc
+++ b/test/core/iomgr/tcp_server_posix_test.cc
@@ -439,6 +439,11 @@ int main(int argc, char** argv) {
       static_cast<test_addrs*>(gpr_zalloc(sizeof(*dst_addrs)));
   grpc::testing::TestEnvironment env(argc, argv);
   grpc_init();
+  // wait a few seconds to make sure IPv6 link-local addresses can be bound
+  // if we are running under docker container that has just started.
+  // See https://github.com/moby/moby/issues/38491
+  // See https://github.com/grpc/grpc/issues/15610
+  gpr_sleep_until(grpc_timeout_seconds_to_deadline(4));
   {
     grpc_core::ExecCtx exec_ctx;
     g_pollset = static_cast<grpc_pollset*>(gpr_zalloc(grpc_pollset_size()));


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/15610

See b/109797594 and https://github.com/moby/moby/issues/38491 for details about the workaround.
The reason why the workaround isn't needed for run_tests.py tests but is needed for foundry is that (unlike run_tests.py) foundry runs each test in a new docker container, so IPv6 link local addresses might not be ready yet when the test is executing.
