### PR TITLE
Replace 32bit/debian:jessie with i386/debian:jessie

### DIFF
--- a/templates/tools/dockerfile/test/cxx_jessie_x86/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_jessie_x86/Dockerfile.template
@@ -14,7 +14,7 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
   
-  FROM 32bit/debian:jessie
+  FROM i386/debian:jessie
   RUN sed -i '/deb http:\/\/http.debian.net\/debian jessie-updates main/d' /etc/apt/sources.list
   
   <%include file="../../apt_get_basic.include"/>

--- a/tools/dockerfile/distribtest/csharp_jessie_x86/Dockerfile
+++ b/tools/dockerfile/distribtest/csharp_jessie_x86/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM 32bit/debian:jessie
+FROM i386/debian:jessie
 
 RUN apt-get update && apt-get install -y apt-transport-https && apt-get clean
 

--- a/tools/dockerfile/distribtest/node_jessie_x86/Dockerfile
+++ b/tools/dockerfile/distribtest/node_jessie_x86/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM 32bit/debian:jessie
+FROM i386/debian:jessie
 
 RUN apt-get update && apt-get install -y curl
 

--- a/tools/dockerfile/distribtest/python_dev_jessie_x86/Dockerfile
+++ b/tools/dockerfile/distribtest/python_dev_jessie_x86/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM 32bit/debian:jessie
+FROM i386/debian:jessie
 
 RUN apt-get update && apt-get install -y python python-pip
 

--- a/tools/dockerfile/distribtest/python_jessie_x86/Dockerfile
+++ b/tools/dockerfile/distribtest/python_jessie_x86/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM 32bit/debian:jessie
+FROM i386/debian:jessie
 
 RUN apt-get update && apt-get install -y python python-pip
 

--- a/tools/dockerfile/distribtest/ruby_jessie_x86/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_jessie_x86/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM 32bit/debian:jessie
+FROM i386/debian:jessie
 
 RUN apt-get update && apt-get install -y ruby-full
 

--- a/tools/dockerfile/test/cxx_jessie_x86/Dockerfile
+++ b/tools/dockerfile/test/cxx_jessie_x86/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM 32bit/debian:jessie
+FROM i386/debian:jessie
 RUN sed -i '/deb http:\/\/http.debian.net\/debian jessie-updates main/d' /etc/apt/sources.list
 
 # Install Git and basic packages.

--- a/tools/internal_ci/helper_scripts/prepare_build_linux_perf_multilang_rc
+++ b/tools/internal_ci/helper_scripts/prepare_build_linux_perf_multilang_rc
@@ -30,7 +30,7 @@ sudo pip install tabulate
 export PATH="$HOME/.rbenv/bin:$PATH"
 eval "$(rbenv init -)"
 gem list bundler
-gem install bundler --no-ri --no-rdoc
+gem install bundler --no-document
 
 # Allow SSH to Kokoro performance workers without explicit key verification
 gsutil cp gs://grpc-testing-secrets/grpc_kokoro_performance_ssh_keys/id_rsa ~/.ssh


### PR DESCRIPTION
Changed the base image of all docker images based on `32bit/debian:jessie` to `i386/debian:jessie` because it's more proper and up-to-date one.