### PR TITLE
Get the ruby interop client buildable at the 1.18.0 tag

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -201,6 +201,10 @@ LANG_RELEASE_MATRIX = {
         ('v1.15.0', ReleaseInfo()),
         ('v1.16.0', ReleaseInfo()),
         ('v1.17.1', ReleaseInfo()),
+        ('v1.18.0',
+         ReleaseInfo(patch=[
+             'tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh',
+         ])),
     ]),
     'php':
     OrderedDict([

--- a/tools/interop_matrix/patches/ruby_v1.18.0/git_repo.patch
+++ b/tools/interop_matrix/patches/ruby_v1.18.0/git_repo.patch
@@ -1,0 +1,10 @@
+diff --git a/tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh b/tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh
+index 67f66090ae..e71ad91499 100755
+--- a/tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh
++++ b/tools/dockerfile/interoptest/grpc_interop_ruby/build_interop.sh
+@@ -30,4 +30,4 @@ cd /var/local/git/grpc
+ rvm --default use ruby-2.5
+ 
+ # build Ruby interop client and server
+-(cd src/ruby && gem update bundler && bundle && rake compile)
++(cd src/ruby && gem install bundler -v 1.17.3 && bundle && rake compile)


### PR DESCRIPTION
Alternative to backporting https://github.com/grpc/grpc/pull/17739 and then publishing a new no-op tag