### PR TITLE
Caching bytebuffer PullWithoutRef method

### DIFF
--- a/src/core/ext/filters/http/client/http_client_filter.cc
+++ b/src/core/ext/filters/http/client/http_client_filter.cc
@@ -226,10 +226,11 @@ static void send_message_on_complete(void* arg, grpc_error* error) {
 // calld->send_message_bytes_read.
 static grpc_error* pull_slice_from_send_message(call_data* calld) {
   grpc_slice incoming_slice;
-  grpc_error* error = calld->send_message_caching_stream->Pull(&incoming_slice);
+  grpc_error* error =
+      calld->send_message_caching_stream->PullWithoutRef(&incoming_slice);
   if (error == GRPC_ERROR_NONE) {
     calld->send_message_bytes_read += GRPC_SLICE_LENGTH(incoming_slice);
-    grpc_slice_unref_internal(incoming_slice);
+    //    grpc_slice_unref_internal(incoming_slice);
   }
   return error;
 }

--- a/src/core/lib/transport/byte_stream.h
+++ b/src/core/lib/transport/byte_stream.h
@@ -130,6 +130,8 @@ class ByteStreamCache {
 
     bool Next(size_t max_size_hint, grpc_closure* on_complete) override;
     grpc_error* Pull(grpc_slice* slice) override;
+    grpc_error* PullWithoutRef(grpc_slice* slice);
+
     void Shutdown(grpc_error* error) override;
 
     // Resets the byte stream to the start of the underlying stream.


### PR DESCRIPTION
Http Client Filter uses a caching byte buffer - it attempts to read all of it, so it can (maybe) convert a request into a GET if able.

In the process, it refs and immediately unrefs the slice after. Since the byte buffer is caching, it is then reset and read by a subsequent filter or perhaps the transport.

If we add a PullWithoutRef method to the caching byte buffer specifically, we can avoid the ref/unref pair for callers that only need to peek at the data without holding onto it.