### PR TITLE
ReadKey does not work in C# core hence changing to readline.

### DIFF
--- a/examples/csharp/Helloworld/GreeterServer/Program.cs
+++ b/examples/csharp/Helloworld/GreeterServer/Program.cs
@@ -43,7 +43,7 @@ namespace GreeterServer
 
             Console.WriteLine("Greeter server listening on port " + Port);
             Console.WriteLine("Press any key to stop the server...");
-            Console.ReadKey();
+            Console.ReadLine();//ReadKey does not work in C# core 
 
             server.ShutdownAsync().Wait();
         }


### PR DESCRIPTION
 Currently the solution is throwing unhandled exception.Workaround for user https://stackoverflow.com/questions/46901071/readkey-not-working-in-net-core




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
