### PR TITLE
Re-enable c-ares as the default resolver; but don't turn on SRV queries

### DIFF
--- a/include/grpc/impl/codegen/grpc_types.h
+++ b/include/grpc/impl/codegen/grpc_types.h
@@ -350,6 +350,11 @@ typedef struct {
 /** If set, inhibits health checking (which may be enabled via the
  *  service config.) */
 #define GRPC_ARG_INHIBIT_HEALTH_CHECKING "grpc.inhibit_health_checking"
+/** If set, the channel's resolver is allowed to query for SRV records.
+ * For example, this is useful as a way to enable the "grpclb"
+ * load balancing policy. Note that this only works with the "ares"
+ * DNS resolver, and isn't supported by the "native" DNS resolver. */
+#define GRPC_ARG_DNS_ENABLE_SRV_QUERIES "grpc.dns_enable_srv_queries"
 /** If set, determines the number of milliseconds that the c-ares based
  * DNS resolver will wait on queries before cancelling them. The default value
  * is 10000. Setting this to "0" will disable c-ares query timeouts

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -125,6 +125,8 @@ class AresDnsResolver : public Resolver {
   bool shutdown_initiated_ = false;
   // timeout in milliseconds for active DNS queries
   int query_timeout_ms_;
+  // whether or not to enable SRV DNS queries
+  bool enable_srv_queries_;
 };
 
 AresDnsResolver::AresDnsResolver(const ResolverArgs& args)
@@ -146,14 +148,18 @@ AresDnsResolver::AresDnsResolver(const ResolverArgs& args)
     dns_server_ = gpr_strdup(args.uri->authority);
   }
   channel_args_ = grpc_channel_args_copy(args.args);
+  // Disable service config option
   const grpc_arg* arg = grpc_channel_args_find(
       channel_args_, GRPC_ARG_SERVICE_CONFIG_DISABLE_RESOLUTION);
-  grpc_integer_options integer_options = {false, false, true};
-  request_service_config_ = !grpc_channel_arg_get_integer(arg, integer_options);
+  request_service_config_ = !grpc_channel_arg_get_bool(arg, false);
+  // Min time b/t resolutions option
   arg = grpc_channel_args_find(channel_args_,
                                GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS);
   min_time_between_resolutions_ =
       grpc_channel_arg_get_integer(arg, {1000, 0, INT_MAX});
+  // Enable SRV queries option
+  arg = grpc_channel_args_find(channel_args_, GRPC_ARG_DNS_ENABLE_SRV_QUERIES);
+  enable_srv_queries_ = grpc_channel_arg_get_bool(arg, false);
   interested_parties_ = grpc_pollset_set_create();
   if (args.pollset_set != nullptr) {
     grpc_pollset_set_add_pollset_set(interested_parties_, args.pollset_set);
@@ -419,7 +425,7 @@ void AresDnsResolver::StartResolvingLocked() {
   service_config_json_ = nullptr;
   pending_request_ = grpc_dns_lookup_ares_locked(
       dns_server_, name_to_resolve_, kDefaultPort, interested_parties_,
-      &on_resolved_, &addresses_, true /* check_grpclb */,
+      &on_resolved_, &addresses_, enable_srv_queries_ /* check_grpclb */,
       request_service_config_ ? &service_config_json_ : nullptr,
       query_timeout_ms_, combiner());
   last_resolution_timestamp_ = grpc_core::ExecCtx::Get()->Now();
@@ -472,13 +478,12 @@ static grpc_address_resolver_vtable ares_resolver = {
     grpc_resolve_address_ares, blocking_resolve_address_ares};
 
 static bool should_use_ares(const char* resolver_env) {
-  return resolver_env != nullptr && gpr_stricmp(resolver_env, "ares") == 0;
+  return resolver_env == nullptr || strlen(resolver_env) == 0 ||
+         gpr_stricmp(resolver_env, "ares") == 0;
 }
 
 void grpc_resolver_dns_ares_init() {
   char* resolver_env = gpr_getenv("GRPC_DNS_RESOLVER");
-  /* TODO(zyc): Turn on c-ares based resolver by default after the address
-     sorter and the CNAME support are added. */
   if (should_use_ares(resolver_env)) {
     gpr_log(GPR_DEBUG, "Using ares dns resolver");
     address_sorting_init();

--- a/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
@@ -205,6 +205,7 @@ grpc_channel* grpc_secure_channel_create(grpc_channel_credentials* creds,
         grpc_channel_credentials_to_arg(creds)};
     grpc_channel_args* new_args = grpc_channel_args_copy_and_add(
         args, args_to_add, GPR_ARRAY_SIZE(args_to_add));
+    new_args = creds->update_arguments(new_args);
     // Create channel.
     channel = client_channel_factory_create_channel(
         &client_channel_factory, target, GRPC_CLIENT_CHANNEL_TYPE_REGULAR,

--- a/src/core/lib/security/credentials/composite/composite_credentials.h
+++ b/src/core/lib/security/credentials/composite/composite_credentials.h
@@ -49,6 +49,10 @@ class grpc_composite_channel_credentials : public grpc_channel_credentials {
       const char* target, const grpc_channel_args* args,
       grpc_channel_args** new_args) override;
 
+  grpc_channel_args* update_arguments(grpc_channel_args* args) override {
+    return inner_creds_->update_arguments(args);
+  }
+
   const grpc_channel_credentials* inner_creds() const {
     return inner_creds_.get();
   }

--- a/src/core/lib/security/credentials/credentials.h
+++ b/src/core/lib/security/credentials/credentials.h
@@ -123,6 +123,14 @@ struct grpc_channel_credentials
     return Ref();
   }
 
+  // Allows credentials to optionally modify a parent channel's args.
+  // By default, leave channel args as is. The callee takes ownership
+  // of the passed-in channel args, and the caller takes ownership
+  // of the returned channel args.
+  virtual grpc_channel_args* update_arguments(grpc_channel_args* args) {
+    return args;
+  }
+
   const char* type() const { return type_; }
 
   GRPC_ABSTRACT_BASE_CLASS

--- a/src/core/lib/security/credentials/google_default/google_default_credentials.cc
+++ b/src/core/lib/security/credentials/google_default/google_default_credentials.cc
@@ -114,6 +114,19 @@ grpc_google_default_channel_credentials::create_security_connector(
   return sc;
 }
 
+grpc_channel_args* grpc_google_default_channel_credentials::update_arguments(
+    grpc_channel_args* args) {
+  grpc_channel_args* updated = args;
+  if (grpc_channel_args_find(args, GRPC_ARG_DNS_ENABLE_SRV_QUERIES) ==
+      nullptr) {
+    grpc_arg new_srv_arg = grpc_channel_arg_integer_create(
+        const_cast<char*>(GRPC_ARG_DNS_ENABLE_SRV_QUERIES), true);
+    updated = grpc_channel_args_copy_and_add(args, &new_srv_arg, 1);
+    grpc_channel_args_destroy(args);
+  }
+  return updated;
+}
+
 static void on_metadata_server_detection_http_response(void* user_data,
                                                        grpc_error* error) {
   metadata_server_detector* detector =

--- a/src/core/lib/security/credentials/google_default/google_default_credentials.h
+++ b/src/core/lib/security/credentials/google_default/google_default_credentials.h
@@ -58,6 +58,8 @@ class grpc_google_default_channel_credentials
       const char* target, const grpc_channel_args* args,
       grpc_channel_args** new_args) override;
 
+  grpc_channel_args* update_arguments(grpc_channel_args* args) override;
+
   const grpc_channel_credentials* alts_creds() const {
     return alts_creds_.get();
   }

--- a/templates/test/cpp/naming/resolver_component_tests_defs.include
+++ b/templates/test/cpp/naming/resolver_component_tests_defs.include
@@ -55,7 +55,6 @@ if cur_resolver and cur_resolver != 'ares':
       'needs to use GRPC_DNS_RESOLVER=ares.'))
   test_runner_log('Exit 1 without running tests.')
   sys.exit(1)
-os.environ.update({'GRPC_DNS_RESOLVER': 'ares'})
 os.environ.update({'GRPC_TRACE': 'cares_resolver'})
 
 def wait_until_dns_server_is_up(args,

--- a/test/core/client_channel/resolvers/dns_resolver_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_test.cc
@@ -75,7 +75,7 @@ int main(int argc, char** argv) {
   test_succeeds(dns, "dns:www.google.com");
   test_succeeds(dns, "dns:///www.google.com");
   char* resolver_env = gpr_getenv("GRPC_DNS_RESOLVER");
-  if (resolver_env == nullptr || gpr_stricmp(resolver_env, "native") == 0) {
+  if (resolver_env != nullptr && gpr_stricmp(resolver_env, "native") == 0) {
     test_fails(dns, "dns://8.8.8.8/8.8.8.8:8888");
   } else {
     test_succeeds(dns, "dns://8.8.8.8/8.8.8.8:8888");

--- a/test/cpp/naming/gen_build_yaml.py
+++ b/test/cpp/naming/gen_build_yaml.py
@@ -48,6 +48,7 @@ def _resolver_test_cases(resolver_component_data):
             ('expected_chosen_service_config',
              (test_case['expected_chosen_service_config'] or '')),
             ('expected_lb_policy', (test_case['expected_lb_policy'] or '')),
+            ('enable_srv_queries', test_case['enable_srv_queries']),
         ],
     })
   return out

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -19,6 +19,7 @@
 #include <grpc/support/port_platform.h>
 
 #include <grpc/grpc.h>
+#include <grpc/impl/codegen/grpc_types.h>
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
 #include <grpc/support/string_util.h>
@@ -91,6 +92,13 @@ DEFINE_string(expected_chosen_service_config, "",
 DEFINE_string(
     local_dns_server_address, "",
     "Optional. This address is placed as the uri authority if present.");
+DEFINE_string(
+    enable_srv_queries, "",
+    "Whether or not to enable SRV queries for the ares resolver instance."
+    "It would be better if this arg could be bool, but the way that we "
+    "generate "
+    "the python script runner doesn't allow us to pass a gflags bool to this "
+    "binary.");
 DEFINE_string(expected_lb_policy, "",
               "Expected lb policy name that appears in resolver result channel "
               "arg. Empty for none.");
@@ -438,10 +446,26 @@ void RunResolvesRelevantRecordsTest(void (*OnDoneLocked)(void* arg,
   GPR_ASSERT(gpr_asprintf(&whole_uri, "dns://%s/%s",
                           FLAGS_local_dns_server_address.c_str(),
                           FLAGS_target_name.c_str()));
+  gpr_log(GPR_DEBUG, "resolver_component_test: --enable_srv_queries: %s",
+          FLAGS_enable_srv_queries.c_str());
+  grpc_channel_args* resolver_args = nullptr;
+  // By default, SRV queries are disabled, so tests that expect no SRV query
+  // should avoid setting any channel arg. Test cases that do rely on the SRV
+  // query must explicitly enable SRV though.
+  if (FLAGS_enable_srv_queries == "True") {
+    grpc_arg srv_queries_arg = grpc_channel_arg_integer_create(
+        const_cast<char*>(GRPC_ARG_DNS_ENABLE_SRV_QUERIES), true);
+    resolver_args =
+        grpc_channel_args_copy_and_add(nullptr, &srv_queries_arg, 1);
+  } else if (FLAGS_enable_srv_queries != "False") {
+    gpr_log(GPR_DEBUG, "Invalid value for --enable_srv_queries.");
+    abort();
+  }
   // create resolver and resolve
   grpc_core::OrphanablePtr<grpc_core::Resolver> resolver =
-      grpc_core::ResolverRegistry::CreateResolver(whole_uri, nullptr,
+      grpc_core::ResolverRegistry::CreateResolver(whole_uri, resolver_args,
                                                   args.pollset_set, args.lock);
+  grpc_channel_args_destroy(resolver_args);
   gpr_free(whole_uri);
   grpc_closure on_resolver_result_changed;
   GRPC_CLOSURE_INIT(&on_resolver_result_changed, OnDoneLocked, (void*)&args,

--- a/test/cpp/naming/resolver_component_tests_runner.py
+++ b/test/cpp/naming/resolver_component_tests_runner.py
@@ -55,7 +55,6 @@ if cur_resolver and cur_resolver != 'ares':
       'needs to use GRPC_DNS_RESOLVER=ares.'))
   test_runner_log('Exit 1 without running tests.')
   sys.exit(1)
-os.environ.update({'GRPC_DNS_RESOLVER': 'ares'})
 os.environ.update({'GRPC_TRACE': 'cares_resolver'})
 
 def wait_until_dns_server_is_up(args,
@@ -126,6 +125,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '5.5.5.5:443,False',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
+  '--enable_srv_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -138,6 +138,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:1234,True',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
+  '--enable_srv_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -150,6 +151,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.5:1234,True;1.2.3.6:1234,True;1.2.3.7:1234,True',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
+  '--enable_srv_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -162,6 +164,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '[2607:f8b0:400a:801::1001]:1234,True',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
+  '--enable_srv_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -174,6 +177,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1003]:1234,True;[2607:f8b0:400a:801::1004]:1234,True',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
+  '--enable_srv_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -186,6 +190,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:1234,True',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}',
   '--expected_lb_policy', 'round_robin',
+  '--enable_srv_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -198,6 +203,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}',
   '--expected_lb_policy', 'round_robin',
+  '--enable_srv_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -210,6 +216,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
+  '--enable_srv_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -222,6 +229,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
+  '--enable_srv_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -234,6 +242,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}',
   '--expected_lb_policy', 'round_robin',
+  '--enable_srv_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -246,6 +255,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}',
   '--expected_lb_policy', 'round_robin',
+  '--enable_srv_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -258,6 +268,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:1234,True;1.2.3.4:443,False',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
+  '--enable_srv_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -270,6 +281,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '[2607:f8b0:400a:801::1002]:1234,True;[2607:f8b0:400a:801::1002]:443,False',
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
+  '--enable_srv_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -282,6 +294,72 @@ current_test_subprocess = subprocess.Popen([
   '--expected_addrs', '1.2.3.4:443,False',
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}',
   '--expected_lb_policy', '',
+  '--enable_srv_queries', 'True',
+  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+current_test_subprocess.communicate()
+if current_test_subprocess.returncode != 0:
+  num_test_failures += 1
+
+test_runner_log('Run test with target: %s' % 'srv-ipv4-single-target-srv-disabled.resolver-tests-version-4.grpctestingexp.')
+current_test_subprocess = subprocess.Popen([
+  args.test_bin_path,
+  '--target_name', 'srv-ipv4-single-target-srv-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--expected_addrs', '2.3.4.5:443,False',
+  '--expected_chosen_service_config', '',
+  '--expected_lb_policy', '',
+  '--enable_srv_queries', 'False',
+  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+current_test_subprocess.communicate()
+if current_test_subprocess.returncode != 0:
+  num_test_failures += 1
+
+test_runner_log('Run test with target: %s' % 'srv-ipv4-multi-target-srv-disabled.resolver-tests-version-4.grpctestingexp.')
+current_test_subprocess = subprocess.Popen([
+  args.test_bin_path,
+  '--target_name', 'srv-ipv4-multi-target-srv-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--expected_addrs', '9.2.3.5:443,False;9.2.3.6:443,False;9.2.3.7:443,False',
+  '--expected_chosen_service_config', '',
+  '--expected_lb_policy', '',
+  '--enable_srv_queries', 'False',
+  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+current_test_subprocess.communicate()
+if current_test_subprocess.returncode != 0:
+  num_test_failures += 1
+
+test_runner_log('Run test with target: %s' % 'srv-ipv6-single-target-srv-disabled.resolver-tests-version-4.grpctestingexp.')
+current_test_subprocess = subprocess.Popen([
+  args.test_bin_path,
+  '--target_name', 'srv-ipv6-single-target-srv-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--expected_addrs', '[2600::1001]:443,False',
+  '--expected_chosen_service_config', '',
+  '--expected_lb_policy', '',
+  '--enable_srv_queries', 'False',
+  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+current_test_subprocess.communicate()
+if current_test_subprocess.returncode != 0:
+  num_test_failures += 1
+
+test_runner_log('Run test with target: %s' % 'srv-ipv6-multi-target-srv-disabled.resolver-tests-version-4.grpctestingexp.')
+current_test_subprocess = subprocess.Popen([
+  args.test_bin_path,
+  '--target_name', 'srv-ipv6-multi-target-srv-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--expected_addrs', '[2600::1002]:443,False;[2600::1003]:443,False;[2600::1004]:443,False',
+  '--expected_chosen_service_config', '',
+  '--expected_lb_policy', '',
+  '--enable_srv_queries', 'False',
+  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+current_test_subprocess.communicate()
+if current_test_subprocess.returncode != 0:
+  num_test_failures += 1
+
+test_runner_log('Run test with target: %s' % 'srv-ipv4-simple-service-config-srv-disabled.resolver-tests-version-4.grpctestingexp.')
+current_test_subprocess = subprocess.Popen([
+  args.test_bin_path,
+  '--target_name', 'srv-ipv4-simple-service-config-srv-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--expected_addrs', '5.5.3.4:443,False',
+  '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}',
+  '--expected_lb_policy', 'round_robin',
+  '--enable_srv_queries', 'False',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:

--- a/test/cpp/naming/resolver_test_record_groups.yaml
+++ b/test/cpp/naming/resolver_test_record_groups.yaml
@@ -1,9 +1,11 @@
 resolver_tests_common_zone_name: resolver-tests-version-4.grpctestingexp.
 resolver_component_tests:
+# Tests for which we enable SRV queries
 - expected_addrs:
   - {address: '5.5.5.5:443', is_balancer: false}
   expected_chosen_service_config: null
   expected_lb_policy: null
+  enable_srv_queries: true
   record_to_resolve: no-srv-ipv4-single-target
   records:
     no-srv-ipv4-single-target:
@@ -12,6 +14,7 @@ resolver_component_tests:
   - {address: '1.2.3.4:1234', is_balancer: true}
   expected_chosen_service_config: null
   expected_lb_policy: null
+  enable_srv_queries: true
   record_to_resolve: srv-ipv4-single-target
   records:
     _grpclb._tcp.srv-ipv4-single-target:
@@ -24,6 +27,7 @@ resolver_component_tests:
   - {address: '1.2.3.7:1234', is_balancer: true}
   expected_chosen_service_config: null
   expected_lb_policy: null
+  enable_srv_queries: true
   record_to_resolve: srv-ipv4-multi-target
   records:
     _grpclb._tcp.srv-ipv4-multi-target:
@@ -36,6 +40,7 @@ resolver_component_tests:
   - {address: '[2607:f8b0:400a:801::1001]:1234', is_balancer: true}
   expected_chosen_service_config: null
   expected_lb_policy: null
+  enable_srv_queries: true
   record_to_resolve: srv-ipv6-single-target
   records:
     _grpclb._tcp.srv-ipv6-single-target:
@@ -48,6 +53,7 @@ resolver_component_tests:
   - {address: '[2607:f8b0:400a:801::1004]:1234', is_balancer: true}
   expected_chosen_service_config: null
   expected_lb_policy: null
+  enable_srv_queries: true
   record_to_resolve: srv-ipv6-multi-target
   records:
     _grpclb._tcp.srv-ipv6-multi-target:
@@ -60,6 +66,7 @@ resolver_component_tests:
   - {address: '1.2.3.4:1234', is_balancer: true}
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}'
   expected_lb_policy: round_robin
+  enable_srv_queries: true
   record_to_resolve: srv-ipv4-simple-service-config
   records:
     _grpclb._tcp.srv-ipv4-simple-service-config:
@@ -73,6 +80,7 @@ resolver_component_tests:
   - {address: '1.2.3.4:443', is_balancer: false}
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}'
   expected_lb_policy: round_robin
+  enable_srv_queries: true
   record_to_resolve: ipv4-no-srv-simple-service-config
   records:
     ipv4-no-srv-simple-service-config:
@@ -84,6 +92,7 @@ resolver_component_tests:
   - {address: '1.2.3.4:443', is_balancer: false}
   expected_chosen_service_config: null
   expected_lb_policy: null
+  enable_srv_queries: true
   record_to_resolve: ipv4-no-config-for-cpp
   records:
     ipv4-no-config-for-cpp:
@@ -95,6 +104,7 @@ resolver_component_tests:
   - {address: '1.2.3.4:443', is_balancer: false}
   expected_chosen_service_config: null
   expected_lb_policy: null
+  enable_srv_queries: true
   record_to_resolve: ipv4-cpp-config-has-zero-percentage
   records:
     ipv4-cpp-config-has-zero-percentage:
@@ -106,6 +116,7 @@ resolver_component_tests:
   - {address: '1.2.3.4:443', is_balancer: false}
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}'
   expected_lb_policy: round_robin
+  enable_srv_queries: true
   record_to_resolve: ipv4-second-language-is-cpp
   records:
     ipv4-second-language-is-cpp:
@@ -117,6 +128,7 @@ resolver_component_tests:
   - {address: '1.2.3.4:443', is_balancer: false}
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}'
   expected_lb_policy: round_robin
+  enable_srv_queries: true
   record_to_resolve: ipv4-config-with-percentages
   records:
     ipv4-config-with-percentages:
@@ -129,6 +141,7 @@ resolver_component_tests:
   - {address: '1.2.3.4:443', is_balancer: false}
   expected_chosen_service_config: null
   expected_lb_policy: null
+  enable_srv_queries: true
   record_to_resolve: srv-ipv4-target-has-backend-and-balancer
   records:
     _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer:
@@ -142,6 +155,7 @@ resolver_component_tests:
   - {address: '[2607:f8b0:400a:801::1002]:443', is_balancer: false}
   expected_chosen_service_config: null
   expected_lb_policy: null
+  enable_srv_queries: true
   record_to_resolve: srv-ipv6-target-has-backend-and-balancer
   records:
     _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer:
@@ -154,10 +168,92 @@ resolver_component_tests:
   - {address: '1.2.3.4:443', is_balancer: false}
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}'
   expected_lb_policy: null
+  enable_srv_queries: true
   record_to_resolve: ipv4-config-causing-fallback-to-tcp
   records:
     ipv4-config-causing-fallback-to-tcp:
     - {TTL: '2100', data: 1.2.3.4, type: A}
     _grpc_config.ipv4-config-causing-fallback-to-tcp:
     - {TTL: '2100', data: 'grpc_config=[{"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}}]',
+      type: TXT}
+# Tests for which we don't enable SRV queries
+- expected_addrs:
+  - {address: '2.3.4.5:443', is_balancer: false}
+  expected_chosen_service_config: null
+  expected_lb_policy: null
+  enable_srv_queries: false
+  record_to_resolve: srv-ipv4-single-target-srv-disabled
+  records:
+    _grpclb._tcp.srv-ipv4-single-target-srv-disabled:
+    - {TTL: '2100', data: 0 0 1234 ipv4-single-target-srv-disabled, type: SRV}
+    ipv4-single-target-srv-disabled:
+    - {TTL: '2100', data: 1.2.3.4, type: A}
+    srv-ipv4-single-target-srv-disabled:
+    - {TTL: '2100', data: 2.3.4.5, type: A}
+- expected_addrs:
+  - {address: '9.2.3.5:443', is_balancer: false}
+  - {address: '9.2.3.6:443', is_balancer: false}
+  - {address: '9.2.3.7:443', is_balancer: false}
+  expected_chosen_service_config: null
+  expected_lb_policy: null
+  enable_srv_queries: false
+  record_to_resolve: srv-ipv4-multi-target-srv-disabled
+  records:
+    _grpclb._tcp.srv-ipv4-multi-target-srv-disabled:
+    - {TTL: '2100', data: 0 0 1234 ipv4-multi-target-srv-disabled, type: SRV}
+    ipv4-multi-target-srv-disabled:
+    - {TTL: '2100', data: 1.2.3.5, type: A}
+    - {TTL: '2100', data: 1.2.3.6, type: A}
+    - {TTL: '2100', data: 1.2.3.7, type: A}
+    srv-ipv4-multi-target-srv-disabled:
+    - {TTL: '2100', data: 9.2.3.5, type: A}
+    - {TTL: '2100', data: 9.2.3.6, type: A}
+    - {TTL: '2100', data: 9.2.3.7, type: A}
+- expected_addrs:
+  - {address: '[2600::1001]:443', is_balancer: false}
+  expected_chosen_service_config: null
+  expected_lb_policy: null
+  enable_srv_queries: false
+  record_to_resolve: srv-ipv6-single-target-srv-disabled
+  records:
+    _grpclb._tcp.srv-ipv6-single-target-srv-disabled:
+    - {TTL: '2100', data: 0 0 1234 ipv6-single-target-srv-disabled, type: SRV}
+    ipv6-single-target-srv-disabled:
+    - {TTL: '2100', data: '2607:f8b0:400a:801::1001', type: AAAA}
+    srv-ipv6-single-target-srv-disabled:
+    - {TTL: '2100', data: '2600::1001', type: AAAA}
+- expected_addrs:
+  - {address: '[2600::1002]:443', is_balancer: false}
+  - {address: '[2600::1003]:443', is_balancer: false}
+  - {address: '[2600::1004]:443', is_balancer: false}
+  expected_chosen_service_config: null
+  expected_lb_policy: null
+  enable_srv_queries: false
+  record_to_resolve: srv-ipv6-multi-target-srv-disabled
+  records:
+    _grpclb._tcp.srv-ipv6-multi-target-srv-disabled:
+    - {TTL: '2100', data: 0 0 1234 ipv6-multi-target-srv-disabled, type: SRV}
+    ipv6-multi-target-srv-disabled:
+    - {TTL: '2100', data: '2607:f8b0:400a:801::1002', type: AAAA}
+    - {TTL: '2100', data: '2607:f8b0:400a:801::1003', type: AAAA}
+    - {TTL: '2100', data: '2607:f8b0:400a:801::1004', type: AAAA}
+    srv-ipv6-multi-target-srv-disabled:
+    - {TTL: '2100', data: '2600::1002', type: AAAA}
+    - {TTL: '2100', data: '2600::1003', type: AAAA}
+    - {TTL: '2100', data: '2600::1004', type: AAAA}
+- expected_addrs:
+  - {address: '5.5.3.4:443', is_balancer: false}
+  expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}'
+  expected_lb_policy: round_robin
+  enable_srv_queries: false
+  record_to_resolve: srv-ipv4-simple-service-config-srv-disabled
+  records:
+    _grpclb._tcp.srv-ipv4-simple-service-config-srv-disabled:
+    - {TTL: '2100', data: 0 0 1234 ipv4-simple-service-config-srv-disabled, type: SRV}
+    ipv4-simple-service-config-srv-disabled:
+    - {TTL: '2100', data: 1.2.3.4, type: A}
+    srv-ipv4-simple-service-config-srv-disabled:
+    - {TTL: '2100', data: 5.5.3.4, type: A}
+    _grpc_config.srv-ipv4-simple-service-config-srv-disabled:
+    - {TTL: '2100', data: 'grpc_config=[{"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}}]',
       type: TXT}


### PR DESCRIPTION
This PR changes the behavior of setting the environment variable `GRPC_DNS_RESOLVER=ares`, to <i>not</i> query for SRV records by default, and then sets `ares` as the default DNS resolver (instead of `native`). It also introduces a channel arg, `grpc.dns_enable_srv_queries`, which can turn on SRV queries on a per-channel basis, but defaults to "off".

Un-reverts https://github.com/grpc/grpc/pull/16862

--------

Also included in this PR is the would-be-newly-needed change to `google_default_credentials`, to set the `dns_enable_srv_queries` channel arg.