### PR TITLE
Add script to run build tests of ObjC examples

### DIFF
--- a/src/objective-c/tests/examples_build_test.sh
+++ b/src/objective-c/tests/examples_build_test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+SCHEME=HelloWorld EXAMPLE_PATH=examples/objective-c/helloworld ./build_one_example.sh
+SCHEME=RouteGuideClient EXAMPLE_PATH=examples/objective-c/route_guide ./build_one_example.sh
+SCHEME=AuthSample EXAMPLE_PATH=examples/objective-c/auth_sample ./build_one_example.sh

--- a/src/objective-c/tests/examples_build_test.sh
+++ b/src/objective-c/tests/examples_build_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2015 gRPC authors.
+# Copyright 2019 gRPC authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/objective-c/tests/examples_build_test.sh
+++ b/src/objective-c/tests/examples_build_test.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used after a release to verify the released pods are working appropriately
 
 set -ex
 


### PR DESCRIPTION
Follow up of #18815. The new script runs the build tests that got removed from CI in #18815. It will be run manually after each release.

cc: @srini100 