### PR TITLE
Wait longer before sending the drop update

### DIFF
--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -1190,13 +1190,16 @@ TEST_F(SingleBalancerTest, DropUpdate) {
                                     {{kLbDropType, kDropPerMillionForLb}}),
       0);
   // The second EDS response contains two drop categories.
+  // TODO(juanlishen): Change the EDS response sending to deterministic style
+  // (e.g., by using condition variable) so that we can shorten the test
+  // duration.
   ScheduleResponseForBalancer(
       0,
       EdsServiceImpl::BuildResponse(
           GetBackendPortsInGroups(),
           {{kLbDropType, kDropPerMillionForLb},
            {kThrottleDropType, kDropPerMillionForThrottle}}),
-      5000);
+      10000);
   WaitForAllBackends();
   // Send kNumRpcs RPCs and count the drops.
   size_t num_drops = 0;


### PR DESCRIPTION
When importing this PR, we are seeing a bunch of failures where the first batch of RPC's have higher than expected drop rate. The reason is that the update (with higher drop rate) is received before we are done with the first batch of RPC's.

A temporary workaround is to simply delay the update. But we should solve this in a cleaner way by making the EDS update better controlled.