### PR TITLE
Run auditwheel-show to python artifacts

### DIFF
--- a/tools/dockerfile/grpc_artifact_python_manylinux_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux_x64/Dockerfile
@@ -32,7 +32,7 @@ RUN /opt/python/cp37-cp37m/bin/pip install cython
 ####################################################
 # Install auditwheel with fix for namespace packages
 RUN git clone https://github.com/pypa/auditwheel /usr/local/src/auditwheel
-RUN cd /usr/local/src/auditwheel && git checkout bf071b38c9fe78b025ea05c78b1cb61d7cb09939
-RUN /opt/python/cp35-cp35m/bin/pip install /usr/local/src/auditwheel
+RUN cd /usr/local/src/auditwheel && git checkout 2.1
+RUN /opt/python/cp36-cp36m/bin/pip install /usr/local/src/auditwheel
 RUN rm /usr/local/bin/auditwheel
-RUN cd /usr/local/bin && ln -s /opt/python/cp35-cp35m/bin/auditwheel
+RUN cd /usr/local/bin && ln -s /opt/python/cp36-cp36m/bin/auditwheel

--- a/tools/dockerfile/grpc_artifact_python_manylinux_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux_x86/Dockerfile
@@ -32,7 +32,8 @@ RUN /opt/python/cp37-cp37m/bin/pip install cython
 ####################################################
 # Install auditwheel with fix for namespace packages
 RUN git clone https://github.com/pypa/auditwheel /usr/local/src/auditwheel
-RUN cd /usr/local/src/auditwheel && git checkout bf071b38c9fe78b025ea05c78b1cb61d7cb09939
-RUN /opt/python/cp35-cp35m/bin/pip install /usr/local/src/auditwheel
+RUN cd /usr/local/src/auditwheel && git checkout 2.1
+RUN /opt/python/cp36-cp36m/bin/pip install /usr/local/src/auditwheel
 RUN rm /usr/local/bin/auditwheel
-RUN cd /usr/local/bin && ln -s /opt/python/cp35-cp35m/bin/auditwheel
+RUN cd /usr/local/bin && ln -s /opt/python/cp36-cp36m/bin/auditwheel
+

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -79,10 +79,12 @@ ${SETARCH_CMD} "${PYTHON}" tools/distrib/python/grpcio_tools/setup.py bdist_whee
 if [ "$GRPC_BUILD_MANYLINUX_WHEEL" != "" ]
 then
   for wheel in dist/*.whl; do
+    "${AUDITWHEEL}" show "$wheel" | tee /dev/stderr | grep \"manylinux1
     "${AUDITWHEEL}" repair "$wheel" -w "$ARTIFACT_DIR"
     rm "$wheel"
   done
   for wheel in tools/distrib/python/grpcio_tools/dist/*.whl; do
+    "${AUDITWHEEL}" show "$wheel" | tee /dev/stderr | grep \"manylinux1
     "${AUDITWHEEL}" repair "$wheel" -w "$ARTIFACT_DIR"
     rm "$wheel"
   done


### PR DESCRIPTION
- Updated `auditwheel` to 2.1
- Updated the build script to run `auditwheel-show` to make sure that built artifacts are compliant with `manylinux1`