### PR TITLE
Removed singleton CQ contention in callback mode.

### DIFF
--- a/include/grpcpp/server_impl.h
+++ b/include/grpcpp/server_impl.h
@@ -372,11 +372,11 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
 
   // callback_cq_shards_references the callbackable completion queues associated
   // with this server (if any). It is set on the first call to CallbackCQ().
-  // It is _not owned_ by the server; ownership belongs with its internal
-  // shutdown callback tag (invoked when the CQ is fully shutdown).
-  // It is protected by mu_
-  CompletionQueue** callback_cq_shards_ = nullptr;
-  size_t num_cb_cq_shards_ = 0;
+  // The CQs themselves are _not owned_ by the server; ownership belongs with
+  // the internal shutdown callback tag (invoked when the CQ is fully shutdown).
+  // It is protected by mu_. This is why callback_cq_shards_ is a vector of
+  // pointers, and not a vector of completion queues.
+  std::vector<CompletionQueue*> callback_cq_shards_;
   void MakeCallbackCQShardsLocked();
 };
 

--- a/include/grpcpp/server_impl.h
+++ b/include/grpcpp/server_impl.h
@@ -377,7 +377,6 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   // It is protected by mu_
   CompletionQueue* callback_cq_shards_ = nullptr;
   size_t num_cb_cq_shards_ = 0;
-  static constexpr unsigned kDefaultCallbackCqShards = 32;
   void MakeCallbackCQShardsLocked();
 };
 

--- a/include/grpcpp/server_impl.h
+++ b/include/grpcpp/server_impl.h
@@ -284,7 +284,7 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   }
 
   CompletionQueue* CallbackCQ() override;
-  std::pair<grpc::CompletionQueue*, size_t> CallbackCQShards();
+  std::pair<grpc::CompletionQueue**, size_t> CallbackCQShards();
 
   grpc_impl::ServerInitializer* initializer();
 
@@ -375,7 +375,7 @@ class Server : public grpc::ServerInterface, private grpc::GrpcLibraryCodegen {
   // It is _not owned_ by the server; ownership belongs with its internal
   // shutdown callback tag (invoked when the CQ is fully shutdown).
   // It is protected by mu_
-  CompletionQueue* callback_cq_shards_ = nullptr;
+  CompletionQueue** callback_cq_shards_ = nullptr;
   size_t num_cb_cq_shards_ = 0;
   void MakeCallbackCQShardsLocked();
 };

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -1186,14 +1186,7 @@ void grpc_server_setup_transport(
     chand->channelz_socket_uuid = 0;
   }
 
-  size_t cq_idx;
-  for (cq_idx = 0; cq_idx < s->cq_count; cq_idx++) {
-    if (grpc_cq_pollset(s->cqs[cq_idx]) == accepting_pollset) break;
-  }
-  if (cq_idx == s->cq_count) {
-    /* completion queue not found: pick a random one to publish new calls to */
-    cq_idx = static_cast<size_t>(rand()) % s->cq_count;
-  }
+  size_t cq_idx = static_cast<size_t>(rand()) % s->cq_count;
   chand->cq_idx = cq_idx;
 
   num_registered_methods = 0;

--- a/src/core/lib/surface/server.cc
+++ b/src/core/lib/surface/server.cc
@@ -1186,7 +1186,9 @@ void grpc_server_setup_transport(
     chand->channelz_socket_uuid = 0;
   }
 
-  size_t cq_idx = static_cast<size_t>(rand()) % s->cq_count;
+  const size_t cq_idx = gpr_murmur_hash3(&transport, sizeof(grpc_transport*),
+                                         grpc_core::g_hash_seed) &
+                        (s->cq_count - 1);
   chand->cq_idx = cq_idx;
 
   num_registered_methods = 0;

--- a/src/cpp/server/server_builder.cc
+++ b/src/cpp/server/server_builder.cc
@@ -338,10 +338,10 @@ std::unique_ptr<grpc::Server> ServerBuilder::BuildAndStart() {
   }
 
   if (has_callback_methods || callback_generic_service_ != nullptr) {
-    std::pair<grpc::CompletionQueue*, size_t> cb_cq_shards =
+    std::pair<grpc::CompletionQueue**, size_t> cb_cq_shards =
         server->CallbackCQShards();
     for (auto idx = 0; idx < cb_cq_shards.second; idx++) {
-      grpc::CompletionQueue* cq = &cb_cq_shards.first[idx];
+      grpc::CompletionQueue* cq = cb_cq_shards.first[idx];
       grpc_server_register_completion_queue(server->server_, cq->cq(), nullptr);
     }
   }

--- a/src/cpp/server/server_builder.cc
+++ b/src/cpp/server/server_builder.cc
@@ -338,8 +338,12 @@ std::unique_ptr<grpc::Server> ServerBuilder::BuildAndStart() {
   }
 
   if (has_callback_methods || callback_generic_service_ != nullptr) {
-    auto* cq = server->CallbackCQ();
-    grpc_server_register_completion_queue(server->server_, cq->cq(), nullptr);
+    std::pair<grpc::CompletionQueue*, size_t> cb_cq_shards =
+        server->CallbackCQShards();
+    for (auto idx = 0; idx < cb_cq_shards.second; idx++) {
+      grpc::CompletionQueue* cq = &cb_cq_shards.first[idx];
+      grpc_server_register_completion_queue(server->server_, cq->cq(), nullptr);
+    }
   }
 
   // cqs_ contains the completion queue added by calling the ServerBuilder's

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -1009,9 +1009,10 @@ Server::~Server() {
     grpc::internal::ReleasableMutexLock lock(&mu_);
     if (callback_cq_shards_ != nullptr) {
       for (auto idx = 0; idx < num_cb_cq_shards_; idx++) {
-        auto* cb_cq = &callback_cq_shards_[idx];
-        cb_cq->Shutdown();
+        callback_cq_shards_[idx]->Shutdown();
       }
+      gpr_free(callback_cq_shards_);
+      callback_cq_shards_ = nullptr;
     }
     if (started_ && !shutdown_) {
       lock.Unlock();
@@ -1371,14 +1372,15 @@ grpc::ServerInitializer* Server::initializer() {
 static constexpr unsigned kDefaultCallbackCqShards = 32;
 void GPR_ATTRIBUTE_NOINLINE Server::MakeCallbackCQShardsLocked() {
   num_cb_cq_shards_ = std::max(gpr_cpu_num_cores(), kDefaultCallbackCqShards);
-  callback_cq_shards_ = static_cast<CompletionQueue*>(
+  callback_cq_shards_ = static_cast<CompletionQueue**>(
       gpr_malloc(num_cb_cq_shards_ * sizeof(*callback_cq_shards_)));
   for (auto idx = 0; idx < num_cb_cq_shards_; idx++) {
     auto* shutdown_callback = new grpc::ShutdownCallback;
-    CompletionQueue* cq = &callback_cq_shards_[idx];
-    new (cq) grpc::CompletionQueue(grpc_completion_queue_attributes{
-        GRPC_CQ_CURRENT_VERSION, GRPC_CQ_CALLBACK, GRPC_CQ_DEFAULT_POLLING,
-        shutdown_callback});
+    CompletionQueue* cq =
+        new grpc::CompletionQueue(grpc_completion_queue_attributes{
+            GRPC_CQ_CURRENT_VERSION, GRPC_CQ_CALLBACK, GRPC_CQ_DEFAULT_POLLING,
+            shutdown_callback});
+    callback_cq_shards_[idx] = cq;
 
     // Transfer ownership of the new cq to its own shutdown callback
     shutdown_callback->TakeCQ(cq);
@@ -1392,16 +1394,16 @@ grpc::CompletionQueue* Server::CallbackCQ() {
   if (GPR_UNLIKELY(callback_cq_shards_ == nullptr)) {
     MakeCallbackCQShardsLocked();
   }
-  return &callback_cq_shards_[rand() % num_cb_cq_shards_];
+  return callback_cq_shards_[rand() % num_cb_cq_shards_];
 }
 
-std::pair<grpc::CompletionQueue*, size_t> Server::CallbackCQShards() {
+std::pair<grpc::CompletionQueue**, size_t> Server::CallbackCQShards() {
   grpc::internal::MutexLock l(&mu_);
   if (GPR_UNLIKELY(callback_cq_shards_ == nullptr)) {
     MakeCallbackCQShardsLocked();
   }
-  return std::make_pair<grpc::CompletionQueue*, size_t>(
-      std::forward<grpc::CompletionQueue*>(callback_cq_shards_),
+  return std::make_pair<grpc::CompletionQueue**, size_t>(
+      std::forward<grpc::CompletionQueue**>(callback_cq_shards_),
       std::forward<size_t>(num_cb_cq_shards_));
 }
 

--- a/src/cpp/server/server_cc.cc
+++ b/src/cpp/server/server_cc.cc
@@ -1368,6 +1368,7 @@ grpc::ServerInitializer* Server::initializer() {
   return server_initializer_.get();
 }
 
+static constexpr unsigned kDefaultCallbackCqShards = 32;
 void GPR_ATTRIBUTE_NOINLINE Server::MakeCallbackCQShardsLocked() {
   num_cb_cq_shards_ = std::max(gpr_cpu_num_cores(), kDefaultCallbackCqShards);
   callback_cq_shards_ = static_cast<CompletionQueue*>(


### PR DESCRIPTION
Contentionz shows publish_new_rpc as a significant source of contention on the server side, due to a singleton CQ => singleton MPSCQ to push/pop requested_call objects with. All transports attempt to pop it, all callback requests attempt to push to it.

Instead: we shard the callback CQ so there is at least one per CPU on the system (or 32 if we could not get the number of CPUs). Specifically, 2^(ceil(log_2(num_cores))), or the nearest power of 2 >= the number of CPUs. Both callback requests and transports are randomly sharded onto one of the CQ shards; as before, if there was no requested_call available on that particular MPSCQ, we iterate the next one.

This removes contention caused by publish_new_rpc entirely.