### PR TITLE
Allow call credentials interception at PRE_SEND_INITIAL_METADATA

### DIFF
--- a/include/grpcpp/impl/codegen/client_context_impl.h
+++ b/include/grpcpp/impl/codegen/client_context_impl.h
@@ -310,11 +310,11 @@ class ClientContext {
   /// client’s identity, role, or whether it is authorized to make a particular
   /// call.
   ///
+  /// It is legal to call this only before initial metadata is sent.
+  ///
   /// \see  https://grpc.io/docs/guides/auth.html
   void set_credentials(
-      const std::shared_ptr<grpc_impl::CallCredentials>& creds) {
-    creds_ = creds;
-  }
+      const std::shared_ptr<grpc_impl::CallCredentials>& creds);
 
   /// Return the compression algorithm the client call will request be used.
   /// Note that the gRPC runtime may decide to ignore this request, for example,

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -341,8 +341,7 @@ class End2endTest : public ::testing::TestWithParam<TestScenario> {
   void ResetChannel(
       std::vector<
           std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
-          interceptor_creators = std::vector<std::unique_ptr<
-              experimental::ClientInterceptorFactoryInterface>>()) {
+          interceptor_creators = {}) {
     if (!is_server_started_) {
       StartServer(std::shared_ptr<AuthMetadataProcessor>());
     }
@@ -380,8 +379,7 @@ class End2endTest : public ::testing::TestWithParam<TestScenario> {
   void ResetStub(
       std::vector<
           std::unique_ptr<experimental::ClientInterceptorFactoryInterface>>
-          interceptor_creators = std::vector<std::unique_ptr<
-              experimental::ClientInterceptorFactoryInterface>>()) {
+          interceptor_creators = {}) {
     ResetChannel(std::move(interceptor_creators));
     if (GetParam().use_proxy) {
       proxy_service_.reset(new Proxy(channel_));


### PR DESCRIPTION
Allow call credentials to be set even after the call is created but before initial metadata is sent.

This allows call credentials to be set at the PRE_SEND_INITIAL_METADATA hook point.