### PR TITLE
updated C# server_reflection.md

### DIFF
--- a/doc/csharp/server_reflection.md
+++ b/doc/csharp/server_reflection.md
@@ -28,6 +28,25 @@ server = new Server()
 };
 server.Start();
 ```
+### Server Reflection in C# in .NET Core 3.0 sevices
+Since now a days in .NET Core 3.0, sevices are registered in startup.cs and build in program.cs , below is the way one can implement Server Reflection
+
+```csharp
+//Create a class named ReflectionImplementation which inherits ReflectionServiceImpl (using nuget Grpc.Reflection)
+ public class ReflectionImplementation: ReflectionServiceImpl
+{
+    public ReflectionImplementation():base(Calculator.Descriptor, Greeter.Descriptor, ServerReflection.Descriptor)
+    {
+    }
+
+}
+```
+
+```csharp
+// add below line startup.cs
+endpoints.MapGrpcService<ReflectionImplementation>();
+```
+
 
 After starting the server, you can verify that the server reflection
 is working properly by using the [`grpc_cli` command line


### PR DESCRIPTION
The server reflection example in C# is old (as service registration happen in in startup.cs and build in program.cs)
https://github.com/grpc/grpc/blob/master/doc/csharp/server_reflection.md

I have a working example which had server reflection implementation in a another way (can be read as "better" way). this implementation in easy to understand and inline with current .net core structure.
https://github.com/rupeshtech/k8s-grpc-dotntecore/blob/master/SampleGrpcService/Services/ReflectionImplementation.cs
https://github.com/rupeshtech/k8s-grpc-dotntecore/blob/master/SampleGrpcService/Startup.cs

release notes:
Added  another implementation of server reflection for language csharp (c#)
language: C# (chsarp)
Version: .net core 3.0

@nicolasnoble
