### PR TITLE
Flesh out some missing API's

### DIFF
--- a/src/core/lib/surface/version.cc
+++ b/src/core/lib/surface/version.cc
@@ -26,3 +26,9 @@
 const char* grpc_version_string(void) { return "7.0.0"; }
 
 const char* grpc_g_stands_for(void) { return "gangnam"; }
+
+const char* grpc_r_stands_for(void) { return "remote"; }
+
+const char* grpc_p_stands_for(void) { return "procedure"; }
+
+const char* grpc_c_stands_for(void) { return "call"; }

--- a/templates/src/core/lib/surface/version.cc.template
+++ b/templates/src/core/lib/surface/version.cc.template
@@ -28,3 +28,10 @@
   const char* grpc_version_string(void) { return "${settings.core_version}"; }
 
   const char* grpc_g_stands_for(void) { return "${settings.g_stands_for}"; }
+
+  const char* grpc_r_stands_for(void) { return "remote"; }
+
+  const char* grpc_p_stands_for(void) { return "procedure"; }
+
+  const char* grpc_c_stands_for(void) { return "call"; }
+


### PR DESCRIPTION
gRPC core proudly advertises what g stands for, but fails to define r,
p, and c.

This change provides the missing definitions for applications that are
curious.