### PR TITLE
Removed custom int64 typedef in favor of int64_t.

### DIFF
--- a/include/grpcpp/impl/codegen/config_protobuf.h
+++ b/include/grpcpp/impl/codegen/config_protobuf.h
@@ -21,11 +21,6 @@
 
 #define GRPC_OPEN_SOURCE_PROTO
 
-#ifndef GRPC_CUSTOM_PROTOBUF_INT64
-#include <google/protobuf/stubs/common.h>
-#define GRPC_CUSTOM_PROTOBUF_INT64 ::google::protobuf::int64
-#endif
-
 #ifndef GRPC_CUSTOM_MESSAGE
 #ifdef GRPC_USE_PROTO_LITE
 #include <google/protobuf/message_lite.h>
@@ -79,7 +74,6 @@ namespace protobuf {
 
 typedef GRPC_CUSTOM_MESSAGE Message;
 typedef GRPC_CUSTOM_MESSAGELITE MessageLite;
-typedef GRPC_CUSTOM_PROTOBUF_INT64 int64;
 
 typedef GRPC_CUSTOM_DESCRIPTOR Descriptor;
 typedef GRPC_CUSTOM_DESCRIPTORPOOL DescriptorPool;

--- a/include/grpcpp/impl/codegen/proto_buffer_reader.h
+++ b/include/grpcpp/impl/codegen/proto_buffer_reader.h
@@ -121,9 +121,7 @@ class ProtoBufferReader : public ::grpc::protobuf::io::ZeroCopyInputStream {
   }
 
   /// Returns the total number of bytes read since this object was created.
-  grpc::protobuf::int64 ByteCount() const override {
-    return byte_count_ - backup_count_;
-  }
+  int64_t ByteCount() const override { return byte_count_ - backup_count_; }
 
   // These protected members are needed to support internal optimizations.
   // they expose internal bits of grpc core that are NOT stable. If you have

--- a/include/grpcpp/impl/codegen/proto_buffer_writer.h
+++ b/include/grpcpp/impl/codegen/proto_buffer_writer.h
@@ -138,7 +138,7 @@ class ProtoBufferWriter : public ::grpc::protobuf::io::ZeroCopyOutputStream {
   }
 
   /// Returns the total number of bytes written since this object was created.
-  grpc::protobuf::int64 ByteCount() const override { return byte_count_; }
+  int64_t ByteCount() const override { return byte_count_; }
 
   // These protected members are needed to support internal optimizations.
   // they expose internal bits of grpc core that are NOT stable. If you have


### PR DESCRIPTION
ByteCount() now returns int64_t in all configurations
so there is no longer any need for typedef indirection here.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@veblush
