### PR TITLE
Get rid of unused Version.csproj.include

### DIFF
--- a/src/csharp/Grpc.Core/Version.csproj.include
+++ b/src/csharp/Grpc.Core/Version.csproj.include
@@ -1,7 +1,0 @@
-<!-- This file is generated -->
-<Project>
-  <PropertyGroup>
-    <GrpcCsharpVersion>1.19.1</GrpcCsharpVersion>
-    <GoogleProtobufVersion>3.8.0</GoogleProtobufVersion>
-  </PropertyGroup>
-</Project>

--- a/src/csharp/build/dependencies.props
+++ b/src/csharp/build/dependencies.props
@@ -2,6 +2,6 @@
 <Project>
   <PropertyGroup>
     <GrpcCsharpVersion>1.23.0-dev</GrpcCsharpVersion>
-    <GoogleProtobufVersion>3.7.0</GoogleProtobufVersion>
+    <GoogleProtobufVersion>3.8.0</GoogleProtobufVersion>
   </PropertyGroup>
 </Project>

--- a/templates/src/csharp/build/dependencies.props.template
+++ b/templates/src/csharp/build/dependencies.props.template
@@ -4,6 +4,6 @@
   <Project>
     <PropertyGroup>
       <GrpcCsharpVersion>${settings.csharp_version}</GrpcCsharpVersion>
-      <GoogleProtobufVersion>3.7.0</GoogleProtobufVersion>
+      <GoogleProtobufVersion>3.8.0</GoogleProtobufVersion>
     </PropertyGroup>
   </Project>


### PR DESCRIPTION
In https://github.com/grpc/grpc/pull/18486/files, `Version.csproj.include` was replaced with `dependencies.props`, but it wasn't really removed and we ended up with a dead copy of `Version.csproj.include` which isn't used from anywhere (but it was actually updated by some PRs by accident, making it looks that Google.Protobuf dependency version was updated when it really wasn't).

This PR removes the dead copy and makes dependencies.props up to date.