### PR TITLE
Remove pollset_set when resetting LB policies

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
@@ -430,6 +430,9 @@ void XdsLb::Helper::UpdateState(grpc_connectivity_state state,
       GRPC_ERROR_UNREF(state_error);
       return;
     }
+    grpc_pollset_set_del_pollset_set(
+        parent_->child_policy_->interested_parties(),
+        parent_->interested_parties());
     MutexLock lock(&parent_->child_policy_mu_);
     parent_->child_policy_ = std::move(parent_->pending_child_policy_);
   } else if (!CalledByCurrentChild()) {
@@ -1153,6 +1156,14 @@ void XdsLb::ShutdownLocked() {
   shutting_down_ = true;
   if (fallback_timer_callback_pending_) {
     grpc_timer_cancel(&lb_fallback_timer_);
+  }
+  if (child_policy_ != nullptr) {
+    grpc_pollset_set_del_pollset_set(child_policy_->interested_parties(),
+                                     interested_parties());
+  }
+  if (pending_child_policy_ != nullptr) {
+    grpc_pollset_set_del_pollset_set(
+        pending_child_policy_->interested_parties(), interested_parties());
   }
   {
     MutexLock lock(&child_policy_mu_);

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.cc
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.cc
@@ -110,6 +110,9 @@ class ResolvingLoadBalancingPolicy::ResolvingControlHelper
         GRPC_ERROR_UNREF(state_error);
         return;
       }
+      grpc_pollset_set_del_pollset_set(
+          parent_->lb_policy_->interested_parties(),
+          parent_->interested_parties());
       MutexLock lock(&parent_->lb_policy_mu_);
       parent_->lb_policy_ = std::move(parent_->pending_lb_policy_);
     } else if (!CalledByCurrentChild()) {


### PR DESCRIPTION
Add missing calls to `grpc_pollset_set_del_pollset_set()`.