### PR TITLE
Experiment, attempt to fix brew update

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -40,6 +40,7 @@ fi
 set +ex  # rvm script is very verbose and exits with errorcode
 # Advice from https://github.com/Homebrew/homebrew-cask/issues/8629#issuecomment-68641176
 brew update && brew upgrade brew-cask && brew cleanup && brew cask cleanup
+rvm --debug requirements ruby-2.5.0
 source $HOME/.rvm/scripts/rvm
 set -e  # rvm commands are very verbose
 time rvm install 2.5.0


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/17729

I don't fully understand the issue here, but the rvm `requirements` command seems to fix it

```
requirements  :: Installs additional OS specific dependencies/requirements for
                 building various rubies. Usually run by install.
```

Did a run with more verbose logs in https://github.com/grpc/grpc/pull/17755, e.g. artifact macos job logs in https://source.cloud.google.com/results/invocations/aa0f26ec-e3e1-47b6-86cc-5843d3cf1bb4/log

... where this command can be seen running:

```
++ rvm --debug requirements ruby-2.5.0
rvm_autolibs_flag=4
Checking requirements for osx.
requirements code for osx loaded
requirements lib type set to osx_brew
brew seems to be writable
Found required packages: autoconf, automake, libtool, pkg-config, coreutils, libyaml, readline, libksba, openssl@1.1.
==> Upgrading 2 outdated packages:
openssl@1.1 1.1.1 -> 1.1.1a, readline 7.0.5 -> 8.0.0
==> Upgrading openssl@1.1
```