### PR TITLE
Refactor hpack encoder to be smaller footprint.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_encoder.cc
@@ -42,6 +42,12 @@
 #include "src/core/lib/transport/static_metadata.h"
 #include "src/core/lib/transport/timeout_encoding.h"
 
+/* don't consider adding anything bigger than this to the hpack table */
+#define MAX_DECODER_SPACE_USAGE 512
+#define DATA_FRAME_HEADER_SIZE 9
+
+namespace { /* (Maybe-cuckoo) hpack encoder hash table implementation. */
+#define GRPC_HPACK_ENCODER_USE_CUCKOO_HASH 1
 #define HASH_FRAGMENT_MASK (GRPC_CHTTP2_HPACKC_NUM_VALUES - 1)
 #define HASH_FRAGMENT_1(x) ((x)&HASH_FRAGMENT_MASK)
 #define HASH_FRAGMENT_2(x) \
@@ -54,17 +60,170 @@
 /* if the probability of this item being seen again is < 1/x then don't add
    it to the table */
 #define ONE_ON_ADD_PROBABILITY (GRPC_CHTTP2_HPACKC_NUM_VALUES >> 1)
-/* don't consider adding anything bigger than this to the hpack table */
-#define MAX_DECODER_SPACE_USAGE 512
+/* Meaningful to encoder and parser on remote end. */
+typedef uint32_t HpackEncoderIndex;
+/* Internal-table bookkeeping (*not* the hpack index). */
+typedef uint32_t HpackEncoderSlotHash;
 
-#define DATA_FRAME_HEADER_SIZE 9
-
-static grpc_slice_refcount terminal_slice_refcount(
-    grpc_slice_refcount::Type::STATIC);
-static const grpc_slice terminal_slice = {
-    &terminal_slice_refcount, /* refcount */
-    {{0, nullptr}}            /* data.refcounted */
+struct SliceRefComparator {
+  typedef grpc_slice_refcount* Type;
+  static grpc_slice_refcount* Null() { return nullptr; }
+  static bool Equals(grpc_slice_refcount* s1, grpc_slice_refcount* s2) {
+    return s1 == s2;
+  }
+  static void Ref(grpc_slice_refcount* sref) { sref->Ref(); }
+  static void Unref(grpc_slice_refcount* sref) { sref->Unref(); }
 };
+
+struct MetadataComparator {
+  typedef grpc_mdelem Type;
+  static const grpc_mdelem Null() { return {0}; }
+  static bool Equals(const grpc_mdelem md1, const grpc_mdelem md2) {
+    return md1.payload == md2.payload;
+  }
+  static void Ref(grpc_mdelem md) { GRPC_MDELEM_REF(md); }
+  static void Unref(grpc_mdelem md) { GRPC_MDELEM_UNREF(md); }
+};
+
+/* Index table management */
+template <typename H>
+static HpackEncoderIndex HpackIndex(const H* hashtable,
+                                    HpackEncoderSlotHash hash_index) {
+  return hashtable[hash_index].index;
+}
+
+template <typename R, typename H>
+static const R& GetEntry(const H* hashtable, HpackEncoderSlotHash hash_index) {
+  return hashtable[hash_index].value;
+}
+
+template <typename Cmp, typename H>
+static bool TableEmptyAt(const H* hashtable, HpackEncoderSlotHash hash_index) {
+  return Cmp::Equals(hashtable[hash_index].value, Cmp::Null());
+}
+
+template <typename Cmp, typename H, typename T>
+static bool Matches(const H* hashtable, const T& value,
+                    HpackEncoderSlotHash hash_index) {
+  return Cmp::Equals(value, hashtable[hash_index].value);
+}
+
+template <typename H>
+static void UpdateIndex(H* hashtable, HpackEncoderSlotHash hash_index,
+                        HpackEncoderIndex hpack_index) {
+  hashtable[hash_index].index = hpack_index;
+}
+
+template <typename H, typename T>
+static void SetIndex(H* hashtable, HpackEncoderSlotHash hash_index,
+                     const T& value, HpackEncoderIndex hpack_index) {
+  hashtable[hash_index].value = value;
+  UpdateIndex(hashtable, hash_index, hpack_index);
+}
+
+template <typename Cmp, typename H, typename T>
+static bool GetMatchingIndex(H* hashtable, const T& value, uint32_t value_hash,
+                             HpackEncoderIndex* index) {
+  const HpackEncoderSlotHash cuckoo_first = HASH_FRAGMENT_2(value_hash);
+  if (Matches<Cmp>(hashtable, value, cuckoo_first)) {
+    *index = HpackIndex(hashtable, cuckoo_first);
+    return true;
+  }
+#if GRPC_HPACK_ENCODER_USE_CUCKOO_HASH
+  const HpackEncoderSlotHash cuckoo_second = HASH_FRAGMENT_3(value_hash);
+
+  if (Matches<Cmp>(hashtable, value, cuckoo_second)) {
+    *index = HpackIndex(hashtable, cuckoo_second);
+    return true;
+  }
+#endif
+  return false;
+}
+
+template <typename Cmp, typename H, typename T>
+static T ReplaceOlderIndex(H* hashtable, const T& value,
+                           HpackEncoderSlotHash hash_index_a,
+                           HpackEncoderSlotHash hash_index_b,
+                           HpackEncoderIndex new_index) {
+  const uint32_t hpack_idx_a = hashtable[hash_index_a].index;
+  const uint32_t hpack_idx_b = hashtable[hash_index_b].index;
+  if (hpack_idx_a < hpack_idx_b) {
+    T old = GetEntry<typename Cmp::Type>(hashtable, hash_index_a);
+    SetIndex(hashtable, hash_index_a, value, new_index);
+    return old;
+  } else {
+    T old = GetEntry<typename Cmp::Type>(hashtable, hash_index_b);
+    SetIndex(hashtable, hash_index_b, value, new_index);
+    return old;
+  }
+}
+
+template <typename Cmp, typename H, typename T>
+static void UpdateAddOrEvict(H* hashtable, const T& value, uint32_t value_hash,
+                             HpackEncoderIndex new_index) {
+  const HpackEncoderSlotHash cuckoo_first = HASH_FRAGMENT_2(value_hash);
+  if (Matches<Cmp>(hashtable, value, cuckoo_first)) {
+    UpdateIndex(hashtable, cuckoo_first, new_index);
+    return;
+  }
+  if (TableEmptyAt<Cmp>(hashtable, cuckoo_first)) {
+    Cmp::Ref(value);
+    SetIndex(hashtable, cuckoo_first, value, new_index);
+    return;
+  }
+#if GRPC_HPACK_ENCODER_USE_CUCKOO_HASH
+  const HpackEncoderSlotHash cuckoo_second = HASH_FRAGMENT_3(value_hash);
+  if (Matches<Cmp>(hashtable, value, cuckoo_second)) {
+    UpdateIndex(hashtable, cuckoo_second, new_index);
+    return;
+  }
+  Cmp::Ref(value);
+  if (TableEmptyAt<Cmp>(hashtable, cuckoo_second)) {
+    SetIndex(hashtable, cuckoo_second, value, new_index);
+    return;
+  }
+  Cmp::Unref(ReplaceOlderIndex<Cmp>(hashtable, value, cuckoo_first,
+                                    cuckoo_second, new_index));
+#else
+  T old = GetEntry<typename Cmp::Type>(hashtable, cuckoo_first);
+  SetIndex(hashtable, cuckoo_first, value, new_index);
+  Cmp::Unref(old);
+#endif
+}
+
+/* increment a filter count, halve all counts if one element reaches max */
+static void HalveFilter(uint8_t idx, uint32_t* sum, uint8_t* elems) {
+  *sum = 0;
+  for (int i = 0; i < GRPC_CHTTP2_HPACKC_NUM_VALUES; i++) {
+    elems[i] /= 2;
+    (*sum) += elems[i];
+  }
+}
+
+/* increment a filter count, halve all counts if one element reaches max */
+static void IncFilter(uint8_t idx, uint32_t* sum, uint8_t* elems) {
+  elems[idx]++;
+  if (GPR_LIKELY(elems[idx] < 255)) {
+    (*sum)++;
+  } else {
+    HalveFilter(idx, sum, elems);
+  }
+}
+
+static uint32_t UpdateHashtablePopularity(grpc_chttp2_hpack_compressor* c,
+                                          uint32_t elem_hash) {
+  const uint32_t popularity_hash = HASH_FRAGMENT_1(elem_hash);
+  IncFilter(popularity_hash, &c->filter_elems_sum, c->filter_elems);
+  return popularity_hash;
+}
+
+static bool CanAddToHashtable(grpc_chttp2_hpack_compressor* c,
+                              uint32_t popularity_hash) {
+  const bool can_add = c->filter_elems[popularity_hash] >=
+                       c->filter_elems_sum / ONE_ON_ADD_PROBABILITY;
+  return can_add;
+}
+} /* namespace */
 
 typedef struct {
   int is_first_frame;
@@ -73,8 +232,10 @@ typedef struct {
   size_t output_length_at_start_of_frame;
   /* index (in output) of the header for the current frame */
   size_t header_idx;
+#ifndef NDEBUG
   /* have we seen a regular (non-colon-prefixed) header yet? */
   uint8_t seen_regular_header;
+#endif
   /* output stream id */
   uint32_t stream_id;
   grpc_slice_buffer* output;
@@ -156,21 +317,6 @@ static void ensure_space(framer_state* st, size_t need_bytes) {
   begin_frame(st);
 }
 
-/* increment a filter count, halve all counts if one element reaches max */
-static void inc_filter(uint8_t idx, uint32_t* sum, uint8_t* elems) {
-  elems[idx]++;
-  if (elems[idx] < 255) {
-    (*sum)++;
-  } else {
-    int i;
-    *sum = 0;
-    for (i = 0; i < GRPC_CHTTP2_HPACKC_NUM_VALUES; i++) {
-      elems[i] /= 2;
-      (*sum) += elems[i];
-    }
-  }
-}
-
 static void add_header_data(framer_state* st, grpc_slice slice) {
   size_t len = GRPC_SLICE_LENGTH(slice);
   size_t remaining;
@@ -199,7 +345,7 @@ static void evict_entry(grpc_chttp2_hpack_compressor* c) {
   GPR_ASSERT(c->tail_remote_index > 0);
   GPR_ASSERT(c->table_size >=
              c->table_elem_size[c->tail_remote_index % c->cap_table_elems]);
-  GPR_ASSERT(c->table_elems > 0);
+  GPR_DEBUG_ASSERT(c->table_elems > 0);
   c->table_size = static_cast<uint16_t>(
       c->table_size -
       c->table_elem_size[c->tail_remote_index % c->cap_table_elems]);
@@ -228,8 +374,7 @@ static uint32_t prepare_space_for_new_elem(grpc_chttp2_hpack_compressor* c,
   while (c->table_size + elem_size > c->max_table_size) {
     evict_entry(c);
   }
-  // TODO(arjunroy): Are we conflating size in bytes vs. membership?
-  GPR_ASSERT(c->table_elems < c->max_table_size);
+  GPR_DEBUG_ASSERT(c->table_elems < c->max_table_size);
   c->table_elem_size[new_index % c->cap_table_elems] =
       static_cast<uint16_t>(elem_size);
   c->table_size = static_cast<uint16_t>(c->table_size + elem_size);
@@ -240,103 +385,48 @@ static uint32_t prepare_space_for_new_elem(grpc_chttp2_hpack_compressor* c,
 
 // Add a key to the dynamic table. Both key and value will be added to table at
 // the decoder.
-static void add_key_with_index(grpc_chttp2_hpack_compressor* c,
-                               grpc_mdelem elem, uint32_t new_index,
-                               uint32_t key_hash) {
-  if (new_index == 0) {
-    return;
-  }
-
-  /* Store the key into {entries,indices}_keys */
-  if (grpc_slice_static_interned_equal(
-          c->entries_keys[HASH_FRAGMENT_2(key_hash)], GRPC_MDKEY(elem))) {
-    c->indices_keys[HASH_FRAGMENT_2(key_hash)] = new_index;
-  } else if (grpc_slice_static_interned_equal(
-                 c->entries_keys[HASH_FRAGMENT_3(key_hash)],
-                 GRPC_MDKEY(elem))) {
-    c->indices_keys[HASH_FRAGMENT_3(key_hash)] = new_index;
-  } else if (c->entries_keys[HASH_FRAGMENT_2(key_hash)].refcount ==
-             &terminal_slice_refcount) {
-    c->entries_keys[HASH_FRAGMENT_2(key_hash)] =
-        grpc_slice_ref_internal(GRPC_MDKEY(elem));
-    c->indices_keys[HASH_FRAGMENT_2(key_hash)] = new_index;
-  } else if (c->entries_keys[HASH_FRAGMENT_3(key_hash)].refcount ==
-             &terminal_slice_refcount) {
-    c->entries_keys[HASH_FRAGMENT_3(key_hash)] =
-        grpc_slice_ref_internal(GRPC_MDKEY(elem));
-    c->indices_keys[HASH_FRAGMENT_3(key_hash)] = new_index;
-  } else if (c->indices_keys[HASH_FRAGMENT_2(key_hash)] <
-             c->indices_keys[HASH_FRAGMENT_3(key_hash)]) {
-    grpc_slice_unref_internal(c->entries_keys[HASH_FRAGMENT_2(key_hash)]);
-    c->entries_keys[HASH_FRAGMENT_2(key_hash)] =
-        grpc_slice_ref_internal(GRPC_MDKEY(elem));
-    c->indices_keys[HASH_FRAGMENT_2(key_hash)] = new_index;
-  } else {
-    grpc_slice_unref_internal(c->entries_keys[HASH_FRAGMENT_3(key_hash)]);
-    c->entries_keys[HASH_FRAGMENT_3(key_hash)] =
-        grpc_slice_ref_internal(GRPC_MDKEY(elem));
-    c->indices_keys[HASH_FRAGMENT_3(key_hash)] = new_index;
-  }
+static void AddKeyWithIndex(grpc_chttp2_hpack_compressor* c,
+                            grpc_slice_refcount* key_ref, uint32_t new_index,
+                            uint32_t key_hash) {
+  UpdateAddOrEvict<SliceRefComparator>(c->key_table.entries_, key_ref, key_hash,
+                                       new_index);
 }
 
 /* add an element to the decoder table */
-static void add_elem_with_index(grpc_chttp2_hpack_compressor* c,
-                                grpc_mdelem elem, uint32_t new_index,
-                                uint32_t elem_hash, uint32_t key_hash) {
-  if (new_index == 0) {
-    return;
-  }
+static void AddElemWithIndex(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
+                             uint32_t new_index, uint32_t elem_hash,
+                             uint32_t key_hash) {
   GPR_DEBUG_ASSERT(GRPC_MDELEM_IS_INTERNED(elem));
-
-  /* Store this element into {entries,indices}_elem */
-  if (grpc_mdelem_both_interned_eq(c->entries_elems[HASH_FRAGMENT_2(elem_hash)],
-                                   elem)) {
-    /* already there: update with new index */
-    c->indices_elems[HASH_FRAGMENT_2(elem_hash)] = new_index;
-  } else if (grpc_mdelem_both_interned_eq(
-                 c->entries_elems[HASH_FRAGMENT_3(elem_hash)], elem)) {
-    /* already there (cuckoo): update with new index */
-    c->indices_elems[HASH_FRAGMENT_3(elem_hash)] = new_index;
-  } else if (GRPC_MDISNULL(c->entries_elems[HASH_FRAGMENT_2(elem_hash)])) {
-    /* not there, but a free element: add */
-    c->entries_elems[HASH_FRAGMENT_2(elem_hash)] = GRPC_MDELEM_REF(elem);
-    c->indices_elems[HASH_FRAGMENT_2(elem_hash)] = new_index;
-  } else if (GRPC_MDISNULL(c->entries_elems[HASH_FRAGMENT_3(elem_hash)])) {
-    /* not there (cuckoo), but a free element: add */
-    c->entries_elems[HASH_FRAGMENT_3(elem_hash)] = GRPC_MDELEM_REF(elem);
-    c->indices_elems[HASH_FRAGMENT_3(elem_hash)] = new_index;
-  } else if (c->indices_elems[HASH_FRAGMENT_2(elem_hash)] <
-             c->indices_elems[HASH_FRAGMENT_3(elem_hash)]) {
-    /* not there: replace oldest */
-    GRPC_MDELEM_UNREF(c->entries_elems[HASH_FRAGMENT_2(elem_hash)]);
-    c->entries_elems[HASH_FRAGMENT_2(elem_hash)] = GRPC_MDELEM_REF(elem);
-    c->indices_elems[HASH_FRAGMENT_2(elem_hash)] = new_index;
-  } else {
-    /* not there: replace oldest */
-    GRPC_MDELEM_UNREF(c->entries_elems[HASH_FRAGMENT_3(elem_hash)]);
-    c->entries_elems[HASH_FRAGMENT_3(elem_hash)] = GRPC_MDELEM_REF(elem);
-    c->indices_elems[HASH_FRAGMENT_3(elem_hash)] = new_index;
-  }
-
-  add_key_with_index(c, elem, new_index, key_hash);
+  UpdateAddOrEvict<MetadataComparator>(c->elem_table.entries_, elem, elem_hash,
+                                       new_index);
+  AddKeyWithIndex(c, GRPC_MDKEY(elem).refcount, new_index, key_hash);
 }
 
 static void add_elem(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
                      size_t elem_size, uint32_t elem_hash, uint32_t key_hash) {
   uint32_t new_index = prepare_space_for_new_elem(c, elem_size);
-  add_elem_with_index(c, elem, new_index, elem_hash, key_hash);
+  if (new_index != 0) {
+    AddElemWithIndex(c, elem, new_index, elem_hash, key_hash);
+  }
 }
 
 static void add_key(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
                     size_t elem_size, uint32_t key_hash) {
   uint32_t new_index = prepare_space_for_new_elem(c, elem_size);
-  add_key_with_index(c, elem, new_index, key_hash);
+  if (new_index != 0) {
+    AddKeyWithIndex(c, GRPC_MDKEY(elem).refcount, new_index, key_hash);
+  }
 }
 
+template <bool static_entry>
 static void emit_indexed(grpc_chttp2_hpack_compressor* c, uint32_t elem_index,
                          framer_state* st) {
   GRPC_STATS_INC_HPACK_SEND_INDEXED();
-  uint32_t len = GRPC_CHTTP2_VARINT_LENGTH(elem_index, 1);
+  const uint32_t len =
+      static_entry ? 1 : GRPC_CHTTP2_VARINT_LENGTH(elem_index, 1);
+  if (static_entry) {
+    GPR_DEBUG_ASSERT(len == GRPC_CHTTP2_VARINT_LENGTH(elem_index, 1));
+  }
   GRPC_CHTTP2_WRITE_VARINT(elem_index, 1, 0x80, add_tiny_header_data(st, len),
                            len);
 }
@@ -429,7 +519,7 @@ static void emit_lithdr(grpc_chttp2_hpack_compressor* c, uint32_t key_index,
   add_header_data(st, value.data);
 }
 
-template <EmitLitHdrVType type>
+template <EmitLitHdrVType type, bool key_definitely_refcounted>
 static void emit_lithdr_v(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
                           framer_state* st) {
   switch (type) {
@@ -441,8 +531,11 @@ static void emit_lithdr_v(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
       break;
   }
   GRPC_STATS_INC_HPACK_SEND_UNCOMPRESSED();
+  const grpc_slice& elem_key = GRPC_MDKEY(elem);
   const uint32_t len_key =
-      static_cast<uint32_t>(GRPC_SLICE_LENGTH(GRPC_MDKEY(elem)));
+      key_definitely_refcounted
+          ? static_cast<uint32_t>(elem_key.data.refcounted.length)
+          : static_cast<uint32_t>(GRPC_SLICE_LENGTH(GRPC_MDKEY(elem)));
   const wire_value value =
       type == EmitLitHdrVType::INC_IDX_V
           ? get_wire_value<true>(elem, st->use_true_binary_metadata)
@@ -455,7 +548,13 @@ static void emit_lithdr_v(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
   uint8_t* key_buf = add_tiny_header_data(st, 1 + len_key_len);
   key_buf[0] = type == EmitLitHdrVType::INC_IDX_V ? 0x40 : 0x00;
   GRPC_CHTTP2_WRITE_VARINT(len_key, 1, 0x00, &key_buf[1], len_key_len);
-  add_header_data(st, grpc_slice_ref_internal(GRPC_MDKEY(elem)));
+  if (key_definitely_refcounted) {
+    GPR_DEBUG_ASSERT(elem_key.refcount != nullptr);
+    elem_key.refcount->Ref();
+  } else {
+    grpc_slice_ref_internal(elem_key);
+  }
+  add_header_data(st, elem_key);
   uint8_t* value_buf = add_tiny_header_data(
       st, len_val_len + (value.insert_null_before_wire_value ? 1 : 0));
   GRPC_CHTTP2_WRITE_VARINT(len_val, 1, value.huffman_prefix, value_buf,
@@ -516,30 +615,20 @@ static EmitIndexedStatus maybe_emit_indexed(grpc_chttp2_hpack_compressor* c,
                 ->hash()
           : reinterpret_cast<grpc_core::StaticMetadata*>(GRPC_MDELEM_DATA(elem))
                 ->hash();
-
-  inc_filter(HASH_FRAGMENT_1(elem_hash), &c->filter_elems_sum, c->filter_elems);
-
+  /* Update filter to see if we can perhaps add this elem. */
+  const uint32_t popularity_hash = UpdateHashtablePopularity(c, elem_hash);
   /* is this elem currently in the decoders table? */
-  if (grpc_mdelem_both_interned_eq(c->entries_elems[HASH_FRAGMENT_2(elem_hash)],
-                                   elem) &&
-      c->indices_elems[HASH_FRAGMENT_2(elem_hash)] > c->tail_remote_index) {
-    /* HIT: complete element (first cuckoo hash) */
-    emit_indexed(c, dynidx(c, c->indices_elems[HASH_FRAGMENT_2(elem_hash)]),
-                 st);
-    return EmitIndexedStatus(elem_hash, true, false);
+  HpackEncoderIndex indices_key;
+  if (GetMatchingIndex<MetadataComparator>(c->elem_table.entries_, elem,
+                                           elem_hash, &indices_key)) {
+    if (indices_key > c->tail_remote_index) {
+      emit_indexed<false>(c, dynidx(c, indices_key), st);
+      return EmitIndexedStatus(elem_hash, true, false);
+    }
   }
-  if (grpc_mdelem_both_interned_eq(c->entries_elems[HASH_FRAGMENT_3(elem_hash)],
-                                   elem) &&
-      c->indices_elems[HASH_FRAGMENT_3(elem_hash)] > c->tail_remote_index) {
-    /* HIT: complete element (second cuckoo hash) */
-    emit_indexed(c, dynidx(c, c->indices_elems[HASH_FRAGMENT_3(elem_hash)]),
-                 st);
-    return EmitIndexedStatus(elem_hash, true, false);
-  }
-
-  const bool can_add = c->filter_elems[HASH_FRAGMENT_1(elem_hash)] >=
-                       c->filter_elems_sum / ONE_ON_ADD_PROBABILITY;
-  return EmitIndexedStatus(elem_hash, false, can_add);
+  /* Didn't hit either cuckoo index, so no emit. */
+  return EmitIndexedStatus(elem_hash, false,
+                           CanAddToHashtable(c, popularity_hash));
 }
 
 static void emit_maybe_add(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
@@ -557,14 +646,15 @@ static void emit_maybe_add(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
 /* encode an mdelem */
 static void hpack_enc(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
                       framer_state* st) {
+  const grpc_slice& elem_key = GRPC_MDKEY(elem);
   /* User-provided key len validated in grpc_validate_header_key_is_legal(). */
-  GPR_DEBUG_ASSERT(GRPC_SLICE_LENGTH(GRPC_MDKEY(elem)) > 0);
+  GPR_DEBUG_ASSERT(GRPC_SLICE_LENGTH(elem_key) > 0);
   /* Header ordering: all reserved headers (prefixed with ':') must precede
    * regular headers. This can be a debug assert, since:
    * 1) User cannot give us ':' headers (grpc_validate_header_key_is_legal()).
    * 2) grpc filters/core should be checked during debug builds. */
 #ifndef NDEBUG
-  if (GRPC_SLICE_START_PTR(GRPC_MDKEY(elem))[0] != ':') { /* regular header */
+  if (GRPC_SLICE_START_PTR(elem_key)[0] != ':') { /* regular header */
     st->seen_regular_header = 1;
   } else {
     GPR_DEBUG_ASSERT(
@@ -575,14 +665,11 @@ static void hpack_enc(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
   if (GRPC_TRACE_FLAG_ENABLED(grpc_http_trace)) {
     hpack_enc_log(elem);
   }
-
   const bool elem_interned = GRPC_MDELEM_IS_INTERNED(elem);
-  const bool key_interned =
-      elem_interned || grpc_slice_is_interned(GRPC_MDKEY(elem));
-
+  const bool key_interned = elem_interned || grpc_slice_is_interned(elem_key);
   /* Key is not interned, emit literals. */
   if (!key_interned) {
-    emit_lithdr_v<EmitLitHdrVType::NO_IDX_V>(c, elem, st);
+    emit_lithdr_v<EmitLitHdrVType::NO_IDX_V, false>(c, elem, st);
     return;
   }
   /* Interned metadata => maybe already indexed. */
@@ -591,7 +678,6 @@ static void hpack_enc(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
   if (ret.emitted) {
     return;
   }
-
   /* should this elem be in the table? */
   const size_t decoder_space_usage =
       grpc_chttp2_get_size_in_hpack_table(elem, st->use_true_binary_metadata);
@@ -600,35 +686,23 @@ static void hpack_enc(grpc_chttp2_hpack_compressor* c, grpc_mdelem elem,
   const bool should_add_elem =
       elem_interned && decoder_space_available && ret.can_add;
   const uint32_t elem_hash = ret.elem_hash;
-
   /* no hits for the elem... maybe there's a key? */
-  const uint32_t key_hash = GRPC_MDKEY(elem).refcount->Hash(GRPC_MDKEY(elem));
-  uint32_t indices_key = c->indices_keys[HASH_FRAGMENT_2(key_hash)];
-  if (grpc_slice_static_interned_equal(
-          c->entries_keys[HASH_FRAGMENT_2(key_hash)], GRPC_MDKEY(elem)) &&
-      indices_key > c->tail_remote_index) {
-    /* HIT: key (first cuckoo hash) */
-    emit_maybe_add(c, elem, st, indices_key, should_add_elem,
-                   decoder_space_usage, elem_hash, key_hash);
-    return;
+  const uint32_t key_hash = elem_key.refcount->Hash(elem_key);
+  HpackEncoderIndex indices_key;
+  if (GetMatchingIndex<SliceRefComparator>(
+          c->key_table.entries_, elem_key.refcount, key_hash, &indices_key)) {
+    if (indices_key > c->tail_remote_index) {
+      emit_maybe_add(c, elem, st, indices_key, should_add_elem,
+                     decoder_space_usage, elem_hash, key_hash);
+      return;
+    }
   }
-
-  indices_key = c->indices_keys[HASH_FRAGMENT_3(key_hash)];
-  if (grpc_slice_static_interned_equal(
-          c->entries_keys[HASH_FRAGMENT_3(key_hash)], GRPC_MDKEY(elem)) &&
-      indices_key > c->tail_remote_index) {
-    /* HIT: key (second cuckoo hash) */
-    emit_maybe_add(c, elem, st, indices_key, should_add_elem,
-                   decoder_space_usage, elem_hash, key_hash);
-    return;
-  }
-
   /* no elem, key in the table... fall back to literal emission */
   const bool should_add_key = !elem_interned && decoder_space_available;
   if (should_add_elem || should_add_key) {
-    emit_lithdr_v<EmitLitHdrVType::INC_IDX_V>(c, elem, st);
+    emit_lithdr_v<EmitLitHdrVType::INC_IDX_V, true>(c, elem, st);
   } else {
-    emit_lithdr_v<EmitLitHdrVType::NO_IDX_V>(c, elem, st);
+    emit_lithdr_v<EmitLitHdrVType::NO_IDX_V, true>(c, elem, st);
   }
   if (should_add_elem) {
     add_elem(c, elem, decoder_space_usage, elem_hash, key_hash);
@@ -660,22 +734,18 @@ void grpc_chttp2_hpack_compressor_init(grpc_chttp2_hpack_compressor* c) {
   c->cap_table_elems = elems_for_bytes(c->max_table_size);
   c->max_table_elems = c->cap_table_elems;
   c->max_usable_size = GRPC_CHTTP2_HPACKC_INITIAL_TABLE_SIZE;
-  c->table_elem_size = static_cast<uint16_t*>(
-      gpr_malloc(sizeof(*c->table_elem_size) * c->cap_table_elems));
-  memset(c->table_elem_size, 0,
-         sizeof(*c->table_elem_size) * c->cap_table_elems);
-  for (size_t i = 0; i < GPR_ARRAY_SIZE(c->entries_keys); i++) {
-    c->entries_keys[i] = terminal_slice;
-  }
+  const size_t alloc_sz = sizeof(*c->table_elem_size) * c->cap_table_elems;
+  c->table_elem_size = static_cast<uint16_t*>(gpr_malloc(alloc_sz));
+  memset(c->table_elem_size, 0, alloc_sz);
 }
 
 void grpc_chttp2_hpack_compressor_destroy(grpc_chttp2_hpack_compressor* c) {
-  int i;
-  for (i = 0; i < GRPC_CHTTP2_HPACKC_NUM_VALUES; i++) {
-    if (c->entries_keys[i].refcount != &terminal_slice_refcount) {
-      grpc_slice_unref_internal(c->entries_keys[i]);
+  for (int i = 0; i < GRPC_CHTTP2_HPACKC_NUM_VALUES; i++) {
+    auto* const key = GetEntry<grpc_slice_refcount*>(c->key_table.entries_, i);
+    if (key != nullptr) {
+      key->Unref();
     }
-    GRPC_MDELEM_UNREF(c->entries_elems[i]);
+    GRPC_MDELEM_UNREF(GetEntry<grpc_mdelem>(c->elem_table.entries_, i));
   }
   gpr_free(c->table_elem_size);
 }
@@ -744,7 +814,9 @@ void grpc_chttp2_encode_header(grpc_chttp2_hpack_compressor* c,
      validates that stream_id is not 0. So, this can be a debug assert. */
   GPR_DEBUG_ASSERT(options->stream_id != 0);
   framer_state st;
+#ifndef NDEBUG
   st.seen_regular_header = 0;
+#endif
   st.stream_id = options->stream_id;
   st.output = outbuf;
   st.is_first_frame = 1;
@@ -769,7 +841,7 @@ void grpc_chttp2_encode_header(grpc_chttp2_hpack_compressor* c,
         (static_index =
              reinterpret_cast<grpc_core::StaticMetadata*>(GRPC_MDELEM_DATA(md))
                  ->StaticIndex()) < GRPC_CHTTP2_LAST_STATIC_ENTRY) {
-      emit_indexed(c, static_cast<uint32_t>(static_index + 1), &st);
+      emit_indexed<true>(c, static_cast<uint32_t>(static_index + 1), &st);
     } else {
       hpack_enc(c, md, &st);
     }
@@ -783,7 +855,7 @@ void grpc_chttp2_encode_header(grpc_chttp2_hpack_compressor* c,
         (static_index = reinterpret_cast<grpc_core::StaticMetadata*>(
                             GRPC_MDELEM_DATA(l->md))
                             ->StaticIndex()) < GRPC_CHTTP2_LAST_STATIC_ENTRY) {
-      emit_indexed(c, static_cast<uint32_t>(static_index + 1), &st);
+      emit_indexed<true>(c, static_cast<uint32_t>(static_index + 1), &st);
     } else {
       hpack_enc(c, l->md, &st);
     }

--- a/src/core/ext/transport/chttp2/transport/hpack_encoder.h
+++ b/src/core/ext/transport/chttp2/transport/hpack_encoder.h
@@ -38,14 +38,10 @@
 
 extern grpc_core::TraceFlag grpc_http_trace;
 
-typedef struct {
-  uint32_t filter_elems_sum;
+struct grpc_chttp2_hpack_compressor {
   uint32_t max_table_size;
   uint32_t max_table_elems;
   uint32_t cap_table_elems;
-  /** if non-zero, advertise to the decoder that we'll start using a table
-      of this size */
-  uint8_t advertise_table_size_change;
   /** maximum number of bytes we'll use for the decode table (to guard against
       peers ooming us by setting decode table size high) */
   uint32_t max_usable_size;
@@ -53,23 +49,34 @@ typedef struct {
   uint32_t tail_remote_index;
   uint32_t table_size;
   uint32_t table_elems;
+  uint16_t* table_elem_size;
+  /** if non-zero, advertise to the decoder that we'll start using a table
+      of this size */
+  uint8_t advertise_table_size_change;
 
   /* filter tables for elems: this tables provides an approximate
      popularity count for particular hashes, and are used to determine whether
      a new literal should be added to the compression table or not.
      They track a single integer that counts how often a particular value has
      been seen. When that count reaches max (255), all values are halved. */
+  uint32_t filter_elems_sum;
   uint8_t filter_elems[GRPC_CHTTP2_HPACKC_NUM_VALUES];
 
   /* entry tables for keys & elems: these tables track values that have been
      seen and *may* be in the decompressor table */
-  grpc_slice entries_keys[GRPC_CHTTP2_HPACKC_NUM_VALUES];
-  grpc_mdelem entries_elems[GRPC_CHTTP2_HPACKC_NUM_VALUES];
-  uint32_t indices_keys[GRPC_CHTTP2_HPACKC_NUM_VALUES];
-  uint32_t indices_elems[GRPC_CHTTP2_HPACKC_NUM_VALUES];
-
-  uint16_t* table_elem_size;
-} grpc_chttp2_hpack_compressor;
+  struct {
+    struct {
+      grpc_mdelem value;
+      uint32_t index;
+    } entries_[GRPC_CHTTP2_HPACKC_NUM_VALUES];
+  } elem_table; /* Metadata table management */
+  struct {
+    struct {
+      grpc_slice_refcount* value;
+      uint32_t index;
+    } entries_[GRPC_CHTTP2_HPACKC_NUM_VALUES];
+  } key_table; /* Key table management */
+};
 
 void grpc_chttp2_hpack_compressor_init(grpc_chttp2_hpack_compressor* c);
 void grpc_chttp2_hpack_compressor_destroy(grpc_chttp2_hpack_compressor* c);

--- a/src/core/lib/transport/metadata.h
+++ b/src/core/lib/transport/metadata.h
@@ -277,8 +277,8 @@ class RefcountedMdBase {
   /* must be byte compatible with grpc_mdelem_data */
   grpc_slice key_;
   grpc_slice value_;
-  grpc_core::Atomic<intptr_t> refcnt_;
   uint32_t hash_ = 0;
+  grpc_core::Atomic<intptr_t> refcnt_;
 };
 
 class InternedMetadata : public RefcountedMdBase {


### PR DESCRIPTION
Reduced size of hpack encoder, and reduced expected number of cache misses in index table lookup.

BM_HpackEncoderInitDestroy                                                                                                                          226ns ± 0%              138ns ± 0%  -38.72%        (p=0.000 n=18+16)
BM_HpackEncoderEncodeDeadline                                                       [framing_bytes/iter:9 header_bytes/iter:6       ]               124ns ± 0%              121ns ± 1%   -2.25%        (p=0.000 n=16+20)
BM_HpackEncoderEncodeHeader<EmptyBatch>/0/16384                                     [framing_bytes/iter:9 header_bytes/iter:0       ]              34.2ns ± 0%             34.0ns ± 1%   -0.74%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<EmptyBatch>/1/16384                                     [framing_bytes/iter:9 header_bytes/iter:0       ]              34.3ns ± 0%             34.0ns ± 1%   -0.81%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<SingleStaticElem>/0/16384                               [framing_bytes/iter:9 header_bytes/iter:1       ]              45.9ns ± 1%             44.9ns ± 0%   -2.30%        (p=0.000 n=20+18)
BM_HpackEncoderEncodeHeader<SingleInternedKeyElem>/0/16384                          [framing_bytes/iter:9 header_bytes/iter:6       ]              68.4ns ± 1%             64.2ns ± 0%   -6.15%        (p=0.000 n=20+19)
BM_HpackEncoderEncodeHeader<SingleInternedElem>/0/16384                             [framing_bytes/iter:9 header_bytes/iter:1       ]              45.7ns ± 0%             45.0ns ± 1%   -1.64%        (p=0.000 n=18+20)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<1, false>>/0/16384             [framing_bytes/iter:9 header_bytes/iter:1       ]              45.5ns ± 0%             44.4ns ± 0%   -2.35%        (p=0.000 n=13+16)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<3, false>>/0/16384             [framing_bytes/iter:9 header_bytes/iter:1       ]              45.7ns ± 0%             45.0ns ± 1%   -1.59%        (p=0.000 n=17+20)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<10, false>>/0/16384            [framing_bytes/iter:9 header_bytes/iter:1       ]              45.7ns ± 0%             45.0ns ± 1%   -1.65%        (p=0.000 n=18+20)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<31, false>>/0/16384            [framing_bytes/iter:9 header_bytes/iter:1       ]              45.8ns ± 0%             45.0ns ± 1%   -1.67%        (p=0.000 n=19+20)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<100, false>>/0/16384           [framing_bytes/iter:9 header_bytes/iter:1       ]              45.8ns ± 0%             45.0ns ± 1%   -1.66%        (p=0.000 n=20+19)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<1, true>>/0/16384              [framing_bytes/iter:9 header_bytes/iter:1       ]              45.5ns ± 0%             44.5ns ± 1%   -2.26%        (p=0.000 n=14+17)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<3, true>>/0/16384              [framing_bytes/iter:9 header_bytes/iter:1       ]              45.8ns ± 1%             45.1ns ± 1%   -1.57%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<10, true>>/0/16384             [framing_bytes/iter:9 header_bytes/iter:1       ]              45.8ns ± 0%             45.0ns ± 1%   -1.67%        (p=0.000 n=20+20)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<31, true>>/0/16384             [framing_bytes/iter:9 header_bytes/iter:1       ]              45.8ns ± 0%             45.0ns ± 1%   -1.72%        (p=0.000 n=20+18)
BM_HpackEncoderEncodeHeader<SingleInternedBinaryElem<100, true>>/0/16384            [framing_bytes/iter:9 header_bytes/iter:1       ]              45.8ns ± 1%             45.0ns ± 1%   -1.65%        (p=0.000 n=19+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedElem>/0/16384                          [framing_bytes/iter:9 header_bytes/iter:9       ]              75.1ns ± 0%             77.3ns ± 1%   +2.82%        (p=0.000 n=19+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<3, false>>/0/16384          [framing_bytes/iter:9 header_bytes/iter:13      ]               104ns ± 0%              105ns ± 1%   +0.60%        (p=0.000 n=19+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<10, false>>/0/16384         [framing_bytes/iter:9 header_bytes/iter:21      ]               127ns ± 0%              128ns ± 0%   +1.45%        (p=0.000 n=18+18)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<31, false>>/0/16384         [framing_bytes/iter:9 header_bytes/iter:45      ]               221ns ± 0%              225ns ± 0%   +1.98%        (p=0.000 n=19+20)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<100, false>>/0/16384        [framing_bytes/iter:9 header_bytes/iter:121     ]               471ns ± 0%              475ns ± 0%   +0.86%        (p=0.000 n=19+17)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<1, true>>/0/16384           [framing_bytes/iter:9 header_bytes/iter:12      ]              75.0ns ± 0%             75.6ns ± 1%   +0.81%        (p=0.000 n=19+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<3, true>>/0/16384           [framing_bytes/iter:9 header_bytes/iter:14      ]              75.3ns ± 0%             76.7ns ± 1%   +1.89%        (p=0.000 n=19+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<10, true>>/0/16384          [framing_bytes/iter:9 header_bytes/iter:21      ]              75.3ns ± 0%             76.9ns ± 1%   +2.02%        (p=0.000 n=16+19)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<31, true>>/0/16384          [framing_bytes/iter:9 header_bytes/iter:42      ]              90.5ns ± 2%             91.4ns ± 0%   +0.97%        (p=0.000 n=20+15)
BM_HpackEncoderEncodeHeader<SingleNonInternedBinaryElem<100, true>>/0/16384         [framing_bytes/iter:9 header_bytes/iter:111     ]              90.6ns ± 1%             91.5ns ± 1%   +1.01%        (p=0.000 n=20+17)
BM_HpackEncoderEncodeHeader<SingleNonInternedElem>/0/1                              [framing_bytes/iter:27 header_bytes/iter:9      ]               149ns ± 0%              147ns ± 0%   -0.97%        (p=0.000 n=15+16)
BM_HpackEncoderEncodeHeader<RepresentativeClientInitialMetadata>/0/16384            [framing_bytes/iter:9 header_bytes/iter:8.00001 ]               110ns ± 1%              110ns ± 1%   -0.31%        (p=0.002 n=20+19)
BM_HpackEncoderEncodeHeader<MoreRepresentativeClientInitialMetadata>/0/16384        [framing_bytes/iter:9 header_bytes/iter:16      ]               169ns ± 0%              162ns ± 1%   -3.94%        (p=0.000 n=16+19)
BM_HpackEncoderEncodeHeader<RepresentativeServerInitialMetadata>/0/16384            [framing_bytes/iter:9 header_bytes/iter:3       ]              62.6ns ± 0%             61.1ns ± 0%   -2.35%        (p=0.000 n=18+18)
BM_HpackEncoderEncodeHeader<RepresentativeServerTrailingMetadata>/1/16384           [framing_bytes/iter:9 header_bytes/iter:1       ]              46.0ns ± 0%             44.9ns ± 0%   -2.31%        (p=0.000 n=19+18)
BM_HpackParserParseHeader<EmptyBatch, UnrefHeader>                                                                                                 10.2ns ± 0%             10.1ns ± 0%   -0.05%        (p=0.001 n=17+18)
BM_HpackParserParseHeader<AddIndexedSingleStaticElem, UnrefHeader>                                                                                  116ns ± 1%              115ns ± 1%   -0.81%        (p=0.000 n=18+18)
BM_HpackParserParseHeader<NonIndexedBinaryElem<3, false>, UnrefHeader>                                                                              190ns ± 2%              191ns ± 1%   +0.49%        (p=0.048 n=18+20)
BM_HpackParserParseHeader<NonIndexedBinaryElem<100, false>, UnrefHeader>                                                                          1.60µs ± 0%             1.61µs ± 0%   +0.95%        (p=0.000 n=20+16)
BM_HpackParserParseHeader<RepresentativeClientInitialMetadata, UnrefHeader>                                                                         121ns ± 0%              121ns ± 0%   -0.05%        (p=0.000 n=18+16)
BM_HpackParserParseHeader<RepresentativeServerInitialMetadata, UnrefHeader>                                                                        37.7ns ± 0%             37.7ns ± 0%   +0.21%        (p=0.000 n=19+19)
BM_HpackParserParseHeader<SameDeadline, OnHeaderTimeout>                                                                                           97.9ns ± 0%             98.0ns ± 0%   +0.03%        (p=0.011 n=17+16)

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

