### PR TITLE
Update Python packages before building ARM wheels.

### DIFF
--- a/tools/dockerfile/grpc_artifact_linux_armv6/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_linux_armv6/Dockerfile
@@ -14,11 +14,13 @@
 
 # Docker file for building gRPC Raspbian binaries
 
+# TODO(https://github.com/grpc/grpc/issues/19199): Move off of this image.
 FROM quay.io/grpc/raspbian_armv6
 
 # Place any extra build instructions between these commands
 # Recommend modifying upstream docker image (quay.io/grpc/raspbian_armv6)
 # for build steps because running them under QEMU is very slow
 # (https://github.com/kpayson64/armv7hf-debian-qemu)
-# RUN [ "cross-build-start" ]
-# RUN [ "cross-build-end" ]
+RUN [ "cross-build-start" ]
+RUN find /usr/local/bin -regex '.*python[0-9]+\.[0-9]+' | xargs -n1 -i{} bash -c "{} -m pip install --upgrade wheel setuptools"
+RUN [ "cross-build-end" ]

--- a/tools/dockerfile/grpc_artifact_linux_armv7/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_linux_armv7/Dockerfile
@@ -14,11 +14,13 @@
 
 # Docker file for building gRPC Raspbian binaries
 
+# TODO(https://github.com/grpc/grpc/issues/19199): Move off of this base image.
 FROM quay.io/grpc/raspbian_armv7
 
 # Place any extra build instructions between these commands
 # Recommend modifying upstream docker image (quay.io/grpc/raspbian_armv7)
 # for build steps because running them under QEMU is very slow
 # (https://github.com/kpayson64/armv7hf-debian-qemu)
-# RUN [ "cross-build-start" ]
-# RUN [ "cross-build-end" ]
+RUN [ "cross-build-start" ]
+RUN find /usr/local/bin -regex '.*python[0-9]+\.[0-9]+' | xargs -n1 -i{} bash -c "{} -m pip install --upgrade wheel setuptools"
+RUN [ "cross-build-end" ]


### PR DESCRIPTION
This partially addresses https://github.com/grpc/grpc/issues/19162. The Windows and Mac environments still need to be audited. Due to https://github.com/grpc/grpc/issues/19102, I strongly suspect that these are also out of date.

I manually verified that the artifacts generated by these updated Dockerfiles respect the environment markers specified by `setup.py`. (after waiting three hours for `qemu` to build them...)

I filed https://github.com/grpc/grpc/issues/19199 to document the fact that we no longer have write permissions to the base images used in this build.