### PR TITLE
Remove the unused import that breaks import

### DIFF
--- a/src/python/grpcio_tests/tests/unit/_signal_handling_test.py
+++ b/src/python/grpcio_tests/tests/unit/_signal_handling_test.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 """Test of responsiveness to signals."""
 
-from __future__ import print_function
-
 import logging
 import os
 import signal


### PR DESCRIPTION
This is a fix-forward for https://github.com/grpc/grpc/pull/19481.
The import code modifier seems not working well with `from __future__` statement.