### PR TITLE
Reduced ops for grpc_chttp2_stream_map_find().

### DIFF
--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -2066,7 +2066,7 @@ static void remove_stream(grpc_chttp2_transport* t, uint32_t id,
                           grpc_error* error) {
   grpc_chttp2_stream* s = static_cast<grpc_chttp2_stream*>(
       grpc_chttp2_stream_map_delete(&t->stream_map, id));
-  GPR_ASSERT(s);
+  GPR_DEBUG_ASSERT(s);
   if (t->incoming_stream == s) {
     t->incoming_stream = nullptr;
     grpc_chttp2_parsing_become_skip_parser(t);


### PR DESCRIPTION
1) Cached grpc_chttp2_parsing_lookup_stream() results.
2) Inlined grpc_chttp2_parsing_lookup_stream() - it's a direct jump to
grpc_chttp2_stream_map_find().
3) Removed a few branches in grpc_chttp2_stream_map_find().