### PR TITLE
Unskip google default creds for Go and Java in cloud to prod tests

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -229,7 +229,7 @@ class JavaLanguage:
         return {}
 
     def unimplemented_test_cases(self):
-        return _SKIP_GOOGLE_DEFAULT_CREDS
+        return []
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION
@@ -254,7 +254,7 @@ class JavaOkHttpClient:
         return {}
 
     def unimplemented_test_cases(self):
-        return _SKIP_DATA_FRAME_PADDING + _SKIP_SPECIAL_STATUS_MESSAGE + _SKIP_GOOGLE_DEFAULT_CREDS
+        return _SKIP_DATA_FRAME_PADDING + _SKIP_SPECIAL_STATUS_MESSAGE
 
     def __str__(self):
         return 'javaokhttp'
@@ -285,7 +285,7 @@ class GoLanguage:
         return {}
 
     def unimplemented_test_cases(self):
-        return _SKIP_COMPRESSION + _SKIP_GOOGLE_DEFAULT_CREDS
+        return _SKIP_COMPRESSION
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION


### PR DESCRIPTION
Followup to https://github.com/grpc/grpc-java/pull/5295 and https://github.com/grpc/grpc-go/pull/2600