### PR TITLE
Correct cancel() return value

### DIFF
--- a/src/python/grpcio/grpc/_channel.py
+++ b/src/python/grpcio/grpc/_channel.py
@@ -267,7 +267,9 @@ class _Rendezvous(grpc.RpcError, grpc.Future, grpc.Call):  # pylint: disable=too
                 self._state.cancelled = True
                 _abort(self._state, code, details)
                 self._state.condition.notify_all()
-            return False
+                return True
+            else:
+                return False
 
     def cancelled(self):
         with self._state.condition:

--- a/src/python/grpcio_tests/tests/unit/_rpc_test.py
+++ b/src/python/grpcio_tests/tests/unit/_rpc_test.py
@@ -887,12 +887,13 @@ class RPCTest(unittest.TestCase):
     def _cancelled_unary_request_stream_response(self, multi_callable):
         request = b'\x07\x19'
 
+        response_iterator = None
         with self._control.pause():
             response_iterator = multi_callable(
                 request,
                 metadata=(('test', 'CancelledUnaryRequestStreamResponse'),))
             self._control.block_until_paused()
-            response_iterator.cancel()
+            self.assertTrue(response_iterator.cancel())
 
         with self.assertRaises(grpc.RpcError) as exception_context:
             next(response_iterator)
@@ -902,6 +903,7 @@ class RPCTest(unittest.TestCase):
         self.assertIs(grpc.StatusCode.CANCELLED, response_iterator.code())
         self.assertIsNotNone(response_iterator.details())
         self.assertIsNotNone(response_iterator.trailing_metadata())
+        self.assertFalse(response_iterator.cancel())
 
     def _cancelled_stream_request_stream_response(self, multi_callable):
         requests = tuple(

--- a/src/python/grpcio_tests/tests/unit/framework/common/test_control.py
+++ b/src/python/grpcio_tests/tests/unit/framework/common/test_control.py
@@ -73,10 +73,12 @@ class PauseFailControl(Control):
         """Pauses code under control while controlling code is in context."""
         with self._condition:
             self._pause = True
-        yield
-        with self._condition:
-            self._pause = False
-            self._condition.notify_all()
+        try:
+            yield
+        finally:
+            with self._condition:
+                self._pause = False
+                self._condition.notify_all()
 
     def block_until_paused(self):
         """Blocks controlling code until code under control is paused.


### PR DESCRIPTION
The API contract for `grpc.Future` states

```text
Returns:
bool:
Returns True if the computation was canceled.

Returns False under all other circumstances, for example:

1. computation has begun and could not be canceled.
2. computation has finished
3. computation is scheduled for execution and it is impossible
     to determine its state without blocking.
```

Our current implementation returns False in *all* cases. This fixes that
bug. Fingers crossed that Hyrum's Law doesn't bite us.