### PR TITLE
Add v1.22.3 and v1.23.1 release of grpc-go to interop matrix.

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -145,7 +145,8 @@ LANG_RELEASE_MATRIX = {
              ReleaseInfo(runtimes=['go1.11'], testcases_file='go__v1.0.5')),
             ('v1.20.0', ReleaseInfo(runtimes=['go1.11'])),
             ('v1.21.3', ReleaseInfo(runtimes=['go1.11'])),
-            ('v1.22.2', ReleaseInfo(runtimes=['go1.11'])),
+            ('v1.22.3', ReleaseInfo(runtimes=['go1.11'])),
+            ('v1.23.1', ReleaseInfo(runtimes=['go1.11'])),
         ]),
     'java':
     OrderedDict([


### PR DESCRIPTION
v1.23.0 seems to have missed out since the
[PR](https://github.com/grpc/grpc/pull/19928) to add that had a merge
conflict and was never merged.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@karthikravis
