### PR TITLE
Increase timeout for macos/grpc-node test to 120 minutes

### DIFF
--- a/tools/internal_ci/macos/grpc_basictests_node.cfg
+++ b/tools/internal_ci/macos/grpc_basictests_node.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_tests_matrix.sh"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
-timeout_mins: 60
+timeout_mins: 120
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"

--- a/tools/internal_ci/macos/pull_request/grpc_basictests_node.cfg
+++ b/tools/internal_ci/macos/pull_request/grpc_basictests_node.cfg
@@ -17,7 +17,7 @@
 # Location of the continuous shell script in repository.
 build_file: "grpc/tools/internal_ci/macos/grpc_run_tests_matrix.sh"
 gfile_resources: "/bigstore/grpc-testing-secrets/gcp_credentials/GrpcTesting-d0eeee2db331.json"
-timeout_mins: 60
+timeout_mins: 120
 action {
   define_artifacts {
     regex: "**/*sponge_log.*"


### PR DESCRIPTION
macos/grpc-node test has been failing all the time due to timeout. It seems that macos doesn't have tests run in parallel and it has 2 tests to run. Each test takes about ~27 minutes and 60 minutes is not enough to run them sequentially. 120 minutes would be enough to run them without timeout.