### PR TITLE
[WIP] Add Support for Full Chain Callbacks

### DIFF
--- a/include/grpc/grpc_security.h
+++ b/include/grpc/grpc_security.h
@@ -203,6 +203,9 @@ typedef struct {
      cleaned up. The userdata argument will be passed to it. The intent is
      to perform any cleanup associated with that userdata. */
   void (*verify_peer_destruct)(void* userdata);
+
+  /** server verification options */
+  grpc_ssl_peer_cert_request_type peer_cert_request_type;
 } grpc_ssl_verify_peer_options;
 
 /** Deprecated in favor of grpc_ssl_server_credentials_create_ex. It will be
@@ -264,10 +267,14 @@ GRPCAPI grpc_channel_credentials* grpc_ssl_credentials_create(
      with which you can do additional verification. Can be NULL, in which
      case verification will retain default behavior. Any settings in
      verify_options are copied during this call, so the verify_options
-     object can be released afterwards. */
+     object can be released afterwards.
+   - server_verification_option controls whether default server verification
+     will be done or skipped */
 GRPCAPI grpc_channel_credentials* grpc_ssl_credentials_create_ex(
     const char* pem_root_certs, grpc_ssl_pem_key_cert_pair* pem_key_cert_pair,
-    const grpc_ssl_verify_peer_options* verify_options, void* reserved);
+    const grpc_ssl_verify_peer_options* verify_options,
+    grpc_ssl_server_verification_option server_verification_option,
+    void* reserved);
 
 /** --- grpc_call_credentials object.
 

--- a/include/grpc/grpc_security_constants.h
+++ b/include/grpc/grpc_security_constants.h
@@ -29,6 +29,7 @@ extern "C" {
 #define GRPC_X509_CN_PROPERTY_NAME "x509_common_name"
 #define GRPC_X509_SAN_PROPERTY_NAME "x509_subject_alternative_name"
 #define GRPC_X509_PEM_CERT_PROPERTY_NAME "x509_pem_cert"
+#define GRPC_X509_PEM_CERT_CHAIN_PROPERTY_NAME "x509_pem_cert_chain"
 #define GRPC_SSL_SESSION_REUSED_PROPERTY "ssl_session_reused"
 
 /** Environment variable that points to the default SSL roots file. This file
@@ -104,6 +105,28 @@ typedef enum {
      be established. */
   GRPC_SSL_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY
 } grpc_ssl_client_certificate_request_type;
+
+
+typedef enum {
+  /** Default option: performs server certificate verification and hostname
+     verification */
+  GRPC_SSL_SERVER_VERIFICATION,
+  /** Performs server certificate verification, but skips hostname verification
+   */
+  GRPC_SSL_SKIP_HOSTNAME_VERIFICATION,
+  /** Performs hostname name verification, but skips server certificate
+     verification */
+  GRPC_SSL_SKIP_SERVER_CERTIFICATE_VERIFICATION,
+  /** Skips both server certificate and hostname verification */
+  GRPC_SSL_SKIP_ALL_SERVER_VERIFICATION
+} grpc_ssl_server_verification_option;
+
+typedef enum {
+  /** Get peer leaf certificate */
+  GRPC_SSL_PEER_LEAF_CERTIFICATE,
+  /** Get peer full chain */
+  GRPC_SSL_PEER_FULL_CHAIN
+} grpc_ssl_peer_cert_request_type;
 
 /**
  * Type of local connections for which local channel/server credentials will be

--- a/include/grpcpp/security/credentials.h
+++ b/include/grpcpp/security/credentials.h
@@ -26,6 +26,7 @@ namespace grpc {
 typedef ::grpc_impl::ChannelCredentials ChannelCredentials;
 typedef ::grpc_impl::CallCredentials CallCredentials;
 typedef ::grpc_impl::SslCredentialsOptions SslCredentialsOptions;
+typedef ::grpc_impl::SslClientCredentialsOptions SslClientCredentialsOptions;
 typedef ::grpc_impl::SecureCallCredentials SecureCallCredentials;
 typedef ::grpc_impl::SecureChannelCredentials SecureChannelCredentials;
 typedef ::grpc_impl::MetadataCredentialsPlugin MetadataCredentialsPlugin;
@@ -38,6 +39,11 @@ GoogleDefaultCredentials() {
 static inline std::shared_ptr<ChannelCredentials> SslCredentials(
     const SslCredentialsOptions& options) {
   return ::grpc_impl::SslCredentials(options);
+}
+
+static inline std::shared_ptr<ChannelCredentials> SslClientCredentials(
+    const SslClientCredentialsOptions& options) {
+  return ::grpc_impl::SslClientCredentials(options);
 }
 
 static inline std::shared_ptr<grpc_impl::CallCredentials>

--- a/include/grpcpp/security/credentials_impl.h
+++ b/include/grpcpp/security/credentials_impl.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include <grpc/grpc_security_constants.h>
+#include <grpc/grpc_security.h>
 #include <grpcpp/channel_impl.h>
 #include <grpcpp/impl/codegen/client_interceptor.h>
 #include <grpcpp/impl/codegen/grpc_library.h>
@@ -147,6 +148,18 @@ struct SslCredentialsOptions {
   grpc::string pem_cert_chain;
 };
 
+/// Options used to build SslClientCredentials
+struct SslClientCredentialsOptions {
+  /// This contains roots, client cert chain and the private key
+  SslCredentialsOptions credential_options;
+
+  /// grpc_ssl_verify_peer_options for verifying peer certificates
+  grpc_ssl_verify_peer_options *verify_options;
+
+  /// grpc_ssl_server_verification_option
+  grpc_ssl_server_verification_option server_verification_option;
+};
+
 // Factories for building different types of Credentials The functions may
 // return empty shared_ptr when credentials cannot be created. If a
 // Credentials pointer is returned, it can still be invalid when used to create
@@ -163,6 +176,10 @@ std::shared_ptr<ChannelCredentials> GoogleDefaultCredentials();
 /// Builds SSL Credentials given SSL specific options
 std::shared_ptr<ChannelCredentials> SslCredentials(
     const SslCredentialsOptions& options);
+
+/// Builds SSL Credentials given SslClientCredentialsOptions
+std::shared_ptr<ChannelCredentials> SslClientCredentials(
+    const SslClientCredentialsOptions& options);
 
 /// Builds credentials for use when running in GCE
 ///

--- a/src/core/lib/security/credentials/ssl/ssl_credentials.cc
+++ b/src/core/lib/security/credentials/ssl/ssl_credentials.cc
@@ -46,7 +46,7 @@ void grpc_tsi_ssl_pem_key_cert_pairs_destroy(tsi_ssl_pem_key_cert_pair* kp,
 
 grpc_ssl_credentials::grpc_ssl_credentials(
     const char* pem_root_certs, grpc_ssl_pem_key_cert_pair* pem_key_cert_pair,
-    const verify_peer_options* verify_options)
+    const grpc_ssl_verify_peer_options* verify_options)
     : grpc_channel_credentials(GRPC_CHANNEL_CREDENTIALS_TYPE_SSL) {
   if (verify_options != nullptr) {
     grpc_ssl_verify_peer_options options;

--- a/src/core/lib/security/credentials/ssl/ssl_credentials.h
+++ b/src/core/lib/security/credentials/ssl/ssl_credentials.h
@@ -28,7 +28,12 @@ class grpc_ssl_credentials : public grpc_channel_credentials {
  public:
   grpc_ssl_credentials(const char* pem_root_certs,
                        grpc_ssl_pem_key_cert_pair* pem_key_cert_pair,
-                       const grpc_ssl_verify_peer_options* verify_options);
+                       const verify_peer_options* verify_options);
+
+  grpc_ssl_credentials(const char* pem_root_certs,
+                       grpc_ssl_pem_key_cert_pair* pem_key_cert_pair,
+                       const grpc_ssl_verify_peer_options* verify_options,
+      grpc_ssl_server_verification_option server_verification_option);
 
   ~grpc_ssl_credentials() override;
 
@@ -41,7 +46,8 @@ class grpc_ssl_credentials : public grpc_channel_credentials {
  private:
   void build_config(const char* pem_root_certs,
                     grpc_ssl_pem_key_cert_pair* pem_key_cert_pair,
-                    const grpc_ssl_verify_peer_options* verify_options);
+                    const grpc_ssl_verify_peer_options* verify_options,
+      grpc_ssl_server_verification_option server_verification_option);
 
   grpc_ssl_config config_;
 };

--- a/src/core/lib/security/credentials/ssl/ssl_credentials.h
+++ b/src/core/lib/security/credentials/ssl/ssl_credentials.h
@@ -28,7 +28,7 @@ class grpc_ssl_credentials : public grpc_channel_credentials {
  public:
   grpc_ssl_credentials(const char* pem_root_certs,
                        grpc_ssl_pem_key_cert_pair* pem_key_cert_pair,
-                       const verify_peer_options* verify_options);
+                       const grpc_ssl_verify_peer_options* verify_options);
 
   grpc_ssl_credentials(const char* pem_root_certs,
                        grpc_ssl_pem_key_cert_pair* pem_key_cert_pair,

--- a/src/core/lib/security/security_connector/ssl/ssl_security_connector.h
+++ b/src/core/lib/security/security_connector/ssl/ssl_security_connector.h
@@ -32,7 +32,8 @@
 typedef struct {
   tsi_ssl_pem_key_cert_pair* pem_key_cert_pair;
   char* pem_root_certs;
-  verify_peer_options verify_options;
+  grpc_ssl_verify_peer_options verify_options;
+  grpc_ssl_server_verification_option server_verification_option;
 } grpc_ssl_config;
 
 /* Creates an SSL channel_security_connector.

--- a/src/core/lib/security/security_connector/ssl_utils.h
+++ b/src/core/lib/security/security_connector/ssl_utils.h
@@ -68,6 +68,12 @@ tsi_client_certificate_request_type
 grpc_get_tsi_client_certificate_request_type(
     grpc_ssl_client_certificate_request_type grpc_request_type);
 
+/* Map from grpc_ssl_server_verification_option to
+ * tsi_server_verification_option. */
+tsi_server_verification_option
+grpc_get_tsi_server_verification_option(
+    grpc_ssl_server_verification_option server_verification_option);
+
 /* Return an array of strings containing alpn protocols. */
 const char** grpc_fill_alpn_protocol_strings(size_t* num_alpn_protocols);
 

--- a/src/core/tsi/ssl_transport_security.cc
+++ b/src/core/tsi/ssl_transport_security.cc
@@ -1048,7 +1048,7 @@ static tsi_result ssl_handshaker_result_extract_peer(
                                    &alpn_selected_len);
   }
 
-  STACK_OF(X509) *peer_chain = SSL_get0_verified_chain(impl->ssl);
+  STACK_OF(X509) *peer_chain = SSL_get_peer_cert_chain(impl->ssl);
   // 1 is for session reused property.
   size_t new_property_count = peer->property_count + 1;
   if (alpn_selected != nullptr) new_property_count++;

--- a/src/core/tsi/ssl_transport_security.h
+++ b/src/core/tsi/ssl_transport_security.h
@@ -35,6 +35,8 @@
 
 #define TSI_X509_PEM_CERT_PROPERTY "x509_pem_cert"
 
+#define TSI_X509_PEM_CERT_CHAIN_PROPERTY "x509_pem_cert_chain"
+
 #define TSI_SSL_ALPN_SELECTED_PROTOCOL "ssl_alpn_selected_protocol"
 
 /* --- tsi_ssl_root_certs_store object ---
@@ -142,6 +144,9 @@ struct tsi_ssl_client_handshaker_options {
   /* ssl_session_cache is a cache for reusable client-side sessions. */
   tsi_ssl_session_cache* session_cache;
 
+  /* Server verification option */
+  tsi_server_verification_option server_verification_option;
+
   tsi_ssl_client_handshaker_options()
       : pem_key_cert_pair(nullptr),
         pem_root_certs(nullptr),
@@ -149,7 +154,8 @@ struct tsi_ssl_client_handshaker_options {
         cipher_suites(nullptr),
         alpn_protocols(nullptr),
         num_alpn_protocols(0),
-        session_cache(nullptr) {}
+        session_cache(nullptr),
+        server_verification_option(TSI_SERVER_VERIFICATION) {}
 };
 
 /* Creates a client handshaker factory.

--- a/src/core/tsi/transport_security_interface.h
+++ b/src/core/tsi/transport_security_interface.h
@@ -55,6 +55,14 @@ typedef enum {
   TSI_REQUEST_AND_REQUIRE_CLIENT_CERTIFICATE_AND_VERIFY,
 } tsi_client_certificate_request_type;
 
+typedef enum {
+  // Default option
+  TSI_SERVER_VERIFICATION,
+  TSI_SKIP_HOSTNAME_VERIFICATION,
+  TSI_SKIP_SERVER_CERTIFICATE_VERIFICATION,
+  TSI_SKIP_ALL_SERVER_VERIFICATION,
+} tsi_server_verification_option;
+
 const char* tsi_result_to_string(tsi_result result);
 
 /* --- tsi tracing --- */

--- a/src/cpp/client/secure_credentials.cc
+++ b/src/cpp/client/secure_credentials.cc
@@ -113,6 +113,23 @@ std::shared_ptr<ChannelCredentials> SslCredentials(
   return WrapChannelCredentials(c_creds);
 }
 
+// Builds SSL Credentials given SSL specific options
+std::shared_ptr<ChannelCredentials> SslClientCredentials(
+    const SslClientCredentialsOptions& options) {
+  grpc::GrpcLibraryCodegen init;  // To call grpc_init().
+  grpc_ssl_pem_key_cert_pair pem_key_cert_pair = {
+      options.credential_options.pem_private_key.c_str(),
+      options.credential_options.pem_cert_chain.c_str()};
+
+  grpc_channel_credentials* c_creds = grpc_ssl_credentials_create_ex(
+      options.credential_options.pem_root_certs.empty() ? nullptr
+          : options.credential_options.pem_root_certs.c_str(),
+      options.credential_options.pem_private_key.empty() ? nullptr
+                                                         : &pem_key_cert_pair,
+      options.verify_options, options.server_verification_option, nullptr);
+  return WrapChannelCredentials(c_creds);
+}
+
 namespace experimental {
 
 namespace {


### PR DESCRIPTION
This fixes #18293 partially where it adds support for Full Chain callbacks. It is based on discussions at https://github.com/grpc/grpc/pull/20316#issuecomment-538168131. 

This PR does not contain unittests as we wanted to get the feedback on the approach first. 

It adds  `x509_pem_cert_chain` in addition to `x509_pem_cert` and configures `grpc_verify_peer_callback` to use `x509_pem_cert_chain`

Also, one question remains on how to specify gRPC on client side that don't fail for default server validation. We see `SSL_CTX_set_verify(ssl_context, SSL_VERIFY_PEER, nullptr);` but that can't be configured to ignore errors and let callback handle that validation? Similar to what `tsi_client_certificate_request_type`

@jiangtaoli2016 for feedback. 

@yihuazhang @markdroth @nicolasnoble FYI, 
 