### PR TITLE
Remove hostname trailing slash

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCChannelPool.m
+++ b/src/objective-c/GRPCClient/private/GRPCChannelPool.m
@@ -236,6 +236,12 @@ static const NSTimeInterval kDefaultChannelDestroyDelay = 30;
     return nil;
   }
 
+  // remove trailing slash of hostname
+  NSURL *hostURL = [NSURL URLWithString:[@"https://" stringByAppendingString:host]];
+  if (hostURL.host && hostURL.port == nil) {
+    host = [hostURL.host stringByAppendingString:@":443"];
+  }
+
   GRPCPooledChannel *pooledChannel = nil;
   GRPCChannelConfiguration *configuration =
       [[GRPCChannelConfiguration alloc] initWithHost:host callOptions:callOptions];


### PR DESCRIPTION
gRPC ObjC library used to removes trailing slash of hostnames. A recent change #16190 removed that part and caused name resolution issue for some users. This PR recovers the failure.