### PR TITLE
Stop the failing Python LocalCredentials test on Windows

### DIFF
--- a/src/python/grpcio_tests/commands.py
+++ b/src/python/grpcio_tests/commands.py
@@ -160,8 +160,7 @@ class TestGevent(setuptools.Command):
     )
     BANNED_WINDOWS_TESTS = (
         # TODO(https://github.com/grpc/grpc/pull/15411) enable this test
-        'unit._dns_resolver_test.DNSResolverTest.test_connect_loopback',
-    )
+        'unit._dns_resolver_test.DNSResolverTest.test_connect_loopback',)
     description = 'run tests with gevent.  Assumes grpc/gevent are installed'
     user_options = []
 
@@ -187,7 +186,7 @@ class TestGevent(setuptools.Command):
         loader = tests.Loader()
         loader.loadTestsFromNames(['tests'])
         runner = tests.Runner()
-        if os.name == 'nt':
+        if sys.platform == 'win32':
             runner.skip_tests(self.BANNED_TESTS + self.BANNED_WINDOWS_TESTS)
         else:
             runner.skip_tests(self.BANNED_TESTS)


### PR DESCRIPTION
Related: #20078
