### PR TITLE
Fix generated init prefixed methods

### DIFF
--- a/src/compiler/objective_c_generator.cc
+++ b/src/compiler/objective_c_generator.cc
@@ -38,6 +38,18 @@ using ::std::set;
 namespace grpc_objective_c_generator {
 namespace {
 
+// A method starting with init... becomes an initializer in ObjC. If a service's
+// method starts with init..., we prefix the method signature with "call..." to
+// avoid creating an initializer.
+::grpc::string MutateInitPrefixedMethod(::grpc::string method_name) {
+  if (method_name.find("init") == 0 &&
+      (method_name.length() == 4 || isupper(method_name[4]))) {
+    method_name = ::grpc::string("callI") +
+                  method_name.substr(1, method_name.length() - 1);
+  }
+  return method_name;
+}
+
 void PrintProtoRpcDeclarationAsPragma(
     Printer* printer, const MethodDescriptor* method,
     map< ::grpc::string, ::grpc::string> vars) {
@@ -128,8 +140,8 @@ void PrintV2Signature(Printer* printer, const MethodDescriptor* method,
   } else {
     vars["return_type"] = "GRPCUnaryProtoCall *";
   }
-  vars["method_name"] =
-      grpc_generator::LowercaseFirstLetter(vars["method_name"]);
+  vars["method_name"] = MutateInitPrefixedMethod(
+      grpc_generator::LowercaseFirstLetter(vars["method_name"]));
 
   PrintAllComments(method, printer);
 

--- a/src/objective-c/tests/RemoteTestClient/test.proto
+++ b/src/objective-c/tests/RemoteTestClient/test.proto
@@ -54,4 +54,16 @@ service TestService {
   // first request.
   rpc HalfDuplexCall(stream StreamingOutputCallRequest)
       returns (stream StreamingOutputCallResponse);
+
+  // Test method with "Init" as prefix.
+  // This method should not be used in tests. It is to build-test the
+  // correctness of generated Objective-C stub. The generated method signature
+  // is expected to have a prefix "call".
+  rpc InitMethod(SimpleRequest) returns (SimpleResponse);
+
+  // Test method with "Initialize" as prefix.
+  // This method should not be used in tests. It is to build-test the
+  // correctness of generated Objective-C stub. The generated method signature
+  // should not have any prefix before "initialize".
+  rpc InitializeMethod(SimpleRequest) returns (SimpleResponse);
 }


### PR DESCRIPTION
ObjC plugin generates Protobuf method `InitXXX` verbosely as `initXXXWith...`, which is mistakenly interpreted as an initializer method. This PR adds a prefix "call" to such type of methods, making the generated stub method `callInitXXXWith...`. 

The change is based on the rationale that it does not make much sense for a service to have two methods named `InitXXX` and `CallInitXXX` at the same time, so there is no potential conflict between their generated stub methods.

Discussions are welcome.

Fix #18187 