### PR TITLE
Fix PHP unit test warnings

### DIFF
--- a/src/php/tests/unit_tests/InterceptorTest.php
+++ b/src/php/tests/unit_tests/InterceptorTest.php
@@ -103,7 +103,11 @@ class ChangeMetadataInterceptor extends Grpc\Interceptor
         $metadata["foo"] = array('interceptor_from_unary_request');
         return $continuation($method, $argument, $deserialize, $metadata, $options);
     }
-    public function interceptStreamUnary($method, $deserialize, array $metadata = [], array $options = [], $continuation)
+    public function interceptStreamUnary($method,
+                                         $deserialize,
+                                         array $metadata = [],
+                                         array $options = [],
+                                         $continuation)
     {
         $metadata["foo"] = array('interceptor_from_stream_request');
         return $continuation($method, $deserialize, $metadata, $options);
@@ -178,7 +182,11 @@ class ChangeRequestInterceptor extends Grpc\Interceptor
         $argument->setData('intercepted_unary_request');
         return $continuation($method, $argument, $deserialize, $metadata, $options);
     }
-    public function interceptStreamUnary($method, $deserialize, array $metadata = [], array $options = [], $continuation)
+    public function interceptStreamUnary($method,
+                                         $deserialize,
+                                         array $metadata = [],
+                                         array $options = [],
+                                         $continuation)
     {
         return new ChangeRequestCall(
             $continuation($method, $deserialize, $metadata, $options)
@@ -190,6 +198,7 @@ class StopCallInterceptor extends Grpc\Interceptor
 {
     public function interceptUnaryUnary($method,
                                         $argument,
+                                        $deserialize,
                                         array $metadata = [],
                                         array $options = [],
                                         $continuation)
@@ -197,6 +206,7 @@ class StopCallInterceptor extends Grpc\Interceptor
         $metadata["foo"] = array('interceptor_from_request_response');
     }
     public function interceptStreamUnary($method,
+                                         $deserialize,
                                          array $metadata = [],
                                          array $options = [],
                                          $continuation)


### PR DESCRIPTION
```
Warning: Declaration of StopCallInterceptor::interceptUnaryUnary($method, $argument, array $metadata, array $options, $continuation) should be compatible with Grpc\Interceptor::interceptUnaryUnary($method, $argument, $deserialize, array $metadata, array $options, $continuation) in /Volumes/BuildData/tmpfs/src/github/grpc/workspace_php_macos_dbg_native/src/php/tests/unit_tests/InterceptorTest.php on line 206

Warning: Declaration of StopCallInterceptor::interceptStreamUnary($method, array $metadata, array $options, $continuation) should be compatible with Grpc\Interceptor::interceptStreamUnary($method, $deserialize, array $metadata, array $options, $continuation) in /Volumes/BuildData/tmpfs/src/github/grpc/workspace_php_macos_dbg_native/src/php/tests/unit_tests/InterceptorTest.php on line 206
```