### PR TITLE
Demonstrate issue where we get too many timer wakeups

### DIFF
--- a/src/core/lib/iomgr/timer_manager.cc
+++ b/src/core/lib/iomgr/timer_manager.cc
@@ -180,10 +180,10 @@ static bool wait_until(grpc_millis next) {
         g_has_timed_waiter = true;
         g_timed_waiter_deadline = next;
 
-        if (GRPC_TRACE_FLAG_ENABLED(grpc_timer_check_trace)) {
+        //if (GRPC_TRACE_FLAG_ENABLED(grpc_timer_check_trace)) {
           grpc_millis wait_time = next - grpc_core::ExecCtx::Get()->Now();
-          gpr_log(GPR_INFO, "sleep for a %" PRId64 " milliseconds", wait_time);
-        }
+          gpr_log(GPR_ERROR, "sleep for a %" PRId64 " milliseconds", wait_time);
+        //}
       } else {  // g_timed_waiter == true && next >= g_timed_waiter_deadline
         next = GRPC_MILLIS_INF_FUTURE;
       }
@@ -197,11 +197,11 @@ static bool wait_until(grpc_millis next) {
     gpr_cv_wait(&g_cv_wait, &g_mu,
                 grpc_millis_to_timespec(next, GPR_CLOCK_MONOTONIC));
 
-    if (GRPC_TRACE_FLAG_ENABLED(grpc_timer_check_trace)) {
-      gpr_log(GPR_INFO, "wait ended: was_timed:%d kicked:%d",
+    //if (GRPC_TRACE_FLAG_ENABLED(grpc_timer_check_trace)) {
+      gpr_log(GPR_ERROR, "wait ended: was_timed:%d kicked:%d",
               my_timed_waiter_generation == g_timed_waiter_generation,
               g_kicked);
-    }
+    //}
     // if this was the timed waiter, then we need to check timers, and flag
     // that there's now no timed waiter... we'll look for a replacement if
     // there's work to do after checking timers (code above)

--- a/test/cpp/common/BUILD
+++ b/test/cpp/common/BUILD
@@ -32,6 +32,19 @@ grpc_cc_test(
 )
 
 grpc_cc_test(
+    name = "timer_test",
+    srcs = ["timer_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
+    deps = [
+        "//:grpc++",
+        "//test/core/util:grpc_test_util",
+    ],
+    tags = ["no_windows"],
+)
+
+grpc_cc_test(
     name = "auth_property_iterator_test",
     srcs = ["auth_property_iterator_test.cc"],
     external_deps = [

--- a/test/cpp/common/timer_test.cc
+++ b/test/cpp/common/timer_test.cc
@@ -20,9 +20,55 @@
 #include <gtest/gtest.h>
 
 #include "src/core/lib/iomgr/closure.h"
+#include "src/core/lib/iomgr/error.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/timer.h"
 #include "test/core/util/test_config.h"
+
+static gpr_mu g_mu;
+extern gpr_timespec (*gpr_now_impl)(gpr_clock_type clock_type);
+gpr_timespec (*gpr_now_impl_orig)(gpr_clock_type clock_type) = gpr_now_impl;
+static int g_time_shift_sec = 0;
+static int g_time_shift_nsec = 0;
+static gpr_timespec now_impl(gpr_clock_type clock) {
+  auto ts = gpr_now_impl_orig(clock);
+  // We only manipulate the realtime clock to simulate changes in wall-clock
+  // time
+  if (clock != GPR_CLOCK_REALTIME) {
+    return ts;
+  }
+  GPR_ASSERT(ts.tv_nsec >= 0);
+  GPR_ASSERT(ts.tv_nsec < GPR_NS_PER_SEC);
+  gpr_mu_lock(&g_mu);
+  ts.tv_sec += g_time_shift_sec;
+  ts.tv_nsec += g_time_shift_nsec;
+  gpr_mu_unlock(&g_mu);
+  if (ts.tv_nsec >= GPR_NS_PER_SEC) {
+    ts.tv_nsec -= GPR_NS_PER_SEC;
+    ++ts.tv_sec;
+  } else if (ts.tv_nsec < 0) {
+    --ts.tv_sec;
+    ts.tv_nsec = GPR_NS_PER_SEC + ts.tv_nsec;
+  }
+  return ts;
+}
+
+// offset the value returned by gpr_now(GPR_CLOCK_REALTIME) by msecs
+// milliseconds
+static void set_now_offset(int msecs) {
+  gpr_mu_lock(&g_mu);
+  g_time_shift_sec = msecs / 1000;
+  g_time_shift_nsec = (msecs % 1000) * 1e6;
+  gpr_mu_unlock(&g_mu);
+}
+
+// restore the original implementation of gpr_now()
+static void reset_now_offset() {
+  gpr_mu_lock(&g_mu);
+  g_time_shift_sec = 0;
+  g_time_shift_nsec = 0;
+  gpr_mu_unlock(&g_mu);
+}
 
 
 namespace grpc {
@@ -40,10 +86,34 @@ TEST(TimerTest, TimerExpiry) {
   grpc_shutdown();
 }
 
+TEST(TimerTest, TimeJumpsBackwards) {
+  grpc_init();
+  grpc_core::ExecCtx exec_ctx;
+  gpr_log(GPR_ERROR, "sleeping for 5 seconds");
+  set_now_offset(-3000);
+  sleep(5);
+  gpr_log(GPR_ERROR, "sleep done");
+  reset_now_offset();
+  grpc_shutdown();
+}
+
+TEST(TimerTest, TimeJumpsForward) {
+  grpc_init();
+  grpc_core::ExecCtx exec_ctx;
+  gpr_log(GPR_ERROR, "sleeping for 5 seconds");
+  set_now_offset(3000);
+  sleep(5);
+  gpr_log(GPR_ERROR, "sleep done");
+  reset_now_offset();
+  grpc_shutdown();
+}
+
 }  // namespace
 }  // namespace grpc
 
 int main(int argc, char** argv) {
+  gpr_mu_init(&g_mu);
+  gpr_now_impl = now_impl;
   grpc::testing::TestEnvironment env(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/cpp/common/timer_test.cc
+++ b/test/cpp/common/timer_test.cc
@@ -1,0 +1,50 @@
+/*
+ *
+ * Copyright 2015 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <grpc/grpc.h>
+#include <gtest/gtest.h>
+
+#include "src/core/lib/iomgr/closure.h"
+#include "src/core/lib/iomgr/exec_ctx.h"
+#include "src/core/lib/iomgr/timer.h"
+#include "test/core/util/test_config.h"
+
+
+namespace grpc {
+namespace {
+
+TEST(TimerTest, TimerExpiry) {
+  grpc_init();
+  grpc_core::ExecCtx exec_ctx;
+  grpc_timer timer;
+  grpc_timer_init(&timer, 1500,
+                  GRPC_CLOSURE_CREATE([](void*, grpc_error*) { gpr_log(GPR_ERROR, "Timer fired");}, nullptr, grpc_schedule_on_exec_ctx));
+  gpr_log(GPR_ERROR, "sleeping for 5 seconds");
+  sleep(5);
+  gpr_log(GPR_ERROR, "sleep done");
+  grpc_shutdown();
+}
+
+}  // namespace
+}  // namespace grpc
+
+int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
The test creates a timer that fires in 1.5 seconds, then sleeps for 5 seconds.

 I would expect 6 grpc timer wakeups: 1 wakeup/second when there are no timers (this is based on my testing, not sure if it's intended behavior) + 1 wakeup for the timer that fires after 1.5 seconds.
What we actually see is 11 wakeups. 

If you create more timers, you'll notice that the issue gets worse - there are even more seemingly unnecessary timer wakeups.

I think the problem is in the [deadline calculation](https://github.com/grpc/grpc/blob/master/src/core/lib/iomgr/timer_generic.cc#L503).

```
$  bazel-bin/test/cpp/common/timer_test
D0731 17:10:51.917567000 4554032576 test_config.cc:384]                test slowdown factor: sanitizer=1, fixture=1, poller=1, total=1
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from TimerTest
[ RUN      ] TimerTest.TimerExpiry
E0731 17:10:51.919765000 4554032576 timer_test.cc:37]                  sleeping for 5 seconds
E0731 17:10:51.919802000 123145472860160 timer_manager.cc:185]         sleep for a 541 milliseconds
E0731 17:10:52.464437000 123145472860160 timer_manager.cc:201]         wait ended: was_timed:1 kicked:0
E0731 17:10:52.464512000 123145472860160 timer_manager.cc:185]         sleep for a 457 milliseconds
E0731 17:10:52.922711000 123145472860160 timer_manager.cc:201]         wait ended: was_timed:1 kicked:0
E0731 17:10:52.922780000 123145472860160 timer_manager.cc:185]         sleep for a 153 milliseconds
E0731 17:10:53.076916000 123145472860160 timer_manager.cc:201]         wait ended: was_timed:1 kicked:0
E0731 17:10:53.076953000 123145472860160 timer_manager.cc:185]         sleep for a 342 milliseconds
E0731 17:10:53.422647000 123145472860160 timer_manager.cc:201]         wait ended: was_timed:1 kicked:0
E0731 17:10:53.422903000 123145472860160 timer_test.cc:36]             Timer fired
E0731 17:10:53.422928000 123145472860160 timer_manager.cc:185]         sleep for a 357 milliseconds
E0731 17:10:53.782250000 123145472860160 timer_manager.cc:201]         wait ended: was_timed:1 kicked:0
E0731 17:10:53.782305000 123145472860160 timer_manager.cc:185]         sleep for a 142 milliseconds
E0731 17:10:53.928712000 123145472860160 timer_manager.cc:201]         wait ended: was_timed:1 kicked:0
E0731 17:10:53.928783000 123145472860160 timer_manager.cc:185]         sleep for a 651 milliseconds
E0731 17:10:54.581226000 123145472860160 timer_manager.cc:201]         wait ended: was_timed:1 kicked:0
E0731 17:10:54.581282000 123145472860160 timer_manager.cc:185]         sleep for a 348 milliseconds
E0731 17:10:54.932272000 123145472860160 timer_manager.cc:201]         wait ended: was_timed:1 kicked:0
E0731 17:10:54.932307000 123145472860160 timer_manager.cc:185]         sleep for a 526 milliseconds
E0731 17:10:55.462168000 123145472860160 timer_manager.cc:201]         wait ended: was_timed:1 kicked:0
E0731 17:10:55.462226000 123145472860160 timer_manager.cc:185]         sleep for a 470 milliseconds
E0731 17:10:55.936669000 123145472860160 timer_manager.cc:201]         wait ended: was_timed:1 kicked:0
E0731 17:10:55.936737000 123145472860160 timer_manager.cc:185]         sleep for a 456 milliseconds
E0731 17:10:56.395491000 123145472860160 timer_manager.cc:201]         wait ended: was_timed:1 kicked:0
E0731 17:10:56.395548000 123145472860160 timer_manager.cc:185]         sleep for a 543 milliseconds
E0731 17:10:56.923576000 4554032576 timer_test.cc:39]                  sleep done
[       OK ] TimerTest.TimerExpiry (5005 ms)
[----------] 1 test from TimerTest (5005 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (5005 ms total)
[  PASSED  ] 1 test.
E0731 17:10:56.923973000 123145473396736 timer_manager.cc:201]         wait ended: was_timed:0 kicked:0
E0731 17:10:56.924058000 123145472860160 timer_manager.cc:201]         wait ended: was_timed:1 kicked:0
```