### PR TITLE
Make C# code compile with C# 6 compiler

### DIFF
--- a/src/csharp/Grpc.Core.Testing/Grpc.Core.Testing.csproj
+++ b/src/csharp/Grpc.Core.Testing/Grpc.Core.Testing.csproj
@@ -7,6 +7,7 @@
     <Copyright>Copyright 2017, Google Inc.</Copyright>
     <AssemblyTitle>gRPC C# Core Testing</AssemblyTitle>
     <VersionPrefix>$(GrpcCsharpVersion)</VersionPrefix>
+    <LangVersion>6</LangVersion>
     <Authors>Google Inc.</Authors>
     <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/csharp/Grpc.Core.Testing/TestServerCallContext.cs
+++ b/src/csharp/Grpc.Core.Testing/TestServerCallContext.cs
@@ -88,8 +88,28 @@ namespace Grpc.Core.Testing
 
             protected override Metadata ResponseTrailersCore => responseTrailers;
 
-            protected override Status StatusCore { get => status; set => status = value; }
-            protected override WriteOptions WriteOptionsCore { get => writeOptionsGetter(); set => writeOptionsSetter(value); }
+            protected override Status StatusCore { 
+                get 
+                {
+                    return status;
+                } 
+                
+                set 
+                { 
+                    status = value; 
+                }
+            }
+            protected override WriteOptions WriteOptionsCore { 
+                get 
+                {
+                    return writeOptionsGetter();
+                }
+                
+                set 
+                {
+                    writeOptionsSetter(value); 
+                }
+            }
 
             protected override AuthContext AuthContextCore => authContext;
 

--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Grpc.Core.Tests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -7,6 +7,7 @@
     <Copyright>Copyright 2015, Google Inc.</Copyright>
     <AssemblyTitle>gRPC C# Core</AssemblyTitle>
     <VersionPrefix>$(GrpcCsharpVersion)</VersionPrefix>
+    <LangVersion>6</LangVersion>
     <Authors>Google Inc.</Authors>
     <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
     <AssemblyName>Grpc.Core</AssemblyName>

--- a/src/csharp/Grpc.Core/Internal/DefaultServerCallContext.cs
+++ b/src/csharp/Grpc.Core/Internal/DefaultServerCallContext.cs
@@ -87,14 +87,28 @@ namespace Grpc.Core
 
         protected override Status StatusCore
         {
-            get => status;
-            set => status = value;
+            get 
+            {
+                return status;
+            }
+            
+            set 
+            {
+                status = value;
+            }
         }
 
         protected override WriteOptions WriteOptionsCore
         {
-            get => serverResponseStream.WriteOptions;
-            set => serverResponseStream.WriteOptions = value;
+            get 
+            { 
+                return serverResponseStream.WriteOptions;
+            }
+
+            set 
+            {
+                serverResponseStream.WriteOptions = value;
+            }
         }
 
         protected override AuthContext AuthContextCore => authContext.Value;

--- a/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
+++ b/src/csharp/Grpc.Core/Internal/UnmanagedLibrary.cs
@@ -50,8 +50,9 @@ namespace Grpc.Core.Internal
             this.libraryPath = FirstValidLibraryPath(libraryPathAlternatives);
 
             Logger.Debug("Attempting to load native library \"{0}\"", this.libraryPath);
-
-            this.handle = PlatformSpecificLoadLibrary(this.libraryPath, out string loadLibraryErrorDetail);
+            
+            string loadLibraryErrorDetail;
+            this.handle = PlatformSpecificLoadLibrary(this.libraryPath, out loadLibraryErrorDetail);
 
             if (this.handle == IntPtr.Zero)
             {

--- a/src/csharp/Grpc.Core/Metadata.cs
+++ b/src/csharp/Grpc.Core/Metadata.cs
@@ -358,7 +358,8 @@ namespace Grpc.Core
             {
                 GrpcPreconditions.CheckNotNull(key, "key");
 
-                GrpcPreconditions.CheckArgument(IsValidKey(key, out bool isLowercase), 
+                bool isLowercase;
+                GrpcPreconditions.CheckArgument(IsValidKey(key, out isLowercase), 
                     "Metadata entry key not valid. Keys can only contain lowercase alphanumeric characters, underscores, hyphens and dots.");
                 if (isLowercase)
                 {

--- a/src/csharp/Grpc.Examples.MathClient/Grpc.Examples.MathClient.csproj
+++ b/src/csharp/Grpc.Examples.MathClient/Grpc.Examples.MathClient.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Grpc.Examples.MathClient</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/csharp/Grpc.Examples.MathServer/Grpc.Examples.MathServer.csproj
+++ b/src/csharp/Grpc.Examples.MathServer/Grpc.Examples.MathServer.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Grpc.Examples.MathServer</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.csproj
+++ b/src/csharp/Grpc.Examples.Tests/Grpc.Examples.Tests.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Grpc.Examples.Tests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/csharp/Grpc.Examples/Grpc.Examples.csproj
+++ b/src/csharp/Grpc.Examples/Grpc.Examples.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Grpc.Examples</AssemblyName>
     <PackageId>Grpc.Examples</PackageId>

--- a/src/csharp/Grpc.HealthCheck.Tests/Grpc.HealthCheck.Tests.csproj
+++ b/src/csharp/Grpc.HealthCheck.Tests/Grpc.HealthCheck.Tests.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Grpc.HealthCheck.Tests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.csproj
+++ b/src/csharp/Grpc.HealthCheck/Grpc.HealthCheck.csproj
@@ -7,6 +7,7 @@
     <Copyright>Copyright 2015, Google Inc.</Copyright>
     <AssemblyTitle>gRPC C# Healthchecking</AssemblyTitle>
     <VersionPrefix>$(GrpcCsharpVersion)</VersionPrefix>
+    <LangVersion>6</LangVersion>
     <Authors>Google Inc.</Authors>
     <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
     <AssemblyName>Grpc.HealthCheck</AssemblyName>

--- a/src/csharp/Grpc.IntegrationTesting.Client/Grpc.IntegrationTesting.Client.csproj
+++ b/src/csharp/Grpc.IntegrationTesting.Client/Grpc.IntegrationTesting.Client.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Grpc.IntegrationTesting.Client</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/csharp/Grpc.IntegrationTesting.QpsWorker/Grpc.IntegrationTesting.QpsWorker.csproj
+++ b/src/csharp/Grpc.IntegrationTesting.QpsWorker/Grpc.IntegrationTesting.QpsWorker.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Grpc.IntegrationTesting.QpsWorker</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/csharp/Grpc.IntegrationTesting.Server/Grpc.IntegrationTesting.Server.csproj
+++ b/src/csharp/Grpc.IntegrationTesting.Server/Grpc.IntegrationTesting.Server.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Grpc.IntegrationTesting.Server</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/csharp/Grpc.IntegrationTesting.StressClient/Grpc.IntegrationTesting.StressClient.csproj
+++ b/src/csharp/Grpc.IntegrationTesting.StressClient/Grpc.IntegrationTesting.StressClient.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Grpc.IntegrationTesting.StressClient</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
+++ b/src/csharp/Grpc.IntegrationTesting/Grpc.IntegrationTesting.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Grpc.IntegrationTesting</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/csharp/Grpc.Microbenchmarks/CompletionRegistryBenchmark.cs
+++ b/src/csharp/Grpc.Microbenchmarks/CompletionRegistryBenchmark.cs
@@ -51,7 +51,7 @@ namespace Grpc.Microbenchmarks
 
         private void ThreadBody(int iterations, CompletionRegistry optionalSharedRegistry)
         {
-            var completionRegistry = optionalSharedRegistry ?? new CompletionRegistry(environment, () => throw new NotImplementedException(), () => throw new NotImplementedException());
+            var completionRegistry = optionalSharedRegistry ?? new CompletionRegistry(environment, () => { throw new NotImplementedException(); }, () => { throw new NotImplementedException(); });
             var ctx = BatchContextSafeHandle.Create();
   
             var stopwatch = Stopwatch.StartNew();

--- a/src/csharp/Grpc.Microbenchmarks/Grpc.Microbenchmarks.csproj
+++ b/src/csharp/Grpc.Microbenchmarks/Grpc.Microbenchmarks.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Grpc.Microbenchmarks</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/csharp/Grpc.Microbenchmarks/SendMessageBenchmark.cs
+++ b/src/csharp/Grpc.Microbenchmarks/SendMessageBenchmark.cs
@@ -52,7 +52,7 @@ namespace Grpc.Microbenchmarks
 
         private void ThreadBody(int iterations, int payloadSize)
         {
-            var completionRegistry = new CompletionRegistry(environment, () => environment.BatchContextPool.Lease(), () => throw new NotImplementedException());
+            var completionRegistry = new CompletionRegistry(environment, () => environment.BatchContextPool.Lease(), () => { throw new NotImplementedException(); });
             var cq = CompletionQueueSafeHandle.CreateAsync(completionRegistry);
             var call = CreateFakeCall(cq);
 

--- a/src/csharp/Grpc.Reflection.Tests/Grpc.Reflection.Tests.csproj
+++ b/src/csharp/Grpc.Reflection.Tests/Grpc.Reflection.Tests.csproj
@@ -4,6 +4,7 @@
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
     <AssemblyName>Grpc.Reflection.Tests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/src/csharp/Grpc.Reflection/Grpc.Reflection.csproj
+++ b/src/csharp/Grpc.Reflection/Grpc.Reflection.csproj
@@ -8,6 +8,7 @@
     <AssemblyTitle>gRPC C# Reflection</AssemblyTitle>
     <VersionPrefix>$(GrpcCsharpVersion)</VersionPrefix>
     <Authors>Google Inc.</Authors>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
     <AssemblyName>Grpc.Reflection</AssemblyName>
     <PackageId>Grpc.Reflection</PackageId>

--- a/src/csharp/Grpc.Tools.Tests/DepFileUtilTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/DepFileUtilTest.cs
@@ -47,12 +47,13 @@ namespace Grpc.Tools.Tests
                 DepFileUtil.GetDepFilenameForProto("", "foo.proto"));
         }
 
+        internal static string PickHash(string fname) {
+            return DepFileUtil.GetDepFilenameForProto("", fname).Substring(0, 16);
+        }
+
         [Test]
         public void GetDepFilenameForProto_HashesDir()
         {
-            string PickHash(string fname) =>
-                DepFileUtil.GetDepFilenameForProto("", fname).Substring(0, 16);
-
             string same1 = PickHash("dir1/dir2/foo.proto");
             string same2 = PickHash("dir1/dir2/proto.foo");
             string same3 = PickHash("dir1/dir2/proto");

--- a/src/csharp/Grpc.Tools.Tests/Grpc.Tools.Tests.csproj
+++ b/src/csharp/Grpc.Tools.Tests/Grpc.Tools.Tests.csproj
@@ -3,6 +3,7 @@
   <Import Project="..\Grpc.Core\Version.csproj.include" />
 
   <PropertyGroup>
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netcoreapp1.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>

--- a/src/csharp/Grpc.Tools/Grpc.Tools.csproj
+++ b/src/csharp/Grpc.Tools/Grpc.Tools.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>Protobuf.MSBuild</AssemblyName>
     <Version>$(GrpcCsharpVersion)</Version>
     <!-- If changing targets, change also paths in Google.Protobuf.Tools.targets. -->
+    <LangVersion>6</LangVersion>
     <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/csharp/Grpc.Tools/ProtoCompile.cs
+++ b/src/csharp/Grpc.Tools/ProtoCompile.cs
@@ -348,6 +348,14 @@ namespace Grpc.Tools
             return trim;
         }
 
+        internal void PrintQuoting(StringBuilder printer, string str, char[] quotable, int start, int count)
+        {
+            bool wrap = count == 0 || str.IndexOfAny(quotable, start, count) >= 0;
+            if (wrap) printer.Append('"');
+            printer.Append(str, start, count);
+            if (wrap) printer.Append('"');
+        }
+
         // Called by the base class to log tool's command line.
         //
         // Protoc command file is peculiar, with one argument per line, separated
@@ -363,13 +371,6 @@ namespace Grpc.Tools
             // characters requiring quoting is not by any means exhaustive; we are
             // just striving to be nice, not guaranteeing to be nice.
             var quotable = new[] { ' ', '!', '$', '&', '\'', '^' };
-            void PrintQuoting(string str, int start, int count)
-            {
-                bool wrap = count == 0 || str.IndexOfAny(quotable, start, count) >= 0;
-                if (wrap) printer.Append('"');
-                printer.Append(str, start, count);
-                if (wrap) printer.Append('"');
-            }
 
             for (int ib = 0, ie; (ie = cmd.IndexOf('\n', ib)) >= 0; ib = ie + 1)
             {
@@ -380,7 +381,7 @@ namespace Grpc.Tools
                     int iep = cmd.IndexOf(" --");
                     if (iep > 0)
                     {
-                        PrintQuoting(cmd, 0, iep);
+                        PrintQuoting(printer, cmd, quotable, 0, iep);
                         ib = iep + 1;
                     }
                 }
@@ -399,7 +400,7 @@ namespace Grpc.Tools
                     ib = iarg + 1;
                 }
                 // A positional argument or switch value.
-                PrintQuoting(cmd, ib, ie - ib);
+                PrintQuoting(printer, cmd, quotable, ib, ie - ib);
             }
 
             base.LogToolCommand(printer.ToString());


### PR DESCRIPTION
release notes: C# 6 compatibility

This change makes C# code compile with a C# 6 compiler.

This is required for Unity's C# compiler (mono) to compile GRPC code.

A similar change was incorporated into protobuffer code in https://github.com/protocolbuffers/protobuf/commit/24638088c67116f9cf94548dec7b0e4d135762bb
and
https://github.com/protocolbuffers/protobuf/commit/db0a9e0b962084cdb7f51a31d9ed670f54189981