### PR TITLE
Remove duplicated word 'for for' in doc

### DIFF
--- a/doc/server_reflection_tutorial.md
+++ b/doc/server_reflection_tutorial.md
@@ -15,8 +15,8 @@ server reflection, you can link this library to your server binary.
 
 Some platforms (e.g. Ubuntu 11.10 onwards) only link in libraries that directly
 contain symbols used by the application. On these platforms, LD flag
-`--no-as-needed` is needed for for dynamic linking and `--whole-archive` is
-needed for for static linking.
+`--no-as-needed` is needed for dynamic linking and `--whole-archive` is
+needed for static linking.
 
 This [Makefile](../examples/cpp/helloworld/Makefile#L37#L45) demonstrates
 enabling c++ server reflection on Linux and MacOS.


### PR DESCRIPTION
Although it is spelling mistakes, it might make an affects while reading.

Co-Authored-By: Nguyen Phuong An <AnNP@vn.fujitsu.com>
Signed-off-by: Kim Bao Long <longkb@vn.fujitsu.com>