### PR TITLE
Add a detection of missing file in filegroup.uses

### DIFF
--- a/tools/buildgen/plugins/expand_filegroups.py
+++ b/tools/buildgen/plugins/expand_filegroups.py
@@ -55,6 +55,7 @@ def mako_plugin(dictionary):
     libs = dictionary.get('libs')
     targets = dictionary.get('targets')
     filegroups_list = dictionary.get('filegroups')
+    filegroups_set = set(fg['name'] for fg in filegroups_list)
     filegroups = {}
 
     for fg in filegroups_list:
@@ -78,8 +79,10 @@ def mako_plugin(dictionary):
         todo = todo[1:]
         # check all uses filegroups are present (if no, skip and come back later)
         skip = False
-        for uses in cur.get('uses', []):
-            if uses not in filegroups:
+        for use in cur.get('uses', []):
+            assert use in filegroups_set, (
+                "filegroup(%s) uses non-existent %s" % (cur['name'], use))
+            if use not in filegroups:
                 skip = True
         if skip:
             skips += 1


### PR DESCRIPTION
When generating project files from build.yaml and there is a non-existent target in file-groups.uses, it was throwing an error saying "there is a infinite loop", which can be misleading. To address this, a detection code is added to verify its target actually exists in filegroups.