### PR TITLE
Use correct C integer types in Cython

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -13,15 +13,7 @@
 # limitations under the License.
 
 cimport libc.time
-from libc.stdint cimport intptr_t
-
-
-# Typedef types with approximately the same semantics to provide their names to
-# Cython
-ctypedef unsigned char uint8_t
-ctypedef int int32_t
-ctypedef unsigned uint32_t
-ctypedef long int64_t
+from libc.stdint cimport intptr_t, uint8_t, int32_t, uint32_t, int64_t
 
 
 cdef extern from "grpc/support/alloc.h":


### PR DESCRIPTION
As I mentioned in https://github.com/grpc/grpc/pull/18246#issuecomment-473137982, the Cython integer type def is problematic. The size of `long` differs across platform:

OS | Architecture | Size of "long" type
-- | -- | --
Windows | IA-32 | 4 bytes
  | Intel® 64 | 4 bytes
Linux | IA-32 | 4 bytes
  | Intel® 64 | 8 bytes
mac OS | Intel® 64 | 8 bytes 

So, the original `ctypedef long int64_t` is one of the root causes of #18246 and #18244. It will result in OverflowError if you feed it `PyInt`, and it will overflow silently to a random number if you feed it `PyFloat`.