### PR TITLE
Fix forward cpp_generator.cc

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -138,6 +138,7 @@ grpc::string GetHeaderIncludes(grpc_generator::File* file,
     }
     static const char* headers_strs[] = {
         "functional",
+        "grpcpp/channel.h",
         "grpcpp/impl/codegen/async_generic_service.h",
         "grpcpp/impl/codegen/async_stream.h",
         "grpcpp/impl/codegen/async_unary_call.h",


### PR DESCRIPTION
This part of the diff seems to have been needed internally by #18370 and #18371, but it wasn't originally in those PR's - thus there's currently a perpetual diff between this file in github and internal.