### PR TITLE
Clean up Python Channel.__del__ logic

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -966,11 +966,6 @@ def _poll_connectivity(state, channel, initial_try_to_connect):
                         _spawn_delivery(state, callbacks)
 
 
-def _moot(state):
-    with state.lock:
-        del state.callbacks_and_connectivities[:]
-
-
 def _subscribe(state, callback, try_to_connect):
     with state.lock:
         if not state.callbacks_and_connectivities and not state.polling:
@@ -998,11 +993,6 @@ def _unsubscribe(state, callback):
             if callback == subscribed_callback:
                 state.callbacks_and_connectivities.pop(index)
                 break
-
-
-def _unsubscribe_all(state):
-    with state.lock:
-        del state.callbacks_and_connectivities[:]
 
 
 def _augment_options(base_options, compression):
@@ -1071,16 +1061,21 @@ class Channel(grpc.Channel):
             self._channel, _channel_managed_call_management(self._call_state),
             _common.encode(method), request_serializer, response_deserializer)
 
+    def _unsubscribe_all(self):
+        state = self._connectivity_state
+        if state:
+            with state.lock:
+                del state.callbacks_and_connectivities[:]
+
     def _close(self):
-        _unsubscribe_all(self._connectivity_state)
+        self._unsubscribe_all()
         self._channel.close(cygrpc.StatusCode.cancelled, 'Channel closed!')
         cygrpc.fork_unregister_channel(self)
-        _moot(self._connectivity_state)
 
     def _close_on_fork(self):
+        self._unsubscribe_all()
         self._channel.close_on_fork(cygrpc.StatusCode.cancelled,
                                     'Channel closed due to fork')
-        _moot(self._connectivity_state)
 
     def __enter__(self):
         return self
@@ -1102,7 +1097,9 @@ class Channel(grpc.Channel):
         # for as long as they are in use and to close them after using them,
         # then deletion of this grpc._channel.Channel instance can be made to
         # effect closure of the underlying cygrpc.Channel instance.
-        # This prevent the failed-at-initializing object removal from failing.
-        # Though the __init__ failed, the removal will still trigger __del__.
-        if _moot is not None and hasattr(self, '_connectivity_state'):
-            _moot(self._connectivity_state)
+        try:
+            self._unsubscribe_all()
+        except:
+            # Exceptions in __del__ are ignored by Python anyway, but they can
+            # keep spamming logs.  Just silence them.
+            pass

--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -1099,7 +1099,7 @@ class Channel(grpc.Channel):
         # effect closure of the underlying cygrpc.Channel instance.
         try:
             self._unsubscribe_all()
-        except:
+        except:  # pylint: disable=bare-except
             # Exceptions in __del__ are ignored by Python anyway, but they can
             # keep spamming logs.  Just silence them.
             pass


### PR DESCRIPTION
Python finalizers are tricky.  Unfortunately, when your finalizer runs, other things may be already deallocated (and yes, that includes symbols referring to functions like `_moot` 🤦‍♂️). Also, if your initializer fails, `__del__` can still be called but the object does not have the full set of attributes.

Additionally, there are logic issues with `grpc.Channel` finalization (cyclical references due to bad design, along with connectivity poller thread holding references) make matters weird.  When watching connectivity on the channel, if the program shuts down, you may face logspam like:

`Exception TypeError: "'NoneType' object is not callable" in <bound method Channel.__del__ of <grpc._channel.Channel object at 0x7f58f02f4390>> ignored`

Python already ignores exceptions in `__del__`, but that can still result in log spam.

This PR:

- merges `_moot` and `_unsubscribe_all` (my bad; the function basically existed and I accidentally rewrote a clone)
- turns `_moot` into a class method to ensure the global function symbol is not destroyed before our object instance.
- preinitializes `_connectivity_state` attribute to `None` to simplify `__del__` logic so it does not have to check `hasattr` (in case cygrpc channel initialization raises an exception).
- eats all the exceptions raised in `__del__` so they don't result in logspam (not ideal, but they are ignored by the interpreter anyway, so this will not change the logic of the program, just alleviates the pain). Ideally the polling logic should be simplified so it does not keep background threads and circular references out there, but this helps for now.

cc @gnossen @lidizheng 