### PR TITLE
Disable flaky health service test

### DIFF
--- a/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
+++ b/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
@@ -176,6 +176,7 @@ class BaseWatchTests(object):
             self.assertTrue(response_queue1.empty())
             self.assertTrue(response_queue2.empty())
 
+        @unittest.skip("https://github.com/grpc/grpc/issues/18127")
         def test_cancelled_watch_removed_from_watch_list(self):
             request = health_pb2.HealthCheckRequest(service=_WATCH_SERVICE)
             response_queue = queue.Queue()


### PR DESCRIPTION
The test has been flaky (https://github.com/grpc/grpc/issues/18127) and it seems like the assumption that the cancellation of the rendezvous will always propagate to the server context callback in a timely manner is false. The test also peeks into an internal member of the watch class, so perhaps is also a candidate for deletion, but I'll see if I can salvage it some other way.