### PR TITLE
Fix fork support in PHP extension.

### DIFF
--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -180,7 +180,7 @@ void postfork_child() {
   grpc_php_shutdown_completion_queue(TSRMLS_C);
 
   // clean-up grpc_core
-  grpc_shutdown();
+  grpc_shutdown_blocking();
   if (grpc_is_initialized() > 0) {
     zend_throw_exception(spl_ce_UnexpectedValueException,
                          "Oops, failed to shutdown gRPC Core after fork()",


### PR DESCRIPTION
After 456f748b2f63be2197da033fc250be753439fb48, the fork support in the PHP extension stopped working properly. This can be reproduced with:
```
GRPC_ENABLE_FORK_SUPPORT=1 GRPC_POLL_STRATEGY=epoll1 php -d 'extension=grpc.so' -r '$pid = pcntl_fork(); if ($pid) {pcntl_waitpid($pid, $status);}'
PHP Fatal error:  Uncaught UnexpectedValueException: Oops, failed to shutdown gRPC Core after fork() in
```
This issue is that `grpc_shutdown` now moves most of the shutdown execution onto a background thread. This means that when `grpc_shutdown` returns, grpc is still technically initialized, and reports as much when you call `grpc_is_initialized()`. It appears that `grpc_shutdown_blocking` was added for use cases like ours where we need to wait for the shutdown to complete synchronously.

Note: it would be nice to add a test to the PHP extension tests to cover this but I haven't had much success getting the tests in `src/php` to run properly.