### PR TITLE
Add a test client for certain grpclb fallback scenarios

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -638,7 +638,9 @@ add_dependencies(buildtests_cxx grpc_linux_system_roots_test)
 add_dependencies(buildtests_cxx grpc_tool_test)
 add_dependencies(buildtests_cxx grpclb_api_test)
 add_dependencies(buildtests_cxx grpclb_end2end_test)
+if(_gRPC_PLATFORM_LINUX)
 add_dependencies(buildtests_cxx grpclb_fallback_test)
+endif()
 add_dependencies(buildtests_cxx h2_ssl_cert_test)
 add_dependencies(buildtests_cxx h2_ssl_session_reuse_test)
 add_dependencies(buildtests_cxx health_service_end2end_test)
@@ -14468,6 +14470,7 @@ target_link_libraries(grpclb_end2end_test
 
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
+if(_gRPC_PLATFORM_LINUX)
 
 add_executable(grpclb_fallback_test
   ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/empty.pb.cc
@@ -14528,6 +14531,7 @@ target_link_libraries(grpclb_fallback_test
 )
 
 
+endif()
 endif (gRPC_BUILD_TESTS)
 if (gRPC_BUILD_TESTS)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -638,6 +638,7 @@ add_dependencies(buildtests_cxx grpc_linux_system_roots_test)
 add_dependencies(buildtests_cxx grpc_tool_test)
 add_dependencies(buildtests_cxx grpclb_api_test)
 add_dependencies(buildtests_cxx grpclb_end2end_test)
+add_dependencies(buildtests_cxx grpclb_fallback_test)
 add_dependencies(buildtests_cxx h2_ssl_cert_test)
 add_dependencies(buildtests_cxx h2_ssl_session_reuse_test)
 add_dependencies(buildtests_cxx health_service_end2end_test)
@@ -14461,6 +14462,68 @@ target_link_libraries(grpclb_end2end_test
   grpc++
   grpc
   gpr
+  ${_gRPC_GFLAGS_LIBRARIES}
+)
+
+
+endif (gRPC_BUILD_TESTS)
+if (gRPC_BUILD_TESTS)
+
+add_executable(grpclb_fallback_test
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/empty.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/empty.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/empty.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/empty.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/messages.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/messages.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/messages.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/messages.grpc.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/test.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/test.grpc.pb.cc
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/test.pb.h
+  ${_gRPC_PROTO_GENS_DIR}/src/proto/grpc/testing/test.grpc.pb.h
+  test/cpp/interop/grpclb_fallback_test.cc
+  third_party/googletest/googletest/src/gtest-all.cc
+  third_party/googletest/googlemock/src/gmock-all.cc
+)
+
+protobuf_generate_grpc_cpp(
+  src/proto/grpc/testing/empty.proto
+)
+protobuf_generate_grpc_cpp(
+  src/proto/grpc/testing/messages.proto
+)
+protobuf_generate_grpc_cpp(
+  src/proto/grpc/testing/test.proto
+)
+
+target_include_directories(grpclb_fallback_test
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
+  PRIVATE ${_gRPC_SSL_INCLUDE_DIR}
+  PRIVATE ${_gRPC_PROTOBUF_INCLUDE_DIR}
+  PRIVATE ${_gRPC_ZLIB_INCLUDE_DIR}
+  PRIVATE ${_gRPC_BENCHMARK_INCLUDE_DIR}
+  PRIVATE ${_gRPC_CARES_INCLUDE_DIR}
+  PRIVATE ${_gRPC_GFLAGS_INCLUDE_DIR}
+  PRIVATE ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+  PRIVATE ${_gRPC_NANOPB_INCLUDE_DIR}
+  PRIVATE third_party/googletest/googletest/include
+  PRIVATE third_party/googletest/googletest
+  PRIVATE third_party/googletest/googlemock/include
+  PRIVATE third_party/googletest/googlemock
+  PRIVATE ${_gRPC_PROTO_GENS_DIR}
+)
+
+target_link_libraries(grpclb_fallback_test
+  ${_gRPC_PROTOBUF_LIBRARIES}
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc++_test_util
+  grpc_test_util
+  grpc++
+  grpc
+  gpr
+  grpc++_test_config
   ${_gRPC_GFLAGS_LIBRARIES}
 )
 

--- a/build.yaml
+++ b/build.yaml
@@ -5041,6 +5041,21 @@ targets:
   - grpc++
   - grpc
   - gpr
+- name: grpclb_fallback_test
+  build: test
+  language: c++
+  src:
+  - src/proto/grpc/testing/empty.proto
+  - src/proto/grpc/testing/messages.proto
+  - src/proto/grpc/testing/test.proto
+  - test/cpp/interop/grpclb_fallback_test.cc
+  deps:
+  - grpc++_test_util
+  - grpc_test_util
+  - grpc++
+  - grpc
+  - gpr
+  - grpc++_test_config
 - name: h2_ssl_cert_test
   gtest: true
   build: test

--- a/build.yaml
+++ b/build.yaml
@@ -5056,6 +5056,8 @@ targets:
   - grpc
   - gpr
   - grpc++_test_config
+  platforms:
+  - linux
 - name: h2_ssl_cert_test
   gtest: true
   build: test

--- a/src/proto/grpc/testing/messages.proto
+++ b/src/proto/grpc/testing/messages.proto
@@ -48,6 +48,21 @@ message EchoStatus {
   string message = 2;
 }
 
+// The type of route that a client took to reach a server w.r.t. gRPCLB.
+// The server must fill in "fallback" if it detects that the RPC reached
+// the server via the "gRPCLB fallback" path, and "backend" if it detects
+// that the RPC reached the server via "gRPCLB backend" path (i.e. if it got
+// the address of this server from the gRPCLB server BalanceLoad RPC). Exactly
+// how this detection is done is context and server dependant.
+enum GrpclbRouteType {
+  // Server didn't detect the route that a client took to reach it.
+  GRPCLB_ROUTE_TYPE_UNKNOWN = 0;
+  // Indicates that a client reached a server via gRPCLB fallback.
+  GRPCLB_ROUTE_TYPE_FALLBACK = 1;
+  // Indicates that a client reached a server as a gRPCLB-given backend.
+  GRPCLB_ROUTE_TYPE_BACKEND = 2;
+}
+
 // Unary request.
 message SimpleRequest {
   // Desired payload type in the response from the server.
@@ -80,6 +95,9 @@ message SimpleRequest {
 
   // Whether SimpleResponse should include server_id.
   bool fill_server_id = 9;
+
+  // Whether SimpleResponse should include grpclb_route_type.
+  bool fill_grpclb_route_type = 10;
 }
 
 // Unary response, as configured by the request.
@@ -95,6 +113,8 @@ message SimpleResponse {
   // Server ID. This must be unique among different server instances,
   // but the same across all RPC's made to a particular server instance.
   string server_id = 4;
+  // gRPCLB Path.
+  GrpclbRouteType grpclb_route_type = 5;
 }
 
 // Client-streaming request.

--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -39,6 +39,22 @@ grpc_cc_library(
 )
 
 grpc_cc_binary(
+    name = "grpclb_fallback_test",
+    srcs = [
+        "grpclb_fallback_test.cc",
+    ],
+    language = "C++",
+    deps = [
+        "//src/proto/grpc/testing:empty_proto",
+        "//src/proto/grpc/testing:messages_proto",
+        "//src/proto/grpc/testing:test_proto",
+        "//test/cpp/util:test_config",
+        "//test/cpp/util:test_util",
+        "//:grpc++",
+    ],
+)
+
+grpc_cc_binary(
     name = "interop_server",
     srcs = [
         "interop_server_bootstrap.cc",

--- a/test/cpp/interop/grpclb_fallback_test.cc
+++ b/test/cpp/interop/grpclb_fallback_test.cc
@@ -1,0 +1,254 @@
+#include <grpc/support/port_platform.h>
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <gflags/gflags.h>
+#include <inttypes.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <grpc/support/alloc.h>
+#include <grpc/support/log.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/grpcpp.h>
+#include <grpcpp/support/channel_arguments.h>
+
+#include "src/core/lib/gpr/string.h"
+#include "src/core/lib/iomgr/socket_mutator.h"
+#include "src/proto/grpc/testing/empty.pb.h"
+#include "src/proto/grpc/testing/messages.pb.h"
+#include "src/proto/grpc/testing/test.grpc.pb.h"
+#include "src/proto/grpc/testing/test.pb.h"
+
+#include "test/cpp/util/test_config.h"
+#include "test/cpp/util/test_credentials_provider.h"
+
+DEFINE_string(custom_credentials_type, "", "User provided credentials type.");
+DEFINE_string(server_uri, "localhost:1000", "Server URI target");
+DEFINE_string(unroute_lb_and_backend_addrs_cmd, "exit 1",
+              "Shell command used to make LB and backend addresses unroutable");
+DEFINE_string(blackhole_lb_and_backend_addrs_cmd, "exit 1",
+              "Shell command used to make LB and backend addresses blackholed");
+DEFINE_string(
+    test_case, "",
+    "Test case to run. Valid options are:\n\n"
+    "fast_fallback_before_startup : fallback before establishing connection to "
+    "LB;\n"
+    "fast_fallback_after_startup : fallback after startup due to LB/backend "
+    "addresses becoming unroutable;\n"
+    "slow_fallback_before_startup : fallback before startup due to LB address "
+    "being blackholed;\n"
+    "slow_fallback_after_startup : fallback after startup due to LB/backend "
+    "addresses becoming blackholed;\n");
+
+using grpc::testing::GrpclbRouteType;
+using grpc::testing::SimpleRequest;
+using grpc::testing::SimpleResponse;
+using grpc::testing::TestService;
+
+namespace {
+
+enum RpcMode {
+  FailFast,
+  WaitForReady,
+};
+
+GrpclbRouteType DoRPCAndGetPath(TestService::Stub* stub, int deadline_seconds,
+                                RpcMode rpc_mode) {
+  gpr_log(GPR_INFO, "DoRPCAndGetPath deadline_seconds:%d rpc_mode:%d",
+          deadline_seconds, rpc_mode);
+  SimpleRequest request;
+  SimpleResponse response;
+  grpc::ClientContext context;
+  if (rpc_mode == WaitForReady) {
+    context.set_wait_for_ready(true);
+  }
+  request.set_fill_grpclb_route_type(true);
+  std::chrono::system_clock::time_point deadline =
+      std::chrono::system_clock::now() + std::chrono::seconds(deadline_seconds);
+  context.set_deadline(deadline);
+  grpc::Status s = stub->UnaryCall(&context, request, &response);
+  if (!s.ok()) {
+    gpr_log(GPR_INFO, "DoRPCAndGetPath failed. status-message: %s",
+            s.error_message().c_str());
+    return GrpclbRouteType::GRPCLB_ROUTE_TYPE_UNKNOWN;
+  }
+  GPR_ASSERT(response.grpclb_route_type() ==
+                 GrpclbRouteType::GRPCLB_ROUTE_TYPE_BACKEND ||
+             response.grpclb_route_type() ==
+                 GrpclbRouteType::GRPCLB_ROUTE_TYPE_FALLBACK);
+  gpr_log(GPR_INFO, "DoRPCAndGetPath done. grpclb_route_type:%d",
+          response.grpclb_route_type());
+  return response.grpclb_route_type();
+}
+
+GrpclbRouteType DoRPCAndGetPath(TestService::Stub* stub, int deadline_seconds) {
+  return DoRPCAndGetPath(stub, deadline_seconds, FailFast);
+}
+
+GrpclbRouteType DoWaitForReadyRPCAndGetPath(TestService::Stub* stub,
+                                            int deadline_seconds) {
+  return DoRPCAndGetPath(stub, deadline_seconds, WaitForReady);
+}
+
+bool TcpUserTimeoutMutateFd(int fd, grpc_socket_mutator* mutator) {
+  int timeout = 20000;  // 20 seconds
+  gpr_log(GPR_INFO, "Setting socket option TCP_USER_TIMEOUT on fd: %d", fd);
+  if (0 != setsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &timeout,
+                      sizeof(timeout))) {
+    gpr_log(GPR_ERROR, "Failed to set socket option TCP_USER_TIMEOUT");
+    abort();
+  }
+  int newval;
+  socklen_t len = sizeof(newval);
+  if (0 != getsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &newval, &len) ||
+      newval != timeout) {
+    gpr_log(GPR_ERROR, "Failed to set socket option TCP_USER_TIMEOUT");
+    abort();
+  }
+  return true;
+}
+
+int TcpUserTimeoutCompare(grpc_socket_mutator* a, grpc_socket_mutator* b) {
+  return 0;
+}
+
+void TcpUserTimeoutDestroy(grpc_socket_mutator* mutator) { gpr_free(mutator); }
+
+const grpc_socket_mutator_vtable kTcpUserTimeoutMutatorVtable =
+    grpc_socket_mutator_vtable{
+        .mutate_fd = TcpUserTimeoutMutateFd,
+        .compare = TcpUserTimeoutCompare,
+        .destroy = TcpUserTimeoutDestroy,
+    };
+
+std::unique_ptr<TestService::Stub> CreateFallbackTestStub() {
+  grpc::ChannelArguments channel_args;
+  grpc_socket_mutator* tcp_user_timeout_mutator =
+      static_cast<grpc_socket_mutator*>(
+          gpr_malloc(sizeof(tcp_user_timeout_mutator)));
+  grpc_socket_mutator_init(tcp_user_timeout_mutator,
+                           &kTcpUserTimeoutMutatorVtable);
+  channel_args.SetSocketMutator(tcp_user_timeout_mutator);
+  // Allow LB policy to be configured by service config
+  channel_args.SetInt(GRPC_ARG_SERVICE_CONFIG_DISABLE_RESOLUTION, 0);
+  std::shared_ptr<grpc::ChannelCredentials> channel_creds =
+      grpc::testing::GetCredentialsProvider()->GetChannelCredentials(
+          FLAGS_custom_credentials_type, &channel_args);
+  return TestService::NewStub(
+      grpc::CreateCustomChannel(FLAGS_server_uri, channel_creds, channel_args));
+}
+
+void RunCommand(const std::string command) {
+  gpr_log(GPR_INFO, "RunCommand: |%s|", command.c_str());
+  int out = std::system(command.c_str());
+  if (WIFEXITED(out)) {
+    int code = WEXITSTATUS(out);
+    if (code != 0) {
+      gpr_log(GPR_ERROR, "RunCommand failed exit code:%d command:|%s|", code,
+              command.c_str());
+      abort();
+    }
+  } else {
+    gpr_log(GPR_ERROR, "RunCommand failed command:|%s|", command.c_str());
+    abort();
+  }
+}
+
+void RunFallbackBeforeStartupTest(
+    const std::string break_lb_and_backend_conns_cmd,
+    int per_rpc_deadline_seconds) {
+  std::unique_ptr<TestService::Stub> stub = CreateFallbackTestStub();
+  RunCommand(break_lb_and_backend_conns_cmd);
+  for (size_t i = 0; i < 30; i++) {
+    GrpclbRouteType grpclb_route_type =
+        DoRPCAndGetPath(stub.get(), per_rpc_deadline_seconds);
+    if (grpclb_route_type != GrpclbRouteType::GRPCLB_ROUTE_TYPE_FALLBACK) {
+      gpr_log(GPR_ERROR, "Expected grpclb route type: FALLBACK. Got: %d",
+              grpclb_route_type);
+      abort();
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+}
+
+void DoFastFallbackBeforeStartup() {
+  RunFallbackBeforeStartupTest(FLAGS_unroute_lb_and_backend_addrs_cmd, 9);
+}
+
+void DoSlowFallbackBeforeStartup() {
+  RunFallbackBeforeStartupTest(FLAGS_blackhole_lb_and_backend_addrs_cmd, 20);
+}
+
+void RunFallbackAfterStartupTest(
+    const std::string break_lb_and_backend_conns_cmd) {
+  std::unique_ptr<TestService::Stub> stub = CreateFallbackTestStub();
+  GrpclbRouteType grpclb_route_type = DoRPCAndGetPath(stub.get(), 20);
+  if (grpclb_route_type != GrpclbRouteType::GRPCLB_ROUTE_TYPE_BACKEND) {
+    gpr_log(GPR_ERROR, "Expected grpclb route type: BACKEND. Got: %d",
+            grpclb_route_type);
+    abort();
+  }
+  RunCommand(break_lb_and_backend_conns_cmd);
+  for (size_t i = 0; i < 40; i++) {
+    GrpclbRouteType grpclb_route_type =
+        DoWaitForReadyRPCAndGetPath(stub.get(), 1);
+    // Backends should be unreachable by now, otherwise the test is broken.
+    GPR_ASSERT(grpclb_route_type != GrpclbRouteType::GRPCLB_ROUTE_TYPE_BACKEND);
+    if (grpclb_route_type == GrpclbRouteType::GRPCLB_ROUTE_TYPE_FALLBACK) {
+      gpr_log(GPR_INFO,
+              "Made one successul RPC to a fallback. Now expect the same for "
+              "the rest.");
+      break;
+    } else {
+      gpr_log(GPR_ERROR, "Retryable RPC failure on iteration: %" PRIdPTR, i);
+    }
+  }
+  for (size_t i = 0; i < 30; i++) {
+    GrpclbRouteType grpclb_route_type = DoRPCAndGetPath(stub.get(), 20);
+    if (grpclb_route_type != GrpclbRouteType::GRPCLB_ROUTE_TYPE_FALLBACK) {
+      gpr_log(GPR_ERROR, "Expected grpclb route type: FALLBACK. Got: %d",
+              grpclb_route_type);
+      abort();
+    }
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+}
+
+void DoFastFallbackAfterStartup() {
+  RunFallbackAfterStartupTest(FLAGS_unroute_lb_and_backend_addrs_cmd);
+}
+
+void DoSlowFallbackAfterStartup() {
+  RunFallbackAfterStartupTest(FLAGS_blackhole_lb_and_backend_addrs_cmd);
+}
+}  // namespace
+
+int main(int argc, char** argv) {
+  grpc::testing::InitTest(&argc, &argv, true);
+  gpr_log(GPR_INFO, "Testing: %s", FLAGS_test_case.c_str());
+  if (FLAGS_test_case == "fast_fallback_before_startup") {
+    DoFastFallbackBeforeStartup();
+    gpr_log(GPR_INFO, "DoFastFallbackBeforeStartup done!");
+  } else if (FLAGS_test_case == "slow_fallback_before_startup") {
+    DoSlowFallbackBeforeStartup();
+    gpr_log(GPR_INFO, "DoSlowFallbackBeforeStartup done!");
+  } else if (FLAGS_test_case == "fast_fallback_after_startup") {
+    DoFastFallbackAfterStartup();
+    gpr_log(GPR_INFO, "DoFastFallbackAfterStartup done!");
+  } else if (FLAGS_test_case == "slow_fallback_after_startup") {
+    DoSlowFallbackAfterStartup();
+    gpr_log(GPR_INFO, "DoSlowFallbackAfterStartup done!");
+  } else {
+    gpr_log(GPR_ERROR, "Invalid test case: %s", FLAGS_test_case.c_str());
+    abort();
+  }
+}

--- a/test/cpp/interop/grpclb_fallback_test.cc
+++ b/test/cpp/interop/grpclb_fallback_test.cc
@@ -1,3 +1,21 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 #include <grpc/support/port_platform.h>
 
 #include <arpa/inet.h>
@@ -111,7 +129,7 @@ bool TcpUserTimeoutMutateFd(int fd, grpc_socket_mutator* mutator) {
   socklen_t len = sizeof(newval);
   if (0 != getsockopt(fd, IPPROTO_TCP, TCP_USER_TIMEOUT, &newval, &len) ||
       newval != timeout) {
-    gpr_log(GPR_ERROR, "Failed to set socket option TCP_USER_TIMEOUT");
+    gpr_log(GPR_ERROR, "Failed to get expected socket option TCP_USER_TIMEOUT");
     abort();
   }
   return true;
@@ -147,7 +165,7 @@ std::unique_ptr<TestService::Stub> CreateFallbackTestStub() {
       grpc::CreateCustomChannel(FLAGS_server_uri, channel_creds, channel_args));
 }
 
-void RunCommand(const std::string command) {
+void RunCommand(const std::string& command) {
   gpr_log(GPR_INFO, "RunCommand: |%s|", command.c_str());
   int out = std::system(command.c_str());
   if (WIFEXITED(out)) {
@@ -164,7 +182,7 @@ void RunCommand(const std::string command) {
 }
 
 void RunFallbackBeforeStartupTest(
-    const std::string break_lb_and_backend_conns_cmd,
+    const std::string& break_lb_and_backend_conns_cmd,
     int per_rpc_deadline_seconds) {
   std::unique_ptr<TestService::Stub> stub = CreateFallbackTestStub();
   RunCommand(break_lb_and_backend_conns_cmd);
@@ -189,7 +207,7 @@ void DoSlowFallbackBeforeStartup() {
 }
 
 void RunFallbackAfterStartupTest(
-    const std::string break_lb_and_backend_conns_cmd) {
+    const std::string& break_lb_and_backend_conns_cmd) {
   std::unique_ptr<TestService::Stub> stub = CreateFallbackTestStub();
   GrpclbRouteType grpclb_route_type = DoRPCAndGetPath(stub.get(), 20);
   if (grpclb_route_type != GrpclbRouteType::GRPCLB_ROUTE_TYPE_BACKEND) {

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -4042,6 +4042,35 @@
       "gpr", 
       "grpc", 
       "grpc++", 
+      "grpc++_test_config", 
+      "grpc++_test_util", 
+      "grpc_test_util"
+    ], 
+    "headers": [
+      "src/proto/grpc/testing/empty.grpc.pb.h", 
+      "src/proto/grpc/testing/empty.pb.h", 
+      "src/proto/grpc/testing/empty_mock.grpc.pb.h", 
+      "src/proto/grpc/testing/messages.grpc.pb.h", 
+      "src/proto/grpc/testing/messages.pb.h", 
+      "src/proto/grpc/testing/messages_mock.grpc.pb.h", 
+      "src/proto/grpc/testing/test.grpc.pb.h", 
+      "src/proto/grpc/testing/test.pb.h", 
+      "src/proto/grpc/testing/test_mock.grpc.pb.h"
+    ], 
+    "is_filegroup": false, 
+    "language": "c++", 
+    "name": "grpclb_fallback_test", 
+    "src": [
+      "test/cpp/interop/grpclb_fallback_test.cc"
+    ], 
+    "third_party": false, 
+    "type": "target"
+  }, 
+  {
+    "deps": [
+      "gpr", 
+      "grpc", 
+      "grpc++", 
       "grpc++_test", 
       "grpc_test_util"
     ], 

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -4826,6 +4826,30 @@
     "exclude_configs": [], 
     "exclude_iomgrs": [], 
     "flaky": false, 
+    "gtest": false, 
+    "language": "c++", 
+    "name": "grpclb_fallback_test", 
+    "platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "uses_polling": true
+  }, 
+  {
+    "args": [], 
+    "benchmark": false, 
+    "ci_platforms": [
+      "linux", 
+      "mac", 
+      "posix", 
+      "windows"
+    ], 
+    "cpu_cost": 1.0, 
+    "exclude_configs": [], 
+    "exclude_iomgrs": [], 
+    "flaky": false, 
     "gtest": true, 
     "language": "c++", 
     "name": "h2_ssl_cert_test", 

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -4817,10 +4817,7 @@
     "args": [], 
     "benchmark": false, 
     "ci_platforms": [
-      "linux", 
-      "mac", 
-      "posix", 
-      "windows"
+      "linux"
     ], 
     "cpu_cost": 1.0, 
     "exclude_configs": [], 
@@ -4830,10 +4827,7 @@
     "language": "c++", 
     "name": "grpclb_fallback_test", 
     "platforms": [
-      "linux", 
-      "mac", 
-      "posix", 
-      "windows"
+      "linux"
     ], 
     "uses_polling": true
   }, 


### PR DESCRIPTION
This synchronizes upstream test protos from https://github.com/grpc/grpc-proto/pull/55 and https://github.com/grpc/grpc-proto/pull/56, and then adds a new one-off test client.

Checking this test into this repo is mostly done to simply the build process - the runner for this test will live outside of this repo. Also note this has been manually tested.