### PR TITLE
Remove unused code as comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ DerivedData
 # Objective-C generated files
 *.pbobjc.*
 *.pbrpc.*
+src/objective-c/**/Build
 
 # Cocoapods artifacts
 Pods/

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1101,17 +1101,6 @@ class ObjCLanguage(object):
                     'EXAMPLE_PATH': 'src/objective-c/examples/tvOS-sample',
                     'FRAMEWORKS': 'NO'
                 }))
-        # out.append(
-        #     self.config.job_spec(
-        #         ['src/objective-c/tests/build_one_example.sh'],
-        #         timeout_seconds=10 * 60,
-        #         shortname='ios-buildtest-example-tvOS-sample-framework',
-        #         cpu_cost=1e6,
-        #         environ={
-        #             'SCHEME': 'tvOS-sample',
-        #             'EXAMPLE_PATH': 'src/objective-c/examples/tvOS-sample',
-        #             'FRAMEWORKS': 'YES'
-        #         }))
         out.append(
             self.config.job_spec(
                 ['src/objective-c/tests/build_one_example.sh'],
@@ -1123,17 +1112,6 @@ class ObjCLanguage(object):
                     'EXAMPLE_PATH': 'src/objective-c/examples/watchOS-sample',
                     'FRAMEWORKS': 'NO'
                 }))
-        # out.append(
-        #     self.config.job_spec(
-        #         ['src/objective-c/tests/build_one_example.sh'],
-        #         timeout_seconds=20 * 60,
-        #         shortname='ios-buildtest-example-watchOS-sample-framework',
-        #         cpu_cost=1e6,
-        #         environ={
-        #             'SCHEME': 'watchOS-sample-WatchKit-App',
-        #             'EXAMPLE_PATH': 'src/objective-c/examples/watchOS-sample',
-        #             'FRAMEWORKS': 'YES'
-        #         }))
         out.append(
             self.config.job_spec(
                 ['src/objective-c/tests/run_plugin_tests.sh'],


### PR DESCRIPTION
This slipped through the crack in #19787. Removing unused targets.

Also include the temporary build files in .gitignore