### PR TITLE
Revert "Fix compilation error in JWT using const_cast."

### DIFF
--- a/src/core/lib/security/credentials/jwt/jwt_verifier.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.cc
@@ -624,9 +624,8 @@ static int verify_jwt_signature(EVP_PKEY* key, const char* alg,
     gpr_log(GPR_ERROR, "EVP_DigestVerifyUpdate failed.");
     goto end;
   }
-  if (EVP_DigestVerifyFinal(
-          md_ctx, const_cast<uint8_t*>(GRPC_SLICE_START_PTR(signature)),
-          GRPC_SLICE_LENGTH(signature)) != 1) {
+  if (EVP_DigestVerifyFinal(md_ctx, GRPC_SLICE_START_PTR(signature),
+                            GRPC_SLICE_LENGTH(signature)) != 1) {
     gpr_log(GPR_ERROR, "JWT signature verification failed.");
     goto end;
   }


### PR DESCRIPTION
Reverts grpc/grpc#18475

#18530 supersedes this one fix, so let's not have hacks. Let's see if this clears out the previously failing check.