### PR TITLE
Remove references to GRPCConnectivityMonitor from ConnectivityTestingApp

### DIFF
--- a/src/objective-c/tests/Connectivity/ConnectivityTestingApp/ViewController.m
+++ b/src/objective-c/tests/Connectivity/ConnectivityTestingApp/ViewController.m
@@ -24,8 +24,6 @@
 #import <RxLibrary/GRXWriter+Immediate.h>
 #import <RxLibrary/GRXWriter+Transformations.h>
 
-#import "src/objective-c/GRPCClient/private/GRPCConnectivityMonitor.h"
-
 NSString *host = @"grpc-test.sandbox.googleapis.com";
 
 @interface ViewController : UIViewController
@@ -34,10 +32,6 @@ NSString *host = @"grpc-test.sandbox.googleapis.com";
 @implementation ViewController
 - (void)viewDidLoad {
   [super viewDidLoad];
-
-#ifndef GRPC_CFSTREAM
-  [GRPCConnectivityMonitor registerObserver:self selector:@selector(reachabilityChanged:)];
-#endif
 }
 
 - (void)reachabilityChanged:(NSNotification *)note {


### PR DESCRIPTION
GRPCConnectivityMonitor was removed in #19663. This PR removes undefined references to #19663 in ConnectivityTestingApp.