### PR TITLE
Add config for C/C++ build only PR job

### DIFF
--- a/tools/internal_ci/linux/pull_request/grpc_basictests_c_cpp_build_only.cfg
+++ b/tools/internal_ci/linux/pull_request/grpc_basictests_c_cpp_build_only.cfg
@@ -1,0 +1,30 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Config file for the internal CI (in protobuf text format)
+
+# Location of the continuous shell script in repository.
+build_file: "grpc/tools/internal_ci/linux/grpc_run_tests_matrix.sh"
+timeout_mins: 60
+action {
+  define_artifacts {
+    regex: "**/*sponge_log.*"
+    regex: "github/grpc/reports/**"
+  }
+}
+
+env_vars {
+  key: "RUN_TESTS_FLAGS"
+  value: "-f basictests linux corelang --inner_jobs 16 -j 1 --internal_ci --build_only"
+}


### PR DESCRIPTION
Preparation for switching over to bazel RBE as the primary source of truth. (will build C/C++ using run_tests.py only in build_only mode).