### PR TITLE
Use bazel 0.29.1 for RBE windows

### DIFF
--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -14,8 +14,7 @@
 
 @rem TODO(jtattermusch): make this generate less output
 @rem TODO(jtattermusch): use tools/bazel script to keep the versions in sync
-@rem TODO(jtattermusch): https://github.com/bazelbuild/bazel/issues/9369 prevents upgrade to 0.29.1
-choco install bazel -y --version 0.29.0 --limit-output
+choco install bazel -y --version 0.29.1 --limit-output
 
 cd github/grpc
 set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%

--- a/tools/remote_build/README.md
+++ b/tools/remote_build/README.md
@@ -32,7 +32,7 @@ bazel --bazelrc=tools/remote_build/manual.bazelrc test --config=asan //test/...
 Run on Windows MSVC:
 ```
 # RBE manual run only for c-core (must be run on a Windows host machine)
-bazel --bazelrc=tools/remote_build/windows.bazelrc build :all [--google_credentials=(path to service account credentials)]
+bazel --bazelrc=tools/remote_build/windows.bazelrc build :all
 ```
 
 Available command line options can be found in

--- a/tools/remote_build/README.md
+++ b/tools/remote_build/README.md
@@ -32,7 +32,7 @@ bazel --bazelrc=tools/remote_build/manual.bazelrc test --config=asan //test/...
 Run on Windows MSVC:
 ```
 # RBE manual run only for c-core (must be run on a Windows host machine)
-bazel --bazelrc=tools/remote_build/windows.bazelrc build :all [--credentials_json=(path to service account credentials)]
+bazel --bazelrc=tools/remote_build/windows.bazelrc build :all [--google_credentials=(path to service account credentials)]
 ```
 
 Available command line options can be found in

--- a/tools/remote_build/manual.bazelrc
+++ b/tools/remote_build/manual.bazelrc
@@ -20,11 +20,10 @@ import %workspace%/tools/remote_build/rbe_common.bazelrc
 build --remote_cache=grpcs://remotebuildexecution.googleapis.com
 build --remote_executor=grpcs://remotebuildexecution.googleapis.com
 
-# Enable authentication. This will pick up application default credentials by
-# default. You can use --auth_credentials=some_file.json to use a service
-# account credential instead.
+# Enable authentication. Bazel will use application default credentials
+# unless overridden by --google_credentials=service_account_credentials.json
 # How to setup credentials:
-# See https://cloud.google.com/remote-build-execution/docs/getting-started#set_credentials
+# https://cloud.google.com/remote-build-execution/docs/results-ui/getting-started-results-ui
 build --auth_enabled=true
 
 # Set flags for uploading to BES in order to view results in the Bazel Build

--- a/tools/remote_build/windows.bazelrc
+++ b/tools/remote_build/windows.bazelrc
@@ -3,6 +3,8 @@ startup --host_jvm_args=-Dbazel.DigestFunction=SHA256
 build --remote_cache=grpcs://remotebuildexecution.googleapis.com
 build --remote_executor=grpcs://remotebuildexecution.googleapis.com
 
+build --auth_enabled=true
+
 build --host_crosstool_top=//third_party/toolchains/bazel_0.26.0_rbe_windows:toolchain
 build --crosstool_top=//third_party/toolchains/bazel_0.26.0_rbe_windows:toolchain
 build --extra_toolchains=//third_party/toolchains/bazel_0.26.0_rbe_windows:cc-toolchain-x64_windows


### PR DESCRIPTION
Looks like  https://github.com/bazelbuild/bazel/issues/9369 which was preventing the windows bazel 0.29.1 upgrade was a transient issue, now things are working fine.

Also upgrading the bazel RBE documentation so one can run bazel RBE tests on windows manually.

Verified that the same credential instructions can be used on both linux and windows, so simplifying the README.md further.