### PR TITLE
Build grpc_objective_c_plugin parallel

### DIFF
--- a/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
+++ b/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
@@ -121,7 +121,7 @@ Pod::Spec.new do |s|
       # TODO(jcanizales): I reckon make will try to use locally-installed libprotoc (headers and
       # library binary) if found, which _we do not want_. Find a way for this to always use the
       # sources in the repo.
-      make #{plugin}
+      make #{plugin} -j
       cd -
     fi
   CMD

--- a/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
@@ -123,7 +123,7 @@
         # TODO(jcanizales): I reckon make will try to use locally-installed libprotoc (headers and
         # library binary) if found, which _we do not want_. Find a way for this to always use the
         # sources in the repo.
-        make #{plugin}
+        make #{plugin} -j
         cd -
       fi
     CMD


### PR DESCRIPTION
Part 2 of efforts to reduce ObjC test time consumption.

During the test, build `grpc_objective_c_plugin` with `-j` option to make it faster.