### PR TITLE
Fix undeclared identifier HOST_NAME_MAX when compiling with clang.

### DIFF
--- a/src/core/lib/iomgr/gethostname_host_name_max.cc
+++ b/src/core/lib/iomgr/gethostname_host_name_max.cc
@@ -29,7 +29,8 @@
 #include <grpc/support/alloc.h>
 
 char* grpc_gethostname() {
-  char* hostname = static_cast<char*>(gpr_malloc(HOST_NAME_MAX));
+  size_t host_name_max = (size_t)sysconf(_POSIX_HOST_NAME_MAX);
+  char* hostname = static_cast<char*>(gpr_malloc(host_name_max));
   if (gethostname(hostname, HOST_NAME_MAX) != 0) {
     gpr_free(hostname);
     return nullptr;


### PR DESCRIPTION
external/com_github_grpc_grpc/src/core/lib/iomgr/gethostname_host_name_max.cc:32:50: error: use of undeclared identifier 'HOST_NAME_MAX'
  char* hostname = static_cast<char*>(gpr_malloc(HOST_NAME_MAX));

release notes: yes