### PR TITLE
Fix Windows's STACKFRAME Frame Addr in test_config.cc

### DIFF
--- a/test/core/util/test_config.cc
+++ b/test/core/util/test_config.cc
@@ -114,7 +114,7 @@ static void print_stack_from_context(CONTEXT c) {
   imageType = IMAGE_FILE_MACHINE_AMD64;
   s.AddrPC.Offset = c.Rip;
   s.AddrPC.Mode = AddrModeFlat;
-  s.AddrFrame.Offset = c.Rsp;
+  s.AddrFrame.Offset = c.Rbp;
   s.AddrFrame.Mode = AddrModeFlat;
   s.AddrStack.Offset = c.Rsp;
   s.AddrStack.Mode = AddrModeFlat;


### PR DESCRIPTION
Windows's STACKFRAME Frame Addr should be RBP, the base pointer, not RSP, the stack pointer. This is documented here: https://docs.microsoft.com/en-us/windows/win32/api/dbghelp/ns-dbghelp-stackframe with the comment "AddrFrame x64:  The frame pointer is RBP or RDI." Note that this is also what StackWalker uses: https://github.com/JochenKalmbach/StackWalker#initializing-the-stackframe64 and what Chromium uses: https://codesearch.chromium.org/chromium/src/v8/src/base/debug/stack_trace_win.cc?l=200&rcl=69d20d247f62a3378d15ce0956ed8bf9665e6a44

release notes: no



<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@mhaidrygoog