### PR TITLE
Loosen the dependency on the googleapis-common-protos-types gem

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.platform      = Gem::Platform::RUBY
 
   s.add_dependency 'google-protobuf', '~> 3.7'
-  s.add_dependency 'googleapis-common-protos-types', '~> 1.0.0'
+  s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
   s.add_development_dependency 'bundler',            '~> 1.9'
   s.add_development_dependency 'facter',             '~> 2.4'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -32,7 +32,7 @@
     s.platform      = Gem::Platform::RUBY
 
     s.add_dependency 'google-protobuf', '~> 3.7'
-    s.add_dependency 'googleapis-common-protos-types', '~> 1.0.0'
+    s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
     s.add_development_dependency 'bundler',            '~> 1.9'
     s.add_development_dependency 'facter',             '~> 2.4'


### PR DESCRIPTION
Can the dependency on the common protos gem be relaxed or is there a reason why it is fixed at `~> 1.0.0`?