### PR TITLE
[Performance Improvement] - reserve vectors to avoid reallocation cost in c++

### DIFF
--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -269,6 +269,7 @@ void MetadataCredentialsPluginWrapper::InvokePlugin(
   Status status = plugin_->GetMetadata(context.service_url, context.method_name,
                                        cpp_channel_auth_context, &metadata);
   std::vector<grpc_metadata> md;
+  md.reserve(metadata.size());
   for (auto it = metadata.begin(); it != metadata.end(); ++it) {
     grpc_metadata md_entry;
     md_entry.key = SliceFromCopiedString(it->first);

--- a/src/cpp/server/secure_server_credentials.cc
+++ b/src/cpp/server/secure_server_credentials.cc
@@ -69,6 +69,7 @@ void AuthMetadataProcessorAyncWrapper::InvokeProcessor(
                                       &response_metadata);
 
   std::vector<grpc_metadata> consumed_md;
+  consumed_md.reserve(consumed_metadata.size());
   for (auto it = consumed_metadata.begin(); it != consumed_metadata.end();
        ++it) {
     grpc_metadata md_entry;
@@ -78,6 +79,7 @@ void AuthMetadataProcessorAyncWrapper::InvokeProcessor(
     consumed_md.push_back(md_entry);
   }
   std::vector<grpc_metadata> response_md;
+  response_md.reserve(response_metadata.size());
   for (auto it = response_metadata.begin(); it != response_metadata.end();
        ++it) {
     grpc_metadata md_entry;
@@ -109,6 +111,7 @@ void SecureServerCredentials::SetAuthMetadataProcessor(
 std::shared_ptr<ServerCredentials> SslServerCredentials(
     const SslServerCredentialsOptions& options) {
   std::vector<grpc_ssl_pem_key_cert_pair> pem_key_cert_pairs;
+  pem_key_cert_pairs.reserve(options.pem_key_cert_pairs.size());
   for (auto key_cert_pair = options.pem_key_cert_pairs.begin();
        key_cert_pair != options.pem_key_cert_pairs.end(); key_cert_pair++) {
     grpc_ssl_pem_key_cert_pair p = {key_cert_pair->private_key.c_str(),


### PR DESCRIPTION
Reserve vectors where size is already known to avoid reallocation costs.