### PR TITLE
Prevent merging if PR labeled DO NOT MERGE

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,14 +1,18 @@
 mergeable:
   pull_requests:
     label:
-      or:
-        - and:
+      and:
+        - must_exclude:
+            regex: '^disposition/DO NOT MERGE'
+            message: 'Pull request marked not mergeable'
+        - or:
+          - and:
+            - must_include:
+                regex: 'release notes: yes'
+                message: 'Please include release note: yes'
+            - must_include:
+                regex: '^lang\/'
+                message: 'Please include a language label'
           - must_include:
-              regex: 'release notes: yes'
-              message: 'Please include release note: yes'
-          - must_include:
-              regex: '^lang\/'
-              message: 'Please include a language label'
-        - must_include:
-            regex: 'release notes: no'
-            message: 'Please include release note: no'
+              regex: 'release notes: no'
+              message: 'Please include release note: no'


### PR DESCRIPTION
Adding a DO NOT MERGE label should prevent the merging of a PR.
You can test this PR by toggling the DO NOT MERGE label and watching the Mergeable check go true/false
