### PR TITLE
Surface exceptions in gevent IO manager

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pxd.pxi
@@ -67,25 +67,25 @@ cdef extern from "src/core/lib/iomgr/tcp_custom.h":
   ctypedef void (*grpc_custom_close_callback)(grpc_custom_socket* socket)
 
   struct grpc_socket_vtable:
-      grpc_error* (*init)(grpc_custom_socket* socket, int domain);
+      grpc_error* (*init)(grpc_custom_socket* socket, int domain) except *
       void (*connect)(grpc_custom_socket* socket, const grpc_sockaddr* addr,
-                      size_t len, grpc_custom_connect_callback cb);
-      void (*destroy)(grpc_custom_socket* socket);
-      void (*shutdown)(grpc_custom_socket* socket);
-      void (*close)(grpc_custom_socket* socket, grpc_custom_close_callback cb);
+                      size_t len, grpc_custom_connect_callback cb) except *
+      void (*destroy)(grpc_custom_socket* socket) except *
+      void (*shutdown)(grpc_custom_socket* socket) except *
+      void (*close)(grpc_custom_socket* socket, grpc_custom_close_callback cb) except *
       void (*write)(grpc_custom_socket* socket, grpc_slice_buffer* slices,
-                    grpc_custom_write_callback cb);
+                    grpc_custom_write_callback cb) except *
       void (*read)(grpc_custom_socket* socket, char* buffer, size_t length,
-                   grpc_custom_read_callback cb);
+                   grpc_custom_read_callback cb) except *
       grpc_error* (*getpeername)(grpc_custom_socket* socket,
-                                 const grpc_sockaddr* addr, int* len);
+                                 const grpc_sockaddr* addr, int* len) except *
       grpc_error* (*getsockname)(grpc_custom_socket* socket,
-                             const grpc_sockaddr* addr, int* len);
+                             const grpc_sockaddr* addr, int* len) except *
       grpc_error* (*bind)(grpc_custom_socket* socket, const grpc_sockaddr* addr,
-                          size_t len, int flags);
-      grpc_error* (*listen)(grpc_custom_socket* socket);
+                          size_t len, int flags) except *
+      grpc_error* (*listen)(grpc_custom_socket* socket) except *
       void (*accept)(grpc_custom_socket* socket, grpc_custom_socket* client,
-                     grpc_custom_accept_callback cb);
+                     grpc_custom_accept_callback cb) except *
 
 cdef extern from "src/core/lib/iomgr/timer_custom.h":
   struct grpc_custom_timer:
@@ -94,17 +94,17 @@ cdef extern from "src/core/lib/iomgr/timer_custom.h":
      # We don't care about the rest of the fields
 
   struct grpc_custom_timer_vtable:
-    void (*start)(grpc_custom_timer* t);
-    void (*stop)(grpc_custom_timer* t);
+    void (*start)(grpc_custom_timer* t) except *
+    void (*stop)(grpc_custom_timer* t) except *
 
-  void grpc_custom_timer_callback(grpc_custom_timer* t, grpc_error* error);
+  void grpc_custom_timer_callback(grpc_custom_timer* t, grpc_error* error)
 
 cdef extern from "src/core/lib/iomgr/pollset_custom.h":
   struct grpc_custom_poller_vtable:
-    void (*init)()
-    void (*poll)(size_t timeout_ms)
-    void (*kick)()
-    void (*shutdown)()
+    void (*init)() except *
+    void (*poll)(size_t timeout_ms) except *
+    void (*kick)() except *
+    void (*shutdown)() except *
 
 cdef extern from "src/core/lib/iomgr/iomgr_custom.h":
   void grpc_custom_iomgr_init(grpc_socket_vtable* socket,

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pxd.pxi
@@ -44,12 +44,12 @@ cdef extern from "src/core/lib/iomgr/resolve_address_custom.h":
     pass
 
   struct grpc_custom_resolver_vtable:
-    grpc_error* (*resolve)(char* host, char* port, grpc_resolved_addresses** res);
-    void (*resolve_async)(grpc_custom_resolver* resolver, char* host, char* port);
+    grpc_error* (*resolve)(char* host, char* port, grpc_resolved_addresses** res) except *
+    void (*resolve_async)(grpc_custom_resolver* resolver, char* host, char* port) except *
 
   void grpc_custom_resolve_callback(grpc_custom_resolver* resolver,
                                     grpc_resolved_addresses* result,
-                                    grpc_error* error);
+                                    grpc_error* error)
 
 cdef extern from "src/core/lib/iomgr/tcp_custom.h":
   struct grpc_custom_socket:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/grpc_gevent.pyx.pxi
@@ -84,7 +84,7 @@ cdef class SocketWrapper:
     self.c_buffer = NULL
     self.len = 0
 
-cdef grpc_error* socket_init(grpc_custom_socket* socket, int domain) with gil:
+cdef grpc_error* socket_init(grpc_custom_socket* socket, int domain) except * with gil:
   sw = SocketWrapper()
   sw.c_socket = socket
   sw.sockopts = []
@@ -112,7 +112,7 @@ def socket_connect_async(socket_wrapper, addr_tuple):
 
 cdef void socket_connect(grpc_custom_socket* socket, const grpc_sockaddr* addr,
                          size_t addr_len,
-                         grpc_custom_connect_callback cb) with gil:
+                         grpc_custom_connect_callback cb) except * with gil:
   py_socket = None
   socket_wrapper = <SocketWrapper>socket.impl
   socket_wrapper.connect_cb = cb
@@ -125,10 +125,10 @@ cdef void socket_connect(grpc_custom_socket* socket, const grpc_sockaddr* addr,
   socket_wrapper.socket = py_socket
   _spawn_greenlet(socket_connect_async, socket_wrapper, addr_tuple)
 
-cdef void socket_destroy(grpc_custom_socket* socket) with gil:
+cdef void socket_destroy(grpc_custom_socket* socket) except * with gil:
   cpython.Py_DECREF(<SocketWrapper>socket.impl)
 
-cdef void socket_shutdown(grpc_custom_socket* socket) with gil:
+cdef void socket_shutdown(grpc_custom_socket* socket) except * with gil:
   try:
     (<SocketWrapper>socket.impl).socket.shutdown(gevent_socket.SHUT_RDWR)
   except IOError as io_error:
@@ -136,7 +136,7 @@ cdef void socket_shutdown(grpc_custom_socket* socket) with gil:
       raise io_error
 
 cdef void socket_close(grpc_custom_socket* socket,
-                       grpc_custom_close_callback cb) with gil:
+                       grpc_custom_close_callback cb) except * with gil:
   socket_wrapper = (<SocketWrapper>socket.impl)
   if socket_wrapper.socket is not None:
     socket_wrapper.socket.close()
@@ -176,7 +176,7 @@ def socket_write_async(socket_wrapper, write_bytes):
   socket_write_async_cython(socket_wrapper, write_bytes)
 
 cdef void socket_write(grpc_custom_socket* socket, grpc_slice_buffer* buffer,
-                       grpc_custom_write_callback cb) with gil:
+                       grpc_custom_write_callback cb) except * with gil:
   cdef char* start
   sw = <SocketWrapper>socket.impl
   sw.write_cb = cb
@@ -204,7 +204,7 @@ def socket_read_async(socket_wrapper):
   socket_read_async_cython(socket_wrapper)
 
 cdef void socket_read(grpc_custom_socket* socket, char* buffer,
-                      size_t length, grpc_custom_read_callback cb) with gil:
+                      size_t length, grpc_custom_read_callback cb) except * with gil:
   sw = <SocketWrapper>socket.impl
   sw.read_cb = cb
   sw.c_buffer = buffer
@@ -213,7 +213,7 @@ cdef void socket_read(grpc_custom_socket* socket, char* buffer,
 
 cdef grpc_error* socket_getpeername(grpc_custom_socket* socket,
                                     const grpc_sockaddr* addr,
-                                    int* length) with gil:
+                                    int* length) except * with gil:
   cdef char* src_buf
   peer = (<SocketWrapper>socket.impl).socket.getpeername()
 
@@ -226,7 +226,7 @@ cdef grpc_error* socket_getpeername(grpc_custom_socket* socket,
 
 cdef grpc_error* socket_getsockname(grpc_custom_socket* socket,
                                     const grpc_sockaddr* addr,
-                                    int* length) with gil:
+                                    int* length) except * with gil:
   cdef char* src_buf
   cdef grpc_resolved_address c_addr
   if (<SocketWrapper>socket.impl).socket is None:
@@ -245,7 +245,7 @@ def applysockopts(s):
 
 cdef grpc_error* socket_bind(grpc_custom_socket* socket,
                              const grpc_sockaddr* addr,
-                             size_t len, int flags) with gil:
+                             size_t len, int flags) except * with gil:
   addr_tuple = sockaddr_to_tuple(addr, len)
   try:
     try:
@@ -262,7 +262,7 @@ cdef grpc_error* socket_bind(grpc_custom_socket* socket,
   else:
     return grpc_error_none()
 
-cdef grpc_error* socket_listen(grpc_custom_socket* socket) with gil:
+cdef grpc_error* socket_listen(grpc_custom_socket* socket) except * with gil:
   (<SocketWrapper>socket.impl).socket.listen(50)
   return grpc_error_none()
 
@@ -374,16 +374,16 @@ cdef void timer_stop(grpc_custom_timer* t) with gil:
 ### pollset implementation ###
 ###############################
 
-cdef void init_loop() with gil:
+cdef void init_loop() except * with gil:
   pass
 
-cdef void destroy_loop() with gil:
+cdef void destroy_loop() except * with gil:
   g_pool.join()
 
-cdef void kick_loop() with gil:
+cdef void kick_loop() except * with gil:
   g_event.set()
 
-cdef void run_loop(size_t timeout_ms) with gil:
+cdef void run_loop(size_t timeout_ms) except * with gil:
     timeout = timeout_ms / 1000.0
     if timeout_ms > 0:
       g_event.wait(timeout)


### PR DESCRIPTION
These functions were ignored before in https://github.com/grpc/grpc/issues/16643. They were hiding behind `void *` in C layer, but will potentially raise Python exceptions.

This effort hopefully fixes: #15880

Let's see if tests are happy in macOS/Windows :)