### PR TITLE
Move RBE test timeout configuration to a single place

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_on_foundry_dbg.sh
+++ b/tools/internal_ci/linux/grpc_bazel_on_foundry_dbg.sh
@@ -16,5 +16,5 @@
 set -ex
 
 export UPLOAD_TEST_RESULTS=true
-EXTRA_FLAGS="--config=dbg --test_timeout=300,450,1200,3600 --cache_test_results=no"
+EXTRA_FLAGS="--config=dbg --cache_test_results=no"
 github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh "${EXTRA_FLAGS}"

--- a/tools/internal_ci/linux/grpc_bazel_on_foundry_opt.sh
+++ b/tools/internal_ci/linux/grpc_bazel_on_foundry_opt.sh
@@ -16,5 +16,5 @@
 set -ex
 
 export UPLOAD_TEST_RESULTS=true
-EXTRA_FLAGS="--config=opt --test_timeout=300,450,1200,3600 --cache_test_results=no"
+EXTRA_FLAGS="--config=opt --cache_test_results=no"
 github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh "${EXTRA_FLAGS}"

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_dbg.sh
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_dbg.sh
@@ -15,5 +15,5 @@
 
 set -ex
 
-EXTRA_FLAGS="--config=dbg --test_timeout=300,450,1200,3600"
+EXTRA_FLAGS="--config=dbg"
 github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh "${EXTRA_FLAGS}"

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_opt.sh
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_opt.sh
@@ -15,5 +15,5 @@
 
 set -ex
 
-EXTRA_FLAGS="--config=opt --test_timeout=300,450,1200,3600"
+EXTRA_FLAGS="--config=opt"
 github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh "${EXTRA_FLAGS}"

--- a/tools/remote_build/manual.bazelrc
+++ b/tools/remote_build/manual.bazelrc
@@ -37,9 +37,5 @@ build --project_id=grpc-testing
 
 build --jobs=100
 
-# TODO(jtattermusch): this should be part of the common config
-# but currently sanitizers use different test_timeout values
-build --test_timeout=300,450,1200,3600
-
 # print output for tests that fail (default is "summary")
 build --test_output=errors

--- a/tools/remote_build/rbe_common.bazelrc
+++ b/tools/remote_build/rbe_common.bazelrc
@@ -44,6 +44,10 @@ build --define GRPC_PORT_ISOLATED_RUNTIME=1
 # without verbose gRPC logs the test outputs are not very useful
 test --test_env=GRPC_VERBOSITY=debug
 
+# Default test timeouts for all RBE tests (sanitizers override these values)
+# TODO(jtattermusch): revisit the non-standard test timeout values
+build --test_timeout=300,450,1200,3600
+
 # address sanitizer: most settings are already in %workspace%/.bazelrc
 # we only need a few additional ones that are Foundry specific
 build:asan --copt=-gmlt


### PR DESCRIPTION
Setting test timeouts for RBE all over the place is messy and makes stuff hard to debug. Move everything to `rbe_common.bazelrc`.

Sanitizers do override the default test timeouts fine (can be checked in Invocation Details -> canonical bazel command line), because the more specific (per-config) settings take precedence over the less specific.