### PR TITLE
Expose root_certificates in BUILD file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2454,3 +2454,11 @@ grpc_cc_library(
 )
 
 grpc_generate_one_off_targets()
+
+filegroup(
+    name = "root_certificates",
+    srcs = [
+        "etc/roots.pem",
+    ],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
I'd like to be able to grab the root_certificates and use them in my build process to bundle them as part of my package I ship to prod, and this prevents me from having two repos for gRPC, one having a custom BUILD file that allows me to grab the roots.pem file, which is what I do now to add this into our build process.