### PR TITLE
Produce Python Wheels with a Valid long_description field

### DIFF
--- a/src/python/grpcio/README.rst
+++ b/src/python/grpcio/README.rst
@@ -16,8 +16,8 @@ Installation
 
 gRPC Python is available for Linux, macOS, and Windows.
 
-From PyPI
-~~~~~~~~~
+Installing From PyPI
+~~~~~~~~~~~~~~~~~~~~
 
 If you are installing locally...
 
@@ -45,8 +45,8 @@ n.b. On Windows and on Mac OS X one *must* have a recent release of :code:`pip`
 to retrieve the proper wheel from PyPI. Be sure to upgrade to the latest
 version!
 
-From Source
-~~~~~~~~~~~
+Installing From Source
+~~~~~~~~~~~~~~~~~~~~~~
 
 Building from source requires that you have the Python headers (usually a
 package named :code:`python-dev`).

--- a/tools/distrib/python/grpcio_tools/README.rst
+++ b/tools/distrib/python/grpcio_tools/README.rst
@@ -17,8 +17,8 @@ Installation
 The gRPC Python tools package is available for Linux, Mac OS X, and Windows
 running Python 2.7.
 
-From PyPI
-~~~~~~~~~
+Installing From PyPI
+~~~~~~~~~~~~~~~~~~~~
 
 If you are installing locally...
 
@@ -50,8 +50,8 @@ You might also need to install Cython to handle installation via the source
 distribution if gRPC Python's system coverage with wheels does not happen to
 include your system.
 
-From Source
-~~~~~~~~~~~
+Installing From Source
+~~~~~~~~~~~~~~~~~~~~~~
 
 Building from source requires that you have the Python headers (usually a
 package named :code:`python-dev`) and Cython installed. It further requires a

--- a/tools/run_tests/artifacts/build_artifact_python.bat
+++ b/tools/run_tests/artifacts/build_artifact_python.bat
@@ -46,6 +46,10 @@ pushd tools\distrib\python\grpcio_tools
 python setup.py bdist_wheel || goto :error
 popd
 
+@rem Ensure the generate artifacts are valid.
+pip install twine
+python -m twine check dist\* tools\distrib\python\grpcio_tools\dist\* || goto :error
+
 xcopy /Y /I /S dist\* %ARTIFACT_DIR% || goto :error
 xcopy /Y /I /S tools\distrib\python\grpcio_tools\dist\* %ARTIFACT_DIR% || goto :error
 

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -130,5 +130,8 @@ then
   cp -r src/python/grpcio_status/dist/* "$ARTIFACT_DIR"
 fi
 
+"${PIP}" install twine
+
+twine check dist/* tools/distrib/python/grpcio_tools/dist/*
 cp -r dist/* "$ARTIFACT_DIR"
 cp -r tools/distrib/python/grpcio_tools/dist/* "$ARTIFACT_DIR"

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -130,8 +130,9 @@ then
   cp -r src/python/grpcio_status/dist/* "$ARTIFACT_DIR"
 fi
 
+# Ensure the generated artifacts are valid.
 "${PIP}" install twine
+"${PYTHON}" -m twine check dist/* tools/distrib/python/grpcio_tools/dist/*
 
-twine check dist/* tools/distrib/python/grpcio_tools/dist/*
 cp -r dist/* "$ARTIFACT_DIR"
 cp -r tools/distrib/python/grpcio_tools/dist/* "$ARTIFACT_DIR"


### PR DESCRIPTION
While uploading the `1.21.0` artifacts to PyPI, I encountered the following error:
```
 <h1>400 The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.</h1>
  The server could not comply with the request since it is either malformed or otherwise incorrect.<br/><br/>
The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.
```

Digging in, I found that 24 of our 69 artifacts contained corrupted `DESCRIPTION.rst` files. Header line starting with "From" had become ">From" in the wheel, causing the following underline to be syntactically invalid RST. I verified that `grpcio-1.21.0-cp27-cp27mu-linux_armv7l.whl` was able to be uploaded after removing the offending character and repacking the wheel.

I tracked down https://github.com/pypa/wheel/issues/189, which describes this exact issue. 

Using `twine`, I was able to verify the exact list of offending wheels:
 - `./grpcio-1.21.0-cp36-cp36m-win32.whl`
 - `./grpcio-1.21.0-cp27-cp27m-win32.whl`
 - `./grpcio-1.21.0-cp35-cp35m-linux_armv7l.whl`
 - `./grpcio_tools-1.21.0-cp34-cp34m-linux_armv7l.whl`
 - `./grpcio_tools-1.21.0-cp27-cp27m-win_amd64.whl`
 - `./grpcio_tools-1.21.0-cp36-cp36m-win_amd64.whl`
 - `./grpcio_tools-1.21.0-cp34-cp34m-win_amd64.whl`
 - `./grpcio-1.21.0-cp27-cp27m-win_amd64.whl`
 - `./grpcio_tools-1.21.0-cp35-cp35m-win32.whl`
 - `./grpcio_tools-1.21.0-cp35-cp35m-win_amd64.whl`
 - `./grpcio_tools-1.21.0-cp36-cp36m-linux_armv7l.whl`
 - `./grpcio-1.21.0-cp36-cp36m-win_amd64.whl`
 - `./grpcio-1.21.0-cp34-cp34m-win32.whl`
 - `./grpcio_tools-1.21.0-cp27-cp27m-win32.whl`
 - `./grpcio_tools-1.21.0-cp35-cp35m-linux_armv7l.whl`
 - `./grpcio-1.21.0-cp36-cp36m-linux_armv7l.whl`
 - `./grpcio_tools-1.21.0-cp36-cp36m-win32.whl`
 - `./grpcio-1.21.0-cp34-cp34m-win_amd64.whl`
 - `./grpcio-1.21.0-cp34-cp34m-linux_armv7l.whl`
 - `./grpcio_tools-1.21.0-cp27-cp27mu-linux_armv7l.whl`
 - `./grpcio-1.21.0-cp27-cp27mu-linux_armv7l.whl`
 - `./grpcio-1.21.0-cp35-cp35m-win32.whl`
 - `./grpcio-1.21.0-cp35-cp35m-win_amd64.whl`

Only Mac, Windows, and ARM artifacts were seeing the problem. I began to wonder if this was simply because these build environments were using an outdated version of the `wheel` package.

This PR:
 - Updates the `long_description` field to avoid the bug.
 - Runs `twine check` after generating wheels to ensure that they will upload successfully.