### PR TITLE
Ruby: refactor init/shutdown logic to avoid using atexit; fix windows

### DIFF
--- a/src/ruby/ext/grpc/rb_channel_credentials.c
+++ b/src/ruby/ext/grpc/rb_channel_credentials.c
@@ -48,8 +48,7 @@ typedef struct grpc_rb_channel_credentials {
   grpc_channel_credentials* wrapped;
 } grpc_rb_channel_credentials;
 
-/* Destroys the credentials instances. */
-static void grpc_rb_channel_credentials_free(void* p) {
+static void grpc_rb_channel_credentials_free_internal(void* p) {
   grpc_rb_channel_credentials* wrapper = NULL;
   if (p == NULL) {
     return;
@@ -59,6 +58,12 @@ static void grpc_rb_channel_credentials_free(void* p) {
   wrapper->wrapped = NULL;
 
   xfree(p);
+}
+
+/* Destroys the credentials instances. */
+static void grpc_rb_channel_credentials_free(void* p) {
+  grpc_rb_channel_credentials_free_internal(p);
+  grpc_ruby_shutdown();
 }
 
 /* Protects the mark object from GC */
@@ -90,6 +95,7 @@ static rb_data_type_t grpc_rb_channel_credentials_data_type = {
 /* Allocates ChannelCredential instances.
    Provides safe initial defaults for the instance fields. */
 static VALUE grpc_rb_channel_credentials_alloc(VALUE cls) {
+  grpc_ruby_init();
   grpc_rb_channel_credentials* wrapper = ALLOC(grpc_rb_channel_credentials);
   wrapper->wrapped = NULL;
   wrapper->mark = Qnil;
@@ -146,8 +152,6 @@ static VALUE grpc_rb_channel_credentials_init(int argc, VALUE* argv,
   grpc_ssl_pem_key_cert_pair key_cert_pair;
   const char* pem_root_certs_cstr = NULL;
   MEMZERO(&key_cert_pair, grpc_ssl_pem_key_cert_pair, 1);
-
-  grpc_ruby_once_init();
 
   /* "03" == no mandatory arg, 3 optional */
   rb_scan_args(argc, argv, "03", &pem_root_certs, &pem_private_key,

--- a/src/ruby/ext/grpc/rb_compression_options.c
+++ b/src/ruby/ext/grpc/rb_compression_options.c
@@ -52,21 +52,24 @@ typedef struct grpc_rb_compression_options {
   grpc_compression_options* wrapped;
 } grpc_rb_compression_options;
 
-/* Destroys the compression options instances and free the
- * wrapped grpc compression options. */
-static void grpc_rb_compression_options_free(void* p) {
+static void grpc_rb_compression_options_free_internal(void* p) {
   grpc_rb_compression_options* wrapper = NULL;
   if (p == NULL) {
     return;
   };
   wrapper = (grpc_rb_compression_options*)p;
-
   if (wrapper->wrapped != NULL) {
     gpr_free(wrapper->wrapped);
     wrapper->wrapped = NULL;
   }
-
   xfree(p);
+}
+
+/* Destroys the compression options instances and free the
+ * wrapped grpc compression options. */
+static void grpc_rb_compression_options_free(void* p) {
+  grpc_rb_compression_options_free_internal(p);
+  grpc_ruby_shutdown();
 }
 
 /* Ruby recognized data type for the CompressionOptions class. */
@@ -87,9 +90,8 @@ static rb_data_type_t grpc_rb_compression_options_data_type = {
    Allocate the wrapped grpc compression options and
    initialize it here too. */
 static VALUE grpc_rb_compression_options_alloc(VALUE cls) {
+  grpc_ruby_init();
   grpc_rb_compression_options* wrapper = NULL;
-
-  grpc_ruby_once_init();
 
   wrapper = gpr_malloc(sizeof(grpc_rb_compression_options));
   wrapper->wrapped = NULL;

--- a/src/ruby/ext/grpc/rb_event_thread.c
+++ b/src/ruby/ext/grpc/rb_event_thread.c
@@ -115,6 +115,7 @@ static void grpc_rb_event_unblocking_func(void* arg) {
 static VALUE grpc_rb_event_thread(VALUE arg) {
   grpc_rb_event* event;
   (void)arg;
+  grpc_ruby_init();
   while (true) {
     event = (grpc_rb_event*)rb_thread_call_without_gvl(
         grpc_rb_wait_for_event_no_gil, NULL, grpc_rb_event_unblocking_func,
@@ -128,6 +129,7 @@ static VALUE grpc_rb_event_thread(VALUE arg) {
     }
   }
   grpc_rb_event_queue_destroy();
+  grpc_ruby_shutdown();
   return Qnil;
 }
 

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -276,10 +276,6 @@ static bool grpc_ruby_forked_after_init(void) {
 }
 #endif
 
-static void grpc_rb_shutdown(void) {
-  if (!grpc_ruby_forked_after_init()) grpc_shutdown();
-}
-
 /* Initialize the GRPC module structs */
 
 /* grpc_rb_sNewServerRpc is the struct that holds new server rpc details. */
@@ -298,12 +294,6 @@ VALUE sym_metadata = Qundef;
 
 static gpr_once g_once_init = GPR_ONCE_INIT;
 
-static void grpc_ruby_once_init_internal() {
-  grpc_ruby_set_init_pid();
-  grpc_init();
-  atexit(grpc_rb_shutdown);
-}
-
 void grpc_ruby_fork_guard() {
   if (grpc_ruby_forked_after_init()) {
     rb_raise(rb_eRuntimeError, "grpc cannot be used before and after forking");
@@ -313,19 +303,7 @@ void grpc_ruby_fork_guard() {
 static VALUE bg_thread_init_rb_mu = Qundef;
 static int bg_thread_init_done = 0;
 
-void grpc_ruby_once_init() {
-  /* ruby_vm_at_exit doesn't seem to be working. It would crash once every
-   * blue moon, and some users are getting it repeatedly. See the discussions
-   *  - https://github.com/grpc/grpc/pull/5337
-   *  - https://bugs.ruby-lang.org/issues/12095
-   *
-   * In order to still be able to handle the (unlikely) situation where the
-   * extension is loaded by a first Ruby VM that is subsequently destroyed,
-   * then loaded again by another VM within the same process, we need to
-   * schedule our initialization and destruction only once.
-   */
-  gpr_once_init(&g_once_init, grpc_ruby_once_init_internal);
-
+static void grpc_ruby_init_threads() {
   // Avoid calling calling into ruby library (when creating threads here)
   // in gpr_once_init. In general, it appears to be unsafe to call
   // into the ruby library while holding a non-ruby mutex, because a gil yield
@@ -337,6 +315,27 @@ void grpc_ruby_once_init() {
     bg_thread_init_done = 1;
   }
   rb_mutex_unlock(bg_thread_init_rb_mu);
+}
+
+static int64_t g_grpc_ruby_init_count;
+
+void grpc_ruby_init() {
+  gpr_once_init(&g_once_init, grpc_ruby_set_init_pid);
+  grpc_init();
+  grpc_ruby_init_threads();
+  // (only gpr_log after logging has been initialized)
+  gpr_log(GPR_DEBUG,
+          "GRPC_RUBY: grpc_ruby_init - prev g_grpc_ruby_init_count:%" PRId64,
+          g_grpc_ruby_init_count++);
+}
+
+void grpc_ruby_shutdown() {
+  GPR_ASSERT(g_grpc_ruby_init_count > 0);
+  if (!grpc_ruby_forked_after_init()) grpc_shutdown();
+  gpr_log(
+      GPR_DEBUG,
+      "GRPC_RUBY: grpc_ruby_shutdown - prev g_grpc_ruby_init_count:%" PRId64,
+      g_grpc_ruby_init_count--);
 }
 
 void Init_grpc_c() {

--- a/src/ruby/ext/grpc/rb_grpc.h
+++ b/src/ruby/ext/grpc/rb_grpc.h
@@ -67,8 +67,10 @@ VALUE grpc_rb_cannot_init_copy(VALUE copy, VALUE self);
 /* grpc_rb_time_timeval creates a gpr_timespec from a ruby time object. */
 gpr_timespec grpc_rb_time_timeval(VALUE time, int interval);
 
-void grpc_ruby_once_init();
-
 void grpc_ruby_fork_guard();
+
+void grpc_ruby_init();
+
+void grpc_ruby_shutdown();
 
 #endif /* GRPC_RB_H_ */


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/17799

It looks like grpc-ruby on Windows is running into the issue described in [this interesting blog post](https://www.luke1410.de/blog/?p=95). Currently, in the ruby extension on Windows, Ruby loads the grpc-ruby extension library, and that library sets up an `atexit` handler to call `grpc_rb_shutdown`, which then calls into the C-core dll. Apparently, on Windows each dll has it's own separate `atexit` stack, and the order of process shutdown goes roughly as follows:
1) main thread falls of main and starts to kill off background threads
2)  the dll's present in the library have their own `atexit` handlers called as a part of their unloading

So in grpc-ruby extension's `atexit` handler, it calls `grpc_shutdown` and proceeds to try to [await timer threads to signal their completions](https://github.com/grpc/grpc/blob/master/src/core/lib/iomgr/timer_manager.cc#L340), but the timer threads are no longer running, and so we hang.

Overall it seems `atexit` is dubious. So this PR refactors the `grpc_init`/`grpc_shutdown` logic as follows:
1) At the top of the "alloc" hook of every ruby object that has a dependency on C-core, call `grpc_ruby_init`
2) At the end of every such object's GC hook, call `grpc_ruby_shutdown`
3) Wrap the lifetime of grpc-ruby background threads (the call creds thread and the connection poller thread) in a `grpc_ruby_init`/`grpc_ruby_shutdown` pair.

Note that we no longer schedule grpc init and shutdown only once, and I've deleted the comment on why that's needed. But I believe the described scenario would have been broken for a long time anyways :), because there are ruby-level grpc background threads for which we don't make any attempt to cleanly reset their state at the end of a ruby VM's lifetime.