### PR TITLE
Datetimeoffset deadline

### DIFF
--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -467,7 +467,7 @@ void GenerateClientStub(Printer* out, const ServiceDescriptor* service) {
       out->Print(
           "public virtual $response$ $methodname$($request$ request, "
           "grpc::Metadata "
-          "headers = null, global::System.DateTime? deadline = null, "
+          "headers = null, global::System.DateTimeOffset? deadline = null, "
           "global::System.Threading.CancellationToken "
           "cancellationToken = "
           "default(global::System.Threading.CancellationToken))\n",
@@ -510,7 +510,7 @@ void GenerateClientStub(Printer* out, const ServiceDescriptor* service) {
     out->Print(
         "public virtual $returntype$ "
         "$methodname$($request_maybe$grpc::Metadata "
-        "headers = null, global::System.DateTime? deadline = null, "
+        "headers = null, global::System.DateTimeOffset? deadline = null, "
         "global::System.Threading.CancellationToken "
         "cancellationToken = "
         "default(global::System.Threading.CancellationToken))\n",

--- a/src/csharp/Grpc.Core.Api/ServerCallContext.cs
+++ b/src/csharp/Grpc.Core.Api/ServerCallContext.cs
@@ -64,7 +64,7 @@ namespace Grpc.Core
         public string Peer => PeerCore;
 
         /// <summary>Deadline for this RPC.</summary>
-        public DateTime Deadline => DeadlineCore;
+        public DateTimeOffset Deadline => DeadlineCore;
 
         /// <summary>Initial metadata sent by client.</summary>
         public Metadata RequestHeaders => RequestHeadersCore;
@@ -124,7 +124,7 @@ namespace Grpc.Core
         /// <summary>Provides implementation of a non-virtual public member.</summary>
         protected abstract string PeerCore { get; }
         /// <summary>Provides implementation of a non-virtual public member.</summary>
-        protected abstract DateTime DeadlineCore { get; }
+        protected abstract DateTimeOffset DeadlineCore { get; }
         /// <summary>Provides implementation of a non-virtual public member.</summary>
         protected abstract Metadata RequestHeadersCore { get; }
         /// <summary>Provides implementation of a non-virtual public member.</summary>

--- a/src/csharp/Grpc.Core.Testing/TestServerCallContext.cs
+++ b/src/csharp/Grpc.Core.Testing/TestServerCallContext.cs
@@ -31,7 +31,7 @@ namespace Grpc.Core.Testing
         /// Creates a test double for <c>ServerCallContext</c>. Only for testing.
         /// Note: experimental API that can change or be removed without any prior notice.
         /// </summary>
-        public static ServerCallContext Create(string method, string host, DateTime deadline, Metadata requestHeaders, CancellationToken cancellationToken,
+        public static ServerCallContext Create(string method, string host, DateTimeOffset deadline, Metadata requestHeaders, CancellationToken cancellationToken,
             string peer, AuthContext authContext, ContextPropagationToken contextPropagationToken,
             Func<Metadata, Task> writeHeadersFunc, Func<WriteOptions> writeOptionsGetter, Action<WriteOptions> writeOptionsSetter)
         {
@@ -43,7 +43,7 @@ namespace Grpc.Core.Testing
         {
             private readonly string method;
             private readonly string host;
-            private readonly DateTime deadline;
+            private readonly DateTimeOffset deadline;
             private readonly Metadata requestHeaders;
             private readonly CancellationToken cancellationToken;
             private readonly Metadata responseTrailers = new Metadata();
@@ -55,7 +55,7 @@ namespace Grpc.Core.Testing
             private readonly Func<WriteOptions> writeOptionsGetter;
             private readonly Action<WriteOptions> writeOptionsSetter;
 
-            public TestingServerCallContext(string method, string host, DateTime deadline, Metadata requestHeaders, CancellationToken cancellationToken,
+            public TestingServerCallContext(string method, string host, DateTimeOffset deadline, Metadata requestHeaders, CancellationToken cancellationToken,
                 string peer, AuthContext authContext, ContextPropagationToken contextPropagationToken,
                 Func<Metadata, Task> writeHeadersFunc, Func<WriteOptions> writeOptionsGetter, Action<WriteOptions> writeOptionsSetter)
             {
@@ -80,7 +80,7 @@ namespace Grpc.Core.Testing
 
             protected override string PeerCore => peer;
 
-            protected override DateTime DeadlineCore => deadline;
+            protected override DateTimeOffset DeadlineCore => deadline;
 
             protected override Metadata RequestHeadersCore => requestHeaders;
 

--- a/src/csharp/Grpc.Core.Tests/CallOptionsTest.cs
+++ b/src/csharp/Grpc.Core.Tests/CallOptionsTest.cs
@@ -36,7 +36,7 @@ namespace Grpc.Core.Tests
             var metadata = new Metadata();
             Assert.AreSame(metadata, options.WithHeaders(metadata).Headers);
 
-            var deadline = DateTime.UtcNow;
+            var deadline = DateTimeOffset.UtcNow;
             Assert.AreEqual(deadline, options.WithDeadline(deadline).Deadline.Value);
 
             var cancellationToken = new CancellationTokenSource().Token;
@@ -45,7 +45,7 @@ namespace Grpc.Core.Tests
             var writeOptions = new WriteOptions();
             Assert.AreSame(writeOptions, options.WithWriteOptions(writeOptions).WriteOptions);
 
-            var propagationToken = new ContextPropagationTokenImpl(CallSafeHandle.NullInstance, DateTime.UtcNow,
+            var propagationToken = new ContextPropagationTokenImpl(CallSafeHandle.NullInstance, DateTimeOffset.UtcNow,
                 CancellationToken.None, ContextPropagationOptions.Default);
             Assert.AreSame(propagationToken, options.WithPropagationToken(propagationToken).PropagationToken);
 
@@ -69,9 +69,9 @@ namespace Grpc.Core.Tests
         public void Normalize()
         {
             Assert.AreSame(Metadata.Empty, new CallOptions().Normalize().Headers);
-            Assert.AreEqual(DateTime.MaxValue, new CallOptions().Normalize().Deadline.Value);
+            Assert.AreEqual(DateTimeOffset.MaxValue, new CallOptions().Normalize().Deadline.Value);
 
-            var deadline = DateTime.UtcNow;
+            var deadline = DateTimeOffset.UtcNow;
             var propagationToken1 = new ContextPropagationTokenImpl(CallSafeHandle.NullInstance, deadline, CancellationToken.None,
                 new ContextPropagationOptions(propagateDeadline: true, propagateCancellation: false));
             Assert.AreEqual(deadline, new CallOptions(propagationToken: propagationToken1).Normalize().Deadline.Value);

--- a/src/csharp/Grpc.Core.Tests/ContextPropagationTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ContextPropagationTest.cs
@@ -79,13 +79,13 @@ namespace Grpc.Core.Tests
                 {
                     await Calls.AsyncUnaryCall(helper.CreateUnaryCall(callOptions), "xyz");
                 }
-                catch(RpcException)
+                catch (RpcException)
                 {
                     // Child call will get cancelled, eat the exception.
                 }
                 return "";
             });
-                
+
             var cts = new CancellationTokenSource();
             var parentCall = Calls.AsyncClientStreamingCall(helper.CreateClientStreamingCall(new CallOptions(cancellationToken: cts.Token)));
             await readyToCancelTcs.Task;
@@ -105,7 +105,7 @@ namespace Grpc.Core.Tests
         [Test]
         public async Task PropagateDeadline()
         {
-            var deadline = DateTime.UtcNow.AddDays(7);
+            var deadline = DateTimeOffset.UtcNow.AddDays(7);
             helper.UnaryHandler = new UnaryServerMethod<string, string>((request, context) =>
             {
                 Assert.IsTrue(context.Deadline < deadline.AddMinutes(1));
@@ -119,14 +119,14 @@ namespace Grpc.Core.Tests
                 {
                     // Trying to override deadline while propagating deadline from parent call will throw.
                     Calls.BlockingUnaryCall(helper.CreateUnaryCall(
-                        new CallOptions(deadline: DateTime.UtcNow.AddDays(8),
+                        new CallOptions(deadline: DateTimeOffset.UtcNow.AddDays(8),
                                         propagationToken: context.CreatePropagationToken())), "");
                 });
 
                 var callOptions = new CallOptions(propagationToken: context.CreatePropagationToken());
                 return await Calls.AsyncUnaryCall(helper.CreateUnaryCall(callOptions), "xyz");
             });
-                
+
             var call = Calls.AsyncClientStreamingCall(helper.CreateClientStreamingCall(new CallOptions(deadline: deadline)));
             await call.RequestStream.CompleteAsync();
             Assert.AreEqual("PASS", await call);
@@ -137,7 +137,7 @@ namespace Grpc.Core.Tests
         {
             helper.UnaryHandler = new UnaryServerMethod<string, string>((request, context) =>
             {
-                Assert.AreEqual(DateTime.MaxValue, context.Deadline);
+                Assert.AreEqual(DateTimeOffset.MaxValue, context.Deadline);
                 return Task.FromResult("PASS");
             });
 
@@ -150,7 +150,7 @@ namespace Grpc.Core.Tests
             });
 
             var cts = new CancellationTokenSource();
-            var call = Calls.AsyncClientStreamingCall(helper.CreateClientStreamingCall(new CallOptions(deadline: DateTime.UtcNow.AddDays(7))));
+            var call = Calls.AsyncClientStreamingCall(helper.CreateClientStreamingCall(new CallOptions(deadline: DateTimeOffset.UtcNow.AddDays(7))));
             await call.RequestStream.CompleteAsync();
             Assert.AreEqual("PASS", await call);
         }

--- a/src/csharp/Grpc.Core.Tests/Internal/TimespecTest.cs
+++ b/src/csharp/Grpc.Core.Tests/Internal/TimespecTest.cs
@@ -153,14 +153,14 @@ namespace Grpc.Core.Internal.Tests
             Assert.AreEqual(new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero),
                 new Timespec(0, 0).ToDateTimeOffset());
 
-            Assert.AreEqual(new DateTimeOffset(1970, 1, 1, 0, 0, 10, TimeSpan.FromTicks(50)),
+            Assert.AreEqual(new DateTimeOffset(1970, 1, 1, 0, 0, 10, TimeSpan.Zero).AddTicks(50),
                 new Timespec(10, 5000).ToDateTimeOffset());
 
             Assert.AreEqual(new DateTimeOffset(2015, 7, 21, 4, 21, 48, TimeSpan.Zero),
                 new Timespec(1437452508, 0).ToDateTimeOffset());
 
             // before epoch
-            Assert.AreEqual(new DateTimeOffset(1969, 12, 31, 23, 59, 55, TimeSpan.FromTicks(10)),
+            Assert.AreEqual(new DateTimeOffset(1969, 12, 31, 23, 59, 55, TimeSpan.Zero).AddTicks(10),
                 new Timespec(-5, 1000).ToDateTimeOffset());
 
             // infinity
@@ -168,7 +168,7 @@ namespace Grpc.Core.Internal.Tests
             Assert.AreEqual(DateTime.MinValue, Timespec.InfPast.ToDateTime());
 
             // nanos are rounded to ticks are rounded up
-            Assert.AreEqual(new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.FromTicks(1)),
+            Assert.AreEqual(new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero).AddTicks(1),
                 new Timespec(0, 99).ToDateTimeOffset());
 
             // Illegal inputs
@@ -234,14 +234,14 @@ namespace Grpc.Core.Internal.Tests
                 Timespec.FromDateTimeOffset(new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero)));
 
             Assert.AreEqual(new Timespec(10, 5000),
-                Timespec.FromDateTimeOffset(new DateTimeOffset(1970, 1, 1, 0, 0, 10, TimeSpan.FromTicks(50))));
+                Timespec.FromDateTimeOffset(new DateTimeOffset(1970, 1, 1, 0, 0, 10, TimeSpan.Zero).AddTicks(50)));
 
             Assert.AreEqual(new Timespec(1437452508, 0),
                 Timespec.FromDateTimeOffset(new DateTimeOffset(2015, 7, 21, 4, 21, 48, TimeSpan.Zero)));
 
             // before epoch
             Assert.AreEqual(new Timespec(-5, 1000),
-                Timespec.FromDateTimeOffset(new DateTimeOffset(1969, 12, 31, 23, 59, 55, TimeSpan.FromTicks(10))));
+                Timespec.FromDateTimeOffset(new DateTimeOffset(1969, 12, 31, 23, 59, 55, TimeSpan.Zero).AddTicks(10)));
 
             // infinity
             Assert.AreEqual(Timespec.InfFuture, Timespec.FromDateTimeOffset(DateTimeOffset.MaxValue));

--- a/src/csharp/Grpc.Core.Tests/TimeoutsTest.cs
+++ b/src/csharp/Grpc.Core.Tests/TimeoutsTest.cs
@@ -59,21 +59,21 @@ namespace Grpc.Core.Tests
         {
             helper.UnaryHandler = new UnaryServerMethod<string, string>((request, context) =>
             {
-                Assert.AreEqual(DateTime.MaxValue, context.Deadline);
+                Assert.AreEqual(DateTimeOffset.MaxValue, context.Deadline);
                 return Task.FromResult("PASS");
             });
 
             // no deadline specified, check server sees infinite deadline
             Assert.AreEqual("PASS", Calls.BlockingUnaryCall(helper.CreateUnaryCall(), "abc"));
 
-            // DateTime.MaxValue deadline specified, check server sees infinite deadline
-            Assert.AreEqual("PASS", Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(deadline: DateTime.MaxValue)), "abc"));
+            // DateTimeOffset.MaxValue deadline specified, check server sees infinite deadline
+            Assert.AreEqual("PASS", Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(deadline: DateTimeOffset.MaxValue)), "abc"));
         }
 
         [Test]
         public void DeadlineTransferredToServer()
         {
-            var clientDeadline = DateTime.UtcNow + TimeSpan.FromDays(7);
+            var clientDeadline = DateTimeOffset.UtcNow + TimeSpan.FromDays(7);
 
             helper.UnaryHandler = new UnaryServerMethod<string, string>((request, context) =>
             {
@@ -95,7 +95,7 @@ namespace Grpc.Core.Tests
                 return "FAIL";
             });
 
-            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(deadline: DateTime.MinValue)), "abc"));
+            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(deadline: DateTimeOffset.MinValue)), "abc"));
             // We can't guarantee the status code always DeadlineExceeded. See issue #2685.
             Assert.Contains(ex.Status.StatusCode, new[] { StatusCode.DeadlineExceeded, StatusCode.Internal });
         }
@@ -109,7 +109,7 @@ namespace Grpc.Core.Tests
                 return "FAIL";
             });
 
-            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(deadline: DateTime.UtcNow.Add(TimeSpan.FromSeconds(5)))), "abc"));
+            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(deadline: DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(5)))), "abc"));
             // We can't guarantee the status code always DeadlineExceeded. See issue #2685.
             Assert.Contains(ex.Status.StatusCode, new[] { StatusCode.DeadlineExceeded, StatusCode.Internal });
         }
@@ -119,7 +119,7 @@ namespace Grpc.Core.Tests
         {
             var serverReceivedCancellationTcs = new TaskCompletionSource<bool>();
 
-            helper.UnaryHandler = new UnaryServerMethod<string, string>(async (request, context) => 
+            helper.UnaryHandler = new UnaryServerMethod<string, string>(async (request, context) =>
             {
                 // wait until cancellation token is fired.
                 var tcs = new TaskCompletionSource<object>();
@@ -129,7 +129,7 @@ namespace Grpc.Core.Tests
                 return "";
             });
 
-            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(deadline: DateTime.UtcNow.Add(TimeSpan.FromSeconds(5)))), "abc"));
+            var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(deadline: DateTimeOffset.UtcNow.Add(TimeSpan.FromSeconds(5)))), "abc"));
             // We can't guarantee the status code always DeadlineExceeded. See issue #2685.
             Assert.Contains(ex.Status.StatusCode, new[] { StatusCode.DeadlineExceeded, StatusCode.Internal });
 

--- a/src/csharp/Grpc.Core/CallOptions.cs
+++ b/src/csharp/Grpc.Core/CallOptions.cs
@@ -30,7 +30,7 @@ namespace Grpc.Core
     public struct CallOptions
     {
         Metadata headers;
-        DateTime? deadline;
+        DateTimeOffset? deadline;
         CancellationToken cancellationToken;
         WriteOptions writeOptions;
         ContextPropagationToken propagationToken;
@@ -46,7 +46,7 @@ namespace Grpc.Core
         /// <param name="writeOptions">Write options that will be used for this call.</param>
         /// <param name="propagationToken">Context propagation token obtained from <see cref="ServerCallContext"/>.</param>
         /// <param name="credentials">Credentials to use for this call.</param>
-        public CallOptions(Metadata headers = null, DateTime? deadline = null, CancellationToken cancellationToken = default(CancellationToken),
+        public CallOptions(Metadata headers = null, DateTimeOffset? deadline = null, CancellationToken cancellationToken = default(CancellationToken),
                            WriteOptions writeOptions = null, ContextPropagationToken propagationToken = null, CallCredentials credentials = null)
         {
             this.headers = headers;
@@ -69,7 +69,7 @@ namespace Grpc.Core
         /// <summary>
         /// Call deadline.
         /// </summary>
-        public DateTime? Deadline
+        public DateTimeOffset? Deadline
         {
             get { return deadline; }
         }
@@ -147,7 +147,7 @@ namespace Grpc.Core
         /// <c>Deadline</c> set to the value provided. Values of all other fields are preserved.
         /// </summary>
         /// <param name="deadline">The deadline.</param>
-        public CallOptions WithDeadline(DateTime deadline)
+        public CallOptions WithDeadline(DateTimeOffset deadline)
         {
             var newOptions = this;
             newOptions.deadline = deadline;
@@ -255,7 +255,7 @@ namespace Grpc.Core
             }
 
             newOptions.headers = newOptions.headers ?? Metadata.Empty;
-            newOptions.deadline = newOptions.deadline ?? DateTime.MaxValue;
+            newOptions.deadline = newOptions.deadline ?? DateTimeOffset.MaxValue;
             return newOptions;
         }
     }

--- a/src/csharp/Grpc.Core/Internal/AsyncCall.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCall.cs
@@ -501,7 +501,7 @@ namespace Grpc.Core.Internal
             {
                 var result = details.Channel.Handle.CreateCall(
                              parentCall, ContextPropagationTokenImpl.DefaultMask, cq,
-                             details.Method, details.Host, Timespec.FromDateTime(details.Options.Deadline.Value), nativeCredentials);
+                             details.Method, details.Host, Timespec.FromDateTimeOffset(details.Options.Deadline.Value), nativeCredentials);
                 return result;
             }
         }

--- a/src/csharp/Grpc.Core/Internal/ContextPropagationTokenImpl.cs
+++ b/src/csharp/Grpc.Core/Internal/ContextPropagationTokenImpl.cs
@@ -46,11 +46,11 @@ namespace Grpc.Core.Internal
             & ~ContextPropagationFlags.Deadline & ~ContextPropagationFlags.Cancellation;
 
         readonly CallSafeHandle parentCall;
-        readonly DateTime deadline;
+        readonly DateTimeOffset deadline;
         readonly CancellationToken cancellationToken;
         readonly ContextPropagationOptions options;
 
-        internal ContextPropagationTokenImpl(CallSafeHandle parentCall, DateTime deadline, CancellationToken cancellationToken, ContextPropagationOptions options)
+        internal ContextPropagationTokenImpl(CallSafeHandle parentCall, DateTimeOffset deadline, CancellationToken cancellationToken, ContextPropagationOptions options)
         {
             this.parentCall = GrpcPreconditions.CheckNotNull(parentCall);
             this.deadline = deadline;
@@ -72,7 +72,7 @@ namespace Grpc.Core.Internal
         /// <summary>
         /// Gets the parent call's deadline.
         /// </summary>
-        internal DateTime ParentDeadline
+        internal DateTimeOffset ParentDeadline
         {
             get
             {

--- a/src/csharp/Grpc.Core/Internal/DefaultServerCallContext.cs
+++ b/src/csharp/Grpc.Core/Internal/DefaultServerCallContext.cs
@@ -32,7 +32,7 @@ namespace Grpc.Core
         private readonly CallSafeHandle callHandle;
         private readonly string method;
         private readonly string host;
-        private readonly DateTime deadline;
+        private readonly DateTimeOffset deadline;
         private readonly Metadata requestHeaders;
         private readonly CancellationToken cancellationToken;
         private readonly Metadata responseTrailers;
@@ -45,7 +45,7 @@ namespace Grpc.Core
         /// To allow reuse of ServerCallContext API by different gRPC implementations, the implementation of some members is provided externally.
         /// To provide state, this <c>ServerCallContext</c> instance and <c>extraData</c> will be passed to the member implementations.
         /// </summary>
-        internal DefaultServerCallContext(CallSafeHandle callHandle, string method, string host, DateTime deadline,
+        internal DefaultServerCallContext(CallSafeHandle callHandle, string method, string host, DateTimeOffset deadline,
             Metadata requestHeaders, CancellationToken cancellationToken, IServerResponseStream serverResponseStream)
         {
             this.callHandle = callHandle;
@@ -77,7 +77,7 @@ namespace Grpc.Core
 
         protected override string PeerCore => callHandle.GetPeer();
 
-        protected override DateTime DeadlineCore => deadline;
+        protected override DateTimeOffset DeadlineCore => deadline;
 
         protected override Metadata RequestHeadersCore => requestHeaders;
 

--- a/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerCallHandler.cs
@@ -321,7 +321,7 @@ namespace Grpc.Core.Internal
 
         public static ServerCallContext NewContext(ServerRpcNew newRpc, IServerResponseStream serverResponseStream, CancellationToken cancellationToken)
         {
-            DateTime realtimeDeadline = newRpc.Deadline.ToClockType(ClockType.Realtime).ToDateTime();
+            DateTimeOffset realtimeDeadline = newRpc.Deadline.ToClockType(ClockType.Realtime).ToDateTimeOffset();
             return new DefaultServerCallContext(newRpc.Call, newRpc.Method, newRpc.Host, realtimeDeadline, newRpc.RequestMetadata, cancellationToken, serverResponseStream);
         }
     }

--- a/src/csharp/Grpc.Core/Internal/Timespec.cs
+++ b/src/csharp/Grpc.Core/Internal/Timespec.cs
@@ -33,6 +33,7 @@ namespace Grpc.Core.Internal
 
         static readonly NativeMethods Native = NativeMethods.Get();
         static readonly DateTime UnixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+        static readonly DateTimeOffset DtoUnixEpoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
 
         public Timespec(long tv_sec, int tv_nsec) : this(tv_sec, tv_nsec, ClockType.Realtime)
         {
@@ -111,7 +112,7 @@ namespace Grpc.Core.Internal
         {
             return Native.gprsharp_convert_clock_type(this, targetClock);
         }
-            
+
         /// <summary>
         /// Converts Timespec to DateTime.
         /// Timespec needs to be of type GPRClockType.Realtime and needs to represent a legal value.
@@ -159,7 +160,12 @@ namespace Grpc.Core.Internal
                 return tv_sec > 0 ? DateTime.MaxValue : DateTime.MinValue;
             }
         }
-            
+
+        public DateTimeOffset ToDateTimeOffset()
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Creates DateTime to Timespec.
         /// DateTime has to be in UTC (DateTimeKind.Utc) unless it's DateTime.MaxValue or DateTime.MinValue.
@@ -187,9 +193,9 @@ namespace Grpc.Core.Internal
                 TimeSpan timeSpan = dateTime - UnixEpoch;
                 long ticks = timeSpan.Ticks;
 
-                long seconds = ticks / TicksPerSecond;  
+                long seconds = ticks / TicksPerSecond;
                 int nanos = (int)((ticks % TicksPerSecond) * NanosPerTick);
-                if (nanos < 0) 
+                if (nanos < 0)
                 {
                     // correct the result based on C# modulo semantics for negative dividend
                     seconds--;
@@ -201,6 +207,11 @@ namespace Grpc.Core.Internal
             {
                 return dateTime > UnixEpoch ? Timespec.InfFuture : Timespec.InfPast;
             }
+        }
+
+        public static Timespec FromDateTimeOffset(DateTimeOffset dateTimeOffset)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Examples.Tests/MathClientServerTests.cs
+++ b/src/csharp/Grpc.Examples.Tests/MathClientServerTests.cs
@@ -133,7 +133,7 @@ namespace Math.Tests
         public void FibWithDeadline()
         {
             using (var call = client.Fib(new FibArgs { Limit = 0 }, 
-                deadline: DateTime.UtcNow.AddMilliseconds(500)))
+                deadline: DateTimeOffset.Now.AddMilliseconds(500)))
             {
                 var ex = Assert.ThrowsAsync<RpcException>(async () => await call.ResponseStream.ToListAsync());
 

--- a/src/csharp/Grpc.Examples.Tests/MathServiceImplTestabilityTest.cs
+++ b/src/csharp/Grpc.Examples.Tests/MathServiceImplTestabilityTest.cs
@@ -38,7 +38,7 @@ namespace Math.Tests
 
             // Use a factory method provided by Grpc.Core.Testing.TestServerCallContext to create an instance of server call context.
             // This allows testing even those server-side implementations that rely on the contents of ServerCallContext.
-            var fakeServerCallContext = TestServerCallContext.Create("fooMethod", null, DateTime.UtcNow.AddHours(1), new Metadata(), CancellationToken.None, "127.0.0.1", null, null, (metadata) => TaskUtils.CompletedTask, () => new WriteOptions(), (writeOptions) => { });
+            var fakeServerCallContext = TestServerCallContext.Create("fooMethod", null, DateTimeOffset.Now.AddHours(1), new Metadata(), CancellationToken.None, "127.0.0.1", null, null, (metadata) => TaskUtils.CompletedTask, () => new WriteOptions(), (writeOptions) => { });
             var response = await mathImpl.Div(new DivArgs { Dividend = 10, Divisor = 2 }, fakeServerCallContext);
             Assert.AreEqual(5, response.Quotient);
             Assert.AreEqual(0, response.Remainder);

--- a/src/csharp/Grpc.Examples/MathGrpc.cs
+++ b/src/csharp/Grpc.Examples/MathGrpc.cs
@@ -4,13 +4,13 @@
 // </auto-generated>
 // Original file comments:
 // Copyright 2015 gRPC authors.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -156,7 +156,7 @@ namespace Math {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::Math.DivReply Div(global::Math.DivArgs request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Math.DivReply Div(global::Math.DivArgs request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return Div(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -180,7 +180,7 @@ namespace Math {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::Math.DivReply> DivAsync(global::Math.DivArgs request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Math.DivReply> DivAsync(global::Math.DivArgs request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return DivAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -205,7 +205,7 @@ namespace Math {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncDuplexStreamingCall<global::Math.DivArgs, global::Math.DivReply> DivMany(grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncDuplexStreamingCall<global::Math.DivArgs, global::Math.DivReply> DivMany(grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return DivMany(new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -231,7 +231,7 @@ namespace Math {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncServerStreamingCall<global::Math.Num> Fib(global::Math.FibArgs request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncServerStreamingCall<global::Math.Num> Fib(global::Math.FibArgs request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return Fib(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -255,7 +255,7 @@ namespace Math {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncClientStreamingCall<global::Math.Num, global::Math.Num> Sum(grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncClientStreamingCall<global::Math.Num, global::Math.Num> Sum(grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return Sum(new grpc::CallOptions(headers, deadline, cancellationToken));
       }

--- a/src/csharp/Grpc.HealthCheck/HealthGrpc.cs
+++ b/src/csharp/Grpc.HealthCheck/HealthGrpc.cs
@@ -4,13 +4,13 @@
 // </auto-generated>
 // Original file comments:
 // Copyright 2015 The gRPC Authors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -128,7 +128,7 @@ namespace Grpc.Health.V1 {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::Grpc.Health.V1.HealthCheckResponse Check(global::Grpc.Health.V1.HealthCheckRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Grpc.Health.V1.HealthCheckResponse Check(global::Grpc.Health.V1.HealthCheckRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return Check(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -152,7 +152,7 @@ namespace Grpc.Health.V1 {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::Grpc.Health.V1.HealthCheckResponse> CheckAsync(global::Grpc.Health.V1.HealthCheckRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Health.V1.HealthCheckResponse> CheckAsync(global::Grpc.Health.V1.HealthCheckRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return CheckAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -189,7 +189,7 @@ namespace Grpc.Health.V1 {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncServerStreamingCall<global::Grpc.Health.V1.HealthCheckResponse> Watch(global::Grpc.Health.V1.HealthCheckRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncServerStreamingCall<global::Grpc.Health.V1.HealthCheckResponse> Watch(global::Grpc.Health.V1.HealthCheckRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return Watch(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }

--- a/src/csharp/Grpc.IntegrationTesting/BenchmarkServiceGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/BenchmarkServiceGrpc.cs
@@ -4,13 +4,13 @@
 // </auto-generated>
 // Original file comments:
 // Copyright 2015 gRPC authors.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -174,7 +174,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::Grpc.Testing.SimpleResponse UnaryCall(global::Grpc.Testing.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Grpc.Testing.SimpleResponse UnaryCall(global::Grpc.Testing.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return UnaryCall(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -198,7 +198,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.SimpleResponse> UnaryCallAsync(global::Grpc.Testing.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.SimpleResponse> UnaryCallAsync(global::Grpc.Testing.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return UnaryCallAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -222,7 +222,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncDuplexStreamingCall<global::Grpc.Testing.SimpleRequest, global::Grpc.Testing.SimpleResponse> StreamingCall(grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncDuplexStreamingCall<global::Grpc.Testing.SimpleRequest, global::Grpc.Testing.SimpleResponse> StreamingCall(grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return StreamingCall(new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -245,7 +245,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncClientStreamingCall<global::Grpc.Testing.SimpleRequest, global::Grpc.Testing.SimpleResponse> StreamingFromClient(grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncClientStreamingCall<global::Grpc.Testing.SimpleRequest, global::Grpc.Testing.SimpleResponse> StreamingFromClient(grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return StreamingFromClient(new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -268,7 +268,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncServerStreamingCall<global::Grpc.Testing.SimpleResponse> StreamingFromServer(global::Grpc.Testing.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncServerStreamingCall<global::Grpc.Testing.SimpleResponse> StreamingFromServer(global::Grpc.Testing.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return StreamingFromServer(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -291,7 +291,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncDuplexStreamingCall<global::Grpc.Testing.SimpleRequest, global::Grpc.Testing.SimpleResponse> StreamingBothWays(grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncDuplexStreamingCall<global::Grpc.Testing.SimpleRequest, global::Grpc.Testing.SimpleResponse> StreamingBothWays(grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return StreamingBothWays(new grpc::CallOptions(headers, deadline, cancellationToken));
       }

--- a/src/csharp/Grpc.IntegrationTesting/Empty.cs
+++ b/src/csharp/Grpc.IntegrationTesting/Empty.cs
@@ -44,7 +44,6 @@ namespace Grpc.Testing {
   ///   service Foo {
   ///     rpc Bar (grpc.testing.Empty) returns (grpc.testing.Empty) { };
   ///   };
-  ///
   /// </summary>
   public sealed partial class Empty : pb::IMessage<Empty> {
     private static readonly pb::MessageParser<Empty> _parser = new pb::MessageParser<Empty>(() => new Empty());

--- a/src/csharp/Grpc.IntegrationTesting/EmptyServiceGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/EmptyServiceGrpc.cs
@@ -4,13 +4,13 @@
 // </auto-generated>
 // Original file comments:
 // Copyright 2018 gRPC authors.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
@@ -94,7 +94,7 @@ namespace Grpc.IntegrationTesting
         private async Task Run()
         {
             var credentials = await CreateCredentialsAsync();
-            
+
             List<ChannelOption> channelOptions = null;
             if (!string.IsNullOrEmpty(options.ServerHostOverride))
             {
@@ -343,7 +343,7 @@ namespace Grpc.IntegrationTesting
         public static void RunJwtTokenCreds(TestService.TestServiceClient client)
         {
             Console.WriteLine("running jwt_token_creds");
-           
+
             var request = new SimpleRequest
             {
                 ResponseSize = 314159,
@@ -450,7 +450,7 @@ namespace Grpc.IntegrationTesting
         {
             Console.WriteLine("running timeout_on_sleeping_server");
 
-            var deadline = DateTime.UtcNow.AddMilliseconds(1);
+            var deadline = DateTimeOffset.Now.AddMilliseconds(1);
             using (var call = client.FullDuplexCall(deadline: deadline))
             {
                 try

--- a/src/csharp/Grpc.IntegrationTesting/MetricsGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/MetricsGrpc.cs
@@ -4,13 +4,13 @@
 // </auto-generated>
 // Original file comments:
 // Copyright 2015-2016 gRPC authors.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,7 +19,7 @@
 //
 // Contains the definitions for a metrics service and the type of metrics
 // exposed by the service.
-// 
+//
 // Currently, 'Gauge' (i.e a metric that represents the measured value of
 // something at an instant of time) is the only metric type supported by the
 // service.
@@ -118,7 +118,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncServerStreamingCall<global::Grpc.Testing.GaugeResponse> GetAllGauges(global::Grpc.Testing.EmptyMessage request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncServerStreamingCall<global::Grpc.Testing.GaugeResponse> GetAllGauges(global::Grpc.Testing.EmptyMessage request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return GetAllGauges(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -141,7 +141,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::Grpc.Testing.GaugeResponse GetGauge(global::Grpc.Testing.GaugeRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Grpc.Testing.GaugeResponse GetGauge(global::Grpc.Testing.GaugeRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return GetGauge(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -163,7 +163,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.GaugeResponse> GetGaugeAsync(global::Grpc.Testing.GaugeRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.GaugeResponse> GetGaugeAsync(global::Grpc.Testing.GaugeRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return GetGaugeAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }

--- a/src/csharp/Grpc.IntegrationTesting/ReportQpsScenarioServiceGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ReportQpsScenarioServiceGrpc.cs
@@ -4,13 +4,13 @@
 // </auto-generated>
 // Original file comments:
 // Copyright 2015 gRPC authors.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -92,7 +92,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::Grpc.Testing.Void ReportScenario(global::Grpc.Testing.ScenarioResult request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Grpc.Testing.Void ReportScenario(global::Grpc.Testing.ScenarioResult request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return ReportScenario(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -114,7 +114,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.Void> ReportScenarioAsync(global::Grpc.Testing.ScenarioResult request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.Void> ReportScenarioAsync(global::Grpc.Testing.ScenarioResult request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return ReportScenarioAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }

--- a/src/csharp/Grpc.IntegrationTesting/TestGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/TestGrpc.cs
@@ -4,13 +4,13 @@
 // </auto-generated>
 // Original file comments:
 // Copyright 2015-2016 gRPC authors.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -241,7 +241,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::Grpc.Testing.Empty EmptyCall(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Grpc.Testing.Empty EmptyCall(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return EmptyCall(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -263,7 +263,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.Empty> EmptyCallAsync(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.Empty> EmptyCallAsync(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return EmptyCallAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -285,7 +285,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::Grpc.Testing.SimpleResponse UnaryCall(global::Grpc.Testing.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Grpc.Testing.SimpleResponse UnaryCall(global::Grpc.Testing.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return UnaryCall(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -307,7 +307,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.SimpleResponse> UnaryCallAsync(global::Grpc.Testing.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.SimpleResponse> UnaryCallAsync(global::Grpc.Testing.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return UnaryCallAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -331,7 +331,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::Grpc.Testing.SimpleResponse CacheableUnaryCall(global::Grpc.Testing.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Grpc.Testing.SimpleResponse CacheableUnaryCall(global::Grpc.Testing.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return CacheableUnaryCall(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -357,7 +357,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.SimpleResponse> CacheableUnaryCallAsync(global::Grpc.Testing.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.SimpleResponse> CacheableUnaryCallAsync(global::Grpc.Testing.SimpleRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return CacheableUnaryCallAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -382,7 +382,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncServerStreamingCall<global::Grpc.Testing.StreamingOutputCallResponse> StreamingOutputCall(global::Grpc.Testing.StreamingOutputCallRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncServerStreamingCall<global::Grpc.Testing.StreamingOutputCallResponse> StreamingOutputCall(global::Grpc.Testing.StreamingOutputCallRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return StreamingOutputCall(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -405,7 +405,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncClientStreamingCall<global::Grpc.Testing.StreamingInputCallRequest, global::Grpc.Testing.StreamingInputCallResponse> StreamingInputCall(grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncClientStreamingCall<global::Grpc.Testing.StreamingInputCallRequest, global::Grpc.Testing.StreamingInputCallResponse> StreamingInputCall(grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return StreamingInputCall(new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -428,7 +428,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncDuplexStreamingCall<global::Grpc.Testing.StreamingOutputCallRequest, global::Grpc.Testing.StreamingOutputCallResponse> FullDuplexCall(grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncDuplexStreamingCall<global::Grpc.Testing.StreamingOutputCallRequest, global::Grpc.Testing.StreamingOutputCallResponse> FullDuplexCall(grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return FullDuplexCall(new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -453,7 +453,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncDuplexStreamingCall<global::Grpc.Testing.StreamingOutputCallRequest, global::Grpc.Testing.StreamingOutputCallResponse> HalfDuplexCall(grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncDuplexStreamingCall<global::Grpc.Testing.StreamingOutputCallRequest, global::Grpc.Testing.StreamingOutputCallResponse> HalfDuplexCall(grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return HalfDuplexCall(new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -478,7 +478,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::Grpc.Testing.Empty UnimplementedCall(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Grpc.Testing.Empty UnimplementedCall(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return UnimplementedCall(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -502,7 +502,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.Empty> UnimplementedCallAsync(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.Empty> UnimplementedCallAsync(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return UnimplementedCallAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -626,7 +626,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::Grpc.Testing.Empty UnimplementedCall(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Grpc.Testing.Empty UnimplementedCall(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return UnimplementedCall(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -648,7 +648,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.Empty> UnimplementedCallAsync(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.Empty> UnimplementedCallAsync(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return UnimplementedCallAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -756,7 +756,7 @@ namespace Grpc.Testing {
       {
       }
 
-      public virtual global::Grpc.Testing.Empty Start(global::Grpc.Testing.ReconnectParams request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Grpc.Testing.Empty Start(global::Grpc.Testing.ReconnectParams request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return Start(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -764,7 +764,7 @@ namespace Grpc.Testing {
       {
         return CallInvoker.BlockingUnaryCall(__Method_Start, null, options, request);
       }
-      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.Empty> StartAsync(global::Grpc.Testing.ReconnectParams request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.Empty> StartAsync(global::Grpc.Testing.ReconnectParams request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return StartAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -772,7 +772,7 @@ namespace Grpc.Testing {
       {
         return CallInvoker.AsyncUnaryCall(__Method_Start, null, options, request);
       }
-      public virtual global::Grpc.Testing.ReconnectInfo Stop(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Grpc.Testing.ReconnectInfo Stop(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return Stop(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -780,7 +780,7 @@ namespace Grpc.Testing {
       {
         return CallInvoker.BlockingUnaryCall(__Method_Stop, null, options, request);
       }
-      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.ReconnectInfo> StopAsync(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.ReconnectInfo> StopAsync(global::Grpc.Testing.Empty request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return StopAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }

--- a/src/csharp/Grpc.IntegrationTesting/WorkerServiceGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/WorkerServiceGrpc.cs
@@ -4,13 +4,13 @@
 // </auto-generated>
 // Original file comments:
 // Copyright 2015 gRPC authors.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -167,7 +167,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncDuplexStreamingCall<global::Grpc.Testing.ServerArgs, global::Grpc.Testing.ServerStatus> RunServer(grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncDuplexStreamingCall<global::Grpc.Testing.ServerArgs, global::Grpc.Testing.ServerStatus> RunServer(grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return RunServer(new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -197,7 +197,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncDuplexStreamingCall<global::Grpc.Testing.ClientArgs, global::Grpc.Testing.ClientStatus> RunClient(grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncDuplexStreamingCall<global::Grpc.Testing.ClientArgs, global::Grpc.Testing.ClientStatus> RunClient(grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return RunClient(new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -223,7 +223,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::Grpc.Testing.CoreResponse CoreCount(global::Grpc.Testing.CoreRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Grpc.Testing.CoreResponse CoreCount(global::Grpc.Testing.CoreRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return CoreCount(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -245,7 +245,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.CoreResponse> CoreCountAsync(global::Grpc.Testing.CoreRequest request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.CoreResponse> CoreCountAsync(global::Grpc.Testing.CoreRequest request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return CoreCountAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -267,7 +267,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The response received from the server.</returns>
-      public virtual global::Grpc.Testing.Void QuitWorker(global::Grpc.Testing.Void request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual global::Grpc.Testing.Void QuitWorker(global::Grpc.Testing.Void request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return QuitWorker(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
@@ -289,7 +289,7 @@ namespace Grpc.Testing {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.Void> QuitWorkerAsync(global::Grpc.Testing.Void request, grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncUnaryCall<global::Grpc.Testing.Void> QuitWorkerAsync(global::Grpc.Testing.Void request, grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return QuitWorkerAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }

--- a/src/csharp/Grpc.Reflection/ReflectionGrpc.cs
+++ b/src/csharp/Grpc.Reflection/ReflectionGrpc.cs
@@ -4,13 +4,13 @@
 // </auto-generated>
 // Original file comments:
 // Copyright 2016 gRPC authors.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -94,7 +94,7 @@ namespace Grpc.Reflection.V1Alpha {
       /// <param name="deadline">An optional deadline for the call. The call will be cancelled if deadline is hit.</param>
       /// <param name="cancellationToken">An optional token for canceling the call.</param>
       /// <returns>The call object.</returns>
-      public virtual grpc::AsyncDuplexStreamingCall<global::Grpc.Reflection.V1Alpha.ServerReflectionRequest, global::Grpc.Reflection.V1Alpha.ServerReflectionResponse> ServerReflectionInfo(grpc::Metadata headers = null, global::System.DateTime? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
+      public virtual grpc::AsyncDuplexStreamingCall<global::Grpc.Reflection.V1Alpha.ServerReflectionRequest, global::Grpc.Reflection.V1Alpha.ServerReflectionResponse> ServerReflectionInfo(grpc::Metadata headers = null, global::System.DateTimeOffset? deadline = null, global::System.Threading.CancellationToken cancellationToken = default(global::System.Threading.CancellationToken))
       {
         return ServerReflectionInfo(new grpc::CallOptions(headers, deadline, cancellationToken));
       }


### PR DESCRIPTION
This PR addresses #17773 
I'm making this a draft PR to get feedback. 
From an user point of view `DateTimeOffset` is more suitable than `DateTime` for representing deadline since the deadline value should be universal. 
This PR changes the deadline fields in `ServerCallContext` and `CallOptions` to using DateTimeOffset, which is a breaking change. Such breaking change could be avoided by generating extra overload for the client class (e.g. one call with `deadline` argument of type `DateTime?` and another of type `DateTimeOffset?` ) and maintain the type of `ServerCallContext.Deadline` but that would result in a less-nice set of APIs.
Looking for feedback on what should be appropriate. 