### PR TITLE
Set "uses_polling" arg for bazel tests

### DIFF
--- a/bazel/grpc_build_system.bzl
+++ b/bazel/grpc_build_system.bzl
@@ -212,7 +212,7 @@ def grpc_cc_test(name, srcs = [], deps = [], external_deps = [], args = [], data
                 exec_compatible_with = exec_compatible_with,
             )
     else:
-        native.cc_test(tags = tags, **args)
+        native.cc_test(name = name, tags = tags, **args)
     ios_cc_test(
         name = name,
         tags = tags,

--- a/test/core/avl/BUILD
+++ b/test/core/avl/BUILD
@@ -27,4 +27,5 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )

--- a/test/core/backoff/BUILD
+++ b/test/core/backoff/BUILD
@@ -35,4 +35,5 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )

--- a/test/core/channel/BUILD
+++ b/test/core/channel/BUILD
@@ -27,6 +27,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -38,6 +39,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -60,6 +62,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -107,6 +110,7 @@ grpc_cc_test(
         "//:grpc++",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -120,4 +124,5 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )

--- a/test/core/client_channel/BUILD
+++ b/test/core/client_channel/BUILD
@@ -53,6 +53,7 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
     ],
     tags = ["no_windows"],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -78,6 +79,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(

--- a/test/core/compression/BUILD
+++ b/test/core/compression/BUILD
@@ -27,6 +27,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -38,6 +39,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -49,6 +51,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -60,4 +63,5 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )

--- a/test/core/debug/BUILD
+++ b/test/core/debug/BUILD
@@ -30,4 +30,5 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )

--- a/test/core/end2end/BUILD
+++ b/test/core/end2end/BUILD
@@ -141,6 +141,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(

--- a/test/core/gpr/BUILD
+++ b/test/core/gpr/BUILD
@@ -26,6 +26,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -36,6 +37,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -46,6 +48,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -56,6 +59,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -66,6 +70,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -76,6 +81,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -86,6 +92,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -96,6 +103,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -106,6 +114,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -116,6 +125,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -126,6 +136,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -136,4 +147,5 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )

--- a/test/core/gprpp/BUILD
+++ b/test/core/gprpp/BUILD
@@ -26,6 +26,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -39,6 +40,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -52,6 +54,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -62,6 +65,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -72,6 +76,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -85,6 +90,7 @@ grpc_cc_test(
         "//:gpr_base",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -98,6 +104,7 @@ grpc_cc_test(
         "//:gpr_base",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -122,6 +129,7 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -198,4 +206,5 @@ grpc_cc_test(
         "//:gpr",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )

--- a/test/core/http/BUILD
+++ b/test/core/http/BUILD
@@ -109,6 +109,7 @@ grpc_cc_test(
         "//test/core/end2end:ssl_test_data",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(

--- a/test/core/iomgr/BUILD
+++ b/test/core/iomgr/BUILD
@@ -70,6 +70,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -128,6 +129,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -139,6 +141,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -290,6 +293,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -301,6 +305,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -312,6 +317,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -323,6 +329,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(

--- a/test/core/json/BUILD
+++ b/test/core/json/BUILD
@@ -59,6 +59,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -70,6 +71,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -81,4 +83,5 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )

--- a/test/core/memory_usage/BUILD
+++ b/test/core/memory_usage/BUILD
@@ -54,4 +54,5 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )

--- a/test/core/security/BUILD
+++ b/test/core/security/BUILD
@@ -63,6 +63,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -98,6 +99,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -109,6 +111,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(

--- a/test/core/slice/BUILD
+++ b/test/core/slice/BUILD
@@ -53,6 +53,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -64,6 +65,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -75,6 +77,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -86,6 +89,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -100,6 +104,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -114,6 +119,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -125,4 +131,5 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )

--- a/test/core/surface/BUILD
+++ b/test/core/surface/BUILD
@@ -27,6 +27,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -82,6 +83,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(

--- a/test/core/transport/BUILD
+++ b/test/core/transport/BUILD
@@ -30,6 +30,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -44,6 +45,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -105,6 +107,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -116,6 +119,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -127,6 +131,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -140,4 +145,5 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )

--- a/test/core/transport/chttp2/BUILD
+++ b/test/core/transport/chttp2/BUILD
@@ -50,6 +50,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -61,6 +62,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -75,6 +77,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -86,6 +89,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -97,6 +101,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -108,6 +113,7 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -144,4 +150,5 @@ grpc_cc_test(
         "//:grpc",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )

--- a/test/core/util/BUILD
+++ b/test/core/util/BUILD
@@ -119,6 +119,7 @@ grpc_cc_test(
         ":grpc_test_util",
         "//:gpr",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_library(
@@ -145,6 +146,7 @@ grpc_cc_test(
         ":grpc_test_util",
         "//:gpr",
     ],
+    uses_polling = False,
 )
 
 sh_library(

--- a/test/cpp/codegen/BUILD
+++ b/test/cpp/codegen/BUILD
@@ -28,6 +28,7 @@ grpc_cc_test(
         "//:grpc++",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -40,6 +41,7 @@ grpc_cc_test(
         "//:grpc++",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -53,6 +55,7 @@ grpc_cc_test(
         "//:grpc++",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_binary(

--- a/test/cpp/common/BUILD
+++ b/test/cpp/common/BUILD
@@ -66,6 +66,7 @@ grpc_cc_test(
         "//test/core/util:grpc_test_util",
         "//test/cpp/util:test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -78,6 +79,7 @@ grpc_cc_test(
         "//:grpc++",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -90,6 +92,7 @@ grpc_cc_test(
         "//:grpc++",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(

--- a/test/cpp/qps/BUILD
+++ b/test/cpp/qps/BUILD
@@ -163,6 +163,7 @@ grpc_cc_test(
         ":interarrival",
         "//test/cpp/util:test_config",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(

--- a/test/cpp/util/BUILD
+++ b/test/cpp/util/BUILD
@@ -213,6 +213,7 @@ grpc_cc_test(
     deps = [
         ":test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -226,6 +227,7 @@ grpc_cc_test(
     deps = [
         ":test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -240,6 +242,7 @@ grpc_cc_test(
         "//:grpc++",
         "//test/core/util:grpc_test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(
@@ -253,6 +256,7 @@ grpc_cc_test(
     deps = [
         ":test_util",
     ],
+    uses_polling = False,
 )
 
 grpc_cc_test(


### PR DESCRIPTION
Currently the bazel build supports "uses_polling" arg, but it's not set by any test and there's also a bug in grpc_build_system.bzl that prevents generating tests that use uses_polling=False.

- fix the bug in `grpc_cc_test` in `grpc_build_system.bzl`
- set uses_polling=False for (hopefully) all the tests that have `uses_polling: false` in build.yaml

The sideeffect of this PR is that we no longer run non-poller-related tests X times (once for each poller) unnecessarily on bazel RBE