### PR TITLE
Remove subchannel args

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel_factory.cc
+++ b/src/core/ext/filters/client_channel/client_channel_factory.cc
@@ -30,7 +30,7 @@ void grpc_client_channel_factory_unref(grpc_client_channel_factory* factory) {
 }
 
 grpc_subchannel* grpc_client_channel_factory_create_subchannel(
-    grpc_client_channel_factory* factory, const grpc_subchannel_args* args) {
+    grpc_client_channel_factory* factory, const grpc_channel_args* args) {
   return factory->vtable->create_subchannel(factory, args);
 }
 

--- a/src/core/ext/filters/client_channel/client_channel_factory.h
+++ b/src/core/ext/filters/client_channel/client_channel_factory.h
@@ -49,7 +49,7 @@ struct grpc_client_channel_factory_vtable {
   void (*ref)(grpc_client_channel_factory* factory);
   void (*unref)(grpc_client_channel_factory* factory);
   grpc_subchannel* (*create_subchannel)(grpc_client_channel_factory* factory,
-                                        const grpc_subchannel_args* args);
+                                        const grpc_channel_args* args);
   grpc_channel* (*create_client_channel)(grpc_client_channel_factory* factory,
                                          const char* target,
                                          grpc_client_channel_type type,
@@ -61,7 +61,7 @@ void grpc_client_channel_factory_unref(grpc_client_channel_factory* factory);
 
 /** Create a new grpc_subchannel */
 grpc_subchannel* grpc_client_channel_factory_create_subchannel(
-    grpc_client_channel_factory* factory, const grpc_subchannel_args* args);
+    grpc_client_channel_factory* factory, const grpc_channel_args* args);
 
 /** Create a new grpc_channel */
 grpc_channel* grpc_client_channel_factory_create_channel(

--- a/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
+++ b/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
@@ -509,12 +509,10 @@ SubchannelList<SubchannelListType, SubchannelDataType>::SubchannelList(
                                          GRPC_ARG_SERVER_ADDRESS_LIST,
                                          GRPC_ARG_INHIBIT_HEALTH_CHECKING};
   // Create a subchannel for each address.
-  grpc_subchannel_args sc_args;
   for (size_t i = 0; i < addresses.size(); i++) {
     // If there were any balancer addresses, we would have chosen grpclb
     // policy, which does not use a SubchannelList.
     GPR_ASSERT(!addresses[i].IsBalancer());
-    memset(&sc_args, 0, sizeof(grpc_subchannel_args));
     InlinedVector<grpc_arg, 4> args_to_add;
     args_to_add.emplace_back(
         grpc_create_subchannel_address_arg(&addresses[i].address()));
@@ -527,9 +525,8 @@ SubchannelList<SubchannelListType, SubchannelDataType>::SubchannelList(
         &args, keys_to_remove, GPR_ARRAY_SIZE(keys_to_remove),
         args_to_add.data(), args_to_add.size());
     gpr_free(args_to_add[0].value.string);
-    sc_args.args = new_args;
     grpc_subchannel* subchannel = grpc_client_channel_factory_create_subchannel(
-        client_channel_factory, &sc_args);
+        client_channel_factory, new_args);
     grpc_channel_args_destroy(new_args);
     if (subchannel == nullptr) {
       // Subchannel could not be created.

--- a/src/core/ext/filters/client_channel/subchannel.h
+++ b/src/core/ext/filters/client_channel/subchannel.h
@@ -38,7 +38,6 @@
     address. Provides a target for load balancing. */
 typedef struct grpc_subchannel grpc_subchannel;
 typedef struct grpc_subchannel_call grpc_subchannel_call;
-typedef struct grpc_subchannel_args grpc_subchannel_args;
 typedef struct grpc_subchannel_key grpc_subchannel_key;
 
 #ifndef NDEBUG
@@ -186,16 +185,9 @@ void grpc_subchannel_call_set_cleanup_closure(
 grpc_call_stack* grpc_subchannel_call_get_call_stack(
     grpc_subchannel_call* subchannel_call);
 
-struct grpc_subchannel_args {
-  /* When updating this struct, also update subchannel_index.c */
-
-  /** Channel arguments to be supplied to the newly created channel */
-  const grpc_channel_args* args;
-};
-
 /** create a subchannel given a connector */
 grpc_subchannel* grpc_subchannel_create(grpc_connector* connector,
-                                        const grpc_subchannel_args* args);
+                                        const grpc_channel_args* args);
 
 /// Sets \a addr from \a args.
 void grpc_get_subchannel_address_arg(const grpc_channel_args* args,

--- a/src/core/ext/filters/client_channel/subchannel_index.cc
+++ b/src/core/ext/filters/client_channel/subchannel_index.cc
@@ -39,38 +39,37 @@ static gpr_mu g_mu;
 static gpr_refcount g_refcount;
 
 struct grpc_subchannel_key {
-  grpc_subchannel_args args;
+  grpc_channel_args* args;
 };
 
 static bool g_force_creation = false;
 
 static grpc_subchannel_key* create_key(
-    const grpc_subchannel_args* args,
+    const grpc_channel_args* args,
     grpc_channel_args* (*copy_channel_args)(const grpc_channel_args* args)) {
   grpc_subchannel_key* k =
       static_cast<grpc_subchannel_key*>(gpr_malloc(sizeof(*k)));
-  k->args.args = copy_channel_args(args->args);
+  k->args = copy_channel_args(args);
   return k;
 }
 
-grpc_subchannel_key* grpc_subchannel_key_create(
-    const grpc_subchannel_args* args) {
+grpc_subchannel_key* grpc_subchannel_key_create(const grpc_channel_args* args) {
   return create_key(args, grpc_channel_args_normalize);
 }
 
 static grpc_subchannel_key* subchannel_key_copy(grpc_subchannel_key* k) {
-  return create_key(&k->args, grpc_channel_args_copy);
+  return create_key(k->args, grpc_channel_args_copy);
 }
 
 int grpc_subchannel_key_compare(const grpc_subchannel_key* a,
                                 const grpc_subchannel_key* b) {
   // To pretend the keys are different, return a non-zero value.
   if (GPR_UNLIKELY(g_force_creation)) return 1;
-  return grpc_channel_args_compare(a->args.args, b->args.args);
+  return grpc_channel_args_compare(a->args, b->args);
 }
 
 void grpc_subchannel_key_destroy(grpc_subchannel_key* k) {
-  grpc_channel_args_destroy(const_cast<grpc_channel_args*>(k->args.args));
+  grpc_channel_args_destroy(k->args);
   gpr_free(k);
 }
 

--- a/src/core/ext/filters/client_channel/subchannel_index.h
+++ b/src/core/ext/filters/client_channel/subchannel_index.h
@@ -27,8 +27,7 @@
     shared amongst channels */
 
 /** Create a key that can be used to uniquely identify a subchannel */
-grpc_subchannel_key* grpc_subchannel_key_create(
-    const grpc_subchannel_args* args);
+grpc_subchannel_key* grpc_subchannel_key_create(const grpc_channel_args* args);
 
 /** Destroy a subchannel key */
 void grpc_subchannel_key_destroy(grpc_subchannel_key* key);

--- a/src/core/ext/transport/chttp2/client/insecure/channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/insecure/channel_create.cc
@@ -40,14 +40,12 @@ static void client_channel_factory_unref(
     grpc_client_channel_factory* cc_factory) {}
 
 static grpc_subchannel* client_channel_factory_create_subchannel(
-    grpc_client_channel_factory* cc_factory, const grpc_subchannel_args* args) {
-  grpc_subchannel_args final_sc_args;
-  memcpy(&final_sc_args, args, sizeof(*args));
-  final_sc_args.args = grpc_default_authority_add_if_not_present(args->args);
+    grpc_client_channel_factory* cc_factory, const grpc_channel_args* args) {
+  grpc_channel_args* new_args = grpc_default_authority_add_if_not_present(args);
   grpc_connector* connector = grpc_chttp2_connector_create();
-  grpc_subchannel* s = grpc_subchannel_create(connector, &final_sc_args);
+  grpc_subchannel* s = grpc_subchannel_create(connector, new_args);
   grpc_connector_unref(connector);
-  grpc_channel_args_destroy(const_cast<grpc_channel_args*>(final_sc_args.args));
+  grpc_channel_args_destroy(new_args);
   return s;
 }
 

--- a/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
@@ -46,10 +46,10 @@ static void client_channel_factory_ref(
 static void client_channel_factory_unref(
     grpc_client_channel_factory* cc_factory) {}
 
-static grpc_subchannel_args* get_secure_naming_subchannel_args(
-    const grpc_subchannel_args* args) {
+static grpc_channel_args* get_secure_naming_channel_args(
+    const grpc_channel_args* args) {
   grpc_channel_credentials* channel_credentials =
-      grpc_channel_credentials_find_in_args(args->args);
+      grpc_channel_credentials_find_in_args(args);
   if (channel_credentials == nullptr) {
     gpr_log(GPR_ERROR,
             "Can't create subchannel: channel credentials missing for secure "
@@ -57,7 +57,7 @@ static grpc_subchannel_args* get_secure_naming_subchannel_args(
     return nullptr;
   }
   // Make sure security connector does not already exist in args.
-  if (grpc_security_connector_find_in_args(args->args) != nullptr) {
+  if (grpc_security_connector_find_in_args(args) != nullptr) {
     gpr_log(GPR_ERROR,
             "Can't create subchannel: security connector already present in "
             "channel args.");
@@ -65,19 +65,18 @@ static grpc_subchannel_args* get_secure_naming_subchannel_args(
   }
   // To which address are we connecting? By default, use the server URI.
   const grpc_arg* server_uri_arg =
-      grpc_channel_args_find(args->args, GRPC_ARG_SERVER_URI);
+      grpc_channel_args_find(args, GRPC_ARG_SERVER_URI);
   const char* server_uri_str = grpc_channel_arg_get_string(server_uri_arg);
   GPR_ASSERT(server_uri_str != nullptr);
   grpc_uri* server_uri =
       grpc_uri_parse(server_uri_str, true /* supress errors */);
   GPR_ASSERT(server_uri != nullptr);
   const grpc_core::TargetAuthorityTable* target_authority_table =
-      grpc_core::FindTargetAuthorityTableInArgs(args->args);
+      grpc_core::FindTargetAuthorityTableInArgs(args);
   grpc_core::UniquePtr<char> authority;
   if (target_authority_table != nullptr) {
     // Find the authority for the target.
-    const char* target_uri_str =
-        grpc_get_subchannel_address_uri_arg(args->args);
+    const char* target_uri_str = grpc_get_subchannel_address_uri_arg(args);
     grpc_uri* target_uri =
         grpc_uri_parse(target_uri_str, false /* suppress errors */);
     GPR_ASSERT(target_uri != nullptr);
@@ -100,15 +99,14 @@ static grpc_subchannel_args* get_secure_naming_subchannel_args(
   }
   grpc_arg args_to_add[2];
   size_t num_args_to_add = 0;
-  if (grpc_channel_args_find(args->args, GRPC_ARG_DEFAULT_AUTHORITY) ==
-      nullptr) {
+  if (grpc_channel_args_find(args, GRPC_ARG_DEFAULT_AUTHORITY) == nullptr) {
     // If the channel args don't already contain GRPC_ARG_DEFAULT_AUTHORITY, add
     // the arg, setting it to the value just obtained.
     args_to_add[num_args_to_add++] = grpc_channel_arg_string_create(
         const_cast<char*>(GRPC_ARG_DEFAULT_AUTHORITY), authority.get());
   }
   grpc_channel_args* args_with_authority =
-      grpc_channel_args_copy_and_add(args->args, args_to_add, num_args_to_add);
+      grpc_channel_args_copy_and_add(args, args_to_add, num_args_to_add);
   grpc_uri_destroy(server_uri);
   // Create the security connector using the credentials and target name.
   grpc_channel_args* new_args_from_connector = nullptr;
@@ -137,29 +135,21 @@ static grpc_subchannel_args* get_secure_naming_subchannel_args(
     grpc_channel_args_destroy(new_args_from_connector);
   }
   grpc_channel_args_destroy(args_with_authority);
-  grpc_subchannel_args* final_sc_args =
-      static_cast<grpc_subchannel_args*>(gpr_malloc(sizeof(*final_sc_args)));
-  memcpy(final_sc_args, args, sizeof(*args));
-  final_sc_args->args = new_args;
-  return final_sc_args;
+  return new_args;
 }
 
 static grpc_subchannel* client_channel_factory_create_subchannel(
-    grpc_client_channel_factory* cc_factory, const grpc_subchannel_args* args) {
-  grpc_subchannel_args* subchannel_args =
-      get_secure_naming_subchannel_args(args);
-  if (subchannel_args == nullptr) {
-    gpr_log(
-        GPR_ERROR,
-        "Failed to create subchannel arguments during subchannel creation.");
+    grpc_client_channel_factory* cc_factory, const grpc_channel_args* args) {
+  grpc_channel_args* new_args = get_secure_naming_channel_args(args);
+  if (new_args == nullptr) {
+    gpr_log(GPR_ERROR,
+            "Failed to create channel args during subchannel creation.");
     return nullptr;
   }
   grpc_connector* connector = grpc_chttp2_connector_create();
-  grpc_subchannel* s = grpc_subchannel_create(connector, subchannel_args);
+  grpc_subchannel* s = grpc_subchannel_create(connector, new_args);
   grpc_connector_unref(connector);
-  grpc_channel_args_destroy(
-      const_cast<grpc_channel_args*>(subchannel_args->args));
-  gpr_free(subchannel_args);
+  grpc_channel_args_destroy(new_args);
   return s;
 }
 

--- a/test/cpp/microbenchmarks/bm_call_create.cc
+++ b/test/cpp/microbenchmarks/bm_call_create.cc
@@ -326,7 +326,7 @@ class FakeClientChannelFactory : public grpc_client_channel_factory {
   static void NoRef(grpc_client_channel_factory* factory) {}
   static void NoUnref(grpc_client_channel_factory* factory) {}
   static grpc_subchannel* CreateSubchannel(grpc_client_channel_factory* factory,
-                                           const grpc_subchannel_args* args) {
+                                           const grpc_channel_args* args) {
     return nullptr;
   }
   static grpc_channel* CreateClientChannel(grpc_client_channel_factory* factory,


### PR DESCRIPTION
After https://github.com/grpc/grpc/pull/17629, the `grpc_subchannel_args` can be replaced with the flat `grpc_channel_args`.

https://github.com/grpc/grpc/pull/17513 needs to pass `subchannel_pool` as an arg, and we will make it an ordinary channel arg.

I extracted this PR from https://github.com/grpc/grpc/pull/17513 because I had difficulty debugging some secure channel related issue there.