### PR TITLE
Explicitly call getsockname after accept for unix sockets to get the sun_path

### DIFF
--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -225,6 +225,7 @@ static void on_read(void* arg, grpc_error* err) {
       if (getsockname(fd, reinterpret_cast<struct sockaddr*>(addr.addr),
                       &(addr.len)) < 0) {
         gpr_log(GPR_ERROR, "Failed getsockname: %s", strerror(errno));
+        close(fd);
         goto error;
       }
     }

--- a/src/core/lib/iomgr/tcp_server_posix.cc
+++ b/src/core/lib/iomgr/tcp_server_posix.cc
@@ -217,6 +217,18 @@ static void on_read(void* arg, grpc_error* err) {
       }
     }
 
+    /* For UNIX sockets, the accept call might not fill up the member sun_path
+     * of sockaddr_un, so explicitly call getsockname to get it. */
+    if (grpc_is_unix_socket(&addr)) {
+      memset(&addr, 0, sizeof(addr));
+      addr.len = static_cast<socklen_t>(sizeof(struct sockaddr_storage));
+      if (getsockname(fd, reinterpret_cast<struct sockaddr*>(addr.addr),
+                      &(addr.len)) < 0) {
+        gpr_log(GPR_ERROR, "Failed getsockname: %s", strerror(errno));
+        goto error;
+      }
+    }
+
     grpc_set_socket_no_sigpipe_if_possible(fd);
 
     addr_str = grpc_sockaddr_to_uri(&addr);

--- a/test/core/end2end/tests/simple_request.cc
+++ b/test/core/end2end/tests/simple_request.cc
@@ -86,6 +86,14 @@ static void end_test(grpc_end2end_test_fixture* f) {
   grpc_completion_queue_destroy(f->shutdown_cq);
 }
 
+static void check_peer(char* peer_name) {
+  // If the peer name is a uds path, then check if it is filled
+  if (strncmp(peer_name, "unix:/", strlen("unix:/")) == 0) {
+    GPR_ASSERT(strncmp(peer_name, "unix:/tmp/grpc_fullstack_test.",
+                       strlen("unix:/tmp/grpc_fullstack_test.")) == 0);
+  }
+}
+
 static void simple_request_body(grpc_end2end_test_config config,
                                 grpc_end2end_test_fixture f) {
   grpc_call* c;
@@ -166,10 +174,12 @@ static void simple_request_body(grpc_end2end_test_config config,
   peer = grpc_call_get_peer(s);
   GPR_ASSERT(peer != nullptr);
   gpr_log(GPR_DEBUG, "server_peer=%s", peer);
+  check_peer(peer);
   gpr_free(peer);
   peer = grpc_call_get_peer(c);
   GPR_ASSERT(peer != nullptr);
   gpr_log(GPR_DEBUG, "client_peer=%s", peer);
+  check_peer(peer);
   gpr_free(peer);
 
   memset(ops, 0, sizeof(ops));


### PR DESCRIPTION
Fixes #18065
Explicitly call getsockname after accept for unix sockets to get the sun_path