### PR TITLE
Fix BoringSSL-GRPC and gRPC-Core podspecs so they compile under the linter

### DIFF
--- a/gRPC-Core.podspec
+++ b/gRPC-Core.podspec
@@ -35,9 +35,9 @@ Pod::Spec.new do |s|
     :submodules => true,
   }
 
-  # gRPC podspecs depend on fix for https://github.com/CocoaPods/CocoaPods/issues/6024,
-  # which was released in Cocoapods v1.2.0.
-  s.cocoapods_version = '>= 1.2.0'
+  # gRPC podspecs depend on the fix in https://github.com/CocoaPods/CocoaPods/pull/9019,
+  # which was released in Cocoapods v1.8.0.
+  s.cocoapods_version = '>= 1.8.0'
 
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.9'
@@ -53,16 +53,10 @@ Pod::Spec.new do |s|
   # <gRPC-Core/grpc.h>`.
   s.module_name = name
 
-  # When creating a dynamic framework, copy the headers under `include/grpc/` into the root of
-  # the `Headers/` directory of the framework (i.e., not under `Headers/include/grpc`).
-  #
-  # TODO(jcanizales): Debug why this doesn't work on macOS.
-  s.header_mappings_dir = 'include/grpc'
-
-  # The above has an undesired effect when creating a static library: It forces users to write
-  # includes like `#include <gRPC-Core/grpc.h>`. `s.header_dir` adds a path prefix to that, and
-  # because Cocoapods lets omit the pod name when including headers of static libraries, the
-  # following lets users write `#include <grpc/grpc.h>`.
+  # The header_mappings_dir in the Interface subspecs have an undesired effect when creating a static
+  # library: It forces users to write includes like `#include <gRPC-Core/grpc.h>`. `s.header_dir` adds
+  # a path prefix to that, and because Cocoapods lets omit the pod name when including headers of static
+  # libraries, the following lets users write `#include <grpc/grpc.h>`.
   s.header_dir = name
 
   # The module map created automatically by Cocoapods doesn't work for C libraries like gRPC-Core.
@@ -71,29 +65,18 @@ Pod::Spec.new do |s|
   # To compile the library, we need the user headers search path (quoted includes) to point to the
   # root of the repo, and the system headers search path (angled includes) to point to `include/`.
   # Cocoapods effectively clones the repo under `<Podfile dir>/Pods/gRPC-Core/`, and sets a build
-  # variable called `$(PODS_ROOT)` to `<Podfile dir>/Pods/`, so we use that.
+  # variable called `$(PODS_TARGET_SRCROOT)` to that directory, so we use that.
   #
-  # Relying on the file structure under $(PODS_ROOT) isn't officially supported in Cocoapods, as it
-  # is taken as an implementation detail. We've asked for an alternative, and have been told that
-  # what we're doing should keep working: https://github.com/CocoaPods/CocoaPods/issues/4386
-  #
-  # The `src_root` value of `$(PODS_ROOT)/gRPC-Core` assumes Cocoapods is installing this pod from
-  # its remote repo. For local development of this library, enabled by using `:path` in the Podfile,
-  # that assumption is wrong. In such case, the following settings need to be reset with the
-  # appropriate value of `src_root`. This can be accomplished in the `pre_install` hook of the
-  # Podfile; see `src/objective-c/tests/Podfile` for an example.
-  src_root = '$(PODS_ROOT)/gRPC-Core'
+  # If we don't set ALWAYS_SEARCH_USER_PATHS and USE_HEADERMAP, `include/grpc/support/time.h` and
+  # `src/core/lib/gpr/string.h` shadow the system `<time.h>` and `<string.h>`, breaking the
+  # build.
   s.pod_target_xcconfig = {
-    'GRPC_SRC_ROOT' => src_root,
-    'HEADER_SEARCH_PATHS' => '"$(inherited)" "$(GRPC_SRC_ROOT)/include"',
-    'USER_HEADER_SEARCH_PATHS' => '"$(GRPC_SRC_ROOT)"',
-    # If we don't set these two settings, `include/grpc/support/time.h` and
-    # `src/core/lib/gpr/string.h` shadow the system `<time.h>` and `<string.h>`, breaking the
-    # build.
-    'USE_HEADERMAP' => 'NO',
     'ALWAYS_SEARCH_USER_PATHS' => 'NO',
-    'GCC_PREPROCESSOR_DEFINITIONS' => '"$(inherited)" "COCOAPODS=1"',
     'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
+    'GCC_PREPROCESSOR_DEFINITIONS' => '"$(inherited)" "COCOAPODS=1"',
+    'HEADER_SEARCH_PATHS' => '"$(inherited)" "$(PODS_TARGET_SRCROOT)/include"',
+    'USER_HEADER_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)"',
+    'USE_HEADERMAP' => 'NO',
   }
 
   s.default_subspecs = 'Interface', 'Implementation'
@@ -181,6 +164,7 @@ Pod::Spec.new do |s|
                       'include/grpc/support/workaround_list.h',
                       'include/grpc/census.h'
   end
+
   s.subspec 'Implementation' do |ss|
     ss.header_mappings_dir = '.'
     ss.libraries = 'z'
@@ -1333,8 +1317,11 @@ Pod::Spec.new do |s|
   end
 
   s.subspec 'Cronet-Implementation' do |ss|
+    ss.platform = :ios
+
     ss.header_mappings_dir = '.'
 
+    ss.dependency 'CronetFramework', '0.0.4'
     ss.dependency "#{s.name}/Interface", version
     ss.dependency "#{s.name}/Implementation", version
     ss.dependency "#{s.name}/Cronet-Interface", version
@@ -1490,6 +1477,7 @@ Pod::Spec.new do |s|
 
   # TODO (mxyan): Instead of this hack, add include path "third_party" to C core's include path?
   s.prepare_command = <<-END_OF_COMMAND
+    sed -E -i '' 's;(#include "third_party/objective_c/Cronet/((.*)\\.h)");#if COCOAPODS==1\\\n  #include <Cronet/\\2>\\\n#else\\\n  \\1\\\n#endif;g' $(find src/core -type f \\( -path '*.h' -or -path '*.cc' \\) -print | xargs grep -H -c '#include <Cronet/' | grep 0$ | cut -d':' -f1)
     sed -E -i '' 's;#include <openssl/(.*)>;#if COCOAPODS==1\\\n  #include <openssl_grpc/\\1>\\\n#else\\\n  #include <openssl/\\1>\\\n#endif;g' $(find src/core -type f \\( -path '*.h' -or -path '*.cc' \\) -print | xargs grep -H -c '#include <openssl_grpc/' | grep 0$ | cut -d':' -f1)
     find src/core/ third_party/upb/ -type f \\( -name '*.h' -or -name '*.c' -or -name '*.cc' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include "upb/(.*)";#if COCOAPODS==1\\\n  #include  "third_party/upb/upb/\\1"\\\n#else\\\n  #include  "upb/\\1"\\\n#endif;g'
     find src/core/ third_party/upb/ -type f -name '*.grpc_back' -print0 | xargs -0 rm

--- a/templates/gRPC-Core.podspec.template
+++ b/templates/gRPC-Core.podspec.template
@@ -88,9 +88,9 @@
       :submodules => true,
     }
 
-    # gRPC podspecs depend on fix for https://github.com/CocoaPods/CocoaPods/issues/6024,
-    # which was released in Cocoapods v1.2.0.
-    s.cocoapods_version = '>= 1.2.0'
+    # gRPC podspecs depend on the fix in https://github.com/CocoaPods/CocoaPods/pull/9019,
+    # which was released in Cocoapods v1.8.0.
+    s.cocoapods_version = '>= 1.8.0'
 
     s.ios.deployment_target = '7.0'
     s.osx.deployment_target = '10.9'
@@ -106,16 +106,10 @@
     # <gRPC-Core/grpc.h>`.
     s.module_name = name
 
-    # When creating a dynamic framework, copy the headers under `include/grpc/` into the root of
-    # the `Headers/` directory of the framework (i.e., not under `Headers/include/grpc`).
-    #
-    # TODO(jcanizales): Debug why this doesn't work on macOS.
-    s.header_mappings_dir = 'include/grpc'
-
-    # The above has an undesired effect when creating a static library: It forces users to write
-    # includes like `#include <gRPC-Core/grpc.h>`. `s.header_dir` adds a path prefix to that, and
-    # because Cocoapods lets omit the pod name when including headers of static libraries, the
-    # following lets users write `#include <grpc/grpc.h>`.
+    # The header_mappings_dir in the Interface subspecs have an undesired effect when creating a static
+    # library: It forces users to write includes like `#include <gRPC-Core/grpc.h>`. `s.header_dir` adds
+    # a path prefix to that, and because Cocoapods lets omit the pod name when including headers of static
+    # libraries, the following lets users write `#include <grpc/grpc.h>`.
     s.header_dir = name
 
     # The module map created automatically by Cocoapods doesn't work for C libraries like gRPC-Core.
@@ -124,29 +118,18 @@
     # To compile the library, we need the user headers search path (quoted includes) to point to the
     # root of the repo, and the system headers search path (angled includes) to point to `include/`.
     # Cocoapods effectively clones the repo under `<Podfile dir>/Pods/gRPC-Core/`, and sets a build
-    # variable called `$(PODS_ROOT)` to `<Podfile dir>/Pods/`, so we use that.
+    # variable called `$(PODS_TARGET_SRCROOT)` to that directory, so we use that.
     #
-    # Relying on the file structure under $(PODS_ROOT) isn't officially supported in Cocoapods, as it
-    # is taken as an implementation detail. We've asked for an alternative, and have been told that
-    # what we're doing should keep working: https://github.com/CocoaPods/CocoaPods/issues/4386
-    #
-    # The `src_root` value of `$(PODS_ROOT)/gRPC-Core` assumes Cocoapods is installing this pod from
-    # its remote repo. For local development of this library, enabled by using `:path` in the Podfile,
-    # that assumption is wrong. In such case, the following settings need to be reset with the
-    # appropriate value of `src_root`. This can be accomplished in the `pre_install` hook of the
-    # Podfile; see `src/objective-c/tests/Podfile` for an example.
-    src_root = '$(PODS_ROOT)/gRPC-Core'
+    # If we don't set ALWAYS_SEARCH_USER_PATHS and USE_HEADERMAP, `include/grpc/support/time.h` and
+    # `src/core/lib/gpr/string.h` shadow the system `<time.h>` and `<string.h>`, breaking the
+    # build.
     s.pod_target_xcconfig = {
-      'GRPC_SRC_ROOT' => src_root,
-      'HEADER_SEARCH_PATHS' => '"$(inherited)" "$(GRPC_SRC_ROOT)/include"',
-      'USER_HEADER_SEARCH_PATHS' => '"$(GRPC_SRC_ROOT)"',
-      # If we don't set these two settings, `include/grpc/support/time.h` and
-      # `src/core/lib/gpr/string.h` shadow the system `<time.h>` and `<string.h>`, breaking the
-      # build.
-      'USE_HEADERMAP' => 'NO',
       'ALWAYS_SEARCH_USER_PATHS' => 'NO',
-      'GCC_PREPROCESSOR_DEFINITIONS' => '"$(inherited)" "COCOAPODS=1"',
       'CLANG_WARN_STRICT_PROTOTYPES' => 'NO',
+      'GCC_PREPROCESSOR_DEFINITIONS' => '"$(inherited)" "COCOAPODS=1"',
+      'HEADER_SEARCH_PATHS' => '"$(inherited)" "$(PODS_TARGET_SRCROOT)/include"',
+      'USER_HEADER_SEARCH_PATHS' => '"$(PODS_TARGET_SRCROOT)"',
+      'USE_HEADERMAP' => 'NO',
     }
 
     s.default_subspecs = 'Interface', 'Implementation'
@@ -168,6 +151,7 @@
 
       ss.source_files = ${ruby_multiline_list(grpc_public_headers(libs), 22)}
     end
+
     s.subspec 'Implementation' do |ss|
       ss.header_mappings_dir = '.'
       ss.libraries = 'z'
@@ -191,8 +175,11 @@
     end
 
     s.subspec 'Cronet-Implementation' do |ss|
+      ss.platform = :ios
+
       ss.header_mappings_dir = '.'
 
+      ss.dependency 'CronetFramework', '0.0.4'
       ss.dependency "#{s.name}/Interface", version
       ss.dependency "#{s.name}/Implementation", version
       ss.dependency "#{s.name}/Cronet-Interface", version
@@ -212,6 +199,7 @@
 
     # TODO (mxyan): Instead of this hack, add include path "third_party" to C core's include path?
     s.prepare_command = <<-END_OF_COMMAND
+      sed -E -i '' 's;(#include "third_party/objective_c/Cronet/((.*)\\.h)");#if COCOAPODS==1\\\n  #include <Cronet/\\2>\\\n#else\\\n  \\1\\\n#endif;g' $(find src/core -type f \\( -path '*.h' -or -path '*.cc' \\) -print | xargs grep -H -c '#include <Cronet/' | grep 0$ | cut -d':' -f1)
       sed -E -i '' 's;#include <openssl/(.*)>;#if COCOAPODS==1\\\n  #include <openssl_grpc/\\1>\\\n#else\\\n  #include <openssl/\\1>\\\n#endif;g' $(find src/core -type f \\( -path '*.h' -or -path '*.cc' \\) -print | xargs grep -H -c '#include <openssl_grpc/' | grep 0$ | cut -d':' -f1)
       find src/core/ third_party/upb/ -type f \\( -name '*.h' -or -name '*.c' -or -name '*.cc' \\) -print0 | xargs -0 -L1 sed -E -i'.grpc_back' 's;#include "upb/(.*)";#if COCOAPODS==1\\\n  #include  "third_party/upb/upb/\\1"\\\n#else\\\n  #include  "upb/\\1"\\\n#endif;g'
       find src/core/ third_party/upb/ -type f -name '*.grpc_back' -print0 | xargs -0 rm

--- a/templates/src/objective-c/BoringSSL-GRPC.podspec.template
+++ b/templates/src/objective-c/BoringSSL-GRPC.podspec.template
@@ -84,6 +84,10 @@
       :commit => "b29b21a81b32ec273f118f589f46d56ad3332420",
     }
 
+    # gRPC podspecs depend on the fix in https://github.com/CocoaPods/CocoaPods/pull/9019,
+    # which was released in Cocoapods v1.8.0.
+    s.cocoapods_version = '>= 1.8.0'
+
     s.ios.deployment_target = '7.0'
     s.osx.deployment_target = '10.7'
     s.tvos.deployment_target = '10.0'
@@ -91,21 +95,15 @@
 
     name = 'openssl_grpc'
 
-    # When creating a dynamic framework, name it openssl.framework instead of BoringSSL.framework.
-    # This lets users write their includes like `#include <openssl/ssl.h>` as opposed to `#include
+    # When creating a dynamic framework, name it openssl_grpc.framework instead of BoringSSL.framework.
+    # This lets users write their includes like `#include <openssl_grpc/ssl.h>` as opposed to `#include
     # <BoringSSL/ssl.h>`.
     s.module_name = name
 
-    # When creating a dynamic framework, copy the headers under `include/openssl/` into the root of
-    # the `Headers/` directory of the framework (i.e., not under `Headers/include/openssl`).
-    #
-    # TODO(jcanizales): Debug why this doesn't work on macOS.
-    s.header_mappings_dir = 'include/openssl'
-
-    # The above has an undesired effect when creating a static library: It forces users to write
-    # includes like `#include <BoringSSL/ssl.h>`. `s.header_dir` adds a path prefix to that, and
-    # because Cocoapods lets omit the pod name when including headers of static libraries, the
-    # following lets users write `#include <openssl/ssl.h>`.
+    # The header_mappings_dir in the Interface subspec has an undesired effect when creating a static
+    # library: It forces users to write includes like `#include <BoringSSL/ssl.h>`. `s.header_dir` adds
+    # a path prefix to that, and because Cocoapods lets omit the pod name when including headers of
+    # static libraries, the following lets users write `#include <openssl_grpc/ssl.h>`.
     s.header_dir = name
 
     # The module map and umbrella header created automatically by Cocoapods don't work for C libraries
@@ -122,10 +120,12 @@
     # sources and private headers in other directories outside `include/`. Cocoapods' linter doesn't
     # allow any header to be listed outside the `header_mappings_dir` (even though doing so works in
     # practice). Because we need our `header_mappings_dir` to be `include/openssl/` for the reason
-    # mentioned above, we work around the linter limitation by dividing the pod into two subspecs, one
+    # mentioned below, we work around the linter limitation by dividing the pod into two subspecs, one
     # for public headers and the other for implementation. Each gets its own `header_mappings_dir`,
     # making the linter happy.
     s.subspec 'Interface' do |ss|
+      # When creating a dynamic framework, copy the headers under `include/openssl/` into the root of
+      # the `Headers/` directory of the framework (i.e., not under `Headers/include/openssl`).
       ss.header_mappings_dir = 'include/openssl'
       ss.source_files = 'include/openssl/*.h'
     end
@@ -141,7 +141,8 @@
                                 'ssl/**/*.h',
                                 '*.h',
                                 'crypto/*.h',
-                                'crypto/**/*.h'
+                                'crypto/**/*.h',
+                                'third_party/fiat/*.h'
       # bcm.c includes other source files, creating duplicated symbols. Since it is not used, we
       # explicitly exclude it from the pod.
       # TODO (mxyan): Work with BoringSSL team to remove this hack.
@@ -159,10 +160,10 @@
         #include "ssl.h"
         #include "crypto.h"
         #include "aes.h"
-        /* The following macros are defined by base.h. The latter is the first file included by the    
-           other headers. */    
-        #if defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)    
-        #  include "arm_arch.h"   
+        /* The following macros are defined by base.h. The latter is the first file included by the
+           other headers. */
+        #if defined(OPENSSL_ARM) || defined(OPENSSL_AARCH64)
+        #  include "arm_arch.h"
         #endif
         #include "asn1.h"
         #include "asn1_mac.h"
@@ -196,7 +197,7 @@
         #include "x509v3.h"
       EOF
       cat > include/openssl/BoringSSL.modulemap <<EOF
-        framework module openssl {
+        framework module #{name} {
           umbrella header "umbrella.h"
           textual header "arm_arch.h"
           export *
@@ -1551,6 +1552,7 @@
             "";
       EOF
 
+      sed -i'.back' '/#include <inttypes.h>/d' include/openssl/bn.h
       sed -i'.back' '/^#define \\([A-Za-z0-9_]*\\) \\1/d' include/openssl/ssl.h
       sed -i'.back' 'N;/^#define \\([A-Za-z0-9_]*\\) *\\\\\\n *\\1/d' include/openssl/ssl.h
       sed -i'.back' 's/#ifndef md5_block_data_order/#ifndef GRPC_SHADOW_md5_block_data_order/g' crypto/fipsmodule/md5/md5.c
@@ -1560,6 +1562,6 @@
     # Redefine symbols to avoid conflict when the same app also depends on OpenSSL. The list of
     # symbols are src/objective-c/grpc_shadow_boringssl_symbol_list.
     # This is the last part of this file.
-    s.prefix_header_contents = 
+    s.prefix_header_contents =
       ${expand_symbol_list(settings.grpc_shadow_boringssl_symbols)}
   end


### PR DESCRIPTION
Unfortunately there are still some warnings, but this gets things compiling again.

**BoringSSL-GRPC**

```
   Testing with `xcodebuild`.
 -> BoringSSL-GRPC (0.0.4)
    - WARN  | source: Git sources should specify a tag.
```

**gRPC-Core**

```
   Testing with `xcodebuild`.
 -> gRPC-Core (1.25.0-dev)
    - NOTE  | [gRPC-Core/Interface, gRPC-Core/Implementation, gRPC-Core/CFStream-Implementation, and more...] xcodebuild:  note: Using new build system
    - NOTE  | [gRPC-Core/Interface, gRPC-Core/Implementation, gRPC-Core/CFStream-Implementation, and more...] xcodebuild:  note: Planning build
    - NOTE  | [gRPC-Core/Interface, gRPC-Core/Implementation, gRPC-Core/CFStream-Implementation, and more...] xcodebuild:  note: Constructing build description
    - WARN  | [gRPC-Core/Cronet-Implementation] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/third_party/objective_c/Cronet/bidirectional_stream_c.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Cronet-Implementation] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header 'grpc_cronet.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Cronet-Implementation] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/src/core/ext/transport/cronet/transport/cronet_transport.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Cronet-Implementation] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/src/core/ext/transport/cronet/client/secure/cronet_channel_create.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/passthru_endpoint.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/mock_endpoint.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/port.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/grpc_profiler.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/cmdline.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/memory_counters.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/fuzzer_util.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/port_server_client.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/histogram.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/test_config.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/tracer_util.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/test_lb_policies.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/debugger_macros.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/trickle_endpoint.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning:
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/subprocess.h' [-Wincomplete-umbrella]
    - NOTE  | [iOS] [gRPC-Core/Tests] xcodebuild:  1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/slice_splitter.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/security/oauth2_utils.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/end2end/cq_verifier.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/end2end/tests/cancel_test_helpers.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/end2end/fixtures/http_proxy_fixture.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/end2end/fixtures/proxy.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/end2end/fixtures/local_util.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/end2end/end2end_tests.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/end2end/data/ssl_test_data.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/iomgr/endpoint_tests.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/parse_hexstring.h' [-Wincomplete-umbrella]
    - WARN  | [gRPC-Core/Tests] xcodebuild:  <module-includes>:1:1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/slice_splitter.h' [-Wincomplete-umbrella]
    - NOTE  | [OSX] [gRPC-Core/Tests] xcodebuild:  1: warning: umbrella header for module 'grpc' does not include header '/test/core/util/port.h' [-Wincomplete-umbrella]
    - NOTE  | [tvOS] [gRPC-Core/Tests] xcodebuild:  warning: umbrella header for module 'grpc' does not include header '/test/core/util/test_lb_policies.h' [-Wincomplete-umbrella]
    - NOTE  | [watchOS] [gRPC-Core/Tests] xcodebuild:  warning: umbrella header for module 'grpc' does not include header '/test/core/util/fuzzer_util.h' [-Wincomplete-umbrella]
```

@nicolasnoble
