### PR TITLE
python docs: details are UTF-8 encodable, not just ASCII.

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -282,7 +282,7 @@ class Status(six.with_metaclass(abc.ABCMeta)):
 
     Attributes:
       code: A StatusCode object to be sent to the client.
-      details: An ASCII-encodable string to be sent to the client upon
+      details: A UTF-8-encodable string to be sent to the client upon
         termination of the RPC.
       trailing_metadata: The trailing :term:`metadata` in the RPC.
     """
@@ -1131,7 +1131,7 @@ class ServicerContext(six.with_metaclass(abc.ABCMeta, RpcContext)):
         Args:
           code: A StatusCode object to be sent to the client.
             It must not be StatusCode.OK.
-          details: An ASCII-encodable string to be sent to the client upon
+          details: A UTF-8-encodable string to be sent to the client upon
             termination of the RPC.
 
         Raises:
@@ -1179,7 +1179,7 @@ class ServicerContext(six.with_metaclass(abc.ABCMeta, RpcContext)):
         no details to transmit.
 
         Args:
-          details: An ASCII-encodable string to be sent to the client upon
+          details: A UTF-8-encodable string to be sent to the client upon
             termination of the RPC.
         """
         raise NotImplementedError()


### PR DESCRIPTION
Context detail messages are Unicode strings in both the implementation and
specification. Fix the documentation to make this clearer. The
specification for the Status-Message response field says "Status-Message is
[...] a Unicode string [...] encoded as UTF-8". The implementation
seems to call _common.encode(), so anything that is UTF-8 encodable works.
For example:

    context.set_code(grpc.StatusCode.ABORTED)
    context.set_details('emoji error: \U0001F600')

Correctly returns a smiley face emoji to the client.