### PR TITLE
Add a developer trick to the installation doc, reorganize a bit

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -14,6 +14,7 @@ If you plan to build from source and run tests, install the following as well:
  $ [sudo] apt-get install libgflags-dev libgtest-dev
  $ [sudo] apt-get install clang libc++-dev
 ```
+Lastly, see the Protoc section below if you do not yet have the protoc compiler installed.
 
 ## MacOS
 
@@ -46,6 +47,7 @@ installed by `brew` is being used:
 ```sh
  $ LIBTOOL=glibtool LIBTOOLIZE=glibtoolize make
 ```
+Lastly, see the Protoc section below if you do not yet have the protoc compiler.
 
 ## Windows
 
@@ -111,6 +113,12 @@ for guidance on how to add gRPC as a dependency to a C++ application (there are 
 From the grpc repository root
 ```sh
  $ make
+```
+NOTE: if you get an error on linux such as 'aclocal-1.15: command not found', which can happen if you ran 'make' before installing the pre-reqs, try the following:
+```sh
+$ git clean -f -d -x && git submodule foreach --recursive git clean -f -d -x
+$ [sudo] apt-get install build-essential autoconf libtool pkg-config
+$ make
 ```
 
 ## bazel


### PR DESCRIPTION
This PR adds some commands to solve an issue I encountered while installing grpc. I also reorganize the documentation regarding protoc a bit. Most users who read this page will filter by OS first and may bypass the protoc documentation entirely if it's not referenced from inside the OS sections.