### PR TITLE
Fix undeclared identifier HOST_NAME_MAX when compiling with clang.

### DIFF
--- a/src/core/lib/iomgr/gethostname_host_name_max.cc
+++ b/src/core/lib/iomgr/gethostname_host_name_max.cc
@@ -29,8 +29,9 @@
 #include <grpc/support/alloc.h>
 
 char* grpc_gethostname() {
-  char* hostname = static_cast<char*>(gpr_malloc(HOST_NAME_MAX));
-  if (gethostname(hostname, HOST_NAME_MAX) != 0) {
+  size_t host_name_max = (size_t)sysconf(_POSIX_HOST_NAME_MAX);
+  char* hostname = static_cast<char*>(gpr_malloc(host_name_max));
+  if (gethostname(hostname, host_name_max) != 0) {
     gpr_free(hostname);
     return nullptr;
   }


### PR DESCRIPTION
com_github_grpc_grpc/src/core/lib/iomgr/gethostname_host_name_max.cc:32:50: error: use of undeclared identifier 'HOST_NAME_MAX'
  char* hostname = static_cast<char*>(gpr_malloc(HOST_NAME_MAX));