### PR TITLE
Update debian:jessie docker to pin bundler version

### DIFF
--- a/tools/dockerfile/distribtest/ruby_jessie_x64/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_jessie_x64/Dockerfile
@@ -16,4 +16,4 @@ FROM debian:jessie
 
 RUN apt-get update && apt-get install -y ruby-full
 
-RUN gem install bundler
+RUN gem install bundler -v 1.17.3 --no-document

--- a/tools/dockerfile/distribtest/ruby_jessie_x86/Dockerfile
+++ b/tools/dockerfile/distribtest/ruby_jessie_x86/Dockerfile
@@ -16,4 +16,4 @@ FROM i386/debian:jessie
 
 RUN apt-get update && apt-get install -y ruby-full
 
-RUN gem install bundler
+RUN gem install bundler -v 1.17.3 --no-document


### PR DESCRIPTION
Since the latest bundler 2 and newer requires ruby 2.3+, the version of bundler should be pinned to get installed on debian:jessie with the ruby 2.1.