### PR TITLE
Add tests for setting a channel to lame on an invalid default service config

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -1069,8 +1069,6 @@ ChannelData::ChannelData(grpc_channel_element_args* args, grpc_error** error)
   // Get default service config
   const char* service_config_json = grpc_channel_arg_get_string(
       grpc_channel_args_find(args->channel_args, GRPC_ARG_SERVICE_CONFIG));
-  // TODO(yashkt): Make sure we set the channel in TRANSIENT_FAILURE on an
-  // invalid default service config
   if (service_config_json != nullptr) {
     *error = GRPC_ERROR_NONE;
     default_service_config_ = ServiceConfig::Create(service_config_json, error);


### PR DESCRIPTION
Add tests for setting a channel to lame on an invalid default service config.
This results in all RPCs on that channel to fail.

Note that the TODO mentions that the channel should be set in TRANSIENT_FAILURE. Offline discussion might be needed. #18890 is where the discussion till now has been