### PR TITLE
Move GetChannelConnectivityStateChangeString to channelz code

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -733,7 +733,8 @@ class ChannelData::ConnectivityStateAndPickerSetter {
       chand->channelz_node_->AddTraceEvent(
           channelz::ChannelTrace::Severity::Info,
           grpc_slice_from_static_string(
-              channelz::GetChannelConnectivityStateChangeString(state)));
+              channelz::ChannelNode::GetChannelConnectivityStateChangeString(
+                  state)));
     }
     // Bounce into the data plane combiner to reset the picker.
     GRPC_CHANNEL_STACK_REF(chand->owning_stack_,

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -733,7 +733,7 @@ class ChannelData::ConnectivityStateAndPickerSetter {
       chand->channelz_node_->AddTraceEvent(
           channelz::ChannelTrace::Severity::Info,
           grpc_slice_from_static_string(
-              GetChannelConnectivityStateChangeString(state)));
+              channelz::GetChannelConnectivityStateChangeString(state)));
     }
     // Bounce into the data plane combiner to reset the picker.
     GRPC_CHANNEL_STACK_REF(chand->owning_stack_,
@@ -744,23 +744,6 @@ class ChannelData::ConnectivityStateAndPickerSetter {
   }
 
  private:
-  static const char* GetChannelConnectivityStateChangeString(
-      grpc_connectivity_state state) {
-    switch (state) {
-      case GRPC_CHANNEL_IDLE:
-        return "Channel state change to IDLE";
-      case GRPC_CHANNEL_CONNECTING:
-        return "Channel state change to CONNECTING";
-      case GRPC_CHANNEL_READY:
-        return "Channel state change to READY";
-      case GRPC_CHANNEL_TRANSIENT_FAILURE:
-        return "Channel state change to TRANSIENT_FAILURE";
-      case GRPC_CHANNEL_SHUTDOWN:
-        return "Channel state change to SHUTDOWN";
-    }
-    GPR_UNREACHABLE_CODE(return "UNKNOWN");
-  }
-
   static void SetPicker(void* arg, grpc_error* ignored) {
     auto* self = static_cast<ConnectivityStateAndPickerSetter*>(arg);
     // Update picker.

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -192,6 +192,23 @@ ChannelNode::ChannelNode(UniquePtr<char> target,
       trace_(channel_tracer_max_nodes),
       parent_uuid_(parent_uuid) {}
 
+const char* ChannelNode::GetChannelConnectivityStateChangeString(
+    grpc_connectivity_state state) {
+  switch (state) {
+    case GRPC_CHANNEL_IDLE:
+      return "Channel state change to IDLE";
+    case GRPC_CHANNEL_CONNECTING:
+      return "Channel state change to CONNECTING";
+    case GRPC_CHANNEL_READY:
+      return "Channel state change to READY";
+    case GRPC_CHANNEL_TRANSIENT_FAILURE:
+      return "Channel state change to TRANSIENT_FAILURE";
+    case GRPC_CHANNEL_SHUTDOWN:
+      return "Channel state change to SHUTDOWN";
+  }
+  GPR_UNREACHABLE_CODE(return "UNKNOWN");
+}
+
 grpc_json* ChannelNode::RenderJson() {
   // We need to track these three json objects to build our object
   grpc_json* top_level_json = grpc_json_create(GRPC_JSON_OBJECT);

--- a/src/core/lib/channel/channelz.h
+++ b/src/core/lib/channel/channelz.h
@@ -70,6 +70,23 @@ class CallCountingHelperPeer;
 class ChannelNodePeer;
 }  // namespace testing
 
+inline static const char* GetChannelConnectivityStateChangeString(
+      grpc_connectivity_state state) {
+  switch (state) {
+    case GRPC_CHANNEL_IDLE:
+      return "Channel state change to IDLE";
+    case GRPC_CHANNEL_CONNECTING:
+      return "Channel state change to CONNECTING";
+    case GRPC_CHANNEL_READY:
+      return "Channel state change to READY";
+    case GRPC_CHANNEL_TRANSIENT_FAILURE:
+      return "Channel state change to TRANSIENT_FAILURE";
+    case GRPC_CHANNEL_SHUTDOWN:
+      return "Channel state change to SHUTDOWN";
+  }
+  GPR_UNREACHABLE_CODE(return "UNKNOWN");
+}
+
 // base class for all channelz entities
 class BaseNode : public RefCounted<BaseNode> {
  public:

--- a/src/core/lib/channel/channelz.h
+++ b/src/core/lib/channel/channelz.h
@@ -70,23 +70,6 @@ class CallCountingHelperPeer;
 class ChannelNodePeer;
 }  // namespace testing
 
-inline static const char* GetChannelConnectivityStateChangeString(
-      grpc_connectivity_state state) {
-  switch (state) {
-    case GRPC_CHANNEL_IDLE:
-      return "Channel state change to IDLE";
-    case GRPC_CHANNEL_CONNECTING:
-      return "Channel state change to CONNECTING";
-    case GRPC_CHANNEL_READY:
-      return "Channel state change to READY";
-    case GRPC_CHANNEL_TRANSIENT_FAILURE:
-      return "Channel state change to TRANSIENT_FAILURE";
-    case GRPC_CHANNEL_SHUTDOWN:
-      return "Channel state change to SHUTDOWN";
-  }
-  GPR_UNREACHABLE_CODE(return "UNKNOWN");
-}
-
 // base class for all channelz entities
 class BaseNode : public RefCounted<BaseNode> {
  public:
@@ -169,6 +152,10 @@ class ChannelNode : public BaseNode {
  public:
   ChannelNode(UniquePtr<char> target, size_t channel_tracer_max_nodes,
               intptr_t parent_uuid);
+
+  // Returns the string description of the given connectivity state.
+  static const char* GetChannelConnectivityStateChangeString(
+      grpc_connectivity_state state);
 
   intptr_t parent_uuid() const { return parent_uuid_; }
 


### PR DESCRIPTION
Moves GetChannelConnectivityStateChangeString so we can use it in multiple files. Moreover, the function probably belongs in channelz code since that's the only place it's used.