### PR TITLE
Run android interop test on a physical device

### DIFF
--- a/src/android/test/interop/app/build.gradle
+++ b/src/android/test/interop/app/build.gradle
@@ -29,7 +29,6 @@ android {
                 arguments '-DgRPC_CPP_PLUGIN_EXECUTABLE=' + grpc_cpp_plugin
             }
         }
-        ndk.abiFilters 'x86'
     }
     buildTypes {
         debug {

--- a/tools/internal_ci/linux/grpc_android.sh
+++ b/tools/internal_ci/linux/grpc_android.sh
@@ -44,7 +44,8 @@ gcloud firebase test android run \
     --device model=Nexus6P,version=24,locale=en,orientation=portrait \
     --device model=Nexus6P,version=23,locale=en,orientation=portrait \
     --device model=Nexus6,version=22,locale=en,orientation=portrait \
-    --device model=Nexus6,version=21,locale=en,orientation=portrait
+    --device model=Nexus6,version=21,locale=en,orientation=portrait \
+    --device model=walleye,version=28,locale=en,orientation=portrait
 
 
 # Build hello world example


### PR DESCRIPTION
This will help catch bugs that only show up on real devices but not emulators, e.g., https://github.com/grpc/grpc/issues/18038.

Sample output:

```
More details are available at [https://console.firebase.google.com/project/grpc-testing/testlab/histories/bh.81c66b2d50e9b941/matrices/5023769035144026546].
┌─────────┬────────────────────────┬─────────────────────┐
│ OUTCOME │    TEST_AXIS_VALUE     │     TEST_DETAILS    │
├─────────┼────────────────────────┼─────────────────────┤
│ Failed  │ walleye-28-en-portrait │ 1 test cases failed │
│ Passed  │ Nexus6-21-en-portrait  │ 6 test cases passed │
│ Passed  │ Nexus6-22-en-portrait  │ 6 test cases passed │
│ Passed  │ Nexus6P-23-en-portrait │ 6 test cases passed │
│ Passed  │ Nexus6P-24-en-portrait │ 6 test cases passed │
│ Passed  │ Nexus6P-25-en-portrait │ 6 test cases passed │
│ Passed  │ Nexus6P-26-en-portrait │ 6 test cases passed │
│ Passed  │ Nexus6P-27-en-portrait │ 6 test cases passed │
└─────────┴────────────────────────┴─────────────────────┘
```

The failure on the physical device is due to https://github.com/grpc/grpc/issues/18038. 