### PR TITLE
Fix counterintuitive test size behavior in grpc_cc_test

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -132,7 +132,7 @@ def grpc_proto_library(
         generate_mocks = generate_mocks,
     )
 
-def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data = [], uses_polling = True, language = "C++", size = "medium", timeout = "moderate", tags = [], exec_compatible_with = []):
+def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data = [], uses_polling = True, language = "C++", size = "medium", timeout = None, tags = [], exec_compatible_with = []):
     copts = []
     if language.upper() == "C":
         copts = if_not_windows(["-std=c99"])

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -223,7 +223,6 @@ grpc_cc_test(
         ":end2end_test_lib",
     ],
     size = "large",  # with poll-cv this takes long, see #17493
-    timeout = "long",
 )
 
 grpc_cc_test(


### PR DESCRIPTION
Currently, a `grpc_cc_test(size=large)` will still have a moderate timeout (instead of `long`) because the default timeout for given test size is overridden by the `timeout` arg value.
This behavior is very counterintuitive and leads to mistakes.

Example of a problem we encountered: https://github.com/grpc/grpc/pull/17809 was not effective (test size stayed the same) and only https://github.com/grpc/grpc/pull/17820 actually changed the timeout.