### PR TITLE
Add Python 3.6 to default gRPC Python test environments

### DIFF
--- a/templates/tools/dockerfile/compile_python_36.include
+++ b/templates/tools/dockerfile/compile_python_36.include
@@ -1,0 +1,15 @@
+#=================
+# Compile CPython 3.6.9 from source
+
+RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
+RUN apt-get update && apt-get install -y jq build-essential libffi-dev
+
+RUN cd /tmp && ${'\\'}
+wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && ${'\\'}
+tar xzvf Python-3.6.9.tgz && ${'\\'}
+cd Python-3.6.9 && ${'\\'}
+./configure && ${'\\'}
+make install
+
+RUN python3.6 -m ensurepip && ${'\\'}
+    python3.6 -m pip install coverage

--- a/templates/tools/dockerfile/compile_python_36.include
+++ b/templates/tools/dockerfile/compile_python_36.include
@@ -5,11 +5,15 @@ RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
 RUN apt-get update && apt-get install -y jq build-essential libffi-dev
 
 RUN cd /tmp && ${'\\'}
-wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && ${'\\'}
-tar xzvf Python-3.6.9.tgz && ${'\\'}
-cd Python-3.6.9 && ${'\\'}
-./configure && ${'\\'}
-make install
+    wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && ${'\\'}
+    tar xzvf Python-3.6.9.tgz && ${'\\'}
+    cd Python-3.6.9 && ${'\\'}
+    ./configure && ${'\\'}
+    make install
+
+RUN cd /tmp && ${'\\'}
+    echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && ${'\\'}
+    md5sum -c checksum.md5
 
 RUN python3.6 -m ensurepip && ${'\\'}
     python3.6 -m pip install coverage

--- a/templates/tools/dockerfile/compile_python_38.include
+++ b/templates/tools/dockerfile/compile_python_38.include
@@ -1,0 +1,19 @@
+#=================
+# Compile CPython 3.8.0b4 from source
+
+RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
+RUN apt-get update && apt-get install -y jq build-essential libffi-dev
+
+RUN cd /tmp && ${'\\'}
+    wget -q https://www.python.org/ftp/python/3.8.0/Python-3.8.0b4.tgz && ${'\\'}
+    tar xzvf Python-3.8.0b4.tgz && ${'\\'}
+    cd Python-3.8.0b4 && ${'\\'}
+    ./configure && ${'\\'}
+    make install
+
+RUN cd /tmp && ${'\\'}
+    echo "b8f4f897df967014ddb42033b90c3058 Python-3.8.0b4.tgz" > checksum.md5 && ${'\\'}
+    md5sum -c checksum.md5
+
+RUN python3.8 -m ensurepip && ${'\\'}
+    python3.8 -m pip install coverage

--- a/templates/tools/dockerfile/python_stretch.include
+++ b/templates/tools/dockerfile/python_stretch.include
@@ -7,5 +7,3 @@ FROM debian:stretch
 RUN echo 'deb http://ftp.de.debian.org/debian buster main' >> /etc/apt/sources.list
 RUN echo 'APT::Default-Release "stretch";' | tee -a /etc/apt/apt.conf.d/00local
 <%include file="./run_tests_addons.include"/>
-# Define the default command.
-CMD ["bash"]

--- a/templates/tools/dockerfile/test/python_stretch_3.6_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_stretch_3.6_x64/Dockerfile.template
@@ -15,18 +15,4 @@
   # limitations under the License.
 
   <%include file="../../python_stretch.include"/>
-
-  RUN apt-get install -y jq zlib1g-dev libssl-dev
-
-  RUN apt-get install -y jq build-essential libffi-dev
-
-  RUN cd /tmp && ${'\\'}
-    wget -q https://github.com/python/cpython/archive/v3.6.9.tar.gz && ${'\\'}
-    tar xzvf v3.6.9.tar.gz && ${'\\'}
-    cd cpython-3.6.9 && ${'\\'}
-    ./configure && ${'\\'}
-    make install
-
-  RUN python3.6 -m ensurepip && ${'\\'}
-      python3.6 -m pip install coverage
-
+  <%include file="../../compile_python_36.include"/>

--- a/templates/tools/dockerfile/test/python_stretch_3.8_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_stretch_3.8_x64/Dockerfile.template
@@ -16,16 +16,4 @@
   # limitations under the License.
 
   <%include file="../../python_stretch.include"/>
-  RUN apt-get install -y jq zlib1g-dev libssl-dev
-
-  RUN apt-get install -y jq build-essential libffi-dev
-
-  RUN cd /tmp && ${'\\'}
-    wget -q https://github.com/python/cpython/archive/v3.8.0b3.tar.gz && ${'\\'}
-    tar xzvf v3.8.0b3.tar.gz && ${'\\'}
-    cd cpython-3.8.0b3 && ${'\\'}
-    ./configure && ${'\\'}
-    make install
-
-  RUN python3.8 -m ensurepip && ${'\\'}
-      python3.8 -m pip install coverage
+  <%include file="../../compile_python_38.include"/>

--- a/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
@@ -25,6 +25,9 @@
     cd cpython-3.6.9 && ${'\\'}
     ./configure && ${'\\'}
     make install
+  
+  RUN echo "ff7cdaef4846c89c1ec0d7b709bbd54d v3.6.9.tar.gz" > checksum.md5
+  RUN md5sum -c checksum.md5
 
   RUN apt-get update && apt-get -t buster install -y python3.7 python3-all-dev
   RUN curl https://bootstrap.pypa.io/get-pip.py | python3.7

--- a/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
@@ -1,0 +1,37 @@
+%YAML 1.2
+--- |
+  # Copyright 2018 The gRPC Authors
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  <%include file="../../python_stretch.include"/>
+
+  RUN apt-get install -y jq zlib1g-dev libssl-dev
+  RUN apt-get install -y jq build-essential libffi-dev
+
+  RUN cd /tmp && ${'\\'}
+    wget -q https://github.com/python/cpython/archive/v3.6.9.tar.gz && ${'\\'}
+    tar xzvf v3.6.9.tar.gz && ${'\\'}
+    cd cpython-3.6.9 && ${'\\'}
+    ./configure && ${'\\'}
+    make install
+
+  RUN apt-get update && apt-get -t buster install -y python3.7 python3-all-dev
+  RUN curl https://bootstrap.pypa.io/get-pip.py | python3.7
+
+  # for Python test coverage reporting
+  RUN python3.7 -m ensurepip && ${'\\'}
+      python3.7 -m pip install coverage
+
+  RUN python3.6 -m ensurepip && ${'\\'}
+      python3.6 -m pip install coverage

--- a/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
@@ -16,8 +16,8 @@
 
   <%include file="../../python_stretch.include"/>
 
-  RUN apt-get install -y jq zlib1g-dev libssl-dev
-  RUN apt-get install -y jq build-essential libffi-dev
+  RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
+  RUN apt-get update && apt-get install -y jq build-essential libffi-dev
 
   RUN cd /tmp && ${'\\'}
     wget -q https://github.com/python/cpython/archive/v3.6.9.tar.gz && ${'\\'}

--- a/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
@@ -20,14 +20,15 @@
   RUN apt-get update && apt-get install -y jq build-essential libffi-dev
 
   RUN cd /tmp && ${'\\'}
-    wget -q https://github.com/python/cpython/archive/v3.6.9.tar.gz && ${'\\'}
-    tar xzvf v3.6.9.tar.gz && ${'\\'}
-    cd cpython-3.6.9 && ${'\\'}
+    wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && ${'\\'}
+    tar xzvf Python-3.6.9.tgz && ${'\\'}
+    cd Python-3.6.9 && ${'\\'}
     ./configure && ${'\\'}
     make install
   
-  RUN echo "ff7cdaef4846c89c1ec0d7b709bbd54d v3.6.9.tar.gz" > checksum.md5
-  RUN md5sum -c checksum.md5
+  RUN cd /tmp && ${'\\'}
+    echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && ${'\\'}
+    md5sum -c checksum.md5
 
   RUN apt-get update && apt-get -t buster install -y python3.7 python3-all-dev
   RUN curl https://bootstrap.pypa.io/get-pip.py | python3.7

--- a/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
@@ -15,17 +15,8 @@
   # limitations under the License.
 
   <%include file="../../python_stretch.include"/>
+  <%include file="../../compile_python_36.include"/>
 
-  RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
-  RUN apt-get update && apt-get install -y jq build-essential libffi-dev
-
-  RUN cd /tmp && ${'\\'}
-    wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && ${'\\'}
-    tar xzvf Python-3.6.9.tgz && ${'\\'}
-    cd Python-3.6.9 && ${'\\'}
-    ./configure && ${'\\'}
-    make install
-  
   RUN cd /tmp && ${'\\'}
     echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && ${'\\'}
     md5sum -c checksum.md5

--- a/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
@@ -16,16 +16,9 @@
 
   <%include file="../../python_stretch.include"/>
   <%include file="../../compile_python_36.include"/>
-
-  RUN cd /tmp && ${'\\'}
-    echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && ${'\\'}
-    md5sum -c checksum.md5
-
+  
   RUN apt-get update && apt-get -t buster install -y python3.7 python3-all-dev
   RUN curl https://bootstrap.pypa.io/get-pip.py | python3.7
 
   # for Python test coverage reporting
   RUN python3.7 -m pip install coverage
-
-  RUN python3.6 -m ensurepip && ${'\\'}
-      python3.6 -m pip install coverage

--- a/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/python_stretch_default_x64/Dockerfile.template
@@ -30,8 +30,7 @@
   RUN curl https://bootstrap.pypa.io/get-pip.py | python3.7
 
   # for Python test coverage reporting
-  RUN python3.7 -m ensurepip && ${'\\'}
-      python3.7 -m pip install coverage
+  RUN python3.7 -m pip install coverage
 
   RUN python3.6 -m ensurepip && ${'\\'}
       python3.6 -m pip install coverage

--- a/tools/dockerfile/interoptest/grpc_interop_python/Dockerfile
+++ b/tools/dockerfile/interoptest/grpc_interop_python/Dockerfile
@@ -63,8 +63,6 @@ RUN echo 'APT::Default-Release "stretch";' | tee -a /etc/apt/apt.conf.d/00local
 
 RUN mkdir /var/local/jenkins
 
-# Define the default command.
-CMD ["bash"]
 
 
 RUN apt-get update && apt-get -t stable install -y python3.7 python3-all-dev

--- a/tools/dockerfile/test/python_stretch_2.7_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_2.7_x64/Dockerfile
@@ -63,6 +63,4 @@ RUN echo 'APT::Default-Release "stretch";' | tee -a /etc/apt/apt.conf.d/00local
 
 RUN mkdir /var/local/jenkins
 
-# Define the default command.
-CMD ["bash"]
 

--- a/tools/dockerfile/test/python_stretch_3.5_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_3.5_x64/Dockerfile
@@ -63,8 +63,6 @@ RUN echo 'APT::Default-Release "stretch";' | tee -a /etc/apt/apt.conf.d/00local
 
 RUN mkdir /var/local/jenkins
 
-# Define the default command.
-CMD ["bash"]
 
 
 RUN apt-get update && apt-get install -y python3.5 python3-all-dev

--- a/tools/dockerfile/test/python_stretch_3.6_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_3.6_x64/Dockerfile
@@ -64,17 +64,18 @@ RUN echo 'APT::Default-Release "stretch";' | tee -a /etc/apt/apt.conf.d/00local
 RUN mkdir /var/local/jenkins
 
 
+#=================
+# Compile CPython 3.6.9 from source
 
-RUN apt-get install -y jq zlib1g-dev libssl-dev
-
-RUN apt-get install -y jq build-essential libffi-dev
+RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
+RUN apt-get update && apt-get install -y jq build-essential libffi-dev
 
 RUN cd /tmp && \
-  wget -q https://github.com/python/cpython/archive/v3.6.9.tar.gz && \
-  tar xzvf v3.6.9.tar.gz && \
-  cd cpython-3.6.9 && \
-  ./configure && \
-  make install
+wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && \
+tar xzvf Python-3.6.9.tgz && \
+cd Python-3.6.9 && \
+./configure && \
+make install
 
 RUN python3.6 -m ensurepip && \
     python3.6 -m pip install coverage

--- a/tools/dockerfile/test/python_stretch_3.6_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_3.6_x64/Dockerfile
@@ -71,11 +71,16 @@ RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
 RUN apt-get update && apt-get install -y jq build-essential libffi-dev
 
 RUN cd /tmp && \
-wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && \
-tar xzvf Python-3.6.9.tgz && \
-cd Python-3.6.9 && \
-./configure && \
-make install
+    wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && \
+    tar xzvf Python-3.6.9.tgz && \
+    cd Python-3.6.9 && \
+    ./configure && \
+    make install
+
+RUN cd /tmp && \
+    echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && \
+    md5sum -c checksum.md5
 
 RUN python3.6 -m ensurepip && \
     python3.6 -m pip install coverage
+

--- a/tools/dockerfile/test/python_stretch_3.6_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_3.6_x64/Dockerfile
@@ -63,8 +63,6 @@ RUN echo 'APT::Default-Release "stretch";' | tee -a /etc/apt/apt.conf.d/00local
 
 RUN mkdir /var/local/jenkins
 
-# Define the default command.
-CMD ["bash"]
 
 
 RUN apt-get install -y jq zlib1g-dev libssl-dev

--- a/tools/dockerfile/test/python_stretch_3.7_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_3.7_x64/Dockerfile
@@ -63,8 +63,6 @@ RUN echo 'APT::Default-Release "stretch";' | tee -a /etc/apt/apt.conf.d/00local
 
 RUN mkdir /var/local/jenkins
 
-# Define the default command.
-CMD ["bash"]
 
 
 RUN apt-get update && apt-get -t buster install -y python3.7 python3-all-dev

--- a/tools/dockerfile/test/python_stretch_3.8_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_3.8_x64/Dockerfile
@@ -64,16 +64,23 @@ RUN echo 'APT::Default-Release "stretch";' | tee -a /etc/apt/apt.conf.d/00local
 RUN mkdir /var/local/jenkins
 
 
-RUN apt-get install -y jq zlib1g-dev libssl-dev
+#=================
+# Compile CPython 3.8.0b4 from source
 
-RUN apt-get install -y jq build-essential libffi-dev
+RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
+RUN apt-get update && apt-get install -y jq build-essential libffi-dev
 
 RUN cd /tmp && \
-  wget -q https://github.com/python/cpython/archive/v3.8.0b3.tar.gz && \
-  tar xzvf v3.8.0b3.tar.gz && \
-  cd cpython-3.8.0b3 && \
-  ./configure && \
-  make install
+    wget -q https://www.python.org/ftp/python/3.8.0/Python-3.8.0b4.tgz && \
+    tar xzvf Python-3.8.0b4.tgz && \
+    cd Python-3.8.0b4 && \
+    ./configure && \
+    make install
+
+RUN cd /tmp && \
+    echo "b8f4f897df967014ddb42033b90c3058 Python-3.8.0b4.tgz" > checksum.md5 && \
+    md5sum -c checksum.md5
 
 RUN python3.8 -m ensurepip && \
     python3.8 -m pip install coverage
+

--- a/tools/dockerfile/test/python_stretch_3.8_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_3.8_x64/Dockerfile
@@ -63,8 +63,6 @@ RUN echo 'APT::Default-Release "stretch";' | tee -a /etc/apt/apt.conf.d/00local
 
 RUN mkdir /var/local/jenkins
 
-# Define the default command.
-CMD ["bash"]
 
 RUN apt-get install -y jq zlib1g-dev libssl-dev
 

--- a/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
@@ -69,14 +69,15 @@ RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
 RUN apt-get update && apt-get install -y jq build-essential libffi-dev
 
 RUN cd /tmp && \
-  wget -q https://github.com/python/cpython/archive/v3.6.9.tar.gz && \
-  tar xzvf v3.6.9.tar.gz && \
-  cd cpython-3.6.9 && \
+  wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && \
+  tar xzvf Python-3.6.9.tgz && \
+  cd Python-3.6.9 && \
   ./configure && \
   make install
 
-RUN echo "ff7cdaef4846c89c1ec0d7b709bbd54d v3.6.9.tar.gz" > checksum.md5
-RUN md5sum -c checksum.md5
+RUN cd /tmp && \
+  echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && \
+  md5sum -c checksum.md5
 
 RUN apt-get update && apt-get -t buster install -y python3.7 python3-all-dev
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.7

--- a/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
@@ -81,8 +81,7 @@ RUN apt-get update && apt-get -t buster install -y python3.7 python3-all-dev
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.7
 
 # for Python test coverage reporting
-RUN python3.7 -m ensurepip && \
-    python3.7 -m pip install coverage
+RUN python3.7 -m pip install coverage
 
 RUN python3.6 -m ensurepip && \
     python3.6 -m pip install coverage

--- a/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
@@ -64,16 +64,21 @@ RUN echo 'APT::Default-Release "stretch";' | tee -a /etc/apt/apt.conf.d/00local
 RUN mkdir /var/local/jenkins
 
 
+#=================
+# Compile CPython 3.6.9 from source
 
 RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
 RUN apt-get update && apt-get install -y jq build-essential libffi-dev
 
 RUN cd /tmp && \
-  wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && \
-  tar xzvf Python-3.6.9.tgz && \
-  cd Python-3.6.9 && \
-  ./configure && \
-  make install
+wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && \
+tar xzvf Python-3.6.9.tgz && \
+cd Python-3.6.9 && \
+./configure && \
+make install
+
+RUN python3.6 -m ensurepip && \
+    python3.6 -m pip install coverage
 
 RUN cd /tmp && \
   echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && \

--- a/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
@@ -71,24 +71,22 @@ RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
 RUN apt-get update && apt-get install -y jq build-essential libffi-dev
 
 RUN cd /tmp && \
-wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && \
-tar xzvf Python-3.6.9.tgz && \
-cd Python-3.6.9 && \
-./configure && \
-make install
+    wget -q https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tgz && \
+    tar xzvf Python-3.6.9.tgz && \
+    cd Python-3.6.9 && \
+    ./configure && \
+    make install
+
+RUN cd /tmp && \
+    echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && \
+    md5sum -c checksum.md5
 
 RUN python3.6 -m ensurepip && \
     python3.6 -m pip install coverage
 
-RUN cd /tmp && \
-  echo "ff7cdaef4846c89c1ec0d7b709bbd54d Python-3.6.9.tgz" > checksum.md5 && \
-  md5sum -c checksum.md5
 
 RUN apt-get update && apt-get -t buster install -y python3.7 python3-all-dev
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.7
 
 # for Python test coverage reporting
 RUN python3.7 -m pip install coverage
-
-RUN python3.6 -m ensurepip && \
-    python3.6 -m pip install coverage

--- a/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
@@ -63,8 +63,6 @@ RUN echo 'APT::Default-Release "stretch";' | tee -a /etc/apt/apt.conf.d/00local
 
 RUN mkdir /var/local/jenkins
 
-# Define the default command.
-CMD ["bash"]
 
 
 RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
@@ -76,6 +74,9 @@ RUN cd /tmp && \
   cd cpython-3.6.9 && \
   ./configure && \
   make install
+
+RUN echo "ff7cdaef4846c89c1ec0d7b709bbd54d v3.6.9.tar.gz" > checksum.md5
+RUN md5sum -c checksum.md5
 
 RUN apt-get update && apt-get -t buster install -y python3.7 python3-all-dev
 RUN curl https://bootstrap.pypa.io/get-pip.py | python3.7

--- a/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
@@ -1,0 +1,88 @@
+# Copyright 2018 The gRPC Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:stretch
+  
+# Install Git and basic packages.
+RUN apt-get update && apt-get install -y \
+  autoconf \
+  autotools-dev \
+  build-essential \
+  bzip2 \
+  ccache \
+  curl \
+  dnsutils \
+  gcc \
+  gcc-multilib \
+  git \
+  golang \
+  gyp \
+  lcov \
+  libc6 \
+  libc6-dbg \
+  libc6-dev \
+  libgtest-dev \
+  libtool \
+  make \
+  perl \
+  strace \
+  python-dev \
+  python-setuptools \
+  python-yaml \
+  telnet \
+  unzip \
+  wget \
+  zip && apt-get clean
+
+#================
+# Build profiling
+RUN apt-get update && apt-get install -y time && apt-get clean
+
+# Google Cloud platform API libraries
+RUN apt-get update && apt-get install -y python-pip && apt-get clean
+RUN pip install --upgrade google-api-python-client oauth2client
+
+# Install Python 2.7
+RUN apt-get update && apt-get install -y python2.7 python-all-dev
+RUN curl https://bootstrap.pypa.io/get-pip.py | python2.7
+
+# Add Debian 'buster' repository, we will need it for installing newer versions of python
+RUN echo 'deb http://ftp.de.debian.org/debian buster main' >> /etc/apt/sources.list
+RUN echo 'APT::Default-Release "stretch";' | tee -a /etc/apt/apt.conf.d/00local
+
+RUN mkdir /var/local/jenkins
+
+# Define the default command.
+CMD ["bash"]
+
+
+RUN apt-get install -y jq zlib1g-dev libssl-dev
+RUN apt-get install -y jq build-essential libffi-dev
+
+RUN cd /tmp && \
+  wget -q https://github.com/python/cpython/archive/v3.6.9.tar.gz && \
+  tar xzvf v3.6.9.tar.gz && \
+  cd cpython-3.6.9 && \
+  ./configure && \
+  make install
+
+RUN apt-get update && apt-get -t buster install -y python3.7 python3-all-dev
+RUN curl https://bootstrap.pypa.io/get-pip.py | python3.7
+
+# for Python test coverage reporting
+RUN python3.7 -m ensurepip && \
+    python3.7 -m pip install coverage
+
+RUN python3.6 -m ensurepip && \
+    python3.6 -m pip install coverage

--- a/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
+++ b/tools/dockerfile/test/python_stretch_default_x64/Dockerfile
@@ -67,8 +67,8 @@ RUN mkdir /var/local/jenkins
 CMD ["bash"]
 
 
-RUN apt-get install -y jq zlib1g-dev libssl-dev
-RUN apt-get install -y jq build-essential libffi-dev
+RUN apt-get update && apt-get install -y zlib1g-dev libssl-dev
+RUN apt-get update && apt-get install -y jq build-essential libffi-dev
 
 RUN cd /tmp && \
   wget -q https://github.com/python/cpython/archive/v3.6.9.tar.gz && \

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -63,8 +63,6 @@ RUN echo 'APT::Default-Release "stretch";' | tee -a /etc/apt/apt.conf.d/00local
 
 RUN mkdir /var/local/jenkins
 
-# Define the default command.
-CMD ["bash"]
 
 #=================
 # C++ dependencies

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -846,6 +846,7 @@ class PythonLanguage(object):
             else:
                 return (
                     python27_config,
+                    python36_config,
                     python37_config,
                 )
         elif args.compiler == 'python2.7':

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -761,7 +761,7 @@ class PythonLanguage(object):
         elif self.args.compiler == 'python3.4':
             return 'jessie'
         else:
-            return 'stretch_3.7'
+            return 'stretch_default'
 
     def _get_pythons(self, args):
         """Get python runtimes to test with, based on current platform, architecture, compiler etc."""


### PR DESCRIPTION
We have observed some breakage during the import (#19960) caused by lacking the test of 3.6. Adding one more default test environment should prevent these kind of breakages from happening again.

Also, since we promised these API should support 3.6, I think we should keep the 3.6 environment longer.