### PR TITLE
Fix uploading bazel RBE results to bigquery

### DIFF
--- a/tools/run_tests/python_utils/upload_rbe_results.py
+++ b/tools/run_tests/python_utils/upload_rbe_results.py
@@ -146,6 +146,8 @@ if __name__ == "__main__":
     invocation_id = args.invocation_id or _get_invocation_id()
     resultstore_actions = _get_resultstore_data(api_key, invocation_id)
 
+    # google.devtools.resultstore.v2.Action schema:
+    # https://github.com/googleapis/googleapis/blob/master/google/devtools/resultstore/v2/action.proto
     bq_rows = []
     for index, action in enumerate(resultstore_actions):
         # Filter out non-test related data, such as build results.
@@ -186,6 +188,8 @@ if __name__ == "__main__":
                 resultstore_actions[index - 1]['timing']['startTime']
             }
         elif 'testSuite' not in action['testAction']:
+            continue
+        elif 'tests' not in action['testAction']['testSuite']:
             continue
         else:
             test_cases = action['testAction']['testSuite']['tests'][0][


### PR DESCRIPTION
Uploading has been broken for the last few days for all bazel RBE jobs on master:
https://source.cloud.google.com/results/invocations/7c701750-65a3-4b4b-a097-b2e9b9bf8197/targets

```
+ python ./tools/run_tests/python_utils/upload_rbe_results.py
Traceback (most recent call last):
  File "./tools/run_tests/python_utils/upload_rbe_results.py", line 191, in <module>
    test_cases = action['testAction']['testSuite']['tests'][0][
KeyError: 'tests'
```

Example action that triggered the failure (from local testing)
```
{"timing": {"duration": "5.502s", "startTime": "2019-04-29T14:35:28.773Z"}, "testAction": {"testTiming": {"testCaching": "CACHE_MISS", "local": {}}, "testSuite": {"suiteName": "Empty suite"}}, "id": {"configurationId": "8be6773e1c5b12a715e6fedc64030603", "targetId": "//test/core/client_channel:uri_fuzzer_test@poller=epoll1", "invocationId": "f8780c9b-9878-4c98-b3be-fb28d8b48c65", "actionId": "test_shard0_run0_attempt0"}, "statusAttributes": {"status": "PASSED"}}
```