### PR TITLE
Fix an incorrect comment

### DIFF
--- a/src/core/lib/transport/transport.h
+++ b/src/core/lib/transport/transport.h
@@ -293,7 +293,7 @@ struct grpc_transport_stream_op_batch_payload {
   struct {
     grpc_metadata_batch* recv_trailing_metadata = nullptr;
     grpc_transport_stream_stats* collect_stats = nullptr;
-    /** Should be enqueued when initial metadata is ready to be processed. */
+    /** Should be enqueued when trailing metadata is ready to be processed. */
     grpc_closure* recv_trailing_metadata_ready = nullptr;
   } recv_trailing_metadata;
 


### PR DESCRIPTION
Probably shouldn't have copy-pasted comments from initial metadata to trailing metadata
