### PR TITLE
Add grpc-proto to third_party

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -54,3 +54,6 @@
 [submodule "third_party/upb"]
 	path = third_party/upb
 	url = https://github.com/protocolbuffers/upb.git
+[submodule "third_party/grpc-proto"]
+	path = third_party/grpc-proto
+	url = https://github.com/grpc/grpc-proto.git

--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -204,6 +204,7 @@ def grpc_deps():
             strip_prefix = "opencensus-cpp-c9a4da319bc669a772928ffc55af4a61be1a1176",
             url = "https://github.com/census-instrumentation/opencensus-cpp/archive/c9a4da319bc669a772928ffc55af4a61be1a1176.tar.gz",
         )
+
     if "upb" not in native.existing_rules():
         http_archive(
             name = "upb",
@@ -211,12 +212,21 @@ def grpc_deps():
             strip_prefix = "upb-931bbecbd3230ae7f22efa5d203639facc47f719",
             url = "https://github.com/protocolbuffers/upb/archive/931bbecbd3230ae7f22efa5d203639facc47f719.tar.gz",
         )
+
     if "envoy_api" not in native.existing_rules():
         http_archive(
             name = "envoy_api",
             sha256 = "a2c6e854fa9653b0ed6510e31ec7c51eac43d578b54cd75c0bc1898f7515c60d",
             strip_prefix = "data-plane-api-a83394157ad97f4dadbc8ed81f56ad5b3a72e542",
             url = "https://github.com/envoyproxy/data-plane-api/archive/a83394157ad97f4dadbc8ed81f56ad5b3a72e542.tar.gz",
+        )
+
+    if "grpc-proto" not in native.existing_rules():
+        http_archive(
+            name = "grpc-proto",
+            sha256 = "48ab204cd7709df757ee25d99855a1ca15111807f0aa23d38d47885f730f42b4",
+            strip_prefix = "grpc-proto-5ce8e3e598b805a1e0372062913f24b0715fdefc",
+            url = "https://github.com/grpc/grpc-proto/archive/5ce8e3e598b805a1e0372062913f24b0715fdefc.tar.gz",
         )
 
     if "io_bazel_rules_go" not in native.existing_rules():

--- a/tools/run_tests/sanity/check_bazel_workspace.py
+++ b/tools/run_tests/sanity/check_bazel_workspace.py
@@ -55,6 +55,7 @@ _GRPC_DEP_NAMES = [
     'com_google_absl',
     'io_opencensus_cpp',
     'envoy_api',
+    'grpc-proto',
     _BAZEL_SKYLIB_DEP_NAME,
     _BAZEL_TOOLCHAINS_DEP_NAME,
     _TWISTED_TWISTED_DEP_NAME,

--- a/tools/run_tests/sanity/check_submodules.sh
+++ b/tools/run_tests/sanity/check_submodules.sh
@@ -36,6 +36,7 @@ cat << EOF | awk '{ print $1 }' | sort > "$want_submodules"
  28f50e0fed19872e0fd50dd23ce2ee8cd759338e third_party/gflags (v2.2.0-5-g30dbc81)
  80ed4d0bbf65d57cc267dfc63bd2584557f11f9b third_party/googleapis (common-protos-1_3_1-915-g80ed4d0bb)
  2fe3bd994b3189899d93f1d5a881e725e046fdc2 third_party/googletest (release-1.8.1)
+ 5ce8e3e598b805a1e0372062913f24b0715fdefc third_party/google-proto (heads/master)
  6599cac0965be8e5a835ab7a5684bbef033d5ad0 third_party/libcxx (heads/release_60)
  9245d481eb3e890f708ff2d7dadf2a10c04748ba third_party/libcxxabi (heads/release_60)
  09745575a923640154bcf307fba8aedff47f240a third_party/protobuf (v3.7.0-rc.2-247-g09745575)


### PR DESCRIPTION
gRPC protobuf repository is added to third_party instead of duplicating required protobuf files. `third_party/grpc-proto/grpc` will supersede `src/proto/grpc/grpc`