### PR TITLE
Support libuv pipes for custom socket on platforms with UDS

### DIFF
--- a/src/core/lib/iomgr/port.h
+++ b/src/core/lib/iomgr/port.h
@@ -32,7 +32,9 @@
 #define GRPC_ARES_RESOLVE_LOCALHOST_MANUALLY 1
 #endif
 #if defined(GRPC_CUSTOM_SOCKET)
-// Do Nothing
+#if !defined(GPR_WINDOWS)
+#define GRPC_HAVE_UNIX_SOCKET 1
+#endif
 #elif defined(GPR_MANYLINUX1)
 #define GRPC_HAVE_ARPA_NAMESER 1
 #define GRPC_HAVE_IFADDRS 1

--- a/src/core/lib/iomgr/tcp_client_custom.cc
+++ b/src/core/lib/iomgr/tcp_client_custom.cc
@@ -134,7 +134,8 @@ static void tcp_connect(grpc_closure* closure, grpc_endpoint** ep,
   grpc_custom_socket* socket =
       (grpc_custom_socket*)gpr_malloc(sizeof(grpc_custom_socket));
   socket->refs = 2;
-  grpc_custom_socket_vtable->init(socket, GRPC_AF_UNSPEC);
+  grpc_sockaddr* sock_addr = (grpc_sockaddr*)resolved_addr->addr;
+  grpc_custom_socket_vtable->init(socket, sock_addr->sa_family);
   connect =
       (grpc_custom_tcp_connect*)gpr_malloc(sizeof(grpc_custom_tcp_connect));
   connect->closure = closure;

--- a/src/core/lib/iomgr/unix_sockets_posix.cc
+++ b/src/core/lib/iomgr/unix_sockets_posix.cc
@@ -27,6 +27,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/un.h>
+#include <unistd.h>
 
 #include "src/core/lib/iomgr/unix_sockets_posix.h"
 
@@ -34,6 +35,9 @@
 #include <grpc/support/log.h>
 
 #include "src/core/lib/gpr/useful.h"
+
+const int sun_path_len = sizeof(((sockaddr_un*)nullptr)->sun_path);
+const int sun_path_offset = offsetof(sockaddr_un, sun_path);
 
 void grpc_create_socketpair_if_unix(int sv[2]) {
   GPR_ASSERT(socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == 0);
@@ -92,13 +96,18 @@ char* grpc_sockaddr_to_uri_unix_if_possible(
     const grpc_resolved_address* resolved_addr) {
   const grpc_sockaddr* addr =
       reinterpret_cast<const grpc_sockaddr*>(resolved_addr->addr);
-  if (addr->sa_family != AF_UNIX) {
+  char* result;
+  const char* path = grpc_sockaddr_to_path_if_possible(addr);
+  if (!path) {
     return nullptr;
   }
-
-  char* result;
-  gpr_asprintf(&result, "unix:%s", ((struct sockaddr_un*)addr)->sun_path);
+  gpr_asprintf(&result, "unix:%s", path);
   return result;
+}
+
+const char* grpc_sockaddr_to_path_if_possible(const struct sockaddr* addr) {
+  return (addr->sa_family == AF_UNIX) ? ((struct sockaddr_un*)addr)->sun_path
+                                      : nullptr;
 }
 
 #endif

--- a/src/core/lib/iomgr/unix_sockets_posix.h
+++ b/src/core/lib/iomgr/unix_sockets_posix.h
@@ -27,6 +27,9 @@
 
 #include "src/core/lib/iomgr/resolve_address.h"
 
+extern const int sun_path_len;
+extern const int sun_path_offset;
+
 void grpc_create_socketpair_if_unix(int sv[2]);
 
 grpc_error* grpc_resolve_unix_domain_address(
@@ -39,5 +42,7 @@ void grpc_unlink_if_unix_domain_socket(
 
 char* grpc_sockaddr_to_uri_unix_if_possible(
     const grpc_resolved_address* resolved_addr);
+
+const char* grpc_sockaddr_to_path_if_possible(const struct sockaddr* addr);
 
 #endif /* GRPC_CORE_LIB_IOMGR_UNIX_SOCKETS_POSIX_H */

--- a/src/core/lib/iomgr/unix_sockets_posix_noop.cc
+++ b/src/core/lib/iomgr/unix_sockets_posix_noop.cc
@@ -24,6 +24,9 @@
 
 #include <grpc/support/log.h>
 
+const int sun_path_len = 0;
+const int sun_path_offset = 0;
+
 void grpc_create_socketpair_if_unix(int sv[2]) {
   // TODO: Either implement this for the non-Unix socket case or make
   // sure that it is never called in any such case. Until then, leave an
@@ -43,6 +46,10 @@ int grpc_is_unix_socket(const grpc_resolved_address* addr) { return false; }
 void grpc_unlink_if_unix_domain_socket(const grpc_resolved_address* addr) {}
 
 char* grpc_sockaddr_to_uri_unix_if_possible(const grpc_resolved_address* addr) {
+  return NULL;
+}
+
+const char* grpc_sockaddr_to_path_if_possible(const struct sockaddr* addr) {
   return NULL;
 }
 


### PR DESCRIPTION
Unix domain socket cannot be used with libuv custom socket implementation, although that libuv supports named pipes which on unix-like platforms translate to unix domain sockets (UDS). It is not that difficult to extend current libuv tcp backend to handle UDS in addition to TCP sockets.

Although that libuv provides platform independent implementation of named pipes, grpc does not. So the code added in this pull request has to be ifdef'd in `GRPC_HAVE_UNIX_SOCKET` blocks, which are omitted when grpc is built on windows. On the other platforms the way how the type of a socket, which should be used, is determined is simple. If the host name begins with slash, it is treated as a path to UDS. In all other cases the original code path gets executed (implicit socket type is tcp).

I have tested the code using UDS client and server in nodejs (nodejs uses bindings to grpc C lib with libuv custom socket). The only OS where I have tested the changes is Linux.