### PR TITLE
Make sure Grpc metapackage includes Grpc.Core.targets

### DIFF
--- a/src/csharp/Grpc/Grpc.csproj
+++ b/src/csharp/Grpc/Grpc.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-      <!-- PrivateAssets set to None to ensure the build targets/props are propagated to parent project -->
+    <!-- PrivateAssets set to None to ensure the build targets/props are propagated to parent project -->
     <ProjectReference Include="../Grpc.Core/Grpc.Core.csproj" PrivateAssets="None" />
   </ItemGroup>
 </Project>

--- a/src/csharp/Grpc/Grpc.csproj
+++ b/src/csharp/Grpc/Grpc.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Grpc.Core/Grpc.Core.csproj" />
+      <!-- PrivateAssets set to None to ensure the build targets/props are propagated to parent project -->
+    <ProjectReference Include="../Grpc.Core/Grpc.Core.csproj" PrivateAssets="None" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/18824 by making sure Grpc.Core.targets (responsible for copying the native libraries to the output folder when on net45+) gets included in the build even when only `Grpc` metapackage is referenced. 