### PR TITLE
fix flake in test_abort_does_not_leak_local_vars

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_abort_test.py
+++ b/src/python/grpcio_tests/tests/unit/_abort_test.py
@@ -120,13 +120,13 @@ class AbortTest(unittest.TestCase):
         weak_ref = weakref.ref(do_not_leak_me)
 
         # Servicer will abort() after creating a local ref to do_not_leak_me.
-        with self.assertRaises(grpc.RpcError) as exception_context:
+        with self.assertRaises(grpc.RpcError):
             self._channel.unary_unary(_ABORT)(_REQUEST)
-        rpc_error = exception_context.exception
 
+        # Server may still have a stack frame reference to the exception even
+        # after client sees error, so ensure server has shutdown.
+        self._server.stop(None)
         do_not_leak_me = None
-        # Force garbage collection
-        gc.collect()
         self.assertIsNone(weak_ref())
 
     def test_abort_with_status(self):


### PR DESCRIPTION
This ~~is~~ was intended to fix https://github.com/grpc/grpc/issues/17927, although since that's not using python3 afaict there is likely another issue lurking...regardless, this change is still worthwhile.

CPython's own weakref tests (https://github.com/python/cpython/blob/master/Lib/test/test_weakref.py) do not manually invoke `gc.collect()` for non-reference cycles, so it should not be necessary here either. The server thread may still be in the code that caught the raised exception, which on Python3 includes a reference to the global variable, so this makes sure the server is shutdown before checking that the referent has been collected.