### PR TITLE
Make //examples/python/...:all compatible with Bazel 0.26

### DIFF
--- a/examples/python/multiprocessing/BUILD
+++ b/examples/python/multiprocessing/BUILD
@@ -36,7 +36,7 @@ py_binary(
         "//src/python/grpcio/grpc:grpcio",
         ":prime_proto_pb2",
     ],
-    default_python_version = "PY3",
+    srcs_version = "PY3",
 )
 
 py_binary(
@@ -50,7 +50,7 @@ py_binary(
         "//conditions:default": [requirement("futures")],
         "//:python3": [],
     }),
-    default_python_version = "PY3",
+    srcs_version = "PY3",
 )
 
 py_test(


### PR DESCRIPTION
@nicolasnoble This should unblock https://github.com/grpc/grpc/pull/19258. Sorry for the rigmarole.

Manually tested against Bazel 0.26.0 with `bazel test //examples/python/...:all`