### PR TITLE
Specify RepositoryUrl in interop test build to fix latest Source Link

### DIFF
--- a/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
@@ -39,4 +39,6 @@
     ln -s $(pwd)/.dotnet/dotnet /usr/local/bin/dotnet
   fi
 
-  dotnet build --configuration Debug Grpc.DotNet.sln
+  # Cloning from a local path sets RepositoryUrl to a path and breaks Source Link.
+  # Override RepositoryUrl to a URL to fix Source Link. The value doesn't matter.
+  dotnet build --configuration Debug Grpc.DotNet.sln -p:RepositoryUrl=https://localhost

--- a/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
+++ b/templates/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh.template
@@ -41,4 +41,4 @@
 
   # Cloning from a local path sets RepositoryUrl to a path and breaks Source Link.
   # Override RepositoryUrl to a URL to fix Source Link. The value doesn't matter.
-  dotnet build --configuration Debug Grpc.DotNet.sln -p:RepositoryUrl=https://localhost
+  dotnet build --configuration Debug Grpc.DotNet.sln -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git

--- a/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_aspnetcore/build_interop.sh
@@ -37,4 +37,6 @@ then
   ln -s $(pwd)/.dotnet/dotnet /usr/local/bin/dotnet
 fi
 
-dotnet build --configuration Debug Grpc.DotNet.sln
+# Cloning from a local path sets RepositoryUrl to a path and breaks Source Link.
+# Override RepositoryUrl to a URL to fix Source Link. The value doesn't matter.
+dotnet build --configuration Debug Grpc.DotNet.sln -p:RepositoryUrl=https://github.com/grpc/grpc-dotnet.git


### PR DESCRIPTION
The latest Source Link package breaks the interop test build because the repo is cloned from a local path.

https://source.cloud.google.com/results/invocations/014c0694-0b01-47ff-984f-0807d46fcbb4/targets/github%2Fgrpc%2Finterop_docker_build/tests

@jtattermusch 