### PR TITLE
Fix channel args cmp

### DIFF
--- a/src/core/lib/channel/channel_args.cc
+++ b/src/core/lib/channel/channel_args.cc
@@ -214,6 +214,8 @@ void grpc_channel_args_destroy(grpc_channel_args* a) {
 
 int grpc_channel_args_compare(const grpc_channel_args* a,
                               const grpc_channel_args* b) {
+  if (a == nullptr && b == nullptr) return 0;
+  if (a == nullptr || b == nullptr) return a == nullptr ? -1 : 1;
   int c = GPR_ICMP(a->num_args, b->num_args);
   if (c != 0) return c;
   for (size_t i = 0; i < a->num_args; i++) {


### PR DESCRIPTION
Found in test of https://github.com/grpc/grpc/pull/18745

https://source.cloud.google.com/results/invocations/6ad522ae-1ba8-4d03-90f2-337d01d8aebe/targets/%2F%2Ftest%2Fcpp%2Fend2end:xds_end2end_test@poller%3Depoll1/log