### PR TITLE
Return empty strings on optional ports for backward compatibility.

### DIFF
--- a/src/core/lib/gprpp/host_port.cc
+++ b/src/core/lib/gprpp/host_port.cc
@@ -44,7 +44,10 @@ int JoinHostPort(UniquePtr<char>* out, const char* host, int port) {
   return ret;
 }
 
-bool SplitHostPort(StringView name, StringView* host, StringView* port) {
+namespace {
+bool DoSplitHostPort(StringView name, StringView* host, StringView* port,
+                     bool* has_port) {
+  *has_port = false;
   if (name[0] == '[') {
     /* Parse a bracketed host, typically an IPv6 literal. */
     const size_t rbracket = name.find(']', 1);
@@ -58,6 +61,7 @@ bool SplitHostPort(StringView name, StringView* host, StringView* port) {
     } else if (name[rbracket + 1] == ':') {
       /* ]:<port?> */
       *port = name.substr(rbracket + 2, name.size() - rbracket - 2);
+      *has_port = true;
     } else {
       /* ]<invalid> */
       return false;
@@ -76,6 +80,7 @@ bool SplitHostPort(StringView name, StringView* host, StringView* port) {
       /* Exactly 1 colon.  Split into host:port. */
       *host = name.substr(0, colon);
       *port = name.substr(colon + 1, name.size() - colon - 1);
+      *has_port = true;
     } else {
       /* 0 or 2+ colons.  Bare hostname or IPv6 litearal. */
       *host = name;
@@ -84,6 +89,12 @@ bool SplitHostPort(StringView name, StringView* host, StringView* port) {
   }
   return true;
 }
+}  // namespace
+
+bool SplitHostPort(StringView name, StringView* host, StringView* port) {
+  bool unused;
+  return DoSplitHostPort(name, host, port, &unused);
+}
 
 bool SplitHostPort(StringView name, UniquePtr<char>* host,
                    UniquePtr<char>* port) {
@@ -91,12 +102,13 @@ bool SplitHostPort(StringView name, UniquePtr<char>* host,
   GPR_DEBUG_ASSERT(port != nullptr && *port == nullptr);
   StringView host_view;
   StringView port_view;
-  const bool ret = SplitHostPort(name, &host_view, &port_view);
+  bool has_port;
+  const bool ret = DoSplitHostPort(name, &host_view, &port_view, &has_port);
   if (ret) {
     // We always set the host, but port is set only when it's non-empty,
     // to remain backward compatible with the old split_host_port API.
     *host = host_view.dup();
-    if (!port_view.empty()) {
+    if (has_port) {
       *port = port_view.dup();
     }
   }

--- a/src/core/lib/gprpp/host_port.cc
+++ b/src/core/lib/gprpp/host_port.cc
@@ -105,8 +105,9 @@ bool SplitHostPort(StringView name, UniquePtr<char>* host,
   bool has_port;
   const bool ret = DoSplitHostPort(name, &host_view, &port_view, &has_port);
   if (ret) {
-    // We always set the host, but port is set only when it's non-empty,
-    // to remain backward compatible with the old split_host_port API.
+    // We always set the host, but port is set only when DoSplitHostPort find a
+    // port in the string, to remain backward compatible with the old
+    // gpr_split_host_port API.
     *host = host_view.dup();
     if (has_port) {
       *port = port_view.dup();

--- a/test/core/gprpp/host_port_test.cc
+++ b/test/core/gprpp/host_port_test.cc
@@ -71,7 +71,9 @@ static void test_split_host_port() {
   split_host_port_expect("", "", nullptr, true);
   split_host_port_expect("[a:b]", "a:b", nullptr, true);
   split_host_port_expect("1.2.3.4", "1.2.3.4", nullptr, true);
+  split_host_port_expect("0.0.0.0:", "0.0.0.0", "", true);
   split_host_port_expect("a:b:c::", "a:b:c::", nullptr, true);
+  split_host_port_expect("[a:b:c::]:", "a:b:c::", "", true);
   split_host_port_expect("[a:b]:30", "a:b", "30", true);
   split_host_port_expect("1.2.3.4:30", "1.2.3.4", "30", true);
   split_host_port_expect(":30", "", "30", true);


### PR DESCRIPTION
gpr_split_host_port returns an empty string for the port
when given "0.0.0.0:" as the input.

Change the emptiness check to an explicit argument called has_port,
to remain backward compatible.

Added a test to cover both v4 and v6.