### PR TITLE
WIP: Swap in new LB policy when it's ready

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy.cc
+++ b/src/core/ext/filters/client_channel/lb_policy.cc
@@ -58,7 +58,10 @@ LoadBalancingPolicy::LoadBalancingPolicy(Args args, intptr_t initial_refcount)
     : InternallyRefCounted(&grpc_trace_lb_policy_refcount, initial_refcount),
       combiner_(GRPC_COMBINER_REF(args.combiner, "lb_policy")),
       interested_parties_(grpc_pollset_set_create()),
-      channel_control_helper_(std::move(args.channel_control_helper)) {}
+      channel_control_helper_(std::move(args.channel_control_helper)),
+      usage_status_(args.status) {
+  channel_control_helper_->set_lb_policy(this);
+}
 
 LoadBalancingPolicy::~LoadBalancingPolicy() {
   grpc_pollset_set_destroy(interested_parties_);

--- a/src/core/ext/filters/client_channel/lb_policy.cc
+++ b/src/core/ext/filters/client_channel/lb_policy.cc
@@ -28,6 +28,72 @@ grpc_core::DebugOnlyTraceFlag grpc_trace_lb_policy_refcount(
 
 namespace grpc_core {
 
+UniquePtr<LoadBalancingPolicy::Swapper>
+LoadBalancingPolicy::Swapper::CreateLocked(
+    LoadBalancingPolicy::Swapper::Args args) {
+  auto swapper = MakeUnique<Swapper>(std::move(args));
+  // If there is no pending LB policy, there is no need for any LB swapper.
+  if (swapper->new_policy_ == nullptr) return nullptr;
+  return swapper;
+}
+
+LoadBalancingPolicy::Swapper::Swapper(LoadBalancingPolicy::Swapper::Args args)
+    : old_policy_(args.old_policy),
+      interested_parties_(args.interested_parties),
+      tracer_(args.tracer) {
+  args.new_args.channel_control_helper->set_lb_swapper(this);
+  new_policy_ = LoadBalancingPolicyRegistry::CreateLoadBalancingPolicy(
+      args.new_name, std::move(args.new_args));
+  *args.new_policy = new_policy_.get();
+  if (GPR_UNLIKELY(new_policy_ == nullptr)) {
+    gpr_log(GPR_ERROR, "lb_swapper=%p: could not create LB policy \"%s\"", this,
+            args.new_name);
+    return;
+  }
+  if (tracer_->enabled()) {
+    gpr_log(GPR_INFO,
+            "lb_swapper=%p: created new pending LB policy \"%s\" (%p)", this,
+            args.new_name, new_policy_.get());
+  }
+  grpc_pollset_set_add_pollset_set(new_policy_->interested_parties(),
+                                   args.interested_parties);
+  new_policy_->ExitIdleLocked();
+  // If we don't have any existing policy yet, swap immediately.
+  if (*args.old_policy == nullptr || status_ == TO_BE_CURRENT) {
+    DoSwapLocked();
+  }
+  status_ = DETERMINED;
+}
+
+LoadBalancingPolicy::Swapper::~Swapper() {
+  if (new_policy_ != nullptr) {
+    grpc_pollset_set_del_pollset_set(new_policy_->interested_parties(),
+                                     interested_parties_);
+    new_policy_->channel_control_helper()->set_lb_swapper(nullptr);
+  }
+}
+
+void LoadBalancingPolicy::Swapper::MaybeSwap() {
+  if (status_ == TO_BE_PENDING || status_ == TO_BE_CURRENT) {
+    status_ = TO_BE_CURRENT;
+    return;
+  }
+  DoSwapLocked();
+}
+
+void LoadBalancingPolicy::Swapper::DoSwapLocked() {
+  if (*old_policy_ != nullptr) {
+    if (tracer_->enabled()) {
+      gpr_log(GPR_INFO, "lb_swapper=%p: shutting down old lb_policy=%p", this,
+              (*old_policy_).get());
+    }
+    grpc_pollset_set_del_pollset_set((*old_policy_)->interested_parties(),
+                                     interested_parties_);
+  }
+  *old_policy_ = std::move(new_policy_);
+  (*old_policy_)->channel_control_helper()->set_lb_swapper(nullptr);
+}
+
 grpc_json* LoadBalancingPolicy::ParseLoadBalancingConfig(
     const grpc_json* lb_config_array) {
   if (lb_config_array == nullptr || lb_config_array->type != GRPC_JSON_ARRAY) {
@@ -58,8 +124,7 @@ LoadBalancingPolicy::LoadBalancingPolicy(Args args, intptr_t initial_refcount)
     : InternallyRefCounted(&grpc_trace_lb_policy_refcount, initial_refcount),
       combiner_(GRPC_COMBINER_REF(args.combiner, "lb_policy")),
       interested_parties_(grpc_pollset_set_create()),
-      channel_control_helper_(std::move(args.channel_control_helper)),
-      usage_status_(args.status) {
+      channel_control_helper_(std::move(args.channel_control_helper)) {
   channel_control_helper_->set_lb_policy(this);
 }
 

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.h
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.h
@@ -130,6 +130,7 @@ class ResolvingLoadBalancingPolicy : public LoadBalancingPolicy {
 
   // Child LB policy and associated state.
   OrphanablePtr<LoadBalancingPolicy> lb_policy_;
+  OrphanablePtr<LoadBalancingPolicy> pending_lb_policy_;
 };
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.h
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.h
@@ -130,7 +130,8 @@ class ResolvingLoadBalancingPolicy : public LoadBalancingPolicy {
 
   // Child LB policy and associated state.
   OrphanablePtr<LoadBalancingPolicy> lb_policy_;
-  OrphanablePtr<LoadBalancingPolicy> pending_lb_policy_;
+  //  OrphanablePtr<LoadBalancingPolicy> pending_lb_policy_;
+  UniquePtr<LoadBalancingPolicy::Swapper> lb_swapper_;
 };
 
 }  // namespace grpc_core


### PR DESCRIPTION
I still need to clean up some code before it's reviewable. But early comments are welcome, especially because the code is more complex than expected. 

The first commit doesn't include the `Swapper` API but only uses the `ChannelControlHelper` (and some additional helper methods.) The code is complex because the LB policy may call `ChannelControlHelper::UpdateState()` while it's still being constructed, which makes swapping difficult. I'm relying on some status flag to delay such swap. I haven't thought of easier way to solve this problem.

Since the logic is not that straightforward, I choose to add the `Swapper` API. It may increase more LOC than without it, but the complex part of code is reused and the caller code will be much easier.