### PR TITLE
Delete the exited container after running python bazel_deps.sh

### DIFF
--- a/tools/distrib/python/bazel_deps.sh
+++ b/tools/distrib/python/bazel_deps.sh
@@ -26,6 +26,7 @@ else
   docker build -t bazel_local_img tools/dockerfile/test/sanity
   docker run -v "$(realpath .):/src/grpc/:ro" \
     -w /src/grpc/third_party/protobuf         \
+    --rm=true                                 \
     bazel_local_img                           \
     bazel query 'deps('$1')'
 fi


### PR DESCRIPTION
"docker run" by default leave the existed container on the disk, and those images can pile up after a while.
This is the root cause of perf worker running out of space in https://github.com/grpc/grpc/issues/19289