### PR TITLE
Fix stringop truncation compiler warnings.

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.cc
@@ -21,6 +21,7 @@
 #include "pb_decode.h"
 #include "pb_encode.h"
 #include "src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.h"
+#include "src/core/lib/gpr/useful.h"
 
 #include <grpc/support/alloc.h>
 
@@ -67,8 +68,9 @@ grpc_grpclb_request* grpc_grpclb_request_create(const char* lb_service_name) {
   req->has_client_stats = false;
   req->has_initial_request = true;
   req->initial_request.has_name = true;
-  strncpy(req->initial_request.name, lb_service_name,
-          GRPC_GRPCLB_SERVICE_NAME_MAX_LENGTH);
+  memcpy(req->initial_request.name, lb_service_name,
+         GPR_MIN(GRPC_GRPCLB_SERVICE_NAME_MAX_LENGTH,
+                 strlen(lb_service_name) + 1));
   return req;
 }
 

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_load_balancer_api.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_load_balancer_api.cc
@@ -21,6 +21,7 @@
 #include "pb_decode.h"
 #include "pb_encode.h"
 #include "src/core/ext/filters/client_channel/lb_policy/xds/xds_load_balancer_api.h"
+#include "src/core/lib/gpr/useful.h"
 
 #include <grpc/support/alloc.h>
 
@@ -67,8 +68,8 @@ xds_grpclb_request* xds_grpclb_request_create(const char* lb_service_name) {
   req->has_client_stats = false;
   req->has_initial_request = true;
   req->initial_request.has_name = true;
-  strncpy(req->initial_request.name, lb_service_name,
-          XDS_SERVICE_NAME_MAX_LENGTH);
+  memcpy(req->initial_request.name, lb_service_name,
+         GPR_MIN(XDS_SERVICE_NAME_MAX_LENGTH, strlen(lb_service_name) + 1));
   return req;
 }
 


### PR DESCRIPTION
GCC 8 and above raise complaints like this in gRPC:
```
src/core/ext/filters/client_channel/lb_policy/grpclb/load_balancer_api.cc:70:10: warning: 'char* strncpy(char*, const char*, size_t)' specified bound 128 equals destination size [-Wstringop-truncation]
   strncpy(req->initial_request.name, lb_service_name,
   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           GRPC_GRPCLB_SERVICE_NAME_MAX_LENGTH);
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
These cases are actually okay because nanopb determines the end of a string field by finding NUL or hitting the maximum field size.

Avoid the warning by substituting a clunkier memcpy pattern.

Part of #18689.