### PR TITLE
Add non-internal build.cfg files for bazel RBE jobs

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_rbe_asan.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_asan.cfg
@@ -1,0 +1,30 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_asan_on_foundry.sh"
+timeout_mins: 60
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}

--- a/tools/internal_ci/linux/grpc_bazel_rbe_dbg.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_dbg.cfg
@@ -1,0 +1,30 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_dbg.sh"
+timeout_mins: 60
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}

--- a/tools/internal_ci/linux/grpc_bazel_rbe_incompatible_changes.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_incompatible_changes.cfg
@@ -1,0 +1,30 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_bazel_rbe_incompatible_changes.sh"
+timeout_mins: 60
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}

--- a/tools/internal_ci/linux/grpc_bazel_rbe_msan.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_msan.cfg
@@ -1,0 +1,30 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_msan_on_foundry.sh"
+timeout_mins: 60
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}

--- a/tools/internal_ci/linux/grpc_bazel_rbe_opt.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_opt.cfg
@@ -1,0 +1,30 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_opt.sh"
+timeout_mins: 60
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}

--- a/tools/internal_ci/linux/grpc_bazel_rbe_tsan.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_tsan.cfg
@@ -1,0 +1,30 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_tsan_on_foundry.sh"
+timeout_mins: 60
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}

--- a/tools/internal_ci/linux/grpc_bazel_rbe_ubsan.cfg
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_ubsan.cfg
@@ -1,0 +1,30 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_ubsan_on_foundry.sh"
+timeout_mins: 60
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_asan.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_asan.cfg
@@ -1,0 +1,30 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_asan_on_foundry.sh"
+timeout_mins: 60
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_dbg.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_dbg.cfg
@@ -1,0 +1,30 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_dbg.sh"
+timeout_mins: 60
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_msan.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_msan.cfg
@@ -1,0 +1,30 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_msan_on_foundry.sh"
+timeout_mins: 60
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_opt.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_opt.cfg
@@ -1,0 +1,30 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_bazel_on_foundry_opt.sh"
+timeout_mins: 60
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_tsan.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_tsan.cfg
@@ -1,0 +1,30 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_tsan_on_foundry.sh"
+timeout_mins: 60
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}

--- a/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_ubsan.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_bazel_rbe_ubsan.cfg
@@ -1,0 +1,30 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/pull_request/grpc_ubsan_on_foundry.sh"
+timeout_mins: 60
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}

--- a/tools/internal_ci/windows/grpc_bazel_rbe_dbg.cfg
+++ b/tools/internal_ci/windows/grpc_bazel_rbe_dbg.cfg
@@ -1,0 +1,32 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/windows/bazel_rbe.bat"
+
+timeout_mins: 60
+
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/resultstore_api_key"
+gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/rbe-windows-credentials.json"
+
+bazel_setting {
+  # In order for Kokoro to recognize this as a bazel build and publish the bazel resultstore link,
+  # the bazel_setting section needs to be present and "upsalite_frontend_address" needs to be
+  # set. The rest of configuration from bazel_setting is unused (we configure everything when bazel
+  # command is invoked).
+  upsalite_frontend_address: "https://source.cloud.google.com"
+}


### PR DESCRIPTION
Currently bazel RBE jobs build.cfg files live in the internal repository, which is not well aligned with how all the other kokoro builds work. This PR is a preparation for migrating the .cfg files to github to unify and simplify the config of grpc kokoro jobs.