### PR TITLE
Trim trailing spaces from PHP config.m4

### DIFF
--- a/src/php/ext/grpc/config.m4
+++ b/src/php/ext/grpc/config.m4
@@ -46,7 +46,7 @@ if test "$PHP_GRPC" != "no"; then
   PHP_ADD_LIBRARY(dl)
 
   case $host in
-    *darwin*) 
+    *darwin*)
       PHP_ADD_LIBRARY(c++,1,GRPC_SHARED_LIBADD)
       ;;
     *)
@@ -94,7 +94,7 @@ if test "$PHP_COVERAGE" = "yes"; then
   if test "$GCC" != "yes"; then
     AC_MSG_ERROR([GCC is required for --enable-coverage])
   fi
-  
+
   dnl Check if ccache is being used
   case `$php_shtool path $CC` in
     *ccache*[)] gcc_ccache=yes;;
@@ -104,7 +104,7 @@ if test "$PHP_COVERAGE" = "yes"; then
   if test "$gcc_ccache" = "yes" && (test -z "$CCACHE_DISABLE" || test "$CCACHE_DISABLE" != "1"); then
     AC_MSG_ERROR([ccache must be disabled when --enable-coverage option is used. You can disable ccache by setting environment variable CCACHE_DISABLE=1.])
   fi
-  
+
   lcov_version_list="1.5 1.6 1.7 1.9 1.10 1.11 1.12 1.13"
 
   AC_CHECK_PROG(LCOV, lcov, lcov)
@@ -123,7 +123,7 @@ if test "$PHP_COVERAGE" = "yes"; then
       done
     ])
   else
-    lcov_msg="To enable code coverage reporting you must have one of the following LCOV versions installed: $lcov_version_list"      
+    lcov_msg="To enable code coverage reporting you must have one of the following LCOV versions installed: $lcov_version_list"
     AC_MSG_ERROR([$lcov_msg])
   fi
 


### PR DESCRIPTION
Just trimmed trailing spaces. This is about testing distrib_test on php with #20169. It's good to be merged because it cleans up the code a little bit :)