### PR TITLE
Cap deadline to 99999999 seconds on wire

### DIFF
--- a/src/core/lib/transport/timeout_encoding.cc
+++ b/src/core/lib/transport/timeout_encoding.cc
@@ -44,6 +44,9 @@ static int64_t round_up_to_three_sig_figs(int64_t x) {
 /* encode our minimum viable timeout value */
 static void enc_tiny(char* buffer) { memcpy(buffer, "1n", 3); }
 
+/* encode our maximum timeout value, about 1157 days */
+static void enc_huge(char* buffer) { memcpy(buffer, "99999999S", 10); }
+
 static void enc_ext(char* buffer, int64_t value, char ext) {
   int n = int64_ttoa(value, buffer);
   buffer[n] = ext;
@@ -51,6 +54,7 @@ static void enc_ext(char* buffer, int64_t value, char ext) {
 }
 
 static void enc_seconds(char* buffer, int64_t sec) {
+  sec = round_up_to_three_sig_figs(sec);
   if (sec % 3600 == 0) {
     enc_ext(buffer, sec / 3600, 'H');
   } else if (sec % 60 == 0) {
@@ -74,10 +78,13 @@ static void enc_millis(char* buffer, int64_t x) {
 }
 
 void grpc_http2_encode_timeout(grpc_millis timeout, char* buffer) {
+  const grpc_millis kMaxTimeout = 99999999000;
   if (timeout <= 0) {
     enc_tiny(buffer);
   } else if (timeout < 1000 * GPR_MS_PER_SEC) {
     enc_millis(buffer, timeout);
+  } else if (timeout >= kMaxTimeout) {
+    enc_huge(buffer);
   } else {
     enc_seconds(buffer,
                 timeout / GPR_MS_PER_SEC + (timeout % GPR_MS_PER_SEC != 0));

--- a/src/core/lib/transport/timeout_encoding.h
+++ b/src/core/lib/transport/timeout_encoding.h
@@ -27,10 +27,11 @@
 #include "src/core/lib/gpr/string.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 
-#define GRPC_HTTP2_TIMEOUT_ENCODE_MIN_BUFSIZE (GPR_LTOA_MIN_BUFSIZE + 1)
+#define GRPC_HTTP2_TIMEOUT_ENCODE_MIN_BUFSIZE 10
 
 /* Encode/decode timeouts to the GRPC over HTTP/2 format;
-   encoding may round up arbitrarily */
+   encoding may round up arbitrarily. If the timeout is larger than about 1157
+   days, it will be capped and "99999999S" will be sent on the wire. */
 void grpc_http2_encode_timeout(grpc_millis timeout, char* buffer);
 int grpc_http2_decode_timeout(const grpc_slice& text, grpc_millis* timeout);
 

--- a/src/csharp/Grpc.Core.Tests/ContextPropagationTest.cs
+++ b/src/csharp/Grpc.Core.Tests/ContextPropagationTest.cs
@@ -108,8 +108,8 @@ namespace Grpc.Core.Tests
             var deadline = DateTime.UtcNow.AddDays(7);
             helper.UnaryHandler = new UnaryServerMethod<string, string>((request, context) =>
             {
-                Assert.IsTrue(context.Deadline < deadline.AddMinutes(1));
-                Assert.IsTrue(context.Deadline > deadline.AddMinutes(-1));
+                Assert.IsTrue(context.Deadline < deadline.AddHours(1));
+                Assert.IsTrue(context.Deadline > deadline.AddHours(-1));
                 return Task.FromResult("PASS");
             });
 

--- a/src/csharp/Grpc.Core.Tests/TimeoutsTest.cs
+++ b/src/csharp/Grpc.Core.Tests/TimeoutsTest.cs
@@ -80,7 +80,7 @@ namespace Grpc.Core.Tests
                 // A fairly relaxed check that the deadline set by client and deadline seen by server
                 // are in agreement. C core takes care of the work with transferring deadline over the wire,
                 // so we don't need an exact check here.
-                Assert.IsTrue(Math.Abs((clientDeadline - context.Deadline).TotalMilliseconds) < 5000);
+                Assert.IsTrue(Math.Abs((clientDeadline - context.Deadline).TotalHours) < 1);
                 return Task.FromResult("PASS");
             });
             Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(deadline: clientDeadline)), "abc");

--- a/test/core/transport/timeout_encoding_test.cc
+++ b/test/core/transport/timeout_encoding_test.cc
@@ -62,6 +62,9 @@ void test_encoding(void) {
   assert_encodes_as(20 * 60 * GPR_MS_PER_SEC, "20M");
   assert_encodes_as(60 * 60 * GPR_MS_PER_SEC, "1H");
   assert_encodes_as(10 * 60 * 60 * GPR_MS_PER_SEC, "10H");
+  assert_encodes_as(60 * 60 * GPR_MS_PER_SEC - 100, "1H");
+  assert_encodes_as(100 * 60 * 60 * GPR_MS_PER_SEC, "100H");
+  assert_encodes_as(100000000000, "99999999S");
 }
 
 static void assert_decodes_as(const char* buffer, grpc_millis expected) {


### PR DESCRIPTION
- cap deadline to 99,999,999 seconds on the wire
- when time out is over the limit, send "99999999S" on the wire.
- takes only 3 significant digits when timeout is larger than 1000 seconds.
- reduce the timeout encoding buffer size to 10.

This is to conform to the standard that grpc-timeout value should have at most 8 digits. While we can set separate limits for hours, minutes and seconds, 1157 days seems to be a long enough timeout cap for rpcs.