### PR TITLE
Improve bazel RBE scripts

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh
+++ b/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh
@@ -15,12 +15,6 @@
 
 set -ex
 
-# A temporary solution to give Kokoro credentials.
-# The file name 4321_grpc-testing-service needs to match auth_credential in
-# the build config.
-mkdir -p ${KOKORO_KEYSTORE_DIR}
-cp ${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json ${KOKORO_KEYSTORE_DIR}/4321_grpc-testing-service
-
 # Download bazel
 temp_dir="$(mktemp -d)"
 wget -q https://github.com/bazelbuild/bazel/releases/download/0.23.2/bazel-0.23.2-linux-x86_64 -O "${temp_dir}/bazel"
@@ -45,6 +39,7 @@ bazel \
   test \
   --invocation_id="${BAZEL_INVOCATION_ID}" \
   --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh \
+  --google_credentials="${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db331.json" \
   $@ \
   -- //test/... || FAILED="true"
 

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -22,6 +22,7 @@ set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%
 powershell -Command "[guid]::NewGuid().ToString()" >%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
 set /p BAZEL_INVOCATION_ID=<%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
 
+@rem TODO(jtattermusch): windows RBE should be able to use the same credentials as Linux RBE.
 bazel --bazelrc=tools/remote_build/windows.bazelrc build --invocation_id="%BAZEL_INVOCATION_ID%" --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh :all --incompatible_disallow_filetype=false --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json
 set BAZEL_EXITCODE=%errorlevel%
 

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -12,7 +12,19 @@
 @rem See the License for the specific language governing permissions and
 @rem limitations under the License.
 
-choco install bazel -y --version 0.23.2
+@rem TODO(jtattermusch): make this generate less output
+choco install bazel -y --version 0.23.2 --limit-output
+
 cd github/grpc
-set PATH=%PATH%;C:\python27\
-bazel --bazelrc=tools/remote_build/windows.bazelrc build :all --incompatible_disallow_filetype=false --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json
+set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%
+
+@rem Generate a random UUID and store in "bazel_invocation_ids" artifact file
+powershell -Command "[guid]::NewGuid().ToString()" >%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
+set /p BAZEL_INVOCATION_ID=<%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
+
+bazel --bazelrc=tools/remote_build/windows.bazelrc build --invocation_id="%BAZEL_INVOCATION_ID%" --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh :all --incompatible_disallow_filetype=false --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json
+set BAZEL_EXITCODE=%errorlevel%
+
+@rem TODO(jtattermusch): upload results to bigquery
+
+exit /b %BAZEL_EXITCODE%

--- a/tools/remote_build/kokoro.bazelrc
+++ b/tools/remote_build/kokoro.bazelrc
@@ -21,9 +21,6 @@ build --remote_executor=remotebuildexecution.googleapis.com
 build --tls_enabled=true
 
 build --auth_enabled=true
-# magic location where kokoro script puts the credentials
-build --auth_credentials=/tmpfs/src/keystore/4321_grpc-testing-service
-build --auth_scope=https://www.googleapis.com/auth/cloud-source-tools
 
 build --bes_backend=buildeventservice.googleapis.com
 build --bes_timeout=600s


### PR DESCRIPTION
- make sure that the Windows RBE kokoro jobs generate a "Bazel" link
- first step to unify the credentials used by the bazel RBE kokoro jobs (reduce complexity)