### PR TITLE
Remove g-stands-for from user agent string

### DIFF
--- a/src/core/ext/filters/http/client/http_client_filter.cc
+++ b/src/core/ext/filters/http/client/http_client_filter.cc
@@ -538,9 +538,8 @@ static grpc_core::ManagedMemorySlice user_agent_from_args(
     }
   }
 
-  gpr_asprintf(&tmp, "%sgrpc-c/%s (%s; %s; %s)", is_first ? "" : " ",
-               grpc_version_string(), GPR_PLATFORM_STRING, transport_name,
-               grpc_g_stands_for());
+  gpr_asprintf(&tmp, "%sgrpc-c/%s (%s; %s)", is_first ? "" : " ",
+               grpc_version_string(), GPR_PLATFORM_STRING, transport_name);
   is_first = 0;
   gpr_strvec_add(&v, tmp);
 

--- a/src/objective-c/tests/UnitTests/APIv2Tests.m
+++ b/src/objective-c/tests/UnitTests/APIv2Tests.m
@@ -235,12 +235,7 @@ static const NSTimeInterval kInvertedTimeout = 2;
                        expectedUserAgent = [expectedUserAgent stringByAppendingString:@" ("];
                        expectedUserAgent =
                            [expectedUserAgent stringByAppendingString:@GPR_PLATFORM_STRING];
-                       expectedUserAgent =
-                           [expectedUserAgent stringByAppendingString:@"; chttp2; "];
-                       expectedUserAgent = [expectedUserAgent
-                           stringByAppendingString:[NSString
-                                                       stringWithUTF8String:grpc_g_stands_for()]];
-                       expectedUserAgent = [expectedUserAgent stringByAppendingString:@")"];
+                       expectedUserAgent = [expectedUserAgent stringByAppendingString:@"; chttp2)"];
                        XCTAssertEqualObjects(userAgent, expectedUserAgent);
 
                        NSError *error = nil;

--- a/src/objective-c/tests/UnitTests/GRPCClientTests.m
+++ b/src/objective-c/tests/UnitTests/GRPCClientTests.m
@@ -307,10 +307,7 @@ static GRPCProtoMethod *kFullDuplexCallMethod;
         expectedUserAgent = [expectedUserAgent stringByAppendingString:GRPC_C_VERSION_STRING];
         expectedUserAgent = [expectedUserAgent stringByAppendingString:@" ("];
         expectedUserAgent = [expectedUserAgent stringByAppendingString:@GPR_PLATFORM_STRING];
-        expectedUserAgent = [expectedUserAgent stringByAppendingString:@"; chttp2; "];
-        expectedUserAgent = [expectedUserAgent
-            stringByAppendingString:[NSString stringWithUTF8String:grpc_g_stands_for()]];
-        expectedUserAgent = [expectedUserAgent stringByAppendingString:@")"];
+        expectedUserAgent = [expectedUserAgent stringByAppendingString:@"; chttp2)"];
         XCTAssertEqualObjects(userAgent, expectedUserAgent);
 
         // Change in format of user-agent field in a direction that does not match the regex will


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/16630 and ends a long debate.

The main argument is that sending useless bytes around is wasteful.
