### PR TITLE
Correct a format string

### DIFF
--- a/src/core/lib/gpr/log_posix.cc
+++ b/src/core/lib/gpr/log_posix.cc
@@ -24,6 +24,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
 #include <grpc/support/time.h>
+#include <inttypes.h>
 #include <pthread.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -83,7 +84,7 @@ void gpr_default_log(gpr_log_func_args* args) {
   }
 
   char* prefix;
-  gpr_asprintf(&prefix, "%s%s.%09d %7tu %s:%d]",
+  gpr_asprintf(&prefix, "%s%s.%09d %7" PRIdPTR " %s:%d]",
                gpr_log_severity_string(args->severity), time_buffer,
                (int)(now.tv_nsec), gettid(), display_file, args->line);
 


### PR DESCRIPTION
Use a format string macro from inttypes.h when `printf`ing thread IDs on non-Windows, non-Linux platforms. This silences a -Wformat trigger when cross-compiling for macOS.