### PR TITLE
Fix pylint on 1.19.x - backport #18190

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -247,7 +247,7 @@ def _consume_request_iterator(request_iterator, state, call, request_serializer,
     consumption_thread.start()
 
 
-class _Rendezvous(grpc.RpcError, grpc.Future, grpc.Call):
+class _Rendezvous(grpc.RpcError, grpc.Future, grpc.Call):  # pylint: disable=too-many-ancestors
 
     def __init__(self, state, call, response_deserializer, deadline):
         super(_Rendezvous, self).__init__()

--- a/src/python/grpcio/grpc/_interceptor.py
+++ b/src/python/grpcio/grpc/_interceptor.py
@@ -80,7 +80,7 @@ def _unwrap_client_call_details(call_details, default_details):
     return method, timeout, metadata, credentials, wait_for_ready
 
 
-class _FailureOutcome(grpc.RpcError, grpc.Future, grpc.Call):
+class _FailureOutcome(grpc.RpcError, grpc.Future, grpc.Call):  # pylint: disable=too-many-ancestors
 
     def __init__(self, exception, traceback):
         super(_FailureOutcome, self).__init__()
@@ -126,7 +126,7 @@ class _FailureOutcome(grpc.RpcError, grpc.Future, grpc.Call):
     def traceback(self, ignored_timeout=None):
         return self._traceback
 
-    def add_callback(self, callback):
+    def add_callback(self, unused_callback):
         return False
 
     def add_done_callback(self, fn):


### PR DESCRIPTION
Fixes Sanity on 1.19.x (allows https://github.com/grpc/grpc/pull/18202 to proceed).

Backports PR #18190 to 1.19.x, to fix sanity on 1.19.x