### PR TITLE
csharp: remove AuthContext's Lazy<T> usage 

### DIFF
--- a/src/csharp/Grpc.Core.Api/AuthProperty.cs
+++ b/src/csharp/Grpc.Core.Api/AuthProperty.cs
@@ -17,8 +17,6 @@
 #endregion
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Grpc.Core.Utils;
 
@@ -33,13 +31,12 @@ namespace Grpc.Core
         static readonly Encoding EncodingUTF8 = System.Text.Encoding.UTF8;
         string name;
         byte[] valueBytes;
-        Lazy<string> value;
+        string lazyValue;
 
         private AuthProperty(string name, byte[] valueBytes)
         {
             this.name = GrpcPreconditions.CheckNotNull(name);
             this.valueBytes = GrpcPreconditions.CheckNotNull(valueBytes);
-            this.value = new Lazy<string>(() => EncodingUTF8.GetString(this.valueBytes));
         }
 
         /// <summary>
@@ -60,7 +57,7 @@ namespace Grpc.Core
         {
             get
             {
-                return value.Value;
+                return lazyValue ?? (lazyValue = EncodingUTF8.GetString(this.valueBytes));
             }
         }
 

--- a/src/csharp/Grpc.Core/Internal/DefaultServerCallContext.cs
+++ b/src/csharp/Grpc.Core/Internal/DefaultServerCallContext.cs
@@ -38,7 +38,7 @@ namespace Grpc.Core
         private readonly Metadata responseTrailers;
         private Status status;
         private readonly IServerResponseStream serverResponseStream;
-        private readonly Lazy<AuthContext> authContext;
+        private AuthContext lazyAuthContext;
 
         /// <summary>
         /// Creates a new instance of <c>ServerCallContext</c>.
@@ -57,8 +57,6 @@ namespace Grpc.Core
             this.responseTrailers = new Metadata();
             this.status = Status.DefaultSuccess;
             this.serverResponseStream = serverResponseStream;
-            // TODO(jtattermusch): avoid unnecessary allocation of factory function and the lazy object
-            this.authContext = new Lazy<AuthContext>(GetAuthContextEager);
         }
 
         protected override ContextPropagationToken CreatePropagationTokenCore(ContextPropagationOptions options)
@@ -97,7 +95,7 @@ namespace Grpc.Core
             set => serverResponseStream.WriteOptions = value;
         }
 
-        protected override AuthContext AuthContextCore => authContext.Value;
+        protected override AuthContext AuthContextCore => lazyAuthContext ?? (lazyAuthContext = GetAuthContextEager());
 
         private AuthContext GetAuthContextEager()
         {


### PR DESCRIPTION
`Lazy<T>` is showing on the memory profile:

![image](https://user-images.githubusercontent.com/17328/60544061-d8454780-9d0f-11e9-8850-b0bfd9517f53.png)

in the two places it is used, it is pretty easy and reasonable to replace with just a null-coalesce-assignment