### PR TITLE
Remove node from singlevm end to end benchmarks

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_singlevm.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_singlevm.sh
@@ -20,8 +20,10 @@ cd $(dirname $0)/../../..
 source tools/internal_ci/helper_scripts/prepare_build_linux_perf_multilang_rc
 
 # "smoketest" scenarios on a single VM (=no remote VM for running qps_workers)
+# TODO(jtattermusch): add back "node" language once the scenarios are passing again
+# See https://github.com/grpc/grpc/issues/20234
 tools/run_tests/run_performance_tests.py \
-    -l c++ csharp ruby java python go php7 php7_protobuf_c node \
+    -l c++ csharp ruby java python go php7 php7_protobuf_c \
     --netperf \
     --category smoketest \
     -u kbuilder \


### PR DESCRIPTION
They have been failing on all build for long time and we're not getting any useful signal.

We can add them back once they are fixed (filed https://github.com/grpc/grpc/issues/20234)

@hcaseyal  this should make the grpc/core/master/linux/grpc_e2e_performance_singlevm kokoro job green on master.