### PR TITLE
PHP: fixed seg fault caused by access client after it is closed

### DIFF
--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -217,7 +217,7 @@ PHP_METHOD(Call, __construct) {
   }
   wrapped_grpc_channel *channel =
     PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_channel, channel_obj);
-  if (channel->wrapper == NULL || channel->wrapper->wrapped == NULL) {
+  if (channel->wrapper == NULL) {
     zend_throw_exception(spl_ce_InvalidArgumentException,
                          "Call cannot be constructed from a closed Channel",
                          1 TSRMLS_CC);

--- a/src/php/ext/grpc/call.c
+++ b/src/php/ext/grpc/call.c
@@ -217,6 +217,12 @@ PHP_METHOD(Call, __construct) {
   }
   wrapped_grpc_channel *channel =
     PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_channel, channel_obj);
+  if (channel->wrapper == NULL || channel->wrapper->wrapped == NULL) {
+    zend_throw_exception(spl_ce_InvalidArgumentException,
+                         "Call cannot be constructed from a closed Channel",
+                         1 TSRMLS_CC);
+    return;
+  }
   gpr_mu_lock(&channel->wrapper->mu);
   if (channel->wrapper == NULL || channel->wrapper->wrapped == NULL) {
     zend_throw_exception(spl_ce_InvalidArgumentException,


### PR DESCRIPTION
Add a channel->wrapper NULL check before gpr_mu_lock(&channel->wrapper->mu);
Otherwise if a client is closed, then it will raise a seg fault caused by NULL of channel->wrapper