### PR TITLE
Update Google Benchmark v1.5.0 to get CMake < 3.6 fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7954,8 +7954,11 @@ endif
 
 LIBBENCHMARK_SRC = \
     third_party/benchmark/src/benchmark.cc \
+    third_party/benchmark/src/benchmark_api_internal.cc \
     third_party/benchmark/src/benchmark_main.cc \
+    third_party/benchmark/src/benchmark_name.cc \
     third_party/benchmark/src/benchmark_register.cc \
+    third_party/benchmark/src/benchmark_runner.cc \
     third_party/benchmark/src/colorprint.cc \
     third_party/benchmark/src/commandlineflags.cc \
     third_party/benchmark/src/complexity.cc \

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -157,9 +157,9 @@ def grpc_deps():
     if "com_github_google_benchmark" not in native.existing_rules():
         http_archive(
             name = "com_github_google_benchmark",
-            sha256 = "c7682e9007ddfd94072647abab3e89ffd9084089460ae47d67060974467b58bf",
-            strip_prefix = "benchmark-e776aa0275e293707b6a0901e0e8d8a8a3679508",
-            url = "https://github.com/google/benchmark/archive/e776aa0275e293707b6a0901e0e8d8a8a3679508.tar.gz",
+            sha256 = "f68aec93154d010324c05bcd8c5cc53468b87af88d87acb5ddcfaa1bba044837",
+            strip_prefix = "benchmark-090faecb454fbd6e6e17a75ef8146acb037118d4",
+            url = "https://github.com/google/benchmark/archive/090faecb454fbd6e6e17a75ef8146acb037118d4.tar.gz",
         )
 
     if "com_github_cares_cares" not in native.existing_rules():

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -2241,8 +2241,11 @@
       ],
       'sources': [
         'third_party/benchmark/src/benchmark.cc',
+        'third_party/benchmark/src/benchmark_api_internal.cc',
         'third_party/benchmark/src/benchmark_main.cc',
+        'third_party/benchmark/src/benchmark_name.cc',
         'third_party/benchmark/src/benchmark_register.cc',
+        'third_party/benchmark/src/benchmark_runner.cc',
         'third_party/benchmark/src/colorprint.cc',
         'third_party/benchmark/src/commandlineflags.cc',
         'third_party/benchmark/src/complexity.cc',

--- a/tools/run_tests/sanity/check_submodules.sh
+++ b/tools/run_tests/sanity/check_submodules.sh
@@ -27,7 +27,7 @@ want_submodules=$(mktemp /tmp/submXXXXXX)
 git submodule | awk '{ print $1 }' | sort > "$submodules"
 cat << EOF | awk '{ print $1 }' | sort > "$want_submodules"
  74d91756c11bc22f9b0108b94da9326f7f9e376f third_party/abseil-cpp (74d9175)
- e776aa0275e293707b6a0901e0e8d8a8a3679508 third_party/benchmark (v1.2.0)
+ 090faecb454fbd6e6e17a75ef8146acb037118d4 third_party/benchmark (v1.5.0)
  73594cde8c9a52a102c4341c244c833aa61b9c06 third_party/bloaty (remotes/origin/wide-14-g73594cd)
  b29b21a81b32ec273f118f589f46d56ad3332420 third_party/boringssl (remotes/origin/chromium-stable)
  afc30d43eef92979b05776ec0963c9cede5fb80f third_party/boringssl-with-bazel (fips-20180716-116-gafc30d43e)


### PR DESCRIPTION
Google Benchmark v1.4.1 uses a CMake feature that is only in version >=
3.6. This was an inadvertent change in Google Benchmark (too high of a
version) that has been [fixed upstream][1] in v1.5.0.

Google Benchmark v1.5.0 now requires CMake >= 3.5.1. [Another PR][2]
will bump gRPC's minimum version as well.

This PR supersedes https://github.com/grpc/grpc/pull/19466. 

[1]: https://github.com/google/benchmark/commit/505be96ab23056580a3a2315abba048f4428b04e
[2]: https://github.com/grpc/grpc/pull/19467