### PR TITLE
Fixed "implicitly-declared operator= is deprecated" error from gcc 9

### DIFF
--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -88,6 +88,9 @@ class WriteOptions {
   WriteOptions(const WriteOptions& other)
       : flags_(other.flags_), last_message_(other.last_message_) {}
 
+  /// Default assignment operator
+  WriteOptions& operator=(const WriteOptions& other) = default;
+
   /// Clear all flags.
   inline void Clear() { flags_ = 0; }
 


### PR DESCRIPTION
Fixes #19570