### PR TITLE
Add info about C# nightly nuget feed

### DIFF
--- a/src/csharp/README.md
+++ b/src/csharp/README.md
@@ -40,6 +40,17 @@ See [Experimentally supported platforms](experimental) for instructions.
 
 See [Experimentally supported platforms](experimental) for instructions.
 
+NUGET DEVELOPMENT FEED (NIGHTLY BUILDS)
+--------------
+
+In production, you should use officially released stable packages available on http://nuget.org, but if you want to test the newest upstream bug fixes and features early, you can can use the development nuget feed where new nuget builds are uploaded nightly.
+
+Feed URL (NuGet v2): https://grpc.jfrog.io/grpc/api/nuget/grpc-nuget-dev
+
+Feed URL (NuGet v3): Feed https://grpc.jfrog.io/grpc/api/nuget/v3/grpc-nuget-dev
+
+The same development nuget packages and packages for other languages can also be found at https://packages.grpc.io/
+
 BUILD FROM SOURCE
 -----------------
 

--- a/src/csharp/README.md
+++ b/src/csharp/README.md
@@ -47,7 +47,7 @@ In production, you should use officially released stable packages available on h
 
 Feed URL (NuGet v2): https://grpc.jfrog.io/grpc/api/nuget/grpc-nuget-dev
 
-Feed URL (NuGet v3): Feed https://grpc.jfrog.io/grpc/api/nuget/v3/grpc-nuget-dev
+Feed URL (NuGet v3): https://grpc.jfrog.io/grpc/api/nuget/v3/grpc-nuget-dev
 
 The same development nuget packages and packages for other languages can also be found at https://packages.grpc.io/
 


### PR DESCRIPTION
Related: https://github.com/grpc/grpc-dotnet/issues/179

https://github.com/grpc/grpc/pull/18871 has added uploading of the nightly nugets.