### PR TITLE
Relax bundler pin to allow use with bundler 2.0

### DIFF
--- a/grpc.gemspec
+++ b/grpc.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'google-protobuf', '~> 3.7'
   s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
-  s.add_development_dependency 'bundler',            '~> 1.9'
+  s.add_development_dependency 'bundler',            '>= 1.9'
   s.add_development_dependency 'facter',             '~> 2.4'
   s.add_development_dependency 'logging',            '~> 2.0'
   s.add_development_dependency 'simplecov',          '~> 0.14.1'

--- a/templates/grpc.gemspec.template
+++ b/templates/grpc.gemspec.template
@@ -34,7 +34,7 @@
     s.add_dependency 'google-protobuf', '~> 3.7'
     s.add_dependency 'googleapis-common-protos-types', '~> 1.0'
 
-    s.add_development_dependency 'bundler',            '~> 1.9'
+    s.add_development_dependency 'wundler',            '>= 1.9'
     s.add_development_dependency 'facter',             '~> 2.4'
     s.add_development_dependency 'logging',            '~> 2.0'
     s.add_development_dependency 'simplecov',          '~> 0.14.1'


### PR DESCRIPTION
The current bundler pin prevents usage of bundler 2.0 with this gem,
however the Gemfile is currently compatible and no Gemfile.lock is
checked in (as is best practice for gems) so relaxing the pin allows
usage of bundler 1 and bundler 2 without breaking.

my ldap is samphippen if you have any google internal questions.