### PR TITLE
Add ini settings for fork support to PHP extension.

### DIFF
--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -67,27 +67,22 @@ ZEND_GET_MODULE(grpc)
 
 /* {{{ PHP_INI
  */
-/* Remove comments and fill if you need to have entries in php.ini
    PHP_INI_BEGIN()
-   STD_PHP_INI_ENTRY("grpc.global_value", "42", PHP_INI_ALL, OnUpdateLong,
-                     global_value, zend_grpc_globals, grpc_globals)
-   STD_PHP_INI_ENTRY("grpc.global_string", "foobar", PHP_INI_ALL,
-                     OnUpdateString, global_string, zend_grpc_globals,
-                     grpc_globals)
+   STD_PHP_INI_ENTRY("grpc.enable_fork_support", "0", PHP_INI_SYSTEM, OnUpdateBool,
+                     enable_fork_support, zend_grpc_globals, grpc_globals)
+   STD_PHP_INI_ENTRY("grpc.poll_strategy", NULL, PHP_INI_SYSTEM, OnUpdateString,
+                     poll_strategy, zend_grpc_globals, grpc_globals)
    PHP_INI_END()
-*/
 /* }}} */
 
 /* {{{ php_grpc_init_globals
  */
-/* Uncomment this function if you have INI entries
-   static void php_grpc_init_globals(zend_grpc_globals *grpc_globals)
-   {
-     grpc_globals->global_value = 0;
-     grpc_globals->global_string = NULL;
-   }
-*/
+static void php_grpc_init_globals(zend_grpc_globals *grpc_globals) {
+  grpc_globals->enable_fork_support = 0;
+  grpc_globals->poll_strategy = NULL;
+}
 /* }}} */
+
 void create_new_channel(
     wrapped_grpc_channel *channel,
     char *target,
@@ -208,12 +203,22 @@ void register_fork_handlers() {
   }
 }
 
+void apply_ini_settings() {
+  if (GRPC_G(enable_fork_support)) {
+    setenv("GRPC_ENABLE_FORK_SUPPORT", "1", 1 /* overwrite? */);
+  }
+
+  if (GRPC_G(poll_strategy)) {
+    setenv("GRPC_POLL_STRATEGY", GRPC_G(poll_strategy), 1 /* overwrite? */);
+  }
+}
+
 /* {{{ PHP_MINIT_FUNCTION
  */
 PHP_MINIT_FUNCTION(grpc) {
-  /* If you have INI entries, uncomment these lines
-     REGISTER_INI_ENTRIES();
-  */
+  ZEND_INIT_MODULE_GLOBALS(grpc, php_grpc_init_globals, NULL);
+  REGISTER_INI_ENTRIES();
+
   /* Register call error constants */
   REGISTER_LONG_CONSTANT("Grpc\\CALL_OK", GRPC_CALL_OK,
                          CONST_CS | CONST_PERSISTENT);
@@ -349,9 +354,7 @@ PHP_MINIT_FUNCTION(grpc) {
 /* {{{ PHP_MSHUTDOWN_FUNCTION
  */
 PHP_MSHUTDOWN_FUNCTION(grpc) {
-  /* uncomment this line if you have INI entries
-     UNREGISTER_INI_ENTRIES();
-  */
+  UNREGISTER_INI_ENTRIES();
   // WARNING: This function IS being called by PHP when the extension
   // is unloaded but the logs were somehow suppressed.
   if (GRPC_G(initialized)) {
@@ -375,9 +378,7 @@ PHP_MINFO_FUNCTION(grpc) {
   php_info_print_table_row(2, "grpc support", "enabled");
   php_info_print_table_row(2, "grpc module version", PHP_GRPC_VERSION);
   php_info_print_table_end();
-  /* Remove comments if you have entries in php.ini
-     DISPLAY_INI_ENTRIES();
-  */
+  DISPLAY_INI_ENTRIES();
 }
 /* }}} */
 
@@ -385,6 +386,7 @@ PHP_MINFO_FUNCTION(grpc) {
  */
 PHP_RINIT_FUNCTION(grpc) {
   if (!GRPC_G(initialized)) {
+    apply_ini_settings();
     grpc_init();
     register_fork_handlers();
     grpc_php_init_completion_queue(TSRMLS_C);

--- a/src/php/ext/grpc/php_grpc.h
+++ b/src/php/ext/grpc/php_grpc.h
@@ -66,6 +66,8 @@ PHP_RINIT_FUNCTION(grpc);
 */
 ZEND_BEGIN_MODULE_GLOBALS(grpc)
   zend_bool initialized;
+  zend_bool enable_fork_support;
+  char *poll_strategy;
 ZEND_END_MODULE_GLOBALS(grpc)
 
 /* In every utility function you add that needs to use variables

--- a/src/php/ext/grpc/tests/grpc-default-ini.phpt
+++ b/src/php/ext/grpc/tests/grpc-default-ini.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Ensure default ini settings
+--SKIPIF--
+<?php if (!extension_loaded("grpc")) print "skip"; ?>
+--FILE--
+<?php
+if (ini_get('grpc.enable_fork_support')) {
+    die('grpc.enable_fork_support not off by default');
+}
+if (ini_get('grpc.poll_strategy') !== "") {
+    die('grpc.poll_strategy not empty by default');
+}
+echo 'ok';
+--EXPECT--
+ok

--- a/src/php/ext/grpc/tests/grpc-set-ini.phpt
+++ b/src/php/ext/grpc/tests/grpc-set-ini.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Ensure ini settings are handled
+--SKIPIF--
+<?php if (!extension_loaded("grpc")) print "skip"; ?>
+--INI--
+grpc.enable_fork_support = 1
+grpc.poll_strategy = epoll1
+--FILE--
+<?php
+if (!ini_get('grpc.enable_fork_support')) {
+    die('grpc.enable_fork_support not set');
+}
+if (!getenv('GRPC_ENABLE_FORK_SUPPORT')) {
+    die('env GRPC_ENABLE_FORK_SUPPORT not set');
+}
+if (ini_get('grpc.poll_strategy') !== 'epoll1') {
+    die('grpc.poll_strategy !== epoll1');
+}
+if (getenv('GRPC_POLL_STRATEGY') !== 'epoll1') {
+    die('env GRPC_POLL_STRATEGY not epoll1');
+}
+echo 'ok';
+--EXPECT--
+ok


### PR DESCRIPTION
The PHP extension now has the ability to enable fork support by setting the environmental variables `GRPC_ENABLE_FORK_SUPPORT` and `GRPC_POLL_STRATEGY`. Since PHP tends to run in a number of different environments, though, it is often hard to ensure that the environmental variables are set everywhere (and in all subprocesses). Also note that since the environmental variables have to be set at the time the extension is initialized, it is not possible to set them properly in "user" PHP code. Not having these environmental variables set is quite dangerous as it causes subprocesses to hang forever.

This change exposes two new ini settings. `grpc.enable_fork_support` and `grpc.poll_strategy`. This allows users of PHP to ensure this support is enabled by pushing out custom `php.ini` settings. This is something most PHP shops already do. Under the hood, these settings set the proper environmental variables before `grpc_init` is called as part of the extension initialization.