### PR TITLE
Use bazelisk to grab latest bazel version in "incompatible changes" test suite.

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_rbe_incompatible_changes.sh
+++ b/tools/internal_ci/linux/grpc_bazel_rbe_incompatible_changes.sh
@@ -15,9 +15,14 @@
 
 set -ex
 
-# TODO(jtattermusch): use the latest version of bazel
+# Use bazelisk to download the right bazel version
+wget https://github.com/bazelbuild/bazelisk/releases/download/v0.0.7/bazelisk-linux-amd64
+chmod u+x bazelisk-linux-amd64
 
-# Use --all_incompatible_changes to give an early warning about future
-# bazel incompatibilities.
-EXTRA_FLAGS="--config=opt --cache_test_results=no --all_incompatible_changes"
+# We want bazelisk to run the latest stable version
+export USE_BAZEL_VERSION=latest
+# Use bazelisk instead of our usual //tools/bazel wrapper
+mv bazelisk-linux-amd64 github/grpc/tools/bazel
+
+EXTRA_FLAGS="--config=opt --cache_test_results=no"
 github/grpc/tools/internal_ci/linux/grpc_bazel_on_foundry_base.sh "${EXTRA_FLAGS}"


### PR DESCRIPTION
grpc_bazel_rbe_incompatible_changes job should test our codebase with the latest stable bazel version.
We've been told not to use the "--all_incompatible_changes"  flag because it enables incompatibility errors that relate to flags that might never be flipped.

Might investigate with the bazelisk "migrate" option in the future.