### PR TITLE
Avoid regex inefficiencies in no-match scenarios

### DIFF
--- a/src/csharp/Grpc.Tools/ProtoCompile.cs
+++ b/src/csharp/Grpc.Tools/ProtoCompile.cs
@@ -136,7 +136,7 @@ namespace Grpc.Tools
             new ErrorListFilter
             {
                 Pattern = new Regex(
-                    pattern: "(?'FILENAME'.+)\\((?'LINE'\\d+)\\) ?: ?warning in column=(?'COLUMN'\\d+) ?: ?(?'TEXT'.*)",
+                    pattern: "(?'FILENAME'[^\\(]+)\\((?'LINE'\\d+)\\) ?: ?warning in column=(?'COLUMN'\\d+) ?: ?(?'TEXT'.*)",
                     options: RegexOptions.Compiled | RegexOptions.IgnoreCase,
                     matchTimeout: s_regexTimeout),
                 LogAction = (log, match) =>
@@ -162,7 +162,7 @@ namespace Grpc.Tools
             new ErrorListFilter
             {
                 Pattern = new Regex(
-                    pattern: "(?'FILENAME'.+)\\((?'LINE'\\d+)\\) ?: ?error in column=(?'COLUMN'\\d+) ?: ?(?'TEXT'.*)",
+                    pattern: "(?'FILENAME'[^\\(]+)\\((?'LINE'\\d+)\\) ?: ?error in column=(?'COLUMN'\\d+) ?: ?(?'TEXT'.*)",
                     options: RegexOptions.Compiled | RegexOptions.IgnoreCase,
                     matchTimeout: s_regexTimeout),
                 LogAction = (log, match) =>
@@ -185,10 +185,10 @@ namespace Grpc.Tools
 
             // Example warning without location
             //../Protos/greet.proto: warning: Import google/protobuf/empty.proto but not used.
-            new ErrorListFilter 
+            new ErrorListFilter
             {
                 Pattern = new Regex(
-                    pattern: "(?'FILENAME'.+): ?warning: ?(?'TEXT'.*)",
+                    pattern: "(?'FILENAME'[^:]+): ?warning: ?(?'TEXT'.*)",
                     options: RegexOptions.Compiled | RegexOptions.IgnoreCase,
                     matchTimeout: s_regexTimeout),
                 LogAction = (log, match) =>
@@ -211,7 +211,7 @@ namespace Grpc.Tools
             new ErrorListFilter
             {
                 Pattern = new Regex(
-                    pattern: "(?'FILENAME'.+): ?(?'TEXT'.*)",
+                    pattern: "(?'FILENAME'[^:]+): ?(?'TEXT'.*)",
                     options: RegexOptions.Compiled | RegexOptions.IgnoreCase,
                     matchTimeout: s_regexTimeout),
                 LogAction = (log, match) =>
@@ -518,7 +518,7 @@ namespace Grpc.Tools
             foreach (ErrorListFilter filter in s_errorListFilters)
             {
                 Match match = filter.Pattern.Match(singleLine);
-                
+
                 if (match.Success)
                 {
                     filter.LogAction(Log, match);

--- a/src/csharp/Grpc.Tools/ProtoCompile.cs
+++ b/src/csharp/Grpc.Tools/ProtoCompile.cs
@@ -136,7 +136,7 @@ namespace Grpc.Tools
             new ErrorListFilter
             {
                 Pattern = new Regex(
-                    pattern: "(?'FILENAME'[^\\(]+)\\((?'LINE'\\d+)\\) ?: ?warning in column=(?'COLUMN'\\d+) ?: ?(?'TEXT'.*)",
+                    pattern: "^(?'FILENAME'.+?)\\((?'LINE'\\d+)\\) ?: ?warning in column=(?'COLUMN'\\d+) ?: ?(?'TEXT'.*)",
                     options: RegexOptions.Compiled | RegexOptions.IgnoreCase,
                     matchTimeout: s_regexTimeout),
                 LogAction = (log, match) =>
@@ -162,7 +162,7 @@ namespace Grpc.Tools
             new ErrorListFilter
             {
                 Pattern = new Regex(
-                    pattern: "(?'FILENAME'[^\\(]+)\\((?'LINE'\\d+)\\) ?: ?error in column=(?'COLUMN'\\d+) ?: ?(?'TEXT'.*)",
+                    pattern: "^(?'FILENAME'.+?)\\((?'LINE'\\d+)\\) ?: ?error in column=(?'COLUMN'\\d+) ?: ?(?'TEXT'.*)",
                     options: RegexOptions.Compiled | RegexOptions.IgnoreCase,
                     matchTimeout: s_regexTimeout),
                 LogAction = (log, match) =>
@@ -188,7 +188,7 @@ namespace Grpc.Tools
             new ErrorListFilter
             {
                 Pattern = new Regex(
-                    pattern: "(?'FILENAME'[^:]+): ?warning: ?(?'TEXT'.*)",
+                    pattern: "^(?'FILENAME'.+?): ?warning: ?(?'TEXT'.*)",
                     options: RegexOptions.Compiled | RegexOptions.IgnoreCase,
                     matchTimeout: s_regexTimeout),
                 LogAction = (log, match) =>
@@ -211,7 +211,7 @@ namespace Grpc.Tools
             new ErrorListFilter
             {
                 Pattern = new Regex(
-                    pattern: "(?'FILENAME'[^:]+): ?(?'TEXT'.*)",
+                    pattern: "^(?'FILENAME'.+?): ?(?'TEXT'.*)",
                     options: RegexOptions.Compiled | RegexOptions.IgnoreCase,
                     matchTimeout: s_regexTimeout),
                 LogAction = (log, match) =>


### PR DESCRIPTION
Responding to https://github.com/grpc/grpc/pull/18446#issuecomment-499021083.

The problem is that the FILENAME capture group is too lenient and in no-match cases too many comparisons are required to confirm that a match cannot be made. For example, 
```regex
(?'FILENAME'.+)\((?'LINE'\d+)\) ?: ?error in column=(?'COLUMN'\d+) ?: ?(?'TEXT'.*)
```
on
```
../Protos/greet.proto(19) : warning in column=5 : warning : When enum name is stripped and label is PascalCased (Zero) this value label conflicts with Zero.
```
gives no match after 15390 steps (~28ms)

Adding a beginning of line anchor makes the no-match case much more efficient. For example
```regex
^(?'FILENAME'.+)\((?'LINE'\d+)\) ?: ?error in column=(?'COLUMN'\d+) ?: ?(?'TEXT'.*)
```
on the same string gives no match after 325 steps (~1ms).

This should resolve the flaky test issues due to timeout.

cc @jtattermusch 