### PR TITLE
Use Acquire semantics on unref only when it reaches zero

### DIFF
--- a/src/core/lib/gprpp/atomic.h
+++ b/src/core/lib/gprpp/atomic.h
@@ -99,6 +99,10 @@ class Atomic {
   std::atomic<T> storage_;
 };
 
+inline void AtomicThreadFence(MemoryOrder order) {
+  std::atomic_thread_fence(static_cast<std::memory_order>(order));
+}
+
 }  // namespace grpc_core
 
 #endif /* GRPC_CORE_LIB_GPRPP_ATOMIC_H */


### PR DESCRIPTION
We only need to use Acquire semantics on unref when it reaches zero