### PR TITLE
 Make default vtable for pointer argumnet a constant

### DIFF
--- a/src/python/grpcio/grpc/_cython/_cygrpc/arguments.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/arguments.pxd.pxi
@@ -23,7 +23,7 @@ cdef class _ChannelArg:
 
   cdef grpc_arg c_argument
 
-  cdef void c(self, argument, _VTable vtable, references) except *
+  cdef void c(self, argument, references) except *
 
 
 cdef class _ChannelArgs:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/arguments.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/arguments.pyx.pxi
@@ -33,7 +33,7 @@ cdef grpc_arg _unwrap_grpc_arg(tuple wrapped_arg):
 
 cdef class _ChannelArg:
 
-  cdef void c(self, argument, _VTable vtable, references) except *:
+  cdef void c(self, argument, references) except *:
     key, value = argument
     cdef bytes encoded_key = _encode(key)
     if encoded_key is not key:
@@ -56,7 +56,7 @@ cdef class _ChannelArg:
       # lifecycle of the pointer is fixed to the lifecycle of the
       # python object wrapping it.
       self.c_argument.type = GRPC_ARG_POINTER
-      self.c_argument.value.pointer.vtable = &vtable.c_vtable
+      self.c_argument.value.pointer.vtable = &default_vtable
       self.c_argument.value.pointer.address = <void*>(<intptr_t>int(value))
     else:
       raise TypeError(
@@ -65,7 +65,7 @@ cdef class _ChannelArg:
 
 cdef class _ChannelArgs:
 
-  def __cinit__(self, arguments, _VTable vtable not None):
+  def __cinit__(self, arguments):
     self._arguments = () if arguments is None else tuple(arguments)
     self._channel_args = []
     self._references = []
@@ -75,7 +75,7 @@ cdef class _ChannelArgs:
           self._c_arguments.arguments_length * sizeof(grpc_arg))
       for index, argument in enumerate(self._arguments):
         channel_arg = _ChannelArg()
-        channel_arg.c(argument, vtable, self._references)
+        channel_arg.c(argument, self._references)
         self._c_arguments.arguments[index] = channel_arg.c_argument
         self._channel_args.append(channel_arg)
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/call.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/call.pyx.pxi
@@ -17,11 +17,11 @@ cimport cpython
 
 cdef class Call:
 
-  def __cinit__(self, _VTable vtable not None):
+  def __cinit__(self):
     # Create an *empty* call
     fork_handlers_and_grpc_init()
     self.c_call = NULL
-    self.references = [vtable]
+    self.references = []
 
   def _start_batch(self, operations, tag, retain_self):
     if not self.is_valid:

--- a/src/python/grpcio/grpc/_cython/_cygrpc/channel.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channel.pxd.pxi
@@ -69,7 +69,6 @@ cdef class SegregatedCall:
 cdef class Channel:
 
   cdef _ChannelState _state
-  cdef _VTable _vtable
 
   # TODO(https://github.com/grpc/grpc/issues/15662): Eliminate this.
   cdef tuple _arguments

--- a/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/channel.pyx.pxi
@@ -455,9 +455,7 @@ cdef class Channel:
     self._state.c_connectivity_completion_queue = (
         grpc_completion_queue_create_for_next(NULL))
     self._arguments = arguments
-    self._vtable = _VTable()
-    cdef _ChannelArgs channel_args = _ChannelArgs(
-        arguments, self._vtable)
+    cdef _ChannelArgs channel_args = _ChannelArgs(arguments)
     if channel_credentials is None:
       self._state.c_channel = grpc_insecure_channel_create(
           <char *>target, channel_args.c_args(), NULL)

--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pxd.pxi
@@ -16,7 +16,6 @@ cdef class Server:
 
   cdef grpc_server *c_server
 
-  cdef _VTable _vtable
   cdef bint is_started  # start has been called
   cdef bint is_shutting_down  # shutdown has been called
   cdef bint is_shutdown  # notification of complete shutdown received

--- a/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/server.pyx.pxi
@@ -31,8 +31,7 @@ cdef class Server:
     self.is_shutting_down = False
     self.is_shutdown = False
     self.c_server = NULL
-    self._vtable = _VTable()
-    cdef _ChannelArgs channel_args = _ChannelArgs(arguments, self._vtable)
+    cdef _ChannelArgs channel_args = _ChannelArgs(arguments)
     self.c_server = grpc_server_create(channel_args.c_args(), NULL)
     self.references.append(arguments)
 
@@ -43,7 +42,7 @@ cdef class Server:
       raise ValueError("server must be started and not shutting down")
     if server_queue not in self.registered_completion_queues:
       raise ValueError("server_queue must be a registered completion queue")
-    cdef _RequestCallTag request_call_tag = _RequestCallTag(tag, self._vtable)
+    cdef _RequestCallTag request_call_tag = _RequestCallTag(tag)
     request_call_tag.prepare()
     cpython.Py_INCREF(request_call_tag)
     return grpc_server_request_call(

--- a/src/python/grpcio/grpc/_cython/_cygrpc/tag.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/tag.pxd.pxi
@@ -29,7 +29,6 @@ cdef class _RequestCallTag(_Tag):
 
   cdef readonly object _user_tag
   cdef Call call
-  cdef _VTable _vtable
   cdef CallDetails call_details
   cdef grpc_metadata_array c_invocation_metadata
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/tag.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/tag.pyx.pxi
@@ -30,14 +30,13 @@ cdef class _ConnectivityTag(_Tag):
 
 cdef class _RequestCallTag(_Tag):
 
-  def __cinit__(self, user_tag, _VTable vtable not None):
+  def __cinit__(self, user_tag):
     self._user_tag = user_tag
     self.call = None
     self.call_details = None
-    self._vtable = vtable
 
   cdef void prepare(self) except *:
-    self.call = Call(self._vtable)
+    self.call = Call()
     self.call_details = CallDetails()
     grpc_metadata_array_init(&self.c_invocation_metadata)
 

--- a/src/python/grpcio/grpc/_cython/_cygrpc/vtable.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/vtable.pxd.pxi
@@ -15,12 +15,9 @@
 
 cdef void* _copy_pointer(void* pointer)
 
-
 cdef void _destroy_pointer(void* pointer)
-
 
 cdef int _compare_pointer(void* first_pointer, void* second_pointer)
 
 
-cdef class _VTable:
-  cdef grpc_arg_pointer_vtable c_vtable
+cdef grpc_arg_pointer_vtable default_vtable

--- a/src/python/grpcio/grpc/_cython/_cygrpc/vtable.pyx.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/vtable.pyx.pxi
@@ -30,10 +30,7 @@ cdef int _compare_pointer(void* first_pointer, void* second_pointer):
   else:
     return 0
 
-
-cdef class _VTable:
-  def __cinit__(self):
-    self.c_vtable.copy = &_copy_pointer
-    self.c_vtable.destroy = &_destroy_pointer
-    self.c_vtable.cmp = &_compare_pointer
-
+cdef grpc_arg_pointer_vtable default_vtable
+default_vtable.copy = &_copy_pointer
+default_vtable.destroy = &_destroy_pointer
+default_vtable.cmp = &_compare_pointer


### PR DESCRIPTION
@guantaol 
Context b/139707987.

When channel argument accepts a C pointer, we created a vtable along with it. However, during the shutdown phase, there is a potential data race between the destroy of the `_VTable` cdef class and the channel argument in C-Core, and caused TSAN failure.

This issue wasn't revealed before because the shutdown happen in the same thread (hence there won't be data race). Once the event manager is enabled, the TSAN failure can be stably reproduced.

According to the comment in `grpc_types.h`:
```
    However, if one of the args has grpc_arg_type==GRPC_ARG_POINTER, then the
    grpc_arg_pointer_vtable must live until the channel args are done being
    used by core (i.e. when the object for use with which they were passed
    is destroyed).
```

Next question is what is the correct way of handling vtable for pointer arguments? Let's use a channel argument in C-Core that accepts pointer as example:

```C
/** If non-zero, a pointer to a buffer pool (a pointer of type
 * grpc_resource_quota*). (use grpc_resource_quota_arg_vtable() to fetch an
 * appropriate pointer arg vtable) */
#define GRPC_ARG_RESOURCE_QUOTA "grpc.resource_quota"
```

```C
namespace {

void* arg_copy(void* p) {
  auto* subchannel_pool = static_cast<SubchannelPoolInterface*>(p);
  subchannel_pool->Ref().release();
  return p;
}

void arg_destroy(void* p) {
  auto* subchannel_pool = static_cast<SubchannelPoolInterface*>(p);
  subchannel_pool->Unref();
}

int arg_cmp(void* a, void* b) { return GPR_ICMP(a, b); }

const grpc_arg_pointer_vtable subchannel_pool_arg_vtable = {
    arg_copy, arg_destroy, arg_cmp};

}  // namespace
```

To implement a functional vtable for pointer, the correct way requires knowledge to the content of pointer. And should use [grpc_channel_arg_pointer_create ](https://github.com/grpc/grpc/blob/d44dfbc77e3f89042304769b457337c538b4e883/src/core/lib/channel/channel_args.h#L104) function to create the channel argument, which takes in three parameter, key, value, vtable.

For a fix, I recommend to make the Python wrapper default vtable constant.

I think we don't need to modify public API now, until we have a valid use case of accepting custom pointer vtable,