### PR TITLE
Update doc to use clang-5.0

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -12,7 +12,7 @@ gRPC C++ - Building from source
 If you plan to build from source and run tests, install the following as well:
 ```sh
  $ [sudo] apt-get install libgflags-dev libgtest-dev
- $ [sudo] apt-get install clang libc++-dev
+ $ [sudo] apt-get install clang-5.0 libc++-dev
 ```
 
 ## MacOS


### PR DESCRIPTION
Otherwise, errors like the below one will appear.

```
src/core/lib/debug/trace.cc:24:10: fatal error: 'type_traits' file not found
#include <type_traits>
```