### PR TITLE
Bump min CMake to 3.5.1 to match Google benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 
 
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5.1)
 
 set(PACKAGE_NAME      "grpc")
 set(PACKAGE_VERSION   "1.23.0-dev")

--- a/examples/cpp/helloworld/CMakeLists.txt
+++ b/examples/cpp/helloworld/CMakeLists.txt
@@ -17,7 +17,7 @@
 # See cmake_externalproject/CMakeLists.txt for all-in-one cmake build
 # that automatically builds all the dependencies before building helloworld.
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5.1)
 
 project(HelloWorld C CXX)
 

--- a/examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt
+++ b/examples/cpp/helloworld/cmake_externalproject/CMakeLists.txt
@@ -20,7 +20,7 @@
 # including the "helloworld" project itself.
 # See https://blog.kitware.com/cmake-superbuilds-git-submodules/
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.5.1)
 
 # Project
 project(HelloWorld-SuperBuild C CXX)

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -69,7 +69,7 @@
     return 'endif()\n'
   %>
 
-  cmake_minimum_required(VERSION 2.8)
+  cmake_minimum_required(VERSION 3.5.1)
 
   set(PACKAGE_NAME      "grpc")
   set(PACKAGE_VERSION   "${settings.cpp_version}")


### PR DESCRIPTION
The Google Benchmark CMake build needs CMake 3.5.1 or newer. CMake 3.5.1
was released May 24, 2016 and is available in Debian stable and Ubuntu
16.04 and 18.04.
