### PR TITLE
Enable design time builds by default

### DIFF
--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -80,7 +80,7 @@
            >$(Protobuf_PackagedToolsPath)/$(Protobuf_ToolsOs)_$(Protobuf_ToolsCpu)/protoc</Protobuf_ProtocFullPath>
     </PropertyGroup>
 
-    <Error Condition=" '$(DesignTimeBuild)' != 'true' and '$(PROTOBUF_PROTOC)' == ''
+    <Error Condition=" '$(DisableProtobufDesignTimeBuild)' != 'true' and '$(PROTOBUF_PROTOC)' == ''
                         and ( '$(Protobuf_ToolsOs)' == '' or '$(Protobuf_ToolsCpu)' == '' ) "
       Text="Google.Protobuf.Tools cannot determine host OS and CPU.&#10;Use environment variables PROTOBUF_TOOLS_OS={linux|macosx|windows} and PROTOBUF_TOOLS_CPU={x86|x64} to try the closest match to your system.&#10;You may also set PROTOBUF_PROTOC to specify full path to the host-provided compiler (v3.5+ is required)." />
   </Target>
@@ -93,7 +93,7 @@
   <Target Name="Protobuf_BeforeCompile" />
   <Target Name="Protobuf_AfterCompile" />
 
-  <!-- Main compile sequence. Certain steps are gated by the value $(DesignTimeBuild),
+  <!-- Main compile sequence. Certain steps are gated by the value $(DisableProtobufDesignTimeBuild),
        so the sequence is good for either design time or build time. -->
   <Target Name="Protobuf_Compile"
           Condition=" '@(ProtoBuf)' != '' "
@@ -159,7 +159,7 @@
       <Output TaskParameter="PossibleOutputs" ItemName="Protobuf_ExpectedOutputs" />
     </ProtoCompilerOutputs>
     <!-- Read any dependency files from previous compiles. -->
-    <ProtoReadDependencies Condition=" '$(Protobuf_DepFilesPath)' != '' and '$(DesignTimeBuild)' != 'true' "
+    <ProtoReadDependencies Condition=" '$(Protobuf_DepFilesPath)' != '' and '$(DisableProtobufDesignTimeBuild)' != 'true' "
                            ProtoBuf="@(Protobuf_Compile)"
                            ProtoDepDir="$(Protobuf_DepFilesPath)" >
       <Output TaskParameter="Dependencies" ItemName="Protobuf_Dependencies" />
@@ -246,7 +246,7 @@
   </Target>
 
   <Target Name="_Protobuf_CoreCompile"
-          Condition=" '$(DesignTimeBuild)' != 'true' "
+          Condition=" '$(DisableProtobufDesignTimeBuild)' != 'true' "
           DependsOnTargets="Protobuf_PrepareCompileOptions;_Protobuf_GatherStaleFiles">
     <!-- Ensure output directories. -->
     <MakeDir Directories="%(_Protobuf_OutOfDateProto.OutputDir)" />
@@ -289,7 +289,7 @@
        compile though). You can empty this collection in your Before targets to do nothing.
        The target is not executed if the proto compiler is not executed. -->
   <Target Name="Protobuf_ReconcileOutputs"
-          Condition=" '$(DesignTimeBuild)' != 'true' ">
+          Condition=" '$(DisableProtobufDesignTimeBuild)' != 'true' ">
     <!-- Warn about unexpected/missing files outside object file directory only.
          This should have happened because build was incorrectly customized. -->
     <FindUnderPath Path="$(BaseIntermediateOutputPath)" Files="@(Protobuf_ExpectedNotGenerated)">


### PR DESCRIPTION
Addresses first part of https://github.com/grpc/grpc-dotnet/issues/17. This is required to enable design time build by default but users can still opt out of it by setting `DisableGrpcDesignTimeBuild` to `true`.