### PR TITLE
Disable service config resolution with c-ares by default, for now

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -151,7 +151,7 @@ AresDnsResolver::AresDnsResolver(const ResolverArgs& args)
   // Disable service config option
   const grpc_arg* arg = grpc_channel_args_find(
       channel_args_, GRPC_ARG_SERVICE_CONFIG_DISABLE_RESOLUTION);
-  request_service_config_ = !grpc_channel_arg_get_bool(arg, false);
+  request_service_config_ = !grpc_channel_arg_get_bool(arg, true);
   // Min time b/t resolutions option
   arg = grpc_channel_args_find(channel_args_,
                                GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS);

--- a/test/cpp/naming/gen_build_yaml.py
+++ b/test/cpp/naming/gen_build_yaml.py
@@ -49,6 +49,7 @@ def _resolver_test_cases(resolver_component_data):
              (test_case['expected_chosen_service_config'] or '')),
             ('expected_lb_policy', (test_case['expected_lb_policy'] or '')),
             ('enable_srv_queries', test_case['enable_srv_queries']),
+            ('enable_txt_queries', test_case['enable_txt_queries']),
         ],
     })
   return out

--- a/test/cpp/naming/resolver_component_tests_runner.py
+++ b/test/cpp/naming/resolver_component_tests_runner.py
@@ -126,6 +126,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
   '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -139,6 +140,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
   '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -152,6 +154,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
   '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -165,6 +168,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
   '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -178,6 +182,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
   '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -191,6 +196,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}',
   '--expected_lb_policy', 'round_robin',
   '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -204,6 +210,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}',
   '--expected_lb_policy', 'round_robin',
   '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -217,6 +224,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
   '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -230,6 +238,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
   '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -243,6 +252,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}',
   '--expected_lb_policy', 'round_robin',
   '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -256,6 +266,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}',
   '--expected_lb_policy', 'round_robin',
   '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -269,6 +280,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
   '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -282,6 +294,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
   '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -295,6 +308,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}',
   '--expected_lb_policy', '',
   '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -308,6 +322,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
   '--enable_srv_queries', 'False',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -321,6 +336,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
   '--enable_srv_queries', 'False',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -334,6 +350,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
   '--enable_srv_queries', 'False',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -347,6 +364,7 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '',
   '--expected_lb_policy', '',
   '--enable_srv_queries', 'False',
+  '--enable_txt_queries', 'True',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:
@@ -360,6 +378,49 @@ current_test_subprocess = subprocess.Popen([
   '--expected_chosen_service_config', '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}',
   '--expected_lb_policy', 'round_robin',
   '--enable_srv_queries', 'False',
+  '--enable_txt_queries', 'True',
+  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+current_test_subprocess.communicate()
+if current_test_subprocess.returncode != 0:
+  num_test_failures += 1
+
+test_runner_log('Run test with target: %s' % 'srv-ipv4-simple-service-config-txt-disabled.resolver-tests-version-4.grpctestingexp.')
+current_test_subprocess = subprocess.Popen([
+  args.test_bin_path,
+  '--target_name', 'srv-ipv4-simple-service-config-txt-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--expected_addrs', '1.2.3.4:1234,True',
+  '--expected_chosen_service_config', '',
+  '--expected_lb_policy', '',
+  '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'False',
+  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+current_test_subprocess.communicate()
+if current_test_subprocess.returncode != 0:
+  num_test_failures += 1
+
+test_runner_log('Run test with target: %s' % 'ipv4-cpp-config-has-zero-percentage-txt-disabled.resolver-tests-version-4.grpctestingexp.')
+current_test_subprocess = subprocess.Popen([
+  args.test_bin_path,
+  '--target_name', 'ipv4-cpp-config-has-zero-percentage-txt-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--expected_addrs', '1.2.3.4:443,False',
+  '--expected_chosen_service_config', '',
+  '--expected_lb_policy', '',
+  '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'False',
+  '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
+current_test_subprocess.communicate()
+if current_test_subprocess.returncode != 0:
+  num_test_failures += 1
+
+test_runner_log('Run test with target: %s' % 'ipv4-second-language-is-cpp-txt-disabled.resolver-tests-version-4.grpctestingexp.')
+current_test_subprocess = subprocess.Popen([
+  args.test_bin_path,
+  '--target_name', 'ipv4-second-language-is-cpp-txt-disabled.resolver-tests-version-4.grpctestingexp.',
+  '--expected_addrs', '1.2.3.4:443,False',
+  '--expected_chosen_service_config', '',
+  '--expected_lb_policy', '',
+  '--enable_srv_queries', 'True',
+  '--enable_txt_queries', 'False',
   '--local_dns_server_address', '127.0.0.1:%d' % args.dns_server_port])
 current_test_subprocess.communicate()
 if current_test_subprocess.returncode != 0:

--- a/test/cpp/naming/resolver_test_record_groups.yaml
+++ b/test/cpp/naming/resolver_test_record_groups.yaml
@@ -6,6 +6,7 @@ resolver_component_tests:
   expected_chosen_service_config: null
   expected_lb_policy: null
   enable_srv_queries: true
+  enable_txt_queries: true
   record_to_resolve: no-srv-ipv4-single-target
   records:
     no-srv-ipv4-single-target:
@@ -15,6 +16,7 @@ resolver_component_tests:
   expected_chosen_service_config: null
   expected_lb_policy: null
   enable_srv_queries: true
+  enable_txt_queries: true
   record_to_resolve: srv-ipv4-single-target
   records:
     _grpclb._tcp.srv-ipv4-single-target:
@@ -28,6 +30,7 @@ resolver_component_tests:
   expected_chosen_service_config: null
   expected_lb_policy: null
   enable_srv_queries: true
+  enable_txt_queries: true
   record_to_resolve: srv-ipv4-multi-target
   records:
     _grpclb._tcp.srv-ipv4-multi-target:
@@ -41,6 +44,7 @@ resolver_component_tests:
   expected_chosen_service_config: null
   expected_lb_policy: null
   enable_srv_queries: true
+  enable_txt_queries: true
   record_to_resolve: srv-ipv6-single-target
   records:
     _grpclb._tcp.srv-ipv6-single-target:
@@ -54,6 +58,7 @@ resolver_component_tests:
   expected_chosen_service_config: null
   expected_lb_policy: null
   enable_srv_queries: true
+  enable_txt_queries: true
   record_to_resolve: srv-ipv6-multi-target
   records:
     _grpclb._tcp.srv-ipv6-multi-target:
@@ -67,6 +72,7 @@ resolver_component_tests:
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}'
   expected_lb_policy: round_robin
   enable_srv_queries: true
+  enable_txt_queries: true
   record_to_resolve: srv-ipv4-simple-service-config
   records:
     _grpclb._tcp.srv-ipv4-simple-service-config:
@@ -81,6 +87,7 @@ resolver_component_tests:
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"NoSrvSimpleService","waitForReady":true}]}]}'
   expected_lb_policy: round_robin
   enable_srv_queries: true
+  enable_txt_queries: true
   record_to_resolve: ipv4-no-srv-simple-service-config
   records:
     ipv4-no-srv-simple-service-config:
@@ -93,6 +100,7 @@ resolver_component_tests:
   expected_chosen_service_config: null
   expected_lb_policy: null
   enable_srv_queries: true
+  enable_txt_queries: true
   record_to_resolve: ipv4-no-config-for-cpp
   records:
     ipv4-no-config-for-cpp:
@@ -105,6 +113,7 @@ resolver_component_tests:
   expected_chosen_service_config: null
   expected_lb_policy: null
   enable_srv_queries: true
+  enable_txt_queries: true
   record_to_resolve: ipv4-cpp-config-has-zero-percentage
   records:
     ipv4-cpp-config-has-zero-percentage:
@@ -117,6 +126,7 @@ resolver_component_tests:
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}'
   expected_lb_policy: round_robin
   enable_srv_queries: true
+  enable_txt_queries: true
   record_to_resolve: ipv4-second-language-is-cpp
   records:
     ipv4-second-language-is-cpp:
@@ -129,6 +139,7 @@ resolver_component_tests:
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"AlwaysPickedService","waitForReady":true}]}]}'
   expected_lb_policy: round_robin
   enable_srv_queries: true
+  enable_txt_queries: true
   record_to_resolve: ipv4-config-with-percentages
   records:
     ipv4-config-with-percentages:
@@ -142,6 +153,7 @@ resolver_component_tests:
   expected_chosen_service_config: null
   expected_lb_policy: null
   enable_srv_queries: true
+  enable_txt_queries: true
   record_to_resolve: srv-ipv4-target-has-backend-and-balancer
   records:
     _grpclb._tcp.srv-ipv4-target-has-backend-and-balancer:
@@ -156,6 +168,7 @@ resolver_component_tests:
   expected_chosen_service_config: null
   expected_lb_policy: null
   enable_srv_queries: true
+  enable_txt_queries: true
   record_to_resolve: srv-ipv6-target-has-backend-and-balancer
   records:
     _grpclb._tcp.srv-ipv6-target-has-backend-and-balancer:
@@ -169,6 +182,7 @@ resolver_component_tests:
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwo","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooThree","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFour","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooFive","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSix","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooSeven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEight","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooNine","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTen","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooEleven","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]},{"name":[{"method":"FooTwelve","service":"SimpleService","waitForReady":true}]}]}'
   expected_lb_policy: null
   enable_srv_queries: true
+  enable_txt_queries: true
   record_to_resolve: ipv4-config-causing-fallback-to-tcp
   records:
     ipv4-config-causing-fallback-to-tcp:
@@ -182,6 +196,7 @@ resolver_component_tests:
   expected_chosen_service_config: null
   expected_lb_policy: null
   enable_srv_queries: false
+  enable_txt_queries: true
   record_to_resolve: srv-ipv4-single-target-srv-disabled
   records:
     _grpclb._tcp.srv-ipv4-single-target-srv-disabled:
@@ -197,6 +212,7 @@ resolver_component_tests:
   expected_chosen_service_config: null
   expected_lb_policy: null
   enable_srv_queries: false
+  enable_txt_queries: true
   record_to_resolve: srv-ipv4-multi-target-srv-disabled
   records:
     _grpclb._tcp.srv-ipv4-multi-target-srv-disabled:
@@ -214,6 +230,7 @@ resolver_component_tests:
   expected_chosen_service_config: null
   expected_lb_policy: null
   enable_srv_queries: false
+  enable_txt_queries: true
   record_to_resolve: srv-ipv6-single-target-srv-disabled
   records:
     _grpclb._tcp.srv-ipv6-single-target-srv-disabled:
@@ -229,6 +246,7 @@ resolver_component_tests:
   expected_chosen_service_config: null
   expected_lb_policy: null
   enable_srv_queries: false
+  enable_txt_queries: true
   record_to_resolve: srv-ipv6-multi-target-srv-disabled
   records:
     _grpclb._tcp.srv-ipv6-multi-target-srv-disabled:
@@ -246,6 +264,7 @@ resolver_component_tests:
   expected_chosen_service_config: '{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}'
   expected_lb_policy: round_robin
   enable_srv_queries: false
+  enable_txt_queries: true
   record_to_resolve: srv-ipv4-simple-service-config-srv-disabled
   records:
     _grpclb._tcp.srv-ipv4-simple-service-config-srv-disabled:
@@ -256,4 +275,45 @@ resolver_component_tests:
     - {TTL: '2100', data: 5.5.3.4, type: A}
     _grpc_config.srv-ipv4-simple-service-config-srv-disabled:
     - {TTL: '2100', data: 'grpc_config=[{"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}}]',
+      type: TXT}
+- expected_addrs:
+  - {address: '1.2.3.4:1234', is_balancer: true}
+  expected_chosen_service_config: null
+  expected_lb_policy: null
+  enable_srv_queries: true
+  enable_txt_queries: false
+  record_to_resolve: srv-ipv4-simple-service-config-txt-disabled
+  records:
+    _grpclb._tcp.srv-ipv4-simple-service-config-txt-disabled:
+    - {TTL: '2100', data: 0 0 1234 ipv4-simple-service-config-txt-disabled, type: SRV}
+    ipv4-simple-service-config-txt-disabled:
+    - {TTL: '2100', data: 1.2.3.4, type: A}
+    _grpc_config.srv-ipv4-simple-service-config-txt-disabled:
+    - {TTL: '2100', data: 'grpc_config=[{"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"SimpleService","waitForReady":true}]}]}}]',
+      type: TXT}
+- expected_addrs:
+  - {address: '1.2.3.4:443', is_balancer: false}
+  expected_chosen_service_config: null
+  expected_lb_policy: null
+  enable_srv_queries: true
+  enable_txt_queries: false
+  record_to_resolve: ipv4-cpp-config-has-zero-percentage-txt-disabled
+  records:
+    ipv4-cpp-config-has-zero-percentage-txt-disabled:
+    - {TTL: '2100', data: 1.2.3.4, type: A}
+    _grpc_config.ipv4-cpp-config-has-zero-percentage-txt-disabled:
+    - {TTL: '2100', data: 'grpc_config=[{"percentage":0,"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}}]',
+      type: TXT}
+- expected_addrs:
+  - {address: '1.2.3.4:443', is_balancer: false}
+  expected_chosen_service_config: null
+  expected_lb_policy: null
+  enable_srv_queries: true
+  enable_txt_queries: false
+  record_to_resolve: ipv4-second-language-is-cpp-txt-disabled
+  records:
+    ipv4-second-language-is-cpp-txt-disabled:
+    - {TTL: '2100', data: 1.2.3.4, type: A}
+    _grpc_config.ipv4-second-language-is-cpp-txt-disabled:
+    - {TTL: '2100', data: 'grpc_config=[{"clientLanguage":["go"],"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"GoService","waitForReady":true}]}]}},{"clientLanguage":["c++"],"serviceConfig":{"loadBalancingPolicy":"round_robin","methodConfig":[{"name":[{"method":"Foo","service":"CppService","waitForReady":true}]}]}}]',
       type: TXT}


### PR DESCRIPTION
Disable TXT queries for now, at least until [service config error handling](https://github.com/grpc/proposal/pull/100) is in.

This PR sets the default value of the `grpc.service_config_disable_resolution` channel arg to `true`, <i>specifically for the c-ares DNS resolver</i> (which is now the default DNS resolver).

Note that we plan to enable TXT queries and service config resolution by default in the future. Also note that this is a breaking change for users that were previously running their binaries under `GRPC_DNS_RESOLVER=ares` env var setting and having their channels resolve service configs - to regain the same behavior with this PR, one needs to explicitly set the `grpc.service_config_disable_resolution` channel arg  to `false`.