### PR TITLE
Only dbg for sanity test

### DIFF
--- a/tools/run_tests/run_tests_matrix.py
+++ b/tools/run_tests/run_tests_matrix.py
@@ -182,7 +182,7 @@ def _create_test_jobs(extra_args=[], inner_jobs=_DEFAULT_INNER_JOBS):
     # sanity tests
     test_jobs += _generate_jobs(
         languages=['sanity'],
-        configs=['dbg', 'opt'],
+        configs=['dbg'],
         platforms=['linux'],
         labels=['basictests'],
         extra_args=extra_args + ['--report_multi_target'],


### PR DESCRIPTION
It seems that sanity test doesn't need `opt` so make it to have `dbg` only to get done quickly.