### PR TITLE
Expose experimental control plane creds core API in C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12864,6 +12864,7 @@ target_include_directories(credentials_test
 target_link_libraries(credentials_test
   ${_gRPC_PROTOBUF_LIBRARIES}
   ${_gRPC_ALLTARGETS_LIBRARIES}
+  grpc_test_util
   grpc++
   grpc
   gpr

--- a/Makefile
+++ b/Makefile
@@ -15848,16 +15848,16 @@ $(BINDIR)/$(CONFIG)/credentials_test: protobuf_dep_error
 
 else
 
-$(BINDIR)/$(CONFIG)/credentials_test: $(PROTOBUF_DEP) $(CREDENTIALS_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a
+$(BINDIR)/$(CONFIG)/credentials_test: $(PROTOBUF_DEP) $(CREDENTIALS_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a
 	$(E) "[LD]      Linking $@"
 	$(Q) mkdir -p `dirname $@`
-	$(Q) $(LDXX) $(LDFLAGS) $(CREDENTIALS_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) $(LDLIBS_SECURE) $(GTEST_LIB) -o $(BINDIR)/$(CONFIG)/credentials_test
+	$(Q) $(LDXX) $(LDFLAGS) $(CREDENTIALS_TEST_OBJS) $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a $(LDLIBSXX) $(LDLIBS_PROTOBUF) $(LDLIBS) $(LDLIBS_SECURE) $(GTEST_LIB) -o $(BINDIR)/$(CONFIG)/credentials_test
 
 endif
 
 endif
 
-$(OBJDIR)/$(CONFIG)/test/cpp/client/credentials_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a
+$(OBJDIR)/$(CONFIG)/test/cpp/client/credentials_test.o:  $(LIBDIR)/$(CONFIG)/libgrpc_test_util.a $(LIBDIR)/$(CONFIG)/libgrpc++.a $(LIBDIR)/$(CONFIG)/libgrpc.a $(LIBDIR)/$(CONFIG)/libgpr.a
 
 deps_credentials_test: $(CREDENTIALS_TEST_OBJS:.o=.dep)
 

--- a/build.yaml
+++ b/build.yaml
@@ -4746,6 +4746,7 @@ targets:
   src:
   - test/cpp/client/credentials_test.cc
   deps:
+  - grpc_test_util
   - grpc++
   - grpc
   - gpr

--- a/include/grpcpp/security/credentials.h
+++ b/include/grpcpp/security/credentials.h
@@ -134,14 +134,14 @@ static inline std::shared_ptr<grpc_impl::ChannelCredentials> LocalCredentials(
 
 static inline bool AttachControlPlaneChannelCredentials(
     ChannelCredentials* credentials, const grpc::string_ref& authority,
-    std::shared_ptr<ChannelCredentials> control_plane_creds) {
+    const std::shared_ptr<ChannelCredentials>& control_plane_creds) {
   return ::grpc_impl::experimental::AttachControlPlaneChannelCredentials(
       credentials, authority, control_plane_creds);
 }
 
 static inline bool RegisterControlPlaneChannelCreds(
     const grpc::string_ref& authority,
-    std::shared_ptr<ChannelCredentials> control_plane_creds) {
+    const std::shared_ptr<ChannelCredentials>& control_plane_creds) {
   return ::grpc_impl::experimental::RegisterControlPlaneChannelCreds(
       authority, control_plane_creds);
 }

--- a/include/grpcpp/security/credentials.h
+++ b/include/grpcpp/security/credentials.h
@@ -133,14 +133,14 @@ static inline std::shared_ptr<grpc_impl::ChannelCredentials> LocalCredentials(
 }
 
 static inline bool AttachControlPlaneChannelCredentials(
-    ChannelCredentials* credentials, grpc::string_ref authority,
+    ChannelCredentials* credentials, const grpc::string_ref& authority,
     std::shared_ptr<ChannelCredentials> control_plane_creds) {
   return ::grpc_impl::experimental::AttachControlPlaneChannelCredentials(
       credentials, authority, control_plane_creds);
 }
 
 static inline bool RegisterControlPlaneChannelCreds(
-    grpc::string_ref authority,
+    const grpc::string_ref& authority,
     std::shared_ptr<ChannelCredentials> control_plane_creds) {
   return ::grpc_impl::experimental::RegisterControlPlaneChannelCreds(
       authority, control_plane_creds);

--- a/include/grpcpp/security/credentials.h
+++ b/include/grpcpp/security/credentials.h
@@ -132,6 +132,20 @@ static inline std::shared_ptr<grpc_impl::ChannelCredentials> LocalCredentials(
   return ::grpc_impl::experimental::LocalCredentials(type);
 }
 
+static inline bool AttachControlPlaneChannelCredentials(
+    ChannelCredentials* credentials, grpc::string_ref authority,
+    std::shared_ptr<ChannelCredentials> control_plane_creds) {
+  return ::grpc_impl::experimental::AttachControlPlaneChannelCredentials(
+      credentials, authority, control_plane_creds);
+}
+
+static inline bool RegisterControlPlaneChannelCreds(
+    grpc::string_ref authority,
+    std::shared_ptr<ChannelCredentials> control_plane_creds) {
+  return ::grpc_impl::experimental::RegisterControlPlaneChannelCreds(
+      authority, control_plane_creds);
+}
+
 }  // namespace experimental
 }  // namespace grpc
 

--- a/include/grpcpp/security/credentials_impl.h
+++ b/include/grpcpp/security/credentials_impl.h
@@ -63,7 +63,7 @@ std::shared_ptr<Channel> CreateCustomChannelWithInterceptors(
 // class.
 bool AttachControlPlaneChannelCredentials(
     ChannelCredentials* credentials, const grpc::string_ref& authority,
-    std::shared_ptr<ChannelCredentials> control_plane_creds);
+    const std::shared_ptr<ChannelCredentials>& control_plane_creds);
 
 /// Registers \a control_plane_creds in the global map
 /// under the key \a authority.  Returns false if \a authority
@@ -72,7 +72,7 @@ bool AttachControlPlaneChannelCredentials(
 // out of the experimental namespace.
 bool RegisterControlPlaneChannelCreds(
     const grpc::string_ref& authority,
-    std::shared_ptr<ChannelCredentials> control_plane_creds);
+    const std::shared_ptr<ChannelCredentials>& control_plane_creds);
 }  // namespace experimental
 
 /// A channel credentials object encapsulates all the state needed by a client
@@ -93,11 +93,11 @@ class ChannelCredentials : private grpc::GrpcLibraryCodegen {
 
   friend bool grpc_impl::experimental::AttachControlPlaneChannelCredentials(
       ChannelCredentials* credentials, const grpc::string_ref& authority,
-      std::shared_ptr<ChannelCredentials> control_plane_creds);
+      const std::shared_ptr<ChannelCredentials>& control_plane_creds);
 
   friend bool grpc_impl::experimental::RegisterControlPlaneChannelCreds(
       const grpc::string_ref& authority,
-      std::shared_ptr<ChannelCredentials> control_plane_creds);
+      const std::shared_ptr<ChannelCredentials>& control_plane_creds);
 
   virtual SecureChannelCredentials* AsSecureCredentials() = 0;
 

--- a/include/grpcpp/security/credentials_impl.h
+++ b/include/grpcpp/security/credentials_impl.h
@@ -62,7 +62,7 @@ std::shared_ptr<Channel> CreateCustomChannelWithInterceptors(
 // standalone function with a new method on the ChannelCredentials
 // class.
 bool AttachControlPlaneChannelCredentials(
-    ChannelCredentials* credentials, grpc::string_ref authority,
+    ChannelCredentials* credentials, const grpc::string_ref& authority,
     std::shared_ptr<ChannelCredentials> control_plane_creds);
 
 /// Registers \a control_plane_creds in the global map
@@ -71,7 +71,7 @@ bool AttachControlPlaneChannelCredentials(
 // TODO: Once this functionality is deemed mature, move this
 // out of the experimental namespace.
 bool RegisterControlPlaneChannelCreds(
-    grpc::string_ref authority,
+    const grpc::string_ref& authority,
     std::shared_ptr<ChannelCredentials> control_plane_creds);
 }  // namespace experimental
 
@@ -92,11 +92,11 @@ class ChannelCredentials : private grpc::GrpcLibraryCodegen {
       const std::shared_ptr<CallCredentials>& call_creds);
 
   friend bool grpc_impl::experimental::AttachControlPlaneChannelCredentials(
-      ChannelCredentials* credentials, grpc::string_ref authority,
+      ChannelCredentials* credentials, const grpc::string_ref& authority,
       std::shared_ptr<ChannelCredentials> control_plane_creds);
 
   friend bool grpc_impl::experimental::RegisterControlPlaneChannelCreds(
-      grpc::string_ref authority,
+      const grpc::string_ref& authority,
       std::shared_ptr<ChannelCredentials> control_plane_creds);
 
   virtual SecureChannelCredentials* AsSecureCredentials() = 0;

--- a/include/grpcpp/security/credentials_impl.h
+++ b/include/grpcpp/security/credentials_impl.h
@@ -54,7 +54,26 @@ std::shared_ptr<Channel> CreateCustomChannelWithInterceptors(
     std::vector<
         std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>>
         interceptor_creators);
-}
+
+/// Attaches \a control_plane_creds to \a credentials
+/// under the key \a authority.  Returns false if \a authority
+/// is already present, in which case no changes are made.
+// TODO: Once this functionality is deemed mature, replace this
+// standalone function with a new method on the ChannelCredentials
+// class.
+bool AttachControlPlaneChannelCredentials(
+    ChannelCredentials* credentials, grpc::string_ref authority,
+    std::shared_ptr<ChannelCredentials> control_plane_creds);
+
+/// Registers \a control_plane_creds in the global map
+/// under the key \a authority.  Returns false if \a authority
+/// is already present, in which case no changes are made.
+// TODO: Once this functionality is deemed mature, move this
+// out of the experimental namespace.
+bool RegisterControlPlaneChannelCreds(
+    grpc::string_ref authority,
+    std::shared_ptr<ChannelCredentials> control_plane_creds);
+}  // namespace experimental
 
 /// A channel credentials object encapsulates all the state needed by a client
 /// to authenticate with a server for a given channel.
@@ -71,6 +90,14 @@ class ChannelCredentials : private grpc::GrpcLibraryCodegen {
   friend std::shared_ptr<ChannelCredentials> CompositeChannelCredentials(
       const std::shared_ptr<ChannelCredentials>& channel_creds,
       const std::shared_ptr<CallCredentials>& call_creds);
+
+  friend bool grpc_impl::experimental::AttachControlPlaneChannelCredentials(
+      ChannelCredentials* credentials, grpc::string_ref authority,
+      std::shared_ptr<ChannelCredentials> control_plane_creds);
+
+  friend bool grpc_impl::experimental::RegisterControlPlaneChannelCreds(
+      grpc::string_ref authority,
+      std::shared_ptr<ChannelCredentials> control_plane_creds);
 
   virtual SecureChannelCredentials* AsSecureCredentials() = 0;
 

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -282,7 +282,7 @@ std::shared_ptr<ChannelCredentials> LocalCredentials(
 
 bool AttachControlPlaneChannelCredentials(
     ChannelCredentials* credentials, const grpc::string_ref& authority,
-    std::shared_ptr<ChannelCredentials> control_plane_creds) {
+    const std::shared_ptr<ChannelCredentials>& control_plane_creds) {
   grpc::GrpcLibraryCodegen init;  // To call grpc_init().
   if (credentials == nullptr || control_plane_creds == nullptr) {
     return false;
@@ -304,7 +304,7 @@ bool AttachControlPlaneChannelCredentials(
 
 bool RegisterControlPlaneChannelCreds(
     const grpc::string_ref& authority,
-    std::shared_ptr<ChannelCredentials> control_plane_creds) {
+    const std::shared_ptr<ChannelCredentials>& control_plane_creds) {
   grpc::GrpcLibraryCodegen init;  // To call grpc_init().
   if (control_plane_creds == nullptr) {
     return false;

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -281,7 +281,7 @@ std::shared_ptr<ChannelCredentials> LocalCredentials(
 }
 
 bool AttachControlPlaneChannelCredentials(
-    ChannelCredentials* credentials, grpc::string_ref authority,
+    ChannelCredentials* credentials, const grpc::string_ref& authority,
     std::shared_ptr<ChannelCredentials> control_plane_creds) {
   grpc::GrpcLibraryCodegen init;  // To call grpc_init().
   if (credentials == nullptr || control_plane_creds == nullptr) {
@@ -303,7 +303,7 @@ bool AttachControlPlaneChannelCredentials(
 }
 
 bool RegisterControlPlaneChannelCreds(
-    grpc::string_ref authority,
+    const grpc::string_ref& authority,
     std::shared_ptr<ChannelCredentials> control_plane_creds) {
   grpc::GrpcLibraryCodegen init;  // To call grpc_init().
   if (control_plane_creds == nullptr) {

--- a/test/cpp/client/BUILD
+++ b/test/cpp/client/BUILD
@@ -29,6 +29,7 @@ grpc_cc_test(
         "//:grpc",
         "//:grpc++",
         "//test/core/util:grpc_test_util",
+        "//test/core/end2end:ssl_test_data",
     ],
 )
 

--- a/tools/run_tests/generated/sources_and_headers.json
+++ b/tools/run_tests/generated/sources_and_headers.json
@@ -3587,7 +3587,8 @@
     "deps": [
       "gpr", 
       "grpc", 
-      "grpc++"
+      "grpc++", 
+      "grpc_test_util"
     ], 
     "headers": [], 
     "is_filegroup": false, 


### PR DESCRIPTION
This exposes the experimental C-core `grpc_channel_credentials_attach_credentials` and `grpc_control_plane_credentials_register` APIs in C++. These APIs were added to core in  https://github.com/grpc/grpc/pull/19693.

This is mostly a pass-through wrapping of those APIs, but one noteworthy caveat that I realized when doing is is that there are at least some types of C++ `ChannelCredentials` which don't correspond to a C-core `grpc_channel_credentials`, and so we aren't able to directly use these types of `ChannelCredentials` in the control plane creds APIs. The most noteworthy example is probably `InsecureCredentials`. I'm not sure how desirable it is to support e.g. `InsecureCredentials` in the control plane creds APIs - if we were to support that, it would probably need some larger refactoring, or be handled as a one-off case.

This PR lives with that restriction by logging an error and unconditionally returning false in the case that we are using any `ChannelCredentials` for which `AsSecureCredentials` returns `nullptr`, as input to either of the control plane creds APIs.