### PR TITLE
Build c-ares bazel lib with alwayslink=1

### DIFF
--- a/test/cpp/end2end/cfstream_test.cc
+++ b/test/cpp/end2end/cfstream_test.cc
@@ -270,9 +270,6 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   grpc_test_init(argc, argv);
   gpr_setenv("grpc_cfstream", "1");
-  // TODO (pjaikumar): remove the line below when
-  // https://github.com/grpc/grpc/issues/18080 has been fixed.
-  gpr_setenv("GRPC_DNS_RESOLVER", "native");
   const auto result = RUN_ALL_TESTS();
   return result;
 }

--- a/third_party/cares/cares.BUILD
+++ b/third_party/cares/cares.BUILD
@@ -170,4 +170,5 @@ cc_library(
     visibility = [
         "//visibility:public",
     ],
+    alwayslink = 1,
 )


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/18080

Before things change, [the cfstream bazel test](https://github.com/grpc/grpc/blob/master/tools/internal_ci/macos/grpc_run_bazel_tests.sh) fails, and after this change it passes. 

Passing run: https://source.cloud.google.com/results/invocations/5d13fe4f-d667-4e46-9f6b-76af0d1f821d/targets.

I think the issue is related to the one fixed by https://github.com/grpc/grpc/pull/11519