### PR TITLE
return unavailable on transport closed

### DIFF
--- a/test/core/end2end/tests/max_connection_age.cc
+++ b/test/core/end2end/tests/max_connection_age.cc
@@ -204,7 +204,7 @@ static void test_max_age_forcibly_close(grpc_end2end_test_config config) {
 
   /* The connection should be closed immediately after the max age grace period,
      the in-progress RPC should fail. */
-  GPR_ASSERT(status == GRPC_STATUS_INTERNAL);
+  GPR_ASSERT(status == GRPC_STATUS_UNAVAILABLE);
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/foo"));
   GPR_ASSERT(was_cancelled == 1);
 

--- a/test/core/end2end/tests/shutdown_finishes_calls.cc
+++ b/test/core/end2end/tests/shutdown_finishes_calls.cc
@@ -166,9 +166,7 @@ static void test_early_server_shutdown_finishes_inflight_calls(
 
   grpc_server_destroy(f.server);
 
-  // new code should give INTERNAL, some older code will give UNAVAILABLE
-  GPR_ASSERT(status == GRPC_STATUS_INTERNAL ||
-             status == GRPC_STATUS_UNAVAILABLE);
+  GPR_ASSERT(status == GRPC_STATUS_UNAVAILABLE);
   GPR_ASSERT(0 == grpc_slice_str_cmp(call_details.method, "/foo"));
   GPR_ASSERT(was_cancelled == 1);
 


### PR DESCRIPTION
Unless there is an explicit error with grpc or http2 error.

This is consistent with the recommendation in https://github.com/grpc/grpc/blob/master/doc/statuscodes.md

This is a behavior change.