### PR TITLE
Fix bug in CFStream endpoint

### DIFF
--- a/src/core/lib/iomgr/cfstream_handle.cc
+++ b/src/core/lib/iomgr/cfstream_handle.cc
@@ -29,6 +29,7 @@
 
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/iomgr/closure.h"
+#include "src/core/lib/iomgr/error_cfstream.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 
 extern grpc_core::TraceFlag grpc_tcp_trace;
@@ -54,6 +55,8 @@ void CFStreamHandle::ReadCallback(CFReadStreamRef stream,
                                   void* client_callback_info) {
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
+  grpc_error* error;
+  CFErrorRef stream_error;
   CFStreamHandle* handle = static_cast<CFStreamHandle*>(client_callback_info);
   if (grpc_tcp_trace.enabled()) {
     gpr_log(GPR_DEBUG, "CFStream ReadCallback (%p, %p, %lu, %p)", handle,
@@ -68,8 +71,15 @@ void CFStreamHandle::ReadCallback(CFReadStreamRef stream,
       handle->read_event_.SetReady();
       break;
     case kCFStreamEventErrorOccurred:
-      handle->open_event_.SetReady();
-      handle->read_event_.SetReady();
+      stream_error = CFReadStreamCopyError(stream);
+      error = grpc_error_set_int(
+          GRPC_ERROR_CREATE_FROM_CFERROR(stream_error, "read error"),
+          GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);
+      CFRelease(stream_error);
+      handle->open_event_.SetShutdown(GRPC_ERROR_REF(error));
+      handle->write_event_.SetShutdown(GRPC_ERROR_REF(error));
+      handle->read_event_.SetShutdown(GRPC_ERROR_REF(error));
+      GRPC_ERROR_UNREF(error);
       break;
     default:
       GPR_UNREACHABLE_CODE(return );
@@ -80,6 +90,8 @@ void CFStreamHandle::WriteCallback(CFWriteStreamRef stream,
                                    void* clientCallBackInfo) {
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
+  grpc_error* error;
+  CFErrorRef stream_error;
   CFStreamHandle* handle = static_cast<CFStreamHandle*>(clientCallBackInfo);
   if (grpc_tcp_trace.enabled()) {
     gpr_log(GPR_DEBUG, "CFStream WriteCallback (%p, %p, %lu, %p)", handle,
@@ -94,8 +106,15 @@ void CFStreamHandle::WriteCallback(CFWriteStreamRef stream,
       handle->write_event_.SetReady();
       break;
     case kCFStreamEventErrorOccurred:
-      handle->open_event_.SetReady();
-      handle->write_event_.SetReady();
+      stream_error = CFWriteStreamCopyError(stream);
+      error = grpc_error_set_int(
+          GRPC_ERROR_CREATE_FROM_CFERROR(stream_error, "write error"),
+          GRPC_ERROR_INT_GRPC_STATUS, GRPC_STATUS_UNAVAILABLE);
+      CFRelease(stream_error);
+      handle->open_event_.SetShutdown(GRPC_ERROR_REF(error));
+      handle->write_event_.SetShutdown(GRPC_ERROR_REF(error));
+      handle->read_event_.SetShutdown(GRPC_ERROR_REF(error));
+      GRPC_ERROR_UNREF(error);
       break;
     default:
       GPR_UNREACHABLE_CODE(return );

--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -143,6 +143,7 @@ void LoopUntilCancelled(Alarm* alarm, ServerContext* context,
 
 Status TestServiceImpl::Echo(ServerContext* context, const EchoRequest* request,
                              EchoResponse* response) {
+  gpr_log(GPR_DEBUG, "Request message was %s", request->message().c_str());
   // A bit of sleep to make sure that short deadline tests fail
   if (request->has_param() && request->param().server_sleep_us() > 0) {
     gpr_sleep_until(


### PR DESCRIPTION
We were failing to return an error when the transport tried to write to an endpoint that was in an errored state.