### PR TITLE
Disable Gradle daemon for Java interop test building

### DIFF
--- a/templates/tools/dockerfile/java_build_interop.sh.include
+++ b/templates/tools/dockerfile/java_build_interop.sh.include
@@ -22,7 +22,7 @@ cp -r /var/local/jenkins/grpc-java /tmp/grpc-java
 cp -r /var/local/jenkins/service_account $HOME || true
 
 pushd /tmp/grpc-java
-./gradlew :grpc-interop-testing:installDist -PskipCodegen=true
+./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true
 
 mkdir -p /var/local/git/grpc-java/
 cp -r --parents -t /var/local/git/grpc-java/ ${'\\'}

--- a/tools/dockerfile/interoptest/grpc_interop_java/build_interop.sh
+++ b/tools/dockerfile/interoptest/grpc_interop_java/build_interop.sh
@@ -22,7 +22,7 @@ cp -r /var/local/jenkins/grpc-java /tmp/grpc-java
 cp -r /var/local/jenkins/service_account $HOME || true
 
 pushd /tmp/grpc-java
-./gradlew :grpc-interop-testing:installDist -PskipCodegen=true
+./gradlew --no-daemon :grpc-interop-testing:installDist -PskipCodegen=true
 
 mkdir -p /var/local/git/grpc-java/
 cp -r --parents -t /var/local/git/grpc-java/ \


### PR DESCRIPTION
We have seen an issue where `rm -r "$HOME/.gradle"` fails because
"Directory not empty". It seems likely this is due the fact Gradle is
still running in daemon form. The build script doesn't get any advantage
by running the daemon, so we just disable it.

Fixes #20423