### PR TITLE
Revert "Remove the fake package dependency && temporarily skip the Channelz tests"

### DIFF
--- a/src/python/grpcio_tests/setup.py
+++ b/src/python/grpcio_tests/setup.py
@@ -37,19 +37,13 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    'coverage>=4.0',
-    'enum34>=1.0.4',
+    'coverage>=4.0', 'enum34>=1.0.4',
     'grpcio>={version}'.format(version=grpc_version.VERSION),
-    # TODO(https://github.com/pypa/warehouse/issues/5196)
-    # Re-enable it once we got the name back
-    # 'grpcio-channelz>={version}'.format(version=grpc_version.VERSION),
+    'grpcio-channelz>={version}'.format(version=grpc_version.VERSION),
     'grpcio-status>={version}'.format(version=grpc_version.VERSION),
     'grpcio-tools>={version}'.format(version=grpc_version.VERSION),
     'grpcio-health-checking>={version}'.format(version=grpc_version.VERSION),
-    'oauth2client>=1.4.7',
-    'protobuf>=3.6.0',
-    'six>=1.10',
-    'google-auth>=1.0.0',
+    'oauth2client>=1.4.7', 'protobuf>=3.6.0', 'six>=1.10', 'google-auth>=1.0.0',
     'requests>=2.14.2')
 
 if not PY3:

--- a/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
@@ -91,7 +91,6 @@ def _close_channel_server_pairs(pairs):
         pair.channel.close()
 
 
-@unittest.skip('https://github.com/pypa/warehouse/issues/5196')
 class ChannelzServicerTest(unittest.TestCase):
 
     def _send_successful_unary_unary(self, idx):


### PR DESCRIPTION
Since we got the "grpcio-channelz" name back, we should enable this test.

This reverts commit 08a90f03d4d0ac846f517c9aeab7aeb05b1cfdca.