### PR TITLE
Reduced atomic strictness inside grpc_core::Fork.

### DIFF
--- a/src/core/lib/gprpp/fork.h
+++ b/src/core/lib/gprpp/fork.h
@@ -21,7 +21,7 @@
 
 #include <grpc/support/port_platform.h>
 
-#include <atomic>
+#include "src/core/lib/gprpp/atomic.h"
 
 /*
  * NOTE: FORKING IS NOT GENERALLY SUPPORTED, THIS IS ONLY INTENDED TO WORK
@@ -47,10 +47,18 @@ class Fork {
 
   // Increment the count of active ExecCtxs.
   // Will block until a pending fork is complete if one is in progress.
-  static void IncExecCtxCount();
+  static void IncExecCtxCount() {
+    if (GPR_UNLIKELY(support_enabled_.Load(MemoryOrder::RELAXED))) {
+      DoIncExecCtxCount();
+    }
+  }
 
   // Decrement the count of active ExecCtxs
-  static void DecExecCtxCount();
+  static void DecExecCtxCount() {
+    if (GPR_UNLIKELY(support_enabled_.Load(MemoryOrder::RELAXED))) {
+      DoDecExecCtxCount();
+    }
+  }
 
   // Provide a function that will be invoked in the child's postfork handler to
   // reset the polling engine's internal state.
@@ -80,9 +88,12 @@ class Fork {
   static void Enable(bool enable);
 
  private:
+  static void DoIncExecCtxCount();
+  static void DoDecExecCtxCount();
+
   static internal::ExecCtxState* exec_ctx_state_;
   static internal::ThreadState* thread_state_;
-  static std::atomic<bool> support_enabled_;
+  static grpc_core::Atomic<bool> support_enabled_;
   static bool override_enabled_;
   static child_postfork_func reset_child_polling_engine_;
 };


### PR DESCRIPTION
The enable state for fork operations, used by ExecCtx initialization, uses
default std::atomic semantics on read/write - this is sequential consistency by
default. However, this variable is only set:
1) On init,
2) Using testing interfaces

And thus we can just use relaxed semantics instead. This PR also moves from
std::atomic to grpc_core::Atomic.