### PR TITLE
Use kokoro env variable to get the PRs target branch

### DIFF
--- a/tools/internal_ci/helper_scripts/prepare_build_linux_perf_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_linux_perf_rc
@@ -19,12 +19,6 @@
 ulimit -n 32768
 ulimit -c unlimited
 
-# Performance PR testing needs GH API key and PR metadata to comment results
-if [ -n "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
-  sudo apt-get install -y jq
-  export ghprbTargetBranch=$(curl -s https://api.github.com/repos/grpc/grpc/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER | jq -r .base.ref)
-fi
-
 sudo pip install tabulate
 
 # Python dependencies for tools/run_tests/python_utils/check_on_pr.py

--- a/tools/internal_ci/helper_scripts/prepare_build_macos_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_macos_rc
@@ -25,10 +25,7 @@ export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_GFILE_DIR}/GrpcTesting-d0eeee2db3
 
 # If this is a PR using RUN_TESTS_FLAGS var, then add flags to filter tests
 if [ -n "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
-  brew update
-  brew install jq || brew upgrade jq
-  ghprbTargetBranch=$(curl -s https://api.github.com/repos/grpc/grpc/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER | jq -r .base.ref)
-  export RUN_TESTS_FLAGS="$RUN_TESTS_FLAGS --filter_pr_tests --base_branch origin/$ghprbTargetBranch"
+  export RUN_TESTS_FLAGS="$RUN_TESTS_FLAGS --filter_pr_tests --base_branch origin/$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH"
 fi
 
 set +ex  # rvm script is very verbose and exits with errorcode

--- a/tools/internal_ci/helper_scripts/prepare_build_windows.bat
+++ b/tools/internal_ci/helper_scripts/prepare_build_windows.bat
@@ -18,10 +18,7 @@ set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%
 
 @rem If this is a PR using RUN_TESTS_FLAGS var, then add flags to filter tests
 if defined KOKORO_GITHUB_PULL_REQUEST_NUMBER if defined RUN_TESTS_FLAGS (
-  chocolatey install -y jq
-  for /f "usebackq delims=" %%x in (`curl -s https://api.github.com/repos/grpc/grpc/pulls/%KOKORO_GITHUB_PULL_REQUEST_NUMBER% ^| jq -r .base.ref`) do ( 
-    set RUN_TESTS_FLAGS=%RUN_TESTS_FLAGS% --filter_pr_tests --base_branch origin/%%x
-  )
+  set RUN_TESTS_FLAGS=%RUN_TESTS_FLAGS% --filter_pr_tests --base_branch origin/%KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH%
 )
 
 @rem Update DNS settings to:

--- a/tools/internal_ci/linux/grpc_microbenchmark_diff.sh
+++ b/tools/internal_ci/linux/grpc_microbenchmark_diff.sh
@@ -26,9 +26,9 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_perf_rc
 
 tools/run_tests/start_port_server.py
 tools/internal_ci/linux/run_if_c_cpp_modified.sh tools/profiling/bloat/bloat_diff.py \
-  -d origin/$ghprbTargetBranch || FAILED="true"
+  -d "origin/$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH" || FAILED="true"
 tools/internal_ci/linux/run_if_c_cpp_modified.sh tools/profiling/microbenchmarks/bm_diff/bm_main.py \
-  -d origin/$ghprbTargetBranch \
+  -d "origin/$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH" \
   -b $BENCHMARKS_TO_RUN || FAILED="true"
 
 # kill port_server.py to prevent the build from hanging

--- a/tools/internal_ci/linux/grpc_run_tests_matrix.sh
+++ b/tools/internal_ci/linux/grpc_run_tests_matrix.sh
@@ -22,10 +22,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_rc
 
 # If this is a PR using RUN_TESTS_FLAGS var, then add flags to filter tests
 if [ -n "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ] && [ -n "$RUN_TESTS_FLAGS" ]; then
-  sudo apt-get update
-  sudo apt-get install -y jq
-  ghprbTargetBranch=$(curl -s https://api.github.com/repos/grpc/grpc/pulls/$KOKORO_GITHUB_PULL_REQUEST_NUMBER | jq -r .base.ref)
-  export RUN_TESTS_FLAGS="$RUN_TESTS_FLAGS --filter_pr_tests --base_branch origin/$ghprbTargetBranch"
+  export RUN_TESTS_FLAGS="$RUN_TESTS_FLAGS --filter_pr_tests --base_branch origin/$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH"
 fi
 
 tools/run_tests/run_tests_matrix.py $RUN_TESTS_FLAGS || FAILED="true"

--- a/tools/internal_ci/linux/grpc_trickle_diff.sh
+++ b/tools/internal_ci/linux/grpc_trickle_diff.sh
@@ -26,7 +26,7 @@ source tools/internal_ci/helper_scripts/prepare_build_linux_perf_rc
 
 tools/run_tests/start_port_server.py
 tools/internal_ci/linux/run_if_c_cpp_modified.sh tools/profiling/microbenchmarks/bm_diff/bm_main.py \
-  -d origin/$ghprbTargetBranch \
+  -d "origin/$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH" \
   -b bm_fullstack_trickle \
   -l 4 \
   -t $BENCHMARKS_TO_RUN \

--- a/tools/internal_ci/linux/run_if_c_cpp_modified.sh
+++ b/tools/internal_ci/linux/run_if_c_cpp_modified.sh
@@ -20,13 +20,11 @@ set -ex
 # Enter the gRPC repo root
 cd $(dirname $0)/../../..
 
-# TODO(jtattermusch): the "ghprbTargetBranch" is Jenkins specific and probably
-# does not work on kokoro?
 AFFECTS_C_CPP=`python -c 'import os; \
                import sys; \
                sys.path.insert(0, "tools/run_tests/python_utils"); \
                import filter_pull_request_tests as filter; \
-               github_target_branch = os.environ.get("ghprbTargetBranch"); \
+               github_target_branch = os.environ.get("KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH"); \
                print(filter.affects_c_cpp("origin/%s" % github_target_branch))'`
 
 if [ $AFFECTS_C_CPP == "False" ] ; then

--- a/tools/internal_ci/macos/grpc_ios_binary_size.sh
+++ b/tools/internal_ci/macos/grpc_ios_binary_size.sh
@@ -24,4 +24,4 @@ cd $(dirname $0)/../../..
 source tools/internal_ci/helper_scripts/prepare_build_macos_rc
 
 tools/profiling/ios_bin/binary_size.py \
-  -d origin/$ghprbTargetBranch
+  -d "origin/$KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH"


### PR DESCRIPTION
turns out kokoro provides the base branch for PRs through an environment variable `KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH` so there's no need for querying the github API ourselves (and parsing the response with jq).

Fixes #18968. Supersedes #19112 and https://github.com/grpc/grpc/pull/19062.

This also gets rid of of all the mentions of `ghprbTargetBranch` env variable which dates back to the times when we were still using Jenkins (the var used to be set by Jenkins' github pull request builder plugin).