### PR TITLE
Cronet fixes

### DIFF
--- a/src/objective-c/tests/ConfigureCronet.h
+++ b/src/objective-c/tests/ConfigureCronet.h
@@ -15,6 +15,7 @@
  * limitations under the License.
  *
  */
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -23,7 +24,7 @@ extern "C" {
 /**
  * Enable Cronet for once.
  */
-void configureCronet(void);
+void configureCronet(bool enable_netlog);
 
 #ifdef __cplusplus
 }

--- a/src/objective-c/tests/ConfigureCronet.m
+++ b/src/objective-c/tests/ConfigureCronet.m
@@ -19,7 +19,7 @@
 #import "ConfigureCronet.h"
 #import <Cronet/Cronet.h>
 
-void configureCronet(void) {
+void configureCronet(bool enable_netlog) {
   static dispatch_once_t configureCronet;
   dispatch_once(&configureCronet, ^{
     NSLog(@"configureCronet()");
@@ -29,7 +29,9 @@ void configureCronet(void) {
     NSURL *url = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory
                                                          inDomains:NSUserDomainMask] lastObject];
     NSLog(@"Documents directory: %@", url);
+    if (enable_netlog) {
+      [Cronet startNetLogToFile:@"cronet_netlog.json" logBytes:YES];
+    }
     [Cronet start];
-    [Cronet startNetLogToFile:@"cronet_netlog.json" logBytes:YES];
   });
 }

--- a/src/objective-c/tests/CronetTests/CoreCronetEnd2EndTests.mm
+++ b/src/objective-c/tests/CronetTests/CoreCronetEnd2EndTests.mm
@@ -177,7 +177,7 @@ static char *roots_filename;
 
   grpc_init();
 
-  configureCronet();
+  configureCronet(/*enable_netlog=*/false);
 }
 
 // The tearDown() function is run after all test cases finish running

--- a/src/objective-c/tests/CronetTests/CronetUnitTests.mm
+++ b/src/objective-c/tests/CronetTests/CronetUnitTests.mm
@@ -64,7 +64,7 @@ static void drain_cq(grpc_completion_queue *cq) {
   grpc_test_init(1, argv);
 
   grpc_init();
-  configureCronet();
+  configureCronet(/*enable_netlog=*/false);
   init_ssl();
 }
 

--- a/src/objective-c/tests/CronetTests/InteropTestsRemoteWithCronet.m
+++ b/src/objective-c/tests/CronetTests/InteropTestsRemoteWithCronet.m
@@ -42,7 +42,7 @@ static int32_t kRemoteInteropServerOverhead = 12;
 @implementation InteropTestsRemoteWithCronet
 
 + (void)setUp {
-  configureCronet();
+  configureCronet(/*enable_netlog=*/false);
   [GRPCCall useCronetWithEngine:[Cronet getGlobalEngine]];
 
   [super setUp];

--- a/src/objective-c/tests/InteropTests/InteropTestsMultipleChannels.m
+++ b/src/objective-c/tests/InteropTests/InteropTestsMultipleChannels.m
@@ -85,7 +85,7 @@ dispatch_once_t initCronet;
   self.continueAfterFailure = NO;
 
   _remoteService = [RMTTestService serviceWithHost:kRemoteSSLHost callOptions:nil];
-  configureCronet();
+  configureCronet(/*enable_netlog=*/false);
 
   // Default stack with remote host
   GRPCMutableCallOptions *options = [[GRPCMutableCallOptions alloc] init];

--- a/src/objective-c/tests/PerfTests/PerfTestsCronet.m
+++ b/src/objective-c/tests/PerfTests/PerfTestsCronet.m
@@ -42,7 +42,7 @@ static int32_t kRemoteInteropServerOverhead = 12;
 @implementation PerfTestsCronet
 
 + (void)setUp {
-  configureCronet();
+  configureCronet(/*enable_netlog=*/false);
   [GRPCCall useCronetWithEngine:[Cronet getGlobalEngine]];
 
   [super setUp];


### PR DESCRIPTION
*  Fixed bug in cronet_transport where completed ops were not removed from storage
*  Don't collect cronet netlog. It's slow and file size can be huge
*  Cronet Perf tests: Added 1 KB unary RPC test case
* Reduce number of messages from 10000->1000 to reduce test run time.