### PR TITLE
Add run: false to grpclb_fallback_test in build.yaml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2381,8 +2381,6 @@ test_cxx: buildtests_cxx
 	$(Q) $(BINDIR)/$(CONFIG)/grpclb_api_test || ( echo test grpclb_api_test failed ; exit 1 )
 	$(E) "[RUN]     Testing grpclb_end2end_test"
 	$(Q) $(BINDIR)/$(CONFIG)/grpclb_end2end_test || ( echo test grpclb_end2end_test failed ; exit 1 )
-	$(E) "[RUN]     Testing grpclb_fallback_test"
-	$(Q) $(BINDIR)/$(CONFIG)/grpclb_fallback_test || ( echo test grpclb_fallback_test failed ; exit 1 )
 	$(E) "[RUN]     Testing h2_ssl_cert_test"
 	$(Q) $(BINDIR)/$(CONFIG)/h2_ssl_cert_test || ( echo test h2_ssl_cert_test failed ; exit 1 )
 	$(E) "[RUN]     Testing h2_ssl_session_reuse_test"

--- a/build.yaml
+++ b/build.yaml
@@ -5170,6 +5170,7 @@ targets:
   - gpr
 - name: grpclb_fallback_test
   build: test
+  run: false
   language: c++
   src:
   - src/proto/grpc/testing/empty.proto

--- a/tools/run_tests/generated/tests.json
+++ b/tools/run_tests/generated/tests.json
@@ -4911,24 +4911,6 @@
     "args": [], 
     "benchmark": false, 
     "ci_platforms": [
-      "linux"
-    ], 
-    "cpu_cost": 1.0, 
-    "exclude_configs": [], 
-    "exclude_iomgrs": [], 
-    "flaky": false, 
-    "gtest": false, 
-    "language": "c++", 
-    "name": "grpclb_fallback_test", 
-    "platforms": [
-      "linux"
-    ], 
-    "uses_polling": true
-  }, 
-  {
-    "args": [], 
-    "benchmark": false, 
-    "ci_platforms": [
       "linux", 
       "mac", 
       "posix", 


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/19915

The grpclb_fallback_test binary was added to this repo for build-only reasons, and wasn't meant to be ran by continuous test runners of this repo (e.g. in bazel it's a `cc_binary` rather than a `cc_test`).

I forgot to add `run: false` to the build.yaml entry though, and so some continuous test runners that use `run_tests.py`are trying to run it (and failing).