### PR TITLE
Convert compile-time bool into template param in slicebuf

### DIFF
--- a/src/core/lib/slice/slice_buffer.cc
+++ b/src/core/lib/slice/slice_buffer.cc
@@ -262,9 +262,9 @@ void grpc_slice_buffer_move_into(grpc_slice_buffer* src,
   src->length = 0;
 }
 
+template <bool incref>
 static void slice_buffer_move_first_maybe_ref(grpc_slice_buffer* src, size_t n,
-                                              grpc_slice_buffer* dst,
-                                              bool incref) {
+                                              grpc_slice_buffer* dst) {
   GPR_ASSERT(src->length >= n);
   if (src->length == n) {
     grpc_slice_buffer_move_into(src, dst);
@@ -304,12 +304,12 @@ static void slice_buffer_move_first_maybe_ref(grpc_slice_buffer* src, size_t n,
 
 void grpc_slice_buffer_move_first(grpc_slice_buffer* src, size_t n,
                                   grpc_slice_buffer* dst) {
-  slice_buffer_move_first_maybe_ref(src, n, dst, true);
+  slice_buffer_move_first_maybe_ref<true>(src, n, dst);
 }
 
 void grpc_slice_buffer_move_first_no_ref(grpc_slice_buffer* src, size_t n,
                                          grpc_slice_buffer* dst) {
-  slice_buffer_move_first_maybe_ref(src, n, dst, false);
+  slice_buffer_move_first_maybe_ref<false>(src, n, dst);
 }
 
 void grpc_slice_buffer_move_first_into_buffer(grpc_slice_buffer* src, size_t n,


### PR DESCRIPTION
Simplifying https://github.com/grpc/grpc/pull/19543 by moving a template declaration into a small easily-reviewed change.