### PR TITLE
grpc_prefork(): check grpc_is_initialized before creating execctx

### DIFF
--- a/src/core/lib/iomgr/fork_posix.cc
+++ b/src/core/lib/iomgr/fork_posix.cc
@@ -47,11 +47,11 @@ bool registered_handlers = false;
 }  // namespace
 
 void grpc_prefork() {
-  grpc_core::ExecCtx exec_ctx;
   skipped_handler = true;
   if (!grpc_is_initialized()) {
     return;
   }
+  grpc_core::ExecCtx exec_ctx;
   if (!grpc_core::Fork::Enabled()) {
     gpr_log(GPR_ERROR,
             "Fork support not enabled; try running with the "

--- a/src/core/lib/iomgr/fork_posix.cc
+++ b/src/core/lib/iomgr/fork_posix.cc
@@ -48,6 +48,8 @@ bool registered_handlers = false;
 
 void grpc_prefork() {
   skipped_handler = true;
+  // This  may be called after core shuts down, so verify initialized before
+  // instantiating an ExecCtx.
   if (!grpc_is_initialized()) {
     return;
   }


### PR DESCRIPTION
This fixes a bug introduced into core's prefork handler in https://github.com/grpc/grpc/pull/14647.

`grpc_prefork()` is registered as a prefork handler via `pthread_atfork` when grpc is [first initialized](https://github.com/grpc/grpc/blob/f7ef20b5104bb62aa438aacfe7d8e46058f517b1/src/core/lib/surface/init.cc#L124). This method works fine as-is as long as grpc core never shuts down.

However, there is no corresponding syscall to "undo" the original call to `pthread_atfork` to unregister our fork handler when grpc shuts down. So `grpc_prefork()` will be called at fork time even after grpc has shutdown, and when this happens (e.g., `grpc_is_initialized()` returns false) attempting to create an`ExecCtx` can fail in a variety of ways: e.g., the mutex `mu_` in `ExecCtxState` will have been [torn down](https://github.com/grpc/grpc/blob/master/src/core/lib/surface/init.cc#L184) and obtaining a lock on it in `IncExecCtxCount` tends to blow up.