### PR TITLE
Update ObjC manual test minimum deployment target

### DIFF
--- a/src/objective-c/manual_tests/GrpcIosTest.xcodeproj/project.pbxproj
+++ b/src/objective-c/manual_tests/GrpcIosTest.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -342,6 +343,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
To meet phone's iOS version. Adjust as necessary.