### PR TITLE
Fix error object memory leak in GetSystemRootCerts

### DIFF
--- a/src/core/lib/security/security_connector/load_system_roots_linux.cc
+++ b/src/core/lib/security/security_connector/load_system_roots_linux.cc
@@ -67,6 +67,7 @@ grpc_slice GetSystemRootCerts() {
     if (error == GRPC_ERROR_NONE) {
       return valid_bundle_slice;
     }
+    GRPC_ERROR_UNREF(error);
   }
   return grpc_empty_slice();
 }


### PR DESCRIPTION
This fixed https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10257




<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@AspirinSJL
