### PR TITLE
Fix build with bazel 0.21

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -124,8 +124,8 @@ def grpc_deps():
     if "com_google_protobuf" not in native.existing_rules():
         http_archive(
             name = "com_google_protobuf",
-            strip_prefix = "protobuf-48cb18e5c419ddd23d9badcfe4e9df7bde1979b2",
-            url = "https://github.com/google/protobuf/archive/48cb18e5c419ddd23d9badcfe4e9df7bde1979b2.tar.gz",
+            strip_prefix = "protobuf-66dc42d891a4fc8e9190c524fd67961688a37bbe",
+            url = "https://github.com/google/protobuf/archive/66dc42d891a4fc8e9190c524fd67961688a37bbe.tar.gz",
         )
 
     if "com_github_nanopb_nanopb" not in native.existing_rules():


### PR DESCRIPTION
Together with changes in https://github.com/grpc/grpc/pull/17678 this fixes https://github.com/grpc/grpc/issues/17564

I tested locally and both problems mentioned in  #17564 go away if protobuf is upgraded to https://github.com/protocolbuffers/protobuf/releases/tag/v3.6.1.3