### PR TITLE
Increase VM timeout for grpc_ios_binary_size job

### DIFF
--- a/tools/internal_ci/macos/pull_request/grpc_ios_binary_size.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_ios_binary_size.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_ios_binary_size.sh"
-timeout_mins: 60
+timeout_mins: 90
 before_action {
   fetch_keystore {
     keystore_resource {


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/17561.

It would be good to reduce the overall runtime though, the job is extremely slow for what it's doing.