### PR TITLE
Start running windows bazel RBE tests

### DIFF
--- a/bazel/grpc_deps.bzl
+++ b/bazel/grpc_deps.bzl
@@ -174,13 +174,14 @@ def grpc_deps():
         )
 
     if "bazel_toolchains" not in native.existing_rules():
+        # list of releases is at https://releases.bazel.build/bazel-toolchains.html
         http_archive(
             name = "bazel_toolchains",
-            sha256 = "872955b658113924eb1a3594b04d43238da47f4f90c17b76e8785709490dc041",
-            strip_prefix = "bazel-toolchains-1083686fde6032378d52b4c98044922cebde364e",
+            sha256 = "22ca5b8115c8673ecb627a02b606529e813961e447933863fccdf325cc5f999f",
+            strip_prefix = "bazel-toolchains-0.29.5",
             urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/1083686fde6032378d52b4c98044922cebde364e.tar.gz",
-                "https://github.com/bazelbuild/bazel-toolchains/archive/1083686fde6032378d52b4c98044922cebde364e.tar.gz",
+                "https://github.com/bazelbuild/bazel-toolchains/releases/download/0.29.5/bazel-toolchains-0.29.5.tar.gz",
+                "https://mirror.bazel.build/github.com/bazelbuild/bazel-toolchains/archive/0.29.5.tar.gz",
             ],
         )
 

--- a/test/core/bad_ssl/generate_tests.bzl
+++ b/test/core/bad_ssl/generate_tests.bzl
@@ -46,4 +46,5 @@ def grpc_bad_ssl_tests():
         deps = ['//test/core/util:grpc_test_util',
                 '//:gpr',
                 '//test/core/end2end:cq_verifier'],
+        tags = ["no_windows"],
     )

--- a/test/core/client_channel/BUILD
+++ b/test/core/client_channel/BUILD
@@ -30,6 +30,7 @@ grpc_fuzzer(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_cc_test(

--- a/test/core/end2end/BUILD
+++ b/test/core/end2end/BUILD
@@ -117,6 +117,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_cc_test(

--- a/test/core/end2end/fuzzers/BUILD
+++ b/test/core/end2end/fuzzers/BUILD
@@ -33,6 +33,7 @@ grpc_fuzzer(
         "//test/core/end2end:ssl_test_data",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_fuzzer(
@@ -45,6 +46,7 @@ grpc_fuzzer(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_fuzzer(
@@ -57,4 +59,5 @@ grpc_fuzzer(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )

--- a/test/core/fling/BUILD
+++ b/test/core/fling/BUILD
@@ -59,7 +59,7 @@ grpc_cc_test(
         "//test/core/end2end:ssl_test_data",
         "//test/core/util:grpc_test_util",
     ],
-    tags = ["no_windows],
+    tags = ["no_windows"],
 )
 
 grpc_cc_test(
@@ -75,5 +75,5 @@ grpc_cc_test(
         "//test/core/end2end:ssl_test_data",
         "//test/core/util:grpc_test_util",
     ],
-    tags = ["no_windows],
+    tags = ["no_windows"],
 )

--- a/test/core/fling/BUILD
+++ b/test/core/fling/BUILD
@@ -59,6 +59,7 @@ grpc_cc_test(
         "//test/core/end2end:ssl_test_data",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows],
 )
 
 grpc_cc_test(
@@ -74,4 +75,5 @@ grpc_cc_test(
         "//test/core/end2end:ssl_test_data",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows],
 )

--- a/test/core/gprpp/BUILD
+++ b/test/core/gprpp/BUILD
@@ -125,6 +125,7 @@ grpc_cc_test(
     srcs = ["mpscq_test.cc"],
     exec_compatible_with = ["//third_party/toolchains/machine_size:large"],
     language = "C++",
+    tags = ["no_windows"],  # machine_size:large is not configured for windows RBE
     deps = [
         "//:gpr",
         "//test/core/util:grpc_test_util",

--- a/test/core/gprpp/BUILD
+++ b/test/core/gprpp/BUILD
@@ -22,6 +22,7 @@ grpc_cc_test(
     name = "fork_test",
     srcs = ["fork_test.cc"],
     language = "C++",
+    tags = ["no_windows"],
     deps = [
         "//:gpr",
         "//test/core/util:grpc_test_util",

--- a/test/core/gprpp/BUILD
+++ b/test/core/gprpp/BUILD
@@ -51,6 +51,7 @@ grpc_cc_test(
         "gtest",
     ],
     language = "C++",
+    tags = ["no_windows"],  # TODO(jtattermusch): fix the failure on windows
     deps = [
         "//:gpr",
         "//test/core/util:grpc_test_util",

--- a/test/core/handshake/BUILD
+++ b/test/core/handshake/BUILD
@@ -97,4 +97,5 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )

--- a/test/core/http/BUILD
+++ b/test/core/http/BUILD
@@ -80,6 +80,7 @@ grpc_cc_test(
         "//test/core/end2end:ssl_test_data",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_cc_test(
@@ -99,6 +100,7 @@ grpc_cc_test(
         "//test/core/end2end:ssl_test_data",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_cc_test(

--- a/test/core/http/BUILD
+++ b/test/core/http/BUILD
@@ -30,6 +30,7 @@ grpc_fuzzer(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_fuzzer(
@@ -42,6 +43,7 @@ grpc_fuzzer(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 # Copyright 2017 gRPC authors.

--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -41,6 +41,7 @@ grpc_cc_test(
     srcs = ["combiner_test.cc"],
     exec_compatible_with = ["//third_party/toolchains/machine_size:large"],
     language = "C++",
+    tags = ["no_windows"],  # machine_size:large is not configured for windows RBE
     deps = [
         "//:gpr",
         "//:grpc",

--- a/test/core/json/BUILD
+++ b/test/core/json/BUILD
@@ -30,6 +30,7 @@ grpc_fuzzer(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_cc_binary(

--- a/test/core/memory_usage/BUILD
+++ b/test/core/memory_usage/BUILD
@@ -49,6 +49,7 @@ grpc_cc_test(
         ":memory_usage_server",
     ],
     language = "C++",
+    tags = ["no_windows"],  # TODO(jtattermusch): breaks windows RBE build if enabled
     deps = [
         "//:gpr",
         "//:grpc",

--- a/test/core/nanopb/BUILD
+++ b/test/core/nanopb/BUILD
@@ -30,6 +30,7 @@ grpc_fuzzer(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_fuzzer(
@@ -42,4 +43,5 @@ grpc_fuzzer(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )

--- a/test/core/security/BUILD
+++ b/test/core/security/BUILD
@@ -30,6 +30,7 @@ grpc_fuzzer(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_fuzzer(
@@ -43,6 +44,7 @@ grpc_fuzzer(
         "//test/core/end2end:ssl_test_data",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_cc_library(

--- a/test/core/security/BUILD
+++ b/test/core/security/BUILD
@@ -177,6 +177,7 @@ grpc_cc_binary(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_binary(
@@ -201,6 +202,7 @@ grpc_cc_binary(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(

--- a/test/core/security/BUILD
+++ b/test/core/security/BUILD
@@ -177,7 +177,6 @@ grpc_cc_binary(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
-    uses_polling = False,
 )
 
 grpc_cc_binary(
@@ -202,7 +201,6 @@ grpc_cc_binary(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
-    uses_polling = False,
 )
 
 grpc_cc_test(

--- a/test/core/slice/BUILD
+++ b/test/core/slice/BUILD
@@ -30,6 +30,7 @@ grpc_fuzzer(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_fuzzer(
@@ -42,6 +43,7 @@ grpc_fuzzer(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_cc_test(

--- a/test/core/transport/BUILD
+++ b/test/core/transport/BUILD
@@ -25,6 +25,7 @@ grpc_cc_test(
         "gtest",
     ],
     language = "C++",
+    tags = ["no_windows"],  # TODO(jtattermusch): investigate the timeout on windows
     deps = [
         "//:gpr",
         "//:grpc",

--- a/test/core/transport/chttp2/BUILD
+++ b/test/core/transport/chttp2/BUILD
@@ -28,6 +28,7 @@ grpc_fuzzer(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_cc_test(

--- a/test/core/tsi/BUILD
+++ b/test/core/tsi/BUILD
@@ -85,6 +85,7 @@ grpc_cc_test(
         "//:tsi",
         "//test/core/util:grpc_test_util",
     ],
+    tags = ["no_windows"],
 )
 
 grpc_cc_test(

--- a/test/cpp/codegen/BUILD
+++ b/test/cpp/codegen/BUILD
@@ -71,7 +71,6 @@ grpc_cc_binary(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_config",
     ],
-    uses_polling = False,
 )
 
 genrule(

--- a/test/cpp/codegen/BUILD
+++ b/test/cpp/codegen/BUILD
@@ -71,6 +71,7 @@ grpc_cc_binary(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_config",
     ],
+    uses_polling = False,
 )
 
 genrule(

--- a/test/cpp/common/BUILD
+++ b/test/cpp/common/BUILD
@@ -24,6 +24,7 @@ grpc_cc_test(
     external_deps = [
         "gtest",
     ],
+    tags = ["no_windows"],  # TODO(jtattermusch): fix test on windows RBE
     deps = [
         "//:grpc++_unsecure",
         "//test/core/util:grpc_test_util_unsecure",

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -122,7 +122,7 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    tags = ["no_test_ios"],
+    tags = ["no_test_ios", "no_windows"],
 )
 
 grpc_cc_binary(
@@ -567,7 +567,7 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
-    tags = ["no_test_ios"],
+    tags = ["no_test_ios", "no_windows"],
 )
 
 grpc_cc_binary(

--- a/test/cpp/end2end/BUILD
+++ b/test/cpp/end2end/BUILD
@@ -442,6 +442,7 @@ grpc_cc_test(
         "//test/core/util:test_lb_policies",
         "//test/cpp/util:test_util",
     ],
+    tags = ["no_windows"],  # TODO(jtattermusch): fix test on windows
 )
 
 grpc_cc_test(
@@ -482,6 +483,7 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
+    tags = ["no_windows"],  # TODO(jtattermusch): fix test on windows
 )
 
 grpc_cc_test(
@@ -505,6 +507,7 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
+    tags = ["no_windows"],  # TODO(jtattermusch): fix test on windows
 )
 
 grpc_cc_test(
@@ -621,7 +624,7 @@ grpc_cc_test(
         "//src/proto/grpc/testing:echo_proto",
         "//test/cpp/util:test_util",
     ],
-    tags = ["no_test_ios"],
+    tags = ["no_test_ios", "no_windows"],
 )
 
 grpc_cc_test(
@@ -687,6 +690,7 @@ grpc_cc_test(
     external_deps = [
         "gtest",
     ],
+    tags = ["no_windows"],  # TODO(jtattermusch): fix test on windows
     deps = [
         "//:gpr",
         "//:grpc",

--- a/test/cpp/ext/filters/census/BUILD
+++ b/test/cpp/ext/filters/census/BUILD
@@ -37,4 +37,5 @@ grpc_cc_test(
         "//test/cpp/util:test_config",
         "//test/cpp/util:test_util",
     ],
+    tags = ["no_windows"],  # TODO(jtattermusch): fix test on windows
 )

--- a/test/cpp/interop/BUILD
+++ b/test/cpp/interop/BUILD
@@ -44,6 +44,7 @@ grpc_cc_binary(
         "grpclb_fallback_test.cc",
     ],
     language = "C++",
+    tags = ["no_windows"],
     deps = [
         "//src/proto/grpc/testing:empty_proto",
         "//src/proto/grpc/testing:messages_proto",

--- a/test/cpp/qps/BUILD
+++ b/test/cpp/qps/BUILD
@@ -170,6 +170,7 @@ grpc_cc_test(
     name = "qps_openloop_test",
     srcs = ["qps_openloop_test.cc"],
     exec_compatible_with = ["//third_party/toolchains/machine_size:large"],
+    tags = ["no_windows"],  # machine_size:large is not configured for windows RBE
     deps = [
         ":benchmark_config",
         ":driver_impl",

--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -188,7 +188,8 @@ grpc_cc_test(
         "gtest",
     ],
     tags = ["nomsan",  # death tests seem to be incompatible with msan
-            "no_test_ios"
+            "no_test_ios",
+            "no_windows",
     ],
     deps = [
         ":grpc_cli_libs",

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -24,7 +24,7 @@ powershell -Command "[guid]::NewGuid().ToString()" >%KOKORO_ARTIFACTS_DIR%/bazel
 set /p BAZEL_INVOCATION_ID=<%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
 
 @rem TODO(jtattermusch): windows RBE should be able to use the same credentials as Linux RBE.
-bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json //test/core/gpr:log_test
+bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json //test/core/...
 set BAZEL_EXITCODE=%errorlevel%
 
 @rem TODO(jtattermusch): upload results to bigquery

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -24,7 +24,7 @@ powershell -Command "[guid]::NewGuid().ToString()" >%KOKORO_ARTIFACTS_DIR%/bazel
 set /p BAZEL_INVOCATION_ID=<%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
 
 @rem TODO(jtattermusch): windows RBE should be able to use the same credentials as Linux RBE.
-bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json //test/core/...
+bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json //test/...
 set BAZEL_EXITCODE=%errorlevel%
 
 @rem TODO(jtattermusch): upload results to bigquery

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -24,7 +24,7 @@ powershell -Command "[guid]::NewGuid().ToString()" >%KOKORO_ARTIFACTS_DIR%/bazel
 set /p BAZEL_INVOCATION_ID=<%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
 
 @rem TODO(jtattermusch): windows RBE should be able to use the same credentials as Linux RBE.
-bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json //test/...
+bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json //test/core/gpr:log_test
 set BAZEL_EXITCODE=%errorlevel%
 
 @rem TODO(jtattermusch): upload results to bigquery

--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -24,7 +24,7 @@ powershell -Command "[guid]::NewGuid().ToString()" >%KOKORO_ARTIFACTS_DIR%/bazel
 set /p BAZEL_INVOCATION_ID=<%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
 
 @rem TODO(jtattermusch): windows RBE should be able to use the same credentials as Linux RBE.
-bazel --bazelrc=tools/remote_build/windows.bazelrc build --invocation_id="%BAZEL_INVOCATION_ID%" --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh :all --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json
+bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json //test/...
 set BAZEL_EXITCODE=%errorlevel%
 
 @rem TODO(jtattermusch): upload results to bigquery

--- a/tools/remote_build/README.md
+++ b/tools/remote_build/README.md
@@ -31,8 +31,8 @@ bazel --bazelrc=tools/remote_build/manual.bazelrc test --config=asan //test/...
 
 Run on Windows MSVC:
 ```
-# RBE manual run only for c-core (must be run on a Windows host machine)
-bazel --bazelrc=tools/remote_build/windows.bazelrc build :all
+# manual run of bazel tests remotely on RBE Windows (must be run from Windows machine)
+bazel --bazelrc=tools/remote_build/windows.bazelrc test //test/...
 ```
 
 Available command line options can be found in

--- a/tools/remote_build/rbe_common.bazelrc
+++ b/tools/remote_build/rbe_common.bazelrc
@@ -44,6 +44,11 @@ build --define GRPC_PORT_ISOLATED_RUNTIME=1
 # without verbose gRPC logs the test outputs are not very useful
 test --test_env=GRPC_VERBOSITY=debug
 
+# we assume the default bazel RBE build is on linux,
+# so filter out stuff that should not be built or run there.
+build --test_tag_filters=-no_linux
+build --build_tag_filters=-no_linux
+
 # Default test timeouts for all RBE tests (sanitizers override these values)
 # TODO(jtattermusch): revisit the non-standard test timeout values
 build --test_timeout=300,450,1200,3600
@@ -53,7 +58,7 @@ build --test_timeout=300,450,1200,3600
 build:asan --copt=-gmlt
 # TODO(jtattermusch): use more reasonable test timeout
 build:asan --test_timeout=3600
-build:asan --test_tag_filters=-qps_json_driver
+build:asan --test_tag_filters=-no_linux,-qps_json_driver
 
 # memory sanitizer: most settings are already in %workspace%/.bazelrc
 # we only need a few additional ones that are Foundry specific
@@ -61,7 +66,7 @@ build:msan --copt=-gmlt
 # TODO(jtattermusch): use more reasonable test timeout
 build:msan --test_timeout=3600
 # TODO(jtattermusch): revisit the disabled tests
-build:msan --test_tag_filters=-nomsan,-json_run_localhost
+build:msan --test_tag_filters=-no_linux,-nomsan,-json_run_localhost
 build:msan --cxxopt=--stdlib=libc++
 # setting LD_LIBRARY_PATH is necessary
 # to avoid "libc++.so.1: cannot open shared object file"
@@ -75,7 +80,7 @@ build:msan --crosstool_top=@rbe_msan//cc:toolchain
 build:tsan --copt=-gmlt
 # TODO(jtattermusch): use more reasonable test timeout
 build:tsan --test_timeout=3600
-build:tsan --test_tag_filters=-qps_json_driver
+build:tsan --test_tag_filters=-no_linux,-qps_json_driver
 build:tsan --extra_execution_platforms=//third_party/toolchains:rbe_ubuntu1604,//third_party/toolchains:rbe_ubuntu1604_large
 
 # undefined behavior sanitizer: most settings are already in %workspace%/.bazelrc

--- a/tools/remote_build/windows.bazelrc
+++ b/tools/remote_build/windows.bazelrc
@@ -34,6 +34,9 @@ build --define GRPC_PORT_ISOLATED_RUNTIME=1
 build --test_tag_filters=-no_windows
 build --build_tag_filters=-no_windows
 
+# required for the tests to pass on Windows RBE
+build --incompatible_windows_native_test_wrapper
+
 # without verbose gRPC logs the test outputs are not very useful
 test --test_env=GRPC_VERBOSITY=debug
 


### PR DESCRIPTION
Make sure Windows bazel RBE tests are buildable and make them run.

- switch the windows RBE build to actually building and running windows tests, make a few adjustments to grpc_build_system.bzl to make that possible
- adjust end2end tests' generate_tests.bzl to allow generating test cases on other platforms than just linux.
- apply "no_windows" label to tests that aren't runnable/buildable on windows (info taken from build.yaml metadata)
- apply "no_windows" to a few tests that are currently failing on bazel RBE  and add a TODO that they should be fixed eventually (the failures didn't seem very serious and some of the tests we've never run on windows before, so it's understandable if they fail - fixing all of them is out of scope of this PR).

Because of https://github.com/bazelbuild/bazel/issues/3780, there is no ideal way of preventing non-windows tests from being run on windows automatically, so the "no_linux", "no_mac" and "no_windows" are currently the best we can do.
I tried to modify things in a way that if no extra bazel args are used on linux, things still work as expected - this is maintain good developer experience on linux (majority of our devs are on linux).

What's missing:
- we currently don't run qps_json_localhost tests on windows. That's not a regression as we currently don't run any C++ test by cmake at all.
- compare the tests being run by cmake on windows vs tests run by bazel to make sure we are getting the same (or better signal) with bazel.