### PR TITLE
Adjust the order of IOMgr timer initialization and comment of grpc_timer::heap_index

### DIFF
--- a/src/core/lib/iomgr/iomgr.cc
+++ b/src/core/lib/iomgr/iomgr.cc
@@ -57,10 +57,10 @@ void grpc_iomgr_init() {
   gpr_mu_init(&g_mu);
   gpr_cv_init(&g_rcv);
   grpc_core::Executor::InitAll();
-  grpc_timer_list_init();
   g_root_object.next = g_root_object.prev = &g_root_object;
   g_root_object.name = (char*)"root";
   grpc_iomgr_platform_init();
+  grpc_timer_list_init();
   grpc_core::grpc_errqueue_init();
 }
 

--- a/src/core/lib/iomgr/timer.h
+++ b/src/core/lib/iomgr/timer.h
@@ -29,7 +29,8 @@
 
 typedef struct grpc_timer {
   grpc_millis deadline;
-  uint32_t heap_index; /* INVALID_HEAP_INDEX if not in heap */
+  // Uninitialized if not using heap, or INVALID_HEAP_INDEX if not in heap.
+  uint32_t heap_index;
   bool pending;
   struct grpc_timer* next;
   struct grpc_timer* prev;


### PR DESCRIPTION
Adjust the order of IOMgr initialization, so as to set up a customized timer correctly.

Also, change the comment of grpc_timer::heap_index.