### PR TITLE
Revert "Implemented _abort method on ServicerContext"

### DIFF
--- a/src/python/grpcio_testing/grpc_testing/_server/_servicer_context.py
+++ b/src/python/grpcio_testing/grpc_testing/_server/_servicer_context.py
@@ -74,8 +74,7 @@ class ServicerContext(grpc.ServicerContext):
             _common.fuss_with_metadata(trailing_metadata))
 
     def abort(self, code, details):
-        with self._rpc._condition:
-            self._rpc._abort(code, details)
+        raise NotImplementedError()
 
     def abort_with_status(self, status):
         raise NotImplementedError()


### PR DESCRIPTION
Reverts grpc/grpc#20077
It breaks import and let's revert it first.