### PR TITLE
Revert "Objective C should use error codes defined by C core"

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.h
+++ b/src/objective-c/GRPCClient/GRPCCall.h
@@ -34,7 +34,6 @@
 
 #import <Foundation/Foundation.h>
 #import <RxLibrary/GRXWriter.h>
-#include <grpc/status.h>
 
 #include <AvailabilityMacros.h>
 
@@ -54,20 +53,20 @@ extern NSString *const kGRPCErrorDomain;
  */
 typedef NS_ENUM(NSUInteger, GRPCErrorCode) {
   /** The operation was cancelled (typically by the caller). */
-  GRPCErrorCodeCancelled = GRPC_STATUS_CANCELLED,
+  GRPCErrorCodeCancelled = 1,
 
   /**
    * Unknown error. Errors raised by APIs that do not return enough error information may be
    * converted to this error.
    */
-  GRPCErrorCodeUnknown = GRPC_STATUS_UNKNOWN,
+  GRPCErrorCodeUnknown = 2,
 
   /**
    * The client specified an invalid argument. Note that this differs from FAILED_PRECONDITION.
    * INVALID_ARGUMENT indicates arguments that are problematic regardless of the state of the
    * server (e.g., a malformed file name).
    */
-  GRPCErrorCodeInvalidArgument = GRPC_STATUS_INVALID_ARGUMENT,
+  GRPCErrorCodeInvalidArgument = 3,
 
   /**
    * Deadline expired before operation could complete. For operations that change the state of the
@@ -75,13 +74,13 @@ typedef NS_ENUM(NSUInteger, GRPCErrorCode) {
    * example, a successful response from the server could have been delayed long enough for the
    * deadline to expire.
    */
-  GRPCErrorCodeDeadlineExceeded = GRPC_STATUS_DEADLINE_EXCEEDED,
+  GRPCErrorCodeDeadlineExceeded = 4,
 
   /** Some requested entity (e.g., file or directory) was not found. */
-  GRPCErrorCodeNotFound = GRPC_STATUS_NOT_FOUND,
+  GRPCErrorCodeNotFound = 5,
 
   /** Some entity that we attempted to create (e.g., file or directory) already exists. */
-  GRPCErrorCodeAlreadyExists = GRPC_STATUS_ALREADY_EXISTS,
+  GRPCErrorCodeAlreadyExists = 6,
 
   /**
    * The caller does not have permission to execute the specified operation. PERMISSION_DENIED isn't
@@ -89,16 +88,16 @@ typedef NS_ENUM(NSUInteger, GRPCErrorCode) {
    * those errors). PERMISSION_DENIED doesn't indicate a failure to identify the caller
    * (UNAUTHENTICATED is used instead for those errors).
    */
-  GRPCErrorCodePermissionDenied = GRPC_STATUS_PERMISSION_DENIED,
+  GRPCErrorCodePermissionDenied = 7,
 
   /**
    * The request does not have valid authentication credentials for the operation (e.g. the caller's
    * identity can't be verified).
    */
-  GRPCErrorCodeUnauthenticated = GRPC_STATUS_UNAUTHENTICATED,
+  GRPCErrorCodeUnauthenticated = 16,
 
   /** Some resource has been exhausted, perhaps a per-user quota. */
-  GRPCErrorCodeResourceExhausted = GRPC_STATUS_RESOURCE_EXHAUSTED,
+  GRPCErrorCodeResourceExhausted = 8,
 
   /**
    * The RPC was rejected because the server is not in a state required for the procedure's
@@ -107,14 +106,14 @@ typedef NS_ENUM(NSUInteger, GRPCErrorCode) {
    * performing another RPC). The details depend on the service being called, and should be found in
    * the NSError's userInfo.
    */
-  GRPCErrorCodeFailedPrecondition = GRPC_STATUS_FAILED_PRECONDITION,
+  GRPCErrorCodeFailedPrecondition = 9,
 
   /**
    * The RPC was aborted, typically due to a concurrency issue like sequencer check failures,
    * transaction aborts, etc. The client should retry at a higher-level (e.g., restarting a read-
    * modify-write sequence).
    */
-  GRPCErrorCodeAborted = GRPC_STATUS_ABORTED,
+  GRPCErrorCodeAborted = 10,
 
   /**
    * The RPC was attempted past the valid range. E.g., enumerating past the end of a list.
@@ -123,25 +122,25 @@ typedef NS_ENUM(NSUInteger, GRPCErrorCode) {
    * to return the element at a negative index, but it will generate OUT_OF_RANGE if asked to return
    * the element at an index past the current size of the list.
    */
-  GRPCErrorCodeOutOfRange = GRPC_STATUS_OUT_OF_RANGE,
+  GRPCErrorCodeOutOfRange = 11,
 
   /** The procedure is not implemented or not supported/enabled in this server. */
-  GRPCErrorCodeUnimplemented = GRPC_STATUS_UNIMPLEMENTED,
+  GRPCErrorCodeUnimplemented = 12,
 
   /**
    * Internal error. Means some invariant expected by the server application or the gRPC library has
    * been broken.
    */
-  GRPCErrorCodeInternal = GRPC_STATUS_INTERNAL,
+  GRPCErrorCodeInternal = 13,
 
   /**
    * The server is currently unavailable. This is most likely a transient condition and may be
    * corrected by retrying with a backoff.
    */
-  GRPCErrorCodeUnavailable = GRPC_STATUS_UNAVAILABLE,
+  GRPCErrorCodeUnavailable = 14,
 
   /** Unrecoverable data loss or corruption. */
-  GRPCErrorCodeDataLoss = GRPC_STATUS_DATA_LOSS,
+  GRPCErrorCodeDataLoss = 15,
 };
 
 /**

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -41,7 +41,8 @@ static NSError *ErrorForBadProto(id proto, Class expectedClass, NSError *parsing
     @"Expected class" : expectedClass,
     @"Received value" : proto,
   };
-  return [NSError errorWithDomain:kGRPCErrorDomain code:GRPCErrorCodeInternal userInfo:info];
+  // TODO(jcanizales): Use kGRPCErrorDomain and GRPCErrorCodeInternal when they're public.
+  return [NSError errorWithDomain:@"io.grpc" code:13 userInfo:info];
 }
 
 @implementation GRPCUnaryProtoCall {

--- a/src/objective-c/tests/APIv2Tests/APIv2Tests.m
+++ b/src/objective-c/tests/APIv2Tests/APIv2Tests.m
@@ -151,7 +151,7 @@ static const NSTimeInterval kTestTimeout = 16;
                                  closeCallback:^(NSDictionary *trailingMetadata, NSError *error) {
                                    trailing_md = trailingMetadata;
                                    if (error) {
-                                     XCTAssertEqual(error.code, GRPCErrorCodeUnauthenticated,
+                                     XCTAssertEqual(error.code, 16,
                                                     @"Finished with unexpected error: %@", error);
                                      XCTAssertEqualObjects(init_md,
                                                            error.userInfo[kGRPCHeadersKey]);

--- a/src/objective-c/tests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests.m
@@ -355,9 +355,9 @@ BOOL isRemoteInteropTest(NSString *host) {
     request.responseSize = 314159;
     request.payload.body = [NSMutableData dataWithLength:271828];
     if (i % 3 == 0) {
-      request.responseStatus.code = GRPCErrorCodeUnavailable;
+      request.responseStatus.code = GRPC_STATUS_UNAVAILABLE;
     } else if (i % 7 == 0) {
-      request.responseStatus.code = GRPCErrorCodeCancelled;
+      request.responseStatus.code = GRPC_STATUS_CANCELLED;
     }
     GRPCMutableCallOptions *options = [[GRPCMutableCallOptions alloc] init];
     options.transportType = [[self class] transportType];
@@ -404,9 +404,9 @@ BOOL isRemoteInteropTest(NSString *host) {
     request.responseSize = 314159;
     request.payload.body = [NSMutableData dataWithLength:271828];
     if (i % 3 == 0) {
-      request.responseStatus.code = GRPCErrorCodeUnavailable;
+      request.responseStatus.code = GRPC_STATUS_UNAVAILABLE;
     } else if (i % 7 == 0) {
-      request.responseStatus.code = GRPCErrorCodeCancelled;
+      request.responseStatus.code = GRPC_STATUS_CANCELLED;
     }
 
     [_service unaryCallWithRequest:request
@@ -726,7 +726,7 @@ BOOL isRemoteInteropTest(NSString *host) {
       RPCToStreamingInputCallWithRequestsWriter:requestsBuffer
                                         handler:^(RMTStreamingInputCallResponse *response,
                                                   NSError *error) {
-                                          XCTAssertEqual(error.code, GRPCErrorCodeCancelled);
+                                          XCTAssertEqual(error.code, GRPC_STATUS_CANCELLED);
                                           [expectation fulfill];
                                         }];
   XCTAssertEqual(call.state, GRXWriterStateNotStarted);
@@ -754,8 +754,7 @@ BOOL isRemoteInteropTest(NSString *host) {
                                                 }
                                                 closeCallback:^(NSDictionary *trailingMetadata,
                                                                 NSError *error) {
-                                                  XCTAssertEqual(error.code,
-                                                                 GRPCErrorCodeCancelled);
+                                                  XCTAssertEqual(error.code, GRPC_STATUS_CANCELLED);
                                                   [expectation fulfill];
                                                 }]
                                 callOptions:nil];
@@ -786,7 +785,7 @@ BOOL isRemoteInteropTest(NSString *host) {
                                               NSError *error) {
                                  if (receivedResponse) {
                                    XCTAssert(done, @"Unexpected extra response %@", response);
-                                   XCTAssertEqual(error.code, GRPCErrorCodeCancelled);
+                                   XCTAssertEqual(error.code, GRPC_STATUS_CANCELLED);
                                    [expectation fulfill];
                                  } else {
                                    XCTAssertNil(error, @"Finished with unexpected error: %@",
@@ -829,7 +828,7 @@ BOOL isRemoteInteropTest(NSString *host) {
                                             }
                                             closeCallback:^(NSDictionary *trailingMetadata,
                                                             NSError *error) {
-                                              XCTAssertEqual(error.code, GRPCErrorCodeCancelled);
+                                              XCTAssertEqual(error.code, GRPC_STATUS_CANCELLED);
                                               [completionExpectation fulfill];
                                             }]
                             callOptions:options];
@@ -859,7 +858,7 @@ BOOL isRemoteInteropTest(NSString *host) {
                                             }
                                             closeCallback:^(NSDictionary *trailingMetadata,
                                                             NSError *error) {
-                                              XCTAssertEqual(error.code, GRPCErrorCodeCancelled);
+                                              XCTAssertEqual(error.code, GRPC_STATUS_CANCELLED);
                                               [completionExpectation fulfill];
                                             }]
                             callOptions:options];
@@ -960,7 +959,7 @@ BOOL isRemoteInteropTest(NSString *host) {
                             } else {
                               // Keepalive should kick after 1s elapsed and fails the call.
                               XCTAssertNotNil(error);
-                              XCTAssertEqual(error.code, GRPCErrorCodeUnavailable);
+                              XCTAssertEqual(error.code, GRPC_STATUS_UNAVAILABLE);
                               XCTAssertEqualObjects(
                                   error.localizedDescription, @"keepalive watchdog timeout",
                                   @"Unexpected failure that is not keepalive watchdog timeout.");

--- a/src/objective-c/tests/UnitTests/UnitTests.m
+++ b/src/objective-c/tests/UnitTests/UnitTests.m
@@ -42,18 +42,18 @@
       [NSError grpc_errorFromStatusCode:GRPC_STATUS_UNAVAILABLE details:nil errorString:nil];
 
   XCTAssertNil(error1);
-  XCTAssertEqual(error2.code, GRPCErrorCodeCancelled);
+  XCTAssertEqual(error2.code, 1);
   XCTAssertEqualObjects(error2.domain, @"io.grpc");
   XCTAssertEqualObjects(error2.userInfo[NSLocalizedDescriptionKey],
                         [NSString stringWithUTF8String:kDetails]);
   XCTAssertEqualObjects(error2.userInfo[NSDebugDescriptionErrorKey],
                         [NSString stringWithUTF8String:kErrorString]);
-  XCTAssertEqual(error3.code, GRPCErrorCodeUnauthenticated);
+  XCTAssertEqual(error3.code, 16);
   XCTAssertEqualObjects(error3.domain, @"io.grpc");
   XCTAssertEqualObjects(error3.userInfo[NSLocalizedDescriptionKey],
                         [NSString stringWithUTF8String:kDetails]);
   XCTAssertNil(error3.userInfo[NSDebugDescriptionErrorKey]);
-  XCTAssertEqual(error4.code, GRPCErrorCodeUnavailable);
+  XCTAssertEqual(error4.code, 14);
   XCTAssertEqualObjects(error4.domain, @"io.grpc");
   XCTAssertNil(error4.userInfo[NSLocalizedDescriptionKey]);
   XCTAssertNil(error4.userInfo[NSDebugDescriptionErrorKey]);


### PR DESCRIPTION
This reverts commit 2d5468e8263cfdb0595dfd36fba9df6f7c63075a.