### PR TITLE
Eliminate a signed/unsigned comparison

### DIFF
--- a/src/core/ext/filters/client_channel/xds/xds_api.cc
+++ b/src/core/ext/filters/client_channel/xds/xds_api.cc
@@ -91,7 +91,7 @@ bool XdsDropConfig::ShouldDrop(const UniquePtr<char>** category_name) const {
   for (size_t i = 0; i < drop_category_list_.size(); ++i) {
     const auto& drop_category = drop_category_list_[i];
     // Generate a random number in [0, 1000000).
-    const int random = rand() % 1000000;
+    const uint32_t random = static_cast<uint32_t>(rand()) % 1000000;
     if (random < drop_category.parts_per_million) {
       *category_name = &drop_category.name;
       return true;


### PR DESCRIPTION
Since `rand()` is defined to return non-negative numbers the cast is
always safe.

We see a warning about this when building google-cloud-spanner:

```
warning: comparison of integer expressions of different signedness: 'const int' and 'const uint32_t' {aka 'const unsigned int'} [-Wsign-compare]
     if (random < drop_category.parts_per_million) {
         ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
