### PR TITLE
csharp: DefaultDeserializationContext: never allocate for empty payloads

### DIFF
--- a/src/csharp/Grpc.Core.Api/DeserializationContext.cs
+++ b/src/csharp/Grpc.Core.Api/DeserializationContext.cs
@@ -31,7 +31,7 @@ namespace Grpc.Core
         public abstract int PayloadLength { get; }
 
         /// <summary>
-        /// Gets the entire payload as a newly allocated byte array.
+        /// Gets the entire payload as a newly allocated byte array (or a shared zero-length array, if the payload is empty).
         /// Once the byte array is returned, the byte array becomes owned by the caller and won't be ever accessed or reused by gRPC again.
         /// NOTE: Obtaining the buffer as a newly allocated byte array is the simplest way of accessing the payload,
         /// but it can have important consequences in high-performance scenarios.

--- a/src/csharp/Grpc.Core/Internal/DefaultDeserializationContext.cs
+++ b/src/csharp/Grpc.Core/Internal/DefaultDeserializationContext.cs
@@ -46,12 +46,12 @@ namespace Grpc.Core.Internal
 
         public override byte[] PayloadAsNewBuffer()
         {
-            if (payloadLength == 0) return EmptyBlob;
+            if (payloadLength == 0) return EmptyByteArray;
             var buffer = new byte[payloadLength];
             FillContinguousBuffer(bufferReader, buffer);
             return buffer;
         }
-        private static readonly byte[] EmptyBlob = new byte[0];
+        private static readonly byte[] EmptyByteArray = new byte[0];
 
 #if GRPC_CSHARP_SUPPORT_SYSTEM_MEMORY
         public override ReadOnlySequence<byte> PayloadAsReadOnlySequence()

--- a/src/csharp/Grpc.Core/Internal/DefaultDeserializationContext.cs
+++ b/src/csharp/Grpc.Core/Internal/DefaultDeserializationContext.cs
@@ -46,10 +46,12 @@ namespace Grpc.Core.Internal
 
         public override byte[] PayloadAsNewBuffer()
         {
+            if (payloadLength == 0) return EmptyBlob;
             var buffer = new byte[payloadLength];
             FillContinguousBuffer(bufferReader, buffer);
             return buffer;
         }
+        private static readonly byte[] EmptyBlob = new byte[0];
 
 #if GRPC_CSHARP_SUPPORT_SYSTEM_MEMORY
         public override ReadOnlySequence<byte> PayloadAsReadOnlySequence()

--- a/src/csharp/Grpc.Core/Internal/DefaultDeserializationContext.cs
+++ b/src/csharp/Grpc.Core/Internal/DefaultDeserializationContext.cs
@@ -46,9 +46,13 @@ namespace Grpc.Core.Internal
 
         public override byte[] PayloadAsNewBuffer()
         {
-            if (payloadLength == 0) return EmptyByteArray;
-            var buffer = new byte[payloadLength];
-            FillContinguousBuffer(bufferReader, buffer);
+            var buffer = payloadLength == 0 ? EmptyByteArray : new byte[payloadLength];
+            if (payloadLength != 0 | bufferReader == null)
+            {   // ^^ this might look odd, but when empty, we *want* this to fail
+                // if this is because it has been reset and not assigned; we make
+                // it fail in a known way by trying to fill from the (invalid) source
+                FillContinguousBuffer(bufferReader, buffer);
+            }
             return buffer;
         }
         private static readonly byte[] EmptyByteArray = new byte[0];


### PR DESCRIPTION
A lot of payloads are empty - or more specifically `.google.protobuf.Empty`; this can add up:

![image](https://user-images.githubusercontent.com/17328/60606805-e9479480-9db3-11e9-9250-76732f171494.png)

and can be avoided trivially:

![image](https://user-images.githubusercontent.com/17328/60606823-f06ea280-9db3-11e9-8b94-cf371f91546b.png)

