### PR TITLE
Confer Maintainer Status on @pfreixes

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -37,6 +37,7 @@ for general contribution guidelines.
 - [nanahpang](https://github.com/nanahpang), Google LLC
 - [nathanielmanistaatgoogle](https://github.com/nathanielmanistaatgoogle), Google LLC
 - [nicolasnoble](https://github.com/nicolasnoble), Google LLC
+- [pfreixes](https://github.com/pfreixes), Skyscanner Ltd
 - [qixuanl1](https://github.com/qixuanl1), Google LLC
 - [ran-su](https://github.com/ran-su), Google LLC
 - [rmstar](https://github.com/rmstar), Google LLC


### PR DESCRIPTION
This PR is a proposal to confer maintainer status on @pfreixes in accordance with https://github.com/grpc/grpc-community/blob/master/governance.md. This proposal will be raised during the gRPC Team Meeting on 10/8/2019, to which a majority of gRPC maintainers will be in attendance.