### PR TITLE
iOS performance test enhancements

### DIFF
--- a/src/objective-c/CronetFramework.podspec
+++ b/src/objective-c/CronetFramework.podspec
@@ -30,7 +30,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "CronetFramework"
-  v = '0.0.4'
+  v = '0.0.5'
   s.version      = v
   s.summary      = "Cronet, precompiled and used as a framework."
   s.homepage     = "http://chromium.org"

--- a/src/objective-c/tests/Tests.xcodeproj/xcshareddata/xcschemes/PerfTestsPosix.xcscheme
+++ b/src/objective-c/tests/Tests.xcodeproj/xcshareddata/xcschemes/PerfTestsPosix.xcscheme
@@ -5,22 +5,6 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B0F2D0B9232991BA008C2575"
-               BuildableName = "PerfTests.xctest"
-               BlueprintName = "PerfTests"
-               ReferencedContainer = "container:Tests.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Test"
@@ -45,19 +29,13 @@
                   Identifier = "PerfTestsCFStreamCleartext">
                </Test>
                <Test
-                  Identifier = "PerfTestsCronet/testPingPongRPCWithFlowControl">
+                  Identifier = "PerfTestsCFStreamSSL">
                </Test>
                <Test
-                  Identifier = "PerfTestsCronet/testPingPongRPCWithInterceptor">
-               </Test>
-               <Test
-                  Identifier = "PerfTestsCronet/testPingPongRPCWithV1API">
+                  Identifier = "PerfTestsCronet">
                </Test>
                <Test
                   Identifier = "PerfTestsNoCFStreamCleartext">
-               </Test>
-               <Test
-                  Identifier = "PerfTestsNoCFStreamSSL">
                </Test>
                <Test
                   Identifier = "PerfTestsNoCFStreamSSL/testPingPongRPCWithFlowControl">
@@ -87,15 +65,6 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "B0F2D0B9232991BA008C2575"
-            BuildableName = "PerfTests.xctest"
-            BlueprintName = "PerfTests"
-            ReferencedContainer = "container:Tests.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
@@ -105,15 +74,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "B0F2D0B9232991BA008C2575"
-            BuildableName = "PerfTests.xctest"
-            BlueprintName = "PerfTests"
-            ReferencedContainer = "container:Tests.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/tools/run_tests/run_tests.py
+++ b/tools/run_tests/run_tests.py
@@ -1189,6 +1189,24 @@ class ObjCLanguage(object):
                 }))
         out.append(
             self.config.job_spec(
+                ['src/objective-c/tests/run_one_test.sh'],
+                timeout_seconds=30 * 60,
+                shortname='ios-perf-test',
+                cpu_cost=1e6,
+                environ={
+                    'SCHEME': 'PerfTests'
+                }))
+        out.append(
+            self.config.job_spec(
+                ['src/objective-c/tests/run_one_test.sh'],
+                timeout_seconds=30 * 60,
+                shortname='ios-perf-test-posix',
+                cpu_cost=1e6,
+                environ={
+                    'SCHEME': 'PerfTestsPosix'
+                }))
+        out.append(
+            self.config.job_spec(
                 ['test/cpp/ios/build_and_run_tests.sh'],
                 timeout_seconds=20 * 60,
                 shortname='ios-cpp-test-cronet',


### PR DESCRIPTION
- Added new test scenario: 0-byte RPCs sent in parallel over 10 channels
- Update Cronet.framework to use recent version of Cronet
- Added new scheme for Posix client tests as it can't be run in the same scheme as CFStream tests (CFStream is enabled/disabled based on environment variable that's read at when gRPC is initialized).
- Added iOS performance tests to run_tests.py. I'll add the tests to kokoro as part of a separate commit after the tests have been stabilized and cronet perf issues have been fixed.