### PR TITLE
Fix grpc-dotnet interop tests

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
@@ -25,8 +25,13 @@
   cp -r /var/local/jenkins/service_account $HOME || true
 
   cd /var/local/git/grpc-dotnet
+  
+  # If needed, update dotnet SDK and put it on path
   ./build/get-dotnet.sh
-  export PATH="$HOME/.dotnet/:$PATH"
+  if [ -f $HOME/.dotnet/dotnet ]
+  then
+    ln -s $HOME/.dotnet/dotnet /usr/local/bin/dotnet
+  fi
   
   ./build/get-grpc.sh
 

--- a/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
@@ -26,6 +26,8 @@
 
   cd /var/local/git/grpc-dotnet
   ./build/get-dotnet.sh
+  export PATH="$HOME/.dotnet/:$PATH"
+  
   ./build/get-grpc.sh
 
   cd testassets/InteropTestsWebsite

--- a/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
@@ -24,6 +24,8 @@ cp -r /var/local/jenkins/service_account $HOME || true
 
 cd /var/local/git/grpc-dotnet
 ./build/get-dotnet.sh
+export PATH="$HOME/.dotnet/:$PATH"
+
 ./build/get-grpc.sh
 
 cd testassets/InteropTestsWebsite

--- a/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
@@ -23,8 +23,13 @@ git clone /var/local/jenkins/grpc-dotnet /var/local/git/grpc-dotnet
 cp -r /var/local/jenkins/service_account $HOME || true
 
 cd /var/local/git/grpc-dotnet
+
+# If needed, update dotnet SDK and put it on path
 ./build/get-dotnet.sh
-export PATH="$HOME/.dotnet/:$PATH"
+if [ -f $HOME/.dotnet/dotnet ]
+then
+  ln -s $HOME/.dotnet/dotnet /usr/local/bin/dotnet
+fi
 
 ./build/get-grpc.sh
 


### PR DESCRIPTION
Fixes failure:

https://source.cloud.google.com/results/invocations/b4cb94a8-f918-4a73-bd2e-fcf4d3707984/targets/github%2Fgrpc%2Finterop_docker_build/tests

```
A compatible installed dotnet SDK for global.json version: [3.0.100-preview4-010898] from [/var/local/git/grpc-dotnet/global.json] was not found
Please install the [3.0.100-preview4-010898] SDK or update [/var/local/git/grpc-dotnet/global.json] with an installed dotnet SDK:
  3.0.100-preview3-010431 [/usr/share/dotnet/sdk]
```