### PR TITLE
Update comment on ssl hotname override

### DIFF
--- a/include/grpcpp/support/channel_arguments_impl.h
+++ b/include/grpcpp/support/channel_arguments_impl.h
@@ -61,8 +61,8 @@ class ChannelArguments {
   void SetChannelArgs(grpc_channel_args* channel_args) const;
 
   // gRPC specific channel argument setters
-  /// Set target name override for SSL host name checking. This option is for
-  /// testing only and should never be used in production.
+  /// Set target name override for SSL host name checking. This option should
+  /// be used with caution in production.
   void SetSslTargetNameOverride(const grpc::string& name);
   // TODO(yangg) add flow control options
   /// Set the compression algorithm for the channel.


### PR DESCRIPTION
Remove the testing only tag to be consistent with Java and Golang. Of course, this SSL hostname override shall be used with caution in production. 