### PR TITLE
Check count instead of length in maybe_embiggen() to reset the slice pointer.

### DIFF
--- a/src/core/lib/slice/slice_buffer.cc
+++ b/src/core/lib/slice/slice_buffer.cc
@@ -33,7 +33,7 @@
 #define GROW(x) (3 * (x) / 2)
 
 static void maybe_embiggen(grpc_slice_buffer* sb) {
-  if (sb->length == 0) {
+  if (sb->count == 0) {
     sb->slices = sb->base_slices;
   }
 


### PR DESCRIPTION
add_tiny overrides the length before calling maybe_embiggen(). Generally
using count as a signal for emptiness is more reliable.