### PR TITLE
Add python deprecation notices.

### DIFF
--- a/src/python/grpcio/README.rst
+++ b/src/python/grpcio/README.rst
@@ -3,6 +3,14 @@ gRPC Python
 
 Package for gRPC Python.
 
+Supported Python Versions
+-------------------------
+Python >= 3.5
+
+Deprecated Python Versions
+--------------------------
+Python == 2.7. Python 2.7 support will be removed on January 1, 2020.
+
 Installation
 ------------
 

--- a/src/python/grpcio_channelz/README.rst
+++ b/src/python/grpcio_channelz/README.rst
@@ -3,6 +3,14 @@ gRPC Python Channelz package
 
 Channelz is a live debug tool in gRPC Python.
 
+Supported Python Versions
+-------------------------
+Python >= 3.5
+
+Deprecated Python Versions
+--------------------------
+Python == 2.7. Python 2.7 support will be removed on January 1, 2020.
+
 Dependencies
 ------------
 

--- a/src/python/grpcio_channelz/setup.py
+++ b/src/python/grpcio_channelz/setup.py
@@ -18,6 +18,9 @@ import sys
 
 import setuptools
 
+_PACKAGE_PATH = os.path.realpath(os.path.dirname(__file__))
+_README_PATH = os.path.join(_PACKAGE_PATH, 'README.rst')
+
 # Ensure we're in the proper directory whether or not we're being used by pip.
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
@@ -85,6 +88,7 @@ setuptools.setup(
     version=grpc_version.VERSION,
     license='Apache License 2.0',
     description='Channel Level Live Debug Information Service for gRPC',
+    long_description=open(_README_PATH, 'r').read(),
     author='The gRPC Authors',
     author_email='grpc-io@googlegroups.com',
     classifiers=CLASSIFIERS,

--- a/src/python/grpcio_health_checking/README.rst
+++ b/src/python/grpcio_health_checking/README.rst
@@ -3,6 +3,14 @@ gRPC Python Health Checking
 
 Reference package for GRPC Python health checking.
 
+Supported Python Versions
+-------------------------
+Python >= 3.5
+
+Deprecated Python Versions
+--------------------------
+Python == 2.7. Python 2.7 support will be removed on January 1, 2020.
+
 Dependencies
 ------------
 

--- a/src/python/grpcio_health_checking/setup.py
+++ b/src/python/grpcio_health_checking/setup.py
@@ -17,6 +17,9 @@ import os
 
 import setuptools
 
+_PACKAGE_PATH = os.path.realpath(os.path.dirname(__file__))
+_README_PATH = os.path.join(_PACKAGE_PATH, 'README.rst')
+
 # Ensure we're in the proper directory whether or not we're being used by pip.
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
@@ -83,6 +86,7 @@ setuptools.setup(
     name='grpcio-health-checking',
     version=grpc_version.VERSION,
     description='Standard Health Checking Service for gRPC',
+    long_description=open(_README_PATH, 'r').read(),
     author='The gRPC Authors',
     author_email='grpc-io@googlegroups.com',
     url='https://grpc.io',

--- a/src/python/grpcio_reflection/README.rst
+++ b/src/python/grpcio_reflection/README.rst
@@ -3,6 +3,14 @@ gRPC Python Reflection package
 
 Reference package for reflection in GRPC Python.
 
+Supported Python Versions
+-------------------------
+Python >= 3.5
+
+Deprecated Python Versions
+--------------------------
+Python == 2.7. Python 2.7 support will be removed on January 1, 2020.
+
 Dependencies
 ------------
 

--- a/src/python/grpcio_reflection/setup.py
+++ b/src/python/grpcio_reflection/setup.py
@@ -18,6 +18,9 @@ import sys
 
 import setuptools
 
+_PACKAGE_PATH = os.path.realpath(os.path.dirname(__file__))
+_README_PATH = os.path.join(_PACKAGE_PATH, 'README.rst')
+
 # Ensure we're in the proper directory whether or not we're being used by pip.
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
@@ -85,6 +88,7 @@ setuptools.setup(
     version=grpc_version.VERSION,
     license='Apache License 2.0',
     description='Standard Protobuf Reflection Service for gRPC',
+    long_description=open(_README_PATH, 'r').read(),
     author='The gRPC Authors',
     author_email='grpc-io@googlegroups.com',
     classifiers=CLASSIFIERS,

--- a/src/python/grpcio_status/README.rst
+++ b/src/python/grpcio_status/README.rst
@@ -3,6 +3,14 @@ gRPC Python Status Proto
 
 Reference package for GRPC Python status proto mapping.
 
+Supported Python Versions
+-------------------------
+Python >= 3.5
+
+Deprecated Python Versions
+--------------------------
+Python == 2.7. Python 2.7 support will be removed on January 1, 2020.
+
 Dependencies
 ------------
 

--- a/src/python/grpcio_status/setup.py
+++ b/src/python/grpcio_status/setup.py
@@ -17,6 +17,9 @@ import os
 
 import setuptools
 
+_PACKAGE_PATH = os.path.realpath(os.path.dirname(__file__))
+_README_PATH = os.path.join(_PACKAGE_PATH, 'README.rst')
+
 # Ensure we're in the proper directory whether or not we're being used by pip.
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
@@ -82,6 +85,7 @@ setuptools.setup(
     name='grpcio-status',
     version=grpc_version.VERSION,
     description='Status proto mapping for gRPC',
+    long_description=open(_README_PATH, 'r').read(),
     author='The gRPC Authors',
     author_email='grpc-io@googlegroups.com',
     url='https://grpc.io',

--- a/src/python/grpcio_testing/README.rst
+++ b/src/python/grpcio_testing/README.rst
@@ -3,6 +3,14 @@ gRPC Python Testing Package
 
 Testing utilities for gRPC Python
 
+Supported Python Versions
+-------------------------
+Python >= 3.5
+
+Deprecated Python Versions
+--------------------------
+Python == 2.7. Python 2.7 support will be removed on January 1, 2020.
+
 Dependencies
 ------------
 

--- a/src/python/grpcio_testing/setup.py
+++ b/src/python/grpcio_testing/setup.py
@@ -18,6 +18,9 @@ import sys
 
 import setuptools
 
+_PACKAGE_PATH = os.path.realpath(os.path.dirname(__file__))
+_README_PATH = os.path.join(_PACKAGE_PATH, 'README.rst')
+
 # Ensure we're in the proper directory whether or not we're being used by pip.
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
@@ -68,6 +71,7 @@ setuptools.setup(
     version=grpc_version.VERSION,
     license='Apache License 2.0',
     description='Testing utilities for gRPC Python',
+    long_description=open(_README_PATH, 'r').read(),
     author='The gRPC Authors',
     author_email='grpc-io@googlegroups.com',
     url='https://grpc.io',

--- a/tools/distrib/python/grpcio_tools/README.rst
+++ b/tools/distrib/python/grpcio_tools/README.rst
@@ -3,6 +3,14 @@ gRPC Python Tools
 
 Package for gRPC Python tools.
 
+Supported Python Versions
+-------------------------
+Python >= 3.5
+
+Deprecated Python Versions
+--------------------------
+Python == 2.7. Python 2.7 support will be removed on January 1, 2020.
+
 Installation
 ------------
 

--- a/tools/distrib/python/grpcio_tools/setup.py
+++ b/tools/distrib/python/grpcio_tools/setup.py
@@ -31,6 +31,9 @@ from setuptools.command import build_ext
 
 # TODO(atash) add flag to disable Cython use
 
+_PACKAGE_PATH = os.path.realpath(os.path.dirname(__file__))
+_README_PATH = os.path.join(_PACKAGE_PATH, 'README.rst')
+
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, os.path.abspath('.'))
 
@@ -191,6 +194,7 @@ setuptools.setup(
     name='grpcio-tools',
     version=grpc_version.VERSION,
     description='Protobuf code generator for gRPC',
+    long_description=open(_README_PATH, 'r').read(),
     author='The gRPC Authors',
     author_email='grpc-io@googlegroups.com',
     url='https://grpc.io',


### PR DESCRIPTION
Cherry-pick of https://github.com/grpc/grpc/pull/19081.

This PR adds Python 2 deprecation notices to all gRPC packages uploaded to PyPI. These changes are in line with the messaging present on Google Cloud Client library packages. This change is to be duplicated on `master`.

It appears there is no formal metadatum to indicate deprecation of a Python version (as per [PEP 345](https://www.python.org/dev/peps/pep-0345/)), so the notice is purely textual.