### PR TITLE
grpc-performance-kokoro-v5 kokoro perf image changes

### DIFF
--- a/tools/gce/create_linux_kokoro_performance_worker_from_image.sh
+++ b/tools/gce/create_linux_kokoro_performance_worker_from_image.sh
@@ -22,7 +22,7 @@ cd "$(dirname "$0")"
 
 CLOUD_PROJECT=grpc-testing
 ZONE=us-central1-b  # this zone allows 32core machines
-LATEST_PERF_WORKER_IMAGE=grpc-performance-kokoro-v4  # update if newer image exists
+LATEST_PERF_WORKER_IMAGE=grpc-performance-kokoro-v5  # update if newer image exists
 
 INSTANCE_NAME="${1:-grpc-kokoro-performance-server}"
 MACHINE_TYPE="${2:-n1-standard-32}"

--- a/tools/gce/linux_kokoro_performance_worker_init.sh
+++ b/tools/gce/linux_kokoro_performance_worker_init.sh
@@ -219,6 +219,8 @@ touch /tmpfs/READY
 # See https://github.com/grpc/grpc/issues/17794
 sudo sed -i 's/APT::Periodic::Update-Package-Lists "1"/APT::Periodic::Update-Package-Lists "0"/' /etc/apt/apt.conf.d/10periodic
 sudo sed -i 's/APT::Periodic::AutocleanInterval "1"/APT::Periodic::AutocleanInterval "0"/' /etc/apt/apt.conf.d/10periodic
+sudo sed -i 's/APT::Periodic::Update-Package-Lists "1"/APT::Periodic::Update-Package-Lists "0"/' /etc/apt/apt.conf.d/20auto-upgrades
+sudo sed -i 's/APT::Periodic::Unattended-Upgrade "1"/APT::Periodic::Unattended-Upgrade "0"/' /etc/apt/apt.conf.d/20auto-upgrades
 
 # Restart for VM to pick up kernel update
 echo 'Successfully initialized the linux worker, going for reboot in 10 seconds'


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc/pull/17928.

These changes in the kokoro image should fix https://github.com/grpc/grpc/issues/17794, but kokoro jobs need to be upgraded to v5 version of the image by an internal CL for the change to take effect.