### PR TITLE
Revert "Clear thread local after use"

### DIFF
--- a/src/core/lib/iomgr/executor.cc
+++ b/src/core/lib/iomgr/executor.cc
@@ -264,8 +264,6 @@ void Executor::ThreadMain(void* arg) {
     grpc_core::ExecCtx::Get()->InvalidateNow();
     subtract_depth = RunClosures(ts->name, closures);
   }
-  // Clear the thread local after use.
-  gpr_tls_set(&g_this_thread_state, reinterpret_cast<intptr_t>(nullptr));
 }
 
 void Executor::Enqueue(grpc_closure* closure, grpc_error* error,


### PR DESCRIPTION
Reverts grpc/grpc#20297

This seems to trigger some ios/macos test failures because of pre-existing problems of thread local handling. Reverting this for now to make the tests pass.