### PR TITLE
Added an option to disable ALPN for C++ CMake builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ option(gRPC_BUILD_TESTS "Build tests" OFF)
 option(gRPC_BUILD_CODEGEN "Build codegen" ON)
 option(gRPC_BUILD_CSHARP_EXT "Build C# extensions" ON)
 option(gRPC_BACKWARDS_COMPATIBILITY_MODE "Build libraries that are binary compatible across a larger number of OS and libc versions" OFF)
+option(gRPC_DISABLE_ALPN "Build with ALPN disabled" OFF)
 
 set(gRPC_INSTALL_default ON)
 if (NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)

--- a/cmake/ssl.cmake
+++ b/cmake/ssl.cmake
@@ -43,6 +43,10 @@ elseif("${gRPC_SSL_PROVIDER}" STREQUAL "package")
   # project itself does not provide installation support in its CMakeLists.txt
   # See https://cmake.org/cmake/help/v3.6/module/FindOpenSSL.html
   find_package(OpenSSL REQUIRED)
+
+  if(gRPC_DISABLE_ALPN)
+    add_definitions(-DTSI_OPENSSL_ALPN_SUPPORT=0)
+  endif()
   
   if(TARGET OpenSSL::SSL)
     set(_gRPC_SSL_LIBRARIES OpenSSL::SSL OpenSSL::Crypto)

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -89,6 +89,7 @@
   option(gRPC_BUILD_CODEGEN "Build codegen" ON)
   option(gRPC_BUILD_CSHARP_EXT "Build C# extensions" ON)
   option(gRPC_BACKWARDS_COMPATIBILITY_MODE "Build libraries that are binary compatible across a larger number of OS and libc versions" OFF)
+  option(gRPC_DISABLE_ALPN "Build with ALPN disabled" OFF)
 
   set(gRPC_INSTALL_default ON)
   if (NOT CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)


### PR DESCRIPTION
The new `gRPC_DISABLE_ALPN` option disables ALPN and makes gRPC fall
back to NPN, to enable C++ builds on older systems.