### PR TITLE
Ensure errors link to correct line numbers through the VS Error List

### DIFF
--- a/src/csharp/Grpc.Tools.Tests/ProtoCompileBasicTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/ProtoCompileBasicTest.cs
@@ -16,6 +16,8 @@
 
 #endregion
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;  // UWYU: Object.GetType() extension.
 using Microsoft.Build.Framework;
 using Moq;
@@ -30,6 +32,7 @@ namespace Grpc.Tools.Tests
         {
             public string LastPathToTool { get; private set; }
             public string[] LastResponseFile { get; private set; }
+            public List<string> StdErrMessages { get; } = new List<string>();
 
             protected override int ExecuteTool(string pathToTool,
                                                string response,
@@ -45,8 +48,13 @@ namespace Grpc.Tools.Tests
                 LastPathToTool = pathToTool;
                 LastResponseFile = response.Remove(response.Length - 1).Split('\n');
 
+                foreach (string message in StdErrMessages)
+                {
+                    LogEventsFromTextOutput(message, MessageImportance.High);
+                }
+
                 // Do not run the tool, but pretend it ran successfully.
-                return 0;
+                return StdErrMessages.Any() ? -1 : 0;
             }
         };
 

--- a/src/csharp/Grpc.Tools.Tests/ProtoCompileCommandLineGeneratorTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/ProtoCompileCommandLineGeneratorTest.cs
@@ -245,7 +245,8 @@ namespace Grpc.Tools.Tests
                     else
                     {
                         // Ignore expected error
-                        if (e.Message != "\"protoc.exe\" exited with code -1.")
+                        // "protoc/protoc.exe" existed with code -1.
+                        if (!e.Message.EndsWith("exited with code -1."))
                         {
                             Assert.Fail($"Error logged by build engine:\n{e.Message}");
                         }

--- a/src/csharp/Grpc.Tools.Tests/ProtoCompileCommandLineGeneratorTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/ProtoCompileCommandLineGeneratorTest.cs
@@ -175,5 +175,85 @@ namespace Grpc.Tools.Tests
             Assert.That(_task.LastResponseFile,
                         Does.Contain("--csharp_out=" + expect));
         }
+
+        [TestCase(
+            "../Protos/greet.proto(19) : warning in column=5 : warning : When enum name is stripped and label is PascalCased (Zero) this value label conflicts with Zero.",
+            "../Protos/greet.proto",
+            19,
+            5,
+            "warning : When enum name is stripped and label is PascalCased (Zero) this value label conflicts with Zero.")]
+        [TestCase(
+            "../Protos/greet.proto: warning: Import google/protobuf/empty.proto but not used.",
+            "../Protos/greet.proto",
+            0,
+            0,
+            "Import google/protobuf/empty.proto but not used.")]
+        [TestCase("../Protos/greet.proto(14) : error in column=10: \"name\" is already defined in \"Greet.HelloRequest\".", null, 0, 0, null)]
+        [TestCase("../Protos/greet.proto: Import \"google / protobuf / empty.proto\" was listed twice.", null, 0, 0, null)]
+        public void WarningsParsed(string stderr, string file, int line, int col, string message)
+        {
+            _task.StdErrMessages.Add(stderr);
+
+            _mockEngine
+                .Setup(me => me.LogWarningEvent(It.IsAny<BuildWarningEventArgs>()))
+                .Callback((BuildWarningEventArgs e) => {
+                    if (file != null)
+                    {
+                        Assert.AreEqual(file, e.File);
+                        Assert.AreEqual(line, e.LineNumber);
+                        Assert.AreEqual(col, e.ColumnNumber);
+                        Assert.AreEqual(message, e.Message);
+                    }
+                    else
+                    {
+                        Assert.Fail($"Error logged by build engine:\n{e.Message}");
+                    }
+                });
+
+            bool result = _task.Execute();
+            Assert.IsFalse(result);
+        }
+
+        [TestCase(
+            "../Protos/greet.proto(14) : error in column=10: \"name\" is already defined in \"Greet.HelloRequest\".",
+            "../Protos/greet.proto",
+            14,
+            10,
+            "\"name\" is already defined in \"Greet.HelloRequest\".")]
+        [TestCase(
+            "../Protos/greet.proto: Import \"google / protobuf / empty.proto\" was listed twice.",
+            "../Protos/greet.proto",
+            0,
+            0,
+            "Import \"google / protobuf / empty.proto\" was listed twice.")]
+        [TestCase("../Protos/greet.proto(19) : warning in column=5 : warning : When enum name is stripped and label is PascalCased (Zero) this value label conflicts with Zero.", null, 0, 0, null)]
+        [TestCase("../Protos/greet.proto: warning: Import google/protobuf/empty.proto but not used.", null, 0, 0, null)]
+        public void ErrorsParsed(string stderr, string file, int line, int col, string message)
+        {
+            _task.StdErrMessages.Add(stderr);
+
+            _mockEngine
+                .Setup(me => me.LogErrorEvent(It.IsAny<BuildErrorEventArgs>()))
+                .Callback((BuildErrorEventArgs e) => {
+                    if (file != null)
+                    {
+                        Assert.AreEqual(file, e.File);
+                        Assert.AreEqual(line, e.LineNumber);
+                        Assert.AreEqual(col, e.ColumnNumber);
+                        Assert.AreEqual(message, e.Message);
+                    }
+                    else
+                    {
+                        // Ignore expected error
+                        if (e.Message != "\"protoc.exe\" exited with code -1.")
+                        {
+                            Assert.Fail($"Error logged by build engine:\n{e.Message}");
+                        }
+                    }
+                });
+
+            bool result = _task.Execute();
+            Assert.IsFalse(result);
+        }
     };
 }

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -271,7 +271,6 @@
       GrpcPluginExe="%(_Protobuf_OutOfDateProto.GrpcPluginExe)"
       GrpcOutputDir="%(_Protobuf_OutOfDateProto.GrpcOutputDir)"
       GrpcOutputOptions="%(_Protobuf_OutOfDateProto._GrpcOutputOptions)"
-      LogStandardErrorAsError="true"
     >
       <Output TaskParameter="GeneratedFiles" ItemName="_Protobuf_GeneratedFiles"/>
     </ProtoCompile>


### PR DESCRIPTION
Addresses https://github.com/grpc/grpc-dotnet/issues/129

This PR addresses the second concern which is that double clicking the error/warning in the error list should link to the file location where the issue occurs.

The overall design follows the implementation of [VCToolTask](https://docs.microsoft.com/en-us/visualstudio/msbuild/vctooltask-base-class?view=vs-2017), the source is not publicly available but can be read through disassembly of Microsoft.Build.CPPTasks.Common. It works as follows:
1. The MSBuild task invokes a command line executable (cl.exe or protoc.exe) which compiles the source files
2. The executable writes warnings and errors to standard out or standard error.
3. The MSBuild uses Regex to parse the warnings and errors and outputs them in a format that's understood by VS Error List

I've tried to implement the same logic here to handle the warnings and errors output by protoc. But here's a few things to note:
1. The formatting of protoc.exe seems strange. When the msvs option is specified, the output looks something like: 
`../Protos/greet.proto(14) : error in column=10: "name" is already defined in "Greet.HelloRequest".` 
However, the current format of errors is: 
`Startup.cs(12,17): error CS1001: Identifier expected` 
Note that the column number is formatted differently and there's a error code `CS1001` specified. Is there a reason why protoc.exe outputs in a different format for msvs?
2. Warnings do not specify location in the file. For example: `../Protos/greet.proto: warning: Import google/protobuf/empty.proto but not used.` Why is the location information missing? I've defaulted the link to the beginning of the file but I feel this information should be available from protoc.exe and it should be updated.
3. Sometimes errors also don't specify location. For example: `../Protos/greet.proto: Import "google/protobuf/empty.proto" was listed twice.` Again, I've defaulted the link to the beginning of the file but I feel this information should be available from protoc.exe and it should be updated.
4. Does protoc.exe ever write anything other than errors and warnings to standard output or standard error?
5. Do errors and warnings ever use a different format than the ones I've listed?

Until these questions are answered, I'll keep this PR as a draft since the implementation might need to be updated.