### PR TITLE
Remove unused ChannelCredentials.c_credentials

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
@@ -53,9 +53,6 @@ cdef class ChannelCredentials:
 
   cdef grpc_channel_credentials *c(self) except *
 
-  # TODO(https://github.com/grpc/grpc/issues/12531): remove.
-  cdef grpc_channel_credentials *c_credentials
-
 
 cdef class SSLSessionCacheLRU:
 


### PR DESCRIPTION
remnant of the past not used anywhere

cc @lidizheng.