### PR TITLE
Fix broken php7 performance benchmarks build

### DIFF
--- a/src/ruby/qps/proxy-worker.rb
+++ b/src/ruby/qps/proxy-worker.rb
@@ -48,7 +48,7 @@ class ProxyBenchmarkClientServiceImpl < Grpc::Testing::ProxyClientService::Servi
         if @use_c_ext
           puts "Use protobuf c extension"
           command = "php -d extension=" + File.expand_path(File.dirname(__FILE__)) +
-            "/../../php/tests/qps/vendor/google/protobuf/php/ext/google/protobuf/modules/protobuf.so " +
+            "/../../../third_party/protobuf/php/ext/google/protobuf/modules/protobuf.so " +
             "-d extension=" + File.expand_path(File.dirname(__FILE__)) + "/../../php/ext/grpc/modules/grpc.so " +
             File.expand_path(File.dirname(__FILE__)) + "/" + @php_client_bin + " " + @mytarget + " #{chan%@config.server_targets.length}"
         else

--- a/tools/run_tests/performance/build_performance_php7.sh
+++ b/tools/run_tests/performance/build_performance_php7.sh
@@ -23,7 +23,7 @@ python tools/run_tests/run_tests.py -l php7 -c "$CONFIG" --build_only -j 8
 cd src/php/tests/qps
 composer install
 # Install protobuf C-extension for php
-cd vendor/google/protobuf/php/ext/google/protobuf
+cd ../../../../third_party/protobuf/php/ext/google/protobuf
 phpize
 ./configure
 make


### PR DESCRIPTION
Fixes #18274 

The protobuf team changed how their PHP composer package is delivered. It no longer carries the source code for the C extension.