### PR TITLE
Add environment variable for disabling ALPN verification

### DIFF
--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -45,13 +45,29 @@
 #define TSI_OPENSSL_ALPN_SUPPORT 1
 #endif
 
+namespace grpc_core {
+namespace {
+bool _alpn_disabled = false;
+
+void alpn_disabled_init(const char* env_var) {
+  char* e = gpr_getenv(env_var);
+  if (e != nullptr) {
+    if(e[0] == '1') {
+      _alpn_disabled = true;
+    }
+    gpr_free(e);
+  }
+}
+
+}
+} // namespace grpc_core
+
 namespace {
 grpc_error* ssl_check_peer(
     const char* peer_name, const tsi_peer* peer,
-    grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
-    bool _alpn_disabled) {
+    grpc_core::RefCountedPtr<grpc_auth_context>* auth_context) {
 #if TSI_OPENSSL_ALPN_SUPPORT
-  if(!_alpn_disabled) {
+  if(!grpc_core::_alpn_disabled) {
     /* Check the ALPN if ALPN is supported. */
     const tsi_peer_property* p =
       tsi_peer_get_property_by_name(peer, TSI_SSL_ALPN_SELECTED_PROTOCOL);
@@ -95,17 +111,6 @@ class grpc_ssl_channel_security_connector final
     char* port;
     gpr_split_host_port(target_name, &target_name_, &port);
     gpr_free(port);
-    alpn_disabled_init("GRPC_ALPN_DISABLED");
-  }
-
-  void alpn_disabled_init(const char* env_var) {
-    char* e = gpr_getenv(env_var);
-    if (e != nullptr) {
-      if(e[0] == '1') {
-        _alpn_disabled = true;
-      }
-      gpr_free(e);
-    }
   }
 
   ~grpc_ssl_channel_security_connector() override {
@@ -169,7 +174,7 @@ class grpc_ssl_channel_security_connector final
     const char* target_name = overridden_target_name_ != nullptr
                                   ? overridden_target_name_
                                   : target_name_;
-    grpc_error* error = ssl_check_peer(target_name, &peer, auth_context, _alpn_disabled);
+    grpc_error* error = ssl_check_peer(target_name, &peer, auth_context);
     if (error == GRPC_ERROR_NONE &&
         verify_options_->verify_peer_callback != nullptr) {
       const tsi_peer_property* p =
@@ -243,7 +248,6 @@ class grpc_ssl_channel_security_connector final
   char* target_name_;
   char* overridden_target_name_;
   const verify_peer_options* verify_options_;
-  bool _alpn_disabled;
 };
 
 class grpc_ssl_server_security_connector
@@ -326,7 +330,7 @@ class grpc_ssl_server_security_connector
   void check_peer(tsi_peer peer, grpc_endpoint* ep,
                   grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
                   grpc_closure* on_peer_checked) override {
-    grpc_error* error = ssl_check_peer(nullptr, &peer, auth_context, false);
+    grpc_error* error = ssl_check_peer(nullptr, &peer, auth_context);
     tsi_peer_destruct(&peer);
     GRPC_CLOSURE_SCHED(on_peer_checked, error);
   }
@@ -479,3 +483,8 @@ grpc_ssl_server_security_connector_create(
   }
   return c;
 }
+
+void grpc_ssl_security_connector_init() {
+  grpc_core::alpn_disabled_init("GRPC_ALPN_DISABLED");
+}
+

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.h
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.h
@@ -29,6 +29,8 @@
 #include "src/core/tsi/ssl_transport_security.h"
 #include "src/core/tsi/transport_security_interface.h"
 
+void grpc_ssl_security_connector_init();
+
 typedef struct {
   tsi_ssl_pem_key_cert_pair* pem_key_cert_pair;
   char* pem_root_certs;

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -53,6 +53,7 @@
 #include "src/core/lib/transport/bdp_estimator.h"
 #include "src/core/lib/transport/connectivity_state.h"
 #include "src/core/lib/transport/transport_impl.h"
+#include "src/core/lib/security/security_connector/ssl/ssl_security_connector.h"
 
 /* (generated) built in registry of plugins */
 extern void grpc_register_built_in_plugins(void);
@@ -159,6 +160,7 @@ void grpc_init(void) {
     /* no more changes to channel init pipelines */
     grpc_channel_init_finalize();
     grpc_iomgr_start();
+    grpc_ssl_security_connector_init();
   }
 
   GRPC_API_TRACE("grpc_init(void)", 0, ());

--- a/src/core/lib/surface/init_unsecure.cc
+++ b/src/core/lib/surface/init_unsecure.cc
@@ -25,3 +25,5 @@ void grpc_security_pre_init(void) {}
 void grpc_register_security_filters(void) {}
 
 void grpc_security_init(void) {}
+
+void grpc_ssl_security_connector_init(void) {}


### PR DESCRIPTION
AWS ELBs proxying gRPC traffic do so in a Layer 4 TCP mode. If they are configured to terminate SSL, then they do not advertise any ALPN protocols. This causes clients dependent on the C core to fail to connect if going directly through the proxy. To work around this, one can use Envoy as it is less strict around the ALPN settings.

This change adds an env var that will globally disable ALPN verification in the SSL security connector for the duration of that process. This allows any language to by-pass the protocol verification. 

I'm interested in if this is something that would be considered at all, and I believe it would be very valuable for us and possibly others. If so, I'd love feedback on how I can add tests for this or improve any aspect. It seems like there aren't any tests around the security connector right now and I'm not sure if this init pattern is quite right.

I prototyped a different approach that added a flag on channel credential construction, but that seemed very heavyweight for what I was looking for. 

Here's some related issues:

https://github.com/grpc/grpc/issues/18549
https://github.com/grpc/grpc/issues/9991

The `ifndef` additions will go away once https://github.com/grpc/grpc/pull/18563 is merged.