### PR TITLE
Fix Python distribution test

### DIFF
--- a/test/distrib/python/test_packages.sh
+++ b/test/distrib/python/test_packages.sh
@@ -37,7 +37,7 @@ TESTING_ARCHIVES=("$EXTERNAL_GIT_ROOT"/input_artifacts/grpcio-testing-[0-9]*.tar
 VIRTUAL_ENV=$(mktemp -d)
 virtualenv "$VIRTUAL_ENV"
 PYTHON=$VIRTUAL_ENV/bin/python
-"$PYTHON" -m pip install --upgrade six pip
+"$PYTHON" -m pip install --upgrade six pip wheel
 
 function validate_wheel_hashes() {
   for file in "$@"; do

--- a/test/distrib/python/test_packages.sh
+++ b/test/distrib/python/test_packages.sh
@@ -41,7 +41,7 @@ PYTHON=$VIRTUAL_ENV/bin/python
 
 function validate_wheel_hashes() {
   for file in "$@"; do
-    "$PYTHON" -m wheel unpack "$file" --dest-dir /tmp || return 1
+    "$PYTHON" -m wheel unpack "$file" -d /tmp || return 1
   done
   return 0
 }


### PR DESCRIPTION
The Python [`wheel`](https://wheel.readthedocs.io/en/stable/reference/wheel_unpack.html) command is quite strange, its may not well documented the version that added the additional argument.

So, I presume an upgrade of the package may solve the problem.

Failed log:
> They started failing here: https://source.cloud.google.com/results/invocations/98c11d21-a520-493c-a566-1b8ebebafee4/log

Related PR #18306