### PR TITLE
Add IAsyncStreamReader.ReadAllAsync extension method

### DIFF
--- a/src/csharp/Grpc.Core.Api/AsyncStreamReaderExtensions.cs
+++ b/src/csharp/Grpc.Core.Api/AsyncStreamReaderExtensions.cs
@@ -17,6 +17,8 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -46,5 +48,27 @@ namespace Grpc.Core
 
             return streamReader.MoveNext(CancellationToken.None);
         }
+
+#if NETSTANDARD2_0
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="streamReader"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async static IAsyncEnumerable<T> ReadAllAsync<T>(this IAsyncStreamReader<T> streamReader, [EnumeratorCancellation]CancellationToken cancellationToken = default)
+        {
+            if (streamReader == null)
+            {
+                throw new System.ArgumentNullException(nameof(streamReader));
+            }
+
+            while (await streamReader.MoveNext(cancellationToken))
+            {
+                yield return streamReader.Current;
+            }
+        }
+#endif
     }
 }

--- a/src/csharp/Grpc.Core.Api/Grpc.Core.Api.csproj
+++ b/src/csharp/Grpc.Core.Api/Grpc.Core.Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="..\Grpc.Core\Common.csproj.include" />
 
@@ -12,6 +12,7 @@
     <PackageTags>gRPC RPC HTTP/2</PackageTags>
     <VersionPrefix>$(GrpcCsharpVersion)</VersionPrefix>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -29,6 +30,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0-preview7.19362.9" />
   </ItemGroup>
 
 </Project>

--- a/src/csharp/Grpc.Core.Tests/CallCancellationTest.cs
+++ b/src/csharp/Grpc.Core.Tests/CallCancellationTest.cs
@@ -122,7 +122,6 @@ namespace Grpc.Core.Tests
             Assert.AreEqual("SUCCESS", await successTcs.Task);
         }
 
-#if NETCOREAPP2_1
         [Test]
         public async Task ClientStreamingCall_CancelServerSideRead()
         {
@@ -147,8 +146,8 @@ namespace Grpc.Core.Tests
                 Assert.AreEqual(StatusCode.Cancelled, ex.Status.StatusCode);
             }
         }
-#endif
 
+#if NETCOREAPP2_1
         [Test]
         public async Task ClientStreamingCall_CancelServerSideReadAllAsync()
         {
@@ -176,6 +175,7 @@ namespace Grpc.Core.Tests
                 Assert.AreEqual(StatusCode.Cancelled, ex.Status.StatusCode);
             }
         }
+#endif
 
         [Test]
         public async Task ServerStreamingCall_CancelClientSideRead()

--- a/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
+++ b/src/csharp/Grpc.Core.Tests/Grpc.Core.Tests.csproj
@@ -7,6 +7,7 @@
     <OutputType>Exe</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-dotnet/issues/41

Issues:
* Currently this depends on a preview version of `Microsoft.Bcl.AsyncInterfaces`. Will need to see when this package will be published as non-preview. An alternative would be to have a `netstandard2.1` target for `Grpc.Core.Api`.
* Uses C# 8. Required for async method generation and await foreach. What are the requirements for C# version in this repo?