### PR TITLE
Update tools to ensure error details appear in VS

### DIFF
--- a/src/csharp/Grpc.Tools.Tests/ProtoCompileCommandLineGeneratorTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/ProtoCompileCommandLineGeneratorTest.cs
@@ -49,7 +49,7 @@ namespace Grpc.Tools.Tests
             ExecuteExpectSuccess();
             Assert.That(_task.LastPathToTool, Does.Match(@"protoc(.exe)?$"));
             Assert.That(_task.LastResponseFile, Is.EqualTo(new[] {
-                "--csharp_out=outdir", "a.proto" }));
+                "--csharp_out=outdir", "--error_format=msvs", "a.proto" }));
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace Grpc.Tools.Tests
             _task.ProtoBuf = Utils.MakeSimpleItems("a.proto", "foo/b.proto");
             ExecuteExpectSuccess();
             Assert.That(_task.LastResponseFile, Is.EqualTo(new[] {
-                "--csharp_out=outdir", "a.proto", "foo/b.proto" }));
+                "--csharp_out=outdir", "--error_format=msvs", "a.proto", "foo/b.proto" }));
         }
 
         [Test]
@@ -68,7 +68,7 @@ namespace Grpc.Tools.Tests
             ExecuteExpectSuccess();
             Assert.That(_task.LastResponseFile, Is.EqualTo(new[] {
                 "--csharp_out=outdir", "--proto_path=/path1",
-                "--proto_path=/path2", "a.proto" }));
+                "--proto_path=/path2", "--error_format=msvs", "a.proto" }));
         }
 
         [TestCase("Cpp")]
@@ -87,7 +87,7 @@ namespace Grpc.Tools.Tests
             ExecuteExpectSuccess();
             gen = gen.ToLowerInvariant();
             Assert.That(_task.LastResponseFile, Is.EqualTo(new[] {
-                $"--{gen}_out=outdir", $"--{gen}_opt=foo,bar", "a.proto" }));
+                $"--{gen}_out=outdir", $"--{gen}_opt=foo,bar", "--error_format=msvs", "a.proto" }));
         }
 
         [Test]

--- a/src/csharp/Grpc.Tools/ProtoCompile.cs
+++ b/src/csharp/Grpc.Tools/ProtoCompile.cs
@@ -322,6 +322,7 @@ namespace Grpc.Tools
             {
                 cmd.AddArg(proto.ItemSpec);
             }
+            cmd.AddSwitchMaybe("error_format", "msvs");
             return cmd.ToString();
         }
 

--- a/src/csharp/Grpc.Tools/ProtoCompile.cs
+++ b/src/csharp/Grpc.Tools/ProtoCompile.cs
@@ -318,11 +318,11 @@ namespace Grpc.Tools
                     cmd.AddSwitchMaybe("proto_path", TrimEndSlash(path));
             }
             cmd.AddSwitchMaybe("dependency_out", DependencyOut);
+            cmd.AddSwitchMaybe("error_format", "msvs");
             foreach (var proto in ProtoBuf)
             {
                 cmd.AddArg(proto.ItemSpec);
             }
-            cmd.AddSwitchMaybe("error_format", "msvs");
             return cmd.ToString();
         }
 

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -271,6 +271,7 @@
       GrpcPluginExe="%(_Protobuf_OutOfDateProto.GrpcPluginExe)"
       GrpcOutputDir="%(_Protobuf_OutOfDateProto.GrpcOutputDir)"
       GrpcOutputOptions="%(_Protobuf_OutOfDateProto._GrpcOutputOptions)"
+      LogStandardErrorAsError="true"
     >
       <Output TaskParameter="GeneratedFiles" ItemName="_Protobuf_GeneratedFiles"/>
     </ProtoCompile>


### PR DESCRIPTION
Partially addresses https://github.com/grpc/grpc-dotnet/issues/129.

This PR enables the ProtoCompile task to output errors which will then be picked up by the VS error list. 

Before:
![image](https://user-images.githubusercontent.com/2030323/54304340-2debbd80-4582-11e9-8370-032b48c439e5.png)

After:
![image](https://user-images.githubusercontent.com/2030323/54304306-1b718400-4582-11e9-8130-148fd8fe5e2e.png)
