### PR TITLE
Replacing 'HTTP' by 'HTTPS' for securing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ Libraries in different languages may be in various states of development. We are
 
 | Language                | Source repo                                          |
 |-------------------------|------------------------------------------------------|
-| Java                    | [grpc-java](http://github.com/grpc/grpc-java)        |
-| Go                      | [grpc-go](http://github.com/grpc/grpc-go)            |
+| Java                    | [grpc-java](https://github.com/grpc/grpc-java)        |
+| Go                      | [grpc-go](https://github.com/grpc/grpc-go)            |
 | NodeJS                  | [grpc-node](https://github.com/grpc/grpc-node)       |
 | WebJS                   | [grpc-web](https://github.com/grpc/grpc-web)         |
 | Dart                    | [grpc-dart](https://github.com/grpc/grpc-dart)       |


### PR DESCRIPTION
Currently, when we access **github.com** with **HTTP**, it is
redirected to **HTTPS** automatically. So this commit aims to
replace **http://github.com** by **https://github.com** for security.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>