### PR TITLE
Stop using assert in impl/codegen (use GPR_CODEGEN_ASSERT)

### DIFF
--- a/include/grpcpp/impl/codegen/async_stream_impl.h
+++ b/include/grpcpp/impl/codegen/async_stream_impl.h
@@ -198,7 +198,7 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    assert(size == sizeof(ClientAsyncReader));
+    GPR_CODEGEN_ASSERT(size == sizeof(ClientAsyncReader));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -206,10 +206,10 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { assert(0); }
+  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
 
   void StartCall(void* tag) override {
-    assert(!started_);
+    GPR_CODEGEN_ASSERT(!started_);
     started_ = true;
     StartCallInternal(tag);
   }
@@ -223,7 +223,7 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
   ///     calling code can access the received metadata through the
   ///     \a ClientContext.
   void ReadInitialMetadata(void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
 
     meta_ops_.set_output_tag(tag);
@@ -232,7 +232,7 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
   }
 
   void Read(R* msg, void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     read_ops_.set_output_tag(tag);
     if (!context_->initial_metadata_received_) {
       read_ops_.RecvInitialMetadata(context_);
@@ -247,7 +247,7 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
   ///   - the \a ClientContext associated with this call is updated with
   ///     possible initial and trailing metadata received from the server.
   void Finish(::grpc::Status* status, void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     finish_ops_.set_output_tag(tag);
     if (!context_->initial_metadata_received_) {
       finish_ops_.RecvInitialMetadata(context_);
@@ -269,7 +269,7 @@ class ClientAsyncReader final : public ClientAsyncReaderInterface<R> {
     if (start) {
       StartCallInternal(tag);
     } else {
-      assert(tag == nullptr);
+      GPR_CODEGEN_ASSERT(tag == nullptr);
     }
   }
 
@@ -347,7 +347,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    assert(size == sizeof(ClientAsyncWriter));
+    GPR_CODEGEN_ASSERT(size == sizeof(ClientAsyncWriter));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -355,10 +355,10 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { assert(0); }
+  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
 
   void StartCall(void* tag) override {
-    assert(!started_);
+    GPR_CODEGEN_ASSERT(!started_);
     started_ = true;
     StartCallInternal(tag);
   }
@@ -371,7 +371,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
   ///     associated with this call is updated, and the calling code can access
   ///     the received metadata through the \a ClientContext.
   void ReadInitialMetadata(void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
 
     meta_ops_.set_output_tag(tag);
@@ -380,7 +380,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
   }
 
   void Write(const W& msg, void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     write_ops_.set_output_tag(tag);
     // TODO(ctiller): don't assert
     GPR_CODEGEN_ASSERT(write_ops_.SendMessage(msg).ok());
@@ -388,7 +388,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
   }
 
   void Write(const W& msg, ::grpc::WriteOptions options, void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     write_ops_.set_output_tag(tag);
     if (options.is_last_message()) {
       options.set_buffer_hint();
@@ -400,7 +400,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
   }
 
   void WritesDone(void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     write_ops_.set_output_tag(tag);
     write_ops_.ClientSendClose();
     call_.PerformOps(&write_ops_);
@@ -414,7 +414,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
   ///   - attempts to fill in the \a response parameter passed to this class's
   ///     constructor with the server's response message.
   void Finish(::grpc::Status* status, void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     finish_ops_.set_output_tag(tag);
     if (!context_->initial_metadata_received_) {
       finish_ops_.RecvInitialMetadata(context_);
@@ -435,7 +435,7 @@ class ClientAsyncWriter final : public ClientAsyncWriterInterface<W> {
     if (start) {
       StartCallInternal(tag);
     } else {
-      assert(tag == nullptr);
+      GPR_CODEGEN_ASSERT(tag == nullptr);
     }
   }
 
@@ -515,7 +515,7 @@ class ClientAsyncReaderWriter final
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    assert(size == sizeof(ClientAsyncReaderWriter));
+    GPR_CODEGEN_ASSERT(size == sizeof(ClientAsyncReaderWriter));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -523,10 +523,10 @@ class ClientAsyncReaderWriter final
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { assert(0); }
+  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
 
   void StartCall(void* tag) override {
-    assert(!started_);
+    GPR_CODEGEN_ASSERT(!started_);
     started_ = true;
     StartCallInternal(tag);
   }
@@ -539,7 +539,7 @@ class ClientAsyncReaderWriter final
   ///     is updated with it, and then the receiving initial metadata can
   ///     be accessed through this \a ClientContext.
   void ReadInitialMetadata(void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
 
     meta_ops_.set_output_tag(tag);
@@ -548,7 +548,7 @@ class ClientAsyncReaderWriter final
   }
 
   void Read(R* msg, void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     read_ops_.set_output_tag(tag);
     if (!context_->initial_metadata_received_) {
       read_ops_.RecvInitialMetadata(context_);
@@ -558,7 +558,7 @@ class ClientAsyncReaderWriter final
   }
 
   void Write(const W& msg, void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     write_ops_.set_output_tag(tag);
     // TODO(ctiller): don't assert
     GPR_CODEGEN_ASSERT(write_ops_.SendMessage(msg).ok());
@@ -566,7 +566,7 @@ class ClientAsyncReaderWriter final
   }
 
   void Write(const W& msg, ::grpc::WriteOptions options, void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     write_ops_.set_output_tag(tag);
     if (options.is_last_message()) {
       options.set_buffer_hint();
@@ -578,7 +578,7 @@ class ClientAsyncReaderWriter final
   }
 
   void WritesDone(void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     write_ops_.set_output_tag(tag);
     write_ops_.ClientSendClose();
     call_.PerformOps(&write_ops_);
@@ -589,7 +589,7 @@ class ClientAsyncReaderWriter final
   ///   - the \a ClientContext associated with this call is updated with
   ///     possible initial and trailing metadata sent from the server.
   void Finish(::grpc::Status* status, void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     finish_ops_.set_output_tag(tag);
     if (!context_->initial_metadata_received_) {
       finish_ops_.RecvInitialMetadata(context_);
@@ -607,7 +607,7 @@ class ClientAsyncReaderWriter final
     if (start) {
       StartCallInternal(tag);
     } else {
-      assert(tag == nullptr);
+      GPR_CODEGEN_ASSERT(tag == nullptr);
     }
   }
 

--- a/include/grpcpp/impl/codegen/async_unary_call_impl.h
+++ b/include/grpcpp/impl/codegen/async_unary_call_impl.h
@@ -19,7 +19,6 @@
 #ifndef GRPCPP_IMPL_CODEGEN_ASYNC_UNARY_CALL_IMPL_H
 #define GRPCPP_IMPL_CODEGEN_ASYNC_UNARY_CALL_IMPL_H
 
-#include <assert.h>
 #include <grpcpp/impl/codegen/call.h>
 #include <grpcpp/impl/codegen/channel_interface.h>
 #include <grpcpp/impl/codegen/client_context_impl.h>
@@ -97,7 +96,7 @@ class ClientAsyncResponseReader final
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    assert(size == sizeof(ClientAsyncResponseReader));
+    GPR_CODEGEN_ASSERT(size == sizeof(ClientAsyncResponseReader));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -105,10 +104,10 @@ class ClientAsyncResponseReader final
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { assert(0); }
+  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
 
   void StartCall() override {
-    assert(!started_);
+    GPR_CODEGEN_ASSERT(!started_);
     started_ = true;
     StartCallInternal();
   }
@@ -120,7 +119,7 @@ class ClientAsyncResponseReader final
   ///   - the \a ClientContext associated with this call is updated with
   ///     possible initial and trailing metadata sent from the server.
   void ReadInitialMetadata(void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     GPR_CODEGEN_ASSERT(!context_->initial_metadata_received_);
 
     single_buf.set_output_tag(tag);
@@ -135,7 +134,7 @@ class ClientAsyncResponseReader final
   ///   - the \a ClientContext associated with this call is updated with
   ///     possible initial and trailing metadata sent from the server.
   void Finish(R* msg, ::grpc::Status* status, void* tag) override {
-    assert(started_);
+    GPR_CODEGEN_ASSERT(started_);
     if (initial_metadata_read_) {
       finish_buf.set_output_tag(tag);
       finish_buf.RecvMessage(msg);

--- a/include/grpcpp/impl/codegen/call_op_set.h
+++ b/include/grpcpp/impl/codegen/call_op_set.h
@@ -19,7 +19,6 @@
 #ifndef GRPCPP_IMPL_CODEGEN_CALL_OP_SET_H
 #define GRPCPP_IMPL_CODEGEN_CALL_OP_SET_H
 
-#include <assert.h>
 #include <cstring>
 #include <map>
 #include <memory>

--- a/include/grpcpp/impl/codegen/callback_common.h
+++ b/include/grpcpp/impl/codegen/callback_common.h
@@ -70,7 +70,7 @@ class CallbackWithStatusTag
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    assert(size == sizeof(CallbackWithStatusTag));
+    GPR_CODEGEN_ASSERT(size == sizeof(CallbackWithStatusTag));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -78,7 +78,7 @@ class CallbackWithStatusTag
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { assert(0); }
+  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
 
   CallbackWithStatusTag(grpc_call* call, std::function<void(Status)> f,
                         CompletionQueueTag* ops)
@@ -134,7 +134,7 @@ class CallbackWithSuccessTag
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    assert(size == sizeof(CallbackWithSuccessTag));
+    GPR_CODEGEN_ASSERT(size == sizeof(CallbackWithSuccessTag));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -142,7 +142,7 @@ class CallbackWithSuccessTag
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { assert(0); }
+  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
 
   CallbackWithSuccessTag() : call_(nullptr) {}
 

--- a/include/grpcpp/impl/codegen/client_callback_impl.h
+++ b/include/grpcpp/impl/codegen/client_callback_impl.h
@@ -422,7 +422,7 @@ class ClientCallbackReaderWriterImpl
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    assert(size == sizeof(ClientCallbackReaderWriterImpl));
+    GPR_CODEGEN_ASSERT(size == sizeof(ClientCallbackReaderWriterImpl));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -430,7 +430,7 @@ class ClientCallbackReaderWriterImpl
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { assert(0); }
+  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
 
   void MaybeFinish() {
     if (GPR_UNLIKELY(callbacks_outstanding_.fetch_sub(
@@ -634,7 +634,7 @@ class ClientCallbackReaderImpl
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    assert(size == sizeof(ClientCallbackReaderImpl));
+    GPR_CODEGEN_ASSERT(size == sizeof(ClientCallbackReaderImpl));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -642,7 +642,7 @@ class ClientCallbackReaderImpl
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { assert(0); }
+  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
 
   void MaybeFinish() {
     if (GPR_UNLIKELY(callbacks_outstanding_.fetch_sub(
@@ -774,7 +774,7 @@ class ClientCallbackWriterImpl
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    assert(size == sizeof(ClientCallbackWriterImpl));
+    GPR_CODEGEN_ASSERT(size == sizeof(ClientCallbackWriterImpl));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -782,7 +782,7 @@ class ClientCallbackWriterImpl
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { assert(0); }
+  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
 
   void MaybeFinish() {
     if (GPR_UNLIKELY(callbacks_outstanding_.fetch_sub(
@@ -962,7 +962,7 @@ class ClientCallbackUnaryImpl final : public experimental::ClientCallbackUnary {
  public:
   // always allocated against a call arena, no memory free required
   static void operator delete(void* /*ptr*/, std::size_t size) {
-    assert(size == sizeof(ClientCallbackUnaryImpl));
+    GPR_CODEGEN_ASSERT(size == sizeof(ClientCallbackUnaryImpl));
   }
 
   // This operator should never be called as the memory should be freed as part
@@ -970,7 +970,7 @@ class ClientCallbackUnaryImpl final : public experimental::ClientCallbackUnary {
   // delete to the operator new so that some compilers will not complain (see
   // https://github.com/grpc/grpc/issues/11301) Note at the time of adding this
   // there are no tests catching the compiler warning.
-  static void operator delete(void*, void*) { assert(0); }
+  static void operator delete(void*, void*) { GPR_CODEGEN_ASSERT(false); }
 
   void StartCall() override {
     // This call initiates two batches, each with a callback


### PR DESCRIPTION
When cleaning up unused headers, I found this funny pattern that we are using assert in some places in impl/codegen when we are supposed to be using GPR_CODEGEN_ASSERT . Fix those.

<!--

Your pull request will be routed to the following person by default for triaging.
If you know who should review your pull request, please remove the mentioning below.

-->

@yang-g
