### PR TITLE
Fix debug logging of stream refcounts.

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -1180,6 +1180,10 @@ ChannelData::ChannelData(grpc_channel_element_args* args, grpc_error** error)
       interested_parties_(grpc_pollset_set_create()),
       subchannel_pool_(GetSubchannelPool(args->channel_args)),
       disconnect_error_(GRPC_ERROR_NONE) {
+  if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
+    gpr_log(GPR_INFO, "chand=%p: creating client_channel for channel stack %p",
+            this, owning_stack_);
+  }
   // Initialize data members.
   grpc_connectivity_state_init(&state_tracker_, GRPC_CHANNEL_IDLE,
                                "client_channel");
@@ -1259,6 +1263,9 @@ ChannelData::ChannelData(grpc_channel_element_args* args, grpc_error** error)
 }
 
 ChannelData::~ChannelData() {
+  if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
+    gpr_log(GPR_INFO, "chand=%p: destroying channel", this);
+  }
   if (resolving_lb_policy_ != nullptr) {
     grpc_pollset_set_del_pollset_set(resolving_lb_policy_->interested_parties(),
                                      interested_parties_);

--- a/src/core/lib/transport/transport.cc
+++ b/src/core/lib/transport/transport.cc
@@ -90,7 +90,7 @@ void grpc_stream_ref_init(grpc_stream_refcount* refcount, int initial_refs,
 #endif
   GRPC_CLOSURE_INIT(&refcount->destroy, cb, cb_arg, grpc_schedule_on_exec_ctx);
 
-  new (&refcount->refs) grpc_core::RefCount();
+  new (&refcount->refs) grpc_core::RefCount(1, &grpc_trace_stream_refcount);
   new (&refcount->slice_refcount) grpc_slice_refcount(
       grpc_slice_refcount::Type::REGULAR, &refcount->refs, slice_stream_destroy,
       refcount, &refcount->slice_refcount);


### PR DESCRIPTION
Ever since @arjunroy's #18407, the `stream_refcount` tracer (which, confusingly, is also used for channel refcounting) has stopped actually including the refcount in its logging, which severely limits its usefulness.  I've had a couple of different occassions when I've needed to manually change it in order to get useful output while debugging a channel ref-counting problem, so I think we need to fix this so that that stops being an issue.

This PR attempts to fix this in a slighty sub-optimal way: it passes the stream refcount tracer into `grpc_core::RefCount`, which results in duplicate log messages, each with a slightly different subset of information: one from `grpc_stream_refcount` and another from the underlying `grpc_core::RefCount` object.  This is not ideal, because it would be better to include all the information in a single log message, but I don't see a reasonable way to do that without breaking API boundaries.  I'd be open to better suggestions here.

This change only affects debug builds, so I don't think there will be any performance impact that we care about, but please confirm that seems correct.

Thanks!