### PR TITLE
Fix a typo in CompareExchangeStrong()

### DIFF
--- a/src/core/lib/gprpp/atomic.h
+++ b/src/core/lib/gprpp/atomic.h
@@ -58,7 +58,7 @@ class Atomic {
 
   bool CompareExchangeStrong(T* expected, T desired, MemoryOrder success,
                              MemoryOrder failure) {
-    return GPR_ATM_INC_CAS_THEN(storage_.compare_exchange_weak(
+    return GPR_ATM_INC_CAS_THEN(storage_.compare_exchange_strong(
         *expected, desired, static_cast<std::memory_order>(success),
         static_cast<std::memory_order>(failure)));
   }


### PR DESCRIPTION
Use compare_exchange_strong() instead of compare_exchange_weak(), which
can be spuriously fail on some platforms.

Thanks to @markdroth  to pointing this out!