### PR TITLE
Add .history to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,6 +140,7 @@ bm_*.json
 
 # Visual Studio Code artifacts
 .vscode/*
+.history/
 
 # Clion artifacts
 cmake-build-debug/


### PR DESCRIPTION
Added `.history` directory which history plugin for visual studio code uses to `.gitignore`.