### PR TITLE
Check call.trailing_metadata() for None before iterating it

### DIFF
--- a/src/python/grpcio_status/grpc_status/rpc_status.py
+++ b/src/python/grpcio_status/grpc_status/rpc_status.py
@@ -52,6 +52,8 @@ def from_call(call):
       ValueError: If the gRPC call's code or details are inconsistent with the
         status code and message inside of the google.rpc.status.Status.
     """
+    if call.trailing_metadata() is None:
+        return None
     for key, value in call.trailing_metadata():
         if key == _GRPC_DETAILS_METADATA_KEY:
             rich_status = status_pb2.Status.FromString(value)


### PR DESCRIPTION
In case of handling exception within intercepted call, [grpc._interceptor._FailureOutcome.trailing_metadata() will return None](https://github.com/grpc/grpc/blob/f900eec41d4314fa16fee25978b5b53a0e00b7ef/src/python/grpcio/grpc/_interceptor.py#L98), causing
rpc_status.from_call() called from inside of interceptor to raise "TypeError: 'NoneType' object is not iterable".

There is a fix.