### PR TITLE
Rename gevent_util file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -855,7 +855,7 @@ grpc_cc_library(
         "src/core/lib/iomgr/executor/mpmcqueue.h",
         "src/core/lib/iomgr/executor/threadpool.h",
         "src/core/lib/iomgr/gethostname.h",
-        "src/core/lib/iomgr/gevent_util.h",
+        "src/core/lib/iomgr/python_util.h",
         "src/core/lib/iomgr/grpc_if_nametoindex.h",
         "src/core/lib/iomgr/internal_errqueue.h",
         "src/core/lib/iomgr/iocp_windows.h",

--- a/src/core/lib/iomgr/python_util.h
+++ b/src/core/lib/iomgr/python_util.h
@@ -16,8 +16,8 @@
  *
  */
 
-#ifndef GRPC_CORE_LIB_IOMGR_GEVENT_UTIL_H
-#define GRPC_CORE_LIB_IOMGR_GEVENT_UTIL_H
+#ifndef GRPC_CORE_LIB_IOMGR_PYTHON_UTIL_H
+#define GRPC_CORE_LIB_IOMGR_PYTHON_UTIL_H
 
 #include <grpc/support/port_platform.h>
 
@@ -25,8 +25,8 @@
 #include <grpc/status.h>
 #include "src/core/lib/iomgr/error.h"
 
-// These are only used by the gRPC Python extension for gevent
-// support.  They are easier to define here (rather than in Cython)
+// These are only used by the gRPC Python extensions.
+// They are easier to define here (rather than in Cython)
 // because Cython doesn't handle #defines well.
 
 grpc_error* grpc_socket_error(char* error) {

--- a/src/python/grpcio/grpc/_cython/_cygrpc/iomgr.pxd.pxi
+++ b/src/python/grpcio/grpc/_cython/_cygrpc/iomgr.pxd.pxi
@@ -23,7 +23,7 @@ cdef extern from "src/core/lib/iomgr/error.h":
 
 # TODO(https://github.com/grpc/grpc/issues/20135) Change the filename
 # for something more meaningful.
-cdef extern from "src/core/lib/iomgr/gevent_util.h":
+cdef extern from "src/core/lib/iomgr/python_util.h":
   grpc_error* grpc_socket_error(char* error) 
   char* grpc_slice_buffer_start(grpc_slice_buffer* buffer, int i)
   int grpc_slice_buffer_length(grpc_slice_buffer* buffer, int i)


### PR DESCRIPTION
Since functions implemented by `gevent_util.h` are used also by the new experimental `Aio` module, the file holding these functions needs to be renamed to something more meaningful.

Fixes: #20135