### PR TITLE
Remove call from queued picks when failing it due to channel destruction

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -3881,6 +3881,7 @@ void CallData::StartPickLocked(void* arg, grpc_error* error) {
         GRPC_ERROR_UNREF(result.error);
         GRPC_CLOSURE_SCHED(&calld->pick_closure_,
                            GRPC_ERROR_REF(disconnect_error));
+        if (calld->pick_queued_) calld->RemoveCallFromQueuedPicksLocked(elem);
         break;
       }
       // If wait_for_ready is false, then the error indicates the RPC


### PR DESCRIPTION
This fixes the repro of a SEGV seen in an internal stress test

For background, the test involves a few hundred grpclb/DNS channels. Here's the bottom of the log of a crash: https://gist.github.com/apolcyn/c30716d9b03d5414be0b463f3d66cf1c. gdb showed a nullptr access on `pending_batches_[0].batch` on [this line](https://github.com/grpc/grpc/blob/7564664f077cdaa720451633107352cb39e233e4/src/core/ext/filters/client_channel/client_channel.cc#L3854), with [SetPickerInDataPlane](https://github.com/grpc/grpc/blob/7564664f077cdaa720451633107352cb39e233e4/src/core/ext/filters/client_channel/client_channel.cc#L1136) in the stack trace. It also showed that this happened after the call's channel's `disconnect_error_` had already been set.