### PR TITLE
Expose interop tests and add --tls_key_file flag for interop_server

### DIFF
--- a/src/proto/grpc/testing/BUILD
+++ b/src/proto/grpc/testing/BUILD
@@ -18,11 +18,17 @@ load("//bazel:grpc_build_system.bzl", "grpc_proto_library", "grpc_package")
 load("@grpc_python_dependencies//:requirements.bzl", "requirement")
 load("//bazel:python_rules.bzl", "py_proto_library")
 
-grpc_package(name = "testing", visibility = "public")
+grpc_package(
+    name = "testing",
+    visibility = "public",
+)
 
 exports_files([
     "echo.proto",
     "echo_messages.proto",
+    "test.proto",
+    "empty.proto",
+    "messages.proto",
 ])
 
 grpc_proto_library(
@@ -50,9 +56,11 @@ grpc_proto_library(
 grpc_proto_library(
     name = "echo_proto",
     srcs = ["echo.proto"],
-    deps = ["echo_messages_proto",
-            "simple_messages_proto"],
     generate_mocks = True,
+    deps = [
+        "echo_messages_proto",
+        "simple_messages_proto",
+    ],
 )
 
 grpc_proto_library(
@@ -102,7 +110,7 @@ grpc_proto_library(
     name = "benchmark_service_proto",
     srcs = ["benchmark_service.proto"],
     deps = [
-      "messages_proto",
+        "messages_proto",
     ],
 )
 
@@ -110,7 +118,7 @@ grpc_proto_library(
     name = "report_qps_scenario_service_proto",
     srcs = ["report_qps_scenario_service.proto"],
     deps = [
-      "control_proto",
+        "control_proto",
     ],
 )
 
@@ -118,7 +126,7 @@ grpc_proto_library(
     name = "worker_service_proto",
     srcs = ["worker_service.proto"],
     deps = [
-      "control_proto",
+        "control_proto",
     ],
 )
 
@@ -134,7 +142,7 @@ grpc_proto_library(
     has_services = False,
     deps = [
         "//src/proto/grpc/core:stats_proto",
-    ]
+    ],
 )
 
 grpc_proto_library(
@@ -190,6 +198,5 @@ py_proto_library(
     name = "py_test_proto",
     deps = [
         ":test_proto_descriptor",
-    ]
+    ],
 )
-

--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -16,7 +16,10 @@ licenses(["notice"])  # Apache v2
 
 load("//bazel:grpc_build_system.bzl", "grpc_cc_library", "grpc_cc_test", "grpc_cc_binary", "grpc_package")
 
-grpc_package(name = "test/cpp/interop")
+grpc_package(
+    name = "test/cpp/interop",
+    visibility = "public",
+)
 
 grpc_cc_library(
     name = "server_helper_lib",
@@ -104,6 +107,20 @@ grpc_cc_binary(
 )
 
 grpc_cc_binary(
+    name = "metrics_client",
+    srcs = ["metrics_client.cc"],
+    external_deps = [
+        "gflags",
+    ],
+    language = "C++",
+    deps = [
+        "//:grpc++",
+        "//test/cpp/util:metrics_server_lib",
+        "//test/cpp/util:test_config",
+    ],
+)
+
+grpc_cc_binary(
     name = "reconnect_interop_client",
     srcs = [
         "reconnect_interop_client.cc",
@@ -153,6 +170,7 @@ grpc_cc_test(
     external_deps = [
         "gflags",
     ],
+    tags = ["no_windows"],
     deps = [
         "//:gpr",
         "//:grpc",
@@ -161,5 +179,4 @@ grpc_cc_test(
         "//test/cpp/util:test_config",
         "//test/cpp/util:test_util",
     ],
-    tags = ["no_windows"],
 )

--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -75,6 +75,7 @@ grpc_cc_library(
         "test_credentials_provider.h",
     ],
     external_deps = [
+        "gflags",
         "protobuf",
     ],
     deps = [

--- a/test/cpp/util/test_credentials_provider.cc
+++ b/test/cpp/util/test_credentials_provider.cc
@@ -119,8 +119,8 @@ class DefaultCredentialsProvider : public CredentialsProvider {
       SslServerCredentialsOptions ssl_opts;
       ssl_opts.pem_root_certs = "";
       if (!custom_server_key_.empty() && !custom_server_cert_.empty()) {
-        SslServerCredentialsOptions::PemKeyCertPair pkcp = {custom_server_key_,
-                                                            custom_server_cert_};
+        SslServerCredentialsOptions::PemKeyCertPair pkcp = {
+            custom_server_key_, custom_server_cert_};
         ssl_opts.pem_key_cert_pairs.push_back(pkcp);
       } else {
         SslServerCredentialsOptions::PemKeyCertPair pkcp = {test_server1_key,

--- a/test/cpp/util/test_credentials_provider.cc
+++ b/test/cpp/util/test_credentials_provider.cc
@@ -19,21 +19,50 @@
 
 #include "test/cpp/util/test_credentials_provider.h"
 
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+
 #include <mutex>
 #include <unordered_map>
 
+#include <gflags/gflags.h>
 #include <grpc/support/log.h>
 #include <grpc/support/sync.h>
 #include <grpcpp/security/server_credentials.h>
 
 #include "test/core/end2end/data/ssl_test_data.h"
 
+DEFINE_string(tls_cert_file, "", "The TLS cert file used when --use_tls=true");
+DEFINE_string(tls_key_file, "", "The TLS key file used when --use_tls=true");
+
 namespace grpc {
 namespace testing {
 namespace {
 
+grpc::string ReadFile(const grpc::string& src_path) {
+  std::ifstream src;
+  src.open(src_path, std::ifstream::in | std::ifstream::binary);
+
+  grpc::string contents;
+  src.seekg(0, std::ios::end);
+  contents.reserve(src.tellg());
+  src.seekg(0, std::ios::beg);
+  contents.assign((std::istreambuf_iterator<char>(src)),
+                  (std::istreambuf_iterator<char>()));
+  return contents;
+}
+
 class DefaultCredentialsProvider : public CredentialsProvider {
  public:
+  DefaultCredentialsProvider() {
+    if (!FLAGS_tls_key_file.empty()) {
+      custom_server_key_ = ReadFile(FLAGS_tls_key_file);
+    }
+    if (!FLAGS_tls_cert_file.empty()) {
+      custom_server_cert_ = ReadFile(FLAGS_tls_cert_file);
+    }
+  }
   ~DefaultCredentialsProvider() override {}
 
   void AddSecureType(
@@ -87,11 +116,17 @@ class DefaultCredentialsProvider : public CredentialsProvider {
       grpc::experimental::AltsServerCredentialsOptions alts_opts;
       return grpc::experimental::AltsServerCredentials(alts_opts);
     } else if (type == grpc::testing::kTlsCredentialsType) {
-      SslServerCredentialsOptions::PemKeyCertPair pkcp = {test_server1_key,
-                                                          test_server1_cert};
       SslServerCredentialsOptions ssl_opts;
       ssl_opts.pem_root_certs = "";
-      ssl_opts.pem_key_cert_pairs.push_back(pkcp);
+      if (!custom_server_key_.empty() && !custom_server_cert_.empty()) {
+        SslServerCredentialsOptions::PemKeyCertPair pkcp = {custom_server_key_,
+                                                            custom_server_cert_};
+        ssl_opts.pem_key_cert_pairs.push_back(pkcp);
+      } else {
+        SslServerCredentialsOptions::PemKeyCertPair pkcp = {test_server1_key,
+                                                            test_server1_cert};
+        ssl_opts.pem_key_cert_pairs.push_back(pkcp);
+      }
       return SslServerCredentials(ssl_opts);
     } else {
       std::unique_lock<std::mutex> lock(mu_);
@@ -121,6 +156,8 @@ class DefaultCredentialsProvider : public CredentialsProvider {
   std::vector<grpc::string> added_secure_type_names_;
   std::vector<std::unique_ptr<CredentialTypeProvider>>
       added_secure_type_providers_;
+  grpc::string custom_server_key_;
+  grpc::string custom_server_cert_;
 };
 
 CredentialsProvider* g_provider = nullptr;


### PR DESCRIPTION
[ESP](https://github.com/cloudendpoints/esp) was using grpc-go interop tests for its e2e tests and stress tests.  ESP is c++ code using bazel,  the mixing of go with bazel causes a lot of troubles.  Beside, it has to use a very old grpc-go version result in very difficult to upgrade bazel.

In order for ESP to use grpc-cpp interop, folllowing changes are needed:
* change test/cpp/interop default package visibility to public 
* export some more proto files in src/proto/grpc/testing
* build metrics_client 
* add two flags --tls_cert_file and --tls_key_file flags (just like golang interop_server) to provide custom cert for interop_server.

