### PR TITLE
Fix gcc 8+ warnings

### DIFF
--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -91,6 +91,9 @@ class WriteOptions {
   /// Clear all flags.
   inline void Clear() { flags_ = 0; }
 
+  /// Default copy assignment.
+  inline WriteOptions &operator=(const WriteOptions &) = default;
+
   /// Returns raw flags bitset.
   inline uint32_t flags() const { return flags_; }
 

--- a/src/core/ext/filters/client_idle/client_idle_filter.cc
+++ b/src/core/ext/filters/client_idle/client_idle_filter.cc
@@ -194,7 +194,7 @@ void ChannelData::EnterIdle() {
   // Hold a ref to the channel stack for the transport op.
   GRPC_CHANNEL_STACK_REF(channel_stack_, "idle transport op");
   // Initialize the transport op.
-  memset(&idle_transport_op_, 0, sizeof(idle_transport_op_));
+  memset(static_cast<void*>(&idle_transport_op_), 0, sizeof(idle_transport_op_));
   idle_transport_op_.disconnect_with_error = grpc_error_set_int(
       GRPC_ERROR_CREATE_FROM_STATIC_STRING("enter idle"),
       GRPC_ERROR_INT_CHANNEL_CONNECTIVITY_STATE, GRPC_CHANNEL_IDLE);


### PR DESCRIPTION
This MR contains some fixes for avoid gcc warnings and errors. Tested on gcc 8/9 and clang 8