### PR TITLE
Create App context callback for timer custom

### DIFF
--- a/src/core/lib/iomgr/timer_custom.cc
+++ b/src/core/lib/iomgr/timer_custom.cc
@@ -32,6 +32,7 @@ static grpc_custom_timer_vtable* custom_timer_impl;
 
 void grpc_custom_timer_callback(grpc_custom_timer* t, grpc_error* error) {
   GRPC_CUSTOM_IOMGR_ASSERT_SAME_THREAD();
+  grpc_core::ApplicationCallbackExecCtx callback_exec_ctx;
   grpc_core::ExecCtx exec_ctx;
   grpc_timer* timer = t->original;
   GPR_ASSERT(timer->pending);


### PR DESCRIPTION
When a timer reaches its deadline and it uses the combination of having
enabled the custom timer and using a completion queue of callback type we
must provide the App context callback at TLS level. Otherwise, a segfault
is produced during the enqueuing process of the application callback.

Resolves partially this issue #18721 

**What is missing?**

Testing, before implementing it I would prefer on having the blessing on the intentionality of that PR and also some advice on how to implement a test for this PR. 

I have the impression that test this fix should be doable at unit test level, so having an ad-hoc test into a new file that will basically call the `grpc_custom_timer_callback` function by mocking a `timer->closure` function that would try to enqueue something into the application callback context.

Another alternative is not doing any unit test at all considering that other commits related to that issue haven't considered it [1], maybe relying on a - future ? - end2end test?

**Further work**
If this PR is accepted future PR would be done for all of the custom iomgr files that lack, like `tcp_custom` or `tcp_server_custom`, on the application context.

/cc @vjpai and @markdroth happy to hear your comments

[1] https://github.com/grpc/grpc/commit/85d76b2888ddd19a743191d6676d4be17df6a584