### PR TITLE
Do not suppress errors in the Python gevent poller

### DIFF
--- a/src/core/lib/iomgr/pollset_custom.cc
+++ b/src/core/lib/iomgr/pollset_custom.cc
@@ -77,14 +77,14 @@ static grpc_error* pollset_work(grpc_pollset* pollset,
   // control back to the application
   grpc_core::ExecCtx* curr = grpc_core::ExecCtx::Get();
   grpc_core::ExecCtx::Set(nullptr);
-  poller_vtable->poll(static_cast<size_t>(timeout));
+  grpc_error* err = poller_vtable->poll(static_cast<size_t>(timeout));
   grpc_core::ExecCtx::Set(curr);
   grpc_core::ExecCtx::Get()->InvalidateNow();
   if (grpc_core::ExecCtx::Get()->HasWork()) {
     grpc_core::ExecCtx::Get()->Flush();
   }
   gpr_mu_lock(&pollset->mu);
-  return GRPC_ERROR_NONE;
+  return err;
 }
 
 static grpc_error* pollset_kick(grpc_pollset* pollset,

--- a/src/core/lib/iomgr/pollset_custom.h
+++ b/src/core/lib/iomgr/pollset_custom.h
@@ -19,13 +19,14 @@
 #ifndef GRPC_CORE_LIB_IOMGR_POLLSET_CUSTOM_H
 #define GRPC_CORE_LIB_IOMGR_POLLSET_CUSTOM_H
 
+#include "src/core/lib/iomgr/error.h"
 #include <grpc/support/port_platform.h>
 
 #include <stddef.h>
 
 typedef struct grpc_custom_poller_vtable {
   void (*init)();
-  void (*poll)(size_t timeout_ms);
+  grpc_error* (*poll)(size_t timeout_ms);
   void (*kick)();
   void (*shutdown)();
 } grpc_custom_poller_vtable;

--- a/src/core/lib/iomgr/pollset_uv.cc
+++ b/src/core/lib/iomgr/pollset_uv.cc
@@ -24,6 +24,7 @@
 
 #include <grpc/support/alloc.h>
 #include <grpc/support/log.h>
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/pollset_custom.h"
 
 #include <uv.h>
@@ -54,7 +55,7 @@ static void empty_timer_cb(uv_timer_t* handle) {}
 
 static void kick_timer_cb(uv_timer_t* handle) { g_kicked = false; }
 
-static void run_loop(size_t timeout) {
+static grpc_error* run_loop(size_t timeout) {
   if (grpc_pollset_work_run_loop) {
     if (timeout == 0) {
       uv_run(uv_default_loop(), UV_RUN_NOWAIT);
@@ -64,6 +65,7 @@ static void run_loop(size_t timeout) {
       uv_timer_stop(&g_handle->poll_timer);
     }
   }
+  return GRPC_ERROR_NONE;
 }
 
 static void kick() {

--- a/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/completion_queue.pyx.pxi
@@ -20,6 +20,15 @@ import time
 cdef int _INTERRUPT_CHECK_PERIOD_MS = 200
 
 
+cdef grpc_event _grpc_completion_queue_next(grpc_completion_queue *cq,
+                                            gpr_timespec deadline,
+                                            void *reserved) except *:
+    # Wrap the call to the C++ core in an 'except *' helper to propagate any
+    # errors raised by the gevent poller callback
+    with nogil:
+      return grpc_completion_queue_next(cq, deadline, reserved)
+
+
 cdef grpc_event _next(grpc_completion_queue *c_completion_queue, deadline) except *:
   cdef gpr_timespec c_increment
   cdef gpr_timespec c_timeout
@@ -36,7 +45,9 @@ cdef grpc_event _next(grpc_completion_queue *c_completion_queue, deadline) excep
       if gpr_time_cmp(c_timeout, c_deadline) > 0:
         c_timeout = c_deadline
   
-      c_event = grpc_completion_queue_next(c_completion_queue, c_timeout, NULL)
+      with gil:
+          c_event = _grpc_completion_queue_next(c_completion_queue, c_timeout,
+                                                NULL)
   
       if (c_event.type != GRPC_QUEUE_TIMEOUT or
           gpr_time_cmp(c_timeout, c_deadline) == 0):
@@ -115,7 +126,7 @@ cdef class CompletionQueue:
         grpc_completion_queue_shutdown(self.c_completion_queue)
       # Pump the queue (All outstanding calls should have been cancelled)
       while not self.is_shutdown:
-        event = grpc_completion_queue_next(
+        event = _grpc_completion_queue_next(
             self.c_completion_queue, c_deadline, NULL)
         self._interpret_event(event)
       grpc_completion_queue_destroy(self.c_completion_queue)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pxd.pxi
@@ -102,7 +102,7 @@ cdef extern from "src/core/lib/iomgr/timer_custom.h":
 cdef extern from "src/core/lib/iomgr/pollset_custom.h":
   struct grpc_custom_poller_vtable:
     void (*init)()
-    void (*poll)(size_t timeout_ms)
+    grpc_error* (*poll)(size_t timeout_ms)
     void (*kick)()
     void (*shutdown)()
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx.pxi
@@ -383,11 +383,12 @@ cdef void destroy_loop() with gil:
 cdef void kick_loop() with gil:
   g_event.set()
 
-cdef void run_loop(size_t timeout_ms) with gil:
+cdef grpc_error* run_loop(size_t timeout_ms) with gil:
     timeout = timeout_ms / 1000.0
     if timeout_ms > 0:
       g_event.wait(timeout)
       g_event.clear()
+    return grpc_error_none()
 
 ###############################
 ### Initializer ###############


### PR DESCRIPTION
As reported in issue #15880, when running with gevent support enabled, the gevent poller ignores any exceptions raised by `gevent.wait()`, such as `GreenletExit` and `Timeout`:

```
Exception gevent.timeout.Timeout: <Timeout at 0x7fda3cdf5cd0 seconds=1> in 'grpc._cython.cygrpc.run_loop' ignored
```

Since gevent uses these exceptions to kill greenlets, ignoring them causes greenlets to be unkillable while waiting. To address this, this PR cancels the gRPC call if an exception is raised, stores the exception in Python's own exception registers and reraises it after returning from the gRPC core back to Python so it is received by the application.