### PR TITLE
Increase lower bound on DNS re-resolution period to 30 seconds

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -144,7 +144,7 @@ AresDnsResolver::AresDnsResolver(ResolverArgs args)
   arg = grpc_channel_args_find(channel_args_,
                                GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS);
   min_time_between_resolutions_ =
-      grpc_channel_arg_get_integer(arg, {1000, 0, INT_MAX});
+      grpc_channel_arg_get_integer(arg, {1000 * 30, 0, INT_MAX});
   // Enable SRV queries option
   arg = grpc_channel_args_find(channel_args_, GRPC_ARG_DNS_ENABLE_SRV_QUERIES);
   enable_srv_queries_ = grpc_channel_arg_get_bool(arg, false);

--- a/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
@@ -110,7 +110,7 @@ NativeDnsResolver::NativeDnsResolver(ResolverArgs args)
   const grpc_arg* arg = grpc_channel_args_find(
       args.args, GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS);
   min_time_between_resolutions_ =
-      grpc_channel_arg_get_integer(arg, {1000, 0, INT_MAX});
+      grpc_channel_arg_get_integer(arg, {1000 * 30, 0, INT_MAX});
   interested_parties_ = grpc_pollset_set_create();
   if (args.pollset_set != nullptr) {
     grpc_pollset_set_add_pollset_set(interested_parties_, args.pollset_set);

--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -185,13 +185,23 @@ int main(int argc, char** argv) {
   char* addr;
 
   grpc_channel_args client_args;
-  grpc_arg arg_array[1];
+  grpc_arg arg_array[2];
   arg_array[0].type = GRPC_ARG_INTEGER;
   arg_array[0].key =
       const_cast<char*>("grpc.testing.fixed_reconnect_backoff_ms");
   arg_array[0].value.integer = 1000;
+  /* When this test brings down server1 and then brings up server2,
+   * the targetted server port number changes, and the client channel
+   * needs to re-resolve to pick this up. This test requires that
+   * happen within 10 seconds, but gRPC's DNS resolvers rate limit
+   * resolution attempts to at most once every 30 seconds by default.
+   * So we tweak it for this test. */
+  arg_array[1].type = GRPC_ARG_INTEGER;
+  arg_array[1].key =
+      const_cast<char*>(GRPC_ARG_DNS_MIN_TIME_BETWEEN_RESOLUTIONS_MS);
+  arg_array[1].value.integer = 1000;
   client_args.args = arg_array;
-  client_args.num_args = 1;
+  client_args.num_args = 2;
 
   /* create a channel that picks first amongst the servers */
   grpc_channel* chan =


### PR DESCRIPTION
Per conversation in https://github.com/grpc/grpc-go/issues/2402, this makes C-core more consistent with Go and Java.

Also makes DNS clients slightly less aggressive when running into certain types of connection failures.