### PR TITLE
Don't require_relative for an absolute path

### DIFF
--- a/src/ruby/lib/grpc/grpc.rb
+++ b/src/ruby/lib/grpc/grpc.rb
@@ -17,7 +17,7 @@ begin
   distrib_lib_dir = File.expand_path(ruby_version_dirname,
                                      File.dirname(__FILE__))
   if File.directory?(distrib_lib_dir)
-    require_relative "#{distrib_lib_dir}/grpc_c"
+    require "#{distrib_lib_dir}/grpc_c"
   else
     require 'grpc/grpc_c'
   end


### PR DESCRIPTION
Ruby's `require_relative` method currently converts paths to absolute
paths. This idiosyncrasy means that the implementation of the require
for the distributed shared library works, however the semantics do not
mesh with the semantics of `require_relative`.

This is an issue when you redefine `require_relative` and follow the
semantics of the method, as [derailed_benchmarks does][1]. This means
that any project that uses `grpc` also cannot use that project (which
I will also be patching).

In the event that a new version of Ruby follows the semantics of the
method (whether or not that is likely), this will break as well.

By switching to `require` here instead of `require_relative`, we
maintain the functionality but do not use a semantically incompatible
method to do so.

[1]: https://github.com/schneems/derailed_benchmarks/blob/1b0c425720fd6cc575edbb389b434f461cb65989/lib/derailed_benchmarks/core_ext/kernel_require.rb#L24-L27