### PR TITLE
Fix shutdown SIGSEGV of Channelz Registry with gevent

### DIFF
--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -45,7 +45,7 @@ const int kPaginationLimit = 100;
 
 void ChannelzRegistry::Init() { g_channelz_registry = New<ChannelzRegistry>(); }
 
-void ChannelzRegistry::Shutdown() { Delete(g_channelz_registry); }
+void ChannelzRegistry::Shutdown() { Delete(g_channelz_registry); g_channelz_registry = nullptr; }
 
 ChannelzRegistry* ChannelzRegistry::Default() {
   GPR_DEBUG_ASSERT(g_channelz_registry != nullptr);
@@ -59,6 +59,7 @@ void ChannelzRegistry::InternalRegister(BaseNode* node) {
 }
 
 void ChannelzRegistry::InternalUnregister(intptr_t uuid) {
+  if (g_channelz_registry == nullptr) return;
   GPR_ASSERT(uuid >= 1);
   MutexLock lock(&mu_);
   GPR_ASSERT(uuid <= uuid_generator_);

--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -45,7 +45,10 @@ const int kPaginationLimit = 100;
 
 void ChannelzRegistry::Init() { g_channelz_registry = New<ChannelzRegistry>(); }
 
-void ChannelzRegistry::Shutdown() { Delete(g_channelz_registry); g_channelz_registry = nullptr; }
+void ChannelzRegistry::Shutdown() {
+  Delete(g_channelz_registry);
+  g_channelz_registry = nullptr;
+}
 
 ChannelzRegistry* ChannelzRegistry::Default() {
   GPR_DEBUG_ASSERT(g_channelz_registry != nullptr);

--- a/src/core/lib/channel/channelz_registry.cc
+++ b/src/core/lib/channel/channelz_registry.cc
@@ -38,16 +38,20 @@ namespace {
 
 // singleton instance of the registry.
 ChannelzRegistry* g_channelz_registry = nullptr;
+bool g_channelz_registry_running = false;
 
 const int kPaginationLimit = 100;
 
 }  // anonymous namespace
 
-void ChannelzRegistry::Init() { g_channelz_registry = New<ChannelzRegistry>(); }
+void ChannelzRegistry::Init() {
+  g_channelz_registry = New<ChannelzRegistry>();
+  g_channelz_registry_running = true;
+}
 
 void ChannelzRegistry::Shutdown() {
   Delete(g_channelz_registry);
-  g_channelz_registry = nullptr;
+  g_channelz_registry_running = false;
 }
 
 ChannelzRegistry* ChannelzRegistry::Default() {
@@ -62,7 +66,7 @@ void ChannelzRegistry::InternalRegister(BaseNode* node) {
 }
 
 void ChannelzRegistry::InternalUnregister(intptr_t uuid) {
-  if (g_channelz_registry == nullptr) return;
+  if (!g_channelz_registry_running) return;
   GPR_ASSERT(uuid >= 1);
   MutexLock lock(&mu_);
   GPR_ASSERT(uuid <= uuid_generator_);


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/20299

---

The `Delete` in our `memory.h` seems not setting pointer back to `nulltpr`. The deletion seems half-done. I don't have a comprehensive fix for it, but with several lines of changes the segfault of gevent should go away.