### PR TITLE
Correct the default DNS resolver to ares

### DIFF
--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -124,7 +124,8 @@ some configuration as environment variables that can be set.
   Declares which DNS resolver to use. The default is ares if gRPC is built with
   c-ares support. Otherwise, the value of this environment variable is ignored.
   Available DNS resolver include:
-  - ares (default)- a DNS resolver based around the c-ares library
+  - ares (default on most platforms except iOS, Android or Node)- a DNS
+    resolver based around the c-ares library
   - native - a DNS resolver based around getaddrinfo(), creates a new thread to
     perform name resolution
 

--- a/doc/environment_variables.md
+++ b/doc/environment_variables.md
@@ -124,9 +124,9 @@ some configuration as environment variables that can be set.
   Declares which DNS resolver to use. The default is ares if gRPC is built with
   c-ares support. Otherwise, the value of this environment variable is ignored.
   Available DNS resolver include:
-  - native (default)- a DNS resolver based around getaddrinfo(), creates a new thread to
+  - ares (default)- a DNS resolver based around the c-ares library
+  - native - a DNS resolver based around getaddrinfo(), creates a new thread to
     perform name resolution
-  - ares - a DNS resolver based around the c-ares library
 
 * GRPC_CLIENT_CHANNEL_BACKUP_POLL_INTERVAL_MS
   Default: 5000


### PR DESCRIPTION
The default value for `GRPC_DNS_RESOLVER` is changed since https://github.com/grpc/grpc/pull/17723 which released in `v1.19.0`. So, this part of doc should be corrected.