### PR TITLE
Pass WSA_FLAG_NO_HANDLE_INHERIT flag to the WSASocketA() to avoid handle leaking on the Windows in case of using CreateProcess() on the server

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -442,7 +442,9 @@ class SockToPolledFdMap {
    */
   static ares_socket_t Socket(int af, int type, int protocol, void* user_data) {
     SockToPolledFdMap* map = static_cast<SockToPolledFdMap*>(user_data);
-    SOCKET s = grpc_create_wsa_socket(af, type, protocol, nullptr, 0, WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+    SOCKET s = grpc_create_wsa_socket(
+        af, type, protocol, nullptr, 0,
+        WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
     if (s == INVALID_SOCKET) {
       return s;
     }

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -442,7 +442,7 @@ class SockToPolledFdMap {
    */
   static ares_socket_t Socket(int af, int type, int protocol, void* user_data) {
     SockToPolledFdMap* map = static_cast<SockToPolledFdMap*>(user_data);
-    SOCKET s = WSASocket(af, type, protocol, nullptr, 0, WSA_FLAG_OVERLAPPED);
+    SOCKET s = grpc_create_wsa_socket(af, type, protocol, nullptr, 0, WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
     if (s == INVALID_SOCKET) {
       return s;
     }

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -442,7 +442,8 @@ class SockToPolledFdMap {
    */
   static ares_socket_t Socket(int af, int type, int protocol, void* user_data) {
     SockToPolledFdMap* map = static_cast<SockToPolledFdMap*>(user_data);
-    SOCKET s = WSASocket(af, type, protocol, nullptr, 0, grpc_wsa_socket_flags);
+    SOCKET s = WSASocket(af, type, protocol, nullptr, 0,
+                         grpc_get_default_wsa_socket_flags());
     if (s == INVALID_SOCKET) {
       return s;
     }

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -442,9 +442,7 @@ class SockToPolledFdMap {
    */
   static ares_socket_t Socket(int af, int type, int protocol, void* user_data) {
     SockToPolledFdMap* map = static_cast<SockToPolledFdMap*>(user_data);
-    SOCKET s = grpc_create_wsa_socket(
-        af, type, protocol, nullptr, 0,
-        WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+    SOCKET s = WSASocket(af, type, protocol, nullptr, 0, grpc_wsa_socket_flags);
     if (s == INVALID_SOCKET) {
       return s;
     }

--- a/src/core/lib/iomgr/endpoint_pair_windows.cc
+++ b/src/core/lib/iomgr/endpoint_pair_windows.cc
@@ -40,8 +40,8 @@ static void create_sockets(SOCKET sv[2]) {
   SOCKADDR_IN addr;
   int addr_len = sizeof(addr);
 
-  lst_sock = WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                       WSA_FLAG_OVERLAPPED);
+  lst_sock = grpc_create_wsa_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                       WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
   GPR_ASSERT(lst_sock != INVALID_SOCKET);
 
   memset(&addr, 0, sizeof(addr));
@@ -53,8 +53,8 @@ static void create_sockets(SOCKET sv[2]) {
   GPR_ASSERT(getsockname(lst_sock, (grpc_sockaddr*)&addr, &addr_len) !=
              SOCKET_ERROR);
 
-  cli_sock = WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                       WSA_FLAG_OVERLAPPED);
+  cli_sock = grpc_create_wsa_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                       WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
   GPR_ASSERT(cli_sock != INVALID_SOCKET);
 
   GPR_ASSERT(WSAConnect(cli_sock, (grpc_sockaddr*)&addr, addr_len, NULL, NULL,

--- a/src/core/lib/iomgr/endpoint_pair_windows.cc
+++ b/src/core/lib/iomgr/endpoint_pair_windows.cc
@@ -41,7 +41,7 @@ static void create_sockets(SOCKET sv[2]) {
   int addr_len = sizeof(addr);
 
   lst_sock = WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                       grpc_wsa_socket_flags);
+                       grpc_get_default_wsa_socket_flags());
   GPR_ASSERT(lst_sock != INVALID_SOCKET);
 
   memset(&addr, 0, sizeof(addr));
@@ -54,7 +54,7 @@ static void create_sockets(SOCKET sv[2]) {
              SOCKET_ERROR);
 
   cli_sock = WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                       grpc_wsa_socket_flags);
+                       grpc_get_default_wsa_socket_flags());
   GPR_ASSERT(cli_sock != INVALID_SOCKET);
 
   GPR_ASSERT(WSAConnect(cli_sock, (grpc_sockaddr*)&addr, addr_len, NULL, NULL,

--- a/src/core/lib/iomgr/endpoint_pair_windows.cc
+++ b/src/core/lib/iomgr/endpoint_pair_windows.cc
@@ -40,8 +40,9 @@ static void create_sockets(SOCKET sv[2]) {
   SOCKADDR_IN addr;
   int addr_len = sizeof(addr);
 
-  lst_sock = grpc_create_wsa_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                       WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+  lst_sock =
+      grpc_create_wsa_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                             WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
   GPR_ASSERT(lst_sock != INVALID_SOCKET);
 
   memset(&addr, 0, sizeof(addr));
@@ -53,8 +54,9 @@ static void create_sockets(SOCKET sv[2]) {
   GPR_ASSERT(getsockname(lst_sock, (grpc_sockaddr*)&addr, &addr_len) !=
              SOCKET_ERROR);
 
-  cli_sock = grpc_create_wsa_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                       WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+  cli_sock =
+      grpc_create_wsa_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                             WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
   GPR_ASSERT(cli_sock != INVALID_SOCKET);
 
   GPR_ASSERT(WSAConnect(cli_sock, (grpc_sockaddr*)&addr, addr_len, NULL, NULL,

--- a/src/core/lib/iomgr/endpoint_pair_windows.cc
+++ b/src/core/lib/iomgr/endpoint_pair_windows.cc
@@ -40,9 +40,8 @@ static void create_sockets(SOCKET sv[2]) {
   SOCKADDR_IN addr;
   int addr_len = sizeof(addr);
 
-  lst_sock =
-      grpc_create_wsa_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                             WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+  lst_sock = WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                       grpc_wsa_socket_flags);
   GPR_ASSERT(lst_sock != INVALID_SOCKET);
 
   memset(&addr, 0, sizeof(addr));
@@ -54,9 +53,8 @@ static void create_sockets(SOCKET sv[2]) {
   GPR_ASSERT(getsockname(lst_sock, (grpc_sockaddr*)&addr, &addr_len) !=
              SOCKET_ERROR);
 
-  cli_sock =
-      grpc_create_wsa_socket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                             WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+  cli_sock = WSASocket(AF_INET, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                       grpc_wsa_socket_flags);
   GPR_ASSERT(cli_sock != INVALID_SOCKET);
 
   GPR_ASSERT(WSAConnect(cli_sock, (grpc_sockaddr*)&addr, addr_len, NULL, NULL,

--- a/src/core/lib/iomgr/iomgr_windows.cc
+++ b/src/core/lib/iomgr/iomgr_windows.cc
@@ -61,6 +61,7 @@ static void iomgr_platform_init(void) {
   winsock_init();
   grpc_iocp_init();
   grpc_pollset_global_init();
+  grpc_wsa_socket_flags_init();
 }
 
 static void iomgr_platform_flush(void) { grpc_iocp_flush(); }

--- a/src/core/lib/iomgr/socket_windows.cc
+++ b/src/core/lib/iomgr/socket_windows.cc
@@ -39,6 +39,8 @@
 #include "src/core/lib/iomgr/sockaddr_windows.h"
 #include "src/core/lib/iomgr/socket_windows.h"
 
+DWORD grpc_wsa_socket_flags;
+
 grpc_winsocket* grpc_winsocket_create(SOCKET socket, const char* name) {
   char* final_name;
   grpc_winsocket* r = (grpc_winsocket*)gpr_malloc(sizeof(grpc_winsocket));

--- a/src/core/lib/iomgr/socket_windows.cc
+++ b/src/core/lib/iomgr/socket_windows.cc
@@ -181,23 +181,22 @@ int grpc_ipv6_loopback_available(void) {
   return g_ipv6_loopback_available;
 }
 
-SOCKET grpc_create_wsa_socket(int family,
-                              int type,
-                              int protocol,
-                              LPWSAPROTOCOL_INFO protocol_info,
-                              GROUP group,
+SOCKET grpc_create_wsa_socket(int family, int type, int protocol,
+                              LPWSAPROTOCOL_INFO protocol_info, GROUP group,
                               DWORD flags) {
   bool is_wsa_no_handle_inherit_set = flags & WSA_FLAG_NO_HANDLE_INHERIT;
   if (!g_is_wsa_no_handle_inherit_supported && is_wsa_no_handle_inherit_set) {
     flags ^= WSA_FLAG_NO_HANDLE_INHERIT;
   }
   SOCKET sock = WSASocket(family, type, protocol, protocol_info, group, flags);
-  /* WSA_FLAG_NO_HANDLE_INHERIT may be not supported on the older Windows versions, see
+  /* WSA_FLAG_NO_HANDLE_INHERIT may be not supported on the older Windows
+     versions, see
      https://msdn.microsoft.com/en-us/library/windows/desktop/ms742212(v=vs.85).aspx
      for details. */
   if (sock == INVALID_SOCKET && is_wsa_no_handle_inherit_set) {
     g_is_wsa_no_handle_inherit_supported = false;
-    sock = WSASocket(family, type, protocol, protocol_info, group, flags ^ WSA_FLAG_NO_HANDLE_INHERIT);
+    sock = WSASocket(family, type, protocol, protocol_info, group,
+                     flags ^ WSA_FLAG_NO_HANDLE_INHERIT);
   }
   return sock;
 }

--- a/src/core/lib/iomgr/socket_windows.cc
+++ b/src/core/lib/iomgr/socket_windows.cc
@@ -39,7 +39,7 @@
 #include "src/core/lib/iomgr/sockaddr_windows.h"
 #include "src/core/lib/iomgr/socket_windows.h"
 
-DWORD grpc_wsa_socket_flags;
+static DWORD s_wsa_socket_flags;
 
 grpc_winsocket* grpc_winsocket_create(SOCKET socket, const char* name) {
   char* final_name;
@@ -183,19 +183,19 @@ int grpc_ipv6_loopback_available(void) {
   return g_ipv6_loopback_available;
 }
 
-DWORD grpc_get_default_wsa_socket_flags() { return grpc_wsa_socket_flags; }
+DWORD grpc_get_default_wsa_socket_flags() { return s_wsa_socket_flags; }
 
 void grpc_wsa_socket_flags_init() {
-  grpc_wsa_socket_flags = WSA_FLAG_OVERLAPPED;
+  s_wsa_socket_flags = WSA_FLAG_OVERLAPPED;
   /* WSA_FLAG_NO_HANDLE_INHERIT may be not supported on the older Windows
      versions, see
      https://msdn.microsoft.com/en-us/library/windows/desktop/ms742212(v=vs.85).aspx
      for details. */
   SOCKET sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                          grpc_wsa_socket_flags | WSA_FLAG_NO_HANDLE_INHERIT);
+                          s_wsa_socket_flags | WSA_FLAG_NO_HANDLE_INHERIT);
   if (sock != INVALID_SOCKET) {
     /* Windows 7, Windows 2008 R2 with SP1 or later */
-    grpc_wsa_socket_flags |= WSA_FLAG_NO_HANDLE_INHERIT;
+    s_wsa_socket_flags |= WSA_FLAG_NO_HANDLE_INHERIT;
     closesocket(sock);
   }
 }

--- a/src/core/lib/iomgr/socket_windows.cc
+++ b/src/core/lib/iomgr/socket_windows.cc
@@ -183,13 +183,15 @@ int grpc_ipv6_loopback_available(void) {
   return g_ipv6_loopback_available;
 }
 
+DWORD grpc_get_default_wsa_socket_flags() { return grpc_wsa_socket_flags; }
+
 void grpc_wsa_socket_flags_init() {
   grpc_wsa_socket_flags = WSA_FLAG_OVERLAPPED;
   /* WSA_FLAG_NO_HANDLE_INHERIT may be not supported on the older Windows
      versions, see
      https://msdn.microsoft.com/en-us/library/windows/desktop/ms742212(v=vs.85).aspx
      for details. */
-  SOCKET sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, 0, NULL,
+  SOCKET sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
                           grpc_wsa_socket_flags | WSA_FLAG_NO_HANDLE_INHERIT);
   if (sock != INVALID_SOCKET) {
     /* Windows 7, Windows 2008 R2 with SP1 or later */

--- a/src/core/lib/iomgr/socket_windows.cc
+++ b/src/core/lib/iomgr/socket_windows.cc
@@ -184,7 +184,7 @@ int grpc_ipv6_loopback_available(void) {
 SOCKET grpc_create_wsa_socket(int family,
                               int type,
                               int protocol,
-                              LPWSAPROTOCOL_INFOA protocol_info,
+                              LPWSAPROTOCOL_INFO protocol_info,
                               GROUP group,
                               DWORD flags) {
   bool is_wsa_no_handle_inherit_set = flags & WSA_FLAG_NO_HANDLE_INHERIT;

--- a/src/core/lib/iomgr/socket_windows.cc
+++ b/src/core/lib/iomgr/socket_windows.cc
@@ -188,10 +188,10 @@ void grpc_wsa_socket_flags_init() {
      https://msdn.microsoft.com/en-us/library/windows/desktop/ms742212(v=vs.85).aspx
      for details. */
   SOCKET sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, 0, NULL,
-                          grpc_wsa_socket_flags & WSA_FLAG_NO_HANDLE_INHERIT);
+                          grpc_wsa_socket_flags | WSA_FLAG_NO_HANDLE_INHERIT);
   if (sock != INVALID_SOCKET) {
     /* Windows 7, Windows 2008 R2 with SP1 or later */
-    grpc_wsa_socket_flags &= WSA_FLAG_NO_HANDLE_INHERIT;
+    grpc_wsa_socket_flags |= WSA_FLAG_NO_HANDLE_INHERIT;
     closesocket(sock);
   }
 }

--- a/src/core/lib/iomgr/socket_windows.h
+++ b/src/core/lib/iomgr/socket_windows.h
@@ -114,6 +114,15 @@ void grpc_socket_become_ready(grpc_winsocket* winsocket,
    The value is probed once, and cached for the life of the process. */
 int grpc_ipv6_loopback_available(void);
 
+static bool g_is_wsa_no_handle_inherit_supported = true;
+
+SOCKET grpc_create_wsa_socket(int family,
+                              int type,
+                              int protocol,
+                              LPWSAPROTOCOL_INFOA protocol_info,
+                              GROUP group,
+                              DWORD flags);
+
 #endif
 
 #endif /* GRPC_CORE_LIB_IOMGR_SOCKET_WINDOWS_H */

--- a/src/core/lib/iomgr/socket_windows.h
+++ b/src/core/lib/iomgr/socket_windows.h
@@ -118,11 +118,9 @@ void grpc_socket_become_ready(grpc_winsocket* winsocket,
    The value is probed once, and cached for the life of the process. */
 int grpc_ipv6_loopback_available(void);
 
-static bool g_is_wsa_no_handle_inherit_supported = true;
+static DWORD grpc_wsa_socket_flags = 0;
 
-SOCKET grpc_create_wsa_socket(int family, int type, int protocol,
-                              LPWSAPROTOCOL_INFO protocol_info, GROUP group,
-                              DWORD flags);
+void grpc_wsa_socket_flags_init();
 
 #endif
 

--- a/src/core/lib/iomgr/socket_windows.h
+++ b/src/core/lib/iomgr/socket_windows.h
@@ -120,11 +120,8 @@ int grpc_ipv6_loopback_available(void);
 
 static bool g_is_wsa_no_handle_inherit_supported = true;
 
-SOCKET grpc_create_wsa_socket(int family,
-                              int type,
-                              int protocol,
-                              LPWSAPROTOCOL_INFO protocol_info,
-                              GROUP group,
+SOCKET grpc_create_wsa_socket(int family, int type, int protocol,
+                              LPWSAPROTOCOL_INFO protocol_info, GROUP group,
                               DWORD flags);
 
 #endif

--- a/src/core/lib/iomgr/socket_windows.h
+++ b/src/core/lib/iomgr/socket_windows.h
@@ -118,8 +118,6 @@ void grpc_socket_become_ready(grpc_winsocket* winsocket,
    The value is probed once, and cached for the life of the process. */
 int grpc_ipv6_loopback_available(void);
 
-extern DWORD grpc_wsa_socket_flags;
-
 void grpc_wsa_socket_flags_init();
 
 DWORD grpc_get_default_wsa_socket_flags();

--- a/src/core/lib/iomgr/socket_windows.h
+++ b/src/core/lib/iomgr/socket_windows.h
@@ -32,6 +32,10 @@
 #include "src/core/lib/iomgr/closure.h"
 #include "src/core/lib/iomgr/iomgr_internal.h"
 
+#ifndef WSA_FLAG_NO_HANDLE_INHERIT
+#define WSA_FLAG_NO_HANDLE_INHERIT 0x80
+#endif
+
 /* This holds the data for an outstanding read or write on a socket.
    The mutex to protect the concurrent access to that data is the one
    inside the winsocket wrapper. */

--- a/src/core/lib/iomgr/socket_windows.h
+++ b/src/core/lib/iomgr/socket_windows.h
@@ -122,6 +122,8 @@ extern DWORD grpc_wsa_socket_flags;
 
 void grpc_wsa_socket_flags_init();
 
+DWORD grpc_get_default_wsa_socket_flags();
+
 #endif
 
 #endif /* GRPC_CORE_LIB_IOMGR_SOCKET_WINDOWS_H */

--- a/src/core/lib/iomgr/socket_windows.h
+++ b/src/core/lib/iomgr/socket_windows.h
@@ -123,7 +123,7 @@ static bool g_is_wsa_no_handle_inherit_supported = true;
 SOCKET grpc_create_wsa_socket(int family,
                               int type,
                               int protocol,
-                              LPWSAPROTOCOL_INFOA protocol_info,
+                              LPWSAPROTOCOL_INFO protocol_info,
                               GROUP group,
                               DWORD flags);
 

--- a/src/core/lib/iomgr/socket_windows.h
+++ b/src/core/lib/iomgr/socket_windows.h
@@ -118,7 +118,7 @@ void grpc_socket_become_ready(grpc_winsocket* winsocket,
    The value is probed once, and cached for the life of the process. */
 int grpc_ipv6_loopback_available(void);
 
-static DWORD grpc_wsa_socket_flags = 0;
+extern DWORD grpc_wsa_socket_flags;
 
 void grpc_wsa_socket_flags_init();
 

--- a/src/core/lib/iomgr/tcp_client_windows.cc
+++ b/src/core/lib/iomgr/tcp_client_windows.cc
@@ -147,8 +147,9 @@ static void tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
     addr = &addr6_v4mapped;
   }
 
-  sock = grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                   WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+  sock =
+      grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                             WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
     goto failure;

--- a/src/core/lib/iomgr/tcp_client_windows.cc
+++ b/src/core/lib/iomgr/tcp_client_windows.cc
@@ -147,9 +147,8 @@ static void tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
     addr = &addr6_v4mapped;
   }
 
-  sock =
-      grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                             WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+  sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                   grpc_wsa_socket_flags);
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
     goto failure;

--- a/src/core/lib/iomgr/tcp_client_windows.cc
+++ b/src/core/lib/iomgr/tcp_client_windows.cc
@@ -147,8 +147,8 @@ static void tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
     addr = &addr6_v4mapped;
   }
 
-  sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                   WSA_FLAG_OVERLAPPED);
+  sock = grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                   WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
     goto failure;

--- a/src/core/lib/iomgr/tcp_client_windows.cc
+++ b/src/core/lib/iomgr/tcp_client_windows.cc
@@ -148,7 +148,7 @@ static void tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
   }
 
   sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                   grpc_wsa_socket_flags);
+                   grpc_get_default_wsa_socket_flags());
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
     goto failure;

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -254,9 +254,8 @@ static grpc_error* start_accept_locked(grpc_tcp_listener* port) {
     return GRPC_ERROR_NONE;
   }
 
-  sock =
-      grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                             WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+  sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                   grpc_wsa_socket_flags);
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
     goto failure;
@@ -493,9 +492,8 @@ static grpc_error* tcp_server_add_port(grpc_tcp_server* s,
     addr = &wildcard;
   }
 
-  sock =
-      grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                             WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+  sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                   grpc_wsa_socket_flags);
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
     goto done;

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -255,7 +255,7 @@ static grpc_error* start_accept_locked(grpc_tcp_listener* port) {
   }
 
   sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                   grpc_wsa_socket_flags);
+                   grpc_get_default_wsa_socket_flags());
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
     goto failure;
@@ -493,7 +493,7 @@ static grpc_error* tcp_server_add_port(grpc_tcp_server* s,
   }
 
   sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                   grpc_wsa_socket_flags);
+                   grpc_get_default_wsa_socket_flags());
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
     goto done;

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -255,7 +255,7 @@ static grpc_error* start_accept_locked(grpc_tcp_listener* port) {
   }
 
   sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                   WSA_FLAG_OVERLAPPED);
+                   WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
     goto failure;
@@ -493,7 +493,7 @@ static grpc_error* tcp_server_add_port(grpc_tcp_server* s,
   }
 
   sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                   WSA_FLAG_OVERLAPPED);
+                   WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
     goto done;

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -254,7 +254,7 @@ static grpc_error* start_accept_locked(grpc_tcp_listener* port) {
     return GRPC_ERROR_NONE;
   }
 
-  sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+  sock = grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
                    WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
@@ -492,7 +492,7 @@ static grpc_error* tcp_server_add_port(grpc_tcp_server* s,
     addr = &wildcard;
   }
 
-  sock = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+  sock = grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
                    WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");

--- a/src/core/lib/iomgr/tcp_server_windows.cc
+++ b/src/core/lib/iomgr/tcp_server_windows.cc
@@ -254,8 +254,9 @@ static grpc_error* start_accept_locked(grpc_tcp_listener* port) {
     return GRPC_ERROR_NONE;
   }
 
-  sock = grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                   WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+  sock =
+      grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                             WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
     goto failure;
@@ -492,8 +493,9 @@ static grpc_error* tcp_server_add_port(grpc_tcp_server* s,
     addr = &wildcard;
   }
 
-  sock = grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
-                   WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+  sock =
+      grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, NULL, 0,
+                             WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
   if (sock == INVALID_SOCKET) {
     error = GRPC_WSA_ERROR(WSAGetLastError(), "WSASocket");
     goto done;

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -279,8 +279,8 @@ void OpenAndCloseSocketsStressLoop(int dummy_port, gpr_event* done_ev) {
     }
     std::vector<int> sockets;
     for (size_t i = 0; i < 50; i++) {
-      SOCKET s = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, nullptr, 0,
-                           WSA_FLAG_OVERLAPPED);
+      SOCKET s = grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, nullptr, 0,
+                           WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
       ASSERT_TRUE(s != BAD_SOCKET_RETURN_VAL)
           << "Failed to create TCP ipv6 socket";
       gpr_log(GPR_DEBUG, "Opened socket: %d", s);

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -279,8 +279,9 @@ void OpenAndCloseSocketsStressLoop(int dummy_port, gpr_event* done_ev) {
     }
     std::vector<int> sockets;
     for (size_t i = 0; i < 50; i++) {
-      SOCKET s = grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, nullptr, 0,
-                           WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+      SOCKET s = grpc_create_wsa_socket(
+          AF_INET6, SOCK_STREAM, IPPROTO_TCP, nullptr, 0,
+          WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
       ASSERT_TRUE(s != BAD_SOCKET_RETURN_VAL)
           << "Failed to create TCP ipv6 socket";
       gpr_log(GPR_DEBUG, "Opened socket: %d", s);

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -279,8 +279,8 @@ void OpenAndCloseSocketsStressLoop(int dummy_port, gpr_event* done_ev) {
     }
     std::vector<int> sockets;
     for (size_t i = 0; i < 50; i++) {
-      SOCKET s = grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP,
-                                        nullptr, 0, grpc_wsa_socket_flags);
+      SOCKET s = WSASocket(AF_INET6, SOCK_STREAM, IPPROTO_TCP, nullptr, 0,
+                           WSA_FLAG_OVERLAPPED);
       ASSERT_TRUE(s != BAD_SOCKET_RETURN_VAL)
           << "Failed to create TCP ipv6 socket";
       gpr_log(GPR_DEBUG, "Opened socket: %d", s);

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -279,9 +279,8 @@ void OpenAndCloseSocketsStressLoop(int dummy_port, gpr_event* done_ev) {
     }
     std::vector<int> sockets;
     for (size_t i = 0; i < 50; i++) {
-      SOCKET s = grpc_create_wsa_socket(
-          AF_INET6, SOCK_STREAM, IPPROTO_TCP, nullptr, 0,
-          WSA_FLAG_OVERLAPPED | WSA_FLAG_NO_HANDLE_INHERIT);
+      SOCKET s = grpc_create_wsa_socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP,
+                                        nullptr, 0, grpc_wsa_socket_flags);
       ASSERT_TRUE(s != BAD_SOCKET_RETURN_VAL)
           << "Failed to create TCP ipv6 socket";
       gpr_log(GPR_DEBUG, "Opened socket: %d", s);


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows/desktop/api/winsock2/nf-winsock2-wsasocketa