### PR TITLE
Remove force_creation param from subchannel index

### DIFF
--- a/src/core/ext/filters/client_channel/subchannel_index.cc
+++ b/src/core/ext/filters/client_channel/subchannel_index.cc
@@ -42,8 +42,6 @@ struct grpc_subchannel_key {
   grpc_channel_args* args;
 };
 
-static bool g_force_creation = false;
-
 static grpc_subchannel_key* create_key(
     const grpc_channel_args* args,
     grpc_channel_args* (*copy_channel_args)(const grpc_channel_args* args)) {
@@ -63,8 +61,6 @@ static grpc_subchannel_key* subchannel_key_copy(grpc_subchannel_key* k) {
 
 int grpc_subchannel_key_compare(const grpc_subchannel_key* a,
                                 const grpc_subchannel_key* b) {
-  // To pretend the keys are different, return a non-zero value.
-  if (GPR_UNLIKELY(g_force_creation)) return 1;
   return grpc_channel_args_compare(a->args, b->args);
 }
 
@@ -223,8 +219,4 @@ void grpc_subchannel_index_unregister(grpc_subchannel_key* key,
     grpc_avl_unref(updated, nullptr);
     grpc_avl_unref(index, nullptr);
   }
-}
-
-void grpc_subchannel_index_test_only_set_force_creation(bool force_creation) {
-  g_force_creation = force_creation;
 }

--- a/src/core/ext/filters/client_channel/subchannel_index.h
+++ b/src/core/ext/filters/client_channel/subchannel_index.h
@@ -63,13 +63,4 @@ void grpc_subchannel_index_ref(void);
     to zero, unref the subchannel index and destroy its mutex. */
 void grpc_subchannel_index_unref(void);
 
-/** \em TEST ONLY.
- * If \a force_creation is true, all keys are regarded different, resulting in
- * new subchannels always being created. Otherwise, the keys will be compared as
- * usual.
- *
- * Tests using this function \em MUST run tests with and without \a
- * force_creation set. */
-void grpc_subchannel_index_test_only_set_force_creation(bool force_creation);
-
 #endif /* GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_SUBCHANNEL_INDEX_H */


### PR DESCRIPTION
Reverts the change to subchannel index and `PickFirstManyUpdates` added by https://github.com/grpc/grpc/pull/11761, as advised here https://github.com/grpc/grpc/pull/17513#pullrequestreview-191736800.

Reverting because
1. The change is not obviously related to that PR. We don't have a good reason to keep the change.
2. It's adding overhead to production code just for testing.