### PR TITLE
Updated grpc_slice_buffer_move_first(_maybe_ref).

### DIFF
--- a/src/core/lib/slice/slice.cc
+++ b/src/core/lib/slice/slice.cc
@@ -399,7 +399,7 @@ grpc_slice grpc_slice_split_tail(grpc_slice* source, size_t split) {
   return grpc_slice_split_tail_maybe_ref(source, split, GRPC_SLICE_REF_BOTH);
 }
 
-template <bool do_ref = true>
+template <bool do_ref>
 static grpc_slice slice_split_head(grpc_slice* source, size_t split) {
   grpc_slice head;
 

--- a/src/core/lib/slice/slice_internal.h
+++ b/src/core/lib/slice/slice_internal.h
@@ -327,4 +327,6 @@ inline grpc_slice grpc_slice_from_static_string_internal(const char* s) {
   return grpc_slice_from_static_buffer_internal(s, strlen(s));
 }
 
+grpc_slice grpc_slice_split_head_noref(grpc_slice* source, size_t split);
+
 #endif /* GRPC_CORE_LIB_SLICE_SLICE_INTERNAL_H */


### PR DESCRIPTION
New implementation performs a smaller number of slice copies by not using
grpc_slice_buffer_take_first. Instead, it uses memcpy for every slice except for
the last, which may need to be split.