### PR TITLE
Reset slices pointer to base_slices when slice_bufer length is 0.

### DIFF
--- a/src/core/lib/slice/slice_buffer.cc
+++ b/src/core/lib/slice/slice_buffer.cc
@@ -33,6 +33,10 @@
 #define GROW(x) (3 * (x) / 2)
 
 static void maybe_embiggen(grpc_slice_buffer* sb) {
+  if (sb->length == 0) {
+    sb->slices = sb->base_slices;
+  }
+
   /* How far away from sb->base_slices is sb->slices pointer */
   size_t slice_offset = static_cast<size_t>(sb->slices - sb->base_slices);
   size_t slice_count = sb->count + slice_offset;
@@ -177,6 +181,7 @@ void grpc_slice_buffer_reset_and_unref_internal(grpc_slice_buffer* sb) {
 
   sb->count = 0;
   sb->length = 0;
+  sb->slices = sb->base_slices;
 }
 
 void grpc_slice_buffer_reset_and_unref(grpc_slice_buffer* sb) {


### PR DESCRIPTION
Currently, we keep increasing the slice pointer, and
can run out of the inline space or try to realloc the
non-inline space unnecessarily.

Simply set slices back to the start of the base_slices,
when we know the length of the slice_buffer is 0.

Note: This will change the behavior of undo_take_first(),
      if user tries to grow the slie_buffer, between take_first()
      and undo_take_first() calls. That said, it's not legal
      to add something to the buffer in between take_first()
      and undo_take_first(). So, we shouldn't have any issue.

This is part of a larger performance change.