### PR TITLE
Deflake QPS test.

### DIFF
--- a/test/cpp/qps/driver.cc
+++ b/test/cpp/qps/driver.cc
@@ -495,8 +495,13 @@ std::unique_ptr<ScenarioResult> RunScenario(
   for (size_t i = 0; i < num_clients; i++) {
     auto client = &clients[i];
     Status s = client->stream->Finish();
-    result->add_client_success(s.ok());
-    if (!s.ok()) {
+    // Since we shutdown servers and clients at the same time, clients can
+    // observe cancellation.  Thus, we consider both OK and CANCELLED as good
+    // status.
+    const bool success = s.ok() || static_cast<StatusCode>(s.error_code()) ==
+                                       StatusCode::CANCELLED;
+    result->add_client_success(success);
+    if (!success) {
       gpr_log(GPR_ERROR, "Client %zu had an error %s", i,
               s.error_message().c_str());
     }
@@ -526,8 +531,13 @@ std::unique_ptr<ScenarioResult> RunScenario(
   for (size_t i = 0; i < num_servers; i++) {
     auto server = &servers[i];
     Status s = server->stream->Finish();
-    result->add_server_success(s.ok());
-    if (!s.ok()) {
+    // Since we shutdown servers and clients at the same time, servers can
+    // observe cancellation.  Thus, we consider both OK and CANCELLED as good
+    // status.
+    const bool success = s.ok() || static_cast<StatusCode>(s.error_code()) ==
+                                       StatusCode::CANCELLED;
+    result->add_server_success(success);
+    if (!success) {
       gpr_log(GPR_ERROR, "Server %zu had an error %s", i,
               s.error_message().c_str());
     }


### PR DESCRIPTION
In https://github.com/grpc/grpc/pull/20328, we started shutting down the
servers and the clients at the time to make the benchmark resilient.

Since servers and clients are shutdown in parallel, there is always a
chance that they observe cancelled RPCs. This resulted in QPS benchmarks
failing.  In this commit, we also accept cancelled RPCs in addition to
OK RPCs.

Fixes #20509