### PR TITLE
Backport #17634 to 1.18.x 

### DIFF
--- a/tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh
@@ -30,4 +30,4 @@ cd /var/local/git/grpc
 rvm --default use ruby-2.5
 
 # build Ruby interop client and server
-(cd src/ruby && gem update bundler && bundle && rake compile)
+(cd src/ruby && gem install bundler -v 1.17.3 && bundle && rake compile)


### PR DESCRIPTION
Pin bundler in ruby interop build, to fix the interop matrix images build