### PR TITLE
Remove no-effect std::move() that causes MSVC warning

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy.h
+++ b/src/core/ext/filters/client_channel/lb_policy.h
@@ -202,11 +202,7 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
     /// by the client channel.
     virtual void UpdateState(grpc_connectivity_state state,
                              grpc_error* state_error,
-                             UniquePtr<SubchannelPicker>) {
-      // The rest of this is copied from the GRPC_ABSTRACT macro.
-      gpr_log(GPR_ERROR, "Function marked GRPC_ABSTRACT was not implemented");
-      GPR_ASSERT(false);
-    }
+                             UniquePtr<SubchannelPicker>) GRPC_ABSTRACT;
 
     /// Requests that the resolver re-resolve.
     virtual void RequestReresolution() GRPC_ABSTRACT;
@@ -260,9 +256,8 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
   /// Note that the LB policy gets the set of addresses from the
   /// GRPC_ARG_SERVER_ADDRESS_LIST channel arg.
   virtual void UpdateLocked(const grpc_channel_args& args,
-                            RefCountedPtr<Config> lb_config) {  // NOLINT
-    GRPC_ABSTRACT;
-  }
+                            RefCountedPtr<Config>)  // NOLINT
+      GRPC_ABSTRACT;
 
   /// Tries to enter a READY connectivity state.
   /// This is a no-op by default, since most LB policies never go into

--- a/src/core/ext/filters/client_channel/lb_policy.h
+++ b/src/core/ext/filters/client_channel/lb_policy.h
@@ -260,7 +260,7 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
   /// Note that the LB policy gets the set of addresses from the
   /// GRPC_ARG_SERVER_ADDRESS_LIST channel arg.
   virtual void UpdateLocked(const grpc_channel_args& args,
-                            RefCountedPtr<Config> lb_config) { // NOLINT
+                            RefCountedPtr<Config> lb_config) {  // NOLINT
     GRPC_ABSTRACT;
   }
 

--- a/src/core/ext/filters/client_channel/lb_policy.h
+++ b/src/core/ext/filters/client_channel/lb_policy.h
@@ -260,7 +260,7 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
   /// Note that the LB policy gets the set of addresses from the
   /// GRPC_ARG_SERVER_ADDRESS_LIST channel arg.
   virtual void UpdateLocked(const grpc_channel_args& args,
-                            RefCountedPtr<Config>) {
+                            RefCountedPtr<Config> lb_config) { // NOLINT
     GRPC_ABSTRACT;
   }
 

--- a/src/core/ext/filters/client_channel/lb_policy.h
+++ b/src/core/ext/filters/client_channel/lb_policy.h
@@ -202,8 +202,7 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
     /// by the client channel.
     virtual void UpdateState(grpc_connectivity_state state,
                              grpc_error* state_error,
-                             UniquePtr<SubchannelPicker> picker) {
-      std::move(picker);  // Suppress clang-tidy complaint.
+                             UniquePtr<SubchannelPicker>) {
       // The rest of this is copied from the GRPC_ABSTRACT macro.
       gpr_log(GPR_ERROR, "Function marked GRPC_ABSTRACT was not implemented");
       GPR_ASSERT(false);
@@ -261,8 +260,7 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
   /// Note that the LB policy gets the set of addresses from the
   /// GRPC_ARG_SERVER_ADDRESS_LIST channel arg.
   virtual void UpdateLocked(const grpc_channel_args& args,
-                            RefCountedPtr<Config> lb_config) {
-    std::move(lb_config);  // Suppress clang-tidy complaint.
+                            RefCountedPtr<Config>) {
     GRPC_ABSTRACT;
   }
 

--- a/src/core/ext/filters/client_channel/lb_policy_factory.h
+++ b/src/core/ext/filters/client_channel/lb_policy_factory.h
@@ -31,8 +31,7 @@ class LoadBalancingPolicyFactory {
  public:
   /// Returns a new LB policy instance.
   virtual OrphanablePtr<LoadBalancingPolicy> CreateLoadBalancingPolicy(
-      LoadBalancingPolicy::Args args) const {
-    std::move(args);  // Suppress clang-tidy complaint.
+      LoadBalancingPolicy::Args) const {
     GRPC_ABSTRACT;
   }
 

--- a/src/core/ext/filters/client_channel/lb_policy_factory.h
+++ b/src/core/ext/filters/client_channel/lb_policy_factory.h
@@ -31,9 +31,7 @@ class LoadBalancingPolicyFactory {
  public:
   /// Returns a new LB policy instance.
   virtual OrphanablePtr<LoadBalancingPolicy> CreateLoadBalancingPolicy(
-      LoadBalancingPolicy::Args) const {
-    GRPC_ABSTRACT;
-  }
+      LoadBalancingPolicy::Args) const GRPC_ABSTRACT;
 
   /// Returns the LB policy name that this factory provides.
   /// Caller does NOT take ownership of result.


### PR DESCRIPTION
In C++17 mode of MSVC, std::move() has nodiscard attribute, and causes
a warning if its result is unused.