### PR TITLE
Remove unneeded header

### DIFF
--- a/src/core/lib/iomgr/exec_ctx.h
+++ b/src/core/lib/iomgr/exec_ctx.h
@@ -28,7 +28,6 @@
 
 #include "src/core/lib/gpr/tls.h"
 #include "src/core/lib/gprpp/fork.h"
-#include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/iomgr/closure.h"
 
 typedef int64_t grpc_millis;


### PR DESCRIPTION
This was in the path of the header complaint seen in #17831 so maybe this fixes that part? Not sure that this header inclusion was needed, though I should see it on all platforms.

@lidizheng @ericgribkoff @jtattermusch 
