### PR TITLE
Second attemp to fix use-after-free in health check client

### DIFF
--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -407,7 +407,8 @@ class Subchannel::ConnectedSubchannelStateWatcher
     Subchannel* c = self->subchannel_;
     {
       MutexLock lock(&c->mu_);
-      if (self->health_state_ != GRPC_CHANNEL_SHUTDOWN) {
+      if (self->health_state_ != GRPC_CHANNEL_SHUTDOWN &&
+          self->health_check_client_ != nullptr) {
         if (self->last_connectivity_state_ == GRPC_CHANNEL_READY) {
           grpc_connectivity_state_set(&c->state_and_health_tracker_,
                                       self->health_state_,


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/17803 doesn't work. Then here is my new guess: this might be still a race around SHUTDOWN state checking, but in a different code path.

1. 
https://github.com/grpc/grpc/blob/e06b73cab31bfda2847bd023a7fa0a0a7f2924ce/src/core/ext/filters/client_channel/health/health_check_client.cc#L113

The health state change closure is scheduled but not run yet. The member variable  on_health_changed_ is reset to null.

2. 
https://github.com/grpc/grpc/blob/e06b73cab31bfda2847bd023a7fa0a0a7f2924ce/src/core/ext/filters/client_channel/health/health_check_client.cc#L126
 
For some reason, health_check_client_ is reset to null. Because on_health_changed_ is null now, we don't set the output state to SHUTDOWN.

3. 
https://github.com/grpc/grpc/blob/e06b73cab31bfda2847bd023a7fa0a0a7f2924ce/src/core/ext/filters/client_channel/subchannel.cc#L405

When the health state change closure is run, the state is not SHUTDOWN, so race happens and an invalid health_check_client_ is accessed. 


I think we don't want to set the output state to SHUTDOWN unconditionally, because that breaks the pattern to set and reset the closure and output, and it may cause some other use-after-free bug. Maybe we should check the availability of health_check_client_ directly instead of checking the output health state. 