### PR TITLE
Fix layout of Grpc.Tools package

### DIFF
--- a/src/csharp/Grpc.Tools/Grpc.Tools.csproj
+++ b/src/csharp/Grpc.Tools/Grpc.Tools.csproj
@@ -70,20 +70,20 @@ Linux and MacOS. Managed runtime is supplied separately in the Grpc.Core package
     <!-- TODO(kkm): GPB builds assets into "macosx", GRPC into "macos". -->
     <!-- TODO(kkm): Do not place non-tools under tools/, use build/native/bin/. -->
     <!-- TODO(kkm): Do not package windows x64 builds (#13098). -->
-    <_Asset PackagePath="tools/windows_x86/protoc.exe" Include="$(Assets_ProtoCompiler)windows_x86/protoc.exe" />
-    <_Asset PackagePath="tools/windows_x64/protoc.exe" Include="$(Assets_ProtoCompiler)windows_x64/protoc.exe" />
-    <_Asset PackagePath="tools/linux_x86/protoc" Include="$(Assets_ProtoCompiler)linux_x86/protoc" />
-    <_Asset PackagePath="tools/linux_x64/protoc" Include="$(Assets_ProtoCompiler)linux_x64/protoc" />
-    <_Asset PackagePath="tools/macosx_x86/protoc" Include="$(Assets_ProtoCompiler)macos_x86/protoc" /> <!-- GPB: macosx-->
-    <_Asset PackagePath="tools/macosx_x64/protoc" Include="$(Assets_ProtoCompiler)macos_x64/protoc" /> <!-- GPB: macosx-->
+    <_Asset PackagePath="tools/windows_x86/" Include="$(Assets_ProtoCompiler)windows_x86/protoc.exe" />
+    <_Asset PackagePath="tools/windows_x64/" Include="$(Assets_ProtoCompiler)windows_x64/protoc.exe" />
+    <_Asset PackagePath="tools/linux_x86/" Include="$(Assets_ProtoCompiler)linux_x86/protoc" />
+    <_Asset PackagePath="tools/linux_x64/" Include="$(Assets_ProtoCompiler)linux_x64/protoc" />
+    <_Asset PackagePath="tools/macosx_x86/" Include="$(Assets_ProtoCompiler)macos_x86/protoc" /> <!-- GPB: macosx-->
+    <_Asset PackagePath="tools/macosx_x64/" Include="$(Assets_ProtoCompiler)macos_x64/protoc" /> <!-- GPB: macosx-->
 
     <!-- gRPC assets (for Grpc.Tools) -->
-    <_Asset PackagePath="tools/windows_x86/grpc_csharp_plugin.exe" Include="$(Assets_GrpcPlugins)protoc_windows_x86/grpc_csharp_plugin.exe" />
-    <_Asset PackagePath="tools/windows_x64/grpc_csharp_plugin.exe" Include="$(Assets_GrpcPlugins)protoc_windows_x64/grpc_csharp_plugin.exe" />
-    <_Asset PackagePath="tools/linux_x86/grpc_csharp_plugin" Include="$(Assets_GrpcPlugins)protoc_linux_x86/grpc_csharp_plugin" />
-    <_Asset PackagePath="tools/linux_x64/grpc_csharp_plugin" Include="$(Assets_GrpcPlugins)protoc_linux_x64/grpc_csharp_plugin" />
-    <_Asset PackagePath="tools/macosx_x86/grpc_csharp_plugin" Include="$(Assets_GrpcPlugins)protoc_macos_x86/grpc_csharp_plugin" />
-    <_Asset PackagePath="tools/macosx_x64/grpc_csharp_plugin" Include="$(Assets_GrpcPlugins)protoc_macos_x64/grpc_csharp_plugin" />
+    <_Asset PackagePath="tools/windows_x86/" Include="$(Assets_GrpcPlugins)protoc_windows_x86/grpc_csharp_plugin.exe" />
+    <_Asset PackagePath="tools/windows_x64/" Include="$(Assets_GrpcPlugins)protoc_windows_x64/grpc_csharp_plugin.exe" />
+    <_Asset PackagePath="tools/linux_x86/" Include="$(Assets_GrpcPlugins)protoc_linux_x86/grpc_csharp_plugin" />
+    <_Asset PackagePath="tools/linux_x64/" Include="$(Assets_GrpcPlugins)protoc_linux_x64/grpc_csharp_plugin" />
+    <_Asset PackagePath="tools/macosx_x86/" Include="$(Assets_GrpcPlugins)protoc_macos_x86/grpc_csharp_plugin" />
+    <_Asset PackagePath="tools/macosx_x64/" Include="$(Assets_GrpcPlugins)protoc_macos_x64/grpc_csharp_plugin" />
 
     <None Include="@(_Asset)" Pack="true" Visible="false" />
   </ItemGroup>


### PR DESCRIPTION
Merging of https://github.com/grpc/grpc/pull/17276 has broken the path of `protoc` and `grpc_csharp_plugin` in Grpc.Tools package (there is now one extra directory level with the same name as the file). This is probably due to differences in behavior for newer dotnet SDKs.

The corresponding distribtest failure
```
+ PROTOC=../packages/Grpc.Tools.1.20.0-dev201903141628/tools/linux_x64/protoc
+ PLUGIN=../packages/Grpc.Tools.1.20.0-dev201903141628/tools/linux_x64/grpc_csharp_plugin
+ ../packages/Grpc.Tools.1.20.0-dev201903141628/tools/linux_x64/protoc --plugin=protoc-gen-grpc=../packages/Grpc.Tools.1.20.0-dev201903141628/tools/linux_x64/grpc_csharp_plugin --csharp_out=. --grpc_out=. -I . testcodegen.proto
test_codegen/test_codegen.sh: line 34: ../packages/Grpc.Tools.1.20.0-dev201903141628/tools/linux_x64/protoc: Is a directory
+ FAILED=true
+ '[' '' '!=' '' ']'
+ docker rm -f build_and_run_docker_c936d31f-fbe9-4f91-9fa2-4cdb004563c6
build_and_run_docker_c936d31f-fbe9-4f91-9fa2-4cdb004563c6
+ '[' true '!=' '' ']'
+ exit 1
2019-03-14 09:44:23,190 FAILED: distribtest.csharp_linux_x64_ubuntu1604 [ret=1, pid=8418, time=126.3sec]
```
https://source.cloud.google.com/results/invocations/809137e6-7236-4a0e-b7a0-1c1dc702b939/log

