### PR TITLE
Ignore reserved bit in WINDOW_UPDATE frame

### DIFF
--- a/src/core/ext/transport/chttp2/transport/frame_window_update.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_window_update.cc
@@ -88,8 +88,9 @@ grpc_error* grpc_chttp2_window_update_parser_parse(void* parser,
   }
 
   if (p->byte == 4) {
-    uint32_t received_update = p->amount;
-    if (received_update == 0 || (received_update & 0x80000000u)) {
+    // top bit is reserved and must be ignored.
+    uint32_t received_update = p->amount & 0x7fffffffu;
+    if (received_update == 0) {
       char* msg;
       gpr_asprintf(&msg, "invalid window update bytes: %d", p->amount);
       grpc_error* err = GRPC_ERROR_CREATE_FROM_COPIED_STRING(msg);

--- a/test/core/bad_client/tests/simple_request.cc
+++ b/test/core/bad_client/tests/simple_request.cc
@@ -147,11 +147,12 @@ int main(int argc, char** argv) {
   /* push a window update with bad flags */
   GRPC_RUN_BAD_CLIENT_TEST(failure_verifier, nullptr,
                            PFX_STR "\x00\x00\x00\x08\x10\x00\x00\x00\x01", 0);
-  /* push a window update with bad data */
+  /* push a window update with bad data (0 is not legal window size increment)
+   */
   GRPC_RUN_BAD_CLIENT_TEST(failure_verifier, nullptr,
                            PFX_STR
                            "\x00\x00\x04\x08\x00\x00\x00\x00\x01"
-                           "\xff\xff\xff\xff",
+                           "\x00\x00\x00\x00",
                            0);
   /* push a short goaway */
   GRPC_RUN_BAD_CLIENT_TEST(failure_verifier, nullptr,


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/17840.

When Kestrel server sends the per-connection window update, the top bit of "Windows Size Increment" is set (which is against the spec!), but at the same time gRPC doesn't ignore the set bit (also against the spec!).
This PR makes grpc ignore the top bit.

See
https://http2.github.io/http2-spec/#WINDOW_UPDATE
https://http2.github.io/http2-spec/#FramingLayer

> R: A reserved 1-bit field. The semantics of this bit are undefined, and the bit MUST remain unset (0x0) when sending and MUST be ignored when receiving.

These are the raw bytes I got in the client side when debugging:
```
(gdb) x/13b t->read_buffer->slices[0].data.refcounted.bytes
0x7f8edc00c448:	0x00	0x00	0x04	0x08	0x00	0x00	0x00	0x00
0x7f8edc00c450:	0x00	*0x80	0x01	0x00	0x08
(*) reserved bit set here
```
