### PR TITLE
add enter_graceful_shutdown() to health service

### DIFF
--- a/src/python/grpcio_health_checking/grpc_health/v1/health.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/health.py
@@ -151,6 +151,8 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
         This should be invoked when the server is entering a graceful shutdown
         period. After this method is invoked, future attempts to set the status
         of a service will be ignored.
+
+        This is an EXPERIMENTAL API.
         """
         with self._lock:
             if self._gracefully_shutting_down:

--- a/src/python/grpcio_health_checking/grpc_health/v1/health.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/health.py
@@ -82,6 +82,7 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
         self._send_response_callbacks = {}
         self.Watch.__func__.experimental_non_blocking = experimental_non_blocking
         self.Watch.__func__.experimental_thread_pool = experimental_thread_pool
+        self._gracefully_shutting_down = False
 
     def _on_close_callback(self, send_response_callback, service):
 
@@ -135,9 +136,25 @@ class HealthServicer(_health_pb2_grpc.HealthServicer):
             the service
         """
         with self._lock:
+            if self._gracefully_shutting_down:
+                return
             self._server_status[service] = status
             if service in self._send_response_callbacks:
                 for send_response_callback in self._send_response_callbacks[
                         service]:
                     send_response_callback(
                         _health_pb2.HealthCheckResponse(status=status))
+
+    def enter_graceful_shutdown(self):
+        """Permanently sets the status of all services to NOT_SERVING.
+
+        This should be invoked when the server is entering a graceful shutdown
+        period. After this method is invoked, future attempts to set the status
+        of a service will be ignored.
+        """
+        with self._lock:
+            if self._gracefully_shutting_down:
+                return
+            for service in self._server_status:
+                self.set(service, _health_pb2.HealthCheckResponse.NOT_SERVING)  # pylint: disable=no-member
+            self._gracefully_shutting_down = True

--- a/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
+++ b/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
@@ -194,7 +194,7 @@ class BaseWatchTests(object):
             thread.join()
 
             # Wait, if necessary, for serving thread to process client cancellation
-            timeout = time.time() + test_constants.SHORT_TIMEOUT
+            timeout = time.time() + test_constants.TIME_ALLOWANCE
             while time.time(
             ) < timeout and self._servicer._send_response_callbacks[_WATCH_SERVICE]:
                 time.sleep(1)


### PR DESCRIPTION
This allows the health check service during a graceful shutdown grace period (e.g., after receiving SIGTERM) to report `NOT_SERVING` and freeze any subsequent updates to services' health status.