### PR TITLE
csharp: use a pooled buffer when encoding text Metadata.Entry items

### DIFF
--- a/src/csharp/Grpc.Core.Api/Metadata.cs
+++ b/src/csharp/Grpc.Core.Api/Metadata.cs
@@ -220,7 +220,7 @@ namespace Grpc.Core
 
         internal int GetMaxEncodedTextSize()
         {
-            int max = 0;
+            int max = -1; // negative: no text items
             foreach (var entry in entries)
             {
                 if (!entry.IsBinary)

--- a/src/csharp/Grpc.Core/Grpc.Core.csproj
+++ b/src/csharp/Grpc.Core/Grpc.Core.csproj
@@ -100,6 +100,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Interactive.Async" Version="3.2.0" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/src/csharp/Grpc.Core/Internal/MetadataArraySafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/MetadataArraySafeHandle.cs
@@ -37,7 +37,7 @@ namespace Grpc.Core.Internal
 
             // TODO(jtattermusch): we might wanna check that the metadata is readonly
             int maxTextBytesNeeded = metadata.GetMaxEncodedTextSize();
-            byte[] textBuffer = maxTextBytesNeeded == 0 ? null : ArrayPool<byte>.Shared.Rent(maxTextBytesNeeded);
+            byte[] textBuffer = maxTextBytesNeeded < 0 ? null : ArrayPool<byte>.Shared.Rent(maxTextBytesNeeded);
             try
             {
                 var metadataArray = Native.grpcsharp_metadata_array_create(new UIntPtr((ulong)metadata.Count));


### PR DESCRIPTION
Currently when headers are sent it uses `Encoding.GetBytes()` on each text value, resulting in a lot of allocations; the following is from a single request header and a single response trailer:

``` c#
private Metadata clientHeaders = new Metadata() { { "client-header", "abcdefghijklmnop" } };
private Metadata.Entry serverEntry = new Metadata.Entry("server-header", "ABCDEFGHIJKLMNOP");
```

![image](https://user-images.githubusercontent.com/17328/60672987-9979d380-9e6e-11e9-9054-c2ace62a2bdc.png)

The content only needs to be valid for the duration of each call to `Native.grpcsharp_metadata_array_add`, so instead:

- find the maximum space needed over all the text items
- rent a buffer from the pool to fit the largest requirement
- encode each item *into that pooled buffer*
- send the pooled buffer to `Native.grpcsharp_metadata_array_add`
- return the pooled buffer when complete

Result for same workload:

![image](https://user-images.githubusercontent.com/17328/60673199-26bd2800-9e6f-11e9-9cf9-c7bb79ec365f.png)

(this is for 10k iterations, so we expect to drop 20k allocations, one for the request, one for the response; i.e. "yay")