### PR TITLE
Add per-rpc interop tests for managed grpc-dotnet client

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -208,7 +208,10 @@ class AspNetCoreLanguage:
 
     def unimplemented_test_cases(self):
         return _SKIP_COMPRESSION + \
-            _AUTH_TEST_CASES
+            ['compute_engine_creds']  + \
+            ['jwt_token_creds'] + \
+            _SKIP_GOOGLE_DEFAULT_CREDS + \
+            _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS
 
     def unimplemented_test_cases_server(self):
         return _SKIP_COMPRESSION
@@ -821,8 +824,8 @@ def auth_options(language, test_case, google_default_creds_use_key_file,
 
     if test_case in ['jwt_token_creds', 'per_rpc_creds', 'oauth2_auth_token']:
         if language in [
-                'csharp', 'csharpcoreclr', 'node', 'php', 'php7', 'python',
-                'ruby', 'nodepurejs'
+                'csharp', 'csharpcoreclr', 'aspnetcore', 'node', 'php', 'php7',
+                'python', 'ruby', 'nodepurejs'
         ]:
             env['GOOGLE_APPLICATION_CREDENTIALS'] = service_account_key_file
         else:


### PR DESCRIPTION
Partially supersedes https://github.com/grpc/grpc/pull/19512 and also fixes a problem in run_interop_tests.py that was making the tests fail.

With https://github.com/grpc/grpc-dotnet/pull/395 applied, `per_rpc_creds` and `oauth2_auth_token` should pass for grpc-dotnet managed client.