### PR TITLE
Backport "Add the missing grpc_cfstream dependency" to v1.19.x

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -297,6 +297,7 @@ grpc_cc_library(
     public_hdrs = GRPC_PUBLIC_HDRS + GRPC_SECURE_PUBLIC_HDRS,
     standalone = True,
     deps = [
+        "grpc_cfstream",
         "grpc_common",
         "grpc_lb_policy_grpclb_secure",
         "grpc_lb_policy_xds_secure",


### PR DESCRIPTION
Backport PR #18296