### PR TITLE
Mark assert failure path as unlikely in codegen.

### DIFF
--- a/include/grpcpp/impl/codegen/callback_common.h
+++ b/include/grpcpp/impl/codegen/callback_common.h
@@ -201,9 +201,11 @@ class CallbackWithSuccessTag
     void* ignored = ops_;
     // Allow a "false" return value from FinalizeResult to silence the
     // callback, just as it silences a CQ tag in the async cases
+#ifndef NDEBUG
     auto* ops = ops_;
+#endif
     bool do_callback = ops_->FinalizeResult(&ignored, &ok);
-    GPR_CODEGEN_ASSERT(ignored == ops);
+    GPR_CODEGEN_DEBUG_ASSERT(ignored == ops);
 
     if (do_callback) {
       CatchingCallback(func_, ok);

--- a/include/grpcpp/impl/codegen/core_codegen_interface.h
+++ b/include/grpcpp/impl/codegen/core_codegen_interface.h
@@ -144,7 +144,7 @@ extern CoreCodegenInterface* g_core_codegen_interface;
 /// Codegen specific version of \a GPR_ASSERT.
 #define GPR_CODEGEN_ASSERT(x)                                              \
   do {                                                                     \
-    if (!(x)) {                                                            \
+    if (GPR_UNLIKELY(!(x))) {                                              \
       grpc::g_core_codegen_interface->assert_fail(#x, __FILE__, __LINE__); \
     }                                                                      \
   } while (0)


### PR DESCRIPTION
Mark failure path as unlikely, just like GPR_ASSERT.