### PR TITLE
Windows RBE testing improvements

### DIFF
--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -24,7 +24,7 @@ powershell -Command "[guid]::NewGuid().ToString()" >%KOKORO_ARTIFACTS_DIR%/bazel
 set /p BAZEL_INVOCATION_ID=<%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
 
 @rem TODO(jtattermusch): windows RBE should be able to use the same credentials as Linux RBE.
-bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json //test/...
+bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" %RUN_TESTS_FLAGS% --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json //test/...
 set BAZEL_EXITCODE=%errorlevel%
 
 @rem TODO(jtattermusch): upload results to bigquery

--- a/tools/internal_ci/windows/grpc_bazel_rbe_dbg.cfg
+++ b/tools/internal_ci/windows/grpc_bazel_rbe_dbg.cfg
@@ -30,3 +30,10 @@ bazel_setting {
   # command is invoked).
   upsalite_frontend_address: "https://source.cloud.google.com"
 }
+
+env_vars {
+  # flags will be passed to bazel invocation by bazel_rbe.bat
+  key: "RUN_TESTS_FLAGS"
+  # TODO(jtattermusch): add --config=dbg once that works
+  value: "--cache_test_results=no"
+}

--- a/tools/internal_ci/windows/pull_request/grpc_bazel_rbe_dbg.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_bazel_rbe_dbg.cfg
@@ -30,3 +30,10 @@ bazel_setting {
   # command is invoked).
   upsalite_frontend_address: "https://source.cloud.google.com"
 }
+
+env_vars {
+  # flags will be passed to bazel invocation by bazel_rbe.bat
+  key: "RUN_TESTS_FLAGS"
+  # TODO(jtattermusch): add --config=dbg once that works
+  value: ""
+}

--- a/tools/remote_build/windows.bazelrc
+++ b/tools/remote_build/windows.bazelrc
@@ -47,7 +47,7 @@ build --bes_timeout=60s
 build --bes_results_url="https://source.cloud.google.com/results/invocations/"
 build --project_id=grpc-testing
 
-build --jobs=30
+build --jobs=100
 
 # print output for tests that fail (default is "summary")
 build --test_output=errors


### PR DESCRIPTION
- make sure we are running tests on master without test caching, to get more insight on which test cases are flaky on Win RBE.