### PR TITLE
Migrate bazel proto building rules to stackb/rules_proto

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,20 +1,18 @@
 workspace(name = "com_github_grpc_grpc")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("//bazel:grpc_deps.bzl", "grpc_deps", "grpc_test_only_deps")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-grpc_deps()
-
-grpc_test_only_deps()
-
-register_execution_platforms(
-    "//third_party/toolchains:rbe_ubuntu1604",
-    "//third_party/toolchains:rbe_ubuntu1604_large",
+git_repository(
+    name = "build_stack_rules_proto",
+    remote = "https://github.com/stackb/rules_proto",
+    commit = "e783457abea020e7df6b94acb54f668c0473ae31",
 )
 
-register_toolchains(
-    "//third_party/toolchains:cc-toolchain-clang-x86_64-default",
+git_repository(
+    name = "com_google_protobuf",
+    remote = "https://github.com/protocolbuffers/protobuf",
+    commit = "05e81cb8f41db6e124ae8bcd52cc9abff530a31a",
 )
 
 http_archive(
@@ -27,36 +25,60 @@ http_archive(
     ],
 )
 
-load("//third_party/py:python_configure.bzl", "python_configure")
-
-python_configure(name = "local_config_python")
-
 git_repository(
     name = "io_bazel_rules_python",
-    commit = "8b5d0683a7d878b28fffe464779c8a53659fc645",
     remote = "https://github.com/bazelbuild/rules_python.git",
+    commit = "88532b624f74ab17138fb638d3c62750b5af5f9a",
 )
 
+load("//bazel:grpc_deps.bzl", "grpc_deps", "grpc_test_only_deps")
+load("@build_stack_rules_proto//cpp:deps.bzl", "cpp_proto_compile")
+load("@build_stack_rules_proto//python:deps.bzl",
+     "python_proto_compile", "python_proto_library",
+     "python_grpc_compile", "python_grpc_library")
+
+grpc_deps()
+grpc_test_only_deps()
+cpp_proto_compile()
+python_proto_compile()
+python_proto_library()
+python_grpc_compile()
+python_grpc_library()
+
+load("//third_party/py:python_configure.bzl", "python_configure")
 load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip_import")
 
+python_configure(name = "local_config_python")
 pip_repositories()
+
+pip_import(
+    name = "grpc_py_deps",
+    requirements = "@build_stack_rules_proto//python:requirements.txt",
+)
 
 pip_import(
     name = "grpc_python_dependencies",
     requirements = "//:requirements.bazel.txt",
 )
 
-load("@grpc_python_dependencies//:requirements.bzl", "pip_install")
-
-pip_install()
-
-# NOTE(https://github.com/pubref/rules_protobuf/pull/196): Switch to upstream repo after this gets merged.
-git_repository(
-    name = "org_pubref_rules_protobuf",
-    remote = "https://github.com/ghostwriternr/rules_protobuf",
-    tag = "v0.8.2.1-alpha",
+pip_import(
+    name = "protobuf_py_deps",
+    requirements = "@build_stack_rules_proto//python/requirements:protobuf.txt",
 )
 
-load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_repositories")
+load("@grpc_python_dependencies//:requirements.bzl", "pip_install")
+load("@protobuf_py_deps//:requirements.bzl", protobuf_pip_install = "pip_install")
+load("@grpc_py_deps//:requirements.bzl", grpc_pip_install = "pip_install")
 
-py_proto_repositories()
+pip_install()
+protobuf_pip_install()
+grpc_pip_install()
+
+register_execution_platforms(
+    "//third_party/toolchains:rbe_ubuntu1604",
+    "//third_party/toolchains:rbe_ubuntu1604_large",
+)
+
+register_toolchains(
+    "//third_party/toolchains:cc-toolchain-clang-x86_64-default",
+)

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -15,17 +15,3 @@
 licenses(["notice"])  # Apache v2
 
 package(default_visibility = ["//:__subpackages__"])
-
-load(":cc_grpc_library.bzl", "cc_grpc_library")
-
-proto_library(
-    name = "well_known_protos_list",
-    srcs = ["@com_google_protobuf//:well_known_protos"],
-)
-
-cc_grpc_library(
-    name = "well_known_protos",
-    srcs = "well_known_protos_list",
-    proto_only = True,
-    deps = [],
-)

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -140,7 +140,8 @@ def grpc_proto_library(
         well_known_protos = False,
         has_services = True,
         use_external = False,
-        generate_mocks = False):
+        generate_mocks = False,
+        generate_python = False):
     cc_grpc_library(
         name = name,
         srcs = srcs,
@@ -149,6 +150,7 @@ def grpc_proto_library(
         proto_only = not has_services,
         use_external = use_external,
         generate_mocks = generate_mocks,
+        generate_python = generate_python,
     )
 
 def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data = [], uses_polling = True, language = "C++", size = "medium", timeout = None, tags = [], exec_compatible_with = []):

--- a/src/proto/grpc/channelz/BUILD
+++ b/src/proto/grpc/channelz/BUILD
@@ -23,11 +23,5 @@ grpc_proto_library(
     srcs = ["channelz.proto"],
     has_services = True,
     well_known_protos = True,
-)
-
-filegroup(
-    name = "channelz_proto_file",
-    srcs = [
-        "channelz.proto",
-    ],
+    generate_python = True,
 )

--- a/src/proto/grpc/health/v1/BUILD
+++ b/src/proto/grpc/health/v1/BUILD
@@ -21,6 +21,7 @@ grpc_package(name = "health", visibility = "public")
 grpc_proto_library(
     name = "health_proto",
     srcs = ["health.proto"],
+    generate_python = True,
 )
 
 filegroup(

--- a/src/proto/grpc/reflection/v1alpha/BUILD
+++ b/src/proto/grpc/reflection/v1alpha/BUILD
@@ -21,12 +21,5 @@ grpc_package(name = "reflection", visibility = "public")
 grpc_proto_library(
     name = "reflection_proto",
     srcs = ["reflection.proto"],
+    generate_python = True,
 )
-
-filegroup(
-    name = "reflection_proto_file",
-    srcs = [
-        "reflection.proto",
-    ],
-)
-

--- a/src/proto/grpc/testing/BUILD
+++ b/src/proto/grpc/testing/BUILD
@@ -15,8 +15,6 @@
 licenses(["notice"])  # Apache v2
 
 load("//bazel:grpc_build_system.bzl", "grpc_proto_library", "grpc_package")
-load("@grpc_python_dependencies//:requirements.bzl", "requirement")
-load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_library")
 
 grpc_package(name = "testing", visibility = "public")
 
@@ -59,30 +57,14 @@ grpc_proto_library(
     name = "empty_proto",
     srcs = ["empty.proto"],
     has_services = False,
-)
-
-py_proto_library(
-    name = "py_empty_proto",
-    protos = ["empty.proto",],
-    with_grpc = True,
-    deps = [
-        requirement('protobuf'),
-    ],
+    generate_python = True,
 )
 
 grpc_proto_library(
     name = "messages_proto",
     srcs = ["messages.proto"],
     has_services = False,
-)
-
-py_proto_library(
-    name = "py_messages_proto",
-    protos = ["messages.proto",],
-    with_grpc = True,
-    deps = [
-        requirement('protobuf'),
-    ],
+    generate_python = True,
 )
 
 grpc_proto_library(
@@ -142,18 +124,5 @@ grpc_proto_library(
         "empty_proto",
         "messages_proto",
     ],
+    generate_python = True,
 )
-
-py_proto_library(
-    name = "py_test_proto",
-    protos = ["test.proto",],
-    with_grpc = True,
-    deps = [
-        requirement('protobuf'),
-    ],
-    proto_deps = [
-        ":py_empty_proto",
-        ":py_messages_proto",
-    ]
-)
-

--- a/src/proto/grpc/testing/proto2/BUILD.bazel
+++ b/src/proto/grpc/testing/proto2/BUILD.bazel
@@ -1,30 +1,14 @@
-load("@grpc_python_dependencies//:requirements.bzl", "requirement")
-load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_library")
+load("@build_stack_rules_proto//python:python_proto_library.bzl", "python_proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
-py_proto_library(
+proto_library(
     name = "empty2_proto",
-    protos = [
-        "empty2.proto",
-    ],
-    with_grpc = True,
-    deps = [
-        requirement('protobuf'),
-    ],
+    srcs = ["empty2.proto"],
 )
 
-py_proto_library(
+python_proto_library(
     name = "empty2_extensions_proto",
-    protos = [
-        "empty2_extensions.proto",
-    ],
-    proto_deps = [
-        ":empty2_proto",
-    ],
-    with_grpc = True,
-    deps = [
-        requirement('protobuf'),
-    ],
+    deps = [":empty2_proto"],
 )
 

--- a/src/python/grpcio_channelz/grpc_channelz/v1/BUILD.bazel
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@grpc_python_dependencies//:requirements.bzl", "requirement")
-load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_library")
+load("@build_stack_rules_proto//python:python_grpc_library.bzl", "python_grpc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,31 +7,23 @@ genrule(
     srcs = [
         "//src/proto/grpc/channelz:channelz_proto_file",
     ],
-    outs = ["channelz.proto",],
+    outs = ["channelz.proto"],
     cmd = "cp $< $@",
 )
 
-py_proto_library(
-    name = "py_channelz_proto",
-    protos = ["mv_channelz_proto",],
-    imports = [
-        "external/com_google_protobuf/src/",
-    ],
-    inputs = [
-        "@com_google_protobuf//:well_known_protos",
-    ],
-    with_grpc = True,
+proto_library(
+    name = "channelz_proto",
+    srcs = [":channelz.proto"],
     deps = [
-        requirement('protobuf'),
+        "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:duration_proto",
+        "@com_google_protobuf//:timestamp_proto",
+        "@com_google_protobuf//:wrappers_proto",
     ],
 )
 
-py_library(
+python_grpc_library(
     name = "grpc_channelz",
-    srcs = ["channelz.py",],
-    deps = [
-        ":py_channelz_proto",
-        "//src/python/grpcio/grpc:grpcio",
-    ],
-    imports=["../../",],
+    deps = [":channelz_proto"],
+    has_services = True,
 )

--- a/src/python/grpcio_channelz/grpc_channelz/v1/BUILD.bazel
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/BUILD.bazel
@@ -1,29 +1,11 @@
-load("@build_stack_rules_proto//python:python_grpc_library.bzl", "python_grpc_library")
-
 package(default_visibility = ["//visibility:public"])
 
-genrule(
-    name = "mv_channelz_proto",
-    srcs = [
-        "//src/proto/grpc/channelz:channelz_proto_file",
-    ],
-    outs = ["channelz.proto"],
-    cmd = "cp $< $@",
-)
-
-proto_library(
-    name = "channelz_proto",
-    srcs = [":channelz.proto"],
-    deps = [
-        "@com_google_protobuf//:any_proto",
-        "@com_google_protobuf//:duration_proto",
-        "@com_google_protobuf//:timestamp_proto",
-        "@com_google_protobuf//:wrappers_proto",
-    ],
-)
-
-python_grpc_library(
+py_library(
     name = "grpc_channelz",
-    deps = [":channelz_proto"],
-    has_services = True,
+    srcs = ["channelz.py",],
+    deps = [
+        "//src/proto/grpc/channelz:py_channelz_proto",
+        "//src/python/grpcio/grpc:grpcio",
+    ],
+    imports=["../../",],
 )

--- a/src/python/grpcio_channelz/grpc_channelz/v1/channelz.py
+++ b/src/python/grpcio_channelz/grpc_channelz/v1/channelz.py
@@ -16,8 +16,8 @@
 import grpc
 from grpc._cython import cygrpc
 
-import grpc_channelz.v1.channelz_pb2 as _channelz_pb2
-import grpc_channelz.v1.channelz_pb2_grpc as _channelz_pb2_grpc
+import src.proto.grpc.channelz.channelz_pb2 as _channelz_pb2
+import src.proto.grpc.channelz.channelz_pb2_grpc as _channelz_pb2_grpc
 
 from google.protobuf import json_format
 

--- a/src/python/grpcio_health_checking/grpc_health/v1/BUILD.bazel
+++ b/src/python/grpcio_health_checking/grpc_health/v1/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@grpc_python_dependencies//:requirements.bzl", "requirement")
-load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_library")
+load("@build_stack_rules_proto//python:python_grpc_library.bzl", "python_grpc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -12,22 +11,13 @@ genrule(
     cmd = "cp $< $@",
 )
 
-py_proto_library(
-    name = "py_health_proto",
-    protos = [":mv_health_proto",],
-    with_grpc = True,
-    deps = [
-        requirement('protobuf'),
-    ],
+proto_library(
+    name = "health_proto",
+    srcs = [":health.proto"],
 )
 
-py_library(
+python_grpc_library(
     name = "grpc_health",
-    srcs = ["health.py",],
-    deps = [
-        ":py_health_proto",
-        "//src/python/grpcio/grpc:grpcio",
-    ],
-    imports=["../../",],
+    deps = [":health_proto"],
+    has_services = True
 )
-

--- a/src/python/grpcio_health_checking/grpc_health/v1/BUILD.bazel
+++ b/src/python/grpcio_health_checking/grpc_health/v1/BUILD.bazel
@@ -1,23 +1,11 @@
-load("@build_stack_rules_proto//python:python_grpc_library.bzl", "python_grpc_library")
-
 package(default_visibility = ["//visibility:public"])
 
-genrule(
-    name = "mv_health_proto",
-    srcs = [
-        "//src/proto/grpc/health/v1:health_proto_file",
-    ],
-    outs = ["health.proto",],
-    cmd = "cp $< $@",
-)
-
-proto_library(
-    name = "health_proto",
-    srcs = [":health.proto"],
-)
-
-python_grpc_library(
+py_library(
     name = "grpc_health",
-    deps = [":health_proto"],
-    has_services = True
+    srcs = ["health.py",],
+    deps = [
+        "//src/proto/grpc/health/v1:py_health_proto",
+        "//src/python/grpcio/grpc:grpcio",
+    ],
+    imports=["../../",],
 )

--- a/src/python/grpcio_health_checking/grpc_health/v1/health.py
+++ b/src/python/grpcio_health_checking/grpc_health/v1/health.py
@@ -18,8 +18,8 @@ import threading
 
 import grpc
 
-from grpc_health.v1 import health_pb2 as _health_pb2
-from grpc_health.v1 import health_pb2_grpc as _health_pb2_grpc
+from src.proto.grpc.health.v1 import health_pb2 as _health_pb2
+from src.proto.grpc.health.v1 import health_pb2_grpc as _health_pb2_grpc
 
 SERVICE_NAME = _health_pb2.DESCRIPTOR.services_by_name['Health'].full_name
 

--- a/src/python/grpcio_reflection/grpc_reflection/v1alpha/BUILD.bazel
+++ b/src/python/grpcio_reflection/grpc_reflection/v1alpha/BUILD.bazel
@@ -1,24 +1,11 @@
-load("@build_stack_rules_proto//python:python_grpc_library.bzl", "python_grpc_library")
-
 package(default_visibility = ["//visibility:public"])
 
-genrule(
-    name = "mv_reflection_proto",
-    srcs = [
-        "//src/proto/grpc/reflection/v1alpha:reflection_proto_file",
-    ],
-    outs = ["reflection.proto"],
-    cmd = "cp $< $@",
-)
-
-proto_library(
-    name = "reflection_proto",
-    srcs = [":reflection.proto"],
-)
-
-python_grpc_library(
+py_library(
     name = "grpc_reflection",
-    deps = [":reflection_proto"],
-    has_services = True,
+    srcs = ["reflection.py",],
+    deps = [
+        "//src/proto/grpc/reflection/v1alpha:py_reflection_proto",
+        "//src/python/grpcio/grpc:grpcio",
+    ],
+    imports=["../../",],
 )
-

--- a/src/python/grpcio_reflection/grpc_reflection/v1alpha/BUILD.bazel
+++ b/src/python/grpcio_reflection/grpc_reflection/v1alpha/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@grpc_python_dependencies//:requirements.bzl", "requirement")
-load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_library")
+load("@build_stack_rules_proto//python:python_grpc_library.bzl", "python_grpc_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -8,27 +7,18 @@ genrule(
     srcs = [
         "//src/proto/grpc/reflection/v1alpha:reflection_proto_file",
     ],
-    outs = ["reflection.proto",],
+    outs = ["reflection.proto"],
     cmd = "cp $< $@",
 )
 
-py_proto_library(
-    name = "py_reflection_proto",
-    protos = [":mv_reflection_proto",],
-    with_grpc = True,
-    deps = [
-        requirement('protobuf'),
-    ],
+proto_library(
+    name = "reflection_proto",
+    srcs = [":reflection.proto"],
 )
 
-py_library(
+python_grpc_library(
     name = "grpc_reflection",
-    srcs = ["reflection.py",],
-    deps = [
-        ":py_reflection_proto",
-        "//src/python/grpcio/grpc:grpcio",
-        requirement('protobuf'),
-    ],
-    imports=["../../",],
+    deps = [":reflection_proto"],
+    has_services = True,
 )
 

--- a/src/python/grpcio_reflection/grpc_reflection/v1alpha/reflection.py
+++ b/src/python/grpcio_reflection/grpc_reflection/v1alpha/reflection.py
@@ -17,8 +17,8 @@ import grpc
 from google.protobuf import descriptor_pb2
 from google.protobuf import descriptor_pool
 
-from grpc_reflection.v1alpha import reflection_pb2 as _reflection_pb2
-from grpc_reflection.v1alpha import reflection_pb2_grpc as _reflection_pb2_grpc
+from src.proto.grpc.reflection.v1alpha import reflection_pb2 as _reflection_pb2
+from src.proto.grpc.reflection.v1alpha import reflection_pb2_grpc as _reflection_pb2_grpc
 
 _POOL = descriptor_pool.Default()
 SERVICE_NAME = _reflection_pb2.DESCRIPTOR.services_by_name[

--- a/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
+++ b/src/python/grpcio_tests/tests/channelz/_channelz_servicer_test.py
@@ -19,9 +19,9 @@ from concurrent import futures
 
 import grpc
 from grpc_channelz.v1 import channelz
-from grpc_channelz.v1 import channelz_pb2
-from grpc_channelz.v1 import channelz_pb2_grpc
 
+from src.proto.grpc.channelz import channelz_pb2
+from src.proto.grpc.channelz import channelz_pb2_grpc
 from tests.unit import test_common
 from tests.unit.framework.common import test_constants
 

--- a/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
+++ b/src/python/grpcio_tests/tests/health_check/_health_servicer_test.py
@@ -19,8 +19,8 @@ import unittest
 
 import grpc
 from grpc_health.v1 import health
-from grpc_health.v1 import health_pb2
-from grpc_health.v1 import health_pb2_grpc
+from src.proto.grpc.health.v1 import health_pb2
+from src.proto.grpc.health.v1 import health_pb2_grpc
 
 from tests.unit import test_common
 from tests.unit import thread_pool

--- a/src/python/grpcio_tests/tests/reflection/BUILD.bazel
+++ b/src/python/grpcio_tests/tests/reflection/BUILD.bazel
@@ -1,5 +1,3 @@
-load("@grpc_python_dependencies//:requirements.bzl", "requirement")
-
 package(default_visibility = ["//visibility:public"])
 
 py_test(
@@ -14,7 +12,6 @@ py_test(
         "//src/python/grpcio_tests/tests/unit:test_common",
         "//src/proto/grpc/testing:py_empty_proto",
         "//src/proto/grpc/testing/proto2:empty2_extensions_proto",
-        requirement('protobuf'),
     ],
     imports=["../../",],
 )

--- a/src/python/grpcio_tests/tests/reflection/_reflection_servicer_test.py
+++ b/src/python/grpcio_tests/tests/reflection/_reflection_servicer_test.py
@@ -17,8 +17,8 @@ import unittest
 
 import grpc
 from grpc_reflection.v1alpha import reflection
-from grpc_reflection.v1alpha import reflection_pb2
-from grpc_reflection.v1alpha import reflection_pb2_grpc
+from src.proto.grpc.reflection.v1alpha import reflection_pb2
+from src.proto.grpc.reflection.v1alpha import reflection_pb2_grpc
 
 from google.protobuf import descriptor_pool
 from google.protobuf import descriptor_pb2

--- a/test/core/util/fuzzer_corpus_test.cc
+++ b/test/core/util/fuzzer_corpus_test.cc
@@ -70,12 +70,6 @@ class ExampleGenerator
     if (examples_.empty()) {
       if (!FLAGS_file.empty()) examples_.push_back(FLAGS_file);
       if (!FLAGS_directory.empty()) {
-        char* test_srcdir = gpr_getenv("TEST_SRCDIR");
-        if (test_srcdir != nullptr) {
-          FLAGS_directory = test_srcdir +
-                            std::string("/com_github_grpc_grpc/") +
-                            FLAGS_directory;
-        }
         DIR* dp;
         struct dirent* ep;
         dp = opendir(FLAGS_directory.c_str());
@@ -92,7 +86,6 @@ class ExampleGenerator
           perror("Couldn't open the directory");
           abort();
         }
-        gpr_free(test_srcdir);
       }
     }
   }

--- a/third_party/cares/BUILD
+++ b/third_party/cares/BUILD
@@ -1,3 +1,5 @@
+licenses(["notice"])  # MIT
+
 exports_files([
     "ares_build.h",
     "cares.BUILD",


### PR DESCRIPTION
This patch migrates the Bazel build to use https://github.com/stackb/rules_proto

This fixes https://github.com/grpc/grpc/issues/18256
