### PR TITLE
Add VS integration for design time build of C# projects

### DIFF
--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -38,6 +38,21 @@
     <AvailableItemName Include="Protobuf" />
   </ItemGroup>
 
+  <!-- Design Time Build integration for Visual Studio -->
+  <ItemGroup Condition=" '$(DisableProtobufDesignTimeBuild)' != 'true' " >
+    <!-- Add Protobuf items to Content if they are not added yet -->
+    <UnaddedProtobufContent Include="@(Protobuf)" Exclude="@(Content)" />
+    <Content Include="@(UnaddedProtobufContent)" />
+
+    <!-- Remove Protobuf items from None -->
+    <None Remove="@(Protobuf)" />
+
+    <!-- Add Generator attribute to trigger Protobuf compilation -->
+    <Protobuf Update="@(Protobuf)" >
+      <Generator>MSBuild:Compile</Generator>
+    </Protobuf>
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- NET SDK: by default, do not include proto files in the directory.
          Current Microsoft's recommendation is against globbing:

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -42,7 +42,6 @@
   <!-- Workaround for VS Project System bug: -->
   <!-- Duplicated items in None itemgroup without Generator attribute prevents the items -->
   <!-- in Protobuf itemgroup with Generator attribute from triggering design time build. -->
-  <!-- https://devdiv.visualstudio.com/DevDiv/_workitems/edit/849161?src=WorkItemMention&src-action=artifact_link -->
   <ItemGroup Condition=" '$(DisableProtobufDesignTimeBuild)' != 'true' " >
     <!-- Working around this by removing the duplicated items from None itemgroup. -->
     <None Remove="@(Protobuf)" />

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -39,6 +39,15 @@
     <AvailableItemName Include="Protobuf" />
   </ItemGroup>
 
+  <!-- Workaround for VS Project System bug: -->
+  <!-- Duplicated items in None itemgroup without Generator attribute prevents the items -->
+  <!-- in Protobuf itemgroup with Generator attribute from triggering design time build. -->
+  <!-- https://devdiv.visualstudio.com/DevDiv/_workitems/edit/849161?src=WorkItemMention&src-action=artifact_link -->
+  <ItemGroup Condition=" '$(DisableProtobufDesignTimeBuild)' != 'true' " >
+    <!-- Working around this by removing the duplicated items from None itemgroup. -->
+    <None Remove="@(Protobuf)" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!-- NET SDK: by default, do not include proto files in the directory.
          Current Microsoft's recommendation is against globbing:

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -28,6 +28,7 @@
       <ProtoRoot Condition="'%(Protobuf.ProtoRoot)' == '' " />
       <CompileOutputs Condition="'%(Protobuf.CompileOutputs)' == ''">True</CompileOutputs>
       <OutputDir Condition="'%(Protobuf.OutputDir)' == '' ">$(Protobuf_OutputPath)</OutputDir>
+      <Generator Condition=" '$(DisableProtobufDesignTimeBuild)' != 'true' " >MSBuild:Compile</Generator>
     </Protobuf>
   </ItemDefinitionGroup>
 
@@ -46,11 +47,6 @@
 
     <!-- Remove Protobuf items from None -->
     <None Remove="@(Protobuf)" />
-
-    <!-- Add Generator attribute to trigger Protobuf compilation -->
-    <Protobuf Update="@(Protobuf)" >
-      <Generator>MSBuild:Compile</Generator>
-    </Protobuf>
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -39,15 +39,6 @@
     <AvailableItemName Include="Protobuf" />
   </ItemGroup>
 
-  <!-- Workaround for VS Project System bug: -->
-  <!-- Duplicated items in None itemgroup without Generator attribute prevents the items in Protobuf -->
-  <!-- itemgroup with Generator attribute from triggering design time build. Working around this by -->
-  <!-- removing the duplicated items from None itemgroup. The Remove attribute was introduced -->
-  <!-- in the .NET Framework 3.5, but was only supported inside targets until MSBuild 15.0. -->
-  <ItemGroup Condition=" '$(MSBuildVersion)' &gt;= '15.0' and '$(DisableProtobufDesignTimeBuild)' != 'true' " >
-    <None Remove="@(Protobuf)" />
-  </ItemGroup>
-
   <PropertyGroup>
     <!-- NET SDK: by default, do not include proto files in the directory.
          Current Microsoft's recommendation is against globbing:

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -39,16 +39,6 @@
     <AvailableItemName Include="Protobuf" />
   </ItemGroup>
 
-  <!-- Design Time Build integration for Visual Studio -->
-  <ItemGroup Condition=" '$(DisableProtobufDesignTimeBuild)' != 'true' " >
-    <!-- Add Protobuf items to Content if they are not added yet -->
-    <UnaddedProtobufContent Include="@(Protobuf)" Exclude="@(Content)" />
-    <Content Include="@(UnaddedProtobufContent)" />
-
-    <!-- Remove Protobuf items from None -->
-    <None Remove="@(Protobuf)" />
-  </ItemGroup>
-
   <PropertyGroup>
     <!-- NET SDK: by default, do not include proto files in the directory.
          Current Microsoft's recommendation is against globbing:

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -28,7 +28,7 @@
       <ProtoRoot Condition="'%(Protobuf.ProtoRoot)' == '' " />
       <CompileOutputs Condition="'%(Protobuf.CompileOutputs)' == ''">True</CompileOutputs>
       <OutputDir Condition="'%(Protobuf.OutputDir)' == '' ">$(Protobuf_OutputPath)</OutputDir>
-      <Generator Condition=" '$(DisableProtobufDesignTimeBuild)' != 'true' " >MSBuild:Compile</Generator>
+      <Generator Condition="'%(Protobuf.Generator)' == '' and '$(DisableProtobufDesignTimeBuild)' != 'true' " >MSBuild:Compile</Generator>
     </Protobuf>
   </ItemDefinitionGroup>
 

--- a/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_protobuf/Google.Protobuf.Tools.targets
@@ -40,10 +40,11 @@
   </ItemGroup>
 
   <!-- Workaround for VS Project System bug: -->
-  <!-- Duplicated items in None itemgroup without Generator attribute prevents the items -->
-  <!-- in Protobuf itemgroup with Generator attribute from triggering design time build. -->
-  <ItemGroup Condition=" '$(DisableProtobufDesignTimeBuild)' != 'true' " >
-    <!-- Working around this by removing the duplicated items from None itemgroup. -->
+  <!-- Duplicated items in None itemgroup without Generator attribute prevents the items in Protobuf -->
+  <!-- itemgroup with Generator attribute from triggering design time build. Working around this by -->
+  <!-- removing the duplicated items from None itemgroup. The Remove attribute was introduced -->
+  <!-- in the .NET Framework 3.5, but was only supported inside targets until MSBuild 15.0. -->
+  <ItemGroup Condition=" '$(MSBuildVersion)' &gt;= '15.0' and '$(DisableProtobufDesignTimeBuild)' != 'true' " >
     <None Remove="@(Protobuf)" />
   </ItemGroup>
 


### PR DESCRIPTION
This change would allow us to enable Design Time Build protobuf compilation in VS for `<Protobuf>` items in C# projects without any modifications to their *.csproj file. Design Time Builds are triggered on an ongoing basis as the file is edited and saved. We would like to enable this functionality to improve inner loop experience.

**EDIT: The only change required is 1, the other steps were due to a bug in the project system.**

To enable protobuf compilation during design time build, the following steps are needed:
1. Add the `<Generator>` attribute to the <Protobuf> item, this is required to specify which target to run when the Protobuf file is edited and saved
2. Add the Protobuf file to `<Content>`. VS keeps track of specific item groups to trigger design time builds and `<Content>` is a good fit for Protobuf files.
3. Remove the Protobuf file from the `<None>`. Protobuf files are added to this item group by default and design time build is ignored for this item group.

Currently to enable this, the following need to be added to the *.csproj:
```XML
  <ItemGroup>
    <Protobuf Include="Protos\greet.proto" GrpcServices="Server" Generator="MSBuild:Compile"/>
    <Content Include="@(Protobuf)" />
    <None Remove="@(Protobuf)" />
  </ItemGroup>
```

After this change, this can be simplified to:
```XML
  <ItemGroup>
    <Protobuf Include="Protos\greet.proto" GrpcServices="Server" />
  </ItemGroup>
```

While I have tested that these changes achieves the results that we want, there are still a few assumptions I would like to check. Feel free to review though the implementation may change.