### PR TITLE
Remove noisy log message.

### DIFF
--- a/test/cpp/end2end/test_service_impl.cc
+++ b/test/cpp/end2end/test_service_impl.cc
@@ -143,7 +143,6 @@ void LoopUntilCancelled(Alarm* alarm, ServerContext* context,
 
 Status TestServiceImpl::Echo(ServerContext* context, const EchoRequest* request,
                              EchoResponse* response) {
-  gpr_log(GPR_DEBUG, "Request message was %s", request->message().c_str());
   // A bit of sleep to make sure that short deadline tests fail
   if (request->has_param() && request->param().server_sleep_us() > 0) {
     gpr_sleep_until(


### PR DESCRIPTION
This log message was added in #18381 but is way too noisy.  It makes the output of client_lb_end2end_test and grpclb_end2end_test much harder to understand.

cc @rmstar @muxi 