### PR TITLE
PHP: add various scenarios to test PECL extension

### DIFF
--- a/examples/php/echo/README.md
+++ b/examples/php/echo/README.md
@@ -1,0 +1,86 @@
+
+# gRPC PHP End-to-End Examples
+
+This page shows a number of ways to create a PHP gRPC client and connect with
+a gRPC backend service.
+
+
+## Run the Server
+
+For all the following examples, we use a simple gRPC server, written in Node.
+
+```sh
+$ git clone https://github.com/grpc/grpc-web
+$ cd grpc-web
+$ docker-compose build common node-server
+$ docker run -d -p 9090:9090 --name node-server grpcweb/node-server
+```
+
+
+## Install the gRPC PECL extension
+
+All the following commands are assumed to be run from this current directory.
+
+```sh
+$ cd grpc/examples/php/echo
+```
+
+
+In order to build a PHP gRPC client, we need to install the `grpc` extension
+first.
+
+```sh
+$ docker build -t grpc-php/base -f ./base.Dockerfile .
+```
+
+
+## CLI
+
+
+Let's first build a simple CLI gRPC client:
+
+```sh
+$ docker build -t grpc-php/echo-client -f ./cli.Dockerfile .
+$ docker run -it --rm --link node-server:node-server grpc-php/echo-client
+$ php client.php
+```
+
+
+
+## Apache
+
+
+Now let's see how the gRPC PHP client can run with Apache:
+
+```sh
+$ docker build -t grpc-php/apache -f ./apache.Dockerfile .
+$ docker run -it --rm --link node-server:node-server -p 80:80 grpc-php/apache
+```
+
+Open the browser to `http://localhost`.
+
+
+
+## Nginx + FPM
+
+
+We can also try running PHP-FPM and put Nginx in front of it.
+
+
+The PHP-FPM part:
+
+```sh
+$ docker build -t grpc-php/fpm -f ./fpm.Dockerfile .
+$ docker run -it --rm --link node-server:node-server -p 9000:9000 \
+  --name fpm grpc-php/fpm
+```
+
+The Nginx part:
+
+```sh
+$ docker run -it --rm -v $(pwd)/nginx.conf:/etc/nginx/conf.d/default.conf:ro \
+  --link fpm:fpm -p 80:80 nginx:1.17.4
+```
+
+
+Open the browser to `http://localhost`.

--- a/examples/php/echo/apache.Dockerfile
+++ b/examples/php/echo/apache.Dockerfile
@@ -1,0 +1,49 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM composer:1.8.6 as composer
+
+
+FROM grpc-php/base as grpc-base
+
+
+FROM php:7.2-apache-stretch
+
+RUN apt-get -qq update && apt-get -qq install -y git
+
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+COPY --from=grpc-base /usr/local/bin/protoc /usr/local/bin/protoc
+
+COPY --from=grpc-base /github/grpc/bins/opt/grpc_php_plugin \
+  /usr/local/bin/protoc-gen-grpc
+
+COPY --from=grpc-base \
+  /usr/local/lib/php/extensions/no-debug-non-zts-20170718/grpc.so \
+  /usr/local/lib/php/extensions/no-debug-non-zts-20170718/grpc.so
+
+
+RUN docker-php-ext-enable grpc
+
+
+WORKDIR /var/www/html
+
+COPY client.php ./index.php
+COPY composer.json .
+COPY echo.proto .
+
+RUN protoc -I=. echo.proto --php_out=. --grpc_out=.
+
+RUN composer install

--- a/examples/php/echo/base.Dockerfile
+++ b/examples/php/echo/base.Dockerfile
@@ -1,0 +1,38 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM php:7.2-stretch
+
+RUN apt-get -qq update && apt-get -qq install -y \
+  autoconf automake curl git libtool \
+  pkg-config unzip zlib1g-dev
+
+
+WORKDIR /tmp
+
+RUN curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/\
+protoc-3.8.0-linux-x86_64.zip -o /tmp/protoc.zip && \
+  unzip -qq protoc.zip && \
+  cp /tmp/bin/protoc /usr/local/bin/protoc
+
+
+WORKDIR /github/grpc
+
+RUN git clone https://github.com/grpc/grpc . && \
+  git submodule update --init && \
+  cd third_party/protobuf && git submodule update --init
+
+RUN make grpc_php_plugin
+
+RUN pecl install grpc

--- a/examples/php/echo/cli.Dockerfile
+++ b/examples/php/echo/cli.Dockerfile
@@ -1,0 +1,52 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM composer:1.8.6 as composer
+
+
+FROM grpc-php/base as grpc-base
+
+
+FROM php:7.2-stretch
+
+RUN apt-get -qq update && apt-get -qq install -y git
+
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+COPY --from=grpc-base /usr/local/bin/protoc /usr/local/bin/protoc
+
+COPY --from=grpc-base /github/grpc/bins/opt/grpc_php_plugin \
+  /usr/local/bin/protoc-gen-grpc
+
+COPY --from=grpc-base \
+  /usr/local/lib/php/extensions/no-debug-non-zts-20170718/grpc.so \
+  /usr/local/lib/php/extensions/no-debug-non-zts-20170718/grpc.so
+
+
+RUN docker-php-ext-enable grpc
+
+
+WORKDIR /github/grpc-php/examples/echo
+
+COPY client.php .
+COPY composer.json .
+COPY echo.proto .
+
+RUN protoc -I=. echo.proto --php_out=. --grpc_out=.
+
+RUN composer install
+
+
+CMD ["/bin/bash"]

--- a/examples/php/echo/client.php
+++ b/examples/php/echo/client.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+require dirname(__FILE__).'/vendor/autoload.php';
+
+$client = new Grpc\Gateway\Testing\EchoServiceClient('node-server:9090', [
+    'credentials' => Grpc\ChannelCredentials::createInsecure(),
+]);
+
+
+// unary call
+$request = new Grpc\Gateway\Testing\EchoRequest();
+$request->setMessage("Hello World!");
+
+list($response, $status) = $client->Echo($request)->wait();
+
+echo $response->getMessage()."\n";
+
+
+// server streaming call
+$stream_request = new Grpc\Gateway\Testing\ServerStreamingEchoRequest();
+$stream_request->setMessage("stream message");
+$stream_request->setMessageCount(5);
+
+$responses = $client->ServerStreamingEcho($stream_request)->responses();
+
+foreach ($responses as $response) {
+    echo $response->getMessage()."\n";
+}

--- a/examples/php/echo/composer.json
+++ b/examples/php/echo/composer.json
@@ -1,0 +1,12 @@
+{
+  "name": "grpc-php/echo-example",
+  "require": {
+    "grpc/grpc": "^v1.22.0",
+    "google/protobuf": "^3.7.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "": "./"
+    }
+  }
+}

--- a/examples/php/echo/echo.proto
+++ b/examples/php/echo/echo.proto
@@ -1,0 +1,100 @@
+// Copyright 2019 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package grpc.gateway.testing;
+
+message Empty {}
+
+message EchoRequest {
+  string message = 1;
+}
+
+message EchoResponse {
+  string message = 1;
+  int32 message_count = 2;
+}
+
+// Request type for server side streaming echo.
+message ServerStreamingEchoRequest {
+  // Message string for server streaming request.
+  string message = 1;
+
+  // The total number of messages to be generated before the server
+  // closes the stream; default is 10.
+  int32 message_count = 2;
+
+  // The interval (ms) between two server messages. The server implementation
+  // may enforce some minimum interval (e.g. 100ms) to avoid message overflow.
+  int32 message_interval = 3;
+}
+
+// Response type for server streaming response.
+message ServerStreamingEchoResponse {
+  // Response message.
+  string message = 1;
+}
+
+// Request type for client side streaming echo.
+message ClientStreamingEchoRequest {
+  // A special value "" indicates that there's no further messages.
+  string message = 1;
+}
+
+// Response type for client side streaming echo.
+message ClientStreamingEchoResponse {
+  // Total number of client messages that have been received.
+  int32 message_count = 1;
+}
+
+// A simple echo service.
+service EchoService {
+  // One request followed by one response
+  // The server returns the client message as-is.
+  rpc Echo(EchoRequest) returns (EchoResponse);
+
+  // Sends back abort status.
+  rpc EchoAbort(EchoRequest) returns (EchoResponse) {}
+
+  // One empty request, ZERO processing, followed by one empty response
+  // (minimum effort to do message serialization).
+  rpc NoOp(Empty) returns (Empty);
+
+  // One request followed by a sequence of responses (streamed download).
+  // The server will return the same client message repeatedly.
+  rpc ServerStreamingEcho(ServerStreamingEchoRequest)
+      returns (stream ServerStreamingEchoResponse);
+
+  // One request followed by a sequence of responses (streamed download).
+  // The server abort directly.
+  rpc ServerStreamingEchoAbort(ServerStreamingEchoRequest)
+      returns (stream ServerStreamingEchoResponse) {}
+
+  // A sequence of requests followed by one response (streamed upload).
+  // The server returns the total number of messages as the result.
+  rpc ClientStreamingEcho(stream ClientStreamingEchoRequest)
+      returns (ClientStreamingEchoResponse);
+
+  // A sequence of requests with each message echoed by the server immediately.
+  // The server returns the same client messages in order.
+  // E.g. this is how the speech API works.
+  rpc FullDuplexEcho(stream EchoRequest) returns (stream EchoResponse);
+
+  // A sequence of requests followed by a sequence of responses.
+  // The server buffers all the client messages and then returns the same
+  // client messages one by one after the client half-closes the stream.
+  // This is how an image recognition API may work.
+  rpc HalfDuplexEcho(stream EchoRequest) returns (stream EchoResponse);
+}

--- a/examples/php/echo/fpm.Dockerfile
+++ b/examples/php/echo/fpm.Dockerfile
@@ -1,0 +1,49 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM composer:1.8.6 as composer
+
+
+FROM grpc-php/base as grpc-base
+
+
+FROM php:7.2-fpm-stretch
+
+RUN apt-get -qq update && apt-get -qq install -y git
+
+
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+COPY --from=grpc-base /usr/local/bin/protoc /usr/local/bin/protoc
+
+COPY --from=grpc-base /github/grpc/bins/opt/grpc_php_plugin \
+  /usr/local/bin/protoc-gen-grpc
+
+COPY --from=grpc-base \
+  /usr/local/lib/php/extensions/no-debug-non-zts-20170718/grpc.so \
+  /usr/local/lib/php/extensions/no-debug-non-zts-20170718/grpc.so
+
+
+RUN docker-php-ext-enable grpc
+
+
+WORKDIR /var/www/html
+
+COPY client.php ./index.php
+COPY composer.json .
+COPY echo.proto .
+
+RUN protoc -I=. echo.proto --php_out=. --grpc_out=.
+
+RUN composer install

--- a/examples/php/echo/nginx.conf
+++ b/examples/php/echo/nginx.conf
@@ -1,0 +1,23 @@
+server {
+  listen 80;
+  server_name localhost;
+  root /var/www/html;
+
+  index index.php;
+
+  location / {
+    try_files $uri $uri/ /index.php?$args;
+  }
+
+  location ~ [^/]\.php(/|$) {
+    fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+
+    include fastcgi_params;
+    fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+    fastcgi_param PATH_INFO       $fastcgi_path_info;
+    fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
+
+    fastcgi_pass   fpm:9000;
+    fastcgi_index  index.php;
+  }
+}

--- a/src/php/bin/build_all_docker_images.sh
+++ b/src/php/bin/build_all_docker_images.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+cd $(dirname $0)/../../..
+
+ALL_IMAGES=( grpc-ext grpc-src alpine php5 php-src php-future php-zts
+             fork-support )
+
+if [[ "$1" == "--cmds" ]]; then
+  for arg in "${ALL_IMAGES[@]}"
+  do
+    echo "docker build -t grpc-php/$arg -f ./src/php/docker/$arg/Dockerfile ."
+  done
+  exit 0
+fi
+
+if [[ $# -eq 0 ]]; then
+  lst=("${ALL_IMAGES[@]}")
+else
+  lst=("$@")
+fi
+
+set -x
+for arg in "${lst[@]}"
+do
+  docker build -t grpc-php/"$arg" -f ./src/php/docker/"$arg"/Dockerfile .
+done

--- a/src/php/bin/run_all_docker_images.sh
+++ b/src/php/bin/run_all_docker_images.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Copyright 2018 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+cd $(dirname $0)/../../..
+
+ALL_IMAGES=( grpc-ext grpc-src alpine php5 php-src php-future php-zts
+             fork-support )
+
+if [[ "$1" == "--cmds" ]]; then
+  for arg in "${ALL_IMAGES[@]}"
+  do
+    echo "docker run -it --rm grpc-php/$arg"
+  done
+  exit 0
+fi
+
+if [[ $# -eq 0 ]]; then
+  lst=("${ALL_IMAGES[@]}")
+else
+  lst=("$@")
+fi
+
+set -x
+for arg in "${lst[@]}"
+do
+  docker run -it --rm grpc-php/"$arg"
+done

--- a/src/php/docker/README.md
+++ b/src/php/docker/README.md
@@ -1,0 +1,96 @@
+
+# Docker Images for Testing
+
+This directory contains a number of docker images to assist testing the
+[gRPC PECL extension](http://pecl.php.net/package/grpc) against various
+different PHP environments.
+
+
+## Build and Run Tests
+
+To build all docker images:
+
+```sh
+# cd grpc
+$ ./src/php/bin/build_all_docker_images.sh
+
+# or to only build some selected images
+$ ./src/php/bin/build_all_docker_images.sh grpc-ext php-src
+
+# or to only print out individual `docker build` commands
+$ ./src/php/bin/build_all_docker_images.sh --cmds
+```
+
+
+To run all tests:
+
+```sh
+$ cd grpc
+$ ./src/php/bin/run_all_docker_images.sh
+
+# or to only run some selected images
+$ ./src/php/bin/run_all_docker_images.sh grpc-ext php-src
+
+# or to only print out individual `docker run` commands
+$ ./src/php/bin/run_all_docker_images.sh --cmds
+```
+
+
+## `grpc-ext`
+
+This image builds the full `grpc` PECL extension (effectively the current
+release candidate), installs it against the current PHP version, and runs the
+unit tests.
+
+
+## `grpc-src`
+
+This image builds the `grpc` PECL extension in a 'thin' way, only containing
+the gRPC extension source files. The gRPC C Core library is expected to be
+installed separately and dynamically linked. The extension is installed
+against the current PHP version.
+
+This also allows us to compile our `grpc` extension with some additional
+configure options, like `--enable-tests`, which allows some additional unit
+tests to be run.
+
+
+## `alpine`
+
+This image builds the `grpc` extension against the current PHP version in an
+Alpine-Linux base image.
+
+
+## `php-src`
+
+Instead of using a general purpose base docker image provided by PHP, here we
+compile PHP itself from
+[source](https://github.com/php/php-src). This will allow us to change some
+`configure` options, like `--enable-debug`. Then we proceed to build the full
+`grpc` PECL extension and run the unit tests.
+
+
+## `php-zts`
+
+This image builds the `grpc` extension against the current PHP version with ZTS
+enabled.
+
+
+## `php-future`
+
+This image builds the `grpc` extension against the next future PHP version
+currently in alpha, beta or release candidate stage.
+
+
+## `php5`
+
+This image builds the `grpc` extension against a PHP 5 base image with ZTS
+enabled.
+
+NOTE: PHP 5.x has reached the end-of-life state and is no longer supported.
+
+
+## `fork-support`
+
+This image tests `pcntl_fork()` support and makes sure scripts using
+`pcntl_fork()` don't hang or crash.

--- a/src/php/docker/alpine/Dockerfile
+++ b/src/php/docker/alpine/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM php:7.2-alpine3.9
+
+RUN apk add autoconf g++ make zlib-dev git bash wget
+
+
+WORKDIR /tmp
+
+RUN wget https://phar.phpunit.de/phpunit-4.8.36.phar && \
+  mv phpunit-4.8.36.phar /usr/local/bin/phpunit && \
+  chmod +x /usr/local/bin/phpunit
+
+
+WORKDIR /github/grpc
+
+RUN git clone https://github.com/grpc/grpc . && \
+  git submodule update --init
+
+COPY src/ ./src
+
+RUN pear package && \
+  find . -name grpc-*.tgz | xargs -I{} pecl install {}
+
+
+CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests"]

--- a/src/php/docker/fork-support/Dockerfile
+++ b/src/php/docker/fork-support/Dockerfile
@@ -1,0 +1,27 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM grpc-php/php-src
+
+WORKDIR /tmp
+
+COPY src/php/docker/fork-support/fork.php .
+
+RUN echo '\
+extension=grpc.so\n\
+grpc.enable_fork_support=1\n\
+grpc.poll_strategy=epoll1\n\
+' >> /usr/local/lib/php.ini
+
+CMD ["php", "fork.php"]

--- a/src/php/docker/fork-support/fork.php
+++ b/src/php/docker/fork-support/fork.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+$pid = pcntl_fork();
+if ($pid == -1) {
+  die("could not fork");
+
+} else if ($pid) {
+  // parent
+  echo "parent waiting...\n";
+  pcntl_waitpid($pid, /*&*/$pcntl_status);
+
+} else {
+  // child
+  echo "child exiting...\n";
+  exit(0);
+}
+
+echo "parent finishing. Done\n";

--- a/src/php/docker/grpc-ext/Dockerfile
+++ b/src/php/docker/grpc-ext/Dockerfile
@@ -1,0 +1,40 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM php:7.2-stretch
+
+RUN apt-get -qq update && apt-get -qq install -y \
+  autoconf automake git libtool pkg-config \
+  valgrind wget zlib1g-dev
+
+
+WORKDIR /tmp
+
+RUN wget https://phar.phpunit.de/phpunit-4.8.36.phar && \
+  mv phpunit-4.8.36.phar /usr/local/bin/phpunit && \
+  chmod +x /usr/local/bin/phpunit
+
+
+WORKDIR /github/grpc
+
+RUN git clone https://github.com/grpc/grpc . && \
+  git submodule update --init
+
+COPY src/ ./src
+
+RUN pear package && \
+  find . -name grpc-*.tgz | xargs -I{} pecl install {}
+
+
+CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests"]

--- a/src/php/docker/grpc-src/Dockerfile
+++ b/src/php/docker/grpc-src/Dockerfile
@@ -1,0 +1,48 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM php:7.2-stretch
+
+RUN apt-get -qq update && apt-get -qq install -y \
+  autoconf automake git libtool pkg-config \
+  valgrind wget zlib1g-dev
+
+
+WORKDIR /tmp
+
+RUN wget https://phar.phpunit.de/phpunit-4.8.36.phar && \
+  mv phpunit-4.8.36.phar /usr/local/bin/phpunit && \
+  chmod +x /usr/local/bin/phpunit
+
+
+WORKDIR /github/grpc
+
+RUN git clone https://github.com/grpc/grpc . && \
+  git submodule update --init && \
+  make && make install
+
+
+WORKDIR /github/grpc/src/php/ext/grpc
+
+COPY src/php/ext/grpc/*.c ./
+COPY src/php/ext/grpc/*.h ./
+COPY src/php/ext/grpc/config.m4 ./
+
+RUN phpize && \
+  ./configure --enable-tests && \
+  make && \
+  make install
+
+
+CMD ["/github/grpc/src/php/bin/run_tests.sh"]

--- a/src/php/docker/php-future/Dockerfile
+++ b/src/php/docker/php-future/Dockerfile
@@ -1,0 +1,40 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM php:7.4.0RC1-buster
+
+RUN apt-get -qq update && apt-get -qq install -y \
+  autoconf automake git libtool pkg-config \
+  wget zlib1g-dev
+
+
+WORKDIR /tmp
+
+RUN wget https://phar.phpunit.de/phpunit-4.8.36.phar && \
+  mv phpunit-4.8.36.phar /usr/local/bin/phpunit && \
+  chmod +x /usr/local/bin/phpunit
+
+
+WORKDIR /github/grpc
+
+RUN git clone https://github.com/grpc/grpc . && \
+  git submodule update --init
+
+COPY src/ ./src
+
+RUN pear package && \
+  find . -name grpc-*.tgz | xargs -I{} pecl install {}
+
+
+CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests"]

--- a/src/php/docker/php-src/Dockerfile
+++ b/src/php/docker/php-src/Dockerfile
@@ -1,0 +1,62 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian:stretch
+
+RUN apt-get -qq update && apt-get -qq install -y \
+  autoconf build-essential git libtool \
+  libcurl4-openssl-dev libedit-dev libsodium-dev \
+  libssl-dev libxml2-dev \
+  pkg-config valgrind wget zlib1g-dev
+
+
+WORKDIR /tmp
+
+RUN wget https://phar.phpunit.de/phpunit-4.8.36.phar && \
+  mv phpunit-4.8.36.phar /usr/local/bin/phpunit && \
+  chmod +x /usr/local/bin/phpunit
+
+
+RUN wget http://ftp.gnu.org/gnu/bison/bison-3.4.2.tar.gz && \
+  tar -zxvf bison-3.4.2.tar.gz && \
+  cd bison-3.4.2 && \
+  ./configure && make && make install
+
+
+WORKDIR /github/php-src
+
+RUN git clone https://github.com/php/php-src .
+
+RUN git checkout php-7.2.22 && \
+  ./buildconf --force && \
+  ./configure --build=x86_64-linux-gnu --enable-option-checking=fatal \
+    --enable-debug --enable-pcntl \
+    --enable-ftp --enable-mbstring --enable-mysqlnd \
+    --with-curl --with-libedit --with-mhash --with-openssl \
+    --with-sodium=shared --with-zlib && \
+  make && make install
+
+
+WORKDIR /github/grpc
+
+RUN git clone https://github.com/grpc/grpc . && \
+  git submodule update --init
+
+COPY src/ ./src
+
+RUN pear package && \
+  find . -name grpc-*.tgz | xargs -I{} pecl install {}
+
+
+CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests"]

--- a/src/php/docker/php-zts/Dockerfile
+++ b/src/php/docker/php-zts/Dockerfile
@@ -1,0 +1,40 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM php:7.2-zts-stretch
+
+RUN apt-get -qq update && apt-get -qq install -y \
+  autoconf automake git libtool pkg-config \
+  wget zlib1g-dev
+
+
+WORKDIR /tmp
+
+RUN wget https://phar.phpunit.de/phpunit-4.8.36.phar && \
+  mv phpunit-4.8.36.phar /usr/local/bin/phpunit && \
+  chmod +x /usr/local/bin/phpunit
+
+
+WORKDIR /github/grpc
+
+RUN git clone https://github.com/grpc/grpc . && \
+  git submodule update --init
+
+COPY src/ ./src
+
+RUN pear package && \
+  find . -name grpc-*.tgz | xargs -I{} pecl install {}
+
+
+CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests"]

--- a/src/php/docker/php5/Dockerfile
+++ b/src/php/docker/php5/Dockerfile
@@ -1,0 +1,40 @@
+# Copyright 2019 gRPC authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM php:5.6-zts-stretch
+
+RUN apt-get -qq update && apt-get -qq install -y \
+  autoconf automake git libtool pkg-config \
+  valgrind wget zlib1g-dev
+
+
+WORKDIR /tmp
+
+RUN wget https://phar.phpunit.de/phpunit-4.8.36.phar && \
+  mv phpunit-4.8.36.phar /usr/local/bin/phpunit && \
+  chmod +x /usr/local/bin/phpunit
+
+
+WORKDIR /github/grpc
+
+RUN git clone https://github.com/grpc/grpc . && \
+  git submodule update --init
+
+COPY src/ ./src
+
+RUN pear package && \
+  find . -name grpc-*.tgz | xargs -I{} pecl install {}
+
+
+CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests"]

--- a/templates/examples/php/echo/apache.Dockerfile.template
+++ b/templates/examples/php/echo/apache.Dockerfile.template
@@ -1,0 +1,41 @@
+%YAML 1.2
+--- |
+  # Copyright 2019 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  FROM composer:1.8.6 as composer
+
+
+  FROM grpc-php/base as grpc-base
+
+
+  FROM php:${settings.php_version.php_current_version()}-apache-${settings.php_version.php_debian_version()}
+
+  RUN apt-get -qq update && apt-get -qq install -y git
+
+
+  <%include file="copy_from_grpc_base.include" />
+
+  RUN docker-php-ext-enable grpc
+
+
+  WORKDIR /var/www/html
+
+  COPY client.php ./index.php
+  COPY composer.json .
+  COPY echo.proto .
+
+  RUN protoc -I=. echo.proto --php_out=. --grpc_out=.
+
+  RUN composer install

--- a/templates/examples/php/echo/base.Dockerfile.template
+++ b/templates/examples/php/echo/base.Dockerfile.template
@@ -1,0 +1,40 @@
+%YAML 1.2
+--- |
+  # Copyright 2019 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  FROM php:${settings.php_version.php_current_version()}-${settings.php_version.php_debian_version()}
+
+  RUN apt-get -qq update && apt-get -qq install -y ${'\\'}
+    autoconf automake curl git libtool ${'\\'}
+    pkg-config unzip zlib1g-dev
+
+
+  WORKDIR /tmp
+
+  RUN curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.8.0/${'\\'}
+  protoc-3.8.0-linux-x86_64.zip -o /tmp/protoc.zip && ${'\\'}
+    unzip -qq protoc.zip && ${'\\'}
+    cp /tmp/bin/protoc /usr/local/bin/protoc
+
+
+  WORKDIR /github/grpc
+
+  RUN git clone https://github.com/grpc/grpc . && ${'\\'}
+    git submodule update --init && ${'\\'}
+    cd third_party/protobuf && git submodule update --init
+
+  RUN make grpc_php_plugin
+
+  RUN pecl install grpc

--- a/templates/examples/php/echo/cli.Dockerfile.template
+++ b/templates/examples/php/echo/cli.Dockerfile.template
@@ -1,0 +1,44 @@
+%YAML 1.2
+--- |
+  # Copyright 2019 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  FROM composer:1.8.6 as composer
+
+
+  FROM grpc-php/base as grpc-base
+
+
+  FROM php:${settings.php_version.php_current_version()}-${settings.php_version.php_debian_version()}
+
+  RUN apt-get -qq update && apt-get -qq install -y git
+
+
+  <%include file="copy_from_grpc_base.include" />
+
+  RUN docker-php-ext-enable grpc
+
+
+  WORKDIR /github/grpc-php/examples/echo
+
+  COPY client.php .
+  COPY composer.json .
+  COPY echo.proto .
+
+  RUN protoc -I=. echo.proto --php_out=. --grpc_out=.
+
+  RUN composer install
+
+
+  CMD ["/bin/bash"]

--- a/templates/examples/php/echo/copy_from_grpc_base.include
+++ b/templates/examples/php/echo/copy_from_grpc_base.include
@@ -1,0 +1,10 @@
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+COPY --from=grpc-base /usr/local/bin/protoc /usr/local/bin/protoc
+
+COPY --from=grpc-base /github/grpc/bins/opt/grpc_php_plugin ${'\\'}
+  /usr/local/bin/protoc-gen-grpc
+
+COPY --from=grpc-base ${'\\'}
+  /usr/local/lib/php/extensions/no-debug-non-zts-20170718/grpc.so ${'\\'}
+  /usr/local/lib/php/extensions/no-debug-non-zts-20170718/grpc.so

--- a/templates/examples/php/echo/fpm.Dockerfile.template
+++ b/templates/examples/php/echo/fpm.Dockerfile.template
@@ -1,0 +1,41 @@
+%YAML 1.2
+--- |
+  # Copyright 2019 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  FROM composer:1.8.6 as composer
+
+
+  FROM grpc-php/base as grpc-base
+
+
+  FROM php:${settings.php_version.php_current_version()}-fpm-${settings.php_version.php_debian_version()}
+
+  RUN apt-get -qq update && apt-get -qq install -y git
+
+
+  <%include file="copy_from_grpc_base.include" />
+
+  RUN docker-php-ext-enable grpc
+
+
+  WORKDIR /var/www/html
+
+  COPY client.php ./index.php
+  COPY composer.json .
+  COPY echo.proto .
+
+  RUN protoc -I=. echo.proto --php_out=. --grpc_out=.
+
+  RUN composer install

--- a/templates/src/php/docker/alpine/Dockerfile.template
+++ b/templates/src/php/docker/alpine/Dockerfile.template
@@ -1,0 +1,28 @@
+%YAML 1.2
+--- |
+  # Copyright 2019 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  FROM php:${settings.php_version.php_current_version()}-alpine3.9
+
+  RUN apk add autoconf g++ make zlib-dev git bash wget
+
+
+  WORKDIR /tmp
+
+  <%include file="../download_phpunit.include" />
+
+  <%include file="../pecl_ext_build_src.include" />
+
+  CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests"]

--- a/templates/src/php/docker/download_phpunit.include
+++ b/templates/src/php/docker/download_phpunit.include
@@ -1,0 +1,3 @@
+RUN wget https://phar.phpunit.de/phpunit-4.8.36.phar && ${'\\'}
+  mv phpunit-4.8.36.phar /usr/local/bin/phpunit && ${'\\'}
+  chmod +x /usr/local/bin/phpunit

--- a/templates/src/php/docker/grpc-ext/Dockerfile.template
+++ b/templates/src/php/docker/grpc-ext/Dockerfile.template
@@ -1,0 +1,30 @@
+%YAML 1.2
+--- |
+  # Copyright 2019 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  FROM php:${settings.php_version.php_current_version()}-${settings.php_version.php_debian_version()}
+
+  RUN apt-get -qq update && apt-get -qq install -y ${'\\'}
+    autoconf automake git libtool pkg-config ${'\\'}
+    valgrind wget zlib1g-dev
+
+
+  WORKDIR /tmp
+
+  <%include file="../download_phpunit.include" />
+
+  <%include file="../pecl_ext_build_src.include" />
+
+  CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests"]

--- a/templates/src/php/docker/grpc-src/Dockerfile.template
+++ b/templates/src/php/docker/grpc-src/Dockerfile.template
@@ -1,0 +1,47 @@
+%YAML 1.2
+--- |
+  # Copyright 2019 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  FROM php:${settings.php_version.php_current_version()}-${settings.php_version.php_debian_version()}
+
+  RUN apt-get -qq update && apt-get -qq install -y ${'\\'}
+    autoconf automake git libtool pkg-config ${'\\'}
+    valgrind wget zlib1g-dev
+
+
+  WORKDIR /tmp
+
+  <%include file="../download_phpunit.include" />
+
+  WORKDIR /github/grpc
+
+  RUN git clone https://github.com/grpc/grpc . && ${'\\'}
+    git submodule update --init && ${'\\'}
+    make && make install
+
+
+  WORKDIR /github/grpc/src/php/ext/grpc
+
+  COPY src/php/ext/grpc/*.c ./
+  COPY src/php/ext/grpc/*.h ./
+  COPY src/php/ext/grpc/config.m4 ./
+
+  RUN phpize && ${'\\'}
+    ./configure --enable-tests && ${'\\'}
+    make && ${'\\'}
+    make install
+
+
+  CMD ["/github/grpc/src/php/bin/run_tests.sh"]

--- a/templates/src/php/docker/pecl_ext_build_src.include
+++ b/templates/src/php/docker/pecl_ext_build_src.include
@@ -1,0 +1,9 @@
+WORKDIR /github/grpc
+
+RUN git clone https://github.com/grpc/grpc . && ${'\\'}
+  git submodule update --init
+
+COPY src/ ./src
+
+RUN pear package && ${'\\'}
+  find . -name grpc-*.tgz | xargs -I{} pecl install {}

--- a/templates/src/php/docker/php-future/Dockerfile.template
+++ b/templates/src/php/docker/php-future/Dockerfile.template
@@ -1,0 +1,30 @@
+%YAML 1.2
+--- |
+  # Copyright 2019 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  FROM php:7.4.0RC1-buster
+
+  RUN apt-get -qq update && apt-get -qq install -y ${'\\'}
+    autoconf automake git libtool pkg-config ${'\\'}
+    wget zlib1g-dev
+
+
+  WORKDIR /tmp
+
+  <%include file="../download_phpunit.include" />
+
+  <%include file="../pecl_ext_build_src.include" />
+
+  CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests"]

--- a/templates/src/php/docker/php-src/Dockerfile.template
+++ b/templates/src/php/docker/php-src/Dockerfile.template
@@ -1,0 +1,52 @@
+%YAML 1.2
+--- |
+  # Copyright 2019 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  FROM debian:${settings.php_version.php_debian_version()}
+
+  RUN apt-get -qq update && apt-get -qq install -y ${'\\'}
+    autoconf build-essential git libtool ${'\\'}
+    libcurl4-openssl-dev libedit-dev libsodium-dev ${'\\'}
+    libssl-dev libxml2-dev ${'\\'}
+    pkg-config valgrind wget zlib1g-dev
+
+
+  WORKDIR /tmp
+
+  <%include file="../download_phpunit.include" />
+
+  RUN wget http://ftp.gnu.org/gnu/bison/bison-3.4.2.tar.gz && ${'\\'}
+    tar -zxvf bison-3.4.2.tar.gz && ${'\\'}
+    cd bison-3.4.2 && ${'\\'}
+    ./configure && make && make install
+
+
+  WORKDIR /github/php-src
+
+  RUN git clone https://github.com/php/php-src .
+
+  RUN git checkout php-7.2.22 && ${'\\'}
+    ./buildconf --force && ${'\\'}
+    ./configure --build=x86_64-linux-gnu --enable-option-checking=fatal ${'\\'}
+      --enable-debug --enable-pcntl ${'\\'}
+      --enable-ftp --enable-mbstring --enable-mysqlnd ${'\\'}
+      --with-curl --with-libedit --with-mhash --with-openssl ${'\\'}
+      --with-sodium=shared --with-zlib && ${'\\'}
+    make && make install
+
+
+  <%include file="../pecl_ext_build_src.include" />
+
+  CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests"]

--- a/templates/src/php/docker/php-zts/Dockerfile.template
+++ b/templates/src/php/docker/php-zts/Dockerfile.template
@@ -1,0 +1,30 @@
+%YAML 1.2
+--- |
+  # Copyright 2019 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  FROM php:${settings.php_version.php_current_version()}-zts-${settings.php_version.php_debian_version()}
+
+  RUN apt-get -qq update && apt-get -qq install -y ${'\\'}
+    autoconf automake git libtool pkg-config ${'\\'}
+    wget zlib1g-dev
+
+
+  WORKDIR /tmp
+
+  <%include file="../download_phpunit.include" />
+
+  <%include file="../pecl_ext_build_src.include" />
+
+  CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests"]

--- a/templates/src/php/docker/php5/Dockerfile.template
+++ b/templates/src/php/docker/php5/Dockerfile.template
@@ -1,0 +1,30 @@
+%YAML 1.2
+--- |
+  # Copyright 2019 gRPC authors.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+  FROM php:5.6-zts-stretch
+
+  RUN apt-get -qq update && apt-get -qq install -y ${'\\'}
+    autoconf automake git libtool pkg-config ${'\\'}
+    valgrind wget zlib1g-dev
+
+
+  WORKDIR /tmp
+
+  <%include file="../download_phpunit.include" />
+
+  <%include file="../pecl_ext_build_src.include" />
+
+  CMD ["/github/grpc/src/php/bin/run_tests.sh", "--skip-persistent-channel-tests"]

--- a/tools/buildgen/plugins/expand_version.py
+++ b/tools/buildgen/plugins/expand_version.py
@@ -100,6 +100,12 @@ class Version:
         """Version string for PHP Composer package"""
         return '%d.%d.%d' % (self.major, self.minor, self.patch)
 
+    def php_current_version(self):
+        return '7.2'
+
+    def php_debian_version(self):
+        return 'stretch'
+
 
 def mako_plugin(dictionary):
     """Expand version numbers:


### PR DESCRIPTION
This PR tries to serve two purposes:

1. Show how easy it is to build a gRPC PHP client, connecting to a gRPC server. There had been a number of ask from users to show how the gRPC PHP client can work with Apache or PHP-FPM with Nginx and here we have a couple of simple docker images. Just build and run them!

All source code are in the `examples/php/echo` directory.

2. Over the course of last few months we run into several issues with our `grpc` extension due to the variation of the PHP runtime itself. What if PHP is run on Alpine? What if PHP has ZTS enabled? What if PHP is a debug build? What about `pcntl_fork()`? etc, etc. Here we created a suite of docker images to make sure we test all these scenarios during development, and the release candidate process, hopefully to cut down on these unexpected events.

All source code are in the `src/php/docker` directory

Also, most of the `Dockerfile` here are templatized (see the `templates/` directory) to cut down on the repeated snippets. 