### PR TITLE
make cmake grpc.pc depend on openssl too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19470,7 +19470,7 @@ generate_pkgconfig(
   "gRPC"
   "high performance general RPC framework"
   "${gRPC_CORE_VERSION}"
-  "gpr"
+  "gpr openssl"
   "-lgrpc -laddress_sorting -lcares -lz"
   ""
   "grpc.pc")

--- a/templates/CMakeLists.txt.template
+++ b/templates/CMakeLists.txt.template
@@ -604,7 +604,7 @@
     "gRPC"
     "high performance general RPC framework"
     "<%text>${gRPC_CORE_VERSION}</%text>"
-    "gpr"
+    "gpr openssl"
     "-lgrpc -laddress_sorting -lcares -lz"
     ""
     "grpc.pc")


### PR DESCRIPTION
Tentative fix for https://github.com/grpc/grpc/pull/20606#issuecomment-542385501

The idea is that in the distribtest, we rely on system-installed openssl, but pkgconfig file doesn't reflect that. I have no idea why this has only been triggered by #20606.

This PR adds "openssl" to the grpc.pc "Requires"

CC @markdroth  @zackgalbreath @nicolasnoble 