### PR TITLE
Add BindServiceAttribute

### DIFF
--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -383,7 +383,8 @@ void GenerateServerClass(Printer* out, const ServiceDescriptor* service) {
       "$servicename$</summary>\n",
       "servicename", GetServiceClassName(service));
   out->Print(
-      "[grpc::BindService(typeof($classname$), nameof($classname$.BindService))]\n",
+      "[grpc::BindService(typeof($classname$), "
+      "nameof($classname$.BindService))]\n",
       "classname", GetServiceClassName(service));
   out->Print("public abstract partial class $name$\n", "name",
              GetServerClassName(service));

--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -384,7 +384,7 @@ void GenerateServerClass(Printer* out, const ServiceDescriptor* service) {
       "servicename", GetServiceClassName(service));
   out->Print(
       "[grpc::BindService(typeof($classname$), "
-      "nameof($classname$.BindService))]\n",
+      "\"BindService\")]\n",
       "classname", GetServiceClassName(service));
   out->Print("public abstract partial class $name$\n", "name",
              GetServerClassName(service));

--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -382,6 +382,9 @@ void GenerateServerClass(Printer* out, const ServiceDescriptor* service) {
       "/// <summary>Base class for server-side implementations of "
       "$servicename$</summary>\n",
       "servicename", GetServiceClassName(service));
+  out->Print(
+      "[grpc::BindService(typeof($classname$), nameof($classname$.BindService))]\n",
+      "classname", GetServiceClassName(service));
   out->Print("public abstract partial class $name$\n", "name",
              GetServerClassName(service));
   out->Print("{\n");

--- a/src/compiler/csharp_generator.cc
+++ b/src/compiler/csharp_generator.cc
@@ -383,7 +383,7 @@ void GenerateServerClass(Printer* out, const ServiceDescriptor* service) {
       "$servicename$</summary>\n",
       "servicename", GetServiceClassName(service));
   out->Print(
-      "[grpc::BindService(typeof($classname$), "
+      "[grpc::BindServiceMethod(typeof($classname$), "
       "\"BindService\")]\n",
       "classname", GetServiceClassName(service));
   out->Print("public abstract partial class $name$\n", "name",

--- a/src/csharp/Grpc.Core.Api/BindServiceAttribute.cs
+++ b/src/csharp/Grpc.Core.Api/BindServiceAttribute.cs
@@ -1,0 +1,48 @@
+#region Copyright notice and license
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+
+namespace Grpc.Core
+{
+    /// <summary>
+    /// Defines the location of the service bind method for a gRPC service.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
+    public class BindServiceAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BindServiceAttribute"/> class.
+        /// </summary>
+        /// <param name="bindType">The type the service bind method is defined on.</param>
+        /// <param name="bindMethodName">The name of the service bind method.</param>
+        public BindServiceAttribute(Type bindType, string bindMethodName)
+        {
+            BindType = bindType;
+            BindMethodName = bindMethodName;
+        }
+
+        /// <summary>
+        /// Gets the type the service bind method is defined on.
+        /// </summary>
+        public Type BindType { get; }
+
+        /// <summary>
+        /// Gets the name of the service bind method.
+        /// </summary>
+        public string BindMethodName { get; }
+    }
+}

--- a/src/csharp/Grpc.Core.Api/BindServiceAttribute.cs
+++ b/src/csharp/Grpc.Core.Api/BindServiceAttribute.cs
@@ -19,7 +19,12 @@ using System;
 namespace Grpc.Core
 {
     /// <summary>
-    /// Defines the location of the service bind method for a gRPC service.
+    /// Specifies the location of the service bind method for a gRPC service.
+    /// The bind method is typically generated code and is used to register a service's
+    /// methods with the server on startup.
+    /// 
+    /// The bind method signature takes a <see cref="ServiceBinderBase"/> and an optional
+    /// instance of the service base class, e.g. <c>static void BindService(ServiceBinderBase, GreeterService)</c>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
     public class BindServiceAttribute : Attribute

--- a/src/csharp/Grpc.Core.Api/BindServiceMethodAttribute.cs
+++ b/src/csharp/Grpc.Core.Api/BindServiceMethodAttribute.cs
@@ -27,14 +27,14 @@ namespace Grpc.Core
     /// instance of the service base class, e.g. <c>static void BindService(ServiceBinderBase, GreeterService)</c>.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
-    public class BindServiceAttribute : Attribute
+    public class BindServiceMethodAttribute : Attribute
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="BindServiceAttribute"/> class.
+        /// Initializes a new instance of the <see cref="BindServiceMethodAttribute"/> class.
         /// </summary>
         /// <param name="bindType">The type the service bind method is defined on.</param>
         /// <param name="bindMethodName">The name of the service bind method.</param>
-        public BindServiceAttribute(Type bindType, string bindMethodName)
+        public BindServiceMethodAttribute(Type bindType, string bindMethodName)
         {
             BindType = bindType;
             BindMethodName = bindMethodName;

--- a/src/csharp/Grpc.Core.Api/BindServiceMethodAttribute.cs
+++ b/src/csharp/Grpc.Core.Api/BindServiceMethodAttribute.cs
@@ -1,5 +1,5 @@
 #region Copyright notice and license
-// Copyright 2015 gRPC authors.
+// Copyright 2019 The gRPC Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/csharp/Grpc.Examples/MathGrpc.cs
+++ b/src/csharp/Grpc.Examples/MathGrpc.cs
@@ -67,6 +67,7 @@ namespace Math {
     }
 
     /// <summary>Base class for server-side implementations of Math</summary>
+    [grpc::BindService(typeof(Math), "BindService")]
     public abstract partial class MathBase
     {
       /// <summary>

--- a/src/csharp/Grpc.Examples/MathGrpc.cs
+++ b/src/csharp/Grpc.Examples/MathGrpc.cs
@@ -67,7 +67,7 @@ namespace Math {
     }
 
     /// <summary>Base class for server-side implementations of Math</summary>
-    [grpc::BindService(typeof(Math), "BindService")]
+    [grpc::BindServiceMethod(typeof(Math), "BindService")]
     public abstract partial class MathBase
     {
       /// <summary>

--- a/src/csharp/Grpc.HealthCheck/HealthGrpc.cs
+++ b/src/csharp/Grpc.HealthCheck/HealthGrpc.cs
@@ -54,6 +54,7 @@ namespace Grpc.Health.V1 {
     }
 
     /// <summary>Base class for server-side implementations of Health</summary>
+    [grpc::BindService(typeof(Health), "BindService")]
     public abstract partial class HealthBase
     {
       /// <summary>

--- a/src/csharp/Grpc.HealthCheck/HealthGrpc.cs
+++ b/src/csharp/Grpc.HealthCheck/HealthGrpc.cs
@@ -54,7 +54,7 @@ namespace Grpc.Health.V1 {
     }
 
     /// <summary>Base class for server-side implementations of Health</summary>
-    [grpc::BindService(typeof(Health), "BindService")]
+    [grpc::BindServiceMethod(typeof(Health), "BindService")]
     public abstract partial class HealthBase
     {
       /// <summary>

--- a/src/csharp/Grpc.IntegrationTesting/BenchmarkServiceGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/BenchmarkServiceGrpc.cs
@@ -74,6 +74,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of BenchmarkService</summary>
+    [grpc::BindService(typeof(BenchmarkService), "BindService")]
     public abstract partial class BenchmarkServiceBase
     {
       /// <summary>

--- a/src/csharp/Grpc.IntegrationTesting/BenchmarkServiceGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/BenchmarkServiceGrpc.cs
@@ -74,7 +74,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of BenchmarkService</summary>
-    [grpc::BindService(typeof(BenchmarkService), "BindService")]
+    [grpc::BindServiceMethod(typeof(BenchmarkService), "BindService")]
     public abstract partial class BenchmarkServiceBase
     {
       /// <summary>

--- a/src/csharp/Grpc.IntegrationTesting/EmptyServiceGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/EmptyServiceGrpc.cs
@@ -39,6 +39,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of EmptyService</summary>
+    [grpc::BindService(typeof(EmptyService), "BindService")]
     public abstract partial class EmptyServiceBase
     {
     }

--- a/src/csharp/Grpc.IntegrationTesting/EmptyServiceGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/EmptyServiceGrpc.cs
@@ -39,7 +39,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of EmptyService</summary>
-    [grpc::BindService(typeof(EmptyService), "BindService")]
+    [grpc::BindServiceMethod(typeof(EmptyService), "BindService")]
     public abstract partial class EmptyServiceBase
     {
     }

--- a/src/csharp/Grpc.IntegrationTesting/MetricsGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/MetricsGrpc.cs
@@ -58,6 +58,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of MetricsService</summary>
+    [grpc::BindService(typeof(MetricsService), "BindService")]
     public abstract partial class MetricsServiceBase
     {
       /// <summary>

--- a/src/csharp/Grpc.IntegrationTesting/MetricsGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/MetricsGrpc.cs
@@ -58,7 +58,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of MetricsService</summary>
-    [grpc::BindService(typeof(MetricsService), "BindService")]
+    [grpc::BindServiceMethod(typeof(MetricsService), "BindService")]
     public abstract partial class MetricsServiceBase
     {
       /// <summary>

--- a/src/csharp/Grpc.IntegrationTesting/ReportQpsScenarioServiceGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ReportQpsScenarioServiceGrpc.cs
@@ -46,6 +46,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of ReportQpsScenarioService</summary>
+    [grpc::BindService(typeof(ReportQpsScenarioService), "BindService")]
     public abstract partial class ReportQpsScenarioServiceBase
     {
       /// <summary>

--- a/src/csharp/Grpc.IntegrationTesting/ReportQpsScenarioServiceGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/ReportQpsScenarioServiceGrpc.cs
@@ -46,7 +46,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of ReportQpsScenarioService</summary>
-    [grpc::BindService(typeof(ReportQpsScenarioService), "BindService")]
+    [grpc::BindServiceMethod(typeof(ReportQpsScenarioService), "BindService")]
     public abstract partial class ReportQpsScenarioServiceBase
     {
       /// <summary>

--- a/src/csharp/Grpc.IntegrationTesting/TestGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/TestGrpc.cs
@@ -105,7 +105,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of TestService</summary>
-    [grpc::BindService(typeof(TestService), "BindService")]
+    [grpc::BindServiceMethod(typeof(TestService), "BindService")]
     public abstract partial class TestServiceBase
     {
       /// <summary>
@@ -581,7 +581,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of UnimplementedService</summary>
-    [grpc::BindService(typeof(UnimplementedService), "BindService")]
+    [grpc::BindServiceMethod(typeof(UnimplementedService), "BindService")]
     public abstract partial class UnimplementedServiceBase
     {
       /// <summary>
@@ -721,7 +721,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of ReconnectService</summary>
-    [grpc::BindService(typeof(ReconnectService), "BindService")]
+    [grpc::BindServiceMethod(typeof(ReconnectService), "BindService")]
     public abstract partial class ReconnectServiceBase
     {
       public virtual global::System.Threading.Tasks.Task<global::Grpc.Testing.Empty> Start(global::Grpc.Testing.ReconnectParams request, grpc::ServerCallContext context)

--- a/src/csharp/Grpc.IntegrationTesting/TestGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/TestGrpc.cs
@@ -105,6 +105,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of TestService</summary>
+    [grpc::BindService(typeof(TestService), "BindService")]
     public abstract partial class TestServiceBase
     {
       /// <summary>
@@ -580,6 +581,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of UnimplementedService</summary>
+    [grpc::BindService(typeof(UnimplementedService), "BindService")]
     public abstract partial class UnimplementedServiceBase
     {
       /// <summary>
@@ -719,6 +721,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of ReconnectService</summary>
+    [grpc::BindService(typeof(ReconnectService), "BindService")]
     public abstract partial class ReconnectServiceBase
     {
       public virtual global::System.Threading.Tasks.Task<global::Grpc.Testing.Empty> Start(global::Grpc.Testing.ReconnectParams request, grpc::ServerCallContext context)

--- a/src/csharp/Grpc.IntegrationTesting/WorkerServiceGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/WorkerServiceGrpc.cs
@@ -72,6 +72,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of WorkerService</summary>
+    [grpc::BindService(typeof(WorkerService), "BindService")]
     public abstract partial class WorkerServiceBase
     {
       /// <summary>

--- a/src/csharp/Grpc.IntegrationTesting/WorkerServiceGrpc.cs
+++ b/src/csharp/Grpc.IntegrationTesting/WorkerServiceGrpc.cs
@@ -72,7 +72,7 @@ namespace Grpc.Testing {
     }
 
     /// <summary>Base class for server-side implementations of WorkerService</summary>
-    [grpc::BindService(typeof(WorkerService), "BindService")]
+    [grpc::BindServiceMethod(typeof(WorkerService), "BindService")]
     public abstract partial class WorkerServiceBase
     {
       /// <summary>

--- a/src/csharp/Grpc.Reflection/ReflectionGrpc.cs
+++ b/src/csharp/Grpc.Reflection/ReflectionGrpc.cs
@@ -46,7 +46,7 @@ namespace Grpc.Reflection.V1Alpha {
     }
 
     /// <summary>Base class for server-side implementations of ServerReflection</summary>
-    [grpc::BindService(typeof(ServerReflection), "BindService")]
+    [grpc::BindServiceMethod(typeof(ServerReflection), "BindService")]
     public abstract partial class ServerReflectionBase
     {
       /// <summary>

--- a/src/csharp/Grpc.Reflection/ReflectionGrpc.cs
+++ b/src/csharp/Grpc.Reflection/ReflectionGrpc.cs
@@ -46,6 +46,7 @@ namespace Grpc.Reflection.V1Alpha {
     }
 
     /// <summary>Base class for server-side implementations of ServerReflection</summary>
+    [grpc::BindService(typeof(ServerReflection), "BindService")]
     public abstract partial class ServerReflectionBase
     {
       /// <summary>


### PR DESCRIPTION
Add a BindServiceAttribute so .NET libraries can easily resolve the location of the bind service method for a gRPC service.

// @jtattermusch

https://github.com/grpc/grpc-dotnet/issues/107