### PR TITLE
cfstream_test: run server in a subprocess

### DIFF
--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -665,6 +665,9 @@ grpc_cc_test(
         "gtest",
     ],
     tags = ["manual"],  # test requires root, won't work with bazel RBE
+    data = [
+        ":client_crash_test_server",
+    ],
     deps = [
         ":test_service_impl",
         "//:gpr",


### PR DESCRIPTION
We're hitting some possible heap corruption issues in cfstream_test. Run the server in a separate subprocess to make it easier to debug.