### PR TITLE
Unref watcher after releasing lock

### DIFF
--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -405,18 +405,22 @@ class Subchannel::ConnectedSubchannelStateWatcher
   static void OnHealthChanged(void* arg, grpc_error* error) {
     auto* self = static_cast<ConnectedSubchannelStateWatcher*>(arg);
     Subchannel* c = self->subchannel_;
-    MutexLock lock(&c->mu_);
-    if (self->health_state_ == GRPC_CHANNEL_SHUTDOWN) {
-      self->Unref();
-      return;
+    {
+      MutexLock lock(&c->mu_);
+      if (self->health_state_ != GRPC_CHANNEL_SHUTDOWN) {
+        if (self->last_connectivity_state_ == GRPC_CHANNEL_READY) {
+          grpc_connectivity_state_set(&c->state_and_health_tracker_,
+                                      self->health_state_,
+                                      GRPC_ERROR_REF(error), "health_changed");
+        }
+        self->health_check_client_->NotifyOnHealthChange(
+            &self->health_state_, &self->on_health_changed_);
+        self = nullptr;  // So we don't unref below.
+      }
     }
-    if (self->last_connectivity_state_ == GRPC_CHANNEL_READY) {
-      grpc_connectivity_state_set(&c->state_and_health_tracker_,
-                                  self->health_state_, GRPC_ERROR_REF(error),
-                                  "health_changed");
-    }
-    self->health_check_client_->NotifyOnHealthChange(&self->health_state_,
-                                                     &self->on_health_changed_);
+    // Don't unref until we've released the lock, because this might
+    // cause the subchannel (which contains the lock) to be destroyed.
+    if (self != nullptr) self->Unref();
   }
 
   Subchannel* subchannel_;


### PR DESCRIPTION
A followup of https://github.com/grpc/grpc/pull/17803.

This is what the `OnConnectivityChanged()` does. `OnHealthChanged()` should do the same thing, for the same reason.

