### PR TITLE
use isinstance for internal api to workaround mocks

### DIFF
--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -19,6 +19,7 @@ import logging
 import threading
 import time
 
+from concurrent import futures
 import six
 
 import grpc
@@ -565,8 +566,8 @@ def _send_message_callback_to_blocking_iterator_adapter(
 
 
 def _select_thread_pool_for_behavior(behavior, default_thread_pool):
-    if hasattr(behavior, 'experimental_thread_pool'
-              ) and behavior.experimental_thread_pool is not None:
+    if hasattr(behavior, 'experimental_thread_pool') and isinstance(
+            behavior.experimental_thread_pool, futures.ThreadPoolExecutor):
         return behavior.experimental_thread_pool
     else:
         return default_thread_pool

--- a/src/python/grpcio_tests/tests/unit/thread_pool.py
+++ b/src/python/grpcio_tests/tests/unit/thread_pool.py
@@ -16,7 +16,7 @@ import threading
 from concurrent import futures
 
 
-class RecordingThreadPool(futures.Executor):
+class RecordingThreadPool(futures.ThreadPoolExecutor):
     """A thread pool that records if used."""
 
     def __init__(self, max_workers):


### PR DESCRIPTION
Mocked servicers will return a non-None `behavior.experimental_thread_pool` that will accept jobs, but not actually run them, which isn't what we want here. This adds an isinstance of check to ensure that the `experimental_thread_pool` attribute is actually a `futures.ThreadPoolExecutor` - this is only ever set by our own code (the health service) so a cludgy isinstance of check seems appropriate for now.

This works around some internal test failures for users that were mocking servicers. I'm inclined to think we don't want users doing this, but for a non-public API that broke a couple tests it seems easier just to explicitly check the type.

Patched and verified internally that the previously failing tests pass with this change.