### PR TITLE
Add subchannel state transition from TRANSIENT_FAILURE to IDLE

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/pick_first/pick_first.cc
@@ -354,6 +354,11 @@ void PickFirst::PickFirstSubchannelData::ProcessConnectivityChangeLocked(
   GPR_ASSERT(subchannel_list() == p->subchannel_list_.get() ||
              subchannel_list() == p->latest_pending_subchannel_list_.get());
   GPR_ASSERT(connectivity_state != GRPC_CHANNEL_SHUTDOWN);
+  if (connectivity_state == GRPC_CHANNEL_IDLE) {
+    // Currently, PF ignores IDLE state report. Later this state will be used to
+    // optimize Happy Eyeballs.
+    return;
+  }
   // Handle updates for the currently selected subchannel.
   if (p->selected_ == this) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_lb_pick_first_trace)) {

--- a/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/round_robin/round_robin.cc
@@ -445,6 +445,10 @@ void RoundRobin::RoundRobinSubchannelData::ProcessConnectivityChangeLocked(
     grpc_connectivity_state connectivity_state) {
   RoundRobin* p = static_cast<RoundRobin*>(subchannel_list()->policy());
   GPR_ASSERT(subchannel() != nullptr);
+  if (connectivity_state == GRPC_CHANNEL_IDLE) {
+    // Round robin does not care about subchannel's IDLE state.
+    return;
+  }
   // If the new state is TRANSIENT_FAILURE, re-resolve.
   // Only do this if we've started watching, not at startup time.
   // Otherwise, if the subchannel was already in state TRANSIENT_FAILURE

--- a/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
+++ b/src/core/ext/filters/client_channel/lb_policy/subchannel_list.h
@@ -111,8 +111,6 @@ class SubchannelData {
   }
 
   // Resets the connection backoff.
-  // TODO(roth): This method should go away when we move the backoff
-  // code out of the subchannel and into the LB policies.
   void ResetBackoffLocked();
 
   // Starts watching the connectivity state of the subchannel.

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -948,11 +948,13 @@ void Subchannel::SetConnectivityStateLocked(grpc_connectivity_state state) {
     const grpc_millis backoff_duration =
         next_attempt_deadline_ - ExecCtx::Get()->Now();
     if (backoff_duration <= 0) {
-      gpr_log(GPR_INFO, "Subchannel %p: Transient failure occurs. Can retry"
-              " immediately.", this);
-    }
-    else {
-      gpr_log(GPR_INFO, "Subchannel %p: Transient failure occurs. Can not retry"
+      gpr_log(GPR_INFO,
+              "Subchannel %p: Transient failure occurs. Can retry"
+              " immediately.",
+              this);
+    } else {
+      gpr_log(GPR_INFO,
+              "Subchannel %p: Transient failure occurs. Can not retry"
               " in %" PRId64 " milliseconds due to the backoff restriction.",
               this, backoff_duration);
     }
@@ -1012,7 +1014,8 @@ void Subchannel::OnConnectingFinished(void* arg, grpc_error* error) {
 void Subchannel::BackoffTimerCallback(void* arg, grpc_error* error) {
   auto* c = static_cast<Subchannel*>(arg);
   // We use ReleasableMutexLock here because we can NOT unref this subchannel
-  // while holding its lock, since unref may cause the subchannel to be destroyed.
+  // while holding its lock, since unref may cause the subchannel to be
+  // destroyed.
   // TODO(qianchengz): Once subchannel refcounting is simplified, we can use
   // MutexLock instead of ReleasableMutexLock here.
   ReleasableMutexLock lock(&c->mu_);

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -963,19 +963,14 @@ void Subchannel::SetConnectivityStateLocked(grpc_connectivity_state state) {
 }
 
 void Subchannel::MaybeStartConnectingLocked() {
-  if (disconnected_) {
+  if (!disconnected_) {
     // Don't try to connect if we're already disconnected.
-    return;
-  }
-  if (connected_subchannel_ != nullptr) {
-    // Already connected: don't restart.
-    return;
-  }
-  if (state_ == GRPC_CHANNEL_TRANSIENT_FAILURE) {
-    connection_attempt_requested_while_in_backoff_ = true;
-  } else if (state_ == GRPC_CHANNEL_IDLE) {
-    GRPC_SUBCHANNEL_WEAK_REF(this, "connecting");
-    ContinueConnectingLocked();
+    if (state_ == GRPC_CHANNEL_TRANSIENT_FAILURE) {
+      connection_attempt_requested_while_in_backoff_ = true;
+    } else if (state_ == GRPC_CHANNEL_IDLE) {
+      GRPC_SUBCHANNEL_WEAK_REF(this, "connecting");
+      ContinueConnectingLocked();
+    }
   }
 }
 

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -342,8 +342,6 @@ class Subchannel::ConnectedSubchannelStateWatcher {
             }
             c->connected_subchannel_.reset();
             c->SetConnectivityStateLocked(GRPC_CHANNEL_TRANSIENT_FAILURE);
-            // c->backoff_begun_ = false;
-            // c->backoff_.Reset();
             c->ResetBackoffLocked();
           }
           break;
@@ -759,8 +757,7 @@ void Subchannel::WeakUnref(GRPC_SUBCHANNEL_REF_EXTRA_ARGS) {
     GRPC_CLOSURE_SCHED(GRPC_CLOSURE_CREATE(subchannel_destroy, this,
                                            grpc_schedule_on_exec_ctx),
                        GRPC_ERROR_NONE);
-  }
-  else if (old_refs == 2 && state_ == GRPC_CHANNEL_TRANSIENT_FAILURE) {
+  } else if (old_refs == 2 && state_ == GRPC_CHANNEL_TRANSIENT_FAILURE) {
     have_retry_attempt_ = false;
     grpc_timer_cancel(&backoff_end_alarm_);
   }
@@ -859,14 +856,6 @@ void Subchannel::AttemptToConnect() {
 
 void Subchannel::ResetBackoff() {
   MutexLock lock(&mu_);
-  // backoff_.Reset();
-  // if (have_retry_alarm_) {
-  //   retry_immediately_ = true;
-  //   grpc_timer_cancel(&retry_alarm_);
-  // } else {
-  //   backoff_begun_ = false;
-  //   MaybeStartConnectingLocked();
-  // }
   ResetBackoffLocked();
 }
 
@@ -961,7 +950,7 @@ void Subchannel::SetConnectivityStateLocked(grpc_connectivity_state state) {
   if (state_ == GRPC_CHANNEL_TRANSIENT_FAILURE) {
     GRPC_SUBCHANNEL_WEAK_REF(this, "in transient failure");
     GRPC_CLOSURE_INIT(&on_backoff_end_alarm_, OnBackoffEndAlarm, this,
-                        grpc_schedule_on_exec_ctx);
+                      grpc_schedule_on_exec_ctx);
     grpc_timer_init(&backoff_end_alarm_, next_attempt_deadline_,
                     &on_backoff_end_alarm_);
   }
@@ -982,56 +971,12 @@ void Subchannel::MaybeStartConnectingLocked() {
   }
   connecting_ = true;
   GRPC_SUBCHANNEL_WEAK_REF(this, "connecting");
-  // if (!backoff_begun_) {
-  //   backoff_begun_ = true;
-  //   ContinueConnectingLocked();
-  // } else {
-  //   GPR_ASSERT(!have_retry_alarm_);
-  //   have_retry_alarm_ = true;
-  //   const grpc_millis time_til_next =
-  //       next_attempt_deadline_ - ExecCtx::Get()->Now();
-  //   if (time_til_next <= 0) {
-  //     gpr_log(GPR_INFO, "Subchannel %p: Retry immediately", this);
-  //   } else {
-  //     gpr_log(GPR_INFO, "Subchannel %p: Retry in %" PRId64 " milliseconds",
-  //             this, time_til_next);
-  //   }
-  //   GRPC_CLOSURE_INIT(&on_retry_alarm_, OnRetryAlarm, this,
-  //                     grpc_schedule_on_exec_ctx);
-  //   grpc_timer_init(&retry_alarm_, next_attempt_deadline_, &on_retry_alarm_);
-  // }
   if (state_ == GRPC_CHANNEL_TRANSIENT_FAILURE) {
     have_retry_attempt_ = true;
   } else {  // state == GRPC_CHANNEL_IDLE
     ContinueConnectingLocked();
   }
 }
-
-// void Subchannel::OnRetryAlarm(void* arg, grpc_error* error) {
-//   Subchannel* c = static_cast<Subchannel*>(arg);
-//   // TODO(soheilhy): Once subchannel refcounting is simplified, we can get use
-//   //                 MutexLock instead of ReleasableMutexLock, here.
-//   ReleasableMutexLock lock(&c->mu_);
-//   c->have_retry_alarm_ = false;
-//   if (c->disconnected_) {
-//     error = GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING("Disconnected",
-//                                                              &error, 1);
-//   } else if (c->retry_immediately_) {
-//     c->retry_immediately_ = false;
-//     error = GRPC_ERROR_NONE;
-//   } else {
-//     GRPC_ERROR_REF(error);
-//   }
-//   if (error == GRPC_ERROR_NONE) {
-//     gpr_log(GPR_INFO, "Failed to connect to channel, retrying");
-//     c->ContinueConnectingLocked();
-//     lock.Unlock();
-//   } else {
-//     lock.Unlock();
-//     GRPC_SUBCHANNEL_WEAK_UNREF(c, "connecting");
-//   }
-//   GRPC_ERROR_UNREF(error);
-// }
 
 void Subchannel::ContinueConnectingLocked() {
   grpc_connect_in_args args;

--- a/src/core/ext/filters/client_channel/subchannel.h
+++ b/src/core/ext/filters/client_channel/subchannel.h
@@ -350,7 +350,6 @@ class Subchannel {
   grpc_closure on_connecting_finished_;
   // Active connection, or null.
   RefCountedPtr<ConnectedSubchannel> connected_subchannel_;
-  bool connecting_ = false;
   bool disconnected_ = false;
 
   // Connectivity state tracking.

--- a/src/core/ext/filters/client_channel/subchannel.h
+++ b/src/core/ext/filters/client_channel/subchannel.h
@@ -319,11 +319,13 @@ class Subchannel {
 
   // Methods for connection.
   void MaybeStartConnectingLocked();
-  static void OnRetryAlarm(void* arg, grpc_error* error);
+  // static void OnRetryAlarm(void* arg, grpc_error* error);
   void ContinueConnectingLocked();
   static void OnConnectingFinished(void* arg, grpc_error* error);
+  static void OnBackoffEndAlarm(void* arg, grpc_error* error);
   bool PublishTransportLocked();
   void Disconnect();
+  void ResetBackoffLocked();
 
   gpr_atm RefMutate(gpr_atm delta,
                     int barrier GRPC_SUBCHANNEL_REF_MUTATE_EXTRA_ARGS);
@@ -367,14 +369,19 @@ class Subchannel {
   BackOff backoff_;
   grpc_millis next_attempt_deadline_;
   grpc_millis min_connect_timeout_ms_;
-  bool backoff_begun_ = false;
+  // bool backoff_begun_ = false;
 
-  // Retry alarm.
-  grpc_timer retry_alarm_;
-  grpc_closure on_retry_alarm_;
-  bool have_retry_alarm_ = false;
-  // reset_backoff() was called while alarm was pending.
-  bool retry_immediately_ = false;
+  // // Retry alarm.
+  // grpc_timer retry_alarm_;
+  // grpc_closure on_retry_alarm_;
+  // bool have_retry_alarm_ = false;
+  // // reset_backoff() was called while alarm was pending.
+  // bool retry_immediately_ = false;
+
+  // Backoff end alarm.
+  grpc_timer backoff_end_alarm_;
+  grpc_closure on_backoff_end_alarm_;
+  bool have_retry_attempt_ = false;
 
   // Channelz tracking.
   RefCountedPtr<channelz::SubchannelNode> channelz_node_;

--- a/src/core/ext/filters/client_channel/subchannel.h
+++ b/src/core/ext/filters/client_channel/subchannel.h
@@ -317,7 +317,7 @@ class Subchannel {
   void MaybeStartConnectingLocked();
   void ContinueConnectingLocked();
   static void OnConnectingFinished(void* arg, grpc_error* error);
-  static void OnBackoffTimerAlarm(void* arg, grpc_error* error);
+  static void OnBackoffTimer(void* arg, grpc_error* error);
   bool PublishTransportLocked();
   void Disconnect();
   void ResetBackoffLocked();

--- a/src/core/ext/filters/client_channel/subchannel.h
+++ b/src/core/ext/filters/client_channel/subchannel.h
@@ -317,7 +317,7 @@ class Subchannel {
   void MaybeStartConnectingLocked();
   void ContinueConnectingLocked();
   static void OnConnectingFinished(void* arg, grpc_error* error);
-  static void BackoffTimerCallback(void* arg, grpc_error* error);
+  static void OnBackoffTimerAlarm(void* arg, grpc_error* error);
   bool PublishTransportLocked();
   void Disconnect();
   void ResetBackoffLocked();
@@ -363,14 +363,12 @@ class Subchannel {
   BackOff backoff_;
   grpc_millis next_attempt_deadline_;
   grpc_millis min_connect_timeout_ms_;
-
-  // Backoff end alarm.
   grpc_timer backoff_timer_;
-  grpc_closure backoff_timer_callback_;
+  grpc_closure on_backoff_timer_;
   // This boolean value will be set to true when AttemptToConnect()
   // is called while the subchannel is in backoff and then set back to
   // false in BackoffTimerCallback() when the subchannel exits backoff
-  // and start the next connection attempt.
+  // and starts the next connection attempt.
   bool connection_attempt_requested_while_in_backoff_ = false;
 
   // Channelz tracking.

--- a/src/core/ext/filters/client_channel/subchannel.h
+++ b/src/core/ext/filters/client_channel/subchannel.h
@@ -319,7 +319,6 @@ class Subchannel {
 
   // Methods for connection.
   void MaybeStartConnectingLocked();
-  // static void OnRetryAlarm(void* arg, grpc_error* error);
   void ContinueConnectingLocked();
   static void OnConnectingFinished(void* arg, grpc_error* error);
   static void OnBackoffEndAlarm(void* arg, grpc_error* error);
@@ -369,14 +368,6 @@ class Subchannel {
   BackOff backoff_;
   grpc_millis next_attempt_deadline_;
   grpc_millis min_connect_timeout_ms_;
-  // bool backoff_begun_ = false;
-
-  // // Retry alarm.
-  // grpc_timer retry_alarm_;
-  // grpc_closure on_retry_alarm_;
-  // bool have_retry_alarm_ = false;
-  // // reset_backoff() was called while alarm was pending.
-  // bool retry_immediately_ = false;
 
   // Backoff end alarm.
   grpc_timer backoff_end_alarm_;


### PR DESCRIPTION
Previously, once a subchannel leaves the IDLE state, it will never come to IDLE. And a subchannel in TRANSIENT_FAILURE state can only go to CONNECTING state, only when a connection attempt is made on this subchannel.
Now we not only set TRANSIENT_FAILURE to report a failure, but also use it to tell LB policies that the subchannel is in backoff. Once the subchannel's backoff ends, the state of the subchannel should turn into either IDLE or CONNECTING, depending on whether it has a retry attempt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/19300)
<!-- Reviewable:end -->
