### PR TITLE
Increase allocated space for cmsgs

### DIFF
--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -715,13 +715,15 @@ static void process_errors(grpc_tcp* tcp) {
     msg.msg_iovlen = 0;
     msg.msg_flags = 0;
 
+    /* Allocate enough space so we don't need to keep increasing this as size
+     * of OPT_STATS increase */
+    constexpr size_t cmsg_alloc_space =
+        1024 /*CMSG_SPACE(sizeof(grpc_core::scm_timestamping)) +
+                CMSG_SPACE(sizeof(sock_extended_err) + sizeof(sockaddr_in)) +
+                CMSG_SPACE(16 * NLA_ALIGN(NLA_HDRLEN + sizeof(uint64_t)))*/;
     /* Allocate aligned space for cmsgs received along with timestamps */
     union {
-      /* Allocate enough space so we don't need to keep increasing this as size
-       * of OPT_STATS increase */
-      char rbuf[1024 /*CMSG_SPACE(sizeof(grpc_core::scm_timestamping)) +
-                CMSG_SPACE(sizeof(sock_extended_err) + sizeof(sockaddr_in)) +
-                CMSG_SPACE(16 * NLA_ALIGN(NLA_HDRLEN + sizeof(uint64_t)))*/];
+      char rbuf[cmsg_alloc_space];
       struct cmsghdr align;
     } aligned_buf;
     memset(&aligned_buf, 0, sizeof(aligned_buf));

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -715,11 +715,13 @@ static void process_errors(grpc_tcp* tcp) {
     msg.msg_iovlen = 0;
     msg.msg_flags = 0;
 
-    // Allocate aligned space for cmsgs received along with a timestamps
+    /* Allocate aligned space for cmsgs received along with timestamps */
     union {
-      char rbuf[CMSG_SPACE(sizeof(grpc_core::scm_timestamping)) +
+      /* Allocate enough space so we don't need to keep increasing this as size
+       * of OPT_STATS increase */
+      char rbuf[1024 /*CMSG_SPACE(sizeof(grpc_core::scm_timestamping)) +
                 CMSG_SPACE(sizeof(sock_extended_err) + sizeof(sockaddr_in)) +
-                CMSG_SPACE(16 * NLA_ALIGN(NLA_HDRLEN + sizeof(uint64_t)))];
+                CMSG_SPACE(16 * NLA_ALIGN(NLA_HDRLEN + sizeof(uint64_t)))*/];
       struct cmsghdr align;
     } aligned_buf;
     memset(&aligned_buf, 0, sizeof(aligned_buf));
@@ -739,10 +741,8 @@ static void process_errors(grpc_tcp* tcp) {
     if (r == -1) {
       return;
     }
-    if (grpc_tcp_trace.enabled()) {
-      if ((msg.msg_flags & MSG_CTRUNC) == 1) {
-        gpr_log(GPR_INFO, "Error message was truncated.");
-      }
+    if ((msg.msg_flags & MSG_CTRUNC) == 1) {
+      gpr_log(GPR_ERROR, "Error message was truncated.");
     }
 
     if (msg.msg_controllen == 0) {

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -718,9 +718,9 @@ static void process_errors(grpc_tcp* tcp) {
     /* Allocate enough space so we don't need to keep increasing this as size
      * of OPT_STATS increase */
     constexpr size_t cmsg_alloc_space =
-        1024 /*CMSG_SPACE(sizeof(grpc_core::scm_timestamping)) +
-                CMSG_SPACE(sizeof(sock_extended_err) + sizeof(sockaddr_in)) +
-                CMSG_SPACE(16 * NLA_ALIGN(NLA_HDRLEN + sizeof(uint64_t)))*/;
+        CMSG_SPACE(sizeof(grpc_core::scm_timestamping)) +
+        CMSG_SPACE(sizeof(sock_extended_err) + sizeof(sockaddr_in)) +
+        CMSG_SPACE(32 * NLA_ALIGN(NLA_HDRLEN + sizeof(uint64_t)));
     /* Allocate aligned space for cmsgs received along with timestamps */
     union {
       char rbuf[cmsg_alloc_space];


### PR DESCRIPTION
Increase allocated space for cmsgs to a large size of 1024. (Hoping very hard that we do not exceed stack limits.) This causes issues when the size of OPT_STATS is larger than expected