### PR TITLE
Add retries for downloading interop matrix images

### DIFF
--- a/tools/interop_matrix/run_interop_matrix_tests.py
+++ b/tools/interop_matrix/run_interop_matrix_tests.py
@@ -224,7 +224,8 @@ def _pull_images_for_lang(lang, images):
             cmdline=cmdline,
             shortname='pull_image_%s' % (image),
             timeout_seconds=_PULL_IMAGE_TIMEOUT_SECONDS,
-            shell=True)
+            shell=True,
+            flake_retries=2)
         download_specs.append(spec)
     # too many image downloads at once tend to get stuck
     max_pull_jobs = min(args.jobs, _MAX_PARALLEL_DOWNLOADS)


### PR DESCRIPTION
Retry if downloading the image from GCR fails.
This is to prevent b/122124535. The problems seems not to be a flaky download itself, 
but gcloud authentication (that we need to download from GCR), which doesn't work reliably if multiple attempts to authenticate run in parallel.

Let's see if just adding retries help. If not, we'll need to look into adding a backoff timeout or use a different authentication method.

