### PR TITLE
Add a fast path in grpc_error_get_status() for GRPC_ERROR_NONE.

### DIFF
--- a/src/core/lib/transport/error_utils.cc
+++ b/src/core/lib/transport/error_utils.cc
@@ -48,6 +48,18 @@ void grpc_error_get_status(grpc_error* error, grpc_millis deadline,
                            grpc_status_code* code, grpc_slice* slice,
                            grpc_http2_error_code* http_error,
                            const char** error_string) {
+  // Fast path: We expect no error.
+  if (GPR_LIKELY(error == GRPC_ERROR_NONE)) {
+    if (code != nullptr) *code = GRPC_STATUS_OK;
+    if (slice != nullptr) {
+      grpc_error_get_str(error, GRPC_ERROR_STR_GRPC_MESSAGE, slice);
+    }
+    if (http_error != nullptr) {
+      *http_error = GRPC_HTTP2_NO_ERROR;
+    }
+    return;
+  }
+
   // Start with the parent error and recurse through the tree of children
   // until we find the first one that has a status code.
   grpc_error* found_error =


### PR DESCRIPTION
In most of the cases, as we hope, RPCs shouldn't have errors.
But, in grpc_error_get_status() we treat GRPC_ERROR_NONE
similar to other errors, and waste quite a few cycles.

This patch is part of a larger performance improvements.
On client side, this particular code path accounts for 0.5%+.