### PR TITLE
Revert "Strip Python wheel binary"

### DIFF
--- a/test/distrib/python/test_packages.sh
+++ b/test/distrib/python/test_packages.sh
@@ -41,7 +41,7 @@ PYTHON=$VIRTUAL_ENV/bin/python
 
 function at_least_one_installs() {
   for file in "$@"; do
-    if "$PYTHON" -m pip install --require-hashes "$file"; then
+    if "$PYTHON" -m pip install "$file"; then
       return 0
     fi
   done

--- a/tools/run_tests/artifacts/build_package_python.sh
+++ b/tools/run_tests/artifacts/build_package_python.sh
@@ -23,24 +23,6 @@ mkdir -p artifacts/
 # and we only collect them here to deliver them to the distribtest phase.
 cp -r "${EXTERNAL_GIT_ROOT}"/input_artifacts/python_*/* artifacts/ || true
 
-strip_binary_wheel() {
-    WHEEL_PATH="$1"
-    TEMP_WHEEL_DIR=$(mktemp -d)
-    wheel unpack "$WHEEL_PATH" -d "$TEMP_WHEEL_DIR"
-    find "$TEMP_WHEEL_DIR" -name "_protoc_compiler*.so" -exec strip --strip-debug {} ";"
-    find "$TEMP_WHEEL_DIR" -name "cygrpc*.so" -exec strip --strip-debug {} ";"
-
-    WHEEL_FILE=$(basename "$WHEEL_PATH")
-    DISTRIBUTION_NAME=$(basename "$WHEEL_PATH" | cut -d '-' -f 1)
-    VERSION=$(basename "$WHEEL_PATH" | cut -d '-' -f 2)
-    wheel pack "$TEMP_WHEEL_DIR/$DISTRIBUTION_NAME-$VERSION" -d "$TEMP_WHEEL_DIR"
-    mv "$TEMP_WHEEL_DIR/$WHEEL_FILE" "$WHEEL_PATH"
-}
-
-for wheel in artifacts/*.whl; do
-    strip_binary_wheel "$wheel"
-done
-
 # TODO: all the artifact builder configurations generate a grpcio-VERSION.tar.gz
 # source distribution package, and only one of them will end up
 # in the artifacts/ directory. They should be all equivalent though.


### PR DESCRIPTION
Reverts grpc/grpc#18241

Looks like the PR is breaking https://source.cloud.google.com/results/invocations/aa0c24cb-4ae7-4a67-bc0d-34360a95529d/targets/github%2Fgrpc/tests;group=tasks;test=build_package.python_package;row=1

https://fusion.corp.google.com/projectanalysis/current/KOKORO/prod%3Agrpc%2Fcore%2Fmaster%2Flinux%2Fgrpc_build_packages

