### PR TITLE
Generate C# docs also for Grpc.Core.Api (for v1.19.x)

### DIFF
--- a/src/csharp/doc/docfx.json
+++ b/src/csharp/doc/docfx.json
@@ -3,7 +3,8 @@
     {
       "src": [
         {
-          "files": ["Grpc.Core/Grpc.Core.csproj",
+          "files": ["Grpc.Core.Api/Grpc.Core.Api.csproj",
+                    "Grpc.Core/Grpc.Core.csproj",
                     "Grpc.Auth/Grpc.Auth.csproj",
                     "Grpc.Core.Testing/Grpc.Core.Testing.csproj",
                     "Grpc.HealthCheck/Grpc.HealthCheck.csproj",


### PR DESCRIPTION
otherwise the types moved to Grpc.Core.Api are missing in the generated docs.