### PR TITLE
Illumos / SmartOS / Solaris compatibility fix

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
@@ -24,6 +24,12 @@
 #include <string.h>
 #include <sys/ioctl.h>
 
+#ifdef __sun
+#include <sys/filio.h>
+#include <unistd.h>
+#include <stropts.h>
+#endif
+
 #include "src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h"
 
 #include <grpc/support/alloc.h>


### PR DESCRIPTION
For FIONREAD you need 'sys/filio.h' on Solaris(like) OS'es.

In order to use ioctl() you need 'unistd.h' and 'stropts.h'.