### PR TITLE
adding python version environmental markers in the new style when pyhon version is greater than 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -298,11 +298,12 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    'six>=1.5.2',
+    "six>=1.5.2",
+    "futures>=2.2.0 ; python_version<'3.2'",	
+    "enum34>=1.0.4 ; python_version<'3.4'"	
 )
-
 if not PY3:
-  INSTALL_REQUIRES += ('futures>=2.2.0', 'enum34>=1.0.4')
+  INSTALL_REQUIRES = ("six>=1.5.2", 'futures>=2.2.0', 'enum34>=1.0.4')
 
 SETUP_REQUIRES = INSTALL_REQUIRES + (
     'Sphinx~=1.8.1',


### PR DESCRIPTION
This is a follow up to discussion on PR #16235