### PR TITLE
grpc_interop_java: Remove unnecessary cruft from container

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_java_oracle8/Dockerfile.include
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_java_oracle8/Dockerfile.include
@@ -15,13 +15,6 @@
 <%include file="../../debian_jessie_header.include"/>
 
 <%include file="java_deps.include"/>
-<%include file="../../python_deps.include"/>
-
-# Trigger download of as many Gradle artifacts as possible.
-RUN git clone --recursive --depth 1 https://github.com/grpc/grpc-java.git && ${'\\'}
-  cd grpc-java && ${'\\'}
-  ./gradlew :grpc-interop-testing:installDist -PskipCodegen=true && ${'\\'}
-  rm -r "$(pwd)"
 
 # Define the default command.
 CMD ["bash"]

--- a/templates/tools/dockerfile/interoptest/grpc_interop_java_oracle8/java_deps.include
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_java_oracle8/java_deps.include
@@ -1,16 +1,11 @@
-# Install JDK 8 and Git
+# Install JDK 8
 #
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && ${'\\'}
   echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list && ${'\\'}
   echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list && ${'\\'}
-  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
-
-RUN apt-get update && apt-get -y install ${'\\'}
-      git ${'\\'}
-      libapr1 ${'\\'}
-      oracle-java8-installer ${'\\'}
-      && ${'\\'}
-    apt-get clean && rm -r /var/cache/oracle-jdk8-installer/
+  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886 && ${'\\'}
+  apt-get update && apt-get -y install oracle-java8-installer && ${'\\'}
+  apt-get clean && rm -r /var/cache/oracle-jdk8-installer/
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 ENV PATH $PATH:$JAVA_HOME/bin

--- a/templates/tools/dockerfile/java_build_interop.sh.include
+++ b/templates/tools/dockerfile/java_build_interop.sh.include
@@ -16,15 +16,23 @@
 # Builds Java interop server and client in a base image.
 set -e
 
-mkdir -p /var/local/git
-git clone --recursive --depth 1 /var/local/jenkins/grpc-java /var/local/git/grpc-java
+cp -r /var/local/jenkins/grpc-java /tmp/grpc-java
 
 # copy service account keys if available
 cp -r /var/local/jenkins/service_account $HOME || true
 
-cd /var/local/git/grpc-java
-
+pushd /tmp/grpc-java
 ./gradlew :grpc-interop-testing:installDist -PskipCodegen=true
+
+mkdir -p /var/local/git/grpc-java/
+cp -r --parents -t /var/local/git/grpc-java/ ${'\\'}
+    interop-testing/build/install/ ${'\\'}
+    run-test-client.sh ${'\\'}
+    run-test-server.sh
+
+popd
+rm -r /tmp/grpc-java
+rm -r "$HOME/.gradle"
 
 # enable extra java logging
 mkdir -p /var/local/grpc_java_logging

--- a/tools/dockerfile/interoptest/grpc_interop_java/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_java/Dockerfile
@@ -16,45 +16,20 @@ FROM debian:jessie
 RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
 
 
-# Install JDK 8 and Git
+# Install JDK 8
 #
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
   echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list && \
   echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list && \
-  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
-
-RUN apt-get update && apt-get -y install \
-      git \
-      libapr1 \
-      oracle-java8-installer \
-      && \
-    apt-get clean && rm -r /var/cache/oracle-jdk8-installer/
+  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886 && \
+  apt-get update && apt-get -y install oracle-java8-installer && \
+  apt-get clean && rm -r /var/cache/oracle-jdk8-installer/
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 ENV PATH $PATH:$JAVA_HOME/bin
 
 
-#====================
-# Python dependencies
-
-# Install dependencies
-
-RUN apt-get update && apt-get install -y \
-    python-all-dev \
-    python3-all-dev \
-    python-pip
-
-# Install Python packages from PyPI
-RUN pip install --upgrade pip==10.0.1
-RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
-
-
-# Trigger download of as many Gradle artifacts as possible.
-RUN git clone --recursive --depth 1 https://github.com/grpc/grpc-java.git && \
-  cd grpc-java && \
-  ./gradlew :grpc-interop-testing:installDist -PskipCodegen=true && \
-  rm -r "$(pwd)"
 
 # Define the default command.
 CMD ["bash"]
+

--- a/tools/dockerfile/interoptest/grpc_interop_java/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_java/build_interop.sh
@@ -16,15 +16,23 @@
 # Builds Java interop server and client in a base image.
 set -e
 
-mkdir -p /var/local/git
-git clone --recursive --depth 1 /var/local/jenkins/grpc-java /var/local/git/grpc-java
+cp -r /var/local/jenkins/grpc-java /tmp/grpc-java
 
 # copy service account keys if available
 cp -r /var/local/jenkins/service_account $HOME || true
 
-cd /var/local/git/grpc-java
-
+pushd /tmp/grpc-java
 ./gradlew :grpc-interop-testing:installDist -PskipCodegen=true
+
+mkdir -p /var/local/git/grpc-java/
+cp -r --parents -t /var/local/git/grpc-java/ \
+    interop-testing/build/install/ \
+    run-test-client.sh \
+    run-test-server.sh
+
+popd
+rm -r /tmp/grpc-java
+rm -r "$HOME/.gradle"
 
 # enable extra java logging
 mkdir -p /var/local/grpc_java_logging

--- a/tools/dockerfile/interoptest/grpc_interop_java_oracle8/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_java_oracle8/Dockerfile
@@ -16,45 +16,20 @@ FROM debian:jessie
 RUN sed -i '/deb http:\/\/deb.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
 
 
-# Install JDK 8 and Git
+# Install JDK 8
 #
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
   echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list && \
   echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list && \
-  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
-
-RUN apt-get update && apt-get -y install \
-      git \
-      libapr1 \
-      oracle-java8-installer \
-      && \
-    apt-get clean && rm -r /var/cache/oracle-jdk8-installer/
+  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886 && \
+  apt-get update && apt-get -y install oracle-java8-installer && \
+  apt-get clean && rm -r /var/cache/oracle-jdk8-installer/
 
 ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
 ENV PATH $PATH:$JAVA_HOME/bin
 
 
-#====================
-# Python dependencies
-
-# Install dependencies
-
-RUN apt-get update && apt-get install -y \
-    python-all-dev \
-    python3-all-dev \
-    python-pip
-
-# Install Python packages from PyPI
-RUN pip install --upgrade pip==10.0.1
-RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
-
-
-# Trigger download of as many Gradle artifacts as possible.
-RUN git clone --recursive --depth 1 https://github.com/grpc/grpc-java.git && \
-  cd grpc-java && \
-  ./gradlew :grpc-interop-testing:installDist -PskipCodegen=true && \
-  rm -r "$(pwd)"
 
 # Define the default command.
 CMD ["bash"]
+

--- a/tools/dockerfile/interoptest/grpc_interop_java_oracle8/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_java_oracle8/build_interop.sh
@@ -16,15 +16,23 @@
 # Builds Java interop server and client in a base image.
 set -e
 
-mkdir -p /var/local/git
-git clone --recursive --depth 1 /var/local/jenkins/grpc-java /var/local/git/grpc-java
+cp -r /var/local/jenkins/grpc-java /tmp/grpc-java
 
 # copy service account keys if available
 cp -r /var/local/jenkins/service_account $HOME || true
 
-cd /var/local/git/grpc-java
-
+pushd /tmp/grpc-java
 ./gradlew :grpc-interop-testing:installDist -PskipCodegen=true
+
+mkdir -p /var/local/git/grpc-java/
+cp -r --parents -t /var/local/git/grpc-java/ \
+    interop-testing/build/install/ \
+    run-test-client.sh \
+    run-test-server.sh
+
+popd
+rm -r /tmp/grpc-java
+rm -r "$HOME/.gradle"
 
 # enable extra java logging
 mkdir -p /var/local/grpc_java_logging


### PR DESCRIPTION
This reduces the container size from 1.4 GB to 640 MB. 129 MB is
jessie, 489 MB jdk, and 22 MB grpc-java. When we swap from jessie to
stretch, we could swap to openjdk:8-jdk-slim-stretch which would make
the entire image 265 MB.

Python was never needed; it was added by mistake in 0589e533.
Pre-downloading gradle artifacts isn't helpful these days, because we
build on a clean machine. Git isn't needed as cp is sufficient. libapr1
has not been required by tcnative for a long time, and we even use
tcnative-boringssl-static since at least 1.0, which also doesn't need
it. The final cleanup is to remove source and downloaded artifacts when
done compiling.

-----

I used `tools/interop_matrix/create_matrix_images.py --language java` to
rebuild the container and tested the result with `docker_image=gcr.io/grpc-testing/grpc_interop_java_oracle8:master tools/interop_matrix/testcases/java__master`.
I did this for grpc-java master and 1.0.x.