### PR TITLE
Feature request: allow direct access to message binary

### DIFF
--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -1815,7 +1815,9 @@ def server(thread_pool,
            interceptors=None,
            options=None,
            maximum_concurrent_rpcs=None,
-           compression=None):
+           compression=None,
+           request_mapper=None,
+           response_mapper=None):
     """Creates a Server with which RPCs can be serviced.
 
     Args:
@@ -1836,6 +1838,16 @@ def server(thread_pool,
       compression: An element of grpc.compression, e.g.
         grpc.compression.Gzip. This compression algorithm will be used for the
         lifetime of the server unless overridden. This is an EXPERIMENTAL option.
+      request_mapper: A method that will be called with three arguments:
+        `method_name` (string, canonical method name), `metadata` (dict, gRPC
+        message metadata) and `message` (bytes, serialized gRPC message payload).
+        The method will be called before `message` is deserialized. The function
+        should return a `metadata` and `message` (same types) tuple.
+      response_mapper: A method that will be called with three arguments:
+        `method_name` (string, canonical method name), `metadata` (dict, gRPC
+        response metadata), and `message` (bytes, serialized gRPC message
+        payload). The function should return a `metadata` and `message` (same
+        types) tuple.
 
     Returns:
       A Server object.
@@ -1845,7 +1857,8 @@ def server(thread_pool,
                                  if handlers is None else handlers, ()
                                  if interceptors is None else interceptors, ()
                                  if options is None else options,
-                                 maximum_concurrent_rpcs, compression)
+                                 maximum_concurrent_rpcs, compression,
+                                 request_mapper, response_mapper)
 
 
 @contextlib.contextmanager

--- a/src/python/grpcio/grpc/__init__.py
+++ b/src/python/grpcio/grpc/__init__.py
@@ -1840,14 +1840,15 @@ def server(thread_pool,
         lifetime of the server unless overridden. This is an EXPERIMENTAL option.
       request_mapper: A method that will be called with three arguments:
         `method_name` (string, canonical method name), `metadata` (dict, gRPC
-        message metadata) and `message` (bytes, serialized gRPC message payload).
-        The method will be called before `message` is deserialized. The function
-        should return a `metadata` and `message` (same types) tuple.
+        message metadata) and `serialized_request` (bytes, serialized gRPC message
+        payload). The method will be called before `message` is deserialized. The 
+        function should return a `serialized_request` (bytes), which will be
+        (internally) deserialized into a gRPC message.
       response_mapper: A method that will be called with three arguments:
         `method_name` (string, canonical method name), `metadata` (dict, gRPC
-        response metadata), and `message` (bytes, serialized gRPC message
-        payload). The function should return a `metadata` and `message` (same
-        types) tuple.
+        response metadata), and `serialized_response` (bytes, serialized gRPC message
+        payload). The function should return a `serialized_response` (bytes), which
+        will be sent to the client.
 
     Returns:
       A Server object.

--- a/src/python/grpcio/grpc/_server.py
+++ b/src/python/grpcio/grpc/_server.py
@@ -202,7 +202,7 @@ def _receive_message(state, rpc_event, request_deserializer, request_mapper):
                 metadata = rpc_event.invocation_metadata
                 method_name = _common.decode(rpc_event.call_details.method)
                 try:
-                    metadata, serialized_request = request_mapper(method_name, metadata, serialized_request)
+                    serialized_request = request_mapper(method_name, metadata, serialized_request)
                     # TODO: set downstream metadata
                 except Exception as ex:
                     _abort(state, rpc_event.call, cygrpc.StatusCode.internal,
@@ -489,7 +489,7 @@ def _serialize_response(rpc_event, state, response, response_serializer, respons
         method_name = _common.decode(rpc_event.call_details.method)
         metadata = rpc_event.invocation_metadata
         try:
-            metadata, serialized_response = response_mapper(method_name, metadata, serialized_response)
+            serialized_response = response_mapper(method_name, metadata, serialized_response)
             # TODO: update metadata
         except Exception as ex:
             _abort(state, rpc_event.call, cygrpc.StatusCode.internal,


### PR DESCRIPTION
A gRPC-based project I'm working on requires signing requests (with RSA or HMAC). In our implementation, we concatenate the method name, relevant headers, and the message binary to create a digest (inspiration stole from [this](https://tools.ietf.org/id/draft-cavage-http-signatures-08.html) RFC draft). However, I couldn't find an easy way of accessing the message binary server-side (interceptors only give access to method + headers), so I had to hack this in. 

I understand that this may not be suitable for streaming messages, etc. but I thought I'd contribute this PR to open a discussion on the idea. Overall, this change increases the lifetime of a message's binary buffer to be the same as the lifetime of the context, which will increase the overall (on-average) memory usage of a gRPC server because it gives the GC less to play with across the lifetime of one gRPC request.