### PR TITLE
Move compiler targets from /BUILD to /src/compiler/BUILD

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -30,7 +30,6 @@ load(
     "//bazel:grpc_build_system.bzl",
     "grpc_cc_library",
     "grpc_generate_one_off_targets",
-    "grpc_proto_plugin",
 )
 
 config_setting(
@@ -427,92 +426,6 @@ grpc_cc_library(
         "grpc++",
         "//src/proto/grpc/status:status_proto",
     ],
-)
-
-grpc_cc_library(
-    name = "grpc_plugin_support",
-    srcs = [
-        "src/compiler/cpp_generator.cc",
-        "src/compiler/csharp_generator.cc",
-        "src/compiler/node_generator.cc",
-        "src/compiler/objective_c_generator.cc",
-        "src/compiler/php_generator.cc",
-        "src/compiler/python_generator.cc",
-        "src/compiler/ruby_generator.cc",
-    ],
-    hdrs = [
-        "src/compiler/config.h",
-        "src/compiler/cpp_generator.h",
-        "src/compiler/cpp_generator_helpers.h",
-        "src/compiler/cpp_plugin.h",
-        "src/compiler/csharp_generator.h",
-        "src/compiler/csharp_generator_helpers.h",
-        "src/compiler/generator_helpers.h",
-        "src/compiler/node_generator.h",
-        "src/compiler/node_generator_helpers.h",
-        "src/compiler/objective_c_generator.h",
-        "src/compiler/objective_c_generator_helpers.h",
-        "src/compiler/php_generator.h",
-        "src/compiler/php_generator_helpers.h",
-        "src/compiler/protobuf_plugin.h",
-        "src/compiler/python_generator.h",
-        "src/compiler/python_generator_helpers.h",
-        "src/compiler/python_private_generator.h",
-        "src/compiler/ruby_generator.h",
-        "src/compiler/ruby_generator_helpers-inl.h",
-        "src/compiler/ruby_generator_map-inl.h",
-        "src/compiler/ruby_generator_string-inl.h",
-        "src/compiler/schema_interface.h",
-    ],
-    external_deps = [
-        "protobuf_clib",
-    ],
-    language = "c++",
-    deps = [
-        "grpc++_config_proto",
-    ],
-)
-
-grpc_proto_plugin(
-    name = "grpc_cpp_plugin",
-    srcs = ["src/compiler/cpp_plugin.cc"],
-    deps = [":grpc_plugin_support"],
-)
-
-grpc_proto_plugin(
-    name = "grpc_csharp_plugin",
-    srcs = ["src/compiler/csharp_plugin.cc"],
-    deps = [":grpc_plugin_support"],
-)
-
-grpc_proto_plugin(
-    name = "grpc_node_plugin",
-    srcs = ["src/compiler/node_plugin.cc"],
-    deps = [":grpc_plugin_support"],
-)
-
-grpc_proto_plugin(
-    name = "grpc_objective_c_plugin",
-    srcs = ["src/compiler/objective_c_plugin.cc"],
-    deps = [":grpc_plugin_support"],
-)
-
-grpc_proto_plugin(
-    name = "grpc_php_plugin",
-    srcs = ["src/compiler/php_plugin.cc"],
-    deps = [":grpc_plugin_support"],
-)
-
-grpc_proto_plugin(
-    name = "grpc_python_plugin",
-    srcs = ["src/compiler/python_plugin.cc"],
-    deps = [":grpc_plugin_support"],
-)
-
-grpc_proto_plugin(
-    name = "grpc_ruby_plugin",
-    srcs = ["src/compiler/ruby_plugin.cc"],
-    deps = [":grpc_plugin_support"],
 )
 
 grpc_cc_library(

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -1413,6 +1413,7 @@ config("grpc_config") {
         "include/grpc++/impl/codegen/config_protobuf.h",
         "include/grpcpp/impl/codegen/config_protobuf.h",
         "src/compiler/config.h",
+        "src/compiler/config_protobuf.h",
         "src/compiler/cpp_generator.cc",
         "src/compiler/cpp_generator.h",
         "src/compiler/cpp_generator_helpers.h",

--- a/bazel/cc_grpc_library.bzl
+++ b/bazel/cc_grpc_library.bzl
@@ -88,7 +88,7 @@ def cc_grpc_library(
         generate_cc(
             name = codegen_grpc_target,
             srcs = proto_targets,
-            plugin = "@com_github_grpc_grpc//:grpc_cpp_plugin",
+            plugin = "@com_github_grpc_grpc//src/compiler:grpc_cpp_plugin",
             well_known_protos = well_known_protos,
             generate_mocks = generate_mocks,
             **kwargs

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -78,7 +78,7 @@ def grpc_deps():
 
     native.bind(
         name = "grpc_cpp_plugin",
-        actual = "@com_github_grpc_grpc//:grpc_cpp_plugin",
+        actual = "@com_github_grpc_grpc//src/compiler:grpc_cpp_plugin",
     )
 
     native.bind(

--- a/bazel/python_rules.bzl
+++ b/bazel/python_rules.bzl
@@ -163,7 +163,7 @@ def py_proto_library(
         _generate_py(
             name = codegen_grpc_target,
             deps = deps,
-            plugin = "//:grpc_python_plugin",
+            plugin = "//src/compiler:grpc_python_plugin",
             well_known_protos = well_known_protos,
             **kwargs
         )

--- a/build.yaml
+++ b/build.yaml
@@ -1969,6 +1969,7 @@ libs:
   language: c++
   headers:
   - src/compiler/config.h
+  - src/compiler/config_protobuf.h
   - src/compiler/cpp_generator.h
   - src/compiler/cpp_generator_helpers.h
   - src/compiler/csharp_generator.h

--- a/src/compiler/BUILD
+++ b/src/compiler/BUILD
@@ -1,0 +1,120 @@
+# gRPC Bazel BUILD file.
+#
+# Copyright 2016 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+licenses(["notice"])  # Apache v2
+
+exports_files(["LICENSE"])
+
+package(
+    default_visibility = ["//visibility:public"],
+    features = [
+        "-layering_check",
+        "-parse_headers",
+    ],
+)
+
+load(
+    "//bazel:grpc_build_system.bzl",
+    "grpc_cc_library",
+    "grpc_proto_plugin",
+)
+
+grpc_cc_library(
+    name = "grpc_plugin_support",
+    srcs = [
+        "cpp_generator.cc",
+        "csharp_generator.cc",
+        "node_generator.cc",
+        "objective_c_generator.cc",
+        "php_generator.cc",
+        "python_generator.cc",
+        "ruby_generator.cc",
+    ],
+    hdrs = [
+        "config_protobuf.h",
+        "config.h",
+        "cpp_generator.h",
+        "cpp_generator_helpers.h",
+        "cpp_plugin.h",
+        "csharp_generator.h",
+        "csharp_generator_helpers.h",
+        "generator_helpers.h",
+        "node_generator.h",
+        "node_generator_helpers.h",
+        "objective_c_generator.h",
+        "objective_c_generator_helpers.h",
+        "php_generator.h",
+        "php_generator_helpers.h",
+        "protobuf_plugin.h",
+        "python_generator.h",
+        "python_generator_helpers.h",
+        "python_private_generator.h",
+        "ruby_generator.h",
+        "ruby_generator_helpers-inl.h",
+        "ruby_generator_map-inl.h",
+        "ruby_generator_string-inl.h",
+        "schema_interface.h",
+    ],
+    external_deps = [
+        "protobuf_clib",
+    ],
+    language = "c++",
+    deps = [
+        "//:grpc++_config_proto",
+    ],
+)
+
+grpc_proto_plugin(
+    name = "grpc_cpp_plugin",
+    srcs = ["cpp_plugin.cc"],
+    deps = [":grpc_plugin_support"],
+)
+
+grpc_proto_plugin(
+    name = "grpc_csharp_plugin",
+    srcs = ["csharp_plugin.cc"],
+    deps = [":grpc_plugin_support"],
+)
+
+grpc_proto_plugin(
+    name = "grpc_node_plugin",
+    srcs = ["node_plugin.cc"],
+    deps = [":grpc_plugin_support"],
+)
+
+grpc_proto_plugin(
+    name = "grpc_objective_c_plugin",
+    srcs = ["objective_c_plugin.cc"],
+    deps = [":grpc_plugin_support"],
+)
+
+grpc_proto_plugin(
+    name = "grpc_php_plugin",
+    srcs = ["php_plugin.cc"],
+    deps = [":grpc_plugin_support"],
+)
+
+grpc_proto_plugin(
+    name = "grpc_python_plugin",
+    srcs = ["python_plugin.cc"],
+    deps = [":grpc_plugin_support"],
+)
+
+grpc_proto_plugin(
+    name = "grpc_ruby_plugin",
+    srcs = ["ruby_plugin.cc"],
+    deps = [":grpc_plugin_support"],
+)

--- a/src/compiler/config.h
+++ b/src/compiler/config.h
@@ -19,35 +19,7 @@
 #ifndef SRC_COMPILER_CONFIG_H
 #define SRC_COMPILER_CONFIG_H
 
-#include <grpcpp/impl/codegen/config_protobuf.h>
-
-#ifndef GRPC_CUSTOM_CODEGENERATOR
-#include <google/protobuf/compiler/code_generator.h>
-#define GRPC_CUSTOM_CODEGENERATOR ::google::protobuf::compiler::CodeGenerator
-#define GRPC_CUSTOM_GENERATORCONTEXT \
-  ::google::protobuf::compiler::GeneratorContext
-#endif
-
-#ifndef GRPC_CUSTOM_PRINTER
-#include <google/protobuf/io/coded_stream.h>
-#include <google/protobuf/io/printer.h>
-#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
-#define GRPC_CUSTOM_PRINTER ::google::protobuf::io::Printer
-#define GRPC_CUSTOM_CODEDOUTPUTSTREAM ::google::protobuf::io::CodedOutputStream
-#define GRPC_CUSTOM_STRINGOUTPUTSTREAM \
-  ::google::protobuf::io::StringOutputStream
-#endif
-
-#ifndef GRPC_CUSTOM_PLUGINMAIN
-#include <google/protobuf/compiler/plugin.h>
-#define GRPC_CUSTOM_PLUGINMAIN ::google::protobuf::compiler::PluginMain
-#endif
-
-#ifndef GRPC_CUSTOM_PARSEGENERATORPARAMETER
-#include <google/protobuf/compiler/code_generator.h>
-#define GRPC_CUSTOM_PARSEGENERATORPARAMETER \
-  ::google::protobuf::compiler::ParseGeneratorParameter
-#endif
+#include "src/compiler/config_protobuf.h"
 
 #ifndef GRPC_CUSTOM_STRING
 #include <string>

--- a/src/compiler/config_protobuf.h
+++ b/src/compiler/config_protobuf.h
@@ -1,0 +1,52 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef SRC_COMPILER_CONFIG_PROTOBUF_H
+#define SRC_COMPILER_CONFIG_PROTOBUF_H
+
+#include <grpcpp/impl/codegen/config_protobuf.h>
+
+#ifndef GRPC_CUSTOM_CODEGENERATOR
+#include <google/protobuf/compiler/code_generator.h>
+#define GRPC_CUSTOM_CODEGENERATOR ::google::protobuf::compiler::CodeGenerator
+#define GRPC_CUSTOM_GENERATORCONTEXT \
+  ::google::protobuf::compiler::GeneratorContext
+#endif
+
+#ifndef GRPC_CUSTOM_PRINTER
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/printer.h>
+#include <google/protobuf/io/zero_copy_stream_impl_lite.h>
+#define GRPC_CUSTOM_PRINTER ::google::protobuf::io::Printer
+#define GRPC_CUSTOM_CODEDOUTPUTSTREAM ::google::protobuf::io::CodedOutputStream
+#define GRPC_CUSTOM_STRINGOUTPUTSTREAM \
+  ::google::protobuf::io::StringOutputStream
+#endif
+
+#ifndef GRPC_CUSTOM_PLUGINMAIN
+#include <google/protobuf/compiler/plugin.h>
+#define GRPC_CUSTOM_PLUGINMAIN ::google::protobuf::compiler::PluginMain
+#endif
+
+#ifndef GRPC_CUSTOM_PARSEGENERATORPARAMETER
+#include <google/protobuf/compiler/code_generator.h>
+#define GRPC_CUSTOM_PARSEGENERATORPARAMETER \
+  ::google::protobuf::compiler::ParseGeneratorParameter
+#endif
+
+#endif  // SRC_COMPILER_CONFIG_PROTOBUF_H

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -7184,6 +7184,7 @@
     ], 
     "headers": [
       "src/compiler/config.h", 
+      "src/compiler/config_protobuf.h", 
       "src/compiler/cpp_generator.h", 
       "src/compiler/cpp_generator_helpers.h", 
       "src/compiler/csharp_generator.h", 
@@ -7210,6 +7211,7 @@
     "name": "grpc_plugin_support", 
     "src": [
       "src/compiler/config.h", 
+      "src/compiler/config_protobuf.h", 
       "src/compiler/cpp_generator.cc", 
       "src/compiler/cpp_generator.h", 
       "src/compiler/cpp_generator_helpers.h", 


### PR DESCRIPTION
Move compiler targets from /BUILD to /src/compiler/BUILD to prevent /BUILD from having dependencies against protobuf compiler-specific target, which is important to keep unnecessary dependency at bay. Compiler specific targets is only required to build gRPC compiler but not gRPC library itself.

- Create new /src/compiler/BUILD to include compiler stuff.
- Create new /src/compiler/config_protobuf.h to split configuration into protobuf-specifics and general.