### PR TITLE
Fix node interop build scripts

### DIFF
--- a/tools/dockerfile/interoptest/grpc_interop_node/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_node/build_interop.sh
@@ -29,6 +29,4 @@ cp -r /var/local/jenkins/service_account $HOME || true
 cd /var/local/git/grpc-node
 
 # build Node interop client & server
-npm install -g node-gyp gulp
-npm install
-gulp setup
+./setup_interop.sh

--- a/tools/dockerfile/interoptest/grpc_interop_nodepurejs/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_nodepurejs/build_interop.sh
@@ -29,8 +29,4 @@ cp -r /var/local/jenkins/service_account $HOME || true
 cd /var/local/git/grpc-node
 
 # build Node interop client & server
-npm install -g gulp
-npm install
-gulp js.core.install
-gulp protobuf.install
-gulp internal.test.install
+./setup_interop_purejs.sh


### PR DESCRIPTION
Backport #19006 to v1.21.x. Not having this caused build failures in #19037.