### PR TITLE
Fix multiprocessing example for MacOS.

### DIFF
--- a/examples/python/multiprocessing/server.py
+++ b/examples/python/multiprocessing/server.py
@@ -87,7 +87,7 @@ def _reserve_port():
     """Find and reserve a port for all subprocesses to use."""
     sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
-    if sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT) != 1:
+    if sock.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT) == 0:
         raise RuntimeError("Failed to set SO_REUSEPORT.")
     sock.bind(('', 0))
     try:


### PR DESCRIPTION
A closer reading of the API for getsockopt revealed that we were
depending on an implementation detail of getsockopt on Linux. This
assumption breaks down on MacOS.

getsockopt merely guarantees that it will return on 0 in case of failure
and a value greater than 0 in case of success. There is no guarantee as
to *which* non-zero value you will receive. On Linux, it seems to be 1,
the value which was explicitly set. On MacOS, it seems to be the value
of the FLAG which was set, i.e. 512 for SO_REUSEPORT.

This commit ensures the check we use does not rely on either of these
implementation details.