### PR TITLE
wrap_memcpy.cc: add GPR_DISABLE_WRAPPED_MEMCPY

### DIFF
--- a/src/core/lib/gpr/wrap_memcpy.cc
+++ b/src/core/lib/gpr/wrap_memcpy.cc
@@ -28,7 +28,7 @@
 
 extern "C" {
 #ifdef __linux__
-#if defined(__x86_64__) && !defined(GPR_MUSL_LIBC_COMPAT)
+#if defined(__x86_64__) && !defined(GPR_MUSL_LIBC_COMPAT) && !defined(GPR_DISABLE_WRAPPED_MEMCPY)
 __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
 void* __wrap_memcpy(void* destination, const void* source, size_t num) {
   return memcpy(destination, source, num);


### PR DESCRIPTION
Add GPR_DISABLE_WRAPPED_MEMCPY to allow the user to disable wrapped
memcpy. This will fix build on x86_64 on musl/uclibc without changing
the cpu behavior.

Fixes:
 - http://autobuild.buildroot.org/results/20d6f2489a4e291a53bd514da66105eb607e1014

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>