### PR TITLE
Use manylinux2010 to build python artifacts

### DIFF
--- a/tools/dockerfile/grpc_artifact_python_manylinux1_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux1_x64/Dockerfile
@@ -14,7 +14,7 @@
 
 # Docker file for building gRPC manylinux Python artifacts.
 
-FROM quay.io/pypa/manylinux1_x86_64
+FROM quay.io/pypa/manylinux2010_x86_64
 
 # Update the package manager
 RUN yum update -y
@@ -36,3 +36,7 @@ RUN cd /usr/local/src/auditwheel && git checkout 2.1
 RUN /opt/python/cp36-cp36m/bin/pip install /usr/local/src/auditwheel
 RUN rm /usr/local/bin/auditwheel
 RUN cd /usr/local/bin && ln -s /opt/python/cp36-cp36m/bin/auditwheel
+
+##############################################
+# Change the declaraed version of glibc to 2.5
+RUN sed -i 's/__GLIBC_MINOR__\t12/__GLIBC_MINOR__\t5/g' /usr/include/features.h

--- a/tools/run_tests/artifacts/artifact_targets.py
+++ b/tools/run_tests/artifacts/artifact_targets.py
@@ -161,7 +161,7 @@ class PythonArtifact:
                 environ=environ,
                 timeout_seconds=60 * 60,
                 docker_base_image='quay.io/pypa/manylinux1_i686'
-                if self.arch == 'x86' else 'quay.io/pypa/manylinux1_x86_64')
+                if self.arch == 'x86' else 'quay.io/pypa/manylinux2010_x86_64')
         elif self.platform == 'windows':
             if 'Python27' in self.py_version or 'Python34' in self.py_version:
                 environ['EXT_COMPILER'] = 'mingw32'


### PR DESCRIPTION
This is about using the latest tool chain to build gRPC. It doesn't mean that python artifacts are targeting `manylinux2010`. It will stick with `manylinux1` for a while.

Since `manylinux1` docker image doesn't support gcc 4.9+, it'd be better to use `manylinux2010` docker image bundled with gcc 8. This enables us to build abseil which requires gcc 4.9+ and might make us use abseil on gRPC Core in future.

This test is done only with x86_64 since manylinux2010 doesn't come with i686 yet.