### PR TITLE
Allow trust anchor in gRPC ssl transport security

### DIFF
--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -651,6 +651,8 @@ static tsi_result ssl_ctx_load_verification_certs(SSL_CTX* context,
                                                   STACK_OF(X509_NAME) *
                                                       *root_name) {
   X509_STORE* cert_store = SSL_CTX_get_cert_store(context);
+  X509_STORE_set_flags(cert_store,
+                       X509_V_FLAG_PARTIAL_CHAIN | X509_V_FLAG_TRUSTED_FIRST);
   return x509_store_load_certs(cert_store, pem_roots, pem_roots_size,
                                root_name);
 }


### PR DESCRIPTION
Allow both local trust anchors and prefer local trust settings in gRPC SSL transport security. This aligns with modern OpenSSL setting and also addresses the inconsistent behavior between grpc core and grpc golang.