### PR TITLE
Fix broken mac to prod interop

### DIFF
--- a/tools/internal_ci/macos/grpc_interop_toprod.sh
+++ b/tools/internal_ci/macos/grpc_interop_toprod.sh
@@ -30,7 +30,8 @@ export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$(pwd)/etc/roots.pem"
 # building all languages in the same working copy can also lead to conflicts
 # due to different compilation flags
 tools/run_tests/run_interop_tests.py -l c++ \
-    --cloud_to_prod --cloud_to_prod_auth --on_gce=false \
+    --cloud_to_prod --cloud_to_prod_auth \
+    --google_default_creds_use_key_file=true \
     --prod_servers default gateway_v4 \
     --service_account_key_file="${KOKORO_GFILE_DIR}/GrpcTesting-726eb1347f15.json" \
     --skip_compute_engine_creds --internal_ci -t -j 4 || FAILED="true"

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -723,7 +723,10 @@ def compute_engine_creds_required(language, test_case):
     return False
 
 
-def auth_options(language, test_case, on_gce, service_account_key_file=None):
+def auth_options(language,
+                 test_case,
+                 google_default_creds_use_key_file,
+                 service_account_key_file=None):
     """Returns (cmdline, env) tuple with cloud_to_prod_auth test options."""
 
     language = str(language)
@@ -757,7 +760,7 @@ def auth_options(language, test_case, on_gce, service_account_key_file=None):
         cmdargs += [oauth_scope_arg, default_account_arg]
 
     if test_case == _GOOGLE_DEFAULT_CREDS_TEST_CASE:
-        if not on_gce:
+        if google_default_creds_use_key_file:
             env['GOOGLE_APPLICATION_CREDENTIALS'] = service_account_key_file
         cmdargs += [default_account_arg]
 
@@ -778,7 +781,7 @@ def cloud_to_prod_jobspec(language,
                           test_case,
                           server_host_nickname,
                           server_host,
-                          on_gce,
+                          google_default_creds_use_key_file,
                           docker_image=None,
                           auth=False,
                           manual_cmd_log=None,
@@ -804,7 +807,8 @@ def cloud_to_prod_jobspec(language,
     cmdargs = cmdargs + transport_security_options
     environ = dict(language.cloud_to_prod_env(), **language.global_env())
     if auth:
-        auth_cmdargs, auth_env = auth_options(language, test_case, on_gce,
+        auth_cmdargs, auth_env = auth_options(language, test_case,
+                                              google_default_creds_use_key_file,
                                               service_account_key_file)
         cmdargs += auth_cmdargs
         environ.update(auth_env)
@@ -1083,11 +1087,13 @@ argp.add_argument(
     const=True,
     help='Run cloud_to_prod_auth tests.')
 argp.add_argument(
-    '--on_gce',
-    default=True,
+    '--google_default_creds_use_key_file',
+    default=False,
     action='store_const',
     const=True,
-    help='Whether or not this test script is running on GCE.')
+    help=('Whether or not we should use a key file for the '
+          'google_default_credentials test case, e.g. by '
+          'setting env var GOOGLE_APPLICATION_CREDENTIALS.'))
 argp.add_argument(
     '--prod_servers',
     choices=prod_servers.keys(),
@@ -1343,7 +1349,8 @@ try:
                                 test_case,
                                 server_host_nickname,
                                 prod_servers[server_host_nickname],
-                                on_gce=args.on_gce,
+                                google_default_creds_use_key_file=args.
+                                google_default_creds_use_key_file,
                                 docker_image=docker_images.get(str(language)),
                                 manual_cmd_log=client_manual_cmd_log,
                                 service_account_key_file=args.
@@ -1358,7 +1365,8 @@ try:
                                     test_case,
                                     server_host_nickname,
                                     prod_servers[server_host_nickname],
-                                    on_gce=args.on_gce,
+                                    google_default_creds_use_key_file=args.
+                                    google_default_creds_use_key_file,
                                     docker_image=docker_images.get(
                                         str(language)),
                                     manual_cmd_log=client_manual_cmd_log,
@@ -1375,7 +1383,8 @@ try:
                         test_case,
                         server_host_nickname,
                         prod_servers[server_host_nickname],
-                        on_gce=args.on_gce,
+                        google_default_creds_use_key_file=args.
+                        google_default_creds_use_key_file,
                         docker_image=docker_images.get(str(http2Interop)),
                         manual_cmd_log=client_manual_cmd_log,
                         service_account_key_file=args.service_account_key_file,
@@ -1402,7 +1411,8 @@ try:
                                 test_case,
                                 server_host_nickname,
                                 prod_servers[server_host_nickname],
-                                on_gce=args.on_gce,
+                                google_default_creds_use_key_file=args.
+                                google_default_creds_use_key_file,
                                 docker_image=docker_images.get(str(language)),
                                 auth=True,
                                 manual_cmd_log=client_manual_cmd_log,


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/17853

What I originally intended with the `on_gce` arg to `run_interop_tests.py` (added in #17213 ), was to default it to "true" and then set "false" on mac. However, I guess we can't store false to a boolean argparse para (i.e. the only way to set "false" is to default it false and not set anything). So this PR replaces `on_gce` with `google_default_creds_use_key_file`, which, semantically makes sense to default "false" and is also more specific.