### PR TITLE
Fix fuzzer test

### DIFF
--- a/src/core/lib/gpr/cpu_posix.cc
+++ b/src/core/lib/gpr/cpu_posix.cc
@@ -25,7 +25,6 @@
 #include <string.h>
 #include <unistd.h>
 
-#include <grpc/support/alloc.h>
 #include <grpc/support/cpu.h>
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
@@ -52,7 +51,7 @@ unsigned gpr_cpu_num_cores(void) {
 
 static void delete_thread_id(void* value) {
   if (value) {
-    gpr_free(value);
+    free(value);
   }
 }
 
@@ -71,7 +70,7 @@ unsigned gpr_cpu_current_cpu(void) {
   unsigned int* thread_id =
       static_cast<unsigned int*>(pthread_getspecific(thread_id_key));
   if (thread_id == nullptr) {
-    thread_id = static_cast<unsigned int*>(gpr_malloc(sizeof(unsigned int)));
+    thread_id = static_cast<unsigned int*>(malloc(sizeof(unsigned int)));
     pthread_setspecific(thread_id_key, thread_id);
   }
 

--- a/src/core/lib/gpr/cpu_posix.cc
+++ b/src/core/lib/gpr/cpu_posix.cc
@@ -70,6 +70,9 @@ unsigned gpr_cpu_current_cpu(void) {
   unsigned int* thread_id =
       static_cast<unsigned int*>(pthread_getspecific(thread_id_key));
   if (thread_id == nullptr) {
+    // Note we cannot use gpr_malloc here because this allocation can happen in
+    // a main thread and will only be free'd when the main thread exits, which
+    // will cause our internal memory counters to believe it is a leak.
     thread_id = static_cast<unsigned int*>(malloc(sizeof(unsigned int)));
     pthread_setspecific(thread_id_key, thread_id);
   }

--- a/test/core/slice/percent_decode_corpus/clusterfuzz-testcase-minimized-grpc_percent_decode_fuzzer-5652313562808320
+++ b/test/core/slice/percent_decode_corpus/clusterfuzz-testcase-minimized-grpc_percent_decode_fuzzer-5652313562808320
@@ -1,0 +1,1 @@
+%c4%cc%c4%cc%cc%ccccc%cccc%ccc%ccc%cc%ccc%ccc

--- a/test/core/slice/percent_decode_fuzzer.cc
+++ b/test/core/slice/percent_decode_fuzzer.cc
@@ -31,23 +31,20 @@ bool squelch = true;
 bool leak_check = true;
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  grpc_core::testing::LeakDetector leak_detector(true);
   grpc_init();
-  {
-    grpc_core::testing::LeakDetector leak_detector(true);
-    grpc_slice input = grpc_slice_from_copied_buffer((const char*)data, size);
-    grpc_slice output;
-    if (grpc_strict_percent_decode_slice(
-            input, grpc_url_percent_encoding_unreserved_bytes, &output)) {
-      grpc_slice_unref(output);
-    }
-    if (grpc_strict_percent_decode_slice(
-            input, grpc_compatible_percent_encoding_unreserved_bytes,
-            &output)) {
-      grpc_slice_unref(output);
-    }
-    grpc_slice_unref(grpc_permissive_percent_decode_slice(input));
-    grpc_slice_unref(input);
+  grpc_slice input = grpc_slice_from_copied_buffer((const char*)data, size);
+  grpc_slice output;
+  if (grpc_strict_percent_decode_slice(
+          input, grpc_url_percent_encoding_unreserved_bytes, &output)) {
+    grpc_slice_unref(output);
   }
+  if (grpc_strict_percent_decode_slice(
+          input, grpc_compatible_percent_encoding_unreserved_bytes, &output)) {
+    grpc_slice_unref(output);
+  }
+  grpc_slice_unref(grpc_permissive_percent_decode_slice(input));
+  grpc_slice_unref(input);
   grpc_shutdown_blocking();
   return 0;
 }

--- a/test/core/slice/percent_encode_fuzzer.cc
+++ b/test/core/slice/percent_encode_fuzzer.cc
@@ -31,25 +31,23 @@ bool squelch = true;
 bool leak_check = true;
 
 static void test(const uint8_t* data, size_t size, const uint8_t* dict) {
+  grpc_core::testing::LeakDetector leak_detector(true);
   grpc_init();
-  {
-    grpc_core::testing::LeakDetector leak_detector(true);
-    grpc_slice input = grpc_slice_from_copied_buffer(
-        reinterpret_cast<const char*>(data), size);
-    grpc_slice output = grpc_percent_encode_slice(input, dict);
-    grpc_slice decoded_output;
-    // encoder must always produce decodable output
-    GPR_ASSERT(grpc_strict_percent_decode_slice(output, dict, &decoded_output));
-    grpc_slice permissive_decoded_output =
-        grpc_permissive_percent_decode_slice(output);
-    // and decoded output must always match the input
-    GPR_ASSERT(grpc_slice_eq(input, decoded_output));
-    GPR_ASSERT(grpc_slice_eq(input, permissive_decoded_output));
-    grpc_slice_unref(input);
-    grpc_slice_unref(output);
-    grpc_slice_unref(decoded_output);
-    grpc_slice_unref(permissive_decoded_output);
-  }
+  grpc_slice input =
+      grpc_slice_from_copied_buffer(reinterpret_cast<const char*>(data), size);
+  grpc_slice output = grpc_percent_encode_slice(input, dict);
+  grpc_slice decoded_output;
+  // encoder must always produce decodable output
+  GPR_ASSERT(grpc_strict_percent_decode_slice(output, dict, &decoded_output));
+  grpc_slice permissive_decoded_output =
+      grpc_permissive_percent_decode_slice(output);
+  // and decoded output must always match the input
+  GPR_ASSERT(grpc_slice_eq(input, decoded_output));
+  GPR_ASSERT(grpc_slice_eq(input, permissive_decoded_output));
+  grpc_slice_unref(input);
+  grpc_slice_unref(output);
+  grpc_slice_unref(decoded_output);
+  grpc_slice_unref(permissive_decoded_output);
   grpc_shutdown_blocking();
 }
 

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -169174,6 +169174,29 @@
   }, 
   {
     "args": [
+      "test/core/slice/percent_decode_corpus/clusterfuzz-testcase-minimized-grpc_percent_decode_fuzzer-5652313562808320"
+    ], 
+    "ci_platforms": [
+      "linux"
+    ], 
+    "cpu_cost": 0.1, 
+    "exclude_configs": [
+      "tsan"
+    ], 
+    "exclude_iomgrs": [
+      "uv"
+    ], 
+    "flaky": false, 
+    "language": "c", 
+    "name": "percent_decode_fuzzer_one_entry", 
+    "platforms": [
+      "mac", 
+      "linux"
+    ], 
+    "uses_polling": false
+  }, 
+  {
+    "args": [
       "test/core/slice/percent_decode_corpus/d5b2a7177339ba2b7ce2f60e5f4459bef1e72758"
     ], 
     "ci_platforms": [


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/chromium/issues/detail?id=937607

Change the gpr_malloc and gpr_free to malloc and free in cpu_posix for the thread_local state. There is an allocation takes in the main test thread that will not yet be destroyed when the LeakDetector is checking for leaks. It will be mistakenly reported as a leak.
