### PR TITLE
Allow larger than 1<<14 bytes for security framing.

### DIFF
--- a/src/core/lib/security/transport/security_handshaker.cc
+++ b/src/core/lib/security/transport/security_handshaker.cc
@@ -200,8 +200,10 @@ void SecurityHandshaker::OnPeerCheckedInner(grpc_error* error) {
   }
   // Create zero-copy frame protector, if implemented.
   tsi_zero_copy_grpc_protector* zero_copy_protector = nullptr;
+  // Allow the handshaker to choose the maximum frame size it prefers.
+  size_t max_frame_size = 128 * 1024;
   tsi_result result = tsi_handshaker_result_create_zero_copy_grpc_protector(
-      handshaker_result_, nullptr, &zero_copy_protector);
+      handshaker_result_, &max_frame_size, &zero_copy_protector);
   if (result != TSI_OK && result != TSI_UNIMPLEMENTED) {
     error = grpc_set_tsi_error_result(
         GRPC_ERROR_CREATE_FROM_STATIC_STRING(


### PR DESCRIPTION
We pass `nullptr` as `max_output_protected_frame_size`, which results
in always selecting 1<<14 bytes for security frames even though
the upper transport uses a much larger frame when possible.

Simply pass max of size_t, so that the implementation uses the
maximum frame size possible.

This saves 1-3% on both cpu and latency in real application
benchmarks.