### PR TITLE
Issue 19208: Fix pollset_set_del_fd to cleanup all fd references.

### DIFF
--- a/src/core/lib/iomgr/ev_poll_posix.cc
+++ b/src/core/lib/iomgr/ev_poll_posix.cc
@@ -1379,7 +1379,9 @@ static void reset_event_manager_on_fork() {
   gpr_mu_lock(&fork_fd_list_mu);
   while (fork_fd_list_head != nullptr) {
     if (fork_fd_list_head->fd != nullptr) {
-      close(fork_fd_list_head->fd->fd);
+      if (!fork_fd_list_head->fd->closed) {
+        close(fork_fd_list_head->fd->fd);
+      }
       fork_fd_list_head->fd->fd = -1;
     } else {
       close(fork_fd_list_head->cached_wakeup_fd->fd.read_fd);


### PR DESCRIPTION
Make the logic of pollset_set_del_fd mirror that of
polsset_set_add_fd. The latter has 3 distinct stanzas where an FD can
be referenced (in fds, pollset, pollset_sets).  Prior to this change
pollset_set_del_fd only removed references from fds and pollset_sets.



<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
