### PR TITLE
Gracefully handle exceptions raised by signal handlers on the main thread while unary RPCs are in flight.

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
@@ -472,6 +472,9 @@ cdef class Channel:
       queue_deadline = time.time() + 1.0
     else:
       queue_deadline = None
+    # NOTE(gnossen): It is acceptable for on_failure to be None here because
+    # failure conditions can only ever happen on the main thread and this
+    # method is only ever invoked on the channel spin thread.
     return _next_call_event(self._state, self._state.c_call_completion_queue,
                             on_success, None, queue_deadline)
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
@@ -165,6 +165,8 @@ cdef _next_call_event(
   """
   try:
     tag, event = _latent_event(c_completion_queue, deadline)
+  # NOTE(rbellevi): This broad except enables us to clean up resources before
+  # propagating any exceptions raised by signal handlers to the application.
   except:
     if on_failure is not None:
       on_failure()

--- a/src/python/grpcio_tests/tests/unit/_signal_client.py
+++ b/src/python/grpcio_tests/tests/unit/_signal_client.py
@@ -79,11 +79,12 @@ def main_unary_with_exception(server_target):
     try:
         channel.unary_unary(UNARY_UNARY)(_MESSAGE, wait_for_ready=True)
     except KeyboardInterrupt:
-        sys.stderr.write("Running signal handler.\n"); sys.stderr.flush()
+        sys.stderr.write("Running signal handler.\n")
+        sys.stderr.flush()
 
-    sys.stderr.write("Calling Channel.close()"); sys.stderr.flush()
     # This call should not hang.
     channel.close()
+
 
 def main_streaming_with_exception(server_target):
     """Initiate an RPC with wait_for_ready set and no server backing the RPC."""
@@ -91,19 +92,20 @@ def main_streaming_with_exception(server_target):
     try:
         channel.unary_stream(UNARY_STREAM)(_MESSAGE, wait_for_ready=True)
     except KeyboardInterrupt:
-        sys.stderr.write("Running signal handler.\n"); sys.stderr.flush()
+        sys.stderr.write("Running signal handler.\n")
+        sys.stderr.flush()
 
-    sys.stderr.write("Calling Channel.close()"); sys.stderr.flush()
     # This call should not hang.
     channel.close()
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Signal test client.')
     parser.add_argument('server', help='Server target')
+    parser.add_argument('arity', help='Arity', choices=('unary', 'streaming'))
     parser.add_argument(
-        'arity', help='Arity', choices=('unary', 'streaming'))
-    parser.add_argument(
-        '--exception', help='Whether the signal throws an exception',
+        '--exception',
+        help='Whether the signal throws an exception',
         action='store_true')
     args = parser.parse_args()
     if args.arity == 'unary' and not args.exception:

--- a/src/python/grpcio_tests/tests/unit/_signal_client.py
+++ b/src/python/grpcio_tests/tests/unit/_signal_client.py
@@ -74,7 +74,7 @@ def main_streaming(server_target):
 
 
 def main_unary_with_exception(server_target):
-    """Initiate an RPC with wait_for_ready set and no server backing the RPC."""
+    """Initiate a unary RPC with a signal handler that will raise."""
     channel = grpc.insecure_channel(server_target)
     try:
         channel.unary_unary(UNARY_UNARY)(_MESSAGE, wait_for_ready=True)
@@ -87,7 +87,7 @@ def main_unary_with_exception(server_target):
 
 
 def main_streaming_with_exception(server_target):
-    """Initiate an RPC with wait_for_ready set and no server backing the RPC."""
+    """Initiate a streaming RPC with a signal handler that will raise."""
     channel = grpc.insecure_channel(server_target)
     try:
         channel.unary_stream(UNARY_STREAM)(_MESSAGE, wait_for_ready=True)

--- a/src/python/grpcio_tests/tests/unit/_signal_client.py
+++ b/src/python/grpcio_tests/tests/unit/_signal_client.py
@@ -90,7 +90,8 @@ def main_streaming_with_exception(server_target):
     """Initiate a streaming RPC with a signal handler that will raise."""
     channel = grpc.insecure_channel(server_target)
     try:
-        channel.unary_stream(UNARY_STREAM)(_MESSAGE, wait_for_ready=True)
+        for _ in channel.unary_stream(UNARY_STREAM)(_MESSAGE, wait_for_ready=True):
+            pass
     except KeyboardInterrupt:
         sys.stderr.write("Running signal handler.\n")
         sys.stderr.flush()

--- a/src/python/grpcio_tests/tests/unit/_signal_client.py
+++ b/src/python/grpcio_tests/tests/unit/_signal_client.py
@@ -90,7 +90,8 @@ def main_streaming_with_exception(server_target):
     """Initiate a streaming RPC with a signal handler that will raise."""
     channel = grpc.insecure_channel(server_target)
     try:
-        for _ in channel.unary_stream(UNARY_STREAM)(_MESSAGE, wait_for_ready=True):
+        for _ in channel.unary_stream(UNARY_STREAM)(
+                _MESSAGE, wait_for_ready=True):
             pass
     except KeyboardInterrupt:
         sys.stderr.write("Running signal handler.\n")

--- a/src/python/grpcio_tests/tests/unit/_signal_client.py
+++ b/src/python/grpcio_tests/tests/unit/_signal_client.py
@@ -45,6 +45,7 @@ def handle_sigint(unused_signum, unused_frame):
     if per_process_rpc_future is not None:
         per_process_rpc_future.cancel()
     sys.stderr.flush()
+    # This sys.exit(0) avoids an exception caused by the cancelled RPC.
     sys.exit(0)
 
 
@@ -72,13 +73,44 @@ def main_streaming(server_target):
         assert False, _ASSERTION_MESSAGE
 
 
+def main_unary_with_exception(server_target):
+    """Initiate an RPC with wait_for_ready set and no server backing the RPC."""
+    channel = grpc.insecure_channel(server_target)
+    try:
+        channel.unary_unary(UNARY_UNARY)(_MESSAGE, wait_for_ready=True)
+    except KeyboardInterrupt:
+        sys.stderr.write("Running signal handler.\n"); sys.stderr.flush()
+
+    sys.stderr.write("Calling Channel.close()"); sys.stderr.flush()
+    # This call should not hang.
+    channel.close()
+
+def main_streaming_with_exception(server_target):
+    """Initiate an RPC with wait_for_ready set and no server backing the RPC."""
+    channel = grpc.insecure_channel(server_target)
+    try:
+        channel.unary_stream(UNARY_STREAM)(_MESSAGE, wait_for_ready=True)
+    except KeyboardInterrupt:
+        sys.stderr.write("Running signal handler.\n"); sys.stderr.flush()
+
+    sys.stderr.write("Calling Channel.close()"); sys.stderr.flush()
+    # This call should not hang.
+    channel.close()
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Signal test client.')
     parser.add_argument('server', help='Server target')
     parser.add_argument(
-        'arity', help='RPC arity', choices=('unary', 'streaming'))
+        'arity', help='Arity', choices=('unary', 'streaming'))
+    parser.add_argument(
+        '--exception', help='Whether the signal throws an exception',
+        action='store_true')
     args = parser.parse_args()
-    if args.arity == 'unary':
+    if args.arity == 'unary' and not args.exception:
         main_unary(args.server)
-    else:
+    elif args.arity == 'streaming' and not args.exception:
         main_streaming(args.server)
+    elif args.arity == 'unary' and args.exception:
+        main_unary_with_exception(args.server)
+    else:
+        main_streaming_with_exception(args.server)

--- a/src/python/grpcio_tests/tests/unit/_signal_handling_test.py
+++ b/src/python/grpcio_tests/tests/unit/_signal_handling_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Test of responsiveness to signals."""
 
-import contextlib
 import logging
 import os
 import signal
@@ -21,7 +20,6 @@ import subprocess
 import tempfile
 import threading
 import unittest
-import socket
 import sys
 
 import grpc
@@ -185,8 +183,9 @@ class SignalHandlingTest(unittest.TestCase):
         server_target = '{}:{}'.format(_HOST, self._port)
         with tempfile.TemporaryFile(mode='r') as client_stdout:
             with tempfile.TemporaryFile(mode='r') as client_stderr:
-                client = _start_client(('--exception', server_target, 'streaming'),
-                                       client_stdout, client_stderr)
+                client = _start_client(
+                    ('--exception', server_target, 'streaming'), client_stdout,
+                    client_stderr)
                 self._handler.await_connected_client()
                 client.send_signal(signal.SIGINT)
                 client.wait()

--- a/src/python/grpcio_tests/tests/unit/_signal_handling_test.py
+++ b/src/python/grpcio_tests/tests/unit/_signal_handling_test.py
@@ -191,3 +191,8 @@ class SignalHandlingTest(unittest.TestCase):
                 client.wait()
                 print(_read_stream(client_stderr))
                 self.assertEqual(0, client.returncode)
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    unittest.main(verbosity=2)

--- a/src/python/grpcio_tests/tests/unit/_signal_handling_test.py
+++ b/src/python/grpcio_tests/tests/unit/_signal_handling_test.py
@@ -168,54 +168,27 @@ class SignalHandlingTest(unittest.TestCase):
                 self.assertIn(_signal_client.SIGTERM_MESSAGE,
                               client_stdout.read())
 
-
-@contextlib.contextmanager
-def _get_free_loopback_tcp_port():
-    sock = socket.socket(socket.AF_INET6)
-    sock.bind(('', 0))
-    address_tuple = sock.getsockname()
-    try:
-        yield "[::1]:%s" % (address_tuple[1])
-    finally:
-        sock.close()
-
-
-# TODO(gnossen): Consider combining classes.
-class SignalHandlingTestWithoutServer(unittest.TestCase):
-
     @unittest.skipIf(os.name == 'nt', 'SIGINT not supported on windows')
-    def testUnaryHandlerWithException(self):
-        with _get_free_loopback_tcp_port() as server_target:
-            with tempfile.TemporaryFile(mode='r') as client_stdout:
-                with tempfile.TemporaryFile(mode='r') as client_stderr:
-                    client = _start_client(('--exception', server_target, 'unary'),
-                                           client_stdout, client_stderr)
-                    # TODO(rbellevi): Figure out a way to determininstically hook
-                    # in here.
-                    import time; time.sleep(1)
-                    client.send_signal(signal.SIGINT)
-                    client.wait()
-                    print(_read_stream(client_stderr))
-                    self.assertEqual(0, client.returncode)
+    def testUnaryWithException(self):
+        server_target = '{}:{}'.format(_HOST, self._port)
+        with tempfile.TemporaryFile(mode='r') as client_stdout:
+            with tempfile.TemporaryFile(mode='r') as client_stderr:
+                client = _start_client(('--exception', server_target, 'unary'),
+                                       client_stdout, client_stderr)
+                self._handler.await_connected_client()
+                client.send_signal(signal.SIGINT)
+                client.wait()
+                self.assertEqual(0, client.returncode)
 
     @unittest.skipIf(os.name == 'nt', 'SIGINT not supported on windows')
     def testStreamingHandlerWithException(self):
-        with _get_free_loopback_tcp_port() as server_target:
-            with tempfile.TemporaryFile(mode='r') as client_stdout:
-                with tempfile.TemporaryFile(mode='r') as client_stderr:
-                    client = _start_client(('--exception', server_target, 'streaming'),
-                                           client_stdout, client_stderr)
-                    # TODO(rbellevi): Figure out a way to deterministically hook
-                    # in here.
-                    import time; time.sleep(1)
-                    client.send_signal(signal.SIGINT)
-                    client.wait()
-                    print(_read_stream(client_stderr))
-                    self.assertEqual(0, client.returncode)
-
-
-
-
-if __name__ == '__main__':
-    logging.basicConfig()
-    unittest.main(verbosity=2)
+        server_target = '{}:{}'.format(_HOST, self._port)
+        with tempfile.TemporaryFile(mode='r') as client_stdout:
+            with tempfile.TemporaryFile(mode='r') as client_stderr:
+                client = _start_client(('--exception', server_target, 'streaming'),
+                                       client_stdout, client_stderr)
+                self._handler.await_connected_client()
+                client.send_signal(signal.SIGINT)
+                client.wait()
+                print(_read_stream(client_stderr))
+                self.assertEqual(0, client.returncode)


### PR DESCRIPTION
This fixes https://github.com/grpc/grpc/issues/19973