### PR TITLE
enable compute_engine_creds and jwt_token_creds interop tests for managed dotnet client

### DIFF
--- a/tools/run_tests/run_interop_tests.py
+++ b/tools/run_tests/run_interop_tests.py
@@ -208,8 +208,6 @@ class AspNetCoreLanguage:
 
     def unimplemented_test_cases(self):
         return _SKIP_COMPRESSION + \
-            ['compute_engine_creds']  + \
-            ['jwt_token_creds'] + \
             _SKIP_GOOGLE_DEFAULT_CREDS + \
             _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS
 


### PR DESCRIPTION
They should work now due to recently added support for ChannelCredentials.

Removing _SKIP_GOOGLE_DEFAULT_CREDS and _SKIP_COMPUTE_ENGINE_CHANNEL_CREDS is out of scope for now because they rely on special functionality implemented only in C core and one the auth test cases are enabling sufficiently cover all the use cases we need.