### PR TITLE
Fix error in usage of _SC_THREAD_STACK_MIN in test

### DIFF
--- a/src/core/lib/gprpp/thd_posix.cc
+++ b/src/core/lib/gprpp/thd_posix.cc
@@ -59,8 +59,9 @@ size_t RoundUpToPageSize(size_t size) {
 // Returns the minimum valid stack size that can be passed to
 // pthread_attr_setstacksize.
 size_t MinValidStackSize(size_t request_size) {
-  if (request_size < _SC_THREAD_STACK_MIN) {
-    request_size = _SC_THREAD_STACK_MIN;
+  size_t min_stacksize = sysconf(_SC_THREAD_STACK_MIN);
+  if (request_size < min_stacksize) {
+    request_size = min_stacksize;
   }
 
   // On some systems, pthread_attr_setstacksize() can fail if stacksize is


### PR DESCRIPTION
_SC_THREAD_STACK_MIN is intended to be used as an argument to sysconf
and not by itself.  This may have slipped past testing on x86 due to
the round up to page size, but failed on aarch64 because aarch64 has
conservative stack guard requirements to account for different page
sizes (4K and 64K).

Sysconfs get used correctly elsewhere in this file, so this is likely
just a typo.




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
