### PR TITLE
Update grpc_ssl_peer_to_auth_context() to take in transport security type as a parameter

### DIFF
--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.cc
@@ -56,7 +56,8 @@ grpc_error* ssl_check_peer(
     gpr_free(msg);
     return error;
   }
-  *auth_context = grpc_ssl_peer_to_auth_context(peer);
+  *auth_context =
+      grpc_ssl_peer_to_auth_context(peer, GRPC_SSL_TRANSPORT_SECURITY_TYPE);
   return GRPC_ERROR_NONE;
 }
 

--- a/src/core/lib/security/security_connector/ssl_utils.cc
+++ b/src/core/lib/security/security_connector/ssl_utils.cc
@@ -195,7 +195,7 @@ int grpc_ssl_cmp_target_name(
 }
 
 grpc_core::RefCountedPtr<grpc_auth_context> grpc_ssl_peer_to_auth_context(
-    const tsi_peer* peer) {
+    const tsi_peer* peer, const char* transport_security_type) {
   size_t i;
   const char* peer_identity_property_name = nullptr;
 
@@ -205,7 +205,7 @@ grpc_core::RefCountedPtr<grpc_auth_context> grpc_ssl_peer_to_auth_context(
       grpc_core::MakeRefCounted<grpc_auth_context>(nullptr);
   grpc_auth_context_add_cstring_property(
       ctx.get(), GRPC_TRANSPORT_SECURITY_TYPE_PROPERTY_NAME,
-      GRPC_SSL_TRANSPORT_SECURITY_TYPE);
+      transport_security_type);
   for (i = 0; i < peer->property_count; i++) {
     const tsi_peer_property* prop = &peer->properties[i];
     if (prop->name == nullptr) continue;

--- a/src/core/lib/security/security_connector/ssl_utils.h
+++ b/src/core/lib/security/security_connector/ssl_utils.h
@@ -85,7 +85,7 @@ grpc_security_status grpc_ssl_tsi_server_handshaker_factory_init(
 
 /* Exposed for testing only. */
 grpc_core::RefCountedPtr<grpc_auth_context> grpc_ssl_peer_to_auth_context(
-    const tsi_peer* peer);
+    const tsi_peer* peer, const char* transport_security_type);
 tsi_peer grpc_shallow_peer_from_ssl_auth_context(
     const grpc_auth_context* auth_context);
 void grpc_shallow_peer_destruct(tsi_peer* peer);

--- a/src/core/lib/security/security_connector/tls/spiffe_security_connector.cc
+++ b/src/core/lib/security/security_connector/tls/spiffe_security_connector.cc
@@ -173,7 +173,8 @@ void SpiffeChannelSecurityConnector::check_peer(
     tsi_peer_destruct(&peer);
     return;
   }
-  *auth_context = grpc_ssl_peer_to_auth_context(&peer);
+  *auth_context = grpc_ssl_peer_to_auth_context(
+      &peer, GRPC_TLS_SPIFFE_TRANSPORT_SECURITY_TYPE);
   const SpiffeCredentials* creds =
       static_cast<const SpiffeCredentials*>(channel_creds());
   const grpc_tls_server_authorization_check_config* config =
@@ -436,7 +437,8 @@ void SpiffeServerSecurityConnector::check_peer(
     grpc_core::RefCountedPtr<grpc_auth_context>* auth_context,
     grpc_closure* on_peer_checked) {
   grpc_error* error = grpc_ssl_check_alpn(&peer);
-  *auth_context = grpc_ssl_peer_to_auth_context(&peer);
+  *auth_context = grpc_ssl_peer_to_auth_context(
+      &peer, GRPC_TLS_SPIFFE_TRANSPORT_SECURITY_TYPE);
   tsi_peer_destruct(&peer);
   GRPC_CLOSURE_SCHED(on_peer_checked, error);
 }

--- a/test/core/security/security_connector_test.cc
+++ b/test/core/security/security_connector_test.cc
@@ -92,7 +92,7 @@ static void test_unauthenticated_ssl_peer(void) {
                  TSI_CERTIFICATE_TYPE_PEER_PROPERTY, TSI_X509_CERTIFICATE_TYPE,
                  &peer.properties[0]) == TSI_OK);
   grpc_core::RefCountedPtr<grpc_auth_context> ctx =
-      grpc_ssl_peer_to_auth_context(&peer);
+      grpc_ssl_peer_to_auth_context(&peer, GRPC_SSL_TRANSPORT_SECURITY_TYPE);
   GPR_ASSERT(ctx != nullptr);
   GPR_ASSERT(!grpc_auth_context_peer_is_authenticated(ctx.get()));
   GPR_ASSERT(check_transport_security_type(ctx.get()));
@@ -192,7 +192,7 @@ static void test_cn_only_ssl_peer_to_auth_context(void) {
                  TSI_X509_PEM_CERT_PROPERTY, expected_pem_cert,
                  &peer.properties[2]) == TSI_OK);
   grpc_core::RefCountedPtr<grpc_auth_context> ctx =
-      grpc_ssl_peer_to_auth_context(&peer);
+      grpc_ssl_peer_to_auth_context(&peer, GRPC_SSL_TRANSPORT_SECURITY_TYPE);
   GPR_ASSERT(ctx != nullptr);
   GPR_ASSERT(grpc_auth_context_peer_is_authenticated(ctx.get()));
   GPR_ASSERT(
@@ -230,7 +230,7 @@ static void test_cn_and_one_san_ssl_peer_to_auth_context(void) {
                  &peer.properties[3]) == TSI_OK);
 
   grpc_core::RefCountedPtr<grpc_auth_context> ctx =
-      grpc_ssl_peer_to_auth_context(&peer);
+      grpc_ssl_peer_to_auth_context(&peer, GRPC_SSL_TRANSPORT_SECURITY_TYPE);
   GPR_ASSERT(ctx != nullptr);
   GPR_ASSERT(grpc_auth_context_peer_is_authenticated(ctx.get()));
   GPR_ASSERT(
@@ -271,7 +271,7 @@ static void test_cn_and_multiple_sans_ssl_peer_to_auth_context(void) {
                    expected_sans[i], &peer.properties[3 + i]) == TSI_OK);
   }
   grpc_core::RefCountedPtr<grpc_auth_context> ctx =
-      grpc_ssl_peer_to_auth_context(&peer);
+      grpc_ssl_peer_to_auth_context(&peer, GRPC_SSL_TRANSPORT_SECURITY_TYPE);
   GPR_ASSERT(ctx != nullptr);
   GPR_ASSERT(grpc_auth_context_peer_is_authenticated(ctx.get()));
   GPR_ASSERT(check_identity(ctx.get(), GRPC_X509_SAN_PROPERTY_NAME,
@@ -317,7 +317,7 @@ static void test_cn_and_multiple_sans_and_others_ssl_peer_to_auth_context(
                    expected_sans[i], &peer.properties[5 + i]) == TSI_OK);
   }
   grpc_core::RefCountedPtr<grpc_auth_context> ctx =
-      grpc_ssl_peer_to_auth_context(&peer);
+      grpc_ssl_peer_to_auth_context(&peer, GRPC_SSL_TRANSPORT_SECURITY_TYPE);
   GPR_ASSERT(ctx != nullptr);
   GPR_ASSERT(grpc_auth_context_peer_is_authenticated(ctx.get()));
   GPR_ASSERT(check_identity(ctx.get(), GRPC_X509_SAN_PROPERTY_NAME,


### PR DESCRIPTION
`grpc_ssl_peer_to_auth_context()` is used by both SSL and SPIFFE and we need to distinguish them for transport security type in `grpc_auth_context`. 