### PR TITLE
csharp: coalesce async => async calls into single async method

### DIFF
--- a/src/csharp/Grpc.Core/Internal/ServerRpcState.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerRpcState.cs
@@ -1,0 +1,50 @@
+#region Copyright notice and license
+
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+
+namespace Grpc.Core.Internal
+{
+    internal struct ServerRpcState
+    {
+        private readonly Server server;
+        private readonly CompletionQueueSafeHandle cq;
+        private readonly Action<Server, CompletionQueueSafeHandle> continuation;
+
+        public ServerRpcState(Server server, CompletionQueueSafeHandle cq, Action<Server, CompletionQueueSafeHandle> continuation)
+        {
+            this.server = server;
+            this.cq = cq;
+            this.continuation = continuation;
+        }
+
+        public CompletionQueueSafeHandle CompletionQueue
+        {
+            get { return cq; }
+        }
+
+        public void InvokeContinuation()
+        {
+            if (continuation != null) continuation(server, cq);
+        }
+        public void LogError(Exception ex)
+        {
+            if (server != null) server.LogError(ex);
+        }
+    }
+}


### PR DESCRIPTION
When an incomplete async operation needs to schedule a continuation, there is a lot of machinery by way of `System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1.AsyncStateMachineBox`1` that needs to get involved. When the `await` is genuinely needed, that's fine - but a lot of times it isn't.

Here, I identify `async Task HandleCallAsync(...)` which calls `async Task HandleCall(...)`; the only non-trivial piece it adds is a modest try/catch/finally - but that logic can be very efficiently refactored into a new struct, `ServerRpcState`, allowing `HandleCallAsync` to lose the `async`. 

Before:

![image](https://user-images.githubusercontent.com/17328/60721561-46635780-9f26-11e9-9baf-e5d470fc9d31.png)

After:

![image](https://user-images.githubusercontent.com/17328/60721585-54b17380-9f26-11e9-9e09-afe7197b164f.png)

(there are probably a few other candidates for this, although we expect `HandleCall` to stay `async`)