### PR TITLE
Transition into state CONNECTING when we start name resolution

### DIFF
--- a/src/core/ext/filters/client_channel/resolving_lb_policy.cc
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.cc
@@ -218,6 +218,9 @@ void ResolvingLoadBalancingPolicy::StartResolvingLocked() {
   }
   GPR_ASSERT(!started_resolving_);
   started_resolving_ = true;
+  channel_control_helper()->UpdateState(
+      GRPC_CHANNEL_CONNECTING, GRPC_ERROR_NONE,
+      UniquePtr<SubchannelPicker>(New<QueuePicker>(Ref())));
   Ref().release();
   resolver_->NextLocked(&resolver_result_, &on_resolver_result_changed_);
 }


### PR DESCRIPTION
When the channel starts name resolution, it should transition into state CONNECTING.  We were previously failing to do that and remaining in state IDLE until after the LB policy was created, which is incorrect.

Built on #18096.