### PR TITLE
Ensure we have the right version of dotnet SDK when building grpc-dotnet interop image.

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/Dockerfile.template
@@ -16,5 +16,8 @@
 
   FROM mcr.microsoft.com/dotnet/core/sdk:3.0.100-preview3-stretch
 
+  # needed by get-dotnet.sh script
+  RUN apt-get update && apt-get install -y jq && apt-get clean
+
   # Define the default command.
   CMD ["bash"]

--- a/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
@@ -25,6 +25,7 @@
   cp -r /var/local/jenkins/service_account $HOME || true
 
   cd /var/local/git/grpc-dotnet
+  ./build/get-dotnet.sh
   ./build/get-grpc.sh
 
   cd testassets/InteropTestsWebsite

--- a/tools/dockerfile/interoptest/grpc_interop_aspnetcore/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_aspnetcore/Dockerfile
@@ -14,5 +14,8 @@
 
 FROM mcr.microsoft.com/dotnet/core/sdk:3.0.100-preview3-stretch
 
+# needed by get-dotnet.sh script
+RUN apt-get update && apt-get install -y jq && apt-get clean
+
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
@@ -23,6 +23,7 @@ git clone /var/local/jenkins/grpc-dotnet /var/local/git/grpc-dotnet
 cp -r /var/local/jenkins/service_account $HOME || true
 
 cd /var/local/git/grpc-dotnet
+./build/get-dotnet.sh
 ./build/get-grpc.sh
 
 cd testassets/InteropTestsWebsite


### PR DESCRIPTION
A prerequisite for merging https://github.com/grpc/grpc-dotnet/pull/162