### PR TITLE
Expose max protected frame size value for testing.

### DIFF
--- a/src/core/tsi/alts/frame_protector/alts_frame_protector.cc
+++ b/src/core/tsi/alts/frame_protector/alts_frame_protector.cc
@@ -34,7 +34,7 @@
 
 constexpr size_t kMinFrameLength = 1024;
 constexpr size_t kDefaultFrameLength = 16 * 1024;
-constexpr size_t kMaxFrameLength = 16 * 1024 * 1024;
+constexpr size_t kMaxFrameLength = 1024 * 1024;
 
 // Limit k on number of frames such that at most 2^(8 * k) frames can be sent.
 constexpr size_t kAltsRecordProtocolRekeyFrameLimit = 8;

--- a/src/core/tsi/alts/zero_copy_frame_protector/alts_zero_copy_grpc_protector.cc
+++ b/src/core/tsi/alts/zero_copy_frame_protector/alts_zero_copy_grpc_protector.cc
@@ -37,7 +37,7 @@
 
 constexpr size_t kMinFrameLength = 1024;
 constexpr size_t kDefaultFrameLength = 16 * 1024;
-constexpr size_t kMaxFrameLength = 1024 * 1024;
+constexpr size_t kMaxFrameLength = 16 * 1024 * 1024;
 
 /**
  * Main struct for alts_zero_copy_grpc_protector.
@@ -233,11 +233,21 @@ static void alts_zero_copy_grpc_protector_destroy(
   gpr_free(protector);
 }
 
+static tsi_result alts_zero_copy_grpc_protector_max_frame_size(
+    tsi_zero_copy_grpc_protector* self, size_t& max_frame_size) {
+  if (self == nullptr) return TSI_INVALID_ARGUMENT;
+  alts_zero_copy_grpc_protector* protector =
+      reinterpret_cast<alts_zero_copy_grpc_protector*>(self);
+  max_frame_size = protector->max_protected_frame_size;
+  return TSI_OK;
+}
+
 static const tsi_zero_copy_grpc_protector_vtable
     alts_zero_copy_grpc_protector_vtable = {
         alts_zero_copy_grpc_protector_protect,
         alts_zero_copy_grpc_protector_unprotect,
-        alts_zero_copy_grpc_protector_destroy};
+        alts_zero_copy_grpc_protector_destroy,
+        alts_zero_copy_grpc_protector_max_frame_size};
 
 tsi_result alts_zero_copy_grpc_protector_create(
     const uint8_t* key, size_t key_size, bool is_rekey, bool is_client,

--- a/src/core/tsi/fake_transport_security.cc
+++ b/src/core/tsi/fake_transport_security.cc
@@ -483,6 +483,7 @@ static const tsi_zero_copy_grpc_protector_vtable
         fake_zero_copy_grpc_protector_protect,
         fake_zero_copy_grpc_protector_unprotect,
         fake_zero_copy_grpc_protector_destroy,
+        nullptr /* fake_zero_copy_grpc_protector_max_frame_size */
 };
 
 /* --- tsi_handshaker_result methods implementation. ---*/

--- a/src/core/tsi/local_transport_security.cc
+++ b/src/core/tsi/local_transport_security.cc
@@ -84,7 +84,8 @@ static const tsi_zero_copy_grpc_protector_vtable
     local_zero_copy_grpc_protector_vtable = {
         local_zero_copy_grpc_protector_protect,
         local_zero_copy_grpc_protector_unprotect,
-        local_zero_copy_grpc_protector_destroy};
+        local_zero_copy_grpc_protector_destroy,
+        nullptr /* local_zero_copy_grpc_protector_max_frame_size */};
 
 tsi_result local_zero_copy_grpc_protector_create(
     tsi_zero_copy_grpc_protector** protector) {

--- a/src/core/tsi/transport_security_grpc.cc
+++ b/src/core/tsi/transport_security_grpc.cc
@@ -64,3 +64,10 @@ void tsi_zero_copy_grpc_protector_destroy(tsi_zero_copy_grpc_protector* self) {
   if (self == nullptr) return;
   self->vtable->destroy(self);
 }
+
+tsi_result tsi_zero_copy_grpc_protector_max_frame_size(
+    tsi_zero_copy_grpc_protector* self, size_t& max_frame_size) {
+  if (self == nullptr) return TSI_INVALID_ARGUMENT;
+  if (self->vtable->max_frame_size == nullptr) return TSI_UNIMPLEMENTED;
+  return self->vtable->max_frame_size(self, max_frame_size);
+}

--- a/src/core/tsi/transport_security_grpc.h
+++ b/src/core/tsi/transport_security_grpc.h
@@ -56,6 +56,10 @@ tsi_result tsi_zero_copy_grpc_protector_unprotect(
 /* Destroys the tsi_zero_copy_grpc_protector object.  */
 void tsi_zero_copy_grpc_protector_destroy(tsi_zero_copy_grpc_protector* self);
 
+/* Returns value of max protected frame size. Useful for testing. */
+tsi_result tsi_zero_copy_grpc_protector_max_frame_size(
+    tsi_zero_copy_grpc_protector* self, size_t& max_frame_size);
+
 /* Base for tsi_zero_copy_grpc_protector implementations.  */
 typedef struct {
   tsi_result (*protect)(tsi_zero_copy_grpc_protector* self,
@@ -65,6 +69,8 @@ typedef struct {
                           grpc_slice_buffer* protected_slices,
                           grpc_slice_buffer* unprotected_slices);
   void (*destroy)(tsi_zero_copy_grpc_protector* self);
+  tsi_result (*max_frame_size)(tsi_zero_copy_grpc_protector* self,
+                               size_t& max_frame_size);
 } tsi_zero_copy_grpc_protector_vtable;
 
 struct tsi_zero_copy_grpc_protector {

--- a/test/core/tsi/alts/zero_copy_frame_protector/alts_zero_copy_grpc_protector_test.cc
+++ b/test/core/tsi/alts/zero_copy_frame_protector/alts_zero_copy_grpc_protector_test.cc
@@ -109,15 +109,22 @@ alts_zero_copy_grpc_protector_test_fixture_create(bool rekey,
   size_t key_length = rekey ? kAes128GcmRekeyKeyLength : kAes128GcmKeyLength;
   uint8_t* key;
   size_t max_protected_frame_size = 1024;
+  size_t actual_max_protected_frame_size;
   gsec_test_random_array(&key, key_length);
   GPR_ASSERT(alts_zero_copy_grpc_protector_create(
                  key, key_length, rekey, /*is_client=*/true, integrity_only,
                  enable_extra_copy, &max_protected_frame_size,
                  &fixture->client) == TSI_OK);
+  GPR_ASSERT(tsi_zero_copy_grpc_protector_max_frame_size(
+                 fixture->client, actual_max_protected_frame_size) == TSI_OK);
+  GPR_ASSERT(actual_max_protected_frame_size == max_protected_frame_size);
   GPR_ASSERT(alts_zero_copy_grpc_protector_create(
                  key, key_length, rekey, /*is_client=*/false, integrity_only,
                  enable_extra_copy, &max_protected_frame_size,
                  &fixture->server) == TSI_OK);
+  GPR_ASSERT(tsi_zero_copy_grpc_protector_max_frame_size(
+                 fixture->server, actual_max_protected_frame_size) == TSI_OK);
+  GPR_ASSERT(actual_max_protected_frame_size == max_protected_frame_size);
   gpr_free(key);
   grpc_core::ExecCtx::Get()->Flush();
   return fixture;


### PR DESCRIPTION
Added a method to get max frame size value after frame size negotiation. Useful for testing.