### PR TITLE
Add extra kokoro build info to Win RBE runs

### DIFF
--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -24,7 +24,7 @@ powershell -Command "[guid]::NewGuid().ToString()" >%KOKORO_ARTIFACTS_DIR%/bazel
 set /p BAZEL_INVOCATION_ID=<%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
 
 @rem TODO(jtattermusch): windows RBE should be able to use the same credentials as Linux RBE.
-bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" %RUN_TESTS_FLAGS% --workspace_status_command=tools/remote_build/workspace_status_kokoro.sh --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json //test/...
+bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" %RUN_TESTS_FLAGS% --workspace_status_command=tools/remote_build/workspace_status_kokoro.bat --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json //test/...
 set BAZEL_EXITCODE=%errorlevel%
 
 @rem TODO(jtattermusch): upload results to bigquery

--- a/tools/remote_build/workspace_status_kokoro.bat
+++ b/tools/remote_build/workspace_status_kokoro.bat
@@ -1,0 +1,29 @@
+@rem Copyright 2019 gRPC authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem     http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+
+@echo off
+@rem Adds additional labels to results page for Bazel RBE builds on Kokoro
+@rem Note that this script needs to be a .bat file, the .sh version of this
+@rem script is simply ignored when used on Windows.
+
+@rem Provide a way to go from Bazel RBE links back to Kokoro job results
+@rem which is important for debugging test infrastructure problems.
+@rem TODO(jtattermusch): replace this workaround by something more user-friendly.
+
+echo KOKORO_RESULTSTORE_URL https://source.cloud.google.com/results/invocations/%KOKORO_BUILD_ID%
+echo KOKORO_SPONGE_URL http://sponge.corp.google.com/%KOKORO_BUILD_ID%
+
+echo KOKORO_BUILD_NUMBER %KOKORO_BUILD_NUMBER%
+echo KOKORO_JOB_NAME %KOKORO_JOB_NAME%
+echo KOKORO_GITHUB_COMMIT %KOKORO_GITHUB_COMMIT%


### PR DESCRIPTION
Turns out using the `--workspace_status_command=tools/remote_build/workspace_status_kokoro.sh` flag doesn't work on windows.
According to bazel docs:
*The flag's value must be a path to a native program. On Linux/macOS this may be any executable. On Windows this must be a native binary, typically an ".exe", ".bat", or a ".cmd" file.*