### PR TITLE
python: do not store raised exception in _Context.abort()

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_abort_test.py
+++ b/src/python/grpcio_tests/tests/unit/_abort_test.py
@@ -15,6 +15,7 @@
 
 import unittest
 import collections
+import gc
 import logging
 import weakref
 
@@ -124,6 +125,8 @@ class AbortTest(unittest.TestCase):
         rpc_error = exception_context.exception
 
         do_not_leak_me = None
+        # Force garbage collection
+        gc.collect()
         self.assertIsNone(weak_ref())
 
     def test_abort_with_status(self):

--- a/src/python/grpcio_tests/tests/unit/_abort_test.py
+++ b/src/python/grpcio_tests/tests/unit/_abort_test.py
@@ -16,6 +16,7 @@
 import unittest
 import collections
 import logging
+import weakref
 
 import grpc
 
@@ -39,7 +40,15 @@ class _Status(
     pass
 
 
+class _Object(object):
+    pass
+
+
+do_not_leak_me = _Object()
+
+
 def abort_unary_unary(request, servicer_context):
+    this_should_not_be_leaked = do_not_leak_me
     servicer_context.abort(
         grpc.StatusCode.INTERNAL,
         _ABORT_DETAILS,
@@ -100,6 +109,22 @@ class AbortTest(unittest.TestCase):
 
         self.assertEqual(rpc_error.code(), grpc.StatusCode.INTERNAL)
         self.assertEqual(rpc_error.details(), _ABORT_DETAILS)
+
+    # This test ensures that abort() does not store the raised exception, which
+    # on Python 3 (via the `__traceback__` attribute) holds a reference to
+    # all local vars. Storing the raised exception can prevent GC and stop the
+    # grpc_call from being unref'ed, even after server shutdown.
+    def test_abort_does_not_leak_local_vars(self):
+        global do_not_leak_me  # pylint: disable=global-statement
+        weak_ref = weakref.ref(do_not_leak_me)
+
+        # Servicer will abort() after creating a local ref to do_not_leak_me.
+        with self.assertRaises(grpc.RpcError) as exception_context:
+            self._channel.unary_unary(_ABORT)(_REQUEST)
+        rpc_error = exception_context.exception
+
+        do_not_leak_me = None
+        self.assertIsNone(weak_ref())
 
     def test_abort_with_status(self):
         with self.assertRaises(grpc.RpcError) as exception_context:


### PR DESCRIPTION
Python 3 exceptions include a `__traceback__` attribute that includes
refs to all local variables. Saving the exception results in leaking
references to the, among other things, the Cython grpc_call wrapper and
prevents garbage collection and release of core resources, even after
the server is shutdown.

See
https://www.python.org/dev/peps/pep-3134/#open-issue-garbage-collection