### PR TITLE
Add a fast path to allocate slices in the resource quota.

### DIFF
--- a/src/core/lib/iomgr/endpoint_cfstream.cc
+++ b/src/core/lib/iomgr/endpoint_cfstream.cc
@@ -261,10 +261,12 @@ static void CFStreamRead(grpc_endpoint* ep, grpc_slice_buffer* slices,
   ep_impl->read_cb = cb;
   ep_impl->read_slices = slices;
   grpc_slice_buffer_reset_and_unref_internal(slices);
-  grpc_resource_user_alloc_slices(&ep_impl->slice_allocator,
-                                  GRPC_TCP_DEFAULT_READ_SLICE_SIZE, 1,
-                                  ep_impl->read_slices);
   EP_REF(ep_impl, "read");
+  if (grpc_resource_user_alloc_slices(&ep_impl->slice_allocator,
+                                      GRPC_TCP_DEFAULT_READ_SLICE_SIZE, 1,
+                                      ep_impl->read_slices)) {
+    ep_impl->stream_sync->NotifyOnRead(&ep_impl->read_action);
+  }
 }
 
 static void CFStreamWrite(grpc_endpoint* ep, grpc_slice_buffer* slices,

--- a/src/core/lib/iomgr/resource_quota.h
+++ b/src/core/lib/iomgr/resource_quota.h
@@ -124,13 +124,15 @@ bool grpc_resource_user_safe_alloc(grpc_resource_user* resource_user,
  * If optional_on_done is NULL, then allocate immediately. This may push the
  * quota over-limit, at which point reclamation will kick in. The caller is
  * always responsible to free the memory eventually.
- * If optional_on_done is non-NULL, it will be scheduled without error when the
- * allocation has been granted by the quota, and the caller is responsible to
- * free the memory eventually. Or it may be scheduled with an error, in which
- * case the caller fails to allocate the memory and shouldn't free the memory.
+ * Returns true if the allocation was successful. Otherwise, if optional_on_done
+ * is non-NULL, it will be scheduled without error when the allocation has been
+ * granted by the quota, and the caller is responsible to free the memory
+ * eventually. Or it may be scheduled with an error, in which case the caller
+ * fails to allocate the memory and shouldn't free the memory.
  */
-void grpc_resource_user_alloc(grpc_resource_user* resource_user, size_t size,
-                              grpc_closure* optional_on_done);
+bool grpc_resource_user_alloc(grpc_resource_user* resource_user, size_t size,
+                              grpc_closure* optional_on_done)
+    GRPC_MUST_USE_RESULT;
 /* Release memory back to the quota */
 void grpc_resource_user_free(grpc_resource_user* resource_user, size_t size);
 /* Post a memory reclaimer to the resource user. Only one benign and one
@@ -165,9 +167,11 @@ void grpc_resource_user_slice_allocator_init(
     grpc_resource_user* resource_user, grpc_iomgr_cb_func cb, void* p);
 
 /* Allocate \a count slices of length \a length into \a dest. Only one request
-   can be outstanding at a time. */
-void grpc_resource_user_alloc_slices(
+   can be outstanding at a time.
+   Returns whether the slice was allocated inline in the function. If true,
+   the callback will not be called. */
+bool grpc_resource_user_alloc_slices(
     grpc_resource_user_slice_allocator* slice_allocator, size_t length,
-    size_t count, grpc_slice_buffer* dest);
+    size_t count, grpc_slice_buffer* dest) GRPC_MUST_USE_RESULT;
 
 #endif /* GRPC_CORE_LIB_IOMGR_RESOURCE_QUOTA_H */

--- a/src/core/lib/iomgr/resource_quota.h
+++ b/src/core/lib/iomgr/resource_quota.h
@@ -169,7 +169,7 @@ void grpc_resource_user_slice_allocator_init(
 /* Allocate \a count slices of length \a length into \a dest. Only one request
    can be outstanding at a time.
    Returns whether the slice was allocated inline in the function. If true,
-   the callback will not be called. */
+   the \a slice_allocator->on_allocated callback will not be called. */
 bool grpc_resource_user_alloc_slices(
     grpc_resource_user_slice_allocator* slice_allocator, size_t length,
     size_t count, grpc_slice_buffer* dest) GRPC_MUST_USE_RESULT;

--- a/src/core/lib/iomgr/tcp_custom.cc
+++ b/src/core/lib/iomgr/tcp_custom.cc
@@ -201,9 +201,11 @@ static void endpoint_read(grpc_endpoint* ep, grpc_slice_buffer* read_slices,
   tcp->read_slices = read_slices;
   grpc_slice_buffer_reset_and_unref_internal(read_slices);
   TCP_REF(tcp, "read");
-  grpc_resource_user_alloc_slices(&tcp->slice_allocator,
-                                  GRPC_TCP_DEFAULT_READ_SLICE_SIZE, 1,
-                                  tcp->read_slices);
+  if (grpc_resource_user_alloc_slices(&tcp->slice_allocator,
+                                      GRPC_TCP_DEFAULT_READ_SLICE_SIZE, 1,
+                                      tcp->read_slices)) {
+    tcp_read_allocation_done(tcp, GRPC_ERROR_NONE);
+  }
 }
 
 static void custom_write_callback(grpc_custom_socket* socket,

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -571,7 +571,7 @@ static void tcp_read_allocation_done(void* tcpp, grpc_error* error) {
     gpr_log(GPR_INFO, "TCP:%p read_allocation_done: %s", tcp,
             grpc_error_string(error));
   }
-  if (error != GRPC_ERROR_NONE) {
+  if (GPR_UNLIKELY(error != GRPC_ERROR_NONE)) {
     grpc_slice_buffer_reset_and_unref_internal(tcp->incoming_buffer);
     grpc_slice_buffer_reset_and_unref_internal(&tcp->last_read_buffer);
     call_read_cb(tcp, GRPC_ERROR_REF(error));
@@ -589,14 +589,17 @@ static void tcp_continue_read(grpc_tcp* tcp) {
     if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
       gpr_log(GPR_INFO, "TCP:%p alloc_slices", tcp);
     }
-    grpc_resource_user_alloc_slices(&tcp->slice_allocator, target_read_size, 1,
-                                    tcp->incoming_buffer);
-  } else {
-    if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
-      gpr_log(GPR_INFO, "TCP:%p do_read", tcp);
+    if (GPR_UNLIKELY(!grpc_resource_user_alloc_slices(&tcp->slice_allocator,
+                                                      target_read_size, 1,
+                                                      tcp->incoming_buffer))) {
+      // Wait for allocation.
+      return;
     }
-    tcp_do_read(tcp);
   }
+  if (GRPC_TRACE_FLAG_ENABLED(grpc_tcp_trace)) {
+    gpr_log(GPR_INFO, "TCP:%p do_read", tcp);
+  }
+  tcp_do_read(tcp);
 }
 
 static void tcp_handle_read(void* arg /* grpc_tcp */, grpc_error* error) {
@@ -605,7 +608,7 @@ static void tcp_handle_read(void* arg /* grpc_tcp */, grpc_error* error) {
     gpr_log(GPR_INFO, "TCP:%p got_read: %s", tcp, grpc_error_string(error));
   }
 
-  if (error != GRPC_ERROR_NONE) {
+  if (GPR_UNLIKELY(error != GRPC_ERROR_NONE)) {
     grpc_slice_buffer_reset_and_unref_internal(tcp->incoming_buffer);
     grpc_slice_buffer_reset_and_unref_internal(&tcp->last_read_buffer);
     call_read_cb(tcp, GRPC_ERROR_REF(error));


### PR DESCRIPTION
Currently, we are always scheduling a callback to run the allocation.
Instead, this patch adds a fastpath so that TCP can read the socket inline,
instead of waiting for the exec context to flush.

```
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/64/2         [polls/iter:12         ]  65.3µs ± 0%   64.7µs ± 1% -0.92%   (p=0.032 n=4+5)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/2       [polls/iter:12.0002    ]  61.4µs ± 4%   57.3µs ±13% -6.66%   (p=0.030 n=5+7)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/1/2       [polls/iter:12.0002    ]  61.7µs ± 1%   60.8µs ± 1% -1.49%   (p=0.003 n=9+4)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/32768/2   [polls/iter:12.0002    ]   114µs ± 2%   112µs ± 0%  -2.09%   (p=0.030 n=10+2)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/1/2          [polls/iter:12.0002    ]  62.9µs ± 0%   62.0µs ± 1% -1.32%   (p=0.001 n=7+6)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/64/2         [polls/iter:12.0002    ]  66.5µs ± 3%   64.4µs ± 1% -3.20%   (p=0.016 n=5+4)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/512/2        [polls/iter:12         ]  66.1µs ± 1%   65.2µs ± 1% -1.30%   (p=0.003 n=8+5)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/4096/2       [polls/iter:12         ]  72.1µs ± 4%   70.8µs ± 1% -1.92%   (p=0.004 n=9+5)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/2       [polls/iter:12.0001    ]  60.4µs ± 1%   59.4µs ± 0% -1.55%   (p=0.004 n=6+5)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/8/2          [polls/iter:12         ]  63.6µs ± 1%   62.2µs ± 1% -2.13%   (p=0.001 n=7+6)
BM_StreamingPingPongMsgs<TCP, NoOpMutator, NoOpMutator>/4096     [polls/iter:4.00008    ]  20.9µs ± 1%   19.8µs ±13% -5.30%   (p=0.029 n=4+4)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/1       [polls/iter:8.00014    ]  44.4µs ± 1%   41.9µs ±13% -5.51%   (p=0.010 n=6+4)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/8/2       [polls/iter:12.0001    ]  62.1µs ± 0%   61.1µs ± 1% -1.56%   (p=0.036 n=3+5)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/64/2      [polls/iter:12.0002    ]  64.0µs ± 0%   63.3µs ± 0% -1.14%   (p=0.004 n=5+6)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/1/2       [polls/iter:12         ]  62.0µs ± 1%   61.0µs ± 1% -1.61%   (p=0.032 n=4+5)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/0/2          [polls/iter:12.0002    ]  62.4µs ± 4%   60.6µs ± 1% -2.82%   (p=0.003 n=7+5)
BM_StreamingPingPongMsgs<TCP, NoOpMutator, NoOpMutator>/512      [polls/iter:4.00009    ]  17.9µs ± 1%   16.5µs ±11% -7.40%   (p=0.032 n=4+5)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/4096/1       [polls/iter:8.00016    ]  50.2µs ± 0%   49.5µs ± 1% -1.46%   (p=0.024 n=3+6)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/512/2     [polls/iter:12.0002    ]  65.5µs ± 3%   61.9µs ±13% -5.59%   (p=0.048 n=5+7)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/0           [polls/iter:3.00009    ]  23.4µs ± 2%   23.0µs ± 0% -1.88%   (p=0.036 n=3+5)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/512/0            [polls/iter:3.0001     ]  25.6µs ± 2%   25.0µs ± 0% -2.44%   (p=0.017 n=7+3)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/262144/0         [polls/iter:3.00022    ]   164µs ± 2%   161µs ± 1%  -1.83%   (p=0.048 n=3+6)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/19933)
<!-- Reviewable:end -->
