### PR TITLE
Fix a typo in chttp2 stream initialization.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -633,7 +633,7 @@ struct grpc_chttp2_stream {
       GRPC_STREAM_COMPRESSION_IDENTITY_COMPRESS;
   /* Stream decompression method to be used. */
   grpc_stream_compression_method stream_decompression_method =
-      GRPC_STREAM_COMPRESSION_IDENTITY_COMPRESS;
+      GRPC_STREAM_COMPRESSION_IDENTITY_DECOMPRESS;
   /** Stream compression decompress context */
   grpc_stream_compression_context* stream_decompression_ctx = nullptr;
   /** Stream compression compress context */


### PR DESCRIPTION
Found this during performance optimizations. We always reinitialize
this to the correct value, so this wasn't caught in tests.