### PR TITLE
Fix CMake upb build: add missing headers directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5661,6 +5661,7 @@ target_include_directories(upb
   PRIVATE ${_gRPC_GFLAGS_INCLUDE_DIR}
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
+  PRIVATE third_party/upb
 )
   # avoid dependency on libstdc++
   if (_gRPC_CORE_NOSTDCXX_FLAGS)

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -101,7 +101,7 @@
   # Providers for third-party dependencies (gRPC_*_PROVIDER properties):
   # "module": build the dependency using sources from git submodule (under third_party)
   # "package": use cmake's find_package functionality to locate a pre-installed dependency
-  
+
   set(gRPC_ZLIB_PROVIDER "module" CACHE STRING "Provider of zlib library")
   set_property(CACHE gRPC_ZLIB_PROVIDER PROPERTY STRINGS "module" "package")
 
@@ -142,7 +142,7 @@
 
   ## Some libraries are shared even with BUILD_SHARED_LIBRARIES=OFF
   set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
-  
+
   add_definitions(-DPB_FIELD_32BIT)
 
   if (MSVC)
@@ -441,6 +441,9 @@
   % if lib.language == 'c++':
     PRIVATE <%text>${_gRPC_PROTO_GENS_DIR}</%text>
   % endif
+  % if lib.name in ['upb']:
+    PRIVATE third_party/upb
+  % endif
   )
   % if lib.language in ['c', 'csharp']:
     # avoid dependency on libstdc++
@@ -573,6 +576,6 @@
       DESTINATION <%text>${gRPC_INSTALL_CMAKEDIR}</%text>
     )
   endforeach()
-  
+
   install(FILES <%text>${CMAKE_CURRENT_SOURCE_DIR}/etc/roots.pem</%text>
     DESTINATION <%text>${gRPC_INSTALL_SHAREDIR}</%text>)


### PR DESCRIPTION
When build with CMake, the upb library was failing to build as the
include path was incorrect. This commit add an include path for just the
upb library.

The Makefile template was working as the default CFLAGS for upb include
`-Ithird_party/upb` already.

Fixes https://github.com/grpc/grpc/issues/18975