### PR TITLE
C# - fix #19470 - emulate legacy serializer/deserializer when contextual API is used

### DIFF
--- a/src/csharp/Grpc.Core.Api/DeserializationContext.cs
+++ b/src/csharp/Grpc.Core.Api/DeserializationContext.cs
@@ -61,7 +61,7 @@ namespace Grpc.Core
         /// <returns>read only sequence containing the entire payload.</returns>
         public virtual System.Buffers.ReadOnlySequence<byte> PayloadAsReadOnlySequence()
         {
-            throw new NotImplementedException();
+            return new System.Buffers.ReadOnlySequence<byte>(PayloadAsNewBuffer());
         }
 #endif        
     }

--- a/src/csharp/Grpc.Core.Api/Marshaller.cs
+++ b/src/csharp/Grpc.Core.Api/Marshaller.cs
@@ -164,39 +164,39 @@ namespace Grpc.Core
     internal class LegacyDeserializationContext : DeserializationContext
     {
         private LegacyDeserializationContext() { }
-        private static readonly LegacyDeserializationContext s_singleton = new LegacyDeserializationContext();
+        private static readonly LegacyDeserializationContext Singleton = new LegacyDeserializationContext();
 
         internal static DeserializationContext Prepare(byte[] payload)
         {
             GrpcPreconditions.CheckNotNull(payload, nameof(payload));
-            ts_payload = payload;
-            return s_singleton;
+            ThreadStaticPayload = payload;
+            return Singleton;
         }
         [ThreadStatic]
-        private static byte[] ts_payload;
+        private static byte[] ThreadStaticPayload;
 
         public override int PayloadLength
         {
             get
             {
-                return ts_payload.Length;
+                return ThreadStaticPayload.Length;
             }
         }
         public override byte[] PayloadAsNewBuffer()
         {
-            return ts_payload;
+            return ThreadStaticPayload;
         }
 
 #if GRPC_CSHARP_SUPPORT_SYSTEM_MEMORY
         public override ReadOnlySequence<byte> PayloadAsReadOnlySequence()
         {
-            return new ReadOnlySequence<byte>(ts_payload);
+            return new ReadOnlySequence<byte>(ThreadStaticPayload);
         }
 #endif
 
         internal static void Complete()
         {
-            ts_payload = null;
+            ThreadStaticPayload = null;
         }
     }
     /// <summary>
@@ -205,26 +205,26 @@ namespace Grpc.Core
     internal class LegacySerializationContext : SerializationContext
     {
         private LegacySerializationContext() { }
-        private static readonly LegacySerializationContext s_singleton = new LegacySerializationContext();
+        private static readonly LegacySerializationContext Singleton = new LegacySerializationContext();
         [ThreadStatic]
-        private static byte[] ts_payload;
+        private static byte[] ThreadStaticPayload;
 
         internal static SerializationContext Prepare()
         {
-            ts_payload = null;
-            return s_singleton;
+            ThreadStaticPayload = null;
+            return Singleton;
         }
 
         public override void Complete(byte[] payload)
         {
-            GrpcPreconditions.CheckState(ts_payload == null);
+            GrpcPreconditions.CheckState(ThreadStaticPayload == null);
             GrpcPreconditions.CheckNotNull(payload, nameof(payload));
-            ts_payload = payload;
+            ThreadStaticPayload = payload;
         }
         internal static byte[] Complete()
         {
-            var tmp = ts_payload;
-            ts_payload = null;
+            var tmp = ThreadStaticPayload;
+            ThreadStaticPayload = null;
             GrpcPreconditions.CheckState(tmp != null);
             return tmp;
         }

--- a/src/csharp/Grpc.Core.Api/Marshaller.cs
+++ b/src/csharp/Grpc.Core.Api/Marshaller.cs
@@ -105,7 +105,7 @@ namespace Grpc.Core
         }
 
 
-        // for backward compatibility, emulate the contextual deserializer using the simple one
+        // for backward compatibility, emulate the simple deserializer using the contextual one
         private T EmulateLegacyDeserializer(byte[] payload)
         {
             var ctx = LegacyDeserializationContext.Prepare(payload);
@@ -114,7 +114,7 @@ namespace Grpc.Core
             return value;
         }
 
-        // for backward compatibility, emulate the contextual serializer using the simple one
+        // for backward compatibility, emulate the simple serializer using the contextual one
         private byte[] EmulateLegacySerializer(T value)
         {
             var ctx = LegacySerializationContext.Prepare();

--- a/src/csharp/Grpc.Core.Api/Marshaller.cs
+++ b/src/csharp/Grpc.Core.Api/Marshaller.cs
@@ -17,8 +17,11 @@
 #endregion
 
 using System;
-using System.Buffers;
 using Grpc.Core.Utils;
+
+#if GRPC_CSHARP_SUPPORT_SYSTEM_MEMORY
+using System.Buffers;
+#endif
 
 namespace Grpc.Core
 {
@@ -178,10 +181,13 @@ namespace Grpc.Core
         {
             return ts_payload;
         }
+
+#if GRPC_CSHARP_SUPPORT_SYSTEM_MEMORY
         public override ReadOnlySequence<byte> PayloadAsReadOnlySequence()
         {
             return new ReadOnlySequence<byte>(ts_payload);
         }
+#endif
 
         internal static void Complete()
         {

--- a/src/csharp/Grpc.Core.Api/Marshaller.cs
+++ b/src/csharp/Grpc.Core.Api/Marshaller.cs
@@ -164,6 +164,7 @@ namespace Grpc.Core
 
         internal static DeserializationContext Prepare(byte[] payload)
         {
+            GrpcPreconditions.CheckNotNull(payload, nameof(payload));
             ts_payload = payload;
             return s_singleton;
         }
@@ -174,7 +175,7 @@ namespace Grpc.Core
         {
             get
             {
-                return ts_payload == null ? 0 : ts_payload.Length;
+                return ts_payload.Length;
             }
         }
         public override byte[] PayloadAsNewBuffer()
@@ -212,12 +213,15 @@ namespace Grpc.Core
 
         public override void Complete(byte[] payload)
         {
+            GrpcPreconditions.CheckState(ts_payload == null);
+            GrpcPreconditions.CheckNotNull(payload, nameof(payload));
             ts_payload = payload;
         }
         internal static byte[] Complete()
         {
             var tmp = ts_payload;
             ts_payload = null;
+            GrpcPreconditions.CheckState(tmp != null);
             return tmp;
         }
     }

--- a/src/csharp/Grpc.Core.Tests/MarshallerTest.cs
+++ b/src/csharp/Grpc.Core.Tests/MarshallerTest.cs
@@ -69,8 +69,9 @@ namespace Grpc.Core.Tests
 
             Assert.AreSame(contextualSerializer, marshaller.ContextualSerializer);
             Assert.AreSame(contextualDeserializer, marshaller.ContextualDeserializer);
-            Assert.Throws(typeof(NotImplementedException), () => marshaller.Serializer("abc"));
-            Assert.Throws(typeof(NotImplementedException), () => marshaller.Deserializer(new byte[] {1, 2, 3}));
+
+            Assert.AreEqual("abc", System.Text.Encoding.UTF8.GetString(marshaller.Serializer("abc")));
+            Assert.AreEqual("abc", marshaller.Deserializer(System.Text.Encoding.UTF8.GetBytes("abc")));
         }
 
         class FakeSerializationContext : SerializationContext


### PR DESCRIPTION
ref https://github.com/grpc/grpc/issues/19470

1. ensure that .Serializer/.Deserializer do something useful when the `Marshaller<T>` is created with contextual implementations
2. also use sane default implementation of PayloadAsReadOnlySequence, as not all contexts might implement correctly

This is because grpc-dotnet uses .Serializer/.Deserializer directly, see https://github.com/grpc/grpc-dotnet/issues/357