### PR TITLE
Make grpc_testing's Servicer context abort method stop execution of the servicer handler

### DIFF
--- a/src/python/grpcio_testing/grpc_testing/_server/_servicer_context.py
+++ b/src/python/grpcio_testing/grpc_testing/_server/_servicer_context.py
@@ -76,6 +76,7 @@ class ServicerContext(grpc.ServicerContext):
     def abort(self, code, details):
         with self._rpc._condition:
             self._rpc._abort(code, details)
+        raise Exception()
 
     def abort_with_status(self, status):
         raise NotImplementedError()

--- a/src/python/grpcio_tests/tests/testing/_application_common.py
+++ b/src/python/grpcio_tests/tests/testing/_application_common.py
@@ -32,5 +32,10 @@ STREAM_UNARY_RESPONSE = services_pb2.Strange(first_strange_field=17)
 STREAM_STREAM_REQUEST = requests_pb2.Top(first_top_field=19)
 STREAM_STREAM_RESPONSE = services_pb2.Bottom(first_bottom_field=23)
 TWO_STREAM_STREAM_RESPONSES = (STREAM_STREAM_RESPONSE,) * 2
+ABORT_REQUEST = requests_pb2.Up(first_up_field=42)
+ABORT_SUCCESS_QUERY = requests_pb2.Up(first_up_field=43)
+ABORT_NO_STATUS_RESPONSE = services_pb2.Down(first_down_field=50)
+ABORT_SUCCESS_RESPONSE = services_pb2.Down(first_down_field=51)
+ABORT_FAILURE_RESPONSE = services_pb2.Down(first_down_field=52)
 
 INFINITE_REQUEST_STREAM_TIMEOUT = 0.2

--- a/src/python/grpcio_tests/tests/testing/_server_application.py
+++ b/src/python/grpcio_tests/tests/testing/_server_application.py
@@ -15,6 +15,8 @@
 
 import grpc
 
+import threading
+
 # requests_pb2 is a semantic dependency of this module.
 from tests.testing import _application_common
 from tests.testing.proto import requests_pb2  # pylint: disable=unused-import
@@ -25,9 +27,25 @@ from tests.testing.proto import services_pb2_grpc
 class FirstServiceServicer(services_pb2_grpc.FirstServiceServicer):
     """Services RPCs."""
 
+    def __init__(self):
+        self._abort_lock = threading.RLock()
+        self._abort_response = _application_common.ABORT_NO_STATUS_RESPONSE
+
     def UnUn(self, request, context):
         if _application_common.UNARY_UNARY_REQUEST == request:
             return _application_common.UNARY_UNARY_RESPONSE
+        elif request == _application_common.ABORT_REQUEST:
+            with self._abort_lock:
+                try:
+                    context.abort(grpc.StatusCode.PERMISSION_DENIED,
+                                  "Denying permission to test abort.")
+                except Exception as e:
+                    self._abort_response = _application_common.ABORT_SUCCESS_RESPONSE
+                else:
+                    self._abort_status = _application_common.ABORT_FAILURE_RESPONSE
+        elif request == _application_common.ABORT_SUCCESS_QUERY:
+            with self._abort_lock:
+                return self._abort_response
         else:
             context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
             context.set_details('Something is wrong with your request!')

--- a/src/python/grpcio_tests/tests/testing/_server_application.py
+++ b/src/python/grpcio_tests/tests/testing/_server_application.py
@@ -32,7 +32,7 @@ class FirstServiceServicer(services_pb2_grpc.FirstServiceServicer):
         self._abort_response = _application_common.ABORT_NO_STATUS_RESPONSE
 
     def UnUn(self, request, context):
-        if _application_common.UNARY_UNARY_REQUEST == request:
+        if request == _application_common.UNARY_UNARY_REQUEST:
             return _application_common.UNARY_UNARY_RESPONSE
         elif request == _application_common.ABORT_REQUEST:
             with self._abort_lock:

--- a/src/python/grpcio_tests/tests/testing/_server_application.py
+++ b/src/python/grpcio_tests/tests/testing/_server_application.py
@@ -39,10 +39,11 @@ class FirstServiceServicer(services_pb2_grpc.FirstServiceServicer):
                 try:
                     context.abort(grpc.StatusCode.PERMISSION_DENIED,
                                   "Denying permission to test abort.")
-                except Exception as e:
+                except Exception as e:  # pylint: disable=broad-except
                     self._abort_response = _application_common.ABORT_SUCCESS_RESPONSE
                 else:
                     self._abort_status = _application_common.ABORT_FAILURE_RESPONSE
+            return None  # NOTE: For the linter.
         elif request == _application_common.ABORT_SUCCESS_QUERY:
             with self._abort_lock:
                 return self._abort_response

--- a/src/python/grpcio_tests/tests/testing/_server_test.py
+++ b/src/python/grpcio_tests/tests/testing/_server_test.py
@@ -168,12 +168,12 @@ class FirstServiceServicerTest(unittest.TestCase):
         rpc = self._real_time_server.invoke_unary_unary(
             _application_testing_common.FIRST_SERVICE_UNUN, (),
             _application_common.ABORT_REQUEST, None)
-        response, trailing_metadata, code, details = rpc.termination()
+        _, _, code, _ = rpc.termination()
         self.assertIs(code, grpc.StatusCode.PERMISSION_DENIED)
         rpc = self._real_time_server.invoke_unary_unary(
             _application_testing_common.FIRST_SERVICE_UNUN, (),
             _application_common.ABORT_SUCCESS_QUERY, None)
-        response, trailing_metadata, code, details = rpc.termination()
+        response, _, code, _ = rpc.termination()
         self.assertEqual(_application_common.ABORT_SUCCESS_RESPONSE, response)
         self.assertIs(code, grpc.StatusCode.OK)
 

--- a/src/python/grpcio_tests/tests/testing/_server_test.py
+++ b/src/python/grpcio_tests/tests/testing/_server_test.py
@@ -164,6 +164,19 @@ class FirstServiceServicerTest(unittest.TestCase):
 
         self.assertIs(code, grpc.StatusCode.DEADLINE_EXCEEDED)
 
+    def test_servicer_context_abort(self):
+        rpc = self._real_time_server.invoke_unary_unary(
+            _application_testing_common.FIRST_SERVICE_UNUN, (),
+            _application_common.ABORT_REQUEST, None)
+        response, trailing_metadata, code, details = rpc.termination()
+        self.assertIs(code, grpc.StatusCode.PERMISSION_DENIED)
+        rpc = self._real_time_server.invoke_unary_unary(
+            _application_testing_common.FIRST_SERVICE_UNUN, (),
+            _application_common.ABORT_SUCCESS_QUERY, None)
+        response, trailing_metadata, code, details = rpc.termination()
+        self.assertEqual(_application_common.ABORT_SUCCESS_RESPONSE, response)
+        self.assertIs(code, grpc.StatusCode.OK)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
https://github.com/grpc/grpc/pull/20077 implemented `context.abort()` in `grpc_testing`, but it does not completely fulfill the contract laid out in the API docs:

> Raises an exception to terminate the RPC with a non-OK status.

In that PR, no exception was raised on the servicer side, allowing execution to continue in applications' handlers past the call to `context.abort()`. Ironically, the previous `raise NotImplementedError()` implementation *did* fulfill this aspect of the API contract and some internal users have come to rely on it.

This PR fixes the implementation and adds a test of the proper behavior.