### PR TITLE
Demonstrate a use after free bug

### DIFF
--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_windows.cc
@@ -816,6 +816,9 @@ class SockToPolledFdMap {
     SockToPolledFdMap* map = static_cast<SockToPolledFdMap*>(user_data);
     GrpcPolledFdWindows* polled_fd = map->LookupPolledFd(s);
     map->RemoveEntry(s);
+    // This trace log should crash in C# DNS resolution w/tracing test.
+    GRPC_CARES_TRACE_LOG("CloseSocket called for socket: %s",
+                         polled_fd->GetName());
     // If a gRPC polled fd has not made it in to the driver's list yet, then
     // the driver has not and will never see this socket.
     if (!polled_fd->gotten_into_driver_list()) {


### PR DESCRIPTION
This is to validate https://github.com/grpc/grpc/pull/20274. The trace log added here hits an access violation during the C# end-to-end DNS resolution with tracing test.

Specifically, all variants of the C# `csharp.Grpc.IntegrationTesting.ExternalDnsWithTracingClientServerTest` deterministically fail with exception: `System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.`.

This is due to the bug described in https://github.com/grpc/grpc/pull/20274