### PR TITLE
Sync API doesn't support set buffer hint (except last message), so clear it on Writes

### DIFF
--- a/include/grpcpp/impl/codegen/sync_stream.h
+++ b/include/grpcpp/impl/codegen/sync_stream.h
@@ -325,6 +325,8 @@ class ClientWriter : public ClientWriterInterface<W> {
     if (options.is_last_message()) {
       options.set_buffer_hint();
       ops.ClientSendClose();
+    } else {
+      options.clear_buffer_hint();  // not supported for sync API
     }
     if (context_->initial_metadata_corked_) {
       ops.SendInitialMetadata(&context_->send_initial_metadata_,
@@ -496,6 +498,8 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
     if (options.is_last_message()) {
       options.set_buffer_hint();
       ops.ClientSendClose();
+    } else {
+      options.clear_buffer_hint();  // not supported for sync API
     }
     if (context_->initial_metadata_corked_) {
       ops.SendInitialMetadata(&context_->send_initial_metadata_,
@@ -654,8 +658,9 @@ class ServerWriter final : public ServerWriterInterface<W> {
   bool Write(const W& msg, WriteOptions options) override {
     if (options.is_last_message()) {
       options.set_buffer_hint();
+    } else {
+      options.clear_buffer_hint();  // not supported for sync API
     }
-
     if (!ctx_->pending_ops_.SendMessagePtr(&msg, options).ok()) {
       return false;
     }
@@ -733,6 +738,8 @@ class ServerReaderWriterBody final {
   bool Write(const W& msg, WriteOptions options) {
     if (options.is_last_message()) {
       options.set_buffer_hint();
+    } else {
+      options.clear_buffer_hint();  // not supported for sync API
     }
     if (!ctx_->pending_ops_.SendMessagePtr(&msg, options).ok()) {
       return false;

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -875,6 +875,25 @@ TEST_P(End2endTest, RequestStreamTwoRequests) {
   EXPECT_TRUE(s.ok());
 }
 
+// This was added to prevent regression from issue:
+// https://github.com/grpc/grpc/issues/12975
+TEST_P(End2endTest, RequestStreamTwoRequestsWithFirstWriteBufferHint) {
+  MAYBE_SKIP_TEST;
+  ResetStub();
+  EchoRequest request;
+  EchoResponse response;
+  ClientContext context;
+
+  auto stream = stub_->RequestStream(&context, &response);
+  request.set_message("hello");
+  EXPECT_TRUE(stream->Write(request, WriteOptions().set_buffer_hint()));
+  EXPECT_TRUE(stream->Write(request));
+  stream->WritesDone();
+  Status s = stream->Finish();
+  EXPECT_EQ(response.message(), "hellohello");
+  EXPECT_TRUE(s.ok());
+}
+
 TEST_P(End2endTest, RequestStreamTwoRequestsWithWriteThrough) {
   MAYBE_SKIP_TEST;
   ResetStub();

--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -470,6 +470,10 @@ Status TestServiceImpl::ResponseStream(ServerContext* context,
     response.set_message(request->message() + grpc::to_string(i));
     if (i == server_responses_to_send - 1 && server_coalescing_api != 0) {
       writer->WriteLast(response, WriteOptions());
+    } else if (i == 0 && server_coalescing_api != 0) {
+      // This code path added to prevent regression from issue:
+      // https://github.com/grpc/grpc/issues/12975
+      writer->Write(response, WriteOptions().set_buffer_hint());
     } else {
       writer->Write(response);
     }


### PR DESCRIPTION
Fixes #12975 

Confirmed that the source patch below is needed to prevent a failure on the test changes below
