### PR TITLE
Use different service_account_key for interop tests

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_interop_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_interop_rc
@@ -30,7 +30,6 @@ git clone --recursive https://github.com/grpc/grpc-node ./../grpc-node
 git clone --recursive https://github.com/grpc/grpc-dart ./../grpc-dart
 git clone --recursive https://github.com/grpc/grpc-dotnet ./../grpc-dotnet
 
-# Download json file.
+# Grab the service account key to run interop tests against prod backends.
 mkdir ~/service_account
-gsutil cp gs://grpc-testing-secrets/interop/service_account/GrpcTesting-726eb1347f15.json ~/service_account
-export GOOGLE_APPLICATION_CREDENTIALS=~/service_account/GrpcTesting-726eb1347f15.json
+cp "${KOKORO_KEYSTORE_DIR}/73836_interop_to_prod_tests_service_account_key" ~/service_account/grpc-testing-ebe7c1ac7381.json || true

--- a/tools/internal_ci/linux/grpc_interop_toprod.cfg
+++ b/tools/internal_ci/linux/grpc_interop_toprod.cfg
@@ -28,3 +28,12 @@ env_vars {
   key: "RUN_TESTS_FLAGS"
   value: "-l all --cloud_to_prod --cloud_to_prod_auth --prod_servers default gateway_v4 --use_docker --internal_ci -t -j 8 --bq_result_table interop_results"
 }
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73836
+      keyname: "interop_to_prod_tests_service_account_key"
+    }
+  }
+}

--- a/tools/internal_ci/linux/pull_request/grpc_interop_toprod.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_interop_toprod.cfg
@@ -28,3 +28,12 @@ env_vars {
   key: "RUN_TESTS_FLAGS"
   value: "-l all --cloud_to_prod --cloud_to_prod_auth --prod_servers default gateway_v4 --use_docker --internal_ci -t -j 12"
 }
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73836
+      keyname: "interop_to_prod_tests_service_account_key"
+    }
+  }
+}

--- a/tools/internal_ci/macos/grpc_interop_toprod.cfg
+++ b/tools/internal_ci/macos/grpc_interop_toprod.cfg
@@ -17,11 +17,19 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_interop_toprod.sh"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
-gfile_resources: "/bigstore/grpc-testing-secrets/interop/service_account/GrpcTesting-726eb1347f15.json"
 timeout_mins: 240
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"
     regex: "github/grpc/reports/**"
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73836
+      keyname: "interop_to_prod_tests_service_account_key"
+    }
   }
 }

--- a/tools/internal_ci/macos/grpc_interop_toprod.sh
+++ b/tools/internal_ci/macos/grpc_interop_toprod.sh
@@ -33,7 +33,7 @@ tools/run_tests/run_interop_tests.py -l c++ \
     --cloud_to_prod --cloud_to_prod_auth \
     --google_default_creds_use_key_file \
     --prod_servers default gateway_v4 \
-    --service_account_key_file="${KOKORO_GFILE_DIR}/GrpcTesting-726eb1347f15.json" \
+    --service_account_key_file="${KOKORO_KEYSTORE_DIR}/73836_interop_to_prod_tests_service_account_key" \
     --skip_compute_engine_creds --internal_ci -t -j 4 || FAILED="true"
 
 tools/internal_ci/helper_scripts/delete_nonartifacts.sh || true

--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -823,9 +823,10 @@ def auth_options(language,
 
     if not service_account_key_file:
         # this file path only works inside docker
-        service_account_key_file = '/root/service_account/GrpcTesting-726eb1347f15.json'
+        service_account_key_file = '/root/service_account/grpc-testing-ebe7c1ac7381.json'
     oauth_scope_arg = '--oauth_scope=https://www.googleapis.com/auth/xapi.zoo'
     key_file_arg = '--service_account_key_file=%s' % service_account_key_file
+    # default compute engine credentials associated with the testing VMs in "grpc-testing" cloud project
     default_account_arg = '--default_service_account=830293263384-compute@developer.gserviceaccount.com'
 
     if test_case in ['jwt_token_creds', 'per_rpc_creds', 'oauth2_auth_token']:


### PR DESCRIPTION
use a dedicated service account key for interop to prod tests.

Currently a service account key is used which has more privileges than needed for interop tests.
I created a dedicated service account just for interop to prod tests. 
Storing in keystore is better than storing in GCS.

Also see internal b/79912536 for more context.