### PR TITLE
Add MSBuild metadata to set LiteClient for client generation.

### DIFF
--- a/src/csharp/Grpc.Tools/build/_grpc/Grpc.CSharp.xml
+++ b/src/csharp/Grpc.Tools/build/_grpc/Grpc.CSharp.xml
@@ -28,7 +28,7 @@
 
     <EnumProperty Name="ClientBaseType" DisplayName="gRPC Client Base Type"
                   Category="gRPC" Default="ClientBase"
-                  Description="The base type to use for the client.">
+                  Description="The base type to use for the client. This is an experimental feature.">
       <EnumValue Name="ClientBase" DisplayName="Use ClientBase" />
       <EnumValue Name="LiteClientBase" DisplayName="Use LiteClientBase" />
       <EnumProperty.DataSource>

--- a/src/csharp/Grpc.Tools/build/_grpc/Grpc.CSharp.xml
+++ b/src/csharp/Grpc.Tools/build/_grpc/Grpc.CSharp.xml
@@ -26,5 +26,16 @@
       </EnumProperty.DataSource>
     </EnumProperty>
 
+    <EnumProperty Name="ClientBaseType" DisplayName="gRPC Client Base Type"
+                  Category="gRPC" Default="ClientBase"
+                  Description="The base type to use for the client.">
+      <EnumValue Name="ClientBase" DisplayName="Use ClientBase" />
+      <EnumValue Name="LiteClientBase" DisplayName="Use LiteClientBase" />
+      <EnumProperty.DataSource>
+        <DataSource ItemType="Protobuf" SourceOfDefaultValue="AfterContext"
+                    PersistenceStyle="Attribute" />
+      </EnumProperty.DataSource>
+    </EnumProperty>
+
   </Rule>
 </ProjectSchemaDefinitions>

--- a/src/csharp/Grpc.Tools/build/_grpc/_Grpc.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_grpc/_Grpc.Tools.targets
@@ -38,6 +38,7 @@
       </Protobuf_Compile>
       <Protobuf_Compile Condition=" '%(Protobuf_Compile.GrpcServices)' == 'Client' ">
         <_GrpcOutputOptions>%(Protobuf_Compile._GrpcOutputOptions);no_server</_GrpcOutputOptions>
+        <_GrpcOutputOptions Condition=" '%(Protobuf_Compile.ClientType)' == 'LiteClient' ">%(Protobuf_Compile._GrpcOutputOptions);lite_client</_GrpcOutputOptions>
       </Protobuf_Compile>
       <Protobuf_Compile Condition=" '%(Protobuf_Compile.GrpcServices)' == 'Server' ">
         <_GrpcOutputOptions>%(Protobuf_Compile._GrpcOutputOptions);no_client</_GrpcOutputOptions>

--- a/src/csharp/Grpc.Tools/build/_grpc/_Grpc.Tools.targets
+++ b/src/csharp/Grpc.Tools/build/_grpc/_Grpc.Tools.targets
@@ -38,10 +38,12 @@
       </Protobuf_Compile>
       <Protobuf_Compile Condition=" '%(Protobuf_Compile.GrpcServices)' == 'Client' ">
         <_GrpcOutputOptions>%(Protobuf_Compile._GrpcOutputOptions);no_server</_GrpcOutputOptions>
-        <_GrpcOutputOptions Condition=" '%(Protobuf_Compile.ClientType)' == 'LiteClient' ">%(Protobuf_Compile._GrpcOutputOptions);lite_client</_GrpcOutputOptions>
       </Protobuf_Compile>
       <Protobuf_Compile Condition=" '%(Protobuf_Compile.GrpcServices)' == 'Server' ">
         <_GrpcOutputOptions>%(Protobuf_Compile._GrpcOutputOptions);no_client</_GrpcOutputOptions>
+      </Protobuf_Compile>
+      <Protobuf_Compile Condition=" '%(Protobuf_Compile.GrpcServices)' == 'Client' or  '%(Protobuf_Compile.GrpcServices)' == 'Both' ">
+        <_GrpcOutputOptions Condition=" '%(Protobuf_Compile.ClientBaseType)' == 'LiteClientBase' ">%(Protobuf_Compile._GrpcOutputOptions);lite_client</_GrpcOutputOptions>
       </Protobuf_Compile>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
I realized there's no public property to set to enable the lite_client option, so I'm adding one. The alternative is to set _GrpcOutputOptions directly, would you prefer that instead @jtattermusch? It's prefixed with _ so I figured it's a private property that's not meant to be set.