### PR TITLE
Avoid copying grpc_slice as much as possible.

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel_channelz.h
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.h
@@ -71,11 +71,11 @@ class SubchannelNode : public BaseNode {
   grpc_json* RenderJson() override;
 
   // proxy methods to composed classes.
-  void AddTraceEvent(ChannelTrace::Severity severity, grpc_slice data) {
+  void AddTraceEvent(ChannelTrace::Severity severity, const grpc_slice& data) {
     trace_.AddTraceEvent(severity, data);
   }
   void AddTraceEventWithReference(ChannelTrace::Severity severity,
-                                  grpc_slice data,
+                                  const grpc_slice& data,
                                   RefCountedPtr<BaseNode> referenced_channel) {
     trace_.AddTraceEventWithReference(severity, data,
                                       std::move(referenced_channel));

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.cc
@@ -161,10 +161,10 @@ void grpc_grpclb_request_destroy(grpc_grpclb_request* request) {
 
 typedef grpc_lb_v1_LoadBalanceResponse grpc_grpclb_response;
 grpc_grpclb_initial_response* grpc_grpclb_initial_response_parse(
-    grpc_slice encoded_grpc_grpclb_response) {
-  pb_istream_t stream =
-      pb_istream_from_buffer(GRPC_SLICE_START_PTR(encoded_grpc_grpclb_response),
-                             GRPC_SLICE_LENGTH(encoded_grpc_grpclb_response));
+    const grpc_slice& encoded_grpc_grpclb_response) {
+  pb_istream_t stream = pb_istream_from_buffer(
+      const_cast<uint8_t*>(GRPC_SLICE_START_PTR(encoded_grpc_grpclb_response)),
+      GRPC_SLICE_LENGTH(encoded_grpc_grpclb_response));
   grpc_grpclb_response res;
   memset(&res, 0, sizeof(grpc_grpclb_response));
   if (GPR_UNLIKELY(
@@ -185,10 +185,10 @@ grpc_grpclb_initial_response* grpc_grpclb_initial_response_parse(
 }
 
 grpc_grpclb_serverlist* grpc_grpclb_response_parse_serverlist(
-    grpc_slice encoded_grpc_grpclb_response) {
-  pb_istream_t stream =
-      pb_istream_from_buffer(GRPC_SLICE_START_PTR(encoded_grpc_grpclb_response),
-                             GRPC_SLICE_LENGTH(encoded_grpc_grpclb_response));
+    const grpc_slice& encoded_grpc_grpclb_response) {
+  pb_istream_t stream = pb_istream_from_buffer(
+      const_cast<uint8_t*>(GRPC_SLICE_START_PTR(encoded_grpc_grpclb_response)),
+      GRPC_SLICE_LENGTH(encoded_grpc_grpclb_response));
   pb_istream_t stream_at_start = stream;
   grpc_grpclb_serverlist* sl = static_cast<grpc_grpclb_serverlist*>(
       gpr_zalloc(sizeof(grpc_grpclb_serverlist)));

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.h
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.h
@@ -55,11 +55,11 @@ void grpc_grpclb_request_destroy(grpc_grpclb_request* request);
 /** Parse (ie, decode) the bytes in \a encoded_grpc_grpclb_response as a \a
  * grpc_grpclb_initial_response */
 grpc_grpclb_initial_response* grpc_grpclb_initial_response_parse(
-    grpc_slice encoded_grpc_grpclb_response);
+    const grpc_slice& encoded_grpc_grpclb_response);
 
 /** Parse the list of servers from an encoded \a grpc_grpclb_response */
 grpc_grpclb_serverlist* grpc_grpclb_response_parse_serverlist(
-    grpc_slice encoded_grpc_grpclb_response);
+    const grpc_slice& encoded_grpc_grpclb_response);
 
 /** Return a copy of \a sl. The caller is responsible for calling \a
  * grpc_grpclb_destroy_serverlist on the returned copy. */

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_load_balancer_api.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_load_balancer_api.cc
@@ -161,10 +161,10 @@ void xds_grpclb_request_destroy(xds_grpclb_request* request) {
 
 typedef grpc_lb_v1_LoadBalanceResponse xds_grpclb_response;
 xds_grpclb_initial_response* xds_grpclb_initial_response_parse(
-    grpc_slice encoded_xds_grpclb_response) {
-  pb_istream_t stream =
-      pb_istream_from_buffer(GRPC_SLICE_START_PTR(encoded_xds_grpclb_response),
-                             GRPC_SLICE_LENGTH(encoded_xds_grpclb_response));
+    const grpc_slice& encoded_xds_grpclb_response) {
+  pb_istream_t stream = pb_istream_from_buffer(
+      const_cast<uint8_t*>(GRPC_SLICE_START_PTR(encoded_xds_grpclb_response)),
+      GRPC_SLICE_LENGTH(encoded_xds_grpclb_response));
   xds_grpclb_response res;
   memset(&res, 0, sizeof(xds_grpclb_response));
   if (GPR_UNLIKELY(
@@ -185,10 +185,10 @@ xds_grpclb_initial_response* xds_grpclb_initial_response_parse(
 }
 
 xds_grpclb_serverlist* xds_grpclb_response_parse_serverlist(
-    grpc_slice encoded_xds_grpclb_response) {
-  pb_istream_t stream =
-      pb_istream_from_buffer(GRPC_SLICE_START_PTR(encoded_xds_grpclb_response),
-                             GRPC_SLICE_LENGTH(encoded_xds_grpclb_response));
+    const grpc_slice& encoded_xds_grpclb_response) {
+  pb_istream_t stream = pb_istream_from_buffer(
+      const_cast<uint8_t*>(GRPC_SLICE_START_PTR(encoded_xds_grpclb_response)),
+      GRPC_SLICE_LENGTH(encoded_xds_grpclb_response));
   pb_istream_t stream_at_start = stream;
   xds_grpclb_serverlist* sl = static_cast<xds_grpclb_serverlist*>(
       gpr_zalloc(sizeof(xds_grpclb_serverlist)));

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_load_balancer_api.h
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_load_balancer_api.h
@@ -55,11 +55,11 @@ void xds_grpclb_request_destroy(xds_grpclb_request* request);
 /** Parse (ie, decode) the bytes in \a encoded_xds_grpclb_response as a \a
  * xds_grpclb_initial_response */
 xds_grpclb_initial_response* xds_grpclb_initial_response_parse(
-    grpc_slice encoded_xds_grpclb_response);
+    const grpc_slice& encoded_xds_grpclb_response);
 
 /** Parse the list of servers from an encoded \a xds_grpclb_response */
 xds_grpclb_serverlist* xds_grpclb_response_parse_serverlist(
-    grpc_slice encoded_xds_grpclb_response);
+    const grpc_slice& encoded_xds_grpclb_response);
 
 /** Return a copy of \a sl. The caller is responsible for calling \a
  * xds_grpclb_destroy_serverlist on the returned copy. */

--- a/src/core/ext/transport/chttp2/transport/bin_decoder.cc
+++ b/src/core/ext/transport/chttp2/transport/bin_decoder.cc
@@ -51,7 +51,7 @@ static uint8_t decode_table[] = {
 
 static const uint8_t tail_xtra[4] = {0, 0, 1, 2};
 
-static bool input_is_valid(uint8_t* input_ptr, size_t length) {
+static bool input_is_valid(const uint8_t* input_ptr, size_t length) {
   size_t i;
 
   for (i = 0; i < length; ++i) {
@@ -158,7 +158,7 @@ bool grpc_base64_decode_partial(struct grpc_base64_decode_context* ctx) {
   return true;
 }
 
-grpc_slice grpc_chttp2_base64_decode(grpc_slice input) {
+grpc_slice grpc_chttp2_base64_decode(const grpc_slice& input) {
   size_t input_length = GRPC_SLICE_LENGTH(input);
   size_t output_length = input_length / 4 * 3;
   struct grpc_base64_decode_context ctx;
@@ -174,7 +174,7 @@ grpc_slice grpc_chttp2_base64_decode(grpc_slice input) {
   }
 
   if (input_length > 0) {
-    uint8_t* input_end = GRPC_SLICE_END_PTR(input);
+    const uint8_t* input_end = GRPC_SLICE_END_PTR(input);
     if (*(--input_end) == '=') {
       output_length--;
       if (*(--input_end) == '=') {
@@ -202,7 +202,7 @@ grpc_slice grpc_chttp2_base64_decode(grpc_slice input) {
   return output;
 }
 
-grpc_slice grpc_chttp2_base64_decode_with_length(grpc_slice input,
+grpc_slice grpc_chttp2_base64_decode_with_length(const grpc_slice& input,
                                                  size_t output_length) {
   size_t input_length = GRPC_SLICE_LENGTH(input);
   grpc_slice output = GRPC_SLICE_MALLOC(output_length);

--- a/src/core/ext/transport/chttp2/transport/bin_decoder.h
+++ b/src/core/ext/transport/chttp2/transport/bin_decoder.h
@@ -26,8 +26,8 @@
 
 struct grpc_base64_decode_context {
   /* input/output: */
-  uint8_t* input_cur;
-  uint8_t* input_end;
+  const uint8_t* input_cur;
+  const uint8_t* input_end;
   uint8_t* output_cur;
   uint8_t* output_end;
   /* Indicate if the decoder should handle the tail of input data*/
@@ -42,12 +42,12 @@ bool grpc_base64_decode_partial(struct grpc_base64_decode_context* ctx);
 
 /* base64 decode a slice with pad chars. Returns a new slice, does not take
    ownership of the input. Returns an empty slice if decoding is failed. */
-grpc_slice grpc_chttp2_base64_decode(grpc_slice input);
+grpc_slice grpc_chttp2_base64_decode(const grpc_slice& input);
 
 /* base64 decode a slice without pad chars, data length is needed. Returns a new
    slice, does not take ownership of the input. Returns an empty slice if
    decoding is failed. */
-grpc_slice grpc_chttp2_base64_decode_with_length(grpc_slice input,
+grpc_slice grpc_chttp2_base64_decode_with_length(const grpc_slice& input,
                                                  size_t output_length);
 
 /* Infer the length of decoded data from encoded data. */

--- a/src/core/ext/transport/chttp2/transport/bin_encoder.cc
+++ b/src/core/ext/transport/chttp2/transport/bin_encoder.cc
@@ -48,13 +48,13 @@ static const b64_huff_sym huff_alphabet[64] = {
 
 static const uint8_t tail_xtra[3] = {0, 2, 3};
 
-grpc_slice grpc_chttp2_base64_encode(grpc_slice input) {
+grpc_slice grpc_chttp2_base64_encode(const grpc_slice& input) {
   size_t input_length = GRPC_SLICE_LENGTH(input);
   size_t input_triplets = input_length / 3;
   size_t tail_case = input_length % 3;
   size_t output_length = input_triplets * 4 + tail_xtra[tail_case];
   grpc_slice output = GRPC_SLICE_MALLOC(output_length);
-  uint8_t* in = GRPC_SLICE_START_PTR(input);
+  const uint8_t* in = GRPC_SLICE_START_PTR(input);
   char* out = reinterpret_cast<char*> GRPC_SLICE_START_PTR(output);
   size_t i;
 
@@ -92,9 +92,9 @@ grpc_slice grpc_chttp2_base64_encode(grpc_slice input) {
   return output;
 }
 
-grpc_slice grpc_chttp2_huffman_compress(grpc_slice input) {
+grpc_slice grpc_chttp2_huffman_compress(const grpc_slice& input) {
   size_t nbits;
-  uint8_t* in;
+  const uint8_t* in;
   uint8_t* out;
   grpc_slice output;
   uint32_t temp = 0;
@@ -166,7 +166,8 @@ static void enc_add1(huff_out* out, uint8_t a) {
   enc_flush_some(out);
 }
 
-grpc_slice grpc_chttp2_base64_encode_and_huffman_compress(grpc_slice input) {
+grpc_slice grpc_chttp2_base64_encode_and_huffman_compress(
+    const grpc_slice& input) {
   size_t input_length = GRPC_SLICE_LENGTH(input);
   size_t input_triplets = input_length / 3;
   size_t tail_case = input_length % 3;
@@ -174,7 +175,7 @@ grpc_slice grpc_chttp2_base64_encode_and_huffman_compress(grpc_slice input) {
   size_t max_output_bits = 11 * output_syms;
   size_t max_output_length = max_output_bits / 8 + (max_output_bits % 8 != 0);
   grpc_slice output = GRPC_SLICE_MALLOC(max_output_length);
-  uint8_t* in = GRPC_SLICE_START_PTR(input);
+  const uint8_t* in = GRPC_SLICE_START_PTR(input);
   uint8_t* start_out = GRPC_SLICE_START_PTR(output);
   huff_out out;
   size_t i;

--- a/src/core/ext/transport/chttp2/transport/bin_encoder.h
+++ b/src/core/ext/transport/chttp2/transport/bin_encoder.h
@@ -25,17 +25,18 @@
 
 /* base64 encode a slice. Returns a new slice, does not take ownership of the
    input */
-grpc_slice grpc_chttp2_base64_encode(grpc_slice input);
+grpc_slice grpc_chttp2_base64_encode(const grpc_slice& input);
 
 /* Compress a slice with the static huffman encoder detailed in the hpack
    standard. Returns a new slice, does not take ownership of the input */
-grpc_slice grpc_chttp2_huffman_compress(grpc_slice input);
+grpc_slice grpc_chttp2_huffman_compress(const grpc_slice& input);
 
 /* equivalent to:
    grpc_slice x = grpc_chttp2_base64_encode(input);
    grpc_slice y = grpc_chttp2_huffman_compress(x);
    grpc_slice_unref_internal( x);
    return y; */
-grpc_slice grpc_chttp2_base64_encode_and_huffman_compress(grpc_slice input);
+grpc_slice grpc_chttp2_base64_encode_and_huffman_compress(
+    const grpc_slice& input);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_BIN_ENCODER_H */

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -1129,7 +1129,7 @@ static void queue_setting_update(grpc_chttp2_transport* t,
 
 void grpc_chttp2_add_incoming_goaway(grpc_chttp2_transport* t,
                                      uint32_t goaway_error,
-                                     grpc_slice goaway_text) {
+                                     const grpc_slice& goaway_text) {
   // Discard the error from a previous goaway frame (if any)
   if (t->goaway_error != GRPC_ERROR_NONE) {
     GRPC_ERROR_UNREF(t->goaway_error);
@@ -2996,7 +2996,7 @@ void Chttp2IncomingByteStream::PublishError(grpc_error* error) {
   grpc_chttp2_cancel_stream(transport_, stream_, GRPC_ERROR_REF(error));
 }
 
-grpc_error* Chttp2IncomingByteStream::Push(grpc_slice slice,
+grpc_error* Chttp2IncomingByteStream::Push(const grpc_slice& slice,
                                            grpc_slice* slice_out) {
   if (remaining_bytes_ < GRPC_SLICE_LENGTH(slice)) {
     grpc_error* error =

--- a/src/core/ext/transport/chttp2/transport/frame_data.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_data.cc
@@ -287,7 +287,8 @@ grpc_error* grpc_deframe_unprocessed_incoming_frames(
 grpc_error* grpc_chttp2_data_parser_parse(void* parser,
                                           grpc_chttp2_transport* t,
                                           grpc_chttp2_stream* s,
-                                          grpc_slice slice, int is_last) {
+                                          const grpc_slice& slice,
+                                          int is_last) {
   if (!s->pending_byte_stream) {
     grpc_slice_ref_internal(slice);
     grpc_slice_buffer_add(&s->frame_storage, slice);

--- a/src/core/ext/transport/chttp2/transport/frame_data.h
+++ b/src/core/ext/transport/chttp2/transport/frame_data.h
@@ -67,7 +67,7 @@ grpc_error* grpc_chttp2_data_parser_begin_frame(grpc_chttp2_data_parser* parser,
 grpc_error* grpc_chttp2_data_parser_parse(void* parser,
                                           grpc_chttp2_transport* t,
                                           grpc_chttp2_stream* s,
-                                          grpc_slice slice, int is_last);
+                                          const grpc_slice& slice, int is_last);
 
 void grpc_chttp2_encode_data(uint32_t id, grpc_slice_buffer* inbuf,
                              uint32_t write_bytes, int is_eof,

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.cc
@@ -57,10 +57,11 @@ grpc_error* grpc_chttp2_goaway_parser_begin_frame(grpc_chttp2_goaway_parser* p,
 grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
                                             grpc_chttp2_transport* t,
                                             grpc_chttp2_stream* s,
-                                            grpc_slice slice, int is_last) {
-  uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
-  uint8_t* const end = GRPC_SLICE_END_PTR(slice);
-  uint8_t* cur = beg;
+                                            const grpc_slice& slice,
+                                            int is_last) {
+  const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
+  const uint8_t* const end = GRPC_SLICE_END_PTR(slice);
+  const uint8_t* cur = beg;
   grpc_chttp2_goaway_parser* p =
       static_cast<grpc_chttp2_goaway_parser*>(parser);
 
@@ -149,7 +150,7 @@ grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
 }
 
 void grpc_chttp2_goaway_append(uint32_t last_stream_id, uint32_t error_code,
-                               grpc_slice debug_data,
+                               const grpc_slice& debug_data,
                                grpc_slice_buffer* slice_buffer) {
   grpc_slice header = GRPC_SLICE_MALLOC(9 + 4 + 4);
   uint8_t* p = GRPC_SLICE_START_PTR(header);

--- a/src/core/ext/transport/chttp2/transport/frame_goaway.h
+++ b/src/core/ext/transport/chttp2/transport/frame_goaway.h
@@ -53,10 +53,11 @@ grpc_error* grpc_chttp2_goaway_parser_begin_frame(
 grpc_error* grpc_chttp2_goaway_parser_parse(void* parser,
                                             grpc_chttp2_transport* t,
                                             grpc_chttp2_stream* s,
-                                            grpc_slice slice, int is_last);
+                                            const grpc_slice& slice,
+                                            int is_last);
 
 void grpc_chttp2_goaway_append(uint32_t last_stream_id, uint32_t error_code,
-                               grpc_slice debug_data,
+                               const grpc_slice& debug_data,
                                grpc_slice_buffer* slice_buffer);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_FRAME_GOAWAY_H */

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -73,10 +73,11 @@ grpc_error* grpc_chttp2_ping_parser_begin_frame(grpc_chttp2_ping_parser* parser,
 grpc_error* grpc_chttp2_ping_parser_parse(void* parser,
                                           grpc_chttp2_transport* t,
                                           grpc_chttp2_stream* s,
-                                          grpc_slice slice, int is_last) {
-  uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
-  uint8_t* const end = GRPC_SLICE_END_PTR(slice);
-  uint8_t* cur = beg;
+                                          const grpc_slice& slice,
+                                          int is_last) {
+  const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
+  const uint8_t* const end = GRPC_SLICE_END_PTR(slice);
+  const uint8_t* cur = beg;
   grpc_chttp2_ping_parser* p = static_cast<grpc_chttp2_ping_parser*>(parser);
 
   while (p->byte != 8 && cur != end) {

--- a/src/core/ext/transport/chttp2/transport/frame_ping.h
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.h
@@ -37,7 +37,7 @@ grpc_error* grpc_chttp2_ping_parser_begin_frame(grpc_chttp2_ping_parser* parser,
 grpc_error* grpc_chttp2_ping_parser_parse(void* parser,
                                           grpc_chttp2_transport* t,
                                           grpc_chttp2_stream* s,
-                                          grpc_slice slice, int is_last);
+                                          const grpc_slice& slice, int is_last);
 
 /* Test-only function for disabling ping ack */
 void grpc_set_disable_ping_ack(bool disable_ping_ack);

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -74,10 +74,11 @@ grpc_error* grpc_chttp2_rst_stream_parser_begin_frame(
 grpc_error* grpc_chttp2_rst_stream_parser_parse(void* parser,
                                                 grpc_chttp2_transport* t,
                                                 grpc_chttp2_stream* s,
-                                                grpc_slice slice, int is_last) {
-  uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
-  uint8_t* const end = GRPC_SLICE_END_PTR(slice);
-  uint8_t* cur = beg;
+                                                const grpc_slice& slice,
+                                                int is_last) {
+  const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
+  const uint8_t* const end = GRPC_SLICE_END_PTR(slice);
+  const uint8_t* cur = beg;
   grpc_chttp2_rst_stream_parser* p =
       static_cast<grpc_chttp2_rst_stream_parser*>(parser);
 

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.h
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.h
@@ -38,6 +38,7 @@ grpc_error* grpc_chttp2_rst_stream_parser_begin_frame(
 grpc_error* grpc_chttp2_rst_stream_parser_parse(void* parser,
                                                 grpc_chttp2_transport* t,
                                                 grpc_chttp2_stream* s,
-                                                grpc_slice slice, int is_last);
+                                                const grpc_slice& slice,
+                                                int is_last);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_FRAME_RST_STREAM_H */

--- a/src/core/ext/transport/chttp2/transport/frame_settings.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.cc
@@ -111,7 +111,8 @@ grpc_error* grpc_chttp2_settings_parser_begin_frame(
 
 grpc_error* grpc_chttp2_settings_parser_parse(void* p, grpc_chttp2_transport* t,
                                               grpc_chttp2_stream* s,
-                                              grpc_slice slice, int is_last) {
+                                              const grpc_slice& slice,
+                                              int is_last) {
   grpc_chttp2_settings_parser* parser =
       static_cast<grpc_chttp2_settings_parser*>(p);
   const uint8_t* cur = GRPC_SLICE_START_PTR(slice);

--- a/src/core/ext/transport/chttp2/transport/frame_settings.h
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.h
@@ -55,6 +55,7 @@ grpc_error* grpc_chttp2_settings_parser_begin_frame(
 grpc_error* grpc_chttp2_settings_parser_parse(void* parser,
                                               grpc_chttp2_transport* t,
                                               grpc_chttp2_stream* s,
-                                              grpc_slice slice, int is_last);
+                                              const grpc_slice& slice,
+                                              int is_last);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_FRAME_SETTINGS_H */

--- a/src/core/ext/transport/chttp2/transport/frame_window_update.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_window_update.cc
@@ -69,11 +69,11 @@ grpc_error* grpc_chttp2_window_update_parser_begin_frame(
 grpc_error* grpc_chttp2_window_update_parser_parse(void* parser,
                                                    grpc_chttp2_transport* t,
                                                    grpc_chttp2_stream* s,
-                                                   grpc_slice slice,
+                                                   const grpc_slice& slice,
                                                    int is_last) {
-  uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
-  uint8_t* const end = GRPC_SLICE_END_PTR(slice);
-  uint8_t* cur = beg;
+  const uint8_t* const beg = GRPC_SLICE_START_PTR(slice);
+  const uint8_t* const end = GRPC_SLICE_END_PTR(slice);
+  const uint8_t* cur = beg;
   grpc_chttp2_window_update_parser* p =
       static_cast<grpc_chttp2_window_update_parser*>(parser);
 

--- a/src/core/ext/transport/chttp2/transport/frame_window_update.h
+++ b/src/core/ext/transport/chttp2/transport/frame_window_update.h
@@ -39,7 +39,7 @@ grpc_error* grpc_chttp2_window_update_parser_begin_frame(
 grpc_error* grpc_chttp2_window_update_parser_parse(void* parser,
                                                    grpc_chttp2_transport* t,
                                                    grpc_chttp2_stream* s,
-                                                   grpc_slice slice,
+                                                   const grpc_slice& slice,
                                                    int is_last);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_FRAME_WINDOW_UPDATE_H */

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -1570,16 +1570,16 @@ void grpc_chttp2_hpack_parser_destroy(grpc_chttp2_hpack_parser* p) {
 }
 
 grpc_error* grpc_chttp2_hpack_parser_parse(grpc_chttp2_hpack_parser* p,
-                                           grpc_slice slice) {
+                                           const grpc_slice& slice) {
 /* max number of bytes to parse at a time... limits call stack depth on
  * compilers without TCO */
 #define MAX_PARSE_LENGTH 1024
   p->current_slice_refcount = slice.refcount;
-  uint8_t* start = GRPC_SLICE_START_PTR(slice);
-  uint8_t* end = GRPC_SLICE_END_PTR(slice);
+  const uint8_t* start = GRPC_SLICE_START_PTR(slice);
+  const uint8_t* end = GRPC_SLICE_END_PTR(slice);
   grpc_error* error = GRPC_ERROR_NONE;
   while (start != end && error == GRPC_ERROR_NONE) {
-    uint8_t* target = start + GPR_MIN(MAX_PARSE_LENGTH, end - start);
+    const uint8_t* target = start + GPR_MIN(MAX_PARSE_LENGTH, end - start);
     error = p->state(p, start, target);
     start = target;
   }
@@ -1621,7 +1621,8 @@ static void parse_stream_compression_md(grpc_chttp2_transport* t,
 grpc_error* grpc_chttp2_header_parser_parse(void* hpack_parser,
                                             grpc_chttp2_transport* t,
                                             grpc_chttp2_stream* s,
-                                            grpc_slice slice, int is_last) {
+                                            const grpc_slice& slice,
+                                            int is_last) {
   GPR_TIMER_SCOPE("grpc_chttp2_header_parser_parse", 0);
   grpc_chttp2_hpack_parser* parser =
       static_cast<grpc_chttp2_hpack_parser*>(hpack_parser);

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.h
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.h
@@ -97,13 +97,14 @@ void grpc_chttp2_hpack_parser_destroy(grpc_chttp2_hpack_parser* p);
 void grpc_chttp2_hpack_parser_set_has_priority(grpc_chttp2_hpack_parser* p);
 
 grpc_error* grpc_chttp2_hpack_parser_parse(grpc_chttp2_hpack_parser* p,
-                                           grpc_slice slice);
+                                           const grpc_slice& slice);
 
 /* wraps grpc_chttp2_hpack_parser_parse to provide a frame level parser for
    the transport */
 grpc_error* grpc_chttp2_header_parser_parse(void* hpack_parser,
                                             grpc_chttp2_transport* t,
                                             grpc_chttp2_stream* s,
-                                            grpc_slice slice, int is_last);
+                                            const grpc_slice& slice,
+                                            int is_last);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_HPACK_PARSER_H */

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -245,7 +245,7 @@ class Chttp2IncomingByteStream : public ByteStream {
 
   void PublishError(grpc_error* error);
 
-  grpc_error* Push(grpc_slice slice, grpc_slice* slice_out);
+  grpc_error* Push(const grpc_slice& slice, grpc_slice* slice_out);
 
   grpc_error* Finished(grpc_error* error, bool reset_on_error);
 
@@ -438,7 +438,8 @@ struct grpc_chttp2_transport {
   void* parser_data = nullptr;
   grpc_chttp2_stream* incoming_stream = nullptr;
   grpc_error* (*parser)(void* parser_user_data, grpc_chttp2_transport* t,
-                        grpc_chttp2_stream* s, grpc_slice slice, int is_last);
+                        grpc_chttp2_stream* s, const grpc_slice& slice,
+                        int is_last);
 
   grpc_chttp2_write_cb* write_cb_pool = nullptr;
 
@@ -681,7 +682,7 @@ void grpc_chttp2_end_write(grpc_chttp2_transport* t, grpc_error* error);
 /** Process one slice of incoming data; return 1 if the connection is still
     viable after reading, or 0 if the connection should be torn down */
 grpc_error* grpc_chttp2_perform_read(grpc_chttp2_transport* t,
-                                     grpc_slice slice);
+                                     const grpc_slice& slice);
 
 bool grpc_chttp2_list_add_writable_stream(grpc_chttp2_transport* t,
                                           grpc_chttp2_stream* s);
@@ -740,7 +741,7 @@ grpc_chttp2_stream* grpc_chttp2_parsing_accept_stream(grpc_chttp2_transport* t,
 
 void grpc_chttp2_add_incoming_goaway(grpc_chttp2_transport* t,
                                      uint32_t goaway_error,
-                                     grpc_slice goaway_text);
+                                     const grpc_slice& goaway_text);
 
 void grpc_chttp2_parsing_become_skip_parser(grpc_chttp2_transport* t);
 

--- a/src/core/ext/transport/chttp2/transport/parsing.cc
+++ b/src/core/ext/transport/chttp2/transport/parsing.cc
@@ -45,14 +45,14 @@ static grpc_error* init_goaway_parser(grpc_chttp2_transport* t);
 static grpc_error* init_skip_frame_parser(grpc_chttp2_transport* t,
                                           int is_header);
 
-static grpc_error* parse_frame_slice(grpc_chttp2_transport* t, grpc_slice slice,
-                                     int is_last);
+static grpc_error* parse_frame_slice(grpc_chttp2_transport* t,
+                                     const grpc_slice& slice, int is_last);
 
 grpc_error* grpc_chttp2_perform_read(grpc_chttp2_transport* t,
-                                     grpc_slice slice) {
-  uint8_t* beg = GRPC_SLICE_START_PTR(slice);
-  uint8_t* end = GRPC_SLICE_END_PTR(slice);
-  uint8_t* cur = beg;
+                                     const grpc_slice& slice) {
+  const uint8_t* beg = GRPC_SLICE_START_PTR(slice);
+  const uint8_t* end = GRPC_SLICE_END_PTR(slice);
+  const uint8_t* cur = beg;
   grpc_error* err;
 
   if (cur == end) return GRPC_ERROR_NONE;
@@ -312,7 +312,7 @@ static grpc_error* init_frame_parser(grpc_chttp2_transport* t) {
 }
 
 static grpc_error* skip_parser(void* parser, grpc_chttp2_transport* t,
-                               grpc_chttp2_stream* s, grpc_slice slice,
+                               grpc_chttp2_stream* s, const grpc_slice& slice,
                                int is_last) {
   return GRPC_ERROR_NONE;
 }
@@ -753,8 +753,8 @@ static grpc_error* init_settings_frame_parser(grpc_chttp2_transport* t) {
   return GRPC_ERROR_NONE;
 }
 
-static grpc_error* parse_frame_slice(grpc_chttp2_transport* t, grpc_slice slice,
-                                     int is_last) {
+static grpc_error* parse_frame_slice(grpc_chttp2_transport* t,
+                                     const grpc_slice& slice, int is_last) {
   grpc_chttp2_stream* s = t->incoming_stream;
   grpc_error* err = t->parser(t->parser_data, t, s, slice, is_last);
   intptr_t unused;

--- a/src/core/lib/channel/channel_trace.cc
+++ b/src/core/lib/channel/channel_trace.cc
@@ -41,7 +41,7 @@
 namespace grpc_core {
 namespace channelz {
 
-ChannelTrace::TraceEvent::TraceEvent(Severity severity, grpc_slice data,
+ChannelTrace::TraceEvent::TraceEvent(Severity severity, const grpc_slice& data,
                                      RefCountedPtr<BaseNode> referenced_entity)
     : severity_(severity),
       data_(data),
@@ -51,7 +51,7 @@ ChannelTrace::TraceEvent::TraceEvent(Severity severity, grpc_slice data,
       referenced_entity_(std::move(referenced_entity)),
       memory_usage_(sizeof(TraceEvent) + grpc_slice_memory_usage(data)) {}
 
-ChannelTrace::TraceEvent::TraceEvent(Severity severity, grpc_slice data)
+ChannelTrace::TraceEvent::TraceEvent(Severity severity, const grpc_slice& data)
     : severity_(severity),
       data_(data),
       timestamp_(grpc_millis_to_timespec(grpc_core::ExecCtx::Get()->Now(),
@@ -107,7 +107,7 @@ void ChannelTrace::AddTraceEventHelper(TraceEvent* new_trace_event) {
   }
 }
 
-void ChannelTrace::AddTraceEvent(Severity severity, grpc_slice data) {
+void ChannelTrace::AddTraceEvent(Severity severity, const grpc_slice& data) {
   if (max_event_memory_ == 0) {
     grpc_slice_unref_internal(data);
     return;  // tracing is disabled if max_event_memory_ == 0
@@ -116,7 +116,7 @@ void ChannelTrace::AddTraceEvent(Severity severity, grpc_slice data) {
 }
 
 void ChannelTrace::AddTraceEventWithReference(
-    Severity severity, grpc_slice data,
+    Severity severity, const grpc_slice& data,
     RefCountedPtr<BaseNode> referenced_entity) {
   if (max_event_memory_ == 0) {
     grpc_slice_unref_internal(data);

--- a/src/core/lib/channel/channel_trace.h
+++ b/src/core/lib/channel/channel_trace.h
@@ -62,7 +62,7 @@ class ChannelTrace {
   // TODO(ncteisen): as this call is used more and more throughout the gRPC
   // stack, determine if it makes more sense to accept a char* instead of a
   // slice.
-  void AddTraceEvent(Severity severity, grpc_slice data);
+  void AddTraceEvent(Severity severity, const grpc_slice& data);
 
   // Adds a new trace event to the tracing object. This trace event refers to a
   // an event that concerns a different channelz entity. For example, if this
@@ -72,7 +72,7 @@ class ChannelTrace {
   // NOTE: see the note in the method above.
   //
   // TODO(ncteisen): see the todo in the method above.
-  void AddTraceEventWithReference(Severity severity, grpc_slice data,
+  void AddTraceEventWithReference(Severity severity, const grpc_slice& data,
                                   RefCountedPtr<BaseNode> referenced_entity);
 
   // Creates and returns the raw grpc_json object, so a parent channelz
@@ -87,12 +87,12 @@ class ChannelTrace {
   class TraceEvent {
    public:
     // Constructor for a TraceEvent that references a channel.
-    TraceEvent(Severity severity, grpc_slice data,
+    TraceEvent(Severity severity, const grpc_slice& data,
                RefCountedPtr<BaseNode> referenced_entity_);
 
     // Constructor for a TraceEvent that does not reverence a different
     // channel.
-    TraceEvent(Severity severity, grpc_slice data);
+    TraceEvent(Severity severity, const grpc_slice& data);
 
     ~TraceEvent();
 

--- a/src/core/lib/channel/channelz.h
+++ b/src/core/lib/channel/channelz.h
@@ -180,11 +180,11 @@ class ChannelNode : public BaseNode {
   bool ChannelIsDestroyed() { return channel_ == nullptr; }
 
   // proxy methods to composed classes.
-  void AddTraceEvent(ChannelTrace::Severity severity, grpc_slice data) {
+  void AddTraceEvent(ChannelTrace::Severity severity, const grpc_slice& data) {
     trace_.AddTraceEvent(severity, data);
   }
   void AddTraceEventWithReference(ChannelTrace::Severity severity,
-                                  grpc_slice data,
+                                  const grpc_slice& data,
                                   RefCountedPtr<BaseNode> referenced_channel) {
     trace_.AddTraceEventWithReference(severity, data,
                                       std::move(referenced_channel));
@@ -214,11 +214,11 @@ class ServerNode : public BaseNode {
                             intptr_t pagination_limit);
 
   // proxy methods to composed classes.
-  void AddTraceEvent(ChannelTrace::Severity severity, grpc_slice data) {
+  void AddTraceEvent(ChannelTrace::Severity severity, const grpc_slice& data) {
     trace_.AddTraceEvent(severity, data);
   }
   void AddTraceEventWithReference(ChannelTrace::Severity severity,
-                                  grpc_slice data,
+                                  const grpc_slice& data,
                                   RefCountedPtr<BaseNode> referenced_channel) {
     trace_.AddTraceEventWithReference(severity, data,
                                       std::move(referenced_channel));

--- a/src/core/lib/compression/algorithm_metadata.h
+++ b/src/core/lib/compression/algorithm_metadata.h
@@ -32,7 +32,7 @@ grpc_slice grpc_compression_algorithm_slice(
 /** Find compression algorithm based on passed in mdstr - returns
  *  GRPC_COMPRESS_ALGORITHM_COUNT on failure */
 grpc_compression_algorithm grpc_compression_algorithm_from_slice(
-    grpc_slice str);
+    const grpc_slice& str);
 
 /** Return compression algorithm based metadata element */
 grpc_mdelem grpc_compression_encoding_mdelem(
@@ -51,11 +51,11 @@ grpc_mdelem grpc_stream_compression_encoding_mdelem(
 /** Find compression algorithm based on passed in mdstr - returns
  * GRPC_COMPRESS_ALGORITHM_COUNT on failure */
 grpc_message_compression_algorithm
-grpc_message_compression_algorithm_from_slice(grpc_slice str);
+grpc_message_compression_algorithm_from_slice(const grpc_slice& str);
 
 /** Find stream compression algorithm based on passed in mdstr - returns
  * GRPC_STREAM_COMPRESS_ALGORITHM_COUNT on failure */
 grpc_stream_compression_algorithm grpc_stream_compression_algorithm_from_slice(
-    grpc_slice str);
+    const grpc_slice& str);
 
 #endif /* GRPC_CORE_LIB_COMPRESSION_ALGORITHM_METADATA_H */

--- a/src/core/lib/compression/compression.cc
+++ b/src/core/lib/compression/compression.cc
@@ -147,7 +147,7 @@ grpc_slice grpc_compression_algorithm_slice(
 }
 
 grpc_compression_algorithm grpc_compression_algorithm_from_slice(
-    grpc_slice str) {
+    const grpc_slice& str) {
   if (grpc_slice_eq(str, GRPC_MDSTR_IDENTITY)) return GRPC_COMPRESS_NONE;
   if (grpc_slice_eq(str, GRPC_MDSTR_DEFLATE)) return GRPC_COMPRESS_DEFLATE;
   if (grpc_slice_eq(str, GRPC_MDSTR_GZIP)) return GRPC_COMPRESS_GZIP;

--- a/src/core/lib/compression/compression_internal.cc
+++ b/src/core/lib/compression/compression_internal.cc
@@ -32,7 +32,7 @@
 /* Interfaces related to MD */
 
 grpc_message_compression_algorithm
-grpc_message_compression_algorithm_from_slice(grpc_slice str) {
+grpc_message_compression_algorithm_from_slice(const grpc_slice& str) {
   if (grpc_slice_eq(str, GRPC_MDSTR_IDENTITY))
     return GRPC_MESSAGE_COMPRESS_NONE;
   if (grpc_slice_eq(str, GRPC_MDSTR_DEFLATE))
@@ -42,7 +42,7 @@ grpc_message_compression_algorithm_from_slice(grpc_slice str) {
 }
 
 grpc_stream_compression_algorithm grpc_stream_compression_algorithm_from_slice(
-    grpc_slice str) {
+    const grpc_slice& str) {
   if (grpc_slice_eq(str, GRPC_MDSTR_IDENTITY)) return GRPC_STREAM_COMPRESS_NONE;
   if (grpc_slice_eq(str, GRPC_MDSTR_GZIP)) return GRPC_STREAM_COMPRESS_GZIP;
   return GRPC_STREAM_COMPRESS_ALGORITHMS_COUNT;

--- a/src/core/lib/http/httpcli.cc
+++ b/src/core/lib/http/httpcli.cc
@@ -229,7 +229,8 @@ static void internal_request_begin(grpc_httpcli_context* context,
                                    const grpc_httpcli_request* request,
                                    grpc_millis deadline, grpc_closure* on_done,
                                    grpc_httpcli_response* response,
-                                   const char* name, grpc_slice request_text) {
+                                   const char* name,
+                                   const grpc_slice& request_text) {
   internal_request* req =
       static_cast<internal_request*>(gpr_malloc(sizeof(internal_request)));
   memset(req, 0, sizeof(*req));

--- a/src/core/lib/http/parser.cc
+++ b/src/core/lib/http/parser.cc
@@ -351,7 +351,8 @@ void grpc_http_response_destroy(grpc_http_response* response) {
   gpr_free(response->hdrs);
 }
 
-grpc_error* grpc_http_parser_parse(grpc_http_parser* parser, grpc_slice slice,
+grpc_error* grpc_http_parser_parse(grpc_http_parser* parser,
+                                   const grpc_slice& slice,
                                    size_t* start_of_body) {
   for (size_t i = 0; i < GRPC_SLICE_LENGTH(slice); i++) {
     bool found_body_start = false;

--- a/src/core/lib/http/parser.h
+++ b/src/core/lib/http/parser.h
@@ -101,7 +101,8 @@ void grpc_http_parser_init(grpc_http_parser* parser, grpc_http_type type,
 void grpc_http_parser_destroy(grpc_http_parser* parser);
 
 /* Sets \a start_of_body to the offset in \a slice of the start of the body. */
-grpc_error* grpc_http_parser_parse(grpc_http_parser* parser, grpc_slice slice,
+grpc_error* grpc_http_parser_parse(grpc_http_parser* parser,
+                                   const grpc_slice& slice,
                                    size_t* start_of_body);
 grpc_error* grpc_http_parser_eof(grpc_http_parser* parser);
 

--- a/src/core/lib/iomgr/error.h
+++ b/src/core/lib/iomgr/error.h
@@ -138,8 +138,9 @@ void grpc_enable_error_creation();
 const char* grpc_error_string(grpc_error* error);
 
 /// Create an error - but use GRPC_ERROR_CREATE instead
-grpc_error* grpc_error_create(const char* file, int line, grpc_slice desc,
-                              grpc_error** referencing, size_t num_referencing);
+grpc_error* grpc_error_create(const char* file, int line,
+                              const grpc_slice& desc, grpc_error** referencing,
+                              size_t num_referencing);
 /// Create an error (this is the preferred way of generating an error that is
 ///   not due to a system call - for system calls, use GRPC_OS_ERROR or
 ///   GRPC_WSA_ERROR as appropriate)
@@ -200,7 +201,7 @@ bool grpc_error_get_int(grpc_error* error, grpc_error_ints which, intptr_t* p);
 /// This call takes ownership of the slice; the error is responsible for
 /// eventually unref-ing it.
 grpc_error* grpc_error_set_str(grpc_error* src, grpc_error_strs which,
-                               grpc_slice str) GRPC_MUST_USE_RESULT;
+                               const grpc_slice& str) GRPC_MUST_USE_RESULT;
 /// Returns false if the specified string is not set.
 /// Caller does NOT own the slice.
 bool grpc_error_get_str(grpc_error* error, grpc_error_strs which,

--- a/src/core/lib/security/credentials/jwt/jwt_verifier.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.cc
@@ -134,7 +134,8 @@ static void jose_header_destroy(jose_header* h) {
 }
 
 /* Takes ownership of json and buffer. */
-static jose_header* jose_header_from_json(grpc_json* json, grpc_slice buffer) {
+static jose_header* jose_header_from_json(grpc_json* json,
+                                          const grpc_slice& buffer) {
   grpc_json* cur;
   jose_header* h = static_cast<jose_header*>(gpr_zalloc(sizeof(jose_header)));
   h->buffer = buffer;
@@ -235,7 +236,8 @@ gpr_timespec grpc_jwt_claims_not_before(const grpc_jwt_claims* claims) {
 }
 
 /* Takes ownership of json and buffer even in case of failure. */
-grpc_jwt_claims* grpc_jwt_claims_from_json(grpc_json* json, grpc_slice buffer) {
+grpc_jwt_claims* grpc_jwt_claims_from_json(grpc_json* json,
+                                           const grpc_slice& buffer) {
   grpc_json* cur;
   grpc_jwt_claims* claims =
       static_cast<grpc_jwt_claims*>(gpr_malloc(sizeof(grpc_jwt_claims)));
@@ -350,7 +352,7 @@ typedef struct {
 /* Takes ownership of the header, claims and signature. */
 static verifier_cb_ctx* verifier_cb_ctx_create(
     grpc_jwt_verifier* verifier, grpc_pollset* pollset, jose_header* header,
-    grpc_jwt_claims* claims, const char* audience, grpc_slice signature,
+    grpc_jwt_claims* claims, const char* audience, const grpc_slice& signature,
     const char* signed_jwt, size_t signed_jwt_len, void* user_data,
     grpc_jwt_verification_done_cb cb) {
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
@@ -602,7 +604,8 @@ static EVP_PKEY* find_verification_key(const grpc_json* json,
 }
 
 static int verify_jwt_signature(EVP_PKEY* key, const char* alg,
-                                grpc_slice signature, grpc_slice signed_data) {
+                                const grpc_slice& signature,
+                                const grpc_slice& signed_data) {
   EVP_MD_CTX* md_ctx = EVP_MD_CTX_create();
   const EVP_MD* md = evp_md_from_alg(alg);
   int result = 0;

--- a/src/core/lib/security/credentials/jwt/jwt_verifier.h
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.h
@@ -115,7 +115,8 @@ void grpc_jwt_verifier_verify(grpc_jwt_verifier* verifier,
 
 /* --- TESTING ONLY exposed functions. --- */
 
-grpc_jwt_claims* grpc_jwt_claims_from_json(grpc_json* json, grpc_slice buffer);
+grpc_jwt_claims* grpc_jwt_claims_from_json(grpc_json* json,
+                                           const grpc_slice& buffer);
 grpc_jwt_verifier_status grpc_jwt_claims_check(const grpc_jwt_claims* claims,
                                                const char* audience);
 const char* grpc_jwt_issuer_email_domain(const char* issuer);

--- a/src/core/lib/security/transport/auth_filters.h
+++ b/src/core/lib/security/transport/auth_filters.h
@@ -28,8 +28,8 @@ extern const grpc_channel_filter grpc_client_auth_filter;
 extern const grpc_channel_filter grpc_server_auth_filter;
 
 void grpc_auth_metadata_context_build(
-    const char* url_scheme, grpc_slice call_host, grpc_slice call_method,
-    grpc_auth_context* auth_context,
+    const char* url_scheme, const grpc_slice& call_host,
+    const grpc_slice& call_method, grpc_auth_context* auth_context,
     grpc_auth_metadata_context* auth_md_context);
 
 void grpc_auth_metadata_context_reset(grpc_auth_metadata_context* context);

--- a/src/core/lib/security/transport/client_auth_filter.cc
+++ b/src/core/lib/security/transport/client_auth_filter.cc
@@ -155,8 +155,8 @@ static void on_credentials_metadata(void* arg, grpc_error* input_error) {
 }
 
 void grpc_auth_metadata_context_build(
-    const char* url_scheme, grpc_slice call_host, grpc_slice call_method,
-    grpc_auth_context* auth_context,
+    const char* url_scheme, const grpc_slice& call_host,
+    const grpc_slice& call_method, grpc_auth_context* auth_context,
     grpc_auth_metadata_context* auth_md_context) {
   char* service = grpc_slice_to_c_string(call_method);
   char* last_slash = strrchr(service, '/');

--- a/src/core/lib/slice/percent_encoding.cc
+++ b/src/core/lib/slice/percent_encoding.cc
@@ -38,7 +38,7 @@ static bool is_unreserved_character(uint8_t c,
   return ((unreserved_bytes[c / 8] >> (c % 8)) & 1) != 0;
 }
 
-grpc_slice grpc_percent_encode_slice(grpc_slice slice,
+grpc_slice grpc_percent_encode_slice(const grpc_slice& slice,
                                      const uint8_t* unreserved_bytes) {
   static const uint8_t hex[] = "0123456789ABCDEF";
 
@@ -86,7 +86,7 @@ static uint8_t dehex(uint8_t c) {
   GPR_UNREACHABLE_CODE(return 255);
 }
 
-bool grpc_strict_percent_decode_slice(grpc_slice slice_in,
+bool grpc_strict_percent_decode_slice(const grpc_slice& slice_in,
                                       const uint8_t* unreserved_bytes,
                                       grpc_slice* slice_out) {
   const uint8_t* p = GRPC_SLICE_START_PTR(slice_in);
@@ -126,7 +126,7 @@ bool grpc_strict_percent_decode_slice(grpc_slice slice_in,
   return true;
 }
 
-grpc_slice grpc_permissive_percent_decode_slice(grpc_slice slice_in) {
+grpc_slice grpc_permissive_percent_decode_slice(const grpc_slice& slice_in) {
   const uint8_t* p = GRPC_SLICE_START_PTR(slice_in);
   const uint8_t* in_end = GRPC_SLICE_END_PTR(slice_in);
   size_t out_length = 0;

--- a/src/core/lib/slice/percent_encoding.h
+++ b/src/core/lib/slice/percent_encoding.h
@@ -46,7 +46,7 @@ extern const uint8_t grpc_compatible_percent_encoding_unreserved_bytes[256 / 8];
 /* Percent-encode a slice, returning the new slice (this cannot fail):
    unreserved_bytes is a bitfield indicating which bytes are considered
    unreserved and thus do not need percent encoding */
-grpc_slice grpc_percent_encode_slice(grpc_slice slice,
+grpc_slice grpc_percent_encode_slice(const grpc_slice& slice,
                                      const uint8_t* unreserved_bytes);
 /* Percent-decode a slice, strictly.
    If the input is legal (contains no unreserved bytes, and legal % encodings),
@@ -54,12 +54,12 @@ grpc_slice grpc_percent_encode_slice(grpc_slice slice,
    If the input is not legal, returns false and leaves *slice_out untouched.
    unreserved_bytes is a bitfield indicating which bytes are considered
    unreserved and thus do not need percent encoding */
-bool grpc_strict_percent_decode_slice(grpc_slice slice_in,
+bool grpc_strict_percent_decode_slice(const grpc_slice& slice_in,
                                       const uint8_t* unreserved_bytes,
                                       grpc_slice* slice_out);
 /* Percent-decode a slice, permissively.
    If a % triplet can not be decoded, pass it through verbatim.
    This cannot fail. */
-grpc_slice grpc_permissive_percent_decode_slice(grpc_slice slice_in);
+grpc_slice grpc_permissive_percent_decode_slice(const grpc_slice& slice_in);
 
 #endif /* GRPC_CORE_LIB_SLICE_PERCENT_ENCODING_H */

--- a/src/core/lib/slice/slice.cc
+++ b/src/core/lib/slice/slice.cc
@@ -50,19 +50,6 @@ grpc_slice grpc_slice_copy(grpc_slice s) {
   return out;
 }
 
-grpc_slice grpc_slice_ref_internal(grpc_slice slice) {
-  if (slice.refcount) {
-    slice.refcount->vtable->ref(slice.refcount);
-  }
-  return slice;
-}
-
-void grpc_slice_unref_internal(grpc_slice slice) {
-  if (slice.refcount) {
-    slice.refcount->vtable->unref(slice.refcount);
-  }
-}
-
 /* Public API */
 grpc_slice grpc_slice_ref(grpc_slice slice) {
   return grpc_slice_ref_internal(slice);

--- a/src/core/lib/slice/slice_hash_table.h
+++ b/src/core/lib/slice/slice_hash_table.h
@@ -88,7 +88,7 @@ class SliceHashTable : public RefCounted<SliceHashTable<T>> {
   SliceHashTable(size_t num_entries, Entry* entries, ValueCmp value_cmp);
   virtual ~SliceHashTable();
 
-  void Add(grpc_slice key, T& value);
+  void Add(const grpc_slice& key, T& value);
 
   // Default value comparison function, if none specified by caller.
   static int DefaultValueCmp(const T& a, const T& b) { return GPR_ICMP(a, b); }
@@ -137,7 +137,7 @@ SliceHashTable<T>::~SliceHashTable() {
 }
 
 template <typename T>
-void SliceHashTable<T>::Add(grpc_slice key, T& value) {
+void SliceHashTable<T>::Add(const grpc_slice& key, T& value) {
   const size_t hash = grpc_slice_hash(key);
   for (size_t offset = 0; offset < size_; ++offset) {
     const size_t idx = (hash + offset) % size_;

--- a/src/core/lib/slice/slice_intern.cc
+++ b/src/core/lib/slice/slice_intern.cc
@@ -196,7 +196,7 @@ grpc_slice grpc_slice_maybe_static_intern(grpc_slice slice,
   return slice;
 }
 
-bool grpc_slice_is_interned(grpc_slice slice) {
+bool grpc_slice_is_interned(const grpc_slice& slice) {
   return (slice.refcount && slice.refcount->vtable == &interned_slice_vtable) ||
          GRPC_IS_STATIC_METADATA_STRING(slice);
 }

--- a/src/core/lib/slice/slice_internal.h
+++ b/src/core/lib/slice/slice_internal.h
@@ -24,15 +24,26 @@
 #include <grpc/slice.h>
 #include <grpc/slice_buffer.h>
 
-grpc_slice grpc_slice_ref_internal(grpc_slice slice);
-void grpc_slice_unref_internal(grpc_slice slice);
+inline const grpc_slice& grpc_slice_ref_internal(const grpc_slice& slice) {
+  if (slice.refcount) {
+    slice.refcount->vtable->ref(slice.refcount);
+  }
+  return slice;
+}
+
+inline void grpc_slice_unref_internal(const grpc_slice& slice) {
+  if (slice.refcount) {
+    slice.refcount->vtable->unref(slice.refcount);
+  }
+}
+
 void grpc_slice_buffer_reset_and_unref_internal(grpc_slice_buffer* sb);
 void grpc_slice_buffer_partial_unref_internal(grpc_slice_buffer* sb,
                                               size_t idx);
 void grpc_slice_buffer_destroy_internal(grpc_slice_buffer* sb);
 
 /* Check if a slice is interned */
-bool grpc_slice_is_interned(grpc_slice slice);
+bool grpc_slice_is_interned(const grpc_slice& slice);
 
 void grpc_slice_intern_init(void);
 void grpc_slice_intern_shutdown(void);

--- a/src/core/lib/slice/slice_traits.h
+++ b/src/core/lib/slice/slice_traits.h
@@ -24,8 +24,8 @@
 #include <grpc/slice.h>
 #include <stdbool.h>
 
-bool grpc_slice_is_legal_header(grpc_slice s);
-bool grpc_slice_is_legal_nonbin_header(grpc_slice s);
-bool grpc_slice_is_bin_suffixed(grpc_slice s);
+bool grpc_slice_is_legal_header(const grpc_slice& s);
+bool grpc_slice_is_legal_nonbin_header(const grpc_slice& s);
+bool grpc_slice_is_bin_suffixed(const grpc_slice& s);
 
 #endif /* GRPC_CORE_LIB_SLICE_SLICE_TRAITS_H */

--- a/src/core/lib/slice/slice_weak_hash_table.h
+++ b/src/core/lib/slice/slice_weak_hash_table.h
@@ -46,7 +46,7 @@ class SliceWeakHashTable : public RefCounted<SliceWeakHashTable<T, Size>> {
 
   /// Add a mapping from \a key to \a value, taking ownership of \a key. This
   /// operation will always succeed. It may discard older entries.
-  void Add(grpc_slice key, T value) {
+  void Add(const grpc_slice& key, T value) {
     const size_t idx = grpc_slice_hash(key) % Size;
     entries_[idx].Set(key, std::move(value));
     return;
@@ -54,7 +54,7 @@ class SliceWeakHashTable : public RefCounted<SliceWeakHashTable<T, Size>> {
 
   /// Returns the value from the table associated with / \a key or null if not
   /// found.
-  const T* Get(const grpc_slice key) const {
+  const T* Get(const grpc_slice& key) const {
     const size_t idx = grpc_slice_hash(key) % Size;
     const auto& entry = entries_[idx];
     return grpc_slice_eq(entry.key(), key) ? entry.value() : nullptr;
@@ -79,7 +79,7 @@ class SliceWeakHashTable : public RefCounted<SliceWeakHashTable<T, Size>> {
     ~Entry() {
       if (is_set_) grpc_slice_unref_internal(key_);
     }
-    grpc_slice key() const { return key_; }
+    const grpc_slice& key() const { return key_; }
 
     /// Return the entry's value, or null if unset.
     const T* value() const {
@@ -88,7 +88,7 @@ class SliceWeakHashTable : public RefCounted<SliceWeakHashTable<T, Size>> {
     }
 
     /// Set the \a key and \a value (which is moved) for the entry.
-    void Set(grpc_slice key, T&& value) {
+    void Set(const grpc_slice& key, T&& value) {
       if (is_set_) grpc_slice_unref_internal(key_);
       key_ = key;
       value_ = std::move(value);

--- a/src/core/lib/transport/metadata_batch.cc
+++ b/src/core/lib/transport/metadata_batch.cc
@@ -227,7 +227,7 @@ void grpc_metadata_batch_remove(grpc_metadata_batch* batch,
 }
 
 void grpc_metadata_batch_set_value(grpc_linked_mdelem* storage,
-                                   grpc_slice value) {
+                                   const grpc_slice& value) {
   grpc_mdelem old_mdelem = storage->md;
   grpc_mdelem new_mdelem = grpc_mdelem_from_slices(
       grpc_slice_ref_internal(GRPC_MDKEY(old_mdelem)), value);

--- a/src/core/lib/transport/metadata_batch.h
+++ b/src/core/lib/transport/metadata_batch.h
@@ -74,7 +74,7 @@ grpc_error* grpc_metadata_batch_substitute(grpc_metadata_batch* batch,
                                            grpc_mdelem new_value);
 
 void grpc_metadata_batch_set_value(grpc_linked_mdelem* storage,
-                                   grpc_slice value);
+                                   const grpc_slice& value);
 
 /** Add \a storage to the beginning of \a batch. storage->md is
     assumed to be valid.

--- a/src/core/lib/transport/service_config.h
+++ b/src/core/lib/transport/service_config.h
@@ -92,7 +92,7 @@ class ServiceConfig : public RefCounted<ServiceConfig> {
   /// Caller does NOT own a reference to the result.
   template <typename T>
   static RefCountedPtr<T> MethodConfigTableLookup(
-      const SliceHashTable<RefCountedPtr<T>>& table, grpc_slice path);
+      const SliceHashTable<RefCountedPtr<T>>& table, const grpc_slice& path);
 
  private:
   // So New() can call our private ctor.
@@ -223,7 +223,7 @@ ServiceConfig::CreateMethodConfigTable(CreateValue<T> create_value) {
 
 template <typename T>
 RefCountedPtr<T> ServiceConfig::MethodConfigTableLookup(
-    const SliceHashTable<RefCountedPtr<T>>& table, grpc_slice path) {
+    const SliceHashTable<RefCountedPtr<T>>& table, const grpc_slice& path) {
   const RefCountedPtr<T>* value = table.Get(path);
   // If we didn't find a match for the path, try looking for a wildcard
   // entry (i.e., change "/service/method" to "/service/*").

--- a/src/core/lib/transport/timeout_encoding.cc
+++ b/src/core/lib/transport/timeout_encoding.cc
@@ -89,7 +89,7 @@ static int is_all_whitespace(const char* p, const char* end) {
   return p == end;
 }
 
-int grpc_http2_decode_timeout(grpc_slice text, grpc_millis* timeout) {
+int grpc_http2_decode_timeout(const grpc_slice& text, grpc_millis* timeout) {
   grpc_millis x = 0;
   const uint8_t* p = GRPC_SLICE_START_PTR(text);
   const uint8_t* end = GRPC_SLICE_END_PTR(text);

--- a/src/core/lib/transport/timeout_encoding.h
+++ b/src/core/lib/transport/timeout_encoding.h
@@ -32,6 +32,6 @@
 /* Encode/decode timeouts to the GRPC over HTTP/2 format;
    encoding may round up arbitrarily */
 void grpc_http2_encode_timeout(grpc_millis timeout, char* buffer);
-int grpc_http2_decode_timeout(grpc_slice text, grpc_millis* timeout);
+int grpc_http2_decode_timeout(const grpc_slice& text, grpc_millis* timeout);
 
 #endif /* GRPC_CORE_LIB_TRANSPORT_TIMEOUT_ENCODING_H */

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.cc
@@ -363,7 +363,7 @@ static tsi_result handshaker_client_next(alts_handshaker_client* c,
   alts_grpc_handshaker_client* client =
       reinterpret_cast<alts_grpc_handshaker_client*>(c);
   grpc_slice_unref_internal(client->recv_bytes);
-  client->recv_bytes = grpc_slice_ref(*bytes_received);
+  client->recv_bytes = grpc_slice_ref_internal(*bytes_received);
   grpc_byte_buffer* buffer = get_serialized_next(bytes_received);
   if (buffer == nullptr) {
     gpr_log(GPR_ERROR, "get_serialized_next() failed");
@@ -406,7 +406,7 @@ static const alts_handshaker_client_vtable vtable = {
 alts_handshaker_client* alts_grpc_handshaker_client_create(
     alts_tsi_handshaker* handshaker, grpc_channel* channel,
     const char* handshaker_service_url, grpc_pollset_set* interested_parties,
-    grpc_alts_credentials_options* options, grpc_slice target_name,
+    grpc_alts_credentials_options* options, const grpc_slice& target_name,
     grpc_iomgr_cb_func grpc_cb, tsi_handshaker_on_next_done_cb cb,
     void* user_data, alts_handshaker_client_vtable* vtable_for_testing,
     bool is_client) {
@@ -487,7 +487,7 @@ void alts_handshaker_client_set_recv_bytes_for_testing(
   GPR_ASSERT(c != nullptr);
   alts_grpc_handshaker_client* client =
       reinterpret_cast<alts_grpc_handshaker_client*>(c);
-  client->recv_bytes = grpc_slice_ref(*recv_bytes);
+  client->recv_bytes = grpc_slice_ref_internal(*recv_bytes);
 }
 
 void alts_handshaker_client_set_fields_for_testing(

--- a/src/core/tsi/alts/handshaker/alts_handshaker_client.h
+++ b/src/core/tsi/alts/handshaker/alts_handshaker_client.h
@@ -138,7 +138,7 @@ void alts_handshaker_client_destroy(alts_handshaker_client* client);
 alts_handshaker_client* alts_grpc_handshaker_client_create(
     alts_tsi_handshaker* handshaker, grpc_channel* channel,
     const char* handshaker_service_url, grpc_pollset_set* interested_parties,
-    grpc_alts_credentials_options* options, grpc_slice target_name,
+    grpc_alts_credentials_options* options, const grpc_slice& target_name,
     grpc_iomgr_cb_func grpc_cb, tsi_handshaker_on_next_done_cb cb,
     void* user_data, alts_handshaker_client_vtable* vtable_for_testing,
     bool is_client);

--- a/src/core/tsi/alts/handshaker/transport_security_common_api.cc
+++ b/src/core/tsi/alts/handshaker/transport_security_common_api.cc
@@ -106,15 +106,16 @@ bool grpc_gcp_rpc_protocol_versions_encode(
 }
 
 bool grpc_gcp_rpc_protocol_versions_decode(
-    grpc_slice slice, grpc_gcp_rpc_protocol_versions* versions) {
+    const grpc_slice& slice, grpc_gcp_rpc_protocol_versions* versions) {
   if (versions == nullptr) {
     gpr_log(GPR_ERROR,
             "version is nullptr in "
             "grpc_gcp_rpc_protocol_versions_decode().");
     return false;
   }
-  pb_istream_t stream = pb_istream_from_buffer(GRPC_SLICE_START_PTR(slice),
-                                               GRPC_SLICE_LENGTH(slice));
+  pb_istream_t stream =
+      pb_istream_from_buffer(const_cast<uint8_t*>(GRPC_SLICE_START_PTR(slice)),
+                             GRPC_SLICE_LENGTH(slice));
   if (!pb_decode(&stream, grpc_gcp_RpcProtocolVersions_fields, versions)) {
     gpr_log(GPR_ERROR, "nanopb error: %s", PB_GET_ERROR(&stream));
     return false;

--- a/src/core/tsi/alts/handshaker/transport_security_common_api.h
+++ b/src/core/tsi/alts/handshaker/transport_security_common_api.h
@@ -112,7 +112,7 @@ bool grpc_gcp_rpc_protocol_versions_encode(
  * The method returns true on success and false otherwise.
  */
 bool grpc_gcp_rpc_protocol_versions_decode(
-    grpc_slice slice, grpc_gcp_rpc_protocol_versions* versions);
+    const grpc_slice& slice, grpc_gcp_rpc_protocol_versions* versions);
 
 /**
  * This method performs a deep copy operation on rpc protocol versions


### PR DESCRIPTION
Passing grpc_slice by value and/or returning it can be very costly,
introducing many extra instructions to push the structure to the
stack and poping it.

This CL, wherever possible, changes grpc_slice to be passed by
value.

On a local benchmark, I obserse 4-7% improvements in latency and QPS.

There are still copies to the slice_ref vtable which @arjunroy
is fixing as part of his major effort to use grpc_core::RefCount
for slices and devirtualizing them.