### PR TITLE
core: fix typo in bitwise condition

### DIFF
--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -720,7 +720,7 @@ static void process_errors(grpc_tcp* tcp) {
       return;
     }
     if (grpc_tcp_trace.enabled()) {
-      if ((msg.msg_flags & MSG_CTRUNC) == 1) {
+      if (msg.msg_flags & MSG_CTRUNC) {
         gpr_log(GPR_INFO, "Error message was truncated.");
       }
     }


### PR DESCRIPTION
release notes: no

```
src/core/lib/iomgr/tcp_posix.cc:725:40: error: bitwise comparison always evaluates to false [-Werror=tautological-compare]
       if ((msg.msg_flags & MSG_CTRUNC) == 1) {
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~
```