### PR TITLE
Satisfy GCC class-memaccess warning

### DIFF
--- a/src/cpp/common/channel_filter.cc
+++ b/src/cpp/common/channel_filter.cc
@@ -30,7 +30,7 @@ namespace grpc {
 grpc_linked_mdelem* MetadataBatch::AddMetadata(const string& key,
                                                const string& value) {
   grpc_linked_mdelem* storage = new grpc_linked_mdelem;
-  memset(storage, 0, sizeof(grpc_linked_mdelem));
+  memset(static_cast<void*>(storage), 0, sizeof(grpc_linked_mdelem));
   storage->md = grpc_mdelem_from_slices(SliceFromCopiedString(key),
                                         SliceFromCopiedString(value));
   GRPC_LOG_IF_ERROR("MetadataBatch::AddMetadata",


### PR DESCRIPTION
GCC 8 added a -Wclass-memaccess that is enabled in -Wall that warns when
making direct memory modifications to non-trivial objects. The object
that is modified here is only "non-trivial" in non-interesting ways
(e.g., non-default constructor) and can be safely modified as is being
done.

This simply explicitly casts the pointer before calling memset to
indicate that it should be treated as raw memory.