### PR TITLE
dont use shutdownRef count for sync completion queue

### DIFF
--- a/src/csharp/Grpc.Core/Internal/CompletionQueueSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/CompletionQueueSafeHandle.cs
@@ -104,20 +104,16 @@ namespace Grpc.Core.Internal
 
         private void BeginOp()
         {
-            if (shutdownRefcount != null)
-            {
-                bool success = false;
-                shutdownRefcount.IncrementIfNonzero(ref success);
-                GrpcPreconditions.CheckState(success, "Shutdown has already been called");
-            }
+            GrpcPreconditions.CheckNotNull(shutdownRefcount, nameof(shutdownRefcount));
+            bool success = false;
+            shutdownRefcount.IncrementIfNonzero(ref success);
+            GrpcPreconditions.CheckState(success, "Shutdown has already been called");
         }
 
         private void EndOp()
         {
-            if (shutdownRefcount != null)
-            {
-                DecrementShutdownRefcount();
-            }
+            GrpcPreconditions.CheckNotNull(shutdownRefcount, nameof(shutdownRefcount));
+            DecrementShutdownRefcount();
         }
 
         // Allows declaring BeginOp and EndOp of a completion queue with a using statement.

--- a/src/csharp/Grpc.Core/Internal/CompletionQueueSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/CompletionQueueSafeHandle.cs
@@ -29,7 +29,7 @@ namespace Grpc.Core.Internal
     {
         static readonly NativeMethods Native = NativeMethods.Get();
 
-        AtomicCounter shutdownRefcount = new AtomicCounter(1);
+        AtomicCounter shutdownRefcount;
         CompletionRegistry completionRegistry;
 
         private CompletionQueueSafeHandle()
@@ -51,6 +51,7 @@ namespace Grpc.Core.Internal
         {
             var cq = Native.grpcsharp_completion_queue_create_async();
             cq.completionRegistry = completionRegistry;
+            cq.shutdownRefcount = new AtomicCounter(1);
             return cq;
         }
 
@@ -95,7 +96,7 @@ namespace Grpc.Core.Internal
 
         private void DecrementShutdownRefcount()
         {
-            if (shutdownRefcount.Decrement() == 0)
+            if (shutdownRefcount == null || shutdownRefcount.Decrement() == 0)
             {
                 Native.grpcsharp_completion_queue_shutdown(this);
             }
@@ -103,14 +104,20 @@ namespace Grpc.Core.Internal
 
         private void BeginOp()
         {
-            bool success = false;
-            shutdownRefcount.IncrementIfNonzero(ref success);
-            GrpcPreconditions.CheckState(success, "Shutdown has already been called");
+            if (shutdownRefcount != null)
+            {
+                bool success = false;
+                shutdownRefcount.IncrementIfNonzero(ref success);
+                GrpcPreconditions.CheckState(success, "Shutdown has already been called");
+            }
         }
 
         private void EndOp()
         {
-            DecrementShutdownRefcount();
+            if (shutdownRefcount != null)
+            {
+                DecrementShutdownRefcount();
+            }
         }
 
         // Allows declaring BeginOp and EndOp of a completion queue with a using statement.


### PR DESCRIPTION
Save AtomicCounter allocation for sync unary call (currently there's 1 alloc per call).
The optimization is possible because keeping track of unfinished cq operations is only useful for async completion queues.
At the same time, allocating AtomicCounter for async completion queues doesn't bother us as the async cqs only get created very rarely (at startup).

Supersedes
https://github.com/grpc/grpc/pull/19536
