### PR TITLE
Windows bazel RBE improvements

### DIFF
--- a/tools/internal_ci/windows/bazel_rbe.bat
+++ b/tools/internal_ci/windows/bazel_rbe.bat
@@ -24,9 +24,13 @@ powershell -Command "[guid]::NewGuid().ToString()" >%KOKORO_ARTIFACTS_DIR%/bazel
 set /p BAZEL_INVOCATION_ID=<%KOKORO_ARTIFACTS_DIR%/bazel_invocation_ids
 
 @rem TODO(jtattermusch): windows RBE should be able to use the same credentials as Linux RBE.
-bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" %RUN_TESTS_FLAGS% --workspace_status_command=tools/remote_build/workspace_status_kokoro.bat --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json //test/...
+bazel --bazelrc=tools/remote_build/windows.bazelrc test --invocation_id="%BAZEL_INVOCATION_ID%" %BAZEL_FLAGS% --workspace_status_command=tools/remote_build/workspace_status_kokoro.bat --google_credentials=%KOKORO_GFILE_DIR%/rbe-windows-credentials.json //test/...
 set BAZEL_EXITCODE=%errorlevel%
 
-@rem TODO(jtattermusch): upload results to bigquery
+if not "%UPLOAD_TEST_RESULTS%"=="" (
+  @rem Sleep to let ResultStore finish writing results before querying
+  timeout /t 60 /nobreak
+  python ./tools/run_tests/python_utils/upload_rbe_results.py
+)
 
 exit /b %BAZEL_EXITCODE%

--- a/tools/internal_ci/windows/grpc_bazel_rbe_opt.cfg
+++ b/tools/internal_ci/windows/grpc_bazel_rbe_opt.cfg
@@ -34,10 +34,8 @@ bazel_setting {
 env_vars {
   # flags will be passed to bazel invocation by bazel_rbe.bat
   key: "BAZEL_FLAGS"
-  # TODO(jtattermusch): add --config=dbg once that works
-  value: "--cache_test_results=no"
+  value: "--cache_test_results=no --config=opt"
 }
-
 env_vars {
   key: "UPLOAD_TEST_RESULTS"
   value: "true"

--- a/tools/internal_ci/windows/pull_request/grpc_bazel_rbe_dbg.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_bazel_rbe_dbg.cfg
@@ -33,7 +33,7 @@ bazel_setting {
 
 env_vars {
   # flags will be passed to bazel invocation by bazel_rbe.bat
-  key: "RUN_TESTS_FLAGS"
+  key: "BAZEL_FLAGS"
   # TODO(jtattermusch): add --config=dbg once that works
   value: ""
 }

--- a/tools/internal_ci/windows/pull_request/grpc_bazel_rbe_opt.cfg
+++ b/tools/internal_ci/windows/pull_request/grpc_bazel_rbe_opt.cfg
@@ -34,11 +34,5 @@ bazel_setting {
 env_vars {
   # flags will be passed to bazel invocation by bazel_rbe.bat
   key: "BAZEL_FLAGS"
-  # TODO(jtattermusch): add --config=dbg once that works
-  value: "--cache_test_results=no"
-}
-
-env_vars {
-  key: "UPLOAD_TEST_RESULTS"
-  value: "true"
+  value: "--config=opt"
 }


### PR DESCRIPTION
- add configs for windows RBE "opt" jobs
- start using "BAZEL_FLAGS" env var for better readability
- upload RBE test results to bigquery for master jobs (for flakiness analysis etc., we already do that for Linux RBE tests).