### PR TITLE
Fix PHP extension segfault

### DIFF
--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -205,7 +205,9 @@ void register_fork_handlers() {
 
 void apply_ini_settings() {
   if (GRPC_G(enable_fork_support)) {
-    putenv("GRPC_ENABLE_FORK_SUPPORT=1");
+    char *enable_str = malloc(sizeof("GRPC_ENABLE_FORK_SUPPORT=1"));
+    strcpy(enable_str, "GRPC_ENABLE_FORK_SUPPORT=1");
+    putenv(enable_str);
   }
 
   if (GRPC_G(poll_strategy)) {


### PR DESCRIPTION
Backport of #19109 to `v1.21.x` branch. PHP will need to do a `v1.21.1` release for this.