### PR TITLE
Slightly better codegen for hpack_encoder.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
@@ -130,8 +130,9 @@ static void begin_frame(framer_state* st) {
    space to add at least about_to_add bytes -- finishes the current frame if
    needed */
 static void ensure_space(framer_state* st, size_t need_bytes) {
-  if (st->output->length - st->output_length_at_start_of_frame + need_bytes <=
-      st->max_frame_size) {
+  if (GPR_LIKELY(st->output->length - st->output_length_at_start_of_frame +
+                     need_bytes <=
+                 st->max_frame_size)) {
     return;
   }
   finish_frame(st, 0, 0);


### PR DESCRIPTION
hpack_encoder::ensure_space checks to see if we need to allocate to start a
frame or not. The common case is that we don't need to, so we mark that code
branch as the more likely one to occur. This causes the common case to jump
around less.

BM_HpackEncoderEncodeDeadline
152ns ± 0% 149ns ± 0%  -1.99%        (p=0.000 n=19+17)
BM_HpackEncoderEncodeHeader<EmptyBatch>/0/16384
35.0ns ± 2% 34.6ns ± 0%  -1.10%        (p=0.000 n=20+17)
BM_HpackEncoderEncodeHeader<EmptyBatch>/1/16384
34.9ns ± 1% 34.7ns ± 1%  -0.81%        (p=0.007 n=20+19)
BM_HpackEncoderEncodeHeader<SingleStaticElem>/0/16384
50.6ns ± 0% 49.1ns ± 1%  -3.06%        (p=0.000 n=17+19)
BM_HpackEncoderEncodeHeader<SingleInternedKeyElem>/0/16384
84.9ns ± 1% 82.4ns ± 1%  -2.90%        (p=0.000 n=20+19)
BM_HpackEncoderEncodeHeader<SingleInternedElem>/0/16384
50.5ns ± 0% 49.2ns ± 1%  -2.54%        (p=0.000 n=15+19)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<1, false>>/0/16384
50.8ns ± 2% 49.6ns ± 1%  -2.46%        (p=0.000 n=17+19)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<3, false>>/0/16384
50.9ns ± 2% 49.5ns ± 1%  -2.78%        (p=0.000 n=20+19)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<10, false>>/0/16384
50.4ns ± 1% 49.2ns ± 1%  -2.32%        (p=0.000 n=18+19)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<31, false>>/0/16384
50.3ns ± 0% 49.2ns ± 1%  -2.16%        (p=0.000 n=18+19)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<100, false>>/0/16384
50.4ns ± 1% 49.2ns ± 1%  -2.35%        (p=0.000 n=19+19)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<1, true>>/0/16384
50.9ns ± 2% 49.4ns ± 1%  -2.81%        (p=0.000 n=20+19)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<3, true>>/0/16384
50.9ns ± 2% 49.4ns ± 1%  -2.91%        (p=0.000 n=20+19)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<10, true>>/0/16384
50.2ns ± 0% 49.2ns ± 0%  -2.04%        (p=0.000 n=17+19)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<31, true>>/0/16384
50.4ns ± 1% 49.2ns ± 1%  -2.38%        (p=0.000 n=19+19)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<100, true>>/0/16384
50.3ns ± 0% 49.2ns ± 0%  -2.06%        (p=0.000 n=19+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedElem>/0/16384
91.7ns ± 1% 85.6ns ± 1%  -6.64%        (p=0.000 n=19+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<1, false>>/0/16384
116ns ± 1% 112ns ± 1%  -3.95%        (p=0.000 n=19+18)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<3, false>>/0/16384
122ns ± 0% 117ns ± 1%  -3.63%        (p=0.000 n=18+17)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<10, false>>/0/16384
145ns ± 1% 140ns ± 0%  -2.89%        (p=0.000 n=18+18)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<31, false>>/0/16384
233ns ± 1% 231ns ± 1%  -1.14%        (p=0.000 n=20+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<100, false>>/0/16384
472ns ± 1% 469ns ± 1%  -0.64%        (p=0.000 n=20+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<1, true>>/0/16384
93.2ns ± 1% 87.3ns ± 1%  -6.41%        (p=0.000 n=20+17)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<3, true>>/0/16384
94.2ns ± 1% 88.0ns ± 1%  -6.59%        (p=0.000 n=20+17)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<10, true>>/0/16384
94.1ns ± 2% 87.5ns ± 1%  -6.98%        (p=0.000 n=20+17)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<31, true>>/0/16384
107ns ± 2% 102ns ± 4%  -4.30%        (p=0.000 n=19+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<100, true>>/0/16384
106ns ± 1% 100ns ± 1%  -5.64%        (p=0.000 n=20+17)
BM_HpackEncoderEncodeHeader<SingleNonInternedElem>/0/1
356ns ± 1% 355ns ± 1%  -0.47%        (p=0.001 n=20+18)
BM_HpackEncoderEncodeHeader<RepresentativeClientInitialMetadata>/0/16384
140ns ± 1% 128ns ± 1%  -7.99%        (p=0.000 n=20+19)
BM_HpackEncoderEncodeHeader<MoreRepresentativeClientInitialMetadata>/0/16384
237ns ± 1% 218ns ± 1%  -7.93%        (p=0.000 n=19+19)
BM_HpackEncoderEncodeHeader<RepresentativeServerInitialMetadata>/0/16384
73.7ns ± 1% 69.7ns ± 1%  -5.47%        (p=0.000 n=20+19)

BM_HpackEncoderEncodeHeader<RepresentativeServerTrailingMetadata>/1/16384
50.7ns ± 0% 49.0ns ± 2%  -3.19%        (p=0.000 n=18+19)