### PR TITLE
Fix compilation error in JWT using const_cast.

### DIFF
--- a/src/core/lib/security/credentials/jwt/jwt_verifier.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.cc
@@ -624,8 +624,9 @@ static int verify_jwt_signature(EVP_PKEY* key, const char* alg,
     gpr_log(GPR_ERROR, "EVP_DigestVerifyUpdate failed.");
     goto end;
   }
-  if (EVP_DigestVerifyFinal(md_ctx, GRPC_SLICE_START_PTR(signature),
-                            GRPC_SLICE_LENGTH(signature)) != 1) {
+  if (EVP_DigestVerifyFinal(
+          md_ctx, const_cast<uint8_t*>(GRPC_SLICE_START_PTR(signature)),
+          GRPC_SLICE_LENGTH(signature)) != 1) {
     gpr_log(GPR_ERROR, "JWT signature verification failed.");
     goto end;
   }


### PR DESCRIPTION
I got this error on an unrelated patch, and I believe the Distribution Test is broken:    
```
    /var/local/git/grpc/src/core/lib/security/credentials/jwt/jwt_verifier.cc:628:57: error: invalid conversion from 'const uint8_t* {aka const unsigned char*}' to 'unsigned char*' [-fpermissive]
                                 GRPC_SLICE_LENGTH(signature)) != 1) {
                                                             ^
    In file included from /usr/include/openssl/pem.h:69:0,
                     from /var/local/git/grpc/src/core/lib/security/credentials/jwt/jwt_verifier.cc:35:
    /usr/include/openssl/evp.h:642:5: note: initializing argument 2 of 'int EVP_DigestVerifyFinal(EVP_MD_CTX*, unsigned char*, size_t)'
     int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx, unsigned char *sig, size_t siglen);
```