### PR TITLE
Add 1.21.1 and 1.22.1 of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -142,8 +142,8 @@ LANG_RELEASE_MATRIX = {
             ('v1.19.0',
              ReleaseInfo(runtimes=['go1.11'], testcases_file='go__v1.0.5')),
             ('v1.20.0', ReleaseInfo(runtimes=['go1.11'])),
-            ('v1.21.0', ReleaseInfo(runtimes=['go1.11'])),
-            ('v1.22.0', ReleaseInfo(runtimes=['go1.11'])),
+            ('v1.21.2', ReleaseInfo(runtimes=['go1.11'])),
+            ('v1.22.1', ReleaseInfo(runtimes=['go1.11'])),
         ]),
     'java':
     OrderedDict([


### PR DESCRIPTION
```
$ gcloud beta container images list-tags gcr.io/grpc-testing/grpc_interop_go1.11
DIGEST        TAGS     TIMESTAMP            VULNERABILITIES                        FROM                             VULNERABILITY_SCAN_STATUS
f7c303347c2d  v1.22.1  2019-07-25T10:51:25  CRITICAL=2,HIGH=18,LOW=15,MEDIUM=113   us-mirror.gcr.io/library/debian  FINISHED_SUCCESS
3f1cc250de00  v1.21.2  2019-07-25T10:46:51  CRITICAL=2,HIGH=18,LOW=15,MEDIUM=113   us-mirror.gcr.io/library/debian  PENDING
b7a3dcc12671  v1.22.0  2019-07-02T14:14:58  CRITICAL=10,HIGH=56,LOW=49,MEDIUM=307  us-mirror.gcr.io/library/golang  FINISHED_SUCCESS
484f32770c98  v1.21.0  2019-05-22T10:44:36  CRITICAL=7,HIGH=41,LOW=35,MEDIUM=267   us-mirror.gcr.io/library/golang  FINISHED_SUCCESS
63449136dc73  v1.20.0  2019-04-09T14:41:00  CRITICAL=10,HIGH=56,LOW=49,MEDIUM=307  us-mirror.gcr.io/library/golang  FINISHED_SUCCESS
0942a3770da4  v1.19.0  2019-02-26T11:16:30  CRITICAL=9,HIGH=56,LOW=47,MEDIUM=305   us-mirror.gcr.io/library/golang  PENDING
40b538616579  v1.18.0  2019-01-15T16:34:39  CRITICAL=10,HIGH=56,LOW=49,MEDIUM=307  us-mirror.gcr.io/library/golang  PENDING
a162f049dd62  v1.17.0  2019-01-07T08:51:13  CRITICAL=10,HIGH=59,LOW=50,MEDIUM=312  us-mirror.gcr.io/library/golang  FINISHED_SUCCESS
```