### PR TITLE
Provide access to verify_peer_callback from C# (take two)

### DIFF
--- a/src/csharp/Grpc.Core/ChannelCredentials.cs
+++ b/src/csharp/Grpc.Core/ChannelCredentials.cs
@@ -18,9 +18,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 
 using Grpc.Core.Internal;
+using Grpc.Core.Logging;
 using Grpc.Core.Utils;
 
 namespace Grpc.Core
@@ -105,19 +107,35 @@ namespace Grpc.Core
     }
 
     /// <summary>
+    /// Callback invoked with the expected targetHost and the peer's certificate.
+    /// If false is returned by this callback then it is treated as a
+    /// verification failure. Invocation of the callback is blocking, so any
+    /// implementation should be light-weight.
+    /// </summary>
+    /// <param name="context">The <see cref="T:Grpc.Core.VerifyPeerContext"/> associated with the callback</param>
+    /// <returns>true if verification succeeded, false otherwise.</returns>
+    /// Note: experimental API that can change or be removed without any prior notice.
+    public delegate bool VerifyPeerCallback(VerifyPeerContext context);
+
+    /// <summary>
     /// Client-side SSL credentials.
     /// </summary>
     public sealed class SslCredentials : ChannelCredentials
     {
+        static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<SslCredentials>();
+
         readonly string rootCertificates;
         readonly KeyCertificatePair keyCertificatePair;
+        readonly VerifyPeerCallback verifyPeerCallback;
+        readonly VerifyPeerCallbackInternal verifyPeerCallbackInternal;
+        readonly GCHandle gcHandle;
 
         /// <summary>
         /// Creates client-side SSL credentials loaded from
         /// disk file pointed to by the GRPC_DEFAULT_SSL_ROOTS_FILE_PATH environment variable.
         /// If that fails, gets the roots certificates from a well known place on disk.
         /// </summary>
-        public SslCredentials() : this(null, null)
+        public SslCredentials() : this(null, null, null)
         {
         }
 
@@ -125,19 +143,37 @@ namespace Grpc.Core
         /// Creates client-side SSL credentials from
         /// a string containing PEM encoded root certificates.
         /// </summary>
-        public SslCredentials(string rootCertificates) : this(rootCertificates, null)
+        public SslCredentials(string rootCertificates) : this(rootCertificates, null, null)
         {
         }
-            
+
         /// <summary>
         /// Creates client-side SSL credentials.
         /// </summary>
         /// <param name="rootCertificates">string containing PEM encoded server root certificates.</param>
         /// <param name="keyCertificatePair">a key certificate pair.</param>
-        public SslCredentials(string rootCertificates, KeyCertificatePair keyCertificatePair)
+        public SslCredentials(string rootCertificates, KeyCertificatePair keyCertificatePair) :
+            this(rootCertificates, keyCertificatePair, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates client-side SSL credentials.
+        /// </summary>
+        /// <param name="rootCertificates">string containing PEM encoded server root certificates.</param>
+        /// <param name="keyCertificatePair">a key certificate pair.</param>
+        /// <param name="verifyPeerCallback">a callback to verify peer's target name and certificate.</param>
+        /// Note: experimental API that can change or be removed without any prior notice.
+        public SslCredentials(string rootCertificates, KeyCertificatePair keyCertificatePair, VerifyPeerCallback verifyPeerCallback)
         {
             this.rootCertificates = rootCertificates;
             this.keyCertificatePair = keyCertificatePair;
+            if (verifyPeerCallback != null)
+            {
+                this.verifyPeerCallback = verifyPeerCallback;
+                this.verifyPeerCallbackInternal = this.VerifyPeerCallbackHandler;
+                gcHandle = GCHandle.Alloc(verifyPeerCallbackInternal);
+            }
         }
 
         /// <summary>
@@ -171,7 +207,30 @@ namespace Grpc.Core
 
         internal override ChannelCredentialsSafeHandle CreateNativeCredentials()
         {
-            return ChannelCredentialsSafeHandle.CreateSslCredentials(rootCertificates, keyCertificatePair);
+            return ChannelCredentialsSafeHandle.CreateSslCredentials(rootCertificates, keyCertificatePair, this.verifyPeerCallbackInternal);
+        }
+
+        private int VerifyPeerCallbackHandler(IntPtr host, IntPtr pem, IntPtr userData, bool isDestroy)
+        {
+            if (isDestroy)
+            {
+                this.gcHandle.Free();
+                return 0;
+            }
+
+            try
+            {
+                var context = new VerifyPeerContext(Marshal.PtrToStringAnsi(host), Marshal.PtrToStringAnsi(pem));
+
+                return this.verifyPeerCallback(context) ? 0 : 1;
+            }
+            catch (Exception e)
+            {
+                // eat the exception, we must not throw when inside callback from native code.
+                Logger.Error(e, "Exception occurred while invoking verify peer callback handler.");
+                // Return validation failure in case of exception.
+                return 1;
+            }
         }
     }
 

--- a/src/csharp/Grpc.Core/ChannelCredentials.cs
+++ b/src/csharp/Grpc.Core/ChannelCredentials.cs
@@ -226,7 +226,7 @@ namespace Grpc.Core
                 return VerifyPeerCallbackHandler(arg0, arg1, arg2 != IntPtr.Zero);
             }
 
-            private int VerifyPeerCallbackHandler(IntPtr host, IntPtr pem, bool isDestroy)
+            private int VerifyPeerCallbackHandler(IntPtr targetName, IntPtr peerPem, bool isDestroy)
             {
                 if (isDestroy)
                 {
@@ -236,7 +236,7 @@ namespace Grpc.Core
 
                 try
                 {
-                    var context = new VerifyPeerContext(Marshal.PtrToStringAnsi(host), Marshal.PtrToStringAnsi(pem));
+                    var context = new VerifyPeerContext(Marshal.PtrToStringAnsi(targetName), Marshal.PtrToStringAnsi(peerPem));
 
                     return this.verifyPeerCallback(context) ? 0 : 1;
                 }

--- a/src/csharp/Grpc.Core/ChannelCredentials.cs
+++ b/src/csharp/Grpc.Core/ChannelCredentials.cs
@@ -109,8 +109,12 @@ namespace Grpc.Core
     /// <summary>
     /// Callback invoked with the expected targetHost and the peer's certificate.
     /// If false is returned by this callback then it is treated as a
-    /// verification failure. Invocation of the callback is blocking, so any
+    /// verification failure and the attempted connection will fail.
+    /// Invocation of the callback is blocking, so any
     /// implementation should be light-weight.
+    /// Note that the callback can potentially be invoked multiple times,
+    /// concurrently from different threads (e.g. when multiple connections
+    /// are being created for the same credentials).
     /// </summary>
     /// <param name="context">The <see cref="T:Grpc.Core.VerifyPeerContext"/> associated with the callback</param>
     /// <returns>true if verification succeeded, false otherwise.</returns>

--- a/src/csharp/Grpc.Core/Internal/ChannelCredentialsSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/ChannelCredentialsSafeHandle.cs
@@ -20,12 +20,6 @@ using System.Threading.Tasks;
 
 namespace Grpc.Core.Internal
 {
-    internal delegate int VerifyPeerCallbackInternal(
-        IntPtr targetHost,
-        IntPtr targetPem,
-        IntPtr userData,
-        bool isDestroy);
-
     /// <summary>
     /// grpc_channel_credentials from <c>grpc/grpc_security.h</c>
     /// </summary>
@@ -44,15 +38,15 @@ namespace Grpc.Core.Internal
             return creds;
         }
 
-        public static ChannelCredentialsSafeHandle CreateSslCredentials(string pemRootCerts, KeyCertificatePair keyCertPair, VerifyPeerCallbackInternal verifyPeerCallback)
+        public static ChannelCredentialsSafeHandle CreateSslCredentials(string pemRootCerts, KeyCertificatePair keyCertPair, IntPtr verifyPeerCallbackTag)
         {
             if (keyCertPair != null)
             {
-                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, keyCertPair.CertificateChain, keyCertPair.PrivateKey, verifyPeerCallback);
+                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, keyCertPair.CertificateChain, keyCertPair.PrivateKey, verifyPeerCallbackTag);
             }
             else
             {
-                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, null, null, verifyPeerCallback);
+                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, null, null, verifyPeerCallbackTag);
             }
         }
 

--- a/src/csharp/Grpc.Core/Internal/ChannelCredentialsSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/ChannelCredentialsSafeHandle.cs
@@ -20,6 +20,12 @@ using System.Threading.Tasks;
 
 namespace Grpc.Core.Internal
 {
+    internal delegate int VerifyPeerCallbackInternal(
+        IntPtr targetHost,
+        IntPtr targetPem,
+        IntPtr userData,
+        bool isDestroy);
+
     /// <summary>
     /// grpc_channel_credentials from <c>grpc/grpc_security.h</c>
     /// </summary>
@@ -38,15 +44,15 @@ namespace Grpc.Core.Internal
             return creds;
         }
 
-        public static ChannelCredentialsSafeHandle CreateSslCredentials(string pemRootCerts, KeyCertificatePair keyCertPair)
+        public static ChannelCredentialsSafeHandle CreateSslCredentials(string pemRootCerts, KeyCertificatePair keyCertPair, VerifyPeerCallbackInternal verifyPeerCallback)
         {
             if (keyCertPair != null)
             {
-                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, keyCertPair.CertificateChain, keyCertPair.PrivateKey);
+                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, keyCertPair.CertificateChain, keyCertPair.PrivateKey, verifyPeerCallback);
             }
             else
             {
-                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, null, null);
+                return Native.grpcsharp_ssl_credentials_create(pemRootCerts, null, null, verifyPeerCallback);
             }
         }
 

--- a/src/csharp/Grpc.Core/Internal/NativeCallbackDispatcher.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeCallbackDispatcher.cs
@@ -63,7 +63,7 @@ namespace Grpc.Core.Internal
             catch (Exception e)
             {
                 // eat the exception, we must not throw when inside callback from native code.
-                Logger.Error(e, "Caught exception inside callback from native callback.");
+                Logger.Error(e, "Caught exception inside callback from native code.");
                 return 0;
             }
         }

--- a/src/csharp/Grpc.Core/Internal/NativeMethods.Generated.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMethods.Generated.cs
@@ -482,7 +482,7 @@ namespace Grpc.Core.Internal
             public delegate void grpcsharp_channel_args_set_integer_delegate(ChannelArgsSafeHandle args, UIntPtr index, string key, int value);
             public delegate void grpcsharp_channel_args_destroy_delegate(IntPtr args);
             public delegate void grpcsharp_override_default_ssl_roots_delegate(string pemRootCerts);
-            public delegate ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create_delegate(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey);
+            public delegate ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create_delegate(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, VerifyPeerCallbackInternal verifyPeerCallback);
             public delegate ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create_delegate(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds);
             public delegate void grpcsharp_channel_credentials_release_delegate(IntPtr credentials);
             public delegate ChannelSafeHandle grpcsharp_insecure_channel_create_delegate(string target, ChannelArgsSafeHandle channelArgs);
@@ -676,7 +676,7 @@ namespace Grpc.Core.Internal
             public static extern void grpcsharp_override_default_ssl_roots(string pemRootCerts);
             
             [DllImport(ImportName)]
-            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey);
+            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, VerifyPeerCallbackInternal verifyPeerCallback);
             
             [DllImport(ImportName)]
             public static extern ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds);
@@ -972,7 +972,7 @@ namespace Grpc.Core.Internal
             public static extern void grpcsharp_override_default_ssl_roots(string pemRootCerts);
             
             [DllImport(ImportName)]
-            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey);
+            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, VerifyPeerCallbackInternal verifyPeerCallback);
             
             [DllImport(ImportName)]
             public static extern ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds);

--- a/src/csharp/Grpc.Core/Internal/NativeMethods.Generated.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMethods.Generated.cs
@@ -482,7 +482,7 @@ namespace Grpc.Core.Internal
             public delegate void grpcsharp_channel_args_set_integer_delegate(ChannelArgsSafeHandle args, UIntPtr index, string key, int value);
             public delegate void grpcsharp_channel_args_destroy_delegate(IntPtr args);
             public delegate void grpcsharp_override_default_ssl_roots_delegate(string pemRootCerts);
-            public delegate ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create_delegate(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, VerifyPeerCallbackInternal verifyPeerCallback);
+            public delegate ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create_delegate(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr verifyPeerCallbackTag);
             public delegate ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create_delegate(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds);
             public delegate void grpcsharp_channel_credentials_release_delegate(IntPtr credentials);
             public delegate ChannelSafeHandle grpcsharp_insecure_channel_create_delegate(string target, ChannelArgsSafeHandle channelArgs);
@@ -676,7 +676,7 @@ namespace Grpc.Core.Internal
             public static extern void grpcsharp_override_default_ssl_roots(string pemRootCerts);
             
             [DllImport(ImportName)]
-            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, VerifyPeerCallbackInternal verifyPeerCallback);
+            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr verifyPeerCallbackTag);
             
             [DllImport(ImportName)]
             public static extern ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds);
@@ -972,7 +972,7 @@ namespace Grpc.Core.Internal
             public static extern void grpcsharp_override_default_ssl_roots(string pemRootCerts);
             
             [DllImport(ImportName)]
-            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, VerifyPeerCallbackInternal verifyPeerCallback);
+            public static extern ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr verifyPeerCallbackTag);
             
             [DllImport(ImportName)]
             public static extern ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds);

--- a/src/csharp/Grpc.Core/VerifyPeerContext.cs
+++ b/src/csharp/Grpc.Core/VerifyPeerContext.cs
@@ -1,0 +1,30 @@
+namespace Grpc.Core
+{
+    /// <summary>
+    /// Verification context for VerifyPeerCallback.
+    /// Note: experimental API that can change or be removed without any prior notice.
+    /// </summary>
+    public class VerifyPeerContext
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:Grpc.Core.VerifyPeerContext"/> class.
+        /// </summary>
+        /// <param name="targetHost">string containing the host name of the peer.</param>
+        /// <param name="targetPem">string containing PEM encoded certificate of the peer.</param>
+        internal VerifyPeerContext(string targetHost, string targetPem)
+        {
+            this.TargetHost = targetHost;
+            this.TargetPem = targetPem;
+        }
+
+        /// <summary>
+        /// String containing the host name of the peer.
+        /// </summary>
+        public string TargetHost { get; }
+
+        /// <summary>
+        /// string containing PEM encoded certificate of the peer.
+        /// </summary>
+        public string TargetPem { get; }
+    }
+}

--- a/src/csharp/Grpc.Core/VerifyPeerContext.cs
+++ b/src/csharp/Grpc.Core/VerifyPeerContext.cs
@@ -27,22 +27,22 @@ namespace Grpc.Core
         /// <summary>
         /// Initializes a new instance of the <see cref="T:Grpc.Core.VerifyPeerContext"/> class.
         /// </summary>
-        /// <param name="targetHost">string containing the host name of the peer.</param>
-        /// <param name="targetPem">string containing PEM encoded certificate of the peer.</param>
-        internal VerifyPeerContext(string targetHost, string targetPem)
+        /// <param name="targetName">The target name of the peer.</param>
+        /// <param name="peerPem">The PEM encoded certificate of the peer.</param>
+        internal VerifyPeerContext(string targetName, string peerPem)
         {
-            this.TargetHost = targetHost;
-            this.TargetPem = targetPem;
+            this.TargetName = targetName;
+            this.PeerPem = peerPem;
         }
 
         /// <summary>
-        /// String containing the host name of the peer.
+        /// The target name of the peer.
         /// </summary>
-        public string TargetHost { get; }
+        public string TargetName { get; }
 
         /// <summary>
-        /// string containing PEM encoded certificate of the peer.
+        /// The PEM encoded certificate of the peer.
         /// </summary>
-        public string TargetPem { get; }
+        public string PeerPem { get; }
     }
 }

--- a/src/csharp/Grpc.Core/VerifyPeerContext.cs
+++ b/src/csharp/Grpc.Core/VerifyPeerContext.cs
@@ -1,3 +1,21 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
 namespace Grpc.Core
 {
     /// <summary>

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -948,11 +948,11 @@ static void grpcsharp_verify_peer_destroy_handler(void* userdata) {
                              NULL, NULL);
 }
 
-static int grpcsharp_verify_peer_handler(const char* target_host,
-                                         const char* target_pem,
+static int grpcsharp_verify_peer_handler(const char* target_name,
+                                         const char* peer_pem,
                                          void* userdata) {
-  return native_callback_dispatcher(userdata, (void*)target_host,
-                             (void*)target_pem, (void*)0, NULL,
+  return native_callback_dispatcher(userdata, (void*)target_name,
+                             (void*)peer_pem, (void*)0, NULL,
                              NULL, NULL);
 }
 

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -960,25 +960,29 @@ grpcsharp_ssl_credentials_create(const char* pem_root_certs,
                                  void* verify_peer_callback_tag) {
   grpc_ssl_pem_key_cert_pair key_cert_pair;
   verify_peer_options verify_options;
-  verify_peer_options* p_verify_options = NULL;
-  if (verify_peer_callback_tag != NULL) {
-    verify_options.verify_peer_callback_userdata = verify_peer_callback_tag;
-    verify_options.verify_peer_destruct = grpcsharp_verify_peer_destroy_handler;
-    verify_options.verify_peer_callback = grpcsharp_verify_peer_handler;
-    p_verify_options = &verify_options;
-  }
+  grpc_ssl_pem_key_cert_pair* key_cert_pair_ptr = NULL;
+  verify_peer_options* verify_options_ptr = NULL;
 
   if (key_cert_pair_cert_chain || key_cert_pair_private_key) {
+    memset(&key_cert_pair, 0, sizeof(key_cert_pair));
     key_cert_pair.cert_chain = key_cert_pair_cert_chain;
     key_cert_pair.private_key = key_cert_pair_private_key;
-    return grpc_ssl_credentials_create(pem_root_certs, &key_cert_pair,
-                                       p_verify_options, NULL);
+    key_cert_pair_ptr = &key_cert_pair;
   } else {
     GPR_ASSERT(!key_cert_pair_cert_chain);
     GPR_ASSERT(!key_cert_pair_private_key);
-    return grpc_ssl_credentials_create(pem_root_certs, NULL, p_verify_options,
-                                       NULL);
   }
+
+  if (verify_peer_callback_tag != NULL) {
+    memset(&verify_options, 0, sizeof(verify_peer_options));
+    verify_options.verify_peer_callback_userdata = verify_peer_callback_tag;
+    verify_options.verify_peer_destruct = grpcsharp_verify_peer_destroy_handler;
+    verify_options.verify_peer_callback = grpcsharp_verify_peer_handler;
+    verify_options_ptr = &verify_options;
+  }
+
+  return grpc_ssl_credentials_create(pem_root_certs, key_cert_pair_ptr,
+                                     verify_options_ptr, NULL);
 }
 
 GPR_EXPORT void GPR_CALLTYPE

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -927,20 +927,53 @@ grpcsharp_override_default_ssl_roots(const char* pem_root_certs) {
   grpc_set_ssl_roots_override_callback(override_ssl_roots_handler);
 }
 
+typedef int(GPR_CALLTYPE* grpcsharp_verify_peer_func)(const char* target_host,
+                                                      const char* target_pem,
+                                                      void* userdata,
+                                                      int32_t isDestroy);
+
+static void grpcsharp_verify_peer_destroy_handler(void* userdata) {
+  grpcsharp_verify_peer_func callback =
+      (grpcsharp_verify_peer_func)(intptr_t)userdata;
+  callback(NULL, NULL, NULL, 1);
+}
+
+static int grpcsharp_verify_peer_handler(const char* target_host,
+                                         const char* target_pem,
+                                         void* userdata) {
+  grpcsharp_verify_peer_func callback =
+      (grpcsharp_verify_peer_func)(intptr_t)userdata;
+  return callback(target_host, target_pem, NULL, 0);
+}
+
+
 GPR_EXPORT grpc_channel_credentials* GPR_CALLTYPE
 grpcsharp_ssl_credentials_create(const char* pem_root_certs,
                                  const char* key_cert_pair_cert_chain,
-                                 const char* key_cert_pair_private_key) {
+                                 const char* key_cert_pair_private_key,
+                                 grpcsharp_verify_peer_func verify_peer_func) {
   grpc_ssl_pem_key_cert_pair key_cert_pair;
+  verify_peer_options verify_options;
+  verify_peer_options* p_verify_options = NULL;
+  if (verify_peer_func != NULL) {
+    verify_options.verify_peer_callback_userdata =
+            (void*)(intptr_t)verify_peer_func;
+    verify_options.verify_peer_destruct =
+            grpcsharp_verify_peer_destroy_handler;
+    verify_options.verify_peer_callback = grpcsharp_verify_peer_handler;
+    p_verify_options = &verify_options;
+  }
+
   if (key_cert_pair_cert_chain || key_cert_pair_private_key) {
     key_cert_pair.cert_chain = key_cert_pair_cert_chain;
     key_cert_pair.private_key = key_cert_pair_private_key;
-    return grpc_ssl_credentials_create(pem_root_certs, &key_cert_pair, NULL,
-                                       NULL);
+    return grpc_ssl_credentials_create(pem_root_certs, &key_cert_pair,
+                                       p_verify_options, NULL);
   } else {
     GPR_ASSERT(!key_cert_pair_cert_chain);
     GPR_ASSERT(!key_cert_pair_private_key);
-    return grpc_ssl_credentials_create(pem_root_certs, NULL, NULL, NULL);
+    return grpc_ssl_credentials_create(pem_root_certs, NULL, p_verify_options,
+                                       NULL);
   }
 }
 

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -943,19 +943,15 @@ grpcsharp_override_default_ssl_roots(const char* pem_root_certs) {
 }
 
 static void grpcsharp_verify_peer_destroy_handler(void* userdata) {
-  native_callback_dispatcher(userdata, NULL,
-                             NULL, (void*)1, NULL,
-                             NULL, NULL);
+  native_callback_dispatcher(userdata, NULL, NULL, (void*)1, NULL, NULL, NULL);
 }
 
 static int grpcsharp_verify_peer_handler(const char* target_name,
-                                         const char* peer_pem,
-                                         void* userdata) {
+                                         const char* peer_pem, void* userdata) {
   return native_callback_dispatcher(userdata, (void*)target_name,
-                             (void*)peer_pem, (void*)0, NULL,
-                             NULL, NULL);
+                                    (void*)peer_pem, (void*)0, NULL, NULL,
+                                    NULL);
 }
-
 
 GPR_EXPORT grpc_channel_credentials* GPR_CALLTYPE
 grpcsharp_ssl_credentials_create(const char* pem_root_certs,
@@ -966,10 +962,8 @@ grpcsharp_ssl_credentials_create(const char* pem_root_certs,
   verify_peer_options verify_options;
   verify_peer_options* p_verify_options = NULL;
   if (verify_peer_callback_tag != NULL) {
-    verify_options.verify_peer_callback_userdata =
-            verify_peer_callback_tag;
-    verify_options.verify_peer_destruct =
-            grpcsharp_verify_peer_destroy_handler;
+    verify_options.verify_peer_callback_userdata = verify_peer_callback_tag;
+    verify_options.verify_peer_destruct = grpcsharp_verify_peer_destroy_handler;
     verify_options.verify_peer_callback = grpcsharp_verify_peer_handler;
     p_verify_options = &verify_options;
   }

--- a/templates/src/csharp/Grpc.Core/Internal/native_methods.include
+++ b/templates/src/csharp/Grpc.Core/Internal/native_methods.include
@@ -44,7 +44,7 @@ native_method_signatures = [
     'void grpcsharp_channel_args_set_integer(ChannelArgsSafeHandle args, UIntPtr index, string key, int value)',
     'void grpcsharp_channel_args_destroy(IntPtr args)',
     'void grpcsharp_override_default_ssl_roots(string pemRootCerts)',
-    'ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey)',
+    'ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, VerifyPeerCallbackInternal verifyPeerCallback)',
     'ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds)',
     'void grpcsharp_channel_credentials_release(IntPtr credentials)',
     'ChannelSafeHandle grpcsharp_insecure_channel_create(string target, ChannelArgsSafeHandle channelArgs)',

--- a/templates/src/csharp/Grpc.Core/Internal/native_methods.include
+++ b/templates/src/csharp/Grpc.Core/Internal/native_methods.include
@@ -44,7 +44,7 @@ native_method_signatures = [
     'void grpcsharp_channel_args_set_integer(ChannelArgsSafeHandle args, UIntPtr index, string key, int value)',
     'void grpcsharp_channel_args_destroy(IntPtr args)',
     'void grpcsharp_override_default_ssl_roots(string pemRootCerts)',
-    'ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, VerifyPeerCallbackInternal verifyPeerCallback)',
+    'ChannelCredentialsSafeHandle grpcsharp_ssl_credentials_create(string pemRootCerts, string keyCertPairCertChain, string keyCertPairPrivateKey, IntPtr verifyPeerCallbackTag)',
     'ChannelCredentialsSafeHandle grpcsharp_composite_channel_credentials_create(ChannelCredentialsSafeHandle channelCreds, CallCredentialsSafeHandle callCreds)',
     'void grpcsharp_channel_credentials_release(IntPtr credentials)',
     'ChannelSafeHandle grpcsharp_insecure_channel_create(string target, ChannelArgsSafeHandle channelArgs)',


### PR DESCRIPTION
Supersedes https://github.com/grpc/grpc/pull/17051 (changes are based on that PR but some refactoring and cleanup has been done).

- expose VerifyPeerCallback on SslCredentials (using NativeCallbackDispatcher)
- tests