### PR TITLE
Make grpclb work when selected via service config with no balancer addresses.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb.cc
@@ -1681,18 +1681,6 @@ class GrpcLbFactory : public LoadBalancingPolicyFactory {
  public:
   OrphanablePtr<LoadBalancingPolicy> CreateLoadBalancingPolicy(
       LoadBalancingPolicy::Args args) const override {
-    /* Count the number of gRPC-LB addresses. There must be at least one. */
-    const ServerAddressList* addresses =
-        FindServerAddressListChannelArg(args.args);
-    if (addresses == nullptr) return nullptr;
-    bool found_balancer = false;
-    for (size_t i = 0; i < addresses->size(); ++i) {
-      if ((*addresses)[i].IsBalancer()) {
-        found_balancer = true;
-        break;
-      }
-    }
-    if (!found_balancer) return nullptr;
     return OrphanablePtr<LoadBalancingPolicy>(New<GrpcLb>(std::move(args)));
   }
 

--- a/test/cpp/end2end/grpclb_end2end_test.cc
+++ b/test/cpp/end2end/grpclb_end2end_test.cc
@@ -723,6 +723,47 @@ TEST_F(SingleBalancerTest, SelectGrpclbWithMigrationServiceConfig) {
   EXPECT_EQ("grpclb", channel_->GetLoadBalancingPolicyName());
 }
 
+TEST_F(SingleBalancerTest,
+       SelectGrpclbWithMigrationServiceConfigAndNoAddresses) {
+  const int kFallbackTimeoutMs = 200 * grpc_test_slowdown_factor();
+  ResetStub(kFallbackTimeoutMs);
+  SetNextResolution({},
+                    "{\n"
+                    "  \"loadBalancingConfig\":[\n"
+                    "    { \"does_not_exist\":{} },\n"
+                    "    { \"grpclb\":{} }\n"
+                    "  ]\n"
+                    "}");
+  // Try to connect.
+  EXPECT_EQ(GRPC_CHANNEL_IDLE, channel_->GetState(true));
+  // Should go into state TRANSIENT_FAILURE when we enter fallback mode.
+  const gpr_timespec deadline = grpc_timeout_seconds_to_deadline(1);
+  grpc_connectivity_state state;
+  while ((state = channel_->GetState(false)) !=
+         GRPC_CHANNEL_TRANSIENT_FAILURE) {
+    ASSERT_TRUE(channel_->WaitForStateChange(state, deadline));
+  }
+  // Check LB policy name for the channel.
+  EXPECT_EQ("grpclb", channel_->GetLoadBalancingPolicyName());
+}
+
+TEST_F(SingleBalancerTest,
+       SelectGrpclbWithMigrationServiceConfigAndNoBalancerAddresses) {
+  const int kFallbackTimeoutMs = 200 * grpc_test_slowdown_factor();
+  ResetStub(kFallbackTimeoutMs);
+  // Resolution includes fallback address but no balancers.
+  SetNextResolution({AddressData{backend_servers_[0].port_, false, ""}},
+                    "{\n"
+                    "  \"loadBalancingConfig\":[\n"
+                    "    { \"does_not_exist\":{} },\n"
+                    "    { \"grpclb\":{} }\n"
+                    "  ]\n"
+                    "}");
+  CheckRpcSendOk(1, 1000 /* timeout_ms */, true /* wait_for_ready */);
+  // Check LB policy name for the channel.
+  EXPECT_EQ("grpclb", channel_->GetLoadBalancingPolicyName());
+}
+
 TEST_F(SingleBalancerTest, UsePickFirstChildPolicy) {
   SetNextResolutionAllBalancers(
       "{\n"


### PR DESCRIPTION
This is important in the wake of #18263, in case someone accidentally enables grpclb via the service config without sending any balancer addresses.