### PR TITLE
hpack encoder optimizations.

### DIFF
--- a/src/core/lib/slice/slice_internal.h
+++ b/src/core/lib/slice/slice_internal.h
@@ -214,23 +214,39 @@ struct InternedSliceRefcount {
 
 }  // namespace grpc_core
 
+inline size_t grpc_refcounted_slice_length(const grpc_slice& slice) {
+  GPR_DEBUG_ASSERT(slice.refcount != nullptr);
+  return slice.data.refcounted.length;
+}
+
+inline const uint8_t* grpc_refcounted_slice_data(const grpc_slice& slice) {
+  GPR_DEBUG_ASSERT(slice.refcount != nullptr);
+  return slice.data.refcounted.bytes;
+}
+
 inline int grpc_slice_refcount::Eq(const grpc_slice& a, const grpc_slice& b) {
+  GPR_DEBUG_ASSERT(a.refcount != nullptr);
+  GPR_DEBUG_ASSERT(a.refcount == this);
   switch (ref_type_) {
     case Type::STATIC:
-      return GRPC_STATIC_METADATA_INDEX(a) == GRPC_STATIC_METADATA_INDEX(b);
+      GPR_DEBUG_ASSERT(
+          (GRPC_STATIC_METADATA_INDEX(a) == GRPC_STATIC_METADATA_INDEX(b)) ==
+          (a.refcount == b.refcount));
     case Type::INTERNED:
       return a.refcount == b.refcount;
     case Type::NOP:
     case Type::REGULAR:
       break;
   }
-  if (GRPC_SLICE_LENGTH(a) != GRPC_SLICE_LENGTH(b)) return false;
-  if (GRPC_SLICE_LENGTH(a) == 0) return true;
-  return 0 == memcmp(GRPC_SLICE_START_PTR(a), GRPC_SLICE_START_PTR(b),
-                     GRPC_SLICE_LENGTH(a));
+  if (grpc_refcounted_slice_length(a) != GRPC_SLICE_LENGTH(b)) return false;
+  if (grpc_refcounted_slice_length(a) == 0) return true;
+  return 0 == memcmp(grpc_refcounted_slice_data(a), GRPC_SLICE_START_PTR(b),
+                     grpc_refcounted_slice_length(a));
 }
 
 inline uint32_t grpc_slice_refcount::Hash(const grpc_slice& slice) {
+  GPR_DEBUG_ASSERT(slice.refcount != nullptr);
+  GPR_DEBUG_ASSERT(slice.refcount == this);
   switch (ref_type_) {
     case Type::STATIC:
       return ::grpc_static_metadata_hash_values[GRPC_STATIC_METADATA_INDEX(
@@ -242,8 +258,8 @@ inline uint32_t grpc_slice_refcount::Hash(const grpc_slice& slice) {
     case Type::REGULAR:
       break;
   }
-  return gpr_murmur_hash3(GRPC_SLICE_START_PTR(slice), GRPC_SLICE_LENGTH(slice),
-                          g_hash_seed);
+  return gpr_murmur_hash3(grpc_refcounted_slice_data(slice),
+                          grpc_refcounted_slice_length(slice), g_hash_seed);
 }
 
 inline const grpc_slice& grpc_slice_ref_internal(const grpc_slice& slice) {

--- a/src/core/lib/surface/call.cc
+++ b/src/core/lib/surface/call.cc
@@ -910,6 +910,9 @@ static int prepare_application_metadata(grpc_call* call, int count,
                    "validate_metadata",
                    grpc_validate_header_nonbin_value_is_legal(md->value))) {
       break;
+    } else if (GRPC_SLICE_LENGTH(md->value) >= UINT32_MAX) {
+      // HTTP2 hpack encoding has a maximum limit.
+      break;
     }
     l->md = grpc_mdelem_from_grpc_metadata(const_cast<grpc_metadata*>(md));
   }

--- a/src/core/lib/surface/validate_metadata.cc
+++ b/src/core/lib/surface/validate_metadata.cc
@@ -67,6 +67,10 @@ grpc_error* grpc_validate_header_key_is_legal(const grpc_slice& slice) {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "Metadata keys cannot be zero length");
   }
+  if (GRPC_SLICE_LENGTH(slice) > UINT32_MAX) {
+    return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
+        "Metadata keys cannot be larger than UINT32_MAX");
+  }
   if (GRPC_SLICE_START_PTR(slice)[0] == ':') {
     return GRPC_ERROR_CREATE_FROM_STATIC_STRING(
         "Metadata keys cannot start with :");

--- a/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
+++ b/test/cpp/microbenchmarks/bm_chttp2_hpack.cc
@@ -131,11 +131,12 @@ static void BM_HpackEncoderEncodeHeader(benchmark::State& state) {
   grpc_slice_buffer outbuf;
   grpc_slice_buffer_init(&outbuf);
   while (state.KeepRunning()) {
+    static constexpr int kEnsureMaxFrameAtLeast = 2;
     grpc_encode_header_options hopt = {
         static_cast<uint32_t>(state.iterations()),
         state.range(0) != 0,
         Fixture::kEnableTrueBinary,
-        static_cast<size_t>(state.range(1)),
+        static_cast<size_t>(state.range(1) + kEnsureMaxFrameAtLeast),
         &stats,
     };
     grpc_chttp2_encode_header(c.get(), nullptr, 0, &b, &hopt, &outbuf);


### PR DESCRIPTION
Removed some cycles and branches from hpack_enc for CH2.
Specifically:
1. Pushed certain metadata key/value length checks to
prepare_application_metadata() in src/core/lib/surface/call.cc.
This means that rather than check all key/val lengths for all metadata, we only
do so for custom added user metadata. Inside CH2, we change the length checks to
debug checks so we can catch if core/filter metadata fails to pass the check.

2. Changed various asserts to debug asserts when able.

3. Refactored some of the header emission code to remove duplicated code.

4. Un-inlined some logging methods.

This results in somewhat faster hpack_encoder performance,
and about 2-3% latency improvement for fullstack unary microbenchmarks:

BM_HpackEncoderInitDestroy
222ns ± 0%              221ns ± 0%   -0.29%        (p=0.000 n=34+34)
BM_HpackEncoderEncodeDeadline
[framing_bytes/iter:9 header_bytes/iter:6       ]               135ns ± 1%
124ns ± 0%   -8.05%        (p=0.000 n=39+38)
BM_HpackEncoderEncodeHeader<EmptyBatch>/0/16384
[framing_bytes/iter:9 header_bytes/iter:0       ]              34.2ns ± 0%
34.2ns ± 0%   -0.01%        (p=0.014 n=34+38)
BM_HpackEncoderEncodeHeader<EmptyBatch>/1/16384
[framing_bytes/iter:9 header_bytes/iter:0       ]              34.2ns ± 0%
34.2ns ± 0%   -0.04%        (p=0.004 n=34+37)
BM_HpackEncoderEncodeHeader<SingleStaticElem>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              47.5ns ± 0%
45.9ns ± 0%   -3.28%        (p=0.000 n=28+38)
BM_HpackEncoderEncodeHeader<SingleInternedKeyElem>/0/16384
[framing_bytes/iter:9 header_bytes/iter:6       ]              77.0ns ± 1%
68.3ns ± 1%  -11.33%        (p=0.000 n=39+40)
BM_HpackEncoderEncodeHeader<SingleInternedElem>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              47.7ns ± 1%
45.5ns ± 0%   -4.63%        (p=0.000 n=39+33)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<1, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              47.2ns ± 0%
45.3ns ± 0%   -3.96%        (p=0.000 n=33+34)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<3, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              47.7ns ± 0%
45.6ns ± 0%   -4.54%        (p=0.000 n=38+40)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<10, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              47.7ns ± 0%
45.5ns ± 0%   -4.63%        (p=0.000 n=39+32)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<31, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              47.8ns ± 0%
45.6ns ± 1%   -4.59%        (p=0.000 n=38+39)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<100, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              47.8ns ± 0%
45.5ns ± 0%   -4.64%        (p=0.000 n=39+36)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<1, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              47.3ns ± 0%
45.3ns ± 0%   -4.09%        (p=0.000 n=38+36)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<3, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              47.8ns ± 1%
45.6ns ± 0%   -4.71%        (p=0.000 n=37+40)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<10, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              47.7ns ± 0%
45.5ns ± 0%   -4.66%        (p=0.000 n=39+32)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<31, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              47.8ns ± 1%
45.6ns ± 1%   -4.62%        (p=0.000 n=37+39)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<100, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              47.7ns ± 0%
45.5ns ± 0%   -4.67%        (p=0.000 n=38+32)
BM_HpackEncoderEncodeHeader<SingleNonInternedElem>/0/16384
[framing_bytes/iter:9 header_bytes/iter:9       ]              80.5ns ± 1%
74.7ns ± 0%   -7.16%        (p=0.000 n=38+35)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<1, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:12      ]               105ns ± 1%
99ns ± 0%   -5.91%        (p=0.000 n=38+34)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<3, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:14      ]               111ns ± 1%
106ns ± 1%   -4.86%         (p=0.020 n=39+2)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<10, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:23      ]               135ns ± 0%
130ns ± 0%   -3.45%         (p=0.020 n=35+2)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<31, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:46      ]               225ns ± 1%
223ns ± 0%   -0.91%         (p=0.003 n=37+2)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<100, false>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:120     ]               467ns ± 0%
472ns ± 0%   +1.09%         (p=0.003 n=38+2)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<1, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:12      ]              81.6ns ± 1%
74.8ns ± 0%   -8.40%        (p=0.000 n=37+33)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<3, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:14      ]              82.0ns ± 1%
74.8ns ± 0%   -8.80%        (p=0.000 n=37+32)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<10, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:21      ]              82.1ns ± 1%
74.9ns ± 0%   -8.86%        (p=0.000 n=35+34)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<31, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:42      ]              97.6ns ± 2%
91.8ns ± 0%   -5.95%        (p=0.000 n=35+27)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<100, true>>/0/16384
[framing_bytes/iter:9 header_bytes/iter:111     ]              97.2ns ± 1%
91.2ns ± 2%   -6.19%        (p=0.000 n=37+38)
BM_HpackEncoderEncodeHeader<SingleNonInternedElem>/0/1
[framing_bytes/iter:54 header_bytes/iter:9      ]               230ns ± 0%
221ns ± 0%   -3.91%        (p=0.000 n=38+37)
BM_HpackEncoderEncodeHeader<MoreRepresentativeClientInitialMetadata>/0/16384
[framing_bytes/iter:9 header_bytes/iter:16      ]               206ns ± 2%
170ns ± 1%  -17.51%        (p=0.000 n=39+39)
BM_HpackEncoderEncodeHeader<RepresentativeServerInitialMetadata>/0/16384
[framing_bytes/iter:9 header_bytes/iter:3       ]              66.4ns ± 2%
62.5ns ± 1%   -5.85%        (p=0.000 n=34+39)
BM_HpackEncoderEncodeHeader<RepresentativeServerTrailingMetadata>/1/16384
[framing_bytes/iter:9 header_bytes/iter:1       ]              47.5ns ± 0%
45.9ns ± 1%   -3.29%        (p=0.000 n=26+38)




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nanahpang
