### PR TITLE
Remove warning for old linux without secure_getenv

### DIFF
--- a/src/core/lib/gpr/env_posix.cc
+++ b/src/core/lib/gpr/env_posix.cc
@@ -29,11 +29,6 @@
 #include <grpc/support/string_util.h>
 #include "src/core/lib/gpr/string.h"
 
-const char* gpr_getenv_silent(const char* name, char** dst) {
-  *dst = gpr_getenv(name);
-  return nullptr;
-}
-
 char* gpr_getenv(const char* name) {
   char* result = getenv(name);
   return result == nullptr ? result : gpr_strdup(result);


### PR DESCRIPTION
Showing a warning message about Linux system old enough not to have secure_getenv might be useful for users but it's not gRPC's work. More importantly, this message is shown for users on Alpine which doesn't have secure_getenv, which is just annoying.