### PR TITLE
Pre-compute static metadata index for hpack_encoder.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
@@ -711,18 +711,28 @@ void grpc_chttp2_encode_header(grpc_chttp2_hpack_compressor* c,
   }
   for (size_t i = 0; i < extra_headers_size; ++i) {
     grpc_mdelem md = *extra_headers[i];
-    uintptr_t static_index = grpc_chttp2_get_static_hpack_table_index(md);
-    if (static_index) {
-      emit_indexed(c, static_cast<uint32_t>(static_index), &st);
+    const bool is_static =
+        GRPC_MDELEM_STORAGE(md) == GRPC_MDELEM_STORAGE_STATIC;
+    uintptr_t static_index;
+    if (is_static &&
+        (static_index =
+             reinterpret_cast<grpc_core::StaticMetadata*>(GRPC_MDELEM_DATA(md))
+                 ->StaticIndex()) < GRPC_CHTTP2_LAST_STATIC_ENTRY) {
+      emit_indexed(c, static_cast<uint32_t>(static_index + 1), &st);
     } else {
       hpack_enc(c, md, &st);
     }
   }
   grpc_metadata_batch_assert_ok(metadata);
   for (grpc_linked_mdelem* l = metadata->list.head; l; l = l->next) {
-    uintptr_t static_index = grpc_chttp2_get_static_hpack_table_index(l->md);
-    if (static_index) {
-      emit_indexed(c, static_cast<uint32_t>(static_index), &st);
+    const bool is_static =
+        GRPC_MDELEM_STORAGE(l->md) == GRPC_MDELEM_STORAGE_STATIC;
+    uintptr_t static_index;
+    if (is_static &&
+        (static_index = reinterpret_cast<grpc_core::StaticMetadata*>(
+                            GRPC_MDELEM_DATA(l->md))
+                            ->StaticIndex()) < GRPC_CHTTP2_LAST_STATIC_ENTRY) {
+      emit_indexed(c, static_cast<uint32_t>(static_index + 1), &st);
     } else {
       hpack_enc(c, l->md, &st);
     }

--- a/src/core/lib/transport/metadata.h
+++ b/src/core/lib/transport/metadata.h
@@ -186,19 +186,21 @@ struct UserData {
 
 class StaticMetadata {
  public:
-  StaticMetadata(const grpc_slice& key, const grpc_slice& value)
-      : kv_({key, value}), hash_(0) {}
+  StaticMetadata(const grpc_slice& key, const grpc_slice& value, uintptr_t idx)
+      : kv_({key, value}), hash_(0), static_idx_(idx) {}
 
   const grpc_mdelem_data& data() const { return kv_; }
 
   void HashInit();
   uint32_t hash() { return hash_; }
+  uintptr_t StaticIndex() { return static_idx_; }
 
  private:
   grpc_mdelem_data kv_;
 
   /* private only data */
   uint32_t hash_;
+  uintptr_t static_idx_;
 };
 
 class RefcountedMdBase {

--- a/src/core/lib/transport/static_metadata.cc
+++ b/src/core/lib/transport/static_metadata.cc
@@ -398,262 +398,262 @@ grpc_mdelem grpc_static_mdelem_for_static_strings(intptr_t a, intptr_t b) {
 grpc_core::StaticMetadata grpc_static_mdelem_table[GRPC_STATIC_MDELEM_COUNT] = {
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[3], {{10, g_bytes + 19}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 0),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[1], {{7, g_bytes + 5}}},
-        {&grpc_static_metadata_refcounts[40], {{3, g_bytes + 612}}}),
+        {&grpc_static_metadata_refcounts[40], {{3, g_bytes + 612}}}, 1),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[1], {{7, g_bytes + 5}}},
-        {&grpc_static_metadata_refcounts[41], {{4, g_bytes + 615}}}),
+        {&grpc_static_metadata_refcounts[41], {{4, g_bytes + 615}}}, 2),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[0], {{5, g_bytes + 0}}},
-        {&grpc_static_metadata_refcounts[42], {{1, g_bytes + 619}}}),
+        {&grpc_static_metadata_refcounts[42], {{1, g_bytes + 619}}}, 3),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[0], {{5, g_bytes + 0}}},
-        {&grpc_static_metadata_refcounts[43], {{11, g_bytes + 620}}}),
+        {&grpc_static_metadata_refcounts[43], {{11, g_bytes + 620}}}, 4),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[4], {{7, g_bytes + 29}}},
-        {&grpc_static_metadata_refcounts[44], {{4, g_bytes + 631}}}),
+        {&grpc_static_metadata_refcounts[44], {{4, g_bytes + 631}}}, 5),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[4], {{7, g_bytes + 29}}},
-        {&grpc_static_metadata_refcounts[45], {{5, g_bytes + 635}}}),
+        {&grpc_static_metadata_refcounts[45], {{5, g_bytes + 635}}}, 6),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[2], {{7, g_bytes + 12}}},
-        {&grpc_static_metadata_refcounts[46], {{3, g_bytes + 640}}}),
+        {&grpc_static_metadata_refcounts[46], {{3, g_bytes + 640}}}, 7),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[2], {{7, g_bytes + 12}}},
-        {&grpc_static_metadata_refcounts[47], {{3, g_bytes + 643}}}),
+        {&grpc_static_metadata_refcounts[47], {{3, g_bytes + 643}}}, 8),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[2], {{7, g_bytes + 12}}},
-        {&grpc_static_metadata_refcounts[48], {{3, g_bytes + 646}}}),
+        {&grpc_static_metadata_refcounts[48], {{3, g_bytes + 646}}}, 9),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[2], {{7, g_bytes + 12}}},
-        {&grpc_static_metadata_refcounts[49], {{3, g_bytes + 649}}}),
+        {&grpc_static_metadata_refcounts[49], {{3, g_bytes + 649}}}, 10),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[2], {{7, g_bytes + 12}}},
-        {&grpc_static_metadata_refcounts[50], {{3, g_bytes + 652}}}),
+        {&grpc_static_metadata_refcounts[50], {{3, g_bytes + 652}}}, 11),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[2], {{7, g_bytes + 12}}},
-        {&grpc_static_metadata_refcounts[51], {{3, g_bytes + 655}}}),
+        {&grpc_static_metadata_refcounts[51], {{3, g_bytes + 655}}}, 12),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[2], {{7, g_bytes + 12}}},
-        {&grpc_static_metadata_refcounts[52], {{3, g_bytes + 658}}}),
+        {&grpc_static_metadata_refcounts[52], {{3, g_bytes + 658}}}, 13),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[53], {{14, g_bytes + 661}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 14),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[16], {{15, g_bytes + 186}}},
-        {&grpc_static_metadata_refcounts[54], {{13, g_bytes + 675}}}),
+        {&grpc_static_metadata_refcounts[54], {{13, g_bytes + 675}}}, 15),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[55], {{15, g_bytes + 688}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 16),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[56], {{13, g_bytes + 703}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 17),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[57], {{6, g_bytes + 716}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 18),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[58], {{27, g_bytes + 722}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 19),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[59], {{3, g_bytes + 749}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 20),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[60], {{5, g_bytes + 752}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 21),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[61], {{13, g_bytes + 757}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 22),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[62], {{13, g_bytes + 770}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 23),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[63], {{19, g_bytes + 783}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 24),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[15], {{16, g_bytes + 170}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 25),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[64], {{16, g_bytes + 802}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 26),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[65], {{14, g_bytes + 818}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 27),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[66], {{16, g_bytes + 832}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 28),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[67], {{13, g_bytes + 848}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 29),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[14], {{12, g_bytes + 158}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 30),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[68], {{6, g_bytes + 861}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 31),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[69], {{4, g_bytes + 867}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 32),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[70], {{4, g_bytes + 871}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 33),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[71], {{6, g_bytes + 875}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 34),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[72], {{7, g_bytes + 881}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 35),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[73], {{4, g_bytes + 888}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 36),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[20], {{4, g_bytes + 278}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 37),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[74], {{8, g_bytes + 892}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 38),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[75], {{17, g_bytes + 900}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 39),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[76], {{13, g_bytes + 917}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 40),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[77], {{8, g_bytes + 930}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 41),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[78], {{19, g_bytes + 938}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 42),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[79], {{13, g_bytes + 957}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 43),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[80], {{4, g_bytes + 970}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 44),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[81], {{8, g_bytes + 974}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 45),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[82], {{12, g_bytes + 982}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 46),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[83], {{18, g_bytes + 994}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 47),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[84], {{19, g_bytes + 1012}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 48),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[85], {{5, g_bytes + 1031}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 49),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[86], {{7, g_bytes + 1036}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 50),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[87], {{7, g_bytes + 1043}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 51),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[88], {{11, g_bytes + 1050}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 52),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[89], {{6, g_bytes + 1061}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 53),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[90], {{10, g_bytes + 1067}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 54),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[91], {{25, g_bytes + 1077}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 55),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[92], {{17, g_bytes + 1102}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 56),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[19], {{10, g_bytes + 268}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 57),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[93], {{4, g_bytes + 1119}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 58),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[94], {{3, g_bytes + 1123}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 59),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[95], {{16, g_bytes + 1126}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 60),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[7], {{11, g_bytes + 50}}},
-        {&grpc_static_metadata_refcounts[96], {{1, g_bytes + 1142}}}),
+        {&grpc_static_metadata_refcounts[96], {{1, g_bytes + 1142}}}, 61),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[7], {{11, g_bytes + 50}}},
-        {&grpc_static_metadata_refcounts[25], {{1, g_bytes + 350}}}),
+        {&grpc_static_metadata_refcounts[25], {{1, g_bytes + 350}}}, 62),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[7], {{11, g_bytes + 50}}},
-        {&grpc_static_metadata_refcounts[26], {{1, g_bytes + 351}}}),
+        {&grpc_static_metadata_refcounts[26], {{1, g_bytes + 351}}}, 63),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[9], {{13, g_bytes + 77}}},
-        {&grpc_static_metadata_refcounts[97], {{8, g_bytes + 1143}}}),
+        {&grpc_static_metadata_refcounts[97], {{8, g_bytes + 1143}}}, 64),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[9], {{13, g_bytes + 77}}},
-        {&grpc_static_metadata_refcounts[38], {{4, g_bytes + 597}}}),
+        {&grpc_static_metadata_refcounts[38], {{4, g_bytes + 597}}}, 65),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[9], {{13, g_bytes + 77}}},
-        {&grpc_static_metadata_refcounts[37], {{7, g_bytes + 590}}}),
+        {&grpc_static_metadata_refcounts[37], {{7, g_bytes + 590}}}, 66),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[5], {{2, g_bytes + 36}}},
-        {&grpc_static_metadata_refcounts[98], {{8, g_bytes + 1151}}}),
+        {&grpc_static_metadata_refcounts[98], {{8, g_bytes + 1151}}}, 67),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[14], {{12, g_bytes + 158}}},
-        {&grpc_static_metadata_refcounts[99], {{16, g_bytes + 1159}}}),
+        {&grpc_static_metadata_refcounts[99], {{16, g_bytes + 1159}}}, 68),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[4], {{7, g_bytes + 29}}},
-        {&grpc_static_metadata_refcounts[100], {{4, g_bytes + 1175}}}),
+        {&grpc_static_metadata_refcounts[100], {{4, g_bytes + 1175}}}, 69),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[1], {{7, g_bytes + 5}}},
-        {&grpc_static_metadata_refcounts[101], {{3, g_bytes + 1179}}}),
+        {&grpc_static_metadata_refcounts[101], {{3, g_bytes + 1179}}}, 70),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[16], {{15, g_bytes + 186}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 71),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[15], {{16, g_bytes + 170}}},
-        {&grpc_static_metadata_refcounts[97], {{8, g_bytes + 1143}}}),
+        {&grpc_static_metadata_refcounts[97], {{8, g_bytes + 1143}}}, 72),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[15], {{16, g_bytes + 170}}},
-        {&grpc_static_metadata_refcounts[38], {{4, g_bytes + 597}}}),
+        {&grpc_static_metadata_refcounts[38], {{4, g_bytes + 597}}}, 73),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[21], {{8, g_bytes + 282}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 74),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[102], {{11, g_bytes + 1182}}},
-        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}),
+        {&grpc_static_metadata_refcounts[29], {{0, g_bytes + 354}}}, 75),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[10], {{20, g_bytes + 90}}},
-        {&grpc_static_metadata_refcounts[97], {{8, g_bytes + 1143}}}),
+        {&grpc_static_metadata_refcounts[97], {{8, g_bytes + 1143}}}, 76),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[10], {{20, g_bytes + 90}}},
-        {&grpc_static_metadata_refcounts[37], {{7, g_bytes + 590}}}),
+        {&grpc_static_metadata_refcounts[37], {{7, g_bytes + 590}}}, 77),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[10], {{20, g_bytes + 90}}},
-        {&grpc_static_metadata_refcounts[103], {{16, g_bytes + 1193}}}),
+        {&grpc_static_metadata_refcounts[103], {{16, g_bytes + 1193}}}, 78),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[10], {{20, g_bytes + 90}}},
-        {&grpc_static_metadata_refcounts[38], {{4, g_bytes + 597}}}),
+        {&grpc_static_metadata_refcounts[38], {{4, g_bytes + 597}}}, 79),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[10], {{20, g_bytes + 90}}},
-        {&grpc_static_metadata_refcounts[104], {{13, g_bytes + 1209}}}),
+        {&grpc_static_metadata_refcounts[104], {{13, g_bytes + 1209}}}, 80),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[10], {{20, g_bytes + 90}}},
-        {&grpc_static_metadata_refcounts[105], {{12, g_bytes + 1222}}}),
+        {&grpc_static_metadata_refcounts[105], {{12, g_bytes + 1222}}}, 81),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[10], {{20, g_bytes + 90}}},
-        {&grpc_static_metadata_refcounts[106], {{21, g_bytes + 1234}}}),
+        {&grpc_static_metadata_refcounts[106], {{21, g_bytes + 1234}}}, 82),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[16], {{15, g_bytes + 186}}},
-        {&grpc_static_metadata_refcounts[97], {{8, g_bytes + 1143}}}),
+        {&grpc_static_metadata_refcounts[97], {{8, g_bytes + 1143}}}, 83),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[16], {{15, g_bytes + 186}}},
-        {&grpc_static_metadata_refcounts[38], {{4, g_bytes + 597}}}),
+        {&grpc_static_metadata_refcounts[38], {{4, g_bytes + 597}}}, 84),
     grpc_core::StaticMetadata(
         {&grpc_static_metadata_refcounts[16], {{15, g_bytes + 186}}},
-        {&grpc_static_metadata_refcounts[104], {{13, g_bytes + 1209}}}),
+        {&grpc_static_metadata_refcounts[104], {{13, g_bytes + 1209}}}, 85),
 };
 const uint8_t grpc_static_accept_encoding_metadata[8] = {0,  76, 77, 78,
                                                          79, 80, 81, 82};

--- a/tools/codegen/core/gen_static_metadata.py
+++ b/tools/codegen/core/gen_static_metadata.py
@@ -550,9 +550,9 @@ print >> C, '}'
 print >> C
 
 print >> C, 'grpc_core::StaticMetadata grpc_static_mdelem_table[GRPC_STATIC_MDELEM_COUNT] = {'
-for a, b in all_elems:
-    print >> C, 'grpc_core::StaticMetadata(%s,%s),' % (slice_def(str_idx(a)),
-                                                       slice_def(str_idx(b)))
+for idx, (a, b) in enumerate(all_elems):
+    print >> C, 'grpc_core::StaticMetadata(%s,%s, %d),' % (
+        slice_def(str_idx(a)), slice_def(str_idx(b)), idx)
 print >> C, '};'
 
 print >> H, 'typedef enum {'


### PR DESCRIPTION
Originally, hpack_encoder would check if a metadata was static or not by
comparing its pointer to the known static metadata global table and checking if
it was within bounds. This check was performed regardless of if the metadata was
static or not, and is somewhat costly.

Instead, we now pre-compute the static metadata index during code generation
time, and store it with static metadata objects. We read that value only if we
are dealing with a static metadata flag (which we know from the storage type of
the grpc_mdelem).

This yields slightly faster metadata encoding:

BM_HpackEncoderEncodeHeader<EmptyBatch>/0/16384
[framing_bytes/iter:9 header_bytes/iter:0       ]              34.9ns ± 2%
34.2ns ± 1%  -2.04%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<EmptyBatch>/1/16384
[framing_bytes/iter:9 header_bytes/iter:0       ]              34.9ns ± 2%
34.2ns ± 1%  -2.01%        (p=0.000 n=20+19)
BM_HpackEncoderEncodeHeader<SingleStaticElem>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              50.6ns ± 0%
49.2ns ± 2%  -2.74%        (p=0.000 n=18+20)
BM_HpackEncoderEncodeHeader<SingleInternedKeyElem>/0/16384
[framing_bytes/iter:9 header_bytes/iter:6       ]              84.7ns ± 1%
83.5ns ± 1%  -1.43%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<SingleInternedElem>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              50.4ns ± 0%
47.9ns ± 0%  -4.83%        (p=0.000 n=18+17)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<1, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              51.1ns ± 2%
48.9ns ± 1%  -4.32%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<3, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              50.8ns ± 2%
48.8ns ± 2%  -3.88%        (p=0.000 n=19+20)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<10, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              50.2ns ± 1%
47.9ns ± 0%  -4.47%        (p=0.000 n=19+16)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<31, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              50.2ns ± 0%
47.9ns ± 0%  -4.46%        (p=0.000 n=18+16)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<100, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              50.2ns ± 0%
47.9ns ± 0%  -4.40%        (p=0.000 n=19+17)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<1, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              50.7ns ± 2%
48.8ns ± 2%  -3.81%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<3, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              50.9ns ± 2%
48.8ns ± 2%  -4.05%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<10, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              50.1ns ± 0%
48.0ns ± 1%  -4.27%        (p=0.000 n=17+17)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<31, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              50.1ns ± 0%
48.0ns ± 1%  -4.28%        (p=0.000 n=18+17)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<100, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              50.1ns ± 0%
48.0ns ± 0%  -4.33%        (p=0.000 n=18+17)
BM_HpackEncoderEncodeHeader<SingleNonInternedElem>/0/16384
[framing_bytes/iter:9 header_bytes/iter:9       ]              91.4ns ± 1%
90.7ns ± 1%  -0.79%        (p=0.000 n=18+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<1, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:12      ]               116ns ± 1%
116ns ± 1%  -0.46%        (p=0.002 n=20+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<3, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:14      ]               122ns ± 0%
121ns ± 0%  -0.69%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<10, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:23      ]               144ns ± 1%
144ns ± 0%  -0.23%        (p=0.009 n=20+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<31, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:46      ]               232ns ± 0%
232ns ± 1%  -0.26%        (p=0.021 n=18+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<1, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:12      ]              92.9ns ± 1%
92.0ns ± 1%  -0.97%        (p=0.000 n=19+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<3, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:14      ]              94.0ns ± 1%
92.6ns ± 1%  -1.45%        (p=0.000 n=20+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<10, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:21      ]              93.9ns ± 2%
92.8ns ± 1%  -1.17%        (p=0.001 n=20+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<100, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:111     ]               106ns ± 0%
105ns ± 3%  -1.15%        (p=0.000 n=18+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedElem>/0/1
[framing_bytes/iter:81 header_bytes/iter:9      ]               355ns ± 1%
354ns ± 0%  -0.35%        (p=0.015 n=19+20)
BM_HpackEncoderEncodeHeader<RepresentativeClientInitialMetadata>/0/16384
[framing_bytes/iter:9 header_bytes/iter:8.00002 ]               139ns ± 1%
133ns ± 1%  -4.46%        (p=0.000 n=19+20)
BM_HpackEncoderEncodeHeader<MoreRepresentativeClientInitialMetadata>/0/16384
[framing_bytes/iter:9 header_bytes/iter:16      ]               236ns ± 1%
231ns ± 1%  -2.24%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<RepresentativeServerInitialMetadata>/0/16384
[framing_bytes/iter:9 header_bytes/iter:3       ]              73.6ns ± 1%
70.5ns ± 1%  -4.14%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<RepresentativeServerTrailingMetadata>/1/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              50.5ns ± 0%
49.2ns ± 2%  -2.60%        (p=0.000 n=16+20)