### PR TITLE
 Modify codegen to use grpc_impl namespace and other cleanup

### DIFF
--- a/include/grpcpp/generic/generic_stub_impl.h
+++ b/include/grpcpp/generic/generic_stub_impl.h
@@ -21,6 +21,7 @@
 
 #include <functional>
 
+#include <grpcpp/client_context.h>
 #include <grpcpp/support/async_stream.h>
 #include <grpcpp/support/async_unary_call.h>
 #include <grpcpp/support/byte_buffer.h>

--- a/include/grpcpp/impl/codegen/async_generic_service.h
+++ b/include/grpcpp/impl/codegen/async_generic_service.h
@@ -33,7 +33,7 @@ typedef ServerAsyncResponseWriter<ByteBuffer> GenericServerAsyncResponseWriter;
 typedef ServerAsyncReader<ByteBuffer, ByteBuffer> GenericServerAsyncReader;
 typedef ServerAsyncWriter<ByteBuffer> GenericServerAsyncWriter;
 
-class GenericServerContext final : public ServerContext {
+class GenericServerContext final : public ::grpc_impl::ServerContext {
  public:
   const grpc::string& method() const { return method_; }
   const grpc::string& host() const { return host_; }
@@ -99,7 +99,7 @@ class ServerGenericBidiReactor
   virtual void OnStarted(GenericServerContext* context) {}
 
  private:
-  void OnStarted(ServerContext* ctx) final {
+  void OnStarted(::grpc_impl::ServerContext* ctx) final {
     OnStarted(static_cast<GenericServerContext*>(ctx));
   }
 };

--- a/include/grpcpp/impl/codegen/async_stream.h
+++ b/include/grpcpp/impl/codegen/async_stream.h
@@ -22,7 +22,7 @@
 #include <grpcpp/impl/codegen/call.h>
 #include <grpcpp/impl/codegen/channel_interface.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
-#include <grpcpp/impl/codegen/server_context.h>
+#include <grpcpp/impl/codegen/server_context_impl.h>
 #include <grpcpp/impl/codegen/service_type.h>
 #include <grpcpp/impl/codegen/status.h>
 
@@ -181,7 +181,7 @@ class ClientAsyncReaderFactory {
   static ClientAsyncReader<R>* Create(ChannelInterface* channel,
                                       CompletionQueue* cq,
                                       const ::grpc::internal::RpcMethod& method,
-                                      ClientContext* context, const W& request,
+                                      ::grpc_impl::ClientContext* context, const W& request,
                                       bool start, void* tag) {
     ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
     return new (g_core_codegen_interface->grpc_call_arena_alloc(
@@ -260,7 +260,7 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
  private:
   friend class internal::ClientAsyncReaderFactory<R>;
   template <class W>
-  ClientAsyncReader(::grpc::internal::Call call, ClientContext* context,
+  ClientAsyncReader(::grpc::internal::Call call, ::grpc_impl::ClientContext* context,
                     const W& request, bool start, void* tag)
       : context_(context), call_(call), started_(start) {
     // TODO(ctiller): don't assert
@@ -280,7 +280,7 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
     call_.PerformOps(&init_ops_);
   }
 
-  ClientContext* context_;
+  ::grpc_impl::ClientContext* context_;
   ::grpc::internal::Call call_;
   bool started_;
   ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
@@ -329,7 +329,7 @@ class ClientAsyncWriterFactory {
   static ClientAsyncWriter<W>* Create(ChannelInterface* channel,
                                       CompletionQueue* cq,
                                       const ::grpc::internal::RpcMethod& method,
-                                      ClientContext* context, R* response,
+                                      ::grpc_impl::ClientContext* context, R* response,
                                       bool start, void* tag) {
     ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
     return new (g_core_codegen_interface->grpc_call_arena_alloc(
@@ -426,7 +426,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
  private:
   friend class internal::ClientAsyncWriterFactory<W>;
   template <class R>
-  ClientAsyncWriter(::grpc::internal::Call call, ClientContext* context,
+  ClientAsyncWriter(::grpc::internal::Call call, ::grpc_impl::ClientContext* context,
                     R* response, bool start, void* tag)
       : context_(context), call_(call), started_(start) {
     finish_ops_.RecvMessage(response);
@@ -449,7 +449,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
     }
   }
 
-  ClientContext* context_;
+  ::grpc_impl::ClientContext* context_;
   ::grpc::internal::Call call_;
   bool started_;
   ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata>
@@ -493,7 +493,7 @@ class ClientAsyncReaderWriterFactory {
   /// used to send to the server when starting the call.
   static ClientAsyncReaderWriter<W, R>* Create(
       ChannelInterface* channel, CompletionQueue* cq,
-      const ::grpc::internal::RpcMethod& method, ClientContext* context,
+      const ::grpc::internal::RpcMethod& method, ::grpc_impl::ClientContext* context,
       bool start, void* tag) {
     ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
 
@@ -599,7 +599,7 @@ class ClientAsyncReaderWriter final
 
  private:
   friend class internal::ClientAsyncReaderWriterFactory<W, R>;
-  ClientAsyncReaderWriter(::grpc::internal::Call call, ClientContext* context,
+  ClientAsyncReaderWriter(::grpc::internal::Call call, ::grpc_impl::ClientContext* context,
                           bool start, void* tag)
       : context_(context), call_(call), started_(start) {
     if (start) {
@@ -620,7 +620,7 @@ class ClientAsyncReaderWriter final
     }
   }
 
-  ClientContext* context_;
+  ::grpc_impl::ClientContext* context_;
   ::grpc::internal::Call call_;
   bool started_;
   ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata>
@@ -696,7 +696,7 @@ class ServerAsyncReaderInterface
 template <class W, class R>
 class ServerAsyncReader final : public ServerAsyncReaderInterface<W, R> {
  public:
-  explicit ServerAsyncReader(ServerContext* ctx)
+  explicit ServerAsyncReader(::grpc_impl::ServerContext* ctx)
       : call_(nullptr, nullptr, nullptr), ctx_(ctx) {}
 
   /// See \a ServerAsyncStreamingInterface::SendInitialMetadata for semantics.
@@ -782,7 +782,7 @@ class ServerAsyncReader final : public ServerAsyncReaderInterface<W, R> {
   void BindCall(::grpc::internal::Call* call) override { call_ = *call; }
 
   ::grpc::internal::Call call_;
-  ServerContext* ctx_;
+  ::grpc_impl::ServerContext* ctx_;
   ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
       meta_ops_;
   ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvMessage<R>> read_ops_;
@@ -843,7 +843,7 @@ class ServerAsyncWriterInterface
 template <class W>
 class ServerAsyncWriter final : public ServerAsyncWriterInterface<W> {
  public:
-  explicit ServerAsyncWriter(ServerContext* ctx)
+  explicit ServerAsyncWriter(::grpc_impl::ServerContext* ctx)
       : call_(nullptr, nullptr, nullptr), ctx_(ctx) {}
 
   /// See \a ServerAsyncStreamingInterface::SendInitialMetadata for semantics.
@@ -940,7 +940,7 @@ class ServerAsyncWriter final : public ServerAsyncWriterInterface<W> {
   }
 
   ::grpc::internal::Call call_;
-  ServerContext* ctx_;
+  ::grpc_impl::ServerContext* ctx_;
   ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
       meta_ops_;
   ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,
@@ -1009,7 +1009,7 @@ template <class W, class R>
 class ServerAsyncReaderWriter final
     : public ServerAsyncReaderWriterInterface<W, R> {
  public:
-  explicit ServerAsyncReaderWriter(ServerContext* ctx)
+  explicit ServerAsyncReaderWriter(::grpc_impl::ServerContext* ctx)
       : call_(nullptr, nullptr, nullptr), ctx_(ctx) {}
 
   /// See \a ServerAsyncStreamingInterface::SendInitialMetadata for semantics.
@@ -1114,7 +1114,7 @@ class ServerAsyncReaderWriter final
   }
 
   ::grpc::internal::Call call_;
-  ServerContext* ctx_;
+  ::grpc_impl::ServerContext* ctx_;
   ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
       meta_ops_;
   ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvMessage<R>> read_ops_;

--- a/include/grpcpp/impl/codegen/async_stream.h
+++ b/include/grpcpp/impl/codegen/async_stream.h
@@ -181,8 +181,8 @@ class ClientAsyncReaderFactory {
   static ClientAsyncReader<R>* Create(ChannelInterface* channel,
                                       CompletionQueue* cq,
                                       const ::grpc::internal::RpcMethod& method,
-                                      ::grpc_impl::ClientContext* context, const W& request,
-                                      bool start, void* tag) {
+                                      ::grpc_impl::ClientContext* context,
+                                      const W& request, bool start, void* tag) {
     ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
     return new (g_core_codegen_interface->grpc_call_arena_alloc(
         call.call(), sizeof(ClientAsyncReader<R>)))
@@ -260,8 +260,9 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
  private:
   friend class internal::ClientAsyncReaderFactory<R>;
   template <class W>
-  ClientAsyncReader(::grpc::internal::Call call, ::grpc_impl::ClientContext* context,
-                    const W& request, bool start, void* tag)
+  ClientAsyncReader(::grpc::internal::Call call,
+                    ::grpc_impl::ClientContext* context, const W& request,
+                    bool start, void* tag)
       : context_(context), call_(call), started_(start) {
     // TODO(ctiller): don't assert
     GPR_CODEGEN_ASSERT(init_ops_.SendMessage(request).ok());
@@ -329,8 +330,8 @@ class ClientAsyncWriterFactory {
   static ClientAsyncWriter<W>* Create(ChannelInterface* channel,
                                       CompletionQueue* cq,
                                       const ::grpc::internal::RpcMethod& method,
-                                      ::grpc_impl::ClientContext* context, R* response,
-                                      bool start, void* tag) {
+                                      ::grpc_impl::ClientContext* context,
+                                      R* response, bool start, void* tag) {
     ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
     return new (g_core_codegen_interface->grpc_call_arena_alloc(
         call.call(), sizeof(ClientAsyncWriter<W>)))
@@ -426,8 +427,9 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
  private:
   friend class internal::ClientAsyncWriterFactory<W>;
   template <class R>
-  ClientAsyncWriter(::grpc::internal::Call call, ::grpc_impl::ClientContext* context,
-                    R* response, bool start, void* tag)
+  ClientAsyncWriter(::grpc::internal::Call call,
+                    ::grpc_impl::ClientContext* context, R* response,
+                    bool start, void* tag)
       : context_(context), call_(call), started_(start) {
     finish_ops_.RecvMessage(response);
     finish_ops_.AllowNoMessage();
@@ -493,8 +495,8 @@ class ClientAsyncReaderWriterFactory {
   /// used to send to the server when starting the call.
   static ClientAsyncReaderWriter<W, R>* Create(
       ChannelInterface* channel, CompletionQueue* cq,
-      const ::grpc::internal::RpcMethod& method, ::grpc_impl::ClientContext* context,
-      bool start, void* tag) {
+      const ::grpc::internal::RpcMethod& method,
+      ::grpc_impl::ClientContext* context, bool start, void* tag) {
     ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
 
     return new (g_core_codegen_interface->grpc_call_arena_alloc(
@@ -599,8 +601,9 @@ class ClientAsyncReaderWriter final
 
  private:
   friend class internal::ClientAsyncReaderWriterFactory<W, R>;
-  ClientAsyncReaderWriter(::grpc::internal::Call call, ::grpc_impl::ClientContext* context,
-                          bool start, void* tag)
+  ClientAsyncReaderWriter(::grpc::internal::Call call,
+                          ::grpc_impl::ClientContext* context, bool start,
+                          void* tag)
       : context_(context), call_(call), started_(start) {
     if (start) {
       StartCallInternal(tag);

--- a/include/grpcpp/impl/codegen/async_unary_call.h
+++ b/include/grpcpp/impl/codegen/async_unary_call.h
@@ -81,8 +81,8 @@ class ClientAsyncResponseReaderFactory {
   template <class W>
   static ClientAsyncResponseReader<R>* Create(
       ChannelInterface* channel, ::grpc_impl::CompletionQueue* cq,
-      const ::grpc::internal::RpcMethod& method, ::grpc_impl::ClientContext* context,
-      const W& request, bool start) {
+      const ::grpc::internal::RpcMethod& method,
+      ::grpc_impl::ClientContext* context, const W& request, bool start) {
     ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
     return new (g_core_codegen_interface->grpc_call_arena_alloc(
         call.call(), sizeof(ClientAsyncResponseReader<R>)))
@@ -162,7 +162,8 @@ class ClientAsyncResponseReader final
   bool initial_metadata_read_ = false;
 
   template <class W>
-  ClientAsyncResponseReader(::grpc::internal::Call call, ::grpc_impl::ClientContext* context,
+  ClientAsyncResponseReader(::grpc::internal::Call call,
+                            ::grpc_impl::ClientContext* context,
                             const W& request, bool start)
       : context_(context), call_(call), started_(start) {
     // Bind the metadata at time of StartCallInternal but set up the rest here

--- a/include/grpcpp/impl/codegen/async_unary_call.h
+++ b/include/grpcpp/impl/codegen/async_unary_call.h
@@ -22,8 +22,8 @@
 #include <assert.h>
 #include <grpcpp/impl/codegen/call.h>
 #include <grpcpp/impl/codegen/channel_interface.h>
-#include <grpcpp/impl/codegen/client_context.h>
-#include <grpcpp/impl/codegen/server_context.h>
+#include <grpcpp/impl/codegen/client_context_impl.h>
+#include <grpcpp/impl/codegen/server_context_impl.h>
 #include <grpcpp/impl/codegen/service_type.h>
 #include <grpcpp/impl/codegen/status.h>
 
@@ -80,8 +80,8 @@ class ClientAsyncResponseReaderFactory {
   /// used to send to the server when starting the call.
   template <class W>
   static ClientAsyncResponseReader<R>* Create(
-      ChannelInterface* channel, CompletionQueue* cq,
-      const ::grpc::internal::RpcMethod& method, ClientContext* context,
+      ChannelInterface* channel, ::grpc_impl::CompletionQueue* cq,
+      const ::grpc::internal::RpcMethod& method, ::grpc_impl::ClientContext* context,
       const W& request, bool start) {
     ::grpc::internal::Call call = channel->CreateCall(method, context, cq);
     return new (g_core_codegen_interface->grpc_call_arena_alloc(
@@ -156,13 +156,13 @@ class ClientAsyncResponseReader final
 
  private:
   friend class internal::ClientAsyncResponseReaderFactory<R>;
-  ClientContext* const context_;
+  ::grpc_impl::ClientContext* const context_;
   ::grpc::internal::Call call_;
   bool started_;
   bool initial_metadata_read_ = false;
 
   template <class W>
-  ClientAsyncResponseReader(::grpc::internal::Call call, ClientContext* context,
+  ClientAsyncResponseReader(::grpc::internal::Call call, ::grpc_impl::ClientContext* context,
                             const W& request, bool start)
       : context_(context), call_(call), started_(start) {
     // Bind the metadata at time of StartCallInternal but set up the rest here
@@ -199,7 +199,7 @@ template <class W>
 class ServerAsyncResponseWriter final
     : public internal::ServerAsyncStreamingInterface {
  public:
-  explicit ServerAsyncResponseWriter(ServerContext* ctx)
+  explicit ServerAsyncResponseWriter(::grpc_impl::ServerContext* ctx)
       : call_(nullptr, nullptr, nullptr), ctx_(ctx) {}
 
   /// See \a ServerAsyncStreamingInterface::SendInitialMetadata for semantics.
@@ -289,7 +289,7 @@ class ServerAsyncResponseWriter final
   void BindCall(::grpc::internal::Call* call) override { call_ = *call; }
 
   ::grpc::internal::Call call_;
-  ServerContext* ctx_;
+  ::grpc_impl::ServerContext* ctx_;
   ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata>
       meta_buf_;
   ::grpc::internal::CallOpSet<::grpc::internal::CallOpSendInitialMetadata,

--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -31,7 +31,7 @@
 #include <grpcpp/impl/codegen/call.h>
 #include <grpcpp/impl/codegen/call_hook.h>
 #include <grpcpp/impl/codegen/call_op_set_interface.h>
-#include <grpcpp/impl/codegen/client_context.h>
+#include <grpcpp/impl/codegen/client_context_impl.h>
 #include <grpcpp/impl/codegen/completion_queue.h>
 #include <grpcpp/impl/codegen/completion_queue_tag.h>
 #include <grpcpp/impl/codegen/config.h>
@@ -697,7 +697,7 @@ class CallOpRecvInitialMetadata {
  public:
   CallOpRecvInitialMetadata() : metadata_map_(nullptr) {}
 
-  void RecvInitialMetadata(ClientContext* context) {
+  void RecvInitialMetadata(::grpc_impl::ClientContext* context) {
     context->initial_metadata_received_ = true;
     metadata_map_ = &context->recv_initial_metadata_;
   }
@@ -746,7 +746,7 @@ class CallOpClientRecvStatus {
   CallOpClientRecvStatus()
       : recv_status_(nullptr), debug_error_string_(nullptr) {}
 
-  void ClientRecvStatus(ClientContext* context, Status* status) {
+  void ClientRecvStatus(::grpc_impl::ClientContext* context, Status* status) {
     client_context_ = context;
     metadata_map_ = &client_context_->trailing_metadata_;
     recv_status_ = status;
@@ -807,7 +807,7 @@ class CallOpClientRecvStatus {
 
  private:
   bool hijacked_ = false;
-  ClientContext* client_context_;
+  ::grpc_impl::ClientContext* client_context_;
   MetadataMap* metadata_map_;
   Status* recv_status_;
   const char* debug_error_string_;

--- a/include/grpcpp/impl/codegen/client_callback.h
+++ b/include/grpcpp/impl/codegen/client_callback.h
@@ -44,8 +44,8 @@ class RpcMethod;
 /// TODO(vjpai): Combine as much as possible with the blocking unary call code
 template <class InputMessage, class OutputMessage>
 void CallbackUnaryCall(ChannelInterface* channel, const RpcMethod& method,
-                       ClientContext* context, const InputMessage* request,
-                       OutputMessage* result,
+                       ::grpc_impl::ClientContext* context,
+                       const InputMessage* request, OutputMessage* result,
                        std::function<void(Status)> on_completion) {
   CallbackUnaryCallImpl<InputMessage, OutputMessage> x(
       channel, method, context, request, result, on_completion);
@@ -55,8 +55,8 @@ template <class InputMessage, class OutputMessage>
 class CallbackUnaryCallImpl {
  public:
   CallbackUnaryCallImpl(ChannelInterface* channel, const RpcMethod& method,
-                        ClientContext* context, const InputMessage* request,
-                        OutputMessage* result,
+                        ::grpc_impl::ClientContext* context,
+                        const InputMessage* request, OutputMessage* result,
                         std::function<void(Status)> on_completion) {
     CompletionQueue* cq = channel->CallbackCQ();
     GPR_CODEGEN_ASSERT(cq != nullptr);
@@ -550,7 +550,7 @@ class ClientCallbackReaderWriterImpl
   friend class ClientCallbackReaderWriterFactory<Request, Response>;
 
   ClientCallbackReaderWriterImpl(
-      Call call, ClientContext* context,
+      Call call, ::grpc_impl::ClientContext* context,
       ::grpc::experimental::ClientBidiReactor<Request, Response>* reactor)
       : context_(context),
         call_(call),
@@ -559,7 +559,7 @@ class ClientCallbackReaderWriterImpl
     this->BindReactor(reactor);
   }
 
-  ClientContext* const context_;
+  ::grpc_impl::ClientContext* const context_;
   Call call_;
   ::grpc::experimental::ClientBidiReactor<Request, Response>* const reactor_;
 
@@ -594,7 +594,7 @@ class ClientCallbackReaderWriterFactory {
  public:
   static void Create(
       ChannelInterface* channel, const ::grpc::internal::RpcMethod& method,
-      ClientContext* context,
+      ::grpc_impl::ClientContext* context,
       ::grpc::experimental::ClientBidiReactor<Request, Response>* reactor) {
     Call call = channel->CreateCall(method, context, channel->CallbackCQ());
 
@@ -692,7 +692,7 @@ class ClientCallbackReaderImpl
 
   template <class Request>
   ClientCallbackReaderImpl(
-      Call call, ClientContext* context, Request* request,
+      Call call, ::grpc_impl::ClientContext* context, Request* request,
       ::grpc::experimental::ClientReadReactor<Response>* reactor)
       : context_(context), call_(call), reactor_(reactor) {
     this->BindReactor(reactor);
@@ -701,7 +701,7 @@ class ClientCallbackReaderImpl
     start_ops_.ClientSendClose();
   }
 
-  ClientContext* const context_;
+  ::grpc_impl::ClientContext* const context_;
   Call call_;
   ::grpc::experimental::ClientReadReactor<Response>* const reactor_;
 
@@ -729,7 +729,7 @@ class ClientCallbackReaderFactory {
   template <class Request>
   static void Create(
       ChannelInterface* channel, const ::grpc::internal::RpcMethod& method,
-      ClientContext* context, const Request* request,
+      ::grpc_impl::ClientContext* context, const Request* request,
       ::grpc::experimental::ClientReadReactor<Response>* reactor) {
     Call call = channel->CreateCall(method, context, channel->CallbackCQ());
 
@@ -866,7 +866,7 @@ class ClientCallbackWriterImpl
 
   template <class Response>
   ClientCallbackWriterImpl(
-      Call call, ClientContext* context, Response* response,
+      Call call, ::grpc_impl::ClientContext* context, Response* response,
       ::grpc::experimental::ClientWriteReactor<Request>* reactor)
       : context_(context),
         call_(call),
@@ -877,7 +877,7 @@ class ClientCallbackWriterImpl
     finish_ops_.AllowNoMessage();
   }
 
-  ClientContext* const context_;
+  ::grpc_impl::ClientContext* const context_;
   Call call_;
   ::grpc::experimental::ClientWriteReactor<Request>* const reactor_;
 
@@ -909,7 +909,7 @@ class ClientCallbackWriterFactory {
   template <class Response>
   static void Create(
       ChannelInterface* channel, const ::grpc::internal::RpcMethod& method,
-      ClientContext* context, Response* response,
+      ::grpc_impl::ClientContext* context, Response* response,
       ::grpc::experimental::ClientWriteReactor<Request>* reactor) {
     Call call = channel->CreateCall(method, context, channel->CallbackCQ());
 
@@ -976,8 +976,8 @@ class ClientCallbackUnaryImpl final
   friend class ClientCallbackUnaryFactory;
 
   template <class Request, class Response>
-  ClientCallbackUnaryImpl(Call call, ClientContext* context, Request* request,
-                          Response* response,
+  ClientCallbackUnaryImpl(Call call, ::grpc_impl::ClientContext* context,
+                          Request* request, Response* response,
                           ::grpc::experimental::ClientUnaryReactor* reactor)
       : context_(context), call_(call), reactor_(reactor) {
     this->BindReactor(reactor);
@@ -988,7 +988,7 @@ class ClientCallbackUnaryImpl final
     finish_ops_.AllowNoMessage();
   }
 
-  ClientContext* const context_;
+  ::grpc_impl::ClientContext* const context_;
   Call call_;
   ::grpc::experimental::ClientUnaryReactor* const reactor_;
 
@@ -1011,8 +1011,8 @@ class ClientCallbackUnaryFactory {
   template <class Request, class Response>
   static void Create(ChannelInterface* channel,
                      const ::grpc::internal::RpcMethod& method,
-                     ClientContext* context, const Request* request,
-                     Response* response,
+                     ::grpc_impl::ClientContext* context,
+                     const Request* request, Response* response,
                      ::grpc::experimental::ClientUnaryReactor* reactor) {
     Call call = channel->CreateCall(method, context, channel->CallbackCQ());
 

--- a/include/grpcpp/impl/codegen/intercepted_channel.h
+++ b/include/grpcpp/impl/codegen/intercepted_channel.h
@@ -49,7 +49,7 @@ class InterceptedChannel : public ChannelInterface {
   InterceptedChannel(ChannelInterface* channel, size_t pos)
       : channel_(channel), interceptor_pos_(pos) {}
 
-  Call CreateCall(const RpcMethod& method, ClientContext* context,
+  Call CreateCall(const RpcMethod& method, ::grpc_impl::ClientContext* context,
                   ::grpc_impl::CompletionQueue* cq) override {
     return channel_->CreateCallInternal(method, context, cq, interceptor_pos_);
   }

--- a/include/grpcpp/impl/codegen/method_handler_impl.h
+++ b/include/grpcpp/impl/codegen/method_handler_impl.h
@@ -54,9 +54,9 @@ class RpcMethodHandler : public MethodHandler {
  public:
   RpcMethodHandler(
       std::function<Status(ServiceType*, ::grpc_impl::ServerContext*,
-                                        const RequestType*, ResponseType*)>
-                       func,
-                   ServiceType* service)
+                           const RequestType*, ResponseType*)>
+          func,
+      ServiceType* service)
       : func_(func), service_(service) {}
 
   void RunHandler(const HandlerParameter& param) final {

--- a/include/grpcpp/impl/codegen/method_handler_impl.h
+++ b/include/grpcpp/impl/codegen/method_handler_impl.h
@@ -52,7 +52,8 @@ Status CatchingFunctionHandler(Callable&& handler) {
 template <class ServiceType, class RequestType, class ResponseType>
 class RpcMethodHandler : public MethodHandler {
  public:
-  RpcMethodHandler(std::function<Status(ServiceType*, ServerContext*,
+  RpcMethodHandler(
+      std::function<Status(ServiceType*, ::grpc_impl::ServerContext*,
                                         const RequestType*, ResponseType*)>
                        func,
                    ServiceType* service)
@@ -103,8 +104,8 @@ class RpcMethodHandler : public MethodHandler {
 
  private:
   /// Application provided rpc handler function.
-  std::function<Status(ServiceType*, ServerContext*, const RequestType*,
-                       ResponseType*)>
+  std::function<Status(ServiceType*, ::grpc_impl::ServerContext*,
+                       const RequestType*, ResponseType*)>
       func_;
   // The class the above handler function lives in.
   ServiceType* service_;
@@ -115,7 +116,7 @@ template <class ServiceType, class RequestType, class ResponseType>
 class ClientStreamingHandler : public MethodHandler {
  public:
   ClientStreamingHandler(
-      std::function<Status(ServiceType*, ServerContext*,
+      std::function<Status(ServiceType*, ::grpc_impl::ServerContext*,
                            ServerReader<RequestType>*, ResponseType*)>
           func,
       ServiceType* service)
@@ -147,8 +148,8 @@ class ClientStreamingHandler : public MethodHandler {
   }
 
  private:
-  std::function<Status(ServiceType*, ServerContext*, ServerReader<RequestType>*,
-                       ResponseType*)>
+  std::function<Status(ServiceType*, ::grpc_impl::ServerContext*,
+                       ServerReader<RequestType>*, ResponseType*)>
       func_;
   ServiceType* service_;
 };
@@ -158,8 +159,8 @@ template <class ServiceType, class RequestType, class ResponseType>
 class ServerStreamingHandler : public MethodHandler {
  public:
   ServerStreamingHandler(
-      std::function<Status(ServiceType*, ServerContext*, const RequestType*,
-                           ServerWriter<ResponseType>*)>
+      std::function<Status(ServiceType*, ::grpc_impl::ServerContext*,
+                           const RequestType*, ServerWriter<ResponseType>*)>
           func,
       ServiceType* service)
       : func_(func), service_(service) {}
@@ -207,8 +208,8 @@ class ServerStreamingHandler : public MethodHandler {
   }
 
  private:
-  std::function<Status(ServiceType*, ServerContext*, const RequestType*,
-                       ServerWriter<ResponseType>*)>
+  std::function<Status(ServiceType*, ::grpc_impl::ServerContext*,
+                       const RequestType*, ServerWriter<ResponseType>*)>
       func_;
   ServiceType* service_;
 };
@@ -224,7 +225,7 @@ template <class Streamer, bool WriteNeeded>
 class TemplatedBidiStreamingHandler : public MethodHandler {
  public:
   TemplatedBidiStreamingHandler(
-      std::function<Status(ServerContext*, Streamer*)> func)
+      std::function<Status(::grpc_impl::ServerContext*, Streamer*)> func)
       : func_(func), write_needed_(WriteNeeded) {}
 
   void RunHandler(const HandlerParameter& param) final {
@@ -256,7 +257,7 @@ class TemplatedBidiStreamingHandler : public MethodHandler {
   }
 
  private:
-  std::function<Status(ServerContext*, Streamer*)> func_;
+  std::function<Status(::grpc_impl::ServerContext*, Streamer*)> func_;
   const bool write_needed_;
 };
 
@@ -266,7 +267,7 @@ class BidiStreamingHandler
           ServerReaderWriter<ResponseType, RequestType>, false> {
  public:
   BidiStreamingHandler(
-      std::function<Status(ServiceType*, ServerContext*,
+      std::function<Status(ServiceType*, ::grpc_impl::ServerContext*,
                            ServerReaderWriter<ResponseType, RequestType>*)>
           func,
       ServiceType* service)
@@ -281,7 +282,7 @@ class StreamedUnaryHandler
           ServerUnaryStreamer<RequestType, ResponseType>, true> {
  public:
   explicit StreamedUnaryHandler(
-      std::function<Status(ServerContext*,
+      std::function<Status(::grpc_impl::ServerContext*,
                            ServerUnaryStreamer<RequestType, ResponseType>*)>
           func)
       : TemplatedBidiStreamingHandler<
@@ -294,7 +295,7 @@ class SplitServerStreamingHandler
           ServerSplitStreamer<RequestType, ResponseType>, false> {
  public:
   explicit SplitServerStreamingHandler(
-      std::function<Status(ServerContext*,
+      std::function<Status(::grpc_impl::ServerContext*,
                            ServerSplitStreamer<RequestType, ResponseType>*)>
           func)
       : TemplatedBidiStreamingHandler<
@@ -307,7 +308,7 @@ template <StatusCode code>
 class ErrorMethodHandler : public MethodHandler {
  public:
   template <class T>
-  static void FillOps(ServerContext* context, T* ops) {
+  static void FillOps(::grpc_impl::ServerContext* context, T* ops) {
     Status status(code, "");
     if (!context->sent_initial_metadata_) {
       ops->SendInitialMetadata(&context->initial_metadata_,

--- a/include/grpcpp/impl/codegen/server_interface.h
+++ b/include/grpcpp/impl/codegen/server_interface.h
@@ -26,7 +26,7 @@
 #include <grpcpp/impl/codegen/completion_queue_tag.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
 #include <grpcpp/impl/codegen/rpc_service_method.h>
-#include <grpcpp/impl/codegen/server_context.h>
+#include <grpcpp/impl/codegen/server_context_impl.h>
 
 namespace grpc_impl {
 

--- a/include/grpcpp/impl/codegen/sync_stream.h
+++ b/include/grpcpp/impl/codegen/sync_stream.h
@@ -120,7 +120,7 @@ class WriterInterface {
   ///
   /// \param msg The message to be written to the stream.
   ///
-  /// \return \a true on success, \a false when the stream has been closed.access/marconi/common/grpc/async_grpc_container.h
+  /// \return \a true on success, \a false when the stream has been closed.
   inline bool Write(const W& msg) { return Write(msg, WriteOptions()); }
 
   /// Write \a msg and coalesce it with the writing of trailing metadata, using
@@ -142,7 +142,7 @@ class WriterInterface {
   }
 };
 
-}  // namespace internalaccess/marconi/common/grpc/async_grpc_container.h
+}  // namespace internal
 
 /// Client-side interface for streaming reads of message of type \a R.
 template <class R>

--- a/include/grpcpp/impl/codegen/sync_stream.h
+++ b/include/grpcpp/impl/codegen/sync_stream.h
@@ -21,10 +21,10 @@
 
 #include <grpcpp/impl/codegen/call.h>
 #include <grpcpp/impl/codegen/channel_interface.h>
-#include <grpcpp/impl/codegen/client_context.h>
+#include <grpcpp/impl/codegen/client_context_impl.h>
 #include <grpcpp/impl/codegen/completion_queue.h>
 #include <grpcpp/impl/codegen/core_codegen_interface.h>
-#include <grpcpp/impl/codegen/server_context.h>
+#include <grpcpp/impl/codegen/server_context_impl.h>
 #include <grpcpp/impl/codegen/service_type.h>
 #include <grpcpp/impl/codegen/status.h>
 
@@ -120,7 +120,7 @@ class WriterInterface {
   ///
   /// \param msg The message to be written to the stream.
   ///
-  /// \return \a true on success, \a false when the stream has been closed.
+  /// \return \a true on success, \a false when the stream has been closed.access/marconi/common/grpc/async_grpc_container.h
   inline bool Write(const W& msg) { return Write(msg, WriteOptions()); }
 
   /// Write \a msg and coalesce it with the writing of trailing metadata, using
@@ -142,7 +142,7 @@ class WriterInterface {
   }
 };
 
-}  // namespace internal
+}  // namespace internalaccess/marconi/common/grpc/async_grpc_container.h
 
 /// Client-side interface for streaming reads of message of type \a R.
 template <class R>
@@ -163,7 +163,8 @@ class ClientReaderFactory {
   template <class W>
   static ClientReader<R>* Create(ChannelInterface* channel,
                                  const ::grpc::internal::RpcMethod& method,
-                                 ClientContext* context, const W& request) {
+                                 ::grpc_impl::ClientContext* context,
+                                 const W& request) {
     return new ClientReader<R>(channel, method, context, request);
   }
 };
@@ -230,8 +231,8 @@ class ClientReader final : public ClientReaderInterface<R> {
 
  private:
   friend class internal::ClientReaderFactory<R>;
-  ClientContext* context_;
-  CompletionQueue cq_;
+  ::grpc_impl::ClientContext* context_;
+  ::grpc_impl::CompletionQueue cq_;
   ::grpc::internal::Call call_;
 
   /// Block to create a stream and write the initial metadata and \a request
@@ -240,7 +241,7 @@ class ClientReader final : public ClientReaderInterface<R> {
   template <class W>
   ClientReader(::grpc::ChannelInterface* channel,
                const ::grpc::internal::RpcMethod& method,
-               ClientContext* context, const W& request)
+               ::grpc_impl::ClientContext* context, const W& request)
       : context_(context),
         cq_(grpc_completion_queue_attributes{
             GRPC_CQ_CURRENT_VERSION, GRPC_CQ_PLUCK, GRPC_CQ_DEFAULT_POLLING,
@@ -281,7 +282,8 @@ class ClientWriterFactory {
   template <class R>
   static ClientWriter<W>* Create(::grpc::ChannelInterface* channel,
                                  const ::grpc::internal::RpcMethod& method,
-                                 ClientContext* context, R* response) {
+                                 ::grpc_impl::ClientContext* context,
+                                 R* response) {
     return new ClientWriter<W>(channel, method, context, response);
   }
 };
@@ -374,7 +376,7 @@ class ClientWriter : public ClientWriterInterface<W> {
   template <class R>
   ClientWriter(ChannelInterface* channel,
                const ::grpc::internal::RpcMethod& method,
-               ClientContext* context, R* response)
+               ::grpc_impl::ClientContext* context, R* response)
       : context_(context),
         cq_(grpc_completion_queue_attributes{
             GRPC_CQ_CURRENT_VERSION, GRPC_CQ_PLUCK, GRPC_CQ_DEFAULT_POLLING,
@@ -393,12 +395,12 @@ class ClientWriter : public ClientWriterInterface<W> {
     }
   }
 
-  ClientContext* context_;
+  ::grpc_impl::ClientContext* context_;
   ::grpc::internal::CallOpSet<::grpc::internal::CallOpRecvInitialMetadata,
                               ::grpc::internal::CallOpGenericRecvMessage,
                               ::grpc::internal::CallOpClientRecvStatus>
       finish_ops_;
-  CompletionQueue cq_;
+  ::grpc_impl::CompletionQueue cq_;
   ::grpc::internal::Call call_;
 };
 
@@ -431,7 +433,8 @@ class ClientReaderWriterFactory {
  public:
   static ClientReaderWriter<W, R>* Create(
       ::grpc::ChannelInterface* channel,
-      const ::grpc::internal::RpcMethod& method, ClientContext* context) {
+      const ::grpc::internal::RpcMethod& method,
+      ::grpc_impl::ClientContext* context) {
     return new ClientReaderWriter<W, R>(channel, method, context);
   }
 };
@@ -539,8 +542,8 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
  private:
   friend class internal::ClientReaderWriterFactory<W, R>;
 
-  ClientContext* context_;
-  CompletionQueue cq_;
+  ::grpc_impl::ClientContext* context_;
+  ::grpc_impl::CompletionQueue cq_;
   ::grpc::internal::Call call_;
 
   /// Block to create a stream and write the initial metadata and \a request
@@ -548,7 +551,7 @@ class ClientReaderWriter final : public ClientReaderWriterInterface<W, R> {
   /// used to send to the server when starting the call.
   ClientReaderWriter(::grpc::ChannelInterface* channel,
                      const ::grpc::internal::RpcMethod& method,
-                     ClientContext* context)
+                     ::grpc_impl::ClientContext* context)
       : context_(context),
         cq_(grpc_completion_queue_attributes{
             GRPC_CQ_CURRENT_VERSION, GRPC_CQ_PLUCK, GRPC_CQ_DEFAULT_POLLING,
@@ -607,12 +610,12 @@ class ServerReader final : public ServerReaderInterface<R> {
 
  private:
   internal::Call* const call_;
-  ServerContext* const ctx_;
+  ::grpc_impl::ServerContext* const ctx_;
 
   template <class ServiceType, class RequestType, class ResponseType>
   friend class internal::ClientStreamingHandler;
 
-  ServerReader(internal::Call* call, ServerContext* ctx)
+  ServerReader(internal::Call* call, ::grpc_impl::ServerContext* ctx)
       : call_(call), ctx_(ctx) {}
 };
 
@@ -681,12 +684,12 @@ class ServerWriter final : public ServerWriterInterface<W> {
 
  private:
   internal::Call* const call_;
-  ServerContext* const ctx_;
+  ::grpc_impl::ServerContext* const ctx_;
 
   template <class ServiceType, class RequestType, class ResponseType>
   friend class internal::ServerStreamingHandler;
 
-  ServerWriter(internal::Call* call, ServerContext* ctx)
+  ServerWriter(internal::Call* call, ::grpc_impl::ServerContext* ctx)
       : call_(call), ctx_(ctx) {}
 };
 
@@ -701,7 +704,7 @@ namespace internal {
 template <class W, class R>
 class ServerReaderWriterBody final {
  public:
-  ServerReaderWriterBody(Call* call, ServerContext* ctx)
+  ServerReaderWriterBody(Call* call, ::grpc_impl::ServerContext* ctx)
       : call_(call), ctx_(ctx) {}
 
   void SendInitialMetadata() {
@@ -759,7 +762,7 @@ class ServerReaderWriterBody final {
 
  private:
   Call* const call_;
-  ServerContext* const ctx_;
+  ::grpc_impl::ServerContext* const ctx_;
 };
 
 }  // namespace internal
@@ -797,7 +800,7 @@ class ServerReaderWriter final : public ServerReaderWriterInterface<W, R> {
 
   friend class internal::TemplatedBidiStreamingHandler<ServerReaderWriter<W, R>,
                                                        false>;
-  ServerReaderWriter(internal::Call* call, ServerContext* ctx)
+  ServerReaderWriter(internal::Call* call, ::grpc_impl::ServerContext* ctx)
       : body_(call, ctx) {}
 };
 
@@ -865,7 +868,7 @@ class ServerUnaryStreamer final
 
   friend class internal::TemplatedBidiStreamingHandler<
       ServerUnaryStreamer<RequestType, ResponseType>, true>;
-  ServerUnaryStreamer(internal::Call* call, ServerContext* ctx)
+  ServerUnaryStreamer(internal::Call* call, ::grpc_impl::ServerContext* ctx)
       : body_(call, ctx), read_done_(false), write_done_(false) {}
 };
 
@@ -925,7 +928,7 @@ class ServerSplitStreamer final
 
   friend class internal::TemplatedBidiStreamingHandler<
       ServerSplitStreamer<RequestType, ResponseType>, false>;
-  ServerSplitStreamer(internal::Call* call, ServerContext* ctx)
+  ServerSplitStreamer(internal::Call* call, ::grpc_impl::ServerContext* ctx)
       : body_(call, ctx), read_done_(false) {}
 };
 

--- a/include/grpcpp/impl/server_builder_plugin.h
+++ b/include/grpcpp/impl/server_builder_plugin.h
@@ -21,11 +21,11 @@
 
 #include <memory>
 
+#include <grpcpp/support/channel_arguments.h>
 #include <grpcpp/support/config.h>
 
 namespace grpc_impl {
 
-class ChannelArguments;
 class ServerBuilder;
 class ServerInitializer;
 }  // namespace grpc_impl
@@ -57,7 +57,7 @@ class ServerBuilderPlugin {
 
   /// UpdateChannelArguments will be called in ServerBuilder::BuildAndStart(),
   /// before the Server instance is created.
-  virtual void UpdateChannelArguments(grpc_impl::ChannelArguments* args) {}
+  virtual void UpdateChannelArguments(ChannelArguments* args) {}
 
   virtual bool has_sync_methods() const { return false; }
   virtual bool has_async_methods() const { return false; }

--- a/include/grpcpp/security/credentials.h
+++ b/include/grpcpp/security/credentials.h
@@ -28,6 +28,7 @@ typedef ::grpc_impl::CallCredentials CallCredentials;
 typedef ::grpc_impl::SslCredentialsOptions SslCredentialsOptions;
 typedef ::grpc_impl::SecureCallCredentials SecureCallCredentials;
 typedef ::grpc_impl::SecureChannelCredentials SecureChannelCredentials;
+typedef ::grpc_impl::MetadataCredentialsPlugin MetadataCredentialsPlugin;
 
 static inline std::shared_ptr<grpc_impl::ChannelCredentials>
 GoogleDefaultCredentials() {

--- a/include/grpcpp/security/credentials_impl.h
+++ b/include/grpcpp/security/credentials_impl.h
@@ -24,11 +24,11 @@
 #include <vector>
 
 #include <grpc/grpc_security_constants.h>
-#include <grpcpp/channel.h>
+#include <grpcpp/channel_impl.h>
 #include <grpcpp/impl/codegen/client_interceptor.h>
 #include <grpcpp/impl/codegen/grpc_library.h>
 #include <grpcpp/security/auth_context.h>
-#include <grpcpp/support/channel_arguments.h>
+#include <grpcpp/support/channel_arguments_impl.h>
 #include <grpcpp/support/status.h>
 #include <grpcpp/support/string_ref.h>
 
@@ -41,16 +41,16 @@ class CallCredentials;
 class SecureCallCredentials;
 class SecureChannelCredentials;
 
-std::shared_ptr<::grpc::Channel> CreateCustomChannelImpl(
+std::shared_ptr<Channel> CreateCustomChannelImpl(
     const grpc::string& target,
     const std::shared_ptr<ChannelCredentials>& creds,
-    const grpc::ChannelArguments& args);
+    const ChannelArguments& args);
 
 namespace experimental {
-std::shared_ptr<::grpc::Channel> CreateCustomChannelWithInterceptors(
+std::shared_ptr<Channel> CreateCustomChannelWithInterceptors(
     const grpc::string& target,
     const std::shared_ptr<ChannelCredentials>& creds,
-    const grpc::ChannelArguments& args,
+    const ChannelArguments& args,
     std::vector<
         std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>>
         interceptor_creators);
@@ -75,27 +75,27 @@ class ChannelCredentials : private grpc::GrpcLibraryCodegen {
   virtual SecureChannelCredentials* AsSecureCredentials() = 0;
 
  private:
-  friend std::shared_ptr<::grpc::Channel> CreateCustomChannelImpl(
+  friend std::shared_ptr<Channel> CreateCustomChannelImpl(
       const grpc::string& target,
       const std::shared_ptr<ChannelCredentials>& creds,
-      const grpc::ChannelArguments& args);
+      const ChannelArguments& args);
 
-  friend std::shared_ptr<::grpc::Channel>
+  friend std::shared_ptr<Channel>
   grpc_impl::experimental::CreateCustomChannelWithInterceptors(
       const grpc::string& target,
       const std::shared_ptr<ChannelCredentials>& creds,
-      const grpc::ChannelArguments& args,
+      const ChannelArguments& args,
       std::vector<std::unique_ptr<
           grpc::experimental::ClientInterceptorFactoryInterface>>
           interceptor_creators);
 
-  virtual std::shared_ptr<::grpc::Channel> CreateChannelImpl(
-      const grpc::string& target, const grpc::ChannelArguments& args) = 0;
+  virtual std::shared_ptr<Channel> CreateChannelImpl(
+      const grpc::string& target, const ChannelArguments& args) = 0;
 
   // This function should have been a pure virtual function, but it is
   // implemented as a virtual function so that it does not break API.
-  virtual std::shared_ptr<::grpc::Channel> CreateChannelWithInterceptors(
-      const grpc::string& target, const grpc::ChannelArguments& args,
+  virtual std::shared_ptr<Channel> CreateChannelWithInterceptors(
+      const grpc::string& target, const ChannelArguments& args,
       std::vector<std::unique_ptr<
           grpc::experimental::ClientInterceptorFactoryInterface>>
           interceptor_creators) {

--- a/include/grpcpp/server_impl.h
+++ b/include/grpcpp/server_impl.h
@@ -27,16 +27,16 @@
 
 #include <grpc/compression.h>
 #include <grpc/support/atm.h>
-#include <grpcpp/channel.h>
-#include <grpcpp/completion_queue.h>
+#include <grpcpp/channel_impl.h>
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/impl/call.h>
 #include <grpcpp/impl/codegen/client_interceptor.h>
+#include <grpcpp/impl/codegen/completion_queue_impl.h>
 #include <grpcpp/impl/codegen/grpc_library.h>
 #include <grpcpp/impl/codegen/server_interface.h>
 #include <grpcpp/impl/rpc_service_method.h>
 #include <grpcpp/security/server_credentials.h>
-#include <grpcpp/support/channel_arguments.h>
+#include <grpcpp/support/channel_arguments_impl.h>
 #include <grpcpp/support/config.h>
 #include <grpcpp/support/status.h>
 
@@ -80,7 +80,7 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
    public:
     virtual ~GlobalCallbacks() {}
     /// Called before server is created.
-    virtual void UpdateArguments(grpc::ChannelArguments* args) {}
+    virtual void UpdateArguments(ChannelArguments* args) {}
     /// Called before application callback for each synchronous server request
     virtual void PreSynchronousRequest(grpc_impl::ServerContext* context) = 0;
     /// Called after application callback for each synchronous server request
@@ -108,8 +108,7 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   }
 
   /// Establish a channel for in-process communication
-  std::shared_ptr<::grpc::Channel> InProcessChannel(
-      const grpc::ChannelArguments& args);
+  std::shared_ptr<Channel> InProcessChannel(const ChannelArguments& args);
 
   /// NOTE: class experimental_type is not part of the public API of this class.
   /// TODO(yashykt): Integrate into public API when this is no longer
@@ -120,8 +119,8 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
 
     /// Establish a channel for in-process communication with client
     /// interceptors
-    std::shared_ptr<::grpc::Channel> InProcessChannelWithInterceptors(
-        const grpc::ChannelArguments& args,
+    std::shared_ptr<Channel> InProcessChannelWithInterceptors(
+        const ChannelArguments& args,
         std::vector<std::unique_ptr<
             grpc::experimental::ClientInterceptorFactoryInterface>>
             interceptor_creators);
@@ -182,9 +181,8 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   ///
   /// \param sync_cq_timeout_msec The timeout to use when calling AsyncNext() on
   /// server completion queues passed via sync_server_cqs param.
-  Server(
-      int max_message_size, grpc::ChannelArguments* args,
-      std::shared_ptr<std::vector<std::unique_ptr<grpc::ServerCompletionQueue>>>
+  Server(int max_message_size, ChannelArguments* args,
+         std::shared_ptr<std::vector<std::unique_ptr<ServerCompletionQueue>>>
           sync_server_cqs,
       int min_pollers, int max_pollers, int sync_cq_timeout_msec,
       std::vector<
@@ -202,7 +200,7 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   /// caller is required to keep all completion queues live until the server is
   /// destroyed.
   /// \param num_cqs How many completion queues does \a cqs hold.
-  void Start(grpc::ServerCompletionQueue** cqs, size_t num_cqs) override;
+  void Start(ServerCompletionQueue** cqs, size_t num_cqs) override;
 
   grpc_server* server() override { return server_; }
 
@@ -283,7 +281,7 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
     return max_receive_message_size_;
   }
 
-  grpc::CompletionQueue* CallbackCQ() override;
+  CompletionQueue* CallbackCQ() override;
 
   grpc_impl::ServerInitializer* initializer();
 
@@ -304,7 +302,7 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   /// The following completion queues are ONLY used in case of Sync API
   /// i.e. if the server has any services with sync methods. The server uses
   /// these completion queues to poll for new RPCs
-  std::shared_ptr<std::vector<std::unique_ptr<grpc::ServerCompletionQueue>>>
+  std::shared_ptr<std::vector<std::unique_ptr<ServerCompletionQueue>>>
       sync_server_cqs_;
 
   /// List of \a ThreadManager instances (one for each cq in
@@ -374,7 +372,7 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   // It is _not owned_ by the server; ownership belongs with its internal
   // shutdown callback tag (invoked when the CQ is fully shutdown).
   // It is protected by mu_
-  grpc::CompletionQueue* callback_cq_ = nullptr;
+  CompletionQueue* callback_cq_ = nullptr;
 };
 
 }  // namespace grpc_impl

--- a/include/grpcpp/server_impl.h
+++ b/include/grpcpp/server_impl.h
@@ -183,16 +183,16 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   /// server completion queues passed via sync_server_cqs param.
   Server(int max_message_size, ChannelArguments* args,
          std::shared_ptr<std::vector<std::unique_ptr<ServerCompletionQueue>>>
-          sync_server_cqs,
-      int min_pollers, int max_pollers, int sync_cq_timeout_msec,
-      std::vector<
-          std::shared_ptr<grpc::internal::ExternalConnectionAcceptorImpl>>
-          acceptors,
-      grpc_resource_quota* server_rq = nullptr,
-      std::vector<std::unique_ptr<
-          grpc::experimental::ServerInterceptorFactoryInterface>>
-          interceptor_creators = std::vector<std::unique_ptr<
-              grpc::experimental::ServerInterceptorFactoryInterface>>());
+             sync_server_cqs,
+         int min_pollers, int max_pollers, int sync_cq_timeout_msec,
+         std::vector<
+             std::shared_ptr<grpc::internal::ExternalConnectionAcceptorImpl>>
+             acceptors,
+         grpc_resource_quota* server_rq = nullptr,
+         std::vector<std::unique_ptr<
+             grpc::experimental::ServerInterceptorFactoryInterface>>
+             interceptor_creators = std::vector<std::unique_ptr<
+                 grpc::experimental::ServerInterceptorFactoryInterface>>());
 
   /// Start the server.
   ///

--- a/src/compiler/cpp_generator.cc
+++ b/src/compiler/cpp_generator.cc
@@ -142,14 +142,17 @@ grpc::string GetHeaderIncludes(grpc_generator::File* file,
         "grpcpp/impl/codegen/async_stream.h",
         "grpcpp/impl/codegen/async_unary_call.h",
         "grpcpp/impl/codegen/client_callback.h",
+        "grpcpp/impl/codegen/client_context.h",
         "grpcpp/impl/codegen/method_handler_impl.h",
         "grpcpp/impl/codegen/proto_utils.h",
         "grpcpp/impl/codegen/rpc_method.h",
         "grpcpp/impl/codegen/server_callback.h",
+        "grpcpp/impl/codegen/server_context.h",
         "grpcpp/impl/codegen/service_type.h",
         "grpcpp/impl/codegen/status.h",
         "grpcpp/impl/codegen/stub_options.h",
-        "grpcpp/impl/codegen/sync_stream.h"};
+        "grpcpp/impl/codegen/sync_stream.h",
+    };
     std::vector<grpc::string> headers(headers_strs, array_end(headers_strs));
     PrintIncludes(printer.get(), headers, params.use_system_headers,
                   params.grpc_search_path);

--- a/src/cpp/client/create_channel_internal.h
+++ b/src/cpp/client/create_channel_internal.h
@@ -21,6 +21,7 @@
 
 #include <memory>
 
+#include <grpcpp/channel.h>
 #include <grpcpp/impl/codegen/client_interceptor.h>
 #include <grpcpp/support/config.h>
 

--- a/src/cpp/client/insecure_credentials.cc
+++ b/src/cpp/client/insecure_credentials.cc
@@ -16,8 +16,6 @@
  *
  */
 
-#include <grpcpp/security/credentials.h>
-
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
 #include <grpcpp/channel.h>
@@ -31,16 +29,16 @@ namespace grpc_impl {
 namespace {
 class InsecureChannelCredentialsImpl final : public ChannelCredentials {
  public:
-  std::shared_ptr<::grpc::Channel> CreateChannelImpl(
-      const grpc::string& target, const grpc::ChannelArguments& args) override {
+  std::shared_ptr<Channel> CreateChannelImpl(
+      const grpc::string& target, const ChannelArguments& args) override {
     return CreateChannelWithInterceptors(
         target, args,
         std::vector<std::unique_ptr<
             grpc::experimental::ClientInterceptorFactoryInterface>>());
   }
 
-  std::shared_ptr<::grpc::Channel> CreateChannelWithInterceptors(
-      const grpc::string& target, const grpc::ChannelArguments& args,
+  std::shared_ptr<Channel> CreateChannelWithInterceptors(
+      const grpc::string& target, const ChannelArguments& args,
       std::vector<std::unique_ptr<
           grpc::experimental::ClientInterceptorFactoryInterface>>
           interceptor_creators) override {

--- a/src/cpp/client/insecure_credentials.cc
+++ b/src/cpp/client/insecure_credentials.cc
@@ -15,11 +15,11 @@
  * limitations under the License.
  *
  */
+#include <grpcpp/security/credentials.h>
 
 #include <grpc/grpc.h>
 #include <grpc/support/log.h>
 #include <grpcpp/channel.h>
-#include <grpcpp/security/credentials.h>
 #include <grpcpp/support/channel_arguments.h>
 #include <grpcpp/support/config.h>
 #include "src/cpp/client/create_channel_internal.h"

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -36,17 +36,17 @@ SecureChannelCredentials::SecureChannelCredentials(
   g_gli_initializer.summon();
 }
 
-std::shared_ptr<grpc::Channel> SecureChannelCredentials::CreateChannelImpl(
-    const grpc::string& target, const grpc::ChannelArguments& args) {
+std::shared_ptr<Channel> SecureChannelCredentials::CreateChannelImpl(
+    const grpc::string& target, const ChannelArguments& args) {
   return CreateChannelWithInterceptors(
       target, args,
       std::vector<std::unique_ptr<
           grpc::experimental::ClientInterceptorFactoryInterface>>());
 }
 
-std::shared_ptr<grpc::Channel>
+std::shared_ptr<Channel>
 SecureChannelCredentials::CreateChannelWithInterceptors(
-    const grpc::string& target, const grpc::ChannelArguments& args,
+    const grpc::string& target, const ChannelArguments& args,
     std::vector<
         std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>>
         interceptor_creators) {
@@ -209,7 +209,7 @@ std::shared_ptr<CallCredentials> CompositeCallCredentials(
   return nullptr;
 }
 
-std::shared_ptr<grpc_impl::CallCredentials> MetadataCredentialsFromPlugin(
+std::shared_ptr<CallCredentials> MetadataCredentialsFromPlugin(
     std::unique_ptr<MetadataCredentialsPlugin> plugin) {
   grpc::GrpcLibraryCodegen init;  // To call grpc_init().
   const char* type = plugin->GetType();

--- a/src/cpp/client/secure_credentials.h
+++ b/src/cpp/client/secure_credentials.h
@@ -39,14 +39,14 @@ class SecureChannelCredentials final : public ChannelCredentials {
   }
   grpc_channel_credentials* GetRawCreds() { return c_creds_; }
 
-  std::shared_ptr<::grpc::Channel> CreateChannelImpl(
-      const grpc::string& target, const grpc::ChannelArguments& args) override;
+  std::shared_ptr<Channel> CreateChannelImpl(
+      const grpc::string& target, const ChannelArguments& args) override;
 
   SecureChannelCredentials* AsSecureCredentials() override { return this; }
 
  private:
-  std::shared_ptr<::grpc::Channel> CreateChannelWithInterceptors(
-      const grpc::string& target, const grpc::ChannelArguments& args,
+  std::shared_ptr<Channel> CreateChannelWithInterceptors(
+      const grpc::string& target, const ChannelArguments& args,
       std::vector<std::unique_ptr<
           ::grpc::experimental::ClientInterceptorFactoryInterface>>
           interceptor_creators) override;

--- a/test/cpp/codegen/compiler_test_golden
+++ b/test/cpp/codegen/compiler_test_golden
@@ -31,10 +31,12 @@
 #include <grpcpp/impl/codegen/async_stream.h>
 #include <grpcpp/impl/codegen/async_unary_call.h>
 #include <grpcpp/impl/codegen/client_callback.h>
+#include <grpcpp/impl/codegen/client_context.h>
 #include <grpcpp/impl/codegen/method_handler_impl.h>
 #include <grpcpp/impl/codegen/proto_utils.h>
 #include <grpcpp/impl/codegen/rpc_method.h>
 #include <grpcpp/impl/codegen/server_callback.h>
+#include <grpcpp/impl/codegen/server_context.h>
 #include <grpcpp/impl/codegen/service_type.h>
 #include <grpcpp/impl/codegen/status.h>
 #include <grpcpp/impl/codegen/stub_options.h>

--- a/test/cpp/qps/server.h
+++ b/test/cpp/qps/server.h
@@ -19,6 +19,7 @@
 #ifndef TEST_QPS_SERVER_H
 #define TEST_QPS_SERVER_H
 
+#include <grpcpp/channel.h>
 #include <grpc/support/cpu.h>
 #include <grpc/support/log.h>
 #include <grpcpp/resource_quota.h>

--- a/test/cpp/qps/server.h
+++ b/test/cpp/qps/server.h
@@ -19,9 +19,9 @@
 #ifndef TEST_QPS_SERVER_H
 #define TEST_QPS_SERVER_H
 
-#include <grpcpp/channel.h>
 #include <grpc/support/cpu.h>
 #include <grpc/support/log.h>
+#include <grpcpp/channel.h>
 #include <grpcpp/resource_quota.h>
 #include <grpcpp/security/server_credentials.h>
 #include <grpcpp/server_builder.h>

--- a/test/cpp/util/create_test_channel.h
+++ b/test/cpp/util/create_test_channel.h
@@ -21,8 +21,11 @@
 
 #include <memory>
 
+#include <grpcpp/channel.h>
 #include <grpcpp/impl/codegen/client_interceptor.h>
 #include <grpcpp/security/credentials.h>
+#include <grpcpp/support/channel_arguments.h>
+
 
 namespace grpc_impl {
 
@@ -32,36 +35,35 @@ class Channel;
 namespace grpc {
 
 namespace testing {
-
 typedef enum { INSECURE = 0, TLS, ALTS } transport_security;
 
 }  // namespace testing
 
-std::shared_ptr<::grpc_impl::Channel> CreateTestChannel(
+std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, testing::transport_security security_type);
 
-std::shared_ptr<::grpc_impl::Channel> CreateTestChannel(
+std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& override_hostname,
     testing::transport_security security_type, bool use_prod_roots);
 
-std::shared_ptr<::grpc_impl::Channel> CreateTestChannel(
+std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& override_hostname,
     testing::transport_security security_type, bool use_prod_roots,
     const std::shared_ptr<CallCredentials>& creds);
 
-std::shared_ptr<::grpc_impl::Channel> CreateTestChannel(
+std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& override_hostname,
     testing::transport_security security_type, bool use_prod_roots,
     const std::shared_ptr<CallCredentials>& creds,
     const ChannelArguments& args);
 
-std::shared_ptr<::grpc_impl::Channel> CreateTestChannel(
+std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& cred_type,
     const grpc::string& override_hostname, bool use_prod_roots,
     const std::shared_ptr<CallCredentials>& creds,
     const ChannelArguments& args);
 
-std::shared_ptr<::grpc_impl::Channel> CreateTestChannel(
+std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& credential_type,
     const std::shared_ptr<CallCredentials>& creds);
 
@@ -76,7 +78,8 @@ std::shared_ptr<Channel> CreateTestChannel(
 std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& override_hostname,
     testing::transport_security security_type, bool use_prod_roots,
-    const std::shared_ptr<CallCredentials>& creds, const ChannelArguments& args,
+    const std::shared_ptr<CallCredentials>& creds,
+    const ChannelArguments& args,
     std::vector<
         std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
         interceptor_creators);
@@ -84,7 +87,8 @@ std::shared_ptr<Channel> CreateTestChannel(
 std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& cred_type,
     const grpc::string& override_hostname, bool use_prod_roots,
-    const std::shared_ptr<CallCredentials>& creds, const ChannelArguments& args,
+    const std::shared_ptr<CallCredentials>& creds,
+    const ChannelArguments& args,
     std::vector<
         std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
         interceptor_creators);

--- a/test/cpp/util/create_test_channel.h
+++ b/test/cpp/util/create_test_channel.h
@@ -26,7 +26,6 @@
 #include <grpcpp/security/credentials.h>
 #include <grpcpp/support/channel_arguments.h>
 
-
 namespace grpc_impl {
 
 class Channel;
@@ -79,8 +78,7 @@ std::shared_ptr<Channel> CreateTestChannel(
 std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& override_hostname,
     testing::transport_security security_type, bool use_prod_roots,
-    const std::shared_ptr<CallCredentials>& creds,
-    const ChannelArguments& args,
+    const std::shared_ptr<CallCredentials>& creds, const ChannelArguments& args,
     std::vector<
         std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
         interceptor_creators);
@@ -88,8 +86,7 @@ std::shared_ptr<Channel> CreateTestChannel(
 std::shared_ptr<Channel> CreateTestChannel(
     const grpc::string& server, const grpc::string& cred_type,
     const grpc::string& override_hostname, bool use_prod_roots,
-    const std::shared_ptr<CallCredentials>& creds,
-    const ChannelArguments& args,
+    const std::shared_ptr<CallCredentials>& creds, const ChannelArguments& args,
     std::vector<
         std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
         interceptor_creators);

--- a/test/cpp/util/create_test_channel.h
+++ b/test/cpp/util/create_test_channel.h
@@ -35,6 +35,7 @@ class Channel;
 namespace grpc {
 
 namespace testing {
+
 typedef enum { INSECURE = 0, TLS, ALTS } transport_security;
 
 }  // namespace testing


### PR DESCRIPTION
Release Notes
---------------------
This may break compilation if the user is not including server_context.h or client_context.h. In those cases please add the headers files "include/grpcpp/server_context.h" and "include/grpcpp/client_context.h"