### PR TITLE
Fix C++ tests to run on iOS

### DIFF
--- a/src/core/lib/iomgr/iomgr_posix_cfstream.cc
+++ b/src/core/lib/iomgr/iomgr_posix_cfstream.cc
@@ -90,4 +90,6 @@ void grpc_set_default_iomgr_platform() {
   grpc_set_iomgr_platform_vtable(&vtable);
 }
 
+bool grpc_iomgr_run_in_background() { return false; }
+
 #endif /* GRPC_CFSTREAM_IOMGR */

--- a/test/cpp/common/channel_arguments_test.cc
+++ b/test/cpp/common/channel_arguments_test.cc
@@ -84,6 +84,10 @@ class ChannelArgumentsTest : public ::testing::Test {
     channel_args.SetChannelArgs(args);
   }
 
+  static void SetUpTestCase() { grpc_init(); }
+
+  static void TearDownTestCase() { grpc_shutdown(); }
+
   grpc::string GetDefaultUserAgentPrefix() {
     std::ostringstream user_agent_prefix;
     user_agent_prefix << "grpc-c++/" << Version();
@@ -252,8 +256,6 @@ TEST_F(ChannelArgumentsTest, SetUserAgentPrefix) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  grpc_init();
   int ret = RUN_ALL_TESTS();
-  grpc_shutdown();
   return ret;
 }

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -141,6 +141,12 @@ class ClientLbEnd2endTest : public ::testing::Test {
         creds_(new SecureChannelCredentials(
             grpc_fake_transport_security_credentials_create())) {}
 
+  static void SetUpTestCase() {
+    // Make the backup poller poll very frequently in order to pick up
+    // updates from all the subchannels's FDs.
+    GPR_GLOBAL_CONFIG_SET(grpc_client_channel_backup_poll_interval_ms, 1);
+  }
+
   void SetUp() override {
     grpc_init();
     response_generator_ =
@@ -1481,9 +1487,6 @@ TEST_F(ClientLbInterceptTrailingMetadataTest, InterceptsRetriesEnabled) {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
-  // Make the backup poller poll very frequently in order to pick up
-  // updates from all the subchannels's FDs.
-  GPR_GLOBAL_CONFIG_SET(grpc_client_channel_backup_poll_interval_ms, 1);
   ::testing::InitGoogleTest(&argc, argv);
   grpc::testing::TestEnvironment env(argc, argv);
   const auto result = RUN_ALL_TESTS();

--- a/test/cpp/end2end/filter_end2end_test.cc
+++ b/test/cpp/end2end/filter_end2end_test.cc
@@ -121,6 +121,12 @@ class FilterEnd2endTest : public ::testing::Test {
  protected:
   FilterEnd2endTest() : server_host_("localhost") {}
 
+  static void SetUpTestCase() {
+    gpr_log(GPR_ERROR, "In SetUpTestCase");
+    grpc::RegisterChannelFilter<ChannelDataImpl, CallDataImpl>(
+        "test-filter", GRPC_SERVER_CHANNEL, INT_MAX, nullptr);
+  }
+
   void SetUp() override {
     int port = grpc_pick_unused_port_or_die();
     server_address_ << server_host_ << ":" << port;
@@ -321,11 +327,6 @@ TEST_F(FilterEnd2endTest, SimpleBidiStreaming) {
   EXPECT_EQ(1, GetConnectionCounterValue());
 }
 
-void RegisterFilter() {
-  grpc::RegisterChannelFilter<ChannelDataImpl, CallDataImpl>(
-      "test-filter", GRPC_SERVER_CHANNEL, INT_MAX, nullptr);
-}
-
 }  // namespace
 }  // namespace testing
 }  // namespace grpc
@@ -333,6 +334,5 @@ void RegisterFilter() {
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  grpc::testing::RegisterFilter();
   return RUN_ALL_TESTS();
 }

--- a/test/cpp/end2end/service_config_end2end_test.cc
+++ b/test/cpp/end2end/service_config_end2end_test.cc
@@ -119,6 +119,12 @@ class ServiceConfigEnd2endTest : public ::testing::Test {
         creds_(new SecureChannelCredentials(
             grpc_fake_transport_security_credentials_create())) {}
 
+  static void SetUpTestCase() {
+    // Make the backup poller poll very frequently in order to pick up
+    // updates from all the subchannels's FDs.
+    GPR_GLOBAL_CONFIG_SET(grpc_client_channel_backup_poll_interval_ms, 1);
+  }
+
   void SetUp() override {
     grpc_init();
     response_generator_ =
@@ -611,9 +617,6 @@ TEST_F(ServiceConfigEnd2endTest,
 }  // namespace grpc
 
 int main(int argc, char** argv) {
-  // Make the backup poller poll very frequently in order to pick up
-  // updates from all the subchannels's FDs.
-  GPR_GLOBAL_CONFIG_SET(grpc_client_channel_backup_poll_interval_ms, 1);
   ::testing::InitGoogleTest(&argc, argv);
   grpc::testing::TestEnvironment env(argc, argv);
   const auto result = RUN_ALL_TESTS();

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -370,6 +370,15 @@ class XdsEnd2endTest : public ::testing::Test {
         client_load_reporting_interval_seconds_(
             client_load_reporting_interval_seconds) {}
 
+  static void SetUpTestCase() {
+    // Make the backup poller poll very frequently in order to pick up
+    // updates from all the subchannels's FDs.
+    GPR_GLOBAL_CONFIG_SET(grpc_client_channel_backup_poll_interval_ms, 1);
+    grpc_init();
+  }
+
+  static void TearDownTestCase() { grpc_shutdown(); }
+
   void SetUp() override {
     response_generator_ =
         grpc_core::MakeRefCounted<grpc_core::FakeResolverResponseGenerator>();
@@ -788,7 +797,7 @@ TEST_F(SingleBalancerTest, SecureNamingDeathTest) {
   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   // Make sure that we blow up (via abort() from the security connector) when
   // the name from the balancer doesn't match expectations.
-  ASSERT_DEATH(
+  ASSERT_DEATH_IF_SUPPORTED(
       {
         ResetStub(0, kApplicationTargetName_ + ";lb");
         SetNextResolution({},
@@ -1401,13 +1410,8 @@ class SingleBalancerWithClientLoadReportingTest : public XdsEnd2endTest {
 }  // namespace grpc
 
 int main(int argc, char** argv) {
-  // Make the backup poller poll very frequently in order to pick up
-  // updates from all the subchannels's FDs.
-  GPR_GLOBAL_CONFIG_SET(grpc_client_channel_backup_poll_interval_ms, 1);
-  grpc_init();
   grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   const auto result = RUN_ALL_TESTS();
-  grpc_shutdown();
   return result;
 }

--- a/test/cpp/grpclb/grpclb_api_test.cc
+++ b/test/cpp/grpclb/grpclb_api_test.cc
@@ -31,7 +31,12 @@ namespace {
 using grpc::lb::v1::LoadBalanceRequest;
 using grpc::lb::v1::LoadBalanceResponse;
 
-class GrpclbTest : public ::testing::Test {};
+class GrpclbTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() { grpc_init(); }
+
+  static void TearDownTestCase() { grpc_shutdown(); }
+};
 
 grpc::string Ip4ToPackedString(const char* ip_str) {
   struct in_addr ip4;
@@ -128,8 +133,6 @@ TEST_F(GrpclbTest, ParseResponseServerList) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  grpc_init();
   int ret = RUN_ALL_TESTS();
-  grpc_shutdown();
   return ret;
 }

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -177,7 +177,32 @@ void TestCancelActiveDNSQuery(ArgsStruct* args) {
   ArgsFinish(args);
 }
 
-TEST(CancelDuringAresQuery, TestCancelActiveDNSQuery) {
+class CancelDuringAresQuery : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    GPR_GLOBAL_CONFIG_SET(grpc_dns_resolver, "ares");
+    // Sanity check the time that it takes to run the test
+    // including the teardown time (the teardown
+    // part of the test involves cancelling the DNS query,
+    // which is the main point of interest for this test).
+    overall_deadline = grpc_timeout_seconds_to_deadline(4);
+    grpc_init();
+  }
+
+  static void TearDownTestCase() {
+    grpc_shutdown();
+    if (gpr_time_cmp(gpr_now(GPR_CLOCK_MONOTONIC), overall_deadline) > 0) {
+      gpr_log(GPR_ERROR, "Test took too long");
+      abort();
+    }
+  }
+
+ private:
+  static gpr_timespec overall_deadline;
+};
+gpr_timespec CancelDuringAresQuery::overall_deadline;
+
+TEST_F(CancelDuringAresQuery, TestCancelActiveDNSQuery) {
   grpc_core::ExecCtx exec_ctx;
   ArgsStruct args;
   ArgsInit(&args);
@@ -216,7 +241,7 @@ void MaybePollArbitraryPollsetTwice() {}
 
 #endif
 
-TEST(CancelDuringAresQuery, TestFdsAreDeletedFromPollsetSet) {
+TEST_F(CancelDuringAresQuery, TestFdsAreDeletedFromPollsetSet) {
   grpc_core::ExecCtx exec_ctx;
   ArgsStruct args;
   ArgsInit(&args);
@@ -352,18 +377,18 @@ void TestCancelDuringActiveQuery(
   EndTest(client, cq);
 }
 
-TEST(CancelDuringAresQuery,
-     TestHitDeadlineAndDestroyChannelDuringAresResolutionIsGraceful) {
+TEST_F(CancelDuringAresQuery,
+       TestHitDeadlineAndDestroyChannelDuringAresResolutionIsGraceful) {
   TestCancelDuringActiveQuery(NONE /* don't set query timeouts */);
 }
 
-TEST(
+TEST_F(
     CancelDuringAresQuery,
     TestHitDeadlineAndDestroyChannelDuringAresResolutionWithQueryTimeoutIsGraceful) {
   TestCancelDuringActiveQuery(SHORT /* set short query timeout */);
 }
 
-TEST(
+TEST_F(
     CancelDuringAresQuery,
     TestHitDeadlineAndDestroyChannelDuringAresResolutionWithZeroQueryTimeoutIsGraceful) {
   TestCancelDuringActiveQuery(ZERO /* disable query timeouts */);
@@ -374,18 +399,6 @@ TEST(
 int main(int argc, char** argv) {
   grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
-  GPR_GLOBAL_CONFIG_SET(grpc_dns_resolver, "ares");
-  // Sanity check the time that it takes to run the test
-  // including the teardown time (the teardown
-  // part of the test involves cancelling the DNS query,
-  // which is the main point of interest for this test).
-  gpr_timespec overall_deadline = grpc_timeout_seconds_to_deadline(4);
-  grpc_init();
   auto result = RUN_ALL_TESTS();
-  grpc_shutdown();
-  if (gpr_time_cmp(gpr_now(GPR_CLOCK_MONOTONIC), overall_deadline) > 0) {
-    gpr_log(GPR_ERROR, "Test took too long");
-    abort();
-  }
   return result;
 }

--- a/test/cpp/server/server_builder_test.cc
+++ b/test/cpp/server/server_builder_test.cc
@@ -44,13 +44,19 @@ const grpc::string& GetPort() {
   return g_port;
 }
 
-TEST(ServerBuilderTest, NoOp) { ServerBuilder b; }
+class ServerBuilderTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() { grpc_init(); }
 
-TEST(ServerBuilderTest, CreateServerNoPorts) {
+  static void TearDownTestCase() { grpc_shutdown(); }
+};
+TEST_F(ServerBuilderTest, NoOp) { ServerBuilder b; }
+
+TEST_F(ServerBuilderTest, CreateServerNoPorts) {
   ServerBuilder().RegisterService(&g_service).BuildAndStart()->Shutdown();
 }
 
-TEST(ServerBuilderTest, CreateServerOnePort) {
+TEST_F(ServerBuilderTest, CreateServerOnePort) {
   ServerBuilder()
       .RegisterService(&g_service)
       .AddListeningPort(GetPort(), InsecureServerCredentials())
@@ -58,7 +64,7 @@ TEST(ServerBuilderTest, CreateServerOnePort) {
       ->Shutdown();
 }
 
-TEST(ServerBuilderTest, CreateServerRepeatedPort) {
+TEST_F(ServerBuilderTest, CreateServerRepeatedPort) {
   ServerBuilder()
       .RegisterService(&g_service)
       .AddListeningPort(GetPort(), InsecureServerCredentials())
@@ -67,7 +73,7 @@ TEST(ServerBuilderTest, CreateServerRepeatedPort) {
       ->Shutdown();
 }
 
-TEST(ServerBuilderTest, CreateServerRepeatedPortWithDisallowedReusePort) {
+TEST_F(ServerBuilderTest, CreateServerRepeatedPortWithDisallowedReusePort) {
   EXPECT_EQ(ServerBuilder()
                 .RegisterService(&g_service)
                 .AddListeningPort(GetPort(), InsecureServerCredentials())
@@ -82,8 +88,6 @@ TEST(ServerBuilderTest, CreateServerRepeatedPortWithDisallowedReusePort) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  grpc_init();
   int ret = RUN_ALL_TESTS();
-  grpc_shutdown();
   return ret;
 }

--- a/test/cpp/server/server_builder_with_socket_mutator_test.cc
+++ b/test/cpp/server/server_builder_with_socket_mutator_test.cc
@@ -86,7 +86,14 @@ class MockSocketMutatorServerBuilderOption : public grpc::ServerBuilderOption {
   MockSocketMutator* mock_socket_mutator_;
 };
 
-TEST(ServerBuilderWithSocketMutatorTest, CreateServerWithSocketMutator) {
+class ServerBuilderWithSocketMutatorTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() { grpc_init(); }
+
+  static void TearDownTestCase() { grpc_shutdown(); }
+};
+
+TEST_F(ServerBuilderWithSocketMutatorTest, CreateServerWithSocketMutator) {
   auto address = "localhost:" + std::to_string(grpc_pick_unused_port_or_die());
   auto mock_socket_mutator = new MockSocketMutator();
   std::unique_ptr<grpc::ServerBuilderOption> mock_socket_mutator_builder_option(
@@ -109,8 +116,6 @@ TEST(ServerBuilderWithSocketMutatorTest, CreateServerWithSocketMutator) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  grpc_init();
   int ret = RUN_ALL_TESTS();
-  grpc_shutdown();
   return ret;
 }

--- a/test/cpp/util/byte_buffer_test.cc
+++ b/test/cpp/util/byte_buffer_test.cc
@@ -36,7 +36,12 @@ namespace {
 const char* kContent1 = "hello xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 const char* kContent2 = "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy world";
 
-class ByteBufferTest : public ::testing::Test {};
+class ByteBufferTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() { grpc_init(); }
+
+  static void TearDownTestCase() { grpc_shutdown(); }
+};
 
 TEST_F(ByteBufferTest, CopyCtor) {
   ByteBuffer buffer1;
@@ -121,8 +126,6 @@ TEST_F(ByteBufferTest, SerializationMakesCopy) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  grpc_init();
   int ret = RUN_ALL_TESTS();
-  grpc_shutdown();
   return ret;
 }

--- a/test/cpp/util/slice_test.cc
+++ b/test/cpp/util/slice_test.cc
@@ -33,6 +33,10 @@ const char* kContent = "hello xxxxxxxxxxxxxxxxxxxx world";
 
 class SliceTest : public ::testing::Test {
  protected:
+  static void SetUpTestCase() { grpc_init(); }
+
+  static void TearDownTestCase() { grpc_shutdown(); }
+
   void CheckSliceSize(const Slice& s, const grpc::string& content) {
     EXPECT_EQ(content.size(), s.size());
   }
@@ -132,8 +136,6 @@ TEST_F(SliceTest, Cslice) {
 
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  grpc_init();
   int ret = RUN_ALL_TESTS();
-  grpc_shutdown();
   return ret;
 }


### PR DESCRIPTION
- Define grpc_iomgr_run_in_background in iomgr_posix_cfstream.cc
- Use *_IF_SUPPORTED() for death tests
- Move global test init, teardown to SetUpTestCase, TearDownTestCase as GTMGoogleTestRun doesn't run main()