### PR TITLE
Make Map<> copyable.

### DIFF
--- a/test/core/gprpp/map_test.cc
+++ b/test/core/gprpp/map_test.cc
@@ -466,6 +466,35 @@ TEST_F(MapTest, MoveAssignment) {
   EXPECT_EQ(test_map2.end(), test_map2.find("xxx"));
 }
 
+// Test copy ctor
+TEST_F(MapTest, CopyCtor) {
+  Map<const char*, Payload, StringLess> test_map;
+  for (int i = 0; i < 5; i++) {
+    test_map.emplace(kKeys[i], Payload(i));
+  }
+  Map<const char*, Payload, StringLess> test_map2 = test_map;
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(i, test_map.find(kKeys[i])->second.data());
+    EXPECT_EQ(i, test_map2.find(kKeys[i])->second.data());
+  }
+}
+
+// Test copy assignment
+TEST_F(MapTest, CopyAssignment) {
+  Map<const char*, Payload, StringLess> test_map;
+  for (int i = 0; i < 5; i++) {
+    test_map.emplace(kKeys[i], Payload(i));
+  }
+  Map<const char*, Payload, StringLess> test_map2;
+  test_map2.emplace("xxx", Payload(123));
+  test_map2 = test_map;
+  for (int i = 0; i < 5; i++) {
+    EXPECT_EQ(i, test_map.find(kKeys[i])->second.data());
+    EXPECT_EQ(i, test_map2.find(kKeys[i])->second.data());
+  }
+  EXPECT_EQ(test_map2.end(), test_map2.find("xxx"));
+}
+
 }  // namespace testing
 }  // namespace grpc_core
 


### PR DESCRIPTION
This also adds `const_iterator` support.

Pulled this out of #19036.