### PR TITLE
Disable Nagle algorithm in Windows

### DIFF
--- a/src/core/lib/iomgr/tcp_windows.cc
+++ b/src/core/lib/iomgr/tcp_windows.cc
@@ -88,6 +88,19 @@ static grpc_error* enable_loopback_fast_path(SOCKET sock) {
              : GRPC_WSA_ERROR(status, "WSAIoctl(SIO_LOOPBACK_FAST_PATH)");
 }
 
+static grpc_error* enable_socket_low_latency(SOCKET sock) {
+  int status;
+  BOOL param = TRUE;
+  status = ::setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, 
+                        reinterpret_cast<char*>(&param), sizeof(param));
+  if (status == SOCKET_ERROR) {
+    status = WSAGetLastError();
+  }
+  return status == 0
+             ? GRPC_ERROR_NONE
+             : GRPC_WSA_ERROR(status, "setsockopt(TCP_NODELAY)");
+}
+
 grpc_error* grpc_tcp_prepare_socket(SOCKET sock) {
   grpc_error* err;
   err = grpc_tcp_set_non_block(sock);
@@ -95,6 +108,8 @@ grpc_error* grpc_tcp_prepare_socket(SOCKET sock) {
   err = set_dualstack(sock);
   if (err != GRPC_ERROR_NONE) return err;
   err = enable_loopback_fast_path(sock);
+  if (err != GRPC_ERROR_NONE) return err;
+  err = enable_socket_low_latency(sock);
   if (err != GRPC_ERROR_NONE) return err;
   return GRPC_ERROR_NONE;
 }

--- a/src/core/lib/iomgr/tcp_windows.cc
+++ b/src/core/lib/iomgr/tcp_windows.cc
@@ -91,14 +91,13 @@ static grpc_error* enable_loopback_fast_path(SOCKET sock) {
 static grpc_error* enable_socket_low_latency(SOCKET sock) {
   int status;
   BOOL param = TRUE;
-  status = ::setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, 
+  status = ::setsockopt(sock, IPPROTO_TCP, TCP_NODELAY,
                         reinterpret_cast<char*>(&param), sizeof(param));
   if (status == SOCKET_ERROR) {
     status = WSAGetLastError();
   }
-  return status == 0
-             ? GRPC_ERROR_NONE
-             : GRPC_WSA_ERROR(status, "setsockopt(TCP_NODELAY)");
+  return status == 0 ? GRPC_ERROR_NONE
+                     : GRPC_WSA_ERROR(status, "setsockopt(TCP_NODELAY)");
 }
 
 grpc_error* grpc_tcp_prepare_socket(SOCKET sock) {


### PR DESCRIPTION
Nagle algorithm is disabled by default for posix in `grpc_set_socket_low_latency` in `socket_utils_common_posix.cc`. This change adds similar functionality for the windows implementation. 