### PR TITLE
Backport: PHP fix ZTS build

### DIFF
--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -203,7 +203,7 @@ void register_fork_handlers() {
   }
 }
 
-void apply_ini_settings() {
+void apply_ini_settings(TSRMLS_D) {
   if (GRPC_G(enable_fork_support)) {
     char *enable_str = malloc(sizeof("GRPC_ENABLE_FORK_SUPPORT=1"));
     strcpy(enable_str, "GRPC_ENABLE_FORK_SUPPORT=1");
@@ -392,7 +392,7 @@ PHP_MINFO_FUNCTION(grpc) {
  */
 PHP_RINIT_FUNCTION(grpc) {
   if (!GRPC_G(initialized)) {
-    apply_ini_settings();
+    apply_ini_settings(TSRMLS_C);
     grpc_init();
     register_fork_handlers();
     grpc_php_init_completion_queue(TSRMLS_C);


### PR DESCRIPTION
Backport of #19160 to the `v1.21.x` branch, for PHP bug fix release `v1.21.2`.