### PR TITLE
Fix route guide example

### DIFF
--- a/examples/cpp/route_guide/route_guide_server.cc
+++ b/examples/cpp/route_guide/route_guide_server.cc
@@ -147,24 +147,25 @@ class RouteGuideImpl final : public RouteGuide::Service {
 
   Status RouteChat(ServerContext* context,
                    ServerReaderWriter<RouteNote, RouteNote>* stream) override {
-    std::vector<RouteNote> received_notes;
     RouteNote note;
     while (stream->Read(&note)) {
-      for (const RouteNote& n : received_notes) {
+      std::unique_lock<std::mutex> lock(mu_);
+      for (const RouteNote& n : received_notes_) {
         if (n.location().latitude() == note.location().latitude() &&
             n.location().longitude() == note.location().longitude()) {
           stream->Write(n);
         }
       }
-      received_notes.push_back(note);
+      received_notes_.push_back(note);
     }
 
     return Status::OK;
   }
 
  private:
-
   std::vector<Feature> feature_list_;
+  std::mutex mu_;
+  std::vector<RouteNote> received_notes_;
 };
 
 void RunServer(const std::string& db_path) {


### PR DESCRIPTION
Fix https://github.com/grpc/grpc/issues/18634.

The chat notes should be shared among all the clients. 

This is how other languages implemented this RPC.