### PR TITLE
Removing scheduling logic for combiners from closure initialization time to closure run time

### DIFF
--- a/src/core/ext/filters/client_channel/lb_policy.cc
+++ b/src/core/ext/filters/client_channel/lb_policy.cc
@@ -105,9 +105,8 @@ LoadBalancingPolicy::PickResult LoadBalancingPolicy::QueuePicker::Pick(
   if (!exit_idle_called_) {
     exit_idle_called_ = true;
     parent_->Ref().release();  // ref held by closure.
-    GRPC_CLOSURE_SCHED(
-        GRPC_CLOSURE_CREATE(&CallExitIdle, parent_.get(),
-                            grpc_combiner_scheduler(parent_->combiner())),
+    parent_->combiner()->Run(
+        GRPC_CLOSURE_CREATE(&CallExitIdle, parent_.get(), nullptr),
         GRPC_ERROR_NONE);
   }
   PickResult result;

--- a/src/core/ext/filters/client_channel/lb_policy.h
+++ b/src/core/ext/filters/client_channel/lb_policy.h
@@ -313,7 +313,7 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
     // TODO(roth): Once we have a C++-like interface for combiners, this
     // API should change to take a smart pointer that does pass ownership
     // of a reference.
-    grpc_combiner* combiner = nullptr;
+    Combiner* combiner = nullptr;
     /// Channel control helper.
     /// Note: LB policies MUST NOT call any method on the helper from
     /// their constructor.
@@ -383,7 +383,7 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
   };
 
  protected:
-  grpc_combiner* combiner() const { return combiner_; }
+  Combiner* combiner() const { return combiner_; }
 
   // Note: LB policies MUST NOT call any method on the helper from their
   // constructor.
@@ -396,7 +396,7 @@ class LoadBalancingPolicy : public InternallyRefCounted<LoadBalancingPolicy> {
 
  private:
   /// Combiner under which LB policy actions take place.
-  grpc_combiner* combiner_;
+  Combiner* combiner_;
   /// Owned pointer to interested parties in load balancing decisions.
   grpc_pollset_set* interested_parties_;
   /// Channel control helper.

--- a/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
+++ b/src/core/ext/filters/client_channel/lb_policy/xds/xds.cc
@@ -260,6 +260,7 @@ class XdsLb : public LoadBalancingPolicy {
         grpc_channel_args* CreateChildPolicyArgsLocked(
             const grpc_channel_args* args);
 
+        static void OnDelayedRemovalTimer(void* arg, grpc_error* error);
         static void OnDelayedRemovalTimerLocked(void* arg, grpc_error* error);
 
         XdsLb* xds_policy() const { return locality_map_->xds_policy(); }
@@ -309,6 +310,8 @@ class XdsLb : public LoadBalancingPolicy {
      private:
       void OnLocalityStateUpdateLocked();
       void UpdateConnectivityStateLocked();
+      static void OnDelayedRemovalTimer(void* arg, grpc_error* error);
+      static void OnFailoverTimer(void* arg, grpc_error* error);
       static void OnDelayedRemovalTimerLocked(void* arg, grpc_error* error);
       static void OnFailoverTimerLocked(void* arg, grpc_error* error);
 
@@ -382,6 +385,7 @@ class XdsLb : public LoadBalancingPolicy {
 
   // Methods for dealing with fallback state.
   void MaybeCancelFallbackAtStartupChecks();
+  static void OnFallbackTimer(void* arg, grpc_error* error);
   static void OnFallbackTimerLocked(void* arg, grpc_error* error);
   void UpdateFallbackPolicyLocked();
   OrphanablePtr<LoadBalancingPolicy> CreateFallbackPolicyLocked(
@@ -803,8 +807,8 @@ void XdsLb::UpdateLocked(UpdateArgs args) {
     // Start fallback-at-startup checks.
     grpc_millis deadline = ExecCtx::Get()->Now() + lb_fallback_timeout_ms_;
     Ref(DEBUG_LOCATION, "on_fallback_timer").release();  // Held by closure
-    GRPC_CLOSURE_INIT(&lb_on_fallback_, &XdsLb::OnFallbackTimerLocked, this,
-                      grpc_combiner_scheduler(combiner()));
+    GRPC_CLOSURE_INIT(&lb_on_fallback_, &XdsLb::OnFallbackTimer, this,
+                      grpc_schedule_on_exec_ctx);
     fallback_at_startup_checks_pending_ = true;
     grpc_timer_init(&lb_fallback_timer_, deadline, &lb_on_fallback_);
   }
@@ -857,6 +861,14 @@ void XdsLb::MaybeCancelFallbackAtStartupChecks() {
   }
   grpc_timer_cancel(&lb_fallback_timer_);
   fallback_at_startup_checks_pending_ = false;
+}
+
+void XdsLb::OnFallbackTimer(void* arg, grpc_error* error) {
+  XdsLb* xdslb_policy = static_cast<XdsLb*>(arg);
+  xdslb_policy->combiner()->Run(
+      GRPC_CLOSURE_INIT(&xdslb_policy->lb_on_fallback_,
+                        &XdsLb::OnFallbackTimerLocked, xdslb_policy, nullptr),
+      GRPC_ERROR_REF(error));
 }
 
 void XdsLb::OnFallbackTimerLocked(void* arg, grpc_error* error) {
@@ -1139,10 +1151,9 @@ XdsLb::PriorityList::LocalityMap::LocalityMap(RefCountedPtr<XdsLb> xds_policy,
     gpr_log(GPR_INFO, "[xdslb %p] Creating priority %" PRIu32,
             xds_policy_.get(), priority_);
   }
-  GRPC_CLOSURE_INIT(&on_delayed_removal_timer_, OnDelayedRemovalTimerLocked,
-                    this, grpc_combiner_scheduler(xds_policy_->combiner()));
-  GRPC_CLOSURE_INIT(&on_failover_timer_, OnFailoverTimerLocked, this,
-                    grpc_combiner_scheduler(xds_policy_->combiner()));
+
+  GRPC_CLOSURE_INIT(&on_failover_timer_, OnFailoverTimer, this,
+                    grpc_schedule_on_exec_ctx);
   // Start the failover timer.
   Ref(DEBUG_LOCATION, "LocalityMap+OnFailoverTimerLocked").release();
   grpc_timer_init(
@@ -1258,6 +1269,8 @@ void XdsLb::PriorityList::LocalityMap::DeactivateLocked() {
             xds_policy(), priority_,
             xds_policy()->locality_retention_interval_ms_);
   }
+  GRPC_CLOSURE_INIT(&on_delayed_removal_timer_, OnDelayedRemovalTimer, this,
+                    grpc_schedule_on_exec_ctx);
   grpc_timer_init(
       &delayed_removal_timer_,
       ExecCtx::Get()->Now() + xds_policy()->locality_retention_interval_ms_,
@@ -1386,6 +1399,15 @@ void XdsLb::PriorityList::LocalityMap::UpdateConnectivityStateLocked() {
   }
 }
 
+void XdsLb::PriorityList::LocalityMap::OnDelayedRemovalTimer(
+    void* arg, grpc_error* error) {
+  LocalityMap* self = static_cast<LocalityMap*>(arg);
+  self->xds_policy_->combiner()->Run(
+      GRPC_CLOSURE_INIT(&self->on_delayed_removal_timer_,
+                        OnDelayedRemovalTimerLocked, self, nullptr),
+      GRPC_ERROR_REF(error));
+}
+
 void XdsLb::PriorityList::LocalityMap::OnDelayedRemovalTimerLocked(
     void* arg, grpc_error* error) {
   LocalityMap* self = static_cast<LocalityMap*>(arg);
@@ -1395,13 +1417,13 @@ void XdsLb::PriorityList::LocalityMap::OnDelayedRemovalTimerLocked(
     const bool keep = self->priority_list_update().Contains(self->priority_) &&
                       self->priority_ <= priority_list->current_priority();
     if (!keep) {
-      // This check is to make sure we always delete the locality maps from the
-      // lowest priority even if the closures of the back-to-back timers are not
-      // run in FIFO order.
+      // This check is to make sure we always delete the locality maps from
+      // the lowest priority even if the closures of the back-to-back timers
+      // are not run in FIFO order.
       // TODO(juanlishen): Eliminate unnecessary maintenance overhead for some
       // deactivated locality maps when out-of-order closures are run.
-      // TODO(juanlishen): Check the timer implementation to see if this defense
-      // is necessary.
+      // TODO(juanlishen): Check the timer implementation to see if this
+      // defense is necessary.
       if (self->priority_ == priority_list->LowestPriority()) {
         priority_list->priorities_.pop_back();
       } else {
@@ -1414,6 +1436,15 @@ void XdsLb::PriorityList::LocalityMap::OnDelayedRemovalTimerLocked(
     }
   }
   self->Unref(DEBUG_LOCATION, "LocalityMap+timer");
+}
+
+void XdsLb::PriorityList::LocalityMap::OnFailoverTimer(void* arg,
+                                                       grpc_error* error) {
+  LocalityMap* self = static_cast<LocalityMap*>(arg);
+  self->xds_policy_->combiner()->Run(
+      GRPC_CLOSURE_INIT(&self->on_failover_timer_, OnFailoverTimerLocked, self,
+                        nullptr),
+      GRPC_ERROR_REF(error));
 }
 
 void XdsLb::PriorityList::LocalityMap::OnFailoverTimerLocked(
@@ -1438,8 +1469,6 @@ XdsLb::PriorityList::LocalityMap::Locality::Locality(
     gpr_log(GPR_INFO, "[xdslb %p] created Locality %p for %s", xds_policy(),
             this, name_->AsHumanReadableString());
   }
-  GRPC_CLOSURE_INIT(&on_delayed_removal_timer_, OnDelayedRemovalTimerLocked,
-                    this, grpc_combiner_scheduler(xds_policy()->combiner()));
 }
 
 XdsLb::PriorityList::LocalityMap::Locality::~Locality() {
@@ -1494,8 +1523,8 @@ XdsLb::PriorityList::LocalityMap::Locality::CreateChildPolicyLocked(
             lb_policy.get());
   }
   // Add the xDS's interested_parties pollset_set to that of the newly created
-  // child policy. This will make the child policy progress upon activity on xDS
-  // LB, which in turn is tied to the application's call.
+  // child policy. This will make the child policy progress upon activity on
+  // xDS LB, which in turn is tied to the application's call.
   grpc_pollset_set_add_pollset_set(lb_policy->interested_parties(),
                                    xds_policy()->interested_parties());
   return lb_policy;
@@ -1656,11 +1685,22 @@ void XdsLb::PriorityList::LocalityMap::Locality::DeactivateLocked() {
   weight_ = 0;
   // Start a timer to delete the locality.
   Ref(DEBUG_LOCATION, "Locality+timer").release();
+  GRPC_CLOSURE_INIT(&on_delayed_removal_timer_, OnDelayedRemovalTimer, this,
+                    grpc_schedule_on_exec_ctx);
   grpc_timer_init(
       &delayed_removal_timer_,
       ExecCtx::Get()->Now() + xds_policy()->locality_retention_interval_ms_,
       &on_delayed_removal_timer_);
   delayed_removal_timer_callback_pending_ = true;
+}
+
+void XdsLb::PriorityList::LocalityMap::Locality::OnDelayedRemovalTimer(
+    void* arg, grpc_error* error) {
+  Locality* self = static_cast<Locality*>(arg);
+  self->xds_policy()->combiner()->Run(
+      GRPC_CLOSURE_INIT(&self->on_delayed_removal_timer_,
+                        OnDelayedRemovalTimerLocked, self, nullptr),
+      GRPC_ERROR_REF(error));
 }
 
 void XdsLb::PriorityList::LocalityMap::Locality::OnDelayedRemovalTimerLocked(

--- a/src/core/ext/filters/client_channel/resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver.cc
@@ -30,8 +30,7 @@ namespace grpc_core {
 // Resolver
 //
 
-Resolver::Resolver(grpc_combiner* combiner,
-                   UniquePtr<ResultHandler> result_handler)
+Resolver::Resolver(Combiner* combiner, UniquePtr<ResultHandler> result_handler)
     : InternallyRefCounted(&grpc_trace_resolver_refcount),
       result_handler_(std::move(result_handler)),
       combiner_(GRPC_COMBINER_REF(combiner, "resolver")) {}

--- a/src/core/ext/filters/client_channel/resolver.h
+++ b/src/core/ext/filters/client_channel/resolver.h
@@ -126,19 +126,19 @@ class Resolver : public InternallyRefCounted<Resolver> {
   // TODO(roth): Once we have a C++-like interface for combiners, this
   // API should change to take a RefCountedPtr<>, so that we always take
   // ownership of a new ref.
-  explicit Resolver(grpc_combiner* combiner,
+  explicit Resolver(Combiner* combiner,
                     UniquePtr<ResultHandler> result_handler);
 
   /// Shuts down the resolver.
   virtual void ShutdownLocked() = 0;
 
-  grpc_combiner* combiner() const { return combiner_; }
+  Combiner* combiner() const { return combiner_; }
 
   ResultHandler* result_handler() const { return result_handler_.get(); }
 
  private:
   UniquePtr<ResultHandler> result_handler_;
-  grpc_combiner* combiner_;
+  Combiner* combiner_;
 };
 
 }  // namespace grpc_core

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/dns_resolver_ares.cc
@@ -76,6 +76,8 @@ class AresDnsResolver : public Resolver {
   void MaybeStartResolvingLocked();
   void StartResolvingLocked();
 
+  static void OnNextResolution(void* arg, grpc_error* error);
+  static void OnResolved(void* arg, grpc_error* error);
   static void OnNextResolutionLocked(void* arg, grpc_error* error);
   static void OnResolvedLocked(void* arg, grpc_error* error);
 
@@ -152,10 +154,7 @@ AresDnsResolver::AresDnsResolver(ResolverArgs args)
   if (args.pollset_set != nullptr) {
     grpc_pollset_set_add_pollset_set(interested_parties_, args.pollset_set);
   }
-  GRPC_CLOSURE_INIT(&on_next_resolution_, OnNextResolutionLocked, this,
-                    grpc_combiner_scheduler(combiner()));
-  GRPC_CLOSURE_INIT(&on_resolved_, OnResolvedLocked, this,
-                    grpc_combiner_scheduler(combiner()));
+
   const grpc_arg* query_timeout_ms_arg =
       grpc_channel_args_find(channel_args_, GRPC_ARG_DNS_ARES_QUERY_TIMEOUT_MS);
   query_timeout_ms_ = grpc_channel_arg_get_integer(
@@ -198,6 +197,13 @@ void AresDnsResolver::ShutdownLocked() {
   if (pending_request_ != nullptr) {
     grpc_cancel_ares_request_locked(pending_request_);
   }
+}
+
+void AresDnsResolver::OnNextResolution(void* arg, grpc_error* error) {
+  AresDnsResolver* r = static_cast<AresDnsResolver*>(arg);
+  r->combiner()->Run(GRPC_CLOSURE_INIT(&r->on_next_resolution_,
+                                       OnNextResolutionLocked, r, nullptr),
+                     GRPC_ERROR_REF(error));
 }
 
 void AresDnsResolver::OnNextResolutionLocked(void* arg, grpc_error* error) {
@@ -317,6 +323,13 @@ char* ChooseServiceConfig(char* service_config_choice_json,
   return service_config;
 }
 
+void AresDnsResolver::OnResolved(void* arg, grpc_error* error) {
+  AresDnsResolver* r = static_cast<AresDnsResolver*>(arg);
+  r->combiner()->Run(
+      GRPC_CLOSURE_INIT(&r->on_resolved_, OnResolvedLocked, r, nullptr),
+      GRPC_ERROR_REF(error));
+}
+
 void AresDnsResolver::OnResolvedLocked(void* arg, grpc_error* error) {
   AresDnsResolver* r = static_cast<AresDnsResolver*>(arg);
   GPR_ASSERT(r->resolving_);
@@ -373,6 +386,8 @@ void AresDnsResolver::OnResolvedLocked(void* arg, grpc_error* error) {
     } else {
       GRPC_CARES_TRACE_LOG("resolver:%p retrying immediately", r);
     }
+    GRPC_CLOSURE_INIT(&r->on_next_resolution_, OnNextResolution, r,
+                      grpc_schedule_on_exec_ctx);
     grpc_timer_init(&r->next_resolution_timer_, next_try,
                     &r->on_next_resolution_);
   }
@@ -400,6 +415,8 @@ void AresDnsResolver::MaybeStartResolvingLocked() {
       // new closure API is done, find a way to track this ref with the timer
       // callback as part of the type system.
       Ref(DEBUG_LOCATION, "next_resolution_timer_cooldown").release();
+      GRPC_CLOSURE_INIT(&on_next_resolution_, OnNextResolution, this,
+                        grpc_schedule_on_exec_ctx);
       grpc_timer_init(&next_resolution_timer_,
                       ExecCtx::Get()->Now() + ms_until_next_resolution,
                       &on_next_resolution_);
@@ -417,6 +434,7 @@ void AresDnsResolver::StartResolvingLocked() {
   GPR_ASSERT(!resolving_);
   resolving_ = true;
   service_config_json_ = nullptr;
+  GRPC_CLOSURE_INIT(&on_resolved_, OnResolved, this, grpc_schedule_on_exec_ctx);
   pending_request_ = grpc_dns_lookup_ares_locked(
       dns_server_, name_to_resolve_, kDefaultPort, interested_parties_,
       &on_resolved_, &addresses_, enable_srv_queries_ /* check_grpclb */,

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.cc
@@ -67,7 +67,7 @@ struct grpc_ares_ev_driver {
   gpr_refcount refs;
 
   /** combiner to synchronize c-ares and I/O callbacks on */
-  grpc_combiner* combiner;
+  grpc_core::Combiner* combiner;
   /** a list of grpc_fd that this event driver is currently using. */
   fd_node* fds;
   /** is this event driver currently working? */
@@ -132,8 +132,10 @@ static void fd_node_shutdown_locked(fd_node* fdn, const char* reason) {
   }
 }
 
+static void on_timeout(void* arg, grpc_error* error);
 static void on_timeout_locked(void* arg, grpc_error* error);
 
+static void on_ares_backup_poll_alarm(void* arg, grpc_error* error);
 static void on_ares_backup_poll_alarm_locked(void* arg, grpc_error* error);
 
 static void noop_inject_channel_config(ares_channel channel) {}
@@ -144,7 +146,7 @@ void (*grpc_ares_test_only_inject_config)(ares_channel channel) =
 grpc_error* grpc_ares_ev_driver_create_locked(grpc_ares_ev_driver** ev_driver,
                                               grpc_pollset_set* pollset_set,
                                               int query_timeout_ms,
-                                              grpc_combiner* combiner,
+                                              grpc_core::Combiner* combiner,
                                               grpc_ares_request* request) {
   *ev_driver = grpc_core::New<grpc_ares_ev_driver>();
   ares_options opts;
@@ -173,11 +175,6 @@ grpc_error* grpc_ares_ev_driver_create_locked(grpc_ares_ev_driver** ev_driver,
       grpc_core::NewGrpcPolledFdFactory((*ev_driver)->combiner);
   (*ev_driver)
       ->polled_fd_factory->ConfigureAresChannelLocked((*ev_driver)->channel);
-  GRPC_CLOSURE_INIT(&(*ev_driver)->on_timeout_locked, on_timeout_locked,
-                    *ev_driver, grpc_combiner_scheduler(combiner));
-  GRPC_CLOSURE_INIT(&(*ev_driver)->on_ares_backup_poll_alarm_locked,
-                    on_ares_backup_poll_alarm_locked, *ev_driver,
-                    grpc_combiner_scheduler(combiner));
   (*ev_driver)->query_timeout_ms = query_timeout_ms;
   return GRPC_ERROR_NONE;
 }
@@ -235,6 +232,13 @@ static grpc_millis calculate_next_ares_backup_poll_alarm_ms(
          grpc_core::ExecCtx::Get()->Now();
 }
 
+static void on_timeout(void* arg, grpc_error* error) {
+  grpc_ares_ev_driver* driver = static_cast<grpc_ares_ev_driver*>(arg);
+  driver->combiner->Run(GRPC_CLOSURE_INIT(&driver->on_timeout_locked,
+                                          on_timeout_locked, driver, nullptr),
+                        GRPC_ERROR_REF(error));
+}
+
 static void on_timeout_locked(void* arg, grpc_error* error) {
   grpc_ares_ev_driver* driver = static_cast<grpc_ares_ev_driver*>(arg);
   GRPC_CARES_TRACE_LOG(
@@ -245,6 +249,14 @@ static void on_timeout_locked(void* arg, grpc_error* error) {
     grpc_ares_ev_driver_shutdown_locked(driver);
   }
   grpc_ares_ev_driver_unref(driver);
+}
+
+static void on_ares_backup_poll_alarm(void* arg, grpc_error* error) {
+  grpc_ares_ev_driver* driver = static_cast<grpc_ares_ev_driver*>(arg);
+  driver->combiner->Run(
+      GRPC_CLOSURE_INIT(&driver->on_ares_backup_poll_alarm_locked,
+                        on_ares_backup_poll_alarm_locked, driver, nullptr),
+      GRPC_ERROR_REF(error));
 }
 
 /* In case of non-responsive DNS servers, dropped packets, etc., c-ares has
@@ -279,6 +291,9 @@ static void on_ares_backup_poll_alarm_locked(void* arg, grpc_error* error) {
       grpc_millis next_ares_backup_poll_alarm =
           calculate_next_ares_backup_poll_alarm_ms(driver);
       grpc_ares_ev_driver_ref(driver);
+      GRPC_CLOSURE_INIT(&driver->on_ares_backup_poll_alarm_locked,
+                        on_ares_backup_poll_alarm, driver,
+                        grpc_schedule_on_exec_ctx);
       grpc_timer_init(&driver->ares_backup_poll_alarm,
                       next_ares_backup_poll_alarm,
                       &driver->on_ares_backup_poll_alarm_locked);
@@ -313,6 +328,13 @@ static void on_readable_locked(void* arg, grpc_error* error) {
   grpc_ares_ev_driver_unref(ev_driver);
 }
 
+static void on_readable(void* arg, grpc_error* error) {
+  fd_node* fdn = static_cast<fd_node*>(arg);
+  fdn->ev_driver->combiner->Run(
+      GRPC_CLOSURE_INIT(&fdn->read_closure, on_readable_locked, fdn, nullptr),
+      GRPC_ERROR_REF(error));
+}
+
 static void on_writable_locked(void* arg, grpc_error* error) {
   fd_node* fdn = static_cast<fd_node*>(arg);
   GPR_ASSERT(fdn->writable_registered);
@@ -334,6 +356,13 @@ static void on_writable_locked(void* arg, grpc_error* error) {
   }
   grpc_ares_notify_on_event_locked(ev_driver);
   grpc_ares_ev_driver_unref(ev_driver);
+}
+
+static void on_writable(void* arg, grpc_error* error) {
+  fd_node* fdn = static_cast<fd_node*>(arg);
+  fdn->ev_driver->combiner->Run(
+      GRPC_CLOSURE_INIT(&fdn->write_closure, on_writable_locked, fdn, nullptr),
+      GRPC_ERROR_REF(error));
 }
 
 ares_channel* grpc_ares_ev_driver_get_channel_locked(
@@ -365,10 +394,6 @@ static void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver) {
           fdn->readable_registered = false;
           fdn->writable_registered = false;
           fdn->already_shutdown = false;
-          GRPC_CLOSURE_INIT(&fdn->read_closure, on_readable_locked, fdn,
-                            grpc_combiner_scheduler(ev_driver->combiner));
-          GRPC_CLOSURE_INIT(&fdn->write_closure, on_writable_locked, fdn,
-                            grpc_combiner_scheduler(ev_driver->combiner));
         }
         fdn->next = new_list;
         new_list = fdn;
@@ -380,6 +405,8 @@ static void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver) {
           GRPC_CARES_TRACE_LOG("request:%p notify read on: %s",
                                ev_driver->request,
                                fdn->grpc_polled_fd->GetName());
+          GRPC_CLOSURE_INIT(&fdn->read_closure, on_readable, fdn,
+                            grpc_schedule_on_exec_ctx);
           fdn->grpc_polled_fd->RegisterForOnReadableLocked(&fdn->read_closure);
           fdn->readable_registered = true;
         }
@@ -391,6 +418,8 @@ static void grpc_ares_notify_on_event_locked(grpc_ares_ev_driver* ev_driver) {
                                ev_driver->request,
                                fdn->grpc_polled_fd->GetName());
           grpc_ares_ev_driver_ref(ev_driver);
+          GRPC_CLOSURE_INIT(&fdn->write_closure, on_writable, fdn,
+                            grpc_schedule_on_exec_ctx);
           fdn->grpc_polled_fd->RegisterForOnWriteableLocked(
               &fdn->write_closure);
           fdn->writable_registered = true;
@@ -435,12 +464,17 @@ void grpc_ares_ev_driver_start_locked(grpc_ares_ev_driver* ev_driver) {
         "%" PRId64 " ms",
         ev_driver->request, ev_driver, timeout);
     grpc_ares_ev_driver_ref(ev_driver);
+    GRPC_CLOSURE_INIT(&ev_driver->on_timeout_locked, on_timeout, ev_driver,
+                      grpc_schedule_on_exec_ctx);
     grpc_timer_init(&ev_driver->query_timeout, timeout,
                     &ev_driver->on_timeout_locked);
     // Initialize the backup poll alarm
     grpc_millis next_ares_backup_poll_alarm =
         calculate_next_ares_backup_poll_alarm_ms(ev_driver);
     grpc_ares_ev_driver_ref(ev_driver);
+    GRPC_CLOSURE_INIT(&ev_driver->on_ares_backup_poll_alarm_locked,
+                      on_ares_backup_poll_alarm, ev_driver,
+                      grpc_schedule_on_exec_ctx);
     grpc_timer_init(&ev_driver->ares_backup_poll_alarm,
                     next_ares_backup_poll_alarm,
                     &ev_driver->on_ares_backup_poll_alarm_locked);

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver.h
@@ -43,7 +43,7 @@ ares_channel* grpc_ares_ev_driver_get_channel_locked(
 grpc_error* grpc_ares_ev_driver_create_locked(grpc_ares_ev_driver** ev_driver,
                                               grpc_pollset_set* pollset_set,
                                               int query_timeout_ms,
-                                              grpc_combiner* combiner,
+                                              grpc_core::Combiner* combiner,
                                               grpc_ares_request* request);
 
 /* Called back when all DNS lookups have completed. */
@@ -90,12 +90,12 @@ class GrpcPolledFdFactory {
   /* Creates a new wrapped fd for the current platform */
   virtual GrpcPolledFd* NewGrpcPolledFdLocked(
       ares_socket_t as, grpc_pollset_set* driver_pollset_set,
-      grpc_combiner* combiner) = 0;
+      Combiner* combiner) = 0;
   /* Optionally configures the ares channel after creation */
   virtual void ConfigureAresChannelLocked(ares_channel channel) = 0;
 };
 
-UniquePtr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(grpc_combiner* combiner);
+UniquePtr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(Combiner* combiner);
 
 }  // namespace grpc_core
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_libuv.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_libuv.cc
@@ -41,7 +41,7 @@ void ares_uv_poll_close_cb(uv_handle_t* handle) { Delete(handle); }
 
 class GrpcPolledFdLibuv : public GrpcPolledFd {
  public:
-  GrpcPolledFdLibuv(ares_socket_t as, grpc_combiner* combiner)
+  GrpcPolledFdLibuv(ares_socket_t as, Combiner* combiner)
       : as_(as), combiner_(combiner) {
     gpr_asprintf(&name_, "c-ares socket: %" PRIdPTR, (intptr_t)as);
     handle_ = New<uv_poll_t>();
@@ -107,7 +107,7 @@ class GrpcPolledFdLibuv : public GrpcPolledFd {
   grpc_closure* read_closure_ = nullptr;
   grpc_closure* write_closure_ = nullptr;
   int poll_events_ = 0;
-  grpc_combiner* combiner_;
+  Combiner* combiner_;
 };
 
 struct AresUvPollCbArg {
@@ -153,9 +153,8 @@ void ares_uv_poll_cb(uv_poll_t* handle, int status, int events) {
   GrpcPolledFdLibuv* polled_fd =
       reinterpret_cast<GrpcPolledFdLibuv*>(handle->data);
   AresUvPollCbArg* arg = New<AresUvPollCbArg>(handle, status, events);
-  GRPC_CLOSURE_SCHED(
-      GRPC_CLOSURE_CREATE(ares_uv_poll_cb_locked, arg,
-                          grpc_combiner_scheduler(polled_fd->combiner_)),
+  polled_fd->combiner_->Run(
+      GRPC_CLOSURE_CREATE(ares_uv_poll_cb_locked, arg, nullptr),
       GRPC_ERROR_NONE);
 }
 
@@ -163,14 +162,14 @@ class GrpcPolledFdFactoryLibuv : public GrpcPolledFdFactory {
  public:
   GrpcPolledFd* NewGrpcPolledFdLocked(ares_socket_t as,
                                       grpc_pollset_set* driver_pollset_set,
-                                      grpc_combiner* combiner) override {
+                                      Combiner* combiner) override {
     return New<GrpcPolledFdLibuv>(as, combiner);
   }
 
   void ConfigureAresChannelLocked(ares_channel channel) override {}
 };
 
-UniquePtr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(grpc_combiner* combiner) {
+UniquePtr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(Combiner* combiner) {
   return MakeUnique<GrpcPolledFdFactoryLibuv>();
 }
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_ev_driver_posix.cc
@@ -90,14 +90,14 @@ class GrpcPolledFdFactoryPosix : public GrpcPolledFdFactory {
  public:
   GrpcPolledFd* NewGrpcPolledFdLocked(ares_socket_t as,
                                       grpc_pollset_set* driver_pollset_set,
-                                      grpc_combiner* combiner) override {
+                                      Combiner* combiner) override {
     return New<GrpcPolledFdPosix>(as, driver_pollset_set);
   }
 
   void ConfigureAresChannelLocked(ares_channel channel) override {}
 };
 
-UniquePtr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(grpc_combiner* combiner) {
+UniquePtr<GrpcPolledFdFactory> NewGrpcPolledFdFactory(Combiner* combiner) {
   return MakeUnique<GrpcPolledFdFactoryPosix>();
 }
 

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper.h
@@ -65,7 +65,7 @@ extern grpc_ares_request* (*grpc_dns_lookup_ares_locked)(
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
     bool check_grpclb, char** service_config_json, int query_timeout_ms,
-    grpc_combiner* combiner);
+    grpc_core::Combiner* combiner);
 
 /* Cancel the pending grpc_ares_request \a request */
 extern void (*grpc_cancel_ares_request_locked)(grpc_ares_request* request);

--- a/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_fallback.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/c_ares/grpc_ares_wrapper_fallback.cc
@@ -31,7 +31,7 @@ static grpc_ares_request* grpc_dns_lookup_ares_locked_impl(
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addrs,
     bool check_grpclb, char** service_config_json, int query_timeout_ms,
-    grpc_combiner* combiner) {
+    grpc_core::Combiner* combiner) {
   return NULL;
 }
 
@@ -40,7 +40,7 @@ grpc_ares_request* (*grpc_dns_lookup_ares_locked)(
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addrs,
     bool check_grpclb, char** service_config_json, int query_timeout_ms,
-    grpc_combiner* combiner) = grpc_dns_lookup_ares_locked_impl;
+    grpc_core::Combiner* combiner) = grpc_dns_lookup_ares_locked_impl;
 
 static void grpc_cancel_ares_request_locked_impl(grpc_ares_request* r) {}
 

--- a/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/dns/native/dns_resolver.cc
@@ -66,7 +66,9 @@ class NativeDnsResolver : public Resolver {
   void MaybeStartResolvingLocked();
   void StartResolvingLocked();
 
+  static void OnNextResolution(void* arg, grpc_error* error);
   static void OnNextResolutionLocked(void* arg, grpc_error* error);
+  static void OnResolved(void* arg, grpc_error* error);
   static void OnResolvedLocked(void* arg, grpc_error* error);
 
   /// name to resolve
@@ -115,11 +117,6 @@ NativeDnsResolver::NativeDnsResolver(ResolverArgs args)
   if (args.pollset_set != nullptr) {
     grpc_pollset_set_add_pollset_set(interested_parties_, args.pollset_set);
   }
-  GRPC_CLOSURE_INIT(&on_next_resolution_,
-                    NativeDnsResolver::OnNextResolutionLocked, this,
-                    grpc_combiner_scheduler(args.combiner));
-  GRPC_CLOSURE_INIT(&on_resolved_, NativeDnsResolver::OnResolvedLocked, this,
-                    grpc_combiner_scheduler(args.combiner));
 }
 
 NativeDnsResolver::~NativeDnsResolver() {
@@ -150,6 +147,14 @@ void NativeDnsResolver::ShutdownLocked() {
   }
 }
 
+void NativeDnsResolver::OnNextResolution(void* arg, grpc_error* error) {
+  NativeDnsResolver* r = static_cast<NativeDnsResolver*>(arg);
+  r->combiner()->Run(
+      GRPC_CLOSURE_INIT(&r->on_next_resolution_,
+                        NativeDnsResolver::OnNextResolutionLocked, r, nullptr),
+      GRPC_ERROR_REF(error));
+}
+
 void NativeDnsResolver::OnNextResolutionLocked(void* arg, grpc_error* error) {
   NativeDnsResolver* r = static_cast<NativeDnsResolver*>(arg);
   r->have_next_resolution_timer_ = false;
@@ -157,6 +162,14 @@ void NativeDnsResolver::OnNextResolutionLocked(void* arg, grpc_error* error) {
     r->StartResolvingLocked();
   }
   r->Unref(DEBUG_LOCATION, "retry-timer");
+}
+
+void NativeDnsResolver::OnResolved(void* arg, grpc_error* error) {
+  NativeDnsResolver* r = static_cast<NativeDnsResolver*>(arg);
+  r->combiner()->Run(
+      GRPC_CLOSURE_INIT(&r->on_resolved_, NativeDnsResolver::OnResolvedLocked,
+                        r, nullptr),
+      GRPC_ERROR_REF(error));
 }
 
 void NativeDnsResolver::OnResolvedLocked(void* arg, grpc_error* error) {
@@ -202,6 +215,9 @@ void NativeDnsResolver::OnResolvedLocked(void* arg, grpc_error* error) {
     } else {
       gpr_log(GPR_DEBUG, "retrying immediately");
     }
+    GRPC_CLOSURE_INIT(&r->on_next_resolution_,
+                      NativeDnsResolver::OnNextResolution, r,
+                      grpc_schedule_on_exec_ctx);
     grpc_timer_init(&r->next_resolution_timer_, next_try,
                     &r->on_next_resolution_);
   }
@@ -229,6 +245,9 @@ void NativeDnsResolver::MaybeStartResolvingLocked() {
       // new closure API is done, find a way to track this ref with the timer
       // callback as part of the type system.
       Ref(DEBUG_LOCATION, "next_resolution_timer_cooldown").release();
+      GRPC_CLOSURE_INIT(&on_next_resolution_,
+                        NativeDnsResolver::OnNextResolution, this,
+                        grpc_schedule_on_exec_ctx);
       grpc_timer_init(&next_resolution_timer_,
                       ExecCtx::Get()->Now() + ms_until_next_resolution,
                       &on_next_resolution_);
@@ -247,6 +266,8 @@ void NativeDnsResolver::StartResolvingLocked() {
   GPR_ASSERT(!resolving_);
   resolving_ = true;
   addresses_ = nullptr;
+  GRPC_CLOSURE_INIT(&on_resolved_, NativeDnsResolver::OnResolved, this,
+                    grpc_schedule_on_exec_ctx);
   grpc_resolve_address(name_to_resolve_, kDefaultPort, interested_parties_,
                        &on_resolved_, &addresses_);
   last_resolution_timestamp_ = grpc_core::ExecCtx::Get()->Now();

--- a/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
+++ b/src/core/ext/filters/client_channel/resolver/fake/fake_resolver.cc
@@ -98,8 +98,6 @@ FakeResolver::FakeResolver(ResolverArgs args)
     : Resolver(args.combiner, std::move(args.result_handler)),
       response_generator_(
           FakeResolverResponseGenerator::GetFromArgs(args.args)) {
-  GRPC_CLOSURE_INIT(&reresolution_closure_, ReturnReresolutionResult, this,
-                    grpc_combiner_scheduler(combiner()));
   // Channels sharing the same subchannels may have different resolver response
   // generators. If we don't remove this arg, subchannel pool will create new
   // subchannels for the same address instead of reusing existing ones because
@@ -129,7 +127,9 @@ void FakeResolver::RequestReresolutionLocked() {
     if (!reresolution_closure_pending_) {
       reresolution_closure_pending_ = true;
       Ref().release();  // ref held by closure
-      GRPC_CLOSURE_SCHED(&reresolution_closure_, GRPC_ERROR_NONE);
+      GRPC_CLOSURE_INIT(&reresolution_closure_, ReturnReresolutionResult, this,
+                        nullptr);
+      combiner()->Run(&reresolution_closure_, GRPC_ERROR_NONE);
     }
   }
 }
@@ -208,10 +208,9 @@ void FakeResolverResponseGenerator::SetResponse(Resolver::Result result) {
   SetResponseClosureArg* closure_arg = New<SetResponseClosureArg>();
   closure_arg->resolver = std::move(resolver);
   closure_arg->result = std::move(result);
-  GRPC_CLOSURE_SCHED(
-      GRPC_CLOSURE_INIT(
-          &closure_arg->set_response_closure, SetResponseLocked, closure_arg,
-          grpc_combiner_scheduler(closure_arg->resolver->combiner())),
+  closure_arg->resolver->combiner()->Run(
+      GRPC_CLOSURE_INIT(&closure_arg->set_response_closure, SetResponseLocked,
+                        closure_arg, nullptr),
       GRPC_ERROR_NONE);
 }
 
@@ -238,11 +237,9 @@ void FakeResolverResponseGenerator::SetReresolutionResponse(
   closure_arg->resolver = std::move(resolver);
   closure_arg->result = std::move(result);
   closure_arg->has_result = true;
-  GRPC_CLOSURE_SCHED(
-      GRPC_CLOSURE_INIT(
-          &closure_arg->set_response_closure, SetReresolutionResponseLocked,
-          closure_arg,
-          grpc_combiner_scheduler(closure_arg->resolver->combiner())),
+  closure_arg->resolver->combiner()->Run(
+      GRPC_CLOSURE_INIT(&closure_arg->set_response_closure,
+                        SetReresolutionResponseLocked, closure_arg, nullptr),
       GRPC_ERROR_NONE);
 }
 
@@ -255,11 +252,9 @@ void FakeResolverResponseGenerator::UnsetReresolutionResponse() {
   }
   SetResponseClosureArg* closure_arg = New<SetResponseClosureArg>();
   closure_arg->resolver = std::move(resolver);
-  GRPC_CLOSURE_SCHED(
-      GRPC_CLOSURE_INIT(
-          &closure_arg->set_response_closure, SetReresolutionResponseLocked,
-          closure_arg,
-          grpc_combiner_scheduler(closure_arg->resolver->combiner())),
+  closure_arg->resolver->combiner()->Run(
+      GRPC_CLOSURE_INIT(&closure_arg->set_response_closure,
+                        SetReresolutionResponseLocked, closure_arg, nullptr),
       GRPC_ERROR_NONE);
 }
 
@@ -283,10 +278,9 @@ void FakeResolverResponseGenerator::SetFailure() {
   }
   SetResponseClosureArg* closure_arg = New<SetResponseClosureArg>();
   closure_arg->resolver = std::move(resolver);
-  GRPC_CLOSURE_SCHED(
-      GRPC_CLOSURE_INIT(
-          &closure_arg->set_response_closure, SetFailureLocked, closure_arg,
-          grpc_combiner_scheduler(closure_arg->resolver->combiner())),
+  closure_arg->resolver->combiner()->Run(
+      GRPC_CLOSURE_INIT(&closure_arg->set_response_closure, SetFailureLocked,
+                        closure_arg, nullptr),
       GRPC_ERROR_NONE);
 }
 
@@ -300,10 +294,9 @@ void FakeResolverResponseGenerator::SetFailureOnReresolution() {
   SetResponseClosureArg* closure_arg = New<SetResponseClosureArg>();
   closure_arg->resolver = std::move(resolver);
   closure_arg->immediate = false;
-  GRPC_CLOSURE_SCHED(
-      GRPC_CLOSURE_INIT(
-          &closure_arg->set_response_closure, SetFailureLocked, closure_arg,
-          grpc_combiner_scheduler(closure_arg->resolver->combiner())),
+  closure_arg->resolver->combiner()->Run(
+      GRPC_CLOSURE_INIT(&closure_arg->set_response_closure, SetFailureLocked,
+                        closure_arg, nullptr),
       GRPC_ERROR_NONE);
 }
 
@@ -316,10 +309,9 @@ void FakeResolverResponseGenerator::SetFakeResolver(
     SetResponseClosureArg* closure_arg = New<SetResponseClosureArg>();
     closure_arg->resolver = resolver_->Ref();
     closure_arg->result = std::move(result_);
-    GRPC_CLOSURE_SCHED(
+    resolver_->combiner()->Run(
         GRPC_CLOSURE_INIT(&closure_arg->set_response_closure, SetResponseLocked,
-                          closure_arg,
-                          grpc_combiner_scheduler(resolver_->combiner())),
+                          closure_arg, nullptr),
         GRPC_ERROR_NONE);
     has_result_ = false;
   }

--- a/src/core/ext/filters/client_channel/resolver_factory.h
+++ b/src/core/ext/filters/client_channel/resolver_factory.h
@@ -39,7 +39,7 @@ struct ResolverArgs {
   /// Used to drive I/O in the name resolution process.
   grpc_pollset_set* pollset_set = nullptr;
   /// The combiner under which all resolver calls will be run.
-  grpc_combiner* combiner = nullptr;
+  Combiner* combiner = nullptr;
   /// The result handler to be used by the resolver.
   UniquePtr<Resolver::ResultHandler> result_handler;
 };

--- a/src/core/ext/filters/client_channel/resolver_registry.cc
+++ b/src/core/ext/filters/client_channel/resolver_registry.cc
@@ -145,7 +145,7 @@ bool ResolverRegistry::IsValidTarget(const char* target) {
 
 OrphanablePtr<Resolver> ResolverRegistry::CreateResolver(
     const char* target, const grpc_channel_args* args,
-    grpc_pollset_set* pollset_set, grpc_combiner* combiner,
+    grpc_pollset_set* pollset_set, Combiner* combiner,
     UniquePtr<Resolver::ResultHandler> result_handler) {
   GPR_ASSERT(g_state != nullptr);
   grpc_uri* uri = nullptr;

--- a/src/core/ext/filters/client_channel/resolver_registry.h
+++ b/src/core/ext/filters/client_channel/resolver_registry.h
@@ -68,7 +68,7 @@ class ResolverRegistry {
   /// \a result_handler is used to return results from the resolver.
   static OrphanablePtr<Resolver> CreateResolver(
       const char* target, const grpc_channel_args* args,
-      grpc_pollset_set* pollset_set, grpc_combiner* combiner,
+      grpc_pollset_set* pollset_set, Combiner* combiner,
       UniquePtr<Resolver::ResultHandler> result_handler);
 
   /// Returns the default authority to pass from a client for \a target.

--- a/src/core/ext/filters/client_channel/xds/xds_client.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_client.cc
@@ -92,6 +92,7 @@ class XdsClient::ChannelState::RetryableCall
  private:
   void StartNewCallLocked();
   void StartRetryTimerLocked();
+  static void OnRetryTimer(void* arg, grpc_error* error);
   static void OnRetryTimerLocked(void* arg, grpc_error* error);
 
   // The wrapped xds call that talks to the xds server. It's instantiated
@@ -125,6 +126,8 @@ class XdsClient::ChannelState::AdsCallState
   bool seen_response() const { return seen_response_; }
 
  private:
+  static void OnResponseReceived(void* arg, grpc_error* error);
+  static void OnStatusReceived(void* arg, grpc_error* error);
   static void OnResponseReceivedLocked(void* arg, grpc_error* error);
   static void OnStatusReceivedLocked(void* arg, grpc_error* error);
 
@@ -177,10 +180,6 @@ class XdsClient::ChannelState::LrsCallState
    public:
     Reporter(RefCountedPtr<LrsCallState> parent, grpc_millis report_interval)
         : parent_(std::move(parent)), report_interval_(report_interval) {
-      GRPC_CLOSURE_INIT(&on_next_report_timer_, OnNextReportTimerLocked, this,
-                        grpc_combiner_scheduler(xds_client()->combiner_));
-      GRPC_CLOSURE_INIT(&on_report_done_, OnReportDoneLocked, this,
-                        grpc_combiner_scheduler(xds_client()->combiner_));
       ScheduleNextReportLocked();
     }
 
@@ -188,8 +187,10 @@ class XdsClient::ChannelState::LrsCallState
 
    private:
     void ScheduleNextReportLocked();
+    static void OnNextReportTimer(void* arg, grpc_error* error);
     static void OnNextReportTimerLocked(void* arg, grpc_error* error);
     void SendReportLocked();
+    static void OnReportDone(void* arg, grpc_error* error);
     static void OnReportDoneLocked(void* arg, grpc_error* error);
 
     bool IsCurrentReporterOnCall() const {
@@ -209,6 +210,9 @@ class XdsClient::ChannelState::LrsCallState
     grpc_closure on_report_done_;
   };
 
+  static void OnInitialRequestSent(void* arg, grpc_error* error);
+  static void OnResponseReceived(void* arg, grpc_error* error);
+  static void OnStatusReceived(void* arg, grpc_error* error);
   static void OnInitialRequestSentLocked(void* arg, grpc_error* error);
   static void OnResponseReceivedLocked(void* arg, grpc_error* error);
   static void OnStatusReceivedLocked(void* arg, grpc_error* error);
@@ -253,8 +257,7 @@ class XdsClient::ChannelState::StateWatcher
     : public AsyncConnectivityStateWatcherInterface {
  public:
   explicit StateWatcher(RefCountedPtr<ChannelState> parent)
-      : AsyncConnectivityStateWatcherInterface(
-            grpc_combiner_scheduler(parent->xds_client()->combiner_)),
+      : AsyncConnectivityStateWatcherInterface(parent->xds_client()->combiner_),
         parent_(std::move(parent)) {}
 
  private:
@@ -421,8 +424,6 @@ XdsClient::ChannelState::RetryableCall<T>::RetryableCall(
               .set_multiplier(GRPC_XDS_RECONNECT_BACKOFF_MULTIPLIER)
               .set_jitter(GRPC_XDS_RECONNECT_JITTER)
               .set_max_backoff(GRPC_XDS_RECONNECT_MAX_BACKOFF_SECONDS * 1000)) {
-  GRPC_CLOSURE_INIT(&on_retry_timer_, OnRetryTimerLocked, this,
-                    grpc_combiner_scheduler(chand_->xds_client()->combiner_));
   StartNewCallLocked();
 }
 
@@ -476,8 +477,20 @@ void XdsClient::ChannelState::RetryableCall<T>::StartRetryTimerLocked() {
             chand()->xds_client(), chand(), timeout);
   }
   this->Ref(DEBUG_LOCATION, "RetryableCall+retry_timer_start").release();
+  GRPC_CLOSURE_INIT(&on_retry_timer_, OnRetryTimer, this,
+                    grpc_schedule_on_exec_ctx);
   grpc_timer_init(&retry_timer_, next_attempt_time, &on_retry_timer_);
   retry_timer_callback_pending_ = true;
+}
+
+template <typename T>
+void XdsClient::ChannelState::RetryableCall<T>::OnRetryTimer(
+    void* arg, grpc_error* error) {
+  RetryableCall* calld = static_cast<RetryableCall*>(arg);
+  calld->chand_->xds_client()->combiner_->Run(
+      GRPC_CLOSURE_INIT(&calld->on_retry_timer_, OnRetryTimerLocked, calld,
+                        nullptr),
+      GRPC_ERROR_REF(error));
 }
 
 template <typename T>
@@ -528,10 +541,6 @@ XdsClient::ChannelState::AdsCallState::AdsCallState(
   // Init other data associated with the call.
   grpc_metadata_array_init(&initial_metadata_recv_);
   grpc_metadata_array_init(&trailing_metadata_recv_);
-  GRPC_CLOSURE_INIT(&on_response_received_, OnResponseReceivedLocked, this,
-                    grpc_combiner_scheduler(xds_client()->combiner_));
-  GRPC_CLOSURE_INIT(&on_status_received_, OnStatusReceivedLocked, this,
-                    grpc_combiner_scheduler(xds_client()->combiner_));
   // Start the call.
   if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)) {
     gpr_log(GPR_INFO,
@@ -575,6 +584,8 @@ XdsClient::ChannelState::AdsCallState::AdsCallState(
   op->reserved = nullptr;
   op++;
   Ref(DEBUG_LOCATION, "ADS+OnResponseReceivedLocked").release();
+  GRPC_CLOSURE_INIT(&on_response_received_, OnResponseReceived, this,
+                    grpc_schedule_on_exec_ctx);
   call_error = grpc_call_start_batch_and_execute(call_, ops, (size_t)(op - ops),
                                                  &on_response_received_);
   GPR_ASSERT(GRPC_CALL_OK == call_error);
@@ -590,6 +601,8 @@ XdsClient::ChannelState::AdsCallState::AdsCallState(
   // This callback signals the end of the call, so it relies on the initial
   // ref instead of a new ref. When it's invoked, it's the initial ref that is
   // unreffed.
+  GRPC_CLOSURE_INIT(&on_status_received_, OnStatusReceived, this,
+                    grpc_schedule_on_exec_ctx);
   call_error = grpc_call_start_batch_and_execute(call_, ops, (size_t)(op - ops),
                                                  &on_status_received_);
   GPR_ASSERT(GRPC_CALL_OK == call_error);
@@ -614,6 +627,15 @@ void XdsClient::ChannelState::AdsCallState::Orphan() {
   grpc_call_cancel(call_, nullptr);
   // Note that the initial ref is hold by on_status_received_. So the
   // corresponding unref happens in on_status_received_ instead of here.
+}
+
+void XdsClient::ChannelState::AdsCallState::OnResponseReceived(
+    void* arg, grpc_error* error) {
+  AdsCallState* ads_calld = static_cast<AdsCallState*>(arg);
+  ads_calld->xds_client()->combiner_->Run(
+      GRPC_CLOSURE_INIT(&ads_calld->on_response_received_,
+                        OnResponseReceivedLocked, ads_calld, nullptr),
+      GRPC_ERROR_REF(error));
 }
 
 void XdsClient::ChannelState::AdsCallState::OnResponseReceivedLocked(
@@ -757,9 +779,20 @@ void XdsClient::ChannelState::AdsCallState::OnResponseReceivedLocked(
   op.reserved = nullptr;
   GPR_ASSERT(ads_calld->call_ != nullptr);
   // Reuse the "ADS+OnResponseReceivedLocked" ref taken in ctor.
+  GRPC_CLOSURE_INIT(&ads_calld->on_response_received_, OnResponseReceived,
+                    ads_calld, grpc_schedule_on_exec_ctx);
   const grpc_call_error call_error = grpc_call_start_batch_and_execute(
       ads_calld->call_, &op, 1, &ads_calld->on_response_received_);
   GPR_ASSERT(GRPC_CALL_OK == call_error);
+}
+
+void XdsClient::ChannelState::AdsCallState::OnStatusReceived(
+    void* arg, grpc_error* error) {
+  AdsCallState* ads_calld = static_cast<AdsCallState*>(arg);
+  ads_calld->xds_client()->combiner_->Run(
+      GRPC_CLOSURE_INIT(&ads_calld->on_status_received_, OnStatusReceivedLocked,
+                        ads_calld, nullptr),
+      GRPC_ERROR_REF(error));
 }
 
 void XdsClient::ChannelState::AdsCallState::OnStatusReceivedLocked(
@@ -807,9 +840,20 @@ void XdsClient::ChannelState::LrsCallState::Reporter::Orphan() {
 void XdsClient::ChannelState::LrsCallState::Reporter::
     ScheduleNextReportLocked() {
   const grpc_millis next_report_time = ExecCtx::Get()->Now() + report_interval_;
+  GRPC_CLOSURE_INIT(&on_next_report_timer_, OnNextReportTimer, this,
+                    grpc_schedule_on_exec_ctx);
   grpc_timer_init(&next_report_timer_, next_report_time,
                   &on_next_report_timer_);
   next_report_timer_callback_pending_ = true;
+}
+
+void XdsClient::ChannelState::LrsCallState::Reporter::OnNextReportTimer(
+    void* arg, grpc_error* error) {
+  Reporter* self = static_cast<Reporter*>(arg);
+  self->xds_client()->combiner_->Run(
+      GRPC_CLOSURE_INIT(&self->on_next_report_timer_, OnNextReportTimerLocked,
+                        self, nullptr),
+      GRPC_ERROR_REF(error));
 }
 
 void XdsClient::ChannelState::LrsCallState::Reporter::OnNextReportTimerLocked(
@@ -851,6 +895,8 @@ void XdsClient::ChannelState::LrsCallState::Reporter::SendReportLocked() {
   memset(&op, 0, sizeof(op));
   op.op = GRPC_OP_SEND_MESSAGE;
   op.data.send_message.send_message = parent_->send_message_payload_;
+  GRPC_CLOSURE_INIT(&on_report_done_, OnReportDone, this,
+                    grpc_schedule_on_exec_ctx);
   grpc_call_error call_error = grpc_call_start_batch_and_execute(
       parent_->call_, &op, 1, &on_report_done_);
   if (GPR_UNLIKELY(call_error != GRPC_CALL_OK)) {
@@ -859,6 +905,15 @@ void XdsClient::ChannelState::LrsCallState::Reporter::SendReportLocked() {
             xds_client(), this, call_error);
     GPR_ASSERT(GRPC_CALL_OK == call_error);
   }
+}
+
+void XdsClient::ChannelState::LrsCallState::Reporter::OnReportDone(
+    void* arg, grpc_error* error) {
+  Reporter* self = static_cast<Reporter*>(arg);
+  self->xds_client()->combiner_->Run(
+      GRPC_CLOSURE_INIT(&self->on_report_done_, OnReportDoneLocked, self,
+                        nullptr),
+      GRPC_ERROR_REF(error));
 }
 
 void XdsClient::ChannelState::LrsCallState::Reporter::OnReportDoneLocked(
@@ -908,12 +963,6 @@ XdsClient::ChannelState::LrsCallState::LrsCallState(
   // Init other data associated with the LRS call.
   grpc_metadata_array_init(&initial_metadata_recv_);
   grpc_metadata_array_init(&trailing_metadata_recv_);
-  GRPC_CLOSURE_INIT(&on_initial_request_sent_, OnInitialRequestSentLocked, this,
-                    grpc_combiner_scheduler(xds_client()->combiner_));
-  GRPC_CLOSURE_INIT(&on_response_received_, OnResponseReceivedLocked, this,
-                    grpc_combiner_scheduler(xds_client()->combiner_));
-  GRPC_CLOSURE_INIT(&on_status_received_, OnStatusReceivedLocked, this,
-                    grpc_combiner_scheduler(xds_client()->combiner_));
   // Start the call.
   if (GRPC_TRACE_FLAG_ENABLED(grpc_xds_client_trace)) {
     gpr_log(GPR_INFO,
@@ -940,6 +989,8 @@ XdsClient::ChannelState::LrsCallState::LrsCallState(
   op->reserved = nullptr;
   op++;
   Ref(DEBUG_LOCATION, "LRS+OnInitialRequestSentLocked").release();
+  GRPC_CLOSURE_INIT(&on_initial_request_sent_, OnInitialRequestSent, this,
+                    grpc_schedule_on_exec_ctx);
   call_error = grpc_call_start_batch_and_execute(call_, ops, (size_t)(op - ops),
                                                  &on_initial_request_sent_);
   GPR_ASSERT(GRPC_CALL_OK == call_error);
@@ -958,6 +1009,8 @@ XdsClient::ChannelState::LrsCallState::LrsCallState(
   op->reserved = nullptr;
   op++;
   Ref(DEBUG_LOCATION, "LRS+OnResponseReceivedLocked").release();
+  GRPC_CLOSURE_INIT(&on_response_received_, OnResponseReceived, this,
+                    grpc_schedule_on_exec_ctx);
   call_error = grpc_call_start_batch_and_execute(call_, ops, (size_t)(op - ops),
                                                  &on_response_received_);
   GPR_ASSERT(GRPC_CALL_OK == call_error);
@@ -973,6 +1026,8 @@ XdsClient::ChannelState::LrsCallState::LrsCallState(
   // This callback signals the end of the call, so it relies on the initial
   // ref instead of a new ref. When it's invoked, it's the initial ref that is
   // unreffed.
+  GRPC_CLOSURE_INIT(&on_status_received_, OnStatusReceived, this,
+                    grpc_schedule_on_exec_ctx);
   call_error = grpc_call_start_batch_and_execute(call_, ops, (size_t)(op - ops),
                                                  &on_status_received_);
   GPR_ASSERT(GRPC_CALL_OK == call_error);
@@ -1021,6 +1076,15 @@ void XdsClient::ChannelState::LrsCallState::MaybeStartReportingLocked() {
       Ref(DEBUG_LOCATION, "LRS+load_report+start"), load_reporting_interval_);
 }
 
+void XdsClient::ChannelState::LrsCallState::OnInitialRequestSent(
+    void* arg, grpc_error* error) {
+  LrsCallState* lrs_calld = static_cast<LrsCallState*>(arg);
+  lrs_calld->xds_client()->combiner_->Run(
+      GRPC_CLOSURE_INIT(&lrs_calld->on_initial_request_sent_,
+                        OnInitialRequestSentLocked, lrs_calld, nullptr),
+      GRPC_ERROR_REF(error));
+}
+
 void XdsClient::ChannelState::LrsCallState::OnInitialRequestSentLocked(
     void* arg, grpc_error* error) {
   LrsCallState* lrs_calld = static_cast<LrsCallState*>(arg);
@@ -1029,6 +1093,15 @@ void XdsClient::ChannelState::LrsCallState::OnInitialRequestSentLocked(
   lrs_calld->send_message_payload_ = nullptr;
   lrs_calld->MaybeStartReportingLocked();
   lrs_calld->Unref(DEBUG_LOCATION, "LRS+OnInitialRequestSentLocked");
+}
+
+void XdsClient::ChannelState::LrsCallState::OnResponseReceived(
+    void* arg, grpc_error* error) {
+  LrsCallState* lrs_calld = static_cast<LrsCallState*>(arg);
+  lrs_calld->xds_client()->combiner_->Run(
+      GRPC_CLOSURE_INIT(&lrs_calld->on_response_received_,
+                        OnResponseReceivedLocked, lrs_calld, nullptr),
+      GRPC_ERROR_REF(error));
 }
 
 void XdsClient::ChannelState::LrsCallState::OnResponseReceivedLocked(
@@ -1114,9 +1187,20 @@ void XdsClient::ChannelState::LrsCallState::OnResponseReceivedLocked(
   op.reserved = nullptr;
   GPR_ASSERT(lrs_calld->call_ != nullptr);
   // Reuse the "OnResponseReceivedLocked" ref taken in ctor.
+  GRPC_CLOSURE_INIT(&lrs_calld->on_response_received_, OnResponseReceived,
+                    lrs_calld, grpc_schedule_on_exec_ctx);
   const grpc_call_error call_error = grpc_call_start_batch_and_execute(
       lrs_calld->call_, &op, 1, &lrs_calld->on_response_received_);
   GPR_ASSERT(GRPC_CALL_OK == call_error);
+}
+
+void XdsClient::ChannelState::LrsCallState::OnStatusReceived(
+    void* arg, grpc_error* error) {
+  LrsCallState* lrs_calld = static_cast<LrsCallState*>(arg);
+  lrs_calld->xds_client()->combiner_->Run(
+      GRPC_CLOSURE_INIT(&lrs_calld->on_status_received_, OnStatusReceivedLocked,
+                        lrs_calld, nullptr),
+      GRPC_ERROR_REF(error));
 }
 
 void XdsClient::ChannelState::LrsCallState::OnStatusReceivedLocked(
@@ -1165,8 +1249,7 @@ UniquePtr<char> GenerateBuildVersionString() {
 
 }  // namespace
 
-XdsClient::XdsClient(grpc_combiner* combiner,
-                     grpc_pollset_set* interested_parties,
+XdsClient::XdsClient(Combiner* combiner, grpc_pollset_set* interested_parties,
                      StringView server_name,
                      UniquePtr<ServiceConfigWatcherInterface> watcher,
                      const grpc_channel_args& channel_args, grpc_error** error)
@@ -1193,8 +1276,8 @@ XdsClient::XdsClient(grpc_combiner* combiner,
     // TODO(juanlishen): Start LDS call and do not return service config
     // until we get the first LDS response.
     GRPC_CLOSURE_INIT(&service_config_notify_, NotifyOnServiceConfig,
-                      Ref().release(), grpc_combiner_scheduler(combiner_));
-    GRPC_CLOSURE_SCHED(&service_config_notify_, GRPC_ERROR_NONE);
+                      Ref().release(), nullptr);
+    combiner_->Run(&service_config_notify_, GRPC_ERROR_NONE);
   }
 }
 

--- a/src/core/ext/filters/client_channel/xds/xds_client.h
+++ b/src/core/ext/filters/client_channel/xds/xds_client.h
@@ -71,7 +71,7 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
 
   // If *error is not GRPC_ERROR_NONE after construction, then there was
   // an error initializing the client.
-  XdsClient(grpc_combiner* combiner, grpc_pollset_set* interested_parties,
+  XdsClient(Combiner* combiner, grpc_pollset_set* interested_parties,
             StringView server_name,
             UniquePtr<ServiceConfigWatcherInterface> watcher,
             const grpc_channel_args& channel_args, grpc_error** error);
@@ -196,7 +196,7 @@ class XdsClient : public InternallyRefCounted<XdsClient> {
 
   UniquePtr<char> build_version_;
 
-  grpc_combiner* combiner_;
+  Combiner* combiner_;
   grpc_pollset_set* interested_parties_;
 
   UniquePtr<XdsBootstrap> bootstrap_;

--- a/src/core/ext/transport/chttp2/transport/hpack_parser.cc
+++ b/src/core/ext/transport/chttp2/transport/hpack_parser.cc
@@ -1741,9 +1741,8 @@ grpc_error* grpc_chttp2_header_parser_parse(void* hpack_parser,
              however -- it might be that we receive a RST_STREAM following this
              and can avoid the extra write */
           GRPC_CHTTP2_STREAM_REF(s, "final_rst");
-          GRPC_CLOSURE_SCHED(
-              GRPC_CLOSURE_CREATE(force_client_rst_stream, s,
-                                  grpc_combiner_finally_scheduler(t->combiner)),
+          t->combiner->FinallyRun(
+              GRPC_CLOSURE_CREATE(force_client_rst_stream, s, nullptr),
               GRPC_ERROR_NONE);
         }
         grpc_chttp2_mark_stream_closed(t, s, true, false, GRPC_ERROR_NONE);

--- a/src/core/ext/transport/chttp2/transport/internal.h
+++ b/src/core/ext/transport/chttp2/transport/internal.h
@@ -300,7 +300,7 @@ struct grpc_chttp2_transport {
 
   grpc_resource_user* resource_user;
 
-  grpc_combiner* combiner;
+  grpc_core::Combiner* combiner;
 
   grpc_closure* notify_on_receive_settings = nullptr;
 
@@ -459,6 +459,8 @@ struct grpc_chttp2_transport {
 
   /* next bdp ping timer */
   bool have_next_bdp_ping_timer = false;
+  /** If start_bdp_ping_locked has been called */
+  bool bdp_ping_started = false;
   grpc_timer next_bdp_ping_timer;
 
   /* keep-alive ping support */
@@ -480,6 +482,8 @@ struct grpc_chttp2_transport {
   grpc_millis keepalive_timeout;
   /** if keepalive pings are allowed when there's no outstanding streams */
   bool keepalive_permit_without_calls = false;
+  /** If start_keepalive_ping_locked has been called */
+  bool keepalive_ping_started = false;
   /** keep-alive state machine state */
   grpc_chttp2_keepalive_state keepalive_state;
   grpc_core::ContextList* cl = nullptr;
@@ -861,5 +865,7 @@ void grpc_chttp2_fail_pending_writes(grpc_chttp2_transport* t,
     initialization */
 void grpc_chttp2_config_default_keepalive_args(grpc_channel_args* args,
                                                bool is_client);
+
+void grpc_chttp2_retry_initiate_ping(void* tp, grpc_error* error);
 
 #endif /* GRPC_CORE_EXT_TRANSPORT_CHTTP2_TRANSPORT_INTERNAL_H */

--- a/src/core/ext/transport/chttp2/transport/writing.cc
+++ b/src/core/ext/transport/chttp2/transport/writing.cc
@@ -96,6 +96,9 @@ static void maybe_initiate_ping(grpc_chttp2_transport* t) {
     if (!t->ping_state.is_delayed_ping_timer_set) {
       t->ping_state.is_delayed_ping_timer_set = true;
       GRPC_CHTTP2_REF_TRANSPORT(t, "retry_initiate_ping_locked");
+      GRPC_CLOSURE_INIT(&t->retry_initiate_ping_locked,
+                        grpc_chttp2_retry_initiate_ping, t,
+                        grpc_schedule_on_exec_ctx);
       grpc_timer_init(&t->ping_state.delayed_ping_timer, next_allowed_ping,
                       &t->retry_initiate_ping_locked);
     }

--- a/src/core/lib/iomgr/combiner.cc
+++ b/src/core/lib/iomgr/combiner.cc
@@ -45,42 +45,16 @@ grpc_core::DebugOnlyTraceFlag grpc_combiner_trace(false, "combiner");
 #define STATE_UNORPHANED 1
 #define STATE_ELEM_COUNT_LOW_BIT 2
 
-struct grpc_combiner {
-  grpc_combiner* next_combiner_on_this_exec_ctx = nullptr;
-  grpc_closure_scheduler scheduler;
-  grpc_closure_scheduler finally_scheduler;
-  grpc_core::MultiProducerSingleConsumerQueue queue;
-  // either:
-  // a pointer to the initiating exec ctx if that is the only exec_ctx that has
-  // ever queued to this combiner, or NULL. If this is non-null, it's not
-  // dereferencable (since the initiating exec_ctx may have gone out of scope)
-  gpr_atm initiating_exec_ctx_or_null;
-  // state is:
-  // lower bit - zero if orphaned (STATE_UNORPHANED)
-  // other bits - number of items queued on the lock (STATE_ELEM_COUNT_LOW_BIT)
-  gpr_atm state;
-  bool time_to_execute_final_list = false;
-  grpc_closure_list final_list;
-  grpc_closure offload;
-  gpr_refcount refs;
-};
-
-static void combiner_run(grpc_closure* closure, grpc_error* error);
-static void combiner_exec(grpc_closure* closure, grpc_error* error);
-static void combiner_finally_exec(grpc_closure* closure, grpc_error* error);
-
-static const grpc_closure_scheduler_vtable scheduler = {
-    combiner_run, combiner_exec, "combiner:immediately"};
-static const grpc_closure_scheduler_vtable finally_scheduler = {
-    combiner_finally_exec, combiner_finally_exec, "combiner:finally"};
+static void combiner_exec(grpc_core::Combiner* lock, grpc_closure* closure,
+                          grpc_error* error);
+static void combiner_finally_exec(grpc_core::Combiner* lock,
+                                  grpc_closure* closure, grpc_error* error);
 
 static void offload(void* arg, grpc_error* error);
 
-grpc_combiner* grpc_combiner_create(void) {
-  grpc_combiner* lock = grpc_core::New<grpc_combiner>();
+grpc_core::Combiner* grpc_combiner_create(void) {
+  grpc_core::Combiner* lock = grpc_core::New<grpc_core::Combiner>();
   gpr_ref_init(&lock->refs, 1);
-  lock->scheduler.vtable = &scheduler;
-  lock->finally_scheduler.vtable = &finally_scheduler;
   gpr_atm_no_barrier_store(&lock->state, STATE_UNORPHANED);
   grpc_closure_list_init(&lock->final_list);
   GRPC_CLOSURE_INIT(
@@ -90,13 +64,13 @@ grpc_combiner* grpc_combiner_create(void) {
   return lock;
 }
 
-static void really_destroy(grpc_combiner* lock) {
+static void really_destroy(grpc_core::Combiner* lock) {
   GRPC_COMBINER_TRACE(gpr_log(GPR_INFO, "C:%p really_destroy", lock));
   GPR_ASSERT(gpr_atm_no_barrier_load(&lock->state) == 0);
   grpc_core::Delete(lock);
 }
 
-static void start_destroy(grpc_combiner* lock) {
+static void start_destroy(grpc_core::Combiner* lock) {
   gpr_atm old_state = gpr_atm_full_fetch_add(&lock->state, -STATE_UNORPHANED);
   GRPC_COMBINER_TRACE(gpr_log(
       GPR_INFO, "C:%p really_destroy old_state=%" PRIdPTR, lock, old_state));
@@ -117,20 +91,21 @@ static void start_destroy(grpc_combiner* lock) {
 #define GRPC_COMBINER_DEBUG_SPAM(op, delta)
 #endif
 
-void grpc_combiner_unref(grpc_combiner* lock GRPC_COMBINER_DEBUG_ARGS) {
+void grpc_combiner_unref(grpc_core::Combiner* lock GRPC_COMBINER_DEBUG_ARGS) {
   GRPC_COMBINER_DEBUG_SPAM("UNREF", -1);
   if (gpr_unref(&lock->refs)) {
     start_destroy(lock);
   }
 }
 
-grpc_combiner* grpc_combiner_ref(grpc_combiner* lock GRPC_COMBINER_DEBUG_ARGS) {
+grpc_core::Combiner* grpc_combiner_ref(
+    grpc_core::Combiner* lock GRPC_COMBINER_DEBUG_ARGS) {
   GRPC_COMBINER_DEBUG_SPAM("  REF", 1);
   gpr_ref(&lock->refs);
   return lock;
 }
 
-static void push_last_on_exec_ctx(grpc_combiner* lock) {
+static void push_last_on_exec_ctx(grpc_core::Combiner* lock) {
   lock->next_combiner_on_this_exec_ctx = nullptr;
   if (grpc_core::ExecCtx::Get()->combiner_data()->active_combiner == nullptr) {
     grpc_core::ExecCtx::Get()->combiner_data()->active_combiner =
@@ -143,7 +118,7 @@ static void push_last_on_exec_ctx(grpc_combiner* lock) {
   }
 }
 
-static void push_first_on_exec_ctx(grpc_combiner* lock) {
+static void push_first_on_exec_ctx(grpc_core::Combiner* lock) {
   lock->next_combiner_on_this_exec_ctx =
       grpc_core::ExecCtx::Get()->combiner_data()->active_combiner;
   grpc_core::ExecCtx::Get()->combiner_data()->active_combiner = lock;
@@ -152,14 +127,10 @@ static void push_first_on_exec_ctx(grpc_combiner* lock) {
   }
 }
 
-#define COMBINER_FROM_CLOSURE_SCHEDULER(closure, scheduler_name) \
-  ((grpc_combiner*)(((char*)((closure)->scheduler)) -            \
-                    offsetof(grpc_combiner, scheduler_name)))
-
-static void combiner_exec(grpc_closure* cl, grpc_error* error) {
+static void combiner_exec(grpc_core::Combiner* lock, grpc_closure* cl,
+                          grpc_error* error) {
   GPR_TIMER_SCOPE("combiner.execute", 0);
   GRPC_STATS_INC_COMBINER_LOCKS_SCHEDULED_ITEMS();
-  grpc_combiner* lock = COMBINER_FROM_CLOSURE_SCHEDULER(cl, scheduler);
   gpr_atm last = gpr_atm_full_fetch_add(&lock->state, STATE_ELEM_COUNT_LOW_BIT);
   GRPC_COMBINER_TRACE(gpr_log(GPR_INFO,
                               "C:%p grpc_combiner_execute c=%p last=%" PRIdPTR,
@@ -198,11 +169,11 @@ static void move_next() {
 }
 
 static void offload(void* arg, grpc_error* error) {
-  grpc_combiner* lock = static_cast<grpc_combiner*>(arg);
+  grpc_core::Combiner* lock = static_cast<grpc_core::Combiner*>(arg);
   push_last_on_exec_ctx(lock);
 }
 
-static void queue_offload(grpc_combiner* lock) {
+static void queue_offload(grpc_core::Combiner* lock) {
   GRPC_STATS_INC_COMBINER_LOCKS_OFFLOADED();
   move_next();
   GRPC_COMBINER_TRACE(gpr_log(GPR_INFO, "C:%p queue_offload", lock));
@@ -211,7 +182,7 @@ static void queue_offload(grpc_combiner* lock) {
 
 bool grpc_combiner_continue_exec_ctx() {
   GPR_TIMER_SCOPE("combiner.continue_exec_ctx", 0);
-  grpc_combiner* lock =
+  grpc_core::Combiner* lock =
       grpc_core::ExecCtx::Get()->combiner_data()->active_combiner;
   if (lock == nullptr) {
     return false;
@@ -329,19 +300,20 @@ bool grpc_combiner_continue_exec_ctx() {
 
 static void enqueue_finally(void* closure, grpc_error* error);
 
-static void combiner_finally_exec(grpc_closure* closure, grpc_error* error) {
+static void combiner_finally_exec(grpc_core::Combiner* lock,
+                                  grpc_closure* closure, grpc_error* error) {
+  GPR_ASSERT(lock != nullptr);
   GPR_TIMER_SCOPE("combiner.execute_finally", 0);
   GRPC_STATS_INC_COMBINER_LOCKS_SCHEDULED_FINAL_ITEMS();
-  grpc_combiner* lock =
-      COMBINER_FROM_CLOSURE_SCHEDULER(closure, finally_scheduler);
   GRPC_COMBINER_TRACE(gpr_log(
       GPR_INFO, "C:%p grpc_combiner_execute_finally c=%p; ac=%p", lock, closure,
       grpc_core::ExecCtx::Get()->combiner_data()->active_combiner));
   if (grpc_core::ExecCtx::Get()->combiner_data()->active_combiner != lock) {
     GPR_TIMER_MARK("slowpath", 0);
-    GRPC_CLOSURE_SCHED(GRPC_CLOSURE_CREATE(enqueue_finally, closure,
-                                           grpc_combiner_scheduler(lock)),
-                       error);
+    // Reusing scheduler to store the combiner so that it can be accessed in
+    // enqueue_finally
+    closure->scheduler = reinterpret_cast<grpc_closure_scheduler*>(lock);
+    lock->Run(GRPC_CLOSURE_CREATE(enqueue_finally, closure, nullptr), error);
     return;
   }
 
@@ -351,32 +323,24 @@ static void combiner_finally_exec(grpc_closure* closure, grpc_error* error) {
   grpc_closure_list_append(&lock->final_list, closure, error);
 }
 
-static void combiner_run(grpc_closure* closure, grpc_error* error) {
-  grpc_combiner* lock = COMBINER_FROM_CLOSURE_SCHEDULER(closure, scheduler);
-#ifndef NDEBUG
-  closure->scheduled = false;
-  GRPC_COMBINER_TRACE(gpr_log(
-      GPR_DEBUG,
-      "Combiner:%p grpc_combiner_run closure:%p created [%s:%d] run [%s:%d]",
-      lock, closure, closure->file_created, closure->line_created,
-      closure->file_initiated, closure->line_initiated));
-#endif
-  GPR_ASSERT(grpc_core::ExecCtx::Get()->combiner_data()->active_combiner ==
-             lock);
-  closure->cb(closure->cb_arg, error);
-  GRPC_ERROR_UNREF(error);
-}
-
 static void enqueue_finally(void* closure, grpc_error* error) {
-  combiner_finally_exec(static_cast<grpc_closure*>(closure),
-                        GRPC_ERROR_REF(error));
+  grpc_closure* cl = static_cast<grpc_closure*>(closure);
+  combiner_finally_exec(reinterpret_cast<grpc_core::Combiner*>(cl->scheduler),
+                        cl, GRPC_ERROR_REF(error));
 }
 
-grpc_closure_scheduler* grpc_combiner_scheduler(grpc_combiner* combiner) {
-  return &combiner->scheduler;
+namespace grpc_core {
+void Combiner::Run(grpc_closure* closure, grpc_error* error) {
+  GPR_ASSERT(closure->scheduler == nullptr ||
+             closure->scheduler ==
+                 reinterpret_cast<grpc_closure_scheduler*>(this));
+  combiner_exec(this, closure, error);
 }
 
-grpc_closure_scheduler* grpc_combiner_finally_scheduler(
-    grpc_combiner* combiner) {
-  return &combiner->finally_scheduler;
+void Combiner::FinallyRun(grpc_closure* closure, grpc_error* error) {
+  GPR_ASSERT(closure->scheduler == nullptr ||
+             closure->scheduler ==
+                 reinterpret_cast<grpc_closure_scheduler*>(this));
+  combiner_finally_exec(this, closure, error);
 }
+}  // namespace grpc_core

--- a/src/core/lib/iomgr/combiner.h
+++ b/src/core/lib/iomgr/combiner.h
@@ -27,6 +27,34 @@
 #include "src/core/lib/debug/trace.h"
 #include "src/core/lib/iomgr/exec_ctx.h"
 
+namespace grpc_core {
+// TODO(yashkt) : Remove this class and replace it with a class that does not
+// use ExecCtx
+class Combiner {
+ public:
+  void Run(grpc_closure* closure, grpc_error* error);
+  // TODO(yashkt) : Remove this method
+  void FinallyRun(grpc_closure* closure, grpc_error* error);
+  Combiner* next_combiner_on_this_exec_ctx = nullptr;
+  grpc_closure_scheduler scheduler;
+  grpc_closure_scheduler finally_scheduler;
+  MultiProducerSingleConsumerQueue queue;
+  // either:
+  // a pointer to the initiating exec ctx if that is the only exec_ctx that has
+  // ever queued to this combiner, or NULL. If this is non-null, it's not
+  // dereferencable (since the initiating exec_ctx may have gone out of scope)
+  gpr_atm initiating_exec_ctx_or_null;
+  // state is:
+  // lower bit - zero if orphaned (STATE_UNORPHANED)
+  // other bits - number of items queued on the lock (STATE_ELEM_COUNT_LOW_BIT)
+  gpr_atm state;
+  bool time_to_execute_final_list = false;
+  grpc_closure_list final_list;
+  grpc_closure offload;
+  gpr_refcount refs;
+};
+}  // namespace grpc_core
+
 // Provides serialized access to some resource.
 // Each action queued on a combiner is executed serially in a borrowed thread.
 // The actual thread executing actions may change over time (but there will only
@@ -34,7 +62,7 @@
 
 // Initialize the lock, with an optional workqueue to shift load to when
 // necessary
-grpc_combiner* grpc_combiner_create(void);
+grpc_core::Combiner* grpc_combiner_create(void);
 
 #ifndef NDEBUG
 #define GRPC_COMBINER_DEBUG_ARGS \
@@ -51,12 +79,9 @@ grpc_combiner* grpc_combiner_create(void);
 
 // Ref/unref the lock, for when we're sharing the lock ownership
 // Prefer to use the macros above
-grpc_combiner* grpc_combiner_ref(grpc_combiner* lock GRPC_COMBINER_DEBUG_ARGS);
-void grpc_combiner_unref(grpc_combiner* lock GRPC_COMBINER_DEBUG_ARGS);
-// Fetch a scheduler to schedule closures against
-grpc_closure_scheduler* grpc_combiner_scheduler(grpc_combiner* lock);
-// Scheduler to execute \a action within the lock just prior to unlocking.
-grpc_closure_scheduler* grpc_combiner_finally_scheduler(grpc_combiner* lock);
+grpc_core::Combiner* grpc_combiner_ref(
+    grpc_core::Combiner* lock GRPC_COMBINER_DEBUG_ARGS);
+void grpc_combiner_unref(grpc_core::Combiner* lock GRPC_COMBINER_DEBUG_ARGS);
 
 bool grpc_combiner_continue_exec_ctx();
 

--- a/src/core/lib/iomgr/exec_ctx.h
+++ b/src/core/lib/iomgr/exec_ctx.h
@@ -63,6 +63,7 @@ grpc_millis grpc_cycle_counter_to_millis_round_down(gpr_cycle_counter cycles);
 grpc_millis grpc_cycle_counter_to_millis_round_up(gpr_cycle_counter cycles);
 
 namespace grpc_core {
+class Combiner;
 /** Execution context.
  *  A bag of data that collects information along a callstack.
  *  It is created on the stack at core entry points (public API or iomgr), and
@@ -136,9 +137,9 @@ class ExecCtx {
 
   struct CombinerData {
     /* currently active combiner: updated only via combiner.c */
-    grpc_combiner* active_combiner;
+    Combiner* active_combiner;
     /* last active combiner in the active combiner list */
-    grpc_combiner* last_combiner;
+    Combiner* last_combiner;
   };
 
   /** Only to be used by grpc-combiner code */

--- a/src/core/lib/iomgr/resource_quota.cc
+++ b/src/core/lib/iomgr/resource_quota.cc
@@ -132,7 +132,7 @@ struct grpc_resource_quota {
 
   /* Master combiner lock: all activity on a quota executes under this combiner
    * (so no mutex is needed for this data structure) */
-  grpc_combiner* combiner;
+  grpc_core::Combiner* combiner;
   /* Size of the resource quota */
   int64_t size;
   /* Amount of free memory in the resource quota */
@@ -293,7 +293,8 @@ static void rq_step_sched(grpc_resource_quota* resource_quota) {
   if (resource_quota->step_scheduled) return;
   resource_quota->step_scheduled = true;
   grpc_resource_quota_ref_internal(resource_quota);
-  GRPC_CLOSURE_SCHED(&resource_quota->rq_step_closure, GRPC_ERROR_NONE);
+  resource_quota->combiner->FinallyRun(&resource_quota->rq_step_closure,
+                                       GRPC_ERROR_NONE);
 }
 
 /* update the atomically available resource estimate - use no barriers since
@@ -655,10 +656,9 @@ grpc_resource_quota* grpc_resource_quota_create(const char* name) {
                  (intptr_t)resource_quota);
   }
   GRPC_CLOSURE_INIT(&resource_quota->rq_step_closure, rq_step, resource_quota,
-                    grpc_combiner_finally_scheduler(resource_quota->combiner));
+                    nullptr);
   GRPC_CLOSURE_INIT(&resource_quota->rq_reclamation_done_closure,
-                    rq_reclamation_done, resource_quota,
-                    grpc_combiner_scheduler(resource_quota->combiner));
+                    rq_reclamation_done, resource_quota, nullptr);
   for (int i = 0; i < GRPC_RULIST_COUNT; i++) {
     resource_quota->roots[i] = nullptr;
   }
@@ -774,19 +774,15 @@ grpc_resource_user* grpc_resource_user_create(
   resource_user->resource_quota =
       grpc_resource_quota_ref_internal(resource_quota);
   GRPC_CLOSURE_INIT(&resource_user->allocate_closure, &ru_allocate,
-                    resource_user,
-                    grpc_combiner_scheduler(resource_quota->combiner));
+                    resource_user, nullptr);
   GRPC_CLOSURE_INIT(&resource_user->add_to_free_pool_closure,
-                    &ru_add_to_free_pool, resource_user,
-                    grpc_combiner_scheduler(resource_quota->combiner));
+                    &ru_add_to_free_pool, resource_user, nullptr);
   GRPC_CLOSURE_INIT(&resource_user->post_reclaimer_closure[0],
-                    &ru_post_benign_reclaimer, resource_user,
-                    grpc_combiner_scheduler(resource_quota->combiner));
+                    &ru_post_benign_reclaimer, resource_user, nullptr);
   GRPC_CLOSURE_INIT(&resource_user->post_reclaimer_closure[1],
-                    &ru_post_destructive_reclaimer, resource_user,
-                    grpc_combiner_scheduler(resource_quota->combiner));
+                    &ru_post_destructive_reclaimer, resource_user, nullptr);
   GRPC_CLOSURE_INIT(&resource_user->destroy_closure, &ru_destroy, resource_user,
-                    grpc_combiner_scheduler(resource_quota->combiner));
+                    nullptr);
   gpr_mu_init(&resource_user->mu);
   gpr_atm_rel_store(&resource_user->refs, 1);
   gpr_atm_rel_store(&resource_user->shutdown, 0);
@@ -827,7 +823,8 @@ static void ru_unref_by(grpc_resource_user* resource_user, gpr_atm amount) {
   gpr_atm old = gpr_atm_full_fetch_add(&resource_user->refs, -amount);
   GPR_ASSERT(old >= amount);
   if (old == amount) {
-    GRPC_CLOSURE_SCHED(&resource_user->destroy_closure, GRPC_ERROR_NONE);
+    resource_user->resource_quota->combiner->Run(
+        &resource_user->destroy_closure, GRPC_ERROR_NONE);
   }
 }
 
@@ -841,10 +838,8 @@ void grpc_resource_user_unref(grpc_resource_user* resource_user) {
 
 void grpc_resource_user_shutdown(grpc_resource_user* resource_user) {
   if (gpr_atm_full_fetch_add(&resource_user->shutdown, 1) == 0) {
-    GRPC_CLOSURE_SCHED(
-        GRPC_CLOSURE_CREATE(
-            ru_shutdown, resource_user,
-            grpc_combiner_scheduler(resource_user->resource_quota->combiner)),
+    resource_user->resource_quota->combiner->Run(
+        GRPC_CLOSURE_CREATE(ru_shutdown, resource_user, nullptr),
         GRPC_ERROR_NONE);
   }
 }
@@ -902,7 +897,8 @@ static bool resource_user_alloc_locked(grpc_resource_user* resource_user,
   }
   if (!resource_user->allocating) {
     resource_user->allocating = true;
-    GRPC_CLOSURE_SCHED(&resource_user->allocate_closure, GRPC_ERROR_NONE);
+    resource_user->resource_quota->combiner->Run(
+        &resource_user->allocate_closure, GRPC_ERROR_NONE);
   }
   return false;
 }
@@ -957,8 +953,8 @@ void grpc_resource_user_free(grpc_resource_user* resource_user, size_t size) {
   if (is_bigger_than_zero && was_zero_or_negative &&
       !resource_user->added_to_free_pool) {
     resource_user->added_to_free_pool = true;
-    GRPC_CLOSURE_SCHED(&resource_user->add_to_free_pool_closure,
-                       GRPC_ERROR_NONE);
+    resource_quota->combiner->Run(&resource_user->add_to_free_pool_closure,
+                                  GRPC_ERROR_NONE);
   }
   gpr_mu_unlock(&resource_user->mu);
   ru_unref_by(resource_user, static_cast<gpr_atm>(size));
@@ -969,8 +965,8 @@ void grpc_resource_user_post_reclaimer(grpc_resource_user* resource_user,
                                        grpc_closure* closure) {
   GPR_ASSERT(resource_user->new_reclaimers[destructive] == nullptr);
   resource_user->new_reclaimers[destructive] = closure;
-  GRPC_CLOSURE_SCHED(&resource_user->post_reclaimer_closure[destructive],
-                     GRPC_ERROR_NONE);
+  resource_user->resource_quota->combiner->Run(
+      &resource_user->post_reclaimer_closure[destructive], GRPC_ERROR_NONE);
 }
 
 void grpc_resource_user_finish_reclamation(grpc_resource_user* resource_user) {
@@ -978,7 +974,7 @@ void grpc_resource_user_finish_reclamation(grpc_resource_user* resource_user) {
     gpr_log(GPR_INFO, "RQ %s %s: reclamation complete",
             resource_user->resource_quota->name, resource_user->name);
   }
-  GRPC_CLOSURE_SCHED(
+  resource_user->resource_quota->combiner->Run(
       &resource_user->resource_quota->rq_reclamation_done_closure,
       GRPC_ERROR_NONE);
 }

--- a/src/core/lib/iomgr/tcp_posix.cc
+++ b/src/core/lib/iomgr/tcp_posix.cc
@@ -1043,7 +1043,7 @@ static void tcp_handle_write(void* arg /* grpc_tcp */, grpc_error* error) {
       gpr_log(GPR_INFO, "write: %s", str);
     }
     // No need to take a ref on error since tcp_flush provides a ref.
-    GRPC_CLOSURE_SCHED(cb, error);
+    GRPC_CLOSURE_RUN(cb, error);
     TCP_UNREF(tcp, "write");
   }
 }

--- a/src/core/lib/transport/connectivity_state.h
+++ b/src/core/lib/transport/connectivity_state.h
@@ -68,15 +68,16 @@ class AsyncConnectivityStateWatcherInterface
  protected:
   class Notifier;
 
-  explicit AsyncConnectivityStateWatcherInterface(
-      grpc_closure_scheduler* scheduler = grpc_schedule_on_exec_ctx)
-      : scheduler_(scheduler) {}
+  // If \a combiner is nullptr, then the notification will be scheduled on the
+  // ExecCtx.
+  explicit AsyncConnectivityStateWatcherInterface(Combiner* combiner = nullptr)
+      : combiner_(combiner) {}
 
   // Invoked asynchronously when Notify() is called.
   virtual void OnConnectivityStateChange(grpc_connectivity_state new_state) = 0;
 
  private:
-  grpc_closure_scheduler* scheduler_;
+  Combiner* combiner_;
 };
 
 // Tracks connectivity state.  Maintains a list of watchers that are

--- a/test/core/client_channel/resolvers/dns_resolver_connectivity_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_connectivity_test.cc
@@ -33,7 +33,7 @@
 
 static gpr_mu g_mu;
 static bool g_fail_resolution = true;
-static grpc_combiner* g_combiner;
+static grpc_core::Combiner* g_combiner;
 
 static void my_resolve_address(const char* addr, const char* /*default_port*/,
                                grpc_pollset_set* /*interested_parties*/,
@@ -65,7 +65,7 @@ static grpc_ares_request* my_dns_lookup_ares_locked(
     grpc_pollset_set* /*interested_parties*/, grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
     bool /*check_grpclb*/, char** /*service_config_json*/,
-    int /*query_timeout_ms*/, grpc_combiner* /*combiner*/) {
+    int /*query_timeout_ms*/, grpc_core::Combiner* /*combiner*/) {
   gpr_mu_lock(&g_mu);
   GPR_ASSERT(0 == strcmp("test", addr));
   grpc_error* error = GRPC_ERROR_NONE;

--- a/test/core/client_channel/resolvers/dns_resolver_test.cc
+++ b/test/core/client_channel/resolvers/dns_resolver_test.cc
@@ -28,7 +28,7 @@
 #include "src/core/lib/iomgr/combiner.h"
 #include "test/core/util/test_config.h"
 
-static grpc_combiner* g_combiner;
+static grpc_core::Combiner* g_combiner;
 
 class TestResultHandler : public grpc_core::Resolver::ResultHandler {
   void ReturnResult(grpc_core::Resolver::Result /*result*/) override {}

--- a/test/core/client_channel/resolvers/fake_resolver_test.cc
+++ b/test/core/client_channel/resolvers/fake_resolver_test.cc
@@ -63,7 +63,7 @@ class ResultHandler : public grpc_core::Resolver::ResultHandler {
 };
 
 static grpc_core::OrphanablePtr<grpc_core::Resolver> build_fake_resolver(
-    grpc_combiner* combiner,
+    grpc_core::Combiner* combiner,
     grpc_core::FakeResolverResponseGenerator* response_generator,
     grpc_core::UniquePtr<grpc_core::Resolver::ResultHandler> result_handler) {
   grpc_core::ResolverFactory* factory =
@@ -118,7 +118,7 @@ static grpc_core::Resolver::Result create_new_resolver_result() {
 
 static void test_fake_resolver() {
   grpc_core::ExecCtx exec_ctx;
-  grpc_combiner* combiner = grpc_combiner_create();
+  grpc_core::Combiner* combiner = grpc_combiner_create();
   // Create resolver.
   ResultHandler* result_handler = grpc_core::New<ResultHandler>();
   grpc_core::RefCountedPtr<grpc_core::FakeResolverResponseGenerator>

--- a/test/core/client_channel/resolvers/sockaddr_resolver_test.cc
+++ b/test/core/client_channel/resolvers/sockaddr_resolver_test.cc
@@ -28,7 +28,7 @@
 
 #include "test/core/util/test_config.h"
 
-static grpc_combiner* g_combiner;
+static grpc_core::Combiner* g_combiner;
 
 class ResultHandler : public grpc_core::Resolver::ResultHandler {
  public:

--- a/test/core/end2end/fuzzers/api_fuzzer.cc
+++ b/test/core/end2end/fuzzers/api_fuzzer.cc
@@ -379,7 +379,7 @@ grpc_ares_request* my_dns_lookup_ares_locked(
     grpc_pollset_set* /*interested_parties*/, grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
     bool /*check_grpclb*/, char** /*service_config_json*/,
-    int /*query_timeout*/, grpc_combiner* /*combiner*/) {
+    int /*query_timeout*/, grpc_core::Combiner* /*combiner*/) {
   addr_req* r = static_cast<addr_req*>(gpr_malloc(sizeof(*r)));
   r->addr = gpr_strdup(addr);
   r->on_done = on_done;

--- a/test/core/end2end/goaway_server_test.cc
+++ b/test/core/end2end/goaway_server_test.cc
@@ -49,7 +49,7 @@ static grpc_ares_request* (*iomgr_dns_lookup_ares_locked)(
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
     bool check_grpclb, char** service_config_json, int query_timeout_ms,
-    grpc_combiner* combiner);
+    grpc_core::Combiner* combiner);
 
 static void (*iomgr_cancel_ares_request_locked)(grpc_ares_request* request);
 
@@ -106,7 +106,7 @@ static grpc_ares_request* my_dns_lookup_ares_locked(
     grpc_pollset_set* interested_parties, grpc_closure* on_done,
     grpc_core::UniquePtr<grpc_core::ServerAddressList>* addresses,
     bool check_grpclb, char** service_config_json, int query_timeout_ms,
-    grpc_combiner* combiner) {
+    grpc_core::Combiner* combiner) {
   if (0 != strcmp(addr, "test")) {
     return iomgr_dns_lookup_ares_locked(
         dns_server, addr, default_port, interested_parties, on_done, addresses,

--- a/test/core/iomgr/combiner_test.cc
+++ b/test/core/iomgr/combiner_test.cc
@@ -39,13 +39,12 @@ static void set_event_to_true(void* value, grpc_error* /*error*/) {
 static void test_execute_one(void) {
   gpr_log(GPR_DEBUG, "test_execute_one");
 
-  grpc_combiner* lock = grpc_combiner_create();
+  grpc_core::Combiner* lock = grpc_combiner_create();
   gpr_event done;
   gpr_event_init(&done);
   grpc_core::ExecCtx exec_ctx;
-  GRPC_CLOSURE_SCHED(GRPC_CLOSURE_CREATE(set_event_to_true, &done,
-                                         grpc_combiner_scheduler(lock)),
-                     GRPC_ERROR_NONE);
+  lock->Run(GRPC_CLOSURE_CREATE(set_event_to_true, &done, nullptr),
+            GRPC_ERROR_NONE);
   grpc_core::ExecCtx::Get()->Flush();
   GPR_ASSERT(gpr_event_wait(&done, grpc_timeout_seconds_to_deadline(5)) !=
              nullptr);
@@ -54,7 +53,7 @@ static void test_execute_one(void) {
 
 typedef struct {
   size_t ctr;
-  grpc_combiner* lock;
+  grpc_core::Combiner* lock;
   gpr_event done;
 } thd_args;
 
@@ -79,24 +78,22 @@ static void execute_many_loop(void* a) {
       ex_args* c = static_cast<ex_args*>(gpr_malloc(sizeof(*c)));
       c->ctr = &args->ctr;
       c->value = n++;
-      GRPC_CLOSURE_SCHED(GRPC_CLOSURE_CREATE(
-                             check_one, c, grpc_combiner_scheduler(args->lock)),
-                         GRPC_ERROR_NONE);
+      args->lock->Run(GRPC_CLOSURE_CREATE(check_one, c, nullptr),
+                      GRPC_ERROR_NONE);
       grpc_core::ExecCtx::Get()->Flush();
     }
     // sleep for a little bit, to test a combiner draining and another thread
     // picking it up
     gpr_sleep_until(grpc_timeout_milliseconds_to_deadline(100));
   }
-  GRPC_CLOSURE_SCHED(GRPC_CLOSURE_CREATE(set_event_to_true, &args->done,
-                                         grpc_combiner_scheduler(args->lock)),
-                     GRPC_ERROR_NONE);
+  args->lock->Run(GRPC_CLOSURE_CREATE(set_event_to_true, &args->done, nullptr),
+                  GRPC_ERROR_NONE);
 }
 
 static void test_execute_many(void) {
   gpr_log(GPR_DEBUG, "test_execute_many");
 
-  grpc_combiner* lock = grpc_combiner_create();
+  grpc_core::Combiner* lock = grpc_combiner_create();
   grpc_core::Thread thds[100];
   thd_args ta[GPR_ARRAY_SIZE(thds)];
   for (size_t i = 0; i < GPR_ARRAY_SIZE(thds); i++) {
@@ -122,21 +119,17 @@ static void in_finally(void* /*arg*/, grpc_error* /*error*/) {
 }
 
 static void add_finally(void* arg, grpc_error* /*error*/) {
-  GRPC_CLOSURE_SCHED(GRPC_CLOSURE_CREATE(in_finally, arg,
-                                         grpc_combiner_finally_scheduler(
-                                             static_cast<grpc_combiner*>(arg))),
-                     GRPC_ERROR_NONE);
+  static_cast<grpc_core::Combiner*>(arg)->Run(
+      GRPC_CLOSURE_CREATE(in_finally, arg, nullptr), GRPC_ERROR_NONE);
 }
 
 static void test_execute_finally(void) {
   gpr_log(GPR_DEBUG, "test_execute_finally");
 
-  grpc_combiner* lock = grpc_combiner_create();
+  grpc_core::Combiner* lock = grpc_combiner_create();
   grpc_core::ExecCtx exec_ctx;
   gpr_event_init(&got_in_finally);
-  GRPC_CLOSURE_SCHED(
-      GRPC_CLOSURE_CREATE(add_finally, lock, grpc_combiner_scheduler(lock)),
-      GRPC_ERROR_NONE);
+  lock->Run(GRPC_CLOSURE_CREATE(add_finally, lock, nullptr), GRPC_ERROR_NONE);
   grpc_core::ExecCtx::Get()->Flush();
   GPR_ASSERT(gpr_event_wait(&got_in_finally,
                             grpc_timeout_seconds_to_deadline(5)) != nullptr);

--- a/test/cpp/naming/cancel_ares_query_test.cc
+++ b/test/cpp/naming/cancel_ares_query_test.cc
@@ -81,7 +81,7 @@ struct ArgsStruct {
   gpr_mu* mu;
   grpc_pollset* pollset;
   grpc_pollset_set* pollset_set;
-  grpc_combiner* lock;
+  grpc_core::Combiner* lock;
   grpc_channel_args* channel_args;
 };
 

--- a/test/cpp/naming/resolver_component_test.cc
+++ b/test/cpp/naming/resolver_component_test.cc
@@ -192,7 +192,7 @@ struct ArgsStruct {
   gpr_mu* mu;
   grpc_pollset* pollset;
   grpc_pollset_set* pollset_set;
-  grpc_combiner* lock;
+  grpc_core::Combiner* lock;
   grpc_channel_args* channel_args;
   vector<GrpcLBAddress> expected_addrs;
   std::string expected_service_config_string;
@@ -616,9 +616,9 @@ void RunResolvesRelevantRecordsTest(
                                                   CreateResultHandler(&args));
   grpc_channel_args_destroy(resolver_args);
   gpr_free(whole_uri);
-  GRPC_CLOSURE_SCHED(GRPC_CLOSURE_CREATE(StartResolvingLocked, resolver.get(),
-                                         grpc_combiner_scheduler(args.lock)),
-                     GRPC_ERROR_NONE);
+  args.lock->Run(
+      GRPC_CLOSURE_CREATE(StartResolvingLocked, resolver.get(), nullptr),
+      GRPC_ERROR_NONE);
   grpc_core::ExecCtx::Get()->Flush();
   PollPollsetUntilRequestDone(&args);
   ArgsFinish(&args);


### PR DESCRIPTION
The motive of this change is that we don't want the closure logic to be intertwined with schedulers. Effectively, the closure runner/scheduler should make the decision on how the closure needs to be run -
1) Combiners
2) ExecCtx
3) Executors


Therefore, instead of -
```
 GRPC_CLOSURE_INIT(closure, cb, cb_arg, grpc_combiner_scheduler(combiner));
 GRPC_CLOSURE_SCHED(closure, error);
```
we would have -
```
  GRPC_CLOSURE_INIT(closure, cb, cb_arg, nullptr);
  combiner->Run(closure, error);
```

This PR separates the two for combiners.
Strategy for the change -
1) If at the point of scheduling the closure, we have access to the combiner, simple perform the change as shown above.
2) If we do not have access to the combiner at the point of closure, we create a hopper function that will jump into the combiner. This hopper function is scheduled on the ExecCtx.

Note that this is first in a line of PRs. Changes coming in subsequent PRs -
1) A new Combiner API that does not have FinallyRun and does not depend on ExecCtx. (The current API will either be removed altogether or be deprecated)
2) Removal of Executor Schedulers and switch to Executor::Run()
3) Removal of ExecCtx schedulers and switch to ExecCtx::Run()
4) Removal of scheduler from closures.
5) Switching ExecCtx::Run() to direct invokation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grpc/grpc/20542)
<!-- Reviewable:end -->
