### PR TITLE
Add support for OpenSSL ENGINE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1313,6 +1313,45 @@ foreach(_hdr
 endforeach()
 
 endif()
+if(gRPC_BUILD_TESTS)
+
+add_library(engine_passthrough SHARED
+  test/core/end2end/engine_passthrough.cc
+)
+
+set_target_properties(engine_passthrough PROPERTIES
+  VERSION ${gRPC_CORE_VERSION}
+  SOVERSION ${gRPC_CORE_SOVERSION}
+)
+
+if(WIN32 AND MSVC)
+  set_target_properties(engine_passthrough PROPERTIES COMPILE_PDB_NAME "engine_passthrough"
+    COMPILE_PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+  )
+  if(gRPC_INSTALL)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/engine_passthrough.pdb
+      DESTINATION ${gRPC_INSTALL_LIBDIR} OPTIONAL
+    )
+  endif()
+endif()
+
+target_include_directories(engine_passthrough
+  PUBLIC $<INSTALL_INTERFACE:${gRPC_INSTALL_INCLUDEDIR}> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${_gRPC_ADDRESS_SORTING_INCLUDE_DIR}
+    ${_gRPC_SSL_INCLUDE_DIR}
+    ${_gRPC_UPB_GENERATED_DIR}
+    ${_gRPC_UPB_GRPC_GENERATED_DIR}
+    ${_gRPC_UPB_INCLUDE_DIR}
+    ${_gRPC_ZLIB_INCLUDE_DIR}
+)
+target_link_libraries(engine_passthrough
+  ${_gRPC_ALLTARGETS_LIBRARIES}
+)
+
+
+endif()
 
 add_library(gpr
   src/core/lib/gpr/alloc.cc

--- a/Makefile
+++ b/Makefile
@@ -3787,6 +3787,45 @@ endif
 endif
 
 
+LIBENGINE_PASSTHROUGH_SRC = \
+    test/core/end2end/engine_passthrough.cc \
+
+PUBLIC_HEADERS_C += \
+
+LIBENGINE_PASSTHROUGH_OBJS = $(addprefix $(OBJDIR)/$(CONFIG)/, $(addsuffix .o, $(basename $(LIBENGINE_PASSTHROUGH_SRC))))
+
+
+ifeq ($(NO_SECURE),true)
+
+# You can't build secure libraries if you don't have OpenSSL.
+
+$(LIBDIR)/$(CONFIG)/libengine_passthrough.a: openssl_dep_error
+
+
+else
+
+
+$(LIBDIR)/$(CONFIG)/libengine_passthrough.a: $(ZLIB_DEP) $(OPENSSL_DEP) $(CARES_DEP) $(ADDRESS_SORTING_DEP) $(UPB_DEP) $(GRPC_ABSEIL_DEP)  $(LIBENGINE_PASSTHROUGH_OBJS) 
+	$(E) "[AR]      Creating $@"
+	$(Q) mkdir -p `dirname $@`
+	$(Q) rm -f $(LIBDIR)/$(CONFIG)/libengine_passthrough.a
+	$(Q) $(AR) $(AROPTS) $(LIBDIR)/$(CONFIG)/libengine_passthrough.a $(LIBENGINE_PASSTHROUGH_OBJS) 
+ifeq ($(SYSTEM),Darwin)
+	$(Q) ranlib -no_warning_for_no_symbols $(LIBDIR)/$(CONFIG)/libengine_passthrough.a
+endif
+
+
+
+
+endif
+
+ifneq ($(NO_SECURE),true)
+ifneq ($(NO_DEPS),true)
+-include $(LIBENGINE_PASSTHROUGH_OBJS:.o=.dep)
+endif
+endif
+
+
 LIBGPR_SRC = \
     src/core/lib/gpr/alloc.cc \
     src/core/lib/gpr/atm.cc \
@@ -23734,6 +23773,7 @@ test/core/end2end/data/server1_cert.cc: $(OPENSSL_DEP)
 test/core/end2end/data/server1_key.cc: $(OPENSSL_DEP)
 test/core/end2end/data/test_root_cert.cc: $(OPENSSL_DEP)
 test/core/end2end/end2end_tests.cc: $(OPENSSL_DEP)
+test/core/end2end/engine_passthrough.cc: $(OPENSSL_DEP)
 test/core/end2end/tests/call_creds.cc: $(OPENSSL_DEP)
 test/core/security/oauth2_utils.cc: $(OPENSSL_DEP)
 test/core/tsi/alts/crypt/gsec_test_util.cc: $(OPENSSL_DEP)

--- a/build.yaml
+++ b/build.yaml
@@ -1699,6 +1699,12 @@ libs:
   filegroups:
   - grpc_test_util_base
   secure: true
+- name: engine_passthrough
+  build: test
+  language: c
+  src:
+  - test/core/end2end/engine_passthrough.cc
+  dll: only
 - name: gpr
   build: all
   language: c

--- a/grpc.gyp
+++ b/grpc.gyp
@@ -430,6 +430,15 @@
       ],
     },
     {
+      'target_name': 'engine_passthrough',
+      'type': 'static_library',
+      'dependencies': [
+      ],
+      'sources': [
+        'test/core/end2end/engine_passthrough.cc',
+      ],
+    },
+    {
       'target_name': 'gpr',
       'type': 'static_library',
       'dependencies': [

--- a/test/core/end2end/engine_passthrough.cc
+++ b/test/core/end2end/engine_passthrough.cc
@@ -1,0 +1,73 @@
+/*
+ *
+ * Copyright 2020 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// This is a sample openSSL engine which tests the openSSL
+// engine plugability with gRPC.
+// This sample engine expects KeyId to be actual PEM encoded
+// key itself and just calls standard openSSL functions.
+
+#include <openssl/bio.h>
+#include <openssl/engine.h>
+#include <openssl/pem.h>
+
+#ifndef OPENSSL_IS_BORINGSSL
+
+#include <stdio.h>
+#include <string.h>
+
+extern "C" {
+static const char engine_id[] = "libengine_passthrough";
+static const char engine_name[] = "A passthrough engine for private keys";
+static int e_passthrough_idx = -1;
+
+static int e_passthrough_init(ENGINE* e) {
+  if (e_passthrough_idx < 0) {
+    e_passthrough_idx = ENGINE_get_ex_new_index(0, NULL, NULL, NULL, 0);
+    if (e_passthrough_idx < 0) return 0;
+  }
+  return 1;
+}
+
+EVP_PKEY* e_passthrough_load_privkey(ENGINE* eng, const char* key_id,
+                                     UI_METHOD* ui_method,
+                                     void* callback_data) {
+  EVP_PKEY* pkey = NULL;
+  BIO* pem = BIO_new_mem_buf((void*)key_id, (int)(strlen(key_id)));
+  if (pem == NULL) return NULL;
+  pkey = PEM_read_bio_PrivateKey(pem, NULL, NULL, (void*)"");
+  BIO_free(pem);
+  return pkey;
+}
+
+int passthrough_bind_helper(ENGINE* e, const char* id) {
+  if (id && strcmp(id, engine_id)) {
+    return 0;
+  }
+  if (!ENGINE_set_id(e, engine_id) || !ENGINE_set_name(e, engine_name) ||
+      !ENGINE_set_flags(e, ENGINE_FLAGS_NO_REGISTER_ALL) ||
+      !ENGINE_set_init_function(e, e_passthrough_init) ||
+      !ENGINE_set_load_privkey_function(e, e_passthrough_load_privkey)) {
+    return 0;
+  }
+  return 1;
+}
+
+IMPLEMENT_DYNAMIC_BIND_FN(passthrough_bind_helper)
+IMPLEMENT_DYNAMIC_CHECK_FN()
+}
+#endif  // OPENSSL_IS_BORINGSSL


### PR DESCRIPTION
This fixes Issue https://github.com/grpc/grpc/issues/18293 

**Requirements**: 
- **_Cryptographic key isolation_** – The idea is that a process that is listening for incoming traffic has no direct access to private key bits and instead only gets oracle access to perform cryptographic operations (e.g. TLS server authentication). Default OpenSSL crypto ENGINE implementation doesn’t support it and 1) uses keys in-proc and 2) requires keys be provisioned in the clear on the server via PEM files so that they can be loaded in-proc. OpenSSL as a library allows custom ENGINES to be used that can provide key isolation (e.g. HSM vendor can author an ENGINE that talks to their hardware). However, gRPC config or APIs, don’t allow targeting a custom engine. This is a big gap for us. 
 
- **Custom certificate validation** – In closed system scenarios (e.g. communication of the infrastructure servers and devices in a data center), it is important to restrict the trust of certificates that an application may accept. This allows the application to not be a victim of a 3rd party CA compromise and enables building a PKI that separates high-value certificates from lesser ones. For example, a certificate that is used for a server to distribute security policies, patches, credentials, etc should be hard to get. The way you do that is that you 1) trim down the list of roots you trust and 2) process additional rules like EKU extension, policy identifiers and name constraints. Similar to the above, gRPC doesn’t give us enough flexibility to do that, but we can setup a callback with gRPC to do extra checking, but we don’t get the full certificate chain, only the leaf cert. This is not enough. We need the full chain.

**_Design Choices_**:
- **Engine support** - gRPC has two interfaces to configure certs and keys from the client and server side. From Client side, it takes `SslCredentialsOptions` to create channel credentials and from the server it takes `SslServerCredentialsOptions`. These structures takes private key in the clear. If we compare to nginx support for engines, they provide an option to specify the private key in `engine:<engineid>:<keyId>` format. More details are http://nginx.org/en/docs/http/ngx_http_ssl_module.html. This PR takes that approach. 

- **Custom certificate validation** - This has to happen for whole chain and not only the leaf certificate. Our design is based on curl design for https://curl.haxx.se/libcurl/c/CURLOPT_SSL_CTX_FUNCTION.html and https://curl.haxx.se/libcurl/c/CURLOPT_SSL_CTX_DATA.html. Basically, before making the connection, a callback to the client is called which can set appropriate properties for the channel. 

- **Full certificate chain** - It's support is not there in this PR but we are thinking of adding another property called `GRPC_X509_PEM_CERT_CHAIN_PROPERTY_NAME` similar to `GRPC_X509_PEM_CERT_PROPERTY_NAME` which can give the full chain. 

@jiangtaoli2016 for review and provide feedback
