### PR TITLE
C#: Activate sourcelink when building nuget packages

### DIFF
--- a/src/csharp/Grpc.Core/SourceLink.csproj.include
+++ b/src/csharp/Grpc.Core/SourceLink.csproj.include
@@ -1,17 +1,6 @@
 <!-- Ensure that debugging of the resulting NuGet packages work (we're using SourceLink). -->
 <Project>
 
-  <ItemGroup Label="dotnet pack instructions">
-    <Content Include="$(OutputPath)netstandard1.5\$(PackageId).pdb">
-      <Pack>true</Pack>
-      <PackagePath>lib/netstandard1.5</PackagePath>
-    </Content>
-    <Content Include="$(OutputPath)net45\$(PackageId).pdb">
-      <Pack>true</Pack>
-      <PackagePath>lib/net45</PackagePath>
-    </Content>
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.7.6" PrivateAssets="all" />
   </ItemGroup>

--- a/src/csharp/build_packages_dotnetcli.bat
+++ b/src/csharp/build_packages_dotnetcli.bat
@@ -32,13 +32,13 @@ expand_dev_version.sh
 @rem To be able to build, we also need to put grpc_csharp_ext to its normal location
 xcopy /Y /I nativelibs\csharp_ext_windows_x64\grpc_csharp_ext.dll ..\..\cmake\build\x64\Release\
 
-%DOTNET% pack --configuration Release Grpc.Core.Api --output ..\..\..\artifacts || goto :error
-%DOTNET% pack --configuration Release Grpc.Core --output ..\..\..\artifacts || goto :error
-%DOTNET% pack --configuration Release Grpc.Core.Testing --output ..\..\..\artifacts || goto :error
-%DOTNET% pack --configuration Release Grpc.Auth --output ..\..\..\artifacts || goto :error
-%DOTNET% pack --configuration Release Grpc.HealthCheck --output ..\..\..\artifacts || goto :error
-%DOTNET% pack --configuration Release Grpc.Reflection --output ..\..\..\artifacts || goto :error
-%DOTNET% pack --configuration Release Grpc.Tools --output ..\..\..\artifacts || goto :error
+%DOTNET% pack --configuration Release Grpc.Core.Api /p:SourceLinkCreate=true --output ..\..\..\artifacts || goto :error
+%DOTNET% pack --configuration Release Grpc.Core /p:SourceLinkCreate=true --output ..\..\..\artifacts || goto :error
+%DOTNET% pack --configuration Release Grpc.Core.Testing /p:SourceLinkCreate=true --output ..\..\..\artifacts || goto :error
+%DOTNET% pack --configuration Release Grpc.Auth /p:SourceLinkCreate=true --output ..\..\..\artifacts || goto :error
+%DOTNET% pack --configuration Release Grpc.HealthCheck /p:SourceLinkCreate=true --output ..\..\..\artifacts || goto :error
+%DOTNET% pack --configuration Release Grpc.Reflection /p:SourceLinkCreate=true --output ..\..\..\artifacts || goto :error
+%DOTNET% pack --configuration Release Grpc.Tools /p:SourceLinkCreate=true --output ..\..\..\artifacts || goto :error
 @rem build auxiliary packages
 %DOTNET% pack --configuration Release Grpc --output ..\..\..\artifacts || goto :error
 %DOTNET% pack --configuration Release Grpc.Core.NativeDebug --output ..\..\..\artifacts || goto :error


### PR DESCRIPTION
- In order to make SourceLink work, an msbuild property needs to be set when building to dotnet packages.
- PDB files are added to the nupkg packages even without special handling.

Tentative fix for https://github.com/grpc/grpc/issues/18287