### PR TITLE
PHP: Fix ZTS build shutdown segfault

### DIFF
--- a/src/php/ext/grpc/php_grpc.c
+++ b/src/php/ext/grpc/php_grpc.c
@@ -42,6 +42,8 @@ const zend_function_entry grpc_functions[] = {
 };
 /* }}} */
 
+ZEND_DECLARE_MODULE_GLOBALS(grpc);
+
 /* {{{ grpc_module_entry
  */
 zend_module_entry grpc_module_entry = {
@@ -77,10 +79,13 @@ ZEND_GET_MODULE(grpc)
 
 /* {{{ php_grpc_init_globals
  */
-static void php_grpc_init_globals(zend_grpc_globals *grpc_globals) {
-  grpc_globals->enable_fork_support = 0;
-  grpc_globals->poll_strategy = NULL;
-}
+/* Uncomment this function if you have INI entries
+   static void php_grpc_init_globals(zend_grpc_globals *grpc_globals)
+   {
+     grpc_globals->global_value = 0;
+     grpc_globals->global_string = NULL;
+   }
+*/
 /* }}} */
 
 void create_new_channel(
@@ -222,7 +227,6 @@ void apply_ini_settings(TSRMLS_D) {
 /* {{{ PHP_MINIT_FUNCTION
  */
 PHP_MINIT_FUNCTION(grpc) {
-  ZEND_INIT_MODULE_GLOBALS(grpc, php_grpc_init_globals, NULL);
   REGISTER_INI_ENTRIES();
 
   /* Register call error constants */
@@ -406,6 +410,8 @@ PHP_RINIT_FUNCTION(grpc) {
  */
 static PHP_GINIT_FUNCTION(grpc) {
   grpc_globals->initialized = 0;
+  grpc_globals->enable_fork_support = 0;
+  grpc_globals->poll_strategy = NULL;
 }
 /* }}} */
 

--- a/src/php/ext/grpc/php_grpc.h
+++ b/src/php/ext/grpc/php_grpc.h
@@ -70,6 +70,8 @@ ZEND_BEGIN_MODULE_GLOBALS(grpc)
   char *poll_strategy;
 ZEND_END_MODULE_GLOBALS(grpc)
 
+ZEND_EXTERN_MODULE_GLOBALS(grpc);
+
 /* In every utility function you add that needs to use variables
    in php_grpc_globals, call TSRMLS_FETCH(); after declaring other
    variables used by that function, or better yet, pass in TSRMLS_CC


### PR DESCRIPTION
Fixes #18987 

Problem:
 - The `grpc` PECL extension is causing PHP to segfault at shutdown, but only in PHP ZTS builds, and from version `v1.20.0` onwards.

Apparently, we shouldn't be calling `ZEND_INIT_MODULE_GLOBALS`, according to this article https://wiki.php.net/internals/engine.

> Note: do not use ZEND_INIT_MODULE_GLOBALS/ts_allocate_id. If used a shared extension, they will provoke an attempt to call the destructor after the module has been unloaded! Also, for all that is holy, do NOT initialize globals on MINIT (EXTNAME_G(var_ptr) = NULL), that won't work correctly in ZTS as it won't initialize the value in all threads.

So this PR follows the instructions in that article:
 - Add calling `ZEND_DECLARE_MODULE_GLOBALS` in `php_grpc.c`
 - Add calling `ZEND_EXTERN_MODULE_GLOBALS` in `php_grpc.h`
 - Since we already have `PHP_GINIT_FUNCTION`, which is the correct place to initialize the global values, we don't need `php_grpc_init_globals(...)`