### PR TITLE
Fix qps composer.json

### DIFF
--- a/src/php/tests/qps/composer.json
+++ b/src/php/tests/qps/composer.json
@@ -1,7 +1,7 @@
 {
   "require": {
     "grpc/grpc": "dev-master",
-    "google/protobuf": "v3.5.1.1"
+    "google/protobuf": "^v3.3.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Fixes #18274 

For some reason protobuf team deleted the `3.5.1.1` release from the composer package recently. But also for no apparent reason this particular `composer.json` file is pinning to that specific version. 

Fixing this to be inline with other similar `composer.json` file for testing.