### PR TITLE
Adding src/core/ext/upb-generated in our include path.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ CPPFLAGS += -fPIC
 LDFLAGS += -fPIC
 endif
 
-INCLUDES = . include $(GENDIR) third_party/upb third_party/upb/generated_for_cmake
+INCLUDES = . include $(GENDIR) third_party/upb third_party/upb/generated_for_cmake src/core/ext/upb-generated
 LDFLAGS += -Llibs/$(CONFIG)
 
 ifeq ($(SYSTEM),Darwin)

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -240,7 +240,7 @@
   LDFLAGS += -fPIC
   endif
 
-  INCLUDES = . include $(GENDIR) third_party/upb third_party/upb/generated_for_cmake
+  INCLUDES = . include $(GENDIR) third_party/upb third_party/upb/generated_for_cmake src/core/ext/upb-generated
   LDFLAGS += -Llibs/$(CONFIG)
 
   ifeq ($(SYSTEM),Darwin)


### PR DESCRIPTION
This enables us to build both from Bazel and make.