### PR TITLE
Pre-fetch Cocoapods master repo

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -48,6 +48,10 @@ set -ex
 
 # cocoapods
 export LANG=en_US.UTF-8
+# pre-fetch cocoapods master repo with HEAD only
+mkdir -p ~/.cocoapods/repos
+git clone --depth 1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master
+
 time pod repo update  # needed by python
 
 # python

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -48,11 +48,9 @@ set -ex
 
 # cocoapods
 export LANG=en_US.UTF-8
-# pre-fetch cocoapods master repo with HEAD only
+# pre-fetch cocoapods master repo's most recent commit only
 mkdir -p ~/.cocoapods/repos
-git clone --depth 1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master
-
-time pod repo update  # needed by python
+time git clone --depth 1 https://github.com/CocoaPods/Specs.git ~/.cocoapods/repos/master
 
 # python
 time pip install virtualenv --user python

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1126,7 +1126,7 @@ class ObjCLanguage(object):
                 }),
             self.config.job_spec(
                 ['test/core/iomgr/ios/CFStreamTests/run_tests.sh'],
-                timeout_seconds=10 * 60,
+                timeout_seconds=20 * 60,
                 shortname='cfstream-tests',
                 cpu_cost=1e6,
                 environ=_FORCE_ENVIRON_FOR_WRAPPERS),


### PR DESCRIPTION
Part 1 of efforts to reduce ObjC test time consumption.

Fetch the Cocoapods master repo when setting up machine rather than as part of ObjC tests. Also fetch HEAD only, rather than the entire Cocoapods master repo to save time.

ref: #17814 