### PR TITLE
Avoid creating and copying strings when Status is OK in FinishOp.

### DIFF
--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -772,19 +772,23 @@ class CallOpClientRecvStatus {
 
   void FinishOp(bool* /*status*/) {
     if (recv_status_ == nullptr || hijacked_) return;
-    grpc::string binary_error_details = metadata_map_->GetBinaryErrorDetails();
-    *recv_status_ =
-        Status(static_cast<StatusCode>(status_code_),
-               GRPC_SLICE_IS_EMPTY(error_message_)
-                   ? grpc::string()
-                   : grpc::string(GRPC_SLICE_START_PTR(error_message_),
-                                  GRPC_SLICE_END_PTR(error_message_)),
-               binary_error_details);
-    client_context_->set_debug_error_string(
-        debug_error_string_ != nullptr ? debug_error_string_ : "");
-    g_core_codegen_interface->grpc_slice_unref(error_message_);
-    if (debug_error_string_ != nullptr) {
-      g_core_codegen_interface->gpr_free((void*)debug_error_string_);
+    if (status_code_ == StatusCode::OK) {
+      *recv_status_ = Status();
+      GPR_CODEGEN_DEBUG_ASSERT(GRPC_SLICE_IS_EMPTY(error_message_));
+      GPR_CODEGEN_DEBUG_ASSERT(debug_error_string_ == nullptr);
+    } else {
+      *recv_status_ =
+          Status(static_cast<StatusCode>(status_code_),
+                 GRPC_SLICE_IS_EMPTY(error_message_)
+                     ? grpc::string()
+                     : grpc::string(GRPC_SLICE_START_PTR(error_message_),
+                                    GRPC_SLICE_END_PTR(error_message_)),
+                 metadata_map_->GetBinaryErrorDetails());
+      g_core_codegen_interface->grpc_slice_unref(error_message_);
+      if (debug_error_string_ != nullptr) {
+        client_context_->set_debug_error_string(debug_error_string_);
+        g_core_codegen_interface->gpr_free((void*)debug_error_string_);
+      }
     }
   }
 


### PR DESCRIPTION
```
BM_PumpStreamClientToServer<InProcess>/0               [polls/iter:0                              ]            1.22µs ± 1%             1.21µs ± 2%  -0.73%        (p=0.002 n=19+19)
BM_PumpStreamClientToServer<InProcess>/8               [polls/iter:0                              ]            1.33µs ± 1%             1.33µs ± 1%  -0.71%        (p=0.000 n=18+18)
BM_PumpStreamClientToServer<InProcess>/134217728       [polls/iter:0                              ]              161ms ± 1%              160ms ± 1%  -0.67%        (p=0.002 n=16+20)
BM_PumpStreamServerToClient<InProcess>/0               [polls/iter:0                              ]            1.22µs ± 1%             1.21µs ± 1%  -1.51%        (p=0.000 n=18+18)
BM_PumpStreamServerToClient<InProcess>/1               [polls/iter:0                              ]            1.32µs ± 1%             1.31µs ± 1%  -0.81%        (p=0.000 n=16+20)
BM_PumpStreamServerToClient<InProcess>/8               [polls/iter:0                              ]            1.33µs ± 1%             1.32µs ± 1%  -0.97%        (p=0.000 n=17+20)
BM_PumpStreamServerToClient<InProcess>/64              [polls/iter:0                              ]            1.36µs ± 1%             1.36µs ± 1%  -0.43%        (p=0.020 n=17+20)
BM_PumpStreamServerToClient<InProcess>/32768           [polls/iter:0                              ]            10.9µs ± 2%             10.8µs ± 2%  -0.71%        (p=0.022 n=18+20)
BM_PumpStreamClientToServer<MinInProcess>/0            [polls/iter:0                              ]            1.21µs ± 1%             1.20µs ± 1%  -0.89%        (p=0.000 n=18+19)
BM_PumpStreamServerToClient<MinInProcess>/0            [polls/iter:0                              ]            1.22µs ± 1%             1.20µs ± 1%  -1.40%        (p=0.000 n=18+19)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/0                                                   [polls/iter:0                              ]            6.48µs ± 5%             6.25µs ± 4%  -3.45%        (p=0.000 n=20+17)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/1/0                                                   [polls/iter:0                              ]            6.60µs ± 6%             6.36µs ± 2%  -3.66%        (p=0.000 n=20+18)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/1                                                   [polls/iter:0                              ]            6.61µs ± 7%             6.37µs ± 3%  -3.59%        (p=0.000 n=20+17)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/1/1                                                   [polls/iter:0                              ]            6.65µs ± 6%             6.48µs ± 3%  -2.57%        (p=0.000 n=20+18)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/8                                                   [polls/iter:0                              ]            6.56µs ± 5%             6.35µs ± 3%  -3.29%        (p=0.000 n=20+18)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/8/8                                                   [polls/iter:0                              ]            6.64µs ± 6%             6.55µs ± 5%  -1.43%        (p=0.050 n=19+19)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/64                                                  [polls/iter:0                              ]            6.64µs ± 6%             6.50µs ± 4%  -2.10%        (p=0.030 n=20+19)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/64/64                                                 [polls/iter:0                              ]            6.72µs ± 4%             6.56µs ± 1%  -2.34%        (p=0.000 n=18+16)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/512/0                                                 [polls/iter:0                              ]            6.69µs ± 2%             6.55µs ± 2%  -2.12%        (p=0.000 n=17+18)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/512                                                 [polls/iter:0                              ]            6.71µs ± 2%             6.55µs ± 2%  -2.39%        (p=0.000 n=17+17)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/512/512                                               [polls/iter:0                              ]            6.97µs ± 3%             6.82µs ± 1%  -2.16%        (p=0.000 n=18+16)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/4096/0                                                [polls/iter:0                              ]            7.74µs ± 1%             7.60µs ± 1%  -1.81%        (p=0.000 n=20+16)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/4096                                                [polls/iter:0                              ]            7.77µs ± 2%             7.63µs ± 2%  -1.74%        (p=0.000 n=18+19)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/4096/4096                                             [polls/iter:0                              ]            8.98µs ± 1%             8.92µs ± 2%  -0.61%        (p=0.028 n=20+19)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/32768/0                                               [polls/iter:0                              ]            15.9µs ± 1%             15.8µs ± 0%  -0.80%        (p=0.000 n=19+15)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/0/32768                                               [polls/iter:0                              ]            16.3µs ± 1%             16.2µs ± 2%  -0.77%        (p=0.005 n=20+19)
BM_UnaryPingPong<InProcess, NoOpMutator, NoOpMutator>/262144/0                                              [polls/iter:0                              ]            86.2µs ± 1%             86.1µs ± 0%  -0.18%        (p=0.036 n=19+15)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/0                                                [polls/iter:0                              ]            6.44µs ± 6%             6.28µs ± 6%  -2.50%        (p=0.044 n=20+19)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/1/0                                                [polls/iter:0                              ]            6.62µs ± 5%             6.39µs ± 5%  -3.50%        (p=0.008 n=20+19)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/1/1                                                [polls/iter:0                              ]            6.57µs ± 7%             6.39µs ± 4%  -2.71%        (p=0.001 n=20+16)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/64/0                                               [polls/iter:0                              ]            6.41µs ± 2%             6.35µs ± 6%  -0.84%        (p=0.001 n=18+17)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/512/0                                              [polls/iter:0                              ]            6.60µs ± 3%             6.51µs ± 4%  -1.33%        (p=0.002 n=18+18)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/512                                              [polls/iter:0                              ]            6.62µs ± 2%             6.47µs ± 1%  -2.25%        (p=0.000 n=17+17)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/512/512                                            [polls/iter:0                              ]            6.87µs ± 1%             6.76µs ± 1%  -1.54%        (p=0.000 n=18+17)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/4096/0                                             [polls/iter:0                              ]            7.65µs ± 2%             7.59µs ± 3%  -0.82%        (p=0.006 n=18+18)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/4096                                             [polls/iter:0                              ]            7.66µs ± 1%             7.54µs ± 2%  -1.52%        (p=0.000 n=18+19)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/4096/4096                                          [polls/iter:0                              ]            8.91µs ± 2%             8.80µs ± 1%  -1.20%        (p=0.000 n=18+18)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/32768/0                                            [polls/iter:0                              ]            15.8µs ± 0%             15.7µs ± 0%  -0.80%        (p=0.000 n=17+16)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/32768                                            [polls/iter:0                              ]            16.3µs ± 2%             16.1µs ± 1%  -1.21%        (p=0.000 n=20+19)
BM_UnaryPingPong<MinInProcess, NoOpMutator, NoOpMutator>/32768/32768                                        [polls/iter:0                              ]            25.6µs ± 2%             25.4µs ± 1%  -0.66%        (p=0.002 n=19+18)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomBinaryMetadata<31>, 1>, NoOpMutator>/0/0               [polls/iter:0                              ]            7.16µs ± 5%             7.05µs ± 2%  -1.45%        (p=0.012 n=19+19)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomBinaryMetadata<100>, 1>, NoOpMutator>/0/0              [polls/iter:0                              ]            7.29µs ± 5%             7.12µs ± 2%  -2.43%        (p=0.001 n=20+19)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomBinaryMetadata<10>, 2>, NoOpMutator>/0/0               [polls/iter:0                              ]            7.66µs ± 3%             7.56µs ± 2%  -1.28%        (p=0.001 n=17+17)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomBinaryMetadata<31>, 2>, NoOpMutator>/0/0               [polls/iter:0                              ]            7.83µs ± 3%             7.70µs ± 2%  -1.60%        (p=0.000 n=18+19)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomBinaryMetadata<100>, 2>, NoOpMutator>/0/0              [polls/iter:0                              ]            7.96µs ± 2%             7.83µs ± 2%  -1.54%        (p=0.000 n=17+19)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomBinaryMetadata<10>, 1>>/0/0        [polls/iter:0                              ]            7.13µs ± 5%             6.93µs ± 2%  -2.73%        (p=0.000 n=20+19)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomBinaryMetadata<31>, 1>>/0/0        [polls/iter:0                              ]            7.14µs ± 2%             7.01µs ± 2%  -1.88%        (p=0.000 n=17+19)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomBinaryMetadata<100>, 1>>/0/0       [polls/iter:0                              ]            7.24µs ± 2%             7.09µs ± 2%  -2.17%        (p=0.000 n=18+20)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomAsciiMetadata<10>, 1>, NoOpMutator>/0/0                [polls/iter:0                              ]            6.96µs ± 1%             6.93µs ± 2%  -0.53%        (p=0.004 n=17+18)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomAsciiMetadata<31>, 1>, NoOpMutator>/0/0                [polls/iter:0                              ]            7.08µs ± 2%             6.99µs ± 1%  -1.32%        (p=0.000 n=17+19)
BM_UnaryPingPong<InProcess, Client_AddMetadata<RandomAsciiMetadata<100>, 1>, NoOpMutator>/0/0               [polls/iter:0                              ]            7.26µs ± 3%             7.19µs ± 1%  -1.01%        (p=0.000 n=17+20)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomAsciiMetadata<10>, 1>>/0/0         [polls/iter:0                              ]            7.09µs ± 4%             6.89µs ± 1%  -2.84%        (p=0.000 n=19+19)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomAsciiMetadata<31>, 1>>/0/0         [polls/iter:0                              ]            7.14µs ± 2%             7.05µs ± 2%  -1.39%        (p=0.000 n=16+19)
BM_UnaryPingPong<InProcess, NoOpMutator, Server_AddInitialMetadata<RandomAsciiMetadata<100>, 1>>/0/0        [polls/iter:0                              ]            7.37µs ± 4%             7.18µs ± 1%  -2.62%        (p=0.000 n=18+18)
BM_UnaryPingPong<TCP, NoOpMutator, NoOpMutator>/0/0                                                         [polls/iter:3.00009                        ]            23.6µs ± 0%             23.5µs ± 0%  -0.47%          (p=0.024 n=6+3)
BM_UnaryPingPong<UDS, NoOpMutator, NoOpMutator>/0/0                                                         [polls/iter:3.00012                        ]            20.7µs ± 1%             20.4µs ± 0%  -1.50%          (p=0.029 n=4+4)
BM_UnaryPingPong<MinUDS, NoOpMutator, NoOpMutator>/0/0                                                      [polls/iter:3.00017                        ]            19.9µs ± 1%             19.7µs ± 1%  -1.22%          (p=0.029 n=4+4)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/1/2                                           [polls/iter:12.0001                        ]             62.2µs ± 2%             61.2µs ± 1%  -1.54%          (p=0.029 n=9+5)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/64/2                                          [polls/iter:12.0001                        ]             64.6µs ± 1%             63.1µs ± 0%  -2.28%          (p=0.003 n=7+5)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/0/0                                     [polls/iter:0                              ]             5.71µs ± 1%             5.65µs ± 1%  -1.00%        (p=0.000 n=19+18)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/0/1                                     [polls/iter:0                              ]             8.46µs ± 1%             8.39µs ± 1%  -0.82%        (p=0.000 n=19+19)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/0/2                                     [polls/iter:0                              ]             11.1µs ± 1%             11.0µs ± 1%  -0.42%        (p=0.013 n=20+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/1/1                                     [polls/iter:0                              ]             8.72µs ± 1%             8.66µs ± 1%  -0.80%        (p=0.000 n=20+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/1/2                                     [polls/iter:0                              ]             11.6µs ± 1%             11.5µs ± 1%  -0.37%        (p=0.012 n=20+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/8/1                                     [polls/iter:0                              ]             8.72µs ± 1%             8.66µs ± 1%  -0.64%        (p=0.000 n=19+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/64/1                                    [polls/iter:0                              ]             8.86µs ± 1%             8.82µs ± 1%  -0.47%        (p=0.000 n=20+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/64/2                                    [polls/iter:0                              ]             11.8µs ± 1%             11.7µs ± 1%  -0.49%        (p=0.000 n=19+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/512/1                                   [polls/iter:0                              ]             9.14µs ± 1%             9.08µs ± 0%  -0.65%        (p=0.000 n=20+16)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/512/2                                   [polls/iter:0                              ]             12.3µs ± 0%             12.3µs ± 1%  -0.43%        (p=0.000 n=19+19)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/4096/1                                  [polls/iter:0                              ]             11.2µs ± 1%             11.1µs ± 1%  -0.60%        (p=0.000 n=19+20)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/262144/1                                [polls/iter:0                              ]              169µs ± 1%              171µs ± 2%  +0.98%        (p=0.000 n=20+19)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/262144/2                                [polls/iter:0                              ]              329µs ± 1%              331µs ± 2%  +0.66%        (p=0.007 n=18+19)
BM_StreamingPingPong<InProcess, NoOpMutator, NoOpMutator>/2097152/1                               [polls/iter:0                              ]              2.08ms ±10%             2.14ms ± 1%  +3.13%        (p=0.043 n=20+15)
BM_StreamingPingPongMsgs<TCP, NoOpMutator, NoOpMutator>/8                                         [polls/iter:4.00007                        ]             16.4µs ± 2%             16.1µs ± 0%  -2.00%          (p=0.036 n=5+3)
BM_StreamingPingPongMsgs<InProcess, NoOpMutator, NoOpMutator>/0                                   [polls/iter:0                              ]             2.45µs ± 1%             2.44µs ± 1%  -0.60%        (p=0.006 n=20+20)
BM_StreamingPingPongMsgs<InProcess, NoOpMutator, NoOpMutator>/1                                   [polls/iter:0                              ]             2.65µs ± 1%             2.67µs ± 1%  +0.75%        (p=0.000 n=20+20)
BM_StreamingPingPongMsgs<InProcess, NoOpMutator, NoOpMutator>/8                                   [polls/iter:0                              ]             2.65µs ± 1%             2.67µs ± 1%  +0.85%        (p=0.000 n=20+20)
BM_StreamingPingPongMsgs<InProcess, NoOpMutator, NoOpMutator>/512                                 [polls/iter:0                              ]             2.96µs ± 1%             2.98µs ± 1%  +0.52%        (p=0.009 n=20+20)
BM_StreamingPingPongMsgs<InProcess, NoOpMutator, NoOpMutator>/4096                                [polls/iter:0                              ]             4.83µs ± 2%             4.88µs ± 4%  +1.19%        (p=0.005 n=19+20)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/512/2                                      [polls/iter:12.0001                        ]             64.2µs ± 1%             63.4µs ± 1%  -1.36%          (p=0.017 n=5+6)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/0                                  [polls/iter:0                              ]             5.71µs ± 1%             5.63µs ± 1%  -1.51%        (p=0.000 n=18+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/1                                  [polls/iter:0                              ]             8.43µs ± 1%             8.34µs ± 1%  -1.10%        (p=0.000 n=20+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/0/2                                  [polls/iter:0                              ]             11.0µs ± 1%             11.0µs ± 0%  -0.57%        (p=0.000 n=19+15)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/1/1                                  [polls/iter:0                              ]             8.68µs ± 1%             8.59µs ± 1%  -1.07%        (p=0.000 n=17+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/1/2                                  [polls/iter:0                              ]             11.5µs ± 1%             11.4µs ± 1%  -0.34%        (p=0.002 n=19+19)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/8/1                                  [polls/iter:0                              ]             8.71µs ± 1%             8.59µs ± 1%  -1.47%        (p=0.000 n=20+18)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/64/1                                 [polls/iter:0                              ]             8.82µs ± 1%             8.76µs ± 1%  -0.75%        (p=0.000 n=20+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/64/2                                 [polls/iter:0                              ]             11.7µs ± 1%             11.7µs ± 1%  -0.48%        (p=0.000 n=20+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/512/1                                [polls/iter:0                              ]             9.13µs ± 1%             9.04µs ± 1%  -0.96%        (p=0.000 n=20+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/4096/1                               [polls/iter:0                              ]             11.1µs ± 1%             11.0µs ± 1%  -0.67%        (p=0.002 n=19+20)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/32768/1                              [polls/iter:0                              ]             28.1µs ± 1%             28.0µs ± 1%  -0.54%        (p=0.016 n=19+18)
BM_StreamingPingPong<MinInProcess, NoOpMutator, NoOpMutator>/16777216/2                           [polls/iter:0                              ]              64.1ms ± 5%             65.2ms ± 4%  +1.66%        (p=0.020 n=19+19)
BM_StreamingPingPongMsgs<MinInProcess, NoOpMutator, NoOpMutator>/0                                [polls/iter:0                              ]             2.43µs ± 1%             2.42µs ± 1%  -0.50%        (p=0.000 n=19+18)
BM_StreamingPingPongMsgs<MinInProcess, NoOpMutator, NoOpMutator>/1                                [polls/iter:0                              ]             2.62µs ± 1%             2.64µs ± 0%  +0.55%        (p=0.000 n=20+18)
BM_StreamingPingPongMsgs<MinInProcess, NoOpMutator, NoOpMutator>/8                                [polls/iter:0                              ]             2.62µs ± 1%             2.64µs ± 1%  +0.64%        (p=0.000 n=20+19)
BM_StreamingPingPongMsgs<MinInProcess, NoOpMutator, NoOpMutator>/64                               [polls/iter:0                              ]             2.71µs ± 1%             2.71µs ± 1%  -0.32%        (p=0.015 n=19+19)
BM_StreamingPingPongMsgs<MinInProcess, NoOpMutator, NoOpMutator>/512                              [polls/iter:0                              ]             2.94µs ± 1%             2.95µs ± 1%  +0.32%        (p=0.024 n=20+19)
BM_StreamingPingPongWithCoalescingApi<InProcessCHTTP2, NoOpMutator, NoOpMutator>/134217728/1/0    [polls/iter:5.75 writes/iter:10            ]               419ms ± 0%              417ms ± 1%  -0.55%          (p=0.030 n=5+7)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/0/0/0                  [polls/iter:0                              ]             5.36µs ± 1%             5.27µs ± 1%  -1.80%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/0/0/1                  [polls/iter:0                              ]             5.36µs ± 1%             5.28µs ± 1%  -1.51%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/0/1/0                  [polls/iter:0                              ]             7.65µs ± 1%             7.59µs ± 1%  -0.76%        (p=0.000 n=17+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/0/2/0                  [polls/iter:0                              ]             10.4µs ± 1%             10.3µs ± 1%  -0.44%        (p=0.021 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/0/1/1                  [polls/iter:0                              ]             7.22µs ± 2%             7.12µs ± 1%  -1.36%        (p=0.000 n=18+18)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/1/1/0                  [polls/iter:0                              ]             7.91µs ± 1%             7.84µs ± 1%  -0.96%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/1/2/0                  [polls/iter:0                              ]             10.8µs ± 1%             10.8µs ± 1%  -0.44%        (p=0.008 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/1/1/1                  [polls/iter:0                              ]             7.48µs ± 2%             7.36µs ± 1%  -1.65%        (p=0.000 n=18+18)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/1/2/1                  [polls/iter:0                              ]             10.4µs ± 1%             10.3µs ± 1%  -0.50%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/8/1/0                  [polls/iter:0                              ]             7.89µs ± 1%             7.84µs ± 1%  -0.58%        (p=0.000 n=19+19)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/8/1/1                  [polls/iter:0                              ]             7.47µs ± 1%             7.40µs ± 1%  -0.94%        (p=0.000 n=18+18)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/64/2/0                 [polls/iter:0                              ]             11.0µs ± 1%             10.9µs ± 1%  -0.31%        (p=0.034 n=19+19)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/64/1/1                 [polls/iter:0                              ]             7.77µs ± 7%             7.49µs ± 1%  -3.67%        (p=0.000 n=20+19)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/64/2/1                 [polls/iter:0                              ]             10.6µs ± 1%             10.6µs ± 1%  -0.45%        (p=0.001 n=19+19)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/512/1/0                [polls/iter:0                              ]             8.30µs ± 1%             8.26µs ± 1%  -0.50%        (p=0.002 n=19+18)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/512/1/1                [polls/iter:0                              ]             7.87µs ± 1%             7.76µs ± 1%  -1.36%        (p=0.000 n=19+18)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/512/2/1                [polls/iter:0                              ]             11.1µs ± 1%             11.1µs ± 1%  -0.38%        (p=0.013 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/4096/1/0               [polls/iter:0                              ]             10.4µs ± 2%             10.3µs ± 2%  -0.85%        (p=0.009 n=20+19)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/4096/2/0               [polls/iter:0                              ]             15.5µs ± 2%             15.4µs ± 2%  -0.65%        (p=0.033 n=20+20)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/4096/1/1               [polls/iter:0                              ]             10.0µs ± 1%              9.8µs ± 2%  -1.54%        (p=0.000 n=20+19)
BM_StreamingPingPongWithCoalescingApi<InProcess, NoOpMutator, NoOpMutator>/4096/2/1               [polls/iter:0                              ]             15.1µs ± 2%             15.0µs ± 2%  -0.56%        (p=0.049 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/0/0/0               [polls/iter:0                              ]             5.27µs ± 1%             5.18µs ± 1%  -1.64%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/0/0/1               [polls/iter:0                              ]             5.27µs ± 1%             5.19µs ± 1%  -1.52%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/0/1/0               [polls/iter:0                              ]             7.58µs ± 1%             7.49µs ± 1%  -1.17%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/0/2/0               [polls/iter:0                              ]             10.2µs ± 1%             10.1µs ± 1%  -0.97%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/0/1/1               [polls/iter:0                              ]             7.16µs ± 1%             7.11µs ± 3%  -0.67%        (p=0.011 n=19+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/0/2/1               [polls/iter:0                              ]             9.81µs ± 1%             9.76µs ± 1%  -0.56%        (p=0.001 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/1/1/0               [polls/iter:0                              ]             7.82µs ± 1%             7.72µs ± 1%  -1.31%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/1/2/0               [polls/iter:0                              ]             10.7µs ± 1%             10.6µs ± 1%  -0.82%        (p=0.000 n=19+19)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/1/1/1               [polls/iter:0                              ]             7.38µs ± 1%             7.28µs ± 1%  -1.26%        (p=0.000 n=18+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/1/2/1               [polls/iter:0                              ]             10.3µs ± 1%             10.2µs ± 1%  -0.57%        (p=0.000 n=19+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/8/1/0               [polls/iter:0                              ]             7.81µs ± 1%             7.74µs ± 1%  -0.90%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/8/2/0               [polls/iter:0                              ]             10.6µs ± 1%             10.6µs ± 1%  -0.50%        (p=0.001 n=18+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/8/1/1               [polls/iter:0                              ]             7.42µs ± 1%             7.32µs ± 1%  -1.24%        (p=0.000 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/8/2/1               [polls/iter:0                              ]             10.3µs ± 1%             10.2µs ± 1%  -0.45%        (p=0.002 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/64/1/0              [polls/iter:0                              ]             7.93µs ± 1%             7.84µs ± 0%  -1.20%        (p=0.000 n=19+18)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/64/2/0              [polls/iter:0                              ]             10.9µs ± 1%             10.8µs ± 1%  -0.60%        (p=0.000 n=18+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/64/1/1              [polls/iter:0                              ]             7.56µs ± 3%             7.43µs ± 1%  -1.64%        (p=0.000 n=19+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/64/2/1              [polls/iter:0                              ]             10.5µs ± 1%             10.5µs ± 1%  -0.64%        (p=0.000 n=20+19)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/512/1/0             [polls/iter:0                              ]             8.24µs ± 1%             8.14µs ± 1%  -1.18%        (p=0.000 n=19+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/512/2/0             [polls/iter:0                              ]             11.4µs ± 2%             11.4µs ± 1%  -0.54%        (p=0.003 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/512/1/1             [polls/iter:0                              ]             7.84µs ± 2%             7.73µs ± 1%  -1.42%        (p=0.000 n=19+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/512/2/1             [polls/iter:0                              ]             11.0µs ± 1%             11.0µs ± 1%  -0.39%        (p=0.004 n=19+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/4096/1/0            [polls/iter:0                              ]             10.3µs ± 1%             10.2µs ± 2%  -0.74%        (p=0.002 n=18+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/4096/2/0            [polls/iter:0                              ]             15.3µs ± 2%             15.3µs ± 2%  -0.59%        (p=0.035 n=20+20)
BM_StreamingPingPongWithCoalescingApi<MinInProcess, NoOpMutator, NoOpMutator>/4096/1/1            [polls/iter:0                              ]             9.92µs ± 2%             9.71µs ± 1%  -2.12%        (p=0.000 n=20+20)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/8/2                                           [polls/iter:12.0001                        ]             62.2µs ± 2%             61.2µs ± 0%  -1.65%          (p=0.002 n=8+5)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/512/2                                         [polls/iter:12.0001                        ]             65.5µs ± 2%             64.7µs ± 3%  -1.13%          (p=0.045 n=8+5)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/262144/1                                      [polls/iter:8.00022                        ]              325µs ± 1%              321µs ± 0%  -1.21%          (p=0.036 n=5+3)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/1/2                                        [polls/iter:12.0001                        ]             61.3µs ± 2%             60.1µs ± 1%  -2.01%          (p=0.008 n=7+6)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/0/2                                           [polls/iter:12                             ]             61.1µs ± 1%             59.9µs ± 1%  -1.95%          (p=0.016 n=5+5)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/64/2                                       [polls/iter:12.0001                        ]             63.5µs ± 1%             62.4µs ± 1%  -1.75%          (p=0.008 n=6+8)
BM_StreamingPingPongWithCoalescingApi<InProcessCHTTP2, NoOpMutator, NoOpMutator>/134217728/1/1    [polls/iter:5.75 writes/iter:10.25         ]               414ms ± 1%              419ms ± 0%  +1.29%          (p=0.033 n=7+3)
BM_StreamingPingPong<TCP, NoOpMutator, NoOpMutator>/512/2                                         [polls/iter:12.0002                        ]             65.6µs ± 2%             64.6µs ± 1%  -1.52%          (p=0.043 n=6+8)
BM_StreamingPingPongMsgs<TCP, NoOpMutator, NoOpMutator>/32768                                     [polls/iter:4.00009                        ]             42.8µs ± 1%             42.3µs ± 0%  -1.15%          (p=0.048 n=6+3)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/64/2                                       [polls/iter:12.0002                        ]             63.6µs ± 1%             62.4µs ± 1%  -1.86%          (p=0.032 n=4+5)
BM_StreamingPingPong<MinTCP, NoOpMutator, NoOpMutator>/4096/2                                     [polls/iter:12.0002                        ]             69.1µs ± 1%             68.4µs ± 0%  -0.97%          (p=0.036 n=5+3)
```
