### PR TITLE
Fix a typo in the GRPC::RpcServer constructor description

### DIFF
--- a/src/ruby/lib/grpc/generic/rpc_server.rb
+++ b/src/ruby/lib/grpc/generic/rpc_server.rb
@@ -210,7 +210,7 @@ module GRPC
     # A server arguments hash to be passed down to the underlying core server
     #
     # * interceptors:
-    # Am array of GRPC::ServerInterceptor objects that will be used for
+    # An array of GRPC::ServerInterceptor objects that will be used for
     # intercepting server handlers to provide extra functionality.
     # Interceptors are an EXPERIMENTAL API.
     #


### PR DESCRIPTION
Found a typo in a `GRPC::RpcServer` constructor comment under `src/ruby`