### PR TITLE
Fix a NULL deref in tcp_client_windows.cc

### DIFF
--- a/src/core/lib/iomgr/tcp_client_windows.cc
+++ b/src/core/lib/iomgr/tcp_client_windows.cc
@@ -213,10 +213,12 @@ static void tcp_connect(grpc_closure* on_done, grpc_endpoint** endpoint,
 failure:
   GPR_ASSERT(error != GRPC_ERROR_NONE);
   char* target_uri = grpc_sockaddr_to_uri(addr);
-  grpc_error* final_error = grpc_error_set_str(
-      GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Failed to connect",
-                                                       &error, 1),
-      GRPC_ERROR_STR_TARGET_ADDRESS, grpc_slice_from_copied_string(target_uri));
+  grpc_error* final_error =
+      grpc_error_set_str(GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
+                             "Failed to connect", &error, 1),
+                         GRPC_ERROR_STR_TARGET_ADDRESS,
+                         grpc_slice_from_copied_string(
+                             target_uri == nullptr ? "NULL" : target_uri));
   GRPC_ERROR_UNREF(error);
   if (socket != NULL) {
     grpc_winsocket_destroy(socket);


### PR DESCRIPTION
`grpc_sockaddr_to_uri(addr)` can return nullptr, and we are directly
passing it to grpc_slice_from_copied_string. Clusterfuzz found this
issue in https://clusterfuzz.com/testcase-detail/5188592759603200

Use "NULL" when target URI is nullptr, to avoid null deref.

Fixes #18544