### PR TITLE
Added grpc_slice_buffer_reserve and grpc_slice_buffer_note_add method…

### DIFF
--- a/src/core/ext/filters/http/message_compress/message_compress_filter.cc
+++ b/src/core/ext/filters/http/message_compress/message_compress_filter.cc
@@ -283,14 +283,11 @@ static void fail_send_message_batch_in_call_combiner(void* arg,
 
 // Pulls a slice from the send_message byte stream and adds it to calld->slices.
 static grpc_error* pull_slice_from_send_message(call_data* calld) {
-  grpc_slice incoming_slice;
-  grpc_error* error =
-      calld->send_message_batch->payload->send_message.send_message->Pull(
-          &incoming_slice);
-  if (error == GRPC_ERROR_NONE) {
-    grpc_slice_buffer_add(&calld->slices, incoming_slice);
-  }
-  return error;
+  auto pull = [&](grpc_slice* slice) -> grpc_error* {
+    return calld->send_message_batch->payload->send_message.send_message->Pull(
+        slice);
+  };
+  return grpc_slice_buffer_emplace(&calld->slices, pull);
 }
 
 // Reads as many slices as possible from the send_message byte stream.

--- a/src/core/ext/filters/http/server/http_server_filter.cc
+++ b/src/core/ext/filters/http/server/http_server_filter.cc
@@ -264,11 +264,13 @@ static grpc_error* hs_filter_incoming_metadata(grpc_call_element* elem,
       const int k_url_safe = 1;
       grpc_slice_buffer read_slice_buffer;
       grpc_slice_buffer_init(&read_slice_buffer);
-      grpc_slice_buffer_add(
-          &read_slice_buffer,
-          grpc_base64_decode_with_len(
-              reinterpret_cast<const char*> GRPC_SLICE_START_PTR(query_slice),
-              GRPC_SLICE_LENGTH(query_slice), k_url_safe));
+      auto b64_dec = [&](grpc_slice* s) -> grpc_error* {
+        grpc_base64_decode_with_len(
+            reinterpret_cast<const char*> GRPC_SLICE_START_PTR(query_slice),
+            GRPC_SLICE_LENGTH(query_slice), k_url_safe, s);
+        return GRPC_ERROR_NONE;
+      };
+      grpc_slice_buffer_emplace(&read_slice_buffer, b64_dec);
       calld->read_stream.Init(&read_slice_buffer, 0);
       grpc_slice_buffer_destroy_internal(&read_slice_buffer);
       calld->have_read_stream = true;

--- a/src/core/ext/transport/chttp2/transport/frame_ping.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.cc
@@ -29,9 +29,10 @@
 
 static bool g_disable_ping_ack = false;
 
-grpc_slice grpc_chttp2_ping_create(uint8_t ack, uint64_t opaque_8bytes) {
-  grpc_slice slice = GRPC_SLICE_MALLOC(9 + 8);
-  uint8_t* p = GRPC_SLICE_START_PTR(slice);
+void grpc_chttp2_ping_marshall(uint8_t ack, uint64_t opaque_8bytes,
+                               grpc_slice* slice) {
+  *slice = GRPC_SLICE_MALLOC(kGrpcPingSz);
+  uint8_t* p = GRPC_SLICE_START_PTR(*slice);
 
   *p++ = 0;
   *p++ = 0;
@@ -50,8 +51,6 @@ grpc_slice grpc_chttp2_ping_create(uint8_t ack, uint64_t opaque_8bytes) {
   *p++ = static_cast<uint8_t>(opaque_8bytes >> 16);
   *p++ = static_cast<uint8_t>(opaque_8bytes >> 8);
   *p++ = static_cast<uint8_t>(opaque_8bytes);
-
-  return slice;
 }
 
 grpc_error* grpc_chttp2_ping_parser_begin_frame(grpc_chttp2_ping_parser* parser,

--- a/src/core/ext/transport/chttp2/transport/frame_ping.h
+++ b/src/core/ext/transport/chttp2/transport/frame_ping.h
@@ -30,7 +30,14 @@ typedef struct {
   uint64_t opaque_8bytes;
 } grpc_chttp2_ping_parser;
 
-grpc_slice grpc_chttp2_ping_create(uint8_t ack, uint64_t opaque_8bytes);
+constexpr size_t kGrpcPingSz = 9 + 8;
+void grpc_chttp2_ping_marshall(uint8_t ack, uint64_t opaque_8bytes,
+                               grpc_slice* slice);
+inline size_t grpc_chttp2_ping_create(uint8_t ack, uint64_t opaque_8bytes,
+                                      grpc_slice* slice) {
+  grpc_chttp2_ping_marshall(ack, opaque_8bytes, slice);
+  return kGrpcPingSz;
+}
 
 grpc_error* grpc_chttp2_ping_parser_begin_frame(grpc_chttp2_ping_parser* parser,
                                                 uint32_t length, uint8_t flags);

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.cc
@@ -29,12 +29,10 @@
 #include "src/core/lib/gprpp/memory.h"
 #include "src/core/lib/transport/http2_errors.h"
 
-grpc_slice grpc_chttp2_rst_stream_create(uint32_t id, uint32_t code,
-                                         grpc_transport_one_way_stats* stats) {
-  static const size_t frame_size = 13;
-  grpc_slice slice = GRPC_SLICE_MALLOC(frame_size);
-  if (stats != nullptr) stats->framing_bytes += frame_size;
-  uint8_t* p = GRPC_SLICE_START_PTR(slice);
+void grpc_chttp2_rst_stream_marshall(uint32_t id, uint32_t code,
+                                     grpc_slice* slice) {
+  *slice = GRPC_SLICE_MALLOC(kGrpcChttp2RstStreamFrameSz);
+  uint8_t* p = GRPC_SLICE_START_PTR(*slice);
 
   // Frame size.
   *p++ = 0;
@@ -54,8 +52,6 @@ grpc_slice grpc_chttp2_rst_stream_create(uint32_t id, uint32_t code,
   *p++ = static_cast<uint8_t>(code >> 16);
   *p++ = static_cast<uint8_t>(code >> 8);
   *p++ = static_cast<uint8_t>(code);
-
-  return slice;
 }
 
 grpc_error* grpc_chttp2_rst_stream_parser_begin_frame(

--- a/src/core/ext/transport/chttp2/transport/frame_rst_stream.h
+++ b/src/core/ext/transport/chttp2/transport/frame_rst_stream.h
@@ -30,8 +30,16 @@ typedef struct {
   uint8_t reason_bytes[4];
 } grpc_chttp2_rst_stream_parser;
 
-grpc_slice grpc_chttp2_rst_stream_create(uint32_t stream_id, uint32_t code,
-                                         grpc_transport_one_way_stats* stats);
+constexpr size_t kGrpcChttp2RstStreamFrameSz = 13;
+void grpc_chttp2_rst_stream_marshall(uint32_t id, uint32_t code,
+                                     grpc_slice* slice);
+inline size_t grpc_chttp2_rst_stream_create(uint32_t stream_id, uint32_t code,
+                                            grpc_transport_one_way_stats* stats,
+                                            grpc_slice* slice) {
+  if (stats != nullptr) stats->framing_bytes += kGrpcChttp2RstStreamFrameSz;
+  grpc_chttp2_rst_stream_marshall(stream_id, code, slice);
+  return kGrpcChttp2RstStreamFrameSz;
+}
 
 grpc_error* grpc_chttp2_rst_stream_parser_begin_frame(
     grpc_chttp2_rst_stream_parser* parser, uint32_t length, uint8_t flags);

--- a/src/core/ext/transport/chttp2/transport/frame_settings.cc
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.cc
@@ -77,10 +77,10 @@ grpc_slice grpc_chttp2_settings_create(uint32_t* old_settings,
   return output;
 }
 
-grpc_slice grpc_chttp2_settings_ack_create(void) {
-  grpc_slice output = GRPC_SLICE_MALLOC(9);
-  fill_header(GRPC_SLICE_START_PTR(output), 0, GRPC_CHTTP2_FLAG_ACK);
-  return output;
+static size_t grpc_chttp2_settings_ack_create(grpc_slice* output) {
+  *output = GRPC_SLICE_MALLOC(9);
+  fill_header(GRPC_SLICE_START_PTR(*output), 0, GRPC_CHTTP2_FLAG_ACK);
+  return 9;
 }
 
 grpc_error* grpc_chttp2_settings_parser_begin_frame(
@@ -132,7 +132,11 @@ grpc_error* grpc_chttp2_settings_parser_parse(void* p, grpc_chttp2_transport* t,
           if (is_last) {
             memcpy(parser->target_settings, parser->incoming_settings,
                    GRPC_CHTTP2_NUM_SETTINGS * sizeof(uint32_t));
-            grpc_slice_buffer_add(&t->qbuf, grpc_chttp2_settings_ack_create());
+            auto ack_create = [&](grpc_slice* s) -> grpc_error* {
+              grpc_chttp2_settings_ack_create(s);
+              return GRPC_ERROR_NONE;
+            };
+            grpc_slice_buffer_emplace(&t->qbuf, ack_create);
             if (t->notify_on_receive_settings != nullptr) {
               GRPC_CLOSURE_SCHED(t->notify_on_receive_settings,
                                  GRPC_ERROR_NONE);

--- a/src/core/ext/transport/chttp2/transport/frame_settings.h
+++ b/src/core/ext/transport/chttp2/transport/frame_settings.h
@@ -46,8 +46,6 @@ typedef struct {
 /* Create a settings frame by diffing old & new, and updating old to be new */
 grpc_slice grpc_chttp2_settings_create(uint32_t* old, const uint32_t* newval,
                                        uint32_t force_mask, size_t count);
-/* Create an ack settings frame */
-grpc_slice grpc_chttp2_settings_ack_create(void);
 
 grpc_error* grpc_chttp2_settings_parser_begin_frame(
     grpc_chttp2_settings_parser* parser, uint32_t length, uint8_t flags,

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -107,8 +107,11 @@ static void maybe_initiate_ping(grpc_chttp2_transport* t) {
   GRPC_CLOSURE_LIST_SCHED(&pq->lists[GRPC_CHTTP2_PCL_INITIATE]);
   grpc_closure_list_move(&pq->lists[GRPC_CHTTP2_PCL_NEXT],
                          &pq->lists[GRPC_CHTTP2_PCL_INFLIGHT]);
-  grpc_slice_buffer_add(&t->outbuf,
-                        grpc_chttp2_ping_create(false, pq->inflight_id));
+  auto ping_create = [&](grpc_slice* slice) -> grpc_error* {
+    grpc_chttp2_ping_create(false, pq->inflight_id, slice);
+    return GRPC_ERROR_NONE;
+  };
+  grpc_slice_buffer_emplace(&t->outbuf, ping_create);
   GRPC_STATS_INC_HTTP2_PINGS_SENT();
   t->ping_state.last_ping_sent_time = now;
   if (GRPC_TRACE_FLAG_ENABLED(grpc_http_trace) ||
@@ -236,8 +239,11 @@ class WriteContext {
 
   void FlushPingAcks() {
     for (size_t i = 0; i < t_->ping_ack_count; i++) {
-      grpc_slice_buffer_add(&t_->outbuf,
-                            grpc_chttp2_ping_create(true, t_->ping_acks[i]));
+      auto ping_create = [&](grpc_slice* slice) -> grpc_error* {
+        grpc_chttp2_ping_create(true, t_->ping_acks[i], slice);
+        return GRPC_ERROR_NONE;
+      };
+      grpc_slice_buffer_emplace(&t_->outbuf, ping_create);
     }
     t_->ping_ack_count = 0;
   }
@@ -607,9 +613,12 @@ class StreamWriteContext {
     s_->eos_sent = true;
 
     if (!t_->is_client && !s_->read_closed) {
-      grpc_slice_buffer_add(
-          &t_->outbuf, grpc_chttp2_rst_stream_create(
-                           s_->id, GRPC_HTTP2_NO_ERROR, &s_->stats.outgoing));
+      auto rst_create = [&](grpc_slice* slice) -> grpc_error* {
+        grpc_chttp2_rst_stream_create(s_->id, GRPC_HTTP2_NO_ERROR,
+                                      &s_->stats.outgoing, slice);
+        return GRPC_ERROR_NONE;
+      };
+      grpc_slice_buffer_emplace(&t_->outbuf, rst_create);
     }
     grpc_chttp2_mark_stream_closed(t_, s_, !t_->is_client, true,
                                    GRPC_ERROR_NONE);

--- a/src/core/lib/security/credentials/jwt/jwt_verifier.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.cc
@@ -83,7 +83,7 @@ static grpc_json* parse_json_part_from_jwt(const char* str, size_t len,
                                            grpc_slice* buffer) {
   grpc_json* json;
 
-  *buffer = grpc_base64_decode_with_len(str, len, 1);
+  grpc_base64_decode_with_len(str, len, 1, buffer);
   if (GRPC_SLICE_IS_EMPTY(*buffer)) {
     gpr_log(GPR_ERROR, "Invalid base64.");
     return nullptr;

--- a/src/core/lib/security/transport/security_handshaker.cc
+++ b/src/core/lib/security/transport/security_handshaker.cc
@@ -297,10 +297,14 @@ grpc_error* SecurityHandshaker::OnHandshakeNextDoneLocked(
   }
   if (bytes_to_send_size > 0) {
     // Send data to peer, if needed.
-    grpc_slice to_send = grpc_slice_from_copied_buffer(
-        reinterpret_cast<const char*>(bytes_to_send), bytes_to_send_size);
     grpc_slice_buffer_reset_and_unref_internal(&outgoing_);
-    grpc_slice_buffer_add(&outgoing_, to_send);
+    auto emplace_buf = [&](grpc_slice* slice) -> grpc_error* {
+      grpc_slice_emplace_copied_buffer(
+          reinterpret_cast<const char*>(bytes_to_send), bytes_to_send_size,
+          slice);
+      return GRPC_ERROR_NONE;
+    };
+    grpc_slice_buffer_emplace(&outgoing_, emplace_buf);
     grpc_endpoint_write(args_->endpoint, &outgoing_,
                         &on_handshake_data_sent_to_peer_, nullptr);
   } else if (handshaker_result == nullptr) {

--- a/src/core/lib/slice/b64.cc
+++ b/src/core/lib/slice/b64.cc
@@ -125,7 +125,9 @@ void grpc_base64_encode_core(char* result, const void* vdata, size_t data_size,
 }
 
 grpc_slice grpc_base64_decode(const char* b64, int url_safe) {
-  return grpc_base64_decode_with_len(b64, strlen(b64), url_safe);
+  grpc_slice result;
+  grpc_base64_decode_with_len(b64, strlen(b64), url_safe, &result);
+  return result;
 }
 
 static void decode_one_char(const unsigned char* codes, unsigned char* result,
@@ -189,10 +191,10 @@ static int decode_group(const unsigned char* codes, size_t num_codes,
   return 1;
 }
 
-grpc_slice grpc_base64_decode_with_len(const char* b64, size_t b64_len,
-                                       int url_safe) {
-  grpc_slice result = GRPC_SLICE_MALLOC(b64_len);
-  unsigned char* current = GRPC_SLICE_START_PTR(result);
+void grpc_base64_decode_with_len(const char* b64, size_t b64_len, int url_safe,
+                                 grpc_slice* result) {
+  *result = GRPC_SLICE_MALLOC(b64_len);
+  unsigned char* current = GRPC_SLICE_START_PTR(*result);
   size_t result_size = 0;
   unsigned char codes[4];
   size_t num_codes = 0;
@@ -231,10 +233,10 @@ grpc_slice grpc_base64_decode_with_len(const char* b64, size_t b64_len,
       !decode_group(codes, num_codes, current, &result_size)) {
     goto fail;
   }
-  GRPC_SLICE_SET_LENGTH(result, result_size);
-  return result;
+  GRPC_SLICE_SET_LENGTH(*result, result_size);
+  return;
 
 fail:
-  grpc_slice_unref_internal(result);
-  return grpc_empty_slice();
+  grpc_slice_unref_internal(*result);
+  *result = grpc_empty_slice();
 }

--- a/src/core/lib/slice/b64.h
+++ b/src/core/lib/slice/b64.h
@@ -45,7 +45,7 @@ void grpc_base64_encode_core(char* result, const void* vdata, size_t data_size,
 grpc_slice grpc_base64_decode(const char* b64, int url_safe);
 
 /* Same as above except that the length is provided by the caller. */
-grpc_slice grpc_base64_decode_with_len(const char* b64, size_t b64_len,
-                                       int url_safe);
+void grpc_base64_decode_with_len(const char* b64, size_t b64_len, int url_safe,
+                                 grpc_slice* slice);
 
 #endif /* GRPC_CORE_LIB_SLICE_B64_H */

--- a/src/core/lib/slice/slice.cc
+++ b/src/core/lib/slice/slice.cc
@@ -202,10 +202,20 @@ grpc_slice grpc_slice_new_with_len(void* p, size_t len,
   return slice;
 }
 
+size_t grpc_slice_emplace_copied_buffer(const char* source, size_t length,
+                                        grpc_slice* slice) {
+  if (length == 0) {
+    *slice = grpc_empty_slice();
+    return length;
+  }
+  *slice = GRPC_SLICE_MALLOC(length);
+  memcpy(GRPC_SLICE_START_PTR(*slice), source, length);
+  return length;
+}
+
 grpc_slice grpc_slice_from_copied_buffer(const char* source, size_t length) {
-  if (length == 0) return grpc_empty_slice();
-  grpc_slice slice = GRPC_SLICE_MALLOC(length);
-  memcpy(GRPC_SLICE_START_PTR(slice), source, length);
+  grpc_slice slice;
+  grpc_slice_emplace_copied_buffer(source, length, &slice);
   return slice;
 }
 


### PR DESCRIPTION
Added grpc_slice_buffer_reserve and grpc_slice_buffer_note_add methods for emplace-style semantics for slice buffer ads. Changed the implementation of maybe_embiggen to clobber registers less often.

Ready for further review.