### PR TITLE
Use requirements.bazel.txt to generate Python documents

### DIFF
--- a/tools/distrib/python/docgen.py
+++ b/tools/distrib/python/docgen.py
@@ -44,7 +44,7 @@ PROJECT_ROOT = os.path.abspath(os.path.join(SCRIPT_DIR, '..', '..', '..'))
 
 CONFIG = args.config
 SETUP_PATH = os.path.join(PROJECT_ROOT, 'setup.py')
-REQUIREMENTS_PATH = os.path.join(PROJECT_ROOT, 'requirements.txt')
+REQUIREMENTS_PATH = os.path.join(PROJECT_ROOT, 'requirements.bazel.txt')
 DOC_PATH = os.path.join(PROJECT_ROOT, 'doc/build')
 INCLUDE_PATH = os.path.join(PROJECT_ROOT, 'include')
 LIBRARY_PATH = os.path.join(PROJECT_ROOT, 'libs/{}'.format(CONFIG))


### PR DESCRIPTION
The recent introduction of `grpcio-status` depends on `googleapis-common-protos` which is not in `requirements.txt`, and it breaks document generation.

The `requirements.bazel.txt` includes all dependencies for all gRPC Python packages (grpcio & grpcio-*). Since we use Bazel to run all of our unit tests, `requirements.bazel.txt` should be always updated. Hence, I think it is better to directly depend on `requirements.bazel.txt` instead of adding arbitrary packages into the installation list in `docgen.py`.