### PR TITLE
remove notification observer to avoid iOS 8 crash

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -648,6 +648,8 @@ const char *kCFStreamVarName = "grpc_cfstream";
 }
 
 - (void)dealloc {
+  [GRPCConnectivityMonitor unregisterObserver:self];
+  
   __block GRPCWrappedCall *wrappedCall = _wrappedCall;
   dispatch_async(_callQueue, ^{
     wrappedCall = nil;

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -649,7 +649,7 @@ const char *kCFStreamVarName = "grpc_cfstream";
 
 - (void)dealloc {
   [GRPCConnectivityMonitor unregisterObserver:self];
-  
+
   __block GRPCWrappedCall *wrappedCall = _wrappedCall;
   dispatch_async(_callQueue, ^{
     wrappedCall = nil;


### PR DESCRIPTION
fix #18567