### PR TITLE
PHP:Migrate php:unit_tests to  latest version PHPUnit 8

### DIFF
--- a/src/php/tests/unit_tests/CallCredentials2Test.php
+++ b/src/php/tests/unit_tests/CallCredentials2Test.php
@@ -17,9 +17,9 @@
  *
  */
 
-class CallCredentials2Test extends PHPUnit_Framework_TestCase
+class CallCredentials2Test extends PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $credentials = Grpc\ChannelCredentials::createSsl(
             file_get_contents(dirname(__FILE__).'/../data/ca.pem'));
@@ -43,7 +43,7 @@ class CallCredentials2Test extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->channel);
         unset($this->server);

--- a/src/php/tests/unit_tests/CallCredentialsTest.php
+++ b/src/php/tests/unit_tests/CallCredentialsTest.php
@@ -17,9 +17,9 @@
  *
  */
 
-class CallCredentialsTest extends PHPUnit_Framework_TestCase
+class CallCredentialsTest extends PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->credentials = Grpc\ChannelCredentials::createSsl(
             file_get_contents(dirname(__FILE__).'/../data/ca.pem'));
@@ -49,7 +49,7 @@ class CallCredentialsTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->channel);
         unset($this->server);
@@ -139,20 +139,22 @@ class CallCredentialsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testCreateFromPluginInvalidParam()
-    {
+    {   $this->expectException(InvalidArgumentException::class);
+        
         $call_credentials = Grpc\CallCredentials::createFromPlugin(
             'callbackFunc'
         );
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testCreateCompositeInvalidParam()
-    {
+    {   $this->expectException(InvalidArgumentException::class);
+
         $call_credentials3 = Grpc\CallCredentials::createComposite(
             $this->call_credentials,
             $this->credentials

--- a/src/php/tests/unit_tests/CallInvokerTest.php
+++ b/src/php/tests/unit_tests/CallInvokerTest.php
@@ -159,16 +159,16 @@ class CallInvokerChangeRequestCall
     }
 }
 
-class CallInvokerTest extends PHPUnit_Framework_TestCase
+class CallInvokerTest extends PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->server = new Grpc\Server([]);
         $this->port = $this->server->addHttp2Port('0.0.0.0:0');
         $this->server->start();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->server);
     }
@@ -176,11 +176,13 @@ class CallInvokerTest extends PHPUnit_Framework_TestCase
     public function testCreateDefaultCallInvoker()
     {
         $call_invoker = new \Grpc\DefaultCallInvoker();
+        $this->assertTrue(true);
     }
 
     public function testCreateCallInvoker()
     {
         $call_invoker = new CallInvokerUpdateChannel();
+        $this->assertTrue(true);
     }
 
     public function testCallInvokerAccessChannel()

--- a/src/php/tests/unit_tests/CallTest.php
+++ b/src/php/tests/unit_tests/CallTest.php
@@ -16,18 +16,18 @@
  * limitations under the License.
  *
  */
-class CallTest extends PHPUnit_Framework_TestCase
+class CallTest extends PHPUnit\Framework\TestCase
 {
     public static $server;
     public static $port;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$server = new Grpc\Server([]);
         self::$port = self::$server->addHttp2Port('0.0.0.0:53000');
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->channel = new Grpc\Channel('localhost:'.self::$port, [
             'force_new' => true,
@@ -37,7 +37,7 @@ class CallTest extends PHPUnit_Framework_TestCase
                                     Grpc\Timeval::infFuture());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->channel->close();
     }
@@ -107,10 +107,12 @@ class CallTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidStartBatchKey()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $batch = [
             'invalid' => ['key1' => 'value1'],
         ];
@@ -118,10 +120,12 @@ class CallTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidMetadataStrKey()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $batch = [
             Grpc\OP_SEND_INITIAL_METADATA => ['Key' => ['value1', 'value2']],
         ];
@@ -129,10 +133,12 @@ class CallTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidMetadataIntKey()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $batch = [
             Grpc\OP_SEND_INITIAL_METADATA => [1 => ['value1', 'value2']],
         ];
@@ -140,10 +146,12 @@ class CallTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidMetadataInnerValue()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $batch = [
             Grpc\OP_SEND_INITIAL_METADATA => ['key1' => 'value1'],
         ];
@@ -151,36 +159,44 @@ class CallTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidConstuctor()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $this->call = new Grpc\Call();
         $this->assertNull($this->call);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidConstuctor2()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $this->call = new Grpc\Call('hi', 'hi', 'hi');
         $this->assertNull($this->call);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidSetCredentials()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $this->call->setCredentials('hi');
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidSetCredentials2()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $this->call->setCredentials([]);
     }
 }

--- a/src/php/tests/unit_tests/ChannelCredentialsTest.php
+++ b/src/php/tests/unit_tests/ChannelCredentialsTest.php
@@ -17,13 +17,13 @@
  *
  */
 
-class ChanellCredentialsTest extends PHPUnit_Framework_TestCase
+class ChanellCredentialsTest extends PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
     }
 
@@ -47,18 +47,22 @@ class ChanellCredentialsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidCreateSsl()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $channel_credentials = Grpc\ChannelCredentials::createSsl([]);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidCreateComposite()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $channel_credentials = Grpc\ChannelCredentials::createComposite(
             'something', 'something');
     }

--- a/src/php/tests/unit_tests/ChannelTest.php
+++ b/src/php/tests/unit_tests/ChannelTest.php
@@ -17,13 +17,13 @@
  *
  */
 
-class ChannelTest extends PHPUnit_Framework_TestCase
+class ChannelTest extends PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if (!empty($this->channel)) {
             $this->channel->close();
@@ -39,8 +39,9 @@ class ChannelTest extends PHPUnit_Framework_TestCase
 
     public function testConstructorCreateSsl()
     {
-        new Grpc\Channel('localhost:50033', 
+        $this->channel = new Grpc\Channel('localhost:50033', 
             ['credentials' => \Grpc\ChannelCredentials::createSsl()]);
+        $this->assertSame('Grpc\Channel', get_class($this->channel));
     }
 
     public function testGetConnectivityState()
@@ -106,66 +107,76 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidConstructorWithNull()
-    {
+    {   $this->expectException(InvalidArgumentException::class);
+
         $this->channel = new Grpc\Channel();
         $this->assertNull($this->channel);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidConstructorWith()
-    {
+    {   $this->expectException(InvalidArgumentException::class);
+
         $this->channel = new Grpc\Channel('localhost:50008', 'invalid');
         $this->assertNull($this->channel);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidCredentials()
-    {
+    {   $this->expectException(InvalidArgumentException::class);
+
         $this->channel = new Grpc\Channel('localhost:50009',
             ['credentials' => new Grpc\Timeval(100)]);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidOptionsArray()
-    {
+    {   $this->expectException(InvalidArgumentException::class);
+
         $this->channel = new Grpc\Channel('localhost:50010',
             ['abc' => []]);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidGetConnectivityStateWithArray()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $this->channel = new Grpc\Channel('localhost:50011',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->getConnectivityState([]);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidWatchConnectivityState()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $this->channel = new Grpc\Channel('localhost:50012',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->watchConnectivityState([]);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidWatchConnectivityState2()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $this->channel = new Grpc\Channel('localhost:50013',
             ['credentials' => Grpc\ChannelCredentials::createInsecure()]);
         $this->channel->watchConnectivityState(1, 'hi');
@@ -410,10 +421,12 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * expectedException RuntimeException
      */
     public function testPersistentChannelSharedChannelClose2()
     {
+        $this->expectException(RuntimeException::class);
+
         // same underlying channel
         $this->channel1 = new Grpc\Channel('localhost:50223', [
             "grpc_target_persist_bound" => 3,
@@ -646,10 +659,11 @@ class ChannelTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException RuntimeException
+     * expectedException RuntimeException
      */
     public function testPersistentChannelForceNewOldChannelClose2()
     {
+        $this->expectException(RuntimeException::class);
 
         $this->channel1 = new Grpc\Channel('localhost:50230', [
             "grpc_target_persist_bound" => 2,

--- a/src/php/tests/unit_tests/EndToEndTest.php
+++ b/src/php/tests/unit_tests/EndToEndTest.php
@@ -16,9 +16,9 @@
  * limitations under the License.
  *
  */
-class EndToEndTest extends PHPUnit_Framework_TestCase
+class EndToEndTest extends PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->server = new Grpc\Server([]);
         $this->port = $this->server->addHttp2Port('0.0.0.0:0');
@@ -28,7 +28,7 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
         $this->server->start();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->channel->close();
         unset($this->server);
@@ -189,10 +189,12 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidClientMessageArray()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -210,10 +212,12 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidClientMessageString()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -230,11 +234,11 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
+    
     public function testInvalidClientMessageFlags()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -254,10 +258,12 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidServerStatusMetadata()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -295,10 +301,12 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidServerStatusCode()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -336,10 +344,12 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testMissingServerStatusCode()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -376,10 +386,12 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidServerStatusDetails()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -417,10 +429,12 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testMissingServerStatusDetails()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -457,10 +471,12 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidStartBatchKey()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -476,10 +492,12 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException LogicException
+     * expectedException LogicException
      */
     public function testInvalidStartBatch()
     {
+        $this->expectException(LogicException::class);
+
         $deadline = Grpc\Timeval::infFuture();
         $req_text = 'client_server_full_request_response';
         $reply_text = 'reply:client_server_full_request_response';
@@ -558,28 +576,34 @@ class EndToEndTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testGetConnectivityStateInvalidParam()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $this->assertTrue($this->channel->getConnectivityState(
             new Grpc\Timeval()));
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testWatchConnectivityStateInvalidParam()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $this->assertTrue($this->channel->watchConnectivityState(
             0, 1000));
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testChannelConstructorInvalidParam()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $this->channel = new Grpc\Channel('localhost:'.$this->port, null);
     }
 

--- a/src/php/tests/unit_tests/InterceptorTest.php
+++ b/src/php/tests/unit_tests/InterceptorTest.php
@@ -215,9 +215,9 @@ class StopCallInterceptor extends Grpc\Interceptor
     }
 }
 
-class InterceptorTest extends PHPUnit_Framework_TestCase
+class InterceptorTest extends PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->server = new Grpc\Server([]);
         $this->port = $this->server->addHttp2Port('0.0.0.0:0');
@@ -227,7 +227,7 @@ class InterceptorTest extends PHPUnit_Framework_TestCase
         $this->server->start();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->channel->close();
         unset($this->server);

--- a/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php
+++ b/src/php/tests/unit_tests/PersistentChannelTests/PersistentChannelTest.php
@@ -20,13 +20,13 @@
 /**
  * @group persistent_list_bound_tests
  */
-class PersistentListTest extends PHPUnit_Framework_TestCase
+class PersistentListTest extends PHPUnit\Framework\TestCase
 {
-  public function setUp()
+  public function setUp(): void
   {
   }
 
-  public function tearDown()
+  public function tearDown(): void
   {
     $channel_clean_persistent =
         new Grpc\Channel('localhost:50010', []);

--- a/src/php/tests/unit_tests/SecureEndToEndTest.php
+++ b/src/php/tests/unit_tests/SecureEndToEndTest.php
@@ -16,9 +16,9 @@
  * limitations under the License.
  *
  */
-class SecureEndToEndTest extends PHPUnit_Framework_TestCase
+class SecureEndToEndTest extends PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $credentials = Grpc\ChannelCredentials::createSsl(
             file_get_contents(dirname(__FILE__).'/../data/ca.pem'));
@@ -42,7 +42,7 @@ class SecureEndToEndTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->channel->close();
         unset($this->server);

--- a/src/php/tests/unit_tests/ServerTest.php
+++ b/src/php/tests/unit_tests/ServerTest.php
@@ -17,14 +17,14 @@
  *
  */
 
-class ServerTest extends PHPUnit_Framework_TestCase
+class ServerTest extends PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->server = null;
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->server);
     }
@@ -91,64 +91,76 @@ class ServerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidConstructor()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $this->server = new Grpc\Server('invalid_host');
         $this->assertNull($this->server);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidConstructorWithNumKeyOfArray()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $this->server = new Grpc\Server([10 => '127.0.0.1',
                                          20 => '8080', ]);
         $this->assertNull($this->server);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidConstructorWithList()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $this->server = new Grpc\Server(['127.0.0.1', '8080']);
         $this->assertNull($this->server);
     }
-    /**
-     * @expectedException InvalidArgumentException
-     */
+
     public function testInvalidAddHttp2Port()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $this->server = new Grpc\Server([]);
         $port = $this->server->addHttp2Port(['0.0.0.0:0']);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidAddSecureHttp2Port()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $this->server = new Grpc\Server([]);
         $port = $this->server->addSecureHttp2Port(['0.0.0.0:0']);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidAddSecureHttp2Port2()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $this->server = new Grpc\Server();
         $port = $this->server->addSecureHttp2Port('0.0.0.0:0');
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testInvalidAddSecureHttp2Port3()
-    {
+    {   
+        $this->expectException(InvalidArgumentException::class);
+
         $this->server = new Grpc\Server();
         $port = $this->server->addSecureHttp2Port('0.0.0.0:0', 'invalid');
     }

--- a/src/php/tests/unit_tests/TimevalTest.php
+++ b/src/php/tests/unit_tests/TimevalTest.php
@@ -16,13 +16,13 @@
  * limitations under the License.
  *
  */
-class TimevalTest extends PHPUnit_Framework_TestCase
+class TimevalTest extends PHPUnit\Framework\TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->time);
     }
@@ -152,44 +152,54 @@ class TimevalTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testConstructorInvalidParam()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $delta = new Grpc\Timeval('abc');
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testAddInvalidParam()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $a = Grpc\Timeval::now();
         $a->add(1000);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testSubtractInvalidParam()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $a = Grpc\Timeval::now();
         $a->subtract(1000);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testCompareInvalidParam()
     {
+        $this->expectException(InvalidArgumentException::class);
+
         $a = Grpc\Timeval::compare(1000, 1100);
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * expectedException InvalidArgumentException
      */
     public function testSimilarInvalidParam()
     {
+        $this->expectException(InvalidArgumentException::class);
+        
         $a = Grpc\Timeval::similar(1000, 1100, 1200);
         $this->assertNull($delta);
     }


### PR DESCRIPTION
For PHPUnit 8:
PHPUnit\Framework\TestCase::setUpBeforeClass()
PHPUnit\Framework\TestCase::setUp()
PHPUnit\Framework\TestCase::tearDown()
The methods listed above now must be declared void.

The @expectedException, @expectedExceptionCode, @expectedExceptionMessage, and @expectedExceptionMessageRegExp annotations are deprecated. They will be removed in PHPUnit 9. Refactor your test to use expectException(), expectExceptionCode(), expectExceptionMessage(), or expectExceptionMessageRegExp() instead.

@stanley-cheung 