### PR TITLE
use stricter memory order in client_idle_filter

### DIFF
--- a/src/core/ext/filters/client_idle/client_idle_filter.cc
+++ b/src/core/ext/filters/client_idle/client_idle_filter.cc
@@ -320,7 +320,7 @@ void ChannelData::IdleTimerCallback(void* arg, grpc_error* error) {
         // EnterIdle() operation finishes, preventing mistakenly entering IDLE
         // when active RPC exists.
         finished = chand->state_.CompareExchangeWeak(
-            &state, PROCESSING, MemoryOrder::RELAXED, MemoryOrder::RELAXED);
+            &state, PROCESSING, MemoryOrder::ACQUIRE, MemoryOrder::RELAXED);
         if (finished) {
           chand->EnterIdle();
           chand->state_.Store(IDLE, MemoryOrder::RELAXED);


### PR DESCRIPTION
In `IdleTimerCallback()`, to change the state from TIMER_PENDING to IDLE, we are going to use ACQUIRE memory order instead of RELAXED.
Because TIMER_PENDING is the state RELEASE-stored by `DecreaseCallCount()`, which sets the non-atomic variable `last_idle_time_` and guards it by RELEASE storing. So to change this state, we would better use ACQUIRE to prevent the following writes to `last_idle_time_` being reordered ahead.
Here is the case I'm concerning about. Consider this part of the state machine.
```
  ---> Triggered by IncreaseCallCount()
  ===> Triggered by DecreaseCallCount()
  ***> Triggered by IdleTimerCallback()

                                            IDLE
                                            |  ^
            ---------------------------------  *
            |                                  *
            v                                  *
      CALLS_ACTIVE =================> TIMER_PENDING
```
- Thread 1 calls `DecreaseCallCount()`, writing `Now()` to `last_idle_time_` and setting the state from CALLS_ACTIVE to TIMER_PENDING.
- Thread 2 executes `IdleTimerCallback()`, setting the state from TIMER_PENDING to IDLE.
- Thread 2 calls `IncreaseCallCount()`, setting the state from IDLE to CALLS_ACTIVE.
- Thread 2 calls `DecreaseCallCount()`, writting `Now()` to `last_idle_time_`. However, this write is not guarded by any AQCUIRE load, so it might be reordered ahead, even before the previous write to `last_idle_time_`.

I don't think this can really happen. But since we have already used ACQUIRE in `IncreaseCallCount()`(line 228) and `IdleTimerCallback()`(line 338), for consistency and safety, let's use ACQUIRE in line 323 without any harm to the performance.