### PR TITLE
Update googletest version to master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -451,7 +451,7 @@ USE_BUILT_PROTOC = false
 endif
 
 GTEST_LIB = -Ithird_party/googletest/googletest/include -Ithird_party/googletest/googletest third_party/googletest/googletest/src/gtest-all.cc -Ithird_party/googletest/googlemock/include -Ithird_party/googletest/googlemock third_party/googletest/googlemock/src/gmock-all.cc
-GTEST_LIB += -lgflags
+GTEST_LIB += -lgflags -std=c++11
 ifeq ($(V),1)
 E = @:
 Q =

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -67,7 +67,7 @@ def grpc_deps():
         name = "gtest",
         actual = "@com_github_google_googletest//:gtest",
     )
-
+    
     native.bind(
         name = "benchmark",
         actual = "@com_github_google_benchmark//:benchmark",
@@ -141,9 +141,17 @@ def grpc_deps():
     if "com_github_google_googletest" not in native.existing_rules():
         http_archive(
             name = "com_github_google_googletest",
-            sha256 = "d0d447b4feeedca837a0d46a289d4223089b32ac2f84545fa4982755cc8919be",
-            strip_prefix = "googletest-2fe3bd994b3189899d93f1d5a881e725e046fdc2",
-            url = "https://github.com/google/googletest/archive/2fe3bd994b3189899d93f1d5a881e725e046fdc2.tar.gz",
+            sha256 = "443d383db648ebb8e391382c0ab63263b7091d03197f304390baac10f178a468",
+            strip_prefix = "googletest-c9ccac7cb7345901884aabf5d1a786cfa6e2f397",
+            url = "https://github.com/google/googletest/archive/c9ccac7cb7345901884aabf5d1a786cfa6e2f397.tar.gz", # 2019-08-19
+        )
+
+    if "rules_cc" not in native.existing_rules():
+        http_archive(
+            name = "rules_cc",
+            sha256 = "35f2fb4ea0b3e61ad64a369de284e4fbbdcdba71836a5555abb5e194cf119509",
+            strip_prefix = "rules_cc-624b5d59dfb45672d4239422fa1e3de1822ee110",
+            url = "https://github.com/bazelbuild/rules_cc/archive/624b5d59dfb45672d4239422fa1e3de1822ee110.tar.gz", #2019-08-15
         )
 
     if "com_github_gflags_gflags" not in native.existing_rules():

--- a/templates/Makefile.template
+++ b/templates/Makefile.template
@@ -321,7 +321,7 @@
   endif
 
   GTEST_LIB = -Ithird_party/googletest/googletest/include -Ithird_party/googletest/googletest third_party/googletest/googletest/src/gtest-all.cc -Ithird_party/googletest/googlemock/include -Ithird_party/googletest/googlemock third_party/googletest/googlemock/src/gmock-all.cc
-  GTEST_LIB += -lgflags
+  GTEST_LIB += -lgflags -std=c++11
   ifeq ($(V),1)
   E = @:
   Q =

--- a/tools/run_tests/sanity/check_bazel_workspace.py
+++ b/tools/run_tests/sanity/check_bazel_workspace.py
@@ -48,6 +48,7 @@ _GRPC_DEP_NAMES = [
     'zlib',
     'com_google_protobuf',
     'com_github_google_googletest',
+    'rules_cc',
     'com_github_gflags_gflags',
     'com_github_nanopb_nanopb',
     'com_github_google_benchmark',
@@ -67,6 +68,7 @@ _GRPC_DEP_NAMES = [
 ]
 
 _GRPC_BAZEL_ONLY_DEPS = [
+    'rules_cc',
     'com_google_absl',
     'io_opencensus_cpp',
     _BAZEL_SKYLIB_DEP_NAME,

--- a/tools/run_tests/sanity/check_submodules.sh
+++ b/tools/run_tests/sanity/check_submodules.sh
@@ -35,7 +35,7 @@ cat << EOF | awk '{ print $1 }' | sort > "$want_submodules"
  a83394157ad97f4dadbc8ed81f56ad5b3a72e542 third_party/envoy-api (heads/master)
  28f50e0fed19872e0fd50dd23ce2ee8cd759338e third_party/gflags (v2.2.0-5-g30dbc81)
  80ed4d0bbf65d57cc267dfc63bd2584557f11f9b third_party/googleapis (common-protos-1_3_1-915-g80ed4d0bb)
- 2fe3bd994b3189899d93f1d5a881e725e046fdc2 third_party/googletest (release-1.8.1)
+ c9ccac7cb7345901884aabf5d1a786cfa6e2f397 third_party/googletest (6e2f397)
  6599cac0965be8e5a835ab7a5684bbef033d5ad0 third_party/libcxx (heads/release_60)
  9245d481eb3e890f708ff2d7dadf2a10c04748ba third_party/libcxxabi (heads/release_60)
  09745575a923640154bcf307fba8aedff47f240a third_party/protobuf (v3.7.0-rc.2-247-g09745575)


### PR DESCRIPTION
This should fix the boringSSL test that's currently failing on master with the error:

third_party/boringssl/ssl/ssl_test.cc:1662:25: error: expected constructor, destructor, or type conversion before '(' token
 INSTANTIATE_TEST_SUITE_P(WithVersion, SSLVersionTest,

