### PR TITLE
Upgrade bazel to 0.29.1

### DIFF
--- a/templates/tools/dockerfile/bazel.include
+++ b/templates/tools/dockerfile/bazel.include
@@ -2,7 +2,7 @@
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 0.28.1
+ENV BAZEL_VERSION 0.29.0
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1

--- a/templates/tools/dockerfile/bazel.include
+++ b/templates/tools/dockerfile/bazel.include
@@ -2,7 +2,7 @@
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 0.29.0
+ENV BAZEL_VERSION 0.29.1
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1

--- a/tools/bazel
+++ b/tools/bazel
@@ -32,7 +32,7 @@ then
   exec -a "$0" "${BAZEL_REAL}" "$@"
 fi
 
-VERSION=0.28.1
+VERSION=0.29.0
 
 echo "INFO: Running bazel wrapper (see //tools/bazel for details), bazel version $VERSION will be used instead of system-wide bazel installation."
 

--- a/tools/bazel
+++ b/tools/bazel
@@ -32,7 +32,7 @@ then
   exec -a "$0" "${BAZEL_REAL}" "$@"
 fi
 
-VERSION=0.29.0
+VERSION=0.29.1
 
 echo "INFO: Running bazel wrapper (see //tools/bazel for details), bazel version $VERSION will be used instead of system-wide bazel installation."
 

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -52,7 +52,7 @@ RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 t
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 0.28.1
+ENV BAZEL_VERSION 0.29.0
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1

--- a/tools/dockerfile/test/bazel/Dockerfile
+++ b/tools/dockerfile/test/bazel/Dockerfile
@@ -52,7 +52,7 @@ RUN pip install futures==2.2.0 enum34==1.0.4 protobuf==3.5.2.post1 six==1.10.0 t
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 0.29.0
+ENV BAZEL_VERSION 0.29.1
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -97,7 +97,7 @@ ENV CLANG_TIDY=clang-tidy
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 0.28.1
+ENV BAZEL_VERSION 0.29.0
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1

--- a/tools/dockerfile/test/sanity/Dockerfile
+++ b/tools/dockerfile/test/sanity/Dockerfile
@@ -97,7 +97,7 @@ ENV CLANG_TIDY=clang-tidy
 # Bazel installation
 
 # Must be in sync with tools/bazel
-ENV BAZEL_VERSION 0.29.0
+ENV BAZEL_VERSION 0.29.1
 
 # The correct bazel version is already preinstalled, no need to use //tools/bazel wrapper.
 ENV DISABLE_BAZEL_WRAPPER 1

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -24,7 +24,7 @@ powershell -Command "[guid]::NewGuid().ToString()" >%KOKORO_ARTIFACTS_DIR%/bazel
 set /p BAZEL_INVOCATION_ID=<%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
 
 @rem TODO(jtattermusch): windows RBE should be able to use the same credentials as Linux RBE.
-bazel --bazelrc=tools/remote_build/windows.bazelrc build --invocation_id="%BAZEL_INVOCATION_ID%" --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh :all --incompatible_disallow_filetype=false --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json
+bazel --bazelrc=tools/remote_build/windows.bazelrc build --invocation_id="%BAZEL_INVOCATION_ID%" --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh :all --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json
 set BAZEL_EXITCODE=%errorlevel%
 
 @rem TODO(jtattermusch): upload results to bigquery

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -14,7 +14,7 @@
 
 @rem TODO(jtattermusch): make this generate less output
 @rem TODO(jtattermusch): use tools/bazel script to keep the versions in sync
-choco install bazel -y --version 0.26.0 --limit-output
+choco install bazel -y --version 0.29.0 --limit-output
 
 cd github/grpc
 set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -14,7 +14,7 @@
 
 @rem TODO(jtattermusch): make this generate less output
 @rem TODO(jtattermusch): use tools/bazel script to keep the versions in sync
-choco install bazel -y --version 0.29.0 --limit-output
+choco install bazel -y --version 0.29.1 --limit-output
 
 cd github/grpc
 set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -14,7 +14,8 @@
 
 @rem TODO(jtattermusch): make this generate less output
 @rem TODO(jtattermusch): use tools/bazel script to keep the versions in sync
-choco install bazel -y --version 0.29.1 --limit-output
+@rem TODO(jtattermusch): https://github.com/bazelbuild/bazel/issues/9369 prevents upgrade to 0.29.1
+choco install bazel -y --version 0.29.0 --limit-output
 
 cd github/grpc
 set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%

--- a/tools/remote_build/windows.bazelrc
+++ b/tools/remote_build/windows.bazelrc
@@ -1,8 +1,7 @@
 startup --host_jvm_args=-Dbazel.DigestFunction=SHA256
 
-build --remote_cache=remotebuildexecution.googleapis.com
-build --remote_executor=remotebuildexecution.googleapis.com
-build --tls_enabled=true
+build --remote_cache=grpcs://remotebuildexecution.googleapis.com
+build --remote_executor=grpcs://remotebuildexecution.googleapis.com
 
 build --host_crosstool_top=//third_party/toolchains/bazel_0.26.0_rbe_windows:toolchain
 build --crosstool_top=//third_party/toolchains/bazel_0.26.0_rbe_windows:toolchain
@@ -38,7 +37,7 @@ test --test_env=GRPC_VERBOSITY=debug
 
 # Set flags for uploading to BES in order to view results in the Bazel Build
 # Results UI.
-build --bes_backend="buildeventservice.googleapis.com"
+build --bes_backend=grpcs://buildeventservice.googleapis.com
 build --bes_timeout=60s
 build --bes_results_url="https://source.cloud.google.com/results/invocations/"
 build --project_id=grpc-testing


### PR DESCRIPTION
Bring back https://github.com/grpc/grpc/pull/20165 (which has been previously reverted), but this time also upgrade to just-released 0.29.1 (which fixes the bazel bug we hit with 0.29)
