### PR TITLE
Update build command to build cc_ targets only

### DIFF
--- a/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
+++ b/tools/internal_ci/linux/grpc_bazel_build_in_docker.sh
@@ -24,4 +24,6 @@ git clone /var/local/jenkins/grpc /var/local/git/grpc
 && git submodule update --init --reference /var/local/jenkins/grpc/${name} \
 ${name}')
 cd /var/local/git/grpc
-bazel build --spawn_strategy=standalone --genrule_strategy=standalone :all test/... examples/...
+# grep lines not starting with INFO to avoid messages when using Bazel wrapper
+bazel build --spawn_strategy=standalone --genrule_strategy=standalone \
+$(bazel query 'kind(cc_.*, :all)' | grep -v "^INFO\: ") test/... examples/...


### PR DESCRIPTION
When objc_library's are added to root BUILD, they fail the c/c++ tests because currently Bazel's objc_library is not supported on Linux, so targets are filtered to include only cc_ targets in the root package.