### PR TITLE
Move Kokoro build files to /tmpfs

### DIFF
--- a/src/objective-c/tests/build_one_example.sh
+++ b/src/objective-c/tests/build_one_example.sh
@@ -36,6 +36,13 @@ rm -f Podfile.lock
 
 pod install
 
+# If building on Kokoro, use /tmpfs to store derived data
+if [ "$KOKORO_BUILD" -eq 1 ]; then
+  DERIVED_DIR="/tmpfs/Build/Build"
+else
+  DERIVED_DIR="Build/Build"
+fi
+
 set -o pipefail
 XCODEBUILD_FILTER='(^CompileC |^Ld |^.*clang |^ *cd |^ *export |^Libtool |^.*libtool |^CpHeader |^ *builtin-copy )'
 xcodebuild \
@@ -43,7 +50,7 @@ xcodebuild \
     -workspace *.xcworkspace \
     -scheme $SCHEME \
     -destination generic/platform=iOS \
-    -derivedDataPath Build/Build \
+    -derivedDataPath $DERIVED_DIR \
     CODE_SIGN_IDENTITY="" \
     CODE_SIGNING_REQUIRED=NO \
     | egrep -v "$XCODEBUILD_FILTER" \

--- a/src/objective-c/tests/build_one_example.sh
+++ b/src/objective-c/tests/build_one_example.sh
@@ -43,6 +43,8 @@ else
   DERIVED_DIR="Build/Build"
 fi
 
+rm -rf $DERIVED_DIR
+
 set -o pipefail
 XCODEBUILD_FILTER='(^CompileC |^Ld |^.*clang |^ *cd |^ *export |^Libtool |^.*libtool |^CpHeader |^ *builtin-copy )'
 xcodebuild \

--- a/src/objective-c/tests/build_tests.sh
+++ b/src/objective-c/tests/build_tests.sh
@@ -16,6 +16,8 @@
 # Don't run this script standalone. Instead, run from the repository root:
 # ./tools/run_tests/run_tests.py -l objc
 
+echo "Running build_tests.sh"
+
 set -e
 
 # CocoaPods requires the terminal to be using UTF-8 encoding.

--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -24,6 +24,10 @@ cd $(dirname $0)
 
 BINDIR=../../../bins/$CONFIG
 
+clean_build_dir () {
+  rm -rf "$1"
+}
+
 [ -f $BINDIR/interop_server ] || {
     echo >&2 "Can't find the test server. Make sure run_tests.py is making" \
              "interop_server before calling this script."
@@ -100,6 +104,8 @@ xcodebuild \
     | egrep -v '^$' \
     | egrep -v "(GPBDictionary|GPBArray)" -
 
+clean_build_dir "$DERIVED_DIR"
+
 echo "TIME:  $(date)"
 xcodebuild \
     -workspace Tests.xcworkspace \
@@ -110,6 +116,8 @@ xcodebuild \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v '^$' \
     | egrep -v "(GPBDictionary|GPBArray)" -
+
+clean_build_dir "$DERIVED_DIR"
 
 echo "TIME:  $(date)"
 xcodebuild \
@@ -122,6 +130,8 @@ xcodebuild \
     | egrep -v '^$' \
     | egrep -v "(GPBDictionary|GPBArray)" -
 
+clean_build_dir "$DERIVED_DIR"
+
 echo "TIME:  $(date)"
 xcodebuild \
     -workspace Tests.xcworkspace \
@@ -132,6 +142,8 @@ xcodebuild \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v '^$' \
     | egrep -v "(GPBDictionary|GPBArray)" -
+
+clean_build_dir "$DERIVED_DIR"
 
 echo "TIME:  $(date)"
 xcodebuild \
@@ -145,6 +157,8 @@ xcodebuild \
     | egrep -v '^$' \
     | egrep -v "(GPBDictionary|GPBArray)" -
 
+clean_build_dir "$DERIVED_DIR"
+
 echo "TIME:  $(date)"
 xcodebuild \
     -workspace Tests.xcworkspace \
@@ -156,6 +170,8 @@ xcodebuild \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v '^$' \
     | egrep -v "(GPBDictionary|GPBArray)" -
+
+clean_build_dir "$DERIVED_DIR"
 
 echo "TIME:  $(date)"
 xcodebuild \
@@ -169,6 +185,8 @@ xcodebuild \
     | egrep -v '^$' \
     | egrep -v "(GPBDictionary|GPBArray)" -
 
+clean_build_dir "$DERIVED_DIR"
+
 echo "TIME:  $(date)"
 xcodebuild \
     -workspace Tests.xcworkspace \
@@ -181,6 +199,8 @@ xcodebuild \
     | egrep -v '^$' \
     | egrep -v "(GPBDictionary|GPBArray)" -
 
+clean_build_dir "$DERIVED_DIR"
+
 echo "TIME:  $(date)"
 xcodebuild \
     -workspace Tests.xcworkspace \
@@ -192,6 +212,8 @@ xcodebuild \
     | egrep -v '^$' \
     | egrep -v "(GPBDictionary|GPBArray)" -
 
+clean_build_dir "$DERIVED_DIR"
+
 echo "TIME:  $(date)"
 xcodebuild \
     -workspace Tests.xcworkspace \
@@ -202,6 +224,8 @@ xcodebuild \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v '^$' \
     | egrep -v "(GPBDictionary|GPBArray)" -
+
+clean_build_dir "$DERIVED_DIR"
 
 echo "TIME:  $(date)"
 xcodebuild \
@@ -215,5 +239,7 @@ xcodebuild \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v '^$' \
     | egrep -v "(GPBDictionary|GPBArray)" -
+
+clean_build_dir "$DERIVED_DIR"
 
 exit 0

--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -28,6 +28,7 @@ BINDIR=../../../bins/$CONFIG
 
 clean_build_dir () {
   rm -rf "$1"
+  mkdir -p "$1"
 }
 
 [ -f $BINDIR/interop_server ] || {
@@ -57,6 +58,8 @@ else
 fi
 
 echo "TIME:  $(date)"
+
+clean_build_dir "$DERIVED_DIR"
 
 # Retry the test for up to 3 times when return code is 65, due to Xcode issue:
 # http://www.openradar.me/29785686

--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -16,6 +16,8 @@
 # Don't run this script standalone. Instead, run from the repository root:
 # ./tools/run_tests/run_tests.py -l objc
 
+echo "Running run_tests.py"
+
 set -ev
 
 cd $(dirname $0)

--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -43,8 +43,10 @@ XCODEBUILD_FILTER='(^CompileC |^Ld |^ *[^ ]*clang |^ *cd |^ *export |^Libtool |^
 
 # If building on Kokoro, use /tmpfs to store derived data
 if [ "$KOKORO_BUILD" -eq 1 ]; then
+  echo "Kokoro build; use /tmpfs"
   DERIVED_DIR="/tmpfs/Build/Build"
 else
+  echo "Local build"
   DERIVED_DIR="Build/Build"
 fi
 

--- a/src/objective-c/tests/run_tests.sh
+++ b/src/objective-c/tests/run_tests.sh
@@ -41,6 +41,13 @@ set -o pipefail
 # TODO(jcanizales): Use xctool instead? Issue #2540.
 XCODEBUILD_FILTER='(^CompileC |^Ld |^ *[^ ]*clang |^ *cd |^ *export |^Libtool |^ *[^ ]*libtool |^CpHeader |^ *builtin-copy )'
 
+# If building on Kokoro, use /tmpfs to store derived data
+if [ "$KOKORO_BUILD" -eq 1 ]; then
+  DERIVED_DIR="/tmpfs/Build/Build"
+else
+  DERIVED_DIR="Build/Build"
+fi
+
 echo "TIME:  $(date)"
 
 # Retry the test for up to 3 times when return code is 65, due to Xcode issue:
@@ -54,6 +61,7 @@ while [ $retries -lt 3 ]; do
         -workspace Tests.xcworkspace \
         -scheme AllTests \
         -destination name="iPhone 8" \
+        -derivedDataPath $DERIVED_DIR \
         HOST_PORT_LOCALSSL=localhost:5051 \
         HOST_PORT_LOCAL=localhost:5050 \
         HOST_PORT_REMOTE=grpc-test.sandbox.googleapis.com \
@@ -84,6 +92,7 @@ xcodebuild \
     -workspace Tests.xcworkspace \
     -scheme CoreCronetEnd2EndTests \
     -destination name="iPhone 8" \
+    -derivedDataPath $DERIVED_DIR \
     test \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v '^$' \
@@ -94,6 +103,7 @@ xcodebuild \
     -workspace Tests.xcworkspace \
     -scheme CoreCronetEnd2EndTests_Asan \
     -destination name="iPhone 6" \
+    -derivedDataPath $DERIVED_DIR \
     test \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v '^$' \
@@ -104,6 +114,7 @@ xcodebuild \
     -workspace Tests.xcworkspace \
     -scheme CoreCronetEnd2EndTests_Tsan \
     -destination name="iPhone 6" \
+    -derivedDataPath $DERIVED_DIR \
     test \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v '^$' \
@@ -114,6 +125,7 @@ xcodebuild \
     -workspace Tests.xcworkspace \
     -scheme CronetUnitTests \
     -destination name="iPhone 8" \
+    -derivedDataPath $DERIVED_DIR \
     test \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v '^$' \
@@ -124,6 +136,7 @@ xcodebuild \
     -workspace Tests.xcworkspace \
     -scheme InteropTestsRemoteWithCronet \
     -destination name="iPhone 8" \
+    -derivedDataPath $DERIVED_DIR \
     HOST_PORT_REMOTE=grpc-test.sandbox.googleapis.com \
     test \
     | egrep -v "$XCODEBUILD_FILTER" \
@@ -135,6 +148,7 @@ xcodebuild \
     -workspace Tests.xcworkspace \
     -scheme InteropTestsRemoteCFStream \
     -destination name="iPhone 8" \
+    -derivedDataPath $DERIVED_DIR \
     HOST_PORT_REMOTE=grpc-test.sandbox.googleapis.com \
     test \
     | egrep -v "$XCODEBUILD_FILTER" \
@@ -146,6 +160,7 @@ xcodebuild \
     -workspace Tests.xcworkspace \
     -scheme InteropTestsLocalCleartextCFStream \
     -destination name="iPhone 8" \
+    -derivedDataPath $DERIVED_DIR \
     HOST_PORT_LOCAL=localhost:5050 \
     test \
     | egrep -v "$XCODEBUILD_FILTER" \
@@ -157,6 +172,7 @@ xcodebuild \
     -workspace Tests.xcworkspace \
     -scheme InteropTestsLocalSSLCFStream \
     -destination name="iPhone 8" \
+    -derivedDataPath $DERIVED_DIR \
     HOST_PORT_LOCALSSL=localhost:5051 \
     test \
     | egrep -v "$XCODEBUILD_FILTER" \
@@ -168,6 +184,7 @@ xcodebuild \
     -workspace Tests.xcworkspace \
     -scheme UnitTests \
     -destination name="iPhone 8" \
+    -derivedDataPath $DERIVED_DIR \
     test \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v '^$' \
@@ -178,6 +195,7 @@ xcodebuild \
     -workspace Tests.xcworkspace \
     -scheme ChannelTests \
     -destination name="iPhone 8" \
+    -derivedDataPath $DERIVED_DIR \
     test \
     | egrep -v "$XCODEBUILD_FILTER" \
     | egrep -v '^$' \
@@ -188,6 +206,7 @@ xcodebuild \
     -workspace Tests.xcworkspace \
     -scheme APIv2Tests \
     -destination name="iPhone 8" \
+    -derivedDataPath $DERIVED_DIR \
     HOST_PORT_LOCAL=localhost:5050 \
     HOST_PORT_REMOTE=grpc-test.sandbox.googleapis.com \
     test \

--- a/test/core/iomgr/ios/CFStreamTests/CFStreamTests.xcodeproj/xcshareddata/xcschemes/CFStreamTests.xcscheme
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamTests.xcodeproj/xcshareddata/xcschemes/CFStreamTests.xcscheme
@@ -36,6 +36,13 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "grpc_cfstream"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/test/core/iomgr/ios/CFStreamTests/CFStreamTests.xcodeproj/xcshareddata/xcschemes/CFStreamTests_Asan.xcscheme
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamTests.xcodeproj/xcshareddata/xcschemes/CFStreamTests_Asan.xcscheme
@@ -12,7 +12,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableAddressSanitizer = "YES"
       enableASanStackUseAfterReturn = "YES"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -34,13 +33,19 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableASanStackUseAfterReturn = "YES"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "grpc_cfstream"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/test/core/iomgr/ios/CFStreamTests/CFStreamTests.xcodeproj/xcshareddata/xcschemes/CFStreamTests_Msan.xcscheme
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamTests.xcodeproj/xcshareddata/xcschemes/CFStreamTests_Msan.xcscheme
@@ -10,7 +10,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -51,13 +50,19 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "grpc_cfstream"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/test/core/iomgr/ios/CFStreamTests/CFStreamTests.xcodeproj/xcshareddata/xcschemes/CFStreamTests_Tsan.xcscheme
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamTests.xcodeproj/xcshareddata/xcschemes/CFStreamTests_Tsan.xcscheme
@@ -11,7 +11,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableThreadSanitizer = "YES"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -32,7 +31,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -40,6 +38,13 @@
       stopOnEveryThreadSanitizerIssue = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "grpc_cfstream"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1076,7 +1076,8 @@ class ObjCLanguage(object):
                 cpu_cost=1e6,
                 environ={
                     'SCHEME': 'HelloWorld',
-                    'EXAMPLE_PATH': 'examples/objective-c/helloworld'
+                    'EXAMPLE_PATH': 'examples/objective-c/helloworld',
+                    'KOKORO_BUILD': '1'
                 }),
             self.config.job_spec(
                 ['src/objective-c/tests/build_one_example.sh'],
@@ -1085,7 +1086,8 @@ class ObjCLanguage(object):
                 cpu_cost=1e6,
                 environ={
                     'SCHEME': 'RouteGuideClient',
-                    'EXAMPLE_PATH': 'examples/objective-c/route_guide'
+                    'EXAMPLE_PATH': 'examples/objective-c/route_guide',
+                    'KOKORO_BUILD': '1'
                 }),
             self.config.job_spec(
                 ['src/objective-c/tests/build_one_example.sh'],
@@ -1094,7 +1096,8 @@ class ObjCLanguage(object):
                 cpu_cost=1e6,
                 environ={
                     'SCHEME': 'AuthSample',
-                    'EXAMPLE_PATH': 'examples/objective-c/auth_sample'
+                    'EXAMPLE_PATH': 'examples/objective-c/auth_sample',
+                    'KOKORO_BUILD': '1'
                 }),
             self.config.job_spec(
                 ['src/objective-c/tests/build_one_example.sh'],
@@ -1103,7 +1106,8 @@ class ObjCLanguage(object):
                 cpu_cost=1e6,
                 environ={
                     'SCHEME': 'Sample',
-                    'EXAMPLE_PATH': 'src/objective-c/examples/Sample'
+                    'EXAMPLE_PATH': 'src/objective-c/examples/Sample',
+                    'KOKORO_BUILD': '1'
                 }),
             self.config.job_spec(
                 ['src/objective-c/tests/build_one_example.sh'],
@@ -1113,7 +1117,8 @@ class ObjCLanguage(object):
                 environ={
                     'SCHEME': 'Sample',
                     'EXAMPLE_PATH': 'src/objective-c/examples/Sample',
-                    'FRAMEWORKS': 'YES'
+                    'FRAMEWORKS': 'YES',
+                    'KOKORO_BUILD': '1'
                 }),
             self.config.job_spec(
                 ['src/objective-c/tests/build_one_example.sh'],
@@ -1122,7 +1127,8 @@ class ObjCLanguage(object):
                 cpu_cost=1e6,
                 environ={
                     'SCHEME': 'SwiftSample',
-                    'EXAMPLE_PATH': 'src/objective-c/examples/SwiftSample'
+                    'EXAMPLE_PATH': 'src/objective-c/examples/SwiftSample',
+                    'KOKORO_BUILD': '1'
                 }),
             self.config.job_spec(
                 ['test/core/iomgr/ios/CFStreamTests/run_tests.sh'],

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1062,7 +1062,9 @@ class ObjCLanguage(object):
                 timeout_seconds=60 * 60,
                 shortname='objc-tests',
                 cpu_cost=1e6,
-                environ=_FORCE_ENVIRON_FOR_WRAPPERS),
+                environ={
+                    'KOKORO_BUILD': '1'
+                }),
             self.config.job_spec(
                 ['src/objective-c/tests/run_plugin_tests.sh'],
                 timeout_seconds=60 * 60,


### PR DESCRIPTION
Some ObjC builds seem to be suffering insufficient space issue on Kokoro. Moving the build files to `/tmpfs` which provides more space.

Also fixes a test flake in `CFStream-test`

Fixes #17814 