### PR TITLE
work around slice_test compiler bug (for windows bazel opt build)

### DIFF
--- a/test/core/slice/slice_test.cc
+++ b/test/core/slice/slice_test.cc
@@ -241,13 +241,13 @@ static void test_slice_interning(void) {
   LOG_TEST_NAME("test_slice_interning");
 
   grpc_init();
-  grpc_slice src1 = grpc_slice_from_copied_string("hello1234567891234567891");
-  grpc_slice src2 = grpc_slice_from_copied_string("hello1234567891234567891");
+  grpc_slice src1 = grpc_slice_from_copied_string("hello123456789123456789");
+  grpc_slice src2 = grpc_slice_from_copied_string("hello123456789123456789");
 
-  // make sure slices are refcounted to guarantee slices' start ptrs are
-  // distinct (even on windows opt 64bit build).
+  // Explicitly checking that the slices are at different addresses prevents
+  // failure with windows opt 64bit build.
   // See https://github.com/grpc/grpc/issues/20519
-  GPR_ASSERT(src1.refcount);
+  GPR_ASSERT(&src1 != &src2);
   GPR_ASSERT(GRPC_SLICE_START_PTR(src1) != GRPC_SLICE_START_PTR(src2));
 
   grpc_slice interned1 = grpc_slice_intern(src1);

--- a/test/core/slice/slice_test.cc
+++ b/test/core/slice/slice_test.cc
@@ -244,10 +244,9 @@ static void test_slice_interning(void) {
   grpc_slice src1 = grpc_slice_from_copied_string("hello123456789123456789");
   grpc_slice src2 = grpc_slice_from_copied_string("hello123456789123456789");
 
-  // Do not remove the log line. It actually supresses a compiler bug in windows
+  // Do not remote the log line. It actually supresses a compiler bug in windows
   // bazel opt build. See https://github.com/grpc/grpc/issues/20519
-  gpr_log(GPR_DEBUG, "src1 start ptr: %p, src2 start ptr: %p",
-          GRPC_SLICE_START_PTR(src1), GRPC_SLICE_START_PTR(src2));
+  gpr_log(GPR_DEBUG, "src1 start ptr: %p, src2 start ptr: %p", GRPC_SLICE_START_PTR(src1), GRPC_SLICE_START_PTR(src2));
   GPR_ASSERT(GRPC_SLICE_START_PTR(src1) != GRPC_SLICE_START_PTR(src2));
 
   grpc_slice interned1 = grpc_slice_intern(src1);

--- a/test/core/slice/slice_test.cc
+++ b/test/core/slice/slice_test.cc
@@ -241,12 +241,13 @@ static void test_slice_interning(void) {
   LOG_TEST_NAME("test_slice_interning");
 
   grpc_init();
-  grpc_slice src1 = grpc_slice_from_copied_string("hello123456789123456789");
-  grpc_slice src2 = grpc_slice_from_copied_string("hello123456789123456789");
+  grpc_slice src1 = grpc_slice_from_copied_string("hello1234567891234567891");
+  grpc_slice src2 = grpc_slice_from_copied_string("hello1234567891234567891");
 
-  // Do not remote the log line. It actually supresses a compiler bug in windows
-  // bazel opt build. See https://github.com/grpc/grpc/issues/20519
-  gpr_log(GPR_DEBUG, "src1 start ptr: %p, src2 start ptr: %p", GRPC_SLICE_START_PTR(src1), GRPC_SLICE_START_PTR(src2));
+  // make sure slices are refcounted to guarantee slices' start ptrs are
+  // distinct (even on windows opt 64bit build).
+  // See https://github.com/grpc/grpc/issues/20519
+  GPR_ASSERT(src1.refcount);
   GPR_ASSERT(GRPC_SLICE_START_PTR(src1) != GRPC_SLICE_START_PTR(src2));
 
   grpc_slice interned1 = grpc_slice_intern(src1);

--- a/test/core/slice/slice_test.cc
+++ b/test/core/slice/slice_test.cc
@@ -243,7 +243,13 @@ static void test_slice_interning(void) {
   grpc_init();
   grpc_slice src1 = grpc_slice_from_copied_string("hello123456789123456789");
   grpc_slice src2 = grpc_slice_from_copied_string("hello123456789123456789");
+
+  // Do not remove the log line. It actually supresses a compiler bug in windows
+  // bazel opt build. See https://github.com/grpc/grpc/issues/20519
+  gpr_log(GPR_DEBUG, "src1 start ptr: %p, src2 start ptr: %p",
+          GRPC_SLICE_START_PTR(src1), GRPC_SLICE_START_PTR(src2));
   GPR_ASSERT(GRPC_SLICE_START_PTR(src1) != GRPC_SLICE_START_PTR(src2));
+
   grpc_slice interned1 = grpc_slice_intern(src1);
   grpc_slice interned2 = grpc_slice_intern(src2);
   GPR_ASSERT(GRPC_SLICE_START_PTR(interned1) ==


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc/issues/20519.

The fix may look a bit random but I actually spent a fair amount of time debugging the problem 
and I'm now pretty sure that the failure is due to a compiler bug.

See https://github.com/grpc/grpc/pull/20554/files that demonstrates and explains the problem.