### PR TITLE
csharp: use IThreadPoolWorkItem on netcoreapp3.0 (blocked on .NET Core 3)

### DIFF
--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="Common.csproj.include" />
 
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.5;netstandard2.0;netcoreapp3.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
@@ -26,6 +26,11 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <LangVersion>7.2</LangVersion>
     <DefineConstants>$(DefineConstants);GRPC_CSHARP_SUPPORT_SYSTEM_MEMORY</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <LangVersion>7.2</LangVersion>
+    <DefineConstants>$(DefineConstants);GRPC_CSHARP_SUPPORT_SYSTEM_MEMORY;GRPC_CSHARP_SUPPORT_THREADPOOLWORKITEM</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/csharp/Grpc.Core/Internal/BatchContextSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/BatchContextSafeHandle.cs
@@ -17,15 +17,15 @@
 #endregion
 
 using System;
-using System.Runtime.InteropServices;
-using System.Text;
-using Grpc.Core;
 using Grpc.Core.Logging;
 using Grpc.Core.Utils;
 
 namespace Grpc.Core.Internal
 {
     internal interface IOpCompletionCallback
+#if GRPC_CSHARP_SUPPORT_THREADPOOLWORKITEM
+        : System.Threading.IThreadPoolWorkItem
+#endif
     {
         void OnComplete(bool success);
     }
@@ -42,6 +42,9 @@ namespace Grpc.Core.Internal
     /// </summary>
     internal class BatchContextSafeHandle : SafeHandleZeroIsInvalid, IOpCompletionCallback, IPooledObject<BatchContextSafeHandle>, IBufferReader
     {
+#if GRPC_CSHARP_SUPPORT_THREADPOOLWORKITEM
+        void System.Threading.IThreadPoolWorkItem.Execute() => ((IOpCompletionCallback)this).OnComplete(true); // when called this way: means success
+#endif
         static readonly NativeMethods Native = NativeMethods.Get();
         static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<BatchContextSafeHandle>();
 

--- a/src/csharp/Grpc.Core/Internal/RequestCallContextSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/RequestCallContextSafeHandle.cs
@@ -18,7 +18,6 @@
 
 using System;
 using System.Runtime.InteropServices;
-using Grpc.Core;
 using Grpc.Core.Logging;
 using Grpc.Core.Utils;
 
@@ -29,6 +28,9 @@ namespace Grpc.Core.Internal
     /// </summary>
     internal class RequestCallContextSafeHandle : SafeHandleZeroIsInvalid, IOpCompletionCallback, IPooledObject<RequestCallContextSafeHandle>
     {
+#if GRPC_CSHARP_SUPPORT_THREADPOOLWORKITEM
+        void System.Threading.IThreadPoolWorkItem.Execute() => ((IOpCompletionCallback)this).OnComplete(true); // when called this way: means success
+#endif
         static readonly NativeMethods Native = NativeMethods.Get();
         static readonly ILogger Logger = GrpcEnvironment.Logger.ForType<RequestCallContextSafeHandle>();
         Action<RequestCallContextSafeHandle> returnToPoolAction;

--- a/src/csharp/Grpc.Microbenchmarks/Grpc.Microbenchmarks.csproj
+++ b/src/csharp/Grpc.Microbenchmarks/Grpc.Microbenchmarks.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
NOTE: blocked by netcoreapp3.0 release

This change requires adding a `netcoreapp3.0` TFM to `Grpc.Core`

`GrpcThreadPool` makes heavy use of `ThreadPool.QueueUserWorkItem`, which can be surprisingly expensive for allocations:

![image](https://user-images.githubusercontent.com/17328/60666988-5153b480-9e60-11e9-85fe-090c1344ea00.png)

There *is* an alternative API, `UnsafeQueueUserWorkItem`, but this is actually *even more* expensive for allocations:

![image](https://user-images.githubusercontent.com/17328/60667042-71837380-9e60-11e9-9cf9-ce9712f02f83.png)

However, .NET Core 3 adds a new API, `System.Threading.IThreadPoolWorkItem`. An object that implements this interface can be **queued directly**, without any delegates or allocations.

Since "success" is measurably more common than "failure", I propose that when available, `IOpCompletionCallback : IThreadPoolWorkItem`, with execution in this way meaning "success"; this has zero allocation cost. Failures would use the old approach, which still has some cost:

![image](https://user-images.githubusercontent.com/17328/60667213-e3f45380-9e60-11e9-8225-86804618fb2a.png)

Result: allocations from the thread-pool reduced to ~25% of what they were.

---

Edit: a more radical follow-on change would be to change the API so that success is specified *separately* to execution, i.e.

``` c#
interface IOpCompletionCallback : IThreadPoolWorkItem {
  void OnComplete(bool success);
}
```

becomes

``` c#
interface IOpCompletionCallback : IThreadPoolWorkItem {
  void OnComplete();
  bool Outcome {get;set;} // naming is hard
}
```

then we could do (in `RunHandlerLoop`):

``` c#
callback.Outcome = success;
ThreadPool.UnsafeQueueUserWorkItem(callback, preferLocal: false);
```

and remove **all** allocations from the thread-pool ([like this](https://github.com/mgravell/grpc/commit/bcf51b19a96a4d01aa62d6ddc5a05cfc9ea42df9)):

![image](https://user-images.githubusercontent.com/17328/60668386-ba88f700-9e63-11e9-9fd5-52c5046371bd.png)
