### PR TITLE
Fix crash on received header

### DIFF
--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -717,8 +717,8 @@ const char *kCFStreamVarName = "grpc_cfstream";
         // it is ok to set nil because headers are only received once
         strongSelf.responseHeaders = nil;
         // copy the header so that the GRPCOpRecvMetadata object may be dealloc'ed
-        NSDictionary *copiedHeaders = [[NSDictionary alloc] initWithDictionary:headers
-                                                                     copyItems:YES];
+        NSDictionary *copiedHeaders =
+            [[NSDictionary alloc] initWithDictionary:headers copyItems:YES];
         strongSelf.responseHeaders = copiedHeaders;
         strongSelf->_pendingCoreRead = NO;
         [strongSelf maybeStartNextRead];

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -714,7 +714,12 @@ const char *kCFStreamVarName = "grpc_cfstream";
     __strong GRPCCall *strongSelf = weakSelf;
     if (strongSelf) {
       @synchronized(strongSelf) {
-        strongSelf.responseHeaders = headers;
+        // it is ok to set nil because headers are only received once
+        strongSelf.responseHeaders = nil;
+        // copy the header so that the GRPCOpRecvMetadata object may be dealloc'ed
+        NSDictionary *copiedHeaders = [[NSDictionary alloc] initWithDictionary:headers
+                                                                     copyItems:YES];
+        strongSelf.responseHeaders = copiedHeaders;
         strongSelf->_pendingCoreRead = NO;
         [strongSelf maybeStartNextRead];
       }


### PR DESCRIPTION
This is a tentative fix for the crash [when GRPCCall receives header from core](https://github.com/grpc/grpc/blob/b8759c2af4e234c724fc2898b0f444c51d0782cf/src/objective-c/GRPCClient/GRPCCall.m#L717). It does two things:
* Reset `GRPCCall.responseHeader` to `nil`. This is OK since headers should only be received once.
* Make a copy of the received headers in case there's a hidden `dealloc` happened to the received headers

This change may eliminate the crash, but if not, the crash stack trace will provide more information about where the problem is.