### PR TITLE
Make sure there is at least a header in the frame storge of H2.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2016,9 +2016,10 @@ void grpc_chttp2_maybe_complete_recv_trailing_metadata(grpc_chttp2_transport* t,
        * maybe decompress the next 5 bytes in the stream. */
       if (s->stream_decompression_method ==
           GRPC_STREAM_COMPRESSION_IDENTITY_DECOMPRESS) {
-        grpc_slice_buffer_move_first(&s->frame_storage,
-                                     GRPC_HEADER_SIZE_IN_BYTES,
-                                     &s->unprocessed_incoming_frames_buffer);
+        grpc_slice_buffer_move_first(
+            &s->frame_storage,
+            GPR_MIN(s->frame_storage.length, GRPC_HEADER_SIZE_IN_BYTES),
+            &s->unprocessed_incoming_frames_buffer);
         if (s->unprocessed_incoming_frames_buffer.length > 0) {
           s->unprocessed_incoming_frames_decompressed = true;
           pending_data = true;


### PR DESCRIPTION
grpc_chttp2_maybe_complete_recv_trailing_metadata() moves at
least GRPC_HEADER_SIZE_IN_BYTES from the frame storage, whenever
the frame storage is non-empty:
https://github.com/grpc/grpc/blob/master/src/core/ext/transport/chttp2/transport/chttp2_transport.cc#L2019-L2021

Instead ensure that we have at least GRPC_HEADER_SIZE_IN_BYTES
in the frame storage.

This results in bugs detected by clusterfuzz in chrome:
https://bugs.chromium.org/p/chromium/issues/detail?id=984534
https://bugs.chromium.org/p/chromium/issues/detail?id=984478#c2