### PR TITLE
Repro of bazel test failure

### DIFF
--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -21,6 +21,30 @@ grpc_package(
     visibility = "public",
 )  # Allows external users to implement end2end tests.
 
+cc_test(
+    name = "my_test_notworking",
+    deps = [
+        "//external:gtest",
+        ":my_test_lib",
+    ],
+)
+
+cc_test(
+    name = "my_test_working",
+    srcs = ["my_test.cc"],
+    deps = [
+        "//external:gtest",
+    ],
+)
+
+cc_library(
+    name = "my_test_lib",
+    srcs = ["my_test.cc"],
+    deps = [
+        "//external:gtest",
+    ],
+)
+
 grpc_cc_library(
     name = "test_service_impl",
     testonly = True,

--- a/test/cpp/end2end/my_test.cc
+++ b/test/cpp/end2end/my_test.cc
@@ -1,0 +1,7 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  int ret = RUN_ALL_TESTS();
+  return ret;
+}


### PR DESCRIPTION
Reproduce bazel test failure.

\# this works as expected:
bazel test //test/cpp/end2end:my_test_working


\# fails with error: dyld: Symbol not found: __ZN7testing14InitGoogleTestEPiPPc
\# Missing symbol is testing::InitGoogleTest(int*, char**). So gtest lib is not linked correctly for some reason.
bazel test //test/cpp/end2end:my_test_notworking