### PR TITLE
Coalesced some grpc_slice_buffer_tiny_add calls in hpack_enc

### DIFF
--- a/src/core/lib/slice/slice_buffer.cc
+++ b/src/core/lib/slice/slice_buffer.cc
@@ -103,7 +103,7 @@ uint8_t* grpc_slice_buffer_tiny_add(grpc_slice_buffer* sb, size_t n) {
 
   sb->length += n;
 
-  if (sb->count == 0) goto add_new;
+  if (sb->count == 0) goto add_first;
   back = &sb->slices[sb->count - 1];
   if (back->refcount) goto add_new;
   if ((back->data.inlined.length + n) > sizeof(back->data.inlined.bytes))
@@ -115,6 +115,7 @@ uint8_t* grpc_slice_buffer_tiny_add(grpc_slice_buffer* sb, size_t n) {
 
 add_new:
   maybe_embiggen(sb);
+add_first:
   back = &sb->slices[sb->count];
   sb->count++;
   back->refcount = nullptr;


### PR DESCRIPTION
Reduced calls to grpc_slice_buffer_tiny_add by coalescing. Each call to tiny_add() that successfully performed an inlined append is 27 instructions executed.


BM_HpackEncoderInitDestroy                                                                         255ns ± 0%              255ns ± 0%  +0.18%        (p=0.001 n=20+18)
BM_HpackEncoderEncodeDeadline                                                                      154ns ± 2%              148ns ± 2%  -3.47%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<EmptyBatch>/0/16384                                                   37.4ns ± 0%             37.3ns ± 0%  -0.44%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<EmptyBatch>/1/16384                                                   37.4ns ± 0%             37.3ns ± 0%  -0.50%        (p=0.000 n=17+20)
BM_HpackEncoderEncodeHeader<SingleStaticElem>/0/16384                                             52.1ns ± 1%             51.4ns ± 1%  -1.32%        (p=0.000 n=20+19)
BM_HpackEncoderEncodeHeader<SingleInternedKeyElem>/0/16384                                        87.0ns ± 1%             81.8ns ± 1%  -6.01%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<SingleInternedElem>/0/16384                                           51.4ns ± 0%             51.5ns ± 0%  +0.22%        (p=0.000 n=19+17)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<10, false>>/0/16384                          51.4ns ± 0%             51.6ns ± 0%  +0.31%        (p=0.000 n=17+19)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<31, false>>/0/16384                          51.4ns ± 0%             51.6ns ± 0%  +0.29%        (p=0.000 n=16+18)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<100, false>>/0/16384                         51.4ns ± 0%             51.6ns ± 0%  +0.24%        (p=0.000 n=18+19)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<10, true>>/0/16384                           51.5ns ± 1%             51.6ns ± 0%  +0.21%        (p=0.003 n=20+20)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<31, true>>/0/16384                           51.5ns ± 1%             51.6ns ± 0%  +0.23%        (p=0.003 n=19+20)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<100, true>>/0/16384                          51.5ns ± 0%             51.6ns ± 0%  +0.34%        (p=0.000 n=19+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedElem>/0/16384                                        98.8ns ± 0%             93.0ns ± 1%  -5.83%        (p=0.000 n=20+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<1, false>>/0/16384                         121ns ± 0%              116ns ± 1%  -4.86%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<3, false>>/0/16384                         127ns ± 1%              122ns ± 1%  -4.46%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<10, false>>/0/16384                        151ns ± 1%              146ns ± 1%  -3.36%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<31, false>>/0/16384                        244ns ± 1%              238ns ± 1%  -2.14%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<100, false>>/0/16384                       480ns ± 0%              475ns ± 0%  -1.16%        (p=0.000 n=17+17)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<1, true>>/0/16384                          100ns ± 1%               95ns ± 1%  -5.29%        (p=0.000 n=19+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<3, true>>/0/16384                          101ns ± 0%               96ns ± 1%  -5.17%        (p=0.000 n=19+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<10, true>>/0/16384                         102ns ± 1%               96ns ± 1%  -5.30%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<31, true>>/0/16384                         117ns ± 1%              112ns ± 0%  -4.40%        (p=0.000 n=17+17)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<100, true>>/0/16384                        117ns ± 1%              112ns ± 1%  -4.52%        (p=0.000 n=19+20)
BM_HpackEncoderEncodeHeader<RepresentativeClientInitialMetadata>/0/16384                           140ns ± 0%              138ns ± 1%  -1.03%        (p=0.000 n=19+20)
BM_HpackEncoderEncodeHeader<MoreRepresentativeClientInitialMetadata>/0/16384                       239ns ± 0%              232ns ± 1%  -2.92%        (p=0.000 n=19+20)
BM_HpackEncoderEncodeHeader<RepresentativeServerInitialMetadata>/0/16384                          74.9ns ± 1%             73.9ns ± 0%  -1.36%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<RepresentativeServerTrailingMetadata>/1/16384                         52.2ns ± 1%             51.4ns ± 1%  -1.41%        (p=0.000 n=20+20)
BM_HpackParserInitDestroy                                                                         5.31µs ± 1%             5.32µs ± 1%  +0.34%        (p=0.001 n=20+17)
BM_HpackParserParseHeader<AddIndexedSingleStaticElem, UnrefHeader>                                 162ns ± 0%              163ns ± 0%  +0.07%        (p=0.001 n=18+17)
BM_HpackParserParseHeader<KeyIndexedSingleStaticElem, UnrefHeader>                                 216ns ± 1%              218ns ± 1%  +0.63%        (p=0.004 n=18+19)
BM_HpackParserParseHeader<NonIndexedBinaryElem<10, false>, UnrefHeader>                            345ns ± 2%              340ns ± 1%  -1.61%        (p=0.000 n=20+20)
BM_HpackParserParseHeader<NonIndexedBinaryElem<100, false>, UnrefHeader>                          1.71µs ± 2%             1.70µs ± 1%  -1.08%        (p=0.000 n=20+19)
BM_HpackParserParseHeader<RepresentativeServerInitialMetadata, UnrefHeader>                       46.3ns ± 0%             46.4ns ± 0%  +0.33%        (p=0.000 n=18+17)
BM_HpackParserParseHeader<RepresentativeClientInitialMetadata, OnInitialHeader>                    445ns ± 0%              453ns ± 1%  +1.63%        (p=0.000 n=20+20)
BM_HpackParserParseHeader<RepresentativeServerInitialMetadata, OnInitialHeader>                    156ns ± 1%              155ns ± 1%  -0.26%        (p=0.026 n=19+19)
BM_HpackParserParseHeader<SameDeadline, OnHeaderTimeout>                                           116ns ± 0%              116ns ± 1%  -0.26%        (p=0.001 n=18+19)