### PR TITLE
Remove CreateChannel() method from LB helper API.

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -960,11 +960,6 @@ class ChannelData::ClientChannelControlHelper
     return subchannel;
   }
 
-  grpc_channel* CreateChannel(const char* target,
-                              const grpc_channel_args& args) override {
-    return chand_->client_channel_factory_->CreateChannel(target, &args);
-  }
-
   void UpdateState(
       grpc_connectivity_state state,
       UniquePtr<LoadBalancingPolicy::SubchannelPicker> picker) override {

--- a/src/core/ext/filters/client_channel/client_channel_factory.h
+++ b/src/core/ext/filters/client_channel/client_channel_factory.h
@@ -36,10 +36,6 @@ class ClientChannelFactory {
   virtual Subchannel* CreateSubchannel(const grpc_channel_args* args)
       GRPC_ABSTRACT;
 
-  // Creates a channel for the specified target with the specified args.
-  virtual grpc_channel* CreateChannel(
-      const char* target, const grpc_channel_args* args) GRPC_ABSTRACT;
-
   // Returns a channel arg containing the specified factory.
   static grpc_arg CreateChannelArg(ClientChannelFactory* factory);
 

--- a/src/core/ext/filters/client_channel/lb_policy.h
+++ b/src/core/ext/filters/client_channel/lb_policy.h
@@ -191,12 +191,6 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
     virtual Subchannel* CreateSubchannel(const grpc_channel_args& args)
         GRPC_ABSTRACT;
 
-    /// Creates a channel with the specified target and channel args.
-    /// This can be used in cases where the LB policy needs to create a
-    /// channel for its own use (e.g., to talk to an external load balancer).
-    virtual grpc_channel* CreateChannel(
-        const char* target, const grpc_channel_args& args) GRPC_ABSTRACT;
-
     /// Sets the connectivity state and returns a new picker to be used
     /// by the client channel.
     virtual void UpdateState(grpc_connectivity_state state,

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.cc
@@ -20,7 +20,16 @@
 
 #include "src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.h"
 
-grpc_channel_args* grpc_lb_policy_grpclb_modify_lb_channel_args(
-    const grpc_core::ServerAddressList& addresses, grpc_channel_args* args) {
+namespace grpc_core {
+
+grpc_channel_args* ModifyGrpclbBalancerChannelArgs(
+    const ServerAddressList& addresses, grpc_channel_args* args) {
   return args;
 }
+
+grpc_channel* CreateGrpclbBalancerChannel(
+    const char* target_uri, const grpc_channel_args& args) {
+  return grpc_insecure_channel_create(target_uri, &args, nullptr);
+}
+
+}  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.h
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel.h
@@ -25,14 +25,21 @@
 
 #include "src/core/ext/filters/client_channel/server_address.h"
 
+namespace grpc_core {
+
 /// Makes any necessary modifications to \a args for use in the grpclb
 /// balancer channel.
 ///
 /// Takes ownership of \a args.
 ///
 /// Caller takes ownership of the returned args.
-grpc_channel_args* grpc_lb_policy_grpclb_modify_lb_channel_args(
-    const grpc_core::ServerAddressList& addresses, grpc_channel_args* args);
+grpc_channel_args* ModifyGrpclbBalancerChannelArgs(
+    const ServerAddressList& addresses, grpc_channel_args* args);
+
+grpc_channel* CreateGrpclbBalancerChannel(
+    const char* target_uri, const grpc_channel_args& args);
+
+}  // namespace grpc_core
 
 #endif /* GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_LB_POLICY_GRPCLB_GRPCLB_CHANNEL_H \
         */

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/grpclb_channel_secure.cc
@@ -35,6 +35,7 @@
 #include "src/core/lib/slice/slice_internal.h"
 
 namespace grpc_core {
+
 namespace {
 
 int BalancerNameCmp(const grpc_core::UniquePtr<char>& a,
@@ -65,37 +66,49 @@ RefCountedPtr<TargetAuthorityTable> CreateTargetAuthorityTable(
 }
 
 }  // namespace
-}  // namespace grpc_core
 
-grpc_channel_args* grpc_lb_policy_grpclb_modify_lb_channel_args(
-    const grpc_core::ServerAddressList& addresses, grpc_channel_args* args) {
-  const char* args_to_remove[1];
-  size_t num_args_to_remove = 0;
-  grpc_arg args_to_add[2];
-  size_t num_args_to_add = 0;
+grpc_channel_args* ModifyGrpclbBalancerChannelArgs(
+    const ServerAddressList& addresses, grpc_channel_args* args) {
+  InlinedVector<const char*, 1> args_to_remove;
+  InlinedVector<grpc_arg, 2> args_to_add;
   // Add arg for targets info table.
-  grpc_core::RefCountedPtr<grpc_core::TargetAuthorityTable>
-      target_authority_table = grpc_core::CreateTargetAuthorityTable(addresses);
-  args_to_add[num_args_to_add++] =
-      grpc_core::CreateTargetAuthorityTableChannelArg(
-          target_authority_table.get());
+  RefCountedPtr<TargetAuthorityTable> target_authority_table =
+      CreateTargetAuthorityTable(addresses);
+  args_to_add.emplace_back(
+      CreateTargetAuthorityTableChannelArg(target_authority_table.get()));
   // Substitute the channel credentials with a version without call
   // credentials: the load balancer is not necessarily trusted to handle
   // bearer token credentials.
   grpc_channel_credentials* channel_credentials =
       grpc_channel_credentials_find_in_args(args);
-  grpc_core::RefCountedPtr<grpc_channel_credentials> creds_sans_call_creds;
+  RefCountedPtr<grpc_channel_credentials> creds_sans_call_creds;
   if (channel_credentials != nullptr) {
     creds_sans_call_creds =
         channel_credentials->duplicate_without_call_credentials();
     GPR_ASSERT(creds_sans_call_creds != nullptr);
-    args_to_remove[num_args_to_remove++] = GRPC_ARG_CHANNEL_CREDENTIALS;
-    args_to_add[num_args_to_add++] =
-        grpc_channel_credentials_to_arg(creds_sans_call_creds.get());
+    args_to_remove.emplace_back(GRPC_ARG_CHANNEL_CREDENTIALS);
+    args_to_add.emplace_back(
+        grpc_channel_credentials_to_arg(creds_sans_call_creds.get()));
   }
   grpc_channel_args* result = grpc_channel_args_copy_and_add_and_remove(
-      args, args_to_remove, num_args_to_remove, args_to_add, num_args_to_add);
+      args, args_to_remove.data(), args_to_remove.size(), args_to_add.data(),
+      args_to_add.size());
   // Clean up.
   grpc_channel_args_destroy(args);
   return result;
 }
+
+grpc_channel* CreateGrpclbBalancerChannel(
+    const char* target_uri, const grpc_channel_args& args) {
+  grpc_channel_credentials* creds =
+      grpc_channel_credentials_find_in_args(&args);
+  const char* arg_to_remove = GRPC_ARG_CHANNEL_CREDENTIALS;
+  grpc_channel_args* new_args =
+      grpc_channel_args_copy_and_remove(&args, &arg_to_remove, 1);
+  grpc_channel* channel =
+      grpc_secure_channel_create(creds, target_uri, new_args, nullptr);
+  grpc_channel_args_destroy(new_args);
+  return channel;
+}
+
+}  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
@@ -338,8 +338,6 @@ class XdsLb : public LoadBalancingPolicy {
         : parent_(std::move(parent)) {}
 
     Subchannel* CreateSubchannel(const grpc_channel_args& args) override;
-    grpc_channel* CreateChannel(const char* target,
-                                const grpc_channel_args& args) override;
     void UpdateState(grpc_connectivity_state state,
                      UniquePtr<SubchannelPicker> picker) override;
     void RequestReresolution() override;
@@ -378,8 +376,6 @@ class XdsLb : public LoadBalancingPolicy {
             : entry_(std::move(entry)) {}
 
         Subchannel* CreateSubchannel(const grpc_channel_args& args) override;
-        grpc_channel* CreateChannel(const char* target,
-                                    const grpc_channel_args& args) override;
         void UpdateState(grpc_connectivity_state state,
                          UniquePtr<SubchannelPicker> picker) override;
         void RequestReresolution() override;
@@ -593,15 +589,6 @@ Subchannel* XdsLb::FallbackHelper::CreateSubchannel(
   return parent_->channel_control_helper()->CreateSubchannel(args);
 }
 
-grpc_channel* XdsLb::FallbackHelper::CreateChannel(
-    const char* target, const grpc_channel_args& args) {
-  if (parent_->shutting_down_ ||
-      (!CalledByPendingFallback() && !CalledByCurrentFallback())) {
-    return nullptr;
-  }
-  return parent_->channel_control_helper()->CreateChannel(target, args);
-}
-
 void XdsLb::FallbackHelper::UpdateState(grpc_connectivity_state state,
                                         UniquePtr<SubchannelPicker> picker) {
   if (parent_->shutting_down_) return;
@@ -723,7 +710,7 @@ ServerAddressList ProcessServerlist(const xds_grpclb_serverlist* serverlist) {
 
 XdsLb::BalancerChannelState::BalancerChannelState(
     const char* balancer_name, const grpc_channel_args& args,
-    grpc_core::RefCountedPtr<grpc_core::XdsLb> parent_xdslb_policy)
+    RefCountedPtr<XdsLb> parent_xdslb_policy)
     : InternallyRefCounted<BalancerChannelState>(&grpc_lb_xds_trace),
       xdslb_policy_(std::move(parent_xdslb_policy)),
       lb_call_backoff_(
@@ -736,8 +723,7 @@ XdsLb::BalancerChannelState::BalancerChannelState(
   GRPC_CLOSURE_INIT(&on_connectivity_changed_,
                     &XdsLb::BalancerChannelState::OnConnectivityChangedLocked,
                     this, grpc_combiner_scheduler(xdslb_policy_->combiner()));
-  channel_ = xdslb_policy_->channel_control_helper()->CreateChannel(
-      balancer_name, args);
+  channel_ = CreateXdsBalancerChannel(balancer_name, args);
   GPR_ASSERT(channel_ != nullptr);
   StartCallLocked();
 }
@@ -1329,7 +1315,7 @@ grpc_channel_args* BuildBalancerChannelArgs(const grpc_channel_args* args) {
       // factory will re-add this arg with the right value.
       GRPC_ARG_SERVER_URI,
       // The LB channel should use the authority indicated by the target
-      // authority table (see \a grpc_lb_policy_xds_modify_lb_channel_args),
+      // authority table (see \a ModifyXdsBalancerChannelArgs),
       // as opposed to the authority from the parent channel.
       GRPC_ARG_DEFAULT_AUTHORITY,
       // Just as for \a GRPC_ARG_DEFAULT_AUTHORITY, the LB channel should be
@@ -1352,7 +1338,7 @@ grpc_channel_args* BuildBalancerChannelArgs(const grpc_channel_args* args) {
       args, args_to_remove, GPR_ARRAY_SIZE(args_to_remove), args_to_add,
       GPR_ARRAY_SIZE(args_to_add));
   // Make any necessary modifications for security.
-  return grpc_lb_policy_xds_modify_lb_channel_args(new_args);
+  return ModifyXdsBalancerChannelArgs(new_args);
 }
 
 //
@@ -2012,15 +1998,6 @@ Subchannel* XdsLb::LocalityMap::LocalityEntry::Helper::CreateSubchannel(
     return nullptr;
   }
   return entry_->parent_->channel_control_helper()->CreateSubchannel(args);
-}
-
-grpc_channel* XdsLb::LocalityMap::LocalityEntry::Helper::CreateChannel(
-    const char* target, const grpc_channel_args& args) {
-  if (entry_->parent_->shutting_down_ ||
-      (!CalledByPendingChild() && !CalledByCurrentChild())) {
-    return nullptr;
-  }
-  return entry_->parent_->channel_control_helper()->CreateChannel(target, args);
 }
 
 void XdsLb::LocalityMap::LocalityEntry::Helper::UpdateState(

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_channel.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_channel.cc
@@ -20,7 +20,15 @@
 
 #include "src/core/ext/filters/client_channel/lb_policy/xds/xds_channel.h"
 
-grpc_channel_args* grpc_lb_policy_xds_modify_lb_channel_args(
-    grpc_channel_args* args) {
+namespace grpc_core {
+
+grpc_channel_args* ModifyXdsBalancerChannelArgs(grpc_channel_args* args) {
   return args;
 }
+
+grpc_channel* CreateXdsBalancerChannel(const char* target_uri,
+                                       const grpc_channel_args& args) {
+  return grpc_insecure_channel_create(target_uri, &args, nullptr);
+}
+
+}  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_channel.h
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_channel.h
@@ -23,14 +23,20 @@
 
 #include <grpc/impl/codegen/grpc_types.h>
 
+namespace grpc_core {
+
 /// Makes any necessary modifications to \a args for use in the xds
 /// balancer channel.
 ///
 /// Takes ownership of \a args.
 ///
 /// Caller takes ownership of the returned args.
-grpc_channel_args* grpc_lb_policy_xds_modify_lb_channel_args(
-    grpc_channel_args* args);
+grpc_channel_args* ModifyXdsBalancerChannelArgs(grpc_channel_args* args);
+
+grpc_channel* CreateXdsBalancerChannel(const char* target_uri,
+                                       const grpc_channel_args& args);
+
+}  // namespace grpc_core
 
 #endif /* GRPC_CORE_EXT_FILTERS_CLIENT_CHANNEL_LB_POLICY_XDS_XDS_CHANNEL_H \
         */

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_channel_secure.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_channel_secure.cc
@@ -33,29 +33,44 @@
 #include "src/core/lib/security/transport/target_authority_table.h"
 #include "src/core/lib/slice/slice_internal.h"
 
-grpc_channel_args* grpc_lb_policy_xds_modify_lb_channel_args(
-    grpc_channel_args* args) {
-  const char* args_to_remove[1];
-  size_t num_args_to_remove = 0;
-  grpc_arg args_to_add[2];
-  size_t num_args_to_add = 0;
+namespace grpc_core {
+
+grpc_channel_args* ModifyXdsBalancerChannelArgs(grpc_channel_args* args) {
+  InlinedVector<const char*, 1> args_to_remove;
+  InlinedVector<grpc_arg, 2> args_to_add;
   // Substitute the channel credentials with a version without call
   // credentials: the load balancer is not necessarily trusted to handle
   // bearer token credentials.
   grpc_channel_credentials* channel_credentials =
       grpc_channel_credentials_find_in_args(args);
-  grpc_core::RefCountedPtr<grpc_channel_credentials> creds_sans_call_creds;
+  RefCountedPtr<grpc_channel_credentials> creds_sans_call_creds;
   if (channel_credentials != nullptr) {
     creds_sans_call_creds =
         channel_credentials->duplicate_without_call_credentials();
     GPR_ASSERT(creds_sans_call_creds != nullptr);
-    args_to_remove[num_args_to_remove++] = GRPC_ARG_CHANNEL_CREDENTIALS;
-    args_to_add[num_args_to_add++] =
-        grpc_channel_credentials_to_arg(creds_sans_call_creds.get());
+    args_to_remove.emplace_back(GRPC_ARG_CHANNEL_CREDENTIALS);
+    args_to_add.emplace_back(
+        grpc_channel_credentials_to_arg(creds_sans_call_creds.get()));
   }
   grpc_channel_args* result = grpc_channel_args_copy_and_add_and_remove(
-      args, args_to_remove, num_args_to_remove, args_to_add, num_args_to_add);
+      args, args_to_remove.data(), args_to_remove.size(), args_to_add.data(),
+      args_to_add.size());
   // Clean up.
   grpc_channel_args_destroy(args);
   return result;
 }
+
+grpc_channel* CreateXdsBalancerChannel(const char* target_uri,
+                                       const grpc_channel_args& args) {
+  grpc_channel_credentials* creds =
+      grpc_channel_credentials_find_in_args(&args);
+  const char* arg_to_remove = GRPC_ARG_CHANNEL_CREDENTIALS;
+  grpc_channel_args* new_args =
+      grpc_channel_args_copy_and_remove(&args, &arg_to_remove, 1);
+  grpc_channel* channel =
+      grpc_secure_channel_create(creds, target_uri, new_args, nullptr);
+  grpc_channel_args_destroy(new_args);
+  return channel;
+}
+
+}  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.cc
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.cc
@@ -112,13 +112,6 @@ class ResolvingLoadBalancingPolicy::ResolvingControlHelper
     return parent_->channel_control_helper()->CreateSubchannel(args);
   }
 
-  grpc_channel* CreateChannel(const char* target,
-                              const grpc_channel_args& args) override {
-    if (parent_->resolver_ == nullptr) return nullptr;  // Shutting down.
-    if (!CalledByCurrentChild() && !CalledByPendingChild()) return nullptr;
-    return parent_->channel_control_helper()->CreateChannel(target, args);
-  }
-
   void UpdateState(grpc_connectivity_state state,
                    UniquePtr<SubchannelPicker> picker) override {
     if (parent_->resolver_ == nullptr) return;  // Shutting down.

--- a/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
+++ b/src/core/ext/transport/chttp2/client/secure/secure_channel_create.cc
@@ -58,26 +58,6 @@ class Chttp2SecureClientChannelFactory : public ClientChannelFactory {
     return s;
   }
 
-  grpc_channel* CreateChannel(const char* target,
-                              const grpc_channel_args* args) override {
-    if (target == nullptr) {
-      gpr_log(GPR_ERROR, "cannot create channel with NULL target name");
-      return nullptr;
-    }
-    // Add channel arg containing the server URI.
-    UniquePtr<char> canonical_target =
-        ResolverRegistry::AddDefaultPrefixIfNeeded(target);
-    grpc_arg arg = grpc_channel_arg_string_create(
-        const_cast<char*>(GRPC_ARG_SERVER_URI), canonical_target.get());
-    const char* to_remove[] = {GRPC_ARG_SERVER_URI};
-    grpc_channel_args* new_args =
-        grpc_channel_args_copy_and_add_and_remove(args, to_remove, 1, &arg, 1);
-    grpc_channel* channel =
-        grpc_channel_create(target, new_args, GRPC_CLIENT_CHANNEL, nullptr);
-    grpc_channel_args_destroy(new_args);
-    return channel;
-  }
-
  private:
   static grpc_channel_args* GetSecureNamingChannelArgs(
       const grpc_channel_args* args) {
@@ -170,6 +150,29 @@ class Chttp2SecureClientChannelFactory : public ClientChannelFactory {
   }
 };
 
+namespace {
+
+grpc_channel* CreateChannel(const char* target, const grpc_channel_args* args) {
+  if (target == nullptr) {
+    gpr_log(GPR_ERROR, "cannot create channel with NULL target name");
+    return nullptr;
+  }
+  // Add channel arg containing the server URI.
+  UniquePtr<char> canonical_target =
+      ResolverRegistry::AddDefaultPrefixIfNeeded(target);
+  grpc_arg arg = grpc_channel_arg_string_create(
+      const_cast<char*>(GRPC_ARG_SERVER_URI), canonical_target.get());
+  const char* to_remove[] = {GRPC_ARG_SERVER_URI};
+  grpc_channel_args* new_args =
+      grpc_channel_args_copy_and_add_and_remove(args, to_remove, 1, &arg, 1);
+  grpc_channel* channel =
+      grpc_channel_create(target, new_args, GRPC_CLIENT_CHANNEL, nullptr);
+  grpc_channel_args_destroy(new_args);
+  return channel;
+}
+
+}  // namespace
+
 }  // namespace grpc_core
 
 namespace {
@@ -209,7 +212,7 @@ grpc_channel* grpc_secure_channel_create(grpc_channel_credentials* creds,
         args, args_to_add, GPR_ARRAY_SIZE(args_to_add));
     new_args = creds->update_arguments(new_args);
     // Create channel.
-    channel = g_factory->CreateChannel(target, new_args);
+    channel = grpc_core::CreateChannel(target, new_args);
     // Clean up.
     grpc_channel_args_destroy(new_args);
   }

--- a/test/core/util/test_lb_policies.cc
+++ b/test/core/util/test_lb_policies.cc
@@ -145,11 +145,6 @@ class InterceptRecvTrailingMetadataLoadBalancingPolicy
       return parent_->channel_control_helper()->CreateSubchannel(args);
     }
 
-    grpc_channel* CreateChannel(const char* target,
-                                const grpc_channel_args& args) override {
-      return parent_->channel_control_helper()->CreateChannel(target, args);
-    }
-
     void UpdateState(grpc_connectivity_state state,
                      UniquePtr<SubchannelPicker> picker) override {
       parent_->channel_control_helper()->UpdateState(

--- a/test/cpp/microbenchmarks/bm_call_create.cc
+++ b/test/cpp/microbenchmarks/bm_call_create.cc
@@ -322,10 +322,6 @@ class FakeClientChannelFactory : public grpc_core::ClientChannelFactory {
       const grpc_channel_args* args) override {
     return nullptr;
   }
-  grpc_channel* CreateChannel(const char* target,
-                              const grpc_channel_args* args) override {
-    return nullptr;
-  }
 };
 
 static grpc_arg StringArg(const char* key, const char* value) {


### PR DESCRIPTION
This removes more surface area from the LB policy API, as requested by Sanjay.  It also eliminates a method from the `ClientChannelFactory` API, which is provided by most transports.  (The latter will require internal changes in order to import this PR, so I will probably do the import as a cherry-pick.)

Instead of creating channels through the helper, LB policies now go directly to the C-core API.  Eventually, they will be able to use the C generic bidi streaming callback API that we will build after we move to the callback API in C++.

Note that this change does slightly change the semantics of how grpclb or xds interact with alternative transports.  Prior to this PR, using the helper to create the balancer channel ensured that the balancer channel would always use the same transport as the parent channel; with this PR, grpclb and xds will always use the HTTP/2 transport.  This should be fine for now, since we don't actually have any use-cases where we need to use grpclb or xds with any other transport (inproc and cronet use direct channels and therefore don't support load balancing at all, and our internal quic transport is not currently used in production).  And if we do encounter such use-cases in the future, I suspect that we will want to address them in a different way anyway, since we will probably want to allow selecting the transport for the backend and balancer channels independently of each other.