### PR TITLE
Solve current 32-bit hpack fuzz issue

### DIFF
--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -1451,7 +1451,7 @@ static grpc_error* begin_parse_string(grpc_chttp2_hpack_parser* p,
                                       const uint8_t* cur, const uint8_t* end,
                                       uint8_t binary,
                                       grpc_chttp2_hpack_parser_string* str) {
-  if (!p->huff && binary == NOT_BINARY &&
+  if ((end > cur) && !p->huff && binary == NOT_BINARY &&
       (end - cur) >= static_cast<intptr_t>(p->strlen) &&
       p->current_slice_refcount != nullptr) {
     GRPC_STATS_INC_HPACK_RECV_UNCOMPRESSED();


### PR DESCRIPTION
Fixes #18132 

@equinox1993 observed this fuzz issue on 32-bit and suggested based on stack traces that it is just a question of properly handling the cur==end case in parsing. This PR deals with that case by adding a single check for that condition.