### PR TITLE
Memset before setting length

### DIFF
--- a/src/core/lib/iomgr/buffer_list.cc
+++ b/src/core/lib/iomgr/buffer_list.cc
@@ -188,8 +188,8 @@ void extract_opt_stats_from_cmsg(ConnectionMetrics* metrics,
 }
 
 static int get_socket_tcp_info(grpc_core::tcp_info* info, int fd) {
-  info->length = sizeof(*info) - sizeof(socklen_t);
   memset(info, 0, sizeof(*info));
+  info->length = sizeof(*info) - sizeof(socklen_t);
   return getsockopt(fd, IPPROTO_TCP, TCP_INFO, info, &(info->length));
 }
 } /* namespace */

--- a/test/core/iomgr/buffer_list_test.cc
+++ b/test/core/iomgr/buffer_list_test.cc
@@ -66,6 +66,7 @@ static void TestVerifierCalledOnAckVerifier(void* arg,
   GPR_ASSERT(ts->acked_time.time.clock_type == GPR_CLOCK_REALTIME);
   GPR_ASSERT(ts->acked_time.time.tv_sec == 123);
   GPR_ASSERT(ts->acked_time.time.tv_nsec == 456);
+  GPR_ASSERT(ts->info.length > 0);
   gpr_atm* done = reinterpret_cast<gpr_atm*>(arg);
   gpr_atm_rel_store(done, static_cast<gpr_atm>(1));
 }


### PR DESCRIPTION
I noticed that we weren't receiving opt_stats for sendmsg. I initially thought that it was just not available at the time, but then I saw this.

Stupid me