### PR TITLE
do not write unnecessary new lines in the grpc_cli as the formatters already write them

### DIFF
--- a/test/cpp/util/grpc_cli.cc
+++ b/test/cpp/util/grpc_cli.cc
@@ -68,7 +68,7 @@ DEFINE_string(outfile, "", "Output file (default is stdout)");
 static bool SimplePrint(const grpc::string& outfile,
                         const grpc::string& output) {
   if (outfile.empty()) {
-    std::cout << output << std::endl;
+    std::cout << output << std::flush;
   } else {
     std::ofstream output_file(outfile, std::ios::app | std::ios::binary);
     output_file << output << std::endl;


### PR DESCRIPTION
Currently the grpc_cli does not round-trip when using stdout:
`echo 'name: "my-name"' | bazel-bin/test/cpp/util/grpc_cli tobinary --proto_path examples/protos/ helloworld.proto helloworld.HelloRequest | bazel-bin/test/cpp/util/grpc_cli totext --proto_path examples/protos/ helloworld.proto helloworld.HelloRequest`
fails with
`Failed to deserialize proto.
Failed to deserialize the message.
`

This PR fixes it (at least on `v1.20.1` as master does not currently build 