### PR TITLE
Update BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -72,6 +72,7 @@ If 'protoc' compiler has not been installed, following commands can be used for 
 
 ```sh
 $ cd grpc/third_party/protobuf
+$ ./configure
 $ sudo make install   # 'make' should have been run by core grpc
 ```
 


### PR DESCRIPTION
The current build instruction do not specify that you need to run ./configure to generate the Makefile 