### PR TITLE
Remove -DGTM_USING_XCTEST

### DIFF
--- a/third_party/objective_c/google_toolbox_for_mac/BUILD
+++ b/third_party/objective_c/google_toolbox_for_mac/BUILD
@@ -21,9 +21,6 @@ native.objc_library(
     srcs = [
         "UnitTesting/GTMGoogleTestRunner.mm",
     ],
-    copts = [
-        "-DGTM_USING_XCTEST",
-    ],
     deps = [
         "//external:gtest",
     ],


### PR DESCRIPTION
It is not longer being used in GTMGoogleTestRunner, so no need to define it.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@karthikravis
