### PR TITLE
Remove C# workaround for DeadlineExceeded status #2685

### DIFF
--- a/src/csharp/Grpc.Core.Tests/TimeoutsTest.cs
+++ b/src/csharp/Grpc.Core.Tests/TimeoutsTest.cs
@@ -96,8 +96,7 @@ namespace Grpc.Core.Tests
             });
 
             var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(deadline: DateTime.MinValue)), "abc"));
-            // We can't guarantee the status code always DeadlineExceeded. See issue #2685.
-            Assert.Contains(ex.Status.StatusCode, new[] { StatusCode.DeadlineExceeded, StatusCode.Internal });
+            Assert.AreEqual(StatusCode.DeadlineExceeded, ex.Status.StatusCode);
         }
 
         [Test]
@@ -110,8 +109,7 @@ namespace Grpc.Core.Tests
             });
 
             var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(deadline: DateTime.UtcNow.Add(TimeSpan.FromSeconds(5)))), "abc"));
-            // We can't guarantee the status code always DeadlineExceeded. See issue #2685.
-            Assert.Contains(ex.Status.StatusCode, new[] { StatusCode.DeadlineExceeded, StatusCode.Internal });
+            Assert.AreEqual(StatusCode.DeadlineExceeded, ex.Status.StatusCode);
         }
 
         [Test]
@@ -130,9 +128,7 @@ namespace Grpc.Core.Tests
             });
 
             var ex = Assert.Throws<RpcException>(() => Calls.BlockingUnaryCall(helper.CreateUnaryCall(new CallOptions(deadline: DateTime.UtcNow.Add(TimeSpan.FromSeconds(5)))), "abc"));
-            // We can't guarantee the status code always DeadlineExceeded. See issue #2685.
-            Assert.Contains(ex.Status.StatusCode, new[] { StatusCode.DeadlineExceeded, StatusCode.Internal });
-
+            Assert.AreEqual(StatusCode.DeadlineExceeded, ex.Status.StatusCode);
             Assert.IsTrue(await serverReceivedCancellationTcs.Task);
         }
     }

--- a/src/csharp/Grpc.Examples.Tests/MathClientServerTests.cs
+++ b/src/csharp/Grpc.Examples.Tests/MathClientServerTests.cs
@@ -136,9 +136,7 @@ namespace Math.Tests
                 deadline: DateTime.UtcNow.AddMilliseconds(500)))
             {
                 var ex = Assert.ThrowsAsync<RpcException>(async () => await call.ResponseStream.ToListAsync());
-
-                // We can't guarantee the status code always DeadlineExceeded. See issue #2685.
-                Assert.Contains(ex.Status.StatusCode, new[] { StatusCode.DeadlineExceeded, StatusCode.Internal });
+                Assert.AreEqual(StatusCode.DeadlineExceeded, ex.Status.StatusCode);
             }
         }
 

--- a/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
+++ b/src/csharp/Grpc.IntegrationTesting/InteropClient.cs
@@ -476,8 +476,7 @@ namespace Grpc.IntegrationTesting
                 }
                 catch (RpcException ex)
                 {
-                    // We can't guarantee the status code always DeadlineExceeded. See issue #2685.
-                    Assert.Contains(ex.Status.StatusCode, new[] { StatusCode.DeadlineExceeded, StatusCode.Internal });
+                    Assert.AreEqual(StatusCode.DeadlineExceeded, ex.Status.StatusCode);
                 }
             }
             Console.WriteLine("Passed!");


### PR DESCRIPTION
It seems that the workaround for #2685 is no longer needed.
I ran 1000 iterations of the TimeoutsTest locally and it worked just fine.

Also, it seems that other languages are no longer using this workaround, e.g.:
https://github.com/grpc/grpc/blob/f78966eb522fe37bff65e609a7847cf473483291/test/cpp/interop/interop_client.cc#L811
https://github.com/grpc/grpc/blob/95511c0cfd13a85a83e2d457b75fcc8c201adb33/src/ruby/pb/test/client.rb#L462
https://github.com/grpc/grpc/blob/f1dfe791ab9730a1c7f1c32beb19eb72ff835e38/src/python/grpcio_tests/tests/interop/methods.py#L263
