### PR TITLE
C++ callback API: Add support for client-side extra-reaction operations via Holds

### DIFF
--- a/test/cpp/end2end/client_callback_end2end_test.cc
+++ b/test/cpp/end2end/client_callback_end2end_test.cc
@@ -1117,6 +1117,82 @@ TEST_P(ClientCallbackEnd2endTest, UnimplementedRpc) {
   }
 }
 
+TEST_P(ClientCallbackEnd2endTest,
+       ResponseStreamExtraReactionFlowReadsUntilDone) {
+  MAYBE_SKIP_TEST;
+  ResetStub();
+  class ReadAllIncomingDataClient
+      : public grpc::experimental::ClientReadReactor<EchoResponse> {
+   public:
+    ReadAllIncomingDataClient(grpc::testing::EchoTestService::Stub* stub) {
+      request_.set_message("Hello client ");
+      stub->experimental_async()->ResponseStream(&context_, &request_, this);
+    }
+    bool WaitForReadDone() {
+      std::unique_lock<std::mutex> l(mu_);
+      while (!read_done_) {
+        read_cv_.wait(l);
+      }
+      read_done_ = false;
+      return read_ok_;
+    }
+    void Await() {
+      std::unique_lock<std::mutex> l(mu_);
+      while (!done_) {
+        done_cv_.wait(l);
+      }
+    }
+    const Status& status() {
+      std::unique_lock<std::mutex> l(mu_);
+      return status_;
+    }
+
+   private:
+    void OnReadDone(bool ok) override {
+      std::unique_lock<std::mutex> l(mu_);
+      read_ok_ = ok;
+      read_done_ = true;
+      read_cv_.notify_one();
+    }
+    void OnDone(const Status& s) override {
+      std::unique_lock<std::mutex> l(mu_);
+      done_ = true;
+      status_ = s;
+      done_cv_.notify_one();
+    }
+
+    EchoRequest request_;
+    EchoResponse response_;
+    ClientContext context_;
+    bool read_ok_ = false;
+    bool read_done_ = false;
+    std::mutex mu_;
+    std::condition_variable read_cv_;
+    std::condition_variable done_cv_;
+    bool done_ = false;
+    Status status_;
+  } client{stub_.get()};
+
+  int reads_complete = 0;
+  client.AddHold();
+  client.StartCall();
+
+  EchoResponse response;
+  bool read_ok = true;
+  while (read_ok) {
+    client.StartRead(&response);
+    read_ok = client.WaitForReadDone();
+    if (read_ok) {
+      ++reads_complete;
+    }
+  }
+  client.RemoveHold();
+  client.Await();
+
+  EXPECT_EQ(kServerDefaultResponseStreamsToSend, reads_complete);
+  EXPECT_EQ(client.status().error_code(), grpc::StatusCode::OK);
+}
+
 std::vector<TestScenario> CreateTestScenarios(bool test_insecure) {
   std::vector<TestScenario> scenarios;
   std::vector<grpc::string> credentials_types{


### PR DESCRIPTION
Streaming RPCs that will conduct extra-reaction operations must place "Hold"s on the RPC to make sure that they don't get destructured or OnDone'd before the extra-reaction operations are complete.

Review plan: This PR was de-facto pair-programmed as separate commits. I will review the changes in `test` that were written by @sheenaqotj and I'm asking @sheenaqotj to review the changes in `include` that were written by me.

