### PR TITLE
Fix tautological comparison

### DIFF
--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -740,7 +740,7 @@ static void process_errors(grpc_tcp* tcp) {
       return;
     }
     if (grpc_tcp_trace.enabled()) {
-      if ((msg.msg_flags & MSG_CTRUNC) == 1) {
+      if ((msg.msg_flags & MSG_CTRUNC) != 0) {
         gpr_log(GPR_INFO, "Error message was truncated.");
       }
     }


### PR DESCRIPTION
Masking a value and comparing to one will only work if the mask itself
is equal to one (which is not the case here). Comparing to zero works
for any mask.

This was detected by a -Wtautological-compare warning (always evaluates
to false) in GCC.