### PR TITLE
C# Tooling: change the case to 'Protobuf' consistently

### DIFF
--- a/src/csharp/Grpc.Tools.Tests/ProtoCompileBasicTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/ProtoCompileBasicTest.cs
@@ -62,7 +62,7 @@ namespace Grpc.Tools.Tests
             };
         }
 
-        [TestCase("ProtoBuf")]
+        [TestCase("Protobuf")]
         [TestCase("Generator")]
         [TestCase("OutputDir")]
         [Description("We trust MSBuild to initialize these properties.")]

--- a/src/csharp/Grpc.Tools.Tests/ProtoCompileCommandLineGeneratorTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/ProtoCompileCommandLineGeneratorTest.cs
@@ -30,7 +30,7 @@ namespace Grpc.Tools.Tests
         {
             _task.Generator = "csharp";
             _task.OutputDir = "outdir";
-            _task.ProtoBuf = Utils.MakeSimpleItems("a.proto");
+            _task.Protobuf = Utils.MakeSimpleItems("a.proto");
         }
 
         void ExecuteExpectSuccess()
@@ -55,7 +55,7 @@ namespace Grpc.Tools.Tests
         [Test]
         public void CompileTwoFiles()
         {
-            _task.ProtoBuf = Utils.MakeSimpleItems("a.proto", "foo/b.proto");
+            _task.Protobuf = Utils.MakeSimpleItems("a.proto", "foo/b.proto");
             ExecuteExpectSuccess();
             Assert.That(_task.LastResponseFile, Is.EqualTo(new[] {
                 "--csharp_out=outdir", "--error_format=msvs", "a.proto", "foo/b.proto" }));

--- a/src/csharp/Grpc.Tools.Tests/ProtoCompileCommandLinePrinterTest.cs
+++ b/src/csharp/Grpc.Tools.Tests/ProtoCompileCommandLinePrinterTest.cs
@@ -29,7 +29,7 @@ namespace Grpc.Tools.Tests
         {
             _task.Generator = "csharp";
             _task.OutputDir = "outdir";
-            _task.ProtoBuf = Utils.MakeSimpleItems("a.proto");
+            _task.Protobuf = Utils.MakeSimpleItems("a.proto");
 
             _mockEngine
               .Setup(me => me.LogMessageEvent(It.IsAny<BuildMessageEventArgs>()))

--- a/src/csharp/Grpc.Tools/Common.cs
+++ b/src/csharp/Grpc.Tools/Common.cs
@@ -31,7 +31,7 @@ namespace Grpc.Tools
     {
         // On output dependency lists.
         public static string Source = "Source";
-        // On ProtoBuf items.
+        // On Protobuf items.
         public static string ProtoRoot = "ProtoRoot";
         public static string OutputDir = "OutputDir";
         public static string GrpcServices = "GrpcServices";

--- a/src/csharp/Grpc.Tools/GeneratorServices.cs
+++ b/src/csharp/Grpc.Tools/GeneratorServices.cs
@@ -164,7 +164,7 @@ namespace Grpc.Tools
             protoDir = EndWithSlash(protoDir);
             if (!protoDir.StartsWith(rootDir))
             {
-                Log.LogWarning("ProtoBuf item '{0}' has the ProtoRoot metadata '{1}' " +
+                Log.LogWarning("Protobuf item '{0}' has the ProtoRoot metadata '{1}' " +
                   "which is not prefix to its path. Cannot compute relative path.",
                   proto, root);
                 return "";

--- a/src/csharp/Grpc.Tools/ProtoCompile.cs
+++ b/src/csharp/Grpc.Tools/ProtoCompile.cs
@@ -133,7 +133,7 @@ namespace Grpc.Tools
         /// Protobuf files to compile.
         /// </summary>
         [Required]
-        public ITaskItem[] ProtoBuf { get; set; }
+        public ITaskItem[] Protobuf { get; set; }
 
         /// <summary>
         /// Directory where protoc dependency files are cached. If provided, dependency
@@ -237,7 +237,7 @@ namespace Grpc.Tools
                 Log.LogError("Properties ProtoDepDir and DependencyOut may not be both specified");
             }
 
-            if (ProtoBuf.Length > 1 && (ProtoDepDir != null || DependencyOut != null))
+            if (Protobuf.Length > 1 && (ProtoDepDir != null || DependencyOut != null))
             {
                 Log.LogError("Proto compiler currently allows only one input when " +
                              "--dependency_out is specified (via ProtoDepDir or DependencyOut). " +
@@ -247,7 +247,7 @@ namespace Grpc.Tools
             // Use ProtoDepDir to autogenerate DependencyOut
             if (ProtoDepDir != null)
             {
-                DependencyOut = DepFileUtil.GetDepFilenameForProto(ProtoDepDir, ProtoBuf[0].ItemSpec);
+                DependencyOut = DepFileUtil.GetDepFilenameForProto(ProtoDepDir, Protobuf[0].ItemSpec);
             }
 
             if (GrpcPluginExe == null)
@@ -319,7 +319,7 @@ namespace Grpc.Tools
             }
             cmd.AddSwitchMaybe("dependency_out", DependencyOut);
             cmd.AddSwitchMaybe("error_format", "msvs");
-            foreach (var proto in ProtoBuf)
+            foreach (var proto in Protobuf)
             {
                 cmd.AddArg(proto.ItemSpec);
             }

--- a/src/csharp/Grpc.Tools/ProtoCompilerOutputs.cs
+++ b/src/csharp/Grpc.Tools/ProtoCompilerOutputs.cs
@@ -38,7 +38,7 @@ namespace Grpc.Tools
         /// files actually produced by the compiler.
         /// </summary>
         [Required]
-        public ITaskItem[] ProtoBuf { get; set; }
+        public ITaskItem[] Protobuf { get; set; }
 
         /// <summary>
         /// Output items per each potential output. We do not look at existing
@@ -68,7 +68,7 @@ namespace Grpc.Tools
             // Get language-specific possible output. The generator expects certain
             // metadata be set on the proto item.
             var possible = new List<ITaskItem>();
-            foreach (var proto in ProtoBuf)
+            foreach (var proto in Protobuf)
             {
                 var outputs = generator.GetPossibleOutputs(proto);
                 foreach (string output in outputs)

--- a/src/csharp/Grpc.Tools/ProtoReadDependencies.cs
+++ b/src/csharp/Grpc.Tools/ProtoReadDependencies.cs
@@ -29,7 +29,7 @@ namespace Grpc.Tools
         /// of proto files cached under ProtoDepDir.
         /// </summary>
         [Required]
-        public ITaskItem[] ProtoBuf { get; set; }
+        public ITaskItem[] Protobuf { get; set; }
 
         /// <summary>
         /// Directory where protoc dependency files are cached.
@@ -55,7 +55,7 @@ namespace Grpc.Tools
             if (ProtoDepDir != null)
             {
                 var dependencies = new List<ITaskItem>();
-                foreach (var proto in ProtoBuf)
+                foreach (var proto in Protobuf)
                 {
                     string[] deps = DepFileUtil.ReadDependencyInputs(ProtoDepDir, proto.ItemSpec, Log);
                     foreach (string dep in deps)

--- a/src/csharp/Grpc.Tools/build/_grpc/Grpc.CSharp.xml
+++ b/src/csharp/Grpc.Tools/build/_grpc/Grpc.CSharp.xml
@@ -1,11 +1,11 @@
 <ProjectSchemaDefinitions xmlns="http://schemas.microsoft.com/build/2009/properties">
-  <Rule Name="ProtoBuf"
+  <Rule Name="Protobuf"
         DisplayName="File Properties"
         PageTemplate="generic"
         Description="File Properties"
         OverrideMode="Extend">
     <Rule.DataSource>
-      <DataSource Persistence="ProjectFile" Label="Configuration" ItemType="ProtoBuf"
+      <DataSource Persistence="ProjectFile" Label="Configuration" ItemType="Protobuf"
                   HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
 
@@ -21,7 +21,7 @@
       <EnumValue Name="Server" DisplayName="Server only" />
       <EnumValue Name="None" DisplayName="Do not generate" />
       <EnumProperty.DataSource>
-        <DataSource ItemType="ProtoBuf" SourceOfDefaultValue="AfterContext"
+        <DataSource ItemType="Protobuf" SourceOfDefaultValue="AfterContext"
                     PersistenceStyle="Attribute" />
       </EnumProperty.DataSource>
     </EnumProperty>

--- a/src/csharp/Grpc.Tools/build/_grpc/_Grpc.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_grpc/_Grpc.Tools.targets
@@ -13,9 +13,9 @@
   </ItemGroup>
 
   <ItemDefinitionGroup Condition=" '$(Protobuf_ProjectSupported)' == 'true' and '$(Language)' == 'C#' ">
-    <ProtoBuf>
-      <GrpcServices Condition=" '%(ProtoBuf.GrpcServices)' == '' ">Both</GrpcServices>
-    </ProtoBuf>
+    <Protobuf>
+      <GrpcServices Condition=" '%(Protobuf.GrpcServices)' == '' ">Both</GrpcServices>
+    </Protobuf>
   </ItemDefinitionGroup>
 
   <!-- This target is invoked in a C# project, or can be called in a customized project. -->

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.props
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.props
@@ -15,10 +15,10 @@
   <!-- NET SDK projects only: include proto files by default. Other project
        types are not setting or using $(EnableDefaultItems).
        Note that MSBuild evaluates all ItemGroups and their conditions in the
-       final pass over the build script, so properties like EnableDefaultProtoBufItems
+       final pass over the build script, so properties like EnableDefaultProtobufItems
        here can be changed later in the project. -->
   <ItemGroup Condition=" '$(Protobuf_ProjectSupported)' == 'true' ">
-    <ProtoBuf Include="**/*.proto"
-              Condition=" '$(EnableDefaultItems)' == 'true' and '$(EnableDefaultProtoBufItems)' == 'true' " />
+    <Protobuf Include="**/*.proto"
+              Condition=" '$(EnableDefaultItems)' == 'true' and '$(EnableDefaultProtobufItems)' == 'true' " />
   </ItemGroup>
 </Project>

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -22,27 +22,27 @@
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition=" '$(Protobuf_ProjectSupported)' == 'true' and '$(Language)' == 'C#' ">
-    <ProtoBuf>
-      <Access Condition="'%(ProtoBuf.Access)' == '' ">Public</Access>
-      <ProtoCompile Condition="'%(ProtoBuf.ProtoCompile)' == '' ">True</ProtoCompile>
-      <ProtoRoot Condition="'%(ProtoBuf.ProtoRoot)' == '' " />
-      <CompileOutputs Condition="'%(ProtoBuf.CompileOutputs)' == ''">True</CompileOutputs>
-      <OutputDir Condition="'%(ProtoBuf.OutputDir)' == '' ">$(Protobuf_OutputPath)</OutputDir>
-    </ProtoBuf>
+    <Protobuf>
+      <Access Condition="'%(Protobuf.Access)' == '' ">Public</Access>
+      <ProtoCompile Condition="'%(Protobuf.ProtoCompile)' == '' ">True</ProtoCompile>
+      <ProtoRoot Condition="'%(Protobuf.ProtoRoot)' == '' " />
+      <CompileOutputs Condition="'%(Protobuf.CompileOutputs)' == ''">True</CompileOutputs>
+      <OutputDir Condition="'%(Protobuf.OutputDir)' == '' ">$(Protobuf_OutputPath)</OutputDir>
+    </Protobuf>
   </ItemDefinitionGroup>
 
   <ItemGroup Condition=" '$(Protobuf_ProjectSupported)' == 'true' and '$(Language)' == 'C#' ">
     <PropertyPageSchema Include="$(MSBuildThisFileDirectory)Protobuf.CSharp.xml">
       <Context>File;BrowseObject</Context>
     </PropertyPageSchema>
-    <AvailableItemName Include="ProtoBuf" />
+    <AvailableItemName Include="Protobuf" />
   </ItemGroup>
 
   <PropertyGroup>
     <!-- NET SDK: by default, do not include proto files in the directory.
          Current Microsoft's recommendation is against globbing:
          https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#recommendation -->
-    <EnableDefaultProtoBufItems Condition=" '$(EnableDefaultProtoBufItems)' == '' ">false</EnableDefaultProtoBufItems>
+    <EnableDefaultProtobufItems Condition=" '$(EnableDefaultProtobufItems)' == '' ">false</EnableDefaultProtobufItems>
   </PropertyGroup>
 
   <!-- Check configuration sanity before build. -->
@@ -96,7 +96,7 @@
   <!-- Main compile sequence. Certain steps are gated by the value $(DisableProtobufDesignTimeBuild),
        so the sequence is good for either design time or build time. -->
   <Target Name="Protobuf_Compile"
-          Condition=" '@(ProtoBuf)' != '' "
+          Condition=" '@(Protobuf)' != '' "
           DependsOnTargets=" Protobuf_BeforeCompile;
                              Protobuf_ResolvePlatform;
                              _Protobuf_SelectFiles;
@@ -120,13 +120,13 @@
          to "." for the project's directory, as it is the current when compiling; for the
          files outside of project directory, use each .proto file's directory as the root. -->
     <FindUnderPath Path="$(MSBuildProjectDirectory)"
-                   Files="@(ProtoBuf->WithMetadataValue('ProtoRoot',''))">
+                   Files="@(Protobuf->WithMetadataValue('ProtoRoot',''))">
       <Output TaskParameter="InPath" ItemName="_Protobuf_NoRootInProject"/>
       <Output TaskParameter="OutOfPath" ItemName="_Protobuf_NoRootElsewhere"/>
     </FindUnderPath>
     <ItemGroup>
       <!-- Files with explicit metadata. -->
-      <Protobuf_Compile Include="@(ProtoBuf->HasMetadata('ProtoRoot'))" />
+      <Protobuf_Compile Include="@(Protobuf->HasMetadata('ProtoRoot'))" />
       <!-- In-project files will have ProtoRoot='.'. -->
       <Protobuf_Compile Include="@(_Protobuf_NoRootInProject)">
         <ProtoRoot>.</ProtoRoot>
@@ -154,13 +154,13 @@
   <Target Name="Protobuf_PrepareCompile" Condition=" '@(Protobuf_Compile)' != '' ">
     <!-- Predict expected names. -->
     <ProtoCompilerOutputs Condition=" '$(Language)' == 'C#' "
-                          ProtoBuf="@(Protobuf_Compile)"
+                          Protobuf="@(Protobuf_Compile)"
                           Generator="$(Protobuf_Generator)">
       <Output TaskParameter="PossibleOutputs" ItemName="Protobuf_ExpectedOutputs" />
     </ProtoCompilerOutputs>
     <!-- Read any dependency files from previous compiles. -->
     <ProtoReadDependencies Condition=" '$(Protobuf_DepFilesPath)' != '' and '$(DisableProtobufDesignTimeBuild)' != 'true' "
-                           ProtoBuf="@(Protobuf_Compile)"
+                           Protobuf="@(Protobuf_Compile)"
                            ProtoDepDir="$(Protobuf_DepFilesPath)" >
       <Output TaskParameter="Dependencies" ItemName="Protobuf_Dependencies" />
     </ProtoReadDependencies>
@@ -263,7 +263,7 @@
     <ProtoCompile Condition=" '@(_Protobuf_OutOfDateProto)' != '' "
       ToolExe="$(Protobuf_ProtocFullPath)"
       Generator="$(Protobuf_Generator)"
-      ProtoBuf="%(_Protobuf_OutOfDateProto.Source)"
+      Protobuf="%(_Protobuf_OutOfDateProto.Source)"
       ProtoPath="%(_Protobuf_OutOfDateProto.AdditionalImportDirs);$(Protobuf_StandardImportsPath);%(_Protobuf_OutOfDateProto.ProtoRoot)"
       ProtoDepDir="$(Protobuf_DepFilesPath)"
       OutputDir="%(_Protobuf_OutOfDateProto.OutputDir)"
@@ -327,7 +327,7 @@
 
   <!-- Main cleanup sequence. -->
   <Target Name="Protobuf_Clean"
-          Condition=" '@(ProtoBuf)' != '' "
+          Condition=" '@(Protobuf)' != '' "
           DependsOnTargets=" Protobuf_BeforeClean;
                              Protobuf_PrepareClean;
                              _Protobuf_CoreClean;
@@ -354,7 +354,7 @@
   <Target Name="Protobuf_PrepareClean" Condition=" '@(Protobuf)' != '' ">
     <!-- Predict expected names. -->
     <ProtoCompilerOutputs Condition=" '$(Language)' == 'C#' "
-                          ProtoBuf="@(Protobuf)"
+                          Protobuf="@(Protobuf)"
                           Generator="$(Protobuf_Generator)">
       <Output TaskParameter="PossibleOutputs" ItemName="Protobuf_ExpectedOutputs" />
     </ProtoCompilerOutputs>
@@ -376,9 +376,9 @@
        * The Pack target includes .proto files into the source package.  -->
   <Target Name="_Protobuf_SourceFilesProjectOutputGroup"
           BeforeTargets="SourceFilesProjectOutputGroup"
-          Condition=" '@(ProtoBuf)' != '' " >
+          Condition=" '@(Protobuf)' != '' " >
     <ItemGroup>
-      <SourceFilesProjectOutputGroupOutput Include="@(ProtoBuf->'%(FullPath)')" />
+      <SourceFilesProjectOutputGroupOutput Include="@(Protobuf->'%(FullPath)')" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/csharp/Grpc.Tools/build/_protobuf/Protobuf.CSharp.xml
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Protobuf.CSharp.xml
@@ -4,18 +4,18 @@
 
   <ContentType Name="ProtoFile"
                DisplayName="Protocol buffer definitions file"
-               ItemType="ProtoBuf" />
+               ItemType="Protobuf" />
 
-  <ItemType Name="ProtoBuf"
+  <ItemType Name="Protobuf"
             DisplayName="Protobuf compiler" />
 
-  <Rule Name="ProtoBuf"
+  <Rule Name="Protobuf"
         DisplayName="File Properties"
         PageTemplate="generic"
         Description="File Properties"
         OverrideMode="Extend">
     <Rule.DataSource>
-      <DataSource Persistence="ProjectFile" Label="Configuration" ItemType="ProtoBuf"
+      <DataSource Persistence="ProjectFile" Label="Configuration" ItemType="Protobuf"
                   HasConfigurationCondition="false" SourceOfDefaultValue="AfterContext" />
     </Rule.DataSource>
 
@@ -31,7 +31,7 @@
 
     <StringProperty Name="Identity" Visible="false" ReadOnly="true">
       <StringProperty.DataSource>
-        <DataSource Persistence="Intrinsic" ItemType="ProtoBuf"
+        <DataSource Persistence="Intrinsic" ItemType="Protobuf"
                     PersistedName="Identity" SourceOfDefaultValue="AfterContext" />
       </StringProperty.DataSource>
     </StringProperty>
@@ -42,7 +42,7 @@
                     Category="Misc"
                     Description="Location of the file.">
       <StringProperty.DataSource>
-        <DataSource Persistence="Intrinsic" ItemType="ProtoBuf"
+        <DataSource Persistence="Intrinsic" ItemType="Protobuf"
                     PersistedName="FullPath" SourceOfDefaultValue="AfterContext" />
       </StringProperty.DataSource>
     </StringProperty>
@@ -53,7 +53,7 @@
                     Category="Misc"
                     Description="Name of the file or folder.">
       <StringProperty.DataSource>
-        <DataSource Persistence="Intrinsic" ItemType="ProtoBuf"
+        <DataSource Persistence="Intrinsic" ItemType="Protobuf"
                     PersistedName="FileNameAndExtension" SourceOfDefaultValue="AfterContext" />
       </StringProperty.DataSource>
     </StringProperty>
@@ -81,7 +81,7 @@
       <EnumValue Name="Public" DisplayName="Public" IsDefault="true" />
       <EnumValue Name="Internal" DisplayName="Internal" />
       <EnumProperty.DataSource>
-        <DataSource ItemType="ProtoBuf" SourceOfDefaultValue="AfterContext"
+        <DataSource ItemType="Protobuf" SourceOfDefaultValue="AfterContext"
                     PersistenceStyle="Attribute" />
       </EnumProperty.DataSource>
     </EnumProperty>
@@ -90,7 +90,7 @@
                   Category="Protobuf" Default="true"
                   Description="Specifies if this file is compiled or only imported by other files.">
       <BoolProperty.DataSource>
-        <DataSource ItemType="ProtoBuf" SourceOfDefaultValue="AfterContext"
+        <DataSource ItemType="Protobuf" SourceOfDefaultValue="AfterContext"
                     PersistenceStyle="Attribute" />
       </BoolProperty.DataSource>
     </BoolProperty>


### PR DESCRIPTION
Users will not be affected, as MSBuild is entirely case-insensitive.

The changes in C# code are also entirely for consistency; they do not affect the tooling dll at runtime. I actually confirmed that by first replacing the dll in the test setup on Linux and rebuilding, so that the dll with renamed properties still works with old, unchanged xml files. Then replaced the rest of the files and confirmed the build behaves as expected again.

Looks like this should be entirely safe.

Closes #17884