### PR TITLE
PHP: modify php unit test script to allow skipping certain tests

### DIFF
--- a/src/php/bin/run_tests.sh
+++ b/src/php/bin/run_tests.sh
@@ -25,8 +25,18 @@ export DYLD_LIBRARY_PATH=$root/libs/$CONFIG
 $(which php) $extension_dir -d max_execution_time=300 $(which phpunit) -v --debug \
   --exclude-group persistent_list_bound_tests ../tests/unit_tests
 
-$(which php) $extension_dir -d max_execution_time=300 $(which phpunit) -v --debug \
-  ../tests/unit_tests/PersistentChannelTests
+for arg in "$@"
+do
+  if [[ "$arg" == "--skip-persistent-channel-tests" ]]; then
+    SKIP_PERSISTENT_CHANNEL_TESTS=true
+    break
+  fi
+done
+
+if [[ "$SKIP_PERSISTENT_CHANNEL_TESTS" != "true" ]]; then
+   $(which php) $extension_dir -d max_execution_time=300 $(which phpunit) -v --debug \
+     ../tests/unit_tests/PersistentChannelTests
+fi
 
 export ZEND_DONT_UNLOAD_MODULES=1
 export USE_ZEND_ALLOC=0


### PR DESCRIPTION
Add if statement around PersistentChannelTests. Run the tests by default. Use command "./run_tests.sh --skip-persistent-channel-tests" to not run the tests.