### PR TITLE
Propagate KeyboardInterrupt above completion queue

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pxd.pxi
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-cdef grpc_event _next(grpc_completion_queue *c_completion_queue, deadline)
+cdef grpc_event _next(grpc_completion_queue *c_completion_queue, deadline) except *
 
 
 cdef _interpret_event(grpc_event c_event)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pyx.pxi
@@ -20,7 +20,7 @@ import time
 cdef int _INTERRUPT_CHECK_PERIOD_MS = 200
 
 
-cdef grpc_event _next(grpc_completion_queue *c_completion_queue, deadline):
+cdef grpc_event _next(grpc_completion_queue *c_completion_queue, deadline) except *:
   cdef gpr_timespec c_increment
   cdef gpr_timespec c_timeout
   cdef gpr_timespec c_deadline


### PR DESCRIPTION
Currently, if one of the thread of a gRPC Python client is blocking by `_next`, it will ignore `KeyboardInterrupt` until it is done. I missed this function in #16643.