### PR TITLE
Add an early flush so that the shutdown callback does not have to wait for deadline expiration

### DIFF
--- a/test/core/util/test_tcp_server.cc
+++ b/test/core/util/test_tcp_server.cc
@@ -95,16 +95,13 @@ static void finish_pollset(void* arg, grpc_error* error) {
 
 void test_tcp_server_destroy(test_tcp_server* server) {
   grpc_core::ExecCtx exec_ctx;
-  gpr_timespec shutdown_deadline;
   grpc_closure do_nothing_cb;
   grpc_tcp_server_unref(server->tcp_server);
   GRPC_CLOSURE_INIT(&do_nothing_cb, do_nothing, nullptr,
                     grpc_schedule_on_exec_ctx);
-  shutdown_deadline = gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
-                                   gpr_time_from_seconds(5, GPR_TIMESPAN));
-  while (!server->shutdown &&
-         gpr_time_cmp(gpr_now(GPR_CLOCK_MONOTONIC), shutdown_deadline) < 0) {
-    test_tcp_server_poll(server, 1000);
+  grpc_core::ExecCtx::Get()->Flush();
+  while (!server->shutdown) {
+    test_tcp_server_poll(server, 100);
   }
   grpc_pollset_shutdown(server->pollset,
                         GRPC_CLOSURE_CREATE(finish_pollset, server->pollset,


### PR DESCRIPTION
It seems we explicitly asked for a 5s polling for server to shutdown cleanly. This caused some tests to run slow with repeating creation/destroy of the test server. I replaced it with a flush and it does not seem to break anything.