### PR TITLE
backport #18606 - Add a dummy function to grpc cfstream library

### DIFF
--- a/src/core/lib/iomgr/cfstream_handle.cc
+++ b/src/core/lib/iomgr/cfstream_handle.cc
@@ -173,4 +173,11 @@ void CFStreamHandle::Unref(const char* file, int line, const char* reason) {
   }
 }
 
+#else
+
+/* Creating a dummy function so that the grpc_cfstream library will be
+ * non-empty.
+ */
+void CFStreamDummy() {}
+
 #endif


### PR DESCRIPTION
backport #18606 - Add a dummy function to grpc cfstream library