### PR TITLE
Fixing memory leak in interceptor by removing unsued send_status_

### DIFF
--- a/include/grpcpp/impl/codegen/interceptor_common.h
+++ b/include/grpcpp/impl/codegen/interceptor_common.h
@@ -403,7 +403,6 @@ class InterceptorBatchMethodsImpl
   grpc_status_code* code_ = nullptr;
   grpc::string* error_details_ = nullptr;
   grpc::string* error_message_ = nullptr;
-  Status send_status_;
 
   std::multimap<grpc::string, grpc::string>* send_trailing_metadata_ = nullptr;
 


### PR DESCRIPTION
This pull request fixes a memory leak in `InterceptorBatchMethodsImpl` that ocurred on every call.

In contrast to most of the class members, `Status send_status_` was not a pointer and constructed with the class itself. I am not that familiar with the class design, but using a memory leak detector I noticed increased memory usage on every call that pointed to a string inside `::grpc::Status`. There are no references to `send_status_` anywhere in the code, so I assume it is a leftover.

Removing this member variable cleared those memory leaks.

Tested with:
* gRPC version: 1.18.0
* Operating system: Windows 10
* Runtime:  Visual Studio Compiler 19.15.26731

Due to the simple nature of the problem, I did not create an issue. Please tell me if you need more information.