### PR TITLE
Use cluster name from LRS response to report loads

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds_load_balancer_api.h
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds_load_balancer_api.h
@@ -114,12 +114,12 @@ grpc_slice XdsLrsRequestCreateAndEncode(const char* server_name);
 grpc_slice XdsLrsRequestCreateAndEncode(const char* server_name,
                                         XdsClientStats* client_stats);
 
-// Parses the LRS response and returns the client-side load reporting interval.
-// If there is any error (e.g., the found server name doesn't match \a
-// expected_server_name), the output config is invalid.
+// Parses the LRS response and returns \a cluster_name and \a
+// load_reporting_interval for client-side load reporting. If there is any
+// error, the output config is invalid.
 grpc_error* XdsLrsResponseDecodeAndParse(const grpc_slice& encoded_response,
-                                         grpc_millis* load_reporting_interval,
-                                         const char* expected_server_name);
+                                         UniquePtr<char>* cluster_name,
+                                         grpc_millis* load_reporting_interval);
 
 }  // namespace grpc_core
 


### PR DESCRIPTION
to comply with the update in the LRS design doc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/20340)
<!-- Reviewable:end -->
