### PR TITLE
Properly detect C++ exception for MSVC

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -618,10 +618,14 @@ typedef unsigned __int64 uint64_t;
 
 /* GRPC_ALLOW_EXCEPTIONS should be 0 or 1 if exceptions are allowed or not */
 #ifndef GRPC_ALLOW_EXCEPTIONS
-/* If not already set, set to 1 on Windows (style guide standard) but to
- * 0 on non-Windows platforms unless the compiler defines __EXCEPTIONS */
 #ifdef GPR_WINDOWS
+#if defined(_MSC_VER) && defined(_CPPUNWIND)
 #define GRPC_ALLOW_EXCEPTIONS 1
+#elif defined(__EXCEPTIONS)
+#define GRPC_ALLOW_EXCEPTIONS 1
+#else
+#define GRPC_ALLOW_EXCEPTIONS 0
+#endif
 #else /* GPR_WINDOWS */
 #ifdef __EXCEPTIONS
 #define GRPC_ALLOW_EXCEPTIONS 1


### PR DESCRIPTION
Inspired from protobuf

https://github.com/protocolbuffers/protobuf/blob/77f03d932a35e8aa0a98c0c728ad3f5aacfe30ce/src/google/protobuf/stubs/common.h#L50