### PR TITLE
Enable CFStream by default on  iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1364,6 +1364,9 @@ target_link_libraries(grpc
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gpr
 )
+if (_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
+  target_link_libraries(grpc "-framework CoreFoundation")
+endif()
 
 foreach(_hdr
   include/grpc/impl/codegen/byte_buffer.h
@@ -1762,6 +1765,9 @@ target_link_libraries(grpc_cronet
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gpr
 )
+if (_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
+  target_link_libraries(grpc_cronet "-framework CoreFoundation")
+endif()
 
 foreach(_hdr
   include/grpc/impl/codegen/byte_buffer.h
@@ -2091,6 +2097,9 @@ target_link_libraries(grpc_test_util
   gpr
   grpc
 )
+if (_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
+  target_link_libraries(grpc_test_util "-framework CoreFoundation")
+endif()
 
 foreach(_hdr
   include/grpc/support/alloc.h
@@ -2421,6 +2430,9 @@ target_link_libraries(grpc_test_util_unsecure
   gpr
   grpc_unsecure
 )
+if (_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
+  target_link_libraries(grpc_test_util_unsecure "-framework CoreFoundation")
+endif()
 
 foreach(_hdr
   include/grpc/support/alloc.h
@@ -2774,6 +2786,9 @@ target_link_libraries(grpc_unsecure
   ${_gRPC_ALLTARGETS_LIBRARIES}
   gpr
 )
+if (_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
+  target_link_libraries(grpc_unsecure "-framework CoreFoundation")
+endif()
 
 foreach(_hdr
   include/grpc/impl/codegen/byte_buffer.h
@@ -3729,6 +3744,9 @@ target_link_libraries(grpc++_cronet
   grpc_cronet
   grpc
 )
+if (_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
+  target_link_libraries(grpc++_cronet "-framework CoreFoundation")
+endif()
 
 foreach(_hdr
   include/grpc++/alarm.h

--- a/Makefile
+++ b/Makefile
@@ -351,6 +351,7 @@ CFLAGS += -std=c99 -Wsign-conversion -Wconversion $(W_SHADOW) $(W_EXTRA_SEMI)
 CXXFLAGS += -std=c++11
 ifeq ($(SYSTEM),Darwin)
 CXXFLAGS += -stdlib=libc++
+LDFLAGS += -framework CoreFoundation
 endif
 CXXFLAGS += -Wnon-virtual-dtor
 CPPFLAGS += -g -Wall -Wextra -Werror -Wno-long-long -Wno-unused-parameter -DOSATOMIC_USE_INLINED=1 -Wno-deprecated-declarations -Ithird_party/nanopb -DPB_FIELD_32BIT

--- a/src/objective-c/GRPCClient/GRPCCall.m
+++ b/src/objective-c/GRPCClient/GRPCCall.m
@@ -322,9 +322,6 @@ const char *kCFStreamVarName = "grpc_cfstream";
   // Guarantees the code in {} block is invoked only once. See ref at:
   // https://developer.apple.com/documentation/objectivec/nsobject/1418639-initialize?language=objc
   if (self == [GRPCCall self]) {
-    // Enable CFStream by default by do not overwrite if the user explicitly disables CFStream with
-    // environment variable "grpc_cfstream=0"
-    setenv(kCFStreamVarName, "1", 0);
     grpc_init();
     callFlags = [NSMutableDictionary dictionary];
   }
@@ -780,7 +777,7 @@ const char *kCFStreamVarName = "grpc_cfstream";
 
     // Connectivity monitor is not required for CFStream
     char *enableCFStream = getenv(kCFStreamVarName);
-    if (enableCFStream == nil || enableCFStream[0] != '1') {
+    if (enableCFStream != nil && enableCFStream[0] != '1') {
       [GRPCConnectivityMonitor registerObserver:self selector:@selector(connectivityChanged:)];
     }
   }

--- a/src/objective-c/manual_tests/main.m
+++ b/src/objective-c/manual_tests/main.m
@@ -21,8 +21,6 @@
 
 int main(int argc, char* argv[]) {
   @autoreleasepool {
-    // enable CFStream API
-    setenv("grpc_cfstream", "1", 1);
     return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
   }
 }

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -467,6 +467,13 @@
     )
   endif (_gRPC_PLATFORM_ANDROID)
   % endif
+  % if lib.name in ["grpc", "grpc_cronet", "grpc_test_util", \
+                    "grpc_test_util_unsecure", "grpc_unsecure", \
+                    "grpc++_cronet"]:
+  if (_gRPC_PLATFORM_IOS OR _gRPC_PLATFORM_MAC)
+    target_link_libraries(${lib.name} "-framework CoreFoundation")
+  endif()
+  %endif
 
   % if len(lib.get('public_headers', [])) > 0:
   foreach(_hdr

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -220,6 +220,7 @@
   CXXFLAGS += -std=c++11
   ifeq ($(SYSTEM),Darwin)
   CXXFLAGS += -stdlib=libc++
+  LDFLAGS += -framework CoreFoundation
   endif
   % for arg in ['CFLAGS', 'CXXFLAGS', 'CPPFLAGS', 'COREFLAGS', 'LDFLAGS', 'DEFINES']:
   %  if defaults.get('global', []).get(arg, None) is not None:


### PR DESCRIPTION
Enable CFStream on iOS for all wrapped languages.