### PR TITLE
Surface exception from metadata credentails plugin methods

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pxd.pxi
@@ -26,9 +26,9 @@ cdef int _get_metadata(
     grpc_credentials_plugin_metadata_cb cb, void *user_data,
     grpc_metadata creds_md[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
     size_t *num_creds_md, grpc_status_code *status,
-    const char **error_details) with gil
+    const char **error_details) except * with gil
 
-cdef void _destroy(void *state) with gil
+cdef void _destroy(void *state) except * with gil
 
 
 cdef class MetadataPluginCallCredentials(CallCredentials):

--- a/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/credentials.pyx.pxi
@@ -42,7 +42,7 @@ cdef int _get_metadata(
     grpc_credentials_plugin_metadata_cb cb, void *user_data,
     grpc_metadata creds_md[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
     size_t *num_creds_md, grpc_status_code *status,
-    const char **error_details) with gil:
+    const char **error_details) except * with gil:
   cdef size_t metadata_count
   cdef grpc_metadata *c_metadata
   def callback(metadata, grpc_status_code status, bytes error_details):
@@ -57,7 +57,7 @@ cdef int _get_metadata(
   return 0  # Asynchronous return
 
 
-cdef void _destroy(void *state) with gil:
+cdef void _destroy(void *state) except * with gil:
   cpython.Py_DECREF(<object>state)
   grpc_shutdown_blocking()
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc.pxi
@@ -546,8 +546,8 @@ cdef extern from "grpc/grpc_security.h":
         grpc_credentials_plugin_metadata_cb cb, void *user_data,
         grpc_metadata creds_md[GRPC_METADATA_CREDENTIALS_PLUGIN_SYNC_MAX],
         size_t *num_creds_md, grpc_status_code *status,
-        const char **error_details)
-    void (*destroy)(void *state)
+        const char **error_details) except *
+    void (*destroy)(void *state) except *
     void *state
     const char *type
 


### PR DESCRIPTION
Related Issue: https://github.com/grpc/grpc/issues/16643 https://github.com/grpc/grpc/issues/14523

In https://github.com/grpc/grpc/issues/14523, our Cython package ignored the exception. This should be fixed to give our users a chance to react to it, instead of broken silently.