### PR TITLE
interop_matrix: add gcloud debug info

### DIFF
--- a/tools/internal_ci/linux/grpc_interop_matrix.sh
+++ b/tools/internal_ci/linux/grpc_interop_matrix.sh
@@ -31,6 +31,7 @@ tools/interop_matrix/run_interop_matrix_tests.py $RUN_TESTS_FLAGS || FAILED="tru
 df -h
 
 # TODO(jtattermusch): Diagnose problems with gcloud auth. Remove once not needed.
+gcloud info
 gcloud info --show-log
 
 if [ "$FAILED" != "" ]

--- a/tools/internal_ci/linux/grpc_interop_matrix.sh
+++ b/tools/internal_ci/linux/grpc_interop_matrix.sh
@@ -30,6 +30,9 @@ tools/interop_matrix/run_interop_matrix_tests.py $RUN_TESTS_FLAGS || FAILED="tru
 # TODO(jtattermusch): Diagnose out of disk space problems. Remove once not needed.
 df -h
 
+# TODO(jtattermusch): Diagnose problems with gcloud auth. Remove once not needed.
+gcloud info --show-log
+
 if [ "$FAILED" != "" ]
 then
   exit 1

--- a/tools/interop_matrix/run_interop_matrix_tests.py
+++ b/tools/interop_matrix/run_interop_matrix_tests.py
@@ -217,7 +217,7 @@ def _pull_images_for_lang(lang, images):
         # First time we use an image with "docker run", it takes time to unpack
         # the image and later this delay would fail our test cases.
         cmdline = [
-            'time gcloud docker --verbosity=debug -- pull %s && time docker run --rm=true %s /bin/true'
+            'time gcloud docker --log-http --verbosity=debug -- pull %s && time docker run --rm=true %s /bin/true'
             % (image, image)
         ]
         spec = jobset.JobSpec(

--- a/tools/interop_matrix/run_interop_matrix_tests.py
+++ b/tools/interop_matrix/run_interop_matrix_tests.py
@@ -217,7 +217,7 @@ def _pull_images_for_lang(lang, images):
         # First time we use an image with "docker run", it takes time to unpack
         # the image and later this delay would fail our test cases.
         cmdline = [
-            'time gcloud docker -- pull %s && time docker run --rm=true %s /bin/true'
+            'time gcloud docker --verbosity=debug -- pull %s && time docker run --rm=true %s /bin/true'
             % (image, image)
         ]
         spec = jobset.JobSpec(


### PR DESCRIPTION
To debug a `gcloud docker pull` authentication flake.