### PR TITLE
Avoid metadata leak assertion in asan builds.

### DIFF
--- a/src/core/lib/transport/metadata.cc
+++ b/src/core/lib/transport/metadata.cc
@@ -222,7 +222,12 @@ void grpc_mdctx_global_shutdown() {
         abort();
       }
     }
+      // For ASAN builds, we don't want to crash here, because that will
+      // prevent ASAN from providing leak detection information, which is
+      // far more useful than this simple assertion.
+#ifndef GRPC_ASAN_ENABLED
     GPR_DEBUG_ASSERT(shard->count == 0);
+#endif
     gpr_free(shard->elems);
   }
 }


### PR DESCRIPTION
The asan leak detection output is far more useful than this assertion, but when the assertion triggers, it causes the program to exit before asan can print its leak detection output.  So we now inhibit the assertion for asan builds.