### PR TITLE
Demonstrate thread local issues on Mac OS and iOS.

### DIFF
--- a/src/core/lib/gpr/tls_pthread.cc
+++ b/src/core/lib/gpr/tls_pthread.cc
@@ -18,13 +18,47 @@
 
 #include <grpc/support/port_platform.h>
 
+#include <errno.h>
+#include <grpc/support/time.h>
+
 #ifdef GPR_PTHREAD_TLS
 
 #include "src/core/lib/gpr/tls.h"
 
 intptr_t gpr_tls_set(struct gpr_pthread_thread_local* tls, intptr_t value) {
-  GPR_ASSERT(0 == pthread_setspecific(tls->key, (void*)value));
+  int ret= pthread_setspecific(tls->key, (void*)value);
+  if (ret != 0) {
+    gpr_log(GPR_ERROR, "pthread_setspecific(0x%lx) returned %d", tls->key, ret);
+  }
+  GPR_ASSERT(0 == ret);
+  gpr_log(GPR_ERROR, "pthread_setspecific(0x%lx)", tls->key);
   return value;
+}
+
+void gpr_tls_init(struct gpr_pthread_thread_local* tls) {
+  int ret;
+  do {
+    ret = pthread_key_create(&(tls)->key, NULL);
+    if (ret != 0) {
+      gpr_log(GPR_ERROR, "pthread_key_create returned %d", ret);
+    }
+    GPR_ASSERT(0 == ret || EAGAIN == ret);
+    if (ret == EAGAIN) {
+      gpr_sleep_until(gpr_time_add(gpr_now(GPR_CLOCK_MONOTONIC),
+                                   gpr_time_from_millis(100, GPR_TIMESPAN)));
+    }
+  } while (ret == EAGAIN);
+
+  gpr_log(GPR_ERROR, "pthread_key_create(0x%lx)", tls->key);
+}
+
+int gpr_tls_destroy(struct gpr_pthread_thread_local* tls) {
+  gpr_log(GPR_ERROR, "pthread_key_delete(0x%lx)", tls->key);
+  int ret = pthread_key_delete((tls)->key);
+  if (ret != 0) {
+    gpr_log(GPR_ERROR, "pthread_key_delete(0x%lx) returned %d", tls->key, ret);
+  }
+  return ret;
 }
 
 #endif /* GPR_PTHREAD_TLS */

--- a/src/core/lib/gpr/tls_pthread.h
+++ b/src/core/lib/gpr/tls_pthread.h
@@ -42,13 +42,13 @@ struct gpr_pthread_thread_local {
  *  GPR_TLS_CLASS_DEF needs to be called to define this member. */
 #define GPR_TLS_CLASS_DEF(name) struct gpr_pthread_thread_local name = {0}
 
-#define gpr_tls_init(tls) GPR_ASSERT(0 == pthread_key_create(&(tls)->key, NULL))
-#define gpr_tls_destroy(tls) pthread_key_delete((tls)->key)
 #define gpr_tls_get(tls) ((intptr_t)pthread_getspecific((tls)->key))
 #ifdef __cplusplus
 extern "C" {
 #endif
+void gpr_tls_init(struct gpr_pthread_thread_local* tls);
 intptr_t gpr_tls_set(struct gpr_pthread_thread_local* tls, intptr_t value);
+int gpr_tls_destroy(struct gpr_pthread_thread_local* tls);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- Log errors returned by the following:
  - `pthread_key_create`
  - `pthread_setspecific`
  - `pthread_key_delete`
- Retry `pthread_key_create` when it returns EAGAIN
