### PR TITLE
Optimize grpc timer implementation.

### DIFF
--- a/src/core/lib/iomgr/timer_generic.cc
+++ b/src/core/lib/iomgr/timer_generic.cc
@@ -36,6 +36,7 @@
 #include "src/core/lib/gpr/tls.h"
 #include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/gprpp/atomic.h"
+#include "src/core/lib/gprpp/manual_constructor.h"
 #include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/gprpp/sync.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
@@ -291,14 +292,12 @@ struct shared_mutables {
   grpc_core::Mutex mu;
 } GPR_ALIGN_STRUCT(GPR_CACHELINE_SIZE);
 
-static shared_mutables* g_shared_mutables = nullptr;
+static grpc_core::ManualConstructor<shared_mutables> g_shared_mutables;
 static gpr_once g_once_init_shared_mutables = GPR_ONCE_INIT;
 
 shared_mutables& GetSharedMutables() {
   gpr_once_init(&g_once_init_shared_mutables, [] {
-    g_shared_mutables =
-        new (gpr_malloc_aligned(sizeof(shared_mutables), GPR_CACHELINE_SIZE))
-            shared_mutables();
+    g_shared_mutables.Init();
   });
   return *g_shared_mutables;
 }

--- a/src/core/lib/iomgr/timer_generic.cc
+++ b/src/core/lib/iomgr/timer_generic.cc
@@ -296,9 +296,7 @@ static grpc_core::ManualConstructor<shared_mutables> g_shared_mutables;
 static gpr_once g_once_init_shared_mutables = GPR_ONCE_INIT;
 
 shared_mutables& GetSharedMutables() {
-  gpr_once_init(&g_once_init_shared_mutables, [] {
-    g_shared_mutables.Init();
-  });
+  gpr_once_init(&g_once_init_shared_mutables, [] { g_shared_mutables.Init(); });
   return *g_shared_mutables;
 }
 


### PR DESCRIPTION
This is an overhaul of the timer implementation to avoid contentions in
the hot path:
1) We generally want to use 2 x cpus of timer shards, but due to
   a contention in timer_init(), we couldn't do that. The problem
   is that we add the first timer in a shard, we grab the global lock.
   For highly parallel applications, this results in high contention
   if we have more than 32 shards.
2) Whenever we insert the first timer, we should the timer queue.
   This results in many copies on first timer insertion.

For (1) this patch tracks an atomic on the earliest deadline,
and for (2) it simply sort the timer list, when we are checking the timers.

Also, this patch convert the code to use C++ RIAA classes, and use an anonymous
namespace to hide the symobls.