### PR TITLE
Define Struct::Status in Ruby

### DIFF
--- a/src/ruby/end2end/errors_load_before_grpc_lib.rb
+++ b/src/ruby/end2end/errors_load_before_grpc_lib.rb
@@ -18,12 +18,32 @@ this_dir = File.expand_path(File.dirname(__FILE__))
 grpc_lib_dir = File.join(File.dirname(this_dir), 'lib')
 $LOAD_PATH.unshift(grpc_lib_dir) unless $LOAD_PATH.include?(grpc_lib_dir)
 
+def check_to_status(error)
+  my_status = error.to_status
+  fail('GRPC BadStatus#to_status not expected to return nil') if my_status.nil?
+  fail('GRPC BadStatus#to_status code expected to be 2') unless my_status.code == 2
+  fail('GRPC BadStatus#to_status details expected to be unknown') unless my_status.details == 'unknown'
+  fail('GRPC BadStatus#to_status metadata expected to be empty hash') unless my_status.metadata == {}
+  fail('GRPC library loaded after BadStatus#to_status') if GRPC::Core.const_defined?(:Channel)
+end
+
+def check_to_rpc_status(error)
+  my_rpc_status = error.to_rpc_status
+  fail('GRPC BadStatus#to_rpc_status expected to return nil') unless my_rpc_status.nil?
+  fail('GRPC library loaded after BadStatus#to_rpc_status') if GRPC::Core.const_defined?(:Channel)
+end
+
 def main
   fail('GRPC constant loaded before expected') if Object.const_defined?(:GRPC)
   require 'grpc/errors'
   fail('GRPC constant not loaded when expected') unless Object.const_defined?(:GRPC)
   fail('GRPC BadStatus not loaded after required') unless GRPC.const_defined?(:BadStatus)
+  fail('GRPC Core not loaded after required') unless GRPC.const_defined?(:Core)
+  fail('GRPC StatusCodes not loaded after required') unless GRPC::Core.const_defined?(:StatusCodes)
   fail('GRPC library loaded before required') if GRPC::Core.const_defined?(:Channel)
+  error = GRPC::BadStatus.new 2, 'unknown'
+  check_to_status(error)
+  check_to_rpc_status(error)
   require 'grpc'
   fail('GRPC library not loaded after required') unless GRPC::Core.const_defined?(:Channel)
 end

--- a/src/ruby/ext/grpc/rb_grpc.c
+++ b/src/ruby/ext/grpc/rb_grpc.c
@@ -312,8 +312,7 @@ void Init_grpc_c() {
   grpc_rb_mGrpcCore = rb_define_module_under(grpc_rb_mGRPC, "Core");
   grpc_rb_sNewServerRpc = rb_struct_define(
       "NewServerRpc", "method", "host", "deadline", "metadata", "call", NULL);
-  grpc_rb_sStatus =
-      rb_struct_define("Status", "code", "details", "metadata", NULL);
+  grpc_rb_sStatus = rb_const_get(rb_cStruct, rb_intern("Status"));
   sym_code = ID2SYM(rb_intern("code"));
   sym_details = ID2SYM(rb_intern("details"));
   sym_metadata = ID2SYM(rb_intern("metadata"));

--- a/src/ruby/lib/grpc.rb
+++ b/src/ruby/lib/grpc.rb
@@ -15,6 +15,7 @@
 ssl_roots_path = File.expand_path('../../../../etc/roots.pem', __FILE__)
 
 require_relative 'grpc/errors'
+require_relative 'grpc/structs'
 require_relative 'grpc/grpc'
 require_relative 'grpc/logconfig'
 require_relative 'grpc/notifier'

--- a/src/ruby/lib/grpc/errors.rb
+++ b/src/ruby/lib/grpc/errors.rb
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require_relative './structs'
 require_relative './core/status_codes'
+require_relative './google_rpc_status_utils'
 
 # GRPC contains the General RPC module.
 module GRPC
@@ -57,12 +59,7 @@ module GRPC
     #
     # @return [Google::Rpc::Status, nil]
     def to_rpc_status
-      # Lazily require google_rpc_status_utils to scope
-      # loading protobuf_c.so to the users of this method.
-      require_relative './google_rpc_status_utils'
-      status = to_status
-      return if status.nil?
-      GoogleRpcStatusUtils.extract_google_rpc_status(status)
+      GoogleRpcStatusUtils.extract_google_rpc_status(to_status)
     rescue Google::Protobuf::ParseError => parse_error
       GRPC.logger.warn('parse error: to_rpc_status failed')
       GRPC.logger.warn(parse_error)

--- a/src/ruby/lib/grpc/google_rpc_status_utils.rb
+++ b/src/ruby/lib/grpc/google_rpc_status_utils.rb
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative './grpc'
-require 'google/rpc/status_pb'
+require_relative './structs'
 
 # GRPC contains the General RPC module.
 module GRPC
@@ -28,8 +27,14 @@ module GRPC
     def self.extract_google_rpc_status(status)
       fail ArgumentError, 'bad type' unless status.is_a? Struct::Status
       grpc_status_details_bin_trailer = 'grpc-status-details-bin'
-      return nil if status.metadata[grpc_status_details_bin_trailer].nil?
-      Google::Rpc::Status.decode(status.metadata[grpc_status_details_bin_trailer])
+      binstatus = status.metadata[grpc_status_details_bin_trailer]
+      return nil if binstatus.nil?
+
+      # Lazily load grpc_c and protobuf_c.so for users of this method.
+      require_relative './grpc'
+      require 'google/rpc/status_pb'
+
+      Google::Rpc::Status.decode(binstatus)
     end
   end
 end

--- a/src/ruby/lib/grpc/structs.rb
+++ b/src/ruby/lib/grpc/structs.rb
@@ -1,0 +1,15 @@
+# Copyright 2015 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Struct.new('Status', :code, :details, :metadata)

--- a/src/ruby/spec/errors_spec.rb
+++ b/src/ruby/spec/errors_spec.rb
@@ -14,6 +14,7 @@
 
 require 'spec_helper'
 require 'google/protobuf/well_known_types'
+require 'google/rpc/status_pb'
 require_relative '../pb/src/proto/grpc/testing/messages_pb'
 
 describe GRPC::BadStatus do


### PR DESCRIPTION
This change defines `Struct::Status` in Ruby instead of in `grpc_c`. This corrects an issue with `GRPC::BadStatus` still depending on `grpc_c` that was discussed in https://github.com/grpc/grpc/pull/19893#issuecomment-521006344.