### PR TITLE
More strict C++

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_load_balancer_api.h
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_load_balancer_api.h
@@ -37,7 +37,8 @@ struct XdsLocalityInfo {
 
   // This comparator only compares the locality names.
   struct Less {
-    bool operator()(const XdsLocalityInfo& lhs, const XdsLocalityInfo& rhs) {
+    bool operator()(const XdsLocalityInfo& lhs,
+                    const XdsLocalityInfo& rhs) const {
       return XdsLocalityName::Less()(lhs.locality_name, rhs.locality_name);
     }
   };

--- a/src/core/ext/filters/client_channel/resolving_lb_policy.cc
+++ b/src/core/ext/filters/client_channel/resolving_lb_policy.cc
@@ -160,6 +160,8 @@ class ResolvingLoadBalancingPolicy::ResolvingControlHelper
     }
   }
 
+  void AddTraceEvent(TraceSeverity severity, const char* message) override {}
+
   void set_child(LoadBalancingPolicy* child) { child_ = child; }
 
  private:

--- a/src/core/lib/channel/channelz.h
+++ b/src/core/lib/channel/channelz.h
@@ -81,7 +81,10 @@ class BaseNode : public RefCounted<BaseNode> {
     kSocket,
   };
 
+ protected:
   BaseNode(EntityType type, UniquePtr<char> name);
+
+ public:
   virtual ~BaseNode();
 
   // All children must implement this function.


### PR DESCRIPTION
More strict C++ before having full C++11

- Added missing const qualifier to operator() of less.
- Added missing overriding member function `AddTraceEvent` to non-abstract class.
- Hided the constructor of BaseNode because it cannot be instantiated directly.