### PR TITLE
Add v1.23.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -144,6 +144,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.20.0', ReleaseInfo(runtimes=['go1.11'])),
             ('v1.21.0', ReleaseInfo(runtimes=['go1.11'])),
             ('v1.22.0', ReleaseInfo(runtimes=['go1.11'])),
+            ('v1.23.0', ReleaseInfo(runtimes=['go1.11'])),
         ]),
     'java':
     OrderedDict([


### PR DESCRIPTION
```
$ gcloud beta container images list-tags gcr.io/grpc-testing/grpc_interop_go1.11
DIGEST        TAGS     TIMESTAMP            VULNERABILITIES                        FROM                             VULNERABILITY_SCAN_STATUS
c44d839d9abc  v1.23.0  2019-08-13T12:43:54  CRITICAL=7,HIGH=41,LOW=37,MEDIUM=279   us-mirror.gcr.io/library/golang  FINISHED_SUCCESS
f7c303347c2d  v1.22.1  2019-07-25T10:51:25  CRITICAL=3,HIGH=19,LOW=17,MEDIUM=122   us-mirror.gcr.io/library/debian  FINISHED_SUCCESS
3f1cc250de00  v1.21.2  2019-07-25T10:46:51  CRITICAL=3,HIGH=19,LOW=16,MEDIUM=122   us-mirror.gcr.io/library/debian  PENDING
b7a3dcc12671  v1.22.0  2019-07-02T14:14:58  CRITICAL=11,HIGH=58,LOW=51,MEDIUM=319  us-mirror.gcr.io/library/golang  FINISHED_SUCCESS
484f32770c98  v1.21.0  2019-05-22T10:44:36  CRITICAL=8,HIGH=42,LOW=37,MEDIUM=277   us-mirror.gcr.io/library/golang  FINISHED_SUCCESS
63449136dc73  v1.20.0  2019-04-09T14:41:00  CRITICAL=11,HIGH=58,LOW=51,MEDIUM=320  us-mirror.gcr.io/library/golang  FINISHED_SUCCESS
0942a3770da4  v1.19.0  2019-02-26T11:16:30  CRITICAL=10,HIGH=58,LOW=49,MEDIUM=319  us-mirror.gcr.io/library/golang  PENDING
40b538616579  v1.18.0  2019-01-15T16:34:39  CRITICAL=11,HIGH=58,LOW=51,MEDIUM=320  us-mirror.gcr.io/library/golang  PENDING
a162f049dd62  v1.17.0  2019-01-07T08:51:13  CRITICAL=11,HIGH=61,LOW=52,MEDIUM=324  us-mirror.gcr.io/library/golang  FINISHED_SUCCESS
```
