### PR TITLE
Update docker images for manylinux

### DIFF
--- a/tools/dockerfile/grpc_artifact_linux_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_linux_x64/Dockerfile
@@ -84,7 +84,7 @@ RUN apt-get update && apt-get install -t jessie-backports -y cmake && apt-get cl
 # Python AuditWheel dependencies (needed to check manylinux1 compatibility)
 
 RUN apt-get install -y python3 python3-pip
-RUN pip3 install auditwheel==1.10.0
+RUN pip3 install auditwheel==2.1.1
 
 
 RUN mkdir /var/local/jenkins

--- a/tools/dockerfile/grpc_artifact_linux_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_linux_x86/Dockerfile
@@ -77,7 +77,7 @@ RUN apt-get update && apt-get install -t jessie-backports -y cmake && apt-get cl
 # Python AuditWheel dependencies (needed to check manylinux1 compatibility)
 
 RUN apt-get install -y python3 python3-pip
-RUN pip3 install auditwheel==1.10.0
+RUN pip3 install auditwheel==2.1.1
 
 
 RUN mkdir /var/local/jenkins

--- a/tools/dockerfile/grpc_artifact_python_manylinux1_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux1_x64/Dockerfile
@@ -28,11 +28,4 @@ RUN /opt/python/cp34-cp34m/bin/pip install cython
 RUN /opt/python/cp35-cp35m/bin/pip install cython
 RUN /opt/python/cp36-cp36m/bin/pip install cython
 RUN /opt/python/cp37-cp37m/bin/pip install cython
-
-####################################################
-# Install auditwheel with fix for namespace packages
-RUN git clone https://github.com/pypa/auditwheel /usr/local/src/auditwheel
-RUN cd /usr/local/src/auditwheel && git checkout 2.1
-RUN /opt/python/cp36-cp36m/bin/pip install /usr/local/src/auditwheel
-RUN rm /usr/local/bin/auditwheel
-RUN cd /usr/local/bin && ln -s /opt/python/cp36-cp36m/bin/auditwheel
+RUN /opt/python/cp38-cp38/bin/pip install cython

--- a/tools/dockerfile/grpc_artifact_python_manylinux2010_x64/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2010_x64/Dockerfile
@@ -28,11 +28,5 @@ RUN /opt/python/cp34-cp34m/bin/pip install cython
 RUN /opt/python/cp35-cp35m/bin/pip install cython
 RUN /opt/python/cp36-cp36m/bin/pip install cython
 RUN /opt/python/cp37-cp37m/bin/pip install cython
-
-####################################################
-# Install auditwheel with fix for namespace packages
-RUN git clone https://github.com/pypa/auditwheel /usr/local/src/auditwheel
-RUN cd /usr/local/src/auditwheel && git checkout 2.1
-RUN /opt/python/cp36-cp36m/bin/pip install /usr/local/src/auditwheel
-RUN rm /usr/local/bin/auditwheel
-RUN cd /usr/local/bin && ln -s /opt/python/cp36-cp36m/bin/auditwheel
+RUN /opt/python/cp37-cp37m/bin/pip install cython
+RUN /opt/python/cp38-cp38/bin/pip install cython

--- a/tools/dockerfile/grpc_artifact_python_manylinux2010_x86/Dockerfile
+++ b/tools/dockerfile/grpc_artifact_python_manylinux2010_x86/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2016 gRPC authors.
+# Copyright 2019 The gRPC Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 # Docker file for building gRPC manylinux Python artifacts.
 
-FROM quay.io/pypa/manylinux1_i686
+FROM quay.io/pypa/manylinux2010_i686
 
 # Update the package manager
 RUN yum update -y

--- a/tools/run_tests/artifacts/build_artifact_python.sh
+++ b/tools/run_tests/artifacts/build_artifact_python.sh
@@ -79,12 +79,12 @@ ${SETARCH_CMD} "${PYTHON}" tools/distrib/python/grpcio_tools/setup.py bdist_whee
 if [ "$GRPC_BUILD_MANYLINUX_WHEEL" != "" ]
 then
   for wheel in dist/*.whl; do
-    "${AUDITWHEEL}" show "$wheel" | tee /dev/stderr |  grep -E -w 'manylinux(1|2010)_(x86_64|i686)'
+    "${AUDITWHEEL}" show "$wheel" | tee /dev/stderr |  grep -E -w "$AUDITWHEEL_PLAT"
     "${AUDITWHEEL}" repair "$wheel" -w "$ARTIFACT_DIR"
     rm "$wheel"
   done
   for wheel in tools/distrib/python/grpcio_tools/dist/*.whl; do
-    "${AUDITWHEEL}" show "$wheel" | tee /dev/stderr |  grep -E -w 'manylinux(1|2010)_(x86_64|i686)'
+    "${AUDITWHEEL}" show "$wheel" | tee /dev/stderr |  grep -E -w "$AUDITWHEEL_PLAT"
     "${AUDITWHEEL}" repair "$wheel" -w "$ARTIFACT_DIR"
     rm "$wheel"
   done


### PR DESCRIPTION
### General Linux docker images
- Updated `auditwheel` to the latest version, `2.1.1`.

### Manylinux docker images
- Added new `manylinux2010_x86` docker image.
- Added cython for python3.8.
- Removed `auditwheel` installation because it's already there.

### Python artifact build script
- Updated the script to use  `AUDITWHEEL_PLAT` baked in manylinux docker images instead of a regular expression to have a more precise validation.
