### PR TITLE
Fix handling of non-numeric default ports when resolving ip literals in c-ares

### DIFF
--- a/src/core/ext/filters/client_channel/parse_address.cc
+++ b/src/core/ext/filters/client_channel/parse_address.cc
@@ -20,6 +20,7 @@
 
 #include "src/core/ext/filters/client_channel/parse_address.h"
 #include "src/core/lib/iomgr/grpc_if_nametoindex.h"
+#include "src/core/lib/iomgr/resolve_address.h"
 #include "src/core/lib/iomgr/sockaddr.h"
 #include "src/core/lib/iomgr/socket_utils.h"
 
@@ -225,10 +226,8 @@ bool grpc_parse_uri(const grpc_uri* uri, grpc_resolved_address* resolved_addr) {
 }
 
 uint16_t grpc_strhtons(const char* port) {
-  if (strcmp(port, "http") == 0) {
-    return htons(80);
-  } else if (strcmp(port, "https") == 0) {
-    return htons(443);
-  }
-  return htons(static_cast<unsigned short>(atoi(port)));
+  char* updated_port = grpc_get_port_by_name(port);
+  int numeric_port = updated_port != nullptr ? atoi(updated_port) : atoi(port);
+  gpr_free(updated_port);
+  return htons(static_cast<unsigned short>(numeric_port));
 }

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -37,6 +37,7 @@
 #include "src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h"
 #include "src/core/lib/gpr/host_port.h"
 #include "src/core/lib/gpr/string.h"
+#include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/iomgr/combiner.h"
 #include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/executor.h"
@@ -473,6 +474,13 @@ static bool inner_resolve_as_ip_literal_locked(
       return false;
     }
     *port = gpr_strdup(default_port);
+  }
+  const char* svc[][2] = {{"http", "80"}, {"https", "443"}};
+  for (size_t i = 0; i < GPR_ARRAY_SIZE(svc); i++) {
+    if (strcmp(*port, svc[i][0]) == 0) {
+      gpr_free(*port);
+      *port = gpr_strdup(svc[i][1]);
+    }
   }
   grpc_resolved_address addr;
   GPR_ASSERT(gpr_join_host_port(hostport, *host, atoi(*port)));

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -475,12 +475,10 @@ static bool inner_resolve_as_ip_literal_locked(
     }
     *port = gpr_strdup(default_port);
   }
-  const char* svc[][2] = {{"http", "80"}, {"https", "443"}};
-  for (size_t i = 0; i < GPR_ARRAY_SIZE(svc); i++) {
-    if (strcmp(*port, svc[i][0]) == 0) {
-      gpr_free(*port);
-      *port = gpr_strdup(svc[i][1]);
-    }
+  char* updated_port = grpc_get_port_by_name(*port);
+  if (updated_port != nullptr) {
+    gpr_free(*port);
+    *port = updated_port;
   }
   grpc_resolved_address addr;
   GPR_ASSERT(gpr_join_host_port(hostport, *host, atoi(*port)));

--- a/src/core/lib/iomgr/resolve_address.cc
+++ b/src/core/lib/iomgr/resolve_address.cc
@@ -19,6 +19,8 @@
 #include <grpc/support/port_platform.h>
 
 #include <grpc/support/alloc.h>
+#include <grpc/support/string_util.h>
+#include "src/core/lib/gpr/useful.h"
 #include "src/core/lib/iomgr/resolve_address.h"
 
 grpc_address_resolver_vtable* grpc_resolve_address_impl;
@@ -47,4 +49,15 @@ grpc_error* grpc_blocking_resolve_address(const char* name,
                                           grpc_resolved_addresses** addresses) {
   return grpc_resolve_address_impl->blocking_resolve_address(name, default_port,
                                                              addresses);
+}
+
+char* grpc_get_port_by_name(const char* port) {
+  GPR_ASSERT(port != nullptr);
+  const char* svc[][2] = {{"http", "80"}, {"https", "443"}};
+  for (size_t i = 0; i < GPR_ARRAY_SIZE(svc); i++) {
+    if (strcmp(port, svc[i][0]) == 0) {
+      return gpr_strdup(svc[i][1]);
+    }
+  }
+  return nullptr;
 }

--- a/src/core/lib/iomgr/resolve_address.h
+++ b/src/core/lib/iomgr/resolve_address.h
@@ -80,4 +80,9 @@ grpc_error* grpc_blocking_resolve_address(const char* name,
                                           const char* default_port,
                                           grpc_resolved_addresses** addresses);
 
+/* Returns a string representation of the numeric port corresponding to 'port',
+ * if 'port' is a recognized non-numeric i.e. "named" port, otherwise returns
+ * nullptr. The returned string is owned by the caller. */
+char* grpc_get_port_by_name(const char* port);
+
 #endif /* GRPC_CORE_LIB_IOMGR_RESOLVE_ADDRESS_H */

--- a/src/core/lib/iomgr/resolve_address_posix.cc
+++ b/src/core/lib/iomgr/resolve_address_posix.cc
@@ -89,15 +89,11 @@ static grpc_error* posix_blocking_resolve_address(
 
   if (s != 0) {
     /* Retry if well-known service name is recognized */
-    const char* svc[][2] = {{"http", "80"}, {"https", "443"}};
-    for (i = 0; i < GPR_ARRAY_SIZE(svc); i++) {
-      if (strcmp(port, svc[i][0]) == 0) {
-        GRPC_SCHEDULING_START_BLOCKING_REGION;
-        s = getaddrinfo(host, svc[i][1], &hints, &result);
-        GRPC_SCHEDULING_END_BLOCKING_REGION;
-        break;
-      }
+    char* updated_port = grpc_get_port_by_name(port);
+    if (updated_port != nullptr) {
+      s = getaddrinfo(host, updated_port, &hints, &result);
     }
+    gpr_free(updated_port);
   }
 
   if (s != 0) {

--- a/test/core/iomgr/resolve_address_test.cc
+++ b/test/core/iomgr/resolve_address_test.cc
@@ -31,6 +31,8 @@
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/iomgr/executor.h"
 #include "src/core/lib/iomgr/iomgr.h"
+#include "src/core/lib/iomgr/sockaddr.h"
+#include "src/core/lib/iomgr/socket_utils.h"
 #include "test/core/util/cmdline.h"
 #include "test/core/util/test_config.h"
 
@@ -153,6 +155,32 @@ static void must_succeed_with_ipv4_first(void* argsp, grpc_error* err) {
   gpr_mu_unlock(args->mu);
 }
 
+static void must_succeed_with_443_port(void* argsp, grpc_error* err) {
+  args_struct* args = static_cast<args_struct*>(argsp);
+  GPR_ASSERT(err == GRPC_ERROR_NONE);
+  GPR_ASSERT(args->addrs != nullptr);
+  GPR_ASSERT(args->addrs->naddrs > 0);
+  const struct sockaddr* result_addr =
+      reinterpret_cast<const struct sockaddr*>(args->addrs->addrs[0].addr);
+  if (result_addr->sa_family == AF_INET) {
+    GPR_ASSERT(
+        reinterpret_cast<const struct sockaddr_in*>(result_addr)->sin_port ==
+        grpc_htons(443));
+  } else if (result_addr->sa_family == AF_INET6) {
+    GPR_ASSERT(
+        reinterpret_cast<const struct sockaddr_in6*>(result_addr)->sin6_port ==
+        grpc_htons(443));
+  } else {
+    gpr_log(GPR_ERROR, "Got unexpected addr family: %d",
+            result_addr->sa_family);
+    abort();
+  }
+  gpr_atm_rel_store(&args->done_atm, 1);
+  gpr_mu_lock(args->mu);
+  GRPC_LOG_IF_ERROR("pollset_kick", grpc_pollset_kick(args->pollset, nullptr));
+  gpr_mu_unlock(args->mu);
+}
+
 static void test_localhost(void) {
   grpc_core::ExecCtx exec_ctx;
   args_struct args;
@@ -210,10 +238,23 @@ static void test_non_numeric_default_port(void) {
   grpc_core::ExecCtx exec_ctx;
   args_struct args;
   args_init(&args);
-  grpc_resolve_address(
-      "localhost", "https", args.pollset_set,
-      GRPC_CLOSURE_CREATE(must_succeed, &args, grpc_schedule_on_exec_ctx),
-      &args.addrs);
+  grpc_resolve_address("localhost", "https", args.pollset_set,
+                       GRPC_CLOSURE_CREATE(must_succeed_with_443_port, &args,
+                                           grpc_schedule_on_exec_ctx),
+                       &args.addrs);
+  grpc_core::ExecCtx::Get()->Flush();
+  poll_pollset_until_request_done(&args);
+  args_finish(&args);
+}
+
+static void test_ip_literal_with_non_numeric_default_port(void) {
+  grpc_core::ExecCtx exec_ctx;
+  args_struct args;
+  args_init(&args);
+  grpc_resolve_address("127.0.0.1", "https", args.pollset_set,
+                       GRPC_CLOSURE_CREATE(must_succeed_with_443_port, &args,
+                                           grpc_schedule_on_exec_ctx),
+                       &args.addrs);
   grpc_core::ExecCtx::Get()->Flush();
   poll_pollset_until_request_done(&args);
   args_finish(&args);
@@ -372,6 +413,7 @@ int main(int argc, char** argv) {
     test_default_port();
     test_non_numeric_default_port();
     test_missing_default_port();
+    test_ip_literal_with_non_numeric_default_port();
     test_ipv6_with_port();
     test_ipv6_without_port();
     test_invalid_ip_addresses();


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/19233

Also adds a test to cover non-numeric default ports with localhost (this is interesting for windows and libuv)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/19285)
<!-- Reviewable:end -->
