### PR TITLE
Switch to absolute import

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -24,7 +24,7 @@ from grpc._cython import cygrpc as _cygrpc
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 try:
-    from ._grpcio_metadata import __version__
+    from grpc._grpcio_metadata import __version__
 except ImportError:
     __version__ = "dev0"
 


### PR DESCRIPTION
As a rule, we should prefer absolute imports to relative imports.