### PR TITLE
Add support for CMAKE_SYSTEM_NAME=iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,8 @@ if(UNIX)
     set(_gRPC_PLATFORM_LINUX ON)
   elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(_gRPC_PLATFORM_MAC ON)
+  elseif(${CMAKE_SYSTEM_NAME} MATCHES "iOS")
+    set(_gRPC_PLATFORM_IOS ON)
   elseif(${CMAKE_SYSTEM_NAME} MATCHES "Android")
     set(_gRPC_PLATFORM_ANDROID ON)
   else()
@@ -124,7 +126,7 @@ if(gRPC_BACKWARDS_COMPATIBILITY_MODE)
   endif()
 endif()
 
-if (_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC)
+if (_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_IOS)
   # C core has C++ source code, but should not depend on libstc++ (for better portability).
   # We need to use a few tricks to convince cmake to do that.
   # https://stackoverflow.com/questions/15058403/how-to-stop-cmake-from-linking-against-libstdc
@@ -149,7 +151,7 @@ if(NOT MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
-if(_gRPC_PLATFORM_MAC)
+if(_gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_IOS)
   set(_gRPC_ALLTARGETS_LIBRARIES ${CMAKE_DL_LIBS} m pthread)
 elseif(_gRPC_PLATFORM_ANDROID)
   set(_gRPC_ALLTARGETS_LIBRARIES ${CMAKE_DL_LIBS} m)

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -130,6 +130,8 @@
       set(_gRPC_PLATFORM_LINUX ON)
     elseif(<%text>${CMAKE_SYSTEM_NAME}</%text> MATCHES "Darwin")
       set(_gRPC_PLATFORM_MAC ON)
+    elseif(<%text>${CMAKE_SYSTEM_NAME}</%text> MATCHES "iOS")
+      set(_gRPC_PLATFORM_IOS ON)
     elseif(<%text>${CMAKE_SYSTEM_NAME}</%text> MATCHES "Android")
       set(_gRPC_PLATFORM_ANDROID ON)
     else()
@@ -173,7 +175,7 @@
     endif()
   endif()
 
-  if (_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC)
+  if (_gRPC_PLATFORM_LINUX OR _gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_IOS)
     # C core has C++ source code, but should not depend on libstc++ (for better portability).
     # We need to use a few tricks to convince cmake to do that.
     # https://stackoverflow.com/questions/15058403/how-to-stop-cmake-from-linking-against-libstdc
@@ -198,7 +200,7 @@
     set(CMAKE_CXX_FLAGS "<%text>${CMAKE_CXX_FLAGS}</%text> -std=c++11")
   endif()
 
-  if(_gRPC_PLATFORM_MAC)
+  if(_gRPC_PLATFORM_MAC OR _gRPC_PLATFORM_IOS)
     set(_gRPC_ALLTARGETS_LIBRARIES <%text>${CMAKE_DL_LIBS}</%text> m pthread)
   elseif(_gRPC_PLATFORM_ANDROID)
     set(_gRPC_ALLTARGETS_LIBRARIES <%text>${CMAKE_DL_LIBS}</%text> m)


### PR DESCRIPTION
An iOS toolchain is now part of CMake (3.14+), and therefore it
makes sense to consider it. Note: it used to report "Darwin" and
now it reports "iOS". 

Without this patch, it breaks my iOS build because iOS is then considered as "Unix" and the wrong libraries get linked.

Reference: https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-for-ios-tvos-or-watchos

@muxi: This may be of interest for you. That's the patch I apply in #19301 before I get the error reported there.