### PR TITLE
Fast-path for no-error case for grpc_error_get_status.

### DIFF
--- a/src/core/ext/filters/http/client/http_client_filter.cc
+++ b/src/core/ext/filters/http/client/http_client_filter.cc
@@ -558,7 +558,7 @@ static grpc_slice user_agent_from_args(const grpc_channel_args* args,
 
   tmp = gpr_strvec_flatten(&v, nullptr);
   gpr_strvec_destroy(&v);
-  result = grpc_slice_intern(grpc_slice_from_static_string(tmp));
+  result = grpc_slice_intern(grpc_slice_from_static_string_internal(tmp));
   gpr_free(tmp);
 
   return result;

--- a/src/core/ext/filters/http/client_authority_filter.cc
+++ b/src/core/ext/filters/http/client_authority_filter.cc
@@ -101,8 +101,8 @@ grpc_error* init_channel_elem(grpc_channel_element* elem,
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "GRPC_ARG_DEFAULT_AUTHORITY channel arg. must be a string");
   }
-  chand->default_authority =
-      grpc_slice_intern(grpc_slice_from_static_string(default_authority_str));
+  chand->default_authority = grpc_slice_intern(
+      grpc_slice_from_static_string_internal(default_authority_str));
   chand->default_authority_mdelem = grpc_mdelem_create(
       GRPC_MDSTR_AUTHORITY, chand->default_authority, nullptr);
   GPR_ASSERT(!args->is_last);

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -670,7 +670,7 @@ static grpc_slice take_string(grpc_chttp2_hpack_parser* p,
     str->copied = true;
     str->data.referenced = grpc_empty_slice();
   } else if (intern) {
-    s = grpc_slice_intern(grpc_slice_from_static_buffer(
+    s = grpc_slice_intern(grpc_slice_from_static_buffer_internal(
         str->data.copied.str, str->data.copied.length));
   } else {
     s = grpc_slice_from_copied_buffer(str->data.copied.str,
@@ -1496,14 +1496,14 @@ static grpc_error* parse_key_string(grpc_chttp2_hpack_parser* p,
 
 static bool is_binary_literal_header(grpc_chttp2_hpack_parser* p) {
   /* We know that either argument here is a reference counter slice.
-   * 1. If a result of grpc_slice_from_static_buffer, the refcount is set to
-   *    NoopRefcount.
+   * 1. If a result of grpc_slice_from_static_buffer_internal, the refcount is
+   *    set to kNoopRefcount.
    * 2. If it's p->key.data.referenced, then p->key.copied was set to false,
    *    which occurs in begin_parse_string() - where the refcount is set to
    *    p->current_slice_refcount, which is not null. */
   return grpc_is_refcounted_slice_binary_header(
-      p->key.copied ? grpc_slice_from_static_buffer(p->key.data.copied.str,
-                                                    p->key.data.copied.length)
+      p->key.copied ? grpc_slice_from_static_buffer_internal(
+                          p->key.data.copied.str, p->key.data.copied.length)
                     : p->key.data.referenced);
 }
 

--- a/src/core/ext/transport/chttp2/transport/hpack_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_table.cc
@@ -29,6 +29,7 @@
 
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/gpr/murmur_hash.h"
+#include "src/core/lib/slice/slice_internal.h"
 #include "src/core/lib/surface/validate_metadata.h"
 #include "src/core/lib/transport/static_metadata.h"
 
@@ -182,9 +183,10 @@ void grpc_chttp2_hptbl_init(grpc_chttp2_hptbl* tbl) {
   memset(tbl->ents, 0, sizeof(*tbl->ents) * tbl->cap_entries);
   for (i = 1; i <= GRPC_CHTTP2_LAST_STATIC_ENTRY; i++) {
     tbl->static_ents[i - 1] = grpc_mdelem_from_slices(
-        grpc_slice_intern(grpc_slice_from_static_string(static_table[i].key)),
         grpc_slice_intern(
-            grpc_slice_from_static_string(static_table[i].value)));
+            grpc_slice_from_static_string_internal(static_table[i].key)),
+        grpc_slice_intern(
+            grpc_slice_from_static_string_internal(static_table[i].value)));
   }
 }
 

--- a/src/core/ext/transport/inproc/inproc_transport.cc
+++ b/src/core/ext/transport/inproc/inproc_transport.cc
@@ -1203,7 +1203,7 @@ void inproc_transports_create(grpc_transport** server_transport,
  */
 void grpc_inproc_transport_init(void) {
   grpc_core::ExecCtx exec_ctx;
-  g_empty_slice = grpc_slice_from_static_buffer(nullptr, 0);
+  g_empty_slice = grpc_slice_from_static_buffer_internal(nullptr, 0);
 
   grpc_slice key_tmp = grpc_slice_from_static_string(":path");
   g_fake_path_key = grpc_slice_intern(key_tmp);

--- a/src/core/lib/slice/slice_internal.h
+++ b/src/core/lib/slice/slice_internal.h
@@ -171,6 +171,8 @@ struct grpc_slice_refcount {
 
 namespace grpc_core {
 
+extern grpc_slice_refcount kNoopRefcount;
+
 struct InternedSliceRefcount {
   static void Destroy(void* arg) {
     auto* rc = static_cast<InternedSliceRefcount*>(arg);
@@ -311,5 +313,18 @@ grpc_slice grpc_slice_from_moved_string(grpc_core::UniquePtr<char> p);
 // itself. This means that inlined and slices from static strings will return
 // 0. All other slices will return the size of the allocated chars.
 size_t grpc_slice_memory_usage(grpc_slice s);
+
+inline grpc_slice grpc_slice_from_static_buffer_internal(const void* s,
+                                                         size_t len) {
+  grpc_slice slice;
+  slice.refcount = &grpc_core::kNoopRefcount;
+  slice.data.refcounted.bytes = (uint8_t*)s;
+  slice.data.refcounted.length = len;
+  return slice;
+}
+
+inline grpc_slice grpc_slice_from_static_string_internal(const char* s) {
+  return grpc_slice_from_static_buffer_internal(s, strlen(s));
+}
 
 #endif /* GRPC_CORE_LIB_SLICE_SLICE_INTERNAL_H */

--- a/src/core/lib/transport/error_utils.cc
+++ b/src/core/lib/transport/error_utils.cc
@@ -22,6 +22,7 @@
 
 #include <grpc/support/string_util.h>
 #include "src/core/lib/iomgr/error_internal.h"
+#include "src/core/lib/slice/slice_internal.h"
 #include "src/core/lib/transport/status_conversion.h"
 
 static grpc_error* recursively_find_error_with_field(grpc_error* error,
@@ -52,7 +53,15 @@ void grpc_error_get_status(grpc_error* error, grpc_millis deadline,
   if (GPR_LIKELY(error == GRPC_ERROR_NONE)) {
     if (code != nullptr) *code = GRPC_STATUS_OK;
     if (slice != nullptr) {
-      grpc_error_get_str(error, GRPC_ERROR_STR_GRPC_MESSAGE, slice);
+      // Normally, we call grpc_error_get_str(
+      //   error, GRPC_ERROR_STR_GRPC_MESSAGE, slice).
+      // We can fastpath since we know that:
+      // 1) Error is null
+      // 2) which == GRPC_ERROR_STR_GRPC_MESSAGE
+      // 3) The resulting slice is statically known.
+      // 4) Said resulting slice is of length 0 ("").
+      // This means 3 movs, instead of 10s of instructions and a strlen.
+      *slice = grpc_slice_from_static_string_internal("");
     }
     if (http_error != nullptr) {
       *http_error = GRPC_HTTP2_NO_ERROR;

--- a/tools/run_tests/sanity/core_banned_functions.py
+++ b/tools/run_tests/sanity/core_banned_functions.py
@@ -23,6 +23,7 @@ os.chdir(os.path.join(os.path.dirname(sys.argv[0]), '../../..'))
 
 # map of banned function signature to whitelist
 BANNED_EXCEPT = {
+    'grpc_slice_from_static_buffer(': ['src/core/lib/slice/slice.cc'],
     'grpc_resource_quota_ref(': ['src/core/lib/iomgr/resource_quota.cc'],
     'grpc_resource_quota_unref(':
     ['src/core/lib/iomgr/resource_quota.cc', 'src/core/lib/surface/server.cc'],


### PR DESCRIPTION
For each client side call, we execute grpc_error_get_status; in the common case
that there is no error, we save roughly 30 instructions and a call to strlen.