### PR TITLE
Channelz: SubchannelNode no longer holds a pointer to the Subchannel

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel_channelz.cc
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.cc
@@ -33,7 +33,6 @@ namespace channelz {
 SubchannelNode::SubchannelNode(const char* target_address,
                                size_t channel_tracer_max_nodes)
     : BaseNode(EntityType::kSubchannel),
-      subchannel_destroyed_(false),
       target_(UniquePtr<char>(gpr_strdup(target_address))),
       trace_(channel_tracer_max_nodes) {}
 
@@ -49,11 +48,7 @@ void SubchannelNode::SetChildSocketUuid(intptr_t uuid) {
 
 void SubchannelNode::PopulateConnectivityState(grpc_json* json) {
   grpc_connectivity_state state;
-  if (subchannel_destroyed_) {
-    state = GRPC_CHANNEL_SHUTDOWN;
-  } else {
-    state = connectivity_state_.Load(MemoryOrder::RELAXED);
-  }
+  state = connectivity_state_.Load(MemoryOrder::RELAXED);
   json = grpc_json_create_child(nullptr, json, "state", nullptr,
                                 GRPC_JSON_OBJECT, false);
   grpc_json_create_child(nullptr, json, "state",

--- a/src/core/ext/filters/client_channel/client_channel_channelz.cc
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.cc
@@ -47,7 +47,8 @@ void SubchannelNode::SetChildSocketUuid(intptr_t uuid) {
 }
 
 void SubchannelNode::PopulateConnectivityState(grpc_json* json) {
-  grpc_connectivity_state state = connectivity_state_.Load(MemoryOrder::RELAXED);
+  grpc_connectivity_state state =
+      connectivity_state_.Load(MemoryOrder::RELAXED);
   json = grpc_json_create_child(nullptr, json, "state", nullptr,
                                 GRPC_JSON_OBJECT, false);
   grpc_json_create_child(nullptr, json, "state",

--- a/src/core/ext/filters/client_channel/client_channel_channelz.cc
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.cc
@@ -30,23 +30,29 @@
 namespace grpc_core {
 namespace channelz {
 
-SubchannelNode::SubchannelNode(Subchannel* subchannel,
+SubchannelNode::SubchannelNode(const char* target_address,
                                size_t channel_tracer_max_nodes)
     : BaseNode(EntityType::kSubchannel),
-      subchannel_(subchannel),
-      target_(UniquePtr<char>(gpr_strdup(subchannel_->GetTargetAddress()))),
+      subchannel_destroyed_(false),
+      target_(UniquePtr<char>(gpr_strdup(target_address))),
       trace_(channel_tracer_max_nodes) {}
 
 SubchannelNode::~SubchannelNode() {}
 
+void SubchannelNode::UpdateConnectivityState(grpc_connectivity_state state) {
+  connectivity_state_.Store(state, MemoryOrder::RELAXED);
+}
+
+void SubchannelNode::SetChildSocketUuid(intptr_t uuid) {
+  child_socket_uuid_.Store(uuid, MemoryOrder::RELAXED);
+}
+
 void SubchannelNode::PopulateConnectivityState(grpc_json* json) {
   grpc_connectivity_state state;
-  if (subchannel_ == nullptr) {
+  if (subchannel_destroyed_) {
     state = GRPC_CHANNEL_SHUTDOWN;
   } else {
-    state = subchannel_->CheckConnectivityState(
-        nullptr /* health_check_service_name */,
-        nullptr /* connected_subchannel */);
+    state = connectivity_state_.Load(MemoryOrder::RELAXED);
   }
   json = grpc_json_create_child(nullptr, json, "state", nullptr,
                                 GRPC_JSON_OBJECT, false);
@@ -87,7 +93,7 @@ grpc_json* SubchannelNode::RenderJson() {
   call_counter_.PopulateCallCounts(json);
   json = top_level_json;
   // populate the child socket.
-  intptr_t socket_uuid = subchannel_->GetChildSocketUuid();
+  intptr_t socket_uuid = child_socket_uuid_.Load(MemoryOrder::RELAXED);
   if (socket_uuid != 0) {
     grpc_json* array_parent = grpc_json_create_child(
         nullptr, json, "socketRef", nullptr, GRPC_JSON_ARRAY, false);

--- a/src/core/ext/filters/client_channel/client_channel_channelz.cc
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.cc
@@ -47,8 +47,7 @@ void SubchannelNode::SetChildSocketUuid(intptr_t uuid) {
 }
 
 void SubchannelNode::PopulateConnectivityState(grpc_json* json) {
-  grpc_connectivity_state state;
-  state = connectivity_state_.Load(MemoryOrder::RELAXED);
+  grpc_connectivity_state state = connectivity_state_.Load(MemoryOrder::RELAXED);
   json = grpc_json_create_child(nullptr, json, "state", nullptr,
                                 GRPC_JSON_OBJECT, false);
   grpc_json_create_child(nullptr, json, "state",

--- a/src/core/ext/filters/client_channel/client_channel_channelz.h
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.h
@@ -34,8 +34,22 @@ namespace channelz {
 
 class SubchannelNode : public BaseNode {
  public:
-  SubchannelNode(Subchannel* subchannel, size_t channel_tracer_max_nodes);
+  SubchannelNode(const char* target_address, size_t channel_tracer_max_nodes);
   ~SubchannelNode() override;
+
+  void MarkSubchannelDestroyed() {
+    GPR_ASSERT(!subchannel_destroyed_);
+    subchannel_destroyed_ = true;
+  }
+
+  // Used when the subchannel's transport connectivity state changes.
+  void UpdateConnectivityState(grpc_connectivity_state state);
+
+  // Used when the subchannel's child socket uuid changes. This should be set
+  // when the subchannel's transport is created and set to 0 when the subchannel
+  // unrefs the transport. A uuid of 0 indicates that the child socket is no
+  // longer associated with this subchannel.
+  void SetChildSocketUuid(intptr_t uuid);
 
   void MarkSubchannelDestroyed() {
     GPR_ASSERT(subchannel_ != nullptr);
@@ -61,7 +75,9 @@ class SubchannelNode : public BaseNode {
  private:
   void PopulateConnectivityState(grpc_json* json);
 
-  Subchannel* subchannel_;
+  bool subchannel_destroyed_;
+  Atomic<grpc_connectivity_state> connectivity_state_{GRPC_CHANNEL_IDLE};
+  Atomic<intptr_t> child_socket_uuid_{0};
   UniquePtr<char> target_;
   CallCountingHelper call_counter_;
   ChannelTrace trace_;

--- a/src/core/ext/filters/client_channel/client_channel_channelz.h
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.h
@@ -37,11 +37,6 @@ class SubchannelNode : public BaseNode {
   SubchannelNode(const char* target_address, size_t channel_tracer_max_nodes);
   ~SubchannelNode() override;
 
-  void MarkSubchannelDestroyed() {
-    GPR_ASSERT(!subchannel_destroyed_);
-    subchannel_destroyed_ = true;
-  }
-
   // Used when the subchannel's transport connectivity state changes.
   void UpdateConnectivityState(grpc_connectivity_state state);
 
@@ -70,7 +65,6 @@ class SubchannelNode : public BaseNode {
  private:
   void PopulateConnectivityState(grpc_json* json);
 
-  bool subchannel_destroyed_;
   Atomic<grpc_connectivity_state> connectivity_state_{GRPC_CHANNEL_IDLE};
   Atomic<intptr_t> child_socket_uuid_{0};
   UniquePtr<char> target_;

--- a/src/core/ext/filters/client_channel/client_channel_channelz.h
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.h
@@ -37,7 +37,7 @@ class SubchannelNode : public BaseNode {
   SubchannelNode(const char* target_address, size_t channel_tracer_max_nodes);
   ~SubchannelNode() override;
 
-  // Used when the subchannel's connectivity state changes.
+  // Sets the subchannel's connectivity state without health checking.
   void UpdateConnectivityState(grpc_connectivity_state state);
 
   // Used when the subchannel's child socket uuid changes. This should be set

--- a/src/core/ext/filters/client_channel/client_channel_channelz.h
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.h
@@ -37,7 +37,7 @@ class SubchannelNode : public BaseNode {
   SubchannelNode(const char* target_address, size_t channel_tracer_max_nodes);
   ~SubchannelNode() override;
 
-  // Used when the subchannel's transport connectivity state changes.
+  // Used when the subchannel's connectivity state changes.
   void UpdateConnectivityState(grpc_connectivity_state state);
 
   // Used when the subchannel's child socket uuid changes. This should be set

--- a/src/core/ext/filters/client_channel/client_channel_channelz.h
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.h
@@ -51,11 +51,6 @@ class SubchannelNode : public BaseNode {
   // longer associated with this subchannel.
   void SetChildSocketUuid(intptr_t uuid);
 
-  void MarkSubchannelDestroyed() {
-    GPR_ASSERT(subchannel_ != nullptr);
-    subchannel_ = nullptr;
-  }
-
   grpc_json* RenderJson() override;
 
   // proxy methods to composed classes.

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -344,7 +344,7 @@ class Subchannel::ConnectedSubchannelStateWatcher {
                           self->pending_connectivity_state_));
             }
             c->connected_subchannel_.reset();
-             if (c->channelz_node() != nullptr) {
+            if (c->channelz_node() != nullptr) {
               c->channelz_node()->SetChildSocketUuid(0);
             }
             c->SetConnectivityStateLocked(GRPC_CHANNEL_TRANSIENT_FAILURE);

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -933,7 +933,7 @@ const char* SubchannelConnectivityStateChangeString(
 void Subchannel::SetConnectivityStateLocked(grpc_connectivity_state state) {
   state_ = state;
   if (channelz_node_ != nullptr) {
-    channelz_node()->UpdateConnectivityState(state);
+    channelz_node_->UpdateConnectivityState(state);
     channelz_node_->AddTraceEvent(
         channelz::ChannelTrace::Severity::Info,
         grpc_slice_from_static_string(
@@ -1085,8 +1085,8 @@ bool Subchannel::PublishTransportLocked() {
       New<ConnectedSubchannel>(stk, args_, channelz_node_, socket_uuid));
   gpr_log(GPR_INFO, "New connected subchannel at %p for subchannel %p",
           connected_subchannel_.get(), this);
-  if (channelz_node() != nullptr) {
-    channelz_node()->SetChildSocketUuid(socket_uuid);
+  if (channelz_node_ != nullptr) {
+    channelz_node_->SetChildSocketUuid(socket_uuid);
   }
   // Instantiate state watcher.  Will clean itself up.
   New<ConnectedSubchannelStateWatcher>(this);

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -679,7 +679,7 @@ Subchannel::Subchannel(SubchannelKey* key, grpc_connector* connector,
       (size_t)grpc_channel_arg_get_integer(arg, options);
   if (channelz_enabled) {
     channelz_node_ = MakeRefCounted<channelz::SubchannelNode>(
-        this->GetTargetAddress(), channel_tracer_max_memory);
+        GetTargetAddress(), channel_tracer_max_memory);
     channelz_node_->AddTraceEvent(
         channelz::ChannelTrace::Severity::Info,
         grpc_slice_from_static_string("subchannel created"));

--- a/src/core/ext/filters/client_channel/subchannel.cc
+++ b/src/core/ext/filters/client_channel/subchannel.cc
@@ -691,7 +691,7 @@ Subchannel::~Subchannel() {
     channelz_node_->AddTraceEvent(
         channelz::ChannelTrace::Severity::Info,
         grpc_slice_from_static_string("Subchannel destroyed"));
-    channelz_node_->MarkSubchannelDestroyed();
+    channelz_node_->UpdateConnectivityState(GRPC_CHANNEL_SHUTDOWN);
   }
   grpc_channel_args_destroy(args_);
   grpc_connector_unref(connector_);

--- a/src/core/ext/filters/client_channel/subchannel.h
+++ b/src/core/ext/filters/client_channel/subchannel.h
@@ -85,8 +85,7 @@ class ConnectedSubchannel : public ConnectedSubchannelInterface {
 
   ConnectedSubchannel(
       grpc_channel_stack* channel_stack, const grpc_channel_args* args,
-      RefCountedPtr<channelz::SubchannelNode> channelz_subchannel,
-      intptr_t socket_uuid);
+      RefCountedPtr<channelz::SubchannelNode> channelz_subchannel);
   ~ConnectedSubchannel();
 
   void NotifyOnStateChange(grpc_pollset_set* interested_parties,
@@ -101,7 +100,6 @@ class ConnectedSubchannel : public ConnectedSubchannelInterface {
   channelz::SubchannelNode* channelz_subchannel() const {
     return channelz_subchannel_.get();
   }
-  intptr_t socket_uuid() const { return socket_uuid_; }
 
   size_t GetInitialCallSizeEstimate(size_t parent_data_size) const;
 
@@ -111,8 +109,6 @@ class ConnectedSubchannel : public ConnectedSubchannelInterface {
   // ref counted pointer to the channelz node in this connected subchannel's
   // owning subchannel.
   RefCountedPtr<channelz::SubchannelNode> channelz_subchannel_;
-  // uuid of this subchannel's socket. 0 if this subchannel is not connected.
-  const intptr_t socket_uuid_;
 };
 
 // Implements the interface of RefCounted<>.
@@ -199,8 +195,6 @@ class Subchannel {
   // non-zero. If the strong refcount is zero, does not alter the refcount and
   // returns null.
   Subchannel* RefFromWeakRef(GRPC_SUBCHANNEL_REF_EXTRA_ARGS);
-
-  intptr_t GetChildSocketUuid();
 
   // Gets the string representing the subchannel address.
   // Caller doesn't take ownership.


### PR DESCRIPTION
This change makes it so that the SubchannelNode no longer holds a ref to the Subchannel. Instead, the Subchannel will alert the SubchannelNode when the connectivity state and child socket uuid change. 

The purpose of the change is to enable different types of subchannels (which are not of type Subchannel) to use the SubchannelNode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/19463)
<!-- Reviewable:end -->
