### PR TITLE
Mitigate Python Bazel Breakage

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,6 +17,26 @@ register_toolchains(
     "//third_party/toolchains:cc-toolchain-clang-x86_64-default",
 )
 
+# TODO(https://github.com/grpc/grpc/issues/18331): Move off of this dependency.
+git_repository(
+    name = "org_pubref_rules_protobuf",
+    remote = "https://github.com/ghostwriternr/rules_protobuf",
+    tag = "v0.8.2.1-alpha",
+)
+
+git_repository(
+    name = "io_bazel_rules_python",
+    commit = "8b5d0683a7d878b28fffe464779c8a53659fc645",
+    remote = "https://github.com/bazelbuild/rules_python.git",
+)
+
+load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip_import")
+
+pip_import(
+    name = "grpc_python_dependencies",
+    requirements = "//:requirements.bazel.txt",
+)
+
 http_archive(
     name = "cython",
     build_file = "//third_party:cython.BUILD",
@@ -27,36 +47,6 @@ http_archive(
     ],
 )
 
-load("//third_party/py:python_configure.bzl", "python_configure")
+load("//bazel:grpc_python_deps.bzl", "grpc_python_deps")
 
-python_configure(name = "local_config_python")
-
-git_repository(
-    name = "io_bazel_rules_python",
-    commit = "8b5d0683a7d878b28fffe464779c8a53659fc645",
-    remote = "https://github.com/bazelbuild/rules_python.git",
-)
-
-load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip_import")
-
-pip_repositories()
-
-pip_import(
-    name = "grpc_python_dependencies",
-    requirements = "//:requirements.bazel.txt",
-)
-
-load("@grpc_python_dependencies//:requirements.bzl", "pip_install")
-
-pip_install()
-
-# NOTE(https://github.com/pubref/rules_protobuf/pull/196): Switch to upstream repo after this gets merged.
-git_repository(
-    name = "org_pubref_rules_protobuf",
-    remote = "https://github.com/ghostwriternr/rules_protobuf",
-    tag = "v0.8.2.1-alpha",
-)
-
-load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_repositories")
-
-py_proto_repositories()
+grpc_python_deps()

--- a/bazel/grpc_python_deps.bzl
+++ b/bazel/grpc_python_deps.bzl
@@ -1,0 +1,15 @@
+load("//third_party/py:python_configure.bzl", "python_configure")
+load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories")
+load("@grpc_python_dependencies//:requirements.bzl", "pip_install")
+load("@org_pubref_rules_protobuf//python:rules.bzl", "py_proto_repositories")
+
+def grpc_python_deps():
+    # TODO(https://github.com/grpc/grpc/issues/18256): Remove conditional.
+    if hasattr(native, "http_archive"):
+        python_configure(name = "local_config_python")
+        pip_repositories()
+        pip_install()
+        py_proto_repositories()
+    else:
+        print("Building python gRPC with bazel 23.0+ is disabled pending resolution of https://github.com/grpc/grpc/issues/18256.")
+

--- a/bazel/grpc_python_deps.bzl
+++ b/bazel/grpc_python_deps.bzl
@@ -11,5 +11,6 @@ def grpc_python_deps():
         pip_install()
         py_proto_repositories()
     else:
-        print("Building python gRPC with bazel 23.0+ is disabled pending resolution of https://github.com/grpc/grpc/issues/18256.")
+        print("Building Python gRPC with bazel 23.0+ is disabled pending " +
+              "resolution of https://github.com/grpc/grpc/issues/18256.")
 


### PR DESCRIPTION
This PR mitigates #18256.

`bazel build //:all` is currently broken on Bazel version 23.0 and up. Ultimately, this comes down to an [orphaned python bazel dependency](https://github.com/ghostwriternr/rules_protobuf) that has become incompatible with the latest versions of Bazel. In the long term, this problem needs to be resolved by coming up with a better story for generating python protobuf code.

In the meantime, this PR skips python dependencies for incompatible versions of Bazel. People invoking `bazel build //:all` will see a warning that python dependencies are being skipped, but will be able to build successfully. Kokoro will continue to succeed since it is pinned. And the python team will not be blocked because we are all able to work with older versions of bazel.

Within the next couple of days, I will follow up with a PR implementing `py_proto_library` entirely in this repo.