### PR TITLE
Update build instructions for PHP to prevent hanging caused by fork

### DIFF
--- a/src/php/README.md
+++ b/src/php/README.md
@@ -100,7 +100,7 @@ $ git clone -b $(curl -L https://grpc.io/release) https://github.com/grpc/grpc
 ```sh
 $ cd grpc
 $ git submodule update --init
-$ make
+$ CXXFLAGS="-DGRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK=1" make
 $ sudo make install
 ```
 

--- a/src/php/ext/grpc/config.m4
+++ b/src/php/ext/grpc/config.m4
@@ -84,7 +84,7 @@ if test "$PHP_GRPC" != "no"; then
 
   PHP_NEW_EXTENSION(grpc, byte_buffer.c call.c call_credentials.c channel.c \
     channel_credentials.c completion_queue.c timeval.c server.c \
-    server_credentials.c php_grpc.c, $ext_shared, , -Wall -Werror -std=c11)
+    server_credentials.c php_grpc.c, $ext_shared, , -Wall -Werror -std=c11 -DGRPC_POSIX_FORK_ALLOW_PTHREAD_ATFORK=1)
 fi
 
 if test "$PHP_COVERAGE" = "yes"; then


### PR DESCRIPTION
This updates the instructions and config for building the PHP library. Specifically, it guides the user to build a gRPC core library and PHP library that doesn't hang on fork.

I was confused because the fork/hanging problem was reported as fixed in v1.17.0. The installation instructions should help guide users to build a functionally-similar package to the PECL installation route.

