### PR TITLE
Workaround RBE UBSAN

### DIFF
--- a/tools/remote_build/rbe_common.bazelrc
+++ b/tools/remote_build/rbe_common.bazelrc
@@ -81,6 +81,10 @@ build:tsan --extra_execution_platforms=//third_party/toolchains:rbe_ubuntu1604,/
 # undefined behavior sanitizer: most settings are already in %workspace%/.bazelrc
 # we only need a few additional ones that are Foundry specific
 build:ubsan --copt=-gmlt
+# workaround to use libc++ instead of libstdc++ because gcc 4.9 installed in ubuntu16_04_clang
+# has an issue with ubsan. (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66017)
+build:ubsan --cxxopt=-stdlib=libc++
+build:ubsan --linkopt=-stdlib=libc++
 # TODO(jtattermusch): use more reasonable test timeout
 build:ubsan --test_timeout=3600
 # override the config-agnostic crosstool_top


### PR DESCRIPTION
Bazel RBE has an issue with UBSAN test because `ubuntu16_04_clang` image has gcc 4.9 libstdc++ which has a bug not to address the alignment attribute properly. ([bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66017))

You can see a UBSAN test failure [here](https://source.cloud.google.com/results/invocations/2bebcb7a-5df2-47f5-bd3d-16647512a93a/targets/%2F%2Ftest%2Fcpp%2Fend2end:xds_end2end_test@poller%3Depollex/log) for the PR #19981 

There is no alternative image which use later version of libstdc++ so this is a workaround to use libc++ instead of libstdc++.