### PR TITLE
Decrease verbosity of ALTS platform check to avoid a spam log message

### DIFF
--- a/src/core/lib/security/credentials/alts/check_gcp_environment_no_op.cc
+++ b/src/core/lib/security/credentials/alts/check_gcp_environment_no_op.cc
@@ -25,8 +25,8 @@
 #include <grpc/support/log.h>
 
 bool grpc_alts_is_running_on_gcp() {
-  gpr_log(GPR_ERROR,
-          "Platforms other than Linux and Windows are not supported");
+  gpr_log(GPR_INFO,
+          "ALTS: Platforms other than Linux and Windows are not supported");
   return false;
 }
 


### PR DESCRIPTION
Currently, when using "google default credentials" from e.g. a mac laptop (a supported use case), we get a log message, "only linux and windows are supported", during ALTS creds creation, even though RPC's still succeed. In this case, the log message is a red herring, because we actually expect for ALTS creds creation to fail and for the channel to be stuck with SSL anyways. The behavior is WAI, but the log message is spam.