### PR TITLE
Ignore Visual Studio Code configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,10 +139,6 @@ bm_*.json
 
 # Visual Studio Code artifacts
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
 
 # Clion artifacts
 cmake-build-debug/


### PR DESCRIPTION
I see the `.vscode/` is added to `gitignore`, but I wonder what is the reason to keep those `.json` files. After all, they are the places to store per-project configurations.

As a VS Code user, I hope to ignore them, and keep those files local.

Previous PR: #18792