### PR TITLE
Fix BUILD.gn file

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1076,6 +1076,7 @@ config("grpc_config") {
         "include/grpcpp/impl/server_initializer_impl.h",
         "include/grpcpp/impl/service_type.h",
         "include/grpcpp/resource_quota.h",
+        "include/grpcpp/resource_quota_impl.h",
         "include/grpcpp/security/auth_context.h",
         "include/grpcpp/security/auth_metadata_processor.h",
         "include/grpcpp/security/credentials.h",


### PR DESCRIPTION
Root cause: https://github.com/grpc/grpc/pull/18345 did not add a file to BUILD.gn causing generate_projects.sh to fail causing this error.

Solution: Fixing it by running the generate_projects.sh script.
