### PR TITLE
Fix CFStreamTests

### DIFF
--- a/test/core/iomgr/ios/CFStreamTests/CFStreamEndpointTests.mm
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamEndpointTests.mm
@@ -187,7 +187,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
   grpc_slice_buffer_init(&read_one_slice);
   while (read_slices.length < kBufferSize) {
     init_event_closure(&read_done, &read);
-    grpc_endpoint_read(ep_, &read_one_slice, &read_done);
+    grpc_endpoint_read(ep_, &read_one_slice, &read_done, /*urgent=*/false);
     XCTAssertEqual([self waitForEvent:&read timeout:kReadTimeout], YES);
     XCTAssertEqual(reinterpret_cast<grpc_error *>(read), GRPC_ERROR_NONE);
     grpc_slice_buffer_move_into(&read_one_slice, &read_slices);
@@ -218,7 +218,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 
   grpc_slice_buffer_init(&read_slices);
   init_event_closure(&read_done, &read);
-  grpc_endpoint_read(ep_, &read_slices, &read_done);
+  grpc_endpoint_read(ep_, &read_slices, &read_done, /*urgent=*/false);
 
   grpc_slice_buffer_init(&write_slices);
   slice = grpc_slice_from_static_buffer(write_buffer, kBufferSize);
@@ -267,7 +267,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 
   init_event_closure(&read_done, &read);
   grpc_slice_buffer_init(&read_slices);
-  grpc_endpoint_read(ep_, &read_slices, &read_done);
+  grpc_endpoint_read(ep_, &read_slices, &read_done, /*urgent=*/false);
 
   grpc_slice_buffer_init(&write_slices);
   slice = grpc_slice_from_static_buffer(write_buffer, kBufferSize);
@@ -306,7 +306,7 @@ static bool compare_slice_buffer_with_buffer(grpc_slice_buffer *slices, const ch
 
   init_event_closure(&read_done, &read);
   grpc_slice_buffer_init(&read_slices);
-  grpc_endpoint_read(ep_, &read_slices, &read_done);
+  grpc_endpoint_read(ep_, &read_slices, &read_done, /*urgent=*/false);
 
   struct linger so_linger;
   so_linger.l_onoff = 1;

--- a/test/core/iomgr/ios/CFStreamTests/CFStreamTests.xcodeproj/project.pbxproj
+++ b/test/core/iomgr/ios/CFStreamTests/CFStreamTests.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		5E143B892069D72200715A6E /* CFStreamClientTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5E143B882069D72200715A6E /* CFStreamClientTests.mm */; };
-		5E143B8C206B5F9F00715A6E /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5E143B8A2069D72700715A6E /* Info.plist */; };
 		5E143B8E206C5B9A00715A6E /* CFStreamEndpointTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5E143B8D206C5B9A00715A6E /* CFStreamEndpointTests.mm */; };
 		604EA96D9CD477A8EA411BDF /* libPods-CFStreamTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = AFFA154D492751CEAC05D591 /* libPods-CFStreamTests.a */; };
 /* End PBXBuildFile section */
@@ -82,7 +81,6 @@
 				4EBA55D3E23FC6C84596E3D5 /* [CP] Check Pods Manifest.lock */,
 				5E143B752069D67300715A6E /* Sources */,
 				5E143B762069D67300715A6E /* Frameworks */,
-				5E143B772069D67300715A6E /* Resources */,
 			);
 			buildRules = (
 			);
@@ -125,17 +123,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXResourcesBuildPhase section */
-		5E143B772069D67300715A6E /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				5E143B8C206B5F9F00715A6E /* Info.plist in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		4EBA55D3E23FC6C84596E3D5 /* [CP] Check Pods Manifest.lock */ = {

--- a/test/core/iomgr/ios/CFStreamTests/run_tests.sh
+++ b/test/core/iomgr/ios/CFStreamTests/run_tests.sh
@@ -17,6 +17,7 @@
 # ./tools/run_tests/run_tests.py -l objc
 
 set -ev
+set -o pipefail
 
 cd "$(dirname "$0")"
 


### PR DESCRIPTION
- Pass extra param to grpc_endpoint_read() as the API has changed.
- Fixed build error seen with Xcode 10.
- Enable pipefail so xcodebuild errors are propagated to the caller.