### PR TITLE
Fix warning in client_idle_filter.cc to support gcc8

### DIFF
--- a/src/core/ext/filters/client_idle/client_idle_filter.cc
+++ b/src/core/ext/filters/client_idle/client_idle_filter.cc
@@ -370,7 +370,7 @@ void ChannelData::EnterIdle() {
   // Hold a ref to the channel stack for the transport op.
   GRPC_CHANNEL_STACK_REF(channel_stack_, "idle transport op");
   // Initialize the transport op.
-  memset(&idle_transport_op_, 0, sizeof(idle_transport_op_));
+  idle_transport_op_ = {};
   idle_transport_op_.disconnect_with_error = grpc_error_set_int(
       GRPC_ERROR_CREATE_FROM_STATIC_STRING("enter idle"),
       GRPC_ERROR_INT_CHANNEL_CONNECTIVITY_STATE, GRPC_CHANNEL_IDLE);


### PR DESCRIPTION
After gcc8, this warning in client_idle_filter is no longer being ignored:

src/core/ext/filters/client_idle/client_idle_filter.cc: In member function ‘void grpc_core::{anonymous}::ChannelData::EnterIdle()’:
src/core/ext/filters/client_idle/client_idle_filter.cc:373:60: error: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘grpc_transport_op’ {aka ‘struct grpc_transport_op’}; use assignment or value-initialization instead [-Werror=class-memaccess]
   memset(&idle_transport_op_, 0, sizeof(idle_transport_op_));

This PR fixes the code to no longer produce this warning.