### PR TITLE
Objective C should use error codes defined by C core

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -34,6 +34,7 @@
 
 #import <Foundation/Foundation.h>
 #import <RxLibrary/GRXWriter.h>
+#include <grpc/status.h>
 
 #include <AvailabilityMacros.h>
 
@@ -53,20 +54,20 @@ extern NSString *const kGRPCErrorDomain;
  */
 typedef NS_ENUM(NSUInteger, GRPCErrorCode) {
   /** The operation was cancelled (typically by the caller). */
-  GRPCErrorCodeCancelled = 1,
+  GRPCErrorCodeCancelled = GRPC_STATUS_CANCELLED,
 
   /**
    * Unknown error. Errors raised by APIs that do not return enough error information may be
    * converted to this error.
    */
-  GRPCErrorCodeUnknown = 2,
+  GRPCErrorCodeUnknown = GRPC_STATUS_UNKNOWN,
 
   /**
    * The client specified an invalid argument. Note that this differs from FAILED_PRECONDITION.
    * INVALID_ARGUMENT indicates arguments that are problematic regardless of the state of the
    * server (e.g., a malformed file name).
    */
-  GRPCErrorCodeInvalidArgument = 3,
+  GRPCErrorCodeInvalidArgument = GRPC_STATUS_INVALID_ARGUMENT,
 
   /**
    * Deadline expired before operation could complete. For operations that change the state of the
@@ -74,13 +75,13 @@ typedef NS_ENUM(NSUInteger, GRPCErrorCode) {
    * example, a successful response from the server could have been delayed long enough for the
    * deadline to expire.
    */
-  GRPCErrorCodeDeadlineExceeded = 4,
+  GRPCErrorCodeDeadlineExceeded = GRPC_STATUS_DEADLINE_EXCEEDED,
 
   /** Some requested entity (e.g., file or directory) was not found. */
-  GRPCErrorCodeNotFound = 5,
+  GRPCErrorCodeNotFound = GRPC_STATUS_NOT_FOUND,
 
   /** Some entity that we attempted to create (e.g., file or directory) already exists. */
-  GRPCErrorCodeAlreadyExists = 6,
+  GRPCErrorCodeAlreadyExists = GRPC_STATUS_ALREADY_EXISTS,
 
   /**
    * The caller does not have permission to execute the specified operation. PERMISSION_DENIED isn't
@@ -88,16 +89,16 @@ typedef NS_ENUM(NSUInteger, GRPCErrorCode) {
    * those errors). PERMISSION_DENIED doesn't indicate a failure to identify the caller
    * (UNAUTHENTICATED is used instead for those errors).
    */
-  GRPCErrorCodePermissionDenied = 7,
+  GRPCErrorCodePermissionDenied = GRPC_STATUS_PERMISSION_DENIED,
 
   /**
    * The request does not have valid authentication credentials for the operation (e.g. the caller's
    * identity can't be verified).
    */
-  GRPCErrorCodeUnauthenticated = 16,
+  GRPCErrorCodeUnauthenticated = GRPC_STATUS_UNAUTHENTICATED,
 
   /** Some resource has been exhausted, perhaps a per-user quota. */
-  GRPCErrorCodeResourceExhausted = 8,
+  GRPCErrorCodeResourceExhausted = GRPC_STATUS_RESOURCE_EXHAUSTED,
 
   /**
    * The RPC was rejected because the server is not in a state required for the procedure's
@@ -106,14 +107,14 @@ typedef NS_ENUM(NSUInteger, GRPCErrorCode) {
    * performing another RPC). The details depend on the service being called, and should be found in
    * the NSError's userInfo.
    */
-  GRPCErrorCodeFailedPrecondition = 9,
+  GRPCErrorCodeFailedPrecondition = GRPC_STATUS_FAILED_PRECONDITION,
 
   /**
    * The RPC was aborted, typically due to a concurrency issue like sequencer check failures,
    * transaction aborts, etc. The client should retry at a higher-level (e.g., restarting a read-
    * modify-write sequence).
    */
-  GRPCErrorCodeAborted = 10,
+  GRPCErrorCodeAborted = GRPC_STATUS_ABORTED,
 
   /**
    * The RPC was attempted past the valid range. E.g., enumerating past the end of a list.
@@ -122,25 +123,25 @@ typedef NS_ENUM(NSUInteger, GRPCErrorCode) {
    * to return the element at a negative index, but it will generate OUT_OF_RANGE if asked to return
    * the element at an index past the current size of the list.
    */
-  GRPCErrorCodeOutOfRange = 11,
+  GRPCErrorCodeOutOfRange = GRPC_STATUS_OUT_OF_RANGE,
 
   /** The procedure is not implemented or not supported/enabled in this server. */
-  GRPCErrorCodeUnimplemented = 12,
+  GRPCErrorCodeUnimplemented = GRPC_STATUS_UNIMPLEMENTED,
 
   /**
    * Internal error. Means some invariant expected by the server application or the gRPC library has
    * been broken.
    */
-  GRPCErrorCodeInternal = 13,
+  GRPCErrorCodeInternal = GRPC_STATUS_INTERNAL,
 
   /**
    * The server is currently unavailable. This is most likely a transient condition and may be
    * corrected by retrying with a backoff.
    */
-  GRPCErrorCodeUnavailable = 14,
+  GRPCErrorCodeUnavailable = GRPC_STATUS_UNAVAILABLE,
 
   /** Unrecoverable data loss or corruption. */
-  GRPCErrorCodeDataLoss = 15,
+  GRPCErrorCodeDataLoss = GRPC_STATUS_DATA_LOSS,
 };
 
 /**

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -41,8 +41,7 @@ static NSError *ErrorForBadProto(id proto, Class expectedClass, NSError *parsing
     @"Expected class" : expectedClass,
     @"Received value" : proto,
   };
-  // TODO(jcanizales): Use kGRPCErrorDomain and GRPCErrorCodeInternal when they're public.
-  return [NSError errorWithDomain:@"io.grpc" code:13 userInfo:info];
+  return [NSError errorWithDomain:kGRPCErrorDomain code:GRPCErrorCodeInternal userInfo:info];
 }
 
 @implementation GRPCUnaryProtoCall {

--- a/src/objective-c/tests/APIv2Tests/APIv2Tests.m
+++ b/src/objective-c/tests/APIv2Tests/APIv2Tests.m
@@ -151,7 +151,7 @@ static const NSTimeInterval kTestTimeout = 16;
                                  closeCallback:^(NSDictionary *trailingMetadata, NSError *error) {
                                    trailing_md = trailingMetadata;
                                    if (error) {
-                                     XCTAssertEqual(error.code, 16,
+                                     XCTAssertEqual(error.code, GRPCErrorCodeUnauthenticated,
                                                     @"Finished with unexpected error: %@", error);
                                      XCTAssertEqualObjects(init_md,
                                                            error.userInfo[kGRPCHeadersKey]);

--- a/src/objective-c/tests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests.m
@@ -355,9 +355,9 @@ BOOL isRemoteInteropTest(NSString *host) {
     request.responseSize = 314159;
     request.payload.body = [NSMutableData dataWithLength:271828];
     if (i % 3 == 0) {
-      request.responseStatus.code = GRPC_STATUS_UNAVAILABLE;
+      request.responseStatus.code = GRPCErrorCodeUnavailable;
     } else if (i % 7 == 0) {
-      request.responseStatus.code = GRPC_STATUS_CANCELLED;
+      request.responseStatus.code = GRPCErrorCodeCancelled;
     }
     GRPCMutableCallOptions *options = [[GRPCMutableCallOptions alloc] init];
     options.transportType = [[self class] transportType];
@@ -404,9 +404,9 @@ BOOL isRemoteInteropTest(NSString *host) {
     request.responseSize = 314159;
     request.payload.body = [NSMutableData dataWithLength:271828];
     if (i % 3 == 0) {
-      request.responseStatus.code = GRPC_STATUS_UNAVAILABLE;
+      request.responseStatus.code = GRPCErrorCodeUnavailable;
     } else if (i % 7 == 0) {
-      request.responseStatus.code = GRPC_STATUS_CANCELLED;
+      request.responseStatus.code = GRPCErrorCodeCancelled;
     }
 
     [_service unaryCallWithRequest:request
@@ -726,7 +726,7 @@ BOOL isRemoteInteropTest(NSString *host) {
       RPCToStreamingInputCallWithRequestsWriter:requestsBuffer
                                         handler:^(RMTStreamingInputCallResponse *response,
                                                   NSError *error) {
-                                          XCTAssertEqual(error.code, GRPC_STATUS_CANCELLED);
+                                          XCTAssertEqual(error.code, GRPCErrorCodeCancelled);
                                           [expectation fulfill];
                                         }];
   XCTAssertEqual(call.state, GRXWriterStateNotStarted);
@@ -754,7 +754,8 @@ BOOL isRemoteInteropTest(NSString *host) {
                                                 }
                                                 closeCallback:^(NSDictionary *trailingMetadata,
                                                                 NSError *error) {
-                                                  XCTAssertEqual(error.code, GRPC_STATUS_CANCELLED);
+                                                  XCTAssertEqual(error.code,
+                                                                 GRPCErrorCodeCancelled);
                                                   [expectation fulfill];
                                                 }]
                                 callOptions:nil];
@@ -785,7 +786,7 @@ BOOL isRemoteInteropTest(NSString *host) {
                                               NSError *error) {
                                  if (receivedResponse) {
                                    XCTAssert(done, @"Unexpected extra response %@", response);
-                                   XCTAssertEqual(error.code, GRPC_STATUS_CANCELLED);
+                                   XCTAssertEqual(error.code, GRPCErrorCodeCancelled);
                                    [expectation fulfill];
                                  } else {
                                    XCTAssertNil(error, @"Finished with unexpected error: %@",
@@ -828,7 +829,7 @@ BOOL isRemoteInteropTest(NSString *host) {
                                             }
                                             closeCallback:^(NSDictionary *trailingMetadata,
                                                             NSError *error) {
-                                              XCTAssertEqual(error.code, GRPC_STATUS_CANCELLED);
+                                              XCTAssertEqual(error.code, GRPCErrorCodeCancelled);
                                               [completionExpectation fulfill];
                                             }]
                             callOptions:options];
@@ -858,7 +859,7 @@ BOOL isRemoteInteropTest(NSString *host) {
                                             }
                                             closeCallback:^(NSDictionary *trailingMetadata,
                                                             NSError *error) {
-                                              XCTAssertEqual(error.code, GRPC_STATUS_CANCELLED);
+                                              XCTAssertEqual(error.code, GRPCErrorCodeCancelled);
                                               [completionExpectation fulfill];
                                             }]
                             callOptions:options];
@@ -959,7 +960,7 @@ BOOL isRemoteInteropTest(NSString *host) {
                             } else {
                               // Keepalive should kick after 1s elapsed and fails the call.
                               XCTAssertNotNil(error);
-                              XCTAssertEqual(error.code, GRPC_STATUS_UNAVAILABLE);
+                              XCTAssertEqual(error.code, GRPCErrorCodeUnavailable);
                               XCTAssertEqualObjects(
                                   error.localizedDescription, @"keepalive watchdog timeout",
                                   @"Unexpected failure that is not keepalive watchdog timeout.");

--- a/src/objective-c/tests/UnitTests/UnitTests.m
+++ b/src/objective-c/tests/UnitTests/UnitTests.m
@@ -42,18 +42,18 @@
       [NSError grpc_errorFromStatusCode:GRPC_STATUS_UNAVAILABLE details:nil errorString:nil];
 
   XCTAssertNil(error1);
-  XCTAssertEqual(error2.code, 1);
+  XCTAssertEqual(error2.code, GRPCErrorCodeCancelled);
   XCTAssertEqualObjects(error2.domain, @"io.grpc");
   XCTAssertEqualObjects(error2.userInfo[NSLocalizedDescriptionKey],
                         [NSString stringWithUTF8String:kDetails]);
   XCTAssertEqualObjects(error2.userInfo[NSDebugDescriptionErrorKey],
                         [NSString stringWithUTF8String:kErrorString]);
-  XCTAssertEqual(error3.code, 16);
+  XCTAssertEqual(error3.code, GRPCErrorCodeUnauthenticated);
   XCTAssertEqualObjects(error3.domain, @"io.grpc");
   XCTAssertEqualObjects(error3.userInfo[NSLocalizedDescriptionKey],
                         [NSString stringWithUTF8String:kDetails]);
   XCTAssertNil(error3.userInfo[NSDebugDescriptionErrorKey]);
-  XCTAssertEqual(error4.code, 14);
+  XCTAssertEqual(error4.code, GRPCErrorCodeUnavailable);
   XCTAssertEqualObjects(error4.domain, @"io.grpc");
   XCTAssertNil(error4.userInfo[NSLocalizedDescriptionKey]);
   XCTAssertNil(error4.userInfo[NSDebugDescriptionErrorKey]);


### PR DESCRIPTION
Don't hardcode error codes in objc layer. Use the codes defined by C core instead.