### PR TITLE
Initialize time as part of basic initialization.

### DIFF
--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -73,6 +73,7 @@ static void do_basic_init(void) {
   g_shutting_down = false;
   grpc_register_built_in_plugins();
   grpc_cq_global_init();
+  gpr_time_init();
   g_initializations = 0;
 }
 
@@ -132,7 +133,6 @@ void grpc_init(void) {
     }
     grpc_core::Fork::GlobalInit();
     grpc_fork_handlers_auto_register();
-    gpr_time_init();
     gpr_arena_init();
     grpc_stats_init();
     grpc_slice_intern_init();


### PR DESCRIPTION
`gpr_time_init` must happen in `do_basic_init`, because
for normal initialization we may need the precise clock
(e.g., if profilers are enabled).

Otherwise, we will have an stack overflow.

Fixes #18589