### PR TITLE
Don't include Grpc.Core.Api/Version.cs twice

### DIFF
--- a/src/csharp/Grpc.Core.Api/Grpc.Core.Api.csproj
+++ b/src/csharp/Grpc.Core.Api/Grpc.Core.Api.csproj
@@ -22,10 +22,6 @@
   <Import Project="..\Grpc.Core\SourceLink.csproj.include" />
 
   <ItemGroup>
-    <Compile Include="..\Grpc.Core.Api\Version.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="System.Interactive.Async" Version="3.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Fix a build time warning (Version.cs is already in the Grpc.Core.Api directory so it's included by default),
```
CSC : warning CS2002: Source file 'Version.cs' specified multiple times [/Users/jtattermusch/github/grpc/src/csharp/Grpc.Core.Api/Grpc.Core.Api.csproj]
```