### PR TITLE
C#: save allocations by looking up known method names

### DIFF
--- a/src/csharp/Grpc.Core.Tests/Internal/BinaryStringDictionaryTest.cs
+++ b/src/csharp/Grpc.Core.Tests/Internal/BinaryStringDictionaryTest.cs
@@ -1,0 +1,77 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using NUnit.Framework;
+
+namespace Grpc.Core.Internal.Tests
+{
+    public class BinaryStringDictionaryTest
+    {
+        [Test]
+        public void Lookup() 
+        {
+            var dict = new BinaryStringDictionary();
+            dict.Add("abc");
+            dict.Add("def");
+            dict.Add("abcdef");
+
+            Assert.AreEqual("abc", NativeLookup(dict, new byte[] {0x61, 0x62, 0x63} ));
+            Assert.AreEqual("def", NativeLookup(dict, new byte[] {0x64, 0x65, 0x66} ));
+            Assert.AreEqual("abcdef", NativeLookup(dict, new byte[] {0x61, 0x62, 0x63, 0x64, 0x65, 0x66} ));
+        }
+
+        [Test]
+        public void Lookup_KeyNotFound() 
+        {
+            var dict = new BinaryStringDictionary();
+            dict.Add("abc");
+
+            Assert.IsNull(NativeLookup(dict, new byte[] {0x61, 0x62, 0x63, 0x64} ));
+        }
+
+        [Test]
+        public void Lookup_ReturnsCachedString() 
+        {
+            var dict = new BinaryStringDictionary();
+            var abcString = "abc";
+            dict.Add(abcString);
+
+            Assert.AreSame(abcString, NativeLookup(dict, new byte[] {0x61, 0x62, 0x63} ));
+            Assert.AreSame(abcString, NativeLookup(dict, new byte[] {0x61, 0x62, 0x63} ));
+        }
+
+        [Test]
+        public void Lookup_SpecialCharacters() 
+        {
+            var dict = new BinaryStringDictionary();
+            dict.Add("\n\t");
+
+            Assert.AreEqual("\n\t", NativeLookup(dict, new byte[] {0x0a, 0x09} ));
+        }
+
+        unsafe string NativeLookup(BinaryStringDictionary dict, byte[] bytes)
+        {
+            fixed (byte *ptr = bytes)
+            {
+                return dict.Lookup(new IntPtr(ptr), bytes.Length);
+            }
+        }
+    }
+
+}

--- a/src/csharp/Grpc.Core/Internal/BinaryKeyDictionary.cs
+++ b/src/csharp/Grpc.Core/Internal/BinaryKeyDictionary.cs
@@ -1,0 +1,128 @@
+#region Copyright notice and license
+
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+using Grpc.Core.Utils;
+
+namespace Grpc.Core.Internal
+{
+    /// <summary>
+    /// Read only cache of string instances that can be looked up by their binary
+    /// representation.
+    /// </summary>
+    internal class BinaryKeyDictionary
+    {
+        // TODO: use same encoding as RequestCallContextSafeHandle
+        static readonly Encoding EncodingACII = System.Text.Encoding.ASCII;
+        Dictionary<BinaryKey, string> dict = new Dictionary<BinaryKey, string>();
+
+        public BinaryKeyDictionary()
+        {
+        }
+
+        public void Add(string str)
+        {
+            dict.Add(new BinaryKey(EncodingACII.GetBytes(str)), str);
+        }
+
+        public string Lookup(IntPtr nativeData, int nativeDataLen)
+        {
+            var key = new BinaryKey(nativeData, nativeDataLen);
+            dict.TryGetValue(key, out string str);
+            return str;
+        }
+        
+        private struct BinaryKey : IEquatable<BinaryKey>
+        {
+            private byte[] data;
+            private IntPtr nativeData;
+            private int nativeDataLen;
+
+            public BinaryKey(byte[] data)
+            {
+                this.data = GrpcPreconditions.CheckNotNull(data);
+                this.nativeData = IntPtr.Zero;
+                this.nativeDataLen = 0;
+            }
+
+            public BinaryKey(IntPtr nativeData, int nativeDataLen)
+            {
+                GrpcPreconditions.CheckArgument(nativeData != IntPtr.Zero);
+                GrpcPreconditions.CheckArgument(nativeDataLen >= 0);
+                this.data = null;
+                this.nativeData = nativeData;
+                this.nativeDataLen = nativeDataLen;
+            }
+
+            /// <summary>
+            /// Indicates whether this instance and a specified object are equal.
+            /// </summary>
+            public override bool Equals(object obj)
+            {
+                return obj is BinaryKey && Equals((BinaryKey)obj);
+            }
+
+            /// <summary>
+            /// Returns the hash code for this instance.
+            /// </summary>
+            public override int GetHashCode()
+            {
+                return ComputeHashCode(GetSpan());
+            }
+
+            /// <summary>
+            /// Indicates whether this instance and a specified object are equal.
+            /// </summary>
+            public bool Equals(BinaryKey other)
+            {
+                return GetSpan().SequenceEqual(other.GetSpan());
+            }
+
+            private ReadOnlySpan<byte> GetSpan()
+            {
+                if (this.data != null)
+                {
+                    return new ReadOnlySpan<byte>(this.data);
+                }
+                if (this.nativeData != IntPtr.Zero)
+                {
+                    unsafe { return new ReadOnlySpan<byte>((byte*)this.nativeData, this.nativeDataLen); }
+                }
+                throw new ArgumentNullException("Content cannot be null.");
+            }
+
+            private static int ComputeHashCode(ReadOnlySpan<byte> data)
+            {
+                unchecked
+                {
+                    // TODO(jtattermusch): there should be a faster way of computing some meaninful hashcode
+                    // for a block of memory, but for now this should be sufficient.
+                    int hc = 1768953197;
+                    for (int i=0; i < data.Length; i++)
+                    {
+                       hc = hc * 17 + data[i];
+                    }
+                    return hc;
+                }
+            }
+        }
+    }
+}

--- a/src/csharp/Grpc.Core/Internal/BinaryStringDictionary.cs
+++ b/src/csharp/Grpc.Core/Internal/BinaryStringDictionary.cs
@@ -25,16 +25,15 @@ using Grpc.Core.Utils;
 namespace Grpc.Core.Internal
 {
     /// <summary>
-    /// Read only cache of string instances that can be looked up by their binary
-    /// representation.
+    /// Dictionary of string instances that can be looked up by their binary
+    /// representation (ASCII encoded).
     /// </summary>
-    internal class BinaryKeyDictionary
+    internal class BinaryStringDictionary
     {
-        // TODO: use same encoding as RequestCallContextSafeHandle
         static readonly Encoding EncodingACII = System.Text.Encoding.ASCII;
         Dictionary<BinaryKey, string> dict = new Dictionary<BinaryKey, string>();
 
-        public BinaryKeyDictionary()
+        public BinaryStringDictionary()
         {
         }
 
@@ -43,6 +42,9 @@ namespace Grpc.Core.Internal
             dict.Add(new BinaryKey(EncodingACII.GetBytes(str)), str);
         }
 
+        /// <summary>
+        /// Looks up the string based on its ASCII-encoded binary form.
+        /// </summary>
         public string Lookup(IntPtr nativeData, int nativeDataLen)
         {
             var key = new BinaryKey(nativeData, nativeDataLen);

--- a/src/csharp/Grpc.Core/Internal/NativeMethods.Generated.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMethods.Generated.cs
@@ -114,6 +114,7 @@ namespace Grpc.Core.Internal
         public readonly Delegates.grpcsharp_server_add_secure_http2_port_delegate grpcsharp_server_add_secure_http2_port;
         public readonly Delegates.grpcsharp_server_start_delegate grpcsharp_server_start;
         public readonly Delegates.grpcsharp_server_request_call_delegate grpcsharp_server_request_call;
+        public readonly Delegates.grpcsharp_test_server_request_call_fake_delegate grpcsharp_test_server_request_call_fake;
         public readonly Delegates.grpcsharp_server_cancel_all_calls_delegate grpcsharp_server_cancel_all_calls;
         public readonly Delegates.grpcsharp_server_shutdown_and_notify_callback_delegate grpcsharp_server_shutdown_and_notify_callback;
         public readonly Delegates.grpcsharp_server_destroy_delegate grpcsharp_server_destroy;
@@ -216,6 +217,7 @@ namespace Grpc.Core.Internal
             this.grpcsharp_server_add_secure_http2_port = GetMethodDelegate<Delegates.grpcsharp_server_add_secure_http2_port_delegate>(library);
             this.grpcsharp_server_start = GetMethodDelegate<Delegates.grpcsharp_server_start_delegate>(library);
             this.grpcsharp_server_request_call = GetMethodDelegate<Delegates.grpcsharp_server_request_call_delegate>(library);
+            this.grpcsharp_test_server_request_call_fake = GetMethodDelegate<Delegates.grpcsharp_test_server_request_call_fake_delegate>(library);
             this.grpcsharp_server_cancel_all_calls = GetMethodDelegate<Delegates.grpcsharp_server_cancel_all_calls_delegate>(library);
             this.grpcsharp_server_shutdown_and_notify_callback = GetMethodDelegate<Delegates.grpcsharp_server_shutdown_and_notify_callback_delegate>(library);
             this.grpcsharp_server_destroy = GetMethodDelegate<Delegates.grpcsharp_server_destroy_delegate>(library);
@@ -317,6 +319,7 @@ namespace Grpc.Core.Internal
             this.grpcsharp_server_add_secure_http2_port = DllImportsFromStaticLib.grpcsharp_server_add_secure_http2_port;
             this.grpcsharp_server_start = DllImportsFromStaticLib.grpcsharp_server_start;
             this.grpcsharp_server_request_call = DllImportsFromStaticLib.grpcsharp_server_request_call;
+            this.grpcsharp_test_server_request_call_fake = DllImportsFromStaticLib.grpcsharp_test_server_request_call_fake;
             this.grpcsharp_server_cancel_all_calls = DllImportsFromStaticLib.grpcsharp_server_cancel_all_calls;
             this.grpcsharp_server_shutdown_and_notify_callback = DllImportsFromStaticLib.grpcsharp_server_shutdown_and_notify_callback;
             this.grpcsharp_server_destroy = DllImportsFromStaticLib.grpcsharp_server_destroy;
@@ -418,6 +421,7 @@ namespace Grpc.Core.Internal
             this.grpcsharp_server_add_secure_http2_port = DllImportsFromSharedLib.grpcsharp_server_add_secure_http2_port;
             this.grpcsharp_server_start = DllImportsFromSharedLib.grpcsharp_server_start;
             this.grpcsharp_server_request_call = DllImportsFromSharedLib.grpcsharp_server_request_call;
+            this.grpcsharp_test_server_request_call_fake = DllImportsFromSharedLib.grpcsharp_test_server_request_call_fake;
             this.grpcsharp_server_cancel_all_calls = DllImportsFromSharedLib.grpcsharp_server_cancel_all_calls;
             this.grpcsharp_server_shutdown_and_notify_callback = DllImportsFromSharedLib.grpcsharp_server_shutdown_and_notify_callback;
             this.grpcsharp_server_destroy = DllImportsFromSharedLib.grpcsharp_server_destroy;
@@ -522,6 +526,7 @@ namespace Grpc.Core.Internal
             public delegate int grpcsharp_server_add_secure_http2_port_delegate(ServerSafeHandle server, string addr, ServerCredentialsSafeHandle creds);
             public delegate void grpcsharp_server_start_delegate(ServerSafeHandle server);
             public delegate CallError grpcsharp_server_request_call_delegate(ServerSafeHandle server, CompletionQueueSafeHandle cq, RequestCallContextSafeHandle ctx);
+            public delegate CallError grpcsharp_test_server_request_call_fake_delegate(ServerSafeHandle server, CompletionQueueSafeHandle cq, RequestCallContextSafeHandle ctx);
             public delegate void grpcsharp_server_cancel_all_calls_delegate(ServerSafeHandle server);
             public delegate void grpcsharp_server_shutdown_and_notify_callback_delegate(ServerSafeHandle server, CompletionQueueSafeHandle cq, BatchContextSafeHandle ctx);
             public delegate void grpcsharp_server_destroy_delegate(IntPtr server);
@@ -787,6 +792,9 @@ namespace Grpc.Core.Internal
             
             [DllImport(ImportName)]
             public static extern CallError grpcsharp_server_request_call(ServerSafeHandle server, CompletionQueueSafeHandle cq, RequestCallContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_test_server_request_call_fake(ServerSafeHandle server, CompletionQueueSafeHandle cq, RequestCallContextSafeHandle ctx);
             
             [DllImport(ImportName)]
             public static extern void grpcsharp_server_cancel_all_calls(ServerSafeHandle server);
@@ -1086,6 +1094,9 @@ namespace Grpc.Core.Internal
             
             [DllImport(ImportName)]
             public static extern CallError grpcsharp_server_request_call(ServerSafeHandle server, CompletionQueueSafeHandle cq, RequestCallContextSafeHandle ctx);
+            
+            [DllImport(ImportName)]
+            public static extern CallError grpcsharp_test_server_request_call_fake(ServerSafeHandle server, CompletionQueueSafeHandle cq, RequestCallContextSafeHandle ctx);
             
             [DllImport(ImportName)]
             public static extern void grpcsharp_server_cancel_all_calls(ServerSafeHandle server);

--- a/src/csharp/Grpc.Core/Internal/RequestCallContextSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/RequestCallContextSafeHandle.cs
@@ -60,7 +60,7 @@ namespace Grpc.Core.Internal
         public RequestCallCompletionDelegate CompletionCallback { get; set; }
 
         // Gets data of server_rpc_new completion.
-        public ServerRpcNew GetServerRpcNew(Server server, BinaryKeyDictionary methodLookup)
+        public ServerRpcNew GetServerRpcNew(Server server, BinaryStringDictionary methodLookup)
         {
             var call = Native.grpcsharp_request_call_context_call(this);
 

--- a/src/csharp/Grpc.Core/Internal/RequestCallContextSafeHandle.cs
+++ b/src/csharp/Grpc.Core/Internal/RequestCallContextSafeHandle.cs
@@ -60,13 +60,18 @@ namespace Grpc.Core.Internal
         public RequestCallCompletionDelegate CompletionCallback { get; set; }
 
         // Gets data of server_rpc_new completion.
-        public ServerRpcNew GetServerRpcNew(Server server)
+        public ServerRpcNew GetServerRpcNew(Server server, BinaryKeyDictionary methodLookup)
         {
             var call = Native.grpcsharp_request_call_context_call(this);
 
             UIntPtr methodLen;
             IntPtr methodPtr = Native.grpcsharp_request_call_context_method(this, out methodLen);
-            var method = Marshal.PtrToStringAnsi(methodPtr, (int) methodLen.ToUInt32());
+
+            var method = methodLookup.Lookup(methodPtr, (int) methodLen);
+            if (method == null)
+            {
+                method = Marshal.PtrToStringAnsi(methodPtr, (int) methodLen.ToUInt32());
+            }
 
             UIntPtr hostLen;
             IntPtr hostPtr = Native.grpcsharp_request_call_context_host(this, out hostLen);

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -265,6 +265,16 @@ namespace Grpc.Core
             }
         }
 
+        // only for testing.
+        internal void AddCallHandlerInternal(string methodName, IServerCallHandler handler)
+        {
+            lock (myLock)
+            {
+                GrpcPreconditions.CheckState(!startRequested);
+                callHandlers.Add(methodName, handler);
+            }
+        }
+
         /// <summary>
         /// Adds a listening port.
         /// </summary>

--- a/src/csharp/Grpc.Core/Server.cs
+++ b/src/csharp/Grpc.Core/Server.cs
@@ -48,7 +48,7 @@ namespace Grpc.Core
         readonly List<ServerServiceDefinition> serviceDefinitionsList = new List<ServerServiceDefinition>();
         readonly List<ServerPort> serverPortList = new List<ServerPort>();
         readonly Dictionary<string, IServerCallHandler> callHandlers = new Dictionary<string, IServerCallHandler>();
-        readonly BinaryKeyDictionary methodLookup = new BinaryKeyDictionary();
+        readonly BinaryStringDictionary methodLookup = new BinaryStringDictionary();
         readonly TaskCompletionSource<object> shutdownTcs = new TaskCompletionSource<object>();
 
         bool startRequested;

--- a/src/csharp/Grpc.Microbenchmarks/HandleServerCallOverheadBenchmark.cs
+++ b/src/csharp/Grpc.Microbenchmarks/HandleServerCallOverheadBenchmark.cs
@@ -1,0 +1,130 @@
+#region Copyright notice and license
+
+// Copyright 2019 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Grpc.Core;
+using Grpc.Core.Internal;
+using Grpc.Core.Utils;
+using System;
+
+using System.Collections.Generic;
+
+namespace Grpc.Microbenchmarks
+{
+    // this test measures the overhead of C# wrapping layer when requesting and dispatching
+    // a new call on the server side
+    [ClrJob, CoreJob]
+    [MemoryDiagnoser]
+    public class HandleServerCallOverheadBenchmark
+    {
+         Server server;
+        readonly Stack<RequestedCallDetails> requestedCalls = new Stack<RequestedCallDetails>();
+
+        [Benchmark]
+        public void RequestAndDispatchRpcOverhead()
+        { 
+            var origRequestedCallCount = requestedCalls.Count;
+
+            var requestedCall = requestedCalls.Pop();
+            var completionCallback = requestedCall.completionRegistry.Extract(requestedCall.tag);
+            // the completion for requested call extracts details of the call,
+            // dispatches it and also submits a request for another call.
+            completionCallback.OnComplete(true);
+
+            // checking that a new call was requested is a good way of checking that
+            // the benchmark is working as expected.
+            GrpcPreconditions.CheckState(requestedCalls.Count == origRequestedCallCount);
+        }
+
+       
+        [GlobalSetup]
+        public void Setup()
+        {
+            GrpcEnvironment.SetCompletionQueueCount(1);
+            var native = NativeMethods.Get();
+
+            // replace the implementation of a native method with a fake
+            NativeMethods.Delegates.grpcsharp_server_request_call_delegate fakeServerRequestCall = (ServerSafeHandle server, CompletionQueueSafeHandle cq, RequestCallContextSafeHandle ctx) => {
+                var result = native.grpcsharp_test_server_request_call_fake(server, cq, ctx);
+                requestedCalls.Push(new RequestedCallDetails(cq.CompletionRegistry, ctx.Handle));
+                return result;
+            };
+            native.GetType().GetField(nameof(native.grpcsharp_server_request_call)).SetValue(native, fakeServerRequestCall);
+
+            NativeMethods.Delegates.grpcsharp_call_destroy_delegate fakeCallDestroy = (IntPtr) =>
+            {
+                // just ignore, the call pointers returned by 
+                // grpcsharp_test_server_request_call_fake are not real object.
+            };
+            native.GetType().GetField(nameof(native.grpcsharp_call_destroy)).SetValue(native, fakeCallDestroy);
+
+            // create server, the listening port and address is not important as the logic for requesting
+            // calls in short-circuted
+            server = new Server
+            {
+                Services = { },
+                Ports = { { "localhost", ServerPort.PickUnused, ServerCredentials.Insecure } }
+            };
+            var fakeCallHandler = new FakeCallHandler();
+            // method name needs to match to whatever is produced by grpcsharp_test_server_request_call_fake
+            server.AddCallHandlerInternal("/someservice/somemethod", fakeCallHandler);
+
+            server.Start();
+        }
+
+        [GlobalCleanup]
+        public async Task Cleanup()
+        {
+            // drain the requested calls to prevent getting a "pending completions" error at shutdown
+            while (requestedCalls.Count > 0)
+            {
+                var requestedCall = requestedCalls.Pop();
+                var completionCallback = requestedCall.completionRegistry.Extract(requestedCall.tag);
+                
+                // cleanup contents of ctx cleanly by setting callback to NOP
+                // but still running OnComplete
+                var ctx = (RequestCallContextSafeHandle) completionCallback;
+                ctx.CompletionCallback = (success, _) => {};
+                completionCallback.OnComplete(true);
+            }
+            await server.ShutdownAsync();
+        }
+
+        private class FakeCallHandler : IServerCallHandler
+        {
+            public Task HandleCall(ServerRpcNew newRpc, CompletionQueueSafeHandle cq)
+            {
+                // don't do anything, just return synchronously
+                newRpc.Call.Dispose();  // prevent the call objects from accumulating.
+                return Task.CompletedTask;
+            }
+        }
+
+        private struct RequestedCallDetails
+        {
+            public RequestedCallDetails(CompletionRegistry completionRegistry, IntPtr tag)
+            {
+                this.completionRegistry = completionRegistry;
+                this.tag = tag;
+            }
+            public readonly CompletionRegistry completionRegistry;
+            public readonly IntPtr tag;
+        }
+    }
+}

--- a/src/csharp/ext/grpc_csharp_ext.c
+++ b/src/csharp/ext/grpc_csharp_ext.c
@@ -943,6 +943,18 @@ grpcsharp_server_request_call(grpc_server* server, grpc_completion_queue* cq,
                                   &(ctx->request_metadata), cq, cq, ctx);
 }
 
+GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcsharp_test_server_request_call_fake(
+    grpc_server* server, grpc_completion_queue* cq,
+    grpcsharp_request_call_context* ctx) {
+  ctx->call = (grpc_call*)0xdeadbeef;  // fake pointer, tests will need to mock
+                                       // grpcsharp_call_destroy
+  ctx->call_details.method =
+      grpc_slice_from_copied_string("/someservice/somemethod");
+  ctx->call_details.host = grpc_slice_from_copied_string("localhost:1234");
+  ctx->call_details.deadline = gpr_inf_future(GPR_CLOCK_REALTIME);
+  return GRPC_CALL_OK;
+}
+
 /* Native callback dispatcher */
 
 typedef int(GPR_CALLTYPE* grpcsharp_native_callback_dispatcher_func)(

--- a/src/csharp/tests.json
+++ b/src/csharp/tests.json
@@ -4,6 +4,7 @@
     "Grpc.Core.Interceptors.Tests.ServerInterceptorTest",
     "Grpc.Core.Internal.Tests.AsyncCallServerTest",
     "Grpc.Core.Internal.Tests.AsyncCallTest",
+    "Grpc.Core.Internal.Tests.BinaryStringDictionaryTest",
     "Grpc.Core.Internal.Tests.ChannelArgsSafeHandleTest",
     "Grpc.Core.Internal.Tests.CompletionQueueEventTest",
     "Grpc.Core.Internal.Tests.CompletionQueueSafeHandleTest",

--- a/src/csharp/unitypackage/unitypackage_skeleton/Plugins/Grpc.Core/runtimes/grpc_csharp_ext_dummy_stubs.c
+++ b/src/csharp/unitypackage/unitypackage_skeleton/Plugins/Grpc.Core/runtimes/grpc_csharp_ext_dummy_stubs.c
@@ -342,6 +342,10 @@ void grpcsharp_server_request_call() {
   fprintf(stderr, "Should never reach here");
   abort();
 }
+void grpcsharp_test_server_request_call_fake() {
+  fprintf(stderr, "Should never reach here");
+  abort();
+}
 void grpcsharp_server_cancel_all_calls() {
   fprintf(stderr, "Should never reach here");
   abort();

--- a/templates/src/csharp/Grpc.Core/Internal/native_methods.include
+++ b/templates/src/csharp/Grpc.Core/Internal/native_methods.include
@@ -80,6 +80,7 @@ native_method_signatures = [
     'int grpcsharp_server_add_secure_http2_port(ServerSafeHandle server, string addr, ServerCredentialsSafeHandle creds)',
     'void grpcsharp_server_start(ServerSafeHandle server)',
     'CallError grpcsharp_server_request_call(ServerSafeHandle server, CompletionQueueSafeHandle cq, RequestCallContextSafeHandle ctx)',
+    'CallError grpcsharp_test_server_request_call_fake(ServerSafeHandle server, CompletionQueueSafeHandle cq, RequestCallContextSafeHandle ctx)',
     'void grpcsharp_server_cancel_all_calls(ServerSafeHandle server)',
     'void grpcsharp_server_shutdown_and_notify_callback(ServerSafeHandle server, CompletionQueueSafeHandle cq, BatchContextSafeHandle ctx)',
     'void grpcsharp_server_destroy(IntPtr server)',


### PR DESCRIPTION
Still WIP, but most of the implementation is there.

- server maintains a dictionary with binary blob keys and whenever a method of known name is requested, a cached `string` instance with the name is returned.