### PR TITLE
Make AuthContext constructor public

### DIFF
--- a/src/csharp/Grpc.Core.Api/AuthContext.cs
+++ b/src/csharp/Grpc.Core.Api/AuthContext.cs
@@ -39,7 +39,7 @@ namespace Grpc.Core
         /// </summary>
         /// <param name="peerIdentityPropertyName">Peer identity property name.</param>
         /// <param name="properties">Multimap of auth properties by name.</param>
-        internal AuthContext(string peerIdentityPropertyName, Dictionary<string, List<AuthProperty>> properties)
+        public AuthContext(string peerIdentityPropertyName, Dictionary<string, List<AuthProperty>> properties)
         {
             this.peerIdentityPropertyName = peerIdentityPropertyName;
             this.properties = GrpcPreconditions.CheckNotNull(properties);


### PR DESCRIPTION
to enable creating instances of AuthContext in grpc-dotnet.

Fixes https://github.com/grpc/grpc-dotnet/issues/76. 