### PR TITLE
avoid AttributeError when object init fails

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -1063,5 +1063,5 @@ class Channel(grpc.Channel):
             cygrpc.fork_unregister_channel(self)
         # This prevent the failed-at-initializing object removal from failing.
         # Though the __init__ failed, the removal will still trigger __del__.
-        if _moot is not None and hasattr(self, "_connectivity_state"):
+        if _moot is not None and hasattr(self, '_connectivity_state'):
             _moot(self._connectivity_state)

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -860,9 +860,10 @@ class _Server(grpc.Server):
         return _stop(self._state, grace)
 
     def __del__(self):
-        # We can not grab a lock in __del__(), so set a flag to signal the
-        # serving daemon thread (if it exists) to initiate shutdown.
-        self._state.server_deallocated = True
+        if hasattr(self, '_state'):
+            # We can not grab a lock in __del__(), so set a flag to signal the
+            # serving daemon thread (if it exists) to initiate shutdown.
+            self._state.server_deallocated = True
 
 
 def create_server(thread_pool, generic_rpc_handlers, interceptors, options,


### PR DESCRIPTION
@lidizheng #16864 included a similar check for channel-side. I think it's probably worth backporting this to 1.18.x to avoid the potential logspam; will follow up with a backport PR if you agree.