### PR TITLE
fix broken link and move links to bottom

### DIFF
--- a/doc/python/server_reflection.md
+++ b/doc/python/server_reflection.md
@@ -1,14 +1,13 @@
 # gRPC Python Server Reflection
 
 This document shows how to use gRPC Server Reflection in gRPC Python.
-Please see [C++ Server Reflection Tutorial](../server_reflection_tutorial.md)
-for general information and more examples how to use server reflection.
+Please see [C++ Server Reflection Tutorial] for general information
+and more examples how to use server reflection.
 
 ## Enable server reflection in Python servers
 
-gRPC Python Server Reflection is an add-on library.
-To use it, first install the [grpcio-reflection](https://pypi.org/project/grpcio-reflection/)
-PyPI package into your project.
+gRPC Python Server Reflection is an add-on library. To use it, first install 
+the [grpcio-reflection] PyPI package into your project.
 
 Note that with Python you need to manually register the service
 descriptors with the reflection service implementation when creating a server
@@ -30,15 +29,11 @@ def serve():
     server.start()
 ```
 
-Please see
-[greeter_server_with_reflection.py](https://github.com/grpc/grpc/blob/master/examples/python/helloworld/greeter_server_with_reflection.py)
-in the examples directory for the full example, which extends the gRPC [Python
-`Greeter` example](https://github.com/grpc/tree/master/examples/python/helloworld) on a
-reflection-enabled server.
+Please see [greeter_server_with_reflection.py] in the examples directory for the full 
+example, which extends the gRPC [Python `Greeter` example] on a reflection-enabled server.
 
 After starting the server, you can verify that the server reflection
-is working properly by using the [`grpc_cli` command line
-tool](https://github.com/grpc/grpc/blob/master/doc/command_line_tool.md):
+is working properly by using the [`grpc_cli` command line tool]:
 
  ```sh
   $ grpc_cli ls localhost:50051
@@ -51,11 +46,21 @@ tool](https://github.com/grpc/grpc/blob/master/doc/command_line_tool.md):
   ```
 
   For more examples and instructions how to use the `grpc_cli` tool,
-  please refer to the [`grpc_cli` documentation](../command_line_tool.md)
-  and the [C++ Server Reflection Tutorial](../server_reflection_tutorial.md).
+  please refer to the [`grpc_cli` documentation] and the
+  [C++ Server Reflection Tutorial].
 
 ## Additional Resources
 
-The [Server Reflection Protocol](../server-reflection.md) provides detailed
+The [Server Reflection Protocol] provides detailed
 information about how the server reflection works and describes the server reflection
 protocol in detail.
+
+
+[C++ Server Reflection Tutorial]: ../server_reflection_tutorial.md
+[grpcio-reflection]: https://pypi.org/project/grpcio-reflection/
+[greeter_server_with_reflection.py]: https://github.com/grpc/grpc/blob/master/examples/python/helloworld/greeter_server_with_reflection.py
+[Python `Greeter` example]: https://github.com/grpc/grpc/tree/master/examples/python/helloworld
+[`grpc_cli` command line tool]: https://github.com/grpc/grpc/blob/master/doc/command_line_tool.md
+[`grpc_cli` documentation]: ../command_line_tool.md
+[C++ Server Reflection Tutorial]: ../server_reflection_tutorial.md
+[Server Reflection Protocol]: ../server-reflection.md


### PR DESCRIPTION
The link to the following was broken:

Python `Greeter` example: https://github.com/grpc/tree/master/examples/python/helloworld

I updated it to: 
https://github.com/grpc/grpc/tree/master/examples/python/helloworld

I also put all the links at the bottom of the page so this is easier to spot moving forward. 