### PR TITLE
Fix service config tests

### DIFF
--- a/test/core/client_channel/service_config_test.cc
+++ b/test/core/client_channel/service_config_test.cc
@@ -921,10 +921,7 @@ TEST_F(ClientChannelParserTest, InvalidHealthCheckMultipleEntries) {
                   "error)(.*)(referenced_errors)(.*)(Global "
                   "Params)(.*)(referenced_errors)(.*)(field:healthCheckConfig "
                   "error:Duplicate entry)"));
-  std::smatch match;
-  std::string s(grpc_error_string(error));
-  EXPECT_TRUE(std::regex_search(s, match, e));
-  GRPC_ERROR_UNREF(error);
+  VerifyRegexMatch(error, e);
 }
 
 class MessageSizeParserTest : public ::testing::Test {
@@ -1014,6 +1011,11 @@ TEST_F(MessageSizeParserTest, InvalidMaxResponseMessageBytes) {
 }  // namespace grpc_core
 
 int main(int argc, char** argv) {
+// Regexes don't work in gcc4.8 and below, so just skip testing in those cases
+#if defined(__GNUC__) && \
+    ((__GNUC__ < 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__) <= 8))
+  return 0;
+#endif
   grpc::testing::TestEnvironment env(argc, argv);
   grpc_init();
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
These tests are failing in some of our portability test runs. That's because std::regex doesn't functionally work on gcc4.8 and below (it compiles, but it's buggy and only partially implemented). To ameliorate this, I add a macro check to skip the service_config tests on older gcc versions.