### PR TITLE
Make run_performance_tests.py scenarios show up as separate targets in the UI

### DIFF
--- a/tools/internal_ci/linux/grpc_e2e_performance_singlevm.sh
+++ b/tools/internal_ci/linux/grpc_e2e_performance_singlevm.sh
@@ -28,4 +28,4 @@ tools/run_tests/run_performance_tests.py \
     --category smoketest \
     -u kbuilder \
     --bq_result_table performance_test.performance_experiment_singlevm \
-    --xml_report reports/singlemachine/sponge_log.xml
+    --xml_report run_performance_tests/singlemachine/sponge_log.xml

--- a/tools/internal_ci/linux/grpc_full_performance_master.sh
+++ b/tools/internal_ci/linux/grpc_full_performance_master.sh
@@ -27,7 +27,7 @@ tools/run_tests/run_performance_tests.py \
     --remote_worker_host grpc-kokoro-performance-server-8core grpc-kokoro-performance-client-8core grpc-kokoro-performance-client2-8core \
     -u kbuilder \
     --bq_result_table performance_test.performance_experiment \
-    --xml_report reports/8core/sponge_log.xml \
+    --xml_report run_performance_tests/8core/sponge_log.xml \
     || EXIT_CODE=1
 
 # prevent pushing leftover build files to remote hosts in the next step.
@@ -41,7 +41,7 @@ tools/run_tests/run_performance_tests.py \
     --remote_worker_host grpc-kokoro-performance-server-32core grpc-kokoro-performance-client-32core grpc-kokoro-performance-client2-32core \
     -u kbuilder \
     --bq_result_table performance_test.performance_experiment_32core \
-    --xml_report reports/32core/sponge_log.xml \
+    --xml_report run_performance_tests/32core/sponge_log.xml \
     || EXIT_CODE=1
 
 # prevent pushing leftover build files to remote hosts in the next step.
@@ -53,7 +53,7 @@ tools/run_tests/run_performance_tests.py \
     --category scalable \
     --remote_worker_host grpc-kokoro-performance-windows1 grpc-kokoro-performance-windows2 \
     --bq_result_table performance_test.performance_experiment_windows \
-    --xml_report reports/windows/sponge_log.xml \
+    --xml_report run_performance_tests/windows/sponge_log.xml \
     || EXIT_CODE=1
 
 exit $EXIT_CODE

--- a/tools/internal_ci/linux/grpc_full_performance_release.sh
+++ b/tools/internal_ci/linux/grpc_full_performance_release.sh
@@ -27,7 +27,7 @@ tools/run_tests/run_performance_tests.py \
     --remote_worker_host grpc-kokoro-performance-server-8core grpc-kokoro-performance-client-8core grpc-kokoro-performance-client2-8core \
     -u kbuilder \
     --bq_result_table performance_released.performance_experiment \
-    --xml_report reports/8core/sponge_log.xml \
+    --xml_report run_performance_tests/8core/sponge_log.xml \
     || EXIT_CODE=1
 
 # prevent pushing leftover build files to remote hosts in the next step.
@@ -41,7 +41,7 @@ tools/run_tests/run_performance_tests.py \
     --remote_worker_host grpc-kokoro-performance-server-32core grpc-kokoro-performance-client-32core grpc-kokoro-performance-client2-32core \
     -u kbuilder \
     --bq_result_table performance_released.performance_experiment_32core \
-    --xml_report reports/32core/sponge_log.xml \
+    --xml_report run_performance_tests/32core/sponge_log.xml \
     || EXIT_CODE=1
 
 # prevent pushing leftover build files to remote hosts in the next step.
@@ -53,7 +53,7 @@ tools/run_tests/run_performance_tests.py \
     --category scalable \
     --remote_worker_host grpc-kokoro-performance-windows1 grpc-kokoro-performance-windows2 \
     --bq_result_table performance_released.performance_experiment_windows \
-    --xml_report reports/windows/sponge_log.xml \
+    --xml_report run_performance_tests/windows/sponge_log.xml \
     || EXIT_CODE=1
 
 exit $EXIT_CODE

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -707,7 +707,7 @@ def main():
             '%s/index.html' % args.flame_graph_reports, profile_output_files)
 
     report_utils.render_junit_xml_report(
-        merged_resultset, args.xml_report, suite_name='benchmarks')
+        merged_resultset, args.xml_report, suite_name='benchmarks', multi_target=True)
 
     if total_scenario_failures > 0 or qps_workers_killed > 0:
         print('%s scenarios failed and %s qps worker jobs killed' %

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -709,7 +709,10 @@ def main():
             '%s/index.html' % args.flame_graph_reports, profile_output_files)
 
     report_utils.render_junit_xml_report(
-        merged_resultset, args.xml_report, suite_name='benchmarks', multi_target=True)
+        merged_resultset,
+        args.xml_report,
+        suite_name='benchmarks',
+        multi_target=True)
 
     if total_scenario_failures > 0 or qps_workers_killed > 0:
         print('%s scenarios failed and %s qps worker jobs killed' %

--- a/tools/run_tests/run_performance_tests.py
+++ b/tools/run_tests/run_performance_tests.py
@@ -135,7 +135,7 @@ def create_scenario_jobspec(scenario_json,
 
     return jobset.JobSpec(
         cmdline=[cmd],
-        shortname='qps_json_driver.%s' % scenario_json['name'],
+        shortname='%s' % scenario_json['name'],
         timeout_seconds=_SCENARIO_TIMEOUT,
         shell=True,
         verbose_success=True)
@@ -153,7 +153,7 @@ def create_quit_jobspec(workers, remote_host=None):
 
     return jobset.JobSpec(
         cmdline=[cmd],
-        shortname='qps_json_driver.quit',
+        shortname='shutdown_workers',
         timeout_seconds=_QUIT_WORKER_TIMEOUT,
         shell=True,
         verbose_success=True)
@@ -670,6 +670,8 @@ def main():
                     worker.start()
                 jobs = [scenario.jobspec]
                 if scenario.workers:
+                    # TODO(jtattermusch): ideally the "quit" job won't show up
+                    # in the report
                     jobs.append(
                         create_quit_jobspec(
                             scenario.workers,

--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -66,10 +66,8 @@ def _matrix_job_logfilename(shortname_for_multi_target):
     # for the corresponding 'sponge_log.xml' report.
     # the shortname_for_multi_target component must be set to match the sponge_log.xml location
     # because the top-level render_junit_xml_report is called with multi_target=True
-    s = '%s/%s/%s' % (_MATRIX_REPORT_NAME, shortname_for_multi_target,
-                      'sponge_log.log')
-    print(s)
-    return s
+    return '%s/%s/%s' % (_MATRIX_REPORT_NAME, shortname_for_multi_target,
+                         'sponge_log.log')
 
 
 def _docker_jobspec(name,


### PR DESCRIPTION
Make performance benchmark test reports more readable 

Example before:
https://source.cloud.google.com/results/invocations/3b5c0bd5-d099-49b5-b589-260172a23586/targets

Example after:
https://source.cloud.google.com/results/invocations/b4f73cb5-9707-4efb-8cf4-8f892d0fa5e3/targets;collapsed=

Similar idea to
https://github.com/grpc/grpc/pull/20206
