### PR TITLE
Don't pass service config from parent channel to grpclb balancer channel.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -917,6 +917,9 @@ grpc_channel_args* BuildBalancerChannelArgs(
       // LB policy name, since we want to use the default (pick_first) in
       // the LB channel.
       GRPC_ARG_LB_POLICY_NAME,
+      // Strip out the service config, since we don't want the LB policy
+      // config specified for the parent channel to affect the LB channel.
+      GRPC_ARG_SERVICE_CONFIG,
       // The channel arg for the server URI, since that will be different for
       // the LB channel than for the parent channel.  The client channel
       // factory will re-add this arg with the right value.
@@ -928,7 +931,7 @@ grpc_channel_args* BuildBalancerChannelArgs(
       // resolver will have is_balancer=false, whereas our own addresses have
       // is_balancer=true.  We need the LB channel to return addresses with
       // is_balancer=false so that it does not wind up recursively using the
-      // grpclb LB policy, as per the special case logic in client_channel.c.
+      // grpclb LB policy.
       GRPC_ARG_SERVER_ADDRESS_LIST,
       // The fake resolver response generator, because we are replacing it
       // with the one from the grpclb policy, used to propagate updates to

--- a/test/cpp/end2end/grpclb_end2end_test.cc
+++ b/test/cpp/end2end/grpclb_end2end_test.cc
@@ -404,14 +404,6 @@ class GrpclbEnd2endTest : public ::testing::Test {
     }
   }
 
-  void SetNextResolutionAllBalancers() {
-    std::vector<AddressData> addresses;
-    for (size_t i = 0; i < balancer_servers_.size(); ++i) {
-      addresses.emplace_back(AddressData{balancer_servers_[i].port_, true, ""});
-    }
-    SetNextResolution(addresses);
-  }
-
   void ResetStub(int fallback_timeout = 0,
                  const grpc::string& expected_targets = "") {
     ChannelArguments args;
@@ -533,12 +525,29 @@ class GrpclbEnd2endTest : public ::testing::Test {
     return addresses;
   }
 
-  void SetNextResolution(const std::vector<AddressData>& address_data) {
+  void SetNextResolutionAllBalancers(
+      const char* service_config_json = nullptr) {
+    std::vector<AddressData> addresses;
+    for (size_t i = 0; i < balancer_servers_.size(); ++i) {
+      addresses.emplace_back(AddressData{balancer_servers_[i].port_, true, ""});
+    }
+    SetNextResolution(addresses, service_config_json);
+  }
+
+  void SetNextResolution(const std::vector<AddressData>& address_data,
+                         const char* service_config_json = nullptr) {
     grpc_core::ExecCtx exec_ctx;
     grpc_core::ServerAddressList addresses =
         CreateLbAddressesFromAddressDataList(address_data);
-    grpc_arg fake_addresses = CreateServerAddressListChannelArg(&addresses);
-    grpc_channel_args fake_result = {1, &fake_addresses};
+    std::vector<grpc_arg> args = {
+        CreateServerAddressListChannelArg(&addresses),
+    };
+    if (service_config_json != nullptr) {
+      args.push_back(grpc_channel_arg_string_create(
+          const_cast<char*>(GRPC_ARG_SERVICE_CONFIG),
+          const_cast<char*>(service_config_json)));
+    }
+    grpc_channel_args fake_result = {args.size(), args.data()};
     response_generator_->SetResponse(&fake_result);
   }
 
@@ -689,6 +698,27 @@ TEST_F(SingleBalancerTest, Vanilla) {
   // and sent a single response.
   EXPECT_EQ(1U, balancer_servers_[0].service_->response_count());
 
+  // Check LB policy name for the channel.
+  EXPECT_EQ("grpclb", channel_->GetLoadBalancingPolicyName());
+}
+
+TEST_F(SingleBalancerTest, SelectGrpclbWithMigrationServiceConfig) {
+  SetNextResolutionAllBalancers(
+      "{\n"
+      "  \"loadBalancingConfig\":[\n"
+      "    { \"does_not_exist\":{} },\n"
+      "    { \"grpclb\":{} }\n"
+      "  ]\n"
+      "}");
+  ScheduleResponseForBalancer(
+      0, BalancerServiceImpl::BuildResponseForBackends(GetBackendPorts(), {}),
+      0);
+  CheckRpcSendOk(1, 1000 /* timeout_ms */, true /* wait_for_ready */);
+  balancers_[0]->NotifyDoneWithServerlists();
+  // The balancer got a single request.
+  EXPECT_EQ(1U, balancer_servers_[0].service_->request_count());
+  // and sent a single response.
+  EXPECT_EQ(1U, balancer_servers_[0].service_->response_count());
   // Check LB policy name for the channel.
   EXPECT_EQ("grpclb", channel_->GetLoadBalancingPolicyName());
 }


### PR DESCRIPTION
This fixes grpclb to support the migration plan described in https://github.com/grpc/proposal/blob/master/A24-lb-policy-config.md#rationale.