### PR TITLE
test C# on .NET core by default too

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -197,10 +197,21 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
         inner_jobs=inner_jobs,
         timeout_seconds=_CPP_RUNTESTS_TIMEOUT)
 
+    # C# tests on .NET desktop/mono
     test_jobs += _generate_jobs(
         languages=['csharp'],
         configs=['dbg', 'opt'],
         platforms=['linux', 'macos', 'windows'],
+        labels=['basictests', 'multilang'],
+        extra_args=extra_args,
+        inner_jobs=inner_jobs)
+    # C# tests on .NET core
+    test_jobs += _generate_jobs(
+        languages=['csharp'],
+        configs=['dbg', 'opt'],
+        platforms=['linux', 'macos', 'windows'],
+        arch='default',
+        compiler='coreclr',
         labels=['basictests', 'multilang'],
         extra_args=extra_args,
         inner_jobs=inner_jobs)
@@ -388,16 +399,6 @@ def _create_portability_test_jobs(extra_args=[],
         platforms=['linux'],
         arch='default',
         compiler='python_alpine',
-        labels=['portability', 'multilang'],
-        extra_args=extra_args,
-        inner_jobs=inner_jobs)
-
-    test_jobs += _generate_jobs(
-        languages=['csharp'],
-        configs=['dbg'],
-        platforms=['linux'],
-        arch='default',
-        compiler='coreclr',
         labels=['portability', 'multilang'],
         extra_args=extra_args,
         inner_jobs=inner_jobs)


### PR DESCRIPTION
.NET core has become the default platform for .NET, but on some platforms we were only running tests on net45.