### PR TITLE
Revert "Enable bitcode for ios native libraries" in v1.24.x

### DIFF
--- a/src/csharp/experimental/build_native_ext_for_ios.sh
+++ b/src/csharp/experimental/build_native_ext_for_ios.sh
@@ -28,7 +28,7 @@ function build {
     PATH_CC="$(xcrun --sdk $SDK --find clang)"
     PATH_CXX="$(xcrun --sdk $SDK --find clang++)"
 
-    CPPFLAGS="-O2 -Wframe-larger-than=16384 -arch $ARCH -isysroot $(xcrun --sdk $SDK --show-sdk-path) -fembed-bitcode -mios-version-min=6.0 -DPB_NO_PACKED_STRUCTS=1"
+    CPPFLAGS="-O2 -Wframe-larger-than=16384 -arch $ARCH -isysroot $(xcrun --sdk $SDK --show-sdk-path) -mios-version-min=6.0 -DPB_NO_PACKED_STRUCTS=1"
     LDFLAGS="-arch $ARCH -isysroot $(xcrun --sdk $SDK --show-sdk-path) -Wl,ios_version_min=6.0"
 
     # TODO(jtattermusch): revisit the build arguments


### PR DESCRIPTION
Reverts  https://github.com/grpc/grpc/pull/20113 in the release branch.
The size increase of the libgrpc.a is way too much to be shipped as part of Grpc.Core nuget (right now libgrpc.a  is >250MB).

FYI @koshelevpavel  if we don't figure out a good way how to decrease the size or iOS binaries, we'll need to revert.

