### PR TITLE
Hold on to the lock while calling grpc_pollset_shutdown() on the backup poller

### DIFF
--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -177,13 +177,13 @@ static void run_poller(void* bp, grpc_error* error_ignored) {
     if (grpc_tcp_trace.enabled()) {
       gpr_log(GPR_INFO, "BACKUP_POLLER:%p done cas_ok=%d", p, cas_ok);
     }
-    gpr_mu_unlock(p->pollset_mu);
     if (grpc_tcp_trace.enabled()) {
       gpr_log(GPR_INFO, "BACKUP_POLLER:%p shutdown", p);
     }
     grpc_pollset_shutdown(BACKUP_POLLER_POLLSET(p),
                           GRPC_CLOSURE_INIT(&p->run_poller, done_poller, p,
                                             grpc_schedule_on_exec_ctx));
+    gpr_mu_unlock(p->pollset_mu);
   } else {
     if (grpc_tcp_trace.enabled()) {
       gpr_log(GPR_INFO, "BACKUP_POLLER:%p reschedule", p);


### PR DESCRIPTION
Caught this while auditing the code. The document says we should have the lock
when calling `grpc_pollset_shutdown().`