### PR TITLE
Add three more channel option constants for .NET

### DIFF
--- a/src/csharp/Grpc.Core/ChannelOptions.cs
+++ b/src/csharp/Grpc.Core/ChannelOptions.cs
@@ -197,6 +197,18 @@ namespace Grpc.Core
         [Obsolete("Use MaxReceiveMessageLength instead.")]
         public const string MaxMessageLength = MaxReceiveMessageLength;
 
+        /// <summary>Maximum time that a channel may exist in milliseconds.
+        /// <see cref="int.MaxValue"/> means unlimited.</summary>
+        public const string MaxConnectionAgeMs = "grpc.max_connection_age_ms";
+
+        /// <summary>Grace period after the channel reaches its max age in milliseconds.
+        /// <see cref="int.MaxValue"/> means unlimited.</summary>
+        public const string MaxConnectionAgeGraceMs = "grpc.max_connection_age_grace_ms";
+
+        /// <summary>Maximum time that a channel may have no outstanding rpcs, after which the server
+        /// will close the connection. <see cref="int.MaxValue"/> means unlimited.</summary>
+        public const string MaxConnectionIdleMs = "grpc.max_connection_idle_ms";
+
         /// <summary>Initial sequence number for http2 transports</summary>
         public const string Http2InitialSequenceNumber = "grpc.http2.initial_sequence_number";
 


### PR DESCRIPTION
This PR adds three more channel option string constants to the `ChannelOptions` class for .NET.  These channel options are defined [here](https://github.com/grpc/grpc/blob/master/include/grpc/impl/codegen/grpc_types.h#L160-L169), and I attempted to adapt the descriptions there to match the style of the existing C# comments: 

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@karthikravis

Namely has an organizational CLA for this project, and I believe I'm covered under it.  I hope this PR is useful.  Thank you.