### PR TITLE
C# docs: add a note about grpc-dotnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Libraries in different languages may be in various states of development. We are
 | Ruby                    | [src/ruby](src/ruby)                |
 | Python                  | [src/python](src/python)            |
 | PHP                     | [src/php](src/php)                  |
-| C#                      | [src/csharp](src/csharp)            |
+| C# (core library based) | [src/csharp](src/csharp)            |
 | Objective-C             | [src/objective-c](src/objective-c)  |
 
 | Language                | Source repo                                          |
@@ -82,4 +82,4 @@ Libraries in different languages may be in various states of development. We are
 | NodeJS                  | [grpc-node](https://github.com/grpc/grpc-node)       |
 | WebJS                   | [grpc-web](https://github.com/grpc/grpc-web)         |
 | Dart                    | [grpc-dart](https://github.com/grpc/grpc-dart)       |
-
+| .NET (pure C# impl.)    | [grpc-dotnet](https://github.com/grpc/grpc-dotnet)   |

--- a/src/csharp/README.md
+++ b/src/csharp/README.md
@@ -2,7 +2,18 @@
 gRPC C#
 =======
 
-A C# implementation of gRPC.
+A C# implementation of gRPC based on the native gRPC Core library.
+
+There are currently two official implementations of gRPC for C#
+
+- The original gRPC C# implementation based on the native gRPC Core library (the source code lives in this directory)
+- The new "gRPC for .NET" implementation written in pure C# and based on the newly released .NET Core 3 (source code available at https://github.com/grpc/grpc-dotnet)
+
+The implementations are meant to coexist side-by-side and each has its own advantages in terms of available features, integrations, supported platforms, maturity level and performance.
+They share the same API for invoking and handling RPCs, thus limiting the lock-in and enabling users to choose the implementation that satisfies their needs the best
+(and perhaps adjust their choice over time without needing to do too much refactoring).
+
+The following documentation is for the original gRPC C# implementation only (the `Grpc.Core` nuget package).
 
 SUPPORTED PLATFORMS
 ------------------


### PR DESCRIPTION
Mention grpc-dotnet and the relationship between src/csharp and grpc-dotnet