### PR TITLE
Remove out of context writes from H2.

### DIFF
--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -306,10 +306,6 @@ struct grpc_chttp2_transport {
 
   /** write execution state of the transport */
   grpc_chttp2_write_state write_state = GRPC_CHTTP2_WRITE_STATE_IDLE;
-  /** is this the first write in a series of writes?
-      set when we initiate writing from idle, cleared when we
-      initiate writing from writing+more */
-  bool is_first_write_in_batch = false;
 
   /** is the transport destroying itself? */
   uint8_t destroying = false;
@@ -318,8 +314,6 @@ struct grpc_chttp2_transport {
 
   /** is there a read request to the endpoint outstanding? */
   uint8_t endpoint_reading = 1;
-
-  grpc_chttp2_optimization_target opt_target = GRPC_CHTTP2_OPTIMIZE_FOR_LATENCY;
 
   /** various lists of streams */
   grpc_chttp2_stream_list lists[STREAM_LIST_COUNT] = {};

--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -463,6 +463,17 @@ std::unique_ptr<ScenarioResult> RunScenario(
       gpr_log(GPR_ERROR, "Failed WritesDone for client %zu", i);
     }
   }
+  gpr_log(GPR_INFO, "Finishing servers");
+  for (size_t i = 0; i < num_servers; i++) {
+    auto server = &servers[i];
+    if (!server->stream->Write(server_mark)) {
+      gpr_log(GPR_ERROR, "Couldn't write mark to server %zu", i);
+    }
+    if (!server->stream->WritesDone()) {
+      gpr_log(GPR_ERROR, "Failed WritesDone for server %zu", i);
+    }
+  }
+
   for (size_t i = 0; i < num_clients; i++) {
     auto client = &clients[i];
     // Read the client final status
@@ -499,16 +510,6 @@ std::unique_ptr<ScenarioResult> RunScenario(
     rrc->set_count(it->second);
   }
 
-  gpr_log(GPR_INFO, "Finishing servers");
-  for (size_t i = 0; i < num_servers; i++) {
-    auto server = &servers[i];
-    if (!server->stream->Write(server_mark)) {
-      gpr_log(GPR_ERROR, "Couldn't write mark to server %zu", i);
-    }
-    if (!server->stream->WritesDone()) {
-      gpr_log(GPR_ERROR, "Failed WritesDone for server %zu", i);
-    }
-  }
   for (size_t i = 0; i < num_servers; i++) {
     auto server = &servers[i];
     // Read the server final status


### PR DESCRIPTION
There is major improvement in production benchmarks (99p latency is
halved).

Microbenchmarks show up to 14% improvements:
```
BM_PumpStreamClientToServer<InProcess>/16777216        [polls/iter:0                              ]             15.6ms ± 4%             15.3ms ± 6%  -2.32%        (p=0.002 n=18+20)
BM_PumpStreamServerToClient<InProcess>/0               [polls/iter:0                              ]            1.23µs ± 1%             1.21µs ± 1%  -1.54%        (p=0.000 n=18+18)
BM_PumpStreamServerToClient<InProcess>/1               [polls/iter:0                              ]            1.33µs ± 1%             1.31µs ± 1%  -1.47%        (p=0.000 n=16+19)
BM_PumpStreamServerToClient<InProcess>/8               [polls/iter:0                              ]            1.33µs ± 1%             1.31µs ± 1%  -1.47%        (p=0.000 n=17+20)
BM_PumpStreamServerToClient<InProcess>/64              [polls/iter:0                              ]            1.37µs ± 1%             1.36µs ± 1%  -0.86%        (p=0.000 n=17+20)
BM_PumpStreamServerToClient<InProcess>/4096            [polls/iter:0                              ]            2.40µs ± 3%             2.35µs ± 3%  -2.43%        (p=0.000 n=18+19)
BM_PumpStreamServerToClient<MinInProcess>/0            [polls/iter:0                              ]            1.21µs ± 0%             1.20µs ± 1%  -0.87%        (p=0.000 n=15+17)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/1/2                                           [polls/iter:12.0002                        ]            62.3µs ± 3%             61.2µs ± 1%   -1.78%         (p=0.007 n=7+10)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/8/2                                           [polls/iter:12.0002                        ]            62.3µs ± 2%             61.4µs ± 1%   -1.39%         (p=0.016 n=11+9)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/64/2                                          [polls/iter:12.0002                        ]            65.1µs ± 2%             63.9µs ± 2%   -1.76%          (p=0.005 n=7+9)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/512/1                                         [polls/iter:8.00012                        ]            47.1µs ± 1%             46.3µs ± 1%   -1.77%          (p=0.008 n=5+5)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/4096/2                                        [polls/iter:12                             ]            71.3µs ± 1%             70.2µs ± 1%   -1.51%          (p=0.008 n=5+5)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/0/0                                     [polls/iter:0                              ]            5.73µs ± 2%             5.68µs ± 1%   -0.96%        (p=0.000 n=20+19)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/1/1                                     [polls/iter:0                              ]            8.74µs ± 1%             8.69µs ± 1%   -0.53%        (p=0.002 n=20+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/1/2                                     [polls/iter:0                              ]            11.6µs ± 1%             11.5µs ± 1%   -0.57%        (p=0.000 n=20+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/8/1                                     [polls/iter:0                              ]            8.72µs ± 1%             8.70µs ± 1%   -0.25%        (p=0.038 n=20+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/64/1                                    [polls/iter:0                              ]            8.87µs ± 1%             8.83µs ± 1%   -0.41%        (p=0.003 n=20+19)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/64/2                                    [polls/iter:0                              ]            11.8µs ± 1%             11.8µs ± 1%   -0.62%        (p=0.000 n=20+19)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/512/1                                   [polls/iter:0                              ]            9.16µs ± 1%             9.10µs ± 1%   -0.60%        (p=0.000 n=20+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/512/2                                   [polls/iter:0                              ]            12.3µs ± 1%             12.2µs ± 1%   -0.70%        (p=0.000 n=20+18)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/32768/2                                 [polls/iter:0                              ]            50.0µs ± 1%             50.2µs ± 2%   +0.47%        (p=0.026 n=20+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/2097152/1                               [polls/iter:0                              ]             2.14ms ± 2%             1.89ms ± 1%  -11.52%        (p=0.000 n=18+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/2097152/2                               [polls/iter:0                              ]             4.27ms ± 2%             3.78ms ± 1%  -11.41%        (p=0.000 n=18+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/16777216/1                              [polls/iter:0                              ]             32.9ms ± 6%             29.2ms ± 6%  -11.34%        (p=0.000 n=19+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/16777216/2                              [polls/iter:0                              ]             64.7ms ± 4%             58.0ms ± 5%  -10.33%        (p=0.000 n=17+19)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/134217728/1                             [polls/iter:0                              ]              326ms ± 2%              323ms ± 2%   -1.08%        (p=0.001 n=20+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/134217728/2                             [polls/iter:0                              ]              652ms ± 2%              644ms ± 2%   -1.19%        (p=0.001 n=20+20)
BM_StreamingPingPongMsgs<TCP, NoOpMutator, NoOpMutator>/8                                         [polls/iter:4.00007                        ]            16.3µs ± 2%             16.0µs ± 1%   -1.77%          (p=0.038 n=6+4)
BM_StreamingPingPongMsgs<InProcess, NoOpMutator, NoOpMutator>/2097152                             [polls/iter:0                              ]             2.02ms ± 7%             1.88ms ± 1%   -6.63%        (p=0.002 n=20+20)
BM_StreamingPingPongMsgs<InProcess, NoOpMutator, NoOpMutator>/16777216                            [polls/iter:0                              ]             32.3ms ± 6%             29.3ms ± 5%   -9.55%        (p=0.000 n=19+20)
BM_StreamingPingPongMsgs<InProcess, NoOpMutator, NoOpMutator>/134217728                           [polls/iter:0                              ]              327ms ± 1%              323ms ± 1%   -1.22%        (p=0.000 n=20+20)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/2                                        [polls/iter:12.0001                        ]            59.5µs ± 2%             58.6µs ± 1%   -1.48%          (p=0.014 n=9+9)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/1/2                                        [polls/iter:12.0001                        ]            60.9µs ± 2%             60.0µs ± 2%   -1.43%          (p=0.023 n=9+7)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/8/2                                        [polls/iter:12.0002                        ]            61.4µs ± 2%             60.0µs ± 1%   -2.27%          (p=0.012 n=7+4)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/0                                  [polls/iter:0                              ]            5.71µs ± 2%             5.62µs ± 2%   -1.51%        (p=0.000 n=20+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/1                                  [polls/iter:0                              ]            8.44µs ± 1%             8.39µs ± 1%   -0.65%        (p=0.001 n=20+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/2                                  [polls/iter:0                              ]            11.0µs ± 1%             11.0µs ± 1%   -0.26%        (p=0.037 n=19+19)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/1/1                                  [polls/iter:0                              ]            8.68µs ± 1%             8.61µs ± 1%   -0.78%        (p=0.000 n=19+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/1/2                                  [polls/iter:0                              ]            11.5µs ± 1%             11.4µs ± 1%   -0.24%        (p=0.044 n=19+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/8/1                                  [polls/iter:0                              ]            8.72µs ± 1%             8.62µs ± 1%   -1.18%        (p=0.000 n=20+19)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/64/1                                 [polls/iter:0                              ]            8.83µs ± 1%             8.76µs ± 1%   -0.87%        (p=0.000 n=20+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/64/2                                 [polls/iter:0                              ]            11.7µs ± 1%             11.7µs ± 1%   -0.47%        (p=0.014 n=20+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/512/1                                [polls/iter:0                              ]            9.13µs ± 1%             9.05µs ± 1%   -0.85%        (p=0.000 n=20+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/512/2                                [polls/iter:0                              ]            12.3µs ± 1%             12.2µs ± 1%   -0.55%        (p=0.004 n=20+19)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/4096/1                               [polls/iter:0                              ]            11.1µs ± 1%             11.1µs ± 1%   -0.55%        (p=0.010 n=18+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/2097152/1                            [polls/iter:0                              ]             2.08ms ± 9%             1.90ms ± 1%   -8.68%        (p=0.000 n=20+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/2097152/2                            [polls/iter:0                              ]             4.14ms ± 9%             3.77ms ± 1%   -8.95%        (p=0.000 n=20+17)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/16777216/1                           [polls/iter:0                              ]             32.1ms ± 7%             28.6ms ± 3%  -10.87%        (p=0.000 n=20+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/16777216/2                           [polls/iter:0                              ]             64.0ms ± 7%             57.4ms ± 2%  -10.28%        (p=0.000 n=20+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/134217728/1                          [polls/iter:0                              ]              326ms ± 2%              321ms ± 2%   -1.40%        (p=0.000 n=20+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/134217728/2                          [polls/iter:0                              ]              652ms ± 2%              643ms ± 2%   -1.39%        (p=0.000 n=20+20)
BM_StreamingPingPongMsgs<MinInProcess, NoOpMutator, NoOpMutator>/8                                [polls/iter:0                              ]            2.61µs ± 0%             2.62µs ± 1%   +0.32%        (p=0.018 n=17+20)
BM_StreamingPingPongMsgs<MinInProcess, NoOpMutator, NoOpMutator>/32768                            [polls/iter:0                              ]            21.7µs ± 1%             21.9µs ± 2%   +0.63%        (p=0.041 n=19+20)
BM_StreamingPingPongMsgs<MinInProcess, NoOpMutator, NoOpMutator>/2097152                          [polls/iter:0                              ]             2.04ms ± 8%             1.89ms ± 2%   -7.42%        (p=0.006 n=20+20)
BM_StreamingPingPongMsgs<MinInProcess, NoOpMutator, NoOpMutator>/16777216                         [polls/iter:0                              ]             32.5ms ± 7%             28.5ms ± 2%  -12.22%        (p=0.000 n=20+20)
BM_StreamingPingPongMsgs<MinInProcess, NoOpMutator, NoOpMutator>/134217728                        [polls/iter:0                              ]              327ms ± 1%              320ms ± 2%   -2.33%        (p=0.000 n=17+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/0/0/0                  [polls/iter:0                              ]            5.37µs ± 1%             5.31µs ± 2%   -1.06%        (p=0.000 n=19+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/0/0/1                  [polls/iter:0                              ]            5.37µs ± 1%             5.31µs ± 1%   -1.02%        (p=0.000 n=20+18)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/0/1/0                  [polls/iter:0                              ]            7.66µs ± 1%             7.59µs ± 1%   -0.91%        (p=0.000 n=20+19)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/0/2/0                  [polls/iter:0                              ]            10.4µs ± 1%             10.3µs ± 1%   -0.99%        (p=0.000 n=20+19)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/1/1/0                  [polls/iter:0                              ]            7.93µs ± 2%             7.82µs ± 1%   -1.31%        (p=0.000 n=20+19)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/1/2/0                  [polls/iter:0                              ]            10.8µs ± 1%             10.7µs ± 1%   -0.96%        (p=0.000 n=20+17)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/1/2/1                  [polls/iter:0                              ]            10.4µs ± 1%             10.4µs ± 1%   -0.30%        (p=0.038 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/8/1/0                  [polls/iter:0                              ]            7.91µs ± 1%             7.83µs ± 1%   -1.03%        (p=0.000 n=20+19)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/8/2/0                  [polls/iter:0                              ]            10.8µs ± 1%             10.7µs ± 1%   -0.45%        (p=0.003 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/64/1/0                 [polls/iter:0                              ]            8.02µs ± 1%             7.96µs ± 1%   -0.70%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/64/2/0                 [polls/iter:0                              ]            11.0µs ± 1%             10.9µs ± 1%   -0.56%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/512/1/0                [polls/iter:0                              ]            8.31µs ± 1%             8.24µs ± 1%   -0.84%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/512/2/0                [polls/iter:0                              ]            11.5µs ± 1%             11.4µs ± 1%   -0.66%        (p=0.000 n=18+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/512/2/1                [polls/iter:0                              ]            11.1µs ± 1%             11.1µs ± 1%   -0.33%        (p=0.016 n=19+18)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/4096/1/0               [polls/iter:0                              ]            10.4µs ± 2%             10.3µs ± 2%   -0.70%        (p=0.015 n=19+19)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/2097152/1/0            [polls/iter:0                              ]             2.02ms ± 7%             1.90ms ± 2%   -6.22%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/2097152/2/0            [polls/iter:0                              ]             4.03ms ± 7%             3.79ms ± 1%   -6.14%        (p=0.001 n=20+18)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/2097152/1/1            [polls/iter:0                              ]             2.02ms ± 7%             1.90ms ± 1%   -6.13%        (p=0.004 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/2097152/2/1            [polls/iter:0                              ]             4.03ms ± 7%             3.78ms ± 1%   -6.20%        (p=0.004 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/16777216/1/0           [polls/iter:0                              ]             32.3ms ± 6%             28.5ms ± 3%  -11.64%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/16777216/2/0           [polls/iter:0                              ]             64.8ms ± 6%             57.0ms ± 3%  -12.10%        (p=0.000 n=19+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/16777216/1/1           [polls/iter:0                              ]             32.2ms ± 7%             28.5ms ± 3%  -11.41%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/16777216/2/1           [polls/iter:0                              ]             63.8ms ± 6%             57.0ms ± 3%  -10.55%        (p=0.000 n=19+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/134217728/1/0          [polls/iter:0                              ]              327ms ± 1%              321ms ± 2%   -1.79%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/134217728/2/0          [polls/iter:0                              ]              653ms ± 1%              641ms ± 2%   -1.83%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/134217728/1/1          [polls/iter:0                              ]              327ms ± 1%              321ms ± 2%   -1.86%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/134217728/2/1          [polls/iter:0                              ]              654ms ± 1%              640ms ± 2%   -2.00%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/0/0/0               [polls/iter:0                              ]            5.28µs ± 1%             5.23µs ± 2%   -0.84%        (p=0.001 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/0/0/1               [polls/iter:0                              ]            5.27µs ± 2%             5.24µs ± 1%   -0.68%        (p=0.004 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/0/1/0               [polls/iter:0                              ]            7.59µs ± 2%             7.53µs ± 1%   -0.82%        (p=0.000 n=20+19)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/0/2/0               [polls/iter:0                              ]            10.2µs ± 1%             10.2µs ± 1%   -0.58%        (p=0.001 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/0/1/1               [polls/iter:0                              ]            7.16µs ± 1%             7.11µs ± 1%   -0.76%        (p=0.000 n=20+19)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/1/1/0               [polls/iter:0                              ]            7.83µs ± 1%             7.75µs ± 1%   -1.00%        (p=0.000 n=20+18)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/1/2/0               [polls/iter:0                              ]            10.7µs ± 1%             10.6µs ± 1%   -0.66%        (p=0.000 n=19+18)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/1/2/1               [polls/iter:0                              ]            10.3µs ± 1%             10.2µs ± 1%   -0.40%        (p=0.003 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/8/1/0               [polls/iter:0                              ]            7.82µs ± 1%             7.76µs ± 1%   -0.72%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/8/2/0               [polls/iter:0                              ]            10.7µs ± 1%             10.6µs ± 1%   -0.46%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/64/1/0              [polls/iter:0                              ]            7.94µs ± 1%             7.89µs ± 1%   -0.62%        (p=0.003 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/64/1/1              [polls/iter:0                              ]            7.54µs ± 2%             7.88µs ± 6%   +4.56%        (p=0.000 n=19+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/512/1/0             [polls/iter:0                              ]            8.24µs ± 1%             8.18µs ± 1%   -0.79%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/512/2/0             [polls/iter:0                              ]            11.4µs ± 1%             11.3µs ± 1%   -0.58%        (p=0.000 n=19+19)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/512/1/1             [polls/iter:0                              ]            7.83µs ± 1%             8.13µs ± 5%   +3.85%        (p=0.002 n=17+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/512/2/1             [polls/iter:0                              ]            11.0µs ± 1%             11.0µs ± 1%   -0.31%        (p=0.021 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/4096/1/0            [polls/iter:0                              ]            10.3µs ± 1%             10.2µs ± 3%   -0.96%        (p=0.003 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/4096/2/0            [polls/iter:0                              ]            15.4µs ± 1%             15.3µs ± 2%   -0.54%        (p=0.035 n=19+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/2097152/1/0         [polls/iter:0                              ]             2.02ms ± 7%             1.90ms ± 1%   -6.05%        (p=0.003 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/2097152/2/0         [polls/iter:0                              ]             4.03ms ± 7%             3.79ms ± 1%   -6.10%        (p=0.004 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/2097152/1/1         [polls/iter:0                              ]             2.02ms ± 7%             1.90ms ± 1%   -6.13%        (p=0.001 n=20+19)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/2097152/2/1         [polls/iter:0                              ]             4.03ms ± 7%             3.78ms ± 1%   -6.11%        (p=0.001 n=20+19)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/16777216/1/0        [polls/iter:0                              ]             32.3ms ± 7%             28.5ms ± 3%  -11.76%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/16777216/2/0        [polls/iter:0                              ]             64.4ms ± 4%             57.2ms ± 3%  -11.20%        (p=0.000 n=16+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/16777216/1/1        [polls/iter:0                              ]             32.2ms ± 6%             28.6ms ± 3%  -11.18%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/16777216/2/1        [polls/iter:0                              ]             63.8ms ± 7%             57.1ms ± 2%  -10.47%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/134217728/1/0       [polls/iter:0                              ]              327ms ± 1%              320ms ± 2%   -1.95%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/134217728/2/0       [polls/iter:0                              ]              654ms ± 1%              641ms ± 1%   -2.01%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/134217728/1/1       [polls/iter:0                              ]              327ms ± 1%              320ms ± 2%   -2.17%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/134217728/2/1       [polls/iter:0                              ]              655ms ± 1%              641ms ± 1%   -2.13%        (p=0.000 n=20+20)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/0/2                                           [polls/iter:12.0001                        ]            60.9µs ± 3%             59.5µs ± 1%   -2.28%          (p=0.002 n=8+7)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/64/2                                          [polls/iter:12.0001                        ]            64.1µs ± 1%             63.3µs ± 0%   -1.32%          (p=0.016 n=5+4)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/8/2                                        [polls/iter:12.0001                        ]            61.7µs ± 3%             60.4µs ± 1%   -2.10%          (p=0.032 n=5+4)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/64/1                                          [polls/iter:8.00012                        ]            47.0µs ± 1%             46.2µs ± 2%   -1.84%          (p=0.048 n=3+6)
BM_StreamingPingPongMsgs<TCP, NoOpMutator, NoOpMutator>/0                                         [polls/iter:4.00008                        ]            15.5µs ± 2%             15.3µs ± 2%   -1.53%          (p=0.048 n=5+7)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/8/2                                           [polls/iter:12                             ]            63.9µs ± 4%             61.7µs ± 1%   -3.44%          (p=0.032 n=5+4)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/8/2                                        [polls/iter:12                             ]            61.9µs ± 1%             60.9µs ± 2%   -1.65%          (p=0.032 n=5+5)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/32768/1                                    [polls/iter:8.00019                        ]            71.7µs ± 1%             70.9µs ± 0%   -1.13%          (p=0.038 n=6+4)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/8/8                                                   [polls/iter:0                              ]            6.70µs ± 8%             6.62µs ± 7%   -1.12%        (p=0.049 n=20+20)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/64/0                                                  [polls/iter:0                              ]            6.61µs ± 6%             6.47µs ± 1%   -2.15%        (p=0.001 n=20+17)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/64                                                  [polls/iter:0                              ]            6.59µs ± 6%             6.44µs ± 3%   -2.17%        (p=0.000 n=19+18)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/512                                                 [polls/iter:0                              ]            6.81µs ± 6%             6.70µs ± 7%   -1.61%        (p=0.008 n=20+19)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/4096/0                                                [polls/iter:0                              ]            7.76µs ± 3%             7.68µs ± 2%   -0.98%        (p=0.011 n=18+19)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/4096                                                [polls/iter:0                              ]            7.75µs ± 2%             7.71µs ± 2%   -0.60%        (p=0.030 n=19+20)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/32768/0                                               [polls/iter:0                              ]            15.9µs ± 1%             15.9µs ± 1%   -0.20%        (p=0.022 n=19+20)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/32768                                               [polls/iter:0                              ]            16.3µs ± 1%             16.2µs ± 2%   -0.54%        (p=0.021 n=20+20)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/262144/0                                              [polls/iter:0                              ]            86.3µs ± 1%             86.0µs ± 1%   -0.42%        (p=0.003 n=17+18)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/16777216/0                                            [polls/iter:0                              ]             17.8ms ± 6%             15.6ms ± 3%  -12.50%        (p=0.000 n=20+20)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/16777216                                            [polls/iter:0                              ]             16.1ms ± 8%             13.9ms ± 2%  -14.01%        (p=0.000 n=20+17)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/16777216/16777216                                     [polls/iter:0                              ]             35.4ms ± 6%             31.2ms ± 2%  -11.76%        (p=0.000 n=20+20)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/134217728/0                                           [polls/iter:0                              ]              178ms ± 2%              176ms ± 1%   -1.60%        (p=0.000 n=20+20)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/134217728                                           [polls/iter:0                              ]              160ms ± 2%              158ms ± 1%   -1.66%        (p=0.000 n=20+20)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/134217728/134217728                                   [polls/iter:0                              ]              341ms ± 2%              336ms ± 1%   -1.53%        (p=0.000 n=20+20)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/1/0                                                [polls/iter:0                              ]            6.58µs ± 5%             6.28µs ± 2%   -4.44%        (p=0.000 n=20+17)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/1                                                [polls/iter:0                              ]            6.54µs ± 5%             6.24µs ± 1%   -4.59%        (p=0.000 n=20+17)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/1/1                                                [polls/iter:0                              ]            6.64µs ± 8%             6.41µs ± 3%   -3.54%        (p=0.000 n=20+19)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/8/0                                                [polls/iter:0                              ]            6.50µs ± 8%             6.25µs ± 1%   -3.85%        (p=0.000 n=20+17)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/8                                                [polls/iter:0                              ]            6.42µs ± 3%             6.23µs ± 1%   -3.00%        (p=0.000 n=19+16)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/8/8                                                [polls/iter:0                              ]            6.64µs ± 8%             6.36µs ± 1%   -4.23%        (p=0.000 n=20+19)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/64/0                                               [polls/iter:0                              ]            6.43µs ± 2%             6.36µs ± 1%   -1.20%        (p=0.000 n=18+18)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/64                                               [polls/iter:0                              ]            6.48µs ± 4%             6.34µs ± 2%   -2.21%        (p=0.000 n=19+17)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/64/64                                              [polls/iter:0                              ]            6.59µs ± 2%             6.53µs ± 1%   -0.93%        (p=0.000 n=17+20)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/512/0                                              [polls/iter:0                              ]            6.61µs ± 2%             6.49µs ± 1%   -1.79%        (p=0.000 n=18+19)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/512                                              [polls/iter:0                              ]            6.62µs ± 2%             6.51µs ± 1%   -1.56%        (p=0.000 n=18+18)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/512/512                                            [polls/iter:0                              ]            6.87µs ± 1%             6.83µs ± 2%   -0.49%        (p=0.022 n=16+19)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/4096/0                                             [polls/iter:0                              ]            7.66µs ± 2%             7.58µs ± 1%   -1.09%        (p=0.000 n=16+20)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/4096                                             [polls/iter:0                              ]            7.71µs ± 4%             7.59µs ± 1%   -1.58%        (p=0.000 n=17+19)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/32768/0                                            [polls/iter:0                              ]            15.9µs ± 1%             15.8µs ± 1%   -0.36%        (p=0.002 n=18+19)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/32768/32768                                        [polls/iter:0                              ]            25.5µs ± 1%             25.7µs ± 2%   +0.85%        (p=0.002 n=17+20)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/262144/262144                                      [polls/iter:0                              ]             168µs ± 2%              169µs ± 2%   +0.61%        (p=0.048 n=17+20)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/16777216/0                                         [polls/iter:0                              ]             17.8ms ±10%             15.5ms ± 5%  -13.12%        (p=0.000 n=20+20)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/16777216                                         [polls/iter:0                              ]             16.2ms ± 6%             13.8ms ± 3%  -14.41%        (p=0.000 n=20+20)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/16777216/16777216                                  [polls/iter:0                              ]             35.3ms ± 7%             31.2ms ± 2%  -11.56%        (p=0.000 n=20+19)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/134217728/0                                        [polls/iter:0                              ]              179ms ± 1%              176ms ± 1%   -1.67%        (p=0.000 n=18+18)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/134217728                                        [polls/iter:0                              ]              161ms ± 1%              158ms ± 1%   -1.80%        (p=0.000 n=19+18)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/134217728/134217728                                [polls/iter:0                              ]              342ms ± 1%              336ms ± 1%   -1.70%        (p=0.000 n=20+19)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomBinaryMetadata<10>, 1>, NoOpMutator>/0/0               [polls/iter:0                              ]            6.99µs ± 1%             7.20µs ± 5%   +3.11%        (p=0.026 n=17+20)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomBinaryMetadata<31>, 1>, NoOpMutator>/0/0               [polls/iter:0                              ]            7.19µs ± 5%             7.34µs ± 4%   +2.13%        (p=0.024 n=20+20)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomBinaryMetadata<100>, 1>, NoOpMutator>/0/0              [polls/iter:0                              ]            7.15µs ± 2%             7.31µs ± 5%   +2.20%        (p=0.028 n=16+20)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomBinaryMetadata<10>, 1>>/0/0        [polls/iter:0                              ]            7.11µs ± 5%             6.93µs ± 4%   -2.52%        (p=0.000 n=19+17)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomBinaryMetadata<31>, 1>>/0/0        [polls/iter:0                              ]            7.21µs ± 5%             7.08µs ± 2%   -1.83%        (p=0.011 n=20+18)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomBinaryMetadata<100>, 1>>/0/0       [polls/iter:0                              ]            7.19µs ± 2%             7.08µs ± 2%   -1.60%        (p=0.000 n=17+18)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomAsciiMetadata<10>, 1>>/0/0         [polls/iter:0                              ]            7.06µs ± 3%             7.00µs ± 6%   -0.79%        (p=0.005 n=18+19)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomAsciiMetadata<31>, 1>>/0/0         [polls/iter:0                              ]            7.18µs ± 2%             7.05µs ± 2%   -1.71%        (p=0.000 n=18+17)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomAsciiMetadata<100>, 1>>/0/0        [polls/iter:0                              ]            7.36µs ± 2%             7.23µs ± 1%   -1.78%        (p=0.000 n=18+18)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomAsciiMetadata<10>, 100>>/0/0       [polls/iter:0                              ]            75.7µs ± 2%             74.8µs ± 2%   -1.12%        (p=0.001 n=18+19)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/64/0                                                        [polls/iter:3.0001                         ]            25.6µs ± 1%             24.7µs ± 1%   -3.61%          (p=0.036 n=3+5)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/64/64                                                    [polls/iter:3.00008                        ]            25.0µs ± 3%             24.5µs ± 1%   -1.88%          (p=0.030 n=7+5)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/262144                                                    [polls/iter:3.00034                        ]             169µs ± 1%              167µs ± 1%   -1.11%          (p=0.016 n=4+5)
BM_UnaryPingPong<MinTCP, NoOpMutator, NoOpMutator>/0/8                                                      [polls/iter:3.00006                        ]            24.1µs ± 3%             23.4µs ± 1%   -3.03%          (p=0.032 n=4+5)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/0                                                         [polls/iter:3.00008                        ]            24.2µs ± 3%             23.3µs ± 0%   -3.46%          (p=0.016 n=5+4)
```