### PR TITLE
Add v1.24.0 release of grpc-go to interop matrix

### DIFF
--- a/tools/interop_matrix/client_matrix.py
+++ b/tools/interop_matrix/client_matrix.py
@@ -147,6 +147,7 @@ LANG_RELEASE_MATRIX = {
             ('v1.21.3', ReleaseInfo(runtimes=['go1.11'])),
             ('v1.22.3', ReleaseInfo(runtimes=['go1.11'])),
             ('v1.23.1', ReleaseInfo(runtimes=['go1.11'])),
+            ('v1.24.0', ReleaseInfo(runtimes=['go1.11'])),
         ]),
     'java':
     OrderedDict([


### PR DESCRIPTION
```
$ gcloud beta container images list-tags gcr.io/grpc-testing/grpc_interop_go1.11 | grep "v1.24.0"
58cdba31af48  v1.24.0  2019-09-25T14:14:26  CRITICAL=15,HIGH=70,LOW=57,MEDIUM=348                                           PENDING
```