### PR TITLE
Rename root certificate bundle in gRPC-C++ pod

### DIFF
--- a/gRPC-C++.podspec
+++ b/gRPC-C++.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.name     = 'gRPC-C++'
   # TODO (mxyan): use version that match gRPC version when pod is stabilized
   # version = '1.22.0-dev'
-  version = '0.0.8-dev'
+  version = '0.0.9-dev'
   s.version  = version
   s.summary  = 'gRPC C++ library'
   s.homepage = 'https://grpc.io'
@@ -72,7 +72,7 @@ Pod::Spec.new do |s|
   s.default_subspecs = 'Interface', 'Implementation'
 
   # Certificates, to be able to establish TLS connections:
-  s.resource_bundles = { 'gRPCCertificates' => ['etc/roots.pem'] }
+  s.resource_bundles = { 'gRPCCertificates-Cpp' => ['etc/roots.pem'] }
 
   s.header_mappings_dir = 'include/grpcpp'
 

--- a/templates/gRPC-C++.podspec.template
+++ b/templates/gRPC-C++.podspec.template
@@ -140,7 +140,7 @@
     s.name     = 'gRPC-C++'
     # TODO (mxyan): use version that match gRPC version when pod is stabilized
     # version = '${settings.version}'
-    version = '${modify_podspec_version_string('0.0.8', settings.version)}'
+    version = '${modify_podspec_version_string('0.0.9', settings.version)}'
     s.version  = version
     s.summary  = 'gRPC C++ library'
     s.homepage = 'https://grpc.io'
@@ -188,7 +188,7 @@
     s.default_subspecs = 'Interface', 'Implementation'
 
     # Certificates, to be able to establish TLS connections:
-    s.resource_bundles = { 'gRPCCertificates' => ['etc/roots.pem'] }
+    s.resource_bundles = { 'gRPCCertificates-Cpp' => ['etc/roots.pem'] }
 
     s.header_mappings_dir = 'include/grpcpp'
 


### PR DESCRIPTION
The bundle's name in `gRPC-C++` pod and `gRPC` pod are the same and are conflicting with each other in projects that include both `gRPC` and `gRPC-C++` pods. Renaming the one in gRPC-C++ avoids making breaking change to `gRPC` pod and works for gRPC-C++ too since it's still in 0.0.x versions.

The fix is not ideal though. Ideally we should expect there to be only 1 copy of the pem file in any project. We may come back for a better solution later.