### PR TITLE
Remove example build tests that do not depend on changes in a PR or master branch

### DIFF
--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1064,33 +1064,6 @@ class ObjCLanguage(object):
             self.config.job_spec(
                 ['src/objective-c/tests/build_one_example.sh'],
                 timeout_seconds=10 * 60,
-                shortname='objc-build-example-helloworld',
-                cpu_cost=1e6,
-                environ={
-                    'SCHEME': 'HelloWorld',
-                    'EXAMPLE_PATH': 'examples/objective-c/helloworld'
-                }),
-            self.config.job_spec(
-                ['src/objective-c/tests/build_one_example.sh'],
-                timeout_seconds=10 * 60,
-                shortname='objc-build-example-routeguide',
-                cpu_cost=1e6,
-                environ={
-                    'SCHEME': 'RouteGuideClient',
-                    'EXAMPLE_PATH': 'examples/objective-c/route_guide'
-                }),
-            self.config.job_spec(
-                ['src/objective-c/tests/build_one_example.sh'],
-                timeout_seconds=10 * 60,
-                shortname='objc-build-example-authsample',
-                cpu_cost=1e6,
-                environ={
-                    'SCHEME': 'AuthSample',
-                    'EXAMPLE_PATH': 'examples/objective-c/auth_sample'
-                }),
-            self.config.job_spec(
-                ['src/objective-c/tests/build_one_example.sh'],
-                timeout_seconds=10 * 60,
                 shortname='objc-build-example-sample',
                 cpu_cost=1e6,
                 environ={


### PR DESCRIPTION
The affected build tests in this PR are example apps which download released versions of gRPC from Cocoapods, which is not related to changes in a PR or the master branch. So we should not run them with the CI system. Instead these build tests should be run after each release of gRPC ObjC package to verify the release is successful. This PR removes these tests from CI, and it will be followed by update of the release process doc.