### PR TITLE
Update RBE-debian8 docker image to the latest

### DIFF
--- a/templates/tools/dockerfile/test/cxx_sanitizers_jessie_x64/Dockerfile.template
+++ b/templates/tools/dockerfile/test/cxx_sanitizers_jessie_x64/Dockerfile.template
@@ -15,7 +15,7 @@
   # limitations under the License.
 
   # This is the base Docker image we use for running tests on RBE
-  FROM gcr.io/cloud-marketplace/google/rbe-debian8@sha256:1ede2a929b44d629ec5abe86eee6d7ffea1d5a4d247489a8867d46cfde3e38bd
+  FROM gcr.io/cloud-marketplace/google/rbe-debian8@sha256:cda3a8608d0fc545dffc6c68f6cfab8eda280c7a1558bde0753ed2e8e3006224
   RUN sed -i '/deb http:\/\/httpredir.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
 
   <%include file="../../apt_get_basic.include"/>

--- a/tools/dockerfile/test/cxx_sanitizers_jessie_x64/Dockerfile
+++ b/tools/dockerfile/test/cxx_sanitizers_jessie_x64/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This is the base Docker image we use for running tests on RBE
-FROM gcr.io/cloud-marketplace/google/rbe-debian8@sha256:1ede2a929b44d629ec5abe86eee6d7ffea1d5a4d247489a8867d46cfde3e38bd
+FROM gcr.io/cloud-marketplace/google/rbe-debian8@sha256:cda3a8608d0fc545dffc6c68f6cfab8eda280c7a1558bde0753ed2e8e3006224
 RUN sed -i '/deb http:\/\/httpredir.debian.org\/debian jessie-updates main/d' /etc/apt/sources.list
 
 # Install Git and basic packages.

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -531,8 +531,8 @@ class CLanguage(object):
         elif compiler == 'clang3.7':
             return ('ubuntu1604',
                     self._clang_make_options(version_suffix='-3.7'))
-        elif compiler == 'clang7.0':
-            # clang++-7.0 alias doesn't exist and there are no other clang versions
+        elif compiler == 'clang8.0':
+            # clang++-8.0 alias doesn't exist and there are no other clang versions
             # installed.
             return ('sanitizers_jessie', self._clang_make_options())
         else:
@@ -1424,7 +1424,7 @@ argp.add_argument(
     '--compiler',
     choices=[
         'default', 'gcc4.4', 'gcc4.6', 'gcc4.8', 'gcc4.9', 'gcc5.3', 'gcc7.2',
-        'gcc_musl', 'clang3.4', 'clang3.5', 'clang3.6', 'clang3.7', 'clang7.0',
+        'gcc_musl', 'clang3.4', 'clang3.5', 'clang3.6', 'clang3.7', 'clang8.0',
         'python2.7', 'python3.4', 'python3.5', 'python3.6', 'python3.7',
         'python3.8', 'pypy', 'pypy3', 'python_alpine', 'all_the_cpythons',
         'electron1.3', 'electron1.6', 'coreclr', 'cmake', 'cmake_vs2015',

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -259,7 +259,7 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
         configs=['msan', 'asan', 'tsan', 'ubsan'],
         platforms=['linux'],
         arch='x64',
-        compiler='clang7.0',
+        compiler='clang8.0',
         labels=['sanitizers', 'corelang'],
         extra_args=extra_args,
         inner_jobs=inner_jobs,
@@ -269,7 +269,7 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
         configs=['asan'],
         platforms=['linux'],
         arch='x64',
-        compiler='clang7.0',
+        compiler='clang8.0',
         labels=['sanitizers', 'corelang'],
         extra_args=extra_args,
         inner_jobs=inner_jobs,
@@ -279,7 +279,7 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
         configs=['tsan'],
         platforms=['linux'],
         arch='x64',
-        compiler='clang7.0',
+        compiler='clang8.0',
         labels=['sanitizers', 'corelang'],
         extra_args=extra_args,
         inner_jobs=inner_jobs,
@@ -305,7 +305,7 @@ def _create_portability_test_jobs(extra_args=[],
     # portability C and C++ on x64
     for compiler in [
             'gcc4.8', 'gcc5.3', 'gcc7.2', 'gcc_musl', 'clang3.5', 'clang3.6',
-            'clang3.7', 'clang7.0'
+            'clang3.7', 'clang8.0'
     ]:
         test_jobs += _generate_jobs(
             languages=['c', 'c++'],


### PR DESCRIPTION
Update the docker image for sanity test to the latest. ([container registry](https://pantheon.corp.google.com/gcr/images/cloud-marketplace/GLOBAL/google/rbe-debian8?gcrImageListsize=30))
As a result, this also changes the version of clang from 7.0 to 8.0 so related files are updated correspondingly.

Package contents:
- Debian 8
- Clang 8 r346485
- OpenJDK 1.8.0_171
- Python 2.7.9
- Python 3.6.5
- Go 1.11.2

This is related with #20182 but this is only for having an up-to-date docker image.