### PR TITLE
Support "darwin_x86_64" CPU in cares.BUILD.

### DIFF
--- a/third_party/cares/cares.BUILD
+++ b/third_party/cares/cares.BUILD
@@ -4,6 +4,11 @@ config_setting(
 )
 
 config_setting(
+    name = "darwin_x86_64",
+    values = {"cpu": "darwin_x86_64"},
+)
+
+config_setting(
     name = "windows",
     values = {"cpu": "x64_windows"},
 )
@@ -54,6 +59,7 @@ genrule(
         ":ios_armv7s": ["@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h"],
         ":ios_arm64": ["@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h"],
         ":darwin": ["@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h"],
+        ":darwin_x86_64": ["@com_github_grpc_grpc//third_party/cares:config_darwin/ares_config.h"],
         ":windows": ["@com_github_grpc_grpc//third_party/cares:config_windows/ares_config.h"],
         ":android": ["@com_github_grpc_grpc//third_party/cares:config_android/ares_config.h"],
         "//conditions:default": ["@com_github_grpc_grpc//third_party/cares:config_linux/ares_config.h"],


### PR DESCRIPTION
Bazel recognizes both "darwin" and "darwin_x86_64" as CPU values, and
the Apple Bazel rules currently recommend the latter for building
macOS targets. Until this is cleaned up, this change allows grpc to
build correctly when that configuration is used.

Fixes #17649.