### PR TITLE
Channelz: use RefCountedPtr instead of raw pointer for ChildSocketsList

### DIFF
--- a/src/core/lib/channel/channelz.h
+++ b/src/core/lib/channel/channelz.h
@@ -64,7 +64,7 @@ intptr_t GetParentUuidFromArgs(const grpc_channel_args& args);
 typedef InlinedVector<intptr_t, 10> ChildRefsList;
 
 class SocketNode;
-typedef InlinedVector<SocketNode*, 10> ChildSocketsList;
+typedef InlinedVector<RefCountedPtr<SocketNode>, 10> ChildSocketsList;
 
 namespace testing {
 class CallCountingHelperPeer;

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -1248,7 +1248,7 @@ void grpc_server_populate_server_sockets(
   channel_data* c = nullptr;
   for (c = s->root_channel_data.next; c != &s->root_channel_data; c = c->next) {
     if (c->socket_node != nullptr && c->socket_node->uuid() >= start_idx) {
-      server_sockets->push_back(c->socket_node.get());
+      server_sockets->push_back(c->socket_node);
     }
   }
   gpr_mu_unlock(&s->mu_global);


### PR DESCRIPTION
Fix a bug where the raw pointer to the server's sockets was getting passed to the channelz service. This is unsafe because the server's sockets could get destroyed after this point.