### PR TITLE
Faster hpack table creation

### DIFF
--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -1559,7 +1559,6 @@ void grpc_chttp2_hpack_parser_init(grpc_chttp2_hpack_parser* p) {
   p->value.data.copied.length = 0;
   p->dynamic_table_update_allowed = 2;
   p->last_error = GRPC_ERROR_NONE;
-  grpc_chttp2_hptbl_init(&p->table);
 }
 
 void grpc_chttp2_hpack_parser_set_has_priority(grpc_chttp2_hpack_parser* p) {

--- a/src/core/ext/transport/chttp2/transport/hpack_table.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_table.cc
@@ -35,179 +35,18 @@
 
 extern grpc_core::TraceFlag grpc_http_trace;
 
-static struct {
-  const char* key;
-  const char* value;
-} static_table[] = {
-    /* 0: */
-    {nullptr, nullptr},
-    /* 1: */
-    {":authority", ""},
-    /* 2: */
-    {":method", "GET"},
-    /* 3: */
-    {":method", "POST"},
-    /* 4: */
-    {":path", "/"},
-    /* 5: */
-    {":path", "/index.html"},
-    /* 6: */
-    {":scheme", "http"},
-    /* 7: */
-    {":scheme", "https"},
-    /* 8: */
-    {":status", "200"},
-    /* 9: */
-    {":status", "204"},
-    /* 10: */
-    {":status", "206"},
-    /* 11: */
-    {":status", "304"},
-    /* 12: */
-    {":status", "400"},
-    /* 13: */
-    {":status", "404"},
-    /* 14: */
-    {":status", "500"},
-    /* 15: */
-    {"accept-charset", ""},
-    /* 16: */
-    {"accept-encoding", "gzip, deflate"},
-    /* 17: */
-    {"accept-language", ""},
-    /* 18: */
-    {"accept-ranges", ""},
-    /* 19: */
-    {"accept", ""},
-    /* 20: */
-    {"access-control-allow-origin", ""},
-    /* 21: */
-    {"age", ""},
-    /* 22: */
-    {"allow", ""},
-    /* 23: */
-    {"authorization", ""},
-    /* 24: */
-    {"cache-control", ""},
-    /* 25: */
-    {"content-disposition", ""},
-    /* 26: */
-    {"content-encoding", ""},
-    /* 27: */
-    {"content-language", ""},
-    /* 28: */
-    {"content-length", ""},
-    /* 29: */
-    {"content-location", ""},
-    /* 30: */
-    {"content-range", ""},
-    /* 31: */
-    {"content-type", ""},
-    /* 32: */
-    {"cookie", ""},
-    /* 33: */
-    {"date", ""},
-    /* 34: */
-    {"etag", ""},
-    /* 35: */
-    {"expect", ""},
-    /* 36: */
-    {"expires", ""},
-    /* 37: */
-    {"from", ""},
-    /* 38: */
-    {"host", ""},
-    /* 39: */
-    {"if-match", ""},
-    /* 40: */
-    {"if-modified-since", ""},
-    /* 41: */
-    {"if-none-match", ""},
-    /* 42: */
-    {"if-range", ""},
-    /* 43: */
-    {"if-unmodified-since", ""},
-    /* 44: */
-    {"last-modified", ""},
-    /* 45: */
-    {"link", ""},
-    /* 46: */
-    {"location", ""},
-    /* 47: */
-    {"max-forwards", ""},
-    /* 48: */
-    {"proxy-authenticate", ""},
-    /* 49: */
-    {"proxy-authorization", ""},
-    /* 50: */
-    {"range", ""},
-    /* 51: */
-    {"referer", ""},
-    /* 52: */
-    {"refresh", ""},
-    /* 53: */
-    {"retry-after", ""},
-    /* 54: */
-    {"server", ""},
-    /* 55: */
-    {"set-cookie", ""},
-    /* 56: */
-    {"strict-transport-security", ""},
-    /* 57: */
-    {"transfer-encoding", ""},
-    /* 58: */
-    {"user-agent", ""},
-    /* 59: */
-    {"vary", ""},
-    /* 60: */
-    {"via", ""},
-    /* 61: */
-    {"www-authenticate", ""},
-};
-
-static uint32_t entries_for_bytes(uint32_t bytes) {
-  return (bytes + GRPC_CHTTP2_HPACK_ENTRY_OVERHEAD - 1) /
-         GRPC_CHTTP2_HPACK_ENTRY_OVERHEAD;
-}
-
-void grpc_chttp2_hptbl_init(grpc_chttp2_hptbl* tbl) {
-  size_t i;
-
-  memset(tbl, 0, sizeof(*tbl));
-  tbl->current_table_bytes = tbl->max_bytes =
-      GRPC_CHTTP2_INITIAL_HPACK_TABLE_SIZE;
-  tbl->max_entries = tbl->cap_entries =
-      entries_for_bytes(tbl->current_table_bytes);
-  tbl->ents = static_cast<grpc_mdelem*>(
-      gpr_malloc(sizeof(*tbl->ents) * tbl->cap_entries));
-  memset(tbl->ents, 0, sizeof(*tbl->ents) * tbl->cap_entries);
-  for (i = 1; i <= GRPC_CHTTP2_LAST_STATIC_ENTRY; i++) {
-    tbl->static_ents[i - 1] = grpc_mdelem_from_slices(
-        grpc_slice_intern(
-            grpc_slice_from_static_string_internal(static_table[i].key)),
-        grpc_slice_intern(
-            grpc_slice_from_static_string_internal(static_table[i].value)));
-  }
-}
-
 void grpc_chttp2_hptbl_destroy(grpc_chttp2_hptbl* tbl) {
   size_t i;
-  for (i = 0; i < GRPC_CHTTP2_LAST_STATIC_ENTRY; i++) {
-    GRPC_MDELEM_UNREF(tbl->static_ents[i]);
-  }
   for (i = 0; i < tbl->num_ents; i++) {
     GRPC_MDELEM_UNREF(tbl->ents[(tbl->first_ent + i) % tbl->cap_entries]);
   }
   gpr_free(tbl->ents);
+  tbl->ents = nullptr;
 }
 
-grpc_mdelem grpc_chttp2_hptbl_lookup(const grpc_chttp2_hptbl* tbl,
-                                     uint32_t tbl_index) {
-  /* Static table comes first, just return an entry from it */
-  if (tbl_index <= GRPC_CHTTP2_LAST_STATIC_ENTRY) {
-    return tbl->static_ents[tbl_index - 1];
-  }
-  /* Otherwise, find the value in the list of valid entries */
+grpc_mdelem grpc_chttp2_hptbl_lookup_dynamic_index(const grpc_chttp2_hptbl* tbl,
+                                                   uint32_t tbl_index) {
+  /* Not static - find the value in the list of valid entries */
   tbl_index -= (GRPC_CHTTP2_LAST_STATIC_ENTRY + 1);
   if (tbl_index < tbl->num_ents) {
     uint32_t offset =
@@ -280,7 +119,7 @@ grpc_error* grpc_chttp2_hptbl_set_current_table_size(grpc_chttp2_hptbl* tbl,
     evict1(tbl);
   }
   tbl->current_table_bytes = bytes;
-  tbl->max_entries = entries_for_bytes(bytes);
+  tbl->max_entries = grpc_chttp2_hptbl::entries_for_bytes(bytes);
   if (tbl->max_entries > tbl->cap_entries) {
     rebuild_ents(tbl, GPR_MAX(tbl->max_entries, 2 * tbl->cap_entries));
   } else if (tbl->max_entries < tbl->cap_entries / 3) {
@@ -350,7 +189,7 @@ grpc_chttp2_hptbl_find_result grpc_chttp2_hptbl_find(
 
   /* See if the string is in the static table */
   for (i = 0; i < GRPC_CHTTP2_LAST_STATIC_ENTRY; i++) {
-    grpc_mdelem ent = tbl->static_ents[i];
+    grpc_mdelem ent = grpc_static_mdelem_manifested[i];
     if (!grpc_slice_eq(GRPC_MDKEY(md), GRPC_MDKEY(ent))) continue;
     r.index = i + 1u;
     r.has_value = grpc_slice_eq(GRPC_MDVALUE(md), GRPC_MDVALUE(ent));

--- a/src/core/lib/transport/static_metadata.cc
+++ b/src/core/lib/transport/static_metadata.cc
@@ -337,6 +337,447 @@ const grpc_slice grpc_static_slice_table[GRPC_STATIC_MDSTR_COUNT] = {
     {&grpc_static_metadata_refcounts[106], {{21, g_bytes + 1234}}},
 };
 
+/* Warning: the core static metadata currently operates under the soft
+constraint that the first GRPC_CHTTP2_LAST_STATIC_ENTRY (61) entries must
+contain metadata specified by the http2 hpack standard. The CHTTP2 transport
+reads the core metadata with this assumption in mind. If the order of the core
+static metadata is to be changed, then the CHTTP2 transport must be changed as
+well to stop relying on the core metadata. */
+
+grpc_mdelem grpc_static_mdelem_manifested[GRPC_STATIC_MDELEM_COUNT] = {
+    // clang-format off
+    /* GRPC_MDELEM_AUTHORITY_EMPTY: 
+     ":authority": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[0].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_METHOD_GET: 
+     ":method": "GET" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[1].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_METHOD_POST: 
+     ":method": "POST" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[2].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_PATH_SLASH: 
+     ":path": "/" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[3].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_PATH_SLASH_INDEX_DOT_HTML: 
+     ":path": "/index.html" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[4].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_SCHEME_HTTP: 
+     ":scheme": "http" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[5].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_SCHEME_HTTPS: 
+     ":scheme": "https" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[6].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_STATUS_200: 
+     ":status": "200" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[7].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_STATUS_204: 
+     ":status": "204" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[8].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_STATUS_206: 
+     ":status": "206" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[9].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_STATUS_304: 
+     ":status": "304" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[10].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_STATUS_400: 
+     ":status": "400" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[11].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_STATUS_404: 
+     ":status": "404" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[12].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_STATUS_500: 
+     ":status": "500" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[13].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_ACCEPT_CHARSET_EMPTY: 
+     "accept-charset": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[14].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_ACCEPT_ENCODING_GZIP_COMMA_DEFLATE: 
+     "accept-encoding": "gzip, deflate" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[15].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_ACCEPT_LANGUAGE_EMPTY: 
+     "accept-language": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[16].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_ACCEPT_RANGES_EMPTY: 
+     "accept-ranges": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[17].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_ACCEPT_EMPTY: 
+     "accept": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[18].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_ACCESS_CONTROL_ALLOW_ORIGIN_EMPTY: 
+     "access-control-allow-origin": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[19].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_AGE_EMPTY: 
+     "age": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[20].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_ALLOW_EMPTY: 
+     "allow": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[21].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_AUTHORIZATION_EMPTY: 
+     "authorization": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[22].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_CACHE_CONTROL_EMPTY: 
+     "cache-control": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[23].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_CONTENT_DISPOSITION_EMPTY: 
+     "content-disposition": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[24].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_CONTENT_ENCODING_EMPTY: 
+     "content-encoding": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[25].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_CONTENT_LANGUAGE_EMPTY: 
+     "content-language": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[26].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_CONTENT_LENGTH_EMPTY: 
+     "content-length": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[27].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_CONTENT_LOCATION_EMPTY: 
+     "content-location": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[28].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_CONTENT_RANGE_EMPTY: 
+     "content-range": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[29].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_CONTENT_TYPE_EMPTY: 
+     "content-type": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[30].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_COOKIE_EMPTY: 
+     "cookie": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[31].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_DATE_EMPTY: 
+     "date": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[32].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_ETAG_EMPTY: 
+     "etag": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[33].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_EXPECT_EMPTY: 
+     "expect": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[34].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_EXPIRES_EMPTY: 
+     "expires": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[35].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_FROM_EMPTY: 
+     "from": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[36].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_HOST_EMPTY: 
+     "host": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[37].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_IF_MATCH_EMPTY: 
+     "if-match": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[38].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_IF_MODIFIED_SINCE_EMPTY: 
+     "if-modified-since": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[39].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_IF_NONE_MATCH_EMPTY: 
+     "if-none-match": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[40].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_IF_RANGE_EMPTY: 
+     "if-range": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[41].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_IF_UNMODIFIED_SINCE_EMPTY: 
+     "if-unmodified-since": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[42].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_LAST_MODIFIED_EMPTY: 
+     "last-modified": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[43].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_LINK_EMPTY: 
+     "link": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[44].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_LOCATION_EMPTY: 
+     "location": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[45].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_MAX_FORWARDS_EMPTY: 
+     "max-forwards": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[46].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_PROXY_AUTHENTICATE_EMPTY: 
+     "proxy-authenticate": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[47].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_PROXY_AUTHORIZATION_EMPTY: 
+     "proxy-authorization": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[48].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_RANGE_EMPTY: 
+     "range": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[49].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_REFERER_EMPTY: 
+     "referer": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[50].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_REFRESH_EMPTY: 
+     "refresh": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[51].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_RETRY_AFTER_EMPTY: 
+     "retry-after": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[52].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_SERVER_EMPTY: 
+     "server": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[53].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_SET_COOKIE_EMPTY: 
+     "set-cookie": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[54].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_STRICT_TRANSPORT_SECURITY_EMPTY: 
+     "strict-transport-security": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[55].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_TRANSFER_ENCODING_EMPTY: 
+     "transfer-encoding": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[56].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_USER_AGENT_EMPTY: 
+     "user-agent": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[57].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_VARY_EMPTY: 
+     "vary": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[58].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_VIA_EMPTY: 
+     "via": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[59].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_WWW_AUTHENTICATE_EMPTY: 
+     "www-authenticate": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[60].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_GRPC_STATUS_0: 
+     "grpc-status": "0" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[61].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_GRPC_STATUS_1: 
+     "grpc-status": "1" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[62].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_GRPC_STATUS_2: 
+     "grpc-status": "2" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[63].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_GRPC_ENCODING_IDENTITY: 
+     "grpc-encoding": "identity" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[64].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_GRPC_ENCODING_GZIP: 
+     "grpc-encoding": "gzip" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[65].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_GRPC_ENCODING_DEFLATE: 
+     "grpc-encoding": "deflate" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[66].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_TE_TRAILERS: 
+     "te": "trailers" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[67].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_CONTENT_TYPE_APPLICATION_SLASH_GRPC: 
+     "content-type": "application/grpc" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[68].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_SCHEME_GRPC: 
+     ":scheme": "grpc" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[69].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_METHOD_PUT: 
+     ":method": "PUT" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[70].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_ACCEPT_ENCODING_EMPTY: 
+     "accept-encoding": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[71].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_CONTENT_ENCODING_IDENTITY: 
+     "content-encoding": "identity" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[72].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_CONTENT_ENCODING_GZIP: 
+     "content-encoding": "gzip" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[73].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_LB_TOKEN_EMPTY: 
+     "lb-token": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[74].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_LB_COST_BIN_EMPTY: 
+     "lb-cost-bin": "" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[75].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_GRPC_ACCEPT_ENCODING_IDENTITY: 
+     "grpc-accept-encoding": "identity" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[76].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_GRPC_ACCEPT_ENCODING_DEFLATE: 
+     "grpc-accept-encoding": "deflate" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[77].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_GRPC_ACCEPT_ENCODING_IDENTITY_COMMA_DEFLATE: 
+     "grpc-accept-encoding": "identity,deflate" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[78].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_GRPC_ACCEPT_ENCODING_GZIP: 
+     "grpc-accept-encoding": "gzip" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[79].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_GRPC_ACCEPT_ENCODING_IDENTITY_COMMA_GZIP: 
+     "grpc-accept-encoding": "identity,gzip" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[80].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_GRPC_ACCEPT_ENCODING_DEFLATE_COMMA_GZIP: 
+     "grpc-accept-encoding": "deflate,gzip" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[81].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_GRPC_ACCEPT_ENCODING_IDENTITY_COMMA_DEFLATE_COMMA_GZIP: 
+     "grpc-accept-encoding": "identity,deflate,gzip" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[82].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_ACCEPT_ENCODING_IDENTITY: 
+     "accept-encoding": "identity" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[83].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_ACCEPT_ENCODING_GZIP: 
+     "accept-encoding": "gzip" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[84].data(),
+        GRPC_MDELEM_STORAGE_STATIC),
+    /* GRPC_MDELEM_ACCEPT_ENCODING_IDENTITY_COMMA_GZIP: 
+     "accept-encoding": "identity,gzip" */
+    GRPC_MAKE_MDELEM(
+        &grpc_static_mdelem_table[85].data(),
+        GRPC_MDELEM_STORAGE_STATIC)
+    // clang-format on
+};
 uintptr_t grpc_static_mdelem_user_data[GRPC_STATIC_MDELEM_COUNT] = {
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/src/core/lib/transport/static_metadata.h
+++ b/src/core/lib/transport/static_metadata.h
@@ -272,350 +272,195 @@ extern grpc_slice_refcount
 extern grpc_core::StaticMetadata
     grpc_static_mdelem_table[GRPC_STATIC_MDELEM_COUNT];
 extern uintptr_t grpc_static_mdelem_user_data[GRPC_STATIC_MDELEM_COUNT];
+extern grpc_mdelem grpc_static_mdelem_manifested[GRPC_STATIC_MDELEM_COUNT];
 /* ":authority": "" */
-#define GRPC_MDELEM_AUTHORITY_EMPTY                      \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[0].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_AUTHORITY_EMPTY (grpc_static_mdelem_manifested[0])
 /* ":method": "GET" */
-#define GRPC_MDELEM_METHOD_GET                           \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[1].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_METHOD_GET (grpc_static_mdelem_manifested[1])
 /* ":method": "POST" */
-#define GRPC_MDELEM_METHOD_POST                          \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[2].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_METHOD_POST (grpc_static_mdelem_manifested[2])
 /* ":path": "/" */
-#define GRPC_MDELEM_PATH_SLASH                           \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[3].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_PATH_SLASH (grpc_static_mdelem_manifested[3])
 /* ":path": "/index.html" */
-#define GRPC_MDELEM_PATH_SLASH_INDEX_DOT_HTML            \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[4].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_PATH_SLASH_INDEX_DOT_HTML (grpc_static_mdelem_manifested[4])
 /* ":scheme": "http" */
-#define GRPC_MDELEM_SCHEME_HTTP                          \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[5].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_SCHEME_HTTP (grpc_static_mdelem_manifested[5])
 /* ":scheme": "https" */
-#define GRPC_MDELEM_SCHEME_HTTPS                         \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[6].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_SCHEME_HTTPS (grpc_static_mdelem_manifested[6])
 /* ":status": "200" */
-#define GRPC_MDELEM_STATUS_200                           \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[7].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_STATUS_200 (grpc_static_mdelem_manifested[7])
 /* ":status": "204" */
-#define GRPC_MDELEM_STATUS_204                           \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[8].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_STATUS_204 (grpc_static_mdelem_manifested[8])
 /* ":status": "206" */
-#define GRPC_MDELEM_STATUS_206                           \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[9].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_STATUS_206 (grpc_static_mdelem_manifested[9])
 /* ":status": "304" */
-#define GRPC_MDELEM_STATUS_304                            \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[10].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_STATUS_304 (grpc_static_mdelem_manifested[10])
 /* ":status": "400" */
-#define GRPC_MDELEM_STATUS_400                            \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[11].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_STATUS_400 (grpc_static_mdelem_manifested[11])
 /* ":status": "404" */
-#define GRPC_MDELEM_STATUS_404                            \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[12].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_STATUS_404 (grpc_static_mdelem_manifested[12])
 /* ":status": "500" */
-#define GRPC_MDELEM_STATUS_500                            \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[13].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_STATUS_500 (grpc_static_mdelem_manifested[13])
 /* "accept-charset": "" */
-#define GRPC_MDELEM_ACCEPT_CHARSET_EMPTY                  \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[14].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_ACCEPT_CHARSET_EMPTY (grpc_static_mdelem_manifested[14])
 /* "accept-encoding": "gzip, deflate" */
-#define GRPC_MDELEM_ACCEPT_ENCODING_GZIP_COMMA_DEFLATE    \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[15].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_ACCEPT_ENCODING_GZIP_COMMA_DEFLATE \
+  (grpc_static_mdelem_manifested[15])
 /* "accept-language": "" */
-#define GRPC_MDELEM_ACCEPT_LANGUAGE_EMPTY                 \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[16].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_ACCEPT_LANGUAGE_EMPTY (grpc_static_mdelem_manifested[16])
 /* "accept-ranges": "" */
-#define GRPC_MDELEM_ACCEPT_RANGES_EMPTY                   \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[17].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_ACCEPT_RANGES_EMPTY (grpc_static_mdelem_manifested[17])
 /* "accept": "" */
-#define GRPC_MDELEM_ACCEPT_EMPTY                          \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[18].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_ACCEPT_EMPTY (grpc_static_mdelem_manifested[18])
 /* "access-control-allow-origin": "" */
-#define GRPC_MDELEM_ACCESS_CONTROL_ALLOW_ORIGIN_EMPTY     \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[19].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_ACCESS_CONTROL_ALLOW_ORIGIN_EMPTY \
+  (grpc_static_mdelem_manifested[19])
 /* "age": "" */
-#define GRPC_MDELEM_AGE_EMPTY                             \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[20].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_AGE_EMPTY (grpc_static_mdelem_manifested[20])
 /* "allow": "" */
-#define GRPC_MDELEM_ALLOW_EMPTY                           \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[21].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_ALLOW_EMPTY (grpc_static_mdelem_manifested[21])
 /* "authorization": "" */
-#define GRPC_MDELEM_AUTHORIZATION_EMPTY                   \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[22].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_AUTHORIZATION_EMPTY (grpc_static_mdelem_manifested[22])
 /* "cache-control": "" */
-#define GRPC_MDELEM_CACHE_CONTROL_EMPTY                   \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[23].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_CACHE_CONTROL_EMPTY (grpc_static_mdelem_manifested[23])
 /* "content-disposition": "" */
-#define GRPC_MDELEM_CONTENT_DISPOSITION_EMPTY             \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[24].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_CONTENT_DISPOSITION_EMPTY \
+  (grpc_static_mdelem_manifested[24])
 /* "content-encoding": "" */
-#define GRPC_MDELEM_CONTENT_ENCODING_EMPTY                \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[25].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_CONTENT_ENCODING_EMPTY (grpc_static_mdelem_manifested[25])
 /* "content-language": "" */
-#define GRPC_MDELEM_CONTENT_LANGUAGE_EMPTY                \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[26].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_CONTENT_LANGUAGE_EMPTY (grpc_static_mdelem_manifested[26])
 /* "content-length": "" */
-#define GRPC_MDELEM_CONTENT_LENGTH_EMPTY                  \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[27].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_CONTENT_LENGTH_EMPTY (grpc_static_mdelem_manifested[27])
 /* "content-location": "" */
-#define GRPC_MDELEM_CONTENT_LOCATION_EMPTY                \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[28].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_CONTENT_LOCATION_EMPTY (grpc_static_mdelem_manifested[28])
 /* "content-range": "" */
-#define GRPC_MDELEM_CONTENT_RANGE_EMPTY                   \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[29].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_CONTENT_RANGE_EMPTY (grpc_static_mdelem_manifested[29])
 /* "content-type": "" */
-#define GRPC_MDELEM_CONTENT_TYPE_EMPTY                    \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[30].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_CONTENT_TYPE_EMPTY (grpc_static_mdelem_manifested[30])
 /* "cookie": "" */
-#define GRPC_MDELEM_COOKIE_EMPTY                          \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[31].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_COOKIE_EMPTY (grpc_static_mdelem_manifested[31])
 /* "date": "" */
-#define GRPC_MDELEM_DATE_EMPTY                            \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[32].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_DATE_EMPTY (grpc_static_mdelem_manifested[32])
 /* "etag": "" */
-#define GRPC_MDELEM_ETAG_EMPTY                            \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[33].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_ETAG_EMPTY (grpc_static_mdelem_manifested[33])
 /* "expect": "" */
-#define GRPC_MDELEM_EXPECT_EMPTY                          \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[34].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_EXPECT_EMPTY (grpc_static_mdelem_manifested[34])
 /* "expires": "" */
-#define GRPC_MDELEM_EXPIRES_EMPTY                         \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[35].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_EXPIRES_EMPTY (grpc_static_mdelem_manifested[35])
 /* "from": "" */
-#define GRPC_MDELEM_FROM_EMPTY                            \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[36].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_FROM_EMPTY (grpc_static_mdelem_manifested[36])
 /* "host": "" */
-#define GRPC_MDELEM_HOST_EMPTY                            \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[37].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_HOST_EMPTY (grpc_static_mdelem_manifested[37])
 /* "if-match": "" */
-#define GRPC_MDELEM_IF_MATCH_EMPTY                        \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[38].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_IF_MATCH_EMPTY (grpc_static_mdelem_manifested[38])
 /* "if-modified-since": "" */
-#define GRPC_MDELEM_IF_MODIFIED_SINCE_EMPTY               \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[39].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_IF_MODIFIED_SINCE_EMPTY (grpc_static_mdelem_manifested[39])
 /* "if-none-match": "" */
-#define GRPC_MDELEM_IF_NONE_MATCH_EMPTY                   \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[40].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_IF_NONE_MATCH_EMPTY (grpc_static_mdelem_manifested[40])
 /* "if-range": "" */
-#define GRPC_MDELEM_IF_RANGE_EMPTY                        \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[41].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_IF_RANGE_EMPTY (grpc_static_mdelem_manifested[41])
 /* "if-unmodified-since": "" */
-#define GRPC_MDELEM_IF_UNMODIFIED_SINCE_EMPTY             \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[42].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_IF_UNMODIFIED_SINCE_EMPTY \
+  (grpc_static_mdelem_manifested[42])
 /* "last-modified": "" */
-#define GRPC_MDELEM_LAST_MODIFIED_EMPTY                   \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[43].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_LAST_MODIFIED_EMPTY (grpc_static_mdelem_manifested[43])
 /* "link": "" */
-#define GRPC_MDELEM_LINK_EMPTY                            \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[44].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_LINK_EMPTY (grpc_static_mdelem_manifested[44])
 /* "location": "" */
-#define GRPC_MDELEM_LOCATION_EMPTY                        \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[45].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_LOCATION_EMPTY (grpc_static_mdelem_manifested[45])
 /* "max-forwards": "" */
-#define GRPC_MDELEM_MAX_FORWARDS_EMPTY                    \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[46].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_MAX_FORWARDS_EMPTY (grpc_static_mdelem_manifested[46])
 /* "proxy-authenticate": "" */
-#define GRPC_MDELEM_PROXY_AUTHENTICATE_EMPTY              \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[47].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_PROXY_AUTHENTICATE_EMPTY (grpc_static_mdelem_manifested[47])
 /* "proxy-authorization": "" */
-#define GRPC_MDELEM_PROXY_AUTHORIZATION_EMPTY             \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[48].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_PROXY_AUTHORIZATION_EMPTY \
+  (grpc_static_mdelem_manifested[48])
 /* "range": "" */
-#define GRPC_MDELEM_RANGE_EMPTY                           \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[49].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_RANGE_EMPTY (grpc_static_mdelem_manifested[49])
 /* "referer": "" */
-#define GRPC_MDELEM_REFERER_EMPTY                         \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[50].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_REFERER_EMPTY (grpc_static_mdelem_manifested[50])
 /* "refresh": "" */
-#define GRPC_MDELEM_REFRESH_EMPTY                         \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[51].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_REFRESH_EMPTY (grpc_static_mdelem_manifested[51])
 /* "retry-after": "" */
-#define GRPC_MDELEM_RETRY_AFTER_EMPTY                     \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[52].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_RETRY_AFTER_EMPTY (grpc_static_mdelem_manifested[52])
 /* "server": "" */
-#define GRPC_MDELEM_SERVER_EMPTY                          \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[53].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_SERVER_EMPTY (grpc_static_mdelem_manifested[53])
 /* "set-cookie": "" */
-#define GRPC_MDELEM_SET_COOKIE_EMPTY                      \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[54].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_SET_COOKIE_EMPTY (grpc_static_mdelem_manifested[54])
 /* "strict-transport-security": "" */
-#define GRPC_MDELEM_STRICT_TRANSPORT_SECURITY_EMPTY       \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[55].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_STRICT_TRANSPORT_SECURITY_EMPTY \
+  (grpc_static_mdelem_manifested[55])
 /* "transfer-encoding": "" */
-#define GRPC_MDELEM_TRANSFER_ENCODING_EMPTY               \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[56].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_TRANSFER_ENCODING_EMPTY (grpc_static_mdelem_manifested[56])
 /* "user-agent": "" */
-#define GRPC_MDELEM_USER_AGENT_EMPTY                      \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[57].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_USER_AGENT_EMPTY (grpc_static_mdelem_manifested[57])
 /* "vary": "" */
-#define GRPC_MDELEM_VARY_EMPTY                            \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[58].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_VARY_EMPTY (grpc_static_mdelem_manifested[58])
 /* "via": "" */
-#define GRPC_MDELEM_VIA_EMPTY                             \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[59].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_VIA_EMPTY (grpc_static_mdelem_manifested[59])
 /* "www-authenticate": "" */
-#define GRPC_MDELEM_WWW_AUTHENTICATE_EMPTY                \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[60].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_WWW_AUTHENTICATE_EMPTY (grpc_static_mdelem_manifested[60])
 /* "grpc-status": "0" */
-#define GRPC_MDELEM_GRPC_STATUS_0                         \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[61].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_GRPC_STATUS_0 (grpc_static_mdelem_manifested[61])
 /* "grpc-status": "1" */
-#define GRPC_MDELEM_GRPC_STATUS_1                         \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[62].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_GRPC_STATUS_1 (grpc_static_mdelem_manifested[62])
 /* "grpc-status": "2" */
-#define GRPC_MDELEM_GRPC_STATUS_2                         \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[63].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_GRPC_STATUS_2 (grpc_static_mdelem_manifested[63])
 /* "grpc-encoding": "identity" */
-#define GRPC_MDELEM_GRPC_ENCODING_IDENTITY                \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[64].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_GRPC_ENCODING_IDENTITY (grpc_static_mdelem_manifested[64])
 /* "grpc-encoding": "gzip" */
-#define GRPC_MDELEM_GRPC_ENCODING_GZIP                    \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[65].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_GRPC_ENCODING_GZIP (grpc_static_mdelem_manifested[65])
 /* "grpc-encoding": "deflate" */
-#define GRPC_MDELEM_GRPC_ENCODING_DEFLATE                 \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[66].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_GRPC_ENCODING_DEFLATE (grpc_static_mdelem_manifested[66])
 /* "te": "trailers" */
-#define GRPC_MDELEM_TE_TRAILERS                           \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[67].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_TE_TRAILERS (grpc_static_mdelem_manifested[67])
 /* "content-type": "application/grpc" */
-#define GRPC_MDELEM_CONTENT_TYPE_APPLICATION_SLASH_GRPC   \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[68].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_CONTENT_TYPE_APPLICATION_SLASH_GRPC \
+  (grpc_static_mdelem_manifested[68])
 /* ":scheme": "grpc" */
-#define GRPC_MDELEM_SCHEME_GRPC                           \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[69].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_SCHEME_GRPC (grpc_static_mdelem_manifested[69])
 /* ":method": "PUT" */
-#define GRPC_MDELEM_METHOD_PUT                            \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[70].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_METHOD_PUT (grpc_static_mdelem_manifested[70])
 /* "accept-encoding": "" */
-#define GRPC_MDELEM_ACCEPT_ENCODING_EMPTY                 \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[71].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_ACCEPT_ENCODING_EMPTY (grpc_static_mdelem_manifested[71])
 /* "content-encoding": "identity" */
-#define GRPC_MDELEM_CONTENT_ENCODING_IDENTITY             \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[72].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_CONTENT_ENCODING_IDENTITY \
+  (grpc_static_mdelem_manifested[72])
 /* "content-encoding": "gzip" */
-#define GRPC_MDELEM_CONTENT_ENCODING_GZIP                 \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[73].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_CONTENT_ENCODING_GZIP (grpc_static_mdelem_manifested[73])
 /* "lb-token": "" */
-#define GRPC_MDELEM_LB_TOKEN_EMPTY                        \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[74].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_LB_TOKEN_EMPTY (grpc_static_mdelem_manifested[74])
 /* "lb-cost-bin": "" */
-#define GRPC_MDELEM_LB_COST_BIN_EMPTY                     \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[75].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_LB_COST_BIN_EMPTY (grpc_static_mdelem_manifested[75])
 /* "grpc-accept-encoding": "identity" */
-#define GRPC_MDELEM_GRPC_ACCEPT_ENCODING_IDENTITY         \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[76].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_GRPC_ACCEPT_ENCODING_IDENTITY \
+  (grpc_static_mdelem_manifested[76])
 /* "grpc-accept-encoding": "deflate" */
-#define GRPC_MDELEM_GRPC_ACCEPT_ENCODING_DEFLATE          \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[77].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_GRPC_ACCEPT_ENCODING_DEFLATE \
+  (grpc_static_mdelem_manifested[77])
 /* "grpc-accept-encoding": "identity,deflate" */
 #define GRPC_MDELEM_GRPC_ACCEPT_ENCODING_IDENTITY_COMMA_DEFLATE \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[78].data(),       \
-                    GRPC_MDELEM_STORAGE_STATIC))
+  (grpc_static_mdelem_manifested[78])
 /* "grpc-accept-encoding": "gzip" */
-#define GRPC_MDELEM_GRPC_ACCEPT_ENCODING_GZIP             \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[79].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_GRPC_ACCEPT_ENCODING_GZIP \
+  (grpc_static_mdelem_manifested[79])
 /* "grpc-accept-encoding": "identity,gzip" */
 #define GRPC_MDELEM_GRPC_ACCEPT_ENCODING_IDENTITY_COMMA_GZIP \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[80].data(),    \
-                    GRPC_MDELEM_STORAGE_STATIC))
+  (grpc_static_mdelem_manifested[80])
 /* "grpc-accept-encoding": "deflate,gzip" */
 #define GRPC_MDELEM_GRPC_ACCEPT_ENCODING_DEFLATE_COMMA_GZIP \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[81].data(),   \
-                    GRPC_MDELEM_STORAGE_STATIC))
+  (grpc_static_mdelem_manifested[81])
 /* "grpc-accept-encoding": "identity,deflate,gzip" */
 #define GRPC_MDELEM_GRPC_ACCEPT_ENCODING_IDENTITY_COMMA_DEFLATE_COMMA_GZIP \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[82].data(),                  \
-                    GRPC_MDELEM_STORAGE_STATIC))
+  (grpc_static_mdelem_manifested[82])
 /* "accept-encoding": "identity" */
-#define GRPC_MDELEM_ACCEPT_ENCODING_IDENTITY              \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[83].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_ACCEPT_ENCODING_IDENTITY (grpc_static_mdelem_manifested[83])
 /* "accept-encoding": "gzip" */
-#define GRPC_MDELEM_ACCEPT_ENCODING_GZIP                  \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[84].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_ACCEPT_ENCODING_GZIP (grpc_static_mdelem_manifested[84])
 /* "accept-encoding": "identity,gzip" */
-#define GRPC_MDELEM_ACCEPT_ENCODING_IDENTITY_COMMA_GZIP   \
-  (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[85].data(), \
-                    GRPC_MDELEM_STORAGE_STATIC))
+#define GRPC_MDELEM_ACCEPT_ENCODING_IDENTITY_COMMA_GZIP \
+  (grpc_static_mdelem_manifested[85])
 
 grpc_mdelem grpc_static_mdelem_for_static_strings(intptr_t a, intptr_t b);
 typedef enum {

--- a/test/core/transport/chttp2/hpack_parser_test.cc
+++ b/test/core/transport/chttp2/hpack_parser_test.cc
@@ -102,6 +102,7 @@ static void test_vectors(grpc_slice_split_mode mode) {
   grpc_chttp2_hpack_parser_destroy(&parser);
 
   grpc_chttp2_hpack_parser_init(&parser);
+  new (&parser.table) grpc_chttp2_hptbl();
   /* D.3.1 */
   test_vector(&parser, mode,
               "8286 8441 0f77 7777 2e65 7861 6d70 6c65"
@@ -122,6 +123,7 @@ static void test_vectors(grpc_slice_split_mode mode) {
   grpc_chttp2_hpack_parser_destroy(&parser);
 
   grpc_chttp2_hpack_parser_init(&parser);
+  new (&parser.table) grpc_chttp2_hptbl();
   /* D.4.1 */
   test_vector(&parser, mode,
               "8286 8441 8cf1 e3c2 e5f2 3a6b a0ab 90f4"
@@ -142,6 +144,7 @@ static void test_vectors(grpc_slice_split_mode mode) {
   grpc_chttp2_hpack_parser_destroy(&parser);
 
   grpc_chttp2_hpack_parser_init(&parser);
+  new (&parser.table) grpc_chttp2_hptbl();
   grpc_chttp2_hptbl_set_max_bytes(&parser.table, 256);
   grpc_chttp2_hptbl_set_current_table_size(&parser.table, 256);
   /* D.5.1 */
@@ -176,6 +179,7 @@ static void test_vectors(grpc_slice_split_mode mode) {
   grpc_chttp2_hpack_parser_destroy(&parser);
 
   grpc_chttp2_hpack_parser_init(&parser);
+  new (&parser.table) grpc_chttp2_hptbl();
   grpc_chttp2_hptbl_set_max_bytes(&parser.table, 256);
   grpc_chttp2_hptbl_set_current_table_size(&parser.table, 256);
   /* D.6.1 */

--- a/test/core/transport/chttp2/hpack_table_test.cc
+++ b/test/core/transport/chttp2/hpack_table_test.cc
@@ -48,8 +48,6 @@ static void test_static_lookup(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_chttp2_hptbl tbl;
 
-  grpc_chttp2_hptbl_init(&tbl);
-
   LOG_TEST("test_static_lookup");
   assert_index(&tbl, 1, ":authority", "");
   assert_index(&tbl, 2, ":method", "GET");
@@ -125,7 +123,6 @@ static void test_many_additions(void) {
   LOG_TEST("test_many_additions");
 
   grpc_core::ExecCtx exec_ctx;
-  grpc_chttp2_hptbl_init(&tbl);
 
   for (i = 0; i < 100000; i++) {
     grpc_mdelem elem;
@@ -172,7 +169,6 @@ static void test_find(void) {
 
   LOG_TEST("test_find");
 
-  grpc_chttp2_hptbl_init(&tbl);
   elem = grpc_mdelem_from_slices(grpc_slice_from_static_string("abc"),
                                  grpc_slice_from_static_string("xyz"));
   GPR_ASSERT(grpc_chttp2_hptbl_add(&tbl, elem) == GRPC_ERROR_NONE);

--- a/tools/codegen/core/gen_static_metadata.py
+++ b/tools/codegen/core/gen_static_metadata.py
@@ -451,11 +451,37 @@ print >> H, ('extern grpc_core::StaticMetadata '
              'grpc_static_mdelem_table[GRPC_STATIC_MDELEM_COUNT];')
 print >> H, ('extern uintptr_t '
              'grpc_static_mdelem_user_data[GRPC_STATIC_MDELEM_COUNT];')
+print >> H, ('extern grpc_mdelem '
+             'grpc_static_mdelem_manifested[GRPC_STATIC_MDELEM_COUNT];')
+print >> C, ('''
+/* Warning: the core static metadata currently operates under the soft constraint
+that the first GRPC_CHTTP2_LAST_STATIC_ENTRY (61) entries must contain
+metadata specified by the http2 hpack standard. The CHTTP2 transport reads the
+core metadata with this assumption in mind. If the order of the core static
+metadata is to be changed, then the CHTTP2 transport must be changed as well to
+stop relying on the core metadata. */
+''')
+print >> C, ('grpc_mdelem '
+             'grpc_static_mdelem_manifested[GRPC_STATIC_MDELEM_COUNT] = {')
+print >> C, '// clang-format off'
+static_mds = []
 for i, elem in enumerate(all_elems):
+    md_name = mangle(elem).upper()
+    md_human_readable = '"%s": "%s"' % elem
+    md_spec = '    /* %s: \n     %s */\n' % (md_name, md_human_readable)
+    md_spec += '    GRPC_MAKE_MDELEM(\n'
+    md_spec += (('        &grpc_static_mdelem_table[%d].data(),\n' % i) +
+                '        GRPC_MDELEM_STORAGE_STATIC)')
+    static_mds.append(md_spec)
+print >> C, ',\n'.join(static_mds)
+print >> C, '// clang-format on'
+print >> C, ('};')
+
+for i, elem in enumerate(all_elems):
+    md_name = mangle(elem).upper()
     print >> H, '/* "%s": "%s" */' % elem
-    print >> H, (
-        '#define %s (GRPC_MAKE_MDELEM(&grpc_static_mdelem_table[%d].data(), '
-        'GRPC_MDELEM_STORAGE_STATIC))') % (mangle(elem).upper(), i)
+    print >> H, ('#define %s (grpc_static_mdelem_manifested[%d])' % (md_name,
+                                                                     i))
 print >> H
 
 print >> C, ('uintptr_t grpc_static_mdelem_user_data[GRPC_STATIC_MDELEM_COUNT] '


### PR DESCRIPTION
Removed duplicate static table from hpack table. Removed an or instruction for
every usage of static grpc metadata. Inlined hpack table lookups for static
metadata.

This leads to faster hpack parser creation:
BM_HpackParserInitDestroy 5.32µs ± 1% 0.06µs ± 1%  -98.91% (p=0.000 n=18+19)

And slightly faster parsing:
BM_HpackParserParseHeader<RepresentativeClientInitialMetadata, OnInitialHeader>
456ns ± 1%              435ns ± 1%   -4.74%        (p=0.000 n=18+19)
BM_HpackParserParseHeader<MoreRepresentativeClientInitialMetadata,
OnInitialHeader>
1.06µs ± 2%             1.04µs ± 2%   -1.82%        (p=0.000 n=19+20)

It also yields a slight (0.5 - 1.0 microsecond) reduction in CPU time for
fullstack unary pingpong:
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/512
[polls/iter:3.0001                         ]            23.9µs ± 2%
23.0µs ± 1%  -3.63%          (p=0.002 n=6+6)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/32768
[polls/iter:3.00015                        ]            35.1µs ± 1%
34.2µs ± 1%  -2.57%          (p=0.036 n=5+3)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/8/0
[polls/iter:3.00011                        ]            21.7µs ± 3%
21.2µs ± 2%  -2.44%          (p=0.017 n=6+5)