### PR TITLE
Use GRPC_LINUX_ERRQUEUE

### DIFF
--- a/src/core/lib/iomgr/internal_errqueue.cc
+++ b/src/core/lib/iomgr/internal_errqueue.cc
@@ -38,8 +38,7 @@ bool kernel_supports_errqueue() { return errqueue_supported; }
 void grpc_errqueue_init() {
 /* Both-compile time and run-time linux kernel versions should be atleast 4.0.0
  */
-#ifdef LINUX_VERSION_CODE
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 0, 0)
+#ifdef GRPC_LINUX_ERRQUEUE
   struct utsname buffer;
   if (uname(&buffer) != 0) {
     gpr_log(GPR_ERROR, "uname: %s", strerror(errno));
@@ -55,8 +54,7 @@ void grpc_errqueue_init() {
   } else {
     gpr_log(GPR_DEBUG, "ERRQUEUE support not enabled");
   }
-#endif /* LINUX_VERSION_CODE <= KERNEL_VERSION(4, 0, 0) */
-#endif /* LINUX_VERSION_CODE */
+#endif /* GRPC_LINUX_ERRQUEUE */
 }
 } /* namespace grpc_core */
 


### PR DESCRIPTION
Use GRPC_LINUX_ERRQUEUE instead of checking for LINUX_VERSION_CODE

Fixes #18362