### PR TITLE
Fix Ruby 2.7 compatibility in GenericService.underscore

### DIFF
--- a/src/ruby/lib/grpc/generic/service.rb
+++ b/src/ruby/lib/grpc/generic/service.rb
@@ -31,6 +31,7 @@ module GRPC
     #
     # @param s [String] the string to be converted.
     def self.underscore(s)
+      s = +s # Avoid mutating the argument, as it might be frozen.
       s.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
       s.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
       s.tr!('-', '_')

--- a/src/ruby/spec/generic/service_spec.rb
+++ b/src/ruby/spec/generic/service_spec.rb
@@ -55,6 +55,8 @@ describe GenericService do
       expect(GenericService.underscore('AMethod')).to eq('a_method')
       expect(GenericService.underscore('PrintHTML')).to eq('print_html')
       expect(GenericService.underscore('SeeHTMLBooks')).to eq('see_html_books')
+
+      expect(GenericService.underscore('SeeHTMLBooks'.freeze)).to eq('see_html_books')
     end
   end
 


### PR DESCRIPTION
Ruby recently merged an experimental feature that is very likely to make it to the 2.7 release in december: https://bugs.ruby-lang.org/issues/16150.

In short `Symbol#to_s` will now return a frozen string.

This is breaking the `grpc` gem because the `rpc` dsl directly forward the result of `Symbol#to_s` to the `underscore` helper which then tries to mutate it.

### The fix

Since `grpc` require Ruby 2.3+, we can use [`String#+@`](https://ruby-doc.org/core-2.6/String.html#method-i-2B-40) to conditionally dup the string if it's frozen.

@apolcyn 

