### PR TITLE
Disable c-ares on iOS

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -189,6 +189,8 @@
 #define GPR_PLATFORM_STRING "ios"
 #define GPR_CPU_IPHONE 1
 #define GPR_PTHREAD_TLS 1
+/* the c-ares resolver isnt safe to enable on iOS */
+#define GRPC_ARES 0
 #else /* TARGET_OS_IPHONE */
 #define GPR_PLATFORM_STRING "osx"
 #ifdef __MAC_OS_X_VERSION_MIN_REQUIRED


### PR DESCRIPTION
On iOS, we've ran into problems with c-ares finding/contacting DNS servers - a possible solution might be https://github.com/c-ares/c-ares/commit/affc63cba875df11daade6f6767cb06e013ac6c3, but to avoid risk, this PR just forces c-ares to remain disabled on iOS.