### PR TITLE
Initialize executor thread state globally and remove logic to destroy the thread state during shutdown

### DIFF
--- a/src/core/lib/iomgr/executor.h
+++ b/src/core/lib/iomgr/executor.h
@@ -117,6 +117,9 @@ class Executor {
   gpr_spinlock adding_thread_lock_;
 };
 
+// Global initializer for executor
+void grpc_executor_global_init();
+
 }  // namespace grpc_core
 
 #endif /* GRPC_CORE_LIB_IOMGR_EXECUTOR_H */

--- a/src/core/lib/surface/init.cc
+++ b/src/core/lib/surface/init.cc
@@ -73,6 +73,7 @@ static void do_basic_init(void) {
   g_shutting_down = false;
   grpc_register_built_in_plugins();
   grpc_cq_global_init();
+  grpc_core::grpc_executor_global_init();
   gpr_time_init();
   g_initializations = 0;
 }


### PR DESCRIPTION
… the main thread.

There is a race between shutdown thread and the main executor thread. The shutdown thread may destroy the thread_state before the main thread cleans it up. 
To avoid this move the initialization of the thread states to a global init and remove the code to destroy the thread states

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@nicolasnoble
