### PR TITLE
Don't new unset alarm

### DIFF
--- a/test/cpp/common/alarm_test.cc
+++ b/test/cpp/common/alarm_test.cc
@@ -347,6 +347,13 @@ TEST(AlarmTest, UnsetDestruction) {
   Alarm alarm;
 }
 
+TEST(AlarmTest, UnsetCancellation) {
+  CompletionQueue cq;
+  Alarm alarm;
+
+  alarm.Cancel();
+}
+
 }  // namespace
 }  // namespace grpc
 


### PR DESCRIPTION
Should reduce overhead and contention when an alarm isn't really going to be used (e.g., in the closed-loop QPS tests)
