### PR TITLE
CH2 perform_stream_op_locked() enhancements.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -700,8 +700,22 @@ void grpc_chttp2_end_write(grpc_chttp2_transport* t, grpc_error* error);
 grpc_error* grpc_chttp2_perform_read(grpc_chttp2_transport* t,
                                      const grpc_slice& slice);
 
+namespace grpc_core {
+namespace no_direct_call {
 bool grpc_chttp2_list_add_writable_stream(grpc_chttp2_transport* t,
                                           grpc_chttp2_stream* s);
+} /* namespace no_direct_call */
+} /* namespace grpc_core */
+template <bool strict_checks = true>
+inline bool grpc_chttp2_list_add_writable_stream(grpc_chttp2_transport* t,
+                                                 grpc_chttp2_stream* s) {
+  if (strict_checks) {
+    GPR_ASSERT(s->id != 0);
+  } else {
+    GPR_DEBUG_ASSERT(s->id != 0);
+  }
+  return grpc_core::no_direct_call::grpc_chttp2_list_add_writable_stream(t, s);
+}
 /** Get a writable stream
     returns non-zero if there was a stream available */
 bool grpc_chttp2_list_pop_writable_stream(grpc_chttp2_transport* t,

--- a/src/core/ext/transport/chttp2/transport/stream_lists.cc
+++ b/src/core/ext/transport/chttp2/transport/stream_lists.cc
@@ -137,12 +137,14 @@ static bool stream_list_add(grpc_chttp2_transport* t, grpc_chttp2_stream* s,
 }
 
 /* wrappers for specializations */
-
+namespace grpc_core {
+namespace no_direct_call {
 bool grpc_chttp2_list_add_writable_stream(grpc_chttp2_transport* t,
                                           grpc_chttp2_stream* s) {
-  GPR_ASSERT(s->id != 0);
   return stream_list_add(t, s, GRPC_CHTTP2_LIST_WRITABLE);
 }
+} /* namespace no_direct_call */
+} /* namespace grpc_core */
 
 bool grpc_chttp2_list_pop_writable_stream(grpc_chttp2_transport* t,
                                           grpc_chttp2_stream** s) {

--- a/src/core/lib/compression/stream_compression.h
+++ b/src/core/lib/compression/stream_compression.h
@@ -112,5 +112,38 @@ void grpc_stream_compression_context_destroy(
  */
 int grpc_stream_compression_method_parse(
     grpc_slice value, bool is_compress, grpc_stream_compression_method* method);
+inline grpc_stream_compression_method grpc_stream_compression_method_parse(
+    const grpc_slice& value) {
+  // At present, we only support identity and gzip compression.
+  // If we got an invalid value, we fallback to identity. So, as long as we do
+  // not add other types of compression, we only need to check for gzip.
+  // We place a debug assert to warn us when other types are added.
+  static_assert(
+      GRPC_STREAM_COMPRESSION_IDENTITY_COMPRESS ==
+          static_cast<grpc_stream_compression_method>(0),
+      "Change method if we ever support more than identity/gzip compression.");
+  static_assert(
+      GRPC_STREAM_COMPRESSION_IDENTITY_DECOMPRESS ==
+          static_cast<grpc_stream_compression_method>(1),
+      "Change method if we ever support more than identity/gzip compression.");
+  static_assert(
+      GRPC_STREAM_COMPRESSION_GZIP_COMPRESS ==
+          static_cast<grpc_stream_compression_method>(2),
+      "Change method if we ever support more than identity/gzip compression.");
+  static_assert(
+      GRPC_STREAM_COMPRESSION_GZIP_DECOMPRESS ==
+          static_cast<grpc_stream_compression_method>(3),
+      "Change method if we ever support more than identity/gzip compression.");
+  static_assert(
+      GRPC_STREAM_COMPRESSION_METHOD_COUNT ==
+          static_cast<grpc_stream_compression_method>(4),
+      "Change method if we ever support more than identity/gzip compression.");
+  if (value.refcount == GRPC_MDSTR_GZIP.refcount) {
+    return GRPC_STREAM_COMPRESSION_GZIP_COMPRESS;
+  }
+  return grpc_slice_differs_refcounted(value, GRPC_MDSTR_GZIP)
+             ? GRPC_STREAM_COMPRESSION_IDENTITY_COMPRESS
+             : GRPC_STREAM_COMPRESSION_GZIP_COMPRESS;
+}
 
 #endif


### PR DESCRIPTION
Performance enhancements for perform_stream_op_locked, mostly focusing on send_initial_metadata. Mostly changing some asserts into debug asserts, inlining/fast-pathing stream compression parsing.

Results:
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/0                                                         [polls/iter:3.00009                        ]            21.6µs ± 2%             21.1µs ± 1%  -2.14%          (p=0.000 n=7+9)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/1/0                                                         [polls/iter:3.00008                        ]            22.1µs ± 1%             21.8µs ± 2%  -1.15%          (p=0.019 n=9+9)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/8/0                                                         [polls/iter:3.00008                        ]            22.1µs ± 1%             21.8µs ± 1%  -1.34%         (p=0.011 n=10+6)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/8/8                                                         [polls/iter:3.00011                        ]            22.4µs ± 1%             22.1µs ± 1%  -1.64%          (p=0.003 n=7+5)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/64/0                                                        [polls/iter:3.00006                        ]            22.4µs ± 1%             22.1µs ± 0%  -1.50%          (p=0.006 n=7+4)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/4096/4096                                                   [polls/iter:3.00006                        ]            26.6µs ± 1%             26.1µs ± 0%  -1.84%          (p=0.000 n=7+8)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/1/0                                                      [polls/iter:3.00009                        ]            21.4µs ± 2%             21.1µs ± 2%  -1.49%         (p=0.038 n=11+9)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/1/1                                                      [polls/iter:3.00011                        ]            21.7µs ± 0%             21.2µs ± 1%  -2.45%          (p=0.003 n=5+7)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/8                                                      [polls/iter:3.00006                        ]            21.4µs ± 2%             20.8µs ± 1%  -2.59%         (p=0.030 n=10+2)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/8/8                                                      [polls/iter:3.00008                        ]            21.8µs ± 2%             21.2µs ± 1%  -2.53%          (p=0.000 n=7+9)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/64                                                     [polls/iter:3.00009                        ]            21.9µs ± 1%             21.6µs ± 2%  -1.34%          (p=0.048 n=7+5)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/512                                                    [polls/iter:3.00008                        ]            22.4µs ± 1%             22.0µs ± 1%  -1.95%         (p=0.007 n=3+10)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/4096/0                                                   [polls/iter:3.00008                        ]            23.5µs ± 1%             23.0µs ± 0%  -1.91%          (p=0.001 n=9+5)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/32768                                                  [polls/iter:3.0001                         ]            34.6µs ± 1%             34.2µs ± 1%  -1.17%         (p=0.002 n=6+10)
BM_UnaryPingPong<MinUDS, NoOpMutator, NoOpMutator>/0/0                                                      [polls/iter:3.00013                        ]            19.8µs ± 1%             19.5µs ± 0%  -1.71%          (p=0.010 n=6+4)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/0                                                   [polls/iter:0                              ]            6.33µs ± 6%             6.21µs ± 7%  -1.97%        (p=0.019 n=40+40)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/1/0                                                   [polls/iter:0                              ]            6.50µs ± 6%             6.27µs ± 2%  -3.51%        (p=0.000 n=40+35)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/1                                                   [polls/iter:0                              ]            6.48µs ± 6%             6.24µs ± 3%  -3.64%        (p=0.000 n=40+34)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/1/1                                                   [polls/iter:0                              ]            6.57µs ± 6%             6.40µs ± 5%  -2.61%        (p=0.000 n=40+37)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/8/0                                                   [polls/iter:0                              ]            6.44µs ± 7%             6.24µs ± 2%  -3.10%        (p=0.000 n=40+32)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/8                                                   [polls/iter:0                              ]            6.47µs ± 6%             6.24µs ± 4%  -3.61%        (p=0.000 n=40+35)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/8/8                                                   [polls/iter:0                              ]            6.57µs ± 7%             6.37µs ± 4%  -3.05%        (p=0.000 n=40+34)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/64/0                                                  [polls/iter:0                              ]            6.50µs ± 6%             6.33µs ± 4%  -2.67%        (p=0.000 n=40+34)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/64/64                                                 [polls/iter:0                              ]            6.58µs ± 5%             6.53µs ± 5%  -0.78%        (p=0.017 n=36+34)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/512/0                                                 [polls/iter:0                              ]            6.58µs ± 4%             6.48µs ± 4%  -1.65%        (p=0.000 n=36+33)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/512                                                 [polls/iter:0                              ]            6.49µs ± 2%             6.52µs ± 2%  +0.38%        (p=0.015 n=32+34)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/512/512                                               [polls/iter:0                              ]            6.87µs ± 6%             6.79µs ± 3%  -1.15%        (p=0.023 n=38+35)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/4096/0                                                [polls/iter:0                              ]            7.59µs ± 2%             7.52µs ± 1%  -1.02%        (p=0.000 n=40+34)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/32768/0                                               [polls/iter:0                              ]            15.8µs ± 1%             15.8µs ± 1%  -0.32%        (p=0.000 n=38+39)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/32768                                               [polls/iter:0                              ]            16.1µs ± 1%             16.1µs ± 1%  +0.39%        (p=0.018 n=38+39)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/0                                                [polls/iter:0                              ]            6.32µs ± 6%             6.21µs ± 5%  -1.88%        (p=0.004 n=40+40)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/1/0                                                [polls/iter:0                              ]            6.49µs ± 5%             6.35µs ± 6%  -2.08%        (p=0.002 n=40+40)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/1                                                [polls/iter:0                              ]            6.46µs ± 5%             6.30µs ± 6%  -2.47%        (p=0.005 n=40+40)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/1/1                                                [polls/iter:0                              ]            6.54µs ± 6%             6.40µs ± 6%  -2.20%        (p=0.008 n=40+40)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/8/0                                                [polls/iter:0                              ]            6.33µs ± 7%             6.22µs ± 5%  -1.79%        (p=0.026 n=40+38)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/64/0                                               [polls/iter:0                              ]            6.45µs ± 6%             6.24µs ± 2%  -3.17%        (p=0.000 n=40+37)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/64/64                                              [polls/iter:0                              ]            6.66µs ± 7%             6.45µs ± 2%  -3.21%        (p=0.000 n=40+39)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/512/0                                              [polls/iter:0                              ]            6.68µs ± 6%             6.39µs ± 1%  -4.27%        (p=0.000 n=40+36)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/512/512                                            [polls/iter:0                              ]            6.91µs ± 7%             6.73µs ± 2%  -2.52%        (p=0.005 n=40+35)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/4096/0                                             [polls/iter:0                              ]            7.64µs ± 6%             7.46µs ± 2%  -2.37%        (p=0.000 n=40+37)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/32768/0                                            [polls/iter:0                              ]            15.8µs ± 2%             15.7µs ± 1%  -0.93%        (p=0.000 n=40+34)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/32768/32768                                        [polls/iter:0                              ]            25.6µs ± 2%             25.5µs ± 1%  -0.37%        (p=0.031 n=40+37)
BM_UnaryPingPong<SockPair, NoOpMutator, NoOpMutator>/0/0                                                    [polls/iter:3.00014                        ]            20.0µs ± 1%             19.4µs ± 0%  -2.87%          (p=0.016 n=4+5)
BM_UnaryPingPong<MinSockPair, NoOpMutator, NoOpMutator>/0/0                                                 [polls/iter:3.00012                        ]            19.3µs ± 1%             18.8µs ± 0%  -2.44%          (p=0.004 n=6+5)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomBinaryMetadata<10>, 1>, NoOpMutator>/0/0               [polls/iter:0                              ]            7.24µs ± 6%             7.04µs ± 4%  -2.66%        (p=0.000 n=40+40)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomBinaryMetadata<31>, 1>, NoOpMutator>/0/0               [polls/iter:0                              ]            7.22µs ± 5%             7.04µs ± 4%  -2.40%        (p=0.000 n=40+40)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomBinaryMetadata<100>, 1>, NoOpMutator>/0/0              [polls/iter:0                              ]            7.24µs ± 5%             7.10µs ± 5%  -1.99%        (p=0.002 n=40+40)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomBinaryMetadata<10>, 2>, NoOpMutator>/0/0               [polls/iter:0                              ]            7.80µs ± 5%             7.57µs ± 5%  -2.96%        (p=0.000 n=40+40)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomBinaryMetadata<31>, 2>, NoOpMutator>/0/0               [polls/iter:0                              ]            7.85µs ± 5%             7.63µs ± 4%  -2.87%        (p=0.000 n=40+40)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomBinaryMetadata<100>, 2>, NoOpMutator>/0/0              [polls/iter:0                              ]            8.10µs ± 5%             7.85µs ± 4%  -3.10%        (p=0.000 n=40+40)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomBinaryMetadata<10>, 1>>/0/0        [polls/iter:0                              ]            7.25µs ± 6%             7.08µs ± 4%  -2.28%        (p=0.000 n=40+40)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomBinaryMetadata<31>, 1>>/0/0        [polls/iter:0                              ]            7.15µs ± 5%             7.04µs ± 5%  -1.64%        (p=0.012 n=40+40)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomBinaryMetadata<100>, 1>>/0/0       [polls/iter:0                              ]            7.26µs ± 5%             7.14µs ± 6%  -1.67%        (p=0.023 n=40+40)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomAsciiMetadata<10>, 1>, NoOpMutator>/0/0                [polls/iter:0                              ]            7.12µs ± 5%             6.98µs ± 5%  -2.07%        (p=0.006 n=40+40)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomAsciiMetadata<31>, 1>, NoOpMutator>/0/0                [polls/iter:0                              ]            7.23µs ± 5%             7.10µs ± 5%  -1.70%        (p=0.020 n=40+40)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomAsciiMetadata<100>, 1>, NoOpMutator>/0/0               [polls/iter:0                              ]            7.35µs ± 5%             7.19µs ± 5%  -2.24%        (p=0.001 n=40+40)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomAsciiMetadata<31>, 1>>/0/0         [polls/iter:0                              ]            7.19µs ± 6%             7.06µs ± 5%  -1.84%        (p=0.006 n=40+40)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/8                                                         [polls/iter:3.00009                        ]            22.1µs ± 0%             21.7µs ± 0%  -1.76%          (p=0.044 n=2+8)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/64/64                                                       [polls/iter:3.00008                        ]            23.4µs ± 2%             22.8µs ± 0%  -2.52%         (p=0.001 n=10+5)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/512/0                                                       [polls/iter:3.0001                         ]            22.9µs ± 2%             22.6µs ± 2%  -1.43%         (p=0.036 n=7+12)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/4096/4096                                                   [polls/iter:3.00013                        ]            26.6µs ± 1%             26.1µs ± 1%  -1.93%          (p=0.004 n=6+6)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/262144/262144                                               [polls/iter:3.00021                        ]             291µs ± 1%              289µs ± 1%  -0.71%        (p=0.005 n=12+15)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/0                                                      [polls/iter:3.0001                         ]            21.0µs ± 7%             20.3µs ± 1%  -3.31%          (p=0.003 n=5+7)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/1/1                                                      [polls/iter:3.00009                        ]            21.6µs ± 1%             21.3µs ± 3%  -1.63%          (p=0.050 n=6+9)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/8/0                                                      [polls/iter:3.00009                        ]            21.6µs ± 1%             21.0µs ± 1%  -2.58%          (p=0.000 n=9+8)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/8/8                                                      [polls/iter:3.00009                        ]            21.7µs ± 1%             21.3µs ± 1%  -2.14%          (p=0.003 n=7+5)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/64/0                                                     [polls/iter:3.00008                        ]            21.7µs ± 1%             21.3µs ± 1%  -2.03%         (p=0.000 n=11+7)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/64/64                                                    [polls/iter:3.00008                        ]            22.5µs ± 2%             22.0µs ± 1%  -2.16%          (p=0.001 n=8+7)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/512/0                                                    [polls/iter:3.00008                        ]            22.1µs ± 1%             21.6µs ± 0%  -2.21%          (p=0.000 n=7+9)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/512                                                    [polls/iter:3.00011                        ]            22.3µs ± 1%             22.0µs ± 1%  -1.32%          (p=0.004 n=7+7)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/4096/0                                                   [polls/iter:3.00007                        ]            23.5µs ± 2%             23.1µs ± 1%  -1.55%          (p=0.008 n=6+8)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/4096                                                   [polls/iter:3.00012                        ]            23.6µs ± 1%             23.2µs ± 1%  -1.67%          (p=0.001 n=7+6)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/32768/0                                                  [polls/iter:3.00012                        ]            34.3µs ± 1%             33.8µs ± 0%  -1.36%          (p=0.004 n=4+8)
BM_UnaryPingPong<SockPair, NoOpMutator, NoOpMutator>/0/0                                                    [polls/iter:3.0001                         ]            20.1µs ± 1%             19.4µs ± 1%  -3.15%          (p=0.036 n=3+5)
BM_UnaryPingPong<MinInProcessCHTTP2, NoOpMutator, NoOpMutator>/134217728/0                                  [polls/iter:1.875 writes/iter:5.375        ]              177ms ± 1%              179ms ± 0%  +0.70%          (p=0.024 n=7+4)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/1                                                         [polls/iter:3.00006                        ]            22.0µs ± 1%             21.7µs ± 1%  -1.61%          (p=0.000 n=9+9)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/8/8                                                         [polls/iter:3.00008                        ]            22.4µs ± 2%             22.0µs ± 1%  -1.91%          (p=0.000 n=8+9)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/64/0                                                        [polls/iter:3.00011                        ]            22.6µs ± 1%             22.0µs ± 0%  -2.28%          (p=0.024 n=6+3)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/512/512                                                     [polls/iter:3.00012                        ]            24.0µs ± 1%             23.5µs ± 0%  -2.24%          (p=0.002 n=8+5)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/4096/0                                                      [polls/iter:3.00007                        ]            24.3µs ± 2%             23.8µs ± 1%  -1.80%        (p=0.000 n=13+11)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/4096/4096                                                   [polls/iter:3.00008                        ]            26.7µs ± 1%             26.3µs ± 0%  -1.38%          (p=0.012 n=8+3)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/32768/0                                                     [polls/iter:3.0001                         ]            35.1µs ± 1%             34.8µs ± 1%  -0.84%         (p=0.003 n=12+9)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/0                                                      [polls/iter:3.00009                        ]            20.6µs ± 1%             20.3µs ± 0%  -1.50%          (p=0.001 n=8+6)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/1/0                                                      [polls/iter:3.00011                        ]            21.3µs ± 1%             20.9µs ± 1%  -1.67%          (p=0.024 n=6+3)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/1                                                      [polls/iter:3.00009                        ]            21.3µs ± 1%             20.9µs ± 2%  -1.85%         (p=0.003 n=6+10)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/1/1                                                      [polls/iter:3.00008                        ]            21.7µs ± 3%             21.1µs ± 0%  -2.48%          (p=0.001 n=8+6)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/8/8                                                      [polls/iter:3.00011                        ]            21.8µs ± 1%             21.2µs ± 0%  -2.62%          (p=0.000 n=9+8)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/512/512                                                  [polls/iter:3.00008                        ]            23.2µs ± 1%             22.6µs ± 0%  -2.42%         (p=0.000 n=11+8)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/4096/0                                                   [polls/iter:3.0001                         ]            23.3µs ± 1%             23.0µs ± 1%  -1.24%          (p=0.016 n=5+5)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/4096/4096                                                [polls/iter:3.00009                        ]            25.8µs ± 1%             25.5µs ± 2%  -1.35%          (p=0.014 n=9+9)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/32768/0                                                  [polls/iter:3.0001                         ]            34.3µs ± 1%             33.9µs ± 0%  -1.30%         (p=0.000 n=9+11)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/32768/32768                                              [polls/iter:3.0001                         ]            47.8µs ± 0%             47.3µs ± 1%  -1.12%        (p=0.000 n=10+16)
BM_UnaryPingPong<InProcessCHTTP2, NoOpMutator, NoOpMutator>/0/134217728                                     [polls/iter:3 writes/iter:5.875            ]              160ms ± 1%              159ms ± 1%  -0.79%          (p=0.038 n=8+8)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/1/0                                                         [polls/iter:3.00006                        ]            22.0µs ± 1%             21.8µs ± 1%  -0.94%          (p=0.011 n=8+9)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/8/0                                                         [polls/iter:3.00006                        ]            22.2µs ± 2%             21.8µs ± 0%  -1.79%          (p=0.003 n=4+9)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/8                                                         [polls/iter:3.00006                        ]            22.1µs ± 1%             21.7µs ± 1%  -1.77%          (p=0.008 n=4+8)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/64/0                                                        [polls/iter:3.00008                        ]            22.5µs ± 1%             22.2µs ± 1%  -1.13%         (p=0.005 n=7+13)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/64                                                        [polls/iter:3.00008                        ]            22.5µs ± 1%             22.4µs ± 1%  -0.61%         (p=0.048 n=11+6)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/4096/0                                                      [polls/iter:3.0001                         ]            24.1µs ± 1%             23.8µs ± 1%  -1.05%          (p=0.010 n=6+4)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/32768/32768                                                 [polls/iter:3.00014                        ]            48.6µs ± 1%             48.1µs ± 1%  -1.14%          (p=0.001 n=8+9)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/262144/0                                                 [polls/iter:3.00011                        ]             157µs ± 2%              156µs ± 2%  -0.90%        (p=0.012 n=15+10)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/1                                                         [polls/iter:3.00011                        ]            22.0µs ± 1%             21.7µs ± 0%  -1.54%          (p=0.017 n=7+3)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/1/1                                                         [polls/iter:3.00005                        ]            22.3µs ± 1%             22.0µs ± 1%  -1.25%          (p=0.018 n=7+5)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/0                                                      [polls/iter:3.00006                        ]            20.7µs ± 1%             20.4µs ± 1%  -1.46%          (p=0.001 n=7+8)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/1/0                                                      [polls/iter:3.00006                        ]            21.4µs ± 2%             20.9µs ± 1%  -2.57%          (p=0.029 n=4+4)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/64                                                     [polls/iter:3.00011                        ]            21.8µs ± 0%             21.5µs ± 0%  -1.48%          (p=0.002 n=5+8)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/512/0                                                    [polls/iter:3.00009                        ]            21.9µs ± 0%             21.7µs ± 1%  -1.26%          (p=0.008 n=5+5)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/32768/0                                                  [polls/iter:3.00007                        ]            34.4µs ± 1%             33.9µs ± 1%  -1.57%         (p=0.000 n=15+6)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/1                                                         [polls/iter:3.00008                        ]            21.8µs ± 1%             21.6µs ± 1%  -0.76%          (p=0.005 n=6+9)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/512/0                                                       [polls/iter:3.00008                        ]            22.8µs ± 2%             22.5µs ± 2%  -1.56%          (p=0.002 n=8+8)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/1/0                                                      [polls/iter:3.00008                        ]            21.4µs ± 1%             21.1µs ± 1%  -1.34%          (p=0.036 n=9+3)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/1/1                                                      [polls/iter:3.00006                        ]            21.5µs ± 1%             21.0µs ± 1%  -2.32%          (p=0.036 n=5+3)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/8                                                      [polls/iter:3.00009                        ]            21.4µs ± 2%             20.8µs ± 1%  -2.79%          (p=0.001 n=6+8)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/64/0                                                     [polls/iter:3.00011                        ]            21.8µs ± 2%             21.2µs ± 0%  -2.71%          (p=0.006 n=7+4)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/64                                                     [polls/iter:3.00008                        ]            21.9µs ± 2%             21.5µs ± 0%  -1.87%          (p=0.000 n=9+8)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/32768/32768                                                 [polls/iter:3.0001                         ]            48.6µs ± 1%             48.2µs ± 1%  -0.73%         (p=0.003 n=9+10)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/262144                                                    [polls/iter:3.00011                        ]             159µs ± 1%              160µs ± 1%  +0.70%         (p=0.009 n=10+8)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/64/0                                                     [polls/iter:3.00009                        ]            21.9µs ± 1%             21.4µs ± 2%  -1.89%         (p=0.009 n=5+12)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/32768                                                  [polls/iter:3.00007                        ]            34.6µs ± 1%             34.2µs ± 1%  -1.19%        (p=0.000 n=10+13)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/32768/32768                                              [polls/iter:3.00007                        ]            48.0µs ± 1%             47.4µs ± 1%  -1.24%          (p=0.000 n=8+7)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/262144                                                 [polls/iter:3.00011                        ]             159µs ± 1%              157µs ± 2%  -1.13%          (p=0.038 n=8+8)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/8/0                                                         [polls/iter:3.00011                        ]            22.1µs ± 1%             21.7µs ± 1%  -1.78%          (p=0.044 n=2+8)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/64/64                                                       [polls/iter:3.00005                        ]            23.3µs ± 2%             23.0µs ± 1%  -1.31%          (p=0.006 n=8+5)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/512                                                    [polls/iter:3.00006                        ]            22.3µs ± 1%             21.9µs ± 0%  -1.68%         (p=0.000 n=10+6)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/4096/4096                                                [polls/iter:3.00011                        ]            25.7µs ± 1%             25.3µs ± 1%  -1.60%          (p=0.003 n=4+9)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/1/1                                                         [polls/iter:3.00008                        ]            22.3µs ± 1%             22.1µs ± 1%  -1.11%         (p=0.021 n=8+10)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/0                                                         [polls/iter:3.00005                        ]            21.5µs ± 2%             21.2µs ± 1%  -1.32%          (p=0.017 n=6+5)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/64/64                                                       [polls/iter:3.0001                         ]            23.2µs ± 1%             22.9µs ± 1%  -1.21%         (p=0.014 n=4+10)
BM_UnaryPingPong<UDS, NoOpMutator, NoOpMutator>/0/0                                                         [polls/iter:3.00013                        ]            20.5µs ± 0%             20.3µs ± 1%  -1.15%          (p=0.029 n=4+4)
BM_UnaryPingPong<MinSockPair, NoOpMutator, NoOpMutator>/0/0                                                 [polls/iter:3.00015                        ]            19.4µs ± 1%             18.9µs ± 1%  -2.79%          (p=0.016 n=5+4)
BM_UnaryPingPong<InProcessCHTTP2, NoOpMutator, NoOpMutator>/0/134217728                                     [polls/iter:3 writes/iter:5.625            ]              161ms ± 0%              159ms ± 1%  -0.92%         (p=0.004 n=3+13)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/32768/0                                                     [polls/iter:3.00005                        ]            35.3µs ± 2%             34.8µs ± 0%  -1.37%          (p=0.017 n=3+7)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/512/0                                                    [polls/iter:3.00011                        ]            22.1µs ± 2%             21.8µs ± 2%  -1.63%          (p=0.030 n=5+6)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/512                                                    [polls/iter:3.00009                        ]            22.0µs ± 0%             21.9µs ± 0%  -0.74%          (p=0.012 n=3+8)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/32768                                                     [polls/iter:3.00015                        ]            35.4µs ± 1%             35.0µs ± 0%  -1.11%          (p=0.042 n=7+4)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/4096/0                                                   [polls/iter:3.00005                        ]            23.5µs ± 2%             23.0µs ± 1%  -2.00%          (p=0.005 n=7+5)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/512/0                                                       [polls/iter:3.00005                        ]            22.8µs ± 1%             22.5µs ± 0%  -1.31%          (p=0.016 n=5+5)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/64/0                                                     [polls/iter:3.00006                        ]            21.9µs ± 2%             21.3µs ± 1%  -2.63%          (p=0.002 n=6+6)
BM_UnaryPingPong<SockPair, NoOpMutator, NoOpMutator>/0/0                                                    [polls/iter:3.00017                        ]            20.1µs ± 1%             19.5µs ± 1%  -3.03%          (p=0.001 n=6+7)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/64/0                                                        [polls/iter:3.00005                        ]            22.5µs ± 1%             22.1µs ± 1%  -1.94%          (p=0.016 n=4+5)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/512                                                       [polls/iter:3.0001                         ]            23.0µs ± 1%             22.7µs ± 1%  -1.45%          (p=0.009 n=6+6)
BM_UnaryPingPong<UDS, NoOpMutator, NoOpMutator>/0/0                                                         [polls/iter:3.00012                        ]            20.6µs ± 1%             20.2µs ± 1%  -1.67%          (p=0.024 n=6+3)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/1                                                         [polls/iter:3.00005                        ]            22.0µs ± 1%             21.6µs ± 0%  -1.67%          (p=0.016 n=5+4)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/8/8                                                      [polls/iter:3.00006                        ]            21.6µs ± 1%             21.3µs ± 1%  -1.48%          (p=0.016 n=4+5)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/4096                                                   [polls/iter:3.00008                        ]            23.5µs ± 1%             23.3µs ± 1%  -0.69%         (p=0.040 n=5+10)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/512                                                       [polls/iter:3.00005                        ]            23.2µs ± 1%             22.7µs ± 1%  -2.25%          (p=0.004 n=4+8)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/64                                                     [polls/iter:3.00006                        ]            22.1µs ± 2%             21.7µs ± 1%  -1.71%          (p=0.019 n=4+6)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/8/0                                                      [polls/iter:3.00008                        ]            21.5µs ± 1%             21.1µs ± 1%  -1.72%          (p=0.001 n=8+6)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/0                                                      [polls/iter:3.00012                        ]            20.7µs ± 1%             20.4µs ± 0%  -1.56%          (p=0.016 n=4+5)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/8                                                      [polls/iter:3.00012                        ]            21.8µs ± 6%             20.9µs ± 2%  -3.94%          (p=0.032 n=4+5)
BM_UnaryPingPong<UDS, NoOpMutator, NoOpMutator>/0/0                                                         [polls/iter:3.00016                        ]            20.7µs ± 1%             20.1µs ± 0%  -2.57%          (p=0.017 n=3+7)

