### PR TITLE
Terminate bazel hack

### DIFF
--- a/src/python/grpcio_tests/tests/bazel_namespace_package_hack.py
+++ b/src/python/grpcio_tests/tests/bazel_namespace_package_hack.py
@@ -24,11 +24,8 @@ import sys
 # Analysis in depth: https://github.com/bazelbuild/rules_python/issues/55
 def sys_path_to_site_dir_hack():
     """Add valid sys.path item to site directory to parse the .pth files."""
-    print("Executing hack")
-    print("sys.path: {}".format(sys.path))
     items = []
     for item in sys.path:
-        print("Checking {}".format(item))
         if os.path.exists(item):
             # The only difference between sys.path and site-directory is
             # whether the .pth file will be parsed or not. A site-directory

--- a/src/python/grpcio_tests/tests/bazel_namespace_package_hack.py
+++ b/src/python/grpcio_tests/tests/bazel_namespace_package_hack.py
@@ -24,9 +24,15 @@ import sys
 # Analysis in depth: https://github.com/bazelbuild/rules_python/issues/55
 def sys_path_to_site_dir_hack():
     """Add valid sys.path item to site directory to parse the .pth files."""
+    print("Executing hack")
+    print("sys.path: {}".format(sys.path))
+    items = []
     for item in sys.path:
+        print("Checking {}".format(item))
         if os.path.exists(item):
             # The only difference between sys.path and site-directory is
             # whether the .pth file will be parsed or not. A site-directory
             # will always exist in sys.path, but not another way around.
-            site.addsitedir(item)
+            items.append(item)
+    for item in items:
+        site.addsitedir(item)


### PR DESCRIPTION
`site.addsitedir` affects `sys.path`. As a result, when I ran `python setup.py test_gevent`, the process got stuck running `stat` on a bunch of module directories. This ensures that we don't modify the list as we iterate over it.