### PR TITLE
WIP: Don't make a second DNS resolution attempt if a duplicate attempt is oustanding

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -321,7 +321,7 @@ void AresDnsResolver::OnResolvedLocked(void* arg, grpc_error* error) {
   AresDnsResolver* r = static_cast<AresDnsResolver*>(arg);
   GPR_ASSERT(r->resolving_);
   r->resolving_ = false;
-  gpr_free(r->pending_request_);
+  grpc_ares_request_destroy_locked(r->pending_request_);
   r->pending_request_ = nullptr;
   if (r->shutdown_initiated_) {
     r->Unref(DEBUG_LOCATION, "OnResolvedLocked() shutdown");

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -643,7 +643,8 @@ void grpc_dns_lookup_ares_continue_after_check_localhost_and_ip_literals_locked(
   return;
 
 error_cleanup:
-  GRPC_CLOSURE_SCHED(r->on_done, error);
+  r->error = error;
+  grpc_ares_complete_request_locked(r);
 }
 
 static bool inner_resolve_as_ip_literal_locked(

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.cc
@@ -217,6 +217,9 @@ bool push_pending_request(grpc_ares_request* r) {
       r->next = pending_requests->second;
     }
     (*g_pending_requests)[r->key] = r;
+    GRPC_CARES_TRACE_LOG(
+        "request:%p push_pending_request already_exists:%d r->next:%p", r,
+        already_exists, r->next);
     return already_exists;
   }
 }
@@ -261,6 +264,9 @@ void pop_pending_requests(const GrpcAresPendingRequestKey& key,
     args->service_config_json = gpr_strdup(service_config_json);
     args->r = cur_request;
     GRPC_ERROR_REF(error);
+    GRPC_CARES_TRACE_LOG(
+        "cur_request:%p pop_pending_requests cur_request->next:%p", cur_request,
+        cur_request->next);
     GRPC_CLOSURE_SCHED(
         GRPC_CLOSURE_CREATE(complete_request_locked, args,
                             grpc_combiner_scheduler(cur_request->combiner)),

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
@@ -67,6 +67,9 @@ extern grpc_ares_request* (*grpc_dns_lookup_ares_locked)(
     bool check_grpclb, char** service_config_json, int query_timeout_ms,
     grpc_combiner* combiner);
 
+/* Releases a grpc ares request */
+extern void (*grpc_ares_request_destroy_locked)(grpc_ares_request* r);
+
 /* Cancel the pending grpc_ares_request \a request */
 extern void (*grpc_cancel_ares_request_locked)(grpc_ares_request* request);
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_fallback.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_fallback.cc
@@ -42,6 +42,11 @@ grpc_ares_request* (*grpc_dns_lookup_ares_locked)(
     bool check_grpclb, char** service_config_json, int query_timeout_ms,
     grpc_combiner* combiner) = grpc_dns_lookup_ares_locked_impl;
 
+static void grpc_ares_request_destroy_locked_impl(grpc_ares_request* r) {}
+
+void (*grpc_ares_request_destroy_locked)(grpc_ares_request* r) =
+    grpc_ares_request_destroy_locked_impl;
+
 static void grpc_cancel_ares_request_locked_impl(grpc_ares_request* r) {}
 
 void (*grpc_cancel_ares_request_locked)(grpc_ares_request* r) =

--- a/test/core/client_channel/resolvers/dns_resolver_connectivity_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_connectivity_test.cc
@@ -85,6 +85,10 @@ static grpc_ares_request* my_dns_lookup_ares_locked(
   return nullptr;
 }
 
+static void my_ares_request_destroy_locked(grpc_ares_request* request) {
+  GPR_ASSERT(request == nullptr);
+}
+
 static void my_cancel_ares_request_locked(grpc_ares_request* request) {
   GPR_ASSERT(request == nullptr);
 }
@@ -163,6 +167,7 @@ int main(int argc, char** argv) {
   g_combiner = grpc_combiner_create();
   grpc_set_resolver_impl(&test_resolver);
   grpc_dns_lookup_ares_locked = my_dns_lookup_ares_locked;
+  grpc_ares_request_desroy_locked = my_ares_request_destroy_locked;
   grpc_cancel_ares_request_locked = my_cancel_ares_request_locked;
 
   {

--- a/test/core/client_channel/resolvers/dns_resolver_connectivity_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_connectivity_test.cc
@@ -167,7 +167,7 @@ int main(int argc, char** argv) {
   g_combiner = grpc_combiner_create();
   grpc_set_resolver_impl(&test_resolver);
   grpc_dns_lookup_ares_locked = my_dns_lookup_ares_locked;
-  grpc_ares_request_desroy_locked = my_ares_request_destroy_locked;
+  grpc_ares_request_destroy_locked = my_ares_request_destroy_locked;
   grpc_cancel_ares_request_locked = my_cancel_ares_request_locked;
 
   {

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -391,6 +391,10 @@ grpc_ares_request* my_dns_lookup_ares_locked(
   return nullptr;
 }
 
+static void my_ares_request_destroy_locked(grpc_ares_request* request) {
+  GPR_ASSERT(request == nullptr);
+}
+
 static void my_cancel_ares_request_locked(grpc_ares_request* request) {
   GPR_ASSERT(request == nullptr);
 }
@@ -710,6 +714,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   }
   grpc_set_resolver_impl(&fuzzer_resolver);
   grpc_dns_lookup_ares_locked = my_dns_lookup_ares_locked;
+  grpc_ares_request_destroy_locked = my_ares_request_destroy_locked;
   grpc_cancel_ares_request_locked = my_cancel_ares_request_locked;
 
   GPR_ASSERT(g_channel == nullptr);

--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -133,7 +133,7 @@ static grpc_ares_request* my_dns_lookup_ares_locked(
   return nullptr;
 }
 
-static void my_cancel_ares_request_locked(grpc_ares_request* request) {
+static void my_ares_request_destroy_locked(grpc_ares_request* request) {
   if (request != nullptr) {
     iomgr_ares_request_destroy_locked(request);
   }
@@ -161,6 +161,7 @@ int main(int argc, char** argv) {
   iomgr_cancel_ares_request_locked = grpc_cancel_ares_request_locked;
   iomgr_ares_request_destroy_locked = grpc_ares_request_destroy_locked;
   grpc_dns_lookup_ares_locked = my_dns_lookup_ares_locked;
+  grpc_ares_request_destroy_locked = my_ares_request_destroy_locked;
   grpc_cancel_ares_request_locked = my_cancel_ares_request_locked;
 
   int was_cancelled1;

--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -53,6 +53,8 @@ static grpc_ares_request* (*iomgr_dns_lookup_ares_locked)(
 
 static void (*iomgr_cancel_ares_request_locked)(grpc_ares_request* request);
 
+static void (*iomgr_ares_request_destroy_locked)(grpc_ares_request* request);
+
 static void set_resolve_port(int port) {
   gpr_mu_lock(&g_mu);
   g_resolve_port = port;
@@ -133,6 +135,12 @@ static grpc_ares_request* my_dns_lookup_ares_locked(
 
 static void my_cancel_ares_request_locked(grpc_ares_request* request) {
   if (request != nullptr) {
+    iomgr_ares_request_destroy_locked(request);
+  }
+}
+
+static void my_cancel_ares_request_locked(grpc_ares_request* request) {
+  if (request != nullptr) {
     iomgr_cancel_ares_request_locked(request);
   }
 }
@@ -151,6 +159,7 @@ int main(int argc, char** argv) {
   grpc_set_resolver_impl(&test_resolver);
   iomgr_dns_lookup_ares_locked = grpc_dns_lookup_ares_locked;
   iomgr_cancel_ares_request_locked = grpc_cancel_ares_request_locked;
+  iomgr_ares_request_destroy_locked = grpc_ares_request_destroy_locked;
   grpc_dns_lookup_ares_locked = my_dns_lookup_ares_locked;
   grpc_cancel_ares_request_locked = my_cancel_ares_request_locked;
 

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -394,6 +394,7 @@ void TestCancelDuringActiveQuery(
       "dns://[::1]:%d/dont-care-since-wont-be-resolved.test.com:1234",
       fake_dns_port));
   std::vector<std::thread> thds;
+  thds.reserve(num_thds);
   for (int i = 0; i < num_thds; i++) {
     thds.push_back(
         std::thread(PerformFailingRPC, client_target, query_timeout_setting));

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -276,12 +276,15 @@ typedef enum {
   TOLERATE_DEADLINE_EXCEEDED_OR_UNAVAILABLE,
 } cancellation_test_query_timeout_setting;
 
-void PerformFailingRPC(const char* client_target, cancellation_test_query_timeout_setting query_timeout_setting) {
+void PerformFailingRPC(
+    const char* client_target,
+    cancellation_test_query_timeout_setting query_timeout_setting) {
   gpr_log(GPR_DEBUG, "TestCancelActiveDNSQuery. query timeout setting: %d",
           query_timeout_setting);
   grpc_channel_args* client_args = nullptr;
   grpc_status_code expected_status_code = GRPC_STATUS_OK;
-  if (query_timeout_setting == NONE || query_timeout_setting == TOLERATE_DEADLINE_EXCEEDED_OR_UNAVAILABLE) {
+  if (query_timeout_setting == NONE ||
+      query_timeout_setting == TOLERATE_DEADLINE_EXCEEDED_OR_UNAVAILABLE) {
     expected_status_code = GRPC_STATUS_DEADLINE_EXCEEDED;
     client_args = nullptr;
   } else if (query_timeout_setting == SHORT) {
@@ -355,8 +358,11 @@ void PerformFailingRPC(const char* client_target, cancellation_test_query_timeou
   CQ_EXPECT_COMPLETION(cqv, Tag(1), 1);
   cq_verify(cqv);
   if (query_timeout_setting == TOLERATE_DEADLINE_EXCEEDED_OR_UNAVAILABLE) {
-    if (status != GRPC_STATUS_UNAVAILABLE && status != GRPC_STATUS_DEADLINE_EXCEEDED) {
-      gpr_log(GPR_ERROR, "Expected UNAVAILABLE or DEADLINE_EXCEEDED status. Got: %d", status);
+    if (status != GRPC_STATUS_UNAVAILABLE &&
+        status != GRPC_STATUS_DEADLINE_EXCEEDED) {
+      gpr_log(GPR_ERROR,
+              "Expected UNAVAILABLE or DEADLINE_EXCEEDED status. Got: %d",
+              status);
       abort();
     }
   } else {
@@ -376,7 +382,8 @@ void PerformFailingRPC(const char* client_target, cancellation_test_query_timeou
 }
 
 void TestCancelDuringActiveQuery(
-    cancellation_test_query_timeout_setting query_timeout_setting, int num_thds) {
+    cancellation_test_query_timeout_setting query_timeout_setting,
+    int num_thds) {
   // Start up fake non responsive DNS server
   int fake_dns_port = grpc_pick_unused_port_or_die();
   grpc::testing::FakeNonResponsiveDNSServer fake_dns_server(fake_dns_port);
@@ -388,7 +395,8 @@ void TestCancelDuringActiveQuery(
       fake_dns_port));
   std::vector<std::thread> thds;
   for (int i = 0; i < num_thds; i++) {
-    thds.push_back(std::thread(PerformFailingRPC, client_target, query_timeout_setting));
+    thds.push_back(
+        std::thread(PerformFailingRPC, client_target, query_timeout_setting));
   }
   for (int i = 0; i < thds.size(); i++) {
     thds[i].join();
@@ -398,24 +406,29 @@ void TestCancelDuringActiveQuery(
 
 TEST_F(CancelDuringAresQuery,
        TestHitDeadlineAndDestroyChannelDuringAresResolutionIsGraceful) {
-  TestCancelDuringActiveQuery(NONE /* don't set query timeouts */, 1 /* number of threads */);
+  TestCancelDuringActiveQuery(NONE /* don't set query timeouts */,
+                              1 /* number of threads */);
 }
 
 TEST_F(
     CancelDuringAresQuery,
     TestHitDeadlineAndDestroyChannelDuringAresResolutionWithQueryTimeoutIsGraceful) {
-  TestCancelDuringActiveQuery(SHORT /* set short query timeout */, 1 /* number of threads */);
+  TestCancelDuringActiveQuery(SHORT /* set short query timeout */,
+                              1 /* number of threads */);
 }
 
 TEST_F(
     CancelDuringAresQuery,
     TestHitDeadlineAndDestroyChannelDuringAresResolutionWithZeroQueryTimeoutIsGraceful) {
-  TestCancelDuringActiveQuery(ZERO /* disable query timeouts */, 1 /* number of threads */);
+  TestCancelDuringActiveQuery(ZERO /* disable query timeouts */,
+                              1 /* number of threads */);
 }
 
-TEST_F(CancelDuringAresQuery,
-       TestConcurrentChannelsHitDeadlineAndDestroyDuringAresResolutionIsGraceful) {
-  TestCancelDuringActiveQuery(TOLERATE_DEADLINE_EXCEEDED_OR_UNAVAILABLE, 100 /* number of threads */);
+TEST_F(
+    CancelDuringAresQuery,
+    TestConcurrentChannelsHitDeadlineAndDestroyDuringAresResolutionIsGraceful) {
+  TestCancelDuringActiveQuery(TOLERATE_DEADLINE_EXCEEDED_OR_UNAVAILABLE,
+                              100 /* number of threads */);
 }
 
 }  // namespace

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -585,7 +585,6 @@ void RunResolvesRelevantRecordsTest(
           "resolver_component_test: --inject_broken_nameserver_list: %s",
           FLAGS_inject_broken_nameserver_list.c_str());
   if (FLAGS_inject_broken_nameserver_list == "True") {
-    grpc_ares_test_only_inject_config = InjectBrokenNameServerList;
     GPR_ASSERT(gpr_asprintf(&whole_uri, "dns:///%s", target_name));
   } else if (FLAGS_inject_broken_nameserver_list == "False") {
     gpr_log(GPR_INFO, "Specifying authority in uris to: %s",

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -584,12 +584,7 @@ void RunResolvesRelevantRecordsTest(
   gpr_log(GPR_DEBUG,
           "resolver_component_test: --inject_broken_nameserver_list: %s",
           FLAGS_inject_broken_nameserver_list.c_str());
-  grpc_core::UniquePtr<grpc::testing::FakeNonResponsiveDNSServer>
-      fake_non_responsive_dns_server;
   if (FLAGS_inject_broken_nameserver_list == "True") {
-    fake_non_responsive_dns_server.reset(
-        grpc_core::New<grpc::testing::FakeNonResponsiveDNSServer>(
-            g_fake_non_responsive_dns_server_port));
     grpc_ares_test_only_inject_config = InjectBrokenNameServerList;
     GPR_ASSERT(gpr_asprintf(&whole_uri, "dns:///%s", target_name));
   } else if (FLAGS_inject_broken_nameserver_list == "False") {
@@ -730,8 +725,12 @@ int main(int argc, char** argv) {
     gpr_log(GPR_ERROR, "Missing target_name param.");
     abort();
   }
-  g_fake_non_responsive_dns_server_port = grpc_pick_unused_port_or_die();
-  auto result = RUN_ALL_TESTS();
+  auto result = 0;
+  {
+    g_fake_non_responsive_dns_server_port = grpc_pick_unused_port_or_die();
+    grpc::testing::FakeNonResponsiveDNSServer fake_non_responsive_dns_server(g_fake_non_responsive_dns_server_port);
+    result = RUN_ALL_TESTS();
+  }
   grpc_shutdown();
   return result;
 }

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -730,6 +730,9 @@ int main(int argc, char** argv) {
     g_fake_non_responsive_dns_server_port = grpc_pick_unused_port_or_die();
     grpc::testing::FakeNonResponsiveDNSServer fake_non_responsive_dns_server(
         g_fake_non_responsive_dns_server_port);
+    if (FLAGS_inject_broken_nameserver_list == "True") {
+      grpc_ares_test_only_inject_config = InjectBrokenNameServerList;
+    }
     result = RUN_ALL_TESTS();
   }
   grpc_shutdown();

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -728,7 +728,8 @@ int main(int argc, char** argv) {
   auto result = 0;
   {
     g_fake_non_responsive_dns_server_port = grpc_pick_unused_port_or_die();
-    grpc::testing::FakeNonResponsiveDNSServer fake_non_responsive_dns_server(g_fake_non_responsive_dns_server_port);
+    grpc::testing::FakeNonResponsiveDNSServer fake_non_responsive_dns_server(
+        g_fake_non_responsive_dns_server_port);
     result = RUN_ALL_TESTS();
   }
   grpc_shutdown();

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -26,6 +26,7 @@
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>
 
+#include <pthread.h>
 #include <string.h>
 
 #include <errno.h>
@@ -497,6 +498,31 @@ class CheckingResultHandler : public ResultHandler {
   }
 };
 
+class HealthCheckQueryResultHandler : public ResultHandler {
+ public:
+  static grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler> Create(
+      ArgsStruct* args) {
+    return grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler>(
+        grpc_core::New<HealthCheckQueryResultHandler>(args));
+  }
+
+  explicit HealthCheckQueryResultHandler(ArgsStruct* args) : ResultHandler(args) {}
+
+  void CheckResult(const grpc_core::Resolver::Result& result) override {
+    gpr_log(GPR_INFO, "num addrs found: %" PRIdPTR ". expected 1",
+            result.addresses.size());
+    EXPECT_EQ(result.addresses.size(), 1);
+    char* str;
+    grpc_sockaddr_to_string(&str, &result.addresses[0].address(), 1 /* normalize */);
+    gpr_log(GPR_INFO, "Got health check record result address: %s", str);
+    auto result_address = GrpcLBAddress(std::string(str), result.addresses[0].IsBalancer());
+    gpr_free(str);
+    EXPECT_EQ(GrpcLBAddress("123.123.123.123:443", false), result_address);
+    EXPECT_EQ(result.service_config, nullptr);
+    EXPECT_EQ(grpc_channel_args_find(result.args, GRPC_ARG_LB_POLICY_NAME), nullptr);
+  }
+};
+
 int g_fake_non_responsive_dns_server_port = -1;
 
 /* This function will configure any ares_channel created by the c-ares based
@@ -541,7 +567,7 @@ void StartResolvingLocked(void* arg, grpc_error* unused) {
 
 void RunResolvesRelevantRecordsTest(
     grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler> (
-        *CreateResultHandler)(ArgsStruct* args)) {
+        *CreateResultHandler)(ArgsStruct* args), const char* target_name, gpr_event* proceed_for_polling_ev) {
   grpc_core::ExecCtx exec_ctx;
   ArgsStruct args;
   ArgsInit(&args);
@@ -563,13 +589,13 @@ void RunResolvesRelevantRecordsTest(
             g_fake_non_responsive_dns_server_port));
     grpc_ares_test_only_inject_config = InjectBrokenNameServerList;
     GPR_ASSERT(
-        gpr_asprintf(&whole_uri, "dns:///%s", FLAGS_target_name.c_str()));
+        gpr_asprintf(&whole_uri, "dns:///%s", target_name));
   } else if (FLAGS_inject_broken_nameserver_list == "False") {
     gpr_log(GPR_INFO, "Specifying authority in uris to: %s",
             FLAGS_local_dns_server_address.c_str());
     GPR_ASSERT(gpr_asprintf(&whole_uri, "dns://%s/%s",
                             FLAGS_local_dns_server_address.c_str(),
-                            FLAGS_target_name.c_str()));
+                            target_name));
   } else {
     gpr_log(GPR_DEBUG, "Invalid value for --inject_broken_nameserver_list.");
     abort();
@@ -620,12 +646,16 @@ void RunResolvesRelevantRecordsTest(
                                          grpc_combiner_scheduler(args.lock)),
                      GRPC_ERROR_NONE);
   grpc_core::ExecCtx::Get()->Flush();
+  gpr_event_wait(proceed_for_polling_ev, gpr_inf_future(GPR_CLOCK_REALTIME));
   PollPollsetUntilRequestDone(&args);
   ArgsFinish(&args);
 }
 
 TEST(ResolverComponentTest, TestResolvesRelevantRecords) {
-  RunResolvesRelevantRecordsTest(CheckingResultHandler::Create);
+  gpr_event proceed_for_polling_ev;
+  gpr_event_init(&proceed_for_polling_ev);
+  gpr_event_set(&proceed_for_polling_ev, (void*)1);
+  RunResolvesRelevantRecordsTest(CheckingResultHandler::Create, FLAGS_target_name.c_str(), &proceed_for_polling_ev);
 }
 
 TEST(ResolverComponentTest, TestResolvesRelevantRecordsWithConcurrentFdStress) {
@@ -636,10 +666,43 @@ TEST(ResolverComponentTest, TestResolvesRelevantRecordsWithConcurrentFdStress) {
   std::thread socket_stress_thread(OpenAndCloseSocketsStressLoop, dummy_port,
                                    &done_ev);
   // Run the resolver test
-  RunResolvesRelevantRecordsTest(ResultHandler::Create);
+  gpr_event proceed_for_polling_ev;
+  gpr_event_init(&proceed_for_polling_ev);
+  gpr_event_set(&proceed_for_polling_ev, (void*)1);
+  RunResolvesRelevantRecordsTest(ResultHandler::Create, FLAGS_target_name.c_str(), &proceed_for_polling_ev);
   // Shutdown and join stress thread
   gpr_event_set(&done_ev, (void*)1);
   socket_stress_thread.join();
+}
+
+TEST(ResolverComponentTest, TestConcurrentResolvesRelevantRecordsSameQueries) {
+  gpr_event proceed_for_polling_ev;
+  gpr_event_init(&proceed_for_polling_ev);
+  std::vector<std::thread> thds;
+  for (size_t i = 0; i < 10; i++) {
+    thds.push_back(std::thread(RunResolvesRelevantRecordsTest, CheckingResultHandler::Create, FLAGS_target_name.c_str(), &proceed_for_polling_ev));
+  }
+  gpr_event_set(&proceed_for_polling_ev, (void*)1);
+  for (size_t i = 0; i < thds.size(); i++) {
+    thds[i].join();
+  }
+}
+
+TEST(ResolverComponentTest, TestConcurrentResolvesRelevantRecordsNotAllQueriesSame) {
+  gpr_event proceed_for_polling_ev;
+  gpr_event_init(&proceed_for_polling_ev);
+  std::vector<std::thread> thds;
+  for (size_t i = 0; i < 10; i++) {
+    thds.push_back(std::thread(RunResolvesRelevantRecordsTest, CheckingResultHandler::Create, FLAGS_target_name.c_str(), &proceed_for_polling_ev));
+  }
+  for (size_t i = 0; i < 10; i++) {
+    const char* health_check_record_name = "health-check-local-dns-server-is-alive.resolver-tests.grpctestingexp.";
+    thds.push_back(std::thread(RunResolvesRelevantRecordsTest, HealthCheckQueryResultHandler::Create, health_check_record_name, &proceed_for_polling_ev));
+  }
+  gpr_event_set(&proceed_for_polling_ev, (void*)1);
+  for (size_t i = 0; i < thds.size(); i++) {
+    thds[i].join();
+  }
 }
 
 }  // namespace

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -26,7 +26,6 @@
 #include <grpc/support/sync.h>
 #include <grpc/support/time.h>
 
-#include <pthread.h>
 #include <string.h>
 
 #include <errno.h>
@@ -588,7 +587,6 @@ void RunResolvesRelevantRecordsTest(
   grpc_core::UniquePtr<grpc::testing::FakeNonResponsiveDNSServer>
       fake_non_responsive_dns_server;
   if (FLAGS_inject_broken_nameserver_list == "True") {
-    g_fake_non_responsive_dns_server_port = grpc_pick_unused_port_or_die();
     fake_non_responsive_dns_server.reset(
         grpc_core::New<grpc::testing::FakeNonResponsiveDNSServer>(
             g_fake_non_responsive_dns_server_port));
@@ -732,6 +730,7 @@ int main(int argc, char** argv) {
     gpr_log(GPR_ERROR, "Missing target_name param.");
     abort();
   }
+  g_fake_non_responsive_dns_server_port = grpc_pick_unused_port_or_die();
   auto result = RUN_ALL_TESTS();
   grpc_shutdown();
   return result;


### PR DESCRIPTION
This can be considered as just an idea for now.

There's a problem found internally in which some DNS servers have rate limits, and this doesn't work well when lots of channels are started up concurrently. Lots of concurrent channels starting up seems most common in scenarios where there is a pool of channels targeting one service; this PR brings down the number of concurrent queries to ~1 in this case.

----------------------

FTR there a couple of realized problems in this PR:
* cancellation: if a query is cancelled and it's in the pending duplicate queries list, it needs to be kicked out right away no matter where it is in the "pending" list
* this PR creates polling dependencies between independent channels. If channel A kicks off a DNS resolution but the application stops polling on it, and then B kicks off the same resolution, then channel B won't make progress except by the backup poller.