### PR TITLE
Fix bug that default root certificates file cannot be found on mac

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCSecureChannelFactory.m
+++ b/src/objective-c/GRPCClient/private/GRPCSecureChannelFactory.m
@@ -58,7 +58,8 @@
     NSString *resourceBundlePath = @"gRPCCertificates.bundle";  // .pem
     // Do not use NSBundle.mainBundle, as it's nil for tests of library projects.
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-    NSBundle *resourceBundle = [NSBundle bundleWithURL:[[bundle resourceURL] URLByAppendingPathComponent:resourceBundlePath]];
+    NSBundle *resourceBundle = [NSBundle
+        bundleWithURL:[[bundle resourceURL] URLByAppendingPathComponent:resourceBundlePath]];
     NSString *path = [resourceBundle pathForResource:rootsPEM ofType:@"pem"];
     setenv(GRPC_DEFAULT_SSL_ROOTS_FILE_PATH_ENV_VAR,
            [path cStringUsingEncoding:NSUTF8StringEncoding], 1);

--- a/src/objective-c/GRPCClient/private/GRPCSecureChannelFactory.m
+++ b/src/objective-c/GRPCClient/private/GRPCSecureChannelFactory.m
@@ -54,10 +54,12 @@
                                error:(NSError **)errorPtr {
   static dispatch_once_t loading;
   dispatch_once(&loading, ^{
-    NSString *defaultPath = @"gRPCCertificates.bundle/roots";  // .pem
+    NSString *rootsPEM = @"roots";
+    NSString *resourceBundlePath = @"gRPCCertificates.bundle";  // .pem
     // Do not use NSBundle.mainBundle, as it's nil for tests of library projects.
     NSBundle *bundle = [NSBundle bundleForClass:[self class]];
-    NSString *path = [bundle pathForResource:defaultPath ofType:@"pem"];
+    NSBundle *resourceBundle = [NSBundle bundleWithURL:[[bundle resourceURL] URLByAppendingPathComponent:resourceBundlePath]];
+    NSString *path = [resourceBundle pathForResource:rootsPEM ofType:@"pem"];
     setenv(GRPC_DEFAULT_SSL_ROOTS_FILE_PATH_ENV_VAR,
            [path cStringUsingEncoding:NSUTF8StringEncoding], 1);
   });


### PR DESCRIPTION
The original code search "roots.pem" in a directory that only works on iOS. The directory structure is different on Mac. This change fixes the problem so that it works for both.