### PR TITLE
Add Python 3.8 test

### DIFF
--- a/templates/tools/dockerfile/test/python_stretch_3.8_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_stretch_3.8_x64/Dockerfile.template
@@ -1,0 +1,28 @@
+
+%YAML 1.2
+--- |
+  # Copyright 2019 The gRPC Authors
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  <%include file="../../python_stretch.include"/>
+  RUN apt-get install -y jq zlib1g-dev libssl-dev
+
+  COPY get_cpython.sh /tmp
+  RUN apt-get install -y jq build-essential libffi-dev && ${'\\'}
+    chmod +x /tmp/get_cpython.sh && ${'\\'}
+    /tmp/get_cpython.sh && ${'\\'}
+    rm /tmp/get_cpython.sh
+
+  RUN python3.8 -m ensurepip && ${'\\'}
+      python3.8 -m pip install coverage

--- a/tools/dockerfile/test/python_stretch_3.8_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_3.8_x64/Dockerfile
@@ -1,0 +1,79 @@
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:stretch
+  
+# Install Git and basic packages.
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  autotools-dev \
+  build-essential \
+  bzip2 \
+  ccache \
+  curl \
+  dnsutils \
+  gcc \
+  gcc-multilib \
+  git \
+  golang \
+  gyp \
+  lcov \
+  libc6 \
+  libc6-dbg \
+  libc6-dev \
+  libgtest-dev \
+  libtool \
+  make \
+  perl \
+  strace \
+  python-dev \
+  python-setuptools \
+  python-yaml \
+  telnet \
+  unzip \
+  wget \
+  zip && apt-get clean
+
+#================
+# Build profiling
+RUN apt-get update && apt-get install -y time && apt-get clean
+
+# Google Cloud platform API libraries
+RUN apt-get update && apt-get install -y python-pip && apt-get clean
+RUN pip install --upgrade google-api-python-client oauth2client
+
+# Install Python 2.7
+RUN apt-get update && apt-get install -y python2.7 python-all-dev
+RUN curl https://bootstrap.pypa.io/get-pip.py | python2.7
+
+# Add Debian 'testing' repository
+RUN echo 'deb http://ftp.de.debian.org/debian testing main' >> /etc/apt/sources.list
+RUN echo 'APT::Default-Release "stable";' | tee -a /etc/apt/apt.conf.d/00local
+
+
+RUN mkdir /var/local/jenkins
+
+# Define the default command.
+CMD ["bash"]
+
+RUN apt-get install -y jq zlib1g-dev libssl-dev
+
+COPY get_cpython.sh /tmp
+RUN apt-get install -y jq build-essential libffi-dev && \
+  chmod +x /tmp/get_cpython.sh && \
+  /tmp/get_cpython.sh && \
+  rm /tmp/get_cpython.sh
+
+RUN python3.8 -m ensurepip && \
+    python3.8 -m pip install coverage

--- a/tools/dockerfile/test/python_stretch_3.8_x64/get_cpython.sh
+++ b/tools/dockerfile/test/python_stretch_3.8_x64/get_cpython.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+VERSION_REGEX="v3.8.*"
+REPO="python/cpython"
+
+LATEST=$(curl -s https://api.github.com/repos/$REPO/tags | \
+          jq -r '.[] | select(.name|test("'$VERSION_REGEX'")) | .name' \
+          | sort | tail -n1)
+
+wget https://github.com/$REPO/archive/$LATEST.tar.gz
+tar xzvf *.tar.gz
+( cd cpython*
+  ./configure
+  make install
+)

--- a/tools/dockerfile/test/python_stretch_3.8_x64/get_cpython.sh
+++ b/tools/dockerfile/test/python_stretch_3.8_x64/get_cpython.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2019 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 VERSION_REGEX="v3.8.*"
 REPO="python/cpython"
 

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1349,9 +1349,10 @@ argp.add_argument(
     choices=[
         'default', 'gcc4.4', 'gcc4.6', 'gcc4.8', 'gcc4.9', 'gcc5.3', 'gcc7.2',
         'gcc_musl', 'clang3.4', 'clang3.5', 'clang3.6', 'clang3.7', 'clang7.0',
-        'python2.7', 'python3.4', 'python3.5', 'python3.6', 'python3.7', 'python3.8', 'pypy',
-        'pypy3', 'python_alpine', 'all_the_cpythons', 'electron1.3',
-        'electron1.6', 'coreclr', 'cmake', 'cmake_vs2015', 'cmake_vs2017'
+        'python2.7', 'python3.4', 'python3.5', 'python3.6', 'python3.7',
+        'python3.8', 'pypy', 'pypy3', 'python_alpine', 'all_the_cpythons',
+        'electron1.3', 'electron1.6', 'coreclr', 'cmake', 'cmake_vs2015',
+        'cmake_vs2017'
     ],
     default='default',
     help=

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -753,7 +753,7 @@ class PythonLanguage(object):
     def _python_manager_name(self):
         """Choose the docker image to use based on python version."""
         if self.args.compiler in [
-                'python2.7', 'python3.5', 'python3.6', 'python3.7'
+                'python2.7', 'python3.5', 'python3.6', 'python3.7', 'python3.8'
         ]:
             return 'stretch_' + self.args.compiler[len('python'):]
         elif self.args.compiler == 'python_alpine':
@@ -829,6 +829,12 @@ class PythonLanguage(object):
             minor='7',
             bits=bits,
             config_vars=config_vars)
+        python38_config = _python_config_generator(
+            name='py38',
+            major='3',
+            minor='8',
+            bits=bits,
+            config_vars=config_vars)
         pypy27_config = _pypy_config_generator(
             name='pypy', major='2', config_vars=config_vars)
         pypy32_config = _pypy_config_generator(
@@ -852,6 +858,8 @@ class PythonLanguage(object):
             return (python36_config,)
         elif args.compiler == 'python3.7':
             return (python37_config,)
+        elif args.compiler == 'python3.8':
+            return (python38_config,)
         elif args.compiler == 'pypy':
             return (pypy27_config,)
         elif args.compiler == 'pypy3':
@@ -865,6 +873,7 @@ class PythonLanguage(object):
                 python35_config,
                 python36_config,
                 python37_config,
+                # TODO: Add Python 3.8 once it's released.
             )
         else:
             raise Exception('Compiler %s not supported.' % args.compiler)
@@ -1340,7 +1349,7 @@ argp.add_argument(
     choices=[
         'default', 'gcc4.4', 'gcc4.6', 'gcc4.8', 'gcc4.9', 'gcc5.3', 'gcc7.2',
         'gcc_musl', 'clang3.4', 'clang3.5', 'clang3.6', 'clang3.7', 'clang7.0',
-        'python2.7', 'python3.4', 'python3.5', 'python3.6', 'python3.7', 'pypy',
+        'python2.7', 'python3.4', 'python3.5', 'python3.6', 'python3.7', 'python3.8', 'pypy',
         'pypy3', 'python_alpine', 'all_the_cpythons', 'electron1.3',
         'electron1.6', 'coreclr', 'cmake', 'cmake_vs2015', 'cmake_vs2017'
     ],


### PR DESCRIPTION
This PR adds a compatibility test with Python 3.8. No CI job has been added for it yet and it has not been added as a default test configuration. This should be changed after the final release in October. For the moment, the test image pulls the most recent cpython 3.8 pre-release version and compiles from source. It is expected that this test be run manually. Python 3.8 support has also not yet been added to the wheel metadata.

Related: https://github.com/grpc/grpc/issues/19243