### PR TITLE
Coalesce atomic ops for grpc_stream_unref.

### DIFF
--- a/src/core/lib/channel/channel_stack.h
+++ b/src/core/lib/channel/channel_stack.h
@@ -228,6 +228,8 @@ void grpc_call_stack_set_pollset_or_pollset_set(grpc_call_stack* call_stack,
   grpc_stream_ref(&(call_stack)->refcount, reason)
 #define GRPC_CALL_STACK_UNREF(call_stack, reason) \
   grpc_stream_unref(&(call_stack)->refcount, reason)
+#define GRPC_CALL_STACK_UNREF_N(call_stack, reason, n) \
+  grpc_stream_unref(&(call_stack)->refcount, reason, (n))
 #define GRPC_CHANNEL_STACK_REF(channel_stack, reason) \
   grpc_stream_ref(&(channel_stack)->refcount, reason)
 #define GRPC_CHANNEL_STACK_UNREF(channel_stack, reason) \
@@ -237,6 +239,8 @@ void grpc_call_stack_set_pollset_or_pollset_set(grpc_call_stack* call_stack,
   grpc_stream_ref(&(call_stack)->refcount)
 #define GRPC_CALL_STACK_UNREF(call_stack, reason) \
   grpc_stream_unref(&(call_stack)->refcount)
+#define GRPC_CALL_STACK_UNREF_N(call_stack, reason, n) \
+  grpc_stream_unref(&(call_stack)->refcount, (n))
 #define GRPC_CHANNEL_STACK_REF(channel_stack, reason) \
   grpc_stream_ref(&(channel_stack)->refcount)
 #define GRPC_CHANNEL_STACK_UNREF(channel_stack, reason) \

--- a/src/core/lib/gprpp/ref_counted.h
+++ b/src/core/lib/gprpp/ref_counted.h
@@ -165,38 +165,38 @@ class RefCount {
   }
 
   // Decrements the ref-count and returns true if the ref-count reaches 0.
-  bool Unref() {
+  bool Unref(Value n = 1) {
 #ifndef NDEBUG
     // Grab a copy of the trace flag before the atomic change, since we
     // can't safely access it afterwards if we're going to be freed.
     auto* trace_flag = trace_flag_;
 #endif
-    const Value prior = value_.FetchSub(1, MemoryOrder::ACQ_REL);
+    const Value prior = value_.FetchSub(n, MemoryOrder::ACQ_REL);
 #ifndef NDEBUG
     if (trace_flag != nullptr && trace_flag->enabled()) {
       gpr_log(GPR_INFO, "%s:%p unref %" PRIdPTR " -> %" PRIdPTR,
-              trace_flag->name(), this, prior, prior - 1);
+              trace_flag->name(), this, prior, prior - n);
     }
     GPR_DEBUG_ASSERT(prior > 0);
 #endif
-    return prior == 1;
+    return prior == n;
   }
-  bool Unref(const DebugLocation& location, const char* reason) {
+  bool Unref(const DebugLocation& location, const char* reason, Value n = 1) {
 #ifndef NDEBUG
     // Grab a copy of the trace flag before the atomic change, since we
     // can't safely access it afterwards if we're going to be freed.
     auto* trace_flag = trace_flag_;
 #endif
-    const Value prior = value_.FetchSub(1, MemoryOrder::ACQ_REL);
+    const Value prior = value_.FetchSub(n, MemoryOrder::ACQ_REL);
 #ifndef NDEBUG
     if (trace_flag != nullptr && trace_flag->enabled()) {
       gpr_log(GPR_INFO, "%s:%p %s:%d unref %" PRIdPTR " -> %" PRIdPTR " %s",
               trace_flag->name(), this, location.file(), location.line(), prior,
-              prior - 1, reason);
+              prior - n, reason);
     }
     GPR_DEBUG_ASSERT(prior > 0);
 #endif
-    return prior == 1;
+    return prior == n;
   }
 
  private:

--- a/src/core/lib/surface/call.h
+++ b/src/core/lib/surface/call.h
@@ -61,16 +61,22 @@ void grpc_call_set_completion_queue(grpc_call* call, grpc_completion_queue* cq);
 
 #ifndef NDEBUG
 void grpc_call_internal_ref(grpc_call* call, const char* reason);
-void grpc_call_internal_unref(grpc_call* call, const char* reason);
+void grpc_call_internal_unref(grpc_call* call, const char* reason,
+                              intptr_t n = 1);
 #define GRPC_CALL_INTERNAL_REF(call, reason) \
   grpc_call_internal_ref(call, reason)
 #define GRPC_CALL_INTERNAL_UNREF(call, reason) \
   grpc_call_internal_unref(call, reason)
+#define GRPC_CALL_INTERNAL_UNREF_N(call, reason, n) \
+  grpc_call_internal_unref(call, reason, (n))
 #else
 void grpc_call_internal_ref(grpc_call* call);
-void grpc_call_internal_unref(grpc_call* call);
+void grpc_call_internal_unref(grpc_call* call, intptr_t n = 1);
 #define GRPC_CALL_INTERNAL_REF(call, reason) grpc_call_internal_ref(call)
 #define GRPC_CALL_INTERNAL_UNREF(call, reason) grpc_call_internal_unref(call)
+#define GRPC_CALL_INTERNAL_UNREF_N(call, reason, n) \
+  grpc_call_internal_unref(call, (n))
+
 #endif
 
 grpc_core::Arena* grpc_call_get_arena(grpc_call* call);

--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -92,18 +92,18 @@ void grpc_stream_destroy(grpc_stream_refcount* refcount);
 
 #ifndef NDEBUG
 inline void grpc_stream_unref(grpc_stream_refcount* refcount,
-                              const char* reason) {
+                              const char* reason, intptr_t n = 1) {
   if (grpc_trace_stream_refcount.enabled()) {
     gpr_log(GPR_DEBUG, "%s %p:%p UNREF %s", refcount->object_type, refcount,
             refcount->destroy.cb_arg, reason);
   }
-  if (GPR_UNLIKELY(refcount->refs.Unref(DEBUG_LOCATION, reason))) {
+  if (GPR_UNLIKELY(refcount->refs.Unref(DEBUG_LOCATION, reason, n))) {
     grpc_stream_destroy(refcount);
   }
 }
 #else
-inline void grpc_stream_unref(grpc_stream_refcount* refcount) {
-  if (GPR_UNLIKELY(refcount->refs.Unref())) {
+inline void grpc_stream_unref(grpc_stream_refcount* refcount, intptr_t n = 1) {
+  if (GPR_UNLIKELY(refcount->refs.Unref(n))) {
     grpc_stream_destroy(refcount);
   }
 }


### PR DESCRIPTION
Each grpc_call will execute batched ops, taking atomic refs and unrefs on the
underlying grpc_stream.

Here, we coalesce the expensive unref batch calls into a single unref performed at
call destruction.

API changes:
1) Unref(N) method for grpc_core::RefCount
2) Macros added: GRPC_CALL_STACK_UNREF_N and friends