### PR TITLE
rename census context hooks

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -499,7 +499,7 @@ class _UnaryUnaryMultiCallable(grpc.UnaryUnaryMultiCallable):
         self._method = method
         self._request_serializer = request_serializer
         self._response_deserializer = response_deserializer
-        self._context = cygrpc.build_context()
+        self._context = cygrpc.build_census_context()
 
     def _prepare(self, request, timeout, metadata, wait_for_ready):
         deadline, serialized_request, rendezvous = _start_unary_request(
@@ -590,7 +590,7 @@ class _UnaryStreamMultiCallable(grpc.UnaryStreamMultiCallable):
         self._method = method
         self._request_serializer = request_serializer
         self._response_deserializer = response_deserializer
-        self._context = cygrpc.build_context()
+        self._context = cygrpc.build_census_context()
 
     def __call__(self,
                  request,
@@ -637,7 +637,7 @@ class _StreamUnaryMultiCallable(grpc.StreamUnaryMultiCallable):
         self._method = method
         self._request_serializer = request_serializer
         self._response_deserializer = response_deserializer
-        self._context = cygrpc.build_context()
+        self._context = cygrpc.build_census_context()
 
     def _blocking(self, request_iterator, timeout, metadata, credentials,
                   wait_for_ready):
@@ -714,7 +714,7 @@ class _StreamStreamMultiCallable(grpc.StreamStreamMultiCallable):
         self._method = method
         self._request_serializer = request_serializer
         self._response_deserializer = response_deserializer
-        self._context = cygrpc.build_context()
+        self._context = cygrpc.build_census_context()
 
     def __call__(self,
                  request_iterator,

--- a/src/python/grpcio/grpc/_cython/_cygrpc/_hooks.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/_hooks.pyx.pxi
@@ -16,13 +16,13 @@
 cdef object _custom_op_on_c_call(int op, grpc_call *call):
   raise NotImplementedError("No custom hooks are implemented")
 
-def install_census_context_from_call(Call call):
+def install_context_from_call(Call call):
   pass
 
 def uninstall_context():
   pass
 
-def build_context():
+def build_census_context():
   pass
 
 cdef class CensusContext:

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -484,7 +484,7 @@ def _status(rpc_event, state, serialized_response):
 
 def _unary_response_in_pool(rpc_event, state, behavior, argument_thunk,
                             request_deserializer, response_serializer):
-    cygrpc.install_census_context_from_call(rpc_event.call)
+    cygrpc.install_context_from_call(rpc_event.call)
     try:
         argument = argument_thunk()
         if argument is not None:
@@ -501,7 +501,7 @@ def _unary_response_in_pool(rpc_event, state, behavior, argument_thunk,
 
 def _stream_response_in_pool(rpc_event, state, behavior, argument_thunk,
                              request_deserializer, response_serializer):
-    cygrpc.install_census_context_from_call(rpc_event.call)
+    cygrpc.install_context_from_call(rpc_event.call)
     try:
         argument = argument_thunk()
         if argument is not None:


### PR DESCRIPTION
Renamed as we internally expect context to encompass other elements in addition to the census trace context.