### PR TITLE
Enforce abstract class rule

### DIFF
--- a/test/core/util/test_lb_policies.cc
+++ b/test/core/util/test_lb_policies.cc
@@ -233,6 +233,11 @@ class InterceptTrailingFactory : public LoadBalancingPolicyFactory {
     return kInterceptRecvTrailingMetadataLbPolicyName;
   }
 
+  RefCountedPtr<LoadBalancingPolicy::Config> ParseLoadBalancingConfig(
+      const grpc_json* json, grpc_error** error) const override {
+    return nullptr;
+  }
+
  private:
   InterceptRecvTrailingMetadataCallback cb_;
   void* user_data_;


### PR DESCRIPTION
Abstract class cannot be instantiated but there are some cases to do that because it hasn't been strictly enforced by a compiler. This is because `GRPC_ABSTRACT` has been used instead of `= 0`. As a result, some classes with pure virtual functions happen to be instantiated even though it's actually impossible with `= 0`. This is a fix PR to make C++ compliant code by either adding missing virtual functions or sub-classing the abstract class. 