### PR TITLE
Job split followup: increase timeout for macos and windows C/C++ jobs

### DIFF
--- a/tools/internal_ci/macos/grpc_basictests_c_cpp.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_c_cpp.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_tests_matrix.sh"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
-timeout_mins: 60
+timeout_mins: 120
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/windows/grpc_basictests_c.cfg
+++ b/tools/internal_ci/windows/grpc_basictests_c.cfg
@@ -16,7 +16,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/windows/grpc_run_tests_matrix.bat"
-timeout_mins: 60
+timeout_mins: 120
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
Followup for https://github.com/grpc/grpc/pull/18923.
Turns out macos and windows C/C++ jobs take >60mins. For now increasing the timeout to prevent them from failing, will look into speeding up later.

```
2019-05-04 07:04:33,530 START: run_tests_c_windows_dbg_native
2019-05-04 07:40:08,249 PASSED: run_tests_c_windows_dbg_native [time=2134.7sec, retries=0:0]
2019-05-04 07:40:08,249 START: run_tests_c_windows_opt_native
ERROR: Aborting VM command due to timeout of 3600 seconds
```