### PR TITLE
Resolve delayed callback crash

### DIFF
--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -18,8 +18,6 @@
 
 #import "InteropTests.h"
 
-#import <libkern/OSAtomic.h>
-
 #include <grpc/status.h>
 
 #ifdef GRPC_COMPILE_WITH_CRONET


### PR DESCRIPTION
Avoid XCTest throwing failures in a callback after the test case is already done. This will cause tests to crash.

Fixes #19290 