### PR TITLE
Define Ruby Struct classes under GRPC::Core::

### DIFF
--- a/src/ruby/ext/grpc/rb_call.c
+++ b/src/ruby/ext/grpc/rb_call.c
@@ -280,7 +280,7 @@ static VALUE grpc_rb_call_get_status(VALUE self) {
   Saves a status object on the call.  */
 static VALUE grpc_rb_call_set_status(VALUE self, VALUE status) {
   if (!NIL_P(status) && rb_obj_class(status) != grpc_rb_sStatus) {
-    rb_raise(rb_eTypeError, "bad status: got:<%s> want: <Struct::Status>",
+    rb_raise(rb_eTypeError, "bad status: got:<%s> want: <GRPC::Core::Status>",
              rb_obj_classname(status));
     return Qnil;
   }
@@ -1012,7 +1012,7 @@ void Init_grpc_call() {
   sym_cancelled = ID2SYM(rb_intern("cancelled"));
 
   /* The Struct used to return the run_batch result. */
-  grpc_rb_sBatchResult = rb_struct_define(
+  grpc_rb_sBatchResult = rb_struct_define_under(grpc_rb_mGrpcCore,
       "BatchResult", "send_message", "send_metadata", "send_close",
       "send_status", "message", "metadata", "status", "cancelled", NULL);
 

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -310,10 +310,10 @@ void Init_grpc_c() {
 
   grpc_rb_mGRPC = rb_define_module("GRPC");
   grpc_rb_mGrpcCore = rb_define_module_under(grpc_rb_mGRPC, "Core");
-  grpc_rb_sNewServerRpc = rb_struct_define(
+  grpc_rb_sNewServerRpc = rb_struct_define_under(grpc_rb_mGrpcCore,
       "NewServerRpc", "method", "host", "deadline", "metadata", "call", NULL);
-  grpc_rb_sStatus =
-      rb_struct_define("Status", "code", "details", "metadata", NULL);
+  grpc_rb_sStatus = rb_struct_define_under(grpc_rb_mGrpcCore,
+      "Status", "code", "details", "metadata", NULL);
   sym_code = ID2SYM(rb_intern("code"));
   sym_details = ID2SYM(rb_intern("details"));
   sym_metadata = ID2SYM(rb_intern("metadata"));

--- a/src/ruby/lib/grpc.rb
+++ b/src/ruby/lib/grpc.rb
@@ -34,3 +34,8 @@ begin
 ensure
   file.close
 end
+
+# Add aliases for backwards compatibility
+Struct::BatchResult  = GRPC::Core::BatchResult
+Struct::NewServerRpc = GRPC::Core::NewServerRpc
+Struct::Status       = GRPC::Core::Status

--- a/src/ruby/lib/grpc/errors.rb
+++ b/src/ruby/lib/grpc/errors.rb
@@ -42,12 +42,12 @@ module GRPC
       @metadata = metadata
     end
 
-    # Converts the exception to a {Struct::Status} for use in the networking
+    # Converts the exception to a {GRPC::Core::Status} for use in the networking
     # wrapper layer.
     #
-    # @return [Struct::Status] with the same code and details
+    # @return [GRPC::Core::Status] with the same code and details
     def to_status
-      Struct::Status.new(code, details, metadata)
+      GRPC::Core::Status.new(code, details, metadata)
     end
 
     # Converts the exception to a deserialized {Google::Rpc::Status} object.

--- a/src/ruby/lib/grpc/generic/active_call.rb
+++ b/src/ruby/lib/grpc/generic/active_call.rb
@@ -207,7 +207,7 @@ module GRPC
                     metadata: {})
       send_initial_metadata
       ops = {
-        SEND_STATUS_FROM_SERVER => Struct::Status.new(code, details, metadata)
+        SEND_STATUS_FROM_SERVER => GRPC::Core::Status.new(code, details, metadata)
       }
       ops[RECV_CLOSE_ON_SERVER] = nil if assert_finished
       @call.run_batch(ops)
@@ -234,7 +234,7 @@ module GRPC
 
       payload = @marshal.call(req)
       ops[SEND_MESSAGE] = payload
-      ops[SEND_STATUS_FROM_SERVER] = Struct::Status.new(
+      ops[SEND_STATUS_FROM_SERVER] = GRPC::Core::Status.new(
         code, details, trailing_metadata)
       ops[RECV_CLOSE_ON_SERVER] = nil
 

--- a/src/ruby/lib/grpc/google_rpc_status_utils.rb
+++ b/src/ruby/lib/grpc/google_rpc_status_utils.rb
@@ -26,7 +26,7 @@ module GRPC
   # but they fail to deseriliaze into a GoogleRpcStatus protobuf.
   class GoogleRpcStatusUtils
     def self.extract_google_rpc_status(status)
-      fail ArgumentError, 'bad type' unless status.is_a? Struct::Status
+      fail ArgumentError, 'bad type' unless status.is_a? GRPC::Core::Status
       grpc_status_details_bin_trailer = 'grpc-status-details-bin'
       return nil if status.metadata[grpc_status_details_bin_trailer].nil?
       Google::Rpc::Status.decode(status.metadata[grpc_status_details_bin_trailer])

--- a/src/ruby/spec/call_spec.rb
+++ b/src/ruby/spec/call_spec.rb
@@ -91,7 +91,7 @@ describe GRPC::Core::Call do
   describe '#status' do
     it 'can save the status and read it back' do
       call = make_test_call
-      sts = Struct::Status.new(OK, 'OK')
+      sts = GRPC::Core::Status.new(OK, 'OK')
       expect { call.status = sts }.not_to raise_error
       expect(call.status).to eq(sts)
     end

--- a/src/ruby/spec/client_server_spec.rb
+++ b/src/ruby/spec/client_server_spec.rb
@@ -39,7 +39,7 @@ shared_context 'setup: tags' do
   end
 
   def ok_status
-    Struct::Status.new(StatusCodes::OK, 'OK')
+    GRPC::Core::Status.new(StatusCodes::OK, 'OK')
   end
 end
 
@@ -209,7 +209,7 @@ shared_examples 'basic GRPC message delivery is OK' do
     expect(client_batch.send_close).to be true
 
     # confirm the server can read the inbound message
-    the_status = Struct::Status.new(StatusCodes::OK, 'OK')
+    the_status = GRPC::Core::Status.new(StatusCodes::OK, 'OK')
     server_thread.join
     server_ops = {
       CallOps::SEND_STATUS_FROM_SERVER => the_status
@@ -242,7 +242,7 @@ shared_examples 'basic GRPC message delivery is OK' do
     expect(client_batch.send_message).to be true
 
     # confirm the server can read the inbound message and respond
-    the_status = Struct::Status.new(StatusCodes::OK, 'OK', {})
+    the_status = GRPC::Core::Status.new(StatusCodes::OK, 'OK', {})
     server_thread.join
     server_ops = {
       CallOps::RECV_MESSAGE => nil,

--- a/src/ruby/spec/errors_spec.rb
+++ b/src/ruby/spec/errors_spec.rb
@@ -71,7 +71,7 @@ describe GRPC::BadStatus do
       metadata = { 'key' => 'val' }
 
       exception = GRPC::BadStatus.new(code, details, metadata)
-      status = Struct::Status.new(code, details, metadata)
+      status = GRPC::Core::Status.new(code, details, metadata)
 
       expect(exception.to_status).to eq status
     end

--- a/src/ruby/spec/generic/active_call_spec.rb
+++ b/src/ruby/spec/generic/active_call_spec.rb
@@ -23,7 +23,7 @@ describe GRPC::ActiveCall do
   WriteFlags = GRPC::Core::WriteFlags
 
   def ok_status
-    Struct::Status.new(OK, 'OK')
+    GRPC::Core::Status.new(OK, 'OK')
   end
 
   def send_and_receive_close_and_status(client_call, server_call)

--- a/src/ruby/spec/generic/client_stub_spec.rb
+++ b/src/ruby/spec/generic/client_stub_spec.rb
@@ -64,7 +64,7 @@ end
 def sanity_check_values_of_accessors(op_view,
                                      expected_metadata,
                                      expected_trailing_metadata)
-  expected_status = Struct::Status.new
+  expected_status = GRPC::Core::Status.new
   expected_status.code = 0
   expected_status.details = 'OK'
   expected_status.metadata = expected_trailing_metadata

--- a/src/ruby/spec/google_rpc_status_utils_spec.rb
+++ b/src/ruby/spec/google_rpc_status_utils_spec.rb
@@ -41,7 +41,7 @@ describe 'conversion from a status struct to a google protobuf status' do
 
   it 'fails with some error if the header key fails to deserialize' do
     status = GRPC::Core::Status.new(1, 'details',
-                                'grpc-status-details-bin' => 'string_val')
+                                    'grpc-status-details-bin' => 'string_val')
     expect do
       GRPC::GoogleRpcStatusUtils.extract_google_rpc_status(status)
     end.to raise_error(StandardError)
@@ -52,7 +52,7 @@ describe 'conversion from a status struct to a google protobuf status' do
     proto = Google::Rpc::Status.new(code: 1, message: 'proto message')
     encoded_proto = Google::Rpc::Status.encode(proto)
     status = GRPC::Core::Status.new(1, 'struct message',
-                                'grpc-status-details-bin' => encoded_proto)
+                                    'grpc-status-details-bin' => encoded_proto)
     rpc_status = GRPC::GoogleRpcStatusUtils.extract_google_rpc_status(status)
     expect(rpc_status).to eq(proto)
   end
@@ -62,7 +62,7 @@ describe 'conversion from a status struct to a google protobuf status' do
     proto = Google::Rpc::Status.new(code: 1, message: 'matching message')
     encoded_proto = Google::Rpc::Status.encode(proto)
     status = GRPC::Core::Status.new(2, 'matching message',
-                                'grpc-status-details-bin' => encoded_proto)
+                                    'grpc-status-details-bin' => encoded_proto)
     rpc_status = GRPC::GoogleRpcStatusUtils.extract_google_rpc_status(status)
     expect(rpc_status).to eq(proto)
   end
@@ -72,7 +72,7 @@ describe 'conversion from a status struct to a google protobuf status' do
     proto = Google::Rpc::Status.new(code: 1, message: 'matching message')
     encoded_proto = Google::Rpc::Status.encode(proto)
     status = GRPC::Core::Status.new(1, 'matching message',
-                                'grpc-status-details-bin' => encoded_proto)
+                                    'grpc-status-details-bin' => encoded_proto)
     out = GRPC::GoogleRpcStatusUtils.extract_google_rpc_status(status)
     expect(out.code).to eq(1)
     expect(out.message).to eq('matching message')
@@ -101,7 +101,7 @@ describe 'conversion from a status struct to a google protobuf status' do
                                     ])
     encoded_proto = Google::Rpc::Status.encode(proto)
     status = GRPC::Core::Status.new(1, 'matching message',
-                                'grpc-status-details-bin' => encoded_proto)
+                                    'grpc-status-details-bin' => encoded_proto)
     out = GRPC::GoogleRpcStatusUtils.extract_google_rpc_status(status)
     expect(out.code).to eq(1)
     expect(out.message).to eq('matching message')

--- a/src/ruby/spec/google_rpc_status_utils_spec.rb
+++ b/src/ruby/spec/google_rpc_status_utils_spec.rb
@@ -33,14 +33,14 @@ describe 'conversion from a status struct to a google protobuf status' do
   end
 
   it 'returns nil if the header key is missing' do
-    status = Struct::Status.new(1, 'details', key: 'val')
+    status = GRPC::Core::Status.new(1, 'details', key: 'val')
     expect(status.metadata.nil?).to be false
     expect(GRPC::GoogleRpcStatusUtils.extract_google_rpc_status(
              status)).to be(nil)
   end
 
   it 'fails with some error if the header key fails to deserialize' do
-    status = Struct::Status.new(1, 'details',
+    status = GRPC::Core::Status.new(1, 'details',
                                 'grpc-status-details-bin' => 'string_val')
     expect do
       GRPC::GoogleRpcStatusUtils.extract_google_rpc_status(status)
@@ -51,7 +51,7 @@ describe 'conversion from a status struct to a google protobuf status' do
     'status struct and protobuf status' do
     proto = Google::Rpc::Status.new(code: 1, message: 'proto message')
     encoded_proto = Google::Rpc::Status.encode(proto)
-    status = Struct::Status.new(1, 'struct message',
+    status = GRPC::Core::Status.new(1, 'struct message',
                                 'grpc-status-details-bin' => encoded_proto)
     rpc_status = GRPC::GoogleRpcStatusUtils.extract_google_rpc_status(status)
     expect(rpc_status).to eq(proto)
@@ -61,7 +61,7 @@ describe 'conversion from a status struct to a google protobuf status' do
     'and protobuf status' do
     proto = Google::Rpc::Status.new(code: 1, message: 'matching message')
     encoded_proto = Google::Rpc::Status.encode(proto)
-    status = Struct::Status.new(2, 'matching message',
+    status = GRPC::Core::Status.new(2, 'matching message',
                                 'grpc-status-details-bin' => encoded_proto)
     rpc_status = GRPC::GoogleRpcStatusUtils.extract_google_rpc_status(status)
     expect(rpc_status).to eq(proto)
@@ -71,7 +71,7 @@ describe 'conversion from a status struct to a google protobuf status' do
     'when there are no rpcstatus details' do
     proto = Google::Rpc::Status.new(code: 1, message: 'matching message')
     encoded_proto = Google::Rpc::Status.encode(proto)
-    status = Struct::Status.new(1, 'matching message',
+    status = GRPC::Core::Status.new(1, 'matching message',
                                 'grpc-status-details-bin' => encoded_proto)
     out = GRPC::GoogleRpcStatusUtils.extract_google_rpc_status(status)
     expect(out.code).to eq(1)
@@ -100,7 +100,7 @@ describe 'conversion from a status struct to a google protobuf status' do
                                       payload_any
                                     ])
     encoded_proto = Google::Rpc::Status.encode(proto)
-    status = Struct::Status.new(1, 'matching message',
+    status = GRPC::Core::Status.new(1, 'matching message',
                                 'grpc-status-details-bin' => encoded_proto)
     out = GRPC::GoogleRpcStatusUtils.extract_google_rpc_status(status)
     expect(out.code).to eq(1)


### PR DESCRIPTION
It looks like the intention was to define these classes under `GRPC::Core::`, but they are currently being defined under `Struct::` (which is the default for `rb_struct_define`).

If you want this change to be 100% backwards compatible, we can also add the following aliases:

```ruby
Struct:: BatchResult  = GRPC::Core:: BatchResult
Struct:: NewServerRpc = GRPC::Core:: NewServerRpc
Struct:: Status       = GRPC::Core:: Status
```