### PR TITLE
Fix Hang in build_ext

### DIFF
--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -217,15 +217,12 @@ class BuildExt(build_ext.build_ext):
             """Test if default compiler is okay with specifying c++ version
             when invoked in C mode. GCC is okay with this, while clang is not.
             """
-            print("Checking if compiler okay")
             cc_test = subprocess.Popen(
                 ['cc', '-x', 'c', '-std=c++11', '-'],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
-            print("Attempting to communicate")
             _, cc_err = cc_test.communicate(input=b'int main(){return 0;}')
-            print("Completed with compiler")
             return not 'invalid argument' in str(cc_err)
 
         # This special conditioning is here due to difference of compiler

--- a/src/python/grpcio/commands.py
+++ b/src/python/grpcio/commands.py
@@ -217,11 +217,15 @@ class BuildExt(build_ext.build_ext):
             """Test if default compiler is okay with specifying c++ version
             when invoked in C mode. GCC is okay with this, while clang is not.
             """
+            print("Checking if compiler okay")
             cc_test = subprocess.Popen(
                 ['cc', '-x', 'c', '-std=c++11', '-'],
+                stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE)
-            _, cc_err = cc_test.communicate(input='int main(){return 0;}')
+            print("Attempting to communicate")
+            _, cc_err = cc_test.communicate(input=b'int main(){return 0;}')
+            print("Completed with compiler")
             return not 'invalid argument' in str(cc_err)
 
         # This special conditioning is here due to difference of compiler


### PR DESCRIPTION
The python documentation stipulates
 > Note that if you want to send data to the process’s stdin, you need to create the Popen object with stdin=PIPE. Similarly, to get anything other than None in the result tuple, you need to give stdout=PIPE and/or stderr=PIPE too.

So I'm not 100% sure how this was working before. But in the past month or so, it stopped working. This PR updates our heuristic check to be compliant with the specification of the `subprocess` module.