### PR TITLE
Excluded *.inc from python distribution cleanup

### DIFF
--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -48,7 +48,7 @@ clean_non_source_files() {
 ( cd "$1"
   find . -type f \
     | grep -v '\.c$' | grep -v '\.cc$' | grep -v '\.cpp$' \
-    | grep -v '\.h$' | grep -v '\.hh$' \
+    | grep -v '\.h$' | grep -v '\.hh$' | grep -v '\.inc$' \
     | grep -v '\.s$' | grep -v '\.py$' \
     | while read -r file; do
       rm -f "$file" || true


### PR DESCRIPTION
The existing python distribute script deletes unnecessary files after building python source distribution. But recently added upb has \*.inc files which shouldn't be removed but it's now being pruned by the script and it causes a broken package with missing files. To fix this problem, the pattern for \*.inc files is added to the white-list. (fixed #19795)