### PR TITLE
Create new build config for ASAN on Mac OS

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -13,9 +13,6 @@ build:opt --copt=-Wframe-larger-than=16384
 build:dbg --compilation_mode=dbg
 
 build:asan --strip=never
-# Workaround for https://github.com/bazelbuild/bazel/issues/6932
-build:asan --copt -Wno-macro-redefined
-build:asan --copt -D_FORTIFY_SOURCE=0
 build:asan --copt=-fsanitize=address
 build:asan --copt=-O0
 build:asan --copt=-fno-omit-frame-pointer
@@ -24,6 +21,27 @@ build:asan --copt=-DADDRESS_SANITIZER  # used by absl
 build:asan --linkopt=-fsanitize=address
 build:asan --action_env=ASAN_OPTIONS=detect_leaks=1:color=always
 build:asan --action_env=LSAN_OPTIONS=suppressions=test/core/util/lsan_suppressions.txt:report_objects=1
+
+# We have a separate ASAN config for Mac OS to workaround a couple of bugs:
+# 1. https://github.com/bazelbuild/bazel/issues/6932
+#    _FORTIFY_SOURCE=1 is enabled by default on Mac OS, which breaks ASAN.
+#    We workaround it by setting _FORTIFY_SOURCE=0 and ignoring macro redefined
+#    warnings.
+# 2. https://github.com/google/sanitizers/issues/1026
+#    LSAN is not supported by the version of Clang that ships with Mac OS, so
+#    we disable it.
+build:asan_macos --strip=never
+build:asan_macos --copt=-fsanitize=address
+build:asan_macos --copt -Wno-macro-redefined
+build:asan_macos --copt -D_FORTIFY_SOURCE=0
+build:asan_macos --copt=-fsanitize=address
+build:asan_macos --copt=-O0
+build:asan_macos --copt=-fno-omit-frame-pointer
+build:asan_macos --copt=-DGPR_NO_DIRECT_SYSCALLS
+build:asan_macos --copt=-DADDRESS_SANITIZER  # used by absl
+build:asan_macos --linkopt=-fsanitize=address
+build:asan_macos --action_env=ASAN_OPTIONS=detect_leaks=0
+
 
 build:msan --strip=never
 build:msan --copt=-fsanitize=memory

--- a/tools/internal_ci/macos/grpc_cfstream_asan.cfg
+++ b/tools/internal_ci/macos/grpc_cfstream_asan.cfg
@@ -18,6 +18,6 @@
 build_file: "grpc/tools/internal_ci/macos/grpc_run_bazel_tests.sh"
 env_vars {
   key: "RUN_TESTS_FLAGS"
-  value: "--config=asan"
+  value: "--config=asan_macos"
 }
 


### PR DESCRIPTION
- Workaround ASAN build issues on Mac OS.
- Disable LSAN as it's not supported by the version of clang that ships with Mac OS.