### PR TITLE
Configurable worker thread stack size for sync servers

### DIFF
--- a/include/grpcpp/server_builder_impl.h
+++ b/include/grpcpp/server_builder_impl.h
@@ -225,10 +225,11 @@ class ServerBuilder {
 
   /// Options for synchronous servers.
   enum SyncServerOption {
-    NUM_CQS,         ///< Number of completion queues.
-    MIN_POLLERS,     ///< Minimum number of polling threads.
-    MAX_POLLERS,     ///< Maximum number of polling threads.
-    CQ_TIMEOUT_MSEC  ///< Completion queue timeout in milliseconds.
+    NUM_CQS,           ///< Number of completion queues.
+    MIN_POLLERS,       ///< Minimum number of polling threads.
+    MAX_POLLERS,       ///< Maximum number of polling threads.
+    CQ_TIMEOUT_MSEC,   ///< Completion queue timeout in milliseconds.
+    WORKER_STACK_SIZE, ///< Default stack size for worker threads.
   };
 
   /// Only useful if this is a Synchronous server.
@@ -337,7 +338,7 @@ class ServerBuilder {
 
   struct SyncServerSettings {
     SyncServerSettings()
-        : num_cqs(1), min_pollers(1), max_pollers(2), cq_timeout_msec(10000) {}
+        : num_cqs(1), min_pollers(1), max_pollers(2), cq_timeout_msec(10000), worker_stack_size(0) {}
 
     /// Number of server completion queues to create to listen to incoming RPCs.
     int num_cqs;
@@ -352,6 +353,9 @@ class ServerBuilder {
 
     /// The timeout for server completion queue's AsyncNext call.
     int cq_timeout_msec;
+
+    /// Default stack size for worker threads.
+    int worker_stack_size;
   };
 
   int max_receive_message_size_;

--- a/include/grpcpp/server_impl.h
+++ b/include/grpcpp/server_impl.h
@@ -182,10 +182,13 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   ///
   /// \param sync_cq_timeout_msec The timeout to use when calling AsyncNext() on
   /// server completion queues passed via sync_server_cqs param.
+  ///
+  /// \param worker_stack_size The default stack size for worker threads.
   Server(int max_message_size, ChannelArguments* args,
          std::shared_ptr<std::vector<std::unique_ptr<ServerCompletionQueue>>>
              sync_server_cqs,
          int min_pollers, int max_pollers, int sync_cq_timeout_msec,
+         int worker_stack_size,
          std::vector<
              std::shared_ptr<grpc::internal::ExternalConnectionAcceptorImpl>>
              acceptors,

--- a/src/cpp/server/server_builder.cc
+++ b/src/cpp/server/server_builder.cc
@@ -150,6 +150,9 @@ ServerBuilder& ServerBuilder::SetSyncServerOption(
     case CQ_TIMEOUT_MSEC:
       sync_server_settings_.cq_timeout_msec = val;
       break;
+    case WORKER_STACK_SIZE:
+      sync_server_settings_.worker_stack_size = val;
+      break;
   }
   return *this;
 }
@@ -308,10 +311,11 @@ std::unique_ptr<grpc::Server> ServerBuilder::BuildAndStart() {
     // This is a Sync server
     gpr_log(GPR_INFO,
             "Synchronous server. Num CQs: %d, Min pollers: %d, Max Pollers: "
-            "%d, CQ timeout (msec): %d",
+            "%d, CQ timeout (msec): %d, Worker stack size: %d",
             sync_server_settings_.num_cqs, sync_server_settings_.min_pollers,
             sync_server_settings_.max_pollers,
-            sync_server_settings_.cq_timeout_msec);
+            sync_server_settings_.cq_timeout_msec,
+            sync_server_settings_.worker_stack_size);
   }
 
   if (has_callback_methods) {
@@ -321,8 +325,8 @@ std::unique_ptr<grpc::Server> ServerBuilder::BuildAndStart() {
   std::unique_ptr<grpc::Server> server(new grpc::Server(
       max_receive_message_size_, &args, sync_server_cqs,
       sync_server_settings_.min_pollers, sync_server_settings_.max_pollers,
-      sync_server_settings_.cq_timeout_msec, std::move(acceptors_),
-      resource_quota_, std::move(interceptor_creators_)));
+      sync_server_settings_.cq_timeout_msec, sync_server_settings_.worker_stack_size,
+      std::move(acceptors_), resource_quota_, std::move(interceptor_creators_)));
 
   grpc_impl::ServerInitializer* initializer = server->initializer();
 

--- a/src/cpp/thread_manager/thread_manager.h
+++ b/src/cpp/thread_manager/thread_manager.h
@@ -35,7 +35,7 @@ namespace grpc {
 class ThreadManager {
  public:
   explicit ThreadManager(const char* name, grpc_resource_quota* resource_quota,
-                         int min_pollers, int max_pollers);
+                         int min_pollers, int max_pollers, int worker_stack_size);
   virtual ~ThreadManager();
 
   // Initializes and Starts the Rpc Manager threads
@@ -160,6 +160,7 @@ class ThreadManager {
   // The minimum and maximum number of threads that should be doing polling
   int min_pollers_;
   int max_pollers_;
+  int worker_stack_size_;
 
   // The total number of threads currently active (includes threads includes the
   // threads that are currently polling i.e num_pollers_)


### PR DESCRIPTION
This change threads through a configurable worker thread stack size. We have a use case where we need to dramatically increase the stack size in our worker threads - making this configurable would help address our use case. Potentially this might not be a good approach, or potentially this is not suitable to address in sync servers.

@veblush
