### PR TITLE
Fix import failure due to 'visibility = ["//visibility:public"]'

### DIFF
--- a/test/core/end2end/generate_tests.bzl
+++ b/test/core/end2end/generate_tests.bzl
@@ -380,7 +380,6 @@ def grpc_end2end_tests():
             "end2end_tests.h",
         ],
         language = "C++",
-        visibility = ["//visibility:public"],
         deps = [
             ":cq_verifier",
             ":ssl_test_data",


### PR DESCRIPTION
Internally, we have a regexp replace rule:
```
before = "${string_delimiter_open}//${package}",
after = "${string_delimiter_open}//third_party/grpc/${package}",
```

And funny enough, it turns `//visibility:public` into `//third_party/grpc/visibility:public`.
Also, I don't think tests should be exposed as public.

---

Link to the original PR: Add Asylo platform support. #15577