### PR TITLE
Add gnossen and remove vjpai as bazel/** owner.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # Uses OWNERS files in different modules throughout the
 # repository as the source of truth for module ownership.
 /**/OWNERS @markdroth @nicolasnoble @a11r
-/bazel/** @nicolasnoble @jtattermusch @a11r @gnossen
+/bazel/** @nicolasnoble @jtattermusch @veblush @gnossen
 /cmake/** @jtattermusch @nicolasnoble @apolcyn
 /src/core/ext/filters/client_channel/** @markdroth @apolcyn @AspirinSJL
 /tools/dockerfile/** @jtattermusch @apolcyn @nicolasnoble

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 # Uses OWNERS files in different modules throughout the
 # repository as the source of truth for module ownership.
 /**/OWNERS @markdroth @nicolasnoble @a11r
-/bazel/** @nicolasnoble @jtattermusch @a11r @vjpai
+/bazel/** @nicolasnoble @jtattermusch @a11r @gnossen
 /cmake/** @jtattermusch @nicolasnoble @apolcyn
 /src/core/ext/filters/client_channel/** @markdroth @apolcyn @AspirinSJL
 /tools/dockerfile/** @jtattermusch @apolcyn @nicolasnoble

--- a/bazel/OWNERS
+++ b/bazel/OWNERS
@@ -2,5 +2,5 @@ set noparent
 @nicolasnoble
 @jtattermusch
 @a11r
-@vjpai
+@gnossen
 

--- a/bazel/OWNERS
+++ b/bazel/OWNERS
@@ -1,6 +1,6 @@
 set noparent
 @nicolasnoble
 @jtattermusch
-@a11r
+@veblush
 @gnossen
 


### PR DESCRIPTION
At @vjpai 's request, this PR removes @vjpai and adds @gnossen as a Github codeowner of `bazel/**`.