### PR TITLE
csharp: don't process metadata on blocking unary calls

### DIFF
--- a/src/csharp/Grpc.Core/Calls.cs
+++ b/src/csharp/Grpc.Core/Calls.cs
@@ -41,7 +41,7 @@ namespace Grpc.Core
             where TRequest : class
             where TResponse : class
         {
-            var asyncCall = new AsyncCall<TRequest, TResponse>(call);
+            var asyncCall = new AsyncCall<TRequest, TResponse>(call, expectHeaders: false); // headers never made available to caller, so don't process them
             return asyncCall.UnaryCall(req);
         }
 

--- a/src/csharp/Grpc.Core/Internal/BatchContextSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/BatchContextSafeHandle.cs
@@ -87,7 +87,7 @@ namespace Grpc.Core.Internal
         }
 
         // Gets data of recv_status_on_client completion.
-        public ClientSideStatus GetReceivedStatusOnClient()
+        public ClientSideStatus GetReceivedStatusOnClient(bool fetchMetadata = true)
         {
             UIntPtr detailsLength;
             IntPtr detailsPtr = Native.grpcsharp_batch_context_recv_status_on_client_details(this, out detailsLength);
@@ -95,7 +95,7 @@ namespace Grpc.Core.Internal
             var status = new Status(Native.grpcsharp_batch_context_recv_status_on_client_status(this), details);
 
             IntPtr metadataArrayPtr = Native.grpcsharp_batch_context_recv_status_on_client_trailing_metadata(this);
-            var metadata = MetadataArraySafeHandle.ReadMetadataFromPtrUnsafe(metadataArrayPtr);
+            var metadata = fetchMetadata ? MetadataArraySafeHandle.ReadMetadataFromPtrUnsafe(metadataArrayPtr) : null;
 
             return new ClientSideStatus(status, metadata);
         }


### PR DESCRIPTION
There is literally no way to fetch them, so: no need to process them. This saves, per request:

- 2x `Metadata` (headers, trailers)
- 2x `List<Entry>` (headers, trailers)
- 1x `Task<Metadata>` (headers)
- 1x `TaskCompletionSource<Metadata>` (headers)
- however many header/trailer `Entry` elements (plus their contents) that are sent by the server to the client

before (based on **NO HEADERS BEING SENT**)

![image](https://user-images.githubusercontent.com/17328/60676858-dd250b00-9e77-11e9-9d6b-a6eafae52549.png)

after:

![image](https://user-images.githubusercontent.com/17328/60676867-e31aec00-9e77-11e9-9469-55d90413965d.png)

