### PR TITLE
a few fixes for run_performance_tests.py flame graph generators

### DIFF
--- a/tools/run_tests/performance/process_local_perf_flamegraphs.sh
+++ b/tools/run_tests/performance/process_local_perf_flamegraphs.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -ex
+
 mkdir -p "$OUTPUT_DIR"
 
 PERF_DATA_FILE="${PERF_BASE_NAME}-perf.data"
@@ -22,4 +24,5 @@ PERF_SCRIPT_OUTPUT="${PERF_BASE_NAME}-out.perf"
 echo "running perf script on $PERF_DATA_FILE"
 perf script -i "$PERF_DATA_FILE" > "$PERF_SCRIPT_OUTPUT"
 
+# use https://github.com/brendangregg/FlameGraph
 ~/FlameGraph/stackcollapse-perf.pl "$PERF_SCRIPT_OUTPUT" | ~/FlameGraph/flamegraph.pl > "${OUTPUT_DIR}/${OUTPUT_FILENAME}.svg"

--- a/tools/run_tests/performance/process_remote_perf_flamegraphs.sh
+++ b/tools/run_tests/performance/process_remote_perf_flamegraphs.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -ex
+
 mkdir -p "$OUTPUT_DIR"
 
 PERF_DATA_FILE="${PERF_BASE_NAME}-perf.data"
@@ -27,4 +29,5 @@ scp "$USER_AT_HOST:~/performance_workspace/grpc/$PERF_SCRIPT_OUTPUT.gz" .
 
 gzip -d -f "$PERF_SCRIPT_OUTPUT.gz"
 
+# use https://github.com/brendangregg/FlameGraph
 ~/FlameGraph/stackcollapse-perf.pl --kernel "$PERF_SCRIPT_OUTPUT" | ~/FlameGraph/flamegraph.pl --color=java --hash > "${OUTPUT_DIR}/${OUTPUT_FILENAME}.svg"

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -328,10 +328,10 @@ def perf_report_processor_job(worker_host, perf_base_name, output_filename,
     cmd = ''
     if worker_host != 'localhost':
         user_at_host = "%s@%s" % (_REMOTE_HOST_USERNAME, worker_host)
-        cmd = "USER_AT_HOST=%s OUTPUT_FILENAME=%s OUTPUT_DIR=%s PERF_BASE_NAME=%stools/run_tests/performance/process_remote_perf_flamegraphs.sh" % (
+        cmd = "USER_AT_HOST=%s OUTPUT_FILENAME=%s OUTPUT_DIR=%s PERF_BASE_NAME=%s tools/run_tests/performance/process_remote_perf_flamegraphs.sh" % (
             user_at_host, output_filename, flame_graph_reports, perf_base_name)
     else:
-        cmd = "OUTPUT_FILENAME=%s OUTPUT_DIR=%s PERF_BASE_NAME=%stools/run_tests/performance/process_local_perf_flamegraphs.sh" % (
+        cmd = "OUTPUT_FILENAME=%s OUTPUT_DIR=%s PERF_BASE_NAME=%s tools/run_tests/performance/process_local_perf_flamegraphs.sh" % (
             output_filename, flame_graph_reports, perf_base_name)
 
     return jobset.JobSpec(
@@ -484,7 +484,7 @@ def run_collect_perf_profile_jobs(hosts_and_base_names, scenario_name,
     failures, _ = jobset.run(
         perf_report_jobs, newline_on_success=True, maxjobs=1)
     jobset.message(
-        'END', 'Collecting perf reports from qps workers', do_newline=True)
+        'SUCCESS', 'Collecting perf reports from qps workers', do_newline=True)
     return failures
 
 


### PR DESCRIPTION
I wanted to generate the flamegraph and found out the flamegraph feature in run_performance_tests.py was broken.
It didn't take much to fix it (at least for the scenario I wanted to run).

I was able to get e.g. this command succeed (it's the particular one I needed)
`tools/run_tests/run_performance_tests.py -l c++ -r 'cpp_protobuf_sync_unary_ping_pong_insecure' "--perf_args=record -F 1000 -g"`
