### PR TITLE
Fix ubsan on InternNewStringLocked

### DIFF
--- a/src/core/lib/slice/slice_intern.cc
+++ b/src/core/lib/slice/slice_intern.cc
@@ -208,7 +208,11 @@ static InternedSliceRefcount* InternNewStringLocked(slice_shard* shard,
   InternedSliceRefcount* s =
       static_cast<InternedSliceRefcount*>(gpr_malloc(sizeof(*s) + len));
   new (s) grpc_core::InternedSliceRefcount(len, hash, shard->strs[shard_idx]);
-  memcpy(reinterpret_cast<char*>(s + 1), buffer, len);
+  // TODO(arjunroy): Investigate why hpack tried to intern the nullptr string.
+  // https://github.com/grpc/grpc/pull/20110#issuecomment-526729282
+  if (len > 0) {
+    memcpy(reinterpret_cast<char*>(s + 1), buffer, len);
+  }
   shard->strs[shard_idx] = s;
   shard->count++;
   if (shard->count > shard->capacity * 2) {


### PR DESCRIPTION
This PR fixes the following UBSAN error.

```
src/core/lib/slice/slice_intern.cc:211:42: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:47:28: note: nonnull attribute specified here
    #0 0x5937ab in grpc_core::InternedSliceRefcount* InternNewStringLocked<char const*&, unsigned long&>(slice_shard*, unsigned long, unsigned int, char const*&, unsigned long&) /var/local/git/grpc/src/core/lib/slice/slice_intern.cc:211:3
    #1 0x58e9bf in grpc_core::InternedSliceRefcount* FindOrCreateInternedSlice<char const*&, unsigned long&>(unsigned int, char const*&, unsigned long&) /var/local/git/grpc/src/core/lib/slice/slice_intern.cc:261:9
    #2 0x58d909 in grpc_core::ManagedMemorySlice::ManagedMemorySlice(char const*, unsigned long) /var/local/git/grpc/src/core/lib/slice/slice_intern.cc:281:34
    #3 0x5ffa95 in take_string_intern(grpc_chttp2_hpack_parser*, grpc_chttp2_hpack_parser_string*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:691:9
    #4 0x5f5729 in finish_lithdr_incidx(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:840:34
    #5 0x5f3290 in parse_next(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:702:10
    #6 0x5f8999 in parse_string(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1470:12
    #7 0x5f847d in begin_parse_string(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*, unsigned char, grpc_chttp2_hpack_parser_string*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1517:10
    #8 0x5f67e8 in parse_value_string(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*, bool) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1585:10
    #9 0x5f559a in parse_value_string_with_indexed_key(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1594:10
    #10 0x5f3290 in parse_next(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:702:10
    #11 0x5f604a in parse_string_prefix(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1254:12
    #12 0x5ee21e in parse_lithdr_incidx(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:866:10
    #13 0x5e7d12 in parse_begin(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:714:10
    #14 0x5f57ae in finish_lithdr_incidx(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:842:10
    #15 0x5f3290 in parse_next(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:702:10
    #16 0x5f7a46 in begin_parse_string(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*, unsigned char, grpc_chttp2_hpack_parser_string*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1495:12
    #17 0x5f67e8 in parse_value_string(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*, bool) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1585:10
    #18 0x5f559a in parse_value_string_with_indexed_key(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1594:10
    #19 0x5f3290 in parse_next(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:702:10
    #20 0x5f604a in parse_string_prefix(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1254:12
    #21 0x5ee21e in parse_lithdr_incidx(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:866:10
    #22 0x5e7d12 in parse_begin(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:714:10
    #23 0x601fa0 in finish_max_tbl_size(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1033:10
    #24 0x5f3290 in parse_next(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:702:10
    #25 0x5f289a in parse_value0(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1111:12
    #26 0x5f1860 in parse_max_tbl_size_x(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1068:10
    #27 0x5e7d12 in parse_begin(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:714:10
    #28 0x601fa0 in finish_max_tbl_size(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1033:10
    #29 0x5f1006 in parse_max_tbl_size(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1048:10
    #30 0x5e7d12 in parse_begin(grpc_chttp2_hpack_parser*, unsigned char const*, unsigned char const*) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:714:10
    #31 0x5e9f3a in grpc_chttp2_hpack_parser_parse(grpc_chttp2_hpack_parser*, grpc_slice const&) /var/local/git/grpc/src/core/ext/transport/chttp2/transport/hpack_parser.cc:1657:13
    #32 0x556094 in LLVMFuzzerTestOneInput /var/local/git/grpc/test/core/transport/chttp2/hpack_parser_fuzzer_test.cc:45:5
    #33 0x557e52 in main /var/local/git/grpc/test/core/util/one_corpus_entry_fuzzer.cc:41:3
    #34 0x7fe77a40ab44 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b44)
    #35 0x536c8f in _start (/var/local/git/grpc/bins/ubsan/hpack_parser_fuzzer_test_one_entry+0x536c8f)
```