### PR TITLE
Revert "Enable SIO_LOOPBACK_FAST_PATH on Windows" (for v1.20.x)

### DIFF
--- a/src/core/lib/iomgr/tcp_windows.cc
+++ b/src/core/lib/iomgr/tcp_windows.cc
@@ -74,27 +74,11 @@ static grpc_error* set_dualstack(SOCKET sock) {
              : GRPC_WSA_ERROR(WSAGetLastError(), "setsockopt(IPV6_V6ONLY)");
 }
 
-static grpc_error* enable_loopback_fast_path(SOCKET sock) {
-  int status;
-  uint32_t param = 1;
-  DWORD ret;
-  status = WSAIoctl(sock, /*SIO_LOOPBACK_FAST_PATH==*/_WSAIOW(IOC_VENDOR, 16),
-                    &param, sizeof(param), NULL, 0, &ret, 0, 0);
-  if (status == SOCKET_ERROR) {
-    status = WSAGetLastError();
-  }
-  return status == 0 || status == WSAEOPNOTSUPP
-             ? GRPC_ERROR_NONE
-             : GRPC_WSA_ERROR(status, "WSAIoctl(SIO_LOOPBACK_FAST_PATH)");
-}
-
 grpc_error* grpc_tcp_prepare_socket(SOCKET sock) {
   grpc_error* err;
   err = grpc_tcp_set_non_block(sock);
   if (err != GRPC_ERROR_NONE) return err;
   err = set_dualstack(sock);
-  if (err != GRPC_ERROR_NONE) return err;
-  err = enable_loopback_fast_path(sock);
   if (err != GRPC_ERROR_NONE) return err;
   return GRPC_ERROR_NONE;
 }


### PR DESCRIPTION
This reverts commit f5f5ee31a25e37d6a19939f837f0089431f9951c.

Reverts https://github.com/grpc/grpc/pull/14905 as it's been confirmed to cause  https://github.com/grpc/grpc/issues/18057.

Also see https://github.com/grpc/grpc/pull/18744.