### PR TITLE
Use -static-libstdc++ for ruby.linux

### DIFF
--- a/src/ruby/ext/grpc/extconf.rb
+++ b/src/ruby/ext/grpc/extconf.rb
@@ -76,6 +76,7 @@ if grpc_config == 'dbg'
 end
 
 $LDFLAGS << ' -Wl,-wrap,memcpy' if RUBY_PLATFORM =~ /linux/
+$LDFLAGS << ' -static-libgcc -static-libstdc++' if RUBY_PLATFORM =~ /linux/
 $LDFLAGS << ' -static' if windows
 
 $CFLAGS << ' -std=c99 '


### PR DESCRIPTION
Since a docker image to build ruby artifact is not based on manylinux, it's not safe to use C++ standard library features without static linking to libstdc++. This fixes the following problem.

[Error](https://source.cloud.google.com/results/invocations/3ead24f1-ed22-4bc7-9272-0189f62b0dee/targets/github%2Fgrpc/tests):
```
LoadError: /usr/lib64/libstdc++.so.6: version `GLIBCXX_3.4.14' not found 
(required by /usr/local/rvm/gems/ruby-2.3.8/gems/grpc-1.25.0.dev-x86_64-linux/src/ruby/lib/grpc/2.3/grpc_c.so)
- /usr/local/rvm/gems/ruby-2.3.8/gems/grpc-1.25.0.dev-x86_64-linux/src/ruby/lib/grpc/2.3/grpc_c.so
```
