### PR TITLE
Install iptables in docker containers

### DIFF
--- a/templates/tools/dockerfile/test/cxx_jessie_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_jessie_x64/Dockerfile.template
@@ -25,7 +25,7 @@
   <%include file="../../libuv_install.include"/>
 
   # Install gcc-4.8 and other relevant items
-  RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib && apt-get clean
+  RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib iptables && apt-get clean
 
   # Define the default command.
   CMD ["bash"]

--- a/tools/dockerfile/test/cxx_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_jessie_x64/Dockerfile
@@ -87,7 +87,7 @@ RUN mkdir /var/local/jenkins
 RUN cd /tmp     && wget http://dist.libuv.org/dist/v1.9.1/libuv-v1.9.1.tar.gz     && tar -xf libuv-v1.9.1.tar.gz     && cd libuv-v1.9.1     && sh autogen.sh && ./configure --prefix=/usr && make && make install
 
 # Install gcc-4.8 and other relevant items
-RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib && apt-get clean
+RUN apt-get update && apt-get -y install gcc-4.8 gcc-4.8-multilib g++-4.8 g++-4.8-multilib iptables && apt-get clean
 
 # Define the default command.
 CMD ["bash"]


### PR DESCRIPTION
 Update dockerfiles to install install iptables. Iptables is required for some network state transition tests that I'm working on.