### PR TITLE
Fix PHP build error

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -33,6 +33,8 @@ if test "$PHP_GRPC" != "no"; then
       ;;
   esac
 
+  PHP_SUBST(GRPC_SHARED_LIBADD)
+
   PHP_NEW_EXTENSION(grpc,
     src/php/ext/grpc/byte_buffer.c \
     src/php/ext/grpc/call.c \

--- a/src/php/ext/grpc/config.m4
+++ b/src/php/ext/grpc/config.m4
@@ -42,14 +42,15 @@ if test "$PHP_GRPC" != "no"; then
   dnl  PHP_ADD_LIBRARY(pthread,,GRPC_SHARED_LIBADD)
   GRPC_SHARED_LIBADD="-lpthread $GRPC_SHARED_LIBADD"
   PHP_ADD_LIBRARY(pthread)
-  PHP_ADD_LIBRARY(stdc++,,GRPC_SHARED_LIBADD)
-  PHP_ADD_LIBRARY(stdc++)
   PHP_ADD_LIBRARY(dl,,GRPC_SHARED_LIBADD)
   PHP_ADD_LIBRARY(dl)
 
   case $host in
-    *darwin*) ;;
+    *darwin*) 
+      PHP_ADD_LIBRARY(c++,1,GRPC_SHARED_LIBADD)
+      ;;
     *)
+      PHP_ADD_LIBRARY(stdc++,1,GRPC_SHARED_LIBADD)
       PHP_ADD_LIBRARY(rt,,GRPC_SHARED_LIBADD)
       PHP_ADD_LIBRARY(rt)
       ;;

--- a/templates/config.m4.template
+++ b/templates/config.m4.template
@@ -35,6 +35,8 @@
         ;;
     esac
 
+    PHP_SUBST(GRPC_SHARED_LIBADD)
+
     PHP_NEW_EXTENSION(grpc,
       % for source in php_config_m4.src:
       ${source} ${"\\"}


### PR DESCRIPTION
Fix the PHP build error (introduced by #19918)

```
+ php -d extension=grpc.so -d max_execution_time=300 distribtest.php
PHP Warning:  PHP Startup: Unable to load dynamic library '/usr/lib/php5/20131226/grpc.so' 
  - /usr/lib/php5/20131226/grpc.so: undefined symbol: __cxa_pure_virtual in Unknown on line 0
PHP Fatal error:  Class 'Grpc\Channel' not found in 
  /var/local/git/grpc/test/distrib/php/distribtest.php on line 20
```

This error is caused because the dependency to libstdc++.so was not properly added to gRPC module.