### PR TITLE
Remove build target for microbenchmark

### DIFF
--- a/test/cpp/microbenchmarks/BUILD
+++ b/test/cpp/microbenchmarks/BUILD
@@ -27,14 +27,6 @@ grpc_cc_test(
     deps = ["//test/core/util:grpc_test_util"],
 )
 
-grpc_cc_binary(
-    name = "bm_chttp2_transport",
-    testonly = 1,
-    srcs = ["bm_chttp2_transport.cc"],
-    tags = ["no_windows"],
-    deps = [":helpers"],
-)
-
 grpc_cc_library(
     name = "helpers",
     testonly = 1,


### PR DESCRIPTION
This doesn't build internally and there wasn't a build target for it until my recent PR (https://github.com/grpc/grpc/pull/20091) added one. Remove it.