### PR TITLE
Format all the Bazel build files with buildifier

### DIFF
--- a/examples/BUILD
+++ b/examples/BUILD
@@ -47,69 +47,101 @@ cc_binary(
     name = "greeter_client",
     srcs = ["cpp/helloworld/greeter_client.cc"],
     defines = ["BAZEL_BUILD"],
-    deps = [":helloworld", "//:grpc++"],
+    deps = [
+        ":helloworld",
+        "//:grpc++",
+    ],
 )
 
 cc_binary(
     name = "greeter_server",
     srcs = ["cpp/helloworld/greeter_server.cc"],
     defines = ["BAZEL_BUILD"],
-    deps = [":helloworld", "//:grpc++"],
+    deps = [
+        ":helloworld",
+        "//:grpc++",
+    ],
 )
 
 cc_binary(
     name = "metadata_client",
     srcs = ["cpp/metadata/greeter_client.cc"],
     defines = ["BAZEL_BUILD"],
-    deps = [":helloworld", "//:grpc++"],
+    deps = [
+        ":helloworld",
+        "//:grpc++",
+    ],
 )
 
 cc_binary(
     name = "metadata_server",
     srcs = ["cpp/metadata/greeter_server.cc"],
     defines = ["BAZEL_BUILD"],
-    deps = [":helloworld", "//:grpc++"],
+    deps = [
+        ":helloworld",
+        "//:grpc++",
+    ],
 )
 
 cc_binary(
     name = "lb_client",
     srcs = ["cpp/load_balancing/greeter_client.cc"],
     defines = ["BAZEL_BUILD"],
-    deps = [":helloworld", "//:grpc++"],
+    deps = [
+        ":helloworld",
+        "//:grpc++",
+    ],
 )
 
 cc_binary(
     name = "lb_server",
     srcs = ["cpp/load_balancing/greeter_server.cc"],
     defines = ["BAZEL_BUILD"],
-    deps = [":helloworld", "//:grpc++"],
+    deps = [
+        ":helloworld",
+        "//:grpc++",
+    ],
 )
 
 cc_binary(
     name = "compression_client",
     srcs = ["cpp/compression/greeter_client.cc"],
     defines = ["BAZEL_BUILD"],
-    deps = [":helloworld", "//:grpc++"],
+    deps = [
+        ":helloworld",
+        "//:grpc++",
+    ],
 )
 
 cc_binary(
     name = "compression_server",
     srcs = ["cpp/compression/greeter_server.cc"],
     defines = ["BAZEL_BUILD"],
-    deps = [":helloworld", "//:grpc++"],
+    deps = [
+        ":helloworld",
+        "//:grpc++",
+    ],
 )
 
 cc_binary(
     name = "keyvaluestore_client",
-    srcs = ["cpp/keyvaluestore/caching_interceptor.h",
-            "cpp/keyvaluestore/client.cc"],    
+    srcs = [
+        "cpp/keyvaluestore/caching_interceptor.h",
+        "cpp/keyvaluestore/client.cc",
+    ],
     defines = ["BAZEL_BUILD"],
-    deps = [":keyvaluestore", "//:grpc++"],
+    deps = [
+        ":keyvaluestore",
+        "//:grpc++",
+    ],
 )
 
 cc_binary(
     name = "keyvaluestore_server",
     srcs = ["cpp/keyvaluestore/server.cc"],
     defines = ["BAZEL_BUILD"],
-    deps = [":keyvaluestore", "//:grpc++"],
+    deps = [
+        ":keyvaluestore",
+        "//:grpc++",
+    ],
 )

--- a/src/core/tsi/test_creds/BUILD
+++ b/src/core/tsi/test_creds/BUILD
@@ -15,15 +15,15 @@
 licenses(["notice"])  # Apache v2
 
 exports_files([
-        "ca.pem",
-        "server1.key",
-        "server1.pem",
-        "server0.key",
-        "server0.pem",
-        "client.key",
-        "client.pem",
-        "badserver.key",
-        "badserver.pem",
-        "badclient.key",
-        "badclient.pem",
+    "ca.pem",
+    "server1.key",
+    "server1.pem",
+    "server0.key",
+    "server0.pem",
+    "client.key",
+    "client.pem",
+    "badserver.key",
+    "badserver.pem",
+    "badclient.key",
+    "badclient.pem",
 ])

--- a/src/proto/grpc/channelz/BUILD
+++ b/src/proto/grpc/channelz/BUILD
@@ -14,9 +14,12 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_proto_library", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
 
-grpc_package(name = "channelz", visibility = "public")
+grpc_package(
+    name = "channelz",
+    visibility = "public",
+)
 
 grpc_proto_library(
     name = "channelz_proto",

--- a/src/proto/grpc/core/BUILD
+++ b/src/proto/grpc/core/BUILD
@@ -14,9 +14,12 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_proto_library", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
 
-grpc_package(name = "core", visibility = "public")
+grpc_package(
+    name = "core",
+    visibility = "public",
+)
 
 grpc_proto_library(
     name = "stats_proto",

--- a/src/proto/grpc/health/v1/BUILD
+++ b/src/proto/grpc/health/v1/BUILD
@@ -14,9 +14,12 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_proto_library", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
 
-grpc_package(name = "health", visibility = "public")
+grpc_package(
+    name = "health",
+    visibility = "public",
+)
 
 grpc_proto_library(
     name = "health_proto",

--- a/src/proto/grpc/reflection/v1alpha/BUILD
+++ b/src/proto/grpc/reflection/v1alpha/BUILD
@@ -14,9 +14,12 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_proto_library", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
 
-grpc_package(name = "reflection", visibility = "public")
+grpc_package(
+    name = "reflection",
+    visibility = "public",
+)
 
 grpc_proto_library(
     name = "reflection_proto",
@@ -29,4 +32,3 @@ filegroup(
         "reflection.proto",
     ],
 )
-

--- a/src/proto/grpc/status/BUILD
+++ b/src/proto/grpc/status/BUILD
@@ -14,9 +14,12 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_proto_library", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
 
-grpc_package(name = "status", visibility = "public")
+grpc_package(
+    name = "status",
+    visibility = "public",
+)
 
 grpc_proto_library(
     name = "status_proto",

--- a/src/proto/grpc/testing/BUILD
+++ b/src/proto/grpc/testing/BUILD
@@ -14,11 +14,14 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_proto_library", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
 load("@grpc_python_dependencies//:requirements.bzl", "requirement")
 load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_library")
 
-grpc_package(name = "testing", visibility = "public")
+grpc_package(
+    name = "testing",
+    visibility = "public",
+)
 
 exports_files([
     "echo.proto",
@@ -50,9 +53,11 @@ grpc_proto_library(
 grpc_proto_library(
     name = "echo_proto",
     srcs = ["echo.proto"],
-    deps = ["echo_messages_proto",
-            "simple_messages_proto"],
     generate_mocks = True,
+    deps = [
+        "echo_messages_proto",
+        "simple_messages_proto",
+    ],
 )
 
 grpc_proto_library(
@@ -63,10 +68,10 @@ grpc_proto_library(
 
 py_proto_library(
     name = "py_empty_proto",
-    protos = ["empty.proto",],
+    protos = ["empty.proto"],
     with_grpc = True,
     deps = [
-        requirement('protobuf'),
+        requirement("protobuf"),
     ],
 )
 
@@ -78,10 +83,10 @@ grpc_proto_library(
 
 py_proto_library(
     name = "py_messages_proto",
-    protos = ["messages.proto",],
+    protos = ["messages.proto"],
     with_grpc = True,
     deps = [
-        requirement('protobuf'),
+        requirement("protobuf"),
     ],
 )
 
@@ -100,7 +105,7 @@ grpc_proto_library(
     name = "benchmark_service_proto",
     srcs = ["benchmark_service.proto"],
     deps = [
-      "messages_proto",
+        "messages_proto",
     ],
 )
 
@@ -108,7 +113,7 @@ grpc_proto_library(
     name = "report_qps_scenario_service_proto",
     srcs = ["report_qps_scenario_service.proto"],
     deps = [
-      "control_proto",
+        "control_proto",
     ],
 )
 
@@ -116,7 +121,7 @@ grpc_proto_library(
     name = "worker_service_proto",
     srcs = ["worker_service.proto"],
     deps = [
-      "control_proto",
+        "control_proto",
     ],
 )
 
@@ -132,7 +137,7 @@ grpc_proto_library(
     has_services = False,
     deps = [
         "//src/proto/grpc/core:stats_proto",
-    ]
+    ],
 )
 
 grpc_proto_library(
@@ -146,14 +151,13 @@ grpc_proto_library(
 
 py_proto_library(
     name = "py_test_proto",
-    protos = ["test.proto",],
-    with_grpc = True,
-    deps = [
-        requirement('protobuf'),
-    ],
     proto_deps = [
         ":py_empty_proto",
         ":py_messages_proto",
-    ]
+    ],
+    protos = ["test.proto"],
+    with_grpc = True,
+    deps = [
+        requirement("protobuf"),
+    ],
 )
-

--- a/src/proto/grpc/testing/duplicate/BUILD
+++ b/src/proto/grpc/testing/duplicate/BUILD
@@ -14,9 +14,12 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_proto_library", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_package", "grpc_proto_library")
 
-grpc_package(name = "duplicate", visibility = "public")
+grpc_package(
+    name = "duplicate",
+    visibility = "public",
+)
 
 grpc_proto_library(
     name = "echo_duplicate_proto",

--- a/src/proto/grpc/testing/proto2/BUILD.bazel
+++ b/src/proto/grpc/testing/proto2/BUILD.bazel
@@ -10,21 +10,20 @@ py_proto_library(
     ],
     with_grpc = True,
     deps = [
-        requirement('protobuf'),
+        requirement("protobuf"),
     ],
 )
 
 py_proto_library(
     name = "empty2_extensions_proto",
-    protos = [
-        "empty2_extensions.proto",
-    ],
     proto_deps = [
         ":empty2_proto",
     ],
+    protos = [
+        "empty2_extensions.proto",
+    ],
     with_grpc = True,
     deps = [
-        requirement('protobuf'),
+        requirement("protobuf"),
     ],
 )
-

--- a/src/python/grpcio/grpc/BUILD.bazel
+++ b/src/python/grpcio/grpc/BUILD.bazel
@@ -5,23 +5,23 @@ package(default_visibility = ["//visibility:public"])
 py_library(
     name = "grpcio",
     srcs = ["__init__.py"],
-    deps = [
-        ":utilities",
-        ":auth",
-        ":plugin_wrapping",
-        ":channel",
-        ":interceptor",
-        ":server",
-        "//src/python/grpcio/grpc/_cython:cygrpc",
-        "//src/python/grpcio/grpc/experimental",
-        "//src/python/grpcio/grpc/framework",
-        requirement('enum34'),
-        requirement('six'),
-    ],
     data = [
         "//:grpc",
     ],
-    imports = ["../",],
+    imports = ["../"],
+    deps = [
+        ":auth",
+        ":channel",
+        ":interceptor",
+        ":plugin_wrapping",
+        ":server",
+        ":utilities",
+        "//src/python/grpcio/grpc/_cython:cygrpc",
+        "//src/python/grpcio/grpc/experimental",
+        "//src/python/grpcio/grpc/framework",
+        requirement("enum34"),
+        requirement("six"),
+    ],
 )
 
 py_library(
@@ -58,7 +58,7 @@ py_library(
     srcs = ["_plugin_wrapping.py"],
     deps = [
         ":common",
-    ]
+    ],
 )
 
 py_library(
@@ -77,4 +77,3 @@ py_library(
         ":common",
     ],
 )
-

--- a/src/python/grpcio/grpc/_cython/BUILD.bazel
+++ b/src/python/grpcio/grpc/_cython/BUILD.bazel
@@ -47,6 +47,6 @@ pyx_library(
         "cygrpc.pyx",
     ],
     deps = [
-       "//:grpc",
+        "//:grpc",
     ],
 )

--- a/src/python/grpcio/grpc/experimental/BUILD.bazel
+++ b/src/python/grpcio/grpc/experimental/BUILD.bazel
@@ -1,9 +1,10 @@
 load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
 package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "experimental",
-    srcs = ["__init__.py",],
+    srcs = ["__init__.py"],
     deps = [
         ":gevent",
         ":session_cache",

--- a/src/python/grpcio/grpc/framework/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/BUILD.bazel
@@ -2,7 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "framework",
-    srcs = ["__init__.py",],
+    srcs = ["__init__.py"],
     deps = [
         "//src/python/grpcio/grpc/framework/common",
         "//src/python/grpcio/grpc/framework/foundation",

--- a/src/python/grpcio/grpc/framework/common/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/common/BUILD.bazel
@@ -1,9 +1,10 @@
 load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
 package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "common",
-    srcs = ["__init__.py",],
+    srcs = ["__init__.py"],
     deps = [
         ":cardinality",
         ":style",

--- a/src/python/grpcio/grpc/framework/foundation/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/foundation/BUILD.bazel
@@ -1,16 +1,17 @@
 load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
 package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "foundation",
-    srcs = ["__init__.py",],
+    srcs = ["__init__.py"],
     deps = [
         ":abandonment",
         ":callable_util",
         ":future",
         ":logging_pool",
-        ":stream_util",
         ":stream",
+        ":stream_util",
     ],
 )
 

--- a/src/python/grpcio/grpc/framework/interfaces/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/interfaces/BUILD.bazel
@@ -2,7 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "interfaces",
-    srcs = ["__init__.py",],
+    srcs = ["__init__.py"],
     deps = [
         "//src/python/grpcio/grpc/framework/interfaces/base",
         "//src/python/grpcio/grpc/framework/interfaces/face",

--- a/src/python/grpcio/grpc/framework/interfaces/base/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/interfaces/base/BUILD.bazel
@@ -1,9 +1,10 @@
 load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
 package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "base_lib",
-    srcs = ["__init__.py",],
+    srcs = ["__init__.py"],
     deps = [
         ":base",
         ":utilities",

--- a/src/python/grpcio/grpc/framework/interfaces/face/BUILD.bazel
+++ b/src/python/grpcio/grpc/framework/interfaces/face/BUILD.bazel
@@ -1,9 +1,10 @@
 load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
 package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "face",
-    srcs = ["__init__.py",],
+    srcs = ["__init__.py"],
     deps = [
         ":face_lib",
         ":utilities",
@@ -14,8 +15,8 @@ py_library(
     name = "face_lib",
     srcs = ["face.py"],
     deps = [
-        "//src/python/grpcio/grpc/framework/foundation",
         "//src/python/grpcio/grpc/framework/common",
+        "//src/python/grpcio/grpc/framework/foundation",
         requirement("enum34"),
         requirement("six"),
     ],
@@ -25,8 +26,8 @@ py_library(
     name = "utilities",
     srcs = ["utilities.py"],
     deps = [
+        ":face_lib",
         "//src/python/grpcio/grpc/framework/common",
         "//src/python/grpcio/grpc/framework/foundation:stream",
-        ":face_lib",
     ],
 )

--- a/src/python/grpcio_channelz/grpc_channelz/v1/BUILD.bazel
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/BUILD.bazel
@@ -8,31 +8,31 @@ genrule(
     srcs = [
         "//src/proto/grpc/channelz:channelz_proto_file",
     ],
-    outs = ["channelz.proto",],
+    outs = ["channelz.proto"],
     cmd = "cp $< $@",
 )
 
 py_proto_library(
     name = "py_channelz_proto",
-    protos = ["mv_channelz_proto",],
     imports = [
         "external/com_google_protobuf/src/",
     ],
     inputs = [
         "@com_google_protobuf//:well_known_protos",
     ],
+    protos = ["mv_channelz_proto"],
     with_grpc = True,
     deps = [
-        requirement('protobuf'),
+        requirement("protobuf"),
     ],
 )
 
 py_library(
     name = "grpc_channelz",
-    srcs = ["channelz.py",],
+    srcs = ["channelz.py"],
+    imports = ["../../"],
     deps = [
         ":py_channelz_proto",
         "//src/python/grpcio/grpc:grpcio",
     ],
-    imports=["../../",],
 )

--- a/src/python/grpcio_health_checking/grpc_health/v1/BUILD.bazel
+++ b/src/python/grpcio_health_checking/grpc_health/v1/BUILD.bazel
@@ -8,26 +8,25 @@ genrule(
     srcs = [
         "//src/proto/grpc/health/v1:health_proto_file",
     ],
-    outs = ["health.proto",],
+    outs = ["health.proto"],
     cmd = "cp $< $@",
 )
 
 py_proto_library(
     name = "py_health_proto",
-    protos = [":mv_health_proto",],
+    protos = [":mv_health_proto"],
     with_grpc = True,
     deps = [
-        requirement('protobuf'),
+        requirement("protobuf"),
     ],
 )
 
 py_library(
     name = "grpc_health",
-    srcs = ["health.py",],
+    srcs = ["health.py"],
+    imports = ["../../"],
     deps = [
         ":py_health_proto",
         "//src/python/grpcio/grpc:grpcio",
     ],
-    imports=["../../",],
 )
-

--- a/src/python/grpcio_reflection/grpc_reflection/v1alpha/BUILD.bazel
+++ b/src/python/grpcio_reflection/grpc_reflection/v1alpha/BUILD.bazel
@@ -8,27 +8,26 @@ genrule(
     srcs = [
         "//src/proto/grpc/reflection/v1alpha:reflection_proto_file",
     ],
-    outs = ["reflection.proto",],
+    outs = ["reflection.proto"],
     cmd = "cp $< $@",
 )
 
 py_proto_library(
     name = "py_reflection_proto",
-    protos = [":mv_reflection_proto",],
+    protos = [":mv_reflection_proto"],
     with_grpc = True,
     deps = [
-        requirement('protobuf'),
+        requirement("protobuf"),
     ],
 )
 
 py_library(
     name = "grpc_reflection",
-    srcs = ["reflection.py",],
+    srcs = ["reflection.py"],
+    imports = ["../../"],
     deps = [
         ":py_reflection_proto",
         "//src/python/grpcio/grpc:grpcio",
-        requirement('protobuf'),
+        requirement("protobuf"),
     ],
-    imports=["../../",],
 )
-

--- a/src/python/grpcio_status/grpc_status/BUILD.bazel
+++ b/src/python/grpcio_status/grpc_status/BUILD.bazel
@@ -4,11 +4,11 @@ package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "grpc_status",
-    srcs = ["rpc_status.py",],
+    srcs = ["rpc_status.py"],
+    imports = ["../"],
     deps = [
         "//src/python/grpcio/grpc:grpcio",
-        requirement('protobuf'),
-        requirement('googleapis-common-protos'),
+        requirement("protobuf"),
+        requirement("googleapis-common-protos"),
     ],
-    imports=["../",],
 )

--- a/src/python/grpcio_tests/tests/channelz/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/channelz/BUILD.bazel
@@ -2,14 +2,14 @@ package(default_visibility = ["//visibility:public"])
 
 py_test(
     name = "channelz_servicer_test",
-    srcs = ["_channelz_servicer_test.py"],
-    main = "_channelz_servicer_test.py",
     size = "small",
+    srcs = ["_channelz_servicer_test.py"],
+    imports = ["../../"],
+    main = "_channelz_servicer_test.py",
     deps = [
         "//src/python/grpcio/grpc:grpcio",
         "//src/python/grpcio_channelz/grpc_channelz/v1:grpc_channelz",
         "//src/python/grpcio_tests/tests/unit:test_common",
-        "//src/python/grpcio_tests/tests/unit/framework/common:common",
+        "//src/python/grpcio_tests/tests/unit/framework/common",
     ],
-    imports = ["../../",],
 )

--- a/src/python/grpcio_tests/tests/health_check/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/health_check/BUILD.bazel
@@ -2,15 +2,14 @@ package(default_visibility = ["//visibility:public"])
 
 py_test(
     name = "health_servicer_test",
-    srcs = ["_health_servicer_test.py"],
-    main = "_health_servicer_test.py",
     size = "small",
+    srcs = ["_health_servicer_test.py"],
+    imports = ["../../"],
+    main = "_health_servicer_test.py",
     deps = [
         "//src/python/grpcio/grpc:grpcio",
         "//src/python/grpcio_health_checking/grpc_health/v1:grpc_health",
         "//src/python/grpcio_tests/tests/unit:test_common",
-        "//src/python/grpcio_tests/tests/unit/framework/common:common",
+        "//src/python/grpcio_tests/tests/unit/framework/common",
     ],
-    imports = ["../../",],
 )
-

--- a/src/python/grpcio_tests/tests/interop/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/interop/BUILD.bazel
@@ -5,42 +5,42 @@ package(default_visibility = ["//visibility:public"])
 py_library(
     name = "_intraop_test_case",
     srcs = ["_intraop_test_case.py"],
+    imports = ["../../"],
     deps = [
         ":methods",
     ],
-    imports=["../../",],
 )
 
 py_library(
     name = "client",
     srcs = ["client.py"],
+    imports = ["../../"],
     deps = [
-        "//src/python/grpcio/grpc:grpcio",
         ":methods",
         ":resources",
         "//src/proto/grpc/testing:py_test_proto",
-        requirement('google-auth'),
+        "//src/python/grpcio/grpc:grpcio",
+        requirement("google-auth"),
     ],
-    imports=["../../",],
 )
 
 py_library(
     name = "methods",
     srcs = ["methods.py"],
+    imports = ["../../"],
     deps = [
-        "//src/python/grpcio/grpc:grpcio",
         "//src/proto/grpc/testing:py_empty_proto",
         "//src/proto/grpc/testing:py_messages_proto",
         "//src/proto/grpc/testing:py_test_proto",
-        requirement('google-auth'),
-        requirement('requests'),
-        requirement('enum34'),
-        requirement('urllib3'),
-        requirement('chardet'),
-        requirement('certifi'),
-        requirement('idna'),
+        "//src/python/grpcio/grpc:grpcio",
+        requirement("google-auth"),
+        requirement("requests"),
+        requirement("enum34"),
+        requirement("urllib3"),
+        requirement("chardet"),
+        requirement("certifi"),
+        requirement("idna"),
     ],
-    imports=["../../",],
 )
 
 py_library(
@@ -54,48 +54,47 @@ py_library(
 py_library(
     name = "server",
     srcs = ["server.py"],
+    imports = ["../../"],
     deps = [
-        "//src/python/grpcio/grpc:grpcio",
         ":methods",
         ":resources",
-        "//src/python/grpcio_tests/tests/unit:test_common",
         "//src/proto/grpc/testing:py_test_proto",
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/python/grpcio_tests/tests/unit:test_common",
     ],
-    imports=["../../",],
 )
 
 py_test(
-    name="_insecure_intraop_test",
-    size="small",
-    srcs=["_insecure_intraop_test.py",],
-    main="_insecure_intraop_test.py",
-    deps=[
-        "//src/python/grpcio/grpc:grpcio",
-        ":_intraop_test_case",
-        ":methods",
-        ":server",
-        "//src/python/grpcio_tests/tests/unit:test_common",
-        "//src/proto/grpc/testing:py_test_proto",
-    ],
-    imports=["../../",],
-    data=[
+    name = "_insecure_intraop_test",
+    size = "small",
+    srcs = ["_insecure_intraop_test.py"],
+    data = [
         "//src/python/grpcio_tests/tests/unit/credentials",
     ],
-)
-
-py_test(
-    name="_secure_intraop_test",
-    size="small",
-    srcs=["_secure_intraop_test.py",],
-    main="_secure_intraop_test.py",
-    deps=[
-        "//src/python/grpcio/grpc:grpcio",
+    imports = ["../../"],
+    main = "_insecure_intraop_test.py",
+    deps = [
         ":_intraop_test_case",
         ":methods",
         ":server",
-        "//src/python/grpcio_tests/tests/unit:test_common",
         "//src/proto/grpc/testing:py_test_proto",
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/python/grpcio_tests/tests/unit:test_common",
     ],
-    imports=["../../",],
 )
 
+py_test(
+    name = "_secure_intraop_test",
+    size = "small",
+    srcs = ["_secure_intraop_test.py"],
+    imports = ["../../"],
+    main = "_secure_intraop_test.py",
+    deps = [
+        ":_intraop_test_case",
+        ":methods",
+        ":server",
+        "//src/proto/grpc/testing:py_test_proto",
+        "//src/python/grpcio/grpc:grpcio",
+        "//src/python/grpcio_tests/tests/unit:test_common",
+    ],
+)

--- a/src/python/grpcio_tests/tests/interop/credentials/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/interop/credentials/BUILD.bazel
@@ -1,9 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
-    name="credentials",
-    srcs=glob([
+    name = "credentials",
+    srcs = glob([
         "**",
     ]),
 )
-

--- a/src/python/grpcio_tests/tests/reflection/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/reflection/BUILD.bazel
@@ -3,19 +3,18 @@ load("@grpc_python_dependencies//:requirements.bzl", "requirement")
 package(default_visibility = ["//visibility:public"])
 
 py_test(
-    name="_reflection_servicer_test",
-    size="small",
-    timeout="moderate",
-    srcs=["_reflection_servicer_test.py",],
-    main="_reflection_servicer_test.py",
-    deps=[
+    name = "_reflection_servicer_test",
+    size = "small",
+    timeout = "moderate",
+    srcs = ["_reflection_servicer_test.py"],
+    imports = ["../../"],
+    main = "_reflection_servicer_test.py",
+    deps = [
+        "//src/proto/grpc/testing:py_empty_proto",
+        "//src/proto/grpc/testing/proto2:empty2_extensions_proto",
         "//src/python/grpcio/grpc:grpcio",
         "//src/python/grpcio_reflection/grpc_reflection/v1alpha:grpc_reflection",
         "//src/python/grpcio_tests/tests/unit:test_common",
-        "//src/proto/grpc/testing:py_empty_proto",
-        "//src/proto/grpc/testing/proto2:empty2_extensions_proto",
-        requirement('protobuf'),
+        requirement("protobuf"),
     ],
-    imports=["../../",],
 )
-

--- a/src/python/grpcio_tests/tests/status/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/status/BUILD.bazel
@@ -4,16 +4,16 @@ package(default_visibility = ["//visibility:public"])
 
 py_test(
     name = "grpc_status_test",
-    srcs = ["_grpc_status_test.py"],
-    main = "_grpc_status_test.py",
     size = "small",
+    srcs = ["_grpc_status_test.py"],
+    imports = ["../../"],
+    main = "_grpc_status_test.py",
     deps = [
         "//src/python/grpcio/grpc:grpcio",
-        "//src/python/grpcio_status/grpc_status:grpc_status",
+        "//src/python/grpcio_status/grpc_status",
         "//src/python/grpcio_tests/tests/unit:test_common",
-        "//src/python/grpcio_tests/tests/unit/framework/common:common",
-        requirement('protobuf'),
-        requirement('googleapis-common-protos'),
+        "//src/python/grpcio_tests/tests/unit/framework/common",
+        requirement("protobuf"),
+        requirement("googleapis-common-protos"),
     ],
-    imports = ["../../",],
 )

--- a/src/python/grpcio_tests/tests/testing/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/testing/BUILD.bazel
@@ -2,7 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 py_library(
     name = "testing",
-    srcs = ["__init__.py",],
+    srcs = ["__init__.py"],
     deps = [
         # ":_application_common",
         ":_server_application",
@@ -22,9 +22,6 @@ py_library(
 
 py_library(
     name = "_server_application",
-    srcs = ["_server_application.py",],
-    imports = ["../../",],
+    srcs = ["_server_application.py"],
+    imports = ["../../"],
 )
-
-
-

--- a/src/python/grpcio_tests/tests/unit/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/BUILD.bazel
@@ -36,7 +36,7 @@ GRPCIO_TESTS_UNIT = [
 py_library(
     name = "resources",
     srcs = ["resources.py"],
-    data=[
+    data = [
         "//src/python/grpcio_tests/tests/unit/credentials",
     ],
 )
@@ -68,26 +68,26 @@ py_library(
 
 [
     py_test(
-        name=test_file_name[:-3],
-        size="small",
-        srcs=[test_file_name],
-        main=test_file_name,
-        deps=[
-            "//src/python/grpcio/grpc:grpcio",
-            ":resources",
-            ":test_common",
-            ":_exit_scenarios",
-            ":_server_shutdown_scenarios",
-            ":_thread_pool",
-            ":_from_grpc_import_star",
-            "//src/python/grpcio_tests/tests/unit/framework/common",
-            "//src/python/grpcio_tests/tests/testing",
-            requirement('six'),
-        ],
-        imports=["../../",],
-        data=[
+        name = test_file_name[:-3],
+        size = "small",
+        srcs = [test_file_name],
+        data = [
             "//src/python/grpcio_tests/tests/unit/credentials",
         ],
-    ) for test_file_name in GRPCIO_TESTS_UNIT
+        imports = ["../../"],
+        main = test_file_name,
+        deps = [
+            ":_exit_scenarios",
+            ":_from_grpc_import_star",
+            ":_server_shutdown_scenarios",
+            ":_thread_pool",
+            ":resources",
+            ":test_common",
+            "//src/python/grpcio/grpc:grpcio",
+            "//src/python/grpcio_tests/tests/testing",
+            "//src/python/grpcio_tests/tests/unit/framework/common",
+            requirement("six"),
+        ],
+    )
+    for test_file_name in GRPCIO_TESTS_UNIT
 ]
-

--- a/src/python/grpcio_tests/tests/unit/_cython/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/_cython/BUILD.bazel
@@ -24,23 +24,22 @@ py_library(
 
 [
     py_test(
-        name=test_file_name[:-3],
-        size="small",
-        srcs=[test_file_name],
-        main=test_file_name,
-        deps=[
-            "//src/python/grpcio/grpc:grpcio",
-            ":common",
-            ":test_utilities",
-            "//src/python/grpcio_tests/tests/unit/framework/common",
-            "//src/python/grpcio_tests/tests/unit:test_common",
-            "//src/python/grpcio_tests/tests/unit:resources",
-        ],
-        imports=["../../../",],
-        data=[
+        name = test_file_name[:-3],
+        size = "small",
+        srcs = [test_file_name],
+        data = [
             "//src/python/grpcio_tests/tests/unit/credentials",
         ],
-    ) for test_file_name in GRPCIO_TESTS_UNIT_CYTHON
+        imports = ["../../../"],
+        main = test_file_name,
+        deps = [
+            ":common",
+            ":test_utilities",
+            "//src/python/grpcio/grpc:grpcio",
+            "//src/python/grpcio_tests/tests/unit:resources",
+            "//src/python/grpcio_tests/tests/unit:test_common",
+            "//src/python/grpcio_tests/tests/unit/framework/common",
+        ],
+    )
+    for test_file_name in GRPCIO_TESTS_UNIT_CYTHON
 ]
-
-

--- a/src/python/grpcio_tests/tests/unit/credentials/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/credentials/BUILD.bazel
@@ -1,10 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
-    name="credentials",
-    srcs=glob([
+    name = "credentials",
+    srcs = glob([
         "**",
     ]),
 )
-
-

--- a/src/python/grpcio_tests/tests/unit/framework/common/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/framework/common/BUILD.bazel
@@ -8,4 +8,3 @@ py_library(
         "test_coverage.py",
     ],
 )
-

--- a/src/python/grpcio_tests/tests/unit/framework/foundation/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/unit/framework/foundation/BUILD.bazel
@@ -7,11 +7,10 @@ py_library(
 
 py_test(
     name = "logging_pool_test",
+    size = "small",
     srcs = ["_logging_pool_test.py"],
     main = "_logging_pool_test.py",
-    size = "small",
     deps = [
         "//src/python/grpcio/grpc:grpcio",
     ],
 )
-

--- a/test/core/avl/BUILD
+++ b/test/core/avl/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])  # Apache v2
 

--- a/test/core/backoff/BUILD
+++ b/test/core/backoff/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test")
 
 licenses(["notice"])  # Apache v2
 

--- a/test/core/bad_client/BUILD
+++ b/test/core/bad_client/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/bad_client")
 

--- a/test/core/bad_connection/BUILD
+++ b/test/core/bad_connection/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])  # Apache v2
 

--- a/test/core/bad_ssl/BUILD
+++ b/test/core/bad_ssl/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/bad_ssl")
 

--- a/test/core/channel/BUILD
+++ b/test/core/channel/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/channel")
 

--- a/test/core/client_channel/BUILD
+++ b/test/core/client_channel/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/client_channel")
 

--- a/test/core/client_channel/resolvers/BUILD
+++ b/test/core/client_channel/resolvers/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/client_channel_resolvers")
 

--- a/test/core/compression/BUILD
+++ b/test/core/compression/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/compression")
 

--- a/test/core/debug/BUILD
+++ b/test/core/debug/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/debug")
 

--- a/test/core/end2end/BUILD
+++ b/test/core/end2end/BUILD
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])  # Apache v2
 
 grpc_package(name = "test/core/end2end")
 
-load(":generate_tests.bzl", "grpc_end2end_tests", "grpc_end2end_nosec_tests")
+load(":generate_tests.bzl", "grpc_end2end_nosec_tests", "grpc_end2end_tests")
 
 grpc_cc_library(
     name = "cq_verifier",
@@ -73,14 +73,16 @@ grpc_cc_library(
 grpc_cc_library(
     name = "local_util",
     srcs = ["fixtures/local_util.cc"],
-    hdrs = ["fixtures/local_util.h",
-            "end2end_tests.h"],
+    hdrs = [
+        "end2end_tests.h",
+        "fixtures/local_util.h",
+    ],
     language = "C++",
     deps = [
         "//:gpr",
         "//:grpc",
         "//test/core/util:grpc_test_util",
-  ],
+    ],
 )
 
 grpc_cc_test(

--- a/test/core/end2end/fuzzers/BUILD
+++ b/test/core/end2end/fuzzers/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/end2end/fuzzers")
 
@@ -22,11 +22,11 @@ load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
 
 grpc_fuzzer(
     name = "api_fuzzer",
-    srcs = ["api_fuzzer.cc"],
-    language = "C++",
-    corpus = "api_fuzzer_corpus",
     size = "enormous",
     timeout = "eternal",
+    srcs = ["api_fuzzer.cc"],
+    corpus = "api_fuzzer_corpus",
+    language = "C++",
     deps = [
         "//:gpr",
         "//:grpc",
@@ -38,8 +38,8 @@ grpc_fuzzer(
 grpc_fuzzer(
     name = "client_fuzzer",
     srcs = ["client_fuzzer.cc"],
-    language = "C++",
     corpus = "client_fuzzer_corpus",
+    language = "C++",
     deps = [
         "//:gpr",
         "//:grpc",
@@ -50,8 +50,8 @@ grpc_fuzzer(
 grpc_fuzzer(
     name = "server_fuzzer",
     srcs = ["server_fuzzer.cc"],
-    language = "C++",
     corpus = "server_fuzzer_corpus",
+    language = "C++",
     deps = [
         "//:gpr",
         "//:grpc",

--- a/test/core/fling/BUILD
+++ b/test/core/fling/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/fling")
 

--- a/test/core/gpr/BUILD
+++ b/test/core/gpr/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])  # Apache v2
 

--- a/test/core/gprpp/BUILD
+++ b/test/core/gprpp/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])  # Apache v2
 

--- a/test/core/handshake/BUILD
+++ b/test/core/handshake/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/handshake")
 

--- a/test/core/http/BUILD
+++ b/test/core/http/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/http")
 

--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])  # Apache v2
 

--- a/test/core/json/BUILD
+++ b/test/core/json/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/json")
 

--- a/test/core/nanopb/BUILD
+++ b/test/core/nanopb/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/nanopb")
 
@@ -23,8 +23,8 @@ load("//test/core/util:grpc_fuzzer.bzl", "grpc_fuzzer")
 grpc_fuzzer(
     name = "fuzzer_response",
     srcs = ["fuzzer_response.cc"],
-    language = "C++",
     corpus = "corpus_response",
+    language = "C++",
     deps = [
         "//:gpr",
         "//:grpc",
@@ -35,8 +35,8 @@ grpc_fuzzer(
 grpc_fuzzer(
     name = "fuzzer_serverlist",
     srcs = ["fuzzer_serverlist.cc"],
-    language = "C++",
     corpus = "corpus_serverlist",
+    language = "C++",
     deps = [
         "//:gpr",
         "//:grpc",

--- a/test/core/network_benchmarks/BUILD
+++ b/test/core/network_benchmarks/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(
     name = "test/core/network_benchmarks",

--- a/test/core/security/BUILD
+++ b/test/core/security/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])  # Apache v2
 

--- a/test/core/security/etc/BUILD
+++ b/test/core/security/etc/BUILD
@@ -15,8 +15,8 @@
 licenses(["notice"])  # Apache v2
 
 exports_files([
-        "bundle.pem",
-        "test_roots/cert1.pem",
-        "test_roots/cert2.pem",
-        "test_roots/cert3.pem",
+    "bundle.pem",
+    "test_roots/cert1.pem",
+    "test_roots/cert2.pem",
+    "test_roots/cert3.pem",
 ])

--- a/test/core/slice/BUILD
+++ b/test/core/slice/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/core/slice")
 

--- a/test/core/surface/BUILD
+++ b/test/core/surface/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])  # Apache v2
 

--- a/test/core/transport/BUILD
+++ b/test/core/transport/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])  # Apache v2
 

--- a/test/core/transport/chttp2/BUILD
+++ b/test/core/transport/chttp2/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])  # Apache v2
 

--- a/test/core/tsi/BUILD
+++ b/test/core/tsi/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])  # Apache v2
 

--- a/test/core/tsi/alts/fake_handshaker/BUILD
+++ b/test/core/tsi/alts/fake_handshaker/BUILD
@@ -14,7 +14,7 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_proto_library", "grpc_cc_library", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_package", "grpc_proto_library")
 
 grpc_package(
     name = "test/core/tsi/alts/fake_handshaker",

--- a/test/core/util/BUILD
+++ b/test/core/util/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 licenses(["notice"])  # Apache v2
 
@@ -76,16 +76,16 @@ grpc_cc_library(
         "tracer_util.h",
         "trickle_endpoint.h",
     ],
+    data = [
+        "lsan_suppressions.txt",
+        "tsan_suppressions.txt",
+        "ubsan_suppressions.txt",
+    ],
     language = "C++",
     deps = [
         ":grpc_debugger_macros",
         "//:gpr",
         "//:grpc_common",
-    ],
-    data = [
-        "lsan_suppressions.txt",
-        "tsan_suppressions.txt",
-        "ubsan_suppressions.txt",
     ],
 )
 

--- a/test/cpp/codegen/BUILD
+++ b/test/cpp/codegen/BUILD
@@ -14,7 +14,7 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package", "grpc_cc_binary", "grpc_sh_test")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_test", "grpc_package", "grpc_sh_test")
 
 grpc_package(name = "test/cpp/codegen")
 

--- a/test/cpp/grpclb/BUILD
+++ b/test/cpp/grpclb/BUILD
@@ -14,7 +14,7 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package", "grpc_cc_binary")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(
     name = "test/cpp/grpclb",

--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -14,7 +14,7 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/cpp/interop")
 

--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -14,7 +14,7 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_cc_library", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/cpp/microbenchmarks")
 

--- a/test/cpp/naming/BUILD
+++ b/test/cpp/naming/BUILD
@@ -22,7 +22,7 @@ package(
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_py_binary", "grpc_cc_test")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_py_binary")
 load(":generate_resolver_component_tests.bzl", "generate_resolver_component_tests")
 
 # Meant to be invoked only through the top-level shell script driver.

--- a/test/cpp/naming/utils/BUILD
+++ b/test/cpp/naming/utils/BUILD
@@ -25,26 +25,26 @@ licenses(["notice"])  # Apache v2
 load("//bazel:grpc_build_system.bzl", "grpc_py_binary")
 
 grpc_py_binary(
-  name = "dns_server",
-  srcs = ["dns_server.py"],
-  testonly = True,
-  external_deps = [
-      "twisted",
-      "yaml",
-  ]
+    name = "dns_server",
+    testonly = True,
+    srcs = ["dns_server.py"],
+    external_deps = [
+        "twisted",
+        "yaml",
+    ],
 )
 
 grpc_py_binary(
-  name = "dns_resolver",
-  srcs = ["dns_resolver.py"],
-  testonly = True,
-  external_deps = [
-      "twisted",
-  ]
+    name = "dns_resolver",
+    testonly = True,
+    srcs = ["dns_resolver.py"],
+    external_deps = [
+        "twisted",
+    ],
 )
 
 grpc_py_binary(
-  name = "tcp_connect",
-  srcs = ["tcp_connect.py"],
-  testonly = True,
+    name = "tcp_connect",
+    testonly = True,
+    srcs = ["tcp_connect.py"],
 )

--- a/test/cpp/qps/BUILD
+++ b/test/cpp/qps/BUILD
@@ -14,8 +14,8 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_cc_library", "grpc_cc_binary", "grpc_package")
-load("//test/cpp/qps:qps_benchmark_script.bzl", "qps_json_driver_batch", "json_run_localhost_batch")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
+load("//test/cpp/qps:qps_benchmark_script.bzl", "json_run_localhost_batch", "qps_json_driver_batch")
 
 grpc_package(name = "test/cpp/qps")
 

--- a/test/cpp/server/BUILD
+++ b/test/cpp/server/BUILD
@@ -14,7 +14,7 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_cc_library", "grpc_cc_binary", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(name = "test/cpp/server")
 

--- a/test/cpp/test/BUILD
+++ b/test/cpp/test/BUILD
@@ -14,7 +14,7 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package", "grpc_cc_binary")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(
     name = "test/cpp/test",

--- a/test/cpp/thread_manager/BUILD
+++ b/test/cpp/thread_manager/BUILD
@@ -14,7 +14,7 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_package", "grpc_cc_binary")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(
     name = "test/cpp/thread_manager",

--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -14,7 +14,7 @@
 
 licenses(["notice"])  # Apache v2
 
-load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_binary", "grpc_cc_test", "grpc_package")
+load("//bazel:grpc_build_system.bzl", "grpc_cc_binary", "grpc_cc_library", "grpc_cc_test", "grpc_package")
 
 grpc_package(
     name = "test/cpp/util",

--- a/tools/run_tests/sanity/check_buildifier.sh
+++ b/tools/run_tests/sanity/check_buildifier.sh
@@ -1,0 +1,25 @@
+#! /usr/bin/env bash
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+ROOT="$(dirname "$0")/../../.."
+
+for build_file in $(find "${ROOT}" -type f \
+    -not -path "${ROOT}/third_party/*" \
+    -and \( -iname BUILD -or -iname BUILD.bazel \))
+do
+    buildifier "${build_file}"
+done

--- a/tools/run_tests/sanity/sanity_tests.yaml
+++ b/tools/run_tests/sanity/sanity_tests.yaml
@@ -1,6 +1,7 @@
 # a set of tests that are run in parallel for sanity tests
 - script: tools/run_tests/sanity/check_bad_dependencies.sh
 - script: tools/run_tests/sanity/check_bazel_workspace.py
+- script: tools/run_tests/sanity/check_buildifier.sh
 - script: tools/run_tests/sanity/check_cache_mk.sh
 - script: tools/run_tests/sanity/check_owners.sh
 - script: tools/run_tests/sanity/check_qps_scenario_changes.py


### PR DESCRIPTION
* Excludes the `third_party` folder.
* Adds a check in sanity test to make sure `buildifier` is happy.