### PR TITLE
Use the first socket mutator if present.

### DIFF
--- a/src/core/lib/iomgr/socket_utils_common_posix.cc
+++ b/src/core/lib/iomgr/socket_utils_common_posix.cc
@@ -330,6 +330,19 @@ grpc_error* grpc_set_socket_with_mutator(int fd, grpc_socket_mutator* mutator) {
   return GRPC_ERROR_NONE;
 }
 
+grpc_error* grpc_apply_socket_mutator_in_args(int fd,
+                                              const grpc_channel_args* args) {
+  const grpc_arg* socket_mutator_arg =
+      grpc_channel_args_find(args, GRPC_ARG_SOCKET_MUTATOR);
+  if (socket_mutator_arg == nullptr) {
+    return GRPC_ERROR_NONE;
+  }
+  GPR_DEBUG_ASSERT(socket_mutator_arg->type == GRPC_ARG_POINTER);
+  grpc_socket_mutator* mutator =
+      static_cast<grpc_socket_mutator*>(socket_mutator_arg->value.pointer.p);
+  return grpc_set_socket_with_mutator(fd, mutator);
+}
+
 static gpr_once g_probe_ipv6_once = GPR_ONCE_INIT;
 static int g_ipv6_loopback_available;
 

--- a/src/core/lib/iomgr/socket_utils_posix.h
+++ b/src/core/lib/iomgr/socket_utils_posix.h
@@ -91,6 +91,10 @@ grpc_error* grpc_set_socket_rcvbuf(int fd, int buffer_size_bytes);
 /* Tries to set the socket using a grpc_socket_mutator */
 grpc_error* grpc_set_socket_with_mutator(int fd, grpc_socket_mutator* mutator);
 
+/* Extracts the first socket mutator from args if any and applies on the fd. */
+grpc_error* grpc_apply_socket_mutator_in_args(int fd,
+                                              const grpc_channel_args* args);
+
 /* An enum to keep track of IPv4/IPv6 socket modes.
 
    Currently, this information is only used when a socket is first created, but

--- a/src/core/lib/iomgr/tcp_client_posix.cc
+++ b/src/core/lib/iomgr/tcp_client_posix.cc
@@ -84,17 +84,10 @@ static grpc_error* prepare_socket(const grpc_resolved_address* addr, int fd,
   }
   err = grpc_set_socket_no_sigpipe_if_possible(fd);
   if (err != GRPC_ERROR_NONE) goto error;
-  if (channel_args) {
-    for (size_t i = 0; i < channel_args->num_args; i++) {
-      if (0 == strcmp(channel_args->args[i].key, GRPC_ARG_SOCKET_MUTATOR)) {
-        GPR_ASSERT(channel_args->args[i].type == GRPC_ARG_POINTER);
-        grpc_socket_mutator* mutator = static_cast<grpc_socket_mutator*>(
-            channel_args->args[i].value.pointer.p);
-        err = grpc_set_socket_with_mutator(fd, mutator);
-        if (err != GRPC_ERROR_NONE) goto error;
-      }
-    }
-  }
+
+  err = grpc_apply_socket_mutator_in_args(fd, channel_args);
+  if (err != GRPC_ERROR_NONE) goto error;
+
   goto done;
 
 error:

--- a/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
+++ b/src/core/lib/iomgr/tcp_server_utils_posix_common.cc
@@ -173,17 +173,8 @@ grpc_error* grpc_tcp_server_prepare_socket(grpc_tcp_server* s, int fd,
   err = grpc_set_socket_no_sigpipe_if_possible(fd);
   if (err != GRPC_ERROR_NONE) goto error;
 
-  if (s->channel_args) {
-    for (size_t i = 0; i < s->channel_args->num_args; i++) {
-      if (0 == strcmp(s->channel_args->args[i].key, GRPC_ARG_SOCKET_MUTATOR)) {
-        GPR_ASSERT(s->channel_args->args[i].type == GRPC_ARG_POINTER);
-        grpc_socket_mutator* mutator = static_cast<grpc_socket_mutator*>(
-            s->channel_args->args[i].value.pointer.p);
-        err = grpc_set_socket_with_mutator(fd, mutator);
-        if (err != GRPC_ERROR_NONE) goto error;
-      }
-    }
-  }
+  err = grpc_apply_socket_mutator_in_args(fd, s->channel_args);
+  if (err != GRPC_ERROR_NONE) goto error;
 
   if (bind(fd, reinterpret_cast<grpc_sockaddr*>(const_cast<char*>(addr->addr)),
            addr->len) < 0) {


### PR DESCRIPTION
The C++ API prevents multiple mutators.