### PR TITLE
Add human-readable names for channelz sockets and listen sockets

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel_channelz.cc
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.cc
@@ -32,7 +32,8 @@ namespace channelz {
 
 SubchannelNode::SubchannelNode(const char* target_address,
                                size_t channel_tracer_max_nodes)
-    : BaseNode(EntityType::kSubchannel),
+    : BaseNode(EntityType::kSubchannel,
+               UniquePtr<char>(gpr_strdup(target_address))),
       target_(UniquePtr<char>(gpr_strdup(target_address))),
       trace_(channel_tracer_max_nodes) {}
 
@@ -42,8 +43,9 @@ void SubchannelNode::UpdateConnectivityState(grpc_connectivity_state state) {
   connectivity_state_.Store(state, MemoryOrder::RELAXED);
 }
 
-void SubchannelNode::SetChildSocketUuid(intptr_t uuid) {
-  child_socket_uuid_.Store(uuid, MemoryOrder::RELAXED);
+void SubchannelNode::SetChildSocket(RefCountedPtr<SocketNode> socket) {
+  MutexLock lock(&socket_mu_);
+  child_socket_ = std::move(socket);
 }
 
 void SubchannelNode::PopulateConnectivityState(grpc_json* json) {
@@ -88,14 +90,20 @@ grpc_json* SubchannelNode::RenderJson() {
   call_counter_.PopulateCallCounts(json);
   json = top_level_json;
   // populate the child socket.
-  intptr_t socket_uuid = child_socket_uuid_.Load(MemoryOrder::RELAXED);
-  if (socket_uuid != 0) {
+  RefCountedPtr<SocketNode> child_socket;
+  {
+    MutexLock lock(&socket_mu_);
+    child_socket = child_socket_;
+  }
+  if (child_socket != nullptr && child_socket->uuid() != 0) {
     grpc_json* array_parent = grpc_json_create_child(
         nullptr, json, "socketRef", nullptr, GRPC_JSON_ARRAY, false);
     json_iterator = grpc_json_create_child(json_iterator, array_parent, nullptr,
                                            nullptr, GRPC_JSON_OBJECT, false);
-    grpc_json_add_number_string_child(json_iterator, nullptr, "socketId",
-                                      socket_uuid);
+    grpc_json* sibling_iterator = grpc_json_add_number_string_child(
+        json_iterator, nullptr, "socketId", child_socket->uuid());
+    grpc_json_create_child(sibling_iterator, json_iterator, "name",
+                           child_socket->name(), GRPC_JSON_STRING, false);
   }
   return top_level_json;
 }

--- a/src/core/ext/filters/client_channel/client_channel_channelz.h
+++ b/src/core/ext/filters/client_channel/client_channel_channelz.h
@@ -40,11 +40,10 @@ class SubchannelNode : public BaseNode {
   // Sets the subchannel's connectivity state without health checking.
   void UpdateConnectivityState(grpc_connectivity_state state);
 
-  // Used when the subchannel's child socket uuid changes. This should be set
-  // when the subchannel's transport is created and set to 0 when the subchannel
-  // unrefs the transport. A uuid of 0 indicates that the child socket is no
-  // longer associated with this subchannel.
-  void SetChildSocketUuid(intptr_t uuid);
+  // Used when the subchannel's child socket changes. This should be set when
+  // the subchannel's transport is created and set to nullptr when the
+  // subchannel unrefs the transport.
+  void SetChildSocket(RefCountedPtr<SocketNode> socket);
 
   grpc_json* RenderJson() override;
 
@@ -66,7 +65,8 @@ class SubchannelNode : public BaseNode {
   void PopulateConnectivityState(grpc_json* json);
 
   Atomic<grpc_connectivity_state> connectivity_state_{GRPC_CHANNEL_IDLE};
-  Atomic<intptr_t> child_socket_uuid_{0};
+  Mutex socket_mu_;
+  RefCountedPtr<SocketNode> child_socket_;
   UniquePtr<char> target_;
   CallCountingHelper call_counter_;
   ChannelTrace trace_;

--- a/src/core/ext/filters/client_channel/connector.h
+++ b/src/core/ext/filters/client_channel/connector.h
@@ -22,6 +22,7 @@
 #include <grpc/support/port_platform.h>
 
 #include "src/core/lib/channel/channel_stack.h"
+#include "src/core/lib/channel/channelz.h"
 #include "src/core/lib/iomgr/resolve_address.h"
 #include "src/core/lib/transport/transport.h"
 
@@ -48,8 +49,15 @@ typedef struct {
   /** channel arguments (to be passed to the filters) */
   grpc_channel_args* channel_args;
 
-  /** socket uuid of the connected transport. 0 if not available */
-  intptr_t socket_uuid;
+  /** channelz socket node of the connected transport. nullptr if not available
+   */
+  grpc_core::RefCountedPtr<grpc_core::channelz::SocketNode> socket;
+
+  void reset() {
+    transport = nullptr;
+    channel_args = nullptr;
+    socket = nullptr;
+  }
 } grpc_connect_out_args;
 
 struct grpc_connector_vtable {

--- a/src/core/ext/transport/chttp2/client/chttp2_connector.cc
+++ b/src/core/ext/transport/chttp2/client/chttp2_connector.cc
@@ -111,15 +111,14 @@ static void on_handshake_done(void* arg, grpc_error* error) {
     } else {
       error = GRPC_ERROR_REF(error);
     }
-    memset(c->result, 0, sizeof(*c->result));
+    c->result->reset();
   } else {
     grpc_endpoint_delete_from_pollset_set(args->endpoint,
                                           c->args.interested_parties);
     c->result->transport =
         grpc_create_chttp2_transport(args->args, args->endpoint, true);
-    grpc_core::RefCountedPtr<grpc_core::channelz::SocketNode> socket_node =
+    c->result->socket =
         grpc_chttp2_transport_get_socket_node(c->result->transport);
-    c->result->socket_uuid = socket_node == nullptr ? 0 : socket_node->uuid();
     GPR_ASSERT(c->result->transport);
     // TODO(roth): We ideally want to wait until we receive HTTP/2
     // settings from the server before we consider the connection
@@ -180,7 +179,7 @@ static void connected(void* arg, grpc_error* error) {
     } else {
       error = GRPC_ERROR_REF(error);
     }
-    memset(c->result, 0, sizeof(*c->result));
+    c->result->reset();
     grpc_closure* notify = c->notify;
     c->notify = nullptr;
     GRPC_CLOSURE_SCHED(notify, error);

--- a/src/core/ext/transport/chttp2/server/chttp2_server.cc
+++ b/src/core/ext/transport/chttp2/server/chttp2_server.cc
@@ -317,7 +317,7 @@ static grpc_error* chttp2_server_add_acceptor(grpc_server* server,
   *arg_val = grpc_tcp_server_create_fd_handler(tcp_server);
 
   grpc_server_add_listener(server, state, server_start_listener,
-                           server_destroy_listener, /* socket_uuid */ 0);
+                           server_destroy_listener, /* node */ nullptr);
   return err;
 
 /* Error path: cleanup and return */
@@ -345,7 +345,6 @@ grpc_error* grpc_chttp2_server_add_port(grpc_server* server, const char* addr,
   grpc_error** errors = nullptr;
   size_t naddrs = 0;
   const grpc_arg* arg = nullptr;
-  intptr_t socket_uuid = 0;
 
   *port_num = -1;
 
@@ -413,15 +412,18 @@ grpc_error* grpc_chttp2_server_add_port(grpc_server* server, const char* addr,
 
   arg = grpc_channel_args_find(args, GRPC_ARG_ENABLE_CHANNELZ);
   if (grpc_channel_arg_get_bool(arg, GRPC_ENABLE_CHANNELZ_DEFAULT)) {
+    char* socket_name = nullptr;
+    gpr_asprintf(&socket_name, "chttp2 listener %s", addr);
     state->channelz_listen_socket =
         grpc_core::MakeRefCounted<grpc_core::channelz::ListenSocketNode>(
-            grpc_core::UniquePtr<char>(gpr_strdup(addr)));
-    socket_uuid = state->channelz_listen_socket->uuid();
+            grpc_core::UniquePtr<char>(gpr_strdup(addr)),
+            grpc_core::UniquePtr<char>(socket_name));
   }
 
   /* Register with the server only upon success */
   grpc_server_add_listener(server, state, server_start_listener,
-                           server_destroy_listener, socket_uuid);
+                           server_destroy_listener,
+                           state->channelz_listen_socket);
   goto done;
 
 /* Error path: cleanup and return */

--- a/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
+++ b/src/core/ext/transport/chttp2/transport/chttp2_transport.cc
@@ -378,10 +378,13 @@ static bool read_channel_args(grpc_chttp2_transport* t,
   if (channelz_enabled) {
     // TODO(ncteisen): add an API to endpoint to query for local addr, and pass
     // it in here, so SocketNode knows its own address.
+    char* socket_name = nullptr;
+    gpr_asprintf(&socket_name, "%s %s", get_vtable()->name, t->peer_string);
     t->channelz_socket =
         grpc_core::MakeRefCounted<grpc_core::channelz::SocketNode>(
             grpc_core::UniquePtr<char>(),
-            grpc_core::UniquePtr<char>(gpr_strdup(t->peer_string)));
+            grpc_core::UniquePtr<char>(gpr_strdup(t->peer_string)),
+            grpc_core::UniquePtr<char>(socket_name));
   }
   return enable_bdp;
 }

--- a/src/core/lib/channel/channelz.cc
+++ b/src/core/lib/channel/channelz.cc
@@ -85,7 +85,8 @@ intptr_t GetParentUuidFromArgs(const grpc_channel_args& args) {
 // BaseNode
 //
 
-BaseNode::BaseNode(EntityType type) : type_(type), uuid_(-1) {
+BaseNode::BaseNode(EntityType type, UniquePtr<char> name)
+    : type_(type), uuid_(-1), name_(std::move(name)) {
   // The registry will set uuid_ under its lock.
   ChannelzRegistry::Register(this);
 }
@@ -187,7 +188,8 @@ void CallCountingHelper::PopulateCallCounts(grpc_json* json) {
 ChannelNode::ChannelNode(UniquePtr<char> target,
                          size_t channel_tracer_max_nodes, intptr_t parent_uuid)
     : BaseNode(parent_uuid == 0 ? EntityType::kTopLevelChannel
-                                : EntityType::kInternalChannel),
+                                : EntityType::kInternalChannel,
+               UniquePtr<char>(gpr_strdup(target.get()))),
       target_(std::move(target)),
       trace_(channel_tracer_max_nodes),
       parent_uuid_(parent_uuid) {}
@@ -320,7 +322,8 @@ void ChannelNode::RemoveChildSubchannel(intptr_t child_uuid) {
 //
 
 ServerNode::ServerNode(grpc_server* server, size_t channel_tracer_max_nodes)
-    : BaseNode(EntityType::kServer), trace_(channel_tracer_max_nodes) {}
+    : BaseNode(EntityType::kServer, /* name */ nullptr),
+      trace_(channel_tracer_max_nodes) {}
 
 ServerNode::~ServerNode() {}
 
@@ -334,9 +337,9 @@ void ServerNode::RemoveChildSocket(intptr_t child_uuid) {
   child_sockets_.erase(child_uuid);
 }
 
-void ServerNode::AddChildListenSocket(intptr_t child_uuid) {
+void ServerNode::AddChildListenSocket(RefCountedPtr<ListenSocketNode> node) {
   MutexLock lock(&child_mu_);
-  child_listen_sockets_.insert(MakePair(child_uuid, true));
+  child_listen_sockets_.insert(MakePair(node->uuid(), std::move(node)));
 }
 
 void ServerNode::RemoveChildListenSocket(intptr_t child_uuid) {
@@ -366,7 +369,7 @@ char* ServerNode::RenderServerSockets(intptr_t start_socket_id,
       json_iterator = grpc_json_add_number_string_child(
           socket_ref_json, nullptr, "socketId", it->first);
       grpc_json_create_child(json_iterator, socket_ref_json, "name",
-                             it->second->remote(), GRPC_JSON_STRING, false);
+                             it->second->name(), GRPC_JSON_STRING, false);
     }
   }
   if (sockets_rendered == child_sockets_.size()) {
@@ -416,8 +419,10 @@ grpc_json* ServerNode::RenderJson() {
       json_iterator =
           grpc_json_create_child(json_iterator, array_parent, nullptr, nullptr,
                                  GRPC_JSON_OBJECT, false);
-      grpc_json_add_number_string_child(json_iterator, nullptr, "socketId",
-                                        it.first);
+      grpc_json* sibling_iterator = grpc_json_add_number_string_child(
+          json_iterator, nullptr, "socketId", it.first);
+      grpc_json_create_child(sibling_iterator, json_iterator, "name",
+                             it.second->name(), GRPC_JSON_STRING, false);
     }
   }
   return top_level_json;
@@ -480,8 +485,9 @@ void PopulateSocketAddressJson(grpc_json* json, const char* name,
 
 }  // namespace
 
-SocketNode::SocketNode(UniquePtr<char> local, UniquePtr<char> remote)
-    : BaseNode(EntityType::kSocket),
+SocketNode::SocketNode(UniquePtr<char> local, UniquePtr<char> remote,
+                       UniquePtr<char> name)
+    : BaseNode(EntityType::kSocket, std::move(name)),
       local_(std::move(local)),
       remote_(std::move(remote)) {}
 
@@ -521,6 +527,8 @@ grpc_json* SocketNode::RenderJson() {
   json_iterator = nullptr;
   json_iterator = grpc_json_add_number_string_child(json, json_iterator,
                                                     "socketId", uuid());
+  json_iterator = grpc_json_create_child(json_iterator, json, "name", name(),
+                                         GRPC_JSON_STRING, false);
   json = top_level_json;
   PopulateSocketAddressJson(json, "remote", remote_.get());
   PopulateSocketAddressJson(json, "local", local_.get());
@@ -600,8 +608,10 @@ grpc_json* SocketNode::RenderJson() {
 // ListenSocketNode
 //
 
-ListenSocketNode::ListenSocketNode(UniquePtr<char> local_addr)
-    : BaseNode(EntityType::kSocket), local_addr_(std::move(local_addr)) {}
+ListenSocketNode::ListenSocketNode(UniquePtr<char> local_addr,
+                                   UniquePtr<char> name)
+    : BaseNode(EntityType::kSocket, std::move(name)),
+      local_addr_(std::move(local_addr)) {}
 
 grpc_json* ListenSocketNode::RenderJson() {
   // We need to track these three json objects to build our object
@@ -615,6 +625,8 @@ grpc_json* ListenSocketNode::RenderJson() {
   json_iterator = nullptr;
   json_iterator = grpc_json_add_number_string_child(json, json_iterator,
                                                     "socketId", uuid());
+  json_iterator = grpc_json_create_child(json_iterator, json, "name", name(),
+                                         GRPC_JSON_STRING, false);
   json = top_level_json;
   PopulateSocketAddressJson(json, "local", local_addr_.get());
 

--- a/src/core/lib/surface/server.h
+++ b/src/core/lib/surface/server.h
@@ -34,13 +34,12 @@ extern grpc_core::TraceFlag grpc_server_channel_trace;
 
 /* Add a listener to the server: when the server starts, it will call start,
    and when it shuts down, it will call destroy */
-void grpc_server_add_listener(grpc_server* server, void* listener,
-                              void (*start)(grpc_server* server, void* arg,
-                                            grpc_pollset** pollsets,
-                                            size_t npollsets),
-                              void (*destroy)(grpc_server* server, void* arg,
-                                              grpc_closure* on_done),
-                              intptr_t socket_uuid);
+void grpc_server_add_listener(
+    grpc_server* server, void* listener_arg,
+    void (*start)(grpc_server* server, void* arg, grpc_pollset** pollsets,
+                  size_t npollsets),
+    void (*destroy)(grpc_server* server, void* arg, grpc_closure* on_done),
+    grpc_core::RefCountedPtr<grpc_core::channelz::ListenSocketNode> node);
 
 /* Setup a transport - creates a channel stack, binds the transport to the
    server */

--- a/test/core/channel/channelz_registry_test.cc
+++ b/test/core/channel/channelz_registry_test.cc
@@ -53,7 +53,7 @@ class ChannelzRegistryTest : public ::testing::Test {
 
 TEST_F(ChannelzRegistryTest, UuidStartsAboveZeroTest) {
   RefCountedPtr<BaseNode> channelz_channel =
-      MakeRefCounted<BaseNode>(BaseNode::EntityType::kTopLevelChannel);
+      MakeRefCounted<BaseNode>(BaseNode::EntityType::kTopLevelChannel, nullptr);
   intptr_t uuid = channelz_channel->uuid();
   EXPECT_GT(uuid, 0) << "First uuid chose must be greater than zero. Zero if "
                         "reserved according to "
@@ -65,8 +65,8 @@ TEST_F(ChannelzRegistryTest, UuidsAreIncreasing) {
   std::vector<RefCountedPtr<BaseNode>> channelz_channels;
   channelz_channels.reserve(10);
   for (int i = 0; i < 10; ++i) {
-    channelz_channels.push_back(
-        MakeRefCounted<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
+    channelz_channels.push_back(MakeRefCounted<BaseNode>(
+        BaseNode::EntityType::kTopLevelChannel, nullptr));
   }
   for (size_t i = 1; i < channelz_channels.size(); ++i) {
     EXPECT_LT(channelz_channels[i - 1]->uuid(), channelz_channels[i]->uuid())
@@ -76,7 +76,7 @@ TEST_F(ChannelzRegistryTest, UuidsAreIncreasing) {
 
 TEST_F(ChannelzRegistryTest, RegisterGetTest) {
   RefCountedPtr<BaseNode> channelz_channel =
-      MakeRefCounted<BaseNode>(BaseNode::EntityType::kTopLevelChannel);
+      MakeRefCounted<BaseNode>(BaseNode::EntityType::kTopLevelChannel, nullptr);
   RefCountedPtr<BaseNode> retrieved =
       ChannelzRegistry::Get(channelz_channel->uuid());
   EXPECT_EQ(channelz_channel, retrieved);
@@ -85,8 +85,8 @@ TEST_F(ChannelzRegistryTest, RegisterGetTest) {
 TEST_F(ChannelzRegistryTest, RegisterManyItems) {
   std::vector<RefCountedPtr<BaseNode>> channelz_channels;
   for (int i = 0; i < 100; i++) {
-    channelz_channels.push_back(
-        MakeRefCounted<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
+    channelz_channels.push_back(MakeRefCounted<BaseNode>(
+        BaseNode::EntityType::kTopLevelChannel, nullptr));
     RefCountedPtr<BaseNode> retrieved =
         ChannelzRegistry::Get(channelz_channels[i]->uuid());
     EXPECT_EQ(channelz_channels[i], retrieved);
@@ -95,7 +95,7 @@ TEST_F(ChannelzRegistryTest, RegisterManyItems) {
 
 TEST_F(ChannelzRegistryTest, NullIfNotPresentTest) {
   RefCountedPtr<BaseNode> channelz_channel =
-      MakeRefCounted<BaseNode>(BaseNode::EntityType::kTopLevelChannel);
+      MakeRefCounted<BaseNode>(BaseNode::EntityType::kTopLevelChannel, nullptr);
   // try to pull out a uuid that does not exist.
   RefCountedPtr<BaseNode> nonexistant =
       ChannelzRegistry::Get(channelz_channel->uuid() + 1);
@@ -117,10 +117,10 @@ TEST_F(ChannelzRegistryTest, TestUnregistration) {
     std::vector<RefCountedPtr<BaseNode>> odd_channels;
     odd_channels.reserve(kLoopIterations);
     for (int i = 0; i < kLoopIterations; i++) {
-      even_channels.push_back(
-          MakeRefCounted<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
-      odd_channels.push_back(
-          MakeRefCounted<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
+      even_channels.push_back(MakeRefCounted<BaseNode>(
+          BaseNode::EntityType::kTopLevelChannel, nullptr));
+      odd_channels.push_back(MakeRefCounted<BaseNode>(
+          BaseNode::EntityType::kTopLevelChannel, nullptr));
       odd_uuids.push_back(odd_channels[i]->uuid());
     }
   }
@@ -137,8 +137,8 @@ TEST_F(ChannelzRegistryTest, TestUnregistration) {
   std::vector<RefCountedPtr<BaseNode>> more_channels;
   more_channels.reserve(kLoopIterations);
   for (int i = 0; i < kLoopIterations; i++) {
-    more_channels.push_back(
-        MakeRefCounted<BaseNode>(BaseNode::EntityType::kTopLevelChannel));
+    more_channels.push_back(MakeRefCounted<BaseNode>(
+        BaseNode::EntityType::kTopLevelChannel, nullptr));
     RefCountedPtr<BaseNode> retrieved =
         ChannelzRegistry::Get(more_channels[i]->uuid());
     EXPECT_EQ(more_channels[i], retrieved);

--- a/test/cpp/end2end/channelz_service_test.cc
+++ b/test/cpp/end2end/channelz_service_test.cc
@@ -571,6 +571,8 @@ TEST_F(ChannelzServerTest, ManySubchannelsAndSockets) {
         get_subchannel_resp.subchannel().socket_ref(0).socket_id());
     s = channelz_stub_->GetSocket(&get_socket_ctx, get_socket_req,
                                   &get_socket_resp);
+    EXPECT_TRUE(
+        get_subchannel_resp.subchannel().socket_ref(0).name().find("http"));
     EXPECT_TRUE(s.ok()) << s.error_message();
     // calls started == streams started AND stream succeeded. Since none of
     // these RPCs were canceled, all of the streams will succeeded even though
@@ -626,6 +628,8 @@ TEST_F(ChannelzServerTest, StreamingRPC) {
   ClientContext get_socket_context;
   get_socket_request.set_socket_id(
       get_subchannel_response.subchannel().socket_ref(0).socket_id());
+  EXPECT_TRUE(
+      get_subchannel_response.subchannel().socket_ref(0).name().find("http"));
   s = channelz_stub_->GetSocket(&get_socket_context, get_socket_request,
                                 &get_socket_response);
   EXPECT_TRUE(s.ok()) << "s.error_message() = " << s.error_message();
@@ -659,6 +663,7 @@ TEST_F(ChannelzServerTest, GetServerSocketsTest) {
                                        &get_server_sockets_response);
   EXPECT_TRUE(s.ok()) << "s.error_message() = " << s.error_message();
   EXPECT_EQ(get_server_sockets_response.socket_ref_size(), 1);
+  EXPECT_TRUE(get_server_sockets_response.socket_ref(0).name().find("http"));
 }
 
 TEST_F(ChannelzServerTest, GetServerSocketsPaginationTest) {
@@ -738,6 +743,8 @@ TEST_F(ChannelzServerTest, GetServerListenSocketsTest) {
   GetSocketResponse get_socket_response;
   get_socket_request.set_socket_id(
       get_server_response.server(0).listen_socket(0).socket_id());
+  EXPECT_TRUE(
+      get_server_response.server(0).listen_socket(0).name().find("http"));
   ClientContext get_socket_context;
   s = channelz_stub_->GetSocket(&get_socket_context, get_socket_request,
                                 &get_socket_response);


### PR DESCRIPTION
Support human-readable names for channelz sockets and listen sockets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/19783)
<!-- Reviewable:end -->
