### PR TITLE
Avoid calling ares_library_init and ares_library_cleanup except for w…

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -489,7 +489,7 @@ void grpc_resolver_dns_ares_init() {
     address_sorting_init();
     grpc_error* error = grpc_ares_init();
     if (error != GRPC_ERROR_NONE) {
-      GRPC_LOG_IF_ERROR("ares_library_init() failed", error);
+      GRPC_LOG_IF_ERROR("grpc_ares_init() failed", error);
       return;
     }
     if (default_resolver == nullptr) {

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -8,11 +8,11 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software *
- * distributed under the License is distributed on an "AS IS" BASIS, * WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  *
  */
 


### PR DESCRIPTION
…indows

Also removes a global lock as the functions will only be called under grpc_init/shutdown with a lock there.

See https://www.google.com/url?q=https://c-ares.cool.haxx.narkive.com/Y4BGm68r/huge-problem-with-ares-library-init-and-ares-library-cleanup&sa=D&usg=AFQjCNFpdfPuB7kc9KiX3gZ4tEnzpyFBTQ and b/125921501 for context.
