### PR TITLE
Avoid unused result warning

### DIFF
--- a/src/cpp/server/load_reporter/get_cpu_stats_linux.cc
+++ b/src/cpp/server/load_reporter/get_cpu_stats_linux.cc
@@ -32,7 +32,10 @@ std::pair<uint64_t, uint64_t> GetCpuStatsImpl() {
   FILE* fp;
   fp = fopen("/proc/stat", "r");
   uint64_t user, nice, system, idle;
-  fscanf(fp, "cpu %lu %lu %lu %lu", &user, &nice, &system, &idle);
+  if (fscanf(fp, "cpu %lu %lu %lu %lu", &user, &nice, &system, &idle) != 4) {
+    // Something bad happened with the information, so assume it's all invalid
+    user = nice = system = idle = 0;
+  }
   fclose(fp);
   busy = user + nice + system;
   total = busy + idle;


### PR DESCRIPTION
Ignoring the result of fscanf gives a warning on clang with bazel RBE; we've just been ignoring it.
