### PR TITLE
csharp avoid capture-context in HandleNewServerRpc => HandleCallAsync

### DIFF
--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -334,7 +334,7 @@ namespace Grpc.Core
         /// <summary>
         /// Selects corresponding handler for given call and handles the call.
         /// </summary>
-        private async Task HandleCallAsync(ServerRpcNew newRpc, CompletionQueueSafeHandle cq, Action<CompletionQueueSafeHandle> continuation)
+        private async Task HandleCallAsync(ServerRpcNew newRpc, CompletionQueueSafeHandle cq, Action<Server, CompletionQueueSafeHandle> continuation)
         {
             try
             {
@@ -351,7 +351,7 @@ namespace Grpc.Core
             }
             finally
             {
-                continuation(cq);
+                continuation(this, cq);
             }
         }
 
@@ -374,7 +374,7 @@ namespace Grpc.Core
                     // Don't await, the continuations will run on gRPC thread pool once triggered
                     // by cq.Next().
                     #pragma warning disable 4014
-                    HandleCallAsync(newRpc, cq, state => AllowOneRpc(state));
+                    HandleCallAsync(newRpc, cq, (server, state) => server.AllowOneRpc(state));
                     #pragma warning restore 4014
                 }
             }

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -334,7 +334,7 @@ namespace Grpc.Core
         /// <summary>
         /// Selects corresponding handler for given call and handles the call.
         /// </summary>
-        private async Task HandleCallAsync(ServerRpcNew newRpc, CompletionQueueSafeHandle cq, Action continuation)
+        private async Task HandleCallAsync(ServerRpcNew newRpc, CompletionQueueSafeHandle cq, Action<CompletionQueueSafeHandle> continuation)
         {
             try
             {
@@ -351,7 +351,7 @@ namespace Grpc.Core
             }
             finally
             {
-                continuation();
+                continuation(cq);
             }
         }
 
@@ -374,7 +374,7 @@ namespace Grpc.Core
                     // Don't await, the continuations will run on gRPC thread pool once triggered
                     // by cq.Next().
                     #pragma warning disable 4014
-                    HandleCallAsync(newRpc, cq, () => AllowOneRpc(cq));
+                    HandleCallAsync(newRpc, cq, state => AllowOneRpc(state));
                     #pragma warning restore 4014
                 }
             }


### PR DESCRIPTION
Memory profile:

![image](https://user-images.githubusercontent.com/17328/60515913-8f23d200-9cd4-11e9-9019-e510b7eab942.png)

The capture-context in `() => AllowOneRpc(cq)` is unnecessary and can be avoided very easily by using a state parameter; the compiler automatically detects that `(server, state) => server.AllowOneRpc(state)` doesn't involve a capture context and hoists it into a static field, removing the allocation of the delegate **and** the capture context object.