### PR TITLE
Add constraint_setting, values, and platform for grpc_no_ares

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -38,6 +38,24 @@ config_setting(
     values = {"define": "grpc_no_ares=true"},
 )
 
+# Prefer constraints/platforms to defines/configs, according to Bazel roadmap.
+constraint_setting(name = "grpc_ares_support")
+
+constraint_value(
+    name = "supports_ares",
+    constraint_setting = ":grpc_ares_support",
+)
+
+constraint_value(
+    name = "no_ares",
+    constraint_setting = ":grpc_ares_support",
+)
+
+platform(
+    name = "grpc_no_ares_platform",
+    constraint_values = [":no_ares"],
+)
+
 config_setting(
     name = "grpc_allow_exceptions",
     values = {"define": "GRPC_ALLOW_EXCEPTIONS=1"},

--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -49,6 +49,7 @@ def _get_external_deps(external_deps):
         elif dep == "cares":
             ret += select({
                 "//:grpc_no_ares": [],
+                "//:grpc_no_ares_platform": [],
                 "//conditions:default": ["//external:cares"],
             })
         else:
@@ -95,6 +96,7 @@ def grpc_cc_library(
         srcs = srcs,
         defines = select({
                       "//:grpc_no_ares": ["GRPC_ARES=0"],
+                      "//:grpc_no_ares_platform": ["GRPC_ARES=0"],
                       "//conditions:default": [],
                   }) +
                   select({


### PR DESCRIPTION
The Asylo project builds with --define=grpc_no_ares=true, but is
migrating to new functionality for flagless builds by combining
platforms and "transitions". The preferred method for build
configurability is with constraints and platforms, and not with defines.