### PR TITLE
Enable end2end C++ tests on iOS.

### DIFF
--- a/test/cpp/common/time_jump_test.cc
+++ b/test/cpp/common/time_jump_test.cc
@@ -121,7 +121,7 @@ TEST_P(TimeJumpTest, TimedWait) {
     GPR_ASSERT(1 ==
                gpr_time_similar(gpr_time_sub(after, before),
                                 gpr_time_from_millis(kWaitTimeMs, GPR_TIMESPAN),
-                                gpr_time_from_millis(10, GPR_TIMESPAN)));
+                                gpr_time_from_millis(50, GPR_TIMESPAN)));
 
     thd.join();
   }

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -165,7 +165,6 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    tags = ["no_test_ios"],
 )
 
 grpc_cc_test(
@@ -224,6 +223,7 @@ grpc_cc_library(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
+    alwayslink = 1,
 )
 
 grpc_cc_test(
@@ -272,6 +272,7 @@ grpc_cc_test(
         # system uses it to specialize targets
         "//:grpc++",
     ],
+    tags = ["no_test_ios"],
 )
 
 grpc_cc_test(
@@ -441,7 +442,6 @@ grpc_cc_test(
         "//test/core/util:test_lb_policies",
         "//test/cpp/util:test_util",
     ],
-    tags = ["no_test_ios"],
 )
 
 grpc_cc_test(
@@ -482,7 +482,6 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    tags = ["no_test_ios"],
 )
 
 grpc_cc_test(
@@ -505,7 +504,6 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    tags = ["no_test_ios"],
 )
 
 grpc_cc_test(
@@ -698,7 +696,6 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    tags = ["no_test_ios"],
 )
 
 grpc_cc_test(
@@ -756,5 +753,4 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    tags = ["no_test_ios"],
 )

--- a/test/cpp/end2end/channelz_service_test.cc
+++ b/test/cpp/end2end/channelz_service_test.cc
@@ -29,6 +29,7 @@
 #include <grpcpp/server_context.h>
 
 #include <grpcpp/ext/channelz_service_plugin.h>
+#include "src/core/lib/gpr/env.h"
 #include "src/proto/grpc/channelz/channelz.grpc.pb.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/port.h"
@@ -104,7 +105,12 @@ class Proxy : public ::grpc::testing::EchoTestService::Service {
 class ChannelzServerTest : public ::testing::Test {
  public:
   ChannelzServerTest() {}
-
+  static void SetUpTestCase() {
+#if TARGET_OS_IPHONE
+    // Workaround Apple CFStream bug
+    gpr_setenv("grpc_cfstream", "0");
+#endif
+  }
   void SetUp() override {
     // ensure channel server is brought up on all severs we build.
     ::grpc::channelz::experimental::InitChannelzService();

--- a/test/cpp/end2end/client_callback_end2end_test.cc
+++ b/test/cpp/end2end/client_callback_end2end_test.cc
@@ -32,6 +32,7 @@
 #include <grpcpp/server_context.h>
 #include <grpcpp/support/client_callback.h>
 
+#include "src/core/lib/gpr/env.h"
 #include "src/core/lib/iomgr/iomgr.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
 #include "test/core/util/port.h"
@@ -1336,6 +1337,11 @@ TEST_P(ClientCallbackEnd2endTest,
 }
 
 std::vector<TestScenario> CreateTestScenarios(bool test_insecure) {
+#if TARGET_OS_IPHONE
+  // Workaround Apple CFStream bug
+  gpr_setenv("grpc_cfstream", "0");
+#endif
+
   std::vector<TestScenario> scenarios;
   std::vector<grpc::string> credentials_types{
       GetCredentialsProvider()->GetSecureCredentialsTypeList()};

--- a/test/cpp/end2end/client_lb_end2end_test.cc
+++ b/test/cpp/end2end/client_lb_end2end_test.cc
@@ -45,6 +45,7 @@
 #include "src/core/ext/filters/client_channel/service_config.h"
 #include "src/core/lib/backoff/backoff.h"
 #include "src/core/lib/channel/channel_args.h"
+#include "src/core/lib/gpr/env.h"
 #include "src/core/lib/gprpp/debug_location.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/iomgr/tcp_client.h"
@@ -220,6 +221,10 @@ class ClientLbEnd2endTest : public ::testing::Test {
     // Make the backup poller poll very frequently in order to pick up
     // updates from all the subchannels's FDs.
     GPR_GLOBAL_CONFIG_SET(grpc_client_channel_backup_poll_interval_ms, 1);
+#if TARGET_OS_IPHONE
+    // Workaround Apple CFStream bug
+    gpr_setenv("grpc_cfstream", "0");
+#endif
   }
 
   void SetUp() override { grpc_init(); }

--- a/test/cpp/end2end/grpclb_end2end_test.cc
+++ b/test/cpp/end2end/grpclb_end2end_test.cc
@@ -39,6 +39,7 @@
 #include "src/core/ext/filters/client_channel/resolver/fake/fake_resolver.h"
 #include "src/core/ext/filters/client_channel/server_address.h"
 #include "src/core/ext/filters/client_channel/service_config.h"
+#include "src/core/lib/gpr/env.h"
 #include "src/core/lib/gprpp/ref_counted_ptr.h"
 #include "src/core/lib/iomgr/sockaddr.h"
 #include "src/core/lib/security/credentials/fake/fake_credentials.h"
@@ -378,6 +379,10 @@ class GrpclbEnd2endTest : public ::testing::Test {
     // Make the backup poller poll very frequently in order to pick up
     // updates from all the subchannels's FDs.
     GPR_GLOBAL_CONFIG_SET(grpc_client_channel_backup_poll_interval_ms, 1);
+#if TARGET_OS_IPHONE
+    // Workaround Apple CFStream bug
+    gpr_setenv("grpc_cfstream", "0");
+#endif
     grpc_init();
   }
 

--- a/test/cpp/end2end/hybrid_end2end_test.cc
+++ b/test/cpp/end2end/hybrid_end2end_test.cc
@@ -28,6 +28,7 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
+#include "src/core/lib/gpr/env.h"
 #include "src/core/lib/iomgr/iomgr.h"
 #include "src/proto/grpc/testing/duplicate/echo_duplicate.grpc.pb.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
@@ -228,6 +229,13 @@ class TestServiceImplDupPkg
 class HybridEnd2endTest : public ::testing::TestWithParam<bool> {
  protected:
   HybridEnd2endTest() {}
+
+  static void SetUpTestCase() {
+#if TARGET_OS_IPHONE
+    // Workaround Apple CFStream bug
+    gpr_setenv("grpc_cfstream", "0");
+#endif
+  }
 
   void SetUp() override {
     inproc_ = (::testing::UnitTest::GetInstance()

--- a/test/cpp/end2end/port_sharing_end2end_test.cc
+++ b/test/cpp/end2end/port_sharing_end2end_test.cc
@@ -33,6 +33,7 @@
 #include <mutex>
 #include <thread>
 
+#include "src/core/lib/gpr/env.h"
 #include "src/core/lib/iomgr/endpoint.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 #include "src/core/lib/iomgr/pollset.h"
@@ -310,6 +311,12 @@ static void SendRpc(EchoTestService::Stub* stub, int num_rpcs) {
 std::vector<TestScenario> CreateTestScenarios() {
   std::vector<TestScenario> scenarios;
   std::vector<grpc::string> credentials_types;
+
+#if TARGET_OS_IPHONE
+  // Workaround Apple CFStream bug
+  gpr_setenv("grpc_cfstream", "0");
+#endif
+
   credentials_types = GetCredentialsProvider()->GetSecureCredentialsTypeList();
   // Only allow insecure credentials type when it is registered with the
   // provider. User may create providers that do not have insecure.

--- a/test/cpp/end2end/thread_stress_test.cc
+++ b/test/cpp/end2end/thread_stress_test.cc
@@ -31,6 +31,7 @@
 #include <grpcpp/server_builder.h>
 #include <grpcpp/server_context.h>
 
+#include "src/core/lib/gpr/env.h"
 #include "src/core/lib/surface/api_trace.h"
 #include "src/proto/grpc/testing/duplicate/echo_duplicate.grpc.pb.h"
 #include "src/proto/grpc/testing/echo.grpc.pb.h"
@@ -66,7 +67,12 @@ class TestServiceImpl : public ::grpc::testing::EchoTestService::Service {
 template <class Service>
 class CommonStressTest {
  public:
-  CommonStressTest() : kMaxMessageSize_(8192) {}
+  CommonStressTest() : kMaxMessageSize_(8192) {
+#if TARGET_OS_IPHONE
+    // Workaround Apple CFStream bug
+    gpr_setenv("grpc_cfstream", "0");
+#endif
+  }
   virtual ~CommonStressTest() {}
   virtual void SetUp() = 0;
   virtual void TearDown() = 0;

--- a/test/cpp/end2end/xds_end2end_test.cc
+++ b/test/cpp/end2end/xds_end2end_test.cc
@@ -521,6 +521,10 @@ class XdsEnd2endTest : public ::testing::Test {
     // Make the backup poller poll very frequently in order to pick up
     // updates from all the subchannels's FDs.
     GPR_GLOBAL_CONFIG_SET(grpc_client_channel_backup_poll_interval_ms, 1);
+#if TARGET_OS_IPHONE
+    // Workaround Apple CFStream bug
+    gpr_setenv("grpc_cfstream", "0");
+#endif
     grpc_init();
   }
 


### PR DESCRIPTION
1. Some e2e tests were disabled on iOS because they hit the Apple CFStream bug.
This commit enables e2e tests and works around the Apple bug by disabling CFStream. 

2. Pulled in fix for b/138236556 in GTMGoogleTestRunner.

3. Fixed some bugs in end2end_test and disabled the test because it now it consistenly hits b/138684610.

4. Fix time_jump_test flake.