### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/src/cpp/README.md
+++ b/src/cpp/README.md
@@ -56,8 +56,15 @@ If your project is using cmake, there are several ways to add gRPC dependency.
 
 ## Packaging systems
 
-There's no standard packaging system for C++. We've looked into supporting some (e.g. Conan and vcpkg) but we are not there yet.
-Contributions and community-maintained packages for popular packaging systems are welcome!
+While we do not officially support a C++ package manager, gRPC is available using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install grpc
+
+The gRPC port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 
 ## Examples & Additional Documentation


### PR DESCRIPTION
gRPC is available as a port in [vcpkg](https://github.com/Microsoft/vcpkg), a C++ library manager that simplifies installation for gRPC and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build gRPC, ready to be included in their projects. 

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/grpc/portfile.cmake). We try to keep the library maintained as close as possible to the original library.

@nicolasnoble 