### PR TITLE
Fixes in multimachine benchmark scripts

### DIFF
--- a/tools/internal_ci/linux/grpc_full_performance_master.sh
+++ b/tools/internal_ci/linux/grpc_full_performance_master.sh
@@ -31,7 +31,7 @@ tools/run_tests/run_performance_tests.py \
     || EXIT_CODE=1
 
 # prevent pushing leftover build files to remote hosts in the next step.
-git clean -fdxq -e reports
+git clean -fdxq -e reports -e run_performance_tests
 
 # scalability with 32cores (and upload to a different BQ table)
 tools/run_tests/run_performance_tests.py \
@@ -45,15 +45,6 @@ tools/run_tests/run_performance_tests.py \
     || EXIT_CODE=1
 
 # prevent pushing leftover build files to remote hosts in the next step.
-git clean -fdxq -e reports
-
-# selected scenarios on Windows
-tools/run_tests/run_performance_tests.py \
-    -l csharp \
-    --category scalable \
-    --remote_worker_host grpc-kokoro-performance-windows1 grpc-kokoro-performance-windows2 \
-    --bq_result_table performance_test.performance_experiment_windows \
-    --xml_report run_performance_tests/windows/sponge_log.xml \
-    || EXIT_CODE=1
+git clean -fdxq -e reports -e run_performance_tests
 
 exit $EXIT_CODE

--- a/tools/internal_ci/linux/grpc_full_performance_release.sh
+++ b/tools/internal_ci/linux/grpc_full_performance_release.sh
@@ -31,7 +31,7 @@ tools/run_tests/run_performance_tests.py \
     || EXIT_CODE=1
 
 # prevent pushing leftover build files to remote hosts in the next step.
-git clean -fdxq -e reports
+git clean -fdxq -e reports -e run_performance_tests
 
 # scalability with 32cores (and upload to a different BQ table)
 tools/run_tests/run_performance_tests.py \
@@ -45,15 +45,6 @@ tools/run_tests/run_performance_tests.py \
     || EXIT_CODE=1
 
 # prevent pushing leftover build files to remote hosts in the next step.
-git clean -fdxq -e reports
-
-# selected scenarios on Windows
-tools/run_tests/run_performance_tests.py \
-    -l csharp \
-    --category scalable \
-    --remote_worker_host grpc-kokoro-performance-windows1 grpc-kokoro-performance-windows2 \
-    --bq_result_table performance_released.performance_experiment_windows \
-    --xml_report run_performance_tests/windows/sponge_log.xml \
-    || EXIT_CODE=1
+git clean -fdxq -e reports -e run_performance_tests
 
 exit $EXIT_CODE


### PR DESCRIPTION
- stop running windows multi-machine benchmarks as they are permanently broken an the VMs are out of date.
- as a followup for https://github.com/grpc/grpc/pull/20288/files, stop deleting the reports generated by the run_performance_tests.py scripts
