### PR TITLE
Update remote_build credentials instructions.

### DIFF
--- a/tools/remote_build/README.md
+++ b/tools/remote_build/README.md
@@ -12,7 +12,7 @@ and tests run by Kokoro CI.
 
 - See [Installing Bazel](https://docs.bazel.build/versions/master/install.html) for instructions how to install bazel on your system.
 
-- Setup application default credentials for running remote builds by following ["Set credentials" section.](https://cloud.google.com/remote-build-execution/docs/set-up/first-remote-build)
+- Setup application default credentials for running remote builds by following the ["Set credentials" section](https://cloud.google.com/remote-build-execution/docs/results-ui/getting-started-results-ui). (Note: for the ResultStore UI upload to work, you'll need a special kind of application default credentials, so if the build event upload doesn't work, doublecheck the instructions)
 
 
 ## Running remote build manually from dev workstation


### PR DESCRIPTION
Without it the credentials won't support BEP upload properly.