### PR TITLE
Fixed PyYaml yaml.load warning

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -257,9 +257,9 @@ def grpc_test_only_deps():
     if "com_github_yaml_pyyaml" not in native.existing_rules():
         http_archive(
             name = "com_github_yaml_pyyaml",
-            sha256 = "6b4314b1b2051ddb9d4fcd1634e1fa9c1bb4012954273c9ff3ef689f6ec6c93e",
-            strip_prefix = "pyyaml-3.12",
-            url = "https://github.com/yaml/pyyaml/archive/3.12.zip",
+            sha256 = "f0a35d7f282a6d6b1a4f3f3965ef5c124e30ed27a0088efb97c0977268fd671f",
+            strip_prefix = "pyyaml-5.1",
+            url = "https://github.com/yaml/pyyaml/archive/5.1.zip",
             build_file = "@com_github_grpc_grpc//third_party:yaml.BUILD",
         )
 

--- a/templates/tools/dockerfile/apt_get_basic.include
+++ b/templates/tools/dockerfile/apt_get_basic.include
@@ -23,7 +23,6 @@ RUN apt-get update && apt-get install -y ${'\\'}
   strace ${'\\'}
   python-dev ${'\\'}
   python-setuptools ${'\\'}
-  python-yaml ${'\\'}
   telnet ${'\\'}
   unzip ${'\\'}
   wget ${'\\'}

--- a/templates/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile.template
@@ -16,6 +16,8 @@
   
   FROM debian:stretch
   
+  ARG DEBIAN_FRONTEND=noninteractive
+  
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../python_deps.include"/>
   <%include file="../../csharp_deps.include"/>

--- a/templates/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile.template
@@ -15,6 +15,8 @@
   # limitations under the License.
   
   FROM debian:stretch
+
+  ARG DEBIAN_FRONTEND=noninteractive
   
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../python_deps.include"/>

--- a/templates/tools/dockerfile/python_deps.include
+++ b/templates/tools/dockerfile/python_deps.include
@@ -11,4 +11,4 @@ RUN apt-get update && apt-get install -y ${'\\'}
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1

--- a/templates/tools/dockerfile/python_stretch.include
+++ b/templates/tools/dockerfile/python_stretch.include
@@ -1,5 +1,7 @@
 FROM debian:stretch
-  
+
+ARG DEBIAN_FRONTEND=noninteractive
+
 <%include file="./apt_get_basic.include"/>
 <%include file="./gcp_api_libraries.include"/>
 <%include file="./apt_get_python_27.include"/>

--- a/templates/tools/dockerfile/test/csharp_stretch_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/csharp_stretch_x64/Dockerfile.template
@@ -16,6 +16,8 @@
   
   FROM debian:stretch
   
+  ARG DEBIAN_FRONTEND=noninteractive
+  
   <%include file="../../apt_get_basic.include"/>
   <%include file="../../gcp_api_libraries.include"/>
   <%include file="../../python_deps.include"/>

--- a/templates/tools/dockerfile/test/sanity/Dockerfile.template
+++ b/templates/tools/dockerfile/test/sanity/Dockerfile.template
@@ -28,8 +28,8 @@
         libtool ${"\\"}
         curl ${"\\"}
         shellcheck
-  RUN python2 -m pip install simplejson mako virtualenv lxml
-  RUN python3 -m pip install simplejson mako virtualenv lxml
+  RUN python2 -m pip install simplejson mako virtualenv lxml pyyaml==5.1
+  RUN python3 -m pip install simplejson mako virtualenv lxml pyyaml==5.1
 
   <%include file="../../clang5.include"/>
   <%include file="../../bazel.include"/>

--- a/test/cpp/naming/gen_build_yaml.py
+++ b/test/cpp/naming/gen_build_yaml.py
@@ -59,7 +59,7 @@ def _resolver_test_cases(resolver_component_data):
 def main():
   resolver_component_data = ''
   with open('test/cpp/naming/resolver_test_record_groups.yaml') as f:
-    resolver_component_data = yaml.load(f)
+    resolver_component_data = yaml.full_load(f)
 
   json = {
       'resolver_tests_common_zone_name': resolver_component_data['resolver_tests_common_zone_name'],

--- a/test/cpp/naming/utils/dns_server.py
+++ b/test/cpp/naming/utils/dns_server.py
@@ -68,7 +68,7 @@ def start_local_dns_server(args):
     _push_record(name, dns.Record_TXT(*txt_data_list, ttl=r_ttl))
 
   with open(args.records_config_path) as config:
-    test_records_config = yaml.load(config)
+    test_records_config = yaml.full_load(config)
   common_zone_name = test_records_config['resolver_tests_common_zone_name']
   for group in test_records_config['resolver_component_tests']:
     for name in group['records'].keys():

--- a/test/cpp/qps/gen_build_yaml.py
+++ b/test/cpp/qps/gen_build_yaml.py
@@ -29,7 +29,7 @@ sys.path.append(run_tests_root)
 
 import performance.scenario_config as scenario_config
 
-configs_from_yaml = yaml.load(open(os.path.join(os.path.dirname(sys.argv[0]), '../../../build.yaml')))['configs'].keys()
+configs_from_yaml = yaml.full_load(open(os.path.join(os.path.dirname(sys.argv[0]), '../../../build.yaml')))['configs'].keys()
 
 def mutate_scenario(scenario_json, is_tsan):
   # tweak parameters to get fast test times

--- a/tools/buildgen/build-cleaner.py
+++ b/tools/buildgen/build-cleaner.py
@@ -65,7 +65,7 @@ def clean_elem(indict):
 
 for filename in sys.argv[1:]:
     with open(filename) as f:
-        js = yaml.load(f)
+        js = yaml.full_load(f)
     js = rebuild_as_ordered_dict(js, _TOP_LEVEL_KEYS)
     for grp in ['filegroups', 'libs', 'targets']:
         if grp not in js: continue

--- a/tools/buildgen/mako_renderer.py
+++ b/tools/buildgen/mako_renderer.py
@@ -109,7 +109,7 @@ def main(argv):
         elif opt == '-d':
             assert not got_preprocessed_input
             with open(arg, 'r') as dict_file:
-                bunch.merge_json(json_dict, yaml.load(dict_file.read()))
+                bunch.merge_json(json_dict, yaml.full_load(dict_file.read()))
         elif opt == '-p':
             plugins.append(import_plugin(arg))
         elif opt == '-w':

--- a/tools/codegen/core/gen_stats_data.py
+++ b/tools/codegen/core/gen_stats_data.py
@@ -22,7 +22,7 @@ import yaml
 import json
 
 with open('src/core/lib/debug/stats_data.yaml') as f:
-    attrs = yaml.load(f.read())
+    attrs = yaml.full_load(f.read())
 
 REQUIRED_FIELDS = ['name', 'doc']
 

--- a/tools/dockerfile/grpc_artifact_linux_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_linux_x86/Dockerfile
@@ -39,7 +39,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \

--- a/tools/dockerfile/grpc_clang_tidy/Dockerfile
+++ b/tools/dockerfile/grpc_clang_tidy/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 ADD clang_tidy_all_the_things.sh /
 

--- a/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharp/Dockerfile
@@ -14,6 +14,8 @@
 
 FROM debian:stretch
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -39,7 +41,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -62,7 +63,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #================
 # C# dependencies

--- a/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_csharpcoreclr/Dockerfile
@@ -14,6 +14,8 @@
 
 FROM debian:stretch
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -39,7 +41,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -62,7 +63,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #================
 # C# dependencies

--- a/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_cxx/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -63,7 +62,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #=================
 # C++ dependencies

--- a/tools/dockerfile/interoptest/grpc_interop_go/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_go/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_go1.11/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_go1.11/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_go1.7/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_go1.7/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_go1.8/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_go1.8/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 # Define the default command.
 CMD ["bash"]

--- a/tools/dockerfile/interoptest/grpc_interop_http2/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_http2/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 RUN pip install twisted h2==2.6.1 hyper
 

--- a/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_node/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -63,7 +62,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #==================
 # Node dependencies

--- a/tools/dockerfile/interoptest/grpc_interop_nodepurejs/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_nodepurejs/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \

--- a/tools/dockerfile/interoptest/grpc_interop_php/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_php/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \

--- a/tools/dockerfile/interoptest/grpc_interop_python/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_python/Dockerfile
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 FROM debian:stretch
-  
+
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -39,7 +41,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \

--- a/tools/dockerfile/interoptest/grpc_interop_ruby/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_ruby/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -63,7 +62,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #==================
 # Ruby dependencies

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 
 #========================

--- a/tools/dockerfile/test/csharp_stretch_x64/Dockerfile
+++ b/tools/dockerfile/test/csharp_stretch_x64/Dockerfile
@@ -14,6 +14,8 @@
 
 FROM debian:stretch
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -39,7 +41,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -66,7 +67,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #================
 # C# dependencies

--- a/tools/dockerfile/test/cxx_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_jessie_x64/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -67,7 +66,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #=================
 # C++ dependencies

--- a/tools/dockerfile/test/cxx_jessie_x86/Dockerfile
+++ b/tools/dockerfile/test/cxx_jessie_x86/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -67,7 +66,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #=================
 # C++ dependencies

--- a/tools/dockerfile/test/cxx_sanitizers_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_sanitizers_jessie_x64/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -68,7 +67,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #=================
 # C++ dependencies (purposely excluding Clang because it's part of the base image)

--- a/tools/dockerfile/test/cxx_ubuntu1404_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_ubuntu1404_x64/Dockerfile
@@ -39,7 +39,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -66,7 +65,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #=================
 # C++ dependencies

--- a/tools/dockerfile/test/cxx_ubuntu1604_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_ubuntu1604_x64/Dockerfile
@@ -39,7 +39,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -66,7 +65,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #=================
 # C++ dependencies

--- a/tools/dockerfile/test/cxx_ubuntu1710_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_ubuntu1710_x64/Dockerfile
@@ -39,7 +39,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -66,7 +65,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #=================
 # C++ dependencies

--- a/tools/dockerfile/test/fuzzer/Dockerfile
+++ b/tools/dockerfile/test/fuzzer/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -67,7 +66,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #=================
 # C++ dependencies

--- a/tools/dockerfile/test/node_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/node_jessie_x64/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -78,7 +77,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #==================
 # Node dependencies

--- a/tools/dockerfile/test/php7_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/php7_jessie_x64/Dockerfile
@@ -78,7 +78,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #=================	
 # PHP Test dependencies	

--- a/tools/dockerfile/test/php_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/php_jessie_x64/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -67,7 +66,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #=================
 # PHP dependencies

--- a/tools/dockerfile/test/python_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/python_jessie_x64/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -67,7 +66,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 # Install pip and virtualenv for Python 3.4
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.4

--- a/tools/dockerfile/test/python_stretch_2.7_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_2.7_x64/Dockerfile
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 FROM debian:stretch
-  
+
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -39,7 +41,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \

--- a/tools/dockerfile/test/python_stretch_3.5_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_3.5_x64/Dockerfile
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 FROM debian:stretch
-  
+
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -39,7 +41,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \

--- a/tools/dockerfile/test/python_stretch_3.6_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_3.6_x64/Dockerfile
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 FROM debian:stretch
-  
+
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -39,7 +41,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \

--- a/tools/dockerfile/test/python_stretch_3.7_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_3.7_x64/Dockerfile
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 FROM debian:stretch
-  
+
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -39,7 +41,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \

--- a/tools/dockerfile/test/python_stretch_3.8_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_3.8_x64/Dockerfile
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 FROM debian:stretch
-  
+
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -39,7 +41,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \

--- a/tools/dockerfile/test/ruby_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/ruby_jessie_x64/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -67,7 +66,7 @@ RUN apt-get update && apt-get install -y \
 # Install Python packages from PyPI
 RUN pip install --upgrade pip==10.0.1
 RUN pip install virtualenv
-RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0
+RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 twisted==17.5.0 pyyaml==5.1
 
 #==================
 # Ruby dependencies

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 FROM debian:stretch
-  
+
+ARG DEBIAN_FRONTEND=noninteractive
+
 # Install Git and basic packages.
 RUN apt-get update && apt-get install -y \
   autoconf \
@@ -39,7 +41,6 @@ RUN apt-get update && apt-get install -y \
   strace \
   python-dev \
   python-setuptools \
-  python-yaml \
   telnet \
   unzip \
   wget \
@@ -82,8 +83,8 @@ RUN apt-get update && apt-get install -y \
       libtool \
       curl \
       shellcheck
-RUN python2 -m pip install simplejson mako virtualenv lxml
-RUN python3 -m pip install simplejson mako virtualenv lxml
+RUN python2 -m pip install simplejson mako virtualenv lxml pyyaml==5.1
+RUN python3 -m pip install simplejson mako virtualenv lxml pyyaml==5.1
 
 RUN apt-get update && apt-get -y install wget xz-utils
 RUN wget http://releases.llvm.org/5.0.0/clang+llvm-5.0.0-linux-x86_64-ubuntu14.04.tar.xz

--- a/tools/line_count/yaml2csv.py
+++ b/tools/line_count/yaml2csv.py
@@ -28,7 +28,7 @@ argp.add_argument(
 argp.add_argument('-o', '--output', type=str, default='out.csv')
 args = argp.parse_args()
 
-data = yaml.load(open(args.input).read())
+data = yaml.full_load(open(args.input).read())
 with open(args.output, 'w') as outf:
     writer = csv.DictWriter(
         outf, ['date', 'name', 'language', 'code', 'comment', 'blank'])

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1229,7 +1229,7 @@ class Sanity(object):
                     cmd['script'].split(),
                     timeout_seconds=30 * 60,
                     environ=environ,
-                    cpu_cost=cmd.get('cpu_cost', 1)) for cmd in yaml.load(f)
+                    cpu_cost=cmd.get('cpu_cost', 1)) for cmd in yaml.full_load(f)
             ]
 
     def pre_build_steps(self):

--- a/tools/run_tests/sanity/check_version.py
+++ b/tools/run_tests/sanity/check_version.py
@@ -58,7 +58,7 @@ else:
     check_version = lambda version: True
 
 with open('build.yaml', 'r') as f:
-    build_yaml = yaml.load(f.read())
+    build_yaml = yaml.full_load(f.read())
 
 settings = build_yaml['settings']
 


### PR DESCRIPTION
Make all modules use yaml.full_load instead of yaml.load emitting warnings.
Ref: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation