### PR TITLE
Fix typo that's breaking mac to prod interop

### DIFF
--- a/tools/internal_ci/macos/grpc_interop_toprod.sh
+++ b/tools/internal_ci/macos/grpc_interop_toprod.sh
@@ -31,7 +31,7 @@ export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$(pwd)/etc/roots.pem"
 # due to different compilation flags
 tools/run_tests/run_interop_tests.py -l c++ \
     --cloud_to_prod --cloud_to_prod_auth \
-    --google_default_creds_use_key_file=true \
+    --google_default_creds_use_key_file \
     --prod_servers default gateway_v4 \
     --service_account_key_file="${KOKORO_GFILE_DIR}/GrpcTesting-726eb1347f15.json" \
     --skip_compute_engine_creds --internal_ci -t -j 4 || FAILED="true"


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/17853, which is actually still broken

tested on a mac:

```
tools/run_tests/run_interop_tests.py -l c++ \
   --cloud_to_prod_auth    \
   --prod_servers default gateway_v4 \
    --service_account_key_file=<key file path>  \
     --skip_compute_engine_creds \
  --google_default_creds_use_key_file
```