### PR TITLE
Fix key gen in locality picking

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
@@ -559,9 +559,8 @@ class XdsLb : public LoadBalancingPolicy {
 
 XdsLb::PickResult XdsLb::Picker::Pick(PickArgs args) {
   // TODO(roth): Add support for drop handling.
-  // Generate a random number between 0 and the total weight
-  const uint32_t key =
-      (rand() * pickers_[pickers_.size() - 1].first) / RAND_MAX;
+  // Generate a random number in [0, total weight).
+  const uint32_t key = rand() % pickers_[pickers_.size() - 1].first;
   // Forward pick to whichever locality maps to the range in which the
   // random number falls in.
   PickResult result = PickFromLocality(key, args);


### PR DESCRIPTION
Extracted from https://github.com/grpc/grpc/pull/19729.

Without the fix, I print the generated random number and the key after calculation when there are two localities with lb weight 2 and 8 (`TEST_F(SingleBalancerTest, LocalityMapWeightedRoundRobin)` in https://github.com/grpc/grpc/pull/19858). The key is always 0 or 1 but it should be all the values from 0 to 10.

```
I0805 20:50:55.956463932   74076 xds.cc:646]                  === k=1
I0805 20:50:55.957119744   74076 xds.cc:641]                  === r=2123155330
I0805 20:50:55.957137212   74076 xds.cc:646]                  === k=1
I0805 20:50:55.957828037   74076 xds.cc:641]                  === r=1877894321
I0805 20:50:55.957846711   74076 xds.cc:646]                  === k=0
I0805 20:50:55.958494146   74076 xds.cc:641]                  === r=1319999906
I0805 20:50:55.958510332   74076 xds.cc:646]                  === k=0
I0805 20:50:55.959170496   74076 xds.cc:641]                  === r=1475583076
I0805 20:50:55.959188755   74076 xds.cc:646]                  === k=0
I0805 20:50:55.959838752   74076 xds.cc:641]                  === r=937454448
I0805 20:50:55.959855511   74076 xds.cc:646]                  === k=0
I0805 20:50:55.960534821   74076 xds.cc:641]                  === r=459568752
I0805 20:50:55.960553543   74076 xds.cc:646]                  === k=0
I0805 20:50:55.961144513   74076 xds.cc:641]                  === r=786647529
I0805 20:50:55.961163333   74076 xds.cc:646]                  === k=1
I0805 20:50:55.961910341   74076 xds.cc:641]                  === r=539734014
I0805 20:50:55.961929627   74076 xds.cc:646]                  === k=0
I0805 20:50:55.962498370   74076 xds.cc:641]                  === r=70499694
I0805 20:50:55.962516656   74076 xds.cc:646]                  === k=0
I0805 20:50:55.963255896   74076 xds.cc:641]                  === r=1452157627
I0805 20:50:55.963274805   74076 xds.cc:646]                  === k=0
I0805 20:50:55.963854455   74076 xds.cc:641]                  === r=1993890554
I0805 20:50:55.963872985   74076 xds.cc:646]                  === k=1
I0805 20:50:55.964547621   74076 xds.cc:641]                  === r=792380415
I0805 20:50:55.964565915   74076 xds.cc:646]                  === k=1
I0805 20:50:55.965215317   74076 xds.cc:641]                  === r=1670502228
I0805 20:50:55.965233866   74076 xds.cc:646]                  === k=1
I0805 20:50:55.965919383   74076 xds.cc:641]                  === r=631375815
I0805 20:50:55.965937945   74076 xds.cc:646]                  === k=0
I0805 20:50:55.966626688   74076 xds.cc:641]                  === r=889191250
I0805 20:50:55.966645033   74076 xds.cc:646]                  === k=0
I0805 20:50:55.967333102   74076 xds.cc:641]                  === r=277327268
I0805 20:50:55.967351869   74076 xds.cc:646]                  === k=1
I0805 20:50:55.967989649   74076 xds.cc:641]                  === r=800452492
I0805 20:50:55.968008306   74076 xds.cc:646]                  === k=1
I0805 20:50:55.968640876   74076 xds.cc:641]                  === r=927892680
I0805 20:50:55.968657472   74076 xds.cc:646]                  === k=0
I0805 20:50:55.969319094   74076 xds.cc:641]                  === r=993434727
I0805 20:50:55.969351325   74076 xds.cc:646]                  === k=0
I0805 20:50:55.970065995   74076 xds.cc:641]                  === r=1301168738
I0805 20:50:55.970084826   74076 xds.cc:646]                  === k=0
I0805 20:50:55.970742236   74076 xds.cc:641]                  === r=1349444400
I0805 20:50:55.970758691   74076 xds.cc:646]                  === k=0
I0805 20:50:55.971353948   74076 xds.cc:641]                  === r=335925273
I0805 20:50:55.971369698   74076 xds.cc:646]                  === k=1
I0805 20:50:55.971995075   74076 xds.cc:641]                  === r=1956893133
I0805 20:50:55.972013470   74076 xds.cc:646]                  === k=1
I0805 20:50:55.972643765   74076 xds.cc:641]                  === r=571496563
I0805 20:50:55.972660501   74076 xds.cc:646]                  === k=0
I0805 20:50:55.973342763   74076 xds.cc:641]                  === r=605308113
I0805 20:50:55.973359496   74076 xds.cc:646]                  === k=0
I0805 20:50:55.973961761   74076 xds.cc:641]                  === r=1998477490
I0805 20:50:55.973977506   74076 xds.cc:646]                  === k=1
I0805 20:50:55.974612857   74076 xds.cc:641]                  === r=802399040
I0805 20:50:55.974628666   74076 xds.cc:646]                  === k=1
I0805 20:50:55.975246398   74076 xds.cc:641]                  === r=886072340
I0805 20:50:55.975261951   74076 xds.cc:646]                  === k=0
I0805 20:50:55.975880535   74076 xds.cc:641]                  === r=850915398
I0805 20:50:55.975897524   74076 xds.cc:646]                  === k=1

```