### PR TITLE
C++ callback API: properly handle and test unimplemented RPC method

### DIFF
--- a/include/grpcpp/server.h
+++ b/include/grpcpp/server.h
@@ -326,6 +326,10 @@ class Server : public ServerInterface, private GrpcLibraryCodegen {
   std::unique_ptr<HealthCheckServiceInterface> health_check_service_;
   bool health_check_service_disabled_;
 
+  // When appropriate, use a default callback generic service to handle
+  // unimplemented methods
+  std::unique_ptr<experimental::CallbackGenericService> unimplemented_service_;
+
   // A special handler for resource exhausted in sync case
   std::unique_ptr<internal::MethodHandler> resource_exhausted_handler_;
 

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -1004,6 +1004,14 @@ void Server::Start(ServerCompletionQueue** cqs, size_t num_cqs) {
     RegisterService(nullptr, default_health_check_service_impl);
   }
 
+  // If this server uses callback methods, then create a callback generic
+  // service to handle any unimplemented methods using the default reactor
+  // creator
+  if (!callback_reqs_to_start_.empty() && !has_callback_generic_service_) {
+    unimplemented_service_.reset(new experimental::CallbackGenericService);
+    RegisterCallbackGenericService(unimplemented_service_.get());
+  }
+
   grpc_server_start(server_);
 
   if (!has_async_generic_service_ && !has_callback_generic_service_) {


### PR DESCRIPTION
Fixes and tests an important issue by making sure that callback-only servers properly handle unimplemented methods. This is an easy follow on after #18239 . This is an easy way to do this instead of creating a separate UnknownSyncMethod call (as in the sync API) or UnimplementedAsyncRequest/Response types (as in the async API) because the callback API is based around the idea of background polling; as a result, as long as the callback CQ exists for some purpose, it will be able to also drive an additional service that the user doesn't even know about and which has a default implementation that treats RPCs as unimplemented.