### PR TITLE
Disable nanopb fuzzer test

### DIFF
--- a/test/core/nanopb/fuzzer_response.cc
+++ b/test/core/nanopb/fuzzer_response.cc
@@ -32,10 +32,13 @@ static void dont_log(gpr_log_func_args* args) {}
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   grpc_init();
   if (squelch) gpr_set_log_function(dont_log);
+  // TODO(veblush): Convert this to upb.
+  /*
   grpc_slice slice = grpc_slice_from_copied_buffer((const char*)data, size);
   upb::Arena arena;
   grpc_core::grpc_grpclb_initial_response_parse(slice, arena.ptr());
   grpc_slice_unref(slice);
+  */
   grpc_shutdown();
   return 0;
 }

--- a/test/core/nanopb/fuzzer_serverlist.cc
+++ b/test/core/nanopb/fuzzer_serverlist.cc
@@ -32,12 +32,15 @@ static void dont_log(gpr_log_func_args* args) {}
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   grpc_init();
   if (squelch) gpr_set_log_function(dont_log);
+  // TODO(veblush): Convert this to upb.
+  /*
   grpc_slice slice = grpc_slice_from_copied_buffer((const char*)data, size);
   grpc_core::grpc_grpclb_serverlist* serverlist;
   if ((serverlist = grpc_core::grpc_grpclb_response_parse_serverlist(slice))) {
     grpc_grpclb_destroy_serverlist(serverlist);
   }
   grpc_slice_unref(slice);
+  */
   grpc_shutdown();
   return 0;
 }


### PR DESCRIPTION
Since nanopb is being replaced by upb, fuzzer tests for nanopb also will be replaced. Until those tests are ready, existing nanopb tests are disabled. (fixed #19889)