### PR TITLE
Change page_size to local variable

### DIFF
--- a/src/core/lib/gprpp/thd_posix.cc
+++ b/src/core/lib/gprpp/thd_posix.cc
@@ -49,11 +49,10 @@ struct thd_arg {
   bool tracked;
 };
 
-// TODO(yunjiaw): move this to a function-level static, or remove the use of a
-// non-constexpr initializer when possible
-const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
-
 size_t RoundUpToPageSize(size_t size) {
+  // TODO(yunjiaw): Change this variable (page_size) to a function-level static
+  // when possible
+  size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
   return (size + page_size - 1) & ~(page_size - 1);
 }
 


### PR DESCRIPTION
Change page_size to a local variable to resolve an ASAN error:
`AddressSanitizer: initialization-order-fiasco grpc/src/core/lib/gprpp/thd_posix.cc:57:18 in grpc_core::(anonymous namespace)::RoundUpToPageSize(unsigned long)`