### PR TITLE
C# - remove delegate allocation and boxing from cancellation registrations

### DIFF
--- a/src/csharp/Grpc.Core.Tests/CallCancellationTest.cs
+++ b/src/csharp/Grpc.Core.Tests/CallCancellationTest.cs
@@ -178,5 +178,16 @@ namespace Grpc.Core.Tests
                 Assert.AreEqual(StatusCode.Cancelled, ex.Status.StatusCode);
             }
         }
+
+        [Test]
+        public void CanDisposeDefaultCancellationRegistration()
+        {
+            // prove that we're fine to dispose default CancellationTokenRegistration
+            // values without boxing them to IDisposable for a null-check
+            var obj = default(CancellationTokenRegistration);
+            obj.Dispose();
+
+            using (obj) {}
+        }
     }
 }

--- a/src/csharp/Grpc.Core/Internal/AsyncCall.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCall.cs
@@ -38,7 +38,7 @@ namespace Grpc.Core.Internal
         bool registeredWithChannel;
 
         // Dispose of to de-register cancellation token registration
-        IDisposable cancellationTokenRegistration;
+        CancellationTokenRegistration cancellationTokenRegistration;
 
         // Completion of a pending unary response if not null.
         TaskCompletionSource<TResponse> unaryResponseTcs;
@@ -409,7 +409,7 @@ namespace Grpc.Core.Internal
             // deadlock.
             // See https://github.com/grpc/grpc/issues/14777
             // See https://github.com/dotnet/corefx/issues/14903
-            cancellationTokenRegistration?.Dispose();
+            cancellationTokenRegistration.Dispose();
         }
 
         protected override bool IsClient
@@ -509,11 +509,7 @@ namespace Grpc.Core.Internal
         // Make sure that once cancellationToken for this call is cancelled, Cancel() will be called.
         private void RegisterCancellationCallback()
         {
-            var token = details.Options.CancellationToken;
-            if (token.CanBeCanceled)
-            {
-                cancellationTokenRegistration = token.Register(() => this.Cancel());
-            }
+            cancellationTokenRegistration = RegisterCancellationCallbackForToken(details.Options.CancellationToken);
         }
 
         /// <summary>

--- a/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs
+++ b/src/csharp/Grpc.Core/Internal/AsyncCallBase.cs
@@ -394,5 +394,13 @@ namespace Grpc.Core.Internal
         {
             HandleReadFinished(success, receivedMessageReader);
         }
+
+        internal CancellationTokenRegistration RegisterCancellationCallbackForToken(CancellationToken cancellationToken)
+        {
+            if (cancellationToken.CanBeCanceled) return cancellationToken.Register(CancelCallFromToken, this);
+            return default(CancellationTokenRegistration);
+        }
+
+        private static readonly Action<object> CancelCallFromToken = state => ((AsyncCallBase<TWrite, TRead>)state).Cancel();
     }
 }

--- a/src/csharp/Grpc.Core/Internal/ClientResponseStream.cs
+++ b/src/csharp/Grpc.Core/Internal/ClientResponseStream.cs
@@ -49,8 +49,7 @@ namespace Grpc.Core.Internal
 
         public async Task<bool> MoveNext(CancellationToken token)
         {
-            var cancellationTokenRegistration = token.CanBeCanceled ? token.Register(() => call.Cancel()) : (IDisposable) null;
-            using (cancellationTokenRegistration)
+            using (call.RegisterCancellationCallbackForToken(token))
             {
                 var result = await call.ReadMessageAsync().ConfigureAwait(false);
                 this.current = result;

--- a/src/csharp/Grpc.Core/Internal/ServerRequestStream.cs
+++ b/src/csharp/Grpc.Core/Internal/ServerRequestStream.cs
@@ -49,9 +49,7 @@ namespace Grpc.Core.Internal
 
         public async Task<bool> MoveNext(CancellationToken token)
         {
-            
-            var cancellationTokenRegistration = token.CanBeCanceled ? token.Register(() => call.Cancel()) : (IDisposable) null;
-            using (cancellationTokenRegistration)
+            using (call.RegisterCancellationCallbackForToken(token))
             {
                 var result = await call.ReadMessageAsync().ConfigureAwait(false);
                 this.current = result;


### PR DESCRIPTION
Currently, there are two problems with how cancellations are registered:

1. a delegate is allocated each time (the `Action` API instead of the `Action<object>` API with state)
2. the registration is cast to an `IDisposable`, causing it to become "boxed"

Both of these are unnecessary

1. is fixed using a `static readonly Action<object>` instance, passing `this` as the state argument
2. is fixed by using the value-type directly

A test is added to prove that we can safely dispose the `default(CancellationTokenRegistration)` as a no-op. To avoid duplication and risk of incorrect state object types, the actual implementation is moved to a helper method in `AsyncCallBase<,>`.