### PR TITLE
Remove reference to "class Channel" from gen. code

### DIFF
--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -160,7 +160,6 @@ grpc::string GetHeaderIncludes(grpc_generator::File* file,
     printer->Print(vars, "class MessageAllocator;\n");
     printer->Print(vars, "}  // namespace experimental\n");
     printer->Print(vars, "class CompletionQueue;\n");
-    printer->Print(vars, "class Channel;\n");
     printer->Print(vars, "class ServerCompletionQueue;\n");
     printer->Print(vars, "class ServerContext;\n");
     printer->Print(vars, "}  // namespace grpc\n\n");

--- a/test/cpp/codegen/compiler_test_golden
+++ b/test/cpp/codegen/compiler_test_golden
@@ -46,7 +46,6 @@ template <typename RequestT, typename ResponseT>
 class MessageAllocator;
 }  // namespace experimental
 class CompletionQueue;
-class Channel;
 class ServerCompletionQueue;
 class ServerContext;
 }  // namespace grpc


### PR DESCRIPTION
The generated code doesn't use this, and forward references are a bad thing. That said, I bet there are hundreds of IWYU and Hyrum's Law violations that will break from this.

Cc @apolcyn 