### PR TITLE
Add v1.18.0 releases of grpc-go to interop matrix 

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -118,6 +118,7 @@ LANG_RELEASE_MATRIX = {
         ('v1.15.0', ReleaseInfo(runtime_subset=['go1.8'])),
         ('v1.16.0', ReleaseInfo(runtime_subset=['go1.8'])),
         ('v1.17.0', ReleaseInfo(runtime_subset=['go1.11'])),
+        ('v1.18.0', ReleaseInfo(runtime_subset=['go1.11'])),
     ]),
     'java':
     OrderedDict([


### PR DESCRIPTION
Image was built and uploaded.

```
$ gcloud beta container images list-tags gcr.io/grpc-testing/grpc_interop_go1.11
DIGEST        TAGS     TIMESTAMP            FROM                             VULNERABILITY_SCAN_STATUS
40b538616579  v1.18.0  2019-01-15T16:34:39  us-mirror.gcr.io/library/golang  PENDING
a162f049dd62  v1.17.0  2019-01-07T08:51:13  us-mirror.gcr.io/library/golang  PENDING
```