### PR TITLE
Proper way to include third_party/upb in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,9 @@ set_property(CACHE gRPC_GFLAGS_PROVIDER PROPERTY STRINGS "module" "package")
 set(gRPC_BENCHMARK_PROVIDER "module" CACHE STRING "Provider of benchmark library")
 set_property(CACHE gRPC_BENCHMARK_PROVIDER PROPERTY STRINGS "module" "package")
 
+set(gRPC_UPB_PROVIDER "module" CACHE STRING "Provider of upb library")
+set_property(CACHE gRPC_UPB_PROVIDER PROPERTY STRINGS "module" "package")
+
 set(gRPC_USE_PROTO_LITE OFF CACHE BOOL "Use the protobuf-lite library")
 
 if(UNIX)

--- a/cmake/upb.cmake
+++ b/cmake/upb.cmake
@@ -1,4 +1,4 @@
-# Copyright 2019 gRPC authors.
+# Copyright 2019 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(UPB_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/upb)
-
-set(_gRPC_UPB_INCLUDE_DIR "${UPB_ROOT_DIR}")
 set(_gRPC_UPB_GRPC_GENERATED_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/core/ext/upb-generated")
+
+if("${gRPC_UPB_PROVIDER}" STREQUAL "module")
+  if(NOT UPB_ROOT_DIR)
+    set(UPB_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/upb)
+  endif()
+  add_subdirectory(third_party/upb)
+
+  if(TARGET upb)
+    set(_gRPC_UPB_LIBRARIES upb)
+    set(_gRPC_UPB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/third_party/upb")
+  endif()
+elseif("${gRPC_UPB_PROVIDER}" STREQUAL "package")
+  # Use "CONFIG" as there is no built-in cmake module for upb.
+  find_package(upb REQUIRED CONFIG)
+  if(TARGET upb::upb)
+    set(_gRPC_UPB_LIBRARIES upb::upb)
+    set(_gRPC_UPB_INCLUDE_DIR ${upb_INCLUDE_DIR})
+  endif()
+  set(_gRPC_FIND_UPB "if(NOT upb_FOUND)\n  find_package(upb CONFIG)\nendif()")
+endif()

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -124,6 +124,9 @@
   set(gRPC_BENCHMARK_PROVIDER "module" CACHE STRING "Provider of benchmark library")
   set_property(CACHE gRPC_BENCHMARK_PROVIDER PROPERTY STRINGS "module" "package")
 
+  set(gRPC_UPB_PROVIDER "module" CACHE STRING "Provider of upb library")
+  set_property(CACHE gRPC_UPB_PROVIDER PROPERTY STRINGS "module" "package")
+
   set(gRPC_USE_PROTO_LITE OFF CACHE BOOL "Use the protobuf-lite library")
 
   if(UNIX)

--- a/test/distrib/cpp/run_distrib_test_cmake.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake.sh
@@ -52,10 +52,23 @@ make -j4 install
 cd ../../../..
 rm -rf third_party/protobuf  # wipe out to prevent influencing the grpc build
 
+# Install upb
+cd third_party/upb
+mkdir -p cmake/build
+cd cmake/build
+cmake -DCMAKE_BUILD_TYPE=Release ../..
+make -j4 install
+cd ../../../..
+rm -rf third_party/ubp  # wipe out to prevent influencing the grpc build
+
+# Just before installing gRPC, wipe out contents of all the submodules to simulate
+# a standalone build from an archive
+git submodule foreach 'cd $toplevel; rm -rf $name'
+
 # Install gRPC
 mkdir -p cmake/build
 cd cmake/build
-cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DgRPC_PROTOBUF_PROVIDER=package -DgRPC_ZLIB_PROVIDER=package -DgRPC_CARES_PROVIDER=package -DgRPC_SSL_PROVIDER=package -DCMAKE_BUILD_TYPE=Release ../..
+cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DgRPC_PROTOBUF_PROVIDER=package -DgRPC_ZLIB_PROVIDER=package -DgRPC_CARES_PROVIDER=package -DgRPC_SSL_PROVIDER=package -DgRPC_UPB_PROVIDER=package -DCMAKE_BUILD_TYPE=Release ../..
 make -j4 install
 cd ../..
 

--- a/test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh
+++ b/test/distrib/cpp/run_distrib_test_cmake_pkgconfig.sh
@@ -52,6 +52,10 @@ make -j4 install
 cd ../../../..
 rm -rf third_party/protobuf  # wipe out to prevent influencing the grpc build
 
+# Just before installing gRPC, wipe out contents of all the submodules to simulate
+# a standalone build from an archive
+git submodule foreach 'cd $toplevel; rm -rf $name'
+
 # Install gRPC
 mkdir -p cmake/build
 cd cmake/build


### PR DESCRIPTION
The way upb is included in our cmake build (added in https://github.com/grpc/grpc/pull/18258/files) is not aligned with how other dependencies are configured (we try to use CMakeLists.txt of the dependency if it's available). This PR fixes that (and also fixes some issues around it).
Including ubp in our cmake build properly will become more important once C-core starts depending on the ubp library (dependencies influence the installation story), which is not yet the case.

Fixes https://github.com/grpc/grpc/issues/18975

Supersedes https://github.com/grpc/grpc/pull/18984 and https://github.com/grpc/grpc/pull/19314