### PR TITLE
Fix build tests failed with CMake option '-DgRPC_BUILD_TESTS=ON'.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,10 @@ include(cmake/benchmark.cmake)
 include(cmake/address_sorting.cmake)
 include(cmake/nanopb.cmake)
 
+if(gRPC_BUILD_TESTS)
+  include(cmake/upb.cmake)
+endif()
+
 if(NOT MSVC)
   set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -std=c99")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
@@ -5795,6 +5799,7 @@ target_include_directories(upb
   PRIVATE ${_gRPC_GFLAGS_INCLUDE_DIR}
   PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
   PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
+  PRIVATE ${_gRPC_UPB_INCLUDE_DIR}
 )
   # avoid dependency on libstdc++
   if (_gRPC_CORE_NOSTDCXX_FLAGS)

--- a/cmake/upb.cmake
+++ b/cmake/upb.cmake
@@ -1,0 +1,15 @@
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set(_gRPC_UPB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/upb")


### PR DESCRIPTION
When enable gRPC_BUILD_TESTS with CMake Option '-DgRPC_BUILD_TESTS=ON', we let '${grpc_source_dir}/third_party/upb' be contained in 'include directories'.