### PR TITLE
Do not intern method and host for registered methods.

### DIFF
--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -1194,12 +1194,12 @@ void grpc_server_setup_transport(
       bool has_host;
       grpc_slice method;
       if (rm->host != nullptr) {
-        host = grpc_slice_intern(grpc_slice_from_static_string(rm->host));
+        host = grpc_slice_from_static_string(rm->host);
         has_host = true;
       } else {
         has_host = false;
       }
-      method = grpc_slice_intern(grpc_slice_from_static_string(rm->method));
+      method = grpc_slice_from_static_string(rm->method);
       hash = GRPC_MDSTR_KV_HASH(has_host ? grpc_slice_hash_internal(host) : 0,
                                 grpc_slice_hash_internal(method));
       for (probes = 0; chand->registered_methods[(hash + probes) % slots]


### PR DESCRIPTION
Registered methods already have a strdup() of host and method.
Since we have the copy, the strings are guaranteed to remain
valid.