### PR TITLE
Add environment markers to python version-dependent dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -298,11 +298,10 @@ PACKAGE_DIRECTORIES = {
 }
 
 INSTALL_REQUIRES = (
-    'six>=1.5.2',
+    "six>=1.5.2",
+    "futures>=2.2.0; python_version<'3.2'",
+    "enum34>=1.0.4; python_version<'3.4'",
 )
-
-if not PY3:
-  INSTALL_REQUIRES += ('futures>=2.2.0', 'enum34>=1.0.4')
 
 SETUP_REQUIRES = INSTALL_REQUIRES + (
     'Sphinx~=1.8.1',


### PR DESCRIPTION
[Several issues](https://github.com/grpc/grpc/issues/18013) and [PRs](https://github.com/grpc/grpc/pull/16235) have been raised pointing out that we currently determine whether to mark `futures` and `enum34` as dependencies based on the version of the python interpreter used to build the package. This behavior is incorrect.

[PEP 496](https://www.python.org/dev/peps/pep-0496/) describes environment markers and [PEP 508](https://www.python.org/dev/peps/pep-0508/) describes the semantics of the `python_version` environment marker, tools which allow us to mark certain dependencies as necessary only when the user's python interpreter is within a certain version range.

This appears to have been attempted at least once before, but was subsequently [reverted due to failures on mac OS.](https://github.com/grpc/grpc/pull/16285) However, this appears to be the correct approach.