### PR TITLE
Fix `shorten-64-to-32` warning in `GRPCChannel`

### DIFF
--- a/src/objective-c/GRPCClient/private/GRPCChannel.m
+++ b/src/objective-c/GRPCClient/private/GRPCChannel.m
@@ -103,7 +103,7 @@
 
   if (_callOptions.compressionAlgorithm != GRPC_COMPRESS_NONE) {
     args[@GRPC_COMPRESSION_CHANNEL_DEFAULT_ALGORITHM] =
-        [NSNumber numberWithInt:_callOptions.compressionAlgorithm];
+        [NSNumber numberWithInteger:_callOptions.compressionAlgorithm];
   }
 
   if (_callOptions.keepaliveInterval != 0) {


### PR DESCRIPTION
Per: https://github.com/grpc/grpc/issues/20122 this change avoids the `shorten-64-to-32` warning by calling the correct `NSNumber` factory method for an `NSUInteger` (the base type for the `GRPCCompressionAlgorithm` enum)

@mhaidrygoog