### PR TITLE
ObjC v1.19.0 batch patch

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -1236,7 +1236,6 @@ Pod::Spec.new do |s|
                       'test/core/util/port_isolated_runtime_environment.cc',
                       'test/core/util/port_server_client.cc',
                       'test/core/util/slice_splitter.cc',
-                      'test/core/util/subprocess_posix.cc',
                       'test/core/util/subprocess_windows.cc',
                       'test/core/util/test_config.cc',
                       'test/core/util/test_lb_policies.cc',

--- a/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
+++ b/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec
@@ -101,7 +101,7 @@ Pod::Spec.new do |s|
   s.preserve_paths = plugin
 
   # Restrict the protoc version to the one supported by this plugin.
-  s.dependency '!ProtoCompiler', '3.6.0'
+  s.dependency '!ProtoCompiler', '3.6.1'
   # For the Protobuf dependency not to complain:
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'

--- a/src/objective-c/!ProtoCompiler.podspec
+++ b/src/objective-c/!ProtoCompiler.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
   # exclamation mark ensures that other "regular" pods will be able to find it as it'll be installed
   # before them.
   s.name     = '!ProtoCompiler'
-  v = '3.6.0'
+  v = '3.6.1'
   s.version  = v
   s.summary  = 'The Protobuf Compiler (protoc) generates Objective-C files from .proto files'
   s.description = <<-DESC

--- a/src/objective-c/!ProtoCompiler.podspec
+++ b/src/objective-c/!ProtoCompiler.podspec
@@ -112,6 +112,7 @@ Pod::Spec.new do |s|
   # For the Protobuf dependency not to complain:
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'
+  s.tvos.deployment_target = '10.0'
 
   # This is only for local development of protoc: If the Podfile brings this pod from a local
   # directory using `:path`, CocoaPods won't download the zip file and so the compiler won't be

--- a/src/objective-c/BoringSSL-GRPC.podspec
+++ b/src/objective-c/BoringSSL-GRPC.podspec
@@ -79,7 +79,7 @@ Pod::Spec.new do |s|
     :commit => "b29b21a81b32ec273f118f589f46d56ad3332420",
   }
 
-  s.ios.deployment_target = '5.0'
+  s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.7'
   s.tvos.deployment_target = '10.0'
 

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -61,6 +61,8 @@
   def grpc_test_util_files(libs):
     out = grpc_lib_files(libs, ("grpc_test_util",), ("src", "headers"))
     excl = grpc_private_files(libs)
+    # Subprocess is not supported in tvOS and not needed by our tests.
+    excl += ["test/core/util/subprocess_posix.cc"]
     return [file for file in out if not file in excl]
 
   def end2end_tests_files(libs):

--- a/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
+++ b/templates/src/objective-c/!ProtoCompiler-gRPCPlugin.podspec.template
@@ -103,7 +103,7 @@
     s.preserve_paths = plugin
 
     # Restrict the protoc version to the one supported by this plugin.
-    s.dependency '!ProtoCompiler', '3.6.0'
+    s.dependency '!ProtoCompiler', '3.6.1'
     # For the Protobuf dependency not to complain:
     s.ios.deployment_target = '7.0'
     s.osx.deployment_target = '10.9'

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -84,7 +84,7 @@
       :commit => "b29b21a81b32ec273f118f589f46d56ad3332420",
     }
 
-    s.ios.deployment_target = '5.0'
+    s.ios.deployment_target = '7.0'
     s.osx.deployment_target = '10.7'
     s.tvos.deployment_target = '10.0'
 


### PR DESCRIPTION
A bunch of patches are needed for v1.19.0 release:
* Bump up `!ProtoCompiler.podspec` version since the `third_party/protobuf` dependency version was updated
* Remove `test/core/util/subprocess_posix.cc` from gRPC-Core because 1) it is not used for objc tests and 2) it invokes prohibited functions `fork()` on tvOS
* Add tvos deployment target to `src/objective-c/!ProtoCompiler.podspec` which was missing in the previous PR
* Increase BoringSSL iOS deployment target to 7.0 because 1) only gRPC pods uses this podspec, 2) other pods only deploy to iOS 7.0+, and 3) using 5.0 creates some issues in certain build environments