### PR TITLE
Fix ref-counting issues in channelz registry.

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel_channelz.cc
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.cc
@@ -43,10 +43,11 @@ static const grpc_arg_pointer_vtable client_channel_channelz_vtable = {
     client_channel_channelz_copy, client_channel_channelz_destroy,
     client_channel_channelz_cmp};
 
-ClientChannelNode::ClientChannelNode(grpc_channel* channel,
+ClientChannelNode::ClientChannelNode(intptr_t uuid, grpc_channel* channel,
                                      size_t channel_tracer_max_nodes,
                                      bool is_top_level_channel)
-    : ChannelNode(channel, channel_tracer_max_nodes, is_top_level_channel) {
+    : ChannelNode(uuid, channel, channel_tracer_max_nodes,
+                  is_top_level_channel) {
   client_channel_ =
       grpc_channel_stack_last_element(grpc_channel_get_channel_stack(channel));
   GPR_ASSERT(client_channel_->filter == &grpc_client_channel_filter);
@@ -109,13 +110,13 @@ grpc_arg ClientChannelNode::CreateChannelArg() {
 RefCountedPtr<ChannelNode> ClientChannelNode::MakeClientChannelNode(
     grpc_channel* channel, size_t channel_tracer_max_nodes,
     bool is_top_level_channel) {
-  return MakeRefCounted<ClientChannelNode>(channel, channel_tracer_max_nodes,
-                                           is_top_level_channel);
+  return channelz::ChannelzRegistry::CreateNode<ClientChannelNode>(
+      channel, channel_tracer_max_nodes, is_top_level_channel);
 }
 
-SubchannelNode::SubchannelNode(Subchannel* subchannel,
+SubchannelNode::SubchannelNode(intptr_t uuid, Subchannel* subchannel,
                                size_t channel_tracer_max_nodes)
-    : BaseNode(EntityType::kSubchannel),
+    : BaseNode(uuid, EntityType::kSubchannel),
       subchannel_(subchannel),
       target_(UniquePtr<char>(gpr_strdup(subchannel_->GetTargetAddress()))),
       trace_(channel_tracer_max_nodes) {}

--- a/src/core/ext/filters/client_channel/client_channel_channelz.h
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.h
@@ -40,8 +40,8 @@ class ClientChannelNode : public ChannelNode {
       grpc_channel* channel, size_t channel_tracer_max_nodes,
       bool is_top_level_channel);
 
-  ClientChannelNode(grpc_channel* channel, size_t channel_tracer_max_nodes,
-                    bool is_top_level_channel);
+  ClientChannelNode(intptr_t uuid, grpc_channel* channel,
+                    size_t channel_tracer_max_nodes, bool is_top_level_channel);
   virtual ~ClientChannelNode() {}
 
   // Overriding template methods from ChannelNode to render information that
@@ -60,7 +60,8 @@ class ClientChannelNode : public ChannelNode {
 // Handles channelz bookkeeping for sockets
 class SubchannelNode : public BaseNode {
  public:
-  SubchannelNode(Subchannel* subchannel, size_t channel_tracer_max_nodes);
+  SubchannelNode(intptr_t uuid, Subchannel* subchannel,
+                 size_t channel_tracer_max_nodes);
   ~SubchannelNode() override;
 
   void MarkSubchannelDestroyed() {

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -37,6 +37,7 @@
 #include "src/core/ext/filters/client_channel/subchannel_pool_interface.h"
 #include "src/core/lib/backoff/backoff.h"
 #include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/channel/channelz_registry.h"
 #include "src/core/lib/channel/connected_channel.h"
 #include "src/core/lib/debug/stats.h"
 #include "src/core/lib/gpr/alloc.h"
@@ -672,8 +673,9 @@ Subchannel::Subchannel(SubchannelKey* key, grpc_connector* connector,
   size_t channel_tracer_max_memory =
       (size_t)grpc_channel_arg_get_integer(arg, options);
   if (channelz_enabled) {
-    channelz_node_ = MakeRefCounted<channelz::SubchannelNode>(
-        this, channel_tracer_max_memory);
+    channelz_node_ =
+        channelz::ChannelzRegistry::CreateNode<channelz::SubchannelNode>(
+            this, channel_tracer_max_memory);
     channelz_node_->AddTraceEvent(
         channelz::ChannelTrace::Severity::Info,
         grpc_slice_from_static_string("subchannel created"));

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -35,6 +35,7 @@
 #include "src/core/ext/transport/chttp2/transport/chttp2_transport.h"
 #include "src/core/ext/transport/chttp2/transport/internal.h"
 #include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/channel/channelz_registry.h"
 #include "src/core/lib/channel/handshaker.h"
 #include "src/core/lib/channel/handshaker_registry.h"
 #include "src/core/lib/gpr/host_port.h"
@@ -415,7 +416,8 @@ grpc_error* grpc_chttp2_server_add_port(grpc_server* server, const char* addr,
   arg = grpc_channel_args_find(args, GRPC_ARG_ENABLE_CHANNELZ);
   if (grpc_channel_arg_get_bool(arg, GRPC_ENABLE_CHANNELZ_DEFAULT)) {
     state->channelz_listen_socket =
-        grpc_core::MakeRefCounted<grpc_core::channelz::ListenSocketNode>(
+        grpc_core::channelz::ChannelzRegistry::CreateNode<
+            grpc_core::channelz::ListenSocketNode>(
             grpc_core::UniquePtr<char>(gpr_strdup(addr)));
     socket_uuid = state->channelz_listen_socket->uuid();
   }

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -36,6 +36,7 @@
 #include "src/core/ext/transport/chttp2/transport/internal.h"
 #include "src/core/ext/transport/chttp2/transport/varint.h"
 #include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/channel/channelz_registry.h"
 #include "src/core/lib/compression/stream_compression.h"
 #include "src/core/lib/debug/stats.h"
 #include "src/core/lib/gpr/env.h"
@@ -378,10 +379,10 @@ static bool read_channel_args(grpc_chttp2_transport* t,
   if (channelz_enabled) {
     // TODO(ncteisen): add an API to endpoint to query for local addr, and pass
     // it in here, so SocketNode knows its own address.
-    t->channelz_socket =
-        grpc_core::MakeRefCounted<grpc_core::channelz::SocketNode>(
-            grpc_core::UniquePtr<char>(),
-            grpc_core::UniquePtr<char>(gpr_strdup(t->peer_string)));
+    t->channelz_socket = grpc_core::channelz::ChannelzRegistry::CreateNode<
+        grpc_core::channelz::SocketNode>(
+        grpc_core::UniquePtr<char>(),
+        grpc_core::UniquePtr<char>(gpr_strdup(t->peer_string)));
   }
   return enable_bdp;
 }

--- a/src/core/lib/channel/channelz.h
+++ b/src/core/lib/channel/channelz.h
@@ -81,8 +81,11 @@ class BaseNode : public RefCounted<BaseNode> {
     kSocket,
   };
 
-  explicit BaseNode(EntityType type);
-  virtual ~BaseNode();
+  BaseNode(intptr_t uuid, EntityType type) : uuid_(uuid), type_(type) {}
+  virtual ~BaseNode() = default;
+
+  intptr_t uuid() const { return uuid_; }
+  EntityType type() const { return type_; }
 
   // All children must implement this function.
   virtual grpc_json* RenderJson() GRPC_ABSTRACT;
@@ -91,14 +94,9 @@ class BaseNode : public RefCounted<BaseNode> {
   // caller.
   char* RenderJsonString();
 
-  EntityType type() const { return type_; }
-  intptr_t uuid() const { return uuid_; }
-
  private:
-  // to allow the ChannelzRegistry to set uuid_ under its lock.
-  friend class ChannelzRegistry;
+  const intptr_t uuid_;
   const EntityType type_;
-  intptr_t uuid_;
 };
 
 // This class is a helper class for channelz entities that deal with Channels,
@@ -151,8 +149,8 @@ class ChannelNode : public BaseNode {
       grpc_channel* channel, size_t channel_tracer_max_nodes,
       bool is_top_level_channel);
 
-  ChannelNode(grpc_channel* channel, size_t channel_tracer_max_nodes,
-              bool is_top_level_channel);
+  ChannelNode(intptr_t uuid, grpc_channel* channel,
+              size_t channel_tracer_max_nodes, bool is_top_level_channel);
   ~ChannelNode() override;
 
   grpc_json* RenderJson() override;
@@ -205,7 +203,8 @@ class ChannelNode : public BaseNode {
 // Handles channelz bookkeeping for servers
 class ServerNode : public BaseNode {
  public:
-  ServerNode(grpc_server* server, size_t channel_tracer_max_nodes);
+  ServerNode(intptr_t uuid, grpc_server* server,
+             size_t channel_tracer_max_nodes);
   ~ServerNode() override;
 
   grpc_json* RenderJson() override;
@@ -236,7 +235,7 @@ class ServerNode : public BaseNode {
 // Handles channelz bookkeeping for sockets
 class SocketNode : public BaseNode {
  public:
-  SocketNode(UniquePtr<char> local, UniquePtr<char> remote);
+  SocketNode(intptr_t uuid, UniquePtr<char> local, UniquePtr<char> remote);
   ~SocketNode() override {}
 
   grpc_json* RenderJson() override;
@@ -276,7 +275,7 @@ class SocketNode : public BaseNode {
 class ListenSocketNode : public BaseNode {
  public:
   // ListenSocketNode takes ownership of host.
-  explicit ListenSocketNode(UniquePtr<char> local_addr);
+  ListenSocketNode(intptr_t uuid, UniquePtr<char> local_addr);
   ~ListenSocketNode() override {}
 
   grpc_json* RenderJson() override;

--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -37,6 +37,7 @@ namespace channelz {
 
 namespace {
 const int kPaginationLimit = 100;
+// TODO(roth): Provide a way to force GC when under memory pressure.
 const grpc_millis kSweepIntervalMs = 5000;
 }  // anonymous namespace
 

--- a/src/core/lib/channel/channelz_registry.h
+++ b/src/core/lib/channel/channelz_registry.h
@@ -23,7 +23,9 @@
 
 #include "src/core/lib/channel/channel_trace.h"
 #include "src/core/lib/channel/channelz.h"
-#include "src/core/lib/gprpp/inlined_vector.h"
+#include "src/core/lib/gprpp/orphanable.h"
+#include "src/core/lib/gprpp/sync.h"
+#include "src/core/lib/iomgr/timer.h"
 
 #include <stdint.h>
 
@@ -44,69 +46,90 @@ class ChannelzRegistry {
   // To be called in grpc_shutdown();
   static void Shutdown();
 
-  static void Register(BaseNode* node) {
-    return Default()->InternalRegister(node);
+  template <typename NodeType, typename... Args>
+  static RefCountedPtr<NodeType> CreateNode(Args&&... args) {
+    return (*registry_)->CreateNode<NodeType>(std::forward<Args>(args)...);
   }
-  static void Unregister(intptr_t uuid) { Default()->InternalUnregister(uuid); }
-  static BaseNode* Get(intptr_t uuid) { return Default()->InternalGet(uuid); }
+
+  static RefCountedPtr<BaseNode> Get(intptr_t uuid) {
+    return (*registry_)->Get(uuid);
+  }
 
   // Returns the allocated JSON string that represents the proto
   // GetTopChannelsResponse as per channelz.proto.
   static char* GetTopChannels(intptr_t start_channel_id) {
-    return Default()->InternalGetTopChannels(start_channel_id);
+    return (*registry_)->GetTopChannels(start_channel_id);
   }
 
   // Returns the allocated JSON string that represents the proto
   // GetServersResponse as per channelz.proto.
   static char* GetServers(intptr_t start_server_id) {
-    return Default()->InternalGetServers(start_server_id);
+    return (*registry_)->GetServers(start_server_id);
   }
 
   // Test only helper function to dump the JSON representation to std out.
   // This can aid in debugging channelz code.
-  static void LogAllEntities() { Default()->InternalLogAllEntities(); }
+  static void LogAllEntities() { (*registry_)->LogAllEntities(); }
 
  private:
-  GPRC_ALLOW_CLASS_TO_USE_NON_PUBLIC_NEW
-  GPRC_ALLOW_CLASS_TO_USE_NON_PUBLIC_DELETE
   friend class testing::ChannelzRegistryPeer;
 
-  ChannelzRegistry();
-  ~ChannelzRegistry();
+  class Registry : public InternallyRefCounted<Registry> {
+   public:
+    Registry();
 
-  // Returned the singleton instance of ChannelzRegistry;
-  static ChannelzRegistry* Default();
+    void Orphan() override;
 
-  // globally registers an Entry. Returns its unique uuid
-  void InternalRegister(BaseNode* node);
+    template <typename NodeType, typename... Args>
+    RefCountedPtr<NodeType> CreateNode(Args&&... args) {
+      MutexLock lock(&mu_);
+      const intptr_t uuid = ++uuid_generator_;
+      auto node = MakeRefCounted<NodeType>(uuid, std::forward<Args>(args)...);
+      entities_.push_back(node);
+      return node;
+    }
 
-  // globally unregisters the object that is associated to uuid. Also does
-  // sanity check that an object doesn't try to unregister the wrong type.
-  void InternalUnregister(intptr_t uuid);
+    // Returns a ref to the node for uuid, or nullptr if there is no
+    // node for uuid.
+    RefCountedPtr<BaseNode> Get(intptr_t uuid);
 
-  // if object with uuid has previously been registered as the correct type,
-  // returns the void* associated with that uuid. Else returns nullptr.
-  BaseNode* InternalGet(intptr_t uuid);
+    char* GetTopChannels(intptr_t start_channel_id);
+    char* GetServers(intptr_t start_server_id);
 
-  char* InternalGetTopChannels(intptr_t start_channel_id);
-  char* InternalGetServers(intptr_t start_server_id);
+    void LogAllEntities();
 
-  // If entities_ has over a certain threshold of empty slots, it will
-  // compact the vector and move all used slots to the front.
-  void MaybePerformCompactionLocked();
+   private:
+    friend class testing::ChannelzRegistryPeer;
 
-  // Performs binary search on entities_ to find the index with that uuid.
-  // If direct_hit_needed, then will return -1 in case of absence.
-  // Else, will return idx of the first uuid higher than the target.
-  int FindByUuidLocked(intptr_t uuid, bool direct_hit_needed);
+    static void OnGarbageCollectionTimer(void* arg, grpc_error* error);
 
-  void InternalLogAllEntities();
+    void DoGarbageCollectionLocked();
+    void MaybeRemoveUnusedNodeLocked(size_t idx);
 
-  // protects members
-  gpr_mu mu_;
-  InlinedVector<BaseNode*, 20> entities_;
-  intptr_t uuid_generator_ = 0;
-  int num_empty_slots_ = 0;
+    // If entities_ has over a certain threshold of empty slots, it will
+    // compact the vector and move all used slots to the front.
+    void MaybePerformCompactionLocked();
+
+    // Performs binary search on entities_ to find the index with that uuid.
+    // If direct_hit_needed, then will return -1 in case of absence.
+    // Else, will return idx of the first uuid higher than the target.
+    int FindByUuidLocked(intptr_t uuid, bool direct_hit_needed);
+
+    // protects members
+    Mutex mu_;
+    // TODO(roth): Once the erase() bug has been fixed in our Map<>
+    // implementation, change this to use a map so that we can eliminate
+    // the need for compaction.
+    InlinedVector<RefCountedPtr<BaseNode>, 20> entities_;
+    int num_empty_slots_ = 0;
+    intptr_t uuid_generator_ = 0;
+    bool shutdown_ = false;
+    grpc_timer gc_timer_;
+    grpc_closure gc_closure_;
+  };
+
+  // The singleton Registry instance.
+  static OrphanablePtr<Registry>* registry_;
 };
 
 }  // namespace channelz

--- a/src/core/lib/gprpp/ref_counted.h
+++ b/src/core/lib/gprpp/ref_counted.h
@@ -168,7 +168,7 @@ class RefCount {
   // However, use of this method for things like having an object check
   // whether it's about to be destroyed are considered an anti-pattern
   // and should be avoided.
-  bool HasOnlyOneRef() const { return value_.Load(MemoryOrder::ACQ_REL) == 1; }
+  bool HasOnlyOneRef() const { return value_.Load(MemoryOrder::SEQ_CST) == 1; }
 
  private:
   Value get() const { return value_.Load(MemoryOrder::RELAXED); }

--- a/src/core/lib/gprpp/ref_counted.h
+++ b/src/core/lib/gprpp/ref_counted.h
@@ -168,7 +168,7 @@ class RefCount {
   // However, use of this method for things like having an object check
   // whether it's about to be destroyed are considered an anti-pattern
   // and should be avoided.
-  bool HasOnlyOneRef() const { return get() == 1; }
+  bool HasOnlyOneRef() const { return value_.Load(MemoryOrder::ACQ_REL) == 1; }
 
  private:
   Value get() const { return value_.Load(MemoryOrder::RELAXED); }

--- a/src/core/lib/gprpp/ref_counted.h
+++ b/src/core/lib/gprpp/ref_counted.h
@@ -157,6 +157,19 @@ class RefCount {
     return Unref();
   }
 
+  // Returns true if the ref count is 1.
+  //
+  // Note: Use of this method is discouraged!  Please consider
+  // alternatives before using this.
+  //
+  // Use of this method is required in some rare cases, such as when
+  // registering objects in a global index and removing them when all
+  // refs other than the one held by the index have been released.
+  // However, use of this method for things like having an object check
+  // whether it's about to be destroyed are considered an anti-pattern
+  // and should be avoided.
+  bool HasOnlyOneRef() const { return get() == 1; }
+
  private:
   Value get() const { return value_.Load(MemoryOrder::RELAXED); }
 
@@ -220,6 +233,19 @@ class RefCounted : public Impl {
       Delete(static_cast<Child*>(this));
     }
   }
+
+  // Returns true if the ref count is 1.
+  //
+  // Note: Use of this method is discouraged!  Please consider
+  // alternatives before using this.
+  //
+  // Use of this method is required in some rare cases, such as when
+  // registering objects in a global index and removing them when all
+  // refs other than the one held by the index have been released.
+  // However, use of this method for things like having an object check
+  // whether it's about to be destroyed are considered an anti-pattern
+  // and should be avoided.
+  bool HasOnlyOneRef() const { return refs_.HasOnlyOneRef(); }
 
   // Not copyable nor movable.
   RefCounted(const RefCounted&) = delete;

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -137,11 +137,11 @@ void grpc_init(void) {
     grpc_slice_intern_init();
     grpc_mdctx_global_init();
     grpc_channel_init_init();
-    grpc_core::channelz::ChannelzRegistry::Init();
     grpc_security_pre_init();
     grpc_core::ApplicationCallbackExecCtx::GlobalInit();
     grpc_core::ExecCtx::GlobalInit();
     grpc_iomgr_init();
+    grpc_core::channelz::ChannelzRegistry::Init();
     gpr_timers_global_init();
     grpc_core::HandshakerRegistry::Init();
     grpc_security_init();
@@ -177,13 +177,13 @@ void grpc_shutdown_internal_locked(void) {
         }
       }
     }
+    grpc_core::channelz::ChannelzRegistry::Shutdown();
     grpc_iomgr_shutdown();
     gpr_timers_global_destroy();
     grpc_tracer_shutdown();
     grpc_mdctx_global_shutdown();
     grpc_core::HandshakerRegistry::Shutdown();
     grpc_slice_intern_shutdown();
-    grpc_core::channelz::ChannelzRegistry::Shutdown();
     grpc_stats_shutdown();
     grpc_core::Fork::GlobalShutdown();
   }

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -31,6 +31,7 @@
 #include <utility>
 
 #include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/channel/channelz_registry.h"
 #include "src/core/lib/channel/connected_channel.h"
 #include "src/core/lib/debug/stats.h"
 #include "src/core/lib/gpr/mpscq.h"
@@ -1037,9 +1038,8 @@ grpc_server* grpc_server_create(const grpc_channel_args* args, void* reserved) {
     size_t channel_tracer_max_memory = grpc_channel_arg_get_integer(
         arg,
         {GRPC_MAX_CHANNEL_TRACE_EVENT_MEMORY_PER_NODE_DEFAULT, 0, INT_MAX});
-    server->channelz_server =
-        grpc_core::MakeRefCounted<grpc_core::channelz::ServerNode>(
-            server, channel_tracer_max_memory);
+    server->channelz_server = grpc_core::channelz::ChannelzRegistry::CreateNode<
+        grpc_core::channelz::ServerNode>(server, channel_tracer_max_memory);
     server->channelz_server->AddTraceEvent(
         grpc_core::channelz::ChannelTrace::Severity::Info,
         grpc_slice_from_static_string("Server created"));

--- a/test/core/channel/channel_trace_test.cc
+++ b/test/core/channel/channel_trace_test.cc
@@ -173,7 +173,7 @@ TEST(ChannelTracerTest, ComplexTest) {
   AddSimpleTrace(&tracer);
   AddSimpleTrace(&tracer);
   ChannelFixture channel1(kEventListMemoryLimit);
-  RefCountedPtr<ChannelNode> sc1 = MakeRefCounted<ChannelNode>(
+  RefCountedPtr<ChannelNode> sc1 = ChannelzRegistry::CreateNode<ChannelNode>(
       channel1.channel(), kEventListMemoryLimit, true);
   ChannelNodePeer sc1_peer(sc1.get());
   tracer.AddTraceEventWithReference(
@@ -192,7 +192,7 @@ TEST(ChannelTracerTest, ComplexTest) {
   AddSimpleTrace(&tracer);
   ValidateChannelTrace(&tracer, 5);
   ChannelFixture channel2(kEventListMemoryLimit);
-  RefCountedPtr<ChannelNode> sc2 = MakeRefCounted<ChannelNode>(
+  RefCountedPtr<ChannelNode> sc2 = ChannelzRegistry::CreateNode<ChannelNode>(
       channel2.channel(), kEventListMemoryLimit, true);
   tracer.AddTraceEventWithReference(
       ChannelTrace::Severity::Info,
@@ -221,7 +221,7 @@ TEST(ChannelTracerTest, TestNesting) {
   AddSimpleTrace(&tracer);
   ValidateChannelTrace(&tracer, 2);
   ChannelFixture channel1(kEventListMemoryLimit);
-  RefCountedPtr<ChannelNode> sc1 = MakeRefCounted<ChannelNode>(
+  RefCountedPtr<ChannelNode> sc1 = ChannelzRegistry::CreateNode<ChannelNode>(
       channel1.channel(), kEventListMemoryLimit, true);
   ChannelNodePeer sc1_peer(sc1.get());
   tracer.AddTraceEventWithReference(
@@ -230,7 +230,7 @@ TEST(ChannelTracerTest, TestNesting) {
   ValidateChannelTrace(&tracer, 3);
   AddSimpleTrace(sc1_peer.trace());
   ChannelFixture channel2(kEventListMemoryLimit);
-  RefCountedPtr<ChannelNode> conn1 = MakeRefCounted<ChannelNode>(
+  RefCountedPtr<ChannelNode> conn1 = ChannelzRegistry::CreateNode<ChannelNode>(
       channel2.channel(), kEventListMemoryLimit, true);
   ChannelNodePeer conn1_peer(conn1.get());
   // nesting one level deeper.
@@ -244,7 +244,7 @@ TEST(ChannelTracerTest, TestNesting) {
   ValidateChannelTrace(&tracer, 5);
   ValidateChannelTrace(conn1_peer.trace(), 1);
   ChannelFixture channel3(kEventListMemoryLimit);
-  RefCountedPtr<ChannelNode> sc2 = MakeRefCounted<ChannelNode>(
+  RefCountedPtr<ChannelNode> sc2 = ChannelzRegistry::CreateNode<ChannelNode>(
       channel3.channel(), kEventListMemoryLimit, true);
   tracer.AddTraceEventWithReference(
       ChannelTrace::Severity::Info,


### PR DESCRIPTION
Prior to this PR, the `ChannelzRegistry::Get()` method was inherently unsafe: it returned a pointer to an object on which no ref was held, so the caller had no way of knowing that the object it was about to access had not been freed by another thread immediately after it was returned by `Get()`.

This PR fixes this structural problem by changing the channelz registry to hold a ref to each node and to return a new ref from `Get()`.  However, because the registry itself now holds a ref, nodes will no longer be automatically deleted from the registry when all of their external refs go away; instead, the registry now has a garbage collector that will periodically scan the registry and remove any node whose refcount is 1 (i.e., the only ref held is held by the registry).

The unfortunate part of this is that it requires adding a `HasOnlyOneRef()` method to `RefCounted`, which I had thus far tried to avoid doing, because there are a number of ways it can be abused.  Unfortunately, I don't really see an alternative in this case, and I know of at least one other similar case in which we're also going to need this (the global subchannel index will need it when we eventually get around to finishing #17993).  So I have added it, but with a long comment indicating that it should not be used in the vast majority of cases.

While I was in here anyway, I also eliminated the need for `ChannelzRegistry` to be a friend of `BaseNode`.  Previously, the pattern was that `BaseNode`'s ctor would register the node with the registry, and the registry would set the node's uuid (a private data member) while holding the global lock.  Now, we instead use a templated `ChannelzRegistry::CreateNode()` to allow us to assign the uuid and instantiate the node, both while holding the global lock, so the uuid can be generated before the node is instantiated.