### PR TITLE
PHP: Fix missing addref in channel::constructor()

### DIFF
--- a/src/php/ext/grpc/channel.c
+++ b/src/php/ext/grpc/channel.c
@@ -330,6 +330,7 @@ PHP_METHOD(Channel, __construct) {
                            1 TSRMLS_CC);
       return;
     } else {
+      Z_ADDREF(*creds_obj);
       creds = PHP_GRPC_GET_WRAPPED_OBJECT(wrapped_grpc_channel_credentials,
                                           creds_obj);
       php_grpc_zend_hash_del(array_hash, "credentials", sizeof("credentials"));

--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -37,6 +37,12 @@ class ChannelTest extends PHPUnit_Framework_TestCase
         $this->assertSame('Grpc\Channel', get_class($this->channel));
     }
 
+    public function testConstructorCreateSsl()
+    {
+        new Grpc\Channel('localhost:50033', 
+            ['credentials' => \Grpc\ChannelCredentials::createSsl()]);
+    }
+
     public function testGetConnectivityState()
     {
         $this->channel = new Grpc\Channel('localhost:50001',


### PR DESCRIPTION
Fixed segfault in channel::constructor() and added one unit test case.

Fixes #19721 