### PR TITLE
Backport #18714 to v1.20.0x

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
@@ -28,8 +28,17 @@
 
   # If needed, update dotnet SDK and put it on path
   ./build/get-dotnet.sh
-  source ./activate.sh
-
+  # Normally we would source ./activate.sh
+  # to add dotnet to PATH, but that would only
+  # work for the build and not for a subsequent
+  # dotnet run from a different shell,
+  # so we create a symlink instead.
+  # TODO(jtattermusch): Come up with a cleaner solution.
+  if [ -f $(pwd)/.dotnet/dotnet ]
+  then
+    ln -s $(pwd)/.dotnet/dotnet /usr/local/bin/dotnet
+  fi
+  
   ./build/get-grpc.sh
 
   cd testassets/InteropTestsWebsite

--- a/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
@@ -25,14 +25,11 @@
   cp -r /var/local/jenkins/service_account $HOME || true
 
   cd /var/local/git/grpc-dotnet
-  
+
   # If needed, update dotnet SDK and put it on path
   ./build/get-dotnet.sh
-  if [ -f $HOME/.dotnet/dotnet ]
-  then
-    ln -s $HOME/.dotnet/dotnet /usr/local/bin/dotnet
-  fi
-  
+  source ./activate.sh
+
   ./build/get-grpc.sh
 
   cd testassets/InteropTestsWebsite

--- a/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
@@ -26,10 +26,7 @@ cd /var/local/git/grpc-dotnet
 
 # If needed, update dotnet SDK and put it on path
 ./build/get-dotnet.sh
-if [ -f $HOME/.dotnet/dotnet ]
-then
-  ln -s $HOME/.dotnet/dotnet /usr/local/bin/dotnet
-fi
+source ./activate.sh
 
 ./build/get-grpc.sh
 

--- a/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
@@ -26,7 +26,16 @@ cd /var/local/git/grpc-dotnet
 
 # If needed, update dotnet SDK and put it on path
 ./build/get-dotnet.sh
-source ./activate.sh
+# Normally we would source ./activate.sh
+# to add dotnet to PATH, but that would only
+# work for the build and not for a subsequent
+# dotnet run from a different shell,
+# so we create a symlink instead.
+# TODO(jtattermusch): Come up with a cleaner solution.
+if [ -f $(pwd)/.dotnet/dotnet ]
+then
+  ln -s $(pwd)/.dotnet/dotnet /usr/local/bin/dotnet
+fi
 
 ./build/get-grpc.sh
 


### PR DESCRIPTION
Backports https://github.com/grpc/grpc/pull/18714 to fix the interop build in the release branch.

The original error: 
https://source.cloud.google.com/results/invocations/8b5a80d4-62b4-4c72-a13e-0f56cc02a702/targets/github%2Fgrpc%2Finterop_docker_build/tests