### PR TITLE
Remove UseCommandProcessor init for mono compatibility

### DIFF
--- a/src/csharp/Grpc.Tools/ProtoCompile.cs
+++ b/src/csharp/Grpc.Tools/ProtoCompile.cs
@@ -532,8 +532,6 @@ namespace Grpc.Tools
         // Main task entry point.
         public override bool Execute()
         {
-            base.UseCommandProcessor = false;
-
             bool ok = base.Execute();
             if (!ok)
             {


### PR DESCRIPTION
Explicitly initializing UseCommandProcessor to false causes an issue when running the ProtoCompile task on mono (the property is not a part of the mono ToolTask implementation). Additional information can be found in [this](https://github.com/OmniSharp/omnisharp-roslyn/issues/1481) OmniSharp issue.