### PR TITLE
Removing hack in gRPC-Core.podspec

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -1385,10 +1385,4 @@ Pod::Spec.new do |s|
                       'test/core/end2end/end2end_tests.h'
   end
 
-  # TODO (mxyan): Instead of this hack, add include path "third_party" to C core's include path?
-  s.prepare_command = <<-END_OF_COMMAND
-    find src/core/ -type f ! -path '*.grpc_back' -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include "(pb(_.*)?\\.h)";#include <nanopb/\\1>;g'
-    find src/core/ -type f -path '*.grpc_back' -print0 | xargs -0 rm
-    find src/core/ -type f \\( -path '*.h' -or -path '*.cc' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include <openssl/;#include <openssl_grpc/;g'
-  END_OF_COMMAND
 end

--- a/src/core/ext/filters/client_channel/health/health.pb.h
+++ b/src/core/ext/filters/client_channel/health/health.pb.h
@@ -3,7 +3,12 @@
 
 #ifndef PB_GRPC_HEALTH_V1_HEALTH_PB_H_INCLUDED
 #define PB_GRPC_HEALTH_V1_HEALTH_PB_H_INCLUDED
-#include "pb.h"
+
+#if COCOAPODS
+  #include <nanopb/pb.h>
+#else
+  #include "pb.h"
+#endif
 /* @@protoc_insertion_point(includes) */
 #if PB_PROTO_HEADER_VERSION != 30
 #error Regenerate this file with the current version of nanopb generator.

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/proto/grpc/lb/v1/google/protobuf/duration.pb.h
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/proto/grpc/lb/v1/google/protobuf/duration.pb.h
@@ -3,7 +3,12 @@
 
 #ifndef PB_GOOGLE_PROTOBUF_DURATION_PB_H_INCLUDED
 #define PB_GOOGLE_PROTOBUF_DURATION_PB_H_INCLUDED
-#include "pb.h"
+
+#if COCOAPODS
+  #include <nanopb/pb.h>
+#else
+  #include "pb.h"
+#endif
 /* @@protoc_insertion_point(includes) */
 #if PB_PROTO_HEADER_VERSION != 30
 #error Regenerate this file with the current version of nanopb generator.

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/proto/grpc/lb/v1/google/protobuf/timestamp.pb.h
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/proto/grpc/lb/v1/google/protobuf/timestamp.pb.h
@@ -3,7 +3,12 @@
 
 #ifndef PB_GOOGLE_PROTOBUF_TIMESTAMP_PB_H_INCLUDED
 #define PB_GOOGLE_PROTOBUF_TIMESTAMP_PB_H_INCLUDED
-#include "pb.h"
+
+#if COCOAPODS
+  #include <nanopb/pb.h>
+#else
+  #include "pb.h"
+#endif
 /* @@protoc_insertion_point(includes) */
 #if PB_PROTO_HEADER_VERSION != 30
 #error Regenerate this file with the current version of nanopb generator.

--- a/src/core/ext/filters/client_channel/lb_policy/grpclb/proto/grpc/lb/v1/load_balancer.pb.h
+++ b/src/core/ext/filters/client_channel/lb_policy/grpclb/proto/grpc/lb/v1/load_balancer.pb.h
@@ -3,7 +3,12 @@
 
 #ifndef PB_GRPC_LB_V1_LOAD_BALANCER_PB_H_INCLUDED
 #define PB_GRPC_LB_V1_LOAD_BALANCER_PB_H_INCLUDED
-#include "pb.h"
+
+#if COCOAPODS
+  #include <nanopb/pb.h>
+#else
+  #include "pb.h"
+#endif
 #include "src/core/ext/filters/client_channel/lb_policy/grpclb/proto/grpc/lb/v1/google/protobuf/duration.pb.h"
 #include "src/core/ext/filters/client_channel/lb_policy/grpclb/proto/grpc/lb/v1/google/protobuf/timestamp.pb.h"
 /* @@protoc_insertion_point(includes) */

--- a/src/core/lib/security/credentials/jwt/json_token.cc
+++ b/src/core/lib/security/credentials/jwt/json_token.cc
@@ -34,22 +34,13 @@
 #include "src/core/lib/slice/b64.h"
 
 extern "C" {
-
 #if COCOAPODS
   #include <openssl_grpc/bio.h>
-#else
-  #include <openssl/bio.h>
-#endif
-
-#if COCOAPODS
   #include <openssl_grpc/evp.h>
-#else
-  #include <openssl/evp.h>
-#endif
-
-#if COCOAPODS
   #include <openssl_grpc/pem.h>
 #else
+  #include <openssl/bio.h>
+  #include <openssl/evp.h>
   #include <openssl/pem.h>
 #endif
 }

--- a/src/core/lib/security/credentials/jwt/json_token.cc
+++ b/src/core/lib/security/credentials/jwt/json_token.cc
@@ -34,9 +34,24 @@
 #include "src/core/lib/slice/b64.h"
 
 extern "C" {
-#include <openssl/bio.h>
-#include <openssl/evp.h>
-#include <openssl/pem.h>
+
+#if COCOAPODS
+  #include <openssl_grpc/bio.h>
+#else
+  #include <openssl/bio.h>
+#endif
+
+#if COCOAPODS
+  #include <openssl_grpc/evp.h>
+#else
+  #include <openssl/evp.h>
+#endif
+
+#if COCOAPODS
+  #include <openssl_grpc/pem.h>
+#else
+  #include <openssl/pem.h>
+#endif
 }
 
 /* --- Constants. --- */

--- a/src/core/lib/security/credentials/jwt/json_token.h
+++ b/src/core/lib/security/credentials/jwt/json_token.h
@@ -24,7 +24,12 @@
 #include "src/core/tsi/grpc_shadow_boringssl.h"
 
 #include <grpc/slice.h>
-#include <openssl/rsa.h>
+
+#if COCOAPODS
+  #include <openssl_grpc/rsa.h>
+#else
+  #include <openssl/rsa.h>
+#endif
 
 #include "src/core/lib/json/json.h"
 

--- a/src/core/lib/security/credentials/jwt/jwt_verifier.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.cc
@@ -31,22 +31,13 @@
 #include <grpc/support/sync.h>
 
 extern "C" {
-
 #if COCOAPODS
   #include <openssl_grpc/bn.h>
-#else
-  #include <openssl/bn.h>
-#endif
-
-#if COCOAPODS
   #include <openssl_grpc/pem.h>
-#else
-  #include <openssl/pem.h>
-#endif
-
-#if COCOAPODS
   #include <openssl_grpc/rsa.h>
 #else
+  #include <openssl/bn.h>
+  #include <openssl/pem.h>
   #include <openssl/rsa.h>
 #endif
 }

--- a/src/core/lib/security/credentials/jwt/jwt_verifier.cc
+++ b/src/core/lib/security/credentials/jwt/jwt_verifier.cc
@@ -31,9 +31,24 @@
 #include <grpc/support/sync.h>
 
 extern "C" {
-#include <openssl/bn.h>
-#include <openssl/pem.h>
-#include <openssl/rsa.h>
+
+#if COCOAPODS
+  #include <openssl_grpc/bn.h>
+#else
+  #include <openssl/bn.h>
+#endif
+
+#if COCOAPODS
+  #include <openssl_grpc/pem.h>
+#else
+  #include <openssl/pem.h>
+#endif
+
+#if COCOAPODS
+  #include <openssl_grpc/rsa.h>
+#else
+  #include <openssl/rsa.h>
+#endif
 }
 
 #include "src/core/lib/gpr/string.h"

--- a/src/core/tsi/alts/crypt/aes_gcm.cc
+++ b/src/core/tsi/alts/crypt/aes_gcm.cc
@@ -22,34 +22,17 @@
 
 #include "src/core/tsi/alts/crypt/gsec.h"
 
-
 #if COCOAPODS
   #include <openssl_grpc/bio.h>
-#else
-  #include <openssl/bio.h>
-#endif
-
-#if COCOAPODS
   #include <openssl_grpc/buffer.h>
-#else
-  #include <openssl/buffer.h>
-#endif
-
-#if COCOAPODS
   #include <openssl_grpc/err.h>
-#else
-  #include <openssl/err.h>
-#endif
-
-#if COCOAPODS
   #include <openssl_grpc/evp.h>
-#else
-  #include <openssl/evp.h>
-#endif
-
-#if COCOAPODS
   #include <openssl_grpc/hmac.h>
 #else
+  #include <openssl/bio.h>
+  #include <openssl/buffer.h>
+  #include <openssl/err.h>
+  #include <openssl/evp.h>
   #include <openssl/hmac.h>
 #endif
 #include <string.h>

--- a/src/core/tsi/alts/crypt/aes_gcm.cc
+++ b/src/core/tsi/alts/crypt/aes_gcm.cc
@@ -22,11 +22,36 @@
 
 #include "src/core/tsi/alts/crypt/gsec.h"
 
-#include <openssl/bio.h>
-#include <openssl/buffer.h>
-#include <openssl/err.h>
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
+
+#if COCOAPODS
+  #include <openssl_grpc/bio.h>
+#else
+  #include <openssl/bio.h>
+#endif
+
+#if COCOAPODS
+  #include <openssl_grpc/buffer.h>
+#else
+  #include <openssl/buffer.h>
+#endif
+
+#if COCOAPODS
+  #include <openssl_grpc/err.h>
+#else
+  #include <openssl/err.h>
+#endif
+
+#if COCOAPODS
+  #include <openssl_grpc/evp.h>
+#else
+  #include <openssl/evp.h>
+#endif
+
+#if COCOAPODS
+  #include <openssl_grpc/hmac.h>
+#else
+  #include <openssl/hmac.h>
+#endif
 #include <string.h>
 
 #include <grpc/support/alloc.h>

--- a/src/core/tsi/alts/handshaker/altscontext.pb.h
+++ b/src/core/tsi/alts/handshaker/altscontext.pb.h
@@ -3,7 +3,12 @@
 
 #ifndef PB_GRPC_GCP_ALTSCONTEXT_PB_H_INCLUDED
 #define PB_GRPC_GCP_ALTSCONTEXT_PB_H_INCLUDED
-#include "pb.h"
+
+#if COCOAPODS
+  #include <nanopb/pb.h>
+#else
+  #include "pb.h"
+#endif
 #include "src/core/tsi/alts/handshaker/transport_security_common.pb.h"
 /* @@protoc_insertion_point(includes) */
 #if PB_PROTO_HEADER_VERSION != 30

--- a/src/core/tsi/alts/handshaker/handshaker.pb.h
+++ b/src/core/tsi/alts/handshaker/handshaker.pb.h
@@ -3,7 +3,12 @@
 
 #ifndef PB_GRPC_GCP_HANDSHAKER_PB_H_INCLUDED
 #define PB_GRPC_GCP_HANDSHAKER_PB_H_INCLUDED
-#include "pb.h"
+
+#if COCOAPODS
+  #include <nanopb/pb.h>
+#else
+  #include "pb.h"
+#endif
 #include "src/core/tsi/alts/handshaker/transport_security_common.pb.h"
 /* @@protoc_insertion_point(includes) */
 #if PB_PROTO_HEADER_VERSION != 30

--- a/src/core/tsi/alts/handshaker/transport_security_common.pb.h
+++ b/src/core/tsi/alts/handshaker/transport_security_common.pb.h
@@ -3,7 +3,12 @@
 
 #ifndef PB_GRPC_GCP_TRANSPORT_SECURITY_COMMON_PB_H_INCLUDED
 #define PB_GRPC_GCP_TRANSPORT_SECURITY_COMMON_PB_H_INCLUDED
-#include "pb.h"
+
+#if COCOAPODS
+  #include <nanopb/pb.h>
+#else
+  #include "pb.h"
+#endif
 /* @@protoc_insertion_point(includes) */
 #if PB_PROTO_HEADER_VERSION != 30
 #error Regenerate this file with the current version of nanopb generator.

--- a/src/core/tsi/ssl/session_cache/ssl_session.h
+++ b/src/core/tsi/ssl/session_cache/ssl_session.h
@@ -26,7 +26,12 @@
 #include <grpc/slice.h>
 
 extern "C" {
-#include <openssl/ssl.h>
+
+#if COCOAPODS
+  #include <openssl_grpc/ssl.h>
+#else
+  #include <openssl/ssl.h>
+#endif
 }
 
 #include "src/core/lib/gprpp/ref_counted.h"

--- a/src/core/tsi/ssl/session_cache/ssl_session_cache.h
+++ b/src/core/tsi/ssl/session_cache/ssl_session_cache.h
@@ -27,7 +27,12 @@
 #include <grpc/support/sync.h>
 
 extern "C" {
-#include <openssl/ssl.h>
+
+#if COCOAPODS
+  #include <openssl_grpc/ssl.h>
+#else
+  #include <openssl/ssl.h>
+#endif
 }
 
 #include "src/core/lib/avl/avl.h"

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -42,40 +42,19 @@
 #include <grpc/support/thd_id.h>
 
 extern "C" {
-
 #if COCOAPODS
   #include <openssl_grpc/bio.h>
-#else
-  #include <openssl/bio.h>
-#endif
-
-#if COCOAPODS
-  #include <openssl_grpc/crypto.h>
-#else
-  #include <openssl/crypto.h>
-#endif /* For OPENSSL_free */
-
-#if COCOAPODS
+  #include <openssl_grpc/crypto.h> /* For OPENSSL_free */
   #include <openssl_grpc/err.h>
-#else
-  #include <openssl/err.h>
-#endif
-
-#if COCOAPODS
   #include <openssl_grpc/ssl.h>
-#else
-  #include <openssl/ssl.h>
-#endif
-
-#if COCOAPODS
   #include <openssl_grpc/x509.h>
-#else
-  #include <openssl/x509.h>
-#endif
-
-#if COCOAPODS
   #include <openssl_grpc/x509v3.h>
 #else
+  #include <openssl/bio.h>
+  #include <openssl/crypto.h>
+  #include <openssl/err.h>
+  #include <openssl/ssl.h>
+  #include <openssl/x509.h>
   #include <openssl/x509v3.h>
 #endif
 }

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -42,12 +42,42 @@
 #include <grpc/support/thd_id.h>
 
 extern "C" {
-#include <openssl/bio.h>
-#include <openssl/crypto.h> /* For OPENSSL_free */
-#include <openssl/err.h>
-#include <openssl/ssl.h>
-#include <openssl/x509.h>
-#include <openssl/x509v3.h>
+
+#if COCOAPODS
+  #include <openssl_grpc/bio.h>
+#else
+  #include <openssl/bio.h>
+#endif
+
+#if COCOAPODS
+  #include <openssl_grpc/crypto.h>
+#else
+  #include <openssl/crypto.h>
+#endif /* For OPENSSL_free */
+
+#if COCOAPODS
+  #include <openssl_grpc/err.h>
+#else
+  #include <openssl/err.h>
+#endif
+
+#if COCOAPODS
+  #include <openssl_grpc/ssl.h>
+#else
+  #include <openssl/ssl.h>
+#endif
+
+#if COCOAPODS
+  #include <openssl_grpc/x509.h>
+#else
+  #include <openssl/x509.h>
+#endif
+
+#if COCOAPODS
+  #include <openssl_grpc/x509v3.h>
+#else
+  #include <openssl/x509v3.h>
+#endif
 }
 
 #include "src/core/lib/gpr/useful.h"

--- a/src/core/tsi/ssl_types.h
+++ b/src/core/tsi/ssl_types.h
@@ -31,7 +31,12 @@
 
 #include "src/core/tsi/grpc_shadow_boringssl.h"
 
-#include <openssl/ssl.h>
+
+#if COCOAPODS
+  #include <openssl_grpc/ssl.h>
+#else
+  #include <openssl/ssl.h>
+#endif
 
 #ifdef OPENSSL_IS_BORINGSSL
 #define TSI_INT_AS_SIZE(x) ((size_t)(x))


### PR DESCRIPTION
Since gRPC-Core.podspec defined a preprocessor `COCOAPODS=1`. We branch on that to use different import statements when using different build systems. As a result, `pod install` does not modify source codes, so that both Cocoapods and Bazel can be used at the same time during development without changing source code back and forth.