### PR TITLE
Add environment variable for disabling ALPN verification

### DIFF
--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.h
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.h
@@ -29,6 +29,8 @@
 #include "src/core/tsi/ssl_transport_security.h"
 #include "src/core/tsi/transport_security_interface.h"
 
+void grpc_ssl_security_connector_init();
+
 typedef struct {
   tsi_ssl_pem_key_cert_pair* pem_key_cert_pair;
   char* pem_root_certs;

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -53,6 +53,7 @@
 #include "src/core/lib/transport/bdp_estimator.h"
 #include "src/core/lib/transport/connectivity_state.h"
 #include "src/core/lib/transport/transport_impl.h"
+#include "src/core/lib/security/security_connector/ssl/ssl_security_connector.h"
 
 /* (generated) built in registry of plugins */
 extern void grpc_register_built_in_plugins(void);
@@ -159,6 +160,7 @@ void grpc_init(void) {
     /* no more changes to channel init pipelines */
     grpc_channel_init_finalize();
     grpc_iomgr_start();
+    grpc_ssl_security_connector_init();
   }
 
   GRPC_API_TRACE("grpc_init(void)", 0, ());

--- a/src/core/lib/surface/init_unsecure.cc
+++ b/src/core/lib/surface/init_unsecure.cc
@@ -25,3 +25,5 @@ void grpc_security_pre_init(void) {}
 void grpc_register_security_filters(void) {}
 
 void grpc_security_init(void) {}
+
+void grpc_ssl_security_connector_init(void) {}


### PR DESCRIPTION
AWS ELBs proxying gRPC traffic do so in a Layer 4 TCP mode. If they are configured to terminate SSL, then they do not advertise any ALPN protocols. This causes clients dependent on the C core to fail to connect if going directly through the proxy. To work around this, one can use Envoy as it is less strict around the ALPN settings.

This change adds an env var that will globally disable ALPN verification in the SSL security connector for the duration of that process. This allows any language to by-pass the protocol verification.

I'm interested in if this is something that would be considered at all, and I believe it would be very valuable for us and possibly others. If so, I'd love feedback on how I can add tests for this or improve any aspect. It seems like there aren't any tests around the security connector right now and I'm not sure if this init pattern is quite right.

I prototyped a different approach that added a flag on channel credential construction, but that seemed very heavyweight for what I was looking for.

Here's some related issues:

#18549
#9991

There's a merge conflict due to #18563, but will resolve once this direction looks reasonable to others!