### PR TITLE
explicitly lengthened timeout for end2end test

### DIFF
--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -223,6 +223,7 @@ grpc_cc_test(
         ":end2end_test_lib",
     ],
     size = "large",  # with poll-cv this takes long, see #17493
+    timeout = "long",
 )
 
 grpc_cc_test(


### PR DESCRIPTION
The default parameter for timeout is set to "medium", which I believe overrides the "size" parameter. This attempted fix explicitly states the timeout, overrides the default argument.