### PR TITLE
Fixed an issue where Swift application depending on gRPC is unable to archive

### DIFF
--- a/gRPC.podspec
+++ b/gRPC.podspec
@@ -117,11 +117,9 @@ Pod::Spec.new do |s|
                              'src/objective-c/GRPCClient/GRPCCall+Cronet.h',
                              'src/objective-c/GRPCClient/GRPCCall+OAuth2.h',
                              'src/objective-c/GRPCClient/GRPCCall+Tests.h',
-                             'src/objective-c/GRPCClient/GRPCCall+ChannelArg.h',
-                             'src/objective-c/GRPCClient/internal_testing/*.h'
+                             'src/objective-c/GRPCClient/GRPCCall+ChannelArg.h'
     ss.private_header_files = 'src/objective-c/GRPCClient/private/GRPCCore/*.h'
-    ss.source_files = 'src/objective-c/GRPCClient/internal_testing/*.{h,m}',
-                      'src/objective-c/GRPCClient/private/GRPCCore/*.{h,m}',
+    ss.source_files = 'src/objective-c/GRPCClient/private/GRPCCore/*.{h,m}',
                       'src/objective-c/GRPCClient/GRPCCall+ChannelArg.h',
                       'src/objective-c/GRPCClient/GRPCCall+ChannelArg.m',
                       'src/objective-c/GRPCClient/GRPCCall+ChannelCredentials.h',
@@ -164,6 +162,18 @@ Pod::Spec.new do |s|
   # CFStream is now default. Leaving this subspec only for compatibility purpose.
   s.subspec 'CFStream' do |ss|
     ss.dependency "#{s.name}/GRPCCore", version
+
+    ss.ios.deployment_target = '7.0'
+    ss.osx.deployment_target = '10.9'
+    ss.tvos.deployment_target = '10.0'
+    ss.watchos.deployment_target = '4.0'
+  end
+
+  s.subspec 'InternalTesting' do |ss|
+    ss.dependency "#{s.name}/GRPCCore", version
+    ss.public_header_files = 'src/objective-c/GRPCClient/internal_testing/*.h'
+    ss.source_files = 'src/objective-c/GRPCClient/internal_testing/*.{h,m}'
+    ss.header_mappings_dir = 'src/objective-c/GRPCClient'
 
     ss.ios.deployment_target = '7.0'
     ss.osx.deployment_target = '10.9'

--- a/src/objective-c/tests/Podfile
+++ b/src/objective-c/tests/Podfile
@@ -13,10 +13,10 @@ def grpc_deps
   
   pod 'BoringSSL-GRPC',       :podspec => "#{GRPC_LOCAL_SRC}/src/objective-c", :inhibit_warnings => true
   
-  pod 'gRPC',           :path => GRPC_LOCAL_SRC
-  pod 'gRPC-Core',      :path => GRPC_LOCAL_SRC
-  pod 'gRPC-RxLibrary', :path => GRPC_LOCAL_SRC
-  pod 'gRPC-ProtoRPC',  :path => GRPC_LOCAL_SRC, :inhibit_warnings => true
+  pod 'gRPC/InternalTesting',           :path => GRPC_LOCAL_SRC
+  pod 'gRPC-Core',                      :path => GRPC_LOCAL_SRC
+  pod 'gRPC-RxLibrary',                 :path => GRPC_LOCAL_SRC
+  pod 'gRPC-ProtoRPC',                  :path => GRPC_LOCAL_SRC, :inhibit_warnings => true
   pod 'RemoteTest', :path => "RemoteTestClient", :inhibit_warnings => true
 end
 

--- a/templates/gRPC.podspec.template
+++ b/templates/gRPC.podspec.template
@@ -119,11 +119,9 @@
                                'src/objective-c/GRPCClient/GRPCCall+Cronet.h',
                                'src/objective-c/GRPCClient/GRPCCall+OAuth2.h',
                                'src/objective-c/GRPCClient/GRPCCall+Tests.h',
-                               'src/objective-c/GRPCClient/GRPCCall+ChannelArg.h',
-                               'src/objective-c/GRPCClient/internal_testing/*.h'
+                               'src/objective-c/GRPCClient/GRPCCall+ChannelArg.h'
       ss.private_header_files = 'src/objective-c/GRPCClient/private/GRPCCore/*.h'
-      ss.source_files = 'src/objective-c/GRPCClient/internal_testing/*.{h,m}',
-                        'src/objective-c/GRPCClient/private/GRPCCore/*.{h,m}',
+      ss.source_files = 'src/objective-c/GRPCClient/private/GRPCCore/*.{h,m}',
                         'src/objective-c/GRPCClient/GRPCCall+ChannelArg.h',
                         'src/objective-c/GRPCClient/GRPCCall+ChannelArg.m',
                         'src/objective-c/GRPCClient/GRPCCall+ChannelCredentials.h',
@@ -166,6 +164,18 @@
     # CFStream is now default. Leaving this subspec only for compatibility purpose.
     s.subspec 'CFStream' do |ss|
       ss.dependency "#{s.name}/GRPCCore", version
+
+      ss.ios.deployment_target = '7.0'
+      ss.osx.deployment_target = '10.9'
+      ss.tvos.deployment_target = '10.0'
+      ss.watchos.deployment_target = '4.0'
+    end
+
+    s.subspec 'InternalTesting' do |ss|
+      ss.dependency "#{s.name}/GRPCCore", version
+      ss.public_header_files = 'src/objective-c/GRPCClient/internal_testing/*.h'
+      ss.source_files = 'src/objective-c/GRPCClient/internal_testing/*.{h,m}'
+      ss.header_mappings_dir = 'src/objective-c/GRPCClient'
 
       ss.ios.deployment_target = '7.0'
       ss.osx.deployment_target = '10.9'


### PR DESCRIPTION
The PR moves `internal_testing` directory out of the default gRPC pod, and creates a test-only subspec for it.