### PR TITLE
Fix warning

### DIFF
--- a/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
+++ b/src/cpp/server/load_reporter/load_reporter_async_service_impl.cc
@@ -211,8 +211,8 @@ void LoadReporterAsyncServiceImpl::ReportLoadHandler::OnReadDone(
                                           load_key_);
       const auto& load_report_interval = initial_request.load_report_interval();
       load_report_interval_ms_ =
-          static_cast<uint64_t>(load_report_interval.seconds() * 1000 +
-                                load_report_interval.nanos() / 1000);
+          static_cast<unsigned long>(load_report_interval.seconds() * 1000 +
+                                     load_report_interval.nanos() / 1000);
       gpr_log(
           GPR_INFO,
           "[LRS %p] Initial request received. Start load reporting (load "


### PR DESCRIPTION
This PR is trying to fix the below warning which I noticed while doing `bazel build :all`
```
INFO: From Compiling src/cpp/server/load_reporter/load_reporter_async_service_impl.cc:
src/cpp/server/load_reporter/load_reporter_async_service_impl.cc:220:54: warning: format specifies type 'unsigned long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
          service_, load_balanced_hostname_.c_str(), load_report_interval_ms_,
                                                     ^~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```