### PR TITLE
Reproduce grpc shutdown crash

### DIFF
--- a/test/cpp/common/BUILD
+++ b/test/cpp/common/BUILD
@@ -19,6 +19,20 @@ load("//bazel:grpc_build_system.bzl", "grpc_cc_test", "grpc_package")
 grpc_package(name = "test/cpp/common")
 
 grpc_cc_test(
+    name = "demo_test",
+    srcs = ["demo_test.cc"],
+    external_deps = [
+        "gtest",
+    ],
+    deps = [
+        "//:gpr",
+        "//:grpc",
+        "//:grpc++",
+        "//test/core/util:grpc_test_util",
+    ],
+)
+
+grpc_cc_test(
     name = "alarm_test",
     srcs = ["alarm_test.cc"],
     external_deps = [

--- a/test/cpp/common/demo_test.cc
+++ b/test/cpp/common/demo_test.cc
@@ -1,0 +1,50 @@
+/*
+ *
+ * Copyright 2019 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+
+#include <grpc/grpc.h>
+#include <gtest/gtest.h>
+
+#include "src/core/lib/iomgr/exec_ctx.h"
+#include "test/core/util/test_config.h"
+
+TEST(DemoTest, FailsOnMacOS) {
+  grpc_init();
+  grpc_core::ExecCtx exec_ctx;
+  grpc_shutdown_blocking();
+}
+
+TEST(DemoTest, PassesOnMacOS1) {
+  grpc_init();
+  {
+    grpc_core::ExecCtx exec_ctx;
+  }
+  grpc_shutdown_blocking();
+}
+
+TEST(DemoTest, PassesOnMacOS2) {
+  grpc_init();
+  grpc_core::ExecCtx exec_ctx;
+  grpc_shutdown();
+}
+
+int main(int argc, char** argv) {
+  grpc::testing::TestEnvironment env(argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
```
(lldb) bt all
* thread #1, stop reason = signal SIGSTOP
  * frame #0: 0x000000010b3cf66e libgrpc_base_c.so`grpc_combiner_continue_exec_ctx() + 30
    frame #1: 0x000000010b3da741 libgrpc_base_c.so`grpc_core::ExecCtx::Flush() + 177
    frame #2: 0x000000010aa938f0 demo_test`grpc_core::ExecCtx::~ExecCtx() + 48
    frame #3: 0x000000010aa932b5 demo_test`grpc_core::ExecCtx::~ExecCtx() + 21
    frame #4: 0x000000010aa9325d demo_test`DemoTest_FailsOnMacOS_Test::TestBody() + 45
    frame #5: 0x000000010b58764e libgtest.so`void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) + 126
    frame #6: 0x000000010b55290b libgtest.so`void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) + 123
    frame #7: 0x000000010b552836 libgtest.so`testing::Test::Run() + 198
    frame #8: 0x000000010b553df2 libgtest.so`testing::TestInfo::Run() + 210
    frame #9: 0x000000010b55543c libgtest.so`testing::TestCase::Run() + 236
    frame #10: 0x000000010b56e195 libgtest.so`testing::internal::UnitTestImpl::RunAllTests() + 869
    frame #11: 0x000000010b58afae libgtest.so`bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) + 126
    frame #12: 0x000000010b56dbbb libgtest.so`bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) + 123
    frame #13: 0x000000010b56da7c libgtest.so`testing::UnitTest::Run() + 412
    frame #14: 0x000000010aa93411 demo_test`RUN_ALL_TESTS() + 17
    frame #15: 0x000000010aa933bd demo_test`main + 61
    frame #16: 0x00007fff7128d3d5 libdyld.dylib`start + 1
```