### PR TITLE
Fix uninitialized memory in sockaddr utils

### DIFF
--- a/src/core/lib/iomgr/sockaddr_utils.cc
+++ b/src/core/lib/iomgr/sockaddr_utils.cc
@@ -201,13 +201,11 @@ int grpc_sockaddr_to_string(char** out,
 }
 
 void grpc_string_to_sockaddr(grpc_resolved_address* out, char* addr, int port) {
+  memset(out, 0, sizeof(grpc_resolved_address));
   grpc_sockaddr_in6* addr6 = (grpc_sockaddr_in6*)out->addr;
   grpc_sockaddr_in* addr4 = (grpc_sockaddr_in*)out->addr;
-
   if (grpc_inet_pton(GRPC_AF_INET6, addr, &addr6->sin6_addr) == 1) {
     addr6->sin6_family = GRPC_AF_INET6;
-    addr6->sin6_flowinfo = 0;
-    addr6->sin6_scope_id = 0;
     out->len = sizeof(grpc_sockaddr_in6);
   } else if (grpc_inet_pton(GRPC_AF_INET, addr, &addr4->sin_addr) == 1) {
     addr4->sin_family = GRPC_AF_INET;


### PR DESCRIPTION
```
typedef struct {
  char addr[GRPC_MAX_SOCKADDR_SIZE];
  socklen_t len;
} grpc_resolved_address;
```

The `addr` part should be initialized, otherwise there is an MSAN failure.

`grpc_string_to_sockaddr()` is currently not used, so we haven't seen this failure. 