### PR TITLE
Update CFStream documentation

### DIFF
--- a/src/objective-c/README-CFSTREAM.md
+++ b/src/objective-c/README-CFSTREAM.md
@@ -1,7 +1,7 @@
 [![Cocoapods](https://img.shields.io/cocoapods/v/gRPC.svg)](https://cocoapods.org/pods/gRPC)
 # gRPC Objective-C with CFStream
 
-gRPC Objective-C library now provides the option to use Apple's CFStream API (rather than TCP
+gRPC now provides the option to use Apple's CFStream API (rather than TCP
 sockets) for networking. Using CFStream resolves a bunch of network connectivity transition issues
 (see the [doc](https://github.com/grpc/grpc/blob/master/src/objective-c/NetworkTransitionBehavior.md)
 for more information).
@@ -14,8 +14,11 @@ As of v1.21.0, CFStream integration is now the default networking stack being us
 Objective-C on iOS layer. You get to use it automatically without special configuration needed. See
 below on how to disable CFStream in case of problem.
 
+As of v1.23.0, CFStream is enabled by default on iOS for all wrapped languages. See below on how to
+disable CFStream in case of a problem.
+
 ## Usage
-If you use gRPC Objective-C library on iOS, CFStream is on automatically. If you use it on other
+If you use gRPC on iOS, CFStream is on automatically. If you use it on other
 platforms, you can turn it on with macro `GRPC_CFSTREAM=1` for the pod 'gRPC-Core' and 'gRPC'. In
 case of problem and you want to disable CFStream on iOS, you can set environment variable
 "grpc\_cfstream=0".


### PR DESCRIPTION
Update the documentation to reflect the fact that CFStream has been enabled on iOS for all wrapped languages as of v1.23.0.