### PR TITLE
Implemented _abort method on ServicerContext

### DIFF
--- a/src/python/grpcio_testing/grpc_testing/_server/_servicer_context.py
+++ b/src/python/grpcio_testing/grpc_testing/_server/_servicer_context.py
@@ -74,9 +74,8 @@ class ServicerContext(grpc.ServicerContext):
             _common.fuss_with_metadata(trailing_metadata))
 
     def abort(self, code, details):
-        self._rpc._condition.acquire()
-        self._rpc._abort(code, details)
-        self._rpc._condition.release()
+        with self._rpc._condition:
+            self._rpc._abort(code, details)
 
     def abort_with_status(self, status):
         raise NotImplementedError()


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/19153

This acquires a lock from the _condition member of the context's _rpc
and then aborts the _rpc directly


Note: This is the first PR that I have submitted against grpc/grpc (but not my first attempt). It's been hard for me to get up and running with tests, which is why I didn't follow through with previous attempts on other issues (all related to the Python library). Am willing to spend time onboarding if someone can give me some pointers.

Specifically:
1. How do I run tests?
2. How should versioning be handled? It looks like there's a template, but I hesitate to make any changes there.
