### PR TITLE
grpc: init compression_algorithm_ in ClientContext ctor

### DIFF
--- a/src/cpp/client/client_context.cc
+++ b/src/cpp/client/client_context.cc
@@ -57,6 +57,7 @@ ClientContext::ClientContext()
       deadline_(gpr_inf_future(GPR_CLOCK_REALTIME)),
       census_context_(nullptr),
       propagate_from_call_(nullptr),
+      compression_algorithm_(GRPC_COMPRESS_NONE),
       initial_metadata_corked_(false) {
   g_client_callbacks->DefaultConstructor(this);
 }


### PR DESCRIPTION
`compression_algorithm_` could be a random value because not
initialized in ctor.