### PR TITLE
Use new connection for every test case

### DIFF
--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -364,6 +364,11 @@ initWithInterceptorManager:(GRPCInterceptorManager *)interceptorManager
 
   [GRPCCall resetHostSettings];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  [GRPCCall closeOpenConnections];
+#pragma clang diagnostic pop
+
   _service = [[self class] host] ? [RMTTestService serviceWithHost:[[self class] host]] : nil;
 }
 

--- a/src/objective-c/tests/MacTests/StressTests.m
+++ b/src/objective-c/tests/MacTests/StressTests.m
@@ -118,6 +118,11 @@ extern const char *kCFStreamVarName;
 
   [GRPCCall resetHostSettings];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  [GRPCCall closeOpenConnections];
+#pragma clang diagnostic pop
+
   GRPCMutableCallOptions *options = [[GRPCMutableCallOptions alloc] init];
   options.transportType = [[self class] transportType];
   options.PEMRootCertificates = [[self class] PEMRootCertificates];


### PR DESCRIPTION
It used to be true that we reset connection for every test case for test stability. This behavior change when we introduced the v2api because `[GRPCCall resetHostSettings]` now only removes the `GRPCHost` settings in v1 api but no longer disconnects the channel. This change recovers the original behavior.

This PR tentatively helps to reduce the ObjC test flakiness and hopefully makes the ObjC tests useful to developers again. There could be concern about this change covering up some test failures that only occur with long-lasting channels (particularly the CFStream hang on MacOS). From my local experiments it seems that we are still able to capture this type of issue in some of the large tests. Besides that, we still have bug ticket tracking this issue.