### PR TITLE
Fix subchannel ref_from_weak_ref

### DIFF
--- a/src/core/ext/filters/client_channel/global_subchannel_pool.cc
+++ b/src/core/ext/filters/client_channel/global_subchannel_pool.cc
@@ -66,10 +66,13 @@ Subchannel* GlobalSubchannelPool::RegisterSubchannel(SubchannelKey* key,
     // Check to see if a subchannel already exists.
     c = static_cast<Subchannel*>(grpc_avl_get(old_map, key, nullptr));
     if (c != nullptr) {
-      // The subchannel already exists. Reuse it.
+      // The subchannel already exists. Try to reuse it.
       c = GRPC_SUBCHANNEL_REF_FROM_WEAK_REF(c, "subchannel_register+reuse");
-      GRPC_SUBCHANNEL_UNREF(constructed, "subchannel_register+found_existing");
-      // Exit the CAS loop without modifying the shared map.
+      if (c != nullptr) {
+        GRPC_SUBCHANNEL_UNREF(constructed,
+                              "subchannel_register+found_existing");
+        // Exit the CAS loop without modifying the shared map.
+      }  // Else, reuse failed, so retry CAS loop.
     } else {
       // There hasn't been such subchannel. Add one.
       // Note that we should ref the old map first because grpc_avl_add() will
@@ -128,7 +131,7 @@ Subchannel* GlobalSubchannelPool::FindSubchannel(SubchannelKey* key) {
   grpc_avl index = grpc_avl_ref(subchannel_map_, nullptr);
   gpr_mu_unlock(&mu_);
   Subchannel* c = static_cast<Subchannel*>(grpc_avl_get(index, key, nullptr));
-  if (c != nullptr) GRPC_SUBCHANNEL_REF_FROM_WEAK_REF(c, "found_from_pool");
+  if (c != nullptr) c = GRPC_SUBCHANNEL_REF_FROM_WEAK_REF(c, "found_from_pool");
   grpc_avl_unref(index, nullptr);
   return c;
 }

--- a/src/core/ext/filters/client_channel/subchannel.h
+++ b/src/core/ext/filters/client_channel/subchannel.h
@@ -189,6 +189,9 @@ class Subchannel {
   void Unref(GRPC_SUBCHANNEL_REF_EXTRA_ARGS);
   Subchannel* WeakRef(GRPC_SUBCHANNEL_REF_EXTRA_ARGS);
   void WeakUnref(GRPC_SUBCHANNEL_REF_EXTRA_ARGS);
+  // Attempts to return a strong ref when only the weak refcount is guaranteed
+  // non-zero. If the strong refcount is zero, does not alter the refcount and
+  // returns null.
   Subchannel* RefFromWeakRef(GRPC_SUBCHANNEL_REF_EXTRA_ARGS);
 
   intptr_t GetChildSocketUuid();


### PR DESCRIPTION
Fix https://github.com/grpc/grpc/issues/18008

1. #18008 is caused by #17879. The return value of `GRPC_SUBCHANNEL_REF_FROM_WEAK_REF` shouldn't be ignored. After this bug is fixed, `GRPC_VERBOSITY=DEBUG GRPC_TRACE=pick_first tools/run_tests/run_tests.py -l c -c tsan -r "concurrent_connectivity_test" -n inf -S` can pass >=132 runs. Previously the flakiness is `FLAKE: bins/tsan/concurrent_connectivity_test GRPC_POLL_STRATEGY=epollex [1/6 runs flaked]`.

2. Also fixed a bug caused by #17513. If we find an existing subchannel in the pool but it's shut down and will be destroyed soon, we shouldn't unref the newly created subchannel. Otherwise, I can imagine that there will be some other use-after-free bug when we want to register the new subchannel in the next iteration. 