### PR TITLE
Store LB policy name in Config object.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy.h
+++ b/src/core/ext/filters/client_channel/lb_policy.h
@@ -210,7 +210,8 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
            RefCountedPtr<ServiceConfig> service_config)
         : json_(lb_config), service_config_(std::move(service_config)) {}
 
-    const grpc_json* json() const { return json_; }
+    const char* name() const { return json_->key; }
+    const grpc_json* config() const { return json_->child; }
     RefCountedPtr<ServiceConfig> service_config() const {
       return service_config_;
     }

--- a/src/core/ext/filters/client_channel/resolver_result_parsing.cc
+++ b/src/core/ext/filters/client_channel/resolver_result_parsing.cc
@@ -148,8 +148,8 @@ void ProcessedResolverResult::ParseLbConfigFromServiceConfig(
       LoadBalancingPolicy::ParseLoadBalancingConfig(field);
   if (policy != nullptr) {
     lb_policy_name_.reset(gpr_strdup(policy->key));
-    lb_policy_config_ = MakeRefCounted<LoadBalancingPolicy::Config>(
-        policy->child, service_config_);
+    lb_policy_config_ =
+        MakeRefCounted<LoadBalancingPolicy::Config>(policy, service_config_);
   }
 }
 


### PR DESCRIPTION
This will make it possible to pass the child policy name into `ResolvingLoadBalancingPolicy` in the xds policy via `UpdateLocked()`.