### PR TITLE
PHP: update generated code test

### DIFF
--- a/examples/node/dynamic_codegen/math_server.js
+++ b/examples/node/dynamic_codegen/math_server.js
@@ -1,0 +1,127 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+var PROTO_PATH = __dirname + '/../../../src/proto/math/math.proto';
+
+var grpc = require('grpc');
+var protoLoader = require('@grpc/proto-loader');
+var packageDefinition = protoLoader.loadSync(
+    PROTO_PATH,
+    {keepCase: true,
+     longs: String,
+     enums: String,
+     defaults: true,
+     oneofs: true
+    });
+var math_proto = grpc.loadPackageDefinition(packageDefinition).math;
+
+/**
+ * Implements the Div RPC method.
+ */
+function Div(call, callback) {
+  var divisor = call.request.divisor;
+  var dividend = call.request.dividend;
+  if (divisor == 0) {
+    callback({
+      code: grpc.status.INVALID_ARGUMENT,
+      details: 'Cannot divide by zero'
+    });
+  } else {
+    setTimeout(function () {
+      callback(null, {
+        quotient: Math.floor(dividend / divisor),
+        remainder: dividend % divisor
+      });
+    }, 1); // 1 millisecond, to make sure 1 microsecond timeout from test
+           // will hit. TODO: Consider fixing this.
+  }
+}
+
+/**
+ * Implements the Fib RPC method.
+ */
+function Fib(stream) {
+  var previous = 0, current = 1;
+  for (var i = 0; i < stream.request.limit; i++) {
+    stream.write({
+      num: current
+    });
+    var temp = current;
+    current += previous;
+    previous = temp;
+  }
+  stream.end();
+}
+
+/**
+ * Implements the Sum RPC method.
+ */
+function Sum(call, callback) {
+  var sum = 0;
+  call.on('data', function(data) {
+    sum += parseInt(data.num);
+  });
+  call.on('end', function() {
+    callback(null, {
+      num: sum
+    });
+  });
+}
+
+/**
+ * Implements the DivMany RPC method.
+ */
+function DivMany(stream) {
+  stream.on('data', function(div_args) {
+    var divisor = div_args.divisor;
+    var dividend = div_args.dividend;
+    if (divisor == 0) {
+      stream.emit('error', {
+        code: grpc.status.INVALID_ARGUMENT,
+        details: 'Cannot divide by zero'
+      });
+    } else {
+      stream.write({
+        quotient: Math.floor(dividend / divisor),
+        remainder: dividend % divisor
+      });
+    }
+  });
+  stream.on('end', function() {
+    stream.end();
+  });
+}
+
+
+/**
+ * Starts an RPC server that receives requests for the Math service at the
+ * sample server port
+ */
+function main() {
+  var server = new grpc.Server();
+  server.addService(math_proto.Math.service, {
+    Div: Div,
+    Fib: Fib,
+    Sum: Sum,
+    DivMany: DivMany,
+  });
+  server.bind('0.0.0.0:50051', grpc.ServerCredentials.createInsecure());
+  server.start();
+}
+
+main();

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -294,9 +294,9 @@ Run a local server serving the math services. Please see [Node][] for how to
 run an example server.
 
 ```sh
-$ cd grpc
+$ cd grpc/examples/node
 $ npm install
-$ node src/node/test/math/math_server.js
+$ node dynamic_codegen/math_server.js
 ```
 
 ### Run test client

--- a/src/php/README.md
+++ b/src/php/README.md
@@ -294,9 +294,9 @@ Run a local server serving the math services. Please see [Node][] for how to
 run an example server.
 
 ```sh
-$ cd grpc/examples/node
+$ cd grpc/src/php/tests/generated_code
 $ npm install
-$ node dynamic_codegen/math_server.js
+$ node math_server.js
 ```
 
 ### Run test client

--- a/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
+++ b/src/php/tests/generated_code/AbstractGeneratedCodeTest.php
@@ -81,6 +81,8 @@ abstract class AbstractGeneratedCodeTest extends PHPUnit_Framework_TestCase
     public function testTimeout()
     {
         $div_arg = new Math\DivArgs();
+        $div_arg->setDividend(7);
+        $div_arg->setDivisor(4);
         $call = self::$client->Div($div_arg, [], ['timeout' => 1]);
         list($response, $status) = $call->wait();
         $this->assertSame(\Grpc\STATUS_DEADLINE_EXCEEDED, $status->code);

--- a/src/php/tests/generated_code/math_server.js
+++ b/src/php/tests/generated_code/math_server.js
@@ -16,7 +16,7 @@
  *
  */
 
-var PROTO_PATH = __dirname + '/../../../src/proto/math/math.proto';
+var PROTO_PATH = __dirname + '/../../../proto/math/math.proto';
 
 var grpc = require('grpc');
 var protoLoader = require('@grpc/proto-loader');

--- a/src/php/tests/generated_code/package.json
+++ b/src/php/tests/generated_code/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "grpc-examples",
+  "version": "0.1.0",
+  "dependencies": {
+    "@grpc/proto-loader": "^0.1.0",
+    "async": "^1.5.2",
+    "grpc": "^1.11.0",
+    "lodash": "^4.6.1",
+    "minimist": "^1.2.0"
+  }
+}

--- a/src/php/tests/generated_code/package.json
+++ b/src/php/tests/generated_code/package.json
@@ -3,9 +3,6 @@
   "version": "0.1.0",
   "dependencies": {
     "@grpc/proto-loader": "^0.1.0",
-    "async": "^1.5.2",
-    "grpc": "^1.11.0",
-    "lodash": "^4.6.1",
-    "minimist": "^1.2.0"
+    "grpc": "^1.11.0"
   }
 }


### PR DESCRIPTION
While working on validating #19232, I realized that the PHP "generated code tests" has gotten a bit out-of-date. First, the source code for Node's implementation of "math_server.js" has been moved to a different repo now (grpc/grpc-node). Also there were some quirks around timeouts that became flaky?

So I end up writing my own "math_server.js" and put it back in this repo and update the README on how to run these PHP generated code tests. 

Actually all these work is just to make sure we can add tests to the change we are introducing in #19232.