### PR TITLE
Fix gpr_once initialization.

### DIFF
--- a/src/core/ext/transport/chttp2/client/insecure/channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/insecure/channel_create.cc
@@ -73,7 +73,7 @@ class Chttp2InsecureClientChannelFactory : public ClientChannelFactory {
 namespace {
 
 grpc_core::Chttp2InsecureClientChannelFactory* g_factory;
-gpr_once g_factory_once;
+gpr_once g_factory_once = GPR_ONCE_INIT;
 
 void FactoryInit() {
   g_factory = grpc_core::New<grpc_core::Chttp2InsecureClientChannelFactory>();

--- a/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
@@ -175,7 +175,7 @@ class Chttp2SecureClientChannelFactory : public ClientChannelFactory {
 namespace {
 
 grpc_core::Chttp2SecureClientChannelFactory* g_factory;
-gpr_once g_factory_once;
+gpr_once g_factory_once = GPR_ONCE_INIT;
 
 void FactoryInit() {
   g_factory = grpc_core::New<grpc_core::Chttp2SecureClientChannelFactory>();


### PR DESCRIPTION
I missed this in #18041.  It's breaking some internal tests.