### PR TITLE
Hotfix for PHP jwt_token_creds interop test

### DIFF
--- a/src/php/lib/Grpc/BaseStub.php
+++ b/src/php/lib/Grpc/BaseStub.php
@@ -199,6 +199,13 @@ class BaseStub
      */
     private function _get_jwt_aud_uri($method)
     {
+        // TODO(jtattermusch): This is not the correct implementation
+        // of extracting JWT "aud" claim. We should rely on
+        // grpc_metadata_credentials_plugin which
+        // also provides the correct value of "aud" claim
+        // in the grpc_auth_metadata_context.service_url field.
+        // Trying to do the construction of "aud" field ourselves
+        // is bad.
         $last_slash_idx = strrpos($method, '/');
         if ($last_slash_idx === false) {
             throw new \InvalidArgumentException(
@@ -211,6 +218,12 @@ class BaseStub
             $hostname = $this->hostname_override;
         } else {
             $hostname = $this->hostname;
+        }
+
+        // Remove the port if it is 443
+        // See https://github.com/grpc/grpc/blob/07c9f7a36b2a0d34fcffebc85649cf3b8c339b5d/src/core/lib/security/transport/client_auth_filter.cc#L205
+        if ((strlen($hostname) > 4) && (substr($hostname, -4) === ":443")) {
+            $hostname = substr($hostname, 0, -4);
         }
 
         return 'https://'.$hostname.$service_name;

--- a/src/php/tests/interop/interop_client.php
+++ b/src/php/tests/interop/interop_client.php
@@ -530,12 +530,7 @@ function _makeStub($args)
         throw new Exception('Missing argument: --test_case is required');
     }
 
-    if ($args['server_port'] === '443') {
-        $server_address = $args['server_host'];
-    } else {
-        $server_address = $args['server_host'].':'.$args['server_port'];
-    }
-
+    $server_address = $args['server_host'].':'.$args['server_port'];
     $test_case = $args['test_case'];
 
     $host_override = '';


### PR DESCRIPTION
I've investigated more why PHP jwt token creds test behaves differently than in other languages and found the reason.

As a side effect, this should fix the problem we're seeing in https://github.com/grpc/grpc/pull/19228 (but it's basically a workaround that makes PHP behave like the other languages so the "port resolved to 0" problem is not triggered).