### PR TITLE
Attempt to not depend on stdint.h

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -17,8 +17,6 @@ cimport cpython
 import grpc
 import threading
 
-from libc.stdint cimport uintptr_t
-
 
 def _spawn_callback_in_thread(cb_func, args):
   ForkManagedThread(target=cb_func, args=args).start()

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -13,7 +13,17 @@
 # limitations under the License.
 
 cimport libc.time
-from libc.stdint cimport intptr_t, uint8_t, int32_t, uint32_t, int64_t
+
+ctypedef          ssize_t   intptr_t
+ctypedef          size_t    uintptr_t
+ctypedef   signed char      int8_t
+ctypedef   signed short     int16_t
+ctypedef   signed int       int32_t
+ctypedef   signed long long int64_t
+ctypedef unsigned char      uint8_t
+ctypedef unsigned short     uint16_t
+ctypedef unsigned int       uint32_t
+ctypedef unsigned long long uint64_t
 
 
 cdef extern from "grpc/support/alloc.h":

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pxd.pxi
@@ -13,8 +13,6 @@
 # limitations under the License.
 # distutils: language=c++
 
-from libc.stdint cimport uint32_t
-
 cdef extern from "grpc/impl/codegen/slice.h":
   struct grpc_slice_buffer:
     int count

--- a/src/python/grpcio/grpc/_cython/_cygrpc/records.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/records.pyx.pxi
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from libc.stdint cimport intptr_t
-
 
 cdef bytes _slice_bytes(grpc_slice slice):
   cdef void *start = grpc_slice_start_ptr(slice)


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/18520
Let's see if Windows build are fixed.

`long` size difference across platforms: https://github.com/grpc/grpc/pull/18383#issue-261405892
Windows fundamental type sizes: 
https://docs.microsoft.com/en-us/cpp/cpp/fundamental-types-cpp?view=vs-2017