### PR TITLE
Fix warnings to unblock gcc8 support

### DIFF
--- a/test/core/http/httpcli_test.cc
+++ b/test/core/http/httpcli_test.cc
@@ -77,7 +77,7 @@ static void test_get(int port) {
   req.handshaker = &grpc_httpcli_plaintext;
 
   grpc_http_response response;
-  memset(&response, 0, sizeof(response));
+  response = {};
   grpc_resource_quota* resource_quota = grpc_resource_quota_create("test_get");
   grpc_httpcli_get(
       &g_context, &g_pops, resource_quota, &req, n_seconds_time(15),
@@ -116,7 +116,7 @@ static void test_post(int port) {
   req.handshaker = &grpc_httpcli_plaintext;
 
   grpc_http_response response;
-  memset(&response, 0, sizeof(response));
+  response = {};
   grpc_resource_quota* resource_quota = grpc_resource_quota_create("test_post");
   grpc_httpcli_post(
       &g_context, &g_pops, resource_quota, &req, "hello", 5, n_seconds_time(15),

--- a/test/core/http/httpscli_test.cc
+++ b/test/core/http/httpscli_test.cc
@@ -81,7 +81,7 @@ static void test_get(int port) {
   req.handshaker = &grpc_httpcli_ssl;
 
   grpc_http_response response;
-  memset(&response, 0, sizeof(response));
+  response = {};
   grpc_resource_quota* resource_quota = grpc_resource_quota_create("test_get");
   grpc_httpcli_get(
       &g_context, &g_pops, resource_quota, &req, n_seconds_time(15),
@@ -121,7 +121,7 @@ static void test_post(int port) {
   req.handshaker = &grpc_httpcli_ssl;
 
   grpc_http_response response;
-  memset(&response, 0, sizeof(response));
+  response = {};
   grpc_resource_quota* resource_quota = grpc_resource_quota_create("test_post");
   grpc_httpcli_post(
       &g_context, &g_pops, resource_quota, &req, "hello", 5, n_seconds_time(15),

--- a/test/core/http/parser_test.cc
+++ b/test/core/http/parser_test.cc
@@ -101,7 +101,7 @@ static void test_succeeds(grpc_slice_split_mode split_mode,
   grpc_slice* slices;
   va_list args;
   grpc_http_response response;
-  memset(&response, 0, sizeof(response));
+  response = {};
 
   grpc_split_slices(split_mode, &input_slice, 1, &slices, &num_slices);
   grpc_slice_unref(input_slice);
@@ -155,7 +155,7 @@ static void test_fails(grpc_slice_split_mode split_mode,
   grpc_slice* slices;
   grpc_error* error = GRPC_ERROR_NONE;
   grpc_http_response response;
-  memset(&response, 0, sizeof(response));
+  response = {};
 
   grpc_split_slices(split_mode, &input_slice, 1, &slices, &num_slices);
   grpc_slice_unref(input_slice);

--- a/test/core/http/response_fuzzer.cc
+++ b/test/core/http/response_fuzzer.cc
@@ -31,7 +31,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   grpc_http_parser parser;
   grpc_http_response response;
   grpc_init();
-  memset(&response, 0, sizeof(response));
+  response = {};
   grpc_http_parser_init(&parser, GRPC_HTTP_RESPONSE, &response);
   grpc_slice slice = grpc_slice_from_copied_buffer((const char*)data, size);
   GRPC_ERROR_UNREF(grpc_http_parser_parse(&parser, slice, nullptr));

--- a/test/core/security/credentials_test.cc
+++ b/test/core/security/credentials_test.cc
@@ -149,7 +149,7 @@ static char* test_json_key_str(void) {
 
 static grpc_httpcli_response http_response(int status, const char* body) {
   grpc_httpcli_response response;
-  memset(&response, 0, sizeof(grpc_httpcli_response));
+  response = {};
   response.status = status;
   response.body = gpr_strdup(const_cast<char*>(body));
   response.body_length = strlen(body);
@@ -161,7 +161,7 @@ static grpc_httpcli_response http_response(int status, const char* body) {
 static void test_empty_md_array(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_credentials_mdelem_array md_array;
-  memset(&md_array, 0, sizeof(md_array));
+  md_array = {};
   GPR_ASSERT(md_array.md == nullptr);
   GPR_ASSERT(md_array.size == 0);
   grpc_credentials_mdelem_array_destroy(&md_array);
@@ -170,7 +170,7 @@ static void test_empty_md_array(void) {
 static void test_add_to_empty_md_array(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_credentials_mdelem_array md_array;
-  memset(&md_array, 0, sizeof(md_array));
+  md_array = {};
   const char* key = "hello";
   const char* value = "there blah blah blah blah blah blah blah";
   grpc_mdelem md = grpc_mdelem_from_slices(
@@ -185,7 +185,7 @@ static void test_add_to_empty_md_array(void) {
 static void test_add_abunch_to_md_array(void) {
   grpc_core::ExecCtx exec_ctx;
   grpc_credentials_mdelem_array md_array;
-  memset(&md_array, 0, sizeof(md_array));
+  md_array = {};
   const char* key = "hello";
   const char* value = "there blah blah blah blah blah blah blah";
   grpc_mdelem md = grpc_mdelem_from_slices(

--- a/test/core/security/jwt_verifier_test.cc
+++ b/test/core/security/jwt_verifier_test.cc
@@ -310,7 +310,7 @@ static char* good_google_email_keys(void) {
 
 static grpc_httpcli_response http_response(int status, char* body) {
   grpc_httpcli_response response;
-  memset(&response, 0, sizeof(grpc_httpcli_response));
+  response = {};
   response.status = status;
   response.body = body;
   response.body_length = strlen(body);

--- a/test/core/security/oauth2_utils.cc
+++ b/test/core/security/oauth2_utils.cc
@@ -71,7 +71,7 @@ static void destroy_after_shutdown(void* pollset, grpc_error* error) {
 char* grpc_test_fetch_oauth2_token_with_credentials(
     grpc_call_credentials* creds) {
   oauth2_request request;
-  memset(&request, 0, sizeof(request));
+  request = {};
   grpc_core::ExecCtx exec_ctx;
   grpc_closure destroy_after_shutdown_closure;
   grpc_auth_metadata_context null_ctx = {"", "", nullptr, nullptr};

--- a/test/core/transport/chttp2/hpack_encoder_test.cc
+++ b/test/core/transport/chttp2/hpack_encoder_test.cc
@@ -97,7 +97,7 @@ static void verify(const verify_params params, const char* expected,
   grpc_slice_buffer_init(&output);
 
   grpc_transport_one_way_stats stats;
-  memset(&stats, 0, sizeof(stats));
+  stats = {};
   grpc_encode_header_options hopt = {
       0xdeadbeef,                      /* stream_id */
       params.eof,                      /* is_eof */
@@ -217,7 +217,7 @@ static void verify_table_size_change_match_elem_size(const char* key,
   grpc_slice_buffer_init(&output);
 
   grpc_transport_one_way_stats stats;
-  memset(&stats, 0, sizeof(stats));
+  stats = {};
   grpc_encode_header_options hopt = {
       0xdeadbeef,      /* stream_id */
       false,           /* is_eof */

--- a/test/cpp/microbenchmarks/bm_call_create.cc
+++ b/test/cpp/microbenchmarks/bm_call_create.cc
@@ -456,7 +456,7 @@ class NoOp {
 class SendEmptyMetadata {
  public:
   SendEmptyMetadata() : op_payload_(nullptr) {
-    memset(&op_, 0, sizeof(op_));
+    op_ = {};
     op_.on_complete = GRPC_CLOSURE_INIT(&closure_, DoNothing, nullptr,
                                         grpc_schedule_on_exec_ctx);
     op_.send_initial_metadata = true;

--- a/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
@@ -77,7 +77,7 @@ static void BM_HpackEncoderEncodeDeadline(benchmark::State& state) {
       new grpc_chttp2_hpack_compressor);
   grpc_chttp2_hpack_compressor_init(c.get());
   grpc_transport_one_way_stats stats;
-  memset(&stats, 0, sizeof(stats));
+  stats = {};
   grpc_slice_buffer outbuf;
   grpc_slice_buffer_init(&outbuf);
   while (state.KeepRunning()) {
@@ -127,7 +127,7 @@ static void BM_HpackEncoderEncodeHeader(benchmark::State& state) {
       new grpc_chttp2_hpack_compressor);
   grpc_chttp2_hpack_compressor_init(c.get());
   grpc_transport_one_way_stats stats;
-  memset(&stats, 0, sizeof(stats));
+  stats = {};
   grpc_slice_buffer outbuf;
   grpc_slice_buffer_init(&outbuf);
   while (state.KeepRunning()) {

--- a/test/cpp/microbenchmarks/bm_chttp2_transport.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_transport.cc
@@ -262,7 +262,7 @@ static void BM_StreamCreateDestroy(benchmark::State& state) {
   auto* s = new Stream(&f);
   grpc_transport_stream_op_batch op;
   grpc_transport_stream_op_batch_payload op_payload(nullptr);
-  memset(&op, 0, sizeof(op));
+  op = {};
   op.cancel_stream = true;
   op.payload = &op_payload;
   op_payload.cancel_stream.cancel_error = GRPC_ERROR_CANCELLED;
@@ -315,7 +315,7 @@ static void BM_StreamCreateSendInitialMetadataDestroy(benchmark::State& state) {
   std::unique_ptr<Closure> done;
 
   auto reset_op = [&]() {
-    memset(&op, 0, sizeof(op));
+    op = {};
     op.payload = &op_payload;
   };
 
@@ -366,7 +366,7 @@ static void BM_TransportEmptyOp(benchmark::State& state) {
   grpc_transport_stream_op_batch op;
   grpc_transport_stream_op_batch_payload op_payload(nullptr);
   auto reset_op = [&]() {
-    memset(&op, 0, sizeof(op));
+    op = {};
     op.payload = &op_payload;
   };
   std::unique_ptr<Closure> c = MakeClosure([&](grpc_error* error) {
@@ -398,7 +398,7 @@ static void BM_TransportStreamSend(benchmark::State& state) {
   grpc_transport_stream_op_batch op;
   grpc_transport_stream_op_batch_payload op_payload(nullptr);
   auto reset_op = [&]() {
-    memset(&op, 0, sizeof(op));
+    op = {};
     op.payload = &op_payload;
   };
   // Create the send_message payload slice.
@@ -533,7 +533,7 @@ static void BM_TransportStreamRecv(benchmark::State& state) {
   grpc_slice incoming_data = CreateIncomingDataSlice(state.range(0), 16384);
 
   auto reset_op = [&]() {
-    memset(&op, 0, sizeof(op));
+    op = {};
     op.payload = &op_payload;
   };
 


### PR DESCRIPTION
These warnings show up as compiler errors under gcc8. Fix them.