### PR TITLE
Add wait-for-ready example for gRPC Python

### DIFF
--- a/examples/python/wait_for_ready/BUILD.bazel
+++ b/examples/python/wait_for_ready/BUILD.bazel
@@ -1,0 +1,32 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@grpc_python_dependencies//:requirements.bzl", "requirement")
+
+py_library(
+    name = "wait_for_ready_example",
+    testonly = 1,
+    srcs = ["wait_for_ready_example.py"],
+    deps = [
+        "//src/python/grpcio/grpc:grpcio",
+        "//examples:py_helloworld",
+    ],
+)
+
+py_test(
+    name = "test/_wait_for_ready_example_test",
+    srcs = ["test/_wait_for_ready_example_test.py"],
+    deps = [":wait_for_ready_example",],
+    size = "small",
+)

--- a/examples/python/wait_for_ready/README.md
+++ b/examples/python/wait_for_ready/README.md
@@ -1,6 +1,6 @@
 # gRPC Python Example for Wait-for-ready
 
-The default behavior of an RPC will fail instantly if the server is not ready yet. This example demonstrates how to change that behavior.
+The default behavior of an RPC is to fail instantly if the server is not ready yet. This example demonstrates how to change that behavior.
 
 
 ### Definition of 'wait-for-ready' semantics

--- a/examples/python/wait_for_ready/README.md
+++ b/examples/python/wait_for_ready/README.md
@@ -1,0 +1,32 @@
+# gRPC Python Example for Wait-for-ready
+
+The default behavior of an RPC will fail instantly if the server is not ready yet. This example demonstrates how to change that behavior.
+
+
+### Definition of 'wait-for-ready' semantics
+> If an RPC is issued but the channel is in TRANSIENT_FAILURE or SHUTDOWN states, the RPC is unable to be transmitted promptly. By default, gRPC implementations SHOULD fail such RPCs immediately. This is known as "fail fast," but the usage of the term is historical. RPCs SHOULD NOT fail as a result of the channel being in other states (CONNECTING, READY, or IDLE).
+> 
+> gRPC implementations MAY provide a per-RPC option to not fail RPCs as a result of the channel being in TRANSIENT_FAILURE state. Instead, the implementation queues the RPCs until the channel is READY. This is known as "wait for ready." The RPCs SHOULD still fail before READY if there are unrelated reasons, such as the channel is SHUTDOWN or the RPC's deadline is reached.
+> 
+> From https://github.com/grpc/grpc/blob/master/doc/wait-for-ready.md 
+
+
+### Use cases for 'wait-for-ready'
+
+When developers spin up gRPC clients and servers at the same time, it is very like to fail first couple RPC calls due to unavailability of the server. If developers failed to prepare for this situation, the result can be catastrophic. But with 'wait-for-ready' semantics, developers can initialize the client and server in any order, especially useful in testing.
+
+Also, developers may ensure the server is up before starting client. But in some cases like transient network failure may result in a temporary unavailability of the server. With 'wait-for-ready' semantics, those RPC calls will automatically wait until the server is ready to accept incoming requests.
+
+
+### DEMO Snippets
+
+```Python
+# Per RPC level
+stub = ...Stub(...)
+
+stub.important_transaction_1(..., wait_for_ready=True)
+stub.unimportant_transaction_2(...)
+stub.important_transaction_3(..., wait_for_ready=True)
+stub.unimportant_transaction_4(...)
+# The unimportant transactions can be status report, or health check, etc.
+```

--- a/examples/python/wait_for_ready/test/_wait_for_ready_example_test.py
+++ b/examples/python/wait_for_ready/test/_wait_for_ready_example_test.py
@@ -1,0 +1,31 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests of the wait-for-ready example."""
+
+import unittest
+import logging
+
+from examples.python.wait_for_ready import wait_for_ready_example
+
+
+class WaitForReadyExampleTest(unittest.TestCase):
+
+    def test_wait_for_ready_example(self):
+        wait_for_ready_example.main()
+        # No unhandled exception raised, no deadlock, test passed!
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    unittest.main(verbosity=2)

--- a/examples/python/wait_for_ready/wait_for_ready_example.py
+++ b/examples/python/wait_for_ready/wait_for_ready_example.py
@@ -1,0 +1,112 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The Python example of utilizing wait-for-ready flag."""
+
+from __future__ import print_function
+import logging
+from concurrent import futures
+import socket
+import threading
+
+import grpc
+
+from examples.protos import helloworld_pb2
+from examples.protos import helloworld_pb2_grpc
+
+_LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.INFO)
+
+_ONE_DAY_IN_SECONDS = 60 * 60 * 24
+
+
+def get_free_loopback_tcp_port():
+    tcp = socket.socket(socket.AF_INET6)
+    tcp.bind(('', 0))
+    address_tuple = tcp.getsockname()
+    return tcp, "[::1]:%s" % (address_tuple[1])
+
+
+class Greeter(helloworld_pb2_grpc.GreeterServicer):
+
+    def SayHello(self, request, unused_context):
+        return helloworld_pb2.HelloReply(message='Hello, %s!' % request.name)
+
+
+def create_server(server_address):
+    server = grpc.server(futures.ThreadPoolExecutor())
+    helloworld_pb2_grpc.add_GreeterServicer_to_server(Greeter(), server)
+    bound_port = server.add_insecure_port(server_address)
+    assert bound_port == int(server_address.split(':')[-1])
+    return server
+
+
+def process(stub, wait_for_ready=None):
+    try:
+        response = stub.SayHello(
+            helloworld_pb2.HelloRequest(name='you'),
+            wait_for_ready=wait_for_ready)
+        message = response.message
+    except grpc.RpcError as rpc_error:
+        assert rpc_error.code() == grpc.StatusCode.UNAVAILABLE
+        assert not wait_for_ready
+        message = rpc_error
+    else:
+        assert wait_for_ready
+    _LOGGER.info("Wait-for-ready %s, client received: %s", "enabled"
+                 if wait_for_ready else "disabled", message)
+
+
+def main():
+    # Pick a random free port
+    tcp, server_address = get_free_loopback_tcp_port()
+
+    # Register connectivity event to notify main thread
+    transient_failure_event = threading.Event()
+
+    def wait_for_transient_failure(channel_connectivity):
+        if channel_connectivity == grpc.ChannelConnectivity.TRANSIENT_FAILURE:
+            transient_failure_event.set()
+
+    # Create gRPC channel
+    channel = grpc.insecure_channel(server_address)
+    channel.subscribe(wait_for_transient_failure)
+    stub = helloworld_pb2_grpc.GreeterStub(channel)
+
+    # Fire an RPC without wait_for_ready
+    thread_disabled_wait_for_ready = threading.Thread(
+        target=process, args=(stub, False))
+    thread_disabled_wait_for_ready.start()
+    # Fire an RPC with wait_for_ready
+    thread_enabled_wait_for_ready = threading.Thread(
+        target=process, args=(stub, True))
+    thread_enabled_wait_for_ready.start()
+
+    # Wait for the channel entering TRANSIENT FAILURE state.
+    tcp.close()
+    transient_failure_event.wait()
+    server = create_server(server_address)
+    server.start()
+
+    # Expected to fail with StatusCode.UNAVAILABLE.
+    thread_disabled_wait_for_ready.join()
+    # Expected to success.
+    thread_enabled_wait_for_ready.join()
+
+    server.stop(None)
+    channel.close()
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    main()


### PR DESCRIPTION
I struggled a little about this example. The code has sit for a while. The wait-for-ready mechanism is quite simple to use. The only value-able is `wait_for_ready=True`. So, the options to implement this example is either:

1. A simple Greeter client with `wait_for_ready=True`.
2. A script demonstrating the difference with and without `wait_for_ready`.

For the sake of adding a test at least runnable, I chose option 2. However, it does complicate the example.