### PR TITLE
Update "//test/cpp/end2end:end2end_test" test size to avoid RBE timeouts

### DIFF
--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -222,6 +222,7 @@ grpc_cc_test(
     deps = [
         ":end2end_test_lib",
     ],
+    size = "large",  # with poll-cv this takes long, see #17493
 )
 
 grpc_cc_test(


### PR DESCRIPTION
Fixes #17493 where the tests turns out to be timing out at 450sec, but we didn't realize that's "working as intended" because the test_timeout configuration for RBE tests is messy (cleanup attempt is in  https://github.com/grpc/grpc/pull/17808).

