### PR TITLE
Fix race in bm_chttp2_transport

### DIFF
--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -27,6 +27,14 @@ grpc_cc_test(
     deps = ["//test/core/util:grpc_test_util"],
 )
 
+grpc_cc_binary(
+    name = "bm_chttp2_transport",
+    testonly = 1,
+    srcs = ["bm_chttp2_transport.cc"],
+    tags = ["no_windows"],
+    deps = [":helpers"],
+)
+
 grpc_cc_library(
     name = "helpers",
     testonly = 1,

--- a/test/cpp/microbenchmarks/bm_chttp2_transport.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_transport.cc
@@ -239,7 +239,7 @@ class Stream {
     grpc_transport_destroy_stream(stream->f_->transport(),
                                   static_cast<grpc_stream*>(stream->stream_),
                                   stream->destroy_closure_);
-    gpr_event_set(&stream->done_, (void*)1);
+    gpr_event_set(&stream->done_, (void*)(1));
   }
 
   Fixture* f_;
@@ -254,6 +254,7 @@ class Stream {
 ////////////////////////////////////////////////////////////////////////////////
 // Benchmarks
 //
+std::vector<std::unique_ptr<gpr_event>> done_events;
 
 static void BM_StreamCreateDestroy(benchmark::State& state) {
   TrackCounters track_counters;
@@ -380,14 +381,23 @@ static void BM_TransportEmptyOp(benchmark::State& state) {
   reset_op();
   op.cancel_stream = true;
   op_payload.cancel_stream.cancel_error = GRPC_ERROR_CANCELLED;
+  gpr_event* stream_cancel_done = new gpr_event;
+  gpr_event_init(stream_cancel_done);
+  std::unique_ptr<Closure> stream_cancel_closure =
+      MakeClosure([&](grpc_error* error) {
+        GPR_ASSERT(error == GRPC_ERROR_NONE);
+        gpr_event_set(stream_cancel_done, (void*)(1));
+      });
+  op.on_complete = stream_cancel_closure.get();
   s->Op(&op);
+  f.FlushExecCtx();
+  gpr_event_wait(stream_cancel_done, gpr_inf_future(GPR_CLOCK_REALTIME));
+  done_events.emplace_back(stream_cancel_done);
   s->DestroyThen(MakeOnceClosure([s](grpc_error* error) { delete s; }));
   f.FlushExecCtx();
   track_counters.Finish(state);
 }
 BENCHMARK(BM_TransportEmptyOp);
-
-std::vector<std::unique_ptr<gpr_event>> done_events;
 
 static void BM_TransportStreamSend(benchmark::State& state) {
   TrackCounters track_counters;
@@ -424,7 +434,7 @@ static void BM_TransportStreamSend(benchmark::State& state) {
 
   std::unique_ptr<Closure> c = MakeClosure([&](grpc_error* error) {
     if (!state.KeepRunning()) {
-      gpr_event_set(bm_done, (void*)1);
+      gpr_event_set(bm_done, (void*)(1));
       return;
     }
     grpc_slice_buffer send_buffer;
@@ -455,7 +465,18 @@ static void BM_TransportStreamSend(benchmark::State& state) {
   reset_op();
   op.cancel_stream = true;
   op.payload->cancel_stream.cancel_error = GRPC_ERROR_CANCELLED;
+  gpr_event* stream_cancel_done = new gpr_event;
+  gpr_event_init(stream_cancel_done);
+  std::unique_ptr<Closure> stream_cancel_closure =
+      MakeClosure([&](grpc_error* error) {
+        GPR_ASSERT(error == GRPC_ERROR_NONE);
+        gpr_event_set(stream_cancel_done, (void*)(1));
+      });
+  op.on_complete = stream_cancel_closure.get();
   s->Op(&op);
+  f.FlushExecCtx();
+  gpr_event_wait(stream_cancel_done, gpr_inf_future(GPR_CLOCK_REALTIME));
+  done_events.emplace_back(stream_cancel_done);
   s->DestroyThen(MakeOnceClosure([s](grpc_error* error) { delete s; }));
   f.FlushExecCtx();
   track_counters.Finish(state);
@@ -629,7 +650,18 @@ static void BM_TransportStreamRecv(benchmark::State& state) {
   reset_op();
   op.cancel_stream = true;
   op.payload->cancel_stream.cancel_error = GRPC_ERROR_CANCELLED;
+  gpr_event* stream_cancel_done = new gpr_event;
+  gpr_event_init(stream_cancel_done);
+  std::unique_ptr<Closure> stream_cancel_closure =
+      MakeClosure([&](grpc_error* error) {
+        GPR_ASSERT(error == GRPC_ERROR_NONE);
+        gpr_event_set(stream_cancel_done, (void*)(1));
+      });
+  op.on_complete = stream_cancel_closure.get();
   s->Op(&op);
+  f.FlushExecCtx();
+  gpr_event_wait(stream_cancel_done, gpr_inf_future(GPR_CLOCK_REALTIME));
+  done_events.emplace_back(stream_cancel_done);
   s->DestroyThen(MakeOnceClosure([s](grpc_error* error) { delete s; }));
   grpc_metadata_batch_destroy(&b);
   grpc_metadata_batch_destroy(&b_recv);


### PR DESCRIPTION
This PR fixes a race in bm_chttp2_transport whereby the transport op was going out of scope while perform_stream_op_locked was trying to access it. The issue is that the benchmark was not waiting for the cancel stream op to complete before exiting. There's also another issue of trying to destroy the stream before the stream has been cancelled.

Fixes https://github.com/grpc/grpc/issues/19877

Note to self: I suspect the benchmarks that I didn't modify may suffer from this race as well, but they're of a different structure from the benchmark that's actually failing in our tests, so I have to experiment more with how to fix them. For now, I fixed 3/5 of the benchmarks, and it's important to get this fix in soon since the bug causes near-continuous failures on master.