### PR TITLE
Added convenience class GRPCUnaryResponseHandler for unary calls

### DIFF
--- a/src/objective-c/ProtoRPC/ProtoRPC.h
+++ b/src/objective-c/ProtoRPC/ProtoRPC.h
@@ -70,6 +70,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+/**
+ * A convenience class of objects that act as response handlers of calls. Issues
+ * response to a single handler when the response is completed.
+ */
+@interface GRPCUnaryResponseHandler : NSObject<GRPCProtoResponseHandler>
+
+/**
+ * Creates a responsehandler object with a unary call handler.
+ *
+ * responseHandler: The unary handler to be called when the call is completed.
+ * responseDispatchQueue: the dispatch queue on which the response handler
+ * should be issued.
+ */
+- (nullable instancetype)initWithResponseHandler:(void (^)(GPBMessage *, NSError *))handler
+                           responseDispatchQueue:(dispatch_queue_t)responseDispatchQueue;
+
+/** Response headers received during the call. */
+@property(readonly, nullable) NSDictionary *responseHeaders;
+
+/** Response trailers received during the call. */
+@property(readonly, nullable) NSDictionary *responseTrailers;
+
+@end
+
 /** A unary-request RPC call with Protobuf. */
 @interface GRPCUnaryProtoCall : NSObject
 

--- a/src/objective-c/ProtoRPC/ProtoRPC.h
+++ b/src/objective-c/ProtoRPC/ProtoRPC.h
@@ -81,10 +81,10 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * responseHandler: The unary handler to be called when the call is completed.
  * responseDispatchQueue: the dispatch queue on which the response handler
- * should be issued.
+ * should be issued. If it's nil, the handler will use the main queue.
  */
 - (nullable instancetype)initWithResponseHandler:(void (^)(GPBMessage *, NSError *))handler
-                           responseDispatchQueue:(nullable dispatch_queue_t)responseDispatchQueue;
+                           responseDispatchQueue:(nullable dispatch_queue_t)dispatchQueue;
 
 /** Response headers received during the call. */
 @property(readonly, nullable) NSDictionary *responseHeaders;

--- a/src/objective-c/ProtoRPC/ProtoRPC.h
+++ b/src/objective-c/ProtoRPC/ProtoRPC.h
@@ -84,7 +84,7 @@ NS_ASSUME_NONNULL_BEGIN
  * should be issued.
  */
 - (nullable instancetype)initWithResponseHandler:(void (^)(GPBMessage *, NSError *))handler
-                           responseDispatchQueue:(dispatch_queue_t)responseDispatchQueue;
+                           responseDispatchQueue:(nullable dispatch_queue_t)responseDispatchQueue;
 
 /** Response headers received during the call. */
 @property(readonly, nullable) NSDictionary *responseHeaders;

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -39,9 +39,9 @@
   if ((self = [super init])) {
     _responseHandler = handler;
     if (dispatchQueue == nil) {
-      _responseDispatchQueue = dispatchQueue;
-    } else {
       _responseDispatchQueue = dispatch_get_main_queue();
+    } else {
+      _responseDispatchQueue = dispatchQueue;
     }
   }
   return self;

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -38,7 +38,11 @@
                            responseDispatchQueue:(dispatch_queue_t)dispatchQueue {
   if ((self = [super init])) {
     _responseHandler = handler;
-    _responseDispatchQueue = dispatchQueue;
+    if (dispatchQueue == nil) {
+      _responseDispatchQueue = dispatchQueue;
+    } else {
+      _responseDispatchQueue = dispatch_get_main_queue();
+    }
   }
   return self;
 }

--- a/src/objective-c/ProtoRPC/ProtoRPC.m
+++ b/src/objective-c/ProtoRPC/ProtoRPC.m
@@ -27,6 +27,48 @@
 #import <RxLibrary/GRXWriteable.h>
 #import <RxLibrary/GRXWriter+Transformations.h>
 
+@implementation GRPCUnaryResponseHandler {
+  void (^_responseHandler)(GPBMessage *, NSError *);
+  dispatch_queue_t _responseDispatchQueue;
+
+  GPBMessage *_message;
+}
+
+- (nullable instancetype)initWithResponseHandler:(void (^)(GPBMessage *, NSError *))handler
+                           responseDispatchQueue:(dispatch_queue_t)dispatchQueue {
+  if ((self = [super init])) {
+    _responseHandler = handler;
+    _responseDispatchQueue = dispatchQueue;
+  }
+  return self;
+}
+
+// Implements GRPCProtoResponseHandler
+- (dispatch_queue_t)dispatchQueue {
+  return _responseDispatchQueue;
+}
+
+- (void)didReceiveInitialMetadata:(NSDictionary *)initialMetadata {
+  _responseHeaders = [initialMetadata copy];
+}
+
+- (void)didReceiveProtoMessage:(GPBMessage *)message {
+  _message = message;
+}
+
+- (void)didCloseWithTrailingMetadata:(NSDictionary *)trailingMetadata error:(NSError *)error {
+  _responseTrailers = [trailingMetadata copy];
+  GPBMessage *message = _message;
+  _message = nil;
+  _responseHandler(message, error);
+}
+
+// Intentional no-op since flow control is N/A in a unary call
+- (void)didWriteMessage {
+}
+
+@end
+
 @implementation GRPCUnaryProtoCall {
   GRPCStreamingProtoCall *_call;
   GPBMessage *_message;

--- a/src/objective-c/tests/CronetTests/InteropTestsRemoteWithCronet.m
+++ b/src/objective-c/tests/CronetTests/InteropTestsRemoteWithCronet.m
@@ -60,4 +60,8 @@ static int32_t kRemoteInteropServerOverhead = 12;
   return kRemoteInteropServerOverhead;  // bytes
 }
 
++ (BOOL)isRemoteTest {
+  return YES;
+}
+
 @end

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -563,6 +563,47 @@ static dispatch_once_t initGlobalInterceptorFactory;
   [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
 }
 
+- (void)testUnaryResponseHandler {
+  XCTAssertNotNil([[self class] host]);
+  // The test does not work on a remote server since it does not echo a trailer
+  if ([[self class] isRemoteTest]) return;
+  __weak XCTestExpectation *expectComplete = [self expectationWithDescription:@"received complete"];
+
+  RMTSimpleRequest *request = [RMTSimpleRequest message];
+  request.responseType = RMTPayloadType_Compressable;
+  request.responseSize = 314159;
+  request.payload.body = [NSMutableData dataWithLength:271828];
+
+  GRPCMutableCallOptions *options = [[GRPCMutableCallOptions alloc] init];
+  // For backwards compatibility
+  options.transportType = [[self class] transportType];
+  options.transport = [[self class] transport];
+  options.PEMRootCertificates = [[self class] PEMRootCertificates];
+  options.hostNameOverride = [[self class] hostNameOverride];
+  const unsigned char raw_bytes[] = {1, 2, 3, 4};
+  NSData *trailer_data = [NSData dataWithBytes:raw_bytes length:sizeof(raw_bytes)];
+  options.initialMetadata = @{
+    @"x-grpc-test-echo-trailing-bin" : trailer_data,
+    @"x-grpc-test-echo-initial" : @"test-header"
+  };
+
+  __block GRPCUnaryResponseHandler *handler = [[GRPCUnaryResponseHandler alloc]
+      initWithResponseHandler:^(GPBMessage *response, NSError *error) {
+        XCTAssertNil(error, @"Unexpected error: %@", error);
+        RMTSimpleResponse *expectedResponse = [RMTSimpleResponse message];
+        expectedResponse.payload.type = RMTPayloadType_Compressable;
+        expectedResponse.payload.body = [NSMutableData dataWithLength:314159];
+        XCTAssertEqualObjects(response, expectedResponse);
+        XCTAssertEqualObjects(handler.responseHeaders[@"x-grpc-test-echo-initial"], @"test-header");
+        XCTAssertEqualObjects(handler.responseTrailers[@"x-grpc-test-echo-trailing-bin"],
+                              trailer_data);
+        [expectComplete fulfill];
+      }
+        responseDispatchQueue:dispatch_queue_create(NULL, DISPATCH_QUEUE_SERIAL)];
+  [[_service unaryCallWithMessage:request responseHandler:handler callOptions:options] start];
+  [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
+}
+
 - (void)testLargeUnaryRPCWithV2API {
   XCTAssertNotNil([[self class] host]);
   __weak XCTestExpectation *expectReceive =

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -567,7 +567,8 @@ static dispatch_once_t initGlobalInterceptorFactory;
   XCTAssertNotNil([[self class] host]);
   // The test does not work on a remote server since it does not echo a trailer
   if ([[self class] isRemoteTest]) return;
-  __weak XCTestExpectation *expectComplete = [self expectationWithDescription:@"received complete"];
+  XCTestExpectation *expectComplete = [self expectationWithDescription:@"call complete"];
+  XCTestExpectation *expectCompleteMainQueue = [self expectationWithDescription:@"main queue call complete"];
 
   RMTSimpleRequest *request = [RMTSimpleRequest message];
   request.responseType = RMTPayloadType_Compressable;
@@ -600,7 +601,22 @@ static dispatch_once_t initGlobalInterceptorFactory;
         [expectComplete fulfill];
       }
         responseDispatchQueue:dispatch_queue_create(NULL, DISPATCH_QUEUE_SERIAL)];
+  __block GRPCUnaryResponseHandler *handlerMainQueue = [[GRPCUnaryResponseHandler alloc]
+      initWithResponseHandler:^(GPBMessage *response, NSError *error) {
+        XCTAssertNil(error, @"Unexpected error: %@", error);
+        RMTSimpleResponse *expectedResponse = [RMTSimpleResponse message];
+        expectedResponse.payload.type = RMTPayloadType_Compressable;
+        expectedResponse.payload.body = [NSMutableData dataWithLength:314159];
+        XCTAssertEqualObjects(response, expectedResponse);
+        XCTAssertEqualObjects(handlerMainQueue.responseHeaders[@"x-grpc-test-echo-initial"], @"test-header");
+        XCTAssertEqualObjects(handlerMainQueue.responseTrailers[@"x-grpc-test-echo-trailing-bin"],
+                              trailer_data);
+        [expectCompleteMainQueue fulfill];
+      }
+        responseDispatchQueue:nil];
+
   [[_service unaryCallWithMessage:request responseHandler:handler callOptions:options] start];
+  [[_service unaryCallWithMessage:request responseHandler:handlerMainQueue callOptions:options] start];
   [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
 }
 

--- a/src/objective-c/tests/InteropTests/InteropTests.m
+++ b/src/objective-c/tests/InteropTests/InteropTests.m
@@ -568,7 +568,8 @@ static dispatch_once_t initGlobalInterceptorFactory;
   // The test does not work on a remote server since it does not echo a trailer
   if ([[self class] isRemoteTest]) return;
   XCTestExpectation *expectComplete = [self expectationWithDescription:@"call complete"];
-  XCTestExpectation *expectCompleteMainQueue = [self expectationWithDescription:@"main queue call complete"];
+  XCTestExpectation *expectCompleteMainQueue =
+      [self expectationWithDescription:@"main queue call complete"];
 
   RMTSimpleRequest *request = [RMTSimpleRequest message];
   request.responseType = RMTPayloadType_Compressable;
@@ -608,7 +609,8 @@ static dispatch_once_t initGlobalInterceptorFactory;
         expectedResponse.payload.type = RMTPayloadType_Compressable;
         expectedResponse.payload.body = [NSMutableData dataWithLength:314159];
         XCTAssertEqualObjects(response, expectedResponse);
-        XCTAssertEqualObjects(handlerMainQueue.responseHeaders[@"x-grpc-test-echo-initial"], @"test-header");
+        XCTAssertEqualObjects(handlerMainQueue.responseHeaders[@"x-grpc-test-echo-initial"],
+                              @"test-header");
         XCTAssertEqualObjects(handlerMainQueue.responseTrailers[@"x-grpc-test-echo-trailing-bin"],
                               trailer_data);
         [expectCompleteMainQueue fulfill];
@@ -616,7 +618,8 @@ static dispatch_once_t initGlobalInterceptorFactory;
         responseDispatchQueue:nil];
 
   [[_service unaryCallWithMessage:request responseHandler:handler callOptions:options] start];
-  [[_service unaryCallWithMessage:request responseHandler:handlerMainQueue callOptions:options] start];
+  [[_service unaryCallWithMessage:request responseHandler:handlerMainQueue callOptions:options]
+      start];
   [self waitForExpectationsWithTimeout:TEST_TIMEOUT handler:nil];
 }
 

--- a/src/objective-c/tests/InteropTests/InteropTestsRemote.m
+++ b/src/objective-c/tests/InteropTests/InteropTestsRemote.m
@@ -57,4 +57,8 @@ static int32_t kRemoteInteropServerOverhead = 12;
   return GRPCTransportTypeChttp2BoringSSL;
 }
 
++ (BOOL)isRemoteTest {
+  return YES;
+}
+
 @end

--- a/src/objective-c/tests/TestBase.h
+++ b/src/objective-c/tests/TestBase.h
@@ -57,9 +57,13 @@
 + (NSString *)PEMRootCertificates;
 
 /**
- * The root certificates to be used. The base implementation returns nil. Subclasses should override
- * to appropriate settings.
+ * The host name to be used for TLS verification in the tests.
  */
 + (NSString *)hostNameOverride;
+
+/**
+ * Indication of whether the test is connecting to a remote server.
+ */
++ (BOOL)isRemoteTest;
 
 @end

--- a/src/objective-c/tests/TestBase.m
+++ b/src/objective-c/tests/TestBase.m
@@ -47,4 +47,8 @@
   return nil;
 }
 
++ (BOOL)isRemoteTest {
+  return NO;
+}
+
 @end


### PR DESCRIPTION
The convenience response handler provides a better experience for users that only make unary calls, so that they don't need to create a separate context class for each call. The handler's signature matches v1 RPC methods' response handler, allowing easier migration from v1 to v2.