### PR TITLE
Fix third_party/protoc-gen-validate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -50,7 +50,7 @@
 	url = https://github.com/googleapis/googleapis.git
 [submodule "third_party/protoc-gen-validate"]
 	path = third_party/protoc-gen-validate
-	url = https://github.com/lyft/protoc-gen-validate.git
+	url = https://github.com/envoyproxy/protoc-gen-validate.git
 [submodule "third_party/upb"]
 	path = third_party/upb
 	url = https://github.com/google/upb.git


### PR DESCRIPTION
[Edit:] ~~The repo https://github.com/lyft/protoc-gen-validate seems to be gone.~~ A proper redirect seems to be in place now

[Edit:] Moved to https://github.com/envoyproxy/protoc-gen-validate