### PR TITLE
Temporarily disable client_channel_stress_test on win RBE

### DIFF
--- a/test/cpp/client/BUILD
+++ b/test/cpp/client/BUILD
@@ -48,4 +48,7 @@ grpc_cc_test(
         "//test/cpp/end2end:test_service_impl",
         "//test/cpp/util:test_util",
     ],
+    # TODO(jtattermusch): test fails frequently on Win RBE, but passes locally
+    # reenable the tests once it works reliably on Win RBE.
+    tags = ["no_windows"],
 )


### PR DESCRIPTION
The failure https://github.com/grpc/grpc/issues/20437 seems to be only happening on Win RBE, not when run locally on windows. This makes me think that the failure might be an environment problem rather then an actual win bug - so disabling the tests for now to make the master build green.