### PR TITLE
Add LB swapper

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
@@ -272,7 +272,7 @@ class XdsLb : public LoadBalancingPolicy {
   // Methods for dealing with the child policy.
   void CreateOrUpdateChildPolicyLocked();
   grpc_channel_args* CreateChildPolicyArgsLocked();
-  void CreateChildPolicyLocked(const char* name, Args args);
+  static void AfterChildPolicySwapLocked(void* arg);
   bool PickFromChildPolicyLocked(bool force_async, PendingPick* pp,
                                  grpc_error** error);
   void UpdateConnectivityStateFromChildPolicyLocked(
@@ -342,6 +342,7 @@ class XdsLb : public LoadBalancingPolicy {
 
   // The policy to use for the backends.
   OrphanablePtr<LoadBalancingPolicy> child_policy_;
+  OrphanablePtr<LoadBalancingPolicy::Swapper> child_policy_swapper_;
   UniquePtr<char> child_policy_json_string_;
   grpc_connectivity_state child_connectivity_state_;
   grpc_closure on_child_connectivity_changed_;
@@ -1486,52 +1487,6 @@ bool XdsLb::PickFromChildPolicyLocked(bool force_async, PendingPick* pp,
   return pick_done;
 }
 
-void XdsLb::CreateChildPolicyLocked(const char* name, Args args) {
-  GPR_ASSERT(child_policy_ == nullptr);
-  child_policy_ = LoadBalancingPolicyRegistry::CreateLoadBalancingPolicy(
-      name, std::move(args));
-  if (GPR_UNLIKELY(child_policy_ == nullptr)) {
-    gpr_log(GPR_ERROR, "[xdslb %p] Failure creating a child policy", this);
-    return;
-  }
-  // TODO(roth): We currently track this ref manually.  Once the new
-  // ClosureRef API is done, pass the RefCountedPtr<> along with the closure.
-  auto self = Ref(DEBUG_LOCATION, "on_child_reresolution_requested");
-  self.release();
-  child_policy_->SetReresolutionClosureLocked(&on_child_request_reresolution_);
-  grpc_error* child_state_error = nullptr;
-  child_connectivity_state_ =
-      child_policy_->CheckConnectivityLocked(&child_state_error);
-  // Connectivity state is a function of the child policy updated/created.
-  UpdateConnectivityStateFromChildPolicyLocked(child_state_error);
-  // Add the xDS's interested_parties pollset_set to that of the newly created
-  // child policy. This will make the child policy progress upon activity on
-  // xDS LB, which in turn is tied to the application's call.
-  grpc_pollset_set_add_pollset_set(child_policy_->interested_parties(),
-                                   interested_parties());
-  // Subscribe to changes to the connectivity of the new child policy.
-  // TODO(roth): We currently track this ref manually.  Once the new
-  // ClosureRef API is done, pass the RefCountedPtr<> along with the closure.
-  self = Ref(DEBUG_LOCATION, "on_child_connectivity_changed");
-  self.release();
-  child_policy_->NotifyOnStateChangeLocked(&child_connectivity_state_,
-                                           &on_child_connectivity_changed_);
-  child_policy_->ExitIdleLocked();
-  // Send pending picks to child policy.
-  PendingPick* pp;
-  while ((pp = pending_picks_)) {
-    pending_picks_ = pp->next;
-    if (grpc_lb_xds_trace.enabled()) {
-      gpr_log(
-          GPR_INFO,
-          "[xdslb %p] Pending pick about to (async) PICK from child policy %p",
-          this, child_policy_.get());
-    }
-    grpc_error* error = GRPC_ERROR_NONE;
-    PickFromChildPolicyLocked(true /* force_async */, pp, &error);
-  }
-}
-
 grpc_channel_args* XdsLb::CreateChildPolicyArgsLocked() {
   bool is_backend_from_grpclb_load_balancer = false;
   // This should never be invoked if we do not have serverlist_, as fallback
@@ -1577,28 +1532,80 @@ void XdsLb::CreateOrUpdateChildPolicyLocked() {
     }
     child_policy_name = "round_robin";
   }
-  // TODO(juanlishen): Switch policy according to child_policy_config->key.
-  if (child_policy_ != nullptr) {
+  // Check to see if we're already using the right child policy.
+  const bool child_policy_name_changed =
+      child_policy_ == nullptr ||
+      strcmp(child_policy_->name(), child_policy_name) != 0;
+  if (child_policy_ != nullptr && !child_policy_name_changed) {
+    // Continue using the same child policy.  Update with new addresses.
     if (grpc_lb_xds_trace.enabled()) {
       gpr_log(GPR_INFO, "[xdslb %p] Updating the child policy %p", this,
               child_policy_.get());
     }
     child_policy_->UpdateLocked(*args, child_policy_config);
   } else {
+    // Create a new child policy. If there is an existing child policy, replace
+    // it when the new one becomes ready.
     LoadBalancingPolicy::Args lb_policy_args;
     lb_policy_args.combiner = combiner();
     lb_policy_args.client_channel_factory = client_channel_factory();
     lb_policy_args.subchannel_pool = subchannel_pool()->Ref();
     lb_policy_args.args = args;
     lb_policy_args.lb_config = child_policy_config;
-    CreateChildPolicyLocked(child_policy_name, std::move(lb_policy_args));
-    if (grpc_lb_xds_trace.enabled()) {
-      gpr_log(GPR_INFO, "[xdslb %p] Created a new child policy %p", this,
-              child_policy_.get());
+    LoadBalancingPolicy* new_child_policy = nullptr;
+    LoadBalancingPolicy::Swapper::Args lb_swapper_args;
+    lb_swapper_args.old_policy = &child_policy_;
+    lb_swapper_args.new_name = child_policy_name;
+    lb_swapper_args.new_args = std::move(lb_policy_args);
+    lb_swapper_args.new_policy = &new_child_policy;
+    lb_swapper_args.interested_parties = interested_parties();
+    lb_swapper_args.exit_idle = true;
+    lb_swapper_args.post_swap_callback = AfterChildPolicySwapLocked;
+    lb_swapper_args.post_swap_arg = this;
+    lb_swapper_args.tracer = &grpc_lb_xds_trace;
+    child_policy_swapper_ =
+        LoadBalancingPolicy::Swapper::CreateLocked(std::move(lb_swapper_args));
+    if (new_child_policy != nullptr) {
+      // TODO(roth): We currently track this ref manually.  Once the new
+      // ClosureRef API is done, pass the RefCountedPtr<> along with the
+      // closure.
+      auto self = Ref(DEBUG_LOCATION, "on_child_reresolution_requested");
+      self.release();
+      new_child_policy->SetReresolutionClosureLocked(
+          &on_child_request_reresolution_);
     }
   }
   grpc_channel_args_destroy(args);
   grpc_json_destroy(child_policy_json);
+}
+
+void XdsLb::AfterChildPolicySwapLocked(void* arg) {
+  XdsLb* self = static_cast<XdsLb*>(arg);
+  // Update connectivity state according to the new child policy.
+  grpc_error* child_state_error = GRPC_ERROR_NONE;
+  self->child_connectivity_state_ =
+      self->child_policy_->CheckConnectivityLocked(&child_state_error);
+  self->UpdateConnectivityStateFromChildPolicyLocked(child_state_error);
+  // Subscribe to changes to the connectivity of the new child policy.
+  // TODO(roth): We currently track this ref manually.  Once the new
+  // ClosureRef API is done, pass the RefCountedPtr<> along with the closure.
+  self->Ref(DEBUG_LOCATION, "on_child_connectivity_changed").release();
+  self->child_policy_->NotifyOnStateChangeLocked(
+      &self->child_connectivity_state_, &self->on_child_connectivity_changed_);
+  // Send pending picks to child policy in case it's the first one.
+  PendingPick* pp;
+  while ((pp = self->pending_picks_)) {
+    self->pending_picks_ = pp->next;
+    if (grpc_lb_xds_trace.enabled()) {
+      gpr_log(
+          GPR_INFO,
+          "[xdslb %p] Pending pick about to (async) PICK from child policy %p",
+          self, self->child_policy_.get());
+    }
+    grpc_error* error = GRPC_ERROR_NONE;
+    self->PickFromChildPolicyLocked(true /* force_async */, pp, &error);
+  }
+  self->child_policy_swapper_.reset();
 }
 
 void XdsLb::OnChildPolicyRequestReresolutionLocked(void* arg,

--- a/src/core/ext/filters/client_channel/request_routing.cc
+++ b/src/core/ext/filters/client_channel/request_routing.cc
@@ -899,6 +899,12 @@ void RequestRouter::ShutdownLocked(grpc_error* error) {
                                        interested_parties_);
       lb_policy_.reset();
     }
+    if (lb_swapper_ != nullptr) {
+      GPR_ASSERT(lb_swapper_->new_policy() != nullptr);
+      grpc_pollset_set_del_pollset_set(
+          lb_swapper_->new_policy()->interested_parties(), interested_parties_);
+      lb_swapper_.reset();
+    }
   }
   GRPC_ERROR_UNREF(error);
 }

--- a/src/core/ext/filters/client_channel/request_routing.h
+++ b/src/core/ext/filters/client_channel/request_routing.h
@@ -134,10 +134,7 @@ class RequestRouter {
 
   void StartResolvingLocked();
   void OnResolverShutdownLocked(grpc_error* error);
-  void CreateNewLbPolicyLocked(const char* lb_policy_name, grpc_json* lb_config,
-                               grpc_connectivity_state* connectivity_state,
-                               grpc_error** connectivity_error,
-                               TraceStringVector* trace_strings);
+  static void AfterLbSwapLocked(void* arg);
   void MaybeAddTraceMessagesForAddressChangesLocked(
       TraceStringVector* trace_strings);
   void ConcatenateAndAddChannelTraceLocked(
@@ -168,6 +165,7 @@ class RequestRouter {
 
   // LB policy and associated state.
   OrphanablePtr<LoadBalancingPolicy> lb_policy_;
+  OrphanablePtr<LoadBalancingPolicy::Swapper> lb_swapper_;
   bool exit_idle_when_lb_policy_arrives_ = false;
 
   // Subchannel pool to pass to LB policy.


### PR DESCRIPTION
I tried to pull the common part of swapping LB in request router and xds policy out to the new LB swapper class. But the work after the policy is swapped is quite different in those two places. So there is a callback after the swap to allow that difference. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/17880)
<!-- Reviewable:end -->
