### PR TITLE
Remove get-grpc.sh

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
@@ -38,7 +38,5 @@
   then
     ln -s $(pwd)/.dotnet/dotnet /usr/local/bin/dotnet
   fi
-  
-  ./build/get-grpc.sh
 
   dotnet build --configuration Debug Grpc.AspNetCore.sln

--- a/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
@@ -37,6 +37,4 @@ then
   ln -s $(pwd)/.dotnet/dotnet /usr/local/bin/dotnet
 fi
 
-./build/get-grpc.sh
-
 dotnet build --configuration Debug Grpc.AspNetCore.sln


### PR DESCRIPTION
After the completion of https://github.com/grpc/grpc-dotnet/issues/179. We no longer need the get-grpc.sh script. This is a minor cleanup and would allow us to delete that file in grpc-dotnet.

cc @jtattermusch 