### PR TITLE
Update upb to the latest

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -208,9 +208,9 @@ def grpc_deps():
     if "upb" not in native.existing_rules():
         http_archive(
             name = "upb",
-            sha256 = "6e3c81c9e6c609d918b399110a88d10efeab73b2c8eb3131de15658b1ec86141",
-            strip_prefix = "upb-b70f68269a7d51c5ce372a93742bf6960215ffef",
-            url = "https://github.com/protocolbuffers/upb/archive/b70f68269a7d51c5ce372a93742bf6960215ffef.tar.gz",
+            sha256 = "95150db57b51b65f3422c38953956e0f786945d842d76f8ab685fbcd93ab5caa",
+            strip_prefix = "upb-931bbecbd3230ae7f22efa5d203639facc47f719",
+            url = "https://github.com/protocolbuffers/upb/archive/931bbecbd3230ae7f22efa5d203639facc47f719.tar.gz",
         )
     if "envoy_api" not in native.existing_rules():
         http_archive(

--- a/tools/run_tests/sanity/check_submodules.sh
+++ b/tools/run_tests/sanity/check_submodules.sh
@@ -40,7 +40,7 @@ cat << EOF | awk '{ print $1 }' | sort > "$want_submodules"
  9245d481eb3e890f708ff2d7dadf2a10c04748ba third_party/libcxxabi (heads/release_60)
  09745575a923640154bcf307fba8aedff47f240a third_party/protobuf (v3.7.0-rc.2-247-g09745575)
  e143189bf6f37b3957fb31743df6a1bcf4a8c685 third_party/protoc-gen-validate (v0.0.10)
- b70f68269a7d51c5ce372a93742bf6960215ffef third_party/upb (heads/master)
+ 931bbecbd3230ae7f22efa5d203639facc47f719 third_party/upb (heads/master)
  cacf7f1d4e3d44d871b605da3b647f07d718623f third_party/zlib (v1.2.11)
 EOF
 


### PR DESCRIPTION
This update is to address following problems:
- upb/decode.c(484,1): error: control may reach end of non-void function
- symbol conflict due to `MurmurHash2`


