### PR TITLE
Don't start AuthMetadataProcessor threadpool for non-blocking processor

### DIFF
--- a/src/cpp/server/secure_server_credentials.h
+++ b/src/cpp/server/secure_server_credentials.h
@@ -46,7 +46,11 @@ class AuthMetadataProcessorAyncWrapper final {
 
   AuthMetadataProcessorAyncWrapper(
       const std::shared_ptr<AuthMetadataProcessor>& processor)
-      : thread_pool_(CreateDefaultThreadPool()), processor_(processor) {}
+      : processor_(processor) {
+    if (processor && processor->IsBlocking()) {
+      thread_pool_.reset(CreateDefaultThreadPool());
+    }
+  }
 
  private:
   void InvokeProcessor(grpc_auth_context* context, const grpc_metadata* md,


### PR DESCRIPTION
This is based on #17200 by @nathan-prat which was closed as stale. The code was approved previously but the author never signed a CLA so we could not accept it as is. Revived with minor changes.

Fixes #16855 

Cc @thisisnotapril