### PR TITLE
1.21.4 interop for cxx, csharp, php, ruby and python

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -97,6 +97,7 @@ LANG_RELEASE_MATRIX = {
         ('v1.18.0', ReleaseInfo(testcases_file='cxx__v1.0.1')),
         ('v1.19.0', ReleaseInfo(testcases_file='cxx__v1.0.1')),
         ('v1.20.0', ReleaseInfo()),
+        ('v1.21.4', ReleaseInfo()),
     ]),
     'go':
     OrderedDict(
@@ -209,6 +210,7 @@ LANG_RELEASE_MATRIX = {
         ('v1.18.0', ReleaseInfo()),
         ('v1.19.0', ReleaseInfo()),
         ('v1.20.0', ReleaseInfo()),
+        ('v1.21.4', ReleaseInfo()),
     ]),
     'node':
     OrderedDict([
@@ -257,6 +259,7 @@ LANG_RELEASE_MATRIX = {
          ])),
         ('v1.19.0', ReleaseInfo()),
         ('v1.20.0', ReleaseInfo()),
+        ('v1.21.4', ReleaseInfo()),
         # TODO: https://github.com/grpc/grpc/issues/18262.
         # If you are not encountering the error in above issue
         # go ahead and upload the docker image for new releases.
@@ -281,6 +284,7 @@ LANG_RELEASE_MATRIX = {
         ('v1.16.0', ReleaseInfo(testcases_file='php__v1.0.1')),
         ('v1.17.1', ReleaseInfo(testcases_file='php__v1.0.1')),
         ('v1.18.0', ReleaseInfo()),
+        ('v1.21.4', ReleaseInfo()),
         # TODO:https://github.com/grpc/grpc/issues/18264
         # Error in above issues needs to be resolved.
     ]),
@@ -312,5 +316,6 @@ LANG_RELEASE_MATRIX = {
         ('v1.18.0', ReleaseInfo(testcases_file='csharp__v1.18.0')),
         ('v1.19.0', ReleaseInfo(testcases_file='csharp__v1.18.0')),
         ('v1.20.0', ReleaseInfo()),
+        ('v1.21.4', ReleaseInfo()),
     ]),
 }


### PR DESCRIPTION
1.21.4 interop for cxx, csharp, php, ruby and python. Local tests are passing. 