### PR TITLE
Interop: Make declaration match definition

### DIFF
--- a/test/cpp/interop/interop_client.h
+++ b/test/cpp/interop/interop_client.h
@@ -89,8 +89,8 @@ class InteropClient {
                          const grpc::string& oauth_scope);
   // username is a string containing the user email
   bool DoPerRpcCreds(const grpc::string& json_key);
-  // username is the GCE default service account email
-  bool DoGoogleDefaultCredentials(const grpc::string& username);
+  // default_service_account is the GCE default service account email
+  bool DoGoogleDefaultCredentials(const grpc::string& default_service_account);
 
  private:
   class ServiceStub {


### PR DESCRIPTION
The declaration called it "username" but the definition called it "default_service_account". The latter makes more sense since that's what is really being used here.

This was caught by a linter.
