### PR TITLE
Dummy Shutdown should still unref the error

### DIFF
--- a/src/core/lib/iomgr/buffer_list.h
+++ b/src/core/lib/iomgr/buffer_list.h
@@ -148,7 +148,9 @@ class TracedBuffer {
  public:
   /* Dummy shutdown function */
   static void Shutdown(grpc_core::TracedBuffer** head, void* remaining,
-                       grpc_error* shutdown_err) {}
+                       grpc_error* shutdown_err) {
+    GRPC_ERROR_UNREF(shutdown_err);
+  }
 };
 #endif /* GRPC_LINUX_ERRQUEUE */
 


### PR DESCRIPTION
Dummy Shutdown should still unref the error. 

This is probably the reason #17896 is causing ASAN issues. Systems not supporting ERRQUEUE would end up running the dummy Shutdown version of TracedBuffer.