### PR TITLE
Use grpc_impl namespace for grpc internal implementation code

### DIFF
--- a/include/grpcpp/security/credentials_impl.h
+++ b/include/grpcpp/security/credentials_impl.h
@@ -24,11 +24,11 @@
 #include <vector>
 
 #include <grpc/grpc_security_constants.h>
-#include <grpcpp/channel.h>
+#include <grpcpp/channel_impl.h>
 #include <grpcpp/impl/codegen/client_interceptor.h>
 #include <grpcpp/impl/codegen/grpc_library.h>
 #include <grpcpp/security/auth_context.h>
-#include <grpcpp/support/channel_arguments.h>
+#include <grpcpp/support/channel_arguments_impl.h>
 #include <grpcpp/support/status.h>
 #include <grpcpp/support/string_ref.h>
 
@@ -41,16 +41,16 @@ class CallCredentials;
 class SecureCallCredentials;
 class SecureChannelCredentials;
 
-std::shared_ptr<::grpc::Channel> CreateCustomChannelImpl(
+std::shared_ptr<Channel> CreateCustomChannelImpl(
     const grpc::string& target,
     const std::shared_ptr<ChannelCredentials>& creds,
-    const grpc::ChannelArguments& args);
+    const ChannelArguments& args);
 
 namespace experimental {
-std::shared_ptr<::grpc::Channel> CreateCustomChannelWithInterceptors(
+std::shared_ptr<Channel> CreateCustomChannelWithInterceptors(
     const grpc::string& target,
     const std::shared_ptr<ChannelCredentials>& creds,
-    const grpc::ChannelArguments& args,
+    const ChannelArguments& args,
     std::vector<
         std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>>
         interceptor_creators);
@@ -75,27 +75,27 @@ class ChannelCredentials : private grpc::GrpcLibraryCodegen {
   virtual SecureChannelCredentials* AsSecureCredentials() = 0;
 
  private:
-  friend std::shared_ptr<::grpc::Channel> CreateCustomChannelImpl(
+  friend std::shared_ptr<Channel> CreateCustomChannelImpl(
       const grpc::string& target,
       const std::shared_ptr<ChannelCredentials>& creds,
-      const grpc::ChannelArguments& args);
+      const ChannelArguments& args);
 
-  friend std::shared_ptr<::grpc::Channel>
+  friend std::shared_ptr<Channel>
   grpc_impl::experimental::CreateCustomChannelWithInterceptors(
       const grpc::string& target,
       const std::shared_ptr<ChannelCredentials>& creds,
-      const grpc::ChannelArguments& args,
+      const ChannelArguments& args,
       std::vector<std::unique_ptr<
           grpc::experimental::ClientInterceptorFactoryInterface>>
           interceptor_creators);
 
-  virtual std::shared_ptr<::grpc::Channel> CreateChannelImpl(
-      const grpc::string& target, const grpc::ChannelArguments& args) = 0;
+  virtual std::shared_ptr<Channel> CreateChannelImpl(
+      const grpc::string& target, const ChannelArguments& args) = 0;
 
   // This function should have been a pure virtual function, but it is
   // implemented as a virtual function so that it does not break API.
-  virtual std::shared_ptr<::grpc::Channel> CreateChannelWithInterceptors(
-      const grpc::string& target, const grpc::ChannelArguments& args,
+  virtual std::shared_ptr<Channel> CreateChannelWithInterceptors(
+      const grpc::string& target, const ChannelArguments& args,
       std::vector<std::unique_ptr<
           grpc::experimental::ClientInterceptorFactoryInterface>>
           interceptor_creators) {

--- a/include/grpcpp/server_impl.h
+++ b/include/grpcpp/server_impl.h
@@ -27,16 +27,16 @@
 
 #include <grpc/compression.h>
 #include <grpc/support/atm.h>
-#include <grpcpp/channel.h>
-#include <grpcpp/completion_queue.h>
+#include <grpcpp/channel_impl.h>
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/impl/call.h>
 #include <grpcpp/impl/codegen/client_interceptor.h>
+#include <grpcpp/impl/codegen/completion_queue_impl.h>
 #include <grpcpp/impl/codegen/grpc_library.h>
 #include <grpcpp/impl/codegen/server_interface.h>
 #include <grpcpp/impl/rpc_service_method.h>
 #include <grpcpp/security/server_credentials.h>
-#include <grpcpp/support/channel_arguments.h>
+#include <grpcpp/support/channel_arguments_impl.h>
 #include <grpcpp/support/config.h>
 #include <grpcpp/support/status.h>
 
@@ -80,7 +80,7 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
    public:
     virtual ~GlobalCallbacks() {}
     /// Called before server is created.
-    virtual void UpdateArguments(grpc::ChannelArguments* args) {}
+    virtual void UpdateArguments(ChannelArguments* args) {}
     /// Called before application callback for each synchronous server request
     virtual void PreSynchronousRequest(grpc_impl::ServerContext* context) = 0;
     /// Called after application callback for each synchronous server request
@@ -108,8 +108,8 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   }
 
   /// Establish a channel for in-process communication
-  std::shared_ptr<::grpc::Channel> InProcessChannel(
-      const grpc::ChannelArguments& args);
+  std::shared_ptr<Channel> InProcessChannel(
+      const ChannelArguments& args);
 
   /// NOTE: class experimental_type is not part of the public API of this class.
   /// TODO(yashykt): Integrate into public API when this is no longer
@@ -120,8 +120,8 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
 
     /// Establish a channel for in-process communication with client
     /// interceptors
-    std::shared_ptr<::grpc::Channel> InProcessChannelWithInterceptors(
-        const grpc::ChannelArguments& args,
+    std::shared_ptr<Channel> InProcessChannelWithInterceptors(
+        const ChannelArguments& args,
         std::vector<std::unique_ptr<
             grpc::experimental::ClientInterceptorFactoryInterface>>
             interceptor_creators);
@@ -183,8 +183,8 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   /// \param sync_cq_timeout_msec The timeout to use when calling AsyncNext() on
   /// server completion queues passed via sync_server_cqs param.
   Server(
-      int max_message_size, grpc::ChannelArguments* args,
-      std::shared_ptr<std::vector<std::unique_ptr<grpc::ServerCompletionQueue>>>
+      int max_message_size, ChannelArguments* args,
+      std::shared_ptr<std::vector<std::unique_ptr<ServerCompletionQueue>>>
           sync_server_cqs,
       int min_pollers, int max_pollers, int sync_cq_timeout_msec,
       std::vector<
@@ -202,7 +202,7 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   /// caller is required to keep all completion queues live until the server is
   /// destroyed.
   /// \param num_cqs How many completion queues does \a cqs hold.
-  void Start(grpc::ServerCompletionQueue** cqs, size_t num_cqs) override;
+  void Start(ServerCompletionQueue** cqs, size_t num_cqs) override;
 
   grpc_server* server() override { return server_; }
 
@@ -283,7 +283,7 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
     return max_receive_message_size_;
   }
 
-  grpc::CompletionQueue* CallbackCQ() override;
+  CompletionQueue* CallbackCQ() override;
 
   grpc_impl::ServerInitializer* initializer();
 
@@ -304,7 +304,7 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   /// The following completion queues are ONLY used in case of Sync API
   /// i.e. if the server has any services with sync methods. The server uses
   /// these completion queues to poll for new RPCs
-  std::shared_ptr<std::vector<std::unique_ptr<grpc::ServerCompletionQueue>>>
+  std::shared_ptr<std::vector<std::unique_ptr<ServerCompletionQueue>>>
       sync_server_cqs_;
 
   /// List of \a ThreadManager instances (one for each cq in
@@ -374,7 +374,7 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   // It is _not owned_ by the server; ownership belongs with its internal
   // shutdown callback tag (invoked when the CQ is fully shutdown).
   // It is protected by mu_
-  grpc::CompletionQueue* callback_cq_ = nullptr;
+  CompletionQueue* callback_cq_ = nullptr;
 };
 
 }  // namespace grpc_impl

--- a/src/cpp/client/create_channel_internal.h
+++ b/src/cpp/client/create_channel_internal.h
@@ -28,7 +28,7 @@ struct grpc_channel;
 
 namespace grpc {
 
-std::shared_ptr<Channel> CreateChannelInternal(
+std::shared_ptr<::grpc_impl::Channel> CreateChannelInternal(
     const grpc::string& host, grpc_channel* c_channel,
     std::vector<std::unique_ptr<
         ::grpc::experimental::ClientInterceptorFactoryInterface>>

--- a/src/cpp/client/insecure_credentials.cc
+++ b/src/cpp/client/insecure_credentials.cc
@@ -31,7 +31,7 @@ namespace grpc_impl {
 namespace {
 class InsecureChannelCredentialsImpl final : public ChannelCredentials {
  public:
-  std::shared_ptr<::grpc::Channel> CreateChannelImpl(
+  std::shared_ptr<Channel> CreateChannelImpl(
       const grpc::string& target, const grpc::ChannelArguments& args) override {
     return CreateChannelWithInterceptors(
         target, args,
@@ -39,7 +39,7 @@ class InsecureChannelCredentialsImpl final : public ChannelCredentials {
             grpc::experimental::ClientInterceptorFactoryInterface>>());
   }
 
-  std::shared_ptr<::grpc::Channel> CreateChannelWithInterceptors(
+  std::shared_ptr<Channel> CreateChannelWithInterceptors(
       const grpc::string& target, const grpc::ChannelArguments& args,
       std::vector<std::unique_ptr<
           grpc::experimental::ClientInterceptorFactoryInterface>>

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -36,17 +36,17 @@ SecureChannelCredentials::SecureChannelCredentials(
   g_gli_initializer.summon();
 }
 
-std::shared_ptr<grpc::Channel> SecureChannelCredentials::CreateChannelImpl(
-    const grpc::string& target, const grpc::ChannelArguments& args) {
+std::shared_ptr<Channel> SecureChannelCredentials::CreateChannelImpl(
+    const grpc::string& target, const ChannelArguments& args) {
   return CreateChannelWithInterceptors(
       target, args,
       std::vector<std::unique_ptr<
           grpc::experimental::ClientInterceptorFactoryInterface>>());
 }
 
-std::shared_ptr<grpc::Channel>
+std::shared_ptr<Channel>
 SecureChannelCredentials::CreateChannelWithInterceptors(
-    const grpc::string& target, const grpc::ChannelArguments& args,
+    const grpc::string& target, const ChannelArguments& args,
     std::vector<
         std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>>
         interceptor_creators) {
@@ -209,7 +209,7 @@ std::shared_ptr<CallCredentials> CompositeCallCredentials(
   return nullptr;
 }
 
-std::shared_ptr<grpc_impl::CallCredentials> MetadataCredentialsFromPlugin(
+std::shared_ptr<CallCredentials> MetadataCredentialsFromPlugin(
     std::unique_ptr<MetadataCredentialsPlugin> plugin) {
   grpc::GrpcLibraryCodegen init;  // To call grpc_init().
   const char* type = plugin->GetType();

--- a/src/cpp/client/secure_credentials.h
+++ b/src/cpp/client/secure_credentials.h
@@ -39,14 +39,14 @@ class SecureChannelCredentials final : public ChannelCredentials {
   }
   grpc_channel_credentials* GetRawCreds() { return c_creds_; }
 
-  std::shared_ptr<::grpc::Channel> CreateChannelImpl(
-      const grpc::string& target, const grpc::ChannelArguments& args) override;
+  std::shared_ptr<Channel> CreateChannelImpl(
+      const grpc::string& target, const ChannelArguments& args) override;
 
   SecureChannelCredentials* AsSecureCredentials() override { return this; }
 
  private:
-  std::shared_ptr<::grpc::Channel> CreateChannelWithInterceptors(
-      const grpc::string& target, const grpc::ChannelArguments& args,
+  std::shared_ptr<Channel> CreateChannelWithInterceptors(
+      const grpc::string& target, const ChannelArguments& args,
       std::vector<std::unique_ptr<
           ::grpc::experimental::ClientInterceptorFactoryInterface>>
           interceptor_creators) override;
@@ -83,7 +83,7 @@ class MetadataCredentialsPluginWrapper final : private GrpcLibraryCodegen {
       const char** error_details);
 
   explicit MetadataCredentialsPluginWrapper(
-      std::unique_ptr<MetadataCredentialsPlugin> plugin);
+      std::unique_ptr<::grpc_impl::MetadataCredentialsPlugin> plugin);
 
  private:
   void InvokePlugin(
@@ -93,7 +93,7 @@ class MetadataCredentialsPluginWrapper final : private GrpcLibraryCodegen {
       size_t* num_creds_md, grpc_status_code* status_code,
       const char** error_details);
   std::unique_ptr<ThreadPoolInterface> thread_pool_;
-  std::unique_ptr<MetadataCredentialsPlugin> plugin_;
+  std::unique_ptr<::grpc_impl::MetadataCredentialsPlugin> plugin_;
 };
 
 }  // namespace grpc

--- a/test/cpp/qps/server.h
+++ b/test/cpp/qps/server.h
@@ -21,6 +21,7 @@
 
 #include <grpc/support/cpu.h>
 #include <grpc/support/log.h>
+#include <grpcpp/channel.h>
 #include <grpcpp/resource_quota.h>
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server_builder.h>

--- a/test/cpp/util/create_test_channel.h
+++ b/test/cpp/util/create_test_channel.h
@@ -21,8 +21,11 @@
 
 #include <memory>
 
+#include <grpcpp/channel.h>
 #include <grpcpp/impl/codegen/client_interceptor.h>
 #include <grpcpp/security/credentials.h>
+#include <grpcpp/support/channel_arguments.h>
+
 
 namespace grpc_impl {
 
@@ -32,36 +35,35 @@ class Channel;
 namespace grpc {
 
 namespace testing {
-
 typedef enum { INSECURE = 0, TLS, ALTS } transport_security;
 
 }  // namespace testing
 
-std::shared_ptr<::grpc_impl::Channel> CreateTestChannel(
+std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, testing::transport_security security_type);
 
-std::shared_ptr<::grpc_impl::Channel> CreateTestChannel(
+std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& override_hostname,
     testing::transport_security security_type, bool use_prod_roots);
 
-std::shared_ptr<::grpc_impl::Channel> CreateTestChannel(
+std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& override_hostname,
     testing::transport_security security_type, bool use_prod_roots,
     const std::shared_ptr<CallCredentials>& creds);
 
-std::shared_ptr<::grpc_impl::Channel> CreateTestChannel(
+std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& override_hostname,
     testing::transport_security security_type, bool use_prod_roots,
     const std::shared_ptr<CallCredentials>& creds,
     const ChannelArguments& args);
 
-std::shared_ptr<::grpc_impl::Channel> CreateTestChannel(
+std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& cred_type,
     const grpc::string& override_hostname, bool use_prod_roots,
     const std::shared_ptr<CallCredentials>& creds,
     const ChannelArguments& args);
 
-std::shared_ptr<::grpc_impl::Channel> CreateTestChannel(
+std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& credential_type,
     const std::shared_ptr<CallCredentials>& creds);
 
@@ -71,30 +73,32 @@ std::shared_ptr<Channel> CreateTestChannel(
     const std::shared_ptr<CallCredentials>& creds,
     std::vector<
         std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
-        interceptor_creators);
+    interceptor_creators);
 
 std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& override_hostname,
     testing::transport_security security_type, bool use_prod_roots,
-    const std::shared_ptr<CallCredentials>& creds, const ChannelArguments& args,
+    const std::shared_ptr<CallCredentials>& creds,
+    const ChannelArguments& args,
     std::vector<
         std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
-        interceptor_creators);
+    interceptor_creators);
 
 std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& cred_type,
     const grpc::string& override_hostname, bool use_prod_roots,
-    const std::shared_ptr<CallCredentials>& creds, const ChannelArguments& args,
+    const std::shared_ptr<CallCredentials>& creds,
+    const ChannelArguments& args,
     std::vector<
         std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
-        interceptor_creators);
+    interceptor_creators);
 
 std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& credential_type,
     const std::shared_ptr<CallCredentials>& creds,
     std::vector<
         std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
-        interceptor_creators);
+    interceptor_creators);
 
 }  // namespace grpc
 


### PR DESCRIPTION
This PR mostly is moving usage of Channel, Channel Arguments, Channel Credentials, Completion Queue and ServerCompletionQueue