### PR TITLE
Add ASAN-only leak detection for gpr_mu/cv and fix the newly caught leaks

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -534,6 +534,14 @@ typedef unsigned __int64 uint64_t;
 #endif
 #endif /* GPR_HAS_ATTRIBUTE */
 
+#ifndef GPR_HAS_FEATURE
+#ifdef __has_feature
+#define GPR_HAS_FEATURE(a) __has_feature(a)
+#else
+#define GPR_HAS_FEATURE(a) 0
+#endif
+#endif /* GPR_HAS_FEATURE */
+
 #ifndef GPR_ATTRIBUTE_NOINLINE
 #if GPR_HAS_ATTRIBUTE(noinline) || (defined(__GNUC__) && !defined(__clang__))
 #define GPR_ATTRIBUTE_NOINLINE __attribute__((noinline))
@@ -569,10 +577,15 @@ typedef unsigned __int64 uint64_t;
 /* GRPC_TSAN_ENABLED will be defined, when compiled with thread sanitizer. */
 #if defined(__SANITIZE_THREAD__)
 #define GRPC_TSAN_ENABLED
-#elif defined(__has_feature)
-#if __has_feature(thread_sanitizer)
+#elif GPR_HAS_FEATURE(thread_sanitizer)
 #define GRPC_TSAN_ENABLED
 #endif
+
+/* GRPC_ASAN_ENABLED will be defined, when compiled with address sanitizer. */
+#if defined(__SANITIZE_ADDRESS__)
+#define GRPC_ASAN_ENABLED
+#elif GPR_HAS_FEATURE(address_sanitizer)
+#define GRPC_ASAN_ENABLED
 #endif
 
 /* GRPC_ALLOW_EXCEPTIONS should be 0 or 1 if exceptions are allowed or not */

--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -564,11 +564,9 @@ typedef unsigned __int64 uint64_t;
 #endif /* GPR_ATTRIBUTE_WEAK */
 
 #ifndef GPR_ATTRIBUTE_NO_TSAN /* (1) */
-#if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
+#if GPR_HAS_FEATURE(thread_sanitizer)
 #define GPR_ATTRIBUTE_NO_TSAN __attribute__((no_sanitize("thread")))
-#endif                        /* __has_feature(thread_sanitizer) */
-#endif                        /* defined(__has_feature) */
+#endif                        /* GPR_HAS_FEATURE */
 #ifndef GPR_ATTRIBUTE_NO_TSAN /* (2) */
 #define GPR_ATTRIBUTE_NO_TSAN
 #endif /* GPR_ATTRIBUTE_NO_TSAN (2) */

--- a/include/grpc/impl/codegen/sync_posix.h
+++ b/include/grpc/impl/codegen/sync_posix.h
@@ -26,20 +26,20 @@
 #include <pthread.h>
 
 #ifdef GRPC_ASAN_ENABLED
-/* The member |leak_checker| is used to check whether there is memory leak
- * that may be caused by upper layer logic which missing the |gpr_xx_destroy|
- * call to this object before freeing.
+/* The member |leak_checker| is used to check whether there is a memory leak
+ * caused by upper layer logic that's missing the |gpr_xx_destroy| call
+ * to the object before freeing it.
  * This issue was reported at https://github.com/grpc/grpc/issues/17563
  * and discussed at https://github.com/grpc/grpc/pull/17586
  */
 typedef struct {
   pthread_mutex_t mutex;
-  int *leak_checker;
+  int* leak_checker;
 } gpr_mu;
 
 typedef struct {
   pthread_cond_t cond_var;
-  int *leak_checker;
+  int* leak_checker;
 } gpr_cv;
 #else
 typedef pthread_mutex_t gpr_mu;

--- a/include/grpc/impl/codegen/sync_posix.h
+++ b/include/grpc/impl/codegen/sync_posix.h
@@ -25,8 +25,26 @@
 
 #include <pthread.h>
 
+#ifdef GRPC_ASAN_ENABLED
+/* The member |leak_checker| is used to check whether there is memory leak
+ * that may be caused by upper layer logic which missing the |gpr_xx_destroy|
+ * call to this object before freeing.
+ * This issue was reported at https://github.com/grpc/grpc/issues/17563
+ * and discussed at https://github.com/grpc/grpc/pull/17586
+ */
+typedef struct {
+  pthread_mutex_t mutex;
+  int *leak_checker;
+} gpr_mu;
+
+typedef struct {
+  pthread_cond_t cond_var;
+  int *leak_checker;
+} gpr_cv;
+#else
 typedef pthread_mutex_t gpr_mu;
 typedef pthread_cond_t gpr_cv;
+#endif
 typedef pthread_once_t gpr_once;
 
 #define GPR_ONCE_INIT PTHREAD_ONCE_INIT

--- a/src/core/ext/filters/max_age/max_age_filter.cc
+++ b/src/core/ext/filters/max_age/max_age_filter.cc
@@ -499,7 +499,10 @@ static grpc_error* init_channel_elem(grpc_channel_element* elem,
 }
 
 /* Destructor for channel_data. */
-static void destroy_channel_elem(grpc_channel_element* elem) {}
+static void destroy_channel_elem(grpc_channel_element* elem) {
+  channel_data* chand = static_cast<channel_data*>(elem->channel_data);
+  gpr_mu_destroy(&chand->max_age_timer_mu);
+}
 
 const grpc_channel_filter grpc_max_age_filter = {
     grpc_call_next_op,

--- a/src/core/ext/transport/inproc/inproc_transport.cc
+++ b/src/core/ext/transport/inproc/inproc_transport.cc
@@ -64,6 +64,10 @@ struct shared_mu {
     gpr_ref_init(&refs, 2);
   }
 
+  ~shared_mu() {
+    gpr_mu_destroy(&mu);
+  }
+
   gpr_mu mu;
   gpr_refcount refs;
 };

--- a/src/core/ext/transport/inproc/inproc_transport.cc
+++ b/src/core/ext/transport/inproc/inproc_transport.cc
@@ -64,9 +64,7 @@ struct shared_mu {
     gpr_ref_init(&refs, 2);
   }
 
-  ~shared_mu() {
-    gpr_mu_destroy(&mu);
-  }
+  ~shared_mu() { gpr_mu_destroy(&mu); }
 
   gpr_mu mu;
   gpr_refcount refs;
@@ -87,6 +85,7 @@ struct inproc_transport {
   ~inproc_transport() {
     grpc_connectivity_state_destroy(&connectivity);
     if (gpr_unref(&mu->refs)) {
+      mu->~shared_mu();
       gpr_free(mu);
     }
   }

--- a/src/core/lib/gpr/sync_posix.cc
+++ b/src/core/lib/gpr/sync_posix.cc
@@ -16,8 +16,9 @@
  *
  */
 
-#include <grpc/support/alloc.h>
 #include <grpc/support/port_platform.h>
+
+#include <grpc/support/alloc.h>
 
 #ifdef GPR_POSIX_SYNC
 

--- a/src/core/lib/gpr/sync_posix.cc
+++ b/src/core/lib/gpr/sync_posix.cc
@@ -17,6 +17,7 @@
  */
 
 #include <grpc/support/port_platform.h>
+#include <grpc/support/alloc.h>
 
 #ifdef GPR_POSIX_SYNC
 
@@ -72,27 +73,58 @@ gpr_atm gpr_counter_atm_add = 0;
 #endif
 
 void gpr_mu_init(gpr_mu* mu) {
+#ifdef GRPC_ASAN_ENABLED
+  GPR_ASSERT(pthread_mutex_init(&mu->mutex, nullptr) == 0);
+  mu->leak_checker = (int*)gpr_malloc(sizeof(*mu->leak_checker));
+  GPR_ASSERT(mu->leak_checker != nullptr);
+  /* Initial it with a magic number, make no sense, just use the memory.
+  * This only take effect when ASAN enabled, so,
+  * if memory allocation failed, let it crash.
+  */
+  *mu->leak_checker = 0x12F34D0;
+#else
   GPR_ASSERT(pthread_mutex_init(mu, nullptr) == 0);
+#endif
 }
 
-void gpr_mu_destroy(gpr_mu* mu) { GPR_ASSERT(pthread_mutex_destroy(mu) == 0); }
+void gpr_mu_destroy(gpr_mu* mu) {
+#ifdef GRPC_ASAN_ENABLED
+  GPR_ASSERT(pthread_mutex_destroy(&mu->mutex) == 0);
+  gpr_free(mu->leak_checker);
+#else
+  GPR_ASSERT(pthread_mutex_destroy(mu) == 0);
+#endif
+}
 
 void gpr_mu_lock(gpr_mu* mu) {
 #ifdef GPR_LOW_LEVEL_COUNTERS
   GPR_ATM_INC_COUNTER(gpr_mu_locks);
 #endif
   GPR_TIMER_SCOPE("gpr_mu_lock", 0);
+#ifdef GRPC_ASAN_ENABLED
+  GPR_ASSERT(pthread_mutex_lock(&mu->mutex) == 0);
+#else
   GPR_ASSERT(pthread_mutex_lock(mu) == 0);
+#endif
 }
 
 void gpr_mu_unlock(gpr_mu* mu) {
   GPR_TIMER_SCOPE("gpr_mu_unlock", 0);
+#ifdef GRPC_ASAN_ENABLED
+  GPR_ASSERT(pthread_mutex_unlock(&mu->mutex) == 0);
+#else
   GPR_ASSERT(pthread_mutex_unlock(mu) == 0);
+#endif
 }
 
 int gpr_mu_trylock(gpr_mu* mu) {
   GPR_TIMER_SCOPE("gpr_mu_trylock", 0);
-  int err = pthread_mutex_trylock(mu);
+  int err = 0;
+#ifdef GRPC_ASAN_ENABLED
+  err = pthread_mutex_trylock(&mu->mutex);
+#else
+  err = pthread_mutex_trylock(mu);
+#endif
   GPR_ASSERT(err == 0 || err == EBUSY);
   return err == 0;
 }
@@ -105,10 +137,29 @@ void gpr_cv_init(gpr_cv* cv) {
 #if GPR_LINUX
   GPR_ASSERT(pthread_condattr_setclock(&attr, CLOCK_MONOTONIC) == 0);
 #endif  // GPR_LINUX
+
+#ifdef GRPC_ASAN_ENABLED
+  GPR_ASSERT(pthread_cond_init(&cv->cond_var, &attr) == 0);
+  cv->leak_checker = (int*)gpr_malloc(sizeof(*cv->leak_checker));
+  GPR_ASSERT(cv->leak_checker != nullptr);
+  /* Initial it with a magic number, make no sense, just use the memory.
+  * This only take effect when ASAN enabled, so,
+  * if memory allocation failed, let it crash.
+  */
+  *cv->leak_checker = 0x12F34D0;
+#else
   GPR_ASSERT(pthread_cond_init(cv, &attr) == 0);
+#endif
 }
 
-void gpr_cv_destroy(gpr_cv* cv) { GPR_ASSERT(pthread_cond_destroy(cv) == 0); }
+void gpr_cv_destroy(gpr_cv* cv) {
+#ifdef GRPC_ASAN_ENABLED
+  GPR_ASSERT(pthread_cond_destroy(&cv->cond_var) == 0);
+  gpr_free(cv->leak_checker);
+#else
+  GPR_ASSERT(pthread_cond_destroy(cv) == 0);
+#endif
+}
 
 // For debug of the timer manager crash only.
 // TODO (mxyan): remove after bug is fixed.
@@ -169,7 +220,11 @@ int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu, gpr_timespec abs_deadline) {
 #endif
   if (gpr_time_cmp(abs_deadline, gpr_inf_future(abs_deadline.clock_type)) ==
       0) {
+#ifdef GRPC_ASAN_ENABLED
+    err = pthread_cond_wait(&cv->cond_var, &mu->mutex);
+#else
     err = pthread_cond_wait(cv, mu);
+#endif
   } else {
     struct timespec abs_deadline_ts;
 #if GPR_LINUX
@@ -181,7 +236,13 @@ int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu, gpr_timespec abs_deadline) {
 #endif  // GPR_LINUX
     abs_deadline_ts.tv_sec = static_cast<time_t>(abs_deadline.tv_sec);
     abs_deadline_ts.tv_nsec = abs_deadline.tv_nsec;
+
+#ifdef GRPC_ASAN_ENABLED
+    err = pthread_cond_timedwait(&cv->cond_var, &mu->mutex, &abs_deadline_ts);
+#else
     err = pthread_cond_timedwait(cv, mu, &abs_deadline_ts);
+#endif
+
 #ifdef GRPC_DEBUG_TIMER_MANAGER
     // For debug of the timer manager crash only.
     // TODO (mxyan): remove after bug is fixed.
@@ -226,10 +287,20 @@ int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu, gpr_timespec abs_deadline) {
   return err == ETIMEDOUT;
 }
 
-void gpr_cv_signal(gpr_cv* cv) { GPR_ASSERT(pthread_cond_signal(cv) == 0); }
+void gpr_cv_signal(gpr_cv* cv) {
+#ifdef GRPC_ASAN_ENABLED
+  GPR_ASSERT(pthread_cond_signal(&cv->cond_var) == 0);
+#else
+  GPR_ASSERT(pthread_cond_signal(cv) == 0);
+#endif
+}
 
 void gpr_cv_broadcast(gpr_cv* cv) {
+#ifdef GRPC_ASAN_ENABLED
+  GPR_ASSERT(pthread_cond_broadcast(&cv->cond_var) == 0);
+#else
   GPR_ASSERT(pthread_cond_broadcast(cv) == 0);
+#endif
 }
 
 /*----------------------------------------*/

--- a/src/core/lib/gpr/sync_posix.cc
+++ b/src/core/lib/gpr/sync_posix.cc
@@ -16,8 +16,8 @@
  *
  */
 
-#include <grpc/support/port_platform.h>
 #include <grpc/support/alloc.h>
+#include <grpc/support/port_platform.h>
 
 #ifdef GPR_POSIX_SYNC
 
@@ -77,11 +77,6 @@ void gpr_mu_init(gpr_mu* mu) {
   GPR_ASSERT(pthread_mutex_init(&mu->mutex, nullptr) == 0);
   mu->leak_checker = (int*)gpr_malloc(sizeof(*mu->leak_checker));
   GPR_ASSERT(mu->leak_checker != nullptr);
-  /* Initial it with a magic number, make no sense, just use the memory.
-  * This only take effect when ASAN enabled, so,
-  * if memory allocation failed, let it crash.
-  */
-  *mu->leak_checker = 0x12F34D0;
 #else
   GPR_ASSERT(pthread_mutex_init(mu, nullptr) == 0);
 #endif
@@ -142,11 +137,6 @@ void gpr_cv_init(gpr_cv* cv) {
   GPR_ASSERT(pthread_cond_init(&cv->cond_var, &attr) == 0);
   cv->leak_checker = (int*)gpr_malloc(sizeof(*cv->leak_checker));
   GPR_ASSERT(cv->leak_checker != nullptr);
-  /* Initial it with a magic number, make no sense, just use the memory.
-  * This only take effect when ASAN enabled, so,
-  * if memory allocation failed, let it crash.
-  */
-  *cv->leak_checker = 0x12F34D0;
 #else
   GPR_ASSERT(pthread_cond_init(cv, &attr) == 0);
 #endif

--- a/src/core/lib/gpr/sync_posix.cc
+++ b/src/core/lib/gpr/sync_posix.cc
@@ -76,7 +76,7 @@ gpr_atm gpr_counter_atm_add = 0;
 void gpr_mu_init(gpr_mu* mu) {
 #ifdef GRPC_ASAN_ENABLED
   GPR_ASSERT(pthread_mutex_init(&mu->mutex, nullptr) == 0);
-  mu->leak_checker = (int*)gpr_malloc(sizeof(*mu->leak_checker));
+  mu->leak_checker = static_cast<int*>(gpr_malloc(sizeof(*mu->leak_checker)));
   GPR_ASSERT(mu->leak_checker != nullptr);
 #else
   GPR_ASSERT(pthread_mutex_init(mu, nullptr) == 0);
@@ -136,7 +136,7 @@ void gpr_cv_init(gpr_cv* cv) {
 
 #ifdef GRPC_ASAN_ENABLED
   GPR_ASSERT(pthread_cond_init(&cv->cond_var, &attr) == 0);
-  cv->leak_checker = (int*)gpr_malloc(sizeof(*cv->leak_checker));
+  cv->leak_checker = static_cast<int*>(gpr_malloc(sizeof(*cv->leak_checker)));
   GPR_ASSERT(cv->leak_checker != nullptr);
 #else
   GPR_ASSERT(pthread_cond_init(cv, &attr) == 0);
@@ -227,7 +227,6 @@ int gpr_cv_wait(gpr_cv* cv, gpr_mu* mu, gpr_timespec abs_deadline) {
 #endif  // GPR_LINUX
     abs_deadline_ts.tv_sec = static_cast<time_t>(abs_deadline.tv_sec);
     abs_deadline_ts.tv_nsec = abs_deadline.tv_nsec;
-
 #ifdef GRPC_ASAN_ENABLED
     err = pthread_cond_timedwait(&cv->cond_var, &mu->mutex, &abs_deadline_ts);
 #else

--- a/src/core/lib/iomgr/ev_epollex_linux.cc
+++ b/src/core/lib/iomgr/ev_epollex_linux.cc
@@ -612,6 +612,7 @@ static void pollable_unref(pollable* p, int line, const char* reason) {
     close(p->epfd);
     grpc_wakeup_fd_destroy(&p->wakeup);
     gpr_mu_destroy(&p->owner_orphan_mu);
+    gpr_mu_destroy(&p->mu);
     gpr_free(p);
   }
 }

--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -1535,6 +1535,9 @@ static void cache_harvest_locked() {
                   gpr_inf_future(GPR_CLOCK_MONOTONIC));
     }
     args->poller_thd.Join();
+    gpr_cv_destroy(&args->trigger);
+    gpr_cv_destroy(&args->harvest);
+    gpr_cv_destroy(&args->join);
     gpr_free(args);
   }
 }
@@ -1713,6 +1716,7 @@ static int cvfd_poll(struct pollfd* fds, nfds_t nfds, int timeout) {
   }
 
   gpr_free(fd_cvs);
+  gpr_cv_destroy(pollcv->cv);
   gpr_free(pollcv);
   if (result) {
     decref_poll_result(result);

--- a/test/core/end2end/inproc_callback_test.cc
+++ b/test/core/end2end/inproc_callback_test.cc
@@ -65,7 +65,10 @@ class ShutdownCallback : public grpc_experimental_completion_queue_functor {
     gpr_mu_init(&mu_);
     gpr_cv_init(&cv_);
   }
-  ~ShutdownCallback() {}
+  ~ShutdownCallback() {
+    gpr_mu_destroy(&mu_);
+    gpr_cv_destroy(&cv_);
+  }
   static void StaticRun(grpc_experimental_completion_queue_functor* cb,
                         int ok) {
     auto* callback = static_cast<ShutdownCallback*>(cb);

--- a/test/core/gpr/cpu_test.cc
+++ b/test/core/gpr/cpu_test.cc
@@ -140,6 +140,8 @@ static void cpu_test(void) {
   }
   fprintf(stderr, "] (%d/%d)\n", cores_seen, ct.ncores);
   fflush(stderr);
+  gpr_mu_destroy(&ct.mu);
+  gpr_cv_destroy(&ct.done_cv);
   gpr_free(ct.used);
 }
 

--- a/test/core/gpr/mpscq_test.cc
+++ b/test/core/gpr/mpscq_test.cc
@@ -178,6 +178,7 @@ static void test_mt_multipop(void) {
   for (auto& th : thds) {
     th.Join();
   }
+  gpr_mu_destroy(&pa.mu);
   gpr_mpscq_destroy(&q);
 }
 

--- a/test/core/gprpp/thd_test.cc
+++ b/test/core/gprpp/thd_test.cc
@@ -71,6 +71,8 @@ static void test1(void) {
     th.Join();
   }
   GPR_ASSERT(t.n == 0);
+  gpr_mu_destroy(&t.mu);
+  gpr_cv_destroy(&t.done_cv);
 }
 
 static void thd_body2(void* v) {}

--- a/test/core/util/mock_endpoint.cc
+++ b/test/core/util/mock_endpoint.cc
@@ -89,6 +89,7 @@ static void me_destroy(grpc_endpoint* ep) {
   mock_endpoint* m = reinterpret_cast<mock_endpoint*>(ep);
   grpc_slice_buffer_destroy(&m->read_buffer);
   grpc_resource_user_unref(m->resource_user);
+  gpr_mu_destroy(&m->mu);
   gpr_free(m);
 }
 

--- a/test/cpp/microbenchmarks/bm_closure.cc
+++ b/test/cpp/microbenchmarks/bm_closure.cc
@@ -183,6 +183,7 @@ static void BM_AcquireMutex(benchmark::State& state) {
     DoNothing(nullptr, GRPC_ERROR_NONE);
     gpr_mu_unlock(&mu);
   }
+  gpr_mu_destroy(&mu);
 
   track_counters.Finish(state);
 }
@@ -202,6 +203,7 @@ static void BM_TryAcquireMutex(benchmark::State& state) {
       abort();
     }
   }
+  gpr_mu_destroy(&mu);
 
   track_counters.Finish(state);
 }

--- a/test/cpp/util/grpc_tool.cc
+++ b/test/cpp/util/grpc_tool.cc
@@ -590,6 +590,7 @@ bool GrpcTool::CallMethod(int argc, const char** argv,
 
     call.WritesDoneAndWait();
     read_thread.join();
+    gpr_mu_destroy(&parser_mu);
 
     std::multimap<grpc::string_ref, grpc::string_ref> server_trailing_metadata;
     Status status = call.Finish(&server_trailing_metadata);


### PR DESCRIPTION
* Add MACRO *GPR_HAS_FEATURE*;
* Add test code within MACRO *GRPC_ASAN_ENABLED* for gpr_mu/cv mem-leak detection.

This PR related issue was discussed at [#17586](https://github.com/grpc/grpc/pull/17586)