### PR TITLE
Stop using deprecated gtest macros

### DIFF
--- a/test/core/channel/channelz_test.cc
+++ b/test/core/channel/channelz_test.cc
@@ -533,8 +533,8 @@ TEST_F(ChannelzRegistryBasedTest, ManyServersTest) {
   ValidateGetServers(10);
 }
 
-INSTANTIATE_TEST_CASE_P(ChannelzChannelTestSweep, ChannelzChannelTest,
-                        ::testing::Values(0, 8, 64, 1024, 1024 * 1024));
+INSTANTIATE_TEST_SUITE_P(ChannelzChannelTestSweep, ChannelzChannelTest,
+                         ::testing::Values(0, 8, 64, 1024, 1024 * 1024));
 
 }  // namespace testing
 }  // namespace channelz

--- a/test/core/debug/stats_test.cc
+++ b/test/core/debug/stats_test.cc
@@ -135,8 +135,8 @@ TEST_P(HistogramTest, IncHistogram) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(HistogramTestCases, HistogramTest,
-                        ::testing::Range<int>(0, GRPC_STATS_HISTOGRAM_COUNT));
+INSTANTIATE_TEST_SUITE_P(HistogramTestCases, HistogramTest,
+                         ::testing::Range<int>(0, GRPC_STATS_HISTOGRAM_COUNT));
 
 }  // namespace testing
 }  // namespace grpc

--- a/test/core/end2end/h2_ssl_cert_test.cc
+++ b/test/core/end2end/h2_ssl_cert_test.cc
@@ -346,7 +346,8 @@ TEST_P(H2SslCertTest, SimpleRequestBody) {
   simple_request_body(fixture_, GetParam().result);
 }
 
-INSTANTIATE_TEST_CASE_P(H2SslCert, H2SslCertTest, ::testing::ValuesIn(configs));
+INSTANTIATE_TEST_SUITE_P(H2SslCert, H2SslCertTest,
+                         ::testing::ValuesIn(configs));
 
 }  // namespace testing
 }  // namespace grpc

--- a/test/core/transport/bdp_estimator_test.cc
+++ b/test/core/transport/bdp_estimator_test.cc
@@ -131,9 +131,9 @@ TEST_P(BdpEstimatorRandomTest, GetEstimateRandomValues) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(TooManyNames, BdpEstimatorRandomTest,
-                        ::testing::Values(3, 4, 6, 9, 13, 19, 28, 42, 63, 94,
-                                          141, 211, 316, 474, 711));
+INSTANTIATE_TEST_SUITE_P(TooManyNames, BdpEstimatorRandomTest,
+                         ::testing::Values(3, 4, 6, 9, 13, 19, 28, 42, 63, 94,
+                                           141, 211, 316, 474, 711));
 
 }  // namespace testing
 }  // namespace grpc_core

--- a/test/core/transport/pid_controller_test.cc
+++ b/test/core/transport/pid_controller_test.cc
@@ -75,7 +75,7 @@ TEST_P(SimpleConvergenceTest, Converges) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     X, SimpleConvergenceTest,
     ::testing::Values(SimpleConvergenceTestArgs{0.2, 0, 0, 1, 100, 0},
                       SimpleConvergenceTestArgs{0.2, 0.1, 0, 1, 100, 0},

--- a/test/core/util/fuzzer_corpus_test.cc
+++ b/test/core/util/fuzzer_corpus_test.cc
@@ -140,7 +140,7 @@ ExampleGenerator::End() const {
   return new ExampleIterator(*this, examples_.end());
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     CorpusExamples, FuzzerCorpusTest,
     ::testing::internal::ParamGenerator<std::string>(new ExampleGenerator));
 

--- a/test/cpp/common/time_jump_test.cc
+++ b/test/cpp/common/time_jump_test.cc
@@ -75,8 +75,8 @@ class TimeJumpTest : public ::testing::TestWithParam<std::string> {
 std::vector<std::string> CreateTestScenarios() {
   return {"-1M", "+1M", "-1H", "+1H", "-1d", "+1d", "-1y", "+1y"};
 }
-INSTANTIATE_TEST_CASE_P(TimeJump, TimeJumpTest,
-                        ::testing::ValuesIn(CreateTestScenarios()));
+INSTANTIATE_TEST_SUITE_P(TimeJump, TimeJumpTest,
+                         ::testing::ValuesIn(CreateTestScenarios()));
 
 TEST_P(TimeJumpTest, TimerRunning) {
   grpc_core::ExecCtx exec_ctx;

--- a/test/cpp/end2end/async_end2end_test.cc
+++ b/test/cpp/end2end/async_end2end_test.cc
@@ -1875,11 +1875,12 @@ std::vector<TestScenario> CreateTestScenarios(bool test_secure,
   return scenarios;
 }
 
-INSTANTIATE_TEST_CASE_P(AsyncEnd2end, AsyncEnd2endTest,
-                        ::testing::ValuesIn(CreateTestScenarios(true, true)));
-INSTANTIATE_TEST_CASE_P(AsyncEnd2endServerTryCancel,
-                        AsyncEnd2endServerTryCancelTest,
-                        ::testing::ValuesIn(CreateTestScenarios(false, false)));
+INSTANTIATE_TEST_SUITE_P(AsyncEnd2end, AsyncEnd2endTest,
+                         ::testing::ValuesIn(CreateTestScenarios(true, true)));
+INSTANTIATE_TEST_SUITE_P(AsyncEnd2endServerTryCancel,
+                         AsyncEnd2endServerTryCancelTest,
+                         ::testing::ValuesIn(CreateTestScenarios(false,
+                                                                 false)));
 
 }  // namespace
 }  // namespace testing

--- a/test/cpp/end2end/cfstream_test.cc
+++ b/test/cpp/end2end/cfstream_test.cc
@@ -324,8 +324,8 @@ std::vector<TestScenario> CreateTestScenarios() {
   return scenarios;
 }
 
-INSTANTIATE_TEST_CASE_P(CFStreamTest, CFStreamTest,
-                        ::testing::ValuesIn(CreateTestScenarios()));
+INSTANTIATE_TEST_SUITE_P(CFStreamTest, CFStreamTest,
+                         ::testing::ValuesIn(CreateTestScenarios()));
 
 // gRPC should automatically detech network flaps (without enabling keepalives)
 //  when CFStream is enabled

--- a/test/cpp/end2end/client_callback_end2end_test.cc
+++ b/test/cpp/end2end/client_callback_end2end_test.cc
@@ -1375,8 +1375,8 @@ std::vector<TestScenario> CreateTestScenarios(bool test_insecure) {
   return scenarios;
 }
 
-INSTANTIATE_TEST_CASE_P(ClientCallbackEnd2endTest, ClientCallbackEnd2endTest,
-                        ::testing::ValuesIn(CreateTestScenarios(true)));
+INSTANTIATE_TEST_SUITE_P(ClientCallbackEnd2endTest, ClientCallbackEnd2endTest,
+                         ::testing::ValuesIn(CreateTestScenarios(true)));
 
 }  // namespace
 }  // namespace testing

--- a/test/cpp/end2end/end2end_test.cc
+++ b/test/cpp/end2end/end2end_test.cc
@@ -2251,23 +2251,23 @@ std::vector<TestScenario> CreateTestScenarios(bool use_proxy,
   return scenarios;
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     End2end, End2endTest,
     ::testing::ValuesIn(CreateTestScenarios(false, true, true, true, true)));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     End2endServerTryCancel, End2endServerTryCancelTest,
     ::testing::ValuesIn(CreateTestScenarios(false, true, true, true, true)));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ProxyEnd2end, ProxyEnd2endTest,
     ::testing::ValuesIn(CreateTestScenarios(true, true, true, true, true)));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     SecureEnd2end, SecureEnd2endTest,
     ::testing::ValuesIn(CreateTestScenarios(false, false, true, false, true)));
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     ResourceQuotaEnd2end, ResourceQuotaEnd2endTest,
     ::testing::ValuesIn(CreateTestScenarios(false, true, true, true, true)));
 

--- a/test/cpp/end2end/flaky_network_test.cc
+++ b/test/cpp/end2end/flaky_network_test.cc
@@ -344,8 +344,8 @@ std::vector<TestScenario> CreateTestScenarios() {
   return scenarios;
 }
 
-INSTANTIATE_TEST_CASE_P(FlakyNetworkTest, FlakyNetworkTest,
-                        ::testing::ValuesIn(CreateTestScenarios()));
+INSTANTIATE_TEST_SUITE_P(FlakyNetworkTest, FlakyNetworkTest,
+                         ::testing::ValuesIn(CreateTestScenarios()));
 
 // Network interface connected to server flaps
 TEST_P(FlakyNetworkTest, NetworkTransition) {

--- a/test/cpp/end2end/hybrid_end2end_test.cc
+++ b/test/cpp/end2end/hybrid_end2end_test.cc
@@ -962,8 +962,8 @@ TEST_F(HybridEnd2endTest, GenericMethodWithoutGenericService) {
   EXPECT_EQ(nullptr, server_.get());
 }
 
-INSTANTIATE_TEST_CASE_P(HybridEnd2endTest, HybridEnd2endTest,
-                        ::testing::Bool());
+INSTANTIATE_TEST_SUITE_P(HybridEnd2endTest, HybridEnd2endTest,
+                         ::testing::Bool());
 
 }  // namespace
 }  // namespace testing

--- a/test/cpp/end2end/message_allocator_end2end_test.cc
+++ b/test/cpp/end2end/message_allocator_end2end_test.cc
@@ -400,12 +400,12 @@ std::vector<TestScenario> CreateTestScenarios(bool test_insecure) {
   return scenarios;
 }
 
-INSTANTIATE_TEST_CASE_P(NullAllocatorTest, NullAllocatorTest,
-                        ::testing::ValuesIn(CreateTestScenarios(true)));
-INSTANTIATE_TEST_CASE_P(SimpleAllocatorTest, SimpleAllocatorTest,
-                        ::testing::ValuesIn(CreateTestScenarios(true)));
-INSTANTIATE_TEST_CASE_P(ArenaAllocatorTest, ArenaAllocatorTest,
-                        ::testing::ValuesIn(CreateTestScenarios(true)));
+INSTANTIATE_TEST_SUITE_P(NullAllocatorTest, NullAllocatorTest,
+                         ::testing::ValuesIn(CreateTestScenarios(true)));
+INSTANTIATE_TEST_SUITE_P(SimpleAllocatorTest, SimpleAllocatorTest,
+                         ::testing::ValuesIn(CreateTestScenarios(true)));
+INSTANTIATE_TEST_SUITE_P(ArenaAllocatorTest, ArenaAllocatorTest,
+                         ::testing::ValuesIn(CreateTestScenarios(true)));
 
 }  // namespace
 }  // namespace testing

--- a/test/cpp/end2end/port_sharing_end2end_test.cc
+++ b/test/cpp/end2end/port_sharing_end2end_test.cc
@@ -359,8 +359,8 @@ TEST_P(PortSharingEnd2endTest, TwoHandoffPorts) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(PortSharingEnd2end, PortSharingEnd2endTest,
-                        ::testing::ValuesIn(CreateTestScenarios()));
+INSTANTIATE_TEST_SUITE_P(PortSharingEnd2end, PortSharingEnd2endTest,
+                         ::testing::ValuesIn(CreateTestScenarios()));
 
 }  // namespace
 }  // namespace testing

--- a/test/cpp/end2end/server_builder_plugin_test.cc
+++ b/test/cpp/end2end/server_builder_plugin_test.cc
@@ -257,8 +257,8 @@ TEST_P(ServerBuilderPluginTest, PluginWithServiceTest) {
   EXPECT_TRUE(s.ok());
 }
 
-INSTANTIATE_TEST_CASE_P(ServerBuilderPluginTest, ServerBuilderPluginTest,
-                        ::testing::Values(false, true));
+INSTANTIATE_TEST_SUITE_P(ServerBuilderPluginTest, ServerBuilderPluginTest,
+                         ::testing::Values(false, true));
 
 }  // namespace testing
 }  // namespace grpc

--- a/test/cpp/end2end/shutdown_test.cc
+++ b/test/cpp/end2end/shutdown_test.cc
@@ -136,8 +136,8 @@ std::vector<string> GetAllCredentialsTypeList() {
   return credentials_types;
 }
 
-INSTANTIATE_TEST_CASE_P(End2EndShutdown, ShutdownTest,
-                        ::testing::ValuesIn(GetAllCredentialsTypeList()));
+INSTANTIATE_TEST_SUITE_P(End2EndShutdown, ShutdownTest,
+                         ::testing::ValuesIn(GetAllCredentialsTypeList()));
 
 // TODO(ctiller): leaked objects in this test
 TEST_P(ShutdownTest, ShutdownTest) {


### PR DESCRIPTION
Modern googletest uses INSTANTIATE_TEST_SUITE_P rather than INSTANTIATE_TEST_CASE_P

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
