### PR TITLE
run_tests.py: increase timeout for pre-build step (needed for cmake configuration on win2016)

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -106,6 +106,7 @@ def platform_string():
 
 
 _DEFAULT_TIMEOUT_SECONDS = 5 * 60
+_PRE_BUILD_STEP_TIMEOUT_SECONDS = 10 * 60
 
 
 def run_shell_command(cmd, env=None, cwd=None):
@@ -1634,7 +1635,10 @@ def build_step_environ(cfg):
 build_steps = list(
     set(
         jobset.JobSpec(
-            cmdline, environ=build_step_environ(build_config), flake_retries=2)
+            cmdline,
+            environ=build_step_environ(build_config),
+            timeout_seconds=_PRE_BUILD_STEP_TIMEOUT_SECONDS,
+            flake_retries=2)
         for l in languages
         for cmdline in l.pre_build_steps()))
 if make_targets:


### PR DESCRIPTION
This is needed because for some reason the cmake configuration step is taking much longer on Windows 2016 (and windows 10) than it does on win 7 (which is where we are running our tests anyway).
I tried to diagnose why this is the case, but didn't spot anything suspicious - it just seems to be the way it is.