### PR TITLE
Fix CFStreamTest.NetworkTransition.

### DIFF
--- a/test/cpp/end2end/cfstream_test.cc
+++ b/test/cpp/end2end/cfstream_test.cc
@@ -62,7 +62,7 @@ class CFStreamTest : public ::testing::Test {
   CFStreamTest()
       : server_host_("grpctest"),
         interface_("lo0"),
-        ipv4_address_("127.0.0.2"),
+        ipv4_address_("10.0.0.1"),
         kRequestMessage_("🖖") {}
 
   void DNSUp() {


### PR DESCRIPTION
It looks like CFStream doesn't detect stream errors when the server is listening on 127.0.0.2 and the interface is shutdown.
The test started failing after address was changed from 10.0.0.1 to 127.0.0.2 in #18381. This commit changes the server address back to 10.0.0.1.