### PR TITLE
catch the error if socket initialization fails

### DIFF
--- a/src/core/lib/iomgr/tcp_server_custom.cc
+++ b/src/core/lib/iomgr/tcp_server_custom.cc
@@ -391,7 +391,7 @@ static grpc_error* tcp_server_add_port(grpc_tcp_server* s,
   socket->endpoint = nullptr;
   socket->listener = nullptr;
   socket->connector = nullptr;
-  grpc_custom_socket_vtable->init(socket, family);
+  error = grpc_custom_socket_vtable->init(socket, family);
 
   if (error == GRPC_ERROR_NONE) {
     error = add_socket_to_server(s, socket, addr, port_index, &sp);


### PR DESCRIPTION
The error returned from `grpc_custom_socket_vtable->init(socket, family);` was ignored, causing the program to crash if the socket couldn't be initialized.