### PR TITLE
Grab a ref on fake resolver generator before scheduling a closure

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
@@ -175,11 +175,13 @@ void FakeResolverResponseGenerator::SetResponseLocked(void* arg,
   resolver->next_result_ = std::move(closure_arg->result);
   resolver->has_next_result_ = true;
   resolver->MaybeSendResultLocked();
+  closure_arg->generator->Unref();
   Delete(closure_arg);
 }
 
 void FakeResolverResponseGenerator::SetResponse(Resolver::Result result) {
   if (resolver_ != nullptr) {
+    Ref().release();  // ref to be held by closure
     SetResponseClosureArg* closure_arg = New<SetResponseClosureArg>();
     closure_arg->generator = this;
     closure_arg->result = std::move(result);


### PR DESCRIPTION
https://source.cloud.google.com/results/invocations/8a7f7da4-cc91-4499-9cb1-66c8916676a7/targets/%2F%2Ftest%2Fcpp%2Fclient:client_channel_stress_test@poller%3Dpoll/log

The fake resolver response generator is sometimes getting destroyed by unreffing before SetResponseLocked completes, and that function is triggered by a closure from SetResponse. Since the unref/destruction might come in between SetResponse and the closure that it schedules, there should be a ref/unref pair on the creation/completion of that closure.

I've run client_channel_stress_test on this attempted fix through ASAN with 1000 runs and no flakes.
