### PR TITLE
Explain order of callback execution in executor comments

### DIFF
--- a/src/core/lib/iomgr/executor.cc
+++ b/src/core/lib/iomgr/executor.cc
@@ -120,7 +120,10 @@ size_t Executor::RunClosures(const char* executor_name,
   // thread itself, but this is the point where we could start seeing
   // application-level callbacks. No need to create a new ExecCtx, though,
   // since there already is one and it is flushed (but not destructed) in this
-  // function itself.
+  // function itself. The ApplicationCallbackExecCtx will have its callbacks
+  // invoked on its destruction, which will be after completing any closures in
+  // the executor's closure list (which were explicitly scheduled onto the
+  // executor).
   grpc_core::ApplicationCallbackExecCtx callback_exec_ctx(
       GRPC_APP_CALLBACK_EXEC_CTX_FLAG_IS_INTERNAL_THREAD);
 


### PR DESCRIPTION
A comment to explain the guarantee that makes #19406 avoid deadlock
