### PR TITLE
csharp: refactor AtomicCounter - move from instance to static implementation

### DIFF
--- a/src/csharp/Grpc.Core/Internal/AtomicCounter.cs
+++ b/src/csharp/Grpc.Core/Internal/AtomicCounter.cs
@@ -16,56 +16,53 @@
 
 #endregion
 
-using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Grpc.Core.Internal
 {
-    internal class AtomicCounter
+    internal static class AtomicCounter
     {
-        long counter = 0;
-
-        public AtomicCounter(long initialCount = 0)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long Create(long initialCount = 0)
         {
-            this.counter = initialCount;
+            return initialCount;
         }
 
-        public long Increment()
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long Increment(ref long counter)
         {
             return Interlocked.Increment(ref counter);
         }
 
-        public void IncrementIfNonzero(ref bool success)
+        public static bool IncrementIfNonzero(ref long counter)
         {
-            long origValue = counter;
+            long origValue = Volatile.Read(ref counter);
             while (true)
             {
                 if (origValue == 0)
                 {
-                    success = false;
-                    return;
+                    return false;
                 }
                 long result = Interlocked.CompareExchange(ref counter, origValue + 1, origValue);
                 if (result == origValue)
                 {
-                    success = true;
-                    return;
-                };
+                    return true;
+                }
                 origValue = result;
             }
         }
 
-        public long Decrement()
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long Decrement(ref long counter)
         {
             return Interlocked.Decrement(ref counter);
         }
 
-        public long Count
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long Count(ref long counter)
         {
-            get
-            {
-                return Interlocked.Read(ref counter);
-            }
+            return Interlocked.Read(ref counter);
         }
     }
 }

--- a/src/csharp/Grpc.Core/Internal/CompletionRegistry.cs
+++ b/src/csharp/Grpc.Core/Internal/CompletionRegistry.cs
@@ -51,7 +51,7 @@ namespace Grpc.Core.Internal
 
         public void Register(IntPtr key, IOpCompletionCallback callback)
         {
-            environment.DebugStats.PendingBatchCompletions.Increment();
+            environment.DebugStats.IncrementPendingBatchCompletions();
 
             bool lockTaken = false;
             try
@@ -98,7 +98,7 @@ namespace Grpc.Core.Internal
             {
                 if (lockTaken) spinLock.Exit();
             }
-            environment.DebugStats.PendingBatchCompletions.Decrement();
+            environment.DebugStats.DecrementPendingBatchCompletions();
             return value;
         }
 

--- a/src/csharp/Grpc.Core/Internal/DebugStats.cs
+++ b/src/csharp/Grpc.Core/Internal/DebugStats.cs
@@ -17,20 +17,31 @@
 #endregion
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace Grpc.Core.Internal
 {
     internal class DebugStats
     {
-        public readonly AtomicCounter PendingBatchCompletions = new AtomicCounter();
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void IncrementPendingBatchCompletions()
+        {
+            AtomicCounter.Increment(ref pendingBatchCompletions);
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void DecrementPendingBatchCompletions()
+        {
+            AtomicCounter.Decrement(ref pendingBatchCompletions);
+        }
+        private long pendingBatchCompletions = AtomicCounter.Create();
 
         /// <summary>
         /// Checks the debug stats and take action for any inconsistency found.
         /// </summary>
         public void CheckOK()
         {
-            var pendingBatchCompletions = PendingBatchCompletions.Count;
+            var pendingBatchCompletions = AtomicCounter.Count(ref this.pendingBatchCompletions);
             if (pendingBatchCompletions != 0)
             {
                 DebugWarning(string.Format("Detected {0} pending batch completions.", pendingBatchCompletions));


### PR DESCRIPTION
The instance class was *nice*, but it is showing all over the per-call operation allocations:

![image](https://user-images.githubusercontent.com/17328/60546211-c7e39b80-9d14-11e9-8abf-26f0f8ea7378.png)

For *what it provides*, it doesn't feel like this needs to be an object; here I've **kept the API intact** (via `static`/`ref` methods), but made it operate on `long` fields. I *could* have probably made it a mutable `struct`, but... that's a dangerous move and it is very easy for people to make mistakes with mutable `struct` - so I try to avoid them.

This works, is clean/simple, and removes another pile of allocs.