### PR TITLE
Reset _FORTIFY_SOURCE when GPR_BACKWARDS_COMPATIBILITY_MODE

### DIFF
--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -401,6 +401,7 @@
  * This helps non-glibc systems such as alpine using musl to find symbols.
  */
 #if defined(_FORTIFY_SOURCE) && _FORTIFY_SOURCE > 0
+#undef _FORTIFY_SOURCE
 #define _FORTIFY_SOURCE 0
 #endif
 #endif

--- a/include/grpc/impl/codegen/port_platform.h
+++ b/include/grpc/impl/codegen/port_platform.h
@@ -394,6 +394,17 @@
 #endif
 #endif /* GPR_NO_AUTODETECT_PLATFORM */
 
+#if defined(GPR_BACKWARDS_COMPATIBILITY_MODE)
+/*
+ * For backward compatibility mode, reset _FORTIFY_SOURCE to prevent
+ * a library from having non-standard symbols such as __asprintf_chk.
+ * This helps non-glibc systems such as alpine using musl to find symbols.
+ */
+#if defined(_FORTIFY_SOURCE) && _FORTIFY_SOURCE > 0
+#define _FORTIFY_SOURCE 0
+#endif
+#endif
+
 /*
  *  There are platforms for which TLS should not be used even though the
  * compiler makes it seem like it's supported (Android NDK < r12b for example).


### PR DESCRIPTION
To fix the [issue](https://github.com/grpc/grpc/issues/19668), _FORTIFY_SOURCE is reset when building with GPR_BACKWARDS_COMPATIBILITY_MODE.