### PR TITLE
Add documentation for 'grpcio-status' package

### DIFF
--- a/doc/python/sphinx/conf.py
+++ b/doc/python/sphinx/conf.py
@@ -22,6 +22,7 @@ sys.path.insert(0, os.path.join(PYTHON_FOLDER, 'grpcio'))
 sys.path.insert(0, os.path.join(PYTHON_FOLDER, 'grpcio_channelz'))
 sys.path.insert(0, os.path.join(PYTHON_FOLDER, 'grpcio_health_checking'))
 sys.path.insert(0, os.path.join(PYTHON_FOLDER, 'grpcio_reflection'))
+sys.path.insert(0, os.path.join(PYTHON_FOLDER, 'grpcio_status'))
 sys.path.insert(0, os.path.join(PYTHON_FOLDER, 'grpcio_testing'))
 
 # -- Project information -----------------------------------------------------

--- a/doc/python/sphinx/grpc_status.rst
+++ b/doc/python/sphinx/grpc_status.rst
@@ -1,0 +1,7 @@
+gRPC Status
+====================
+
+Module Contents
+---------------
+
+.. automodule:: grpc_status.rpc_status

--- a/doc/python/sphinx/index.rst
+++ b/doc/python/sphinx/index.rst
@@ -13,6 +13,7 @@ API Reference
    grpc_channelz
    grpc_health_checking
    grpc_reflection
+   grpc_status
    grpc_testing
    glossary
 


### PR DESCRIPTION
Rich status package is released in `v1.19.0`, but the documentation is not published.
Example for error details handling is on the way.