### PR TITLE
Add generic variance to reader and writer interfaces

### DIFF
--- a/src/csharp/Grpc.Core.Api/IAsyncStreamReader.cs
+++ b/src/csharp/Grpc.Core.Api/IAsyncStreamReader.cs
@@ -47,7 +47,7 @@ namespace Grpc.Core
     /// </para>
     /// </summary>
     /// <typeparam name="T">The message type.</typeparam>
-    public interface IAsyncStreamReader<T>
+    public interface IAsyncStreamReader<out T>
     {
         /// <summary>
         /// Gets the current element in the iteration.

--- a/src/csharp/Grpc.Core.Api/IAsyncStreamWriter.cs
+++ b/src/csharp/Grpc.Core.Api/IAsyncStreamWriter.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2015 gRPC authors.
 //
@@ -28,7 +28,7 @@ namespace Grpc.Core
     /// A writable stream of messages.
     /// </summary>
     /// <typeparam name="T">The message type.</typeparam>
-    public interface IAsyncStreamWriter<T>
+    public interface IAsyncStreamWriter<in T>
     {
         /// <summary>
         /// Writes a single asynchronously. Only one write can be pending at a time.

--- a/src/csharp/Grpc.Core.Api/IClientStreamWriter.cs
+++ b/src/csharp/Grpc.Core.Api/IClientStreamWriter.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2015 gRPC authors.
 //
@@ -28,7 +28,7 @@ namespace Grpc.Core
     /// Client-side writable stream of messages with Close capability.
     /// </summary>
     /// <typeparam name="T">The message type.</typeparam>
-    public interface IClientStreamWriter<T> : IAsyncStreamWriter<T>
+    public interface IClientStreamWriter<in T> : IAsyncStreamWriter<T>
     {
         /// <summary>
         /// Completes/closes the stream. Can only be called once there is no pending write. No writes should follow calling this.

--- a/src/csharp/Grpc.Core.Api/IServerStreamWriter.cs
+++ b/src/csharp/Grpc.Core.Api/IServerStreamWriter.cs
@@ -1,4 +1,4 @@
-﻿#region Copyright notice and license
+#region Copyright notice and license
 
 // Copyright 2015 gRPC authors.
 //
@@ -27,7 +27,7 @@ namespace Grpc.Core
     /// <summary>
     /// A writable stream of messages that is used in server-side handlers.
     /// </summary>
-    public interface IServerStreamWriter<T> : IAsyncStreamWriter<T>
+    public interface IServerStreamWriter<in T> : IAsyncStreamWriter<T>
     {
         // TODO(jtattermusch): consider just using IAsyncStreamWriter instead of this interface.
     }


### PR DESCRIPTION
Adding `out` to `IAsyncStreamReader<T>` allows it to be used without knowing the exact type.

```cs
IAsyncStreamReader<MyResponse> exactResponse = call.ResponseStream;
IAsyncStreamReader<object> lessExactResponse = exactResponse;
```

I notice when writing a sample and was forced to specify the exact type - https://github.com/grpc/grpc-dotnet/pull/597/files#r333292212

---

I've also made the writers contravariant but I'm not sure whether that makes sense. Because gRPC is based on code gen, and only knows about values on the actual contract type, derived type values won't be serialized, which could confuse people.

```cs
public class Animal // Code-gen from proto
{
}

public class Fish : Animal
{
    public int Fishiness { get; set; }
}

IAsyncClientWriter<Animal> animalWriter = call.RequestStream;
IAsyncClientWriter<Fish> fishWriter = animalWriter;

await fishWriter.WriteAsync(new Fish { Fishiness = 7 });
```

Let me know if you want to undo contravariance.

@jtattermusch 
