### PR TITLE
Ensure awake pollset_work threads exist on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -755,6 +755,9 @@ if(gRPC_BUILD_TESTS)
   add_dependencies(buildtests_cxx noop-benchmark)
   add_dependencies(buildtests_cxx optional_test)
   add_dependencies(buildtests_cxx orphanable_test)
+  if(_gRPC_PLATFORM_WINDOWS)
+    add_dependencies(buildtests_cxx pollset_windows_starvation_test.cc)
+  endif()
   add_dependencies(buildtests_cxx port_sharing_end2end_test)
   add_dependencies(buildtests_cxx proto_server_reflection_test)
   add_dependencies(buildtests_cxx proto_utils_test)
@@ -14158,6 +14161,44 @@ target_link_libraries(orphanable_test
 )
 
 
+endif()
+if(gRPC_BUILD_TESTS)
+if(_gRPC_PLATFORM_WINDOWS)
+
+  add_executable(pollset_windows_starvation_test.cc
+    test/core/iomgr/pollset_windows_starvation_test.cc
+    third_party/googletest/googletest/src/gtest-all.cc
+    third_party/googletest/googlemock/src/gmock-all.cc
+  )
+
+  target_include_directories(pollset_windows_starvation_test.cc
+    PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/include
+      ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+      ${_gRPC_SSL_INCLUDE_DIR}
+      ${_gRPC_UPB_GENERATED_DIR}
+      ${_gRPC_UPB_GRPC_GENERATED_DIR}
+      ${_gRPC_UPB_INCLUDE_DIR}
+      ${_gRPC_ZLIB_INCLUDE_DIR}
+      third_party/googletest/googletest/include
+      third_party/googletest/googletest
+      third_party/googletest/googlemock/include
+      third_party/googletest/googlemock
+      ${_gRPC_PROTO_GENS_DIR}
+  )
+
+  target_link_libraries(pollset_windows_starvation_test.cc
+    ${_gRPC_PROTOBUF_LIBRARIES}
+    ${_gRPC_ALLTARGETS_LIBRARIES}
+    grpc_test_util
+    grpc
+    gpr
+    ${_gRPC_GFLAGS_LIBRARIES}
+  )
+
+
+endif()
 endif()
 if(gRPC_BUILD_TESTS)
 

--- a/Makefile
+++ b/Makefile
@@ -1263,6 +1263,7 @@ nonblocking_test: $(BINDIR)/$(CONFIG)/nonblocking_test
 noop-benchmark: $(BINDIR)/$(CONFIG)/noop-benchmark
 optional_test: $(BINDIR)/$(CONFIG)/optional_test
 orphanable_test: $(BINDIR)/$(CONFIG)/orphanable_test
+pollset_windows_starvation_test.cc: $(BINDIR)/$(CONFIG)/pollset_windows_starvation_test.cc
 port_sharing_end2end_test: $(BINDIR)/$(CONFIG)/port_sharing_end2end_test
 proto_server_reflection_test: $(BINDIR)/$(CONFIG)/proto_server_reflection_test
 proto_utils_test: $(BINDIR)/$(CONFIG)/proto_utils_test
@@ -1732,6 +1733,7 @@ buildtests_cxx: privatelibs_cxx \
   $(BINDIR)/$(CONFIG)/noop-benchmark \
   $(BINDIR)/$(CONFIG)/optional_test \
   $(BINDIR)/$(CONFIG)/orphanable_test \
+  $(BINDIR)/$(CONFIG)/pollset_windows_starvation_test.cc \
   $(BINDIR)/$(CONFIG)/port_sharing_end2end_test \
   $(BINDIR)/$(CONFIG)/proto_server_reflection_test \
   $(BINDIR)/$(CONFIG)/proto_utils_test \
@@ -1903,6 +1905,7 @@ buildtests_cxx: privatelibs_cxx \
   $(BINDIR)/$(CONFIG)/noop-benchmark \
   $(BINDIR)/$(CONFIG)/optional_test \
   $(BINDIR)/$(CONFIG)/orphanable_test \
+  $(BINDIR)/$(CONFIG)/pollset_windows_starvation_test.cc \
   $(BINDIR)/$(CONFIG)/port_sharing_end2end_test \
   $(BINDIR)/$(CONFIG)/proto_server_reflection_test \
   $(BINDIR)/$(CONFIG)/proto_utils_test \
@@ -2419,6 +2422,8 @@ test_cxx: buildtests_cxx
 	$(Q) $(BINDIR)/$(CONFIG)/optional_test || ( echo test optional_test failed ; exit 1 )
 	$(E) "[RUN]     Testing orphanable_test"
 	$(Q) $(BINDIR)/$(CONFIG)/orphanable_test || ( echo test orphanable_test failed ; exit 1 )
+	$(E) "[RUN]     Testing pollset_windows_starvation_test.cc"
+	$(Q) $(BINDIR)/$(CONFIG)/pollset_windows_starvation_test.cc || ( echo test pollset_windows_starvation_test.cc failed ; exit 1 )
 	$(E) "[RUN]     Testing port_sharing_end2end_test"
 	$(Q) $(BINDIR)/$(CONFIG)/port_sharing_end2end_test || ( echo test port_sharing_end2end_test failed ; exit 1 )
 	$(E) "[RUN]     Testing proto_server_reflection_test"
@@ -18506,6 +18511,49 @@ deps_orphanable_test: $(ORPHANABLE_TEST_OBJS:.o=.dep)
 ifneq ($(NO_SECURE),true)
 ifneq ($(NO_DEPS),true)
 -include $(ORPHANABLE_TEST_OBJS:.o=.dep)
+endif
+endif
+
+
+POLLSET_WINDOWS_STARVATION_TEST.CC_SRC = \
+    test/core/iomgr/pollset_windows_starvation_test.cc \
+
+POLLSET_WINDOWS_STARVATION_TEST.CC_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(POLLSET_WINDOWS_STARVATION_TEST.CC_SRC))))
+ifeq ($(NO_SECURE),true)
+
+# You can't build secure targets if you don't have OpenSSL.
+
+$(BINDIR)/$(CONFIG)/pollset_windows_starvation_test.cc: openssl_dep_error
+
+else
+
+
+
+
+ifeq ($(NO_PROTOBUF),true)
+
+# You can't build the protoc plugins or protobuf-enabled targets if you don't have protobuf 3.5.0+.
+
+$(BINDIR)/$(CONFIG)/pollset_windows_starvation_test.cc: protobuf_dep_error
+
+else
+
+$(BINDIR)/$(CONFIG)/pollset_windows_starvation_test.cc: $(PROTOBUF_DEP) $(POLLSET_WINDOWS_STARVATION_TEST.CC_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a
+	$(E) "[LD]      Linking $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) $(LDXX) $(LDFLAGS) $(POLLSET_WINDOWS_STARVATION_TEST.CC_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) $(LDLIBS_SECURE) $(GTEST_LIB) -o $(BINDIR)/$(CONFIG)/pollset_windows_starvation_test.cc
+
+endif
+
+endif
+
+$(OBJDIR)/$(CONFIG)/test/core/iomgr/pollset_windows_starvation_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a
+
+deps_pollset_windows_starvation_test.cc: $(POLLSET_WINDOWS_STARVATION_TEST.CC_OBJS:.o=.dep)
+
+ifneq ($(NO_SECURE),true)
+ifneq ($(NO_DEPS),true)
+-include $(POLLSET_WINDOWS_STARVATION_TEST.CC_OBJS:.o=.dep)
 endif
 endif
 

--- a/build.yaml
+++ b/build.yaml
@@ -5432,6 +5432,20 @@ targets:
   - grpc++
   - grpc
   - gpr
+- name: pollset_windows_starvation_test.cc
+  cpu_cost: 0.5
+  build: test
+  language: c++
+  src:
+  - test/core/iomgr/pollset_windows_starvation_test.cc
+  deps:
+  - grpc_test_util
+  - grpc
+  - gpr
+  exclude_iomgrs:
+  - uv
+  platforms:
+  - windows
 - name: port_sharing_end2end_test
   gtest: true
   build: test

--- a/src/core/lib/iomgr/pollset_windows.cc
+++ b/src/core/lib/iomgr/pollset_windows.cc
@@ -224,9 +224,8 @@ static grpc_error* pollset_kick(grpc_pollset* p,
     }
   }
   if (should_kick_global && g_active_poller == NULL) {
-    grpc_pollset_worker* next_global_worker =
-        pop_front_worker(&g_global_root_worker,
-                         GRPC_POLLSET_WORKER_LINK_GLOBAL);
+    grpc_pollset_worker* next_global_worker = pop_front_worker(
+        &g_global_root_worker, GRPC_POLLSET_WORKER_LINK_GLOBAL);
     if (next_global_worker != NULL) {
       next_global_worker->kicked = 1;
       gpr_cv_signal(&next_global_worker->cv);

--- a/src/core/lib/iomgr/pollset_windows.cc
+++ b/src/core/lib/iomgr/pollset_windows.cc
@@ -185,19 +185,23 @@ done:
 
 static grpc_error* pollset_kick(grpc_pollset* p,
                                 grpc_pollset_worker* specific_worker) {
+  bool should_kick_global = false;
   if (specific_worker != NULL) {
     if (specific_worker == GRPC_POLLSET_KICK_BROADCAST) {
+      should_kick_global = true;
       for (specific_worker =
                p->root_worker.links[GRPC_POLLSET_WORKER_LINK_POLLSET].next;
            specific_worker != &p->root_worker;
            specific_worker =
                specific_worker->links[GRPC_POLLSET_WORKER_LINK_POLLSET].next) {
         specific_worker->kicked = 1;
+        should_kick_global = false;
         gpr_cv_signal(&specific_worker->cv);
       }
       p->kicked_without_pollers = 1;
       if (p->is_iocp_worker) {
         grpc_iocp_kick();
+        should_kick_global = false;
       }
     } else {
       if (p->is_iocp_worker && g_active_poller == specific_worker) {
@@ -216,6 +220,16 @@ static grpc_error* pollset_kick(grpc_pollset* p,
       grpc_iocp_kick();
     } else {
       p->kicked_without_pollers = 1;
+      should_kick_global = true;
+    }
+  }
+  if (should_kick_global && g_active_poller == NULL) {
+    grpc_pollset_worker* next_global_worker =
+        pop_front_worker(&g_global_root_worker,
+                         GRPC_POLLSET_WORKER_LINK_GLOBAL);
+    if (next_global_worker != NULL) {
+      next_global_worker->kicked = 1;
+      gpr_cv_signal(&next_global_worker->cv);
     }
   }
   return GRPC_ERROR_NONE;

--- a/test/core/iomgr/pollset_windows_starvation_test.cc
+++ b/test/core/iomgr/pollset_windows_starvation_test.cc
@@ -15,8 +15,6 @@
  * limitations under the License.
  *
  */
-#if defined(GRPC_WINSOCK_SOCKET)
-
 #include <vector>
 
 #include <grpc/grpc.h>
@@ -31,36 +29,43 @@
 #include "src/core/lib/surface/init.h"
 #include "test/core/util/test_config.h"
 
+#if defined(GRPC_WINSOCK_SOCKET)
+
+// At least three threads are required to reproduce #18848
+const size_t THREADS = 3;
+
 struct ThreadParams {
   gpr_cv cv;
   gpr_mu mu;
   int complete;
+  int queuing;
+  gpr_mu* pollset_mu[THREADS];
 };
 
 int main(int argc, char** argv) {
   grpc_init();
 
-  // Create three threads that all start queueing for work.
+  // Create the threads that all start queueing for work.
   //
   // The first one becomes the active poller for work and the two other
   // threads go into the poller queue.
   //
-  // When work arrives, the first one notifies the next active poller,
+  // When work arrives, the first one notifies the next queued poller,
   // this wakes the second thread - however all this does is return from
   // the grpc_pollset_work function. It's up to that thread to figure
   // out if it still wants to queue for more work or if it should kick
   // other pollers.
   //
   // Previously that kick only affected pollers in the same pollset, thus
-  // leaving the third thread stuck in the poller queue. Now the pollset-
+  // leaving the other threads stuck in the poller queue. Now the pollset-
   // specific grpc_pollset_kick will also kick pollers from other pollsets
   // if there are no pollers in the current pollset. This frees up the
-  // last thread and completes the test.
+  // last threads and completes the test.
   ThreadParams params = {};
   gpr_cv_init(&params.cv);
   gpr_mu_init(&params.mu);
   std::vector<grpc_core::Thread> threads;
-  for (int i = 0; i < 3; i++) {
+  for (int i = 0; i < THREADS; i++) {
     grpc_core::Thread thd(
         "Poller",
         [](void* params) {
@@ -71,46 +76,66 @@ int main(int argc, char** argv) {
           grpc_pollset pollset = {};
           grpc_pollset_init(&pollset, &mu);
 
+          // Lock the pollset mutex before notifying the test runner thread that
+          // one more thread is queuing. This allows the test runner thread to
+          // wait for all threads to be queued before sending the first kick by
+          // waiting for the mutexes to be released, which happens in
+          // gpr_pollset_work when the poller is queued.
           gpr_mu_lock(mu);
+
+          gpr_mu_lock(&tparams->mu);
+          tparams->pollset_mu[tparams->queuing] = mu;
+          tparams->queuing++;
+          gpr_cv_signal(&tparams->cv);
+          gpr_mu_unlock(&tparams->mu);
 
           // Queue for work and once we're done, make sure to kick the remaining
           // threads.
-          grpc_millis deadline = grpc_timespec_to_millis_round_up(
-              grpc_timeout_seconds_to_deadline(5));
           grpc_error* error;
-          error = grpc_pollset_work(&pollset, NULL, deadline);
+          error = grpc_pollset_work(&pollset, NULL, GRPC_MILLIS_INF_FUTURE);
           error = grpc_pollset_kick(&pollset, NULL);
 
           gpr_mu_unlock(mu);
 
-          {
-            gpr_mu_lock(&tparams->mu);
-            tparams->complete++;
-            gpr_cv_signal(&tparams->cv);
-            gpr_mu_unlock(&tparams->mu);
-          }
+          gpr_mu_lock(&tparams->mu);
+          tparams->complete++;
+          gpr_cv_signal(&tparams->cv);
+          gpr_mu_unlock(&tparams->mu);
         },
         &params);
     thd.Start();
     threads.push_back(std::move(thd));
   }
 
-  // Wait for the threads to start working and then kick one of them.
-  gpr_sleep_until(grpc_timeout_milliseconds_to_deadline(10));
+  // Wait for all three threads to be queuing.
+  gpr_mu_lock(&params.mu);
+  while (
+      params.queuing != THREADS &&
+      !gpr_cv_wait(&params.cv, &params.mu, gpr_inf_future(GPR_CLOCK_REALTIME)))
+    ;
+  gpr_mu_unlock(&params.mu);
+
+  // Wait for the mutexes to be released. This indicates that the threads have
+  // entered the work wait.
+  //
+  // At least currently these are essentially all references to the same global
+  // pollset mutex, but we are still waiting on them once for each thread in
+  // the case this ever changes.
+  for (int i = 0; i < THREADS; i++) {
+    gpr_mu_lock(params.pollset_mu[i]);
+    gpr_mu_unlock(params.pollset_mu[i]);
+  }
+
   grpc_iocp_kick();
 
   // Wait for the threads to complete.
-  gpr_timespec deadline = grpc_timeout_seconds_to_deadline(1);
   gpr_mu_lock(&params.mu);
-  while (params.complete != 3 && !gpr_cv_wait(&params.cv, &params.mu, deadline))
+  while (
+      params.complete != THREADS &&
+      !gpr_cv_wait(&params.cv, &params.mu, gpr_inf_future(GPR_CLOCK_REALTIME)))
     ;
-  if (params.complete != 3) {
-    gpr_mu_unlock(&params.mu);
-    for (auto& t : threads) t.Join();
-    return EXIT_FAILURE;
-  }
-
   gpr_mu_unlock(&params.mu);
+
   for (auto& t : threads) t.Join();
   return EXIT_SUCCESS;
 }

--- a/test/core/iomgr/pollset_windows_starvation_test.cc
+++ b/test/core/iomgr/pollset_windows_starvation_test.cc
@@ -41,7 +41,7 @@
 
 #define LOG_TEST(x) gpr_log(GPR_INFO, "%s", #x)
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv) {
   grpc_init();
 
   // Create three threads that all start queueing for work.
@@ -68,7 +68,7 @@ int main(int argc, char **argv) {
     threads.push_back(std::thread([&]() {
       grpc_core::ExecCtx exec_ctx;
 
-      gpr_mu *g_mu;
+      gpr_mu* g_mu;
       grpc_pollset g_pollset = {};
       grpc_pollset_init(&g_pollset, &g_mu);
 
@@ -76,7 +76,7 @@ int main(int argc, char **argv) {
 
       // Queue for work and once we're done, make sure to kick the remaining
       // threads.
-      grpc_error *error;
+      grpc_error* error;
       error = grpc_pollset_work(&g_pollset, NULL, GRPC_MILLIS_INF_FUTURE);
       error = grpc_pollset_kick(&g_pollset, NULL);
 
@@ -102,8 +102,7 @@ int main(int argc, char **argv) {
       return EXIT_FAILURE;
   }
 
-  for (auto &t : threads)
-    t.join();
+  for (auto& t : threads) t.join();
 
   return EXIT_SUCCESS;
 }

--- a/test/core/iomgr/pollset_windows_starvation_test.cc
+++ b/test/core/iomgr/pollset_windows_starvation_test.cc
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2015 gRPC authors.
+ * Copyright 2019 gRPC authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,31 +15,27 @@
  * limitations under the License.
  *
  */
+#if defined(GRPC_WINSOCK_SOCKET)
 
-#include "src/core/lib/iomgr/port.h"
-
-#include "src/core/lib/iomgr/tcp_server.h"
-
-#include <chrono>
-#include <condition_variable>
-#include <iostream>
-#include <thread>
 #include <vector>
 
 #include <grpc/grpc.h>
-#include <grpc/support/alloc.h>
-#include <grpc/support/log.h>
-#include <grpc/support/sync.h>
 #include <grpc/support/time.h>
 
+#include "src/core/lib/gprpp/thd.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/iocp_windows.h"
 #include "src/core/lib/iomgr/iomgr_internal.h"
 #include "src/core/lib/iomgr/pollset.h"
 #include "src/core/lib/iomgr/pollset_windows.h"
 #include "src/core/lib/surface/init.h"
+#include "test/core/util/test_config.h"
 
-#define LOG_TEST(x) gpr_log(GPR_INFO, "%s", #x)
+struct ThreadParams {
+  gpr_cv cv;
+  gpr_mu mu;
+  int complete;
+};
 
 int main(int argc, char** argv) {
   grpc_init();
@@ -60,49 +56,64 @@ int main(int argc, char** argv) {
   // specific grpc_pollset_kick will also kick pollers from other pollsets
   // if there are no pollers in the current pollset. This frees up the
   // last thread and completes the test.
-  std::condition_variable cv;
-  std::mutex m;
-  int complete = 0;
-  std::vector<std::thread> threads;
+  ThreadParams params = {};
+  gpr_cv_init(&params.cv);
+  gpr_mu_init(&params.mu);
+  std::vector<grpc_core::Thread> threads;
   for (int i = 0; i < 3; i++) {
-    threads.push_back(std::thread([&]() {
-      grpc_core::ExecCtx exec_ctx;
+    grpc_core::Thread thd(
+        "Poller",
+        [](void* params) {
+          ThreadParams* tparams = static_cast<ThreadParams*>(params);
+          grpc_core::ExecCtx exec_ctx;
 
-      gpr_mu* g_mu;
-      grpc_pollset g_pollset = {};
-      grpc_pollset_init(&g_pollset, &g_mu);
+          gpr_mu* mu;
+          grpc_pollset pollset = {};
+          grpc_pollset_init(&pollset, &mu);
 
-      gpr_mu_lock(g_mu);
+          gpr_mu_lock(mu);
 
-      // Queue for work and once we're done, make sure to kick the remaining
-      // threads.
-      grpc_error* error;
-      error = grpc_pollset_work(&g_pollset, NULL, GRPC_MILLIS_INF_FUTURE);
-      error = grpc_pollset_kick(&g_pollset, NULL);
+          // Queue for work and once we're done, make sure to kick the remaining
+          // threads.
+          grpc_millis deadline = grpc_timespec_to_millis_round_up(
+              grpc_timeout_seconds_to_deadline(5));
+          grpc_error* error;
+          error = grpc_pollset_work(&pollset, NULL, deadline);
+          error = grpc_pollset_kick(&pollset, NULL);
 
-      gpr_mu_unlock(g_mu);
+          gpr_mu_unlock(mu);
 
-      {
-        std::unique_lock<std::mutex> lock(m);
-        complete++;
-        cv.notify_all();
-      }
-    }));
+          {
+            gpr_mu_lock(&tparams->mu);
+            tparams->complete++;
+            gpr_cv_signal(&tparams->cv);
+            gpr_mu_unlock(&tparams->mu);
+          }
+        },
+        &params);
+    thd.Start();
+    threads.push_back(std::move(thd));
   }
 
   // Wait for the threads to start working and then kick one of them.
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  gpr_sleep_until(grpc_timeout_milliseconds_to_deadline(10));
   grpc_iocp_kick();
 
   // Wait for the threads to complete.
-  {
-    std::unique_lock<std::mutex> lock(m);
-    if (!cv.wait_for(lock, std::chrono::seconds(1),
-                     [&] { return complete == 3; }))
-      return EXIT_FAILURE;
+  gpr_timespec deadline = grpc_timeout_seconds_to_deadline(1);
+  gpr_mu_lock(&params.mu);
+  while (params.complete != 3 && !gpr_cv_wait(&params.cv, &params.mu, deadline))
+    ;
+  if (params.complete != 3) {
+    gpr_mu_unlock(&params.mu);
+    for (auto& t : threads) t.Join();
+    return EXIT_FAILURE;
   }
 
-  for (auto& t : threads) t.join();
-
+  gpr_mu_unlock(&params.mu);
+  for (auto& t : threads) t.Join();
   return EXIT_SUCCESS;
 }
+#else /* defined(GRPC_WINSOCK_SOCKET) */
+int main(int /*argc*/, char** /*argv*/) { return 0; }
+#endif

--- a/test/core/iomgr/pollset_windows_starvation_test.cc
+++ b/test/core/iomgr/pollset_windows_starvation_test.cc
@@ -1,0 +1,109 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "src/core/lib/iomgr/port.h"
+
+#include "src/core/lib/iomgr/tcp_server.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+#include <grpc/grpc.h>
+#include <grpc/support/alloc.h>
+#include <grpc/support/log.h>
+#include <grpc/support/sync.h>
+#include <grpc/support/time.h>
+
+#include "src/core/lib/iomgr/exec_ctx.h"
+#include "src/core/lib/iomgr/iocp_windows.h"
+#include "src/core/lib/iomgr/iomgr_internal.h"
+#include "src/core/lib/iomgr/pollset.h"
+#include "src/core/lib/iomgr/pollset_windows.h"
+#include "src/core/lib/surface/init.h"
+
+#define LOG_TEST(x) gpr_log(GPR_INFO, "%s", #x)
+
+int main(int argc, char **argv) {
+  grpc_init();
+
+  // Create three threads that all start queueing for work.
+  //
+  // The first one becomes the active poller for work and the two other
+  // threads go into the poller queue.
+  //
+  // When work arrives, the first one notifies the next active poller,
+  // this wakes the second thread - however all this does is return from
+  // the grpc_pollset_work function. It's up to that thread to figure
+  // out if it still wants to queue for more work or if it should kick
+  // other pollers.
+  //
+  // Previously that kick only affected pollers in the same pollset, thus
+  // leaving the third thread stuck in the poller queue. Now the pollset-
+  // specific grpc_pollset_kick will also kick pollers from other pollsets
+  // if there are no pollers in the current pollset. This frees up the
+  // last thread and completes the test.
+  std::condition_variable cv;
+  std::mutex m;
+  int complete = 0;
+  std::vector<std::thread> threads;
+  for (int i = 0; i < 3; i++) {
+    threads.push_back(std::thread([&]() {
+      grpc_core::ExecCtx exec_ctx;
+
+      gpr_mu *g_mu;
+      grpc_pollset g_pollset = {};
+      grpc_pollset_init(&g_pollset, &g_mu);
+
+      gpr_mu_lock(g_mu);
+
+      // Queue for work and once we're done, make sure to kick the remaining
+      // threads.
+      grpc_error *error;
+      error = grpc_pollset_work(&g_pollset, NULL, GRPC_MILLIS_INF_FUTURE);
+      error = grpc_pollset_kick(&g_pollset, NULL);
+
+      gpr_mu_unlock(g_mu);
+
+      {
+        std::unique_lock<std::mutex> lock(m);
+        complete++;
+        cv.notify_all();
+      }
+    }));
+  }
+
+  // Wait for the threads to start working and then kick one of them.
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  grpc_iocp_kick();
+
+  // Wait for the threads to complete.
+  {
+    std::unique_lock<std::mutex> lock(m);
+    if (!cv.wait_for(lock, std::chrono::seconds(1),
+                     [&] { return complete == 3; }))
+      return EXIT_FAILURE;
+  }
+
+  for (auto &t : threads)
+    t.join();
+
+  return EXIT_SUCCESS;
+}

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -5167,6 +5167,26 @@
     "args": [], 
     "benchmark": false, 
     "ci_platforms": [
+      "windows"
+    ], 
+    "cpu_cost": 0.5, 
+    "exclude_configs": [], 
+    "exclude_iomgrs": [
+      "uv"
+    ], 
+    "flaky": false, 
+    "gtest": false, 
+    "language": "c++", 
+    "name": "pollset_windows_starvation_test.cc", 
+    "platforms": [
+      "windows"
+    ], 
+    "uses_polling": true
+  }, 
+  {
+    "args": [], 
+    "benchmark": false, 
+    "ci_platforms": [
       "linux", 
       "mac", 
       "posix", 


### PR DESCRIPTION
There is a chance the C++ gRPC server runs out of active threads trying to pull work from the completion queue in Windows. The issue is described in depth in https://github.com/grpc/grpc/issues/19053#issuecomment-493804100.

The changes in this PR are an attempt to ensure that when the active threads attempt to kick sleeping threads to poll for more work, they will kick threads in the global thread list as well in the case there were no threads associated with their own pollset.

Should fix #18848 and #19053 